### PR TITLE
[Fix] Kill OpenCode SDK server processes when the parent process dies

### DIFF
--- a/.agent-guidance/architecture/agent-context.md
+++ b/.agent-guidance/architecture/agent-context.md
@@ -167,6 +167,16 @@ integration entry points can use their normal fallback UX, such as the Slack
 environment picker. Text-only non-task helper calls still use
 `opencode run --model`.
 
+The host-side SDK server pool
+(`packages/cloud-agents/src/server/opencode-runtime.ts`) spawns each
+`opencode serve` process detached into its own process group and tracks every
+live process. Shutdown hooks (`process` `exit` plus SIGTERM/SIGINT/SIGHUP
+handlers that re-deliver the signal when no other handler owns shutdown)
+SIGKILL the full process groups, so cached servers cannot outlive the parent —
+previously dev-watch restarts of `apps/api` orphaned them to launchd where
+they leaked several hundred MB each. A SIGKILLed parent still leaks its
+servers; nothing catches that.
+
 OpenRouter variant models (`openrouter/<model>:nitro`, `:free`, `:floor`, ...)
 are not catalog model IDs, so OpenCode would reject them with
 `ProviderModelNotFoundError`. Both config generators (worker

--- a/packages/cloud-agents/src/server/__tests__/opencode-runtime.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/opencode-runtime.test.ts
@@ -1,8 +1,14 @@
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { buildOpenCodeCliEnv } from '../opencode-runtime';
+import {
+  buildOpenCodeCliEnv,
+  killOpenCodeSdkServerProcessesForShutdown,
+  leaseOpenCodeSdkServer,
+} from '../opencode-runtime';
 
 describe('buildOpenCodeCliEnv', () => {
   const managedKeys = [
@@ -161,5 +167,142 @@ describe('buildOpenCodeCliEnv', () => {
     expect(env.GOOGLE_APPLICATION_CREDENTIALS).toBe(
       '/etc/roomote/service-account.json',
     );
+  });
+});
+
+// Fake `opencode serve`: answers the readiness probe on the requested port,
+// spawns a grandchild, and records both pids so the test can verify the
+// whole process tree dies on shutdown.
+const FIXTURE_SERVER_SOURCE = `
+const { spawn } = require('node:child_process');
+const { writeFileSync } = require('node:fs');
+const { createServer } = require('node:http');
+
+const portArg = process.argv.find((arg) => arg.startsWith('--port='));
+const port = Number(portArg.split('=')[1]);
+const grandchild = spawn('sleep', ['300']);
+
+createServer((req, res) => {
+  res.statusCode = 200;
+  res.end('ok');
+}).listen(port, '127.0.0.1', () => {
+  writeFileSync(
+    process.env.OPENCODE_FIXTURE_PID_FILE,
+    JSON.stringify({ serverPid: process.pid, grandchildPid: grandchild.pid }),
+  );
+});
+`;
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitFor(
+  condition: () => boolean,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (condition()) {
+      return true;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  return condition();
+}
+
+describe('OpenCode SDK server shutdown', () => {
+  const originalOpencodeCommand = process.env.OPENCODE_COMMAND;
+  let fixtureDir: string;
+  let trackedPids: number[] = [];
+
+  beforeEach(() => {
+    fixtureDir = mkdtempSync(path.join(tmpdir(), 'opencode-runtime-test-'));
+    trackedPids = [];
+  });
+
+  afterEach(() => {
+    if (originalOpencodeCommand === undefined) {
+      delete process.env.OPENCODE_COMMAND;
+    } else {
+      process.env.OPENCODE_COMMAND = originalOpencodeCommand;
+    }
+
+    for (const pid of trackedPids) {
+      try {
+        process.kill(-pid, 'SIGKILL');
+      } catch {
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          // Already dead — the expected case.
+        }
+      }
+    }
+
+    rmSync(fixtureDir, { recursive: true, force: true });
+  });
+
+  it('kills the whole server process tree, including shell-wrapped grandchildren', async () => {
+    const fixturePath = path.join(fixtureDir, 'fixture-server.cjs');
+    const pidFilePath = path.join(fixtureDir, 'pids.json');
+    writeFileSync(fixturePath, FIXTURE_SERVER_SOURCE);
+
+    // A command with whitespace routes the spawn through `bash -lc`, so the
+    // managed proc is the shell and the real server is a grandchild — the
+    // shape that leaked before group signaling.
+    process.env.OPENCODE_COMMAND = `${process.execPath} ${fixturePath}`;
+
+    const lease = await leaseOpenCodeSdkServer({
+      env: { OPENCODE_FIXTURE_PID_FILE: pidFilePath },
+      startTimeoutMs: 15_000,
+    });
+
+    try {
+      const pidFileWritten = await waitFor(() => {
+        try {
+          readFileSync(pidFilePath, 'utf8');
+          return true;
+        } catch {
+          return false;
+        }
+      }, 5_000);
+      expect(pidFileWritten).toBe(true);
+
+      const { serverPid, grandchildPid } = JSON.parse(
+        readFileSync(pidFilePath, 'utf8'),
+      ) as { serverPid: number; grandchildPid: number };
+      trackedPids = [serverPid, grandchildPid];
+
+      expect(isProcessAlive(serverPid)).toBe(true);
+      expect(isProcessAlive(grandchildPid)).toBe(true);
+
+      killOpenCodeSdkServerProcessesForShutdown();
+
+      expect(
+        await waitFor(
+          () => !isProcessAlive(serverPid) && !isProcessAlive(grandchildPid),
+          5_000,
+        ),
+      ).toBe(true);
+    } finally {
+      lease.release();
+    }
+  });
+
+  it('registers terminating-signal handlers once a server is leased', () => {
+    // Leased in the previous test via the shared pool; registration is
+    // per-process, so the handlers must be present now.
+    expect(process.listenerCount('SIGTERM')).toBeGreaterThanOrEqual(1);
+    expect(process.listenerCount('SIGINT')).toBeGreaterThanOrEqual(1);
+    expect(process.listenerCount('SIGHUP')).toBeGreaterThanOrEqual(1);
   });
 });

--- a/packages/cloud-agents/src/server/opencode-runtime.ts
+++ b/packages/cloud-agents/src/server/opencode-runtime.ts
@@ -198,17 +198,54 @@ export function readOpenCodeDebugConfig(): string {
   });
 }
 
-function stopChildProcess(proc: ChildProcess): void {
-  if (proc.exitCode !== null || proc.signalCode !== null) {
+function signalProcessTree(proc: ChildProcess, signal: NodeJS.Signals): void {
+  if (proc.exitCode !== null || proc.signalCode !== null || !proc.pid) {
     return;
   }
 
-  proc.kill('SIGTERM');
-  setTimeout(() => {
-    if (proc.exitCode === null && proc.signalCode === null) {
-      proc.kill('SIGKILL');
+  // Servers are spawned detached into their own process group, so signaling
+  // the negative pid reaches the whole group — including the real opencode
+  // process when OPENCODE_COMMAND routes the spawn through a shell wrapper,
+  // where `proc` is only the shell.
+  try {
+    process.kill(-proc.pid, signal);
+  } catch {
+    try {
+      proc.kill(signal);
+    } catch {
+      // The process exited between the check and the signal.
     }
+  }
+}
+
+function stopChildProcess(proc: ChildProcess): void {
+  signalProcessTree(proc, 'SIGTERM');
+  setTimeout(() => {
+    signalProcessTree(proc, 'SIGKILL');
   }, 2_000).unref();
+}
+
+/**
+ * Every spawned OpenCode SDK server process, cached or still starting.
+ * Entries remove themselves on exit. Used by the shutdown hooks so no
+ * server can outlive the parent process — before this registry existed,
+ * dev-watch restarts of the API orphaned the servers to launchd where
+ * they leaked 300-650MB each.
+ */
+const liveOpenCodeSdkServerProcs = new Set<ChildProcess>();
+
+/**
+ * Immediately kills every live OpenCode SDK server process group. Uses
+ * SIGKILL because this runs while the parent is dying (process 'exit' or a
+ * terminating signal): the event loop is about to stop, so the usual
+ * SIGTERM-then-SIGKILL escalation timer would never fire, and an ignored
+ * SIGTERM would recreate the orphan leak. The servers are stateless
+ * localhost inference caches, so a hard kill loses nothing.
+ */
+export function killOpenCodeSdkServerProcessesForShutdown(): void {
+  for (const proc of liveOpenCodeSdkServerProcs) {
+    signalProcessTree(proc, 'SIGKILL');
+  }
 }
 
 type ManagedOpenCodeSdkServer = {
@@ -377,6 +414,14 @@ async function startManagedOpenCodeSdkServer(
   const proc = spawn(command.command, command.args, {
     env: buildOpenCodeCliEnv(extraEnv),
     stdio: ['ignore', 'pipe', 'pipe'],
+    // Own process group, so shutdown can signal the entire tree (shell
+    // wrappers included) via the negative pid.
+    detached: true,
+  });
+
+  liveOpenCodeSdkServerProcs.add(proc);
+  proc.once('exit', () => {
+    liveOpenCodeSdkServerProcs.delete(proc);
   });
 
   let output = '';
@@ -535,13 +580,6 @@ class OpenCodeSdkServerPool {
     server.close();
   }
 
-  private closeAll(): void {
-    for (const server of this.cache.values()) {
-      this.close(server);
-    }
-    this.startPromises.clear();
-  }
-
   private createLease(server: CachedOpenCodeSdkServer): OpenCodeSdkServerLease {
     server.activeLeases += 1;
 
@@ -572,7 +610,24 @@ class OpenCodeSdkServerPool {
     }
 
     this.shutdownRegistered = true;
-    process.once('exit', () => this.closeAll());
+    process.once('exit', () => {
+      killOpenCodeSdkServerProcessesForShutdown();
+    });
+
+    // A terminating signal with no handler kills Node without running
+    // 'exit' hooks, which is exactly what dev watchers (`node --watch`,
+    // `tsx watch`) and pm2 send on restart — the historical orphan path.
+    // Kill the servers first, then re-deliver the signal so the default
+    // termination still happens unless another handler owns shutdown.
+    for (const signal of ['SIGTERM', 'SIGINT', 'SIGHUP'] as const) {
+      process.once(signal, () => {
+        killOpenCodeSdkServerProcessesForShutdown();
+
+        if (process.listenerCount(signal) === 0) {
+          process.kill(process.pid, signal);
+        }
+      });
+    }
   }
 
   private scheduleIdleClose(server: CachedOpenCodeSdkServer): void {


### PR DESCRIPTION
## Summary

The host-side OpenCode SDK server pool (`packages/cloud-agents/src/server/opencode-runtime.ts`) cleaned up its cached `opencode serve` children only via a `process.once('exit')` hook. A terminating signal with no handler kills Node **without** running `'exit'` hooks — exactly what dev watchers (`node --watch`, `tsx watch`) and pm2 send on restart. Every API dev-watch restart orphaned the servers to launchd, where they leaked 300–650MB apiece. Observed on a dev machine: 15 orphans totaling **5.7GB**, accumulated over a week, eventually exhausting system memory.

## Fix

- **Own process group**: servers spawn `detached: true`, and all kills signal the negative pid — so the whole tree dies even when `OPENCODE_COMMAND` routes the spawn through a `bash -lc` wrapper (where the managed proc is only the shell)
- **Live-process registry**: every spawned server (cached *or* still starting) registers in a module-level set that self-cleans on exit, closing the gap where an in-flight spawn escapes cache-based cleanup
- **Signal hooks**: SIGTERM/SIGINT/SIGHUP handlers (plus the existing `'exit'` hook) SIGKILL all server groups, then re-deliver the signal so default termination proceeds unless another handler owns shutdown. SIGKILL because the event loop is dying — the graceful SIGTERM→SIGKILL escalation timer would never fire, and the servers are stateless localhost inference caches

Known limitation (documented in the guidance): a SIGKILLed parent still leaks its servers; nothing can catch SIGKILL.

## Validation

- New regression test spawns a real fixture server through the shell-wrapper path with a grandchild process and asserts the shutdown kill takes down the entire tree, plus a signal-handler registration check
- Live end-to-end: a harness process leased a pooled server and was sent SIGTERM (the dev-watch restart scenario) — the harness, the server, and its grandchild all died
- `pnpm lint:fast`, `pnpm check-types:fast`, `pnpm knip` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)