### PR TITLE
[CI] Use Blacksmith Docker layer caching for image builds

### DIFF
--- a/.agent-guidance/operations/deployment.md
+++ b/.agent-guidance/operations/deployment.md
@@ -720,6 +720,13 @@ QEMU emulation: rustc segfaults during the worker toolchain install
 (rust-lang/rust#147026). Tags only exist once the manifest job completes, so
 downstream jobs must depend on `publish`, not `build`.
 
+Layer caching uses Blacksmith's persistent builder
+(`useblacksmith/setup-docker-builder` + `useblacksmith/build-push-action`),
+which mounts an NVMe layer cache per repo/Dockerfile/arch on the runner. Do
+not add `type=gha` `cache-from`/`cache-to` directives back: these images
+overflow GitHub's 10GB per-repo Actions cache and its per-ref scoping, so
+every build missed cache and paid a multi-minute cache export on top.
+
 Published bundles are hardened against source disclosure: the tsup configs for
 api, controller, bullmq, preview-proxy, and worker minify when
 `NODE_ENV=production` (with `keepNames` so error/class names survive), and the

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -187,13 +187,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up Docker builder
+        uses: useblacksmith/setup-docker-builder@v1
       - name: Build ${{ matrix.app }} Dockerfile
-        uses: docker/build-push-action@v6
+        uses: useblacksmith/build-push-action@v2
         with:
           context: .
           file: ${{ matrix.dockerfile }}
           push: false
           build-args: APP_ENV=development
-          cache-from: type=gha,scope=${{ matrix.app }}

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -176,8 +176,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      # Blacksmith's builder mounts a persistent NVMe layer cache into the
+      # runner (per repo/Dockerfile/arch). Unlike type=gha caching this has
+      # no 10GB repo cap or per-ref scoping, and skips the multi-minute
+      # cache export upload at the end of every build.
+      - name: Set up Docker builder
+        uses: useblacksmith/setup-docker-builder@v1
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -188,7 +192,7 @@ jobs:
 
       - name: Build and push ${{ matrix.app }} (${{ matrix.arch }}) by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: useblacksmith/build-push-action@v2
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -197,8 +201,6 @@ jobs:
           build-args: |
             APP_ENV=${{ needs.prepare.outputs.app_env }}
             RELEASE_VERSION=${{ needs.prepare.outputs.version }}
-          cache-from: type=gha,scope=ghcr-${{ matrix.app }}-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=ghcr-${{ matrix.app }}-${{ matrix.arch }}
 
       - name: Export digest
         shell: bash


### PR DESCRIPTION
## Problem

GHCR image builds almost never hit their Docker layer cache. Diagnosed from [run 28962359037](https://github.com/RooCodeInc/Roomote/actions/runs/28962359037):

- The publish workflow used `type=gha` buildx caching with `mode=max` across four scopes (app/worker × amd64/arm64). The exported layers total more than GitHub's **10GB per-repo Actions cache cap** (the repo was sitting at 10.55GB with LRU eviction active).
- GHA cache reads are scoped to the run's own ref plus the default branch, so publishing the same commit from `develop`, `main`, and a `v*` tag re-exported the full multi-GB cache set three times under three refs, evicting each other.
- Net effect: nearly every build (ARM especially) rebuilt the full image from scratch (~8-10 min) and then spent **~3.5 minutes uploading a cache export** that rarely survived to the next run.
- CI's Dockerfile build pulled from a `gha` scope that no workflow writes, so it never hit either.

## Change

Switch both workflows to Blacksmith's persistent builder (`useblacksmith/setup-docker-builder@v1` + `useblacksmith/build-push-action@v2`, a drop-in fork of `docker/build-push-action`):

- Layer cache lives on an NVMe sticky disk mounted into the runner, keyed per repo/Dockerfile/arch: no 10GB cap, no ref scoping, no cache export upload step.
- Dropped the now-unneeded `cache-from`/`cache-to` directives.
- The manifest-merge job keeps stock `docker/setup-buildx-action` since it only runs `imagetools create`.
- Documented the caching setup in the deployment guidance doc.

The existing native-runner matrix (no QEMU) and push-by-digest flow are unchanged; the Blacksmith action exposes the same `digest` output.

## Expected impact

Warm builds should drop from ~8-10 min per arch to roughly image-push time. The first run per Dockerfile/arch is a cold cache and will still take full build time.

## Validation

- `pnpm lint` (prettier) passes on the edited workflows; pre-push hook (lint:fast, check-types:fast, knip) passed.
- CI on this PR exercises the new actions via the Dockerfile build job.
- The publish path only runs on develop/main/tag pushes, so the first real verification will be the next develop push (expect a cold build) and the one after it (expect cache hits).
