### PR TITLE
[Chore] Validate deployment artifacts in CI

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -26,19 +26,19 @@ runs:
   using: 'composite'
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
       with:
         version: ${{ inputs.pnpm-version }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
 
     - name: Restore Turbo cache
       if: inputs.enable-turbo-cache == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: .turbo
         key: turbo-${{ runner.os }}-${{ runner.arch }}-${{ inputs.turbo-cache-scope }}-${{ github.ref_name }}-${{ github.sha }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
       docs_only: ${{ steps.changed-paths.outputs.docs_only }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: Classify changed paths
@@ -76,7 +76,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup environment
         uses: ./.github/actions/setup-environment
         with:
@@ -95,7 +95,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup environment
         uses: ./.github/actions/setup-environment
         with:
@@ -112,7 +112,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup environment
         uses: ./.github/actions/setup-environment
         with:
@@ -131,7 +131,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     services:
       postgres:
-        image: postgres:17.5
+        image: postgres:17.5@sha256:aadf2c0696f5ef357aa7a68da995137f0cf17bad0bf6e1f17de06ae5c769b302
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
@@ -144,7 +144,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       redis:
-        image: redis:7
+        image: redis:7@sha256:b2b95679e3b46fb51864949ed25ea976fc3a6bcc00a40a1bc00d568cb2822e50
         ports:
           - 6379:6379
         options: >-
@@ -154,7 +154,7 @@ jobs:
           --health-retries 5
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup environment
         uses: ./.github/actions/setup-environment
         with:
@@ -203,19 +203,39 @@ jobs:
           - app: migrate
             dockerfile: .docker/app/Dockerfile
             target: runtime-migrate
+          - app: worker
+            dockerfile: apps/worker/Dockerfile
+            target: runtime
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Validate production Compose security contract
         if: matrix.app == 'app'
         run: deploy/scripts/validate-compose-security.sh
       - name: Set up Docker builder
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: useblacksmith/setup-docker-builder@47a5d0102cc44712a17a633c2599f755008cc40e # v1
       - name: Build ${{ matrix.app }} Dockerfile
-        uses: useblacksmith/build-push-action@v2
+        uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2
         with:
           context: .
           file: ${{ matrix.dockerfile }}
           target: ${{ matrix.target }}
           push: false
           build-args: APP_ENV=development
+
+  deployment-config:
+    name: Deployment artifacts
+    needs: changes
+    if: ${{ needs.changes.outputs.docs_only != 'true' }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+        with:
+          frozen-lockfile: 'true'
+          node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+      - name: Validate Compose, installers, and platform templates
+        run: pnpm deployment:validate

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -36,7 +36,7 @@ jobs:
       extra_tag: ${{ steps.vars.outputs.extra_tag }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: Classify changed paths
@@ -137,9 +137,55 @@ jobs:
           echo "app_env=$app_env" >> "$GITHUB_OUTPUT"
           echo "extra_tag=$extra_tag" >> "$GITHUB_OUTPUT"
 
+  deployment-acceptance:
+    name: Deployment acceptance (amd64)
+    needs: prepare
+    if: ${{ needs.prepare.outputs.docs_only != 'true' }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+        with:
+          frozen-lockfile: 'true'
+          node-version: 24.13.1
+          pnpm-version: 10.29.3
+      - name: Set up Docker builder
+        uses: useblacksmith/setup-docker-builder@47a5d0102cc44712a17a633c2599f755008cc40e # v1
+      - name: Resolve previous published channel
+        id: baseline
+        shell: bash
+        env:
+          EXTRA_TAG: ${{ needs.prepare.outputs.extra_tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          baseline="$EXTRA_TAG"
+          if [ "$baseline" = 'latest' ]; then
+            baseline="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name 2>/dev/null || true)"
+            # v0.0.1 predates the current migration baseline. Use the prior
+            # main candidate for the first gated release; later releases use
+            # the immediately preceding immutable release tag.
+            if [ -z "$baseline" ] || [ "$baseline" = 'v0.0.1' ]; then
+              baseline='main'
+            fi
+          elif [ -z "$baseline" ]; then
+            baseline='main'
+          fi
+          echo "version=$baseline" >> "$GITHUB_OUTPUT"
+      - name: Exercise deployment lifecycle
+        env:
+          BASELINE_VERSION: ${{ steps.baseline.outputs.version }}
+          CANDIDATE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: pnpm deployment:smoke
+
   build:
     name: Build ${{ matrix.app }} (${{ matrix.arch }})
-    needs: prepare
+    needs: [prepare, deployment-acceptance]
     if: ${{ needs.prepare.outputs.docs_only != 'true' }}
     runs-on: ${{ matrix.runner }}
     permissions:
@@ -250,17 +296,17 @@ jobs:
             runner: blacksmith-4vcpu-ubuntu-2404-arm
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Blacksmith's builder mounts a persistent NVMe layer cache into the
       # runner (per repo/Dockerfile/arch). Unlike type=gha caching this has
       # no 10GB repo cap or per-ref scoping, and skips the multi-minute
       # cache export upload at the end of every build.
       - name: Set up Docker builder
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: useblacksmith/setup-docker-builder@47a5d0102cc44712a17a633c2599f755008cc40e # v1
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -268,7 +314,7 @@ jobs:
 
       - name: Build and push ${{ matrix.app }} (${{ matrix.arch }}) by digest
         id: build
-        uses: useblacksmith/build-push-action@v2
+        uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -288,7 +334,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: digests-${{ matrix.app }}-${{ matrix.arch }}
           path: /tmp/digests/*
@@ -324,17 +370,17 @@ jobs:
             image: roomote-worker
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: digests-${{ matrix.app }}-*
           path: /tmp/digests
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -284,9 +284,11 @@ docker compose --env-file .env -f docker-compose.prod.yml pull
 docker compose --env-file .env -f docker-compose.prod.yml up -d --wait --wait-timeout 600
 ```
 
-The Compose file defines container healthchecks for `web`, `api`, and
-`preview-proxy`, and `up --wait` holds the deploy command until those services
-are healthy. The deployer stops the controller before deployment metadata
+The Compose file defines container healthchecks for `web`, `api`, `controller`,
+`bullmq`, and `preview-proxy`. The controller probe uses the API's Redis
+heartbeat and stuck-task checks; the BullMQ probe queries its queues. `up
+--wait` holds the deploy command until the complete execution plane is healthy.
+The deployer stops the controller before deployment metadata
 changes and image pulls so new tasks remain queued during rollout instead of
 being claimed by the old controller. The wait timeout is intentionally longer
 than the controller stop grace so any already-active hosted-provider spawn can
@@ -326,7 +328,7 @@ Equivalent remote command:
 cd /opt/roomote
 mkdir -p backups
 docker run --rm --network roomote_default --env-file /opt/roomote/.env \
-  postgres:17.5 sh -c 'pg_dump --clean --if-exists --no-owner --no-privileges "$DATABASE_URL"' \
+  postgres:17.5@sha256:aadf2c0696f5ef357aa7a68da995137f0cf17bad0bf6e1f17de06ae5c769b302 sh -c 'pg_dump --clean --if-exists --no-owner --no-privileges "$DATABASE_URL"' \
   > "backups/backup-$(date +%F-%H%M%S).sql"
 ```
 
@@ -353,9 +355,9 @@ cd /opt/roomote
 docker compose --env-file .env -f docker-compose.prod.yml \
   stop web api controller bullmq preview-proxy
 docker run --rm --network roomote_default --env-file /opt/roomote/.env \
-  postgres:17.5 sh -c 'psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;"'
+  postgres:17.5@sha256:aadf2c0696f5ef357aa7a68da995137f0cf17bad0bf6e1f17de06ae5c769b302 sh -c 'psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;"'
 docker run --rm --network roomote_default --env-file /opt/roomote/.env -i \
-  postgres:17.5 sh -c 'psql "$DATABASE_URL" -v ON_ERROR_STOP=1' \
+  postgres:17.5@sha256:aadf2c0696f5ef357aa7a68da995137f0cf17bad0bf6e1f17de06ae5c769b302 sh -c 'psql "$DATABASE_URL" -v ON_ERROR_STOP=1' \
   < /opt/roomote/backups/backup.sql
 docker compose --env-file .env -f docker-compose.prod.yml \
   up -d --wait --wait-timeout 600

--- a/deploy/ci/deployment-smoke.sh
+++ b/deploy/ci/deployment-smoke.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+candidate_version="${CANDIDATE_VERSION:-deployment-ci}"
+baseline_version="${BASELINE_VERSION:-}"
+project_name="${COMPOSE_PROJECT_NAME:-roomote-deployment-ci}"
+postgres_port="${DEPLOYMENT_CI_POSTGRES_PORT:-55432}"
+redis_port="${DEPLOYMENT_CI_REDIS_PORT:-56379}"
+default_network="${ROOMOTE_DEFAULT_NETWORK:-${project_name}_default}"
+worker_network="${DOCKER_WORKER_NETWORK:-${project_name}_worker}"
+temporary_directory="$(mktemp -d)"
+env_file="$temporary_directory/deployment.env"
+backup_file="$temporary_directory/roomote.sql"
+launched_worker_container=''
+
+case "$candidate_version" in
+  '' | *[!A-Za-z0-9._-]*)
+    printf 'invalid candidate image tag: %s\n' "$candidate_version" >&2
+    exit 1
+    ;;
+esac
+
+compose() {
+  docker compose \
+    --project-name "$project_name" \
+    --env-file "$env_file" \
+    -f "$repo_root/deploy/compose/docker-compose.prod.yml" \
+    -f "$repo_root/deploy/ci/docker-compose.ci.yml" \
+    "$@"
+}
+
+cleanup() {
+  if [ -n "$launched_worker_container" ]; then
+    docker rm --force "$launched_worker_container" >/dev/null 2>&1 || true
+  fi
+  compose down --volumes --remove-orphans >/dev/null 2>&1 || true
+  rm -rf "$temporary_directory"
+}
+trap cleanup EXIT
+
+report_failure() {
+  local exit_code="$?"
+  printf 'Deployment smoke test failed; final Compose state follows.\n' >&2
+  compose ps --all >&2 || true
+  compose logs --no-color --tail 200 >&2 || true
+  return "$exit_code"
+}
+trap report_failure ERR
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    printf 'required command not found: %s\n' "$1" >&2
+    exit 1
+  }
+}
+
+for command in docker openssl pnpm jq; do
+  require_command "$command"
+done
+
+docker_arch="$(docker info --format '{{.Architecture}}')"
+case "$docker_arch" in
+  amd64 | x86_64) platform='linux/amd64' ;;
+  arm64 | aarch64) platform='linux/arm64' ;;
+  *)
+    printf 'unsupported Docker architecture: %s\n' "$docker_arch" >&2
+    exit 1
+    ;;
+esac
+
+generate_keypair() {
+  local name="$1"
+  openssl ecparam -name prime256v1 -genkey -noout -out "$temporary_directory/$name-raw.pem" 2>/dev/null
+  openssl pkcs8 -topk8 -nocrypt \
+    -in "$temporary_directory/$name-raw.pem" \
+    -out "$temporary_directory/$name-private.pem" 2>/dev/null
+  openssl ec -in "$temporary_directory/$name-raw.pem" \
+    -pubout -out "$temporary_directory/$name-public.pem" 2>/dev/null
+}
+
+single_line_base64() {
+  base64 <"$1" | tr -d '\n'
+}
+
+generate_keypair job
+generate_keypair preview
+
+job_private="$(single_line_base64 "$temporary_directory/job-private.pem")"
+job_public="$(single_line_base64 "$temporary_directory/job-public.pem")"
+preview_private="$(single_line_base64 "$temporary_directory/preview-private.pem")"
+preview_public="$(single_line_base64 "$temporary_directory/preview-public.pem")"
+encryption_key="$(openssl rand -base64 32 | tr -d '\n')"
+artifact_signing_key="$(openssl rand -base64 32 | tr -d '\n')"
+dashboard_password="$(openssl rand -base64 24 | tr -d '\n')"
+s3_password="$(openssl rand -base64 32 | tr -d '\n')"
+setup_token="$(openssl rand -hex 24)"
+
+write_env() {
+  local version="$1"
+  cat >"$env_file" <<EOF
+APP_ENV=production
+ARTIFACT_SIGNING_KEY=$artifact_signing_key
+CADDY_HTTP_PORT=18080
+CADDY_HTTPS_PORT=18443
+COMPOSE_PROFILES=local-postgres
+DASHBOARD_PASSWORD=$dashboard_password
+DATABASE_URL=postgres://postgres:roomote-postgres-password@postgres:5432/roomote
+DEFAULT_COMPUTE_PROVIDER=docker
+DEPLOYMENT_CI_POSTGRES_PORT=$postgres_port
+DEPLOYMENT_CI_REDIS_PORT=$redis_port
+DOCKER_WORKER_IMAGE=localhost/roomote/roomote-worker:$version
+DOCKER_WORKER_NETWORK=$worker_network
+DOCKER_WORKER_PLATFORM=$platform
+DOCKER_WORKER_RELEASE_PATH=/roomote/releases/worker-current.tar.gz
+ENCRYPTION_KEY=$encryption_key
+IMAGE_NAMESPACE=roomote
+IMAGE_REGISTRY=localhost
+JOB_AUTH_PRIVATE_KEY=$job_private
+JOB_AUTH_PUBLIC_KEY=$job_public
+NEXT_PUBLIC_GITHUB_APP_SLUG=deployment-ci
+POSTGRES_DB=roomote
+POSTGRES_PASSWORD=roomote-postgres-password
+POSTGRES_USER=postgres
+PREVIEW_AUTH_PRIVATE_KEY=$preview_private
+PREVIEW_AUTH_PUBLIC_KEY=$preview_public
+REDIS_URL=redis://redis:6379
+ROOMOTE_APP_DOMAIN=roomote.localhost
+ROOMOTE_APP_URL=http://roomote.localhost
+ROOMOTE_DEFAULT_NETWORK=$default_network
+ROOMOTE_PREVIEW_DOMAIN=preview.roomote.localhost
+ROOMOTE_VERSION=$version
+S3_ACCESS_KEY_ID=roomote
+S3_BUCKET_ARTIFACTS=roomote-artifacts
+S3_ENDPOINT=http://minio:9000
+S3_PRESIGN_ENDPOINT=http://minio:9000
+S3_REGION=us-east-1
+S3_SECRET_ACCESS_KEY=$s3_password
+SETUP_TOKEN=$setup_token
+TRPC_URL=http://api:3001
+EOF
+}
+
+build_candidate_images() {
+  if [ "${DEPLOYMENT_CI_SKIP_BUILD:-false}" = 'true' ]; then
+    return
+  fi
+
+  printf 'Building candidate app image (%s)\n' "$platform"
+  docker buildx build --load \
+    --platform "$platform" \
+    --build-arg APP_ENV=production \
+    --build-arg "RELEASE_VERSION=$candidate_version" \
+    --tag "localhost/roomote/roomote-app:$candidate_version" \
+    --file "$repo_root/.docker/app/Dockerfile" \
+    "$repo_root"
+
+  printf 'Building candidate worker image (%s)\n' "$platform"
+  docker buildx build --load \
+    --platform "$platform" \
+    --tag "localhost/roomote/roomote-worker:$candidate_version" \
+    --file "$repo_root/apps/worker/Dockerfile" \
+    "$repo_root"
+}
+
+prepare_baseline_images() {
+  if [ -z "$baseline_version" ]; then
+    return 0
+  fi
+
+  printf 'Pulling previous release %s for upgrade validation\n' "$baseline_version"
+  docker pull --platform "$platform" "ghcr.io/roocodeinc/roomote-app:$baseline_version"
+  docker pull --platform "$platform" "ghcr.io/roocodeinc/roomote-worker:$baseline_version"
+  docker tag \
+    "ghcr.io/roocodeinc/roomote-app:$baseline_version" \
+    'localhost/roomote/roomote-app:baseline'
+  docker tag \
+    "ghcr.io/roocodeinc/roomote-worker:$baseline_version" \
+    'localhost/roomote/roomote-worker:baseline'
+}
+
+start_stack() {
+  compose up \
+    --detach \
+    --wait \
+    --wait-timeout 600 \
+    postgres redis minio minio-init db-migrate api web controller bullmq preview-proxy
+}
+
+verify_stack() {
+  local migration_container migration_exit
+  migration_container="$(compose ps --all --quiet db-migrate)"
+  [ -n "$migration_container" ] || {
+    printf 'db-migrate container was not created\n' >&2
+    return 1
+  }
+  migration_exit="$(docker inspect --format '{{.State.ExitCode}}' "$migration_container")"
+  [ "$migration_exit" = '0' ] || {
+    printf 'db-migrate exited with %s\n' "$migration_exit" >&2
+    return 1
+  }
+
+  compose exec -T api curl -fsS --max-time 5 http://127.0.0.1:3001/health/liveness >/dev/null
+  compose exec -T web curl -fsS --max-time 5 http://127.0.0.1:3000/health >/dev/null
+  compose exec -T web curl -fsS --max-time 10 "http://127.0.0.1:3000/setup?token=$setup_token" >/dev/null
+  compose exec -T controller curl -fsS --max-time 5 http://api:3001/health/controller >/dev/null
+  compose exec -T bullmq curl -fsS --max-time 5 http://127.0.0.1:3002/admin/health >/dev/null
+}
+
+write_marker() {
+  compose exec -T postgres psql -v ON_ERROR_STOP=1 -U postgres -d roomote <<'SQL'
+CREATE TABLE IF NOT EXISTS deployment_ci_marker (
+  id integer PRIMARY KEY,
+  value text NOT NULL
+);
+INSERT INTO deployment_ci_marker (id, value)
+VALUES (1, 'preserved')
+ON CONFLICT (id) DO UPDATE SET value = EXCLUDED.value;
+SQL
+}
+
+verify_marker() {
+  local value
+  value="$(compose exec -T postgres psql -At -U postgres -d roomote -c 'SELECT value FROM deployment_ci_marker WHERE id = 1')"
+  [ "$value" = 'preserved' ] || {
+    printf 'deployment marker was not preserved (got %s)\n' "$value" >&2
+    return 1
+  }
+}
+
+validate_upgrade_and_rollback() {
+  if [ -z "$baseline_version" ]; then
+    return 0
+  fi
+
+  write_env baseline
+  start_stack
+  verify_stack
+  write_marker
+
+  printf 'Upgrading previous release to candidate\n'
+  write_env "$candidate_version"
+  start_stack
+  verify_stack
+  verify_marker
+
+  printf 'Rolling back candidate to previous release\n'
+  write_env baseline
+  start_stack
+  verify_stack
+  verify_marker
+
+  printf 'Returning stack to candidate after rollback probe\n'
+  write_env "$candidate_version"
+  start_stack
+  verify_stack
+  verify_marker
+}
+
+launch_docker_task() {
+  local task_output task_json
+  printf 'Launching Docker-backed task through the production controller\n'
+  task_output="$(pnpm exec dotenvx run -f "$env_file" -- \
+    env \
+      "DATABASE_URL=postgres://postgres:roomote-postgres-password@127.0.0.1:$postgres_port/roomote" \
+      "REDIS_URL=redis://127.0.0.1:$redis_port" \
+      pnpm --filter @roomote/cloud-agents deployment:launch-docker-task)"
+  printf '%s\n' "$task_output"
+
+  task_json="$(printf '%s\n' "$task_output" | awk '/^\{.*\}$/ { line = $0 } END { print line }')"
+  launched_worker_container="$(printf '%s' "$task_json" | jq -er '.machineId')"
+  if [[ ! "$launched_worker_container" =~ ^roomote-worker-[0-9]+$ ]]; then
+    printf 'unexpected worker container name: %s\n' "$launched_worker_container" >&2
+    return 1
+  fi
+
+  compose exec -T postgres psql -v ON_ERROR_STOP=1 -U postgres -d roomote \
+    -c "UPDATE task_runs SET status = 'canceled', canceled_at = NOW(), error = 'Deployment CI probe completed' WHERE machine_id = '$launched_worker_container'"
+  docker rm --force "$launched_worker_container" >/dev/null
+  launched_worker_container=''
+}
+
+backup_and_restore_fresh_stack() {
+  printf 'Backing up candidate database\n'
+  write_marker
+  compose exec -T postgres \
+    pg_dump --clean --if-exists --no-owner --no-privileges -U postgres roomote \
+    >"$backup_file"
+  test -s "$backup_file"
+
+  printf 'Restoring backup onto fresh volumes\n'
+  compose down --volumes --remove-orphans
+  write_env "$candidate_version"
+  compose up --detach --wait --wait-timeout 180 postgres redis minio minio-init
+  compose exec -T postgres psql --quiet -v ON_ERROR_STOP=1 -U postgres -d roomote <"$backup_file"
+  start_stack
+  verify_stack
+  verify_marker
+}
+
+cd "$repo_root"
+write_env "$candidate_version"
+build_candidate_images
+prepare_baseline_images
+
+if [ -n "$baseline_version" ]; then
+  validate_upgrade_and_rollback
+else
+  start_stack
+  verify_stack
+fi
+
+launch_docker_task
+backup_and_restore_fresh_stack
+
+printf 'Deployment smoke test passed for %s on %s\n' "$candidate_version" "$platform"

--- a/deploy/ci/docker-compose.ci.yml
+++ b/deploy/ci/docker-compose.ci.yml
@@ -1,0 +1,45 @@
+services:
+  db-migrate:
+    env_file: !reset []
+
+  web:
+    env_file: !reset []
+
+  api:
+    env_file: !reset []
+
+  controller:
+    env_file: !reset []
+
+  bullmq:
+    env_file: !reset []
+
+  preview-proxy:
+    env_file: !reset []
+
+  postgres:
+    ports:
+      - '127.0.0.1:${DEPLOYMENT_CI_POSTGRES_PORT:-55432}:5432'
+
+  redis:
+    ports:
+      - '127.0.0.1:${DEPLOYMENT_CI_REDIS_PORT:-56379}:6379'
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+  minio:
+    healthcheck:
+      test: ['CMD', 'mc', 'ready', 'local']
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 5s
+
+networks:
+  default:
+    name: ${ROOMOTE_DEFAULT_NETWORK:-roomote_ci_default}
+  worker:
+    name: ${DOCKER_WORKER_NETWORK:-roomote_ci_worker}

--- a/deploy/ci/validate-deployment-artifacts.mjs
+++ b/deploy/ci/validate-deployment-artifacts.mjs
@@ -1,0 +1,286 @@
+import { execFileSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { parse as parseToml } from 'smol-toml';
+import YAML from 'yaml';
+
+const root = resolve(import.meta.dirname, '../..');
+const read = (path) => readFileSync(join(root, path), 'utf8');
+const catalog = JSON.parse(read('deploy/deployment-catalog.json'));
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function assert(condition, message) {
+  if (!condition) fail(message);
+}
+
+function commandText(command) {
+  if (Array.isArray(command)) return command.join(' ');
+  return String(command ?? '');
+}
+
+const composeEnv = {
+  ...process.env,
+  APP_ENV: 'production',
+  ARTIFACT_SIGNING_KEY: 'deployment-ci-artifact-signing-key',
+  CADDY_HTTP_PORT: '18080',
+  CADDY_HTTPS_PORT: '18443',
+  COMPOSE_PROFILES: 'local-postgres',
+  DASHBOARD_PASSWORD: 'deployment-ci-dashboard-password',
+  DATABASE_URL: 'postgres://postgres:password@postgres:5432/roomote',
+  DEFAULT_COMPUTE_PROVIDER: 'docker',
+  DOCKER_WORKER_IMAGE: 'roomote-worker:deployment-ci',
+  ENCRYPTION_KEY: 'deployment-ci-encryption-key',
+  IMAGE_NAMESPACE: 'roomote',
+  IMAGE_REGISTRY: 'localhost',
+  JOB_AUTH_PRIVATE_KEY: 'deployment-ci-job-private-key',
+  JOB_AUTH_PUBLIC_KEY: 'deployment-ci-job-public-key',
+  NEXT_PUBLIC_GITHUB_APP_SLUG: 'deployment-ci',
+  PREVIEW_AUTH_PRIVATE_KEY: 'deployment-ci-preview-private-key',
+  PREVIEW_AUTH_PUBLIC_KEY: 'deployment-ci-preview-public-key',
+  REDIS_URL: 'redis://redis:6379',
+  ROOMOTE_APP_DOMAIN: 'roomote.localhost',
+  ROOMOTE_PREVIEW_DOMAIN: 'preview.roomote.localhost',
+  ROOMOTE_VERSION: 'deployment-ci',
+  S3_ACCESS_KEY_ID: 'roomote',
+  S3_SECRET_ACCESS_KEY: 'deployment-ci-minio-password',
+};
+
+function validateComposeShape(shape) {
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), 'roomote-compose-'));
+  let files = shape.files.map((file) => join(root, file));
+
+  try {
+    if (shape.coolify) {
+      const normalized = read(shape.files[0]).replace(
+        /^([ \t]*)exclude_from_hc:/gm,
+        '$1x-exclude_from_hc:',
+      );
+      const normalizedPath = join(temporaryDirectory, 'docker-compose.yaml');
+      writeFileSync(normalizedPath, normalized);
+      files = [normalizedPath];
+    } else if (
+      shape.files.length === 1 &&
+      read(shape.files[0]).includes('    - .env')
+    ) {
+      const serviceEnvPath = join(temporaryDirectory, 'service.env');
+      writeFileSync(
+        serviceEnvPath,
+        Object.entries(composeEnv)
+          .filter(([, value]) => typeof value === 'string')
+          .map(([key, value]) => `${key}=${value}`)
+          .join('\n'),
+      );
+      const normalized = read(shape.files[0]).replace(
+        '    - .env',
+        `    - ${serviceEnvPath}`,
+      );
+      const normalizedPath = join(temporaryDirectory, 'docker-compose.yml');
+      writeFileSync(normalizedPath, normalized);
+      files = [normalizedPath];
+    }
+
+    const args = ['compose', '--profile', '*'];
+    for (const file of files) args.push('-f', file);
+    args.push('config', '--format', 'json');
+
+    const output = execFileSync('docker', args, {
+      cwd: root,
+      env: composeEnv,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const config = JSON.parse(output);
+
+    assert(
+      config.services && Object.keys(config.services).length > 0,
+      `${shape.name}: docker compose config produced no services`,
+    );
+
+    if (shape.requiresExecutionHealth) {
+      for (const serviceName of ['controller', 'bullmq']) {
+        const service = config.services[serviceName];
+        assert(service, `${shape.name}: missing ${serviceName} service`);
+        assert(
+          service.healthcheck?.test?.length,
+          `${shape.name}: ${serviceName} must have a production healthcheck`,
+        );
+      }
+    }
+
+    console.log(`validated compose shape: ${shape.name}`);
+  } finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+for (const shape of catalog.composeShapes) validateComposeShape(shape);
+
+const railway = YAML.parse(read('deploy/railway/template.yaml'));
+for (const [name, contract] of Object.entries(catalog.runtimeServices)) {
+  const service = railway.services?.[name];
+  assert(service, `railway: missing ${name}`);
+  assert(
+    commandText(service.start_command).endsWith(` ${contract.command}`),
+    `railway: ${name} does not use the ${contract.command} app command`,
+  );
+  if (service.healthcheck_path) {
+    assert(
+      service.healthcheck_path === contract.healthPath,
+      `railway: ${name} health path drifted from the catalog`,
+    );
+  }
+}
+for (const key of catalog.sharedPlatformEnvironment) {
+  assert(
+    key in railway.services.api.env,
+    `railway: api is missing shared ${key}`,
+  );
+}
+
+const render = YAML.parse(read('render.yaml'));
+const renderServices = new Map(
+  render.services.map((service) => [
+    service.name.replace(/^roomote-/, ''),
+    service,
+  ]),
+);
+for (const [name, contract] of Object.entries(catalog.runtimeServices)) {
+  if (name === 'controller' || name === 'bullmq') {
+    assert(renderServices.has(name), `render: missing ${name}`);
+  } else {
+    assert(
+      renderServices.get(name)?.healthCheckPath === contract.healthPath,
+      `render: ${name} health path drifted from the catalog`,
+    );
+  }
+  assert(
+    commandText(renderServices.get(name)?.dockerCommand).endsWith(
+      ` ${contract.command}`,
+    ),
+    `render: ${name} does not use the ${contract.command} app command`,
+  );
+}
+assert(
+  renderServices.get('api')?.preDeployCommand?.endsWith(' db-migrate'),
+  'render: api must run migrations before deploy',
+);
+
+const coolify = YAML.parse(read('deploy/coolify/docker-compose.yaml'));
+for (const [name, contract] of Object.entries(catalog.runtimeServices)) {
+  const service = coolify.services?.[name];
+  assert(service, `coolify: missing ${name}`);
+  assert(
+    commandText(service.command) === contract.command,
+    `coolify: ${name} command drifted from the catalog`,
+  );
+  if (name !== 'controller' && name !== 'bullmq') {
+    assert(
+      commandText(service.healthcheck?.test).includes(contract.healthPath),
+      `coolify: ${name} health path drifted from the catalog`,
+    );
+  }
+}
+
+const fly = parseToml(read('deploy/fly/fly.toml'));
+for (const [name, contract] of Object.entries(catalog.runtimeServices)) {
+  if (name === 'api' || name === 'web') {
+    assert(
+      fly.processes?.[name] === contract.command,
+      `fly: ${name} command drifted from the catalog`,
+    );
+  } else {
+    assert(
+      fly.processes?.[name] === contract.command,
+      `fly: missing ${name} process`,
+    );
+  }
+}
+assert(
+  fly.deploy?.release_command === 'db-migrate',
+  'fly: missing migration release command',
+);
+
+const imageLocations = {
+  postgres: [
+    'docker-compose.yml',
+    'deploy/compose/docker-compose.prod.yml',
+    'deploy/coolify/docker-compose.yaml',
+    'deploy/scripts/backup.sh',
+    'deploy/scripts/restore.sh',
+    'deploy/host/roomote',
+  ],
+  redis: [
+    'docker-compose.yml',
+    'deploy/compose/docker-compose.prod.yml',
+    'deploy/coolify/docker-compose.yaml',
+  ],
+  minio: [
+    'docker-compose.yml',
+    'deploy/compose/docker-compose.prod.yml',
+    'deploy/coolify/docker-compose.yaml',
+    'deploy/railway/template.yaml',
+    'render.yaml',
+  ],
+  minioClient: ['docker-compose.yml', 'deploy/compose/docker-compose.prod.yml'],
+  caddy: [
+    'docker-compose.yml',
+    'docker-compose.production.yml',
+    'deploy/compose/docker-compose.prod.yml',
+  ],
+};
+
+for (const [imageName, locations] of Object.entries(imageLocations)) {
+  const pinnedImage = catalog.criticalImages[imageName];
+  for (const location of locations) {
+    assert(
+      read(location).includes(pinnedImage),
+      `${location}: ${imageName} must match deployment-catalog.json`,
+    );
+  }
+}
+
+for (const script of [
+  'deploy/install.sh',
+  'deploy/host/roomote',
+  'deploy/scripts/backup.sh',
+  'deploy/scripts/deploy.sh',
+  'deploy/scripts/destroy.sh',
+  'deploy/scripts/lib.sh',
+  'deploy/scripts/prune-release-images.sh',
+  'deploy/scripts/restore.sh',
+  'deploy/scripts/roomote-deploy',
+  'deploy/scripts/upgrade.sh',
+  'deploy/ci/deployment-smoke.sh',
+]) {
+  execFileSync('bash', ['-n', join(root, script)], { stdio: 'pipe' });
+}
+
+for (const directory of ['.github/workflows', '.github/actions']) {
+  for (const entry of readdirSync(join(root, directory), { recursive: true })) {
+    if (!/\.ya?ml$/.test(entry)) continue;
+    const path = join(directory, entry);
+    for (const match of read(path).matchAll(
+      /^\s*uses:\s*([^\s#]+)(?:\s*#.*)?$/gm,
+    )) {
+      const target = match[1];
+      if (target.startsWith('./')) continue;
+      assert(
+        /@[0-9a-f]{40}$/.test(target),
+        `${path}: external action is not pinned to a commit SHA: ${target}`,
+      );
+    }
+  }
+}
+
+console.log('deployment artifacts match the shared catalog');

--- a/deploy/ci/validate-deployment-artifacts.mjs
+++ b/deploy/ci/validate-deployment-artifacts.mjs
@@ -194,17 +194,10 @@ for (const [name, contract] of Object.entries(catalog.runtimeServices)) {
 
 const fly = parseToml(read('deploy/fly/fly.toml'));
 for (const [name, contract] of Object.entries(catalog.runtimeServices)) {
-  if (name === 'api' || name === 'web') {
-    assert(
-      fly.processes?.[name] === contract.command,
-      `fly: ${name} command drifted from the catalog`,
-    );
-  } else {
-    assert(
-      fly.processes?.[name] === contract.command,
-      `fly: missing ${name} process`,
-    );
-  }
+  assert(
+    fly.processes?.[name] === contract.command,
+    `fly: ${name} command drifted from the catalog`,
+  );
 }
 assert(
   fly.deploy?.release_command === 'db-migrate',

--- a/deploy/compose/docker-compose.prod.yml
+++ b/deploy/compose/docker-compose.prod.yml
@@ -218,7 +218,7 @@ x-roomote-service: &roomote-service
 
 services:
   postgres:
-    image: postgres:17.5
+    image: postgres:17.5@sha256:aadf2c0696f5ef357aa7a68da995137f0cf17bad0bf6e1f17de06ae5c769b302
     profiles:
       - local-postgres
     restart: unless-stopped
@@ -236,14 +236,14 @@ services:
       start_period: 30s
 
   redis:
-    image: redis:7-alpine
+    image: redis:7-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
     restart: unless-stopped
     volumes:
       - redis_data:/data
     command: redis-server --appendonly yes
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     restart: unless-stopped
     volumes:
       - minio_data:/data
@@ -253,7 +253,7 @@ services:
     command: server /data --console-address ':9001'
 
   minio-init:
-    image: minio/mc:latest
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
     restart: 'no'
     depends_on:
       minio:
@@ -382,6 +382,16 @@ services:
         condition: service_started
     environment:
       <<: *roomote-controller-env
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'curl -fsS --max-time 5 http://api:3001/health/controller >/dev/null',
+        ]
+      interval: 5s
+      timeout: 6s
+      retries: 12
+      start_period: 20s
 
   bullmq:
     <<: *roomote-service
@@ -395,6 +405,16 @@ services:
     environment:
       <<: *roomote-bullmq-env
       PORT: 3002
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'curl -fsS --max-time 5 http://127.0.0.1:3002/admin/health >/dev/null',
+        ]
+      interval: 5s
+      timeout: 6s
+      retries: 12
+      start_period: 20s
 
   preview-proxy:
     <<: *roomote-service
@@ -420,7 +440,7 @@ services:
       start_period: 20s
 
   caddy:
-    image: caddy:2.10-alpine
+    image: caddy:2.10-alpine@sha256:4c6e91c6ed0e2fa03efd5b44747b625fec79bc9cd06ac5235a779726618e530d
     restart: unless-stopped
     depends_on:
       api:

--- a/deploy/coolify/README.md
+++ b/deploy/coolify/README.md
@@ -100,14 +100,14 @@ edits are needed — the derived values follow the images.
 
 | Service         | Image                  | Public domain              | Healthcheck        |
 | --------------- | ---------------------- | -------------------------- | ------------------ |
-| `postgres`      | `postgres:17.5`        | no                         | `pg_isready`       |
-| `redis`         | `redis:7-alpine`       | no                         | `redis-cli ping`   |
-| `minio`         | `minio/minio` + volume | yes (routed to port 9000)  | `mc ready local`   |
+| `postgres`      | pinned `postgres:17.5` | no                         | `pg_isready`       |
+| `redis`         | pinned `redis:7-alpine` | no                        | `redis-cli ping`   |
+| `minio`         | pinned MinIO + volume  | yes (routed to port 9000)  | `mc ready local`   |
 | `db-migrate`    | `roomote-app:develop`  | no (one-shot)              | excluded           |
 | `web`           | `roomote-app:develop`  | yes (port 3000)            | `/health`          |
 | `api`           | `roomote-app:develop`  | yes (port 3001)            | `/health/liveness` |
-| `controller`    | `roomote-app:develop`  | no                         | —                  |
-| `bullmq`        | `roomote-app:develop`  | no                         | —                  |
+| `controller`    | `roomote-app:develop`  | no                         | `/health/controller` via API |
+| `bullmq`        | `roomote-app:develop`  | no                         | `/admin/health`    |
 | `preview-proxy` | `roomote-app:develop`  | optional (wildcard domain) | `/health`          |
 
 ## Environment variables

--- a/deploy/coolify/docker-compose.yaml
+++ b/deploy/coolify/docker-compose.yaml
@@ -69,7 +69,7 @@ x-roomote-shared-env: &roomote-shared-env
 
 services:
   postgres:
-    image: postgres:17.5
+    image: postgres:17.5@sha256:aadf2c0696f5ef357aa7a68da995137f0cf17bad0bf6e1f17de06ae5c769b302
     restart: unless-stopped
     volumes:
       - pg_data:/var/lib/postgresql/data
@@ -85,7 +85,7 @@ services:
       start_period: 30s
 
   redis:
-    image: redis:7-alpine
+    image: redis:7-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
     restart: unless-stopped
     volumes:
       - redis_data:/data
@@ -97,7 +97,7 @@ services:
       retries: 12
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     restart: unless-stopped
     command: server /data --console-address ':9001'
     volumes:
@@ -238,6 +238,16 @@ services:
       # roomote_worker network is not wired up here until that is verified
       # against a live Coolify deployment.
       DOCKER_WORKER_NETWORK: roomote_default
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'curl -fsS --max-time 5 http://api:3001/health/controller >/dev/null',
+        ]
+      interval: 5s
+      timeout: 6s
+      retries: 12
+      start_period: 20s
 
   bullmq:
     image: *roomote-app-image
@@ -251,6 +261,16 @@ services:
     environment:
       <<: *roomote-shared-env
       PORT: 3002
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'curl -fsS --max-time 5 http://127.0.0.1:3002/admin/health >/dev/null',
+        ]
+      interval: 5s
+      timeout: 6s
+      retries: 12
+      start_period: 20s
 
   # Optional. Uncomment only when enabling live previews with a wildcard
   # domain routed to this service; everything else works without it. See

--- a/deploy/deployment-catalog.json
+++ b/deploy/deployment-catalog.json
@@ -1,0 +1,79 @@
+{
+  "criticalImages": {
+    "postgres": "postgres:17.5@sha256:aadf2c0696f5ef357aa7a68da995137f0cf17bad0bf6e1f17de06ae5c769b302",
+    "redis": "redis:7-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99",
+    "minio": "minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e",
+    "minioClient": "minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727",
+    "caddy": "caddy:2.10-alpine@sha256:4c6e91c6ed0e2fa03efd5b44747b625fec79bc9cd06ac5235a779726618e530d"
+  },
+  "composeShapes": [
+    {
+      "name": "development",
+      "files": ["docker-compose.yml"]
+    },
+    {
+      "name": "self-host",
+      "files": ["docker-compose.yml", "docker-compose.self-host.yml"]
+    },
+    {
+      "name": "self-host-production",
+      "files": [
+        "docker-compose.yml",
+        "docker-compose.self-host.yml",
+        "docker-compose.production.yml"
+      ],
+      "requiresExecutionHealth": true
+    },
+    {
+      "name": "self-host-docker-compute",
+      "files": [
+        "docker-compose.yml",
+        "docker-compose.self-host.yml",
+        "docker-compose.compute-docker.yml"
+      ]
+    },
+    {
+      "name": "installer-production",
+      "files": ["deploy/compose/docker-compose.prod.yml"],
+      "requiresExecutionHealth": true
+    },
+    {
+      "name": "coolify",
+      "files": ["deploy/coolify/docker-compose.yaml"],
+      "coolify": true,
+      "requiresExecutionHealth": true
+    }
+  ],
+  "runtimeServices": {
+    "api": {
+      "command": "api",
+      "healthPath": "/health/liveness"
+    },
+    "web": {
+      "command": "web",
+      "healthPath": "/health"
+    },
+    "controller": {
+      "command": "controller",
+      "healthPath": "/health/controller"
+    },
+    "bullmq": {
+      "command": "bullmq",
+      "healthPath": "/admin/health"
+    }
+  },
+  "sharedPlatformEnvironment": [
+    "APP_ENV",
+    "ROOMOTE_DOCKER_LOAD_ENV_FILE",
+    "ROOMOTE_AUTO_GENERATE_KEYS",
+    "ENCRYPTION_KEY",
+    "ARTIFACT_SIGNING_KEY",
+    "DASHBOARD_PASSWORD",
+    "SETUP_TOKEN",
+    "DATABASE_URL",
+    "REDIS_URL",
+    "S3_ENDPOINT",
+    "S3_PRESIGN_ENDPOINT",
+    "DEFAULT_COMPUTE_PROVIDER"
+  ]
+}

--- a/deploy/host/roomote
+++ b/deploy/host/roomote
@@ -331,7 +331,7 @@ cmd_backup() {
 
   log "Dumping database to $install_root/$backup_file"
   docker run --rm --network roomote_default --env-file "$env_file" \
-    postgres:17.5 sh -c 'pg_dump --clean --if-exists --no-owner --no-privileges "$DATABASE_URL"' \
+    postgres:17.5@sha256:aadf2c0696f5ef357aa7a68da995137f0cf17bad0bf6e1f17de06ae5c769b302 sh -c 'pg_dump --clean --if-exists --no-owner --no-privileges "$DATABASE_URL"' \
     >"$install_root/$backup_file"
   log "Backup written to $install_root/$backup_file"
 }
@@ -351,11 +351,11 @@ cmd_restore() {
 
   log "Dropping and recreating the public schema"
   docker run --rm --network roomote_default --env-file "$env_file" \
-    postgres:17.5 sh -c 'psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;"'
+    postgres:17.5@sha256:aadf2c0696f5ef357aa7a68da995137f0cf17bad0bf6e1f17de06ae5c769b302 sh -c 'psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;"'
 
   log "Restoring $backup_file"
   docker run --rm --network roomote_default --env-file "$env_file" -i \
-    postgres:17.5 sh -c 'psql "$DATABASE_URL" -v ON_ERROR_STOP=1' \
+    postgres:17.5@sha256:aadf2c0696f5ef357aa7a68da995137f0cf17bad0bf6e1f17de06ae5c769b302 sh -c 'psql "$DATABASE_URL" -v ON_ERROR_STOP=1' \
     <"$backup_file"
 
   log "Restarting app services"

--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -107,7 +107,7 @@ follow the image.
 | --------------- | --------------------------------- | -------------------------------------------------- | -------------------------- | ------------------ |
 | `Postgres`      | Railway managed PostgreSQL        | —                                                  | no                         | managed            |
 | `Redis`         | Railway managed Redis             | —                                                  | no                         | managed            |
-| `minio`         | `minio/minio` + volume at `/data` | `minio server /data --console-address :9001`       | yes (HTTP proxy port 9000) | —                  |
+| `minio`         | pinned `minio/minio` + `/data`    | `minio server /data --console-address :9001`       | yes (HTTP proxy port 9000) | —                  |
 | `web`           | `roomote-app:<channel>`           | `/roomote/.docker/app/entrypoint.sh web`           | yes (HTTP proxy port 8080) | `/health`          |
 | `api`           | `roomote-app:<channel>`           | `/roomote/.docker/app/entrypoint.sh api`           | yes (HTTP proxy port 8080) | `/health/liveness` |
 | `controller`    | `roomote-app:<channel>`           | `/roomote/.docker/app/entrypoint.sh controller`    | no                         | —                  |

--- a/deploy/railway/template.yaml
+++ b/deploy/railway/template.yaml
@@ -106,7 +106,7 @@ services:
     notes: Provides `${{Redis.REDIS_URL}}`. Prefer the private-network URL.
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     service_name: minio # rename from the default "minio/minio" — the slash breaks ${{minio.*}} references
     start_command: minio server /data --console-address :9001
     volume: /data

--- a/deploy/render/README.md
+++ b/deploy/render/README.md
@@ -133,8 +133,8 @@ production deployments): put the same immutable tag (`v*` or
 are needed — the derived values follow the image.
 
 MinIO is the exception: the Blueprint pins it to an immutable `RELEASE.*`
-tag because the service owns the artifact disk, and a mutable `latest` tag
-could pull an unreviewed breaking change on redeploy. Bump the pin
+tag and manifest digest because the service owns the artifact disk, and a
+mutable `latest` tag could pull an unreviewed breaking change on redeploy. Bump the pin
 deliberately, ideally right after a disk backup.
 
 ## Service topology

--- a/deploy/scripts/backup.sh
+++ b/deploy/scripts/backup.sh
@@ -75,7 +75,7 @@ set -euo pipefail
 cd /opt/roomote
 mkdir -p backups
 backup="backups/backup-$(date +%F-%H%M%S).sql"
-docker run --rm --network roomote_default --env-file /opt/roomote/.env postgres:17.5 sh -c 'pg_dump --clean --if-exists --no-owner --no-privileges "$DATABASE_URL"' > "$backup"
+docker run --rm --network roomote_default --env-file /opt/roomote/.env postgres:17.5@sha256:aadf2c0696f5ef357aa7a68da995137f0cf17bad0bf6e1f17de06ae5c769b302 sh -c 'pg_dump --clean --if-exists --no-owner --no-privileges "$DATABASE_URL"' > "$backup"
 chmod 600 "$backup"
 printf '/opt/roomote/%s\n' "$backup"
 REMOTE

--- a/deploy/scripts/restore.sh
+++ b/deploy/scripts/restore.sh
@@ -89,8 +89,8 @@ cd /opt/roomote
 # Quiesce the app services so live connections are not killed mid-restore and
 # nothing writes to the database while the dump loads.
 docker compose --env-file .env -f docker-compose.prod.yml stop web api controller bullmq preview-proxy
-docker run --rm --network roomote_default --env-file /opt/roomote/.env postgres:17.5 sh -c 'psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;"'
-docker run --rm --network roomote_default --env-file /opt/roomote/.env -i postgres:17.5 sh -c 'psql "$DATABASE_URL" -v ON_ERROR_STOP=1' < "$ROOMOTE_RESTORE_BACKUP"
+docker run --rm --network roomote_default --env-file /opt/roomote/.env postgres:17.5@sha256:aadf2c0696f5ef357aa7a68da995137f0cf17bad0bf6e1f17de06ae5c769b302 sh -c 'psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;"'
+docker run --rm --network roomote_default --env-file /opt/roomote/.env -i postgres:17.5@sha256:aadf2c0696f5ef357aa7a68da995137f0cf17bad0bf6e1f17de06ae5c769b302 sh -c 'psql "$DATABASE_URL" -v ON_ERROR_STOP=1' < "$ROOMOTE_RESTORE_BACKUP"
 docker compose --env-file .env -f docker-compose.prod.yml up -d --wait --wait-timeout 600
 REMOTE
 

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -104,35 +104,85 @@ services:
     environment:
       <<: *roomote-production-env
     ports: !reset []
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'curl -fsS --max-time 2 http://127.0.0.1:3000/health >/dev/null',
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 20s
 
   api:
     environment:
       <<: *roomote-production-env
     ports: !reset []
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'curl -fsS --max-time 2 http://127.0.0.1:3001/health/liveness >/dev/null',
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 20s
 
   controller:
     environment:
       <<: *roomote-production-env
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'curl -fsS --max-time 5 http://api:3001/health/controller >/dev/null',
+        ]
+      interval: 5s
+      timeout: 6s
+      retries: 12
+      start_period: 20s
 
   bullmq:
     environment:
       <<: *roomote-production-env
     ports: !reset []
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'curl -fsS --max-time 5 http://127.0.0.1:3002/admin/health >/dev/null',
+        ]
+      interval: 5s
+      timeout: 6s
+      retries: 12
+      start_period: 20s
 
   preview-proxy:
     environment:
       <<: *roomote-production-env
     ports: !reset []
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'curl -fsS --max-time 2 http://127.0.0.1:8081/health >/dev/null',
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 20s
 
   caddy:
-    image: caddy:2.10-alpine
+    image: caddy:2.10-alpine@sha256:4c6e91c6ed0e2fa03efd5b44747b625fec79bc9cd06ac5235a779726618e530d
     container_name: roomote-caddy
     restart: unless-stopped
     depends_on:
       web:
-        condition: service_started
+        condition: service_healthy
       preview-proxy:
-        condition: service_started
+        condition: service_healthy
     environment:
       ROOMOTE_APP_DOMAIN: ${ROOMOTE_APP_DOMAIN:?ROOMOTE_APP_DOMAIN is required}
       ROOMOTE_PREVIEW_DOMAIN: ${ROOMOTE_PREVIEW_DOMAIN:?ROOMOTE_PREVIEW_DOMAIN is required}

--- a/docker-compose.self-host.yml
+++ b/docker-compose.self-host.yml
@@ -166,6 +166,16 @@ services:
         condition: service_completed_successfully
       api:
         condition: service_started
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'curl -fsS --max-time 5 http://api:3001/health/controller >/dev/null',
+        ]
+      interval: 5s
+      timeout: 6s
+      retries: 12
+      start_period: 20s
 
   bullmq:
     <<: *roomote-service
@@ -177,6 +187,16 @@ services:
       PORT: 3002
     ports:
       - '127.0.0.1:13002:3002'
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'curl -fsS --max-time 5 http://127.0.0.1:3002/admin/health >/dev/null',
+        ]
+      interval: 5s
+      timeout: 6s
+      retries: 12
+      start_period: 20s
 
   preview-proxy:
     <<: *roomote-service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ name: roomote
 services:
   postgres:
     container_name: roomote-postgres
-    image: postgres:17.5
+    image: postgres:17.5@sha256:aadf2c0696f5ef357aa7a68da995137f0cf17bad0bf6e1f17de06ae5c769b302
     # Publish datastore ports to loopback only so Postgres, Redis, and MinIO are
     # never reachable from another host. The production Caddy overlay resets
     # these to none; use an SSH tunnel or reverse proxy if remote access is
@@ -26,7 +26,7 @@ services:
 
   redis:
     container_name: roomote-redis
-    image: redis:7-alpine
+    image: redis:7-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
     ports:
       - '127.0.0.1:16379:6379'
     volumes:
@@ -35,7 +35,7 @@ services:
 
   minio:
     container_name: roomote-minio
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     ports:
       - '127.0.0.1:19000:9000'
       - '127.0.0.1:19001:9001'
@@ -47,7 +47,7 @@ services:
     command: server /data --console-address ':9001'
 
   minio-init:
-    image: minio/mc:latest
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
     restart: 'no'
     depends_on:
       minio:
@@ -70,7 +70,7 @@ services:
   # workers can reach the API through the public app URL.
   caddy-dev:
     container_name: roomote-caddy-dev
-    image: caddy:2.10-alpine
+    image: caddy:2.10-alpine@sha256:4c6e91c6ed0e2fa03efd5b44747b625fec79bc9cd06ac5235a779726618e530d
     ports:
       - '127.0.0.1:18080:18080'
     volumes:

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "db:reset": "pnpm db:down && docker volume rm -f roomote_pg_data roomote_redis_data roomote_minio_data && pnpm db:up",
     "db:seed": "pnpm --silent --filter @roomote/db db:seed",
     "db:seed:demo": "pnpm --silent --filter @roomote/db db:seed:demo",
+    "deployment:validate": "node deploy/ci/validate-deployment-artifacts.mjs",
+    "deployment:smoke": "bash deploy/ci/deployment-smoke.sh",
     "dev": "pnpm --silent --filter @roomote/dev dev",
     "doctor": "pnpm --filter @roomote/dev run doctor",
     "storybook": "pnpm --filter @roomote/web storybook",
@@ -50,9 +52,11 @@
     "lint-staged": "^16.2.7",
     "prettier": "^3.8.1",
     "rimraf": "^6.1.2",
+    "smol-toml": "1.6.1",
     "tsx": "4.20.4",
     "turbo": "^2.9.14",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "yaml": "^2.9.0"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,css}": [

--- a/packages/cloud-agents/package.json
+++ b/packages/cloud-agents/package.json
@@ -55,6 +55,7 @@
     "check-types:fast": "tsgo --noEmit",
     "test": "dotenvx run -f ../../.env.test -- vitest",
     "test:router": "dotenvx run -f ../../.env.local -- tsx scripts/test-llm-router.ts",
+    "deployment:launch-docker-task": "tsx src/server/deployment-ci-launch-task.ts",
     "clean": "rimraf .turbo",
     "eval:authorship": "dotenvx run -f ../../.env.local -- npx promptfoo@0.115.0 eval -c evals/authorship/promptfooconfig.ts --no-cache --table-cell-max-length 200",
     "eval:router": "dotenvx run -f ../../.env.local -- npx promptfoo@0.115.0 eval -c evals/router/promptfooconfig.ts --no-cache --table-cell-max-length 200",

--- a/packages/cloud-agents/src/server/deployment-ci-launch-task.ts
+++ b/packages/cloud-agents/src/server/deployment-ci-launch-task.ts
@@ -1,0 +1,68 @@
+import { db, ensureAutomationRows, eq, taskRuns } from '@roomote/db/server';
+import { ALL_REPOSITORIES, RunStatus, TaskPayloadKind } from '@roomote/types';
+
+import { enqueueTask } from './cloud-job-queue';
+
+const timeoutMs = Number(process.env.DEPLOYMENT_CI_TASK_TIMEOUT_MS ?? 90_000);
+
+await ensureAutomationRows();
+
+const run = await enqueueTask(
+  {
+    task: {
+      type: TaskPayloadKind.StandardTask,
+      computeProvider: 'docker',
+      requestedWorkKindDecision: {
+        kind: 'question',
+        source: 'explicit_bootstrap',
+        confidence: null,
+      },
+      payload: {
+        repo: ALL_REPOSITORIES,
+        description:
+          'Deployment CI probe. Start the Docker task sandbox and then exit.',
+      },
+    },
+    initiator: { kind: 'automation', key: 'suggester' },
+    workflow: 'standard',
+    surface: 'api',
+    trigger: 'manual',
+    visibility: 'hidden',
+  },
+  { skipEarlyTitleGeneration: true },
+);
+
+const deadline = Date.now() + timeoutMs;
+
+while (Date.now() < deadline) {
+  const current = await db.query.taskRuns.findFirst({
+    where: eq(taskRuns.id, run.id),
+    columns: {
+      id: true,
+      machineId: true,
+      vendor: true,
+      status: true,
+      error: true,
+    },
+  });
+
+  if (current?.machineId && current.vendor === 'docker') {
+    console.log(JSON.stringify(current));
+    process.exit(0);
+  }
+
+  if (
+    current?.status === RunStatus.Failed ||
+    current?.status === RunStatus.Canceled
+  ) {
+    throw new Error(
+      `Docker task ${run.id} failed before a sandbox was launched: ${current.error ?? current.status}`,
+    );
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 1_000));
+}
+
+throw new Error(
+  `Timed out after ${timeoutMs}ms waiting for Docker task ${run.id} to launch`,
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       rimraf:
         specifier: ^6.1.2
         version: 6.1.2
+      smol-toml:
+        specifier: 1.6.1
+        version: 1.6.1
       tsx:
         specifier: 4.20.4
         version: 4.20.4
@@ -96,6 +99,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
   apps/api:
     dependencies:

--- a/render.yaml
+++ b/render.yaml
@@ -85,7 +85,7 @@ services:
       # Pinned to an immutable MinIO release: this service owns a persistent
       # disk, so a mutable `latest` tag could pull an unreviewed breaking
       # change on redeploy. Bump deliberately alongside a disk backup.
-      url: docker.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
+      url: docker.io/minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     plan: starter
     dockerCommand: minio server /data --address :9000 --console-address :9001
     healthCheckPath: /minio/health/live


### PR DESCRIPTION
## What changed

- build both app and worker images in pull-request CI
- validate every maintained Compose shape plus Railway, Render, Coolify, and Fly against a shared deployment catalog
- add production controller and BullMQ health checks
- gate image publishing on a production deployment lifecycle: generated secrets, migrations, setup/health probes, Docker-backed task launch, prior-channel upgrade, rollback, backup, and fresh-volume restore
- retain native amd64 and arm64 release builds
- pin critical infrastructure images and external GitHub Actions to immutable digests/commit SHAs

## Why

Deployment artifacts were not first-class CI inputs, so `docker compose up --wait` could succeed while the execution plane was unhealthy and release-only deployment paths could drift unnoticed.

## Validation

- `pnpm deployment:validate`
- `pnpm --filter @roomote/cloud-agents check-types`
- `pnpm --filter @roomote/cloud-agents lint`
- `pnpm knip`
- pre-push `pnpm lint:fast`, `pnpm check-types:fast`, and `pnpm knip`
- production app and worker image builds on linux/arm64
- prior `develop` image → candidate migration → rollback → candidate
- Docker-backed task launch through the production controller
- backup restored onto fresh Compose volumes with all services healthy

## Compatibility note

`v0.0.1` predates the current rewritten Drizzle migration baseline and cannot be used as a direct migration predecessor. For the first gated tagged release, CI tests the prior published `main` candidate. Subsequent tagged releases use the immediately preceding immutable release tag.
