### PR TITLE
[Feat] Show a typing indicator while delivering Telegram replies

### DIFF
--- a/.agent-guidance/features/telegram-integration.md
+++ b/.agent-guidance/features/telegram-integration.md
@@ -198,6 +198,15 @@ current user.
   (`apps/api/src/handlers/mcp/slack.ts`). Image artifacts are sent as native
   photos via `sendPhoto` (Telegram fetches the artifact URL), falling back to
   a caption-plus-link text message when Telegram rejects the URL.
+- While a reply is being delivered, `sendTelegramThreadReply` shows a
+  "typing…" chat action (`provider.sendChatAction`) on a ~4s heartbeat
+  (`startTelegramTypingHeartbeat`), stopping the instant delivery finishes.
+  The reply text is composed on the worker before the API is called, so this
+  spans the delivery window (chunks, photo fetch, footer), not the work
+  phase — it never lingers during idle or long silences, and a chat-action
+  failure never blocks the reply. Telegram auto-clears the action after ~5s
+  and when the message lands, so it is a fire-and-forget burst, not a state
+  to turn off.
 - Inbound messages that are queued to an active job or accepted as task
   entries get an eyes-emoji ack reaction (`ackTelegramMessageBestEffort`),
   mirroring Slack's ack. Bot reactions are limited to Telegram's fixed
@@ -271,9 +280,17 @@ codes, analogous to `slack_user_mappings`), routing confirmation with a
 manual workspace picker (same Yes/Nope-then-picker two-step as Slack, via
 inline keyboard + `editMessageText`; same 0.95 confidence gate but a ~5s
 auto-confirm vs Slack's 30s constant; router fallback shows the picker
-instead of silently launching in all repos). Unlike Slack there is no free-text correction
-while a confirmation is pending — a new message in the chat starts a fresh
-routing flow and invalidates the old card.
+instead of silently launching in all repos), and a "typing…" indicator while
+a reply is delivered (`sendChatAction` heartbeat, bounded to the send).
+Unlike Slack there is no free-text correction while a confirmation is
+pending — a new message in the chat starts a fresh routing flow and
+invalidates the old card.
+
+The typing indicator is scoped to reply delivery, not the work phase: there
+is no worker→API progress signal before a reply is composed (the worker
+sends the finished text), so the long silence between the eyes ack and the
+first reply is still unfilled. A "still working" status line during that
+silence remains a possible future addition (would reuse `editMessageText`).
 
 Not supported (Bot API or product limitations): thread/channel history reads,
 account-link education, MCP setup

--- a/.agents/skills/mock-telegram-testing/references/scenarios.md
+++ b/.agents/skills/mock-telegram-testing/references/scenarios.md
@@ -130,8 +130,17 @@ When the router is unsure (confidence < 0.95, workspace remapped, or all-reposit
 - Expect: suggestion claimed atomically (double taps do not double-launch), task launched through normal routing.
 - Assert: DB `agentSuggestionMessages.launchClaimedAt`; state.
 
+## 17. typing-indicator
+
+While a worker reply is being delivered, the bot shows "typing…".
+
+- Drive a running task to post a `send_chat_reply` (or call the MCP thread-reply endpoint directly), OR unit-test the provider: `provider.sendChatAction({ channelId })`.
+- Expect: one or more `sendChatAction` calls with `action: "typing"` for the chat, fired on a ~4s heartbeat that stops the moment delivery finishes. It never fires during the idle/work phase (no worker→API signal exists before the reply is composed).
+- Assert: state `.chatActions` (array of `{ chat_id, action, message_thread_id? }`); the reply message(s) still land even if the typing action errors (best-effort).
+- Note: Telegram auto-clears a chat action after ~5s and when the message lands, so a single short reply shows one brief flash; a long chunked/photo reply re-fires until the last message posts.
+
 ## Known parity gaps (do not file as harness bugs)
 
-- No progress streaming or typing indicator: between the eyes ack and the final reply, the chat is silent by design (current gap).
+- No "still working" indicator during the long silence: the typing indicator is scoped to reply _delivery_, so the gap between the eyes ack and the first reply is unfilled (no worker→API pre-reply signal exists). A status line via `editMessageText` would be a future addition.
 - No free-text routing correction: while a confirmation card is pending, a new message starts a fresh routing flow (and invalidates the old card) instead of being classified as confirm/cancel/correct like Slack.
 - No thread/channel history reads: the Bot API cannot fetch history, so routing sees only the current message and queued follow-ups.

--- a/apps/api/src/handlers/mcp/__tests__/communication-thread-replies.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/communication-thread-replies.test.ts
@@ -6,6 +6,7 @@ const {
   envMock,
   getLatestInboundMessageIdMock,
   postMessageMock,
+  sendChatActionMock,
   resolveTelegramRuntimeCredentialsMock,
   withThreadReplyFooterLockMock,
 } = vi.hoisted(() => ({
@@ -13,6 +14,7 @@ const {
   envMock: { ROOMOTE_APP_URL: 'https://app.example.com' },
   getLatestInboundMessageIdMock: vi.fn(),
   postMessageMock: vi.fn(),
+  sendChatActionMock: vi.fn(),
   resolveTelegramRuntimeCredentialsMock: vi.fn(),
   withThreadReplyFooterLockMock: vi.fn(),
 }));
@@ -28,7 +30,7 @@ vi.mock('@roomote/communication', () => ({
   formatMarkdownLink: vi.fn(),
   getThreadReplyFooterRecord: vi.fn(),
   TelegramCommunicationProvider: vi.fn().mockImplementation(function () {
-    return { postMessage: postMessageMock };
+    return { postMessage: postMessageMock, sendChatAction: sendChatActionMock };
   }),
   TeamsCommunicationProvider: vi.fn(),
   UnsupportedCommunicationOperationError: class UnsupportedCommunicationOperationError extends Error {},
@@ -227,6 +229,7 @@ describe('maybeSendCommunicationThreadReply (Telegram)', () => {
     buildThreadReplyImagesMock.mockResolvedValue([]);
     getLatestInboundMessageIdMock.mockResolvedValue(null);
     postMessageMock.mockResolvedValue({ messageId: '999' });
+    sendChatActionMock.mockResolvedValue(undefined);
     // Skip the footer path by returning null footer (resolveSlackThreadLinkedPr mocked)
   });
 
@@ -276,6 +279,31 @@ describe('maybeSendCommunicationThreadReply (Telegram)', () => {
         channelId: '222',
         replyToMessageId: '100',
       }),
+    );
+  });
+
+  it('shows a typing action for the chat while delivering the reply', async () => {
+    await maybeSendCommunicationThreadReply({
+      cloudJob: telegramCloudJob,
+      parsedBody: { text: 'done', images: [] },
+    });
+
+    expect(sendChatActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ channelId: '222' }),
+    );
+  });
+
+  it('delivers the reply even if the typing action fails', async () => {
+    sendChatActionMock.mockRejectedValue(new Error('typing failed'));
+
+    const response = await maybeSendCommunicationThreadReply({
+      cloudJob: telegramCloudJob,
+      parsedBody: { text: 'done', images: [] },
+    });
+
+    expect(response).not.toBeNull();
+    expect(postMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({ channelId: '222', text: 'done' }),
     );
   });
 });

--- a/apps/api/src/handlers/mcp/communication-thread-replies.ts
+++ b/apps/api/src/handlers/mcp/communication-thread-replies.ts
@@ -28,6 +28,42 @@ const TEAMS_THREAD_REPLY_FOOTER_LOCK_PREFIX = 'teams:thread_reply_footer_lock:';
 const TELEGRAM_THREAD_REPLY_FOOTER_LOCK_PREFIX =
   'telegram:thread_reply_footer_lock:';
 
+// Telegram clears a chat action after ~5s; re-send inside that window so the
+// "typing…" indicator spans the whole reply delivery (chunks, photo fetch,
+// footer) instead of lapsing partway through.
+const TELEGRAM_TYPING_HEARTBEAT_MS = 4_000;
+
+/**
+ * Show "typing…" while a Telegram reply is being delivered. Fires immediately,
+ * then on a heartbeat until the returned stop function runs. Entirely
+ * best-effort: a chat-action failure must never disrupt the actual reply.
+ */
+function startTelegramTypingHeartbeat(
+  provider: TelegramCommunicationProvider,
+  input: { channelId: string; threadId?: string },
+): () => void {
+  const fire = () => {
+    void provider
+      .sendChatAction({
+        channelId: input.channelId,
+        ...(input.threadId ? { threadId: input.threadId } : {}),
+      })
+      .catch((error) => {
+        console.error(
+          `[${LOG_CONTEXT}] Telegram typing action failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      });
+  };
+
+  fire();
+  const timer = setInterval(fire, TELEGRAM_TYPING_HEARTBEAT_MS);
+  timer.unref?.();
+
+  return () => clearInterval(timer);
+}
+
 async function createTeamsCommunicationProvider(): Promise<TeamsCommunicationProvider | null> {
   return createTeamsCommunicationProviderFromRuntimeCredentials();
 }
@@ -249,21 +285,34 @@ async function sendTelegramThreadReply(params: {
     );
   }
 
-  const reply = await provider.postMessage({
+  // The reply text is already composed by the worker; the only window the API
+  // owns is this delivery. Show "typing…" across it so the message(s) don't
+  // land abruptly after the silence, and stop the instant delivery finishes.
+  const stopTyping = startTelegramTypingHeartbeat(provider, {
     channelId,
     ...(threadId ? { threadId } : {}),
-    replyToMessageId: replyToMessageId ?? undefined,
-    ...(text ? { text } : {}),
-    textFormat: 'markdown',
-    images,
   });
 
-  await postTelegramThreadReplyFooterBestEffort({
-    provider,
-    cloudJob: params.cloudJob,
-    channelId,
-    threadId,
-  });
+  let reply;
+  try {
+    reply = await provider.postMessage({
+      channelId,
+      ...(threadId ? { threadId } : {}),
+      replyToMessageId: replyToMessageId ?? undefined,
+      ...(text ? { text } : {}),
+      textFormat: 'markdown',
+      images,
+    });
+
+    await postTelegramThreadReplyFooterBestEffort({
+      provider,
+      cloudJob: params.cloudJob,
+      channelId,
+      threadId,
+    });
+  } finally {
+    stopTyping();
+  }
 
   return new Response(JSON.stringify({ messageTs: reply.messageId }), {
     headers: { 'content-type': 'application/json' },

--- a/packages/communication/src/__tests__/mock-telegram-server.test.ts
+++ b/packages/communication/src/__tests__/mock-telegram-server.test.ts
@@ -290,6 +290,38 @@ describe('MockTelegramServer', () => {
     ).rejects.toThrow('message to edit not found');
   });
 
+  it('records typing chat actions through sendChatAction', async () => {
+    const { server, baseUrl } = await startServer();
+    onCleanup(() => server.stop());
+
+    const provider = providerFor(baseUrl);
+    await provider.sendChatAction({ channelId: '111000111' });
+    await provider.sendChatAction({
+      channelId: '-100222000222',
+      action: 'upload_photo',
+      threadId: '7',
+    });
+
+    expect(server.getState().chatActions).toEqual([
+      { chat_id: '111000111', action: 'typing' },
+      {
+        chat_id: '-100222000222',
+        action: 'upload_photo',
+        message_thread_id: 7,
+      },
+    ]);
+  });
+
+  it('rejects a chat action to an unknown chat', async () => {
+    const { server, baseUrl } = await startServer();
+    onCleanup(() => server.stop());
+
+    const provider = providerFor(baseUrl);
+    await expect(
+      provider.sendChatAction({ channelId: '999999999' }),
+    ).rejects.toThrow('chat not found');
+  });
+
   it('replaces the inline keyboard through editMessageReplyMarkup', async () => {
     const { server, baseUrl } = await startServer();
     onCleanup(() => server.stop());

--- a/packages/communication/src/mock-telegram-server.ts
+++ b/packages/communication/src/mock-telegram-server.ts
@@ -60,6 +60,12 @@ export type MockTelegramCallbackAnswer = {
   text?: string;
 };
 
+export type MockTelegramChatAction = {
+  chat_id: string;
+  action: string;
+  message_thread_id?: number;
+};
+
 /**
  * Failure-injection knobs. Real Telegram rejects whole requests for these
  * cases; the flags let tests exercise the provider's fallback paths.
@@ -84,6 +90,7 @@ export type MockTelegramState = {
   messages?: MockTelegramStoredMessage[];
   webhook?: MockTelegramWebhookRegistration;
   callbackAnswers?: MockTelegramCallbackAnswer[];
+  chatActions?: MockTelegramChatAction[];
   behavior?: MockTelegramBehavior;
 };
 
@@ -164,6 +171,7 @@ function normalizeState(state: MockTelegramState): MockTelegramState {
       reactions: message.reactions ?? [],
     })),
     callbackAnswers: [...(state.callbackAnswers ?? [])],
+    chatActions: [...(state.chatActions ?? [])],
   };
 }
 
@@ -729,6 +737,28 @@ export class MockTelegramServer {
           {
             callback_query_id: callbackQueryId,
             ...(typeof body.text === 'string' ? { text: body.text } : {}),
+          },
+        ];
+        apiResult(response, true);
+        return;
+      }
+
+      case 'sendChatAction': {
+        const chat = this.findChat(body.chat_id);
+
+        if (!chat) {
+          apiError(response, 400, 'Bad Request: chat not found');
+          return;
+        }
+
+        this.state.chatActions = [
+          ...(this.state.chatActions ?? []),
+          {
+            chat_id: String(body.chat_id),
+            action: String(body.action ?? ''),
+            ...(typeof body.message_thread_id === 'number'
+              ? { message_thread_id: body.message_thread_id }
+              : {}),
           },
         ];
         apiResult(response, true);

--- a/packages/communication/src/telegram-provider.ts
+++ b/packages/communication/src/telegram-provider.ts
@@ -385,6 +385,25 @@ export class TelegramCommunicationProvider implements CommunicationProviderAdapt
     });
   }
 
+  /**
+   * Show a chat action (default `typing`). Telegram displays it for ~5s then
+   * clears it automatically, and any message the bot sends clears it early —
+   * so this is a fire-and-forget burst, re-sent on a heartbeat to span a
+   * longer reply delivery, never a state that must be turned off.
+   */
+  async sendChatAction(input: {
+    channelId: string;
+    action?: string;
+    threadId?: string;
+  }): Promise<void> {
+    const threadId = parsePositiveInteger(input.threadId);
+    await this.callBotApi('sendChatAction', {
+      chat_id: input.channelId,
+      action: input.action ?? 'typing',
+      ...(threadId ? { message_thread_id: threadId } : {}),
+    });
+  }
+
   /** Delete a message the bot sent (Bot API allows this within 48 hours). */
   async deleteMessage(input: {
     channelId: string;


### PR DESCRIPTION
## What

Telegram tasks were silent between the 👀 ack and the final reply. This adds a bounded "typing…" indicator so replies don't land abruptly.

**Key constraint (why it's scoped to delivery):** the reply text is composed on the worker and arrives at the API already finished — there's no worker→API signal before composition. So the only window the API owns is the reply's *delivery*. `sendTelegramThreadReply` now runs a "typing…" heartbeat (`sendChatAction` every ~4s) across that delivery — chunks, photo fetch, footer — and stops the instant it finishes. It never fires during the idle/work phase, so there's no risk of a perpetual/"broken-looking" typing state. Telegram auto-clears the action after ~5s and when a message lands, so it's a fire-and-forget burst, not a state to turn off.

## Changes
- `TelegramCommunicationProvider.sendChatAction` (default `typing`) via the existing `callBotApi` helper.
- `startTelegramTypingHeartbeat` wraps the send in `try/finally` so the timer always clears; the interval is `unref`'d so it can't keep the process alive; chat-action failures are swallowed (best-effort) and never block the reply.
- Mock Telegram harness gains a `sendChatAction` route recording `state.chatActions`, plus scenario-catalog coverage.

## Testing
- Provider→mock integration over real HTTP (harness suite), handler heartbeat fires and tolerates a failing chat action — 26 tests across `mock-telegram-server.test.ts` and `communication-thread-replies.test.ts`.
- Standalone real-HTTP check of the new mock route (valid chat records the action; unknown chat 400s).
- Validated on the current `develop` base in an isolated worktree: typecheck, lint, format, knip, knowledge-check all clean.

Note: a full worker-driven reply wasn't run live (needs a whole cloud job reaching `send_chat_reply`); the provider/mock path is covered by real-HTTP integration tests instead.

## Docs
`.agent-guidance/features/telegram-integration.md` (outbound flow + parity notes) and the `mock-telegram-testing` scenario catalog updated. A "still working" status line for the pre-reply silence is noted as a possible future addition (would reuse `editMessageText`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)