### PR TITLE
[Fix] Live transcript converges to persisted envelopes on every history refetch

### DIFF
--- a/apps/web/src/app/(sandbox)/task/[taskId]/hooks/__tests__/steered-task-history.client.test.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/hooks/__tests__/steered-task-history.client.test.ts
@@ -1,0 +1,394 @@
+import { ACP_ENVELOPE_EVENT_TYPES } from '@roomote/types';
+
+vi.mock('@roomote/env', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@roomote/env')>();
+
+  return {
+    ...actual,
+    Env: {
+      NODE_ENV: 'test',
+      DATABASE_URL: 'postgres://postgres:password@localhost:5432/test',
+    },
+  };
+});
+
+import {
+  acpEnvelope,
+  createAcpStore,
+  textBlock,
+} from './use-sandbox-store-test-kit';
+
+const SESSION = 'ses_repro';
+
+function userPromptEnvelope(options: {
+  id: string;
+  ts: number;
+  text: string;
+  clientMessageId?: string;
+  visibleInTranscript?: boolean;
+}) {
+  const logicalEventId = `${SESSION}:${options.clientMessageId ?? 'no-turn'}:no-tool:${ACP_ENVELOPE_EVENT_TYPES.UserPrompt}`;
+
+  return acpEnvelope({
+    id: options.id,
+    ts: options.ts,
+    eventType: ACP_ENVELOPE_EVENT_TYPES.UserPrompt,
+    kind: 'text',
+    role: 'user',
+    text: options.text,
+    contentBlocks: [textBlock(options.text)],
+    visibleInTranscript: options.visibleInTranscript,
+    metadata: {
+      sessionId: SESSION,
+      logicalEventId,
+      ...(options.clientMessageId
+        ? { clientMessageId: options.clientMessageId }
+        : {}),
+      ...(options.visibleInTranscript === false
+        ? { visibleInTranscript: false }
+        : {}),
+    },
+    payload: {
+      sessionId: SESSION,
+      text: options.text,
+      logicalEventId,
+      ...(options.clientMessageId
+        ? { clientMessageId: options.clientMessageId }
+        : {}),
+    },
+  });
+}
+
+function assistantMessageEnvelope(options: {
+  id: string;
+  ts: number;
+  messageId: string;
+  text: string;
+}) {
+  const logicalEventId = `${SESSION}:${options.messageId}:no-tool:${ACP_ENVELOPE_EVENT_TYPES.AssistantMessage}`;
+
+  return acpEnvelope({
+    id: options.id,
+    ts: options.ts,
+    eventType: ACP_ENVELOPE_EVENT_TYPES.AssistantMessage,
+    kind: 'text',
+    role: 'assistant',
+    ...(options.text.length > 0 ? { text: options.text } : {}),
+    contentBlocks: options.text.length > 0 ? [textBlock(options.text)] : [],
+    metadata: {
+      sessionId: SESSION,
+      turnId: options.messageId,
+      logicalEventId,
+    },
+    payload: {
+      sessionId: SESSION,
+      turnId: options.messageId,
+      text: options.text,
+      logicalEventId,
+    },
+  });
+}
+
+function envelopeFixture() {
+  return [
+    userPromptEnvelope({
+      id: 'env-1',
+      ts: 1000,
+      text: '<request>Investigate the queued follow-up flow</request>',
+      visibleInTranscript: false,
+    }),
+    assistantMessageEnvelope({
+      id: 'env-2',
+      ts: 1100,
+      messageId: 'msg-a',
+      text: '',
+    }),
+    assistantMessageEnvelope({
+      id: 'env-3',
+      ts: 1200,
+      messageId: 'msg-b',
+      text: 'Reading the repo guidance and then tracing the flow.',
+    }),
+    assistantMessageEnvelope({
+      id: 'env-4',
+      ts: 1300,
+      messageId: 'msg-c',
+      text: '',
+    }),
+    assistantMessageEnvelope({
+      id: 'env-5',
+      ts: 1400,
+      messageId: 'msg-d',
+      text: 'Here is the full turn-one answer.',
+    }),
+    userPromptEnvelope({
+      id: 'env-6',
+      ts: 1500,
+      text: 'Yes - produce the tighter walkthrough for all three flows.',
+      clientMessageId: 'client-follow-up',
+      visibleInTranscript: true,
+    }),
+    assistantMessageEnvelope({
+      id: 'env-7',
+      ts: 1600,
+      messageId: 'msg-e',
+      text: '',
+    }),
+    assistantMessageEnvelope({
+      id: 'env-8',
+      ts: 1700,
+      messageId: 'msg-f',
+      text: 'Here is the full turn-two answer.',
+    }),
+    userPromptEnvelope({
+      id: 'env-9',
+      ts: 1800,
+      text: 'Quick change of direction: skip the snapshot-resume flow.',
+      clientMessageId: 'client-steer',
+      visibleInTranscript: true,
+    }),
+    assistantMessageEnvelope({
+      id: 'env-10',
+      ts: 1900,
+      messageId: 'msg-g',
+      text: 'Skipping snapshot resume. Here is the steered answer.',
+    }),
+  ];
+}
+
+describe('steered-task history reconstruction', () => {
+  it('keeps every turn and user prompt after a reload-style history merge', () => {
+    const store = createAcpStore();
+
+    // Mirrors the persisted envelope stream of a real steered task
+    // (openmote task 190holbb4xm2k): initial hidden prompt, a first turn
+    // with interleaved empty assistant messages and a final answer, a
+    // visible follow-up, a second turn, a steer, and the steered answer.
+    store.getState()._mergeAcpHistory(envelopeFixture());
+
+    const texts = store
+      .getState()
+      .messages.filter((msg) => (msg.text ?? '').length > 0)
+      .map((msg) => ({ role: msg.role, text: msg.text }));
+
+    expect(texts).toEqual([
+      {
+        role: 'user',
+        text: '<request>Investigate the queued follow-up flow</request>',
+      },
+      {
+        role: 'assistant',
+        text: 'Reading the repo guidance and then tracing the flow.',
+      },
+      { role: 'assistant', text: 'Here is the full turn-one answer.' },
+      {
+        role: 'user',
+        text: 'Yes - produce the tighter walkthrough for all three flows.',
+      },
+      { role: 'assistant', text: 'Here is the full turn-two answer.' },
+      {
+        role: 'user',
+        text: 'Quick change of direction: skip the snapshot-resume flow.',
+      },
+      {
+        role: 'assistant',
+        text: 'Skipping snapshot resume. Here is the steered answer.',
+      },
+    ]);
+  });
+
+  it('keeps the transcript intact when a refetch merges over a loaded history', () => {
+    const store = createAcpStore();
+
+    // Initial page load hydrates via the envelope loader...
+    store.getState()._loadAcpHistory(envelopeFixture());
+
+    const loadedTexts = store
+      .getState()
+      .messages.filter((msg) => (msg.text ?? '').length > 0)
+      .map((msg) => ({ role: msg.role, text: msg.text }));
+
+    // ...then the connect-triggered envelope refetch merges the same
+    // envelopes again (this is what happens on every live page).
+    store.getState()._mergeAcpHistory(envelopeFixture());
+    store.getState()._mergeAcpHistory(envelopeFixture());
+
+    const mergedTexts = store
+      .getState()
+      .messages.filter((msg) => (msg.text ?? '').length > 0)
+      .map((msg) => ({ role: msg.role, text: msg.text }));
+
+    expect(mergedTexts).toEqual(loadedTexts);
+  });
+
+  it('inserts a refetched envelope the socket missed in timestamp order', () => {
+    const store = createAcpStore();
+    const fixture = envelopeFixture();
+
+    // Page loads history before the steer prompt was persisted...
+    store.getState()._loadAcpHistory(fixture.slice(0, 8));
+
+    // ...the steered answer arrives over the live socket...
+    store.getState()._handleAcpEvent(fixture[9] as never);
+
+    // ...and the steer user prompt itself only shows up in the next
+    // envelope refetch (the socket connection missed it).
+    store.getState()._mergeAcpHistory(fixture);
+
+    const texts = store
+      .getState()
+      .messages.filter((msg) => (msg.text ?? '').length > 0)
+      .map((msg) => msg.text);
+
+    const steerIndex = texts.findIndex((text) =>
+      text?.startsWith('Quick change of direction'),
+    );
+    const answerIndex = texts.findIndex((text) =>
+      text?.startsWith('Skipping snapshot resume'),
+    );
+
+    expect(steerIndex).toBeGreaterThan(-1);
+    expect(answerIndex).toBeGreaterThan(-1);
+    expect(steerIndex).toBeLessThan(answerIndex);
+  });
+
+  it('recovers the full transcript when live state has collapsed to a subset', () => {
+    const store = createAcpStore();
+    const fixture = envelopeFixture();
+
+    // Simulate the corruption observed on live sessions (openmote task
+    // 190holbb4xm2k, 2026-07-09): the in-memory transcript collapsed to just
+    // the initial prompt and the latest answer while the server still held
+    // every envelope.
+    store.getState()._loadAcpHistory([fixture[0]!, fixture[9]!]);
+    expect(store.getState().messages.length).toBeLessThan(4);
+
+    // The next envelope refetch must converge the UI back to server truth.
+    store.getState()._mergeAcpHistory(fixture);
+
+    const texts = store
+      .getState()
+      .messages.filter((msg) => (msg.text ?? '').length > 0)
+      .map((msg) => ({ role: msg.role, text: msg.text }));
+
+    expect(texts).toEqual([
+      {
+        role: 'user',
+        text: '<request>Investigate the queued follow-up flow</request>',
+      },
+      {
+        role: 'assistant',
+        text: 'Reading the repo guidance and then tracing the flow.',
+      },
+      { role: 'assistant', text: 'Here is the full turn-one answer.' },
+      {
+        role: 'user',
+        text: 'Yes - produce the tighter walkthrough for all three flows.',
+      },
+      { role: 'assistant', text: 'Here is the full turn-two answer.' },
+      {
+        role: 'user',
+        text: 'Quick change of direction: skip the snapshot-resume flow.',
+      },
+      {
+        role: 'assistant',
+        text: 'Skipping snapshot resume. Here is the steered answer.',
+      },
+    ]);
+  });
+
+  it('carries over optimistic and unpersisted live messages across a merge', () => {
+    const store = createAcpStore();
+    const fixture = envelopeFixture();
+
+    store.getState()._loadAcpHistory(fixture);
+
+    // An optimistic send still waiting for its envelope...
+    store.getState()._appendOptimisticAcpEvent({
+      id: 'local:optimistic-1',
+      ts: 2000,
+      eventType: ACP_ENVELOPE_EVENT_TYPES.UserPrompt,
+      role: 'user',
+      kind: 'text',
+      text: 'One more question about the retry timer.',
+      contentBlocks: [textBlock('One more question about the retry timer.')],
+      metadata: { clientMessageId: 'client-optimistic-1' },
+      payload: {
+        text: 'One more question about the retry timer.',
+        clientMessageId: 'client-optimistic-1',
+      },
+    } as never);
+
+    // ...and a live assistant message whose envelope has not persisted yet.
+    store.getState()._handleAcpEvent({
+      id: 'opencode-server:99',
+      ts: 2100,
+      eventType: ACP_ENVELOPE_EVENT_TYPES.AssistantMessage,
+      role: 'assistant',
+      kind: 'text',
+      text: 'Looking into the retry timer now.',
+      contentBlocks: [textBlock('Looking into the retry timer now.')],
+      metadata: {
+        sessionId: SESSION,
+        logicalEventId: `${SESSION}:msg-live-99:no-tool:${ACP_ENVELOPE_EVENT_TYPES.AssistantMessage}`,
+      },
+      payload: {
+        sessionId: SESSION,
+        text: 'Looking into the retry timer now.',
+      },
+    } as never);
+
+    // A refetch that does NOT yet include either message must keep both.
+    store.getState()._mergeAcpHistory(fixture);
+
+    const texts = store.getState().messages.map((msg) => msg.text ?? '');
+    expect(texts).toContain('One more question about the retry timer.');
+    expect(texts).toContain('Looking into the retry timer now.');
+
+    // They stay in timestamp order at the tail.
+    const lastTwo = store.getState().messages.slice(-2);
+    expect(lastTwo[0]?.text).toBe('One more question about the retry timer.');
+    expect(lastTwo[1]?.text).toBe('Looking into the retry timer now.');
+  });
+
+  it('returns the same state reference when a refetch changes nothing', () => {
+    const store = createAcpStore();
+    const fixture = envelopeFixture();
+
+    store.getState()._loadAcpHistory(fixture);
+    const before = store.getState().messages;
+
+    store.getState()._mergeAcpHistory(fixture);
+
+    expect(store.getState().messages).toBe(before);
+  });
+
+  it('heals drifted message content that kept a persisted envelope id', () => {
+    const store = createAcpStore();
+    const fixture = envelopeFixture();
+
+    // Live drift can leave a message with the right envelope id but wrong
+    // content (e.g. a replacement applied at a stale index). An id-based
+    // incremental merge skips such envelopes forever; the rebuild heals it.
+    const drifted = fixture.map((envelope) =>
+      envelope.id === 'env-5'
+        ? {
+            ...envelope,
+            text: 'CORRUPTED',
+            contentBlocks: [textBlock('CORRUPTED')],
+          }
+        : envelope,
+    );
+
+    store.getState()._loadAcpHistory(drifted);
+    expect(
+      store.getState().messages.some((msg) => msg.text === 'CORRUPTED'),
+    ).toBe(true);
+
+    store.getState()._mergeAcpHistory(fixture);
+
+    const texts = store.getState().messages.map((msg) => msg.text ?? '');
+    expect(texts).not.toContain('CORRUPTED');
+    expect(texts).toContain('Here is the full turn-one answer.');
+  });
+});

--- a/apps/web/src/app/(sandbox)/task/[taskId]/hooks/__tests__/use-sandbox-store.client.test.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/hooks/__tests__/use-sandbox-store.client.test.ts
@@ -281,12 +281,14 @@ describe('createSandboxStore', () => {
       }),
     ]);
 
+    // The refreshed history is authoritative: the surviving message is the
+    // persisted envelope (its id is the durable anchor used by reloads and
+    // the historical view), not the ephemeral live twin.
     expect(store.getState().messages).toMatchObject([
       {
-        id: 'live:slack-follow-up',
+        id: 'persisted:slack-follow-up',
         text: 'So what is it',
         clientMessageId: 'slack:1710000000.123',
-        optimistic: false,
       },
     ]);
     expect(store.getState().messages).toHaveLength(1);

--- a/apps/web/src/app/(sandbox)/task/[taskId]/hooks/use-sandbox-store.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/hooks/use-sandbox-store.ts
@@ -8,6 +8,7 @@ import {
   ACP_ENVELOPE_EVENT_TYPES,
   ACP_LIVE_EVENT_TYPES,
   ROOMOTE_RUNTIME_TASK_MESSAGE_PROTOCOL,
+  canonicalizeAcpLogicalEventId,
 } from '@roomote/types';
 
 import type { TaskMessageEnvelope } from '@/types';
@@ -218,6 +219,91 @@ function getOptimisticUserTextDedupeKey(message: AcpUiMessage): string | null {
   }
 
   return [message.sessionId ?? '', message.kind, text].join('\u0000');
+}
+
+/**
+ * Identity keys that link a live in-memory message to its persisted
+ * counterpart in a rebuilt transcript. Live messages carry ephemeral ids
+ * (`opencode-server:N`), so reconciliation matches on the durable
+ * identities both sides share: the logical event id, the user prompt's
+ * clientMessageId, the tool call id, and the emitter timestamp of the
+ * originating runtime event.
+ */
+function getMergeCoverageKeys(message: AcpUiMessage): string[] {
+  const keys: string[] = [`id:${message.id}`];
+
+  const logicalEventId = canonicalizeAcpLogicalEventId(
+    message.logicalEventId ?? null,
+  );
+
+  if (logicalEventId) {
+    keys.push(`logical:${logicalEventId}`);
+  }
+
+  if (message.role === 'user' && message.clientMessageId) {
+    keys.push(`client:${message.clientMessageId}`);
+  }
+
+  if (
+    (message.kind === 'tool_call' || message.kind === 'tool_result') &&
+    message.toolCallId
+  ) {
+    keys.push(`tool:${message.toolCallId}`);
+  }
+
+  if (message.optimistic !== true) {
+    keys.push(
+      `event:${message.updateType ?? message.kind}|${message.sessionId ?? ''}|${message.ts}`,
+    );
+  }
+
+  return keys;
+}
+
+function isSameRenderedMessageList(
+  left: AcpUiMessage[],
+  right: AcpUiMessage[],
+): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  for (let index = 0; index < left.length; index += 1) {
+    const a = left[index]!;
+    const b = right[index]!;
+
+    if (
+      a.id !== b.id ||
+      a.ts !== b.ts ||
+      a.kind !== b.kind ||
+      a.partial !== b.partial ||
+      a.isTurnCompletion !== b.isTurnCompletion ||
+      (a.text ?? '') !== (b.text ?? '')
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isSameTodoList(left: AcpPlanTodo[], right: AcpPlanTodo[]): boolean {
+  if (left === right) {
+    return true;
+  }
+
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((todo, index) => {
+    const other = right[index]!;
+    return (
+      todo.id === other.id &&
+      todo.content === other.content &&
+      todo.status === other.status
+    );
+  });
 }
 
 function chooseLogicalEventMessage(
@@ -721,34 +807,58 @@ export function createSandboxStore(
         const sorted = envelopes.slice().sort(compareHistoricalEnvelopeOrder);
 
         set((state) => {
-          const existingIds = new Set(state.messages.map((msg) => msg.id));
-          let messages = state.messages;
-          let todos = state.todos;
+          // Rebuild the transcript from the persisted envelopes with the
+          // same builder the historical view uses, instead of patching the
+          // live in-memory list envelope-by-envelope through the live-event
+          // handler. Every refetch thereby converges the UI to the server's
+          // authoritative transcript, so any live-session drift (missed
+          // socket events, mis-applied replacements, ordering skew) heals on
+          // the next refetch rather than persisting until the sandbox
+          // sleeps.
+          const rebuilt = acpService.loadAcpEnvelopes(sorted);
 
-          for (const envelope of sorted) {
-            if (existingIds.has(envelope.id)) {
-              continue;
-            }
+          const envelopeIds = new Set(sorted.map((envelope) => envelope.id));
+          const coveredKeys = new Set<string>();
 
-            const result = acpService.applyOutputEvent(
-              messages,
-              envelope as unknown as AcpMessage,
-            );
-
-            if (!result) {
-              continue;
-            }
-
-            messages = result.acpMessages;
-
-            if ('todos' in result && result.todos) {
-              todos = result.todos;
+          for (const message of rebuilt.acpMessages) {
+            for (const key of getMergeCoverageKeys(message)) {
+              coveredKeys.add(key);
             }
           }
 
-          const normalized = normalizeMergedAcpMessages(messages);
+          // Keep what the fetch does not cover yet: optimistic sends and
+          // live-only messages whose envelopes have not been persisted.
+          // Everything the rebuilt transcript covers — matched by id,
+          // logical event id, user clientMessageId, tool call id, or the
+          // emitter timestamp of the same event — is dropped in favor of
+          // the persisted version.
+          const carriedOver = state.messages.filter((message) => {
+            if (envelopeIds.has(message.id)) {
+              return false;
+            }
 
-          if (messages === state.messages && !normalized.changed) {
+            return !getMergeCoverageKeys(message).some((key) =>
+              coveredKeys.has(key),
+            );
+          });
+
+          // Carried-over messages go first so an optimistic user prompt is
+          // indexed before its persisted counterpart and gets replaced by
+          // the text-dedupe pass; the final order is by timestamp anyway.
+          const normalized = normalizeMergedAcpMessages([
+            ...carriedOver,
+            ...rebuilt.acpMessages,
+          ]);
+          const todos = rebuilt.todos.length > 0 ? rebuilt.todos : state.todos;
+
+          if (
+            isSameRenderedMessageList(state.messages, normalized.messages) &&
+            isSameTodoList(state.todos, todos)
+          ) {
+            // Nothing user-visible changed — keep the existing references
+            // (no re-render), but leave the service indexes pointing at the
+            // kept array's ids/positions, which are identical by check.
+            acpService.setMessages(state.messages);
             return state;
           }
 


### PR DESCRIPTION
## What problem this solves

Root-cause fix for the live-session transcript corruption from the steering test pass (tasks `190holbb4xm2k`, `11nl0xsy05oyl` on openmote): transcripts collapsing to the initial prompt + latest answer after a reload, blank renders mid-session, steered messages rendering out of chronological order, and missed live replies staying missing — always self-resolving once the sandbox slept (historical rendering was always correct, and server envelope data was always intact).

## Root cause

The live page reconstructed history through **two different code paths**:
- Initial load: `loadAcpEnvelopes` — the envelope-aware builder the historical view uses (always correct).
- Every subsequent refetch: `_mergeAcpHistory` patched the in-memory list envelope-by-envelope **through the live-event handler**, and skipped any envelope whose id was already present.

The skip-by-id rule means any drift in the live in-memory state (missed socket events, replacements at stale indexes, ordering skew) could never be corrected by a refetch — it persisted until the sandbox slept and the page fell back to the historical loader.

## What changed

- `_mergeAcpHistory` now **rebuilds** the transcript from the fetched envelopes with the same `loadAcpEnvelopes` builder, then carries over only messages the fetch doesn't cover yet: optimistic sends and live-only events, matched via logical event id, user `clientMessageId`, `toolCallId`, or the originating event timestamp. Every refetch — which fires on every socket (re)connect — is now a convergence point to the server's authoritative transcript.
- Duplicate live/persisted twins resolve to the **persisted** message (its id is the durable anchor reloads and the historical view use). One existing test expectation updated accordingly.
- An identical refetch returns the exact previous references (no re-render churn).

## Provability

The new `steered-task-history.client.test.ts` suite (7 tests) includes a drift-healing case — content corrupted under a matching envelope id — that **fails against the previous merge implementation** (verified: 1 failed / 6 passed on the old code) and passes with the rebuild. Also covered: collapse-recovery to full transcript, carried-over optimistic + unpersisted live messages, timestamp ordering for envelopes the socket missed, and the no-change fast path.

## Validation

Full `src/app/(sandbox)/task/` suite green (483 tests, incl. the 64-case store suite), `pnpm lint:fast` + `check-types:fast` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)