### PR TITLE
[Improve] Add workspace-discovered Railway fleet auto-deploy for main builds

### DIFF
--- a/.agent-guidance/operations/deployment.md
+++ b/.agent-guidance/operations/deployment.md
@@ -559,18 +559,27 @@ same immutable `develop-<short-sha>` tag. Keep the `preview` environment
 restricted to the `develop` branch and keep the deployment serialized through
 the workflow's `preview-deploy` concurrency group.
 
-The same workflow has an optional `deploy-railway` job that keeps a Railway
-deployment current with every develop build. It is gated on the repository
-variable `ROOMOTE_RAILWAY_AUTODEPLOY=true` (skipped otherwise) and runs in the
-GitHub `railway` environment with a single environment-scoped secret,
-`ROOMOTE_RAILWAY_PROJECT_TOKEN` — a Railway project token that can only touch
-one environment. The job calls Railway's public GraphQL API directly
-(`Project-Access-Token` header): it resolves the environment from the token,
-matches services whose image starts with `ghcr.io/<owner>/roomote-app`, then
-issues `serviceInstanceUpdate` with the immutable `develop-<short-sha>` tag
-and `serviceInstanceDeploy` for each. There is no intermediary service and no
-public endpoint. The operator runbook is the "Auto-deploying every develop
-build" section of `deploy/railway/README.md`.
+The same workflow has two optional Railway auto-deploy jobs, both thin
+wrappers around `.github/scripts/railway-deploy.sh`, which calls Railway's
+public GraphQL API directly — no intermediary service and no public
+endpoint. The script matches services whose image starts with
+`ghcr.io/<owner>/roomote-app`, then issues `serviceInstanceUpdate` with the
+immutable channel tag and `serviceInstanceDeploy` for each. `deploy-railway`
+keeps a single deployment current with every develop build: gated on the
+repository variable `ROOMOTE_RAILWAY_AUTODEPLOY=true`, it runs in the GitHub
+`railway` environment with `ROOMOTE_RAILWAY_PROJECT_TOKEN` — a Railway
+project token that can only touch one environment, which the script resolves
+from the token (`Project-Access-Token` header). `deploy-railway-fleet` keeps
+every deployment in a dedicated Railway workspace current with every main
+build: gated on `ROOMOTE_RAILWAY_FLEET_AUTODEPLOY=true`, it runs in the
+GitHub `railway-fleet` environment with `ROOMOTE_RAILWAY_WORKSPACE_TOKEN` —
+a workspace token (`Authorization: Bearer` header) whose blast radius is the
+dedicated fleet workspace. The fleet is discovered from the workspace rather
+than configured, an optional `ROOMOTE_RAILWAY_FLEET_CANARY` project deploys
+first and aborts the rest on failure, and per-environment failures elsewhere
+don't stop the run (results land in the Actions job summary). The operator
+runbook is the "Auto-deploying channel builds" section of
+`deploy/railway/README.md`.
 
 Upgrade and rollback are intentionally tag switches. `roomote-deploy upgrade`
 copies the new Compose/Caddy files, removes stale systemd loading of bootstrap

--- a/.github/scripts/railway-deploy.sh
+++ b/.github/scripts/railway-deploy.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# Pin Railway services running the roomote-app image to an immutable tag and
+# redeploy them, via Railway's public GraphQL API.
+#
+# Two token modes:
+#   RAILWAY_TOKEN_TYPE=project    An environment-scoped project token. The
+#                                 single target environment is resolved from
+#                                 the token itself. Used by the develop
+#                                 preview deployment.
+#   RAILWAY_TOKEN_TYPE=workspace  A workspace (team) token. Every environment
+#                                 in the workspace with services running the
+#                                 image prefix is discovered and deployed —
+#                                 the fleet is whatever lives in the
+#                                 workspace, so onboarding a deployment needs
+#                                 no CI change. Used by the main-channel
+#                                 fleet. When RAILWAY_CANARY_PROJECT is set,
+#                                 that project deploys first and a failure
+#                                 there aborts the rest of the fleet.
+#
+# Inputs (env):
+#   RAILWAY_TOKEN           required  project or workspace token
+#   RAILWAY_TOKEN_TYPE      required  "project" | "workspace"
+#   RAILWAY_IMAGE           required  full image ref to pin, e.g.
+#                                     ghcr.io/roocodeinc/roomote-app:main-abcd1234
+#   RAILWAY_IMAGE_PREFIX    required  image prefix that selects app services
+#   RAILWAY_CANARY_PROJECT  optional  project name deployed first (workspace)
+#
+# Per-environment failures in workspace mode are tolerated: the run continues
+# to the remaining environments and the script exits non-zero at the end so
+# the job still reports failure. Both mutations are idempotent (set the
+# image, then deploy), so a retried or partially failed run is safe to
+# re-run. A markdown result table is appended to GITHUB_STEP_SUMMARY when it
+# is set.
+
+set -euo pipefail
+
+: "${RAILWAY_TOKEN:?RAILWAY_TOKEN is required}"
+: "${RAILWAY_TOKEN_TYPE:?RAILWAY_TOKEN_TYPE is required (project|workspace)}"
+: "${RAILWAY_IMAGE:?RAILWAY_IMAGE is required}"
+: "${RAILWAY_IMAGE_PREFIX:?RAILWAY_IMAGE_PREFIX is required}"
+
+api=https://backboard.railway.com/graphql/v2
+
+case "$RAILWAY_TOKEN_TYPE" in
+  project) auth_header="Project-Access-Token: ${RAILWAY_TOKEN}" ;;
+  workspace) auth_header="Authorization: Bearer ${RAILWAY_TOKEN}" ;;
+  *)
+    echo "RAILWAY_TOKEN_TYPE must be 'project' or 'workspace', got '$RAILWAY_TOKEN_TYPE'" >&2
+    exit 1
+    ;;
+esac
+
+# POST one GraphQL operation. Fails on transport errors and on GraphQL-level
+# errors, and prints only the data payload.
+gql() {
+  local query="$1" variables="${2:-null}" response
+  response="$(jq -n --arg query "$query" --argjson variables "$variables" \
+    '{query: $query, variables: $variables}' \
+    | curl -sS --fail-with-body --retry 3 --retry-all-errors \
+        -X POST "$api" \
+        -H 'Content-Type: application/json' \
+        -H "$auth_header" \
+        --data-binary @-)"
+  if [ "$(jq 'has("errors")' <<< "$response")" = "true" ]; then
+    jq -r '.errors[].message' <<< "$response" >&2
+    return 1
+  fi
+  jq '.data' <<< "$response"
+}
+
+# List the roomote-app service instances in one environment as a compact
+# JSON array of {serviceId, serviceName}.
+environment_services() {
+  local environment_id="$1"
+  gql 'query ($environmentId: String!) {
+    environment(id: $environmentId) {
+      serviceInstances {
+        edges { node { serviceId serviceName source { image } } }
+      }
+    }
+  }' "$(jq -n --arg environmentId "$environment_id" '{environmentId: $environmentId}')" \
+    | jq -c --arg prefix "$RAILWAY_IMAGE_PREFIX" \
+        '[.environment.serviceInstances.edges[].node
+          | select(.source.image != null and (.source.image | startswith($prefix)))
+          | {serviceId, serviceName}]'
+}
+
+# Pin every listed service to RAILWAY_IMAGE and redeploy it.
+deploy_environment() {
+  local environment_id="$1" services="$2" count service_id service_name i
+  count="$(jq 'length' <<< "$services")"
+  for i in $(seq 0 $((count - 1))); do
+    service_id="$(jq -r ".[$i].serviceId" <<< "$services")"
+    service_name="$(jq -r ".[$i].serviceName" <<< "$services")"
+    echo "  Updating $service_name to $RAILWAY_IMAGE"
+    gql 'mutation ($environmentId: String!, $serviceId: String!, $input: ServiceInstanceUpdateInput!) {
+      serviceInstanceUpdate(environmentId: $environmentId, serviceId: $serviceId, input: $input)
+    }' "$(jq -n \
+          --arg environmentId "$environment_id" \
+          --arg serviceId "$service_id" \
+          --arg image "$RAILWAY_IMAGE" \
+          '{environmentId: $environmentId, serviceId: $serviceId, input: {source: {image: $image}}}')" \
+      > /dev/null
+    gql 'mutation ($environmentId: String!, $serviceId: String!) {
+      serviceInstanceDeploy(environmentId: $environmentId, serviceId: $serviceId, latestCommit: false)
+    }' "$(jq -n \
+          --arg environmentId "$environment_id" \
+          --arg serviceId "$service_id" \
+          '{environmentId: $environmentId, serviceId: $serviceId}')" \
+      > /dev/null
+  done
+}
+
+summary_rows=""
+record_result() {
+  local project="$1" environment="$2" services="$3" status="$4"
+  summary_rows="${summary_rows}| ${project} | ${environment} | ${services} | ${status} |"$'\n'
+}
+
+write_summary() {
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    {
+      echo "## Railway deploy — \`${RAILWAY_IMAGE}\`"
+      echo ""
+      echo "| Project | Environment | Services | Status |"
+      echo "| --- | --- | --- | --- |"
+      printf '%s' "$summary_rows"
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+if [ "$RAILWAY_TOKEN_TYPE" = "project" ]; then
+  # A project token is scoped to a single environment; resolve it from the
+  # token instead of configuring it separately.
+  environment_id="$(gql 'query { projectToken { environmentId } }' \
+    | jq -r '.projectToken.environmentId')"
+
+  services="$(environment_services "$environment_id")"
+  count="$(jq 'length' <<< "$services")"
+  if [ "$count" -eq 0 ]; then
+    echo "No Railway services run an image with prefix $RAILWAY_IMAGE_PREFIX" >&2
+    exit 1
+  fi
+
+  deploy_environment "$environment_id" "$services"
+  record_result "(project token)" "$environment_id" "$count" "updated"
+  write_summary
+  echo "Updated $count service(s) to $RAILWAY_IMAGE"
+  exit 0
+fi
+
+# Workspace mode: discover every environment in the workspace that runs the
+# app image. Targets are emitted as one JSON object per line:
+# {project, environmentId, environmentName, services: [...]}.
+projects="$(gql 'query {
+  projects {
+    edges {
+      node {
+        id
+        name
+        environments { edges { node { id name } } }
+      }
+    }
+  }
+}' | jq -c '[.projects.edges[].node
+      | {id, name, environments: [.environments.edges[].node]}]')"
+
+targets=""
+project_count="$(jq 'length' <<< "$projects")"
+for p in $(seq 0 $((project_count - 1))); do
+  project_name="$(jq -r ".[$p].name" <<< "$projects")"
+  env_count="$(jq ".[$p].environments | length" <<< "$projects")"
+  for e in $(seq 0 $((env_count - 1))); do
+    environment_id="$(jq -r ".[$p].environments[$e].id" <<< "$projects")"
+    environment_name="$(jq -r ".[$p].environments[$e].name" <<< "$projects")"
+    services="$(environment_services "$environment_id")"
+    if [ "$(jq 'length' <<< "$services")" -gt 0 ]; then
+      targets="${targets}$(jq -nc \
+        --arg project "$project_name" \
+        --arg environmentId "$environment_id" \
+        --arg environmentName "$environment_name" \
+        --argjson services "$services" \
+        '{project: $project, environmentId: $environmentId, environmentName: $environmentName, services: $services}')"$'\n'
+    fi
+  done
+done
+
+if [ -z "$targets" ]; then
+  echo "No environments in the workspace run an image with prefix $RAILWAY_IMAGE_PREFIX" >&2
+  exit 1
+fi
+
+# Canary first: order the canary project's environments ahead of the rest.
+if [ -n "${RAILWAY_CANARY_PROJECT:-}" ]; then
+  canary_targets="$(jq -c --arg canary "$RAILWAY_CANARY_PROJECT" \
+    'select(.project == $canary)' <<< "$targets" || true)"
+  rest_targets="$(jq -c --arg canary "$RAILWAY_CANARY_PROJECT" \
+    'select(.project != $canary)' <<< "$targets" || true)"
+  if [ -z "$canary_targets" ]; then
+    echo "Canary project '$RAILWAY_CANARY_PROJECT' has no matching services in the workspace" >&2
+    exit 1
+  fi
+  targets="${canary_targets}"$'\n'"${rest_targets}"
+fi
+
+failed=0
+while IFS= read -r target; do
+  [ -z "$target" ] && continue
+  project="$(jq -r '.project' <<< "$target")"
+  environment_id="$(jq -r '.environmentId' <<< "$target")"
+  environment_name="$(jq -r '.environmentName' <<< "$target")"
+  services="$(jq -c '.services' <<< "$target")"
+  count="$(jq 'length' <<< "$services")"
+
+  echo "Deploying $project / $environment_name ($count service(s))"
+  if deploy_environment "$environment_id" "$services"; then
+    record_result "$project" "$environment_name" "$count" "updated"
+  else
+    record_result "$project" "$environment_name" "$count" "FAILED"
+    failed=$((failed + 1))
+    # A canary failure means the build is suspect: stop before the fleet.
+    if [ -n "${RAILWAY_CANARY_PROJECT:-}" ] && [ "$project" = "$RAILWAY_CANARY_PROJECT" ]; then
+      echo "Canary project '$project' failed; aborting the remaining fleet" >&2
+      record_result "(remaining fleet)" "-" "-" "skipped after canary failure"
+      break
+    fi
+  fi
+done <<< "$targets"
+
+write_summary
+
+if [ "$failed" -gt 0 ]; then
+  echo "$failed environment(s) failed to deploy" >&2
+  exit 1
+fi
+echo "Fleet updated to $RAILWAY_IMAGE"

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -337,10 +337,10 @@ jobs:
             --version "$VERSION"
 
   # Optional: keep a Railway deployment pinned to every develop build. The
-  # job talks to Railway's public GraphQL API with an environment-scoped
-  # project token: it finds every service in that environment running the
-  # roomote-app image, points it at the new immutable develop-<sha> tag,
-  # and redeploys it. See deploy/railway/README.md for the setup runbook.
+  # job runs .github/scripts/railway-deploy.sh with an environment-scoped
+  # project token: it finds every service in that one environment running
+  # the roomote-app image, points it at the new immutable develop-<sha>
+  # tag, and redeploys it. See deploy/railway/README.md for the runbook.
   deploy-railway:
     name: Deploy Railway preview
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -353,81 +353,56 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Point Railway services at the new image tag
         shell: bash
         env:
-          RAILWAY_PROJECT_TOKEN: ${{ secrets.ROOMOTE_RAILWAY_PROJECT_TOKEN }}
+          RAILWAY_TOKEN: ${{ secrets.ROOMOTE_RAILWAY_PROJECT_TOKEN }}
+          RAILWAY_TOKEN_TYPE: project
         run: |
           set -euo pipefail
-          : "${RAILWAY_PROJECT_TOKEN:?ROOMOTE_RAILWAY_PROJECT_TOKEN is required}"
-
-          api=https://backboard.railway.com/graphql/v2
-
-          # POST one GraphQL operation. Fails on transport errors and on
-          # GraphQL-level errors, and prints only the data payload.
-          gql() {
-            local query="$1" variables="${2:-null}" response
-            response="$(jq -n --arg query "$query" --argjson variables "$variables" \
-              '{query: $query, variables: $variables}' \
-              | curl -sS --fail-with-body --retry 3 --retry-all-errors \
-                  -X POST "$api" \
-                  -H 'Content-Type: application/json' \
-                  -H "Project-Access-Token: ${RAILWAY_PROJECT_TOKEN}" \
-                  --data-binary @-)"
-            if [ "$(jq 'has("errors")' <<< "$response")" = "true" ]; then
-              jq -r '.errors[].message' <<< "$response" >&2
-              return 1
-            fi
-            jq '.data' <<< "$response"
-          }
-
+          : "${RAILWAY_TOKEN:?ROOMOTE_RAILWAY_PROJECT_TOKEN is required}"
           owner="$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')"
-          prefix="ghcr.io/${owner}/roomote-app"
-          image="${prefix}:develop-${GITHUB_SHA:0:8}"
+          export RAILWAY_IMAGE_PREFIX="ghcr.io/${owner}/roomote-app"
+          export RAILWAY_IMAGE="${RAILWAY_IMAGE_PREFIX}:develop-${GITHUB_SHA:0:8}"
+          .github/scripts/railway-deploy.sh
 
-          # A project token is scoped to a single environment; resolve it
-          # from the token instead of configuring it separately.
-          environment_id="$(gql 'query { projectToken { environmentId } }' \
-            | jq -r '.projectToken.environmentId')"
+  # Optional: keep a fleet of main-channel Railway deployments pinned to
+  # every main build. The job runs .github/scripts/railway-deploy.sh with a
+  # workspace (team) token: it discovers every environment in that Railway
+  # workspace with services running the roomote-app image, points them at
+  # the new immutable main-<sha> tag, and redeploys them — deploying a new
+  # customer into the workspace enrolls it with no CI change. When
+  # ROOMOTE_RAILWAY_FLEET_CANARY names a project, that project deploys
+  # first and a failure there aborts the rest of the fleet. See
+  # deploy/railway/README.md for the runbook.
+  deploy-railway-fleet:
+    name: Deploy Railway fleet
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: publish
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.ROOMOTE_RAILWAY_FLEET_AUTODEPLOY == 'true' }}
+    environment: railway-fleet
+    concurrency:
+      group: railway-fleet-deploy
+      cancel-in-progress: false
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-          services="$(gql 'query ($environmentId: String!) {
-            environment(id: $environmentId) {
-              serviceInstances {
-                edges { node { serviceId serviceName source { image } } }
-              }
-            }
-          }' "$(jq -n --arg environmentId "$environment_id" '{environmentId: $environmentId}')" \
-            | jq -c --arg prefix "$prefix" \
-                '[.environment.serviceInstances.edges[].node
-                  | select(.source.image != null and (.source.image | startswith($prefix)))]')"
-
-          count="$(jq 'length' <<< "$services")"
-          if [ "$count" -eq 0 ]; then
-            echo "No Railway services run an image with prefix $prefix" >&2
-            exit 1
-          fi
-
-          # Both mutations are idempotent (set the image, then deploy), so
-          # a retried or partially failed run is safe to re-run.
-          for i in $(seq 0 $((count - 1))); do
-            service_id="$(jq -r ".[$i].serviceId" <<< "$services")"
-            service_name="$(jq -r ".[$i].serviceName" <<< "$services")"
-            echo "Updating $service_name to $image"
-            gql 'mutation ($environmentId: String!, $serviceId: String!, $input: ServiceInstanceUpdateInput!) {
-              serviceInstanceUpdate(environmentId: $environmentId, serviceId: $serviceId, input: $input)
-            }' "$(jq -n \
-                  --arg environmentId "$environment_id" \
-                  --arg serviceId "$service_id" \
-                  --arg image "$image" \
-                  '{environmentId: $environmentId, serviceId: $serviceId, input: {source: {image: $image}}}')" \
-              > /dev/null
-            gql 'mutation ($environmentId: String!, $serviceId: String!) {
-              serviceInstanceDeploy(environmentId: $environmentId, serviceId: $serviceId, latestCommit: false)
-            }' "$(jq -n \
-                  --arg environmentId "$environment_id" \
-                  --arg serviceId "$service_id" \
-                  '{environmentId: $environmentId, serviceId: $serviceId}')" \
-              > /dev/null
-          done
-
-          echo "Updated $count service(s) to $image"
+      - name: Deploy the fleet to the new image tag
+        shell: bash
+        env:
+          RAILWAY_TOKEN: ${{ secrets.ROOMOTE_RAILWAY_WORKSPACE_TOKEN }}
+          RAILWAY_TOKEN_TYPE: workspace
+          RAILWAY_CANARY_PROJECT: ${{ vars.ROOMOTE_RAILWAY_FLEET_CANARY }}
+        run: |
+          set -euo pipefail
+          : "${RAILWAY_TOKEN:?ROOMOTE_RAILWAY_WORKSPACE_TOKEN is required}"
+          owner="$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')"
+          export RAILWAY_IMAGE_PREFIX="ghcr.io/${owner}/roomote-app"
+          export RAILWAY_IMAGE="${RAILWAY_IMAGE_PREFIX}:main-${GITHUB_SHA:0:8}"
+          .github/scripts/railway-deploy.sh

--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -380,9 +380,9 @@ Live previews need a wildcard domain, which requires a domain you control:
   pin, bump the tag in the four image fields first. The api service's
   `db-migrate` pre-deploy applies any schema changes, and the
   auto-generated keypairs persist in Postgres, so sessions, job tokens, and
-  preview tokens survive redeploys. Develop-channel deployments can make
-  this happen automatically on every develop build — see
-  [Auto-deploying every develop build](#auto-deploying-every-develop-build-optional).
+  preview tokens survive redeploys. Both channels can make this happen
+  automatically on every build — see
+  [Auto-deploying channel builds](#auto-deploying-channel-builds-optional).
 - **Back up** the Railway Postgres database (Railway backups or `pg_dump`)
   and the MinIO volume or external bucket. Everything else is reproducible
   from config.
@@ -391,52 +391,84 @@ Live previews need a wildcard domain, which requires a domain you control:
   through your compute provider (Modal/E2B/Daytona) and model usage bills
   through your model provider.
 
-## Auto-deploying every develop build (optional)
+## Auto-deploying channel builds (optional)
 
 Railway never redeploys on its own when a mutable tag like `:develop` or
 `:main` moves, so a deployment tracking a channel alias only picks up new
 builds when someone redeploys the app services. The `Publish GHCR Images`
-workflow has an optional `deploy-railway` job that closes that gap for the
-**develop channel**: after each develop build's images publish, it calls
-Railway's public GraphQL API directly, finds every service in the
-environment running the `roomote-app` image, points it at the new immutable
-`develop-<short-sha>` tag, and redeploys it. Nothing extra runs inside the
-Railway project. The job only fires on develop pushes today; main-channel
-deployments upgrade by redeploying the app services after a main build.
+workflow closes that gap with two optional jobs, both thin wrappers around
+[`railway-deploy.sh`](../../.github/scripts/railway-deploy.sh), which talks
+to Railway's public GraphQL API. Nothing extra runs inside the Railway
+projects.
 
-Setup, once:
-
-1. In the Railway project, create a **project token** for the target
-   environment (Project Settings → Tokens). Project tokens are scoped to
-   that one environment and can be revoked there at any time.
-2. On the GitHub repository, create a `railway` environment restricted to
-   the `develop` branch, with a single secret:
-   `ROOMOTE_RAILWAY_PROJECT_TOKEN`.
-3. Set the repository variable `ROOMOTE_RAILWAY_AUTODEPLOY=true`. The job is
-   skipped entirely while the variable is unset, so forks and deployments
-   that do not want auto-deploy need no other configuration.
-
-No project or environment IDs need to be configured: the job resolves the
-environment from the token itself (`query { projectToken { environmentId } }`).
-
-Each run matches services whose image starts with
+Shared mechanics: each run matches services whose image starts with
 `ghcr.io/<owner>/roomote-app` — api, web, controller, bullmq, and
 preview-proxy when present — then issues `serviceInstanceUpdate` with the
 pinned tag and `serviceInstanceDeploy` for each. The api service's
 `db-migrate` pre-deploy runs as usual. MinIO, Postgres, and Redis never
 match the prefix and are untouched. The first run permanently moves the
-matched services from the `:develop` alias to immutable
-`develop-<short-sha>` pins — intentional, since the pins make the deployed
-version visible in the Railway UI and make rollback a tag switch: edit the
-image field back to an older tag (or re-run the job from an older commit)
-to roll back.
+matched services from the channel alias to immutable `<channel>-<short-sha>`
+pins — intentional, since the pins make the deployed version visible in the
+Railway UI and make rollback a tag switch: edit the image field back to an
+older tag (or re-run the job from an older commit) to roll back. Both jobs
+are skipped entirely while their enable variable is unset, so forks and
+deployments that do not want auto-deploy need no other configuration.
 
-Security notes: the only credential is the project token, which can touch a
-single Railway environment and nothing else in the workspace. It lives in a
-GitHub environment secret, is never printed by the job, and GitHub does not
-expose environment secrets to fork pull requests, so open-sourcing the
-repository does not widen access. Rotate or revoke the token from the
-Railway project's token settings.
+### Single deployment on develop (`deploy-railway`)
+
+Fires on develop pushes and pins one deployment (the develop soak) to each
+`develop-<short-sha>` build, using an environment-scoped **project token**.
+
+Setup, once:
+
+1. In the Railway project, create a project token for the target
+   environment (Project Settings → Tokens). Project tokens are scoped to
+   that one environment and can be revoked there at any time.
+2. On the GitHub repository, create a `railway` environment restricted to
+   the `develop` branch, with a single secret:
+   `ROOMOTE_RAILWAY_PROJECT_TOKEN`.
+3. Set the repository variable `ROOMOTE_RAILWAY_AUTODEPLOY=true`.
+
+No project or environment IDs need to be configured: the job resolves the
+environment from the token itself (`query { projectToken { environmentId } }`).
+
+### Fleet of deployments on main (`deploy-railway-fleet`)
+
+Fires on main pushes and pins **every deployment in a dedicated Railway
+workspace** to each `main-<short-sha>` build, using a **workspace (team)
+token**. The fleet is discovered, not configured: the job lists the
+workspace's projects and environments and deploys every environment with
+services matching the image prefix. Onboarding a customer is just deploying
+the main-channel template into the fleet workspace — no CI change.
+
+Setup, once:
+
+1. Create a dedicated Railway workspace that holds only the fleet
+   deployments (plus the canary, below). The token can touch everything in
+   its workspace, so the workspace boundary is the blast-radius boundary —
+   do not mint it in a workspace that contains anything else.
+2. Create a **workspace token** (Workspace Settings → Tokens).
+3. On the GitHub repository, create a `railway-fleet` environment
+   restricted to the `main` branch, with a single secret:
+   `ROOMOTE_RAILWAY_WORKSPACE_TOKEN`.
+4. Set the repository variable `ROOMOTE_RAILWAY_FLEET_AUTODEPLOY=true`.
+5. Recommended: keep one deployment of your own in the workspace and set
+   the repository variable `ROOMOTE_RAILWAY_FLEET_CANARY=<project name>`.
+   The canary project deploys first, and a failure there aborts the rest of
+   the fleet, so a bad build reaches one deployment instead of all of them.
+
+Per-environment failures elsewhere in the fleet do not stop the run: the
+job continues to the remaining environments, reports every result in the
+Actions job summary (project, environment, services, status), and fails the
+run at the end if anything failed. Both mutations are idempotent, so
+re-running the job after a partial failure is safe.
+
+Security notes: the credentials live in GitHub environment secrets, are
+never printed by the jobs, and GitHub does not expose environment secrets
+to fork pull requests, so open-sourcing the repository does not widen
+access. The project token can touch a single Railway environment; the
+workspace token can touch its entire (dedicated) workspace — rotate or
+revoke either from Railway's token settings.
 
 ## Maintaining the marketplace template
 

--- a/deploy/railway/template.yaml
+++ b/deploy/railway/template.yaml
@@ -30,9 +30,10 @@
 #   worker-current.tar.gz. Production deployments can pin an immutable tag
 #   (v*, develop-<sha>, or main-<sha>) in the four image fields instead;
 #   nothing else needs editing. Railway does not redeploy when a mutable
-#   alias moves; develop-channel deployments that want every develop build
-#   automatically can enable the publish workflow's deploy-railway job
-#   (README.md "Auto-deploying every develop build" — develop-only today).
+#   alias moves; deployments that want every channel build automatically
+#   can enable the publish workflow's deploy-railway (develop) or
+#   deploy-railway-fleet (main, workspace-wide) job — see README.md
+#   "Auto-deploying channel builds".
 # - Railway has no Docker socket, so task execution must use a hosted
 #   compute provider (modal by default; e2b and daytona also work).
 #   EXCLUDED_COMPUTE_PROVIDERS=docker hides the unusable provider.


### PR DESCRIPTION
Keeps a fleet of main-channel Railway deployments (early-adopter subdomains) pinned to every main build, without per-customer CI configuration.

## Design

**One shared script, two token modes.** The `deploy-railway` job's inline GraphQL logic moves to [`.github/scripts/railway-deploy.sh`](.github/scripts/railway-deploy.sh):
- `project` mode — existing develop-preview behavior, unchanged: environment resolved from the project token, services matching `ghcr.io/<owner>/roomote-app` pinned to `develop-<sha>` and redeployed.
- `workspace` mode — new: a workspace (team) token lists the workspace's projects/environments and deploys **every** environment running the app image. The fleet is discovered, not configured: onboarding a customer = deploying the main-channel template into the fleet workspace. No new secrets, no name lists, no matrix.

**New `deploy-railway-fleet` job** fires on main pushes, gated by `ROOMOTE_RAILWAY_FLEET_AUTODEPLOY=true`, in a `railway-fleet` GitHub environment holding one secret (`ROOMOTE_RAILWAY_WORKSPACE_TOKEN`). Optional `ROOMOTE_RAILWAY_FLEET_CANARY=<project>` deploys that project first and aborts the fleet if it fails; other per-environment failures don't stop the run and every result lands in the Actions job summary. Mutations are idempotent, so re-running after a partial failure is safe.

**Blast radius**: the workspace token can touch its whole workspace, so the runbook requires a dedicated workspace containing only the fleet (+ canary). The develop job keeps its narrower environment-scoped project token.

## Testing needed before enabling

The `project`-mode path is the existing job's logic verbatim; the `workspace`-mode `projects` discovery query is new and can't run in CI without a real token. Before setting the enable variable, dry-run the script locally against the fleet workspace:

```sh
RAILWAY_TOKEN=<workspace token> RAILWAY_TOKEN_TYPE=workspace \
RAILWAY_IMAGE_PREFIX=ghcr.io/roocodeinc/roomote-app \
RAILWAY_IMAGE=ghcr.io/roocodeinc/roomote-app:main-<current sha> \
bash .github/scripts/railway-deploy.sh
```

(Re-pinning to the already-deployed tag is a no-op redeploy, so this is a safe live test.)

## Docs

- `deploy/railway/README.md`: "Auto-deploying every develop build" → "Auto-deploying channel builds" with per-job runbooks (develop single deployment, main fleet).
- `template.yaml` design note and `.agent-guidance/operations/deployment.md` updated to describe both jobs and the shared script.