### PR TITLE
[Improve] Add a main-channel Railway template and a custom-domain deploy prompt

### DIFF
--- a/.agent-guidance/operations/deployment.md
+++ b/.agent-guidance/operations/deployment.md
@@ -39,15 +39,19 @@ Active infrastructure:
 9. `pnpm run doctor` local runtime diagnostics
 10. Validation GitHub Actions CI
 11. Railway PaaS deployment path under `deploy/railway/` — a maintained
-    template spec (`template.yaml`) plus operator guide for running the
+    template spec (`template.yaml`, published as two marketplace templates
+    that differ only in image channel: stable `:main` and latest-build
+    `:develop`) plus operator guide for running the
     published images on Railway with managed Postgres/Redis, hosted compute
     (Modal/E2B/Daytona; the Docker provider cannot run without a Docker
     socket), separate web/API origins instead of Caddy path routing, and
     `ROOMOTE_AUTO_GENERATE_KEYS=true` instead of installer-generated
     keypairs. `ROOMOTE_APP_URL` on the api service is the single
     canonical-origin knob (`ROOMOTE_PUBLIC_URL` stays unset; the app falls
-    back), so attaching a custom domain is a one-variable edit — see
-    "Attaching a custom domain" in `deploy/railway/README.md`
+    back) and the template's one optional deploy-time prompt, so a custom
+    domain is either entered on the deploy screen before first boot or
+    attached later as a one-variable edit — see "Attaching a custom
+    domain" in `deploy/railway/README.md`
 12. Coolify deployment path under `deploy/coolify/` — a maintained,
     paste-ready Docker Compose resource (`docker-compose.yaml`) plus operator
     guide for running the published images on a Coolify-managed server.

--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ _We're interested in PRs for tested support for other PaaS providers._
 ### Railway
 
 Railway uses managed Postgres/Redis and hosted compute such as Modal, E2B, or
-Daytona. Docker compute is not available there; see
+Daytona. Docker compute is not available there. The template below tracks the
+stable `main` channel; a develop-channel template also exists — see
 [deploy/railway/README.md](deploy/railway/README.md).
 
-[![Deploy with the template](https://railway.com/button.svg)](https://railway.com/deploy/bP3Lsu)
+[![Deploy with the template](https://railway.com/button.svg)](https://railway.com/deploy/Rj2cFo)
 
 ### Coolify
 

--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -1,13 +1,19 @@
 # Running Roomote on Railway
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/bP3Lsu)
+Two official templates are published, one per image channel:
+
+| Channel                     | Tracks     | Deploy                                                                                    |
+| --------------------------- | ---------- | ----------------------------------------------------------------------------------------- |
+| **main** (stable)           | `:main`    | [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/Rj2cFo) |
+| **develop** (latest builds) | `:develop` | [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/bP3Lsu) |
 
 This guide covers deploying Roomote on [Railway](https://railway.com) — either
-through the official Roomote template or by composing the services manually.
-The maintained service specification for the official template lives in
-[`template.yaml`](template.yaml); Railway does not read that file directly,
-but it is the source of truth that maintainers mirror into Railway's Template
-Composer.
+through an official Roomote template or by composing the services manually.
+Both templates are mirrored from the same maintained service specification,
+[`template.yaml`](template.yaml), and differ only in which image alias the
+four app services track; everything in this guide applies to both. Railway
+does not read that file directly, but it is the source of truth that
+maintainers mirror into Railway's Template Composer.
 
 For single-host Docker deployments, use the one-command installer or the
 Compose paths in [SELF_HOSTING.md](../../SELF_HOSTING.md) instead.
@@ -37,9 +43,12 @@ Compose paths in [SELF_HOSTING.md](../../SELF_HOSTING.md) instead.
   more than one service: each occurrence generates a different value, and
   `ENCRYPTION_KEY` must be identical everywhere.
 - **Provider credentials live in the app, not the template.** The template
-  ships with zero deploy-time inputs. Modal tokens and the model provider
-  API key are entered in the `/setup` wizard (or Settings) after first boot
-  and stored encrypted in Postgres.
+  ships with zero required deploy-time inputs. Modal tokens and the model
+  provider API key are entered in the `/setup` wizard (or Settings) after
+  first boot and stored encrypted in Postgres. The one optional prompt on
+  the deploy screen is `ROOMOTE_APP_URL`, for deployers who want a custom
+  domain from the start (see
+  [Attaching a custom domain](#attaching-a-custom-domain)).
 - **Live previews are off by default.** Preview subdomains need a wildcard
   domain, and Railway-generated service domains are single-label. Previews
   can be enabled later with a wildcard custom domain (see below); everything
@@ -64,9 +73,17 @@ needed.
 
 ## Image channel and versions
 
-The template tracks the mutable **`:develop`** alias, which the publish
-workflow moves to every new develop build (releases also move `:latest`).
-Nothing else in the template encodes a version:
+Each template tracks one mutable channel alias, which the publish workflow
+moves on every matching build:
+
+- The **main-channel** template tracks **`:main`**, moved on every build of
+  the `main` branch (each build also publishes an immutable `main-<sha>`
+  tag). This is the stable choice.
+- The **develop-channel** template tracks **`:develop`**, moved on every
+  build of the `develop` branch (immutable tag: `develop-<sha>`). Tagged
+  `v*` releases additionally move `:latest`.
+
+Nothing else in either template encodes a version:
 
 - The images bake `RELEASE_VERSION` at build time, and the app derives
   `DOCKER_WORKER_IMAGE` and `MODAL_BASE_IMAGE_REF` from it when those are
@@ -76,21 +93,24 @@ Nothing else in the template encodes a version:
   constant.
 
 To pin instead (recommended for production deployments): put the same
-immutable tag (`v*` or `develop-<sha>`) in the four app-service image fields.
-No other edits are needed — the derived values follow the image.
+immutable tag (`v*`, `main-<sha>`, or `develop-<sha>`) in the four
+app-service image fields. No other edits are needed — the derived values
+follow the image.
 
 ## Service topology
 
-| Railway service | Source                            | Start command                                      | Public domain                | Healthcheck        |
-| --------------- | --------------------------------- | -------------------------------------------------- | ---------------------------- | ------------------ |
-| `Postgres`      | Railway managed PostgreSQL        | —                                                  | no                           | managed            |
-| `Redis`         | Railway managed Redis             | —                                                  | no                           | managed            |
-| `minio`         | `minio/minio` + volume at `/data` | `minio server /data --console-address :9001`       | yes (HTTP proxy port 9000)   | —                  |
-| `web`           | `roomote-app:develop`             | `/roomote/.docker/app/entrypoint.sh web`           | yes (HTTP proxy port 8080)   | `/health`          |
-| `api`           | `roomote-app:develop`             | `/roomote/.docker/app/entrypoint.sh api`           | yes (HTTP proxy port 8080)   | `/health/liveness` |
-| `controller`    | `roomote-app:develop`             | `/roomote/.docker/app/entrypoint.sh controller`    | no                           | —                  |
-| `bullmq`        | `roomote-app:develop`             | `/roomote/.docker/app/entrypoint.sh bullmq`        | no                           | —                  |
-| `preview-proxy` | `roomote-app:develop` (optional)  | `/roomote/.docker/app/entrypoint.sh preview-proxy` | yes + wildcard custom domain | `/health`          |
+`<channel>` below is `main` or `develop`, per template.
+
+| Railway service | Source                             | Start command                                      | Public domain                | Healthcheck        |
+| --------------- | ---------------------------------- | -------------------------------------------------- | ---------------------------- | ------------------ |
+| `Postgres`      | Railway managed PostgreSQL         | —                                                  | no                           | managed            |
+| `Redis`         | Railway managed Redis              | —                                                  | no                           | managed            |
+| `minio`         | `minio/minio` + volume at `/data`  | `minio server /data --console-address :9001`       | yes (HTTP proxy port 9000)   | —                  |
+| `web`           | `roomote-app:<channel>`            | `/roomote/.docker/app/entrypoint.sh web`           | yes (HTTP proxy port 8080)   | `/health`          |
+| `api`           | `roomote-app:<channel>`            | `/roomote/.docker/app/entrypoint.sh api`           | yes (HTTP proxy port 8080)   | `/health/liveness` |
+| `controller`    | `roomote-app:<channel>`            | `/roomote/.docker/app/entrypoint.sh controller`    | no                           | —                  |
+| `bullmq`        | `roomote-app:<channel>`            | `/roomote/.docker/app/entrypoint.sh bullmq`        | no                           | —                  |
+| `preview-proxy` | `roomote-app:<channel>` (optional) | `/roomote/.docker/app/entrypoint.sh preview-proxy` | yes + wildcard custom domain | `/health`          |
 
 Railway's custom start command **bypasses the image entrypoint** and executes
 the command directly, so the full `/roomote/.docker/app/entrypoint.sh <service>`
@@ -175,8 +195,8 @@ uploads it into hosted-compute sandboxes at spawn time — no shared volume is
 needed. The version-less `worker-current.tar.gz` name works because the
 controller reads the release version from the `VERSION` file inside the
 archive. Do not leave `DOCKER_WORKER_RELEASE_PATH` unset: without it the
-controller falls back to fetching GitHub worker releases, which do not exist
-for `develop` builds.
+controller falls back to fetching GitHub worker releases, which only exist
+for tagged `v*` releases — not for `develop` or `main` branch builds.
 
 minio:
 
@@ -189,10 +209,12 @@ Notes:
 
 - `ROOMOTE_APP_URL` on api is the **single canonical-origin knob**: it is the
   URL users browse, and web/controller/bullmq reference
-  `${{api.ROOMOTE_APP_URL}}` rather than repeating the value. Do not set
-  `ROOMOTE_PUBLIC_URL` — it is optional and the app falls back to
-  `ROOMOTE_APP_URL` everywhere it would apply. See
-  [Attaching a custom domain](#attaching-a-custom-domain).
+  `${{api.ROOMOTE_APP_URL}}` rather than repeating the value. It is also the
+  template's one optional deploy-time prompt — the deploy screen shows it
+  pre-filled with the generated-domain reference so a custom domain can be
+  entered before first boot. Do not set `ROOMOTE_PUBLIC_URL` — it is
+  optional and the app falls back to `ROOMOTE_APP_URL` everywhere it would
+  apply. See [Attaching a custom domain](#attaching-a-custom-domain).
 - Leave `DOCKER_WORKER_IMAGE` and `MODAL_BASE_IMAGE_REF` **unset**. The app
   derives both from the `RELEASE_VERSION` baked into the running image, so
   they always match the deployed build. Setting them explicitly overrides
@@ -251,7 +273,11 @@ logs a warning when creation fails).
    `[auth-keypairs] Generated ...` in an app service's logs — whichever app
    service boots first wins the race and generates them).
 2. Open `https://<web-domain>/setup` (append `?token=<SETUP_TOKEN>` or paste
-   the token into the wizard's token step if you configured one).
+   the token into the wizard's token step if you configured one). If you
+   entered a custom domain in the `ROOMOTE_APP_URL` prompt at deploy time,
+   attach that domain to the web service and finish DNS first, then open
+   `/setup` on the custom domain — the generated domain will reject auth
+   with `403 Invalid origin`.
 3. Create the founding admin account (email/password works immediately;
    Slack or Microsoft sign-in can be added later).
 4. Connect GitHub with **Create GitHub App** — the manifest flow derives the
@@ -267,16 +293,34 @@ logs a warning when creation fails).
 
 ## Attaching a custom domain
 
-The template boots on Railway-generated domains, and `ROOMOTE_APP_URL` — the
-origin users browse — derives from the web service's generated domain. When
-you attach a custom domain to the web service, Railway does **not** update
-`RAILWAY_PUBLIC_DOMAIN`, so the app keeps treating the generated domain as
-canonical. The symptom is a working dashboard that rejects signup, login,
-and OAuth flows with `403 {"error":"Invalid origin"}`: the browser sends the
-custom domain as its `Origin`, and the auth layer only trusts
-`ROOMOTE_APP_URL`.
+By default the template boots on Railway-generated domains, and
+`ROOMOTE_APP_URL` — the origin users browse — derives from the web service's
+generated domain. A custom domain can be set either at deploy time (through
+the template's one optional prompt) or after deploy (a one-variable edit).
+Setting it at deploy time is preferable when you already own the domain:
+everything the setup wizard registers — in particular the GitHub App's OAuth
+callback and webhook URLs — derives from the canonical origin, so getting it
+right before `/setup` avoids reconnecting integrations later.
 
-The fix is a one-variable edit, because the app services all reference
+**At deploy time.** The deploy screen shows `ROOMOTE_APP_URL` on the api
+service pre-filled with the generated-domain reference
+(`https://${{web.RAILWAY_PUBLIC_DOMAIN}}`). Replace it with your domain, for
+example `https://app.example.com`. Then, after the project deploys:
+
+1. Add `app.example.com` as a custom domain on the **web** service and
+   complete the DNS setup.
+2. Open `/setup` on the custom domain — not the generated one. Once
+   `ROOMOTE_APP_URL` points at the custom domain, the generated web domain
+   rejects signup and login with `403 {"error":"Invalid origin"}`, which is
+   expected: only the canonical origin is trusted.
+
+**After deploy.** When you attach a custom domain to the web service on a
+running deployment, Railway does **not** update `RAILWAY_PUBLIC_DOMAIN`, so
+the app keeps treating the generated domain as canonical. The symptom is a
+working dashboard that rejects signup, login, and OAuth flows with
+`403 {"error":"Invalid origin"}`: the browser sends the custom domain as its
+`Origin`, and the auth layer only trusts `ROOMOTE_APP_URL`. The fix is a
+one-variable edit, because the app services all reference
 `${{api.ROOMOTE_APP_URL}}`:
 
 1. Add the custom domain (for example `app.example.com`) to the **web**
@@ -320,13 +364,14 @@ Live previews need a wildcard domain, which requires a domain you control:
   Railway's template-update notifications only exist for GitHub-repo-based
   templates, not Docker-image-based ones like this. Template changes affect
   new deploys only.
-- **Upgrade a deployment on `:develop`** by redeploying the four app
-  services — they pull the current alias, and everything version-coupled
-  derives from the new image. On an immutable pin, bump the tag in the four
-  image fields first. The api service's `db-migrate` pre-deploy applies any
-  schema changes, and the auto-generated keypairs persist in Postgres, so
-  sessions, job tokens, and preview tokens survive redeploys. To make this
-  happen automatically on every develop build, see
+- **Upgrade a deployment on a channel alias** (`:main` or `:develop`) by
+  redeploying the four app services — they pull the current alias, and
+  everything version-coupled derives from the new image. On an immutable
+  pin, bump the tag in the four image fields first. The api service's
+  `db-migrate` pre-deploy applies any schema changes, and the
+  auto-generated keypairs persist in Postgres, so sessions, job tokens, and
+  preview tokens survive redeploys. Develop-channel deployments can make
+  this happen automatically on every develop build — see
   [Auto-deploying every develop build](#auto-deploying-every-develop-build-optional).
 - **Back up** the Railway Postgres database (Railway backups or `pg_dump`)
   and the MinIO volume or external bucket. Everything else is reproducible
@@ -338,14 +383,16 @@ Live previews need a wildcard domain, which requires a domain you control:
 
 ## Auto-deploying every develop build (optional)
 
-Railway never redeploys on its own when a mutable tag like `:develop` moves,
-so a deployment tracking the alias only picks up new builds when someone
-redeploys the app services. The `Publish GHCR Images` workflow has an
-optional `deploy-railway` job that closes that gap: after each develop
-build's images publish, it calls Railway's public GraphQL API directly,
-finds every service in the environment running the `roomote-app` image,
-points it at the new immutable `develop-<short-sha>` tag, and redeploys it.
-Nothing extra runs inside the Railway project.
+Railway never redeploys on its own when a mutable tag like `:develop` or
+`:main` moves, so a deployment tracking a channel alias only picks up new
+builds when someone redeploys the app services. The `Publish GHCR Images`
+workflow has an optional `deploy-railway` job that closes that gap for the
+**develop channel**: after each develop build's images publish, it calls
+Railway's public GraphQL API directly, finds every service in the
+environment running the `roomote-app` image, points it at the new immutable
+`develop-<short-sha>` tag, and redeploys it. Nothing extra runs inside the
+Railway project. The job only fires on develop pushes today; main-channel
+deployments upgrade by redeploying the app services after a main build.
 
 Setup, once:
 
@@ -383,11 +430,25 @@ Railway project's token settings.
 
 ## Maintaining the marketplace template
 
-When the template needs to change, edit [`template.yaml`](template.yaml)
-first, then mirror the change into the published template through Railway's
-Template Composer. Re-run the first-boot verification on a scratch Railway
-project before publishing the update. When the change touches reference
-variables — in particular the `${{api.*}}` references to values that are
-themselves references, like `ROOMOTE_APP_URL` — also open each app
-service's Variables tab on the scratch project and confirm the resolved
-values are real URLs, not literal `${{...}}` strings.
+Two published templates mirror the one spec in
+[`template.yaml`](template.yaml): the main-channel template
+(`railway.com/deploy/Rj2cFo`) and the develop-channel template
+(`railway.com/deploy/bP3Lsu`). They differ only in the app image alias
+(`:main` vs `:develop`); everything else must stay identical. When the spec
+changes, edit `template.yaml` first, then mirror the change into **both**
+published templates through Railway's Template Composer (Railway has no
+template-duplicate feature, so each is edited by hand). Re-run the
+first-boot verification on a scratch Railway project before publishing an
+update (one scratch run on either channel covers a change that does not
+touch the image fields). When the change touches reference variables — in
+particular the `${{api.*}}` references to values that are themselves
+references, like `ROOMOTE_APP_URL` — also open each app service's Variables
+tab on the scratch project and confirm the resolved values are real URLs,
+not literal `${{...}}` strings.
+
+The `ROOMOTE_APP_URL` deploy-time prompt needs its own check on the scratch
+deploy: confirm the deploy screen shows the variable with the description
+from `template.yaml` and the reference default pre-filled, that leaving the
+default still resolves to the generated web domain after deploy, and that
+overriding it with a test value reaches the app services as that literal
+value.

--- a/deploy/railway/template.yaml
+++ b/deploy/railway/template.yaml
@@ -1,11 +1,15 @@
 # Roomote Railway template definition.
 #
 # This file is the maintained source of truth for the official Roomote
-# template on Railway's marketplace. Railway does not consume this file
-# directly: a maintainer mirrors it into Railway's Template Composer when
-# creating or updating the published template. Values in `${{ ... }}` use
-# Railway's reference-variable and template-function syntax and are resolved
-# by Railway at deploy time.
+# templates on Railway's marketplace. Two templates are published from this
+# one spec — a develop-channel template tracking `:develop` and a
+# main-channel template tracking `:main` — and they differ ONLY in the app
+# image alias below; every service, variable, and note is otherwise
+# identical. Railway does not consume this file directly: a maintainer
+# mirrors it into Railway's Template Composer when creating or updating
+# each published template. Values in `${{ ... }}` use Railway's
+# reference-variable and template-function syntax and are resolved by
+# Railway at deploy time.
 #
 # Design notes:
 # - One shared `roomote-app` image runs web, api, controller, and bullmq;
@@ -18,21 +22,28 @@
 #   (including all `${{secret(n)}}` generated secrets, which MUST NOT be
 #   pasted into more than one service), and the other app services reference
 #   them as `${{api.NAME}}`.
-# - The template tracks the mutable `:develop` image alias and contains no
+# - Each published template tracks one mutable channel alias — `:develop`
+#   (every develop build) or `:main` (every main build) — and contains no
 #   version strings. The images bake RELEASE_VERSION; the app derives
 #   DOCKER_WORKER_IMAGE and MODAL_BASE_IMAGE_REF from it, and the controller
 #   reads the worker release version from the VERSION file inside
 #   worker-current.tar.gz. Production deployments can pin an immutable tag
-#   in the four image fields instead; nothing else needs editing. Railway
-#   does not redeploy when a mutable alias moves; deployments that want
-#   every develop build automatically can enable the publish workflow's
-#   deploy-railway job (README.md "Auto-deploying every develop build").
+#   (v*, develop-<sha>, or main-<sha>) in the four image fields instead;
+#   nothing else needs editing. Railway does not redeploy when a mutable
+#   alias moves; develop-channel deployments that want every develop build
+#   automatically can enable the publish workflow's deploy-railway job
+#   (README.md "Auto-deploying every develop build" — develop-only today).
 # - Railway has no Docker socket, so task execution must use a hosted
 #   compute provider (modal by default; e2b and daytona also work).
 #   EXCLUDED_COMPUTE_PROVIDERS=docker hides the unusable provider.
-# - Zero deploy-time inputs. Modal tokens and model provider keys are
-#   entered in the /setup wizard after first boot and stored encrypted in
-#   Postgres. Auth keypairs come from ROOMOTE_AUTO_GENERATE_KEYS=true.
+# - Zero required deploy-time inputs. Modal tokens and model provider keys
+#   are entered in the /setup wizard after first boot and stored encrypted
+#   in Postgres. Auth keypairs come from ROOMOTE_AUTO_GENERATE_KEYS=true.
+#   The one optional deploy-time prompt is ROOMOTE_APP_URL on api (see the
+#   annotation on that variable): deployers who already own a domain
+#   override the pre-filled default with https://<their-domain> before the
+#   first deploy instead of editing the variable after hitting 403
+#   "Invalid origin" errors.
 # - The api service must be publicly reachable: hosted compute workers and
 #   GitHub webhooks call `TRPC_URL` directly.
 # - Both published images are public on GHCR: Railway pulls roomote-app and
@@ -47,9 +58,10 @@
 #   app services receive the resolved URL, not a literal ${{...}} string;
 #   if resolution ever fails, fall back to repeating the raw
 #   https://${{web.RAILWAY_PUBLIC_DOMAIN}} value per service and accept the
-#   multi-service edit when changing domains. Attaching a custom domain is
-#   otherwise a one-variable edit; see "Attaching a custom domain" in
-#   README.md. ROOMOTE_PUBLIC_URL is intentionally not set — the app falls
+#   multi-service edit when changing domains. A custom domain is either set
+#   at deploy time through the ROOMOTE_APP_URL prompt or attached later as
+#   a one-variable edit; see "Attaching a custom domain" in README.md.
+#   ROOMOTE_PUBLIC_URL is intentionally not set — the app falls
 #   back to ROOMOTE_APP_URL wherever it would apply. Railway does not
 #   update RAILWAY_PUBLIC_DOMAIN when a custom domain is attached, and
 #   browsing an origin the app was not told about fails auth with 403
@@ -60,8 +72,12 @@
 # - Live previews stay disabled by default. They need a customer-owned
 #   wildcard custom domain; see the preview-proxy section in README.md.
 
+# The ONLY line that differs between the two published templates. Use the
+# alias for the channel being mirrored; deployments can also pin an
+# immutable v* / develop-<sha> / main-<sha> tag instead.
 image:
-  app: ghcr.io/roocodeinc/roomote-app:develop # or pin an immutable v* / develop-<sha> tag
+  app: ghcr.io/roocodeinc/roomote-app:main # main-channel template (stable)
+  # app: ghcr.io/roocodeinc/roomote-app:develop # develop-channel template
   worker: derived # ghcr.io/roocodeinc/roomote-worker:<baked RELEASE_VERSION>, resolved by the app
 
 # The api service anchors every shared value. Other app services reference
@@ -111,8 +127,20 @@ services:
       EXCLUDED_COMPUTE_PROVIDERS: docker
       DATABASE_URL: ${{Postgres.DATABASE_URL}}
       REDIS_URL: ${{Redis.REDIS_URL}}
-      # The single canonical-origin knob. To attach a custom domain, add it
-      # to the web service and change only this value to https://<domain>.
+      # The single canonical-origin knob, and the template's one (optional)
+      # deploy-time prompt. In the Template Composer, give this variable the
+      # description below so Railway surfaces it on the deploy screen with
+      # the reference default pre-filled. Leaving the default keeps the
+      # Railway-generated domain; overriding it with https://<domain> sets a
+      # custom domain before first boot, so the setup wizard derives OAuth
+      # callback and webhook URLs from the right origin from day one. The
+      # deployer must still attach the domain to the web service and finish
+      # DNS after deploy — see "Attaching a custom domain" in README.md.
+      # Composer description: "The URL users will browse. Leave the default
+      # to use the Railway-generated domain. To use a custom domain, replace
+      # this with https://app.example.com — then, after deploying, add that
+      # domain to the web service, finish DNS setup, and open /setup on the
+      # custom domain."
       ROOMOTE_APP_URL: https://${{web.RAILWAY_PUBLIC_DOMAIN}}
       TRPC_URL: https://${{api.RAILWAY_PUBLIC_DOMAIN}}
       S3_ENDPOINT: http://${{minio.RAILWAY_PRIVATE_DOMAIN}}:9000
@@ -156,8 +184,8 @@ services:
       # controller uploads it into hosted-compute sandboxes at spawn time.
       # The version-less name works because the controller reads the release
       # version from the VERSION file inside the archive. Do not unset: the
-      # fallback is GitHub worker releases, which do not exist for develop
-      # builds.
+      # fallback is GitHub worker releases, which only exist for tagged v*
+      # releases, not develop or main branch builds.
       DOCKER_WORKER_RELEASE_PATH: /roomote/releases/worker-current.tar.gz
 
   bullmq:


### PR DESCRIPTION
## What

Docs-and-spec update for the Railway deployment path (`deploy/railway/`). No runtime code changes.

### Per-channel marketplace templates

Two official Railway templates now exist, both mirrored from the single `template.yaml` spec and differing only in the app image alias:

| Channel | Tracks | Deploy |
| --- | --- | --- |
| **main** (stable) | `:main` | https://railway.com/deploy/Rj2cFo (new) |
| **develop** (latest builds) | `:develop` | https://railway.com/deploy/bP3Lsu (existing) |

The root README's quick-start button now points at the stable main-channel template. Channel/versioning docs are generalized (`main-<sha>` immutable pins, GitHub worker releases only existing for `v*` tags), and the GraphQL auto-deploy job is documented as develop-channel-only.

### Custom domain as a deploy-time prompt

`ROOMOTE_APP_URL` on the api service becomes the template's one optional deploy-time prompt, pre-filled with the generated-domain reference. Deployers who already own a domain can enter `https://app.example.com` on the deploy screen instead of discovering the post-deploy 403 "Invalid origin" fix, and the setup wizard's GitHub App manifest derives OAuth callback/webhook URLs from the right origin from day one. The default keeps today's behavior. The README's "Attaching a custom domain" section now documents both the deploy-time and after-deploy paths, and the maintainer checklist gains a scratch-project check for the prompt.

## Notes for reviewers

- The published templates were already updated in Railway's Template Composer (the main-channel template is live at the URL above); this PR brings the source-of-truth spec and docs in line.
- The maintainer checklist calls for first-boot verification on a scratch project, including confirming the `ROOMOTE_APP_URL` prompt renders with its description and that `${{api.*}}` references resolve to real URLs.
- `.agent-guidance/operations/deployment.md` is updated in the same change per guidance rules.

## Validation

- `pnpm exec prettier --check` on all touched files
- Pre-push hook (`lint:fast`, `check-types:fast`, `knip`) passed