### PR TITLE
[Fix] Resolve lint and knip failures in automation work items tool

### DIFF
--- a/apps/worker/src/mcp/roomote-mcp-server/automation-work-items-tool.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/automation-work-items-tool.ts
@@ -74,10 +74,8 @@ export const automationWorkItemInputSchema = {
     ),
 };
 
-const automationWorkItemObjectSchema = z.object(automationWorkItemInputSchema);
-
-export type AutomationWorkItemToolParams = z.infer<
-  typeof automationWorkItemObjectSchema
+type AutomationWorkItemToolParams = z.infer<
+  z.ZodObject<typeof automationWorkItemInputSchema>
 >;
 
 export function buildAutomationWorkItem(params: AutomationWorkItemToolParams) {


### PR DESCRIPTION
## Summary

Develop CI (Lint + Knip) has been red since the "Flatten submit_automation_work_items to one work item" commit landed:

- `automationWorkItemObjectSchema` was a value used only in a type position (`@typescript-eslint/no-unused-vars` at max-warnings=0)
- `AutomationWorkItemToolParams` was exported with no external consumers (Knip unused-export)

Infer the params type directly from the input schema shape via `z.ZodObject<typeof automationWorkItemInputSchema>` and drop the export. No runtime change.

This also unblocks CI on #119, whose merge-ref checks inherit the develop breakage.

## Validation

- `pnpm --filter @roomote/worker lint`
- `pnpm --filter @roomote/worker check-types`
- `pnpm knip`
- `pnpm --filter @roomote/worker exec vitest run src/mcp/roomote-mcp-server/__tests__/automation-work-items-tool-schema.test.ts` (6 tests)