### PR TITLE
[Fix] Auto-start channel save blocked by an unrelated unresolvable channel

### DIFF
--- a/apps/web/src/components/settings/automations/AutomationsSettings.client.test.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.client.test.tsx
@@ -229,6 +229,7 @@ describe('Automations selection helpers', () => {
       ...baseFormState,
       channelAutoStartSlackChannels: [
         {
+          channelId: null,
           slackChannel: '#bugs',
           instructions: 'Treat each message as a bug report.',
           launchMode: DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
@@ -251,6 +252,7 @@ describe('Automations selection helpers', () => {
 
     expect(saveState.channelAutoStartSlackChannels).toEqual([
       {
+        channelId: null,
         slackChannel: '#bugs',
         instructions: 'Treat each message as a bug report.',
         launchMode: DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
@@ -258,6 +260,39 @@ describe('Automations selection helpers', () => {
       },
     ]);
     expect(saveState.managerSlackChannel).toBe('#managers');
+  });
+
+  it('sends the persisted channel id for an untouched channel auto-start row so the server resolves it by id instead of by name', () => {
+    const currentFormState: FormState = {
+      ...baseFormState,
+      channelAutoStartSlackChannels: [
+        // Hydrated from the server: a channel the user is not editing. Its name
+        // may no longer resolve (archived/renamed), but its id still does.
+        {
+          channelId: 'C0DEEP',
+          slackChannel: '#deepstrike-roo',
+          instructions: 'Handle deep strike reports.',
+          launchMode: DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
+          launchCriteria: '',
+        },
+      ],
+    };
+
+    const saveInput = buildAutomationSettingsSaveInput(
+      currentFormState,
+      baseFormState,
+      'channelAutoStart',
+    );
+
+    expect(saveInput.channelAutoStartSlackChannels).toEqual([
+      {
+        channelId: 'C0DEEP',
+        slackChannel: '#deepstrike-roo',
+        instructions: 'Handle deep strike reports.',
+        launchMode: DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
+        launchCriteria: null,
+      },
+    ]);
   });
 
   it('builds an API save input from the merged agent save state', () => {
@@ -320,6 +355,7 @@ describe('Automations selection helpers', () => {
         instructions: 'Treat each message as a bug report.',
       }),
     ).toEqual({
+      channelId: null,
       slackChannel: '#bugs',
       instructions: 'Treat each message as a bug report.',
       launchMode: DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
@@ -331,6 +367,7 @@ describe('Automations selection helpers', () => {
     expect(
       getAvailableAutoRespondChannelTemplates([
         {
+          channelId: null,
           slackChannel: '#bugs',
           instructions: 'Treat each message as a bug report.',
           launchMode: DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
@@ -344,24 +381,28 @@ describe('Automations selection helpers', () => {
     expect(
       getAvailableAutoRespondChannelTemplates([
         {
+          channelId: null,
           slackChannel: '#bugs',
           instructions: 'Treat each message as a bug report.',
           launchMode: DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
           launchCriteria: '',
         },
         {
+          channelId: null,
           slackChannel: '#support-inbound',
           instructions: 'Treat each message as a support request.',
           launchMode: DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
           launchCriteria: '',
         },
         {
+          channelId: null,
           slackChannel: '#ask-engineering',
           instructions: 'Treat each message as a technical question.',
           launchMode: DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
           launchCriteria: '',
         },
         {
+          channelId: null,
           slackChannel: '#ops-requests',
           instructions: 'Treat each message as an operational request.',
           launchMode: DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
@@ -376,6 +417,7 @@ describe('Automations selection helpers', () => {
       ...baseFormState,
       channelAutoStartSlackChannels: [
         {
+          channelId: 'C0BUGS',
           slackChannel: '#bugs',
           instructions: '',
           launchMode: DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
@@ -388,6 +430,7 @@ describe('Automations selection helpers', () => {
       ...baseFormState,
       channelAutoStartSlackChannels: [
         {
+          channelId: 'C0BUGS',
           slackChannel: '#bugs',
           instructions: 'Treat each message as a bug report.',
           launchMode: DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
@@ -404,6 +447,7 @@ describe('Automations selection helpers', () => {
 
     expect(saveState.channelAutoStartSlackChannels).toEqual([
       {
+        channelId: 'C0BUGS',
         slackChannel: '#bugs',
         instructions: '',
         launchMode: DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,

--- a/apps/web/src/components/settings/automations/AutomationsSettings.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.tsx
@@ -674,6 +674,7 @@ function mapSettingsToFormState(
     conflictResolverInstructions: settings.conflictResolverInstructions ?? '',
     channelAutoStartSlackChannels: settings.channelAutoStartSlackChannels.map(
       ({ channelId, instructions, launchMode, launchCriteria }) => ({
+        channelId,
         slackChannel:
           settings.channelAutoStartSlackChannelNames?.[channelId] ??
           channelId ??

--- a/apps/web/src/components/settings/automations/ChannelAutoStartEditor.client.test.tsx
+++ b/apps/web/src/components/settings/automations/ChannelAutoStartEditor.client.test.tsx
@@ -34,15 +34,17 @@ function renderEditor(rows: ChannelAutoStartFormRow[]) {
 }
 
 describe('ChannelAutoStartEditor', () => {
-  it('updates launch criteria within the edited row', () => {
+  it('updates launch criteria within the edited row while keeping every persisted channel id', () => {
     const { onRowsChange } = renderEditor([
       {
+        channelId: 'C0BUGS',
         slackChannel: '#bugs',
         instructions: 'Treat each message as a bug report.',
         launchMode: DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
         launchCriteria: '',
       },
       {
+        channelId: 'C0OPS',
         slackChannel: '#ops',
         instructions: 'Treat each message as an incident.',
         launchMode: DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
@@ -57,18 +59,50 @@ describe('ChannelAutoStartEditor', () => {
       },
     );
 
+    // Editing a non-channel field must preserve the persisted channel ids so
+    // the server keeps resolving those rows by id rather than by name.
     expect(onRowsChange).toHaveBeenCalledWith([
       {
+        channelId: 'C0BUGS',
         slackChannel: '#bugs',
         instructions: 'Treat each message as a bug report.',
         launchMode: DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
         launchCriteria: 'Only launch on new production incidents.',
       },
       {
+        channelId: 'C0OPS',
         slackChannel: '#ops',
         instructions: 'Treat each message as an incident.',
         launchMode: DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
         launchCriteria: 'Only launch on new incidents.',
+      },
+    ]);
+  });
+
+  it('clears the persisted channel id when the channel field is edited', () => {
+    const { onRowsChange } = renderEditor([
+      {
+        channelId: 'C0BUGS',
+        slackChannel: '#bugs',
+        instructions: 'Treat each message as a bug report.',
+        launchMode: DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
+        launchCriteria: '',
+      },
+    ]);
+
+    fireEvent.change(screen.getByLabelText('Monitor this Slack channel'), {
+      target: { value: '#bugs-triage' },
+    });
+
+    // A changed channel invalidates the persisted id, so it must be dropped and
+    // re-resolved from the new name on save.
+    expect(onRowsChange).toHaveBeenCalledWith([
+      {
+        channelId: null,
+        slackChannel: '#bugs-triage',
+        instructions: 'Treat each message as a bug report.',
+        launchMode: DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
+        launchCriteria: '',
       },
     ]);
   });
@@ -80,6 +114,7 @@ describe('ChannelAutoStartEditor', () => {
 
     expect(onRowsChange).toHaveBeenCalledWith([
       {
+        channelId: null,
         slackChannel: '',
         instructions: '',
         launchMode: DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,

--- a/apps/web/src/components/settings/automations/ChannelAutoStartEditor.tsx
+++ b/apps/web/src/components/settings/automations/ChannelAutoStartEditor.tsx
@@ -66,6 +66,7 @@ const AUTO_RESPOND_CHANNEL_TEMPLATES: readonly AutoRespondChannelTemplate[] = [
 
 function createEmptyChannelAutoStartRow(): ChannelAutoStartFormRow {
   return {
+    channelId: null,
     slackChannel: '',
     instructions: '',
     launchMode: DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
@@ -77,6 +78,7 @@ export function createChannelAutoStartRowFromTemplate(
   template: Pick<AutoRespondChannelTemplate, 'channel' | 'instructions'>,
 ): ChannelAutoStartFormRow {
   return {
+    channelId: null,
     slackChannel: template.channel,
     instructions: template.instructions,
     launchMode: DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
@@ -153,6 +155,12 @@ export function ChannelAutoStartEditor({
     );
   };
 
+  // Editing the channel invalidates any persisted channel ID, so drop it and
+  // force the server to resolve the new value on save.
+  const changeRowChannel = (rowIndex: number, slackChannel: string) => {
+    updateRow(rowIndex, { slackChannel, channelId: null });
+  };
+
   const addRow = (row: ChannelAutoStartFormRow) => {
     onRowsChange([...rows, row]);
   };
@@ -201,7 +209,7 @@ export function ChannelAutoStartEditor({
                         id={`channel-auto-start-slack-channel-${index}`}
                         value={row.slackChannel || null}
                         onChange={(value) =>
-                          updateRow(index, { slackChannel: value ?? '' })
+                          changeRowChannel(index, value ?? '')
                         }
                         options={slackChannelOptions ?? []}
                         disabled={!slackConnected}
@@ -217,7 +225,7 @@ export function ChannelAutoStartEditor({
                         id={`channel-auto-start-slack-channel-${index}`}
                         value={row.slackChannel}
                         onChange={(event) =>
-                          updateRow(index, { slackChannel: event.target.value })
+                          changeRowChannel(index, event.target.value)
                         }
                         placeholder="#bugs or C123ABC456"
                         className="w-m"

--- a/apps/web/src/components/settings/automations/formState.ts
+++ b/apps/web/src/components/settings/automations/formState.ts
@@ -23,6 +23,11 @@ export type ReviewerEnvironmentScope = 'all' | 'specific';
 export type ReviewerAuthorReviewMode = 'all' | 'specific' | 'none';
 
 export type ChannelAutoStartFormRow = {
+  // Canonical Slack channel ID persisted for this row, or null for rows the
+  // user just added or whose channel field they edited. When present it is the
+  // authoritative identity so saving never has to re-resolve the channel by
+  // name (which fails for archived/renamed/private channels).
+  channelId: string | null;
   slackChannel: string;
   instructions: string;
   launchMode: ChannelAutoStartLaunchMode;
@@ -275,6 +280,7 @@ export function buildAutomationSettingsSaveInput(
       stateToSave.conflictResolverInstructions.trim() || null,
     channelAutoStartSlackChannels:
       stateToSave.channelAutoStartSlackChannels.map((row) => ({
+        channelId: row.channelId,
         slackChannel: row.slackChannel.trim() || null,
         instructions: row.instructions.trim() || null,
         launchMode: row.launchMode,

--- a/apps/web/src/trpc/commands/automations/channel-auto-start.ts
+++ b/apps/web/src/trpc/commands/automations/channel-auto-start.ts
@@ -122,6 +122,7 @@ export function normalizeChannelAutoStartInputRows(params: {
     params.legacyInstructions
       ? [
           {
+            channelId: null,
             slackChannel: params.legacyChannel ?? null,
             instructions: params.legacyInstructions ?? null,
             launchMode: DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
@@ -132,6 +133,7 @@ export function normalizeChannelAutoStartInputRows(params: {
 
   return inputRows
     .map((row) => ({
+      channelId: normalizeOptionalText(row.channelId),
       slackChannel: normalizeOptionalText(row.slackChannel),
       instructions: normalizeOptionalText(row.instructions),
       launchMode:
@@ -140,5 +142,5 @@ export function normalizeChannelAutoStartInputRows(params: {
           : DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
       launchCriteria: normalizeOptionalText(row.launchCriteria),
     }))
-    .filter((row) => row.slackChannel || row.instructions);
+    .filter((row) => row.channelId || row.slackChannel || row.instructions);
 }

--- a/apps/web/src/trpc/commands/automations/settings-update.ts
+++ b/apps/web/src/trpc/commands/automations/settings-update.ts
@@ -367,7 +367,12 @@ export async function updateBackgroundAgentSettingsCommand(
       channelAutoStartRows.map((row) =>
         resolveChannelId({
           field: 'channelAutoStartSlackChannels',
-          input: row.slackChannel,
+          // Prefer the persisted channel ID for untouched rows: resolving by ID
+          // short-circuits without a Slack lookup, so an archived/renamed/private
+          // channel elsewhere in the list can't block saving an edit to another
+          // row. Fall back to the submitted name for new or channel-edited rows.
+          input:
+            normalizeSlackChannelIdInput(row.channelId) ?? row.slackChannel,
           notifier,
         }),
       ),
@@ -556,7 +561,7 @@ export async function updateBackgroundAgentSettingsCommand(
 
   if (
     shouldUpdateChannelAutoStart &&
-    channelAutoStartRows.some((row) => !row.slackChannel) &&
+    channelAutoStartRows.some((row) => !row.slackChannel && !row.channelId) &&
     !fieldErrors.channelAutoStartSlackChannels
   ) {
     fieldErrors.channelAutoStartSlackChannels =

--- a/apps/web/src/trpc/commands/automations/types.ts
+++ b/apps/web/src/trpc/commands/automations/types.ts
@@ -94,6 +94,10 @@ export interface SlackChannelDisplayNames {
 }
 
 export interface ChannelAutoStartInputRow {
+  // Canonical Slack channel ID persisted for this row. When present and valid it
+  // is used as the resolution input so an unchanged row never has to be
+  // re-resolved by name on save. Null/absent for new or channel-edited rows.
+  channelId?: string | null;
   slackChannel: string | null;
   instructions: string | null;
   launchMode?: ChannelAutoStartLaunchMode | null;

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -414,6 +414,7 @@ const automationsRouter = createRouter({
         channelAutoStartSlackChannels: z
           .array(
             z.object({
+              channelId: z.string().trim().max(64).nullable().default(null),
               slackChannel: z.string().trim().max(160).nullable().default(null),
               instructions: z.string().max(8_000).nullable().default(null),
               launchMode: z.enum(['always_start']).default('always_start'),


### PR DESCRIPTION
## Problem

Editing one Slack auto-respond channel in **Settings → Automations** re-validates *every* configured channel and fails the whole save if **any single one** can't be resolved by name. A customer hit this editing `#hospital-bug-report` and got `Could not resolve Slack channel #deepstrike-roo.` — a completely different channel they weren't touching (reported in [this thread](https://roomote-dev.slack.com/archives/C08RY7GTP0E/p1783534068093099)).

## Root cause — a lossy identity round-trip

Auto-start channels are stored by **channel ID**, but the form round-trips them through the **channel name**, and the read and save paths use asymmetric Slack lookups:

| Step | Lookup | Behavior |
|---|---|---|
| **Read** (hydrate form) | `conversations.info?channel=<ID>` | by ID — works for archived / renamed / private channels |
| **Save** (validate) | `conversations.list` + match name | by name — **excludes archived**, misses private-not-member, bails on rate limits |

The form dropped the stored ID and refilled each row with the display name (`AutomationsSettings.tsx`). On save the server re-resolved **every** row by name (`settings-update.ts`), and the first failure set a field error and aborted the entire save before any DB write. So a channel that resolved fine when the page *loaded* (by ID) failed when the user *saved* (by name), vetoing an unrelated edit.

Notably manager/coach/etc. channels don't have this bug — they keep their persisted ID (`keepPersistedSlackChannel`) when not being edited. Auto-start rows had no equivalent path.

## Fix

Preserve the persisted `channelId` through the form round-trip and use it as the resolution input for untouched rows:

- `ChannelAutoStartFormRow` carries `channelId`; hydrated from settings, serialized into the save payload, and threaded through the tRPC input schema + server normalizer.
- On save, `input: normalizeSlackChannelIdInput(row.channelId) ?? row.slackChannel` — resolving by ID short-circuits without a Slack lookup, so a stale channel elsewhere in the list can't block saving another row.
- The ID is cleared **only** when the user actually edits that row's channel (both the picker and the text input), forcing a fresh name resolution for genuinely-changed channels.

### Behavior note
If a channel is fully deleted its ID is now re-saved rather than blocking the save (same as manager/coach channels). The existing "app isn't in this channel" access warning still surfaces the problem — it just no longer holds the whole form hostage.

## Tests
- `buildAutomationSettingsSaveInput` sends the persisted ID for an untouched row.
- Editing a non-channel field **preserves** the ID; editing the channel **clears** it.
- Updated existing form-state / editor tests for the new field.

`@roomote/web` typecheck, eslint, prettier, and the automations vitest suite (55 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)