### PR TITLE
[Fix] Recognize database-configured GitHub App slugs in bot-identity checks

### DIFF
--- a/apps/api/src/handlers/github/__tests__/handlePrComment.test.ts
+++ b/apps/api/src/handlers/github/__tests__/handlePrComment.test.ts
@@ -21,6 +21,7 @@ vi.mock('@roomote/github', () => ({
   Schemas: {
     isRoomoteGitHubLogin: vi.fn(() => false),
   },
+  getEffectiveGitHubAppSlug: vi.fn(() => 'roomote'),
   getInstallationOctokit: mockGetInstallationOctokit,
 }));
 

--- a/apps/api/src/handlers/github/__tests__/index.test.ts
+++ b/apps/api/src/handlers/github/__tests__/index.test.ts
@@ -14,6 +14,7 @@ const {
   mockQueuePrReviewActivityNotification,
   mockQueuePrReviewSummaryNotification,
   mockRecordWebhook,
+  mockResolveConfiguredGitHubAppSlug,
   mockResolveDeploymentEnvVar,
   mockUpdateTaskPrStatus,
   mockUpsertGitHubPullRequestFactFromWebhook,
@@ -40,6 +41,7 @@ const {
   mockQueuePrReviewActivityNotification: vi.fn(),
   mockQueuePrReviewSummaryNotification: vi.fn(),
   mockRecordWebhook: vi.fn(),
+  mockResolveConfiguredGitHubAppSlug: vi.fn(),
   mockResolveDeploymentEnvVar: vi.fn(),
   mockUpdateTaskPrStatus: vi.fn(),
   mockUpsertGitHubPullRequestFactFromWebhook: vi.fn(),
@@ -87,6 +89,7 @@ vi.mock('@roomote/db/server', () => ({
 
 vi.mock('@roomote/github', () => ({
   isRepoSkipped: mockIsRepoSkipped,
+  resolveConfiguredGitHubAppSlug: mockResolveConfiguredGitHubAppSlug,
 }));
 
 vi.mock('@roomote/sdk/server', () => ({
@@ -167,12 +170,14 @@ describe('github webhook router', () => {
     mockQueuePrReviewActivityNotification.mockReset();
     mockQueuePrReviewSummaryNotification.mockReset();
     mockRecordWebhook.mockReset();
+    mockResolveConfiguredGitHubAppSlug.mockReset();
     mockResolveDeploymentEnvVar.mockReset();
     mockUpdateTaskPrStatus.mockReset();
     mockUpsertGitHubPullRequestFactFromWebhook.mockReset();
     mockVerifyAndReceive.mockReset();
 
     mockIsRepoSkipped.mockReturnValue(false);
+    mockResolveConfiguredGitHubAppSlug.mockResolvedValue('roomote');
     mockResolveDeploymentEnvVar.mockResolvedValue('test-secret');
     mockHandlePrComment.mockResolvedValue({ status: 'ok' });
     mockRecordWebhook.mockImplementation(
@@ -312,6 +317,24 @@ describe('github webhook router', () => {
     );
     expect(webhooksConstructorParams).toEqual([{ secret: 'db-only-secret' }]);
     expect(mockHandlePushConflictCheck).toHaveBeenCalled();
+  });
+
+  it('refreshes the configured app slug before dispatching handlers', async () => {
+    const response = await app.request('http://localhost/api/webhooks/github', {
+      method: 'POST',
+      headers: {
+        'x-github-delivery': 'delivery-slug',
+        'x-github-event': 'push',
+        'x-hub-signature-256': 'sha256=test',
+      },
+      body: JSON.stringify({ ref: 'refs/heads/main' }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockResolveConfiguredGitHubAppSlug).toHaveBeenCalledTimes(1);
+    expect(
+      mockResolveConfiguredGitHubAppSlug.mock.invocationCallOrder[0],
+    ).toBeLessThan(mockVerifyAndReceive.mock.invocationCallOrder[0]!);
   });
 
   it('returns 401 without processing when no webhook secret is configured', async () => {

--- a/apps/api/src/handlers/github/__tests__/isMention.test.ts
+++ b/apps/api/src/handlers/github/__tests__/isMention.test.ts
@@ -11,6 +11,8 @@ vi.mock('@roomote/env', async (importOriginal) => {
   };
 });
 
+import { setConfiguredGitHubAppSlugCache } from '@roomote/github';
+
 import { isMention } from '../isMention';
 
 describe('isMention', () => {
@@ -75,5 +77,45 @@ describe('isMention', () => {
         user: null,
       }),
     ).toBe(false);
+  });
+
+  describe('with a database-configured app slug', () => {
+    beforeEach(() => {
+      setConfiguredGitHubAppSlugCache({
+        value: 'openmote',
+        expiresAt: Date.now() + 60_000,
+      });
+    });
+
+    afterEach(() => {
+      setConfiguredGitHubAppSlugCache(null);
+    });
+
+    it('detects mentions of the configured slug', () => {
+      expect(
+        isMention({
+          body: 'Hey @openmote can you take a look?',
+          user: { login: 'testuser' },
+        }),
+      ).toBe(true);
+    });
+
+    it('ignores mentions of the default slug when another slug is configured', () => {
+      expect(
+        isMention({
+          body: 'Hey @roomote can you take a look?',
+          user: { login: 'testuser' },
+        }),
+      ).toBe(false);
+    });
+
+    it('returns false for comments authored by the configured bot', () => {
+      expect(
+        isMention({
+          body: 'Hey @openmote can you take a look?',
+          user: { login: 'openmote[bot]' },
+        }),
+      ).toBe(false);
+    });
   });
 });

--- a/apps/api/src/handlers/github/__tests__/notifyPrReviewActivity.test.ts
+++ b/apps/api/src/handlers/github/__tests__/notifyPrReviewActivity.test.ts
@@ -65,6 +65,8 @@ vi.mock('@roomote/cloud-agents/server', () => ({
     ),
 }));
 
+import { setConfiguredGitHubAppSlugCache } from '@roomote/github';
+
 import {
   buildPrReviewActivityNotificationInput,
   buildPrReviewSummaryNotification,
@@ -359,6 +361,74 @@ describe('buildPrReviewSummaryNotification', () => {
   it('skips non-PR issue comments', () => {
     expect(
       buildPrReviewSummaryNotification(summaryPayload({ isPr: false })),
+    ).toBeNull();
+  });
+});
+
+// Regression: a deployment whose GitHub App was created through the /setup
+// flow keeps its slug in the encrypted environment_variables table, so the
+// process env falls back to `roomote` while the bot posts under the
+// configured slug (e.g. openmote[bot]). The identity helpers must honor the
+// resolved slug or every review-summary notification is silently dropped.
+describe('with a database-configured app slug', () => {
+  beforeEach(() => {
+    setConfiguredGitHubAppSlugCache({
+      value: 'openmote',
+      expiresAt: Date.now() + 60_000,
+    });
+  });
+
+  afterEach(() => {
+    setConfiguredGitHubAppSlugCache(null);
+  });
+
+  it('builds a review_summary event for the configured bot login', () => {
+    const notification = buildPrReviewSummaryNotification(
+      summaryPayload({ login: 'openmote[bot]' }),
+    );
+
+    expect(notification?.input.event).toMatchObject({
+      kind: 'review_summary',
+      authorLogin: 'openmote[bot]',
+      roomoteAuthored: true,
+    });
+  });
+
+  it('still skips summary-shaped comments from unrelated bots', () => {
+    expect(
+      buildPrReviewSummaryNotification(
+        summaryPayload({ login: 'othermote[bot]' }),
+      ),
+    ).toBeNull();
+  });
+
+  it('marks new review threads from the configured bot as roomote-authored', () => {
+    expect(
+      buildPrReviewActivityNotificationInput(
+        reviewCommentPayload({ login: 'openmote[bot]' }),
+      ),
+    ).toMatchObject({
+      event: {
+        kind: 'review_comment',
+        authorLogin: 'openmote[bot]',
+        roomoteAuthored: true,
+      },
+    });
+  });
+
+  it('skips replies to existing review threads from the configured bot', () => {
+    expect(
+      buildPrReviewActivityNotificationInput(
+        reviewCommentPayload({ login: 'openmote[bot]', inReplyToId: 99 }),
+      ),
+    ).toBeNull();
+  });
+
+  it('skips review comments that mention the configured slug', () => {
+    expect(
+      buildPrReviewActivityNotificationInput(
+        reviewCommentPayload({ body: '@openmote fix this' }),
+      ),
     ).toBeNull();
   });
 });

--- a/apps/api/src/handlers/github/index.ts
+++ b/apps/api/src/handlers/github/index.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { Webhooks } from '@octokit/webhooks';
 
 import { resolveDeploymentEnvVar } from '@roomote/db/server';
-import { isRepoSkipped } from '@roomote/github';
+import { isRepoSkipped, resolveConfiguredGitHubAppSlug } from '@roomote/github';
 import {
   updateTaskPrStatus,
   upsertGitHubPullRequestFactFromWebhook,
@@ -460,6 +460,12 @@ github.post('/', async (c) => {
     );
 
     const payload = await c.req.text();
+
+    // The event handlers classify logins synchronously (mention detection,
+    // bot-identity checks); refresh the configured app slug first so an app
+    // created through the /setup flow is recognized as ourselves.
+    await resolveConfiguredGitHubAppSlug();
+
     await webhooks.verifyAndReceive({ id, name, signature, payload });
     return c.json({ message: 'webhook_processed' });
   } catch (error) {

--- a/apps/api/src/handlers/github/isMention.ts
+++ b/apps/api/src/handlers/github/isMention.ts
@@ -1,5 +1,7 @@
-import { Env } from '@roomote/env';
-import { Schemas as GitHubSchemas } from '@roomote/github';
+import {
+  getEffectiveGitHubAppSlug,
+  Schemas as GitHubSchemas,
+} from '@roomote/github';
 
 export const isMention = (comment: {
   body: string;
@@ -12,7 +14,7 @@ export const isMention = (comment: {
   return (
     comment.body
       .toLowerCase()
-      .includes(`@${Env.NEXT_PUBLIC_GITHUB_APP_SLUG.toLowerCase()}`) &&
+      .includes(`@${getEffectiveGitHubAppSlug().toLowerCase()}`) &&
     !GitHubSchemas.isRoomoteGitHubLogin(comment.user.login)
   );
 };

--- a/apps/web/src/lib/server/analytics.ts
+++ b/apps/web/src/lib/server/analytics.ts
@@ -826,6 +826,10 @@ function isRoomotePullRequestAuthor(login: string | null) {
 }
 
 async function getRoomotePullRequestMetadataByKey(_auth: UserAuthSuccess) {
+  // isRoomotePullRequestAuthor classifies logins synchronously from the
+  // cached configured app slug.
+  await GitHub.resolveConfiguredGitHubAppSlug();
+
   const results = await db
     .select({
       taskId: taskPullRequests.taskId,

--- a/apps/web/src/trpc/commands/automations/reviewer.ts
+++ b/apps/web/src/trpc/commands/automations/reviewer.ts
@@ -11,9 +11,9 @@ import {
   upsertAutomation,
   users,
 } from '@roomote/db/server';
+import { getEffectiveGitHubAppSlug } from '@roomote/github';
 
 import type { UserAuthSuccess } from '@/types';
-import { Env } from '@/lib/server/env';
 
 import { assertAdmin } from './feature-gates';
 
@@ -49,18 +49,15 @@ function normalizeGitHubLogins(logins: string[]): string[] {
   );
 }
 
-let roomoteReviewerLogins: string[] | null = null;
-
 function getRoomoteReviewerLogins(): string[] {
-  // Keep Env access out of module evaluation so Next.js instrumentation can
-  // bootstrap the Node.js runtime before server routes import this module.
-  if (!roomoteReviewerLogins) {
-    roomoteReviewerLogins = normalizeGitHubLogins(
-      getRoomoteManagedGitHubLogins(Env.NEXT_PUBLIC_GITHUB_APP_SLUG),
-    );
-  }
-
-  return roomoteReviewerLogins;
+  // Computed per call rather than memoized: the configured slug can be
+  // resolved from the database after this module is imported (see
+  // resolveConfiguredGitHubAppSlug), and env access stays out of module
+  // evaluation so Next.js instrumentation can bootstrap the Node.js runtime
+  // before server routes import this module.
+  return normalizeGitHubLogins(
+    getRoomoteManagedGitHubLogins(getEffectiveGitHubAppSlug()),
+  );
 }
 
 export function mapReviewerSettingsToBackgroundSettings(

--- a/apps/web/src/trpc/commands/automations/settings-read.ts
+++ b/apps/web/src/trpc/commands/automations/settings-read.ts
@@ -13,6 +13,7 @@ import {
   listAutomations,
   tasks,
 } from '@roomote/db/server';
+import { resolveConfiguredGitHubAppSlug } from '@roomote/github';
 import { SlackNotifier } from '@roomote/slack';
 
 import type { UserAuthSuccess } from '@/types';
@@ -266,6 +267,10 @@ export async function getBackgroundAgentSettingsCommand(
     ciFailureTriageSlackChannelId:
       visibleSettings.ciFailureTriageSlackChannelId,
   });
+
+  // The reviewer mapping derives its managed-login list synchronously from
+  // the cached configured app slug.
+  await resolveConfiguredGitHubAppSlug();
 
   return {
     settings: visibleSettings,

--- a/apps/web/src/trpc/commands/automations/settings-update.ts
+++ b/apps/web/src/trpc/commands/automations/settings-update.ts
@@ -20,6 +20,7 @@ import {
 } from '@roomote/db/server';
 import { validateSuggestionRoutingInstructions } from '@roomote/cloud-agents/server';
 import { FeatureFlag } from '@roomote/feature-flags';
+import { resolveConfiguredGitHubAppSlug } from '@roomote/github';
 import { SlackNotifier } from '@roomote/slack';
 
 import type { UserAuthSuccess } from '@/types';
@@ -973,6 +974,10 @@ export async function updateBackgroundAgentSettingsCommand(
     auth,
     getRelayEligibleCreatorIds(updatedSettings.reviewCodeSettings),
   );
+
+  // The reviewer mapping derives its managed-login list synchronously from
+  // the cached configured app slug.
+  await resolveConfiguredGitHubAppSlug();
 
   return {
     success: true,

--- a/packages/github/src/__tests__/resolve-app-slug.test.ts
+++ b/packages/github/src/__tests__/resolve-app-slug.test.ts
@@ -1,0 +1,117 @@
+// pnpm --filter @roomote/github test src/__tests__/resolve-app-slug.test.ts
+
+const { mockResolveDeploymentEnvVar } = vi.hoisted(() => ({
+  mockResolveDeploymentEnvVar: vi.fn(),
+}));
+
+vi.mock('@roomote/db/server', () => ({
+  resolveDeploymentEnvVar: mockResolveDeploymentEnvVar,
+}));
+
+vi.mock('@roomote/env', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@roomote/env')>();
+
+  return {
+    ...actual,
+    Env: { NEXT_PUBLIC_GITHUB_APP_SLUG: 'roomote' },
+  };
+});
+
+describe('resolveConfiguredGitHubAppSlug', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockResolveDeploymentEnvVar.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves the configured slug and caches non-empty values', async () => {
+    mockResolveDeploymentEnvVar.mockResolvedValueOnce('openmote');
+
+    const { resolveConfiguredGitHubAppSlug } =
+      await import('../resolve-app-slug');
+    const { getEffectiveGitHubAppSlug } = await import('../app-slug');
+
+    await expect(resolveConfiguredGitHubAppSlug()).resolves.toBe('openmote');
+    expect(getEffectiveGitHubAppSlug()).toBe('openmote');
+
+    await expect(resolveConfiguredGitHubAppSlug()).resolves.toBe('openmote');
+    expect(mockResolveDeploymentEnvVar).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the GITHUB_APP_SLUG alias', async () => {
+    mockResolveDeploymentEnvVar
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce('openmote');
+
+    const { resolveConfiguredGitHubAppSlug } =
+      await import('../resolve-app-slug');
+
+    await expect(resolveConfiguredGitHubAppSlug()).resolves.toBe('openmote');
+    expect(mockResolveDeploymentEnvVar).toHaveBeenNthCalledWith(
+      1,
+      'NEXT_PUBLIC_GITHUB_APP_SLUG',
+    );
+    expect(mockResolveDeploymentEnvVar).toHaveBeenNthCalledWith(
+      2,
+      'GITHUB_APP_SLUG',
+    );
+  });
+
+  it('does not cache misses so a freshly saved slug is picked up', async () => {
+    mockResolveDeploymentEnvVar.mockResolvedValue(null);
+
+    const { resolveConfiguredGitHubAppSlug } =
+      await import('../resolve-app-slug');
+
+    await expect(resolveConfiguredGitHubAppSlug()).resolves.toBe('roomote');
+    await expect(resolveConfiguredGitHubAppSlug()).resolves.toBe('roomote');
+
+    // Two aliases checked on each of the two calls.
+    expect(mockResolveDeploymentEnvVar).toHaveBeenCalledTimes(4);
+  });
+
+  it('re-resolves after the cache expires', async () => {
+    vi.useFakeTimers();
+    mockResolveDeploymentEnvVar.mockResolvedValue('openmote');
+
+    const { resolveConfiguredGitHubAppSlug } =
+      await import('../resolve-app-slug');
+
+    await expect(resolveConfiguredGitHubAppSlug()).resolves.toBe('openmote');
+    vi.advanceTimersByTime(61_000);
+    await expect(resolveConfiguredGitHubAppSlug()).resolves.toBe('openmote');
+
+    expect(mockResolveDeploymentEnvVar).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the last known slug when the database is unavailable', async () => {
+    vi.useFakeTimers();
+    mockResolveDeploymentEnvVar.mockResolvedValueOnce('openmote');
+
+    const { resolveConfiguredGitHubAppSlug } =
+      await import('../resolve-app-slug');
+
+    await expect(resolveConfiguredGitHubAppSlug()).resolves.toBe('openmote');
+
+    vi.advanceTimersByTime(61_000);
+    mockResolveDeploymentEnvVar.mockRejectedValueOnce(
+      new Error('database unavailable'),
+    );
+
+    await expect(resolveConfiguredGitHubAppSlug()).resolves.toBe('openmote');
+  });
+
+  it('falls back to the process-env slug when resolution fails cold', async () => {
+    mockResolveDeploymentEnvVar.mockRejectedValueOnce(
+      new Error('database unavailable'),
+    );
+
+    const { resolveConfiguredGitHubAppSlug } =
+      await import('../resolve-app-slug');
+
+    await expect(resolveConfiguredGitHubAppSlug()).resolves.toBe('roomote');
+  });
+});

--- a/packages/github/src/__tests__/schema.test.ts
+++ b/packages/github/src/__tests__/schema.test.ts
@@ -23,4 +23,33 @@ describe('isRoomoteGitHubLogin', () => {
     expect(isRoomoteGitHubLogin('app/roomote-dev')).toBe(true);
     expect(isRoomoteGitHubLogin('octocat')).toBe(false);
   });
+
+  it('recognizes a database-configured app slug once resolved', async () => {
+    vi.doMock('@roomote/env', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('@roomote/env')>();
+
+      return {
+        ...actual,
+        Env: { NEXT_PUBLIC_GITHUB_APP_SLUG: 'roomote' },
+      };
+    });
+
+    const { isRoomoteGitHubLogin } = await import('../schema');
+    const { setConfiguredGitHubAppSlugCache } = await import('../app-slug');
+
+    // Before resolution the process-env default applies.
+    expect(isRoomoteGitHubLogin('openmote[bot]')).toBe(false);
+
+    setConfiguredGitHubAppSlugCache({
+      value: 'openmote',
+      expiresAt: Date.now() + 60_000,
+    });
+
+    expect(isRoomoteGitHubLogin('openmote[bot]')).toBe(true);
+    expect(isRoomoteGitHubLogin('app/openmote')).toBe(true);
+    // The hosted-product logins stay recognized alongside the configured one.
+    expect(isRoomoteGitHubLogin('roomote[bot]')).toBe(true);
+    expect(isRoomoteGitHubLogin('roomote-dev[bot]')).toBe(true);
+    expect(isRoomoteGitHubLogin('octocat')).toBe(false);
+  });
 });

--- a/packages/github/src/app-slug.ts
+++ b/packages/github/src/app-slug.ts
@@ -1,0 +1,37 @@
+import { Env } from '@roomote/env';
+
+/**
+ * Cached result of resolving the deployment's configured GitHub App slug
+ * through the deployment env layer. `value: null` records that resolution ran
+ * and found nothing configured; a `null` cache means resolution has not run
+ * in this process yet. Lives in its own module so the synchronous identity
+ * helpers stay free of database imports.
+ */
+export type ConfiguredGitHubAppSlugCache = {
+  value: string | null;
+  expiresAt: number;
+};
+
+let configuredAppSlugCache: ConfiguredGitHubAppSlugCache | null = null;
+
+export function getConfiguredGitHubAppSlugCache(): ConfiguredGitHubAppSlugCache | null {
+  return configuredAppSlugCache;
+}
+
+export function setConfiguredGitHubAppSlugCache(
+  cache: ConfiguredGitHubAppSlugCache | null,
+): void {
+  configuredAppSlugCache = cache;
+}
+
+/**
+ * The deployment's GitHub App slug: the configured value when one has been
+ * resolved (see `resolveConfiguredGitHubAppSlug`), otherwise the process-env
+ * value with its hosted-product default. An expired cache entry is still
+ * preferred over the default — the configured slug only changes when an
+ * operator re-runs the GitHub App setup, and the stale value beats
+ * misclassifying the deployment's own bot login.
+ */
+export function getEffectiveGitHubAppSlug(): string {
+  return configuredAppSlugCache?.value ?? Env.NEXT_PUBLIC_GITHUB_APP_SLUG;
+}

--- a/packages/github/src/cli.ts
+++ b/packages/github/src/cli.ts
@@ -16,6 +16,7 @@ import {
   isValidReviewComment,
   isValidIssueComment,
 } from './schema';
+import { resolveConfiguredGitHubAppSlug } from './resolve-app-slug';
 
 export interface FetchParams {
   gitHubToken: string;
@@ -368,6 +369,10 @@ export async function fetchReviewComments({
     { shell: true, env },
   );
 
+  // isValidReviewComment classifies the deployment's own bot login from the
+  // cached configured slug.
+  await resolveConfiguredGitHubAppSlug();
+
   try {
     return z
       .array(reviewCommentSchema)
@@ -419,6 +424,10 @@ export async function fetchIssueComments({
       ['api', `repos/${repo}/issues/${prNumber}/comments`],
       { shell: true, env },
     );
+
+    // isValidIssueComment classifies the deployment's own bot login from the
+    // cached configured slug.
+    await resolveConfiguredGitHubAppSlug();
 
     return z
       .array(issueCommentSchema)

--- a/packages/github/src/index.ts
+++ b/packages/github/src/index.ts
@@ -1,6 +1,8 @@
 export * from './api';
+export * from './app-slug';
 export * from './commit-timestamps';
 export * from './is-repo-skipped';
+export * from './resolve-app-slug';
 
 export * as Schemas from './schema';
 export * as Cli from './cli';

--- a/packages/github/src/resolve-app-slug.ts
+++ b/packages/github/src/resolve-app-slug.ts
@@ -1,0 +1,50 @@
+import { resolveDeploymentEnvVar } from '@roomote/db/server';
+
+import {
+  getConfiguredGitHubAppSlugCache,
+  getEffectiveGitHubAppSlug,
+  setConfiguredGitHubAppSlugCache,
+} from './app-slug';
+
+// Non-empty values are cached briefly to avoid a decrypting DB read on every
+// webhook delivery; misses are not cached so a slug saved by the /setup
+// manifest flow is picked up immediately (same policy as the webhook secret
+// resolution in the api webhook route).
+const CONFIGURED_APP_SLUG_CACHE_TTL_MS = 60_000;
+
+/**
+ * Resolves the deployment's configured GitHub App slug through the deployment
+ * env layer (process env, then the encrypted environment_variables table) and
+ * caches it for the synchronous identity helpers (`isRoomoteGitHubLogin`,
+ * mention detection). Identity-sensitive paths await this before classifying
+ * logins so a deployment whose app was created through the /setup flow — and
+ * therefore has no slug in the process environment — still recognizes its own
+ * bot. Falls back to the last cached or process-env value when the database
+ * is unavailable.
+ */
+export async function resolveConfiguredGitHubAppSlug(): Promise<string> {
+  const cache = getConfiguredGitHubAppSlugCache();
+
+  if (cache?.value && cache.expiresAt > Date.now()) {
+    return getEffectiveGitHubAppSlug();
+  }
+
+  try {
+    const slug =
+      (await resolveDeploymentEnvVar('NEXT_PUBLIC_GITHUB_APP_SLUG')) ??
+      (await resolveDeploymentEnvVar('GITHUB_APP_SLUG'));
+
+    setConfiguredGitHubAppSlugCache({
+      value: slug,
+      expiresAt: Date.now() + CONFIGURED_APP_SLUG_CACHE_TTL_MS,
+    });
+  } catch (error) {
+    console.warn(
+      `[resolveConfiguredGitHubAppSlug] falling back to the last known app slug: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  return getEffectiveGitHubAppSlug();
+}

--- a/packages/github/src/schema.ts
+++ b/packages/github/src/schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Env } from '@roomote/env';
+
+import { getEffectiveGitHubAppSlug } from './app-slug';
 
 /**
  * PullRequest
@@ -117,7 +118,7 @@ export type ReviewComment = z.infer<typeof reviewCommentSchema>;
 export const isRoomoteGitHubLogin = (login: string) => {
   const normalizedLogin = login.toLowerCase();
   const appSlugs = new Set([
-    Env.NEXT_PUBLIC_GITHUB_APP_SLUG.toLowerCase(),
+    getEffectiveGitHubAppSlug().toLowerCase(),
     'roomote',
     'roomote-dev',
   ]);

--- a/packages/sdk/src/server/lib/manager-stats.ts
+++ b/packages/sdk/src/server/lib/manager-stats.ts
@@ -281,6 +281,10 @@ export async function buildManagerStatsDigest(params: {
   actorUserId: string;
   since: Date;
 }) {
+  // isRoomotePullRequestAuthor classifies logins synchronously from the
+  // cached configured app slug.
+  await GitHub.resolveConfiguredGitHubAppSlug();
+
   const repositoryIds = await getAnalyticsRepositoryIds();
 
   if (repositoryIds.length === 0) {


### PR DESCRIPTION
## Problem

Deployments that create their GitHub App through the `/setup` manifest flow store the app slug in the encrypted `environment_variables` table, not the process environment. `isRoomoteGitHubLogin()` and mention detection read `Env.NEXT_PUBLIC_GITHUB_APP_SLUG` directly, which silently falls back to the hosted-product default (`roomote`), so those instances never recognize their own bot login.

Observed on nightly (app slug `openmote`, stored only in the DB): the PR #108 review summary went terminal at 17:39 UTC on Jul 10, GitHub delivered the `issue_comment.edited` webhook (200 OK), and `buildPrReviewSummaryNotification` dropped it at the `isRoomoteGitHubLogin('openmote[bot]')` check. No enqueue, no log lines, no Slack notification. The feature from #60 was working as coded; the instance just didn't know its own name.

Same root cause also affected: `@<slug>` mention detection, `roomoteAuthored` classification of the bot's own review threads, the reviewer automation's managed-login list, analytics/manager-stats PR attribution, and the cli comment fetchers filtering out the bot's own `Bot`-typed comments (which is why review summary comments were not reused across runs).

## Fix

- New `resolveConfiguredGitHubAppSlug()` in `@roomote/github` resolves the slug through the deployment env layer (process env, then the DB via `resolveDeploymentEnvVar`, honoring the `GITHUB_APP_SLUG` alias) with the same 60s cache-hits-not-misses policy as the webhook secret resolution, and falls back to the last known value if the database is unavailable.
- The synchronous identity helpers (`isRoomoteGitHubLogin`, `isMention`, reviewer login list) read the cached value via `getEffectiveGitHubAppSlug()`, keeping the hosted `roomote`/`roomote-dev` logins recognized alongside the configured slug.
- Refresh points: the GitHub webhook route (before dispatching handlers), the cli review/issue comment fetchers, analytics PR metadata, manager stats digest, and the automations settings read/update paths.

## Testing

- New unit tests: resolver caching semantics (TTL, miss-not-cached, alias fallback, DB-failure fallback), configured-slug recognition in `isRoomoteGitHubLogin`, mention detection with a configured slug, and regression tests for the review-summary/review-comment classification with a `openmote[bot]`-style author.
- Full vitest suites pass for `@roomote/github`, `@roomote/api`, `@roomote/web`, `@roomote/sdk`; `pnpm lint` passes; `check-types:fast` passes for all touched workspaces.
- Note: `@roomote/cloud-agents` has a pre-existing failure on develop unrelated to this change (`deployment-ci-launch-task.ts` imports the removed `./cloud-job-queue`, breaking check-types/knip, plus one OpenCode packaging test) — being handled separately.