### PR TITLE
[Fix] Roomote MCP tool calls hang the task forever when the API stalls

### DIFF
--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/api-client.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/api-client.test.ts
@@ -4,8 +4,10 @@ import {
   confirmUpload,
   uploadArtifact,
   fetchArtifactMetadata,
+  fetchWithTimeout,
   getDownloadUrl,
   parseApiError,
+  resolvePlatformApiTimeoutMs,
 } from '../api-client.js';
 import type { ArtifactConfig } from '../types.js';
 
@@ -13,6 +15,126 @@ const config: ArtifactConfig = {
   token: 'test-token',
   platformApiUrl: 'https://test-api.example.com',
 };
+
+// Mirrors undici: a pending request rejects with the signal's reason when the
+// signal aborts, and never settles otherwise.
+function neverRespondingFetch() {
+  return vi.fn((_url: unknown, options?: RequestInit) => {
+    return new Promise<Response>((_resolve, reject) => {
+      options?.signal?.addEventListener('abort', () =>
+        reject(
+          (options.signal as AbortSignal).reason ??
+            new DOMException('Aborted', 'AbortError'),
+        ),
+      );
+    });
+  });
+}
+
+describe('fetchWithTimeout', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.ROOMOTE_MCP_PLATFORM_API_TIMEOUT_MS;
+  });
+
+  it('rejects with a retryable error when the API never responds', async () => {
+    process.env.ROOMOTE_MCP_PLATFORM_API_TIMEOUT_MS = '25';
+    global.fetch = neverRespondingFetch() as unknown as typeof fetch;
+
+    await expect(
+      fetchWithTimeout(
+        'https://test-api.example.com/api/mcp/tasks/t1/source_control',
+        { method: 'POST' },
+        { label: 'Failed to manage source control' },
+      ),
+    ).rejects.toThrow(
+      'Failed to manage source control: no response from the Roomote API within 25ms; the request was aborted and is safe to retry.',
+    );
+  });
+
+  it('honors an explicit timeoutMs over the environment default', async () => {
+    process.env.ROOMOTE_MCP_PLATFORM_API_TIMEOUT_MS = '60000';
+    global.fetch = neverRespondingFetch() as unknown as typeof fetch;
+
+    await expect(
+      fetchWithTimeout(
+        'https://s3.example.com/upload',
+        { method: 'PUT' },
+        { label: 'Failed to upload to S3', timeoutMs: 25 },
+      ),
+    ).rejects.toThrow('no response from the Roomote API within 25ms');
+  });
+
+  it('passes through non-timeout failures unchanged', async () => {
+    global.fetch = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new TypeError('fetch failed'),
+      ) as unknown as typeof fetch;
+
+    await expect(
+      fetchWithTimeout(
+        'https://test-api.example.com/api/mcp/tasks',
+        {},
+        { label: 'Failed to search tasks' },
+      ),
+    ).rejects.toThrow('fetch failed');
+  });
+
+  it('preserves a caller-provided abort as an abort, not a timeout', async () => {
+    global.fetch = neverRespondingFetch() as unknown as typeof fetch;
+    const controller = new AbortController();
+    const pending = fetchWithTimeout(
+      'https://test-api.example.com/api/mcp/tasks',
+      { signal: controller.signal },
+      { label: 'Failed to search tasks' },
+    );
+
+    controller.abort();
+
+    await expect(pending).rejects.toSatisfy(
+      (error: unknown) =>
+        error instanceof DOMException && error.name === 'AbortError',
+    );
+  });
+
+  it('returns the response when the API answers within the deadline', async () => {
+    const response = { ok: true } as Response;
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(response) as unknown as typeof fetch;
+
+    await expect(
+      fetchWithTimeout(
+        'https://test-api.example.com/api/mcp/tasks',
+        {},
+        { label: 'Failed to search tasks' },
+      ),
+    ).resolves.toBe(response);
+  });
+});
+
+describe('resolvePlatformApiTimeoutMs', () => {
+  afterEach(() => {
+    delete process.env.ROOMOTE_MCP_PLATFORM_API_TIMEOUT_MS;
+  });
+
+  it('defaults to two minutes', () => {
+    expect(resolvePlatformApiTimeoutMs()).toBe(120_000);
+  });
+
+  it('reads a positive integer override from the environment', () => {
+    process.env.ROOMOTE_MCP_PLATFORM_API_TIMEOUT_MS = '45000';
+    expect(resolvePlatformApiTimeoutMs()).toBe(45_000);
+  });
+
+  it('ignores non-positive or malformed overrides', () => {
+    process.env.ROOMOTE_MCP_PLATFORM_API_TIMEOUT_MS = '-5';
+    expect(resolvePlatformApiTimeoutMs()).toBe(120_000);
+    process.env.ROOMOTE_MCP_PLATFORM_API_TIMEOUT_MS = 'soon';
+    expect(resolvePlatformApiTimeoutMs()).toBe(120_000);
+  });
+});
 
 describe('parseApiError', () => {
   it('should extract error field from JSON response', async () => {

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/tasks-api-client.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/tasks-api-client.test.ts
@@ -746,3 +746,40 @@ describe('updateEnvironment', () => {
     );
   });
 });
+
+describe('manageSourceControl timeout', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.ROOMOTE_MCP_PLATFORM_API_TIMEOUT_MS;
+  });
+
+  it('fails as a retryable tool error instead of hanging when the API stalls', async () => {
+    // Regression: create_or_update_pull_request calls hung for over an hour
+    // when the API stopped responding mid-request; the bare fetch had no
+    // deadline, so the MCP tool call — and with it the whole task turn —
+    // wedged until a human stopped the task.
+    process.env.ROOMOTE_MCP_PLATFORM_API_TIMEOUT_MS = '25';
+    global.fetch = vi.fn((_url: unknown, options?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        options?.signal?.addEventListener('abort', () =>
+          reject((options.signal as AbortSignal).reason),
+        );
+      });
+    }) as unknown as typeof fetch;
+
+    const { manageSourceControl } = await import('../tasks-api-client.js');
+
+    await expect(
+      manageSourceControl(config, 'task-1', {
+        action: 'create_or_update_pull_request',
+        repositoryFullName: 'owner/repo',
+        sourceBranch: 'feature/x',
+        targetBranch: 'develop',
+        title: 'Test PR',
+        body: 'Body',
+      }),
+    ).rejects.toThrow(
+      'Failed to manage source control: no response from the Roomote API within 25ms; the request was aborted and is safe to retry.',
+    );
+  });
+});

--- a/apps/worker/src/mcp/roomote-mcp-server/api-client.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/api-client.ts
@@ -9,6 +9,63 @@ import type {
   ListArtifactsResponse,
 } from './types.js';
 
+// Ceiling on any single platform-API request from the sandbox. These calls run
+// inside an MCP tool invocation, which nothing else bounds: OpenCode waits on
+// the tool indefinitely, so a request that never gets a response (API instance
+// stall, half-open connection through a restart) wedges the whole task in a
+// silently "running" turn until a human intervenes. A bounded failure surfaces
+// as a normal tool error the agent can retry; the ceiling is deliberately
+// generous so slow-but-alive operations (PR creation against a provider API)
+// are never killed.
+const DEFAULT_PLATFORM_API_TIMEOUT_MS = 120_000;
+// Artifact/S3 transfers move real payloads (screenshots, videos), so give them
+// a wider window than control-plane calls before declaring the transfer dead.
+export const ARTIFACT_TRANSFER_TIMEOUT_MS = 600_000;
+
+export function resolvePlatformApiTimeoutMs(): number {
+  const raw = process.env.ROOMOTE_MCP_PLATFORM_API_TIMEOUT_MS?.trim();
+
+  if (!raw) {
+    return DEFAULT_PLATFORM_API_TIMEOUT_MS;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_PLATFORM_API_TIMEOUT_MS;
+}
+
+/**
+ * `fetch` with a hard deadline. Composes with any caller-provided signal, and
+ * translates the deadline expiry into a retryable error message instead of a
+ * bare AbortError. The timeout signal also bounds body reads started within
+ * the window (undici ties the response stream to the request signal).
+ */
+export async function fetchWithTimeout(
+  url: string,
+  options: RequestInit,
+  context: { label: string; timeoutMs?: number },
+): Promise<Response> {
+  const timeoutMs = context.timeoutMs ?? resolvePlatformApiTimeoutMs();
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const signal = options.signal
+    ? AbortSignal.any([options.signal, timeoutSignal])
+    : timeoutSignal;
+
+  try {
+    return await fetch(url, { ...options, signal });
+  } catch (error) {
+    if (timeoutSignal.aborted) {
+      throw new Error(
+        `${context.label}: no response from the Roomote API within ${timeoutMs}ms; the request was aborted and is safe to retry.`,
+      );
+    }
+
+    throw error;
+  }
+}
+
 export function buildApiHeaders(
   config: Pick<
     ArtifactConfig,
@@ -63,13 +120,17 @@ export async function createArtifactRecord(
       : artifactType === 'visual-proof'
         ? '/api/artifacts/visual-proof'
         : '/api/artifacts';
-  const response = await fetch(`${config.platformApiUrl}${createPath}`, {
-    method: 'POST',
-    headers: buildApiHeaders(config, {
-      'Content-Type': 'application/json',
-    }),
-    body: JSON.stringify(params),
-  });
+  const response = await fetchWithTimeout(
+    `${config.platformApiUrl}${createPath}`,
+    {
+      method: 'POST',
+      headers: buildApiHeaders(config, {
+        'Content-Type': 'application/json',
+      }),
+      body: JSON.stringify(params),
+    },
+    { label: 'Failed to create artifact' },
+  );
 
   if (!response.ok) {
     const error = await parseApiError(response);
@@ -87,14 +148,21 @@ export async function uploadToPresignedUrl(
   content: Buffer,
   contentType: string,
 ): Promise<void> {
-  const response = await fetch(uploadUrl, {
-    method: 'PUT',
-    headers: {
-      'Content-Type': contentType,
-      'Content-Length': content.length.toString(),
+  const response = await fetchWithTimeout(
+    uploadUrl,
+    {
+      method: 'PUT',
+      headers: {
+        'Content-Type': contentType,
+        'Content-Length': content.length.toString(),
+      },
+      body: new Uint8Array(content),
     },
-    body: new Uint8Array(content),
-  });
+    {
+      label: 'Failed to upload to S3',
+      timeoutMs: ARTIFACT_TRANSFER_TIMEOUT_MS,
+    },
+  );
 
   if (!response.ok) {
     throw new Error(
@@ -111,12 +179,13 @@ export async function confirmUpload(
   artifactId: string,
   taskId: string,
 ): Promise<void> {
-  const response = await fetch(
+  const response = await fetchWithTimeout(
     `${config.platformApiUrl}/api/artifacts/${encodeURIComponent(artifactId)}/upload_complete?taskId=${encodeURIComponent(taskId)}`,
     {
       method: 'POST',
       headers: buildApiHeaders(config),
     },
+    { label: 'Failed to confirm upload' },
   );
 
   if (!response.ok) {
@@ -183,12 +252,13 @@ export async function fetchArtifactMetadata(
   const versionQuery =
     params.version !== undefined ? `?v=${params.version}` : '';
 
-  const response = await fetch(
+  const response = await fetchWithTimeout(
     `${config.platformApiUrl}/api/tasks/${encodeURIComponent(params.taskId)}/artifacts/${encodedPath}${versionQuery}`,
     {
       method: 'GET',
       headers: buildApiHeaders(config),
     },
+    { label: 'Failed to fetch artifact metadata' },
   );
 
   if (!response.ok) {
@@ -213,12 +283,13 @@ export async function listArtifacts(
     ? `?artifactType=${encodeURIComponent(params.artifactType)}`
     : '';
 
-  const response = await fetch(
+  const response = await fetchWithTimeout(
     `${config.platformApiUrl}/api/tasks/${encodeURIComponent(params.taskId)}/artifacts${typeQuery}`,
     {
       method: 'GET',
       headers: buildApiHeaders(config),
     },
+    { label: 'Failed to list artifacts' },
   );
 
   if (!response.ok) {
@@ -237,12 +308,13 @@ export async function getDownloadUrl(
   artifactId: string,
   taskId: string,
 ): Promise<DownloadUrlResponse> {
-  const response = await fetch(
+  const response = await fetchWithTimeout(
     `${config.platformApiUrl}/api/artifacts/${encodeURIComponent(artifactId)}/url?taskId=${encodeURIComponent(taskId)}`,
     {
       method: 'GET',
       headers: buildApiHeaders(config),
     },
+    { label: 'Failed to get download URL' },
   );
 
   if (!response.ok) {

--- a/apps/worker/src/mcp/roomote-mcp-server/chat-api-client.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/chat-api-client.ts
@@ -1,4 +1,8 @@
-import { buildApiHeaders, parseApiError } from './api-client.js';
+import {
+  buildApiHeaders,
+  fetchWithTimeout,
+  parseApiError,
+} from './api-client.js';
 import type {
   RoomoteConfig,
   SlackChannelMessagesResponse,
@@ -26,7 +30,7 @@ async function postToChatEndpoint<
   errorPrefix: string,
 ): Promise<TResponse> {
   for (let attempt = 0; ; attempt += 1) {
-    const response = await fetch(
+    const response = await fetchWithTimeout(
       `${config.platformApiUrl}/api/mcp/slack/${path}`,
       {
         method: 'POST',
@@ -35,6 +39,7 @@ async function postToChatEndpoint<
         }),
         body: JSON.stringify(input),
       },
+      { label: errorPrefix },
     );
 
     if (response.ok) {

--- a/apps/worker/src/mcp/roomote-mcp-server/download.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/download.ts
@@ -2,7 +2,12 @@ import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, basename } from 'node:path';
 
-import { fetchArtifactMetadata, getDownloadUrl } from './api-client.js';
+import {
+  ARTIFACT_TRANSFER_TIMEOUT_MS,
+  fetchArtifactMetadata,
+  fetchWithTimeout,
+  getDownloadUrl,
+} from './api-client.js';
 import { errorResult, successResult, catchError } from './tool-result.js';
 import type { ArtifactConfig, ToolResult } from './types.js';
 
@@ -23,7 +28,14 @@ export async function handleDownload(
 
     const urlData = await getDownloadUrl(config, metadata.id, metadata.taskId);
 
-    const downloadResponse = await fetch(urlData.url);
+    const downloadResponse = await fetchWithTimeout(
+      urlData.url,
+      {},
+      {
+        label: 'Failed to download artifact',
+        timeoutMs: ARTIFACT_TRANSFER_TIMEOUT_MS,
+      },
+    );
     if (!downloadResponse.ok) {
       return errorResult(
         `Failed to download from S3: ${downloadResponse.status} ${downloadResponse.statusText}`,

--- a/apps/worker/src/mcp/roomote-mcp-server/tasks-api-client.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/tasks-api-client.ts
@@ -1,4 +1,8 @@
-import { buildApiHeaders, parseApiError } from './api-client.js';
+import {
+  buildApiHeaders,
+  fetchWithTimeout,
+  parseApiError,
+} from './api-client.js';
 import type {
   AutomationWorkItemDisposition,
   SourceControlProvider,
@@ -37,12 +41,16 @@ async function apiFetch<T>(
   options: RequestInit = {},
   errorPrefix: string,
 ): Promise<T> {
-  const response = await fetch(`${config.platformApiUrl}${path}`, {
-    ...options,
-    headers: buildApiHeaders(config, {
-      ...(options.headers as Record<string, string> | undefined),
-    }),
-  });
+  const response = await fetchWithTimeout(
+    `${config.platformApiUrl}${path}`,
+    {
+      ...options,
+      headers: buildApiHeaders(config, {
+        ...(options.headers as Record<string, string> | undefined),
+      }),
+    },
+    { label: errorPrefix },
+  );
 
   if (!response.ok) {
     const error = await parseApiError(response);


### PR DESCRIPTION
## Incident

Openmote task `2o885wsfv775m` went non-responsive **for 61 minutes inside a `manage_source_control` / `create_or_update_pull_request` call** (05:17:56 UTC), produced nothing until the user stopped it, then **wedged again the same way 30 seconds after being revived** (06:21:14 UTC). Other tasks were making successful MCP calls one minute after the wedge, so the API wasn't down — the individual request just never got a response.

## Root cause (client side)

Every platform-API request from the sandbox's roomote MCP server is a **bare `fetch` with no deadline and no AbortSignal**. A request that never gets a response — API instance stall, half-open connection through a restart/deploy — hangs the MCP tool call, and OpenCode waits on the tool indefinitely. MCP calls are exactly the tool kind nothing else bounds: shell tools carry their own timeout, but an in-flight MCP call suspends even the subagent inactivity watchdog. Result: the whole task sits silently "running" until a human intervenes.

(The server-side trigger — why that specific request stalled, twice, targeting the same existing PR while everything else was healthy — is still open; it needs API logs / `pg_locks` on the affected deployment. The window coincides with the #45 data-model deploy. This PR removes the unbounded-hang failure mode regardless of the trigger.)

## Change

- New `fetchWithTimeout` in the shared `api-client`:
  - control-plane calls: generous **2-minute** ceiling, overridable via `ROOMOTE_MCP_PLATFORM_API_TIMEOUT_MS`
  - artifact/S3 transfers (upload, download): **10-minute** ceiling
  - expiry surfaces as a normal retryable tool error ("no response from the Roomote API within Nms; … safe to retry"), so the agent retries instead of the task wedging
  - composes with caller-provided signals via `AbortSignal.any`; non-timeout failures pass through unchanged
- Routed all fetches through it: `tasks-api-client.ts` (incl. the incident path), `api-client.ts`, `chat-api-client.ts`, `download.ts`. No bare `fetch` remains in `roomote-mcp-server/`.

## Tests

- `fetchWithTimeout`: never-responding fetch → retryable error; explicit `timeoutMs` precedence; non-timeout error passthrough; caller-abort stays an `AbortError`; success passthrough; env-var parsing.
- Regression test through the incident path: `manageSourceControl` with a stalled API fails with the retryable message instead of hanging.
- Full `src/mcp/` suite: **265 tests pass**; typecheck / eslint / prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)