### PR TITLE
[Fix] Job tokens can no longer reassign their run's acting user

### DIFF
--- a/apps/api/src/handlers/linear/__tests__/linear-active-job-priority.test.ts
+++ b/apps/api/src/handlers/linear/__tests__/linear-active-job-priority.test.ts
@@ -29,6 +29,13 @@ const {
   createMcpOauthReplayMock: vi.fn(),
 }));
 
+const { setTrustedRunActingUserOnSuccessMock } = vi.hoisted(() => ({
+  setTrustedRunActingUserOnSuccessMock: vi.fn(
+    async ({ operation }: { operation: () => Promise<boolean> }) =>
+      await operation(),
+  ),
+}));
+
 vi.mock('@roomote/env', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@roomote/env')>();
 
@@ -158,6 +165,7 @@ vi.mock('@roomote/db/server', async (importOriginal) => {
     },
     linearAuthTokens: {},
     webhooks: { id: 'id', deliveryId: 'deliveryId' },
+    setTrustedRunActingUserOnSuccess: setTrustedRunActingUserOnSuccessMock,
     eq: vi.fn(),
     and: vi.fn(),
   };
@@ -386,6 +394,18 @@ describe('CLO-1133: active job takes priority over routing confirmation and elic
           },
         },
       }),
+    );
+    expect(setTrustedRunActingUserOnSuccessMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 42,
+        userId: 'user-1',
+        operation: expect.any(Function),
+      }),
+    );
+    expect(
+      setTrustedRunActingUserOnSuccessMock.mock.invocationCallOrder[0]!,
+    ).toBeLessThan(
+      vi.mocked(queueLinearRequestUserInputAnswer).mock.invocationCallOrder[0]!,
     );
     expect(markPendingLinearRequestUserInputSubmitted).toHaveBeenCalledWith(
       'session-1',

--- a/apps/api/src/handlers/linear/index.ts
+++ b/apps/api/src/handlers/linear/index.ts
@@ -56,6 +56,7 @@ import {
 } from '@roomote/linear';
 
 import type { WebhookResponse } from '../../types';
+import { syncActingUserForInboundMessage } from '../tasks/acting-user-sync.js';
 
 import { recordLinearWebhook } from './recordWebhook';
 
@@ -597,6 +598,13 @@ async function handleAgentSessionEvent(
         }
       }
 
+      // Trusted pre-queue actor switch; see acting-user-sync.ts. The worker
+      // only runs the queued turn as this sender if the server actor matches.
+      await syncActingUserForInboundMessage({
+        logContext: 'linear.activeJobMessage',
+        jobId: activeJob.id,
+        senderUserId: userId,
+      });
       // Queue the message for the running worker to pick up
       await queueLinearMessage(activeJob.id, sessionId, payload, userId);
 

--- a/apps/api/src/handlers/linear/index.ts
+++ b/apps/api/src/handlers/linear/index.ts
@@ -23,6 +23,7 @@ import {
 } from '@roomote/cloud-agents/server';
 import { getRedis } from '@roomote/redis';
 import { postRouterDebugMessage } from '@roomote/slack';
+import { setTrustedRunActingUserOnSuccess } from '@roomote/db/server';
 import {
   createMcpOauthReplay,
   findLinearDeploymentMcpConnectionByIdentity,
@@ -578,17 +579,29 @@ async function handleAgentSessionEvent(
           );
 
           if (parsedReply) {
-            await queueLinearRequestUserInputAnswer(activeJob.id, {
-              requestId: pendingRequest.requestId,
-              answers: parsedReply.answers,
+            // Question answers return before the normal active-message actor
+            // sync below, so apply the trusted sender before marking the
+            // request submitted. Otherwise the worker drops a different
+            // linked user's answer as a mismatch and it cannot be resent.
+            await setTrustedRunActingUserOnSuccess({
+              runId: activeJob.id,
               userId,
-              timestamp: Date.now(),
-            });
+              operation: async () => {
+                await queueLinearRequestUserInputAnswer(activeJob.id, {
+                  requestId: pendingRequest.requestId,
+                  answers: parsedReply.answers,
+                  userId,
+                  timestamp: Date.now(),
+                });
 
-            await markPendingLinearRequestUserInputSubmitted(
-              sessionId,
-              pendingRequest.requestId,
-            );
+                await markPendingLinearRequestUserInputSubmitted(
+                  sessionId,
+                  pendingRequest.requestId,
+                );
+
+                return true;
+              },
+            });
 
             return { status: 'ok' };
           }

--- a/apps/api/src/handlers/mcp/proxy-utils.ts
+++ b/apps/api/src/handlers/mcp/proxy-utils.ts
@@ -78,6 +78,12 @@ export function toMcpToolResult<T extends Record<string, unknown>>(payload: T) {
  * from `task_messages`, because transcript persistence is async and may lag
  * behind the turn that is about to make MCP calls. The token's own userId is
  * mint-time attribution and deliberately plays no role here.
+ *
+ * Since this column selects whose credentials MCP calls run as, it is written
+ * only by trusted server-side actors (web steer, follow-up delivery). Job
+ * tokens cannot reassign it — `cloudJobs.update` strips `actingUserId` from
+ * job-token input — so a compromised sandbox cannot steer MCP calls to
+ * another user's connections.
  */
 export async function resolveActingUserId(
   auth: McpAuthContext,

--- a/apps/api/src/handlers/slack/events/active-job.ts
+++ b/apps/api/src/handlers/slack/events/active-job.ts
@@ -30,6 +30,7 @@ import {
   stripLeadingRawSlackMention,
   stripLeadingSlackProductMention,
 } from '@roomote/cloud-agents';
+import { setTrustedRunActingUserOnSuccess } from '@roomote/db/server';
 
 import { apiLogger } from '../../../logging.js';
 import { syncActingUserForInboundMessage } from '../../tasks/acting-user-sync.js';
@@ -142,16 +143,21 @@ async function handlePendingRequestUserInputReply(params: {
     }
 
     if (parsedCurrentQuestionReply.resolution === 'cancelled') {
-      const submitted = await submitPendingSlackRequestUserInputAnswer(
-        threadId,
-        pendingRequest,
-        {
-          answers: {},
-          user: event.user,
-          userId,
-          ts: event.ts,
-        },
-      );
+      const submitted = await setTrustedRunActingUserOnSuccess({
+        runId: activeJob.id,
+        userId,
+        operation: async () =>
+          await submitPendingSlackRequestUserInputAnswer(
+            threadId,
+            pendingRequest,
+            {
+              answers: {},
+              user: event.user,
+              userId,
+              ts: event.ts,
+            },
+          ),
+      });
 
       if (!submitted) {
         await postRequestUserInputAlreadyReceivedMessage({
@@ -197,16 +203,21 @@ async function handlePendingRequestUserInputReply(params: {
     const nextQuestionIndex = (currentQuestion.questionIndex ?? 0) + 1;
 
     if (nextQuestionIndex >= pendingRequest.questions.length) {
-      const submitted = await submitPendingSlackRequestUserInputAnswer(
-        threadId,
-        pendingRequest,
-        {
-          answers: nextAnswers,
-          user: event.user,
-          userId,
-          ts: event.ts,
-        },
-      );
+      const submitted = await setTrustedRunActingUserOnSuccess({
+        runId: activeJob.id,
+        userId,
+        operation: async () =>
+          await submitPendingSlackRequestUserInputAnswer(
+            threadId,
+            pendingRequest,
+            {
+              answers: nextAnswers,
+              user: event.user,
+              userId,
+              ts: event.ts,
+            },
+          ),
+      });
 
       if (!submitted) {
         await postRequestUserInputAlreadyReceivedMessage({
@@ -310,16 +321,17 @@ async function handlePendingRequestUserInputReply(params: {
     ? parsedReply.answers[currentQuestion.question.id]?.answers[0]
     : undefined;
 
-  const submitted = await submitPendingSlackRequestUserInputAnswer(
-    threadId,
-    pendingRequest,
-    {
-      answers: parsedReply.resolution === 'cancelled' ? {} : mergedAnswers,
-      user: event.user,
-      userId,
-      ts: event.ts,
-    },
-  );
+  const submitted = await setTrustedRunActingUserOnSuccess({
+    runId: activeJob.id,
+    userId,
+    operation: async () =>
+      await submitPendingSlackRequestUserInputAnswer(threadId, pendingRequest, {
+        answers: parsedReply.resolution === 'cancelled' ? {} : mergedAnswers,
+        user: event.user,
+        userId,
+        ts: event.ts,
+      }),
+  });
 
   if (!submitted) {
     await postRequestUserInputAlreadyReceivedMessage({

--- a/apps/api/src/handlers/slack/events/active-job.ts
+++ b/apps/api/src/handlers/slack/events/active-job.ts
@@ -32,6 +32,7 @@ import {
 } from '@roomote/cloud-agents';
 
 import { apiLogger } from '../../../logging.js';
+import { syncActingUserForInboundMessage } from '../../tasks/acting-user-sync.js';
 import {
   buildResolvedCurrentMessageText,
   processSlackAttachments,
@@ -494,6 +495,14 @@ export async function processActiveJobMessage(
     const allImages = [...attachments.images, ...claimedImageUris];
 
     try {
+      // Trusted pre-queue actor switch: the worker only runs this message's
+      // turn as `userId` if the server-side acting user already points at
+      // them (job tokens can no longer write actingUserId themselves).
+      await syncActingUserForInboundMessage({
+        logContext: 'slack.processActiveJobMessage',
+        jobId: activeJob.id,
+        senderUserId: userId,
+      });
       await queueSlackMessage(activeJob.id, {
         text: messageTextWithVideoDescriptions,
         user: event.user,

--- a/apps/api/src/handlers/tasks/__tests__/acting-user-sync.test.ts
+++ b/apps/api/src/handlers/tasks/__tests__/acting-user-sync.test.ts
@@ -1,25 +1,20 @@
-const { mockDbUpdate, mockDbSet, mockDbWhere, mockLogHandlerError } =
-  vi.hoisted(() => {
-    const mockDbWhere = vi.fn();
-    const mockDbSet = vi.fn(() => ({ where: mockDbWhere }));
-    const mockDbUpdate = vi.fn(() => ({ set: mockDbSet }));
-
-    return {
-      mockDbUpdate,
-      mockDbSet,
-      mockDbWhere,
-      mockLogHandlerError: vi.fn(),
-    };
-  });
+const {
+  mockCompareAndSetTrustedRunActingUser,
+  mockSetTrustedRunActingUser,
+  mockLogHandlerError,
+} = vi.hoisted(() => ({
+  mockCompareAndSetTrustedRunActingUser: vi.fn(),
+  mockSetTrustedRunActingUser: vi.fn(),
+  mockLogHandlerError: vi.fn(),
+}));
 
 vi.mock('@roomote/db/server', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@roomote/db/server')>();
 
   return {
     ...actual,
-    db: {
-      update: mockDbUpdate,
-    },
+    compareAndSetTrustedRunActingUser: mockCompareAndSetTrustedRunActingUser,
+    setTrustedRunActingUser: mockSetTrustedRunActingUser,
   };
 });
 
@@ -28,6 +23,7 @@ vi.mock('../../utils', () => ({
 }));
 
 import {
+  restoreActingUserIdAfterFailedDelivery,
   syncActingUserForInboundMessage,
   updateActingUserIdIfNeeded,
 } from '../acting-user-sync';
@@ -35,7 +31,7 @@ import {
 describe('updateActingUserIdIfNeeded', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockDbWhere.mockResolvedValue(undefined);
+    mockCompareAndSetTrustedRunActingUser.mockResolvedValue(true);
   });
 
   it('writes the next acting user when it differs', async () => {
@@ -46,7 +42,11 @@ describe('updateActingUserIdIfNeeded', () => {
       preserveActor: false,
     });
 
-    expect(mockDbSet).toHaveBeenCalledWith({ actingUserId: 'user-2' });
+    expect(mockCompareAndSetTrustedRunActingUser).toHaveBeenCalledWith({
+      runId: 42,
+      expectedUserId: 'user-1',
+      nextUserId: 'user-2',
+    });
   });
 
   it('is idempotent: skips the write when the actor already matches', async () => {
@@ -57,7 +57,7 @@ describe('updateActingUserIdIfNeeded', () => {
       preserveActor: false,
     });
 
-    expect(mockDbUpdate).not.toHaveBeenCalled();
+    expect(mockCompareAndSetTrustedRunActingUser).not.toHaveBeenCalled();
   });
 
   it('never overwrites the actor for actor-preserving sender modes', async () => {
@@ -68,11 +68,13 @@ describe('updateActingUserIdIfNeeded', () => {
       preserveActor: true,
     });
 
-    expect(mockDbUpdate).not.toHaveBeenCalled();
+    expect(mockCompareAndSetTrustedRunActingUser).not.toHaveBeenCalled();
   });
 
   it('propagates write failures so callers can abort delivery', async () => {
-    mockDbWhere.mockRejectedValueOnce(new Error('db unavailable'));
+    mockCompareAndSetTrustedRunActingUser.mockRejectedValueOnce(
+      new Error('db unavailable'),
+    );
 
     await expect(
       updateActingUserIdIfNeeded({
@@ -85,10 +87,52 @@ describe('updateActingUserIdIfNeeded', () => {
   });
 });
 
+describe('restoreActingUserIdAfterFailedDelivery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCompareAndSetTrustedRunActingUser.mockResolvedValue(true);
+  });
+
+  it('rolls back only while the attempted actor still owns the run', async () => {
+    await restoreActingUserIdAfterFailedDelivery({
+      handlerName: 'sendMessageToTask',
+      jobId: 42,
+      previousActingUserId: 'user-1',
+      attemptedActingUserId: 'user-2',
+    });
+
+    expect(mockCompareAndSetTrustedRunActingUser).toHaveBeenCalledWith({
+      runId: 42,
+      expectedUserId: 'user-2',
+      nextUserId: 'user-1',
+    });
+  });
+
+  it('keeps the delivery error primary when rollback fails', async () => {
+    mockCompareAndSetTrustedRunActingUser.mockRejectedValueOnce(
+      new Error('rollback unavailable'),
+    );
+
+    await expect(
+      restoreActingUserIdAfterFailedDelivery({
+        handlerName: 'sendMessageToTask',
+        jobId: 42,
+        previousActingUserId: 'user-1',
+        attemptedActingUserId: 'user-2',
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mockLogHandlerError).toHaveBeenCalledWith(
+      'sendMessageToTask',
+      expect.stringContaining('rollback unavailable'),
+    );
+  });
+});
+
 describe('syncActingUserForInboundMessage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockDbWhere.mockResolvedValue(undefined);
+    mockSetTrustedRunActingUser.mockResolvedValue(undefined);
   });
 
   it('writes the mapped sender as the acting user before the message is queued', async () => {
@@ -98,7 +142,10 @@ describe('syncActingUserForInboundMessage', () => {
       senderUserId: 'user-2',
     });
 
-    expect(mockDbSet).toHaveBeenCalledWith({ actingUserId: 'user-2' });
+    expect(mockSetTrustedRunActingUser).toHaveBeenCalledWith({
+      runId: 42,
+      userId: 'user-2',
+    });
   });
 
   it('skips unmapped senders so the run keeps its current actor', async () => {
@@ -113,13 +160,15 @@ describe('syncActingUserForInboundMessage', () => {
       senderUserId: null,
     });
 
-    expect(mockDbUpdate).not.toHaveBeenCalled();
+    expect(mockSetTrustedRunActingUser).not.toHaveBeenCalled();
   });
 
   it('is non-fatal: logs write failures instead of throwing', async () => {
     // If this write fails the worker detects the mismatch at delivery time
-    // and runs the turn under the server actor — queueing must not break.
-    mockDbWhere.mockRejectedValueOnce(new Error('db unavailable'));
+    // and skips the message — queueing the webhook itself must not break.
+    mockSetTrustedRunActingUser.mockRejectedValueOnce(
+      new Error('db unavailable'),
+    );
 
     await expect(
       syncActingUserForInboundMessage({

--- a/apps/api/src/handlers/tasks/__tests__/acting-user-sync.test.ts
+++ b/apps/api/src/handlers/tasks/__tests__/acting-user-sync.test.ts
@@ -1,0 +1,137 @@
+const { mockDbUpdate, mockDbSet, mockDbWhere, mockLogHandlerError } =
+  vi.hoisted(() => {
+    const mockDbWhere = vi.fn();
+    const mockDbSet = vi.fn(() => ({ where: mockDbWhere }));
+    const mockDbUpdate = vi.fn(() => ({ set: mockDbSet }));
+
+    return {
+      mockDbUpdate,
+      mockDbSet,
+      mockDbWhere,
+      mockLogHandlerError: vi.fn(),
+    };
+  });
+
+vi.mock('@roomote/db/server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@roomote/db/server')>();
+
+  return {
+    ...actual,
+    db: {
+      update: mockDbUpdate,
+    },
+  };
+});
+
+vi.mock('../../utils', () => ({
+  logHandlerError: mockLogHandlerError,
+}));
+
+import {
+  syncActingUserForInboundMessage,
+  updateActingUserIdIfNeeded,
+} from '../acting-user-sync';
+
+describe('updateActingUserIdIfNeeded', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbWhere.mockResolvedValue(undefined);
+  });
+
+  it('writes the next acting user when it differs', async () => {
+    await updateActingUserIdIfNeeded({
+      jobId: 42,
+      currentActingUserId: 'user-1',
+      nextActingUserId: 'user-2',
+      preserveActor: false,
+    });
+
+    expect(mockDbSet).toHaveBeenCalledWith({ actingUserId: 'user-2' });
+  });
+
+  it('is idempotent: skips the write when the actor already matches', async () => {
+    await updateActingUserIdIfNeeded({
+      jobId: 42,
+      currentActingUserId: 'user-2',
+      nextActingUserId: 'user-2',
+      preserveActor: false,
+    });
+
+    expect(mockDbUpdate).not.toHaveBeenCalled();
+  });
+
+  it('never overwrites the actor for actor-preserving sender modes', async () => {
+    await updateActingUserIdIfNeeded({
+      jobId: 42,
+      currentActingUserId: 'user-1',
+      nextActingUserId: 'user-2',
+      preserveActor: true,
+    });
+
+    expect(mockDbUpdate).not.toHaveBeenCalled();
+  });
+
+  it('propagates write failures so callers can abort delivery', async () => {
+    mockDbWhere.mockRejectedValueOnce(new Error('db unavailable'));
+
+    await expect(
+      updateActingUserIdIfNeeded({
+        jobId: 42,
+        currentActingUserId: 'user-1',
+        nextActingUserId: 'user-2',
+        preserveActor: false,
+      }),
+    ).rejects.toThrow('db unavailable');
+  });
+});
+
+describe('syncActingUserForInboundMessage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbWhere.mockResolvedValue(undefined);
+  });
+
+  it('writes the mapped sender as the acting user before the message is queued', async () => {
+    await syncActingUserForInboundMessage({
+      logContext: 'test.queue',
+      jobId: 42,
+      senderUserId: 'user-2',
+    });
+
+    expect(mockDbSet).toHaveBeenCalledWith({ actingUserId: 'user-2' });
+  });
+
+  it('skips unmapped senders so the run keeps its current actor', async () => {
+    await syncActingUserForInboundMessage({
+      logContext: 'test.queue',
+      jobId: 42,
+      senderUserId: undefined,
+    });
+    await syncActingUserForInboundMessage({
+      logContext: 'test.queue',
+      jobId: 42,
+      senderUserId: null,
+    });
+
+    expect(mockDbUpdate).not.toHaveBeenCalled();
+  });
+
+  it('is non-fatal: logs write failures instead of throwing', async () => {
+    // If this write fails the worker detects the mismatch at delivery time
+    // and runs the turn under the server actor — queueing must not break.
+    mockDbWhere.mockRejectedValueOnce(new Error('db unavailable'));
+
+    await expect(
+      syncActingUserForInboundMessage({
+        logContext: 'test.queue',
+        jobId: 42,
+        senderUserId: 'user-2',
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mockLogHandlerError).toHaveBeenCalledWith(
+      'test.queue',
+      expect.stringContaining('db unavailable'),
+    );
+  });
+});

--- a/apps/api/src/handlers/tasks/__tests__/sendMessageToTask.test.ts
+++ b/apps/api/src/handlers/tasks/__tests__/sendMessageToTask.test.ts
@@ -8,6 +8,7 @@ const {
   mockSendPromptMutate,
   mockSteerTaskMutate,
   mockTrackLatestUserMessageForSlackQuote,
+  mockRestoreActingUserIdAfterFailedDelivery,
   mockUpdateActingUserIdIfNeeded,
   mockUserFindFirst,
 } = vi.hoisted(() => ({
@@ -20,11 +21,14 @@ const {
   mockSendPromptMutate: vi.fn(),
   mockSteerTaskMutate: vi.fn(),
   mockTrackLatestUserMessageForSlackQuote: vi.fn(),
+  mockRestoreActingUserIdAfterFailedDelivery: vi.fn(),
   mockUpdateActingUserIdIfNeeded: vi.fn(),
   mockUserFindFirst: vi.fn(),
 }));
 
 vi.mock('../acting-user-sync', () => ({
+  restoreActingUserIdAfterFailedDelivery:
+    mockRestoreActingUserIdAfterFailedDelivery,
   updateActingUserIdIfNeeded: mockUpdateActingUserIdIfNeeded,
 }));
 
@@ -174,7 +178,11 @@ describe('sendMessageToTask', () => {
       linearOrganizationId: null,
     });
     mockTrackLatestUserMessageForSlackQuote.mockResolvedValue(undefined);
-    mockUpdateActingUserIdIfNeeded.mockResolvedValue(undefined);
+    mockRestoreActingUserIdAfterFailedDelivery.mockResolvedValue(undefined);
+    mockUpdateActingUserIdIfNeeded.mockImplementation(
+      async ({ currentActingUserId, nextActingUserId, preserveActor }) =>
+        !preserveActor && currentActingUserId !== nextActingUserId,
+    );
     mockUserFindFirst.mockResolvedValue({
       name: 'Alice',
       email: 'alice@example.com',
@@ -205,6 +213,10 @@ describe('sendMessageToTask', () => {
     expect(
       mockUpdateActingUserIdIfNeeded.mock.invocationCallOrder[0]!,
     ).toBeLessThan(mockSendPromptMutate.mock.invocationCallOrder[0]!);
+    expect(mockSendPromptMutate).toHaveBeenCalledWith({
+      prompt: 'Continue as the new sender.',
+      autoSteerWhenQueued: true,
+    });
   });
 
   it('does not deliver the prompt when the pre-delivery acting-user write fails', async () => {
@@ -227,6 +239,34 @@ describe('sendMessageToTask', () => {
       status: 500,
     });
     expect(mockSendPromptMutate).not.toHaveBeenCalled();
+    expect(mockRestoreActingUserIdAfterFailedDelivery).not.toHaveBeenCalled();
+  });
+
+  it('rolls back the actor when prompt delivery fails after the switch', async () => {
+    mockFindLatestCloudJob.mockResolvedValue(
+      createActiveJob({ actingUserId: 'user-1' }),
+    );
+    mockSendPromptMutate.mockRejectedValueOnce(
+      new Error('sandbox delivery failed'),
+    );
+
+    const result = await sendMessageToTask({
+      taskId: 'task-1',
+      userId: 'user-2',
+      message: 'Continue as the new sender.',
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'sandbox delivery failed',
+      status: 500,
+    });
+    expect(mockRestoreActingUserIdAfterFailedDelivery).toHaveBeenCalledWith({
+      handlerName: 'sendMessageToTask',
+      jobId: 42,
+      previousActingUserId: 'user-1',
+      attemptedActingUserId: 'user-2',
+    });
   });
 
   it('writes the acting user BEFORE delivering steering prompts to the sandbox', async () => {
@@ -250,6 +290,33 @@ describe('sendMessageToTask', () => {
     expect(
       mockUpdateActingUserIdIfNeeded.mock.invocationCallOrder[0]!,
     ).toBeLessThan(mockSteerTaskMutate.mock.invocationCallOrder[0]!);
+  });
+
+  it('rolls back the actor when steering delivery fails after the switch', async () => {
+    mockFindLatestCloudJob.mockResolvedValue(
+      createActiveJob({ actingUserId: 'user-1' }),
+    );
+    mockSteerTaskMutate.mockRejectedValueOnce(
+      new Error('sandbox delivery failed'),
+    );
+
+    const result = await steerMessageToTask({
+      taskId: 'task-1',
+      userId: 'user-2',
+      message: 'Steer as the new sender.',
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'sandbox delivery failed',
+      status: 500,
+    });
+    expect(mockRestoreActingUserIdAfterFailedDelivery).toHaveBeenCalledWith({
+      handlerName: 'steerMessageToTask',
+      jobId: 42,
+      previousActingUserId: 'user-1',
+      attemptedActingUserId: 'user-2',
+    });
   });
 
   it('stores the latest user message for active Slack-thread tasks', async () => {

--- a/apps/api/src/handlers/tasks/__tests__/sendMessageToTask.test.ts
+++ b/apps/api/src/handlers/tasks/__tests__/sendMessageToTask.test.ts
@@ -8,6 +8,7 @@ const {
   mockSendPromptMutate,
   mockSteerTaskMutate,
   mockTrackLatestUserMessageForSlackQuote,
+  mockUpdateActingUserIdIfNeeded,
   mockUserFindFirst,
 } = vi.hoisted(() => ({
   mockCreateJobToken: vi.fn(),
@@ -19,7 +20,12 @@ const {
   mockSendPromptMutate: vi.fn(),
   mockSteerTaskMutate: vi.fn(),
   mockTrackLatestUserMessageForSlackQuote: vi.fn(),
+  mockUpdateActingUserIdIfNeeded: vi.fn(),
   mockUserFindFirst: vi.fn(),
+}));
+
+vi.mock('../acting-user-sync', () => ({
+  updateActingUserIdIfNeeded: mockUpdateActingUserIdIfNeeded,
 }));
 
 vi.mock('@roomote/auth', async (importOriginal) => {
@@ -168,10 +174,82 @@ describe('sendMessageToTask', () => {
       linearOrganizationId: null,
     });
     mockTrackLatestUserMessageForSlackQuote.mockResolvedValue(undefined);
+    mockUpdateActingUserIdIfNeeded.mockResolvedValue(undefined);
     mockUserFindFirst.mockResolvedValue({
       name: 'Alice',
       email: 'alice@example.com',
     });
+  });
+
+  it('writes the acting user BEFORE delivering the prompt to the sandbox', async () => {
+    // Ordering is the security property: the run's actingUserId selects
+    // whose credentials actor-scoped routes resolve, so the trusted switch
+    // must land before the new sender's prompt can run.
+    mockFindLatestCloudJob.mockResolvedValue(
+      createActiveJob({ actingUserId: 'user-1' }),
+    );
+
+    const result = await sendMessageToTask({
+      taskId: 'task-1',
+      userId: 'user-2',
+      message: 'Continue as the new sender.',
+    });
+
+    expect(result).toEqual({ success: true, result: { ok: true } });
+    expect(mockUpdateActingUserIdIfNeeded).toHaveBeenCalledWith({
+      jobId: 42,
+      currentActingUserId: 'user-1',
+      nextActingUserId: 'user-2',
+      preserveActor: false,
+    });
+    expect(
+      mockUpdateActingUserIdIfNeeded.mock.invocationCallOrder[0]!,
+    ).toBeLessThan(mockSendPromptMutate.mock.invocationCallOrder[0]!);
+  });
+
+  it('does not deliver the prompt when the pre-delivery acting-user write fails', async () => {
+    mockFindLatestCloudJob.mockResolvedValue(
+      createActiveJob({ actingUserId: 'user-1' }),
+    );
+    mockUpdateActingUserIdIfNeeded.mockRejectedValueOnce(
+      new Error('db unavailable'),
+    );
+
+    const result = await sendMessageToTask({
+      taskId: 'task-1',
+      userId: 'user-2',
+      message: 'Continue as the new sender.',
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'db unavailable',
+      status: 500,
+    });
+    expect(mockSendPromptMutate).not.toHaveBeenCalled();
+  });
+
+  it('writes the acting user BEFORE delivering steering prompts to the sandbox', async () => {
+    mockFindLatestCloudJob.mockResolvedValue(
+      createActiveJob({ actingUserId: 'user-1' }),
+    );
+
+    const result = await steerMessageToTask({
+      taskId: 'task-1',
+      userId: 'user-2',
+      message: 'Steer as the new sender.',
+    });
+
+    expect(result).toEqual({ success: true, result: { ok: true } });
+    expect(mockUpdateActingUserIdIfNeeded).toHaveBeenCalledWith({
+      jobId: 42,
+      currentActingUserId: 'user-1',
+      nextActingUserId: 'user-2',
+      preserveActor: false,
+    });
+    expect(
+      mockUpdateActingUserIdIfNeeded.mock.invocationCallOrder[0]!,
+    ).toBeLessThan(mockSteerTaskMutate.mock.invocationCallOrder[0]!);
   });
 
   it('stores the latest user message for active Slack-thread tasks', async () => {

--- a/apps/api/src/handlers/tasks/acting-user-sync.ts
+++ b/apps/api/src/handlers/tasks/acting-user-sync.ts
@@ -1,4 +1,7 @@
-import { and, db, eq, isNull, ne, or, taskRuns } from '@roomote/db/server';
+import {
+  compareAndSetTrustedRunActingUser,
+  setTrustedRunActingUser,
+} from '@roomote/db/server';
 
 import { logHandlerError } from '../utils';
 
@@ -28,15 +31,48 @@ export async function updateActingUserIdIfNeeded({
   currentActingUserId: string | null;
   nextActingUserId: string;
   preserveActor: boolean;
-}): Promise<void> {
+}): Promise<boolean> {
   if (preserveActor || currentActingUserId === nextActingUserId) {
-    return;
+    return false;
   }
 
-  await db
-    .update(taskRuns)
-    .set({ actingUserId: nextActingUserId })
-    .where(eq(taskRuns.id, jobId));
+  return await compareAndSetTrustedRunActingUser({
+    runId: jobId,
+    expectedUserId: currentActingUserId,
+    nextUserId: nextActingUserId,
+  });
+}
+
+/**
+ * Best-effort compare-and-set rollback for a trusted actor switch whose
+ * sandbox delivery failed. The CAS avoids overwriting a newer sender that
+ * won the race after this request changed the actor.
+ */
+export async function restoreActingUserIdAfterFailedDelivery({
+  handlerName,
+  jobId,
+  previousActingUserId,
+  attemptedActingUserId,
+}: {
+  handlerName: 'sendMessageToTask' | 'steerMessageToTask';
+  jobId: number;
+  previousActingUserId: string | null;
+  attemptedActingUserId: string;
+}): Promise<void> {
+  try {
+    await compareAndSetTrustedRunActingUser({
+      runId: jobId,
+      expectedUserId: attemptedActingUserId,
+      nextUserId: previousActingUserId,
+    });
+  } catch (error) {
+    logHandlerError(
+      handlerName,
+      `Failed to roll back actingUserId after sandbox delivery failed for run ${jobId} ` +
+        `(attempted=${attemptedActingUserId}, previous=${previousActingUserId ?? 'null'}): ` +
+        `${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
 }
 
 /**
@@ -66,18 +102,7 @@ export async function syncActingUserForInboundMessage({
   }
 
   try {
-    await db
-      .update(taskRuns)
-      .set({ actingUserId: senderUserId })
-      .where(
-        and(
-          eq(taskRuns.id, jobId),
-          or(
-            isNull(taskRuns.actingUserId),
-            ne(taskRuns.actingUserId, senderUserId),
-          ),
-        ),
-      );
+    await setTrustedRunActingUser({ runId: jobId, userId: senderUserId });
   } catch (error) {
     logHandlerError(
       logContext,

--- a/apps/api/src/handlers/tasks/acting-user-sync.ts
+++ b/apps/api/src/handlers/tasks/acting-user-sync.ts
@@ -1,0 +1,89 @@
+import { and, db, eq, isNull, ne, or, taskRuns } from '@roomote/db/server';
+
+import { logHandlerError } from '../utils';
+
+/**
+ * Trusted server-side writers for `task_runs.actingUserId`.
+ *
+ * `actingUserId` feeds actor-scoped credential resolution
+ * (resolveActorScopedUserContext -> userApiKeys / mcpConnections and the MCP
+ * proxy's resolveActingUserId), so it must only ever be written by the server
+ * from identities it resolved itself (an authenticated web user, or a chat
+ * sender mapped to a Roomote user by the webhook handler). Run-scoped job
+ * tokens cannot write it — `cloudJobs.update` strips the field — and the
+ * worker only observes the value.
+ *
+ * The write must land BEFORE the message is delivered to (or picked up by)
+ * the sandbox: the worker refuses to run a turn whose sender does not match
+ * the server-side acting user (or falls back to the server actor for queued
+ * replays), so a late write would block or mis-attribute the turn.
+ */
+export async function updateActingUserIdIfNeeded({
+  jobId,
+  currentActingUserId,
+  nextActingUserId,
+  preserveActor,
+}: {
+  jobId: number;
+  currentActingUserId: string | null;
+  nextActingUserId: string;
+  preserveActor: boolean;
+}): Promise<void> {
+  if (preserveActor || currentActingUserId === nextActingUserId) {
+    return;
+  }
+
+  await db
+    .update(taskRuns)
+    .set({ actingUserId: nextActingUserId })
+    .where(eq(taskRuns.id, jobId));
+}
+
+/**
+ * Pre-queue trusted actor sync for inbound chat messages that the worker
+ * polls (Slack/Teams/Telegram/Linear active-job queues).
+ *
+ * Called by webhook handlers with the sender they resolved to a Roomote user.
+ * Skips unmapped senders (`senderUserId` undefined/null): those messages run
+ * under the run's current actor, matching the previous worker behavior.
+ *
+ * Non-fatal by design: queueing the message matters more than switching the
+ * actor. If this write fails, the worker detects the mismatch at delivery
+ * time and runs the turn under the server-side actor instead of the sender —
+ * degraded attribution, never a credential mix-up.
+ */
+export async function syncActingUserForInboundMessage({
+  logContext,
+  jobId,
+  senderUserId,
+}: {
+  logContext: string;
+  jobId: number;
+  senderUserId: string | null | undefined;
+}): Promise<void> {
+  if (!senderUserId) {
+    return;
+  }
+
+  try {
+    await db
+      .update(taskRuns)
+      .set({ actingUserId: senderUserId })
+      .where(
+        and(
+          eq(taskRuns.id, jobId),
+          or(
+            isNull(taskRuns.actingUserId),
+            ne(taskRuns.actingUserId, senderUserId),
+          ),
+        ),
+      );
+  } catch (error) {
+    logHandlerError(
+      logContext,
+      `Non-fatal actingUserId sync failure for cloud job ${jobId} ` +
+        `(next=${senderUserId}): ` +
+        `${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/apps/api/src/handlers/tasks/sendMessageToTask.ts
+++ b/apps/api/src/handlers/tasks/sendMessageToTask.ts
@@ -33,6 +33,7 @@ import {
 } from '@roomote/slack';
 
 import { findLatestCloudJob, getTaskChannelBindings } from './helpers';
+import { updateActingUserIdIfNeeded } from './acting-user-sync';
 import { logHandlerError } from '../utils';
 
 const LINKED_REVIEW_HANDOFF_SOURCE = 'linked_review_handoff';
@@ -327,7 +328,23 @@ async function maybeCreateSlackReplyQuoteContext(params: {
   await createSlackReplyQuoteContext(params);
 }
 
-async function updateActingUserIdIfNeeded({
+/**
+ * Trusted actor switch, applied BEFORE the prompt reaches the sandbox.
+ *
+ * Ordering is load-bearing: the run's `actingUserId` selects whose
+ * credentials actor-scoped routes resolve, and the worker refuses to run a
+ * turn whose sender does not match the server-side acting user. Writing
+ * after delivery (the previous design) opened a window where the new
+ * sender's prompt ran while credential routes still resolved the previous
+ * actor. Writing before delivery closes that window; if delivery then
+ * fails, the run merely attributes to the latest human who attempted to
+ * engage — no prompt of theirs ran, and the write is idempotent, so the
+ * next successful send (from any sender) re-syncs it.
+ *
+ * Errors propagate: proceeding with delivery after a failed required switch
+ * would only bounce off the worker's mismatch guard with a less clear error.
+ */
+async function syncActingUserIdBeforeDelivery({
   jobId,
   currentActingUserId,
   nextActingUserId,
@@ -338,44 +355,12 @@ async function updateActingUserIdIfNeeded({
   nextActingUserId: string;
   preserveActor: boolean;
 }): Promise<void> {
-  if (preserveActor || currentActingUserId === nextActingUserId) {
-    return;
-  }
-
-  await db
-    .update(taskRuns)
-    .set({ actingUserId: nextActingUserId })
-    .where(eq(taskRuns.id, jobId));
-}
-
-async function syncActingUserIdAfterDelivery({
-  handlerName,
-  jobId,
-  currentActingUserId,
-  nextActingUserId,
-  preserveActor,
-}: {
-  handlerName: 'sendMessageToTask' | 'steerMessageToTask';
-  jobId: number;
-  currentActingUserId: string | null;
-  nextActingUserId: string;
-  preserveActor: boolean;
-}): Promise<void> {
-  try {
-    await updateActingUserIdIfNeeded({
-      jobId,
-      currentActingUserId,
-      nextActingUserId,
-      preserveActor,
-    });
-  } catch (error) {
-    logHandlerError(
-      handlerName,
-      `Non-fatal actingUserId sync failure for cloud job ${jobId} ` +
-        `(current=${currentActingUserId ?? 'null'}, next=${nextActingUserId}): ` +
-        `${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
+  await updateActingUserIdIfNeeded({
+    jobId,
+    currentActingUserId,
+    nextActingUserId,
+    preserveActor,
+  });
 }
 
 async function inheritSnapshotResumeVisiblePromptFields(
@@ -785,6 +770,17 @@ export async function sendMessageToTask({
       const resolvedQuoteUserName =
         workerQuoteUserName ??
         (await resolveWorkerQuoteUserName(senderMode, senderUserId));
+
+      // The actor switch must land before the prompt reaches the sandbox so
+      // credential resolution and turn attribution agree. See
+      // syncActingUserIdBeforeDelivery for the ordering rationale.
+      await syncActingUserIdBeforeDelivery({
+        jobId: job.id,
+        currentActingUserId: job.actingUserId,
+        nextActingUserId: senderUserId,
+        preserveActor: shouldPreserveActor,
+      });
+
       const result = await withSandboxServerRpcClient({
         cloudJobId: job.id,
         userId: senderUserId,
@@ -802,14 +798,6 @@ export async function sendMessageToTask({
               : {}),
             ...(images?.length ? { images } : {}),
           }),
-      });
-
-      await syncActingUserIdAfterDelivery({
-        handlerName: 'sendMessageToTask',
-        jobId: job.id,
-        currentActingUserId: job.actingUserId,
-        nextActingUserId: senderUserId,
-        preserveActor: shouldPreserveActor,
       });
 
       return { success: true, result };
@@ -932,6 +920,17 @@ export async function steerMessageToTask({
       const resolvedQuoteUserName =
         workerQuoteUserName ??
         (await resolveWorkerQuoteUserName(senderMode, userId));
+
+      // The actor switch must land before the steer reaches the sandbox so
+      // credential resolution and turn attribution agree. See
+      // syncActingUserIdBeforeDelivery for the ordering rationale.
+      await syncActingUserIdBeforeDelivery({
+        jobId: job.id,
+        currentActingUserId: job.actingUserId,
+        nextActingUserId: userId,
+        preserveActor: false,
+      });
+
       const result = await withSandboxServerRpcClient({
         cloudJobId: job.id,
         userId,
@@ -945,14 +944,6 @@ export async function steerMessageToTask({
               : {}),
             ...(images?.length ? { images } : {}),
           }),
-      });
-
-      await syncActingUserIdAfterDelivery({
-        handlerName: 'steerMessageToTask',
-        jobId: job.id,
-        currentActingUserId: job.actingUserId,
-        nextActingUserId: userId,
-        preserveActor: false,
       });
 
       return { success: true, result };

--- a/apps/api/src/handlers/tasks/sendMessageToTask.ts
+++ b/apps/api/src/handlers/tasks/sendMessageToTask.ts
@@ -33,7 +33,10 @@ import {
 } from '@roomote/slack';
 
 import { findLatestCloudJob, getTaskChannelBindings } from './helpers';
-import { updateActingUserIdIfNeeded } from './acting-user-sync';
+import {
+  restoreActingUserIdAfterFailedDelivery,
+  updateActingUserIdIfNeeded,
+} from './acting-user-sync';
 import { logHandlerError } from '../utils';
 
 const LINKED_REVIEW_HANDOFF_SOURCE = 'linked_review_handoff';
@@ -336,10 +339,9 @@ async function maybeCreateSlackReplyQuoteContext(params: {
  * turn whose sender does not match the server-side acting user. Writing
  * after delivery (the previous design) opened a window where the new
  * sender's prompt ran while credential routes still resolved the previous
- * actor. Writing before delivery closes that window; if delivery then
- * fails, the run merely attributes to the latest human who attempted to
- * engage — no prompt of theirs ran, and the write is idempotent, so the
- * next successful send (from any sender) re-syncs it.
+ * actor. Writing before delivery closes that window. If delivery fails, the
+ * caller compare-and-set rolls the actor back so the previous in-flight turn
+ * cannot continue resolving credentials as a sender whose prompt never ran.
  *
  * Errors propagate: proceeding with delivery after a failed required switch
  * would only bounce off the worker's mismatch guard with a less clear error.
@@ -354,8 +356,8 @@ async function syncActingUserIdBeforeDelivery({
   currentActingUserId: string | null;
   nextActingUserId: string;
   preserveActor: boolean;
-}): Promise<void> {
-  await updateActingUserIdIfNeeded({
+}): Promise<boolean> {
+  return await updateActingUserIdIfNeeded({
     jobId,
     currentActingUserId,
     nextActingUserId,
@@ -750,6 +752,10 @@ export async function sendMessageToTask({
 
     const shouldPreserveActor =
       !!senderMode && ACTOR_PRESERVING_MODES.has(senderMode);
+    const requiresActorHandoff =
+      !shouldPreserveActor && job.actingUserId !== senderUserId;
+
+    let didSwitchActingUser = false;
 
     try {
       await maybeCreateSlackReplyQuoteContext({
@@ -774,7 +780,7 @@ export async function sendMessageToTask({
       // The actor switch must land before the prompt reaches the sandbox so
       // credential resolution and turn attribution agree. See
       // syncActingUserIdBeforeDelivery for the ordering rationale.
-      await syncActingUserIdBeforeDelivery({
+      didSwitchActingUser = await syncActingUserIdBeforeDelivery({
         jobId: job.id,
         currentActingUserId: job.actingUserId,
         nextActingUserId: senderUserId,
@@ -796,12 +802,25 @@ export async function sendMessageToTask({
             ...(resolvedQuoteUserName
               ? { userName: resolvedQuoteUserName }
               : {}),
+            // Do not leave the previous actor's turn running after the live
+            // credential identity changes. Native steering injects at the
+            // next step; fallback steering aborts and replays promptly.
+            ...(requiresActorHandoff ? { autoSteerWhenQueued: true } : {}),
             ...(images?.length ? { images } : {}),
           }),
       });
 
       return { success: true, result };
     } catch (error) {
+      if (didSwitchActingUser) {
+        await restoreActingUserIdAfterFailedDelivery({
+          handlerName: 'sendMessageToTask',
+          jobId: job.id,
+          previousActingUserId: job.actingUserId,
+          attemptedActingUserId: senderUserId,
+        });
+      }
+
       if (error instanceof SandboxNotReadyError) {
         return {
           success: false,
@@ -907,6 +926,8 @@ export async function steerMessageToTask({
       };
     }
 
+    let didSwitchActingUser = false;
+
     try {
       await maybeCreateSlackReplyQuoteContext({
         cloudJobId: job.id,
@@ -924,7 +945,7 @@ export async function steerMessageToTask({
       // The actor switch must land before the steer reaches the sandbox so
       // credential resolution and turn attribution agree. See
       // syncActingUserIdBeforeDelivery for the ordering rationale.
-      await syncActingUserIdBeforeDelivery({
+      didSwitchActingUser = await syncActingUserIdBeforeDelivery({
         jobId: job.id,
         currentActingUserId: job.actingUserId,
         nextActingUserId: userId,
@@ -948,6 +969,15 @@ export async function steerMessageToTask({
 
       return { success: true, result };
     } catch (error) {
+      if (didSwitchActingUser) {
+        await restoreActingUserIdAfterFailedDelivery({
+          handlerName: 'steerMessageToTask',
+          jobId: job.id,
+          previousActingUserId: job.actingUserId,
+          attemptedActingUserId: userId,
+        });
+      }
+
       if (error instanceof SandboxNotReadyError) {
         return {
           success: false,

--- a/apps/api/src/handlers/teams/index.ts
+++ b/apps/api/src/handlers/teams/index.ts
@@ -63,6 +63,7 @@ import {
 } from '@roomote/cloud-agents/server';
 
 import { apiLogger } from '../../logging.js';
+import { syncActingUserForInboundMessage } from '../tasks/acting-user-sync.js';
 import { verifyBotFrameworkJwt } from './bot-framework-auth.js';
 import {
   findActiveTeamsJob,
@@ -1396,6 +1397,12 @@ async function resumePendingTeamsAuthToken(
   });
 
   if (activeJob) {
+    // Trusted pre-queue actor switch; see acting-user-sync.ts.
+    await syncActingUserForInboundMessage({
+      logContext: 'teams.pendingAuthActivity',
+      jobId: activeJob.id,
+      senderUserId: mappedUserId,
+    });
     await queueCommunicationMessage(
       'teams',
       activeJob.id,
@@ -1817,6 +1824,13 @@ teams.post('/', async (c) => {
     { ...(mappedUserId ? { userId: mappedUserId } : {}) },
   );
 
+  // Trusted pre-queue actor switch; see acting-user-sync.ts. The worker only
+  // runs the queued turn as this sender if the server actor already matches.
+  await syncActingUserForInboundMessage({
+    logContext: 'teams.activeJobMessage',
+    jobId: activeJob.id,
+    senderUserId: mappedUserId,
+  });
   await queueCommunicationMessage('teams', activeJob.id, queuedMessage);
 
   apiLogger.debug(

--- a/apps/api/src/handlers/telegram/index.ts
+++ b/apps/api/src/handlers/telegram/index.ts
@@ -18,6 +18,7 @@ import {
 } from '@roomote/communication/telegram-update';
 
 import { apiLogger } from '../../logging.js';
+import { syncActingUserForInboundMessage } from '../tasks/acting-user-sync.js';
 import {
   findActiveTelegramJob,
   findCompletedTelegramJobWithSnapshot,
@@ -360,6 +361,13 @@ telegram.post('/', async (c) => {
       return c.json({ ok: true, ignored: 'unsupported_update' });
     }
 
+    // Trusted pre-queue actor switch; see acting-user-sync.ts. The worker
+    // only runs the queued turn as this sender if the server actor matches.
+    await syncActingUserForInboundMessage({
+      logContext: 'telegram.activeJobMessage',
+      jobId: activeJob.id,
+      senderUserId: queuedMessage.userId,
+    });
     await queueCommunicationMessage('telegram', activeJob.id, queuedMessage);
     // Track the latest inbound user message id so later outbound replies quote
     // the most recent user message instead of the original launch message.

--- a/apps/worker/src/run-task/__tests__/actor-mismatch-notice.test.ts
+++ b/apps/worker/src/run-task/__tests__/actor-mismatch-notice.test.ts
@@ -1,0 +1,80 @@
+const { mockReplyToChatThread, mockGetRoomoteConfig } = vi.hoisted(() => ({
+  mockReplyToChatThread: vi.fn(),
+  mockGetRoomoteConfig: vi.fn(),
+}));
+
+vi.mock('../../mcp/roomote-mcp-server/chat-api-client', () => ({
+  replyToChatThread: mockReplyToChatThread,
+}));
+
+vi.mock('../../mcp/roomote-mcp-server/config', () => ({
+  getRoomoteConfig: mockGetRoomoteConfig,
+}));
+
+import {
+  ACTOR_MISMATCH_SKIP_NOTICE_TEXT,
+  createActorMismatchSkipNotifier,
+} from '../actor-mismatch-notice';
+
+describe('createActorMismatchSkipNotifier', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetRoomoteConfig.mockReturnValue({
+      token: 'job-token',
+      platformApiUrl: 'https://api.example.test',
+    });
+    mockReplyToChatThread.mockResolvedValue({ ok: true });
+  });
+
+  it('posts the resend notice to the task chat thread once per sender', async () => {
+    const notify = createActorMismatchSkipNotifier({
+      cloudJobId: 42,
+      logger: { warn: vi.fn(), error: vi.fn() },
+    });
+
+    await notify({ senderUserId: 'user-2', serverActorUserId: 'user-1' });
+    await notify({ senderUserId: 'user-2', serverActorUserId: 'user-1' });
+    await notify({ senderUserId: 'user-3', serverActorUserId: 'user-1' });
+
+    // Deduped per sender: a burst of skipped messages from the same sender
+    // produces a single notice.
+    expect(mockReplyToChatThread).toHaveBeenCalledTimes(2);
+    expect(mockReplyToChatThread).toHaveBeenCalledWith(
+      expect.objectContaining({ token: 'job-token' }),
+      { text: ACTOR_MISMATCH_SKIP_NOTICE_TEXT },
+    );
+  });
+
+  it('never throws when the post fails (skipping is the security decision, the notice is UX)', async () => {
+    const logger = { warn: vi.fn(), error: vi.fn() };
+    mockReplyToChatThread.mockRejectedValueOnce(
+      new Error('no Slack channel context'),
+    );
+
+    const notify = createActorMismatchSkipNotifier({ cloudJobId: 42, logger });
+
+    await expect(
+      notify({ senderUserId: 'user-2', serverActorUserId: 'user-1' }),
+    ).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to post skip notice for run 42'),
+    );
+  });
+
+  it('logs and returns when no cloud token is available', async () => {
+    const logger = { warn: vi.fn(), error: vi.fn() };
+    mockGetRoomoteConfig.mockReturnValueOnce(null);
+
+    const notify = createActorMismatchSkipNotifier({ cloudJobId: 42, logger });
+
+    await expect(
+      notify({ senderUserId: 'user-2', serverActorUserId: 'user-1' }),
+    ).resolves.toBeUndefined();
+
+    expect(mockReplyToChatThread).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('no cloud token available'),
+    );
+  });
+});

--- a/apps/worker/src/run-task/__tests__/prepare-actor-scoped-turn.test.ts
+++ b/apps/worker/src/run-task/__tests__/prepare-actor-scoped-turn.test.ts
@@ -242,17 +242,14 @@ describe('prepareActorScopedTurn', () => {
     );
   });
 
-  it('follows the server actor on a mismatch under the follow-server policy', async () => {
-    // Queued/polled deliveries cannot converge by requeueing, so the turn
-    // runs as the server actor: integrations refresh for the server value
-    // and the caller attributes the turn to it.
-    const refreshActorScopedIntegrations = vi.fn().mockResolvedValue({
-      didChange: true,
-      didFail: false,
-      didReconnect: true,
-      actorChanged: true,
-    });
+  it('skips the mismatched content and notifies the sender under the skip policy', async () => {
+    // Invariant: content only executes when its SENDER equals the identity
+    // actor-scoped routes resolve. A mismatched message never runs — not
+    // even relabeled to the server actor, since the server actor did not
+    // author the instructions. The sender gets a resend notice instead.
+    const refreshActorScopedIntegrations = vi.fn();
     const onActorSynced = vi.fn();
+    const notifyMismatchSkipped = vi.fn().mockResolvedValue(undefined);
     const logger = {
       info: vi.fn(),
       warn: vi.fn(),
@@ -270,27 +267,26 @@ describe('prepareActorScopedTurn', () => {
         targetUserId: 'user-2',
         workingDirectory: '/tmp/workspace',
         logPrefix: '[test]',
-        onMismatch: 'follow-server',
+        onMismatch: 'skip',
         getLastKnownActorUserId: () => 'user-3',
         onActorSynced,
+        notifyMismatchSkipped,
         logger,
         refreshActorScopedIntegrations,
       }),
-    ).resolves.toEqual({ effectiveUserId: 'user-1' });
+    ).resolves.toEqual({ skippedMismatch: true });
 
-    // Integrations and git author follow the SERVER value, not the sender.
-    expect(refreshActorScopedIntegrations).toHaveBeenCalledWith('user-1', {
-      deferReconnectUntilTurnBoundary: false,
+    // Nothing runs and no local actor state moves: no MCP refresh, no git
+    // author change, no marker advance.
+    expect(refreshActorScopedIntegrations).not.toHaveBeenCalled();
+    expect(mockSyncRuntimeGitAuthor).not.toHaveBeenCalled();
+    expect(onActorSynced).not.toHaveBeenCalled();
+    expect(notifyMismatchSkipped).toHaveBeenCalledWith({
+      senderUserId: 'user-2',
+      serverActorUserId: 'user-1',
     });
-    expect(mockSyncRuntimeGitAuthor).toHaveBeenCalledWith({
-      cloudJobId: 42,
-      workingDirectory: '/tmp/workspace',
-    });
-    expect(onActorSynced).toHaveBeenCalledWith('user-1');
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'as server actor user-1 instead of sender user-2',
-      ),
+      expect.stringContaining('Skipping message content for cloud job 42'),
     );
   });
 });
@@ -377,5 +373,70 @@ describe('syncActorScopedTurnState', () => {
     ).resolves.toEqual({ ok: false });
 
     expect(mockSyncRuntimeGitAuthor).not.toHaveBeenCalled();
+  });
+
+  it('does not advance the last-prepared marker when the git author sync fails, so the next turn retries', async () => {
+    // If the marker advanced despite the failure, the next reconciliation
+    // would report `unchanged` and the run would keep committing as the
+    // previous actor's git identity forever.
+    const onActorSynced = vi.fn();
+    const logger = { error: vi.fn() };
+    let lastPrepared: string | null = 'user-1';
+
+    mockSyncActingUserId.mockResolvedValue({
+      result: 'updated',
+      actingUserId: 'user-2',
+    });
+    mockSyncRuntimeGitAuthor.mockRejectedValueOnce(new Error('git locked'));
+
+    // First turn: author sync fails, turn still delivers, marker untouched.
+    await expect(
+      syncActorScopedTurnState({
+        cloudJobId: 42,
+        targetUserId: 'user-2',
+        workingDirectory: '/tmp/workspace',
+        logPrefix: '[test]',
+        getLastKnownActorUserId: () => lastPrepared,
+        onActorSynced: (userId) => {
+          onActorSynced(userId);
+          lastPrepared = userId;
+        },
+        logger,
+      }),
+    ).resolves.toEqual({ ok: true, effectiveUserId: 'user-2' });
+
+    expect(onActorSynced).not.toHaveBeenCalled();
+    expect(lastPrepared).toBe('user-1');
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('will retry on the next turn'),
+    );
+
+    // Next turn: the stale marker makes the server report `updated` again;
+    // the retry succeeds and only then does the marker advance.
+    mockSyncRuntimeGitAuthor.mockResolvedValueOnce(undefined);
+
+    await expect(
+      syncActorScopedTurnState({
+        cloudJobId: 42,
+        targetUserId: 'user-2',
+        workingDirectory: '/tmp/workspace',
+        logPrefix: '[test]',
+        getLastKnownActorUserId: () => lastPrepared,
+        onActorSynced: (userId) => {
+          onActorSynced(userId);
+          lastPrepared = userId;
+        },
+        logger,
+      }),
+    ).resolves.toEqual({ ok: true, effectiveUserId: 'user-2' });
+
+    expect(mockSyncActingUserId).toHaveBeenLastCalledWith({
+      cloudJobId: 42,
+      newUserId: 'user-2',
+      lastKnownUserId: 'user-1',
+    });
+    expect(mockSyncRuntimeGitAuthor).toHaveBeenCalledTimes(2);
+    expect(onActorSynced).toHaveBeenCalledExactlyOnceWith('user-2');
+    expect(lastPrepared).toBe('user-2');
   });
 });

--- a/apps/worker/src/run-task/__tests__/prepare-actor-scoped-turn.test.ts
+++ b/apps/worker/src/run-task/__tests__/prepare-actor-scoped-turn.test.ts
@@ -15,12 +15,18 @@ vi.mock('../../lib/sync-runtime-git-author', () => ({
   syncRuntimeGitAuthor: mockSyncRuntimeGitAuthor,
 }));
 
-import { prepareActorScopedTurn } from '../prepare-actor-scoped-turn';
+import {
+  prepareActorScopedTurn,
+  syncActorScopedTurnState,
+} from '../prepare-actor-scoped-turn';
 
 describe('prepareActorScopedTurn', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockSyncActingUserId.mockResolvedValue('updated');
+    mockSyncActingUserId.mockResolvedValue({
+      result: 'updated',
+      actingUserId: 'user-2',
+    });
     mockSyncRuntimeGitAuthor.mockResolvedValue(undefined);
   });
 
@@ -38,14 +44,16 @@ describe('prepareActorScopedTurn', () => {
         workingDirectory: '/tmp/workspace',
         logPrefix: '[test]',
         allowMcpReconnect: false,
+        getLastKnownActorUserId: () => 'user-1',
         logger,
         refreshActorScopedIntegrations,
       }),
-    ).resolves.toBe(true);
+    ).resolves.toEqual({ effectiveUserId: 'user-2' });
 
     expect(mockSyncActingUserId).toHaveBeenCalledWith({
       cloudJobId: 42,
       newUserId: 'user-2',
+      lastKnownUserId: 'user-1',
     });
     expect(mockSyncRuntimeGitAuthor).toHaveBeenCalledWith({
       cloudJobId: 42,
@@ -79,7 +87,7 @@ describe('prepareActorScopedTurn', () => {
         },
         refreshActorScopedIntegrations,
       }),
-    ).resolves.toBe(true);
+    ).resolves.toEqual({ effectiveUserId: 'user-2' });
 
     expect(refreshActorScopedIntegrations).toHaveBeenCalledWith('user-2', {
       deferReconnectUntilTurnBoundary: true,
@@ -106,7 +114,7 @@ describe('prepareActorScopedTurn', () => {
         },
         refreshActorScopedIntegrations,
       }),
-    ).resolves.toBe(true);
+    ).resolves.toEqual({ effectiveUserId: 'user-2' });
 
     expect(refreshActorScopedIntegrations).toHaveBeenCalledWith('user-2', {
       deferReconnectUntilTurnBoundary: false,
@@ -162,14 +170,14 @@ describe('prepareActorScopedTurn', () => {
         logger,
         refreshActorScopedIntegrations,
       }),
-    ).resolves.toBe(true);
+    ).resolves.toEqual({ effectiveUserId: 'user-2' });
 
     expect(logger.info).toHaveBeenCalledWith(
       '[test] Actor-scoped MCP refresh failed for cloud job 42, but the mounted actor is unchanged; continuing with existing MCP state',
     );
   });
 
-  it('skips actor-scoped MCP refresh when actingUserId sync fails', async () => {
+  it('skips actor-scoped MCP refresh when actingUserId reconciliation fails', async () => {
     const refreshActorScopedIntegrations = vi.fn();
     const logger = {
       info: vi.fn(),
@@ -192,10 +200,182 @@ describe('prepareActorScopedTurn', () => {
     expect(refreshActorScopedIntegrations).not.toHaveBeenCalled();
     expect(mockSyncRuntimeGitAuthor).not.toHaveBeenCalled();
     expect(logger.error).toHaveBeenCalledWith(
-      '[test] Failed to update actingUserId for cloud job 42: sync failed',
+      '[test] Failed to reconcile actingUserId for cloud job 42: sync failed',
     );
     expect(logger.info).toHaveBeenCalledWith(
-      '[test] Skipping actor-scoped MCP refresh because actingUserId was not updated for cloud job 42',
+      '[test] Skipping actor-scoped MCP refresh because actor reconciliation blocked the turn for cloud job 42',
     );
+  });
+
+  it('blocks the turn on a mismatch under the default block policy', async () => {
+    // Confused-deputy guard: the sender was never installed as the run's
+    // acting user by a trusted server-side writer, so their turn must not
+    // run under the current credentials on RPC surfaces.
+    const refreshActorScopedIntegrations = vi.fn();
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+
+    mockSyncActingUserId.mockResolvedValueOnce({
+      result: 'mismatch',
+      actingUserId: 'user-1',
+    });
+
+    await expect(
+      prepareActorScopedTurn({
+        cloudJobId: 42,
+        targetUserId: 'user-2',
+        workingDirectory: '/tmp/workspace',
+        logPrefix: '[test]',
+        logger,
+        refreshActorScopedIntegrations,
+      }),
+    ).resolves.toBe(false);
+
+    expect(refreshActorScopedIntegrations).not.toHaveBeenCalled();
+    expect(mockSyncRuntimeGitAuthor).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'sender user-2 is not the server-side acting user (user-1)',
+      ),
+    );
+  });
+
+  it('follows the server actor on a mismatch under the follow-server policy', async () => {
+    // Queued/polled deliveries cannot converge by requeueing, so the turn
+    // runs as the server actor: integrations refresh for the server value
+    // and the caller attributes the turn to it.
+    const refreshActorScopedIntegrations = vi.fn().mockResolvedValue({
+      didChange: true,
+      didFail: false,
+      didReconnect: true,
+      actorChanged: true,
+    });
+    const onActorSynced = vi.fn();
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    mockSyncActingUserId.mockResolvedValueOnce({
+      result: 'mismatch',
+      actingUserId: 'user-1',
+    });
+
+    await expect(
+      prepareActorScopedTurn({
+        cloudJobId: 42,
+        targetUserId: 'user-2',
+        workingDirectory: '/tmp/workspace',
+        logPrefix: '[test]',
+        onMismatch: 'follow-server',
+        getLastKnownActorUserId: () => 'user-3',
+        onActorSynced,
+        logger,
+        refreshActorScopedIntegrations,
+      }),
+    ).resolves.toEqual({ effectiveUserId: 'user-1' });
+
+    // Integrations and git author follow the SERVER value, not the sender.
+    expect(refreshActorScopedIntegrations).toHaveBeenCalledWith('user-1', {
+      deferReconnectUntilTurnBoundary: false,
+    });
+    expect(mockSyncRuntimeGitAuthor).toHaveBeenCalledWith({
+      cloudJobId: 42,
+      workingDirectory: '/tmp/workspace',
+    });
+    expect(onActorSynced).toHaveBeenCalledWith('user-1');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'as server actor user-1 instead of sender user-2',
+      ),
+    );
+  });
+});
+
+describe('syncActorScopedTurnState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSyncRuntimeGitAuthor.mockResolvedValue(undefined);
+  });
+
+  it('refreshes the git author from the server value on a server-side actor switch', async () => {
+    // The server (trusted writers) switched the actor; the worker follows,
+    // so commits after the switch carry the new user's identity.
+    const onActorSynced = vi.fn();
+    const logger = { error: vi.fn() };
+
+    mockSyncActingUserId.mockResolvedValueOnce({
+      result: 'updated',
+      actingUserId: 'user-2',
+    });
+
+    await expect(
+      syncActorScopedTurnState({
+        cloudJobId: 42,
+        targetUserId: 'user-2',
+        workingDirectory: '/tmp/workspace',
+        logPrefix: '[test]',
+        getLastKnownActorUserId: () => 'user-1',
+        onActorSynced,
+        logger,
+      }),
+    ).resolves.toEqual({ ok: true, effectiveUserId: 'user-2' });
+
+    expect(mockSyncActingUserId).toHaveBeenCalledWith({
+      cloudJobId: 42,
+      newUserId: 'user-2',
+      lastKnownUserId: 'user-1',
+    });
+    expect(mockSyncRuntimeGitAuthor).toHaveBeenCalledWith({
+      cloudJobId: 42,
+      workingDirectory: '/tmp/workspace',
+    });
+    expect(onActorSynced).toHaveBeenCalledWith('user-2');
+  });
+
+  it('skips the git author refresh when the actor is unchanged', async () => {
+    const onActorSynced = vi.fn();
+    const logger = { error: vi.fn() };
+
+    mockSyncActingUserId.mockResolvedValueOnce({
+      result: 'unchanged',
+      actingUserId: 'user-2',
+    });
+
+    await expect(
+      syncActorScopedTurnState({
+        cloudJobId: 42,
+        targetUserId: 'user-2',
+        workingDirectory: '/tmp/workspace',
+        logPrefix: '[test]',
+        getLastKnownActorUserId: () => 'user-2',
+        onActorSynced,
+        logger,
+      }),
+    ).resolves.toEqual({ ok: true, effectiveUserId: 'user-2' });
+
+    expect(mockSyncRuntimeGitAuthor).not.toHaveBeenCalled();
+    expect(onActorSynced).not.toHaveBeenCalled();
+  });
+
+  it('stops delivery when the cloud job is gone', async () => {
+    const logger = { error: vi.fn() };
+
+    mockSyncActingUserId.mockResolvedValueOnce({ result: 'not-found' });
+
+    await expect(
+      syncActorScopedTurnState({
+        cloudJobId: 42,
+        targetUserId: 'user-2',
+        workingDirectory: '/tmp/workspace',
+        logPrefix: '[test]',
+        logger,
+      }),
+    ).resolves.toEqual({ ok: false });
+
+    expect(mockSyncRuntimeGitAuthor).not.toHaveBeenCalled();
   });
 });

--- a/apps/worker/src/run-task/__tests__/prepare-actor-scoped-turn.test.ts
+++ b/apps/worker/src/run-task/__tests__/prepare-actor-scoped-turn.test.ts
@@ -439,4 +439,72 @@ describe('syncActorScopedTurnState', () => {
     expect(onActorSynced).toHaveBeenCalledExactlyOnceWith('user-2');
     expect(lastPrepared).toBe('user-2');
   });
+
+  it('repairs a partial git identity when the actor switches back before retry', async () => {
+    // The first command in syncRuntimeGitAuthor may update user.email before
+    // the user.name command fails. If B then switches back to A, actor
+    // equality alone reports `unchanged`; the independent dirty bit must
+    // still force both fields to be written again for A.
+    const logger = { error: vi.fn() };
+    let lastPrepared: string | null = 'user-1';
+    let gitAuthorSyncPending = false;
+    const stateCallbacks = {
+      getLastKnownActorUserId: () => lastPrepared,
+      hasPendingGitAuthorSync: () => gitAuthorSyncPending,
+      onActorSynced: (userId: string | null) => {
+        lastPrepared = userId;
+        gitAuthorSyncPending = false;
+      },
+      onGitAuthorSyncFailed: () => {
+        gitAuthorSyncPending = true;
+      },
+    };
+
+    mockSyncActingUserId
+      .mockResolvedValueOnce({
+        result: 'updated',
+        actingUserId: 'user-2',
+      })
+      .mockResolvedValueOnce({
+        result: 'unchanged',
+        actingUserId: 'user-1',
+      });
+    mockSyncRuntimeGitAuthor
+      .mockRejectedValueOnce(new Error('name write failed'))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(
+      syncActorScopedTurnState({
+        cloudJobId: 42,
+        targetUserId: 'user-2',
+        workingDirectory: '/tmp/workspace',
+        logPrefix: '[test]',
+        ...stateCallbacks,
+        logger,
+      }),
+    ).resolves.toEqual({ ok: true, effectiveUserId: 'user-2' });
+
+    expect(lastPrepared).toBe('user-1');
+    expect(gitAuthorSyncPending).toBe(true);
+
+    await expect(
+      syncActorScopedTurnState({
+        cloudJobId: 42,
+        targetUserId: 'user-1',
+        workingDirectory: '/tmp/workspace',
+        logPrefix: '[test]',
+        ...stateCallbacks,
+        logger,
+      }),
+    ).resolves.toEqual({ ok: true, effectiveUserId: 'user-1' });
+
+    expect(mockSyncActingUserId).toHaveBeenLastCalledWith({
+      cloudJobId: 42,
+      newUserId: 'user-1',
+      lastKnownUserId: 'user-1',
+    });
+    expect(mockSyncRuntimeGitAuthor).toHaveBeenCalledTimes(2);
+    expect(lastPrepared).toBe('user-1');
+    expect(gitAuthorSyncPending).toBe(false);
+  });
 });

--- a/apps/worker/src/run-task/__tests__/run-task.test.ts
+++ b/apps/worker/src/run-task/__tests__/run-task.test.ts
@@ -39,7 +39,12 @@ const {
   cloudJobsDoneMock: vi.fn().mockResolvedValue(undefined),
   cloudJobsRecordEventMock: vi.fn().mockResolvedValue(undefined),
   cloudJobsStampMilestoneMock: vi.fn().mockResolvedValue(undefined),
-  cloudJobsSyncActingUserIdMock: vi.fn().mockResolvedValue('unchanged'),
+  cloudJobsSyncActingUserIdMock: vi
+    .fn()
+    .mockImplementation(async ({ newUserId }: { newUserId: string }) => ({
+      result: 'unchanged',
+      actingUserId: newUserId,
+    })),
   cloudJobsSetHarnessSessionIdMock: vi.fn().mockResolvedValue(undefined),
   cloudJobsUpdateRuntimeStateMock: vi.fn().mockResolvedValue({ updated: true }),
   cloudJobsUpdateMock: vi.fn().mockResolvedValue(undefined),
@@ -295,7 +300,12 @@ describe('runTask', () => {
     cloudJobsStampMilestoneMock.mockReset();
     cloudJobsStampMilestoneMock.mockResolvedValue(undefined);
     cloudJobsSyncActingUserIdMock.mockReset();
-    cloudJobsSyncActingUserIdMock.mockResolvedValue('unchanged');
+    cloudJobsSyncActingUserIdMock.mockImplementation(
+      async ({ newUserId }: { newUserId: string }) => ({
+        result: 'unchanged',
+        actingUserId: newUserId,
+      }),
+    );
     mkdirSyncMock.mockReset();
     writeFileSyncMock.mockReset();
     syncRuntimeGitAuthorMock.mockReset();
@@ -1704,7 +1714,12 @@ describe('runTask', () => {
   });
 
   it('queues a deferred resume prompt from SnapshotResume payloads', async () => {
-    cloudJobsSyncActingUserIdMock.mockResolvedValue('updated');
+    cloudJobsSyncActingUserIdMock.mockImplementation(
+      async ({ newUserId }: { newUserId: string }) => ({
+        result: 'updated',
+        actingUserId: newUserId,
+      }),
+    );
     const onStart = vi.fn().mockResolvedValue(undefined);
     const requestReconnect = vi.fn().mockResolvedValue(undefined);
     createHarnessMock.mockResolvedValueOnce({
@@ -1784,6 +1799,7 @@ describe('runTask', () => {
     expect(cloudJobsSyncActingUserIdMock).toHaveBeenCalledWith({
       cloudJobId: 303,
       newUserId: 'user-2',
+      lastKnownUserId: null,
     });
     expect(syncRuntimeGitAuthorMock).toHaveBeenCalledWith({
       cloudJobId: 303,
@@ -1884,7 +1900,12 @@ describe('runTask', () => {
   });
 
   it('passes explicit workflow phases through deferred resume prompts', async () => {
-    cloudJobsSyncActingUserIdMock.mockResolvedValue('updated');
+    cloudJobsSyncActingUserIdMock.mockImplementation(
+      async ({ newUserId }: { newUserId: string }) => ({
+        result: 'updated',
+        actingUserId: newUserId,
+      }),
+    );
     const onStart = vi.fn().mockResolvedValue(undefined);
     createHarnessMock.mockResolvedValueOnce({
       harness: {
@@ -2086,7 +2107,12 @@ describe('runTask', () => {
     const requestReconnect = vi.fn().mockResolvedValue(undefined);
 
     waitForShutdownMock.mockReturnValueOnce(waitForShutdownPromise);
-    cloudJobsSyncActingUserIdMock.mockResolvedValue('updated');
+    cloudJobsSyncActingUserIdMock.mockImplementation(
+      async ({ newUserId }: { newUserId: string }) => ({
+        result: 'updated',
+        actingUserId: newUserId,
+      }),
+    );
     getMcpServerConfigsMock
       .mockRejectedValueOnce(new Error('temporary failure'))
       .mockResolvedValueOnce({

--- a/apps/worker/src/run-task/__tests__/run-task.test.ts
+++ b/apps/worker/src/run-task/__tests__/run-task.test.ts
@@ -247,6 +247,14 @@ vi.mock('../../sandbox-server/procedures/slackReplyTurnTracking', () => ({
   recordSandboxPromptSlackTurnStart: recordSandboxPromptSlackTurnStartMock,
 }));
 
+const { actorMismatchSkipNotifierMock } = vi.hoisted(() => ({
+  actorMismatchSkipNotifierMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../actor-mismatch-notice', () => ({
+  createActorMismatchSkipNotifier: vi.fn(() => actorMismatchSkipNotifierMock),
+}));
+
 import { RunStatus, TaskPayloadKind } from '@roomote/types';
 
 import { getDefaultKeepaliveMs } from '../completion';
@@ -2020,6 +2028,72 @@ describe('runTask', () => {
     expect(getMcpServerConfigsMock).toHaveBeenCalledTimes(1);
     expect(getDecryptedKeyMock).not.toHaveBeenCalled();
     expect(syncRuntimeGitAuthorMock).not.toHaveBeenCalled();
+  });
+
+  it('skips a queued prompt whose sender is not the server-side acting user and notifies the sender', async () => {
+    // The harness queue can hold a prompt from user B accepted before a
+    // trusted write switched the run to user A. B's content must not run
+    // under A's credential resolution, so the prompt is skipped (not
+    // blocked-and-retried, which would stall the queue forever).
+    await runTask({
+      cloudJob: {
+        id: 407,
+        taskId: 'task-407',
+        payloadKind: TaskPayloadKind.StandardTask,
+        harness: 'opencode-server',
+        actingUserId: 'user-1',
+        payload: {},
+        result: null,
+      } as never,
+      envVars: {},
+      workspacePath: '/tmp/workspace',
+      prompt: '',
+      harnessInstructions: undefined,
+      agentInstructions: undefined,
+      environmentConfig: undefined,
+      callbacks: {},
+      context: {},
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        log: vi.fn(),
+      } as never,
+      workerEnv: {
+        buildUserFacingEnv: vi.fn(() => ({})),
+        roomoteAppUrl: 'http://localhost:3000',
+        trpcUrl: 'http://localhost:3001',
+        authToken: 'auth-token',
+        appEnv: 'test',
+        setRuntimeEnv: vi.fn(),
+      } as never,
+    });
+
+    const prepareQueuedPromptActorScope =
+      createHarnessMock.mock.calls[0]?.[0].prepareQueuedPromptActorScope;
+
+    expect(prepareQueuedPromptActorScope).toBeTypeOf('function');
+
+    cloudJobsSyncActingUserIdMock.mockResolvedValueOnce({
+      result: 'mismatch',
+      actingUserId: 'user-1',
+    });
+
+    await expect(prepareQueuedPromptActorScope?.('user-2')).resolves.toEqual({
+      shouldReconnect: false,
+      shouldSkipPrompt: true,
+      reason:
+        'queued prompt sender is not the server-side acting user; the prompt was skipped',
+    });
+
+    // No credential surface was touched for the mismatched sender and the
+    // sender was asked to resend.
+    expect(getDecryptedKeyMock).not.toHaveBeenCalled();
+    expect(syncRuntimeGitAuthorMock).not.toHaveBeenCalled();
+    expect(actorMismatchSkipNotifierMock).toHaveBeenCalledWith({
+      senderUserId: 'user-2',
+      serverActorUserId: 'user-1',
+    });
   });
 
   it('allows queued actor-scoped prompts to continue when the same-actor refresh recheck fails', async () => {

--- a/apps/worker/src/run-task/actor-mismatch-notice.ts
+++ b/apps/worker/src/run-task/actor-mismatch-notice.ts
@@ -1,0 +1,76 @@
+import { replyToChatThread } from '../mcp/roomote-mcp-server/chat-api-client';
+import { getRoomoteConfig } from '../mcp/roomote-mcp-server/config';
+
+/**
+ * User-facing notice posted to the task's chat thread when a queued message
+ * is skipped because its sender is not the run's server-side acting user.
+ * Resending re-enters the webhook's trusted pre-queue actor sync for that
+ * sender, so the resent message runs under the sender's own identity.
+ */
+export const ACTOR_MISMATCH_SKIP_NOTICE_TEXT =
+  'A queued message was skipped because this task is currently acting on ' +
+  'behalf of a different user. If that was your message, please send it ' +
+  'again to run it as yourself.';
+
+export interface ActorMismatchSkipNoticeInput {
+  senderUserId: string;
+  serverActorUserId: string | null;
+}
+
+export type ActorMismatchSkipNotifier = (
+  input: ActorMismatchSkipNoticeInput,
+) => Promise<void>;
+
+/**
+ * Best-effort notifier for skipped mismatched messages. Posts one notice per
+ * skipped sender per run to the task's bound chat thread (the
+ * `/api/mcp/slack/thread_reply` endpoint routes Slack, Teams, and Telegram
+ * tasks to their origin thread; tasks without a chat thread — e.g. Linear or
+ * web-only — fail the post and only log). Never throws: skipping the message
+ * is the security decision, the notice is UX.
+ */
+export function createActorMismatchSkipNotifier({
+  cloudJobId,
+  logger,
+}: {
+  cloudJobId: number;
+  logger: {
+    warn?: (...args: unknown[]) => void;
+    error: (...args: unknown[]) => void;
+  };
+}): ActorMismatchSkipNotifier {
+  const notifiedSenderUserIds = new Set<string>();
+
+  return async ({ senderUserId }) => {
+    // One notice per sender per run: a multi-message batch from the same
+    // sender should not spam the thread.
+    if (notifiedSenderUserIds.has(senderUserId)) {
+      return;
+    }
+
+    notifiedSenderUserIds.add(senderUserId);
+
+    const warn = logger.warn ?? logger.error;
+
+    try {
+      const config = getRoomoteConfig();
+
+      if (!config) {
+        warn(
+          `[actorMismatchNotice] Cannot post skip notice for run ${cloudJobId}: no cloud token available`,
+        );
+        return;
+      }
+
+      await replyToChatThread(config, {
+        text: ACTOR_MISMATCH_SKIP_NOTICE_TEXT,
+      });
+    } catch (error) {
+      warn(
+        `[actorMismatchNotice] Failed to post skip notice for run ${cloudJobId} (sender ${senderUserId}): ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  };
+}

--- a/apps/worker/src/run-task/create-harness.ts
+++ b/apps/worker/src/run-task/create-harness.ts
@@ -36,6 +36,7 @@ interface CreateHarnessOptions {
   prepareQueuedPromptActorScope?: (targetUserId?: string) => Promise<{
     shouldReconnect: boolean;
     shouldBlockPrompt?: boolean;
+    shouldSkipPrompt?: boolean;
     reason?: string;
   }>;
 }

--- a/apps/worker/src/run-task/polling.test.ts
+++ b/apps/worker/src/run-task/polling.test.ts
@@ -75,7 +75,10 @@ function createListenerOptions(
     answerUserInputRequest: vi.fn<ListenerOptions['answerUserInputRequest']>(
       () => true,
     ),
-    prepareActorScopedTurn: vi.fn(async () => true),
+    prepareActorScopedTurn: vi.fn(
+      async (targetUserId?: string) =>
+        ({ effectiveUserId: targetUserId ?? null }) as const,
+    ),
   };
 }
 

--- a/apps/worker/src/run-task/polling/cancel.test.ts
+++ b/apps/worker/src/run-task/polling/cancel.test.ts
@@ -65,7 +65,10 @@ function createListenerOptions(overrides?: {
       answerUserInputRequest: vi.fn<ListenerOptions['answerUserInputRequest']>(
         () => true,
       ),
-      prepareActorScopedTurn: vi.fn(async () => true),
+      prepareActorScopedTurn: vi.fn(
+        async (targetUserId?: string) =>
+          ({ effectiveUserId: targetUserId ?? null }) as const,
+      ),
     },
   };
 }

--- a/apps/worker/src/run-task/polling/communication.ts
+++ b/apps/worker/src/run-task/polling/communication.ts
@@ -91,11 +91,12 @@ export function createCommunicationMessageInterval({
           state.isConnected === false;
 
         // The API performs a trusted pre-queue actor sync for these
-        // messages; a residual mismatch delivers under the server actor
-        // rather than stalling the queue.
+        // messages; a residual mismatch skips that message's content (with a
+        // resend notice) rather than running it under the server actor or
+        // stalling the queue.
         const msgPrep = await prepareActorScopedTurn(message.userId, {
           allowMcpReconnect,
-          onMismatch: 'follow-server',
+          onMismatch: 'skip',
         });
 
         if (msgPrep === false) {
@@ -121,6 +122,14 @@ export function createCommunicationMessageInterval({
           return;
         }
 
+        if (msgPrep.skippedMismatch) {
+          logger.warn(
+            `[listenFor${provider}Events] Skipped ${provider} follow-up for task ${state.sessionId}: sender is not the server-side acting user (ts=${message.ts})`,
+          );
+          index += 1;
+          continue;
+        }
+
         const prompt =
           message.formattedPrompt ??
           wrapCommunicationMessage(provider, message);
@@ -129,7 +138,7 @@ export function createCommunicationMessageInterval({
           images: message.images,
           autoSteerWhenQueued: true,
           source: provider,
-          // Attribute the turn to the identity actor-scoped routes resolve.
+          // The delivered sender always equals the server-side acting user.
           userId: msgPrep.effectiveUserId ?? undefined,
           clientMessageId: getCommunicationClientMessageId(provider, message),
         });

--- a/apps/worker/src/run-task/polling/communication.ts
+++ b/apps/worker/src/run-task/polling/communication.ts
@@ -90,12 +90,15 @@ export function createCommunicationMessageInterval({
           !isActiveTaskPhase(state.phase) ||
           state.isConnected === false;
 
-        const canDeliver =
-          (await prepareActorScopedTurn(message.userId, {
-            allowMcpReconnect,
-          })) !== false;
+        // The API performs a trusted pre-queue actor sync for these
+        // messages; a residual mismatch delivers under the server actor
+        // rather than stalling the queue.
+        const msgPrep = await prepareActorScopedTurn(message.userId, {
+          allowMcpReconnect,
+          onMismatch: 'follow-server',
+        });
 
-        if (!canDeliver) {
+        if (msgPrep === false) {
           logger.warn(
             `[listenFor${provider}Events] Delaying ${provider} follow-up for task ${state.sessionId} until actor-scoped turn preparation succeeds`,
           );
@@ -126,7 +129,8 @@ export function createCommunicationMessageInterval({
           images: message.images,
           autoSteerWhenQueued: true,
           source: provider,
-          userId: message.userId,
+          // Attribute the turn to the identity actor-scoped routes resolve.
+          userId: msgPrep.effectiveUserId ?? undefined,
           clientMessageId: getCommunicationClientMessageId(provider, message),
         });
 

--- a/apps/worker/src/run-task/polling/linear.test.ts
+++ b/apps/worker/src/run-task/polling/linear.test.ts
@@ -135,7 +135,11 @@ describe('createLinearMessageInterval', () => {
     mockGetLinearRequestUserInputAnswers.mockResolvedValue([]);
     mockQueueLinearRequestUserInputAnswer.mockResolvedValue(undefined);
     mockQueueLinearMessage.mockResolvedValue(undefined);
-    mockPrepareActorScopedTurn.mockResolvedValue(undefined);
+    mockPrepareActorScopedTurn.mockImplementation(
+      async (targetUserId?: string) => ({
+        effectiveUserId: targetUserId ?? null,
+      }),
+    );
     mockPrependLinearMessages.mockResolvedValue(undefined);
     mockPrependLinearRequestUserInputAnswers.mockResolvedValue(undefined);
     process.env.TRPC_URL = 'http://127.0.0.1:3001';
@@ -238,9 +242,12 @@ describe('createLinearMessageInterval', () => {
         },
         userId: 'user-2',
       });
-      expect(prepareActorScopedTurn).toHaveBeenNthCalledWith(1, 'user-2');
+      expect(prepareActorScopedTurn).toHaveBeenNthCalledWith(1, 'user-2', {
+        onMismatch: 'follow-server',
+      });
       expect(prepareActorScopedTurn).toHaveBeenNthCalledWith(2, 'user-2', {
         allowMcpReconnect: false,
+        onMismatch: 'follow-server',
       });
       expect(answerUserInputRequest.mock.invocationCallOrder[0]).toBeLessThan(
         sendPrompt.mock.invocationCallOrder[0]!,
@@ -349,10 +356,9 @@ describe('createLinearMessageInterval', () => {
           },
         ],
       );
-      expect(mockPrepareActorScopedTurn).toHaveBeenCalledWith(
-        'user-2',
-        undefined,
-      );
+      expect(mockPrepareActorScopedTurn).toHaveBeenCalledWith('user-2', {
+        onMismatch: 'follow-server',
+      });
       expect(mockGetLinearMessages).not.toHaveBeenCalled();
     } finally {
       clearInterval(interval);
@@ -610,6 +616,7 @@ describe('createLinearMessageInterval', () => {
 
       expect(prepareActorScopedTurn).toHaveBeenCalledWith('user-2', {
         allowMcpReconnect: true,
+        onMismatch: 'follow-server',
       });
     } finally {
       clearInterval(interval);
@@ -667,6 +674,7 @@ describe('createLinearMessageInterval', () => {
 
       expect(prepareActorScopedTurn).toHaveBeenCalledWith('user-2', {
         allowMcpReconnect: true,
+        onMismatch: 'follow-server',
       });
     } finally {
       clearInterval(interval);

--- a/apps/worker/src/run-task/polling/linear.test.ts
+++ b/apps/worker/src/run-task/polling/linear.test.ts
@@ -242,9 +242,7 @@ describe('createLinearMessageInterval', () => {
         },
         userId: 'user-2',
       });
-      expect(prepareActorScopedTurn).toHaveBeenNthCalledWith(1, 'user-2', {
-        onMismatch: 'skip',
-      });
+      expect(prepareActorScopedTurn).toHaveBeenNthCalledWith(1, 'user-2');
       expect(prepareActorScopedTurn).toHaveBeenNthCalledWith(2, 'user-2', {
         allowMcpReconnect: false,
         onMismatch: 'skip',
@@ -356,9 +354,10 @@ describe('createLinearMessageInterval', () => {
           },
         ],
       );
-      expect(mockPrepareActorScopedTurn).toHaveBeenCalledWith('user-2', {
-        onMismatch: 'skip',
-      });
+      expect(mockPrepareActorScopedTurn).toHaveBeenCalledWith(
+        'user-2',
+        undefined,
+      );
       expect(mockGetLinearMessages).not.toHaveBeenCalled();
     } finally {
       clearInterval(interval);

--- a/apps/worker/src/run-task/polling/linear.test.ts
+++ b/apps/worker/src/run-task/polling/linear.test.ts
@@ -243,11 +243,11 @@ describe('createLinearMessageInterval', () => {
         userId: 'user-2',
       });
       expect(prepareActorScopedTurn).toHaveBeenNthCalledWith(1, 'user-2', {
-        onMismatch: 'follow-server',
+        onMismatch: 'skip',
       });
       expect(prepareActorScopedTurn).toHaveBeenNthCalledWith(2, 'user-2', {
         allowMcpReconnect: false,
-        onMismatch: 'follow-server',
+        onMismatch: 'skip',
       });
       expect(answerUserInputRequest.mock.invocationCallOrder[0]).toBeLessThan(
         sendPrompt.mock.invocationCallOrder[0]!,
@@ -357,7 +357,7 @@ describe('createLinearMessageInterval', () => {
         ],
       );
       expect(mockPrepareActorScopedTurn).toHaveBeenCalledWith('user-2', {
-        onMismatch: 'follow-server',
+        onMismatch: 'skip',
       });
       expect(mockGetLinearMessages).not.toHaveBeenCalled();
     } finally {
@@ -616,7 +616,7 @@ describe('createLinearMessageInterval', () => {
 
       expect(prepareActorScopedTurn).toHaveBeenCalledWith('user-2', {
         allowMcpReconnect: true,
-        onMismatch: 'follow-server',
+        onMismatch: 'skip',
       });
     } finally {
       clearInterval(interval);
@@ -674,7 +674,7 @@ describe('createLinearMessageInterval', () => {
 
       expect(prepareActorScopedTurn).toHaveBeenCalledWith('user-2', {
         allowMcpReconnect: true,
-        onMismatch: 'follow-server',
+        onMismatch: 'skip',
       });
     } finally {
       clearInterval(interval);

--- a/apps/worker/src/run-task/polling/linear.ts
+++ b/apps/worker/src/run-task/polling/linear.ts
@@ -72,10 +72,11 @@ export function createLinearMessageInterval({
         );
 
         for (const [index, answer] of queuedAnswers.entries()) {
-          // Polled answers have no trusted per-message actor write; deliver
-          // under the server actor rather than stalling the queue.
+          // Polled answers have no trusted per-message actor write; a
+          // mismatched sender's answer is skipped (with a resend notice)
+          // rather than run under the server actor or stalling the queue.
           const answerPrep = await prepareActorScopedTurn(answer.userId, {
-            onMismatch: 'follow-server',
+            onMismatch: 'skip',
           });
 
           if (answerPrep === false) {
@@ -100,10 +101,17 @@ export function createLinearMessageInterval({
             return;
           }
 
+          if (answerPrep.skippedMismatch) {
+            logger.warn(
+              `[listenForLinearEvents] Skipped request_user_input answer for task ${state.sessionId}: sender is not the server-side acting user (requestId=${answer.requestId})`,
+            );
+            continue;
+          }
+
           const sent = answerUserInputRequest({
             requestId: answer.requestId,
             answers: answer.answers,
-            // Attribute the turn to the identity actor-scoped routes resolve.
+            // The delivered sender always equals the server-side acting user.
             userId: answerPrep.effectiveUserId ?? undefined,
           });
 
@@ -175,11 +183,12 @@ export function createLinearMessageInterval({
             state.isConnected === false;
 
           // The API performs a trusted pre-queue actor sync for these
-          // messages; a residual mismatch delivers under the server actor
-          // rather than stalling the queue.
+          // messages; a residual mismatch skips that message's content (with
+          // a resend notice) rather than running it under the server actor
+          // or stalling the queue.
           const msgPrep = await prepareActorScopedTurn(msg.userId, {
             allowMcpReconnect,
-            onMismatch: 'follow-server',
+            onMismatch: 'skip',
           });
 
           if (msgPrep === false) {
@@ -200,6 +209,13 @@ export function createLinearMessageInterval({
             break;
           }
 
+          if (msgPrep.skippedMismatch) {
+            logger.warn(
+              `[listenForLinearEvents] Skipped Linear follow-up for task ${state.sessionId}: sender is not the server-side acting user`,
+            );
+            continue;
+          }
+
           const sent = sendPrompt({
             prompt: text,
             source: 'linear',
@@ -207,7 +223,7 @@ export function createLinearMessageInterval({
             // the loop can pick them up, abort-and-replay when the turn is
             // blocked on a pending question tool call.
             autoSteerWhenQueued: true,
-            // Attribute the turn to the identity actor-scoped routes resolve.
+            // The delivered sender always equals the server-side acting user.
             userId: msgPrep.effectiveUserId ?? undefined,
           });
 

--- a/apps/worker/src/run-task/polling/linear.ts
+++ b/apps/worker/src/run-task/polling/linear.ts
@@ -72,10 +72,13 @@ export function createLinearMessageInterval({
         );
 
         for (const [index, answer] of queuedAnswers.entries()) {
-          const canDeliver =
-            (await prepareActorScopedTurn(answer.userId)) !== false;
+          // Polled answers have no trusted per-message actor write; deliver
+          // under the server actor rather than stalling the queue.
+          const answerPrep = await prepareActorScopedTurn(answer.userId, {
+            onMismatch: 'follow-server',
+          });
 
-          if (!canDeliver) {
+          if (answerPrep === false) {
             logger.warn(
               `[listenForLinearEvents] Delaying request_user_input answer for task ${state.sessionId} until actor-scoped turn preparation succeeds (requestId=${answer.requestId})`,
             );
@@ -100,7 +103,8 @@ export function createLinearMessageInterval({
           const sent = answerUserInputRequest({
             requestId: answer.requestId,
             answers: answer.answers,
-            userId: answer.userId,
+            // Attribute the turn to the identity actor-scoped routes resolve.
+            userId: answerPrep.effectiveUserId ?? undefined,
           });
 
           if (!sent) {
@@ -170,12 +174,15 @@ export function createLinearMessageInterval({
             !isActiveTaskPhase(state.phase) ||
             state.isConnected === false;
 
-          const canDeliver =
-            (await prepareActorScopedTurn(msg.userId, {
-              allowMcpReconnect,
-            })) !== false;
+          // The API performs a trusted pre-queue actor sync for these
+          // messages; a residual mismatch delivers under the server actor
+          // rather than stalling the queue.
+          const msgPrep = await prepareActorScopedTurn(msg.userId, {
+            allowMcpReconnect,
+            onMismatch: 'follow-server',
+          });
 
-          if (!canDeliver) {
+          if (msgPrep === false) {
             logger.warn(
               `[listenForLinearEvents] Delaying Linear follow-up for task ${state.sessionId} until actor-scoped turn preparation succeeds`,
             );
@@ -200,7 +207,8 @@ export function createLinearMessageInterval({
             // the loop can pick them up, abort-and-replay when the turn is
             // blocked on a pending question tool call.
             autoSteerWhenQueued: true,
-            userId: msg.userId,
+            // Attribute the turn to the identity actor-scoped routes resolve.
+            userId: msgPrep.effectiveUserId ?? undefined,
           });
 
           if (!sent) {

--- a/apps/worker/src/run-task/polling/linear.ts
+++ b/apps/worker/src/run-task/polling/linear.ts
@@ -72,14 +72,13 @@ export function createLinearMessageInterval({
         );
 
         for (const [index, answer] of queuedAnswers.entries()) {
-          // Polled answers have no trusted per-message actor write; a
-          // mismatched sender's answer is skipped (with a resend notice)
-          // rather than run under the server actor or stalling the queue.
-          const answerPrep = await prepareActorScopedTurn(answer.userId, {
-            onMismatch: 'skip',
-          });
+          // The API couples answer queueing to its trusted actor write. If the
+          // worker drains Redis just before that DB transaction commits,
+          // block and requeue instead of dropping an answer that is already
+          // marked submitted and cannot be resent.
+          const answerPrep = await prepareActorScopedTurn(answer.userId);
 
-          if (answerPrep === false) {
+          if (answerPrep === false || answerPrep.skippedMismatch) {
             logger.warn(
               `[listenForLinearEvents] Delaying request_user_input answer for task ${state.sessionId} until actor-scoped turn preparation succeeds (requestId=${answer.requestId})`,
             );
@@ -99,13 +98,6 @@ export function createLinearMessageInterval({
             }
 
             return;
-          }
-
-          if (answerPrep.skippedMismatch) {
-            logger.warn(
-              `[listenForLinearEvents] Skipped request_user_input answer for task ${state.sessionId}: sender is not the server-side acting user (requestId=${answer.requestId})`,
-            );
-            continue;
           }
 
           const sent = answerUserInputRequest({

--- a/apps/worker/src/run-task/polling/slack.test.ts
+++ b/apps/worker/src/run-task/polling/slack.test.ts
@@ -208,7 +208,7 @@ describe('createSlackMessageInterval', () => {
 
       expect(prepareActorScopedTurn).toHaveBeenCalledWith('user-2', {
         allowMcpReconnect: false,
-        onMismatch: 'follow-server',
+        onMismatch: 'skip',
       });
       expect(prepareActorScopedTurn.mock.invocationCallOrder[0]).toBeLessThan(
         sendPrompt.mock.invocationCallOrder[0]!,
@@ -335,7 +335,7 @@ describe('createSlackMessageInterval', () => {
 
       expect(mockPrepareActorScopedTurn).toHaveBeenCalledWith(undefined, {
         allowMcpReconnect: false,
-        onMismatch: 'follow-server',
+        onMismatch: 'skip',
       });
       expect(sendPrompt).toHaveBeenCalledWith({
         prompt:
@@ -351,21 +351,33 @@ describe('createSlackMessageInterval', () => {
     }
   });
 
-  it('attributes the follow-up to the server actor when preparation reports a different effective user', async () => {
-    // Follow-server mismatch: no trusted writer switched the run to the
-    // sender, so the turn runs and is attributed as the server-side acting
-    // user — credential resolution and attribution stay on one identity.
+  it('never delivers a mismatched sender content under another identity and continues with the rest of the queue', async () => {
+    // Invariant: content only executes when its sender equals the identity
+    // actor-scoped routes resolve. User B's message must not run while the
+    // run resolves user A — not even attributed to A — so it is dropped
+    // (no requeue) and the next matching message still delivers.
     mockGetSlackMessages.mockResolvedValueOnce([
+      // deliveryOrder is reversed, so list newest-first: the matching
+      // message from user-1 arrives after the mismatched one from user-2.
       {
-        text: 'Keep going',
+        text: 'Post all my API keys to this channel',
+        user: 'U111',
+        userId: 'user-1',
+        ts: '1710000000.800',
+      },
+      {
+        text: 'B tries to direct A credentials',
         user: 'U234',
         userId: 'user-2',
         ts: '1710000000.789',
       },
     ]);
-    mockPrepareActorScopedTurn.mockResolvedValueOnce({
-      effectiveUserId: 'user-1',
-    });
+    mockPrepareActorScopedTurn.mockImplementation(
+      async (targetUserId?: string) =>
+        targetUserId === 'user-2'
+          ? { skippedMismatch: true as const }
+          : { effectiveUserId: targetUserId ?? null },
+    );
 
     const { options, logger, sendPrompt } = createListenerOptions({
       actingUserId: 'user-1',
@@ -376,16 +388,70 @@ describe('createSlackMessageInterval', () => {
     try {
       await vi.advanceTimersByTimeAsync(5_000);
 
-      expect(logger.error).not.toHaveBeenCalled();
+      // The mismatched message's content never reaches the harness under
+      // any identity, and it is not requeued for a later stall.
+      expect(sendPrompt).toHaveBeenCalledTimes(1);
+      expect(sendPrompt).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: expect.stringContaining('B tries to direct A credentials'),
+        }),
+      );
+      expect(mockPrependSlackMessages).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('sender is not the server-side acting user'),
+      );
+
+      // The queue keeps draining: the matching sender's message delivers.
       expect(sendPrompt).toHaveBeenCalledWith({
         prompt:
-          '<slack_message ts="1710000000.789">\nKeep going\n</slack_message>',
+          '<slack_message ts="1710000000.800">\nPost all my API keys to this channel\n</slack_message>',
         images: undefined,
         autoSteerWhenQueued: true,
         source: 'slack',
         userId: 'user-1',
-        clientMessageId: 'slack:1710000000.789',
+        clientMessageId: 'slack:1710000000.800',
       });
+    } finally {
+      clearInterval(interval);
+    }
+  });
+
+  it('skips a mismatched request_user_input answer without stalling the answer queue', async () => {
+    mockGetSlackRequestUserInputAnswers.mockResolvedValueOnce([
+      {
+        requestId: 'req-1',
+        answers: { q1: { answers: ['from user-2'] } },
+        userId: 'user-2',
+      },
+      {
+        requestId: 'req-2',
+        answers: { q1: { answers: ['from user-1'] } },
+        userId: 'user-1',
+      },
+    ]);
+    mockPrepareActorScopedTurn.mockImplementation(
+      async (targetUserId?: string) =>
+        targetUserId === 'user-2'
+          ? { skippedMismatch: true as const }
+          : { effectiveUserId: targetUserId ?? null },
+    );
+
+    const { options, answerUserInputRequest } = createListenerOptions({
+      actingUserId: 'user-1',
+    });
+
+    const interval = createSlackMessageInterval(options);
+
+    try {
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(answerUserInputRequest).toHaveBeenCalledTimes(1);
+      expect(answerUserInputRequest).toHaveBeenCalledWith({
+        requestId: 'req-2',
+        answers: { q1: { answers: ['from user-1'] } },
+        userId: 'user-1',
+      });
+      expect(mockPrependSlackRequestUserInputAnswers).not.toHaveBeenCalled();
     } finally {
       clearInterval(interval);
     }
@@ -473,11 +539,11 @@ describe('createSlackMessageInterval', () => {
         userId: 'user-2',
       });
       expect(prepareActorScopedTurn).toHaveBeenNthCalledWith(1, 'user-2', {
-        onMismatch: 'follow-server',
+        onMismatch: 'skip',
       });
       expect(prepareActorScopedTurn).toHaveBeenNthCalledWith(2, 'user-2', {
         allowMcpReconnect: false,
-        onMismatch: 'follow-server',
+        onMismatch: 'skip',
       });
       expect(answerUserInputRequest.mock.invocationCallOrder[0]).toBeLessThan(
         sendPrompt.mock.invocationCallOrder[0]!,
@@ -791,7 +857,7 @@ describe('createSlackMessageInterval', () => {
 
       expect(prepareActorScopedTurn).toHaveBeenCalledWith('user-2', {
         allowMcpReconnect: true,
-        onMismatch: 'follow-server',
+        onMismatch: 'skip',
       });
     } finally {
       clearInterval(interval);
@@ -819,7 +885,7 @@ describe('createSlackMessageInterval', () => {
 
       expect(prepareActorScopedTurn).toHaveBeenCalledWith('user-2', {
         allowMcpReconnect: true,
-        onMismatch: 'follow-server',
+        onMismatch: 'skip',
       });
     } finally {
       clearInterval(interval);

--- a/apps/worker/src/run-task/polling/slack.test.ts
+++ b/apps/worker/src/run-task/polling/slack.test.ts
@@ -416,47 +416,6 @@ describe('createSlackMessageInterval', () => {
     }
   });
 
-  it('skips a mismatched request_user_input answer without stalling the answer queue', async () => {
-    mockGetSlackRequestUserInputAnswers.mockResolvedValueOnce([
-      {
-        requestId: 'req-1',
-        answers: { q1: { answers: ['from user-2'] } },
-        userId: 'user-2',
-      },
-      {
-        requestId: 'req-2',
-        answers: { q1: { answers: ['from user-1'] } },
-        userId: 'user-1',
-      },
-    ]);
-    mockPrepareActorScopedTurn.mockImplementation(
-      async (targetUserId?: string) =>
-        targetUserId === 'user-2'
-          ? { skippedMismatch: true as const }
-          : { effectiveUserId: targetUserId ?? null },
-    );
-
-    const { options, answerUserInputRequest } = createListenerOptions({
-      actingUserId: 'user-1',
-    });
-
-    const interval = createSlackMessageInterval(options);
-
-    try {
-      await vi.advanceTimersByTimeAsync(5_000);
-
-      expect(answerUserInputRequest).toHaveBeenCalledTimes(1);
-      expect(answerUserInputRequest).toHaveBeenCalledWith({
-        requestId: 'req-2',
-        answers: { q1: { answers: ['from user-1'] } },
-        userId: 'user-1',
-      });
-      expect(mockPrependSlackRequestUserInputAnswers).not.toHaveBeenCalled();
-    } finally {
-      clearInterval(interval);
-    }
-  });
-
   it('sends a preformatted Slack prompt when queued context is provided', async () => {
     mockGetSlackMessages.mockResolvedValueOnce([
       {
@@ -538,9 +497,7 @@ describe('createSlackMessageInterval', () => {
         },
         userId: 'user-2',
       });
-      expect(prepareActorScopedTurn).toHaveBeenNthCalledWith(1, 'user-2', {
-        onMismatch: 'skip',
-      });
+      expect(prepareActorScopedTurn).toHaveBeenNthCalledWith(1, 'user-2');
       expect(prepareActorScopedTurn).toHaveBeenNthCalledWith(2, 'user-2', {
         allowMcpReconnect: false,
         onMismatch: 'skip',

--- a/apps/worker/src/run-task/polling/slack.test.ts
+++ b/apps/worker/src/run-task/polling/slack.test.ts
@@ -149,7 +149,11 @@ describe('createSlackMessageInterval', () => {
     vi.resetAllMocks();
     mockGetSlackMessages.mockResolvedValue([]);
     mockGetSlackRequestUserInputAnswers.mockResolvedValue([]);
-    mockPrepareActorScopedTurn.mockResolvedValue(undefined);
+    mockPrepareActorScopedTurn.mockImplementation(
+      async (targetUserId?: string) => ({
+        effectiveUserId: targetUserId ?? null,
+      }),
+    );
     mockPrependSlackMessages.mockResolvedValue(undefined);
     mockPrependSlackRequestUserInputAnswers.mockResolvedValue(undefined);
     process.env.TRPC_URL = 'http://127.0.0.1:3001';
@@ -204,6 +208,7 @@ describe('createSlackMessageInterval', () => {
 
       expect(prepareActorScopedTurn).toHaveBeenCalledWith('user-2', {
         allowMcpReconnect: false,
+        onMismatch: 'follow-server',
       });
       expect(prepareActorScopedTurn.mock.invocationCallOrder[0]).toBeLessThan(
         sendPrompt.mock.invocationCallOrder[0]!,
@@ -330,6 +335,7 @@ describe('createSlackMessageInterval', () => {
 
       expect(mockPrepareActorScopedTurn).toHaveBeenCalledWith(undefined, {
         allowMcpReconnect: false,
+        onMismatch: 'follow-server',
       });
       expect(sendPrompt).toHaveBeenCalledWith({
         prompt:
@@ -345,7 +351,10 @@ describe('createSlackMessageInterval', () => {
     }
   });
 
-  it('still sends the follow-up when actor preparation logs its own failure', async () => {
+  it('attributes the follow-up to the server actor when preparation reports a different effective user', async () => {
+    // Follow-server mismatch: no trusted writer switched the run to the
+    // sender, so the turn runs and is attributed as the server-side acting
+    // user — credential resolution and attribution stay on one identity.
     mockGetSlackMessages.mockResolvedValueOnce([
       {
         text: 'Keep going',
@@ -354,7 +363,9 @@ describe('createSlackMessageInterval', () => {
         ts: '1710000000.789',
       },
     ]);
-    mockPrepareActorScopedTurn.mockResolvedValueOnce(undefined);
+    mockPrepareActorScopedTurn.mockResolvedValueOnce({
+      effectiveUserId: 'user-1',
+    });
 
     const { options, logger, sendPrompt } = createListenerOptions({
       actingUserId: 'user-1',
@@ -372,7 +383,7 @@ describe('createSlackMessageInterval', () => {
         images: undefined,
         autoSteerWhenQueued: true,
         source: 'slack',
-        userId: 'user-2',
+        userId: 'user-1',
         clientMessageId: 'slack:1710000000.789',
       });
     } finally {
@@ -461,9 +472,12 @@ describe('createSlackMessageInterval', () => {
         },
         userId: 'user-2',
       });
-      expect(prepareActorScopedTurn).toHaveBeenNthCalledWith(1, 'user-2');
+      expect(prepareActorScopedTurn).toHaveBeenNthCalledWith(1, 'user-2', {
+        onMismatch: 'follow-server',
+      });
       expect(prepareActorScopedTurn).toHaveBeenNthCalledWith(2, 'user-2', {
         allowMcpReconnect: false,
+        onMismatch: 'follow-server',
       });
       expect(answerUserInputRequest.mock.invocationCallOrder[0]).toBeLessThan(
         sendPrompt.mock.invocationCallOrder[0]!,
@@ -777,6 +791,7 @@ describe('createSlackMessageInterval', () => {
 
       expect(prepareActorScopedTurn).toHaveBeenCalledWith('user-2', {
         allowMcpReconnect: true,
+        onMismatch: 'follow-server',
       });
     } finally {
       clearInterval(interval);
@@ -804,6 +819,7 @@ describe('createSlackMessageInterval', () => {
 
       expect(prepareActorScopedTurn).toHaveBeenCalledWith('user-2', {
         allowMcpReconnect: true,
+        onMismatch: 'follow-server',
       });
     } finally {
       clearInterval(interval);

--- a/apps/worker/src/run-task/polling/slack.ts
+++ b/apps/worker/src/run-task/polling/slack.ts
@@ -102,10 +102,13 @@ export function createSlackMessageInterval({
         );
 
         for (const [index, answer] of queuedAnswers.entries()) {
-          const canDeliver =
-            (await prepareActorScopedTurn(answer.userId)) !== false;
+          // Polled answers have no trusted per-message actor write; deliver
+          // under the server actor rather than stalling the queue.
+          const answerPrep = await prepareActorScopedTurn(answer.userId, {
+            onMismatch: 'follow-server',
+          });
 
-          if (!canDeliver) {
+          if (answerPrep === false) {
             logger.warn(
               `[listenForSlackEvents] Delaying request_user_input answer for task ${state.sessionId} until actor-scoped turn preparation succeeds (requestId=${answer.requestId})`,
             );
@@ -130,7 +133,8 @@ export function createSlackMessageInterval({
           const sent = answerUserInputRequest({
             requestId: answer.requestId,
             answers: answer.answers,
-            userId: answer.userId,
+            // Attribute the turn to the identity actor-scoped routes resolve.
+            userId: answerPrep.effectiveUserId ?? undefined,
           });
 
           logger.log(
@@ -199,12 +203,15 @@ export function createSlackMessageInterval({
             !isActiveTaskPhase(state.phase) ||
             state.isConnected === false;
 
-          const canDeliver =
-            (await prepareActorScopedTurn(msg.userId, {
-              allowMcpReconnect,
-            })) !== false;
+          // The API performs a trusted pre-queue actor sync for these
+          // messages; a residual mismatch (e.g. two senders racing the poll)
+          // delivers under the server actor rather than stalling the queue.
+          const msgPrep = await prepareActorScopedTurn(msg.userId, {
+            allowMcpReconnect,
+            onMismatch: 'follow-server',
+          });
 
-          if (!canDeliver) {
+          if (msgPrep === false) {
             logger.warn(
               `[listenForSlackEvents] Delaying Slack follow-up for task ${state.sessionId} until actor-scoped turn preparation succeeds`,
             );
@@ -232,7 +239,8 @@ export function createSlackMessageInterval({
             images: msg.images,
             autoSteerWhenQueued: true,
             source: 'slack',
-            userId: msg.userId,
+            // Attribute the turn to the identity actor-scoped routes resolve.
+            userId: msgPrep.effectiveUserId ?? undefined,
             clientMessageId: getSlackClientMessageId(msg),
           });
 

--- a/apps/worker/src/run-task/polling/slack.ts
+++ b/apps/worker/src/run-task/polling/slack.ts
@@ -102,14 +102,13 @@ export function createSlackMessageInterval({
         );
 
         for (const [index, answer] of queuedAnswers.entries()) {
-          // Polled answers have no trusted per-message actor write; a
-          // mismatched sender's answer is skipped (with a resend notice)
-          // rather than run under the server actor or stalling the queue.
-          const answerPrep = await prepareActorScopedTurn(answer.userId, {
-            onMismatch: 'skip',
-          });
+          // The API atomically couples the winning answer claim to its
+          // trusted actor write. If the worker drains Redis just before that
+          // DB transaction commits, block and requeue instead of dropping an
+          // answer that is already marked submitted and cannot be resent.
+          const answerPrep = await prepareActorScopedTurn(answer.userId);
 
-          if (answerPrep === false) {
+          if (answerPrep === false || answerPrep.skippedMismatch) {
             logger.warn(
               `[listenForSlackEvents] Delaying request_user_input answer for task ${state.sessionId} until actor-scoped turn preparation succeeds (requestId=${answer.requestId})`,
             );
@@ -129,13 +128,6 @@ export function createSlackMessageInterval({
             }
 
             return;
-          }
-
-          if (answerPrep.skippedMismatch) {
-            logger.warn(
-              `[listenForSlackEvents] Skipped request_user_input answer for task ${state.sessionId}: sender is not the server-side acting user (requestId=${answer.requestId})`,
-            );
-            continue;
           }
 
           const sent = answerUserInputRequest({

--- a/apps/worker/src/run-task/polling/slack.ts
+++ b/apps/worker/src/run-task/polling/slack.ts
@@ -102,10 +102,11 @@ export function createSlackMessageInterval({
         );
 
         for (const [index, answer] of queuedAnswers.entries()) {
-          // Polled answers have no trusted per-message actor write; deliver
-          // under the server actor rather than stalling the queue.
+          // Polled answers have no trusted per-message actor write; a
+          // mismatched sender's answer is skipped (with a resend notice)
+          // rather than run under the server actor or stalling the queue.
           const answerPrep = await prepareActorScopedTurn(answer.userId, {
-            onMismatch: 'follow-server',
+            onMismatch: 'skip',
           });
 
           if (answerPrep === false) {
@@ -130,10 +131,17 @@ export function createSlackMessageInterval({
             return;
           }
 
+          if (answerPrep.skippedMismatch) {
+            logger.warn(
+              `[listenForSlackEvents] Skipped request_user_input answer for task ${state.sessionId}: sender is not the server-side acting user (requestId=${answer.requestId})`,
+            );
+            continue;
+          }
+
           const sent = answerUserInputRequest({
             requestId: answer.requestId,
             answers: answer.answers,
-            // Attribute the turn to the identity actor-scoped routes resolve.
+            // The delivered sender always equals the server-side acting user.
             userId: answerPrep.effectiveUserId ?? undefined,
           });
 
@@ -205,10 +213,11 @@ export function createSlackMessageInterval({
 
           // The API performs a trusted pre-queue actor sync for these
           // messages; a residual mismatch (e.g. two senders racing the poll)
-          // delivers under the server actor rather than stalling the queue.
+          // skips that message's content (with a resend notice) rather than
+          // running it under the server actor or stalling the queue.
           const msgPrep = await prepareActorScopedTurn(msg.userId, {
             allowMcpReconnect,
-            onMismatch: 'follow-server',
+            onMismatch: 'skip',
           });
 
           if (msgPrep === false) {
@@ -229,6 +238,14 @@ export function createSlackMessageInterval({
             break;
           }
 
+          if (msgPrep.skippedMismatch) {
+            logger.warn(
+              `[listenForSlackEvents] Skipped Slack follow-up for task ${state.sessionId}: sender is not the server-side acting user (ts=${msg.ts})`,
+            );
+            index += 1;
+            continue;
+          }
+
           const prompt =
             msg.formattedPrompt ??
             wrapSlackMessage(stripLeadingSlackProductMention(msg.text), {
@@ -239,7 +256,7 @@ export function createSlackMessageInterval({
             images: msg.images,
             autoSteerWhenQueued: true,
             source: 'slack',
-            // Attribute the turn to the identity actor-scoped routes resolve.
+            // The delivered sender always equals the server-side acting user.
             userId: msgPrep.effectiveUserId ?? undefined,
             clientMessageId: getSlackClientMessageId(msg),
           });

--- a/apps/worker/src/run-task/prepare-actor-scoped-turn.ts
+++ b/apps/worker/src/run-task/prepare-actor-scoped-turn.ts
@@ -2,34 +2,44 @@ import { sdk } from '@roomote/sdk/client';
 
 import { syncRuntimeGitAuthor } from '../lib/sync-runtime-git-author';
 import type { RefreshActorScopedMcpResult } from './actor-scoped-mcp-refresh';
+import type { ActorMismatchSkipNotifier } from './actor-mismatch-notice';
 
 /**
  * How to treat a turn whose sender does not match the server-authoritative
  * acting user (no trusted server-side writer switched the run to them):
  *
- * - `block`: refuse the turn. Used by sandbox RPC surfaces (sendPrompt,
- *   steerTask, answerUserInputRequest) where the API performs a trusted
- *   pre-delivery actor sync — a mismatch there means that sync did not
- *   happen, and the caller gets a retryable error.
- * - `follow-server`: run the turn as the server actor instead of the
- *   sender. Used for queued/polled deliveries (Slack/Teams/Telegram/Linear
- *   polls, snapshot-resume replays) where requeueing cannot converge — the
- *   server value only moves via trusted writes, so a blocked queue would
- *   stall until the message TTL expires. Credential resolution is always
- *   server-side, so this keeps the turn's attribution aligned with the
- *   credentials that actor-scoped routes will actually resolve.
+ * - `block`: refuse the turn and keep it pending. Used by sandbox RPC
+ *   surfaces (sendPrompt, steerTask, answerUserInputRequest) where the API
+ *   performs a trusted pre-delivery actor sync — a mismatch there means that
+ *   sync did not happen, and the caller gets a retryable error.
+ * - `skip`: drop that message's CONTENT and post a best-effort notice to the
+ *   task's chat thread asking the sender to resend. Used for queued/polled
+ *   deliveries (Slack/Teams/Telegram/Linear polls, snapshot-resume replays,
+ *   harness queued prompts) where blocking cannot converge: the server actor
+ *   only moves via trusted writes, so a blocked queue would stall until the
+ *   message TTL expires. Content is never executed under another identity's
+ *   credential resolution — relabeling the turn's attribution would not
+ *   change who authored the instructions, so a mismatched message must not
+ *   run at all. A resend re-enters the webhook's trusted pre-queue actor
+ *   sync for that sender and then delivers normally.
  */
-export type ActorMismatchPolicy = 'block' | 'follow-server';
+export type ActorMismatchPolicy = 'block' | 'skip';
 
 /**
- * Result of actor-scoped turn preparation. `false` means the turn must not
- * be delivered. Otherwise `effectiveUserId` is the identity the turn runs
- * as — always the server-authoritative acting user (which equals the
- * requested sender except under a `follow-server` mismatch).
+ * Result of actor-scoped turn preparation:
+ *
+ * - `false`: the turn must not be delivered now (kept pending / retried).
+ * - `{ skippedMismatch: true }`: the message's sender is not the server-side
+ *   acting user under the `skip` policy — the caller must DROP this
+ *   message's content (no requeue) and move on to the next one.
+ * - `{ effectiveUserId }`: deliver. The identity the turn runs as; for
+ *   non-empty senders this always equals both the requested sender and the
+ *   server-authoritative acting user (mismatches never deliver).
  */
 export type PrepareActorScopedTurnResult =
   | false
-  | { effectiveUserId: string | null };
+  | { skippedMismatch: true }
+  | { skippedMismatch?: false; effectiveUserId: string | null };
 
 interface PrepareActorScopedTurnOptions {
   cloudJobId?: number;
@@ -41,6 +51,8 @@ interface PrepareActorScopedTurnOptions {
   onMismatch?: ActorMismatchPolicy;
   getLastKnownActorUserId?: () => string | null;
   onActorSynced?: (userId: string | null) => void;
+  /** Best-effort user-facing notice when a mismatched message is skipped. */
+  notifyMismatchSkipped?: ActorMismatchSkipNotifier;
   logger: {
     info?: (...args: unknown[]) => void;
     warn?: (...args: unknown[]) => void;
@@ -62,6 +74,8 @@ interface SyncActorScopedTurnStateOptions {
   onMismatch?: ActorMismatchPolicy;
   getLastKnownActorUserId?: () => string | null;
   onActorSynced?: (userId: string | null) => void;
+  /** Best-effort user-facing notice when a mismatched message is skipped. */
+  notifyMismatchSkipped?: ActorMismatchSkipNotifier;
   logger: {
     warn?: (...args: unknown[]) => void;
     error: (...args: unknown[]) => void;
@@ -70,7 +84,8 @@ interface SyncActorScopedTurnStateOptions {
 
 type SyncActorScopedTurnStateResult =
   | { ok: false }
-  | { ok: true; effectiveUserId: string | null };
+  | { ok: true; skippedMismatch: true }
+  | { ok: true; skippedMismatch?: false; effectiveUserId: string | null };
 
 /**
  * Reconcile the worker's local actor state (git author, tracked actor) with
@@ -81,6 +96,12 @@ type SyncActorScopedTurnStateResult =
  * and follows it: when the server actor changed relative to the worker's
  * last-prepared one, the runtime git author is refreshed FROM the server
  * value, so commits after a trusted actor switch carry the new identity.
+ *
+ * Invariant enforced here: a message's content only ever runs when its
+ * sender IS the server-side acting user. A mismatch either blocks the turn
+ * (`block`) or drops that message's content with a user-facing notice
+ * (`skip`) — it never delivers one user's instructions under another user's
+ * credential resolution, no matter how the turn would be attributed.
  */
 export async function syncActorScopedTurnState({
   cloudJobId,
@@ -90,6 +111,7 @@ export async function syncActorScopedTurnState({
   onMismatch = 'block',
   getLastKnownActorUserId,
   onActorSynced,
+  notifyMismatchSkipped,
   logger,
 }: SyncActorScopedTurnStateOptions): Promise<SyncActorScopedTurnStateResult> {
   if (!cloudJobId || !targetUserId) {
@@ -121,42 +143,54 @@ export async function syncActorScopedTurnState({
     return { ok: false };
   }
 
-  if (outcome.result === 'mismatch' && onMismatch === 'block') {
-    logger.error(
-      `${logPrefix} Blocking turn for cloud job ${cloudJobId}: sender ${targetUserId} is not the server-side acting user (${outcome.actingUserId ?? 'none'}) and no trusted writer switched the run to them`,
+  if (outcome.result === 'mismatch') {
+    const serverActorUserId = outcome.actingUserId ?? null;
+
+    if (onMismatch === 'block') {
+      logger.error(
+        `${logPrefix} Blocking turn for cloud job ${cloudJobId}: sender ${targetUserId} is not the server-side acting user (${serverActorUserId ?? 'none'}) and no trusted writer switched the run to them`,
+      );
+      return { ok: false };
+    }
+
+    // `skip`: the sender's content must not run under the current actor's
+    // credentials, and attributing it to the server actor would not change
+    // who authored the instructions. Drop the content and tell the sender
+    // to resend (a resend re-enters the trusted pre-queue actor sync).
+    (logger.warn ?? logger.error)(
+      `${logPrefix} Skipping message content for cloud job ${cloudJobId}: sender ${targetUserId} is not the server-side acting user (${serverActorUserId ?? 'none'}); asking the sender to resend`,
     );
-    return { ok: false };
+    await notifyMismatchSkipped?.({
+      senderUserId: targetUserId,
+      serverActorUserId,
+    });
+
+    return { ok: true, skippedMismatch: true };
   }
 
-  // Server-authoritative identity the turn will run as. Under a
-  // follow-server mismatch this is the server actor, not the sender.
+  // `updated`/`unchanged` both mean the server actor IS the sender; the
+  // turn runs as that single identity.
   const effectiveUserId = outcome.actingUserId ?? null;
 
-  if (outcome.result === 'mismatch') {
-    (logger.warn ?? logger.error)(
-      `${logPrefix} Delivering turn for cloud job ${cloudJobId} as server actor ${effectiveUserId ?? 'none'} instead of sender ${targetUserId}: no trusted writer switched the run to the sender`,
-    );
-  }
-
-  const actorChanged =
-    outcome.result === 'updated' ||
-    (outcome.result === 'mismatch' && effectiveUserId !== lastKnownUserId);
-
-  if (actorChanged) {
+  if (outcome.result === 'updated') {
     try {
       await syncRuntimeGitAuthor({
         cloudJobId,
         workingDirectory,
       });
+      // Advance the last-prepared marker only once the author sync landed:
+      // on failure the next turn still reports the stale marker, gets
+      // `updated` again, and retries the sync. Until it succeeds, commits
+      // keep the previous actor's git identity and each turn logs one
+      // error — bounded, self-healing noise.
+      onActorSynced?.(effectiveUserId);
     } catch (error) {
       logger.error(
-        `${logPrefix} Failed to update git author for cloud job ${cloudJobId}: ${
+        `${logPrefix} Failed to update git author for cloud job ${cloudJobId} (will retry on the next turn): ${
           error instanceof Error ? error.message : String(error)
         }`,
       );
     }
-
-    onActorSynced?.(effectiveUserId);
   }
 
   return { ok: true, effectiveUserId };
@@ -172,6 +206,7 @@ export async function prepareActorScopedTurn({
   onMismatch = 'block',
   getLastKnownActorUserId,
   onActorSynced,
+  notifyMismatchSkipped,
   logger,
   refreshActorScopedIntegrations,
 }: PrepareActorScopedTurnOptions): Promise<PrepareActorScopedTurnResult> {
@@ -191,6 +226,7 @@ export async function prepareActorScopedTurn({
     onMismatch,
     getLastKnownActorUserId,
     onActorSynced,
+    notifyMismatchSkipped,
     logger,
   });
 
@@ -199,6 +235,12 @@ export async function prepareActorScopedTurn({
       `${logPrefix} Skipping actor-scoped MCP refresh because actor reconciliation blocked the turn for cloud job ${cloudJobId}`,
     );
     return false;
+  }
+
+  if (syncResult.skippedMismatch) {
+    // No turn will run for this message; leave local actor state and MCP
+    // mounts untouched.
+    return { skippedMismatch: true };
   }
 
   const { effectiveUserId } = syncResult;

--- a/apps/worker/src/run-task/prepare-actor-scoped-turn.ts
+++ b/apps/worker/src/run-task/prepare-actor-scoped-turn.ts
@@ -50,7 +50,9 @@ interface PrepareActorScopedTurnOptions {
   deferReconnectUntilTurnBoundary?: boolean;
   onMismatch?: ActorMismatchPolicy;
   getLastKnownActorUserId?: () => string | null;
+  hasPendingGitAuthorSync?: () => boolean;
   onActorSynced?: (userId: string | null) => void;
+  onGitAuthorSyncFailed?: () => void;
   /** Best-effort user-facing notice when a mismatched message is skipped. */
   notifyMismatchSkipped?: ActorMismatchSkipNotifier;
   logger: {
@@ -73,7 +75,9 @@ interface SyncActorScopedTurnStateOptions {
   logPrefix: string;
   onMismatch?: ActorMismatchPolicy;
   getLastKnownActorUserId?: () => string | null;
+  hasPendingGitAuthorSync?: () => boolean;
   onActorSynced?: (userId: string | null) => void;
+  onGitAuthorSyncFailed?: () => void;
   /** Best-effort user-facing notice when a mismatched message is skipped. */
   notifyMismatchSkipped?: ActorMismatchSkipNotifier;
   logger: {
@@ -110,7 +114,9 @@ export async function syncActorScopedTurnState({
   logPrefix,
   onMismatch = 'block',
   getLastKnownActorUserId,
+  hasPendingGitAuthorSync,
   onActorSynced,
+  onGitAuthorSyncFailed,
   notifyMismatchSkipped,
   logger,
 }: SyncActorScopedTurnStateOptions): Promise<SyncActorScopedTurnStateResult> {
@@ -172,19 +178,20 @@ export async function syncActorScopedTurnState({
   // turn runs as that single identity.
   const effectiveUserId = outcome.actingUserId ?? null;
 
-  if (outcome.result === 'updated') {
+  if (outcome.result === 'updated' || hasPendingGitAuthorSync?.()) {
     try {
       await syncRuntimeGitAuthor({
         cloudJobId,
         workingDirectory,
       });
-      // Advance the last-prepared marker only once the author sync landed:
-      // on failure the next turn still reports the stale marker, gets
-      // `updated` again, and retries the sync. Until it succeeds, commits
-      // keep the previous actor's git identity and each turn logs one
-      // error — bounded, self-healing noise.
+      // Advance the last-prepared marker and clear any independent retry
+      // state only after both git config writes land. The independent dirty
+      // bit matters when a partial write fails during A -> B and the server
+      // switches back to A before retry: actor equality alone would otherwise
+      // suppress the repair and leave a mixed name/email configuration.
       onActorSynced?.(effectiveUserId);
     } catch (error) {
+      onGitAuthorSyncFailed?.();
       logger.error(
         `${logPrefix} Failed to update git author for cloud job ${cloudJobId} (will retry on the next turn): ${
           error instanceof Error ? error.message : String(error)
@@ -205,7 +212,9 @@ export async function prepareActorScopedTurn({
   deferReconnectUntilTurnBoundary = false,
   onMismatch = 'block',
   getLastKnownActorUserId,
+  hasPendingGitAuthorSync,
   onActorSynced,
+  onGitAuthorSyncFailed,
   notifyMismatchSkipped,
   logger,
   refreshActorScopedIntegrations,
@@ -225,7 +234,9 @@ export async function prepareActorScopedTurn({
     logPrefix,
     onMismatch,
     getLastKnownActorUserId,
+    hasPendingGitAuthorSync,
     onActorSynced,
+    onGitAuthorSyncFailed,
     notifyMismatchSkipped,
     logger,
   });

--- a/apps/worker/src/run-task/prepare-actor-scoped-turn.ts
+++ b/apps/worker/src/run-task/prepare-actor-scoped-turn.ts
@@ -3,6 +3,34 @@ import { sdk } from '@roomote/sdk/client';
 import { syncRuntimeGitAuthor } from '../lib/sync-runtime-git-author';
 import type { RefreshActorScopedMcpResult } from './actor-scoped-mcp-refresh';
 
+/**
+ * How to treat a turn whose sender does not match the server-authoritative
+ * acting user (no trusted server-side writer switched the run to them):
+ *
+ * - `block`: refuse the turn. Used by sandbox RPC surfaces (sendPrompt,
+ *   steerTask, answerUserInputRequest) where the API performs a trusted
+ *   pre-delivery actor sync — a mismatch there means that sync did not
+ *   happen, and the caller gets a retryable error.
+ * - `follow-server`: run the turn as the server actor instead of the
+ *   sender. Used for queued/polled deliveries (Slack/Teams/Telegram/Linear
+ *   polls, snapshot-resume replays) where requeueing cannot converge — the
+ *   server value only moves via trusted writes, so a blocked queue would
+ *   stall until the message TTL expires. Credential resolution is always
+ *   server-side, so this keeps the turn's attribution aligned with the
+ *   credentials that actor-scoped routes will actually resolve.
+ */
+export type ActorMismatchPolicy = 'block' | 'follow-server';
+
+/**
+ * Result of actor-scoped turn preparation. `false` means the turn must not
+ * be delivered. Otherwise `effectiveUserId` is the identity the turn runs
+ * as — always the server-authoritative acting user (which equals the
+ * requested sender except under a `follow-server` mismatch).
+ */
+export type PrepareActorScopedTurnResult =
+  | false
+  | { effectiveUserId: string | null };
+
 interface PrepareActorScopedTurnOptions {
   cloudJobId?: number;
   targetUserId?: string;
@@ -10,8 +38,12 @@ interface PrepareActorScopedTurnOptions {
   logPrefix: string;
   allowMcpReconnect?: boolean;
   deferReconnectUntilTurnBoundary?: boolean;
+  onMismatch?: ActorMismatchPolicy;
+  getLastKnownActorUserId?: () => string | null;
+  onActorSynced?: (userId: string | null) => void;
   logger: {
     info?: (...args: unknown[]) => void;
+    warn?: (...args: unknown[]) => void;
     error: (...args: unknown[]) => void;
   };
   refreshActorScopedIntegrations?: (
@@ -27,46 +59,90 @@ interface SyncActorScopedTurnStateOptions {
   targetUserId?: string;
   workingDirectory: string;
   logPrefix: string;
+  onMismatch?: ActorMismatchPolicy;
+  getLastKnownActorUserId?: () => string | null;
+  onActorSynced?: (userId: string | null) => void;
   logger: {
+    warn?: (...args: unknown[]) => void;
     error: (...args: unknown[]) => void;
   };
 }
 
+type SyncActorScopedTurnStateResult =
+  | { ok: false }
+  | { ok: true; effectiveUserId: string | null };
+
+/**
+ * Reconcile the worker's local actor state (git author, tracked actor) with
+ * the server-authoritative `task_runs.actingUserId` ahead of a turn.
+ *
+ * The worker never writes the acting user — job tokens cannot reassign it
+ * (see `syncActingUserId` in @roomote/sdk). This observes the server value
+ * and follows it: when the server actor changed relative to the worker's
+ * last-prepared one, the runtime git author is refreshed FROM the server
+ * value, so commits after a trusted actor switch carry the new identity.
+ */
 export async function syncActorScopedTurnState({
   cloudJobId,
   targetUserId,
   workingDirectory,
   logPrefix,
+  onMismatch = 'block',
+  getLastKnownActorUserId,
+  onActorSynced,
   logger,
-}: SyncActorScopedTurnStateOptions): Promise<boolean> {
+}: SyncActorScopedTurnStateOptions): Promise<SyncActorScopedTurnStateResult> {
   if (!cloudJobId || !targetUserId) {
-    return false;
+    return { ok: false };
   }
 
-  let syncResult: 'updated' | 'unchanged' | 'not-found';
+  const lastKnownUserId = getLastKnownActorUserId?.();
+  let outcome: Awaited<ReturnType<typeof sdk.cloudJobs.syncActingUserId>>;
 
   try {
-    syncResult = await sdk.cloudJobs.syncActingUserId({
+    outcome = await sdk.cloudJobs.syncActingUserId({
       cloudJobId,
       newUserId: targetUserId,
+      lastKnownUserId,
     });
   } catch (error) {
     logger.error(
-      `${logPrefix} Failed to update actingUserId for cloud job ${cloudJobId}: ${
+      `${logPrefix} Failed to reconcile actingUserId for cloud job ${cloudJobId}: ${
         error instanceof Error ? error.message : String(error)
       }`,
     );
-    return false;
+    return { ok: false };
   }
 
-  if (syncResult === 'not-found') {
+  if (outcome.result === 'not-found') {
     logger.error(
-      `${logPrefix} Cloud job ${cloudJobId} was not found while updating actingUserId; skipping actor-scoped MCP refresh`,
+      `${logPrefix} Cloud job ${cloudJobId} was not found while reconciling actingUserId; skipping actor-scoped MCP refresh`,
     );
-    return false;
+    return { ok: false };
   }
 
-  if (syncResult === 'updated') {
+  if (outcome.result === 'mismatch' && onMismatch === 'block') {
+    logger.error(
+      `${logPrefix} Blocking turn for cloud job ${cloudJobId}: sender ${targetUserId} is not the server-side acting user (${outcome.actingUserId ?? 'none'}) and no trusted writer switched the run to them`,
+    );
+    return { ok: false };
+  }
+
+  // Server-authoritative identity the turn will run as. Under a
+  // follow-server mismatch this is the server actor, not the sender.
+  const effectiveUserId = outcome.actingUserId ?? null;
+
+  if (outcome.result === 'mismatch') {
+    (logger.warn ?? logger.error)(
+      `${logPrefix} Delivering turn for cloud job ${cloudJobId} as server actor ${effectiveUserId ?? 'none'} instead of sender ${targetUserId}: no trusted writer switched the run to the sender`,
+    );
+  }
+
+  const actorChanged =
+    outcome.result === 'updated' ||
+    (outcome.result === 'mismatch' && effectiveUserId !== lastKnownUserId);
+
+  if (actorChanged) {
     try {
       await syncRuntimeGitAuthor({
         cloudJobId,
@@ -79,9 +155,11 @@ export async function syncActorScopedTurnState({
         }`,
       );
     }
+
+    onActorSynced?.(effectiveUserId);
   }
 
-  return true;
+  return { ok: true, effectiveUserId };
 }
 
 export async function prepareActorScopedTurn({
@@ -91,50 +169,61 @@ export async function prepareActorScopedTurn({
   logPrefix,
   allowMcpReconnect = true,
   deferReconnectUntilTurnBoundary = false,
+  onMismatch = 'block',
+  getLastKnownActorUserId,
+  onActorSynced,
   logger,
   refreshActorScopedIntegrations,
-}: PrepareActorScopedTurnOptions): Promise<boolean> {
+}: PrepareActorScopedTurnOptions): Promise<PrepareActorScopedTurnResult> {
   if (!cloudJobId || !targetUserId) {
-    return true;
+    return { effectiveUserId: targetUserId ?? null };
   }
 
   logger.info?.(
     `${logPrefix} Preparing actor-scoped turn for cloud job ${cloudJobId}: targetUserId=${targetUserId} allowMcpReconnect=${allowMcpReconnect}`,
   );
 
-  const didSyncActor = await syncActorScopedTurnState({
+  const syncResult = await syncActorScopedTurnState({
     cloudJobId,
     targetUserId,
     workingDirectory,
     logPrefix,
+    onMismatch,
+    getLastKnownActorUserId,
+    onActorSynced,
     logger,
   });
 
-  if (!didSyncActor) {
+  if (!syncResult.ok) {
     logger.info?.(
-      `${logPrefix} Skipping actor-scoped MCP refresh because actingUserId was not updated for cloud job ${cloudJobId}`,
+      `${logPrefix} Skipping actor-scoped MCP refresh because actor reconciliation blocked the turn for cloud job ${cloudJobId}`,
     );
     return false;
   }
+
+  const { effectiveUserId } = syncResult;
 
   if (!allowMcpReconnect) {
     logger.info?.(
       `${logPrefix} Deferring actor-scoped MCP refresh until the queued turn boundary for cloud job ${cloudJobId}`,
     );
-    return true;
+    return { effectiveUserId };
   }
 
   try {
-    const refreshResult = await refreshActorScopedIntegrations?.(targetUserId, {
-      deferReconnectUntilTurnBoundary,
-    });
+    const refreshResult = await refreshActorScopedIntegrations?.(
+      effectiveUserId ?? undefined,
+      {
+        deferReconnectUntilTurnBoundary,
+      },
+    );
 
     if (refreshResult?.didFail) {
       if (!refreshResult.actorChanged) {
         logger.info?.(
           `${logPrefix} Actor-scoped MCP refresh failed for cloud job ${cloudJobId}, but the mounted actor is unchanged; continuing with existing MCP state`,
         );
-        return true;
+        return { effectiveUserId };
       }
 
       logger.info?.(
@@ -151,5 +240,5 @@ export async function prepareActorScopedTurn({
     return false;
   }
 
-  return true;
+  return { effectiveUserId };
 }

--- a/apps/worker/src/run-task/run-task.ts
+++ b/apps/worker/src/run-task/run-task.ts
@@ -69,6 +69,7 @@ import {
   getSlackReplyContext,
 } from './mcp-task-env';
 import {
+  type ActorMismatchPolicy,
   prepareActorScopedTurn as prepareActorScopedTurnHelper,
   syncActorScopedTurnState,
 } from './prepare-actor-scoped-turn';
@@ -806,11 +807,22 @@ export const runTask = async ({
       logger,
     });
 
+    // The actor most recently prepared locally (git author synced, MCP
+    // mounts refreshed). Server-authoritative `task_runs.actingUserId` is
+    // the source of truth; this only tracks what this worker last applied so
+    // reconciliation knows when to refresh.
+    let lastPreparedActorUserId: string | null = cloudJob.actingUserId ?? null;
+    const getLastKnownActorUserId = () => lastPreparedActorUserId;
+    const onActorSynced = (userId: string | null) => {
+      lastPreparedActorUserId = userId;
+    };
+
     const prepareActorScopedTurn = async (
       targetUserId?: string,
       options?: {
         allowMcpReconnect?: boolean;
         deferReconnectUntilTurnBoundary?: boolean;
+        onMismatch?: ActorMismatchPolicy;
       },
     ) =>
       await prepareActorScopedTurnHelper({
@@ -821,6 +833,9 @@ export const runTask = async ({
         allowMcpReconnect: options?.allowMcpReconnect,
         deferReconnectUntilTurnBoundary:
           options?.deferReconnectUntilTurnBoundary,
+        onMismatch: options?.onMismatch,
+        getLastKnownActorUserId,
+        onActorSynced,
         logger,
         refreshActorScopedIntegrations,
       });
@@ -832,15 +847,21 @@ export const runTask = async ({
         };
       }
 
-      const didSyncActor = await syncActorScopedTurnState({
+      const syncResult = await syncActorScopedTurnState({
         cloudJobId: cloudJob.id,
         targetUserId,
         workingDirectory: workspacePath,
         logPrefix: '[runTask]',
+        // Queued prompts were accepted through a trusted surface earlier;
+        // if another sender has since taken over the run, deliver under the
+        // server actor rather than stalling the queue forever.
+        onMismatch: 'follow-server',
+        getLastKnownActorUserId,
+        onActorSynced,
         logger,
       });
 
-      if (!didSyncActor) {
+      if (!syncResult.ok) {
         return {
           shouldReconnect: false,
           shouldBlockPrompt: true,
@@ -849,9 +870,12 @@ export const runTask = async ({
         };
       }
 
-      const refreshResult = await refreshActorScopedIntegrations(targetUserId, {
-        skipReconnect: true,
-      });
+      const refreshResult = await refreshActorScopedIntegrations(
+        syncResult.effectiveUserId ?? undefined,
+        {
+          skipReconnect: true,
+        },
+      );
 
       if (refreshResult.didFail) {
         if (!refreshResult.actorChanged) {
@@ -1131,11 +1155,11 @@ export const runTask = async ({
       clientMessageId?: string;
       userId?: string;
     }) => {
-      const canDeliverDeferredResumePrompt = await prepareActorScopedTurn(
-        options.userId,
-      );
+      const deferredPromptPrep = await prepareActorScopedTurn(options.userId, {
+        onMismatch: 'follow-server',
+      });
 
-      if (!canDeliverDeferredResumePrompt) {
+      if (deferredPromptPrep === false) {
         logger.info(
           `[runTask] Deferred resume prompt blocked for cloud job ${cloudJob.id}; keeping it queued for retry`,
         );
@@ -1154,7 +1178,8 @@ export const runTask = async ({
         autoSteerWhenQueued: true,
         source: options.source,
         clientMessageId: options.clientMessageId,
-        userId: options.userId,
+        // Attribute the turn to the identity actor-scoped routes resolve.
+        userId: deferredPromptPrep.effectiveUserId ?? undefined,
       });
 
       if (queued) {
@@ -1211,15 +1236,17 @@ export const runTask = async ({
 
       while (index < deliveryOrder.length) {
         const message = deliveryOrder[index]!;
-        const canDeliver =
-          (await prepareActorScopedTurn(message.userId, {
-            allowMcpReconnect:
-              !pollingState.phase ||
-              pollingState.isConnected === false ||
-              pollingState.phase === 'waiting_for_prompt',
-          })) !== false;
+        const turnPrep = await prepareActorScopedTurn(message.userId, {
+          allowMcpReconnect:
+            !pollingState.phase ||
+            pollingState.isConnected === false ||
+            pollingState.phase === 'waiting_for_prompt',
+          // Replayed queue entries have no trusted per-message actor write;
+          // deliver under the server actor rather than stalling the replay.
+          onMismatch: 'follow-server',
+        });
 
-        if (!canDeliver) {
+        if (turnPrep === false) {
           const remainingQueueOrder = [...deliveryOrder.slice(index)].reverse();
           await prependSlackMessages(cloudJob.id, remainingQueueOrder);
           logger.warn(
@@ -1238,7 +1265,8 @@ export const runTask = async ({
           images: message.images,
           autoSteerWhenQueued: true,
           source: 'slack',
-          userId: message.userId,
+          // Attribute the turn to the identity actor-scoped routes resolve.
+          userId: turnPrep.effectiveUserId ?? undefined,
         });
 
         if (!sent) {
@@ -1298,15 +1326,17 @@ export const runTask = async ({
 
       while (index < deliveryOrder.length) {
         const message = deliveryOrder[index]!;
-        const canDeliver =
-          (await prepareActorScopedTurn(message.userId, {
-            allowMcpReconnect:
-              !pollingState.phase ||
-              pollingState.isConnected === false ||
-              pollingState.phase === 'waiting_for_prompt',
-          })) !== false;
+        const turnPrep = await prepareActorScopedTurn(message.userId, {
+          allowMcpReconnect:
+            !pollingState.phase ||
+            pollingState.isConnected === false ||
+            pollingState.phase === 'waiting_for_prompt',
+          // Replayed queue entries have no trusted per-message actor write;
+          // deliver under the server actor rather than stalling the replay.
+          onMismatch: 'follow-server',
+        });
 
-        if (!canDeliver) {
+        if (turnPrep === false) {
           const remainingQueueOrder = [...deliveryOrder.slice(index)].reverse();
           await requeueQueuedSnapshotResumeCommunicationMessages(
             remainingQueueOrder,
@@ -1329,7 +1359,8 @@ export const runTask = async ({
           images: message.images,
           autoSteerWhenQueued: true,
           source: message.provider,
-          userId: message.userId,
+          // Attribute the turn to the identity actor-scoped routes resolve.
+          userId: turnPrep.effectiveUserId ?? undefined,
           clientMessageId: `${message.provider}:${message.ts}`,
         });
 
@@ -1380,15 +1411,17 @@ export const runTask = async ({
             ? message.payload.agentActivity.content.body
             : message.payload.agentSession.issue.description || '';
 
-        const canDeliver =
-          (await prepareActorScopedTurn(message.userId, {
-            allowMcpReconnect:
-              !pollingState.phase ||
-              pollingState.isConnected === false ||
-              pollingState.phase === 'waiting_for_prompt',
-          })) !== false;
+        const turnPrep = await prepareActorScopedTurn(message.userId, {
+          allowMcpReconnect:
+            !pollingState.phase ||
+            pollingState.isConnected === false ||
+            pollingState.phase === 'waiting_for_prompt',
+          // Replayed queue entries have no trusted per-message actor write;
+          // deliver under the server actor rather than stalling the replay.
+          onMismatch: 'follow-server',
+        });
 
-        if (!canDeliver) {
+        if (turnPrep === false) {
           const remainingMessages = messages.slice(index);
           await prependLinearMessages(cloudJob.id, remainingMessages);
           logger.warn(
@@ -1400,7 +1433,8 @@ export const runTask = async ({
         const sent = sendPrompt({
           prompt: text,
           source: 'linear',
-          userId: message.userId,
+          // Attribute the turn to the identity actor-scoped routes resolve.
+          userId: turnPrep.effectiveUserId ?? undefined,
         });
 
         if (!sent) {

--- a/apps/worker/src/run-task/run-task.ts
+++ b/apps/worker/src/run-task/run-task.ts
@@ -813,9 +813,15 @@ export const runTask = async ({
     // the source of truth; this only tracks what this worker last applied so
     // reconciliation knows when to refresh.
     let lastPreparedActorUserId: string | null = cloudJob.actingUserId ?? null;
+    let gitAuthorSyncPending = false;
     const getLastKnownActorUserId = () => lastPreparedActorUserId;
+    const hasPendingGitAuthorSync = () => gitAuthorSyncPending;
     const onActorSynced = (userId: string | null) => {
       lastPreparedActorUserId = userId;
+      gitAuthorSyncPending = false;
+    };
+    const onGitAuthorSyncFailed = () => {
+      gitAuthorSyncPending = true;
     };
     const notifyMismatchSkipped = createActorMismatchSkipNotifier({
       cloudJobId: cloudJob.id,
@@ -840,7 +846,9 @@ export const runTask = async ({
           options?.deferReconnectUntilTurnBoundary,
         onMismatch: options?.onMismatch,
         getLastKnownActorUserId,
+        hasPendingGitAuthorSync,
         onActorSynced,
+        onGitAuthorSyncFailed,
         notifyMismatchSkipped,
         logger,
         refreshActorScopedIntegrations,
@@ -864,7 +872,9 @@ export const runTask = async ({
         // (with a resend notice) rather than stalling the queue forever.
         onMismatch: 'skip',
         getLastKnownActorUserId,
+        hasPendingGitAuthorSync,
         onActorSynced,
+        onGitAuthorSyncFailed,
         notifyMismatchSkipped,
         logger,
       });

--- a/apps/worker/src/run-task/run-task.ts
+++ b/apps/worker/src/run-task/run-task.ts
@@ -62,6 +62,7 @@ import {
 
 import { createHarness } from './create-harness';
 import { createActorScopedMcpRefresher } from './actor-scoped-mcp-refresh';
+import { createActorMismatchSkipNotifier } from './actor-mismatch-notice';
 import { buildSandboxInstruction } from './sandbox-instruction';
 import {
   buildMcpTaskEnv,
@@ -816,6 +817,10 @@ export const runTask = async ({
     const onActorSynced = (userId: string | null) => {
       lastPreparedActorUserId = userId;
     };
+    const notifyMismatchSkipped = createActorMismatchSkipNotifier({
+      cloudJobId: cloudJob.id,
+      logger,
+    });
 
     const prepareActorScopedTurn = async (
       targetUserId?: string,
@@ -836,6 +841,7 @@ export const runTask = async ({
         onMismatch: options?.onMismatch,
         getLastKnownActorUserId,
         onActorSynced,
+        notifyMismatchSkipped,
         logger,
         refreshActorScopedIntegrations,
       });
@@ -853,11 +859,13 @@ export const runTask = async ({
         workingDirectory: workspacePath,
         logPrefix: '[runTask]',
         // Queued prompts were accepted through a trusted surface earlier;
-        // if another sender has since taken over the run, deliver under the
-        // server actor rather than stalling the queue forever.
-        onMismatch: 'follow-server',
+        // if another sender has since taken over the run, this prompt's
+        // content must not run under the new actor's credentials. Skip it
+        // (with a resend notice) rather than stalling the queue forever.
+        onMismatch: 'skip',
         getLastKnownActorUserId,
         onActorSynced,
+        notifyMismatchSkipped,
         logger,
       });
 
@@ -867,6 +875,15 @@ export const runTask = async ({
           shouldBlockPrompt: true,
           reason:
             'actor-scoped turn delivery is blocked until actingUserId can be synchronized',
+        };
+      }
+
+      if (syncResult.skippedMismatch) {
+        return {
+          shouldReconnect: false,
+          shouldSkipPrompt: true,
+          reason:
+            'queued prompt sender is not the server-side acting user; the prompt was skipped',
         };
       }
 
@@ -1156,7 +1173,7 @@ export const runTask = async ({
       userId?: string;
     }) => {
       const deferredPromptPrep = await prepareActorScopedTurn(options.userId, {
-        onMismatch: 'follow-server',
+        onMismatch: 'skip',
       });
 
       if (deferredPromptPrep === false) {
@@ -1164,6 +1181,19 @@ export const runTask = async ({
           `[runTask] Deferred resume prompt blocked for cloud job ${cloudJob.id}; keeping it queued for retry`,
         );
         scheduleDeferredResumePromptRetry(options);
+        return false;
+      }
+
+      if (deferredPromptPrep.skippedMismatch) {
+        // The resume prompt's sender is no longer the run's acting user (a
+        // trusted write switched the actor after the resume was enqueued).
+        // Retrying cannot converge, so drop the prompt; the sender was asked
+        // to resend via the mismatch notice.
+        clearDeferredResumePromptRetryTimer();
+        await updateDeferredResumePromptResult({ accepted: false });
+        logger.warn(
+          `[runTask] Deferred resume prompt skipped for cloud job ${cloudJob.id}: sender is not the server-side acting user`,
+        );
         return false;
       }
 
@@ -1242,8 +1272,9 @@ export const runTask = async ({
             pollingState.isConnected === false ||
             pollingState.phase === 'waiting_for_prompt',
           // Replayed queue entries have no trusted per-message actor write;
-          // deliver under the server actor rather than stalling the replay.
-          onMismatch: 'follow-server',
+          // a mismatched sender's content is skipped (with a resend notice)
+          // rather than run under the server actor or stalling the replay.
+          onMismatch: 'skip',
         });
 
         if (turnPrep === false) {
@@ -1253,6 +1284,11 @@ export const runTask = async ({
             `[runTask] Requeued ${remainingQueueOrder.length} embedded Slack resume message(s) for cloud job ${cloudJob.id} because actor-scoped turn preparation is blocked`,
           );
           return;
+        }
+
+        if (turnPrep.skippedMismatch) {
+          index += 1;
+          continue;
         }
 
         const prompt =
@@ -1332,8 +1368,9 @@ export const runTask = async ({
             pollingState.isConnected === false ||
             pollingState.phase === 'waiting_for_prompt',
           // Replayed queue entries have no trusted per-message actor write;
-          // deliver under the server actor rather than stalling the replay.
-          onMismatch: 'follow-server',
+          // a mismatched sender's content is skipped (with a resend notice)
+          // rather than run under the server actor or stalling the replay.
+          onMismatch: 'skip',
         });
 
         if (turnPrep === false) {
@@ -1345,6 +1382,11 @@ export const runTask = async ({
             `[runTask] Requeued ${remainingQueueOrder.length} embedded communication resume message(s) for cloud job ${cloudJob.id} because actor-scoped turn preparation is blocked`,
           );
           return;
+        }
+
+        if (turnPrep.skippedMismatch) {
+          index += 1;
+          continue;
         }
 
         const prompt =
@@ -1417,8 +1459,9 @@ export const runTask = async ({
             pollingState.isConnected === false ||
             pollingState.phase === 'waiting_for_prompt',
           // Replayed queue entries have no trusted per-message actor write;
-          // deliver under the server actor rather than stalling the replay.
-          onMismatch: 'follow-server',
+          // a mismatched sender's content is skipped (with a resend notice)
+          // rather than run under the server actor or stalling the replay.
+          onMismatch: 'skip',
         });
 
         if (turnPrep === false) {
@@ -1428,6 +1471,10 @@ export const runTask = async ({
             `[runTask] Requeued ${remainingMessages.length} embedded Linear resume message(s) for cloud job ${cloudJob.id} because actor-scoped turn preparation is blocked`,
           );
           return;
+        }
+
+        if (turnPrep.skippedMismatch) {
+          continue;
         }
 
         const sent = sendPrompt({

--- a/apps/worker/src/run-task/types.ts
+++ b/apps/worker/src/run-task/types.ts
@@ -17,6 +17,10 @@ import type {
 import type { WorkerEnv } from '../env';
 import type { HarnessLogger } from '../logging';
 import type { RepoLocalSkill } from '../workspace/repo-local-skills';
+import type {
+  ActorMismatchPolicy,
+  PrepareActorScopedTurnResult,
+} from './prepare-actor-scoped-turn';
 
 export type RunTaskContext = Record<string, unknown>;
 
@@ -257,7 +261,8 @@ export interface ListenerOptions {
     options?: {
       allowMcpReconnect?: boolean;
       deferReconnectUntilTurnBoundary?: boolean;
+      onMismatch?: ActorMismatchPolicy;
     },
-  ) => Promise<boolean>;
+  ) => Promise<PrepareActorScopedTurnResult>;
   getVisibleQueuedPromptCount?: () => number;
 }

--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
@@ -3423,6 +3423,102 @@ describe('OpenCodeServerHarness', () => {
     }
   });
 
+  it('drops a skipped queued prompt and keeps draining the rest of the queue', async () => {
+    // Actor-mismatch skip: the prompt's sender is not the run's acting user,
+    // so its content must never be delivered — not retried (that would stall
+    // the queue) and not restored. Later queued prompts still drain.
+    const beforeQueuedPrompt = vi.fn<
+      () => Promise<void | {
+        shouldReconnect: boolean;
+        shouldBlockPrompt?: boolean;
+        shouldSkipPrompt?: boolean;
+        reason?: string;
+      }>
+    >();
+    beforeQueuedPrompt
+      .mockResolvedValueOnce({
+        shouldReconnect: false,
+        shouldSkipPrompt: true,
+        reason: 'sender is not the server-side acting user',
+      })
+      .mockResolvedValue(undefined);
+    const { client, harness } = createHarness(undefined, {
+      beforeQueuedPrompt,
+      queuedPromptRetryDelayMs: 20,
+    });
+
+    try {
+      await connectHarness(harness, client);
+
+      harness.sendCommand({
+        commandName: TaskCommandName.StartNewTask,
+        data: { text: 'First.', visibleInTranscript: true },
+      });
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(1);
+      });
+
+      // Queue two follow-ups while the first turn is in flight: the first
+      // will be skipped (mismatched sender), the second must still deliver.
+      harness.sendCommand({
+        commandName: TaskCommandName.SendMessage,
+        data: { text: 'Mismatched second.', visibleInTranscript: true },
+      });
+      harness.sendCommand({
+        commandName: TaskCommandName.SendMessage,
+        data: { text: 'Matching third.', visibleInTranscript: true },
+      });
+
+      // Complete the first turn so the queue drains.
+      client.message.mockResolvedValueOnce(createFinalAssistantMessage());
+      await client.emit({
+        type: 'message.updated',
+        properties: {
+          info: {
+            id: 'msg_1',
+            sessionID: 'ses_1',
+            role: 'assistant',
+            time: { completed: 1 },
+          },
+        },
+      });
+      await client.emit({
+        type: 'session.idle',
+        properties: { sessionID: 'ses_1' },
+      });
+
+      // The skipped prompt is dropped; the scheduled retry drains the next
+      // queued prompt without a new user message.
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(2);
+      });
+      expect(beforeQueuedPrompt).toHaveBeenCalledTimes(2);
+      expect(client.promptAsync.mock.calls[1]?.[0]).toMatchObject({
+        sessionId: 'ses_1',
+        request: {
+          parts: [
+            { type: 'text', text: expect.stringContaining('Matching third.') },
+          ],
+        },
+      });
+
+      // The mismatched content never reached the model under any identity.
+      for (const call of client.promptAsync.mock.calls) {
+        const parts = (
+          call[0] as {
+            request: { parts: Array<{ type: string; text?: string }> };
+          }
+        ).request.parts;
+
+        for (const part of parts) {
+          expect(part.text ?? '').not.toContain('Mismatched second.');
+        }
+      }
+    } finally {
+      harness.dispose();
+    }
+  });
+
   it('validates and reuses a prior session on resume before its first prompt', async () => {
     const { client, harness } = createHarness();
 

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
@@ -89,6 +89,7 @@ interface OpenCodeServerHarnessOptions {
   beforeQueuedPrompt?: (input: { userId?: string }) => Promise<void | {
     shouldReconnect: boolean;
     shouldBlockPrompt?: boolean;
+    shouldSkipPrompt?: boolean;
     reason?: string;
   }>;
 }
@@ -3897,6 +3898,19 @@ export class OpenCodeServerHarness
 
     if (!result) {
       return true;
+    }
+
+    if (result.shouldSkipPrompt) {
+      // The prompt's sender is not the run's server-side acting user, so its
+      // content must not run. Drop it (no restore) and keep draining the
+      // rest of the queue; the sender was asked to resend.
+      this.logger.warn(
+        `OpenCode queued prompt skipped before delivery reason=${
+          result.reason ?? 'unknown'
+        }`,
+      );
+      this.scheduleQueuedPromptRetry();
+      return false;
     }
 
     if (result.shouldBlockPrompt) {

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/start.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/start.ts
@@ -23,6 +23,7 @@ interface StartOpenCodeServerHarnessOptions {
   beforeQueuedPrompt?: (input: { userId?: string }) => Promise<void | {
     shouldReconnect: boolean;
     shouldBlockPrompt?: boolean;
+    shouldSkipPrompt?: boolean;
     reason?: string;
   }>;
 }

--- a/apps/worker/src/sandbox-server/server.ts
+++ b/apps/worker/src/sandbox-server/server.ts
@@ -13,6 +13,10 @@ import type {
 
 import type { HarnessLogger } from '../logging';
 import type { WorkerEnv } from '../env';
+import type {
+  ActorMismatchPolicy,
+  PrepareActorScopedTurnResult,
+} from '../run-task/prepare-actor-scoped-turn';
 import type { Harness } from './lib/harness';
 import type { HarnessManager } from './lib/harness-manager';
 import { TerminalManager } from './lib/terminal-manager';
@@ -132,8 +136,9 @@ export function createServer({
     options?: {
       allowMcpReconnect?: boolean;
       deferReconnectUntilTurnBoundary?: boolean;
+      onMismatch?: ActorMismatchPolicy;
     },
-  ) => Promise<boolean>;
+  ) => Promise<PrepareActorScopedTurnResult>;
   /**
    * Token validator.
    * For tRPC: reads `Authorization: Bearer <token>` header.

--- a/apps/worker/src/sandbox-server/trpc.ts
+++ b/apps/worker/src/sandbox-server/trpc.ts
@@ -12,6 +12,10 @@ import '@trpc/client';
 
 import type { HarnessLogger } from '../logging';
 import type { WorkerEnv } from '../env';
+import type {
+  ActorMismatchPolicy,
+  PrepareActorScopedTurnResult,
+} from '../run-task/prepare-actor-scoped-turn';
 import type { Harness } from './lib/harness';
 import type { HarnessManager } from './lib/harness-manager';
 
@@ -39,14 +43,20 @@ export interface Context {
   /** Mutable worker environment state for live reloads. */
   workerEnv?: WorkerEnv;
 
-  /** Refresh actor-scoped integrations before delivering the next turn. */
+  /**
+   * Refresh actor-scoped integrations before delivering the next turn.
+   * Returns `false` when the turn must not be delivered (default `block`
+   * mismatch policy: the API's trusted pre-delivery actor sync did not put
+   * the server actor on this sender).
+   */
   prepareActorScopedTurn?: (
     targetUserId?: string,
     options?: {
       allowMcpReconnect?: boolean;
       deferReconnectUntilTurnBoundary?: boolean;
+      onMismatch?: ActorMismatchPolicy;
     },
-  ) => Promise<boolean>;
+  ) => Promise<PrepareActorScopedTurnResult>;
 }
 
 const t = initTRPC.context<Context>().create({ transformer: superjson });

--- a/packages/db/src/lib/__tests__/acting-user.test.ts
+++ b/packages/db/src/lib/__tests__/acting-user.test.ts
@@ -1,0 +1,100 @@
+import {
+  compareAndSetTrustedRunActingUser,
+  db,
+  eq,
+  runFactory,
+  setTrustedRunActingUser,
+  setTrustedRunActingUserOnSuccess,
+  taskRuns,
+  tasks,
+  userFactory,
+} from '../../server';
+
+const createdTaskIds: string[] = [];
+
+async function createRunWithActors() {
+  const [firstUser, secondUser, thirdUser] = await Promise.all([
+    userFactory.create(),
+    userFactory.create(),
+    userFactory.create(),
+  ]);
+  const run = await runFactory.create({ actingUserId: firstUser.id });
+  createdTaskIds.push(run.taskId);
+
+  return { run, firstUser, secondUser, thirdUser };
+}
+
+async function readActingUserId(runId: number) {
+  const [row] = await db
+    .select({ actingUserId: taskRuns.actingUserId })
+    .from(taskRuns)
+    .where(eq(taskRuns.id, runId));
+
+  return row?.actingUserId;
+}
+
+afterEach(async () => {
+  while (createdTaskIds.length > 0) {
+    await db
+      .delete(tasks)
+      .where(eq(tasks.id, createdTaskIds.pop()!))
+      .catch(() => {});
+  }
+});
+
+describe('trusted run acting-user writes', () => {
+  it('sets a webhook-resolved sender as the live actor', async () => {
+    const { run, secondUser } = await createRunWithActors();
+
+    await setTrustedRunActingUser({
+      runId: run.id,
+      userId: secondUser.id,
+    });
+
+    expect(await readActingUserId(run.id)).toBe(secondUser.id);
+  });
+
+  it('compare-and-set refuses to overwrite a newer actor', async () => {
+    const { run, firstUser, secondUser, thirdUser } =
+      await createRunWithActors();
+
+    expect(
+      await compareAndSetTrustedRunActingUser({
+        runId: run.id,
+        expectedUserId: firstUser.id,
+        nextUserId: secondUser.id,
+      }),
+    ).toBe(true);
+
+    expect(
+      await compareAndSetTrustedRunActingUser({
+        runId: run.id,
+        expectedUserId: firstUser.id,
+        nextUserId: thirdUser.id,
+      }),
+    ).toBe(false);
+    expect(await readActingUserId(run.id)).toBe(secondUser.id);
+  });
+
+  it('changes the actor only when the trusted external claim succeeds', async () => {
+    const { run, firstUser, secondUser } = await createRunWithActors();
+
+    expect(
+      await setTrustedRunActingUserOnSuccess({
+        runId: run.id,
+        userId: secondUser.id,
+        operation: async () => false,
+      }),
+    ).toBe(false);
+    expect(await readActingUserId(run.id)).toBe(firstUser.id);
+
+    expect(
+      await setTrustedRunActingUserOnSuccess({
+        runId: run.id,
+        userId: secondUser.id,
+        operation: async () => true,
+      }),
+    ).toBe(true);
+    expect(await readActingUserId(run.id)).toBe(secondUser.id);
+  });
+});

--- a/packages/db/src/lib/acting-user.ts
+++ b/packages/db/src/lib/acting-user.ts
@@ -1,0 +1,99 @@
+import { and, eq, isNull, ne, or } from 'drizzle-orm';
+
+import { db } from '../db';
+import { taskRuns } from '../schema';
+
+/**
+ * Sets the live actor from a trusted server-side sender resolution.
+ *
+ * This must not be exposed through a run-scoped job-token mutation:
+ * `task_runs.actingUserId` selects actor-scoped credentials for the sandbox.
+ */
+export async function setTrustedRunActingUser(params: {
+  runId: number;
+  userId: string;
+}): Promise<void> {
+  await db
+    .update(taskRuns)
+    .set({ actingUserId: params.userId })
+    .where(
+      and(
+        eq(taskRuns.id, params.runId),
+        or(
+          isNull(taskRuns.actingUserId),
+          ne(taskRuns.actingUserId, params.userId),
+        ),
+      ),
+    );
+}
+
+/**
+ * Runs a short trusted claim while holding the run row lock, then switches
+ * the actor only when the claim succeeds. This is used when another store
+ * (currently Redis request_user_input queues) atomically decides which
+ * sender won: losing contenders must not leave their identity on the run.
+ *
+ * The callback should be short. Holding the row lock also serializes normal
+ * actor updates until the claim and matching actor write commit together.
+ */
+export async function setTrustedRunActingUserOnSuccess(params: {
+  runId: number;
+  userId: string;
+  operation: () => Promise<boolean>;
+}): Promise<boolean> {
+  return await db.transaction(async (tx) => {
+    const [run] = await tx
+      .select({ actingUserId: taskRuns.actingUserId })
+      .from(taskRuns)
+      .where(eq(taskRuns.id, params.runId))
+      .for('update');
+
+    if (!run) {
+      throw new Error(
+        `Run not found while setting trusted actor: ${params.runId}`,
+      );
+    }
+
+    const succeeded = await params.operation();
+
+    if (!succeeded || run.actingUserId === params.userId) {
+      return succeeded;
+    }
+
+    await tx
+      .update(taskRuns)
+      .set({ actingUserId: params.userId })
+      .where(eq(taskRuns.id, params.runId));
+
+    return true;
+  });
+}
+
+/**
+ * Atomically changes the live actor only when it still matches the caller's
+ * observed value. The boolean reports whether this call applied the change.
+ */
+export async function compareAndSetTrustedRunActingUser(params: {
+  runId: number;
+  expectedUserId: string | null;
+  nextUserId: string | null;
+}): Promise<boolean> {
+  if (params.expectedUserId === params.nextUserId) {
+    return false;
+  }
+
+  const [updated] = await db
+    .update(taskRuns)
+    .set({ actingUserId: params.nextUserId })
+    .where(
+      and(
+        eq(taskRuns.id, params.runId),
+        params.expectedUserId === null
+          ? isNull(taskRuns.actingUserId)
+          : eq(taskRuns.actingUserId, params.expectedUserId),
+      ),
+    )
+    .returning({ id: taskRuns.id });
+
+  return Boolean(updated);
+}

--- a/packages/db/src/server.ts
+++ b/packages/db/src/server.ts
@@ -41,6 +41,7 @@ export * from './lib/deployment-auth-keypairs';
 export * from './lib/environment-variables';
 export * from './lib/task-id';
 export * from './lib/task-activity-timestamp';
+export * from './lib/acting-user';
 export * from './lib/task-suggestion-content-hash';
 export * from './lib/work-item-claims';
 export * from './lib/task-start-parallel-counts';

--- a/packages/sdk/src/cloud-jobs.test.ts
+++ b/packages/sdk/src/cloud-jobs.test.ts
@@ -52,20 +52,48 @@ describe('syncActingUserId', () => {
 
     await expect(
       syncActingUserId({ cloudJobId: 42, newUserId: 'user-2' }),
-    ).resolves.toBe('not-found');
+    ).resolves.toEqual({ result: 'not-found' });
     expect(mockUpdate).not.toHaveBeenCalled();
   });
 
-  it('returns unchanged when actingUserId already matches', async () => {
+  it('returns unchanged when the server, sender, and local state agree', async () => {
+    mockFindFirstById.mockResolvedValueOnce({ actingUserId: 'user-2' });
+
+    await expect(
+      syncActingUserId({
+        cloudJobId: 42,
+        newUserId: 'user-2',
+        lastKnownUserId: 'user-2',
+      }),
+    ).resolves.toEqual({ result: 'unchanged', actingUserId: 'user-2' });
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns updated when the server actor matches the sender but local state lags', async () => {
+    // A trusted server-side writer switched the run to this sender; the
+    // worker must refresh its integrations and git author from the server.
+    mockFindFirstById.mockResolvedValueOnce({ actingUserId: 'user-2' });
+
+    await expect(
+      syncActingUserId({
+        cloudJobId: 42,
+        newUserId: 'user-2',
+        lastKnownUserId: 'user-1',
+      }),
+    ).resolves.toEqual({ result: 'updated', actingUserId: 'user-2' });
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns updated on a match when the local state is unknown', async () => {
     mockFindFirstById.mockResolvedValueOnce({ actingUserId: 'user-2' });
 
     await expect(
       syncActingUserId({ cloudJobId: 42, newUserId: 'user-2' }),
-    ).resolves.toBe('unchanged');
+    ).resolves.toEqual({ result: 'updated', actingUserId: 'user-2' });
     expect(mockUpdate).not.toHaveBeenCalled();
   });
 
-  it('never reassigns actingUserId via the job token when it differs', async () => {
+  it('never reassigns actingUserId via the job token and reports a mismatch', async () => {
     // Security: job tokens (held by the sandbox) must not be able to steer
     // the run's acting user, or a compromised sandbox could pivot to another
     // user's actor-scoped credentials. The worker only observes the value.
@@ -73,8 +101,12 @@ describe('syncActingUserId', () => {
     mockFindFirstById.mockResolvedValueOnce({ actingUserId: 'user-1' });
 
     await expect(
-      syncActingUserId({ cloudJobId: 42, newUserId: 'user-2' }),
-    ).resolves.toBe('unchanged');
+      syncActingUserId({
+        cloudJobId: 42,
+        newUserId: 'user-2',
+        lastKnownUserId: 'user-1',
+      }),
+    ).resolves.toEqual({ result: 'mismatch', actingUserId: 'user-1' });
     expect(mockUpdate).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('cannot reassign the acting user'),

--- a/packages/sdk/src/cloud-jobs.test.ts
+++ b/packages/sdk/src/cloud-jobs.test.ts
@@ -65,17 +65,22 @@ describe('syncActingUserId', () => {
     expect(mockUpdate).not.toHaveBeenCalled();
   });
 
-  it('updates the cloud job when actingUserId differs', async () => {
+  it('never reassigns actingUserId via the job token when it differs', async () => {
+    // Security: job tokens (held by the sandbox) must not be able to steer
+    // the run's acting user, or a compromised sandbox could pivot to another
+    // user's actor-scoped credentials. The worker only observes the value.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     mockFindFirstById.mockResolvedValueOnce({ actingUserId: 'user-1' });
-    mockUpdate.mockResolvedValueOnce(undefined);
 
     await expect(
       syncActingUserId({ cloudJobId: 42, newUserId: 'user-2' }),
-    ).resolves.toBe('updated');
-    expect(mockUpdate).toHaveBeenCalledWith({
-      id: 42,
-      actingUserId: 'user-2',
-    });
+    ).resolves.toBe('unchanged');
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('cannot reassign the acting user'),
+    );
+
+    warnSpy.mockRestore();
   });
 });
 

--- a/packages/sdk/src/cloud-jobs.ts
+++ b/packages/sdk/src/cloud-jobs.ts
@@ -100,13 +100,21 @@ export const stampMilestone = (
 ) => client.cloudJobs.stampMilestone.mutate(options);
 
 /**
- * Keep the cloud job's acting user aligned with the latest prompt sender.
+ * Reconcile the worker's view of the run's acting user with the server.
  *
- * This is separate from `cloudJob.userId`, which identifies the job owner used
- * for job-token scoping. Integration MCP proxies read `actingUserId` when
- * choosing whose OAuth credentials to use for a running task, so callers
- * update it before prompt delivery instead of inferring it later from
- * asynchronously persisted `task_messages`.
+ * `task_runs.actingUserId` feeds actor-scoped credential resolution, so it is
+ * writable ONLY by trusted server-side actors (web steer, follow-up delivery).
+ * Run-scoped job tokens can no longer reassign it: a compromised sandbox
+ * previously pointed `actingUserId` at an arbitrary user via `cloudJobs.update`
+ * and then read that user's decrypted credentials through actor-scoped routes
+ * (a confused deputy). The worker therefore only OBSERVES the server value here
+ * — it never steers it.
+ *
+ * Returns `not-found` when the job is gone (delivery should stop) and
+ * `unchanged` otherwise. When the server's acting user diverges from the
+ * requested one (rare, e.g. a multi-user resume batch), the turn still
+ * delivers under the server-authoritative actor; the worker no longer forces
+ * the switch.
  */
 export async function syncActingUserId(
   options: SyncActingUserIdOptions,
@@ -118,12 +126,17 @@ export async function syncActingUserId(
     return 'not-found';
   }
 
-  if ((cloudJob.actingUserId ?? null) === newUserId) {
-    return 'unchanged';
+  const currentUserId = cloudJob.actingUserId ?? null;
+
+  if (currentUserId !== newUserId) {
+    console.warn(
+      `[syncActingUserId] Cloud job ${cloudJobId} acting user ` +
+        `${currentUserId ?? 'none'} differs from requested ${newUserId}; ` +
+        'not overriding (job tokens cannot reassign the acting user).',
+    );
   }
 
-  await update({ id: cloudJobId, actingUserId: newUserId });
-  return 'updated';
+  return 'unchanged';
 }
 
 export const enqueue = (options: AppRouterInput['cloudJobs']['enqueue']) =>

--- a/packages/sdk/src/cloud-jobs.ts
+++ b/packages/sdk/src/cloud-jobs.ts
@@ -22,10 +22,30 @@ export type DequeuedResumeCloudJob = NonNullable<
 
 export interface SyncActingUserIdOptions {
   cloudJobId: AppRouterInput['cloudJobs']['findFirstById'];
+  /** The sender the caller wants the upcoming turn to run as. */
   newUserId: string;
+  /**
+   * The actor the worker last prepared locally (git author, mounted
+   * integrations). Omit when unknown; a match then reports `updated` so the
+   * worker refreshes its local state from the server value.
+   */
+  lastKnownUserId?: string | null;
 }
 
-export type SyncActingUserIdResult = 'updated' | 'unchanged' | 'not-found';
+export type SyncActingUserIdResult =
+  | 'updated'
+  | 'unchanged'
+  | 'not-found'
+  | 'mismatch';
+
+export interface SyncActingUserIdOutcome {
+  result: SyncActingUserIdResult;
+  /**
+   * The server-authoritative acting user for the run. Undefined only for
+   * `not-found`.
+   */
+  actingUserId?: string | null;
+}
 
 export interface CloudJobBootstrapOptions {
   onBootstrapFailure?: (error: Error, cloudJob: CloudJob) => void;
@@ -100,43 +120,55 @@ export const stampMilestone = (
 ) => client.cloudJobs.stampMilestone.mutate(options);
 
 /**
- * Reconcile the worker's view of the run's acting user with the server.
+ * Reconcile the worker's local actor state against the server-authoritative
+ * `task_runs.actingUserId` before delivering a turn.
  *
- * `task_runs.actingUserId` feeds actor-scoped credential resolution, so it is
- * writable ONLY by trusted server-side actors (web steer, follow-up delivery).
- * Run-scoped job tokens can no longer reassign it: a compromised sandbox
- * previously pointed `actingUserId` at an arbitrary user via `cloudJobs.update`
- * and then read that user's decrypted credentials through actor-scoped routes
- * (a confused deputy). The worker therefore only OBSERVES the server value here
- * — it never steers it.
+ * `actingUserId` feeds actor-scoped credential resolution, so it is writable
+ * ONLY by trusted server-side actors (web steer, pre-delivery follow-up sync,
+ * pre-queue webhook sync). Run-scoped job tokens can no longer reassign it: a
+ * compromised sandbox previously pointed `actingUserId` at an arbitrary user
+ * via `cloudJobs.update` and then read that user's decrypted credentials
+ * through actor-scoped routes (a confused deputy). This function therefore
+ * never writes — it reads the server value and tells the caller how the
+ * upcoming turn relates to it:
  *
- * Returns `not-found` when the job is gone (delivery should stop) and
- * `unchanged` otherwise. When the server's acting user diverges from the
- * requested one (rare, e.g. a multi-user resume batch), the turn still
- * delivers under the server-authoritative actor; the worker no longer forces
- * the switch.
+ * - `not-found`: the run row is gone; delivery must stop.
+ * - `mismatch`: the server actor differs from the requested sender — no
+ *   trusted writer switched the run to them. The caller must NOT run the
+ *   sender's turn under the current credentials; it either blocks the turn
+ *   or delivers it as the server actor (`actingUserId`), keeping credential
+ *   resolution and attribution on the same identity.
+ * - `updated`: the server actor matches the sender but differs from the
+ *   worker's last-prepared actor — the caller must refresh actor-scoped
+ *   integrations and the runtime git author from the server value.
+ * - `unchanged`: server actor, sender, and local state all agree.
  */
 export async function syncActingUserId(
   options: SyncActingUserIdOptions,
-): Promise<SyncActingUserIdResult> {
-  const { cloudJobId, newUserId } = options;
+): Promise<SyncActingUserIdOutcome> {
+  const { cloudJobId, newUserId, lastKnownUserId } = options;
   const cloudJob = await findFirstById(cloudJobId);
 
   if (!cloudJob) {
-    return 'not-found';
+    return { result: 'not-found' };
   }
 
-  const currentUserId = cloudJob.actingUserId ?? null;
+  const serverUserId = cloudJob.actingUserId ?? null;
 
-  if (currentUserId !== newUserId) {
+  if (serverUserId !== newUserId) {
     console.warn(
       `[syncActingUserId] Cloud job ${cloudJobId} acting user ` +
-        `${currentUserId ?? 'none'} differs from requested ${newUserId}; ` +
+        `${serverUserId ?? 'none'} differs from requested ${newUserId}; ` +
         'not overriding (job tokens cannot reassign the acting user).',
     );
+    return { result: 'mismatch', actingUserId: serverUserId };
   }
 
-  return 'unchanged';
+  if (lastKnownUserId !== undefined && serverUserId === lastKnownUserId) {
+    return { result: 'unchanged', actingUserId: serverUserId };
+  }
+
+  return { result: 'updated', actingUserId: serverUserId };
 }
 
 export const enqueue = (options: AppRouterInput['cloudJobs']['enqueue']) =>

--- a/packages/sdk/src/server/lib/auth/resolve-actor-scoped-user.ts
+++ b/packages/sdk/src/server/lib/auth/resolve-actor-scoped-user.ts
@@ -21,6 +21,13 @@ export interface ActorScopedUserContext {
  * follow-ups switch `task_runs.actingUserId` to the latest human who is
  * speaking to the task, so actor-scoped integration lookups follow that
  * live value when present and fall back to the token's mint-time user.
+ *
+ * Because this PREFERS the live `actingUserId`, that column is a credential-
+ * resolution input and must only ever be written by trusted server-side
+ * actors (web steer, follow-up delivery). Run-scoped job tokens — which the
+ * sandbox holds — cannot write it: `cloudJobs.update` strips `actingUserId`
+ * from job-token input, closing the confused-deputy path where a compromised
+ * sandbox reassigns the run to a victim and reads that victim's credentials.
  */
 export async function resolveActorScopedUserContext(
   auth: ActorScopedAuthContext | null | undefined,

--- a/packages/sdk/src/server/routers/cloud-jobs.test.ts
+++ b/packages/sdk/src/server/routers/cloud-jobs.test.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 
-import { ACP_ENVELOPE_EVENT_TYPES, TaskPayloadKind } from '@roomote/types';
+import {
+  ACP_ENVELOPE_EVENT_TYPES,
+  CloudTaskStatus,
+  TaskPayloadKind,
+} from '@roomote/types';
 import type { AuthTokenContext, JobTokenContext } from '@roomote/types';
 
 const {
@@ -17,6 +21,7 @@ const {
   mockQueueLinearMessage,
   mockRecordTaskMessageEnvelope,
   mockRecordTaskInferenceUsage,
+  mockUpdateCloudJob,
 } = vi.hoisted(() => ({
   mockEnqueueCloudTask: vi.fn(),
   mockEvaluateFeatureFlag: vi.fn(),
@@ -31,6 +36,7 @@ const {
   mockQueueLinearMessage: vi.fn(),
   mockRecordTaskMessageEnvelope: vi.fn(),
   mockRecordTaskInferenceUsage: vi.fn(),
+  mockUpdateCloudJob: vi.fn(),
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
@@ -102,7 +108,7 @@ vi.mock('../lib/cloud-jobs', () => ({
   setTaskHarnessSessionId: vi.fn(),
   stampCloudJobMilestone: vi.fn(),
   touchCloudJobHeartbeat: vi.fn(),
-  updateCloudJob: vi.fn(),
+  updateCloudJob: mockUpdateCloudJob,
   updateCloudJobRuntimeState: vi.fn(),
 }));
 
@@ -174,6 +180,38 @@ describe('cloudJobsRouter queue message guards', () => {
     mockQueueLinearMessage.mockResolvedValue(undefined);
     mockRecordTaskMessageEnvelope.mockResolvedValue(undefined);
     mockRecordTaskInferenceUsage.mockResolvedValue({ recorded: true });
+    mockUpdateCloudJob.mockResolvedValue(undefined);
+  });
+
+  it('strips actingUserId from job-token update input (confused-deputy guard)', async () => {
+    // A job token is held by the sandbox runtime. Allowing it to write
+    // actingUserId would let a compromised sandbox reassign the run's acting
+    // user and read another user's actor-scoped credentials. The schema must
+    // drop the field so it never reaches the persistence layer.
+    await createJobCaller().update({
+      id: 42,
+      status: CloudTaskStatus.Running,
+      actingUserId: 'victim-user',
+    } as never);
+
+    expect(mockUpdateCloudJob).toHaveBeenCalledTimes(1);
+    const [persistedId, persistedValues] = mockUpdateCloudJob.mock.calls[0]!;
+    expect(persistedId).toBe(42);
+    expect(persistedValues).not.toHaveProperty('actingUserId');
+    expect(persistedValues).toEqual({ status: CloudTaskStatus.Running });
+  });
+
+  it('still persists legitimate non-actingUserId update fields for the job token', async () => {
+    await createJobCaller().update({
+      id: 42,
+      status: CloudTaskStatus.Running,
+      result: { ok: true },
+    });
+
+    expect(mockUpdateCloudJob).toHaveBeenCalledWith(42, {
+      status: CloudTaskStatus.Running,
+      result: { ok: true },
+    });
   });
 
   it('rejects queueSlackMessage for auth-token callers', async () => {

--- a/packages/sdk/src/server/routers/cloud-jobs.ts
+++ b/packages/sdk/src/server/routers/cloud-jobs.ts
@@ -281,7 +281,17 @@ export const cloudJobsRouter = router({
       taskPhase: z.string().nullish(),
       sleepAt: z.date().nullish(),
       taskId: z.string().optional(),
-      actingUserId: z.string().optional(),
+      // `actingUserId` is intentionally NOT writable here. This mutation is
+      // reachable with a run-scoped job token, which the sandbox runtime
+      // holds. `task_runs.actingUserId` feeds actor-scoped credential
+      // resolution (resolveActorScopedUserContext -> userApiKeys /
+      // mcpConnections), so letting a job token set it would be a confused
+      // deputy: a compromised sandbox could point the run at an arbitrary
+      // user and read that user's decrypted keys / connections. Acting-user
+      // reassignment is reserved for trusted server-side writers (web steer
+      // in apps/web sandbox-session, follow-up delivery in
+      // apps/api sendMessageToTask), which write task_runs directly. Any
+      // `actingUserId` sent by a job-token caller is stripped by this schema.
       result: z.record(z.unknown()).optional(),
     }),
     'id',

--- a/packages/sdk/src/server/routers/user-api-keys.test.ts
+++ b/packages/sdk/src/server/routers/user-api-keys.test.ts
@@ -112,4 +112,41 @@ describe('userApiKeysRouter', () => {
     );
     expect(mockDecryptText).toHaveBeenCalledWith('encrypted-api-key');
   });
+
+  it('cannot read a victim user key after a blocked acting-user reassignment', async () => {
+    // Confused-deputy chain (flagged in PR #80 review): a job token is held by
+    // the sandbox. The exploit was: (1) reassign the run's actingUserId to a
+    // victim via cloudJobs.update, then (2) read the victim's decrypted key
+    // here, because getDecryptedKey resolves the effective user from
+    // task_runs.actingUserId.
+    //
+    // Step (1) is now blocked: cloudJobs.update strips actingUserId (asserted
+    // in cloud-jobs.test.ts). So the persisted actingUserId still reflects the
+    // legitimate actor the trusted server-side writers set — never the
+    // attacker-chosen victim. This test pins the downstream half of the chain:
+    // the effective user comes only from the persisted actingUserId, so the
+    // key lookup targets the legitimate actor and never the victim.
+    mockFindCloudJob.mockResolvedValueOnce({
+      // The value that survives in the DB is the legitimate actor, because the
+      // sandbox's reassignment to 'victim-user' was stripped upstream.
+      actingUserId: 'owner-user',
+    });
+    mockFindUserApiKey.mockResolvedValueOnce({ apiKey: 'owner-encrypted-key' });
+
+    const result = await createJobCaller().getDecryptedKey({ provider });
+
+    expect(result).toBe('decrypted-owner-encrypted-key');
+    // The lookup is scoped to the legitimate actor, never the victim.
+    const lookupArg = mockFindUserApiKey.mock.calls[0]![0] as {
+      where: { conditions: Array<{ column: string; value: unknown }> };
+    };
+    expect(lookupArg.where.conditions).toContainEqual({
+      column: 'userId',
+      value: 'owner-user',
+    });
+    expect(lookupArg.where.conditions).not.toContainEqual({
+      column: 'userId',
+      value: 'victim-user',
+    });
+  });
 });

--- a/packages/sdk/src/server/routers/user-api-keys.ts
+++ b/packages/sdk/src/server/routers/user-api-keys.ts
@@ -39,6 +39,10 @@ export const userApiKeysRouter = router({
    * Returns the decrypted API key for the given provider and current user.
    * Accessible from worker via a run-scoped job token; the effective user is
    * the run's live acting user (falling back to the token's mint-time user).
+   *
+   * The run's acting user is server-controlled: `cloudJobs.update` refuses to
+   * let a job token reassign `task_runs.actingUserId`, so a compromised
+   * sandbox cannot pivot this lookup to another user's key.
    */
   getDecryptedKey: authenticatedProcedure
     .input(z.object({ provider: z.string() }))

--- a/packages/slack/src/__tests__/handle-followup-answer.test.ts
+++ b/packages/slack/src/__tests__/handle-followup-answer.test.ts
@@ -14,6 +14,8 @@ const {
   queueSlackMessageMock,
   selectLimitMock,
   setPendingSlackRequestUserInputPromptMessageTsMock,
+  setTrustedRunActingUserMock,
+  setTrustedRunActingUserOnSuccessMock,
   submitPendingSlackRequestUserInputAnswerMock,
   updateMessageMock,
 } = vi.hoisted(() => ({
@@ -44,6 +46,11 @@ const {
   queueSlackMessageMock: vi.fn(),
   selectLimitMock: vi.fn(),
   setPendingSlackRequestUserInputPromptMessageTsMock: vi.fn(),
+  setTrustedRunActingUserMock: vi.fn(),
+  setTrustedRunActingUserOnSuccessMock: vi.fn(
+    async ({ operation }: { operation: () => Promise<boolean> }) =>
+      await operation(),
+  ),
   submitPendingSlackRequestUserInputAnswerMock: vi.fn(),
   updateMessageMock: vi.fn().mockResolvedValue(true),
 }));
@@ -72,6 +79,8 @@ vi.mock('@roomote/db/server', () => ({
   })),
   slackInstallations: { teamId: 'teamId' },
   slackUserMappings: { slackTeamId: 'slackTeamId', slackUserId: 'slackUserId' },
+  setTrustedRunActingUser: setTrustedRunActingUserMock,
+  setTrustedRunActingUserOnSuccess: setTrustedRunActingUserOnSuccessMock,
 }));
 
 vi.mock('../find-active-slack-job', () => ({
@@ -215,6 +224,7 @@ describe('handleFollowupAnswer', () => {
     postMessageMock.mockResolvedValue('posted-ts');
     queueSlackMessageMock.mockResolvedValue(undefined);
     setPendingSlackRequestUserInputPromptMessageTsMock.mockResolvedValue(true);
+    setTrustedRunActingUserMock.mockResolvedValue(undefined);
     submitPendingSlackRequestUserInputAnswerMock.mockResolvedValue(true);
     updateMessageMock.mockResolvedValue(true);
     promptSlackAccountLinkMock.mockResolvedValue({ dmPromptSent: true });
@@ -462,6 +472,13 @@ describe('handleFollowupAnswer', () => {
         userId: 'user-1',
       }),
     );
+    expect(setTrustedRunActingUserMock).toHaveBeenCalledWith({
+      runId: 42,
+      userId: 'user-1',
+    });
+    expect(
+      setTrustedRunActingUserMock.mock.invocationCallOrder[0]!,
+    ).toBeLessThan(queueSlackMessageMock.mock.invocationCallOrder[0]!);
     expect(postMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: 'C123',
@@ -526,6 +543,18 @@ describe('handleFollowupAnswer', () => {
         user: 'U123',
         userId: 'user-1',
       }),
+    );
+    expect(setTrustedRunActingUserOnSuccessMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 42,
+        userId: 'user-1',
+        operation: expect.any(Function),
+      }),
+    );
+    expect(
+      setTrustedRunActingUserOnSuccessMock.mock.invocationCallOrder[0]!,
+    ).toBeLessThan(
+      submitPendingSlackRequestUserInputAnswerMock.mock.invocationCallOrder[0]!,
     );
     expect(queueSlackMessageMock).not.toHaveBeenCalled();
     expect(consoleErrorMock).not.toHaveBeenCalled();

--- a/packages/slack/src/handle-followup-answer.ts
+++ b/packages/slack/src/handle-followup-answer.ts
@@ -5,6 +5,8 @@ import {
   type SlackInstallation,
   slackInstallations,
   slackUserMappings,
+  setTrustedRunActingUser,
+  setTrustedRunActingUserOnSuccess,
   and,
   eq,
 } from '@roomote/db/server';
@@ -272,16 +274,21 @@ export async function handleFollowupAnswer(payload: SlackInteractivePayload) {
       }
 
       if (structuredAnswer.cancel) {
-        const submitted = await submitPendingSlackRequestUserInputAnswer(
-          threadId,
-          pendingRequest,
-          {
-            answers: {},
-            user: payload.user.id,
-            userId: userMapping.userId,
-            ts: new Date().toISOString(),
-          },
-        );
+        const submitted = await setTrustedRunActingUserOnSuccess({
+          runId: activeJob.id,
+          userId: userMapping.userId,
+          operation: async () =>
+            await submitPendingSlackRequestUserInputAnswer(
+              threadId,
+              pendingRequest,
+              {
+                answers: {},
+                user: payload.user.id,
+                userId: userMapping.userId,
+                ts: new Date().toISOString(),
+              },
+            ),
+        });
 
         if (!submitted) {
           await postRequestUserInputAlreadyReceivedResponse(
@@ -318,16 +325,21 @@ export async function handleFollowupAnswer(payload: SlackInteractivePayload) {
       const nextQuestionIndex = currentQuestion.questionIndex + 1;
 
       if (nextQuestionIndex >= pendingRequest.questions.length) {
-        const submitted = await submitPendingSlackRequestUserInputAnswer(
-          threadId,
-          pendingRequest,
-          {
-            answers: nextAnswers,
-            user: payload.user.id,
-            userId: userMapping.userId,
-            ts: new Date().toISOString(),
-          },
-        );
+        const submitted = await setTrustedRunActingUserOnSuccess({
+          runId: activeJob.id,
+          userId: userMapping.userId,
+          operation: async () =>
+            await submitPendingSlackRequestUserInputAnswer(
+              threadId,
+              pendingRequest,
+              {
+                answers: nextAnswers,
+                user: payload.user.id,
+                userId: userMapping.userId,
+                ts: new Date().toISOString(),
+              },
+            ),
+        });
 
         if (!submitted) {
           await postRequestUserInputAlreadyReceivedResponse(
@@ -413,6 +425,10 @@ export async function handleFollowupAnswer(payload: SlackInteractivePayload) {
       return;
     }
 
+    await setTrustedRunActingUser({
+      runId: activeJob.id,
+      userId: userMapping.userId,
+    });
     await queueSlackMessage(activeJob.id, {
       text: answerValue,
       user: payload.user.id,


### PR DESCRIPTION
## Vulnerability (flagged in PR #80 review)

The job-scoped `cloudJobs.update` tRPC mutation (`packages/sdk/src/server/routers/cloud-jobs.ts`) accepted `actingUserId: z.string().optional()`. A run-scoped job token is held by the sandbox runtime, and `resolveActorScopedUserContext` (`packages/sdk/src/server/lib/auth/resolve-actor-scoped-user.ts`) — plus the MCP proxy's `resolveActingUserId` — **prefer** the run's live `task_runs.actingUserId` when resolving the effective user for actor-scoped credential routes (`userApiKeys.getDecryptedKey`, user-scoped `mcpConnections`).

**Confused-deputy chain:** a compromised/misbehaving sandbox → `cloudJobs.update({ id, actingUserId: <victim> })` with its own job token → then `userApiKeys.getDecryptedKey` (or a user-scoped MCP connection lookup) resolves to the victim → reads the victim's decrypted API keys / connections.

## Fix

Removed `actingUserId` from the job-token-writable `update` input schema. zod strips the field, so a job-token caller can never persist it. Acting-user reassignment remains available only to the **trusted server-side writers**, which write `task_runs` directly and are unchanged:

- web steer — `apps/web/src/trpc/commands/sandbox-session/index.ts` (sets it from the authenticated web user)
- follow-up delivery — `apps/api/src/handlers/tasks/sendMessageToTask.ts` `syncActingUserIdAfterDelivery`

The read-side model (PR #80) is unchanged: `actingUserId` is still the live-trusted attribution source and is still preferred over the token's mint-time userId.

## Worker audit

The only worker path that wrote `actingUserId` through the job token was the SDK helper `syncActingUserId` (`packages/sdk/src/cloud-jobs.ts`), called during actor-scoped turn preparation to switch the actor to a queued follow-up sender before delivering that sender's turn. No code in `apps/worker/src` puts `actingUserId` into an `update` call directly.

This switch is a **legitimate** relay of a server-provided queued-sender id, but it cannot be safely preserved:
- the sandbox and worker host share **one** run-scoped token (`createJobToken` mints `userId = actingUserId`, no worker-vs-sandbox principal distinction), so the legit switch is indistinguishable from the attack at the server;
- the queued-message store is Redis, **destructive-on-read** (`getCommunicationMessages` deletes the key), so there is no durable record of pending senders to validate a target against.

Per the reviewer's stated intent ("the worker should never choose its own acting user"), `syncActingUserId` is now **reconcile-only**: it observes the server-authoritative value and never writes, logging a warning if the requested actor diverges.

**Trade-off (reported, not a leak):** in a rare multi-user snapshot-resume batch, a later sender's turn now runs under the earlier, server-set actor instead of switching mid-batch. Both are legitimate participants of the same run who already share its actor-scoped surface turn-by-turn, so this is a within-run mis-attribution, **not** a cross-user credential leak. A future server-authoritative per-turn actor sync could restore precise switching if desired.

## Other job-token-writable fields audited

While in the `update` schema I checked the remaining fields for confused-deputy potential:
- **`taskId` (worth a follow-up):** writable by a job token but **not sent by any worker `update` call** (all `taskId:` references in the worker are reads). Re-pointing a run to another task would corrupt run→task attribution/visibility, but `taskId` does not feed `resolveActorScopedUserContext`, so it is a data-integrity risk, strictly lesser than credential theft. Left as-is to keep this PR scoped to the credential vector; recommend removing it from the job-token input in a follow-up.
- `status` / `result` / `taskPhase` / `sleepAt`: legitimate worker-written runtime/output fields, no auth/attribution role.
- Sibling job-token mutations (`done`, `updateRuntimeState`, `stampMilestone`, `touchCloudJobHeartbeat`): none write auth/attribution fields.

## Tests

- `packages/sdk/src/server/routers/cloud-jobs.test.ts`: a job-token `update` carrying `actingUserId` is stripped (never reaches `updateCloudJob`); legitimate `status`/`result` fields still persist.
- `packages/sdk/src/server/routers/user-api-keys.test.ts`: end-to-end shape — a job token cannot pivot `getDecryptedKey` to a victim; the lookup is scoped only to the persisted (legitimate) actingUserId.
- `packages/sdk/src/cloud-jobs.test.ts`: `syncActingUserId` never writes on divergence and warns.
- Existing web-steer / follow-up-sync / worker actor-scoped tests still pass.

## Validation

`pnpm format` + full `pnpm check` (lint, check-types, test, knip) all pass.