### PR TITLE
[Fix] Surface a readable provider message instead of raw session-error JSON

### DIFF
--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
@@ -1949,6 +1949,69 @@ describe('OpenCodeServerHarness', () => {
     }
   });
 
+  it('surfaces a readable provider message instead of the raw session error JSON', async () => {
+    const { client, harness } = createHarness();
+    const persistedEnvelopes: AcpPersistedEnvelope[] = [];
+
+    harness.subscribeRuntimePersistedEnvelope((envelope) =>
+      persistedEnvelopes.push(envelope),
+    );
+
+    try {
+      await connectHarness(harness, client);
+
+      expect(
+        harness.sendCommand({
+          commandName: TaskCommandName.StartNewTask,
+          data: {
+            text: 'Start work.',
+            visibleInTranscript: true,
+          },
+        }),
+      ).toBe(true);
+
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(1);
+      });
+
+      await client.emit({
+        type: 'session.error',
+        properties: {
+          sessionID: 'ses_1',
+          error: {
+            name: 'APIError',
+            data: {
+              message:
+                '[xAI] The model grok-4.5 is not available in your region.',
+              statusCode: 403,
+              isRetryable: false,
+              responseHeaders: { 'cf-ray': 'a184f336b9add2b6-FRA' },
+              responseBody: '{"error":{"message":"Provider returned error"}}',
+            },
+          },
+        },
+      });
+
+      const errorMessage = persistedEnvelopes.find(
+        (envelope) =>
+          envelope.eventType === ACP_ENVELOPE_EVENT_TYPES.AssistantMessage &&
+          String(envelope.payload.text ?? '').includes(
+            'The provider returned an error',
+          ),
+      );
+
+      expect(String(errorMessage?.payload.text)).toBe(
+        'The provider returned an error: [xAI] The model grok-4.5 is not available in your region.',
+      );
+      expect(String(errorMessage?.payload.text)).not.toContain(
+        'responseHeaders',
+      );
+      expect(String(errorMessage?.payload.text)).not.toContain('cf-ray');
+    } finally {
+      harness.dispose();
+    }
+  });
+
   it('records OpenCode question tool requests and delivers answers as a follow-up prompt', async () => {
     const beforeQueuedPrompt = vi.fn(async () => undefined);
     const { client, harness } = createHarness(undefined, {

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
@@ -989,6 +989,39 @@ function isOpenCodeMessageAbortedError(error: unknown): boolean {
   return name === 'MessageAbortedError' || message === 'Aborted';
 }
 
+const SESSION_ERROR_FALLBACK_MAX_CHARS = 600;
+
+/**
+ * Session errors used to be dumped into the transcript as the raw
+ * `JSON.stringify(error)` blob (status codes, response headers, provider
+ * metadata). Surface the human-readable provider message instead; the full
+ * payload still goes to the harness log for debugging.
+ */
+function formatOpenCodeSessionErrorText(error: unknown): string {
+  const record = asRecord(error);
+  const name = asString(record?.name);
+  const message =
+    asString(asRecord(record?.data)?.message) ?? asString(record?.message);
+
+  if (message) {
+    return name && name !== 'APIError'
+      ? `The provider returned an error (${name}): ${message}`
+      : `The provider returned an error: ${message}`;
+  }
+
+  if (name) {
+    return `The session ended with an error: ${name}`;
+  }
+
+  const serialized = JSON.stringify(error ?? {});
+
+  return `The session ended with an error: ${
+    serialized.length > SESSION_ERROR_FALLBACK_MAX_CHARS
+      ? `${serialized.slice(0, SESSION_ERROR_FALLBACK_MAX_CHARS)}…`
+      : serialized
+  }`;
+}
+
 function formatOpenCodeUserInputResponsePrompt(options: {
   request: HarnessPendingUserInputRequest;
   answers: AcpRequestUserInputAnswers;
@@ -3020,9 +3053,12 @@ export class OpenCodeServerHarness
     }
 
     if (sessionId) {
+      this.logger.error(
+        `OpenCode session error sessionId=${sessionId}: ${JSON.stringify(error ?? {})}`,
+      );
       this.runtimeEvents.assistantMessage({
         sessionId,
-        text: `OpenCode session error: ${JSON.stringify(error ?? {})}`,
+        text: formatOpenCodeSessionErrorText(error),
       });
       this.prompts.clear();
       this.clearQueuedPromptRetryTimer();


### PR DESCRIPTION
## What problem this solves

Fix 5 from the steering test pass. When an OpenCode session errors (e.g. the staging default Grok 4.5 model 403s via OpenRouter with "not available in your region"), the transcript rendered the entire `JSON.stringify` of the error — status codes, `cf-ray` response headers, CSP noise, provider metadata — as an assistant message (repro: openmote task `39myfrd6growb`).

## What changed

- `handleSessionError` in the OpenCode harness now emits a readable message extracted from the error (`error.data.message` → `error.message` → error name → truncated JSON fallback): e.g. `The provider returned an error: [xAI] The model grok-4.5 is not available in your region.`
- The full raw error payload is still logged to the harness log for debugging.

Note: the *other* half of this staging finding — Grok 4.5 being the default model while the xAI BYOK key is region-blocked — is deployment config on openmote, not a code change; worth flipping the default or fixing the key separately.

## Validation

- New harness test asserting the friendly text (and absence of response-header noise) for an APIError-shaped session error; full sandbox-server suite green (283 tests); lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)