### PR TITLE
[Improve] Correct Railway Composer notes after configuring the live prompts

### DIFF
--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -151,6 +151,8 @@ S3_ACCESS_KEY_ID=roomote
 S3_REGION=us-east-1
 S3_BUCKET_ARTIFACTS=roomote-artifacts
 S3_AUTO_CREATE_BUCKET=true
+SETUP_TOKEN=${{secret(32)}}
+ROOMOTE_PING_BASE_URL=https://ping.openmote.dev
 DEFAULT_COMPUTE_PROVIDER=modal
 EXCLUDED_COMPUTE_PROVIDERS=docker
 DATABASE_URL=${{Postgres.DATABASE_URL}}
@@ -174,6 +176,8 @@ S3_SECRET_ACCESS_KEY=${{api.S3_SECRET_ACCESS_KEY}}
 S3_ACCESS_KEY_ID=${{api.S3_ACCESS_KEY_ID}}
 S3_REGION=${{api.S3_REGION}}
 S3_BUCKET_ARTIFACTS=${{api.S3_BUCKET_ARTIFACTS}}
+SETUP_TOKEN=${{api.SETUP_TOKEN}}
+ROOMOTE_PING_BASE_URL=${{api.ROOMOTE_PING_BASE_URL}}
 DEFAULT_COMPUTE_PROVIDER=${{api.DEFAULT_COMPUTE_PROVIDER}}
 EXCLUDED_COMPUTE_PROVIDERS=${{api.EXCLUDED_COMPUTE_PROVIDERS}}
 DATABASE_URL=${{Postgres.DATABASE_URL}}
@@ -225,13 +229,18 @@ Notes:
   `/setup` wizard (or Settings → Compute / Models) after first boot; they are
   stored encrypted in Postgres. Setting them as env vars still works and
   takes precedence, but is unnecessary.
-- `SETUP_TOKEN` is optional and the template does not set it. When unset,
-  the pre-auth `/setup` wizard is open until the founding admin account is
-  created — on a publicly reachable Railway domain that is a short race
-  window you accept in exchange for a simpler first-run. To gate the wizard,
-  add `SETUP_TOKEN=${{secret(16)}}` on api: visitors to `/setup` are then
-  prompted for the token, which the operator copies from the api service's
-  variables panel. The URL form `/setup?token=<value>` also works.
+- `SETUP_TOKEN` gates the pre-auth `/setup` wizard and is **required**: the
+  app refuses tokenless first-admin bootstrap everywhere except local
+  development, so a deployment without it cannot complete setup at all.
+  The template generates it with `${{secret(32)}}`. Visitors to `/setup`
+  are prompted for the token, which the operator copies from the api
+  service's Variables tab in the deployed project. The URL form
+  `/setup?token=<value>` also works.
+- `ROOMOTE_PING_BASE_URL` is the endpoint for Roomote's anonymous analytics
+  and version checks (the image default is `https://ping.roomote.dev`; the
+  template points at the openmote ping service). Admins can opt out of
+  anonymous analytics in the setup wizard or **Settings → Misc**; version
+  checks ignore that setting.
 - Leave `PREVIEW_PROXY_BASE_URL` and `PREVIEW_DOMAINS` unset unless you
   enable live previews. Roomote boots without them; previews report as not
   configured in **Settings → Live Previews** until set.
@@ -272,8 +281,9 @@ logs a warning when creation fails).
    first boot also generates and persists the auth keypairs (watch for
    `[auth-keypairs] Generated ...` in an app service's logs — whichever app
    service boots first wins the race and generates them).
-2. Open `https://<web-domain>/setup` (append `?token=<SETUP_TOKEN>` or paste
-   the token into the wizard's token step if you configured one). If you
+2. Open `https://<web-domain>/setup` and paste the `SETUP_TOKEN` value from
+   the api service's Variables tab into the wizard's token step (or append
+   `?token=<SETUP_TOKEN>` to the URL). If you
    entered a custom domain in the `ROOMOTE_APP_URL` prompt at deploy time,
    attach that domain to the web service and finish DNS first, then open
    `/setup` on the custom domain — the generated domain will reject auth

--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -436,8 +436,9 @@ Two published templates mirror the one spec in
 (`railway.com/deploy/bP3Lsu`). They differ only in the app image alias
 (`:main` vs `:develop`); everything else must stay identical. When the spec
 changes, edit `template.yaml` first, then mirror the change into **both**
-published templates through Railway's Template Composer (Railway has no
-template-duplicate feature, so each is edited by hand). Re-run the
+published templates through Railway's Template Composer (the Templates list
+has a Duplicate action for seeding a new template, but edits to existing
+templates are applied to each by hand). Re-run the
 first-boot verification on a scratch Railway project before publishing an
 update (one scratch run on either channel covers a change that does not
 touch the image fields). When the change touches reference variables — in
@@ -447,8 +448,9 @@ tab on the scratch project and confirm the resolved values are real URLs,
 not literal `${{...}}` strings.
 
 The `ROOMOTE_APP_URL` deploy-time prompt needs its own check on the scratch
-deploy: confirm the deploy screen shows the variable with the description
-from `template.yaml` and the reference default pre-filled, that leaving the
-default still resolves to the generated web domain after deploy, and that
-overriding it with a test value reaches the app services as that literal
-value.
+deploy: on the deploy screen, open the api service's **Configure** step and
+expand its pre-configured environment variables — `ROOMOTE_APP_URL` must
+appear as an editable field with the description from `template.yaml` and
+the reference default pre-filled. Confirm that leaving the default still
+resolves to the generated web domain after deploy, and that overriding it
+with a test value reaches the app services as that literal value.

--- a/deploy/railway/template.yaml
+++ b/deploy/railway/template.yaml
@@ -52,13 +52,15 @@
 # - ROOMOTE_APP_URL on api is the single canonical-origin knob; the other
 #   app services reference ${{api.ROOMOTE_APP_URL}}. Note api's own value
 #   is itself a reference (https://${{web.RAILWAY_PUBLIC_DOMAIN}}), so this
-#   is a reference to a reference — a pattern Railway's docs neither
-#   promise nor rule out. The mandatory scratch-project first-boot run (see
-#   "Maintaining the marketplace template" in README.md) must confirm the
-#   app services receive the resolved URL, not a literal ${{...}} string;
-#   if resolution ever fails, fall back to repeating the raw
-#   https://${{web.RAILWAY_PUBLIC_DOMAIN}} value per service and accept the
-#   multi-service edit when changing domains. A custom domain is either set
+#   is a reference to a reference. Verified working on a scratch deploy
+#   (2026-07-08): the app services receive the resolved URL, not a literal
+#   ${{...}} string. Re-check it on the scratch-project first-boot run
+#   after template changes (see "Maintaining the marketplace template" in
+#   README.md); if resolution ever regresses, fall back to repeating the
+#   raw https://${{web.RAILWAY_PUBLIC_DOMAIN}} value per service and accept
+#   the multi-service edit when changing domains. Do NOT flatten the
+#   ${{api.*}} references to raw values in the Composer — that silently
+#   breaks the one-variable custom-domain edit. A custom domain is either set
 #   at deploy time through the ROOMOTE_APP_URL prompt or attached later as
 #   a one-variable edit; see "Attaching a custom domain" in README.md.
 #   ROOMOTE_PUBLIC_URL is intentionally not set — the app falls

--- a/deploy/railway/template.yaml
+++ b/deploy/railway/template.yaml
@@ -66,9 +66,16 @@
 #   update RAILWAY_PUBLIC_DOMAIN when a custom domain is attached, and
 #   browsing an origin the app was not told about fails auth with 403
 #   "Invalid origin".
-# - SETUP_TOKEN is intentionally unset for a simpler first run; /setup is
-#   open until the founding admin exists. Deployments that want to gate the
-#   wizard add SETUP_TOKEN=${{secret(16)}} on api (see README.md).
+# - SETUP_TOKEN=${{secret(32)}} gates the /setup wizard. The app requires a
+#   setup token everywhere except local development — a deployment without
+#   one cannot bootstrap its founding admin at all — so the template must
+#   generate it. The operator copies the value from the api service's
+#   Variables tab and pastes it into the wizard's token step (the URL form
+#   /setup?token=<value> also works).
+# - ROOMOTE_PING_BASE_URL points the anonymous-analytics and version-check
+#   pings at the openmote ping service (the code default is
+#   https://ping.roomote.dev). Admins can opt out of analytics in the setup
+#   wizard or Settings -> Misc; version checks ignore that setting.
 # - Live previews stay disabled by default. They need a customer-owned
 #   wildcard custom domain; see the preview-proxy section in README.md.
 
@@ -123,6 +130,8 @@ services:
       S3_REGION: us-east-1
       S3_BUCKET_ARTIFACTS: roomote-artifacts
       S3_AUTO_CREATE_BUCKET: 'true' # api creates the MinIO bucket at boot; no manual mc step
+      SETUP_TOKEN: ${{secret(32)}} # gates /setup; required outside local dev (see design notes)
+      ROOMOTE_PING_BASE_URL: https://ping.openmote.dev # anonymous-analytics / version-check pings
       DEFAULT_COMPUTE_PROVIDER: modal
       EXCLUDED_COMPUTE_PROVIDERS: docker
       DATABASE_URL: ${{Postgres.DATABASE_URL}}
@@ -165,6 +174,8 @@ services:
       S3_ACCESS_KEY_ID: ${{api.S3_ACCESS_KEY_ID}}
       S3_REGION: ${{api.S3_REGION}}
       S3_BUCKET_ARTIFACTS: ${{api.S3_BUCKET_ARTIFACTS}}
+      SETUP_TOKEN: ${{api.SETUP_TOKEN}}
+      ROOMOTE_PING_BASE_URL: ${{api.ROOMOTE_PING_BASE_URL}}
       DEFAULT_COMPUTE_PROVIDER: ${{api.DEFAULT_COMPUTE_PROVIDER}}
       EXCLUDED_COMPUTE_PROVIDERS: ${{api.EXCLUDED_COMPUTE_PROVIDERS}}
       DATABASE_URL: ${{Postgres.DATABASE_URL}}


### PR DESCRIPTION
Follow-up to #10, aligning the spec and operator guide with the published templates (main `Rj2cFo`, develop `bP3Lsu`).

**Composer corrections** (from configuring the `ROOMOTE_APP_URL` deploy-screen prompt on both templates and verifying on the live deploy screens):
- Railway **does** have a template Duplicate action; the maintainer note no longer claims otherwise.
- The prompt surfaces inside the api service's **Configure** step, and the verification checklist now says where to look.

**Spec adoption of two variables the published templates already ship:**
- `SETUP_TOKEN=${{secret(32)}}` on api (referenced by the other app services). This is not optional anymore: `apps/web/src/lib/server/setup-token.ts` refuses tokenless first-admin bootstrap outside local development, so a template without it cannot complete setup at all. The spec previously said it was intentionally unset — that note was stale against the app.
- `ROOMOTE_PING_BASE_URL=https://ping.openmote.dev` — anonymous-analytics and version-check pings (image default is `ping.roomote.dev`); analytics opt-out stays available in the setup wizard and Settings → Misc.