### PR TITLE
Improve Microsoft Teams setup flow

### DIFF
--- a/apps/docs/environment-variables.mdx
+++ b/apps/docs/environment-variables.mdx
@@ -133,37 +133,37 @@ as per-task auth tokens or workspace paths.
 
 ### Models and inference providers
 
-| Env var                                      | Required     | Used for                                                                                                     |
-| -------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------ |
-| `ROOMOTE_MODEL`                              | Optional     | Env-level default coding model. Overrides the default selected in **Settings > Models** for new task starts. |
-| `ROOMOTE_SMALL_MODEL`                        | Optional     | Helper model for routing, titles, summaries, and lightweight model calls.                                    |
-| `ROOMOTE_VISION_MODEL`                       | Optional     | Vision-capable model for visual inspection and screenshot/image work.                                        |
-| `ROOMOTE_CODE_REVIEW_MODEL`                  | Optional     | Model for initial PR/MR review and review-sync tasks.                                                        |
-| `ROOMOTE_EXPLORE_MODEL`                      | Optional     | Exploration/helper model for investigation-oriented subtasks.                                                |
-| `ROOMOTE_PLANNING_MODEL`                     | Optional     | Planning model used for longer coding-task planning.                                                         |
-| `ROOMOTE_MODEL_REASONING_EFFORT`             | Optional     | Reasoning level for the coding model: `low`, `medium`, `high`, or `xhigh`.                                   |
-| `ROOMOTE_SMALL_MODEL_REASONING_EFFORT`       | Optional     | Reasoning level for the helper model.                                                                        |
-| `ROOMOTE_VISION_MODEL_REASONING_EFFORT`      | Optional     | Reasoning level for the vision model.                                                                        |
-| `ROOMOTE_CODE_REVIEW_MODEL_REASONING_EFFORT` | Optional     | Reasoning level for the code review model.                                                                   |
-| `ROOMOTE_EXPLORE_MODEL_REASONING_EFFORT`     | Optional     | Reasoning level for the exploration model.                                                                   |
-| `ROOMOTE_PLANNING_MODEL_REASONING_EFFORT`    | Optional     | Reasoning level for the planning model.                                                                      |
-| `ROOMOTE_MODEL_ENV_KEYS`                     | Optional     | Comma- or space-separated list of extra provider key env vars to forward to task workers.                    |
-| `OPENROUTER_API_KEY`                         | Provider key | OpenRouter API key. Can also be saved from **Settings > Models**.                                            |
-| `AI_GATEWAY_API_KEY`                         | Provider key | Vercel AI Gateway API key.                                                                                   |
-| `OPENAI_API_KEY`                             | Provider key | OpenAI API key.                                                                                              |
-| `ANTHROPIC_API_KEY`                          | Provider key | Anthropic API key.                                                                                           |
-| `XAI_API_KEY`                                | Provider key | xAI / Grok API key.                                                                                          |
-| `MOONSHOT_API_KEY`                           | Provider key | Moonshot AI / Kimi API key.                                                                                  |
-| `MINIMAX_API_KEY`                            | Provider key | MiniMax API key.                                                                                             |
-| `OPENCODE_API_KEY`                           | Provider key | OpenCode Zen / Go API key.                                                                                   |
-| `GEMINI_API_KEY`                             | Provider key | Google Gemini API key. Can also be saved from **Settings > Models**.                                         |
-| `GOOGLE_GENERATIVE_AI_API_KEY`               | Provider key | Alternate Google/Gemini provider key forwarded when configured or inferred.                                  |
-| `AWS_BEARER_TOKEN_BEDROCK`                   | Provider key | Amazon Bedrock API key (bearer token). Can also be saved from **Settings > Models**.                         |
-| `AWS_REGION`                                 | Provider key | AWS region for Amazon Bedrock models. Defaults to `us-east-1` at the runtime when unset.                     |
+| Env var                                      | Required     | Used for                                                                                                                                |
+| -------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `ROOMOTE_MODEL`                              | Optional     | Env-level default coding model. Overrides the default selected in **Settings > Models** for new task starts.                            |
+| `ROOMOTE_SMALL_MODEL`                        | Optional     | Helper model for routing, titles, summaries, and lightweight model calls.                                                               |
+| `ROOMOTE_VISION_MODEL`                       | Optional     | Vision-capable model for visual inspection and screenshot/image work.                                                                   |
+| `ROOMOTE_CODE_REVIEW_MODEL`                  | Optional     | Model for initial PR/MR review and review-sync tasks.                                                                                   |
+| `ROOMOTE_EXPLORE_MODEL`                      | Optional     | Exploration/helper model for investigation-oriented subtasks.                                                                           |
+| `ROOMOTE_PLANNING_MODEL`                     | Optional     | Planning model used for longer coding-task planning.                                                                                    |
+| `ROOMOTE_MODEL_REASONING_EFFORT`             | Optional     | Reasoning level for the coding model: `low`, `medium`, `high`, or `xhigh`.                                                              |
+| `ROOMOTE_SMALL_MODEL_REASONING_EFFORT`       | Optional     | Reasoning level for the helper model.                                                                                                   |
+| `ROOMOTE_VISION_MODEL_REASONING_EFFORT`      | Optional     | Reasoning level for the vision model.                                                                                                   |
+| `ROOMOTE_CODE_REVIEW_MODEL_REASONING_EFFORT` | Optional     | Reasoning level for the code review model.                                                                                              |
+| `ROOMOTE_EXPLORE_MODEL_REASONING_EFFORT`     | Optional     | Reasoning level for the exploration model.                                                                                              |
+| `ROOMOTE_PLANNING_MODEL_REASONING_EFFORT`    | Optional     | Reasoning level for the planning model.                                                                                                 |
+| `ROOMOTE_MODEL_ENV_KEYS`                     | Optional     | Comma- or space-separated list of extra provider key env vars to forward to task workers.                                               |
+| `OPENROUTER_API_KEY`                         | Provider key | OpenRouter API key. Can also be saved from **Settings > Models**.                                                                       |
+| `AI_GATEWAY_API_KEY`                         | Provider key | Vercel AI Gateway API key.                                                                                                              |
+| `OPENAI_API_KEY`                             | Provider key | OpenAI API key.                                                                                                                         |
+| `ANTHROPIC_API_KEY`                          | Provider key | Anthropic API key.                                                                                                                      |
+| `XAI_API_KEY`                                | Provider key | xAI / Grok API key.                                                                                                                     |
+| `MOONSHOT_API_KEY`                           | Provider key | Moonshot AI / Kimi API key.                                                                                                             |
+| `MINIMAX_API_KEY`                            | Provider key | MiniMax API key.                                                                                                                        |
+| `OPENCODE_API_KEY`                           | Provider key | OpenCode Zen / Go API key.                                                                                                              |
+| `GEMINI_API_KEY`                             | Provider key | Google Gemini API key. Can also be saved from **Settings > Models**.                                                                    |
+| `GOOGLE_GENERATIVE_AI_API_KEY`               | Provider key | Alternate Google/Gemini provider key forwarded when configured or inferred.                                                             |
+| `AWS_BEARER_TOKEN_BEDROCK`                   | Provider key | Amazon Bedrock API key (bearer token). Can also be saved from **Settings > Models**.                                                    |
+| `AWS_REGION`                                 | Provider key | AWS region for Amazon Bedrock models. Defaults to `us-east-1` at the runtime when unset.                                                |
 | `GOOGLE_APPLICATION_CREDENTIALS`             | Provider key | Google Vertex AI service account credentials: a file path, or pasted JSON contents that Roomote materializes to a file for the runtime. |
-| `GOOGLE_VERTEX_PROJECT`                      | Provider key | Google Cloud project ID for Vertex AI models.                                                                |
-| `GOOGLE_VERTEX_LOCATION`                     | Provider key | Vertex AI location. Defaults to `us-central1` at the runtime when unset.                                     |
-| `MISTRAL_API_KEY`                            | Provider key | Mistral provider key forwarded when configured.                                                              |
+| `GOOGLE_VERTEX_PROJECT`                      | Provider key | Google Cloud project ID for Vertex AI models.                                                                                           |
+| `GOOGLE_VERTEX_LOCATION`                     | Provider key | Vertex AI location. Defaults to `us-central1` at the runtime when unset.                                                                |
+| `MISTRAL_API_KEY`                            | Provider key | Mistral provider key forwarded when configured.                                                                                         |
 
 ### Sandbox providers
 
@@ -171,12 +171,12 @@ as per-task auth tokens or workspace paths.
 | ---------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | `DEFAULT_COMPUTE_PROVIDER`   | Optional          | Runtime default sandbox provider when no admin default is saved. Supported values are `docker`, `modal`, `e2b`, and `daytona`. |
 | `EXCLUDED_COMPUTE_PROVIDERS` | Optional          | Comma-separated provider IDs to hide or exclude from default selection.                                                        |
-| `DOCKER_WORKER_IMAGE`        | Optional          | Worker image used by Docker and for hosted sandbox derivation. In production, prefer an immutable registry-qualified tag.              |
+| `DOCKER_WORKER_IMAGE`        | Optional          | Worker image used by Docker and for hosted sandbox derivation. In production, prefer an immutable registry-qualified tag.      |
 | `ROOMOTE_WORKER_IMAGE_REPO`  | Optional          | Registry repository used to derive the worker image from `RELEASE_VERSION` when `DOCKER_WORKER_IMAGE` is unset.                |
-| `DOCKER_WORKER_PLATFORM`     | Optional          | Docker worker platform. Defaults to the host architecture (`linux/arm64` on arm hosts, `linux/amd64` otherwise). |
+| `DOCKER_WORKER_PLATFORM`     | Optional          | Docker worker platform. Defaults to the host architecture (`linux/arm64` on arm hosts, `linux/amd64` otherwise).               |
 | `DOCKER_WORKER_NETWORK`      | Self-host Docker  | Docker network for worker containers in Compose/self-host mode.                                                                |
 | `DOCKER_WORKER_RELEASE_PATH` | Optional          | Path to a packaged worker release archive used by Docker worker bootstrap.                                                     |
-| `MODAL_TOKEN_ID`             | Modal             | Modal token ID. Can also be saved from **Settings > Sandboxes**.                                                                 |
+| `MODAL_TOKEN_ID`             | Modal             | Modal token ID. Can also be saved from **Settings > Sandboxes**.                                                               |
 | `MODAL_TOKEN_SECRET`         | Modal             | Modal token secret.                                                                                                            |
 | `MODAL_BASE_IMAGE_REF`       | Modal             | Modal base image reference. Usually derived from the worker image; set only to pin a custom image.                             |
 | `MODAL_ENDPOINT`             | Optional          | Modal endpoint override.                                                                                                       |
@@ -186,12 +186,12 @@ as per-task auth tokens or workspace paths.
 | `MODAL_REGISTRY_PASSWORD`    | Private registry  | Registry password for private non-ECR image pulls.                                                                             |
 | `MODAL_ECR_OIDC_ROLE_ARN`    | ECR               | AWS IAM role ARN used by Modal for ECR OIDC pulls.                                                                             |
 | `MODAL_ECR_REGION`           | ECR               | AWS region for Modal ECR OIDC pulls.                                                                                           |
-| `MODAL_REGIONS`              | Optional          | Comma-separated Modal sandbox placement regions (for example `us` or `us-west`). Unset keeps Modal default placement.         |
-| `E2B_API_KEY`                | E2B               | E2B API key. Can also be saved from **Settings > Sandboxes**.                                                                    |
+| `MODAL_REGIONS`              | Optional          | Comma-separated Modal sandbox placement regions (for example `us` or `us-west`). Unset keeps Modal default placement.          |
+| `E2B_API_KEY`                | E2B               | E2B API key. Can also be saved from **Settings > Sandboxes**.                                                                  |
 | `E2B_TEMPLATE_ID`            | E2B               | Worker template ID. Usually provisioned from the worker image by Roomote.                                                      |
 | `E2B_DOMAIN`                 | Optional          | E2B domain for self-hosted or custom E2B clusters.                                                                             |
 | `E2B_MAX_SANDBOX_TIMEOUT_MS` | Optional          | Maximum E2B sandbox timeout Roomote will request. Defaults to one hour.                                                        |
-| `DAYTONA_API_KEY`            | Daytona           | Daytona API key. Can also be saved from **Settings > Sandboxes**.                                                                |
+| `DAYTONA_API_KEY`            | Daytona           | Daytona API key. Can also be saved from **Settings > Sandboxes**.                                                              |
 | `DAYTONA_API_URL`            | Optional          | Daytona API URL override.                                                                                                      |
 | `DAYTONA_TARGET`             | Optional          | Daytona target or region.                                                                                                      |
 | `DAYTONA_SNAPSHOT_NAME`      | Daytona           | Worker snapshot name. Usually registered from the worker image by Roomote.                                                     |
@@ -275,9 +275,9 @@ as per-task auth tokens or workspace paths.
 
 ### Declarative environments
 
-| Env var                     | Required | Used for                                                                                                                          |
-| --------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `ROOMOTE_ENVIRONMENTS_DIR`  | Optional | Directory of environment definition files (`*.yaml`, `*.yml`, `*.json`) applied at API startup. One environment per file.        |
+| Env var                     | Required | Used for                                                                                                                       |
+| --------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `ROOMOTE_ENVIRONMENTS_DIR`  | Optional | Directory of environment definition files (`*.yaml`, `*.yml`, `*.json`) applied at API startup. One environment per file.      |
 | `ROOMOTE_ENVIRONMENTS_YAML` | Optional | Inline multi-document YAML with environment definitions applied at API startup, for platforms where mounting files is awkward. |
 
 See [Environments](/environments#provision-environments-declaratively) for the

--- a/apps/docs/providers/communications/microsoft-teams.mdx
+++ b/apps/docs/providers/communications/microsoft-teams.mdx
@@ -121,7 +121,7 @@ include the bot entry in the manifest:
   "bots": [
     {
       "botId": "<TEAMS_BOT_APP_ID>",
-      "scopes": ["personal", "team", "groupchat"],
+      "scopes": ["personal", "team", "groupChat"],
       "supportsFiles": true,
       "isNotificationOnly": false
     }

--- a/apps/docs/providers/communications/microsoft-teams.mdx
+++ b/apps/docs/providers/communications/microsoft-teams.mdx
@@ -88,7 +88,8 @@ Upload the package in Teams under **Apps > Manage your apps > Upload an app**,
 or import it in the
 [Microsoft Teams Developer Portal](https://dev.teams.microsoft.com/apps).
 
-The generated manifest enables all three messaging scopes:
+The generated manifest uses Teams manifest v1.25, declares channel feature
+readiness, and enables all three messaging scopes:
 
 - **Personal** - direct messages to the bot start tasks
 - **Team** - channel messages that mention the bot start tasks
@@ -100,14 +101,32 @@ include the bot entry in the manifest:
 
 ```json
 {
+  "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.25/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.25",
+  "accentColor": "#d6ee26",
+  "authorization": {
+    "permissions": {
+      "resourceSpecific": [
+        { "name": "Channel.Create.Group", "type": "Application" },
+        { "name": "ChannelMember.Read.Group", "type": "Application" },
+        { "name": "ChannelMessage.Read.Group", "type": "Application" },
+        { "name": "ChannelMessage.Send.Group", "type": "Application" },
+        { "name": "ChannelSettings.Read.Group", "type": "Application" },
+        { "name": "ChatMessage.Read.Chat", "type": "Application" },
+        { "name": "ChatMessage.Send.Chat", "type": "Application" },
+        { "name": "Member.Read.Group", "type": "Application" }
+      ]
+    }
+  },
   "bots": [
     {
       "botId": "<TEAMS_BOT_APP_ID>",
       "scopes": ["personal", "team", "groupchat"],
-      "supportsFiles": false,
+      "supportsFiles": true,
       "isNotificationOnly": false
     }
   ],
+  "supportsChannelFeatures": "tier1",
   "validDomains": ["<public-host-without-scheme>"]
 }
 ```

--- a/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
+++ b/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
@@ -10,6 +10,7 @@ import {
   Check,
   CopyIconButton,
   Download,
+  EnvVarsInfoNote,
   ExternalLink,
   Input,
   Button,
@@ -21,7 +22,18 @@ import { StepTitle } from './StepTitle';
 import { ProviderSetupInstructions } from './ProviderSetupInstructions';
 import { getProviderSetupCopy } from './providerSetupCopy';
 
-type ProviderStatus = SetupAuthStatus['providers'][number];
+export type ProviderSetupExperienceProvider =
+  | SetupAuthStatus['providers'][number]
+  | {
+      id: SetupAuthStatus['providers'][number]['id'] | 'telegram';
+      label: string;
+      fields: SetupAuthStatus['providers'][number]['fields'];
+      runtimeSatisfied: boolean;
+      savedSatisfied: boolean;
+      setupSatisfied: boolean;
+    };
+
+type ProviderStatus = ProviderSetupExperienceProvider;
 type ProviderFieldStatus = ProviderStatus['fields'][number];
 
 const MASKED_VALUE = '••••••••••••••••••••••••••••';
@@ -283,6 +295,8 @@ type ProviderSetupExperienceProps = {
   clearedSavedValues: Record<string, boolean>;
   teamsAppPackageHref: string | null;
   showManualSlackValues: boolean;
+  surface?: 'setup' | 'settings';
+  envVarsInfoNote?: React.ReactNode;
   onShowManualSlackValues: () => void;
   onValueChange: (envVarName: string, value: string) => void;
   onEditingSavedValueChange: (envVarName: string, editing: boolean) => void;
@@ -290,15 +304,43 @@ type ProviderSetupExperienceProps = {
   onBack?: () => void;
 };
 
+function SettingsEnvVarsInfoNote({
+  runtimeConfigured,
+  children,
+}: {
+  runtimeConfigured: boolean;
+  children?: React.ReactNode;
+}) {
+  return (
+    <EnvVarsInfoNote runtimeConfigured={runtimeConfigured}>
+      {children}
+    </EnvVarsInfoNote>
+  );
+}
+
+function ProviderSetupTitle({
+  surface,
+  text,
+}: {
+  surface?: 'setup' | 'settings';
+  text: string;
+}) {
+  return surface === 'settings' ? null : <StepTitle text={text} />;
+}
+
 function SlackSetupExperience(props: ProviderSetupExperienceProps) {
   const slackManifestPrefillUrl = buildSlackManifestPrefillUrl({
     publicOrigin: props.publicOrigin,
   });
 
-  if (!props.showManualSlackValues && !props.provider.runtimeSatisfied) {
+  if (
+    !props.showManualSlackValues &&
+    !props.provider.runtimeSatisfied &&
+    !props.provider.savedSatisfied
+  ) {
     return (
       <div className="relative w-full max-w-2xl space-y-4 py-2 md:py-0">
-        <StepTitle text="Create Slack app" />
+        <ProviderSetupTitle surface={props.surface} text="Create Slack app" />
 
         <div className="space-y-3 max-w-xl">
           <p>
@@ -367,13 +409,19 @@ function MicrosoftSetupExperience(props: ProviderSetupExperienceProps) {
       }).trim().length > 0
     );
   });
-  const pendingStepClassName = teamsAppValuesComplete
+  const teamsAppPackageAvailable =
+    Boolean(props.teamsAppPackageHref) &&
+    (teamsAppValuesComplete || props.surface === 'settings');
+  const pendingStepClassName = teamsAppPackageAvailable
     ? undefined
     : 'opacity-50';
 
   return (
     <div className="relative w-full max-w-2xl space-y-5 py-2 md:py-0">
-      <StepTitle text="Configure Microsoft Teams app" />
+      <ProviderSetupTitle
+        surface={props.surface}
+        text="Configure Microsoft Teams app"
+      />
 
       <NumberedStep number={1} className="mt-6">
         <p className="font-semibold">Create a Microsoft Entra app.</p>
@@ -404,6 +452,11 @@ function MicrosoftSetupExperience(props: ProviderSetupExperienceProps) {
           Enter the Microsoft app generated values.
         </p>
         <ProviderFields fields={fields} {...props} />
+        {props.surface === 'settings' ? (
+          <SettingsEnvVarsInfoNote
+            runtimeConfigured={props.provider.runtimeSatisfied}
+          />
+        ) : null}
       </NumberedStep>
 
       <NumberedStep number={3} className={pendingStepClassName}>
@@ -413,7 +466,7 @@ function MicrosoftSetupExperience(props: ProviderSetupExperienceProps) {
             Download your pre-filled Teams app package (manifest + icons), go to
             the Teams Developer Portal → Import App.
           </p>
-          {teamsAppValuesComplete && props.teamsAppPackageHref ? (
+          {teamsAppPackageAvailable && props.teamsAppPackageHref ? (
             <div className="flex items-center gap-2">
               <Button asChild variant="outline" size="sm">
                 <a href={props.teamsAppPackageHref} download>
@@ -458,7 +511,7 @@ function MicrosoftSetupExperience(props: ProviderSetupExperienceProps) {
           <InstructionUrlContent
             heading="Bot messaging endpoint"
             url={teamsWebhookUrl}
-            disabled={!teamsAppValuesComplete}
+            disabled={!teamsAppPackageAvailable}
           />
         </div>
       </NumberedStep>
@@ -474,7 +527,10 @@ function GenericSetupExperience(props: ProviderSetupExperienceProps) {
 
   return (
     <div className="relative w-full max-w-2xl space-y-5 py-2 md:py-0">
-      <StepTitle text={`Configure ${providerSetupLabel}`} />
+      <ProviderSetupTitle
+        surface={props.surface}
+        text={`Configure ${providerSetupLabel}`}
+      />
 
       <NumberedStep number={1} className="mt-6">
         <p className="font-semibold">
@@ -516,20 +572,24 @@ function GenericSetupExperience(props: ProviderSetupExperienceProps) {
       <NumberedStep number={3}>
         <p className="font-semibold">Enter the values below:</p>
         <ProviderFields fields={fields} {...props} />
+        {props.surface === 'settings' ? (
+          <SettingsEnvVarsInfoNote
+            runtimeConfigured={props.provider.runtimeSatisfied}
+          >
+            {props.envVarsInfoNote}
+          </SettingsEnvVarsInfoNote>
+        ) : null}
       </NumberedStep>
     </div>
   );
 }
 
-const PROVIDER_SETUP_EXPERIENCES = {
+const PROVIDER_SETUP_EXPERIENCES: Partial<
+  Record<ProviderSetupExperienceProvider['id'], typeof GenericSetupExperience>
+> = {
   slack: SlackSetupExperience,
   microsoft: MicrosoftSetupExperience,
-} satisfies Partial<
-  Record<
-    SetupAuthStatus['providers'][number]['id'],
-    typeof GenericSetupExperience
-  >
->;
+};
 
 export function ProviderSetupExperience(props: ProviderSetupExperienceProps) {
   const Component =

--- a/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
+++ b/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
@@ -141,15 +141,27 @@ function NumberedStep({
 }) {
   return (
     <div className={`flex gap-2 items-start ${className ?? ''}`}>
-      <span className="rounded-full bg-foreground text-background font-bold size-8 inline-flex items-center justify-center shrink-0 mt-1">
+      <span className="rounded-full bg-foreground text-background font-bold size-8 inline-flex items-center justify-center shrink-0">
         {number}
       </span>
-      <div className="min-w-0 flex-1">{children}</div>
+      <div className="min-w-0 flex-1 space-y-1">{children}</div>
     </div>
   );
 }
 
 function InstructionUrl({ heading, url }: { heading: string; url: string }) {
+  return <InstructionUrlContent heading={heading} url={url} />;
+}
+
+function InstructionUrlContent({
+  heading,
+  url,
+  disabled = false,
+}: {
+  heading: string;
+  url: string;
+  disabled?: boolean;
+}) {
   return (
     <div className="space-y-1 flex gap-2 items-center">
       <p className="font-semibold text-foreground text-sm w-45 shrink-0">
@@ -164,6 +176,7 @@ function InstructionUrl({ heading, url }: { heading: string; url: string }) {
         <CopyIconButton
           aria-label={`Copy ${heading}`}
           content={url}
+          disabled={disabled}
           tooltip={`Copy ${heading}`}
         />
       </div>
@@ -342,6 +355,26 @@ function MicrosoftSetupExperience(props: ProviderSetupExperienceProps) {
   const providerSetupCopy = getProviderSetupCopy(props.provider.id);
   const webRedirectUri = `${props.publicOrigin}/api/auth/oauth2/callback/microsoft-entra-id`;
   const teamsWebhookUrl = `${props.publicOrigin}/api/webhooks/teams`;
+  const teamsAppValuesComplete = fields.every((field) => {
+    if (field.required === false || field.runtimeSatisfied) {
+      return true;
+    }
+
+    if (field.savedSatisfied && !props.clearedSavedValues[field.envVarName]) {
+      return true;
+    }
+
+    return (
+      getSetupEffectiveFieldValue({
+        provider: props.provider,
+        field,
+        values: props.values,
+      }).trim().length > 0
+    );
+  });
+  const pendingStepClassName = teamsAppValuesComplete
+    ? undefined
+    : 'opacity-50';
 
   return (
     <div className="relative w-full max-w-2xl space-y-5 py-2 md:py-0">
@@ -372,22 +405,20 @@ function MicrosoftSetupExperience(props: ProviderSetupExperienceProps) {
       </NumberedStep>
 
       <NumberedStep number={2}>
-        <p className="font-semibold">Enter the Microsoft app values.</p>
-        <p className="text-sm text-muted-foreground max-w-xl">
-          Roomote stores these values for Microsoft sign-in and also saves
-          hidden Teams bot credentials copied from them.
+        <p className="font-semibold">
+          Enter the Microsoft app generated values.
         </p>
         <ProviderFields fields={fields} {...props} />
       </NumberedStep>
 
-      <NumberedStep number={3}>
+      <NumberedStep number={3} className={pendingStepClassName}>
         <div className="space-y-2">
           <p className="font-semibold">Upload Roomote to Microsoft Teams.</p>
           <p className="text-sm text-muted-foreground">
             Download your pre-filled Teams app package (manifest + icons), go to
             the Teams Developer Portal → Import App.
           </p>
-          {props.teamsAppPackageHref ? (
+          {teamsAppValuesComplete && props.teamsAppPackageHref ? (
             <div className="flex items-center gap-2">
               <Button asChild variant="outline" size="sm">
                 <a href={props.teamsAppPackageHref} download>
@@ -406,14 +437,20 @@ function MicrosoftSetupExperience(props: ProviderSetupExperienceProps) {
               </Button>
             </div>
           ) : (
-            <p className="text-sm text-muted-foreground">
-              Enter the Microsoft Client ID above to enable the download.
-            </p>
+            <div className="flex items-center gap-2">
+              <Button variant="outline" size="sm" disabled>
+                <Download />
+                Download Teams app package
+              </Button>
+              <Button variant="outline" size="sm" disabled>
+                Go <ExternalLink className="inline size-3 -mt-1 ml-1" />
+              </Button>
+            </div>
           )}
         </div>
       </NumberedStep>
 
-      <NumberedStep number={4}>
+      <NumberedStep number={4} className={pendingStepClassName}>
         <p className="font-semibold">
           Add the Teams bot capability to that app.
         </p>
@@ -423,9 +460,10 @@ function MicrosoftSetupExperience(props: ProviderSetupExperienceProps) {
             Use the same Client ID for the bot app ID. Set this messaging
             endpoint for the bot:
           </p>
-          <InstructionUrl
+          <InstructionUrlContent
             heading="Bot messaging endpoint"
             url={teamsWebhookUrl}
+            disabled={!teamsAppValuesComplete}
           />
         </div>
       </NumberedStep>

--- a/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
+++ b/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
@@ -10,7 +10,6 @@ import {
   Check,
   CopyIconButton,
   Download,
-  EnvVarsInfoNote,
   ExternalLink,
   Input,
   Button,
@@ -271,10 +270,6 @@ function ProviderFields({
           </div>
         );
       })}
-
-      <div className="space-y-2 text-sm text-muted-foreground">
-        <EnvVarsInfoNote runtimeConfigured={provider.runtimeSatisfied} />
-      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
+++ b/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
@@ -22,7 +22,7 @@ import { StepTitle } from './StepTitle';
 import { ProviderSetupInstructions } from './ProviderSetupInstructions';
 import { getProviderSetupCopy } from './providerSetupCopy';
 
-export type ProviderSetupExperienceProvider =
+type ProviderSetupExperienceProvider =
   | SetupAuthStatus['providers'][number]
   | {
       id: SetupAuthStatus['providers'][number]['id'] | 'telegram';

--- a/apps/web/src/app/(onboarding)/setup/ProviderSetupInstructions.tsx
+++ b/apps/web/src/app/(onboarding)/setup/ProviderSetupInstructions.tsx
@@ -12,16 +12,6 @@ import { cn } from '@/lib/utils';
 
 type ProviderSetupInstructionsProviderId = SetupAuthProviderId | 'telegram';
 
-export function hasProviderSetupInstructions(
-  providerId: ProviderSetupInstructionsProviderId | null | undefined,
-) {
-  return (
-    providerId === 'slack' ||
-    providerId === 'microsoft' ||
-    providerId === 'telegram'
-  );
-}
-
 function InstructionText({
   heading,
   children,

--- a/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.client.test.tsx
@@ -107,20 +107,6 @@ vi.mock('@/components/system', () => ({
   ),
   Download: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
   ExternalLink: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
-  EnvVarsInfoNote: ({
-    children,
-    runtimeConfigured,
-  }: {
-    children?: ReactNode;
-    runtimeConfigured?: boolean;
-  }) => (
-    <p>
-      {children ??
-        (runtimeConfigured
-          ? "These values are being passed via ENV vars and can't be overridden here."
-          : "You can pass these in as ENV vars. When configured here, they're encrypted in the database.")}
-    </p>
-  ),
   Info: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
   Pencil: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
   Sparkles: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,

--- a/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.client.test.tsx
@@ -106,6 +106,20 @@ vi.mock('@/components/system', () => ({
     />
   ),
   Download: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
+  EnvVarsInfoNote: ({
+    children,
+    runtimeConfigured,
+  }: {
+    children?: ReactNode;
+    runtimeConfigured?: boolean;
+  }) => (
+    <div>
+      {children ??
+        (runtimeConfigured
+          ? "These values are being passed via ENV vars and can't be overridden here."
+          : "You can pass these in as ENV vars. When configured here, they're encrypted in the database.")}
+    </div>
+  ),
   ExternalLink: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
   Info: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
   Pencil: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
@@ -474,6 +488,22 @@ describe('StepAuthEnvVars', () => {
     expectHeadingInNumberedStep('Enter the Microsoft app generated values.', 2);
     expectHeadingInNumberedStep('Upload Roomote to Microsoft Teams.', 3);
     expectHeadingInNumberedStep('Add the Teams bot capability to that app.', 4);
+  });
+
+  it('does not show the settings env-var storage note in setup', () => {
+    render(
+      <StepAuthEnvVars
+        authSetup={buildAuthSetup('microsoft')}
+        selectedProviderId="microsoft"
+        onContinue={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByText(
+        "You can pass these in as ENV vars. When configured here, they're encrypted in the database.",
+      ),
+    ).not.toBeInTheDocument();
   });
 
   it('enables the Teams app package download once a Microsoft app id is entered', () => {

--- a/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.client.test.tsx
@@ -677,8 +677,7 @@ describe('StepAuthEnvVars', () => {
     await waitFor(() => {
       expect(signInOauth2Mock).toHaveBeenCalledWith({
         providerId: 'slack',
-        callbackURL:
-          '/api/slack/install-after-auth?redirect=%2Fsetup%3Fstep%3Dauth-env-vars',
+        callbackURL: '/api/slack/install-after-auth?redirect=%2Fsetup',
         disableRedirect: true,
       });
     });
@@ -689,6 +688,49 @@ describe('StepAuthEnvVars', () => {
         SLACK_CLIENT_ID: 'client-id',
         SLACK_CLIENT_SECRET: 'client-secret',
         SLACK_SIGNING_SECRET: 'signing-secret',
+      }),
+    });
+  });
+
+  it('starts bootstrap Microsoft sign-in with setup flow continuation callback', async () => {
+    const mutateAsync = setupMutationMock();
+
+    render(
+      <StepAuthEnvVars
+        authSetup={buildAuthSetup('microsoft')}
+        selectedProviderId="microsoft"
+        onContinue={vi.fn()}
+        bootstrapMode
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Microsoft Client ID'), {
+      target: { value: '11111111-2222-3333-4444-555555555555' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Microsoft Client Secret'), {
+      target: { value: 'client-secret' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Microsoft Tenant ID'), {
+      target: { value: '22222222-3333-4444-5555-666666666666' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /save and sign in/i }));
+
+    await waitFor(() => {
+      expect(signInOauth2Mock).toHaveBeenCalledWith({
+        providerId: 'microsoft-entra-id',
+        callbackURL: '/setup',
+        disableRedirect: true,
+      });
+    });
+    expect(locationAssignMock).toHaveBeenCalledWith('https://slack.test');
+    expect(mutateAsync).toHaveBeenCalledWith({
+      provider: 'microsoft',
+      values: expect.objectContaining({
+        ROOMOTE_AUTH_MICROSOFT_CLIENT_ID:
+          '11111111-2222-3333-4444-555555555555',
+        ROOMOTE_AUTH_MICROSOFT_CLIENT_SECRET: 'client-secret',
+        ROOMOTE_AUTH_MICROSOFT_TENANT_ID:
+          '22222222-3333-4444-5555-666666666666',
       }),
     });
   });
@@ -744,8 +786,7 @@ describe('StepAuthEnvVars', () => {
     await waitFor(() => {
       expect(signInOauth2Mock).toHaveBeenCalledWith({
         providerId: 'slack',
-        callbackURL:
-          '/api/slack/install-after-auth?redirect=%2Fsetup%3Fstep%3Dauth-env-vars',
+        callbackURL: '/api/slack/install-after-auth?redirect=%2Fsetup',
         disableRedirect: true,
       });
     });

--- a/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.client.test.tsx
@@ -86,11 +86,19 @@ vi.mock('@/components/system', () => ({
   Check: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
   CopyIconButton: ({
     'aria-label': ariaLabel,
+    disabled,
   }: {
     'aria-label'?: string;
     content: string;
+    disabled?: boolean;
     tooltip?: ReactNode;
-  }) => <button type="button" aria-label={ariaLabel ?? 'Copy'} />,
+  }) => (
+    <button
+      type="button"
+      aria-label={ariaLabel ?? 'Copy'}
+      disabled={disabled}
+    />
+  ),
   Download: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
   ExternalLink: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
   EnvVarsInfoNote: ({
@@ -488,11 +496,25 @@ describe('StepAuthEnvVars', () => {
       screen.queryByRole('link', { name: /download teams app package/i }),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByText(/enter the microsoft client id above/i),
-    ).toBeInTheDocument();
+      screen.getByRole('button', { name: /download teams app package/i }),
+    ).toBeDisabled();
+    expect(
+      screen.getAllByRole('button', { name: /^go/i }).at(1),
+    ).toBeDisabled();
 
     fireEvent.change(screen.getByPlaceholderText('Microsoft Client ID'), {
       target: { value: '11111111-2222-3333-4444-555555555555' },
+    });
+
+    expect(
+      screen.queryByRole('link', { name: /download teams app package/i }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Microsoft Client Secret'), {
+      target: { value: 'client-secret' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Microsoft Tenant ID'), {
+      target: { value: '22222222-3333-4444-5555-666666666666' },
     });
 
     expect(
@@ -505,6 +527,51 @@ describe('StepAuthEnvVars', () => {
       'href',
       'https://dev.teams.microsoft.com/home',
     );
+  });
+
+  it('keeps Microsoft Teams setup steps pending until all app values are filled', () => {
+    render(
+      <StepAuthEnvVars
+        authSetup={buildAuthSetup('microsoft')}
+        selectedProviderId="microsoft"
+        onContinue={vi.fn()}
+      />,
+    );
+
+    const uploadStep = screen
+      .getByText('Upload Roomote to Microsoft Teams.')
+      .closest('.flex');
+    const botStep = screen
+      .getByText('Add the Teams bot capability to that app.')
+      .closest('.flex');
+
+    expect(uploadStep).toHaveClass('opacity-50');
+    expect(botStep).toHaveClass('opacity-50');
+    expect(
+      screen.getByRole('button', { name: /download teams app package/i }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: /copy bot messaging endpoint/i }),
+    ).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText('Microsoft Client ID'), {
+      target: { value: '11111111-2222-3333-4444-555555555555' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Microsoft Client Secret'), {
+      target: { value: 'client-secret' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Microsoft Tenant ID'), {
+      target: { value: '22222222-3333-4444-5555-666666666666' },
+    });
+
+    expect(uploadStep).not.toHaveClass('opacity-50');
+    expect(botStep).not.toHaveClass('opacity-50');
+    expect(
+      screen.getByRole('link', { name: /download teams app package/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /copy bot messaging endpoint/i }),
+    ).toBeEnabled();
   });
 
   it('submits hidden Teams bot values for the single Microsoft app path', async () => {

--- a/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.client.test.tsx
@@ -677,7 +677,8 @@ describe('StepAuthEnvVars', () => {
     await waitFor(() => {
       expect(signInOauth2Mock).toHaveBeenCalledWith({
         providerId: 'slack',
-        callbackURL: expect.any(String),
+        callbackURL:
+          '/api/slack/install-after-auth?redirect=%2Fsetup%3Fstep%3Dauth-env-vars',
         disableRedirect: true,
       });
     });
@@ -743,7 +744,8 @@ describe('StepAuthEnvVars', () => {
     await waitFor(() => {
       expect(signInOauth2Mock).toHaveBeenCalledWith({
         providerId: 'slack',
-        callbackURL: expect.any(String),
+        callbackURL:
+          '/api/slack/install-after-auth?redirect=%2Fsetup%3Fstep%3Dauth-env-vars',
         disableRedirect: true,
       });
     });

--- a/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.client.test.tsx
@@ -10,13 +10,19 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { SetupAuthStatus } from '@roomote/types';
 
-const { replaceMock, refreshMock, signInOauth2Mock, signInSocialMock } =
-  vi.hoisted(() => ({
-    replaceMock: vi.fn(),
-    refreshMock: vi.fn(),
-    signInOauth2Mock: vi.fn(),
-    signInSocialMock: vi.fn(),
-  }));
+const {
+  locationAssignMock,
+  replaceMock,
+  refreshMock,
+  signInOauth2Mock,
+  signInSocialMock,
+} = vi.hoisted(() => ({
+  locationAssignMock: vi.fn(),
+  replaceMock: vi.fn(),
+  refreshMock: vi.fn(),
+  signInOauth2Mock: vi.fn(),
+  signInSocialMock: vi.fn(),
+}));
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
@@ -333,6 +339,7 @@ describe('StepAuthEnvVars', () => {
       writable: true,
       value: {
         ...window.location,
+        assign: locationAssignMock,
         origin: 'https://roomote.example.com',
       },
     });
@@ -478,7 +485,7 @@ describe('StepAuthEnvVars', () => {
     expect(
       screen.getByPlaceholderText('Microsoft Client ID'),
     ).toBeInTheDocument();
-    expectHeadingInNumberedStep('Enter the Microsoft app values.', 2);
+    expectHeadingInNumberedStep('Enter the Microsoft app generated values.', 2);
     expectHeadingInNumberedStep('Upload Roomote to Microsoft Teams.', 3);
     expectHeadingInNumberedStep('Add the Teams bot capability to that app.', 4);
   });
@@ -685,8 +692,10 @@ describe('StepAuthEnvVars', () => {
       expect(signInOauth2Mock).toHaveBeenCalledWith({
         providerId: 'slack',
         callbackURL: expect.any(String),
+        disableRedirect: true,
       });
     });
+    expect(locationAssignMock).toHaveBeenCalledWith('https://slack.test');
     expect(mutateAsync).toHaveBeenCalledWith({
       provider: 'slack',
       values: expect.objectContaining({
@@ -749,8 +758,10 @@ describe('StepAuthEnvVars', () => {
       expect(signInOauth2Mock).toHaveBeenCalledWith({
         providerId: 'slack',
         callbackURL: expect.any(String),
+        disableRedirect: true,
       });
     });
+    expect(locationAssignMock).toHaveBeenCalledWith('https://slack.test');
     expect(mutateAsync).toHaveBeenCalledWith({
       provider: 'slack',
       values: {},

--- a/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.tsx
@@ -18,7 +18,6 @@ import {
 } from '@/components/system';
 
 import { StepTitle } from './StepTitle';
-import { getSetupStepPath } from './types';
 import {
   getSetupEffectiveFieldValue,
   getSetupSubmitValues,
@@ -29,6 +28,7 @@ import {
 /** Microsoft app (client) IDs are GUIDs. */
 const MICROSOFT_APP_ID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const BOOTSTRAP_SIGN_IN_CALLBACK_PATH = '/setup';
 
 function getOAuth2ProviderId(
   providerId: SetupAuthStatus['preselectedProvider'],
@@ -86,7 +86,7 @@ export function StepAuthEnvVars({
         if (bootstrapMode && selectedProvider) {
           const callbackURL = getAuthProviderCallbackUrl(
             selectedProvider.id,
-            getSetupStepPath('auth-env-vars'),
+            BOOTSTRAP_SIGN_IN_CALLBACK_PATH,
           );
           const oauth2ProviderId = getOAuth2ProviderId(selectedProvider.id);
           const result = oauth2ProviderId

--- a/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/components/system';
 
 import { StepTitle } from './StepTitle';
+import { getSetupStepPath } from './types';
 import {
   getSetupEffectiveFieldValue,
   getSetupSubmitValues,
@@ -85,7 +86,7 @@ export function StepAuthEnvVars({
         if (bootstrapMode && selectedProvider) {
           const callbackURL = getAuthProviderCallbackUrl(
             selectedProvider.id,
-            '/setup',
+            getSetupStepPath('auth-env-vars'),
           );
           const oauth2ProviderId = getOAuth2ProviderId(selectedProvider.id);
           const result = oauth2ProviderId

--- a/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.tsx
@@ -92,10 +92,12 @@ export function StepAuthEnvVars({
             ? await authClient.signIn.oauth2({
                 providerId: oauth2ProviderId,
                 callbackURL,
+                disableRedirect: true,
               })
             : await authClient.signIn.social({
                 provider: selectedProvider.id,
                 callbackURL,
+                disableRedirect: true,
               });
 
           if (result.error) {
@@ -103,11 +105,13 @@ export function StepAuthEnvVars({
             return;
           }
 
-          if (!result.data?.url) {
-            router.replace(callbackURL);
-            router.refresh();
+          if (result.data?.url) {
+            window.location.assign(result.data.url);
+            return;
           }
 
+          router.replace(callbackURL);
+          router.refresh();
           return;
         }
 

--- a/apps/web/src/app/(onboarding)/setup/StepComputeConfig.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepComputeConfig.client.test.tsx
@@ -45,7 +45,6 @@ vi.mock('@/components/system', () => ({
   ),
   Check: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
   ChevronDown: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
-  EnvVarsInfoNote: () => <p>Env vars note</p>,
   Input: ({
     secret: _secret,
     ...props

--- a/apps/web/src/app/(onboarding)/setup/StepComputeConfig.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepComputeConfig.tsx
@@ -19,7 +19,6 @@ import {
   Button,
   Check,
   ChevronDown,
-  EnvVarsInfoNote,
   Input,
   Spinner,
 } from '@/components/system';
@@ -440,8 +439,6 @@ export function StepComputeConfig({
                 </div>
               ) : null}
 
-              {!advancedExpanded && <EnvVarsInfoNote />}
-
               {isHostedProvider && workerImage.hostedReady ? (
                 <div className="flex items-start gap-2 text-muted-foreground mt-4">
                   <Check className="inline size-4 mt-0.5 shrink-0 text-foreground" />
@@ -542,8 +539,6 @@ export function StepComputeConfig({
                   )}
                 </div>
               ) : null}
-
-              {advancedExpanded && <EnvVarsInfoNote />}
             </div>
           </div>
         ) : null}

--- a/apps/web/src/app/(onboarding)/setup/StepInferenceProvider.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepInferenceProvider.client.test.tsx
@@ -75,9 +75,6 @@ vi.mock('@/components/system', () => ({
     </button>
   ),
   Check: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
-  EnvVarsInfoNote: ({ children }: { children?: ReactNode }) => (
-    <p>{children}</p>
-  ),
   Input: ({
     secret: _secret,
     ...props

--- a/apps/web/src/app/(onboarding)/setup/StepInferenceProvider.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepInferenceProvider.tsx
@@ -15,7 +15,6 @@ import {
   ArrowRight,
   Button,
   Check,
-  EnvVarsInfoNote,
   Input,
   Select,
   SelectContent,
@@ -309,14 +308,6 @@ export function StepInferenceProvider({
           </Button>
         </div>
       )}
-
-      <div className="space-y-2 text-sm text-muted-foreground">
-        <EnvVarsInfoNote>
-          You can pass keys in as ENV vars when running Roomote (highly
-          recommended in production). When configured here, they&apos;re
-          encrypted in the database.
-        </EnvVarsInfoNote>
-      </div>
 
       <ChatGptConnectDialog
         open={isChatGptDialogOpen}

--- a/apps/web/src/app/(onboarding)/setup/StepInvoke.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepInvoke.client.test.tsx
@@ -93,6 +93,21 @@ vi.mock('@/components/system', () => ({
   BrandIcon: ({ name }: { name: string }) => (
     <span aria-label={name} data-testid="brand-icon" />
   ),
+  Checkbox: ({
+    checked,
+    onCheckedChange,
+    ...props
+  }: {
+    checked?: boolean;
+    onCheckedChange?: (checked: boolean) => void;
+  } & Record<string, unknown>) => (
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={(event) => onCheckedChange?.(event.target.checked)}
+      aria-label={String(props['aria-label'] ?? 'checkbox')}
+    />
+  ),
   Loader2: () => <span>Loader2</span>,
   LinearLogo: () => <span>LinearLogo</span>,
   ArrowRight: () => <span>ArrowRight</span>,

--- a/apps/web/src/app/(onboarding)/setup/StepInvoke.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepInvoke.tsx
@@ -5,13 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { PRODUCT_NAME } from '@roomote/types';
 import type { SourceControlProvider } from '@roomote/types';
-import {
-  Button,
-  Loader2,
-  ArrowRight,
-  Switch,
-  Checkbox,
-} from '@/components/system';
+import { Button, Loader2, ArrowRight, Checkbox } from '@/components/system';
 import { useTRPC } from '@/trpc/client';
 import { useEnvironments } from '@/hooks/environments/useEnvironments';
 import { buildInvokeMethods } from '../invokeMethods';

--- a/apps/web/src/app/(onboarding)/setup/StepInvoke.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepInvoke.tsx
@@ -5,7 +5,13 @@ import { useRouter } from 'next/navigation';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { PRODUCT_NAME } from '@roomote/types';
 import type { SourceControlProvider } from '@roomote/types';
-import { Button, Loader2, ArrowRight, Switch } from '@/components/system';
+import {
+  Button,
+  Loader2,
+  ArrowRight,
+  Switch,
+  Checkbox,
+} from '@/components/system';
 import { useTRPC } from '@/trpc/client';
 import { useEnvironments } from '@/hooks/environments/useEnvironments';
 import { buildInvokeMethods } from '../invokeMethods';
@@ -96,7 +102,7 @@ export function StepInvoke({
   );
 
   return (
-    <div className="relative w-full max-w-xl space-y-6 py-2 md:py-0">
+    <div className="relative w-full max-w-2xl space-y-6 py-2 md:py-0">
       <StepTitle text={INVOKE_STEP.title} />
       <p className="mb-4">How to work with {PRODUCT_NAME}:</p>
       <div className="space-y-5">
@@ -119,22 +125,25 @@ export function StepInvoke({
         ))}
       </div>
 
-      <div className="mt-6 flex items-start justify-between gap-4 rounded-lg border p-3">
-        <div className="space-y-0.5">
-          <p className="text-sm font-semibold">Anonymous analytics</p>
-          <p className="text-sm text-muted-foreground">
-            Share anonymous usage analytics with the {PRODUCT_NAME} team,
-            identified only by random IDs. You can change this later in
-            Settings.
-          </p>
-        </div>
-        <Switch
+      <div className="mt-4 flex items-start gap-2 border-t border-foreground/20 pt-4">
+        <Checkbox
           aria-label="Toggle anonymous analytics"
+          className="mt-0.5"
           checked={anonymousAnalyticsEnabled}
           onCheckedChange={(checked) =>
             setAnonymousAnalyticsEnabled(checked === true)
           }
         />
+        <div className="space-y-0.5">
+          <p className="text-sm font-semibold">Anonymous analytics</p>
+          <p className="text-sm text-muted-foreground">
+            Share usage stats with the {PRODUCT_NAME} team for product
+            improvements.
+            <br />
+            No PII, code or conversation content is ever shared. Accrues good
+            karma.
+          </p>
+        </div>
       </div>
 
       <div className="mt-3 flex">

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.tsx
@@ -16,7 +16,6 @@ import {
   Button,
   Check,
   CopyIconButton,
-  EnvVarsInfoNote,
   ExternalLink,
   Input,
   Label,
@@ -436,10 +435,6 @@ export function StepSourceControlConfig({
             </div>
           );
         })}
-
-        <div className="space-y-2 text-sm text-muted-foreground">
-          <EnvVarsInfoNote />
-        </div>
       </div>
 
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center mt-8">

--- a/apps/web/src/app/(onboarding)/setup/bootstrapFlow.client.test.ts
+++ b/apps/web/src/app/(onboarding)/setup/bootstrapFlow.client.test.ts
@@ -2,6 +2,7 @@ import type { SetupAuthProviderId, SetupAuthStatus } from '@roomote/types';
 
 import {
   getBootstrapAuthProvider,
+  getBootstrapStepFromSetupStepParam,
   getBootstrapStepAfterWelcome,
   getNextBootstrapStep,
   shouldSkipBootstrapAccountStep,
@@ -83,5 +84,18 @@ describe('bootstrapFlow', () => {
     expect(getBootstrapAuthProvider(authSetup, pendingProvider)).toBe(
       'microsoft',
     );
+  });
+
+  it('maps only auth setup query steps into the signed-out bootstrap flow', () => {
+    expect(getBootstrapStepFromSetupStepParam('auth-provider')).toBe(
+      'auth-provider',
+    );
+    expect(getBootstrapStepFromSetupStepParam('auth-env-vars')).toBe(
+      'auth-env-vars',
+    );
+    expect(
+      getBootstrapStepFromSetupStepParam('source-control-config'),
+    ).toBeNull();
+    expect(getBootstrapStepFromSetupStepParam(null)).toBeNull();
   });
 });

--- a/apps/web/src/app/(onboarding)/setup/bootstrapFlow.ts
+++ b/apps/web/src/app/(onboarding)/setup/bootstrapFlow.ts
@@ -24,6 +24,12 @@ export function getBootstrapAuthProvider(
   );
 }
 
+export function getBootstrapStepFromSetupStepParam(
+  step: string | null,
+): BootstrapStep | null {
+  return step === 'auth-provider' || step === 'auth-env-vars' ? step : null;
+}
+
 export function getNextBootstrapStep(
   authSetup: SetupAuthStatus | null | undefined,
   pendingAuthProvider?: SetupAuthProviderId | null,

--- a/apps/web/src/app/(onboarding)/setup/layout.tsx
+++ b/apps/web/src/app/(onboarding)/setup/layout.tsx
@@ -40,7 +40,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       <div ref={setUserMenuPortalContainer} className="light text-foreground" />
       <FramedSurface
         variant="bold"
-        frameClassName="h-[calc(var(--effective-viewport-height)-0.25rem)] w-[calc(100svw-0.25rem)] scroll-minimal overflow-hidden md:m-4 md:h-[calc(var(--effective-viewport-height)-2rem)] md:w-[calc(100vw-2rem)]"
+        frameClassName="h-[calc(var(--effective-viewport-height)-0.25rem)] w-[calc(100svw-0.25rem)] scroll-minimal overflow-hidden"
         surfaceClassName="flex flex-col !overflow-y-auto !overflow-x-hidden md:items-center"
       >
         {isSignedIn ? (

--- a/apps/web/src/app/(onboarding)/setup/page.tsx
+++ b/apps/web/src/app/(onboarding)/setup/page.tsx
@@ -44,6 +44,7 @@ import { StepOnboardingAgent } from './StepOnboardingAgent';
 import { getSetupStepPath } from './types';
 import {
   getBootstrapAuthProvider,
+  getBootstrapStepFromSetupStepParam,
   getBootstrapStepAfterWelcome,
   getNextBootstrapStep,
   type BootstrapStep,
@@ -75,6 +76,18 @@ function getSetupRetryReason(status: {
   return 'task-failed';
 }
 
+function getInitialBootstrapStep(): BootstrapStep {
+  if (typeof window === 'undefined') {
+    return 'welcome';
+  }
+
+  return (
+    getBootstrapStepFromSetupStepParam(
+      new URLSearchParams(window.location.search).get('step'),
+    ) ?? 'welcome'
+  );
+}
+
 export default function SetupPage() {
   const router = useRouter();
   const setupBootstrapOpen = useSetupBootstrapOpen();
@@ -84,7 +97,9 @@ export default function SetupPage() {
     authStatus === 'signed-out' && !setupBootstrapOpen;
   const trpc = useTRPC();
   const queryClient = useQueryClient();
-  const [bootstrapStep, setBootstrapStep] = useState<BootstrapStep>('welcome');
+  const [bootstrapStep, setBootstrapStep] = useState<BootstrapStep>(
+    getInitialBootstrapStep,
+  );
   const [pendingAuthProvider, setPendingAuthProvider] =
     useState<SetupAuthProviderId | null>(null);
   const [pendingSourceControlProvider, setPendingSourceControlProvider] =

--- a/apps/web/src/app/(unauthenticated)/auth-form.client.test.tsx
+++ b/apps/web/src/app/(unauthenticated)/auth-form.client.test.tsx
@@ -45,9 +45,7 @@ describe('AuthForm', () => {
 
     render(<AuthForm />);
 
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Continue with Slack' }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Login with Slack' }));
 
     await waitFor(() => {
       expect(signInOauth2Mock).toHaveBeenCalledWith({
@@ -64,7 +62,7 @@ describe('AuthForm', () => {
     render(<AuthForm />);
 
     fireEvent.click(
-      screen.getByRole('button', { name: 'Continue with Microsoft Teams' }),
+      screen.getByRole('button', { name: 'Login with Microsoft Teams' }),
     );
 
     await waitFor(() => {
@@ -81,7 +79,7 @@ describe('AuthForm', () => {
     render(<AuthForm />);
 
     fireEvent.click(
-      screen.getByRole('button', { name: 'Continue with Microsoft Teams' }),
+      screen.getByRole('button', { name: 'Login with Microsoft Teams' }),
     );
 
     await waitFor(() => {
@@ -98,7 +96,7 @@ describe('AuthForm', () => {
     render(<AuthForm />);
 
     fireEvent.click(
-      screen.getByRole('button', { name: 'Continue with Microsoft Teams' }),
+      screen.getByRole('button', { name: 'Login with Microsoft Teams' }),
     );
 
     await waitFor(() => {
@@ -115,9 +113,7 @@ describe('AuthForm', () => {
 
     render(<AuthForm />);
 
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Continue with Slack' }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Login with Slack' }));
 
     await waitFor(() => {
       expect(replaceMock).toHaveBeenCalledWith(
@@ -135,9 +131,7 @@ describe('AuthForm', () => {
 
     render(<AuthForm />);
 
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Continue with Slack' }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Login with Slack' }));
 
     expect(await screen.findByText('Provider is not configured')).toBeVisible();
     expect(replaceMock).not.toHaveBeenCalled();
@@ -148,11 +142,11 @@ describe('AuthForm', () => {
 
     expect(
       screen.getByRole('heading', {
-        name: 'Hi there, welcome to Roomote.',
+        name: 'Welcome! Come on in.',
       }),
     ).toBeVisible();
     expect(
-      screen.getByRole('button', { name: 'Continue with email' }),
+      screen.getByRole('button', { name: 'Login in with email' }),
     ).toBeVisible();
     expect(screen.queryByLabelText('Email')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
@@ -162,20 +156,20 @@ describe('AuthForm', () => {
     render(<AuthForm />);
 
     fireEvent.click(
-      screen.getByRole('button', { name: 'Continue with email' }),
+      screen.getByRole('button', { name: 'Login in with email' }),
     );
 
     expect(screen.getByLabelText('Email')).toBeVisible();
     expect(screen.getByLabelText('Password')).toBeVisible();
     expect(screen.getByRole('button', { name: 'Sign in' })).toBeVisible();
     expect(
-      screen.queryByRole('button', { name: 'Continue with email' }),
+      screen.queryByRole('button', { name: 'Login in with email' }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole('button', { name: 'Continue with Slack' }),
+      screen.queryByRole('button', { name: 'Login with Slack' }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole('button', { name: 'Continue with Microsoft Teams' }),
+      screen.queryByRole('button', { name: 'Login with Microsoft Teams' }),
     ).not.toBeInTheDocument();
   });
 
@@ -183,17 +177,17 @@ describe('AuthForm', () => {
     render(<AuthForm enabledProviders={[]} />);
 
     expect(
-      screen.queryByRole('button', { name: 'Continue with Slack' }),
+      screen.queryByRole('button', { name: 'Login with Slack' }),
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: 'Continue with Telegram' }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole('button', { name: 'Continue with Microsoft Teams' }),
+      screen.queryByRole('button', { name: 'Login with Microsoft Teams' }),
     ).not.toBeInTheDocument();
     expect(
       screen.getByRole('heading', {
-        name: 'Hi there, welcome to Roomote.',
+        name: 'Welcome! Come on in.',
       }),
     ).toBeVisible();
     expect(screen.getByLabelText('Email')).toBeVisible();
@@ -223,7 +217,7 @@ describe('AuthForm', () => {
     render(<AuthForm canSignUp />);
 
     fireEvent.click(
-      screen.getByRole('button', { name: 'Continue with email' }),
+      screen.getByRole('button', { name: 'Login in with email' }),
     );
 
     expect(
@@ -238,7 +232,7 @@ describe('AuthForm', () => {
     render(<AuthForm />);
 
     fireEvent.click(
-      screen.getByRole('button', { name: 'Continue with email' }),
+      screen.getByRole('button', { name: 'Login in with email' }),
     );
 
     expect(
@@ -268,7 +262,7 @@ describe('AuthForm', () => {
     render(<AuthForm canSignUp />);
 
     fireEvent.click(
-      screen.getByRole('button', { name: 'Continue with email' }),
+      screen.getByRole('button', { name: 'Login in with email' }),
     );
 
     expect(screen.getByLabelText('Name')).toBeVisible();
@@ -283,7 +277,7 @@ describe('AuthForm', () => {
     render(<AuthForm />);
 
     fireEvent.click(
-      screen.getByRole('button', { name: 'Continue with email' }),
+      screen.getByRole('button', { name: 'Login in with email' }),
     );
 
     expect(screen.queryByLabelText('Name')).not.toBeInTheDocument();
@@ -298,7 +292,7 @@ describe('AuthForm', () => {
     expect(screen.getByText(/reached its licensed user limit/)).toBeVisible();
     // Sign-in stays available: existing users are never blocked by the gate.
     fireEvent.click(
-      screen.getByRole('button', { name: 'Continue with email' }),
+      screen.getByRole('button', { name: 'Login in with email' }),
     );
     expect(screen.getByRole('button', { name: 'Sign in' })).toBeVisible();
   });

--- a/apps/web/src/app/(unauthenticated)/auth-form.client.test.tsx
+++ b/apps/web/src/app/(unauthenticated)/auth-form.client.test.tsx
@@ -146,7 +146,7 @@ describe('AuthForm', () => {
       }),
     ).toBeVisible();
     expect(
-      screen.getByRole('button', { name: 'Login in with email' }),
+      screen.getByRole('button', { name: 'Log in with email' }),
     ).toBeVisible();
     expect(screen.queryByLabelText('Email')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
@@ -155,15 +155,13 @@ describe('AuthForm', () => {
   it('reveals email sign-in from the provider selection list', () => {
     render(<AuthForm />);
 
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Login in with email' }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Log in with email' }));
 
     expect(screen.getByLabelText('Email')).toBeVisible();
     expect(screen.getByLabelText('Password')).toBeVisible();
     expect(screen.getByRole('button', { name: 'Sign in' })).toBeVisible();
     expect(
-      screen.queryByRole('button', { name: 'Login in with email' }),
+      screen.queryByRole('button', { name: 'Log in with email' }),
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: 'Login with Slack' }),
@@ -216,9 +214,7 @@ describe('AuthForm', () => {
   it('offers account creation to invited visitors', () => {
     render(<AuthForm canSignUp />);
 
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Login in with email' }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Log in with email' }));
 
     expect(
       screen.getByRole('button', { name: 'Need an account? Create one' }),
@@ -231,9 +227,7 @@ describe('AuthForm', () => {
   it('hides account creation and points at an admin without an invite', () => {
     render(<AuthForm />);
 
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Login in with email' }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Log in with email' }));
 
     expect(
       screen.queryByRole('button', { name: /create/i }),
@@ -261,9 +255,7 @@ describe('AuthForm', () => {
 
     render(<AuthForm canSignUp />);
 
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Login in with email' }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Log in with email' }));
 
     expect(screen.getByLabelText('Name')).toBeVisible();
     expect(
@@ -276,9 +268,7 @@ describe('AuthForm', () => {
 
     render(<AuthForm />);
 
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Login in with email' }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Log in with email' }));
 
     expect(screen.queryByLabelText('Name')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Sign in' })).toBeVisible();
@@ -291,9 +281,7 @@ describe('AuthForm', () => {
 
     expect(screen.getByText(/reached its licensed user limit/)).toBeVisible();
     // Sign-in stays available: existing users are never blocked by the gate.
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Login in with email' }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Log in with email' }));
     expect(screen.getByRole('button', { name: 'Sign in' })).toBeVisible();
   });
 

--- a/apps/web/src/app/(unauthenticated)/auth-form.client.test.tsx
+++ b/apps/web/src/app/(unauthenticated)/auth-form.client.test.tsx
@@ -143,7 +143,7 @@ describe('AuthForm', () => {
     expect(replaceMock).not.toHaveBeenCalled();
   });
 
-  it('shows provider configuration guidance', () => {
+  it('shows provider configuration guidance and hides email behind an option', () => {
     render(<AuthForm />);
 
     expect(
@@ -151,8 +151,32 @@ describe('AuthForm', () => {
         name: 'Hi there, welcome to Roomote.',
       }),
     ).toBeVisible();
+    expect(
+      screen.getByRole('button', { name: 'Continue with email' }),
+    ).toBeVisible();
+    expect(screen.queryByLabelText('Email')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
+  });
+
+  it('reveals email sign-in from the provider selection list', () => {
+    render(<AuthForm />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Continue with email' }),
+    );
+
     expect(screen.getByLabelText('Email')).toBeVisible();
     expect(screen.getByLabelText('Password')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeVisible();
+    expect(
+      screen.queryByRole('button', { name: 'Continue with email' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Continue with Slack' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Continue with Microsoft Teams' }),
+    ).not.toBeInTheDocument();
   });
 
   it('omits provider buttons when no provider is configured', () => {
@@ -198,6 +222,10 @@ describe('AuthForm', () => {
   it('offers account creation to invited visitors', () => {
     render(<AuthForm canSignUp />);
 
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Continue with email' }),
+    );
+
     expect(
       screen.getByRole('button', { name: 'Need an account? Create one' }),
     ).toBeVisible();
@@ -208,6 +236,10 @@ describe('AuthForm', () => {
 
   it('hides account creation and points at an admin without an invite', () => {
     render(<AuthForm />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Continue with email' }),
+    );
 
     expect(
       screen.queryByRole('button', { name: /create/i }),
@@ -235,6 +267,10 @@ describe('AuthForm', () => {
 
     render(<AuthForm canSignUp />);
 
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Continue with email' }),
+    );
+
     expect(screen.getByLabelText('Name')).toBeVisible();
     expect(
       screen.getByRole('button', { name: 'Create account' }),
@@ -245,6 +281,10 @@ describe('AuthForm', () => {
     searchParams = new URLSearchParams('invited=1');
 
     render(<AuthForm />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Continue with email' }),
+    );
 
     expect(screen.queryByLabelText('Name')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Sign in' })).toBeVisible();
@@ -257,6 +297,9 @@ describe('AuthForm', () => {
 
     expect(screen.getByText(/reached its licensed user limit/)).toBeVisible();
     // Sign-in stays available: existing users are never blocked by the gate.
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Continue with email' }),
+    );
     expect(screen.getByRole('button', { name: 'Sign in' })).toBeVisible();
   });
 

--- a/apps/web/src/app/(unauthenticated)/auth-form.tsx
+++ b/apps/web/src/app/(unauthenticated)/auth-form.tsx
@@ -19,6 +19,7 @@ import {
   ArrowRight,
   BrandIcon,
   Button,
+  Mail,
   Slack,
   Spinner,
 } from '@/components/system';
@@ -98,10 +99,13 @@ export function AuthForm({
   const visibleProviders = SOCIAL_PROVIDERS.filter((provider) =>
     enabledProviderSet.has(provider.id),
   );
+  const hasVisibleProviders = visibleProviders.length > 0;
 
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isEmailAuthVisible, setIsEmailAuthVisible] = useState(false);
   const [submittingProvider, setSubmittingProvider] =
     useState<AuthProvider | null>(null);
+  const showEmailAuth = !hasVisibleProviders || isEmailAuthVisible;
 
   const handleSocialSignIn = async (provider: AuthProvider) => {
     setErrorMessage(null);
@@ -140,20 +144,14 @@ export function AuthForm({
   };
 
   return (
-    <main className="flex w-full justify-center md:justify-start">
+    <main className="flex w-full">
       <div className="relative w-full max-w-2xl space-y-6 py-2 text-left md:py-0">
         <h1 className="relative text-3xl font-bold tracking-tighter">
           <span className="relative flex items-center gap-3">
-            <span className="absolute -left-6 hidden w-3 rounded-lg border border-foreground bg-accent-bright-foreground md:inline-block" />
-            Hi there, welcome to Roomote.
+            Welcome! Come on in.
           </span>
         </h1>
         <div className="max-w-xl space-y-4">
-          <p>
-            Sign in with your team&apos;s messaging tool. Email is available
-            below.
-          </p>
-
           <div className="space-y-2">
             <OriginMismatchAlert />
             {noticeMessage && (
@@ -170,60 +168,63 @@ export function AuthForm({
             )}
           </div>
 
-          <div className="max-w-sm space-y-0.5">
-            {visibleProviders.map((provider) => {
-              const isSubmitting = submittingProvider === provider.id;
+          {!showEmailAuth ? (
+            <div className="max-w-sm space-y-0.5">
+              {visibleProviders.map((provider) => {
+                const isSubmitting = submittingProvider === provider.id;
 
-              return (
-                <Button
-                  className={cn(
-                    'group flex h-auto w-full py-5',
-                    'hover:bg-foreground hover:text-accent-foreground',
-                  )}
-                  disabled={isSubmitting}
-                  key={provider.id}
-                  onClick={() => void handleSocialSignIn(provider.id)}
-                  type="button"
-                >
-                  <span className="flex min-w-0 grow items-center gap-2">
-                    {isSubmitting ? (
-                      <Spinner />
-                    ) : (
-                      <AuthProviderIcon provider={provider.icon} />
-                    )}
-                    <span className="grow truncate text-left font-medium">
-                      Continue with {provider.label}
+                return (
+                  <Button
+                    className={cn('w-full')}
+                    disabled={isSubmitting}
+                    key={provider.id}
+                    onClick={() => void handleSocialSignIn(provider.id)}
+                    type="button"
+                  >
+                    <span className="flex min-w-0 grow items-center gap-2">
+                      {isSubmitting ? (
+                        <Spinner />
+                      ) : (
+                        <AuthProviderIcon provider={provider.icon} />
+                      )}
+                      <span className="grow truncate text-left font-medium">
+                        Login with {provider.label}
+                      </span>
                     </span>
-                  </span>
-                  <ArrowRight />
-                </Button>
-              );
-            })}
-          </div>
+                    <ArrowRight />
+                  </Button>
+                );
+              })}
 
-          {visibleProviders.length > 0 && (
-            <div className="flex max-w-sm items-center gap-3 py-1 text-xs text-muted-foreground">
-              <span className="h-px flex-1 bg-border" />
-              or
-              <span className="h-px flex-1 bg-border" />
+              <Button
+                className={cn('w-full')}
+                onClick={() => setIsEmailAuthVisible(true)}
+                type="button"
+              >
+                <Mail />
+                <span className="grow text-left font-medium">
+                  Login in with email
+                </span>
+                <ArrowRight />
+              </Button>
             </div>
-          )}
+          ) : null}
 
-          <div className="max-w-sm">
-            <EmailPasswordAuth
-              redirectUrl={redirectUrl}
-              allowSignUp={canSignUp}
-              labelsAsPlaceholders={true}
-              hideModeSwitchMessage={hideModeSwitchMessage}
-              defaultMode={
-                canSignUp && searchParams.get('invited') ? 'sign-up' : 'sign-in'
-              }
-              submitButtonClassName={cn(
-                'h-auto w-full justify-between py-5',
-                'hover:bg-foreground hover:text-accent-foreground',
-              )}
-            />
-          </div>
+          {showEmailAuth ? (
+            <div className="max-w-sm">
+              <EmailPasswordAuth
+                redirectUrl={redirectUrl}
+                allowSignUp={canSignUp}
+                labelsAsPlaceholders={true}
+                hideModeSwitchMessage={hideModeSwitchMessage}
+                defaultMode={
+                  canSignUp && searchParams.get('invited')
+                    ? 'sign-up'
+                    : 'sign-in'
+                }
+              />
+            </div>
+          ) : null}
         </div>
       </div>
     </main>

--- a/apps/web/src/app/(unauthenticated)/auth-form.tsx
+++ b/apps/web/src/app/(unauthenticated)/auth-form.tsx
@@ -203,7 +203,7 @@ export function AuthForm({
               >
                 <Mail />
                 <span className="grow text-left font-medium">
-                  Login in with email
+                  Log in with email
                 </span>
                 <ArrowRight />
               </Button>

--- a/apps/web/src/app/(unauthenticated)/auth-form.tsx
+++ b/apps/web/src/app/(unauthenticated)/auth-form.tsx
@@ -9,6 +9,7 @@ import {
 
 import { authClient } from '@/lib/auth-client';
 import { getAuthProviderCallbackUrl } from '@/lib/auth-provider-callback';
+import { cn } from '@/lib/utils';
 import { OriginMismatchAlert } from '@/components/layout';
 import { EmailPasswordAuth } from './email-password-auth';
 import {
@@ -18,7 +19,6 @@ import {
   ArrowRight,
   BrandIcon,
   Button,
-  Card,
   Slack,
   Spinner,
 } from '@/components/system';
@@ -140,46 +140,58 @@ export function AuthForm({
   };
 
   return (
-    <main className="flex w-full items-center justify-center">
-      <Card className="w-full max-w-md text-center">
-        <h1 className="text-xl font-semibold tracking-tight">
-          Hi there, welcome to Roomote.
+    <main className="flex w-full justify-center md:justify-start">
+      <div className="relative w-full max-w-2xl space-y-6 py-2 text-left md:py-0">
+        <h1 className="relative text-3xl font-bold tracking-tighter">
+          <span className="relative flex items-center gap-3">
+            <span className="absolute -left-6 hidden w-3 rounded-lg border border-foreground bg-accent-bright-foreground md:inline-block" />
+            Hi there, welcome to Roomote.
+          </span>
         </h1>
-        <div className="space-y-2">
-          <OriginMismatchAlert />
-          {noticeMessage && (
-            <Alert variant="destructive">
-              <AlertCircle />
-              <AlertDescription>{noticeMessage}</AlertDescription>
-            </Alert>
-          )}
-          {errorMessage && (
-            <Alert variant="destructive">
-              <AlertCircle />
-              <AlertDescription>{errorMessage}</AlertDescription>
-            </Alert>
-          )}
+        <div className="max-w-xl space-y-4">
+          <p>
+            Sign in with your team&apos;s messaging tool. Email is available
+            below.
+          </p>
 
           <div className="space-y-2">
+            <OriginMismatchAlert />
+            {noticeMessage && (
+              <Alert variant="destructive">
+                <AlertCircle />
+                <AlertDescription>{noticeMessage}</AlertDescription>
+              </Alert>
+            )}
+            {errorMessage && (
+              <Alert variant="destructive">
+                <AlertCircle />
+                <AlertDescription>{errorMessage}</AlertDescription>
+              </Alert>
+            )}
+          </div>
+
+          <div className="max-w-sm space-y-0.5">
             {visibleProviders.map((provider) => {
               const isSubmitting = submittingProvider === provider.id;
 
               return (
                 <Button
-                  className="w-full"
+                  className={cn(
+                    'group flex h-auto w-full py-5',
+                    'hover:bg-foreground hover:text-accent-foreground',
+                  )}
                   disabled={isSubmitting}
                   key={provider.id}
                   onClick={() => void handleSocialSignIn(provider.id)}
                   type="button"
-                  size="lg"
                 >
-                  <span className="flex min-w-0 items-center gap-2">
+                  <span className="flex min-w-0 grow items-center gap-2">
                     {isSubmitting ? (
                       <Spinner />
                     ) : (
                       <AuthProviderIcon provider={provider.icon} />
                     )}
-                    <span className="truncate">
+                    <span className="grow truncate text-left font-medium">
                       Continue with {provider.label}
                     </span>
                   </span>
@@ -190,14 +202,14 @@ export function AuthForm({
           </div>
 
           {visibleProviders.length > 0 && (
-            <div className="flex items-center gap-3 py-1 text-xs text-muted-foreground">
+            <div className="flex max-w-sm items-center gap-3 py-1 text-xs text-muted-foreground">
               <span className="h-px flex-1 bg-border" />
               or
               <span className="h-px flex-1 bg-border" />
             </div>
           )}
 
-          <div className="max-w-xs mx-auto">
+          <div className="max-w-sm">
             <EmailPasswordAuth
               redirectUrl={redirectUrl}
               allowSignUp={canSignUp}
@@ -206,10 +218,14 @@ export function AuthForm({
               defaultMode={
                 canSignUp && searchParams.get('invited') ? 'sign-up' : 'sign-in'
               }
+              submitButtonClassName={cn(
+                'h-auto w-full justify-between py-5',
+                'hover:bg-foreground hover:text-accent-foreground',
+              )}
             />
           </div>
         </div>
-      </Card>
+      </div>
     </main>
   );
 }

--- a/apps/web/src/app/(unauthenticated)/email-password-auth.tsx
+++ b/apps/web/src/app/(unauthenticated)/email-password-auth.tsx
@@ -33,7 +33,6 @@ export function EmailPasswordAuth({
   hideModeSwitchMessage = false,
   showNameField = true,
   submitRowClassName,
-  submitButtonClassName = 'w-full',
   submitLeadingAction,
 }: {
   redirectUrl: string;
@@ -166,11 +165,7 @@ export function EmailPasswordAuth({
 
       <div className={cn('flex items-center gap-2', submitRowClassName)}>
         {submitLeadingAction}
-        <Button
-          className={submitButtonClassName}
-          type="submit"
-          disabled={isSubmitting}
-        >
+        <Button className="w-full" type="submit" disabled={isSubmitting}>
           {isSubmitting ? <Spinner /> : null}
           {mode === 'sign-up' ? 'Create account' : 'Sign in'}
           <ArrowRight />
@@ -178,9 +173,9 @@ export function EmailPasswordAuth({
       </div>
 
       {allowSignUp && showModeToggle && (
-        <button
+        <Button
           type="button"
-          className="w-full text-center text-xs text-muted-foreground underline-offset-4 hover:underline"
+          className="w-full"
           onClick={() => {
             setErrorMessage(null);
             setModeState(mode === 'sign-up' ? 'sign-in' : 'sign-up');
@@ -190,10 +185,10 @@ export function EmailPasswordAuth({
           {mode === 'sign-up'
             ? 'Already have an account? Sign in'
             : 'Need an account? Create one'}
-        </button>
+        </Button>
       )}
       {hideModeSwitchMessage ? null : (
-        <p className="w-full text-center text-xs text-muted-foreground mt-8">
+        <p className="w-full text-sm text-muted-foreground mt-8">
           Need an account? Forgot your password?
           <br />
           Ask your admin.

--- a/apps/web/src/app/(unauthenticated)/email-password-auth.tsx
+++ b/apps/web/src/app/(unauthenticated)/email-password-auth.tsx
@@ -33,6 +33,7 @@ export function EmailPasswordAuth({
   hideModeSwitchMessage = false,
   showNameField = true,
   submitRowClassName,
+  submitButtonClassName,
   submitLeadingAction,
 }: {
   redirectUrl: string;
@@ -165,7 +166,11 @@ export function EmailPasswordAuth({
 
       <div className={cn('flex items-center gap-2', submitRowClassName)}>
         {submitLeadingAction}
-        <Button className="w-full" type="submit" disabled={isSubmitting}>
+        <Button
+          className={cn('w-full', submitButtonClassName)}
+          type="submit"
+          disabled={isSubmitting}
+        >
           {isSubmitting ? <Spinner /> : null}
           {mode === 'sign-up' ? 'Create account' : 'Sign in'}
           <ArrowRight />

--- a/apps/web/src/app/(unauthenticated)/layout.client.test.tsx
+++ b/apps/web/src/app/(unauthenticated)/layout.client.test.tsx
@@ -45,7 +45,7 @@ describe('Unauthenticated layout', () => {
     roomoteWordmarkMock.mockClear();
   });
 
-  it('renders the logged-out shell at full effective viewport height', () => {
+  it('renders the logged-out shell in the setup-style centered frame', () => {
     render(
       <Layout>
         <div>child</div>
@@ -58,9 +58,11 @@ describe('Unauthenticated layout', () => {
     expect(framedSurfaceMock).toHaveBeenCalledWith(
       expect.objectContaining({
         variant: 'bold',
-        frameClassName: expect.stringContaining('items-center justify-center'),
+        frameClassName: expect.stringContaining(
+          'h-[calc(var(--effective-viewport-height)-0.25rem)]',
+        ),
         surfaceClassName: expect.stringContaining(
-          'light flex items-center justify-center text-foreground',
+          'light flex flex-col !overflow-y-auto !overflow-x-hidden text-foreground md:items-center',
         ),
         style: expect.objectContaining({
           height: 'var(--effective-viewport-height)',
@@ -69,15 +71,26 @@ describe('Unauthenticated layout', () => {
       }),
       undefined,
     );
-    expect(screen.getByText('RoomoteWordmark').parentElement).toHaveClass(
+    const contentColumn = screen.getByText('RoomoteWordmark').parentElement;
+    expect(contentColumn).toHaveClass(
       'flex',
-      'max-h-full',
-      'gap-8',
-      'overflow-y-auto',
+      'w-full',
+      'flex-col',
+      'md:my-auto',
+    );
+
+    const centeredShell = contentColumn?.parentElement;
+    expect(centeredShell).toHaveClass('relative', 'max-w-3xl', 'md:min-h-full');
+    expect(centeredShell?.firstElementChild).toHaveClass(
+      'absolute',
+      'inset-y-0',
+      'left-0',
+      'border-l-2',
+      'border-dotted',
     );
     expect(screen.getByText('RoomoteWordmark')).toHaveAttribute(
       'data-wordmark-class-name',
-      expect.stringContaining('shrink-0'),
+      expect.stringContaining('mb-8'),
     );
   });
 });

--- a/apps/web/src/app/(unauthenticated)/layout.tsx
+++ b/apps/web/src/app/(unauthenticated)/layout.tsx
@@ -10,16 +10,19 @@ export default function AuthenticatedLayout({
   return (
     <FramedSurface
       variant="bold"
-      frameClassName="items-center justify-center"
-      surfaceClassName="light flex items-center justify-center text-foreground"
+      frameClassName="h-[calc(var(--effective-viewport-height)-0.25rem)] w-[calc(100svw-0.25rem)] scroll-minimal overflow-hidden"
+      surfaceClassName="light flex flex-col !overflow-y-auto !overflow-x-hidden text-foreground md:items-center"
       style={{
         height: 'var(--effective-viewport-height)',
         minHeight: 'var(--effective-viewport-height)',
       }}
     >
-      <div className="flex max-h-full min-h-0 w-full flex-col items-center gap-8 overflow-y-auto p-4 sm:p-6 lg:p-8">
-        <RoomoteWordmark className="h-20 shrink-0" />
-        {children}
+      <div className="relative flex w-full max-w-3xl flex-col md:min-h-full">
+        <div className="pointer-events-none absolute inset-y-0 left-0 hidden border-black border-l-2 border-dotted md:block" />
+        <div className="flex w-full flex-col px-4 py-6 space-y-4 md:my-auto md:px-0 md:py-10 md:pl-6">
+          <RoomoteWordmark className="mb-8 h-14 w-fit shrink-0" />
+          {children}
+        </div>
       </div>
     </FramedSurface>
   );

--- a/apps/web/src/app/(unauthenticated)/reset-password/page.client.tsx
+++ b/apps/web/src/app/(unauthenticated)/reset-password/page.client.tsx
@@ -11,12 +11,6 @@ import {
   AlertDescription,
   ArrowRight,
   Button,
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
   Input,
   Label,
   Spinner,
@@ -86,25 +80,34 @@ export function ResetPasswordPageClient() {
   };
 
   return (
-    <main className="flex w-full items-center justify-center">
-      <Card className="w-full max-w-md">
-        <CardHeader className="text-center">
-          <CardTitle>Reset password</CardTitle>
-          <CardDescription>
-            Choose a new password for your Roomote account.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
+    <main className="flex w-full">
+      <div className="relative w-full max-w-2xl space-y-6 py-2 text-left md:py-0">
+        <h1 className="relative text-3xl font-bold tracking-tighter">
+          <span className="relative flex items-center gap-3">
+            Reset password
+          </span>
+        </h1>
+        <div className="max-w-xl space-y-4">
+          <p>Choose a new password for your Roomote account.</p>
+
           {isInvalidToken ? (
-            <Alert variant="destructive">
-              <AlertCircle />
-              <AlertDescription>
-                This reset link is invalid or expired. Ask an admin to create a
-                new password reset link.
-              </AlertDescription>
-            </Alert>
+            <div className="max-w-sm space-y-3">
+              <Alert variant="destructive">
+                <AlertCircle />
+                <AlertDescription>
+                  This reset link is invalid or expired. Ask an admin to create
+                  a new password reset link.
+                </AlertDescription>
+              </Alert>
+              <Button asChild variant="outline" className="w-full">
+                <Link href="/sign-in">Back to sign in</Link>
+              </Button>
+            </div>
           ) : (
-            <form className="space-y-3 mx-auto w-80" onSubmit={handleSubmit}>
+            <form
+              className="max-w-sm space-y-3 text-left"
+              onSubmit={handleSubmit}
+            >
               {errorMessage ? (
                 <Alert variant="destructive">
                   <AlertCircle />
@@ -149,15 +152,8 @@ export function ResetPasswordPageClient() {
               </Button>
             </form>
           )}
-        </CardContent>
-        {isInvalidToken ? (
-          <CardFooter align="center">
-            <Button asChild variant="outline">
-              <Link href="/sign-in">Back to sign in</Link>
-            </Button>
-          </CardFooter>
-        ) : null}
-      </Card>
+        </div>
+      </div>
     </main>
   );
 }

--- a/apps/web/src/components/settings/CommsProviderSection.test.tsx
+++ b/apps/web/src/components/settings/CommsProviderSection.test.tsx
@@ -1,4 +1,9 @@
-import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import type {
+  AnchorHTMLAttributes,
+  ButtonHTMLAttributes,
+  ReactElement,
+  ReactNode,
+} from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { CommsProviderSection } from './CommsProviderSection';
@@ -188,11 +193,28 @@ vi.mock('@/components/system', () => ({
   BrandIcon: ({ icon }: { icon: string }) => (
     <svg aria-label={icon} role="img" />
   ),
-  Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
-    <button type="button" {...props}>
-      {children}
-    </button>
-  ),
+  Button: ({
+    asChild,
+    children,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement> & {
+    asChild?: boolean;
+    children: ReactNode;
+  }) => {
+    if (asChild) {
+      const child = children as ReactElement<
+        AnchorHTMLAttributes<HTMLAnchorElement>
+      >;
+
+      return <a {...child.props}>{child.props.children}</a>;
+    }
+
+    return (
+      <button type="button" {...props}>
+        {children}
+      </button>
+    );
+  },
   Card: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   CardAction: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   CardContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -223,13 +245,27 @@ vi.mock('@/components/system', () => ({
   ),
   DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
   Download: () => <svg aria-hidden="true" />,
-  EnvVarsInfoNote: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
+  EnvVarsInfoNote: ({
+    children,
+    runtimeConfigured,
+  }: {
+    children?: ReactNode;
+    runtimeConfigured?: boolean;
+  }) => (
+    <div>
+      {children ??
+        (runtimeConfigured
+          ? "These values are being passed via ENV vars and can't be overridden here."
+          : "You can pass these in as ENV vars. When configured here, they're encrypted in the database.")}
+    </div>
   ),
   ExternalLink: () => <svg aria-hidden="true" />,
   Info: () => <svg aria-hidden="true" />,
-  Input: (props: ButtonHTMLAttributes<HTMLInputElement>) => (
-    <input {...(props as object)} />
+  Input: ({
+    secret: _secret,
+    ...props
+  }: ButtonHTMLAttributes<HTMLInputElement> & { secret?: boolean }) => (
+    <input {...props} />
   ),
   Label: ({ children }: { children: ReactNode }) => <label>{children}</label>,
   Pencil: () => <svg aria-hidden="true" />,
@@ -265,7 +301,21 @@ vi.mock('@/lib/slack-callback-paths', () => ({
   SLACK_SIGN_IN_CALLBACK_PATH: '/api/slack/signin',
 }));
 vi.mock('@/app/(onboarding)/setup/providerSetupCopy', () => ({
-  getProviderSetupCopy: () => null,
+  getProviderSetupCopy: (providerId: 'slack' | 'microsoft' | 'telegram') =>
+    ({
+      slack: {
+        creationHref: 'https://api.slack.com/apps?new_app=1',
+        setupLabel: 'Slack app',
+      },
+      microsoft: {
+        creationHref: 'https://portal.azure.com/apps',
+        setupLabel: 'Microsoft Teams app',
+      },
+      telegram: {
+        creationHref: 'https://t.me/BotFather',
+        setupLabel: 'Telegram bot',
+      },
+    })[providerId],
 }));
 vi.mock('@/lib/settings', () => ({
   SETTINGS_PATHS: {
@@ -396,6 +446,49 @@ function buildMicrosoftProvider(
   };
 }
 
+function buildTelegramProvider(
+  overrides: Partial<CommsProviderStatus> = {},
+): CommsProviderStatus {
+  return {
+    id: 'telegram',
+    label: 'Telegram',
+    fields: [
+      {
+        envVarName: 'TELEGRAM_BOT_TOKEN',
+        acceptedEnvVarNames: ['TELEGRAM_BOT_TOKEN'],
+        label: 'Telegram Bot Token',
+        secret: true,
+        runtimeSatisfied: false,
+        savedSatisfied: false,
+        satisfiedByEnvVarName: null,
+      },
+      {
+        envVarName: 'TELEGRAM_WEBHOOK_SECRET',
+        acceptedEnvVarNames: ['TELEGRAM_WEBHOOK_SECRET'],
+        label: 'Telegram Webhook Secret',
+        secret: true,
+        runtimeSatisfied: false,
+        savedSatisfied: false,
+        satisfiedByEnvVarName: null,
+      },
+      {
+        envVarName: 'TELEGRAM_BOT_USERNAME',
+        acceptedEnvVarNames: ['TELEGRAM_BOT_USERNAME'],
+        label: 'Telegram Bot Username',
+        required: false,
+        runtimeSatisfied: false,
+        savedSatisfied: false,
+        satisfiedByEnvVarName: null,
+      },
+    ],
+    runtimeSatisfied: false,
+    savedSatisfied: false,
+    setupSatisfied: false,
+    telegramWebhook: null,
+    ...overrides,
+  };
+}
+
 describe('CommsProviderSection', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -426,6 +519,106 @@ describe('CommsProviderSection', () => {
     state.slackChannelsIsError = false;
     state.slackChannelsIsFetching = false;
     state.updateRouterDebugIsPending = false;
+  });
+
+  describe('numbered setup instructions', () => {
+    it('shows the Slack create-app screen first, then numbered manual setup in settings', () => {
+      render(
+        <CommsProviderSection
+          provider={buildSlackProvider()}
+          onSave={vi.fn()}
+          onClear={vi.fn()}
+          savePending={false}
+          clearPending={false}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Set it up' }));
+
+      expect(
+        screen.queryByRole('heading', { name: 'Create Slack app' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: 'Create Slack app' }),
+      ).toBeInTheDocument();
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /Enter values manually/ }),
+      );
+
+      expect(
+        screen.queryByRole('heading', { name: 'Configure Slack app' }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText('1')).toBeInTheDocument();
+      expect(screen.getByText('2')).toBeInTheDocument();
+      expect(screen.getByText('3')).toBeInTheDocument();
+      expect(screen.getByText(/Create a new Slack app/)).toBeInTheDocument();
+      expect(screen.getByText('Authorized redirect URLs')).toBeInTheDocument();
+      expect(screen.getByText('Enter the values below:')).toBeInTheDocument();
+    });
+
+    it('shows numbered Microsoft setup with the settings env-var note', () => {
+      render(
+        <CommsProviderSection
+          provider={buildMicrosoftProvider()}
+          onSave={vi.fn()}
+          onClear={vi.fn()}
+          savePending={false}
+          clearPending={false}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Set it up' }));
+
+      expect(
+        screen.queryByRole('heading', {
+          name: 'Configure Microsoft Teams app',
+        }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByText('Create a Microsoft Entra app.'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('Enter the Microsoft app generated values.'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('Upload Roomote to Microsoft Teams.'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('Add the Teams bot capability to that app.'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "You can pass these in as ENV vars. When configured here, they're encrypted in the database.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('shows numbered Telegram setup with the settings-only webhook note', () => {
+      render(
+        <CommsProviderSection
+          provider={buildTelegramProvider()}
+          onSave={vi.fn()}
+          onClear={vi.fn()}
+          savePending={false}
+          clearPending={false}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Set it up' }));
+
+      expect(
+        screen.queryByRole('heading', { name: 'Configure Telegram bot' }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText(/Create a new Telegram bot/)).toBeInTheDocument();
+      expect(screen.getByText('Create bot')).toBeInTheDocument();
+      expect(screen.getByText('Bot token')).toBeInTheDocument();
+      expect(screen.getByText('Webhook')).toBeInTheDocument();
+      expect(screen.getByText('Enter the values below:')).toBeInTheDocument();
+      expect(
+        screen.getByText(/Roomote will generate the webhook secret/),
+      ).toBeInTheDocument();
+    });
   });
 
   describe('Slack workspace auth button', () => {
@@ -588,10 +781,10 @@ describe('CommsProviderSection', () => {
       expect(
         screen.getByText(/Team members can link Microsoft Teams accounts/),
       ).toBeInTheDocument();
-      expect(screen.getByText('Teams Bot App ID')).toBeInTheDocument();
+      expect(screen.queryByText('Teams Bot App ID')).toBeNull();
       expect(screen.queryByText('Teams Bot App ID (optional)')).toBeNull();
       expect(
-        screen.getByRole('button', { name: /Open in Teams/ }),
+        screen.getByRole('link', { name: /Open in Teams/ }),
       ).toBeInTheDocument();
     });
 
@@ -641,10 +834,10 @@ describe('CommsProviderSection', () => {
         screen.getByText(/Bot configured for incoming Teams messages/),
       ).toBeInTheDocument();
       expect(
-        screen.getByRole('button', { name: /Open in Teams/ }),
+        screen.getByRole('link', { name: /Open in Teams/ }),
       ).toBeInTheDocument();
       expect(
-        screen.getByRole('button', { name: /Download Teams app package/ }),
+        screen.getByRole('link', { name: /Download Teams app package/ }),
       ).toBeInTheDocument();
     });
   });

--- a/apps/web/src/components/settings/CommsProviderSection.tsx
+++ b/apps/web/src/components/settings/CommsProviderSection.tsx
@@ -14,6 +14,12 @@ import {
 } from '@/hooks/slack';
 import { useTeamsIntegrationStatus } from '@/hooks/teams';
 import { SETTINGS_PATHS } from '@/lib/settings';
+import {
+  getSetupEffectiveFieldValue,
+  getSetupSubmitValues,
+  getSetupVisibleFields,
+  ProviderSetupExperience,
+} from '@/app/(onboarding)/setup/ProviderSetupExperience';
 
 type CommsProviderId = SetupAuthProviderStatus['id'] | 'telegram';
 type TelegramWebhookStatus = {
@@ -53,12 +59,6 @@ const TELEGRAM_WEBHOOK_STATUS_COPY: Record<
   },
 };
 
-import { buildSlackManifestPrefillUrl } from '@/lib/slack-app-manifest';
-import {
-  hasProviderSetupInstructions,
-  ProviderSetupInstructions,
-} from '@/app/(onboarding)/setup/ProviderSetupInstructions';
-import { getProviderSetupCopy } from '@/app/(onboarding)/setup/providerSetupCopy';
 import {
   ArrowLeft,
   BrandIcon,
@@ -70,19 +70,14 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  Download,
-  EnvVarsInfoNote,
   ExternalLink,
   Info,
-  Input,
-  Pencil,
   Plug,
   RefreshCw,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
-  Sparkles,
   Spinner,
   Trash2,
   TriangleAlert,
@@ -90,7 +85,8 @@ import {
 import { Section } from './Section';
 import { TelegramLinkAccountStep } from './TelegramLinkAccountStep';
 
-const MASKED_VALUE = '••••••••••••••••••••••••••••';
+const MICROSOFT_APP_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function getProviderIconId(providerId: CommsProviderId): string {
   return providerId === 'microsoft' ? 'teams' : providerId;
@@ -495,12 +491,16 @@ export function CommsProviderSection({
   const [editingSavedValues, setEditingSavedValues] = useState<
     Record<string, boolean>
   >({});
+  const [clearedSavedValues, setClearedSavedValues] = useState<
+    Record<string, boolean>
+  >({});
   const [showManualSlackValues, setShowManualSlackValues] = useState(false);
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
 
   useEffect(() => {
     setValues({});
     setEditingSavedValues({});
+    setClearedSavedValues({});
     setShowManualSlackValues(false);
     setRemoveDialogOpen(false);
   }, [provider.id, provider.runtimeSatisfied, provider.savedSatisfied]);
@@ -518,33 +518,30 @@ export function CommsProviderSection({
     teamsBotConfigured,
   ]);
 
-  const providerSetupCopy = getProviderSetupCopy(provider.id);
-  const providerSetupLabel =
-    providerSetupCopy?.setupLabel ?? `${provider.label}`;
   const publicOrigin =
     typeof window === 'undefined'
       ? 'https://your-deployment-url'
       : window.location.origin;
-  const slackManifestPrefillUrl =
-    provider.id === 'slack'
-      ? buildSlackManifestPrefillUrl({ publicOrigin })
-      : null;
+  const visibleFields = getSetupVisibleFields(provider);
 
-  const showProviderSetupInstructions = hasProviderSetupInstructions(
-    provider.id,
-  );
-
-  const hasPendingValueChanges = provider.fields.some((field) => {
+  const hasPendingValueChanges = visibleFields.some((field) => {
     const nextValue = values[field.envVarName]?.trim() ?? '';
-    return !field.runtimeSatisfied && nextValue.length > 0;
+    return (
+      !field.runtimeSatisfied &&
+      (nextValue.length > 0 || Boolean(clearedSavedValues[field.envVarName]))
+    );
   });
 
-  const hasMissingRequiredValue = provider.fields.some((field) => {
-    const nextValue = values[field.envVarName]?.trim() ?? '';
+  const hasMissingRequiredValue = visibleFields.some((field) => {
+    const nextValue = getSetupEffectiveFieldValue({
+      provider,
+      field,
+      values,
+    }).trim();
     return (
       field.required !== false &&
       !field.runtimeSatisfied &&
-      !field.savedSatisfied &&
+      (!field.savedSatisfied || clearedSavedValues[field.envVarName]) &&
       nextValue.length === 0
     );
   });
@@ -553,15 +550,42 @@ export function CommsProviderSection({
 
   const hasConfiguredValues =
     provider.runtimeSatisfied || provider.savedSatisfied;
-  const hasEditableFields = provider.fields.some(
+  const hasEditableFields = visibleFields.some(
     (field) => !field.runtimeSatisfied,
   );
-
-  const isSlackCreateAppStep =
+  const providerOwnsActions =
     provider.id === 'slack' && !showManualSlackValues && !hasConfiguredValues;
 
+  const teamsBotAppIdField = provider.fields.find(
+    (field) => field.envVarName === 'TEAMS_BOT_APP_ID',
+  );
+  const enteredTeamsBotAppId =
+    isMicrosoftProvider && teamsBotAppIdField
+      ? getSetupEffectiveFieldValue({
+          provider,
+          field: teamsBotAppIdField,
+          values,
+        }).trim()
+      : '';
+  const typedTeamsBotAppId = MICROSOFT_APP_ID_PATTERN.test(enteredTeamsBotAppId)
+    ? enteredTeamsBotAppId
+    : '';
+  const teamsBotAppIdStored = isMicrosoftProvider
+    ? provider.fields.some(
+        (field) =>
+          (field.envVarName === 'TEAMS_BOT_APP_ID' ||
+            field.envVarName === 'ROOMOTE_AUTH_MICROSOFT_CLIENT_ID') &&
+          (field.runtimeSatisfied || field.savedSatisfied),
+      )
+    : false;
+  const teamsAppPackageHref = typedTeamsBotAppId
+    ? `/api/setup/teams-app-package?botAppId=${encodeURIComponent(typedTeamsBotAppId)}`
+    : teamsBotAppIdStored || teamsBotConfigured
+      ? '/api/teams/app-package'
+      : null;
+
   const handleSave = () => {
-    onSave(provider.id, values);
+    onSave(provider.id, getSetupSubmitValues({ provider, values }));
   };
 
   const handleRemove = () => {
@@ -596,250 +620,111 @@ export function CommsProviderSection({
               Set it up
             </button>
           </p>
-        ) : isSlackCreateAppStep ? (
-          <div className="space-y-3 max-w-xl py-2">
-            <p className="text-sm">
-              Create a Slack app from Roomote&apos;s manifest, then enter the
-              generated configuration values here.
-            </p>
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-              <Button asChild>
-                <a
-                  href={slackManifestPrefillUrl ?? 'https://api.slack.com/apps'}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={() => setShowManualSlackValues(true)}
-                >
-                  <Sparkles />
-                  Create Slack app
-                </a>
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => setShowManualSlackValues(true)}
-              >
-                <Pencil />
-                Enter values manually
-              </Button>
-            </div>
-          </div>
         ) : (
           <div className="space-y-8">
-            {!hasConfiguredValues && (
-              <div>
-                <p className="font-semibold text-sm">
-                  {providerSetupCopy ? (
-                    <>
-                      Create a new{' '}
-                      <a
-                        href={providerSetupCopy.creationHref}
-                        target="_blank"
-                        rel="noopener noreferrer underline"
-                      >
-                        {providerSetupCopy.setupLabel}.
-                        <ExternalLink className="inline size-4 -mt-1 ml-1" />
-                      </a>
-                    </>
+            <ProviderSetupExperience
+              provider={provider}
+              values={values}
+              publicOrigin={publicOrigin}
+              disabled={savePending}
+              editingSavedValues={editingSavedValues}
+              clearedSavedValues={clearedSavedValues}
+              teamsAppPackageHref={teamsAppPackageHref}
+              showManualSlackValues={showManualSlackValues}
+              surface="settings"
+              envVarsInfoNote={
+                !provider.runtimeSatisfied && provider.id === 'telegram'
+                  ? 'Roomote will generate the webhook secret if you leave it blank, register the webhook automatically when you save, and default Telegram task launches to the admin who saves this configuration.'
+                  : undefined
+              }
+              onShowManualSlackValues={() => setShowManualSlackValues(true)}
+              onValueChange={(envVarName, value) =>
+                setValues((current) => ({ ...current, [envVarName]: value }))
+              }
+              onEditingSavedValueChange={(envVarName, editing) =>
+                setEditingSavedValues((current) => ({
+                  ...current,
+                  [envVarName]: editing,
+                }))
+              }
+              onClearedSavedValueChange={(envVarName, cleared) =>
+                setClearedSavedValues((current) => ({
+                  ...current,
+                  [envVarName]: cleared,
+                }))
+              }
+            />
+
+            <div className="space-y-2 text-sm text-muted-foreground">
+              {provider.id === 'telegram' && provider.telegramWebhook && (
+                <div className="flex items-start gap-2 mt-4">
+                  {TELEGRAM_WEBHOOK_STATUS_COPY[provider.telegramWebhook.status]
+                    .tone === 'ok' ? (
+                    <Check className="inline size-4 mt-0.5 shrink-0 text-green-600" />
                   ) : (
-                    <>create a new {providerSetupLabel}.</>
+                    <Info className="inline size-4 mt-0.5 shrink-0 text-amber-600" />
                   )}
-                </p>
-                <p className="text-sm text-muted-foreground mt-1">
-                  If you need our logo,{' '}
-                  <Link
-                    className="underline underline-offset-4 hover:text-foreground"
-                    href="/api/setup/roomote-logo"
-                  >
-                    download here
-                  </Link>
-                  .
-                </p>
-              </div>
-            )}
-
-            {showProviderSetupInstructions && (
-              <ProviderSetupInstructions
-                providerId={provider.id}
-                publicOrigin={publicOrigin}
-              />
-            )}
-
-            <div className="flex gap-2 items-start">
-              <div>
-                <p className="font-semibold text-sm">
-                  {hasConfiguredValues
-                    ? 'Configuration values'
-                    : 'Enter the values below:'}
-                </p>
-                <div className="space-y-2 mt-2">
-                  {provider.fields.map((field) => {
-                    const value = values[field.envVarName] ?? '';
-                    const shouldShowSavedValueMask =
-                      !field.runtimeSatisfied &&
-                      field.savedSatisfied &&
-                      value.length === 0 &&
-                      !editingSavedValues[field.envVarName];
-
-                    return (
-                      <div
-                        key={field.envVarName}
-                        className="grid gap-2 md:grid-cols-[180px_minmax(0,1fr)] md:items-center max-w-xl"
-                      >
-                        <div className="space-y-1">
-                          <div className="text-sm font-medium">
-                            {field.label}
-                            {field.required === false ? ' (optional)' : ''}
-                          </div>
-                        </div>
-                        <div>
-                          <div className="flex items-center gap-2">
-                            <Input
-                              secret={field.secret && !field.runtimeSatisfied}
-                              className="font-mono"
-                              value={
-                                field.runtimeSatisfied
-                                  ? MASKED_VALUE
-                                  : shouldShowSavedValueMask
-                                    ? MASKED_VALUE
-                                    : value
-                              }
-                              onFocus={() => {
-                                if (shouldShowSavedValueMask) {
-                                  setEditingSavedValues((current) => ({
-                                    ...current,
-                                    [field.envVarName]: true,
-                                  }));
-                                }
-                              }}
-                              onBlur={() => {
-                                if (
-                                  field.savedSatisfied &&
-                                  value.length === 0
-                                ) {
-                                  setEditingSavedValues((current) => ({
-                                    ...current,
-                                    [field.envVarName]: false,
-                                  }));
-                                }
-                              }}
-                              onChange={(event) => {
-                                const nextValue = event.target.value;
-                                setValues((current) => ({
-                                  ...current,
-                                  [field.envVarName]: nextValue,
-                                }));
-                              }}
-                              placeholder={
-                                field.runtimeSatisfied ? '' : field.label
-                              }
-                              disabled={savePending || field.runtimeSatisfied}
-                              data-1p-ignore
-                            />
-                            {(field.runtimeSatisfied ||
-                              field.savedSatisfied) && <Check />}
-                          </div>
-                        </div>
-                      </div>
-                    );
-                  })}
-
-                  <div className="space-y-2 text-sm text-muted-foreground">
-                    {provider.id === 'telegram' && provider.telegramWebhook && (
-                      <div className="flex items-start gap-2 mt-4">
-                        {TELEGRAM_WEBHOOK_STATUS_COPY[
-                          provider.telegramWebhook.status
-                        ].tone === 'ok' ? (
-                          <Check className="inline size-4 mt-0.5 shrink-0 text-green-600" />
-                        ) : (
-                          <Info className="inline size-4 mt-0.5 shrink-0 text-amber-600" />
-                        )}
-                        <p className="text-sm">
-                          {
-                            TELEGRAM_WEBHOOK_STATUS_COPY[
-                              provider.telegramWebhook.status
-                            ].label
-                          }
-                          {provider.telegramWebhook.lastErrorMessage
-                            ? ` Last delivery error: ${provider.telegramWebhook.lastErrorMessage}`
-                            : ''}
-                        </p>
-                      </div>
-                    )}
-                    {provider.id === 'telegram' && hasConfiguredValues && (
-                      <TelegramLinkAccountStep />
-                    )}
-                    {provider.id === 'microsoft' &&
-                      (hasConfiguredValues || teamsBotConfigured) && (
-                        <div className="space-y-2 mt-4">
-                          <p className="text-sm">
-                            Download the Teams app package (manifest + icons)
-                            and upload it in Teams under Apps → Manage your apps
-                            → Upload an app, or import it in the Developer
-                            Portal.
-                          </p>
-                          <Button asChild variant="outline" size="sm">
-                            <a href="/api/teams/app-package" download>
-                              <Download />
-                              Download Teams app package
-                            </a>
-                          </Button>
-                        </div>
-                      )}
-                    {provider.id === 'microsoft' &&
-                      (hasConfiguredValues || teamsBotConfigured) && (
-                        <TeamsBotStatus />
-                      )}
-                    {provider.id === 'slack' && hasConfiguredValues && (
-                      <SlackDiagnosticsChannel />
-                    )}
-                    <EnvVarsInfoNote
-                      runtimeConfigured={provider.runtimeSatisfied}
-                    >
-                      {!provider.runtimeSatisfied && provider.id === 'telegram'
-                        ? 'Roomote will generate the webhook secret if you leave it blank, register the webhook automatically when you save, and default Telegram task launches to the admin who saves this configuration.'
-                        : undefined}
-                    </EnvVarsInfoNote>
-                  </div>
+                  <p className="text-sm">
+                    {
+                      TELEGRAM_WEBHOOK_STATUS_COPY[
+                        provider.telegramWebhook.status
+                      ].label
+                    }
+                    {provider.telegramWebhook.lastErrorMessage
+                      ? ` Last delivery error: ${provider.telegramWebhook.lastErrorMessage}`
+                      : ''}
+                  </p>
                 </div>
-              </div>
+              )}
+              {provider.id === 'telegram' && hasConfiguredValues && (
+                <TelegramLinkAccountStep />
+              )}
+              {provider.id === 'microsoft' &&
+                (hasConfiguredValues || teamsBotConfigured) && (
+                  <TeamsBotStatus />
+                )}
+              {provider.id === 'slack' && hasConfiguredValues && (
+                <SlackDiagnosticsChannel />
+              )}
             </div>
 
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-              {provider.id === 'slack' && !hasConfiguredValues && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setShowManualSlackValues(false)}
-                >
-                  <ArrowLeft />
-                  Back
-                </Button>
-              )}
-              {provider.savedSatisfied && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setRemoveDialogOpen(true)}
-                  disabled={clearPending}
-                >
-                  <Trash2 />
-                  {clearPending ? 'Removing...' : 'Remove'}
-                  {clearPending ? <Spinner /> : null}
-                </Button>
-              )}
-              {hasEditableFields && (
-                <Button
-                  type="button"
-                  onClick={handleSave}
-                  disabled={isActionDisabled || savePending}
-                >
-                  <Check />
-                  {savePending ? 'Saving...' : 'Save'}
-                  {savePending ? <Spinner /> : null}
-                </Button>
-              )}
-            </div>
+            {providerOwnsActions ? null : (
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                {provider.id === 'slack' && !hasConfiguredValues && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => setShowManualSlackValues(false)}
+                  >
+                    <ArrowLeft />
+                    Back
+                  </Button>
+                )}
+                {provider.savedSatisfied && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => setRemoveDialogOpen(true)}
+                    disabled={clearPending}
+                  >
+                    <Trash2 />
+                    {clearPending ? 'Removing...' : 'Remove'}
+                    {clearPending ? <Spinner /> : null}
+                  </Button>
+                )}
+                {hasEditableFields && (
+                  <Button
+                    type="button"
+                    onClick={handleSave}
+                    disabled={isActionDisabled || savePending}
+                  >
+                    <Check />
+                    {savePending ? 'Saving...' : 'Save'}
+                    {savePending ? <Spinner /> : null}
+                  </Button>
+                )}
+              </div>
+            )}
           </div>
         )}
       </Section>

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -6,11 +6,13 @@ import { genericOAuthClient } from 'better-auth/client/plugins';
 type BaseAuthClient = ReturnType<typeof createAuthClient>;
 type OAuth2SignInInput = {
   callbackURL?: string;
+  disableRedirect?: boolean;
   providerId: string;
 };
-type OAuth2SignInResult = Awaited<
-  ReturnType<BaseAuthClient['signIn']['social']>
->;
+type OAuth2SignInResult = {
+  data?: { redirect?: boolean; url?: string } | null;
+  error?: { code?: string; message?: string; status?: number } | null;
+};
 type OAuth2LinkInput = {
   callbackURL: string;
   errorCallbackURL?: string;

--- a/apps/web/src/lib/server/__tests__/access-policy.test.ts
+++ b/apps/web/src/lib/server/__tests__/access-policy.test.ts
@@ -192,6 +192,17 @@ describe('evaluateSignInAccess', () => {
     ).resolves.toEqual({ allowed: true, via: 'org_membership' });
   });
 
+  it('treats a setup-token Microsoft sign-in as bootstrap before org membership', async () => {
+    mockEnvState.SETUP_TOKEN = 'setup-secret';
+    mockInviteState.requestToken = 'setup-secret';
+    mockSetupBootstrapState.open = true;
+
+    await expect(
+      evaluateSignInAccess({ userId: 'user-2', email: 'admin@example.com' }),
+    ).resolves.toEqual({ allowed: true, via: 'bootstrap' });
+    expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+
   it('admits invite holders and reports the invite id', async () => {
     mockInviteState.requestToken = 'invite-token';
     mockInviteState.usableInvite = { id: 'invite-1' };

--- a/apps/web/src/lib/server/__tests__/access-policy.test.ts
+++ b/apps/web/src/lib/server/__tests__/access-policy.test.ts
@@ -44,6 +44,8 @@ vi.mock('@roomote/db/server', () => ({
   },
   eq: vi.fn(),
   isNull: vi.fn(),
+  ne: vi.fn(),
+  not: vi.fn(),
   slackInstallations: { teamId: 'team_id', isActive: 'is_active' },
   users: { id: 'users.id' },
 }));
@@ -158,6 +160,7 @@ describe('evaluateSignInAccess', () => {
   });
 
   it('admits existing members', async () => {
+    queueWhereLimitSelect([{ id: 'other-user' }]); // hasAnyOtherRealAppUser
     queueWhereLimitSelect([{ id: 'user-1' }]); // hasExistingAppUser
 
     await expect(
@@ -166,6 +169,7 @@ describe('evaluateSignInAccess', () => {
   });
 
   it('admits slack users from the anchored workspace', async () => {
+    queueWhereLimitSelect([{ id: 'founding-user' }]); // hasAnyOtherRealAppUser
     queueWhereLimitSelect([]); // hasExistingAppUser -> none
     queueWhereSelect([
       {
@@ -181,6 +185,7 @@ describe('evaluateSignInAccess', () => {
   });
 
   it('admits microsoft users because the tenant is enforced at OAuth', async () => {
+    queueWhereLimitSelect([{ id: 'founding-user' }]); // hasAnyOtherRealAppUser
     queueWhereLimitSelect([]); // hasExistingAppUser
     queueWhereSelect([
       { providerId: 'microsoft-entra-id', idToken: fakeJwt({ tid: 't' }) },
@@ -207,8 +212,8 @@ describe('evaluateSignInAccess', () => {
     mockInviteState.requestToken = 'invite-token';
     mockInviteState.usableInvite = { id: 'invite-1' };
 
+    queueWhereLimitSelect([{ id: 'founding-user' }]); // hasAnyOtherRealAppUser
     queueWhereLimitSelect([]); // hasExistingAppUser
-    queueWhereSelect([]); // accounts (none)
 
     await expect(
       evaluateSignInAccess({ userId: 'user-3', email: 'new@example.com' }),
@@ -269,12 +274,21 @@ describe('evaluateSignInAccess', () => {
 
   it('admits the first sign-in in local development when no setup token is configured', async () => {
     vi.stubEnv('APP_ENV', 'development');
-    queueWhereLimitSelect([]); // hasExistingAppUser
-    queueWhereSelect([]); // accounts
+    queueWhereLimitSelect([]); // hasAnyOtherRealAppUser
 
     await expect(
       evaluateSignInAccess({ userId: 'user-1', email: 'dev@example.com' }),
     ).resolves.toEqual({ allowed: true, via: 'bootstrap' });
+  });
+
+  it('treats local tokenless Microsoft setup as bootstrap before org membership', async () => {
+    vi.stubEnv('APP_ENV', 'development');
+    queueWhereLimitSelect([]); // hasAnyOtherRealAppUser
+
+    await expect(
+      evaluateSignInAccess({ userId: 'user-2', email: 'admin@example.com' }),
+    ).resolves.toEqual({ allowed: true, via: 'bootstrap' });
+    expect(mockDbSelect).toHaveBeenCalledTimes(1);
   });
 
   it('denies the first sign-in on a non-local deployment when no setup token is configured', async () => {

--- a/apps/web/src/lib/server/__tests__/teams-app-package.test.ts
+++ b/apps/web/src/lib/server/__tests__/teams-app-package.test.ts
@@ -121,8 +121,18 @@ describe('buildTeamsAppManifest', () => {
         appUrl: 'https://roomote.example.com',
       }),
     ) as {
+      $schema: string;
+      manifestVersion: string;
       id: string;
-      bots: Array<{ botId: string; scopes: string[] }>;
+      packageName?: string;
+      accentColor: string;
+      bots: Array<{
+        botId: string;
+        scopes: string[];
+        supportsFiles: boolean;
+      }>;
+      supportedChannelTypes?: string[];
+      supportsChannelFeatures: string;
       validDomains: string[];
       icons: { color: string; outline: string };
       developer: { websiteUrl: string };
@@ -135,11 +145,20 @@ describe('buildTeamsAppManifest', () => {
       };
     };
 
+    expect(manifest.$schema).toBe(
+      'https://developer.microsoft.com/en-us/json-schemas/teams/v1.25/MicrosoftTeams.schema.json',
+    );
+    expect(manifest.manifestVersion).toBe('1.25');
     expect(manifest.id).toBe('5037b551-0000-0000-0000-000000000000');
+    expect(manifest.packageName).toBeUndefined();
+    expect(manifest.accentColor).toBe('#d6ee26');
     expect(manifest.bots[0]).toMatchObject({
       botId: '5037b551-0000-0000-0000-000000000000',
       scopes: ['personal', 'team', 'groupChat'],
+      supportsFiles: true,
     });
+    expect(manifest.supportedChannelTypes).toBeUndefined();
+    expect(manifest.supportsChannelFeatures).toBe('tier1');
     expect(manifest.validDomains).toEqual(['roomote.example.com']);
     expect(manifest.icons).toEqual({
       color: 'color.png',
@@ -151,8 +170,14 @@ describe('buildTeamsAppManifest', () => {
       resource: 'https://roomote.example.com',
     });
     expect(manifest.authorization.permissions.resourceSpecific).toEqual([
+      { name: 'Channel.Create.Group', type: 'Application' },
+      { name: 'ChannelMember.Read.Group', type: 'Application' },
       { name: 'ChannelMessage.Read.Group', type: 'Application' },
+      { name: 'ChannelMessage.Send.Group', type: 'Application' },
+      { name: 'ChannelSettings.Read.Group', type: 'Application' },
       { name: 'ChatMessage.Read.Chat', type: 'Application' },
+      { name: 'ChatMessage.Send.Chat', type: 'Application' },
+      { name: 'Member.Read.Group', type: 'Application' },
     ]);
     expect(manifest.description.full).toContain(
       'receives channel and chat messages',

--- a/apps/web/src/lib/server/access-policy.ts
+++ b/apps/web/src/lib/server/access-policy.ts
@@ -5,6 +5,8 @@ import {
   deploymentSettings,
   eq,
   isNull,
+  ne,
+  not,
   slackInstallations,
   users,
 } from '@roomote/db/server';
@@ -22,6 +24,7 @@ import { isSetupBootstrapOpen } from './setup-bootstrap';
 import { isSetupTokenValid } from './setup-token';
 
 const DEFAULT_DEPLOYMENT_ID = 'default';
+const SETUP_BOOTSTRAP_USER_ID = 'setup-bootstrap-user';
 const SLACK_TEAM_ID_CLAIM = 'https://slack.com/team_id';
 const MICROSOFT_ENTRA_PROVIDER_ID = 'microsoft-entra-id';
 
@@ -90,6 +93,18 @@ async function hasExistingAppUser(userId: string): Promise<boolean> {
     .select({ id: users.id })
     .from(users)
     .where(and(eq(users.id, userId), isNull(users.deletedAt)))
+    .limit(1);
+
+  return existingUser != null;
+}
+
+async function hasAnyOtherRealAppUser(userId: string): Promise<boolean> {
+  const [existingUser] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(
+      and(ne(users.id, SETUP_BOOTSTRAP_USER_ID), not(eq(users.id, userId))),
+    )
     .limit(1);
 
   return existingUser != null;
@@ -181,12 +196,17 @@ export async function evaluateSignInAccess({
     }
   }
 
-  if (await hasExistingAppUser(userId)) {
-    return { allowed: true, via: 'existing_user' };
+  if (
+    setupBootstrapOpen &&
+    !Env.SETUP_TOKEN &&
+    isSetupTokenValid(undefined) &&
+    !(await hasAnyOtherRealAppUser(userId))
+  ) {
+    return { allowed: true, via: 'bootstrap' };
   }
 
-  if (await isUserInProviderOrg(userId)) {
-    return { allowed: true, via: 'org_membership' };
+  if (await hasExistingAppUser(userId)) {
+    return { allowed: true, via: 'existing_user' };
   }
 
   const invite = await findUsableInviteByToken(inviteToken);
@@ -195,8 +215,8 @@ export async function evaluateSignInAccess({
     return { allowed: true, via: 'invite', inviteId: invite.id };
   }
 
-  if (setupBootstrapOpen && isSetupTokenValid(undefined)) {
-    return { allowed: true, via: 'bootstrap' };
+  if (await isUserInProviderOrg(userId)) {
+    return { allowed: true, via: 'org_membership' };
   }
 
   return { allowed: false };

--- a/apps/web/src/lib/server/access-policy.ts
+++ b/apps/web/src/lib/server/access-policy.ts
@@ -166,22 +166,10 @@ export async function evaluateSignInAccess({
     return { allowed: false };
   }
 
-  if (await hasExistingAppUser(userId)) {
-    return { allowed: true, via: 'existing_user' };
-  }
-
-  if (await isUserInProviderOrg(userId)) {
-    return { allowed: true, via: 'org_membership' };
-  }
-
   const inviteToken = await getRequestInviteToken();
-  const invite = await findUsableInviteByToken(inviteToken);
+  const setupBootstrapOpen = await isSetupBootstrapOpen();
 
-  if (invite) {
-    return { allowed: true, via: 'invite', inviteId: invite.id };
-  }
-
-  if (await isSetupBootstrapOpen()) {
+  if (setupBootstrapOpen && Env.SETUP_TOKEN && inviteToken) {
     // The system invite: while initial setup is still open, a valid
     // SETUP_TOKEN admits the deployment operator, even when an earlier
     // aborted setup attempt already left an account behind. Only local
@@ -191,6 +179,24 @@ export async function evaluateSignInAccess({
     if (isSetupTokenValid(inviteToken ?? undefined)) {
       return { allowed: true, via: 'bootstrap' };
     }
+  }
+
+  if (await hasExistingAppUser(userId)) {
+    return { allowed: true, via: 'existing_user' };
+  }
+
+  if (await isUserInProviderOrg(userId)) {
+    return { allowed: true, via: 'org_membership' };
+  }
+
+  const invite = await findUsableInviteByToken(inviteToken);
+
+  if (invite) {
+    return { allowed: true, via: 'invite', inviteId: invite.id };
+  }
+
+  if (setupBootstrapOpen && isSetupTokenValid(undefined)) {
+    return { allowed: true, via: 'bootstrap' };
   }
 
   return { allowed: false };

--- a/apps/web/src/lib/server/auth-context.test.ts
+++ b/apps/web/src/lib/server/auth-context.test.ts
@@ -197,6 +197,30 @@ describe('authorize', () => {
     ]);
   });
 
+  it('promotes an existing member admitted by the setup token while setup is open', async () => {
+    mockAccessDecision.current = { allowed: true, via: 'bootstrap' };
+    mockUsersFindFirst.mockResolvedValue({
+      id: 'user-1',
+      role: 'member',
+      createdAt: new Date('2025-01-01T00:00:00.000Z'),
+      imageUrl: 'https://example.com/avatar.png',
+      onboardingCompletedAt: new Date('2025-01-01T00:00:00.000Z'),
+      deletedAt: null,
+    });
+
+    const result = await authorize();
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+
+    expect(result.isAdmin).toBe(true);
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ role: 'admin' }),
+    );
+  });
+
   it('admits non-bootstrap newcomers as members when users already exist', async () => {
     mockAccessDecision.current = { allowed: true, via: 'org_membership' };
     mockUsersFindFirst.mockResolvedValue(null);

--- a/apps/web/src/lib/server/auth-context.ts
+++ b/apps/web/src/lib/server/auth-context.ts
@@ -201,7 +201,11 @@ async function ensureDeploymentIdentity({
     // exists (e.g. a manual database edit) and access policy re-admits them,
     // restore the row as a member rather than leaving it in limbo.
     const isRestoring = existingUser.deletedAt != null;
-    role = isRestoring ? 'member' : existingUser.role;
+    role = admittedViaBootstrap
+      ? 'admin'
+      : isRestoring
+        ? 'member'
+        : existingUser.role;
 
     const profileUpdate = {
       name,
@@ -210,6 +214,9 @@ async function ensureDeploymentIdentity({
       entity: userEntity,
       onboardingCompletedAt: existingUser.onboardingCompletedAt ?? now,
       updatedAt: now,
+      ...(admittedViaBootstrap && existingUser.role !== 'admin'
+        ? { role }
+        : {}),
     };
 
     if (isRestoring) {

--- a/apps/web/src/lib/server/teams-app-package.ts
+++ b/apps/web/src/lib/server/teams-app-package.ts
@@ -24,11 +24,10 @@ export function buildTeamsAppManifest(params: TeamsAppManifestParams): string {
   return JSON.stringify(
     {
       $schema:
-        'https://developer.microsoft.com/en-us/json-schemas/teams/v1.16/MicrosoftTeams.schema.json',
-      manifestVersion: '1.16',
+        'https://developer.microsoft.com/en-us/json-schemas/teams/v1.25/MicrosoftTeams.schema.json',
+      manifestVersion: '1.25',
       version: '1.0.0',
       id: params.botAppId,
-      packageName: 'com.roomote.teams',
       developer: {
         name: 'Roomote',
         websiteUrl: origin,
@@ -47,7 +46,7 @@ export function buildTeamsAppManifest(params: TeamsAppManifestParams): string {
         color: COLOR_ICON_FILENAME,
         outline: OUTLINE_ICON_FILENAME,
       },
-      accentColor: '#1A1A1A',
+      accentColor: '#d6ee26',
       webApplicationInfo: {
         id: params.botAppId,
         resource: origin,
@@ -56,11 +55,35 @@ export function buildTeamsAppManifest(params: TeamsAppManifestParams): string {
         permissions: {
           resourceSpecific: [
             {
+              name: 'Channel.Create.Group',
+              type: 'Application',
+            },
+            {
+              name: 'ChannelMember.Read.Group',
+              type: 'Application',
+            },
+            {
               name: 'ChannelMessage.Read.Group',
               type: 'Application',
             },
             {
+              name: 'ChannelMessage.Send.Group',
+              type: 'Application',
+            },
+            {
+              name: 'ChannelSettings.Read.Group',
+              type: 'Application',
+            },
+            {
               name: 'ChatMessage.Read.Chat',
+              type: 'Application',
+            },
+            {
+              name: 'ChatMessage.Send.Chat',
+              type: 'Application',
+            },
+            {
+              name: 'Member.Read.Group',
               type: 'Application',
             },
           ],
@@ -70,11 +93,12 @@ export function buildTeamsAppManifest(params: TeamsAppManifestParams): string {
         {
           botId: params.botAppId,
           scopes: ['personal', 'team', 'groupChat'],
-          supportsFiles: false,
+          supportsFiles: true,
           isNotificationOnly: false,
         },
       ],
       permissions: ['identity', 'messageTeamMembers'],
+      supportsChannelFeatures: 'tier1',
       validDomains: [appUrl.host],
     },
     null,

--- a/packages/types/src/setup-auth-config.ts
+++ b/packages/types/src/setup-auth-config.ts
@@ -91,18 +91,18 @@ export const SETUP_AUTH_PROVIDER_CATALOG = [
       {
         envVarName: 'ROOMOTE_AUTH_MICROSOFT_CLIENT_ID',
         acceptedEnvVarNames: ['ROOMOTE_AUTH_MICROSOFT_CLIENT_ID'],
-        label: 'App Client ID',
+        label: 'App (Client) ID',
       },
       {
         envVarName: 'ROOMOTE_AUTH_MICROSOFT_CLIENT_SECRET',
         acceptedEnvVarNames: ['ROOMOTE_AUTH_MICROSOFT_CLIENT_SECRET'],
-        label: 'Client Secret',
+        label: 'Client Secret Value',
         secret: true,
       },
       {
         envVarName: 'ROOMOTE_AUTH_MICROSOFT_TENANT_ID',
         acceptedEnvVarNames: ['ROOMOTE_AUTH_MICROSOFT_TENANT_ID'],
-        label: 'Tenant ID',
+        label: 'Directory (Tenant) ID',
       },
       {
         envVarName: 'TEAMS_BOT_APP_ID',


### PR DESCRIPTION
## Summary
- update generated Microsoft Teams app packages to manifest v1.25, including channel install readiness, file support, the Roomote accent color, and required RSC permissions
- refresh the Teams setup and manual docs so Microsoft Entra, Teams bot capability, redirect URI, messaging endpoint, group chat scope casing, and app-package upload steps match the new flow
- tighten setup bootstrap auth so setup-token and local tokenless first-admin sign-ins are admitted as bootstrap users, become admins, preserve the `/setup` step through OAuth/callback redirects, and ignore soft-deleted users when determining whether a real user already exists
- simplify and restyle the setup experience: remove setup-only env-var storage notes, keep setup auth callbacks on the credential step, align provider/setup layouts, and keep comms settings in sync with the setup flow
- align logged-out, reset-password, and email/password auth screens with the setup styling, while preserving caller-provided submit-button layout overrides and fixing the email login button copy
- update auth, setup, comms settings, Teams package, and access-policy coverage for the changed behavior

## Review feedback addressed
- updated the Microsoft setup heading assertion to the new generated-values copy
- excluded soft-deleted users from local tokenless bootstrap first-user detection
- restored `submitButtonClassName` support for `EmailPasswordAuth`
- fixed the visible `Log in with email` button copy and test assertions
- added the missing `Checkbox` export to the StepInvoke component mock after CI exercised the full web suite
- changed the manual Teams manifest snippet from `groupchat` to the v1.25 `groupChat` scope value

## Validation
- rebased `bb/teams` onto `origin/develop` (`bbed642`) and resolved conflicts
- `mise exec -- pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/web exec vitest run src/lib/server/__tests__/access-policy.test.ts` (passes; `.env.test` is absent, dotenvx injected 0 vars)
- `mise exec -- pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/web exec vitest run src/app/\(unauthenticated\)/auth-form.client.test.tsx src/lib/server/__tests__/access-policy.test.ts` (passes; `.env.test` is absent, dotenvx injected 0 vars)
- `mise exec -- pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/web exec vitest run src/app/\(onboarding\)/setup/StepInvoke.client.test.tsx src/app/\(unauthenticated\)/auth-form.client.test.tsx src/lib/server/__tests__/access-policy.test.ts` (passes; `.env.test` is absent, dotenvx injected 0 vars)
- `mise exec -- pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/web exec vitest run src/app/\(onboarding\)/setup/StepInvoke.client.test.tsx src/app/\(unauthenticated\)/auth-form.client.test.tsx src/lib/server/__tests__/access-policy.test.ts src/app/\(onboarding\)/setup/StepComputeConfig.client.test.tsx` (passes; `.env.test` is absent, dotenvx injected 0 vars)
- pre-push hook passed via `mise exec -- git push origin bb/teams`: `pnpm lint:fast`, `pnpm check-types:fast`, `pnpm knip`
