### PR TITLE
[Chore] Ignore local env files in get-roomote project

### DIFF
--- a/deploy/get-roomote/.gitignore
+++ b/deploy/get-roomote/.gitignore
@@ -1,1 +1,2 @@
 .vercel
+.env*


### PR DESCRIPTION
The Vercel CLI appended `.env*` to `deploy/get-roomote/.gitignore` when linking the local directory to the `roo-code/get-roomote` project (it writes a local `.env.local` on link). Keeps pulled env files out of the repo.