### PR TITLE
[Chore] Replace unused Railway auto-deploy job with a repository dispatch hook

### DIFF
--- a/.agent-guidance/operations/deployment.md
+++ b/.agent-guidance/operations/deployment.md
@@ -554,18 +554,14 @@ Preview soak hosts are upgraded manually with `roomote-deploy upgrade` after the
 GHCR workflow publishes the matching `develop-<short-sha>` image tag. The
 publish workflow no longer auto-deploys a DigitalOcean preview droplet.
 
-The same workflow has an optional `deploy-railway` job that keeps a Railway
-deployment current with every develop build. It is gated on the repository
-variable `ROOMOTE_RAILWAY_AUTODEPLOY=true` (skipped otherwise) and runs in the
-GitHub `railway` environment with a single environment-scoped secret,
-`ROOMOTE_RAILWAY_PROJECT_TOKEN` — a Railway project token that can only touch
-one environment. The job calls Railway's public GraphQL API directly
-(`Project-Access-Token` header): it resolves the environment from the token,
-matches services whose image starts with `ghcr.io/<owner>/roomote-app`, then
-issues `serviceInstanceUpdate` with the immutable `develop-<short-sha>` tag
-and `serviceInstanceDeploy` for each. There is no intermediary service and no
-public endpoint. The operator runbook is the "Auto-deploying every develop
-build" section of `deploy/railway/README.md`.
+The same workflow has a `notify-ops` job that, on develop pushes, sends a
+`repository_dispatch` event (`roomote-develop-build`, with `client_payload`
+fields `image_tag`/`sha`/`ref`) to the repository named by the
+`ROOMOTE_OPS_REPO` repository variable, authenticated by the
+`ROOMOTE_OPS_DISPATCH_TOKEN` secret (a fine-grained token with access to only
+that repository). The job is skipped while `ROOMOTE_OPS_REPO` is unset.
+Deployment automation that consumes the event lives in that external
+repository, not in this one.
 
 Upgrade and rollback are intentionally tag switches. `roomote-deploy upgrade`
 copies the new Compose/Caddy files, removes stale systemd loading of bootstrap

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -278,98 +278,23 @@ jobs:
           docker buildx imagetools create "${tag_args[@]}" "${digest_refs[@]}"
           docker buildx imagetools inspect "$IMAGE:$VERSION"
 
-  # Optional: keep a Railway deployment pinned to every develop build. The
-  # job talks to Railway's public GraphQL API with an environment-scoped
-  # project token: it finds every service in that environment running the
-  # roomote-app image, points it at the new immutable develop-<sha> tag,
-  # and redeploys it. See deploy/railway/README.md for the setup runbook.
-  deploy-railway:
-    name: Deploy Railway preview
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+  notify-ops:
+    name: Notify ops repository
+    runs-on: ubuntu-latest
     needs: publish
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' && vars.ROOMOTE_RAILWAY_AUTODEPLOY == 'true' }}
-    environment: railway
-    concurrency:
-      group: railway-deploy
-      cancel-in-progress: false
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' && vars.ROOMOTE_OPS_REPO != '' }}
     permissions:
       contents: read
     steps:
-      - name: Point Railway services at the new image tag
-        shell: bash
+      - name: Send repository dispatch
         env:
-          RAILWAY_PROJECT_TOKEN: ${{ secrets.ROOMOTE_RAILWAY_PROJECT_TOKEN }}
+          GH_TOKEN: ${{ secrets.ROOMOTE_OPS_DISPATCH_TOKEN }}
+          OPS_REPO: ${{ vars.ROOMOTE_OPS_REPO }}
         run: |
           set -euo pipefail
-          : "${RAILWAY_PROJECT_TOKEN:?ROOMOTE_RAILWAY_PROJECT_TOKEN is required}"
-
-          api=https://backboard.railway.com/graphql/v2
-
-          # POST one GraphQL operation. Fails on transport errors and on
-          # GraphQL-level errors, and prints only the data payload.
-          gql() {
-            local query="$1" variables="${2:-null}" response
-            response="$(jq -n --arg query "$query" --argjson variables "$variables" \
-              '{query: $query, variables: $variables}' \
-              | curl -sS --fail-with-body --retry 3 --retry-all-errors \
-                  -X POST "$api" \
-                  -H 'Content-Type: application/json' \
-                  -H "Project-Access-Token: ${RAILWAY_PROJECT_TOKEN}" \
-                  --data-binary @-)"
-            if [ "$(jq 'has("errors")' <<< "$response")" = "true" ]; then
-              jq -r '.errors[].message' <<< "$response" >&2
-              return 1
-            fi
-            jq '.data' <<< "$response"
-          }
-
-          owner="$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')"
-          prefix="ghcr.io/${owner}/roomote-app"
-          image="${prefix}:develop-${GITHUB_SHA:0:8}"
-
-          # A project token is scoped to a single environment; resolve it
-          # from the token instead of configuring it separately.
-          environment_id="$(gql 'query { projectToken { environmentId } }' \
-            | jq -r '.projectToken.environmentId')"
-
-          services="$(gql 'query ($environmentId: String!) {
-            environment(id: $environmentId) {
-              serviceInstances {
-                edges { node { serviceId serviceName source { image } } }
-              }
-            }
-          }' "$(jq -n --arg environmentId "$environment_id" '{environmentId: $environmentId}')" \
-            | jq -c --arg prefix "$prefix" \
-                '[.environment.serviceInstances.edges[].node
-                  | select(.source.image != null and (.source.image | startswith($prefix)))]')"
-
-          count="$(jq 'length' <<< "$services")"
-          if [ "$count" -eq 0 ]; then
-            echo "No Railway services run an image with prefix $prefix" >&2
-            exit 1
-          fi
-
-          # Both mutations are idempotent (set the image, then deploy), so
-          # a retried or partially failed run is safe to re-run.
-          for i in $(seq 0 $((count - 1))); do
-            service_id="$(jq -r ".[$i].serviceId" <<< "$services")"
-            service_name="$(jq -r ".[$i].serviceName" <<< "$services")"
-            echo "Updating $service_name to $image"
-            gql 'mutation ($environmentId: String!, $serviceId: String!, $input: ServiceInstanceUpdateInput!) {
-              serviceInstanceUpdate(environmentId: $environmentId, serviceId: $serviceId, input: $input)
-            }' "$(jq -n \
-                  --arg environmentId "$environment_id" \
-                  --arg serviceId "$service_id" \
-                  --arg image "$image" \
-                  '{environmentId: $environmentId, serviceId: $serviceId, input: {source: {image: $image}}}')" \
-              > /dev/null
-            gql 'mutation ($environmentId: String!, $serviceId: String!) {
-              serviceInstanceDeploy(environmentId: $environmentId, serviceId: $serviceId, latestCommit: false)
-            }' "$(jq -n \
-                  --arg environmentId "$environment_id" \
-                  --arg serviceId "$service_id" \
-                  '{environmentId: $environmentId, serviceId: $serviceId}')" \
-              > /dev/null
-          done
-
-          echo "Updated $count service(s) to $image"
+          : "${GH_TOKEN:?ROOMOTE_OPS_DISPATCH_TOKEN is required}"
+          gh api "repos/${OPS_REPO}/dispatches" \
+            -f event_type=roomote-develop-build \
+            -f "client_payload[image_tag]=develop-${GITHUB_SHA:0:8}" \
+            -f "client_payload[sha]=${GITHUB_SHA}" \
+            -f "client_payload[ref]=${GITHUB_REF}"

--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -380,8 +380,8 @@ Live previews need a wildcard domain, which requires a domain you control:
   pin, bump the tag in the four image fields first. The api service's
   `db-migrate` pre-deploy applies any schema changes, and the
   auto-generated keypairs persist in Postgres, so sessions, job tokens, and
-  preview tokens survive redeploys. Develop-channel deployments can make
-  this happen automatically on every develop build — see
+  preview tokens survive redeploys. These redeploys can be automated against
+  Railway's GraphQL API — see
   [Auto-deploying every develop build](#auto-deploying-every-develop-build-optional).
 - **Back up** the Railway Postgres database (Railway backups or `pg_dump`)
   and the MinIO volume or external bucket. Everything else is reproducible
@@ -393,50 +393,20 @@ Live previews need a wildcard domain, which requires a domain you control:
 
 ## Auto-deploying every develop build (optional)
 
-Railway never redeploys on its own when a mutable tag like `:develop` or
+Railway never redeploys on its own when a mutable alias like `:develop` or
 `:main` moves, so a deployment tracking a channel alias only picks up new
-builds when someone redeploys the app services. The `Publish GHCR Images`
-workflow has an optional `deploy-railway` job that closes that gap for the
-**develop channel**: after each develop build's images publish, it calls
-Railway's public GraphQL API directly, finds every service in the
-environment running the `roomote-app` image, points it at the new immutable
-`develop-<short-sha>` tag, and redeploys it. Nothing extra runs inside the
-Railway project. The job only fires on develop pushes today; main-channel
-deployments upgrade by redeploying the app services after a main build.
+builds when the app services are redeployed.
 
-Setup, once:
-
-1. In the Railway project, create a **project token** for the target
-   environment (Project Settings → Tokens). Project tokens are scoped to
-   that one environment and can be revoked there at any time.
-2. On the GitHub repository, create a `railway` environment restricted to
-   the `develop` branch, with a single secret:
-   `ROOMOTE_RAILWAY_PROJECT_TOKEN`.
-3. Set the repository variable `ROOMOTE_RAILWAY_AUTODEPLOY=true`. The job is
-   skipped entirely while the variable is unset, so forks and deployments
-   that do not want auto-deploy need no other configuration.
-
-No project or environment IDs need to be configured: the job resolves the
-environment from the token itself (`query { projectToken { environmentId } }`).
-
-Each run matches services whose image starts with
-`ghcr.io/<owner>/roomote-app` — api, web, controller, bullmq, and
-preview-proxy when present — then issues `serviceInstanceUpdate` with the
-pinned tag and `serviceInstanceDeploy` for each. The api service's
-`db-migrate` pre-deploy runs as usual. MinIO, Postgres, and Redis never
-match the prefix and are untouched. The first run permanently moves the
-matched services from the `:develop` alias to immutable
-`develop-<short-sha>` pins — intentional, since the pins make the deployed
-version visible in the Railway UI and make rollback a tag switch: edit the
-image field back to an older tag (or re-run the job from an older commit)
-to roll back.
-
-Security notes: the only credential is the project token, which can touch a
-single Railway environment and nothing else in the workspace. It lives in a
-GitHub environment secret, is never printed by the job, and GitHub does not
-expose environment secrets to fork pull requests, so open-sourcing the
-repository does not widen access. Rotate or revoke the token from the
-Railway project's token settings.
+Those redeploys can be automated from any CI system against Railway's public
+GraphQL API using a **project token** (scoped to a single environment).
+Resolve the environment from the token itself
+(`query { projectToken { environmentId } }`), find the services whose image
+starts with `ghcr.io/<owner>/roomote-app`, then for each issue
+`serviceInstanceUpdate` pointing at an immutable tag (e.g.
+`develop-<short-sha>` or `v1.2.3`) followed by `serviceInstanceDeploy`. Both
+mutations are idempotent, so a retried or partially failed run is safe to
+re-run, and pinning immutable tags makes rollback a tag switch — point the
+image field back at an older tag and deploy.
 
 ## Maintaining the marketplace template
 

--- a/deploy/railway/template.yaml
+++ b/deploy/railway/template.yaml
@@ -30,9 +30,8 @@
 #   worker-current.tar.gz. Production deployments can pin an immutable tag
 #   (v*, develop-<sha>, or main-<sha>) in the four image fields instead;
 #   nothing else needs editing. Railway does not redeploy when a mutable
-#   alias moves; develop-channel deployments that want every develop build
-#   automatically can enable the publish workflow's deploy-railway job
-#   (README.md "Auto-deploying every develop build" — develop-only today).
+#   alias moves; redeploys can be automated against Railway's GraphQL API
+#   (README.md "Auto-deploying every develop build").
 # - Railway has no Docker socket, so task execution must use a hosted
 #   sandbox provider (modal by default; e2b and daytona also work).
 #   EXCLUDED_COMPUTE_PROVIDERS=docker hides the unusable provider.


### PR DESCRIPTION
The `deploy-railway` job in the GHCR publish workflow was never enabled (`ROOMOTE_RAILWAY_AUTODEPLOY` was never set). This removes it and adds a minimal `notify-ops` job that sends a `repository_dispatch` event (`roomote-develop-build`, payload: `image_tag`/`sha`/`ref`) to the repository named by the `ROOMOTE_OPS_REPO` variable after each develop image publish. The job is skipped while the variable is unset, so forks need no configuration.

Docs updated to match: the Railway README's auto-deploy section now describes the generic GraphQL automation pattern instead of the removed job, plus matching updates in `deploy/railway/template.yaml` and `.agent-guidance/operations/deployment.md`.

## Validation
- `pnpm exec prettier --check` on all changed files
- `pnpm knowledge:check .agent-guidance/operations/deployment.md`
- Pre-push: `lint:fast` + `check-types:fast` + `knip`