### PR TITLE
[Fix] Remove subagent run timeouts

### DIFF
--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server-subagent-watchdog.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server-subagent-watchdog.test.ts
@@ -10,7 +10,9 @@ import type {
 } from '../opencode-server/types';
 
 const TEST_OPENCODE_MODEL = 'test-provider/main-model';
-const SUBAGENT_TASK_TIMEOUT_MS = 60_000;
+// Far beyond any plausible run length: subagent runs are not time-bounded, so
+// nothing may abort even at this horizon.
+const SIX_HOURS_MS = 6 * 60 * 60_000;
 
 class FakeOpenCodeServerClient {
   private eventHandler:
@@ -63,12 +65,7 @@ function createLogger() {
   };
 }
 
-function createHarness(
-  client = new FakeOpenCodeServerClient(),
-  overrides: {
-    subagentTaskInactivityTimeoutMs?: number;
-  } = {},
-) {
+function createHarness(client = new FakeOpenCodeServerClient()) {
   const logger = createLogger();
   const harness = new OpenCodeServerHarness({
     client: client as unknown as OpenCodeServerClient,
@@ -76,8 +73,6 @@ function createHarness(
     logger,
     model: TEST_OPENCODE_MODEL,
     eventStreamReadyTimeoutMs: 100,
-    subagentTaskTimeoutMs: SUBAGENT_TASK_TIMEOUT_MS,
-    ...overrides,
   });
 
   return { client, harness, logger };
@@ -145,18 +140,6 @@ function createSubtaskPart(overrides: Record<string, unknown> = {}) {
   };
 }
 
-const SUBAGENT_INACTIVITY_TIMEOUT_MS = 10_000;
-
-function createChildTextPart(text: string) {
-  return {
-    id: 'prt_child_text_1',
-    sessionID: 'ses_child_1',
-    messageID: 'msg_child_1',
-    type: 'text',
-    text,
-  };
-}
-
 function createChildToolPart(options: {
   callId: string;
   tool?: string;
@@ -201,13 +184,21 @@ async function armSpawn(
   });
 }
 
-describe('OpenCode subagent watchdog', () => {
+function subagentActivityEvents(outputs: Array<Record<string, unknown>>) {
+  return outputs.filter(
+    (event) =>
+      (event.payload as Record<string, unknown>)?.progressKind ===
+      'subagent_activity',
+  );
+}
+
+describe('OpenCode subagent run tracking', () => {
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it('aborts the child session recorded on the task tool part when the timeout expires', async () => {
-    const { client, harness, logger } = createHarness();
+  it('never aborts a foreground child, no matter how long it runs', async () => {
+    const { client, harness } = createHarness();
 
     try {
       await connectHarness(harness, client);
@@ -218,160 +209,141 @@ describe('OpenCode subagent watchdog', () => {
         properties: {
           part: createTaskToolPart({
             status: 'running',
-            metadata: {
-              sessionId: 'ses_child_1',
-              parentSessionId: 'ses_1',
-            },
+            metadata: { sessionId: 'ses_child_1', parentSessionId: 'ses_1' },
           }),
         },
       });
 
-      // Just before the timeout nothing happens.
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS - 1);
+      await vi.advanceTimersByTimeAsync(SIX_HOURS_MS);
+
       expect(client.abort).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(1);
-
-      // The child session id came from the part metadata, so no children()
-      // lookup is needed.
       expect(client.children).not.toHaveBeenCalled();
-      expect(client.abort).toHaveBeenCalledTimes(1);
-      expect(client.abort).toHaveBeenCalledWith(
-        expect.objectContaining({ sessionId: 'ses_child_1' }),
-      );
-      // Never abort the parent session.
-      expect(client.abort).not.toHaveBeenCalledWith(
-        expect.objectContaining({ sessionId: 'ses_1' }),
-      );
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('subagent run exceeded'),
-      );
     } finally {
       harness.dispose();
     }
   });
 
-  it('falls back to listing children when the task tool part has no child session id', async () => {
+  it('never aborts a spawn whose child session id is unknown', async () => {
     const { client, harness } = createHarness();
 
     try {
       await connectHarness(harness, client);
       vi.useFakeTimers();
-
-      client.children.mockResolvedValueOnce([
-        { id: 'child_1', parentID: 'ses_1' },
-        { id: 'child_2', parentID: 'ses_1' },
-      ]);
 
       await client.emit({
         type: 'message.part.updated',
         properties: { part: createTaskToolPart({ status: 'pending' }) },
       });
 
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS);
+      await vi.advanceTimersByTimeAsync(SIX_HOURS_MS);
 
-      expect(client.children).toHaveBeenCalledTimes(1);
-      expect(client.children).toHaveBeenCalledWith(
-        expect.objectContaining({ sessionId: 'ses_1' }),
-      );
-      expect(client.abort).toHaveBeenCalledTimes(2);
-      expect(client.abort).toHaveBeenCalledWith(
-        expect.objectContaining({ sessionId: 'child_1' }),
-      );
-      expect(client.abort).toHaveBeenCalledWith(
-        expect.objectContaining({ sessionId: 'child_2' }),
-      );
+      expect(client.abort).not.toHaveBeenCalled();
+      expect(client.children).not.toHaveBeenCalled();
     } finally {
       harness.dispose();
     }
   });
 
-  it('does not abort sibling child sessions still owned by a live watchdog', async () => {
+  it('never aborts a child that goes silent between tools', async () => {
+    const { client, harness } = createHarness();
+
+    try {
+      await connectHarness(harness, client);
+      vi.useFakeTimers();
+      await armSpawn(client, harness);
+
+      await client.emit({
+        type: 'message.part.updated',
+        properties: {
+          part: createChildToolPart({ callId: 'c1', command: 'pnpm build' }),
+        },
+      });
+      await client.emit({
+        type: 'message.part.updated',
+        properties: {
+          part: createChildToolPart({ callId: 'c1', status: 'completed' }),
+        },
+      });
+
+      // Silence after the completed tool: a reasoning model may think for a
+      // long stretch without emitting any events. Nothing may kill it.
+      await vi.advanceTimersByTimeAsync(SIX_HOURS_MS);
+
+      expect(client.abort).not.toHaveBeenCalled();
+      expect(client.children).not.toHaveBeenCalled();
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('never aborts subtask-part spawns', async () => {
     const { client, harness } = createHarness();
 
     try {
       await connectHarness(harness, client);
       vi.useFakeTimers();
 
-      // Watchdog A: no child session id ever captured, so its expiry takes the
-      // list-all-children fallback.
       await client.emit({
         type: 'message.part.updated',
-        properties: {
-          part: createTaskToolPart({ status: 'pending', callId: 'call_A' }),
-        },
+        properties: { part: createSubtaskPart() },
       });
 
-      // Watchdog B is armed half a window later, so at A's deadline B is still
-      // live (its own deadline is further out). B owns child session
-      // ses_child_B.
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS / 2);
-      await client.emit({
-        type: 'message.part.updated',
-        properties: {
-          part: createTaskToolPart({
-            status: 'running',
-            callId: 'call_B',
-            metadata: { sessionId: 'ses_child_B' },
-          }),
-        },
-      });
+      await vi.advanceTimersByTimeAsync(SIX_HOURS_MS);
 
-      // The parent session lists both children when A's fallback runs.
-      client.children.mockResolvedValueOnce([
-        { id: 'ses_child_A', parentID: 'ses_1' },
-        { id: 'ses_child_B', parentID: 'ses_1' },
-      ]);
-
-      // Advance to A's total-timeout deadline (B still has half a window left).
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS / 2);
-
-      expect(client.children).toHaveBeenCalledTimes(1);
-      // Only the orphaned child is aborted; the sibling owned by live watchdog
-      // B is spared.
-      expect(client.abort).toHaveBeenCalledTimes(1);
-      expect(client.abort).toHaveBeenCalledWith(
-        expect.objectContaining({ sessionId: 'ses_child_A' }),
-      );
-      expect(client.abort).not.toHaveBeenCalledWith(
-        expect.objectContaining({ sessionId: 'ses_child_B' }),
-      );
+      expect(client.abort).not.toHaveBeenCalled();
+      expect(client.children).not.toHaveBeenCalled();
     } finally {
       harness.dispose();
     }
   });
 
-  it('disarms a watchdog when its child session errors (aborted elsewhere)', async () => {
+  it('stops tracking when the task tool part reaches a terminal status', async () => {
     const { client, harness } = createHarness();
+    const outputs: Array<Record<string, unknown>> = [];
+    harness.on('runtimeOutput', (event) => {
+      outputs.push(event as unknown as Record<string, unknown>);
+    });
 
     try {
       await connectHarness(harness, client);
-
-      // Establish the parent session so the child error routes through the
-      // child-session branch of the dispatcher.
-      harness.sendCommand({
-        commandName: TaskCommandName.StartNewTask,
-        data: { text: 'Do work.', visibleInTranscript: true },
-      });
-      await vi.waitFor(() => {
-        expect(client.createSession).toHaveBeenCalled();
-      });
-
-      vi.useFakeTimers();
-
+      await armSpawn(client, harness);
       await client.emit({
         type: 'message.part.updated',
         properties: {
           part: createTaskToolPart({
-            status: 'running',
+            status: 'completed',
             metadata: { sessionId: 'ses_child_1' },
+            output: '<task_result>done</task_result>',
           }),
         },
       });
 
-      // The child is aborted by some other path; OpenCode surfaces that as a
-      // session.error attributed to the child. The watchdog must disarm so it
-      // never fires its own deadline later.
+      const settledCount = subagentActivityEvents(outputs).length;
+
+      // Child events after settlement no longer fold into the spawn row.
+      await client.emit({
+        type: 'message.part.updated',
+        properties: {
+          part: createChildToolPart({ callId: 'c_late', command: 'ls' }),
+        },
+      });
+
+      expect(subagentActivityEvents(outputs)).toHaveLength(settledCount);
+      expect(client.abort).not.toHaveBeenCalled();
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('disarms tracking on child session.error without finishing the parent turn', async () => {
+    const { client, harness } = createHarness();
+    const taskEvents: TaskEvent[] = [];
+    harness.subscribe((event) => taskEvents.push(event));
+
+    try {
+      await connectHarness(harness, client);
+      await armSpawn(client, harness);
+
       await client.emit({
         type: 'session.error',
         properties: {
@@ -380,197 +352,20 @@ describe('OpenCode subagent watchdog', () => {
         },
       });
 
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS * 2);
-
-      expect(client.children).not.toHaveBeenCalled();
+      expect(
+        taskEvents.some(
+          (event) =>
+            event.eventName === TaskEventName.TaskCompleted ||
+            event.eventName === TaskEventName.TaskAborted,
+        ),
+      ).toBe(false);
       expect(client.abort).not.toHaveBeenCalled();
     } finally {
-      harness.dispose();
+      await harness.dispose();
     }
   });
 
-  it('keeps a single timer across re-emits and picks up the child session id from later updates', async () => {
-    const { client, harness } = createHarness();
-
-    try {
-      await connectHarness(harness, client);
-      vi.useFakeTimers();
-
-      // First update: pending, no metadata yet.
-      await client.emit({
-        type: 'message.part.updated',
-        properties: { part: createTaskToolPart({ status: 'pending' }) },
-      });
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS / 2);
-      // Second update: running with the child session id. Must not reset or
-      // duplicate the timer, but must record the child session id.
-      await client.emit({
-        type: 'message.part.updated',
-        properties: {
-          part: createTaskToolPart({
-            status: 'running',
-            metadata: { sessionId: 'ses_child_1' },
-          }),
-        },
-      });
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS / 2);
-
-      expect(client.children).not.toHaveBeenCalled();
-      expect(client.abort).toHaveBeenCalledTimes(1);
-      expect(client.abort).toHaveBeenCalledWith(
-        expect.objectContaining({ sessionId: 'ses_child_1' }),
-      );
-
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS * 2);
-      expect(client.abort).toHaveBeenCalledTimes(1);
-    } finally {
-      harness.dispose();
-    }
-  });
-
-  it('clears the watchdog when the task tool part reaches a terminal status', async () => {
-    const { client, harness } = createHarness();
-
-    try {
-      await connectHarness(harness, client);
-      vi.useFakeTimers();
-
-      await client.emit({
-        type: 'message.part.updated',
-        properties: {
-          part: createTaskToolPart({
-            status: 'running',
-            metadata: { sessionId: 'ses_child_1' },
-          }),
-        },
-      });
-      await client.emit({
-        type: 'message.part.updated',
-        properties: {
-          part: createTaskToolPart({
-            status: 'completed',
-            metadata: { sessionId: 'ses_child_1' },
-            output: '<task_result>done</task_result>',
-          }),
-        },
-      });
-
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS * 2);
-
-      expect(client.children).not.toHaveBeenCalled();
-      expect(client.abort).not.toHaveBeenCalled();
-    } finally {
-      harness.dispose();
-    }
-  });
-
-  it('keeps a completed foreground task tool part disarming the watchdog even when metadata is present', async () => {
-    const { client, harness } = createHarness();
-
-    try {
-      await connectHarness(harness, client);
-      vi.useFakeTimers();
-
-      await client.emit({
-        type: 'message.part.updated',
-        properties: {
-          part: createTaskToolPart({
-            status: 'running',
-            metadata: { sessionId: 'ses_child_1' },
-          }),
-        },
-      });
-      // No background flag anywhere: completion is terminal for the spawn.
-      await client.emit({
-        type: 'message.part.updated',
-        properties: {
-          part: createTaskToolPart({
-            status: 'completed',
-            metadata: { sessionId: 'ses_child_1' },
-            output: '<task_result>done</task_result>',
-          }),
-        },
-      });
-
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS * 2);
-
-      expect(client.children).not.toHaveBeenCalled();
-      expect(client.abort).not.toHaveBeenCalled();
-    } finally {
-      harness.dispose();
-    }
-  });
-
-  it('keeps the watchdog armed when a background task tool part completes', async () => {
-    const { client, harness } = createHarness();
-
-    try {
-      await connectHarness(harness, client);
-      vi.useFakeTimers();
-
-      // A background launch's tool call completes immediately while the child
-      // session keeps working, so terminal status must not disarm the
-      // watchdog.
-      await client.emit({
-        type: 'message.part.updated',
-        properties: {
-          part: createTaskToolPart({
-            status: 'completed',
-            input: { background: true },
-            metadata: { sessionId: 'ses_child_1' },
-            output: '<task id="job_1" state="running" />',
-          }),
-        },
-      });
-
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS - 1);
-      expect(client.abort).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(1);
-
-      expect(client.children).not.toHaveBeenCalled();
-      expect(client.abort).toHaveBeenCalledTimes(1);
-      expect(client.abort).toHaveBeenCalledWith(
-        expect.objectContaining({ sessionId: 'ses_child_1' }),
-      );
-    } finally {
-      harness.dispose();
-    }
-  });
-
-  it('detects background launches and the child session id from state.metadata alone', async () => {
-    const { client, harness } = createHarness();
-
-    try {
-      await connectHarness(harness, client);
-      vi.useFakeTimers();
-
-      // Some OpenCode builds only report the launch as background metadata
-      // with a `jobId` instead of `sessionId`/`input.background`.
-      await client.emit({
-        type: 'message.part.updated',
-        properties: {
-          part: createTaskToolPart({
-            status: 'completed',
-            metadata: { background: true, jobId: 'ses_child_1' },
-            output: '<task id="job_1" state="running" />',
-          }),
-        },
-      });
-
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS);
-
-      expect(client.children).not.toHaveBeenCalled();
-      expect(client.abort).toHaveBeenCalledTimes(1);
-      expect(client.abort).toHaveBeenCalledWith(
-        expect.objectContaining({ sessionId: 'ses_child_1' }),
-      );
-    } finally {
-      harness.dispose();
-    }
-  });
-
-  it('disarms the background watchdog on child session idle without finishing the parent turn', async () => {
+  it('ends background tracking on child session idle without finishing the parent turn', async () => {
     const { client, harness } = createHarness();
     const taskEvents: TaskEvent[] = [];
     harness.subscribe((event) => taskEvents.push(event));
@@ -578,9 +373,6 @@ describe('OpenCode subagent watchdog', () => {
     try {
       await connectHarness(harness, client);
 
-      // Establish the parent session so the child idle is routed through the
-      // dispatcher's child-session branch (the production path) rather than
-      // falling through to the parent handlers.
       harness.sendCommand({
         commandName: TaskCommandName.StartNewTask,
         data: { text: 'Do work.', visibleInTranscript: true },
@@ -588,8 +380,6 @@ describe('OpenCode subagent watchdog', () => {
       await vi.waitFor(() => {
         expect(client.createSession).toHaveBeenCalled();
       });
-
-      vi.useFakeTimers();
 
       // Keep the parent turn in flight so a wrongly routed child idle would
       // observably complete the turn.
@@ -610,16 +400,12 @@ describe('OpenCode subagent watchdog', () => {
       });
 
       // The child session going idle is the background run's completion
-      // signal: it disarms the watchdog and must not finish the parent turn.
+      // signal: it ends tracking and must not finish the parent turn.
       await client.emit({
         type: 'session.idle',
         properties: { sessionID: 'ses_child_1' },
       });
 
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS * 2);
-
-      expect(client.children).not.toHaveBeenCalled();
-      expect(client.abort).not.toHaveBeenCalled();
       expect(
         taskEvents.some(
           (event) => event.eventName === TaskEventName.TaskCompleted,
@@ -636,13 +422,18 @@ describe('OpenCode subagent watchdog', () => {
           (event) => event.eventName === TaskEventName.TaskCompleted,
         ),
       ).toBe(true);
+      expect(client.abort).not.toHaveBeenCalled();
     } finally {
       harness.dispose();
     }
   });
 
-  it('keeps the background watchdog armed across parent turn finish and aborts the hung child', async () => {
+  it('keeps the background tracker across parent turn finish', async () => {
     const { client, harness } = createHarness();
+    const outputs: Array<Record<string, unknown>> = [];
+    harness.on('runtimeOutput', (event) => {
+      outputs.push(event as unknown as Record<string, unknown>);
+    });
 
     try {
       await connectHarness(harness, client);
@@ -654,8 +445,6 @@ describe('OpenCode subagent watchdog', () => {
       await vi.waitFor(() => {
         expect(client.createSession).toHaveBeenCalled();
       });
-
-      vi.useFakeTimers();
 
       await client.emit({
         type: 'message.part.updated',
@@ -669,221 +458,65 @@ describe('OpenCode subagent watchdog', () => {
         },
       });
 
-      // The parent turn finishes right after launching the background proof
-      // and posting the closeout — the canonical non-blocking delivery shape.
+      // The parent turn finishes right after launching the background run —
+      // the canonical non-blocking delivery shape.
       await client.emit({
         type: 'session.idle',
         properties: { sessionID: 'ses_1' },
       });
 
-      // Turn finish must not disarm the background watchdog: the hung child
-      // is still aborted when the timeout elapses.
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS + 1_000);
-
-      expect(client.abort).toHaveBeenCalledWith(
-        expect.objectContaining({ sessionId: 'ses_child_1' }),
-      );
-    } finally {
-      harness.dispose();
-    }
-  });
-
-  it('still clears foreground watchdogs when the parent turn finishes', async () => {
-    const { client, harness } = createHarness();
-
-    try {
-      await connectHarness(harness, client);
-
-      harness.sendCommand({
-        commandName: TaskCommandName.StartNewTask,
-        data: { text: 'Do work.', visibleInTranscript: true },
-      });
-      await vi.waitFor(() => {
-        expect(client.createSession).toHaveBeenCalled();
-      });
-
-      vi.useFakeTimers();
-
-      // Foreground spawn still running when the turn ends (e.g. an abort
-      // raced the tool result): turn finish disarms its watchdog.
+      // The background child keeps working: its events still fold into the
+      // spawn row after the parent turn finished.
       await client.emit({
         type: 'message.part.updated',
         properties: {
-          part: createTaskToolPart({
-            status: 'running',
-            metadata: { sessionId: 'ses_child_1' },
+          part: createChildToolPart({
+            callId: 'c_bg',
+            command: 'agent-browser screenshot',
           }),
         },
       });
-      await client.emit({
-        type: 'session.idle',
-        properties: { sessionID: 'ses_1' },
-      });
 
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS * 2);
-
+      expect(subagentActivityEvents(outputs).length).toBeGreaterThan(0);
       expect(client.abort).not.toHaveBeenCalled();
-      expect(client.children).not.toHaveBeenCalled();
     } finally {
       harness.dispose();
     }
   });
 
-  it('cleans the child-session key map when a background watchdog expires', async () => {
+  it('clears foreground trackers when the parent turn finishes', async () => {
     const { client, harness } = createHarness();
-    const taskEvents: TaskEvent[] = [];
-    harness.subscribe((event) => taskEvents.push(event));
+    const outputs: Array<Record<string, unknown>> = [];
+    harness.on('runtimeOutput', (event) => {
+      outputs.push(event as unknown as Record<string, unknown>);
+    });
 
     try {
       await connectHarness(harness, client);
+      await armSpawn(client, harness);
 
-      harness.sendCommand({
-        commandName: TaskCommandName.StartNewTask,
-        data: { text: 'Do work.', visibleInTranscript: true },
-      });
-      await vi.waitFor(() => {
-        expect(client.createSession).toHaveBeenCalled();
+      await client.emit({
+        type: 'session.idle',
+        properties: { sessionID: 'ses_1' },
       });
 
-      vi.useFakeTimers();
+      const settledCount = subagentActivityEvents(outputs).length;
 
+      // Foreground spawn tracking ended with the turn: late child events are
+      // inert.
       await client.emit({
         type: 'message.part.updated',
         properties: {
-          part: createTaskToolPart({
-            status: 'completed',
-            input: { background: true },
-            metadata: { sessionId: 'ses_child_1' },
-          }),
+          part: createChildToolPart({ callId: 'c_late', command: 'ls' }),
         },
       });
-
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS + 1_000);
-      expect(client.abort).toHaveBeenCalledTimes(1);
-
-      // Expiry removed the child-session mapping: a late child idle is inert
-      // (no second abort, no parent-turn side effects).
       await client.emit({
         type: 'session.idle',
         properties: { sessionID: 'ses_child_1' },
       });
-      expect(client.abort).toHaveBeenCalledTimes(1);
-      expect(
-        taskEvents.filter(
-          (event) => event.eventName === TaskEventName.TaskCompleted,
-        ).length,
-      ).toBeLessThanOrEqual(1);
-    } finally {
-      harness.dispose();
-    }
-  });
 
-  it('arms the watchdog for subtask parts as well', async () => {
-    const { client, harness } = createHarness();
-
-    try {
-      await connectHarness(harness, client);
-      vi.useFakeTimers();
-
-      client.children.mockResolvedValueOnce([
-        { id: 'child_1', parentID: 'ses_1' },
-      ]);
-
-      await client.emit({
-        type: 'message.part.updated',
-        properties: { part: createSubtaskPart() },
-      });
-
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS);
-
-      expect(client.children).toHaveBeenCalledTimes(1);
-      expect(client.abort).toHaveBeenCalledWith(
-        expect.objectContaining({ sessionId: 'child_1' }),
-      );
-    } finally {
-      harness.dispose();
-    }
-  });
-
-  it('clears the watchdog when a subtask part reaches a terminal status', async () => {
-    const { client, harness } = createHarness();
-
-    try {
-      await connectHarness(harness, client);
-      vi.useFakeTimers();
-
-      await client.emit({
-        type: 'message.part.updated',
-        properties: { part: createSubtaskPart() },
-      });
-      await client.emit({
-        type: 'message.part.updated',
-        properties: {
-          part: createSubtaskPart({ state: { status: 'completed' } }),
-        },
-      });
-
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS * 2);
-
-      expect(client.children).not.toHaveBeenCalled();
+      expect(subagentActivityEvents(outputs)).toHaveLength(settledCount);
       expect(client.abort).not.toHaveBeenCalled();
-    } finally {
-      harness.dispose();
-    }
-  });
-
-  it('clears pending watchdogs when the turn finishes', async () => {
-    const { client, harness } = createHarness();
-
-    try {
-      await connectHarness(harness, client);
-      vi.useFakeTimers();
-
-      await client.emit({
-        type: 'session.status',
-        properties: { sessionID: 'ses_1', status: { type: 'busy' } },
-      });
-      await client.emit({
-        type: 'message.part.updated',
-        properties: { part: createTaskToolPart({ status: 'running' }) },
-      });
-      // Turn completion tears down execute-tool progress and subagent
-      // watchdogs together.
-      await client.emit({
-        type: 'session.status',
-        properties: { sessionID: 'ses_1', status: { type: 'idle' } },
-      });
-
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS * 2);
-
-      expect(client.children).not.toHaveBeenCalled();
-      expect(client.abort).not.toHaveBeenCalled();
-    } finally {
-      harness.dispose();
-    }
-  });
-
-  it('only logs when listing or aborting child sessions fails', async () => {
-    const { client, harness, logger } = createHarness();
-
-    try {
-      await connectHarness(harness, client);
-      vi.useFakeTimers();
-
-      client.children.mockRejectedValueOnce(new Error('children failed'));
-
-      await client.emit({
-        type: 'message.part.updated',
-        properties: { part: createTaskToolPart({ status: 'running' }) },
-      });
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS);
-
-      expect(client.children).toHaveBeenCalledTimes(1);
-      expect(client.abort).not.toHaveBeenCalled();
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to list OpenCode child sessions'),
-      );
-      expect(logger.error).not.toHaveBeenCalled();
     } finally {
       harness.dispose();
     }
@@ -915,11 +548,7 @@ describe('OpenCode subagent live activity', () => {
         },
       });
 
-      const activity = outputs.filter(
-        (event) =>
-          (event.payload as Record<string, unknown>)?.progressKind ===
-          'subagent_activity',
-      );
+      const activity = subagentActivityEvents(outputs);
       expect(activity).toHaveLength(1);
       const payload = activity[0]!.payload as Record<string, unknown>;
       expect(payload.toolCallId).toBe('call_task_1');
@@ -956,12 +585,7 @@ describe('OpenCode subagent live activity', () => {
         },
       });
 
-      let activity = outputs.filter(
-        (event) =>
-          (event.payload as Record<string, unknown>)?.progressKind ===
-          'subagent_activity',
-      );
-      expect(activity).toHaveLength(1);
+      expect(subagentActivityEvents(outputs)).toHaveLength(1);
 
       vi.advanceTimersByTime(6_000);
       await client.emit({
@@ -971,11 +595,7 @@ describe('OpenCode subagent live activity', () => {
         },
       });
 
-      activity = outputs.filter(
-        (event) =>
-          (event.payload as Record<string, unknown>)?.progressKind ===
-          'subagent_activity',
-      );
+      const activity = subagentActivityEvents(outputs);
       expect(activity).toHaveLength(2);
       const details = (activity[1]!.payload as Record<string, unknown>)
         .subagentActivity as Record<string, unknown>;
@@ -1004,323 +624,7 @@ describe('OpenCode subagent live activity', () => {
         },
       });
 
-      expect(
-        outputs.filter(
-          (event) =>
-            (event.payload as Record<string, unknown>)?.progressKind ===
-            'subagent_activity',
-        ),
-      ).toHaveLength(0);
-    } finally {
-      await harness.dispose();
-    }
-  });
-});
-
-describe('OpenCode subagent inactivity deadline', () => {
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  function createInactivityHarness() {
-    return createHarness(new FakeOpenCodeServerClient(), {
-      subagentTaskInactivityTimeoutMs: SUBAGENT_INACTIVITY_TIMEOUT_MS,
-    });
-  }
-
-  it('aborts a child session that stops emitting events at the inactivity deadline', async () => {
-    const { client, harness, logger } = createInactivityHarness();
-
-    try {
-      await connectHarness(harness, client);
-      vi.useFakeTimers();
-      await armSpawn(client, harness);
-
-      await vi.advanceTimersByTimeAsync(SUBAGENT_INACTIVITY_TIMEOUT_MS - 1);
-      expect(client.abort).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(1);
-
-      expect(client.abort).toHaveBeenCalledTimes(1);
-      expect(client.abort).toHaveBeenCalledWith(
-        expect.objectContaining({ sessionId: 'ses_child_1' }),
-      );
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('stalled with no child-session events'),
-      );
-    } finally {
-      await harness.dispose();
-    }
-  });
-
-  it('slides the inactivity deadline forward on child-session events', async () => {
-    const { client, harness } = createInactivityHarness();
-
-    try {
-      await connectHarness(harness, client);
-      vi.useFakeTimers();
-      await armSpawn(client, harness);
-
-      await vi.advanceTimersByTimeAsync(8_000);
-      await client.emit({
-        type: 'message.part.updated',
-        properties: { part: createChildTextPart('still capturing') },
-      });
-
-      // The deadline now measures from the last child event, not the spawn.
-      await vi.advanceTimersByTimeAsync(SUBAGENT_INACTIVITY_TIMEOUT_MS - 1);
-      expect(client.abort).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(1);
-      expect(client.abort).toHaveBeenCalledTimes(1);
-      expect(client.abort).toHaveBeenCalledWith(
-        expect.objectContaining({ sessionId: 'ses_child_1' }),
-      );
-    } finally {
-      await harness.dispose();
-    }
-  });
-
-  it('keeps an active child alive past the inactivity window and still enforces the total timeout', async () => {
-    const { client, harness, logger } = createInactivityHarness();
-
-    try {
-      await connectHarness(harness, client);
-      vi.useFakeTimers();
-      await armSpawn(client, harness);
-
-      // Child streams an event every half inactivity window until just
-      // before the total timeout.
-      const stepMs = SUBAGENT_INACTIVITY_TIMEOUT_MS / 2;
-      for (
-        let elapsedMs = stepMs;
-        elapsedMs < SUBAGENT_TASK_TIMEOUT_MS;
-        elapsedMs += stepMs
-      ) {
-        await vi.advanceTimersByTimeAsync(stepMs);
-        await client.emit({
-          type: 'message.part.updated',
-          properties: { part: createChildTextPart('still capturing') },
-        });
-      }
-
-      expect(client.abort).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(stepMs);
-
-      expect(client.abort).toHaveBeenCalledTimes(1);
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('exceeded the'),
-      );
-    } finally {
-      await harness.dispose();
-    }
-  });
-
-  it('suspends the inactivity deadline while a child tool call is in flight', async () => {
-    const { client, harness } = createInactivityHarness();
-
-    try {
-      await connectHarness(harness, client);
-      vi.useFakeTimers();
-      await armSpawn(client, harness);
-
-      // A silently long-running tool must not be mistaken for a wedged
-      // child: only the total timeout applies while it is in flight.
-      await client.emit({
-        type: 'message.part.updated',
-        properties: {
-          part: createChildToolPart({ callId: 'c1', command: 'pnpm build' }),
-        },
-      });
-
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS - 1);
-      expect(client.abort).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(1);
-      expect(client.abort).toHaveBeenCalledTimes(1);
-    } finally {
-      await harness.dispose();
-    }
-  });
-
-  it('resumes the inactivity deadline when the running child tool completes', async () => {
-    const { client, harness, logger } = createInactivityHarness();
-
-    try {
-      await connectHarness(harness, client);
-      vi.useFakeTimers();
-      await armSpawn(client, harness);
-
-      await client.emit({
-        type: 'message.part.updated',
-        properties: {
-          part: createChildToolPart({ callId: 'c1', command: 'pnpm build' }),
-        },
-      });
-      await vi.advanceTimersByTimeAsync(SUBAGENT_INACTIVITY_TIMEOUT_MS * 3);
-      expect(client.abort).not.toHaveBeenCalled();
-
-      // Tool completes, then the child goes silent: the idle clock restarts
-      // at the completion event and expires one window later.
-      await client.emit({
-        type: 'message.part.updated',
-        properties: {
-          part: createChildToolPart({ callId: 'c1', status: 'completed' }),
-        },
-      });
-
-      await vi.advanceTimersByTimeAsync(SUBAGENT_INACTIVITY_TIMEOUT_MS - 1);
-      expect(client.abort).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(1);
-      expect(client.abort).toHaveBeenCalledTimes(1);
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('stalled with no child-session events'),
-      );
-    } finally {
-      await harness.dispose();
-    }
-  });
-
-  it('suspends the inactivity deadline for long-running non-shell tools (MCP calls)', async () => {
-    const { client, harness } = createInactivityHarness();
-
-    try {
-      await connectHarness(harness, client);
-      vi.useFakeTimers();
-      await armSpawn(client, harness);
-
-      await client.emit({
-        type: 'message.part.updated',
-        properties: {
-          part: createChildToolPart({
-            callId: 'c_mcp',
-            tool: 'mcp__roomote__manage_artifacts',
-          }),
-        },
-      });
-
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS - 1);
-      expect(client.abort).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(1);
-      expect(client.abort).toHaveBeenCalledTimes(1);
-    } finally {
-      await harness.dispose();
-    }
-  });
-
-  it('treats a pending child tool call as in flight', async () => {
-    const { client, harness } = createInactivityHarness();
-
-    try {
-      await connectHarness(harness, client);
-      vi.useFakeTimers();
-      await armSpawn(client, harness);
-
-      await client.emit({
-        type: 'message.part.updated',
-        properties: {
-          part: createChildToolPart({ callId: 'c1', status: 'pending' }),
-        },
-      });
-
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS - 1);
-      expect(client.abort).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(1);
-      expect(client.abort).toHaveBeenCalledTimes(1);
-    } finally {
-      await harness.dispose();
-    }
-  });
-
-  it('treats a child tool part with no status as in flight (fails toward suspension)', async () => {
-    const { client, harness } = createInactivityHarness();
-
-    try {
-      await connectHarness(harness, client);
-      vi.useFakeTimers();
-      await armSpawn(client, harness);
-
-      const part = createChildToolPart({ callId: 'c1' }) as Record<
-        string,
-        unknown
-      >;
-      part.state = { input: {} };
-      await client.emit({
-        type: 'message.part.updated',
-        properties: { part },
-      });
-
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS - 1);
-      expect(client.abort).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(1);
-      expect(client.abort).toHaveBeenCalledTimes(1);
-    } finally {
-      await harness.dispose();
-    }
-  });
-
-  it('resumes the inactivity deadline when the running child tool errors', async () => {
-    const { client, harness, logger } = createInactivityHarness();
-
-    try {
-      await connectHarness(harness, client);
-      vi.useFakeTimers();
-      await armSpawn(client, harness);
-
-      await client.emit({
-        type: 'message.part.updated',
-        properties: { part: createChildToolPart({ callId: 'c1' }) },
-      });
-      await vi.advanceTimersByTimeAsync(SUBAGENT_INACTIVITY_TIMEOUT_MS * 2);
-      expect(client.abort).not.toHaveBeenCalled();
-
-      // The tool fails (e.g. OpenCode's own shell timeout killed it); the
-      // idle clock restarts at the error event.
-      await client.emit({
-        type: 'message.part.updated',
-        properties: {
-          part: createChildToolPart({ callId: 'c1', status: 'error' }),
-        },
-      });
-
-      await vi.advanceTimersByTimeAsync(SUBAGENT_INACTIVITY_TIMEOUT_MS - 1);
-      expect(client.abort).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(1);
-      expect(client.abort).toHaveBeenCalledTimes(1);
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('stalled with no child-session events'),
-      );
-    } finally {
-      await harness.dispose();
-    }
-  });
-
-  it('does not enforce the inactivity deadline before a child session id is known', async () => {
-    const { client, harness } = createInactivityHarness();
-
-    try {
-      await connectHarness(harness, client);
-      vi.useFakeTimers();
-
-      // Spawn with no child session id: there is no activity feed to judge
-      // liveness by, so only the total timeout applies.
-      await client.emit({
-        type: 'message.part.updated',
-        properties: { part: createTaskToolPart({ status: 'pending' }) },
-      });
-
-      await vi.advanceTimersByTimeAsync(SUBAGENT_TASK_TIMEOUT_MS - 1);
-      expect(client.children).not.toHaveBeenCalled();
-      expect(client.abort).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(1);
-      expect(client.children).toHaveBeenCalledTimes(1);
+      expect(subagentActivityEvents(outputs)).toHaveLength(0);
     } finally {
       await harness.dispose();
     }

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
@@ -81,8 +81,6 @@ interface OpenCodeServerHarnessOptions {
   eventStreamReadyTimeoutMs?: number;
   executeToolProgressInitialDelayMs?: number;
   executeToolProgressIntervalMs?: number;
-  subagentTaskTimeoutMs?: number;
-  subagentTaskInactivityTimeoutMs?: number;
   stopHookReminderStallTimeoutMs?: number;
   queuedPromptRetryDelayMs?: number;
   mcpServerNames?: string[];
@@ -187,6 +185,11 @@ interface ActiveOpenCodeExecuteToolProgress {
   timer: ReturnType<typeof setTimeout>;
 }
 
+// Tracks a live subagent spawn. Subagent runs are not time-bounded: the only
+// terminal signals are the task tool part settling, the child session going
+// idle (background launches), or parent-turn teardown. This tracker exists to
+// route child-session events — live activity folded into the spawn row,
+// inference-usage attribution, and the background idle disarm.
 interface ActiveOpenCodeSubagentWatchdog {
   sessionId: string;
   /** Background launches outlive the parent turn; turn finish must not disarm them. */
@@ -197,17 +200,6 @@ interface ActiveOpenCodeSubagentWatchdog {
   agentType: string | null;
   childSessionId: string | null;
   startedAtMs: number;
-  lastActivityAtMs: number;
-  // Child tool calls observed in a non-terminal state. While any are in
-  // flight the inactivity deadline is suspended: a silently running tool is
-  // indistinguishable from a hung one by event flow alone. OpenCode's shell
-  // tool bounds that state itself (default 2-minute timeout that kills the
-  // command and emits a terminal tool event); other tool kinds (MCP calls,
-  // webfetch, nested task spawns) are not self-bounding, so a hang inside
-  // one falls back to the total timeout — a deliberate trade-off, since a
-  // wrong kill of legitimate slow work is worse than a slow abort.
-  activeChildToolCallIds: Set<string>;
-  timer: ReturnType<typeof setTimeout>;
   updatePayload: Record<string, unknown>;
   activitySeenChildToolCallIds: Set<string>;
   activityLastAction: string | null;
@@ -231,26 +223,6 @@ const OPENCODE_STOP_HOOK_REMINDER_STALL_TIMEOUT_MS = 10 * 60_000;
 const EXPECTED_REPLAY_ABORT_SUPPRESSION_MS = 10_000;
 const DEFAULT_EXECUTE_TOOL_PROGRESS_INITIAL_DELAY_MS = 15_000;
 const DEFAULT_EXECUTE_TOOL_PROGRESS_INTERVAL_MS = 30_000;
-// Kill switch for runaway subagent runs: a subagent that produces no terminal
-// signal within this window is presumed dead and its child sessions are
-// aborted so the parent turn can continue instead of hanging silently. Sized
-// for large review/audit subagents that legitimately read hundreds of files;
-// 12 minutes was too tight and killed in-progress work (the sliding inactivity
-// deadline below is the primary wedge detector, so this only backstops a child
-// that stays superficially active but never terminates).
-const DEFAULT_SUBAGENT_TASK_TIMEOUT_MS = 30 * 60_000;
-// Sliding inactivity deadline for subagent runs: once the child session is
-// known, every event it emits (streamed text, tool state, message completion)
-// counts as liveness. A child that goes silent for this window is presumed
-// wedged and aborted without waiting for the total timeout above. Only
-// enforced when it is a strong signal: the child session id must be known
-// (otherwise there is no activity feed to judge by) and no child tool call
-// may be in flight (a legitimately silent long-running tool is
-// indistinguishable from a hung one; OpenCode's own shell-tool timeout
-// bounds that state and its kill emits a terminal tool event). Between
-// tools, a live child streams tokens or issues its next tool call — silence
-// there means the loop is dead.
-const DEFAULT_SUBAGENT_TASK_INACTIVITY_TIMEOUT_MS = 3 * 60_000;
 const DEFAULT_QUEUED_PROMPT_RETRY_DELAY_MS = 1_000;
 const MAX_PROGRESS_COMMAND_CHARS = 240;
 const FALLBACK_OPENCODE_STOP_HOOK_REMINDER =
@@ -1445,8 +1417,6 @@ export class OpenCodeServerHarness
   private readonly eventStreamReadyTimeoutMs: number;
   private readonly executeToolProgressInitialDelayMs: number;
   private readonly executeToolProgressIntervalMs: number;
-  private readonly subagentTaskTimeoutMs: number;
-  private readonly subagentTaskInactivityTimeoutMs: number;
   private readonly stopHookReminderStallTimeoutMs: number;
   private readonly queuedPromptRetryDelayMs: number;
   private readonly streamedPartText = new Map<string, string>();
@@ -1536,11 +1506,6 @@ export class OpenCodeServerHarness
     this.executeToolProgressIntervalMs =
       options.executeToolProgressIntervalMs ??
       DEFAULT_EXECUTE_TOOL_PROGRESS_INTERVAL_MS;
-    this.subagentTaskTimeoutMs =
-      options.subagentTaskTimeoutMs ?? DEFAULT_SUBAGENT_TASK_TIMEOUT_MS;
-    this.subagentTaskInactivityTimeoutMs =
-      options.subagentTaskInactivityTimeoutMs ??
-      DEFAULT_SUBAGENT_TASK_INACTIVITY_TIMEOUT_MS;
     this.stopHookReminderStallTimeoutMs =
       options.stopHookReminderStallTimeoutMs ??
       OPENCODE_STOP_HOOK_REMINDER_STALL_TIMEOUT_MS;
@@ -2206,12 +2171,11 @@ export class OpenCodeServerHarness
     // error, queued replay, dispose) also means the awaited reminder response
     // either arrived or is moot, so disarm the pending fail-safe.
     this.clearStopHookReminderStall();
-    // Subagent watchdogs share the same lifecycle: every teardown point that
-    // clears execute-tool heartbeats (turn finish, cancel, session error,
-    // queued replay, dispose) must also disarm pending subagent watchdogs.
+    // Subagent run tracking shares the same lifecycle: every teardown point
+    // that clears execute-tool heartbeats (turn finish, cancel, session error,
+    // queued replay, dispose) must also drop pending subagent trackers.
     // Exception: background launches outlive the parent turn by design, so
-    // turn finish keeps their watchdogs armed until the child idles or the
-    // timeout aborts it.
+    // turn finish keeps their trackers until the child session goes idle.
     this.clearAllSubagentWatchdogs(options);
   }
 
@@ -2231,23 +2195,19 @@ export class OpenCodeServerHarness
     const existing = this.activeSubagentWatchdogs.get(eventKey);
 
     if (existing) {
-      // Keep the original timer, but pick up details (like the child session
-      // id or the background flag) that only appear on later part updates. A
-      // parent-side part update is itself a liveness signal for the spawn, so
-      // refresh the inactivity clock alongside the details.
+      // Pick up details (like the child session id or the background flag)
+      // that only appear on later part updates.
       existing.background = existing.background || input.background;
       existing.childSessionId = input.childSessionId ?? existing.childSessionId;
       existing.agentType = input.agentType ?? existing.agentType;
       existing.title = input.title;
       existing.updatePayload = input.updatePayload;
-      existing.lastActivityAtMs = Date.now();
       if (existing.childSessionId) {
         this.childSessionWatchdogKeys.set(existing.childSessionId, eventKey);
       }
       return;
     }
 
-    const nowMs = Date.now();
     const watchdog: ActiveOpenCodeSubagentWatchdog = {
       sessionId: input.sessionId,
       background: input.background,
@@ -2256,16 +2216,7 @@ export class OpenCodeServerHarness
       title: input.title,
       agentType: input.agentType,
       childSessionId: input.childSessionId,
-      startedAtMs: nowMs,
-      lastActivityAtMs: nowMs,
-      activeChildToolCallIds: new Set(),
-      timer: this.armSubagentWatchdogTimer(
-        eventKey,
-        Math.min(
-          this.subagentTaskInactivityTimeoutMs,
-          this.subagentTaskTimeoutMs,
-        ),
-      ),
+      startedAtMs: Date.now(),
       updatePayload: input.updatePayload,
       activitySeenChildToolCallIds: new Set(),
       activityLastAction: null,
@@ -2276,77 +2227,9 @@ export class OpenCodeServerHarness
       this.childSessionWatchdogKeys.set(input.childSessionId, eventKey);
     }
     this.logger.info(
-      `Armed OpenCode subagent watchdog timeoutMs=${this.subagentTaskTimeoutMs} inactivityTimeoutMs=${this.subagentTaskInactivityTimeoutMs} toolCallId=${input.toolCallId} agentType=${
+      `Tracking OpenCode subagent run toolCallId=${input.toolCallId} agentType=${
         input.agentType ?? 'unknown'
       } childSessionId=${input.childSessionId ?? 'pending'}`,
-    );
-  }
-
-  private armSubagentWatchdogTimer(
-    eventKey: string,
-    delayMs: number,
-  ): ReturnType<typeof setTimeout> {
-    const timer = setTimeout(() => {
-      void this.handleSubagentWatchdogDeadline(eventKey);
-    }, delayMs);
-    timer.unref?.();
-    return timer;
-  }
-
-  /**
-   * Sliding-deadline check: the timer fires at the earliest possible expiry,
-   * then either expires the watchdog or re-arms it for the remaining window.
-   * Liveness comes from structured child-session events (see
-   * `markSubagentSessionActivity`); the inactivity deadline is only enforced
-   * while it is a strong signal — the child session id is known and no child
-   * tool call is in flight (see `activeChildToolCallIds`). While it is not
-   * enforceable, the timer keeps waking at the inactivity interval so a tool
-   * completion followed by silence is still caught one idle window after the
-   * completion event, and the total timeout always applies.
-   */
-  private async handleSubagentWatchdogDeadline(
-    eventKey: string,
-  ): Promise<void> {
-    const watchdog = this.activeSubagentWatchdogs.get(eventKey);
-
-    if (!watchdog) {
-      return;
-    }
-
-    const nowMs = Date.now();
-    const elapsedMs = nowMs - watchdog.startedAtMs;
-    const idleMs = nowMs - watchdog.lastActivityAtMs;
-
-    if (elapsedMs >= this.subagentTaskTimeoutMs) {
-      await this.expireSubagentWatchdog(
-        eventKey,
-        watchdog,
-        `exceeded the ${this.subagentTaskTimeoutMs}ms watchdog timeout (elapsed=${elapsedMs}ms)`,
-      );
-      return;
-    }
-
-    const idleEnforceable =
-      watchdog.childSessionId !== null &&
-      watchdog.activeChildToolCallIds.size === 0;
-
-    if (idleEnforceable && idleMs >= this.subagentTaskInactivityTimeoutMs) {
-      await this.expireSubagentWatchdog(
-        eventKey,
-        watchdog,
-        `stalled with no child-session events for ${idleMs}ms (inactivity limit ${this.subagentTaskInactivityTimeoutMs}ms, elapsed=${elapsedMs}ms)`,
-      );
-      return;
-    }
-
-    const remainingTotalMs = this.subagentTaskTimeoutMs - elapsedMs;
-    const remainingIdleMs = idleEnforceable
-      ? this.subagentTaskInactivityTimeoutMs - idleMs
-      : this.subagentTaskInactivityTimeoutMs;
-
-    watchdog.timer = this.armSubagentWatchdogTimer(
-      eventKey,
-      Math.min(remainingTotalMs, remainingIdleMs),
     );
   }
 
@@ -2363,8 +2246,8 @@ export class OpenCodeServerHarness
     if (isTerminalOpenCodeToolStatus(normalized.status)) {
       // A background launch's tool call completes immediately while the child
       // session keeps working, so a completed background part must keep the
-      // watchdog armed (keyed to the child session) until the child session
-      // goes idle or the timeout aborts it.
+      // run tracked (keyed to the child session) until the child session
+      // goes idle.
       if (
         normalized.status === 'completed' &&
         isOpenCodeBackgroundTaskToolPart(toolPart)
@@ -2433,24 +2316,10 @@ export class OpenCodeServerHarness
       return;
     }
 
-    clearTimeout(watchdog.timer);
     if (watchdog.childSessionId) {
       this.childSessionWatchdogKeys.delete(watchdog.childSessionId);
     }
     this.activeSubagentWatchdogs.delete(eventKey);
-  }
-
-  /**
-   * True when `childSessionId` is currently tracked by a live watchdog. Used by
-   * the expiry fallback to avoid aborting sibling subagents that are still
-   * being independently monitored — a watchdog with an unknown child session id
-   * must not take down healthy concurrent children of the shared parent
-   * session.
-   */
-  private isChildSessionOwnedByActiveWatchdog(childSessionId: string): boolean {
-    const eventKey = this.childSessionWatchdogKeys.get(childSessionId);
-
-    return eventKey !== undefined && this.activeSubagentWatchdogs.has(eventKey);
   }
 
   private clearAllSubagentWatchdogs(options?: {
@@ -2461,28 +2330,10 @@ export class OpenCodeServerHarness
         continue;
       }
 
-      clearTimeout(watchdog.timer);
       this.activeSubagentWatchdogs.delete(eventKey);
       if (watchdog.childSessionId) {
         this.childSessionWatchdogKeys.delete(watchdog.childSessionId);
       }
-    }
-  }
-
-  /**
-   * Every event a known child session emits — streamed text, tool state,
-   * message completion — counts as liveness for its spawn watchdog. The
-   * inactivity deadline in `handleSubagentWatchdogDeadline` measures against
-   * this clock.
-   */
-  private markSubagentSessionActivity(childSessionId: string): void {
-    const eventKey = this.childSessionWatchdogKeys.get(childSessionId);
-    const watchdog = eventKey
-      ? this.activeSubagentWatchdogs.get(eventKey)
-      : undefined;
-
-    if (watchdog) {
-      watchdog.lastActivityAtMs = Date.now();
     }
   }
 
@@ -2512,19 +2363,9 @@ export class OpenCodeServerHarness
     }
 
     const childToolCallId = asString(part.callID) ?? asString(part.id);
-    const childToolStatus = normalizeOpenCodeToolStatus(
-      asString(asRecord(part.state)?.status),
-    );
 
     if (childToolCallId) {
       watchdog.activitySeenChildToolCallIds.add(childToolCallId);
-      // Track in-flight child tool calls so the inactivity deadline is only
-      // enforced between tools, where silence is a strong wedge signal.
-      if (isTerminalOpenCodeToolStatus(childToolStatus)) {
-        watchdog.activeChildToolCallIds.delete(childToolCallId);
-      } else {
-        watchdog.activeChildToolCallIds.add(childToolCallId);
-      }
     }
 
     const state = asRecord(part.state);
@@ -2632,75 +2473,6 @@ export class OpenCodeServerHarness
       : undefined;
 
     return watchdog?.agentType ?? undefined;
-  }
-
-  private async expireSubagentWatchdog(
-    eventKey: string,
-    watchdog: ActiveOpenCodeSubagentWatchdog,
-    reason: string,
-  ): Promise<void> {
-    this.stopSubagentWatchdog(eventKey);
-    this.logger.warn(
-      `OpenCode subagent run ${reason} toolCallId=${watchdog.toolCallId} agentType=${
-        watchdog.agentType ?? 'unknown'
-      } title=${watchdog.title}; aborting child sessions of sessionId=${watchdog.sessionId}`,
-    );
-
-    // Abort only the child (subagent) sessions — never the parent session.
-    // Child sessions have their own session ids, so the MessageAbortedError
-    // each abort raises arrives as a session.error attributed to the child and
-    // is dropped by the sessionId guard in handleEvent; no replay-abort
-    // suppression is needed here. Prefer the exact child session captured
-    // from the task tool part metadata; fall back to listing all children.
-    //
-    // The fallback lists every child of the parent session, so it must never
-    // abort a child that belongs to a *different, still-live* watchdog: sibling
-    // subagents run concurrently under one parent session, and a healthy
-    // sibling is independently monitored by its own watchdog. Aborting it here
-    // is collateral damage that kills in-progress work. Exclude any child
-    // session still owned by another active watchdog. (This watchdog's own
-    // mapping was already removed by stopSubagentWatchdog above, so only other
-    // watchdogs remain.) The exact-child path is inherently scoped and needs no
-    // filtering.
-    try {
-      const childSessionIds = watchdog.childSessionId
-        ? [watchdog.childSessionId]
-        : (
-            await this.client.children({
-              sessionId: watchdog.sessionId,
-              signal: this.eventAbortController.signal,
-            })
-          )
-            .map((child) => child.id)
-            .filter(
-              (childSessionId) =>
-                !this.isChildSessionOwnedByActiveWatchdog(childSessionId),
-            );
-
-      for (const childSessionId of childSessionIds) {
-        try {
-          await this.client.abort({
-            sessionId: childSessionId,
-            signal: this.eventAbortController.signal,
-          });
-          this.logger.warn(
-            `Aborted OpenCode child session ${childSessionId} after the subagent watchdog expired for toolCallId=${watchdog.toolCallId}`,
-          );
-        } catch (error) {
-          this.logger.warn(
-            `Failed to abort OpenCode child session ${childSessionId} after the subagent watchdog expired: ${
-              error instanceof Error ? error.message : String(error)
-            }`,
-          );
-        }
-      }
-    } catch (error) {
-      this.logger.warn(
-        `Failed to list OpenCode child sessions for sessionId=${watchdog.sessionId} after the subagent watchdog expired: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-    }
   }
 
   private updateExecuteToolProgress(
@@ -3144,18 +2916,13 @@ export class OpenCodeServerHarness
     const sessionId = eventSessionId(payload);
 
     if (sessionId && this.sessionId && sessionId !== this.sessionId) {
-      // Child-session (subagent) events are otherwise dropped here; refresh
-      // the spawn watchdog's inactivity clock, fold tool activity into the
-      // parent spawn row, and record hidden inference usage before returning.
-      // A child session going idle is its completion signal — for background
-      // launches this disarms the watchdog that outlived the instant
-      // task-tool completion. A child `session.error` is equally terminal:
-      // aborting a child (our own watchdog expiry, or a sibling watchdog's
-      // fallback abort) surfaces here as a MessageAbortedError attributed to
-      // the child. Disarm on it too, so a watchdog whose child was already
-      // aborted elsewhere does not linger and fire its own deadline later
-      // (which, with an unknown child session id, would abort whatever
-      // children exist by then — including a fresh, healthy wave).
+      // Child-session (subagent) events are otherwise dropped here; fold tool
+      // activity into the parent spawn row and record hidden inference usage
+      // before returning. A child session going idle or erroring is its
+      // terminal signal — it ends run tracking (for background launches this
+      // is what ends the tracking that outlived the instant task-tool
+      // completion), and a child's idle or error must never finish the
+      // parent turn.
       if (payload.type === 'session.idle' || payload.type === 'session.error') {
         const watchdogKey = this.childSessionWatchdogKeys.get(sessionId);
 
@@ -3166,7 +2933,6 @@ export class OpenCodeServerHarness
         return;
       }
 
-      this.markSubagentSessionActivity(sessionId);
       this.handleChildSessionToolActivity(sessionId, payload);
       this.handleChildSessionMessageUpdated(sessionId, payload);
       return;

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/start.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/start.ts
@@ -278,12 +278,6 @@ export async function startOpenCodeServerHarness({
       commandEnv,
       initialSessionId,
       model,
-      subagentTaskTimeoutMs: parseTimeoutMs(
-        process.env.ROOMOTE_SUBAGENT_TASK_TIMEOUT_MS,
-      ),
-      subagentTaskInactivityTimeoutMs: parseTimeoutMs(
-        process.env.ROOMOTE_SUBAGENT_TASK_INACTIVITY_TIMEOUT_MS,
-      ),
       stopHookReminderStallTimeoutMs: parseTimeoutMs(
         process.env.ROOMOTE_STOP_HOOK_REMINDER_STALL_TIMEOUT_MS,
       ),


### PR DESCRIPTION
Removes both subagent kill switches — the total-runtime timeout and the sliding inactivity abort — plus their options and env overrides (`ROOMOTE_SUBAGENT_TASK_TIMEOUT_MS`, `ROOMOTE_SUBAGENT_TASK_INACTIVITY_TIMEOUT_MS`). Subagent runs are no longer time-bounded.

## Why

The inactivity deadline assumed a live child streams events between tool calls. Reasoning models break that assumption: they think silently for minutes. Observed live on `1i8cs6lzzc1rm`: a GPT-5.6 Sol review subagent was cancelled at 9m35s mid-think while both siblings completed normally — the model then had to re-spawn the work, producing the "task looks stuck" churn reported today. Across ~110 recent tasks on two deployments the timeout machinery caused the only subagent kills we found; genuinely wedged children were rarer than false positives, and wedges inside children via roomote MCP calls are now independently bounded by the platform-API fetch timeouts (#84).

## What stays

The spawn tracker (not the timers): live `subagentActivity` folding into the spawn row, hidden child inference-usage attribution, and background-run tracking ended by child `session.idle`/`session.error`. A genuinely stuck child is now the user's call to stop, not the harness's guess.

## Tests

Watchdog suite rewritten around the new invariants: never aborts (foreground, unknown-child-id, silent-between-tools, subtask parts — all at a 6-hour horizon), tracker lifecycle via observable activity folding (terminal settle, turn-finish clear, background persistence across turn finish, child error/idle disarm). Full harness suite: 137 tests pass; typecheck / eslint / prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)