### PR TITLE
[Fix] Log in to GHCR before the deployment acceptance smoke test

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -156,6 +156,12 @@ jobs:
           pnpm-version: 10.29.3
       - name: Set up Docker builder
         uses: useblacksmith/setup-docker-builder@47a5d0102cc44712a17a633c2599f755008cc40e # v1
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Resolve previous published channel
         id: baseline
         shell: bash


### PR DESCRIPTION
## Problem

Every develop run of **Publish GHCR Images** has been failing in `Deployment acceptance (amd64)` → `Exercise deployment lifecycle`:

```
Error response from daemon: Head "https://ghcr.io/v2/roocodeinc/roomote-web/manifests/develop": unauthorized
```

`deploy/ci/deployment-smoke.sh` pulls the baseline images from GHCR, but the `deployment-acceptance` job has `packages: read` **without a docker login step**, and the packages are private. The `build` and `publish` jobs log in; this job was missed.

Because `build` → `publish` → deploy dispatch all `needs:` this job, the failure has also been **blocking staging deploys** — staging's worker is pinned at `develop-3f602c68` while develop is several commits ahead (including #116, which can't ship until this passes).

This is also the exact root cause the ci-failure-triage automation diagnosed in the incident behind #116 — it just couldn't submit the work item.

## Change

Add the same pinned `docker/login-action` step the build/publish jobs already use, before the smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)