### PR TITLE
[Fix] Modal snapshot resume auth and MCP job-token principal checks

### DIFF
--- a/apps/api/src/handlers/artifacts/auth.ts
+++ b/apps/api/src/handlers/artifacts/auth.ts
@@ -13,11 +13,11 @@ import type { Variables } from '../../types';
 
 type ArtifactRouteAuthContext = {
   /**
-   * Null for deployment-principal job tokens. Authorization stays scoped to
-   * the cloud job itself: `findCloudJobByJobTokenClaims` matches by
-   * `cloudJobId` and only requires `userId` to agree when the job has an
-   * owner, so an ownerless job's deployment token is authorized exactly like
-   * the job's own user would have been.
+   * Null for deployment-principal job tokens. Authorization is scoped to the
+   * cloud job itself: `findCloudJobByJobTokenClaims` resolves by `cloudJobId`
+   * only. The token's userId is mint-time attribution and is never compared
+   * against the mutable `task_runs.actingUserId`, which web steer and
+   * follow-up delivery legitimately switch mid-run.
    */
   userId: string | null;
   cloudJobId: number;

--- a/apps/api/src/handlers/mcp/__tests__/asana-auth.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/asana-auth.test.ts
@@ -177,7 +177,10 @@ describe('asana MCP auth and tool handling', () => {
     });
   });
 
-  it('rejects tokens whose principal does not match the cloud job user', async () => {
+  it('accepts a token minted for user A after the acting user switched to user B', async () => {
+    // Web steer / follow-up delivery mutate task_runs.actingUserId mid-run;
+    // the run-scoped token stays authorized (the token's userId is mint-time
+    // attribution and is never compared against the mutable acting user).
     mockFindCloudJob.mockResolvedValue({
       id: 42,
       actingUserId: 'user-2',
@@ -187,12 +190,25 @@ describe('asana MCP auth and tool handling', () => {
       createApp(createJobToken()),
       createInitializeRequest(1),
     );
-    const body = (await response.json()) as JsonRpcErrorBody;
 
-    expect(response.status).toBe(403);
-    expect(body.error.message).toContain(
-      'MCP token principal does not match cloud job',
+    expect(response.status).toBe(200);
+  });
+
+  it('accepts a deployment-principal token after a human became the acting user', async () => {
+    // A human replying in the thread of an automation run switches the acting
+    // user from null to that human; the run-scoped null-principal token must
+    // keep working.
+    mockFindCloudJob.mockResolvedValue({
+      id: 42,
+      actingUserId: 'user-2',
+    });
+
+    const response = await postMcp(
+      createApp(createJobToken({ userId: null, principal: 'deployment' })),
+      createInitializeRequest(1),
     );
+
+    expect(response.status).toBe(200);
   });
 
   it('allows deployment-principal tokens for deployment-principal cloud jobs', async () => {

--- a/apps/api/src/handlers/mcp/__tests__/grafana-auth.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/grafana-auth.test.ts
@@ -163,7 +163,10 @@ describe('grafana MCP auth and tool handling', () => {
     });
   });
 
-  it('rejects tokens whose principal does not match the cloud job user', async () => {
+  it('accepts a token minted for user A after the acting user switched to user B', async () => {
+    // Web steer / follow-up delivery mutate task_runs.actingUserId mid-run;
+    // the run-scoped token stays authorized (the token's userId is mint-time
+    // attribution and is never compared against the mutable acting user).
     mockFindCloudJob.mockResolvedValue({
       id: 42,
       actingUserId: 'user-2',
@@ -173,12 +176,25 @@ describe('grafana MCP auth and tool handling', () => {
       createApp(createJobToken()),
       createInitializeRequest(1),
     );
-    const body = (await response.json()) as JsonRpcErrorBody;
 
-    expect(response.status).toBe(403);
-    expect(body.error.message).toContain(
-      'MCP token principal does not match cloud job',
+    expect(response.status).toBe(200);
+  });
+
+  it('accepts a deployment-principal token after a human became the acting user', async () => {
+    // A human replying in the thread of an automation run switches the acting
+    // user from null to that human; the run-scoped null-principal token must
+    // keep working.
+    mockFindCloudJob.mockResolvedValue({
+      id: 42,
+      actingUserId: 'user-2',
+    });
+
+    const response = await postMcp(
+      createApp(createJobToken({ userId: null, principal: 'deployment' })),
+      createInitializeRequest(1),
     );
+
+    expect(response.status).toBe(200);
   });
 
   it('allows deployment-principal tokens for deployment-principal cloud jobs', async () => {

--- a/apps/api/src/handlers/mcp/__tests__/slack-channel-post.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/slack-channel-post.test.ts
@@ -248,6 +248,57 @@ describe('slack channel post MCP endpoint', () => {
     });
   });
 
+  it('posts with a token minted for user A after the acting user switched to user B', async () => {
+    // Web steer / follow-up delivery mutate task_runs.actingUserId mid-run;
+    // the run-scoped token stays authorized (the token's userId is mint-time
+    // attribution and is never compared against the mutable acting user).
+    vi.mocked(db.query.taskRuns.findFirst).mockResolvedValue(
+      mockCloudJob({ actingUserId: 'user-2' }) as never,
+    );
+    vi.mocked(db.query.slackInstallations.findFirst).mockResolvedValue({
+      botAccessToken: 'xoxb-test',
+    } as never);
+    resolveChannelIdMock.mockResolvedValueOnce('C123ABC456');
+
+    const response = await postChannelMessage(jobToken, {
+      channel: 'C123ABC456',
+      text: 'closeout message',
+    });
+
+    expect(response.status).toBe(200);
+    expect(postMessageMock).toHaveBeenCalled();
+  });
+
+  it('posts with a deployment-principal token after a human became the acting user', async () => {
+    // A human replying in the thread of an automation run switches the acting
+    // user from null to that human; the run-scoped null-principal token must
+    // keep working so the automation can still post its Slack closeout.
+    vi.mocked(db.query.taskRuns.findFirst).mockResolvedValue(
+      mockCloudJob({ actingUserId: 'user-2' }) as never,
+    );
+    vi.mocked(db.query.slackInstallations.findFirst).mockResolvedValue({
+      botAccessToken: 'xoxb-test',
+    } as never);
+    resolveChannelIdMock.mockResolvedValueOnce('C123ABC456');
+
+    const response = await postChannelMessage(
+      {
+        cloudJobId: 42,
+        userId: null,
+        principal: 'deployment',
+        tokenType: 'cj',
+        version: 1,
+      },
+      {
+        channel: 'C123ABC456',
+        text: 'automation closeout',
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(postMessageMock).toHaveBeenCalled();
+  });
+
   it('passes markdown tables through channel posts unchanged', async () => {
     vi.mocked(db.query.taskRuns.findFirst).mockResolvedValue(
       mockCloudJob() as never,

--- a/apps/api/src/handlers/mcp/__tests__/snowflake-auth.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/snowflake-auth.test.ts
@@ -492,7 +492,10 @@ describe('snowflake MCP auth and tool handling', () => {
     expect(mockFindCloudJob).toHaveBeenCalled();
   });
 
-  it('rejects tokens whose principal does not match the cloud job user', async () => {
+  it('accepts a token minted for user A after the acting user switched to user B', async () => {
+    // Web steer / follow-up delivery mutate task_runs.actingUserId mid-run;
+    // the run-scoped token stays authorized (the token's userId is mint-time
+    // attribution and is never compared against the mutable acting user).
     mockFindCloudJob.mockResolvedValue({
       id: 42,
       actingUserId: 'user-2',
@@ -502,30 +505,25 @@ describe('snowflake MCP auth and tool handling', () => {
       createApp(createJobToken()),
       createInitializeRequest(4),
     );
-    const body = (await response.json()) as JsonRpcErrorBody;
 
-    expect(response.status).toBe(403);
-    expect(body.error.message).toContain(
-      'MCP token principal does not match cloud job',
-    );
+    expect(response.status).toBe(200);
   });
 
-  it('rejects user tokens for deployment-principal cloud jobs', async () => {
+  it('accepts a deployment-principal token after a human became the acting user', async () => {
+    // A human replying in the thread of an automation run switches the acting
+    // user from null to that human; the run-scoped null-principal token must
+    // keep working.
     mockFindCloudJob.mockResolvedValue({
       id: 42,
-      actingUserId: null,
+      actingUserId: 'user-2',
     });
 
     const response = await postMcp(
-      createApp(createJobToken()),
+      createApp(createJobToken({ userId: null, principal: 'deployment' })),
       createInitializeRequest(4),
     );
-    const body = (await response.json()) as JsonRpcErrorBody;
 
-    expect(response.status).toBe(403);
-    expect(body.error.message).toContain(
-      'MCP token principal does not match cloud job',
-    );
+    expect(response.status).toBe(200);
   });
 
   it('allows deployment-principal tokens for deployment-principal cloud jobs backed by a deployment-scoped connection', async () => {

--- a/apps/api/src/handlers/mcp/__tests__/vercel-auth.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/vercel-auth.test.ts
@@ -163,7 +163,10 @@ describe('vercel MCP auth and tool handling', () => {
     });
   });
 
-  it('rejects tokens whose principal does not match the cloud job user', async () => {
+  it('accepts a token minted for user A after the acting user switched to user B', async () => {
+    // Web steer / follow-up delivery mutate task_runs.actingUserId mid-run;
+    // the run-scoped token stays authorized (the token's userId is mint-time
+    // attribution and is never compared against the mutable acting user).
     mockFindCloudJob.mockResolvedValue({
       id: 42,
       actingUserId: 'user-2',
@@ -173,25 +176,20 @@ describe('vercel MCP auth and tool handling', () => {
       createApp(createJobToken()),
       createInitializeRequest(1),
     );
-    const body = (await response.json()) as JsonRpcErrorBody;
 
-    expect(response.status).toBe(403);
-    expect(body.error.message).toContain(
-      'MCP token principal does not match cloud job',
-    );
+    expect(response.status).toBe(200);
   });
 
-  it('rejects deployment-principal tokens for user-owned cloud jobs', async () => {
+  it('accepts a deployment-principal token after a human became the acting user', async () => {
+    // A human replying in the thread of an automation run switches the acting
+    // user from null to that human; the run-scoped null-principal token must
+    // keep working (default mock: actingUserId 'user-1').
     const response = await postMcp(
       createApp(createJobToken({ userId: null, principal: 'deployment' })),
       createInitializeRequest(1),
     );
-    const body = (await response.json()) as JsonRpcErrorBody;
 
-    expect(response.status).toBe(403);
-    expect(body.error.message).toContain(
-      'MCP token principal does not match cloud job',
-    );
+    expect(response.status).toBe(200);
   });
 
   it('allows deployment-principal tokens for deployment-principal cloud jobs', async () => {

--- a/apps/api/src/handlers/mcp/asana/index.ts
+++ b/apps/api/src/handlers/mcp/asana/index.ts
@@ -43,7 +43,7 @@ async function resolveAsanaMcpAuth(
 
   if (isJobTokenContext(authContext)) {
     const cloudJob = await db.query.taskRuns.findFirst({
-      columns: { id: true, actingUserId: true },
+      columns: { id: true },
       where: eq(taskRuns.id, authContext.cloudJobId),
     });
 
@@ -51,17 +51,13 @@ async function resolveAsanaMcpAuth(
       throw new McpProxyError(404, 'Cloud job not found for this MCP token');
     }
 
-    // The token principal must match the run's acting user: a user token must
-    // carry the run's acting user, and a deployment-service-principal token is
-    // only valid for a run with no acting user (null === null). Asana
-    // credentials come from a deployment-scoped connection, so
-    // deployment-principal jobs are fully supported.
-    if ((cloudJob.actingUserId ?? null) !== authContext.userId) {
-      throw new McpProxyError(
-        403,
-        'MCP token principal does not match cloud job',
-      );
-    }
+    // No principal equality check: the run-scoped token IS the authorization
+    // (only this run's sandbox holds it), and Asana credentials come from a
+    // deployment-scoped connection, so the token's userId plays no role in
+    // credential selection. The token's userId is mint-time attribution while
+    // task_runs.actingUserId is current-steering attribution — they
+    // legitimately diverge once a web steer or follow-up switches the acting
+    // user mid-run.
 
     return {
       userId: authContext.userId,

--- a/apps/api/src/handlers/mcp/grafana/index.ts
+++ b/apps/api/src/handlers/mcp/grafana/index.ts
@@ -43,7 +43,7 @@ async function resolveGrafanaMcpAuth(
 
   if (isJobTokenContext(authContext)) {
     const cloudJob = await db.query.taskRuns.findFirst({
-      columns: { id: true, actingUserId: true },
+      columns: { id: true },
       where: eq(taskRuns.id, authContext.cloudJobId),
     });
 
@@ -51,17 +51,13 @@ async function resolveGrafanaMcpAuth(
       throw new McpProxyError(404, 'Cloud job not found for this MCP token');
     }
 
-    // The token principal must match the run's acting user: a user token must
-    // carry the run's acting user, and a deployment-service-principal token is
-    // only valid for a run with no acting user (null === null). Grafana
-    // credentials come from a deployment-scoped connection, so
-    // deployment-principal jobs are fully supported.
-    if ((cloudJob.actingUserId ?? null) !== authContext.userId) {
-      throw new McpProxyError(
-        403,
-        'MCP token principal does not match cloud job',
-      );
-    }
+    // No principal equality check: the run-scoped token IS the authorization
+    // (only this run's sandbox holds it), and Grafana credentials come from a
+    // deployment-scoped connection, so the token's userId plays no role in
+    // credential selection. The token's userId is mint-time attribution while
+    // task_runs.actingUserId is current-steering attribution — they
+    // legitimately diverge once a web steer or follow-up switches the acting
+    // user mid-run.
 
     return {
       userId: authContext.userId,

--- a/apps/api/src/handlers/mcp/proxy-utils.ts
+++ b/apps/api/src/handlers/mcp/proxy-utils.ts
@@ -72,11 +72,12 @@ export function toMcpToolResult<T extends Record<string, unknown>>(payload: T) {
 /**
  * Resolve the effective user for downstream MCP credential lookup.
  *
- * Job tokens remain tied to the run's acting user for authorization checks;
- * integration MCPs execute as the most recent human who launched or replied
- * to the task. That live actor is stored on `task_runs.actingUserId` rather
- * than inferred from `task_messages`, because transcript persistence is async
- * and may lag behind the turn that is about to make MCP calls.
+ * Job tokens are authorized by their run binding (cloudJobId); integration
+ * MCPs execute as the most recent human who launched or replied to the task.
+ * That live actor is stored on `task_runs.actingUserId` rather than inferred
+ * from `task_messages`, because transcript persistence is async and may lag
+ * behind the turn that is about to make MCP calls. The token's own userId is
+ * mint-time attribution and deliberately plays no role here.
  */
 export async function resolveActingUserId(
   auth: McpAuthContext,
@@ -153,11 +154,19 @@ export async function resolveActingUserIdOrNull(
   return cloudJob.actingUserId ?? null;
 }
 
-async function verifyCloudJobTokenMatchesJob(
+/**
+ * Validates that the job token's run still exists. No principal equality
+ * check: the run-scoped token IS the authorization (only that run's sandbox
+ * holds it). The token's userId is mint-time attribution while
+ * `task_runs.actingUserId` is current-steering attribution — web steer and
+ * follow-up delivery mutate the acting user mid-run, so the two legitimately
+ * diverge and must not be compared for authorization.
+ */
+async function verifyCloudJobTokenJobExists(
   auth: JobTokenContext,
 ): Promise<Response | null> {
   const cloudJob = await db.query.taskRuns.findFirst({
-    columns: { id: true, actingUserId: true },
+    columns: { id: true },
     where: eq(taskRuns.id, auth.cloudJobId),
   });
 
@@ -169,25 +178,13 @@ async function verifyCloudJobTokenMatchesJob(
     );
   }
 
-  // The token principal must match the run's acting user: a user token must
-  // carry the run's acting user, and a deployment-service-principal token is
-  // only valid for a run with no acting user. Both being null is the
-  // automation case and is valid.
-  if ((cloudJob.actingUserId ?? null) !== auth.userId) {
-    return jsonRpcErrorResponse(
-      403,
-      -32000,
-      'MCP token principal does not match cloud job',
-    );
-  }
-
   return null;
 }
 
-export async function assertCloudJobTokenMatchesCloudJobUser(
+export async function assertCloudJobTokenJobExists(
   auth: JobTokenContext,
 ): Promise<void> {
-  const validationError = await verifyCloudJobTokenMatchesJob(auth);
+  const validationError = await verifyCloudJobTokenJobExists(auth);
 
   if (!validationError) {
     return;
@@ -406,7 +403,7 @@ export function createMcpProxy(config: McpProxyConfig) {
     resolveCredentials,
     timeoutMs = 30_000,
     allowAuthTokens = false,
-    validateCloudJobToken = verifyCloudJobTokenMatchesJob,
+    validateCloudJobToken = verifyCloudJobTokenJobExists,
     allowedToolNames,
   } = config;
 

--- a/apps/api/src/handlers/mcp/roomote.ts
+++ b/apps/api/src/handlers/mcp/roomote.ts
@@ -28,7 +28,7 @@ import { z } from 'zod';
 import type { Variables } from '../../types';
 
 import {
-  assertCloudJobTokenMatchesCloudJobUser,
+  assertCloudJobTokenJobExists,
   McpProxyError,
   resolveActingUserIdOrNull,
   type McpAuthContext,
@@ -91,7 +91,7 @@ async function resolveRoomoteMcpAuth(
   }
 
   if (isJobTokenContext(authContext)) {
-    await assertCloudJobTokenMatchesCloudJobUser(authContext);
+    await assertCloudJobTokenJobExists(authContext);
 
     return {
       userId: authContext.userId,

--- a/apps/api/src/handlers/mcp/slack.ts
+++ b/apps/api/src/handlers/mcp/slack.ts
@@ -871,17 +871,12 @@ slackMcp.post('/thread_reply', async (c) => {
     return c.json({ error: 'Cloud job not found for this MCP token' }, 404);
   }
 
-  // The token principal must match the run's acting user: a user token must
-  // carry the run's acting user, and a deployment-service-principal token is
-  // only valid for a run with no acting user (null === null). Replies are
-  // posted with the deployment Slack bot token, so no human actor is
-  // required here.
-  if ((cloudJob.actingUserId ?? null) !== authContext.userId) {
-    return c.json(
-      { error: 'MCP token principal does not match cloud job' },
-      403,
-    );
-  }
+  // No principal equality check: the run-scoped token IS the authorization
+  // (only this run's sandbox holds it), and replies go out via the deployment
+  // Slack bot token, so there is no impersonation vector. The token's userId
+  // is mint-time attribution while task_runs.actingUserId is current-steering
+  // attribution — they legitimately diverge once a web steer or follow-up
+  // switches the acting user mid-run.
 
   let parsedBody: {
     text?: string;
@@ -1489,16 +1484,12 @@ slackMcp.post('/thread_lookup', async (c) => {
     return c.json({ error: 'Cloud job not found for this MCP token' }, 404);
   }
 
-  // The token principal must match the run's acting user; a
-  // deployment-service-principal token is valid for a run with no acting
-  // user (null === null). This endpoint operates via the deployment Slack
-  // bot token, so no human actor is required.
-  if ((run.actingUserId ?? null) !== authContext.userId) {
-    return c.json(
-      { error: 'MCP token principal does not match cloud job' },
-      403,
-    );
-  }
+  // No principal equality check: the run-scoped token IS the authorization
+  // (only this run's sandbox holds it), and this endpoint operates via the
+  // deployment Slack bot token, so there is no impersonation vector. The
+  // token's userId is mint-time attribution while task_runs.actingUserId is
+  // current-steering attribution — they legitimately diverge once a web steer
+  // or follow-up switches the acting user mid-run.
 
   const bindings = await getTaskChannelBindings(run.taskId);
   const cloudJob = {
@@ -1565,16 +1556,12 @@ slackMcp.post('/reaction_add', async (c) => {
     return c.json({ error: 'Cloud job not found for this MCP token' }, 404);
   }
 
-  // The token principal must match the run's acting user; a
-  // deployment-service-principal token is valid for a run with no acting
-  // user (null === null). This endpoint operates via the deployment Slack
-  // bot token, so no human actor is required.
-  if ((cloudJob.actingUserId ?? null) !== authContext.userId) {
-    return c.json(
-      { error: 'MCP token principal does not match cloud job' },
-      403,
-    );
-  }
+  // No principal equality check: the run-scoped token IS the authorization
+  // (only this run's sandbox holds it), and this endpoint operates via the
+  // deployment Slack bot token, so there is no impersonation vector. The
+  // token's userId is mint-time attribution while task_runs.actingUserId is
+  // current-steering attribution — they legitimately diverge once a web steer
+  // or follow-up switches the acting user mid-run.
 
   let parsedBody: {
     channel: string;
@@ -1680,16 +1667,12 @@ slackMcp.post('/channel_messages', async (c) => {
     return c.json({ error: 'Cloud job not found for this MCP token' }, 404);
   }
 
-  // The token principal must match the run's acting user; a
-  // deployment-service-principal token is valid for a run with no acting
-  // user (null === null). This endpoint operates via the deployment Slack
-  // bot token, so no human actor is required.
-  if ((run.actingUserId ?? null) !== authContext.userId) {
-    return c.json(
-      { error: 'MCP token principal does not match cloud job' },
-      403,
-    );
-  }
+  // No principal equality check: the run-scoped token IS the authorization
+  // (only this run's sandbox holds it), and this endpoint operates via the
+  // deployment Slack bot token, so there is no impersonation vector. The
+  // token's userId is mint-time attribution while task_runs.actingUserId is
+  // current-steering attribution — they legitimately diverge once a web steer
+  // or follow-up switches the acting user mid-run.
 
   const bindings = await getTaskChannelBindings(run.taskId);
   const cloudJob = {
@@ -1765,16 +1748,12 @@ slackMcp.post('/channel_post', async (c) => {
     return c.json({ error: 'Cloud job not found for this MCP token' }, 404);
   }
 
-  // The token principal must match the run's acting user; a
-  // deployment-service-principal token is valid for a run with no acting
-  // user (null === null). This endpoint operates via the deployment Slack
-  // bot token, so no human actor is required.
-  if ((cloudJob.actingUserId ?? null) !== authContext.userId) {
-    return c.json(
-      { error: 'MCP token principal does not match cloud job' },
-      403,
-    );
-  }
+  // No principal equality check: the run-scoped token IS the authorization
+  // (only this run's sandbox holds it), and this endpoint operates via the
+  // deployment Slack bot token, so there is no impersonation vector. The
+  // token's userId is mint-time attribution while task_runs.actingUserId is
+  // current-steering attribution — they legitimately diverge once a web steer
+  // or follow-up switches the acting user mid-run.
 
   let parsedBody: {
     channel: string;

--- a/apps/api/src/handlers/mcp/slack.ts
+++ b/apps/api/src/handlers/mcp/slack.ts
@@ -1738,7 +1738,6 @@ slackMcp.post('/channel_post', async (c) => {
   const cloudJob = await db.query.taskRuns.findFirst({
     columns: {
       id: true,
-      actingUserId: true,
       taskId: true,
     },
     where: eq(taskRuns.id, authContext.cloudJobId),

--- a/apps/api/src/handlers/mcp/snowflake/index.ts
+++ b/apps/api/src/handlers/mcp/snowflake/index.ts
@@ -43,7 +43,7 @@ async function resolveSnowflakeMcpAuth(
 
   if (isJobTokenContext(authContext)) {
     const cloudJob = await db.query.taskRuns.findFirst({
-      columns: { id: true, actingUserId: true },
+      columns: { id: true },
       where: eq(taskRuns.id, authContext.cloudJobId),
     });
 
@@ -51,17 +51,13 @@ async function resolveSnowflakeMcpAuth(
       throw new McpProxyError(404, 'Cloud job not found for this MCP token');
     }
 
-    // The token principal must match the run's acting user: a user token must
-    // carry the run's acting user, and a deployment-service-principal token is
-    // only valid for a run with no acting user (null === null). Snowflake
-    // credentials come from a deployment-scoped connection, so
-    // deployment-principal jobs are fully supported.
-    if ((cloudJob.actingUserId ?? null) !== authContext.userId) {
-      throw new McpProxyError(
-        403,
-        'MCP token principal does not match cloud job',
-      );
-    }
+    // No principal equality check: the run-scoped token IS the authorization
+    // (only this run's sandbox holds it), and Snowflake credentials come from a
+    // deployment-scoped connection, so the token's userId plays no role in
+    // credential selection. The token's userId is mint-time attribution while
+    // task_runs.actingUserId is current-steering attribution — they
+    // legitimately diverge once a web steer or follow-up switches the acting
+    // user mid-run.
 
     return {
       userId: authContext.userId,

--- a/apps/api/src/handlers/mcp/vercel/index.ts
+++ b/apps/api/src/handlers/mcp/vercel/index.ts
@@ -43,7 +43,7 @@ async function resolveVercelMcpAuth(
 
   if (isJobTokenContext(authContext)) {
     const cloudJob = await db.query.taskRuns.findFirst({
-      columns: { id: true, actingUserId: true },
+      columns: { id: true },
       where: eq(taskRuns.id, authContext.cloudJobId),
     });
 
@@ -51,17 +51,13 @@ async function resolveVercelMcpAuth(
       throw new McpProxyError(404, 'Cloud job not found for this MCP token');
     }
 
-    // The token principal must match the run's acting user: a user token must
-    // carry the run's acting user, and a deployment-service-principal token is
-    // only valid for a run with no acting user (null === null). Vercel
-    // credentials come from a deployment-scoped connection, so
-    // deployment-principal jobs are fully supported.
-    if ((cloudJob.actingUserId ?? null) !== authContext.userId) {
-      throw new McpProxyError(
-        403,
-        'MCP token principal does not match cloud job',
-      );
-    }
+    // No principal equality check: the run-scoped token IS the authorization
+    // (only this run's sandbox holds it), and Vercel credentials come from a
+    // deployment-scoped connection, so the token's userId plays no role in
+    // credential selection. The token's userId is mint-time attribution while
+    // task_runs.actingUserId is current-steering attribution — they
+    // legitimately diverge once a web steer or follow-up switches the acting
+    // user mid-run.
 
     return {
       userId: authContext.userId,

--- a/apps/api/src/handlers/tasks/manageSourceControl.ts
+++ b/apps/api/src/handlers/tasks/manageSourceControl.ts
@@ -18,7 +18,7 @@ import {
 import type { Variables } from '../../types';
 import type { McpAuth } from '../mcp/middleware';
 import {
-  assertCloudJobTokenMatchesCloudJobUser,
+  assertCloudJobTokenJobExists,
   isJobTokenContext,
   McpProxyError,
 } from '../mcp/proxy-utils';
@@ -49,7 +49,7 @@ export async function manageSourceControl(
   }
 
   try {
-    await assertCloudJobTokenMatchesCloudJobUser(auth.authContext);
+    await assertCloudJobTokenJobExists(auth.authContext);
 
     const input = z
       .union([

--- a/packages/compute-providers/src/adapters/modal.test.ts
+++ b/packages/compute-providers/src/adapters/modal.test.ts
@@ -44,6 +44,9 @@ vi.mock('modal', () => {
     public readonly images = {
       fromRegistry: imageFromRegistryMock,
       fromAwsEcr: imageFromAwsEcrMock,
+      // Snapshot resume loads images through the constructed client (auth
+      // travels with it), not the static Image.fromId.
+      fromId: imageFromIdMock,
     };
 
     public constructor(_config: unknown) {}
@@ -51,9 +54,6 @@ vi.mock('modal', () => {
 
   return {
     ModalClient: MockSdkModalClient,
-    Image: {
-      fromId: imageFromIdMock,
-    },
   };
 });
 

--- a/packages/compute-providers/src/adapters/modal.ts
+++ b/packages/compute-providers/src/adapters/modal.ts
@@ -2,7 +2,7 @@ import { MODAL_CAPABILITIES as MODAL_CAPABILITIES_VALUE } from '@roomote/types';
 import { LRUCache } from 'lru-cache';
 import {
   ModalClient as SdkModalClient,
-  Image,
+  type Image,
   type Sandbox,
   type App,
   type Secret as ModalSecret,
@@ -864,7 +864,12 @@ export class ModalClient implements ComputeProviderClient {
       );
 
       image = await raceWithAbort({
-        promise: Image.fromId(input.sourceSnapshotId),
+        // Must go through the constructed client: the static Image.fromId
+        // resolves auth from the default profile/env vars, which are absent
+        // when Modal credentials come from the encrypted deployment env vars
+        // (fresh spawns worked, snapshot resumes failed with "Profile is
+        // missing token_id or token_secret").
+        promise: this.sdk.images.fromId(input.sourceSnapshotId),
         signal: input.signal,
         abortMessage: `Loading Modal snapshot ${input.sourceSnapshotId} was aborted`,
       });

--- a/packages/sdk/src/server/lib/auth/resolve-actor-scoped-user.ts
+++ b/packages/sdk/src/server/lib/auth/resolve-actor-scoped-user.ts
@@ -16,10 +16,11 @@ export interface ActorScopedUserContext {
 /**
  * Resolve the effective human for actor-scoped integration lookups.
  *
- * Job tokens stay authorized as the original job owner, but live-task
- * follow-ups may switch `cloud_jobs.actingUserId` to the latest human who is
- * speaking to the task. Actor-scoped integration lookups should follow that
- * override when present.
+ * Job tokens are authorized by their run-scoped `cloudJobId` binding; the
+ * token's userId is only mint-time attribution. Live-task steers and
+ * follow-ups switch `task_runs.actingUserId` to the latest human who is
+ * speaking to the task, so actor-scoped integration lookups follow that
+ * live value when present and fall back to the token's mint-time user.
  */
 export async function resolveActorScopedUserContext(
   auth: ActorScopedAuthContext | null | undefined,

--- a/packages/sdk/src/server/lib/cloud-jobs/find-cloud-job.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/find-cloud-job.ts
@@ -34,24 +34,21 @@ export const findCloudJobForAccess = async (id: number) =>
     columns: { id: true },
   });
 
+/**
+ * Resolve the run a job token is bound to. The token's `cloudJobId` binding IS
+ * the authorization: only that run's sandbox holds the token, so no principal
+ * equality against `task_runs.actingUserId` is performed. The token's userId
+ * is mint-time attribution while actingUserId is current-steering attribution
+ * — web steer and follow-up delivery mutate the acting user mid-run, so the
+ * two legitimately diverge and must not be compared for authorization.
+ */
 export const findCloudJobByJobTokenClaims = async ({
   cloudJobId,
-  userId,
-}: Pick<JobTokenContext, 'cloudJobId' | 'userId'>) => {
+}: Pick<JobTokenContext, 'cloudJobId'>) => {
   const run = await db.query.taskRuns.findFirst({
     where: eq(taskRuns.id, cloudJobId),
-    columns: { id: true, actingUserId: true },
+    columns: { id: true },
   });
 
-  if (!run) {
-    return null;
-  }
-
-  // Token/run match rule: (run.actingUserId ?? null) === token.userId.
-  // null === null is a valid deployment-principal match.
-  if ((run.actingUserId ?? null) !== (userId ?? null)) {
-    return null;
-  }
-
-  return { id: run.id };
+  return run ? { id: run.id } : null;
 };

--- a/packages/sdk/src/server/routers/user-api-keys.ts
+++ b/packages/sdk/src/server/routers/user-api-keys.ts
@@ -37,7 +37,8 @@ export const userApiKeysRouter = router({
 
   /**
    * Returns the decrypted API key for the given provider and current user.
-   * Accessible from worker via job token (userId is embedded in the token).
+   * Accessible from worker via a run-scoped job token; the effective user is
+   * the run's live acting user (falling back to the token's mint-time user).
    */
   getDecryptedKey: authenticatedProcedure
     .input(z.object({ provider: z.string() }))


### PR DESCRIPTION
Two production bugs found while testing the new data model on the nightly deployment (roomote.roomote.ai).

## Modal snapshot resume fails with "Profile is missing token_id or token_secret"

`resumeFromSnapshot` loaded snapshot images through the Modal SDK's **static** `Image.fromId`, which resolves auth from the default profile/process env — not from the client instance we construct with explicit credentials. When Modal credentials come from the encrypted deployment env vars (the setup-flow storage) instead of process env, fresh spawns worked but every snapshot resume failed after 3 retries. Fixed by routing the load through `this.sdk.images.fromId` so the explicit `tokenId`/`tokenSecret` travel with it.

## Slack MCP calls 403 after a steer or follow-up ("MCP token principal does not match cloud job")

Job tokens snapshot the run's acting user at mint time, but `task_runs.actingUserId` is deliberately mutable: web steer and follow-up delivery both reassign it to the latest human. The MCP handlers (and `findCloudJobByJobTokenClaims`, which gates the worker's entire sandbox→API RPC surface) required strict equality between the two — so the moment anyone steered or replied in-thread (including a human replying in an automation run's thread), every subsequent MCP/RPC call from that worker 403'd. Observed as a worker unable to post its Slack closeout.

The run-scoped `cloudJobId` binding is the actual authorization (only that sandbox holds the token; Slack posts go out via the deployment bot token, so there is no impersonation vector). This PR removes the exact-user equality everywhere the token is already run-bound — the 5 sites in `mcp/slack.ts`, the shared `proxy-utils` validator (renamed to `assertCloudJobTokenJobExists` to match what it now does), the inline copies in the vercel/grafana/snowflake/asana integrations (all resolve credentials from deployment-scoped connections; token userId played no role), and the SDK-side `findCloudJobByJobTokenClaims`. Capability gates by principal *kind* (human vs deployment) and all live-`actingUserId` attribution reads are unchanged.

Tests cover both switch scenarios (user→user and null-principal→human) across the integration auth suites and the Slack channel-post path.

Both commits were validated with the full `pnpm check` gate (lint, types, all tests, knip).