### PR TITLE
Infer Teams setup credentials from Microsoft auth

### DIFF
--- a/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
+++ b/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import Link from 'next/link';
-import type { SetupAuthStatus } from '@roomote/types';
+import {
+  MICROSOFT_SINGLE_APP_TEAMS_BOT_FIELD_SOURCES,
+  type SetupAuthStatus,
+} from '@roomote/types';
 
 import { buildSlackManifestPrefillUrl } from '@/lib/slack-app-manifest';
 import {
@@ -38,14 +41,8 @@ type ProviderFieldStatus = ProviderStatus['fields'][number];
 
 const MASKED_VALUE = '••••••••••••••••••••••••••••';
 
-const MICROSOFT_SINGLE_APP_BOT_FIELD_SOURCES: Record<string, string> = {
-  TEAMS_BOT_APP_ID: 'ROOMOTE_AUTH_MICROSOFT_CLIENT_ID',
-  TEAMS_BOT_APP_PASSWORD: 'ROOMOTE_AUTH_MICROSOFT_CLIENT_SECRET',
-  TEAMS_BOT_TENANT_ID: 'ROOMOTE_AUTH_MICROSOFT_TENANT_ID',
-};
-
 const MICROSOFT_SETUP_HIDDEN_ENV_VAR_NAMES = new Set([
-  ...Object.keys(MICROSOFT_SINGLE_APP_BOT_FIELD_SOURCES),
+  ...Object.keys(MICROSOFT_SINGLE_APP_TEAMS_BOT_FIELD_SOURCES),
   'TEAMS_BOT_TOKEN_ENDPOINT',
   'TEAMS_BOT_OAUTH_SCOPE',
 ]);
@@ -88,7 +85,9 @@ export function getSetupEffectiveFieldValue({
   }
 
   const sourceEnvVarName =
-    MICROSOFT_SINGLE_APP_BOT_FIELD_SOURCES[field.envVarName];
+    MICROSOFT_SINGLE_APP_TEAMS_BOT_FIELD_SOURCES[
+      field.envVarName as keyof typeof MICROSOFT_SINGLE_APP_TEAMS_BOT_FIELD_SOURCES
+    ];
 
   return sourceEnvVarName ? (values[sourceEnvVarName] ?? '') : '';
 }
@@ -124,7 +123,7 @@ export function getSetupSubmitValues({
 
   if (provider.id === 'microsoft') {
     for (const [envVarName, sourceEnvVarName] of Object.entries(
-      MICROSOFT_SINGLE_APP_BOT_FIELD_SOURCES,
+      MICROSOFT_SINGLE_APP_TEAMS_BOT_FIELD_SOURCES,
     )) {
       if (nextValues[envVarName]?.trim()) {
         continue;

--- a/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.client.test.tsx
@@ -324,6 +324,39 @@ function setupMutationMock() {
   return mutateAsync;
 }
 
+function buildRuntimeConfiguredAuthSetup(
+  providerId: Extract<
+    SetupAuthStatus['preselectedProvider'],
+    'slack' | 'microsoft'
+  >,
+): SetupAuthStatus {
+  const authSetup = buildAuthSetup(providerId);
+
+  return {
+    ...authSetup,
+    selectedProvider: providerId,
+    preselectedProvider: providerId,
+    runtimeConfiguredProvider: providerId,
+    runtimeConfiguredProviders: [providerId],
+    lockReason: 'runtime_env',
+    setupSatisfiedByRuntimeEnv: true,
+    providers: authSetup.providers.map((provider) =>
+      provider.id === providerId
+        ? {
+            ...provider,
+            runtimeSatisfied: true,
+            setupSatisfied: true,
+            fields: provider.fields.map((field) => ({
+              ...field,
+              runtimeSatisfied: true,
+              satisfiedByEnvVarName: field.envVarName,
+            })),
+          }
+        : provider,
+    ),
+  };
+}
+
 describe('StepAuthEnvVars', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -765,32 +798,9 @@ describe('StepAuthEnvVars', () => {
     });
   });
 
-  it('starts bootstrap Slack sign-in directly when Slack is runtime configured', async () => {
+  it('shows bootstrap Slack sign-in when Slack is runtime configured', async () => {
     const mutateAsync = setupMutationMock();
-    const authSetup = buildAuthSetup('slack');
-    const runtimeConfiguredAuthSetup: SetupAuthStatus = {
-      ...authSetup,
-      selectedProvider: 'slack',
-      preselectedProvider: 'slack',
-      runtimeConfiguredProvider: 'slack',
-      runtimeConfiguredProviders: ['slack'],
-      lockReason: 'runtime_env',
-      setupSatisfiedByRuntimeEnv: true,
-      providers: authSetup.providers.map((provider) =>
-        provider.id === 'slack'
-          ? {
-              ...provider,
-              runtimeSatisfied: true,
-              setupSatisfied: true,
-              fields: provider.fields.map((field) => ({
-                ...field,
-                runtimeSatisfied: true,
-                satisfiedByEnvVarName: field.envVarName,
-              })),
-            }
-          : provider,
-      ),
-    };
+    const runtimeConfiguredAuthSetup = buildRuntimeConfiguredAuthSetup('slack');
 
     render(
       <StepAuthEnvVars
@@ -808,6 +818,7 @@ describe('StepAuthEnvVars', () => {
       screen.queryByRole('link', { name: /create slack app/i }),
     ).not.toBeInTheDocument();
     expect(screen.getByLabelText('slack')).toBeInTheDocument();
+    expect(signInOauth2Mock).not.toHaveBeenCalled();
 
     fireEvent.click(
       screen.getByRole('button', { name: /sign in with slack/i }),
@@ -823,6 +834,47 @@ describe('StepAuthEnvVars', () => {
     expect(locationAssignMock).toHaveBeenCalledWith('https://slack.test');
     expect(mutateAsync).toHaveBeenCalledWith({
       provider: 'slack',
+      values: {},
+    });
+  });
+
+  it('shows bootstrap Microsoft sign-in when Microsoft is runtime configured', async () => {
+    const mutateAsync = setupMutationMock();
+    const runtimeConfiguredAuthSetup =
+      buildRuntimeConfiguredAuthSetup('microsoft');
+
+    render(
+      <StepAuthEnvVars
+        authSetup={runtimeConfiguredAuthSetup}
+        selectedProviderId="microsoft"
+        onContinue={vi.fn()}
+        bootstrapMode
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        /This deployment is already configured for Microsoft Teams/i,
+      ),
+    ).toBeInTheDocument();
+    expect(signInOauth2Mock).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /sign in with microsoft teams/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(signInOauth2Mock).toHaveBeenCalledWith({
+        providerId: 'microsoft-entra-id',
+        callbackURL: '/setup',
+        disableRedirect: true,
+      });
+    });
+    expect(locationAssignMock).toHaveBeenCalledWith('https://slack.test');
+    expect(mutateAsync).toHaveBeenCalledWith({
+      provider: 'microsoft',
       values: {},
     });
   });

--- a/packages/db/src/lib/teams-runtime-credentials.ts
+++ b/packages/db/src/lib/teams-runtime-credentials.ts
@@ -1,30 +1,11 @@
 import { resolveEffectiveDeploymentEnvVars } from './model-runtime-config';
+import {
+  resolveTeamsBotRuntimeCredentialsFromEnv,
+  TEAMS_BOT_CREDENTIAL_ENV_VAR_NAMES,
+  type TeamsBotRuntimeCredentials,
+} from '@roomote/types';
 
-export type TeamsBotRuntimeCredentials = {
-  botAppId: string | null;
-  botAppPassword: string | null;
-  botTenantId: string | null;
-  botTokenEndpoint: string | null;
-  botOauthScope: string | null;
-  /**
-   * Which app registration the id/password pair came from: dedicated
-   * `TEAMS_BOT_*` values, or the Microsoft sign-in app
-   * (`ROOMOTE_AUTH_MICROSOFT_*`) doubling as the bot app.
-   */
-  source: 'teams_bot' | 'microsoft_auth' | null;
-};
-
-const TEAMS_CREDENTIAL_ENV_VAR_NAMES = [
-  'TEAMS_BOT_APP_ID',
-  'TEAMS_BOT_APP_PASSWORD',
-  'TEAMS_BOT_TENANT_ID',
-  'TEAMS_BOT_NAME',
-  'TEAMS_BOT_TOKEN_ENDPOINT',
-  'TEAMS_BOT_OAUTH_SCOPE',
-  'ROOMOTE_AUTH_MICROSOFT_CLIENT_ID',
-  'ROOMOTE_AUTH_MICROSOFT_CLIENT_SECRET',
-  'ROOMOTE_AUTH_MICROSOFT_TENANT_ID',
-] as const;
+export type { TeamsBotRuntimeCredentials } from '@roomote/types';
 
 const CACHE_TTL_MS = 30_000;
 
@@ -32,58 +13,6 @@ let cachedCredentials: {
   value: TeamsBotRuntimeCredentials;
   expiresAtMs: number;
 } | null = null;
-
-function trimmed(value: string | undefined): string | null {
-  return value?.trim() || null;
-}
-
-function buildCredentials(
-  env: Partial<Record<string, string | undefined>>,
-): TeamsBotRuntimeCredentials {
-  const botTokenEndpoint = trimmed(env.TEAMS_BOT_TOKEN_ENDPOINT);
-  const botOauthScope = trimmed(env.TEAMS_BOT_OAUTH_SCOPE);
-
-  const teamsBotAppId = trimmed(env.TEAMS_BOT_APP_ID);
-  const teamsBotAppPassword = trimmed(env.TEAMS_BOT_APP_PASSWORD);
-
-  // Never mix an id from one app registration with a secret from another:
-  // the id/password pair (and its tenant) always comes from a single source.
-  if (teamsBotAppId && teamsBotAppPassword) {
-    return {
-      botAppId: teamsBotAppId,
-      botAppPassword: teamsBotAppPassword,
-      botTenantId: trimmed(env.TEAMS_BOT_TENANT_ID),
-      botTokenEndpoint,
-      botOauthScope,
-      source: 'teams_bot',
-    };
-  }
-
-  const microsoftClientId = trimmed(env.ROOMOTE_AUTH_MICROSOFT_CLIENT_ID);
-  const microsoftClientSecret = trimmed(
-    env.ROOMOTE_AUTH_MICROSOFT_CLIENT_SECRET,
-  );
-
-  if (microsoftClientId && microsoftClientSecret) {
-    return {
-      botAppId: microsoftClientId,
-      botAppPassword: microsoftClientSecret,
-      botTenantId: trimmed(env.ROOMOTE_AUTH_MICROSOFT_TENANT_ID),
-      botTokenEndpoint,
-      botOauthScope,
-      source: 'microsoft_auth',
-    };
-  }
-
-  return {
-    botAppId: null,
-    botAppPassword: null,
-    botTenantId: null,
-    botTokenEndpoint,
-    botOauthScope,
-    source: null,
-  };
-}
 
 /**
  * Resolve the Teams bot credentials the way operators configure them: real
@@ -95,7 +24,7 @@ function buildCredentials(
  * hit the database on every activity.
  */
 export async function resolveTeamsBotRuntimeCredentials(): Promise<TeamsBotRuntimeCredentials> {
-  const fromEnv = buildCredentials(process.env);
+  const fromEnv = resolveTeamsBotRuntimeCredentialsFromEnv(process.env);
 
   if (fromEnv.source === 'teams_bot') {
     return fromEnv;
@@ -110,11 +39,11 @@ export async function resolveTeamsBotRuntimeCredentials(): Promise<TeamsBotRunti
   const deploymentEnvVars = await resolveEffectiveDeploymentEnvVars();
   const merged: Partial<Record<string, string | undefined>> = {};
 
-  for (const name of TEAMS_CREDENTIAL_ENV_VAR_NAMES) {
+  for (const name of TEAMS_BOT_CREDENTIAL_ENV_VAR_NAMES) {
     merged[name] = process.env[name]?.trim() || deploymentEnvVars[name];
   }
 
-  const value = buildCredentials(merged);
+  const value = resolveTeamsBotRuntimeCredentialsFromEnv(merged);
 
   cachedCredentials = { value, expiresAtMs: nowMs + CACHE_TTL_MS };
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -51,6 +51,7 @@ export * from './setup-source-control-config';
 export * from './source-control';
 export * from './slack';
 export * from './teams';
+export * from './teams-bot-credentials';
 export * from './telegram';
 export * from './task-env-var-requests';
 export * from './task-events';

--- a/packages/types/src/setup-auth-config.test.ts
+++ b/packages/types/src/setup-auth-config.test.ts
@@ -40,12 +40,56 @@ describe('buildSetupAuthStatus', () => {
     });
   });
 
-  it('does not satisfy Teams setup with only Microsoft sign-in values', () => {
+  it('satisfies Teams setup by inferring bot values from Microsoft sign-in values', () => {
     const status = buildSetupAuthStatus({
       persistedEnvVarNames: [
         'ROOMOTE_AUTH_MICROSOFT_CLIENT_ID',
         'ROOMOTE_AUTH_MICROSOFT_CLIENT_SECRET',
         'ROOMOTE_AUTH_MICROSOFT_TENANT_ID',
+      ],
+    });
+
+    expect(status.setupSatisfiedByRuntimeEnv).toBe(false);
+    expect(status.preselectedProvider).toBe('microsoft');
+    expect(status.selectedProvider).toBeNull();
+    expect(status.runtimeConfiguredProvider).toBeNull();
+    expect(status.runtimeConfiguredProviders).toEqual([]);
+    expect(status.lockReason).toBeNull();
+    expect(
+      status.providers.find((provider) => provider.id === 'microsoft'),
+    ).toMatchObject({
+      runtimeSatisfied: false,
+      savedSatisfied: true,
+      setupSatisfied: true,
+    });
+    expect(
+      status.providers.find((provider) => provider.id === 'microsoft')?.fields,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          envVarName: 'TEAMS_BOT_APP_ID',
+          savedSatisfied: true,
+          satisfiedByEnvVarName: 'ROOMOTE_AUTH_MICROSOFT_CLIENT_ID',
+        }),
+        expect.objectContaining({
+          envVarName: 'TEAMS_BOT_APP_PASSWORD',
+          savedSatisfied: true,
+          satisfiedByEnvVarName: 'ROOMOTE_AUTH_MICROSOFT_CLIENT_SECRET',
+        }),
+        expect.objectContaining({
+          envVarName: 'TEAMS_BOT_TENANT_ID',
+          savedSatisfied: true,
+          satisfiedByEnvVarName: 'ROOMOTE_AUTH_MICROSOFT_TENANT_ID',
+        }),
+      ]),
+    );
+  });
+
+  it('does not infer complete Teams setup from incomplete Microsoft sign-in values', () => {
+    const status = buildSetupAuthStatus({
+      persistedEnvVarNames: [
+        'ROOMOTE_AUTH_MICROSOFT_CLIENT_ID',
+        'ROOMOTE_AUTH_MICROSOFT_CLIENT_SECRET',
       ],
     });
 
@@ -82,6 +126,64 @@ describe('buildSetupAuthStatus', () => {
       savedSatisfied: true,
       setupSatisfied: true,
     });
+  });
+
+  it('resolves inferred Teams bot fields from the effective merged credential source', () => {
+    const status = buildSetupAuthStatus({
+      runtimeEnv: {
+        ROOMOTE_AUTH_MICROSOFT_CLIENT_ID: 'microsoft-client-id',
+        ROOMOTE_AUTH_MICROSOFT_CLIENT_SECRET: 'microsoft-client-secret',
+        ROOMOTE_AUTH_MICROSOFT_TENANT_ID: 'microsoft-tenant-id',
+      },
+      persistedEnvVarNames: [
+        'TEAMS_BOT_APP_ID',
+        'TEAMS_BOT_APP_PASSWORD',
+        'TEAMS_BOT_TENANT_ID',
+      ],
+    });
+    const microsoft = status.providers.find(
+      (provider) => provider.id === 'microsoft',
+    );
+
+    expect(status.setupSatisfiedByRuntimeEnv).toBe(false);
+    expect(status.preselectedProvider).toBe('microsoft');
+    expect(status.selectedProvider).toBeNull();
+    expect(status.runtimeConfiguredProvider).toBeNull();
+    expect(status.runtimeConfiguredProviders).toEqual([]);
+    expect(status.lockReason).toBeNull();
+    expect(microsoft).toMatchObject({
+      runtimeSatisfied: false,
+      savedSatisfied: false,
+      setupSatisfied: true,
+    });
+    expect(microsoft?.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          envVarName: 'ROOMOTE_AUTH_MICROSOFT_CLIENT_ID',
+          runtimeSatisfied: true,
+          savedSatisfied: false,
+          satisfiedByEnvVarName: 'ROOMOTE_AUTH_MICROSOFT_CLIENT_ID',
+        }),
+        expect.objectContaining({
+          envVarName: 'TEAMS_BOT_APP_ID',
+          runtimeSatisfied: false,
+          savedSatisfied: true,
+          satisfiedByEnvVarName: 'TEAMS_BOT_APP_ID',
+        }),
+        expect.objectContaining({
+          envVarName: 'TEAMS_BOT_APP_PASSWORD',
+          runtimeSatisfied: false,
+          savedSatisfied: true,
+          satisfiedByEnvVarName: 'TEAMS_BOT_APP_PASSWORD',
+        }),
+        expect.objectContaining({
+          envVarName: 'TEAMS_BOT_TENANT_ID',
+          runtimeSatisfied: false,
+          savedSatisfied: true,
+          satisfiedByEnvVarName: 'TEAMS_BOT_TENANT_ID',
+        }),
+      ]),
+    );
   });
 
   it('honors Slack shared-credential fallback compatibility', () => {
@@ -176,5 +278,22 @@ describe('buildSetupAuthStatus', () => {
     expect(status.runtimeConfiguredProviders).toEqual(['slack', 'microsoft']);
     expect(status.selectedProvider).toBe('slack');
     expect(status.lockReason).toBe('runtime_env');
+  });
+
+  it('runtime-satisfies Teams setup from the Microsoft sign-in app when no dedicated bot pair is configured', () => {
+    const status = buildSetupAuthStatus({
+      runtimeEnv: {
+        ROOMOTE_AUTH_MICROSOFT_CLIENT_ID: 'microsoft-client-id',
+        ROOMOTE_AUTH_MICROSOFT_CLIENT_SECRET: 'microsoft-client-secret',
+        ROOMOTE_AUTH_MICROSOFT_TENANT_ID: 'microsoft-tenant-id',
+      },
+    });
+
+    expect(status.runtimeConfiguredProvider).toBe('microsoft');
+    expect(status.runtimeConfiguredProviders).toEqual(['microsoft']);
+    expect(status.selectedProvider).toBe('microsoft');
+    expect(status.preselectedProvider).toBe('microsoft');
+    expect(status.lockReason).toBe('runtime_env');
+    expect(status.setupSatisfiedByRuntimeEnv).toBe(true);
   });
 });

--- a/packages/types/src/setup-auth-config.ts
+++ b/packages/types/src/setup-auth-config.ts
@@ -1,3 +1,8 @@
+import {
+  resolveTeamsBotCredentialEnvVarNames,
+  type TeamsBotInferredFieldEnvVarName,
+} from './teams-bot-credentials';
+
 export const SETUP_AUTH_PROVIDER_IDS = ['slack', 'microsoft'] as const;
 
 export type SetupAuthProviderId = (typeof SETUP_AUTH_PROVIDER_IDS)[number];
@@ -181,14 +186,35 @@ export function buildSetupAuthStatus(input: {
     Array.from(input.persistedEnvVarNames ?? []).map((name) => name.trim()),
   );
 
+  const effectiveTeamsBotCredentialEnvVarNames =
+    resolveTeamsBotCredentialEnvVarNames({
+      hasConfiguredEnvVar: (name) =>
+        isConfiguredEnvValue(runtimeEnv[name]) ||
+        persistedEnvVarNameSet.has(name),
+    }).fieldSourceEnvVarNames;
+
   const providers = SETUP_AUTH_PROVIDER_CATALOG.map((provider) => {
     const fields = provider.fields.map((field) => {
-      const runtimeMatch = field.acceptedEnvVarNames.find((envVarName) =>
-        isConfiguredEnvValue(runtimeEnv[envVarName]),
-      );
-      const savedMatch = field.acceptedEnvVarNames.find((envVarName) =>
-        persistedEnvVarNameSet.has(envVarName),
-      );
+      const inferredMatch =
+        provider.id === 'microsoft'
+          ? effectiveTeamsBotCredentialEnvVarNames[
+              field.envVarName as TeamsBotInferredFieldEnvVarName
+            ]
+          : undefined;
+      const runtimeMatch =
+        (inferredMatch && isConfiguredEnvValue(runtimeEnv[inferredMatch])
+          ? inferredMatch
+          : undefined) ??
+        field.acceptedEnvVarNames.find((envVarName) =>
+          isConfiguredEnvValue(runtimeEnv[envVarName]),
+        );
+      const savedMatch =
+        (inferredMatch && persistedEnvVarNameSet.has(inferredMatch)
+          ? inferredMatch
+          : undefined) ??
+        field.acceptedEnvVarNames.find((envVarName) =>
+          persistedEnvVarNameSet.has(envVarName),
+        );
 
       return {
         ...field,

--- a/packages/types/src/teams-bot-credentials.ts
+++ b/packages/types/src/teams-bot-credentials.ts
@@ -1,0 +1,137 @@
+export type TeamsBotCredentialSource = 'teams_bot' | 'microsoft_auth' | null;
+
+export type TeamsBotRuntimeCredentials = {
+  botAppId: string | null;
+  botAppPassword: string | null;
+  botTenantId: string | null;
+  botTokenEndpoint: string | null;
+  botOauthScope: string | null;
+  source: TeamsBotCredentialSource;
+};
+
+export const TEAMS_BOT_CREDENTIAL_ENV_VAR_NAMES = [
+  'TEAMS_BOT_APP_ID',
+  'TEAMS_BOT_APP_PASSWORD',
+  'TEAMS_BOT_TENANT_ID',
+  'TEAMS_BOT_NAME',
+  'TEAMS_BOT_TOKEN_ENDPOINT',
+  'TEAMS_BOT_OAUTH_SCOPE',
+  'ROOMOTE_AUTH_MICROSOFT_CLIENT_ID',
+  'ROOMOTE_AUTH_MICROSOFT_CLIENT_SECRET',
+  'ROOMOTE_AUTH_MICROSOFT_TENANT_ID',
+] as const;
+
+export const MICROSOFT_SINGLE_APP_TEAMS_BOT_FIELD_SOURCES = {
+  TEAMS_BOT_APP_ID: 'ROOMOTE_AUTH_MICROSOFT_CLIENT_ID',
+  TEAMS_BOT_APP_PASSWORD: 'ROOMOTE_AUTH_MICROSOFT_CLIENT_SECRET',
+  TEAMS_BOT_TENANT_ID: 'ROOMOTE_AUTH_MICROSOFT_TENANT_ID',
+} as const;
+
+export type TeamsBotInferredFieldEnvVarName =
+  keyof typeof MICROSOFT_SINGLE_APP_TEAMS_BOT_FIELD_SOURCES;
+
+export type TeamsBotCredentialEnvVarResolution = {
+  source: TeamsBotCredentialSource;
+  fieldSourceEnvVarNames: Partial<
+    Record<TeamsBotInferredFieldEnvVarName, string>
+  >;
+};
+
+function trimmed(value: string | undefined): string | null {
+  return value?.trim() || null;
+}
+
+function hasConfiguredValue(
+  env: Partial<Record<string, string | undefined>>,
+  name: string,
+): boolean {
+  return trimmed(env[name]) !== null;
+}
+
+export function resolveTeamsBotCredentialEnvVarNames(input: {
+  hasConfiguredEnvVar: (name: string) => boolean;
+}): TeamsBotCredentialEnvVarResolution {
+  const hasTeamsBotAppId = input.hasConfiguredEnvVar('TEAMS_BOT_APP_ID');
+  const hasTeamsBotAppPassword = input.hasConfiguredEnvVar(
+    'TEAMS_BOT_APP_PASSWORD',
+  );
+
+  if (hasTeamsBotAppId && hasTeamsBotAppPassword) {
+    return {
+      source: 'teams_bot',
+      fieldSourceEnvVarNames: {
+        TEAMS_BOT_APP_ID: 'TEAMS_BOT_APP_ID',
+        TEAMS_BOT_APP_PASSWORD: 'TEAMS_BOT_APP_PASSWORD',
+        ...(input.hasConfiguredEnvVar('TEAMS_BOT_TENANT_ID')
+          ? { TEAMS_BOT_TENANT_ID: 'TEAMS_BOT_TENANT_ID' }
+          : {}),
+      },
+    };
+  }
+
+  const hasMicrosoftClientId = input.hasConfiguredEnvVar(
+    'ROOMOTE_AUTH_MICROSOFT_CLIENT_ID',
+  );
+  const hasMicrosoftClientSecret = input.hasConfiguredEnvVar(
+    'ROOMOTE_AUTH_MICROSOFT_CLIENT_SECRET',
+  );
+
+  if (hasMicrosoftClientId && hasMicrosoftClientSecret) {
+    return {
+      source: 'microsoft_auth',
+      fieldSourceEnvVarNames: {
+        TEAMS_BOT_APP_ID: 'ROOMOTE_AUTH_MICROSOFT_CLIENT_ID',
+        TEAMS_BOT_APP_PASSWORD: 'ROOMOTE_AUTH_MICROSOFT_CLIENT_SECRET',
+        ...(input.hasConfiguredEnvVar('ROOMOTE_AUTH_MICROSOFT_TENANT_ID')
+          ? { TEAMS_BOT_TENANT_ID: 'ROOMOTE_AUTH_MICROSOFT_TENANT_ID' }
+          : {}),
+      },
+    };
+  }
+
+  return {
+    source: null,
+    fieldSourceEnvVarNames: {},
+  };
+}
+
+export function resolveTeamsBotRuntimeCredentialsFromEnv(
+  env: Partial<Record<string, string | undefined>>,
+): TeamsBotRuntimeCredentials {
+  const botTokenEndpoint = trimmed(env.TEAMS_BOT_TOKEN_ENDPOINT);
+  const botOauthScope = trimmed(env.TEAMS_BOT_OAUTH_SCOPE);
+  const resolution = resolveTeamsBotCredentialEnvVarNames({
+    hasConfiguredEnvVar: (name) => hasConfiguredValue(env, name),
+  });
+
+  if (resolution.source === 'teams_bot') {
+    return {
+      botAppId: trimmed(env.TEAMS_BOT_APP_ID),
+      botAppPassword: trimmed(env.TEAMS_BOT_APP_PASSWORD),
+      botTenantId: trimmed(env.TEAMS_BOT_TENANT_ID),
+      botTokenEndpoint,
+      botOauthScope,
+      source: 'teams_bot',
+    };
+  }
+
+  if (resolution.source === 'microsoft_auth') {
+    return {
+      botAppId: trimmed(env.ROOMOTE_AUTH_MICROSOFT_CLIENT_ID),
+      botAppPassword: trimmed(env.ROOMOTE_AUTH_MICROSOFT_CLIENT_SECRET),
+      botTenantId: trimmed(env.ROOMOTE_AUTH_MICROSOFT_TENANT_ID),
+      botTokenEndpoint,
+      botOauthScope,
+      source: 'microsoft_auth',
+    };
+  }
+
+  return {
+    botAppId: null,
+    botAppPassword: null,
+    botTenantId: null,
+    botTokenEndpoint,
+    botOauthScope,
+    source: null,
+  };
+}


### PR DESCRIPTION
## Summary
- share Teams bot credential source inference between setup status and runtime credentials
- treat the Microsoft auth app as the Teams bot app when no dedicated TEAMS_BOT_* pair is configured
- keep the runtime-configured /setup sign-in step user-driven instead of auto-starting OAuth

## Validation
- mise exec -- pnpm --filter @roomote/types exec vitest run src/setup-auth-config.test.ts
- mise exec -- pnpm --filter @roomote/db exec vitest run src/lib/__tests__/teams-runtime-credentials.test.ts
- mise exec -- pnpm --filter @roomote/web exec vitest run 'src/app/(onboarding)/setup/StepAuthEnvVars.client.test.tsx' 'src/app/(onboarding)/setup/bootstrapFlow.client.test.ts'
- mise exec -- pnpm --filter @roomote/web exec vitest run src/trpc/commands/setup-new/index.test.ts
- mise exec -- pnpm --filter @roomote/types check-types
- mise exec -- pnpm --filter @roomote/db check-types
- mise exec -- pnpm --filter @roomote/web check-types
- targeted ESLint for touched files
- pre-push: pnpm lint:fast && pnpm check-types:fast && pnpm knip