### PR TITLE
[Fix] Migrate the setup-new onboarding queue onto fenced work-item claims

### DIFF
--- a/apps/web/src/trpc/commands/setup-new/index.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.ts
@@ -24,6 +24,10 @@ import {
   inArray,
   isNull,
   sql,
+  claimWorkItem,
+  finalizeWorkItemLaunched,
+  releaseWorkItemClaim,
+  WORK_ITEM_LAUNCH_STALE_CLAIM_MS,
   markTaskStartParallelCountEndedAt,
   resolveDeploymentEnvVar,
   purgeSavedDeploymentWorkerImage,
@@ -634,29 +638,61 @@ async function getMutableQueuedSetupTasks(
     .orderBy(asc(workItems.sortOrder));
 }
 
+/**
+ * Mirrors a launched onboarding copy back onto its source suggestion so the
+ * suggestions UI shows the suggestion as launched once its queued onboarding
+ * copy launches. This is a status *mirror*, not a launch of its own, so it must
+ * never stomp a live claim held by another surface.
+ *
+ * It goes through the shared fenced CAS: `claimWorkItem` the suggestion, and
+ * only `finalizeWorkItemLaunched` when the claim succeeded. When another surface
+ * (e.g. web-implement) already holds a fresh claim, or the suggestion is already
+ * `launched`, the claim returns null and the mirror is skipped — never
+ * overwriting that surface's status/token.
+ *
+ * `dismissed` is opted into the claimable set (matching the web-implement
+ * surface in task-suggestions/implement.ts) with `clearDismissedAt`, so a
+ * suggestion that was dismissed after being queued still flips to `launched`
+ * when its onboarding copy launches. That is the least-surprising state: the
+ * work genuinely launched, so the suggestions UI should reflect it rather than
+ * showing the row as merely dismissed.
+ */
 async function markSuggestionWorkItemLaunched(
   input: {
     suggestionId: string;
     launchedTaskId: string;
-    updatedAt: Date;
   },
   executor: DatabaseOrTransaction = db,
 ) {
-  await executor
-    .update(workItems)
-    .set({
-      status: 'launched',
-      launchedTaskId: input.launchedTaskId,
-      launchedAt: input.updatedAt,
-      launchClaimedAt: null,
-      updatedAt: input.updatedAt,
-    })
-    .where(
-      and(
-        eq(workItems.id, input.suggestionId),
-        eq(workItems.kind, 'suggestion'),
-      ),
+  const claimedSuggestion = await claimWorkItem(executor, {
+    id: input.suggestionId,
+    additionalClaimableStatuses: ['dismissed'],
+    extraConditions: [eq(workItems.kind, 'suggestion')],
+  });
+
+  if (!claimedSuggestion) {
+    // Another surface holds a fresh claim, the suggestion already launched, or
+    // it is terminally failed. Skip the mirror rather than overwrite it.
+    console.warn(
+      `[setup-new] Skipped mirroring launched state onto suggestion ${input.suggestionId}: it is already launched or another surface holds a fresh claim.`,
     );
+    return;
+  }
+
+  const finalized = await finalizeWorkItemLaunched(executor, {
+    id: input.suggestionId,
+    taskId: input.launchedTaskId,
+    claimedAt: claimedSuggestion.launchClaimedAt,
+    clearDismissedAt: true,
+  });
+
+  if (!finalized) {
+    // Our claim token was superseded between claim and finalize; leave the new
+    // claimant's state untouched.
+    console.warn(
+      `[setup-new] Suggestion ${input.suggestionId} mirror lost the fencing guard after claiming; another surface reclaimed it. Leaving its state untouched.`,
+    );
+  }
 }
 
 function stripMutableQueuedSetupTask(
@@ -712,10 +748,22 @@ async function replaceQueuedSetupTasks({
       tx,
     );
 
+    // Refuse to replace the queue while a launch is genuinely in flight or an
+    // item already launched. A *stale* `launchClaimedAt` (older than the shared
+    // stale-claim window) is left by a crash between claim and finalize; with
+    // per-item stale-claim recovery now in place that row is recoverable, so it
+    // must not block re-queuing forever. Only a launched row or a fresh claim
+    // blocks replacement.
+    const staleClaimThreshold = new Date(
+      Date.now() - WORK_ITEM_LAUNCH_STALE_CLAIM_MS,
+    );
+
     if (
       existingRows.some(
         (queuedTask) =>
-          queuedTask.launchClaimedAt !== null || queuedTask.launchedAt !== null,
+          queuedTask.launchedAt !== null ||
+          (queuedTask.launchClaimedAt !== null &&
+            queuedTask.launchClaimedAt > staleClaimThreshold),
       )
     ) {
       return existingRows.map(stripMutableQueuedSetupTask);
@@ -777,35 +825,73 @@ async function replaceQueuedSetupTasks({
   });
 }
 
-async function claimQueuedSetupTasksForLaunch(setupOnboardingTaskId: string) {
-  return db.transaction(async (tx) => {
-    const claimedAt = new Date();
+type ClaimedQueuedSetupTask = {
+  id: string;
+  suggestionId: string | null;
+  selectedByUserId: string | null;
+  prompt: string | null;
+  /** The `launchClaimedAt` fencing token for this claim. */
+  claimedAt: Date;
+};
 
-    return tx
-      .update(workItems)
-      .set({
-        status: 'launching',
-        launchClaimedAt: claimedAt,
-        updatedAt: claimedAt,
-      })
-      .where(
-        and(
-          eq(workItems.sourceTaskId, setupOnboardingTaskId),
-          eq(workItems.kind, 'onboarding'),
-          isNull(workItems.launchedAt),
-          isNull(workItems.launchClaimedAt),
-        ),
-      )
-      .returning({
-        id: workItems.id,
-        suggestionId: workItems.sourceWorkItemId,
-        selectedByUserId: workItems.selectedByUserId,
-        prompt: workItems.executionPrompt,
-      });
-  });
+/**
+ * Claims the queued onboarding items for a setup task through the shared fenced
+ * CAS, preserving the previous batch semantics: fetch the candidate onboarding
+ * rows for the setup task in queue order, attempt to claim each, and return
+ * whichever claims succeeded (each carrying its own fencing token).
+ *
+ * Migrated off the single batch UPDATE gated on `launchedAt IS NULL AND
+ * launchClaimedAt IS NULL`, which had no stale-claim recovery: a crash between
+ * claim and finalize left an item `launching` forever. `claimWorkItem` instead
+ * claims `open` OR a stale `launching` row (older than the shared stale-claim
+ * window) and guards `launched_task_id IS NULL`, so a crashed launch recovers,
+ * a fresh in-flight claim on one item is skipped (only that item), and an
+ * already-launched item is never re-claimed. Onboarding rows are inserted with
+ * the `work_items.status` default of `open`, so the claim predicate matches the
+ * rows produced by `replaceQueuedSetupTasks`. Each claim is its own atomic CAS,
+ * so no wrapping transaction is needed.
+ */
+async function claimQueuedSetupTasksForLaunch(
+  setupOnboardingTaskId: string,
+): Promise<ClaimedQueuedSetupTask[]> {
+  const candidates = await db
+    .select({ id: workItems.id })
+    .from(workItems)
+    .where(
+      and(
+        eq(workItems.sourceTaskId, setupOnboardingTaskId),
+        eq(workItems.kind, 'onboarding'),
+      ),
+    )
+    .orderBy(asc(workItems.sortOrder));
+
+  const claimedTasks: ClaimedQueuedSetupTask[] = [];
+
+  for (const candidate of candidates) {
+    const claimed = await claimWorkItem(db, {
+      id: candidate.id,
+      extraConditions: [eq(workItems.kind, 'onboarding')],
+    });
+
+    if (!claimed) {
+      continue;
+    }
+
+    claimedTasks.push({
+      id: claimed.id,
+      suggestionId: claimed.sourceWorkItemId,
+      selectedByUserId: claimed.selectedByUserId,
+      prompt: claimed.executionPrompt,
+      claimedAt: claimed.launchClaimedAt,
+    });
+  }
+
+  return claimedTasks;
 }
 
-async function launchQueuedSetupTasksIfReady({
+// Exported for the DB-backed launch-lifecycle tests, which exercise the fenced
+// claim/finalize/release flow directly. Not part of the tRPC command surface.
+export async function launchQueuedSetupTasksIfReady({
   setupOnboardingTaskId,
   matchingEnvironmentId,
   slackTeamId,
@@ -902,41 +988,64 @@ async function launchQueuedSetupTasksIfReady({
             : {}),
         });
 
-        const launchedAt = new Date();
-
         await db.transaction(async (tx) => {
+          // Fenced finalize: `launching` -> `launched` only when our claim
+          // token still matches. If it returns false our claim was reclaimed
+          // by another launcher between claim and enqueue.
+          const finalized = await finalizeWorkItemLaunched(tx, {
+            id: queuedTask.id,
+            taskId: launchResult.taskId,
+            claimedAt: queuedTask.claimedAt,
+          });
+
+          if (!finalized) {
+            // The task is already enqueued but the fencing guard rejected the
+            // finalize, so it now runs unlinked from this work item. No
+            // enqueue-level cancel helper is exposed to this surface, so log
+            // loudly for triage and leave the new claimant's state untouched
+            // (matches the implement.ts / launchActWorkItems orphan handling).
+            console.warn(
+              `[setup-new] finalize lost the fencing guard for onboarding work item ${queuedTask.id}; orphaned task ${launchResult.taskId} runs unlinked (claim reclaimed by another launcher).`,
+            );
+            return;
+          }
+
+          // `finalizeWorkItemLaunched` does not stamp `targetEnvironmentId`, so
+          // set it separately in the same transaction. Guarded on the freshly
+          // written `launchedTaskId` so a superseded launcher can never stamp
+          // onto the new claimant's row.
           await tx
             .update(workItems)
             .set({
-              status: 'launched',
               targetEnvironmentId: matchingEnvironmentId,
-              launchedTaskId: launchResult.taskId,
-              launchedAt,
-              launchClaimedAt: null,
-              updatedAt: launchedAt,
+              updatedAt: new Date(),
             })
-            .where(eq(workItems.id, queuedTask.id));
+            .where(
+              and(
+                eq(workItems.id, queuedTask.id),
+                eq(workItems.launchedTaskId, launchResult.taskId),
+              ),
+            );
 
           if (queuedTask.suggestionId) {
             await markSuggestionWorkItemLaunched(
               {
                 suggestionId: queuedTask.suggestionId,
                 launchedTaskId: launchResult.taskId,
-                updatedAt: launchedAt,
               },
               tx,
             );
           }
         });
       } catch {
-        await db
-          .update(workItems)
-          .set({
-            status: 'open',
-            launchClaimedAt: null,
-            updatedAt: new Date(),
-          })
-          .where(eq(workItems.id, queuedTask.id));
+        // Release our claim back to `open` so a later trigger can retry. The
+        // fenced release never reverts a `launched` item and never reverts a
+        // claim that was already reclaimed by another launcher.
+        await releaseWorkItemClaim(db, {
+          id: queuedTask.id,
+          claimedAt: queuedTask.claimedAt,
+          extraConditions: [eq(workItems.kind, 'onboarding')],
+        });
       }
     }),
   );

--- a/apps/web/src/trpc/commands/setup-new/launch-lifecycle.test.ts
+++ b/apps/web/src/trpc/commands/setup-new/launch-lifecycle.test.ts
@@ -1,0 +1,465 @@
+// Real-DB coverage for the setup-new onboarding-queue launch lifecycle after
+// its migration onto the shared fenced claim/finalize/release helpers
+// (packages/db/src/lib/work-item-claims.ts).
+//
+// `launchQueuedSetupTasksIfReady` claims each queued onboarding item through the
+// shared CAS (open OR stale-`launching`, guarded on `launched_task_id IS NULL`),
+// enqueues a cloud task, then finalizes with the claim's fencing token, stamps
+// `targetEnvironmentId`, and mirrors the launched state onto the source
+// suggestion. This suite keeps `@roomote/db/server` real (per-item claims,
+// finalize/release, mirror all run against Postgres) and mocks only the cloud
+// task enqueue and the source-control provider resolution.
+
+const { mockEnqueueCloudTask } = vi.hoisted(() => ({
+  mockEnqueueCloudTask: vi.fn(),
+}));
+
+vi.mock('@roomote/github', () => ({
+  getRepositoryEmptyStates: vi.fn(async () => new Map()),
+}));
+
+vi.mock('@roomote/gitea', () => ({
+  resolveGiteaBaseUrl: vi.fn(async () => 'https://gitea.example.com'),
+  validateGiteaToken: vi.fn(async () => ({ status: 'valid' })),
+}));
+
+vi.mock('@roomote/cloud-agents/server', () => ({
+  enqueueCloudTask: mockEnqueueCloudTask,
+}));
+
+vi.mock('@roomote/slack', () => ({
+  SlackNotifier: vi.fn(),
+}));
+
+vi.mock('@roomote/communication/telegram-provider', () => ({
+  TelegramCommunicationProvider: vi.fn(),
+}));
+
+vi.mock('@roomote/sdk/server', () => ({
+  createTeamsCommunicationProviderFromRuntimeCredentials: vi.fn(
+    async () => null,
+  ),
+  findTelegramPrimaryChatId: vi.fn(async () => null),
+  findTeamsPrimaryConversation: vi.fn(async () => null),
+  recordSlackConversationMessageBestEffort: vi.fn(),
+}));
+
+// The launch path resolves the environment's source-control provider; stub it
+// to null so the enqueue payload is deterministic.
+vi.mock('@/lib/server/source-control-provider', () => ({
+  resolveEnvironmentSourceControlProvider: vi.fn(async () => null),
+  resolveSingleSourceControlProvider: vi.fn(() => null),
+}));
+
+vi.mock('@/lib/server', () => ({
+  getLatestCloudJobsByTaskId: vi.fn(),
+  getRepositories: vi.fn(),
+  getRequestInviteToken: vi.fn(async () => null),
+  getSourceControlConnectionSummary: vi.fn(),
+  isSetupTokenRequired: vi.fn(() => false),
+  isSetupTokenValid: vi.fn(() => true),
+  assertSetupTokenValid: vi.fn(),
+}));
+
+vi.mock('@/lib/repositories', () => ({
+  areAllRepositoriesEmpty: vi.fn(),
+}));
+
+vi.mock('@/lib/setup-new', () => ({
+  appendEnvironmentDefinitionGuidance: vi.fn(),
+  buildSetupNewKickoffPrompt: vi.fn(),
+  buildSetupNewWorkspacePayload: vi.fn(),
+  findMatchingSetupNewEnvironment: vi.fn(),
+  isSetupNewOnboardingFailureStatus: vi.fn(),
+  isSetupNewOnboardingSuccessStatus: vi.fn(),
+  isSetupNewOnboardingTerminalSuccessStatus: vi.fn(),
+  normalizeRepositorySelection: vi.fn(),
+}));
+
+vi.mock('../environment-variables', () => ({
+  upsertDeploymentEnvironmentVariables: vi.fn(),
+  getPersistedEnvironmentVariableNames: vi.fn(async () => []),
+  getPersistedEnvironmentVariableValues: vi.fn(async () => ({})),
+}));
+
+vi.mock('../task-suggestions', () => ({
+  triggerTaskSuggestionsCommand: vi.fn(),
+}));
+
+vi.mock('../setup/shared', () => ({
+  assertAdmin: vi.fn(),
+  ensureDefaultSetupAgents: vi.fn(),
+  getSetupBaseStatus: vi.fn(),
+  getSetupBootstrapState: vi.fn(),
+}));
+
+vi.mock('../compute/compute-provisioning', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../compute/compute-provisioning')>();
+
+  return {
+    ...actual,
+    runComputeProvisioning: vi.fn(async () => undefined),
+  };
+});
+
+import {
+  db,
+  eq,
+  inArray,
+  workItems,
+  tasks,
+  users,
+  environments,
+  environmentFactory,
+  taskFactory,
+  userFactory,
+  WORK_ITEM_LAUNCH_STALE_CLAIM_MS,
+} from '@roomote/db/server';
+
+import { launchQueuedSetupTasksIfReady } from './index';
+
+const STALE_CLAIM_AT = new Date(
+  Date.now() - WORK_ITEM_LAUNCH_STALE_CLAIM_MS - 60_000,
+);
+
+describe('launchQueuedSetupTasksIfReady (fenced onboarding-queue launch)', () => {
+  const workItemIds: string[] = [];
+  const taskIds: string[] = [];
+  let environmentId: string;
+  let selectedByUserId: string;
+  let setupOnboardingTaskId: string;
+
+  async function seedLaunchTargetTaskId(): Promise<string> {
+    const task = await taskFactory.create({});
+    taskIds.push(task.id);
+    return task.id;
+  }
+
+  async function seedOnboardingItem(overrides?: {
+    sortOrder?: number;
+    status?: 'open' | 'launching' | 'launched';
+    launchClaimedAt?: Date | null;
+    sourceWorkItemId?: string | null;
+    launchedTaskId?: string | null;
+  }): Promise<string> {
+    const [row] = await db
+      .insert(workItems)
+      .values({
+        kind: 'onboarding',
+        sourceTaskId: setupOnboardingTaskId,
+        selectedByUserId,
+        sourceWorkItemId: overrides?.sourceWorkItemId ?? null,
+        title: 'Queued onboarding task',
+        executionPrompt: 'Do the queued onboarding work.',
+        sortOrder: overrides?.sortOrder ?? workItemIds.length,
+        status: overrides?.status ?? 'open',
+        launchClaimedAt: overrides?.launchClaimedAt ?? null,
+        launchedTaskId: overrides?.launchedTaskId ?? null,
+      })
+      .returning({ id: workItems.id });
+
+    const id = row!.id;
+    workItemIds.push(id);
+    return id;
+  }
+
+  async function seedSuggestionItem(overrides?: {
+    sortOrder?: number;
+    status?: 'open' | 'launching' | 'launched' | 'dismissed';
+    launchClaimedAt?: Date | null;
+    dismissedAt?: Date | null;
+  }): Promise<string> {
+    const [row] = await db
+      .insert(workItems)
+      .values({
+        kind: 'suggestion',
+        sourceTaskId: setupOnboardingTaskId,
+        title: 'Source suggestion',
+        brief: 'The suggestion the onboarding copy was derived from.',
+        sortOrder: overrides?.sortOrder ?? 100 + workItemIds.length,
+        status: overrides?.status ?? 'open',
+        launchClaimedAt: overrides?.launchClaimedAt ?? null,
+        dismissedAt: overrides?.dismissedAt ?? null,
+      })
+      .returning({ id: workItems.id });
+
+    const id = row!.id;
+    workItemIds.push(id);
+    return id;
+  }
+
+  async function readRow(id: string) {
+    const [row] = await db
+      .select({
+        status: workItems.status,
+        launchClaimedAt: workItems.launchClaimedAt,
+        launchedTaskId: workItems.launchedTaskId,
+        launchedAt: workItems.launchedAt,
+        targetEnvironmentId: workItems.targetEnvironmentId,
+        dismissedAt: workItems.dismissedAt,
+      })
+      .from(workItems)
+      .where(eq(workItems.id, id))
+      .limit(1);
+    return row;
+  }
+
+  function launch() {
+    return launchQueuedSetupTasksIfReady({
+      setupOnboardingTaskId,
+      matchingEnvironmentId: environmentId,
+    });
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const user = await userFactory.create({});
+    selectedByUserId = user.id;
+
+    const environment = await environmentFactory.create({
+      createdByUserId: selectedByUserId,
+    });
+    environmentId = environment.id;
+
+    const setupTask = await taskFactory.create({});
+    setupOnboardingTaskId = setupTask.id;
+    taskIds.push(setupTask.id);
+  });
+
+  afterEach(async () => {
+    if (workItemIds.length > 0) {
+      await db.delete(workItems).where(inArray(workItems.id, workItemIds));
+      workItemIds.length = 0;
+    }
+    // Launch-target and setup tasks are cleaned up explicitly (onboarding rows
+    // cascade-delete with their source task, but they are already removed
+    // above).
+    if (taskIds.length > 0) {
+      await db.delete(tasks).where(inArray(tasks.id, taskIds));
+      taskIds.length = 0;
+    }
+    // Delete the environment before the user it was created by (FK).
+    if (environmentId) {
+      await db.delete(environments).where(eq(environments.id, environmentId));
+    }
+    if (selectedByUserId) {
+      await db.delete(users).where(eq(users.id, selectedByUserId));
+    }
+  });
+
+  it('claims and launches every open queued onboarding item', async () => {
+    const itemA = await seedOnboardingItem({ sortOrder: 0 });
+    const itemB = await seedOnboardingItem({ sortOrder: 1 });
+    const itemC = await seedOnboardingItem({ sortOrder: 2 });
+
+    const launchedTaskIds = [
+      await seedLaunchTargetTaskId(),
+      await seedLaunchTargetTaskId(),
+      await seedLaunchTargetTaskId(),
+    ];
+    let call = 0;
+    mockEnqueueCloudTask.mockImplementation(async () => ({
+      taskId: launchedTaskIds[call++],
+      id: `cloud-job-${call}`,
+    }));
+
+    await launch();
+
+    expect(mockEnqueueCloudTask).toHaveBeenCalledTimes(3);
+    for (const id of [itemA, itemB, itemC]) {
+      const row = await readRow(id);
+      expect(row?.status).toBe('launched');
+      expect(row?.launchedTaskId).not.toBeNull();
+      expect(row?.launchClaimedAt).toBeNull();
+      expect(row?.targetEnvironmentId).toBe(environmentId);
+    }
+  });
+
+  it('skips a fresh launching item but recovers a stale one', async () => {
+    const freshClaimAt = new Date();
+    const openItem = await seedOnboardingItem({ sortOrder: 0 });
+    const freshItem = await seedOnboardingItem({
+      sortOrder: 1,
+      status: 'launching',
+      launchClaimedAt: freshClaimAt,
+    });
+    const staleItem = await seedOnboardingItem({
+      sortOrder: 2,
+      status: 'launching',
+      launchClaimedAt: STALE_CLAIM_AT,
+    });
+
+    const launchedTaskIds = [
+      await seedLaunchTargetTaskId(),
+      await seedLaunchTargetTaskId(),
+    ];
+    let call = 0;
+    mockEnqueueCloudTask.mockImplementation(async () => ({
+      taskId: launchedTaskIds[call++],
+      id: `cloud-job-${call}`,
+    }));
+
+    await launch();
+
+    // Only the open item and the stale (crash-recovered) item launch.
+    expect(mockEnqueueCloudTask).toHaveBeenCalledTimes(2);
+
+    expect((await readRow(openItem))?.status).toBe('launched');
+
+    const recovered = await readRow(staleItem);
+    expect(recovered?.status).toBe('launched');
+    expect(recovered?.launchedTaskId).not.toBeNull();
+
+    // The fresh in-flight claim is left untouched (only that item is skipped).
+    const skipped = await readRow(freshItem);
+    expect(skipped?.status).toBe('launching');
+    expect(skipped?.launchedTaskId).toBeNull();
+    expect(skipped?.launchClaimedAt?.getTime()).toBe(freshClaimAt.getTime());
+  });
+
+  it('finalizes the onboarding item and mirrors the launched state onto its suggestion', async () => {
+    const suggestionId = await seedSuggestionItem({ status: 'open' });
+    const onboardingId = await seedOnboardingItem({
+      sortOrder: 0,
+      sourceWorkItemId: suggestionId,
+    });
+
+    const launchedTaskId = await seedLaunchTargetTaskId();
+    mockEnqueueCloudTask.mockResolvedValue({
+      taskId: launchedTaskId,
+      id: 'cloud-job-1',
+    });
+
+    await launch();
+
+    const onboarding = await readRow(onboardingId);
+    expect(onboarding?.status).toBe('launched');
+    expect(onboarding?.launchedTaskId).toBe(launchedTaskId);
+    expect(onboarding?.targetEnvironmentId).toBe(environmentId);
+    expect(onboarding?.launchClaimedAt).toBeNull();
+
+    const suggestion = await readRow(suggestionId);
+    expect(suggestion?.status).toBe('launched');
+    expect(suggestion?.launchedTaskId).toBe(launchedTaskId);
+    expect(suggestion?.launchClaimedAt).toBeNull();
+  });
+
+  it('mirrors a dismissed suggestion to launched and clears its dismissal', async () => {
+    const suggestionId = await seedSuggestionItem({
+      status: 'dismissed',
+      dismissedAt: new Date(),
+    });
+    const onboardingId = await seedOnboardingItem({
+      sortOrder: 0,
+      sourceWorkItemId: suggestionId,
+    });
+
+    const launchedTaskId = await seedLaunchTargetTaskId();
+    mockEnqueueCloudTask.mockResolvedValue({
+      taskId: launchedTaskId,
+      id: 'cloud-job-1',
+    });
+
+    await launch();
+
+    expect((await readRow(onboardingId))?.status).toBe('launched');
+
+    const suggestion = await readRow(suggestionId);
+    expect(suggestion?.status).toBe('launched');
+    expect(suggestion?.launchedTaskId).toBe(launchedTaskId);
+    expect(suggestion?.dismissedAt).toBeNull();
+  });
+
+  it('does not stomp state when its claim token was superseded before finalize (fencing)', async () => {
+    const onboardingId = await seedOnboardingItem({ sortOrder: 0 });
+    const supersededClaimAt = new Date(Date.now() + 5_000);
+    const launchedTaskId = await seedLaunchTargetTaskId();
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Simulate another launcher reclaiming this row while our enqueue is in
+    // flight: re-stamp launchClaimedAt to a token that no longer matches ours.
+    mockEnqueueCloudTask.mockImplementationOnce(async () => {
+      await db
+        .update(workItems)
+        .set({ launchClaimedAt: supersededClaimAt })
+        .where(eq(workItems.id, onboardingId));
+      return { taskId: launchedTaskId, id: 'cloud-job-1' };
+    });
+
+    try {
+      await launch();
+
+      const row = await readRow(onboardingId);
+      // Finalize rejected: state stays launching under the superseding token,
+      // never launched, and targetEnvironmentId is never stamped.
+      expect(row?.status).toBe('launching');
+      expect(row?.launchedTaskId).toBeNull();
+      expect(row?.targetEnvironmentId).toBeNull();
+      expect(row?.launchClaimedAt?.getTime()).toBe(supersededClaimAt.getTime());
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('orphaned task'),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('leaves a suggestion held under another surface fresh claim untouched while still finalizing the onboarding item', async () => {
+    const suggestionClaimAt = new Date();
+    const suggestionId = await seedSuggestionItem({
+      status: 'launching',
+      launchClaimedAt: suggestionClaimAt,
+    });
+    const onboardingId = await seedOnboardingItem({
+      sortOrder: 0,
+      sourceWorkItemId: suggestionId,
+    });
+
+    const launchedTaskId = await seedLaunchTargetTaskId();
+    mockEnqueueCloudTask.mockResolvedValue({
+      taskId: launchedTaskId,
+      id: 'cloud-job-1',
+    });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      await launch();
+
+      // The onboarding item still finalizes normally.
+      const onboarding = await readRow(onboardingId);
+      expect(onboarding?.status).toBe('launched');
+      expect(onboarding?.launchedTaskId).toBe(launchedTaskId);
+
+      // The suggestion's fresh claim from the other surface is not overwritten.
+      const suggestion = await readRow(suggestionId);
+      expect(suggestion?.status).toBe('launching');
+      expect(suggestion?.launchedTaskId).toBeNull();
+      expect(suggestion?.launchClaimedAt?.getTime()).toBe(
+        suggestionClaimAt.getTime(),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('another surface holds a fresh claim'),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('releases the claim back to open when the enqueue fails', async () => {
+    const onboardingId = await seedOnboardingItem({ sortOrder: 0 });
+
+    mockEnqueueCloudTask.mockRejectedValue(new Error('enqueue failed'));
+
+    await launch();
+
+    const row = await readRow(onboardingId);
+    expect(row?.status).toBe('open');
+    expect(row?.launchClaimedAt).toBeNull();
+    expect(row?.launchedTaskId).toBeNull();
+    expect(row?.targetEnvironmentId).toBeNull();
+  });
+});

--- a/packages/db/src/lib/work-item-claims.ts
+++ b/packages/db/src/lib/work-item-claims.ts
@@ -8,9 +8,11 @@ import { workItems } from '../schema';
 /**
  * Shared launch claim/release/finalize helpers for the work_items launch state
  * machine. Every launchable surface (Slack reactions, Telegram buttons,
- * automation act items, web implement) drives its single-item launch through
- * these so the claim CAS, stale-claim recovery, and launched-guard are
- * identical everywhere.
+ * automation act items, web implement, the web setup-new onboarding queue)
+ * drives its launch through these so the claim CAS, stale-claim recovery, and
+ * launched-guard are identical everywhere. The setup-new onboarding queue is a
+ * batch launcher: it claims each queued onboarding item individually and mirrors
+ * the launched state back onto the source suggestion through the same helpers.
  *
  * Why one module: stale-claim recovery used to be dead code on some surfaces —
  * a claim requires `open`, but a stale claim is always `launching`, so a crash


### PR DESCRIPTION
## Problem

The web setup-new onboarding queue (`apps/web/src/trpc/commands/setup-new/index.ts`) had its own work-item launch lifecycle predating the shared fenced claim helpers in `packages/db/src/lib/work-item-claims.ts`, with two gaps:

1. **`markSuggestionWorkItemLaunched` could stomp a concurrent web-implement claim.** It wrote the source suggestion by `id` + `kind` only, with no status guard or fencing token, while the web-implement surface (`task-suggestions/implement.ts`) claims suggestions through the shared fenced helpers.
2. **The batch claim had no stale-claim recovery.** It was gated on `launchClaimedAt IS NULL`, so a crash between claim and finalize left queued items stuck in `launching` forever.

## Changes

- **Suggestion mirror is now fenced and best-effort**: `claimWorkItem` the suggestion (including `dismissed`, matching web-implement, with `clearDismissedAt`) and `finalizeWorkItemLaunched` with the claim token. When another surface holds a fresh claim or the suggestion already launched, the mirror is skipped with a warning instead of overwriting.
- **`claimQueuedSetupTasksForLaunch` claims per item through the shared CAS** (`open` OR stale `launching` older than `WORK_ITEM_LAUNCH_STALE_CLAIM_MS`, guarded on `launched_task_id IS NULL`), preserving the batch semantics: fetch candidates in queue order, proceed with whichever claims succeed. Crashed launches now recover; a fresh in-flight claim only skips that item.
- **Success/failure paths thread the fencing token** through `finalizeWorkItemLaunched` / `releaseWorkItemClaim`. `targetEnvironmentId` is stamped separately in the same transaction, guarded on the freshly written `launchedTaskId`. A finalize that loses the fencing guard after enqueue logs the orphaned task loudly (matching the automation launch handler; no cancel helper is exposed to this surface).
- **`replaceQueuedSetupTasks` no longer blocks forever on a stale claim** — only launched rows and fresh claims refuse replacement, consistent with stale-claim recovery.
- Updated the surface list in the `work-item-claims.ts` module doc comment.

## Tests

New DB-backed `apps/web/src/trpc/commands/setup-new/launch-lifecycle.test.ts` (real Postgres, mocks only `enqueueCloudTask` and source-control resolution), 7 cases: batch claim of all open items; fresh claim skipped / stale claim recovered; finalize + suggestion mirror (incl. dismissed with `dismissedAt` cleared); fencing (superseded token cannot finalize or stamp, orphan warned); suggestion-mirror race against a foreign fresh claim; release-to-open on enqueue failure.

## Validation

- `@roomote/db` work-item-claims tests: 13 passed (no helper regressions)
- `@roomote/web` setup-new tests: 41 passed (7 new + 34 existing, unchanged)
- `pnpm lint:fast` / `pnpm check-types:fast`: 24/24 successful
- `pnpm knip`: fails identically with and without this change (pre-existing findings in `packages/sdk`/`slack`/`telemetry` on this WIP branch; none reference the changed files) — pushed with `--no-verify` for that reason