### PR TITLE
[Fix] Infer source-control provider for routed launches at enqueue time

### DIFF
--- a/.agent-guidance/features/ado-connection-setup.md
+++ b/.agent-guidance/features/ado-connection-setup.md
@@ -37,6 +37,12 @@ The current path supports:
 - launching Azure DevOps-backed manual, environment, and repository-set tasks
 - inferring `sourceControlProvider = 'ado'` for web-launched manual and
   environment tasks from the selected synced repository rows
+- inferring `sourceControlProvider` at enqueue time for any launch whose
+  payload omits it (`enqueueCloudTask` resolves the workspace's repository
+  rows), so router-launched tasks from Slack/Linear/Telegram/Teams mentions
+  get Azure DevOps credentials instead of the GitHub default when they route
+  to an ADO-backed environment; workspaces spanning multiple providers are
+  left unstamped
 - resolving `all_repositories` Azure DevOps workspaces from synced Azure
   DevOps repository rows
 - automatic Azure DevOps service-hook setup during repository sync for pull

--- a/packages/cloud-agents/src/server/__tests__/cloud-job-queue-provider-inference.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/cloud-job-queue-provider-inference.test.ts
@@ -1,0 +1,81 @@
+// pnpm --filter @roomote/cloud-agents test src/server/__tests__/cloud-job-queue-provider-inference.test.ts
+const { mockWhere } = vi.hoisted(() => ({
+  mockWhere: vi.fn(),
+}));
+
+vi.mock('@roomote/db/server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@roomote/db/server')>();
+
+  return {
+    ...actual,
+    db: {
+      ...actual.db,
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          innerJoin: vi.fn(() => ({ where: mockWhere })),
+          where: mockWhere,
+        })),
+      })),
+    },
+  };
+});
+
+import { inferWorkspaceSourceControlProvider } from '../cloud-job-queue';
+
+describe('inferWorkspaceSourceControlProvider', () => {
+  beforeEach(() => {
+    mockWhere.mockReset();
+  });
+
+  it('infers the provider from an environment with a single-provider mapping', async () => {
+    mockWhere.mockResolvedValue([{ provider: 'ado' }]);
+
+    await expect(
+      inferWorkspaceSourceControlProvider({
+        type: 'environment',
+        environmentId: 'env-1',
+      }),
+    ).resolves.toBe('ado');
+  });
+
+  it('infers the provider from a single repository workspace', async () => {
+    mockWhere.mockResolvedValue([{ provider: 'gitlab' }]);
+
+    await expect(
+      inferWorkspaceSourceControlProvider({
+        type: 'repository',
+        repo: 'group/subgroup/repo',
+      }),
+    ).resolves.toBe('gitlab');
+  });
+
+  it('infers the provider from a repository set sharing one provider', async () => {
+    mockWhere.mockResolvedValue([{ provider: 'ado' }, { provider: 'ado' }]);
+
+    await expect(
+      inferWorkspaceSourceControlProvider({
+        type: 'repository_set',
+        repositories: ['acme/Platform/backend', 'acme/Platform/frontend'],
+      }),
+    ).resolves.toBe('ado');
+  });
+
+  it('returns undefined when the workspace spans multiple providers', async () => {
+    mockWhere.mockResolvedValue([{ provider: 'ado' }, { provider: 'github' }]);
+
+    await expect(
+      inferWorkspaceSourceControlProvider({ type: 'all_repositories' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when no repository rows match', async () => {
+    mockWhere.mockResolvedValue([]);
+
+    await expect(
+      inferWorkspaceSourceControlProvider({
+        type: 'repository',
+        repo: 'owner/unknown',
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/cloud-agents/src/server/cloud-job-queue.ts
+++ b/packages/cloud-agents/src/server/cloud-job-queue.ts
@@ -45,6 +45,8 @@ import {
   tasks,
   users,
   environments,
+  environmentRepositoryMappings,
+  repositories,
   and,
   desc,
   eq,
@@ -692,6 +694,55 @@ export interface EnqueueCloudTaskOptions {
   beforeEnqueue?: (cloudJob: CloudJob) => Promise<void>;
 }
 
+/**
+ * Infers the source-control provider for a launch workspace from the linked
+ * repository rows. Routed launches (Slack/Linear/Telegram/Teams mentions)
+ * select an environment or repository without stamping a provider, and a
+ * missing provider defaults to GitHub at runtime — which breaks credential
+ * setup when the workspace is backed by Azure DevOps, GitLab, or Gitea.
+ * Returns undefined when the workspace resolves to no repositories or to
+ * repositories from more than one provider.
+ */
+export async function inferWorkspaceSourceControlProvider(
+  workspace: ReturnType<typeof resolveCloudTaskWorkspace>,
+): Promise<SourceControlProvider | undefined> {
+  const providerRows =
+    workspace.type === 'environment'
+      ? await db
+          .select({ provider: repositories.sourceControlProvider })
+          .from(environmentRepositoryMappings)
+          .innerJoin(
+            repositories,
+            eq(environmentRepositoryMappings.repositoryId, repositories.id),
+          )
+          .where(
+            and(
+              eq(
+                environmentRepositoryMappings.environmentId,
+                workspace.environmentId,
+              ),
+              eq(repositories.isActive, true),
+            ),
+          )
+      : await db
+          .select({ provider: repositories.sourceControlProvider })
+          .from(repositories)
+          .where(
+            and(
+              eq(repositories.isActive, true),
+              workspace.type === 'repository'
+                ? eq(repositories.fullName, workspace.repo)
+                : workspace.type === 'repository_set'
+                  ? inArray(repositories.fullName, workspace.repositories)
+                  : undefined,
+            ),
+          );
+
+  const providers = [...new Set(providerRows.map((row) => row.provider))];
+
+  return providers.length === 1 ? providers[0] : undefined;
+}
+
 export async function enqueueCloudTask(
   task: CloudTask,
   options: EnqueueCloudTaskOptions = {},
@@ -754,6 +805,24 @@ export async function enqueueCloudTask(
 
       console.log(
         `[enqueueCloudTask] Auto-resolved environment ${envId} for ${workspace.repo}`,
+      );
+    }
+  }
+
+  // Routed launches (Slack/Linear/Telegram/Teams) select a workspace without
+  // stamping its source-control provider, and the runtime defaults a missing
+  // provider to GitHub — wrong credentials for ADO/GitLab/Gitea workspaces.
+  // Infer it from the resolved workspace. GitHub is the runtime default, so
+  // stamping an inferred GitHub would only churn existing payloads.
+  if (!task.payload.sourceControlProvider) {
+    const inferredProvider = await inferWorkspaceSourceControlProvider(
+      resolveCloudTaskWorkspace(task.payload),
+    );
+
+    if (inferredProvider && inferredProvider !== 'github') {
+      task.payload.sourceControlProvider = inferredProvider;
+      console.log(
+        `[enqueueCloudTask] Inferred source-control provider ${inferredProvider} for ${task.type} launch`,
       );
     }
   }


### PR DESCRIPTION
## Summary

Routing a chat request into a non-GitHub environment never worked: router-launched tasks (Slack/Linear/Telegram/Teams mentions) select an environment or repository but never stamp `sourceControlProvider` on the payload, and a missing provider defaults to GitHub at runtime. When the LLM router picked an Azure DevOps-backed environment, the worker tried to create **GitHub** credentials and the job died at source-control token creation before doing any work. Same failure shape for GitLab- and Gitea-backed environments. Only the web launch path inferred the provider from the selection; all four routed entry points shared the gap.

## Fix

Infer the provider inside `enqueueCloudTask` when the payload omits it, resolving the launch workspace to its linked repository rows:
- `environment` → providers of the environment's active repository mappings
- `repository` / `repository_set` → providers of the matching active repository rows
- `all_repositories` → providers across all active repositories

Exactly one distinct provider → stamped on the payload; no rows or multiple providers → left unstamped (GitHub default, unchanged behavior). Inferred GitHub is also left unstamped so existing GitHub payloads stay byte-identical. Fixing at the enqueue level covers every routed entry point at once — and any future one — instead of patching each handler.

## Validation

- Unit tests for all four workspace shapes plus the ambiguity and no-match cases
- Verified live with the mock Slack harness: the same `@roomote` mention that previously routed to the ADO environment and failed (`Source control token creation failed... provider: github`) now launches with `sourceControlProvider: ado`, clones through the ADO credential proxy, implements the requested change, and opens a draft pull request in Azure DevOps, replying back into the Slack thread
- `pnpm lint:fast`, `pnpm check-types:fast`, `pnpm knip` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)