### PR TITLE
[Fix] OpenCode subagent watchdog kills healthy reviews and hangs the job

### DIFF
--- a/.agent-guidance/architecture/cloud-job-execution.md
+++ b/.agent-guidance/architecture/cloud-job-execution.md
@@ -1,7 +1,7 @@
 ---
 title: Cloud Job Execution Architecture
 status: active
-last_reviewed: 2026-07-03
+last_reviewed: 2026-07-09
 owner: engineering
 summary: Cloud job execution system covering direct cloud-job submission, controller dispatch, worker runtime, sandbox OIDC refresh, snapshots, and completion.
 ---
@@ -383,7 +383,7 @@ Harnesses:
   are persisted as Roomote runtime subagent-start tool calls. The harness arms
   a per-spawn subagent watchdog (keyed to the child session id from the task
   tool part metadata, `sessionId` or `jobId`) with two deadlines: a total run
-  timeout (default 12 minutes, `ROOMOTE_SUBAGENT_TASK_TIMEOUT_MS`) and a
+  timeout (default 30 minutes, `ROOMOTE_SUBAGENT_TASK_TIMEOUT_MS`) and a
   sliding inactivity deadline (default 3 minutes,
   `ROOMOTE_SUBAGENT_TASK_INACTIVITY_TIMEOUT_MS`) refreshed by every
   child-session event (streamed text, tool state, message completion). The
@@ -398,7 +398,13 @@ Harnesses:
   child that goes silent between tools past the inactivity window — or any
   spawn that exceeds the total timeout — has its child sessions aborted so the
   parent turn continues with the aborted task result instead of hanging; a
-  terminal tool status normally disarms the watchdog. Background launches
+  terminal tool status, or a child `session.error` (the abort surfaces as a
+  MessageAbortedError attributed to the child), disarms the watchdog. Expiry
+  aborts the watchdog's own captured child session; when the child session id
+  was never captured it falls back to listing the parent's children, but skips
+  any child still owned by another live watchdog so a stale watchdog cannot
+  take down a healthy concurrent sibling (all subagents of one turn share the
+  parent session). Background launches
   (`background: true` in the task tool input or background metadata) complete
   the parent tool part instantly while the child session keeps working, so a
   completed background part keeps the watchdog armed; the watchdog disarms
@@ -451,7 +457,13 @@ Persistence model:
   tasks, the harness evaluates the generated stop hook before completion; when
   a terminal Slack-visible closeout is missing, it sends the hook reminder back
   as a hidden queued prompt and withholds `TaskCompleted` until the closeout is
-  satisfied or the guard reaches its retry cap.
+  satisfied or the guard reaches its retry cap. Because that reminder awaits a
+  fresh turn to re-evaluate, a fail-safe deadline (default 10 minutes,
+  `ROOMOTE_STOP_HOOK_REMINDER_STALL_TIMEOUT_MS`) guards against a session that
+  wedges and never produces the follow-up turn: on expiry it force-completes
+  the turn (emits `TaskCompleted`) so the job reaches a terminal state instead
+  of hanging `running` while the sandbox keeps heart-beating. Any normal turn
+  re-entry or teardown disarms it first, so it only fires on genuine silence.
 - Worker startup log UIs rely on provider-side command output streaming when the compute provider supports it. The worker no longer mirrors harness logs into `cloud_jobs.log`.
 
 ### Harness Transport Boundary

--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server-subagent-watchdog.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server-subagent-watchdog.test.ts
@@ -105,14 +105,18 @@ function createTaskToolPart(options: {
   metadata?: Record<string, unknown>;
   output?: string;
   input?: Record<string, unknown>;
+  callId?: string;
+  messageId?: string;
 }) {
+  const callId = options.callId ?? 'call_task_1';
+
   return {
-    id: 'prt_task_1',
+    id: `prt_${callId}`,
     sessionID: 'ses_1',
-    messageID: 'msg_1',
+    messageID: options.messageId ?? 'msg_1',
     type: 'tool',
     tool: 'task',
-    callID: 'call_task_1',
+    callID: callId,
     state: {
       status: options.status ?? 'running',
       input: {
@@ -277,6 +281,109 @@ describe('OpenCode subagent watchdog', () => {
       expect(client.abort).toHaveBeenCalledWith(
         expect.objectContaining({ sessionId: 'child_2' }),
       );
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it('does not abort sibling child sessions still owned by a live watchdog', async () => {
+    const { client, harness } = createHarness();
+
+    try {
+      await connectHarness(harness, client);
+      vi.useFakeTimers();
+
+      // Watchdog A: no child session id ever captured, so its expiry takes the
+      // list-all-children fallback.
+      await client.emit({
+        type: 'message.part.updated',
+        properties: {
+          part: createTaskToolPart({ status: 'pending', callId: 'call_A' }),
+        },
+      });
+
+      // Watchdog B is armed half a window later, so at A's deadline B is still
+      // live (its own deadline is further out). B owns child session
+      // ses_child_B.
+      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS / 2);
+      await client.emit({
+        type: 'message.part.updated',
+        properties: {
+          part: createTaskToolPart({
+            status: 'running',
+            callId: 'call_B',
+            metadata: { sessionId: 'ses_child_B' },
+          }),
+        },
+      });
+
+      // The parent session lists both children when A's fallback runs.
+      client.children.mockResolvedValueOnce([
+        { id: 'ses_child_A', parentID: 'ses_1' },
+        { id: 'ses_child_B', parentID: 'ses_1' },
+      ]);
+
+      // Advance to A's total-timeout deadline (B still has half a window left).
+      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS / 2);
+
+      expect(client.children).toHaveBeenCalledTimes(1);
+      // Only the orphaned child is aborted; the sibling owned by live watchdog
+      // B is spared.
+      expect(client.abort).toHaveBeenCalledTimes(1);
+      expect(client.abort).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: 'ses_child_A' }),
+      );
+      expect(client.abort).not.toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: 'ses_child_B' }),
+      );
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it('disarms a watchdog when its child session errors (aborted elsewhere)', async () => {
+    const { client, harness } = createHarness();
+
+    try {
+      await connectHarness(harness, client);
+
+      // Establish the parent session so the child error routes through the
+      // child-session branch of the dispatcher.
+      harness.sendCommand({
+        commandName: TaskCommandName.StartNewTask,
+        data: { text: 'Do work.', visibleInTranscript: true },
+      });
+      await vi.waitFor(() => {
+        expect(client.createSession).toHaveBeenCalled();
+      });
+
+      vi.useFakeTimers();
+
+      await client.emit({
+        type: 'message.part.updated',
+        properties: {
+          part: createTaskToolPart({
+            status: 'running',
+            metadata: { sessionId: 'ses_child_1' },
+          }),
+        },
+      });
+
+      // The child is aborted by some other path; OpenCode surfaces that as a
+      // session.error attributed to the child. The watchdog must disarm so it
+      // never fires its own deadline later.
+      await client.emit({
+        type: 'session.error',
+        properties: {
+          sessionID: 'ses_child_1',
+          error: { name: 'MessageAbortedError' },
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS * 2);
+
+      expect(client.children).not.toHaveBeenCalled();
+      expect(client.abort).not.toHaveBeenCalled();
     } finally {
       harness.dispose();
     }

--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
@@ -90,6 +90,7 @@ function createHarness(
     executeToolProgressInitialDelayMs?: number;
     executeToolProgressIntervalMs?: number;
     queuedPromptRetryDelayMs?: number;
+    stopHookReminderStallTimeoutMs?: number;
     mcpServerNames?: string[];
     model?: string;
   } = {},
@@ -105,6 +106,7 @@ function createHarness(
       options.executeToolProgressInitialDelayMs,
     executeToolProgressIntervalMs: options.executeToolProgressIntervalMs,
     queuedPromptRetryDelayMs: options.queuedPromptRetryDelayMs,
+    stopHookReminderStallTimeoutMs: options.stopHookReminderStallTimeoutMs,
     mcpServerNames: options.mcpServerNames,
     beforeQueuedPrompt: options.beforeQueuedPrompt,
   });
@@ -1739,6 +1741,149 @@ describe('OpenCodeServerHarness', () => {
         ),
       ).toBe(false);
       expect(client.promptAsync).toHaveBeenCalledTimes(4);
+    } finally {
+      harness.dispose();
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('force-completes the turn when a stop-hook reminder wedges with no follow-up turn', async () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'roomote-opencode-stop-guard-wedge-'),
+    );
+    const stateFilePath = path.join(tempDir, 'slack-state.json');
+    const stopHookPath = path.join(tempDir, 'stop-hook.cjs');
+
+    fs.writeFileSync(
+      stateFilePath,
+      JSON.stringify({
+        currentTurnMessageTs: '111.222',
+        currentTurnStartedAtMs: Date.now() - 1_000,
+      }),
+      'utf8',
+    );
+    fs.writeFileSync(stopHookPath, SLACK_STOP_HOOK_SCRIPT, 'utf8');
+
+    const { client, harness } = createHarness(new FakeOpenCodeServerClient(), {
+      commandEnv: {
+        ROOMOTE_SLACK_REPLY_SATISFACTION_STATE_FILE: stateFilePath,
+        ROOMOTE_OPENCODE_SLACK_STOP_HOOK_SCRIPT: stopHookPath,
+      },
+      stopHookReminderStallTimeoutMs: 50,
+    });
+    const taskEvents: TaskEvent[] = [];
+
+    harness.subscribe((event) => taskEvents.push(event));
+
+    try {
+      await connectHarness(harness, client);
+
+      expect(
+        harness.sendCommand({
+          commandName: TaskCommandName.StartNewTask,
+          data: { text: 'Do work.', visibleInTranscript: true },
+        }),
+      ).toBe(true);
+
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(1);
+      });
+
+      // The blocked turn-end injects a closeout reminder and then awaits a
+      // fresh turn to re-evaluate.
+      await client.emit({
+        type: 'session.idle',
+        properties: { sessionID: 'ses_1' },
+      });
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(2);
+      });
+
+      // The session then wedges: no further events ever arrive. The fail-safe
+      // fires and force-completes the turn so the task reaches a terminal
+      // state instead of hanging "running" forever.
+      await vi.waitFor(() => {
+        expect(
+          taskEvents.some(
+            (event) => event.eventName === TaskEventName.TaskCompleted,
+          ),
+        ).toBe(true);
+      });
+      expect(
+        taskEvents.some(
+          (event) => event.eventName === TaskEventName.TaskAborted,
+        ),
+      ).toBe(false);
+      // No extra reminder was injected — the fail-safe completed the turn.
+      expect(client.promptAsync).toHaveBeenCalledTimes(2);
+    } finally {
+      harness.dispose();
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('disarms the stop-hook reminder fail-safe on teardown', async () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'roomote-opencode-stop-guard-teardown-'),
+    );
+    const stateFilePath = path.join(tempDir, 'slack-state.json');
+    const stopHookPath = path.join(tempDir, 'stop-hook.cjs');
+
+    fs.writeFileSync(
+      stateFilePath,
+      JSON.stringify({
+        currentTurnMessageTs: '111.222',
+        currentTurnStartedAtMs: Date.now() - 1_000,
+      }),
+      'utf8',
+    );
+    fs.writeFileSync(stopHookPath, SLACK_STOP_HOOK_SCRIPT, 'utf8');
+
+    const { client, harness } = createHarness(new FakeOpenCodeServerClient(), {
+      commandEnv: {
+        ROOMOTE_SLACK_REPLY_SATISFACTION_STATE_FILE: stateFilePath,
+        ROOMOTE_OPENCODE_SLACK_STOP_HOOK_SCRIPT: stopHookPath,
+      },
+      stopHookReminderStallTimeoutMs: 50,
+    });
+    const taskEvents: TaskEvent[] = [];
+
+    harness.subscribe((event) => taskEvents.push(event));
+
+    try {
+      await connectHarness(harness, client);
+
+      expect(
+        harness.sendCommand({
+          commandName: TaskCommandName.StartNewTask,
+          data: { text: 'Do work.', visibleInTranscript: true },
+        }),
+      ).toBe(true);
+
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(1);
+      });
+
+      // Blocked turn-end injects a reminder and arms the fail-safe.
+      await client.emit({
+        type: 'session.idle',
+        properties: { sessionID: 'ses_1' },
+      });
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(2);
+      });
+
+      // Teardown must disarm the pending fail-safe. Dispose, then wait well
+      // past the stall window and confirm it never force-completed a disposed
+      // harness.
+      harness.dispose();
+      await new Promise((resolve) => setTimeout(resolve, 120));
+
+      expect(
+        taskEvents.some(
+          (event) => event.eventName === TaskEventName.TaskCompleted,
+        ),
+      ).toBe(false);
     } finally {
       harness.dispose();
       fs.rmSync(tempDir, { recursive: true, force: true });

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
@@ -82,6 +82,7 @@ interface OpenCodeServerHarnessOptions {
   executeToolProgressIntervalMs?: number;
   subagentTaskTimeoutMs?: number;
   subagentTaskInactivityTimeoutMs?: number;
+  stopHookReminderStallTimeoutMs?: number;
   queuedPromptRetryDelayMs?: number;
   mcpServerNames?: string[];
   beforeQueuedPrompt?: (input: { userId?: string }) => Promise<void | {
@@ -216,13 +217,27 @@ const OPEN_CODE_EXECUTE_TOOLS = new Set(['bash', 'shell']);
 const OPEN_CODE_READ_TOOLS = new Set(['read']);
 const OPEN_CODE_SEARCH_TOOLS = new Set(['grep', 'glob', 'find', 'list', 'ls']);
 const MAX_OPENCODE_STOP_HOOK_REMINDERS = 3;
+// Fail-safe for a wedged stop-hook reminder cycle. After a turn finishes
+// without the required Slack closeout, we resubmit a reminder prompt and then
+// wait for a fresh turn (a future session.idle re-enters finishCurrentTurn).
+// If OpenCode never produces that turn — the session wedged, e.g. after a mass
+// subagent abort — nothing else bounds the wait and the job hangs "running"
+// indefinitely while the sandbox keeps heart-beating. This deadline force-
+// completes the turn so the job reaches a terminal state instead. Any normal
+// turn re-entry (or teardown) clears it first via clearAllExecuteToolProgress,
+// so it only ever fires on a genuine silence.
+const OPENCODE_STOP_HOOK_REMINDER_STALL_TIMEOUT_MS = 10 * 60_000;
 const EXPECTED_REPLAY_ABORT_SUPPRESSION_MS = 10_000;
 const DEFAULT_EXECUTE_TOOL_PROGRESS_INITIAL_DELAY_MS = 15_000;
 const DEFAULT_EXECUTE_TOOL_PROGRESS_INTERVAL_MS = 30_000;
 // Kill switch for runaway subagent runs: a subagent that produces no terminal
 // signal within this window is presumed dead and its child sessions are
-// aborted so the parent turn can continue instead of hanging silently.
-const DEFAULT_SUBAGENT_TASK_TIMEOUT_MS = 12 * 60_000;
+// aborted so the parent turn can continue instead of hanging silently. Sized
+// for large review/audit subagents that legitimately read hundreds of files;
+// 12 minutes was too tight and killed in-progress work (the sliding inactivity
+// deadline below is the primary wedge detector, so this only backstops a child
+// that stays superficially active but never terminates).
+const DEFAULT_SUBAGENT_TASK_TIMEOUT_MS = 30 * 60_000;
 // Sliding inactivity deadline for subagent runs: once the child session is
 // known, every event it emits (streamed text, tool state, message completion)
 // counts as liveness. A child that goes silent for this window is presumed
@@ -1396,6 +1411,7 @@ export class OpenCodeServerHarness
   private readonly executeToolProgressIntervalMs: number;
   private readonly subagentTaskTimeoutMs: number;
   private readonly subagentTaskInactivityTimeoutMs: number;
+  private readonly stopHookReminderStallTimeoutMs: number;
   private readonly queuedPromptRetryDelayMs: number;
   private readonly streamedPartText = new Map<string, string>();
   private readonly streamedMessageIds = new Set<string>();
@@ -1437,6 +1453,8 @@ export class OpenCodeServerHarness
   private activeWorkflowSkill: string | null = null;
   private commandEnv: Record<string, string> | undefined;
   private stopHookReminderCount = 0;
+  private stopHookReminderStallTimer: ReturnType<typeof setTimeout> | null =
+    null;
   private resolveEventStreamReady: (() => void) | undefined;
   private rejectEventStreamReady: ((error: unknown) => void) | undefined;
   private finalizedAssistantTurn: FinalizedAssistantTurn | null = null;
@@ -1476,6 +1494,9 @@ export class OpenCodeServerHarness
     this.subagentTaskInactivityTimeoutMs =
       options.subagentTaskInactivityTimeoutMs ??
       DEFAULT_SUBAGENT_TASK_INACTIVITY_TIMEOUT_MS;
+    this.stopHookReminderStallTimeoutMs =
+      options.stopHookReminderStallTimeoutMs ??
+      OPENCODE_STOP_HOOK_REMINDER_STALL_TIMEOUT_MS;
     this.queuedPromptRetryDelayMs =
       options.queuedPromptRetryDelayMs ?? DEFAULT_QUEUED_PROMPT_RETRY_DELAY_MS;
     this.knownMcpServerNames = [
@@ -2058,6 +2079,11 @@ export class OpenCodeServerHarness
     }
 
     this.activeExecuteToolProgress.clear();
+    // The stop-hook reminder fail-safe shares this teardown lifecycle: every
+    // point that clears execute-tool heartbeats (turn finish, cancel, session
+    // error, queued replay, dispose) also means the awaited reminder response
+    // either arrived or is moot, so disarm the pending fail-safe.
+    this.clearStopHookReminderStall();
     // Subagent watchdogs share the same lifecycle: every teardown point that
     // clears execute-tool heartbeats (turn finish, cancel, session error,
     // queued replay, dispose) must also disarm pending subagent watchdogs.
@@ -2292,6 +2318,19 @@ export class OpenCodeServerHarness
     this.activeSubagentWatchdogs.delete(eventKey);
   }
 
+  /**
+   * True when `childSessionId` is currently tracked by a live watchdog. Used by
+   * the expiry fallback to avoid aborting sibling subagents that are still
+   * being independently monitored — a watchdog with an unknown child session id
+   * must not take down healthy concurrent children of the shared parent
+   * session.
+   */
+  private isChildSessionOwnedByActiveWatchdog(childSessionId: string): boolean {
+    const eventKey = this.childSessionWatchdogKeys.get(childSessionId);
+
+    return eventKey !== undefined && this.activeSubagentWatchdogs.has(eventKey);
+  }
+
   private clearAllSubagentWatchdogs(options?: {
     keepBackgroundWatchdogs?: boolean;
   }): void {
@@ -2491,6 +2530,16 @@ export class OpenCodeServerHarness
     // is dropped by the sessionId guard in handleEvent; no replay-abort
     // suppression is needed here. Prefer the exact child session captured
     // from the task tool part metadata; fall back to listing all children.
+    //
+    // The fallback lists every child of the parent session, so it must never
+    // abort a child that belongs to a *different, still-live* watchdog: sibling
+    // subagents run concurrently under one parent session, and a healthy
+    // sibling is independently monitored by its own watchdog. Aborting it here
+    // is collateral damage that kills in-progress work. Exclude any child
+    // session still owned by another active watchdog. (This watchdog's own
+    // mapping was already removed by stopSubagentWatchdog above, so only other
+    // watchdogs remain.) The exact-child path is inherently scoped and needs no
+    // filtering.
     try {
       const childSessionIds = watchdog.childSessionId
         ? [watchdog.childSessionId]
@@ -2499,7 +2548,12 @@ export class OpenCodeServerHarness
               sessionId: watchdog.sessionId,
               signal: this.eventAbortController.signal,
             })
-          ).map((child) => child.id);
+          )
+            .map((child) => child.id)
+            .filter(
+              (childSessionId) =>
+                !this.isChildSessionOwnedByActiveWatchdog(childSessionId),
+            );
 
       for (const childSessionId of childSessionIds) {
         try {
@@ -2916,8 +2970,14 @@ export class OpenCodeServerHarness
       // parent spawn row, and record hidden inference usage before returning.
       // A child session going idle is its completion signal — for background
       // launches this disarms the watchdog that outlived the instant
-      // task-tool completion.
-      if (payload.type === 'session.idle') {
+      // task-tool completion. A child `session.error` is equally terminal:
+      // aborting a child (our own watchdog expiry, or a sibling watchdog's
+      // fallback abort) surfaces here as a MessageAbortedError attributed to
+      // the child. Disarm on it too, so a watchdog whose child was already
+      // aborted elsewhere does not linger and fire its own deadline later
+      // (which, with an unknown child session id, would abort whatever
+      // children exist by then — including a fresh, healthy wave).
+      if (payload.type === 'session.idle' || payload.type === 'session.error') {
         const watchdogKey = this.childSessionWatchdogKeys.get(sessionId);
 
         if (watchdogKey) {
@@ -3404,6 +3464,10 @@ export class OpenCodeServerHarness
             visibleInTranscript: false,
             source: 'opencode-stop-hook',
           });
+          // We now await a fresh turn to re-enter this method. Arm a fail-safe
+          // so a session that never produces that turn (wedged after the
+          // reminder) still reaches a terminal state instead of hanging.
+          this.armStopHookReminderStall(sessionId);
           return;
         }
       }
@@ -3416,6 +3480,48 @@ export class OpenCodeServerHarness
 
       this.runtimeEvents.taskCompleted(sessionId, finalized?.tokenUsage);
     }
+
+    await this.drainQueuedPrompts();
+  }
+
+  private armStopHookReminderStall(sessionId: string): void {
+    this.clearStopHookReminderStall();
+    const timer = setTimeout(() => {
+      void this.handleStopHookReminderStall(sessionId);
+    }, this.stopHookReminderStallTimeoutMs);
+    timer.unref?.();
+    this.stopHookReminderStallTimer = timer;
+  }
+
+  private clearStopHookReminderStall(): void {
+    if (this.stopHookReminderStallTimer) {
+      clearTimeout(this.stopHookReminderStallTimer);
+      this.stopHookReminderStallTimer = null;
+    }
+  }
+
+  /**
+   * Fires when a resubmitted stop-hook reminder produced no follow-up turn
+   * within the deadline: the OpenCode session is presumed wedged. Force the
+   * turn to a terminal state (mirroring the reminder give-up branch) so the
+   * job completes instead of hanging "running" forever while the sandbox keeps
+   * heart-beating. Any normal turn re-entry or teardown disarms this first, so
+   * reaching here always means a genuine silence.
+   */
+  private async handleStopHookReminderStall(sessionId: string): Promise<void> {
+    this.clearStopHookReminderStall();
+
+    if (this.disposed) {
+      return;
+    }
+
+    this.logger.warn(
+      `OpenCode stop-hook reminder produced no follow-up turn within ${this.stopHookReminderStallTimeoutMs}ms; the session appears wedged. Force-completing the turn so the task reaches a terminal state.`,
+    );
+
+    this.inFlight = false;
+    this.stopHookReminderCount = 0;
+    this.runtimeEvents.taskCompleted(sessionId, undefined);
 
     await this.drainQueuedPrompts();
   }

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/start.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/start.ts
@@ -284,6 +284,9 @@ export async function startOpenCodeServerHarness({
       subagentTaskInactivityTimeoutMs: parseTimeoutMs(
         process.env.ROOMOTE_SUBAGENT_TASK_INACTIVITY_TIMEOUT_MS,
       ),
+      stopHookReminderStallTimeoutMs: parseTimeoutMs(
+        process.env.ROOMOTE_STOP_HOOK_REMINDER_STALL_TIMEOUT_MS,
+      ),
       mcpServerNames: Object.keys(mcpServers),
       beforeQueuedPrompt,
     });


### PR DESCRIPTION
## Context

A large PR-review task (fan-out into parallel review subagents on the `opencode-server` harness) stopped responding and left its Slack thread silent. Investigation of the stuck job (`taskPhase: stopped`, `status: running`, worker heart-beating for 2.5+ hours, no closeout posted) surfaced three stacked causes in the OpenCode subagent harness.

## Changes

**1. Subagent total timeout 12 → 30 min** (`harness.ts`)
The total-run kill switch fired on the first review wave at ~12m — too tight for large review/audit subagents that legitimately read hundreds of files. Bumped the default; the sliding 3-min inactivity deadline stays the primary wedge detector. Still overridable via `ROOMOTE_SUBAGENT_TASK_TIMEOUT_MS`.

**2. Watchdog collateral-abort + cleanup** (`harness.ts`)
On expiry with an unknown child session id, the watchdog listed and aborted **every** child of the shared parent session, killing healthy concurrent siblings. Now:
- the fallback skips any child still owned by another live watchdog (`isChildSessionOwnedByActiveWatchdog`), so a stale watchdog can't take down a fresh, healthy wave;
- a child `session.error` (how an abort surfaces — a `MessageAbortedError` attributed to the child) disarms that watchdog, not just `session.idle`, so an already-aborted child's watchdog can't linger and fire its own deadline later.

**3. Zombie-job recovery for a wedged parent turn** (`harness.ts`)
After the subagents were aborted, the session emitted empty turns and wedged: the stop-hook closeout reminder awaited a follow-up turn that never came, with nothing bounding the wait, so the job hung `running` indefinitely. Added a fail-safe deadline (default 10 min, `ROOMOTE_STOP_HOOK_REMINDER_STALL_TIMEOUT_MS`) that force-completes the turn so the job reaches a terminal state. Any normal turn re-entry or teardown disarms it first, so it only fires on genuine silence.

## Tests
- New watchdog tests: scope-safe fallback (spare a live sibling) + child-`session.error` disarm.
- New stop-hook tests: force-complete on a wedged reminder + disarm on teardown.
- **147 harness tests pass**; typecheck / eslint / prettier clean.
- Updated `.agent-guidance/architecture/cloud-job-execution.md` (documented the old 12-min value and abort-all behavior).

## Caveat
The exact trigger for the *second* subagent wave's death (2m32s, matching no configured timeout) couldn't be pinned from the DB transcript alone — that needs in-sandbox harness logs. The collateral-abort hazard fixed in (2) is a real defect regardless, and (1) alone prevents the premature first-wave kill that started the cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)