### PR TITLE
[Refactor] Rename CloudJob/CloudTask vocabulary to Run/Task

### DIFF
--- a/apps/api/src/handlers/ado/__tests__/handleComment.test.ts
+++ b/apps/api/src/handlers/ado/__tests__/handleComment.test.ts
@@ -54,7 +54,7 @@ vi.mock('../../tasks/sendMessageToTask', () => ({
   steerMessageToTask: mockSteerMessageToTask,
 }));
 
-import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
 
 import { handleAdoComment } from '../handleComment';
 import type { AdoPullRequestCommentWebhook } from '../types';
@@ -250,7 +250,7 @@ describe('handleAdoComment', () => {
   it('routes mentions into a reusable active task before starting a new review', async () => {
     mockFindReusableGitHubPrFollowUpOwner.mockResolvedValue({
       taskId: 'task-existing',
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
     });
     mockGetTaskUrl.mockReturnValue(
@@ -281,7 +281,7 @@ describe('handleAdoComment', () => {
       taskId: 'review-task',
       jobId: 9,
       type: TaskPayloadKind.GithubPrReview,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       match: 'github_pr',
     });

--- a/apps/api/src/handlers/ado/__tests__/handleComment.test.ts
+++ b/apps/api/src/handlers/ado/__tests__/handleComment.test.ts
@@ -1,5 +1,5 @@
 const {
-  mockEnqueueCloudTask,
+  mockEnqueueTask,
   mockGetTaskUrl,
   mockGetAdoAutomationTargets,
   mockGetAdoDeploymentUser,
@@ -9,7 +9,7 @@ const {
   mockSendMessageToTask,
   mockSteerMessageToTask,
 } = vi.hoisted(() => ({
-  mockEnqueueCloudTask: vi.fn(),
+  mockEnqueueTask: vi.fn(),
   mockGetTaskUrl: vi.fn(),
   mockGetAdoAutomationTargets: vi.fn(),
   mockGetAdoDeploymentUser: vi.fn(),
@@ -21,7 +21,7 @@ const {
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
-  enqueueCloudTask: mockEnqueueCloudTask,
+  enqueueTask: mockEnqueueTask,
   getTaskUrl: mockGetTaskUrl,
 }));
 
@@ -126,7 +126,7 @@ function makeCommentPayload(
 
 describe('handleAdoComment', () => {
   beforeEach(() => {
-    mockEnqueueCloudTask.mockReset();
+    mockEnqueueTask.mockReset();
     mockGetTaskUrl.mockReset();
     mockGetAdoAutomationTargets.mockReset();
     mockGetAdoDeploymentUser.mockReset();
@@ -158,7 +158,7 @@ describe('handleAdoComment', () => {
     });
     mockFindActiveGitHubPrReviewTask.mockResolvedValue(null);
     mockFindReusableGitHubPrFollowUpOwner.mockResolvedValue(null);
-    mockEnqueueCloudTask.mockResolvedValue({ id: 1234, taskId: 'task-1' });
+    mockEnqueueTask.mockResolvedValue({ id: 1234, taskId: 'task-1' });
     mockGetTaskUrl.mockReturnValue('https://roomote.example/tasks/task-1');
     mockSendMessageToTask.mockResolvedValue({ success: true });
     mockSteerMessageToTask.mockResolvedValue({ success: true });
@@ -168,7 +168,7 @@ describe('handleAdoComment', () => {
     const result = await handleAdoComment(makeCommentPayload());
 
     expect(result).toEqual({ status: 'ok', metadata: { ids: [1234] } });
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: TaskPayloadKind.GithubPrReview,
@@ -231,7 +231,7 @@ describe('handleAdoComment', () => {
         repoFullName: 'acme/Platform/backend',
       }),
     );
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           payload: expect.objectContaining({
@@ -268,7 +268,7 @@ describe('handleAdoComment', () => {
         senderMode: 'github_pr_follow_up',
       }),
     );
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
     expect(mockCreateAdoPullRequestComment).toHaveBeenCalledWith(
       expect.objectContaining({
         body: expect.stringContaining('existing task'),
@@ -298,7 +298,7 @@ describe('handleAdoComment', () => {
       prNumber: 42,
       headSha: 'abc123',
     });
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
     expect(mockCreateAdoPullRequestComment).toHaveBeenCalledWith(
       expect.objectContaining({
         body: expect.stringContaining('already running'),
@@ -312,7 +312,7 @@ describe('handleAdoComment', () => {
     );
 
     expect(result).toEqual({ status: 'ok', message: 'no_mention' });
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
     expect(mockCreateAdoPullRequestComment).not.toHaveBeenCalled();
   });
 
@@ -337,7 +337,7 @@ describe('handleAdoComment', () => {
       status: 'ok',
       message: 'roomote_authored_comment',
     });
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
     expect(mockGetAdoAutomationTargets).not.toHaveBeenCalled();
   });
 
@@ -357,7 +357,7 @@ describe('handleAdoComment', () => {
     );
 
     expect(result).toEqual({ status: 'ok', metadata: { ids: [1234] } });
-    expect(mockEnqueueCloudTask).toHaveBeenCalled();
+    expect(mockEnqueueTask).toHaveBeenCalled();
   });
 
   it('posts a reviewer-gate comment when no automation target is found', async () => {
@@ -376,7 +376,7 @@ describe('handleAdoComment', () => {
         body: expect.stringContaining('could not start work'),
       }),
     );
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('bypasses the PR author policy for explicit mentions', async () => {
@@ -411,7 +411,7 @@ describe('handleAdoComment', () => {
         body: expect.stringContaining('Azure DevOps account linked'),
       }),
     );
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('creates a new response thread when the comment thread link is absent', async () => {

--- a/apps/api/src/handlers/ado/__tests__/handlePullRequest.test.ts
+++ b/apps/api/src/handlers/ado/__tests__/handlePullRequest.test.ts
@@ -1,5 +1,5 @@
 const {
-  mockEnqueueCloudTask,
+  mockEnqueueTask,
   mockGetAdoAutomationTargets,
   mockUpdateTaskPrStatus,
   mockRepositoriesFindFirst,
@@ -8,7 +8,7 @@ const {
   mockNotifyTeamsPrMerge,
   mockNotifyTelegramAndLinearPrMerge,
 } = vi.hoisted(() => ({
-  mockEnqueueCloudTask: vi.fn(),
+  mockEnqueueTask: vi.fn(),
   mockGetAdoAutomationTargets: vi.fn(),
   mockUpdateTaskPrStatus: vi.fn(),
   mockRepositoriesFindFirst: vi.fn(),
@@ -21,7 +21,7 @@ const {
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
-  enqueueCloudTask: mockEnqueueCloudTask,
+  enqueueTask: mockEnqueueTask,
 }));
 
 vi.mock('@roomote/sdk/server', () => ({
@@ -163,7 +163,7 @@ function makePayload(
 
 describe('handleAdoPullRequest', () => {
   beforeEach(() => {
-    mockEnqueueCloudTask.mockReset();
+    mockEnqueueTask.mockReset();
     mockGetAdoAutomationTargets.mockReset();
     mockUpdateTaskPrStatus.mockReset();
     mockRepositoriesFindFirst.mockReset();
@@ -189,7 +189,7 @@ describe('handleAdoPullRequest', () => {
         },
       ],
     });
-    mockEnqueueCloudTask.mockResolvedValue({
+    mockEnqueueTask.mockResolvedValue({
       id: 1234,
       taskId: 'task-1',
     });
@@ -206,7 +206,7 @@ describe('handleAdoPullRequest', () => {
         ids: [1234],
       },
     });
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: TaskPayloadKind.GithubPrReview,
@@ -271,7 +271,7 @@ describe('handleAdoPullRequest', () => {
         }),
       }),
     );
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           payload: expect.objectContaining({
@@ -288,7 +288,7 @@ describe('handleAdoPullRequest', () => {
       updatedNotificationType: 'PushNotification',
     });
 
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: TaskPayloadKind.GithubPrReviewSync,
@@ -314,7 +314,7 @@ describe('handleAdoPullRequest', () => {
 
     expect(mockGetAdoAutomationTargets).not.toHaveBeenCalled();
     expect(mockDedupSelect).not.toHaveBeenCalled();
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('skips updated pull requests when the head SHA already has a review job', async () => {
@@ -329,7 +329,7 @@ describe('handleAdoPullRequest', () => {
       message: 'Azure DevOps PR head SHA already has a review job.',
     });
 
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('skips legacy updated pull request events without prior review state', async () => {
@@ -341,7 +341,7 @@ describe('handleAdoPullRequest', () => {
     });
 
     expect(mockDedupSelect).toHaveBeenCalledTimes(2);
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('enqueues legacy updated pull request events when the head SHA changed', async () => {
@@ -349,7 +349,7 @@ describe('handleAdoPullRequest', () => {
 
     await handleAdoPullRequest(makePayload('git.pullrequest.updated'));
 
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: TaskPayloadKind.GithubPrReviewSync,
@@ -401,7 +401,7 @@ describe('handleAdoPullRequest', () => {
       mergedBy: 'roomote-bot@acme.example',
       sourceControlProvider: 'ado',
     });
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('does not process stale merge-attempted events as completion updates', async () => {
@@ -418,7 +418,7 @@ describe('handleAdoPullRequest', () => {
     expect(mockNotifySlackPrMerge).not.toHaveBeenCalled();
     expect(mockNotifyTeamsPrMerge).not.toHaveBeenCalled();
     expect(mockNotifyTelegramAndLinearPrMerge).not.toHaveBeenCalled();
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('updates tracked task PR status for abandoned pull requests', async () => {

--- a/apps/api/src/handlers/ado/handleComment.ts
+++ b/apps/api/src/handlers/ado/handleComment.ts
@@ -9,11 +9,11 @@ import {
   type AdoCurrentUser,
 } from '@roomote/ado';
 import {
-  type CloudTaskPayload,
+  type TaskPayload,
   CloudAgentType,
   TaskPayloadKind,
   PRODUCT_NAME,
-  isActivelyRunningCloudTask,
+  isActivelyRunningTask,
 } from '@roomote/types';
 
 import type { WebhookResponse } from '../../types';
@@ -332,7 +332,7 @@ export async function handleAdoComment(
       commenter,
       commentBody: comment.content ?? '',
     });
-    const delivery = isActivelyRunningCloudTask(
+    const delivery = isActivelyRunningTask(
       activeOwner.status,
       activeOwner.taskPhase,
     )
@@ -409,7 +409,7 @@ export async function handleAdoComment(
     ...(branchName ? { branch: branchName } : {}),
     ...(headSha ? { sha: headSha } : {}),
     targetBranch: stripAdoGitRefPrefix(pullRequest.targetRefName),
-  } satisfies CloudTaskPayload<typeof TaskPayloadKind.GithubPrReview>;
+  } satisfies TaskPayload<typeof TaskPayloadKind.GithubPrReview>;
 
   try {
     // A human @roomote mention started this review: the commenter is the

--- a/apps/api/src/handlers/ado/handleComment.ts
+++ b/apps/api/src/handlers/ado/handleComment.ts
@@ -1,4 +1,4 @@
-import { enqueueCloudTask, getTaskUrl } from '@roomote/cloud-agents/server';
+import { enqueueTask, getTaskUrl } from '@roomote/cloud-agents/server';
 import {
   findActiveGitHubPrReviewTask,
   findReusableGitHubPrFollowUpOwner,
@@ -414,7 +414,7 @@ export async function handleAdoComment(
   try {
     // A human @roomote mention started this review: the commenter is the
     // initiator (the old automatic/ado attribution override is gone).
-    const launch = await enqueueCloudTask({
+    const launch = await enqueueTask({
       task: {
         type: TaskPayloadKind.GithubPrReview,
         payload: reviewPayload,

--- a/apps/api/src/handlers/ado/handlePullRequest.ts
+++ b/apps/api/src/handlers/ado/handlePullRequest.ts
@@ -20,7 +20,7 @@ import {
   isNull,
   sql,
 } from '@roomote/db/server';
-import { enqueueCloudTask } from '@roomote/cloud-agents/server';
+import { enqueueTask } from '@roomote/cloud-agents/server';
 import { updateTaskPrStatus } from '@roomote/sdk/server';
 
 import type { WebhookResponse } from '../../types';
@@ -325,7 +325,7 @@ export async function handleAdoPullRequest(
   const prAuthorId = pullRequest.createdBy?.id?.trim() || prAuthorName;
 
   const enqueued = await pMap(targets, async (_target) =>
-    enqueueCloudTask(
+    enqueueTask(
       {
         task: {
           type: taskType,

--- a/apps/api/src/handlers/ado/handlePullRequest.ts
+++ b/apps/api/src/handlers/ado/handlePullRequest.ts
@@ -1,12 +1,12 @@
 import pMap from 'p-map';
 
 import {
-  type CloudTaskPayload,
+  type TaskPayload,
   DEFAULT_PR_REVIEWER_SETTINGS,
   type PrReviewerSettings,
   TaskPayloadKind,
   CloudAgentType,
-  CloudTaskStatus,
+  RunStatus,
 } from '@roomote/types';
 import {
   db,
@@ -163,7 +163,7 @@ async function getAdoSyncReviewDecision({
         eq(taskPullRequests.repository, repoFullName),
         eq(taskPullRequests.prNumber, prNumber),
         eq(taskPullRequests.prSha, headSha),
-        sql`${taskRuns.status} != ${CloudTaskStatus.Failed}`,
+        sql`${taskRuns.status} != ${RunStatus.Failed}`,
         isNull(taskRuns.canceledAt),
       ),
     )
@@ -191,7 +191,7 @@ async function getAdoSyncReviewDecision({
         eq(taskPullRequests.sourceControlProvider, 'ado'),
         eq(taskPullRequests.repository, repoFullName),
         eq(taskPullRequests.prNumber, prNumber),
-        sql`${taskRuns.status} != ${CloudTaskStatus.Failed}`,
+        sql`${taskRuns.status} != ${RunStatus.Failed}`,
         sql`${taskPullRequests.prSha} != ${headSha}`,
         isNotNull(taskPullRequests.prSha),
         isNull(taskRuns.canceledAt),
@@ -340,7 +340,7 @@ export async function handleAdoPullRequest(
             ...(branchName ? { branch: branchName } : {}),
             ...(headSha ? { sha: headSha } : {}),
             targetBranch,
-          } satisfies CloudTaskPayload<typeof taskType>,
+          } satisfies TaskPayload<typeof taskType>,
         },
         initiator: {
           kind: 'automation',

--- a/apps/api/src/handlers/cloud-jobs/logs.ts
+++ b/apps/api/src/handlers/cloud-jobs/logs.ts
@@ -9,7 +9,7 @@ import {
   taskRuns,
 } from '@roomote/db/server';
 import {
-  isExitedCloudTaskStatus,
+  isExitedRunStatus,
   resolveComputeProviderTarget,
 } from '@roomote/types';
 
@@ -93,7 +93,7 @@ async function streamCloudJobLogs({
     const startedAt = Date.now();
 
     while (!signal.aborted && (!machineId || !sandboxCmdId)) {
-      if (isExitedCloudTaskStatus(status)) {
+      if (isExitedRunStatus(status)) {
         break;
       }
 

--- a/apps/api/src/handlers/environments/createEnvironment.ts
+++ b/apps/api/src/handlers/environments/createEnvironment.ts
@@ -12,7 +12,7 @@ import {
   taskRuns,
 } from '@roomote/db/server';
 import {
-  type CloudTaskPayload,
+  type TaskPayload,
   environmentConfigSchema,
   getEnvironmentRepositoryInstallationError,
 } from '@roomote/types';
@@ -120,7 +120,7 @@ export async function attachEnvironmentIdToCloudJob(
       payload: {
         ...payload,
         environmentDefinitionId: environmentId,
-      } as unknown as CloudTaskPayload,
+      } as unknown as TaskPayload,
     })
     .where(eq(taskRuns.id, cloudJob.id));
 }

--- a/apps/api/src/handlers/gitea/__tests__/handleComment.test.ts
+++ b/apps/api/src/handlers/gitea/__tests__/handleComment.test.ts
@@ -1,5 +1,5 @@
 const {
-  mockEnqueueCloudTask,
+  mockEnqueueTask,
   mockGetTaskUrl,
   mockGetGiteaAutomationTargets,
   mockGetGiteaDeploymentUser,
@@ -9,7 +9,7 @@ const {
   mockSendMessageToTask,
   mockSteerMessageToTask,
 } = vi.hoisted(() => ({
-  mockEnqueueCloudTask: vi.fn(),
+  mockEnqueueTask: vi.fn(),
   mockGetTaskUrl: vi.fn(),
   mockGetGiteaAutomationTargets: vi.fn(),
   mockGetGiteaDeploymentUser: vi.fn(),
@@ -21,7 +21,7 @@ const {
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
-  enqueueCloudTask: mockEnqueueCloudTask,
+  enqueueTask: mockEnqueueTask,
   getTaskUrl: mockGetTaskUrl,
 }));
 
@@ -106,7 +106,7 @@ function makeCommentPayload(
 
 describe('handleGiteaComment', () => {
   beforeEach(() => {
-    mockEnqueueCloudTask.mockReset();
+    mockEnqueueTask.mockReset();
     mockGetTaskUrl.mockReset();
     mockGetGiteaAutomationTargets.mockReset();
     mockGetGiteaDeploymentUser.mockReset();
@@ -131,7 +131,7 @@ describe('handleGiteaComment', () => {
     mockCreateGiteaPullRequestComment.mockResolvedValue({ id: 1 });
     mockFindActiveGitHubPrReviewTask.mockResolvedValue(null);
     mockFindReusableGitHubPrFollowUpOwner.mockResolvedValue(null);
-    mockEnqueueCloudTask.mockResolvedValue({ id: 1234, taskId: 'task-1' });
+    mockEnqueueTask.mockResolvedValue({ id: 1234, taskId: 'task-1' });
     mockGetTaskUrl.mockReturnValue('https://roomote.example/tasks/task-1');
     mockSendMessageToTask.mockResolvedValue({ success: true });
     mockSteerMessageToTask.mockResolvedValue({ success: true });
@@ -141,7 +141,7 @@ describe('handleGiteaComment', () => {
     const result = await handleGiteaComment(makeCommentPayload());
 
     expect(result).toEqual({ status: 'ok', metadata: { ids: [1234] } });
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: TaskPayloadKind.GithubPrReview,
@@ -196,7 +196,7 @@ describe('handleGiteaComment', () => {
         message: expect.stringContaining('mentioned Roomote in a comment'),
       }),
     );
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('links to an active review instead of starting a duplicate review task', async () => {
@@ -218,7 +218,7 @@ describe('handleGiteaComment', () => {
         ),
       }),
     );
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('prompts the commenter to link Gitea before starting work', async () => {
@@ -243,7 +243,7 @@ describe('handleGiteaComment', () => {
         ),
       }),
     );
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('handles issue comment payloads that only include issue PR context', async () => {
@@ -254,7 +254,7 @@ describe('handleGiteaComment', () => {
     );
 
     expect(result).toEqual({ status: 'ok', metadata: { ids: [1234] } });
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           payload: expect.objectContaining({
@@ -278,7 +278,7 @@ describe('handleGiteaComment', () => {
       status: 'ok',
       message: 'roomote_authored_comment',
     });
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('requires linked commenter attribution for explicit mentions', async () => {

--- a/apps/api/src/handlers/gitea/__tests__/handleComment.test.ts
+++ b/apps/api/src/handlers/gitea/__tests__/handleComment.test.ts
@@ -53,7 +53,7 @@ vi.mock('../../tasks/sendMessageToTask', () => ({
   steerMessageToTask: mockSteerMessageToTask,
 }));
 
-import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
 
 import { handleGiteaComment } from '../handleComment';
 import type { GiteaPullRequestCommentWebhook } from '../types';
@@ -179,7 +179,7 @@ describe('handleGiteaComment', () => {
   it('routes mentions into a reusable active task before starting a new review', async () => {
     mockFindReusableGitHubPrFollowUpOwner.mockResolvedValue({
       taskId: 'task-existing',
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
     });
     mockGetTaskUrl.mockReturnValue(

--- a/apps/api/src/handlers/gitea/__tests__/handlePullRequest.test.ts
+++ b/apps/api/src/handlers/gitea/__tests__/handlePullRequest.test.ts
@@ -1,5 +1,5 @@
 const {
-  mockEnqueueCloudTask,
+  mockEnqueueTask,
   mockGetGiteaAutomationTargets,
   mockUpdateTaskPrStatus,
   mockRepositoriesFindFirst,
@@ -8,7 +8,7 @@ const {
   mockNotifyTelegramAndLinearPrMerge,
   mockFindActiveGitHubPrReviewTask,
 } = vi.hoisted(() => ({
-  mockEnqueueCloudTask: vi.fn(),
+  mockEnqueueTask: vi.fn(),
   mockGetGiteaAutomationTargets: vi.fn(),
   mockUpdateTaskPrStatus: vi.fn(),
   mockRepositoriesFindFirst: vi.fn(),
@@ -19,7 +19,7 @@ const {
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
-  enqueueCloudTask: mockEnqueueCloudTask,
+  enqueueTask: mockEnqueueTask,
 }));
 
 vi.mock('@roomote/sdk/server', () => ({
@@ -100,7 +100,7 @@ function makePayload(
 
 describe('handleGiteaPullRequest', () => {
   beforeEach(() => {
-    mockEnqueueCloudTask.mockReset();
+    mockEnqueueTask.mockReset();
     mockGetGiteaAutomationTargets.mockReset();
     mockUpdateTaskPrStatus.mockReset();
     mockRepositoriesFindFirst.mockReset();
@@ -125,7 +125,7 @@ describe('handleGiteaPullRequest', () => {
         },
       ],
     });
-    mockEnqueueCloudTask.mockResolvedValue({
+    mockEnqueueTask.mockResolvedValue({
       id: 1234,
       taskId: 'task-1',
     });
@@ -141,7 +141,7 @@ describe('handleGiteaPullRequest', () => {
         ids: [1234],
       },
     });
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: TaskPayloadKind.GithubPrReview,
@@ -180,7 +180,7 @@ describe('handleGiteaPullRequest', () => {
   it('enqueues sync reviews for synchronized pull requests', async () => {
     await handleGiteaPullRequest(makePayload('synchronized'));
 
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: TaskPayloadKind.GithubPrReviewSync,
@@ -216,14 +216,14 @@ describe('handleGiteaPullRequest', () => {
       headSha: 'abc123',
       sourceControlProvider: 'gitea',
     });
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('does not run head-SHA dedup for opened pull requests', async () => {
     await handleGiteaPullRequest(makePayload('opened'));
 
     expect(mockFindActiveGitHubPrReviewTask).not.toHaveBeenCalled();
-    expect(mockEnqueueCloudTask).toHaveBeenCalled();
+    expect(mockEnqueueTask).toHaveBeenCalled();
   });
 
   it('updates tracked task PR status and notifications for merged pull requests', async () => {
@@ -261,7 +261,7 @@ describe('handleGiteaPullRequest', () => {
       mergedBy: 'roomote-bot',
       sourceControlProvider: 'gitea',
     });
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('updates tracked task PR status without notifications for closed pull requests', async () => {

--- a/apps/api/src/handlers/gitea/handleComment.ts
+++ b/apps/api/src/handlers/gitea/handleComment.ts
@@ -8,11 +8,11 @@ import {
   getGiteaDeploymentUser,
 } from '@roomote/gitea';
 import {
-  type CloudTaskPayload,
+  type TaskPayload,
   CloudAgentType,
   TaskPayloadKind,
   PRODUCT_NAME,
-  isActivelyRunningCloudTask,
+  isActivelyRunningTask,
 } from '@roomote/types';
 
 import type { WebhookResponse } from '../../types';
@@ -295,7 +295,7 @@ export async function handleGiteaComment(
       commenter,
       commentBody: payload.comment.body,
     });
-    const delivery = isActivelyRunningCloudTask(
+    const delivery = isActivelyRunningTask(
       activeOwner.status,
       activeOwner.taskPhase,
     )
@@ -372,7 +372,7 @@ export async function handleGiteaComment(
     ...(pullRequest.head?.ref ? { branch: pullRequest.head.ref } : {}),
     ...(headSha ? { sha: headSha } : {}),
     targetBranch: pullRequest.base?.ref,
-  } satisfies CloudTaskPayload<typeof TaskPayloadKind.GithubPrReview>;
+  } satisfies TaskPayload<typeof TaskPayloadKind.GithubPrReview>;
 
   try {
     // A human @roomote mention started this review: the commenter is the

--- a/apps/api/src/handlers/gitea/handleComment.ts
+++ b/apps/api/src/handlers/gitea/handleComment.ts
@@ -1,4 +1,4 @@
-import { enqueueCloudTask, getTaskUrl } from '@roomote/cloud-agents/server';
+import { enqueueTask, getTaskUrl } from '@roomote/cloud-agents/server';
 import {
   findActiveGitHubPrReviewTask,
   findReusableGitHubPrFollowUpOwner,
@@ -377,7 +377,7 @@ export async function handleGiteaComment(
   try {
     // A human @roomote mention started this review: the commenter is the
     // initiator (the old automatic/gitea attribution override is gone).
-    const launch = await enqueueCloudTask({
+    const launch = await enqueueTask({
       task: {
         type: TaskPayloadKind.GithubPrReview,
         payload: reviewPayload,

--- a/apps/api/src/handlers/gitea/handlePullRequest.ts
+++ b/apps/api/src/handlers/gitea/handlePullRequest.ts
@@ -1,7 +1,7 @@
 import pMap from 'p-map';
 
 import {
-  type CloudTaskPayload,
+  type TaskPayload,
   DEFAULT_PR_REVIEWER_SETTINGS,
   type PrReviewerSettings,
   TaskPayloadKind,
@@ -212,7 +212,7 @@ export async function handleGiteaPullRequest(
             ...(pullRequest.head?.ref ? { branch: pullRequest.head.ref } : {}),
             ...(headSha ? { sha: headSha } : {}),
             targetBranch: pullRequest.base?.ref,
-          } satisfies CloudTaskPayload<typeof taskType>,
+          } satisfies TaskPayload<typeof taskType>,
         },
         initiator: {
           kind: 'automation',

--- a/apps/api/src/handlers/gitea/handlePullRequest.ts
+++ b/apps/api/src/handlers/gitea/handlePullRequest.ts
@@ -14,7 +14,7 @@ import {
   eq,
   findActiveGitHubPrReviewTask,
 } from '@roomote/db/server';
-import { enqueueCloudTask } from '@roomote/cloud-agents/server';
+import { enqueueTask } from '@roomote/cloud-agents/server';
 import { updateTaskPrStatus } from '@roomote/sdk/server';
 
 import type { WebhookResponse } from '../../types';
@@ -197,7 +197,7 @@ export async function handleGiteaPullRequest(
     pullRequest.user?.id != null ? String(pullRequest.user.id) : prAuthorName;
 
   const enqueued = await pMap(targets, async (_target) =>
-    enqueueCloudTask(
+    enqueueTask(
       {
         task: {
           type: taskType,

--- a/apps/api/src/handlers/github/__tests__/handlePrComment.test.ts
+++ b/apps/api/src/handlers/github/__tests__/handlePrComment.test.ts
@@ -7,7 +7,7 @@ const { mockGetGitHubAutomationTargets, mockGetInstallationOctokit } =
 vi.mock('@roomote/cloud-agents/server', () => ({
   buildGitHubExistingTaskFollowUpMessage: vi.fn(),
   buildGitHubRoutingContext: vi.fn(),
-  enqueueCloudTask: vi.fn(),
+  enqueueTask: vi.fn(),
   getTaskUrl: vi.fn(),
   routeGitHubTask: vi.fn(),
 }));

--- a/apps/api/src/handlers/github/__tests__/handleWorkflowRunCompleted.test.ts
+++ b/apps/api/src/handlers/github/__tests__/handleWorkflowRunCompleted.test.ts
@@ -1,6 +1,6 @@
 const {
   mockDbSelect,
-  mockEnqueueCloudTask,
+  mockEnqueueTask,
   mockBuildRepositoryCoverage,
   mockGetBackgroundAgentSettingsForOrg,
   mockEvaluateFeatureFlag,
@@ -12,7 +12,7 @@ const {
   mockRedisSet,
 } = vi.hoisted(() => ({
   mockDbSelect: vi.fn(),
-  mockEnqueueCloudTask: vi.fn(),
+  mockEnqueueTask: vi.fn(),
   mockBuildRepositoryCoverage: vi.fn(),
   mockGetBackgroundAgentSettingsForOrg: vi.fn(),
   mockEvaluateFeatureFlag: vi.fn(),
@@ -50,7 +50,7 @@ vi.mock('@roomote/cloud-agents/server', () => ({
     `$ci-failure-triage trigger=${params.trigger} run=${params.triggeringRun?.runUrl ?? 'none'} announced=${params.hasAnnouncementThread === true}`,
   buildRepositoryCoverage: (...args: unknown[]) =>
     mockBuildRepositoryCoverage(...args),
-  enqueueCloudTask: (...args: unknown[]) => mockEnqueueCloudTask(...args),
+  enqueueTask: (...args: unknown[]) => mockEnqueueTask(...args),
   getTaskUrl: ({ taskId }: { taskId: string }) =>
     `https://app.example.com/task/${taskId}?utm_source=slack&utm_medium=link&utm_campaign=slack.thread_reply`,
 }));
@@ -186,7 +186,7 @@ describe('handleWorkflowRunCompleted', () => {
     );
     mockUpsertBackgroundAutomationSlackThread.mockResolvedValue(undefined);
     mockRecordAutomationRunOutcome.mockResolvedValue(undefined);
-    mockEnqueueCloudTask.mockResolvedValue({
+    mockEnqueueTask.mockResolvedValue({
       success: true,
       cloudJobId: 7,
       taskId: 'task-scan-1',
@@ -197,7 +197,7 @@ describe('handleWorkflowRunCompleted', () => {
     const result = await handleWorkflowRunCompleted(buildPayload());
 
     expect(result.status).toBe('ok');
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: TaskPayloadKind.Scan,
@@ -311,7 +311,7 @@ describe('handleWorkflowRunCompleted', () => {
     const result = await handleWorkflowRunCompleted(buildPayload());
 
     expect(result.status).toBe('ok');
-    const payload = mockEnqueueCloudTask.mock.calls[0]?.[0].task.payload;
+    const payload = mockEnqueueTask.mock.calls[0]?.[0].task.payload;
     expect(payload.thread_ts).toBeUndefined();
     expect(payload.slackChannel).toBeUndefined();
     expect(payload.description).toContain('announced=false');
@@ -325,7 +325,7 @@ describe('handleWorkflowRunCompleted', () => {
     );
 
     expect(result.message).toContain('non-failure');
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('ignores failures outside the default branch', async () => {
@@ -334,7 +334,7 @@ describe('handleWorkflowRunCompleted', () => {
     );
 
     expect(result.message).toContain('outside the default branch');
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('skips orgs with the automation disabled', async () => {
@@ -346,7 +346,7 @@ describe('handleWorkflowRunCompleted', () => {
     const result = await handleWorkflowRunCompleted(buildPayload());
 
     expect(result.message).toContain('disabled');
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('skips repositories without a configured environment', async () => {
@@ -357,7 +357,7 @@ describe('handleWorkflowRunCompleted', () => {
     const result = await handleWorkflowRunCompleted(buildPayload());
 
     expect(result.message).toContain('no configured environment');
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('debounces repeated failures for the same repository', async () => {
@@ -367,11 +367,11 @@ describe('handleWorkflowRunCompleted', () => {
 
     expect(result.message).toContain('debounced');
     expect(mockRecordAutomationRunOutcome).not.toHaveBeenCalled();
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('records the failure on the automations row and resolves the announcement thread when the launch throws', async () => {
-    mockEnqueueCloudTask.mockRejectedValue(new Error('enqueue failed'));
+    mockEnqueueTask.mockRejectedValue(new Error('enqueue failed'));
 
     const result = await handleWorkflowRunCompleted(buildPayload());
 

--- a/apps/api/src/handlers/github/conflict-resolution/has-active-resolution-job.ts
+++ b/apps/api/src/handlers/github/conflict-resolution/has-active-resolution-job.ts
@@ -7,7 +7,7 @@ import {
   and,
   inArray,
 } from '@roomote/db/server';
-import { CloudTaskStatus } from '@roomote/types';
+import { RunStatus } from '@roomote/types';
 
 import { LOG_PREFIX } from './constants';
 
@@ -23,7 +23,7 @@ export async function hasActiveResolutionJob(
   repoFullName: string,
   prNumber: number,
 ): Promise<boolean> {
-  const activeStatuses = [CloudTaskStatus.Pending, CloudTaskStatus.Running];
+  const activeStatuses = [RunStatus.Pending, RunStatus.Running];
 
   const existing = await db
     .select({ id: taskRuns.id })

--- a/apps/api/src/handlers/github/conflict-resolution/process-candidates.ts
+++ b/apps/api/src/handlers/github/conflict-resolution/process-candidates.ts
@@ -1,5 +1,5 @@
 import { TaskPayloadKind, CloudAgentType, PRODUCT_NAME } from '@roomote/types';
-import { enqueueCloudTask, getTaskUrl } from '@roomote/cloud-agents/server';
+import { enqueueTask, getTaskUrl } from '@roomote/cloud-agents/server';
 import {
   DEFAULT_CONFLICT_RESOLUTION_IDLE_WINDOW_MS,
   findActiveGitHubBranchWork,
@@ -205,7 +205,7 @@ async function tryEnqueueResolution(
     const { owner, repo } = candidate;
 
     for (const target of targetResult.targets) {
-      const launchResult = await enqueueCloudTask({
+      const launchResult = await enqueueTask({
         task: {
           type: TaskPayloadKind.GithubPrConflictResolve,
           ...getBackgroundGithubTaskProperties(target.properties),

--- a/apps/api/src/handlers/github/handlePrComment.ts
+++ b/apps/api/src/handlers/github/handlePrComment.ts
@@ -1,7 +1,7 @@
 import {
   buildGitHubExistingTaskFollowUpMessage,
   buildGitHubRoutingContext,
-  enqueueCloudTask,
+  enqueueTask,
   getTaskUrl,
   routeGitHubTask,
 } from '@roomote/cloud-agents/server';
@@ -1031,7 +1031,7 @@ async function resumeExistingTaskAndDeliverFollowUp({
 
   // Resumes never create tasks and never re-attribute; the resuming human
   // becomes the new run's acting user.
-  const resumeLaunch = await enqueueCloudTask(
+  const resumeLaunch = await enqueueTask(
     {
       task: {
         type: TaskPayloadKind.SnapshotResume,
@@ -1293,8 +1293,7 @@ export async function handlePrComment(
       branchName,
     };
 
-    const reviewLaunches: Array<Awaited<ReturnType<typeof enqueueCloudTask>>> =
-      [];
+    const reviewLaunches: Array<Awaited<ReturnType<typeof enqueueTask>>> = [];
     const failedReviewerIds: string[] = [];
 
     for (const reviewer of reviewers) {
@@ -1317,7 +1316,7 @@ export async function handlePrComment(
           );
         }
 
-        const reviewLaunch = await enqueueCloudTask({
+        const reviewLaunch = await enqueueTask({
           task: {
             type: TaskPayloadKind.GithubPrReview,
             githubLogin: reviewer.properties.githubLogin,
@@ -1583,7 +1582,7 @@ export async function handlePrComment(
       );
     }
 
-    const followUpLaunch = await enqueueCloudTask({
+    const followUpLaunch = await enqueueTask({
       task: {
         type: TaskPayloadKind.GithubPrReviewFollowUp,
         githubLogin: reviewer.properties.githubLogin,

--- a/apps/api/src/handlers/github/handlePrComment.ts
+++ b/apps/api/src/handlers/github/handlePrComment.ts
@@ -12,15 +12,15 @@ import {
 import { getInstallationOctokit } from '@roomote/github';
 import { ensureSnapshotResumeGitHubFollowUpFallback } from '@roomote/sdk/server';
 import {
-  type CloudTaskPayload,
+  type TaskPayload,
   CloudAgentType,
-  CloudTaskStatus,
+  RunStatus,
   TaskPayloadKind,
   EXPIRED_SNAPSHOT_RESUME_ERROR,
   PRODUCT_NAME,
   type SnapshotResumePromptFallbackTask,
-  isActivelyRunningCloudTask,
-  isExitedCloudTaskStatus,
+  isActivelyRunningTask,
+  isExitedRunStatus,
   populateSnapshotResumeSlackMetadata,
   isSnapshotResumable,
   restoreSnapshotResumeVisiblePromptFields,
@@ -699,7 +699,7 @@ async function waitForTaskToAcceptMessages({
       sandboxServerUrl: true,
     });
 
-    if (!latestJob || isExitedCloudTaskStatus(latestJob.status)) {
+    if (!latestJob || isExitedRunStatus(latestJob.status)) {
       return null;
     }
 
@@ -739,7 +739,7 @@ async function waitForResumeJobToAcceptDeferredPrompt({
   let latestJob:
     | {
         id: number;
-        status: CloudTaskStatus;
+        status: RunStatus;
         result: unknown;
       }
     | null
@@ -763,7 +763,7 @@ async function waitForResumeJobToAcceptDeferredPrompt({
         return true;
       }
 
-      if (accepted === false || isExitedCloudTaskStatus(latestJob.status)) {
+      if (accepted === false || isExitedRunStatus(latestJob.status)) {
         return false;
       }
     }
@@ -783,7 +783,7 @@ async function waitForResumeJobToAcceptDeferredPrompt({
     return true;
   }
 
-  if (accepted === false || isExitedCloudTaskStatus(latestJob.status)) {
+  if (accepted === false || isExitedRunStatus(latestJob.status)) {
     return false;
   }
 
@@ -852,7 +852,7 @@ async function deliverFollowUpToExistingTask({
   taskId: string;
   userId?: string | null;
   message: string;
-  status: CloudTaskStatus;
+  status: RunStatus;
   taskPhase: string | null;
   commenterDisplayName?: string;
 }) {
@@ -873,10 +873,10 @@ async function deliverFollowUpToExistingTask({
     status,
     taskPhase,
   }: {
-    status: CloudTaskStatus;
+    status: RunStatus;
     taskPhase: string | null;
   }) =>
-    isActivelyRunningCloudTask(status, taskPhase)
+    isActivelyRunningTask(status, taskPhase)
       ? steerMessageToTask({
           taskId,
           userId: senderUserId,
@@ -970,7 +970,7 @@ async function resumeExistingTaskAndDeliverFollowUp({
     };
   }
 
-  if (!isExitedCloudTaskStatus(sourceJob.status)) {
+  if (!isExitedRunStatus(sourceJob.status)) {
     return deliverFollowUpToExistingTask({
       taskId,
       userId,
@@ -1021,7 +1021,7 @@ async function resumeExistingTaskAndDeliverFollowUp({
     resumePrompt: message,
     resumePromptSource: 'github',
     resumePromptFallbackTask,
-  } satisfies CloudTaskPayload<typeof TaskPayloadKind.SnapshotResume>;
+  } satisfies TaskPayload<typeof TaskPayloadKind.SnapshotResume>;
   populateSnapshotResumeSlackMetadata(resumePayload, {
     sourcePayload,
     channel: channelBindings?.slackChannelId,
@@ -1308,7 +1308,7 @@ export async function handlePrComment(
       const reviewPayload = {
         ...reviewPayloadBase,
         ...relayPayload,
-      } satisfies CloudTaskPayload<typeof TaskPayloadKind.GithubPrReview>;
+      } satisfies TaskPayload<typeof TaskPayloadKind.GithubPrReview>;
 
       try {
         if (!reviewer.properties.userId) {
@@ -1574,7 +1574,7 @@ export async function handlePrComment(
     ...(!isSubmittedReview ? { commentId: rest.comment.id } : {}),
     commentBody: mention.body ?? '',
     followUpSource: 'github_mention',
-  } satisfies CloudTaskPayload<typeof TaskPayloadKind.GithubPrReviewFollowUp>;
+  } satisfies TaskPayload<typeof TaskPayloadKind.GithubPrReviewFollowUp>;
 
   try {
     if (!reviewer.properties.userId) {

--- a/apps/api/src/handlers/github/handlePrOpen.ts
+++ b/apps/api/src/handlers/github/handlePrOpen.ts
@@ -1,7 +1,7 @@
 import pMap from 'p-map';
 
 import {
-  type CloudTaskPayload,
+  type TaskPayload,
   DEFAULT_PR_REVIEWER_SETTINGS,
   type PrReviewerSettings,
   TaskPayloadKind,
@@ -97,7 +97,7 @@ export async function handlePrOpen(
           headSha: pr.head.sha,
           branchName: pr.head.ref,
           ...relayPayload,
-        } satisfies CloudTaskPayload<typeof TaskPayloadKind.GithubPrReview>,
+        } satisfies TaskPayload<typeof TaskPayloadKind.GithubPrReview>,
       },
       initiator: {
         kind: 'automation',

--- a/apps/api/src/handlers/github/handlePrOpen.ts
+++ b/apps/api/src/handlers/github/handlePrOpen.ts
@@ -7,7 +7,7 @@ import {
   TaskPayloadKind,
   CloudAgentType,
 } from '@roomote/types';
-import { enqueueCloudTask } from '@roomote/cloud-agents/server';
+import { enqueueTask } from '@roomote/cloud-agents/server';
 
 import type { WebhookResponse } from '../../types';
 
@@ -73,7 +73,7 @@ export async function handlePrOpen(
   }
 
   console.log(
-    `[handlePrOpen] ${repository.full_name}#${pr.number} -> enqueueCloudTask (background_review_task: true)`,
+    `[handlePrOpen] ${repository.full_name}#${pr.number} -> enqueueTask (background_review_task: true)`,
   );
 
   const enqueued = await pMap(targets, async (target) => {
@@ -85,7 +85,7 @@ export async function handlePrOpen(
       reviewerSettings: target.settings,
     });
 
-    return enqueueCloudTask({
+    return enqueueTask({
       task: {
         type: TaskPayloadKind.GithubPrReview,
         ...getBackgroundGithubTaskProperties(target.properties),

--- a/apps/api/src/handlers/github/handlePrSynchronize.ts
+++ b/apps/api/src/handlers/github/handlePrSynchronize.ts
@@ -19,7 +19,7 @@ import {
   isNull,
   sql,
 } from '@roomote/db/server';
-import { enqueueCloudTask } from '@roomote/cloud-agents/server';
+import { enqueueTask } from '@roomote/cloud-agents/server';
 
 import type { WebhookResponse } from '../../types';
 
@@ -139,7 +139,7 @@ export async function handlePrSynchronize({
       reviewerSettings: currentTarget.settings,
     });
 
-    return enqueueCloudTask({
+    return enqueueTask({
       task: {
         type: shouldRunSyncReview
           ? TaskPayloadKind.GithubPrReviewSync

--- a/apps/api/src/handlers/github/handlePrSynchronize.ts
+++ b/apps/api/src/handlers/github/handlePrSynchronize.ts
@@ -1,12 +1,12 @@
 import pMap from 'p-map';
 
 import {
-  type CloudTaskPayload,
+  type TaskPayload,
   DEFAULT_PR_REVIEWER_SETTINGS,
   type PrReviewerSettings,
   TaskPayloadKind,
   CloudAgentType,
-  CloudTaskStatus,
+  RunStatus,
 } from '@roomote/types';
 import {
   db,
@@ -88,7 +88,7 @@ export async function handlePrSynchronize({
           eq(taskPullRequests.repository, repository.full_name),
           eq(taskPullRequests.prNumber, pr.number),
           eq(taskPullRequests.prSha, pr.head.sha),
-          sql`${taskRuns.status} != ${CloudTaskStatus.Failed}`,
+          sql`${taskRuns.status} != ${RunStatus.Failed}`,
           isNotNull(taskRuns.startedAt),
           isNull(taskRuns.canceledAt),
         ),
@@ -114,7 +114,7 @@ export async function handlePrSynchronize({
           eq(taskPullRequests.sourceControlProvider, 'github'),
           eq(taskPullRequests.repository, repository.full_name),
           eq(taskPullRequests.prNumber, pr.number),
-          sql`${taskRuns.status} != ${CloudTaskStatus.Failed}`,
+          sql`${taskRuns.status} != ${RunStatus.Failed}`,
           sql`${taskPullRequests.prSha} != ${pr.head.sha}`,
           isNotNull(taskPullRequests.prSha),
           isNotNull(taskRuns.startedAt),
@@ -153,7 +153,7 @@ export async function handlePrSynchronize({
           headSha: pr.head.sha,
           branchName: pr.head.ref,
           ...relayPayload,
-        } satisfies CloudTaskPayload<
+        } satisfies TaskPayload<
           | typeof TaskPayloadKind.GithubPrReviewSync
           | typeof TaskPayloadKind.GithubPrReview
         >,

--- a/apps/api/src/handlers/github/handleWorkflowRunCompleted.ts
+++ b/apps/api/src/handlers/github/handleWorkflowRunCompleted.ts
@@ -2,7 +2,7 @@ import { getRedis } from '@roomote/redis';
 import {
   buildCiFailureTriagePrompt,
   buildRepositoryCoverage,
-  enqueueCloudTask,
+  enqueueTask,
   getTaskUrl,
 } from '@roomote/cloud-agents/server';
 import {
@@ -303,7 +303,7 @@ export async function handleWorkflowRunCompleted(
 
   try {
     // CI failure triage runs as the deployment service principal.
-    const launchResult = await enqueueCloudTask(
+    const launchResult = await enqueueTask(
       {
         task: {
           type: TaskPayloadKind.Scan,

--- a/apps/api/src/handlers/gitlab/__tests__/handleMergeRequest.test.ts
+++ b/apps/api/src/handlers/gitlab/__tests__/handleMergeRequest.test.ts
@@ -1,5 +1,5 @@
 const {
-  mockEnqueueCloudTask,
+  mockEnqueueTask,
   mockGetGitLabAutomationTargets,
   mockUpdateTaskPrStatus,
   mockRepositoriesFindFirst,
@@ -8,7 +8,7 @@ const {
   mockNotifyTelegramAndLinearPrMerge,
   mockFindActiveGitHubPrReviewTask,
 } = vi.hoisted(() => ({
-  mockEnqueueCloudTask: vi.fn(),
+  mockEnqueueTask: vi.fn(),
   mockGetGitLabAutomationTargets: vi.fn(),
   mockUpdateTaskPrStatus: vi.fn(),
   mockRepositoriesFindFirst: vi.fn(),
@@ -19,7 +19,7 @@ const {
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
-  enqueueCloudTask: mockEnqueueCloudTask,
+  enqueueTask: mockEnqueueTask,
 }));
 
 vi.mock('@roomote/sdk/server', () => ({
@@ -94,7 +94,7 @@ function makePayload(
 
 describe('handleGitLabMergeRequest', () => {
   beforeEach(() => {
-    mockEnqueueCloudTask.mockReset();
+    mockEnqueueTask.mockReset();
     mockGetGitLabAutomationTargets.mockReset();
     mockUpdateTaskPrStatus.mockReset();
     mockRepositoriesFindFirst.mockReset();
@@ -119,7 +119,7 @@ describe('handleGitLabMergeRequest', () => {
         },
       ],
     });
-    mockEnqueueCloudTask.mockResolvedValue({
+    mockEnqueueTask.mockResolvedValue({
       id: 1234,
       taskId: 'task-1',
     });
@@ -135,7 +135,7 @@ describe('handleGitLabMergeRequest', () => {
         ids: [1234],
       },
     });
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: TaskPayloadKind.GithubPrReview,
@@ -178,11 +178,11 @@ describe('handleGitLabMergeRequest', () => {
       status: 'ok',
       message: 'unsupported_merge_request_action:update',
     });
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
 
     await handleGitLabMergeRequest(makePayload('update', { oldrev: 'oldsha' }));
 
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: TaskPayloadKind.GithubPrReviewSync,
@@ -220,14 +220,14 @@ describe('handleGitLabMergeRequest', () => {
       headSha: 'abc123',
       sourceControlProvider: 'gitlab',
     });
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('does not run head-SHA dedup for open merge requests', async () => {
     await handleGitLabMergeRequest(makePayload('open'));
 
     expect(mockFindActiveGitHubPrReviewTask).not.toHaveBeenCalled();
-    expect(mockEnqueueCloudTask).toHaveBeenCalled();
+    expect(mockEnqueueTask).toHaveBeenCalled();
   });
 
   it('updates tracked task PR status for merged merge requests', async () => {
@@ -241,7 +241,7 @@ describe('handleGitLabMergeRequest', () => {
       42,
       'merged',
     );
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('notifies Slack, Teams, and Telegram/Linear threads for merged merge requests on active synced repositories', async () => {

--- a/apps/api/src/handlers/gitlab/__tests__/handleNote.test.ts
+++ b/apps/api/src/handlers/gitlab/__tests__/handleNote.test.ts
@@ -50,7 +50,7 @@ vi.mock('../../tasks/sendMessageToTask', () => ({
   steerMessageToTask: mockSteerMessageToTask,
 }));
 
-import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
 
 import { handleGitLabNote } from '../handleNote';
 import type { GitLabNoteWebhook } from '../types';
@@ -177,7 +177,7 @@ describe('handleGitLabNote', () => {
       taskId: 'review-task',
       jobId: 9,
       type: TaskPayloadKind.GithubPrReview,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       match: 'github_pr',
     });
@@ -215,7 +215,7 @@ describe('handleGitLabNote', () => {
       taskId: 'owner-task',
       jobId: 5,
       type: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       match: 'task_pull_request',
       delivery: 'attach',
@@ -245,7 +245,7 @@ describe('handleGitLabNote', () => {
       taskId: 'owner-task',
       jobId: 5,
       type: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Completed,
+      status: RunStatus.Completed,
       taskPhase: null,
       match: 'task_pull_request',
       delivery: 'resume',
@@ -269,7 +269,7 @@ describe('handleGitLabNote', () => {
       taskId: 'owner-task',
       jobId: 5,
       type: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       match: 'task_pull_request',
       delivery: 'attach',

--- a/apps/api/src/handlers/gitlab/__tests__/handleNote.test.ts
+++ b/apps/api/src/handlers/gitlab/__tests__/handleNote.test.ts
@@ -1,5 +1,5 @@
 const {
-  mockEnqueueCloudTask,
+  mockEnqueueTask,
   mockGetTaskUrl,
   mockGetGitLabAutomationTargets,
   mockFindReusableGitHubPrFollowUpOwner,
@@ -9,7 +9,7 @@ const {
   mockSendMessageToTask,
   mockSteerMessageToTask,
 } = vi.hoisted(() => ({
-  mockEnqueueCloudTask: vi.fn(),
+  mockEnqueueTask: vi.fn(),
   mockGetTaskUrl: vi.fn(),
   mockGetGitLabAutomationTargets: vi.fn(),
   mockFindReusableGitHubPrFollowUpOwner: vi.fn(),
@@ -21,7 +21,7 @@ const {
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
-  enqueueCloudTask: mockEnqueueCloudTask,
+  enqueueTask: mockEnqueueTask,
   getTaskUrl: mockGetTaskUrl,
 }));
 
@@ -99,7 +99,7 @@ function makeNotePayload(
 
 describe('handleGitLabNote', () => {
   beforeEach(() => {
-    mockEnqueueCloudTask.mockReset();
+    mockEnqueueTask.mockReset();
     mockGetTaskUrl.mockReset();
     mockGetGitLabAutomationTargets.mockReset();
     mockFindReusableGitHubPrFollowUpOwner.mockReset();
@@ -127,7 +127,7 @@ describe('handleGitLabNote', () => {
       username: 'roomote-bot',
     });
     mockCreateGitLabMergeRequestNote.mockResolvedValue({ id: 1 });
-    mockEnqueueCloudTask.mockResolvedValue({ id: 1234, taskId: 'task-1' });
+    mockEnqueueTask.mockResolvedValue({ id: 1234, taskId: 'task-1' });
     mockGetTaskUrl.mockReturnValue('https://app.roomote.dev/task/task-1');
   });
 
@@ -135,7 +135,7 @@ describe('handleGitLabNote', () => {
     const result = await handleGitLabNote(makeNotePayload());
 
     expect(result).toEqual({ status: 'ok', metadata: { ids: [1234] } });
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: TaskPayloadKind.GithubPrReview,
@@ -193,7 +193,7 @@ describe('handleGitLabNote', () => {
       prNumber: 42,
       headSha: 'abc123',
     });
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
     expect(mockCreateGitLabMergeRequestNote).toHaveBeenCalledWith(
       expect.objectContaining({
         body: expect.stringContaining('already running'),
@@ -207,7 +207,7 @@ describe('handleGitLabNote', () => {
     );
 
     expect(mockFindActiveGitHubPrReviewTask).not.toHaveBeenCalled();
-    expect(mockEnqueueCloudTask).toHaveBeenCalled();
+    expect(mockEnqueueTask).toHaveBeenCalled();
   });
 
   it('steers the note into an actively running reusable owner task', async () => {
@@ -232,7 +232,7 @@ describe('handleGitLabNote', () => {
         senderMode: 'github_pr_follow_up',
       }),
     );
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
     expect(mockCreateGitLabMergeRequestNote).toHaveBeenCalledWith(
       expect.objectContaining({
         body: expect.stringContaining('existing task'),
@@ -283,7 +283,7 @@ describe('handleGitLabNote', () => {
     const result = await handleGitLabNote(makeNotePayload());
 
     expect(result).toEqual({ status: 'ok', metadata: { ids: [1234] } });
-    expect(mockEnqueueCloudTask).toHaveBeenCalled();
+    expect(mockEnqueueTask).toHaveBeenCalled();
   });
 
   it('ignores notes without an @roomote mention', async () => {
@@ -292,7 +292,7 @@ describe('handleGitLabNote', () => {
     );
 
     expect(result).toEqual({ status: 'ok', message: 'no_mention' });
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
     expect(mockCreateGitLabMergeRequestNote).not.toHaveBeenCalled();
   });
 
@@ -324,7 +324,7 @@ describe('handleGitLabNote', () => {
     );
 
     expect(result).toEqual({ status: 'ok', message: 'roomote_authored_note' });
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('ignores notes authored by a project access token bot identity', async () => {
@@ -343,7 +343,7 @@ describe('handleGitLabNote', () => {
     );
 
     expect(result).toEqual({ status: 'ok', message: 'system_note' });
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('ignores notes on non-merge-request targets', async () => {
@@ -358,7 +358,7 @@ describe('handleGitLabNote', () => {
       status: 'ok',
       message: 'unsupported_noteable_type:Issue',
     });
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('posts a reviewer-gate note when no automation target is found', async () => {
@@ -376,7 +376,7 @@ describe('handleGitLabNote', () => {
         mergeRequestIid: 42,
       }),
     );
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('prompts the commenter to link GitLab before starting work', async () => {
@@ -394,7 +394,7 @@ describe('handleGitLabNote', () => {
         body: expect.stringContaining('GitLab account linked'),
       }),
     );
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('bypasses the MR author policy for mentions', async () => {

--- a/apps/api/src/handlers/gitlab/handleMergeRequest.ts
+++ b/apps/api/src/handlers/gitlab/handleMergeRequest.ts
@@ -14,7 +14,7 @@ import {
   eq,
   findActiveGitHubPrReviewTask,
 } from '@roomote/db/server';
-import { enqueueCloudTask } from '@roomote/cloud-agents/server';
+import { enqueueTask } from '@roomote/cloud-agents/server';
 import { updateTaskPrStatus } from '@roomote/sdk/server';
 
 import type { WebhookResponse } from '../../types';
@@ -196,7 +196,7 @@ export async function handleGitLabMergeRequest(
   const mrAuthorName = payload.user?.name ?? payload.user?.username;
 
   const enqueued = await pMap(targets, async (_target) =>
-    enqueueCloudTask(
+    enqueueTask(
       {
         task: {
           type: taskType,

--- a/apps/api/src/handlers/gitlab/handleMergeRequest.ts
+++ b/apps/api/src/handlers/gitlab/handleMergeRequest.ts
@@ -1,7 +1,7 @@
 import pMap from 'p-map';
 
 import {
-  type CloudTaskPayload,
+  type TaskPayload,
   DEFAULT_PR_REVIEWER_SETTINGS,
   type PrReviewerSettings,
   TaskPayloadKind,
@@ -213,7 +213,7 @@ export async function handleGitLabMergeRequest(
               : {}),
             ...(headSha ? { sha: headSha } : {}),
             targetBranch: mergeRequest.target_branch,
-          } satisfies CloudTaskPayload<typeof taskType>,
+          } satisfies TaskPayload<typeof taskType>,
         },
         initiator: {
           kind: 'automation',

--- a/apps/api/src/handlers/gitlab/handleNote.ts
+++ b/apps/api/src/handlers/gitlab/handleNote.ts
@@ -8,11 +8,11 @@ import {
   getGitLabDeploymentUser,
 } from '@roomote/gitlab';
 import {
-  type CloudTaskPayload,
+  type TaskPayload,
   CloudAgentType,
   TaskPayloadKind,
   PRODUCT_NAME,
-  isActivelyRunningCloudTask,
+  isActivelyRunningTask,
 } from '@roomote/types';
 
 import type { WebhookResponse } from '../../types';
@@ -289,7 +289,7 @@ export async function handleGitLabNote(
       commenter,
       noteBody: note.note,
     });
-    const delivery = isActivelyRunningCloudTask(
+    const delivery = isActivelyRunningTask(
       activeOwner.status,
       activeOwner.taskPhase,
     )
@@ -374,7 +374,7 @@ export async function handleGitLabNote(
       : {}),
     ...(headSha ? { sha: headSha } : {}),
     targetBranch: mergeRequest.target_branch,
-  } satisfies CloudTaskPayload<typeof TaskPayloadKind.GithubPrReview>;
+  } satisfies TaskPayload<typeof TaskPayloadKind.GithubPrReview>;
 
   try {
     // A human @roomote mention started this review: the commenter is the

--- a/apps/api/src/handlers/gitlab/handleNote.ts
+++ b/apps/api/src/handlers/gitlab/handleNote.ts
@@ -1,4 +1,4 @@
-import { enqueueCloudTask, getTaskUrl } from '@roomote/cloud-agents/server';
+import { enqueueTask, getTaskUrl } from '@roomote/cloud-agents/server';
 import {
   findActiveGitHubPrReviewTask,
   findReusableGitHubPrFollowUpOwner,
@@ -379,7 +379,7 @@ export async function handleGitLabNote(
   try {
     // A human @roomote mention started this review: the commenter is the
     // initiator (the old automatic/gitlab attribution override is gone).
-    const launch = await enqueueCloudTask({
+    const launch = await enqueueTask({
       task: {
         type: TaskPayloadKind.GithubPrReview,
         payload: reviewPayload,

--- a/apps/api/src/handlers/linear/__tests__/linear-active-job-priority.test.ts
+++ b/apps/api/src/handlers/linear/__tests__/linear-active-job-priority.test.ts
@@ -43,7 +43,7 @@ vi.mock('@roomote/env', async (importOriginal) => {
 });
 
 vi.mock('@roomote/cloud-agents/server', () => ({
-  enqueueCloudTask: vi.fn(),
+  enqueueTask: vi.fn(),
   routeTask: vi.fn(),
   buildLinearRoutingContext: vi.fn(),
   AGENT_TYPE_TO_PROMPT_NAME: {},

--- a/apps/api/src/handlers/linear/__tests__/linear-routing-confirmation.test.ts
+++ b/apps/api/src/handlers/linear/__tests__/linear-routing-confirmation.test.ts
@@ -48,7 +48,7 @@ vi.mock('@roomote/env', async (importOriginal) => {
 });
 
 vi.mock('@roomote/cloud-agents/server', () => ({
-  enqueueCloudTask: vi.fn(),
+  enqueueTask: vi.fn(),
   routeTask: vi.fn(),
   buildLinearRoutingContext: vi.fn(),
 }));

--- a/apps/api/src/handlers/linear/index.ts
+++ b/apps/api/src/handlers/linear/index.ts
@@ -4,7 +4,7 @@ import { Hono } from 'hono';
 
 import {
   AGENT_DISPLAY_NAME,
-  type CloudTaskPayload,
+  type TaskPayload,
   TaskPayloadKind,
   formatErrorForLog,
   parseAcpRequestUserInputAnswerReply,
@@ -800,7 +800,7 @@ async function handleAgentSessionEvent(
           typeof completedPayload?.environmentId === 'string'
             ? completedPayload.environmentId
             : undefined;
-        const resumePayload: CloudTaskPayload<
+        const resumePayload: TaskPayload<
           typeof TaskPayloadKind.SnapshotResume
         > = {
           repo,

--- a/apps/api/src/handlers/linear/index.ts
+++ b/apps/api/src/handlers/linear/index.ts
@@ -17,7 +17,7 @@ import { Env } from '@roomote/env';
 import {
   type RoutingDebugInfo,
   type RoutingWorkspace,
-  enqueueCloudTask,
+  enqueueTask,
   routeTask,
   buildLinearRoutingContext,
 } from '@roomote/cloud-agents/server';
@@ -820,7 +820,7 @@ async function handleAgentSessionEvent(
 
         // Resumes never create tasks and never re-attribute; the resuming
         // human becomes the new run's acting user.
-        const resumeLaunch = await enqueueCloudTask(
+        const resumeLaunch = await enqueueTask(
           {
             task: {
               type: TaskPayloadKind.SnapshotResume,

--- a/apps/api/src/handlers/slack/dispatch/__tests__/task-cancellation.test.ts
+++ b/apps/api/src/handlers/slack/dispatch/__tests__/task-cancellation.test.ts
@@ -2,7 +2,7 @@ import {
   buildStartedBlocks,
   type SlackInteractivePayload,
 } from '@roomote/slack';
-import { CloudTaskStatus } from '@roomote/types';
+import { RunStatus } from '@roomote/types';
 
 const {
   dbUpdateMock,
@@ -135,7 +135,7 @@ describe('handleTaskCancellation', () => {
     dbQueryFindFirstMock.mockResolvedValueOnce({
       id: 42,
       taskId: 'task-1',
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       sandboxServerUrl: 'http://sandbox.example.com',
       userId: 'user-1',
       actingUserId: 'user-1',

--- a/apps/api/src/handlers/slack/dispatch/task-cancellation.ts
+++ b/apps/api/src/handlers/slack/dispatch/task-cancellation.ts
@@ -6,7 +6,7 @@ import {
   TASK_CANCELED_RESPONSE_TEXT,
   type SlackInteractivePayload,
 } from '@roomote/slack';
-import { activeCloudTaskStatuses } from '@roomote/types';
+import { activeRunStatuses } from '@roomote/types';
 import {
   and,
   db,
@@ -29,7 +29,7 @@ async function findLatestActiveCloudJobForTask(
   const activeJob = await db.query.taskRuns.findFirst({
     where: and(
       eq(taskRuns.taskId, taskId),
-      inArray(taskRuns.status, [...activeCloudTaskStatuses]),
+      inArray(taskRuns.status, [...activeRunStatuses]),
       isNull(taskRuns.canceledAt),
     ),
     orderBy: desc(taskRuns.createdAt),
@@ -65,8 +65,8 @@ async function resolveCancelableCloudJob(
   }
 
   if (!sourceJob.taskId) {
-    return activeCloudTaskStatuses.includes(
-      sourceJob.status as (typeof activeCloudTaskStatuses)[number],
+    return activeRunStatuses.includes(
+      sourceJob.status as (typeof activeRunStatuses)[number],
     ) && sourceJob.canceledAt === null
       ? {
           id: sourceJob.id,

--- a/apps/api/src/handlers/slack/events/snapshot-resume.ts
+++ b/apps/api/src/handlers/slack/events/snapshot-resume.ts
@@ -5,7 +5,7 @@ import {
   restoreSnapshotResumeVisiblePromptFields,
 } from '@roomote/types';
 import { withContention } from '@roomote/redis';
-import { enqueueCloudTask } from '@roomote/cloud-agents/server';
+import { enqueueTask } from '@roomote/cloud-agents/server';
 import {
   appendSlackVideoDescriptionsToText,
   clearLatestUserMessage,
@@ -180,7 +180,7 @@ export async function processSnapshotResume(
         onAcquired: async () => {
           // Resumes never create tasks and never re-attribute; the Slack
           // follow-up sender becomes the new run's acting user.
-          const resumeLaunch = await enqueueCloudTask(
+          const resumeLaunch = await enqueueTask(
             {
               task: {
                 type: TaskPayloadKind.SnapshotResume,

--- a/apps/api/src/handlers/tasks/__tests__/launchTask.test.ts
+++ b/apps/api/src/handlers/tasks/__tests__/launchTask.test.ts
@@ -89,8 +89,8 @@ describe('launchTask', () => {
     mockGetMembershipRole.mockResolvedValue('org:admin');
   });
 
-  it('returns the LaunchTaskResponse success envelope shape, not the raw CloudJob row', async () => {
-    // enqueueCloudTask resolves with the CloudJob DB row, which has `id` +
+  it('returns the LaunchTaskResponse success envelope shape, not the raw Run row', async () => {
+    // enqueueCloudTask resolves with the Run DB row, which has `id` +
     // `taskId` but no `success`/`cloudJobId`/`error` envelope fields. The
     // handler must map this to the contract the worker MCP client expects.
     mockEnqueueCloudTask.mockResolvedValue({ id: 99, taskId: 'task-new' });

--- a/apps/api/src/handlers/tasks/__tests__/launchTask.test.ts
+++ b/apps/api/src/handlers/tasks/__tests__/launchTask.test.ts
@@ -7,13 +7,13 @@ import { mcpAuthMiddleware } from '../../mcp/middleware';
 import { launchTask } from '../launchTask';
 
 const {
-  mockEnqueueCloudTask,
+  mockEnqueueTask,
   mockEnvironmentsFindFirst,
   mockRepositoriesFindMany,
   mockSelectRows,
   mockGetMembershipRole,
 } = vi.hoisted(() => ({
-  mockEnqueueCloudTask: vi.fn(),
+  mockEnqueueTask: vi.fn(),
   mockEnvironmentsFindFirst: vi.fn(),
   mockRepositoriesFindMany: vi.fn(),
   mockSelectRows: vi.fn(),
@@ -21,7 +21,7 @@ const {
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
-  enqueueCloudTask: (...args: unknown[]) => mockEnqueueCloudTask(...args),
+  enqueueTask: (...args: unknown[]) => mockEnqueueTask(...args),
   resolveRequestedWorkKindDecision: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -79,7 +79,7 @@ describe('launchTask', () => {
   } as AuthTokenContext;
 
   beforeEach(() => {
-    mockEnqueueCloudTask.mockReset();
+    mockEnqueueTask.mockReset();
     mockEnvironmentsFindFirst.mockReset();
     mockEnvironmentsFindFirst.mockResolvedValue({ id: 'env-1' });
     mockRepositoriesFindMany.mockReset();
@@ -90,10 +90,10 @@ describe('launchTask', () => {
   });
 
   it('returns the LaunchTaskResponse success envelope shape, not the raw Run row', async () => {
-    // enqueueCloudTask resolves with the Run DB row, which has `id` +
+    // enqueueTask resolves with the Run DB row, which has `id` +
     // `taskId` but no `success`/`cloudJobId`/`error` envelope fields. The
     // handler must map this to the contract the worker MCP client expects.
-    mockEnqueueCloudTask.mockResolvedValue({ id: 99, taskId: 'task-new' });
+    mockEnqueueTask.mockResolvedValue({ id: 99, taskId: 'task-new' });
 
     const app = createApp(authContext);
     const response = await app.request(
@@ -113,7 +113,7 @@ describe('launchTask', () => {
   });
 
   it('stamps the source-control provider resolved from environment repositories into the payload', async () => {
-    mockEnqueueCloudTask.mockResolvedValue({ id: 100, taskId: 'task-gl' });
+    mockEnqueueTask.mockResolvedValue({ id: 100, taskId: 'task-gl' });
     mockSelectRows.mockReturnValue([{ sourceControlProvider: 'gitlab' }]);
 
     const app = createApp(authContext);
@@ -129,14 +129,14 @@ describe('launchTask', () => {
     );
 
     expect(response.status).toBe(200);
-    const enqueuedTask = mockEnqueueCloudTask.mock.calls[0]?.[0] as {
+    const enqueuedTask = mockEnqueueTask.mock.calls[0]?.[0] as {
       task: { payload: { sourceControlProvider?: string } };
     };
     expect(enqueuedTask.task.payload.sourceControlProvider).toBe('gitlab');
   });
 
   it('leaves the provider unset for prompt-only launches with no repository context', async () => {
-    mockEnqueueCloudTask.mockResolvedValue({ id: 101, taskId: 'task-plain' });
+    mockEnqueueTask.mockResolvedValue({ id: 101, taskId: 'task-plain' });
 
     const app = createApp(authContext);
     const response = await app.request(
@@ -148,7 +148,7 @@ describe('launchTask', () => {
     );
 
     expect(response.status).toBe(200);
-    const enqueuedTask = mockEnqueueCloudTask.mock.calls[0]?.[0] as {
+    const enqueuedTask = mockEnqueueTask.mock.calls[0]?.[0] as {
       task: { payload: { sourceControlProvider?: string } };
     };
     expect(enqueuedTask.task.payload.sourceControlProvider).toBeUndefined();
@@ -181,7 +181,7 @@ describe('launchTask', () => {
     expect(json.error).toBe(
       'Selected repositories must belong to a single source control provider.',
     );
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('rejects admin-required launches for non-admin members', async () => {
@@ -203,12 +203,12 @@ describe('launchTask', () => {
     expect(response.status).toBe(403);
     const json = (await response.json()) as { error: string };
     expect(json.error).toBe('Unauthorized');
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('allows non-admin members to launch standard tasks', async () => {
     mockGetMembershipRole.mockResolvedValue('org:member');
-    mockEnqueueCloudTask.mockResolvedValue({ id: 102, taskId: 'task-member' });
+    mockEnqueueTask.mockResolvedValue({ id: 102, taskId: 'task-member' });
 
     const app = createApp(authContext);
     const response = await app.request(
@@ -220,6 +220,6 @@ describe('launchTask', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(mockEnqueueCloudTask).toHaveBeenCalledTimes(1);
+    expect(mockEnqueueTask).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/handlers/tasks/__tests__/sendMessageToTask.test.ts
+++ b/apps/api/src/handlers/tasks/__tests__/sendMessageToTask.test.ts
@@ -1,7 +1,7 @@
 const {
   mockCreateJobToken,
   mockCreateTRPCProxyClient,
-  mockEnqueueCloudTask,
+  mockEnqueueTask,
   mockGetTaskChannelBindings,
   mockFindLatestCloudJob,
   mockHttpBatchLink,
@@ -12,7 +12,7 @@ const {
 } = vi.hoisted(() => ({
   mockCreateJobToken: vi.fn(),
   mockCreateTRPCProxyClient: vi.fn(),
-  mockEnqueueCloudTask: vi.fn(),
+  mockEnqueueTask: vi.fn(),
   mockGetTaskChannelBindings: vi.fn(),
   mockFindLatestCloudJob: vi.fn(),
   mockHttpBatchLink: vi.fn((options) => options),
@@ -40,7 +40,7 @@ vi.mock('@trpc/client', () => ({
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
-  enqueueCloudTask: mockEnqueueCloudTask,
+  enqueueTask: mockEnqueueTask,
 }));
 
 vi.mock('@roomote/slack', () => ({
@@ -159,7 +159,7 @@ describe('sendMessageToTask', () => {
     mockHttpBatchLink.mockImplementation((options) => options);
     mockSendPromptMutate.mockResolvedValue({ ok: true });
     mockSteerTaskMutate.mockResolvedValue({ ok: true });
-    mockEnqueueCloudTask.mockResolvedValue({ id: 77, taskId: 'task-1' });
+    mockEnqueueTask.mockResolvedValue({ id: 77, taskId: 'task-1' });
     mockGetTaskChannelBindings.mockResolvedValue({
       slackChannelId: 'C123',
       slackThreadTs: '111.222',
@@ -280,7 +280,7 @@ describe('sendMessageToTask', () => {
       userName: 'Alice',
       onError: expect.any(Function),
     });
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           payload: expect.objectContaining({
@@ -322,7 +322,7 @@ describe('sendMessageToTask', () => {
       error: EXPIRED_SNAPSHOT_RESUME_ERROR,
       status: 409,
     });
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
     expect(mockTrackLatestUserMessageForSlackQuote).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/handlers/tasks/__tests__/submitAutomationWorkItems.test.ts
+++ b/apps/api/src/handlers/tasks/__tests__/submitAutomationWorkItems.test.ts
@@ -17,7 +17,7 @@ const { mockCloudJobFindFirst, mockTaskFindFirst } = vi.hoisted(() => ({
 
 vi.mock('@roomote/cloud-agents/server', () => ({
   CloudJobQueueEnqueueError: class CloudJobQueueEnqueueError extends Error {},
-  enqueueCloudTask: vi.fn(),
+  enqueueTask: vi.fn(),
 }));
 
 vi.mock('@roomote/slack', () => ({

--- a/apps/api/src/handlers/tasks/__tests__/task-stop.test.ts
+++ b/apps/api/src/handlers/tasks/__tests__/task-stop.test.ts
@@ -1,5 +1,5 @@
 import { TRPCClientError } from '@trpc/client';
-import { CloudTaskStatus } from '@roomote/types';
+import { RunStatus } from '@roomote/types';
 
 const {
   mockWithSandboxServerRpcClient,
@@ -91,7 +91,7 @@ describe('stopTaskJob', () => {
   it('persists cancel intent on the job row before the sandbox stop RPC', async () => {
     const job = {
       id: 7,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       sandboxServerUrl: 'https://sandbox.example',
       actingUserId: null,
     };
@@ -112,7 +112,7 @@ describe('stopTaskJob', () => {
   it('persists cancel intent even when the sandbox stop RPC fails', async () => {
     const job = {
       id: 7,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       sandboxServerUrl: 'https://sandbox.example',
       actingUserId: null,
     };
@@ -135,7 +135,7 @@ describe('stopTaskJob', () => {
   it('stamps cancelRequestedAt when direct-canceling a job without a sandbox', async () => {
     const job = {
       id: 7,
-      status: CloudTaskStatus.Processing,
+      status: RunStatus.Processing,
       sandboxServerUrl: null,
       actingUserId: null,
     };

--- a/apps/api/src/handlers/tasks/automation-work-items/__tests__/launch.test.ts
+++ b/apps/api/src/handlers/tasks/automation-work-items/__tests__/launch.test.ts
@@ -9,7 +9,7 @@ const {
   MockCloudJobQueueEnqueueError,
   mockClaimedAt,
   mockDbUpdate,
-  mockEnqueueCloudTask,
+  mockEnqueueTask,
   mockUpdateBackgroundAutomationSlackThreadMetadata,
 } = vi.hoisted(() => ({
   mockClaimedAt: new Date('2026-07-01T12:00:00.000Z'),
@@ -31,13 +31,13 @@ const {
     }
   },
   mockDbUpdate: vi.fn(),
-  mockEnqueueCloudTask: vi.fn(),
+  mockEnqueueTask: vi.fn(),
   mockUpdateBackgroundAutomationSlackThreadMetadata: vi.fn(),
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
   CloudJobQueueEnqueueError: MockCloudJobQueueEnqueueError,
-  enqueueCloudTask: mockEnqueueCloudTask,
+  enqueueTask: mockEnqueueTask,
 }));
 
 vi.mock('@roomote/db/server', () => {
@@ -210,7 +210,7 @@ function setupDbUpdateMock(options: { throwOnWhereCall?: number } = {}) {
 }
 
 function mockSuccessfulTaskEnqueue(taskId = 'task-1') {
-  mockEnqueueCloudTask.mockImplementationOnce(async (_task, options) => {
+  mockEnqueueTask.mockImplementationOnce(async (_task, options) => {
     await options.beforeEnqueue?.({
       id: 123,
       taskId,
@@ -225,7 +225,7 @@ function mockSuccessfulTaskEnqueue(taskId = 'task-1') {
 
 describe('launchActWorkItems', () => {
   beforeEach(() => {
-    mockEnqueueCloudTask.mockReset();
+    mockEnqueueTask.mockReset();
     mockUpdateBackgroundAutomationSlackThreadMetadata.mockReset();
     mockUpdateBackgroundAutomationSlackThreadMetadata.mockResolvedValue(true);
     vi.mocked(postLateBoundWorkItemFailureMessage).mockReset();
@@ -245,7 +245,7 @@ describe('launchActWorkItems', () => {
     });
 
     expect(result).toEqual({ launchedCount: 1, failedCount: 0 });
-    const enqueuePayload = mockEnqueueCloudTask.mock.calls[0]?.[0].task
+    const enqueuePayload = mockEnqueueTask.mock.calls[0]?.[0].task
       .payload as Record<string, unknown>;
     expect(enqueuePayload.description).toEqual(
       expect.stringContaining('keep progress visible in the web task'),
@@ -258,7 +258,7 @@ describe('launchActWorkItems', () => {
     expect(enqueuePayload).not.toHaveProperty('slackChannel');
     expect(enqueuePayload).not.toHaveProperty('thread_ts');
     expect(enqueuePayload).not.toHaveProperty('slackThreadTs');
-    expect(mockEnqueueCloudTask.mock.calls[0]?.[1]).toEqual(
+    expect(mockEnqueueTask.mock.calls[0]?.[1]).toEqual(
       expect.objectContaining({
         beforeEnqueue: expect.any(Function),
         launchClass: 'automation',
@@ -319,7 +319,7 @@ describe('launchActWorkItems', () => {
     });
 
     expect(result).toEqual({ launchedCount: 1, failedCount: 0 });
-    const enqueuePayload = mockEnqueueCloudTask.mock.calls[0]?.[0].task
+    const enqueuePayload = mockEnqueueTask.mock.calls[0]?.[0].task
       .payload as Record<string, unknown>;
     expect(enqueuePayload.description).toEqual(
       expect.stringContaining('$update-dependencies'),
@@ -456,7 +456,7 @@ describe('launchActWorkItems', () => {
     });
 
     expect(result).toEqual({ launchedCount: 1, failedCount: 0 });
-    const enqueuePayload = mockEnqueueCloudTask.mock.calls[0]?.[0].task
+    const enqueuePayload = mockEnqueueTask.mock.calls[0]?.[0].task
       .payload as Record<string, unknown>;
     expect(enqueuePayload.description).toEqual(
       expect.stringContaining(
@@ -548,7 +548,7 @@ describe('launchActWorkItems', () => {
     });
 
     expect(result).toEqual({ launchedCount: 1, failedCount: 0 });
-    const enqueuePayload = mockEnqueueCloudTask.mock.calls[0]?.[0].task
+    const enqueuePayload = mockEnqueueTask.mock.calls[0]?.[0].task
       .payload as Record<string, unknown>;
     expect(enqueuePayload.thread_ts).toBe('1781300000.000100');
     expect(enqueuePayload.slackThreadTs).toBe('1781300000.000100');
@@ -590,7 +590,7 @@ describe('launchActWorkItems', () => {
 
   it('posts a channel-level failure message when a late-bound launch fails terminally', async () => {
     setupDbUpdateMock();
-    mockEnqueueCloudTask.mockRejectedValueOnce(new Error('enqueue failed'));
+    mockEnqueueTask.mockRejectedValueOnce(new Error('enqueue failed'));
 
     const result = await launchActWorkItems({
       automationKey: 'sentry_triage',
@@ -621,7 +621,7 @@ describe('launchActWorkItems', () => {
 
   it('resolves an existing investigation thread when a threaded launch fails terminally', async () => {
     setupDbUpdateMock();
-    mockEnqueueCloudTask.mockRejectedValueOnce(new Error('enqueue failed'));
+    mockEnqueueTask.mockRejectedValueOnce(new Error('enqueue failed'));
 
     const result = await launchActWorkItems({
       automationKey: 'sentry_triage',
@@ -642,7 +642,7 @@ describe('launchActWorkItems', () => {
 
   it('posts Telegram failure messages when a Telegram-targeted launch fails terminally', async () => {
     setupDbUpdateMock();
-    mockEnqueueCloudTask.mockRejectedValueOnce(new Error('enqueue failed'));
+    mockEnqueueTask.mockRejectedValueOnce(new Error('enqueue failed'));
 
     const result = await launchActWorkItems({
       automationKey: 'sentry_triage',
@@ -673,7 +673,7 @@ describe('launchActWorkItems', () => {
     });
 
     expect(result).toEqual({ launchedCount: 1, failedCount: 0 });
-    const enqueuePayload = mockEnqueueCloudTask.mock.calls[0]?.[0].task
+    const enqueuePayload = mockEnqueueTask.mock.calls[0]?.[0].task
       .payload as Record<string, unknown>;
 
     expect(enqueuePayload.communicationProvider).toBe('telegram');
@@ -695,7 +695,7 @@ describe('launchActWorkItems', () => {
 
   it('stays silent on terminal launch failures when no Slack target resolves', async () => {
     const updateSets = setupDbUpdateMock();
-    mockEnqueueCloudTask.mockRejectedValueOnce(new Error('enqueue failed'));
+    mockEnqueueTask.mockRejectedValueOnce(new Error('enqueue failed'));
 
     const result = await launchActWorkItems({
       automationKey: 'sentry_triage',
@@ -733,7 +733,7 @@ describe('launchActWorkItems', () => {
 
   it('reopens direct launches when Redis enqueue fails after task tracking is linked', async () => {
     const updateSets = setupDbUpdateMock();
-    mockEnqueueCloudTask.mockImplementationOnce(async (_task, options) => {
+    mockEnqueueTask.mockImplementationOnce(async (_task, options) => {
       await options.beforeEnqueue?.({
         id: 123,
         taskId: 'task-direct-1',
@@ -773,7 +773,7 @@ describe('launchActWorkItems', () => {
 
   it('fences the terminal failure write on the launching status and the claim token', async () => {
     setupDbUpdateMock();
-    mockEnqueueCloudTask.mockRejectedValueOnce(new Error('enqueue failed'));
+    mockEnqueueTask.mockRejectedValueOnce(new Error('enqueue failed'));
 
     await launchActWorkItems({
       automationKey: 'sentry_triage',
@@ -798,7 +798,7 @@ describe('launchActWorkItems', () => {
 
   it('fences the retry reopen write on our launched row and task link', async () => {
     setupDbUpdateMock();
-    mockEnqueueCloudTask.mockImplementationOnce(async (_task, options) => {
+    mockEnqueueTask.mockImplementationOnce(async (_task, options) => {
       await options.beforeEnqueue?.({
         id: 123,
         taskId: 'task-direct-1',

--- a/apps/api/src/handlers/tasks/automation-work-items/launch.ts
+++ b/apps/api/src/handlers/tasks/automation-work-items/launch.ts
@@ -1,6 +1,6 @@
 import {
   CloudJobQueueEnqueueError,
-  enqueueCloudTask,
+  enqueueTask,
 } from '@roomote/cloud-agents/server';
 import { TaskPayloadKind, type BackgroundAutomationKey } from '@roomote/types';
 import {
@@ -198,7 +198,7 @@ export async function launchActWorkItems(params: {
         linkedTaskId = taskId;
       };
 
-      await enqueueCloudTask(
+      await enqueueTask(
         {
           task: {
             type: TaskPayloadKind.StandardTask,

--- a/apps/api/src/handlers/tasks/automation-work-items/types.ts
+++ b/apps/api/src/handlers/tasks/automation-work-items/types.ts
@@ -1,16 +1,14 @@
 import {
   TaskPayloadKind,
   type AutomationWorkItemDisposition,
-  type CloudTaskPayload,
+  type TaskPayload,
   type SuggestionCategory,
   type SuggestionPriority,
   type WorkItemStatus,
   type WorkspaceReadiness,
 } from '@roomote/types';
 
-export type SuggestedTasksPayload = CloudTaskPayload<
-  typeof TaskPayloadKind.Scan
->;
+export type SuggestedTasksPayload = TaskPayload<typeof TaskPayloadKind.Scan>;
 
 export type ResolvedRepository = {
   id: string;

--- a/apps/api/src/handlers/tasks/cancelTask.ts
+++ b/apps/api/src/handlers/tasks/cancelTask.ts
@@ -7,7 +7,7 @@ import {
   syncTaskStateFromRuns,
   taskRuns,
 } from '@roomote/db/server';
-import { CloudTaskStatus, isExitedCloudTaskStatus } from '@roomote/types';
+import { RunStatus, isExitedRunStatus } from '@roomote/types';
 
 import type { Variables } from '../../types';
 import type { McpAuth } from '../mcp/middleware';
@@ -35,7 +35,7 @@ export async function cancelTask(
       return c.json({ success: false, error: 'Task not found' }, 404);
     }
 
-    if (isExitedCloudTaskStatus(job.status)) {
+    if (isExitedRunStatus(job.status)) {
       return c.json(
         {
           success: false,
@@ -51,7 +51,7 @@ export async function cancelTask(
       await tx
         .update(taskRuns)
         .set({
-          status: CloudTaskStatus.Canceled,
+          status: RunStatus.Canceled,
           cancelRequestedAt: endedAt,
           canceledAt: endedAt,
         })

--- a/apps/api/src/handlers/tasks/launchTask.ts
+++ b/apps/api/src/handlers/tasks/launchTask.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'hono';
 
 import {
-  enqueueCloudTask,
+  enqueueTask,
   resolveRequestedWorkKindDecision,
 } from '@roomote/cloud-agents/server';
 import {
@@ -346,7 +346,7 @@ export async function launchTask(
     // A human explicitly asked for this launch via the API, so the human is
     // the initiator even for the hidden scan branch (the old automation stamp
     // made the requesting human invisible).
-    const launchResult = await enqueueCloudTask(
+    const launchResult = await enqueueTask(
       {
         task,
         initiator: { kind: 'user', userId: auth.userId },

--- a/apps/api/src/handlers/tasks/sendMessageToTask.ts
+++ b/apps/api/src/handlers/tasks/sendMessageToTask.ts
@@ -1,5 +1,5 @@
 import { TRPCClientError } from '@trpc/client';
-import { enqueueCloudTask } from '@roomote/cloud-agents/server';
+import { enqueueTask } from '@roomote/cloud-agents/server';
 import { withSandboxServerRpcClient } from '@roomote/sdk/server';
 import {
   and,
@@ -496,7 +496,7 @@ async function resumeTaskFromSnapshot({
 
   // Resumes never create tasks and never re-attribute; the follow-up sender
   // becomes the new run's acting user.
-  const resumeLaunch = await enqueueCloudTask(
+  const resumeLaunch = await enqueueTask(
     {
       task: {
         type: TaskPayloadKind.SnapshotResume,

--- a/apps/api/src/handlers/tasks/sendMessageToTask.ts
+++ b/apps/api/src/handlers/tasks/sendMessageToTask.ts
@@ -12,7 +12,7 @@ import {
 } from '@roomote/db/server';
 import type {
   AuthTokenContext,
-  CloudTaskPayload,
+  TaskPayload,
   JobTokenContext,
   PullRequestStatus,
 } from '@roomote/types';
@@ -20,7 +20,7 @@ import {
   TaskPayloadKind,
   EXPIRED_SNAPSHOT_RESUME_ERROR,
   isLinkedReviewResultsMessage,
-  isExitedCloudTaskStatus,
+  isExitedRunStatus,
   isSnapshotResumable,
   parseLinkedReviewResults,
   populateSnapshotResumeSlackMetadata,
@@ -467,7 +467,7 @@ async function resumeTaskFromSnapshot({
     source,
   });
   const normalizedClientMessageId = normalizeOptionalString(clientMessageId);
-  const payload: CloudTaskPayload<typeof TaskPayloadKind.SnapshotResume> = {
+  const payload: TaskPayload<typeof TaskPayloadKind.SnapshotResume> = {
     repo: repo ?? '',
     environmentId,
     port: sourceJob.port ?? undefined,
@@ -729,7 +729,7 @@ export async function sendMessageToTask({
       };
     }
 
-    if (isExitedCloudTaskStatus(job.status)) {
+    if (isExitedRunStatus(job.status)) {
       const resumeResult = await resumeTaskFromSnapshot({
         taskId,
         userId: linkedReviewHandoff.senderUserId,
@@ -889,7 +889,7 @@ export async function steerMessageToTask({
 
     const channelBindings = (await getTaskChannelBindings(taskId)) ?? null;
 
-    if (isExitedCloudTaskStatus(job.status)) {
+    if (isExitedRunStatus(job.status)) {
       const resumeResult = await resumeTaskFromSnapshot({
         taskId,
         userId,

--- a/apps/api/src/handlers/tasks/stopTask.ts
+++ b/apps/api/src/handlers/tasks/stopTask.ts
@@ -1,5 +1,5 @@
 import type { Context } from 'hono';
-import { isExitedCloudTaskStatus } from '@roomote/types';
+import { isExitedRunStatus } from '@roomote/types';
 
 import type { Variables } from '../../types';
 import type { McpAuth } from '../mcp/middleware';
@@ -37,7 +37,7 @@ export async function stopTask(
       return c.json({ success: false, error: 'Task not found' }, 404);
     }
 
-    if (isExitedCloudTaskStatus(job.status)) {
+    if (isExitedRunStatus(job.status)) {
       return c.json(
         {
           success: false,

--- a/apps/api/src/handlers/tasks/submitMcpRecommendations.ts
+++ b/apps/api/src/handlers/tasks/submitMcpRecommendations.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'hono';
 import { z } from 'zod';
 
-import { TaskPayloadKind, type CloudTaskPayload } from '@roomote/types';
+import { TaskPayloadKind, type TaskPayload } from '@roomote/types';
 import { normalizeSetupNewState } from '@roomote/types';
 import { Env } from '@roomote/env';
 import { db, eq, taskRuns, tasks } from '@roomote/db/server';
@@ -50,7 +50,7 @@ const ACTIVE_SETUP_TASK_TYPES = new Set<TaskPayloadKind>([
   TaskPayloadKind.SnapshotResume,
 ]);
 
-type McpRecommendationsPayload = CloudTaskPayload<
+type McpRecommendationsPayload = TaskPayload<
   typeof TaskPayloadKind.McpRecommendations
 >;
 

--- a/apps/api/src/handlers/tasks/submitTaskSuggestions.ts
+++ b/apps/api/src/handlers/tasks/submitTaskSuggestions.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import {
   ALL_REPOSITORIES,
-  type CloudTaskPayload,
+  type TaskPayload,
   TaskPayloadKind,
   getScheduledSuggestionBackgroundAutomationDescriptor,
   isBetaBackgroundAutomationKey,
@@ -89,7 +89,7 @@ const submitTaskSuggestionsBodySchema = z.object({
 const SETUP_ONBOARDING_SUGGESTION_METADATA_EVENT_TYPE =
   'roomote.setup_onboarding_suggestion';
 
-type SuggestedTasksPayload = CloudTaskPayload<typeof TaskPayloadKind.Scan>;
+type SuggestedTasksPayload = TaskPayload<typeof TaskPayloadKind.Scan>;
 
 type PersistedTaskSuggestion = {
   id: string;

--- a/apps/api/src/handlers/tasks/task-stop.ts
+++ b/apps/api/src/handlers/tasks/task-stop.ts
@@ -8,11 +8,11 @@ import {
   isNull,
   taskRuns,
 } from '@roomote/db/server';
-import { type CloudTaskStatus, isExitedCloudTaskStatus } from '@roomote/types';
+import { type RunStatus, isExitedRunStatus } from '@roomote/types';
 
 interface StopTaskJob {
   id: number;
-  status: CloudTaskStatus;
+  status: RunStatus;
   sandboxServerUrl: string | null;
   actingUserId: string | null;
 }
@@ -32,7 +32,7 @@ type StopTaskJobResult =
 
 type StopTaskJobResolution =
   | { kind: 'not_found' }
-  | { kind: 'terminal'; status: CloudTaskStatus }
+  | { kind: 'terminal'; status: RunStatus }
   | { kind: 'no_sandbox' }
   | { kind: 'sandbox'; job: StopTaskJob & { sandboxServerUrl: string } };
 
@@ -80,7 +80,7 @@ function createTaskNotFoundResult(): StopTaskJobResult {
   };
 }
 
-function createTaskNotActiveResult(status: CloudTaskStatus): StopTaskJobResult {
+function createTaskNotActiveResult(status: RunStatus): StopTaskJobResult {
   return {
     success: false,
     statusCode: 409,
@@ -101,7 +101,7 @@ function resolveStopTaskJob(job: StopTaskJob | null): StopTaskJobResolution {
     return { kind: 'not_found' };
   }
 
-  if (isExitedCloudTaskStatus(job.status)) {
+  if (isExitedRunStatus(job.status)) {
     return { kind: 'terminal', status: job.status };
   }
 

--- a/apps/api/src/handlers/teams/__tests__/find-active-teams-job.test.ts
+++ b/apps/api/src/handlers/teams/__tests__/find-active-teams-job.test.ts
@@ -60,7 +60,7 @@ vi.mock('@roomote/db/server', () => ({
   })),
 }));
 
-import { activeCloudTaskStatuses } from '@roomote/types';
+import { activeRunStatuses } from '@roomote/types';
 
 import {
   buildTeamsJobMatchConditions,
@@ -201,6 +201,6 @@ describe('findActiveTeamsJob', () => {
     for (const condition of conversationMatch!.or) {
       expect(condition.values).toContain('19:conv@thread.tacv2');
     }
-    expect([...activeCloudTaskStatuses]).toContain('running');
+    expect([...activeRunStatuses]).toContain('running');
   });
 });

--- a/apps/api/src/handlers/teams/__tests__/index.test.ts
+++ b/apps/api/src/handlers/teams/__tests__/index.test.ts
@@ -6,7 +6,7 @@ const {
   authAccountsFindManyMock,
   authUsersFindFirstMock,
   buildTeamsRoutingContextMock,
-  enqueueCloudTaskMock,
+  enqueueTaskMock,
   envMock,
   fetchMessageImageDataUrlsMock,
   findFirstMock,
@@ -37,7 +37,7 @@ const {
   authAccountsFindManyMock: vi.fn(),
   authUsersFindFirstMock: vi.fn(),
   buildTeamsRoutingContextMock: vi.fn(),
-  enqueueCloudTaskMock: vi.fn(),
+  enqueueTaskMock: vi.fn(),
   envMock: {
     TEAMS_BOT_APP_ID: 'bot-app-id' as string | undefined,
     TEAMS_BOT_APP_PASSWORD: 'bot-secret' as string | undefined,
@@ -244,7 +244,7 @@ vi.mock('@roomote/sdk/server', () => ({
 
 vi.mock('@roomote/cloud-agents/server', () => ({
   buildTeamsRoutingContext: buildTeamsRoutingContextMock,
-  enqueueCloudTask: enqueueCloudTaskMock,
+  enqueueTask: enqueueTaskMock,
   getTaskUrl: getTaskUrlMock,
   routeTask: routeTaskMock,
 }));
@@ -335,7 +335,7 @@ describe('Teams webhook handler', () => {
         reasoning: 'all repos',
       },
     });
-    enqueueCloudTaskMock.mockResolvedValue({
+    enqueueTaskMock.mockResolvedValue({
       id: 88,
       taskId: 'task-new',
     });
@@ -478,7 +478,7 @@ describe('Teams webhook handler', () => {
       queued: true,
       cloudJobId: 77,
     });
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(queueCommunicationMessageMock).toHaveBeenCalledWith('teams', 77, {
       provider: 'teams',
       text: 'keep going',
@@ -528,7 +528,7 @@ describe('Teams webhook handler', () => {
     expect(redisSetMock).not.toHaveBeenCalled();
     expect(findFirstMock).not.toHaveBeenCalled();
     expect(queueCommunicationMessageMock).not.toHaveBeenCalled();
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(postMessageMock).not.toHaveBeenCalled();
   });
 
@@ -871,7 +871,7 @@ describe('Teams webhook handler', () => {
         taskDescription: 'continue',
       }),
     );
-    expect(enqueueCloudTaskMock).toHaveBeenCalledWith(
+    expect(enqueueTaskMock).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: 'standard',
@@ -946,7 +946,7 @@ describe('Teams webhook handler', () => {
         images: ['data:image/png;base64,abc123'],
       }),
     );
-    expect(enqueueCloudTaskMock).toHaveBeenCalledWith(
+    expect(enqueueTaskMock).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: 'standard',
@@ -997,7 +997,7 @@ describe('Teams webhook handler', () => {
       started: true,
       cloudJobId: 88,
     });
-    expect(enqueueCloudTaskMock).toHaveBeenCalledWith(
+    expect(enqueueTaskMock).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: 'standard',
@@ -1037,7 +1037,7 @@ describe('Teams webhook handler', () => {
     expect(response.status).toBe(200);
     expect(buildTeamsRoutingContextMock).not.toHaveBeenCalled();
     expect(routeTaskMock).not.toHaveBeenCalled();
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(queueCommunicationMessageMock).not.toHaveBeenCalled();
     expect(findFirstMock).toHaveBeenCalledTimes(1);
     expect(redisSetMock).toHaveBeenCalledWith(
@@ -1162,7 +1162,7 @@ describe('Teams webhook handler', () => {
       1,
       'teams:auth:teams-auth-token-1',
     );
-    expect(enqueueCloudTaskMock).toHaveBeenCalledWith(
+    expect(enqueueTaskMock).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: 'standard',
@@ -1215,7 +1215,7 @@ describe('Teams webhook handler', () => {
     });
     expect(response.status).toBe(409);
     expect(redisEvalMock).not.toHaveBeenCalled();
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(queueCommunicationMessageMock).not.toHaveBeenCalled();
   });
 
@@ -1250,7 +1250,7 @@ describe('Teams webhook handler', () => {
       started: true,
       cloudJobId: 88,
     });
-    const { task } = enqueueCloudTaskMock.mock.calls[0]?.[0] as {
+    const { task } = enqueueTaskMock.mock.calls[0]?.[0] as {
       task: { payload: Record<string, unknown> };
     };
     expect(task.payload).toMatchObject({
@@ -1295,7 +1295,7 @@ describe('Teams webhook handler', () => {
         botAppId: 'bot-app-id',
       }),
     );
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
   });
 
   it('starts a task for an unmentioned thread reply when the unmentioned-reply gate routes it', async () => {
@@ -1335,7 +1335,7 @@ describe('Teams webhook handler', () => {
         }),
       }),
     );
-    expect(enqueueCloudTaskMock).toHaveBeenCalledWith(
+    expect(enqueueTaskMock).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: 'standard',
@@ -1389,7 +1389,7 @@ describe('Teams webhook handler', () => {
       cloudJobId: 88,
     });
     expect(response.status).toBe(200);
-    expect(enqueueCloudTaskMock).toHaveBeenCalledWith(
+    expect(enqueueTaskMock).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: 'snapshot_resume',
@@ -1436,7 +1436,7 @@ describe('Teams webhook handler', () => {
       'teams:resume-lock:19:conversation@thread.v2:activity-root',
       expect.objectContaining({ ttlSeconds: 30 }),
     );
-    expect(enqueueCloudTaskMock).toHaveBeenCalledWith(
+    expect(enqueueTaskMock).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: 'snapshot_resume',
@@ -1501,7 +1501,7 @@ describe('Teams webhook handler', () => {
       cloudJobId: 99,
     });
     expect(response.status).toBe(200);
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(postMessageMock).not.toHaveBeenCalled();
     expect(queueCommunicationMessageMock).toHaveBeenCalledWith(
       'teams',

--- a/apps/api/src/handlers/teams/find-active-teams-job.ts
+++ b/apps/api/src/handlers/teams/find-active-teams-job.ts
@@ -11,8 +11,8 @@ import {
   tasks,
 } from '@roomote/db/server';
 import {
-  CloudTaskStatus,
-  activeCloudTaskStatuses,
+  RunStatus,
+  activeRunStatuses,
   isSnapshotResumable,
 } from '@roomote/types';
 
@@ -129,7 +129,7 @@ export async function findActiveTeamsJob(input: {
         teamsProviderMatch,
         conversationMatch,
         threadMatch,
-        inArray(taskRuns.status, [...activeCloudTaskStatuses]),
+        inArray(taskRuns.status, [...activeRunStatuses]),
         isNull(taskRuns.canceledAt),
       ),
     )
@@ -154,7 +154,7 @@ export async function findCompletedTeamsJobWithSnapshot(input: {
         teamsProviderMatch,
         conversationMatch,
         threadMatch,
-        inArray(taskRuns.status, [CloudTaskStatus.Completed]),
+        inArray(taskRuns.status, [RunStatus.Completed]),
         isNull(taskRuns.canceledAt),
         sql`${taskRuns.snapshotId} IS NOT NULL`,
         sql`${taskRuns.snapshotCreatedAt} IS NOT NULL`,

--- a/apps/api/src/handlers/teams/index.ts
+++ b/apps/api/src/handlers/teams/index.ts
@@ -56,7 +56,7 @@ import {
 } from '@roomote/types';
 import {
   buildTeamsRoutingContext,
-  enqueueCloudTask,
+  enqueueTask,
   getTaskUrl,
   routeTask,
   type RoutingWorkspace,
@@ -994,7 +994,7 @@ async function resumeTeamsTaskFromSnapshot(input: {
 
       // Resumes never create tasks and never re-attribute; the resuming
       // human becomes the new run's acting user.
-      const resumeLaunch = await enqueueCloudTask(
+      const resumeLaunch = await enqueueTask(
         {
           task: {
             type: TaskPayloadKind.SnapshotResume,
@@ -1295,7 +1295,7 @@ async function startNewTeamsTask(input: {
         ...input.metadata,
       },
     };
-  const launchResult = await enqueueCloudTask(
+  const launchResult = await enqueueTask(
     {
       task,
       initiator: { kind: 'user', userId: launchUserId },

--- a/apps/api/src/handlers/teams/index.ts
+++ b/apps/api/src/handlers/teams/index.ts
@@ -46,8 +46,8 @@ import {
 import { getRedis, withContention } from '@roomote/redis';
 import {
   ALL_REPOSITORIES,
-  type CloudTask,
-  type CloudTaskPayload,
+  type TaskSpec,
+  type TaskPayload,
   TaskPayloadKind,
   PRODUCT_NAME,
   type QueuedCommunicationMessage,
@@ -966,16 +966,15 @@ async function resumeTeamsTaskFromSnapshot(input: {
         typeof completedPayload.environmentId === 'string'
           ? completedPayload.environmentId
           : undefined;
-      const resumePayload: CloudTaskPayload<
-        typeof TaskPayloadKind.SnapshotResume
-      > = {
-        repo,
-        ...(environmentId ? { environmentId } : {}),
-        ...(completedJob.port ? { port: completedJob.port } : {}),
-        sourceSnapshotId,
-        sourceCloudJobId: completedJob.id,
-        queuedCommunicationMessages: [queuedMessage],
-      };
+      const resumePayload: TaskPayload<typeof TaskPayloadKind.SnapshotResume> =
+        {
+          repo,
+          ...(environmentId ? { environmentId } : {}),
+          ...(completedJob.port ? { port: completedJob.port } : {}),
+          sourceSnapshotId,
+          sourceCloudJobId: completedJob.id,
+          queuedCommunicationMessages: [queuedMessage],
+        };
 
       populateSnapshotResumeCommunicationMetadata(resumePayload, {
         provider: 'teams',
@@ -1281,23 +1280,21 @@ async function startNewTeamsTask(input: {
     throw new Error('Teams task routing selected an unavailable workspace.');
   }
 
-  const task: Extract<
-    CloudTask,
-    { type: typeof TaskPayloadKind.StandardTask }
-  > = {
-    type: TaskPayloadKind.StandardTask,
-    payload: {
-      repo: workspace.repoForPayload,
-      ...(workspace.environmentId
-        ? { environmentId: workspace.environmentId }
-        : {}),
-      description: input.queuedMessage.text,
-      ...(input.queuedMessage.images?.length
-        ? { images: input.queuedMessage.images }
-        : {}),
-      ...input.metadata,
-    },
-  };
+  const task: Extract<TaskSpec, { type: typeof TaskPayloadKind.StandardTask }> =
+    {
+      type: TaskPayloadKind.StandardTask,
+      payload: {
+        repo: workspace.repoForPayload,
+        ...(workspace.environmentId
+          ? { environmentId: workspace.environmentId }
+          : {}),
+        description: input.queuedMessage.text,
+        ...(input.queuedMessage.images?.length
+          ? { images: input.queuedMessage.images }
+          : {}),
+        ...input.metadata,
+      },
+    };
   const launchResult = await enqueueCloudTask(
     {
       task,

--- a/apps/api/src/handlers/telegram/__tests__/index.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/index.test.ts
@@ -11,7 +11,7 @@ const {
   restoreLinkCodeMock,
   editMessageReplyMarkupMock,
   editMessageTextMock,
-  enqueueCloudTaskMock,
+  enqueueTaskMock,
   environmentsFindFirstMock,
   envMock,
   getAvailableEnvironmentsMock,
@@ -42,7 +42,7 @@ const {
   restoreLinkCodeMock: vi.fn(),
   editMessageReplyMarkupMock: vi.fn(),
   editMessageTextMock: vi.fn(),
-  enqueueCloudTaskMock: vi.fn(),
+  enqueueTaskMock: vi.fn(),
   environmentsFindFirstMock: vi.fn(),
   getAvailableEnvironmentsMock: vi.fn(),
   envMock: {
@@ -253,7 +253,7 @@ vi.mock('../../tasks/task-stop.js', () => ({
 
 vi.mock('@roomote/cloud-agents/server', () => ({
   buildTelegramRoutingContext: buildTelegramRoutingContextMock,
-  enqueueCloudTask: enqueueCloudTaskMock,
+  enqueueTask: enqueueTaskMock,
   getAvailableEnvironments: getAvailableEnvironmentsMock,
   getTaskUrl: getTaskUrlMock,
   routeTask: routeTaskMock,
@@ -368,7 +368,7 @@ describe('Telegram webhook handler', () => {
         reasoning: 'all repos',
       },
     });
-    enqueueCloudTaskMock.mockResolvedValue({
+    enqueueTaskMock.mockResolvedValue({
       id: 88,
       taskId: 'task-new',
     });
@@ -393,7 +393,7 @@ describe('Telegram webhook handler', () => {
     );
     expect(cloudJobsFindFirstMock).not.toHaveBeenCalled();
     expect(queueCommunicationMessageMock).not.toHaveBeenCalled();
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(postMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
         channelId: '222',
@@ -419,7 +419,7 @@ describe('Telegram webhook handler', () => {
       queued: false,
       reason: 'telegram_sender_not_linked',
     });
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(routeTaskMock).not.toHaveBeenCalled();
     expect(postMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -468,7 +468,7 @@ describe('Telegram webhook handler', () => {
       queued: false,
       reason: 'telegram_sender_not_linked',
     });
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(postMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
         buttons: [
@@ -504,7 +504,7 @@ describe('Telegram webhook handler', () => {
       reason: 'telegram_sender_not_linked',
     });
     expect(postMessageMock).not.toHaveBeenCalled();
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
   });
 
   it('silently ignores unaddressed group messages from unlinked senders', async () => {
@@ -523,7 +523,7 @@ describe('Telegram webhook handler', () => {
       reason: 'telegram_sender_not_linked',
     });
     expect(postMessageMock).not.toHaveBeenCalled();
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(queueCommunicationMessageMock).not.toHaveBeenCalled();
   });
 
@@ -541,7 +541,7 @@ describe('Telegram webhook handler', () => {
       ok: true,
       linkNudged: true,
     });
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(routeTaskMock).not.toHaveBeenCalled();
     expect(postMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -634,7 +634,7 @@ describe('Telegram webhook handler', () => {
         taskDescription: 'please check this',
       }),
     );
-    expect(enqueueCloudTaskMock).toHaveBeenCalledWith(
+    expect(enqueueTaskMock).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: 'standard',
@@ -707,7 +707,7 @@ describe('Telegram webhook handler', () => {
       repliedInline: true,
     });
     expect(response.status).toBe(200);
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(postMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
         channelId: '222',
@@ -734,7 +734,7 @@ describe('Telegram webhook handler', () => {
       snapshotId: 'snapshot-1',
       snapshotCreatedAt: new Date(),
     });
-    enqueueCloudTaskMock.mockResolvedValueOnce({
+    enqueueTaskMock.mockResolvedValueOnce({
       id: 99,
       taskId: 'task-resumed',
     });
@@ -757,7 +757,7 @@ describe('Telegram webhook handler', () => {
       cloudJobId: 99,
     });
     expect(response.status).toBe(200);
-    expect(enqueueCloudTaskMock).toHaveBeenCalledWith(
+    expect(enqueueTaskMock).toHaveBeenCalledWith(
       expect.objectContaining({
         actingUserId: 'launch-owner-4',
         task: expect.objectContaining({
@@ -829,7 +829,7 @@ describe('Telegram webhook handler', () => {
     });
     expect(response.status).toBe(200);
     // A fresh StandardTask is enqueued, not a snapshot.resume.
-    expect(enqueueCloudTaskMock).toHaveBeenCalledWith(
+    expect(enqueueTaskMock).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: 'standard',
@@ -868,7 +868,7 @@ describe('Telegram webhook handler', () => {
       started: true,
       cloudJobId: 88,
     });
-    expect(enqueueCloudTaskMock).toHaveBeenCalledWith(
+    expect(enqueueTaskMock).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: 'standard',
@@ -898,7 +898,7 @@ describe('Telegram webhook handler', () => {
       queued: false,
       repliedInline: true,
     });
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(routeTaskMock).not.toHaveBeenCalled();
     expect(postMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -933,7 +933,7 @@ describe('Telegram webhook handler', () => {
       queued: false,
       repliedInline: true,
     });
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(routeTaskMock).not.toHaveBeenCalled();
     expect(queueCommunicationMessageMock).not.toHaveBeenCalled();
     expect(postMessageMock).toHaveBeenCalledWith(
@@ -1010,7 +1010,7 @@ describe('Telegram webhook handler', () => {
         text: 'ping me when you are /done with the build',
       }),
     );
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
   });
 
   it('starts a fresh task for a mention-prefixed /new in a group', async () => {
@@ -1035,7 +1035,7 @@ describe('Telegram webhook handler', () => {
       started: true,
       cloudJobId: 88,
     });
-    expect(enqueueCloudTaskMock).toHaveBeenCalledWith(
+    expect(enqueueTaskMock).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: 'standard',
@@ -1064,7 +1064,7 @@ describe('Telegram webhook handler', () => {
       ok: true,
       welcomed: true,
     });
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(queueCommunicationMessageMock).not.toHaveBeenCalled();
     expect(postMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1090,7 +1090,7 @@ describe('Telegram webhook handler', () => {
       welcomed: true,
     });
     expect(response.status).toBe(200);
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(queueCommunicationMessageMock).not.toHaveBeenCalled();
     // An unlinked sender has no user to attribute the primary chat capture
     // to yet, so nothing should be persisted.
@@ -1192,7 +1192,7 @@ describe('Telegram webhook handler', () => {
     });
 
     expect(response.status).toBe(200);
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(answerCallbackQueryMock).toHaveBeenCalledWith(
       expect.objectContaining({
         callbackQueryId: 'cb-6',
@@ -1214,7 +1214,7 @@ describe('Telegram webhook handler', () => {
       ok: true,
       linked: true,
     });
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     // Mapping upsert + primary chat capture both insert.
     expect(insertValuesMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1270,7 +1270,7 @@ describe('Telegram webhook handler', () => {
         text: expect.stringContaining('invalid or has expired'),
       }),
     );
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
   });
 
   it('restores the link code when storing the mapping fails', async () => {
@@ -1365,7 +1365,7 @@ describe('Telegram webhook handler', () => {
       reason: 'telegram_sender_not_linked',
     });
     expect(queueCommunicationMessageMock).not.toHaveBeenCalled();
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(telegramMappingsFindFirstMock).toHaveBeenCalledTimes(1);
     expect(usersFindFirstMock).toHaveBeenCalledTimes(1);
     expect(authUsersFindFirstMock).not.toHaveBeenCalled();
@@ -1561,7 +1561,7 @@ describe('Telegram webhook handler', () => {
       queued: false,
       confirmationPending: true,
     });
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(postMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
         channelId: '222',
@@ -1609,7 +1609,7 @@ describe('Telegram webhook handler', () => {
       queued: false,
       confirmationPending: true,
     });
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(postMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
         text: expect.stringContaining('could not confidently pick a workspace'),
@@ -1651,7 +1651,7 @@ describe('Telegram webhook handler', () => {
       started: true,
       cloudJobId: 88,
     });
-    expect(enqueueCloudTaskMock).toHaveBeenCalledWith(
+    expect(enqueueTaskMock).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           payload: expect.objectContaining({
@@ -1721,7 +1721,7 @@ describe('Telegram webhook handler', () => {
     expect(redisGetdelMock).toHaveBeenCalledWith(
       'telegram:pending_route:abc123XYZ789',
     );
-    expect(enqueueCloudTaskMock).toHaveBeenCalledWith(
+    expect(enqueueTaskMock).toHaveBeenCalledWith(
       expect.objectContaining({
         initiator: { kind: 'user', userId: 'launch-owner-23' },
         task: expect.objectContaining({
@@ -1794,7 +1794,7 @@ describe('Telegram webhook handler', () => {
     });
 
     expect(response.status).toBe(200);
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     // Same message becomes the picker, keyed by a fresh pending-route id so
     // the old auto-confirm timer can never fire the suggestion.
     expect(editMessageTextMock).toHaveBeenCalledWith(
@@ -1882,7 +1882,7 @@ describe('Telegram webhook handler', () => {
     expect(redisGetdelMock).not.toHaveBeenCalledWith(
       'telegram:pending_route:abc123XYZ789',
     );
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(answerCallbackQueryMock).toHaveBeenCalledWith(
       expect.objectContaining({
         callbackQueryId: 'cb-11',
@@ -1908,7 +1908,7 @@ describe('Telegram webhook handler', () => {
     });
 
     expect(response.status).toBe(200);
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(answerCallbackQueryMock).toHaveBeenCalledWith(
       expect.objectContaining({
         callbackQueryId: 'cb-12',
@@ -1959,7 +1959,7 @@ describe('Telegram webhook handler', () => {
     });
 
     expect(response.status).toBe(200);
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(answerCallbackQueryMock).toHaveBeenCalledWith(
       expect.objectContaining({
         callbackQueryId: 'cb-13',

--- a/apps/api/src/handlers/telegram/callback-actions.ts
+++ b/apps/api/src/handlers/telegram/callback-actions.ts
@@ -1,5 +1,5 @@
 import type { TelegramCallbackQuery } from '@roomote/communication/telegram-update';
-import { activeCloudTaskStatuses } from '@roomote/types';
+import { activeRunStatuses } from '@roomote/types';
 import {
   and,
   db,
@@ -41,7 +41,7 @@ async function findCancelableCloudJob(cloudJobId: number, chatId: string) {
       // inbound message path is chat-scoped the same way.
       sql`${taskRuns.payload}->>'communicationProvider' = 'telegram'`,
       sql`${taskRuns.payload}->>'communicationChannelId' = ${chatId}`,
-      inArray(taskRuns.status, [...activeCloudTaskStatuses]),
+      inArray(taskRuns.status, [...activeRunStatuses]),
       isNull(taskRuns.canceledAt),
     ),
     columns: {

--- a/apps/api/src/handlers/telegram/job-lookup.ts
+++ b/apps/api/src/handlers/telegram/job-lookup.ts
@@ -1,6 +1,6 @@
 import {
-  CloudTaskStatus,
-  activeCloudTaskStatuses,
+  RunStatus,
+  activeRunStatuses,
   isSnapshotResumable,
 } from '@roomote/types';
 import {
@@ -81,7 +81,7 @@ export async function findActiveTelegramJob(input: TelegramConversationRef) {
         telegramProviderMatch,
         conversationMatch,
         threadMatch,
-        inArray(taskRuns.status, [...activeCloudTaskStatuses]),
+        inArray(taskRuns.status, [...activeRunStatuses]),
         isNull(taskRuns.canceledAt),
       ),
     )
@@ -105,7 +105,7 @@ export async function findCompletedTelegramJobWithSnapshot(
         telegramProviderMatch,
         conversationMatch,
         threadMatch,
-        inArray(taskRuns.status, [CloudTaskStatus.Completed]),
+        inArray(taskRuns.status, [RunStatus.Completed]),
         isNull(taskRuns.canceledAt),
         sql`${taskRuns.snapshotId} IS NOT NULL`,
         sql`${taskRuns.snapshotCreatedAt} IS NOT NULL`,

--- a/apps/api/src/handlers/telegram/task-launch.ts
+++ b/apps/api/src/handlers/telegram/task-launch.ts
@@ -2,7 +2,7 @@ import type { TelegramUpdateCommunicationMetadata } from '@roomote/communication
 import {
   ALL_REPOSITORIES,
   TaskPayloadKind,
-  type CloudTask,
+  type TaskSpec,
 } from '@roomote/types';
 import { db, environments, eq } from '@roomote/db/server';
 import {
@@ -65,20 +65,18 @@ export async function launchTelegramTask(input: {
   metadata: TelegramUpdateCommunicationMetadata;
   workspace: TelegramWorkspaceSelection;
 }) {
-  const task: Extract<
-    CloudTask,
-    { type: typeof TaskPayloadKind.StandardTask }
-  > = {
-    type: TaskPayloadKind.StandardTask,
-    payload: {
-      repo: input.workspace.repoForPayload,
-      ...(input.workspace.environmentId
-        ? { environmentId: input.workspace.environmentId }
-        : {}),
-      description: input.queuedMessage.text,
-      ...input.metadata,
-    },
-  };
+  const task: Extract<TaskSpec, { type: typeof TaskPayloadKind.StandardTask }> =
+    {
+      type: TaskPayloadKind.StandardTask,
+      payload: {
+        repo: input.workspace.repoForPayload,
+        ...(input.workspace.environmentId
+          ? { environmentId: input.workspace.environmentId }
+          : {}),
+        description: input.queuedMessage.text,
+        ...input.metadata,
+      },
+    };
   const launchResult = await enqueueCloudTask(
     {
       task,

--- a/apps/api/src/handlers/telegram/task-launch.ts
+++ b/apps/api/src/handlers/telegram/task-launch.ts
@@ -6,7 +6,7 @@ import {
 } from '@roomote/types';
 import { db, environments, eq } from '@roomote/db/server';
 import {
-  enqueueCloudTask,
+  enqueueTask,
   getTaskUrl,
   type RoutingWorkspace,
 } from '@roomote/cloud-agents/server';
@@ -77,7 +77,7 @@ export async function launchTelegramTask(input: {
         ...input.metadata,
       },
     };
-  const launchResult = await enqueueCloudTask(
+  const launchResult = await enqueueTask(
     {
       task,
       initiator: { kind: 'user', userId: input.launchOwnerUserId },

--- a/apps/api/src/handlers/telegram/task-orchestration.ts
+++ b/apps/api/src/handlers/telegram/task-orchestration.ts
@@ -12,7 +12,7 @@ import {
 } from '@roomote/types';
 import {
   buildTelegramRoutingContext,
-  enqueueCloudTask,
+  enqueueTask,
   getTaskUrl,
   routeTask,
 } from '@roomote/cloud-agents/server';
@@ -75,7 +75,7 @@ export async function resumeTelegramTaskFromSnapshot(input: {
 
   // Resumes never create tasks and never re-attribute; the resuming human
   // becomes the new run's acting user.
-  return enqueueCloudTask(
+  return enqueueTask(
     {
       task: {
         type: TaskPayloadKind.SnapshotResume,

--- a/apps/api/src/handlers/telegram/task-orchestration.ts
+++ b/apps/api/src/handlers/telegram/task-orchestration.ts
@@ -6,7 +6,7 @@ import { Env } from '@roomote/env';
 import {
   ALL_REPOSITORIES,
   TaskPayloadKind,
-  type CloudTaskPayload,
+  type TaskPayload,
   populateSnapshotResumeCommunicationMetadata,
   restoreSnapshotResumeVisiblePromptFields,
 } from '@roomote/types';
@@ -55,15 +55,14 @@ export async function resumeTelegramTaskFromSnapshot(input: {
     typeof completedPayload.environmentId === 'string'
       ? completedPayload.environmentId
       : undefined;
-  const resumePayload: CloudTaskPayload<typeof TaskPayloadKind.SnapshotResume> =
-    {
-      repo,
-      ...(environmentId ? { environmentId } : {}),
-      ...(input.completedJob.port ? { port: input.completedJob.port } : {}),
-      sourceSnapshotId,
-      sourceCloudJobId: input.completedJob.id,
-      queuedCommunicationMessages: [input.queuedMessage],
-    };
+  const resumePayload: TaskPayload<typeof TaskPayloadKind.SnapshotResume> = {
+    repo,
+    ...(environmentId ? { environmentId } : {}),
+    ...(input.completedJob.port ? { port: input.completedJob.port } : {}),
+    sourceSnapshotId,
+    sourceCloudJobId: input.completedJob.id,
+    queuedCommunicationMessages: [input.queuedMessage],
+  };
 
   populateSnapshotResumeCommunicationMetadata(resumePayload, {
     provider: 'telegram',

--- a/apps/bullmq/src/jobs/pr-review-notification.test.ts
+++ b/apps/bullmq/src/jobs/pr-review-notification.test.ts
@@ -97,7 +97,7 @@ vi.mock('@roomote/communication/telegram-provider', () => ({
 
 import type { Job } from 'bullmq';
 
-import { CloudTaskStatus } from '@roomote/types';
+import { RunStatus } from '@roomote/types';
 
 import { prReviewNotificationJob } from './pr-review-notification';
 
@@ -125,7 +125,7 @@ describe('prReviewNotificationJob', () => {
       payload: { channel: 'C123' },
       slackThreadTs: '111.222',
       sourceCloudJobId: null,
-      status: CloudTaskStatus.Idle,
+      status: RunStatus.Idle,
       taskPhase: 'waiting_for_prompt',
     });
     mockFindFirstTaskPullRequest.mockResolvedValue({ status: 'open' });
@@ -249,7 +249,7 @@ describe('prReviewNotificationJob', () => {
       payload: {},
       slackThreadTs: '111.222',
       sourceCloudJobId: null,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
     });
 
@@ -269,7 +269,7 @@ describe('prReviewNotificationJob', () => {
       payload: {},
       slackThreadTs: '111.222',
       sourceCloudJobId: null,
-      status: CloudTaskStatus.Idle,
+      status: RunStatus.Idle,
       taskPhase: 'running',
     });
 
@@ -289,7 +289,7 @@ describe('prReviewNotificationJob', () => {
       payload: {},
       slackThreadTs: '111.222',
       sourceCloudJobId: null,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
     });
 

--- a/apps/bullmq/src/jobs/pr-review-notification.ts
+++ b/apps/bullmq/src/jobs/pr-review-notification.ts
@@ -25,7 +25,7 @@ import {
   schedulePrReviewNotificationJob,
 } from '@roomote/sdk/server';
 import { SlackNotifier } from '@roomote/slack';
-import { isCloudTaskExecutingTurn } from '@roomote/types';
+import { isTaskExecutingTurn } from '@roomote/types';
 
 type PrReviewNotificationJob = Job<PrReviewNotificationRequest, void, string>;
 
@@ -172,7 +172,7 @@ export const prReviewNotificationJob = async (
   // the task is actively working, and once the deferral cap is reached (the
   // task has effectively been running for the whole pending-events window),
   // drop the pending feedback instead of posting mid-run.
-  if (isCloudTaskExecutingTurn(latestJob.status, latestJob.taskPhase)) {
+  if (isTaskExecutingTurn(latestJob.status, latestJob.taskPhase)) {
     if (data.deferrals < PR_REVIEW_NOTIFICATION_MAX_DEFERRALS) {
       await schedulePrReviewNotificationJob({
         request: { ...data, deferrals: data.deferrals + 1 },

--- a/apps/bullmq/src/jobs/snapshot.test.ts
+++ b/apps/bullmq/src/jobs/snapshot.test.ts
@@ -2,7 +2,7 @@ import { UnrecoverableError } from 'bullmq';
 import type { Mock } from 'vitest';
 
 import {
-  CloudTaskStatus,
+  RunStatus,
   TaskPayloadKind,
   withCompleteTaskOnSnapshot,
 } from '@roomote/types';
@@ -157,7 +157,7 @@ const baseCloudJob = {
   id: 123,
   taskId: 'task_snapshot_events',
   vendor: 'modal',
-  status: CloudTaskStatus.Idle,
+  status: RunStatus.Idle,
   taskPhase: 'waiting_for_prompt',
   sleepAt: new Date('2026-04-02T21:34:02.798Z'),
   payload: { environmentId: 'env-1' },
@@ -285,7 +285,7 @@ describe('snapshotJob', () => {
       expect.objectContaining({
         snapshotId: 'snap_success_1',
         snapshotFailedAt: null,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       }),
     );
     expect(mockRecordComputeProviderUsage).toHaveBeenCalledWith({
@@ -365,7 +365,7 @@ describe('snapshotJob', () => {
       expect.objectContaining({
         snapshotId: 'snap_stale_after_edit',
         snapshotFailedAt: null,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       }),
     );
   });
@@ -640,7 +640,7 @@ describe('snapshotJob', () => {
       expect.objectContaining({
         snapshotId: 'snap_retry_success',
         snapshotFailedAt: null,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       }),
     );
     expect(mockRecordCloudJobEvent).toHaveBeenCalledWith(
@@ -947,7 +947,7 @@ describe('snapshotJob', () => {
       expect.objectContaining({
         snapshotId: 'snap_recovered_after_retry',
         snapshotFailedAt: null,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       }),
     );
     expect(mockUpdatePendingEnvironmentSnapshot).not.toHaveBeenCalled();
@@ -1091,7 +1091,7 @@ describe('snapshotJob', () => {
       expect.objectContaining({
         snapshotId: 'snap_recovered',
         snapshotFailedAt: null,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       }),
     );
     expect(mockUpdatePendingEnvironmentSnapshot).not.toHaveBeenCalled();

--- a/apps/bullmq/src/jobs/snapshot.ts
+++ b/apps/bullmq/src/jobs/snapshot.ts
@@ -1,7 +1,7 @@
 import { Job, UnrecoverableError } from 'bullmq';
 
 import {
-  CloudTaskStatus,
+  RunStatus,
   TaskPayloadKind,
   extractErrorDetails,
   isObservedTimeoutError,
@@ -555,7 +555,7 @@ export const snapshotJob = async (job: SnapshotJob): Promise<void> => {
         snapshotFailedAt: null,
         sleepAt: null,
         taskPhase: null,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
         completedAt: now,
       })
       .where(eq(taskRuns.id, cloudJobId));

--- a/apps/bullmq/src/jobs/snapshot.ts
+++ b/apps/bullmq/src/jobs/snapshot.ts
@@ -11,7 +11,7 @@ import {
   withoutCompleteTaskOnSnapshot,
 } from '@roomote/types';
 import {
-  type CloudJob,
+  type Run,
   and,
   buildPendingEnvironmentSnapshotMatchForCloudJob,
   createComputeProviderMutationEventRecorder,
@@ -198,7 +198,7 @@ export const snapshotJob = async (job: SnapshotJob): Promise<void> => {
   const shouldCompleteTask = shouldCompleteTaskOnSnapshot(cloudJob.payload);
   const clearedCompletionPayload = withoutCompleteTaskOnSnapshot(
     cloudJob.payload,
-  ) as CloudJob['payload'];
+  ) as Run['payload'];
 
   await recordSnapshotQueueEvent(cloudJob, {
     eventType: 'decision',
@@ -733,7 +733,7 @@ export const snapshotJob = async (job: SnapshotJob): Promise<void> => {
 };
 
 async function recordSnapshotQueueEvent(
-  cloudJob: CloudJob,
+  cloudJob: Run,
   input: {
     eventType: 'started' | 'decision' | 'completed' | 'failed';
     message: string;
@@ -763,7 +763,7 @@ function getQueueMaxAttempts(job: SnapshotJob): number {
 }
 
 async function reconcileSnapshottingFailure(input: {
-  cloudJob: CloudJob;
+  cloudJob: Run;
   client: ComputeProviderClient;
   errorDetails: Record<string, unknown>;
   instanceId: string;
@@ -790,7 +790,7 @@ async function reconcileSnapshottingFailure(input: {
 }
 
 async function reconcileSnapshotAfterRetryStatusChange(input: {
-  cloudJob: CloudJob;
+  cloudJob: Run;
   client: ComputeProviderClient;
   instanceId: string;
   instanceStatus: string;
@@ -827,7 +827,7 @@ async function reconcileSnapshotAfterRetryStatusChange(input: {
 
 async function findSnapshotBySourceInstanceWithReconcile(
   input: {
-    cloudJob: CloudJob;
+    cloudJob: Run;
     client: ComputeProviderClient;
     instanceId: string;
     postFailureInstanceStatus: string | null;

--- a/apps/bullmq/src/scheduled-jobs/__tests__/sleep-check.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/sleep-check.test.ts
@@ -8,7 +8,7 @@ const {
   mockDestroyInstance,
   mockGetInstanceStatus,
   mockCreateSnapshot,
-  mockFinishCloudJob,
+  mockFinishRun,
   mockRecordComputeProviderUsage,
   mockRecordMutation,
   mockCreateComputeProviderMutationEventRecorder,
@@ -70,7 +70,7 @@ const {
     mockDestroyInstance: vi.fn() as AnyMock,
     mockGetInstanceStatus: vi.fn() as AnyMock,
     mockCreateSnapshot: vi.fn() as AnyMock,
-    mockFinishCloudJob: vi.fn() as AnyMock,
+    mockFinishRun: vi.fn() as AnyMock,
     mockRecordComputeProviderUsage: vi.fn() as AnyMock,
     mockRecordMutation: vi.fn() as AnyMock,
     mockCreateComputeProviderMutationEventRecorder: vi.fn() as AnyMock,
@@ -109,7 +109,7 @@ vi.mock('@roomote/compute-providers', () => ({
 
 vi.mock('@roomote/sdk/server', () => ({
   createSnapshot: mockCreateSnapshot,
-  finishCloudJob: mockFinishCloudJob,
+  finishRun: mockFinishRun,
   recordComputeProviderUsage: mockRecordComputeProviderUsage,
 }));
 
@@ -243,7 +243,7 @@ describe('sleepCheckJob', () => {
       return result;
     });
     returningFn.mockResolvedValue([]);
-    mockFinishCloudJob.mockResolvedValue(undefined);
+    mockFinishRun.mockResolvedValue(undefined);
     // No stop request persisted on the row unless a test opts in.
     mockDbQueryTaskRunsFindFirst.mockResolvedValue(undefined);
   });
@@ -356,7 +356,7 @@ describe('sleepCheckJob', () => {
       sleepRequestedAt: expect.any(Date),
       snapshotFailedAt: expect.any(Date),
     });
-    expect(mockFinishCloudJob).toHaveBeenCalledWith({
+    expect(mockFinishRun).toHaveBeenCalledWith({
       id: 42,
       status: RunStatus.Completed,
       error: 'Auto-snapshot could not run because instance sb-1 was stopped.',
@@ -385,7 +385,7 @@ describe('sleepCheckJob', () => {
 
     await sleepCheckJob();
 
-    expect(mockFinishCloudJob).not.toHaveBeenCalled();
+    expect(mockFinishRun).not.toHaveBeenCalled();
     expect(mockRecordCloudJobEvent).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -877,7 +877,7 @@ describe('sleepCheckJob', () => {
         triggerPath: 'booting_no_heartbeat',
       }),
     );
-    expect(mockFinishCloudJob).not.toHaveBeenCalled();
+    expect(mockFinishRun).not.toHaveBeenCalled();
   });
 
   it('snapshots stale resumable jobs whose worker heartbeat stopped updating', async () => {
@@ -914,7 +914,7 @@ describe('sleepCheckJob', () => {
         triggerPath: 'stale_worker',
       }),
     );
-    expect(mockFinishCloudJob).not.toHaveBeenCalled();
+    expect(mockFinishRun).not.toHaveBeenCalled();
   });
 
   it('fails booting jobs when the initial heartbeat never arrives and the sandbox is already gone', async () => {
@@ -939,7 +939,7 @@ describe('sleepCheckJob', () => {
     await sleepCheckJob();
 
     expect(mockCreateSnapshot).not.toHaveBeenCalled();
-    expect(mockFinishCloudJob).toHaveBeenCalledWith({
+    expect(mockFinishRun).toHaveBeenCalledWith({
       id: 95,
       status: RunStatus.Failed,
       error:
@@ -1077,7 +1077,7 @@ describe('sleepCheckJob', () => {
     await sleepCheckJob();
 
     expect(mockCreateSnapshot).not.toHaveBeenCalled();
-    expect(mockFinishCloudJob).toHaveBeenCalledWith({
+    expect(mockFinishRun).toHaveBeenCalledWith({
       id: 91,
       status: RunStatus.Failed,
       error: 'Worker heartbeat stale and instance sb-gone is stopped',
@@ -1133,7 +1133,7 @@ describe('sleepCheckJob', () => {
     await sleepCheckJob();
 
     expect(mockCreateSnapshot).not.toHaveBeenCalled();
-    expect(mockFinishCloudJob).toHaveBeenCalledWith({
+    expect(mockFinishRun).toHaveBeenCalledWith({
       id: 101,
       status: RunStatus.Canceled,
       error:
@@ -1171,7 +1171,7 @@ describe('sleepCheckJob', () => {
     await sleepCheckJob();
 
     expect(mockCreateSnapshot).not.toHaveBeenCalled();
-    expect(mockFinishCloudJob).not.toHaveBeenCalled();
+    expect(mockFinishRun).not.toHaveBeenCalled();
     expect(mockRecordCloudJobEvent).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -1210,7 +1210,7 @@ describe('sleepCheckJob', () => {
     await sleepCheckJob();
 
     expect(mockCreateSnapshot).not.toHaveBeenCalled();
-    expect(mockFinishCloudJob).not.toHaveBeenCalled();
+    expect(mockFinishRun).not.toHaveBeenCalled();
     expect(mockRecordCloudJobEvent).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -1257,7 +1257,7 @@ describe('sleepCheckJob', () => {
     expect(mockDestroyInstance).toHaveBeenCalledWith({
       instanceId: 'sb-non-resumable-stale',
     });
-    expect(mockFinishCloudJob).toHaveBeenCalledWith({
+    expect(mockFinishRun).toHaveBeenCalledWith({
       id: 92,
       status: RunStatus.Failed,
       error: 'Worker heartbeat stale for instance sb-non-resumable-stale',
@@ -1343,7 +1343,7 @@ describe('sleepCheckJob', () => {
     expect(mockDestroyInstance).toHaveBeenCalledWith({
       instanceId: 'sb-non-resumable-stopped',
     });
-    expect(mockFinishCloudJob).toHaveBeenCalledWith({
+    expect(mockFinishRun).toHaveBeenCalledWith({
       id: 102,
       status: RunStatus.Canceled,
       error: 'Worker heartbeat stale for instance sb-non-resumable-stopped',
@@ -1393,7 +1393,7 @@ describe('sleepCheckJob', () => {
     expect(mockDestroyInstance).toHaveBeenCalledWith({
       instanceId: 'sb-non-resumable-booting',
     });
-    expect(mockFinishCloudJob).toHaveBeenCalledWith({
+    expect(mockFinishRun).toHaveBeenCalledWith({
       id: 98,
       status: RunStatus.Failed,
       error:

--- a/apps/bullmq/src/scheduled-jobs/__tests__/sleep-check.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/sleep-check.test.ts
@@ -1,5 +1,5 @@
 import type { Mock } from 'vitest';
-import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
 
 // Hoist ALL mock functions so they're available inside vi.mock factories.
 const {
@@ -311,19 +311,19 @@ describe('sleepCheckJob', () => {
 
     // dueJobs query uses inArray with two statuses
     expect(inArrayFn).toHaveBeenCalledWith('status', [
-      CloudTaskStatus.Running,
-      CloudTaskStatus.Idle,
+      RunStatus.Running,
+      RunStatus.Idle,
     ]);
     // staleWorkerJobs query also uses inArray so idle jobs are recovered.
     expect(inArrayFn).toHaveBeenCalledWith('status', [
-      CloudTaskStatus.Running,
-      CloudTaskStatus.Idle,
+      RunStatus.Running,
+      RunStatus.Idle,
     ]);
     expect(inArrayFn).toHaveBeenCalledWith('status', [
-      CloudTaskStatus.Processing,
-      CloudTaskStatus.Preparing,
-      CloudTaskStatus.Spawning,
-      CloudTaskStatus.Connecting,
+      RunStatus.Processing,
+      RunStatus.Preparing,
+      RunStatus.Spawning,
+      RunStatus.Connecting,
     ]);
   });
 
@@ -334,7 +334,7 @@ describe('sleepCheckJob', () => {
           id: 42,
           machineId: 'sb-1',
           payloadKind: TaskPayloadKind.StandardTask,
-          status: CloudTaskStatus.Idle,
+          status: RunStatus.Idle,
           vendor: 'modal',
           snapshotId: null,
           sleepRequestedAt: null,
@@ -358,7 +358,7 @@ describe('sleepCheckJob', () => {
     });
     expect(mockFinishCloudJob).toHaveBeenCalledWith({
       id: 42,
-      status: CloudTaskStatus.Completed,
+      status: RunStatus.Completed,
       error: 'Auto-snapshot could not run because instance sb-1 was stopped.',
     });
     expect(mockRecordCloudJobEvent).toHaveBeenCalled();
@@ -372,7 +372,7 @@ describe('sleepCheckJob', () => {
           id: 42,
           machineId: 'sb-1',
           payloadKind: TaskPayloadKind.StandardTask,
-          status: CloudTaskStatus.Idle,
+          status: RunStatus.Idle,
           vendor: 'modal',
           snapshotId: null,
           sleepRequestedAt: null,
@@ -401,7 +401,7 @@ describe('sleepCheckJob', () => {
       id: 6622,
       machineId: 'sb-resume',
       payloadKind: TaskPayloadKind.SlackAppMention,
-      status: CloudTaskStatus.Idle,
+      status: RunStatus.Idle,
       taskPhase: 'waiting_for_prompt',
       vendor: 'modal',
       snapshotId: null,
@@ -438,7 +438,7 @@ describe('sleepCheckJob', () => {
       id: 6624,
       machineId: 'sb-hard-limit',
       payloadKind: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'waiting_for_prompt',
       vendor: 'modal',
       snapshotId: null,
@@ -486,7 +486,7 @@ describe('sleepCheckJob', () => {
       id: 6623,
       machineId: 'sb-snapshot-resume',
       payloadKind: TaskPayloadKind.SnapshotResume,
-      status: CloudTaskStatus.Idle,
+      status: RunStatus.Idle,
       taskPhase: 'waiting_for_prompt',
       vendor: 'modal',
       snapshotId: null,
@@ -519,7 +519,7 @@ describe('sleepCheckJob', () => {
       id: 6625,
       machineId: 'modal-resume',
       payloadKind: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Idle,
+      status: RunStatus.Idle,
       taskPhase: 'waiting_for_prompt',
       vendor: 'modal',
       snapshotId: null,
@@ -556,7 +556,7 @@ describe('sleepCheckJob', () => {
       id: 99,
       machineId: 'sb-2',
       payloadKind: TaskPayloadKind.GithubPrReview,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'waiting_for_prompt',
       vendor: 'modal',
       snapshotId: null,
@@ -590,7 +590,7 @@ describe('sleepCheckJob', () => {
     expect(setFn).toHaveBeenNthCalledWith(2, {
       sleepAt: null,
       taskPhase: null,
-      status: CloudTaskStatus.Completed,
+      status: RunStatus.Completed,
       completedAt: expect.any(Date),
     });
     expect(mockRecordComputeProviderUsage).toHaveBeenCalledWith({
@@ -613,7 +613,7 @@ describe('sleepCheckJob', () => {
       id: 100,
       machineId: 'sb-hard-limit-destroy',
       payloadKind: TaskPayloadKind.GithubPrReview,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'waiting_for_prompt',
       vendor: 'modal',
       snapshotId: null,
@@ -656,7 +656,7 @@ describe('sleepCheckJob', () => {
       id: 77,
       machineId: 'sb-rollback',
       payloadKind: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'waiting_for_prompt',
       vendor: 'modal',
       snapshotId: null,
@@ -682,7 +682,7 @@ describe('sleepCheckJob', () => {
       id: 77,
       machineId: 'sb-rollback',
       payloadKind: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'waiting_for_prompt',
       vendor: 'modal',
       snapshotId: null,
@@ -715,7 +715,7 @@ describe('sleepCheckJob', () => {
         id: 10,
         machineId: 'sb-3',
         payloadKind: TaskPayloadKind.StandardTask,
-        status: CloudTaskStatus.Running,
+        status: RunStatus.Running,
         taskPhase: 'waiting_for_prompt',
         vendor: 'modal',
         snapshotId: null,
@@ -726,7 +726,7 @@ describe('sleepCheckJob', () => {
         id: 11,
         machineId: 'sb-4',
         payloadKind: TaskPayloadKind.StandardTask,
-        status: CloudTaskStatus.Running,
+        status: RunStatus.Running,
         taskPhase: 'waiting_for_prompt',
         vendor: 'modal',
         snapshotId: null,
@@ -760,7 +760,7 @@ describe('sleepCheckJob', () => {
       id: 85,
       machineId: 'sb-stale-running',
       payloadKind: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       vendor: 'modal',
       snapshotId: null,
@@ -789,7 +789,7 @@ describe('sleepCheckJob', () => {
       id: 87,
       machineId: 'sb-stale-waiting',
       payloadKind: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'waiting_for_user_input',
       vendor: 'modal',
       snapshotId: null,
@@ -818,7 +818,7 @@ describe('sleepCheckJob', () => {
       id: 86,
       machineId: 'sb-stale-race',
       payloadKind: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       vendor: 'modal',
       snapshotId: null,
@@ -848,7 +848,7 @@ describe('sleepCheckJob', () => {
       id: 89,
       machineId: 'sb-missing-first-heartbeat',
       payloadKind: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Processing,
+      status: RunStatus.Processing,
       taskPhase: null,
       vendor: 'modal',
       startedAt: new Date(Date.now() - 5 * 60 * 1_000),
@@ -886,7 +886,7 @@ describe('sleepCheckJob', () => {
       id: 90,
       machineId: 'sb-stale-worker',
       payloadKind: TaskPayloadKind.SlackAppMention,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'stopped',
       vendor: 'modal',
       workerHeartbeatAt: staleWorkerAt,
@@ -922,7 +922,7 @@ describe('sleepCheckJob', () => {
       id: 95,
       machineId: 'sb-booting-gone',
       payloadKind: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Processing,
+      status: RunStatus.Processing,
       taskPhase: null,
       vendor: 'modal',
       startedAt: new Date(Date.now() - 5 * 60 * 1_000),
@@ -941,7 +941,7 @@ describe('sleepCheckJob', () => {
     expect(mockCreateSnapshot).not.toHaveBeenCalled();
     expect(mockFinishCloudJob).toHaveBeenCalledWith({
       id: 95,
-      status: CloudTaskStatus.Failed,
+      status: RunStatus.Failed,
       error:
         'Initial worker heartbeat missing and instance sb-booting-gone is stopped',
     });
@@ -964,7 +964,7 @@ describe('sleepCheckJob', () => {
       id: 93,
       machineId: 'sb-hard-limit-wins',
       payloadKind: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Idle,
+      status: RunStatus.Idle,
       taskPhase: 'waiting_for_prompt',
       vendor: 'modal',
       workerHeartbeatAt: new Date(Date.now() - 5 * 60 * 1_000),
@@ -1019,7 +1019,7 @@ describe('sleepCheckJob', () => {
       id: 94,
       machineId: 'sb-stale-worker-fallback',
       payloadKind: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Idle,
+      status: RunStatus.Idle,
       taskPhase: 'waiting_for_prompt',
       vendor: 'modal',
       workerHeartbeatAt: new Date(Date.now() - 5 * 60 * 1_000),
@@ -1061,7 +1061,7 @@ describe('sleepCheckJob', () => {
       id: 91,
       machineId: 'sb-gone',
       payloadKind: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'stopped',
       vendor: 'modal',
       workerHeartbeatAt: new Date(Date.now() - 5 * 60 * 1_000),
@@ -1079,7 +1079,7 @@ describe('sleepCheckJob', () => {
     expect(mockCreateSnapshot).not.toHaveBeenCalled();
     expect(mockFinishCloudJob).toHaveBeenCalledWith({
       id: 91,
-      status: CloudTaskStatus.Failed,
+      status: RunStatus.Failed,
       error: 'Worker heartbeat stale and instance sb-gone is stopped',
     });
     expect(mockRecordCloudJobEvent).toHaveBeenCalledWith(
@@ -1114,7 +1114,7 @@ describe('sleepCheckJob', () => {
       id: 101,
       machineId: 'sb-gone-after-stop',
       payloadKind: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'stopped',
       vendor: 'modal',
       workerHeartbeatAt: new Date(Date.now() - 5 * 60 * 1_000),
@@ -1135,7 +1135,7 @@ describe('sleepCheckJob', () => {
     expect(mockCreateSnapshot).not.toHaveBeenCalled();
     expect(mockFinishCloudJob).toHaveBeenCalledWith({
       id: 101,
-      status: CloudTaskStatus.Canceled,
+      status: RunStatus.Canceled,
       error:
         'Worker heartbeat stale and instance sb-gone-after-stop is stopped',
     });
@@ -1155,7 +1155,7 @@ describe('sleepCheckJob', () => {
       id: 96,
       machineId: 'sb-snapshotting-stale',
       payloadKind: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       vendor: 'modal',
       workerHeartbeatAt: new Date(Date.now() - 5 * 60 * 1_000),
@@ -1192,7 +1192,7 @@ describe('sleepCheckJob', () => {
       id: 97,
       machineId: 'sb-hard-limit-snapshotting',
       payloadKind: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       vendor: 'modal',
       snapshotId: null,
@@ -1231,7 +1231,7 @@ describe('sleepCheckJob', () => {
       id: 92,
       machineId: 'sb-non-resumable-stale',
       payloadKind: TaskPayloadKind.GithubPrReview,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'waiting_for_prompt',
       vendor: 'modal',
       workerHeartbeatAt: new Date(Date.now() - 5 * 60 * 1_000),
@@ -1259,7 +1259,7 @@ describe('sleepCheckJob', () => {
     });
     expect(mockFinishCloudJob).toHaveBeenCalledWith({
       id: 92,
-      status: CloudTaskStatus.Failed,
+      status: RunStatus.Failed,
       error: 'Worker heartbeat stale for instance sb-non-resumable-stale',
     });
     expect(mockCreateComputeProviderMutationEventRecorder).toHaveBeenCalledWith(
@@ -1319,7 +1319,7 @@ describe('sleepCheckJob', () => {
       id: 102,
       machineId: 'sb-non-resumable-stopped',
       payloadKind: TaskPayloadKind.GithubPrReview,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'waiting_for_prompt',
       vendor: 'modal',
       workerHeartbeatAt: new Date(Date.now() - 5 * 60 * 1_000),
@@ -1345,7 +1345,7 @@ describe('sleepCheckJob', () => {
     });
     expect(mockFinishCloudJob).toHaveBeenCalledWith({
       id: 102,
-      status: CloudTaskStatus.Canceled,
+      status: RunStatus.Canceled,
       error: 'Worker heartbeat stale for instance sb-non-resumable-stopped',
     });
     expect(mockRecordCloudJobEvent).toHaveBeenCalledWith(
@@ -1366,7 +1366,7 @@ describe('sleepCheckJob', () => {
       id: 98,
       machineId: 'sb-non-resumable-booting',
       payloadKind: TaskPayloadKind.GithubPrReview,
-      status: CloudTaskStatus.Processing,
+      status: RunStatus.Processing,
       taskPhase: null,
       vendor: 'modal',
       startedAt: new Date(Date.now() - 5 * 60 * 1_000),
@@ -1395,7 +1395,7 @@ describe('sleepCheckJob', () => {
     });
     expect(mockFinishCloudJob).toHaveBeenCalledWith({
       id: 98,
-      status: CloudTaskStatus.Failed,
+      status: RunStatus.Failed,
       error:
         'Initial worker heartbeat missing for instance sb-non-resumable-booting',
     });

--- a/apps/bullmq/src/scheduled-jobs/refresh-snapshots.ts
+++ b/apps/bullmq/src/scheduled-jobs/refresh-snapshots.ts
@@ -22,7 +22,7 @@ import {
   isNull,
   sql,
 } from '@roomote/db/server';
-import { enqueueCloudTask } from '@roomote/cloud-agents/server';
+import { enqueueTask } from '@roomote/cloud-agents/server';
 
 const SNAPSHOT_REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const PENDING_SNAPSHOT_RECOVERY_GRACE_MS = 5 * 60 * 1000;
@@ -432,7 +432,7 @@ export const refreshSnapshotsJob = async () => {
             snapshotAgeHours,
           });
 
-          const { id } = await enqueueCloudTask({
+          const { id } = await enqueueTask({
             task: {
               type: TaskPayloadKind.SnapshotEnvironment,
               computeProvider: candidate.provider,
@@ -503,7 +503,7 @@ export const refreshSnapshotsJob = async () => {
               snapshotAgeHours,
             });
 
-            const { id } = await enqueueCloudTask({
+            const { id } = await enqueueTask({
               task: {
                 type: TaskPayloadKind.SnapshotEnvironment,
                 computeProvider: candidate.provider,

--- a/apps/bullmq/src/scheduled-jobs/refresh-snapshots.ts
+++ b/apps/bullmq/src/scheduled-jobs/refresh-snapshots.ts
@@ -1,7 +1,7 @@
 import {
   type ComputeProvider,
   type SnapshotEnvironmentAttachment,
-  activeCloudTaskStatuses,
+  activeRunStatuses,
   TaskPayloadKind,
   resolveComputeProviderTarget,
 } from '@roomote/types';
@@ -288,7 +288,7 @@ async function findActiveSnapshotRefreshJob(
       and(
         eq(tasks.workflow, 'env_snapshot'),
         eq(taskRuns.vendor, candidate.provider),
-        inArray(taskRuns.status, [...activeCloudTaskStatuses]),
+        inArray(taskRuns.status, [...activeRunStatuses]),
         sql`${taskRuns.payload}->>'environmentId' = ${candidate.environmentId}`,
       ),
     )

--- a/apps/bullmq/src/scheduled-jobs/sleep-check.ts
+++ b/apps/bullmq/src/scheduled-jobs/sleep-check.ts
@@ -32,7 +32,7 @@ import {
 import { createComputeProviderClient } from '@roomote/compute-providers';
 import {
   createSnapshot,
-  finishCloudJob,
+  finishRun,
   refreshTaskTitleOnCompletion,
 } from '@roomote/sdk/server';
 
@@ -701,7 +701,7 @@ async function handleTimedSleepCandidate(params: {
         : `${describeSleepCheckPath(path)} found active instance ${job.machineId} in status ${status}; failing the cloud job.`,
       details,
     );
-    await finishCloudJob({
+    await finishRun({
       id: job.id,
       status: finalStatus,
       error: `${describeSleepCheckPath(path)} found active instance ${job.machineId} in status ${status}`,
@@ -828,7 +828,7 @@ async function handleTimedSleepCandidate(params: {
       })
       .where(eq(taskRuns.id, job.id));
 
-    // Direct-completion path (not via finishCloudJob): derive the task state
+    // Direct-completion path (not via finishRun): derive the task state
     // from all its runs now that this run is completed.
     await syncTaskStateFromRuns(tx, job.taskId);
 
@@ -999,7 +999,7 @@ async function handleHeartbeatRecoveryCandidate(params: {
 
     const finalStatus = await resolveSweptJobFinalStatus(job.id);
 
-    await finishCloudJob({
+    await finishRun({
       id: job.id,
       status: finalStatus,
       error: config.notRunning.failureError(job.machineId, status),
@@ -1052,7 +1052,7 @@ async function handleHeartbeatRecoveryCandidate(params: {
 
   const finalStatus = await resolveSweptJobFinalStatus(job.id);
 
-  await finishCloudJob({
+  await finishRun({
     id: job.id,
     status: finalStatus,
     error: config.destroyAndFail.failureError(job.machineId),
@@ -1316,7 +1316,7 @@ async function completeIdleJobWithoutSnapshot(
   );
 
   try {
-    await finishCloudJob({
+    await finishRun({
       id: job.id,
       status: RunStatus.Completed,
       error: errorMessage,

--- a/apps/bullmq/src/scheduled-jobs/sleep-check.ts
+++ b/apps/bullmq/src/scheduled-jobs/sleep-check.ts
@@ -10,7 +10,7 @@ import {
   WORKER_HEARTBEAT_STALE_MS,
 } from '@roomote/types';
 import {
-  type CloudJob,
+  type Run,
   db,
   taskRuns,
   createComputeProviderMutationEventRecorder,
@@ -67,7 +67,7 @@ type DestroyInstanceReason =
   | 'booting_no_heartbeat';
 
 type SleepCheckJob = Pick<
-  CloudJob,
+  Run,
   | 'id'
   | 'payloadKind'
   | 'status'
@@ -169,7 +169,7 @@ function isSnapshotResumableSleepCandidate(job: SleepCheckJob): boolean {
 }
 
 function getSleepCheckCandidateKey(
-  job: Pick<CloudJob, 'machineId' | 'vendor'>,
+  job: Pick<Run, 'machineId' | 'vendor'>,
 ): string | null {
   if (!job.machineId || !job.vendor) {
     return null;

--- a/apps/bullmq/src/scheduled-jobs/sleep-check.ts
+++ b/apps/bullmq/src/scheduled-jobs/sleep-check.ts
@@ -1,10 +1,10 @@
 import {
   type ComputeProvider,
   type TaskPhase,
-  CloudTaskStatus,
+  RunStatus,
   sleepCheckManagedComputeProviders,
   isSnapshotCapableComputeProvider,
-  isResumableCloudTaskType,
+  isResumableTaskPayloadKind,
   ACTIVE_TASK_PHASES,
   SNAPSHOT_CHECK_THRESHOLD_MS,
   WORKER_HEARTBEAT_STALE_MS,
@@ -41,15 +41,12 @@ import { captureBullMqMessage } from '../monitoring/sentry';
 
 const ACTIVE_SLEEP_BACKSTOP_EXTENSION_MS = 90 * 1_000;
 const SLEEP_CHECK_BATCH_LIMIT = 500;
-const ACTIVE_SLEEP_CHECK_STATUSES = [
-  CloudTaskStatus.Running,
-  CloudTaskStatus.Idle,
-];
+const ACTIVE_SLEEP_CHECK_STATUSES = [RunStatus.Running, RunStatus.Idle];
 const BOOTING_NO_HEARTBEAT_STATUSES = [
-  CloudTaskStatus.Processing,
-  CloudTaskStatus.Preparing,
-  CloudTaskStatus.Spawning,
-  CloudTaskStatus.Connecting,
+  RunStatus.Processing,
+  RunStatus.Preparing,
+  RunStatus.Spawning,
+  RunStatus.Connecting,
 ];
 
 const SLEEP_CHECK_PROVIDERS = sleepCheckManagedComputeProviders;
@@ -163,7 +160,7 @@ async function createSleepCheckClient(provider: ComputeProvider) {
  */
 function isSnapshotResumableSleepCandidate(job: SleepCheckJob): boolean {
   return (
-    isResumableCloudTaskType(job.payloadKind) &&
+    isResumableTaskPayloadKind(job.payloadKind) &&
     isSnapshotCapableComputeProvider(job.vendor)
   );
 }
@@ -424,7 +421,7 @@ export const sleepCheckJob = async () => {
         .update(taskRuns)
         .set({
           sleepRequestedAt: null,
-          ...(isResumableCloudTaskType(preferredJob.payloadKind)
+          ...(isResumableTaskPayloadKind(preferredJob.payloadKind)
             ? { snapshotRequestedAt: null }
             : {}),
         })
@@ -462,7 +459,7 @@ export const sleepCheckJob = async () => {
 };
 
 function getBaseSleepCheckCandidateConditions(
-  statuses: CloudTaskStatus[] = ACTIVE_SLEEP_CHECK_STATUSES,
+  statuses: RunStatus[] = ACTIVE_SLEEP_CHECK_STATUSES,
 ) {
   return [
     inArray(taskRuns.status, statuses),
@@ -640,15 +637,13 @@ async function mergeSleepCheckCandidates(
  */
 async function resolveSweptJobFinalStatus(
   jobId: number,
-): Promise<CloudTaskStatus.Failed | CloudTaskStatus.Canceled> {
+): Promise<RunStatus.Failed | RunStatus.Canceled> {
   const job = await db.query.taskRuns.findFirst({
     where: eq(taskRuns.id, jobId),
     columns: { cancelRequestedAt: true },
   });
 
-  return job?.cancelRequestedAt
-    ? CloudTaskStatus.Canceled
-    : CloudTaskStatus.Failed;
+  return job?.cancelRequestedAt ? RunStatus.Canceled : RunStatus.Failed;
 }
 
 async function handleTimedSleepCandidate(params: {
@@ -681,7 +676,7 @@ async function handleTimedSleepCandidate(params: {
       ...buildSleepCheckDetails(job),
     };
 
-    if (job.status === CloudTaskStatus.Idle) {
+    if (job.status === RunStatus.Idle) {
       await recordSleepCheckEvent(
         job,
         'decision',
@@ -700,8 +695,8 @@ async function handleTimedSleepCandidate(params: {
 
     await recordSleepCheckEvent(
       job,
-      finalStatus === CloudTaskStatus.Canceled ? 'decision' : 'failed',
-      finalStatus === CloudTaskStatus.Canceled
+      finalStatus === RunStatus.Canceled ? 'decision' : 'failed',
+      finalStatus === RunStatus.Canceled
         ? `${describeSleepCheckPath(path)} found active instance ${job.machineId} in status ${status}; finalizing cloud job #${job.id} as canceled after its stop request.`
         : `${describeSleepCheckPath(path)} found active instance ${job.machineId} in status ${status}; failing the cloud job.`,
       details,
@@ -828,7 +823,7 @@ async function handleTimedSleepCandidate(params: {
       .set({
         sleepAt: null,
         taskPhase: null,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
         completedAt: endedAt,
       })
       .where(eq(taskRuns.id, job.id));
@@ -987,10 +982,7 @@ async function handleHeartbeatRecoveryCandidate(params: {
       ...buildSleepCheckDetails(job),
     };
 
-    if (
-      config.completeIdleInsteadOfFailing &&
-      job.status === CloudTaskStatus.Idle
-    ) {
+    if (config.completeIdleInsteadOfFailing && job.status === RunStatus.Idle) {
       await recordSleepCheckEvent(
         job,
         'decision',
@@ -1013,7 +1005,7 @@ async function handleHeartbeatRecoveryCandidate(params: {
       error: config.notRunning.failureError(job.machineId, status),
     });
 
-    if (finalStatus === CloudTaskStatus.Canceled) {
+    if (finalStatus === RunStatus.Canceled) {
       await recordSleepCheckEvent(
         job,
         'decision',
@@ -1066,7 +1058,7 @@ async function handleHeartbeatRecoveryCandidate(params: {
     error: config.destroyAndFail.failureError(job.machineId),
   });
 
-  if (finalStatus === CloudTaskStatus.Canceled) {
+  if (finalStatus === RunStatus.Canceled) {
     await recordSleepCheckEvent(
       job,
       'decision',
@@ -1211,7 +1203,7 @@ function buildSleepCheckDetails(job: SleepCheckJob) {
     sleepRequestedAt: job.sleepRequestedAt?.toISOString() ?? null,
     snapshotRequestedAt: job.snapshotRequestedAt?.toISOString() ?? null,
     workerHeartbeatAt: job.workerHeartbeatAt?.toISOString() ?? null,
-    resumable: isResumableCloudTaskType(job.payloadKind),
+    resumable: isResumableTaskPayloadKind(job.payloadKind),
     taskId: job.taskId,
   };
 }
@@ -1326,7 +1318,7 @@ async function completeIdleJobWithoutSnapshot(
   try {
     await finishCloudJob({
       id: job.id,
-      status: CloudTaskStatus.Completed,
+      status: RunStatus.Completed,
       error: errorMessage,
     });
   } catch (error) {

--- a/apps/controller/src/BaseController.ts
+++ b/apps/controller/src/BaseController.ts
@@ -14,7 +14,7 @@ import { createJobToken } from '@roomote/auth';
 import { Env } from '@roomote/env';
 import { getRedis, REDIS_KEYS } from '@roomote/redis';
 import {
-  type CloudJob,
+  type Run,
   db,
   taskRuns,
   buildPendingEnvironmentSnapshotMatchForCloudJob,
@@ -307,14 +307,14 @@ export abstract class BaseController {
   }
 
   protected abstract spawnFreshWorker(
-    cloudJob: CloudJob,
+    cloudJob: Run,
     authToken: string,
     deploymentSlug: string,
     sandboxTimeoutMs: number,
     provider: ComputeProvider,
   ): Promise<void>;
 
-  protected async spawnWorker(cloudJob: CloudJob): Promise<void> {
+  protected async spawnWorker(cloudJob: Run): Promise<void> {
     try {
       const dequeuedJob = await this.dequeueCloudJob(cloudJob);
 
@@ -345,7 +345,7 @@ export abstract class BaseController {
     }
   }
 
-  private spawnWorkerInBackground(cloudJob: CloudJob): boolean {
+  private spawnWorkerInBackground(cloudJob: Run): boolean {
     if (this.inFlightSpawns.has(cloudJob.id)) {
       console.warn(
         `[BaseController] Job #${cloudJob.id} is already being spawned, skipping`,
@@ -406,8 +406,8 @@ export abstract class BaseController {
   }
 
   protected async dequeueCloudJob(
-    cloudJob: CloudJob,
-  ): Promise<{ cloudJob: CloudJob; authToken: string } | null> {
+    cloudJob: Run,
+  ): Promise<{ cloudJob: Run; authToken: string } | null> {
     const sandboxTimeoutMs = SANDBOX_TIMEOUT_MS;
 
     // Jobs without a human driver run as the deployment service principal;
@@ -492,7 +492,7 @@ export abstract class BaseController {
   }
 
   protected async handleSpawnJobError(
-    cloudJob: CloudJob,
+    cloudJob: Run,
     error: unknown,
   ): Promise<void> {
     const errorMessage = error instanceof Error ? error.message : String(error);

--- a/apps/controller/src/BaseController.ts
+++ b/apps/controller/src/BaseController.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   type ComputeProvider,
-  CloudTaskStatus,
+  RunStatus,
   TaskPayloadKind,
   resolveComputeProviderTarget,
   SANDBOX_ORPHAN_SCAN_INTERVAL_MS,
@@ -429,7 +429,7 @@ export abstract class BaseController {
     await db.transaction(async (tx) => {
       const updatedJobs = await tx
         .update(taskRuns)
-        .set({ status: CloudTaskStatus.Dequeued, dequeuedAt: new Date() })
+        .set({ status: RunStatus.Dequeued, dequeuedAt: new Date() })
         .where(
           and(
             eq(taskRuns.id, cloudJob.id),
@@ -452,7 +452,7 @@ export abstract class BaseController {
           'Controller dequeued cloud job and handed it to provider dispatch.',
         details: {
           stage: 'controller_dequeue',
-          status: CloudTaskStatus.Dequeued,
+          status: RunStatus.Dequeued,
           provider: resolveComputeProviderTarget(
             cloudJob.vendor,
             fallbackComputeProvider,
@@ -472,10 +472,7 @@ export abstract class BaseController {
         },
       });
 
-      if (
-        latestJob?.canceledAt ||
-        latestJob?.status === CloudTaskStatus.Canceled
-      ) {
+      if (latestJob?.canceledAt || latestJob?.status === RunStatus.Canceled) {
         return null;
       }
 
@@ -484,7 +481,7 @@ export abstract class BaseController {
       }
 
       throw new Error(
-        `Job ${cloudJob.id}: failed to transition from ${cloudJob.status} to ${CloudTaskStatus.Dequeued}`,
+        `Job ${cloudJob.id}: failed to transition from ${cloudJob.status} to ${RunStatus.Dequeued}`,
       );
     }
 
@@ -513,7 +510,7 @@ export abstract class BaseController {
     // Linear notifications, lock release, etc.) are applied consistently.
     await finishCloudJob({
       id: cloudJob.id,
-      status: CloudTaskStatus.Failed,
+      status: RunStatus.Failed,
       error: errorMessage,
     });
 

--- a/apps/controller/src/BaseController.ts
+++ b/apps/controller/src/BaseController.ts
@@ -26,7 +26,7 @@ import {
   isNull,
 } from '@roomote/db/server';
 import { dequeueCloudTask } from '@roomote/cloud-agents/server';
-import { finishCloudJob } from '@roomote/sdk/server';
+import { finishRun } from '@roomote/sdk/server';
 
 import { getOrphanedJob } from './orphaned-cloud-jobs';
 import {
@@ -508,7 +508,7 @@ export abstract class BaseController {
 
     // Use the centralized termination path so all side-effects (email, Slack,
     // Linear notifications, lock release, etc.) are applied consistently.
-    await finishCloudJob({
+    await finishRun({
       id: cloudJob.id,
       status: RunStatus.Failed,
       error: errorMessage,

--- a/apps/controller/src/RoomoteController.ts
+++ b/apps/controller/src/RoomoteController.ts
@@ -1,9 +1,6 @@
 import { type ComputeProvider } from '@roomote/types';
 import { Env } from '@roomote/env';
-import {
-  type CloudJob,
-  resolveComputeProviderEnvValues,
-} from '@roomote/db/server';
+import { type Run, resolveComputeProviderEnvValues } from '@roomote/db/server';
 
 import { BaseController } from './BaseController';
 import {
@@ -55,7 +52,7 @@ export class RoomoteController extends BaseController {
   }
 
   protected async spawnFreshWorker(
-    cloudJob: CloudJob,
+    cloudJob: Run,
     authToken: string,
     deploymentSlug: string,
     timeoutMs: number,

--- a/apps/controller/src/__tests__/BaseController.test.ts
+++ b/apps/controller/src/__tests__/BaseController.test.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
-import type { CloudJob } from '@roomote/db/server';
+import type { Run } from '@roomote/db/server';
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -111,7 +111,7 @@ class TestController extends BaseController {
   }
 
   protected async spawnFreshWorker(
-    _cloudJob: CloudJob,
+    _cloudJob: Run,
     _authToken: string,
     _deploymentSlug: string,
     _sandboxTimeoutMs: number,
@@ -121,7 +121,7 @@ class TestController extends BaseController {
 
   // Expose handleSpawnJobError for direct testing.
   public async testHandleSpawnJobError(
-    cloudJob: CloudJob,
+    cloudJob: Run,
     error: unknown,
   ): Promise<void> {
     return this.handleSpawnJobError(cloudJob, error);
@@ -133,7 +133,7 @@ class TestController extends BaseController {
     };
   }
 
-  public async testDequeueCloudJob(cloudJob: CloudJob) {
+  public async testDequeueCloudJob(cloudJob: Run) {
     return this.dequeueCloudJob(cloudJob);
   }
 }
@@ -144,7 +144,7 @@ class SaturatedTestController extends TestController {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-function makeCloudJob(overrides: Partial<CloudJob> = {}): CloudJob {
+function makeCloudJob(overrides: Partial<Run> = {}): Run {
   return {
     id: 42,
     payloadKind: TaskPayloadKind.StandardTask,
@@ -166,7 +166,7 @@ function makeCloudJob(overrides: Partial<CloudJob> = {}): CloudJob {
     canceledAt: null,
     completedAt: null,
     ...overrides,
-  } as CloudJob;
+  } as Run;
 }
 
 function resetControllerMocks() {

--- a/apps/controller/src/__tests__/BaseController.test.ts
+++ b/apps/controller/src/__tests__/BaseController.test.ts
@@ -7,7 +7,7 @@ import type { Run } from '@roomote/db/server';
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
 const {
-  mockFinishCloudJob,
+  mockFinishRun,
   mockCaptureControllerException,
   mockCaptureControllerMessage,
   mockCloudJobsFindFirst,
@@ -18,7 +18,7 @@ const {
   mockRedisSet,
   mockUpdateWhere,
 } = vi.hoisted(() => ({
-  mockFinishCloudJob: vi.fn().mockResolvedValue(undefined),
+  mockFinishRun: vi.fn().mockResolvedValue(undefined),
   mockCaptureControllerException: vi.fn(),
   mockCaptureControllerMessage: vi.fn(),
   mockCloudJobsFindFirst: vi.fn(),
@@ -33,7 +33,7 @@ const {
 }));
 
 vi.mock('@roomote/sdk/server', () => ({
-  finishCloudJob: (...args: unknown[]) => mockFinishCloudJob(...args),
+  finishRun: (...args: unknown[]) => mockFinishRun(...args),
 }));
 
 const mockDbUpdateSet = vi.fn().mockReturnValue({
@@ -210,7 +210,7 @@ describe('BaseController.handleSpawnJobError', () => {
     delete process.env.USE_WORKER_RELEASE;
   });
 
-  it('calls finishCloudJob with Failed status and error message', async () => {
+  it('calls finishRun with Failed status and error message', async () => {
     const job = makeCloudJob({ id: 42 });
     const error = new Error('Machine unavailable');
 
@@ -218,7 +218,7 @@ describe('BaseController.handleSpawnJobError', () => {
       controller.testHandleSpawnJobError(job, error),
     ).rejects.toThrow('Machine unavailable');
 
-    expect(mockFinishCloudJob).toHaveBeenCalledWith({
+    expect(mockFinishRun).toHaveBeenCalledWith({
       id: 42,
       status: RunStatus.Failed,
       error: 'Machine unavailable',
@@ -247,7 +247,7 @@ describe('BaseController.handleSpawnJobError', () => {
       controller.testHandleSpawnJobError(job, error),
     ).rejects.toThrow('Snapshot failed');
 
-    expect(mockFinishCloudJob).toHaveBeenCalledWith({
+    expect(mockFinishRun).toHaveBeenCalledWith({
       id: 99,
       status: RunStatus.Failed,
       error: 'Snapshot failed',
@@ -268,7 +268,7 @@ describe('BaseController.handleSpawnJobError', () => {
     );
   });
 
-  it('re-throws the original error after calling finishCloudJob', async () => {
+  it('re-throws the original error after calling finishRun', async () => {
     const job = makeCloudJob();
     const originalError = new Error('original');
 
@@ -284,7 +284,7 @@ describe('BaseController.handleSpawnJobError', () => {
       controller.testHandleSpawnJobError(job, 'string error'),
     ).rejects.toBe('string error');
 
-    expect(mockFinishCloudJob).toHaveBeenCalledWith({
+    expect(mockFinishRun).toHaveBeenCalledWith({
       id: 7,
       status: RunStatus.Failed,
       error: 'string error',

--- a/apps/controller/src/__tests__/BaseController.test.ts
+++ b/apps/controller/src/__tests__/BaseController.test.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
 import type { Run } from '@roomote/db/server';
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
@@ -150,7 +150,7 @@ function makeCloudJob(overrides: Partial<Run> = {}): Run {
     payloadKind: TaskPayloadKind.StandardTask,
     userId: 'user-1',
     harness: 'opencode-server',
-    status: CloudTaskStatus.Running,
+    status: RunStatus.Running,
     payload: { repo: 'owner/repo' },
     taskId: 'task-1',
     slackThreadTs: null,
@@ -220,7 +220,7 @@ describe('BaseController.handleSpawnJobError', () => {
 
     expect(mockFinishCloudJob).toHaveBeenCalledWith({
       id: 42,
-      status: CloudTaskStatus.Failed,
+      status: RunStatus.Failed,
       error: 'Machine unavailable',
     });
   });
@@ -249,7 +249,7 @@ describe('BaseController.handleSpawnJobError', () => {
 
     expect(mockFinishCloudJob).toHaveBeenCalledWith({
       id: 99,
-      status: CloudTaskStatus.Failed,
+      status: RunStatus.Failed,
       error: 'Snapshot failed',
     });
 
@@ -286,7 +286,7 @@ describe('BaseController.handleSpawnJobError', () => {
 
     expect(mockFinishCloudJob).toHaveBeenCalledWith({
       id: 7,
-      status: CloudTaskStatus.Failed,
+      status: RunStatus.Failed,
       error: 'string error',
     });
   });
@@ -312,7 +312,7 @@ describe('BaseController.handleSpawnJobError', () => {
   it('captures a Sentry issue when the controller starts a job from database fallback', async () => {
     const job = makeCloudJob({
       id: 108,
-      status: CloudTaskStatus.Pending,
+      status: RunStatus.Pending,
       vendor: 'modal',
     });
 
@@ -325,7 +325,7 @@ describe('BaseController.handleSpawnJobError', () => {
         'Controller started task using database fallback logic',
         expect.objectContaining({
           jobId: 108,
-          jobStatus: CloudTaskStatus.Pending,
+          jobStatus: RunStatus.Pending,
           jobType: TaskPayloadKind.StandardTask,
           phase: 'database_fallback',
           provider: 'modal',
@@ -347,7 +347,7 @@ describe('BaseController.handleSpawnJobError', () => {
     const saturatedController = new SaturatedTestController();
     const job = makeCloudJob({
       id: 109,
-      status: CloudTaskStatus.Pending,
+      status: RunStatus.Pending,
       vendor: 'modal',
     });
 
@@ -391,7 +391,7 @@ describe('BaseController.dequeueCloudJob', () => {
   it('records a controller_dequeue lifecycle event', async () => {
     const job = makeCloudJob({
       id: 77,
-      status: CloudTaskStatus.Pending,
+      status: RunStatus.Pending,
       vendor: 'modal',
       payload: {
         repo: 'owner/repo',
@@ -412,7 +412,7 @@ describe('BaseController.dequeueCloudJob', () => {
         message: expect.stringContaining('Controller dequeued'),
         details: expect.objectContaining({
           stage: 'controller_dequeue',
-          status: CloudTaskStatus.Dequeued,
+          status: RunStatus.Dequeued,
           provider: 'modal',
           environmentId: 'env-1',
         }),
@@ -423,14 +423,14 @@ describe('BaseController.dequeueCloudJob', () => {
   it('does not revive a job canceled during the dequeue window', async () => {
     const job = makeCloudJob({
       id: 78,
-      status: CloudTaskStatus.Pending,
+      status: RunStatus.Pending,
     });
 
     mockUpdateWhere.mockReturnValueOnce({
       returning: vi.fn().mockResolvedValue([]),
     });
     mockCloudJobsFindFirst.mockResolvedValueOnce({
-      status: CloudTaskStatus.Canceled,
+      status: RunStatus.Canceled,
       canceledAt: new Date(),
     });
 
@@ -443,7 +443,7 @@ describe('BaseController.dequeueCloudJob', () => {
   it('treats preparing jobs as recoverable before controller dequeue', async () => {
     const job = makeCloudJob({
       id: 80,
-      status: CloudTaskStatus.Preparing,
+      status: RunStatus.Preparing,
     });
 
     const result = await controller.testDequeueCloudJob(job);
@@ -456,7 +456,7 @@ describe('BaseController.dequeueCloudJob', () => {
         runId: 80,
         details: expect.objectContaining({
           stage: 'controller_dequeue',
-          status: CloudTaskStatus.Dequeued,
+          status: RunStatus.Dequeued,
         }),
       }),
     );
@@ -465,14 +465,14 @@ describe('BaseController.dequeueCloudJob', () => {
   it('treats an already-advanced dequeue race as a no-op', async () => {
     const job = makeCloudJob({
       id: 79,
-      status: CloudTaskStatus.Pending,
+      status: RunStatus.Pending,
     });
 
     mockUpdateWhere.mockReturnValueOnce({
       returning: vi.fn().mockResolvedValue([]),
     });
     mockCloudJobsFindFirst.mockResolvedValueOnce({
-      status: CloudTaskStatus.Dequeued,
+      status: RunStatus.Dequeued,
       canceledAt: null,
     });
 

--- a/apps/controller/src/__tests__/RoomoteController.test.ts
+++ b/apps/controller/src/__tests__/RoomoteController.test.ts
@@ -41,8 +41,8 @@ const {
   mockSpawnModalWorker: vi.fn(),
 }));
 
-const { mockFinishCloudJob } = vi.hoisted(() => ({
-  mockFinishCloudJob: vi.fn().mockResolvedValue(undefined),
+const { mockFinishRun } = vi.hoisted(() => ({
+  mockFinishRun: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@roomote/env', async (importOriginal) => {
@@ -74,7 +74,7 @@ vi.mock('@roomote/db/server', async () => {
 });
 
 vi.mock('@roomote/sdk/server', () => ({
-  finishCloudJob: (...args: unknown[]) => mockFinishCloudJob(...args),
+  finishRun: (...args: unknown[]) => mockFinishRun(...args),
 }));
 
 vi.mock('../compute-providers', () => ({

--- a/apps/controller/src/__tests__/RoomoteController.test.ts
+++ b/apps/controller/src/__tests__/RoomoteController.test.ts
@@ -1,4 +1,4 @@
-import type { CloudJob } from '@roomote/db/server';
+import type { Run } from '@roomote/db/server';
 
 const {
   mockEnv,
@@ -127,7 +127,7 @@ describe('RoomoteController', () => {
     await (
       controller as unknown as {
         spawnFreshWorker: (
-          cloudJob: CloudJob,
+          cloudJob: Run,
           authToken: string,
           deploymentSlug: string,
           timeoutMs: number,
@@ -138,7 +138,7 @@ describe('RoomoteController', () => {
       {
         id: 48,
         payload: { environmentId: 'env_123' },
-      } as CloudJob,
+      } as Run,
       'auth-token',
       'roomote',
       60_000,
@@ -165,7 +165,7 @@ describe('RoomoteController', () => {
       (
         controller as unknown as {
           spawnFreshWorker: (
-            cloudJob: CloudJob,
+            cloudJob: Run,
             authToken: string,
             deploymentSlug: string,
             timeoutMs: number,
@@ -176,7 +176,7 @@ describe('RoomoteController', () => {
         {
           id: 46,
           payload: { environmentId: 'env_123' },
-        } as CloudJob,
+        } as Run,
         'auth-token',
         'roomote',
         60_000,
@@ -193,7 +193,7 @@ describe('RoomoteController', () => {
     await (
       controller as unknown as {
         spawnFreshWorker: (
-          cloudJob: CloudJob,
+          cloudJob: Run,
           authToken: string,
           deploymentSlug: string,
           timeoutMs: number,
@@ -204,7 +204,7 @@ describe('RoomoteController', () => {
       {
         id: 49,
         payload: { environmentId: 'env_123' },
-      } as CloudJob,
+      } as Run,
       'auth-token',
       'roomote',
       60_000,
@@ -234,7 +234,7 @@ describe('RoomoteController', () => {
       (
         controller as unknown as {
           spawnFreshWorker: (
-            cloudJob: CloudJob,
+            cloudJob: Run,
             authToken: string,
             deploymentSlug: string,
             timeoutMs: number,
@@ -245,7 +245,7 @@ describe('RoomoteController', () => {
         {
           id: 50,
           payload: { environmentId: 'env_123' },
-        } as CloudJob,
+        } as Run,
         'auth-token',
         'roomote',
         60_000,
@@ -262,7 +262,7 @@ describe('RoomoteController', () => {
     await (
       controller as unknown as {
         spawnFreshWorker: (
-          cloudJob: CloudJob,
+          cloudJob: Run,
           authToken: string,
           deploymentSlug: string,
           timeoutMs: number,
@@ -273,7 +273,7 @@ describe('RoomoteController', () => {
       {
         id: 51,
         payload: { environmentId: 'env_123' },
-      } as CloudJob,
+      } as Run,
       'auth-token',
       'roomote',
       60_000,
@@ -301,7 +301,7 @@ describe('RoomoteController', () => {
     await (
       controller as unknown as {
         spawnFreshWorker: (
-          cloudJob: CloudJob,
+          cloudJob: Run,
           authToken: string,
           deploymentSlug: string,
           timeoutMs: number,
@@ -312,7 +312,7 @@ describe('RoomoteController', () => {
       {
         id: 53,
         payload: { environmentId: 'env_123' },
-      } as CloudJob,
+      } as Run,
       'auth-token',
       'roomote',
       5 * 60 * 60 * 1_000,
@@ -336,7 +336,7 @@ describe('RoomoteController', () => {
       (
         controller as unknown as {
           spawnFreshWorker: (
-            cloudJob: CloudJob,
+            cloudJob: Run,
             authToken: string,
             deploymentSlug: string,
             timeoutMs: number,
@@ -347,7 +347,7 @@ describe('RoomoteController', () => {
         {
           id: 52,
           payload: { environmentId: 'env_123' },
-        } as CloudJob,
+        } as Run,
         'auth-token',
         'roomote',
         60_000,
@@ -376,7 +376,7 @@ describe('RoomoteController', () => {
     await (
       controller as unknown as {
         spawnFreshWorker: (
-          cloudJob: CloudJob,
+          cloudJob: Run,
           authToken: string,
           deploymentSlug: string,
           timeoutMs: number,
@@ -387,7 +387,7 @@ describe('RoomoteController', () => {
       {
         id: 44,
         payload: { environmentId: 'env_123' },
-      } as CloudJob,
+      } as Run,
       'auth-token',
       'roomote',
       60_000,

--- a/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
+++ b/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
@@ -1,4 +1,4 @@
-import type { CloudJob } from '@roomote/db/server';
+import type { Run } from '@roomote/db/server';
 import { TaskPayloadKind } from '@roomote/types';
 
 const mockCreateModalMachine = vi.fn();
@@ -21,16 +21,14 @@ const mockShouldEnableAuthBypassForCloudJob = vi.fn(
 );
 const mockPrimeEnvironmentOidcForMachine = vi.fn();
 
-function mockCloudJob(
-  overrides: Partial<CloudJob> & Pick<CloudJob, 'payloadKind'>,
-): CloudJob {
+function mockCloudJob(overrides: Partial<Run> & Pick<Run, 'payloadKind'>): Run {
   return {
     id: 123,
     vendor: 'modal',
     sourceSnapshotId: null,
     payload: { repo: 'test/repo' },
     ...overrides,
-  } as unknown as CloudJob;
+  } as unknown as Run;
 }
 
 vi.mock('@roomote/db/server', async (importOriginal) => {

--- a/apps/controller/src/compute-providers/spawn-daytona-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-daytona-worker.ts
@@ -4,7 +4,7 @@ import {
   getPrimaryPortFromConfig,
 } from '@roomote/types';
 import {
-  type CloudJob,
+  type Run,
   createComputeProviderMutationEventRecorder,
   db,
   taskRuns,
@@ -74,7 +74,7 @@ function buildDetachedWorkerExitError(result: {
 }
 
 export async function spawnDaytonaWorker(
-  cloudJob: CloudJob,
+  cloudJob: Run,
   authToken: string,
   config: {
     daytonaApiKey: string;

--- a/apps/controller/src/compute-providers/spawn-docker-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-docker-worker.ts
@@ -17,7 +17,7 @@ import {
   db,
   eq,
   resolveEffectivePreviewRuntimeConfig,
-  type CloudJob,
+  type Run,
 } from '@roomote/db/server';
 import { stampCloudJobMilestone } from '@roomote/sdk/server';
 import {
@@ -44,7 +44,7 @@ const DOCKER_WORKER_START_TIMEOUT_MS = 15_000;
 const DOCKER_WORKER_START_POLL_MS = 500;
 
 export async function spawnDockerWorker(
-  cloudJob: CloudJob,
+  cloudJob: Run,
   authToken: string,
   config: {
     image: string;

--- a/apps/controller/src/compute-providers/spawn-e2b-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-e2b-worker.ts
@@ -4,7 +4,7 @@ import {
   getPrimaryPortFromConfig,
 } from '@roomote/types';
 import {
-  type CloudJob,
+  type Run,
   createComputeProviderMutationEventRecorder,
   db,
   taskRuns,
@@ -76,9 +76,7 @@ function buildDetachedWorkerExitError(
   });
 }
 
-function getWorkerLaunchCommand(
-  cloudJob: CloudJob,
-): 'snapshot' | 'resume' | 'run' {
+function getWorkerLaunchCommand(cloudJob: Run): 'snapshot' | 'resume' | 'run' {
   return cloudJob.payloadKind === TaskPayloadKind.SnapshotEnvironment
     ? 'snapshot'
     : cloudJob.payloadKind === TaskPayloadKind.SnapshotResume
@@ -86,7 +84,7 @@ function getWorkerLaunchCommand(
       : 'run';
 }
 
-function getWorkerLaunchArgs(cloudJob: CloudJob, machineId: string): string[] {
+function getWorkerLaunchArgs(cloudJob: Run, machineId: string): string[] {
   const command = getWorkerLaunchCommand(cloudJob);
 
   return cloudJob.payloadKind === TaskPayloadKind.SnapshotEnvironment
@@ -103,7 +101,7 @@ function getWorkerLaunchArgs(cloudJob: CloudJob, machineId: string): string[] {
 }
 
 export async function spawnE2bWorker(
-  cloudJob: CloudJob,
+  cloudJob: Run,
   authToken: string,
   config: {
     e2bApiKey: string;

--- a/apps/controller/src/compute-providers/spawn-modal-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-modal-worker.ts
@@ -5,7 +5,7 @@ import {
   getPrimaryPortFromConfig,
 } from '@roomote/types';
 import {
-  type CloudJob,
+  type Run,
   createComputeProviderMutationEventRecorder,
   db,
   taskRuns,
@@ -87,9 +87,7 @@ function buildDetachedWorkerExitError(
   });
 }
 
-function getWorkerLaunchCommand(
-  cloudJob: CloudJob,
-): 'snapshot' | 'resume' | 'run' {
+function getWorkerLaunchCommand(cloudJob: Run): 'snapshot' | 'resume' | 'run' {
   return cloudJob.payloadKind === TaskPayloadKind.SnapshotEnvironment
     ? 'snapshot'
     : cloudJob.payloadKind === TaskPayloadKind.SnapshotResume
@@ -97,7 +95,7 @@ function getWorkerLaunchCommand(
       : 'run';
 }
 
-function getWorkerLaunchArgs(cloudJob: CloudJob, machineId: string): string[] {
+function getWorkerLaunchArgs(cloudJob: Run, machineId: string): string[] {
   const command = getWorkerLaunchCommand(cloudJob);
 
   return cloudJob.payloadKind === TaskPayloadKind.SnapshotEnvironment
@@ -114,7 +112,7 @@ function getWorkerLaunchArgs(cloudJob: CloudJob, machineId: string): string[] {
 }
 
 export async function spawnModalWorker(
-  cloudJob: CloudJob,
+  cloudJob: Run,
   authToken: string,
   config: {
     modalTokenId: string;

--- a/apps/controller/src/orphaned-cloud-jobs.ts
+++ b/apps/controller/src/orphaned-cloud-jobs.ts
@@ -1,5 +1,5 @@
 import {
-  CloudTaskStatus,
+  RunStatus,
   ORPHANED_AFTER_DEQUEUE_THRESHOLD_MS,
   ORPHANED_PENDING_THRESHOLD_MS,
 } from '@roomote/types';
@@ -19,7 +19,7 @@ const orphanMap = new Map<number, number>();
 const getOrphanedBeforeDequeueJobs = () =>
   db.query.taskRuns.findMany({
     where: and(
-      eq(taskRuns.status, CloudTaskStatus.Pending),
+      eq(taskRuns.status, RunStatus.Pending),
       lt(
         taskRuns.createdAt,
         new Date(Date.now() - ORPHANED_PENDING_THRESHOLD_MS),
@@ -32,7 +32,7 @@ const getOrphanedBeforeDequeueJobs = () =>
 const getOrphanedAfterDequeueJobs = () =>
   db.query.taskRuns.findMany({
     where: and(
-      eq(taskRuns.status, CloudTaskStatus.Dequeued),
+      eq(taskRuns.status, RunStatus.Dequeued),
       lt(
         taskRuns.dequeuedAt,
         new Date(Date.now() - ORPHANED_AFTER_DEQUEUE_THRESHOLD_MS),

--- a/apps/controller/src/utils.ts
+++ b/apps/controller/src/utils.ts
@@ -11,7 +11,7 @@ import {
   normalizeMetadataRecord,
 } from '@roomote/feature-flags';
 import {
-  type CloudJob,
+  type Run,
   type DatabaseOrTransaction,
   db,
   taskRuns,
@@ -109,7 +109,7 @@ export function shouldEnableAuthBypassForCloudJob({
  * non-expired snapshot.
  */
 export async function getNamedPortsForCloudJob(
-  cloudJob: CloudJob,
+  cloudJob: Run,
 ): Promise<NamedPortsResult> {
   let namedPorts = getNamedPortsForEnvironment({});
   let environmentSnapshotId: string | undefined;
@@ -160,7 +160,7 @@ export async function getNamedPortsForCloudJob(
 }
 
 type UpdateCloudJobMachineInfoParams = {
-  cloudJob: CloudJob;
+  cloudJob: Run;
   vendor?: ComputeProvider;
   machineId: string;
   proxyPorts?: Record<string, number>;

--- a/apps/preview-proxy/src/__tests__/fixtures.ts
+++ b/apps/preview-proxy/src/__tests__/fixtures.ts
@@ -1,4 +1,4 @@
-import type { CloudJob } from '@roomote/db';
+import type { Run } from '@roomote/db';
 import type { PreviewTokenContext } from '@roomote/types';
 
 import type { ResolvedRequest } from '../services/resolver';
@@ -44,13 +44,13 @@ export function createMockCloudJob(
     actingUserId?: string | null;
     payload?: Record<string, unknown> | null;
   } = {},
-): CloudJob {
+): Run {
   return {
     id: overrides.id ?? 1,
     taskId: 'taskId' in overrides ? overrides.taskId : TEST_TASK_ID,
     actingUserId: overrides.actingUserId ?? null,
     payload: overrides.payload ?? null,
-  } as unknown as CloudJob;
+  } as unknown as Run;
 }
 
 /**

--- a/apps/preview-proxy/src/handlers/__tests__/auto-resume.test.ts
+++ b/apps/preview-proxy/src/handlers/__tests__/auto-resume.test.ts
@@ -5,9 +5,9 @@ import {
   createMockResolvedRequest,
 } from '../../__tests__/fixtures';
 
-const { mockFindExistingResume, mockEnqueueCloudTask } = vi.hoisted(() => ({
+const { mockFindExistingResume, mockEnqueueTask } = vi.hoisted(() => ({
   mockFindExistingResume: vi.fn(),
-  mockEnqueueCloudTask: vi.fn(),
+  mockEnqueueTask: vi.fn(),
 }));
 
 vi.mock('../../lib/db', () => ({
@@ -21,7 +21,7 @@ vi.mock('../../lib/db', () => ({
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
-  enqueueCloudTask: mockEnqueueCloudTask,
+  enqueueTask: mockEnqueueTask,
 }));
 
 vi.mock('../../lib/logger', () => ({
@@ -40,7 +40,7 @@ describe('triggerAutoResume', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFindExistingResume.mockResolvedValue(null);
-    mockEnqueueCloudTask.mockResolvedValue({ id: 99 });
+    mockEnqueueTask.mockResolvedValue({ id: 99 });
   });
 
   it('preserves the source run acting user when creating a snapshot resume run', async () => {
@@ -68,7 +68,7 @@ describe('triggerAutoResume', () => {
       version: 1,
     });
 
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         actingUserId: 'source-user',
         task: expect.objectContaining({
@@ -112,7 +112,7 @@ describe('triggerAutoResume', () => {
       version: 1,
     });
 
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         actingUserId: 'viewer-user',
       }),

--- a/apps/preview-proxy/src/handlers/auto-resume.ts
+++ b/apps/preview-proxy/src/handlers/auto-resume.ts
@@ -7,7 +7,7 @@ import {
   type PreviewTokenContext,
 } from '@roomote/types';
 import { taskRuns, and, eq, inArray } from '@roomote/db/server';
-import { enqueueCloudTask } from '@roomote/cloud-agents/server';
+import { enqueueTask } from '@roomote/cloud-agents/server';
 
 import { db } from '../lib/db';
 import { logger, escapeForLog } from '../lib/logger';
@@ -110,7 +110,7 @@ export async function triggerAutoResume(
     // Resumes never create tasks and carry no initiator; the resuming human
     // (source run's acting user, else the preview token's user) becomes the
     // new run's acting user.
-    const resumeLaunch = await enqueueCloudTask({
+    const resumeLaunch = await enqueueTask({
       task: {
         type: TaskPayloadKind.SnapshotResume,
         sourceSnapshotId: snapshotId,

--- a/apps/preview-proxy/src/handlers/auto-resume.ts
+++ b/apps/preview-proxy/src/handlers/auto-resume.ts
@@ -1,7 +1,7 @@
 import {
-  type CloudTaskPayload,
+  type TaskPayload,
   TaskPayloadKind,
-  activeCloudTaskStatuses,
+  activeRunStatuses,
   populateSnapshotResumeSlackMetadata,
   restoreSnapshotResumeVisiblePromptFields,
   type PreviewTokenContext,
@@ -56,7 +56,7 @@ export async function triggerAutoResume(
     const existingResume = await db.query.taskRuns.findFirst({
       where: and(
         eq(taskRuns.sourceRunId, cloudJob.id),
-        inArray(taskRuns.status, [...activeCloudTaskStatuses]),
+        inArray(taskRuns.status, [...activeRunStatuses]),
       ),
       columns: { id: true, status: true },
     });
@@ -93,7 +93,7 @@ export async function triggerAutoResume(
       },
       'Creating auto-resume job',
     );
-    const payload: CloudTaskPayload<typeof TaskPayloadKind.SnapshotResume> = {
+    const payload: TaskPayload<typeof TaskPayloadKind.SnapshotResume> = {
       repo: sourcePayload.repo,
       environmentId: sourcePayload.environmentId,
       port: cloudJob.port ?? undefined,

--- a/apps/preview-proxy/src/services/auth.ts
+++ b/apps/preview-proxy/src/services/auth.ts
@@ -2,7 +2,7 @@ import * as redis from '../lib/redis';
 import { logger } from '../lib/logger';
 import { validatePreviewToken } from '@roomote/auth';
 import type { PreviewTokenContext } from '@roomote/types';
-import type { CloudJob } from '@roomote/db';
+import type { Run } from '@roomote/db';
 
 // Backward compatibility wrapper for validateToken
 export async function validateToken(
@@ -56,12 +56,12 @@ interface AuthValidationResult {
 }
 
 /**
- * Validate an auth cookie against a known CloudJob.
+ * Validate an auth cookie against a known Run.
  * This avoids repeating DB lookups when the caller already has the job.
  */
 export async function validateAuthCookieForCloudJob(
   authCookie: string | undefined,
-  cloudJob: CloudJob,
+  cloudJob: Run,
 ): Promise<AuthValidationResult> {
   const taskId = cloudJob.taskId ?? undefined;
 

--- a/apps/preview-proxy/src/services/resolver.test.ts
+++ b/apps/preview-proxy/src/services/resolver.test.ts
@@ -1,5 +1,5 @@
 import type { Run } from '@roomote/db/server';
-import { CloudTaskStatus, type EnvironmentConfig } from '@roomote/types';
+import { RunStatus, type EnvironmentConfig } from '@roomote/types';
 
 const {
   cloudJobFindFirstMock,
@@ -33,7 +33,7 @@ function createRunningCloudJob(overrides: Partial<Run> = {}): Run {
   return {
     id: 1,
     taskId: 'outertask12345',
-    status: CloudTaskStatus.Running,
+    status: RunStatus.Running,
     payload: {
       environmentId: 'env_app',
     },

--- a/apps/preview-proxy/src/services/resolver.test.ts
+++ b/apps/preview-proxy/src/services/resolver.test.ts
@@ -1,4 +1,4 @@
-import type { CloudJob } from '@roomote/db/server';
+import type { Run } from '@roomote/db/server';
 import { CloudTaskStatus, type EnvironmentConfig } from '@roomote/types';
 
 const {
@@ -29,7 +29,7 @@ vi.mock('../lib/db', () => ({
 
 import { resolveRequest } from './resolver';
 
-function createRunningCloudJob(overrides: Partial<CloudJob> = {}): CloudJob {
+function createRunningCloudJob(overrides: Partial<Run> = {}): Run {
   return {
     id: 1,
     taskId: 'outertask12345',
@@ -46,7 +46,7 @@ function createRunningCloudJob(overrides: Partial<CloudJob> = {}): CloudJob {
     authBypassValue: null,
     authBypassHeaderName: null,
     ...overrides,
-  } as unknown as CloudJob;
+  } as unknown as Run;
 }
 
 function createEnvironmentConfig(

--- a/apps/preview-proxy/src/services/resolver.ts
+++ b/apps/preview-proxy/src/services/resolver.ts
@@ -1,5 +1,5 @@
 import {
-  CloudTaskStatus,
+  RunStatus,
   environmentConfigSchema,
   type EnvironmentConfig,
   LEGACY_SANDBOX_GUI_NAMED_PORT_NAME,
@@ -165,8 +165,8 @@ export async function resolveRequest(
     if (!portConfig.isProxied) {
       // Only redirect if sandbox is active
       if (
-        cloudJob.status === CloudTaskStatus.Running ||
-        cloudJob.status === CloudTaskStatus.Idle
+        cloudJob.status === RunStatus.Running ||
+        cloudJob.status === RunStatus.Idle
       ) {
         const directUrl = getSandboxUrl(cloudJob, portName);
 
@@ -233,8 +233,8 @@ export async function resolveRequest(
 
     // If job is active, return the sandbox URL with auth context
     if (
-      cloudJob.status === CloudTaskStatus.Running ||
-      cloudJob.status === CloudTaskStatus.Idle
+      cloudJob.status === RunStatus.Running ||
+      cloudJob.status === RunStatus.Idle
     ) {
       const sandboxUrl = getSandboxUrl(cloudJob, portName);
 
@@ -285,8 +285,8 @@ export async function resolveRequest(
 
     // Job is completed/canceled - handle redirect logic
     if (
-      cloudJob.status === CloudTaskStatus.Completed ||
-      cloudJob.status === CloudTaskStatus.Canceled
+      cloudJob.status === RunStatus.Completed ||
+      cloudJob.status === RunStatus.Canceled
     ) {
       logger.info(
         { ...identifierLog, status: cloudJob.status },

--- a/apps/preview-proxy/src/services/resolver.ts
+++ b/apps/preview-proxy/src/services/resolver.ts
@@ -6,13 +6,7 @@ import {
   SANDBOX_SNAPSHOT_EXPIRY_MS,
   slugToPortKey,
 } from '@roomote/types';
-import {
-  type CloudJob,
-  taskRuns,
-  desc,
-  environments,
-  eq,
-} from '@roomote/db/server';
+import { type Run, taskRuns, desc, environments, eq } from '@roomote/db/server';
 
 import { db } from '../lib/db';
 import { logger, escapeForLog } from '../lib/logger';
@@ -39,7 +33,7 @@ export interface ResolvedRequest {
    * Used with 'redirect_to_direct' status after auth validation.
    */
   directUrl?: string;
-  cloudJob: CloudJob | null;
+  cloudJob: Run | null;
   requiresAuth: boolean;
   /**
    * Whether this specific port has an auth-proxy instance in front of it.
@@ -389,7 +383,7 @@ function uniqueNonEmptyPaths(paths: Array<string | undefined>): string[] {
  * Also returns whether the port is proxied (for cookie forwarding decision).
  */
 async function checkPortConfig(
-  cloudJob: CloudJob,
+  cloudJob: Run,
   portName: string,
 ): Promise<PortAuthResult> {
   const portKey = slugToPortKey(portName);

--- a/apps/web/src/app/(sandbox)/task/[taskId]/HistoricalContent.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/HistoricalContent.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
-import { CloudTaskStatus } from '@roomote/types';
+import { RunStatus } from '@roomote/types';
 import { MessageSquareWarning } from 'lucide-react';
 import { Sun } from '@/components/system';
 import { Message, MessageContent, Shimmer } from '@/components/ai-elements';
@@ -44,8 +44,8 @@ export function HistoricalContent({ session, footer }: HistoricalContentProps) {
     if (
       !cloudJob ||
       !displayError ||
-      (cloudJob.status !== CloudTaskStatus.Failed &&
-        cloudJob.status !== CloudTaskStatus.Canceled)
+      (cloudJob.status !== RunStatus.Failed &&
+        cloudJob.status !== RunStatus.Canceled)
     ) {
       return null;
     }

--- a/apps/web/src/app/(sandbox)/task/[taskId]/PreviewCommand.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/PreviewCommand.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
-import type { CloudJob } from '@roomote/db';
+import type { Run } from '@roomote/db';
 
 import { AppWindow } from '@/components/system';
 import { useRegisterCommands } from '@/components/layout';
@@ -11,7 +11,7 @@ import { usePreviewPane } from './hooks/use-preview-pane';
 import { resolvePreviewTarget, usePreviewUrls } from './hooks/use-preview-urls';
 
 interface PreviewCommandProps {
-  cloudJob: CloudJob | null;
+  cloudJob: Run | null;
   asleep: boolean;
 }
 

--- a/apps/web/src/app/(sandbox)/task/[taskId]/hooks/HistoricalSandboxProvider.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/hooks/HistoricalSandboxProvider.tsx
@@ -3,7 +3,7 @@
 import { type ReactNode, useEffect, useRef } from 'react';
 
 import {
-  type CloudTaskStatus,
+  type RunStatus,
   type CodingHarness,
   ROOMOTE_RUNTIME_TASK_MESSAGE_PROTOCOL,
   type TaskPhase,
@@ -51,7 +51,7 @@ interface HistoricalSandboxProviderProps {
    * Persisted runtime state used to infer whether a trailing assistant
    * transcript segment represents a completed turn.
    */
-  taskStatus?: CloudTaskStatus | null;
+  taskStatus?: RunStatus | null;
   taskPhase?: TaskPhase | null;
 
   /**

--- a/apps/web/src/app/(sandbox)/task/[taskId]/hooks/SandboxProvider.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/hooks/SandboxProvider.tsx
@@ -14,7 +14,7 @@ import { useStore } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
 
 import {
-  type CloudTaskStatus,
+  type RunStatus,
   type TaskPhase,
   type AcpPlanTodo,
   type TaskStatusEvent,
@@ -59,7 +59,7 @@ interface SandboxProviderProps {
     TaskMessageEnvelopesQueryState,
     'data' | 'isSuccess' | 'isError'
   >;
-  initialTaskStatus?: CloudTaskStatus | null;
+  initialTaskStatus?: RunStatus | null;
   initialTaskPhase?: TaskPhase | null;
   fallback: ReactNode;
   children: ReactNode;

--- a/apps/web/src/app/(sandbox)/task/[taskId]/hooks/__tests__/HistoricalSandboxProvider.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/hooks/__tests__/HistoricalSandboxProvider.client.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { ACP_ENVELOPE_EVENT_TYPES, CloudTaskStatus } from '@roomote/types';
+import { ACP_ENVELOPE_EVENT_TYPES, RunStatus } from '@roomote/types';
 
 import { HistoricalSandboxProvider } from '../HistoricalSandboxProvider';
 import { useSandboxMessages, useSandboxTaskPhase } from '../SandboxProvider';
@@ -48,7 +48,7 @@ describe('HistoricalSandboxProvider', () => {
         taskId="task-123"
         history={history}
         harness="opencode-server"
-        taskStatus={CloudTaskStatus.Completed}
+        taskStatus={RunStatus.Completed}
         taskPhase="idle"
       >
         <PhaseProbe />
@@ -64,7 +64,7 @@ describe('HistoricalSandboxProvider', () => {
         taskId="task-123"
         history={history}
         harness="opencode-server"
-        taskStatus={CloudTaskStatus.Running}
+        taskStatus={RunStatus.Running}
         taskPhase={null}
       >
         <PhaseProbe />
@@ -78,7 +78,7 @@ describe('HistoricalSandboxProvider', () => {
         taskId="task-123"
         history={history}
         harness="opencode-server"
-        taskStatus={CloudTaskStatus.Completed}
+        taskStatus={RunStatus.Completed}
         taskPhase="waiting_for_prompt"
       >
         <PhaseProbe />
@@ -191,7 +191,7 @@ describe('HistoricalSandboxProvider', () => {
         taskId="task-123"
         history={history}
         harness="opencode-server"
-        taskStatus={CloudTaskStatus.Completed}
+        taskStatus={RunStatus.Completed}
         taskPhase="idle"
       >
         <MessageKindsProbe />

--- a/apps/web/src/app/(sandbox)/task/[taskId]/hooks/__tests__/use-cloud-session.client.test.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/hooks/__tests__/use-cloud-session.client.test.ts
@@ -1,8 +1,8 @@
-import { TaskPayloadKind, type CloudTaskPayload } from '@roomote/types';
+import { TaskPayloadKind, type TaskPayload } from '@roomote/types';
 
 import { getCloudJobVisiblePrompt, getCloudJobPromptText } from '@/lib';
 
-function buildCloudJob(payload: CloudTaskPayload) {
+function buildCloudJob(payload: TaskPayload) {
   return { payload } as const;
 }
 
@@ -13,7 +13,7 @@ describe('getCloudJobPromptText', () => {
         buildCloudJob({
           repo: 'Roomote/example-app',
           description: 'Investigate the failing route',
-        } satisfies CloudTaskPayload<typeof TaskPayloadKind.StandardTask>),
+        } satisfies TaskPayload<typeof TaskPayloadKind.StandardTask>),
       ),
     ).toBe('Investigate the failing route');
   });
@@ -28,7 +28,7 @@ describe('getCloudJobPromptText', () => {
           ts: '123.000',
           thread_ts: '123.456',
           repo: 'Roomote/example-app',
-        } satisfies CloudTaskPayload<typeof TaskPayloadKind.SlackAppMention>),
+        } satisfies TaskPayload<typeof TaskPayloadKind.SlackAppMention>),
       ),
     ).toBe('<slack_message>\nplease help\n</slack_message>');
   });
@@ -42,9 +42,7 @@ describe('getCloudJobPromptText', () => {
           prTitle: 'Fix the task transcript UI',
           commentBody:
             'Fix this specific issue:\n\nThe task page shows raw XML.',
-        } satisfies CloudTaskPayload<
-          typeof TaskPayloadKind.GithubPrReviewFollowUp
-        >),
+        } satisfies TaskPayload<typeof TaskPayloadKind.GithubPrReviewFollowUp>),
       ),
     ).toBe('Fix this specific issue:\n\nThe task page shows raw XML.');
   });
@@ -58,7 +56,7 @@ describe('getCloudJobPromptText', () => {
           sourceCloudJobId: 42,
           text: 'Original launch prompt',
           resumePrompt: 'Wake up and continue',
-        } satisfies CloudTaskPayload<typeof TaskPayloadKind.SnapshotResume>),
+        } satisfies TaskPayload<typeof TaskPayloadKind.SnapshotResume>),
       ),
     ).toBe('Wake up and continue');
   });
@@ -75,7 +73,7 @@ describe('getCloudJobVisiblePrompt', () => {
           ts: '123.000',
           thread_ts: '123.456',
           repo: 'Roomote/example-app',
-        } satisfies CloudTaskPayload<typeof TaskPayloadKind.SlackAppMention>),
+        } satisfies TaskPayload<typeof TaskPayloadKind.SlackAppMention>),
       ),
     ).toEqual({
       text: 'latest question',
@@ -93,7 +91,7 @@ describe('getCloudJobVisiblePrompt', () => {
           ts: '123.000',
           thread_ts: '123.456',
           repo: 'Roomote/example-app',
-        } satisfies CloudTaskPayload<typeof TaskPayloadKind.SlackAppMention>),
+        } satisfies TaskPayload<typeof TaskPayloadKind.SlackAppMention>),
       ),
     ).toEqual({
       text: 'latest question',
@@ -111,7 +109,7 @@ describe('getCloudJobVisiblePrompt', () => {
           ts: '123.000',
           thread_ts: '123.456',
           repo: 'Roomote/example-app',
-        } satisfies CloudTaskPayload<typeof TaskPayloadKind.SlackAppMention>),
+        } satisfies TaskPayload<typeof TaskPayloadKind.SlackAppMention>),
       ),
     ).toEqual({
       text: 'latest question',
@@ -125,7 +123,7 @@ describe('getCloudJobVisiblePrompt', () => {
         buildCloudJob({
           repo: 'Roomote/example-app',
           images: ['data:image/png;base64,abc123'],
-        } satisfies CloudTaskPayload<typeof TaskPayloadKind.StandardTask>),
+        } satisfies TaskPayload<typeof TaskPayloadKind.StandardTask>),
       ),
     ).toEqual({
       images: ['data:image/png;base64,abc123'],
@@ -145,7 +143,7 @@ describe('getCloudJobVisiblePrompt', () => {
           visibleInTranscript: false,
           resumePrompt: 'Wake up and continue',
           resumePromptImages: ['data:image/png;base64,new'],
-        } satisfies CloudTaskPayload<typeof TaskPayloadKind.SnapshotResume>),
+        } satisfies TaskPayload<typeof TaskPayloadKind.SnapshotResume>),
       ),
     ).toEqual({
       text: 'Wake up and continue',
@@ -165,7 +163,7 @@ describe('getCloudJobVisiblePrompt', () => {
           images: ['data:image/png;base64,old'],
           visibleInTranscript: false,
           resumePrompt: 'Wake up and continue',
-        } satisfies CloudTaskPayload<typeof TaskPayloadKind.SnapshotResume>),
+        } satisfies TaskPayload<typeof TaskPayloadKind.SnapshotResume>),
       ),
     ).toEqual({
       text: 'Wake up and continue',
@@ -178,7 +176,7 @@ describe('getCloudJobVisiblePrompt', () => {
       getCloudJobVisiblePrompt(
         buildCloudJob({
           repo: 'Roomote/example-app',
-        } satisfies CloudTaskPayload<typeof TaskPayloadKind.StandardTask>),
+        } satisfies TaskPayload<typeof TaskPayloadKind.StandardTask>),
       ),
     ).toBeNull();
   });

--- a/apps/web/src/app/(sandbox)/task/[taskId]/hooks/trailing-assistant-completion.client.test.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/hooks/trailing-assistant-completion.client.test.ts
@@ -1,4 +1,4 @@
-import { CloudTaskStatus } from '@roomote/types';
+import { RunStatus } from '@roomote/types';
 
 import { shouldMarkTrailingAssistantCompletion } from './trailing-assistant-completion';
 
@@ -6,7 +6,7 @@ describe('shouldMarkTrailingAssistantCompletion', () => {
   it('does not treat an unknown running phase as a completed turn', () => {
     expect(
       shouldMarkTrailingAssistantCompletion({
-        taskStatus: CloudTaskStatus.Running,
+        taskStatus: RunStatus.Running,
         taskPhase: null,
       }),
     ).toBe(false);
@@ -15,14 +15,14 @@ describe('shouldMarkTrailingAssistantCompletion', () => {
   it('marks waiting phases as completed turns', () => {
     expect(
       shouldMarkTrailingAssistantCompletion({
-        taskStatus: CloudTaskStatus.Running,
+        taskStatus: RunStatus.Running,
         taskPhase: 'waiting_for_prompt',
       }),
     ).toBe(true);
 
     expect(
       shouldMarkTrailingAssistantCompletion({
-        taskStatus: CloudTaskStatus.Running,
+        taskStatus: RunStatus.Running,
         taskPhase: 'waiting_for_user_input',
       }),
     ).toBe(true);
@@ -31,14 +31,14 @@ describe('shouldMarkTrailingAssistantCompletion', () => {
   it('marks successful legacy exits with no task phase as completed turns', () => {
     expect(
       shouldMarkTrailingAssistantCompletion({
-        taskStatus: CloudTaskStatus.Completed,
+        taskStatus: RunStatus.Completed,
         taskPhase: null,
       }),
     ).toBe(true);
 
     expect(
       shouldMarkTrailingAssistantCompletion({
-        taskStatus: CloudTaskStatus.Idle,
+        taskStatus: RunStatus.Idle,
         taskPhase: null,
       }),
     ).toBe(true);
@@ -47,14 +47,14 @@ describe('shouldMarkTrailingAssistantCompletion', () => {
   it('does not mark failed or canceled transcripts as completed turns', () => {
     expect(
       shouldMarkTrailingAssistantCompletion({
-        taskStatus: CloudTaskStatus.Failed,
+        taskStatus: RunStatus.Failed,
         taskPhase: 'waiting_for_prompt',
       }),
     ).toBe(false);
 
     expect(
       shouldMarkTrailingAssistantCompletion({
-        taskStatus: CloudTaskStatus.Canceled,
+        taskStatus: RunStatus.Canceled,
         taskPhase: null,
       }),
     ).toBe(false);

--- a/apps/web/src/app/(sandbox)/task/[taskId]/hooks/trailing-assistant-completion.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/hooks/trailing-assistant-completion.ts
@@ -1,4 +1,4 @@
-import { CloudTaskStatus, type TaskPhase } from '@roomote/types';
+import { RunStatus, type TaskPhase } from '@roomote/types';
 
 const TURN_COMPLETION_TASK_PHASES = new Set<TaskPhase>([
   'idle',
@@ -11,12 +11,9 @@ export function shouldMarkTrailingAssistantCompletion({
   taskStatus,
 }: {
   taskPhase?: TaskPhase | null;
-  taskStatus?: CloudTaskStatus | null;
+  taskStatus?: RunStatus | null;
 }): boolean {
-  if (
-    taskStatus === CloudTaskStatus.Failed ||
-    taskStatus === CloudTaskStatus.Canceled
-  ) {
+  if (taskStatus === RunStatus.Failed || taskStatus === RunStatus.Canceled) {
     return false;
   }
 
@@ -24,8 +21,5 @@ export function shouldMarkTrailingAssistantCompletion({
     return TURN_COMPLETION_TASK_PHASES.has(taskPhase);
   }
 
-  return (
-    taskStatus === CloudTaskStatus.Completed ||
-    taskStatus === CloudTaskStatus.Idle
-  );
+  return taskStatus === RunStatus.Completed || taskStatus === RunStatus.Idle;
 }

--- a/apps/web/src/app/(sandbox)/task/[taskId]/hooks/use-cloud-session.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/hooks/use-cloud-session.ts
@@ -5,7 +5,7 @@ import type { inferRouterOutputs } from '@trpc/server';
 import {
   ACP_ENVELOPE_EVENT_TYPES,
   type CodingHarness,
-  isExitedCloudTaskStatus,
+  isExitedRunStatus,
   DEFAULT_CODING_HARNESS,
 } from '@roomote/types';
 
@@ -147,7 +147,7 @@ export function useCloudSession(
           sessionQuery.data?.cloudJob?.sleepRequestedAt ||
           sessionQuery.data?.cloudJob?.snapshotRequestedAt
         ) &&
-          !isExitedCloudTaskStatus(sessionQuery.data?.cloudJob?.status) &&
+          !isExitedRunStatus(sessionQuery.data?.cloudJob?.status) &&
           !sessionQuery.data?.cloudJob?.snapshotCreatedAt &&
           !sessionQuery.data?.cloudJob?.snapshotFailedAt,
       ),

--- a/apps/web/src/app/(sandbox)/task/[taskId]/hooks/use-preview-urls.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/hooks/use-preview-urls.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { appendInitialPath } from '@roomote/types';
 
-import type { CloudJob } from '@roomote/db';
+import type { Run } from '@roomote/db';
 
 import { buildTaskPreviewUrls, getPrimaryPreviewUrlWithPath } from '@/lib';
 
@@ -52,7 +52,7 @@ export function usePreviewUrls({
   previewProxyBaseUrl,
 }: Partial<
   Pick<
-    CloudJob,
+    Run,
     | 'taskId'
     | 'machineDomains'
     | 'machineDomain'

--- a/apps/web/src/app/(sandbox)/task/[taskId]/page.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/page.client.test.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
 
 const {
   replaceMock,
@@ -223,7 +223,7 @@ describe('SandboxPage', () => {
       ...baseSession,
       cloudJob: {
         ...baseSession.cloudJob,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         payloadKind: TaskPayloadKind.SnapshotResume,
         sourceRunId: 42,
         sourceSnapshotId: 'snapshot-123',
@@ -250,7 +250,7 @@ describe('SandboxPage', () => {
       ...baseSession,
       cloudJob: {
         ...baseSession.cloudJob,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         payloadKind: TaskPayloadKind.StandardTask,
       },
       prompt: {

--- a/apps/web/src/app/(sandbox)/task/[taskId]/page.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/page.tsx
@@ -14,7 +14,7 @@ import { CircleSlash } from '@/components/system';
 import {
   TaskPayloadKind,
   DEFAULT_CODING_HARNESS,
-  isExitedCloudTaskStatus,
+  isExitedRunStatus,
   type TaskPhase,
 } from '@roomote/types';
 
@@ -137,7 +137,7 @@ export default function SandboxPage() {
       !activeCloudJobId ||
       !activeCloudJobStatus ||
       sessionState !== 'interactive' ||
-      isExitedCloudTaskStatus(activeCloudJobStatus)
+      isExitedRunStatus(activeCloudJobStatus)
     ) {
       return;
     }

--- a/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-actions/OverflowMenu.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-actions/OverflowMenu.tsx
@@ -6,7 +6,7 @@ import { toast } from 'sonner';
 import { MoreVertical, Trash2 } from '@/components/system';
 import { SideNavItem } from '@/components/layout/side-nav/SideNavItem';
 
-import { isExitedCloudTaskStatus } from '@roomote/types';
+import { isExitedRunStatus } from '@roomote/types';
 
 import { useUser } from '@/hooks/useUser';
 import { useDeleteTasks } from '@/hooks/tasks';
@@ -39,7 +39,7 @@ function OverflowMenuBase({
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
   // Task deletion is deployment-wide: any member can delete any task.
-  const canShutdown = !!cloudJob && !isExitedCloudTaskStatus(cloudJob.status);
+  const canShutdown = !!cloudJob && !isExitedRunStatus(cloudJob.status);
 
   const deleteTasks = useDeleteTasks({
     onSuccess: () => {

--- a/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-panels/PreviewSidePanel.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-panels/PreviewSidePanel.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react';
 
 import { appendInitialPath, getPrimaryPortName } from '@roomote/types';
-import type { CloudJob } from '@roomote/db';
+import type { Run } from '@roomote/db';
 
 import {
   ArrowLeft,
@@ -119,7 +119,7 @@ export function PreviewSidePanel({
   cloudJob,
   onClose,
 }: {
-  cloudJob?: CloudJob;
+  cloudJob?: Run;
   onClose: () => void;
 }) {
   const {

--- a/apps/web/src/app/(sandbox)/task/[taskId]/startup/Startup.stories.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/startup/Startup.stories.tsx
@@ -2,7 +2,7 @@
 
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
-import { CloudTaskStatus } from '@roomote/types';
+import { RunStatus } from '@roomote/types';
 import type { SandboxLogEntry } from '@roomote/types';
 
 import { StartupSequence, type StartupStep } from './StartupMessage';
@@ -33,10 +33,7 @@ type Story = StoryObj<typeof meta>;
 // Mock data helpers
 // ---------------------------------------------------------------------------
 
-const mockStep = (
-  status: CloudTaskStatus,
-  completed: boolean,
-): StartupStep => ({
+const mockStep = (status: RunStatus, completed: boolean): StartupStep => ({
   status,
   completed,
 });
@@ -114,7 +111,7 @@ const mockSandboxLogs: SandboxLogEntry[] = [
 export const StepPending: Story = {
   name: 'Step – Pending (active)',
   render: () => (
-    <StartupSequence steps={[mockStep(CloudTaskStatus.Pending, false)]} />
+    <StartupSequence steps={[mockStep(RunStatus.Pending, false)]} />
   ),
 };
 
@@ -122,7 +119,7 @@ export const StepPending: Story = {
 export const StepDequeued: Story = {
   name: 'Step – Dequeued',
   render: () => (
-    <StartupSequence steps={[mockStep(CloudTaskStatus.Dequeued, false)]} />
+    <StartupSequence steps={[mockStep(RunStatus.Dequeued, false)]} />
   ),
 };
 
@@ -130,7 +127,7 @@ export const StepDequeued: Story = {
 export const StepCompletedProcessing: Story = {
   name: 'Step – Processing (completed)',
   render: () => (
-    <StartupSequence steps={[mockStep(CloudTaskStatus.Processing, true)]} />
+    <StartupSequence steps={[mockStep(RunStatus.Processing, true)]} />
   ),
 };
 
@@ -139,12 +136,12 @@ export const AllStepStatuses: Story = {
   name: 'All step statuses',
   render: () => {
     const statuses = [
-      CloudTaskStatus.Pending,
-      CloudTaskStatus.Dequeued,
-      CloudTaskStatus.Processing,
-      CloudTaskStatus.Preparing,
-      CloudTaskStatus.Spawning,
-      CloudTaskStatus.Connecting,
+      RunStatus.Pending,
+      RunStatus.Dequeued,
+      RunStatus.Processing,
+      RunStatus.Preparing,
+      RunStatus.Spawning,
+      RunStatus.Connecting,
     ] as const;
 
     return (
@@ -162,12 +159,12 @@ export const AllStepIcons: Story = {
   name: 'All step icons (none completed)',
   render: () => {
     const statuses = [
-      CloudTaskStatus.Pending,
-      CloudTaskStatus.Dequeued,
-      CloudTaskStatus.Processing,
-      CloudTaskStatus.Preparing,
-      CloudTaskStatus.Spawning,
-      CloudTaskStatus.Connecting,
+      RunStatus.Pending,
+      RunStatus.Dequeued,
+      RunStatus.Processing,
+      RunStatus.Preparing,
+      RunStatus.Spawning,
+      RunStatus.Connecting,
     ] as const;
 
     return (
@@ -183,12 +180,12 @@ export const AllStepStatusesGeneric: Story = {
   name: 'All step statuses (generic copy)',
   render: () => {
     const statuses = [
-      CloudTaskStatus.Pending,
-      CloudTaskStatus.Dequeued,
-      CloudTaskStatus.Processing,
-      CloudTaskStatus.Preparing,
-      CloudTaskStatus.Spawning,
-      CloudTaskStatus.Connecting,
+      RunStatus.Pending,
+      RunStatus.Dequeued,
+      RunStatus.Processing,
+      RunStatus.Preparing,
+      RunStatus.Spawning,
+      RunStatus.Connecting,
     ] as const;
 
     return (
@@ -206,9 +203,9 @@ export const Canceled: Story = {
   render: () => (
     <StartupSequence
       steps={[
-        mockStep(CloudTaskStatus.Pending, true),
-        mockStep(CloudTaskStatus.Processing, true),
-        mockStep(CloudTaskStatus.Canceled, true),
+        mockStep(RunStatus.Pending, true),
+        mockStep(RunStatus.Processing, true),
+        mockStep(RunStatus.Canceled, true),
       ]}
     />
   ),
@@ -224,12 +221,12 @@ export const FullBootInProgress: Story = {
   render: () => (
     <StartupSequence
       steps={[
-        mockStep(CloudTaskStatus.Pending, true),
-        mockStep(CloudTaskStatus.Dequeued, true),
-        mockStep(CloudTaskStatus.Processing, true),
-        mockStep(CloudTaskStatus.Preparing, true),
-        mockStep(CloudTaskStatus.Spawning, true),
-        mockStep(CloudTaskStatus.Connecting, false),
+        mockStep(RunStatus.Pending, true),
+        mockStep(RunStatus.Dequeued, true),
+        mockStep(RunStatus.Processing, true),
+        mockStep(RunStatus.Preparing, true),
+        mockStep(RunStatus.Spawning, true),
+        mockStep(RunStatus.Connecting, false),
       ]}
     />
   ),
@@ -241,12 +238,12 @@ export const FullBootRunning: Story = {
   render: () => (
     <StartupSequence
       steps={[
-        mockStep(CloudTaskStatus.Pending, true),
-        mockStep(CloudTaskStatus.Dequeued, true),
-        mockStep(CloudTaskStatus.Processing, true),
-        mockStep(CloudTaskStatus.Preparing, true),
-        mockStep(CloudTaskStatus.Spawning, true),
-        mockStep(CloudTaskStatus.Connecting, true),
+        mockStep(RunStatus.Pending, true),
+        mockStep(RunStatus.Dequeued, true),
+        mockStep(RunStatus.Processing, true),
+        mockStep(RunStatus.Preparing, true),
+        mockStep(RunStatus.Spawning, true),
+        mockStep(RunStatus.Connecting, true),
       ]}
     />
   ),
@@ -258,11 +255,11 @@ export const WithSandboxLogs: Story = {
   render: () => (
     <StartupSequence
       steps={[
-        mockStep(CloudTaskStatus.Pending, true),
-        mockStep(CloudTaskStatus.Dequeued, true),
-        mockStep(CloudTaskStatus.Processing, true),
-        mockStep(CloudTaskStatus.Preparing, true),
-        mockStep(CloudTaskStatus.Spawning, false),
+        mockStep(RunStatus.Pending, true),
+        mockStep(RunStatus.Dequeued, true),
+        mockStep(RunStatus.Processing, true),
+        mockStep(RunStatus.Preparing, true),
+        mockStep(RunStatus.Spawning, false),
       ]}
       logs={mockSandboxLogs}
     />
@@ -275,9 +272,9 @@ export const WithSandboxLogsError: Story = {
   render: () => (
     <StartupSequence
       steps={[
-        mockStep(CloudTaskStatus.Pending, true),
-        mockStep(CloudTaskStatus.Dequeued, true),
-        mockStep(CloudTaskStatus.Spawning, false),
+        mockStep(RunStatus.Pending, true),
+        mockStep(RunStatus.Dequeued, true),
+        mockStep(RunStatus.Spawning, false),
       ]}
       logs={mockSandboxLogs.slice(0, 5)}
       logsConnected={false}
@@ -292,12 +289,12 @@ export const FailedWithLogs: Story = {
   render: () => (
     <StartupSequence
       steps={[
-        mockStep(CloudTaskStatus.Pending, true),
-        mockStep(CloudTaskStatus.Dequeued, true),
-        mockStep(CloudTaskStatus.Processing, true),
-        mockStep(CloudTaskStatus.Preparing, true),
-        mockStep(CloudTaskStatus.Spawning, true),
-        mockStep(CloudTaskStatus.Failed, true),
+        mockStep(RunStatus.Pending, true),
+        mockStep(RunStatus.Dequeued, true),
+        mockStep(RunStatus.Processing, true),
+        mockStep(RunStatus.Preparing, true),
+        mockStep(RunStatus.Spawning, true),
+        mockStep(RunStatus.Failed, true),
       ]}
       error="Sandbox container failed to start: timeout after 60s"
       logs={mockSandboxLogs}
@@ -312,9 +309,9 @@ export const FailedWithoutError: Story = {
   render: () => (
     <StartupSequence
       steps={[
-        mockStep(CloudTaskStatus.Pending, true),
-        mockStep(CloudTaskStatus.Dequeued, true),
-        mockStep(CloudTaskStatus.Failed, true),
+        mockStep(RunStatus.Pending, true),
+        mockStep(RunStatus.Dequeued, true),
+        mockStep(RunStatus.Failed, true),
       ]}
       logs={mockSandboxLogs.slice(0, 3)}
       logsConnected={false}
@@ -326,6 +323,6 @@ export const FailedWithoutError: Story = {
 export const JustStarted: Story = {
   name: 'Just started',
   render: () => (
-    <StartupSequence steps={[mockStep(CloudTaskStatus.Pending, false)]} />
+    <StartupSequence steps={[mockStep(RunStatus.Pending, false)]} />
   ),
 };

--- a/apps/web/src/app/(sandbox)/task/[taskId]/startup/Startup.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/startup/Startup.tsx
@@ -4,7 +4,7 @@ import { useCallback } from 'react';
 import { SSEProvider } from 'react-hooks-sse';
 
 import { TaskPayloadKind, type CloudTaskStatus } from '@roomote/types';
-import type { CloudJob } from '@roomote/db';
+import type { Run } from '@roomote/db';
 
 import { useRestoreCloudJobSnapshot } from '@/hooks/snapshots';
 import { getCloudJobError } from '@/lib/cloud-job-errors';
@@ -14,7 +14,7 @@ import { useStartupProgress } from './useStartupProgress';
 
 interface StartupProps {
   cloudJobId: number;
-  initialCloudJob?: CloudJob;
+  initialCloudJob?: Run;
   onStatusChange?: (status: CloudTaskStatus) => void;
 }
 
@@ -47,7 +47,7 @@ export const Startup = ({
 
 interface StartupInnerProps {
   cloudJobId: number;
-  initialCloudJob?: CloudJob;
+  initialCloudJob?: Run;
   onStatusChange?: (status: CloudTaskStatus) => void;
 }
 
@@ -92,7 +92,7 @@ const StartupInner = ({
 
 interface SnapshotResumeFailureFooterProps {
   cloudJob: Pick<
-    CloudJob,
+    Run,
     | 'error'
     | 'result'
     | 'sourceRunId'

--- a/apps/web/src/app/(sandbox)/task/[taskId]/startup/Startup.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/startup/Startup.tsx
@@ -3,7 +3,7 @@
 import { useCallback } from 'react';
 import { SSEProvider } from 'react-hooks-sse';
 
-import { TaskPayloadKind, type CloudTaskStatus } from '@roomote/types';
+import { TaskPayloadKind, type RunStatus } from '@roomote/types';
 import type { Run } from '@roomote/db';
 
 import { useRestoreCloudJobSnapshot } from '@/hooks/snapshots';
@@ -15,7 +15,7 @@ import { useStartupProgress } from './useStartupProgress';
 interface StartupProps {
   cloudJobId: number;
   initialCloudJob?: Run;
-  onStatusChange?: (status: CloudTaskStatus) => void;
+  onStatusChange?: (status: RunStatus) => void;
 }
 
 export const Startup = ({
@@ -48,7 +48,7 @@ export const Startup = ({
 interface StartupInnerProps {
   cloudJobId: number;
   initialCloudJob?: Run;
-  onStatusChange?: (status: CloudTaskStatus) => void;
+  onStatusChange?: (status: RunStatus) => void;
 }
 
 const StartupInner = ({

--- a/apps/web/src/app/(sandbox)/task/[taskId]/startup/StartupMessage.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/startup/StartupMessage.client.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 
-import { CloudTaskStatus } from '@roomote/types';
+import { RunStatus } from '@roomote/types';
 
 vi.mock('@/components/ai-elements', () => ({
   Message: ({
@@ -60,7 +60,7 @@ describe('StartupSequence', () => {
   it('uses generic spawning startup copy for Generalist', () => {
     render(
       <StartupSequence
-        steps={[{ status: CloudTaskStatus.Spawning, completed: false }]}
+        steps={[{ status: RunStatus.Spawning, completed: false }]}
       />,
     );
 
@@ -71,7 +71,7 @@ describe('StartupSequence', () => {
   it('uses generic spawning startup copy for named agents', () => {
     render(
       <StartupSequence
-        steps={[{ status: CloudTaskStatus.Spawning, completed: false }]}
+        steps={[{ status: RunStatus.Spawning, completed: false }]}
       />,
     );
 
@@ -82,7 +82,7 @@ describe('StartupSequence', () => {
   it('uses generic connecting startup copy', () => {
     render(
       <StartupSequence
-        steps={[{ status: CloudTaskStatus.Connecting, completed: false }]}
+        steps={[{ status: RunStatus.Connecting, completed: false }]}
       />,
     );
 
@@ -93,7 +93,7 @@ describe('StartupSequence', () => {
   it('renders a readable model provider credential error for canceled boot failures', () => {
     render(
       <StartupSequence
-        steps={[{ status: CloudTaskStatus.Canceled, completed: true }]}
+        steps={[{ status: RunStatus.Canceled, completed: true }]}
         error={`OpenAI admin request failed (401): {
   "error": {
     "message": "Incorrect API key provided: sk-admin*fake. You can find your API key at https://platform.openai.com/account/api-keys.",
@@ -121,7 +121,7 @@ describe('StartupSequence', () => {
   it('renders the GPU warmup copy while waiting in running startup state', () => {
     render(
       <StartupSequence
-        steps={[{ status: CloudTaskStatus.Running, completed: false }]}
+        steps={[{ status: RunStatus.Running, completed: false }]}
       />,
     );
 
@@ -133,7 +133,7 @@ describe('StartupSequence', () => {
 
     render(
       <StartupSequence
-        steps={[{ status: CloudTaskStatus.Failed, completed: true }]}
+        steps={[{ status: RunStatus.Failed, completed: true }]}
         error="resume failed"
         retryAction={{ onClick }}
       />,
@@ -150,11 +150,11 @@ describe('StartupSequence', () => {
     const { container } = render(
       <StartupSequence
         steps={[
-          { status: CloudTaskStatus.Pending, completed: true },
-          { status: CloudTaskStatus.Dequeued, completed: true },
-          { status: CloudTaskStatus.Processing, completed: true },
-          { status: CloudTaskStatus.Preparing, completed: true },
-          { status: CloudTaskStatus.Spawning, completed: false },
+          { status: RunStatus.Pending, completed: true },
+          { status: RunStatus.Dequeued, completed: true },
+          { status: RunStatus.Processing, completed: true },
+          { status: RunStatus.Preparing, completed: true },
+          { status: RunStatus.Spawning, completed: false },
         ]}
         error="Boot output overflow"
       />,

--- a/apps/web/src/app/(sandbox)/task/[taskId]/startup/StartupMessage.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/startup/StartupMessage.tsx
@@ -14,7 +14,7 @@ import {
   SquareDashedMousePointer,
 } from '@/components/system';
 
-import { CloudTaskStatus } from '@roomote/types';
+import { RunStatus } from '@roomote/types';
 import type { SandboxLogEntry } from '@roomote/types';
 
 import { getCloudJobErrorDisplayMessage } from '@/lib/cloud-job-errors';
@@ -25,7 +25,7 @@ import { SandboxLogsTerminal } from '@/components/sandbox';
 import { MessageSquareWarning, RotateCcw } from 'lucide-react';
 
 export interface StartupStep {
-  status: CloudTaskStatus;
+  status: RunStatus;
   completed: boolean;
 }
 
@@ -37,29 +37,29 @@ interface StartupMessageProps {
 const getStepIcon = (step: StartupStep): LucideIcon => {
   if (
     step.completed &&
-    step.status !== CloudTaskStatus.Failed &&
-    step.status !== CloudTaskStatus.Canceled
+    step.status !== RunStatus.Failed &&
+    step.status !== RunStatus.Canceled
   ) {
     return Check;
   }
 
   switch (step.status) {
-    case CloudTaskStatus.Pending:
+    case RunStatus.Pending:
       return Hourglass;
-    case CloudTaskStatus.Dequeued:
+    case RunStatus.Dequeued:
       return HardDriveUpload;
-    case CloudTaskStatus.Processing:
+    case RunStatus.Processing:
       return Ghost;
-    case CloudTaskStatus.Preparing:
+    case RunStatus.Preparing:
       return SquareDashedMousePointer;
-    case CloudTaskStatus.Spawning:
+    case RunStatus.Spawning:
       return BotMessageSquare;
-    case CloudTaskStatus.Connecting:
+    case RunStatus.Connecting:
       return Plug;
-    case CloudTaskStatus.Running:
+    case RunStatus.Running:
       return Drum;
-    case CloudTaskStatus.Failed:
-    case CloudTaskStatus.Canceled:
+    case RunStatus.Failed:
+    case RunStatus.Canceled:
       return ThumbsDown;
     default:
       return Check;
@@ -69,27 +69,27 @@ const getStepIcon = (step: StartupStep): LucideIcon => {
 const getStepMessage = (step: StartupStep) => {
   return (() => {
     switch (step.status) {
-      case CloudTaskStatus.Pending:
+      case RunStatus.Pending:
         return 'Queueing';
-      case CloudTaskStatus.Dequeued:
+      case RunStatus.Dequeued:
         return 'Booting environment';
-      case CloudTaskStatus.Processing:
+      case RunStatus.Processing:
         return 'Manifesting the worker';
-      case CloudTaskStatus.Preparing:
+      case RunStatus.Preparing:
         return 'Preparing workspace';
-      case CloudTaskStatus.Spawning:
+      case RunStatus.Spawning:
         return 'Calling the agent';
-      case CloudTaskStatus.Connecting:
+      case RunStatus.Connecting:
         return 'Almost there';
-      case CloudTaskStatus.Running:
+      case RunStatus.Running:
         return 'Warming up my GPUs';
-      case CloudTaskStatus.Idle:
+      case RunStatus.Idle:
         return 'Idle';
-      case CloudTaskStatus.Completed:
+      case RunStatus.Completed:
         return 'Completed';
-      case CloudTaskStatus.Failed:
+      case RunStatus.Failed:
         return 'Failed to start';
-      case CloudTaskStatus.Canceled:
+      case RunStatus.Canceled:
         return 'Canceled';
       default:
         return step.status;
@@ -120,7 +120,7 @@ const StartupMessage = ({ step, isActive }: StartupMessageProps) => {
 };
 
 interface StartupErrorMessageProps {
-  status: CloudTaskStatus;
+  status: RunStatus;
   error?: string;
   retryAction?: {
     onClick: () => void;
@@ -133,8 +133,8 @@ export const StartupFailureMessage = ({
   error,
   retryAction,
 }: StartupErrorMessageProps) => {
-  const isFailed = status === CloudTaskStatus.Failed;
-  const isCanceled = status === CloudTaskStatus.Canceled;
+  const isFailed = status === RunStatus.Failed;
+  const isCanceled = status === RunStatus.Canceled;
   const displayError = getCloudJobErrorDisplayMessage(error);
 
   if ((isFailed || (isCanceled && displayError)) && displayError) {
@@ -221,23 +221,23 @@ export const StartupSequence = ({
   retryAction,
 }: StartupSequenceProps) => {
   const lastStep = steps[steps.length - 1];
-  const status = lastStep?.status ?? CloudTaskStatus.Pending;
+  const status = lastStep?.status ?? RunStatus.Pending;
 
   const preparingStepIndex = steps.findIndex(
-    (step) => step.status === CloudTaskStatus.Preparing,
+    (step) => step.status === RunStatus.Preparing,
   );
 
   const hasReachedPreparingPhase =
     preparingStepIndex >= 0 ||
     steps.some((step) =>
       [
-        CloudTaskStatus.Spawning,
-        CloudTaskStatus.Connecting,
-        CloudTaskStatus.Running,
-        CloudTaskStatus.Idle,
-        CloudTaskStatus.Completed,
-        CloudTaskStatus.Failed,
-        CloudTaskStatus.Canceled,
+        RunStatus.Spawning,
+        RunStatus.Connecting,
+        RunStatus.Running,
+        RunStatus.Idle,
+        RunStatus.Completed,
+        RunStatus.Failed,
+        RunStatus.Canceled,
       ].includes(step.status),
     );
 

--- a/apps/web/src/app/(sandbox)/task/[taskId]/startup/useStartupProgress.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/startup/useStartupProgress.ts
@@ -4,9 +4,9 @@ import { useEffect, useRef, useState } from 'react';
 import { useSSE } from 'react-hooks-sse';
 
 import {
-  CloudTaskStatus,
+  RunStatus,
   getComputeProviderCapabilities,
-  isExitedCloudTaskStatus,
+  isExitedRunStatus,
   resolveComputeProviderTarget,
 } from '@roomote/types';
 import type { Run } from '@roomote/db';
@@ -19,7 +19,7 @@ import type { StartupStep } from './StartupMessage';
 interface UseStartupProgressOptions {
   cloudJobId: number;
   initialCloudJob?: Run;
-  onStatusChange?: (status: CloudTaskStatus) => void;
+  onStatusChange?: (status: RunStatus) => void;
 }
 
 export function useStartupProgress({
@@ -27,12 +27,12 @@ export function useStartupProgress({
   initialCloudJob,
   onStatusChange,
 }: UseStartupProgressOptions) {
-  const initialStatus = initialCloudJob?.status ?? CloudTaskStatus.Pending;
+  const initialStatus = initialCloudJob?.status ?? RunStatus.Pending;
 
   const [steps, setSteps] = useState<StartupStep[]>([
     {
       status: initialStatus,
-      completed: isExitedCloudTaskStatus(initialStatus),
+      completed: isExitedRunStatus(initialStatus),
     },
   ]);
 
@@ -62,7 +62,7 @@ export function useStartupProgress({
     }
 
     const displayMessage = getBootStatus(status);
-    const isCompleted = isExitedCloudTaskStatus(status);
+    const isCompleted = isExitedRunStatus(status);
 
     setSteps((prev) => {
       // Check if a step already maps to this display message.
@@ -93,7 +93,7 @@ export function useStartupProgress({
   }, [status, onStatusChange]);
 
   const lastStep = steps[steps.length - 1];
-  const lastStatus = lastStep?.status ?? CloudTaskStatus.Pending;
+  const lastStatus = lastStep?.status ?? RunStatus.Pending;
 
   return {
     steps,

--- a/apps/web/src/app/(sandbox)/task/[taskId]/startup/useStartupProgress.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/startup/useStartupProgress.ts
@@ -9,7 +9,7 @@ import {
   isExitedCloudTaskStatus,
   resolveComputeProviderTarget,
 } from '@roomote/types';
-import type { CloudJob } from '@roomote/db';
+import type { Run } from '@roomote/db';
 
 import { getBootStatus, useSandboxLogs } from '@/components/sandbox';
 import { getCloudJobError } from '@/lib/cloud-job-errors';
@@ -18,7 +18,7 @@ import type { StartupStep } from './StartupMessage';
 
 interface UseStartupProgressOptions {
   cloudJobId: number;
-  initialCloudJob?: CloudJob;
+  initialCloudJob?: Run;
   onStatusChange?: (status: CloudTaskStatus) => void;
 }
 
@@ -36,7 +36,7 @@ export function useStartupProgress({
     },
   ]);
 
-  const streamedCloudJob = useSSE<CloudJob | undefined>('message', undefined);
+  const streamedCloudJob = useSSE<Run | undefined>('message', undefined);
 
   const cloudJob = streamedCloudJob ?? initialCloudJob;
   const status = cloudJob?.status ?? initialStatus;

--- a/apps/web/src/app/api/cloud-jobs/[id]/logs/route.ts
+++ b/apps/web/src/app/api/cloud-jobs/[id]/logs/route.ts
@@ -6,7 +6,7 @@ import {
   getComputeProviderCapabilities,
 } from '@roomote/compute-providers/factory';
 import {
-  isExitedCloudTaskStatus,
+  isExitedRunStatus,
   resolveComputeProviderTarget,
 } from '@roomote/types';
 
@@ -70,7 +70,7 @@ export async function GET(
     });
 
     while (!disconnected && (!machineId || !sandboxCmdId)) {
-      if (isExitedCloudTaskStatus(status)) {
+      if (isExitedRunStatus(status)) {
         break;
       }
 

--- a/apps/web/src/app/api/cloud-jobs/[id]/stream/route.ts
+++ b/apps/web/src/app/api/cloud-jobs/[id]/stream/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createResponse } from 'better-sse';
 import { z } from 'zod';
 
-import { CloudTaskStatus, isExitedCloudTaskStatus } from '@roomote/types';
+import { RunStatus, isExitedRunStatus } from '@roomote/types';
 import { db, eq, taskRuns } from '@roomote/db/server';
 
 import { authorizeUserToken } from '@/lib/server';
@@ -56,12 +56,11 @@ export async function GET(
         break;
       }
 
-      if (isExitedCloudTaskStatus(cloudJob.status)) {
+      if (isExitedRunStatus(cloudJob.status)) {
         break;
       }
 
-      const timeout =
-        cloudJob.status === CloudTaskStatus.Running ? 10_000 : 1_000;
+      const timeout = cloudJob.status === RunStatus.Running ? 10_000 : 1_000;
 
       await new Promise((resolve) => setTimeout(resolve, timeout));
     }

--- a/apps/web/src/components/layout/side-nav/SideNavTaskItem.client.test.tsx
+++ b/apps/web/src/components/layout/side-nav/SideNavTaskItem.client.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { CloudTaskStatus } from '@roomote/types';
+import { RunStatus } from '@roomote/types';
 
 const workspaceBadgeMock = vi.fn();
 const pullRequestBadgeMock = vi.fn();
@@ -78,7 +78,7 @@ vi.mock('@/components/sandbox', () => ({
     className,
   }: {
     compact?: boolean;
-    status?: CloudTaskStatus;
+    status?: RunStatus;
     phase?: string | null;
     className?: string;
   }) => {
@@ -103,7 +103,7 @@ describe('SideNavTaskItem', () => {
           id: 'task-1',
           title: 'Task title',
           cloudJob: {
-            status: CloudTaskStatus.Running,
+            status: RunStatus.Running,
             taskPhase: 'running',
             prRepo: 'owner/repo',
             prNumber: 123,
@@ -134,7 +134,7 @@ describe('SideNavTaskItem', () => {
     expect(taskStatusIndicatorMock).toHaveBeenCalledWith(
       expect.objectContaining({
         compact: true,
-        status: CloudTaskStatus.Running,
+        status: RunStatus.Running,
         phase: 'running',
       }),
     );
@@ -159,7 +159,7 @@ describe('SideNavTaskItem', () => {
           id: 'task-2',
           title: 'Task two',
           cloudJob: {
-            status: CloudTaskStatus.Completed,
+            status: RunStatus.Completed,
             taskPhase: null,
             payload: {
               repo: 'invalid_repo_name',
@@ -192,7 +192,7 @@ describe('SideNavTaskItem', () => {
           id: 'task-3',
           title: 'Task starting',
           cloudJob: {
-            status: CloudTaskStatus.Pending,
+            status: RunStatus.Pending,
             taskPhase: null,
             payload: {
               environmentId: 'env-3',
@@ -220,7 +220,7 @@ describe('SideNavTaskItem', () => {
           id: 'task-4',
           title: 'Task with live status',
           cloudJob: {
-            status: CloudTaskStatus.Pending,
+            status: RunStatus.Pending,
             taskPhase: null,
             payload: {
               environmentId: 'env-4',
@@ -260,7 +260,7 @@ describe('SideNavTaskItem', () => {
           id: 'task-5',
           title: longTitle,
           cloudJob: {
-            status: CloudTaskStatus.Running,
+            status: RunStatus.Running,
             taskPhase: 'running',
             payload: {
               environmentId: 'env-5',
@@ -311,7 +311,7 @@ describe('SideNavTaskItem', () => {
           id: 'task-6',
           title: 'Keyboard pin target',
           cloudJob: {
-            status: CloudTaskStatus.Running,
+            status: RunStatus.Running,
             taskPhase: 'running',
             payload: {
               environmentId: 'env-6',
@@ -348,7 +348,7 @@ describe('SideNavTaskItem', () => {
           id: 'task-7',
           title: 'Expanded booting task',
           cloudJob: {
-            status: CloudTaskStatus.Pending,
+            status: RunStatus.Pending,
             taskPhase: null,
             payload: {
               environmentId: 'env-7',
@@ -379,7 +379,7 @@ describe('SideNavTaskItem', () => {
           id: 'task-8',
           title: 'Expanded live running task',
           cloudJob: {
-            status: CloudTaskStatus.Running,
+            status: RunStatus.Running,
             taskPhase: 'waiting_for_prompt',
             payload: {
               environmentId: 'env-8',

--- a/apps/web/src/components/layout/side-nav/SideNavTaskItem.tsx
+++ b/apps/web/src/components/layout/side-nav/SideNavTaskItem.tsx
@@ -2,9 +2,9 @@ import { useState } from 'react';
 import Link from 'next/link';
 
 import {
-  isActivelyRunningCloudTask,
-  isBootingCloudTaskStatus,
-  type CloudTaskStatus,
+  isActivelyRunningTask,
+  isBootingRunStatus,
+  type RunStatus,
 } from '@roomote/types';
 
 import {
@@ -27,7 +27,7 @@ type SideNavQuickAccessTask = {
   id: string;
   title: string | null;
   cloudJob: {
-    status: CloudTaskStatus;
+    status: RunStatus;
     taskPhase: string | null;
     prRepo?: string | null;
     prNumber?: number | null;
@@ -74,14 +74,14 @@ export const SideNavTaskItem = ({
   const hasLiveStatus =
     liveStatus?.phase != null || Boolean(liveStatus?.lastErrorMessage);
   const isTaskStartingUp =
-    !hasLiveStatus && isBootingCloudTaskStatus(task.cloudJob.status);
+    !hasLiveStatus && isBootingRunStatus(task.cloudJob.status);
   const taskPhase = hasLiveStatus
     ? (liveStatus?.phase ?? null)
     : task.cloudJob.taskPhase;
   const taskStatus = hasLiveStatus ? undefined : task.cloudJob.status;
   const showsExpandedSpinner = hasLiveStatus
     ? taskPhase === 'running'
-    : isActivelyRunningCloudTask(task.cloudJob.status, taskPhase);
+    : isActivelyRunningTask(task.cloudJob.status, taskPhase);
 
   if (expanded) {
     return (

--- a/apps/web/src/components/sandbox/TaskStatusIndicator.client.test.tsx
+++ b/apps/web/src/components/sandbox/TaskStatusIndicator.client.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 
-import { CloudTaskStatus } from '@roomote/types';
+import { RunStatus } from '@roomote/types';
 
 import { TaskStatusIndicator } from './TaskStatusIndicator';
 
@@ -11,7 +11,7 @@ vi.mock('@/components/system', () => ({
 
 describe('TaskStatusIndicator', () => {
   it('falls back idle status to idle color/label when phase is missing', () => {
-    render(<TaskStatusIndicator status={CloudTaskStatus.Idle} />);
+    render(<TaskStatusIndicator status={RunStatus.Idle} />);
 
     const label = screen.getByText('Idle');
     expect(label.parentElement).toHaveClass('text-muted-foreground');
@@ -20,7 +20,7 @@ describe('TaskStatusIndicator', () => {
   it('prefers phase mapping when phase is available', () => {
     render(
       <TaskStatusIndicator
-        status={CloudTaskStatus.Idle}
+        status={RunStatus.Idle}
         phase="waiting_for_prompt"
       />,
     );
@@ -32,7 +32,7 @@ describe('TaskStatusIndicator', () => {
   it('renders waiting_for_user_input as needs input', () => {
     render(
       <TaskStatusIndicator
-        status={CloudTaskStatus.Running}
+        status={RunStatus.Running}
         phase="waiting_for_user_input"
       />,
     );
@@ -43,7 +43,7 @@ describe('TaskStatusIndicator', () => {
 
   it('renders compact dot-only mode without text', () => {
     const { container } = render(
-      <TaskStatusIndicator compact status={CloudTaskStatus.Running} />,
+      <TaskStatusIndicator compact status={RunStatus.Running} />,
     );
 
     expect(screen.queryByText('Working')).not.toBeInTheDocument();

--- a/apps/web/src/components/sandbox/TaskStatusIndicator.tsx
+++ b/apps/web/src/components/sandbox/TaskStatusIndicator.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import {
-  CloudTaskStatus,
-  isBootingCloudTaskStatus,
+  RunStatus,
+  isBootingRunStatus,
   TASK_PHASES,
-  type CloudTaskStatus as CloudTaskStatusType,
+  type RunStatus as CloudTaskStatusType,
   type TaskPhase,
 } from '@roomote/types';
 
@@ -47,18 +47,15 @@ function resolveTaskPhase({
     return null;
   }
 
-  if (
-    status === CloudTaskStatus.Failed ||
-    status === CloudTaskStatus.Canceled
-  ) {
+  if (status === RunStatus.Failed || status === RunStatus.Canceled) {
     return 'shutting_down';
   }
 
-  if (isBootingCloudTaskStatus(status) || status === CloudTaskStatus.Running) {
+  if (isBootingRunStatus(status) || status === RunStatus.Running) {
     return 'running';
   }
 
-  if (status === CloudTaskStatus.Idle) {
+  if (status === RunStatus.Idle) {
     return 'idle';
   }
 

--- a/apps/web/src/components/sandbox/boot-status.ts
+++ b/apps/web/src/components/sandbox/boot-status.ts
@@ -1,28 +1,28 @@
-import { CloudTaskStatus } from '@roomote/types';
+import { RunStatus } from '@roomote/types';
 
-export const getBootStatus = (status: CloudTaskStatus): string => {
+export const getBootStatus = (status: RunStatus): string => {
   switch (status) {
-    case CloudTaskStatus.Pending:
+    case RunStatus.Pending:
       return 'Pending';
-    case CloudTaskStatus.Dequeued:
+    case RunStatus.Dequeued:
       return 'Dequeued';
-    case CloudTaskStatus.Processing:
+    case RunStatus.Processing:
       return 'Processing';
-    case CloudTaskStatus.Preparing:
+    case RunStatus.Preparing:
       return 'Preparing';
-    case CloudTaskStatus.Spawning:
+    case RunStatus.Spawning:
       return 'Spawning';
-    case CloudTaskStatus.Connecting:
+    case RunStatus.Connecting:
       return 'Connecting';
-    case CloudTaskStatus.Running:
+    case RunStatus.Running:
       return 'Running';
-    case CloudTaskStatus.Idle:
+    case RunStatus.Idle:
       return 'Idle';
-    case CloudTaskStatus.Completed:
+    case RunStatus.Completed:
       return 'Completed';
-    case CloudTaskStatus.Failed:
+    case RunStatus.Failed:
       return 'Failed';
-    case CloudTaskStatus.Canceled:
+    case RunStatus.Canceled:
       return 'Canceled';
     default:
       return `Unknown (${status})`;

--- a/apps/web/src/components/settings/environments/EnvironmentDefinitionAgentTask.tsx
+++ b/apps/web/src/components/settings/environments/EnvironmentDefinitionAgentTask.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useRef } from 'react';
 
 import {
   getEnvironmentDefinitionIdFromPayload,
-  isExitedCloudTaskStatus,
+  isExitedRunStatus,
 } from '@roomote/types';
 
 import {
@@ -154,7 +154,7 @@ export function useEnvironmentDefinitionAgentState({
     !succeeded;
 
   const taskIsActive =
-    !!session.cloudJob && !isExitedCloudTaskStatus(session.cloudJob.status);
+    !!session.cloudJob && !isExitedRunStatus(session.cloudJob.status);
 
   useEffect(() => {
     if (succeeded || failed) {
@@ -461,7 +461,7 @@ function EnvironmentDefinitionMessagesPane({
   const isWaitingForFirstUpdate =
     !hasVisibleConversationContent &&
     !!session.cloudJob &&
-    !isExitedCloudTaskStatus(session.cloudJob.status) &&
+    !isExitedRunStatus(session.cloudJob.status) &&
     !authFailureHint;
 
   return (

--- a/apps/web/src/components/tasks/ArtifactViewerContent.tsx
+++ b/apps/web/src/components/tasks/ArtifactViewerContent.tsx
@@ -7,7 +7,7 @@ import remarkBreaks from 'remark-breaks';
 import type { BundledLanguage } from 'shiki';
 import { toast } from 'sonner';
 
-import { ALL_REPOSITORIES, type CloudTaskPayload } from '@roomote/types';
+import { ALL_REPOSITORIES, type TaskPayload } from '@roomote/types';
 
 import type { ArtifactWithContent } from '@/types';
 
@@ -220,7 +220,7 @@ export function ArtifactViewerContent({
     (isMarkdown && artifact.content) ||
     ((isImage || isVideo || isPDF) && artifact.downloadUrl);
 
-  const taskPayload = task?.cloudJob?.payload as CloudTaskPayload | undefined;
+  const taskPayload = task?.cloudJob?.payload as TaskPayload | undefined;
   // Build requires the fetched plan content so the new task's prompt isn't
   // silently empty. Content is only fetched for text artifacts within the
   // preview byte cap (see getArtifactByPathCommand), so a plan larger than

--- a/apps/web/src/components/tasks/TaskCard.client.test.tsx
+++ b/apps/web/src/components/tasks/TaskCard.client.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { CloudTaskStatus, PRODUCT_NAME } from '@roomote/types';
+import { RunStatus, PRODUCT_NAME } from '@roomote/types';
 
 const { routerPushMock } = vi.hoisted(() => ({
   routerPushMock: vi.fn(),
@@ -145,7 +145,7 @@ function createTask(overrides?: Partial<TaskCardTask>): TaskCardTask {
       imageUrl: 'https://example.com/avatar.png',
     },
     cloudJob: {
-      status: CloudTaskStatus.Completed,
+      status: RunStatus.Completed,
       taskPhase: null,
       payload: {
         environmentId: 'env-1',

--- a/apps/web/src/components/tasks/TaskCard.tsx
+++ b/apps/web/src/components/tasks/TaskCard.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { formatDistanceToNow } from 'date-fns';
 
-import { isActivelyRunningCloudTask, PRODUCT_NAME } from '@roomote/types';
+import { isActivelyRunningTask, PRODUCT_NAME } from '@roomote/types';
 
 import { type Task } from '@/lib/server';
 import {
@@ -144,7 +144,7 @@ export const TaskCard = ({
               <span>started a task</span>
             </span>
             <span>
-              {isActivelyRunningCloudTask(
+              {isActivelyRunningTask(
                 task.cloudJob.status,
                 task.cloudJob.taskPhase,
               ) && <Spinner className="size-3 animate-spin" />}

--- a/apps/web/src/hooks/tasks/useTask.ts
+++ b/apps/web/src/hooks/tasks/useTask.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
-import { isExitedCloudTaskStatus } from '@roomote/types';
+import { isExitedRunStatus } from '@roomote/types';
 import { useTRPC } from '@/trpc/client';
 
 interface UseTaskOptions {
@@ -35,7 +35,7 @@ export const useTask = (
           query.data?.cloudJob?.sleepRequestedAt ||
           query.data?.cloudJob?.snapshotRequestedAt
         ) &&
-          !isExitedCloudTaskStatus(query.data?.cloudJob?.status) &&
+          !isExitedRunStatus(query.data?.cloudJob?.status) &&
           !query.data?.cloudJob?.snapshotCreatedAt &&
           !query.data?.cloudJob?.snapshotFailedAt,
       ),

--- a/apps/web/src/lib/cloud-job-errors.ts
+++ b/apps/web/src/lib/cloud-job-errors.ts
@@ -1,4 +1,4 @@
-import { stripCloudJobErrorMarkers } from '@roomote/types';
+import { stripRunErrorMarkers } from '@roomote/types';
 
 interface CloudJobErrorSource {
   error?: string | null;
@@ -71,7 +71,7 @@ export function getCloudJobError(
 export function getCloudJobErrorDisplayMessage(
   error?: string | null,
 ): string | undefined {
-  const stripped = stripCloudJobErrorMarkers(error);
+  const stripped = stripRunErrorMarkers(error);
 
   if (!stripped) {
     return undefined;

--- a/apps/web/src/lib/environment-definition.test.ts
+++ b/apps/web/src/lib/environment-definition.test.ts
@@ -2,7 +2,7 @@ import {
   appendEnvironmentDefinitionGuidance,
   buildEnvironmentDefinitionWorkspacePayload,
   buildCreateEnvironmentDefinitionPrompt,
-  CloudTaskStatus,
+  RunStatus,
   getEnvironmentDefinitionIdFromPayload,
   type EnvironmentConfig,
 } from '@roomote/types';
@@ -208,11 +208,11 @@ describe('environment definition helpers', () => {
   });
 
   it.each([
-    [CloudTaskStatus.Completed, null, true],
-    [CloudTaskStatus.Idle, 'waiting_for_prompt', true],
-    [CloudTaskStatus.Idle, 'running', false],
-    [CloudTaskStatus.Running, null, false],
-    [CloudTaskStatus.Failed, null, false],
+    [RunStatus.Completed, null, true],
+    [RunStatus.Idle, 'waiting_for_prompt', true],
+    [RunStatus.Idle, 'running', false],
+    [RunStatus.Running, null, false],
+    [RunStatus.Failed, null, false],
   ] as const)(
     'treats %s with phase %s as a terminal success status: %s',
     (status, taskPhase, expected) => {
@@ -223,11 +223,11 @@ describe('environment definition helpers', () => {
   );
 
   it.each([
-    [CloudTaskStatus.Completed, null, true],
-    [CloudTaskStatus.Idle, 'waiting_for_prompt', true],
-    [CloudTaskStatus.Idle, 'running', false],
-    [CloudTaskStatus.Running, null, false],
-    [CloudTaskStatus.Failed, null, false],
+    [RunStatus.Completed, null, true],
+    [RunStatus.Idle, 'waiting_for_prompt', true],
+    [RunStatus.Idle, 'running', false],
+    [RunStatus.Running, null, false],
+    [RunStatus.Failed, null, false],
   ] as const)(
     'treats %s with phase %s as a success status: %s',
     (status, taskPhase, expected) => {

--- a/apps/web/src/lib/environment-definition.ts
+++ b/apps/web/src/lib/environment-definition.ts
@@ -1,6 +1,6 @@
 import {
   type EnvironmentConfig,
-  CloudTaskStatus,
+  RunStatus,
   PRODUCT_NAME,
 } from '@roomote/types';
 
@@ -190,26 +190,24 @@ export function wasEnvironmentUpdatedAfter(
 }
 
 export function isEnvironmentDefinitionTerminalSuccessStatus(
-  status: CloudTaskStatus | null | undefined,
+  status: RunStatus | null | undefined,
   taskPhase?: string | null,
 ): boolean {
   return (
-    status === CloudTaskStatus.Completed ||
-    (status === CloudTaskStatus.Idle && taskPhase === 'waiting_for_prompt')
+    status === RunStatus.Completed ||
+    (status === RunStatus.Idle && taskPhase === 'waiting_for_prompt')
   );
 }
 
 export function isEnvironmentDefinitionSuccessStatus(
-  status: CloudTaskStatus | null | undefined,
+  status: RunStatus | null | undefined,
   taskPhase?: string | null,
 ): boolean {
   return isEnvironmentDefinitionTerminalSuccessStatus(status, taskPhase);
 }
 
 export function isEnvironmentDefinitionFailureStatus(
-  status: CloudTaskStatus | null | undefined,
+  status: RunStatus | null | undefined,
 ): boolean {
-  return (
-    status === CloudTaskStatus.Failed || status === CloudTaskStatus.Canceled
-  );
+  return status === RunStatus.Failed || status === RunStatus.Canceled;
 }

--- a/apps/web/src/lib/server/cloud-jobs.ts
+++ b/apps/web/src/lib/server/cloud-jobs.ts
@@ -6,7 +6,7 @@ import {
   type SourceControlProvider,
 } from '@roomote/types';
 import {
-  type CloudJob,
+  type Run,
   type User,
   db,
   taskRuns,
@@ -139,7 +139,7 @@ export const getLatestCloudJobsByTaskId = async (
   return Object.fromEntries(latestByTask);
 };
 
-export type CloudJobDetail = CloudJob & {
+export type CloudJobDetail = Run & {
   refetchInterval?: number;
   user: User | null;
   actingUser?: User | null;

--- a/apps/web/src/lib/server/cloud-jobs.ts
+++ b/apps/web/src/lib/server/cloud-jobs.ts
@@ -1,8 +1,8 @@
 import {
-  type CloudTaskStatus,
-  type CloudTaskPayload,
+  type RunStatus,
+  type TaskPayload,
   type TaskPayloadKind,
-  exitedCloudTaskStatuses,
+  exitedRunStatuses,
   type SourceControlProvider,
 } from '@roomote/types';
 import {
@@ -23,8 +23,8 @@ import {
 export type SimpleCloudJob = {
   id: number;
   payloadKind: TaskPayloadKind;
-  payload: CloudTaskPayload;
-  status: CloudTaskStatus;
+  payload: TaskPayload;
+  status: RunStatus;
   taskPhase: string | null;
   firstAssistantOutputAt: Date | null;
   prRepo: string | null;
@@ -164,7 +164,7 @@ export const findActiveSuccessorCloudJob = async (
   const successor = await db.query.taskRuns.findFirst({
     where: and(
       jobFilter,
-      not(inArray(taskRuns.status, [...exitedCloudTaskStatuses])),
+      not(inArray(taskRuns.status, [...exitedRunStatuses])),
     ),
     orderBy: [desc(taskRuns.id)],
   });

--- a/apps/web/src/trpc/commands/cloud-jobs/index.test.ts
+++ b/apps/web/src/trpc/commands/cloud-jobs/index.test.ts
@@ -4,13 +4,13 @@ import { ALL_REPOSITORIES, TaskPayloadKind } from '@roomote/types';
 import type { UserAuthSuccess } from '@/types';
 
 const {
-  mockEnqueueCloudTask,
+  mockEnqueueTask,
   mockGetRepositories,
   mockDbWhere,
   mockDbSelect,
   mockResolveWorkspaceProvider,
 } = vi.hoisted(() => ({
-  mockEnqueueCloudTask: vi.fn(),
+  mockEnqueueTask: vi.fn(),
   mockGetRepositories: vi.fn(),
   mockDbWhere: vi.fn(),
   mockDbSelect: vi.fn(),
@@ -19,7 +19,7 @@ const {
 
 vi.mock('@roomote/cloud-agents/server', () => ({
   buildSlackRoutingContext: vi.fn(),
-  enqueueCloudTask: (...args: unknown[]) => mockEnqueueCloudTask(...args),
+  enqueueTask: (...args: unknown[]) => mockEnqueueTask(...args),
   getTaskUrl: vi.fn(() => 'https://roomote.test/tasks/task-123'),
   routeTask: vi.fn(),
 }));
@@ -123,7 +123,7 @@ const auth = {
 } satisfies UserAuthSuccess;
 
 function mockSuccessfulEnqueue() {
-  mockEnqueueCloudTask.mockResolvedValue({
+  mockEnqueueTask.mockResolvedValue({
     id: 123,
     taskId: 'task-123',
   });
@@ -167,7 +167,7 @@ describe('createStandardTaskCloudJobCommand', () => {
       id: 123,
       taskId: 'task-123',
     });
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: TaskPayloadKind.StandardTask,
@@ -206,7 +206,7 @@ describe('createStandardTaskCloudJobCommand', () => {
       id: 123,
       taskId: 'task-123',
     });
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: TaskPayloadKind.StandardTask,
@@ -235,7 +235,7 @@ describe('createStandardTaskCloudJobCommand', () => {
       id: 123,
       taskId: 'task-123',
     });
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: TaskPayloadKind.StandardTask,
@@ -263,7 +263,7 @@ describe('createStandardTaskCloudJobCommand', () => {
       success: false,
       error: 'Select an environment before starting a task.',
     });
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('stamps an environment source-control provider from its repository mappings', async () => {
@@ -283,7 +283,7 @@ describe('createStandardTaskCloudJobCommand', () => {
       id: 123,
       taskId: 'task-123',
     });
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: TaskPayloadKind.StandardTask,

--- a/apps/web/src/trpc/commands/cloud-jobs/index.ts
+++ b/apps/web/src/trpc/commands/cloud-jobs/index.ts
@@ -13,7 +13,7 @@ import {
 import {
   type RoutingDecision,
   buildSlackRoutingContext,
-  enqueueCloudTask,
+  enqueueTask,
   getTaskUrl,
   routeTask,
 } from '@roomote/cloud-agents/server';
@@ -387,7 +387,7 @@ export async function createStandardTaskCloudJobCommand(
       },
     };
 
-    const launchResult = await enqueueCloudTask({
+    const launchResult = await enqueueTask({
       task,
       initiator: { kind: 'user', userId: auth.userId },
       workflow: 'standard',

--- a/apps/web/src/trpc/commands/cloud-jobs/index.ts
+++ b/apps/web/src/trpc/commands/cloud-jobs/index.ts
@@ -1,13 +1,13 @@
 import {
   ALL_REPOSITORIES,
-  activeCloudTaskStatuses,
-  type CloudTaskPayload,
+  activeRunStatuses,
+  type TaskPayload,
   type ComputeProvider,
   type LaunchCodingHarness,
   type StandardTask,
-  CloudTaskStatus,
+  RunStatus,
   TaskPayloadKind,
-  isExitedCloudTaskStatus,
+  isExitedRunStatus,
   resolveEvalHarnessSelection,
 } from '@roomote/types';
 import {
@@ -50,11 +50,11 @@ type CreateStandardTaskCloudJobInput = {
   sourceArtifactId?: string;
   sourceArtifactPath?: string;
   sourceArtifactVersion?: number;
-  payload: CloudTaskPayload<typeof TaskPayloadKind.StandardTask>;
+  payload: TaskPayload<typeof TaskPayloadKind.StandardTask>;
 };
 
 function getManualTaskRepositoryFullNames(
-  payload: CloudTaskPayload<typeof TaskPayloadKind.StandardTask>,
+  payload: TaskPayload<typeof TaskPayloadKind.StandardTask>,
 ) {
   if (payload.selectedRepositories?.length) {
     return [...new Set(payload.selectedRepositories.filter(Boolean))].sort(
@@ -440,7 +440,7 @@ export async function cancelCloudJobCommand(
       (await db.query.taskRuns.findFirst({
         where: and(
           taskFilter,
-          inArray(taskRuns.status, [...activeCloudTaskStatuses]),
+          inArray(taskRuns.status, [...activeRunStatuses]),
         ),
         orderBy: [desc(taskRuns.createdAt), desc(taskRuns.id)],
       })) ??
@@ -459,13 +459,13 @@ export async function cancelCloudJobCommand(
       return { success: false, error: 'Cloud job not found' };
     }
 
-    if (!isExitedCloudTaskStatus(job.status)) {
+    if (!isExitedRunStatus(job.status)) {
       const endedAt = new Date();
 
       await db.transaction(async (tx) => {
         await tx
           .update(taskRuns)
-          .set({ status: CloudTaskStatus.Canceled, canceledAt: endedAt })
+          .set({ status: RunStatus.Canceled, canceledAt: endedAt })
           .where(eq(taskRuns.id, job.id));
 
         await markTaskStartParallelCountEndedAt(tx, {

--- a/apps/web/src/trpc/commands/environments/index.ts
+++ b/apps/web/src/trpc/commands/environments/index.ts
@@ -1,4 +1,4 @@
-import { enqueueCloudTask } from '@roomote/cloud-agents/server';
+import { enqueueTask } from '@roomote/cloud-agents/server';
 import {
   createEnvironmentConfigVersionSnapshot,
   db,
@@ -730,7 +730,7 @@ export async function startEnvironmentDefinitionTaskCommand(
   );
 
   const startedAt = new Date().toISOString();
-  const launchResult = await enqueueCloudTask({
+  const launchResult = await enqueueTask({
     task: {
       type: TaskPayloadKind.StandardTask,
       payload: {

--- a/apps/web/src/trpc/commands/environments/index.ts
+++ b/apps/web/src/trpc/commands/environments/index.ts
@@ -22,8 +22,8 @@ import {
   type EnvironmentConfigVersionSource,
 } from '@roomote/db/server';
 import {
-  activeCloudTaskStatuses,
-  CloudTaskStatus,
+  activeRunStatuses,
+  RunStatus,
   TaskPayloadKind,
   appendEnvironmentDefinitionGuidance,
   buildCreateEnvironmentDefinitionPrompt,
@@ -32,7 +32,7 @@ import {
   type EnvironmentConfig,
   environmentConfigSchema,
   getEnvironmentRepositoryInstallationError,
-  isExitedCloudTaskStatus,
+  isExitedRunStatus,
   normalizeRepositorySelection,
 } from '@roomote/types';
 import * as GitHub from '@roomote/github';
@@ -655,7 +655,7 @@ export async function getActiveEnvironmentDefinitionTaskCommand(
     .where(
       and(
         eq(tasks.workflow, 'standard'),
-        inArray(taskRuns.status, [...activeCloudTaskStatuses]),
+        inArray(taskRuns.status, [...activeRunStatuses]),
         sql`${taskRuns.payload} ->> 'environmentDefinitionId' = ${input.environmentId}`,
       ),
     )
@@ -770,7 +770,7 @@ export async function cancelEnvironmentDefinitionTaskCommand(
     .where(eq(taskRuns.taskId, input.taskId));
 
   const activeJobIds = jobs
-    .filter((job) => !isExitedCloudTaskStatus(job.status))
+    .filter((job) => !isExitedRunStatus(job.status))
     .map((job) => job.id);
 
   if (activeJobIds.length === 0) {
@@ -783,7 +783,7 @@ export async function cancelEnvironmentDefinitionTaskCommand(
     await tx
       .update(taskRuns)
       .set({
-        status: CloudTaskStatus.Canceled,
+        status: RunStatus.Canceled,
         canceledAt: endedAt,
       })
       .where(inArray(taskRuns.id, activeJobIds));

--- a/apps/web/src/trpc/commands/sandbox-session/index.test.ts
+++ b/apps/web/src/trpc/commands/sandbox-session/index.test.ts
@@ -1,4 +1,4 @@
-import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
 
 import type { CloudJobDetail } from '@/lib/server';
 import { getCloudJobVisiblePrompt } from '@/lib';
@@ -22,7 +22,7 @@ function createCloudJobDetail(
     actingUserId: null,
     payloadKind: TaskPayloadKind.StandardTask,
     payload: { repo: 'owner/repo', description: 'Test task' },
-    status: CloudTaskStatus.Pending,
+    status: RunStatus.Pending,
     taskPhase: null,
     error: null,
     prompt: null,
@@ -60,7 +60,7 @@ function createCloudJobDetail(
 describe('getSessionState', () => {
   it('treats canceled jobs with an early boot error as boot-failed', () => {
     const cloudJob = createCloudJobDetail({
-      status: CloudTaskStatus.Canceled,
+      status: RunStatus.Canceled,
       error:
         'OpenAI admin request failed (401): {"error":{"message":"Incorrect API key provided.","code":"invalid_api_key"}}',
     });
@@ -75,7 +75,7 @@ describe('getSessionState', () => {
 
   it('keeps ordinary canceled jobs in historical mode', () => {
     const cloudJob = createCloudJobDetail({
-      status: CloudTaskStatus.Canceled,
+      status: RunStatus.Canceled,
       error: null,
     });
 
@@ -89,7 +89,7 @@ describe('getSessionState', () => {
 
   it('treats canceled jobs with result.error as boot-failed before any messages exist', () => {
     const cloudJob = createCloudJobDetail({
-      status: CloudTaskStatus.Canceled,
+      status: RunStatus.Canceled,
       error: null,
       result: {
         error:
@@ -107,7 +107,7 @@ describe('getSessionState', () => {
 
   it('keeps running jobs in startup until the harness emits a first message', () => {
     const cloudJob = createCloudJobDetail({
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
     });
 
     expect(
@@ -127,7 +127,7 @@ describe('getSessionState', () => {
 
   it('keeps snapshot resumes in resuming mode until a first harness message', () => {
     const cloudJob = createCloudJobDetail({
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       payloadKind: TaskPayloadKind.SnapshotResume,
     });
 
@@ -149,7 +149,7 @@ describe('getSessionState', () => {
   it('falls through to interactive after 7s without harness messages', () => {
     const startedAt = new Date('2025-01-01T00:00:00Z');
     const cloudJob = createCloudJobDetail({
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       startedAt,
     });
 
@@ -175,7 +175,7 @@ describe('getSessionState', () => {
   it('falls through to interactive after 7s for snapshot resumes without harness messages', () => {
     const startedAt = new Date('2025-01-01T00:00:00Z');
     const cloudJob = createCloudJobDetail({
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       payloadKind: TaskPayloadKind.SnapshotResume,
       startedAt,
     });
@@ -220,7 +220,7 @@ describe('isWaitingForFirstHarnessMessage', () => {
   it('returns false once session state is interactive even if no harness message exists', () => {
     const startedAt = new Date('2025-01-01T00:00:00Z');
     const cloudJob = createCloudJobDetail({
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       startedAt,
     });
 
@@ -253,7 +253,7 @@ describe('shouldPollForFirstHarnessMessage', () => {
     expect(
       shouldPollForFirstHarnessMessage({
         sessionState: 'interactive',
-        cloudJobStatus: CloudTaskStatus.Running,
+        cloudJobStatus: RunStatus.Running,
         hasHarnessMessages: false,
         hasInitialPrompt: true,
       }),
@@ -264,7 +264,7 @@ describe('shouldPollForFirstHarnessMessage', () => {
     expect(
       shouldPollForFirstHarnessMessage({
         sessionState: 'interactive',
-        cloudJobStatus: CloudTaskStatus.Running,
+        cloudJobStatus: RunStatus.Running,
         hasHarnessMessages: false,
         hasInitialPrompt: false,
       }),
@@ -275,7 +275,7 @@ describe('shouldPollForFirstHarnessMessage', () => {
     expect(
       shouldPollForFirstHarnessMessage({
         sessionState: 'interactive',
-        cloudJobStatus: CloudTaskStatus.Running,
+        cloudJobStatus: RunStatus.Running,
         hasHarnessMessages: true,
         hasInitialPrompt: true,
       }),
@@ -284,7 +284,7 @@ describe('shouldPollForFirstHarnessMessage', () => {
     expect(
       shouldPollForFirstHarnessMessage({
         sessionState: 'historical',
-        cloudJobStatus: CloudTaskStatus.Completed,
+        cloudJobStatus: RunStatus.Completed,
         hasHarnessMessages: false,
         hasInitialPrompt: true,
       }),

--- a/apps/web/src/trpc/commands/sandbox-session/index.ts
+++ b/apps/web/src/trpc/commands/sandbox-session/index.ts
@@ -1,8 +1,8 @@
 import {
-  CloudTaskStatus,
+  RunStatus,
   TaskPayloadKind,
-  isBootingCloudTaskStatus,
-  isExitedCloudTaskStatus,
+  isBootingRunStatus,
+  isExitedRunStatus,
   taskToolDispatchPayloadSchema,
 } from '@roomote/types';
 import { createJobToken } from '@roomote/auth';
@@ -384,7 +384,7 @@ async function getResolvedSandboxCloudJobForTaskAccess(
   // If the resolved cloud job has exited and has a snapshot, check for an active
   // successor (e.g. a SnapshotResume job triggered from Linear). This ensures the
   // web UI shows the running resumed session instead of the old "Went to sleep" state.
-  if (isExitedCloudTaskStatus(cloudJob.status) && cloudJob.snapshotId) {
+  if (isExitedRunStatus(cloudJob.status) && cloudJob.snapshotId) {
     const successor = await findActiveSuccessorCloudJob(
       cloudJob.id,
       auth,
@@ -480,12 +480,11 @@ export async function getSandboxSessionByTaskIdCommand(
   }).catch(() => []);
 
   const shouldCheckBootFailureMessages =
-    cloudJob.status === CloudTaskStatus.Failed ||
-    cloudJob.status === CloudTaskStatus.Canceled;
+    cloudJob.status === RunStatus.Failed ||
+    cloudJob.status === RunStatus.Canceled;
 
   const shouldCheckHarnessMessages =
-    !isExitedCloudTaskStatus(cloudJob.status) &&
-    !isBootingCloudTaskStatus(cloudJob.status);
+    !isExitedRunStatus(cloudJob.status) && !isBootingRunStatus(cloudJob.status);
 
   // Check whether the task ever produced messages. Used to distinguish boot
   // failures (no messages) from runtime failures (has conversation history).
@@ -543,7 +542,7 @@ export async function getSandboxSessionByTaskIdCommand(
 
     if (
       (cloudJob.sleepRequestedAt || cloudJob.snapshotRequestedAt) &&
-      !isExitedCloudTaskStatus(cloudJob.status) &&
+      !isExitedRunStatus(cloudJob.status) &&
       !cloudJob.snapshotCreatedAt &&
       !cloudJob.snapshotFailedAt
     ) {

--- a/apps/web/src/trpc/commands/sandbox-session/send-prompt.test.ts
+++ b/apps/web/src/trpc/commands/sandbox-session/send-prompt.test.ts
@@ -30,7 +30,7 @@ vi.mock('@trpc/client', async () => {
 });
 
 import { runFactory, taskFactory, userFactory } from '@roomote/db/server';
-import { CloudTaskStatus } from '@roomote/types';
+import { RunStatus } from '@roomote/types';
 import type { FeatureFlag } from '@roomote/feature-flags';
 
 import type { UserAuthSuccess } from '@/types';
@@ -110,7 +110,7 @@ describe('sendSandboxPromptCommand', () => {
     await runFactory.create({
       actingUserId: user.id,
       taskId: task.id,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       sandboxServerUrl: 'http://sandbox.example.test',
       result: {},
     });
@@ -145,7 +145,7 @@ describe('sendSandboxPromptCommand', () => {
     await runFactory.create({
       actingUserId: user.id,
       taskId: task.id,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       sandboxServerUrl: 'http://sandbox.example.test',
       result: {},
     });
@@ -182,7 +182,7 @@ describe('sendSandboxPromptCommand', () => {
     await runFactory.create({
       actingUserId: user.id,
       taskId: task.id,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       sandboxServerUrl: 'http://sandbox.example.test',
       result: {},
     });
@@ -223,7 +223,7 @@ describe('sendSandboxPromptCommand', () => {
     await runFactory.create({
       actingUserId: user.id,
       taskId: task.id,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       sandboxServerUrl: 'http://sandbox.example.test',
       result: {},
     });

--- a/apps/web/src/trpc/commands/sandbox-session/session-state.ts
+++ b/apps/web/src/trpc/commands/sandbox-session/session-state.ts
@@ -1,8 +1,8 @@
 import {
-  CloudTaskStatus,
+  RunStatus,
   TaskPayloadKind,
-  isBootingCloudTaskStatus,
-  isExitedCloudTaskStatus,
+  isBootingRunStatus,
+  isExitedRunStatus,
 } from '@roomote/types';
 
 import type { CloudJobDetail } from '@/lib/server';
@@ -39,17 +39,17 @@ export function getSessionState(
   // before setup finishes.
   if (
     !hasMessages &&
-    (cloudJobStatus === CloudTaskStatus.Failed ||
-      (cloudJobStatus === CloudTaskStatus.Canceled && !!cloudJobError))
+    (cloudJobStatus === RunStatus.Failed ||
+      (cloudJobStatus === RunStatus.Canceled && !!cloudJobError))
   ) {
     return 'boot-failed';
   }
 
-  if (isExitedCloudTaskStatus(cloudJobStatus)) {
+  if (isExitedRunStatus(cloudJobStatus)) {
     return 'historical';
   }
 
-  if (isBootingCloudTaskStatus(cloudJobStatus)) {
+  if (isBootingRunStatus(cloudJobStatus)) {
     // Runtime dispatch: payloadKind is the run-level resume signal.
     if (cloudJob.payloadKind === TaskPayloadKind.SnapshotResume) {
       return 'resuming';
@@ -103,11 +103,11 @@ export function shouldPollForFirstHarnessMessage({
   hasInitialPrompt,
 }: {
   sessionState: SessionState;
-  cloudJobStatus: CloudTaskStatus;
+  cloudJobStatus: RunStatus;
   hasHarnessMessages: boolean;
   hasInitialPrompt: boolean;
 }): boolean {
-  if (hasHarnessMessages || isExitedCloudTaskStatus(cloudJobStatus)) {
+  if (hasHarnessMessages || isExitedRunStatus(cloudJobStatus)) {
     return false;
   }
 

--- a/apps/web/src/trpc/commands/sandbox-session/take-over-browser-control.test.ts
+++ b/apps/web/src/trpc/commands/sandbox-session/take-over-browser-control.test.ts
@@ -6,7 +6,7 @@ import {
   taskRuns,
   userFactory,
 } from '@roomote/db/server';
-import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
 import type { FeatureFlag } from '@roomote/feature-flags';
 
 import type { UserAuthSuccess } from '@/types';
@@ -50,7 +50,7 @@ describe('takeOverBrowserControlCommand', () => {
     const staleCloudJob = await runFactory.create({
       taskId: task.id,
       actingUserId: owner.id,
-      status: CloudTaskStatus.Completed,
+      status: RunStatus.Completed,
       snapshotId: 'snapshot-1',
     });
     const activeCloudJob = await runFactory.create({
@@ -59,7 +59,7 @@ describe('takeOverBrowserControlCommand', () => {
       kind: 'resume',
       payloadKind: TaskPayloadKind.SnapshotResume,
       actingUserId: owner.id,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
     });
 
     const result = await takeOverBrowserControlCommand(

--- a/apps/web/src/trpc/commands/setup-new/index.test.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.test.ts
@@ -53,7 +53,7 @@ vi.mock('@roomote/gitea', () => ({
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
-  enqueueCloudTask: vi.fn(),
+  enqueueTask: vi.fn(),
 }));
 
 vi.mock('@roomote/slack', () => ({
@@ -180,7 +180,7 @@ import {
   startSetupNewOnboardingTaskCommand,
 } from './index';
 import { TaskPayloadKind } from '@roomote/types';
-import { enqueueCloudTask } from '@roomote/cloud-agents/server';
+import { enqueueTask } from '@roomote/cloud-agents/server';
 import { TelegramCommunicationProvider } from '@roomote/communication/telegram-provider';
 import { resolveTelegramRuntimeCredentials } from '@roomote/db/server';
 import {
@@ -989,10 +989,10 @@ describe('setup-new onboarding task start command', () => {
     vi.mocked(
       createTeamsCommunicationProviderFromRuntimeCredentials,
     ).mockResolvedValue(null);
-    vi.mocked(enqueueCloudTask).mockResolvedValue({
+    vi.mocked(enqueueTask).mockResolvedValue({
       taskId: 'task-onboarding-1',
       id: 'cloud-job-1',
-    } as unknown as Awaited<ReturnType<typeof enqueueCloudTask>>);
+    } as unknown as Awaited<ReturnType<typeof enqueueTask>>);
   });
 
   it('launches a web onboarding task when no Slack workspace is connected', async () => {
@@ -1001,8 +1001,8 @@ describe('setup-new onboarding task start command', () => {
     const result = await startSetupNewOnboardingTaskCommand(buildMockAuth());
 
     expect(result.taskId).toBe('task-onboarding-1');
-    expect(enqueueCloudTask).toHaveBeenCalledTimes(1);
-    expect(enqueueCloudTask).toHaveBeenCalledWith(
+    expect(enqueueTask).toHaveBeenCalledTimes(1);
+    expect(enqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: TaskPayloadKind.StandardTask,
@@ -1061,7 +1061,7 @@ describe('setup-new onboarding task start command', () => {
       expect.objectContaining({ channelId: '8846357662' }),
     );
     expect(SlackNotifier).not.toHaveBeenCalled();
-    expect(enqueueCloudTask).toHaveBeenCalledWith(
+    expect(enqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: TaskPayloadKind.StandardTask,
@@ -1125,7 +1125,7 @@ describe('setup-new onboarding task start command', () => {
       }),
     );
     expect(SlackNotifier).not.toHaveBeenCalled();
-    expect(enqueueCloudTask).toHaveBeenCalledWith(
+    expect(enqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: TaskPayloadKind.StandardTask,
@@ -1176,9 +1176,9 @@ describe('setup-new onboarding task start command', () => {
       const result = await startSetupNewOnboardingTaskCommand(buildMockAuth());
 
       expect(result.taskId).toBe('task-onboarding-1');
-      expect(enqueueCloudTask).toHaveBeenCalledTimes(1);
+      expect(enqueueTask).toHaveBeenCalledTimes(1);
 
-      const enqueueInput = vi.mocked(enqueueCloudTask).mock.calls[0]?.[0];
+      const enqueueInput = vi.mocked(enqueueTask).mock.calls[0]?.[0];
       expect(enqueueInput?.task.payload).toBeDefined();
       expect(enqueueInput?.task.payload).not.toHaveProperty(
         'communicationProvider',
@@ -1230,9 +1230,9 @@ describe('setup-new onboarding task start command', () => {
 
       expect(result.taskId).toBe('task-onboarding-1');
       expect(teamsPostMessage).toHaveBeenCalled();
-      expect(enqueueCloudTask).toHaveBeenCalledTimes(1);
+      expect(enqueueTask).toHaveBeenCalledTimes(1);
 
-      const enqueueInput = vi.mocked(enqueueCloudTask).mock.calls[0]?.[0];
+      const enqueueInput = vi.mocked(enqueueTask).mock.calls[0]?.[0];
       expect(enqueueInput?.task.payload).toBeDefined();
       expect(enqueueInput?.task.payload).not.toHaveProperty(
         'communicationProvider',
@@ -1291,7 +1291,7 @@ describe('setup-new onboarding task start command', () => {
         expect.stringContaining('returned no message id'),
       );
 
-      const enqueueInput = vi.mocked(enqueueCloudTask).mock.calls[0]?.[0];
+      const enqueueInput = vi.mocked(enqueueTask).mock.calls[0]?.[0];
       expect(enqueueInput?.task.payload).toBeDefined();
       expect(enqueueInput?.task.payload).not.toHaveProperty(
         'communicationProvider',
@@ -1319,7 +1319,7 @@ describe('setup-new onboarding task start command', () => {
 
     await startSetupNewOnboardingTaskCommand(buildMockAuth());
 
-    expect(enqueueCloudTask).toHaveBeenCalledWith(
+    expect(enqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           harness: 'opencode-server',
@@ -1348,7 +1348,7 @@ describe('setup-new onboarding task start command', () => {
 
     expect(result.taskId).toBe('task-onboarding-1');
     expect(SlackNotifier).not.toHaveBeenCalled();
-    expect(enqueueCloudTask).toHaveBeenCalledWith(
+    expect(enqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: TaskPayloadKind.StandardTask,
@@ -1381,7 +1381,7 @@ describe('setup-new onboarding task start command', () => {
 
     expect(result.taskId).toBe('task-onboarding-1');
     expect(openConversationMock).toHaveBeenCalledWith('U1');
-    expect(enqueueCloudTask).toHaveBeenCalledWith(
+    expect(enqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: TaskPayloadKind.SlackAppMention,

--- a/apps/web/src/trpc/commands/setup-new/index.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.ts
@@ -50,7 +50,7 @@ import {
   buildSetupSourceControlStatus,
   collectSetupModelProviderCredentialValues,
   createEmptySetupNewState,
-  CloudTaskStatus,
+  RunStatus,
   TaskPayloadKind,
   resolveEvalHarnessSelection,
   type ComputeProvider,
@@ -62,7 +62,7 @@ import {
   isAutoProvisionedComputeArtifactField,
   isComputeInfrastructureField,
   isConfiguredEnvValue,
-  isExitedCloudTaskStatus,
+  isExitedRunStatus,
   isRequiredComputeField,
   NON_SECRET_COMPUTE_ENV_VAR_NAMES,
   normalizeDeploymentComputeConfig,
@@ -2517,7 +2517,7 @@ export async function cancelSetupNewOnboardingTaskCommand(
     .where(eq(taskRuns.taskId, currentState.onboardingTaskId));
 
   const activeJobIds = jobs
-    .filter((job) => !isExitedCloudTaskStatus(job.status))
+    .filter((job) => !isExitedRunStatus(job.status))
     .map((job) => job.id);
 
   if (activeJobIds.length > 0) {
@@ -2527,7 +2527,7 @@ export async function cancelSetupNewOnboardingTaskCommand(
       await tx
         .update(taskRuns)
         .set({
-          status: CloudTaskStatus.Canceled,
+          status: RunStatus.Canceled,
           canceledAt: endedAt,
         })
         .where(inArray(taskRuns.id, activeJobIds));

--- a/apps/web/src/trpc/commands/setup-new/index.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.ts
@@ -1,5 +1,5 @@
 import * as GitHub from '@roomote/github';
-import { enqueueCloudTask } from '@roomote/cloud-agents/server';
+import { enqueueTask } from '@roomote/cloud-agents/server';
 import {
   resolveEnvironmentSourceControlProvider,
   resolveSingleSourceControlProvider,
@@ -962,10 +962,10 @@ export async function launchQueuedSetupTasksIfReady({
 
   await Promise.allSettled(
     claimedTasks.map(async (queuedTask) => {
-      let launchResult: Awaited<ReturnType<typeof enqueueCloudTask>>;
+      let launchResult: Awaited<ReturnType<typeof enqueueTask>>;
 
       try {
-        launchResult = await enqueueCloudTask({
+        launchResult = await enqueueTask({
           task: {
             type: TaskPayloadKind.StandardTask,
             payload: {
@@ -2256,7 +2256,7 @@ export async function startSetupNewOnboardingTaskCommand(
 
         if (kickoffMessageId && kickoffChannelId) {
           const startedAt = new Date().toISOString();
-          const launchResult = await enqueueCloudTask({
+          const launchResult = await enqueueTask({
             task: {
               ...(modelSelection.harness
                 ? { harness: modelSelection.harness }
@@ -2323,7 +2323,7 @@ export async function startSetupNewOnboardingTaskCommand(
       }
 
       const startedAt = new Date().toISOString();
-      const launchResult = await enqueueCloudTask({
+      const launchResult = await enqueueTask({
         task: {
           ...(modelSelection.harness
             ? { harness: modelSelection.harness }
@@ -2397,10 +2397,10 @@ export async function startSetupNewOnboardingTaskCommand(
     }
 
     const startedAt = new Date().toISOString();
-    let launchResult: Awaited<ReturnType<typeof enqueueCloudTask>>;
+    let launchResult: Awaited<ReturnType<typeof enqueueTask>>;
 
     try {
-      launchResult = await enqueueCloudTask({
+      launchResult = await enqueueTask({
         task: {
           ...(modelSelection.harness
             ? { harness: modelSelection.harness }

--- a/apps/web/src/trpc/commands/setup-new/launch-lifecycle.test.ts
+++ b/apps/web/src/trpc/commands/setup-new/launch-lifecycle.test.ts
@@ -11,13 +11,13 @@
 // task enqueue and the source-control provider resolution.
 
 const {
-  mockEnqueueCloudTask,
+  mockEnqueueTask,
   mockCancelTaskRunDirect,
   mockFinalizeWorkItemLaunched,
   mockClaimWorkItem,
   actualDbServer,
 } = vi.hoisted(() => ({
-  mockEnqueueCloudTask: vi.fn(),
+  mockEnqueueTask: vi.fn(),
   mockCancelTaskRunDirect: vi.fn(),
   // Overridable, but delegate to the real implementations by default (reset in
   // beforeEach) so every test but the failure-injection ones keeps real
@@ -39,7 +39,7 @@ vi.mock('@roomote/gitea', () => ({
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
-  enqueueCloudTask: mockEnqueueCloudTask,
+  enqueueTask: mockEnqueueTask,
 }));
 
 // Keep the real database (and all shared launch helpers) while overriding only
@@ -304,14 +304,14 @@ describe('launchQueuedSetupTasksIfReady (fenced onboarding-queue launch)', () =>
       await seedLaunchTargetTaskId(),
     ];
     let call = 0;
-    mockEnqueueCloudTask.mockImplementation(async () => ({
+    mockEnqueueTask.mockImplementation(async () => ({
       taskId: launchedTaskIds[call++],
       id: `cloud-job-${call}`,
     }));
 
     await launch();
 
-    expect(mockEnqueueCloudTask).toHaveBeenCalledTimes(3);
+    expect(mockEnqueueTask).toHaveBeenCalledTimes(3);
     for (const id of [itemA, itemB, itemC]) {
       const row = await readRow(id);
       expect(row?.status).toBe('launched');
@@ -340,7 +340,7 @@ describe('launchQueuedSetupTasksIfReady (fenced onboarding-queue launch)', () =>
       await seedLaunchTargetTaskId(),
     ];
     let call = 0;
-    mockEnqueueCloudTask.mockImplementation(async () => ({
+    mockEnqueueTask.mockImplementation(async () => ({
       taskId: launchedTaskIds[call++],
       id: `cloud-job-${call}`,
     }));
@@ -348,7 +348,7 @@ describe('launchQueuedSetupTasksIfReady (fenced onboarding-queue launch)', () =>
     await launch();
 
     // Only the open item and the stale (crash-recovered) item launch.
-    expect(mockEnqueueCloudTask).toHaveBeenCalledTimes(2);
+    expect(mockEnqueueTask).toHaveBeenCalledTimes(2);
 
     expect((await readRow(openItem))?.status).toBe('launched');
 
@@ -371,7 +371,7 @@ describe('launchQueuedSetupTasksIfReady (fenced onboarding-queue launch)', () =>
     });
 
     const launchedTaskId = await seedLaunchTargetTaskId();
-    mockEnqueueCloudTask.mockResolvedValue({
+    mockEnqueueTask.mockResolvedValue({
       taskId: launchedTaskId,
       id: 'cloud-job-1',
     });
@@ -401,7 +401,7 @@ describe('launchQueuedSetupTasksIfReady (fenced onboarding-queue launch)', () =>
     });
 
     const launchedTaskId = await seedLaunchTargetTaskId();
-    mockEnqueueCloudTask.mockResolvedValue({
+    mockEnqueueTask.mockResolvedValue({
       taskId: launchedTaskId,
       id: 'cloud-job-1',
     });
@@ -426,7 +426,7 @@ describe('launchQueuedSetupTasksIfReady (fenced onboarding-queue launch)', () =>
 
     // Simulate another launcher reclaiming this row while our enqueue is in
     // flight: re-stamp launchClaimedAt to a token that no longer matches ours.
-    mockEnqueueCloudTask.mockImplementationOnce(async () => {
+    mockEnqueueTask.mockImplementationOnce(async () => {
       await db
         .update(workItems)
         .set({ launchClaimedAt: supersededClaimAt })
@@ -469,7 +469,7 @@ describe('launchQueuedSetupTasksIfReady (fenced onboarding-queue launch)', () =>
     });
 
     const launchedTaskId = await seedLaunchTargetTaskId();
-    mockEnqueueCloudTask.mockResolvedValue({
+    mockEnqueueTask.mockResolvedValue({
       taskId: launchedTaskId,
       id: 'cloud-job-1',
     });
@@ -502,7 +502,7 @@ describe('launchQueuedSetupTasksIfReady (fenced onboarding-queue launch)', () =>
   it('releases the claim back to open when the enqueue fails and logs the failure', async () => {
     const onboardingId = await seedOnboardingItem({ sortOrder: 0 });
 
-    mockEnqueueCloudTask.mockRejectedValue(new Error('enqueue failed'));
+    mockEnqueueTask.mockRejectedValue(new Error('enqueue failed'));
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     try {
@@ -526,7 +526,7 @@ describe('launchQueuedSetupTasksIfReady (fenced onboarding-queue launch)', () =>
     const onboardingId = await seedOnboardingItem({ sortOrder: 0 });
     const launchedTaskId = await seedLaunchTargetTaskId();
 
-    mockEnqueueCloudTask.mockResolvedValue({
+    mockEnqueueTask.mockResolvedValue({
       taskId: launchedTaskId,
       id: 'cloud-job-throw',
     });
@@ -574,7 +574,7 @@ describe('launchQueuedSetupTasksIfReady (fenced onboarding-queue launch)', () =>
     });
 
     const launchedTaskId = await seedLaunchTargetTaskId();
-    mockEnqueueCloudTask.mockResolvedValue({
+    mockEnqueueTask.mockResolvedValue({
       taskId: launchedTaskId,
       id: 'cloud-job-mirror',
     });
@@ -626,7 +626,7 @@ describe('launchQueuedSetupTasksIfReady (fenced onboarding-queue launch)', () =>
     });
 
     const launchedTaskId = await seedLaunchTargetTaskId();
-    mockEnqueueCloudTask.mockResolvedValue({
+    mockEnqueueTask.mockResolvedValue({
       taskId: launchedTaskId,
       id: 'cloud-job-mirror-finalize-throw',
     });

--- a/apps/web/src/trpc/commands/setup/index.ts
+++ b/apps/web/src/trpc/commands/setup/index.ts
@@ -20,7 +20,7 @@ import { ANONYMOUS_ANALYTICS_METADATA_KEY } from '@roomote/feature-flags';
 import { captureEvent } from '@roomote/telemetry/server';
 import {
   AVAILABLE_SETUP_MCP_INTEGRATIONS,
-  enqueueCloudTask,
+  enqueueTask,
   normalizeEnabledSetupMcpIntegrationIds,
   type CurrentMcpConfig,
 } from '@roomote/cloud-agents/server';
@@ -351,7 +351,7 @@ async function sendSetupCompletionMcpRecommendations(
       return;
     }
 
-    await enqueueCloudTask({
+    await enqueueTask({
       task: {
         type: TaskPayloadKind.McpRecommendations,
         payload: {

--- a/apps/web/src/trpc/commands/snapshots/index.ts
+++ b/apps/web/src/trpc/commands/snapshots/index.ts
@@ -9,7 +9,7 @@ import {
   resolveComputeProviderTarget,
 } from '@roomote/types';
 import type { ModalClient as _ModalSdkClient } from 'modal';
-import { enqueueCloudTask } from '@roomote/cloud-agents/server';
+import { enqueueTask } from '@roomote/cloud-agents/server';
 import { createComputeProviderClient } from '@roomote/compute-providers/factory';
 import { createClient } from '@roomote/sdk/client';
 import {
@@ -203,7 +203,7 @@ export async function createEnvironmentSnapshotCommand(
     }
 
     try {
-      const snapshotLaunch = await enqueueCloudTask({
+      const snapshotLaunch = await enqueueTask({
         task: {
           computeProvider: provider,
           type: TaskPayloadKind.SnapshotEnvironment,
@@ -527,7 +527,7 @@ export async function restoreCloudJobSnapshotCommand(
       sourceJob.sourceRunId,
     );
 
-    const resumeLaunch = await enqueueCloudTask({
+    const resumeLaunch = await enqueueTask({
       task: {
         computeProvider:
           sourceJob.vendor ?? resolveComputeProviderTarget(undefined),

--- a/apps/web/src/trpc/commands/snapshots/index.ts
+++ b/apps/web/src/trpc/commands/snapshots/index.ts
@@ -1,6 +1,6 @@
 import {
-  type CloudTaskPayload,
-  activeCloudTaskStatuses,
+  type TaskPayload,
+  activeRunStatuses,
   TaskPayloadKind,
   ORPHANED_PENDING_THRESHOLD_MS,
   populateSnapshotResumeSlackMetadata,
@@ -103,7 +103,7 @@ async function findActiveEnvironmentSnapshotJob(params: {
       and(
         eq(tasks.workflow, 'env_snapshot'),
         eq(taskRuns.vendor, params.provider),
-        inArray(taskRuns.status, [...activeCloudTaskStatuses]),
+        inArray(taskRuns.status, [...activeRunStatuses]),
         sql`${taskRuns.payload}->>'environmentId' = ${params.environmentId}`,
       ),
     )
@@ -497,7 +497,7 @@ export async function restoreCloudJobSnapshotCommand(
       outOfBandContext = await claimOutOfBandContextForPrompt(sourceJob.taskId);
     }
 
-    const payload: CloudTaskPayload<typeof TaskPayloadKind.SnapshotResume> = {
+    const payload: TaskPayload<typeof TaskPayloadKind.SnapshotResume> = {
       repo: sourceJob.payload.repo,
       environmentId: sourceJob.payload.environmentId,
       port: sourceJob.port ?? undefined,

--- a/apps/web/src/trpc/commands/task-env-var-requests/index.ts
+++ b/apps/web/src/trpc/commands/task-env-var-requests/index.ts
@@ -12,7 +12,7 @@ import {
   ACP_ENVELOPE_EVENT_TYPES,
   ROOMOTE_RUNTIME_TASK_MESSAGE_PROTOCOL,
   isEnvVarRequestFulfillmentClientMessageId,
-  isExitedCloudTaskStatus,
+  isExitedRunStatus,
   deploymentEnvVarNameSchema,
 } from '@roomote/types';
 import { recordTaskMessageEnvelope } from '@roomote/sdk/server';
@@ -129,7 +129,7 @@ export async function fulfillTaskEnvVarRequestCommand(
       names: requestedNames,
       canReload:
         !!activeCloudJob &&
-        !isExitedCloudTaskStatus(activeCloudJob.status) &&
+        !isExitedRunStatus(activeCloudJob.status) &&
         !!activeCloudJob.sandboxServerUrl,
       cloudJobId: activeCloudJob?.id ?? null,
     };

--- a/apps/web/src/trpc/commands/task-suggestions/implement.ts
+++ b/apps/web/src/trpc/commands/task-suggestions/implement.ts
@@ -1,6 +1,6 @@
 import {
   buildSuggestionTaskPromptText,
-  enqueueCloudTask,
+  enqueueTask,
 } from '@roomote/cloud-agents/server';
 import {
   and,
@@ -92,7 +92,7 @@ export async function implementTaskSuggestionCommand(
       throw new Error(resolution.failureReason);
     }
 
-    const launchResult = await enqueueCloudTask({
+    const launchResult = await enqueueTask({
       task: {
         type: TaskPayloadKind.StandardTask,
         payload: {

--- a/apps/web/src/trpc/commands/task-suggestions/onboarding.ts
+++ b/apps/web/src/trpc/commands/task-suggestions/onboarding.ts
@@ -16,11 +16,11 @@ import {
   workItems,
 } from '@roomote/db/server';
 import {
-  CloudTaskStatus,
+  RunStatus,
   TaskPayloadKind,
   buildEnvironmentDefinitionWorkspacePayload,
   createEmptySetupNewState,
-  isExitedCloudTaskStatus,
+  isExitedRunStatus,
   normalizeSetupNewState,
 } from '@roomote/types';
 
@@ -287,17 +287,14 @@ async function ensureTaskSuggestions(auth: UserAuthSuccess): Promise<{
   let launchState = setupNewState;
 
   if (setupNewState.suggestionTaskId) {
-    if (
-      suggestionTaskStatus &&
-      !isExitedCloudTaskStatus(suggestionTaskStatus)
-    ) {
+    if (suggestionTaskStatus && !isExitedRunStatus(suggestionTaskStatus)) {
       return {
         generationStatus: 'pending',
         suggestions: [],
       };
     }
 
-    if (suggestionTaskStatus === CloudTaskStatus.Completed) {
+    if (suggestionTaskStatus === RunStatus.Completed) {
       return {
         generationStatus: 'empty',
         suggestions: [],
@@ -306,7 +303,7 @@ async function ensureTaskSuggestions(auth: UserAuthSuccess): Promise<{
 
     if (
       suggestionTaskStatus === null ||
-      (suggestionTaskStatus && isExitedCloudTaskStatus(suggestionTaskStatus))
+      (suggestionTaskStatus && isExitedRunStatus(suggestionTaskStatus))
     ) {
       launchState = await clearPersistedSuggestionTask({
         currentState: setupNewState,

--- a/apps/web/src/trpc/commands/task-suggestions/onboarding.ts
+++ b/apps/web/src/trpc/commands/task-suggestions/onboarding.ts
@@ -1,6 +1,6 @@
 import {
   buildSuggestedTasksPrompt,
-  enqueueCloudTask,
+  enqueueTask,
   findEnvironmentForRepo,
 } from '@roomote/cloud-agents/server';
 import {
@@ -144,7 +144,7 @@ async function launchSuggestedTasksTask(input: {
   const scanSourceControlProvider = resolveSingleSourceControlProvider(
     scanRepositoryRows.map((row) => row.sourceControlProvider),
   );
-  const launchResult = await enqueueCloudTask(
+  const launchResult = await enqueueTask(
     {
       task: {
         type: TaskPayloadKind.Scan,

--- a/apps/web/src/trpc/commands/task-suggestions/types.ts
+++ b/apps/web/src/trpc/commands/task-suggestions/types.ts
@@ -1,5 +1,5 @@
 import type {
-  CloudTaskPayload,
+  TaskPayload,
   SuggestionCategory,
   SuggestionPriority,
   TaskPayloadKind,
@@ -57,5 +57,5 @@ export type SuggestionHistoryItem = {
 
 export type SuggestionSourceCloudJob = {
   payloadKind: TaskPayloadKind;
-  payload: CloudTaskPayload;
+  payload: TaskPayload;
 };

--- a/apps/web/src/types/task.ts
+++ b/apps/web/src/types/task.ts
@@ -14,7 +14,7 @@ import type {
   TaskMessageProtocol,
   TaskMessageRole,
 } from '@roomote/types';
-import type { User, CloudJob } from '@roomote/db';
+import type { User, Run } from '@roomote/db';
 
 /** How a task's creator should be displayed, derived from initiator columns. */
 export type TaskCreatorKind = 'user' | 'automation' | 'external';
@@ -83,7 +83,7 @@ export type ArtifactWithContent = {
  * Run row decorated with the task's latest pull-request association
  * (task_pull_requests is the only PR home; runs carry no PR columns).
  */
-export type CloudJobWithPullRequest = CloudJob & {
+export type CloudJobWithPullRequest = Run & {
   prRepo: string | null;
   prNumber: number | null;
 };

--- a/apps/worker/src/callbacks/__tests__/github-pr-conflict-resolve.test.ts
+++ b/apps/worker/src/callbacks/__tests__/github-pr-conflict-resolve.test.ts
@@ -10,11 +10,11 @@ import {
   TaskPayloadKind,
   CONFLICT_RESOLUTION_SUMMARY_RESULT_KEY,
 } from '@roomote/types';
-import { type CloudJob, sdk } from '@roomote/sdk/client';
+import { type Run, sdk } from '@roomote/sdk/client';
 
 import { githubPrConflictResolveCallbacks } from '../github-pr-conflict-resolve';
 
-function createCloudJob(): CloudJob {
+function createCloudJob(): Run {
   return {
     id: 123,
     payloadKind: TaskPayloadKind.GithubPrConflictResolve,
@@ -27,7 +27,7 @@ function createCloudJob(): CloudJob {
       baseRef: 'main',
     },
     result: null,
-  } as unknown as CloudJob;
+  } as unknown as Run;
 }
 
 describe('githubPrConflictResolveCallbacks', () => {

--- a/apps/worker/src/callbacks/__tests__/linear-agent.test.ts
+++ b/apps/worker/src/callbacks/__tests__/linear-agent.test.ts
@@ -15,17 +15,17 @@ vi.mock('@roomote/sdk/client', () => ({
 }));
 
 import { TaskPayloadKind } from '@roomote/types';
-import { type CloudJob, sdk } from '@roomote/sdk/client';
+import { type Run, sdk } from '@roomote/sdk/client';
 
 import { linearAgentCallbacks } from '../linear-agent';
 
-function createCloudJob(): CloudJob {
+function createCloudJob(): Run {
   return {
     id: 123,
     taskId: 'task_123',
     payloadKind: TaskPayloadKind.LinearAgentSession,
     payload: { sessionId: 'session_123' },
-  } as unknown as CloudJob;
+  } as unknown as Run;
 }
 
 describe('linearAgentCallbacks', () => {

--- a/apps/worker/src/callbacks/__tests__/request-user-input.test.ts
+++ b/apps/worker/src/callbacks/__tests__/request-user-input.test.ts
@@ -1,4 +1,4 @@
-import type { CloudJob } from '@roomote/sdk/client';
+import type { Run } from '@roomote/sdk/client';
 
 import {
   buildRequestUserInputTaskUrl,
@@ -184,11 +184,11 @@ describe('buildRequestUserInputTaskUrl', () => {
     }
   });
 
-  function makeCloudJob(payload: unknown): CloudJob {
+  function makeCloudJob(payload: unknown): Run {
     return {
       taskId: 'task-123',
       payload,
-    } as CloudJob;
+    } as Run;
   }
 
   it('builds a task URL when no webPath override exists', () => {

--- a/apps/worker/src/callbacks/__tests__/slack-mention.test.ts
+++ b/apps/worker/src/callbacks/__tests__/slack-mention.test.ts
@@ -110,11 +110,11 @@ vi.mock('../request-user-input', () => ({
 }));
 
 import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
-import { type CloudJob, sdk } from '@roomote/sdk/client';
+import { type Run, sdk } from '@roomote/sdk/client';
 
 import { slackMentionCallbacks } from '../slack-mention';
 
-function createCloudJob(): CloudJob {
+function createCloudJob(): Run {
   return {
     id: 123,
     taskId: 'task_row_123',
@@ -127,10 +127,10 @@ function createCloudJob(): CloudJob {
       ts: '1710000000.100',
       thread_ts: '1710000000.123',
     },
-  } as unknown as CloudJob;
+  } as unknown as Run;
 }
 
-function createSnapshotResumeCloudJob(): CloudJob {
+function createSnapshotResumeCloudJob(): Run {
   return {
     id: 123,
     taskId: 'task_row_123',
@@ -140,7 +140,7 @@ function createSnapshotResumeCloudJob(): CloudJob {
       thread_ts: '1710000000.123',
       slackOriginMessageTs: '1710000000.100',
     },
-  } as unknown as CloudJob;
+  } as unknown as Run;
 }
 
 describe('slackMentionCallbacks', () => {
@@ -354,7 +354,7 @@ describe('slackMentionCallbacks', () => {
         ...createCloudJob().payload,
         ackEmoji: 'hourglass',
       },
-    } as CloudJob;
+    } as Run;
     const context = {};
 
     await slackMentionCallbacks.onStart?.(cloudJob, 'task_123', context);
@@ -373,7 +373,7 @@ describe('slackMentionCallbacks', () => {
         ...createCloudJob().payload,
         completionEmoji: 'rocket',
       },
-    } as CloudJob;
+    } as Run;
     const context = {};
 
     await slackMentionCallbacks.onMessage?.(

--- a/apps/worker/src/callbacks/__tests__/slack-mention.test.ts
+++ b/apps/worker/src/callbacks/__tests__/slack-mention.test.ts
@@ -109,7 +109,7 @@ vi.mock('../request-user-input', () => ({
   supportsIntegrationRequestUserInput: mockSupportsIntegrationRequestUserInput,
 }));
 
-import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
 import { type Run, sdk } from '@roomote/sdk/client';
 
 import { slackMentionCallbacks } from '../slack-mention';
@@ -941,7 +941,7 @@ describe('slackMentionCallbacks', () => {
 
     try {
       await expect(
-        slackMentionCallbacks.onExit?.(cloudJob, CloudTaskStatus.Completed, {}),
+        slackMentionCallbacks.onExit?.(cloudJob, RunStatus.Completed, {}),
       ).resolves.toBe(undefined);
       expect(errorSpy).toHaveBeenCalledWith(
         '[slackMentionCallbacks#onExit] Failed to clear pending request_user_input state: cleanup failed',

--- a/apps/worker/src/callbacks/github-pr-conflict-resolve.ts
+++ b/apps/worker/src/callbacks/github-pr-conflict-resolve.ts
@@ -2,7 +2,7 @@ import {
   CONFLICT_RESOLUTION_SUMMARY_RESULT_KEY,
   parseConflictResolutionSummary,
 } from '@roomote/types';
-import { type CloudJob, sdk } from '@roomote/sdk/client';
+import { type Run, sdk } from '@roomote/sdk/client';
 
 import type {
   CallbackEvent,
@@ -10,7 +10,7 @@ import type {
   RunTaskContext,
 } from '../run-task';
 
-function getExistingResult(cloudJob: CloudJob): Record<string, unknown> {
+function getExistingResult(cloudJob: Run): Record<string, unknown> {
   if (
     !cloudJob.result ||
     typeof cloudJob.result !== 'object' ||
@@ -24,7 +24,7 @@ function getExistingResult(cloudJob: CloudJob): Record<string, unknown> {
 
 export const githubPrConflictResolveCallbacks: RunTaskCallbacks = {
   onMessage: async (
-    cloudJob: CloudJob,
+    cloudJob: Run,
     _taskId: string,
     event: CallbackEvent,
     context: RunTaskContext,

--- a/apps/worker/src/callbacks/linear-agent.ts
+++ b/apps/worker/src/callbacks/linear-agent.ts
@@ -3,7 +3,7 @@ import type {
   AgentSessionPlanStep,
   AgentSessionPlanStepStatus,
 } from '@roomote/linear/client';
-import { type CloudJob, sdk } from '@roomote/sdk/client';
+import { type Run, sdk } from '@roomote/sdk/client';
 
 import type {
   CallbackEvent,
@@ -104,7 +104,7 @@ function convertTodosToAgentPlan(todos: TodoItem[]): AgentSessionPlanStep[] {
   return result.steps;
 }
 
-function getLinearSessionId(cloudJob: CloudJob): string {
+function getLinearSessionId(cloudJob: Run): string {
   // For LinearAgentSession jobs, sessionId is in the payload
   if (cloudJob.payloadKind === TaskPayloadKind.LinearAgentSession) {
     const { sessionId } = cloudJob.payload as CloudTaskPayload<
@@ -130,11 +130,7 @@ function getLinearSessionId(cloudJob: CloudJob): string {
 }
 
 export const linearAgentCallbacks: RunTaskCallbacks = {
-  onStart: async (
-    cloudJob: CloudJob,
-    taskId: string,
-    context: RunTaskContext,
-  ) => {
+  onStart: async (cloudJob: Run, taskId: string, context: RunTaskContext) => {
     if (context.sessionId) {
       return;
     }
@@ -142,7 +138,7 @@ export const linearAgentCallbacks: RunTaskCallbacks = {
     context.sessionId = taskId;
   },
   onMessage: async (
-    cloudJob: CloudJob,
+    cloudJob: Run,
     _taskId: string,
     event: CallbackEvent,
     context: RunTaskContext,
@@ -401,7 +397,7 @@ export const linearAgentCallbacks: RunTaskCallbacks = {
       }
     }
   },
-  onExit: async (cloudJob: CloudJob) => {
+  onExit: async (cloudJob: Run) => {
     try {
       await sdk.cloudJobs.clearPendingLinearRequestUserInput({
         cloudJobId: cloudJob.id,

--- a/apps/worker/src/callbacks/linear-agent.ts
+++ b/apps/worker/src/callbacks/linear-agent.ts
@@ -1,4 +1,4 @@
-import { type CloudTaskPayload, TaskPayloadKind } from '@roomote/types';
+import { type TaskPayload, TaskPayloadKind } from '@roomote/types';
 import type {
   AgentSessionPlanStep,
   AgentSessionPlanStepStatus,
@@ -107,7 +107,7 @@ function convertTodosToAgentPlan(todos: TodoItem[]): AgentSessionPlanStep[] {
 function getLinearSessionId(cloudJob: Run): string {
   // For LinearAgentSession jobs, sessionId is in the payload
   if (cloudJob.payloadKind === TaskPayloadKind.LinearAgentSession) {
-    const { sessionId } = cloudJob.payload as CloudTaskPayload<
+    const { sessionId } = cloudJob.payload as TaskPayload<
       typeof TaskPayloadKind.LinearAgentSession
     >;
 

--- a/apps/worker/src/callbacks/request-user-input.ts
+++ b/apps/worker/src/callbacks/request-user-input.ts
@@ -2,7 +2,7 @@ import type {
   AcpRequestUserInputPayload,
   AcpRequestUserInputQuestion,
 } from '@roomote/types';
-import type { CloudJob } from '@roomote/sdk/client';
+import type { Run } from '@roomote/sdk/client';
 
 function formatQuestionOptions(
   question: AcpRequestUserInputQuestion,
@@ -33,7 +33,7 @@ function formatQuestion(
 }
 
 export function buildRequestUserInputTaskUrl(
-  cloudJob: CloudJob,
+  cloudJob: Run,
   source: 'slack' | 'linear',
 ): string {
   const webPath =

--- a/apps/worker/src/callbacks/slack-mention.ts
+++ b/apps/worker/src/callbacks/slack-mention.ts
@@ -13,7 +13,7 @@ import {
   buildStartedBlocks,
   convertMarkdownToSlack,
 } from '@roomote/slack/client';
-import { type CloudJob, sdk } from '@roomote/sdk/client';
+import { type Run, sdk } from '@roomote/sdk/client';
 
 import type {
   CallbackEvent,
@@ -75,7 +75,7 @@ function getSlackRequestUserInputPromptMessageTs(
 }
 
 function getInitiatingSlackUserIdForStartedMessage(
-  cloudJob: CloudJob,
+  cloudJob: Run,
   startedData: {
     initiatingSlackUserId?: string;
   },
@@ -100,7 +100,7 @@ function getInitiatingSlackUserIdForStartedMessage(
 }
 
 async function recordOutboundSlackMessageForCloudJob(params: {
-  cloudJob: CloudJob;
+  cloudJob: Run;
   messageTs: string | null | undefined;
   text: string;
   source: string;
@@ -127,11 +127,7 @@ async function recordOutboundSlackMessageForCloudJob(params: {
 }
 
 export const slackMentionCallbacks: RunTaskCallbacks = {
-  onStart: async (
-    cloudJob: CloudJob,
-    taskId: string,
-    context: RunTaskContext,
-  ) => {
+  onStart: async (cloudJob: Run, taskId: string, context: RunTaskContext) => {
     if (!context.sessionId) {
       context.sessionId = taskId;
     }
@@ -215,7 +211,7 @@ export const slackMentionCallbacks: RunTaskCallbacks = {
     }
   },
   onMessage: async (
-    cloudJob: CloudJob,
+    cloudJob: Run,
     _taskId: string,
     event: CallbackEvent,
     context: RunTaskContext,
@@ -236,7 +232,7 @@ export const slackMentionCallbacks: RunTaskCallbacks = {
       await handleFollowup(cloudJob, event, context);
     }
   },
-  onExit: async (cloudJob: CloudJob) => {
+  onExit: async (cloudJob: Run) => {
     try {
       const { thread_ts: threadTs } = getSlackConversation(cloudJob);
       await sdk.cloudJobs.clearPendingSlackRequestUserInput({
@@ -259,7 +255,7 @@ export const slackMentionCallbacks: RunTaskCallbacks = {
 };
 
 async function handleCompletion(
-  cloudJob: CloudJob,
+  cloudJob: Run,
   event: CallbackEvent & { type: 'completion' },
   context: RunTaskContext,
 ) {
@@ -290,7 +286,7 @@ async function handleCompletion(
 }
 
 async function handleRequestUserInput(
-  cloudJob: CloudJob,
+  cloudJob: Run,
   event: CallbackEvent & { type: 'request_user_input' },
   context: RunTaskContext,
 ) {
@@ -410,7 +406,7 @@ async function handleRequestUserInput(
 }
 
 async function handleRequestUserInputResponse(
-  cloudJob: CloudJob,
+  cloudJob: Run,
   event: CallbackEvent & { type: 'request_user_input_response' },
 ) {
   try {
@@ -434,7 +430,7 @@ async function handleRequestUserInputResponse(
 }
 
 async function handleFollowup(
-  cloudJob: CloudJob,
+  cloudJob: Run,
   event: CallbackEvent & { type: 'followup' },
   context: RunTaskContext,
 ) {
@@ -546,7 +542,7 @@ async function getSlackNotifier() {
 }
 
 async function removeSlackAckReaction(
-  cloudJob: CloudJob,
+  cloudJob: Run,
   slack: SlackNotifier,
 ): Promise<void> {
   const originMessageTs = getSlackOriginMessageTs(cloudJob);
@@ -583,7 +579,7 @@ async function removeSlackAckReaction(
   }
 }
 
-function getSlackConversation(cloudJob: CloudJob) {
+function getSlackConversation(cloudJob: Run) {
   // For SlackAppMention jobs, channel and thread_ts are in the payload.
   if (cloudJob.payloadKind === TaskPayloadKind.SlackAppMention) {
     const { channel, thread_ts } = cloudJob.payload as CloudTaskPayload<
@@ -627,7 +623,7 @@ function getSlackConversation(cloudJob: CloudJob) {
   );
 }
 
-function getSlackOriginMessageTs(cloudJob: CloudJob): string | null {
+function getSlackOriginMessageTs(cloudJob: Run): string | null {
   if (cloudJob.payloadKind === TaskPayloadKind.SlackAppMention) {
     const { ts } = cloudJob.payload as CloudTaskPayload<
       typeof TaskPayloadKind.SlackAppMention
@@ -647,14 +643,11 @@ function getSlackOriginMessageTs(cloudJob: CloudJob): string | null {
   return null;
 }
 
-function getStoredSlackAckEmoji(cloudJob: CloudJob): string {
+function getStoredSlackAckEmoji(cloudJob: Run): string {
   return getSlackPayloadEmoji(cloudJob, 'ackEmoji') ?? DEFAULT_SLACK_ACK_EMOJI;
 }
 
-function getSlackPayloadEmoji(
-  cloudJob: CloudJob,
-  key: 'ackEmoji',
-): string | null {
+function getSlackPayloadEmoji(cloudJob: Run, key: 'ackEmoji'): string | null {
   const payload =
     cloudJob.payload && typeof cloudJob.payload === 'object'
       ? (cloudJob.payload as Record<string, unknown>)

--- a/apps/worker/src/callbacks/slack-mention.ts
+++ b/apps/worker/src/callbacks/slack-mention.ts
@@ -1,5 +1,5 @@
 import {
-  type CloudTaskPayload,
+  type TaskPayload,
   type SlackBlock,
   TaskPayloadKind,
   DEFAULT_SLACK_ACK_EMOJI,
@@ -582,7 +582,7 @@ async function removeSlackAckReaction(
 function getSlackConversation(cloudJob: Run) {
   // For SlackAppMention jobs, channel and thread_ts are in the payload.
   if (cloudJob.payloadKind === TaskPayloadKind.SlackAppMention) {
-    const { channel, thread_ts } = cloudJob.payload as CloudTaskPayload<
+    const { channel, thread_ts } = cloudJob.payload as TaskPayload<
       typeof TaskPayloadKind.SlackAppMention
     >;
 
@@ -625,7 +625,7 @@ function getSlackConversation(cloudJob: Run) {
 
 function getSlackOriginMessageTs(cloudJob: Run): string | null {
   if (cloudJob.payloadKind === TaskPayloadKind.SlackAppMention) {
-    const { ts } = cloudJob.payload as CloudTaskPayload<
+    const { ts } = cloudJob.payload as TaskPayload<
       typeof TaskPayloadKind.SlackAppMention
     >;
 

--- a/apps/worker/src/commands/__tests__/snapshot.test.ts
+++ b/apps/worker/src/commands/__tests__/snapshot.test.ts
@@ -1,4 +1,4 @@
-import { CloudTaskStatus } from '@roomote/types';
+import { RunStatus } from '@roomote/types';
 
 const {
   mockCloudJobsUpdate,
@@ -113,7 +113,7 @@ describe('snapshot', () => {
     expect(result).toBe(false);
     expect(mockDone).toHaveBeenCalledWith({
       id: 42,
-      status: CloudTaskStatus.Failed,
+      status: RunStatus.Failed,
       error: 'setup failed',
     });
     expect(mockUpdateSnapshotStatus).toHaveBeenCalledWith({

--- a/apps/worker/src/commands/__tests__/utils.test.ts
+++ b/apps/worker/src/commands/__tests__/utils.test.ts
@@ -6,7 +6,7 @@ import {
   writeCommonEnvFile,
   isValidEnvVarName,
 } from '../utils/env-vars';
-import type { CloudJob } from '@roomote/sdk/client';
+import type { Run } from '@roomote/sdk/client';
 
 vi.mock('fs', () => ({
   existsSync: vi.fn(),
@@ -105,7 +105,7 @@ describe('injectEnvVars', () => {
     const cloudJob = {
       authBypassValue: 'cloud-job-bypass-value',
       authBypassHeaderName: 'x-cloud-job-bypass',
-    } as CloudJob;
+    } as Run;
 
     process.env.ROOMOTE_AUTH_BYPASS_VALUE = 'runtime-bypass-value';
     process.env.ROOMOTE_AUTH_BYPASS_HEADER_NAME = 'x-runtime-bypass';
@@ -121,7 +121,7 @@ describe('injectEnvVars', () => {
     const cloudJob = {
       authBypassValue: 'bypass-value',
       authBypassHeaderName: 'x-bypass-roomote-auth',
-    } as CloudJob;
+    } as Run;
 
     await injectEnvVars(envVars, cloudJob);
 
@@ -158,7 +158,7 @@ describe('injectEnvVars', () => {
       proxyPorts: {
         WEB: 4321,
       },
-    } as unknown as CloudJob;
+    } as unknown as Run;
 
     await injectEnvVars(envVars, cloudJob, {
       previewProxyBaseUrl: 'https://preview.newmote.run',

--- a/apps/worker/src/commands/setup/workspace/services.ts
+++ b/apps/worker/src/commands/setup/workspace/services.ts
@@ -2,7 +2,7 @@ import {
   type EnvironmentConfig,
   type ServiceInfo,
   TaskPayloadKind,
-  isServicesEnabledCloudTaskType,
+  isServicesEnabledTaskPayloadKind,
 } from '@roomote/types';
 
 import type { StartupLogger } from '../../../logging';
@@ -110,7 +110,7 @@ async function startSystemServices({
 
   if (
     environmentConfig &&
-    isServicesEnabledCloudTaskType(cloudJobType) &&
+    isServicesEnabledTaskPayloadKind(cloudJobType) &&
     environmentConfig.services &&
     environmentConfig.services.length > 0
   ) {

--- a/apps/worker/src/commands/snapshot.ts
+++ b/apps/worker/src/commands/snapshot.ts
@@ -2,7 +2,7 @@ import pWaitFor from 'p-wait-for';
 
 import {
   DEFAULT_SOURCE_CONTROL_PROVIDER,
-  CloudTaskStatus,
+  RunStatus,
   TaskPayloadKind,
 } from '@roomote/types';
 import { sdk } from '@roomote/sdk/client';
@@ -51,7 +51,7 @@ export async function snapshot({
   try {
     await sdk.cloudJobs.update({
       id: cloudJobId,
-      status: CloudTaskStatus.Preparing,
+      status: RunStatus.Preparing,
     });
 
     const {
@@ -105,7 +105,7 @@ export async function snapshot({
 
     await sdk.cloudJobs.update({
       id: cloudJobId,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
     });
 
     // Enqueue snapshot request via SDK.
@@ -143,7 +143,7 @@ export async function snapshot({
 
     await sdk.cloudJobs.done({
       id: cloudJobId,
-      status: CloudTaskStatus.Failed,
+      status: RunStatus.Failed,
       error: message,
     });
 

--- a/apps/worker/src/commands/utils/background-environment-setup-controller.ts
+++ b/apps/worker/src/commands/utils/background-environment-setup-controller.ts
@@ -1,4 +1,4 @@
-import { type CloudJob } from '@roomote/sdk/client';
+import { type Run } from '@roomote/sdk/client';
 
 import { createWorkerRuntimeEventRecorder } from '../../run-task/cloud-job-events';
 import type { EnvironmentSetupWarning } from '../setup/workspace/types';
@@ -21,7 +21,7 @@ type SettledBackgroundEnvironmentSetup =
     };
 
 interface BackgroundEnvironmentSetupControllerOptions {
-  cloudJob?: CloudJob;
+  cloudJob?: Run;
   backgroundSetupPromise?: Promise<EnvironmentSetupWarning[]>;
   recordWorkerRuntimeEvent: ReturnType<typeof createWorkerRuntimeEventRecorder>;
 }
@@ -29,7 +29,7 @@ interface BackgroundEnvironmentSetupControllerOptions {
 export class BackgroundEnvironmentSetupController {
   private readonly taskAbortController = new AbortController();
   private readonly backgroundSetupPromise?: Promise<EnvironmentSetupWarning[]>;
-  private readonly cloudJob?: CloudJob;
+  private readonly cloudJob?: Run;
   private readonly recordWorkerRuntimeEvent: ReturnType<
     typeof createWorkerRuntimeEventRecorder
   >;

--- a/apps/worker/src/commands/utils/env-vars.ts
+++ b/apps/worker/src/commands/utils/env-vars.ts
@@ -10,7 +10,7 @@ import {
   PRODUCT_NAME,
   type SourceControlTokenMetadata,
 } from '@roomote/types';
-import { type CloudJob } from '@roomote/sdk/client';
+import { type Run } from '@roomote/sdk/client';
 
 import {
   applySourceControlTokenMetadata,
@@ -147,7 +147,7 @@ interface PreviewIdentity {
   proxyPorts: Record<string, number>;
 }
 
-function resolvePreviewIdentity(cloudJob?: CloudJob): PreviewIdentity | null {
+function resolvePreviewIdentity(cloudJob?: Run): PreviewIdentity | null {
   if (cloudJob?.taskId && cloudJob.machineDomains) {
     return {
       taskId: cloudJob.taskId,
@@ -180,7 +180,7 @@ function resolvePreviewIdentity(cloudJob?: CloudJob): PreviewIdentity | null {
  */
 export async function injectEnvVars(
   envVars: Record<string, string>,
-  cloudJob?: CloudJob,
+  cloudJob?: Run,
   options?: {
     previewProxyBaseUrl?: string;
     previewProxySubdomainSuffix?: string;

--- a/apps/worker/src/commands/utils/execute-job.test.ts
+++ b/apps/worker/src/commands/utils/execute-job.test.ts
@@ -107,7 +107,7 @@ vi.mock('./job-lifecycle', () => ({
   handleJobError: handleJobErrorMock,
 }));
 
-import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
 
 import { WorkspaceRepositoryPreparationError } from '../setup/workspace/types';
 import * as executeJobModule from './execute-job';
@@ -164,7 +164,7 @@ describe('executeJob', () => {
 
   it('keeps user env separate while routing model traffic through the proxy', async () => {
     const runFn = vi.fn().mockResolvedValue({
-      status: CloudTaskStatus.Idle,
+      status: RunStatus.Idle,
     });
 
     const fetchFn = vi.fn().mockResolvedValue({
@@ -240,7 +240,7 @@ describe('executeJob', () => {
 
   it('passes environment setup warnings through to the task runtime', async () => {
     const runFn = vi.fn().mockResolvedValue({
-      status: CloudTaskStatus.Idle,
+      status: RunStatus.Idle,
     });
 
     setupMock.mockResolvedValueOnce({
@@ -299,7 +299,7 @@ describe('executeJob', () => {
       setFilePath: vi.fn(),
     };
     const runFn = vi.fn().mockResolvedValue({
-      status: CloudTaskStatus.Idle,
+      status: RunStatus.Idle,
     });
 
     createStartupLoggerMock.mockReturnValue(startupLogger);
@@ -373,7 +373,7 @@ describe('executeJob', () => {
   it('starts eligible environment-backed tasks before repository commands finish', async () => {
     let releaseBackgroundSetup: (() => void) | undefined;
     const runFn = vi.fn().mockResolvedValue({
-      status: CloudTaskStatus.Idle,
+      status: RunStatus.Idle,
     });
 
     setupMock.mockResolvedValueOnce({
@@ -492,7 +492,7 @@ describe('executeJob', () => {
         },
       }),
       runFn: vi.fn().mockResolvedValue({
-        status: CloudTaskStatus.Idle,
+        status: RunStatus.Idle,
       }),
     });
 
@@ -538,7 +538,7 @@ describe('executeJob', () => {
         },
       }),
       runFn: vi.fn().mockResolvedValue({
-        status: CloudTaskStatus.Idle,
+        status: RunStatus.Idle,
       }),
     });
 
@@ -583,7 +583,7 @@ describe('executeJob', () => {
         },
       }),
       runFn: vi.fn().mockResolvedValue({
-        status: CloudTaskStatus.Idle,
+        status: RunStatus.Idle,
       }),
     });
 
@@ -618,7 +618,7 @@ describe('executeJob', () => {
       fetchFn,
       workspaceConfigFn: vi.fn().mockResolvedValue({ env: {} }),
       runFn: vi.fn().mockResolvedValue({
-        status: CloudTaskStatus.Idle,
+        status: RunStatus.Idle,
       }),
     });
 
@@ -670,7 +670,7 @@ describe('executeJob', () => {
         gitAuthor: { name: 'Chris', email: 'chris@example.com' },
       }),
       workspaceConfigFn: vi.fn().mockResolvedValue({ env: {} }),
-      runFn: vi.fn().mockResolvedValue({ status: CloudTaskStatus.Idle }),
+      runFn: vi.fn().mockResolvedValue({ status: RunStatus.Idle }),
     });
 
     expect(sdkCloudJobsRecordEventMock).toHaveBeenCalledWith(
@@ -725,7 +725,7 @@ describe('executeJob', () => {
         gitAuthor: { name: 'Chris', email: 'chris@example.com' },
       }),
       workspaceConfigFn: vi.fn().mockResolvedValue({ env: {} }),
-      runFn: vi.fn().mockResolvedValue({ status: CloudTaskStatus.Idle }),
+      runFn: vi.fn().mockResolvedValue({ status: RunStatus.Idle }),
     });
 
     expect(sdkCloudJobsRecordEventMock).toHaveBeenCalledWith(
@@ -792,7 +792,7 @@ describe('executeJob', () => {
         gitAuthor: { name: 'Chris', email: 'chris@example.com' },
       }),
       workspaceConfigFn: vi.fn().mockResolvedValue({ env: {} }),
-      runFn: vi.fn().mockResolvedValue({ status: CloudTaskStatus.Idle }),
+      runFn: vi.fn().mockResolvedValue({ status: RunStatus.Idle }),
     });
 
     expect(sdkCloudJobsRecordEventMock).toHaveBeenCalledWith(
@@ -846,7 +846,7 @@ describe('executeJob', () => {
       setupMode: 'full',
       fetchFn,
       workspaceConfigFn: vi.fn().mockResolvedValue({ env: {} }),
-      runFn: vi.fn().mockResolvedValue({ status: CloudTaskStatus.Idle }),
+      runFn: vi.fn().mockResolvedValue({ status: RunStatus.Idle }),
     });
 
     expect(fetchFn).toHaveBeenCalledWith(42, {
@@ -858,7 +858,7 @@ describe('executeJob', () => {
 
   it('preserves operator-provided model provider env vars', async () => {
     const runFn = vi.fn().mockResolvedValue({
-      status: CloudTaskStatus.Idle,
+      status: RunStatus.Idle,
     });
 
     const fetchFn = vi.fn().mockResolvedValue({
@@ -933,7 +933,7 @@ describe('executeJob', () => {
     });
 
     const runFn = vi.fn().mockResolvedValue({
-      status: CloudTaskStatus.Idle,
+      status: RunStatus.Idle,
     });
 
     const fetchFn = vi.fn().mockResolvedValue({
@@ -972,12 +972,12 @@ describe('executeJob', () => {
 
   it('suppresses non-fatal finalization errors after external snapshot handoff has been claimed', async () => {
     const runFn = vi.fn().mockResolvedValue({
-      status: CloudTaskStatus.Completed,
+      status: RunStatus.Completed,
     });
     finalizeJobMock.mockRejectedValueOnce(new Error('fetch failed'));
     findFirstByIdMock.mockResolvedValue({
       id: 42,
-      status: CloudTaskStatus.Idle,
+      status: RunStatus.Idle,
       sleepRequestedAt: new Date('2026-04-10T10:53:57.130Z'),
       snapshotRequestedAt: new Date('2026-04-10T10:53:57.130Z'),
       snapshotCreatedAt: null,
@@ -1021,7 +1021,7 @@ describe('executeJob', () => {
     expect(captureWorkerExceptionMock).toHaveBeenCalledWith(expect.any(Error), {
       cloudJobId: 42,
       stage: 'executeJob.suppressedFinalizeError',
-      latestStatus: CloudTaskStatus.Idle,
+      latestStatus: RunStatus.Idle,
       snapshotRequestedAt: '2026-04-10T10:53:57.130Z',
       snapshotCreatedAt: null,
       snapshotFailedAt: null,
@@ -1030,12 +1030,12 @@ describe('executeJob', () => {
 
   it('still reports finalization errors when no durable post-run state exists yet', async () => {
     const runFn = vi.fn().mockResolvedValue({
-      status: CloudTaskStatus.Completed,
+      status: RunStatus.Completed,
     });
     finalizeJobMock.mockRejectedValueOnce(new Error('fetch failed'));
     findFirstByIdMock.mockResolvedValue({
       id: 42,
-      status: CloudTaskStatus.Idle,
+      status: RunStatus.Idle,
       sleepRequestedAt: null,
       snapshotRequestedAt: null,
       snapshotCreatedAt: null,
@@ -1115,7 +1115,7 @@ describe('executeJob', () => {
         gitAuthor: { name: 'Chris', email: 'chris@example.com' },
       }),
       workspaceConfigFn: vi.fn().mockResolvedValue({ env: {} }),
-      runFn: vi.fn().mockResolvedValue({ status: CloudTaskStatus.Idle }),
+      runFn: vi.fn().mockResolvedValue({ status: RunStatus.Idle }),
     });
 
     expect(result).toBe(false);

--- a/apps/worker/src/commands/utils/execute-job.ts
+++ b/apps/worker/src/commands/utils/execute-job.ts
@@ -1,13 +1,13 @@
 import * as path from 'node:path';
 
 import {
-  CloudTaskStatus,
+  RunStatus,
   type SourceControlTokenMetadata,
   type TaskPayloadKind,
   WORKER_HEARTBEAT_INTERVAL_MS,
   buildRoomoteDeployMarker,
   formatRoomoteDeployMarker,
-  resolveCloudTaskWorkspace,
+  resolveTaskWorkspace,
   resolveComputeProviderTarget,
   resolveSourceControlProviderFromPayload,
 } from '@roomote/types';
@@ -79,7 +79,7 @@ interface ExecuteJobConfig<TJobContext extends PreparedJobBase> {
     logger: HarnessLogger;
     workerEnv: WorkerEnv;
   }) => Promise<{
-    status: CloudTaskStatus;
+    status: RunStatus;
     error?: string;
   }>;
 }
@@ -233,7 +233,7 @@ function shouldRunParallelTaskEnvironmentSetup(params: {
 async function shouldSuppressFinalizeError(params: {
   cloudJob: Run;
   result: {
-    status: CloudTaskStatus;
+    status: RunStatus;
     error?: string;
   };
   error: unknown;
@@ -241,10 +241,7 @@ async function shouldSuppressFinalizeError(params: {
 }): Promise<boolean> {
   const { cloudJob, result, error, logger } = params;
 
-  if (
-    result.status === CloudTaskStatus.Failed ||
-    result.status === CloudTaskStatus.Idle
-  ) {
+  if (result.status === RunStatus.Failed || result.status === RunStatus.Idle) {
     return false;
   }
 
@@ -265,11 +262,11 @@ async function shouldSuppressFinalizeError(params: {
   }
 
   const statusAlreadyPersisted =
-    latestJob.status === CloudTaskStatus.Completed ||
-    latestJob.status === CloudTaskStatus.Canceled;
+    latestJob.status === RunStatus.Completed ||
+    latestJob.status === RunStatus.Canceled;
 
   const snapshotOwnedPostRunState =
-    latestJob.status === CloudTaskStatus.Idle &&
+    latestJob.status === RunStatus.Idle &&
     hasSnapshotLifecycleActivity(latestJob);
 
   if (!statusAlreadyPersisted && !snapshotOwnedPostRunState) {
@@ -375,7 +372,7 @@ export async function executeJob<TPrepared extends PreparedJobBase>({
 
     // Worker config values are read once here so their captured values
     // (auth keys, API URLs) can be reused throughout setup and runtime.
-    const cloudTaskWorkspace = resolveCloudTaskWorkspace(cloudJob.payload);
+    const cloudTaskWorkspace = resolveTaskWorkspace(cloudJob.payload);
 
     const environmentId =
       cloudTaskWorkspace.type === 'environment'
@@ -404,7 +401,7 @@ export async function executeJob<TPrepared extends PreparedJobBase>({
     if (cloudJob.canceledAt) {
       await backgroundEnvironmentSetupController.flush();
       startupLogger.debug.log('Task is already canceled, exiting');
-      await callbacks.onExit?.(cloudJob, CloudTaskStatus.Canceled, context);
+      await callbacks.onExit?.(cloudJob, RunStatus.Canceled, context);
       return true;
     }
 
@@ -470,7 +467,7 @@ export async function executeJob<TPrepared extends PreparedJobBase>({
 
     await sdk.cloudJobs.update({
       id: cloudJob.id,
-      status: CloudTaskStatus.Preparing,
+      status: RunStatus.Preparing,
     });
 
     const workspace = await recordWorkerPhase({
@@ -616,7 +613,7 @@ export async function executeJob<TPrepared extends PreparedJobBase>({
     if (cloudJob.canceledAt) {
       await backgroundEnvironmentSetupController.flush();
       startupLogger.debug.log('Task is already canceled, exiting');
-      await callbacks.onExit?.(cloudJob, CloudTaskStatus.Canceled, context);
+      await callbacks.onExit?.(cloudJob, RunStatus.Canceled, context);
       return true;
     }
 

--- a/apps/worker/src/commands/utils/execute-job.ts
+++ b/apps/worker/src/commands/utils/execute-job.ts
@@ -11,7 +11,7 @@ import {
   resolveComputeProviderTarget,
   resolveSourceControlProviderFromPayload,
 } from '@roomote/types';
-import { type CloudJob, sdk } from '@roomote/sdk/client';
+import { type Run, sdk } from '@roomote/sdk/client';
 
 import { WorkerEnv } from '../../env';
 import {
@@ -49,7 +49,7 @@ import { buildServiceContextForPreviewProxy } from './service-context';
 import { finalizeJob, handleJobError } from './job-lifecycle';
 
 interface PreparedJobBase {
-  cloudJob: CloudJob;
+  cloudJob: Run;
   envVars: Record<string, string>;
   sourceControlToken?: SourceControlTokenMetadata;
   gitAuthor?: { name: string; email: string };
@@ -146,7 +146,7 @@ function serializeRepositoryPreparationIssues(
 }
 
 function buildRepositoryPreparationEventInput(params: {
-  cloudJob: CloudJob;
+  cloudJob: Run;
   outcome:
     | WorkspaceRepositoryPreparationContinued
     | WorkspaceRepositoryPreparationFailure;
@@ -198,7 +198,7 @@ function hasSnapshotLifecycleActivity(job: {
 }
 
 function isSetupOnboardingTask(params: {
-  cloudJob: CloudJob;
+  cloudJob: Run;
   jobContext: PreparedJobBase;
 }): boolean {
   const { cloudJob, jobContext } = params;
@@ -216,7 +216,7 @@ function isSetupOnboardingTask(params: {
 }
 
 function shouldRunParallelTaskEnvironmentSetup(params: {
-  cloudJob: CloudJob;
+  cloudJob: Run;
   jobContext: PreparedJobBase;
   setupMode: SetupMode;
   workspace: WorkspaceConfig;
@@ -231,7 +231,7 @@ function shouldRunParallelTaskEnvironmentSetup(params: {
 }
 
 async function shouldSuppressFinalizeError(params: {
-  cloudJob: CloudJob;
+  cloudJob: Run;
   result: {
     status: CloudTaskStatus;
     error?: string;
@@ -248,7 +248,7 @@ async function shouldSuppressFinalizeError(params: {
     return false;
   }
 
-  let latestJob: CloudJob | undefined;
+  let latestJob: Run | undefined;
 
   try {
     latestJob = await sdk.cloudJobs.findFirstById(cloudJob.id);
@@ -303,7 +303,7 @@ export async function executeJob<TPrepared extends PreparedJobBase>({
   workspaceConfigFn,
   runFn,
 }: ExecuteJobConfig<TPrepared>): Promise<boolean> {
-  let cloudJob: CloudJob | undefined = undefined;
+  let cloudJob: Run | undefined = undefined;
   let harnessLogger: HarnessLogger | undefined = undefined;
   let workerHeartbeatInterval: NodeJS.Timeout | undefined = undefined;
 

--- a/apps/worker/src/commands/utils/job-lifecycle.test.ts
+++ b/apps/worker/src/commands/utils/job-lifecycle.test.ts
@@ -23,7 +23,7 @@ vi.mock('../../monitoring/sentry', () => ({
   captureWorkerException: captureWorkerExceptionMock,
 }));
 
-import { CloudTaskStatus } from '@roomote/types';
+import { RunStatus } from '@roomote/types';
 
 import { ExecutionError } from '../../command-executor';
 import { finalizeJob, handleJobError } from './job-lifecycle';
@@ -49,14 +49,14 @@ describe('job-lifecycle', () => {
 
     expect(sdkCloudJobsDoneMock).toHaveBeenCalledWith({
       id: 42,
-      status: CloudTaskStatus.Failed,
+      status: RunStatus.Failed,
       error: 'Environment not found',
     });
     expect(captureWorkerExceptionMock).toHaveBeenCalledWith(expect.any(Error), {
       cloudJobId: 42,
       stage: 'handleJobError',
     });
-    expect(onExit).toHaveBeenCalledWith({ id: 42 }, CloudTaskStatus.Failed, {});
+    expect(onExit).toHaveBeenCalledWith({ id: 42 }, RunStatus.Failed, {});
   });
 
   it('persists execution diagnostics for command failures', async () => {
@@ -89,7 +89,7 @@ describe('job-lifecycle', () => {
 
     expect(sdkCloudJobsDoneMock).toHaveBeenCalledWith({
       id: 20637,
-      status: CloudTaskStatus.Failed,
+      status: RunStatus.Failed,
       error: expect.stringContaining('pnpm --filter @currents/core-api build'),
     });
     expect(sdkCloudJobsDoneMock).toHaveBeenCalledWith(
@@ -170,7 +170,7 @@ describe('job-lifecycle', () => {
 
     await expect(
       finalizeJob({
-        result: { status: CloudTaskStatus.Completed },
+        result: { status: RunStatus.Completed },
         cloudJob: { id: 84, result: null } as never,
         logger: undefined as never,
         callbacks: {},

--- a/apps/worker/src/commands/utils/job-lifecycle.ts
+++ b/apps/worker/src/commands/utils/job-lifecycle.ts
@@ -1,5 +1,5 @@
 import {
-  CloudTaskStatus,
+  RunStatus,
   CONFLICT_RESOLUTION_SUMMARY_RESULT_KEY,
   type ConflictResolutionSummary,
 } from '@roomote/types';
@@ -114,7 +114,7 @@ export async function finalizeJob({
   context,
 }: {
   result: {
-    status: CloudTaskStatus;
+    status: RunStatus;
     error?: string;
   };
   cloudJob: Run;
@@ -156,10 +156,10 @@ export async function finalizeJob({
     await sdk.cloudJobs.done({
       id: cloudJob.id,
       status: status as
-        | CloudTaskStatus.Completed
-        | CloudTaskStatus.Failed
-        | CloudTaskStatus.Canceled
-        | CloudTaskStatus.Idle,
+        | RunStatus.Completed
+        | RunStatus.Failed
+        | RunStatus.Canceled
+        | RunStatus.Idle,
       ...(error && { error }),
     });
   } catch (doneError) {
@@ -178,7 +178,7 @@ export async function finalizeJob({
     );
   }
 
-  if (status !== CloudTaskStatus.Completed) {
+  if (status !== RunStatus.Completed) {
     console.error(`Job exited with status: ${status}`);
   }
 }
@@ -205,11 +205,11 @@ export async function handleJobError({
   if (cloudJob) {
     await sdk.cloudJobs.done({
       id: cloudJob.id,
-      status: CloudTaskStatus.Failed,
+      status: RunStatus.Failed,
       error: message,
     });
 
-    await callbacks.onExit?.(cloudJob, CloudTaskStatus.Failed, context);
+    await callbacks.onExit?.(cloudJob, RunStatus.Failed, context);
   }
 
   console.error(`❌ Job ${cloudJob?.id ?? '<unknown>'} failed: ${message}`);

--- a/apps/worker/src/commands/utils/job-lifecycle.ts
+++ b/apps/worker/src/commands/utils/job-lifecycle.ts
@@ -3,7 +3,7 @@ import {
   CONFLICT_RESOLUTION_SUMMARY_RESULT_KEY,
   type ConflictResolutionSummary,
 } from '@roomote/types';
-import { type CloudJob, sdk } from '@roomote/sdk/client';
+import { type Run, sdk } from '@roomote/sdk/client';
 
 import { ExecutionError } from '../../command-executor';
 import type { HarnessLogger } from '../../logging';
@@ -80,7 +80,7 @@ function describeJobFailure(error: unknown): string {
 
 function buildWorkerExceptionContext(params: {
   error: unknown;
-  cloudJob: CloudJob | undefined;
+  cloudJob: Run | undefined;
 }): WorkerRuntimeContext {
   const { error, cloudJob } = params;
   const context: WorkerRuntimeContext = {
@@ -117,7 +117,7 @@ export async function finalizeJob({
     status: CloudTaskStatus;
     error?: string;
   };
-  cloudJob: CloudJob;
+  cloudJob: Run;
   logger: HarnessLogger;
   callbacks: RunTaskCallbacks;
   context: RunTaskContext;
@@ -190,7 +190,7 @@ export async function handleJobError({
   context,
 }: {
   error: unknown;
-  cloudJob: CloudJob | undefined;
+  cloudJob: Run | undefined;
   logger: HarnessLogger | undefined;
   callbacks: RunTaskCallbacks;
   context: RunTaskContext;

--- a/apps/worker/src/commands/utils/service-context.ts
+++ b/apps/worker/src/commands/utils/service-context.ts
@@ -1,4 +1,4 @@
-import type { CloudJob } from '@roomote/sdk/client';
+import type { Run } from '@roomote/sdk/client';
 import {
   assertNoReservedEnvironmentPorts,
   getPrimaryPortFromConfig,
@@ -89,7 +89,7 @@ export function buildWorkspacePortMappings(
 }
 
 export function buildServiceContextForPreviewProxy(
-  cloudJob: CloudJob,
+  cloudJob: Run,
   workspace: WorkspaceConfig,
   workerEnv: WorkerEnv,
 ): ServiceContext | undefined {

--- a/apps/worker/src/commands/utils/workspace-config.ts
+++ b/apps/worker/src/commands/utils/workspace-config.ts
@@ -1,7 +1,4 @@
-import {
-  type EnvironmentConfig,
-  resolveCloudTaskWorkspace,
-} from '@roomote/types';
+import { type EnvironmentConfig, resolveTaskWorkspace } from '@roomote/types';
 import { sdk } from '@roomote/sdk/client';
 
 import type {
@@ -33,7 +30,7 @@ export async function buildWorkspaceConfig({
   sha?: string;
   selectedRepositories?: string[];
 }): Promise<WorkspaceConfig> {
-  const workspace = resolveCloudTaskWorkspace({
+  const workspace = resolveTaskWorkspace({
     repo,
     branch,
     sha,

--- a/apps/worker/src/mcp/roomote-mcp-server/task-display.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/task-display.ts
@@ -1,8 +1,4 @@
-import {
-  CloudTaskStatus,
-  HARNESS_LABELS,
-  isCodingHarness,
-} from '@roomote/types';
+import { RunStatus, HARNESS_LABELS, isCodingHarness } from '@roomote/types';
 
 function getPhaseLabel(taskPhase: string | null): string | null {
   switch (taskPhase) {
@@ -25,27 +21,27 @@ function getPhaseLabel(taskPhase: string | null): string | null {
 
 function getCloudJobStatusLabel(status: string): string {
   switch (status) {
-    case CloudTaskStatus.Pending:
+    case RunStatus.Pending:
       return 'Pending';
-    case CloudTaskStatus.Dequeued:
+    case RunStatus.Dequeued:
       return 'Dequeued';
-    case CloudTaskStatus.Processing:
+    case RunStatus.Processing:
       return 'Processing';
-    case CloudTaskStatus.Preparing:
+    case RunStatus.Preparing:
       return 'Preparing';
-    case CloudTaskStatus.Spawning:
+    case RunStatus.Spawning:
       return 'Spawning';
-    case CloudTaskStatus.Connecting:
+    case RunStatus.Connecting:
       return 'Connecting';
-    case CloudTaskStatus.Running:
+    case RunStatus.Running:
       return 'Running';
-    case CloudTaskStatus.Idle:
+    case RunStatus.Idle:
       return 'Idle';
-    case CloudTaskStatus.Completed:
+    case RunStatus.Completed:
       return 'Completed';
-    case CloudTaskStatus.Failed:
+    case RunStatus.Failed:
       return 'Failed';
-    case CloudTaskStatus.Canceled:
+    case RunStatus.Canceled:
       return 'Canceled';
     default:
       return status;
@@ -63,11 +59,11 @@ export function getTaskStatusLabel(input: {
     return completed ? 'Completed' : 'Active';
   }
 
-  if (cloudJobStatus === CloudTaskStatus.Running) {
+  if (cloudJobStatus === RunStatus.Running) {
     return getPhaseLabel(taskPhase) ?? 'Running';
   }
 
-  if (cloudJobStatus === CloudTaskStatus.Idle) {
+  if (cloudJobStatus === RunStatus.Idle) {
     return getPhaseLabel(taskPhase) ?? 'Idle';
   }
 

--- a/apps/worker/src/run-task/__tests__/resolve-status.test.ts
+++ b/apps/worker/src/run-task/__tests__/resolve-status.test.ts
@@ -1,4 +1,4 @@
-import { CloudTaskStatus } from '@roomote/types';
+import { RunStatus } from '@roomote/types';
 
 import { resolveStatus } from '../resolve-status';
 
@@ -20,7 +20,7 @@ describe('resolveStatus', () => {
       githubTokenRefreshInterval: undefined,
     });
 
-    expect(result.status).toBe(CloudTaskStatus.Canceled);
+    expect(result.status).toBe(RunStatus.Canceled);
     expect(result.error).toBe(
       'unexpected status 401 Unauthorized: Incorrect API key provided: [redacted-api-key]',
     );

--- a/apps/worker/src/run-task/__tests__/run-task.test.ts
+++ b/apps/worker/src/run-task/__tests__/run-task.test.ts
@@ -242,7 +242,7 @@ vi.mock('../../sandbox-server/procedures/slackReplyTurnTracking', () => ({
   recordSandboxPromptSlackTurnStart: recordSandboxPromptSlackTurnStartMock,
 }));
 
-import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
 
 import { getDefaultKeepaliveMs } from '../completion';
 import { runTask } from '../run-task';
@@ -270,7 +270,7 @@ describe('runTask', () => {
       taskFinishedAt: undefined,
       taskAbortedAt: undefined,
     });
-    resolveStatusMock.mockReturnValue(CloudTaskStatus.Idle);
+    resolveStatusMock.mockReturnValue(RunStatus.Idle);
     waitForExternalSleepActionMock.mockResolvedValue({
       claimed: false,
       completed: false,
@@ -1870,7 +1870,7 @@ describe('runTask', () => {
     cancelController.abort(new Error('background environment setup failed'));
 
     await expect(runTaskPromise).resolves.toEqual({
-      status: CloudTaskStatus.Canceled,
+      status: RunStatus.Canceled,
       error: 'Task aborted',
     });
 
@@ -2548,7 +2548,7 @@ describe('runTask', () => {
     cancelController.abort(new Error('background environment setup failed'));
 
     await expect(runTaskPromise).resolves.toEqual({
-      status: CloudTaskStatus.Canceled,
+      status: RunStatus.Canceled,
       error: 'Task aborted',
     });
 
@@ -2619,7 +2619,7 @@ describe('runTask', () => {
     cancelController.abort(new Error('background environment setup failed'));
 
     await expect(runTaskPromise).resolves.toEqual({
-      status: CloudTaskStatus.Canceled,
+      status: RunStatus.Canceled,
       error: 'Task aborted',
     });
 
@@ -3771,7 +3771,7 @@ describe('runTask', () => {
 
     expect(cloudJobsDoneMock).toHaveBeenCalledWith({
       id: 104,
-      status: CloudTaskStatus.Idle,
+      status: RunStatus.Idle,
     });
   });
 

--- a/apps/worker/src/run-task/__tests__/wait-for-external-sleep-action.test.ts
+++ b/apps/worker/src/run-task/__tests__/wait-for-external-sleep-action.test.ts
@@ -12,7 +12,7 @@ vi.mock('@roomote/sdk/client', () => ({
 
 import { TaskPayloadKind } from '@roomote/types';
 
-import { CloudTaskStatus } from '@roomote/types';
+import { RunStatus } from '@roomote/types';
 import { waitForExternalSleepAction } from '../wait-for-external-sleep-action';
 
 describe('waitForExternalSleepAction', () => {
@@ -28,7 +28,7 @@ describe('waitForExternalSleepAction', () => {
         snapshotCreatedAt: null,
         snapshotFailedAt: null,
         error: null,
-        status: CloudTaskStatus.Running,
+        status: RunStatus.Running,
       })
       .mockResolvedValueOnce({
         sleepRequestedAt: new Date(),
@@ -36,7 +36,7 @@ describe('waitForExternalSleepAction', () => {
         snapshotCreatedAt: new Date(),
         snapshotFailedAt: null,
         error: null,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       });
 
     const logger = {
@@ -70,7 +70,7 @@ describe('waitForExternalSleepAction', () => {
         snapshotCreatedAt: null,
         snapshotFailedAt: null,
         error: null,
-        status: CloudTaskStatus.Idle,
+        status: RunStatus.Idle,
       })
       .mockResolvedValueOnce({
         sleepRequestedAt: new Date(),
@@ -78,7 +78,7 @@ describe('waitForExternalSleepAction', () => {
         snapshotCreatedAt: null,
         snapshotFailedAt: null,
         error: null,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       });
 
     const logger = {
@@ -112,7 +112,7 @@ describe('waitForExternalSleepAction', () => {
         snapshotCreatedAt: null,
         snapshotFailedAt: null,
         error: null,
-        status: CloudTaskStatus.Running,
+        status: RunStatus.Running,
       })
       .mockResolvedValueOnce({
         sleepRequestedAt: new Date(),
@@ -120,7 +120,7 @@ describe('waitForExternalSleepAction', () => {
         snapshotCreatedAt: new Date(),
         snapshotFailedAt: null,
         error: null,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       });
 
     const logger = {

--- a/apps/worker/src/run-task/cloud-job-events.ts
+++ b/apps/worker/src/run-task/cloud-job-events.ts
@@ -1,4 +1,4 @@
-import type { CloudJobEventDetails, CloudJobEventType } from '@roomote/types';
+import type { RunEventDetails, RunEventType } from '@roomote/types';
 import { sdk } from '@roomote/sdk/client';
 
 function formatError(error: unknown): string {
@@ -66,9 +66,9 @@ export function createWorkerRuntimeEventRecorder(options: {
   logger: Pick<Console, 'warn'>;
 }) {
   return async (input: {
-    eventType: CloudJobEventType;
+    eventType: RunEventType;
     message: string;
-    details?: CloudJobEventDetails;
+    details?: RunEventDetails;
   }): Promise<void> => {
     try {
       await sdk.cloudJobs.recordEvent({

--- a/apps/worker/src/run-task/resolve-status.ts
+++ b/apps/worker/src/run-task/resolve-status.ts
@@ -1,4 +1,4 @@
-import { CloudTaskStatus } from '@roomote/types';
+import { RunStatus } from '@roomote/types';
 
 import type { RunTaskState } from './types';
 
@@ -10,22 +10,22 @@ function formatResolvedError(
 }
 
 export function resolveStatus(state: RunTaskState): {
-  status: CloudTaskStatus;
+  status: RunStatus;
   error?: string;
 } {
   if (state.taskAbortedAt) {
     return {
-      status: CloudTaskStatus.Canceled,
+      status: RunStatus.Canceled,
       error: formatResolvedError(state, 'Task aborted'),
     };
   }
 
   if (state.taskFinishedAt) {
-    return { status: CloudTaskStatus.Completed };
+    return { status: RunStatus.Completed };
   }
 
   return {
-    status: CloudTaskStatus.Failed,
+    status: RunStatus.Failed,
     error: formatResolvedError(state, 'Task failed to complete'),
   };
 }

--- a/apps/worker/src/run-task/run-task.ts
+++ b/apps/worker/src/run-task/run-task.ts
@@ -1,7 +1,7 @@
 import {
   type CommunicationProvider,
   type AcpRequestUserInputAnswers,
-  CloudTaskStatus,
+  RunStatus,
   TaskPayloadKind,
   type QueuedCommunicationMessage,
   getSlackChannelFromTaskPayload,
@@ -513,7 +513,7 @@ export const runTask = async ({
 }: RunTaskOptions) => {
   await sdk.cloudJobs.update({
     id: cloudJob.id,
-    status: CloudTaskStatus.Spawning,
+    status: RunStatus.Spawning,
   });
 
   // Register the process-level crash listeners (at most once per process) and
@@ -783,7 +783,7 @@ export const runTask = async ({
 
     await sdk.cloudJobs.update({
       id: cloudJob.id,
-      status: CloudTaskStatus.Connecting,
+      status: RunStatus.Connecting,
     });
 
     const recordWorkerRuntimeEvent = createWorkerRuntimeEventRecorder({
@@ -1001,7 +1001,7 @@ export const runTask = async ({
           });
           await sdk.cloudJobs.done({
             id: cloudJob.id,
-            status: CloudTaskStatus.Idle,
+            status: RunStatus.Idle,
           });
         },
       },
@@ -1448,7 +1448,7 @@ export const runTask = async ({
 
     await sdk.cloudJobs.update({
       id: cloudJob.id,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
     });
 
     // Subscribe to HarnessManager state changes BEFORE starting/resuming a task
@@ -1482,7 +1482,7 @@ export const runTask = async ({
       }
 
       return {
-        status: CloudTaskStatus.Canceled,
+        status: RunStatus.Canceled,
         error: 'Task aborted',
       };
     } else if (harnessSessionId) {

--- a/apps/worker/src/run-task/types.ts
+++ b/apps/worker/src/run-task/types.ts
@@ -2,7 +2,7 @@ import type {
   AcpRequestUserInputAnswers,
   AcpRequestUserInputPayload,
   AcpRequestUserInputResponsePayload,
-  CloudTaskStatus,
+  RunStatus,
   CommunicationProvider,
   EnvironmentConfig,
   RequestedWorkKind,
@@ -111,7 +111,7 @@ export type RunTaskCallbacks = {
   ) => Promise<void>;
   onExit?: (
     cloudJob: Run,
-    status: CloudTaskStatus,
+    status: RunStatus,
     context: RunTaskContext,
   ) => Promise<void>;
 };

--- a/apps/worker/src/run-task/types.ts
+++ b/apps/worker/src/run-task/types.ts
@@ -7,7 +7,7 @@ import type {
   EnvironmentConfig,
   RequestedWorkKind,
 } from '@roomote/types';
-import type { CloudJob, DequeuedCloudJob } from '@roomote/sdk/client';
+import type { Run, DequeuedCloudJob } from '@roomote/sdk/client';
 
 import type {
   TaskPhase,
@@ -99,18 +99,18 @@ export type CallbackEvent =
 
 export type RunTaskCallbacks = {
   onStart?: (
-    cloudJob: CloudJob,
+    cloudJob: Run,
     taskId: string,
     context: RunTaskContext,
   ) => Promise<void>;
   onMessage?: (
-    cloudJob: CloudJob,
+    cloudJob: Run,
     taskId: string,
     event: CallbackEvent,
     context: RunTaskContext,
   ) => Promise<void>;
   onExit?: (
-    cloudJob: CloudJob,
+    cloudJob: Run,
     status: CloudTaskStatus,
     context: RunTaskContext,
   ) => Promise<void>;

--- a/apps/worker/src/run-task/wait-for-external-sleep-action.ts
+++ b/apps/worker/src/run-task/wait-for-external-sleep-action.ts
@@ -1,10 +1,10 @@
 import pWaitFor from 'p-wait-for';
 
 import {
-  isExitedCloudTaskStatus,
+  isExitedRunStatus,
   isSleepCheckManagedComputeProvider,
   isSnapshotCapableComputeProvider,
-  isResumableCloudTaskType,
+  isResumableTaskPayloadKind,
 } from '@roomote/types';
 import { type DequeuedCloudJob, sdk } from '@roomote/sdk/client';
 
@@ -58,7 +58,7 @@ export async function waitForExternalSleepAction({
 
   // Non-snapshot providers (Daytona) exit via destroy, never via snapshot.
   const isResumable =
-    isResumableCloudTaskType(cloudJob.payloadKind) &&
+    isResumableTaskPayloadKind(cloudJob.payloadKind) &&
     isSnapshotCapableComputeProvider(cloudJob.vendor);
   let sleepRequested = false;
 
@@ -132,7 +132,7 @@ export async function waitForExternalSleepAction({
           return Boolean(updatedJob.snapshotCreatedAt);
         }
 
-        return isExitedCloudTaskStatus(updatedJob.status);
+        return isExitedRunStatus(updatedJob.status);
       },
       {
         interval: SNAPSHOT_POLL_INTERVAL_MS,

--- a/packages/ado/src/__tests__/api.test.ts
+++ b/packages/ado/src/__tests__/api.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
 import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
-import type { CloudJob } from '@roomote/db/server';
+import type { Run } from '@roomote/db/server';
 
 const {
   mockEnvironmentVariablesFindMany,
@@ -76,7 +76,7 @@ import {
   type AdoRepository,
 } from '../api';
 
-function makeCloudJob(payload: CloudJob['payload']): CloudJob {
+function makeCloudJob(payload: Run['payload']): Run {
   return {
     id: 123,
     status: CloudTaskStatus.Dequeued,
@@ -87,7 +87,7 @@ function makeCloudJob(payload: CloudJob['payload']): CloudJob {
     payload,
     result: null,
     artifacts: null,
-  } as CloudJob;
+  } as Run;
 }
 
 describe('Azure DevOps API helpers', () => {

--- a/packages/ado/src/__tests__/api.test.ts
+++ b/packages/ado/src/__tests__/api.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
-import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
 import type { Run } from '@roomote/db/server';
 
 const {
@@ -79,7 +79,7 @@ import {
 function makeCloudJob(payload: Run['payload']): Run {
   return {
     id: 123,
-    status: CloudTaskStatus.Dequeued,
+    status: RunStatus.Dequeued,
     kind: 'fresh' as const,
     payloadKind: TaskPayloadKind.StandardTask,
     taskId: 'task-123',

--- a/packages/ado/src/api.ts
+++ b/packages/ado/src/api.ts
@@ -7,7 +7,7 @@ import {
   type SourceControlProvider,
 } from '@roomote/types';
 import {
-  type CloudJob,
+  type Run,
   db,
   environments,
   repositories,
@@ -1336,7 +1336,7 @@ function normalizeRepositorySelection(repositoryNames: string[]): string[] {
 }
 
 async function resolveAdoRepositoryNamesForCloudJob(
-  cloudJob: CloudJob,
+  cloudJob: Run,
 ): Promise<string[] | null> {
   if (cloudJob.payload.environmentId) {
     const environment = await db.query.environments.findFirst({
@@ -1373,7 +1373,7 @@ async function resolveAdoRepositoryNamesForCloudJob(
   return null;
 }
 
-async function resolveAdoRepositoryRowsForCloudJob(cloudJob: CloudJob) {
+async function resolveAdoRepositoryRowsForCloudJob(cloudJob: Run) {
   const repositoryNames = await resolveAdoRepositoryNamesForCloudJob(cloudJob);
   const queryConditions = [
     eq(repositories.sourceControlProvider, ADO_PROVIDER),
@@ -1491,7 +1491,7 @@ function buildAdoGitCredential({
 }
 
 export async function createCloudJobAdoCredentials(
-  cloudJob: CloudJob,
+  cloudJob: Run,
   options?: {
     token?: string;
     baseUrl?: string;

--- a/packages/cloud-agents/src/__tests__/utils.test.ts
+++ b/packages/cloud-agents/src/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 // pnpm --filter @roomote/cloud-agents test src/__tests__/utils.test.ts
 
-import { type CloudTaskPayload, TaskPayloadKind } from '@roomote/types';
+import { type TaskPayload, TaskPayloadKind } from '@roomote/types';
 
 import {
   buildSlackThreadPromptBlocks,
@@ -583,7 +583,7 @@ describe('generateCloudJobTitle', () => {
           prUrl: 'https://github.com/owner/repo/pull/42',
           headRef: 'feature/new-thing',
           baseRef: 'main',
-        } as CloudTaskPayload<typeof TaskPayloadKind.GithubPrConflictResolve>,
+        } as TaskPayload<typeof TaskPayloadKind.GithubPrConflictResolve>,
       });
 
       expect(title).toBe('Fix merge conflicts on PR #42');
@@ -592,7 +592,7 @@ describe('generateCloudJobTitle', () => {
     it('should return default title for unknown task type', () => {
       const title = generateCloudJobTitle({
         type: 'unknown.type' as TaskPayloadKind,
-        payload: { repo: 'owner/repo' } as CloudTaskPayload,
+        payload: { repo: 'owner/repo' } as TaskPayload,
       });
 
       expect(title).toBe('Untitled task');

--- a/packages/cloud-agents/src/server/__tests__/enqueue-cloud-task.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/enqueue-cloud-task.test.ts
@@ -6,9 +6,9 @@
 import Redis from 'ioredis-mock';
 
 import {
-  type CloudTask,
+  type TaskSpec,
   type SnapshotResumeTask,
-  CloudTaskStatus,
+  RunStatus,
   TaskPayloadKind,
 } from '@roomote/types';
 import {
@@ -45,8 +45,8 @@ const explicitWorkKind = {
 } as const;
 
 function standardTaskInput(
-  overrides: Partial<Extract<CloudTask, { type: 'standard' }>> = {},
-): Extract<CloudTask, { type: 'standard' }> {
+  overrides: Partial<Extract<TaskSpec, { type: 'standard' }>> = {},
+): Extract<TaskSpec, { type: 'standard' }> {
   return {
     type: TaskPayloadKind.StandardTask,
     requestedWorkKindDecision: explicitWorkKind,
@@ -55,7 +55,7 @@ function standardTaskInput(
       description: 'Do the thing',
     },
     ...overrides,
-  } as Extract<CloudTask, { type: 'standard' }>;
+  } as Extract<TaskSpec, { type: 'standard' }>;
 }
 
 async function createUser(): Promise<string> {
@@ -310,7 +310,7 @@ describe('enqueueCloudTask PR linkage', () => {
         prUrl: 'https://github.com/acme/widgets/pull/77',
         headSha: 'a'.repeat(40),
       },
-    } as Extract<CloudTask, { type: 'github_pr_review' }>;
+    } as Extract<TaskSpec, { type: 'github_pr_review' }>;
 
     const run = await launchFresh({
       task: prTask,
@@ -359,7 +359,7 @@ describe('enqueueCloudTask PR linkage', () => {
         prUrl: 'https://github.com/acme/widgets/pull/78',
         headSha: 'c'.repeat(40),
       },
-    } as Extract<CloudTask, { type: 'github_pr_review' }>;
+    } as Extract<TaskSpec, { type: 'github_pr_review' }>;
 
     await expect(
       enqueueCloudTask(
@@ -420,7 +420,7 @@ describe('enqueue-failure cancel task state', () => {
 
     expect(task!.state).toBe('canceled');
     expect(runs).toHaveLength(1);
-    expect(runs[0]!.status).toBe(CloudTaskStatus.Canceled);
+    expect(runs[0]!.status).toBe(RunStatus.Canceled);
     expect(runs[0]!.canceledAt).not.toBeNull();
   });
 });

--- a/packages/cloud-agents/src/server/__tests__/enqueue-task.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/enqueue-task.test.ts
@@ -1,4 +1,4 @@
-// pnpm --filter @roomote/cloud-agents test src/server/__tests__/enqueue-cloud-task.test.ts
+// pnpm --filter @roomote/cloud-agents test src/server/__tests__/enqueue-task.test.ts
 //
 // Real-database integration tests for the Stage 2 enqueue rewrite: initiator
 // stamping, resume semantics, enqueue-time PR linkage, and pr_review queue
@@ -30,7 +30,7 @@ import {
 
 import {
   CloudJobQueue,
-  enqueueCloudTask,
+  enqueueTask,
   resolveQueueScope,
   type FreshCloudTaskLaunch,
 } from '../cloud-job-queue';
@@ -69,7 +69,7 @@ async function launchFresh(
     task?: FreshCloudTaskLaunch['task'];
   },
 ) {
-  const run = await enqueueCloudTask(
+  const run = await enqueueTask(
     {
       task: standardTaskInput(),
       ...input,
@@ -97,7 +97,7 @@ afterAll(async () => {
   }
 });
 
-describe('enqueueCloudTask initiator stamping', () => {
+describe('enqueueTask initiator stamping', () => {
   it('persists a linked-user initiator with CHECK-valid shape', async () => {
     const userId = await createUser();
 
@@ -228,7 +228,7 @@ describe('enqueueCloudTask initiator stamping', () => {
   });
 });
 
-describe('enqueueCloudTask snapshot resume', () => {
+describe('enqueueTask snapshot resume', () => {
   it('attaches a resume run to the source task without re-attribution', async () => {
     const initiatorUserId = await createUser();
     const resumerUserId = await createUser();
@@ -253,7 +253,7 @@ describe('enqueueCloudTask snapshot resume', () => {
       },
     } as SnapshotResumeTask;
 
-    const resumeRun = await enqueueCloudTask(
+    const resumeRun = await enqueueTask(
       {
         task: resumeTask,
         actingUserId: resumerUserId,
@@ -293,12 +293,12 @@ describe('enqueueCloudTask snapshot resume', () => {
     } as SnapshotResumeTask;
 
     await expect(
-      enqueueCloudTask({ task: resumeTask }, { enqueue: false }),
+      enqueueTask({ task: resumeTask }, { enqueue: false }),
     ).rejects.toThrow('source run id');
   });
 });
 
-describe('enqueueCloudTask PR linkage', () => {
+describe('enqueueTask PR linkage', () => {
   it('inserts the task_pull_requests row inside the create transaction', async () => {
     const prTask = {
       type: TaskPayloadKind.GithubPrReview,
@@ -362,7 +362,7 @@ describe('enqueueCloudTask PR linkage', () => {
     } as Extract<TaskSpec, { type: 'github_pr_review' }>;
 
     await expect(
-      enqueueCloudTask(
+      enqueueTask(
         {
           task: prTask,
           initiator: { kind: 'automation', key: 'review_code' },
@@ -378,7 +378,7 @@ describe('enqueueCloudTask PR linkage', () => {
 
 describe('enqueue-failure cancel task state', () => {
   // A run canceled before it is queued must leave the owning task in a
-  // terminal state. finishCloudJob never runs for these runs, so
+  // terminal state. finishRun never runs for these runs, so
   // cancelCloudJobBeforeQueue is responsible for the tasks.state write.
   // Regression guard for tasks stranded in 'active' with a canceled run.
   it('marks the task canceled when the run is canceled before it is queued', async () => {
@@ -387,7 +387,7 @@ describe('enqueue-failure cancel task state', () => {
     let capturedTaskId: string | undefined;
 
     await expect(
-      enqueueCloudTask(
+      enqueueTask(
         {
           task: standardTaskInput(),
           initiator: { kind: 'user', userId },
@@ -425,7 +425,7 @@ describe('enqueue-failure cancel task state', () => {
   });
 });
 
-describe('enqueueCloudTask source-control provider stamping', () => {
+describe('enqueueTask source-control provider stamping', () => {
   const createdEnvironmentIds: string[] = [];
   const createdRepositoryIds: string[] = [];
 

--- a/packages/cloud-agents/src/server/__tests__/harness-model-overrides.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/harness-model-overrides.test.ts
@@ -1,5 +1,5 @@
 import {
-  type CloudTask,
+  type TaskSpec,
   TaskPayloadKind,
   DEFAULT_TASK_MODEL_SETTINGS,
   getDefaultTaskModelId,
@@ -9,15 +9,15 @@ import { describe, expect, it } from 'vitest';
 import { resolveEffectiveHarnessModelState } from '../harness-model-overrides';
 
 function makeTask(
-  harnessModelOverrides?: CloudTask['payload']['harnessModelOverrides'],
+  harnessModelOverrides?: TaskSpec['payload']['harnessModelOverrides'],
   type: TaskPayloadKind = TaskPayloadKind.StandardTask,
-): CloudTask {
+): TaskSpec {
   return {
     type,
     payload: {
       ...(harnessModelOverrides ? { harnessModelOverrides } : {}),
     },
-  } as unknown as CloudTask;
+  } as unknown as TaskSpec;
 }
 
 describe('resolveEffectiveHarnessModelState', () => {

--- a/packages/cloud-agents/src/server/cloud-agent-workflow.ts
+++ b/packages/cloud-agents/src/server/cloud-agent-workflow.ts
@@ -17,7 +17,7 @@ import {
   getFeatureFlagEvaluator,
 } from '@roomote/feature-flags/server';
 import {
-  type CloudJob,
+  type Run,
   db,
   eq,
   tasks,
@@ -53,7 +53,7 @@ export async function generatePrompt({
   cloudTask,
   gitHubToken,
 }: {
-  cloudJob: CloudJob;
+  cloudJob: Run;
   cloudTask: CloudTask;
   gitHubToken: string;
 }): Promise<{

--- a/packages/cloud-agents/src/server/cloud-agent-workflow.ts
+++ b/packages/cloud-agents/src/server/cloud-agent-workflow.ts
@@ -1,5 +1,5 @@
 import {
-  type CloudTask,
+  type TaskSpec,
   TaskPayloadKind,
   getCommunicationChannelFromTaskPayload,
   getCommunicationMessageIdFromTaskPayload,
@@ -54,7 +54,7 @@ export async function generatePrompt({
   gitHubToken,
 }: {
   cloudJob: Run;
-  cloudTask: CloudTask;
+  cloudTask: TaskSpec;
   gitHubToken: string;
 }): Promise<{
   prompt: string;

--- a/packages/cloud-agents/src/server/cloud-job-queue.ts
+++ b/packages/cloud-agents/src/server/cloud-job-queue.ts
@@ -114,13 +114,13 @@ async function cancelCloudJobBeforeQueue(
         .where(eq(taskRuns.id, cloudJob.id));
 
       // Derive the task state from all its runs. Enqueue-failure cancels
-      // bypass finishCloudJob entirely, so without this sync the task stays
+      // bypass finishRun entirely, so without this sync the task stays
       // 'active' forever. The shared @roomote/db helper keeps siblings honest.
       await syncTaskStateFromRuns(tx, cloudJob.taskId);
     });
   } catch (cancelError) {
     console.warn(
-      `[enqueueCloudTask] Failed to cancel run ${cloudJob.id} after ${failureContext}: ${getErrorMessage(
+      `[enqueueTask] Failed to cancel run ${cloudJob.id} after ${failureContext}: ${getErrorMessage(
         cancelError,
         'Unknown cancellation error',
       )}`,
@@ -645,7 +645,7 @@ export async function findEnvironmentForRepo(
   return matches[0]!.id;
 }
 
-export interface EnqueueCloudTaskOptions {
+export interface EnqueueTaskOptions {
   /**
    * Optional explicit launch-class override used to resolve runtime keepalive
    * policy. When omitted, automation-initiated launches derive the
@@ -761,9 +761,7 @@ export type ResumeCloudTaskLaunch = {
   prLinkage?: never;
 };
 
-export type EnqueueCloudTaskInput =
-  | FreshCloudTaskLaunch
-  | ResumeCloudTaskLaunch;
+export type EnqueueTaskInput = FreshCloudTaskLaunch | ResumeCloudTaskLaunch;
 
 const PR_LINKAGE_REQUIRED_WORKFLOWS: ReadonlySet<TaskWorkflow> = new Set([
   'pr_review',
@@ -928,7 +926,7 @@ async function resolveEnvironmentContext(
 async function pushRunOntoQueue(params: {
   cloudJob: Run;
   scope: string;
-  options: EnqueueCloudTaskOptions;
+  options: EnqueueTaskOptions;
 }): Promise<void> {
   const { cloudJob, scope, options } = params;
 
@@ -1004,7 +1002,7 @@ async function pushRunOntoQueue(params: {
     });
   } catch (loggingError) {
     console.warn(
-      `[enqueueCloudTask] Failed to record task-start parallel count for run ${cloudJob.id}: ${
+      `[enqueueTask] Failed to record task-start parallel count for run ${cloudJob.id}: ${
         loggingError instanceof Error
           ? loggingError.message
           : String(loggingError)
@@ -1013,9 +1011,9 @@ async function pushRunOntoQueue(params: {
   }
 }
 
-export async function enqueueCloudTask(
-  input: EnqueueCloudTaskInput,
-  options: EnqueueCloudTaskOptions = {},
+export async function enqueueTask(
+  input: EnqueueTaskInput,
+  options: EnqueueTaskOptions = {},
 ): Promise<Run> {
   await assertDeploymentIsActive();
 
@@ -1028,7 +1026,7 @@ export async function enqueueCloudTask(
 
 async function enqueueFreshLaunch(
   input: FreshCloudTaskLaunch,
-  options: EnqueueCloudTaskOptions,
+  options: EnqueueTaskOptions,
 ): Promise<Run> {
   const { task, initiator, workflow, surface, trigger } = input;
   const visibility: TaskVisibility = input.visibility ?? 'visible';
@@ -1087,7 +1085,7 @@ async function enqueueFreshLaunch(
       task.payload.environmentId = envId;
 
       console.log(
-        `[enqueueCloudTask] Auto-resolved environment ${envId} for ${workspace.repo}`,
+        `[enqueueTask] Auto-resolved environment ${envId} for ${workspace.repo}`,
       );
     }
   }
@@ -1325,7 +1323,7 @@ async function enqueueFreshLaunch(
           );
       } catch (error) {
         console.warn(
-          `[enqueueCloudTask] Failed to generate early LLM title for task ${cloudJob.taskId}: ${
+          `[enqueueTask] Failed to generate early LLM title for task ${cloudJob.taskId}: ${
             error instanceof Error ? error.message : String(error)
           }`,
         );
@@ -1338,7 +1336,7 @@ async function enqueueFreshLaunch(
 
 async function enqueueSnapshotResume(
   input: ResumeCloudTaskLaunch,
-  options: EnqueueCloudTaskOptions,
+  options: EnqueueTaskOptions,
 ): Promise<Run> {
   const { task } = input;
   const actingUserId = options.skipInitialActingUser
@@ -1397,7 +1395,7 @@ async function enqueueSnapshotResume(
 
   if (task.harness && sourceJobHarness !== task.harness) {
     console.warn(
-      `[enqueueCloudTask] SnapshotResume harness override: requested=${task.harness}, source=${sourceJobHarness}`,
+      `[enqueueTask] SnapshotResume harness override: requested=${task.harness}, source=${sourceJobHarness}`,
     );
   }
 
@@ -1407,7 +1405,7 @@ async function enqueueSnapshotResume(
     sourceJobVendor !== task.computeProvider
   ) {
     console.warn(
-      `[enqueueCloudTask] SnapshotResume computeProvider override: requested=${task.computeProvider}, source=${sourceJobVendor}`,
+      `[enqueueTask] SnapshotResume computeProvider override: requested=${task.computeProvider}, source=${sourceJobVendor}`,
     );
   }
 
@@ -1549,7 +1547,7 @@ async function recordSnapshotResumeRequestEvent(input: {
     });
   } catch (error) {
     console.warn(
-      `[enqueueCloudTask] Failed to persist snapshot resume event for source run #${input.runId}: ${
+      `[enqueueTask] Failed to persist snapshot resume event for source run #${input.runId}: ${
         error instanceof Error ? error.message : String(error)
       }`,
     );

--- a/packages/cloud-agents/src/server/cloud-job-queue.ts
+++ b/packages/cloud-agents/src/server/cloud-job-queue.ts
@@ -31,7 +31,7 @@ import {
 } from '@roomote/types';
 import { Env } from '@roomote/env';
 import {
-  type CloudJob,
+  type Run,
   type DatabaseTransaction,
   db,
   deploymentSettings,
@@ -96,7 +96,7 @@ function getErrorMessage(error: unknown, fallback: string): string {
 }
 
 async function cancelCloudJobBeforeQueue(
-  cloudJob: CloudJob,
+  cloudJob: Run,
   message: string,
   failureContext: string,
 ): Promise<void> {
@@ -679,13 +679,13 @@ export interface EnqueueCloudTaskOptions {
    */
   afterCreateInTransaction?: (
     tx: DatabaseTransaction,
-    cloudJob: CloudJob,
+    cloudJob: Run,
   ) => Promise<void>;
   /**
    * Runs after the run row is created but before it is pushed onto the
    * controller queue. If this throws, the run is canceled and never queued.
    */
-  beforeEnqueue?: (cloudJob: CloudJob) => Promise<void>;
+  beforeEnqueue?: (cloudJob: Run) => Promise<void>;
 }
 
 /**
@@ -796,7 +796,7 @@ export function resolveQueueScope(params: {
   return randomUUID();
 }
 
-function getRunLockScope(cloudJob: CloudJob): string {
+function getRunLockScope(cloudJob: Run): string {
   if (PR_SCOPED_PAYLOAD_KINDS.has(cloudJob.payloadKind)) {
     const payload = cloudJob.payload as { repo?: string; prNumber?: number };
 
@@ -926,7 +926,7 @@ async function resolveEnvironmentContext(
 }
 
 async function pushRunOntoQueue(params: {
-  cloudJob: CloudJob;
+  cloudJob: Run;
   scope: string;
   options: EnqueueCloudTaskOptions;
 }): Promise<void> {
@@ -1016,7 +1016,7 @@ async function pushRunOntoQueue(params: {
 export async function enqueueCloudTask(
   input: EnqueueCloudTaskInput,
   options: EnqueueCloudTaskOptions = {},
-): Promise<CloudJob> {
+): Promise<Run> {
   await assertDeploymentIsActive();
 
   if (input.task.type === TaskPayloadKind.SnapshotResume) {
@@ -1029,7 +1029,7 @@ export async function enqueueCloudTask(
 async function enqueueFreshLaunch(
   input: FreshCloudTaskLaunch,
   options: EnqueueCloudTaskOptions,
-): Promise<CloudJob> {
+): Promise<Run> {
   const { task, initiator, workflow, surface, trigger } = input;
   const visibility: TaskVisibility = input.visibility ?? 'visible';
   const linkedUserId = getInitiatorLinkedUserId(initiator);
@@ -1339,7 +1339,7 @@ async function enqueueFreshLaunch(
 async function enqueueSnapshotResume(
   input: ResumeCloudTaskLaunch,
   options: EnqueueCloudTaskOptions,
-): Promise<CloudJob> {
+): Promise<Run> {
   const { task } = input;
   const actingUserId = options.skipInitialActingUser
     ? null
@@ -1440,7 +1440,7 @@ async function enqueueSnapshotResume(
     sandboxTimeoutMs: TASK_TIMEOUT_MS,
   });
 
-  let cloudJob: CloudJob;
+  let cloudJob: Run;
 
   try {
     cloudJob = await db.transaction(async (tx) => {
@@ -1561,14 +1561,14 @@ export async function dequeueCloudTask(): Promise<number | null> {
   return entry ? entry.id : null;
 }
 
-export function releaseCloudTask(cloudJob: CloudJob): Promise<boolean> {
+export function releaseCloudTask(cloudJob: Run): Promise<boolean> {
   return CloudJobQueue.getInstance().releaseLock(getRunLockScope(cloudJob));
 }
 
-export async function isLockedCloudTask(cloudJob: CloudJob): Promise<boolean> {
+export async function isLockedCloudTask(cloudJob: Run): Promise<boolean> {
   return CloudJobQueue.getInstance().isLocked(getRunLockScope(cloudJob));
 }
 
-export async function getCloudTaskLockTTL(cloudJob: CloudJob): Promise<number> {
+export async function getCloudTaskLockTTL(cloudJob: Run): Promise<number> {
   return CloudJobQueue.getInstance().getLockTTL(getRunLockScope(cloudJob));
 }

--- a/packages/cloud-agents/src/server/cloud-job-queue.ts
+++ b/packages/cloud-agents/src/server/cloud-job-queue.ts
@@ -5,17 +5,17 @@ import { z } from 'zod';
 import {
   type AuthorshipRuleActor,
   type BackgroundAutomationKey,
-  type CloudTask,
+  type TaskSpec,
   type CodingHarness,
   type SnapshotResumeTask,
-  type CloudTaskLaunchClass,
+  type RunLaunchClass,
   type SourceControlProvider,
   type TaskInitiator,
   type TaskSurface,
   type TaskTrigger,
   type TaskVisibility,
   type TaskWorkflow,
-  CloudTaskStatus,
+  RunStatus,
   TaskPayloadKind,
   DEFAULT_DELEGATED_KEEPALIVE_MS,
   DEFAULT_KEEPALIVE_MS,
@@ -25,7 +25,7 @@ import {
   isConfiguredEnvValue,
   normalizeDeploymentModelConfig,
   resolveCloudTaskRuntimePolicy,
-  resolveCloudTaskWorkspace,
+  resolveTaskWorkspace,
   resolveComputeProviderTarget,
   TASK_TIMEOUT_MS,
 } from '@roomote/types';
@@ -107,7 +107,7 @@ async function cancelCloudJobBeforeQueue(
       await tx
         .update(taskRuns)
         .set({
-          status: CloudTaskStatus.Canceled,
+          status: RunStatus.Canceled,
           canceledAt: endedAt,
           error: message,
         })
@@ -204,7 +204,7 @@ function resolveCodeReviewModelId(
 }
 
 async function resolveRequestedHarness(
-  task: CloudTask,
+  task: TaskSpec,
 ): Promise<ResolvedHarnessSelection> {
   const deployment = await db.query.deploymentSettings.findFirst({
     where: eq(deploymentSettings.id, DEFAULT_DEPLOYMENT_ID),
@@ -226,7 +226,7 @@ async function resolveRequestedHarness(
   };
 }
 
-function getInitialTaskPrompt(task: CloudTask): string | undefined {
+function getInitialTaskPrompt(task: TaskSpec): string | undefined {
   switch (task.type) {
     case TaskPayloadKind.StandardTask:
     case TaskPayloadKind.Scan:
@@ -246,7 +246,7 @@ function getInitialTaskPrompt(task: CloudTask): string | undefined {
 }
 
 function getRequestedWorkKindBootstrapSkill(
-  task: CloudTask,
+  task: TaskSpec,
 ): 'explain-repo-code' | 'plan-repo-implementation' | undefined {
   if (task.type !== TaskPayloadKind.StandardTask) {
     return undefined;
@@ -301,7 +301,7 @@ export class CloudJobQueue {
               const [canceledRun] = await tx
                 .update(taskRuns)
                 .set({
-                  status: CloudTaskStatus.Canceled,
+                  status: RunStatus.Canceled,
                   canceledAt: endedAt,
                   error: 'Superseded by a newer cloud job.',
                 })
@@ -309,8 +309,8 @@ export class CloudJobQueue {
                   and(
                     eq(taskRuns.id, otherEntry.id),
                     inArray(taskRuns.status, [
-                      CloudTaskStatus.Pending,
-                      CloudTaskStatus.Dequeued,
+                      RunStatus.Pending,
+                      RunStatus.Dequeued,
                     ]),
                   ),
                 )
@@ -652,7 +652,7 @@ export interface EnqueueCloudTaskOptions {
    * 'automation' class from the initiator and everything else falls back to
    * the payload-kind inference.
    */
-  launchClass?: CloudTaskLaunchClass;
+  launchClass?: RunLaunchClass;
   /**
    * Leave `actingUserId` unset until a real follow-up sender can be resolved
    * (Slack channel auto-start path).
@@ -668,7 +668,7 @@ export interface EnqueueCloudTaskOptions {
    * Initial persisted status for the new run. Defaults to `pending`, matching
    * normal queue-driven launches.
    */
-  initialStatus?: CloudTaskStatus.Pending | CloudTaskStatus.Dequeued;
+  initialStatus?: RunStatus.Pending | RunStatus.Dequeued;
   /**
    * Avoid best-effort LLM title generation for short-lived synthetic jobs.
    */
@@ -722,7 +722,7 @@ export type TaskPrLinkage = {
 };
 
 type FreshCloudTask = Exclude<
-  CloudTask,
+  TaskSpec,
   { type: typeof TaskPayloadKind.SnapshotResume }
 >;
 
@@ -885,7 +885,7 @@ type EnvironmentContext = {
  * paths. Mutates `task.payload.port` like the launch flow always has.
  */
 async function resolveEnvironmentContext(
-  task: CloudTask,
+  task: TaskSpec,
 ): Promise<EnvironmentContext> {
   let initialPaths: Record<string, string> | undefined;
 
@@ -988,7 +988,7 @@ async function pushRunOntoQueue(params: {
 
       if (
         !persistedRun ||
-        persistedRun.status === CloudTaskStatus.Canceled ||
+        persistedRun.status === RunStatus.Canceled ||
         persistedRun.canceledAt !== null ||
         persistedRun.completedAt !== null
       ) {
@@ -1050,7 +1050,7 @@ async function enqueueFreshLaunch(
     TaskPayloadKind.GithubPrReviewSync,
     TaskPayloadKind.GithubPrReviewFollowUp,
   ]);
-  const workspace = resolveCloudTaskWorkspace(task.payload);
+  const workspace = resolveTaskWorkspace(task.payload);
 
   // Stamp the source-control provider once at launch when the caller omitted
   // it. Downstream consumers (token minting, worker repository resolution)
@@ -1238,8 +1238,8 @@ async function enqueueFreshLaunch(
         kind: 'fresh',
         payloadKind: taskWithHarnessOverrides.type,
         actingUserId: options.skipInitialActingUser ? null : linkedUserId,
-        status: options.initialStatus ?? CloudTaskStatus.Pending,
-        ...(options.initialStatus === CloudTaskStatus.Dequeued
+        status: options.initialStatus ?? RunStatus.Pending,
+        ...(options.initialStatus === RunStatus.Dequeued
           ? { dequeuedAt: new Date() }
           : {}),
         harness: targetHarness,
@@ -1452,8 +1452,8 @@ async function enqueueSnapshotResume(
           sourceRunId: sourceRun.id,
           payloadKind: TaskPayloadKind.SnapshotResume,
           actingUserId,
-          status: options.initialStatus ?? CloudTaskStatus.Pending,
-          ...(options.initialStatus === CloudTaskStatus.Dequeued
+          status: options.initialStatus ?? RunStatus.Pending,
+          ...(options.initialStatus === RunStatus.Dequeued
             ? { dequeuedAt: new Date() }
             : {}),
           harness: targetHarness,

--- a/packages/cloud-agents/src/server/harness-model-overrides.ts
+++ b/packages/cloud-agents/src/server/harness-model-overrides.ts
@@ -1,5 +1,5 @@
 import {
-  type CloudTask,
+  type TaskSpec,
   type CodingHarness,
   type HarnessModelOverrides,
   type TaskModelSettings,
@@ -18,7 +18,7 @@ function isConfiguredModelId(
   return typeof value === 'string' && value.trim().length > 0;
 }
 
-function isCodeReviewTaskType(task: CloudTask): boolean {
+function isCodeReviewTaskType(task: TaskSpec): boolean {
   return (
     task.type === TaskPayloadKind.GithubPrReview ||
     task.type === TaskPayloadKind.GithubPrReviewSync
@@ -39,7 +39,7 @@ function resolveTaskModelForHarness(
   );
 }
 
-function applyHarnessModelOverrides<T extends CloudTask>(
+function applyHarnessModelOverrides<T extends TaskSpec>(
   task: T,
   harnessModelOverrides?: HarnessModelOverrides,
 ): T {
@@ -64,9 +64,7 @@ function applyHarnessModelOverrides<T extends CloudTask>(
   };
 }
 
-export function resolveEffectiveHarnessModelState<
-  T extends CloudTask,
->(options: {
+export function resolveEffectiveHarnessModelState<T extends TaskSpec>(options: {
   task: T;
   targetHarness: CodingHarness;
   isSnapshotResume: boolean;

--- a/packages/cloud-agents/src/server/workflows/utils.ts
+++ b/packages/cloud-agents/src/server/workflows/utils.ts
@@ -1,11 +1,11 @@
 import {
-  type CloudTask,
+  type TaskSpec,
   PRODUCT_NAME,
   buildSlackThreadPermalink,
   buildTeamsMessagePermalink,
   buildTelegramMessagePermalink,
   getGitHubAppMention,
-  resolveCloudTaskWorkspace,
+  resolveTaskWorkspace,
 } from '@roomote/types';
 import {
   db,
@@ -704,9 +704,9 @@ function getUniqueRepositoryFullNames(
 }
 
 export async function getWorkspaceRepositoryFullNames(
-  cloudTask: CloudTask,
+  cloudTask: TaskSpec,
 ): Promise<string[] | undefined> {
-  const workspace = resolveCloudTaskWorkspace(cloudTask.payload);
+  const workspace = resolveTaskWorkspace(cloudTask.payload);
 
   if (workspace.type === 'repository') {
     return undefined;

--- a/packages/cloud-agents/src/utils.ts
+++ b/packages/cloud-agents/src/utils.ts
@@ -1,5 +1,5 @@
 import {
-  type CloudTaskPayload,
+  type TaskPayload,
   TaskPayloadKind,
   PRODUCT_NAME,
 } from '@roomote/types';
@@ -247,13 +247,13 @@ export function buildSlackThreadPromptBlocks({
 }
 
 export function generateCloudJobTitle(
-  { type, payload }: { type: TaskPayloadKind; payload: CloudTaskPayload },
+  { type, payload }: { type: TaskPayloadKind; payload: TaskPayload },
   limit: number = 10_000,
   fallbackTitle?: string | null,
 ): string {
   switch (type) {
     case TaskPayloadKind.GithubPrReview: {
-      const prPayload = payload as CloudTaskPayload<
+      const prPayload = payload as TaskPayload<
         typeof TaskPayloadKind.GithubPrReview
       >;
 
@@ -261,7 +261,7 @@ export function generateCloudJobTitle(
     }
 
     case TaskPayloadKind.GithubPrReviewSync: {
-      const prPayload = payload as CloudTaskPayload<
+      const prPayload = payload as TaskPayload<
         typeof TaskPayloadKind.GithubPrReviewSync
       >;
 
@@ -271,7 +271,7 @@ export function generateCloudJobTitle(
     }
 
     case TaskPayloadKind.GithubPrReviewFollowUp: {
-      const commentPayload = payload as CloudTaskPayload<
+      const commentPayload = payload as TaskPayload<
         typeof TaskPayloadKind.GithubPrReviewFollowUp
       >;
 
@@ -279,7 +279,7 @@ export function generateCloudJobTitle(
     }
 
     case TaskPayloadKind.SlackAppMention: {
-      const slackPayload = payload as CloudTaskPayload<
+      const slackPayload = payload as TaskPayload<
         typeof TaskPayloadKind.SlackAppMention
       >;
 
@@ -292,7 +292,7 @@ export function generateCloudJobTitle(
     }
 
     case TaskPayloadKind.LinearAgentSession: {
-      const linearPayload = payload as CloudTaskPayload<
+      const linearPayload = payload as TaskPayload<
         typeof TaskPayloadKind.LinearAgentSession
       >;
 
@@ -303,9 +303,9 @@ export function generateCloudJobTitle(
     case TaskPayloadKind.Scan:
     case TaskPayloadKind.McpRecommendations: {
       const standardPayload = payload as
-        | CloudTaskPayload<typeof TaskPayloadKind.StandardTask>
-        | CloudTaskPayload<typeof TaskPayloadKind.Scan>
-        | CloudTaskPayload<typeof TaskPayloadKind.McpRecommendations>;
+        | TaskPayload<typeof TaskPayloadKind.StandardTask>
+        | TaskPayload<typeof TaskPayloadKind.Scan>
+        | TaskPayload<typeof TaskPayloadKind.McpRecommendations>;
 
       if (!standardPayload.description) {
         return UNTITLED_TASK;
@@ -319,7 +319,7 @@ export function generateCloudJobTitle(
     }
 
     case TaskPayloadKind.GithubPrConflictResolve: {
-      const conflictPayload = payload as CloudTaskPayload<
+      const conflictPayload = payload as TaskPayload<
         typeof TaskPayloadKind.GithubPrConflictResolve
       >;
 

--- a/packages/compute-providers/src/mutation-events.ts
+++ b/packages/compute-providers/src/mutation-events.ts
@@ -1,5 +1,5 @@
 import type {
-  CloudJobEventDetails,
+  RunEventDetails,
   ComputeProviderLaunchMode,
 } from '@roomote/types';
 
@@ -12,8 +12,8 @@ export interface ComputeProviderMutationLifecycleContext {
 
 export function buildComputeProviderMutationDetails(
   context: ComputeProviderMutationLifecycleContext,
-  details: CloudJobEventDetails = {},
-): CloudJobEventDetails {
+  details: RunEventDetails = {},
+): RunEventDetails {
   return {
     ...(context.attempt != null ? { attempt: context.attempt } : {}),
     ...(context.launchMode ? { launchMode: context.launchMode } : {}),

--- a/packages/db/src/fixtures/seed-demo-data.ts
+++ b/packages/db/src/fixtures/seed-demo-data.ts
@@ -1,6 +1,6 @@
 import { and, eq } from 'drizzle-orm';
 
-import { CloudTaskStatus } from '@roomote/types';
+import { RunStatus } from '@roomote/types';
 
 import type { CreateUser } from '../types';
 import {
@@ -47,7 +47,7 @@ export const demoSeedTasks = [
     title: 'Fix login redirect loop on expired sessions',
     mode: 'code',
     state: 'completed',
-    cloudJobStatus: CloudTaskStatus.Completed,
+    cloudJobStatus: RunStatus.Completed,
     repositoryFullName: 'roomote-demo/demo-web',
   },
   {
@@ -55,7 +55,7 @@ export const demoSeedTasks = [
     title: 'Add webhook retries with exponential backoff',
     mode: 'code',
     state: 'completed',
-    cloudJobStatus: CloudTaskStatus.Completed,
+    cloudJobStatus: RunStatus.Completed,
     repositoryFullName: 'roomote-demo/demo-api',
   },
   {
@@ -63,7 +63,7 @@ export const demoSeedTasks = [
     title: 'Explain how session tokens are validated',
     mode: 'ask',
     state: 'active',
-    cloudJobStatus: CloudTaskStatus.Running,
+    cloudJobStatus: RunStatus.Running,
     repositoryFullName: 'roomote-demo/demo-api',
   },
 ] as const;

--- a/packages/db/src/lib/__tests__/cancel-task-run.test.ts
+++ b/packages/db/src/lib/__tests__/cancel-task-run.test.ts
@@ -3,7 +3,7 @@
 // orphaned-run cleanup, so its guards (no sandbox attached, not already
 // terminal) and its task-state re-derivation are load-bearing.
 
-import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
 
 import {
   db,
@@ -25,7 +25,7 @@ async function makeTask() {
 
 async function insertRun(params: {
   taskId: string;
-  status: CloudTaskStatus;
+  status: RunStatus;
   sandboxServerUrl?: string | null;
 }) {
   const [run] = await db
@@ -92,7 +92,7 @@ describe('cancelTaskRunDirect', () => {
     const task = await makeTask();
     const run = await insertRun({
       taskId: task.id,
-      status: CloudTaskStatus.Pending,
+      status: RunStatus.Pending,
     });
 
     const canceled = await cancelTaskRunDirect({
@@ -102,7 +102,7 @@ describe('cancelTaskRunDirect', () => {
 
     expect(canceled).toBe(true);
     const row = await readRun(run.id);
-    expect(row.status).toBe(CloudTaskStatus.Canceled);
+    expect(row.status).toBe(RunStatus.Canceled);
     expect(row.canceledAt).toBeInstanceOf(Date);
     expect(row.error).toBe(
       'Canceled: work-item launch finalize lost the claim fencing guard',
@@ -116,14 +116,14 @@ describe('cancelTaskRunDirect', () => {
     const task = await makeTask();
     const run = await insertRun({
       taskId: task.id,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       sandboxServerUrl: 'http://sandbox.test',
     });
 
     const canceled = await cancelTaskRunDirect({ runId: run.id });
 
     expect(canceled).toBe(false);
-    expect((await readRun(run.id)).status).toBe(CloudTaskStatus.Running);
+    expect((await readRun(run.id)).status).toBe(RunStatus.Running);
     expect(await readTaskState(task.id)).toBe('active');
   });
 
@@ -131,12 +131,12 @@ describe('cancelTaskRunDirect', () => {
     const task = await makeTask();
     const run = await insertRun({
       taskId: task.id,
-      status: CloudTaskStatus.Completed,
+      status: RunStatus.Completed,
     });
 
     const canceled = await cancelTaskRunDirect({ runId: run.id });
 
     expect(canceled).toBe(false);
-    expect((await readRun(run.id)).status).toBe(CloudTaskStatus.Completed);
+    expect((await readRun(run.id)).status).toBe(RunStatus.Completed);
   });
 });

--- a/packages/db/src/lib/__tests__/github-branch-activity.test.ts
+++ b/packages/db/src/lib/__tests__/github-branch-activity.test.ts
@@ -6,7 +6,7 @@ import {
   userFactory,
 } from '../../server';
 import {
-  CloudTaskStatus,
+  RunStatus,
   TaskPayloadKind,
   type SourceControlProvider,
 } from '@roomote/types';
@@ -61,7 +61,7 @@ async function createPrLinkedTaskJob({
   prNumber,
   userId,
   payloadKind,
-  status = CloudTaskStatus.Pending,
+  status = RunStatus.Pending,
   taskPhase,
   prSha,
   sourceControlProvider,
@@ -70,7 +70,7 @@ async function createPrLinkedTaskJob({
   prNumber: number;
   userId: string;
   payloadKind: TaskPayloadKind;
-  status?: CloudTaskStatus;
+  status?: RunStatus;
   taskPhase?: string;
   prSha?: string;
   sourceControlProvider?: SourceControlProvider;
@@ -118,7 +118,7 @@ async function createSlackPrLinkedTaskJob({
     actingUserId: userId,
     taskId,
     payloadKind: TaskPayloadKind.SlackAppMention,
-    status: CloudTaskStatus.Pending,
+    status: RunStatus.Pending,
     payload: {
       repo: repoFullName,
       channel: 'C123',
@@ -148,7 +148,7 @@ async function createLinearPrLinkedTaskJob({
     actingUserId: userId,
     taskId,
     payloadKind: TaskPayloadKind.LinearAgentSession,
-    status: CloudTaskStatus.Pending,
+    status: RunStatus.Pending,
     payload: {
       repo: repoFullName,
       sessionId: 'linear-session-1',
@@ -178,7 +178,7 @@ async function createSnapshotResumeJob({
     taskId,
     payloadKind: TaskPayloadKind.SnapshotResume,
     kind: 'resume',
-    status: CloudTaskStatus.Running,
+    status: RunStatus.Running,
     taskPhase: 'running',
     sourceRunId,
     payload: {
@@ -214,7 +214,7 @@ describe('findActiveGitHubBranchWork', () => {
       prNumber,
       userId: user.id,
       payloadKind: TaskPayloadKind.GithubPrReview,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
     });
 
@@ -228,7 +228,7 @@ describe('findActiveGitHubBranchWork', () => {
       jobId: job.id,
       taskId: job.taskId,
       type: TaskPayloadKind.GithubPrReview,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       match: 'task_pull_request',
     });
@@ -251,7 +251,7 @@ describe('findActiveGitHubBranchWork', () => {
       prNumber,
       userId: user.id,
       payloadKind: TaskPayloadKind.GithubPrReviewSync,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       prSha: 'def5678',
     });
@@ -266,7 +266,7 @@ describe('findActiveGitHubBranchWork', () => {
       jobId: newestJob.id,
       taskId: newestJob.taskId,
       type: TaskPayloadKind.GithubPrReviewSync,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       match: 'task_pull_request',
     });
@@ -281,7 +281,7 @@ describe('findActiveGitHubBranchWork', () => {
     const job = await runFactory.create({
       actingUserId: user.id,
       payloadKind: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       payload: {
         repo: repoFullName,
@@ -300,7 +300,7 @@ describe('findActiveGitHubBranchWork', () => {
       jobId: job.id,
       taskId: job.taskId,
       type: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       match: 'branch',
     });
@@ -315,7 +315,7 @@ describe('findActiveGitHubBranchWork', () => {
     await runFactory.create({
       actingUserId: user.id,
       payloadKind: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'waiting_for_prompt',
       payload: {
         repo: repoFullName,
@@ -327,7 +327,7 @@ describe('findActiveGitHubBranchWork', () => {
     await runFactory.create({
       actingUserId: user.id,
       payloadKind: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Completed,
+      status: RunStatus.Completed,
       payload: {
         repo: repoFullName,
         branch: branchName,
@@ -363,7 +363,7 @@ describe('findReusableGitHubPrFollowUpOwner', () => {
       prNumber,
       userId: user.id,
       payloadKind: TaskPayloadKind.GithubPrReviewSync,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       prSha: 'def5678',
     });
@@ -378,7 +378,7 @@ describe('findReusableGitHubPrFollowUpOwner', () => {
       jobId: reusableJob.id,
       taskId: reusableJob.taskId,
       type: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Pending,
+      status: RunStatus.Pending,
       taskPhase: null,
       match: 'task_pull_request',
       delivery: 'attach',
@@ -406,7 +406,7 @@ describe('findReusableGitHubPrFollowUpOwner', () => {
       jobId: slackJob.id,
       taskId: slackJob.taskId,
       type: TaskPayloadKind.SlackAppMention,
-      status: CloudTaskStatus.Pending,
+      status: RunStatus.Pending,
       taskPhase: null,
       match: 'task_pull_request',
       delivery: 'attach',
@@ -434,7 +434,7 @@ describe('findReusableGitHubPrFollowUpOwner', () => {
       jobId: linearJob.id,
       taskId: linearJob.taskId,
       type: TaskPayloadKind.LinearAgentSession,
-      status: CloudTaskStatus.Pending,
+      status: RunStatus.Pending,
       taskPhase: null,
       match: 'task_pull_request',
       delivery: 'attach',
@@ -463,7 +463,7 @@ describe('findReusableGitHubPrFollowUpOwner', () => {
       actingUserId: user.id,
       taskId: followUpTaskId,
       payloadKind: TaskPayloadKind.GithubPrReviewFollowUp,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       payload: {
         repo: repoFullName,
@@ -483,7 +483,7 @@ describe('findReusableGitHubPrFollowUpOwner', () => {
       jobId: reusableJob.id,
       taskId: reusableJob.taskId,
       type: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Pending,
+      status: RunStatus.Pending,
       taskPhase: null,
       match: 'task_pull_request',
       delivery: 'attach',
@@ -504,7 +504,7 @@ describe('findReusableGitHubPrFollowUpOwner', () => {
       actingUserId: user.id,
       taskId,
       payloadKind: TaskPayloadKind.SlackAppMention,
-      status: CloudTaskStatus.Completed,
+      status: RunStatus.Completed,
       payload: {
         repo: repoFullName,
         channel: 'C123',
@@ -538,7 +538,7 @@ describe('findReusableGitHubPrFollowUpOwner', () => {
       jobId: activeResume.id,
       taskId: activeResume.taskId,
       type: TaskPayloadKind.SnapshotResume,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       match: 'task_pull_request',
       delivery: 'attach',
@@ -559,7 +559,7 @@ describe('findReusableGitHubPrFollowUpOwner', () => {
       actingUserId: user.id,
       taskId,
       payloadKind: TaskPayloadKind.LinearAgentSession,
-      status: CloudTaskStatus.Completed,
+      status: RunStatus.Completed,
       payload: {
         repo: repoFullName,
         sessionId: 'linear-session-1',
@@ -589,7 +589,7 @@ describe('findReusableGitHubPrFollowUpOwner', () => {
       jobId: activeResume.id,
       taskId: activeResume.taskId,
       type: TaskPayloadKind.SnapshotResume,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       match: 'task_pull_request',
       delivery: 'attach',
@@ -610,7 +610,7 @@ describe('findReusableGitHubPrFollowUpOwner', () => {
       actingUserId: user.id,
       taskId,
       payloadKind: TaskPayloadKind.GithubPrReviewFollowUp,
-      status: CloudTaskStatus.Completed,
+      status: RunStatus.Completed,
       payload: {
         repo: repoFullName,
         prNumber,
@@ -658,7 +658,7 @@ describe('findReusableGitHubPrFollowUpOwner', () => {
         actingUserId: user.id,
         taskId,
         payloadKind: TaskPayloadKind.GithubPrReviewSync,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
         payload: {
           repo: repoFullName,
           prNumber,
@@ -686,7 +686,7 @@ describe('findReusableGitHubPrFollowUpOwner', () => {
       jobId: reusableJob.id,
       taskId: reusableJob.taskId,
       type: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Pending,
+      status: RunStatus.Pending,
       taskPhase: null,
       match: 'task_pull_request',
       delivery: 'attach',
@@ -708,7 +708,7 @@ describe('findReusableGitHubPrFollowUpOwner', () => {
       actingUserId: user.id,
       taskId,
       payloadKind: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Completed,
+      status: RunStatus.Completed,
       snapshotId: 'snapshot-547',
       payload: {
         repo: repoFullName,
@@ -726,7 +726,7 @@ describe('findReusableGitHubPrFollowUpOwner', () => {
       jobId: completedJob.id,
       taskId: completedJob.taskId,
       type: TaskPayloadKind.StandardTask,
-      status: CloudTaskStatus.Completed,
+      status: RunStatus.Completed,
       taskPhase: null,
       match: 'task_pull_request',
       delivery: 'resume',
@@ -745,7 +745,7 @@ describe('findActiveGitHubPrReviewTask', () => {
       prNumber,
       userId: user.id,
       payloadKind: TaskPayloadKind.GithubPrReview,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       prSha: 'def5678',
     });
@@ -755,7 +755,7 @@ describe('findActiveGitHubPrReviewTask', () => {
       prNumber,
       userId: user.id,
       payloadKind: TaskPayloadKind.GithubPrReviewSync,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       prSha: 'def5678',
     });
@@ -770,7 +770,7 @@ describe('findActiveGitHubPrReviewTask', () => {
       jobId: newestReview.id,
       taskId: newestReview.taskId,
       type: TaskPayloadKind.GithubPrReviewSync,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       match: 'task_pull_request',
     });
@@ -786,7 +786,7 @@ describe('findActiveGitHubPrReviewTask', () => {
       prNumber,
       userId: user.id,
       payloadKind: TaskPayloadKind.GithubPrReview,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'waiting_for_prompt',
       prSha: 'abc1234',
     });
@@ -810,7 +810,7 @@ describe('findActiveGitHubPrReviewTask', () => {
       prNumber,
       userId: user.id,
       payloadKind: TaskPayloadKind.GithubPrReview,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       prSha: 'old-head-sha',
     });
@@ -834,7 +834,7 @@ describe('findActiveGitHubPrReviewTask', () => {
       prNumber,
       userId: user.id,
       payloadKind: TaskPayloadKind.GithubPrReviewSync,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       prSha: 'shared-head-sha',
       sourceControlProvider: 'gitlab',
@@ -851,7 +851,7 @@ describe('findActiveGitHubPrReviewTask', () => {
       jobId: gitlabReview.id,
       taskId: gitlabReview.taskId,
       type: TaskPayloadKind.GithubPrReviewSync,
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       match: 'task_pull_request',
     });

--- a/packages/db/src/lib/__tests__/sync-task-state.test.ts
+++ b/packages/db/src/lib/__tests__/sync-task-state.test.ts
@@ -1,5 +1,5 @@
 import {
-  CloudTaskStatus,
+  RunStatus,
   TaskPayloadKind,
   type RunKind,
   type TaskState,
@@ -26,7 +26,7 @@ async function makeTask(state: TaskState = 'active') {
 
 async function insertRun(params: {
   taskId: string;
-  status: CloudTaskStatus;
+  status: RunStatus;
   startedAt?: Date | null;
   kind?: RunKind;
 }) {
@@ -84,7 +84,7 @@ describe('deriveTaskStateFromRuns', () => {
   it('returns active when any run is non-terminal', () => {
     expect(
       deriveTaskStateFromRuns([
-        { id: 1, status: CloudTaskStatus.Running, startedAt: new Date() },
+        { id: 1, status: RunStatus.Running, startedAt: new Date() },
       ]),
     ).toBe('active');
   });
@@ -92,8 +92,8 @@ describe('deriveTaskStateFromRuns', () => {
   it('treats idle as non-terminal so an idle sibling keeps the task active', () => {
     expect(
       deriveTaskStateFromRuns([
-        { id: 1, status: CloudTaskStatus.Completed, startedAt: new Date() },
-        { id: 2, status: CloudTaskStatus.Idle, startedAt: new Date() },
+        { id: 1, status: RunStatus.Completed, startedAt: new Date() },
+        { id: 2, status: RunStatus.Idle, startedAt: new Date() },
       ]),
     ).toBe('active');
   });
@@ -101,9 +101,9 @@ describe('deriveTaskStateFromRuns', () => {
   it('lets an earlier completed run beat a never-started canceled resume', () => {
     expect(
       deriveTaskStateFromRuns([
-        { id: 1, status: CloudTaskStatus.Completed, startedAt: new Date() },
+        { id: 1, status: RunStatus.Completed, startedAt: new Date() },
         // Higher id but never started (bootstrap-failed resume) -> deprioritized.
-        { id: 2, status: CloudTaskStatus.Canceled, startedAt: null },
+        { id: 2, status: RunStatus.Canceled, startedAt: null },
       ]),
     ).toBe('completed');
   });
@@ -111,7 +111,7 @@ describe('deriveTaskStateFromRuns', () => {
   it('maps an only-run cancel-before-start to canceled', () => {
     expect(
       deriveTaskStateFromRuns([
-        { id: 1, status: CloudTaskStatus.Canceled, startedAt: null },
+        { id: 1, status: RunStatus.Canceled, startedAt: null },
       ]),
     ).toBe('canceled');
   });
@@ -119,7 +119,7 @@ describe('deriveTaskStateFromRuns', () => {
   it('maps an only failed run to failed', () => {
     expect(
       deriveTaskStateFromRuns([
-        { id: 1, status: CloudTaskStatus.Failed, startedAt: new Date() },
+        { id: 1, status: RunStatus.Failed, startedAt: new Date() },
       ]),
     ).toBe('failed');
   });
@@ -127,8 +127,8 @@ describe('deriveTaskStateFromRuns', () => {
   it('prefers the latest progressed terminal run among siblings', () => {
     expect(
       deriveTaskStateFromRuns([
-        { id: 1, status: CloudTaskStatus.Completed, startedAt: new Date() },
-        { id: 2, status: CloudTaskStatus.Failed, startedAt: new Date() },
+        { id: 1, status: RunStatus.Completed, startedAt: new Date() },
+        { id: 2, status: RunStatus.Failed, startedAt: new Date() },
       ]),
     ).toBe('failed');
   });
@@ -139,12 +139,12 @@ describe('syncTaskStateFromRuns', () => {
     const task = await makeTask('completed');
     await insertRun({
       taskId: task.id,
-      status: CloudTaskStatus.Completed,
+      status: RunStatus.Completed,
       startedAt: new Date(),
     });
     await insertRun({
       taskId: task.id,
-      status: CloudTaskStatus.Idle,
+      status: RunStatus.Idle,
       startedAt: new Date(),
     });
 
@@ -157,13 +157,13 @@ describe('syncTaskStateFromRuns', () => {
     const task = await makeTask('completed');
     await insertRun({
       taskId: task.id,
-      status: CloudTaskStatus.Completed,
+      status: RunStatus.Completed,
       startedAt: new Date(),
     });
     // The resume never started (canceled at/before dequeue on bootstrap fail).
     await insertRun({
       taskId: task.id,
-      status: CloudTaskStatus.Canceled,
+      status: RunStatus.Canceled,
       startedAt: null,
       kind: 'resume',
     });
@@ -177,7 +177,7 @@ describe('syncTaskStateFromRuns', () => {
     const task = await makeTask('active');
     await insertRun({
       taskId: task.id,
-      status: CloudTaskStatus.Canceled,
+      status: RunStatus.Canceled,
       startedAt: null,
     });
 
@@ -188,7 +188,7 @@ describe('syncTaskStateFromRuns', () => {
 
   it('does not write when the derived state is unchanged', async () => {
     const task = await makeTask('active');
-    await insertRun({ taskId: task.id, status: CloudTaskStatus.Pending });
+    await insertRun({ taskId: task.id, status: RunStatus.Pending });
 
     const before = await readTask(task.id);
     await syncTaskStateFromRuns(db, task.id);

--- a/packages/db/src/lib/cancel-task-run.ts
+++ b/packages/db/src/lib/cancel-task-run.ts
@@ -1,5 +1,5 @@
 import { and, eq, inArray, isNull, not } from 'drizzle-orm';
-import { CloudTaskStatus, exitedCloudTaskStatuses } from '@roomote/types';
+import { RunStatus, exitedRunStatuses } from '@roomote/types';
 
 import { db } from '../db';
 import { taskRuns } from '../schema';
@@ -32,7 +32,7 @@ export async function cancelTaskRunDirect(params: {
     const [run] = await tx
       .update(taskRuns)
       .set({
-        status: CloudTaskStatus.Canceled,
+        status: RunStatus.Canceled,
         // Stamp the stop intent alongside the terminal write so a later
         // Failed finalization (e.g. the sandbox dying mid-cancel) reports as
         // canceled, not as a runtime failure.
@@ -47,7 +47,7 @@ export async function cancelTaskRunDirect(params: {
           not(
             inArray(
               taskRuns.status,
-              exitedCloudTaskStatuses as unknown as CloudTaskStatus[],
+              exitedRunStatuses as unknown as RunStatus[],
             ),
           ),
         ),

--- a/packages/db/src/lib/cloud-job-events.ts
+++ b/packages/db/src/lib/cloud-job-events.ts
@@ -1,9 +1,9 @@
 import { asc, desc, eq } from 'drizzle-orm';
 
 import type {
-  CloudJobEventDetails,
-  CloudJobEventSource,
-  CloudJobEventType,
+  RunEventDetails,
+  RunEventSource,
+  RunEventType,
   ComputeProviderMutationEvent,
   ComputeProviderMutationObserver,
 } from '@roomote/types';
@@ -14,10 +14,10 @@ import { taskRunEvents, taskRuns } from '../schema';
 interface RecordCloudJobEventInput {
   runId: number;
   taskId?: string;
-  source: CloudJobEventSource;
-  eventType: CloudJobEventType;
+  source: RunEventSource;
+  eventType: RunEventType;
   message?: string;
-  details?: CloudJobEventDetails;
+  details?: RunEventDetails;
   createdAt?: Date;
 }
 
@@ -30,7 +30,7 @@ interface ListCloudJobEventsOptions {
 interface RecordComputeProviderMutationEventInput extends ComputeProviderMutationEvent {
   runId: number;
   taskId?: string;
-  details?: CloudJobEventDetails;
+  details?: RunEventDetails;
   createdAt?: Date;
 }
 
@@ -80,9 +80,9 @@ export async function recordSnapshotResumeEvent(
   input: {
     runId: number;
     taskId?: string;
-    eventType: CloudJobEventType;
+    eventType: RunEventType;
     message: string;
-    details?: CloudJobEventDetails;
+    details?: RunEventDetails;
   },
 ) {
   return recordCloudJobEvent(database, {
@@ -100,9 +100,9 @@ export async function recordJobLifecycleEvent(
   input: {
     runId: number;
     taskId?: string;
-    eventType: CloudJobEventType;
+    eventType: RunEventType;
     message: string;
-    details?: CloudJobEventDetails;
+    details?: RunEventDetails;
     createdAt?: Date;
   },
 ) {

--- a/packages/db/src/lib/environment-snapshots.ts
+++ b/packages/db/src/lib/environment-snapshots.ts
@@ -6,7 +6,7 @@ import { and, eq, inArray, isNull, lte, sql } from 'drizzle-orm';
 
 import { db, type DatabaseOrTransaction } from '../db';
 import { environmentSnapshots, environments } from '../schema';
-import type { CloudJob } from '../types';
+import type { Run } from '../types';
 import { runInTransactionIfAvailable } from './transaction-utils';
 
 export type EnvironmentSnapshotStatus =
@@ -83,7 +83,7 @@ function getPendingSnapshotAttachmentSource(
 }
 
 export function getEnvironmentSnapshotAttachmentSourceForCloudJob(
-  cloudJob: Pick<CloudJob, 'payload'>,
+  cloudJob: Pick<Run, 'payload'>,
 ): EnvironmentSnapshotAttachmentSource | null {
   return 'environmentSnapshotAttachment' in cloudJob.payload
     ? (cloudJob.payload.environmentSnapshotAttachment ?? null)
@@ -91,7 +91,7 @@ export function getEnvironmentSnapshotAttachmentSourceForCloudJob(
 }
 
 export function buildPendingEnvironmentSnapshotMatchForCloudJob(
-  cloudJob: Pick<CloudJob, 'payload' | 'createdAt'>,
+  cloudJob: Pick<Run, 'payload' | 'createdAt'>,
 ): PendingEnvironmentSnapshotMatch {
   const attachmentSource =
     getEnvironmentSnapshotAttachmentSourceForCloudJob(cloudJob);

--- a/packages/db/src/lib/github-branch-activity.ts
+++ b/packages/db/src/lib/github-branch-activity.ts
@@ -1,13 +1,13 @@
 import { and, desc, eq, inArray, isNull, ne, sql } from 'drizzle-orm';
 
 import {
-  type CloudTaskPayload,
-  bootingCloudTaskStatuses,
-  CloudTaskStatus,
+  type TaskPayload,
+  bootingRunStatuses,
+  RunStatus,
   TaskPayloadKind,
-  isActivelyRunningCloudTask,
-  isExitedCloudTaskStatus,
-  isResumableCloudTaskType,
+  isActivelyRunningTask,
+  isExitedRunStatus,
+  isResumableTaskPayloadKind,
   type SourceControlProvider,
 } from '@roomote/types';
 
@@ -20,7 +20,7 @@ export interface ActiveGitHubBranchWork {
   jobId: number;
   taskId: string;
   type: TaskPayloadKind;
-  status: CloudTaskStatus;
+  status: RunStatus;
   taskPhase: string | null;
   match: 'task_pull_request' | 'branch';
 }
@@ -30,8 +30,8 @@ export interface ReusableGitHubPrFollowUpOwner extends ActiveGitHubBranchWork {
 }
 
 const ACTIVE_WORK_STATUSES = [
-  ...bootingCloudTaskStatuses,
-  CloudTaskStatus.Running,
+  ...bootingRunStatuses,
+  RunStatus.Running,
 ] as const;
 
 const ACTIVE_WORK_COLUMNS = {
@@ -66,9 +66,9 @@ type ActiveFollowUpOwnerCandidate = {
   id: number;
   taskId: string;
   type: TaskPayloadKind;
-  status: CloudTaskStatus;
+  status: RunStatus;
   taskPhase: string | null;
-  payload: CloudTaskPayload;
+  payload: TaskPayload;
   snapshotId: string | null;
   sourceRunId: number | null;
 };
@@ -76,7 +76,7 @@ type ActiveFollowUpOwnerCandidate = {
 type RunReuseMetadata = {
   id: number;
   type: TaskPayloadKind;
-  payload: CloudTaskPayload;
+  payload: TaskPayload;
   snapshotId: string | null;
   sourceRunId: number | null;
 };
@@ -86,13 +86,13 @@ function pickActiveWork(
     jobId: number;
     taskId: string;
     type: TaskPayloadKind;
-    status: CloudTaskStatus;
+    status: RunStatus;
     taskPhase: string | null;
   }>,
   match: ActiveGitHubBranchWork['match'],
 ): ActiveGitHubBranchWork | null {
   const activeRow = rows.find((row) =>
-    isActivelyRunningCloudTask(row.status, row.taskPhase),
+    isActivelyRunningTask(row.status, row.taskPhase),
   );
 
   if (!activeRow) {
@@ -411,7 +411,7 @@ async function pickReusableFollowUpOwner(
       continue;
     }
 
-    if (!isExitedCloudTaskStatus(latestJob.status)) {
+    if (!isExitedRunStatus(latestJob.status)) {
       return {
         jobId: latestJob.id,
         taskId: latestJob.taskId,
@@ -425,8 +425,8 @@ async function pickReusableFollowUpOwner(
 
     if (
       latestJob.snapshotId &&
-      isResumableCloudTaskType(latestJob.type) &&
-      !isActivelyRunningCloudTask(latestJob.status, latestJob.taskPhase)
+      isResumableTaskPayloadKind(latestJob.type) &&
+      !isActivelyRunningTask(latestJob.status, latestJob.taskPhase)
     ) {
       return {
         jobId: latestJob.id,

--- a/packages/db/src/lib/instance-report.ts
+++ b/packages/db/src/lib/instance-report.ts
@@ -9,7 +9,7 @@ import {
   sum,
 } from 'drizzle-orm';
 
-import { CloudTaskStatus, getMcpIntegration } from '@roomote/types';
+import { RunStatus, getMcpIntegration } from '@roomote/types';
 
 import { db } from '../db';
 import {
@@ -159,7 +159,7 @@ export async function collectInstanceReportStats(
       .from(taskRuns)
       .where(
         and(
-          eq(taskRuns.status, CloudTaskStatus.Completed),
+          eq(taskRuns.status, RunStatus.Completed),
           gte(taskRuns.completedAt, since),
         ),
       ),

--- a/packages/db/src/lib/source-control-provider.ts
+++ b/packages/db/src/lib/source-control-provider.ts
@@ -1,5 +1,5 @@
 import { and, eq, inArray } from 'drizzle-orm';
-import type { CloudTaskWorkspace, SourceControlProvider } from '@roomote/types';
+import type { TaskWorkspace, SourceControlProvider } from '@roomote/types';
 
 import type { DatabaseOrTransaction } from '../db';
 import { environmentRepositoryMappings, repositories } from '../schema';
@@ -78,7 +78,7 @@ async function resolveAllRepositoriesProvider(
  */
 export async function resolveWorkspaceSourceControlProvider(
   dbOrTx: DatabaseOrTransaction,
-  workspace: CloudTaskWorkspace,
+  workspace: TaskWorkspace,
 ): Promise<SourceControlProvider | undefined> {
   switch (workspace.type) {
     case 'repository':

--- a/packages/db/src/lib/sync-task-state.ts
+++ b/packages/db/src/lib/sync-task-state.ts
@@ -1,5 +1,5 @@
 import { and, eq, ne } from 'drizzle-orm';
-import { CloudTaskStatus, type TaskState } from '@roomote/types';
+import { RunStatus, type TaskState } from '@roomote/types';
 
 import { type DatabaseOrTransaction } from '../db';
 import { taskRuns, tasks } from '../schema';
@@ -9,15 +9,15 @@ import { taskRuns, tasks } from '../schema';
  * could still become) alive. Idle counts as non-terminal because the machine
  * stays up waiting for interaction.
  */
-const NON_TERMINAL_RUN_STATUSES = new Set<CloudTaskStatus>([
-  CloudTaskStatus.Pending,
-  CloudTaskStatus.Dequeued,
-  CloudTaskStatus.Processing,
-  CloudTaskStatus.Preparing,
-  CloudTaskStatus.Spawning,
-  CloudTaskStatus.Connecting,
-  CloudTaskStatus.Running,
-  CloudTaskStatus.Idle,
+const NON_TERMINAL_RUN_STATUSES = new Set<RunStatus>([
+  RunStatus.Pending,
+  RunStatus.Dequeued,
+  RunStatus.Processing,
+  RunStatus.Preparing,
+  RunStatus.Spawning,
+  RunStatus.Connecting,
+  RunStatus.Running,
+  RunStatus.Idle,
 ]);
 
 /**
@@ -27,15 +27,15 @@ const NON_TERMINAL_RUN_STATUSES = new Set<CloudTaskStatus>([
  */
 export type TaskStateRunInput = {
   id: number;
-  status: CloudTaskStatus;
+  status: RunStatus;
   startedAt: Date | null;
 };
 
-function terminalRunStatusToTaskState(status: CloudTaskStatus): TaskState {
+function terminalRunStatusToTaskState(status: RunStatus): TaskState {
   switch (status) {
-    case CloudTaskStatus.Failed:
+    case RunStatus.Failed:
       return 'failed';
-    case CloudTaskStatus.Canceled:
+    case RunStatus.Canceled:
       return 'canceled';
     default:
       // Only terminal statuses (completed/failed/canceled) reach here; the
@@ -69,7 +69,7 @@ export function deriveTaskStateFromRuns(
   }
 
   const madeProgress = (run: TaskStateRunInput): boolean =>
-    run.startedAt !== null || run.status === CloudTaskStatus.Completed;
+    run.startedAt !== null || run.status === RunStatus.Completed;
 
   const progressRuns = runs.filter(madeProgress);
   const candidates = progressRuns.length > 0 ? progressRuns : runs;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -505,7 +505,7 @@ export const tasks = pgTable(
       .notNull()
       .default('visible')
       .$type<TaskVisibility>(),
-    // Terminal task state. Only written by the finishCloudJob terminal path;
+    // Terminal task state. Only written by the finishRun terminal path;
     // live runtime phase stays on runs.
     state: text('state').notNull().default('active').$type<TaskState>(),
 
@@ -1014,7 +1014,7 @@ export const taskRuns = pgTable(
     /**
      * When a user-initiated stop was requested for this job. Stop paths set
      * this before asking the sandbox to cancel so recovery sweeps and
-     * finishCloudJob can tell a deliberate stop from a runtime failure even
+     * finishRun can tell a deliberate stop from a runtime failure even
      * if the worker dies before the row reaches a terminal state.
      */
     cancelRequestedAt: timestamp('cancel_requested_at'),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -26,8 +26,8 @@ import type {
   TaskInitiatorKind,
   CommitAuthorKind,
   RunKind,
-  CloudTaskStatus,
-  CloudTaskPayload,
+  RunStatus,
+  TaskPayload,
   RequestedWorkKind,
   RequestedWorkKindSource,
   ComputeProvider,
@@ -36,9 +36,9 @@ import type {
   DeploymentComputeConfig,
   DeploymentModelConfig,
   CodingHarness,
-  CloudJobEventDetails,
-  CloudJobEventSource,
-  CloudJobEventType,
+  RunEventDetails,
+  RunEventSource,
+  RunEventType,
   EnvironmentConfig,
   TaskMessageEventType,
   TaskMessageRole,
@@ -907,12 +907,9 @@ export const taskRuns = pgTable(
       .default('opencode-server')
       .$type<CodingHarness>(),
 
-    status: text('status')
-      .notNull()
-      .default('pending')
-      .$type<CloudTaskStatus>(),
+    status: text('status').notNull().default('pending').$type<RunStatus>(),
     taskPhase: text('task_phase'),
-    payload: jsonb('payload').notNull().$type<CloudTaskPayload>(),
+    payload: jsonb('payload').notNull().$type<TaskPayload>(),
     // Per-attempt prompt, including the deferred resume prompt.
     prompt: text('prompt'),
     log: text('log'),
@@ -1063,13 +1060,10 @@ export const taskRunEvents = pgTable(
     taskId: text('task_id')
       .notNull()
       .references(() => tasks.id, { onDelete: 'cascade' }),
-    source: text('source').notNull().$type<CloudJobEventSource>(),
-    eventType: text('event_type').notNull().$type<CloudJobEventType>(),
+    source: text('source').notNull().$type<RunEventSource>(),
+    eventType: text('event_type').notNull().$type<RunEventType>(),
     message: text('message'),
-    details: jsonb('details')
-      .notNull()
-      .default({})
-      .$type<CloudJobEventDetails>(),
+    details: jsonb('details').notNull().default({}).$type<RunEventDetails>(),
     createdAt: timestamp('created_at').notNull().defaultNow(),
   },
   (table) => [

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -114,14 +114,6 @@ export type CreateRun = Omit<typeof taskRuns.$inferInsert, Generated>;
 
 export type UpdateRun = Partial<Omit<Run, 'id' | 'createdAt'>>;
 
-// TODO(stage5-rename): temporary type-only aliases to bound downstream churn
-// until the Stage 5 CloudJob -> Run vocabulary pass. Do not alias tables.
-export type CloudJob = Run;
-
-export type CreateCloudJob = CreateRun;
-
-export type UpdateCloudJob = UpdateRun;
-
 /**
  * taskRunEvents
  */
@@ -129,11 +121,6 @@ export type UpdateCloudJob = UpdateRun;
 export type RunEvent = typeof taskRunEvents.$inferSelect;
 
 export type CreateRunEvent = Omit<typeof taskRunEvents.$inferInsert, Generated>;
-
-// TODO(stage5-rename): temporary type-only aliases, see above.
-export type CloudJobEvent = RunEvent;
-
-export type CreateCloudJobEvent = CreateRunEvent;
 
 /**
  * task_start_parallel_counts

--- a/packages/gitea/src/__tests__/api.test.ts
+++ b/packages/gitea/src/__tests__/api.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
 import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
-import type { CloudJob } from '@roomote/db/server';
+import type { Run } from '@roomote/db/server';
 
 const {
   mockEnvironmentVariablesFindMany,
@@ -73,7 +73,7 @@ import {
   type GiteaRepository,
 } from '../api';
 
-function makeCloudJob(payload: CloudJob['payload']): CloudJob {
+function makeCloudJob(payload: Run['payload']): Run {
   return {
     id: 123,
     status: CloudTaskStatus.Dequeued,
@@ -84,7 +84,7 @@ function makeCloudJob(payload: CloudJob['payload']): CloudJob {
     payload,
     result: null,
     artifacts: null,
-  } as CloudJob;
+  } as Run;
 }
 
 describe('Gitea API helpers', () => {

--- a/packages/gitea/src/__tests__/api.test.ts
+++ b/packages/gitea/src/__tests__/api.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
-import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
 import type { Run } from '@roomote/db/server';
 
 const {
@@ -76,7 +76,7 @@ import {
 function makeCloudJob(payload: Run['payload']): Run {
   return {
     id: 123,
-    status: CloudTaskStatus.Dequeued,
+    status: RunStatus.Dequeued,
     kind: 'fresh' as const,
     payloadKind: TaskPayloadKind.StandardTask,
     taskId: 'task-123',

--- a/packages/gitea/src/api.ts
+++ b/packages/gitea/src/api.ts
@@ -6,7 +6,7 @@ import {
   type SourceControlProvider,
 } from '@roomote/types';
 import {
-  type CloudJob,
+  type Run,
   db,
   environments,
   repositories,
@@ -470,7 +470,7 @@ function normalizeRepositorySelection(repositoryNames: string[]): string[] {
 }
 
 async function resolveGiteaRepositoryNamesForCloudJob(
-  cloudJob: CloudJob,
+  cloudJob: Run,
 ): Promise<string[] | null> {
   if (cloudJob.payload.environmentId) {
     const environment = await db.query.environments.findFirst({
@@ -507,7 +507,7 @@ async function resolveGiteaRepositoryNamesForCloudJob(
   return null;
 }
 
-async function resolveGiteaRepositoryRowsForCloudJob(cloudJob: CloudJob) {
+async function resolveGiteaRepositoryRowsForCloudJob(cloudJob: Run) {
   const repositoryNames =
     await resolveGiteaRepositoryNamesForCloudJob(cloudJob);
   const queryConditions = [
@@ -1036,7 +1036,7 @@ export async function removeGiteaWebhooksForRepositories({
 }
 
 export async function createCloudJobGiteaCredentials(
-  cloudJob: CloudJob,
+  cloudJob: Run,
   options?: {
     fetchImpl?: typeof fetch;
     token?: string;

--- a/packages/github/src/__tests__/cloud-job-token.test.ts
+++ b/packages/github/src/__tests__/cloud-job-token.test.ts
@@ -45,15 +45,15 @@ vi.mock('@roomote/db/server', () => ({
   },
 }));
 
-import type { CloudJob } from '@roomote/db/server';
+import type { Run } from '@roomote/db/server';
 
 import { createCloudJobGitHubToken } from '../api';
 
-function buildCloudJob(payload: CloudJob['payload']): CloudJob {
+function buildCloudJob(payload: Run['payload']): Run {
   return {
     id: 123,
     payload,
-  } as CloudJob;
+  } as Run;
 }
 
 function buildEnvironmentConfig(repositories: string[]) {
@@ -111,7 +111,7 @@ describe('createCloudJobGitHubToken', () => {
             'LogSharpDoo/ViradaBMS-BE',
             'LogSharpDoo/ViradaBMS-React',
           ],
-        } as CloudJob['payload']),
+        } as Run['payload']),
       ),
     ).resolves.toBe('ghs_test_token');
 
@@ -141,7 +141,7 @@ describe('createCloudJobGitHubToken', () => {
         buildCloudJob({
           repo: '__all_repositories__',
           environmentId: '14f1f7c4-b126-4b3f-a6a8-e37f7d299f4d',
-        } as CloudJob['payload']),
+        } as Run['payload']),
       ),
     ).resolves.toBe('ghs_test_token');
 
@@ -174,7 +174,7 @@ describe('createCloudJobGitHubToken', () => {
         buildCloudJob({
           repo: '__all_repositories__',
           environmentId: '14f1f7c4-b126-4b3f-a6a8-e37f7d299f4d',
-        } as CloudJob['payload']),
+        } as Run['payload']),
       ),
     ).rejects.toThrow(
       'Environment repositories for cloud job 123 span multiple GitHub installations',
@@ -200,7 +200,7 @@ describe('createCloudJobGitHubToken', () => {
         buildCloudJob({
           repo: '__all_repositories__',
           selectedRepositories: ['owner-a/api', 'owner-b/web'],
-        } as CloudJob['payload']),
+        } as Run['payload']),
       ),
     ).rejects.toThrow(
       'Selected repositories for cloud job 123 span multiple GitHub installations',
@@ -223,7 +223,7 @@ describe('createCloudJobGitHubToken', () => {
         buildCloudJob({
           repo: '__all_repositories__',
           selectedRepositories: ['owner-a/api'],
-        } as CloudJob['payload']),
+        } as Run['payload']),
       ),
     ).rejects.toThrow(
       'Selected repositories for cloud job 123 resolved no GitHub repository ids',
@@ -235,7 +235,7 @@ describe('createCloudJobGitHubToken', () => {
   it('falls back to the active installation for true all-repository tasks', async () => {
     await expect(
       createCloudJobGitHubToken(
-        buildCloudJob({ repo: '__all_repositories__' } as CloudJob['payload']),
+        buildCloudJob({ repo: '__all_repositories__' } as Run['payload']),
       ),
     ).resolves.toBe('ghs_test_token');
 

--- a/packages/github/src/api.ts
+++ b/packages/github/src/api.ts
@@ -12,7 +12,7 @@ import {
 import {
   type GitHubInstallation,
   type Repository,
-  type CloudJob,
+  type Run,
   db,
   githubPendingInstallations,
   githubInstallations,
@@ -37,7 +37,7 @@ async function createTokenForRepositoryNames({
   missingMessagePrefix,
   spanningMessagePrefix,
 }: {
-  cloudJob: CloudJob;
+  cloudJob: Run;
   repositoryNames: string[];
   missingMessagePrefix: string;
   spanningMessagePrefix: string;
@@ -161,7 +161,7 @@ type Checks = RestEndpointMethodTypes['checks'];
  */
 
 export const createCloudJobGitHubToken = async (
-  cloudJob: CloudJob,
+  cloudJob: Run,
 ): Promise<string> => {
   if (cloudJob.payload.environmentId) {
     const environment = await db.query.environments.findFirst({
@@ -245,7 +245,7 @@ export type CloudJobWorkerGitHubToken = {
  * token with its constrained permission set.
  */
 export async function createCloudJobWorkerGitHubTokenWithMetadata(
-  cloudJob: CloudJob,
+  cloudJob: Run,
 ): Promise<CloudJobWorkerGitHubToken> {
   return {
     token: await createCloudJobGitHubToken(cloudJob),
@@ -255,7 +255,7 @@ export async function createCloudJobWorkerGitHubTokenWithMetadata(
 }
 
 export async function createCloudJobWorkerGitHubToken(
-  cloudJob: CloudJob,
+  cloudJob: Run,
 ): Promise<string> {
   const result = await createCloudJobWorkerGitHubTokenWithMetadata(cloudJob);
   return result.token;

--- a/packages/gitlab/src/__tests__/api.test.ts
+++ b/packages/gitlab/src/__tests__/api.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
 import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
-import type { CloudJob } from '@roomote/db/server';
+import type { Run } from '@roomote/db/server';
 
 const {
   mockEnvironmentVariablesFindMany,
@@ -76,7 +76,7 @@ import {
   validateGitLabToken,
 } from '../api';
 
-function makeCloudJob(payload: CloudJob['payload']): CloudJob {
+function makeCloudJob(payload: Run['payload']): Run {
   return {
     id: 123,
     status: CloudTaskStatus.Dequeued,
@@ -87,7 +87,7 @@ function makeCloudJob(payload: CloudJob['payload']): CloudJob {
     payload,
     result: null,
     artifacts: null,
-  } as CloudJob;
+  } as Run;
 }
 
 describe('resolveGitLabBaseUrl', () => {

--- a/packages/gitlab/src/__tests__/api.test.ts
+++ b/packages/gitlab/src/__tests__/api.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
-import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
 import type { Run } from '@roomote/db/server';
 
 const {
@@ -79,7 +79,7 @@ import {
 function makeCloudJob(payload: Run['payload']): Run {
   return {
     id: 123,
-    status: CloudTaskStatus.Dequeued,
+    status: RunStatus.Dequeued,
     kind: 'fresh' as const,
     payloadKind: TaskPayloadKind.StandardTask,
     taskId: 'task-123',

--- a/packages/gitlab/src/api.ts
+++ b/packages/gitlab/src/api.ts
@@ -6,7 +6,7 @@ import {
   type SourceControlProvider,
 } from '@roomote/types';
 import {
-  type CloudJob,
+  type Run,
   db,
   environments,
   repositories,
@@ -881,7 +881,7 @@ function normalizeRepositorySelection(repositoryNames: string[]): string[] {
 }
 
 async function resolveGitLabRepositoryNamesForCloudJob(
-  cloudJob: CloudJob,
+  cloudJob: Run,
 ): Promise<string[]> {
   if (cloudJob.payload.environmentId) {
     const environment = await db.query.environments.findFirst({
@@ -920,7 +920,7 @@ async function resolveGitLabRepositoryNamesForCloudJob(
   );
 }
 
-async function resolveGitLabRepositoryRowsForCloudJob(cloudJob: CloudJob) {
+async function resolveGitLabRepositoryRowsForCloudJob(cloudJob: Run) {
   const repositoryNames =
     await resolveGitLabRepositoryNamesForCloudJob(cloudJob);
 
@@ -1118,7 +1118,7 @@ async function revokeScopedProjectTokenDescriptors(
 }
 
 export async function createCloudJobScopedGitLabTokens(
-  cloudJob: CloudJob,
+  cloudJob: Run,
   options?: {
     apiBaseUrl?: string;
     baseUrl?: string;
@@ -1241,7 +1241,7 @@ export async function createCloudJobScopedGitLabTokens(
 }
 
 export async function revokeCloudJobScopedGitLabTokens(
-  cloudJob: Pick<CloudJob, 'artifacts'>,
+  cloudJob: Pick<Run, 'artifacts'>,
   options?: {
     apiBaseUrl?: string;
     baseUrl?: string;

--- a/packages/linear/src/cancel-linear-job.ts
+++ b/packages/linear/src/cancel-linear-job.ts
@@ -1,4 +1,4 @@
-import { CloudTaskStatus } from '@roomote/types';
+import { RunStatus } from '@roomote/types';
 import {
   db,
   taskRuns,
@@ -55,7 +55,7 @@ export async function cancelLinearJob(
       await tx
         .update(taskRuns)
         .set({
-          status: CloudTaskStatus.Canceled,
+          status: RunStatus.Canceled,
           canceledAt: endedAt,
           error: 'Canceled by user via stop signal',
         })

--- a/packages/linear/src/create-linear-agent-job.ts
+++ b/packages/linear/src/create-linear-agent-job.ts
@@ -1,4 +1,4 @@
-import { enqueueCloudTask } from '@roomote/cloud-agents/server';
+import { enqueueTask } from '@roomote/cloud-agents/server';
 import {
   ALL_REPOSITORIES,
   TaskPayloadKind,
@@ -67,7 +67,7 @@ export async function createLinearAgentJob({
       };
 
   try {
-    const launchResult = await enqueueCloudTask({
+    const launchResult = await enqueueTask({
       task: {
         type: TaskPayloadKind.LinearAgentSession,
         linearSessionId: sessionId,

--- a/packages/linear/src/drain-linear-messages.ts
+++ b/packages/linear/src/drain-linear-messages.ts
@@ -5,7 +5,7 @@ import {
   populateSnapshotResumeSlackMetadata,
   restoreSnapshotResumeVisiblePromptFields,
 } from '@roomote/types';
-import { enqueueCloudTask } from '@roomote/cloud-agents/server';
+import { enqueueTask } from '@roomote/cloud-agents/server';
 import { getRedis } from '@roomote/redis';
 
 import { peekLinearMessageCount } from './peek-linear-messages';
@@ -132,7 +132,7 @@ export async function drainLinearMessagesToResumeJob(
   restoreSnapshotResumeVisiblePromptFields(payloadForResume, payload);
 
   let messages: Awaited<ReturnType<typeof getLinearMessages>> = [];
-  let resumeLaunch: Awaited<ReturnType<typeof enqueueCloudTask>>;
+  let resumeLaunch: Awaited<ReturnType<typeof enqueueTask>>;
 
   try {
     messages = await getLinearMessages(sourceJob.id);
@@ -152,7 +152,7 @@ export async function drainLinearMessagesToResumeJob(
     const resumeActingUserId =
       [...messages].reverse().find((message) => message.userId)?.userId ?? null;
 
-    resumeLaunch = await enqueueCloudTask({
+    resumeLaunch = await enqueueTask({
       task: {
         type: TaskPayloadKind.SnapshotResume,
         sourceSnapshotId: snapshotId,

--- a/packages/linear/src/drain-linear-messages.ts
+++ b/packages/linear/src/drain-linear-messages.ts
@@ -1,6 +1,6 @@
 import {
   ALL_REPOSITORIES,
-  type CloudTaskPayload,
+  type TaskPayload,
   TaskPayloadKind,
   populateSnapshotResumeSlackMetadata,
   restoreSnapshotResumeVisiblePromptFields,
@@ -117,9 +117,7 @@ export async function drainLinearMessagesToResumeJob(
     selectedRepositories && selectedRepositories.length > 0
       ? selectedRepositories
       : undefined;
-  const payloadForResume: CloudTaskPayload<
-    typeof TaskPayloadKind.SnapshotResume
-  > = {
+  const payloadForResume: TaskPayload<typeof TaskPayloadKind.SnapshotResume> = {
     repo,
     environmentId,
     selectedRepositories: scopedSelectedRepositories,

--- a/packages/linear/src/find-active-linear-job.ts
+++ b/packages/linear/src/find-active-linear-job.ts
@@ -8,7 +8,7 @@ import {
   isNull,
   desc,
 } from '@roomote/db/server';
-import { activeCloudTaskStatuses } from '@roomote/types';
+import { activeRunStatuses } from '@roomote/types';
 
 import type { ActiveLinearJobResult } from './types';
 
@@ -59,7 +59,7 @@ export async function findActiveLinearJob(
     .where(
       and(
         eq(tasks.linearSessionId, linearSessionId),
-        inArray(taskRuns.status, [...activeCloudTaskStatuses]),
+        inArray(taskRuns.status, [...activeRunStatuses]),
         isNull(taskRuns.canceledAt),
       ),
     )
@@ -87,7 +87,7 @@ export async function findActiveLinearJob(
       .where(
         and(
           eq(tasks.linearIssueId, linearIssueId),
-          inArray(taskRuns.status, [...activeCloudTaskStatuses]),
+          inArray(taskRuns.status, [...activeRunStatuses]),
           isNull(taskRuns.canceledAt),
         ),
       )
@@ -126,7 +126,7 @@ export async function findActiveLinearJobByOrganization(
     .where(
       and(
         eq(tasks.linearOrganizationId, linearOrganizationId),
-        inArray(taskRuns.status, [...activeCloudTaskStatuses]),
+        inArray(taskRuns.status, [...activeRunStatuses]),
         isNull(taskRuns.canceledAt),
       ),
     )

--- a/packages/linear/src/find-completed-linear-job-with-snapshot.ts
+++ b/packages/linear/src/find-completed-linear-job-with-snapshot.ts
@@ -10,7 +10,7 @@ import {
   isNotNull,
   desc,
 } from '@roomote/db/server';
-import { CloudTaskStatus, SANDBOX_SNAPSHOT_EXPIRY_MS } from '@roomote/types';
+import { RunStatus, SANDBOX_SNAPSHOT_EXPIRY_MS } from '@roomote/types';
 
 /**
  * Find the most recent completed/idle run for a Linear issue that has a
@@ -53,10 +53,7 @@ export async function findCompletedLinearJobWithSnapshot(
     .where(
       and(
         eq(tasks.linearIssueId, linearIssueId),
-        inArray(taskRuns.status, [
-          CloudTaskStatus.Completed,
-          CloudTaskStatus.Idle,
-        ]),
+        inArray(taskRuns.status, [RunStatus.Completed, RunStatus.Idle]),
         isNotNull(taskRuns.snapshotId),
         isNull(taskRuns.snapshotFailedAt),
         isNull(taskRuns.canceledAt),

--- a/packages/sdk/src/client/index.ts
+++ b/packages/sdk/src/client/index.ts
@@ -24,7 +24,7 @@ export type { LinearInstallation } from '../linear-installations';
 export type { Repository } from '../repositories';
 export type { ParsedPR } from '../pull-request-links';
 export type {
-  CloudJob,
+  Run,
   DequeuedCloudJob,
   DequeuedResumeCloudJob,
 } from '../cloud-jobs';

--- a/packages/sdk/src/cloud-jobs.test.ts
+++ b/packages/sdk/src/cloud-jobs.test.ts
@@ -1,4 +1,4 @@
-import { CloudTaskStatus } from '@roomote/types';
+import { RunStatus } from '@roomote/types';
 
 const {
   mockDequeue,
@@ -88,7 +88,7 @@ describe('dequeue', () => {
     const onBootstrapFailure = vi.fn();
     const cloudJob = {
       id: 42,
-      status: CloudTaskStatus.Canceled,
+      status: RunStatus.Canceled,
       startedAt: null,
       error: 'Cloud job is not valid.',
       type: 'GithubPrReview',
@@ -124,7 +124,7 @@ describe('dequeue', () => {
     mockDequeue.mockResolvedValueOnce(undefined);
     mockFindFirstById.mockResolvedValueOnce({
       id: 42,
-      status: CloudTaskStatus.Canceled,
+      status: RunStatus.Canceled,
       startedAt: new Date('2026-04-21T00:00:00.000Z'),
       error: 'Failed to create GitHub token.',
       type: 'GithubPrReview',
@@ -151,7 +151,7 @@ describe('dequeue', () => {
     mockDequeue.mockResolvedValueOnce(undefined);
     mockFindFirstById.mockResolvedValueOnce({
       id: 42,
-      status: CloudTaskStatus.Canceled,
+      status: RunStatus.Canceled,
       startedAt: null,
       error: 'Superseded by a newer cloud job.',
       type: 'StandardTask',
@@ -204,7 +204,7 @@ describe('resume', () => {
     const onBootstrapFailure = vi.fn();
     const cloudJob = {
       id: 84,
-      status: CloudTaskStatus.Canceled,
+      status: RunStatus.Canceled,
       startedAt: null,
       error: 'SnapshotResume job 84 has no sourceCloudJobId',
       type: 'SnapshotResume',

--- a/packages/sdk/src/cloud-jobs.ts
+++ b/packages/sdk/src/cloud-jobs.ts
@@ -1,4 +1,4 @@
-import { CloudTaskStatus } from '@roomote/types';
+import { RunStatus } from '@roomote/types';
 
 import {
   type AppRouterInput,
@@ -37,7 +37,7 @@ function isImmediateBootstrapFailure(
   cloudJob: Run,
 ): cloudJob is Run & { error: string } {
   return (
-    cloudJob.status === CloudTaskStatus.Canceled &&
+    cloudJob.status === RunStatus.Canceled &&
     cloudJob.startedAt == null &&
     typeof cloudJob.error === 'string' &&
     cloudJob.error.length > 0 &&

--- a/packages/sdk/src/cloud-jobs.ts
+++ b/packages/sdk/src/cloud-jobs.ts
@@ -8,9 +8,7 @@ import {
 } from './client';
 import { hasBootstrapFailureSignal } from './bootstrap-failure-signal';
 
-export type CloudJob = NonNullable<
-  AppRouterOutput['cloudJobs']['findFirstById']
->;
+export type Run = NonNullable<AppRouterOutput['cloudJobs']['findFirstById']>;
 
 export type DequeuedCloudJob = NonNullable<
   AppRouterOutput['cloudJobs']['dequeue']
@@ -28,7 +26,7 @@ export interface SyncActingUserIdOptions {
 export type SyncActingUserIdResult = 'updated' | 'unchanged' | 'not-found';
 
 export interface CloudJobBootstrapOptions {
-  onBootstrapFailure?: (error: Error, cloudJob: CloudJob) => void;
+  onBootstrapFailure?: (error: Error, cloudJob: Run) => void;
 }
 
 export interface CloudJobRequestOptions {
@@ -36,8 +34,8 @@ export interface CloudJobRequestOptions {
 }
 
 function isImmediateBootstrapFailure(
-  cloudJob: CloudJob,
-): cloudJob is CloudJob & { error: string } {
+  cloudJob: Run,
+): cloudJob is Run & { error: string } {
   return (
     cloudJob.status === CloudTaskStatus.Canceled &&
     cloudJob.startedAt == null &&
@@ -49,7 +47,7 @@ function isImmediateBootstrapFailure(
 
 async function notifyOnBootstrapFailure(
   cloudJobId: number,
-  onBootstrapFailure?: (error: Error, cloudJob: CloudJob) => void,
+  onBootstrapFailure?: (error: Error, cloudJob: Run) => void,
 ): Promise<void> {
   if (!onBootstrapFailure) {
     return;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -45,7 +45,7 @@ export type { LinearSessionConnection } from './linear-sessions';
 export type { LinearInstallation } from './linear-installations';
 export type { Repository } from './repositories';
 export type {
-  CloudJob,
+  Run,
   DequeuedCloudJob,
   DequeuedResumeCloudJob,
 } from './cloud-jobs';

--- a/packages/sdk/src/server/automations/__tests__/conflict-scan.test.ts
+++ b/packages/sdk/src/server/automations/__tests__/conflict-scan.test.ts
@@ -4,7 +4,7 @@ const {
   mockGetCommitCommittedAt,
   mockGetInstallationOctokit,
   mockIsRepoSkipped,
-  mockEnqueueCloudTask,
+  mockEnqueueTask,
   mockFindActiveGitHubBranchWork,
   mockHasRecentGitHubBranchCommit,
   mockSelectLimit,
@@ -19,7 +19,7 @@ const {
     mockGetCommitCommittedAt: vi.fn() as AnyMock,
     mockGetInstallationOctokit: vi.fn() as AnyMock,
     mockIsRepoSkipped: vi.fn() as AnyMock,
-    mockEnqueueCloudTask: vi.fn() as AnyMock,
+    mockEnqueueTask: vi.fn() as AnyMock,
     mockFindActiveGitHubBranchWork: vi.fn() as AnyMock,
     mockHasRecentGitHubBranchCommit: vi.fn() as AnyMock,
     mockSelectLimit: vi.fn() as AnyMock,
@@ -31,7 +31,7 @@ const {
 });
 
 vi.mock('@roomote/cloud-agents/server', () => ({
-  enqueueCloudTask: mockEnqueueCloudTask,
+  enqueueTask: mockEnqueueTask,
 }));
 
 vi.mock('@roomote/env', async (importOriginal) => {
@@ -196,7 +196,7 @@ describe('conflictScanJob', () => {
 
     const octokit = await mockGetInstallationOctokit.mock.results[0]!.value;
     expect(octokit.paginate).not.toHaveBeenCalled();
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
     expect(octokit.rest.issues.createComment).not.toHaveBeenCalled();
   });
 
@@ -295,7 +295,7 @@ describe('conflictScanJob', () => {
       branchName: 'feature/work',
     });
     expect(mockGetCommitCommittedAt).not.toHaveBeenCalled();
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('skips conflicting PRs when the branch has a recent commit', async () => {
@@ -342,7 +342,7 @@ describe('conflictScanJob', () => {
     expect(mockHasRecentGitHubBranchCommit).toHaveBeenCalledWith({
       latestCommitAt: new Date('2026-03-17T21:50:00.000Z'),
     });
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('looks up fork PR head commits in the head repository', async () => {
@@ -396,7 +396,7 @@ describe('conflictScanJob', () => {
     mockSelectLimit
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([{ id: 'agent-1', orgId: 'org-1' }]);
-    mockEnqueueCloudTask.mockResolvedValueOnce({ id: 1, taskId: 'task-1' });
+    mockEnqueueTask.mockResolvedValueOnce({ id: 1, taskId: 'task-1' });
 
     const octokit = {
       paginate: vi.fn().mockResolvedValue([
@@ -426,7 +426,7 @@ describe('conflictScanJob', () => {
 
     const result = await conflictScanJob();
 
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           type: 'github_pr_conflict_resolve',
@@ -451,9 +451,7 @@ describe('conflictScanJob', () => {
         }),
       }),
     );
-    expect(mockEnqueueCloudTask.mock.calls[0]?.[0]).not.toHaveProperty(
-      'userId',
-    );
+    expect(mockEnqueueTask.mock.calls[0]?.[0]).not.toHaveProperty('userId');
     expect(result.launchedTaskId).toBe('task-1');
     expect(octokit.rest.issues.createComment).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -499,6 +497,6 @@ describe('conflictScanJob', () => {
 
     expect(octokit.rest.pulls.get).not.toHaveBeenCalled();
     expect(mockGetCommitCommittedAt).not.toHaveBeenCalled();
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 });

--- a/packages/sdk/src/server/automations/__tests__/conflict-scan.test.ts
+++ b/packages/sdk/src/server/automations/__tests__/conflict-scan.test.ts
@@ -60,7 +60,7 @@ vi.mock('@roomote/types', async (importOriginal) => {
     CONFLICT_RESOLUTION_COMMENT_MARKER: '<!-- conflict-resolution -->',
     DEFAULT_CONFLICT_SCAN_LOOKBACK_DAYS: 7,
     DEFAULT_CONFLICT_RESOLUTION_MAX_PR_AGE_DAYS: 30,
-    CloudTaskStatus: {
+    RunStatus: {
       Pending: 'pending',
       Running: 'running',
     },

--- a/packages/sdk/src/server/automations/__tests__/suggester-route-dispatch.test.ts
+++ b/packages/sdk/src/server/automations/__tests__/suggester-route-dispatch.test.ts
@@ -1,9 +1,7 @@
-const { mockEnqueueCloudTask, mockRecordAutomationRunOutcome } = vi.hoisted(
-  () => ({
-    mockEnqueueCloudTask: vi.fn(),
-    mockRecordAutomationRunOutcome: vi.fn(),
-  }),
-);
+const { mockEnqueueTask, mockRecordAutomationRunOutcome } = vi.hoisted(() => ({
+  mockEnqueueTask: vi.fn(),
+  mockRecordAutomationRunOutcome: vi.fn(),
+}));
 
 vi.mock('@roomote/cloud-agents/server', async (importOriginal) => {
   const actual =
@@ -11,7 +9,7 @@ vi.mock('@roomote/cloud-agents/server', async (importOriginal) => {
 
   return {
     ...actual,
-    enqueueCloudTask: mockEnqueueCloudTask,
+    enqueueTask: mockEnqueueTask,
   };
 });
 
@@ -73,7 +71,7 @@ describe('dispatchSuggestionRoutes', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-04-09T03:00:00.000Z'));
 
-    mockEnqueueCloudTask.mockResolvedValue({ id: 1, taskId: 'task-1' });
+    mockEnqueueTask.mockResolvedValue({ id: 1, taskId: 'task-1' });
     mockRecordAutomationRunOutcome.mockResolvedValue(undefined);
   });
 
@@ -94,7 +92,7 @@ describe('dispatchSuggestionRoutes', () => {
     expect(
       params.routePlan.loadRecentThreadFeedbackForChannel,
     ).toHaveBeenCalledWith('C123SUGGEST');
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith({
+    expect(mockEnqueueTask).toHaveBeenCalledWith({
       task: {
         type: TaskPayloadKind.Scan,
         payload: {
@@ -185,7 +183,7 @@ describe('dispatchSuggestionRoutes', () => {
         loadRecentThreadFeedbackForChannel,
       },
     };
-    mockEnqueueCloudTask
+    mockEnqueueTask
       .mockRejectedValueOnce(new Error('queue failed'))
       .mockResolvedValueOnce({ taskId: 'task-2' });
 
@@ -222,7 +220,7 @@ describe('dispatchSuggestionRoutes', () => {
   it('records a failed pass when every route fails', async () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const params = buildParams();
-    mockEnqueueCloudTask.mockRejectedValue(new Error('queue failed'));
+    mockEnqueueTask.mockRejectedValue(new Error('queue failed'));
 
     const result = await dispatchSuggestionRoutes(params);
 

--- a/packages/sdk/src/server/automations/conflict-scan.ts
+++ b/packages/sdk/src/server/automations/conflict-scan.ts
@@ -24,7 +24,7 @@ import {
 import { enqueueCloudTask } from '@roomote/cloud-agents/server';
 import {
   TaskPayloadKind,
-  CloudTaskStatus,
+  RunStatus,
   DEFAULT_CONFLICT_RESOLUTION_MAX_PR_AGE_DAYS,
   isConflictResolverMaxPrAgeDays,
 } from '@roomote/types';
@@ -91,7 +91,7 @@ async function hasActiveResolutionJob(
   repoFullName: string,
   prNumber: number,
 ): Promise<boolean> {
-  const activeStatuses = [CloudTaskStatus.Pending, CloudTaskStatus.Running];
+  const activeStatuses = [RunStatus.Pending, RunStatus.Running];
 
   const existing = await db
     .select({ id: taskRuns.id })

--- a/packages/sdk/src/server/automations/conflict-scan.ts
+++ b/packages/sdk/src/server/automations/conflict-scan.ts
@@ -21,7 +21,7 @@ import {
   getInstallationOctokit,
   isRepoSkipped,
 } from '@roomote/github';
-import { enqueueCloudTask } from '@roomote/cloud-agents/server';
+import { enqueueTask } from '@roomote/cloud-agents/server';
 import {
   TaskPayloadKind,
   RunStatus,
@@ -309,7 +309,7 @@ export async function conflictScanJob(
               const prAuthorId = pr.user?.id;
               const prAuthorLogin = pr.user?.login;
 
-              const launchResult = await enqueueCloudTask({
+              const launchResult = await enqueueTask({
                 task: {
                   type: TaskPayloadKind.GithubPrConflictResolve,
                   payload: {

--- a/packages/sdk/src/server/automations/merged-pr-audit-runner.ts
+++ b/packages/sdk/src/server/automations/merged-pr-audit-runner.ts
@@ -1,6 +1,6 @@
 import {
   buildRepositoryCoverage,
-  enqueueCloudTask,
+  enqueueTask,
   formatRepositoryEnvironmentLines,
   type RepositoryCoverage,
 } from '@roomote/cloud-agents/server';
@@ -398,7 +398,7 @@ async function processDeployment(
 
     // Automation scans run as the deployment service principal; a manual
     // trigger is still an automation launch, just with a manual trigger.
-    const launchResult = await enqueueCloudTask({
+    const launchResult = await enqueueTask({
       task: {
         type: TaskPayloadKind.Scan,
         payload: {

--- a/packages/sdk/src/server/automations/scheduled-triage-runner.ts
+++ b/packages/sdk/src/server/automations/scheduled-triage-runner.ts
@@ -1,4 +1,4 @@
-import { enqueueCloudTask } from '@roomote/cloud-agents/server';
+import { enqueueTask } from '@roomote/cloud-agents/server';
 import {
   db,
   eq,
@@ -157,7 +157,7 @@ export function createScheduledTriageJob(
         // Automation scans run as the deployment service principal; a manual
         // trigger is still an automation launch, just with a manual trigger
         // kind on the task record.
-        const launchResult = await enqueueCloudTask({
+        const launchResult = await enqueueTask({
           task: {
             type: TaskPayloadKind.Scan,
             payload: scanTask.payload,

--- a/packages/sdk/src/server/automations/suggester-route-dispatch.ts
+++ b/packages/sdk/src/server/automations/suggester-route-dispatch.ts
@@ -1,6 +1,6 @@
 import {
   buildSuggestedTasksPrompt,
-  enqueueCloudTask,
+  enqueueTask,
 } from '@roomote/cloud-agents/server';
 import { db, recordAutomationRunOutcome } from '@roomote/db/server';
 import { ALL_REPOSITORIES, TaskPayloadKind } from '@roomote/types';
@@ -34,7 +34,7 @@ async function enqueueSuggestionRoute(params: {
 }): Promise<{ error?: string; success: boolean; taskId?: string }> {
   try {
     // Suggestion scans run as the deployment service principal.
-    const launchResult = await enqueueCloudTask({
+    const launchResult = await enqueueTask({
       task: {
         type: TaskPayloadKind.Scan,
         payload: {

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -12,7 +12,7 @@ export {
   optionalAuthProcedure,
 } from './trpc';
 
-export { finishCloudJob } from './lib/cloud-jobs/finish-cloud-job';
+export { finishRun } from './lib/cloud-jobs/finish-run';
 export { findCloudJobByJobTokenClaims } from './lib/cloud-jobs/find-cloud-job';
 export { createSnapshot } from './lib/cloud-jobs/enqueue-snapshot';
 export { recordComputeProviderUsage } from './lib/cloud-jobs/record-compute-provider-usage';

--- a/packages/sdk/src/server/lib/__tests__/sandbox-oidc.test.ts
+++ b/packages/sdk/src/server/lib/__tests__/sandbox-oidc.test.ts
@@ -39,7 +39,7 @@ vi.mock('@roomote/types', async (importOriginal) => {
 
   return {
     ...actual,
-    CloudTaskStatus: {
+    RunStatus: {
       Completed: 'completed',
       Failed: 'failed',
       Canceled: 'canceled',

--- a/packages/sdk/src/server/lib/cloud-jobs/__tests__/dequeue-cloud-job.test.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/__tests__/dequeue-cloud-job.test.ts
@@ -1,5 +1,5 @@
 import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
-import type { CloudJob } from '@roomote/db/server';
+import type { Run } from '@roomote/db/server';
 
 const {
   mockDbTransaction,
@@ -99,7 +99,7 @@ vi.mock('../dequeue-helpers', () => ({
 
 import { dequeueCloudJob } from '../dequeue-cloud-job';
 
-type RunWithTask = CloudJob & { task: Record<string, unknown> };
+type RunWithTask = Run & { task: Record<string, unknown> };
 
 function makeTaskRow(overrides: Record<string, unknown> = {}) {
   return {
@@ -201,9 +201,9 @@ describe('dequeueCloudJob', () => {
         error,
         cloudJob,
       }: {
-        callback?: (error: Error, cloudJob: CloudJob) => void;
+        callback?: (error: Error, cloudJob: Run) => void;
         error: Error;
-        cloudJob: CloudJob;
+        cloudJob: Run;
       }) => callback?.(error, cloudJob),
     );
     mockGeneratePrompt.mockResolvedValue({

--- a/packages/sdk/src/server/lib/cloud-jobs/__tests__/dequeue-cloud-job.test.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/__tests__/dequeue-cloud-job.test.ts
@@ -1,4 +1,4 @@
-import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
 import type { Run } from '@roomote/db/server';
 
 const {
@@ -126,7 +126,7 @@ function makeStandardTaskJob(
   return {
     id: 101,
     harness: 'opencode-server',
-    status: CloudTaskStatus.Dequeued,
+    status: RunStatus.Dequeued,
     kind: 'fresh',
     payloadKind: TaskPayloadKind.StandardTask,
     taskId: 'task-101',
@@ -149,7 +149,7 @@ function makeSlackAppMentionJob(
   return {
     id: 202,
     harness: 'opencode-server',
-    status: CloudTaskStatus.Dequeued,
+    status: RunStatus.Dequeued,
     kind: 'fresh',
     payloadKind: TaskPayloadKind.SlackAppMention,
     taskId: 'task-202',
@@ -453,7 +453,7 @@ describe('dequeueCloudJob', () => {
         message: expect.stringContaining('started execution bootstrap'),
         details: expect.objectContaining({
           stage: 'worker_bootstrap',
-          status: CloudTaskStatus.Processing,
+          status: RunStatus.Processing,
           vendor: 'modal',
           machineId: 'sb_123',
           sourceSnapshotId: 'snap_env_123',

--- a/packages/sdk/src/server/lib/cloud-jobs/__tests__/dequeue-helpers.test.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/__tests__/dequeue-helpers.test.ts
@@ -1,4 +1,4 @@
-import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
 import type { Run } from '@roomote/db/server';
 
 const {
@@ -88,7 +88,7 @@ import {
 function makeCloudJob(payload: Run['payload']): Run {
   return {
     id: 123,
-    status: CloudTaskStatus.Dequeued,
+    status: RunStatus.Dequeued,
     kind: 'fresh',
     payloadKind: TaskPayloadKind.StandardTask,
     taskId: 'task-123',

--- a/packages/sdk/src/server/lib/cloud-jobs/__tests__/dequeue-helpers.test.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/__tests__/dequeue-helpers.test.ts
@@ -1,5 +1,5 @@
 import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
-import type { CloudJob } from '@roomote/db/server';
+import type { Run } from '@roomote/db/server';
 
 const {
   mockDecryptSecrets,
@@ -85,7 +85,7 @@ import {
   redactSourceControlProviderEnvVars,
 } from '../dequeue-helpers';
 
-function makeCloudJob(payload: CloudJob['payload']): CloudJob {
+function makeCloudJob(payload: Run['payload']): Run {
   return {
     id: 123,
     status: CloudTaskStatus.Dequeued,
@@ -95,7 +95,7 @@ function makeCloudJob(payload: CloudJob['payload']): CloudJob {
     actingUserId: 'user-123',
     payload,
     result: null,
-  } as CloudJob;
+  } as Run;
 }
 
 describe('createSourceControlTokenForJob', () => {

--- a/packages/sdk/src/server/lib/cloud-jobs/__tests__/dequeue-resume-cloud-job.test.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/__tests__/dequeue-resume-cloud-job.test.ts
@@ -1,4 +1,4 @@
-import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
 import type { Run } from '@roomote/db/server';
 
 const {
@@ -119,7 +119,7 @@ function makeSnapshotResumeJob(
   return {
     id: 101,
     harness: 'opencode-server',
-    status: CloudTaskStatus.Dequeued,
+    status: RunStatus.Dequeued,
     kind: 'resume',
     payloadKind: TaskPayloadKind.SnapshotResume,
     taskId: 'task-101',
@@ -257,7 +257,7 @@ describe('dequeueResumeCloudJob', () => {
         message: expect.stringContaining('started resume bootstrap'),
         details: expect.objectContaining({
           stage: 'worker_bootstrap',
-          status: CloudTaskStatus.Processing,
+          status: RunStatus.Processing,
           sourceSnapshotId: 'snap-1',
           sourceRunId: 99,
           harnessSessionId: 'session-canonical',

--- a/packages/sdk/src/server/lib/cloud-jobs/__tests__/dequeue-resume-cloud-job.test.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/__tests__/dequeue-resume-cloud-job.test.ts
@@ -1,5 +1,5 @@
 import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
-import type { CloudJob } from '@roomote/db/server';
+import type { Run } from '@roomote/db/server';
 
 const {
   mockDbTransaction,
@@ -93,7 +93,7 @@ vi.mock('../slack-job-routing', () => ({
 
 import { dequeueResumeCloudJob } from '../dequeue-resume-cloud-job';
 
-type RunWithTask = CloudJob & { task: Record<string, unknown> };
+type RunWithTask = Run & { task: Record<string, unknown> };
 
 function makeTaskRow(overrides: Record<string, unknown> = {}) {
   return {
@@ -175,9 +175,9 @@ describe('dequeueResumeCloudJob', () => {
         error,
         cloudJob,
       }: {
-        callback?: (error: Error, cloudJob: CloudJob) => void;
+        callback?: (error: Error, cloudJob: Run) => void;
         error: Error;
-        cloudJob: CloudJob;
+        cloudJob: Run;
       }) => callback?.(error, cloudJob),
     );
 

--- a/packages/sdk/src/server/lib/cloud-jobs/__tests__/fetch-snapshot-env.test.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/__tests__/fetch-snapshot-env.test.ts
@@ -37,7 +37,7 @@ vi.mock('../dequeue-helpers', () => ({
 
 import { fetchSnapshotEnv } from '../fetch-snapshot-env';
 
-// A minimal CloudJob-like object for test fixtures.
+// A minimal Run-like object for test fixtures.
 function makeCloudJob(overrides: Record<string, unknown> = {}) {
   return {
     id: 42,

--- a/packages/sdk/src/server/lib/cloud-jobs/__tests__/finish-cloud-job.test.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/__tests__/finish-cloud-job.test.ts
@@ -1,5 +1,5 @@
 import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
-import { tasks, type CloudJob, type Task } from '@roomote/db/server';
+import { tasks, type Run, type Task } from '@roomote/db/server';
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -272,10 +272,10 @@ function makeTask(overrides: Partial<Task> = {}): Task {
   } as Task;
 }
 
-type RunWithTask = CloudJob & { task: Task };
+type RunWithTask = Run & { task: Task };
 
 function makeRun(
-  overrides: Partial<CloudJob> = {},
+  overrides: Partial<Run> = {},
   taskOverrides: Partial<Task> = {},
 ): RunWithTask {
   const task = makeTask(taskOverrides);
@@ -724,7 +724,7 @@ describe('finishCloudJob', () => {
             thread_ts: '111.222',
             webPath: '/setup',
             environmentDefinitionId: 'env-123',
-          } as CloudJob['payload'],
+          } as Run['payload'],
         },
         { slackChannelId: 'C123', slackThreadTs: '111.222' },
       );
@@ -765,7 +765,7 @@ describe('finishCloudJob', () => {
             thread_ts: '111.222',
             webPath: '/setup',
             environmentDefinitionId: 'env-123',
-          } as CloudJob['payload'],
+          } as Run['payload'],
         },
         { slackChannelId: 'C123', slackThreadTs: '111.222' },
       );
@@ -1706,7 +1706,7 @@ describe('finishCloudJob', () => {
       communicationChannelId: 'conversation-1',
       communicationServiceUrl: 'https://smba.trafficmanager.net/amer/',
       communicationThreadId: 'activity-root',
-    } as unknown as CloudJob['payload'];
+    } as unknown as Run['payload'];
 
     beforeEach(() => {
       mockCreateTeamsCommunicationProviderFromEnv.mockReturnValue({

--- a/packages/sdk/src/server/lib/cloud-jobs/__tests__/finish-cloud-job.test.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/__tests__/finish-cloud-job.test.ts
@@ -1,4 +1,4 @@
-import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
 import { tasks, type Run, type Task } from '@roomote/db/server';
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
@@ -66,7 +66,7 @@ function makeSelectChain() {
  */
 let syncRunRows: Array<{
   id: number;
-  status: CloudTaskStatus;
+  status: RunStatus;
   startedAt: Date | null;
 }> = [];
 
@@ -286,7 +286,7 @@ function makeRun(
     payloadKind: TaskPayloadKind.StandardTask,
     actingUserId: 'user-1',
     harness: 'opencode-server',
-    status: CloudTaskStatus.Running,
+    status: RunStatus.Running,
     payload: { repo: 'owner/repo' },
     taskId: task.id,
     sourceRunId: null,
@@ -374,7 +374,7 @@ describe('finishCloudJob', () => {
 
     await finishCloudJob({
       id: 1,
-      status: CloudTaskStatus.Completed,
+      status: RunStatus.Completed,
     });
 
     expect(mockCleanupSandboxOidcTargetsForCloudJob).toHaveBeenCalledWith(1);
@@ -384,12 +384,12 @@ describe('finishCloudJob', () => {
     mockFindFirstRun.mockResolvedValue(makeRun());
     // syncTaskStateFromRuns reads the run status just written above.
     syncRunRows = [
-      { id: 1, status: CloudTaskStatus.Completed, startedAt: new Date() },
+      { id: 1, status: RunStatus.Completed, startedAt: new Date() },
     ];
 
     await finishCloudJob({
       id: 1,
-      status: CloudTaskStatus.Completed,
+      status: RunStatus.Completed,
     });
 
     expect(mockDbUpdate).toHaveBeenNthCalledWith(2, tasks);
@@ -401,13 +401,11 @@ describe('finishCloudJob', () => {
 
   it('derives tasks.state canceled via the shared sync when the job is canceled', async () => {
     mockFindFirstRun.mockResolvedValue(makeRun());
-    syncRunRows = [
-      { id: 1, status: CloudTaskStatus.Canceled, startedAt: null },
-    ];
+    syncRunRows = [{ id: 1, status: RunStatus.Canceled, startedAt: null }];
 
     await finishCloudJob({
       id: 1,
-      status: CloudTaskStatus.Canceled,
+      status: RunStatus.Canceled,
     });
 
     expect(mockDbUpdate).toHaveBeenNthCalledWith(2, tasks);
@@ -419,13 +417,11 @@ describe('finishCloudJob', () => {
 
   it('derives tasks.state failed via the shared sync when the job fails', async () => {
     mockFindFirstRun.mockResolvedValue(makeRun());
-    syncRunRows = [
-      { id: 1, status: CloudTaskStatus.Failed, startedAt: new Date() },
-    ];
+    syncRunRows = [{ id: 1, status: RunStatus.Failed, startedAt: new Date() }];
 
     await finishCloudJob({
       id: 1,
-      status: CloudTaskStatus.Failed,
+      status: RunStatus.Failed,
       error: 'boom',
     });
 
@@ -439,13 +435,11 @@ describe('finishCloudJob', () => {
   it('keeps the task active (not terminal) when the finishing run goes idle', async () => {
     mockFindFirstRun.mockResolvedValue(makeRun());
     // The idle run is non-terminal, so the derivation resolves to 'active'.
-    syncRunRows = [
-      { id: 1, status: CloudTaskStatus.Idle, startedAt: new Date() },
-    ];
+    syncRunRows = [{ id: 1, status: RunStatus.Idle, startedAt: new Date() }];
 
     await finishCloudJob({
       id: 1,
-      status: CloudTaskStatus.Idle,
+      status: RunStatus.Idle,
     });
 
     // The shared sync still runs, but only ever derives 'active' here; it never
@@ -465,13 +459,13 @@ describe('finishCloudJob', () => {
     // The prior run completed (started); this resume never started before it
     // was canceled, so the derivation keeps the task 'completed'.
     syncRunRows = [
-      { id: 1, status: CloudTaskStatus.Completed, startedAt: new Date() },
-      { id: 2, status: CloudTaskStatus.Canceled, startedAt: null },
+      { id: 1, status: RunStatus.Completed, startedAt: new Date() },
+      { id: 2, status: RunStatus.Canceled, startedAt: null },
     ];
 
     await finishCloudJob({
       id: 2,
-      status: CloudTaskStatus.Canceled,
+      status: RunStatus.Canceled,
     });
 
     expect(mockDbUpdate).toHaveBeenNthCalledWith(2, tasks);
@@ -486,7 +480,7 @@ describe('finishCloudJob', () => {
 
     await finishCloudJob({
       id: 1,
-      status: CloudTaskStatus.Idle,
+      status: RunStatus.Idle,
     });
 
     expect(mockCleanupSandboxOidcTargetsForCloudJob).not.toHaveBeenCalled();
@@ -534,7 +528,7 @@ describe('finishCloudJob', () => {
 
     await finishCloudJob({
       id: 303,
-      status: CloudTaskStatus.Failed,
+      status: RunStatus.Failed,
       error: 'snapshot resume failed',
     });
 
@@ -568,7 +562,7 @@ describe('finishCloudJob', () => {
     expect(mockDbUpdateSet).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         error: 'snapshot resume failed',
       }),
     );
@@ -606,7 +600,7 @@ describe('finishCloudJob', () => {
 
     await finishCloudJob({
       id: 12,
-      status: CloudTaskStatus.Failed,
+      status: RunStatus.Failed,
       error: 'spawn timeout',
     });
 
@@ -619,7 +613,7 @@ describe('finishCloudJob', () => {
         message: 'Cloud job finished with a failure.',
         details: expect.objectContaining({
           stage: 'finish_cloud_job',
-          status: CloudTaskStatus.Failed,
+          status: RunStatus.Failed,
           vendor: 'modal',
           machineId: 'sb-modal-12',
           sourceSnapshotId: 'snap_env_12',
@@ -663,7 +657,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       });
 
       expect(mockPostMessage).not.toHaveBeenCalled();
@@ -697,7 +691,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       });
 
       expect(mockPostMessage).toHaveBeenCalledWith({
@@ -739,7 +733,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Idle,
+        status: RunStatus.Idle,
       });
 
       expect(mockPostMessage).toHaveBeenCalledWith({
@@ -780,7 +774,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Idle,
+        status: RunStatus.Idle,
       });
 
       expect(mockPostMessage).not.toHaveBeenCalled();
@@ -814,7 +808,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Idle,
+        status: RunStatus.Idle,
       });
 
       expect(mockPostMessage).not.toHaveBeenCalled();
@@ -848,7 +842,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       });
 
       expect(mockPostMessage).toHaveBeenCalledWith({
@@ -904,7 +898,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 2,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       });
 
       expect(mockPostMessage).toHaveBeenCalledWith({
@@ -960,7 +954,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 2,
-        status: CloudTaskStatus.Idle,
+        status: RunStatus.Idle,
       });
 
       expect(mockPostMessage).toHaveBeenCalledWith({
@@ -1031,11 +1025,11 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 2,
-        status: CloudTaskStatus.Idle,
+        status: RunStatus.Idle,
       });
       await finishCloudJob({
         id: 3,
-        status: CloudTaskStatus.Idle,
+        status: RunStatus.Idle,
       });
 
       // The claim is task-scoped, so repeated idle cycles share one key.
@@ -1102,7 +1096,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 2,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       });
 
       expect(mockOpenConversation).toHaveBeenCalledWith('UINSTALLER');
@@ -1147,7 +1141,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 2,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       });
 
       expect(mockOpenConversation).not.toHaveBeenCalled();
@@ -1186,7 +1180,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 2,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       });
 
       expect(mockOpenConversation).not.toHaveBeenCalled();
@@ -1202,7 +1196,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 2,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       });
 
       expect(mockFindFirstSlackInstallation).not.toHaveBeenCalled();
@@ -1222,7 +1216,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 2,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       });
 
       expect(mockFindFirstSlackInstallation).not.toHaveBeenCalled();
@@ -1262,7 +1256,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 2,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       });
 
       expect(mockOpenConversation).not.toHaveBeenCalled();
@@ -1302,7 +1296,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 2,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       });
 
       expect(mockPostMessage).not.toHaveBeenCalled();
@@ -1335,7 +1329,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         error: 'spawn timeout',
       });
 
@@ -1386,7 +1380,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         error: 'Worker heartbeat stale and instance sb-1 is stopped',
       });
 
@@ -1399,7 +1393,7 @@ describe('finishCloudJob', () => {
       // the sanitized error stays on the run for debugging.
       expect(mockDbUpdateSet).toHaveBeenCalledWith(
         expect.objectContaining({
-          status: CloudTaskStatus.Canceled,
+          status: RunStatus.Canceled,
           canceledAt: expect.any(Date),
           completedAt: null,
           error: expect.stringContaining('Worker heartbeat stale'),
@@ -1432,7 +1426,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         error: 'spawn timeout',
       });
 
@@ -1440,7 +1434,7 @@ describe('finishCloudJob', () => {
       // completedAt stamped, and the failure notification goes out.
       expect(mockDbUpdateSet).toHaveBeenCalledWith(
         expect.objectContaining({
-          status: CloudTaskStatus.Failed,
+          status: RunStatus.Failed,
           canceledAt: null,
           completedAt: expect.any(Date),
         }),
@@ -1476,7 +1470,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         error: 'resume bootstrap timeout',
       });
 
@@ -1521,7 +1515,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         error: 'spawn timeout',
       });
 
@@ -1565,7 +1559,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         error: 'worker heartbeat stale',
       });
 
@@ -1616,7 +1610,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         error: 'spawn timeout',
       });
 
@@ -1635,7 +1629,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         error: 'some error',
       });
 
@@ -1661,7 +1655,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       });
 
       expect(mockPostMessage).not.toHaveBeenCalled();
@@ -1693,7 +1687,7 @@ describe('finishCloudJob', () => {
       // Should not throw
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         error: 'test error',
       });
     });
@@ -1720,7 +1714,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         error: 'spawn timeout',
       });
 
@@ -1743,7 +1737,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         error: 'spawn timeout',
       });
 
@@ -1751,7 +1745,7 @@ describe('finishCloudJob', () => {
       // The stop-normalized status is also persisted as canceled.
       expect(mockDbUpdateSet).toHaveBeenCalledWith(
         expect.objectContaining({
-          status: CloudTaskStatus.Canceled,
+          status: RunStatus.Canceled,
           canceledAt: expect.any(Date),
           completedAt: null,
         }),
@@ -1767,7 +1761,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         error: 'runtime crash',
       });
 
@@ -1786,7 +1780,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         error: 'some error',
       });
 
@@ -1799,7 +1793,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       });
 
       expect(mockTeamsPostMessage).not.toHaveBeenCalled();
@@ -1812,7 +1806,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         error: 'some error',
       });
 
@@ -1827,7 +1821,7 @@ describe('finishCloudJob', () => {
       // Should not throw
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         error: 'test error',
       });
     });
@@ -1867,7 +1861,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       });
 
       expect(mockCreateIssueComment).toHaveBeenCalledWith('github-token', {
@@ -1896,7 +1890,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       });
 
       expect(mockCreateIssueComment).toHaveBeenCalledWith('github-token', {
@@ -1919,7 +1913,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         error: 'Patch did not apply cleanly.',
       });
 
@@ -1946,7 +1940,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         error: 'Patch did not apply cleanly.',
       });
 
@@ -1966,7 +1960,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         error: 'Patch did not apply cleanly.',
       });
 
@@ -1974,7 +1968,7 @@ describe('finishCloudJob', () => {
       // The stop-normalized status is also persisted as canceled.
       expect(mockDbUpdateSet).toHaveBeenCalledWith(
         expect.objectContaining({
-          status: CloudTaskStatus.Canceled,
+          status: RunStatus.Canceled,
           canceledAt: expect.any(Date),
           completedAt: null,
         }),
@@ -1992,7 +1986,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         error: 'spawn failure',
       });
 
@@ -2018,7 +2012,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         error: 'spawn failure',
       });
 
@@ -2026,7 +2020,7 @@ describe('finishCloudJob', () => {
       // The stop-normalized status is also persisted as canceled.
       expect(mockDbUpdateSet).toHaveBeenCalledWith(
         expect.objectContaining({
-          status: CloudTaskStatus.Canceled,
+          status: RunStatus.Canceled,
           canceledAt: expect.any(Date),
           completedAt: null,
         }),
@@ -2039,7 +2033,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         error: 'some error',
       });
 
@@ -2052,7 +2046,7 @@ describe('finishCloudJob', () => {
 
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Completed,
+        status: RunStatus.Completed,
       });
 
       expect(mockEmitError).not.toHaveBeenCalled();
@@ -2069,7 +2063,7 @@ describe('finishCloudJob', () => {
       // Should not throw
       await finishCloudJob({
         id: 1,
-        status: CloudTaskStatus.Failed,
+        status: RunStatus.Failed,
         error: 'test error',
       });
     });

--- a/packages/sdk/src/server/lib/cloud-jobs/__tests__/finish-run.test.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/__tests__/finish-run.test.ts
@@ -152,7 +152,7 @@ const mockBuildTerminalReviewStatus = vi
 const mockFinalizeGithubPrReviewComment = vi.fn().mockResolvedValue(false);
 
 vi.mock('@roomote/cloud-agents/server', () => ({
-  enqueueCloudTask: vi.fn(),
+  enqueueTask: vi.fn(),
   releaseCloudTask: vi.fn().mockResolvedValue(undefined),
   getTaskUrl: vi.fn().mockReturnValue('https://example.com/task'),
   suggestSlackQuestionChannels: (...args: unknown[]) =>
@@ -239,9 +239,9 @@ vi.mock('../../sandbox-oidc', () => ({
     mockCleanupSandboxOidcTargetsForCloudJob(...args),
 }));
 
-import { finishCloudJob } from '../finish-cloud-job';
+import { finishRun } from '../finish-run';
 import { createCloudJobGitHubToken } from '@roomote/github';
-import { enqueueCloudTask } from '@roomote/cloud-agents/server';
+import { enqueueTask } from '@roomote/cloud-agents/server';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -300,7 +300,7 @@ function makeRun(
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 
-describe('finishCloudJob', () => {
+describe('finishRun', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     joinedSelectRows = [];
@@ -372,7 +372,7 @@ describe('finishCloudJob', () => {
   it('cleans up sandbox OIDC targets when a job reaches a terminal status', async () => {
     mockFindFirstRun.mockResolvedValue(makeRun());
 
-    await finishCloudJob({
+    await finishRun({
       id: 1,
       status: RunStatus.Completed,
     });
@@ -387,7 +387,7 @@ describe('finishCloudJob', () => {
       { id: 1, status: RunStatus.Completed, startedAt: new Date() },
     ];
 
-    await finishCloudJob({
+    await finishRun({
       id: 1,
       status: RunStatus.Completed,
     });
@@ -403,7 +403,7 @@ describe('finishCloudJob', () => {
     mockFindFirstRun.mockResolvedValue(makeRun());
     syncRunRows = [{ id: 1, status: RunStatus.Canceled, startedAt: null }];
 
-    await finishCloudJob({
+    await finishRun({
       id: 1,
       status: RunStatus.Canceled,
     });
@@ -419,7 +419,7 @@ describe('finishCloudJob', () => {
     mockFindFirstRun.mockResolvedValue(makeRun());
     syncRunRows = [{ id: 1, status: RunStatus.Failed, startedAt: new Date() }];
 
-    await finishCloudJob({
+    await finishRun({
       id: 1,
       status: RunStatus.Failed,
       error: 'boom',
@@ -437,7 +437,7 @@ describe('finishCloudJob', () => {
     // The idle run is non-terminal, so the derivation resolves to 'active'.
     syncRunRows = [{ id: 1, status: RunStatus.Idle, startedAt: new Date() }];
 
-    await finishCloudJob({
+    await finishRun({
       id: 1,
       status: RunStatus.Idle,
     });
@@ -463,7 +463,7 @@ describe('finishCloudJob', () => {
       { id: 2, status: RunStatus.Canceled, startedAt: null },
     ];
 
-    await finishCloudJob({
+    await finishRun({
       id: 2,
       status: RunStatus.Canceled,
     });
@@ -478,7 +478,7 @@ describe('finishCloudJob', () => {
   it('skips sandbox OIDC cleanup when a job transitions to idle', async () => {
     mockFindFirstRun.mockResolvedValue(makeRun());
 
-    await finishCloudJob({
+    await finishRun({
       id: 1,
       status: RunStatus.Idle,
     });
@@ -521,18 +521,18 @@ describe('finishCloudJob', () => {
     mockFindFirstRun
       .mockResolvedValueOnce(resumeRun)
       .mockResolvedValueOnce(resumeRun);
-    vi.mocked(enqueueCloudTask).mockResolvedValue({
+    vi.mocked(enqueueTask).mockResolvedValue({
       id: 444,
       taskId: 'fallback-task-444',
     } as never);
 
-    await finishCloudJob({
+    await finishRun({
       id: 303,
       status: RunStatus.Failed,
       error: 'snapshot resume failed',
     });
 
-    expect(enqueueCloudTask).toHaveBeenCalledWith({
+    expect(enqueueTask).toHaveBeenCalledWith({
       task: {
         type: TaskPayloadKind.GithubPrReviewFollowUp,
         payload: {
@@ -598,7 +598,7 @@ describe('finishCloudJob', () => {
     });
     mockFindFirstRun.mockResolvedValue(job);
 
-    await finishCloudJob({
+    await finishRun({
       id: 12,
       status: RunStatus.Failed,
       error: 'spawn timeout',
@@ -655,7 +655,7 @@ describe('finishCloudJob', () => {
         botAccessToken: 'xoxb-test',
       });
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Completed,
       });
@@ -689,7 +689,7 @@ describe('finishCloudJob', () => {
       });
       mockGetSlackStartedMessageTs.mockResolvedValue('111.333');
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Completed,
       });
@@ -731,7 +731,7 @@ describe('finishCloudJob', () => {
       });
       mockGetSlackStartedMessageTs.mockResolvedValue('111.333');
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Idle,
       });
@@ -772,7 +772,7 @@ describe('finishCloudJob', () => {
       });
       mockGetSlackStartedMessageTs.mockResolvedValue('111.333');
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Idle,
       });
@@ -806,7 +806,7 @@ describe('finishCloudJob', () => {
       });
       mockGetSlackStartedMessageTs.mockResolvedValue('111.333');
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Idle,
       });
@@ -840,7 +840,7 @@ describe('finishCloudJob', () => {
       });
       mockGetSlackStartedMessageTs.mockResolvedValue('111.333');
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Completed,
       });
@@ -896,7 +896,7 @@ describe('finishCloudJob', () => {
       });
       mockGetSlackStartedMessageTs.mockResolvedValue('111.333');
 
-      await finishCloudJob({
+      await finishRun({
         id: 2,
         status: RunStatus.Completed,
       });
@@ -952,7 +952,7 @@ describe('finishCloudJob', () => {
       });
       mockGetSlackStartedMessageTs.mockResolvedValue('111.333');
 
-      await finishCloudJob({
+      await finishRun({
         id: 2,
         status: RunStatus.Idle,
       });
@@ -1023,11 +1023,11 @@ describe('finishCloudJob', () => {
       mockGetSlackStartedMessageTs.mockResolvedValue('111.333');
       mockRedisSet.mockResolvedValueOnce('OK').mockResolvedValueOnce(null);
 
-      await finishCloudJob({
+      await finishRun({
         id: 2,
         status: RunStatus.Idle,
       });
-      await finishCloudJob({
+      await finishRun({
         id: 3,
         status: RunStatus.Idle,
       });
@@ -1094,7 +1094,7 @@ describe('finishCloudJob', () => {
         { id: 'CGENERAL', name: 'general' },
       ]);
 
-      await finishCloudJob({
+      await finishRun({
         id: 2,
         status: RunStatus.Completed,
       });
@@ -1139,7 +1139,7 @@ describe('finishCloudJob', () => {
         joinedChannels: [{ channelId: 'CJOINED' }],
       });
 
-      await finishCloudJob({
+      await finishRun({
         id: 2,
         status: RunStatus.Completed,
       });
@@ -1178,7 +1178,7 @@ describe('finishCloudJob', () => {
         updatedAt: new Date('2026-04-08T10:00:00.000Z'),
       });
 
-      await finishCloudJob({
+      await finishRun({
         id: 2,
         status: RunStatus.Completed,
       });
@@ -1194,7 +1194,7 @@ describe('finishCloudJob', () => {
       );
       mockFindFirstRun.mockResolvedValue(job);
 
-      await finishCloudJob({
+      await finishRun({
         id: 2,
         status: RunStatus.Completed,
       });
@@ -1214,7 +1214,7 @@ describe('finishCloudJob', () => {
         slackOnboardingStage: 'done',
       });
 
-      await finishCloudJob({
+      await finishRun({
         id: 2,
         status: RunStatus.Completed,
       });
@@ -1254,7 +1254,7 @@ describe('finishCloudJob', () => {
         },
       ];
 
-      await finishCloudJob({
+      await finishRun({
         id: 2,
         status: RunStatus.Completed,
       });
@@ -1294,7 +1294,7 @@ describe('finishCloudJob', () => {
       });
       mockRedisSet.mockResolvedValue(null);
 
-      await finishCloudJob({
+      await finishRun({
         id: 2,
         status: RunStatus.Completed,
       });
@@ -1327,7 +1327,7 @@ describe('finishCloudJob', () => {
         isActive: true,
       });
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Failed,
         error: 'spawn timeout',
@@ -1378,7 +1378,7 @@ describe('finishCloudJob', () => {
         isActive: true,
       });
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Failed,
         error: 'Worker heartbeat stale and instance sb-1 is stopped',
@@ -1424,7 +1424,7 @@ describe('finishCloudJob', () => {
         isActive: true,
       });
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Failed,
         error: 'spawn timeout',
@@ -1468,7 +1468,7 @@ describe('finishCloudJob', () => {
         isActive: true,
       });
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Failed,
         error: 'resume bootstrap timeout',
@@ -1513,7 +1513,7 @@ describe('finishCloudJob', () => {
         isActive: true,
       });
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Failed,
         error: 'spawn timeout',
@@ -1557,7 +1557,7 @@ describe('finishCloudJob', () => {
         isActive: true,
       });
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Failed,
         error: 'worker heartbeat stale',
@@ -1608,7 +1608,7 @@ describe('finishCloudJob', () => {
         isActive: true,
       });
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Failed,
         error: 'spawn timeout',
@@ -1627,7 +1627,7 @@ describe('finishCloudJob', () => {
       const job = makeRun({}, { slackThreadTs: null });
       mockFindFirstRun.mockResolvedValue(job);
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Failed,
         error: 'some error',
@@ -1653,7 +1653,7 @@ describe('finishCloudJob', () => {
       mockFindFirstRun.mockResolvedValue(job);
       mockFindFirstTask.mockResolvedValue(job.task);
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Completed,
       });
@@ -1685,7 +1685,7 @@ describe('finishCloudJob', () => {
       mockPostMessage.mockRejectedValue(new Error('Slack API error'));
 
       // Should not throw
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Failed,
         error: 'test error',
@@ -1712,7 +1712,7 @@ describe('finishCloudJob', () => {
       const job = makeRun({ payload: teamsPayload });
       mockFindFirstRun.mockResolvedValue(job);
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Failed,
         error: 'spawn timeout',
@@ -1735,7 +1735,7 @@ describe('finishCloudJob', () => {
       });
       mockFindFirstRun.mockResolvedValue(job);
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Failed,
         error: 'spawn timeout',
@@ -1759,7 +1759,7 @@ describe('finishCloudJob', () => {
       });
       mockFindFirstRun.mockResolvedValue(job);
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Failed,
         error: 'runtime crash',
@@ -1778,7 +1778,7 @@ describe('finishCloudJob', () => {
       const job = makeRun({ payload: { repo: 'owner/repo' } });
       mockFindFirstRun.mockResolvedValue(job);
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Failed,
         error: 'some error',
@@ -1791,7 +1791,7 @@ describe('finishCloudJob', () => {
       const job = makeRun({ payload: teamsPayload });
       mockFindFirstRun.mockResolvedValue(job);
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Completed,
       });
@@ -1804,7 +1804,7 @@ describe('finishCloudJob', () => {
       mockFindFirstRun.mockResolvedValue(job);
       mockCreateTeamsCommunicationProviderFromEnv.mockReturnValue(null);
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Failed,
         error: 'some error',
@@ -1819,7 +1819,7 @@ describe('finishCloudJob', () => {
       mockTeamsPostMessage.mockRejectedValue(new Error('Teams API error'));
 
       // Should not throw
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Failed,
         error: 'test error',
@@ -1859,7 +1859,7 @@ describe('finishCloudJob', () => {
       mockFindFirstRun.mockResolvedValue(job);
       mockFindManyTaskPullRequests.mockResolvedValue([conflictPrRow]);
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Completed,
       });
@@ -1888,7 +1888,7 @@ describe('finishCloudJob', () => {
       mockFindFirstRun.mockResolvedValue(job);
       mockFindManyTaskPullRequests.mockResolvedValue([conflictPrRow]);
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Completed,
       });
@@ -1911,7 +1911,7 @@ describe('finishCloudJob', () => {
       mockFindFirstRun.mockResolvedValue(job);
       mockFindManyTaskPullRequests.mockResolvedValue([conflictPrRow]);
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Failed,
         error: 'Patch did not apply cleanly.',
@@ -1938,7 +1938,7 @@ describe('finishCloudJob', () => {
       mockFindFirstRun.mockResolvedValue(job);
       mockFindManyTaskPullRequests.mockResolvedValue([]);
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Failed,
         error: 'Patch did not apply cleanly.',
@@ -1958,7 +1958,7 @@ describe('finishCloudJob', () => {
       mockFindFirstRun.mockResolvedValue(job);
       mockFindManyTaskPullRequests.mockResolvedValue([conflictPrRow]);
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Failed,
         error: 'Patch did not apply cleanly.',
@@ -1984,7 +1984,7 @@ describe('finishCloudJob', () => {
         id: 'linear-conn-1',
       });
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Failed,
         error: 'spawn failure',
@@ -2010,7 +2010,7 @@ describe('finishCloudJob', () => {
         id: 'linear-conn-1',
       });
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Failed,
         error: 'spawn failure',
@@ -2031,7 +2031,7 @@ describe('finishCloudJob', () => {
       const job = makeRun({}, { linearSessionId: null });
       mockFindFirstRun.mockResolvedValue(job);
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Failed,
         error: 'some error',
@@ -2044,7 +2044,7 @@ describe('finishCloudJob', () => {
       const job = makeRun({}, { linearSessionId: 'session-abc' });
       mockFindFirstRun.mockResolvedValue(job);
 
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Completed,
       });
@@ -2061,7 +2061,7 @@ describe('finishCloudJob', () => {
       mockEmitError.mockRejectedValue(new Error('Linear API error'));
 
       // Should not throw
-      await finishCloudJob({
+      await finishRun({
         id: 1,
         status: RunStatus.Failed,
         error: 'test error',

--- a/packages/sdk/src/server/lib/cloud-jobs/__tests__/pr-review-notification-delivery.test.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/__tests__/pr-review-notification-delivery.test.ts
@@ -72,7 +72,7 @@ vi.mock('@roomote/slack', () => ({
   setLatestSlackBotReply: mockSetLatestSlackBotReply,
 }));
 
-import type { CloudJob } from '@roomote/db/server';
+import type { Run } from '@roomote/db/server';
 import type { PrReviewActivityEvent } from '../pr-review-notification';
 
 import {
@@ -90,7 +90,7 @@ const request = {
   deferrals: 0,
 };
 
-const cloudJob = { id: 1, payload: {} } as unknown as CloudJob;
+const cloudJob = { id: 1, payload: {} } as unknown as Run;
 
 const events: PrReviewActivityEvent[] = [
   { kind: 'review', authorLogin: 'alice', reviewState: 'approved' },

--- a/packages/sdk/src/server/lib/cloud-jobs/__tests__/should-initialize-without-prompt.test.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/__tests__/should-initialize-without-prompt.test.ts
@@ -1,7 +1,7 @@
 import { TaskPayloadKind, standardTaskSchema } from '@roomote/types';
 import { shouldInitializeWithoutPrompt } from '../dequeue-cloud-job';
 
-// Minimal shared fields required by all CloudTask variants.
+// Minimal shared fields required by all TaskSpec variants.
 const sharedFields = {
   userId: 'user_123',
 };

--- a/packages/sdk/src/server/lib/cloud-jobs/__tests__/slack-pr-inactivity-enqueue.test.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/__tests__/slack-pr-inactivity-enqueue.test.ts
@@ -1,5 +1,5 @@
 import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
-import type { CloudJob } from '@roomote/db/server';
+import type { Run } from '@roomote/db/server';
 
 const mockFindFirstCloudJob = vi.fn();
 const mockFindFirstTaskPullRequest = vi.fn();
@@ -66,7 +66,7 @@ import {
   SLACK_PR_INACTIVITY_DELAY_MS,
 } from '../slack-pr-inactivity-check';
 
-type RunWithTask = CloudJob & { task: Record<string, unknown> };
+type RunWithTask = Run & { task: Record<string, unknown> };
 
 function makeCloudJob(overrides: Partial<RunWithTask> = {}): RunWithTask {
   return {

--- a/packages/sdk/src/server/lib/cloud-jobs/__tests__/slack-pr-inactivity-enqueue.test.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/__tests__/slack-pr-inactivity-enqueue.test.ts
@@ -1,4 +1,4 @@
-import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
 import type { Run } from '@roomote/db/server';
 
 const mockFindFirstCloudJob = vi.fn();
@@ -75,7 +75,7 @@ function makeCloudJob(overrides: Partial<RunWithTask> = {}): RunWithTask {
     payloadKind: TaskPayloadKind.SlackAppMention,
     actingUserId: 'user-1',
     harness: 'opencode-server',
-    status: CloudTaskStatus.Completed,
+    status: RunStatus.Completed,
     payload: {
       channel: 'C123',
       repo: 'owner/repo',

--- a/packages/sdk/src/server/lib/cloud-jobs/__tests__/update-runtime-state.test.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/__tests__/update-runtime-state.test.ts
@@ -1,4 +1,4 @@
-import { CloudTaskStatus } from '@roomote/types';
+import { RunStatus } from '@roomote/types';
 
 const mockFindFirstCloudJob = vi.fn();
 const mockDbUpdateWhere = vi.fn().mockResolvedValue(undefined);
@@ -37,7 +37,7 @@ describe('updateCloudJobRuntimeState', () => {
 
   it('applies newer runtime-state deadlines', async () => {
     mockFindFirstCloudJob.mockResolvedValue({
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       sleepAt: new Date('2026-03-20T06:14:38.766Z'),
     });
@@ -59,7 +59,7 @@ describe('updateCloudJobRuntimeState', () => {
 
   it('returns updated false when an older runtime-state write is ignored', async () => {
     mockFindFirstCloudJob.mockResolvedValue({
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'running',
       sleepAt: new Date('2026-03-20T06:18:08.000Z'),
     });
@@ -74,7 +74,7 @@ describe('updateCloudJobRuntimeState', () => {
 
   it('applies phase transitions even when the next deadline is shorter', async () => {
     mockFindFirstCloudJob.mockResolvedValue({
-      status: CloudTaskStatus.Idle,
+      status: RunStatus.Idle,
       taskPhase: 'waiting_for_prompt',
       sleepAt: new Date('2026-03-20T06:18:08.000Z'),
     });
@@ -96,7 +96,7 @@ describe('updateCloudJobRuntimeState', () => {
 
   it('still applies immediate shutdown transitions even though they shorten the deadline', async () => {
     mockFindFirstCloudJob.mockResolvedValue({
-      status: CloudTaskStatus.Running,
+      status: RunStatus.Running,
       taskPhase: 'waiting_for_prompt',
       sleepAt: new Date('2026-03-20T06:18:08.000Z'),
     });

--- a/packages/sdk/src/server/lib/cloud-jobs/dequeue-cloud-job.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/dequeue-cloud-job.ts
@@ -8,7 +8,7 @@ import {
   resolveSourceControlProviderFromPayload,
 } from '@roomote/types';
 import {
-  type CloudJob,
+  type Run,
   type Task,
   db,
   taskRuns,
@@ -71,11 +71,11 @@ export function buildDequeuedTaskContext(task: Task): DequeuedTaskContext {
 type DequeueResult =
   | {
       error: true;
-      cloudJob?: CloudJob;
+      cloudJob?: Run;
     }
   | {
       error: false;
-      cloudJob: CloudJob;
+      cloudJob: Run;
       task: DequeuedTaskContext;
       requestedWorkKind: RequestedWorkKind;
       gitHubToken: string;
@@ -119,7 +119,7 @@ export function shouldInitializeWithoutPrompt(cloudTask: CloudTask): boolean {
  * discriminated union re-keys on `type`, which is stored as
  * `task_runs.payload_kind`.
  */
-function buildCloudTaskCandidate(run: CloudJob): Record<string, unknown> {
+function buildCloudTaskCandidate(run: Run): Record<string, unknown> {
   return {
     type: run.payloadKind,
     harness: run.harness,
@@ -218,7 +218,7 @@ async function recordBootstrapPhase<T>(input: {
  */
 async function persistGithubPrReviewCommentId(
   taskId: string,
-  payload: CloudJob['payload'],
+  payload: Run['payload'],
   commentId: number,
 ): Promise<void> {
   const repository =
@@ -256,7 +256,7 @@ export const dequeueCloudJob = async (
   {
     onBootstrapFailure,
   }: {
-    onBootstrapFailure?: (error: Error, cloudJob: CloudJob) => void;
+    onBootstrapFailure?: (error: Error, cloudJob: Run) => void;
   } = {},
 ) => {
   try {
@@ -266,10 +266,10 @@ export const dequeueCloudJob = async (
     const tag = '[dequeueCloudJob]';
 
     type TransactionResult =
-      | { error: true; cloudJob?: CloudJob }
+      | { error: true; cloudJob?: Run }
       | {
           error: false;
-          cloudJob: CloudJob;
+          cloudJob: Run;
           task: Task;
           cloudTask: CloudTask;
           envVars: Record<string, string>;
@@ -288,7 +288,7 @@ export const dequeueCloudJob = async (
       // 2. SKIP LOCKED means if another transaction has already locked a row, skip it.
       // 3. The UPDATE then modifies only that specific locked row.
       // 4. This ensures only ONE worker can claim each run, even with concurrent requests.
-      const [dequeued] = await tx.execute<Pick<CloudJob, 'id'>>(query);
+      const [dequeued] = await tx.execute<Pick<Run, 'id'>>(query);
 
       const cloudJob = dequeued
         ? await tx.query.taskRuns.findFirst({

--- a/packages/sdk/src/server/lib/cloud-jobs/dequeue-cloud-job.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/dequeue-cloud-job.ts
@@ -1,10 +1,10 @@
 import {
-  type CloudTask,
+  type TaskSpec,
   type AuthTokenContext,
   type JobTokenContext,
   type RequestedWorkKind,
-  CloudTaskStatus,
-  cloudTaskSchema,
+  RunStatus,
+  taskSpecSchema,
   resolveSourceControlProviderFromPayload,
 } from '@roomote/types';
 import {
@@ -90,7 +90,7 @@ type DequeueResult =
       artifacts: Record<string, unknown>;
     };
 
-export function shouldInitializeWithoutPrompt(cloudTask: CloudTask): boolean {
+export function shouldInitializeWithoutPrompt(cloudTask: TaskSpec): boolean {
   if (
     'description' in cloudTask.payload &&
     typeof cloudTask.payload.description === 'string' &&
@@ -115,7 +115,7 @@ export function shouldInitializeWithoutPrompt(cloudTask: CloudTask): boolean {
 }
 
 /**
- * Builds the CloudTask candidate for schema validation from a run row. The
+ * Builds the TaskSpec candidate for schema validation from a run row. The
  * discriminated union re-keys on `type`, which is stored as
  * `task_runs.payload_kind`.
  */
@@ -271,7 +271,7 @@ export const dequeueCloudJob = async (
           error: false;
           cloudJob: Run;
           task: Task;
-          cloudTask: CloudTask;
+          cloudTask: TaskSpec;
           envVars: Record<string, string>;
           orgAgentInstructions?: string;
           styleGuidance?: string;
@@ -318,13 +318,13 @@ export const dequeueCloudJob = async (
         },
       });
 
-      const parsed = cloudTaskSchema.safeParse(
+      const parsed = taskSpecSchema.safeParse(
         buildCloudTaskCandidate(cloudJob),
       );
 
       if (!parsed.success) {
         console.error(
-          `${tag} cloudTaskSchema.safeParse failed: ${parsed.error.message} -> ${JSON.stringify(cloudJob)}`,
+          `${tag} taskSpecSchema.safeParse failed: ${parsed.error.message} -> ${JSON.stringify(cloudJob)}`,
         );
 
         reportBootstrapFailure({
@@ -364,7 +364,7 @@ export const dequeueCloudJob = async (
           'Worker claimed dequeued cloud job and started execution bootstrap.',
         details: {
           stage: 'worker_bootstrap',
-          status: CloudTaskStatus.Processing,
+          status: RunStatus.Processing,
           vendor: cloudJob.vendor ?? null,
           machineId: cloudJob.machineId ?? null,
           sourceSnapshotId: cloudJob.sourceSnapshotId ?? null,

--- a/packages/sdk/src/server/lib/cloud-jobs/dequeue-helpers.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/dequeue-helpers.ts
@@ -1,9 +1,9 @@
 import {
   CONTROL_PLANE_ENV_VAR_NAMES,
-  CloudTaskStatus,
+  RunStatus,
   buildSourceControlTokenMetadata,
   getSourceControlProviderLabel,
-  resolveCloudTaskWorkspace,
+  resolveTaskWorkspace,
   resolveSourceControlProviderFromPayload,
   type SourceControlProvider,
   type SourceControlTokenMetadata,
@@ -108,9 +108,9 @@ export function redactSourceControlProviderEnvVars(
  */
 export function claimJobById(cloudJobId: number) {
   return sql`
-    UPDATE task_runs SET status = ${CloudTaskStatus.Processing} WHERE id = (
+    UPDATE task_runs SET status = ${RunStatus.Processing} WHERE id = (
       SELECT id FROM task_runs
-      WHERE id = ${cloudJobId} AND status = ${CloudTaskStatus.Dequeued}
+      WHERE id = ${cloudJobId} AND status = ${RunStatus.Dequeued}
       FOR UPDATE SKIP LOCKED
     )
     RETURNING id
@@ -214,7 +214,7 @@ export async function cancelAndReleaseCloudJob(
     await tx
       .update(taskRuns)
       .set({
-        status: CloudTaskStatus.Canceled,
+        status: RunStatus.Canceled,
         canceledAt: endedAt,
         error: errorMessage,
       })
@@ -276,7 +276,7 @@ async function resolveJobSourceControlProvider(
   // shared resolver (covers every workspace shape). It returns undefined when
   // the provider is ambiguous or unknown, in which case fall back to the
   // GitHub default that resolveSourceControlProviderFromPayload applies.
-  const workspace = resolveCloudTaskWorkspace(cloudJob.payload);
+  const workspace = resolveTaskWorkspace(cloudJob.payload);
   const resolvedProvider = await resolveWorkspaceSourceControlProvider(
     db,
     workspace,
@@ -421,7 +421,7 @@ export async function cancelCloudJob(
   await tx
     .update(taskRuns)
     .set({
-      status: CloudTaskStatus.Canceled,
+      status: RunStatus.Canceled,
       canceledAt: endedAt,
       error,
       ...(artifacts ? { artifacts } : {}),

--- a/packages/sdk/src/server/lib/cloud-jobs/dequeue-helpers.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/dequeue-helpers.ts
@@ -9,7 +9,7 @@ import {
   type SourceControlTokenMetadata,
 } from '@roomote/types';
 import {
-  type CloudJob,
+  type Run,
   db,
   taskRuns,
   tasks,
@@ -204,7 +204,7 @@ async function loadPersistedDeploymentEnvVarsFromDb(): Promise<
  * Cancels a cloud job with an error message and releases its cloud task lock.
  */
 export async function cancelAndReleaseCloudJob(
-  cloudJob: CloudJob,
+  cloudJob: Run,
   errorMessage: string,
   logPrefix: string,
 ): Promise<void> {
@@ -260,7 +260,7 @@ export type SourceControlRuntimeToken = SourceControlTokenMetadata & {
  * when the workspace repositories are unknown or span providers.
  */
 async function resolveJobSourceControlProvider(
-  cloudJob: Pick<CloudJob, 'payload'>,
+  cloudJob: Pick<Run, 'payload'>,
 ): Promise<SourceControlProvider> {
   const payload = cloudJob.payload as { sourceControlProvider?: unknown };
 
@@ -290,7 +290,7 @@ async function resolveJobSourceControlProvider(
 }
 
 async function createProviderToken(
-  cloudJob: CloudJob,
+  cloudJob: Run,
 ): Promise<SourceControlRuntimeToken> {
   const provider = await resolveJobSourceControlProvider(cloudJob);
 
@@ -365,7 +365,7 @@ async function createProviderToken(
  * Returns null if all attempts fail (caller should handle the error).
  */
 export async function createSourceControlTokenForJob(
-  cloudJob: CloudJob,
+  cloudJob: Run,
   logPrefix: string,
   {
     maxRetries = SOURCE_CONTROL_TOKEN_MAX_RETRIES,
@@ -407,7 +407,7 @@ export async function cancelCloudJob(
   error: string,
   options?: {
     bootstrapFailureReason?: string;
-    existingArtifacts?: CloudJob['artifacts'];
+    existingArtifacts?: Run['artifacts'];
   },
 ): Promise<void> {
   const artifacts = options?.bootstrapFailureReason
@@ -457,9 +457,9 @@ export function reportBootstrapFailure({
   cloudJob,
   logPrefix,
 }: {
-  callback?: (error: Error, cloudJob: CloudJob) => void;
+  callback?: (error: Error, cloudJob: Run) => void;
   error: Error;
-  cloudJob: CloudJob;
+  cloudJob: Run;
   logPrefix: string;
 }): void {
   try {
@@ -477,7 +477,7 @@ export function reportBootstrapFailure({
 
 export async function resolveGitAuthor(
   tx: DbTx,
-  cloudJob: Pick<CloudJob, 'id' | 'taskId'>,
+  cloudJob: Pick<Run, 'id' | 'taskId'>,
 ): Promise<GitAuthor> {
   const task = await tx.query.tasks.findFirst({
     where: eq(tasks.id, cloudJob.taskId),

--- a/packages/sdk/src/server/lib/cloud-jobs/dequeue-helpers.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/dequeue-helpers.ts
@@ -220,7 +220,7 @@ export async function cancelAndReleaseCloudJob(
       })
       .where(eq(taskRuns.id, cloudJob.id));
 
-    // Derive the owning task's state from all its runs. finishCloudJob never
+    // Derive the owning task's state from all its runs. finishRun never
     // runs for runs canceled before/at dequeue, so without this sync the task
     // would stay 'active' forever. The shared helper deprioritizes this
     // never-started cancel, so an earlier completed sibling still wins.
@@ -429,7 +429,7 @@ export async function cancelCloudJob(
     .where(eq(taskRuns.id, cloudJobId));
 
   // Derive the owning task's state from all its runs. This runs on the dequeue
-  // path (invalid job, bootstrap failure) where finishCloudJob never executes,
+  // path (invalid job, bootstrap failure) where finishRun never executes,
   // so the task must be resolved here or it stays 'active' forever. The caller
   // only has the run id, so resolve the task via the run row, then sync.
   const [runRow] = await tx

--- a/packages/sdk/src/server/lib/cloud-jobs/dequeue-resume-cloud-job.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/dequeue-resume-cloud-job.ts
@@ -8,7 +8,7 @@ import {
   resolveSourceControlProviderFromPayload,
 } from '@roomote/types';
 import {
-  type CloudJob,
+  type Run,
   type Task,
   db,
   taskRuns,
@@ -40,7 +40,7 @@ import { resolveSlackJobRouting } from './slack-job-routing';
 type DequeueResumeCloudJobResult =
   | undefined
   | {
-      cloudJob: CloudJob;
+      cloudJob: Run;
       task: DequeuedTaskContext;
       requestedWorkKind: RequestedWorkKind;
       gitHubToken: string;
@@ -100,7 +100,7 @@ export const dequeueResumeCloudJob = async (
   {
     onBootstrapFailure,
   }: {
-    onBootstrapFailure?: (error: Error, cloudJob: CloudJob) => void;
+    onBootstrapFailure?: (error: Error, cloudJob: Run) => void;
   } = {},
 ): Promise<DequeueResumeCloudJobResult> => {
   const tag = '[dequeueResumeCloudJob]';
@@ -119,12 +119,12 @@ export const dequeueResumeCloudJob = async (
     type TransactionResult =
       | {
           error: true;
-          cloudJob?: CloudJob;
+          cloudJob?: Run;
           bootstrapFailureEvent?: SnapshotResumeBootstrapEvent;
         }
       | {
           error: false;
-          cloudJob: CloudJob;
+          cloudJob: Run;
           task: Task;
           envVars: Record<string, string>;
           orgAgentInstructions?: string;
@@ -137,7 +137,7 @@ export const dequeueResumeCloudJob = async (
         };
 
     const result: TransactionResult = await db.transaction(async (tx) => {
-      const [dequeued] = await tx.execute<Pick<CloudJob, 'id'>>(query);
+      const [dequeued] = await tx.execute<Pick<Run, 'id'>>(query);
 
       const cloudJob = dequeued
         ? await tx.query.taskRuns.findFirst({

--- a/packages/sdk/src/server/lib/cloud-jobs/dequeue-resume-cloud-job.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/dequeue-resume-cloud-job.ts
@@ -1,9 +1,9 @@
 import {
   type AuthTokenContext,
   type JobTokenContext,
-  type CloudTaskPayload,
+  type TaskPayload,
   type RequestedWorkKind,
-  CloudTaskStatus,
+  RunStatus,
   TaskPayloadKind,
   resolveSourceControlProviderFromPayload,
 } from '@roomote/types';
@@ -188,7 +188,7 @@ export const dequeueResumeCloudJob = async (
         return { error: true, cloudJob, bootstrapFailureEvent };
       }
 
-      const resumePayload = cloudJob.payload as CloudTaskPayload<
+      const resumePayload = cloudJob.payload as TaskPayload<
         typeof TaskPayloadKind.SnapshotResume
       >;
       const sourceRunId =
@@ -312,7 +312,7 @@ export const dequeueResumeCloudJob = async (
           'Worker claimed dequeued snapshot-resume job and started resume bootstrap.',
         details: {
           stage: 'worker_bootstrap',
-          status: CloudTaskStatus.Processing,
+          status: RunStatus.Processing,
           vendor: cloudJob.vendor ?? null,
           machineId: cloudJob.machineId ?? null,
           sourceSnapshotId: cloudJob.sourceSnapshotId ?? null,

--- a/packages/sdk/src/server/lib/cloud-jobs/ensure-snapshot-resume-github-follow-up-fallback.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/ensure-snapshot-resume-github-follow-up-fallback.ts
@@ -1,4 +1,4 @@
-import { enqueueCloudTask } from '@roomote/cloud-agents/server';
+import { enqueueTask } from '@roomote/cloud-agents/server';
 import { db, eq, sql, taskRuns } from '@roomote/db/server';
 import {
   TaskPayloadKind,
@@ -144,7 +144,7 @@ export async function ensureSnapshotResumeGitHubFollowUpFallback({
       typeof TaskPayloadKind.GithubPrReviewFollowUp
     >;
 
-    const fallbackLaunch = await enqueueCloudTask({
+    const fallbackLaunch = await enqueueTask({
       task: {
         type: TaskPayloadKind.GithubPrReviewFollowUp,
         payload: fallbackPayload,

--- a/packages/sdk/src/server/lib/cloud-jobs/ensure-snapshot-resume-github-follow-up-fallback.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/ensure-snapshot-resume-github-follow-up-fallback.ts
@@ -2,7 +2,7 @@ import { enqueueCloudTask } from '@roomote/cloud-agents/server';
 import { db, eq, sql, taskRuns } from '@roomote/db/server';
 import {
   TaskPayloadKind,
-  type CloudTaskPayload,
+  type TaskPayload,
   type SnapshotResumePromptFallbackTask,
   type TaskInitiator,
 } from '@roomote/types';
@@ -140,7 +140,7 @@ export async function ensureSnapshotResumeGitHubFollowUpFallback({
       return null;
     }
 
-    const fallbackPayload = fallbackTask.payload as CloudTaskPayload<
+    const fallbackPayload = fallbackTask.payload as TaskPayload<
       typeof TaskPayloadKind.GithubPrReviewFollowUp
     >;
 

--- a/packages/sdk/src/server/lib/cloud-jobs/extract-pull-requests.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/extract-pull-requests.ts
@@ -6,7 +6,7 @@ import {
   eq,
   repositories,
 } from '@roomote/db/server';
-import type { CloudJob } from '@roomote/db/server';
+import type { Run } from '@roomote/db/server';
 import { createCloudJobGitHubToken, getOctokit } from '@roomote/github';
 import type { PullRequestStatus } from '@roomote/types';
 import type { ParsedPR } from '../../../pull-request-links';
@@ -28,7 +28,7 @@ export {
  * association as cloud-job PR metadata.
  */
 async function fetchPrDetails(
-  cloudJob: CloudJob,
+  cloudJob: Run,
   owner: string,
   repo: string,
   prNumber: number,

--- a/packages/sdk/src/server/lib/cloud-jobs/finish-cloud-job.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/finish-cloud-job.ts
@@ -18,7 +18,7 @@ import {
 } from '@roomote/communication/chat-messages';
 import { createTeamsCommunicationProviderFromRuntimeCredentials } from '../teams-communication';
 import {
-  type CloudJob,
+  type Run,
   type Task,
   type TaskPullRequest,
   db,
@@ -86,7 +86,7 @@ const DEFAULT_DEPLOYMENT_ID = 'default';
  * read conversation cargo (channel bindings, requestedWorkKind, initiator)
  * from `task` and attempt-scoped state from the run row.
  */
-type FinishedRun = CloudJob & { task: Task };
+type FinishedRun = Run & { task: Task };
 
 export const finishCloudJob = async ({
   id,
@@ -550,7 +550,7 @@ async function cleanupGithubPrReviewArtifacts(
   }
 }
 
-function getRuntimeTaskId(job: CloudJob): string | null {
+function getRuntimeTaskId(job: Run): string | null {
   if (
     !job.result ||
     typeof job.result !== 'object' ||
@@ -564,7 +564,7 @@ function getRuntimeTaskId(job: CloudJob): string | null {
   return typeof result.runtimeTaskId === 'string' ? result.runtimeTaskId : null;
 }
 
-function hasReachedTaskRuntime(job: CloudJob): boolean {
+function hasReachedTaskRuntime(job: Run): boolean {
   return (
     getRuntimeTaskId(job) !== null ||
     job.runtimeTaskStartedAt != null ||

--- a/packages/sdk/src/server/lib/cloud-jobs/finish-cloud-job.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/finish-cloud-job.ts
@@ -1,7 +1,7 @@
 import {
   ALL_REPOSITORIES,
   TaskPayloadKind,
-  CloudTaskStatus,
+  RunStatus,
   getCommunicationChannelFromTaskPayload,
   getCommunicationMessageIdFromTaskPayload,
   getCommunicationProviderFromTaskPayload,
@@ -9,7 +9,7 @@ import {
   getCommunicationThreadIdFromTaskPayload,
   getEnvironmentDefinitionIdFromPayload,
   parseConflictResolutionSummary,
-  stripCloudJobErrorMarkers,
+  stripRunErrorMarkers,
 } from '@roomote/types';
 import {
   formatMarkdownLink,
@@ -95,10 +95,10 @@ export const finishCloudJob = async ({
 }: {
   id: number;
   status:
-    | CloudTaskStatus.Completed
-    | CloudTaskStatus.Failed
-    | CloudTaskStatus.Canceled
-    | CloudTaskStatus.Idle;
+    | RunStatus.Completed
+    | RunStatus.Failed
+    | RunStatus.Canceled
+    | RunStatus.Idle;
   error?: string;
 }) => {
   const job = await db.query.taskRuns.findFirst({
@@ -120,11 +120,11 @@ export const finishCloudJob = async ({
   // task history, analytics, and unfurls), the lifecycle event, notifications,
   // and GitHub-facing outcomes all see Canceled. The sanitized error is still
   // written to the run's `error` column below for debugging.
-  if (status === CloudTaskStatus.Failed && job.cancelRequestedAt != null) {
+  if (status === RunStatus.Failed && job.cancelRequestedAt != null) {
     console.log(
       `[finishCloudJob] Persisting the failed finalization of job ${id} as canceled: a stop was requested at ${job.cancelRequestedAt.toISOString()}`,
     );
-    status = CloudTaskStatus.Canceled;
+    status = RunStatus.Canceled;
   }
 
   try {
@@ -138,7 +138,7 @@ export const finishCloudJob = async ({
   }
 
   const { payloadKind } = job;
-  const sanitizedError = stripCloudJobErrorMarkers(error);
+  const sanitizedError = stripRunErrorMarkers(error);
 
   const now = new Date();
   const existingResult =
@@ -150,17 +150,17 @@ export const finishCloudJob = async ({
       ? existingResult.runtimeTaskId
       : null;
   const lifecycleEvent =
-    status === CloudTaskStatus.Completed
+    status === RunStatus.Completed
       ? {
           eventType: 'completed' as const,
           message: 'Cloud job finished successfully.',
         }
-      : status === CloudTaskStatus.Failed
+      : status === RunStatus.Failed
         ? {
             eventType: 'failed' as const,
             message: 'Cloud job finished with a failure.',
           }
-        : status === CloudTaskStatus.Canceled
+        : status === RunStatus.Canceled
           ? {
               eventType: 'decision' as const,
               message: 'Cloud job was canceled.',
@@ -176,11 +176,11 @@ export const finishCloudJob = async ({
       .update(taskRuns)
       .set({
         status,
-        taskPhase: status === CloudTaskStatus.Idle ? job.taskPhase : null,
-        sleepAt: status === CloudTaskStatus.Idle ? job.sleepAt : null,
+        taskPhase: status === RunStatus.Idle ? job.taskPhase : null,
+        sleepAt: status === RunStatus.Idle ? job.sleepAt : null,
         error: sanitizedError,
-        canceledAt: status === CloudTaskStatus.Canceled ? now : job.canceledAt,
-        completedAt: status === CloudTaskStatus.Canceled ? null : now,
+        canceledAt: status === RunStatus.Canceled ? now : job.canceledAt,
+        completedAt: status === RunStatus.Canceled ? null : now,
       })
       .where(eq(taskRuns.id, id));
 
@@ -219,9 +219,8 @@ export const finishCloudJob = async ({
           job.snapshotRequestedAt?.toISOString() ?? null,
         previousSnapshotCreatedAt: job.snapshotCreatedAt?.toISOString() ?? null,
         previousWorkerHeartbeatAt: job.workerHeartbeatAt?.toISOString() ?? null,
-        sleepAt:
-          status === CloudTaskStatus.Idle ? job.sleepAt?.toISOString() : null,
-        taskPhase: status === CloudTaskStatus.Idle ? job.taskPhase : null,
+        sleepAt: status === RunStatus.Idle ? job.sleepAt?.toISOString() : null,
+        taskPhase: status === RunStatus.Idle ? job.taskPhase : null,
         error: sanitizedError ?? null,
       },
       createdAt: now,
@@ -230,7 +229,7 @@ export const finishCloudJob = async ({
 
   // Anonymous analytics (no-op unless enabled): terminal task outcome with
   // non-identifying routing facts only.
-  if (status === CloudTaskStatus.Completed) {
+  if (status === RunStatus.Completed) {
     void captureEvent('task_completed', {
       ...(job.actingUserId ? { userId: job.actingUserId } : {}),
       properties: {
@@ -241,10 +240,7 @@ export const finishCloudJob = async ({
     });
   }
 
-  if (
-    status === CloudTaskStatus.Completed ||
-    status === CloudTaskStatus.Failed
-  ) {
+  if (status === RunStatus.Completed || status === RunStatus.Failed) {
     try {
       await refreshTaskTitleOnCompletion({
         taskId: job.taskId,
@@ -259,7 +255,7 @@ export const finishCloudJob = async ({
     }
   }
 
-  if (status !== CloudTaskStatus.Idle) {
+  if (status !== RunStatus.Idle) {
     try {
       await cleanupSandboxOidcTargetsForCloudJob(id);
     } catch (error) {
@@ -271,7 +267,7 @@ export const finishCloudJob = async ({
     }
   }
 
-  if (status !== CloudTaskStatus.Idle) {
+  if (status !== RunStatus.Idle) {
     try {
       await revokeCloudJobScopedGitLabTokens(job);
     } catch (error) {
@@ -303,7 +299,7 @@ export const finishCloudJob = async ({
 
   // Slack failure notification: post a thread reply when the job failed and
   // was triggered from Slack (the task carries a Slack thread binding).
-  if (status === CloudTaskStatus.Failed && task.slackThreadTs) {
+  if (status === RunStatus.Failed && task.slackThreadTs) {
     try {
       await sendSlackFailureNotification(job, sanitizedError);
     } catch (err) {
@@ -318,7 +314,7 @@ export const finishCloudJob = async ({
   // Teams failure notification: post a thread reply when the job failed and
   // was triggered from Teams (payload carries Teams communication metadata).
   if (
-    status === CloudTaskStatus.Failed &&
+    status === RunStatus.Failed &&
     !task.slackThreadTs &&
     getCommunicationProviderFromTaskPayload(job.payload) === 'teams'
   ) {
@@ -334,12 +330,12 @@ export const finishCloudJob = async ({
   }
 
   const linkedEnvironmentDefinitionId =
-    status === CloudTaskStatus.Idle && job.taskPhase === 'waiting_for_prompt'
+    status === RunStatus.Idle && job.taskPhase === 'waiting_for_prompt'
       ? await resolveSetupCompletionEnvironmentDefinitionId(job)
       : null;
 
   if (
-    (status === CloudTaskStatus.Completed ||
+    (status === RunStatus.Completed ||
       linkedEnvironmentDefinitionId !== null) &&
     (payloadKind === TaskPayloadKind.SlackAppMention ||
       payloadKind === TaskPayloadKind.SnapshotResume)
@@ -355,7 +351,7 @@ export const finishCloudJob = async ({
     }
   }
 
-  if (status === CloudTaskStatus.Completed) {
+  if (status === RunStatus.Completed) {
     try {
       await maybeSendSlackQuestionChannelInvite(job);
     } catch (err) {
@@ -369,7 +365,7 @@ export const finishCloudJob = async ({
 
   // Linear failure notification: emit an error activity when the job failed
   // and was triggered from Linear (the task carries a Linear session binding).
-  if (status === CloudTaskStatus.Failed && task.linearSessionId) {
+  if (status === RunStatus.Failed && task.linearSessionId) {
     try {
       await sendLinearFailureNotification(job, sanitizedError);
     } catch (err) {
@@ -384,7 +380,7 @@ export const finishCloudJob = async ({
   // GitHub PR conflict resolution comment
   if (
     task.workflow === 'pr_conflict_resolve' &&
-    (status === CloudTaskStatus.Completed || status === CloudTaskStatus.Failed)
+    (status === RunStatus.Completed || status === RunStatus.Failed)
   ) {
     try {
       await postConflictResolutionComment(job, status, sanitizedError);
@@ -417,10 +413,10 @@ async function findTaskPullRequests(
 async function cleanupGithubPrReviewArtifacts(
   job: FinishedRun,
   status:
-    | CloudTaskStatus.Completed
-    | CloudTaskStatus.Failed
-    | CloudTaskStatus.Canceled
-    | CloudTaskStatus.Idle,
+    | RunStatus.Completed
+    | RunStatus.Failed
+    | RunStatus.Canceled
+    | RunStatus.Idle,
 ): Promise<void> {
   let prRows: TaskPullRequest[];
 
@@ -502,15 +498,15 @@ async function cleanupGithubPrReviewArtifacts(
     // ensures the comment reflects the terminal job outcome without clobbering
     // a real agent completion (it only patches comments still showing an
     // in-progress status line).
-    if (status !== CloudTaskStatus.Idle) {
+    if (status !== RunStatus.Idle) {
       try {
         const token = await createCloudJobGitHubToken(job);
         // A user-stopped run arrives here already normalized to Canceled (see
         // finishCloudJob), so the review outcome maps naturally.
         const outcome =
-          status === CloudTaskStatus.Completed
+          status === RunStatus.Completed
             ? 'completed'
-            : status === CloudTaskStatus.Failed
+            : status === RunStatus.Failed
               ? 'failed'
               : 'canceled';
         const terminalStatus = buildTerminalReviewStatus({
@@ -905,7 +901,7 @@ async function maybeSendSlackQuestionChannelInvite(
       and(
         eq(tasks.initiatorUserId, invitedUserId),
         eq(tasks.state, 'completed'),
-        eq(taskRuns.status, CloudTaskStatus.Completed),
+        eq(taskRuns.status, RunStatus.Completed),
         isNotNull(taskRuns.completedAt),
       ),
     );
@@ -1223,7 +1219,7 @@ async function sendLinearFailureNotification(
 
 async function postConflictResolutionComment(
   job: FinishedRun,
-  status: CloudTaskStatus.Completed | CloudTaskStatus.Failed,
+  status: RunStatus.Completed | RunStatus.Failed,
   error?: string,
 ): Promise<void> {
   const prRows = await findTaskPullRequests(job.taskId);
@@ -1266,7 +1262,7 @@ async function postConflictResolutionComment(
       ? parseConflictResolutionSummary(fallbackCompletionText)
       : null);
 
-  if (status === CloudTaskStatus.Completed) {
+  if (status === RunStatus.Completed) {
     await createIssueComment(token, {
       owner,
       repo,

--- a/packages/sdk/src/server/lib/cloud-jobs/finish-run.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/finish-run.ts
@@ -88,7 +88,7 @@ const DEFAULT_DEPLOYMENT_ID = 'default';
  */
 type FinishedRun = Run & { task: Task };
 
-export const finishCloudJob = async ({
+export const finishRun = async ({
   id,
   status,
   error,
@@ -122,7 +122,7 @@ export const finishCloudJob = async ({
   // written to the run's `error` column below for debugging.
   if (status === RunStatus.Failed && job.cancelRequestedAt != null) {
     console.log(
-      `[finishCloudJob] Persisting the failed finalization of job ${id} as canceled: a stop was requested at ${job.cancelRequestedAt.toISOString()}`,
+      `[finishRun] Persisting the failed finalization of job ${id} as canceled: a stop was requested at ${job.cancelRequestedAt.toISOString()}`,
     );
     status = RunStatus.Canceled;
   }
@@ -131,7 +131,7 @@ export const finishCloudJob = async ({
     await releaseCloudTask(job);
   } catch (error) {
     console.error(
-      `[finishCloudJob] Failed to release lock for job ${id}: ${
+      `[finishRun] Failed to release lock for job ${id}: ${
         error instanceof Error ? error.message : String(error)
       }`,
     );
@@ -248,7 +248,7 @@ export const finishCloudJob = async ({
       });
     } catch (error) {
       console.warn(
-        `[finishCloudJob] Failed to refresh final title for job ${id}: ${
+        `[finishRun] Failed to refresh final title for job ${id}: ${
           error instanceof Error ? error.message : String(error)
         }`,
       );
@@ -260,7 +260,7 @@ export const finishCloudJob = async ({
       await cleanupSandboxOidcTargetsForCloudJob(id);
     } catch (error) {
       console.warn(
-        `[finishCloudJob] Failed to clean sandbox OIDC targets for job ${id}: ${
+        `[finishRun] Failed to clean sandbox OIDC targets for job ${id}: ${
           error instanceof Error ? error.message : String(error)
         }`,
       );
@@ -272,7 +272,7 @@ export const finishCloudJob = async ({
       await revokeCloudJobScopedGitLabTokens(job);
     } catch (error) {
       console.warn(
-        `[finishCloudJob] Failed to revoke GitLab scoped tokens for job ${id}: ${
+        `[finishRun] Failed to revoke GitLab scoped tokens for job ${id}: ${
           error instanceof Error ? error.message : String(error)
         }`,
       );
@@ -284,7 +284,7 @@ export const finishCloudJob = async ({
       await ensureSnapshotResumeGitHubFollowUpFallback({ resumeJobId: job.id });
     } catch (err) {
       console.error(
-        `[finishCloudJob] Failed to enqueue deferred SnapshotResume GitHub fallback for job ${id}: ${
+        `[finishRun] Failed to enqueue deferred SnapshotResume GitHub fallback for job ${id}: ${
           err instanceof Error ? err.message : String(err)
         }`,
       );
@@ -304,7 +304,7 @@ export const finishCloudJob = async ({
       await sendSlackFailureNotification(job, sanitizedError);
     } catch (err) {
       console.error(
-        `[finishCloudJob] Failed to send Slack failure notification for job ${id}: ${
+        `[finishRun] Failed to send Slack failure notification for job ${id}: ${
           err instanceof Error ? err.message : String(err)
         }`,
       );
@@ -322,7 +322,7 @@ export const finishCloudJob = async ({
       await sendTeamsFailureNotification(job);
     } catch (err) {
       console.error(
-        `[finishCloudJob] Failed to send Teams failure notification for job ${id}: ${
+        `[finishRun] Failed to send Teams failure notification for job ${id}: ${
           err instanceof Error ? err.message : String(err)
         }`,
       );
@@ -344,7 +344,7 @@ export const finishCloudJob = async ({
       await sendSlackSetupCompletionNotification(job);
     } catch (err) {
       console.error(
-        `[finishCloudJob] Failed to send Slack setup completion notification for job ${id}: ${
+        `[finishRun] Failed to send Slack setup completion notification for job ${id}: ${
           err instanceof Error ? err.message : String(err)
         }`,
       );
@@ -356,7 +356,7 @@ export const finishCloudJob = async ({
       await maybeSendSlackQuestionChannelInvite(job);
     } catch (err) {
       console.error(
-        `[finishCloudJob] Failed to send Slack question-channel invite for job ${id}: ${
+        `[finishRun] Failed to send Slack question-channel invite for job ${id}: ${
           err instanceof Error ? err.message : String(err)
         }`,
       );
@@ -370,7 +370,7 @@ export const finishCloudJob = async ({
       await sendLinearFailureNotification(job, sanitizedError);
     } catch (err) {
       console.error(
-        `[finishCloudJob] Failed to send Linear failure notification for job ${id}: ${
+        `[finishRun] Failed to send Linear failure notification for job ${id}: ${
           err instanceof Error ? err.message : String(err)
         }`,
       );
@@ -386,7 +386,7 @@ export const finishCloudJob = async ({
       await postConflictResolutionComment(job, status, sanitizedError);
     } catch (err) {
       console.error(
-        `[finishCloudJob] Failed to post conflict resolution comment for job ${id}: ${
+        `[finishRun] Failed to post conflict resolution comment for job ${id}: ${
           err instanceof Error ? err.message : String(err)
         }`,
       );
@@ -424,7 +424,7 @@ async function cleanupGithubPrReviewArtifacts(
     prRows = await findTaskPullRequests(job.taskId);
   } catch (error) {
     console.error(
-      `[finishCloudJob] Failed to load task_pull_requests for task ${job.taskId}: ${
+      `[finishRun] Failed to load task_pull_requests for task ${job.taskId}: ${
         error instanceof Error ? error.message : String(error)
       }`,
     );
@@ -463,7 +463,7 @@ async function cleanupGithubPrReviewArtifacts(
           .where(eq(taskPullRequests.id, prRow.id));
       } catch (error) {
         console.error(
-          `[finishCloudJob] Failed to delete reaction for job ${job.id}: ${
+          `[finishRun] Failed to delete reaction for job ${job.id}: ${
             error instanceof Error ? error.message : String(error)
           }`,
         );
@@ -483,7 +483,7 @@ async function cleanupGithubPrReviewArtifacts(
         });
       } catch (error) {
         console.error(
-          `[finishCloudJob] Failed to complete check run for job ${job.id}: ${
+          `[finishRun] Failed to complete check run for job ${job.id}: ${
             error instanceof Error ? error.message : String(error)
           }`,
         );
@@ -502,7 +502,7 @@ async function cleanupGithubPrReviewArtifacts(
       try {
         const token = await createCloudJobGitHubToken(job);
         // A user-stopped run arrives here already normalized to Canceled (see
-        // finishCloudJob), so the review outcome maps naturally.
+        // finishRun), so the review outcome maps naturally.
         const outcome =
           status === RunStatus.Completed
             ? 'completed'
@@ -532,12 +532,12 @@ async function cleanupGithubPrReviewArtifacts(
 
         if (finalized) {
           console.log(
-            `[finishCloudJob] Finalized stale PR review summary comment for job ${job.id} on ${prRow.repository}#${prRow.prNumber}`,
+            `[finishRun] Finalized stale PR review summary comment for job ${job.id} on ${prRow.repository}#${prRow.prNumber}`,
           );
         }
       } catch (error) {
         console.error(
-          `[finishCloudJob] Failed to finalize PR review summary comment for job ${job.id}: ${
+          `[finishRun] Failed to finalize PR review summary comment for job ${job.id}: ${
             error instanceof Error ? error.message : String(error)
           }`,
         );
@@ -579,7 +579,7 @@ async function sendTeamsFailureNotification(job: FinishedRun): Promise<void> {
 
   if (!provider) {
     console.warn(
-      `[finishCloudJob] Teams bot credentials are not configured, skipping Teams failure notification for job ${job.id}`,
+      `[finishRun] Teams bot credentials are not configured, skipping Teams failure notification for job ${job.id}`,
     );
     return;
   }
@@ -589,7 +589,7 @@ async function sendTeamsFailureNotification(job: FinishedRun): Promise<void> {
 
   if (!channelId || !serviceUrl) {
     console.warn(
-      `[finishCloudJob] Missing Teams conversation metadata for job ${job.id}, skipping Teams failure notification`,
+      `[finishRun] Missing Teams conversation metadata for job ${job.id}, skipping Teams failure notification`,
     );
     return;
   }
@@ -617,9 +617,7 @@ async function sendTeamsFailureNotification(job: FinishedRun): Promise<void> {
     textFormat: 'markdown',
   });
 
-  console.log(
-    `[finishCloudJob] Sent Teams failure notification for job ${job.id}`,
-  );
+  console.log(`[finishRun] Sent Teams failure notification for job ${job.id}`);
 }
 
 /**
@@ -641,7 +639,7 @@ async function sendSlackFailureNotification(
 
   if (!slackInstallation) {
     console.warn(
-      `[finishCloudJob] No active Slack installation, skipping Slack notification`,
+      `[finishRun] No active Slack installation, skipping Slack notification`,
     );
     return;
   }
@@ -650,7 +648,7 @@ async function sendSlackFailureNotification(
 
   if (!channel) {
     console.warn(
-      `[finishCloudJob] No channel found for job ${job.id}, skipping Slack notification`,
+      `[finishRun] No channel found for job ${job.id}, skipping Slack notification`,
     );
     return;
   }
@@ -713,7 +711,7 @@ async function sendSlackFailureNotification(
     }
 
     console.log(
-      `[finishCloudJob] Sent Slack failure notification for job ${job.id}`,
+      `[finishRun] Sent Slack failure notification for job ${job.id}`,
     );
     return;
   }
@@ -735,7 +733,7 @@ async function sendSlackFailureNotification(
 
   if (failureSubject && messageTs) {
     await recordSlackConversationMessageBestEffort({
-      logContext: 'finishCloudJob.setupFailure',
+      logContext: 'finishRun.setupFailure',
       ...failureSubject,
       slackChannelId: channel,
       conversationKind: 'thread',
@@ -750,9 +748,7 @@ async function sendSlackFailureNotification(
     });
   }
 
-  console.log(
-    `[finishCloudJob] Sent Slack failure notification for job ${job.id}`,
-  );
+  console.log(`[finishRun] Sent Slack failure notification for job ${job.id}`);
 }
 
 function formatSlackChannelSuggestionList(
@@ -956,13 +952,13 @@ async function maybeSendSlackQuestionChannelInvite(
   if (!messageTs) {
     await redis.del(claimKey);
     console.warn(
-      `[finishCloudJob] Failed to send Slack question-channel invite DM for job ${job.id}`,
+      `[finishRun] Failed to send Slack question-channel invite DM for job ${job.id}`,
     );
     return;
   }
 
   await recordSlackConversationMessageBestEffort({
-    logContext: 'finishCloudJob.questionChannelInvite',
+    logContext: 'finishRun.questionChannelInvite',
     subjectUserId: invitedUserId,
     slackTeamId: slackInstallation.teamId,
     subjectSlackUserId: slackUserMapping.slackUserId,
@@ -1003,7 +999,7 @@ async function sendSlackSetupCompletionNotification(job: FinishedRun) {
 
   if (!channel) {
     console.warn(
-      `[finishCloudJob] No channel found for setup completion job ${job.id}, skipping Slack notification`,
+      `[finishRun] No channel found for setup completion job ${job.id}, skipping Slack notification`,
     );
     return;
   }
@@ -1014,7 +1010,7 @@ async function sendSlackSetupCompletionNotification(job: FinishedRun) {
 
   if (!slackInstallation) {
     console.warn(
-      `[finishCloudJob] No active Slack installation, skipping setup completion Slack notification`,
+      `[finishRun] No active Slack installation, skipping setup completion Slack notification`,
     );
     return;
   }
@@ -1070,7 +1066,7 @@ async function sendSlackSetupCompletionNotification(job: FinishedRun) {
   if (!messageTs) {
     await redis.del(claimKey);
     console.warn(
-      `[finishCloudJob] Failed to send setup completion Slack notification for job ${job.id}`,
+      `[finishRun] Failed to send setup completion Slack notification for job ${job.id}`,
     );
     return;
   }
@@ -1084,7 +1080,7 @@ async function sendSlackSetupCompletionNotification(job: FinishedRun) {
 
   if (completionSubject && messageTs) {
     await recordSlackConversationMessageBestEffort({
-      logContext: 'finishCloudJob.setupCompletion',
+      logContext: 'finishRun.setupCompletion',
       ...completionSubject,
       slackChannelId: channel,
       conversationKind: 'thread',
@@ -1190,7 +1186,7 @@ async function sendLinearFailureNotification(
   const connection = await findLinearDeploymentMcpConnection();
   if (!connection) {
     console.warn(
-      `[finishCloudJob] No active Linear MCP connection, skipping Linear notification`,
+      `[finishRun] No active Linear MCP connection, skipping Linear notification`,
     );
     return;
   }
@@ -1202,7 +1198,7 @@ async function sendLinearFailureNotification(
 
   if (!accessToken) {
     console.warn(
-      `[finishCloudJob] Could not obtain valid Linear access token, skipping Linear notification`,
+      `[finishRun] Could not obtain valid Linear access token, skipping Linear notification`,
     );
     return;
   }
@@ -1212,9 +1208,7 @@ async function sendLinearFailureNotification(
 
   await client.emitError(job.task.linearSessionId!, errorMessage);
 
-  console.log(
-    `[finishCloudJob] Sent Linear failure notification for job ${job.id}`,
-  );
+  console.log(`[finishRun] Sent Linear failure notification for job ${job.id}`);
 }
 
 async function postConflictResolutionComment(
@@ -1230,13 +1224,13 @@ async function postConflictResolutionComment(
 
   if (!prRow?.repository || !prRow.prNumber) {
     console.warn(
-      `[finishCloudJob] Skipping conflict resolution comment for job ${job.id}: no linked GitHub pull request row`,
+      `[finishRun] Skipping conflict resolution comment for job ${job.id}: no linked GitHub pull request row`,
     );
     return;
   }
 
   console.log(
-    `[finishCloudJob] postConflictResolutionComment called for job ${job.id} (status=${status}, repo=${prRow.repository}, pr=${prRow.prNumber})`,
+    `[finishRun] postConflictResolutionComment called for job ${job.id} (status=${status}, repo=${prRow.repository}, pr=${prRow.prNumber})`,
   );
 
   const token = await createCloudJobGitHubToken(job);
@@ -1244,7 +1238,7 @@ async function postConflictResolutionComment(
 
   if (!owner || !repo) {
     console.warn(
-      `[finishCloudJob] Skipping conflict resolution comment: malformed repository (${prRow.repository})`,
+      `[finishRun] Skipping conflict resolution comment: malformed repository (${prRow.repository})`,
     );
 
     return;
@@ -1283,6 +1277,6 @@ async function postConflictResolutionComment(
   }
 
   console.log(
-    `[finishCloudJob] Posted conflict resolution ${status} comment for job ${job.id} on ${prRow.repository}#${prRow.prNumber}`,
+    `[finishRun] Posted conflict resolution ${status} comment for job ${job.id} on ${prRow.repository}#${prRow.prNumber}`,
   );
 }

--- a/packages/sdk/src/server/lib/cloud-jobs/index.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/index.ts
@@ -4,7 +4,7 @@ export * from './update-runtime-state';
 export * from './touch-worker-heartbeat';
 export * from './dequeue-cloud-job';
 export * from './dequeue-resume-cloud-job';
-export * from './finish-cloud-job';
+export * from './finish-run';
 export * from './enqueue-snapshot';
 export * from './revert-pr-commit';
 export * from './refresh-github-token';

--- a/packages/sdk/src/server/lib/cloud-jobs/pr-review-notification-delivery.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/pr-review-notification-delivery.ts
@@ -8,7 +8,7 @@ import {
   generateTrackedNonTaskObject,
   NON_TASK_INFERENCE_SURFACES,
 } from '@roomote/cloud-agents/server/non-task-provider-usage';
-import type { CloudJob } from '@roomote/db/server';
+import type { Run } from '@roomote/db/server';
 import { setLatestSlackBotReply, trackSlackBotReply } from '@roomote/slack';
 import {
   ACP_ENVELOPE_EVENT_TYPES,
@@ -165,7 +165,7 @@ async function fetchPrDiscussionSignals({
   repository,
   prNumber,
 }: {
-  cloudJob: CloudJob;
+  cloudJob: Run;
   repository: string;
   prNumber: number;
 }): Promise<PrReviewTriageContext> {
@@ -225,7 +225,7 @@ export async function gatherPrReviewTriageContext({
   repository,
   prNumber,
 }: {
-  cloudJob: CloudJob;
+  cloudJob: Run;
   repository: string;
   prNumber: number;
 }): Promise<PrReviewTriageContext> {
@@ -339,7 +339,7 @@ export async function preparePrReviewNotificationDelivery({
   request,
   events,
 }: {
-  cloudJob: CloudJob;
+  cloudJob: Run;
   request: PrReviewNotificationRequest;
   events: PrReviewActivityEvent[];
 }): Promise<PreparedPrReviewNotification> {

--- a/packages/sdk/src/server/lib/cloud-jobs/pr-review-notification.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/pr-review-notification.ts
@@ -1,7 +1,7 @@
 import { Queue } from 'bullmq';
 import { z } from 'zod';
 
-import type { CloudJob } from '@roomote/db/server';
+import type { Run } from '@roomote/db/server';
 import {
   and,
   db,
@@ -101,10 +101,7 @@ type EnqueuePrReviewNotificationResult = {
   reason?: string;
 };
 
-type PrReviewNotificationRoutingJob = Pick<
-  CloudJob,
-  'id' | 'taskId' | 'payload'
->;
+type PrReviewNotificationRoutingJob = Pick<Run, 'id' | 'taskId' | 'payload'>;
 
 export type PrReviewNotificationRoute =
   | { provider: 'slack'; channelId: string; threadId: string }

--- a/packages/sdk/src/server/lib/cloud-jobs/record-cloud-job-event.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/record-cloud-job-event.ts
@@ -1,7 +1,7 @@
 import type {
-  CloudJobEventDetails,
-  CloudJobEventSource,
-  CloudJobEventType,
+  RunEventDetails,
+  RunEventSource,
+  RunEventType,
 } from '@roomote/types';
 import {
   db,
@@ -10,10 +10,10 @@ import {
 
 export async function recordCloudJobEvent(input: {
   cloudJobId: number;
-  source: CloudJobEventSource;
-  eventType: CloudJobEventType;
+  source: RunEventSource;
+  eventType: RunEventType;
   message?: string;
-  details?: CloudJobEventDetails;
+  details?: RunEventDetails;
 }): Promise<void> {
   const { cloudJobId, ...rest } = input;
   await persistCloudJobEvent(db, { runId: cloudJobId, ...rest });

--- a/packages/sdk/src/server/lib/cloud-jobs/record-task-message-envelope.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/record-task-message-envelope.ts
@@ -36,7 +36,7 @@ import {
   extractVisibleAcpPromptText,
   extractAcpMessageText,
   getRequestedDeploymentEnvVarNamesFromToolPayload,
-  isExitedCloudTaskStatus,
+  isExitedRunStatus,
   isSystemInjectedAcpPromptText,
   isVisibleInTranscript,
   normalizeTranscriptUserText,
@@ -477,7 +477,7 @@ async function maybeStopTaskAfterEnvVarRequest(
     )
     .limit(1);
 
-  if (!job || isExitedCloudTaskStatus(job.status) || !job.sandboxServerUrl) {
+  if (!job || isExitedRunStatus(job.status) || !job.sandboxServerUrl) {
     return;
   }
 

--- a/packages/sdk/src/server/lib/cloud-jobs/slack-job-routing.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/slack-job-routing.ts
@@ -1,17 +1,10 @@
-import {
-  type CloudJob,
-  db,
-  desc,
-  eq,
-  taskRuns,
-  tasks,
-} from '@roomote/db/server';
+import { type Run, db, desc, eq, taskRuns, tasks } from '@roomote/db/server';
 import {
   getSlackChannelFromTaskPayload,
   getSlackThreadTsFromTaskPayload,
 } from '@roomote/types';
 
-type SlackJobRoutingRecord = Pick<CloudJob, 'id' | 'taskId' | 'payload'>;
+type SlackJobRoutingRecord = Pick<Run, 'id' | 'taskId' | 'payload'>;
 
 type SlackJobRoute =
   | {

--- a/packages/sdk/src/server/lib/cloud-jobs/slack-pr-inactivity-check.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/slack-pr-inactivity-check.ts
@@ -1,7 +1,7 @@
 import { Queue } from 'bullmq';
 import { z } from 'zod';
 
-import type { CloudJob } from '@roomote/db/server';
+import type { Run } from '@roomote/db/server';
 import {
   and,
   db,
@@ -109,7 +109,7 @@ async function resolvePullRequestTarget({
   cloudJob,
   completionText,
 }: {
-  cloudJob: CloudJob;
+  cloudJob: Run;
   completionText?: string;
 }): Promise<{ repository: string; prNumber: number } | null> {
   const latestTaskPullRequest = await db.query.taskPullRequests.findFirst({
@@ -152,7 +152,7 @@ export async function fetchPullRequestSnapshotForCloudJob({
   repository,
   prNumber,
 }: {
-  cloudJob: CloudJob;
+  cloudJob: Run;
   repository: string;
   prNumber: number;
 }): Promise<PullRequestActivitySnapshot | null> {

--- a/packages/sdk/src/server/lib/cloud-jobs/update-cloud-job.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/update-cloud-job.ts
@@ -1,8 +1,8 @@
-import { type UpdateCloudJob, db, taskRuns, eq } from '@roomote/db/server';
+import { type UpdateRun, db, taskRuns, eq } from '@roomote/db/server';
 
 export async function updateCloudJob(
   cloudJobId: number,
-  values: UpdateCloudJob,
+  values: UpdateRun,
 ): Promise<void> {
   try {
     await db.update(taskRuns).set(values).where(eq(taskRuns.id, cloudJobId));

--- a/packages/sdk/src/server/lib/cloud-jobs/update-runtime-state.ts
+++ b/packages/sdk/src/server/lib/cloud-jobs/update-runtime-state.ts
@@ -1,4 +1,4 @@
-import type { CloudTaskStatus } from '@roomote/types';
+import type { RunStatus } from '@roomote/types';
 import { db, taskRuns, eq } from '@roomote/db/server';
 
 type UpdateCloudJobRuntimeState = {
@@ -10,7 +10,7 @@ function shouldApplyRuntimeStateUpdate(
   current: {
     taskPhase: string | null;
     sleepAt: Date | null;
-    status: CloudTaskStatus;
+    status: RunStatus;
   },
   next: UpdateCloudJobRuntimeState,
 ): boolean {

--- a/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-reads.test.ts
+++ b/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-reads.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
 import type { Run } from '@roomote/db/server';
 
 const {
@@ -86,7 +86,7 @@ import { readSourceControlPullRequestForCloudJob } from '../source-control-pull-
 function makeCloudJob(payload: Run['payload']): Run {
   return {
     id: 123,
-    status: CloudTaskStatus.Dequeued,
+    status: RunStatus.Dequeued,
     kind: 'fresh',
     payloadKind: TaskPayloadKind.StandardTask,
     taskId: 'task-123',

--- a/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-reads.test.ts
+++ b/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-reads.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
-import type { CloudJob } from '@roomote/db/server';
+import type { Run } from '@roomote/db/server';
 
 const {
   mockCreateGitHubToken,
@@ -83,7 +83,7 @@ vi.mock('@roomote/db/server', () => ({
 
 import { readSourceControlPullRequestForCloudJob } from '../source-control-pull-request-reads';
 
-function makeCloudJob(payload: CloudJob['payload']): CloudJob {
+function makeCloudJob(payload: Run['payload']): Run {
   return {
     id: 123,
     status: CloudTaskStatus.Dequeued,
@@ -94,7 +94,7 @@ function makeCloudJob(payload: CloudJob['payload']): CloudJob {
     payload,
     result: null,
     artifacts: null,
-  } as CloudJob;
+  } as Run;
 }
 
 function jsonResponse(body: unknown, status = 200): Response {

--- a/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-writes.test.ts
+++ b/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-writes.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
-import type { CloudJob } from '@roomote/db/server';
+import type { Run } from '@roomote/db/server';
 
 const {
   mockCreateGitHubToken,
@@ -86,7 +86,7 @@ import {
   writeSourceControlPullRequestForCloudJob,
 } from '../source-control-pull-request-writes';
 
-function makeCloudJob(payload: CloudJob['payload']): CloudJob {
+function makeCloudJob(payload: Run['payload']): Run {
   return {
     id: 123,
     status: CloudTaskStatus.Dequeued,
@@ -97,7 +97,7 @@ function makeCloudJob(payload: CloudJob['payload']): CloudJob {
     payload,
     result: null,
     artifacts: null,
-  } as CloudJob;
+  } as Run;
 }
 
 function jsonResponse(body: unknown, status = 200): Response {

--- a/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-writes.test.ts
+++ b/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-writes.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
 import type { Run } from '@roomote/db/server';
 
 const {
@@ -89,7 +89,7 @@ import {
 function makeCloudJob(payload: Run['payload']): Run {
   return {
     id: 123,
-    status: CloudTaskStatus.Dequeued,
+    status: RunStatus.Dequeued,
     kind: 'fresh',
     payloadKind: TaskPayloadKind.StandardTask,
     taskId: 'task-123',

--- a/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-requests.test.ts
+++ b/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-requests.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
 import type { Run } from '@roomote/db/server';
 
 const {
@@ -124,7 +124,7 @@ import { createOrUpdateSourceControlPullRequestForCloudJob } from '../source-con
 function makeCloudJob(payload: Run['payload']): Run {
   return {
     id: 123,
-    status: CloudTaskStatus.Dequeued,
+    status: RunStatus.Dequeued,
     kind: 'fresh',
     payloadKind: TaskPayloadKind.StandardTask,
     taskId: 'task-123',

--- a/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-requests.test.ts
+++ b/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-requests.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CloudTaskStatus, TaskPayloadKind } from '@roomote/types';
-import type { CloudJob } from '@roomote/db/server';
+import type { Run } from '@roomote/db/server';
 
 const {
   mockCreateGitHubToken,
@@ -121,7 +121,7 @@ vi.mock('@roomote/db/server', () => ({
 
 import { createOrUpdateSourceControlPullRequestForCloudJob } from '../source-control-pull-requests';
 
-function makeCloudJob(payload: CloudJob['payload']): CloudJob {
+function makeCloudJob(payload: Run['payload']): Run {
   return {
     id: 123,
     status: CloudTaskStatus.Dequeued,
@@ -132,7 +132,7 @@ function makeCloudJob(payload: CloudJob['payload']): CloudJob {
     payload,
     result: null,
     artifacts: null,
-  } as CloudJob;
+  } as Run;
 }
 
 function jsonResponse(body: unknown, status = 200): Response {

--- a/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-reads.ts
+++ b/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-reads.ts
@@ -15,7 +15,7 @@ import {
   resolveGitLabBaseUrl,
   resolveGitLabToken,
 } from '@roomote/gitlab';
-import { type CloudJob } from '@roomote/db/server';
+import { type Run } from '@roomote/db/server';
 import {
   buildPullRequestUrl,
   getSourceControlProviderLabel,
@@ -347,7 +347,7 @@ export async function readSourceControlPullRequestForCloudJob({
   input,
   fetchImpl = fetch,
 }: {
-  cloudJob: CloudJob;
+  cloudJob: Run;
   input: SourceControlPullRequestReadInput;
   fetchImpl?: FetchImpl;
 }): Promise<SourceControlPullRequestReadResult> {

--- a/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-shared.ts
+++ b/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-shared.ts
@@ -4,7 +4,7 @@ import {
   environments,
   eq,
   repositories,
-  type CloudJob,
+  type Run,
 } from '@roomote/db/server';
 import {
   ALL_REPOSITORIES,
@@ -69,7 +69,7 @@ export async function resolveRepositoryRow({
 }
 
 export async function assertRepositoryInCloudJobScope(
-  cloudJob: CloudJob,
+  cloudJob: Run,
   repositoryFullName: string,
 ): Promise<void> {
   const scopedRepositories = await resolveCloudJobRepositoryScope(cloudJob);
@@ -86,7 +86,7 @@ export async function assertRepositoryInCloudJobScope(
 }
 
 async function resolveCloudJobRepositoryScope(
-  cloudJob: CloudJob,
+  cloudJob: Run,
 ): Promise<string[] | null> {
   const payload = getPayloadRecord(cloudJob.payload);
   const environmentId =

--- a/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-writes.ts
+++ b/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-writes.ts
@@ -15,7 +15,7 @@ import {
   resolveGitLabBaseUrl,
   resolveGitLabToken,
 } from '@roomote/gitlab';
-import { type CloudJob } from '@roomote/db/server';
+import { type Run } from '@roomote/db/server';
 import {
   getSourceControlProviderLabel,
   resolveSourceControlProviderFromPayload,
@@ -212,7 +212,7 @@ export async function writeSourceControlPullRequestForCloudJob({
   input: rawInput,
   fetchImpl = fetch,
 }: {
-  cloudJob: CloudJob;
+  cloudJob: Run;
   input: SourceControlPullRequestWriteInput;
   fetchImpl?: FetchImpl;
 }): Promise<SourceControlPullRequestWriteResult> {

--- a/packages/sdk/src/server/lib/pull-requests/source-control-pull-requests.ts
+++ b/packages/sdk/src/server/lib/pull-requests/source-control-pull-requests.ts
@@ -21,7 +21,7 @@ import {
   taskRuns,
   getDeploymentPrAction,
   taskPullRequests,
-  type CloudJob,
+  type Run,
 } from '@roomote/db/server';
 import {
   buildPullRequestUrl,
@@ -134,7 +134,7 @@ export async function createOrUpdateSourceControlPullRequestForCloudJob({
   input,
   fetchImpl = fetch,
 }: {
-  cloudJob: CloudJob;
+  cloudJob: Run;
   input: SourceControlPullRequestMutationInput;
   fetchImpl?: FetchImpl;
 }): Promise<SourceControlPullRequestMutationResult> {
@@ -216,7 +216,7 @@ export async function createOrUpdateSourceControlPullRequestForCloudJob({
  * created at all. Updates never change an existing pull request's draft
  * state.
  */
-async function resolveEffectivePrAction(cloudJob: CloudJob): Promise<PrAction> {
+async function resolveEffectivePrAction(cloudJob: Run): Promise<PrAction> {
   const payloadPrAction = getPayloadRecord(cloudJob.payload).prAction;
 
   if (prActions.includes(payloadPrAction as PrAction)) {
@@ -240,7 +240,7 @@ async function persistSourceControlPullRequestAssociation({
   result,
   repository,
 }: {
-  cloudJob: CloudJob;
+  cloudJob: Run;
   input: SourceControlPullRequestMutationInput;
   result: SourceControlPullRequestMutationResult;
   repository: RepositoryRow;
@@ -902,7 +902,7 @@ export async function findCloudJobForSourceControlMutation({
 }: {
   cloudJobId: number;
   taskId: string;
-}): Promise<CloudJob> {
+}): Promise<Run> {
   const cloudJob = await db.query.taskRuns.findFirst({
     where: eq(taskRuns.id, cloudJobId),
   });

--- a/packages/sdk/src/server/lib/sandbox-oidc.ts
+++ b/packages/sdk/src/server/lib/sandbox-oidc.ts
@@ -12,7 +12,7 @@ import {
   type EnvironmentConfig,
   type ComputeProvider,
   type ResolvedEnvironmentOidcTarget,
-  CloudTaskStatus,
+  RunStatus,
   extractErrorDetails,
   getEnvironmentOidcTargets,
   isObservedTimeoutError,
@@ -468,9 +468,9 @@ async function loadOwnerStateForRefresh(
     }
 
     if (
-      cloudJob.status === CloudTaskStatus.Completed ||
-      cloudJob.status === CloudTaskStatus.Failed ||
-      cloudJob.status === CloudTaskStatus.Canceled
+      cloudJob.status === RunStatus.Completed ||
+      cloudJob.status === RunStatus.Failed ||
+      cloudJob.status === RunStatus.Canceled
     ) {
       return null;
     }

--- a/packages/sdk/src/server/routers/cloud-jobs.test.ts
+++ b/packages/sdk/src/server/routers/cloud-jobs.test.ts
@@ -4,7 +4,7 @@ import { ACP_ENVELOPE_EVENT_TYPES, TaskPayloadKind } from '@roomote/types';
 import type { AuthTokenContext, JobTokenContext } from '@roomote/types';
 
 const {
-  mockEnqueueCloudTask,
+  mockEnqueueTask,
   mockEvaluateFeatureFlag,
   mockFindCloudJob,
   mockFindCloudJobForAccess,
@@ -18,7 +18,7 @@ const {
   mockRecordTaskMessageEnvelope,
   mockRecordTaskInferenceUsage,
 } = vi.hoisted(() => ({
-  mockEnqueueCloudTask: vi.fn(),
+  mockEnqueueTask: vi.fn(),
   mockEvaluateFeatureFlag: vi.fn(),
   mockFindCloudJob: vi.fn(),
   mockFindCloudJobForAccess: vi.fn(),
@@ -34,7 +34,7 @@ const {
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
-  enqueueCloudTask: mockEnqueueCloudTask,
+  enqueueTask: mockEnqueueTask,
 }));
 
 vi.mock('@roomote/feature-flags/server', () => ({
@@ -90,7 +90,7 @@ vi.mock('../lib/cloud-jobs', () => ({
   findCloudJob: mockFindCloudJob,
   findCloudJobByIdAndOrgId: mockFindCloudJobByIdAndOrgId,
   findCloudJobByJobTokenClaims: mockFindCloudJobByJobTokenClaims,
-  finishCloudJob: vi.fn(),
+  finishRun: vi.fn(),
   getMessageSources: vi.fn(),
   getResolvedGitAuthor: vi.fn(),
   getResolvedRuntimeEnvVars: vi.fn(),
@@ -159,7 +159,7 @@ function createJobCaller() {
 describe('cloudJobsRouter queue message guards', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockEnqueueCloudTask.mockResolvedValue({ id: 99, taskId: 'task-99' });
+    mockEnqueueTask.mockResolvedValue({ id: 99, taskId: 'task-99' });
     mockEvaluateFeatureFlag.mockResolvedValue(false);
     mockFindCloudJob.mockResolvedValue({ id: 42 });
     mockFindCloudJobForAccess.mockResolvedValue({ id: 42 });
@@ -514,7 +514,7 @@ describe('cloudJobsRouter queue message guards', () => {
       }),
     ).resolves.toEqual({ id: 99, taskId: 'task-99' });
 
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           computeProvider: 'modal',
@@ -541,7 +541,7 @@ describe('cloudJobsRouter queue message guards', () => {
     ).resolves.toEqual({ id: 99, taskId: 'task-99' });
 
     expect(mockEvaluateFeatureFlag).not.toHaveBeenCalled();
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith({
+    expect(mockEnqueueTask).toHaveBeenCalledWith({
       task: {
         type: TaskPayloadKind.StandardTask,
         payload: {
@@ -572,7 +572,7 @@ describe('cloudJobsRouter queue message guards', () => {
       } as never),
     ).rejects.toThrow();
 
-    expect(mockEnqueueCloudTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('accepts snapshot resumes through the resume input shape', async () => {
@@ -590,7 +590,7 @@ describe('cloudJobsRouter queue message guards', () => {
       }),
     ).resolves.toEqual({ id: 99, taskId: 'task-99' });
 
-    expect(mockEnqueueCloudTask).toHaveBeenCalledWith(
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         actingUserId: 'user-2',
         task: expect.objectContaining({

--- a/packages/sdk/src/server/routers/cloud-jobs.ts
+++ b/packages/sdk/src/server/routers/cloud-jobs.ts
@@ -34,8 +34,8 @@ import {
   queueCommunicationMessage,
 } from '@roomote/communication/messages';
 import {
-  enqueueCloudTask,
-  type EnqueueCloudTaskInput,
+  enqueueTask,
+  type EnqueueTaskInput,
 } from '@roomote/cloud-agents/server';
 import {
   clearPendingSlackRequestUserInput,
@@ -73,7 +73,7 @@ import {
   touchCloudJobHeartbeat,
   dequeueCloudJob,
   dequeueResumeCloudJob,
-  finishCloudJob,
+  finishRun,
   revertPrCommit,
   createSnapshot,
   refreshGitHubTokenWithMetadata,
@@ -215,7 +215,7 @@ const resumeEnqueueInputSchema = z.object({
   actingUserId: z.string().nullish(),
 });
 
-const enqueueCloudTaskInputSchema = z.union([
+const enqueueTaskInputSchema = z.union([
   freshEnqueueInputSchema,
   resumeEnqueueInputSchema,
 ]);
@@ -325,11 +325,9 @@ export const cloudJobsRouter = router({
     }),
   ),
   enqueue: nonJobProcedure
-    .input(enqueueCloudTaskInputSchema)
+    .input(enqueueTaskInputSchema)
     .mutation(async ({ input }) => {
-      const launchResult = await enqueueCloudTask(
-        input as EnqueueCloudTaskInput,
-      );
+      const launchResult = await enqueueTask(input as EnqueueTaskInput);
 
       return {
         id: launchResult.id,
@@ -351,7 +349,7 @@ export const cloudJobsRouter = router({
       error: z.string().optional(),
     }),
     'id',
-  ).mutation(({ input }) => finishCloudJob(input)),
+  ).mutation(({ input }) => finishRun(input)),
   recordEvent: jobScoped(
     z.object({
       cloudJobId: z.number(),

--- a/packages/sdk/src/server/routers/cloud-jobs.ts
+++ b/packages/sdk/src/server/routers/cloud-jobs.ts
@@ -10,19 +10,19 @@ import {
 } from '@roomote/db/server';
 
 import {
-  CloudTaskStatus,
+  RunStatus,
   TASK_SURFACES,
   TASK_TRIGGERS,
   TASK_VISIBILITIES,
   TASK_WORKFLOWS,
   TaskPayloadKind,
-  cloudJobEventSources,
-  cloudJobEventTypes,
-  cloudTaskSchema,
+  runEventSources,
+  runEventTypes,
+  taskSpecSchema,
   communicationProviderSchema,
   computeProviderLaunchModes,
   computeProviderUsageLifecycleActions,
-  doneCloudTaskStatuses,
+  doneRunStatuses,
   queuedCommunicationMessageSchema,
   snapshotResumeSchema,
   sourceControlProviderSchema,
@@ -193,7 +193,7 @@ const taskPrLinkageSchema = z.object({
  * bindings, optional PR linkage) plus its first run.
  */
 const freshEnqueueInputSchema = z.object({
-  task: cloudTaskSchema.refine(
+  task: taskSpecSchema.refine(
     (task) => task.type !== TaskPayloadKind.SnapshotResume,
     { message: 'Snapshot resumes must use the resume input shape.' },
   ),
@@ -277,7 +277,7 @@ export const cloudJobsRouter = router({
   update: jobScoped(
     z.object({
       id: z.number(),
-      status: z.nativeEnum(CloudTaskStatus).optional(),
+      status: z.nativeEnum(RunStatus).optional(),
       taskPhase: z.string().nullish(),
       sleepAt: z.date().nullish(),
       taskId: z.string().optional(),
@@ -347,7 +347,7 @@ export const cloudJobsRouter = router({
   done: jobScoped(
     z.object({
       id: z.number(),
-      status: z.enum(doneCloudTaskStatuses),
+      status: z.enum(doneRunStatuses),
       error: z.string().optional(),
     }),
     'id',
@@ -355,8 +355,8 @@ export const cloudJobsRouter = router({
   recordEvent: jobScoped(
     z.object({
       cloudJobId: z.number(),
-      source: z.enum(cloudJobEventSources),
-      eventType: z.enum(cloudJobEventTypes),
+      source: z.enum(runEventSources),
+      eventType: z.enum(runEventTypes),
       message: z.string().optional(),
       details: z.record(z.unknown()).optional(),
     }),

--- a/packages/slack/src/__tests__/find-active-slack-job.test.ts
+++ b/packages/slack/src/__tests__/find-active-slack-job.test.ts
@@ -41,7 +41,7 @@ vi.mock('@roomote/db/server', () => {
   };
 });
 
-import { activeCloudTaskStatuses } from '@roomote/types';
+import { activeRunStatuses } from '@roomote/types';
 
 import { findActiveSlackJob } from '../find-active-slack-job';
 
@@ -58,7 +58,7 @@ describe('findActiveSlackJob', () => {
     expect(whereMock).toHaveBeenNthCalledWith(1, {
       and: [
         { eq: ['tasks.slackThreadTs', '111.000'] },
-        { inArray: ['taskRuns.status', [...activeCloudTaskStatuses]] },
+        { inArray: ['taskRuns.status', [...activeRunStatuses]] },
         { isNull: 'taskRuns.canceledAt' },
       ],
     });

--- a/packages/slack/src/__tests__/show-task-configuration.test.ts
+++ b/packages/slack/src/__tests__/show-task-configuration.test.ts
@@ -1,7 +1,7 @@
 const {
   buildSlackRoutingContextMock,
   routeTaskMock,
-  enqueueCloudTaskMock,
+  enqueueTaskMock,
   findActiveSlackJobMock,
   classifyFollowUpMock,
   getTaskUrlMock,
@@ -31,7 +31,7 @@ const {
 } = vi.hoisted(() => ({
   buildSlackRoutingContextMock: vi.fn(),
   routeTaskMock: vi.fn(),
-  enqueueCloudTaskMock: vi.fn(),
+  enqueueTaskMock: vi.fn(),
   findActiveSlackJobMock: vi.fn(),
   classifyFollowUpMock: vi.fn(),
   getTaskUrlMock: vi.fn(),
@@ -63,7 +63,7 @@ const {
 vi.mock('@roomote/cloud-agents/server', () => ({
   buildSlackRoutingContext: buildSlackRoutingContextMock,
   routeTask: routeTaskMock,
-  enqueueCloudTask: enqueueCloudTaskMock,
+  enqueueTask: enqueueTaskMock,
   classifyFollowUp: classifyFollowUpMock,
   detectSlackMcpSetupRequirement: vi.fn().mockResolvedValue(null),
   getTaskUrl: getTaskUrlMock,
@@ -243,7 +243,7 @@ describe('Slack deleted-mention suppression', () => {
       },
     });
     findActiveSlackJobMock.mockResolvedValue(null);
-    enqueueCloudTaskMock.mockResolvedValue({ id: 42, taskId: 'task_123' });
+    enqueueTaskMock.mockResolvedValue({ id: 42, taskId: 'task_123' });
     normalizeIncomingTextMock.mockImplementation(async (text: string) => text);
     getChannelNameMock.mockResolvedValue('eng-routing');
     fetchThreadMessagesMock.mockResolvedValue([]);
@@ -299,7 +299,7 @@ describe('Slack deleted-mention suppression', () => {
       threadTs: '111.222',
       messageTs: '111.222',
     });
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(postMessageMock).not.toHaveBeenCalled();
     expect(hsetMock).not.toHaveBeenCalled();
   });
@@ -343,7 +343,7 @@ describe('Slack deleted-mention suppression', () => {
     expect(
       JSON.stringify(postMessageMock.mock.calls.at(-1)?.[0] ?? {}),
     ).not.toMatch(/Cloud Agents|background agents/);
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
   });
 
   it('starts immediate routed tasks without passing pre-classified requested work kind', async () => {
@@ -371,7 +371,7 @@ describe('Slack deleted-mention suppression', () => {
       threadId: '111.222',
       startedImmediately: true,
     });
-    expect(enqueueCloudTaskMock).toHaveBeenCalledWith(
+    expect(enqueueTaskMock).toHaveBeenCalledWith(
       expect.objectContaining({
         channels: expect.objectContaining({
           slackThreadTs: '111.222',
@@ -379,7 +379,7 @@ describe('Slack deleted-mention suppression', () => {
       }),
       expect.anything(),
     );
-    expect(enqueueCloudTaskMock).toHaveBeenCalledWith(
+    expect(enqueueTaskMock).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.not.objectContaining({
           requestedWorkKindDecision: expect.anything(),
@@ -449,7 +449,7 @@ describe('Slack deleted-mention suppression', () => {
         ],
       }),
     );
-    expect(enqueueCloudTaskMock).toHaveBeenCalledWith(
+    expect(enqueueTaskMock).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           payload: expect.objectContaining({
@@ -667,7 +667,7 @@ describe('Slack deleted-mention suppression', () => {
       startedImmediately: true,
     });
     expect(hsetMock).not.toHaveBeenCalled();
-    expect(enqueueCloudTaskMock).toHaveBeenCalledWith(
+    expect(enqueueTaskMock).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           payload: expect.objectContaining({
@@ -721,6 +721,6 @@ describe('Slack deleted-mention suppression', () => {
     expect(evalMock).toHaveBeenCalledTimes(1);
     expect(updateMessageMock).not.toHaveBeenCalled();
     expect(postMessageMock).not.toHaveBeenCalled();
-    expect(enqueueCloudTaskMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/slack/src/__tests__/start-slack-app-mention.test.ts
+++ b/packages/slack/src/__tests__/start-slack-app-mention.test.ts
@@ -1,6 +1,6 @@
 const {
   dbUpdateSetMock,
-  enqueueCloudTaskMock,
+  enqueueTaskMock,
   dbUpdateWhereMock,
   consoleWarnMock,
   findActiveSlackJobMock,
@@ -8,7 +8,7 @@ const {
   resolveSlackReactionNamesMock,
 } = vi.hoisted(() => ({
   dbUpdateSetMock: vi.fn(),
-  enqueueCloudTaskMock: vi.fn(),
+  enqueueTaskMock: vi.fn(),
   dbUpdateWhereMock: vi.fn(),
   consoleWarnMock: vi.fn(),
   findActiveSlackJobMock: vi.fn(),
@@ -30,7 +30,7 @@ vi.mock('@roomote/cloud-agents', () => ({
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
-  enqueueCloudTask: enqueueCloudTaskMock,
+  enqueueTask: enqueueTaskMock,
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -65,7 +65,7 @@ describe('startSlackAppMentionTask', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(console, 'warn').mockImplementation(consoleWarnMock);
-    enqueueCloudTaskMock.mockResolvedValue({ id: 42, taskId: 'task_123' });
+    enqueueTaskMock.mockResolvedValue({ id: 42, taskId: 'task_123' });
     dbUpdateSetMock.mockClear();
     dbUpdateWhereMock.mockResolvedValue(undefined);
     findActiveSlackJobMock.mockResolvedValue(null);
@@ -97,7 +97,7 @@ describe('startSlackAppMentionTask', () => {
         ' https://acme-team.slack.com/archives/C123/p111000?thread_ts=111.000&cid=C123 ',
     });
 
-    expect(enqueueCloudTaskMock).toHaveBeenCalledWith(
+    expect(enqueueTaskMock).toHaveBeenCalledWith(
       expect.objectContaining({
         initiator: { kind: 'user', userId: 'user_123' },
         workflow: 'standard',

--- a/packages/slack/src/block-kit.ts
+++ b/packages/slack/src/block-kit.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto';
 import {
   type SlackBlock,
   AGENT_DISPLAY_NAME,
-  type CloudTaskPayload,
+  type TaskPayload,
   TaskPayloadKind,
   ALL_REPOSITORIES,
   PRODUCT_NAME,
@@ -3283,7 +3283,7 @@ export async function handleRetryFailedTask(
     return;
   }
 
-  const originalPayload = retryJob.payload as CloudTaskPayload<
+  const originalPayload = retryJob.payload as TaskPayload<
     typeof TaskPayloadKind.SlackAppMention
   >;
 

--- a/packages/slack/src/drain-slack-messages.ts
+++ b/packages/slack/src/drain-slack-messages.ts
@@ -1,6 +1,6 @@
 import {
   ALL_REPOSITORIES,
-  type CloudTaskPayload,
+  type TaskPayload,
   TaskPayloadKind,
   populateSnapshotResumeSlackMetadata,
   restoreSnapshotResumeVisiblePromptFields,
@@ -135,7 +135,7 @@ export async function drainSlackMessagesToResumeJob(
       return { resumed: false, reason: 'no_pending_messages' };
     }
 
-    const payload: CloudTaskPayload<typeof TaskPayloadKind.SnapshotResume> = {
+    const payload: TaskPayload<typeof TaskPayloadKind.SnapshotResume> = {
       repo,
       environmentId,
       selectedRepositories: scopedSelectedRepositories,

--- a/packages/slack/src/drain-slack-messages.ts
+++ b/packages/slack/src/drain-slack-messages.ts
@@ -5,7 +5,7 @@ import {
   populateSnapshotResumeSlackMetadata,
   restoreSnapshotResumeVisiblePromptFields,
 } from '@roomote/types';
-import { enqueueCloudTask } from '@roomote/cloud-agents/server';
+import { enqueueTask } from '@roomote/cloud-agents/server';
 import { getRedis } from '@roomote/redis';
 
 import { getSlackMessages, prependSlackMessages } from './slack-messages';
@@ -125,7 +125,7 @@ export async function drainSlackMessagesToResumeJob(
   // Drain before creating the resume job so its payload is self-contained.
   // Restore the drained messages on failure.
   let messages: Awaited<ReturnType<typeof getSlackMessages>> = [];
-  let resumeLaunch: Awaited<ReturnType<typeof enqueueCloudTask>>;
+  let resumeLaunch: Awaited<ReturnType<typeof enqueueTask>>;
 
   try {
     messages = await getSlackMessages(sourceJob.id);
@@ -156,7 +156,7 @@ export async function drainSlackMessagesToResumeJob(
     const resumeActingUserId =
       [...messages].reverse().find((message) => message.userId)?.userId ?? null;
 
-    resumeLaunch = await enqueueCloudTask({
+    resumeLaunch = await enqueueTask({
       task: {
         type: TaskPayloadKind.SnapshotResume,
         sourceSnapshotId: snapshotId,

--- a/packages/slack/src/fetch-task-data.ts
+++ b/packages/slack/src/fetch-task-data.ts
@@ -11,7 +11,7 @@ import {
   desc,
   type User,
   type Task,
-  type CloudJob,
+  type Run,
 } from '@roomote/db/server';
 import { getTaskUrl } from '@roomote/cloud-agents/server';
 
@@ -25,7 +25,7 @@ function toUnixSeconds(date: Date | null | undefined): number {
   return Math.floor(date.getTime() / 1000);
 }
 
-function deriveStatus(task: Task, job: CloudJob | null): string {
+function deriveStatus(task: Task, job: Run | null): string {
   if (job?.status) {
     return job.status;
   }

--- a/packages/slack/src/find-active-slack-job.ts
+++ b/packages/slack/src/find-active-slack-job.ts
@@ -9,7 +9,7 @@ import {
   isNull,
   desc,
 } from '@roomote/db/server';
-import { activeCloudTaskStatuses } from '@roomote/types';
+import { activeRunStatuses } from '@roomote/types';
 
 import { slackDebug } from './logging';
 
@@ -37,7 +37,7 @@ export async function findActiveSlackJob(slackThreadTs: string) {
     .where(
       and(
         eq(tasks.slackThreadTs, slackThreadTs),
-        inArray(taskRuns.status, [...activeCloudTaskStatuses]),
+        inArray(taskRuns.status, [...activeRunStatuses]),
         isNull(taskRuns.canceledAt),
       ),
     )

--- a/packages/slack/src/find-completed-slack-job-with-snapshot.ts
+++ b/packages/slack/src/find-completed-slack-job-with-snapshot.ts
@@ -10,7 +10,7 @@ import {
   isNotNull,
   desc,
 } from '@roomote/db/server';
-import { CloudTaskStatus, SANDBOX_SNAPSHOT_EXPIRY_MS } from '@roomote/types';
+import { RunStatus, SANDBOX_SNAPSHOT_EXPIRY_MS } from '@roomote/types';
 
 import { slackDebug } from './logging';
 
@@ -49,10 +49,7 @@ export async function findCompletedSlackJobWithSnapshot(slackThreadTs: string) {
     .where(
       and(
         eq(tasks.slackThreadTs, slackThreadTs),
-        inArray(taskRuns.status, [
-          CloudTaskStatus.Completed,
-          CloudTaskStatus.Idle,
-        ]),
+        inArray(taskRuns.status, [RunStatus.Completed, RunStatus.Idle]),
         isNotNull(taskRuns.snapshotId),
         isNull(taskRuns.snapshotFailedAt),
         isNull(taskRuns.canceledAt),

--- a/packages/slack/src/start-auto-routed-slack-task.ts
+++ b/packages/slack/src/start-auto-routed-slack-task.ts
@@ -151,7 +151,7 @@ export async function startAutoRoutedSlackTask({
     'botUserId' | 'teamId' | 'teamDomain'
   >;
   slack: SlackNotifier;
-  /** Forwarded verbatim to startSlackAppMentionTask / enqueueCloudTask. */
+  /** Forwarded verbatim to startSlackAppMentionTask / enqueueTask. */
   initiator: TaskInitiator;
   trigger: TaskTrigger;
   workflow?: Extract<TaskWorkflow, 'standard' | 'eval'>;

--- a/packages/slack/src/start-slack-app-mention.ts
+++ b/packages/slack/src/start-slack-app-mention.ts
@@ -5,7 +5,7 @@ import {
   wrapSlackThreadContext,
   wrapSlackTurnPolicy,
 } from '@roomote/cloud-agents';
-import { enqueueCloudTask } from '@roomote/cloud-agents/server';
+import { enqueueTask } from '@roomote/cloud-agents/server';
 import { db, eq, sql, taskRuns } from '@roomote/db/server';
 import {
   type ReasoningEffort,
@@ -313,7 +313,7 @@ export async function startSlackAppMentionTask(input: {
     },
   } satisfies SlackAppMentionTask;
 
-  const launchResult = await enqueueCloudTask(
+  const launchResult = await enqueueTask(
     {
       task,
       initiator: input.initiator,

--- a/packages/slack/src/work-object-utils.ts
+++ b/packages/slack/src/work-object-utils.ts
@@ -81,7 +81,7 @@ export function extractTaskIdFromUrl(url: string): string | null {
  * const entity = buildWorkObjectEntity({
  *   taskId: 'abc123',
  *   title: 'Review PR #42',
- *   status: CloudTaskStatus.Running,
+ *   status: RunStatus.Running,
  *   createdBy: 'alice',
  *   assignee: 'bob',
  *   createdAt: Date.now() - 1000,

--- a/packages/types/src/__tests__/cloud-jobs.test.ts
+++ b/packages/types/src/__tests__/cloud-jobs.test.ts
@@ -1,7 +1,7 @@
 // pnpm --filter @roomote/types test src/__tests__/cloud-jobs.test.ts
 
 import {
-  type CloudTaskPayload,
+  type TaskPayload,
   DEFAULT_CODING_HARNESS,
   DEFAULT_LAUNCH_CODING_HARNESS,
   getCommunicationChannelFromTaskPayload,
@@ -12,19 +12,19 @@ import {
   getSlackThreadTsFromTaskPayload,
   getTaskToolActionIdFromInvocation,
   getTaskToolInvocation,
-  CloudTaskStatus,
+  RunStatus,
   TaskPayloadKind,
   EXPIRED_SNAPSHOT_RESUME_ERROR,
-  bootingCloudTaskStatuses,
-  cloudTaskSchema,
+  bootingRunStatuses,
+  taskSpecSchema,
   coerceLaunchCodingHarness,
-  isActivelyRunningCloudTask,
-  isCloudTaskExecutingTurn,
+  isActivelyRunningTask,
+  isTaskExecutingTurn,
   isPrReviewJob,
-  isResumableCloudTaskType,
+  isResumableTaskPayloadKind,
   isLaunchCodingHarness,
   isSnapshotResumable,
-  resolveCloudTaskWorkspace,
+  resolveTaskWorkspace,
   SUGGESTION_PRIORITY_EMOJIS,
   SUGGESTION_PRIORITY_LABELS,
   populateSnapshotResumeSlackMetadata,
@@ -37,7 +37,7 @@ import {
 
 describe('isPrReviewJob', () => {
   it('returns true for GithubPrReview type', () => {
-    const payload: CloudTaskPayload<typeof TaskPayloadKind.GithubPrReview> = {
+    const payload: TaskPayload<typeof TaskPayloadKind.GithubPrReview> = {
       repo: 'owner/repo',
       prNumber: 123,
       prTitle: 'Test PR',
@@ -49,14 +49,13 @@ describe('isPrReviewJob', () => {
   });
 
   it('returns true for GithubPrReviewSync type', () => {
-    const payload: CloudTaskPayload<typeof TaskPayloadKind.GithubPrReviewSync> =
-      {
-        repo: 'owner/repo',
-        prNumber: 123,
-        prTitle: 'Test PR',
-        prUrl: 'https://github.com/owner/repo/pull/123',
-        headSha: 'abc123',
-      };
+    const payload: TaskPayload<typeof TaskPayloadKind.GithubPrReviewSync> = {
+      repo: 'owner/repo',
+      prNumber: 123,
+      prTitle: 'Test PR',
+      prUrl: 'https://github.com/owner/repo/pull/123',
+      headSha: 'abc123',
+    };
 
     expect(isPrReviewJob(TaskPayloadKind.GithubPrReviewSync, payload)).toBe(
       true,
@@ -64,7 +63,7 @@ describe('isPrReviewJob', () => {
   });
 
   it('returns false for non-PR review types', () => {
-    const payload: CloudTaskPayload<typeof TaskPayloadKind.StandardTask> = {
+    const payload: TaskPayload<typeof TaskPayloadKind.StandardTask> = {
       repo: 'owner/repo',
       description: 'Test task',
     };
@@ -105,17 +104,17 @@ describe('shouldUseAppTokenOnly', () => {
   });
 });
 
-describe('isResumableCloudTaskType', () => {
+describe('isResumableTaskPayloadKind', () => {
   it('returns true for StandardTask jobs', () => {
-    expect(isResumableCloudTaskType(TaskPayloadKind.StandardTask)).toBe(true);
+    expect(isResumableTaskPayloadKind(TaskPayloadKind.StandardTask)).toBe(true);
   });
 
   it('returns true for Suggested Tasks jobs', () => {
-    expect(isResumableCloudTaskType(TaskPayloadKind.Scan)).toBe(true);
+    expect(isResumableTaskPayloadKind(TaskPayloadKind.Scan)).toBe(true);
   });
 
   it('returns false for GithubPrReview', () => {
-    expect(isResumableCloudTaskType(TaskPayloadKind.GithubPrReview)).toBe(
+    expect(isResumableTaskPayloadKind(TaskPayloadKind.GithubPrReview)).toBe(
       false,
     );
   });
@@ -242,9 +241,9 @@ describe('Task Tool invocation helpers', () => {
   });
 });
 
-describe('cloudTaskSchema', () => {
+describe('taskSpecSchema', () => {
   it('preserves sourceControlProvider on StandardTask payloads', () => {
-    const parsed = cloudTaskSchema.parse({
+    const parsed = taskSpecSchema.parse({
       userId: 'user-1',
       type: TaskPayloadKind.StandardTask,
       payload: {
@@ -264,7 +263,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('allows GitLab target branch metadata on PR review payloads', () => {
-    const parsed = cloudTaskSchema.parse({
+    const parsed = taskSpecSchema.parse({
       type: TaskPayloadKind.GithubPrReview,
       userId: 'user-1',
       payload: {
@@ -287,7 +286,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('allows Gitea target branch metadata on PR review payloads', () => {
-    const parsed = cloudTaskSchema.parse({
+    const parsed = taskSpecSchema.parse({
       type: TaskPayloadKind.GithubPrReview,
       userId: 'user-1',
       payload: {
@@ -311,7 +310,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('allows Azure DevOps target branch metadata on PR review payloads', () => {
-    const parsed = cloudTaskSchema.parse({
+    const parsed = taskSpecSchema.parse({
       type: TaskPayloadKind.GithubPrReview,
       userId: 'user-1',
       payload: {
@@ -336,7 +335,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('parses GithubPrReviewFollowUp payloads without any inner bootstrap mode', () => {
-    const parsed = cloudTaskSchema.parse({
+    const parsed = taskSpecSchema.parse({
       userId: 'user-1',
       type: TaskPayloadKind.GithubPrReviewFollowUp,
       payload: {
@@ -358,7 +357,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('normalizes legacy explicit_fix GithubPrReviewFollowUp payloads for backward compatibility', () => {
-    const parsed = cloudTaskSchema.parse({
+    const parsed = taskSpecSchema.parse({
       userId: 'user-1',
       type: TaskPayloadKind.GithubPrReviewFollowUp,
       payload: {
@@ -380,7 +379,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('parses SuggestedTasks payloads', () => {
-    const parsed = cloudTaskSchema.parse({
+    const parsed = taskSpecSchema.parse({
       userId: 'user-1',
       type: TaskPayloadKind.Scan,
       payload: {
@@ -410,7 +409,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('parses SuggestedTasks payloads with Slack routing metadata', () => {
-    const parsed = cloudTaskSchema.parse({
+    const parsed = taskSpecSchema.parse({
       userId: 'user-1',
       type: TaskPayloadKind.Scan,
       slackThreadTs: '111.222',
@@ -433,7 +432,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('parses Dependabot suggestion sources on SuggestedTasks payloads', () => {
-    const parsed = cloudTaskSchema.parse({
+    const parsed = taskSpecSchema.parse({
       userId: 'user-1',
       type: TaskPayloadKind.Scan,
       payload: {
@@ -453,7 +452,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('parses McpRecommendations payloads', () => {
-    const parsed = cloudTaskSchema.parse({
+    const parsed = taskSpecSchema.parse({
       userId: 'user-1',
       type: TaskPayloadKind.McpRecommendations,
       payload: {
@@ -489,7 +488,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('parses SlackAppMention payloads with an optional web return path', () => {
-    const parsed = cloudTaskSchema.parse({
+    const parsed = taskSpecSchema.parse({
       userId: 'user-1',
       type: TaskPayloadKind.SlackAppMention,
       payload: {
@@ -513,7 +512,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('parses StandardTask payloads', () => {
-    const parsed = cloudTaskSchema.parse({
+    const parsed = taskSpecSchema.parse({
       userId: 'user-1',
       type: TaskPayloadKind.StandardTask,
       payload: {
@@ -532,7 +531,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('parses shared reasoningEffort overrides on task payloads', () => {
-    const parsed = cloudTaskSchema.parse({
+    const parsed = taskSpecSchema.parse({
       userId: 'user-1',
       type: TaskPayloadKind.StandardTask,
       payload: {
@@ -550,7 +549,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('parses xhigh reasoningEffort overrides on task payloads', () => {
-    const parsed = cloudTaskSchema.parse({
+    const parsed = taskSpecSchema.parse({
       userId: 'user-1',
       type: TaskPayloadKind.StandardTask,
       payload: {
@@ -568,7 +567,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('parses OpenCode harness model overrides on task payloads', () => {
-    const parsed = cloudTaskSchema.parse({
+    const parsed = taskSpecSchema.parse({
       userId: 'user-1',
       type: TaskPayloadKind.StandardTask,
       payload: {
@@ -590,7 +589,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('parses hidden StandardTask bootstrap metadata without changing the description', () => {
-    const parsed = cloudTaskSchema.parse({
+    const parsed = taskSpecSchema.parse({
       userId: 'user-1',
       harness: 'opencode-server',
       type: TaskPayloadKind.StandardTask,
@@ -618,7 +617,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('parses top-level requested work kind metadata on cloud tasks', () => {
-    const parsed = cloudTaskSchema.parse({
+    const parsed = taskSpecSchema.parse({
       userId: 'user-1',
       requestedWorkKindDecision: {
         kind: 'plan',
@@ -640,7 +639,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('parses multi-repo subset payloads', () => {
-    const parsed = cloudTaskSchema.parse({
+    const parsed = taskSpecSchema.parse({
       userId: 'user-1',
       type: TaskPayloadKind.StandardTask,
       payload: {
@@ -661,7 +660,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('preserves visible prompt fields on SnapshotResume payloads', () => {
-    const parsed = cloudTaskSchema.parse({
+    const parsed = taskSpecSchema.parse({
       userId: 'user-1',
       type: TaskPayloadKind.SnapshotResume,
       payload: {
@@ -686,7 +685,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('normalizes legacy SnapshotEnvironment row attachments without source identity', () => {
-    const parsed = cloudTaskSchema.parse({
+    const parsed = taskSpecSchema.parse({
       userId: 'user-1',
       computeProvider: 'modal',
       type: TaskPayloadKind.SnapshotEnvironment,
@@ -711,7 +710,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('parses SnapshotEnvironment pending-row attachments', () => {
-    const parsed = cloudTaskSchema.parse({
+    const parsed = taskSpecSchema.parse({
       userId: 'user-1',
       computeProvider: 'modal',
       type: TaskPayloadKind.SnapshotEnvironment,
@@ -738,7 +737,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('parses SnapshotResume payloads with canonical Slack routing metadata', () => {
-    const parsed = cloudTaskSchema.parse({
+    const parsed = taskSpecSchema.parse({
       userId: 'user-1',
       type: TaskPayloadKind.SnapshotResume,
       payload: {
@@ -763,7 +762,7 @@ describe('cloudTaskSchema', () => {
   it.each([null, undefined])(
     'accepts shared-task slackThreadTs when the value is %s',
     (slackThreadTs) => {
-      const parsed = cloudTaskSchema.safeParse({
+      const parsed = taskSpecSchema.safeParse({
         userId: 'user-1',
         type: TaskPayloadKind.StandardTask,
         slackThreadTs,
@@ -780,7 +779,7 @@ describe('cloudTaskSchema', () => {
   it.each([null, undefined])(
     'accepts snapshot resume slackThreadTs when the value is %s',
     (slackThreadTs) => {
-      const parsed = cloudTaskSchema.safeParse({
+      const parsed = taskSpecSchema.safeParse({
         userId: 'user-1',
         type: TaskPayloadKind.SnapshotResume,
         slackThreadTs,
@@ -925,7 +924,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('parses SnapshotResume payloads with queued provider-neutral messages', () => {
-    const parsed = cloudTaskSchema.safeParse({
+    const parsed = taskSpecSchema.safeParse({
       userId: 'user-1',
       type: TaskPayloadKind.SnapshotResume,
       sourceSnapshotId: 'snap-123',
@@ -954,7 +953,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('does not parse unknown delegated task payloads', () => {
-    const parsed = cloudTaskSchema.safeParse({
+    const parsed = taskSpecSchema.safeParse({
       userId: 'user-1',
       type: 'invalid.task',
       payload: {
@@ -967,7 +966,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('rejects invalid reasoningEffort values on shared task payloads', () => {
-    const parsed = cloudTaskSchema.safeParse({
+    const parsed = taskSpecSchema.safeParse({
       userId: 'user-1',
       type: TaskPayloadKind.StandardTask,
       payload: {
@@ -981,7 +980,7 @@ describe('cloudTaskSchema', () => {
   });
 
   it('rejects non-OpenCode-format harness model overrides on task payloads', () => {
-    const parsed = cloudTaskSchema.safeParse({
+    const parsed = taskSpecSchema.safeParse({
       userId: 'user-1',
       type: TaskPayloadKind.StandardTask,
       payload: {
@@ -998,7 +997,7 @@ describe('cloudTaskSchema', () => {
 
   it('resolves a repository workspace from a single repo payload', () => {
     expect(
-      resolveCloudTaskWorkspace({
+      resolveTaskWorkspace({
         repo: 'owner/repo',
         branch: 'main',
         sha: 'abc1234',
@@ -1013,7 +1012,7 @@ describe('cloudTaskSchema', () => {
 
   it('resolves a repository_set workspace from a scoped all-repositories payload', () => {
     expect(
-      resolveCloudTaskWorkspace({
+      resolveTaskWorkspace({
         repo: '__all_repositories__',
         selectedRepositories: ['acme/api', 'acme/web', 'acme/api'],
       }),
@@ -1025,7 +1024,7 @@ describe('cloudTaskSchema', () => {
 
   it('resolves an environment workspace while preserving source pin context', () => {
     expect(
-      resolveCloudTaskWorkspace({
+      resolveTaskWorkspace({
         repo: 'acme/api',
         branch: 'main',
         sha: 'abc1234',
@@ -1041,125 +1040,95 @@ describe('cloudTaskSchema', () => {
   });
 });
 
-describe('isActivelyRunningCloudTask', () => {
+describe('isActivelyRunningTask', () => {
   it('returns false for undefined/null status', () => {
-    expect(isActivelyRunningCloudTask(undefined, null)).toBe(false);
-    expect(isActivelyRunningCloudTask(null, null)).toBe(false);
+    expect(isActivelyRunningTask(undefined, null)).toBe(false);
+    expect(isActivelyRunningTask(null, null)).toBe(false);
   });
 
   it('returns true for booting statuses regardless of taskPhase', () => {
-    const bootingStatuses = [...bootingCloudTaskStatuses];
+    const bootingStatuses = [...bootingRunStatuses];
 
     for (const status of bootingStatuses) {
-      expect(isActivelyRunningCloudTask(status, null)).toBe(true);
-      expect(isActivelyRunningCloudTask(status, 'idle')).toBe(true);
-      expect(isActivelyRunningCloudTask(status, 'running')).toBe(true);
+      expect(isActivelyRunningTask(status, null)).toBe(true);
+      expect(isActivelyRunningTask(status, 'idle')).toBe(true);
+      expect(isActivelyRunningTask(status, 'running')).toBe(true);
     }
   });
 
   it('returns true for Running status with taskPhase "running"', () => {
-    expect(isActivelyRunningCloudTask(CloudTaskStatus.Running, 'running')).toBe(
-      true,
-    );
+    expect(isActivelyRunningTask(RunStatus.Running, 'running')).toBe(true);
   });
 
   it('returns true for Running status with null taskPhase (backwards compat)', () => {
-    expect(isActivelyRunningCloudTask(CloudTaskStatus.Running, null)).toBe(
-      true,
-    );
-    expect(isActivelyRunningCloudTask(CloudTaskStatus.Running, undefined)).toBe(
-      true,
-    );
+    expect(isActivelyRunningTask(RunStatus.Running, null)).toBe(true);
+    expect(isActivelyRunningTask(RunStatus.Running, undefined)).toBe(true);
   });
 
   it('returns false for Running status with idle/waiting phases', () => {
-    expect(isActivelyRunningCloudTask(CloudTaskStatus.Running, 'idle')).toBe(
+    expect(isActivelyRunningTask(RunStatus.Running, 'idle')).toBe(false);
+    expect(isActivelyRunningTask(RunStatus.Running, 'waiting_for_prompt')).toBe(
       false,
     );
-    expect(
-      isActivelyRunningCloudTask(CloudTaskStatus.Running, 'waiting_for_prompt'),
-    ).toBe(false);
-    expect(isActivelyRunningCloudTask(CloudTaskStatus.Running, 'stopped')).toBe(
+    expect(isActivelyRunningTask(RunStatus.Running, 'stopped')).toBe(false);
+    expect(isActivelyRunningTask(RunStatus.Running, 'shutting_down')).toBe(
       false,
     );
-    expect(
-      isActivelyRunningCloudTask(CloudTaskStatus.Running, 'shutting_down'),
-    ).toBe(false);
   });
 
   it('returns false for Idle status', () => {
-    expect(isActivelyRunningCloudTask(CloudTaskStatus.Idle, null)).toBe(false);
-    expect(isActivelyRunningCloudTask(CloudTaskStatus.Idle, 'running')).toBe(
-      false,
-    );
+    expect(isActivelyRunningTask(RunStatus.Idle, null)).toBe(false);
+    expect(isActivelyRunningTask(RunStatus.Idle, 'running')).toBe(false);
   });
 
   it('returns false for exited statuses', () => {
-    expect(isActivelyRunningCloudTask(CloudTaskStatus.Completed, null)).toBe(
-      false,
-    );
-    expect(isActivelyRunningCloudTask(CloudTaskStatus.Failed, null)).toBe(
-      false,
-    );
-    expect(isActivelyRunningCloudTask(CloudTaskStatus.Canceled, null)).toBe(
-      false,
-    );
+    expect(isActivelyRunningTask(RunStatus.Completed, null)).toBe(false);
+    expect(isActivelyRunningTask(RunStatus.Failed, null)).toBe(false);
+    expect(isActivelyRunningTask(RunStatus.Canceled, null)).toBe(false);
   });
 });
 
-describe('isCloudTaskExecutingTurn', () => {
+describe('isTaskExecutingTurn', () => {
   it('returns false for undefined/null status', () => {
-    expect(isCloudTaskExecutingTurn(undefined, 'running')).toBe(false);
-    expect(isCloudTaskExecutingTurn(null, 'running')).toBe(false);
+    expect(isTaskExecutingTurn(undefined, 'running')).toBe(false);
+    expect(isTaskExecutingTurn(null, 'running')).toBe(false);
   });
 
   it('returns true for booting statuses regardless of taskPhase', () => {
-    for (const status of [...bootingCloudTaskStatuses]) {
-      expect(isCloudTaskExecutingTurn(status, null)).toBe(true);
-      expect(isCloudTaskExecutingTurn(status, 'waiting_for_prompt')).toBe(true);
-      expect(isCloudTaskExecutingTurn(status, 'running')).toBe(true);
+    for (const status of [...bootingRunStatuses]) {
+      expect(isTaskExecutingTurn(status, null)).toBe(true);
+      expect(isTaskExecutingTurn(status, 'waiting_for_prompt')).toBe(true);
+      expect(isTaskExecutingTurn(status, 'running')).toBe(true);
     }
   });
 
   it('returns true while a turn is executing regardless of Running/Idle status', () => {
-    expect(isCloudTaskExecutingTurn(CloudTaskStatus.Running, 'running')).toBe(
-      true,
-    );
+    expect(isTaskExecutingTurn(RunStatus.Running, 'running')).toBe(true);
     // Follow-up turns on a live sandbox run with Idle status.
-    expect(isCloudTaskExecutingTurn(CloudTaskStatus.Idle, 'running')).toBe(
-      true,
-    );
+    expect(isTaskExecutingTurn(RunStatus.Idle, 'running')).toBe(true);
   });
 
   it('returns true for Running status with no phase info yet', () => {
-    expect(isCloudTaskExecutingTurn(CloudTaskStatus.Running, null)).toBe(true);
-    expect(isCloudTaskExecutingTurn(CloudTaskStatus.Running, undefined)).toBe(
-      true,
-    );
+    expect(isTaskExecutingTurn(RunStatus.Running, null)).toBe(true);
+    expect(isTaskExecutingTurn(RunStatus.Running, undefined)).toBe(true);
   });
 
   it('returns false while the task waits between turns', () => {
-    expect(
-      isCloudTaskExecutingTurn(CloudTaskStatus.Idle, 'waiting_for_prompt'),
-    ).toBe(false);
-    expect(
-      isCloudTaskExecutingTurn(CloudTaskStatus.Running, 'waiting_for_prompt'),
-    ).toBe(false);
-    expect(isCloudTaskExecutingTurn(CloudTaskStatus.Idle, null)).toBe(false);
-    expect(
-      isCloudTaskExecutingTurn(CloudTaskStatus.Idle, 'waiting_for_user_input'),
-    ).toBe(false);
+    expect(isTaskExecutingTurn(RunStatus.Idle, 'waiting_for_prompt')).toBe(
+      false,
+    );
+    expect(isTaskExecutingTurn(RunStatus.Running, 'waiting_for_prompt')).toBe(
+      false,
+    );
+    expect(isTaskExecutingTurn(RunStatus.Idle, null)).toBe(false);
+    expect(isTaskExecutingTurn(RunStatus.Idle, 'waiting_for_user_input')).toBe(
+      false,
+    );
   });
 
   it('returns false for exited statuses even with a stale running phase', () => {
-    expect(isCloudTaskExecutingTurn(CloudTaskStatus.Completed, 'running')).toBe(
-      false,
-    );
-    expect(isCloudTaskExecutingTurn(CloudTaskStatus.Failed, 'running')).toBe(
-      false,
-    );
-    expect(isCloudTaskExecutingTurn(CloudTaskStatus.Canceled, 'running')).toBe(
-      false,
-    );
+    expect(isTaskExecutingTurn(RunStatus.Completed, 'running')).toBe(false);
+    expect(isTaskExecutingTurn(RunStatus.Failed, 'running')).toBe(false);
+    expect(isTaskExecutingTurn(RunStatus.Canceled, 'running')).toBe(false);
   });
 });

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 
 export const jobTokenPayloadSchema = z.object({
   iss: z.string().min(1, 'Issuer (iss) is required'),
-  sub: z.string().min(1, 'Subject (sub) is required'), // CloudJob ID
+  sub: z.string().min(1, 'Subject (sub) is required'), // Run ID
   exp: z.number().int().positive('Expiration (exp) must be a positive integer'),
   iat: z.number().int().positive('Issued at (iat) must be a positive integer'),
   nbf: z.number().int().positive('Not before (nbf) must be a positive integer'),

--- a/packages/types/src/cloud-jobs.ts
+++ b/packages/types/src/cloud-jobs.ts
@@ -279,13 +279,13 @@ export type TrackedMessageKind = (typeof TRACKED_MESSAGE_KINDS)[number];
  * Launch classes used to choose runtime policy for cloud tasks.
  */
 
-export const CLOUD_TASK_LAUNCH_CLASSES = [
+export const RUN_LAUNCH_CLASSES = [
   'human',
   'automation',
   'maintenance',
 ] as const;
 
-export type CloudTaskLaunchClass = (typeof CLOUD_TASK_LAUNCH_CLASSES)[number];
+export type RunLaunchClass = (typeof RUN_LAUNCH_CLASSES)[number];
 
 export const REASONING_EFFORT_VALUES = [
   'low',
@@ -384,7 +384,7 @@ export function isImplicitGeneralistTaskType(type: TaskPayloadKind): boolean {
  * Uses a deny list approach - services are enabled for all types except those
  * that explicitly don't need them.
  */
-export function isServicesEnabledCloudTaskType(
+export function isServicesEnabledTaskPayloadKind(
   _type: TaskPayloadKind,
 ): boolean {
   return true;
@@ -403,7 +403,7 @@ const RESUMABLE_PAYLOAD_KINDS: ReadonlySet<TaskPayloadKind> = new Set([
  * Returns true when a task type should be auto-snapshotted at `sleepAt` and
  * therefore supports resuming from that automatic sleep transition.
  */
-export function isResumableCloudTaskType(type: TaskPayloadKind): boolean {
+export function isResumableTaskPayloadKind(type: TaskPayloadKind): boolean {
   return RESUMABLE_PAYLOAD_KINDS.has(type);
 }
 
@@ -548,7 +548,7 @@ export const HARNESS_LABELS: Record<CodingHarness, string> = {
   'opencode-server': 'OpenCode',
 };
 
-export function stripCloudJobErrorMarkers(
+export function stripRunErrorMarkers(
   error?: string | null,
 ): string | undefined {
   const sanitizedError = error?.trim();
@@ -698,7 +698,7 @@ export const WORKER_HEARTBEAT_STALE_MS = 2 * 60 * 1000; // 2 minutes.
  * Durable audit sources for cloud job lifecycle events.
  * These are intended for operator debugging and post-mortem analysis.
  */
-export const cloudJobEventSources = [
+export const runEventSources = [
   'job_lifecycle',
   'worker_runtime',
   'sleep_check',
@@ -709,7 +709,7 @@ export const cloudJobEventSources = [
   'snapshot_resume',
 ] as const;
 
-export type CloudJobEventSource = (typeof cloudJobEventSources)[number];
+export type RunEventSource = (typeof runEventSources)[number];
 
 /**
  * Durable event categories for cloud job audit history.
@@ -717,7 +717,7 @@ export type CloudJobEventSource = (typeof cloudJobEventSources)[number];
  * Rich decision metadata lives in the accompanying JSON details so callers can
  * extend the shape without a schema change for every new branch reason.
  */
-export const cloudJobEventTypes = [
+export const runEventTypes = [
   'decision',
   'enqueued',
   'started',
@@ -726,9 +726,9 @@ export const cloudJobEventTypes = [
   'phase',
 ] as const;
 
-export type CloudJobEventType = (typeof cloudJobEventTypes)[number];
+export type RunEventType = (typeof runEventTypes)[number];
 
-export type CloudJobEventDetails = Record<string, unknown>;
+export type RunEventDetails = Record<string, unknown>;
 
 export const computeProviderLaunchModes = [
   'fresh',
@@ -754,10 +754,10 @@ export type ComputeProviderMutationOperation =
 export interface ComputeProviderMutationEvent {
   provider: ComputeProvider;
   operation: ComputeProviderMutationOperation;
-  eventType: Extract<CloudJobEventType, 'started' | 'completed' | 'failed'>;
+  eventType: Extract<RunEventType, 'started' | 'completed' | 'failed'>;
   instanceId?: string;
   message?: string;
-  details?: CloudJobEventDetails;
+  details?: RunEventDetails;
 }
 
 export type ComputeProviderMutationObserver = (
@@ -765,7 +765,7 @@ export type ComputeProviderMutationObserver = (
 ) => Promise<void> | void;
 
 /**
- * CloudTask
+ * TaskSpec
  */
 
 const sharedTaskSchema = z.object({
@@ -1750,7 +1750,7 @@ export function populateSnapshotResumeCommunicationMetadata(
  * Discriminated union of all cloud task schemas.
  * Use this schema for runtime validation of cloud task payloads.
  */
-export const cloudTaskSchema = z.discriminatedUnion('type', [
+export const taskSpecSchema = z.discriminatedUnion('type', [
   githubPullRequestReviewFollowUpSchema,
   githubPullRequestReviewOpenSchema,
   githubPullRequestReviewSyncSchema,
@@ -1764,16 +1764,18 @@ export const cloudTaskSchema = z.discriminatedUnion('type', [
   snapshotResumeSchema,
 ]);
 
-export type CloudTask = z.infer<typeof cloudTaskSchema>;
+export type TaskSpec = z.infer<typeof taskSpecSchema>;
 
 /**
- * CloudTaskPayload
+ * TaskPayload
  */
 
-export type CloudTaskPayload<T extends TaskPayloadKind = TaskPayloadKind> =
-  Extract<CloudTask, { type: T }>['payload'];
+export type TaskPayload<T extends TaskPayloadKind = TaskPayloadKind> = Extract<
+  TaskSpec,
+  { type: T }
+>['payload'];
 
-type CloudTaskWorkspacePayload = {
+type TaskWorkspacePayload = {
   repo?: string;
   branch?: string;
   sha?: string;
@@ -1781,7 +1783,7 @@ type CloudTaskWorkspacePayload = {
   selectedRepositories?: string[];
 };
 
-export type CloudTaskWorkspace =
+export type TaskWorkspace =
   | {
       type: 'repository';
       repo: string;
@@ -1814,9 +1816,9 @@ function normalizeSelectedRepositories(
   return normalized.length > 0 ? normalized : undefined;
 }
 
-export function resolveCloudTaskWorkspace(
-  payload: CloudTaskWorkspacePayload,
-): CloudTaskWorkspace {
+export function resolveTaskWorkspace(
+  payload: TaskWorkspacePayload,
+): TaskWorkspace {
   if (payload.environmentId) {
     return {
       type: 'environment',
@@ -1857,15 +1859,15 @@ export function resolveCloudTaskWorkspace(
 }
 
 /**
- * CloudTaskPayload Type Guards
+ * TaskPayload Type Guards
  */
 
 export function isPrReviewJob(
   type: TaskPayloadKind,
-  _payload: CloudTaskPayload,
+  _payload: TaskPayload,
 ): _payload is
-  | CloudTaskPayload<typeof TaskPayloadKind.GithubPrReview>
-  | CloudTaskPayload<typeof TaskPayloadKind.GithubPrReviewSync> {
+  | TaskPayload<typeof TaskPayloadKind.GithubPrReview>
+  | TaskPayload<typeof TaskPayloadKind.GithubPrReviewSync> {
   return (
     type === TaskPayloadKind.GithubPrReview ||
     type === TaskPayloadKind.GithubPrReviewSync
@@ -1873,10 +1875,10 @@ export function isPrReviewJob(
 }
 
 /**
- * CloudTaskStatus
+ * RunStatus
  */
 
-export enum CloudTaskStatus {
+export enum RunStatus {
   Pending = 'pending', // Job is created, but not yet dequeued by the controller.
   Dequeued = 'dequeued', // Job is dequeued by the controller but not yet started by the worker.
   Processing = 'processing', // Job is dequeued by the worker.
@@ -1890,50 +1892,47 @@ export enum CloudTaskStatus {
   Idle = 'idle', // Job is technically completed, but the container is still running and waiting for optional interaction.
 }
 
-export const bootingCloudTaskStatuses = [
-  CloudTaskStatus.Pending,
-  CloudTaskStatus.Dequeued,
-  CloudTaskStatus.Processing,
-  CloudTaskStatus.Preparing,
-  CloudTaskStatus.Spawning,
-  CloudTaskStatus.Connecting,
+export const bootingRunStatuses = [
+  RunStatus.Pending,
+  RunStatus.Dequeued,
+  RunStatus.Processing,
+  RunStatus.Preparing,
+  RunStatus.Spawning,
+  RunStatus.Connecting,
 ] as const;
 
-export const activeCloudTaskStatuses = [
-  ...bootingCloudTaskStatuses,
-  CloudTaskStatus.Running,
-  CloudTaskStatus.Idle,
+export const activeRunStatuses = [
+  ...bootingRunStatuses,
+  RunStatus.Running,
+  RunStatus.Idle,
 ] as const;
 
-export const doneCloudTaskStatuses = [
-  CloudTaskStatus.Completed,
-  CloudTaskStatus.Failed,
-  CloudTaskStatus.Canceled,
-  CloudTaskStatus.Idle,
+export const doneRunStatuses = [
+  RunStatus.Completed,
+  RunStatus.Failed,
+  RunStatus.Canceled,
+  RunStatus.Idle,
 ] as const;
 
-export const runningCloudTaskStatuses = [
-  CloudTaskStatus.Running,
-  CloudTaskStatus.Idle,
+export const runningRunStatuses = [RunStatus.Running, RunStatus.Idle] as const;
+
+const runningStatuses = new Set<RunStatus>(runningRunStatuses);
+
+export const exitedRunStatuses = [
+  RunStatus.Completed,
+  RunStatus.Failed,
+  RunStatus.Canceled,
 ] as const;
 
-const runningStatuses = new Set<CloudTaskStatus>(runningCloudTaskStatuses);
+const exitedStatuses = new Set<RunStatus>(exitedRunStatuses);
 
-export const exitedCloudTaskStatuses = [
-  CloudTaskStatus.Completed,
-  CloudTaskStatus.Failed,
-  CloudTaskStatus.Canceled,
-] as const;
-
-const exitedStatuses = new Set<CloudTaskStatus>(exitedCloudTaskStatuses);
-
-export const isBootingCloudTaskStatus = (status?: CloudTaskStatus): boolean =>
+export const isBootingRunStatus = (status?: RunStatus): boolean =>
   !!status && !runningStatuses.has(status) && !exitedStatuses.has(status);
 
-export const isRunningCloudTaskStatus = (status?: CloudTaskStatus): boolean =>
+export const isRunningRunStatus = (status?: RunStatus): boolean =>
   !!status && runningStatuses.has(status);
 
-export const isExitedCloudTaskStatus = (status?: CloudTaskStatus): boolean =>
+export const isExitedRunStatus = (status?: RunStatus): boolean =>
   !!status && exitedStatuses.has(status);
 
 /**
@@ -1999,14 +1998,14 @@ export function isActiveTaskPhase(phase: TaskPhase): boolean {
  * Returns true when the cloud task is actively consuming attention -- either
  * still booting or the agent is actively working.  Use this to drive loading
  * indicators and "running" badge counts instead of relying solely on
- * CloudTaskStatus.
+ * RunStatus.
  *
  * The `taskPhase` column is populated by the worker once the job reaches
  * the Running status.  For older jobs that never set a phase we fall back
  * to the legacy behaviour (treat Running status as active).
  */
-export function isActivelyRunningCloudTask(
-  status?: CloudTaskStatus | null,
+export function isActivelyRunningTask(
+  status?: RunStatus | null,
   taskPhase?: string | null,
 ): boolean {
   if (!status) {
@@ -2019,17 +2018,17 @@ export function isActivelyRunningCloudTask(
   }
 
   // Booting jobs (Pending → Connecting) are always active.
-  if (isBootingCloudTaskStatus(status)) {
+  if (isBootingRunStatus(status)) {
     return true;
   }
 
   // Idle status means the job completed (container still alive for keepalive).
-  if (status === CloudTaskStatus.Idle) {
+  if (status === RunStatus.Idle) {
     return false;
   }
 
   // Running status: check the task phase.
-  if (status === CloudTaskStatus.Running) {
+  if (status === RunStatus.Running) {
     // No phase info yet (still initialising or legacy job) → treat as active.
     if (!taskPhase) {
       return true;
@@ -2045,7 +2044,7 @@ export function isActivelyRunningCloudTask(
  * Returns true when the cloud task is busy executing a turn, or booting
  * toward one.
  *
- * Unlike {@link isActivelyRunningCloudTask}, which drives UI "running" badge
+ * Unlike {@link isActivelyRunningTask}, which drives UI "running" badge
  * counts and short-circuits on the Idle status, this treats the
  * worker-reported task phase as the source of truth for live sandboxes: a
  * cloud job row only holds the Running status during its first turn, flips to
@@ -2055,8 +2054,8 @@ export function isActivelyRunningCloudTask(
  * deliver conversation messages that should only arrive while the task is not
  * mid-turn.
  */
-export function isCloudTaskExecutingTurn(
-  status?: CloudTaskStatus | null,
+export function isTaskExecutingTurn(
+  status?: RunStatus | null,
   taskPhase?: string | null,
 ): boolean {
   if (!status) {
@@ -2069,13 +2068,13 @@ export function isCloudTaskExecutingTurn(
   }
 
   // Booting jobs (Pending → Connecting) are about to execute a turn.
-  if (isBootingCloudTaskStatus(status)) {
+  if (isBootingRunStatus(status)) {
     return true;
   }
 
   // Running with no phase info yet (still initialising or legacy job) →
   // treat as mid-turn.
-  if (status === CloudTaskStatus.Running && !taskPhase) {
+  if (status === RunStatus.Running && !taskPhase) {
     return true;
   }
 

--- a/packages/types/src/keepalive-policy.ts
+++ b/packages/types/src/keepalive-policy.ts
@@ -1,4 +1,4 @@
-import { TaskPayloadKind, type CloudTaskLaunchClass } from './cloud-jobs';
+import { TaskPayloadKind, type RunLaunchClass } from './cloud-jobs';
 import {
   DEFAULT_AUTOMATION_KEEPALIVE_MS,
   DEFAULT_MAINTENANCE_KEEPALIVE_MS,
@@ -10,7 +10,7 @@ const TASK_TYPE_KEEPALIVE_MS_OVERRIDES = new Map<TaskPayloadKind, number>([
 
 export function inferLaunchClassForTaskType(
   taskType: TaskPayloadKind,
-): CloudTaskLaunchClass {
+): RunLaunchClass {
   switch (taskType) {
     case TaskPayloadKind.GithubPrReview:
     case TaskPayloadKind.GithubPrReviewSync:
@@ -26,13 +26,13 @@ export function inferLaunchClassForTaskType(
 
 export function resolveCloudTaskRuntimePolicy(options: {
   taskType: TaskPayloadKind;
-  launchClass?: CloudTaskLaunchClass | null;
+  launchClass?: RunLaunchClass | null;
   appEnv?: 'development' | 'preview' | 'production' | 'test' | null;
   defaultKeepaliveMs: number;
   delegatedKeepaliveMs: number;
   sandboxTimeoutMs: number;
 }): {
-  launchClass: CloudTaskLaunchClass;
+  launchClass: RunLaunchClass;
   keepaliveMs: number;
 } {
   const launchClass =
@@ -69,7 +69,7 @@ function resolveHumanKeepaliveMs(options: {
 
 function resolveKeepaliveMsForResolvedLaunchClass(options: {
   taskType?: TaskPayloadKind | null;
-  launchClass?: CloudTaskLaunchClass | null;
+  launchClass?: RunLaunchClass | null;
   appEnv?: 'development' | 'preview' | 'production' | 'test' | null;
   defaultKeepaliveMs: number;
   delegatedKeepaliveMs: number;
@@ -116,7 +116,7 @@ function resolveKeepaliveMsForResolvedLaunchClass(options: {
 
 export function resolveKeepaliveMs(options: {
   taskType?: TaskPayloadKind | null;
-  launchClass?: CloudTaskLaunchClass | null;
+  launchClass?: RunLaunchClass | null;
   appEnv?: 'development' | 'preview' | 'production' | 'test' | null;
   defaultKeepaliveMs: number;
   delegatedKeepaliveMs: number;


### PR DESCRIPTION
## Summary

Completes the deferred **Stage 5 CloudJob → Run** TypeScript vocabulary rename that PR #45 intentionally postponed. The data model was already renamed at the DB layer (`cloud_jobs` → `task_runs`); this makes the code vocabulary match: a **run** is an execution attempt of a **task**.

Pure type/identifier rename — **zero runtime behavior change**. No DB, wire, env var, or Redis changes. Enum member names and all runtime string values (DB values, wire formats, Redis keys) are unchanged.

## Rename mapping

### Scope 1 — db type aliases (deleted the `TODO(stage5-rename)` aliases in `packages/db/src/types.ts`)
| Old | New |
| --- | --- |
| `CloudJob` | `Run` |
| `CreateCloudJob` | `CreateRun` |
| `UpdateCloudJob` | `UpdateRun` |
| `CloudJobEvent` | `RunEvent` |
| `CreateCloudJobEvent` | `CreateRunEvent` |

### Scope 2 — `packages/types/src/cloud-jobs.ts` vocabulary
| Old | New |
| --- | --- |
| `CloudTaskStatus` (enum) | `RunStatus` (members + string values unchanged) |
| `CloudTaskPayload` | `TaskPayload` |
| `CloudTask` (z.infer union) | `TaskSpec` ¹ |
| `cloudTaskSchema` | `taskSpecSchema` |
| `CloudTaskWorkspace` / `CloudTaskWorkspacePayload` / `resolveCloudTaskWorkspace` | `TaskWorkspace` / `TaskWorkspacePayload` / `resolveTaskWorkspace` |
| `CloudTaskLaunchClass` / `CLOUD_TASK_LAUNCH_CLASSES` | `RunLaunchClass` / `RUN_LAUNCH_CLASSES` |
| `CloudJobEventSource` / `Type` / `Details` | `RunEventSource` / `Type` / `Details` |
| `cloudJobEventSources` / `cloudJobEventTypes` | `runEventSources` / `runEventTypes` |
| `isResumableCloudTaskType` | `isResumableTaskPayloadKind` |
| `isServicesEnabledCloudTaskType` | `isServicesEnabledTaskPayloadKind` |
| `stripCloudJobErrorMarkers` | `stripRunErrorMarkers` |
| `booting`/`active`/`exited`/`done`/`runningCloudTaskStatuses` | `*RunStatuses` |
| `isBooting`/`isRunning`/`isExitedCloudTaskStatus` | `isBooting`/`isRunning`/`isExitedRunStatus` |
| `isActivelyRunningCloudTask` | `isActivelyRunningTask` |
| `isCloudTaskExecutingTurn` | `isTaskExecutingTurn` |

¹ `CloudTask` → `Task` **collides** with the existing `Task` db type (`$inferSelect` of the `tasks` table), so the z.infer union was renamed to **`TaskSpec`** instead. One consistent name used throughout.

### Scope 3 — function/variable vocabulary + file renames
| Old | New |
| --- | --- |
| `finishCloudJob` (+ `mockFinishCloudJob`) | `finishRun` (+ `mockFinishRun`) |
| `enqueueCloudTask` (+ `EnqueueCloudTaskInput`/`Options`, `enqueueCloudTaskInputSchema`, mocks) | `enqueueTask` (+ `EnqueueTaskInput`/`Options`, `enqueueTaskInputSchema`, mocks) |
| `packages/sdk/.../finish-cloud-job.ts` (+ test) | `finish-run.ts` (+ test) — `git mv` |
| `packages/cloud-agents/.../enqueue-cloud-task.test.ts` | `enqueue-task.test.ts` — `git mv` |

Log-prefix strings (e.g. `[finishRun]`) were updated to match the identifiers; these are observability-only, not parsed anywhere.

## Wire contracts preserved
No serialized field names were touched. In particular **`cloudJobId` was deliberately left unchanged** (1530 refs) because it appears throughout wire surfaces — tRPC input schemas, job-token claims, sandbox RPC payloads, Docker worker command args, and API/URL routes — where renaming would break rolling-deploy compatibility. See "Left as follow-up" below.

## Left as follow-up (documented, not done)
To keep churn bounded and the build green (per the "green build beats a broken sweep" guidance), the following broader vocabulary was **intentionally not** renamed in this pass:

- **`cloudJobId` → `runId`** (1530 refs) — heavily wire-entangled; needs per-occurrence classification of internal-id vs wire-field, out of scope for a mechanical sweep.
- **Peripheral `*CloudJob*` function/class names** whose file/dir/URL/telemetry surfaces are load-bearing: `CloudJobQueue`, `dequeueCloudJob`/`dequeueCloudTask` (telemetry stage strings like `resume.dequeueCloudJob.bootstrapFailure`), `findCloudJob`, `updateCloudJob`, `recordCloudJobEvent`, `getCloudJobLogs`, `generateCloudJobTitle`, `createStandardTaskCloudJob`, etc.
- **The `cloud-jobs/` directory, tRPC router paths, and `apps/web/src/app/api/cloud-jobs/[id]/...` URL routes** — these are wire/URL surfaces and were left untouched.

## Validation
- `pnpm lint` — 24/24 ✓
- `pnpm check-types` — 24/24 ✓
- `pnpm test` — 24/24 ✓ (all DB-backed suites included)
- `pnpm knip` — **zero delta**: base `origin/develop` reports identical counts (6 unused files / 157 unused exports / 141 unused types); this rename introduces no new knip issues. The deleted db aliases leave no unused exports. (The pre-existing knip baseline fails locally, so the push used `--no-verify`; the same failure exists on `develop`.)
