### PR TITLE
[Fix] Web task-page sends steer the active turn instead of queueing silently

### DIFF
--- a/.agent-guidance/architecture/cloud-job-execution.md
+++ b/.agent-guidance/architecture/cloud-job-execution.md
@@ -418,9 +418,15 @@ Harnesses:
   are not fetched or copied for this handoff. The materialized files are retained
   for the active harness lifetime so transcript `@/tmp/...` references remain
   usable across follow-up turns and snapshot resumes, then cleaned up on harness
-  disposal or terminal error paths. OpenCode steering uses Roomote's queued-prompt
-  cancel/replay fallback, with
-  replay interrupts treated as non-terminal task events. OpenCode's normal
+  disposal or terminal error paths. OpenCode steering is native when possible:
+  a follow-up sent with `autoSteerWhenQueued` while a turn is in flight is
+  injected directly into the active OpenCode session (no abort), falling back
+  to Roomote's queued-prompt cancel/replay when native injection fails or a
+  `request_user_input` question is pending, with replay interrupts treated as
+  non-terminal task events. Provider follow-ups (Slack, Teams, Telegram) and
+  web task-page sends both set `autoSteerWhenQueued`; prompts stay in the local
+  runtime queue only as fallback/replay staging or for explicitly queue-only
+  messages. OpenCode's normal
   config precedence owns provider and model selection; task payload `model`
   overrides are passed as explicit prompt-level overrides only when launch code
   supplies one.

--- a/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/PromptInput.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/PromptInput.client.test.tsx
@@ -585,6 +585,7 @@ describe('PromptInput', () => {
         source: 'web',
         clientMessageId: expect.any(String),
         userImageUrl: undefined,
+        autoSteerWhenQueued: true,
       });
     });
 
@@ -646,6 +647,7 @@ describe('PromptInput', () => {
         source: 'web',
         clientMessageId: expect.any(String),
         userImageUrl: undefined,
+        autoSteerWhenQueued: true,
       });
     });
 
@@ -659,7 +661,7 @@ describe('PromptInput', () => {
     expect(queryClientSetQueryDataMock).toHaveBeenCalledTimes(1);
   });
 
-  it('uses the queued-messages surface for optimistic prompts while the task is running', async () => {
+  it('steers prompts into the transcript while the task is running', async () => {
     useSandboxConnectedMock.mockReturnValue(true);
     useSandboxConnectionStatusMock.mockReturnValue({
       connected: true,
@@ -695,18 +697,19 @@ describe('PromptInput', () => {
         source: 'web',
         clientMessageId: expect.any(String),
         userImageUrl: undefined,
+        autoSteerWhenQueued: true,
       });
     });
 
-    expect(appendOptimisticQueuedMessageMock).toHaveBeenCalledWith(
+    expect(appendOptimisticAcpEventMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        id: expect.stringMatching(/^local:/),
+        eventType: 'roomote_runtime.user_prompt',
+        role: 'user',
         text: 'queued follow-up',
-        optimistic: true,
       }),
     );
-    expect(appendOptimisticAcpEventMock).not.toHaveBeenCalled();
-    expect(queryClientSetQueryDataMock).not.toHaveBeenCalled();
+    expect(appendOptimisticQueuedMessageMock).not.toHaveBeenCalled();
+    expect(queryClientSetQueryDataMock).toHaveBeenCalledTimes(1);
   });
 
   it('steers the oldest queued message from empty Enter even after the parent turn leaves running state', async () => {
@@ -840,7 +843,7 @@ describe('PromptInput', () => {
     expect(toastErrorMock).toHaveBeenCalledWith('Failed to send message.');
   });
 
-  it('removes the optimistic queued message and shows a toast when a running send fails', async () => {
+  it('removes the optimistic transcript message and shows a toast when a running send fails', async () => {
     useSandboxConnectedMock.mockReturnValue(true);
     useSandboxConnectionStatusMock.mockReturnValue({
       connected: true,
@@ -872,12 +875,12 @@ describe('PromptInput', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Send' }));
 
     await waitFor(() => {
-      expect(removeOptimisticQueuedMessageMock).toHaveBeenCalledWith(
+      expect(removeOptimisticMessageMock).toHaveBeenCalledWith(
         expect.any(String),
       );
     });
 
-    expect(removeOptimisticMessageMock).not.toHaveBeenCalled();
+    expect(removeOptimisticQueuedMessageMock).not.toHaveBeenCalled();
     expect(toastErrorMock).toHaveBeenCalledWith('Failed to send message.');
   });
 });

--- a/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/PromptInput.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/PromptInput.tsx
@@ -145,10 +145,6 @@ export const PromptInput = forwardRef<PromptInputHandle, PromptInputProps>(
     const canSteerQueuedMessages =
       isSteerablePhase(taskPhase) &&
       (taskPhase !== 'waiting_for_prompt' || connected);
-    const isIdleLikeTaskPhase =
-      taskPhase == null ||
-      taskPhase === 'idle' ||
-      taskPhase === 'waiting_for_prompt';
     const userImageUrl =
       currentUserInfo?.userImageUrl ?? user?.resource.imageUrl ?? undefined;
     const steerableQueuedMessages = queuedMessages.filter(
@@ -409,7 +405,10 @@ export const PromptInput = forwardRef<PromptInputHandle, PromptInputProps>(
             attachments: message.files,
           });
 
-          optimisticLocation = isIdleLikeTaskPhase ? 'transcript' : 'queue';
+          // Sends steer into an in-flight turn (native injection when the
+          // harness supports it), so the prompt lands in the transcript
+          // rather than sitting in the queue until the turn ends.
+          optimisticLocation = 'transcript';
           const { clientMessageId } = startOptimisticPromptSubmission({
             taskId: cloudJob.taskId,
             prompt: preparedPrompt.text,
@@ -425,6 +424,7 @@ export const PromptInput = forwardRef<PromptInputHandle, PromptInputProps>(
             source: 'web',
             clientMessageId,
             userImageUrl,
+            autoSteerWhenQueued: true,
           });
 
           handleMessageSent();
@@ -458,7 +458,6 @@ export const PromptInput = forwardRef<PromptInputHandle, PromptInputProps>(
         handleMessageSent,
         cloudJob,
         trpcClient,
-        isIdleLikeTaskPhase,
         rollbackOptimisticPromptSubmission,
         startOptimisticPromptSubmission,
         userImageUrl,

--- a/apps/web/src/trpc/commands/sandbox-session/index.ts
+++ b/apps/web/src/trpc/commands/sandbox-session/index.ts
@@ -106,6 +106,7 @@ export const sendSandboxPromptInputSchema = z
     source: z.string().optional(),
     clientMessageId: z.string().optional(),
     userImageUrl: z.string().optional(),
+    autoSteerWhenQueued: z.boolean().optional(),
   })
   .superRefine((data, ctx) => {
     const hasPrompt =
@@ -218,6 +219,7 @@ export async function sendSandboxPromptCommand(
       clientMessageId: parsed.clientMessageId,
       userName: getAuthenticatedPromptUserName(auth),
       userImageUrl: parsed.userImageUrl,
+      autoSteerWhenQueued: parsed.autoSteerWhenQueued,
     });
   } catch (error) {
     await releaseOutOfBandContext(outOfBandContext);

--- a/apps/web/src/trpc/commands/sandbox-session/send-prompt.test.ts
+++ b/apps/web/src/trpc/commands/sandbox-session/send-prompt.test.ts
@@ -136,6 +136,40 @@ describe('sendSandboxPromptCommand', () => {
     );
   });
 
+  it('forwards autoSteerWhenQueued to the sandbox sendPrompt command', async () => {
+    const user = await userFactory.create({ name: 'DB User' });
+    const task = await taskFactory.create({
+      userId: user.id,
+    });
+
+    await cloudJobFactory.create({
+      userId: user.id,
+      taskId: task.id,
+      status: CloudTaskStatus.Running,
+      sandboxServerUrl: 'http://sandbox.example.test',
+      result: {},
+    });
+
+    await sendSandboxPromptCommand(
+      buildMockAuth({
+        userId: user.id,
+      }),
+      {
+        taskId: task.id,
+        prompt: 'change direction',
+        source: 'web',
+        autoSteerWhenQueued: true,
+      },
+    );
+
+    expect(mockSendPromptMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: 'change direction',
+        autoSteerWhenQueued: true,
+      }),
+    );
+  });
+
   it('falls back to the authenticated email when the user name is blank', async () => {
     const user = await userFactory.create({
       name: 'Casey Example',

--- a/apps/worker/src/sandbox-server/procedures/__tests__/sendPrompt.test.ts
+++ b/apps/worker/src/sandbox-server/procedures/__tests__/sendPrompt.test.ts
@@ -1,0 +1,102 @@
+import { appRouter } from '../../routers';
+import type { Context } from '../../trpc';
+import type { JobTokenContext } from '@roomote/types';
+
+const { mockPrepareActorScopedTurn } = vi.hoisted(() => ({
+  mockPrepareActorScopedTurn: vi.fn(),
+}));
+
+function createCaller(options?: {
+  sendFollowUpPrompt?: (args: {
+    prompt: string;
+    images?: string[];
+    workflowPhase?: string;
+    autoSteerWhenQueued?: boolean;
+    userId?: string;
+  }) => boolean;
+  status?: {
+    phase: string;
+    taskStateEvent: null;
+    sessionId: string | undefined;
+    isConnected: boolean;
+    sleepRemainingMs: number | null;
+    lastErrorMessage: string | undefined;
+  };
+}) {
+  const sendFollowUpPrompt = vi.fn(options?.sendFollowUpPrompt ?? (() => true));
+  const getStatus = vi.fn(
+    () =>
+      options?.status ?? {
+        phase: 'running',
+        taskStateEvent: null,
+        sessionId: 'task-1',
+        isConnected: true,
+        sleepRemainingMs: null,
+        lastErrorMessage: undefined,
+      },
+  );
+
+  const ctx = {
+    workingDirectory: '/tmp',
+    harness: {
+      isConnected: true,
+      getPendingUserInputRequests: () => [],
+    },
+    harnessManager: {
+      sendFollowUpPrompt,
+      getStatus,
+    },
+    auth: {
+      cloudJobId: 1,
+      userId: 'sender-user-1',
+      tokenType: 'cj',
+      version: 1,
+    } satisfies JobTokenContext,
+    cloudJobId: 1,
+    prepareActorScopedTurn: mockPrepareActorScopedTurn,
+  } as unknown as Context;
+
+  return {
+    caller: appRouter.createCaller(ctx),
+    sendFollowUpPrompt,
+  };
+}
+
+describe('sendPrompt procedure', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrepareActorScopedTurn.mockResolvedValue(undefined);
+  });
+
+  it('forwards autoSteerWhenQueued to the harness follow-up prompt', async () => {
+    const { caller, sendFollowUpPrompt } = createCaller();
+
+    const result = await caller.commands.sendPrompt({
+      prompt: 'change direction',
+      autoSteerWhenQueued: true,
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(sendFollowUpPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: 'change direction',
+        autoSteerWhenQueued: true,
+      }),
+    );
+  });
+
+  it('leaves autoSteerWhenQueued unset for plain queued sends', async () => {
+    const { caller, sendFollowUpPrompt } = createCaller();
+
+    await caller.commands.sendPrompt({
+      prompt: 'just queue this',
+    });
+
+    expect(sendFollowUpPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: 'just queue this',
+        autoSteerWhenQueued: undefined,
+      }),
+    );
+  });
+});

--- a/apps/worker/src/sandbox-server/procedures/sendPrompt.ts
+++ b/apps/worker/src/sandbox-server/procedures/sendPrompt.ts
@@ -28,6 +28,12 @@ const sendPromptInputSchema = z
     userName: z.string().optional(),
     /** Avatar URL of the sending user (for real-time avatar display). */
     userImageUrl: z.string().optional(),
+    /**
+     * Steer the prompt into an in-flight turn instead of leaving it queued
+     * until the turn ends. Matches the delivery semantics of provider
+     * follow-ups (Slack, Teams, Telegram), which always steer.
+     */
+    autoSteerWhenQueued: z.boolean().optional(),
   })
   .superRefine((data, ctx) => {
     const hasPrompt =
@@ -173,6 +179,7 @@ export const sendPrompt = publicProcedure
         prompt: resolvedPrompt,
         images: input.images,
         ...(workflowPhase ? { workflowPhase } : {}),
+        autoSteerWhenQueued: input.autoSteerWhenQueued,
         source: input.source,
         userId,
         userName: input.userName,

--- a/packages/sdk/src/sandbox-router.ts
+++ b/packages/sdk/src/sandbox-router.ts
@@ -83,6 +83,7 @@ export interface SandboxSendPromptInput {
   clientMessageId?: string;
   userName?: string;
   userImageUrl?: string;
+  autoSteerWhenQueued?: boolean;
 }
 
 export interface SandboxSteerTaskInput {


### PR DESCRIPTION
## What problem this solves

Messages typed on the web task page while a turn was in flight were only appended to the runtime prompt queue and were never delivered until the turn ended — unlike Slack/Teams/Telegram follow-ups, which steer. Two user-facing consequences (found during the staging steering test pass, tasks `190holbb4xm2k`, `11nl0xsy05oyl`, `31qvhb7uek4gy` on openmote):

- A mid-turn direction change silently sat in "Queued" for the whole turn; during a plan-mode run the agent asked the user structured questions while the user's steer — which answered them — sat undelivered.
- With a `request_user_input` question pending, the task deadlocked outright: the turn never ends, so the queued message never drains, and the queued message can only be rescued via the (hard to discover) queued-row steer control.

## What changed

- `sandboxSession.sendPrompt` (web) → sandbox-server `commands.sendPrompt` → `HarnessManager.sendFollowUpPrompt` now pass `autoSteerWhenQueued` end to end, and the task-page prompt input sends with `autoSteerWhenQueued: true`.
- Delivery semantics now match provider follow-ups: native mid-turn injection into the active OpenCode session when possible (no abort, no interruption narration), falling back to queued-prompt cancel/replay when injection fails or a question is pending.
- The optimistic UI places running-turn sends in the transcript instead of the queued-messages surface to match the new delivery path. Explicit queue-only messages and the Enter-on-empty "steer oldest queued message" affordance are unchanged.
- Updated the stale steering paragraph in `.agent-guidance/architecture/cloud-job-execution.md` (it still described steering as cancel/replay only).

## Validation

- `vitest`: new `apps/worker` sendPrompt procedure tests (flag forwarded / left unset), extended web `send-prompt` command test, updated `PromptInput` client tests — full `src/app/(sandbox)/task/` suite green (476 tests), all worker procedure tests green.
- `pnpm lint:fast` and `pnpm check-types:fast` clean. Local `pnpm knip` output is unchanged from base (worktree-environment noise; CI knip is authoritative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)