### PR TITLE
[Fix] Job tokens can no longer re-point their run at a different task

### DIFF
--- a/packages/sdk/src/server/routers/cloud-jobs.test.ts
+++ b/packages/sdk/src/server/routers/cloud-jobs.test.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 
-import { ACP_ENVELOPE_EVENT_TYPES, TaskPayloadKind } from '@roomote/types';
+import {
+  ACP_ENVELOPE_EVENT_TYPES,
+  RunStatus,
+  TaskPayloadKind,
+} from '@roomote/types';
 import type { AuthTokenContext, JobTokenContext } from '@roomote/types';
 
 const {
@@ -17,6 +21,7 @@ const {
   mockQueueLinearMessage,
   mockRecordTaskMessageEnvelope,
   mockRecordTaskInferenceUsage,
+  mockUpdateCloudJob,
 } = vi.hoisted(() => ({
   mockEnqueueTask: vi.fn(),
   mockEvaluateFeatureFlag: vi.fn(),
@@ -31,6 +36,7 @@ const {
   mockQueueLinearMessage: vi.fn(),
   mockRecordTaskMessageEnvelope: vi.fn(),
   mockRecordTaskInferenceUsage: vi.fn(),
+  mockUpdateCloudJob: vi.fn(),
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
@@ -102,7 +108,7 @@ vi.mock('../lib/cloud-jobs', () => ({
   setTaskHarnessSessionId: vi.fn(),
   stampCloudJobMilestone: vi.fn(),
   touchCloudJobHeartbeat: vi.fn(),
-  updateCloudJob: vi.fn(),
+  updateCloudJob: mockUpdateCloudJob,
   updateCloudJobRuntimeState: vi.fn(),
 }));
 
@@ -174,6 +180,25 @@ describe('cloudJobsRouter queue message guards', () => {
     mockQueueLinearMessage.mockResolvedValue(undefined);
     mockRecordTaskMessageEnvelope.mockResolvedValue(undefined);
     mockRecordTaskInferenceUsage.mockResolvedValue({ recorded: true });
+    mockUpdateCloudJob.mockResolvedValue(undefined);
+  });
+
+  it('strips taskId from job-token update input (run->task binding guard)', async () => {
+    // A job token is held by the sandbox runtime. Allowing it to write taskId
+    // would let a compromised sandbox re-point its run at a different task,
+    // corrupting attribution, visibility, and PR linkage. The schema must drop
+    // the field so it never reaches the persistence layer.
+    await createJobCaller().update({
+      id: 42,
+      status: RunStatus.Running,
+      taskId: 'attacker-task',
+    } as never);
+
+    expect(mockUpdateCloudJob).toHaveBeenCalledTimes(1);
+    const [persistedId, persistedValues] = mockUpdateCloudJob.mock.calls[0]!;
+    expect(persistedId).toBe(42);
+    expect(persistedValues).not.toHaveProperty('taskId');
+    expect(persistedValues).toEqual({ status: RunStatus.Running });
   });
 
   it('rejects queueSlackMessage for auth-token callers', async () => {

--- a/packages/sdk/src/server/routers/cloud-jobs.ts
+++ b/packages/sdk/src/server/routers/cloud-jobs.ts
@@ -280,7 +280,13 @@ export const cloudJobsRouter = router({
       status: z.nativeEnum(RunStatus).optional(),
       taskPhase: z.string().nullish(),
       sleepAt: z.date().nullish(),
-      taskId: z.string().optional(),
+      // `taskId` is intentionally NOT writable here. This mutation is
+      // reachable with a run-scoped job token (held by the sandbox runtime),
+      // and a run's task binding is what attribution, visibility, and PR
+      // linkage hang off of. Letting the sandbox re-point its run at a
+      // different task would corrupt run->task integrity; runs are bound to a
+      // task at enqueue time and never re-parented. No worker code path sends
+      // this field.
       actingUserId: z.string().optional(),
       result: z.record(z.unknown()).optional(),
     }),


### PR DESCRIPTION
## Summary

Removes `taskId` from the job-scoped `cloudJobs.update` input schema in `packages/sdk/src/server/routers/cloud-jobs.ts`. The `update` mutation is reachable with a run-scoped job token held by the sandbox runtime, so a compromised sandbox could previously re-point its run at a different task via `updateCloudJob`, corrupting run->task attribution, visibility, and PR linkage. Zod's default strip behavior now drops the field before it reaches the persistence layer.

This mirrors the `actingUserId` hardening in #82 but is lower severity: `taskId` does not feed `resolveActorScopedUserContext`, so it is a data-integrity issue rather than a credential vector. It was intentionally deferred out of #82 to keep that PR scoped.

## Why removal is safe

No worker code path ever sends `taskId` in a `cloudJobs.update` call — every `taskId:` reference in `apps/worker/src` is a read (passing `cloudJob.taskId` into other functions). All `sdk.cloudJobs.update(...)` call sites send only `id`, `status`, and/or `result`. Runs are bound to a task at enqueue time and never re-parented.

## Changes

- Remove `taskId` from the `update` input schema and add a comment explaining why it is not job-token-writable, following the pattern from #82.
- Regression test: a job-token caller sending `taskId` in `update` asserts the field never reaches `updateCloudJob` (only the legitimate fields are persisted).
- Test wiring for `mockUpdateCloudJob` matches #82's version of the same file, so the eventual merge conflict between the two branches resolves to identical lines.

## Note on #82

Both PRs touch adjacent lines in `cloud-jobs.ts` and `cloud-jobs.test.ts`; whichever merges second will have a small mechanical conflict.