### PR TITLE
Revert "[Fix] Let active subagents run without a hard timeout" (#86)

### DIFF
--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server-subagent-watchdog.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server-subagent-watchdog.test.ts
@@ -76,8 +76,7 @@ function createHarness(
     logger,
     model: TEST_OPENCODE_MODEL,
     eventStreamReadyTimeoutMs: 100,
-    subagentTaskUnobservedTimeoutMs: SUBAGENT_TASK_TIMEOUT_MS,
-    subagentTaskInactivityTimeoutMs: SUBAGENT_TASK_TIMEOUT_MS,
+    subagentTaskTimeoutMs: SUBAGENT_TASK_TIMEOUT_MS,
     ...overrides,
   });
 
@@ -207,7 +206,7 @@ describe('OpenCode subagent watchdog', () => {
     vi.useRealTimers();
   });
 
-  it('aborts the child session recorded on the task tool part when it becomes inactive', async () => {
+  it('aborts the child session recorded on the task tool part when the timeout expires', async () => {
     const { client, harness, logger } = createHarness();
 
     try {
@@ -245,7 +244,7 @@ describe('OpenCode subagent watchdog', () => {
         expect.objectContaining({ sessionId: 'ses_1' }),
       );
       expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('stalled with no child-session events'),
+        expect.stringContaining('subagent run exceeded'),
       );
     } finally {
       harness.dispose();
@@ -269,18 +268,7 @@ describe('OpenCode subagent watchdog', () => {
         properties: { part: createTaskToolPart({ status: 'pending' }) },
       });
 
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS / 2);
-      await client.emit({
-        type: 'message.part.updated',
-        properties: { part: createTaskToolPart({ status: 'pending' }) },
-      });
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS / 2);
-
-      // Parent-side progress keeps an unobservable launch alive too.
-      expect(client.children).not.toHaveBeenCalled();
-      expect(client.abort).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS / 2);
+      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS);
 
       expect(client.children).toHaveBeenCalledTimes(1);
       expect(client.children).toHaveBeenCalledWith(
@@ -335,8 +323,7 @@ describe('OpenCode subagent watchdog', () => {
         { id: 'ses_child_B', parentID: 'ses_1' },
       ]);
 
-      // Advance to A's unobservable-launch deadline (B still has half a
-      // window left).
+      // Advance to A's total-timeout deadline (B still has half a window left).
       await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS / 2);
 
       expect(client.children).toHaveBeenCalledTimes(1);
@@ -415,8 +402,8 @@ describe('OpenCode subagent watchdog', () => {
         properties: { part: createTaskToolPart({ status: 'pending' }) },
       });
       await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS / 2);
-      // Second update: running with the child session id. Must not duplicate
-      // the timer, and its observed progress slides the inactivity deadline.
+      // Second update: running with the child session id. Must not reset or
+      // duplicate the timer, but must record the child session id.
       await client.emit({
         type: 'message.part.updated',
         properties: {
@@ -429,10 +416,6 @@ describe('OpenCode subagent watchdog', () => {
       await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS / 2);
 
       expect(client.children).not.toHaveBeenCalled();
-      expect(client.abort).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS / 2);
-
       expect(client.abort).toHaveBeenCalledTimes(1);
       expect(client.abort).toHaveBeenCalledWith(
         expect.objectContaining({ sessionId: 'ses_child_1' }),
@@ -1098,20 +1081,20 @@ describe('OpenCode subagent inactivity deadline', () => {
     }
   });
 
-  it('keeps an active child alive indefinitely while it continues emitting events', async () => {
-    const { client, harness } = createInactivityHarness();
+  it('keeps an active child alive past the inactivity window and still enforces the total timeout', async () => {
+    const { client, harness, logger } = createInactivityHarness();
 
     try {
       await connectHarness(harness, client);
       vi.useFakeTimers();
       await armSpawn(client, harness);
 
-      // Child streams an event every half inactivity window for well beyond
-      // the old wall-clock deadline.
+      // Child streams an event every half inactivity window until just
+      // before the total timeout.
       const stepMs = SUBAGENT_INACTIVITY_TIMEOUT_MS / 2;
       for (
         let elapsedMs = stepMs;
-        elapsedMs < SUBAGENT_TASK_TIMEOUT_MS * 2;
+        elapsedMs < SUBAGENT_TASK_TIMEOUT_MS;
         elapsedMs += stepMs
       ) {
         await vi.advanceTimersByTimeAsync(stepMs);
@@ -1122,12 +1105,19 @@ describe('OpenCode subagent inactivity deadline', () => {
       }
 
       expect(client.abort).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(stepMs);
+
+      expect(client.abort).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('exceeded the'),
+      );
     } finally {
       await harness.dispose();
     }
   });
 
-  it('does not impose a wall-clock timeout while a child tool call is in flight', async () => {
+  it('suspends the inactivity deadline while a child tool call is in flight', async () => {
     const { client, harness } = createInactivityHarness();
 
     try {
@@ -1135,7 +1125,8 @@ describe('OpenCode subagent inactivity deadline', () => {
       vi.useFakeTimers();
       await armSpawn(client, harness);
 
-      // A silently long-running tool must not be mistaken for a wedged child.
+      // A silently long-running tool must not be mistaken for a wedged
+      // child: only the total timeout applies while it is in flight.
       await client.emit({
         type: 'message.part.updated',
         properties: {
@@ -1143,8 +1134,11 @@ describe('OpenCode subagent inactivity deadline', () => {
         },
       });
 
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS * 2);
+      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS - 1);
       expect(client.abort).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(client.abort).toHaveBeenCalledTimes(1);
     } finally {
       await harness.dispose();
     }
@@ -1207,8 +1201,11 @@ describe('OpenCode subagent inactivity deadline', () => {
         },
       });
 
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS * 2);
+      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS - 1);
       expect(client.abort).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(client.abort).toHaveBeenCalledTimes(1);
     } finally {
       await harness.dispose();
     }
@@ -1229,8 +1226,11 @@ describe('OpenCode subagent inactivity deadline', () => {
         },
       });
 
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS * 2);
+      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS - 1);
       expect(client.abort).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(client.abort).toHaveBeenCalledTimes(1);
     } finally {
       await harness.dispose();
     }
@@ -1254,8 +1254,11 @@ describe('OpenCode subagent inactivity deadline', () => {
         properties: { part },
       });
 
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS * 2);
+      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS - 1);
       expect(client.abort).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(client.abort).toHaveBeenCalledTimes(1);
     } finally {
       await harness.dispose();
     }
@@ -1306,7 +1309,7 @@ describe('OpenCode subagent inactivity deadline', () => {
       vi.useFakeTimers();
 
       // Spawn with no child session id: there is no activity feed to judge
-      // liveness by, so the unobservable-launch fallback applies.
+      // liveness by, so only the total timeout applies.
       await client.emit({
         type: 'message.part.updated',
         properties: { part: createTaskToolPart({ status: 'pending' }) },

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
@@ -81,7 +81,7 @@ interface OpenCodeServerHarnessOptions {
   eventStreamReadyTimeoutMs?: number;
   executeToolProgressInitialDelayMs?: number;
   executeToolProgressIntervalMs?: number;
-  subagentTaskUnobservedTimeoutMs?: number;
+  subagentTaskTimeoutMs?: number;
   subagentTaskInactivityTimeoutMs?: number;
   stopHookReminderStallTimeoutMs?: number;
   queuedPromptRetryDelayMs?: number;
@@ -202,9 +202,10 @@ interface ActiveOpenCodeSubagentWatchdog {
   // flight the inactivity deadline is suspended: a silently running tool is
   // indistinguishable from a hung one by event flow alone. OpenCode's shell
   // tool bounds that state itself (default 2-minute timeout that kills the
-  // command and emits a terminal tool event). Other tool kinds can run for as
-  // long as they need; once their terminal event arrives, the inactivity
-  // deadline resumes.
+  // command and emits a terminal tool event); other tool kinds (MCP calls,
+  // webfetch, nested task spawns) are not self-bounding, so a hang inside
+  // one falls back to the total timeout — a deliberate trade-off, since a
+  // wrong kill of legitimate slow work is worse than a slow abort.
   activeChildToolCallIds: Set<string>;
   timer: ReturnType<typeof setTimeout>;
   updatePayload: Record<string, unknown>;
@@ -230,17 +231,18 @@ const OPENCODE_STOP_HOOK_REMINDER_STALL_TIMEOUT_MS = 10 * 60_000;
 const EXPECTED_REPLAY_ABORT_SUPPRESSION_MS = 10_000;
 const DEFAULT_EXECUTE_TOOL_PROGRESS_INITIAL_DELAY_MS = 15_000;
 const DEFAULT_EXECUTE_TOOL_PROGRESS_INTERVAL_MS = 30_000;
-// Backstop for an unobservable subagent launch: if OpenCode never exposes a
-// child session id, Roomote has no child event stream with which to assess
-// liveness. Parent task-part updates slide this deadline while the launch is
-// making observable progress. Once a child session id is known, this fallback
-// no longer applies; working subagents have no wall-clock timeout.
-const DEFAULT_SUBAGENT_TASK_UNOBSERVED_TIMEOUT_MS = 30 * 60_000;
+// Kill switch for runaway subagent runs: a subagent that produces no terminal
+// signal within this window is presumed dead and its child sessions are
+// aborted so the parent turn can continue instead of hanging silently. Sized
+// for large review/audit subagents that legitimately read hundreds of files;
+// 12 minutes was too tight and killed in-progress work (the sliding inactivity
+// deadline below is the primary wedge detector, so this only backstops a child
+// that stays superficially active but never terminates).
+const DEFAULT_SUBAGENT_TASK_TIMEOUT_MS = 30 * 60_000;
 // Sliding inactivity deadline for subagent runs: once the child session is
 // known, every event it emits (streamed text, tool state, message completion)
 // counts as liveness. A child that goes silent for this window is presumed
-// wedged and aborted without waiting for the unobservable-launch fallback
-// above. Only
+// wedged and aborted without waiting for the total timeout above. Only
 // enforced when it is a strong signal: the child session id must be known
 // (otherwise there is no activity feed to judge by) and no child tool call
 // may be in flight (a legitimately silent long-running tool is
@@ -1443,7 +1445,7 @@ export class OpenCodeServerHarness
   private readonly eventStreamReadyTimeoutMs: number;
   private readonly executeToolProgressInitialDelayMs: number;
   private readonly executeToolProgressIntervalMs: number;
-  private readonly subagentTaskUnobservedTimeoutMs: number;
+  private readonly subagentTaskTimeoutMs: number;
   private readonly subagentTaskInactivityTimeoutMs: number;
   private readonly stopHookReminderStallTimeoutMs: number;
   private readonly queuedPromptRetryDelayMs: number;
@@ -1534,9 +1536,8 @@ export class OpenCodeServerHarness
     this.executeToolProgressIntervalMs =
       options.executeToolProgressIntervalMs ??
       DEFAULT_EXECUTE_TOOL_PROGRESS_INTERVAL_MS;
-    this.subagentTaskUnobservedTimeoutMs =
-      options.subagentTaskUnobservedTimeoutMs ??
-      DEFAULT_SUBAGENT_TASK_UNOBSERVED_TIMEOUT_MS;
+    this.subagentTaskTimeoutMs =
+      options.subagentTaskTimeoutMs ?? DEFAULT_SUBAGENT_TASK_TIMEOUT_MS;
     this.subagentTaskInactivityTimeoutMs =
       options.subagentTaskInactivityTimeoutMs ??
       DEFAULT_SUBAGENT_TASK_INACTIVITY_TIMEOUT_MS;
@@ -2262,7 +2263,7 @@ export class OpenCodeServerHarness
         eventKey,
         Math.min(
           this.subagentTaskInactivityTimeoutMs,
-          this.subagentTaskUnobservedTimeoutMs,
+          this.subagentTaskTimeoutMs,
         ),
       ),
       updatePayload: input.updatePayload,
@@ -2275,7 +2276,7 @@ export class OpenCodeServerHarness
       this.childSessionWatchdogKeys.set(input.childSessionId, eventKey);
     }
     this.logger.info(
-      `Armed OpenCode subagent watchdog unobservedTimeoutMs=${this.subagentTaskUnobservedTimeoutMs} inactivityTimeoutMs=${this.subagentTaskInactivityTimeoutMs} toolCallId=${input.toolCallId} agentType=${
+      `Armed OpenCode subagent watchdog timeoutMs=${this.subagentTaskTimeoutMs} inactivityTimeoutMs=${this.subagentTaskInactivityTimeoutMs} toolCallId=${input.toolCallId} agentType=${
         input.agentType ?? 'unknown'
       } childSessionId=${input.childSessionId ?? 'pending'}`,
     );
@@ -2301,8 +2302,7 @@ export class OpenCodeServerHarness
    * tool call is in flight (see `activeChildToolCallIds`). While it is not
    * enforceable, the timer keeps waking at the inactivity interval so a tool
    * completion followed by silence is still caught one idle window after the
-   * completion event. The longer fallback deadline applies only before a child
-   * session id is known; observable child sessions have no wall-clock cap.
+   * completion event, and the total timeout always applies.
    */
   private async handleSubagentWatchdogDeadline(
     eventKey: string,
@@ -2317,22 +2317,18 @@ export class OpenCodeServerHarness
     const elapsedMs = nowMs - watchdog.startedAtMs;
     const idleMs = nowMs - watchdog.lastActivityAtMs;
 
-    const childSessionObservable = watchdog.childSessionId !== null;
-
-    if (
-      !childSessionObservable &&
-      idleMs >= this.subagentTaskUnobservedTimeoutMs
-    ) {
+    if (elapsedMs >= this.subagentTaskTimeoutMs) {
       await this.expireSubagentWatchdog(
         eventKey,
         watchdog,
-        `remained unobservable for ${idleMs}ms without a child session id (limit ${this.subagentTaskUnobservedTimeoutMs}ms, elapsed=${elapsedMs}ms)`,
+        `exceeded the ${this.subagentTaskTimeoutMs}ms watchdog timeout (elapsed=${elapsedMs}ms)`,
       );
       return;
     }
 
     const idleEnforceable =
-      childSessionObservable && watchdog.activeChildToolCallIds.size === 0;
+      watchdog.childSessionId !== null &&
+      watchdog.activeChildToolCallIds.size === 0;
 
     if (idleEnforceable && idleMs >= this.subagentTaskInactivityTimeoutMs) {
       await this.expireSubagentWatchdog(
@@ -2343,16 +2339,14 @@ export class OpenCodeServerHarness
       return;
     }
 
+    const remainingTotalMs = this.subagentTaskTimeoutMs - elapsedMs;
     const remainingIdleMs = idleEnforceable
       ? this.subagentTaskInactivityTimeoutMs - idleMs
       : this.subagentTaskInactivityTimeoutMs;
-    const remainingUnobservedMs = childSessionObservable
-      ? this.subagentTaskInactivityTimeoutMs
-      : this.subagentTaskUnobservedTimeoutMs - idleMs;
 
     watchdog.timer = this.armSubagentWatchdogTimer(
       eventKey,
-      Math.min(remainingUnobservedMs, remainingIdleMs),
+      Math.min(remainingTotalMs, remainingIdleMs),
     );
   }
 

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/start.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/start.ts
@@ -278,12 +278,8 @@ export async function startOpenCodeServerHarness({
       commandEnv,
       initialSessionId,
       model,
-      // Keep the old variable as a compatibility alias, but it now bounds
-      // only launches that never expose a child session id. Observable
-      // subagents are governed solely by the sliding inactivity deadline.
-      subagentTaskUnobservedTimeoutMs: parseTimeoutMs(
-        process.env.ROOMOTE_SUBAGENT_TASK_UNOBSERVED_TIMEOUT_MS ??
-          process.env.ROOMOTE_SUBAGENT_TASK_TIMEOUT_MS,
+      subagentTaskTimeoutMs: parseTimeoutMs(
+        process.env.ROOMOTE_SUBAGENT_TASK_TIMEOUT_MS,
       ),
       subagentTaskInactivityTimeoutMs: parseTimeoutMs(
         process.env.ROOMOTE_SUBAGENT_TASK_INACTIVITY_TIMEOUT_MS,


### PR DESCRIPTION
Restores the unconditional 30-minute total timeout for subagent runs. #86 scoped the hard timeout to *unobserved* subagents only, leaving an observed-but-looping child unbounded.

The false-positive problem #86 targeted is real, but the killer of healthy subagents is the **3-minute inactivity abort**, not the total timeout — confirmed live on task `1i8cs6lzzc1rm`: a GPT-5.6 Sol review subagent was cancelled at 9m35s during a silent think while both siblings completed normally seconds earlier. Reasoning models legitimately go >3 min between tool calls with no observable events, so "silence between tools = dead" doesn't hold.

Follow-up (separate PR): demote the inactivity abort to a warning log, keeping the 30-min total as the only kill switch — MCP-tool wedges inside children are now independently bounded by #84's fetch timeouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)