### PR TITLE
Port recent OpenRoomote changes (#547, #548)

### DIFF
--- a/.agent-guidance/operations/README.md
+++ b/.agent-guidance/operations/README.md
@@ -12,4 +12,5 @@ summary: Index of operational docs covering local deployment, V1 production depl
 - [Deployment & Release](./deployment.md) — Local-first deployment and release process covering Docker Compose, PM2 services, V1 GHCR/DigitalOcean production deploys, worker archive builds, and CI
 - [Monitoring & Health Checks](./monitoring.md) — Health monitoring covering API endpoints, slow-request logging, outbound timeouts, controller heartbeat, orphan detection, and debugging patterns
 - [Dev CLI](./dev-cli.md) — Local development CLI covering database seeding, local seeding, and GitHub bootstrap
+- [Slack Behavior Evals](./slack-behavior-evals.md) — Criterion-based Slack behavior evals via the mock harness, judged by the opencode-bench panel
 - [Testing Strategy](./testing.md) — Prioritizing high-signal tests, choosing the right test layer, and running Roomote validation paths

--- a/.agent-guidance/operations/slack-behavior-evals.md
+++ b/.agent-guidance/operations/slack-behavior-evals.md
@@ -1,0 +1,64 @@
+---
+title: Slack Behavior Evals
+status: active
+last_reviewed: 2026-07-08
+owner: engineering
+summary: Run criterion-based behavior evals against the mock Slack harness and judge captured transcripts with the RooCodeInc/opencode-bench judge panel.
+---
+
+# Slack Behavior Evals
+
+Scenario-driven evals for how Roomote behaves on Slack (threading, dedup,
+reply quality, channel discipline). Each scenario is a JSON file carrying its
+own **authored success criteria**; a runner drives the real local stack
+through the mock Slack harness, captures every outbound message, and emits a
+bundle that the [RooCodeInc/opencode-bench](https://github.com/RooCodeInc/opencode-bench)
+judge panel scores criterion-by-criterion. Results render in that repo's
+dashboard alongside code evals.
+
+## Layout
+
+- Runner: [`packages/slack/evals/run-slack-scenario.ts`](../../packages/slack/evals/run-slack-scenario.ts)
+- Scenarios: [`packages/slack/evals/scenarios/`](../../packages/slack/evals/scenarios/)
+- Mock harness internals: see the `mock-slack-testing` skill and
+  `packages/slack/src/mock-slack-server.ts`
+
+## Running
+
+Prerequisites: local dev stack up (`pnpm dev`), `SLACK_API_BASE_URL` in
+`.env.local` pointing at the mock port (`http://127.0.0.1:3012/api/`), and the
+mock Slack installation/user mapping seeded (see the `mock-slack-testing`
+skill — note its SQL snippet is stale; the real `slack_installations` schema
+has `bot_access_token` + required `scopes`, and no `organization_id`).
+
+```bash
+pnpm --filter @roomote/slack eval:scenario -- \
+  --scenario evals/scenarios/slack-fast-answer.json \
+  --webhook http://localhost:13101/api/webhooks/slack \
+  --target roomote@local-dev --episode 1 --out /tmp/slack-eval-bundles
+```
+
+Then judge the bundles from a checkout of `RooCodeInc/opencode-bench`:
+
+```bash
+bun run scripts/judge-criteria.ts --input /tmp/slack-eval-bundles --out results/slack-evals.json
+```
+
+The `--target` label is the comparison axis (prompt version, branch, model) —
+use it to regression-test prompt edits: run the suite before and after a
+Slack prompt change and compare columns in the bench dashboard.
+
+## Writing scenarios
+
+- One concrete, independently checkable fact per criterion; judges mark each
+  binary satisfied/unsatisfied against the captured artifacts only.
+- Use `$E<n>` / `$TS<n>` tokens for event ids and Slack timestamps — the
+  runner substitutes run-unique values (same token, same value), so repeated
+  episodes never collide on Slack event dedup or thread locks. Reuse the same
+  `$E` token across two events to test duplicate delivery.
+- Prefer `!fast` flows for cheap scenarios (inline answer, no cloud job).
+  Scenarios that need a full cloud job (deleted-thread suppression mid-task,
+  completion notifications) also work but take minutes per episode.
+- The runner settles when the message log is stable for `settleMs` (with at
+  least one bot message) or gives up at `timeoutMs` and judges whatever
+  happened.

--- a/.docker/app/entrypoint.sh
+++ b/.docker/app/entrypoint.sh
@@ -15,6 +15,16 @@ fi
 # dockerCommand parser passes quote characters through literally, so a
 # `sh -c '...'` prelude cannot do it either. Derive the URL-shaped variables
 # from host-only references here instead; explicitly set values always win.
+#
+# A service's very first container can snapshot its environment before its
+# own hostname propagates into the blueprint's cross-service reference,
+# leaving the self-referencing host variable empty. Render injects the
+# service's own hostname directly as RENDER_EXTERNAL_HOSTNAME (never via a
+# reference), so fall back to it for the self-referencing case.
+case "$service" in
+  web) : "${ROOMOTE_WEB_HOST:=${RENDER_EXTERNAL_HOSTNAME:-}}" ;;
+  api) : "${ROOMOTE_API_HOST:=${RENDER_EXTERNAL_HOSTNAME:-}}" ;;
+esac
 if [ -z "${ROOMOTE_APP_URL:-}" ] && [ -n "${ROOMOTE_WEB_HOST:-}" ]; then
   export ROOMOTE_APP_URL="https://${ROOMOTE_WEB_HOST}"
 fi

--- a/deploy/render/README.md
+++ b/deploy/render/README.md
@@ -86,6 +86,18 @@ real hostnames (see
 set the three values manually to the services' `onrender.com` hostnames and
 redeploy.
 
+A service can also lose this race only on its very first boot: its
+container snapshots the environment before the referenced hostname has
+propagated, and the service crash-loops logging
+`❌ Invalid environment variables` with a composed URL reported as
+`Required` — even though the Environment tab already shows the resolved
+hostname. The stored value is fine; the running container just predates
+it. The entrypoint dispatcher heals the self-referencing case on its own
+(a service's own hostname falls back to the Render-injected
+`RENDER_EXTERNAL_HOSTNAME`), so only a cross-service reference can still
+hit this. Fix it with **Manual Deploy → Deploy latest reference** on the
+affected service to take a fresh environment snapshot.
+
 After the first deploy, also consider disabling **Auto-Sync** on the
 Blueprint (Blueprint settings in the Render dashboard). With Auto-Sync on,
 Render re-applies `render.yaml` whenever the tracked branch moves, which

--- a/packages/slack/evals/run-slack-scenario.ts
+++ b/packages/slack/evals/run-slack-scenario.ts
@@ -1,0 +1,196 @@
+#!/usr/bin/env tsx
+/**
+ * Slack behavior eval runner: drives the mock Slack harness through a
+ * scenario, captures everything Roomote posted back, and writes a
+ * criterion-eval bundle for judging (see RooCodeInc/opencode-bench,
+ * scripts/judge-criteria.ts).
+ *
+ * Prerequisites: local dev stack running (pnpm dev) with
+ * SLACK_API_BASE_URL pointing at the mock port used here, and the mock
+ * Slack installation/user mapping seeded (see
+ * .claude/skills/mock-slack-testing/SKILL.md).
+ *
+ * Usage:
+ *   pnpm --filter @roomote/slack eval:scenario -- \
+ *     --scenario evals/scenarios/slack-fast-answer.json \
+ *     --webhook http://localhost:13101/api/webhooks/slack \
+ *     --target roomote@local-dev --episode 1 --out /tmp/slack-eval-bundles
+ */
+
+import { parseArgs } from 'node:util';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { z } from 'zod';
+import {
+  MockSlackServer,
+  type MockSlackState,
+} from '../src/mock-slack-server.js';
+
+const scenarioSchema = z.object({
+  name: z.string().regex(/^[a-z0-9][a-z0-9-]*$/),
+  description: z.string(),
+  criteria: z.array(z.string().min(1)).min(1),
+  state: z.record(z.string(), z.unknown()),
+  events: z.array(
+    z.object({
+      delayMs: z.number().int().nonnegative().default(0),
+      envelope: z.record(z.string(), z.unknown()),
+    }),
+  ),
+  settleMs: z.number().int().positive().default(20_000),
+  timeoutMs: z.number().int().positive().default(180_000),
+});
+
+const { values } = parseArgs({
+  options: {
+    scenario: { type: 'string' },
+    webhook: {
+      type: 'string',
+      default: 'http://localhost:13101/api/webhooks/slack',
+    },
+    port: { type: 'string', default: '3012' },
+    target: { type: 'string', default: 'roomote@local-dev' },
+    episode: { type: 'string', default: '1' },
+    out: { type: 'string', default: '/tmp/slack-eval-bundles' },
+  },
+});
+
+if (!values.scenario) {
+  console.error('Error: --scenario <file> is required');
+  process.exit(1);
+}
+
+const scenario = scenarioSchema.parse(
+  JSON.parse(await readFile(values.scenario, 'utf-8')),
+);
+const episode = Number.parseInt(values.episode!, 10) || 1;
+
+// Substitute run-unique tokens so episodes never collide on Slack event
+// dedup or thread locks: every "$E<n>" becomes a unique event id and every
+// "$TS<n>" a unique Slack timestamp — the same token maps to the same value.
+const runId = `${Date.now().toString(36)}-ep${episode}`;
+const tokens = new Map<string, string>();
+let tsSeq = 0;
+function tokenValue(token: string): string {
+  let v = tokens.get(token);
+  if (!v) {
+    v = token.startsWith('$TS')
+      ? `${Math.floor(Date.now() / 1000)}.${String(100000 + ++tsSeq)}`
+      : `evt-${runId}-${token.slice(2).toLowerCase()}`;
+    tokens.set(token, v);
+  }
+  return v;
+}
+function substitute(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return value.replace(/\$(?:TS|E)\d+/g, (m) => tokenValue(m));
+  }
+  if (Array.isArray(value)) return value.map(substitute);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([k, v]) => [k, substitute(v)]),
+    );
+  }
+  return value;
+}
+
+const server = new MockSlackServer({
+  state: substitute(scenario.state) as MockSlackState,
+  roomoteTarget: {
+    webhookUrl: values.webhook!,
+    signingSecret: process.env.SLACK_SIGNING_SECRET ?? '',
+  },
+});
+const baseUrl = await server.start(Number.parseInt(values.port!, 10));
+console.log(`mock slack listening at ${baseUrl} -> ${values.webhook}`);
+
+const expectedBase = `${baseUrl}/api/`;
+if (
+  process.env.SLACK_API_BASE_URL &&
+  process.env.SLACK_API_BASE_URL !== expectedBase
+) {
+  console.warn(
+    `WARNING: SLACK_API_BASE_URL=${process.env.SLACK_API_BASE_URL} does not match ${expectedBase}; ` +
+      `the API server may post replies somewhere else.`,
+  );
+}
+
+const startedAt = Date.now();
+const dispatched: { at: string; envelope: unknown; result: unknown }[] = [];
+
+try {
+  // Preflight: the webhook must answer a url_verification handshake.
+  const handshake = await server.dispatch({
+    kind: 'url_verification',
+    challenge: `preflight-${runId}`,
+  } as never);
+  if (handshake.status !== 200) {
+    throw new Error(
+      `Webhook preflight failed: HTTP ${handshake.status} from ${values.webhook}`,
+    );
+  }
+
+  for (const { delayMs, envelope } of scenario.events) {
+    if (delayMs) await new Promise((r) => setTimeout(r, delayMs));
+    const resolved = substitute(envelope);
+    const result = await server.dispatch(resolved as never);
+    dispatched.push({
+      at: new Date().toISOString(),
+      envelope: resolved,
+      result,
+    });
+    console.log(
+      `dispatched ${(resolved as { kind: string }).kind} -> HTTP ${result.status}`,
+    );
+  }
+
+  // Settle: wait until the message log has been stable for settleMs (with
+  // at least one bot message), or give up at timeoutMs and judge as-is.
+  let lastCount = -1;
+  let stableSince = Date.now();
+  let timedOut = false;
+  for (;;) {
+    const messages = server.getState().messages ?? [];
+    if (messages.length !== lastCount) {
+      lastCount = messages.length;
+      stableSince = Date.now();
+    }
+    const hasBotMessage = messages.some((m) => m.bot_id);
+    if (hasBotMessage && Date.now() - stableSince >= scenario.settleMs) break;
+    if (Date.now() - startedAt >= scenario.timeoutMs) {
+      timedOut = true;
+      break;
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+
+  const duration = Date.now() - startedAt;
+  const state = server.getState();
+  const bundle = {
+    name: scenario.name,
+    target: values.target,
+    episode,
+    criteria: scenario.criteria,
+    artifacts: {
+      slack_transcript: JSON.stringify(state.messages ?? [], null, 2),
+      dispatched_events: JSON.stringify(dispatched, null, 2),
+      timing: [
+        `run started ${new Date(startedAt).toISOString()}`,
+        `settled after ${Math.round(duration / 1000)}s${timedOut ? ' (TIMEOUT reached before quiescence)' : ''}`,
+        `bot user id: ${state.botUserId}, bot id: ${state.botId}`,
+      ].join('\n'),
+    },
+    duration,
+  };
+
+  await mkdir(values.out!, { recursive: true });
+  const outFile = join(values.out!, `${scenario.name}-ep${episode}.json`);
+  await writeFile(outFile, JSON.stringify(bundle, null, 2));
+  const botCount = (state.messages ?? []).filter((m) => m.bot_id).length;
+  console.log(
+    `captured ${state.messages?.length ?? 0} messages (${botCount} from bot)${timedOut ? ' [timeout]' : ''}`,
+  );
+  console.log(`bundle written to ${outFile}`);
+} finally {
+  await server.stop();
+}

--- a/packages/slack/evals/scenarios/slack-duplicate-delivery.json
+++ b/packages/slack/evals/scenarios/slack-duplicate-delivery.json
@@ -1,0 +1,71 @@
+{
+  "name": "slack-duplicate-delivery",
+  "description": "Slack redelivers the same app_mention event (identical event_id) a few seconds later. Roomote must reply exactly once — the duplicate must be absorbed silently.",
+  "criteria": [
+    "The bot posts exactly one reply message in the mention's thread, even though the identical event (same event_id) was delivered twice",
+    "The reply is a threaded reply whose thread_ts equals the ts of the mention",
+    "The bot posts no error messages, no apologies about duplicates, and no channel-level messages"
+  ],
+  "state": {
+    "team": {
+      "id": "TROOMOTE",
+      "domain": "roomote-mock",
+      "timezone": "America/Los_Angeles"
+    },
+    "acceptedBotTokens": [],
+    "botUserId": "BROOMOTE",
+    "channels": [
+      {
+        "id": "C123ABC456",
+        "name": "product-debug",
+        "type": "public_channel",
+        "isMember": true,
+        "members": ["UDAN", "BROOMOTE"]
+      }
+    ],
+    "users": [
+      { "id": "BROOMOTE", "name": "roomote", "displayName": "Roomote" },
+      {
+        "id": "UDAN",
+        "name": "dan",
+        "displayName": "Dan Riccio",
+        "email": "local@roomote.dev"
+      }
+    ],
+    "messages": []
+  },
+  "events": [
+    {
+      "delayMs": 0,
+      "envelope": {
+        "kind": "event_callback",
+        "eventId": "$E1",
+        "event": {
+          "type": "app_mention",
+          "channel": "C123ABC456",
+          "user": "UDAN",
+          "text": "<@BROOMOTE> !fast In one short paragraph: what is idempotency in API design?",
+          "ts": "$TS1",
+          "channel_type": "channel"
+        }
+      }
+    },
+    {
+      "delayMs": 6000,
+      "envelope": {
+        "kind": "event_callback",
+        "eventId": "$E1",
+        "event": {
+          "type": "app_mention",
+          "channel": "C123ABC456",
+          "user": "UDAN",
+          "text": "<@BROOMOTE> !fast In one short paragraph: what is idempotency in API design?",
+          "ts": "$TS1",
+          "channel_type": "channel"
+        }
+      }
+    }
+  ],
+  "settleMs": 25000,
+  "timeoutMs": 180000
+}

--- a/packages/slack/evals/scenarios/slack-fast-answer.json
+++ b/packages/slack/evals/scenarios/slack-fast-answer.json
@@ -1,0 +1,57 @@
+{
+  "name": "slack-fast-answer",
+  "description": "A user @-mentions Roomote in a channel with a !fast question. Roomote should answer inline with a single, correct, threaded reply and no channel noise.",
+  "criteria": [
+    "The bot posts exactly one reply message, and it is a threaded reply whose thread_ts equals the ts of the mention that triggered it",
+    "The reply correctly answers the question: it explains that HTTP 429 means too many requests / rate limiting, and mentions backing off or honoring Retry-After as the standard client response",
+    "No channel-level (non-threaded) messages are posted by the bot",
+    "The reply is concise — a few sentences or short paragraphs — with no filler, apologies, or meta-commentary about being an AI"
+  ],
+  "state": {
+    "team": {
+      "id": "TROOMOTE",
+      "domain": "roomote-mock",
+      "timezone": "America/Los_Angeles"
+    },
+    "acceptedBotTokens": [],
+    "botUserId": "BROOMOTE",
+    "channels": [
+      {
+        "id": "C123ABC456",
+        "name": "product-debug",
+        "type": "public_channel",
+        "isMember": true,
+        "members": ["UDAN", "BROOMOTE"]
+      }
+    ],
+    "users": [
+      { "id": "BROOMOTE", "name": "roomote", "displayName": "Roomote" },
+      {
+        "id": "UDAN",
+        "name": "dan",
+        "displayName": "Dan Riccio",
+        "email": "local@roomote.dev"
+      }
+    ],
+    "messages": []
+  },
+  "events": [
+    {
+      "delayMs": 0,
+      "envelope": {
+        "kind": "event_callback",
+        "eventId": "$E1",
+        "event": {
+          "type": "app_mention",
+          "channel": "C123ABC456",
+          "user": "UDAN",
+          "text": "<@BROOMOTE> !fast What does HTTP status code 429 mean, and what is the standard way for a client to respond to it?",
+          "ts": "$TS1",
+          "channel_type": "channel"
+        }
+      }
+    }
+  ],
+  "settleMs": 20000,
+  "timeoutMs": 180000
+}

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -15,7 +15,8 @@
     "check-types:fast": "tsgo --noEmit",
     "mock:server": "dotenvx run -f ../../.env.local -- tsx scripts/run-mock-slack.ts",
     "test": "dotenvx run -f ../../.env.test -- vitest",
-    "clean": "rimraf .turbo"
+    "clean": "rimraf .turbo",
+    "eval:scenario": "dotenvx run -f ../../.env.local -- tsx evals/run-slack-scenario.ts"
   },
   "dependencies": {
     "@roomote/cloud-agents": "workspace:^",


### PR DESCRIPTION
Ports the two OpenRoomote changes that landed after this repo's split point (OpenRoomote #544), cherry-picked with original authorship preserved.

## Changes

1. **Slack behavior eval runner** (RooCodeInc/OpenRoomote#547) — criterion-based eval scenarios driven through the mock Slack harness: a new `eval:scenario` script in `packages/slack`, the runner at `packages/slack/evals/run-slack-scenario.ts`, two starter scenarios (`!fast` answer quality, duplicate-delivery dedup), and a guidance doc at `.agent-guidance/operations/slack-behavior-evals.md`. Applied cleanly.
2. **Render first-boot race fix** (RooCodeInc/OpenRoomote#548) — self-referencing hostname fallback to `RENDER_EXTERNAL_HOSTNAME` in `.docker/app/entrypoint.sh` plus a troubleshooting section in `deploy/render/README.md`. The README hunk auto-merged against this repo's diverged copy; reviewed and correct in context.

## How the port was scoped

This repo was cut from OpenRoomote with history squashed, so the split point was located by scanning OpenRoomote history for the commit whose tree is closest to this repo's initial commit: OpenRoomote `affc9a93` (#544). The remaining ~80-file baseline difference is the intentional split transformation (squashed Drizzle migrations, removed `cli`/`email` packages, deploy/docs/CI edits). Only these two commits postdate it.

## Validation

- `@roomote/slack` typecheck and lint pass; Prettier clean on all ported files
- `sh -n` syntax check on the entrypoint script
- Pre-push hooks (`lint:fast`, `check-types:fast`, `knip`) passed