### PR TITLE
[Fix] Let active subagents run without a hard timeout

### DIFF
--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server-subagent-watchdog.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server-subagent-watchdog.test.ts
@@ -76,7 +76,8 @@ function createHarness(
     logger,
     model: TEST_OPENCODE_MODEL,
     eventStreamReadyTimeoutMs: 100,
-    subagentTaskTimeoutMs: SUBAGENT_TASK_TIMEOUT_MS,
+    subagentTaskUnobservedTimeoutMs: SUBAGENT_TASK_TIMEOUT_MS,
+    subagentTaskInactivityTimeoutMs: SUBAGENT_TASK_TIMEOUT_MS,
     ...overrides,
   });
 
@@ -206,7 +207,7 @@ describe('OpenCode subagent watchdog', () => {
     vi.useRealTimers();
   });
 
-  it('aborts the child session recorded on the task tool part when the timeout expires', async () => {
+  it('aborts the child session recorded on the task tool part when it becomes inactive', async () => {
     const { client, harness, logger } = createHarness();
 
     try {
@@ -244,7 +245,7 @@ describe('OpenCode subagent watchdog', () => {
         expect.objectContaining({ sessionId: 'ses_1' }),
       );
       expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('subagent run exceeded'),
+        expect.stringContaining('stalled with no child-session events'),
       );
     } finally {
       harness.dispose();
@@ -268,7 +269,18 @@ describe('OpenCode subagent watchdog', () => {
         properties: { part: createTaskToolPart({ status: 'pending' }) },
       });
 
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS);
+      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS / 2);
+      await client.emit({
+        type: 'message.part.updated',
+        properties: { part: createTaskToolPart({ status: 'pending' }) },
+      });
+      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS / 2);
+
+      // Parent-side progress keeps an unobservable launch alive too.
+      expect(client.children).not.toHaveBeenCalled();
+      expect(client.abort).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS / 2);
 
       expect(client.children).toHaveBeenCalledTimes(1);
       expect(client.children).toHaveBeenCalledWith(
@@ -323,7 +335,8 @@ describe('OpenCode subagent watchdog', () => {
         { id: 'ses_child_B', parentID: 'ses_1' },
       ]);
 
-      // Advance to A's total-timeout deadline (B still has half a window left).
+      // Advance to A's unobservable-launch deadline (B still has half a
+      // window left).
       await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS / 2);
 
       expect(client.children).toHaveBeenCalledTimes(1);
@@ -402,8 +415,8 @@ describe('OpenCode subagent watchdog', () => {
         properties: { part: createTaskToolPart({ status: 'pending' }) },
       });
       await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS / 2);
-      // Second update: running with the child session id. Must not reset or
-      // duplicate the timer, but must record the child session id.
+      // Second update: running with the child session id. Must not duplicate
+      // the timer, and its observed progress slides the inactivity deadline.
       await client.emit({
         type: 'message.part.updated',
         properties: {
@@ -416,6 +429,10 @@ describe('OpenCode subagent watchdog', () => {
       await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS / 2);
 
       expect(client.children).not.toHaveBeenCalled();
+      expect(client.abort).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS / 2);
+
       expect(client.abort).toHaveBeenCalledTimes(1);
       expect(client.abort).toHaveBeenCalledWith(
         expect.objectContaining({ sessionId: 'ses_child_1' }),
@@ -1081,20 +1098,20 @@ describe('OpenCode subagent inactivity deadline', () => {
     }
   });
 
-  it('keeps an active child alive past the inactivity window and still enforces the total timeout', async () => {
-    const { client, harness, logger } = createInactivityHarness();
+  it('keeps an active child alive indefinitely while it continues emitting events', async () => {
+    const { client, harness } = createInactivityHarness();
 
     try {
       await connectHarness(harness, client);
       vi.useFakeTimers();
       await armSpawn(client, harness);
 
-      // Child streams an event every half inactivity window until just
-      // before the total timeout.
+      // Child streams an event every half inactivity window for well beyond
+      // the old wall-clock deadline.
       const stepMs = SUBAGENT_INACTIVITY_TIMEOUT_MS / 2;
       for (
         let elapsedMs = stepMs;
-        elapsedMs < SUBAGENT_TASK_TIMEOUT_MS;
+        elapsedMs < SUBAGENT_TASK_TIMEOUT_MS * 2;
         elapsedMs += stepMs
       ) {
         await vi.advanceTimersByTimeAsync(stepMs);
@@ -1105,19 +1122,12 @@ describe('OpenCode subagent inactivity deadline', () => {
       }
 
       expect(client.abort).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(stepMs);
-
-      expect(client.abort).toHaveBeenCalledTimes(1);
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('exceeded the'),
-      );
     } finally {
       await harness.dispose();
     }
   });
 
-  it('suspends the inactivity deadline while a child tool call is in flight', async () => {
+  it('does not impose a wall-clock timeout while a child tool call is in flight', async () => {
     const { client, harness } = createInactivityHarness();
 
     try {
@@ -1125,8 +1135,7 @@ describe('OpenCode subagent inactivity deadline', () => {
       vi.useFakeTimers();
       await armSpawn(client, harness);
 
-      // A silently long-running tool must not be mistaken for a wedged
-      // child: only the total timeout applies while it is in flight.
+      // A silently long-running tool must not be mistaken for a wedged child.
       await client.emit({
         type: 'message.part.updated',
         properties: {
@@ -1134,11 +1143,8 @@ describe('OpenCode subagent inactivity deadline', () => {
         },
       });
 
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS - 1);
+      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS * 2);
       expect(client.abort).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(1);
-      expect(client.abort).toHaveBeenCalledTimes(1);
     } finally {
       await harness.dispose();
     }
@@ -1201,11 +1207,8 @@ describe('OpenCode subagent inactivity deadline', () => {
         },
       });
 
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS - 1);
+      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS * 2);
       expect(client.abort).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(1);
-      expect(client.abort).toHaveBeenCalledTimes(1);
     } finally {
       await harness.dispose();
     }
@@ -1226,11 +1229,8 @@ describe('OpenCode subagent inactivity deadline', () => {
         },
       });
 
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS - 1);
+      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS * 2);
       expect(client.abort).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(1);
-      expect(client.abort).toHaveBeenCalledTimes(1);
     } finally {
       await harness.dispose();
     }
@@ -1254,11 +1254,8 @@ describe('OpenCode subagent inactivity deadline', () => {
         properties: { part },
       });
 
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS - 1);
+      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS * 2);
       expect(client.abort).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(1);
-      expect(client.abort).toHaveBeenCalledTimes(1);
     } finally {
       await harness.dispose();
     }
@@ -1309,7 +1306,7 @@ describe('OpenCode subagent inactivity deadline', () => {
       vi.useFakeTimers();
 
       // Spawn with no child session id: there is no activity feed to judge
-      // liveness by, so only the total timeout applies.
+      // liveness by, so the unobservable-launch fallback applies.
       await client.emit({
         type: 'message.part.updated',
         properties: { part: createTaskToolPart({ status: 'pending' }) },

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
@@ -81,7 +81,7 @@ interface OpenCodeServerHarnessOptions {
   eventStreamReadyTimeoutMs?: number;
   executeToolProgressInitialDelayMs?: number;
   executeToolProgressIntervalMs?: number;
-  subagentTaskTimeoutMs?: number;
+  subagentTaskUnobservedTimeoutMs?: number;
   subagentTaskInactivityTimeoutMs?: number;
   stopHookReminderStallTimeoutMs?: number;
   queuedPromptRetryDelayMs?: number;
@@ -202,10 +202,9 @@ interface ActiveOpenCodeSubagentWatchdog {
   // flight the inactivity deadline is suspended: a silently running tool is
   // indistinguishable from a hung one by event flow alone. OpenCode's shell
   // tool bounds that state itself (default 2-minute timeout that kills the
-  // command and emits a terminal tool event); other tool kinds (MCP calls,
-  // webfetch, nested task spawns) are not self-bounding, so a hang inside
-  // one falls back to the total timeout — a deliberate trade-off, since a
-  // wrong kill of legitimate slow work is worse than a slow abort.
+  // command and emits a terminal tool event). Other tool kinds can run for as
+  // long as they need; once their terminal event arrives, the inactivity
+  // deadline resumes.
   activeChildToolCallIds: Set<string>;
   timer: ReturnType<typeof setTimeout>;
   updatePayload: Record<string, unknown>;
@@ -231,18 +230,17 @@ const OPENCODE_STOP_HOOK_REMINDER_STALL_TIMEOUT_MS = 10 * 60_000;
 const EXPECTED_REPLAY_ABORT_SUPPRESSION_MS = 10_000;
 const DEFAULT_EXECUTE_TOOL_PROGRESS_INITIAL_DELAY_MS = 15_000;
 const DEFAULT_EXECUTE_TOOL_PROGRESS_INTERVAL_MS = 30_000;
-// Kill switch for runaway subagent runs: a subagent that produces no terminal
-// signal within this window is presumed dead and its child sessions are
-// aborted so the parent turn can continue instead of hanging silently. Sized
-// for large review/audit subagents that legitimately read hundreds of files;
-// 12 minutes was too tight and killed in-progress work (the sliding inactivity
-// deadline below is the primary wedge detector, so this only backstops a child
-// that stays superficially active but never terminates).
-const DEFAULT_SUBAGENT_TASK_TIMEOUT_MS = 30 * 60_000;
+// Backstop for an unobservable subagent launch: if OpenCode never exposes a
+// child session id, Roomote has no child event stream with which to assess
+// liveness. Parent task-part updates slide this deadline while the launch is
+// making observable progress. Once a child session id is known, this fallback
+// no longer applies; working subagents have no wall-clock timeout.
+const DEFAULT_SUBAGENT_TASK_UNOBSERVED_TIMEOUT_MS = 30 * 60_000;
 // Sliding inactivity deadline for subagent runs: once the child session is
 // known, every event it emits (streamed text, tool state, message completion)
 // counts as liveness. A child that goes silent for this window is presumed
-// wedged and aborted without waiting for the total timeout above. Only
+// wedged and aborted without waiting for the unobservable-launch fallback
+// above. Only
 // enforced when it is a strong signal: the child session id must be known
 // (otherwise there is no activity feed to judge by) and no child tool call
 // may be in flight (a legitimately silent long-running tool is
@@ -1445,7 +1443,7 @@ export class OpenCodeServerHarness
   private readonly eventStreamReadyTimeoutMs: number;
   private readonly executeToolProgressInitialDelayMs: number;
   private readonly executeToolProgressIntervalMs: number;
-  private readonly subagentTaskTimeoutMs: number;
+  private readonly subagentTaskUnobservedTimeoutMs: number;
   private readonly subagentTaskInactivityTimeoutMs: number;
   private readonly stopHookReminderStallTimeoutMs: number;
   private readonly queuedPromptRetryDelayMs: number;
@@ -1536,8 +1534,9 @@ export class OpenCodeServerHarness
     this.executeToolProgressIntervalMs =
       options.executeToolProgressIntervalMs ??
       DEFAULT_EXECUTE_TOOL_PROGRESS_INTERVAL_MS;
-    this.subagentTaskTimeoutMs =
-      options.subagentTaskTimeoutMs ?? DEFAULT_SUBAGENT_TASK_TIMEOUT_MS;
+    this.subagentTaskUnobservedTimeoutMs =
+      options.subagentTaskUnobservedTimeoutMs ??
+      DEFAULT_SUBAGENT_TASK_UNOBSERVED_TIMEOUT_MS;
     this.subagentTaskInactivityTimeoutMs =
       options.subagentTaskInactivityTimeoutMs ??
       DEFAULT_SUBAGENT_TASK_INACTIVITY_TIMEOUT_MS;
@@ -2263,7 +2262,7 @@ export class OpenCodeServerHarness
         eventKey,
         Math.min(
           this.subagentTaskInactivityTimeoutMs,
-          this.subagentTaskTimeoutMs,
+          this.subagentTaskUnobservedTimeoutMs,
         ),
       ),
       updatePayload: input.updatePayload,
@@ -2276,7 +2275,7 @@ export class OpenCodeServerHarness
       this.childSessionWatchdogKeys.set(input.childSessionId, eventKey);
     }
     this.logger.info(
-      `Armed OpenCode subagent watchdog timeoutMs=${this.subagentTaskTimeoutMs} inactivityTimeoutMs=${this.subagentTaskInactivityTimeoutMs} toolCallId=${input.toolCallId} agentType=${
+      `Armed OpenCode subagent watchdog unobservedTimeoutMs=${this.subagentTaskUnobservedTimeoutMs} inactivityTimeoutMs=${this.subagentTaskInactivityTimeoutMs} toolCallId=${input.toolCallId} agentType=${
         input.agentType ?? 'unknown'
       } childSessionId=${input.childSessionId ?? 'pending'}`,
     );
@@ -2302,7 +2301,8 @@ export class OpenCodeServerHarness
    * tool call is in flight (see `activeChildToolCallIds`). While it is not
    * enforceable, the timer keeps waking at the inactivity interval so a tool
    * completion followed by silence is still caught one idle window after the
-   * completion event, and the total timeout always applies.
+   * completion event. The longer fallback deadline applies only before a child
+   * session id is known; observable child sessions have no wall-clock cap.
    */
   private async handleSubagentWatchdogDeadline(
     eventKey: string,
@@ -2317,18 +2317,22 @@ export class OpenCodeServerHarness
     const elapsedMs = nowMs - watchdog.startedAtMs;
     const idleMs = nowMs - watchdog.lastActivityAtMs;
 
-    if (elapsedMs >= this.subagentTaskTimeoutMs) {
+    const childSessionObservable = watchdog.childSessionId !== null;
+
+    if (
+      !childSessionObservable &&
+      idleMs >= this.subagentTaskUnobservedTimeoutMs
+    ) {
       await this.expireSubagentWatchdog(
         eventKey,
         watchdog,
-        `exceeded the ${this.subagentTaskTimeoutMs}ms watchdog timeout (elapsed=${elapsedMs}ms)`,
+        `remained unobservable for ${idleMs}ms without a child session id (limit ${this.subagentTaskUnobservedTimeoutMs}ms, elapsed=${elapsedMs}ms)`,
       );
       return;
     }
 
     const idleEnforceable =
-      watchdog.childSessionId !== null &&
-      watchdog.activeChildToolCallIds.size === 0;
+      childSessionObservable && watchdog.activeChildToolCallIds.size === 0;
 
     if (idleEnforceable && idleMs >= this.subagentTaskInactivityTimeoutMs) {
       await this.expireSubagentWatchdog(
@@ -2339,14 +2343,16 @@ export class OpenCodeServerHarness
       return;
     }
 
-    const remainingTotalMs = this.subagentTaskTimeoutMs - elapsedMs;
     const remainingIdleMs = idleEnforceable
       ? this.subagentTaskInactivityTimeoutMs - idleMs
       : this.subagentTaskInactivityTimeoutMs;
+    const remainingUnobservedMs = childSessionObservable
+      ? this.subagentTaskInactivityTimeoutMs
+      : this.subagentTaskUnobservedTimeoutMs - idleMs;
 
     watchdog.timer = this.armSubagentWatchdogTimer(
       eventKey,
-      Math.min(remainingTotalMs, remainingIdleMs),
+      Math.min(remainingUnobservedMs, remainingIdleMs),
     );
   }
 

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/start.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/start.ts
@@ -278,8 +278,12 @@ export async function startOpenCodeServerHarness({
       commandEnv,
       initialSessionId,
       model,
-      subagentTaskTimeoutMs: parseTimeoutMs(
-        process.env.ROOMOTE_SUBAGENT_TASK_TIMEOUT_MS,
+      // Keep the old variable as a compatibility alias, but it now bounds
+      // only launches that never expose a child session id. Observable
+      // subagents are governed solely by the sliding inactivity deadline.
+      subagentTaskUnobservedTimeoutMs: parseTimeoutMs(
+        process.env.ROOMOTE_SUBAGENT_TASK_UNOBSERVED_TIMEOUT_MS ??
+          process.env.ROOMOTE_SUBAGENT_TASK_TIMEOUT_MS,
       ),
       subagentTaskInactivityTimeoutMs: parseTimeoutMs(
         process.env.ROOMOTE_SUBAGENT_TASK_INACTIVITY_TIMEOUT_MS,


### PR DESCRIPTION
## Summary

- remove the absolute wall-clock timeout from observable OpenCode subagents
- keep the sliding inactivity watchdog for children that stop emitting events
- suspend inactivity enforcement while a child tool call is in flight
- retain a sliding fallback only for launches that never expose a child session ID
- add `ROOMOTE_SUBAGENT_TASK_UNOBSERVED_TIMEOUT_MS`, with the old timeout variable retained as a compatibility alias for that fallback

## Validation

- `pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/worker exec vitest run src/sandbox-server/lib/harnesses/__tests__/opencode-server-subagent-watchdog.test.ts` (30 tests)
- `pnpm --filter @roomote/worker check-types`
- `pnpm --filter @roomote/worker lint`
- `pnpm lint:fast`
- `pnpm check-types:fast`
- `pnpm knip` — fails on existing develop findings in unrelated packages; no finding references this change
