### PR TITLE
[Feat] Mock Telegram Bot API harness and routing confirmation for Telegram task entry

### DIFF
--- a/.agent-guidance/features/telegram-integration.md
+++ b/.agent-guidance/features/telegram-integration.md
@@ -24,6 +24,7 @@ messages until they link.
 | `TELEGRAM_WEBHOOK_SECRET`  | Shared secret verified via `x-telegram-bot-api-secret-token`.                                                                                                                |
 | `TELEGRAM_BOT_USERNAME`    | Bot username, used for group-mention task entry detection.                                                                                                                   |
 | `TELEGRAM_PRIMARY_CHAT_ID` | Destination for proactive messages (starter suggestions). Captured automatically from the first private chat that reaches the webhook (`primary-chat.ts`); first write wins. |
+| `TELEGRAM_API_BASE_URL`    | Bot API host, default `https://api.telegram.org`. Point it at the mock Telegram harness to capture outbound Bot API traffic in tests (see Testing).                          |
 
 Saving the Telegram provider from the settings UI registers the webhook
 automatically (`registerTelegramWebhookBestEffort` in
@@ -78,7 +79,30 @@ otherwise the LLM router and workers silently fall back or fail.
    group mention of `TELEGRAM_BOT_USERNAME`): resume from a completed job's
    snapshot when available, else route via the LLM router and either reply
    inline (`platform_answer`) or launch a standard task
-   (`task-orchestration.ts`). Bot commands count as invocations — for both
+   (`task-orchestration.ts`). Before launching, low-confidence routes get a
+   **routing-confirmation card** (`routing-confirmation.ts`, mirroring
+   Slack's gate): when the router's `debug.confidence` is below 0.95, the
+   workspace was remapped, or it picked all-repositories while environments
+   exist, the bot posts a compact card — "Planning to run this in
+   {suggested} — starting in ~5s." with ✅ Yes / ✖️ Nope buttons — instead
+   of launching. Yes (or ~5 seconds of silence) starts the suggestion; the
+   short window keeps the normal flow near-instant, with the started
+   message's cancel button covering late mis-route recovery (in-process
+   timer; a restart drops it and the pending choice expires via its
+   15-minute Redis TTL). Nope swaps the same message into a workspace
+   picker (environments, All repositories, ✖️ Nevermind) via the provider's
+   `editMessageText`; the picker never auto-starts. A router `fallback`
+   shows the picker directly (previously it silently launched in all
+   repos). The pending choice lives in Redis
+   (`telegram:pending_route:<id>`; buttons carry only the short id to stay
+   under the 64-byte callback_data limit) and is claimed one-shot with
+   `GETDEL`, so a click and the auto-confirm timer can never both launch;
+   the Nope transition re-keys the state under a fresh id so the suggestion
+   timer can never fire after the user said no. Only the requester's linked
+   account may click; a new task-entry message in the same chat/topic
+   invalidates the previous pending card. Suggestion
+   buttons and other explicit-intent launches skip the card
+   (`skipRoutingConfirmation`). Bot commands count as invocations — for both
    entry detection and invocation stripping — only when they lead the message
    (offset 0, or preceded only by this bot's mention); a `/command` mentioned
    mid-sentence is ordinary message content and survives into queued text.
@@ -95,7 +119,12 @@ otherwise the LLM router and workers silently fall back or fail.
    answers the callback, removes the button, and posts a confirmation.
    Starter-suggestion buttons (`idea:<suggestionId>`) atomically claim the
    suggestion and launch it through the normal Telegram routing pipeline.
-   Unknown callback data is answered and dropped so buttons never spin.
+   Routing-confirmation buttons (`route_ok:<id>` Yes, `route_alt:<id>` Nope
+   → picker, `route_pick:<id>:<n>` picker choice, `route_no:<id>`
+   Nevermind; build/parse helpers in `callback-data.ts`) claim the pending
+   route from Redis and launch, transition, or dismiss via the shared
+   `launchTelegramTask` (`task-launch.ts`). Unknown callback data is
+   answered and dropped so buttons never spin.
 
 ## Onboarding
 
@@ -192,6 +221,42 @@ current user.
   rejects entity parsing, and splits messages that exceed the 4096-character
   Bot API limit at line/code-fence boundaries.
 
+## Testing
+
+Prefer the mock Telegram harness for integration behavior — it impersonates
+both halves of the Bot API the way the mock Slack harness does for Slack:
+
+- [`packages/communication/src/mock-telegram-server.ts`](../../packages/communication/src/mock-telegram-server.ts) —
+  in-process Bot API fake (`sendMessage`, `sendPhoto`, `setMessageReaction`,
+  `deleteMessage`, `editMessageReplyMarkup`, `answerCallbackQuery`,
+  `setWebhook`/`getWebhookInfo`) with a `/mock/state` + `/mock/events` control
+  plane and an update `dispatch()` that posts signed updates (secret-token
+  header) to the real `/api/webhooks/telegram` handler. It enforces real
+  Telegram limits (4096-char messages, unknown-chat and missing-reply-target
+  rejections) and auto-computes `entities` for injected message text so
+  bot-command/mention detection behaves as in production. Failure-injection
+  knobs (`behavior.rejectHtmlParseMode`, `behavior.rejectPhotos`) exercise the
+  provider's fallback paths.
+- `TELEGRAM_API_BASE_URL` reroutes every runtime
+  `TelegramCommunicationProvider` construction to the harness (resolved in
+  [`packages/communication/src/telegram-api-base-url.ts`](../../packages/communication/src/telegram-api-base-url.ts)).
+- CLI runner: `pnpm --filter @roomote/communication mock:telegram --state <scenario.json>`
+  ([`packages/communication/scripts/run-mock-telegram.ts`](../../packages/communication/scripts/run-mock-telegram.ts),
+  example scenario next to it). Eval runner with LLM-judged criteria bundles:
+  `pnpm --filter @roomote/communication eval:telegram-scenario`
+  ([`packages/communication/evals/run-telegram-scenario.ts`](../../packages/communication/evals/run-telegram-scenario.ts)).
+- Unit coverage: [`packages/communication/src/__tests__/mock-telegram-server.test.ts`](../../packages/communication/src/__tests__/mock-telegram-server.test.ts)
+  drives the real provider against the harness;
+  [`apps/api/src/handlers/telegram/__tests__/`](../../apps/api/src/handlers/telegram/__tests__)
+  covers the webhook handler with module mocks.
+- End-to-end workflow (DB seeding, env wiring, scenario catalog):
+  [`.agents/skills/mock-telegram-testing/SKILL.md`](../../.agents/skills/mock-telegram-testing/SKILL.md).
+
+When a change touches task entry, active-job follow-up queueing, `/new` +
+`/done` handling, or callback buttons, cover both the update payload shape and
+the persisted cloud-job state — chat-id continuity is the Telegram substitute
+for Slack threads, so continuation bugs are the highest-value scenarios.
+
 ## Slack Parity Notes
 
 Supported: task entry, follow-up messages to the active job, snapshot resume,
@@ -202,11 +267,16 @@ reactions with turn-satisfaction enforcement, visual proof auto-post
 buttons (follow task, cancel task, start suggestion), `/start` welcome plus
 starter-suggestions onboarding, task-link reply footers, webhook verification
 and dedup, per-user account linking (`telegram_user_mappings` via link
-codes, analogous to `slack_user_mappings`).
+codes, analogous to `slack_user_mappings`), routing confirmation with a
+manual workspace picker (same Yes/Nope-then-picker two-step as Slack, via
+inline keyboard + `editMessageText`; same 0.95 confidence gate but a ~5s
+auto-confirm vs Slack's 30s constant; router fallback shows the picker
+instead of silently launching in all repos). Unlike Slack there is no free-text correction
+while a confirmation is pending — a new message in the chat starts a fresh
+routing flow and invalidates the old card.
 
 Not supported (Bot API or product limitations): thread/channel history reads,
-routing-confirmation buttons (Telegram routes and launches directly; the
-cancel button covers mis-routes), account-link education, MCP setup
+account-link education, MCP setup
 recommendations, automation thread-feedback collection and an explicit
 automations destination picker (summaries and execution output fall back to
 the primary chat when Slack is absent). The setup kickoff is supported: when

--- a/.agents/skills/mock-telegram-testing/SKILL.md
+++ b/.agents/skills/mock-telegram-testing/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: mock-telegram-testing
+description: Run Roomote Telegram integration flows through the checked-in mock Telegram Bot API harness instead of a real Telegram bot. Use when testing Telegram task entry, follow-up queueing to active jobs, `/new` and `/done` commands, callback buttons, outbound Telegram posts, reply footers, message chunking, `TELEGRAM_API_BASE_URL` routing, `/mock/state`, or `/mock/events`.
+---
+
+# Mock Telegram Testing
+
+Use this skill to exercise Roomote's Telegram integration against the checked-in mock Telegram harness. Do not invent another fake Telegram stack and do not fall back to a real Telegram bot unless the user explicitly asks for that parity test.
+
+Telegram has no threads: conversation continuity is inferred from **chat id (+ forum topic id) → active cloud job**, with `/new` and `/done` as the explicit escape hatches after a task completes. That continuity logic is the highest-value thing to test here.
+
+## Quick Reference
+
+| What                          | Value                                                       |
+| ----------------------------- | ----------------------------------------------------------- |
+| Harness port                  | `3013`                                                      |
+| Harness base URL              | `http://127.0.0.1:3013`                                     |
+| Telegram API base for Roomote | `TELEGRAM_API_BASE_URL=http://127.0.0.1:3013`               |
+| API webhook endpoint          | `http://localhost:3001/api/webhooks/telegram`               |
+| Mock state endpoint           | `http://127.0.0.1:3013/mock/state`                          |
+| Mock event replay endpoint    | `http://127.0.0.1:3013/mock/events`                         |
+| Example scenario              | `packages/communication/scripts/mock-telegram.example.json` |
+| Webhook secret source         | `Env.TELEGRAM_WEBHOOK_SECRET` from dotenvx                  |
+| Mock bot identity             | `roomote_mock_bot` (id `7000000001`)                        |
+| Mock linked user              | Telegram user id `111000111` (`dan_mock`)                   |
+
+## Step 1: Seed the database
+
+The Telegram webhook handler attributes messages only to linked senders: it needs a `telegram_user_mappings` row for the mock Telegram user pointing at a real local user. Query existing state first, then seed only what's missing:
+
+```bash
+# Check existing state
+PGPASSWORD=password psql -h localhost -U postgres -d development -c "SELECT telegram_user_id, telegram_chat_id, user_id FROM telegram_user_mappings LIMIT 5;"
+
+# Get a valid user for seeding
+PGPASSWORD=password psql -h localhost -U postgres -d development -c "SELECT id FROM users LIMIT 1;"
+```
+
+Then seed (adjust user_id from the query above):
+
+```sql
+-- Link mock Telegram user 111000111 to a local Roomote user
+INSERT INTO telegram_user_mappings (telegram_user_id, telegram_chat_id, telegram_username, user_id)
+VALUES ('111000111', '111000111', 'dan_mock', '<user_id>')
+ON CONFLICT ON CONSTRAINT telegram_user_mappings_unique DO NOTHING;
+```
+
+Messages from unlinked senders are acked and dropped (`telegram_sender_not_linked`) — that is itself a scenario worth testing, but every task-entry scenario requires the mapping above.
+
+## Step 2: Wire the API server env
+
+The API resolves Telegram credentials from real env vars first (`resolveTelegramRuntimeCredentials`, cached ~30s). Set these in the API server's environment (or `.env.local`) before it starts:
+
+```bash
+TELEGRAM_BOT_TOKEN=7000000001:mock-telegram-token   # any value; the harness accepts all tokens unless acceptedBotTokens is set
+TELEGRAM_WEBHOOK_SECRET=<any-shared-secret>          # harness reads the same var via dotenvx, so signatures match automatically
+TELEGRAM_BOT_USERNAME=roomote_mock_bot               # required for group-mention and /new@bot gating scenarios
+TELEGRAM_API_BASE_URL=http://127.0.0.1:3013          # reroutes ALL outbound Bot API calls to the harness
+```
+
+Without `TELEGRAM_WEBHOOK_SECRET` the webhook returns 503; with a mismatched secret it returns 401.
+
+## Step 3: Create a scenario file
+
+Copy the example and fix the webhook target to point at the sandbox API (port 3001, not 4000):
+
+```bash
+cp packages/communication/scripts/mock-telegram.example.json /tmp/mock-telegram-test.json
+sed -i '' 's|localhost:4000|localhost:3001|g' /tmp/mock-telegram-test.json   # macOS; drop '' on Linux
+grep webhookUrl /tmp/mock-telegram-test.json
+# Should show: "webhookUrl": "http://localhost:3001/api/webhooks/telegram"
+```
+
+For custom scenarios, edit `/tmp/mock-telegram-test.json` directly. Never mutate the committed example.
+
+## Step 4: Start the harness
+
+```bash
+pnpm --filter @roomote/communication mock:telegram --state /tmp/mock-telegram-test.json
+```
+
+The harness starts on port 3013, replays any events in the `replay` array, and keeps listening. For one-shot replay that exits after: add `--exit-after-replay`.
+
+## Step 5: Inject updates manually (optional)
+
+`update_id` is minted automatically (unique per run) when omitted — pass an explicit `updateId` only when testing the Redis dedup path. `entities` are computed from the text (bot commands, @mentions) exactly like real Telegram, so `/new` and `@roomote_mock_bot` are detected without hand-counting offsets.
+
+```bash
+# Private-chat task entry
+curl -s -X POST http://127.0.0.1:3013/mock/events \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "kind": "message",
+    "message": {
+      "chat": { "id": 111000111, "type": "private", "first_name": "Dan" },
+      "from": { "id": 111000111, "first_name": "Dan", "username": "dan_mock" },
+      "text": "!fast what file handles Telegram webhooks?"
+    }
+  }'
+
+# Follow-up while the job is active (same chat id = same conversation)
+curl -s -X POST http://127.0.0.1:3013/mock/events \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "kind": "message",
+    "message": {
+      "chat": { "id": 111000111, "type": "private", "first_name": "Dan" },
+      "from": { "id": 111000111, "first_name": "Dan", "username": "dan_mock" },
+      "text": "also check the retry logic please"
+    }
+  }'
+
+# Cancel button click (callback_query) — use a real cloudJobId from the DB
+curl -s -X POST http://127.0.0.1:3013/mock/events \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "kind": "callback_query",
+    "callbackQuery": {
+      "id": "cbq-manual-1",
+      "from": { "id": 111000111, "first_name": "Dan", "username": "dan_mock" },
+      "data": "cancel_task:<cloudJobId>",
+      "message": { "message_id": 42, "chat": { "id": 111000111, "type": "private" } }
+    }
+  }'
+```
+
+## Step 6: Inspect results
+
+Always check the mock state after replay — do not declare success just because the harness returned 200:
+
+```bash
+# Full state dump
+curl -s http://127.0.0.1:3013/mock/state | jq .
+
+# Just the messages (bot messages have from.is_bot == true)
+curl -s http://127.0.0.1:3013/mock/state | jq '.messages'
+
+# Bot replies that quote a user message (reply anchoring)
+curl -s http://127.0.0.1:3013/mock/state | jq '.messages[] | select(.reply_to_message_id != null)'
+
+# Ack reactions on inbound messages (eyes = picked up)
+curl -s http://127.0.0.1:3013/mock/state | jq '.messages[] | select(.reactions | length > 0)'
+
+# Callback answers (button spinners stopped)
+curl -s http://127.0.0.1:3013/mock/state | jq '.callbackAnswers'
+```
+
+## Scenario Selection
+
+See `references/scenarios.md` for the full user-journey catalog. Common picks:
+
+- **`private-fast-answer`** — `!fast ...` inline Q&A without a cloud job
+- **`private-task-entry`** — DM task kickoff that creates a cloud job
+- **`followup-to-active-job`** — second message in the same chat queues to the running job instead of launching a new task
+- **`new-task-command`** — `/new <req>` after completion forces a fresh task instead of snapshot resume
+- **`group-mention-gating`** — group messages ignored unless the bot is mentioned
+- **`duplicate-delivery`** — same `update_id` twice → exactly-once handling
+- **`unlinked-sender`** — message from an unmapped Telegram user is nudged and dropped
+- **`long-reply-chunking`** — worker reply over 4096 chars splits into multiple messages
+- **`cancel-button`** — callback_query cancels the running job
+- **`routing-confirmation`** — low-confidence route posts a workspace picker; Nevermind is the zero-side-effect live-test path
+
+LLM-judged eval scenarios live in `packages/communication/evals/scenarios/` and run via `pnpm --filter @roomote/communication eval:telegram-scenario`.
+
+## Guardrails
+
+- Do not create a second mock Telegram server. Use the harness in `packages/communication/`.
+- Do not use a real Telegram bot unless the user explicitly asks for that.
+- Do not declare success because the harness started. Always inspect `/mock/state`.
+- Do not mutate the committed example scenario — copy it to `/tmp/` first.
+- Do not assume the example webhook target port is correct. The sandbox API runs on 3001.
+- Do not reuse explicit `updateId` values across runs — Redis dedups update ids for 5 minutes, silently dropping your event. Omit `updateId` unless the dedup path is what you are testing.
+- Do not claim continuity behavior is covered unless you observed the second message being queued to the existing job (no second task-start ack) in `/mock/state` and `cloud_jobs`.
+
+## Output Standard
+
+End each use of this skill with:
+
+- the scenario used and the webhook target
+- the inbound updates injected (if any)
+- the key messages, reactions, or callback answers observed in `/mock/state`
+- a pass or fail judgment
+- the next debugging lead if the behavior failed

--- a/.agents/skills/mock-telegram-testing/references/scenarios.md
+++ b/.agents/skills/mock-telegram-testing/references/scenarios.md
@@ -1,0 +1,137 @@
+# Telegram User-Journey Scenario Catalog
+
+Each scenario lists the updates to inject, the expected observable behavior, and where to assert it. "State" means `GET http://127.0.0.1:3013/mock/state`; "DB" means the `cloud_jobs` table. Bot messages have `from.is_bot == true`.
+
+Because Telegram has no threads, the core product invariant under test is: **one chat (or forum topic) maps to at most one active conversation**, continuity comes from the active-job lookup, and `/new`/`/done` are the only ways to break out early.
+
+## 1. private-fast-answer
+
+A linked user DMs `!fast <question>`.
+
+- Inject: `message` in private chat `111000111`, text `!fast what file handles Telegram webhooks?`.
+- Expect: eyes reaction on the inbound message; one inline bot answer in the same chat; **no** cloud job created.
+- Assert: state `.messages` (one bot message), `.messages[].reactions`; DB has no new `cloud_jobs` row.
+
+## 2. private-task-entry
+
+A linked user DMs a work request.
+
+- Inject: `message` in private chat, text `fix the flaky login test in apps/web`.
+- Expect: eyes ack; a task-started message with a follow-task URL button and a `cancel_task:<jobId>` cancel button; a new cloud job whose payload carries `communicationProvider: 'telegram'`, `communicationChannelId: '111000111'`.
+- Assert: state (started message with `reply_markup.inline_keyboard`); DB payload fields.
+
+## 3. followup-to-active-job (the no-threads core case)
+
+A second message arrives in the same chat while the job is active.
+
+- Inject: scenario 2, then ~5s later another `message` in the same chat: `also check the retry logic`.
+- Expect: the follow-up is **queued to the running job** (`queueCommunicationMessage`), acked with eyes — no second task-started message, no second job.
+- Assert: state shows the second inbound message with a reaction but no new task-start ack; DB still has one active job for the chat.
+- Regression risk: if active-job lookup breaks, every follow-up silently launches a parallel task — the worst UX failure this surface has.
+
+## 4. new-task-command / done-command
+
+After a task completes, the next plain message resumes its snapshot; `/new` or `/done` must force a fresh task instead.
+
+- Inject: complete a task in the chat (or seed a Completed job with a resumable snapshot), then `message` with text `/new upgrade the login tests to vitest 4`.
+- Expect: a fresh task launch (new job id), not a snapshot resume; the `/new` invocation is stripped from the queued task text.
+- Variants: `/done <req>`; group forms `/new@roomote_mock_bot <req>` and `@roomote_mock_bot /new <req>`; a mid-sentence `/new` must NOT trigger (it is ordinary text); `/new` while a job is still running is refused with an echo-back so the user can resend.
+- Assert: DB (new job vs `SnapshotResume` payload); state for the refusal echo.
+
+## 5. group-mention-gating
+
+Groups only enter tasks on explicit address. Requires `TELEGRAM_BOT_USERNAME=roomote_mock_bot` on the API.
+
+- Inject: `message` in supergroup `-100222000222` without any mention → expect **silence** (no ack, no reply, no job).
+- Inject: `@roomote_mock_bot <request>` in the same group → expect ack + task entry.
+- Follow-ups in the group while that job is active queue to it even without a mention (chat-id continuity), which is intentional but worth observing.
+- Assert: state message list; DB job payload `communicationChannelId: '-100222000222'`.
+
+## 6. forum-topic-isolation
+
+Forum supergroups scope conversations per topic via `message_thread_id`.
+
+- Inject: task entry with `message_thread_id: 7`; then a follow-up with `message_thread_id: 8`.
+- Expect: the topic-8 message does **not** queue to the topic-7 job (thread id is part of the active-job key) — it is its own task entry.
+- Assert: DB `communicationThreadId` on each job; bot replies carry the matching `message_thread_id` in state.
+
+## 7. duplicate-delivery
+
+Telegram redelivers updates on webhook timeouts.
+
+- Inject: the same event twice with an explicit identical `updateId`, 6s apart.
+- Expect: exactly-once handling — one ack, one answer/launch.
+- Assert: state has exactly one bot response; the eval fixture `telegram-duplicate-delivery.json` automates this.
+
+## 8. unlinked-sender
+
+- Inject: `message` from `from.id: 222000222` (no `telegram_user_mappings` row).
+- Expect: private chat → textual "link your account" nudge, update acked and dropped, no job. Group → nudge only when the bot was addressed, rate-limited (once/sender/chat/6h), with a `t.me/...?start=link` deep-link button.
+- Assert: state (nudge message, no task ack); DB unchanged.
+
+## 9. link-code-flow
+
+- Mint a code via the web UI (or `createTelegramLinkCode`), then inject a private `message` whose text is the bare code (or `/start <code>`).
+- Expect: mapping upserted, confirmation reply, primary chat captured (`TELEGRAM_PRIMARY_CHAT_ID` deployment env var written once).
+- Assert: DB `telegram_user_mappings`; state confirmation message. Also verify an invalid/expired code gets an error reply and is never treated as task text.
+
+## 10. start-welcome
+
+- Inject: bare `/start` in a private chat from an unlinked user.
+- Expect: welcome message with linking guidance — no task, no nudge-drop.
+- Assert: state.
+
+## 11. long-reply-chunking
+
+Worker replies over 4096 chars must split at line/code-fence boundaries.
+
+- Drive a running task to produce a long `send_chat_reply` (or call the MCP thread-reply endpoint directly with a long body).
+- Expect: multiple bot messages each ≤ 4096 chars; only the first quotes the user's message (`reply_to_message_id`); code fences reopen across chunks; the task-link footer is a separate message and the previous footer was deleted.
+- Assert: state message lengths, `reply_to_message_id` distribution, exactly one footer message present.
+- The harness enforces the 4096 limit with a real `message is too long` 400, so a chunking regression fails loudly.
+
+## 12. markdown-fallback
+
+- Set `state.behavior.rejectHtmlParseMode: true` in the scenario, then drive any bot reply with markdown.
+- Expect: the provider retries as plain text; the reply lands without parse_mode instead of erroring.
+- Assert: state (`parse_mode` absent, raw markdown text).
+
+## 13. photo-fallback
+
+- Set `state.behavior.rejectPhotos: true`; drive a reply with an image artifact.
+- Expect: caption-plus-link text message instead of a photo.
+- Assert: state (`photo_url` absent, text contains the artifact URL).
+
+## 14. cancel-button
+
+- Inject: `callback_query` with `data: "cancel_task:<jobId>"` for a running job.
+- Expect: job stopped, callback answered (spinner cleared), cancel button removed from the started message, confirmation posted.
+- Assert: state `.callbackAnswers`, the started message's `reply_markup` now empty, confirmation message; DB job status canceled.
+
+## 15. routing-confirmation (verified live 2026-07-08)
+
+When the router is unsure (confidence < 0.95, workspace remapped, or all-repositories picked while environments exist), task entry posts a confirmation card instead of launching.
+
+- Inject: private-chat task entry whose target workspace is ambiguous (e.g. `fix the flaky login test in the web app` with several environments configured).
+- Expect: webhook responds `confirmationPending: true`; a compact card "Planning to run this in **{suggested}** — starting in ~5s." with one row of buttons: ✅ Yes (`route_ok:<id>`) and ✖️ Nope (`route_alt:<id>`). Router `fallback` skips the Yes/Nope step and shows the picker directly ("could not confidently pick a workspace") with no auto-start.
+- Click paths:
+  - ✅ Yes → callback answered `Starting in {workspace}.`, the card is edited in place to "Starting in **{workspace}**." (keyboard removed), task launched.
+  - ✖️ Nope → the same message is edited into the picker ("Okay — where should I run this?" + one button per workspace + ✖️ Nevermind), re-keyed under a fresh pending-route id so the 5s timer can never fire the suggestion afterwards. The picker waits — no timer.
+  - Picker choice (`route_pick:<id>:<n>`) → same as Yes but with the chosen workspace.
+  - ✖️ Nevermind (`route_no:<id>`) → callback answered `Okay — not starting a task.`, card finalized, nothing launches (the safe path for live testing: Nope → Nevermind).
+  - No click → the Yes/Nope card auto-starts the suggestion after ~5s (card edited to "Starting in **{workspace}**." when the timer fires); pickers just expire (15-min Redis TTL).
+  - Click from a different Telegram user → `Only the requester can choose a workspace for this task.` and the pending choice is NOT consumed.
+- Assert: state `.messages` (card text edited through the stages, final `reply_markup` empty), `.callbackAnswers`; DB `cloud_jobs` for the launch (or its absence after Nevermind).
+- Note: the pending choice is one-shot (`GETDEL`) — a second click on a stale card gets `This choice expired — send the request again.` The 5s window is too short to tap from a phone notification; that is intentional — Nope is for users watching the chat, and the started message's cancel button covers everyone else.
+
+## 16. suggestion-button
+
+- Seed starter suggestions (or run the suggester), then inject `callback_query` with `data: "idea:<suggestionId>"`.
+- Expect: suggestion claimed atomically (double taps do not double-launch), task launched through normal routing.
+- Assert: DB `agentSuggestionMessages.launchClaimedAt`; state.
+
+## Known parity gaps (do not file as harness bugs)
+
+- No progress streaming or typing indicator: between the eyes ack and the final reply, the chat is silent by design (current gap).
+- No free-text routing correction: while a confirmation card is pending, a new message starts a fresh routing flow (and invalidates the old card) instead of being classified as confirm/cancel/correct like Slack.
+- No thread/channel history reads: the Bot API cannot fetch history, so routing sees only the current message and queued follow-ups.

--- a/apps/api/src/handlers/telegram/__tests__/callback-data.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/callback-data.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildTelegramCancelTaskCallbackData,
+  buildTelegramRouteAltCallbackData,
+  buildTelegramRouteNoCallbackData,
+  buildTelegramRouteOkCallbackData,
+  buildTelegramRoutePickCallbackData,
+  parseCancelTaskCallbackData,
+  parseTelegramRouteCallbackData,
+} from '../callback-data';
+
+const PENDING_ROUTE_ID = 'aBc123XYZ_-9';
+
+describe('telegram callback data', () => {
+  it('round-trips cancel-task callback data', () => {
+    expect(
+      parseCancelTaskCallbackData(buildTelegramCancelTaskCallbackData(42)),
+    ).toBe(42);
+    expect(parseCancelTaskCallbackData('cancel_task:zero')).toBeNull();
+    expect(parseCancelTaskCallbackData('route_ok:abc')).toBeNull();
+  });
+
+  it('round-trips route callback data', () => {
+    expect(
+      parseTelegramRouteCallbackData(
+        buildTelegramRouteOkCallbackData(PENDING_ROUTE_ID),
+      ),
+    ).toEqual({ action: 'ok', pendingRouteId: PENDING_ROUTE_ID });
+    expect(
+      parseTelegramRouteCallbackData(
+        buildTelegramRoutePickCallbackData(PENDING_ROUTE_ID, 3),
+      ),
+    ).toEqual({
+      action: 'pick',
+      pendingRouteId: PENDING_ROUTE_ID,
+      optionIndex: 3,
+    });
+    expect(
+      parseTelegramRouteCallbackData(
+        buildTelegramRouteAltCallbackData(PENDING_ROUTE_ID),
+      ),
+    ).toEqual({ action: 'alt', pendingRouteId: PENDING_ROUTE_ID });
+    expect(
+      parseTelegramRouteCallbackData(
+        buildTelegramRouteNoCallbackData(PENDING_ROUTE_ID),
+      ),
+    ).toEqual({ action: 'no', pendingRouteId: PENDING_ROUTE_ID });
+  });
+
+  it('stays within the Telegram 64-byte callback_data limit', () => {
+    // Pending route ids are 12 base64url chars (9 random bytes).
+    expect(
+      Buffer.byteLength(
+        buildTelegramRoutePickCallbackData(PENDING_ROUTE_ID, 99),
+      ),
+    ).toBeLessThanOrEqual(64);
+  });
+
+  it('rejects malformed route callback data', () => {
+    expect(parseTelegramRouteCallbackData('route_ok:')).toBeNull();
+    expect(parseTelegramRouteCallbackData('route_ok:has spaces')).toBeNull();
+    expect(
+      parseTelegramRouteCallbackData('route_pick:abc123XYZ_-9'),
+    ).toBeNull();
+    expect(
+      parseTelegramRouteCallbackData('route_pick:abc123XYZ_-9:-1'),
+    ).toBeNull();
+    expect(
+      parseTelegramRouteCallbackData('route_pick:abc123XYZ_-9:one'),
+    ).toBeNull();
+    expect(parseTelegramRouteCallbackData('cancel_task:42')).toBeNull();
+    expect(parseTelegramRouteCallbackData('')).toBeNull();
+  });
+});

--- a/apps/api/src/handlers/telegram/__tests__/index.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/index.test.ts
@@ -10,8 +10,11 @@ const {
   consumeLinkCodeMock,
   restoreLinkCodeMock,
   editMessageReplyMarkupMock,
+  editMessageTextMock,
   enqueueCloudTaskMock,
+  environmentsFindFirstMock,
   envMock,
+  getAvailableEnvironmentsMock,
   getTaskUrlMock,
   insertMock,
   insertOnConflictDoNothingMock,
@@ -19,6 +22,8 @@ const {
   postMessageMock,
   queueCommunicationMessageMock,
   redisDelMock,
+  redisGetMock,
+  redisGetdelMock,
   redisSetMock,
   routeTaskMock,
   setLatestInboundMessageIdMock,
@@ -36,7 +41,10 @@ const {
   consumeLinkCodeMock: vi.fn(),
   restoreLinkCodeMock: vi.fn(),
   editMessageReplyMarkupMock: vi.fn(),
+  editMessageTextMock: vi.fn(),
   enqueueCloudTaskMock: vi.fn(),
+  environmentsFindFirstMock: vi.fn(),
+  getAvailableEnvironmentsMock: vi.fn(),
   envMock: {
     ROOMOTE_APP_URL: 'https://app.example.com',
     TELEGRAM_BOT_TOKEN: 'bot-token' as string | undefined,
@@ -51,6 +59,8 @@ const {
   postMessageMock: vi.fn(),
   queueCommunicationMessageMock: vi.fn(),
   redisDelMock: vi.fn(),
+  redisGetMock: vi.fn(),
+  redisGetdelMock: vi.fn(),
   redisSetMock: vi.fn(),
   routeTaskMock: vi.fn(),
   setLatestInboundMessageIdMock: vi.fn(),
@@ -69,6 +79,8 @@ vi.mock('@roomote/redis', () => ({
   getRedis: vi.fn(() => ({
     set: redisSetMock,
     del: redisDelMock,
+    get: redisGetMock,
+    getdel: redisGetdelMock,
   })),
 }));
 
@@ -99,7 +111,7 @@ vi.mock('@roomote/db/server', () => ({
         findFirst: cloudJobsFindFirstMock,
       },
       environments: {
-        findFirst: vi.fn(),
+        findFirst: environmentsFindFirstMock,
       },
       users: {
         findFirst: usersFindFirstMock,
@@ -180,6 +192,7 @@ vi.mock('@roomote/communication/telegram-provider', () => ({
       addReaction: addReactionMock,
       answerCallbackQuery: answerCallbackQueryMock,
       editMessageReplyMarkup: editMessageReplyMarkupMock,
+      editMessageText: editMessageTextMock,
       postMessage: postMessageMock,
     };
   }),
@@ -192,6 +205,7 @@ vi.mock('../../tasks/task-stop.js', () => ({
 vi.mock('@roomote/cloud-agents/server', () => ({
   buildTelegramRoutingContext: buildTelegramRoutingContextMock,
   enqueueCloudTask: enqueueCloudTaskMock,
+  getAvailableEnvironments: getAvailableEnvironmentsMock,
   getTaskUrl: getTaskUrlMock,
   routeTask: routeTaskMock,
 }));
@@ -273,6 +287,11 @@ describe('Telegram webhook handler', () => {
     envMock.TRPC_URL = 'https://api.example.com';
     redisSetMock.mockResolvedValue('OK');
     redisDelMock.mockResolvedValue(1);
+    redisGetMock.mockResolvedValue(null);
+    redisGetdelMock.mockResolvedValue(null);
+    environmentsFindFirstMock.mockResolvedValue(undefined);
+    getAvailableEnvironmentsMock.mockResolvedValue([]);
+    editMessageTextMock.mockResolvedValue(undefined);
     setLatestInboundMessageIdMock.mockResolvedValue(undefined);
     authUsersFindFirstMock.mockResolvedValue(null);
     usersFindFirstMock.mockResolvedValue(null);
@@ -1450,6 +1469,440 @@ describe('Telegram webhook handler', () => {
     expect(stopTaskJobMock).not.toHaveBeenCalled();
     expect(answerCallbackQueryMock).toHaveBeenCalledWith(
       expect.objectContaining({ callbackQueryId: 'cb-3' }),
+    );
+  });
+
+  it('posts a routing confirmation with workspace options when the router is unsure', async () => {
+    mockTelegramLinkedSender('launch-owner-20');
+    getAvailableEnvironmentsMock.mockResolvedValue([
+      { id: 'env-1', name: 'Web App', repositoryNames: ['org/web'] },
+      { id: 'env-2', name: 'API', repositoryNames: ['org/api'] },
+    ]);
+    routeTaskMock.mockResolvedValueOnce({
+      status: 'routed',
+      result: {
+        workspace: { type: 'environment', id: 'env-1', name: 'Web App' },
+        reasoning: 'weak guess',
+        debug: { confidence: 0.6 },
+      },
+    });
+
+    const response = await postTelegramUpdate(
+      createTelegramUpdate({ message: { text: 'fix the login bug' } }),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      queued: false,
+      confirmationPending: true,
+    });
+    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(postMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: '222',
+        text: expect.stringContaining('Planning to run this in **Web App**'),
+        // Compact Yes/Nope card — the workspace list only appears after Nope.
+        buttons: [
+          [
+            expect.objectContaining({
+              text: '✅ Yes',
+              callbackData: expect.stringMatching(/^route_ok:[\w-]+$/),
+            }),
+            expect.objectContaining({
+              text: '✖️ Nope',
+              callbackData: expect.stringMatching(/^route_alt:[\w-]+$/),
+            }),
+          ],
+        ],
+      }),
+    );
+    // The pending decision is stashed in Redis for the button callbacks.
+    expect(redisSetMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^telegram:pending_route:[\w-]+$/),
+      expect.stringContaining('"launchOwnerUserId":"launch-owner-20"'),
+      'EX',
+      expect.any(Number),
+    );
+  });
+
+  it('asks for a workspace instead of defaulting to all repos when routing falls back', async () => {
+    mockTelegramLinkedSender('launch-owner-21');
+    getAvailableEnvironmentsMock.mockResolvedValue([
+      { id: 'env-1', name: 'Web App', repositoryNames: ['org/web'] },
+    ]);
+    routeTaskMock.mockResolvedValueOnce({
+      status: 'fallback',
+      reason: 'router timeout',
+    });
+
+    const response = await postTelegramUpdate(
+      createTelegramUpdate({ message: { text: 'fix the login bug' } }),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      queued: false,
+      confirmationPending: true,
+    });
+    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(postMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining('could not confidently pick a workspace'),
+        buttons: [
+          [expect.objectContaining({ text: 'Web App' })],
+          [expect.objectContaining({ text: 'All repositories' })],
+          [expect.objectContaining({ text: '✖️ Nevermind' })],
+        ],
+      }),
+    );
+  });
+
+  it('launches immediately when routing confidence is high', async () => {
+    mockTelegramLinkedSender('launch-owner-22');
+    getAvailableEnvironmentsMock.mockResolvedValue([
+      { id: 'env-1', name: 'Web App', repositoryNames: ['org/web'] },
+      { id: 'env-2', name: 'API', repositoryNames: ['org/api'] },
+    ]);
+    environmentsFindFirstMock.mockResolvedValueOnce({
+      id: 'env-1',
+      name: 'Web App',
+      config: { repositories: [{ repository: 'org/web' }] },
+    });
+    routeTaskMock.mockResolvedValueOnce({
+      status: 'routed',
+      result: {
+        workspace: { type: 'environment', id: 'env-1', name: 'Web App' },
+        reasoning: 'clear match',
+        debug: { confidence: 0.98 },
+      },
+    });
+
+    const response = await postTelegramUpdate(
+      createTelegramUpdate({ message: { text: 'fix the login bug' } }),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      started: true,
+      cloudJobId: 88,
+    });
+    expect(enqueueCloudTaskMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          repo: 'org/web',
+          environmentId: 'env-1',
+        }),
+      }),
+      { launchClass: 'human' },
+    );
+    expect(postMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Started a task in Web App.',
+      }),
+    );
+  });
+
+  it('launches the suggested workspace when the confirmation OK button is clicked', async () => {
+    mockTelegramLinkedSender('launch-owner-23');
+    const pending = JSON.stringify({
+      launchOwnerUserId: 'launch-owner-23',
+      queuedMessage: {
+        provider: 'telegram',
+        text: 'fix the login bug',
+        user: 'Ada Lovelace',
+        userId: 'launch-owner-23',
+        ts: '456',
+        channel: '222',
+      },
+      metadata: {
+        communicationProvider: 'telegram',
+        communicationChannelId: '222',
+        communicationMessageId: '456',
+      },
+      options: [
+        {
+          label: 'Web App',
+          workspace: { type: 'environment', id: 'env-1', name: 'Web App' },
+        },
+        { label: 'All repositories', workspace: { type: 'all_repositories' } },
+      ],
+      suggestedIndex: 0,
+      confirmMessageId: '990',
+    });
+    redisGetMock.mockResolvedValue(pending);
+    redisGetdelMock.mockResolvedValue(pending);
+    environmentsFindFirstMock.mockResolvedValueOnce({
+      id: 'env-1',
+      name: 'Web App',
+      config: { repositories: [{ repository: 'org/web' }] },
+    });
+
+    const response = await postTelegramUpdate({
+      update_id: 910,
+      callback_query: {
+        id: 'cb-10',
+        from: { id: 111, first_name: 'Ada' },
+        data: 'route_ok:abc123XYZ789',
+        message: {
+          message_id: 990,
+          chat: { id: 222, type: 'private' },
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(redisGetdelMock).toHaveBeenCalledWith(
+      'telegram:pending_route:abc123XYZ789',
+    );
+    expect(enqueueCloudTaskMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'launch-owner-23',
+        payload: expect.objectContaining({
+          repo: 'org/web',
+          environmentId: 'env-1',
+          description: 'fix the login bug',
+        }),
+      }),
+      { launchClass: 'human' },
+    );
+    expect(answerCallbackQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callbackQueryId: 'cb-10',
+        text: 'Starting in Web App.',
+      }),
+    );
+    // The card is finalized in place: text swapped, keyboard removed.
+    expect(editMessageTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: '222',
+        messageId: '990',
+        text: 'Starting in **Web App**.',
+      }),
+    );
+  });
+
+  it('swaps the card into the workspace picker when Nope is clicked', async () => {
+    mockTelegramLinkedSender('launch-owner-26');
+    const pending = JSON.stringify({
+      launchOwnerUserId: 'launch-owner-26',
+      queuedMessage: {
+        provider: 'telegram',
+        text: 'fix the login bug',
+        user: 'Ada Lovelace',
+        userId: 'launch-owner-26',
+        ts: '456',
+        channel: '222',
+      },
+      metadata: {
+        communicationProvider: 'telegram',
+        communicationChannelId: '222',
+        communicationMessageId: '456',
+      },
+      options: [
+        {
+          label: 'Web App',
+          workspace: { type: 'environment', id: 'env-1', name: 'Web App' },
+        },
+        { label: 'All repositories', workspace: { type: 'all_repositories' } },
+      ],
+      suggestedIndex: 0,
+      confirmMessageId: '995',
+    });
+    redisGetMock.mockResolvedValue(pending);
+    redisGetdelMock.mockResolvedValue(pending);
+
+    const response = await postTelegramUpdate({
+      update_id: 914,
+      callback_query: {
+        id: 'cb-14',
+        from: { id: 111, first_name: 'Ada' },
+        data: 'route_alt:abc123XYZ789',
+        message: {
+          message_id: 995,
+          chat: { id: 222, type: 'private' },
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    // Same message becomes the picker, keyed by a fresh pending-route id so
+    // the old auto-confirm timer can never fire the suggestion.
+    expect(editMessageTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: '222',
+        messageId: '995',
+        text: 'Okay — where should I run this?',
+        buttons: [
+          [
+            expect.objectContaining({
+              text: 'Web App',
+              callbackData: expect.stringMatching(/^route_pick:[\w-]+:0$/),
+            }),
+          ],
+          [
+            expect.objectContaining({
+              text: 'All repositories',
+              callbackData: expect.stringMatching(/^route_pick:[\w-]+:1$/),
+            }),
+          ],
+          [
+            expect.objectContaining({
+              text: '✖️ Nevermind',
+              callbackData: expect.stringMatching(/^route_no:[\w-]+$/),
+            }),
+          ],
+        ],
+      }),
+    );
+    const editCall = editMessageTextMock.mock.calls[0]![0] as {
+      buttons: Array<Array<{ callbackData: string }>>;
+    };
+    expect(editCall.buttons[0]![0]!.callbackData).not.toContain('abc123XYZ789');
+    // The picker state was re-stored under the new id.
+    expect(redisSetMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^telegram:pending_route:[\w-]+$/),
+      expect.stringContaining('"suggestedIndex":null'),
+      'EX',
+      expect.any(Number),
+    );
+  });
+
+  it('rejects confirmation clicks from someone other than the requester without consuming the choice', async () => {
+    mockTelegramLinkedSender('someone-else');
+    redisGetMock.mockResolvedValue(
+      JSON.stringify({
+        launchOwnerUserId: 'launch-owner-24',
+        queuedMessage: {
+          provider: 'telegram',
+          text: 'fix it',
+          user: 'Ada',
+          userId: 'launch-owner-24',
+          ts: '456',
+          channel: '222',
+        },
+        metadata: {
+          communicationProvider: 'telegram',
+          communicationChannelId: '222',
+          communicationMessageId: '456',
+        },
+        options: [
+          {
+            label: 'All repositories',
+            workspace: { type: 'all_repositories' },
+          },
+        ],
+        suggestedIndex: 0,
+      }),
+    );
+
+    const response = await postTelegramUpdate({
+      update_id: 911,
+      callback_query: {
+        id: 'cb-11',
+        from: { id: 999, first_name: 'Mallory' },
+        data: 'route_ok:abc123XYZ789',
+        message: {
+          message_id: 991,
+          chat: { id: 222, type: 'private' },
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(redisGetdelMock).not.toHaveBeenCalledWith(
+      'telegram:pending_route:abc123XYZ789',
+    );
+    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(answerCallbackQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callbackQueryId: 'cb-11',
+        text: 'Only the requester can choose a workspace for this task.',
+      }),
+    );
+  });
+
+  it('acknowledges expired confirmation clicks and clears the stale buttons', async () => {
+    redisGetMock.mockResolvedValue(null);
+
+    const response = await postTelegramUpdate({
+      update_id: 912,
+      callback_query: {
+        id: 'cb-12',
+        from: { id: 111, first_name: 'Ada' },
+        data: 'route_pick:abc123XYZ789:1',
+        message: {
+          message_id: 992,
+          chat: { id: 222, type: 'private' },
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(answerCallbackQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callbackQueryId: 'cb-12',
+        text: 'This choice expired — send the request again.',
+      }),
+    );
+    expect(editMessageReplyMarkupMock).toHaveBeenCalledWith(
+      expect.objectContaining({ channelId: '222', messageId: '992' }),
+    );
+  });
+
+  it('dismisses the confirmation without launching when Nevermind is clicked', async () => {
+    mockTelegramLinkedSender('launch-owner-25');
+    const pending = JSON.stringify({
+      launchOwnerUserId: 'launch-owner-25',
+      queuedMessage: {
+        provider: 'telegram',
+        text: 'fix it',
+        user: 'Ada',
+        userId: 'launch-owner-25',
+        ts: '456',
+        channel: '222',
+      },
+      metadata: {
+        communicationProvider: 'telegram',
+        communicationChannelId: '222',
+        communicationMessageId: '456',
+      },
+      options: [
+        { label: 'All repositories', workspace: { type: 'all_repositories' } },
+      ],
+      suggestedIndex: 0,
+    });
+    redisGetMock.mockResolvedValue(pending);
+    redisGetdelMock.mockResolvedValue(pending);
+
+    const response = await postTelegramUpdate({
+      update_id: 913,
+      callback_query: {
+        id: 'cb-13',
+        from: { id: 111, first_name: 'Ada' },
+        data: 'route_no:abc123XYZ789',
+        message: {
+          message_id: 993,
+          chat: { id: 222, type: 'private' },
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(answerCallbackQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callbackQueryId: 'cb-13',
+        text: 'Okay — not starting a task.',
+      }),
+    );
+    expect(editMessageTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: '222',
+        messageId: '993',
+        text: 'Okay — not starting a task.',
+      }),
     );
   });
 });

--- a/apps/api/src/handlers/telegram/callback-actions.ts
+++ b/apps/api/src/handlers/telegram/callback-actions.ts
@@ -12,40 +12,23 @@ import {
 
 import { apiLogger } from '../../logging.js';
 import { stopTaskJob } from '../tasks/task-stop.js';
+import {
+  parseCancelTaskCallbackData,
+  parseTelegramRouteCallbackData,
+} from './callback-data.js';
 import { resolveTelegramSenderUserId } from './linked-user.js';
 import {
   answerTelegramCallbackQueryBestEffort,
   clearTelegramMessageButtonsBestEffort,
   postTelegramMessageBestEffort,
 } from './replies.js';
+import { handleTelegramRoutingCallback } from './routing-confirmation.js';
 import {
   claimTelegramSuggestionLaunch,
   parseTelegramSuggestionCallbackData,
 } from './setup-suggestions.js';
 import { startNewTelegramTask } from './task-orchestration.js';
 import type { QueuedTelegramCommunicationMessage } from './types.js';
-
-const CANCEL_TASK_CALLBACK_PREFIX = 'cancel_task:';
-
-/** callback_data is limited to 64 bytes, so carry only the cloud job id. */
-export function buildTelegramCancelTaskCallbackData(
-  cloudJobId: number,
-): string {
-  return `${CANCEL_TASK_CALLBACK_PREFIX}${cloudJobId}`;
-}
-
-function parseCancelTaskCallbackData(data: string): number | null {
-  if (!data.startsWith(CANCEL_TASK_CALLBACK_PREFIX)) {
-    return null;
-  }
-
-  const cloudJobId = Number.parseInt(
-    data.slice(CANCEL_TASK_CALLBACK_PREFIX.length),
-    10,
-  );
-
-  return Number.isSafeInteger(cloudJobId) && cloudJobId > 0 ? cloudJobId : null;
-}
 
 async function findCancelableCloudJob(cloudJobId: number, chatId: string) {
   return db.query.cloudJobs.findFirst({
@@ -217,6 +200,8 @@ async function handleSuggestionLaunchCallback(params: {
         communicationChannelId: chatId,
         communicationMessageId: messageId,
       },
+      // The button click already is the explicit start signal.
+      skipRoutingConfirmation: true,
     });
   } catch (error) {
     apiLogger.warn(
@@ -252,6 +237,13 @@ export async function handleTelegramCallbackQuery(
 
   if (suggestionId !== null) {
     await handleSuggestionLaunchCallback({ query, suggestionId });
+    return;
+  }
+
+  const routeAction = parseTelegramRouteCallbackData(data);
+
+  if (routeAction !== null) {
+    await handleTelegramRoutingCallback({ query, action: routeAction });
     return;
   }
 

--- a/apps/api/src/handlers/telegram/callback-data.ts
+++ b/apps/api/src/handlers/telegram/callback-data.ts
@@ -1,0 +1,113 @@
+/**
+ * Build/parse helpers for Telegram inline-keyboard `callback_data` strings.
+ * Telegram limits callback_data to 64 bytes, so every action carries only a
+ * short id (cloud job id, pending-route id) — heavy context is looked up
+ * server-side from that id.
+ */
+
+const CANCEL_TASK_CALLBACK_PREFIX = 'cancel_task:';
+
+export function buildTelegramCancelTaskCallbackData(
+  cloudJobId: number,
+): string {
+  return `${CANCEL_TASK_CALLBACK_PREFIX}${cloudJobId}`;
+}
+
+export function parseCancelTaskCallbackData(data: string): number | null {
+  if (!data.startsWith(CANCEL_TASK_CALLBACK_PREFIX)) {
+    return null;
+  }
+
+  const cloudJobId = Number.parseInt(
+    data.slice(CANCEL_TASK_CALLBACK_PREFIX.length),
+    10,
+  );
+
+  return Number.isSafeInteger(cloudJobId) && cloudJobId > 0 ? cloudJobId : null;
+}
+
+const ROUTE_OK_CALLBACK_PREFIX = 'route_ok:';
+const ROUTE_ALT_CALLBACK_PREFIX = 'route_alt:';
+const ROUTE_PICK_CALLBACK_PREFIX = 'route_pick:';
+const ROUTE_NO_CALLBACK_PREFIX = 'route_no:';
+
+const PENDING_ROUTE_ID_PATTERN = /^[A-Za-z0-9_-]{8,32}$/;
+
+export type TelegramRouteCallbackAction =
+  | { action: 'ok'; pendingRouteId: string }
+  | { action: 'alt'; pendingRouteId: string }
+  | { action: 'pick'; pendingRouteId: string; optionIndex: number }
+  | { action: 'no'; pendingRouteId: string };
+
+export function buildTelegramRouteOkCallbackData(
+  pendingRouteId: string,
+): string {
+  return `${ROUTE_OK_CALLBACK_PREFIX}${pendingRouteId}`;
+}
+
+export function buildTelegramRouteAltCallbackData(
+  pendingRouteId: string,
+): string {
+  return `${ROUTE_ALT_CALLBACK_PREFIX}${pendingRouteId}`;
+}
+
+export function buildTelegramRoutePickCallbackData(
+  pendingRouteId: string,
+  optionIndex: number,
+): string {
+  return `${ROUTE_PICK_CALLBACK_PREFIX}${pendingRouteId}:${optionIndex}`;
+}
+
+export function buildTelegramRouteNoCallbackData(
+  pendingRouteId: string,
+): string {
+  return `${ROUTE_NO_CALLBACK_PREFIX}${pendingRouteId}`;
+}
+
+export function parseTelegramRouteCallbackData(
+  data: string,
+): TelegramRouteCallbackAction | null {
+  if (data.startsWith(ROUTE_OK_CALLBACK_PREFIX)) {
+    const pendingRouteId = data.slice(ROUTE_OK_CALLBACK_PREFIX.length);
+
+    return PENDING_ROUTE_ID_PATTERN.test(pendingRouteId)
+      ? { action: 'ok', pendingRouteId }
+      : null;
+  }
+
+  if (data.startsWith(ROUTE_ALT_CALLBACK_PREFIX)) {
+    const pendingRouteId = data.slice(ROUTE_ALT_CALLBACK_PREFIX.length);
+
+    return PENDING_ROUTE_ID_PATTERN.test(pendingRouteId)
+      ? { action: 'alt', pendingRouteId }
+      : null;
+  }
+
+  if (data.startsWith(ROUTE_NO_CALLBACK_PREFIX)) {
+    const pendingRouteId = data.slice(ROUTE_NO_CALLBACK_PREFIX.length);
+
+    return PENDING_ROUTE_ID_PATTERN.test(pendingRouteId)
+      ? { action: 'no', pendingRouteId }
+      : null;
+  }
+
+  if (data.startsWith(ROUTE_PICK_CALLBACK_PREFIX)) {
+    const rest = data.slice(ROUTE_PICK_CALLBACK_PREFIX.length);
+    const separatorIndex = rest.lastIndexOf(':');
+
+    if (separatorIndex <= 0) {
+      return null;
+    }
+
+    const pendingRouteId = rest.slice(0, separatorIndex);
+    const optionIndex = Number.parseInt(rest.slice(separatorIndex + 1), 10);
+
+    return PENDING_ROUTE_ID_PATTERN.test(pendingRouteId) &&
+      Number.isSafeInteger(optionIndex) &&
+      optionIndex >= 0
+      ? { action: 'pick', pendingRouteId, optionIndex }
+      : null;
+  }
+
+  return null;
+}

--- a/apps/api/src/handlers/telegram/index.ts
+++ b/apps/api/src/handlers/telegram/index.ts
@@ -478,9 +478,17 @@ telegram.post('/', async (c) => {
     });
   }
 
+  if (launch.status === 'confirmation_pending') {
+    return c.json({
+      ok: true,
+      queued: false,
+      confirmationPending: true,
+    });
+  }
+
   return c.json({
     ok: true,
     started: true,
-    cloudJobId: launch.launchResult!.id,
+    cloudJobId: launch.launchResult.id,
   });
 });

--- a/apps/api/src/handlers/telegram/replies.ts
+++ b/apps/api/src/handlers/telegram/replies.ts
@@ -54,6 +54,39 @@ export async function postTelegramMessageBestEffort(input: {
   }
 }
 
+/** Replace the text and keyboard of a bot message (cards, status lines). */
+export async function editTelegramMessageBestEffort(input: {
+  chatId: string;
+  messageId: string;
+  text: string;
+  textFormat?: 'plain' | 'markdown';
+  buttons?: CommunicationMessageButton[][];
+}): Promise<boolean> {
+  const provider = await createTelegramCommunicationProvider();
+
+  if (!provider) {
+    return false;
+  }
+
+  try {
+    await provider.editMessageText({
+      channelId: input.chatId,
+      messageId: input.messageId,
+      text: input.text,
+      ...(input.textFormat ? { textFormat: input.textFormat } : {}),
+      ...(input.buttons ? { buttons: input.buttons } : {}),
+    });
+    return true;
+  } catch (error) {
+    apiLogger.warn(
+      `[telegram] Failed to edit Telegram message: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return false;
+  }
+}
+
 /** Answer a callback query so the clicked button stops showing a spinner. */
 export async function answerTelegramCallbackQueryBestEffort(input: {
   callbackQueryId: string;

--- a/apps/api/src/handlers/telegram/routing-confirmation.ts
+++ b/apps/api/src/handlers/telegram/routing-confirmation.ts
@@ -1,0 +1,641 @@
+import { randomBytes } from 'node:crypto';
+
+import type {
+  TelegramCallbackQuery,
+  TelegramUpdateCommunicationMetadata,
+} from '@roomote/communication/telegram-update';
+import type { CommunicationMessageButton } from '@roomote/communication';
+import { getRedis } from '@roomote/redis';
+import {
+  getAvailableEnvironments,
+  type RoutingDecision,
+  type RoutingWorkspace,
+} from '@roomote/cloud-agents/server';
+
+import { apiLogger } from '../../logging.js';
+import {
+  buildTelegramRouteAltCallbackData,
+  buildTelegramRouteNoCallbackData,
+  buildTelegramRouteOkCallbackData,
+  buildTelegramRoutePickCallbackData,
+  type TelegramRouteCallbackAction,
+} from './callback-data.js';
+import { resolveTelegramSenderUserId } from './linked-user.js';
+import {
+  answerTelegramCallbackQueryBestEffort,
+  clearTelegramMessageButtonsBestEffort,
+  editTelegramMessageBestEffort,
+  postTelegramMessageBestEffort,
+} from './replies.js';
+import { launchTelegramTask, resolveTelegramWorkspace } from './task-launch.js';
+import type { QueuedTelegramCommunicationMessage } from './types.js';
+
+/**
+ * Mirrors Slack's routing auto-confirm gate
+ * (`SLACK_IMMEDIATE_AUTO_CONFIRM_CONFIDENCE` in `packages/slack/block-kit.ts`):
+ * only a high-confidence, un-remapped environment route starts without asking.
+ */
+const TELEGRAM_IMMEDIATE_CONFIRM_CONFIDENCE = 0.95;
+
+/**
+ * How long the Yes/Nope card waits before auto-starting the suggestion. Kept
+ * short so the normal flow feels immediate — the card is a brief veto
+ * window, and the started message's cancel button covers late mis-route
+ * recovery. The picker (after Nope, or on router fallback) has no timer.
+ */
+const TELEGRAM_ROUTING_AUTO_CONFIRM_TIMEOUT_MS = 5_000;
+
+/** Pickers have no auto-start, so give the user a while to choose. */
+const PENDING_ROUTE_TTL_SECONDS = 15 * 60;
+
+const PENDING_ROUTE_KEY_PREFIX = 'telegram:pending_route:';
+const PENDING_ROUTE_POINTER_KEY_PREFIX = 'telegram:pending_route_ptr:';
+
+/** Inline keyboards get unwieldy past a handful of rows. */
+const MAX_ENVIRONMENT_OPTIONS = 5;
+
+const MAX_OPTION_LABEL_LENGTH = 48;
+
+type PendingTelegramRouteOption = {
+  label: string;
+  workspace: RoutingWorkspace;
+};
+
+type PendingTelegramRoute = {
+  launchOwnerUserId: string;
+  queuedMessage: QueuedTelegramCommunicationMessage;
+  metadata: TelegramUpdateCommunicationMetadata;
+  options: PendingTelegramRouteOption[];
+  /**
+   * Index into `options` of the router's suggestion. Null once the card is
+   * in picker mode (after Nope, or on router fallback) — never auto-starts.
+   */
+  suggestedIndex: number | null;
+  confirmMessageId?: string;
+};
+
+function pendingRouteKey(pendingRouteId: string): string {
+  return `${PENDING_ROUTE_KEY_PREFIX}${pendingRouteId}`;
+}
+
+function pendingRoutePointerKey(
+  metadata: TelegramUpdateCommunicationMetadata,
+): string {
+  return `${PENDING_ROUTE_POINTER_KEY_PREFIX}${metadata.communicationChannelId}:${
+    metadata.communicationThreadId ?? '-'
+  }`;
+}
+
+function newPendingRouteId(): string {
+  return randomBytes(9).toString('base64url');
+}
+
+function parsePendingRoute(raw: string | null): PendingTelegramRoute | null {
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(raw) as PendingTelegramRoute;
+  } catch {
+    return null;
+  }
+}
+
+async function peekPendingTelegramRoute(
+  pendingRouteId: string,
+): Promise<PendingTelegramRoute | null> {
+  const redis = getRedis();
+
+  return parsePendingRoute(await redis.get(pendingRouteKey(pendingRouteId)));
+}
+
+/** One-shot claim: whichever of button click / auto-confirm timer runs first wins. */
+async function claimPendingTelegramRoute(
+  pendingRouteId: string,
+): Promise<PendingTelegramRoute | null> {
+  const redis = getRedis();
+
+  return parsePendingRoute(await redis.getdel(pendingRouteKey(pendingRouteId)));
+}
+
+async function storePendingTelegramRoute(
+  pendingRouteId: string,
+  pending: PendingTelegramRoute,
+): Promise<void> {
+  const redis = getRedis();
+  await redis.set(
+    pendingRouteKey(pendingRouteId),
+    JSON.stringify(pending),
+    'EX',
+    PENDING_ROUTE_TTL_SECONDS,
+  );
+  await redis.set(
+    pendingRoutePointerKey(pending.metadata),
+    pendingRouteId,
+    'EX',
+    PENDING_ROUTE_TTL_SECONDS,
+  );
+}
+
+function truncateLabel(label: string): string {
+  return label.length > MAX_OPTION_LABEL_LENGTH
+    ? `${label.slice(0, MAX_OPTION_LABEL_LENGTH - 1)}…`
+    : label;
+}
+
+async function buildWorkspaceOptions(
+  suggested: RoutingWorkspace | null,
+): Promise<{
+  options: PendingTelegramRouteOption[];
+  suggestedIndex: number | null;
+}> {
+  const environments = await getAvailableEnvironments();
+  const suggestedEnvironmentId =
+    suggested?.type === 'environment' ? suggested.id : null;
+
+  const environmentOptions = environments
+    // The suggested environment always keeps its slot at the front.
+    .sort((left, right) =>
+      left.id === suggestedEnvironmentId
+        ? -1
+        : right.id === suggestedEnvironmentId
+          ? 1
+          : left.name.localeCompare(right.name),
+    )
+    .slice(0, MAX_ENVIRONMENT_OPTIONS)
+    .map<PendingTelegramRouteOption>((environment) => ({
+      label: truncateLabel(environment.name),
+      workspace: {
+        type: 'environment',
+        id: environment.id,
+        name: environment.name,
+      },
+    }));
+
+  const options: PendingTelegramRouteOption[] = [
+    ...environmentOptions,
+    { label: 'All repositories', workspace: { type: 'all_repositories' } },
+  ];
+
+  const suggestedIndex =
+    suggested === null
+      ? null
+      : options.findIndex((option) =>
+          suggested.type === 'all_repositories'
+            ? option.workspace.type === 'all_repositories'
+            : option.workspace.type === 'environment' &&
+              option.workspace.id === suggested.id,
+        );
+
+  return {
+    options,
+    suggestedIndex:
+      suggestedIndex === null || suggestedIndex < 0 ? null : suggestedIndex,
+  };
+}
+
+/** The compact Yes/Nope row shown while the suggestion is pending. */
+function buildConfirmButtons(
+  pendingRouteId: string,
+): CommunicationMessageButton[][] {
+  return [
+    [
+      {
+        text: '✅ Yes',
+        callbackData: buildTelegramRouteOkCallbackData(pendingRouteId),
+      },
+      {
+        text: '✖️ Nope',
+        callbackData: buildTelegramRouteAltCallbackData(pendingRouteId),
+      },
+    ],
+  ];
+}
+
+/** The full workspace list, shown after Nope or on router fallback. */
+function buildPickerButtons(
+  pendingRouteId: string,
+  options: PendingTelegramRouteOption[],
+): CommunicationMessageButton[][] {
+  return [
+    ...options.map((option, index) => [
+      {
+        text: option.label,
+        callbackData: buildTelegramRoutePickCallbackData(pendingRouteId, index),
+      },
+    ]),
+    [
+      {
+        text: '✖️ Nevermind',
+        callbackData: buildTelegramRouteNoCallbackData(pendingRouteId),
+      },
+    ],
+  ];
+}
+
+const PICKER_TEXT = 'Okay — where should I run this?';
+
+/** Swap the card into a terminal state: final text, keyboard removed. */
+async function finalizeConfirmationCard(input: {
+  chatId: string;
+  messageId: string;
+  text: string;
+}): Promise<void> {
+  const edited = await editTelegramMessageBestEffort({
+    chatId: input.chatId,
+    messageId: input.messageId,
+    text: input.text,
+    textFormat: 'markdown',
+  });
+
+  if (!edited) {
+    await clearTelegramMessageButtonsBestEffort({
+      chatId: input.chatId,
+      messageId: input.messageId,
+    });
+  }
+}
+
+/**
+ * A superseding request in the same chat/topic invalidates the previous
+ * pending card so two confirmations can never both launch.
+ */
+async function invalidatePreviousPendingRoute(
+  metadata: TelegramUpdateCommunicationMetadata,
+): Promise<void> {
+  const redis = getRedis();
+  const previousId = await redis.getdel(pendingRoutePointerKey(metadata));
+
+  if (!previousId) {
+    return;
+  }
+
+  const previous = parsePendingRoute(
+    await redis.getdel(pendingRouteKey(previousId)),
+  );
+
+  if (previous?.confirmMessageId) {
+    await clearTelegramMessageButtonsBestEffort({
+      chatId: previous.metadata.communicationChannelId,
+      messageId: previous.confirmMessageId,
+    });
+  }
+}
+
+function scheduleTelegramRoutingAutoConfirm(pendingRouteId: string): void {
+  const timer = setTimeout(() => {
+    autoConfirmTelegramRouting(pendingRouteId).catch((error) => {
+      apiLogger.warn(
+        `[telegram] Routing auto-confirm failed for ${pendingRouteId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    });
+  }, TELEGRAM_ROUTING_AUTO_CONFIRM_TIMEOUT_MS);
+
+  // Like Slack's auto-confirm, the timer is in-process: a restart loses it
+  // and the pending route simply expires with its Redis TTL.
+  timer.unref?.();
+}
+
+async function autoConfirmTelegramRouting(
+  pendingRouteId: string,
+): Promise<void> {
+  const pending = await claimPendingTelegramRoute(pendingRouteId);
+
+  if (!pending || pending.suggestedIndex === null) {
+    return;
+  }
+
+  const option = pending.options[pending.suggestedIndex];
+  const workspace = option
+    ? await resolveTelegramWorkspace(option.workspace)
+    : null;
+
+  if (!workspace) {
+    if (pending.confirmMessageId) {
+      await clearTelegramMessageButtonsBestEffort({
+        chatId: pending.metadata.communicationChannelId,
+        messageId: pending.confirmMessageId,
+      });
+    }
+    await postTelegramMessageBestEffort({
+      chatId: pending.metadata.communicationChannelId,
+      threadId: pending.metadata.communicationThreadId,
+      replyToMessageId: pending.metadata.communicationMessageId,
+      text: 'Could not start the task — the suggested workspace is no longer available. Send the request again.',
+    });
+    return;
+  }
+
+  if (pending.confirmMessageId) {
+    await finalizeConfirmationCard({
+      chatId: pending.metadata.communicationChannelId,
+      messageId: pending.confirmMessageId,
+      text: `Starting in **${workspace.workspaceDisplayName}**.`,
+    });
+  }
+
+  await launchTelegramTask({
+    launchOwnerUserId: pending.launchOwnerUserId,
+    queuedMessage: pending.queuedMessage,
+    metadata: pending.metadata,
+    workspace,
+  });
+}
+
+/**
+ * Post a routing-confirmation card when the router was not confident (or
+ * fell back entirely) and there is more than one workspace to choose from.
+ *
+ * Routed suggestions get a compact Yes/Nope card that auto-starts after a
+ * few seconds; Nope swaps the same message into a workspace picker. Router
+ * fallback shows the picker directly and never auto-starts.
+ *
+ * Returns null when the launch should proceed immediately instead: high
+ * confidence, nothing to choose between, or the card could not be stored or
+ * posted (the task must never be dropped because confirmation plumbing
+ * failed).
+ */
+export async function maybeRequestTelegramRoutingConfirmation(input: {
+  routingDecision: Exclude<RoutingDecision, { status: 'platform_answer' }>;
+  launchOwnerUserId: string;
+  queuedMessage: QueuedTelegramCommunicationMessage;
+  metadata: TelegramUpdateCommunicationMetadata;
+}): Promise<{ pendingRouteId: string } | null> {
+  const routed =
+    input.routingDecision.status === 'routed'
+      ? input.routingDecision.result
+      : null;
+
+  if (
+    routed &&
+    routed.workspace.type === 'environment' &&
+    typeof routed.debug?.confidence === 'number' &&
+    routed.debug.confidence >= TELEGRAM_IMMEDIATE_CONFIRM_CONFIDENCE &&
+    routed.debug.workspaceRemapped !== true
+  ) {
+    return null;
+  }
+
+  try {
+    const { options, suggestedIndex } = await buildWorkspaceOptions(
+      routed?.workspace ?? null,
+    );
+
+    if (options.length <= 1) {
+      return null;
+    }
+
+    const pendingRouteId = newPendingRouteId();
+    const pending: PendingTelegramRoute = {
+      launchOwnerUserId: input.launchOwnerUserId,
+      queuedMessage: input.queuedMessage,
+      metadata: input.metadata,
+      options,
+      suggestedIndex,
+    };
+
+    await invalidatePreviousPendingRoute(input.metadata);
+    await storePendingTelegramRoute(pendingRouteId, pending);
+
+    const suggestedLabel =
+      suggestedIndex === null ? null : options[suggestedIndex]!.label;
+    const posted = await postTelegramMessageBestEffort({
+      chatId: input.metadata.communicationChannelId,
+      threadId: input.metadata.communicationThreadId,
+      replyToMessageId: input.metadata.communicationMessageId,
+      text: suggestedLabel
+        ? `Planning to run this in **${suggestedLabel}** — starting in ~${Math.round(TELEGRAM_ROUTING_AUTO_CONFIRM_TIMEOUT_MS / 1000)}s.`
+        : 'I could not confidently pick a workspace for this request. Choose where to run it:',
+      textFormat: 'markdown',
+      buttons:
+        suggestedIndex === null
+          ? buildPickerButtons(pendingRouteId, options)
+          : buildConfirmButtons(pendingRouteId),
+    });
+
+    if (!posted) {
+      // The card never reached the chat, so nobody can click it — reclaim
+      // the state and launch immediately.
+      await claimPendingTelegramRoute(pendingRouteId);
+      return null;
+    }
+
+    // Attach the card's message id (needed to finalize it later); XX so a
+    // click that already claimed the state is not resurrected.
+    const redis = getRedis();
+    await redis.set(
+      pendingRouteKey(pendingRouteId),
+      JSON.stringify({ ...pending, confirmMessageId: posted.messageId }),
+      'EX',
+      PENDING_ROUTE_TTL_SECONDS,
+      'XX',
+    );
+
+    if (suggestedIndex !== null) {
+      scheduleTelegramRoutingAutoConfirm(pendingRouteId);
+    }
+
+    return { pendingRouteId };
+  } catch (error) {
+    apiLogger.warn(
+      `[telegram] Skipping routing confirmation (falling back to immediate launch): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Nope: swap the Yes/Nope card into the workspace picker. The pending state
+ * moves to a fresh id so the already-scheduled auto-confirm timer (which
+ * claims the old id) can never launch the suggestion after the user said no.
+ */
+async function switchToWorkspacePicker(params: {
+  query: TelegramCallbackQuery;
+  chatId: string;
+  messageId: string;
+  claimed: PendingTelegramRoute;
+}): Promise<void> {
+  const nextId = newPendingRouteId();
+  const nextPending: PendingTelegramRoute = {
+    ...params.claimed,
+    suggestedIndex: null,
+    confirmMessageId: params.messageId,
+  };
+
+  await storePendingTelegramRoute(nextId, nextPending);
+
+  const edited = await editTelegramMessageBestEffort({
+    chatId: params.chatId,
+    messageId: params.messageId,
+    text: PICKER_TEXT,
+    buttons: buildPickerButtons(nextId, nextPending.options),
+  });
+
+  if (!edited) {
+    // Editing failed (deleted card, API hiccup) — post the picker as a new
+    // message so the user is not stuck.
+    const posted = await postTelegramMessageBestEffort({
+      chatId: params.chatId,
+      replyToMessageId: params.messageId,
+      text: PICKER_TEXT,
+      buttons: buildPickerButtons(nextId, nextPending.options),
+    });
+
+    if (posted) {
+      const redis = getRedis();
+      await redis.set(
+        pendingRouteKey(nextId),
+        JSON.stringify({ ...nextPending, confirmMessageId: posted.messageId }),
+        'EX',
+        PENDING_ROUTE_TTL_SECONDS,
+        'XX',
+      );
+    }
+  }
+
+  await answerTelegramCallbackQueryBestEffort({
+    callbackQueryId: params.query.id,
+  });
+}
+
+/** Handle a click on one of the routing-confirmation buttons. */
+export async function handleTelegramRoutingCallback(params: {
+  query: TelegramCallbackQuery;
+  action: TelegramRouteCallbackAction;
+}): Promise<void> {
+  const { query, action } = params;
+  const message = query.message;
+  const chatId = message ? String(message.chat.id) : null;
+
+  if (!chatId || !message) {
+    await answerTelegramCallbackQueryBestEffort({ callbackQueryId: query.id });
+    return;
+  }
+
+  const pending = await peekPendingTelegramRoute(action.pendingRouteId);
+
+  if (!pending || pending.metadata.communicationChannelId !== chatId) {
+    await answerTelegramCallbackQueryBestEffort({
+      callbackQueryId: query.id,
+      text: 'This choice expired — send the request again.',
+    });
+    await clearTelegramMessageButtonsBestEffort({
+      chatId,
+      messageId: String(message.message_id),
+    });
+    return;
+  }
+
+  const senderUserId = await resolveTelegramSenderUserId(String(query.from.id));
+
+  // Peek-then-verify so a click from someone else cannot consume the
+  // requester's pending choice.
+  if (!senderUserId || senderUserId !== pending.launchOwnerUserId) {
+    await answerTelegramCallbackQueryBestEffort({
+      callbackQueryId: query.id,
+      text: 'Only the requester can choose a workspace for this task.',
+    });
+    return;
+  }
+
+  const optionIndex =
+    action.action === 'ok'
+      ? pending.suggestedIndex
+      : action.action === 'pick'
+        ? action.optionIndex
+        : null;
+
+  if (
+    (action.action === 'ok' || action.action === 'pick') &&
+    (optionIndex === null || optionIndex < 0)
+  ) {
+    await answerTelegramCallbackQueryBestEffort({ callbackQueryId: query.id });
+    return;
+  }
+
+  const claimed = await claimPendingTelegramRoute(action.pendingRouteId);
+
+  if (!claimed) {
+    await answerTelegramCallbackQueryBestEffort({
+      callbackQueryId: query.id,
+      text: 'This choice expired — send the request again.',
+    });
+    return;
+  }
+
+  if (action.action === 'alt') {
+    await switchToWorkspacePicker({
+      query,
+      chatId,
+      messageId: String(message.message_id),
+      claimed,
+    });
+    return;
+  }
+
+  if (action.action === 'no') {
+    await answerTelegramCallbackQueryBestEffort({
+      callbackQueryId: query.id,
+      text: 'Okay — not starting a task.',
+    });
+    await finalizeConfirmationCard({
+      chatId,
+      messageId: String(message.message_id),
+      text: 'Okay — not starting a task.',
+    });
+    return;
+  }
+
+  const option = claimed.options[optionIndex!];
+  const workspace = option
+    ? await resolveTelegramWorkspace(option.workspace)
+    : null;
+
+  if (!workspace) {
+    await answerTelegramCallbackQueryBestEffort({
+      callbackQueryId: query.id,
+      text: 'That workspace is no longer available.',
+    });
+    await postTelegramMessageBestEffort({
+      chatId,
+      replyToMessageId: String(message.message_id),
+      text: 'Could not start the task — that workspace is no longer available. Send the request again.',
+    });
+    return;
+  }
+
+  await answerTelegramCallbackQueryBestEffort({
+    callbackQueryId: query.id,
+    text: `Starting in ${workspace.workspaceDisplayName}.`,
+  });
+  await finalizeConfirmationCard({
+    chatId,
+    messageId: String(message.message_id),
+    text: `Starting in **${workspace.workspaceDisplayName}**.`,
+  });
+
+  try {
+    await launchTelegramTask({
+      launchOwnerUserId: claimed.launchOwnerUserId,
+      queuedMessage: claimed.queuedMessage,
+      metadata: claimed.metadata,
+      workspace,
+    });
+  } catch (error) {
+    apiLogger.warn(
+      `[telegram] Failed to launch task from routing confirmation: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    await postTelegramMessageBestEffort({
+      chatId,
+      replyToMessageId: String(message.message_id),
+      text: 'Could not start the task — send the request again.',
+    });
+  }
+}

--- a/apps/api/src/handlers/telegram/task-launch.ts
+++ b/apps/api/src/handlers/telegram/task-launch.ts
@@ -1,0 +1,108 @@
+import type { TelegramUpdateCommunicationMetadata } from '@roomote/communication/telegram-update';
+import {
+  ALL_REPOSITORIES,
+  CloudTaskType,
+  type CloudTask,
+} from '@roomote/types';
+import { db, environments, eq } from '@roomote/db/server';
+import {
+  enqueueCloudTask,
+  getTaskUrl,
+  type RoutingWorkspace,
+} from '@roomote/cloud-agents/server';
+
+import { buildTelegramCancelTaskCallbackData } from './callback-data.js';
+import { postTelegramMessageBestEffort } from './replies.js';
+import type {
+  QueuedTelegramCommunicationMessage,
+  TelegramWorkspaceSelection,
+} from './types.js';
+
+export async function resolveTelegramWorkspace(
+  workspace: RoutingWorkspace,
+): Promise<TelegramWorkspaceSelection | null> {
+  if (workspace.type === 'all_repositories') {
+    return {
+      repoForPayload: ALL_REPOSITORIES,
+      workspaceDisplayName: 'all repos',
+    };
+  }
+
+  const environment = await db.query.environments.findFirst({
+    where: eq(environments.id, workspace.id),
+    columns: { id: true, name: true, config: true },
+  });
+
+  if (!environment) {
+    return null;
+  }
+
+  const config = environment.config as {
+    repositories?: Array<{ repository: string }>;
+  };
+  const firstRepo = config.repositories?.[0]?.repository;
+
+  if (!firstRepo) {
+    return null;
+  }
+
+  return {
+    environmentId: environment.id,
+    repoForPayload: firstRepo,
+    workspaceDisplayName: environment.name,
+  };
+}
+
+/**
+ * Enqueue a standard cloud task for a Telegram request and post the
+ * task-started message (with follow/cancel buttons) back to the chat. Shared
+ * by the immediate launch path, the routing-confirmation buttons, and the
+ * confirmation auto-start timer.
+ */
+export async function launchTelegramTask(input: {
+  launchOwnerUserId: string;
+  queuedMessage: QueuedTelegramCommunicationMessage;
+  metadata: TelegramUpdateCommunicationMetadata;
+  workspace: TelegramWorkspaceSelection;
+}) {
+  const task: Extract<CloudTask, { type: CloudTaskType.StandardTask }> = {
+    type: CloudTaskType.StandardTask,
+    userId: input.launchOwnerUserId,
+    payload: {
+      repo: input.workspace.repoForPayload,
+      ...(input.workspace.environmentId
+        ? { environmentId: input.workspace.environmentId }
+        : {}),
+      description: input.queuedMessage.text,
+      ...input.metadata,
+    },
+  };
+  const launchResult = await enqueueCloudTask(task, {
+    launchClass: 'human',
+  });
+
+  const taskUrl = getTaskUrl({
+    taskId: launchResult.taskId,
+    utm: { source: 'telegram', campaign: 'telegram.thread_start' },
+  });
+
+  await postTelegramMessageBestEffort({
+    chatId: input.metadata.communicationChannelId,
+    threadId: input.metadata.communicationThreadId,
+    replyToMessageId: input.metadata.communicationMessageId,
+    text: taskUrl
+      ? `Started a task in ${input.workspace.workspaceDisplayName}.`
+      : `Queued a task in ${input.workspace.workspaceDisplayName}.`,
+    buttons: [
+      ...(taskUrl ? [[{ text: 'Follow Task', url: taskUrl }]] : []),
+      [
+        {
+          text: '✖️ Cancel task',
+          callbackData: buildTelegramCancelTaskCallbackData(launchResult.id),
+        },
+      ],
+    ],
+  });
+
+  return launchResult;
+}

--- a/apps/api/src/handlers/telegram/task-orchestration.ts
+++ b/apps/api/src/handlers/telegram/task-orchestration.ts
@@ -6,68 +6,30 @@ import { Env } from '@roomote/env';
 import {
   ALL_REPOSITORIES,
   CloudTaskType,
-  type CloudTask,
   type CloudTaskPayload,
   populateSnapshotResumeCommunicationMetadata,
   restoreSnapshotResumeVisiblePromptFields,
 } from '@roomote/types';
-import { db, environments, eq } from '@roomote/db/server';
 import {
   buildTelegramRoutingContext,
   enqueueCloudTask,
   getTaskUrl,
   routeTask,
-  type RoutingWorkspace,
 } from '@roomote/cloud-agents/server';
 
 import type { CompletedTelegramJob } from './job-lookup.js';
-import { buildTelegramCancelTaskCallbackData } from './callback-actions.js';
+import { maybeRequestTelegramRoutingConfirmation } from './routing-confirmation.js';
 import { postTelegramMessageBestEffort } from './replies.js';
+import { launchTelegramTask, resolveTelegramWorkspace } from './task-launch.js';
 import type {
   QueuedTelegramCommunicationMessage,
   TelegramConversationRef,
-  TelegramWorkspaceSelection,
 } from './types.js';
 
 function cleanOptionalString(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
 
   return trimmed ? trimmed : undefined;
-}
-
-async function resolveTelegramWorkspace(
-  workspace: RoutingWorkspace,
-): Promise<TelegramWorkspaceSelection | null> {
-  if (workspace.type === 'all_repositories') {
-    return {
-      repoForPayload: ALL_REPOSITORIES,
-      workspaceDisplayName: 'all repos',
-    };
-  }
-
-  const environment = await db.query.environments.findFirst({
-    where: eq(environments.id, workspace.id),
-    columns: { id: true, name: true, config: true },
-  });
-
-  if (!environment) {
-    return null;
-  }
-
-  const config = environment.config as {
-    repositories?: Array<{ repository: string }>;
-  };
-  const firstRepo = config.repositories?.[0]?.repository;
-
-  if (!firstRepo) {
-    return null;
-  }
-
-  return {
-    environmentId: environment.id,
-    repoForPayload: firstRepo,
-    workspaceDisplayName: environment.name,
-  };
 }
 
 export async function resumeTelegramTaskFromSnapshot(input: {
@@ -148,6 +110,11 @@ export async function startNewTelegramTask(input: {
   launchOwnerUserId: string;
   queuedMessage: QueuedTelegramCommunicationMessage;
   metadata: TelegramUpdateCommunicationMetadata;
+  /**
+   * Launch without the routing-confirmation card. Used when the user already
+   * expressed explicit intent (for example a suggestion button click).
+   */
+  skipRoutingConfirmation?: boolean;
 }) {
   const routingContext = await buildTelegramRoutingContext({
     userId: input.launchOwnerUserId,
@@ -181,6 +148,23 @@ export async function startNewTelegramTask(input: {
     };
   }
 
+  if (!input.skipRoutingConfirmation) {
+    const confirmation = await maybeRequestTelegramRoutingConfirmation({
+      routingDecision,
+      launchOwnerUserId: input.launchOwnerUserId,
+      queuedMessage: input.queuedMessage,
+      metadata: input.metadata,
+    });
+
+    if (confirmation) {
+      return {
+        status: 'confirmation_pending' as const,
+        routingDecision,
+        pendingRouteId: confirmation.pendingRouteId,
+      };
+    }
+  }
+
   const workspace =
     routingDecision.status === 'routed'
       ? await resolveTelegramWorkspace(routingDecision.result.workspace)
@@ -193,43 +177,11 @@ export async function startNewTelegramTask(input: {
     throw new Error('Telegram task routing selected an unavailable workspace.');
   }
 
-  const task: Extract<CloudTask, { type: CloudTaskType.StandardTask }> = {
-    type: CloudTaskType.StandardTask,
-    userId: input.launchOwnerUserId,
-    payload: {
-      repo: workspace.repoForPayload,
-      ...(workspace.environmentId
-        ? { environmentId: workspace.environmentId }
-        : {}),
-      description: input.queuedMessage.text,
-      ...input.metadata,
-    },
-  };
-  const launchResult = await enqueueCloudTask(task, {
-    launchClass: 'human',
-  });
-
-  const taskUrl = getTaskUrl({
-    taskId: launchResult.taskId,
-    utm: { source: 'telegram', campaign: 'telegram.thread_start' },
-  });
-
-  await postTelegramMessageBestEffort({
-    chatId: input.metadata.communicationChannelId,
-    threadId: input.metadata.communicationThreadId,
-    replyToMessageId: input.metadata.communicationMessageId,
-    text: taskUrl
-      ? `Started a task in ${workspace.workspaceDisplayName}.`
-      : `Queued a task in ${workspace.workspaceDisplayName}.`,
-    buttons: [
-      ...(taskUrl ? [[{ text: 'Follow Task', url: taskUrl }]] : []),
-      [
-        {
-          text: '✖️ Cancel task',
-          callbackData: buildTelegramCancelTaskCallbackData(launchResult.id),
-        },
-      ],
-    ],
+  const launchResult = await launchTelegramTask({
+    launchOwnerUserId: input.launchOwnerUserId,
+    queuedMessage: input.queuedMessage,
+    metadata: input.metadata,
+    workspace,
   });
 
   return {

--- a/knip.ts
+++ b/knip.ts
@@ -85,6 +85,9 @@ const config: KnipConfig = {
         'evals/router/promptfooconfig.followup.ts',
       ],
     },
+    'packages/communication': {
+      project: ['src/**/*.ts'],
+    },
     'packages/compute-providers': {
       project: ['src/**/*.ts'],
     },

--- a/packages/communication/evals/run-telegram-scenario.ts
+++ b/packages/communication/evals/run-telegram-scenario.ts
@@ -1,0 +1,189 @@
+#!/usr/bin/env tsx
+/**
+ * Telegram behavior eval runner: drives the mock Telegram harness through a
+ * scenario, captures everything Roomote posted back, and writes a
+ * criterion-eval bundle for judging (see RooCodeInc/opencode-bench,
+ * scripts/judge-criteria.ts).
+ *
+ * Prerequisites: local dev stack running (pnpm dev) with
+ * TELEGRAM_API_BASE_URL pointing at the mock port used here, and the mock
+ * Telegram user mapping seeded (see
+ * .agents/skills/mock-telegram-testing/SKILL.md).
+ *
+ * Usage:
+ *   pnpm --filter @roomote/communication eval:telegram-scenario -- \
+ *     --scenario evals/scenarios/telegram-fast-answer.json \
+ *     --webhook http://localhost:13101/api/webhooks/telegram \
+ *     --target roomote@local-dev --episode 1 --out /tmp/telegram-eval-bundles
+ */
+
+import { parseArgs } from 'node:util';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { z } from 'zod';
+import {
+  MockTelegramServer,
+  type MockTelegramState,
+} from '../src/mock-telegram-server.js';
+
+const scenarioSchema = z.object({
+  name: z.string().regex(/^[a-z0-9][a-z0-9-]*$/),
+  description: z.string(),
+  criteria: z.array(z.string().min(1)).min(1),
+  state: z.record(z.string(), z.unknown()),
+  events: z.array(
+    z.object({
+      delayMs: z.number().int().nonnegative().default(0),
+      envelope: z.record(z.string(), z.unknown()),
+    }),
+  ),
+  settleMs: z.number().int().positive().default(20_000),
+  timeoutMs: z.number().int().positive().default(180_000),
+});
+
+const { values } = parseArgs({
+  options: {
+    scenario: { type: 'string' },
+    webhook: {
+      type: 'string',
+      default: 'http://localhost:13101/api/webhooks/telegram',
+    },
+    port: { type: 'string', default: '3013' },
+    target: { type: 'string', default: 'roomote@local-dev' },
+    episode: { type: 'string', default: '1' },
+    out: { type: 'string', default: '/tmp/telegram-eval-bundles' },
+  },
+});
+
+if (!values.scenario) {
+  console.error('Error: --scenario <file> is required');
+  process.exit(1);
+}
+
+const scenario = scenarioSchema.parse(
+  JSON.parse(await readFile(values.scenario, 'utf-8')),
+);
+const episode = Number.parseInt(values.episode!, 10) || 1;
+
+// Substitute run-unique tokens so episodes never collide on the Redis
+// update_id dedup: every "$U<n>" becomes a unique update id and every
+// "$M<n>" a unique message id — the same token maps to the same value.
+// Tokens resolve to numbers when they are the entire value ("$U1"), so
+// update_id/message_id fields keep their integer type.
+const runBase = Math.floor(Date.now() / 10) % 100_000_000;
+const tokens = new Map<string, number>();
+let tokenSeq = 0;
+function tokenValue(token: string): number {
+  let v = tokens.get(token);
+  if (v === undefined) {
+    v = runBase * 100 + ++tokenSeq;
+    tokens.set(token, v);
+  }
+  return v;
+}
+function substitute(value: unknown): unknown {
+  if (typeof value === 'string') {
+    const exact = /^\$(?:U|M)\d+$/.exec(value);
+    if (exact) {
+      return tokenValue(value);
+    }
+    return value.replace(/\$(?:U|M)\d+/g, (m) => String(tokenValue(m)));
+  }
+  if (Array.isArray(value)) return value.map(substitute);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([k, v]) => [k, substitute(v)]),
+    );
+  }
+  return value;
+}
+
+const server = new MockTelegramServer({
+  state: substitute(scenario.state) as MockTelegramState,
+  roomoteTarget: {
+    webhookUrl: values.webhook!,
+    secretToken: process.env.TELEGRAM_WEBHOOK_SECRET ?? '',
+  },
+});
+const baseUrl = await server.start(Number.parseInt(values.port!, 10));
+console.log(`mock telegram listening at ${baseUrl} -> ${values.webhook}`);
+
+if (
+  process.env.TELEGRAM_API_BASE_URL &&
+  process.env.TELEGRAM_API_BASE_URL.replace(/\/+$/, '') !== baseUrl
+) {
+  console.warn(
+    `WARNING: TELEGRAM_API_BASE_URL=${process.env.TELEGRAM_API_BASE_URL} does not match ${baseUrl}; ` +
+      `the API server may post replies somewhere else.`,
+  );
+}
+
+const startedAt = Date.now();
+const dispatched: { at: string; envelope: unknown; result: unknown }[] = [];
+
+try {
+  for (const { delayMs, envelope } of scenario.events) {
+    if (delayMs) await new Promise((r) => setTimeout(r, delayMs));
+    const resolved = substitute(envelope);
+    const result = await server.dispatch(resolved as never);
+    dispatched.push({
+      at: new Date().toISOString(),
+      envelope: resolved,
+      result,
+    });
+    console.log(
+      `dispatched ${(resolved as { kind: string }).kind} -> HTTP ${result.status}`,
+    );
+  }
+
+  // Settle: wait until the message log has been stable for settleMs (with
+  // at least one bot message), or give up at timeoutMs and judge as-is.
+  let lastCount = -1;
+  let stableSince = Date.now();
+  let timedOut = false;
+  for (;;) {
+    const messages = server.getState().messages ?? [];
+    if (messages.length !== lastCount) {
+      lastCount = messages.length;
+      stableSince = Date.now();
+    }
+    const hasBotMessage = messages.some((m) => m.from.is_bot);
+    if (hasBotMessage && Date.now() - stableSince >= scenario.settleMs) break;
+    if (Date.now() - startedAt >= scenario.timeoutMs) {
+      timedOut = true;
+      break;
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+
+  const duration = Date.now() - startedAt;
+  const state = server.getState();
+  const bundle = {
+    name: scenario.name,
+    target: values.target,
+    episode,
+    criteria: scenario.criteria,
+    artifacts: {
+      telegram_transcript: JSON.stringify(state.messages ?? [], null, 2),
+      callback_answers: JSON.stringify(state.callbackAnswers ?? [], null, 2),
+      dispatched_events: JSON.stringify(dispatched, null, 2),
+      timing: [
+        `run started ${new Date(startedAt).toISOString()}`,
+        `settled after ${Math.round(duration / 1000)}s${timedOut ? ' (TIMEOUT reached before quiescence)' : ''}`,
+        `bot: ${state.bot?.username} (id ${state.bot?.id})`,
+      ].join('\n'),
+    },
+    duration,
+  };
+
+  await mkdir(values.out!, { recursive: true });
+  const outFile = join(values.out!, `${scenario.name}-ep${episode}.json`);
+  await writeFile(outFile, JSON.stringify(bundle, null, 2));
+  const botCount = (state.messages ?? []).filter((m) => m.from.is_bot).length;
+  console.log(
+    `captured ${state.messages?.length ?? 0} messages (${botCount} from bot)${timedOut ? ' [timeout]' : ''}`,
+  );
+  console.log(`bundle written to ${outFile}`);
+} finally {
+  await server.stop();
+}

--- a/packages/communication/evals/scenarios/telegram-duplicate-delivery.json
+++ b/packages/communication/evals/scenarios/telegram-duplicate-delivery.json
@@ -1,0 +1,55 @@
+{
+  "name": "telegram-duplicate-delivery",
+  "description": "Telegram redelivers the same update (identical update_id) 6 seconds apart; Redis update_id dedup must make handling exactly-once.",
+  "criteria": [
+    "The bot answered the question exactly once — there is exactly one bot answer message in chat 111000111.",
+    "The second delivery of the same update_id did not produce a second acknowledgement or a second task launch."
+  ],
+  "state": {
+    "bot": {
+      "id": 7000000001,
+      "username": "roomote_mock_bot",
+      "first_name": "Roomote"
+    },
+    "chats": [{ "id": 111000111, "type": "private", "first_name": "Dan" }],
+    "users": [{ "id": 111000111, "first_name": "Dan", "username": "dan_mock" }]
+  },
+  "events": [
+    {
+      "delayMs": 0,
+      "envelope": {
+        "kind": "message",
+        "updateId": "$U1",
+        "message": {
+          "message_id": "$M1",
+          "chat": { "id": 111000111, "type": "private", "first_name": "Dan" },
+          "from": {
+            "id": 111000111,
+            "first_name": "Dan",
+            "username": "dan_mock"
+          },
+          "text": "!fast what does the /new command do on Telegram?"
+        }
+      }
+    },
+    {
+      "delayMs": 6000,
+      "envelope": {
+        "kind": "message",
+        "updateId": "$U1",
+        "message": {
+          "message_id": "$M1",
+          "chat": { "id": 111000111, "type": "private", "first_name": "Dan" },
+          "from": {
+            "id": 111000111,
+            "first_name": "Dan",
+            "username": "dan_mock"
+          },
+          "text": "!fast what does the /new command do on Telegram?"
+        }
+      }
+    }
+  ],
+  "settleMs": 20000,
+  "timeoutMs": 180000
+}

--- a/packages/communication/evals/scenarios/telegram-fast-answer.json
+++ b/packages/communication/evals/scenarios/telegram-fast-answer.json
@@ -1,0 +1,40 @@
+{
+  "name": "telegram-fast-answer",
+  "description": "A linked user asks a !fast question in a private chat; Roomote should answer inline in the same chat without launching a cloud job.",
+  "criteria": [
+    "The bot posted at least one message in chat 111000111 answering the question.",
+    "The bot reply references the Telegram webhook handler (apps/api handlers) or otherwise plausibly answers the question.",
+    "The user's question message received an acknowledgement reaction (👀) or a prompt textual answer.",
+    "The bot did not post duplicate answers for the single inbound message."
+  ],
+  "state": {
+    "bot": {
+      "id": 7000000001,
+      "username": "roomote_mock_bot",
+      "first_name": "Roomote"
+    },
+    "chats": [{ "id": 111000111, "type": "private", "first_name": "Dan" }],
+    "users": [{ "id": 111000111, "first_name": "Dan", "username": "dan_mock" }]
+  },
+  "events": [
+    {
+      "delayMs": 0,
+      "envelope": {
+        "kind": "message",
+        "updateId": "$U1",
+        "message": {
+          "message_id": "$M1",
+          "chat": { "id": 111000111, "type": "private", "first_name": "Dan" },
+          "from": {
+            "id": 111000111,
+            "first_name": "Dan",
+            "username": "dan_mock"
+          },
+          "text": "!fast what file handles Telegram webhooks?"
+        }
+      }
+    }
+  ],
+  "settleMs": 20000,
+  "timeoutMs": 180000
+}

--- a/packages/communication/evals/scenarios/telegram-group-mention-gating.json
+++ b/packages/communication/evals/scenarios/telegram-group-mention-gating.json
@@ -1,0 +1,66 @@
+{
+  "name": "telegram-group-mention-gating",
+  "description": "In a group chat, a message without a bot mention must be ignored while a subsequent @roomote_mock_bot mention becomes task entry. Requires TELEGRAM_BOT_USERNAME=roomote_mock_bot on the API server.",
+  "criteria": [
+    "The bot posted no reply to the first (unmentioned) group message.",
+    "The bot acknowledged or replied to the second message that mentions @roomote_mock_bot in chat -100222000222.",
+    "Any bot replies are in the group chat -100222000222, not in a different chat."
+  ],
+  "state": {
+    "bot": {
+      "id": 7000000001,
+      "username": "roomote_mock_bot",
+      "first_name": "Roomote"
+    },
+    "chats": [
+      { "id": -100222000222, "type": "supergroup", "title": "roomote-dev" }
+    ],
+    "users": [{ "id": 111000111, "first_name": "Dan", "username": "dan_mock" }]
+  },
+  "events": [
+    {
+      "delayMs": 0,
+      "envelope": {
+        "kind": "message",
+        "updateId": "$U1",
+        "message": {
+          "message_id": "$M1",
+          "chat": {
+            "id": -100222000222,
+            "type": "supergroup",
+            "title": "roomote-dev"
+          },
+          "from": {
+            "id": 111000111,
+            "first_name": "Dan",
+            "username": "dan_mock"
+          },
+          "text": "just chatting with the team, nothing for the bot here"
+        }
+      }
+    },
+    {
+      "delayMs": 3000,
+      "envelope": {
+        "kind": "message",
+        "updateId": "$U2",
+        "message": {
+          "message_id": "$M2",
+          "chat": {
+            "id": -100222000222,
+            "type": "supergroup",
+            "title": "roomote-dev"
+          },
+          "from": {
+            "id": 111000111,
+            "first_name": "Dan",
+            "username": "dan_mock"
+          },
+          "text": "@roomote_mock_bot !fast which env var stores the Telegram bot token?"
+        }
+      }
+    }
+  ],
+  "settleMs": 20000,
+  "timeoutMs": 180000
+}

--- a/packages/communication/package.json
+++ b/packages/communication/package.json
@@ -21,8 +21,10 @@
     "lint": "eslint src --ext=ts --max-warnings=0",
     "check-types": "tsc --noEmit",
     "check-types:fast": "tsgo --noEmit",
+    "mock:telegram": "dotenvx run -f ../../.env.local -- tsx scripts/run-mock-telegram.ts",
     "test": "dotenvx run -f ../../.env.test -- vitest",
-    "clean": "rimraf .turbo"
+    "clean": "rimraf .turbo",
+    "eval:telegram-scenario": "dotenvx run -f ../../.env.local -- tsx evals/run-telegram-scenario.ts"
   },
   "dependencies": {
     "@roomote/db": "workspace:^",

--- a/packages/communication/scripts/mock-telegram.example.json
+++ b/packages/communication/scripts/mock-telegram.example.json
@@ -1,0 +1,50 @@
+{
+  "port": 3013,
+  "roomoteTarget": {
+    "webhookUrl": "http://localhost:4000/api/webhooks/telegram"
+  },
+  "state": {
+    "bot": {
+      "id": 7000000001,
+      "username": "roomote_mock_bot",
+      "first_name": "Roomote"
+    },
+    "chats": [
+      {
+        "id": 111000111,
+        "type": "private",
+        "first_name": "Dan"
+      },
+      {
+        "id": -100222000222,
+        "type": "supergroup",
+        "title": "roomote-dev"
+      }
+    ],
+    "users": [
+      {
+        "id": 111000111,
+        "first_name": "Dan",
+        "username": "dan_mock"
+      }
+    ]
+  },
+  "replay": [
+    {
+      "kind": "message",
+      "message": {
+        "chat": {
+          "id": 111000111,
+          "type": "private",
+          "first_name": "Dan"
+        },
+        "from": {
+          "id": 111000111,
+          "first_name": "Dan",
+          "username": "dan_mock"
+        },
+        "text": "!fast what file handles Telegram webhooks?"
+      }
+    }
+  ]
+}

--- a/packages/communication/scripts/run-mock-telegram.ts
+++ b/packages/communication/scripts/run-mock-telegram.ts
@@ -1,0 +1,247 @@
+#!/usr/bin/env npx tsx
+
+import { readFile } from 'node:fs/promises';
+
+import { Env } from '@roomote/env';
+import { z } from 'zod';
+
+import {
+  MockTelegramServer,
+  type MockTelegramReplayEvent,
+  type MockTelegramRoomoteTarget,
+  type MockTelegramState,
+} from '../src/mock-telegram-server';
+
+const inboundMessageSchema = z
+  .object({
+    chat: z
+      .object({
+        id: z.union([z.number(), z.string()]),
+        type: z.string(),
+      })
+      .passthrough(),
+    from: z.object({ id: z.number() }).passthrough().optional(),
+    text: z.string().optional(),
+    message_id: z.number().int().optional(),
+    message_thread_id: z.number().int().optional(),
+    date: z.number().int().optional(),
+    entities: z.array(z.record(z.unknown())).optional(),
+  })
+  .passthrough();
+
+const configSchema = z.object({
+  port: z.number().int().positive().optional(),
+  roomoteTarget: z
+    .object({
+      webhookUrl: z.string().url(),
+      secretToken: z.string().min(1).optional(),
+    })
+    .optional(),
+  state: z.object({
+    bot: z
+      .object({
+        id: z.number().int(),
+        username: z.string().min(1),
+        first_name: z.string().min(1),
+      })
+      .optional(),
+    acceptedBotTokens: z.array(z.string().min(1)).optional(),
+    chats: z.array(
+      z
+        .object({
+          id: z.number(),
+          type: z.enum(['private', 'group', 'supergroup', 'channel']),
+          title: z.string().optional(),
+          username: z.string().optional(),
+          first_name: z.string().optional(),
+          is_forum: z.boolean().optional(),
+        })
+        .passthrough(),
+    ),
+    users: z.array(
+      z
+        .object({
+          id: z.number(),
+          is_bot: z.boolean().optional(),
+          first_name: z.string().optional(),
+          last_name: z.string().optional(),
+          username: z.string().optional(),
+        })
+        .passthrough(),
+    ),
+    messages: z.array(z.record(z.unknown())).optional(),
+    behavior: z
+      .object({
+        rejectHtmlParseMode: z.boolean().optional(),
+        rejectPhotos: z.boolean().optional(),
+      })
+      .optional(),
+  }),
+  replay: z
+    .array(
+      z.discriminatedUnion('kind', [
+        z.object({
+          kind: z.literal('message'),
+          updateId: z.number().int().optional(),
+          message: inboundMessageSchema,
+        }),
+        z.object({
+          kind: z.literal('edited_message'),
+          updateId: z.number().int().optional(),
+          message: inboundMessageSchema,
+        }),
+        z.object({
+          kind: z.literal('callback_query'),
+          updateId: z.number().int().optional(),
+          callbackQuery: z
+            .object({
+              id: z.string().min(1),
+              from: z.object({ id: z.number() }).passthrough(),
+              data: z.string().optional(),
+              message: z.record(z.unknown()).optional(),
+            })
+            .passthrough(),
+        }),
+        z.object({
+          kind: z.literal('update'),
+          update: z.record(z.unknown()),
+        }),
+      ]),
+    )
+    .optional(),
+});
+
+type HarnessConfig = z.infer<typeof configSchema>;
+
+type ParsedOptions = {
+  statePath: string;
+  port?: number;
+  exitAfterReplay: boolean;
+};
+
+function resolveRoomoteTarget(
+  roomoteTarget: HarnessConfig['roomoteTarget'],
+): MockTelegramRoomoteTarget | undefined {
+  if (!roomoteTarget) {
+    return undefined;
+  }
+
+  const secretSource = roomoteTarget.secretToken
+    ? 'config'
+    : 'Env.TELEGRAM_WEBHOOK_SECRET';
+  const secretToken =
+    roomoteTarget.secretToken ?? Env.TELEGRAM_WEBHOOK_SECRET ?? '';
+
+  console.info(`Using Telegram webhook secret from ${secretSource}.`);
+
+  return {
+    webhookUrl: roomoteTarget.webhookUrl,
+    secretToken,
+  };
+}
+
+function parseArgs(argv: string[]): ParsedOptions {
+  const args = [...argv];
+  let statePath = '';
+  let port: number | undefined;
+  let exitAfterReplay = false;
+
+  while (args.length > 0) {
+    const current = args.shift();
+
+    switch (current) {
+      case '--state': {
+        statePath = args.shift() ?? '';
+        break;
+      }
+      case '--port': {
+        const rawPort = args.shift();
+        port = rawPort ? Number.parseInt(rawPort, 10) : undefined;
+        break;
+      }
+      case '--exit-after-replay': {
+        exitAfterReplay = true;
+        break;
+      }
+      case '--help': {
+        printHelp();
+        process.exit(0);
+        return {
+          statePath,
+          port,
+          exitAfterReplay,
+        };
+      }
+      default: {
+        throw new Error(`Unknown argument: ${current}`);
+      }
+    }
+  }
+
+  if (!statePath) {
+    throw new Error('Missing required --state <path> argument.');
+  }
+
+  if (typeof port === 'number' && (!Number.isInteger(port) || port <= 0)) {
+    throw new Error(`Invalid --port value: ${port}`);
+  }
+
+  return { statePath, port, exitAfterReplay };
+}
+
+function printHelp(): void {
+  console.info(`Usage:
+  pnpm --filter @roomote/communication mock:telegram --state scripts/mock-telegram.example.json
+  pnpm --filter @roomote/communication mock:telegram --state scripts/mock-telegram.example.json --port 3013 --exit-after-replay
+`);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const rawConfig = await readFile(options.statePath, 'utf8');
+  const config = configSchema.parse(JSON.parse(rawConfig)) as HarnessConfig;
+  const roomoteTarget = resolveRoomoteTarget(config.roomoteTarget);
+
+  const server = new MockTelegramServer({
+    state: config.state as MockTelegramState,
+    ...(roomoteTarget ? { roomoteTarget } : {}),
+  });
+
+  const baseUrl = await server.start(options.port ?? config.port ?? 0);
+
+  console.info(`Mock Telegram Bot API listening at ${baseUrl}`);
+  console.info(
+    `Set TELEGRAM_API_BASE_URL=${baseUrl} in the Roomote services you want to point at the harness.`,
+  );
+
+  if (config.replay?.length) {
+    for (const [index, event] of config.replay.entries()) {
+      const result = await server.dispatch(event as MockTelegramReplayEvent);
+      console.info(
+        `Replayed ${event.kind} ${index + 1}/${config.replay.length}: ${result.status} ${result.body}`,
+      );
+    }
+  }
+
+  if (options.exitAfterReplay) {
+    await server.stop();
+    return;
+  }
+
+  process.on('SIGINT', async () => {
+    await server.stop();
+    process.exit(0);
+  });
+
+  process.on('SIGTERM', async () => {
+    await server.stop();
+    process.exit(0);
+  });
+
+  await new Promise(() => undefined);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/packages/communication/src/__tests__/mock-telegram-server.test.ts
+++ b/packages/communication/src/__tests__/mock-telegram-server.test.ts
@@ -1,0 +1,491 @@
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from 'node:http';
+import { AddressInfo } from 'node:net';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  MockTelegramServer,
+  TELEGRAM_MESSAGE_TEXT_LIMIT,
+  computeTelegramEntities,
+  type MockTelegramState,
+} from '../mock-telegram-server';
+import { TelegramCommunicationProvider } from '../telegram-provider';
+
+const BOT_TOKEN = '7000000001:mock-telegram-token';
+
+function baseState(): MockTelegramState {
+  return {
+    bot: {
+      id: 7_000_000_001,
+      username: 'roomote_mock_bot',
+      first_name: 'Roomote',
+    },
+    chats: [
+      { id: 111000111, type: 'private', first_name: 'Dan' },
+      { id: -100222000222, type: 'supergroup', title: 'roomote-dev' },
+    ],
+    users: [{ id: 111000111, first_name: 'Dan', username: 'dan_mock' }],
+    messages: [
+      {
+        message_id: 1000,
+        chat_id: '111000111',
+        date: 1_750_000_000,
+        from: { id: 111000111, first_name: 'Dan', username: 'dan_mock' },
+        text: 'please look into the flaky login test',
+        reactions: [],
+      },
+    ],
+  };
+}
+
+async function startServer(
+  state: MockTelegramState = baseState(),
+  roomoteTarget?: { webhookUrl: string; secretToken: string },
+) {
+  const server = new MockTelegramServer({
+    state,
+    ...(roomoteTarget ? { roomoteTarget } : {}),
+  });
+  const baseUrl = await server.start();
+  return { server, baseUrl };
+}
+
+function providerFor(baseUrl: string, botToken = BOT_TOKEN) {
+  return new TelegramCommunicationProvider({
+    botToken,
+    apiBaseUrl: baseUrl,
+  });
+}
+
+describe('MockTelegramServer', () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    while (cleanups.length > 0) {
+      await cleanups.pop()?.();
+    }
+  });
+
+  function onCleanup(fn: () => Promise<void>) {
+    cleanups.push(fn);
+  }
+
+  it('stores a bot message posted through the real provider and anchors the reply', async () => {
+    const { server, baseUrl } = await startServer();
+    onCleanup(() => server.stop());
+
+    const provider = providerFor(baseUrl);
+    const result = await provider.postMessage({
+      channelId: '111000111',
+      text: 'On it — taking a look now.',
+      replyToMessageId: '1000',
+    });
+
+    expect(result.channelId).toBe('111000111');
+
+    const messages = server.getState().messages ?? [];
+    const botMessage = messages.find((m) => m.from.is_bot);
+    expect(botMessage).toBeDefined();
+    expect(botMessage?.text).toBe('On it — taking a look now.');
+    expect(botMessage?.reply_to_message_id).toBe(1000);
+    expect(result.messageId).toBe(String(botMessage?.message_id));
+  });
+
+  it('splits long markdown into multiple messages under the 4096 limit with reply on first and buttons on last', async () => {
+    const { server, baseUrl } = await startServer();
+    onCleanup(() => server.stop());
+
+    const provider = providerFor(baseUrl);
+    const line = 'x'.repeat(100);
+    const longText = Array.from({ length: 120 }, () => line).join('\n');
+
+    await provider.postMessage({
+      channelId: '111000111',
+      text: longText,
+      textFormat: 'markdown',
+      replyToMessageId: '1000',
+      buttons: [[{ text: 'Cancel task', callbackData: 'cancel_task:job-1' }]],
+    });
+
+    const botMessages = (server.getState().messages ?? []).filter(
+      (m) => m.from.is_bot,
+    );
+    expect(botMessages.length).toBeGreaterThan(1);
+
+    for (const message of botMessages) {
+      expect((message.text ?? '').length).toBeLessThanOrEqual(
+        TELEGRAM_MESSAGE_TEXT_LIMIT,
+      );
+    }
+
+    expect(botMessages[0]?.reply_to_message_id).toBe(1000);
+    expect(
+      botMessages.slice(1).every((m) => m.reply_to_message_id === undefined),
+    ).toBe(true);
+
+    const withButtons = botMessages.filter((m) => m.reply_markup !== undefined);
+    expect(withButtons).toHaveLength(1);
+    expect(withButtons[0]?.message_id).toBe(
+      botMessages[botMessages.length - 1]?.message_id,
+    );
+  });
+
+  it('rejects sendMessage text over the Telegram limit', async () => {
+    const { server, baseUrl } = await startServer();
+    onCleanup(() => server.stop());
+
+    const response = await fetch(`${baseUrl}/bot${BOT_TOKEN}/sendMessage`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        chat_id: 111000111,
+        text: 'y'.repeat(TELEGRAM_MESSAGE_TEXT_LIMIT + 1),
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    const parsed = (await response.json()) as {
+      ok: boolean;
+      description: string;
+    };
+    expect(parsed.ok).toBe(false);
+    expect(parsed.description).toContain('message is too long');
+  });
+
+  it('falls back to plain text when HTML parse mode is rejected', async () => {
+    const state = baseState();
+    state.behavior = { rejectHtmlParseMode: true };
+    const { server, baseUrl } = await startServer(state);
+    onCleanup(() => server.stop());
+
+    const provider = providerFor(baseUrl);
+    await provider.postMessage({
+      channelId: '111000111',
+      text: 'Some **bold** update',
+      textFormat: 'markdown',
+    });
+
+    const botMessage = (server.getState().messages ?? []).find(
+      (m) => m.from.is_bot,
+    );
+    expect(botMessage?.text).toBe('Some **bold** update');
+    expect(botMessage?.parse_mode).toBeUndefined();
+  });
+
+  it('falls back to a caption + link text message when the photo is rejected', async () => {
+    const state = baseState();
+    state.behavior = { rejectPhotos: true };
+    const { server, baseUrl } = await startServer(state);
+    onCleanup(() => server.stop());
+
+    const provider = providerFor(baseUrl);
+    await provider.postMessage({
+      channelId: '111000111',
+      images: [
+        {
+          url: 'https://artifacts.example.test/shot.png',
+          altText: 'Screenshot',
+        },
+      ],
+    });
+
+    const botMessage = (server.getState().messages ?? []).find(
+      (m) => m.from.is_bot,
+    );
+    expect(botMessage?.photo_url).toBeUndefined();
+    expect(botMessage?.text).toBe(
+      'Screenshot: https://artifacts.example.test/shot.png',
+    );
+  });
+
+  it('maps reaction names onto the Telegram emoji set via setMessageReaction', async () => {
+    const { server, baseUrl } = await startServer();
+    onCleanup(() => server.stop());
+
+    const provider = providerFor(baseUrl);
+    await provider.addReaction({
+      channelId: '111000111',
+      messageId: '1000',
+      name: 'eyes',
+    });
+
+    const message = (server.getState().messages ?? []).find(
+      (m) => m.message_id === 1000,
+    );
+    expect(message?.reactions).toEqual(['👀']);
+  });
+
+  it('deletes bot messages and errors on a second delete', async () => {
+    const { server, baseUrl } = await startServer();
+    onCleanup(() => server.stop());
+
+    const provider = providerFor(baseUrl);
+    const posted = await provider.postMessage({
+      channelId: '111000111',
+      text: 'Follow along: https://roomote.example.test/tasks/1',
+    });
+
+    await provider.deleteMessage({
+      channelId: '111000111',
+      messageId: posted.messageId,
+    });
+
+    const remaining = (server.getState().messages ?? []).filter(
+      (m) => String(m.message_id) === posted.messageId,
+    );
+    expect(remaining).toHaveLength(0);
+
+    await expect(
+      provider.deleteMessage({
+        channelId: '111000111',
+        messageId: posted.messageId,
+      }),
+    ).rejects.toThrow('message to delete not found');
+  });
+
+  it('replaces text and keyboard in place through editMessageText', async () => {
+    const { server, baseUrl } = await startServer();
+    onCleanup(() => server.stop());
+
+    const provider = providerFor(baseUrl);
+    const posted = await provider.postMessage({
+      channelId: '111000111',
+      text: 'Planning to run this in **web-app** — starting in ~5s.',
+      textFormat: 'markdown',
+      buttons: [[{ text: '✅ Yes', callbackData: 'route_ok:abc123XYZ789' }]],
+    });
+
+    await provider.editMessageText({
+      channelId: '111000111',
+      messageId: posted.messageId,
+      text: 'Okay — where should I run this?',
+      buttons: [
+        [{ text: 'web-app', callbackData: 'route_pick:def456UVW012:0' }],
+        [{ text: '✖️ Nevermind', callbackData: 'route_no:def456UVW012' }],
+      ],
+    });
+
+    const message = (server.getState().messages ?? []).find(
+      (m) => String(m.message_id) === posted.messageId,
+    );
+    expect(message?.text).toBe('Okay — where should I run this?');
+    expect(message?.reply_markup).toEqual({
+      inline_keyboard: [
+        [{ text: 'web-app', callback_data: 'route_pick:def456UVW012:0' }],
+        [{ text: '✖️ Nevermind', callback_data: 'route_no:def456UVW012' }],
+      ],
+    });
+
+    await expect(
+      provider.editMessageText({
+        channelId: '111000111',
+        messageId: '424242',
+        text: 'nothing here',
+      }),
+    ).rejects.toThrow('message to edit not found');
+  });
+
+  it('replaces the inline keyboard through editMessageReplyMarkup', async () => {
+    const { server, baseUrl } = await startServer();
+    onCleanup(() => server.stop());
+
+    const provider = providerFor(baseUrl);
+    const posted = await provider.postMessage({
+      channelId: '111000111',
+      text: 'Task started.',
+      buttons: [[{ text: 'Cancel task', callbackData: 'cancel_task:job-1' }]],
+    });
+
+    await provider.editMessageReplyMarkup({
+      channelId: '111000111',
+      messageId: posted.messageId,
+    });
+
+    const message = (server.getState().messages ?? []).find(
+      (m) => String(m.message_id) === posted.messageId,
+    );
+    expect(message?.reply_markup).toEqual({ inline_keyboard: [] });
+  });
+
+  it('rejects requests carrying a bot token outside acceptedBotTokens', async () => {
+    const state = baseState();
+    state.acceptedBotTokens = [BOT_TOKEN];
+    const { server, baseUrl } = await startServer(state);
+    onCleanup(() => server.stop());
+
+    const provider = providerFor(baseUrl, 'wrong-token');
+    await expect(
+      provider.postMessage({
+        channelId: '111000111',
+        text: 'should never land',
+      }),
+    ).rejects.toThrow('Unauthorized');
+
+    expect(
+      (server.getState().messages ?? []).filter((m) => m.from.is_bot),
+    ).toHaveLength(0);
+  });
+
+  it('rejects sends to unknown chats like real Telegram', async () => {
+    const { server, baseUrl } = await startServer();
+    onCleanup(() => server.stop());
+
+    const provider = providerFor(baseUrl);
+    await expect(
+      provider.postMessage({
+        channelId: '999999999',
+        text: 'nobody lives here',
+      }),
+    ).rejects.toThrow('chat not found');
+  });
+
+  it('round-trips webhook registration through the real provider', async () => {
+    const { server, baseUrl } = await startServer();
+    onCleanup(() => server.stop());
+
+    const provider = providerFor(baseUrl);
+    await provider.registerWebhook({
+      url: 'https://roomote.example.test/api/webhooks/telegram',
+      secretToken: 'webhook-secret',
+    });
+
+    const info = await provider.getWebhookInfo();
+    expect(info.url).toBe('https://roomote.example.test/api/webhooks/telegram');
+    expect(info.allowedUpdates).toEqual(['message', 'callback_query']);
+    expect(server.getState().webhook?.secretToken).toBe('webhook-secret');
+  });
+
+  it('dispatches updates to the Roomote webhook with the secret token header', async () => {
+    const received: Array<{
+      headers: IncomingMessage['headers'];
+      body: string;
+    }> = [];
+    const webhook = await startStubWebhook(received);
+    onCleanup(() => webhook.stop());
+
+    const { server } = await startServer(baseState(), {
+      webhookUrl: webhook.url,
+      secretToken: 'telegram-webhook-secret',
+    });
+    onCleanup(() => server.stop());
+
+    const first = await server.dispatch({
+      kind: 'message',
+      message: {
+        chat: { id: 111000111, type: 'private', first_name: 'Dan' },
+        from: { id: 111000111, first_name: 'Dan', username: 'dan_mock' },
+        text: '/new fix the flaky login test',
+      },
+    });
+
+    expect(first.status).toBe(200);
+    expect(received).toHaveLength(1);
+    expect(received[0]?.headers['x-telegram-bot-api-secret-token']).toBe(
+      'telegram-webhook-secret',
+    );
+
+    const update = JSON.parse(received[0]!.body) as {
+      update_id: number;
+      message: {
+        message_id: number;
+        text: string;
+        entities?: Array<{ type: string; offset: number; length: number }>;
+      };
+    };
+    expect(update.update_id).toBeGreaterThan(0);
+    expect(update.message.text).toBe('/new fix the flaky login test');
+    // Entities are computed the way real Telegram stamps them, so the
+    // handler's bot_command detection works against injected updates.
+    expect(update.message.entities).toEqual([
+      { type: 'bot_command', offset: 0, length: 4 },
+    ]);
+
+    const second = await server.dispatch({
+      kind: 'message',
+      message: {
+        chat: { id: 111000111, type: 'private', first_name: 'Dan' },
+        from: { id: 111000111, first_name: 'Dan' },
+        text: 'thanks!',
+      },
+    });
+    expect(second.status).toBe(200);
+
+    const secondUpdate = JSON.parse(received[1]!.body) as {
+      update_id: number;
+    };
+    expect(secondUpdate.update_id).toBeGreaterThan(update.update_id);
+
+    // Inbound messages are recorded so /mock/state shows the full transcript.
+    const userMessages = (server.getState().messages ?? []).filter(
+      (m) => !m.from.is_bot && m.text === 'thanks!',
+    );
+    expect(userMessages).toHaveLength(1);
+  });
+});
+
+describe('computeTelegramEntities', () => {
+  it('marks a leading bot command', () => {
+    expect(computeTelegramEntities('/new fix the bug')).toEqual([
+      { type: 'bot_command', offset: 0, length: 4 },
+    ]);
+  });
+
+  it('marks a suffixed group command and a mention', () => {
+    expect(
+      computeTelegramEntities('@roomote_mock_bot /new@roomote_mock_bot go'),
+    ).toEqual([
+      { type: 'mention', offset: 0, length: 17 },
+      { type: 'bot_command', offset: 18, length: 21 },
+    ]);
+  });
+
+  it('marks mid-sentence commands the way Telegram does', () => {
+    expect(computeTelegramEntities('try running /done later')).toEqual([
+      { type: 'bot_command', offset: 12, length: 5 },
+    ]);
+  });
+
+  it('ignores snake_case and email-like tokens', () => {
+    expect(computeTelegramEntities('rename snake_case in a/b paths')).toEqual(
+      [],
+    );
+  });
+});
+
+async function startStubWebhook(
+  received: Array<{ headers: IncomingMessage['headers']; body: string }>,
+): Promise<{ url: string; stop: () => Promise<void> }> {
+  const server: Server = createServer(
+    async (request: IncomingMessage, response: ServerResponse) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      received.push({
+        headers: request.headers,
+        body: Buffer.concat(chunks).toString('utf8'),
+      });
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ ok: true }));
+    },
+  );
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+
+  const address = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${address.port}/api/webhooks/telegram`,
+    stop: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}

--- a/packages/communication/src/mock-telegram-server.ts
+++ b/packages/communication/src/mock-telegram-server.ts
@@ -1,0 +1,872 @@
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from 'node:http';
+import { AddressInfo } from 'node:net';
+
+type JsonRecord = Record<string, unknown>;
+
+export type MockTelegramUser = {
+  id: number;
+  is_bot?: boolean;
+  first_name?: string;
+  last_name?: string;
+  username?: string;
+};
+
+export type MockTelegramChat = {
+  id: number;
+  type: 'private' | 'group' | 'supergroup' | 'channel';
+  title?: string;
+  username?: string;
+  first_name?: string;
+  /** Forum-mode supergroups carry topics via `message_thread_id`. */
+  is_forum?: boolean;
+};
+
+export type MockTelegramStoredMessage = {
+  message_id: number;
+  /** Normalized to string so numeric and string chat ids compare equal. */
+  chat_id: string;
+  date: number;
+  from: MockTelegramUser;
+  text?: string;
+  parse_mode?: string;
+  caption?: string;
+  photo_url?: string;
+  message_thread_id?: number;
+  reply_to_message_id?: number;
+  reply_markup?: unknown;
+  link_preview_disabled?: boolean;
+  reactions: string[];
+};
+
+export type MockTelegramBot = {
+  id: number;
+  username: string;
+  first_name: string;
+};
+
+export type MockTelegramWebhookRegistration = {
+  url: string;
+  secretToken?: string;
+  allowedUpdates?: string[];
+};
+
+export type MockTelegramCallbackAnswer = {
+  callback_query_id: string;
+  text?: string;
+};
+
+/**
+ * Failure-injection knobs. Real Telegram rejects whole requests for these
+ * cases; the flags let tests exercise the provider's fallback paths.
+ */
+export type MockTelegramBehavior = {
+  /** Reject `parse_mode: 'HTML'` sends with "can't parse entities". */
+  rejectHtmlParseMode?: boolean;
+  /** Reject `sendPhoto` as if Telegram could not fetch the photo URL. */
+  rejectPhotos?: boolean;
+};
+
+export type MockTelegramState = {
+  bot?: MockTelegramBot;
+  /**
+   * Bot tokens accepted on `/bot<token>/…` paths. Empty or omitted accepts
+   * any token — convenient for exploratory runs; set it to catch requests
+   * built with the wrong credential.
+   */
+  acceptedBotTokens?: string[];
+  chats: MockTelegramChat[];
+  users: MockTelegramUser[];
+  messages?: MockTelegramStoredMessage[];
+  webhook?: MockTelegramWebhookRegistration;
+  callbackAnswers?: MockTelegramCallbackAnswer[];
+  behavior?: MockTelegramBehavior;
+};
+
+export type MockTelegramRoomoteTarget = {
+  webhookUrl: string;
+  secretToken: string;
+};
+
+/**
+ * An inbound message as a scenario author writes it. `message_id` and `date`
+ * are minted when omitted; `entities` are computed from the text (bot
+ * commands and @mentions) when omitted, matching what real Telegram stamps
+ * server-side — pass `entities` explicitly to override.
+ */
+export type MockTelegramInboundMessage = JsonRecord & {
+  chat: JsonRecord & { id: number | string; type: string };
+  from?: JsonRecord & { id: number };
+  text?: string;
+  message_id?: number;
+  message_thread_id?: number;
+  date?: number;
+  entities?: Array<JsonRecord>;
+};
+
+export type MockTelegramReplayEvent =
+  | {
+      kind: 'message';
+      updateId?: number;
+      message: MockTelegramInboundMessage;
+    }
+  | {
+      kind: 'edited_message';
+      updateId?: number;
+      message: MockTelegramInboundMessage;
+    }
+  | {
+      kind: 'callback_query';
+      updateId?: number;
+      callbackQuery: JsonRecord & {
+        id: string;
+        from: JsonRecord;
+        data?: string;
+      };
+    }
+  | {
+      /** Escape hatch: dispatch a raw Update object verbatim. */
+      kind: 'update';
+      update: JsonRecord;
+    };
+
+type MockTelegramDispatchResult = {
+  status: number;
+  body: string;
+};
+
+export const TELEGRAM_MESSAGE_TEXT_LIMIT = 4096;
+const TELEGRAM_CAPTION_LIMIT = 1024;
+
+const DEFAULT_BOT: MockTelegramBot = {
+  id: 7_000_000_001,
+  username: 'roomote_mock_bot',
+  first_name: 'Roomote',
+};
+
+function cloneState<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function normalizeState(state: MockTelegramState): MockTelegramState {
+  return {
+    ...cloneState(state),
+    bot: { ...DEFAULT_BOT, ...state.bot },
+    chats: state.chats.map((chat) => ({ ...chat })),
+    users: state.users.map((user) => ({ ...user })),
+    messages: (state.messages ?? []).map((message) => ({
+      ...message,
+      chat_id: String(message.chat_id),
+      reactions: message.reactions ?? [],
+    })),
+    callbackAnswers: [...(state.callbackAnswers ?? [])],
+  };
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function json(response: ServerResponse, status: number, body: unknown) {
+  response.writeHead(status, {
+    'content-type': 'application/json',
+  });
+  response.end(JSON.stringify(body));
+}
+
+function text(response: ServerResponse, status: number, body: string) {
+  response.writeHead(status, {
+    'content-type': 'text/plain; charset=utf-8',
+  });
+  response.end(body);
+}
+
+function apiError(
+  response: ServerResponse,
+  errorCode: number,
+  description: string,
+) {
+  json(response, errorCode, {
+    ok: false,
+    error_code: errorCode,
+    description,
+  });
+}
+
+function apiResult(response: ServerResponse, result: unknown) {
+  json(response, 200, { ok: true, result });
+}
+
+/**
+ * Real Telegram computes `entities` server-side; scenario authors should not
+ * have to hand-count UTF-16 offsets. Detect bot commands and @mentions the
+ * way Telegram does so `isTelegramBotMentioned` / `getTelegramNewTaskCommand`
+ * behave against injected updates exactly as they do in production.
+ */
+export function computeTelegramEntities(
+  messageText: string,
+): Array<{ type: string; offset: number; length: number }> {
+  const entities: Array<{ type: string; offset: number; length: number }> = [];
+  const pattern = /(^|\s)(\/[A-Za-z0-9_]+(?:@[A-Za-z0-9_]+)?|@[A-Za-z0-9_]+)/g;
+
+  for (const match of messageText.matchAll(pattern)) {
+    const token = match[2]!;
+    const offset = match.index! + match[1]!.length;
+    entities.push({
+      type: token.startsWith('/') ? 'bot_command' : 'mention',
+      offset,
+      length: token.length,
+    });
+  }
+
+  return entities;
+}
+
+export class MockTelegramServer {
+  private server: Server | null = null;
+  private state: MockTelegramState;
+  private readonly roomoteTarget?: MockTelegramRoomoteTarget;
+  private port: number | null = null;
+  private messageSequence: number;
+  // Seed from the clock so update ids never repeat across harness runs —
+  // Roomote dedups updates by update_id in Redis with a 5-minute TTL.
+  private updateSequence = Math.floor(Date.now() / 1000);
+
+  constructor({
+    state,
+    roomoteTarget,
+  }: {
+    state: MockTelegramState;
+    roomoteTarget?: MockTelegramRoomoteTarget;
+  }) {
+    this.state = normalizeState(state);
+    this.roomoteTarget = roomoteTarget;
+    this.messageSequence =
+      Math.max(0, ...(this.state.messages ?? []).map((m) => m.message_id)) + 1;
+  }
+
+  public get baseUrl(): string {
+    if (this.port === null) {
+      throw new Error('Mock Telegram server is not running.');
+    }
+
+    return `http://127.0.0.1:${this.port}`;
+  }
+
+  public getState(): MockTelegramState {
+    return cloneState(this.state);
+  }
+
+  public setState(state: MockTelegramState): void {
+    this.state = normalizeState(state);
+    this.messageSequence = Math.max(
+      this.messageSequence,
+      Math.max(0, ...(this.state.messages ?? []).map((m) => m.message_id)) + 1,
+    );
+  }
+
+  public async start(port = 0): Promise<string> {
+    if (this.server) {
+      return this.baseUrl;
+    }
+
+    this.server = createServer(async (request, response) => {
+      try {
+        await this.handleRequest(request, response);
+      } catch (error) {
+        text(
+          response,
+          500,
+          error instanceof Error
+            ? error.message
+            : 'Unknown mock Telegram error',
+        );
+      }
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      this.server?.once('error', reject);
+      this.server?.listen(port, '127.0.0.1', () => {
+        this.server?.off('error', reject);
+        resolve();
+      });
+    });
+
+    const address = this.server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Failed to resolve mock Telegram server address.');
+    }
+
+    this.port = (address as AddressInfo).port;
+    return this.baseUrl;
+  }
+
+  public async stop(): Promise<void> {
+    if (!this.server) {
+      return;
+    }
+
+    const server = this.server;
+    this.server = null;
+    this.port = null;
+
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve();
+      });
+    });
+  }
+
+  public nextUpdateId(): number {
+    this.updateSequence += 1;
+    return this.updateSequence;
+  }
+
+  private nextMessageId(): number {
+    const id = this.messageSequence;
+    this.messageSequence += 1;
+    return id;
+  }
+
+  public async dispatch(
+    event: MockTelegramReplayEvent,
+  ): Promise<MockTelegramDispatchResult> {
+    if (!this.roomoteTarget) {
+      throw new Error(
+        'No Roomote webhook target configured for mock Telegram replay.',
+      );
+    }
+
+    const update = this.buildUpdate(event);
+
+    const headers: Record<string, string> = {
+      'content-type': 'application/json',
+    };
+
+    if (this.roomoteTarget.secretToken) {
+      headers['x-telegram-bot-api-secret-token'] =
+        this.roomoteTarget.secretToken;
+    }
+
+    const response = await fetch(this.roomoteTarget.webhookUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(update),
+    });
+
+    return {
+      status: response.status,
+      body: await response.text(),
+    };
+  }
+
+  private buildUpdate(event: MockTelegramReplayEvent): JsonRecord {
+    if (event.kind === 'update') {
+      return {
+        update_id: this.nextUpdateId(),
+        ...event.update,
+      };
+    }
+
+    if (event.kind === 'callback_query') {
+      return {
+        update_id: event.updateId ?? this.nextUpdateId(),
+        callback_query: event.callbackQuery,
+      };
+    }
+
+    const message = this.normalizeInboundMessage(event.message);
+
+    return {
+      update_id: event.updateId ?? this.nextUpdateId(),
+      [event.kind === 'edited_message' ? 'edited_message' : 'message']: message,
+    };
+  }
+
+  private normalizeInboundMessage(
+    message: MockTelegramInboundMessage,
+  ): JsonRecord {
+    const normalized: JsonRecord = {
+      message_id: message.message_id ?? this.nextMessageId(),
+      date: message.date ?? Math.floor(Date.now() / 1000),
+      ...message,
+    };
+
+    if (normalized.entities === undefined && typeof message.text === 'string') {
+      const entities = computeTelegramEntities(message.text);
+      if (entities.length > 0) {
+        normalized.entities = entities;
+      }
+    }
+
+    this.recordIncomingMessage(normalized);
+    return normalized;
+  }
+
+  private recordIncomingMessage(message: JsonRecord): void {
+    const chat = message.chat as MockTelegramChat | undefined;
+    const from = message.from as MockTelegramUser | undefined;
+
+    if (!chat?.id) {
+      return;
+    }
+
+    if (
+      !this.state.chats.some((entry) => String(entry.id) === String(chat.id))
+    ) {
+      this.state.chats = [...this.state.chats, { ...chat }];
+    }
+
+    if (from?.id && !this.state.users.some((entry) => entry.id === from.id)) {
+      this.state.users = [...this.state.users, { ...from }];
+    }
+
+    const stored: MockTelegramStoredMessage = {
+      message_id: Number(message.message_id),
+      chat_id: String(chat.id),
+      date: Number(message.date),
+      from: from ?? { id: 0 },
+      ...(typeof message.text === 'string' ? { text: message.text } : {}),
+      ...(typeof message.message_thread_id === 'number'
+        ? { message_thread_id: message.message_thread_id }
+        : {}),
+      reactions: [],
+    };
+
+    const existingIndex = (this.state.messages ?? []).findIndex(
+      (entry) =>
+        entry.chat_id === stored.chat_id &&
+        entry.message_id === stored.message_id,
+    );
+
+    if (existingIndex >= 0) {
+      this.state.messages?.splice(existingIndex, 1, stored);
+      return;
+    }
+
+    this.state.messages = [...(this.state.messages ?? []), stored];
+  }
+
+  private async handleRequest(
+    request: IncomingMessage,
+    response: ServerResponse,
+  ): Promise<void> {
+    const url = new URL(request.url ?? '/', this.baseUrl);
+
+    if (url.pathname.startsWith('/mock/')) {
+      await this.handleControlRequest(request, response, url);
+      return;
+    }
+
+    const botRoute = /^\/bot([^/]+)\/([A-Za-z0-9_]+)$/.exec(url.pathname);
+
+    if (!botRoute) {
+      text(response, 404, 'Not Found');
+      return;
+    }
+
+    const [, token, method] = botRoute;
+
+    if (!this.isAuthorized(token!)) {
+      apiError(response, 401, 'Unauthorized');
+      return;
+    }
+
+    await this.handleBotApiRequest(request, response, method!);
+  }
+
+  private isAuthorized(token: string): boolean {
+    const allowedTokens = this.state.acceptedBotTokens;
+
+    if (!allowedTokens?.length) {
+      return true;
+    }
+
+    return allowedTokens.includes(token);
+  }
+
+  private async handleControlRequest(
+    request: IncomingMessage,
+    response: ServerResponse,
+    url: URL,
+  ): Promise<void> {
+    if (request.method === 'GET' && url.pathname === '/mock/state') {
+      json(response, 200, this.getState() as unknown as JsonRecord);
+      return;
+    }
+
+    if (request.method === 'POST' && url.pathname === '/mock/state') {
+      const body = JSON.parse(
+        await readRequestBody(request),
+      ) as MockTelegramState;
+      this.setState(body);
+      json(response, 200, { ok: true });
+      return;
+    }
+
+    if (request.method === 'POST' && url.pathname === '/mock/events') {
+      const body = JSON.parse(
+        await readRequestBody(request),
+      ) as MockTelegramReplayEvent;
+      const dispatchResult = await this.dispatch(body);
+      json(response, 200, {
+        ok: true,
+        dispatchResult,
+      });
+      return;
+    }
+
+    text(response, 404, 'Not Found');
+  }
+
+  private async handleBotApiRequest(
+    request: IncomingMessage,
+    response: ServerResponse,
+    method: string,
+  ): Promise<void> {
+    const bodyText =
+      request.method === 'POST' ? await readRequestBody(request) : '';
+    const body: JsonRecord = bodyText
+      ? (JSON.parse(bodyText) as JsonRecord)
+      : {};
+
+    switch (method) {
+      case 'getMe': {
+        const bot = this.state.bot ?? DEFAULT_BOT;
+        apiResult(response, {
+          id: bot.id,
+          is_bot: true,
+          first_name: bot.first_name,
+          username: bot.username,
+        });
+        return;
+      }
+
+      case 'sendMessage': {
+        const messageText = String(body.text ?? '');
+
+        if (!messageText) {
+          apiError(response, 400, 'Bad Request: message text is empty');
+          return;
+        }
+
+        if (messageText.length > TELEGRAM_MESSAGE_TEXT_LIMIT) {
+          apiError(response, 400, 'Bad Request: message is too long');
+          return;
+        }
+
+        if (
+          body.parse_mode === 'HTML' &&
+          this.state.behavior?.rejectHtmlParseMode
+        ) {
+          apiError(
+            response,
+            400,
+            "Bad Request: can't parse entities: unsupported start tag",
+          );
+          return;
+        }
+
+        const stored = this.storeOutgoingMessage(response, body, {
+          text: messageText,
+          ...(typeof body.parse_mode === 'string'
+            ? { parse_mode: body.parse_mode }
+            : {}),
+          ...((body.link_preview_options as JsonRecord | undefined)
+            ?.is_disabled === true
+            ? { link_preview_disabled: true }
+            : {}),
+        });
+
+        if (stored) {
+          apiResult(response, this.toTelegramMessage(stored));
+        }
+        return;
+      }
+
+      case 'sendPhoto': {
+        if (this.state.behavior?.rejectPhotos) {
+          apiError(
+            response,
+            400,
+            'Bad Request: wrong file identifier/HTTP URL specified',
+          );
+          return;
+        }
+
+        const caption =
+          typeof body.caption === 'string' ? body.caption : undefined;
+
+        if (caption && caption.length > TELEGRAM_CAPTION_LIMIT) {
+          apiError(response, 400, 'Bad Request: message caption is too long');
+          return;
+        }
+
+        const stored = this.storeOutgoingMessage(response, body, {
+          photo_url: String(body.photo ?? ''),
+          ...(caption ? { caption } : {}),
+        });
+
+        if (stored) {
+          apiResult(response, this.toTelegramMessage(stored));
+        }
+        return;
+      }
+
+      case 'editMessageText': {
+        const message = this.findMessage(body);
+
+        if (!message) {
+          apiError(response, 400, 'Bad Request: message to edit not found');
+          return;
+        }
+
+        const messageText = String(body.text ?? '');
+
+        if (!messageText) {
+          apiError(response, 400, 'Bad Request: message text is empty');
+          return;
+        }
+
+        if (messageText.length > TELEGRAM_MESSAGE_TEXT_LIMIT) {
+          apiError(response, 400, 'Bad Request: message is too long');
+          return;
+        }
+
+        if (
+          body.parse_mode === 'HTML' &&
+          this.state.behavior?.rejectHtmlParseMode
+        ) {
+          apiError(
+            response,
+            400,
+            "Bad Request: can't parse entities: unsupported start tag",
+          );
+          return;
+        }
+
+        message.text = messageText;
+        if (typeof body.parse_mode === 'string') {
+          message.parse_mode = body.parse_mode;
+        } else {
+          delete message.parse_mode;
+        }
+        message.reply_markup = body.reply_markup;
+        apiResult(response, this.toTelegramMessage(message));
+        return;
+      }
+
+      case 'editMessageReplyMarkup': {
+        const message = this.findMessage(body);
+
+        if (!message) {
+          apiError(response, 400, 'Bad Request: message to edit not found');
+          return;
+        }
+
+        message.reply_markup = body.reply_markup;
+        apiResult(response, this.toTelegramMessage(message));
+        return;
+      }
+
+      case 'deleteMessage': {
+        const message = this.findMessage(body);
+
+        if (!message) {
+          apiError(response, 400, 'Bad Request: message to delete not found');
+          return;
+        }
+
+        this.state.messages = (this.state.messages ?? []).filter(
+          (entry) => entry !== message,
+        );
+        apiResult(response, true);
+        return;
+      }
+
+      case 'setMessageReaction': {
+        const message = this.findMessage(body);
+
+        if (!message) {
+          apiError(response, 400, 'Bad Request: message not found');
+          return;
+        }
+
+        const reactions = Array.isArray(body.reaction) ? body.reaction : [];
+        // setMessageReaction replaces the bot's reaction set on the message.
+        message.reactions = reactions
+          .map((entry) => String((entry as JsonRecord).emoji ?? ''))
+          .filter(Boolean);
+        apiResult(response, true);
+        return;
+      }
+
+      case 'answerCallbackQuery': {
+        const callbackQueryId = String(body.callback_query_id ?? '');
+
+        if (!callbackQueryId) {
+          apiError(response, 400, 'Bad Request: query is too old or invalid');
+          return;
+        }
+
+        this.state.callbackAnswers = [
+          ...(this.state.callbackAnswers ?? []),
+          {
+            callback_query_id: callbackQueryId,
+            ...(typeof body.text === 'string' ? { text: body.text } : {}),
+          },
+        ];
+        apiResult(response, true);
+        return;
+      }
+
+      case 'setWebhook': {
+        this.state.webhook = {
+          url: String(body.url ?? ''),
+          ...(typeof body.secret_token === 'string'
+            ? { secretToken: body.secret_token }
+            : {}),
+          ...(Array.isArray(body.allowed_updates)
+            ? { allowedUpdates: body.allowed_updates.map(String) }
+            : {}),
+        };
+        apiResult(response, true);
+        return;
+      }
+
+      case 'deleteWebhook': {
+        delete this.state.webhook;
+        apiResult(response, true);
+        return;
+      }
+
+      case 'getWebhookInfo': {
+        apiResult(response, {
+          url: this.state.webhook?.url ?? '',
+          has_custom_certificate: false,
+          pending_update_count: 0,
+          ...(this.state.webhook?.allowedUpdates
+            ? { allowed_updates: this.state.webhook.allowedUpdates }
+            : {}),
+        });
+        return;
+      }
+
+      default:
+        apiError(
+          response,
+          404,
+          `Not Found: unhandled mock Telegram method "${method}"`,
+        );
+    }
+  }
+
+  private findChat(chatId: unknown): MockTelegramChat | undefined {
+    return this.state.chats.find(
+      (entry) => String(entry.id) === String(chatId),
+    );
+  }
+
+  private findMessage(body: JsonRecord): MockTelegramStoredMessage | undefined {
+    return (this.state.messages ?? []).find(
+      (entry) =>
+        entry.chat_id === String(body.chat_id) &&
+        entry.message_id === Number(body.message_id),
+    );
+  }
+
+  /**
+   * Validates chat + reply target and appends a bot-authored message.
+   * Writes the error response itself and returns undefined on failure.
+   */
+  private storeOutgoingMessage(
+    response: ServerResponse,
+    body: JsonRecord,
+    content: Partial<MockTelegramStoredMessage>,
+  ): MockTelegramStoredMessage | undefined {
+    const chat = this.findChat(body.chat_id);
+
+    if (!chat) {
+      apiError(response, 400, 'Bad Request: chat not found');
+      return undefined;
+    }
+
+    const replyParameters = body.reply_parameters as JsonRecord | undefined;
+    let replyToMessageId: number | undefined;
+
+    if (replyParameters?.message_id !== undefined) {
+      const target = this.findMessage({
+        chat_id: chat.id,
+        message_id: replyParameters.message_id,
+      });
+
+      if (target) {
+        replyToMessageId = target.message_id;
+      } else if (replyParameters.allow_sending_without_reply !== true) {
+        apiError(response, 400, 'Bad Request: message to be replied not found');
+        return undefined;
+      }
+    }
+
+    const bot = this.state.bot ?? DEFAULT_BOT;
+    const stored: MockTelegramStoredMessage = {
+      message_id: this.nextMessageId(),
+      chat_id: String(chat.id),
+      date: Math.floor(Date.now() / 1000),
+      from: {
+        id: bot.id,
+        is_bot: true,
+        first_name: bot.first_name,
+        username: bot.username,
+      },
+      ...(typeof body.message_thread_id === 'number'
+        ? { message_thread_id: body.message_thread_id }
+        : {}),
+      ...(replyToMessageId !== undefined
+        ? { reply_to_message_id: replyToMessageId }
+        : {}),
+      ...(body.reply_markup !== undefined
+        ? { reply_markup: body.reply_markup }
+        : {}),
+      reactions: [],
+      ...content,
+    };
+
+    this.state.messages = [...(this.state.messages ?? []), stored];
+    return stored;
+  }
+
+  private toTelegramMessage(stored: MockTelegramStoredMessage): JsonRecord {
+    const chat = this.findChat(stored.chat_id);
+
+    return {
+      message_id: stored.message_id,
+      date: stored.date,
+      chat: chat ?? { id: Number(stored.chat_id), type: 'private' },
+      from: stored.from,
+      ...(stored.text !== undefined ? { text: stored.text } : {}),
+      ...(stored.caption !== undefined ? { caption: stored.caption } : {}),
+      ...(stored.message_thread_id !== undefined
+        ? { message_thread_id: stored.message_thread_id }
+        : {}),
+      ...(stored.reply_to_message_id !== undefined
+        ? { reply_to_message_id: stored.reply_to_message_id }
+        : {}),
+    };
+  }
+}

--- a/packages/communication/src/telegram-api-base-url.ts
+++ b/packages/communication/src/telegram-api-base-url.ts
@@ -1,0 +1,18 @@
+import { Env } from '@roomote/env';
+
+const DEFAULT_TELEGRAM_API_BASE_URL = 'https://api.telegram.org';
+
+/**
+ * Resolves the Telegram Bot API host, mirroring `getSlackApiBaseUrl` in
+ * `@roomote/slack`: `TELEGRAM_API_BASE_URL` lets tests and the mock Telegram
+ * harness reroute every outbound Bot API call without touching call sites.
+ */
+export function getTelegramApiBaseUrl(): string {
+  const configuredUrl = (
+    process.env.TELEGRAM_API_BASE_URL ??
+    Env.TELEGRAM_API_BASE_URL ??
+    DEFAULT_TELEGRAM_API_BASE_URL
+  ).trim();
+
+  return configuredUrl.replace(/\/+$/, '');
+}

--- a/packages/communication/src/telegram-provider.ts
+++ b/packages/communication/src/telegram-provider.ts
@@ -8,6 +8,7 @@ import type {
   CommunicationThreadLookupResult,
 } from './provider';
 import { UnsupportedCommunicationOperationError } from './provider';
+import { getTelegramApiBaseUrl } from './telegram-api-base-url';
 import {
   TELEGRAM_MAX_MESSAGE_LENGTH,
   chunkTelegramMarkdown,
@@ -76,7 +77,7 @@ export class TelegramCommunicationProvider implements CommunicationProviderAdapt
   private readonly fetchImpl: typeof fetch;
 
   constructor(private readonly options: TelegramCommunicationProviderOptions) {
-    this.apiBaseUrl = options.apiBaseUrl ?? 'https://api.telegram.org';
+    this.apiBaseUrl = options.apiBaseUrl ?? getTelegramApiBaseUrl();
     this.fetchImpl = options.fetch ?? fetch;
   }
 
@@ -293,6 +294,80 @@ export class TelegramCommunicationProvider implements CommunicationProviderAdapt
       callback_query_id: input.callbackQueryId,
       ...(input.text ? { text: input.text } : {}),
     });
+  }
+
+  /**
+   * Replace the text (and keyboard) of an existing bot message. Mirrors the
+   * postMessage markdown handling: try Telegram HTML, fall back to the raw
+   * markdown as plain text when entity parsing fails. The edited text must
+   * fit in one message — this is for cards and status lines, not replies.
+   */
+  async editMessageText(input: {
+    channelId: string;
+    messageId: string;
+    text: string;
+    textFormat?: 'plain' | 'markdown';
+    buttons?: CommunicationMessageButton[][];
+  }): Promise<void> {
+    const useMarkdown = input.textFormat === 'markdown';
+    const firstChunk = useMarkdown
+      ? chunkTelegramMarkdownAsHtml(input.text)[0]
+      : null;
+    const attempts: Array<{ text: string; parseMode?: 'HTML' }> =
+      firstChunk?.html
+        ? [
+            { text: firstChunk.html, parseMode: 'HTML' },
+            { text: firstChunk.markdown },
+          ]
+        : [{ text: firstChunk?.markdown ?? input.text }];
+
+    let lastError: Error | null = null;
+
+    for (const attempt of attempts) {
+      const response = await this.fetchImpl(
+        `${this.apiBaseUrl.replace(/\/$/, '')}/bot${this.options.botToken}/editMessageText`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            chat_id: input.channelId,
+            message_id: Number.parseInt(input.messageId, 10),
+            text: attempt.text,
+            ...(attempt.parseMode ? { parse_mode: attempt.parseMode } : {}),
+            link_preview_options: { is_disabled: true },
+            reply_markup: buildTelegramReplyMarkup(input.buttons) ?? {
+              inline_keyboard: [],
+            },
+          }),
+        },
+      );
+      const parsed = (await response.json().catch(() => null)) as {
+        ok?: boolean;
+        description?: string;
+      } | null;
+
+      if (response.ok && parsed?.ok) {
+        return;
+      }
+
+      const description = parsed?.description;
+      lastError = new Error(
+        `Telegram editMessageText failed${
+          response.status ? ` (${response.status})` : ''
+        }: ${description ?? response.statusText}`,
+      );
+
+      const isEntityParseError =
+        attempt.parseMode === 'HTML' &&
+        response.status === 400 &&
+        Boolean(description?.toLowerCase().includes("can't parse entities"));
+
+      if (!isEntityParseError) {
+        throw lastError;
+      }
+    }
+
+    throw lastError ?? new Error('Telegram editMessageText failed.');
   }
 
   /** Replace or remove the inline keyboard on an existing message. */

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -131,6 +131,7 @@ const serverSchema = {
   TELEGRAM_BOT_TOKEN: z.string().min(1).optional(),
   TELEGRAM_WEBHOOK_SECRET: z.string().min(1).optional(),
   TELEGRAM_BOT_USERNAME: z.string().min(1).optional(),
+  TELEGRAM_API_BASE_URL: z.string().url().default('https://api.telegram.org'),
   ROOMOTE_AUTH_SLACK_CLIENT_ID: z.string().min(1).optional(),
   ROOMOTE_AUTH_SLACK_CLIENT_SECRET: z.string().min(1).optional(),
   ROOMOTE_AUTH_MICROSOFT_CLIENT_ID: z.string().min(1).optional(),


### PR DESCRIPTION
## What

Two related pieces that bring the Telegram integration up to Slack-grade testability and routing UX:

### 1. Mock Telegram Bot API harness (`packages/communication`)
- `MockTelegramServer` — impersonates both halves of the Bot API: outbound methods (`sendMessage`, `sendPhoto`, `editMessageText`, reactions, inline keyboards, webhook registration) and inbound update dispatch (signed with the secret-token header) into the real `/api/webhooks/telegram` handler. Control plane at `/mock/state` + `/mock/events`, mirroring the mock Slack harness.
- Enforces real Telegram limits (4096-char messages, unknown chats, missing reply targets) so regressions fail loudly, and auto-computes `entities` for injected text so bot-command/mention detection behaves exactly as in production.
- `TELEGRAM_API_BASE_URL` env override (default `https://api.telegram.org`) reroutes every runtime provider construction — zero production impact.
- CLI runner (`pnpm --filter @roomote/communication mock:telegram`), LLM-judged eval runner (`eval:telegram-scenario`) + three fixtures, and the `mock-telegram-testing` skill with a 16-scenario user-journey catalog.

### 2. Routing confirmation for Telegram task entry (`apps/api`)
Previously Telegram launched every routed task immediately, and router *fallback* silently launched into all repos — the only mis-route recovery was cancel.

Now (mirroring Slack's gate): when router confidence is < 0.95, the workspace was remapped, or all-repositories was picked while environments exist, task entry posts a compact **✅ Yes / ✖️ Nope** card that auto-starts the suggestion after ~5s. **Nope** edits the same message into a workspace picker (environments + all repos + Nevermind, no timer). Router fallback shows the picker directly.

Mechanics: pending choice in Redis with one-shot `GETDEL` claim (click and timer can never both launch), 64-byte-safe callback data, requester-only clicks, Nope re-keys state so the timer can never fire a rejected suggestion, superseding requests invalidate stale cards, and any confirmation-plumbing failure falls back to immediate launch so tasks are never dropped. Suggestion-button launches skip the card. New `TelegramCommunicationProvider.editMessageText` (with HTML→plain fallback) finalizes cards in place.

## Testing
- 56 API handler tests (11 new for confirmation flows) + 17 harness tests + 59 env tests pass; repo-wide `lint:fast`, `check-types:fast`, `knip` clean.
- Live end-to-end through the mock harness against the dev stack (real LLM router): card posted → Nope swapped it into the picker under a fresh id → the 5s timer no-op'd → Nevermind finalized the card — zero cloud jobs created.

## Docs
`.agent-guidance/features/telegram-integration.md` (config, inbound flow, testing, parity notes) and the `mock-telegram-testing` skill updated in the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)