### PR TITLE
[Improve] Bring the Azure DevOps source-control settings section to parity

### DIFF
--- a/.agent-guidance/features/ado-connection-setup.md
+++ b/.agent-guidance/features/ado-connection-setup.md
@@ -1,7 +1,7 @@
 ---
 title: Azure DevOps Connection Setup
 status: active
-last_reviewed: 2026-07-05
+last_reviewed: 2026-07-08
 owner: engineering
 summary: Operator-facing setup guide for connecting Azure DevOps to Roomote through deployment-token-backed source control, service hooks, and optional Entra-backed commenter account linking.
 ---
@@ -26,6 +26,11 @@ source-control connection. For the shared source-control boundary, see
 
 The current path supports:
 
+- validating newly saved `ADO_TOKEN` values against the organization
+  `connectionData` API from `/setup` and Settings (definitive rejections,
+  including Azure DevOps' 203 sign-in responses, block the save; connectivity
+  failures do not). Validation is skipped when no organization is available
+  from the submitted values or saved configuration.
 - syncing repositories visible to the Azure DevOps PAT into provider-tagged
   `repositories` rows from Settings > Environments > Source Control
 - cloning Azure DevOps repositories from the synced repository row's `cloneUrl`
@@ -112,6 +117,13 @@ environment variables:
    `ROOMOTE_AUTH_MICROSOFT_TENANT_ID` when present, and then to `common`.
 7. Optional `ADO_WEBHOOK_SECRET`. If omitted, the admin sync command generates
    and persists a random secret before creating service hooks.
+
+The Settings Source Control section treats Azure DevOps as configured only
+when the required `ADO_ORGANIZATION` and `ADO_TOKEN` values are present.
+Satisfied optional fields alone do not count: `ADO_TENANT_ID` falls back to
+`ROOMOTE_AUTH_MICROSOFT_TENANT_ID`, so deployments using Microsoft sign-in
+would otherwise show a bare credentials form instead of the provider setup
+instructions.
 
 The sync and worker credential paths resolve values in
 [`packages/ado/src/api.ts`](../../packages/ado/src/api.ts), preferring process
@@ -266,6 +278,7 @@ Use this sequence to verify a connection end to end:
 
 | Symptom                                                           | Likely cause                                                                                                                  | Check                                                                                                                                                             |
 | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Saving the config fails with `Azure DevOps rejected the token.`   | The PAT is expired, revoked, or not valid for the configured organization                                                     | Recreate the PAT for the bot/service account in the target organization and save it again                                                                         |
 | `ADO_ORGANIZATION is required to sync Azure DevOps repositories.` | Organization is missing from both process env and encrypted env vars                                                          | Verify `ADO_ORGANIZATION` is available to the web/runtime process                                                                                                 |
 | `ADO_TOKEN is required to sync Azure DevOps repositories.`        | Token is missing from both process env and encrypted env vars                                                                 | Verify `ADO_TOKEN` is available to the web/runtime process                                                                                                        |
 | Sync succeeds but repo is missing                                 | Token identity cannot see the repository                                                                                      | Confirm the bot/service account has organization, project, or repository access                                                                                   |
@@ -279,7 +292,7 @@ Use this sequence to verify a connection end to end:
 
 ## Related Implementation
 
-- [`packages/ado/src/api.ts`](../../packages/ado/src/api.ts) — token/base URL resolution, repository listing, repository row mapping, sync, service-hook setup, runtime credentials
+- [`packages/ado/src/api.ts`](../../packages/ado/src/api.ts) — token/base URL resolution, token validation, repository listing, repository row mapping, sync, service-hook setup, runtime credentials
 - [`apps/web/src/trpc/commands/source-control/index.ts`](../../apps/web/src/trpc/commands/source-control/index.ts) — admin-only sync command
 - [`apps/api/src/handlers/ado`](../../apps/api/src/handlers/ado) — Azure DevOps webhook ingestion, pull request automation routing, and PR comment mention handling
 - [`apps/web/src/trpc/commands/cloud-jobs/index.ts`](../../apps/web/src/trpc/commands/cloud-jobs/index.ts) — web launch provider inference from selected repositories and environment mappings

--- a/apps/web/src/app/(onboarding)/setup/sourceControlSetupCopy.ts
+++ b/apps/web/src/app/(onboarding)/setup/sourceControlSetupCopy.ts
@@ -3,6 +3,8 @@ import type { SourceControlProvider } from '@roomote/types';
 type SourceControlSetupCopy = {
   creationHref: string;
   setupLabel: string;
+  /** Indefinite article for `setupLabel` ("a" unless the label needs "an"). */
+  setupLabelArticle?: 'a' | 'an';
   creationHint?: string;
 };
 
@@ -29,8 +31,9 @@ const SOURCE_CONTROL_SETUP_COPY: Record<
   ado: {
     creationHref: 'https://dev.azure.com/_usersSettings/tokens',
     setupLabel: 'Azure DevOps personal access token',
+    setupLabelArticle: 'an',
     creationHint:
-      'Create the PAT with Code access and permission to manage service hook subscriptions for the projects Roomote should access. Roomote syncs repositories and configures pull request service hooks automatically.',
+      'Create the PAT with Code read & write scopes and permission to manage service hook subscriptions for the projects Roomote should access. Prefer a bot or service account that is a member of those projects; Roomote syncs repositories and configures pull request service hooks automatically. The organization is the slug from your https://dev.azure.com/<organization> URL.',
   },
 };
 

--- a/apps/web/src/components/settings/SourceControl.test.tsx
+++ b/apps/web/src/components/settings/SourceControl.test.tsx
@@ -51,7 +51,14 @@ const state = vi.hoisted(() => ({
       provider: 'ado',
       fields: [{ runtimeSatisfied: false, savedSatisfied: true }],
     },
-  ],
+  ] as {
+    provider: string;
+    fields: {
+      required?: boolean;
+      runtimeSatisfied: boolean;
+      savedSatisfied: boolean;
+    }[];
+  }[],
 }));
 
 const mutations = vi.hoisted(() => ({
@@ -493,6 +500,73 @@ describe('SourceControl settings', () => {
     expect(
       screen.queryByRole('button', { name: 'Hide config' }),
     ).not.toBeInTheDocument();
+  });
+
+  it('shows ADO setup instructions when only optional fields are satisfied by fallbacks', () => {
+    state.adoRepositories = [];
+    state.configProviders = [
+      {
+        provider: 'gitlab',
+        fields: [{ runtimeSatisfied: false, savedSatisfied: true }],
+      },
+      {
+        provider: 'gitea',
+        fields: [{ runtimeSatisfied: false, savedSatisfied: true }],
+      },
+      {
+        provider: 'ado',
+        fields: [
+          // ADO_ORGANIZATION and ADO_TOKEN (required) are unset; only the
+          // optional ADO_TENANT_ID is satisfied via the
+          // ROOMOTE_AUTH_MICROSOFT_TENANT_ID fallback.
+          { runtimeSatisfied: false, savedSatisfied: false },
+          { runtimeSatisfied: false, savedSatisfied: false },
+          { required: false, runtimeSatisfied: true, savedSatisfied: false },
+        ],
+      },
+    ];
+
+    render(<SourceControl />);
+
+    expect(
+      screen.queryByRole('button', { name: 'Refresh Azure DevOps' }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set it up' }));
+
+    expect(
+      screen.getByRole('link', { name: /Azure DevOps personal access token/ }),
+    ).toHaveAttribute('href', 'https://dev.azure.com/_usersSettings/tokens');
+    expect(screen.getByTestId('source-control-config-ado')).toBeInTheDocument();
+  });
+
+  it('keeps every expanded provider form visible when setting up multiple providers', () => {
+    state.giteaRepositories = [];
+    state.adoRepositories = [];
+    state.configProviders = [
+      {
+        provider: 'gitlab',
+        fields: [{ runtimeSatisfied: false, savedSatisfied: true }],
+      },
+      {
+        provider: 'gitea',
+        fields: [{ runtimeSatisfied: false, savedSatisfied: false }],
+      },
+      {
+        provider: 'ado',
+        fields: [{ runtimeSatisfied: false, savedSatisfied: false }],
+      },
+    ];
+
+    render(<SourceControl />);
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Set it up' })[0]!);
+    fireEvent.click(screen.getByRole('button', { name: 'Set it up' }));
+
+    expect(
+      screen.getByTestId('source-control-config-gitea'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('source-control-config-ado')).toBeInTheDocument();
   });
 
   it('shows a success toast when pull request delivery is saved', () => {

--- a/apps/web/src/components/settings/SourceControl.test.tsx
+++ b/apps/web/src/components/settings/SourceControl.test.tsx
@@ -39,26 +39,10 @@ const state = vi.hoisted(() => ({
   ],
   searchParams: '',
   configProviders: [
-    {
-      provider: 'gitlab',
-      fields: [{ runtimeSatisfied: false, savedSatisfied: true }],
-    },
-    {
-      provider: 'gitea',
-      fields: [{ runtimeSatisfied: false, savedSatisfied: true }],
-    },
-    {
-      provider: 'ado',
-      fields: [{ runtimeSatisfied: false, savedSatisfied: true }],
-    },
-  ] as {
-    provider: string;
-    fields: {
-      required?: boolean;
-      runtimeSatisfied: boolean;
-      savedSatisfied: boolean;
-    }[];
-  }[],
+    { provider: 'gitlab', configSatisfied: true },
+    { provider: 'gitea', configSatisfied: true },
+    { provider: 'ado', configSatisfied: true },
+  ],
 }));
 
 const mutations = vi.hoisted(() => ({
@@ -322,18 +306,9 @@ describe('SourceControl settings', () => {
       },
     ];
     state.configProviders = [
-      {
-        provider: 'gitlab',
-        fields: [{ runtimeSatisfied: false, savedSatisfied: true }],
-      },
-      {
-        provider: 'gitea',
-        fields: [{ runtimeSatisfied: false, savedSatisfied: true }],
-      },
-      {
-        provider: 'ado',
-        fields: [{ runtimeSatisfied: false, savedSatisfied: true }],
-      },
+      { provider: 'gitlab', configSatisfied: true },
+      { provider: 'gitea', configSatisfied: true },
+      { provider: 'ado', configSatisfied: true },
     ];
   });
 
@@ -463,18 +438,9 @@ describe('SourceControl settings', () => {
   it('shows setup links instead of sync for disconnected token providers', () => {
     state.gitLabRepositories = [];
     state.configProviders = [
-      {
-        provider: 'gitlab',
-        fields: [{ runtimeSatisfied: false, savedSatisfied: false }],
-      },
-      {
-        provider: 'gitea',
-        fields: [{ runtimeSatisfied: false, savedSatisfied: true }],
-      },
-      {
-        provider: 'ado',
-        fields: [{ runtimeSatisfied: false, savedSatisfied: true }],
-      },
+      { provider: 'gitlab', configSatisfied: false },
+      { provider: 'gitea', configSatisfied: true },
+      { provider: 'ado', configSatisfied: true },
     ];
 
     render(<SourceControl />);
@@ -502,28 +468,15 @@ describe('SourceControl settings', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('shows ADO setup instructions when only optional fields are satisfied by fallbacks', () => {
+  it('shows ADO setup instructions when required config is not satisfied', () => {
     state.adoRepositories = [];
     state.configProviders = [
-      {
-        provider: 'gitlab',
-        fields: [{ runtimeSatisfied: false, savedSatisfied: true }],
-      },
-      {
-        provider: 'gitea',
-        fields: [{ runtimeSatisfied: false, savedSatisfied: true }],
-      },
-      {
-        provider: 'ado',
-        fields: [
-          // ADO_ORGANIZATION and ADO_TOKEN (required) are unset; only the
-          // optional ADO_TENANT_ID is satisfied via the
-          // ROOMOTE_AUTH_MICROSOFT_TENANT_ID fallback.
-          { runtimeSatisfied: false, savedSatisfied: false },
-          { runtimeSatisfied: false, savedSatisfied: false },
-          { required: false, runtimeSatisfied: true, savedSatisfied: false },
-        ],
-      },
+      { provider: 'gitlab', configSatisfied: true },
+      { provider: 'gitea', configSatisfied: true },
+      // configSatisfied covers required fields only, so ADO stays
+      // unconfigured even when the optional ADO_TENANT_ID is satisfied via
+      // the ROOMOTE_AUTH_MICROSOFT_TENANT_ID fallback.
+      { provider: 'ado', configSatisfied: false },
     ];
 
     render(<SourceControl />);
@@ -544,18 +497,9 @@ describe('SourceControl settings', () => {
     state.giteaRepositories = [];
     state.adoRepositories = [];
     state.configProviders = [
-      {
-        provider: 'gitlab',
-        fields: [{ runtimeSatisfied: false, savedSatisfied: true }],
-      },
-      {
-        provider: 'gitea',
-        fields: [{ runtimeSatisfied: false, savedSatisfied: false }],
-      },
-      {
-        provider: 'ado',
-        fields: [{ runtimeSatisfied: false, savedSatisfied: false }],
-      },
+      { provider: 'gitlab', configSatisfied: true },
+      { provider: 'gitea', configSatisfied: false },
+      { provider: 'ado', configSatisfied: false },
     ];
 
     render(<SourceControl />);

--- a/apps/web/src/components/settings/SourceControl.tsx
+++ b/apps/web/src/components/settings/SourceControl.tsx
@@ -6,7 +6,6 @@ import Link from 'next/link';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
 import {
-  isRequiredField,
   prActions,
   sourceControlProviderDescriptors,
   sourceControlTokenBackedProviders,
@@ -703,17 +702,11 @@ function isProviderConfigured(
     (candidate) => candidate.provider === provider,
   );
 
-  if (!providerStatus) {
-    return false;
-  }
-
-  // Only required fields count: optional fields can be satisfied by
-  // unrelated deployment config (for example ADO_TENANT_ID falling back to
-  // ROOMOTE_AUTH_MICROSOFT_TENANT_ID), which must not hide the provider's
-  // setup instructions.
-  return providerStatus.fields
-    .filter(isRequiredField)
-    .every((field) => field.runtimeSatisfied || field.savedSatisfied);
+  // configSatisfied covers required fields only: optional fields can be
+  // satisfied by unrelated deployment config (for example ADO_TENANT_ID
+  // falling back to ROOMOTE_AUTH_MICROSOFT_TENANT_ID), which must not hide
+  // the provider's setup instructions.
+  return providerStatus?.configSatisfied ?? false;
 }
 
 function RepositoryLinks({

--- a/apps/web/src/components/settings/SourceControl.tsx
+++ b/apps/web/src/components/settings/SourceControl.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
 import {
+  isRequiredField,
   prActions,
   sourceControlProviderDescriptors,
   sourceControlTokenBackedProviders,
@@ -72,7 +73,6 @@ type SourceControlProviderBlockProps = {
   repositoryTarget: string;
   adminHelp?: ReactNode;
   configForm?: ReactNode;
-  onSetupClick?: () => void;
 };
 
 const TOKEN_PROVIDER_UI = {
@@ -219,9 +219,6 @@ export function SourceControl() {
     },
   } satisfies Record<SourceControlTokenBackedProvider, TokenProviderState>;
 
-  const [configuringProvider, setConfiguringProvider] =
-    useState<SourceControlTokenBackedProvider | null>(null);
-
   const providerBlocks: SourceControlProviderBlockProps[] = [
     {
       provider: 'github',
@@ -313,17 +310,14 @@ export function SourceControl() {
         provider,
         isAdmin,
         state: tokenProviderState[provider],
-        onConfigure: () => setConfiguringProvider(provider),
-        configForm:
-          tokenProviderState[provider].isConfigured ||
-          configuringProvider === provider ? (
-            <SourceControlConfigForm
-              provider={provider}
-              configStatus={sourceControlConfigStatus.data}
-              saveSuccessMessage={`${sourceControlProviderDescriptors[provider].label} credentials saved.`}
-              onSaved={() => tokenProviderState[provider].sync.mutate()}
-            />
-          ) : null,
+        configForm: (
+          <SourceControlConfigForm
+            provider={provider}
+            configStatus={sourceControlConfigStatus.data}
+            saveSuccessMessage={`${sourceControlProviderDescriptors[provider].label} credentials saved.`}
+            onSaved={() => tokenProviderState[provider].sync.mutate()}
+          />
+        ),
       }),
     ),
   ];
@@ -405,13 +399,11 @@ function buildTokenProviderBlock({
   provider,
   isAdmin,
   state,
-  onConfigure,
   configForm,
 }: {
   provider: SourceControlTokenBackedProvider;
   isAdmin: boolean;
   state: TokenProviderState;
-  onConfigure: () => void;
   configForm?: ReactNode;
 }): SourceControlProviderBlockProps {
   const { label } = sourceControlProviderDescriptors[provider];
@@ -456,7 +448,6 @@ function buildTokenProviderBlock({
       </>
     ),
     configForm,
-    onSetupClick: onConfigure,
     adminHelp: isAdmin
       ? `Missing a repo here? Confirm the ${label} ${ui.credentialName} can access it, then refresh ${label}.`
       : undefined,
@@ -566,7 +557,6 @@ function SourceControlProviderBlock({
   repositoryTarget,
   adminHelp,
   configForm,
-  onSetupClick,
 }: SourceControlProviderBlockProps) {
   const [isRepositoryListOpen, setIsRepositoryListOpen] = useState(false);
   const [isExpanded, setIsExpanded] = useState(isConfigured);
@@ -602,10 +592,7 @@ function SourceControlProviderBlock({
           <button
             type="button"
             className="cursor-pointer underline underline-offset-4 hover:text-accent-foreground"
-            onClick={() => {
-              setIsExpanded(true);
-              onSetupClick?.();
-            }}
+            onClick={() => setIsExpanded(true)}
           >
             Set it up
           </button>
@@ -681,7 +668,7 @@ function ProviderSetupInstructions({
     <div className="max-w-2xl space-y-4">
       <div className="space-y-2">
         <p className="text-sm font-semibold">
-          Create a{' '}
+          Create {setupCopy.setupLabelArticle ?? 'a'}{' '}
           <a
             href={setupCopy.creationHref}
             target="_blank"
@@ -716,11 +703,17 @@ function isProviderConfigured(
     (candidate) => candidate.provider === provider,
   );
 
-  return (
-    providerStatus?.fields.some(
-      (field) => field.runtimeSatisfied || field.savedSatisfied,
-    ) ?? false
-  );
+  if (!providerStatus) {
+    return false;
+  }
+
+  // Only required fields count: optional fields can be satisfied by
+  // unrelated deployment config (for example ADO_TENANT_ID falling back to
+  // ROOMOTE_AUTH_MICROSOFT_TENANT_ID), which must not hide the provider's
+  // setup instructions.
+  return providerStatus.fields
+    .filter(isRequiredField)
+    .every((field) => field.runtimeSatisfied || field.savedSatisfied);
 }
 
 function RepositoryLinks({

--- a/apps/web/src/trpc/commands/source-control/index.test.ts
+++ b/apps/web/src/trpc/commands/source-control/index.test.ts
@@ -11,6 +11,8 @@ const {
   mockSyncAdoRepositories,
   mockSyncGiteaRepositories,
   mockUpsertDeploymentEnvironmentVariables,
+  mockResolveAdoOrganization,
+  mockValidateAdoToken,
   mockValidateGiteaToken,
   mockEnv,
 } = vi.hoisted(() => ({
@@ -24,6 +26,8 @@ const {
   mockSyncAdoRepositories: vi.fn(),
   mockSyncGiteaRepositories: vi.fn(),
   mockUpsertDeploymentEnvironmentVariables: vi.fn(),
+  mockResolveAdoOrganization: vi.fn(),
+  mockValidateAdoToken: vi.fn(),
   mockValidateGiteaToken: vi.fn(),
   mockEnv: {
     ROOMOTE_APP_URL: 'https://roomote.example.com',
@@ -36,7 +40,9 @@ vi.mock('@roomote/ado', () => ({
     mockEnsureAdoServiceHooksForRepositories,
   removeAdoServiceHooksForRepositories:
     mockRemoveAdoServiceHooksForRepositories,
+  resolveAdoOrganization: mockResolveAdoOrganization,
   syncAdoRepositories: mockSyncAdoRepositories,
+  validateAdoToken: mockValidateAdoToken,
 }));
 
 vi.mock('@roomote/gitea', () => ({
@@ -151,6 +157,8 @@ describe('source-control commands', () => {
       { status: 'created', repositoryFullName: 'acme/Platform/backend' },
     ]);
     mockValidateGiteaToken.mockResolvedValue({ status: 'valid' });
+    mockResolveAdoOrganization.mockResolvedValue(null);
+    mockValidateAdoToken.mockResolvedValue({ status: 'valid' });
   });
 
   it('syncs Gitea repositories and configures pull request webhooks', async () => {
@@ -296,6 +304,53 @@ describe('source-control commands', () => {
         removed: 0,
       },
     });
+  });
+
+  it('rejects invalid Azure DevOps tokens during config validation', async () => {
+    mockValidateAdoToken.mockResolvedValue({
+      status: 'invalid',
+      error: 'Azure DevOps rejected the token.',
+    });
+
+    await expect(
+      assertValidSourceControlConfigInput({
+        provider: 'ado',
+        values: {
+          ADO_ORGANIZATION: 'acme',
+          ADO_TOKEN: 'ado-token',
+        },
+      }),
+    ).rejects.toThrow('Azure DevOps rejected the token.');
+
+    expect(mockValidateAdoToken).toHaveBeenCalledWith({
+      token: 'ado-token',
+      organization: 'acme',
+      baseUrl: undefined,
+    });
+  });
+
+  it('validates a new Azure DevOps token against the saved organization', async () => {
+    mockResolveAdoOrganization.mockResolvedValue('acme');
+
+    await assertValidSourceControlConfigInput({
+      provider: 'ado',
+      values: { ADO_TOKEN: 'ado-token' },
+    });
+
+    expect(mockValidateAdoToken).toHaveBeenCalledWith({
+      token: 'ado-token',
+      organization: 'acme',
+      baseUrl: undefined,
+    });
+  });
+
+  it('skips Azure DevOps token validation when no organization is available', async () => {
+    await assertValidSourceControlConfigInput({
+      provider: 'ado',
+      values: { ADO_TOKEN: 'ado-token' },
+    });
+
+    expect(mockValidateAdoToken).not.toHaveBeenCalled();
   });
 
   it('rejects invalid Gitea tokens during config validation', async () => {

--- a/apps/web/src/trpc/commands/source-control/index.ts
+++ b/apps/web/src/trpc/commands/source-control/index.ts
@@ -604,6 +604,10 @@ export async function assertValidSourceControlConfigInput(params: {
     params.provider === 'gitea'
       ? params.values?.['GITEA_TOKEN']?.trim()
       : undefined;
+  const nextAdoToken =
+    params.provider === 'ado'
+      ? params.values?.['ADO_TOKEN']?.trim()
+      : undefined;
 
   if (nextGitLabToken) {
     const validation = await GitLab.validateGitLabToken({
@@ -627,6 +631,26 @@ export async function assertValidSourceControlConfigInput(params: {
     const validation = await Gitea.validateGiteaToken({
       token: nextGiteaToken,
       baseUrl: nextGiteaBaseUrl,
+    });
+
+    if (validation.status === 'invalid') {
+      throw new Error(validation.error);
+    }
+  }
+
+  if (nextAdoToken) {
+    const nextAdoOrganization =
+      params.values?.['ADO_ORGANIZATION']?.trim() ??
+      (await Ado.resolveAdoOrganization());
+
+    if (!nextAdoOrganization) {
+      return;
+    }
+
+    const validation = await Ado.validateAdoToken({
+      token: nextAdoToken,
+      organization: nextAdoOrganization,
+      baseUrl: params.values?.['ADO_BASE_URL']?.trim() || undefined,
     });
 
     if (validation.status === 'invalid') {

--- a/packages/ado/src/__tests__/api.test.ts
+++ b/packages/ado/src/__tests__/api.test.ts
@@ -71,6 +71,7 @@ import {
   removeAdoServiceHooksForRepositories,
   getAdoDeploymentUser,
   listAdoRepositories,
+  validateAdoToken,
   type AdoRepository,
 } from '../api';
 
@@ -265,6 +266,78 @@ describe('Azure DevOps API helpers', () => {
       },
       isActive: true,
       linkedByUserId: 'user-1',
+    });
+  });
+
+  it('validates Azure DevOps tokens against the connection data API', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          authenticatedUser: {
+            id: 'user-guid',
+            uniqueName: 'roomote-bot@acme.example',
+            providerDisplayName: 'Roomote Bot',
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await expect(
+      validateAdoToken({
+        token: 'ado_test',
+        organization: 'acme',
+        baseUrl: 'https://dev.azure.com',
+        fetchImpl: fetchMock,
+      }),
+    ).resolves.toEqual({ status: 'valid', displayName: 'Roomote Bot' });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://dev.azure.com/acme/_apis/connectionData?api-version=7.1',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: `Basic ${Buffer.from(':ado_test').toString('base64')}`,
+        }),
+      }),
+    );
+  });
+
+  it('rejects definitively invalid Azure DevOps tokens during validation', async () => {
+    // Azure DevOps answers rejected PATs with a 203 sign-in page.
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response('<html>Sign in</html>', { status: 203 }));
+
+    await expect(
+      validateAdoToken({
+        token: 'bad_token',
+        organization: 'acme',
+        baseUrl: 'https://dev.azure.com',
+        fetchImpl: fetchMock,
+      }),
+    ).resolves.toEqual({
+      status: 'invalid',
+      error:
+        'Azure DevOps rejected the token. Confirm the PAT is active, belongs to the organization, and has Code read access.',
+    });
+  });
+
+  it('returns unknown when Azure DevOps token validation cannot complete', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValue(new Error('network unreachable'));
+
+    await expect(
+      validateAdoToken({
+        token: 'ado_test',
+        organization: 'acme',
+        baseUrl: 'https://dev.azure.com',
+        fetchImpl: fetchMock,
+      }),
+    ).resolves.toEqual({
+      status: 'unknown',
+      error: 'Could not verify the Azure DevOps token: network unreachable',
     });
   });
 

--- a/packages/ado/src/api.ts
+++ b/packages/ado/src/api.ts
@@ -19,6 +19,7 @@ import {
 const ADO_PROVIDER = 'ado' satisfies SourceControlProvider;
 const DEFAULT_ADO_BASE_URL = 'https://dev.azure.com';
 const ADO_API_VERSION = '7.1';
+const ADO_TOKEN_VALIDATION_TIMEOUT_MS = 10_000;
 const DEFAULT_ADO_GIT_USERNAME = 'ado';
 const ADO_SERVICE_HOOK_ENSURE_CONCURRENCY = 5;
 const ADO_SERVICE_HOOK_PUBLISHER_ID = 'tfs';
@@ -373,6 +374,85 @@ export async function getAdoDeploymentUser(options?: {
 
 export function clearAdoDeploymentUserCache(): void {
   cachedAdoDeploymentUser = null;
+}
+
+export type AdoTokenValidationResult =
+  | { status: 'valid'; displayName: string }
+  | { status: 'invalid'; error: string }
+  | { status: 'unknown'; error: string };
+
+export async function validateAdoToken({
+  token,
+  organization,
+  baseUrl,
+  fetchImpl = fetch,
+  timeoutMs = ADO_TOKEN_VALIDATION_TIMEOUT_MS,
+}: {
+  token: string;
+  organization: string;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}): Promise<AdoTokenValidationResult> {
+  try {
+    const organizationApiBaseUrl = buildAdoOrganizationApiBaseUrl({
+      baseUrl:
+        baseUrl === undefined
+          ? await resolveAdoBaseUrl()
+          : normalizeBaseUrl(baseUrl),
+      organization,
+    });
+    const response = await fetchImpl(
+      buildAdoApiUrl(organizationApiBaseUrl, '/_apis/connectionData', {
+        'api-version': ADO_API_VERSION,
+      }),
+      {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+          Authorization: buildAdoBasicAuthHeader(token),
+        },
+        signal: AbortSignal.timeout(timeoutMs),
+      },
+    );
+
+    // Azure DevOps answers rejected PATs with a 203 sign-in page instead of
+    // a 401, so treat that status as a definitive rejection too.
+    if ([203, 401, 403].includes(response.status)) {
+      return {
+        status: 'invalid',
+        error:
+          'Azure DevOps rejected the token. Confirm the PAT is active, belongs to the organization, and has Code read access.',
+      };
+    }
+
+    if (response.status !== 200) {
+      return {
+        status: 'unknown',
+        error: `Could not verify the Azure DevOps token: ${response.status} ${response.statusText}`,
+      };
+    }
+
+    const { authenticatedUser } = adoConnectionDataSchema.parse(
+      await response.json(),
+    );
+
+    return {
+      status: 'valid',
+      displayName:
+        authenticatedUser.providerDisplayName ??
+        authenticatedUser.displayName ??
+        authenticatedUser.uniqueName ??
+        authenticatedUser.id,
+    };
+  } catch (error) {
+    return {
+      status: 'unknown',
+      error: `Could not verify the Azure DevOps token: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
 }
 
 function normalizeAdoParentCommentId(


### PR DESCRIPTION
## Summary

Brings the Azure DevOps section of Settings > Source Control to parity with GitLab/Gitea, and fixes two UI bugs surfaced while testing it.

- **Save-time PAT validation**: newly saved `ADO_TOKEN` values are now validated against the organization `connectionData` API before persisting, matching GitLab/Gitea. Definitive rejections block the save — including Azure DevOps' quirk of answering rejected PATs with a 203 sign-in page instead of a 401. Connectivity failures don't block, and validation is skipped when no organization is available yet.
- **Setup instructions no longer hidden by unrelated config**: the settings page treated a provider as "configured" when *any* field was satisfied. `ADO_TENANT_ID` accepts `ROOMOTE_AUTH_MICROSOFT_TENANT_ID` as a fallback, so deployments using Microsoft sign-in showed a bare credentials form with no setup instructions. Providers now count as configured only when all required fields are satisfied.
- **Expanded sections always render their credentials form**: the page tracked a single "configuring" provider, so opening one provider's setup dropped the form out of any other open section (instructions with nowhere to paste credentials). The form now always renders in expanded sections and the extra state is gone.
- **Copy fixes**: correct article ("Create an Azure DevOps personal access token"), plus organization-slug, PAT-scope, and bot-account guidance in the creation hint.

Also updates `.agent-guidance/features/ado-connection-setup.md` to document the new validation and gating behavior.

## Testing

- New unit tests: `validateAdoToken` (valid / 203-rejection / network-unknown), ADO config-validation wiring (invalid token blocks save, saved-org fallback, skip without org), and component regressions for both UI bugs
- Verified live on a dev deployment: ADO shows the full setup walkthrough, and Gitea + ADO setup forms stay visible when both are open
- `pnpm lint:fast`, `pnpm check-types:fast`, and `pnpm knip` all pass