### PR TITLE
Address invocation identity review feedback

### DIFF
--- a/apps/web/src/app/api/setup/teams-app-package/__tests__/route.test.ts
+++ b/apps/web/src/app/api/setup/teams-app-package/__tests__/route.test.ts
@@ -58,4 +58,15 @@ describe('GET /api/setup/teams-app-package', () => {
       error: 'invalid_bot_app_id',
     });
   });
+
+  it('rejects a bot name that exceeds the Teams manifest short-name limit', async () => {
+    const response = await GET(
+      buildRequest(`?botAppId=${BOT_APP_ID}&botName=${'a'.repeat(31)}`),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'invalid_bot_name',
+    });
+  });
 });

--- a/apps/web/src/app/api/setup/teams-app-package/route.ts
+++ b/apps/web/src/app/api/setup/teams-app-package/route.ts
@@ -18,6 +18,7 @@ export const dynamic = 'force-dynamic';
  */
 const GUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const TEAMS_MANIFEST_SHORT_NAME_MAX_LENGTH = 30;
 
 /**
  * Unauthenticated setup-flow variant of `GET /api/teams/app-package`.
@@ -37,6 +38,13 @@ export async function GET(request: Request) {
 
   if (!botAppId || !GUID_PATTERN.test(botAppId)) {
     return new Response(JSON.stringify({ error: 'invalid_bot_app_id' }), {
+      status: 400,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  if (botName && botName.length > TEAMS_MANIFEST_SHORT_NAME_MAX_LENGTH) {
+    return new Response(JSON.stringify({ error: 'invalid_bot_name' }), {
       status: 400,
       headers: { 'content-type': 'application/json' },
     });

--- a/packages/types/src/__tests__/invocation-identity.test.ts
+++ b/packages/types/src/__tests__/invocation-identity.test.ts
@@ -34,6 +34,8 @@ describe('invocation identity formatting', () => {
       displayName: 'Acme Bot',
       mentionText: '@Acme Bot',
       nativeMention: '<@U123>',
+      guidanceName: '@Acme Bot',
+      examplePrompt: '@Acme Bot Add support for a reset password flow.',
     });
 
     expect(
@@ -44,6 +46,8 @@ describe('invocation identity formatting', () => {
       displayName: null,
       mentionText: null,
       nativeMention: '<@U123>',
+      guidanceName: 'Slack app',
+      examplePrompt: null,
     });
   });
 
@@ -56,6 +60,7 @@ describe('invocation identity formatting', () => {
     ).toMatchObject({
       displayName: 'Contoso Bot',
       mentionText: '@Contoso Bot',
+      examplePrompt: '@Contoso Bot Add support for a reset password flow.',
       configured: true,
     });
 
@@ -68,6 +73,14 @@ describe('invocation identity formatting', () => {
       displayName: 'Roomote',
       mentionText: '@Roomote',
       configured: false,
+    });
+  });
+
+  it('builds Teams examples from the normalized mention text', () => {
+    expect(buildTeamsInvocationIdentity('@Contoso')).toMatchObject({
+      displayName: '@Contoso',
+      mentionText: '@Contoso',
+      examplePrompt: '@Contoso Add support for a reset password flow.',
     });
   });
 });

--- a/packages/types/src/invocation-identity.ts
+++ b/packages/types/src/invocation-identity.ts
@@ -115,12 +115,10 @@ export function buildSlackInvocationIdentity(input: {
     mentionText,
     nativeMention,
     deepLinkUrl: null,
-    guidanceName: mentionText ?? nativeMention ?? 'Slack app',
+    guidanceName: mentionText ?? 'Slack app',
     examplePrompt: mentionText
       ? `${mentionText} Add support for a reset password flow.`
-      : nativeMention
-        ? `${nativeMention} Add support for a reset password flow.`
-        : null,
+      : null,
   };
 }
 
@@ -140,18 +138,21 @@ export function buildTeamsInvocationIdentity(
       ? input.configured === true
       : Boolean(displayName?.trim());
   const normalizedName = displayName?.trim() || null;
+  const mentionText = normalizedName
+    ? normalizeMentionHandle(normalizedName)
+    : null;
 
   return {
     provider: 'microsoft',
     label: 'Microsoft Teams',
     configured,
     displayName: normalizedName,
-    mentionText: normalizedName ? normalizeMentionHandle(normalizedName) : null,
+    mentionText,
     nativeMention: null,
     deepLinkUrl: null,
     guidanceName: normalizedName ?? 'Teams bot',
-    examplePrompt: normalizedName
-      ? `@${normalizedName} Add support for a reset password flow.`
+    examplePrompt: mentionText
+      ? `${mentionText} Add support for a reset password flow.`
       : null,
   };
 }


### PR DESCRIPTION
## Summary
- avoid showing Slack native `<@U…>` tokens in human-facing guidance when no display name is available
- validate setup-provided Teams bot names against the v1.25 manifest short-name limit
- build Teams examples from normalized mention text so already-prefixed names do not become `@@name`

## Validation
- mise exec -- pnpm --filter @roomote/types exec vitest run src/__tests__/invocation-identity.test.ts
- mise exec -- pnpm --filter @roomote/web exec vitest run src/app/api/setup/teams-app-package/__tests__/route.test.ts
- mise exec -- pnpm --filter @roomote/types check-types
- mise exec -- pnpm --filter @roomote/web check-types
- mise exec -- pnpm lint:fast && mise exec -- pnpm check-types:fast && mise exec -- pnpm knip
