### PR TITLE
[Fix] Stop leaves no transcript record and trailing output streams in after cancel

### DIFF
--- a/.agent-guidance/architecture/cloud-job-execution.md
+++ b/.agent-guidance/architecture/cloud-job-execution.md
@@ -453,7 +453,16 @@ Persistence model:
   active session as hidden follow-up prompts. The response envelope preserves
   `submitted` versus `cancelled` resolution, and the hidden answer replay
   carries the answering user's `userId` so queued-prompt preparation can
-  refresh actor-scoped MCP state at the next turn boundary. For Slack-backed
+  refresh actor-scoped MCP state at the next turn boundary. An explicit user
+  stop (web Stop button, Slack/Telegram cancel, `POST /api/tasks/:taskId/stop`)
+  threads `cancelledBy` attribution through the sandbox `cancelTask`
+  procedure; the harness then flushes the aborted turn's partial assistant
+  output as its persisted message, emits cancelled responses for any pending
+  questions, persists a `roomote_runtime.task_cancelled` marker envelope
+  (rendered by the web transcript as a centered "Stopped by …" divider), and
+  drops trailing post-abort assistant stream/finalize events until the next
+  prompt. Internal cancels (steer replay, env-var resumable stop, task
+  replacement) carry no attribution and emit no marker. For Slack-backed
   tasks, the harness evaluates the generated stop hook before completion; when
   a terminal Slack-visible closeout is missing, it sends the hook reminder back
   as a hidden queued prompt and withholds `TaskCompleted` until the closeout is

--- a/apps/api/src/handlers/slack/dispatch/task-cancellation.ts
+++ b/apps/api/src/handlers/slack/dispatch/task-cancellation.ts
@@ -133,6 +133,10 @@ export async function handleTaskCancellation(
     const stopResult = await stopTaskJob({
       job: cancelableCloudJob,
       allowDirectCancelWithoutSandbox: true,
+      cancelledBy: {
+        ...(payload.user.name ? { name: payload.user.name } : {}),
+        source: 'slack',
+      },
     });
 
     if (isTerminalStopResult(stopResult)) {

--- a/apps/api/src/handlers/tasks/stopTask.ts
+++ b/apps/api/src/handlers/tasks/stopTask.ts
@@ -50,6 +50,7 @@ export async function stopTask(
     const result = await stopTaskJob({
       job,
       authUserId: auth.userId,
+      cancelledBy: { source: 'api' },
     });
 
     if (!result.success) {

--- a/apps/api/src/handlers/tasks/task-stop.ts
+++ b/apps/api/src/handlers/tasks/task-stop.ts
@@ -28,7 +28,7 @@ interface StopTaskJob {
  * Attribution for the user stop, forwarded to the sandbox so the transcript
  * gets a visible `task_cancelled` marker naming who stopped the task.
  */
-export interface StopTaskAttribution {
+interface StopTaskAttribution {
   name?: string;
   source?: string;
 }

--- a/apps/api/src/handlers/tasks/task-stop.ts
+++ b/apps/api/src/handlers/tasks/task-stop.ts
@@ -24,6 +24,15 @@ interface StopTaskJob {
   actingUserId: string | null;
 }
 
+/**
+ * Attribution for the user stop, forwarded to the sandbox so the transcript
+ * gets a visible `task_cancelled` marker naming who stopped the task.
+ */
+export interface StopTaskAttribution {
+  name?: string;
+  source?: string;
+}
+
 type StopTaskJobResult =
   | { success: true; mode: 'sandbox_stop' | 'direct_cancel' }
   | { success: false; error: string; statusCode: 403 | 404 | 409 | 502 };
@@ -158,8 +167,9 @@ async function readCurrentStopTaskResolution(
 async function stopTaskSandboxJob(params: {
   job: StopTaskJob & { sandboxServerUrl: string };
   authUserId?: string | null;
+  cancelledBy?: StopTaskAttribution;
 }): Promise<StopTaskJobResult> {
-  const { job, authUserId } = params;
+  const { job, authUserId, cancelledBy } = params;
   const tokenUserId = authUserId ?? job.actingUserId ?? job.userId;
 
   if (!tokenUserId) {
@@ -175,7 +185,10 @@ async function stopTaskSandboxJob(params: {
       cloudJobId: job.id,
       userId: tokenUserId,
       sandboxServerUrl: job.sandboxServerUrl,
-      call: (client) => client.commands.cancelTask.mutate(),
+      call: (client) =>
+        client.commands.cancelTask.mutate(
+          cancelledBy ? { cancelledBy } : undefined,
+        ),
     });
 
     return { success: true, mode: 'sandbox_stop' };
@@ -196,8 +209,10 @@ export async function stopTaskJob(params: {
   job: StopTaskJob;
   authUserId?: string | null;
   allowDirectCancelWithoutSandbox?: boolean;
+  cancelledBy?: StopTaskAttribution;
 }): Promise<StopTaskJobResult> {
-  const { job, authUserId, allowDirectCancelWithoutSandbox } = params;
+  const { job, authUserId, allowDirectCancelWithoutSandbox, cancelledBy } =
+    params;
 
   const initialResolution = resolveStopTaskJob(job);
 
@@ -209,6 +224,7 @@ export async function stopTaskJob(params: {
     return await stopTaskSandboxJob({
       job: initialResolution.job,
       authUserId,
+      cancelledBy,
     });
   }
 
@@ -222,6 +238,7 @@ export async function stopTaskJob(params: {
     return await stopTaskSandboxJob({
       job: refreshedResolution.job,
       authUserId,
+      cancelledBy,
     });
   }
 
@@ -239,6 +256,7 @@ export async function stopTaskJob(params: {
     return await stopTaskSandboxJob({
       job: racedResolution.job,
       authUserId,
+      cancelledBy,
     });
   }
 

--- a/apps/api/src/handlers/telegram/callback-actions.ts
+++ b/apps/api/src/handlers/telegram/callback-actions.ts
@@ -85,9 +85,19 @@ async function handleCancelTaskCallback(params: {
     return;
   }
 
+  const cancelledByName =
+    [params.query.from.first_name, params.query.from.last_name]
+      .filter(Boolean)
+      .join(' ')
+      .trim() || params.query.from.username;
+
   const stopResult = await stopTaskJob({
     job: cancelableJob,
     allowDirectCancelWithoutSandbox: true,
+    cancelledBy: {
+      ...(cancelledByName ? { name: cancelledByName } : {}),
+      source: 'telegram',
+    },
   });
 
   const canceled =

--- a/apps/web/src/app/(sandbox)/task/[taskId]/hooks/__tests__/task-cancelled-marker.client.test.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/hooks/__tests__/task-cancelled-marker.client.test.ts
@@ -1,0 +1,210 @@
+import { ACP_ENVELOPE_EVENT_TYPES } from '@roomote/types';
+
+vi.mock('@roomote/env', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@roomote/env')>();
+
+  return {
+    ...actual,
+    Env: {
+      NODE_ENV: 'test',
+      DATABASE_URL: 'postgres://postgres:password@localhost:5432/test',
+    },
+  };
+});
+
+import {
+  acpEnvelope,
+  createAcpStore,
+  textBlock,
+} from './use-sandbox-store-test-kit';
+
+const SESSION = 'ses_cancel';
+
+function userPromptEnvelope(options: { id: string; ts: number; text: string }) {
+  return acpEnvelope({
+    id: options.id,
+    ts: options.ts,
+    eventType: ACP_ENVELOPE_EVENT_TYPES.UserPrompt,
+    kind: 'text',
+    role: 'user',
+    text: options.text,
+    contentBlocks: [textBlock(options.text)],
+    metadata: { sessionId: SESSION },
+    payload: { sessionId: SESSION, text: options.text },
+  });
+}
+
+function assistantMessageEnvelope(options: {
+  id: string;
+  ts: number;
+  messageId: string;
+  text: string;
+}) {
+  return acpEnvelope({
+    id: options.id,
+    ts: options.ts,
+    eventType: ACP_ENVELOPE_EVENT_TYPES.AssistantMessage,
+    kind: 'text',
+    role: 'assistant',
+    text: options.text,
+    contentBlocks: [textBlock(options.text)],
+    metadata: { sessionId: SESSION, turnId: options.messageId },
+    payload: {
+      sessionId: SESSION,
+      turnId: options.messageId,
+      text: options.text,
+    },
+  });
+}
+
+function taskCancelledEnvelope(options: {
+  id: string;
+  ts: number;
+  cancelledByName?: string;
+  source?: string;
+}) {
+  const logicalEventId = `${SESSION}:cancel-${options.ts}:no-tool:${ACP_ENVELOPE_EVENT_TYPES.TaskCancelled}`;
+  const text = options.cancelledByName
+    ? `Stopped by ${options.cancelledByName}`
+    : 'Stopped';
+
+  return acpEnvelope({
+    id: options.id,
+    ts: options.ts,
+    eventType: ACP_ENVELOPE_EVENT_TYPES.TaskCancelled,
+    kind: 'task_cancelled',
+    role: 'system',
+    text,
+    contentBlocks: [textBlock(text)],
+    metadata: { sessionId: SESSION, logicalEventId },
+    payload: {
+      sessionId: SESSION,
+      logicalEventId,
+      ...(options.cancelledByName
+        ? { cancelledByName: options.cancelledByName }
+        : {}),
+      ...(options.source ? { source: options.source } : {}),
+    },
+  });
+}
+
+describe('task_cancelled marker history reconstruction', () => {
+  it('renders the marker after the aborted partial output', () => {
+    const store = createAcpStore();
+
+    store.getState()._loadAcpHistory([
+      userPromptEnvelope({ id: 'env-1', ts: 1000, text: 'Refactor this.' }),
+      assistantMessageEnvelope({
+        id: 'env-2',
+        ts: 1100,
+        messageId: 'msg-a',
+        text: 'Starting the refactor by mapping',
+      }),
+      taskCancelledEnvelope({
+        id: 'env-3',
+        ts: 1200,
+        cancelledByName: 'Daniel',
+        source: 'web',
+      }),
+    ]);
+
+    const messages = store.getState().messages;
+    const marker = messages.find((msg) => msg.kind === 'task_cancelled');
+
+    expect(marker).toMatchObject({
+      role: 'system',
+      updateType: ACP_ENVELOPE_EVENT_TYPES.TaskCancelled,
+      data: expect.objectContaining({
+        cancelledByName: 'Daniel',
+        source: 'web',
+      }),
+    });
+    expect(messages.at(-1)?.kind).toBe('task_cancelled');
+  });
+
+  it('does not style the aborted trailing assistant message as a completed turn', () => {
+    const store = createAcpStore();
+
+    store.getState()._loadAcpHistory([
+      userPromptEnvelope({ id: 'env-1', ts: 1000, text: 'Refactor this.' }),
+      assistantMessageEnvelope({
+        id: 'env-2',
+        ts: 1100,
+        messageId: 'msg-a',
+        text: 'Starting the refactor by mapping',
+      }),
+      taskCancelledEnvelope({ id: 'env-3', ts: 1200 }),
+    ]);
+
+    const aborted = store
+      .getState()
+      .messages.find(
+        (msg) => msg.text === 'Starting the refactor by mapping',
+      );
+
+    expect(aborted).toBeDefined();
+    expect(aborted?.isTurnCompletion).not.toBe(true);
+  });
+
+  it('keeps marking uncancelled trailing turns as completed', () => {
+    const store = createAcpStore();
+
+    store.getState()._loadAcpHistory([
+      userPromptEnvelope({ id: 'env-1', ts: 1000, text: 'Refactor this.' }),
+      assistantMessageEnvelope({
+        id: 'env-2',
+        ts: 1100,
+        messageId: 'msg-a',
+        text: 'Done with the refactor.',
+      }),
+    ]);
+
+    const answer = store
+      .getState()
+      .messages.find((msg) => msg.text === 'Done with the refactor.');
+
+    expect(answer?.isTurnCompletion).toBe(true);
+  });
+
+  it('keeps a follow-up turn after a cancel marker intact', () => {
+    const store = createAcpStore();
+
+    store.getState()._loadAcpHistory([
+      userPromptEnvelope({ id: 'env-1', ts: 1000, text: 'Refactor this.' }),
+      assistantMessageEnvelope({
+        id: 'env-2',
+        ts: 1100,
+        messageId: 'msg-a',
+        text: 'Starting the refactor by mapping',
+      }),
+      taskCancelledEnvelope({
+        id: 'env-3',
+        ts: 1200,
+        cancelledByName: 'Daniel',
+      }),
+      userPromptEnvelope({
+        id: 'env-4',
+        ts: 1300,
+        text: 'Only do the config part.',
+      }),
+      assistantMessageEnvelope({
+        id: 'env-5',
+        ts: 1400,
+        messageId: 'msg-b',
+        text: 'Config-only refactor done.',
+      }),
+    ]);
+
+    const roles = store
+      .getState()
+      .messages.map((msg) => `${msg.role}:${msg.kind}`);
+
+    expect(roles).toEqual([
+      'user:text',
+      'assistant:text',
+      'system:task_cancelled',
+      'user:text',
+      'assistant:text',
+    ]);
+  });
+});

--- a/apps/web/src/app/(sandbox)/task/[taskId]/hooks/__tests__/task-cancelled-marker.client.test.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/hooks/__tests__/task-cancelled-marker.client.test.ts
@@ -138,9 +138,7 @@ describe('task_cancelled marker history reconstruction', () => {
 
     const aborted = store
       .getState()
-      .messages.find(
-        (msg) => msg.text === 'Starting the refactor by mapping',
-      );
+      .messages.find((msg) => msg.text === 'Starting the refactor by mapping');
 
     expect(aborted).toBeDefined();
     expect(aborted?.isTurnCompletion).not.toBe(true);

--- a/apps/web/src/app/(sandbox)/task/[taskId]/hooks/services/acp-protocol-service.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/hooks/services/acp-protocol-service.ts
@@ -362,6 +362,14 @@ export function toAcpUiMessage(
       };
     }
 
+    case 'task_cancelled':
+      return {
+        ...base,
+        role: 'system',
+        kind: 'task_cancelled',
+        data: payloadRecord,
+      };
+
     default:
       return {
         ...base,
@@ -1786,6 +1794,18 @@ export class AcpProtocolService {
           text: formatRequestUserInputResponseText(request, payload),
           data: buildRequestUserInputResponseData(envelope.payload, request),
         });
+
+        continue;
+      }
+
+      if (envelope.eventType === ACP_ENVELOPE_EVENT_TYPES.TaskCancelled) {
+        const message = toAcpUiMessage(envelope);
+
+        // The turn was cut short, not completed — drop any pending completion
+        // so the aborted trailing assistant message is not styled as a
+        // finished turn.
+        clearPendingCompletion(message.sessionId);
+        acpMessages = this.appendPersistedMessage(acpMessages, message);
 
         continue;
       }

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/AcpMessageItem.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/AcpMessageItem.tsx
@@ -3,6 +3,7 @@ import { memo, type ReactNode } from 'react';
 import type { AcpUiMessage } from './types';
 import { AcpCommandOutputMessage } from './AcpCommandOutputMessage';
 import { AcpReasoningMessage } from './AcpReasoningMessage';
+import { AcpTaskCancelledMessage } from './AcpTaskCancelledMessage';
 import { AcpTodoSectionMessage } from './AcpTodoSectionMessage';
 import { AcpTextMessage } from './AcpTextMessage';
 import { AcpToolMessage } from './AcpToolMessage';
@@ -45,6 +46,8 @@ function AcpMessageItemBase({
     case 'plan':
       // Displayed in the header.
       return null;
+    case 'task_cancelled':
+      return <AcpTaskCancelledMessage msg={msg} />;
     default:
       return <AcpUnknownMessage msg={msg} />;
   }

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/AcpTaskCancelledMessage.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/AcpTaskCancelledMessage.tsx
@@ -1,0 +1,37 @@
+import { CircleStop } from 'lucide-react';
+import { parseAcpTaskCancelledPayload } from '@roomote/types';
+
+import type { AcpUiMessage } from './types';
+
+interface AcpTaskCancelledMessageProps {
+  msg: AcpUiMessage;
+}
+
+/**
+ * Centered divider marking the point where a user explicitly stopped the
+ * task. Renders from the persisted `task_cancelled` envelope, so it appears
+ * identically in the live view and reloaded history.
+ */
+export function AcpTaskCancelledMessage({ msg }: AcpTaskCancelledMessageProps) {
+  const payload = parseAcpTaskCancelledPayload(
+    (msg.data as Record<string, unknown>) ?? null,
+  );
+  const label = payload?.cancelledByName
+    ? `Stopped by ${payload.cancelledByName}`
+    : 'Stopped';
+
+  return (
+    <div
+      className="my-4 flex items-center gap-3"
+      data-testid="task-cancelled-marker"
+      title={new Date(msg.ts).toLocaleString()}
+    >
+      <div className="h-px flex-1 bg-border" aria-hidden="true" />
+      <div className="flex items-center gap-1.5 rounded-full border border-border/70 bg-muted/40 px-3 py-1 text-xs text-muted-foreground">
+        <CircleStop className="size-3.5 shrink-0" aria-hidden="true" />
+        <span>{label}</span>
+      </div>
+      <div className="h-px flex-1 bg-border" aria-hidden="true" />
+    </div>
+  );
+}

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/AcpMessageItem.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/AcpMessageItem.client.test.tsx
@@ -37,6 +37,10 @@ vi.mock('../AcpUnknownMessage', () => ({
   AcpUnknownMessage: () => <div>unknown message</div>,
 }));
 
+vi.mock('../AcpTaskCancelledMessage', () => ({
+  AcpTaskCancelledMessage: () => <div>task cancelled marker</div>,
+}));
+
 function buildToolResult(
   kind: string,
   overrides?: Partial<AcpToolResultUiMessage['data']>,
@@ -105,4 +109,23 @@ describe('AcpMessageItem tool routing', () => {
       expect(commandOutputSpy).not.toHaveBeenCalled();
     },
   );
+
+  it('renders task_cancelled messages as the cancel marker', () => {
+    render(
+      <AcpMessageItem
+        msg={{
+          id: 'cancel-1',
+          ts: 1,
+          role: 'system',
+          kind: 'task_cancelled',
+          partial: false,
+          sessionId: 'session-1',
+          updateType: 'roomote_runtime.task_cancelled',
+          data: { sessionId: 'session-1', cancelledByName: 'Daniel' },
+        }}
+      />,
+    );
+
+    expect(screen.getByText('task cancelled marker')).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/AcpTaskCancelledMessage.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/AcpTaskCancelledMessage.client.test.tsx
@@ -4,9 +4,7 @@ import { ACP_ENVELOPE_EVENT_TYPES } from '@roomote/types';
 import { AcpTaskCancelledMessage } from '../AcpTaskCancelledMessage';
 import type { AcpUiMessage } from '../types';
 
-function buildMarker(
-  payload: Record<string, unknown> = {},
-): AcpUiMessage {
+function buildMarker(payload: Record<string, unknown> = {}): AcpUiMessage {
   return {
     id: 'cancel-1',
     ts: 1200,
@@ -21,7 +19,11 @@ function buildMarker(
 
 describe('AcpTaskCancelledMessage', () => {
   it('names the user who stopped the task', () => {
-    render(<AcpTaskCancelledMessage msg={buildMarker({ cancelledByName: 'Daniel' })} />);
+    render(
+      <AcpTaskCancelledMessage
+        msg={buildMarker({ cancelledByName: 'Daniel' })}
+      />,
+    );
 
     expect(screen.getByTestId('task-cancelled-marker')).toHaveTextContent(
       'Stopped by Daniel',

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/AcpTaskCancelledMessage.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/AcpTaskCancelledMessage.client.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { ACP_ENVELOPE_EVENT_TYPES } from '@roomote/types';
+
+import { AcpTaskCancelledMessage } from '../AcpTaskCancelledMessage';
+import type { AcpUiMessage } from '../types';
+
+function buildMarker(
+  payload: Record<string, unknown> = {},
+): AcpUiMessage {
+  return {
+    id: 'cancel-1',
+    ts: 1200,
+    role: 'system',
+    kind: 'task_cancelled',
+    partial: false,
+    sessionId: 'ses_1',
+    updateType: ACP_ENVELOPE_EVENT_TYPES.TaskCancelled,
+    data: { sessionId: 'ses_1', ...payload },
+  };
+}
+
+describe('AcpTaskCancelledMessage', () => {
+  it('names the user who stopped the task', () => {
+    render(<AcpTaskCancelledMessage msg={buildMarker({ cancelledByName: 'Daniel' })} />);
+
+    expect(screen.getByTestId('task-cancelled-marker')).toHaveTextContent(
+      'Stopped by Daniel',
+    );
+  });
+
+  it('falls back to a generic label without attribution', () => {
+    render(<AcpTaskCancelledMessage msg={buildMarker()} />);
+
+    expect(screen.getByTestId('task-cancelled-marker')).toHaveTextContent(
+      'Stopped',
+    );
+  });
+});

--- a/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/PromptInput.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/PromptInput.tsx
@@ -347,6 +347,8 @@ export const PromptInput = forwardRef<PromptInputHandle, PromptInputProps>(
       [focusTextarea, insertFile, insertCommand],
     );
 
+    const cancelledByName = currentUserInfo?.userName ?? user?.name ?? null;
+
     const handleCancel = useCallback(async () => {
       if (cancellingRef.current) {
         return;
@@ -355,13 +357,18 @@ export const PromptInput = forwardRef<PromptInputHandle, PromptInputProps>(
       cancellingRef.current = true;
 
       try {
-        await client?.commands.cancelTask.mutate();
+        await client?.commands.cancelTask.mutate({
+          cancelledBy: {
+            ...(cancelledByName ? { name: cancelledByName } : {}),
+            source: 'web',
+          },
+        });
       } catch (err) {
         console.error('[sandbox] cancelTask error:', err);
       } finally {
         cancellingRef.current = false;
       }
-    }, [client]);
+    }, [client, cancelledByName]);
 
     const handleSubmit = useCallback(
       async (message: PromptInputMessage) => {

--- a/apps/worker/src/sandbox-server/lib/__tests__/harness-manager.test.ts
+++ b/apps/worker/src/sandbox-server/lib/__tests__/harness-manager.test.ts
@@ -667,6 +667,45 @@ describe('HarnessManager cancelTask', () => {
     }
   });
 
+  it('forwards user-stop attribution to the harness cancel command', () => {
+    const { harness, manager } = createManager();
+
+    try {
+      manager.initializeWithoutPrompt();
+      manager.startNewTaskFromPrompt({ prompt: 'hello' });
+
+      manager.cancelTask({
+        cancelledBy: { name: 'Daniel', source: 'web' },
+      });
+
+      expect(harness.sentCommands.at(-1)).toMatchObject({
+        commandName: TaskCommandName.CancelTask,
+        data: { cancelledBy: { name: 'Daniel', source: 'web' } },
+      });
+    } finally {
+      manager.dispose();
+      harness.dispose();
+    }
+  });
+
+  it('sends the cancel command without data when no attribution is given', () => {
+    const { harness, manager } = createManager();
+
+    try {
+      manager.initializeWithoutPrompt();
+      manager.startNewTaskFromPrompt({ prompt: 'hello' });
+
+      manager.cancelTask();
+
+      const command = harness.sentCommands.at(-1);
+      expect(command?.commandName).toBe(TaskCommandName.CancelTask);
+      expect(command).not.toHaveProperty('data');
+    } finally {
+      manager.dispose();
+      harness.dispose();
+    }
+  });
+
   it('allows cancel while waiting for user input', () => {
     const { harness, manager, logger } = createManager();
 

--- a/apps/worker/src/sandbox-server/lib/harness-manager.ts
+++ b/apps/worker/src/sandbox-server/lib/harness-manager.ts
@@ -23,7 +23,7 @@ import { captureWorkerMessage } from '../../monitoring/sentry';
 export { isActiveTaskPhase };
 export type { TaskPhase };
 
-import type { Harness } from './harness';
+import type { CancelTaskAttribution, Harness } from './harness';
 
 /**
  * Event names used by the HarnessManager.
@@ -539,8 +539,10 @@ export class HarnessManager extends EventEmitter<HarnessManagerEvents> {
 
   /**
    * Cancel the current task and keep the sandbox in a resumable stopped state.
+   * Pass `cancelledBy` only for explicit user stops — it makes the harness
+   * leave a visible `task_cancelled` marker in the transcript.
    */
-  cancelTask(): void {
+  cancelTask(options?: { cancelledBy?: CancelTaskAttribution }): void {
     const canCancelRunningTask = this.phase === 'running';
     const canCancelUserInputTask = this.phase === 'waiting_for_user_input';
 
@@ -573,7 +575,12 @@ export class HarnessManager extends EventEmitter<HarnessManagerEvents> {
     this.state.cancelTriggeredAt = Date.now();
     this.setPhase('stopped');
 
-    this.sendHarnessCommand({ commandName: HarnessCommand.CancelTask });
+    this.sendHarnessCommand({
+      commandName: HarnessCommand.CancelTask,
+      ...(options?.cancelledBy
+        ? { data: { cancelledBy: options.cancelledBy } }
+        : {}),
+    });
   }
 
   /**

--- a/apps/worker/src/sandbox-server/lib/harness.ts
+++ b/apps/worker/src/sandbox-server/lib/harness.ts
@@ -136,8 +136,22 @@ export interface AnswerUserInputRequestCommand {
   };
 }
 
+/**
+ * Attribution for a user-initiated cancel. Presence of this data is what
+ * marks the cancel as an explicit user stop (and produces a visible
+ * `task_cancelled` transcript marker); internal cancels (steer replay,
+ * env-var resumable stop, task replacement) omit it.
+ */
+export interface CancelTaskAttribution {
+  name?: string;
+  source?: string;
+}
+
 export interface CancelTaskCommand {
   commandName: typeof TaskCommandName.CancelTask;
+  data?: {
+    cancelledBy?: CancelTaskAttribution;
+  };
 }
 
 export interface CloseTaskCommand {

--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
@@ -3464,8 +3464,7 @@ describe('OpenCodeServerHarness cancel marker', () => {
       });
       expect(
         runtimeOutputEvents.some(
-          (event) =>
-            event.eventType === ACP_ENVELOPE_EVENT_TYPES.TaskCancelled,
+          (event) => event.eventType === ACP_ENVELOPE_EVENT_TYPES.TaskCancelled,
         ),
       ).toBe(true);
     } finally {
@@ -3544,9 +3543,7 @@ describe('OpenCodeServerHarness cancel marker', () => {
             event.eventType === ACP_ENVELOPE_EVENT_TYPES.AssistantMessageChunk,
         ),
       ).toHaveLength(chunkCountAtCancel);
-      expect(client.message.mock.calls).toHaveLength(
-        messageFetchCountAtCancel,
-      );
+      expect(client.message.mock.calls).toHaveLength(messageFetchCountAtCancel);
       expect(
         persistedEnvelopes.filter(
           (envelope) =>

--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
@@ -3342,3 +3342,375 @@ describe('OpenCodeServerHarness', () => {
     }
   });
 });
+
+describe('OpenCodeServerHarness cancel marker', () => {
+  function createPartialAssistantMessage(text: string): OpenCodeSessionMessage {
+    return {
+      info: {
+        id: 'msg_1',
+        sessionID: 'ses_1',
+        role: 'assistant',
+        providerID: 'openrouter',
+        modelID: 'openai/gpt-5.4',
+        mode: 'build',
+        time: {
+          created: 0,
+        },
+        cost: 0,
+        tokens: {
+          input: 5,
+          output: 2,
+          reasoning: 0,
+          cache: {
+            read: 0,
+            write: 0,
+          },
+        },
+      },
+      parts: [
+        {
+          id: 'part_1',
+          sessionID: 'ses_1',
+          messageID: 'msg_1',
+          type: 'text',
+          text,
+        },
+      ],
+    };
+  }
+
+  async function startTurnWithPartialText(
+    harness: OpenCodeServerHarness,
+    client: FakeOpenCodeServerClient,
+  ): Promise<void> {
+    await connectHarness(harness, client);
+
+    harness.sendCommand({
+      commandName: TaskCommandName.StartNewTask,
+      data: { text: 'Start work.', visibleInTranscript: true },
+    });
+    await vi.waitFor(() => {
+      expect(client.promptAsync).toHaveBeenCalledTimes(1);
+    });
+
+    await client.emit({
+      type: 'message.part.updated',
+      properties: {
+        part: {
+          id: 'part_1',
+          sessionID: 'ses_1',
+          messageID: 'msg_1',
+          type: 'text',
+          text: 'Partial answer',
+        },
+        delta: 'Partial answer',
+      },
+    });
+  }
+
+  it('emits a task_cancelled marker after the flushed partial output on an attributed cancel', async () => {
+    const { client, harness } = createHarness();
+    const runtimeOutputEvents: AcpMessage[] = [];
+    const persistedEnvelopes: AcpPersistedEnvelope[] = [];
+    const taskEvents: TaskEvent[] = [];
+
+    harness.subscribeRuntimeOutput((event) => runtimeOutputEvents.push(event));
+    harness.subscribeRuntimePersistedEnvelope((envelope) =>
+      persistedEnvelopes.push(envelope),
+    );
+    harness.subscribe((event) => taskEvents.push(event));
+
+    try {
+      await startTurnWithPartialText(harness, client);
+
+      client.messages.mockResolvedValueOnce([
+        createPartialAssistantMessage('Partial answer'),
+      ]);
+
+      harness.sendCommand({
+        commandName: TaskCommandName.CancelTask,
+        data: { cancelledBy: { name: 'Daniel', source: 'web' } },
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          taskEvents.some(
+            (event) => event.eventName === TaskEventName.TaskAborted,
+          ),
+        ).toBe(true);
+      });
+
+      const assistantIndex = persistedEnvelopes.findIndex(
+        (envelope) =>
+          envelope.eventType === ACP_ENVELOPE_EVENT_TYPES.AssistantMessage &&
+          envelope.payload.text === 'Partial answer',
+      );
+      const markerIndex = persistedEnvelopes.findIndex(
+        (envelope) =>
+          envelope.eventType === ACP_ENVELOPE_EVENT_TYPES.TaskCancelled,
+      );
+
+      // The partial output the user saw is flushed first, then the marker —
+      // the marker is the last transcript entry of the cancelled turn.
+      expect(assistantIndex).toBeGreaterThanOrEqual(0);
+      expect(markerIndex).toBeGreaterThan(assistantIndex);
+      expect(persistedEnvelopes[markerIndex]).toMatchObject({
+        role: 'system',
+        payload: {
+          sessionId: 'ses_1',
+          cancelledByName: 'Daniel',
+          source: 'web',
+        },
+      });
+      expect(
+        runtimeOutputEvents.some(
+          (event) =>
+            event.eventType === ACP_ENVELOPE_EVENT_TYPES.TaskCancelled,
+        ),
+      ).toBe(true);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it('drops trailing assistant output after a cancel until the next prompt', async () => {
+    const { client, harness } = createHarness();
+    const runtimeOutputEvents: AcpMessage[] = [];
+    const persistedEnvelopes: AcpPersistedEnvelope[] = [];
+    const taskEvents: TaskEvent[] = [];
+
+    harness.subscribeRuntimeOutput((event) => runtimeOutputEvents.push(event));
+    harness.subscribeRuntimePersistedEnvelope((envelope) =>
+      persistedEnvelopes.push(envelope),
+    );
+    harness.subscribe((event) => taskEvents.push(event));
+
+    try {
+      await startTurnWithPartialText(harness, client);
+
+      client.messages.mockResolvedValueOnce([
+        createPartialAssistantMessage('Partial answer'),
+      ]);
+
+      harness.sendCommand({
+        commandName: TaskCommandName.CancelTask,
+        data: { cancelledBy: { name: 'Daniel', source: 'web' } },
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          taskEvents.some(
+            (event) => event.eventName === TaskEventName.TaskAborted,
+          ),
+        ).toBe(true);
+      });
+
+      const chunkCountAtCancel = runtimeOutputEvents.filter(
+        (event) =>
+          event.eventType === ACP_ENVELOPE_EVENT_TYPES.AssistantMessageChunk,
+      ).length;
+      const messageFetchCountAtCancel = client.message.mock.calls.length;
+
+      // Trailing stream content and the post-abort finalize must not land
+      // after the marker.
+      await client.emit({
+        type: 'message.part.updated',
+        properties: {
+          part: {
+            id: 'part_1',
+            sessionID: 'ses_1',
+            messageID: 'msg_1',
+            type: 'text',
+            text: 'Partial answer plus a trailing paragraph',
+          },
+          delta: ' plus a trailing paragraph',
+        },
+      });
+      await client.emit({
+        type: 'message.updated',
+        properties: {
+          info: {
+            id: 'msg_1',
+            sessionID: 'ses_1',
+            role: 'assistant',
+            time: { completed: 1 },
+          },
+        },
+      });
+
+      expect(
+        runtimeOutputEvents.filter(
+          (event) =>
+            event.eventType === ACP_ENVELOPE_EVENT_TYPES.AssistantMessageChunk,
+        ),
+      ).toHaveLength(chunkCountAtCancel);
+      expect(client.message.mock.calls).toHaveLength(
+        messageFetchCountAtCancel,
+      );
+      expect(
+        persistedEnvelopes.filter(
+          (envelope) =>
+            envelope.eventType === ACP_ENVELOPE_EVENT_TYPES.AssistantMessage,
+        ),
+      ).toHaveLength(1);
+
+      // The next prompt lifts the suppression: a fresh turn streams normally.
+      harness.sendCommand({
+        commandName: TaskCommandName.SendMessage,
+        data: { text: 'Continue.', visibleInTranscript: true },
+      });
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(2);
+      });
+
+      await client.emit({
+        type: 'message.part.updated',
+        properties: {
+          part: {
+            id: 'part_2',
+            sessionID: 'ses_1',
+            messageID: 'msg_2',
+            type: 'text',
+            text: 'Fresh turn',
+          },
+          delta: 'Fresh turn',
+        },
+      });
+
+      expect(
+        runtimeOutputEvents.filter(
+          (event) =>
+            event.eventType === ACP_ENVELOPE_EVENT_TYPES.AssistantMessageChunk,
+        ).length,
+      ).toBeGreaterThan(chunkCountAtCancel);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it('does not emit a marker for a cancel without attribution', async () => {
+    const { client, harness } = createHarness();
+    const persistedEnvelopes: AcpPersistedEnvelope[] = [];
+    const taskEvents: TaskEvent[] = [];
+
+    harness.subscribeRuntimePersistedEnvelope((envelope) =>
+      persistedEnvelopes.push(envelope),
+    );
+    harness.subscribe((event) => taskEvents.push(event));
+
+    try {
+      await startTurnWithPartialText(harness, client);
+
+      client.messages.mockResolvedValueOnce([
+        createPartialAssistantMessage('Partial answer'),
+      ]);
+
+      harness.sendCommand({ commandName: TaskCommandName.CancelTask });
+
+      await vi.waitFor(() => {
+        expect(
+          taskEvents.some(
+            (event) => event.eventName === TaskEventName.TaskAborted,
+          ),
+        ).toBe(true);
+      });
+
+      expect(
+        persistedEnvelopes.some(
+          (envelope) =>
+            envelope.eventType === ACP_ENVELOPE_EVENT_TYPES.TaskCancelled,
+        ),
+      ).toBe(false);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it('cancels pending questions with explicit responses on an attributed cancel', async () => {
+    const { client, harness } = createHarness();
+    const persistedEnvelopes: AcpPersistedEnvelope[] = [];
+    const taskEvents: TaskEvent[] = [];
+
+    harness.subscribeRuntimePersistedEnvelope((envelope) =>
+      persistedEnvelopes.push(envelope),
+    );
+    harness.subscribe((event) => taskEvents.push(event));
+
+    try {
+      await connectHarness(harness, client);
+
+      harness.sendCommand({
+        commandName: TaskCommandName.StartNewTask,
+        data: { text: 'Start work.', visibleInTranscript: true },
+      });
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(1);
+      });
+
+      await client.emit({
+        type: 'message.part.updated',
+        properties: {
+          part: {
+            id: 'part_q',
+            sessionID: 'ses_1',
+            messageID: 'msg_1',
+            type: 'tool',
+            callID: 'call_q',
+            tool: 'question',
+            state: {
+              status: 'running',
+              input: {
+                questions: [
+                  {
+                    id: 'q1',
+                    header: 'Approach',
+                    question: 'Which approach?',
+                    options: [{ label: 'A', description: 'Approach A.' }],
+                  },
+                ],
+              },
+              title: 'Ask user',
+            },
+          },
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(harness.getPendingUserInputRequests()).toHaveLength(1);
+      });
+
+      client.messages.mockResolvedValueOnce([]);
+
+      harness.sendCommand({
+        commandName: TaskCommandName.CancelTask,
+        data: { cancelledBy: { name: 'Daniel', source: 'web' } },
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          taskEvents.some(
+            (event) => event.eventName === TaskEventName.TaskAborted,
+          ),
+        ).toBe(true);
+      });
+
+      const cancelledResponse = persistedEnvelopes.find(
+        (envelope) =>
+          envelope.eventType ===
+          ACP_ENVELOPE_EVENT_TYPES.RequestUserInputResponse,
+      );
+      const marker = persistedEnvelopes.find(
+        (envelope) =>
+          envelope.eventType === ACP_ENVELOPE_EVENT_TYPES.TaskCancelled,
+      );
+
+      expect(cancelledResponse?.payload).toMatchObject({
+        resolution: 'cancelled',
+      });
+      expect(marker).toBeDefined();
+      expect(harness.getPendingUserInputRequests()).toHaveLength(0);
+    } finally {
+      harness.dispose();
+    }
+  });
+});

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
@@ -28,6 +28,7 @@ import type {
 
 import type {
   AnswerUserInputRequestCommand,
+  CancelTaskCommand,
   Harness,
   HarnessCommandError,
   HarnessEvents,
@@ -1485,6 +1486,11 @@ export class OpenCodeServerHarness
   private replayAbortErrorSuppressionTimeout:
     | ReturnType<typeof setTimeout>
     | undefined;
+  // After a cancel, OpenCode still finalizes the aborted assistant message
+  // and stray part events can trail in; the partial output is flushed at
+  // cancel time instead, and everything after is dropped so nothing lands
+  // below the cancel point. Cleared when the next prompt goes out.
+  private suppressAssistantOutputUntilNextPrompt = false;
 
   constructor(options: OpenCodeServerHarnessOptions) {
     super();
@@ -1846,7 +1852,7 @@ export class OpenCodeServerHarness
         await this.handleSendMessage(command);
         return;
       case TaskCommandName.CancelTask:
-        await this.handleCancelTask();
+        await this.handleCancelTask(command);
         return;
       case TaskCommandName.CloseTask:
         this.currentWorkflowPhase = null;
@@ -1986,7 +1992,7 @@ export class OpenCodeServerHarness
     await this.submitPrompt({ ...command.data, text });
   }
 
-  private async handleCancelTask(): Promise<void> {
+  private async handleCancelTask(command?: CancelTaskCommand): Promise<void> {
     const sessionId = this.sessionId;
 
     if (!sessionId) {
@@ -1998,6 +2004,10 @@ export class OpenCodeServerHarness
       return;
     }
 
+    const cancelledBy = command?.data?.cancelledBy;
+    const hadActiveTurn =
+      this.inFlight || this.pendingUserInputRequests.size > 0;
+
     // Aborting an in-flight turn makes OpenCode emit a MessageAbortedError on the
     // session.error event. For an explicit cancel that's expected, not a failure
     // (the cancel is already surfaced via runtimeEvents.taskAborted), so suppress it the
@@ -2008,13 +2018,84 @@ export class OpenCodeServerHarness
       sessionId,
       signal: this.eventAbortController.signal,
     });
+    // Flush whatever the aborted turn had produced so it persists at the
+    // cancel point, then drop the trailing finalize/part events OpenCode
+    // emits for the aborted message — without this, that content re-emerges
+    // in the transcript after the cancel.
+    if (hadActiveTurn) {
+      await this.flushAssistantMessageForCancel(sessionId);
+    }
+    this.suppressAssistantOutputUntilNextPrompt = true;
     this.inFlight = false;
     this.finalizedAssistantTurn = null;
     this.prompts.clear();
     this.clearQueuedPromptRetryTimer();
-    this.pendingUserInputRequests.clear();
+    // Abandoned questions get an explicit cancelled response so surfaces
+    // that clear pending state on request_user_input_response (Slack,
+    // Linear, the web store) drop them, and late answers are rejected via
+    // the resolved-id set instead of being injected into a dead turn.
+    if (this.pendingUserInputRequests.size > 0) {
+      for (const pending of this.pendingUserInputRequests.values()) {
+        this.runtimeEvents.requestUserInputResponse({
+          request: pending,
+          answers: {},
+          resolution: 'cancelled',
+        });
+        this.recordResolvedUserInputRequest(pending.requestId);
+      }
+      this.pendingUserInputRequests.clear();
+    }
     this.clearAllExecuteToolProgress();
+
+    // Only an explicit user stop that actually interrupted something leaves
+    // a visible marker; internal cancels (steer replay, env-var resumable
+    // stop, task replacement) and idle stops stay silent.
+    if (cancelledBy && hadActiveTurn) {
+      this.runtimeEvents.taskCancelled({
+        sessionId,
+        cancelledByName: cancelledBy.name,
+        source: cancelledBy.source,
+      });
+    }
+
     this.runtimeEvents.taskAborted(sessionId);
+  }
+
+  /**
+   * Persist the in-flight assistant message as it stood at cancel time so the
+   * transcript keeps the partial output the user saw, ordered before the
+   * cancel marker. Marking it persisted also makes the post-abort
+   * `message.updated` finalize a no-op.
+   */
+  private async flushAssistantMessageForCancel(
+    sessionId: string,
+  ): Promise<void> {
+    try {
+      const messages = await this.client.messages({
+        sessionId,
+        limit: 20,
+        signal: this.eventAbortController.signal,
+      });
+      const latestAssistantMessage = [...messages]
+        .reverse()
+        .find(
+          (message) =>
+            message.info.role === 'assistant' &&
+            !this.persistedMessageIds.has(message.info.id),
+        );
+
+      if (!latestAssistantMessage) {
+        return;
+      }
+
+      this.persistAssistantMessage(latestAssistantMessage);
+    } catch (error) {
+      this.logger.warn(
+        `OpenCode cancel could not flush the aborted assistant message sessionId=${sessionId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
   }
 
   private armReplayAbortErrorSuppression(): void {
@@ -2914,6 +2995,7 @@ export class OpenCodeServerHarness
   }
 
   private async submitPrompt(prompt: PromptInput): Promise<void> {
+    this.suppressAssistantOutputUntilNextPrompt = false;
     const sessionId = await this.ensureSession(prompt.text);
     const messageID = createOpenCodeMessageId();
     const nonEmptyImages = (prompt.images ?? []).filter(
@@ -3168,6 +3250,15 @@ export class OpenCodeServerHarness
       messageRole === 'user' ||
       (messageId && this.submittedUserMessageIds.has(messageId))
     ) {
+      return;
+    }
+
+    if (
+      this.suppressAssistantOutputUntilNextPrompt &&
+      (part.type === 'text' || part.type === 'reasoning')
+    ) {
+      // Trailing stream parts for a cancelled turn; the flushed message
+      // already persisted everything the transcript should keep.
       return;
     }
 
@@ -3464,6 +3555,13 @@ export class OpenCodeServerHarness
     }
 
     if (!info.time?.completed) {
+      return;
+    }
+
+    if (this.suppressAssistantOutputUntilNextPrompt) {
+      // Post-cancel finalize of the aborted message; the cancel flush already
+      // persisted its content (and persistedMessageIds makes this a no-op for
+      // that id anyway — this also covers messages created after the abort).
       return;
     }
 

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/runtime-event-emitter.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/runtime-event-emitter.test.ts
@@ -118,4 +118,59 @@ describe('OpenCodeRuntimeEventEmitter', () => {
       payload: { logicalEventId },
     });
   });
+
+  it('emits and persists a task_cancelled marker with attribution', () => {
+    const { emitter, runtimeOutput, runtimePersistedEnvelope } =
+      createEmitter();
+
+    emitter.taskCancelled({
+      sessionId: 'session-1',
+      cancelledByName: 'Daniel',
+      source: 'web',
+    });
+
+    const liveEvent = runtimeOutput.mock.calls[0]?.[0];
+    const persistedEnvelope = runtimePersistedEnvelope.mock.calls[0]?.[0];
+
+    expect(liveEvent).toMatchObject({
+      eventType: ACP_ENVELOPE_EVENT_TYPES.TaskCancelled,
+      kind: 'task_cancelled',
+      role: 'system',
+      text: 'Stopped by Daniel',
+      payload: {
+        sessionId: 'session-1',
+        cancelledByName: 'Daniel',
+        source: 'web',
+      },
+    });
+    expect(persistedEnvelope).toMatchObject({
+      eventType: ACP_ENVELOPE_EVENT_TYPES.TaskCancelled,
+      role: 'system',
+      payload: {
+        sessionId: 'session-1',
+        cancelledByName: 'Daniel',
+        source: 'web',
+      },
+    });
+    // Live and persisted share one logical id so they reconcile as the same
+    // transcript item.
+    expect(liveEvent?.logicalEventId).toBeDefined();
+    expect(liveEvent?.logicalEventId).toBe(persistedEnvelope?.logicalEventId);
+  });
+
+  it('keeps repeated task_cancelled markers logically distinct', () => {
+    const { emitter, runtimePersistedEnvelope } = createEmitter();
+
+    emitter.taskCancelled({ sessionId: 'session-1' });
+    emitter.taskCancelled({ sessionId: 'session-1' });
+
+    const [first, second] = runtimePersistedEnvelope.mock.calls.map(
+      (call) => call[0],
+    );
+
+    expect(first?.payload).not.toHaveProperty('cancelledByName');
+    expect(first?.logicalEventId).toBeDefined();
+    expect(second?.logicalEventId).toBeDefined();
+    expect(first?.logicalEventId).not.toBe(second?.logicalEventId);
+  });
 });

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/runtime-event-emitter.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/runtime-event-emitter.ts
@@ -349,6 +349,42 @@ export class OpenCodeRuntimeEventEmitter extends RuntimeEnvelopeBuilder {
     );
   }
 
+  taskCancelled(options: {
+    sessionId: string;
+    cancelledByName?: string;
+    source?: string;
+  }): void {
+    const ts = this.nextTs();
+    const text = options.cancelledByName
+      ? `Stopped by ${options.cancelledByName}`
+      : 'Stopped';
+
+    this.outputAndPersist(
+      this.withLogicalEventId(
+        {
+          ts,
+          eventType: ACP_ENVELOPE_EVENT_TYPES.TaskCancelled,
+          role: 'system',
+          contentBlocks: [{ type: 'text', text }],
+          metadata: {
+            sessionId: options.sessionId,
+          },
+          payload: {
+            sessionId: options.sessionId,
+            ...(options.cancelledByName
+              ? { cancelledByName: options.cancelledByName }
+              : {}),
+            ...(options.source ? { source: options.source } : {}),
+          },
+        },
+        // Each marker is its own logical transcript item; keying by the
+        // envelope's own ts keeps repeated cancels in one session distinct
+        // while the live emit and the persisted envelope still reconcile.
+        { sessionId: options.sessionId, messageId: `cancel-${ts}` },
+      ),
+    );
+  }
+
   plan(options: {
     sessionId: string;
     messageId?: string;

--- a/apps/worker/src/sandbox-server/procedures/cancelTask.ts
+++ b/apps/worker/src/sandbox-server/procedures/cancelTask.ts
@@ -1,19 +1,41 @@
 import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
 
 import { publicProcedure } from '../trpc';
+
+const cancelTaskInputSchema = z
+  .object({
+    /**
+     * Attribution for an explicit user stop. When present, the harness leaves
+     * a visible `task_cancelled` marker in the transcript.
+     */
+    cancelledBy: z
+      .object({
+        /** Display name of the user who stopped the task. */
+        name: z.string().trim().min(1).max(200).optional(),
+        /** Surface the stop came from (e.g. 'web', 'slack', 'telegram'). */
+        source: z.string().trim().min(1).max(50).optional(),
+      })
+      .optional(),
+  })
+  .optional();
 
 /**
  * Cancel the current task and leave the sandbox ready to resume.
  */
-export const cancelTask = publicProcedure.mutation(async ({ ctx }) => {
-  if (!ctx.harnessManager) {
-    throw new TRPCError({
-      code: 'PRECONDITION_FAILED',
-      message: 'Harness manager is not available',
-    });
-  }
+export const cancelTask = publicProcedure
+  .input(cancelTaskInputSchema)
+  .mutation(async ({ ctx, input }) => {
+    if (!ctx.harnessManager) {
+      throw new TRPCError({
+        code: 'PRECONDITION_FAILED',
+        message: 'Harness manager is not available',
+      });
+    }
 
-  ctx.harnessManager.cancelTask();
+    ctx.harnessManager.cancelTask(
+      input?.cancelledBy ? { cancelledBy: input.cancelledBy } : undefined,
+    );
 
-  return { success: true };
-});
+    return { success: true };
+  });

--- a/packages/sdk/src/sandbox-router.ts
+++ b/packages/sdk/src/sandbox-router.ts
@@ -117,6 +117,17 @@ export interface SandboxAnswerUserInputRequestInput {
   userName?: string;
 }
 
+export interface SandboxCancelTaskInput {
+  /**
+   * Attribution for an explicit user stop; makes the harness leave a visible
+   * `task_cancelled` marker in the transcript.
+   */
+  cancelledBy?: {
+    name?: string;
+    source?: string;
+  };
+}
+
 export interface SandboxSuccessResult {
   success: true;
 }
@@ -185,7 +196,10 @@ export interface SandboxServerRpcClient {
       SandboxSuccessResult
     >;
     sandboxStream: SandboxSubscription<undefined, SandboxStreamEvent>;
-    cancelTask: SandboxMutation<undefined, SandboxSuccessResult>;
+    cancelTask: SandboxMutation<
+      SandboxCancelTaskInput | undefined,
+      SandboxSuccessResult
+    >;
     touchKeepalive: SandboxMutation<undefined, SandboxSuccessResult>;
     reloadDeploymentEnvVars: SandboxMutation<undefined, SandboxSuccessResult>;
   };

--- a/packages/types/src/__tests__/acp.test.ts
+++ b/packages/types/src/__tests__/acp.test.ts
@@ -1,6 +1,9 @@
 import {
+  ACP_ENVELOPE_EVENT_TYPES,
   canonicalizeAcpLogicalEventId,
   extractAcpMcpInvocation,
+  inferAcpMessageKind,
+  parseAcpTaskCancelledPayload,
   type AcpRequestUserInputQuestion,
   isLinkedReviewResultsMessage,
   normalizeTranscriptUserText,
@@ -991,5 +994,37 @@ describe('sanitizeEnvelopeFields', () => {
 
     expect(result.payload).toBeNull();
     expect(result.metadata).toBeNull();
+  });
+});
+
+describe('task_cancelled marker', () => {
+  it('maps the task_cancelled event type to its own message kind', () => {
+    expect(
+      inferAcpMessageKind(ACP_ENVELOPE_EVENT_TYPES.TaskCancelled),
+    ).toBe('task_cancelled');
+  });
+
+  it('parses a task_cancelled payload with attribution', () => {
+    expect(
+      parseAcpTaskCancelledPayload({
+        sessionId: 'ses_1',
+        cancelledByName: 'Daniel',
+        source: 'web',
+      }),
+    ).toEqual({
+      sessionId: 'ses_1',
+      cancelledByName: 'Daniel',
+      source: 'web',
+    });
+  });
+
+  it('parses an attribution-less payload and rejects one without a session', () => {
+    expect(parseAcpTaskCancelledPayload({ sessionId: 'ses_1' })).toEqual({
+      sessionId: 'ses_1',
+    });
+    expect(parseAcpTaskCancelledPayload({ cancelledByName: 'Daniel' })).toBe(
+      null,
+    );
+    expect(parseAcpTaskCancelledPayload(null)).toBe(null);
   });
 });

--- a/packages/types/src/__tests__/acp.test.ts
+++ b/packages/types/src/__tests__/acp.test.ts
@@ -999,9 +999,9 @@ describe('sanitizeEnvelopeFields', () => {
 
 describe('task_cancelled marker', () => {
   it('maps the task_cancelled event type to its own message kind', () => {
-    expect(
-      inferAcpMessageKind(ACP_ENVELOPE_EVENT_TYPES.TaskCancelled),
-    ).toBe('task_cancelled');
+    expect(inferAcpMessageKind(ACP_ENVELOPE_EVENT_TYPES.TaskCancelled)).toBe(
+      'task_cancelled',
+    );
   });
 
   it('parses a task_cancelled payload with attribution', () => {

--- a/packages/types/src/acp.ts
+++ b/packages/types/src/acp.ts
@@ -31,6 +31,7 @@ export const ACP_ENVELOPE_EVENT_TYPES = {
   QueuedMessagesUpdate: 'roomote_runtime.queued_messages_update',
   RequestUserInput: 'roomote_runtime.request_user_input',
   RequestUserInputResponse: 'roomote_runtime.request_user_input_response',
+  TaskCancelled: 'roomote_runtime.task_cancelled',
 } as const;
 
 export type AcpEnvelopeEventType =
@@ -176,6 +177,38 @@ export interface AcpRequestUserInputResponsePayload {
   callId: string;
   answers: AcpRequestUserInputAnswers;
   resolution: 'submitted' | 'cancelled';
+}
+
+/**
+ * Payload of the persisted `task_cancelled` marker envelope emitted when a
+ * user explicitly stops an in-flight turn. Internal aborts (steer replay,
+ * env-var resumable stop) do not emit this marker.
+ */
+export interface AcpTaskCancelledPayload {
+  sessionId: string;
+  /** Display name of the user who stopped the task, when known. */
+  cancelledByName?: string;
+  /** Surface the stop came from, e.g. `web`, `slack`, `telegram`, `api`. */
+  source?: string;
+}
+
+export function parseAcpTaskCancelledPayload(
+  payload: Record<string, unknown> | null,
+): AcpTaskCancelledPayload | null {
+  const sessionId = asStringOrNull(payload?.sessionId);
+
+  if (!sessionId) {
+    return null;
+  }
+
+  const cancelledByName = asStringOrNull(payload?.cancelledByName);
+  const source = asStringOrNull(payload?.source);
+
+  return {
+    sessionId,
+    ...(cancelledByName ? { cancelledByName } : {}),
+    ...(source ? { source } : {}),
+  };
 }
 
 export interface ParsedAcpRequestUserInputReply {
@@ -610,6 +643,7 @@ export type AcpMessageKind =
   | 'tool_call'
   | 'tool_result'
   | 'plan'
+  | 'task_cancelled'
   | 'unknown';
 
 export function inferAcpMessageKind(
@@ -630,6 +664,8 @@ export function inferAcpMessageKind(
     case ACP_ENVELOPE_EVENT_TYPES.ToolCallUpdate:
     case ACP_ENVELOPE_EVENT_TYPES.ToolResult:
       return 'tool_result';
+    case ACP_ENVELOPE_EVENT_TYPES.TaskCancelled:
+      return 'task_cancelled';
     default:
       return 'unknown';
   }


### PR DESCRIPTION
## Problem

Two cancel-UX bugs from the steering test round (T4):

1. **No transcript record on Stop.** Clicking Stop halts the task but nothing lands in the transcript — on reload (or for anyone else looking at the task) there is no sign the turn was deliberately stopped rather than crashed or abandoned. The harness only emitted the non-persisted `taskAborted` runtime event.
2. **A trailing assistant paragraph streams in after Stop.** After abort, OpenCode finalizes the aborted message; when no chunks had streamed yet for it, the consolidated finalize live-emitted the full buffered text — a whole paragraph appearing *after* the user hit Stop, reading as if the agent ignored the cancel. Stray post-abort part events had the same effect.

## Fix

**Persisted cancel marker.** An explicit user stop now threads `cancelledBy { name, source }` end-to-end: web Stop button → sandbox `cancelTask` procedure, and Slack cancel / Telegram cancel / `POST /api/tasks/:taskId/stop` → `stopTaskJob` → same procedure. The harness persists a `roomote_runtime.task_cancelled` envelope (role `system`, kind `task_cancelled`) via the standard `outputAndPersist`/logical-id path, so live view and reloaded history render it identically. The web transcript shows it as a centered divider pill: **⏹ Stopped by Daniel** (generic "Stopped" when the name is unknown).

**The marker is the true end of the turn.** On cancel the harness now:
- flushes the aborted turn's partial assistant output as its persisted message (ordered *above* the marker; the `persistedMessageIds` guard makes the later post-abort finalize a no-op),
- emits `resolution: 'cancelled'` responses for abandoned pending questions and records their ids as resolved — same contract as the steer-replay path from #46, closing the same stale-answer gap for explicit cancels,
- suppresses assistant stream/finalize events until the next prompt goes out (`submitPrompt` clears the flag). Tool updates keep flowing so running tool rows still reach terminal states.

**No false markers.** Internal cancels — steer replay (`cancelTaskAndWaitForTurnExit`), the env-var resumable stop, task replacement in `startNewTaskFromPrompt` — carry no attribution and emit nothing. Idle stops (nothing in flight, no pending question) also skip the marker.

## Rendering behavior

- Historical loader (`loadAcpEnvelopes`) gets an explicit `TaskCancelled` branch that also clears the pending-completion slot, so the aborted trailing paragraph is not styled as a completed turn (a control test pins that uncancelled turns still are).
- Live path flows through the existing generic append; the marker event finalizes any active stream (stops the streaming indicator at the cut point).
- Live emit and persisted envelope share one logical event id (`cancel-<ts>` in the turn slot), so merge/refetch reconciles them as one row and repeated cancels in a session stay distinct.

## Out of scope (follow-ups)

- **Pre-boot `direct_cancel`**: a job cancelled before its sandbox boots writes no envelope (there is no session or transcript to anchor it); the status header already shows Canceled.
- **Cancel→"hiccup" mis-finalization** (persisting cancel intent via `cancelRequestedAt`, sweep finalizing as Canceled, suppressing the failure notification) ships separately — it needs a DB migration.

## Tests

- Worker: cancel with attribution emits flushed partial output → marker (ordered), attribution-less cancel emits none, post-abort stream/finalize dropped until the next prompt lifts suppression, pending questions get cancelled responses (`opencode-server.test.ts`); emitter logical-id pairing and distinctness; manager command passthrough with/without data.
- Web: history reconstruction (marker position/payload, aborted turn not marked completed, control for normal completion, follow-up turn after marker intact), divider component labels, `AcpMessageItem` dispatch, `toAcpUiMessage` mapping.
- Types: kind inference + payload parser.
- `pnpm check-types:fast`, `pnpm lint:fast`, full worker sandbox-server (299), web task-page (499), API stop-path (48) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)