### PR TITLE
[Fix] Make Azure DevOps @roomote comment mentions resolve the commenter

### DIFF
--- a/.agent-guidance/features/ado-connection-setup.md
+++ b/.agent-guidance/features/ado-connection-setup.md
@@ -144,10 +144,16 @@ enable a Better Auth Azure DevOps linked-account flow backed by Microsoft
 Entra. The provider requests the Azure DevOps resource scope
 `499b84ac-1321-427f-aa17-267ca6975798/.default`, then calls global Azure
 DevOps APIs under `https://app.vssps.visualstudio.com`. It stores
-`auth_accounts.provider_id = 'ado'` with the stable
-`connectionData.authenticatedUser.id` so comment-webhook authors can be matched
-to linked Roomote users, and uses the profile API only for display/email
-enrichment. The Entra tenant must have the Azure DevOps enterprise
+`auth_accounts.provider_id = 'ado'` with `account_id` set to the linked
+identity's normalized `uniqueName` (UPN/email). Azure DevOps exposes a user
+under different id namespaces per surface — the OAuth `connectionData` returns
+a vssps user id, while pull request comment webhooks deliver an org identity
+id, and neither equals the Entra object id — so those ids never match across
+surfaces. The `uniqueName` is the one identifier present identically on both
+the link response and the comment webhook, so linked-account matching keys off
+it (normalized via `normalizeAdoLinkedAccountKey`); the profile API is used
+only for display/email enrichment. The Entra tenant must have the Azure DevOps
+enterprise
 application/service principal and admin consent for the app's Azure DevOps
 delegated permission. Comment-triggered work requires this row so the task can
 run as the linked Roomote user while repository clone, API, and comment writes
@@ -245,14 +251,17 @@ gate.
 
 Comment mention routing is explicit-request driven, so it bypasses the PR
 author policy while still requiring the synced repository and environment
-mapping gate. Roomote ignores comments authored by Roomote-prefixed Azure
-DevOps identities or by the current deployment token identity resolved from
-Azure DevOps connection data. Explicit ADO comment mentions require the
-commenter to have a linked Azure DevOps account in Settings > Linked Accounts;
-target resolution matches the webhook comment author's stable `id` to
-`auth_accounts.provider_id = 'ado'` and attributes the task to that linked
-Roomote user. When no linked account exists, Roomote replies on the PR thread
-with a link-account instruction instead of starting work.
+mapping gate. Roomote ignores comments authored by the Roomote bot identity
+(name/handle beginning with `roomote`) or by the current deployment token
+identity resolved from Azure DevOps connection data. The self-identity check is
+name-prefix based, not a bare `@roomote` substring, so real users in a
+`roomote.*` Entra tenant are not mistaken for the bot. Explicit ADO comment
+mentions require the commenter to have a linked Azure DevOps account in
+Settings > Linked Accounts; target resolution matches the webhook comment
+author's normalized `uniqueName` to `auth_accounts.account_id` (provider
+`ado`) and attributes the task to that linked Roomote user. When no linked
+account exists, Roomote replies on the PR thread with a link-account
+instruction instead of starting work.
 
 ## Smoke Test
 

--- a/apps/api/src/handlers/ado/__tests__/getAdoAutomationTargets.test.ts
+++ b/apps/api/src/handlers/ado/__tests__/getAdoAutomationTargets.test.ts
@@ -58,7 +58,10 @@ vi.mock('@roomote/db/server', () => ({
 
 import { CloudAgentType } from '@roomote/types';
 
-import { getAdoAutomationTargets } from '../getAdoAutomationTargets';
+import {
+  getAdoAutomationTargets,
+  isRoomoteAdoIdentity,
+} from '../getAdoAutomationTargets';
 
 const payload = {
   repositoryFullName: 'acme/Platform/backend',
@@ -151,7 +154,7 @@ describe('getAdoAutomationTargets', () => {
     ).resolves.toMatchObject({ status: 'ok' });
   });
 
-  it('uses the linked Azure DevOps commenter account for comment-triggered work', async () => {
+  it('matches the linked account on the commenter uniqueName, not the id', async () => {
     mockAuthAccountsFindFirst.mockResolvedValue({ userId: 'commenter-user-1' });
 
     const result = await getAdoAutomationTargets({
@@ -159,8 +162,11 @@ describe('getAdoAutomationTargets', () => {
       payload: {
         ...payload,
         commentAuthor: {
-          id: 'ado-user-1',
-          uniqueName: 'alice@acme.example',
+          // The webhook author id is a different Azure DevOps id namespace
+          // than the linked account, so matching must ignore it and use the
+          // normalized uniqueName instead.
+          id: 'org-identity-id-that-never-matches',
+          uniqueName: 'Alice@Acme.Example',
         },
       },
       ignoreAuthorPolicy: true,
@@ -179,10 +185,34 @@ describe('getAdoAutomationTargets', () => {
       expect.objectContaining({
         where: expect.arrayContaining([
           expect.objectContaining({ left: 'authAccounts.providerId' }),
-          expect.objectContaining({ left: 'authAccounts.accountId' }),
+          expect.objectContaining({
+            left: 'authAccounts.accountId',
+            right: 'alice@acme.example',
+          }),
         ]),
       }),
     );
+  });
+
+  it('requires a link when the commenter has no uniqueName to match', async () => {
+    const result = await getAdoAutomationTargets({
+      type: CloudAgentType.PrReviewer,
+      payload: {
+        ...payload,
+        commentAuthor: {
+          id: 'org-identity-id',
+          displayName: 'Alice',
+        },
+      },
+      ignoreAuthorPolicy: true,
+      requireLinkedSenderAccount: true,
+    });
+
+    expect(result).toMatchObject({
+      status: 'error',
+      code: 'account_link_required',
+    });
+    expect(mockAuthAccountsFindFirst).not.toHaveBeenCalled();
   });
 
   it('requires an Azure DevOps linked account when comment attribution is required', async () => {
@@ -205,5 +235,23 @@ describe('getAdoAutomationTargets', () => {
       message:
         'Azure DevOps user alice@acme.example is not linked to a Roomote user',
     });
+  });
+});
+
+describe('isRoomoteAdoIdentity', () => {
+  it('matches Roomote bot identities by name or handle', () => {
+    expect(isRoomoteAdoIdentity('roomote')).toBe(true);
+    expect(isRoomoteAdoIdentity('Roomote Bot')).toBe(true);
+    expect(isRoomoteAdoIdentity('roomote-bot@acme.example')).toBe(true);
+    expect(isRoomoteAdoIdentity('@roomote')).toBe(true);
+  });
+
+  it('does not match humans whose email domain contains roomote', () => {
+    // Regression: a bare `@roomote` substring check treated every user in a
+    // `roomote.*` Entra tenant as Roomote's own bot and dropped their
+    // mentions.
+    expect(isRoomoteAdoIdentity('dan@roomote.onmicrosoft.com')).toBe(false);
+    expect(isRoomoteAdoIdentity('alice@roomote.dev')).toBe(false);
+    expect(isRoomoteAdoIdentity('Dan Riccio')).toBe(false);
   });
 });

--- a/apps/api/src/handlers/ado/__tests__/handleComment.test.ts
+++ b/apps/api/src/handlers/ado/__tests__/handleComment.test.ts
@@ -42,8 +42,10 @@ vi.mock('../getAdoAutomationTargets', () => ({
     displayName?: string;
   }) => identity?.uniqueName ?? identity?.displayName,
   isRoomoteAdoIdentity: (identityName: string) => {
-    const normalized = identityName.toLowerCase();
-    return normalized.startsWith('roomote') || normalized.includes('@roomote');
+    const normalized = identityName.toLowerCase().trim();
+    return (
+      normalized.startsWith('roomote') || normalized.startsWith('@roomote')
+    );
   },
 }));
 
@@ -327,6 +329,25 @@ describe('handleAdoComment', () => {
     });
     expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
     expect(mockGetAdoAutomationTargets).not.toHaveBeenCalled();
+  });
+
+  it('processes mentions from a human whose email domain contains roomote', async () => {
+    // Regression: users in a `roomote.*` Entra tenant have `@roomote…`
+    // uniqueNames and must not be mistaken for Roomote's own bot.
+    const result = await handleAdoComment(
+      makeCommentPayload({
+        comment: {
+          author: {
+            id: 'ado-user-2',
+            uniqueName: 'dan@roomote.onmicrosoft.com',
+            displayName: 'Dan Riccio',
+          },
+        },
+      }),
+    );
+
+    expect(result).toEqual({ status: 'ok', metadata: { ids: [1234] } });
+    expect(mockEnqueueCloudTask).toHaveBeenCalled();
   });
 
   it('posts a reviewer-gate comment when no automation target is found', async () => {

--- a/apps/api/src/handlers/ado/getAdoAutomationTargets.ts
+++ b/apps/api/src/handlers/ado/getAdoAutomationTargets.ts
@@ -1,3 +1,4 @@
+import { normalizeAdoLinkedAccountKey } from '@roomote/ado';
 import {
   CloudAgentType,
   DEFAULT_PR_REVIEWER_SETTINGS,
@@ -38,15 +39,17 @@ export function getAdoIdentityName(
   return identity?.uniqueName ?? identity?.displayName;
 }
 
-function getAdoIdentityId(identity: AdoIdentity | undefined): string | null {
-  const id = identity?.id?.trim();
-
-  return id && id.length > 0 ? id : null;
-}
-
 export function isRoomoteAdoIdentity(identityName: string): boolean {
-  const normalized = identityName.toLowerCase();
-  return normalized.startsWith('roomote') || normalized.includes('@roomote');
+  const normalized = identityName.toLowerCase().trim();
+
+  // Match Roomote's own bot by its identity name/handle only. A bare
+  // `@roomote` substring check also matched every human whose Azure DevOps
+  // uniqueName is an email in a `roomote.*` tenant (e.g.
+  // `dan@roomote.onmicrosoft.com`), which silently dropped their `@roomote`
+  // PR comment mentions. The comment path additionally guards against
+  // Roomote's own posts with `isDeploymentTokenAuthor`, which resolves the
+  // exact deployment identity rather than guessing from the name.
+  return normalized.startsWith('roomote') || normalized.startsWith('@roomote');
 }
 
 export async function getAdoAutomationTargets({
@@ -73,7 +76,12 @@ export async function getAdoAutomationTargets({
   const repositoryId = payload.resource.repository.id;
   const fullName = payload.repositoryFullName;
   const authorName = getAdoIdentityName(payload.resource.createdBy);
-  const senderAdoUserId = getAdoIdentityId(payload.commentAuthor);
+  // Linked accounts are keyed on the commenter's normalized uniqueName
+  // (UPN/email); the comment author's raw `id` is a different Azure DevOps id
+  // namespace than the one stored at link time and never matches.
+  const senderLinkedAccountKey = normalizeAdoLinkedAccountKey(
+    payload.commentAuthor?.uniqueName,
+  );
   const senderName = getAdoIdentityName(payload.commentAuthor);
 
   const repo = await db.query.repositories.findFirst({
@@ -99,11 +107,11 @@ export async function getAdoAutomationTargets({
   let linkedSenderUserId: string | null = null;
 
   if (requireLinkedSenderAccount) {
-    const linkedAccount = senderAdoUserId
+    const linkedAccount = senderLinkedAccountKey
       ? await db.query.authAccounts.findFirst({
           where: and(
             eq(authAccounts.providerId, 'ado'),
-            eq(authAccounts.accountId, senderAdoUserId),
+            eq(authAccounts.accountId, senderLinkedAccountKey),
           ),
           orderBy: [desc(authAccounts.updatedAt)],
           columns: {
@@ -118,7 +126,7 @@ export async function getAdoAutomationTargets({
       return {
         status: 'error',
         code: 'account_link_required',
-        message: `Azure DevOps user ${senderName ?? senderAdoUserId ?? 'unknown'} is not linked to a Roomote user`,
+        message: `Azure DevOps user ${senderName ?? senderLinkedAccountKey ?? 'unknown'} is not linked to a Roomote user`,
       };
     }
   }

--- a/apps/web/src/lib/server/auth.test.ts
+++ b/apps/web/src/lib/server/auth.test.ts
@@ -147,7 +147,7 @@ describe('getAuth', () => {
     expect(options?.session?.freshAge).toBe(0);
   });
 
-  it('uses global Azure DevOps connection data for Entra linked-account identity', async () => {
+  it('keys the Entra linked-account identity on the normalized uniqueName', async () => {
     const fetchMock = vi.fn(async (url: string | URL | Request) => {
       const href = String(url);
 
@@ -156,7 +156,7 @@ describe('getAuth', () => {
           authenticatedUser: {
             id: 'connection-user-guid',
             providerDisplayName: 'Matt Rubens',
-            uniqueName: 'matt@roomote.onmicrosoft.com',
+            uniqueName: 'Matt@Roomote.OnMicrosoft.com',
           },
         });
       }
@@ -200,10 +200,13 @@ describe('getAuth', () => {
         },
       },
     );
+    // The account id is the normalized uniqueName (UPN/email), not the vssps
+    // connectionData id — that id namespace never matches the org identity id
+    // Azure DevOps delivers as the comment author on PR webhooks.
     expect(profile).toEqual({
       email: 'matt@roomote.onmicrosoft.com',
       emailVerified: false,
-      id: 'connection-user-guid',
+      id: 'matt@roomote.onmicrosoft.com',
       name: 'Matt Rubens',
     });
   });

--- a/apps/web/src/lib/server/auth.ts
+++ b/apps/web/src/lib/server/auth.ts
@@ -5,6 +5,7 @@ import { APIError } from 'better-auth/api';
 import { nextCookies } from 'better-auth/next-js';
 import { genericOAuth, microsoftEntraId, slack } from 'better-auth/plugins';
 import { drizzleAdapter } from '@better-auth/drizzle-adapter';
+import { normalizeAdoLinkedAccountKey } from '@roomote/ado';
 
 import {
   authUsers,
@@ -665,8 +666,21 @@ async function createAuth(authProviderConfig: ResolvedAuthProviderConfig) {
                 readAdoConnectionDataUserString(user, 'uniqueName') ??
                 `Azure DevOps user ${accountId}`;
 
+              // Key the linked account on the uniqueName (UPN/email). The
+              // vssps connectionData `id` used here does not match the org
+              // identity id Azure DevOps sends as the comment author on PR
+              // webhooks, so id-based matching never resolves. The uniqueName
+              // is the one identifier both surfaces share. Fall back to the
+              // email and then the vssps id if a uniqueName is unavailable.
+              const linkedAccountKey =
+                normalizeAdoLinkedAccountKey(
+                  readAdoConnectionDataUserString(user, 'uniqueName'),
+                ) ??
+                normalizeAdoLinkedAccountKey(email) ??
+                accountId;
+
               return {
-                id: accountId,
+                id: linkedAccountKey,
                 email,
                 emailVerified: false,
                 name,

--- a/packages/ado/src/__tests__/api.test.ts
+++ b/packages/ado/src/__tests__/api.test.ts
@@ -71,6 +71,7 @@ import {
   removeAdoServiceHooksForRepositories,
   getAdoDeploymentUser,
   listAdoRepositories,
+  normalizeAdoLinkedAccountKey,
   validateAdoToken,
   type AdoRepository,
 } from '../api';
@@ -760,5 +761,23 @@ describe('Azure DevOps API helpers', () => {
           body.eventType === 'ms.vss-code.git-pullrequest-comment-event',
       ),
     ).toBe(true);
+  });
+});
+
+describe('normalizeAdoLinkedAccountKey', () => {
+  it('lowercases and trims so the link and webhook sides agree', () => {
+    expect(normalizeAdoLinkedAccountKey('  Dan@Roomote.OnMicrosoft.com ')).toBe(
+      'dan@roomote.onmicrosoft.com',
+    );
+    expect(normalizeAdoLinkedAccountKey('dan@roomote.onmicrosoft.com')).toBe(
+      'dan@roomote.onmicrosoft.com',
+    );
+  });
+
+  it('returns null for empty or missing values', () => {
+    expect(normalizeAdoLinkedAccountKey('')).toBeNull();
+    expect(normalizeAdoLinkedAccountKey('   ')).toBeNull();
+    expect(normalizeAdoLinkedAccountKey(null)).toBeNull();
+    expect(normalizeAdoLinkedAccountKey(undefined)).toBeNull();
   });
 });

--- a/packages/ado/src/api.ts
+++ b/packages/ado/src/api.ts
@@ -377,6 +377,24 @@ export function clearAdoDeploymentUserCache(): void {
   cachedAdoDeploymentUser = null;
 }
 
+/**
+ * Normalizes an Azure DevOps identity to the key used for linked-account
+ * matching. Azure DevOps exposes a user's identity under different ids per
+ * surface: the Entra OAuth `connectionData` returns a vssps user id, while
+ * pull request comment webhooks deliver an org identity id — the two never
+ * match, and neither equals the Entra object id. The `uniqueName` (UPN /
+ * email) is the one value present identically on both surfaces, so linked
+ * accounts key off it. Lowercasing and trimming keeps the link side and the
+ * webhook side in agreement.
+ */
+export function normalizeAdoLinkedAccountKey(
+  value: string | null | undefined,
+): string | null {
+  const normalized = value?.trim().toLowerCase();
+
+  return normalized ? normalized : null;
+}
+
 const adoPullRequestDetailsSchema = z
   .object({ pullRequestId: z.number() })
   .passthrough();


### PR DESCRIPTION
## Summary

Testing the Azure DevOps linked-account flow end to end surfaced two bugs that together made `@roomote` PR comment mentions **never** start work.

### 1. The self-identity guard swallowed every user in a `roomote.*` tenant
`isRoomoteAdoIdentity` classified any name containing the substring `@roomote` as Roomote's own bot. In an Entra tenant whose domain is `roomote.*` (e.g. dogfooding in `roomote.onmicrosoft.com`), **every** user's ADO `uniqueName` is an `@roomote…` email — so all of their `@roomote` mentions were silently dropped as `roomote_authored_comment`. Now the bot is matched by name/handle **prefix** only. Loop-prevention is unaffected: the comment path still guards against Roomote's own posts via `isDeploymentTokenAuthor`, which resolves the exact deployment identity.

### 2. Linked-account matching compared mismatched id namespaces
The comment webhook handler matched `authAccounts.accountId` against the comment `author.id`, but Azure DevOps exposes a user under **different id namespaces per surface**:

| Surface | id for the same user |
| --- | --- |
| Entra OAuth `connectionData` (stored at link time) | `1d5df046-…` (vssps user id) |
| PR comment webhook `author.id` | `b151c0bb-…` (org identity id) |
| Entra access token `oid` | `b13ca284-…` (AAD object id) |

None of these match, so a correctly-linked user's mention was always rejected with `account_link_required`. The one identifier present **identically** on both the link response and the comment webhook is the `uniqueName` (UPN/email). Linked accounts now key off the normalized `uniqueName` via a shared `normalizeAdoLinkedAccountKey` helper used by both the link flow (`auth.ts`) and the webhook handler.

## Validation

- New/updated unit tests: `isRoomoteAdoIdentity` (bot handles match, `roomote.*` humans don't), linked-account matching on `uniqueName` (ignores the mismatched id), `normalizeAdoLinkedAccountKey`, and a handleComment case for a `roomote.*`-tenant human.
- Verified **live** against a real Entra tenant: linking through the OAuth flow now stores the `uniqueName` as `account_id`, which exactly equals what the comment webhook delivers for the same user (previously `1d5df046…` vs `b151c0bb…`, now both `dan@roomote.onmicrosoft.com`).
- `pnpm lint:fast`, `pnpm check-types:fast`, `pnpm knip` all pass.

Note: a full positive comment→task trigger still additionally requires a commenter that isn't the deployment-token PAT owner (a bot-owned PAT or a second ADO account); that's a separate setup step, not a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)