### PR TITLE
[Fix] Derive SLACK_AUTH_URI from ROOMOTE_APP_URL when unset

### DIFF
--- a/apps/docs/environment-variables.mdx
+++ b/apps/docs/environment-variables.mdx
@@ -242,7 +242,7 @@ as per-task auth tokens or workspace paths.
 | `SLACK_CLIENT_ID`                      | Slack app/auth    | Slack OAuth client ID. Also accepted for Slack sign-in setup.                   |
 | `SLACK_CLIENT_SECRET`                  | Slack app/auth    | Slack OAuth client secret. Also accepted for Slack sign-in setup.               |
 | `SLACK_REDIRECT_URI`                   | Optional          | Slack redirect URI override.                                                    |
-| `SLACK_AUTH_URI`                       | Optional          | Slack auth URI override.                                                        |
+| `SLACK_AUTH_URI`                       | Optional          | Slack auth URI override. Defaults to `ROOMOTE_APP_URL` + `/api/slack/auth`.     |
 | `SLACK_SIGNING_SECRET`                 | Slack app/auth    | Slack signing secret for webhook verification.                                  |
 | `SLACK_API_BASE_URL`                   | Optional          | Slack API base URL. Defaults to `https://slack.com/api/`.                       |
 | `SLACK_UNFURL_ALLOWED_DOMAINS`         | Optional          | Domains Slack unfurl handling may allow.                                        |

--- a/packages/env/src/__tests__/index.test.ts
+++ b/packages/env/src/__tests__/index.test.ts
@@ -420,6 +420,58 @@ describe('Env', () => {
     }
   });
 
+  it('derives SLACK_AUTH_URI from ROOMOTE_APP_URL when unset or empty', () => {
+    const previousSkipEnvValidation = process.env.SKIP_ENV_VALIDATION;
+
+    const unsetEnv = { ...productionCoreEnv };
+    delete unsetEnv.SKIP_ENV_VALIDATION;
+    delete unsetEnv.SLACK_AUTH_URI;
+
+    const emptyEnv: NodeJS.ProcessEnv = {
+      ...unsetEnv,
+      SLACK_AUTH_URI: '',
+      ROOMOTE_APP_URL: 'https://roomote.example.com/',
+    };
+
+    try {
+      expect(createRoomoteEnv(unsetEnv).SLACK_AUTH_URI).toBe(
+        'https://roomote.example.com/api/slack/auth',
+      );
+      // Trailing slashes on ROOMOTE_APP_URL must not produce a double slash.
+      expect(createRoomoteEnv(emptyEnv).SLACK_AUTH_URI).toBe(
+        'https://roomote.example.com/api/slack/auth',
+      );
+    } finally {
+      if (previousSkipEnvValidation === undefined) {
+        delete process.env.SKIP_ENV_VALIDATION;
+      } else {
+        process.env.SKIP_ENV_VALIDATION = previousSkipEnvValidation;
+      }
+    }
+  });
+
+  it('prefers an explicit SLACK_AUTH_URI over the derived value', () => {
+    const previousSkipEnvValidation = process.env.SKIP_ENV_VALIDATION;
+    const runtimeEnv: NodeJS.ProcessEnv = {
+      ...productionCoreEnv,
+      SLACK_AUTH_URI: 'https://auth.example.com/slack',
+    };
+
+    delete runtimeEnv.SKIP_ENV_VALIDATION;
+
+    try {
+      const env = createRoomoteEnv(runtimeEnv);
+
+      expect(env.SLACK_AUTH_URI).toBe('https://auth.example.com/slack');
+    } finally {
+      if (previousSkipEnvValidation === undefined) {
+        delete process.env.SKIP_ENV_VALIDATION;
+      } else {
+        process.env.SKIP_ENV_VALIDATION = previousSkipEnvValidation;
+      }
+    }
+  });
+
   it('treats empty optional non-empty env vars as unset', () => {
     const previousSkipEnvValidation = process.env.SKIP_ENV_VALIDATION;
     const runtimeEnv: Record<string, string | undefined> = {

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -541,6 +541,13 @@ function buildRoomoteRuntimeEnv(
     env.S3_BUCKET_ARTIFACTS ??= LOCAL_S3_BUCKET_ARTIFACTS;
   }
 
+  // Slack rejects the whole account-linking DM (invalid_blocks) when the
+  // "Link accounts" button URL is not absolute, so an unset SLACK_AUTH_URI
+  // must fall back to the web app's linking route rather than empty string.
+  if (!env.SLACK_AUTH_URI && env.ROOMOTE_APP_URL) {
+    env.SLACK_AUTH_URI = `${env.ROOMOTE_APP_URL.replace(/\/+$/, '')}/api/slack/auth`;
+  }
+
   return env;
 }
 


### PR DESCRIPTION
## Problem

When `SLACK_AUTH_URI` is unset, the Slack account-linking onboarding DM silently fails. The env schema defaults it to an empty string, so the "Link accounts" button URL becomes `?state=<token>` — Slack rejects the entire `chat.postMessage` with `invalid_blocks` ("invalid url"), and unlinked users who DM the bot get no response at all.

This hit the roomote-nightly Railway deployment on 2026-07-10: none of the fleet deployments set `SLACK_AUTH_URI` (the ops provision script only sets `ROOMOTE_APP_URL`).

## Fix

When `SLACK_AUTH_URI` is unset or empty, derive it from `ROOMOTE_APP_URL` as `${ROOMOTE_APP_URL}/api/slack/auth` — the route the web app already serves for completing the link (`apps/web/src/app/api/slack/auth/route.ts`). An explicitly set `SLACK_AUTH_URI` still wins.

The fallback lives in `buildRoomoteRuntimeEnv` (packages/env) rather than at the button-building site, so every service that constructs env — including `rehydrateEnv` and the web bootstrap — gets it, matching the existing derivation pattern for `SLACK_API_TIMEOUT_MS` and `DOCKER_WORKER_IMAGE`.

## Changes

- `packages/env/src/index.ts` — derive `SLACK_AUTH_URI` from `ROOMOTE_APP_URL` when unset/empty (trailing slashes trimmed)
- `packages/env/src/__tests__/index.test.ts` — tests for the fallback (unset, empty, trailing slash) and explicit-override precedence
- `apps/docs/environment-variables.mdx` — document the default

## Validation

- `pnpm --filter @roomote/env exec vitest run src/__tests__/index.test.ts` — 53 passed
- `pnpm --filter @roomote/slack exec vitest run src/__tests__/block-kit.test.ts` — 21 passed
- `pnpm lint` and `pnpm check-types` — clean across all workspaces

No fleet config change needed: deployments already set `ROOMOTE_APP_URL`, so the next deploy with this commit fixes the silent DM failure.