### PR TITLE
[Fix] Skip candidate-only runtime tool checks when verifying the baseline release

### DIFF
--- a/deploy/ci/deployment-smoke.sh
+++ b/deploy/ci/deployment-smoke.sh
@@ -189,6 +189,11 @@ start_stack() {
 }
 
 verify_stack() {
+  # 'candidate' (default) also asserts the runtime tools the current code
+  # ships in its control-plane images; 'baseline' skips those, because the
+  # previous release predates whatever tooling the candidate introduced and
+  # must only prove it still runs.
+  local release="${1:-candidate}"
   local migration_container migration_exit
   migration_container="$(compose ps --all --quiet db-migrate)"
   [ -n "$migration_container" ] || {
@@ -206,9 +211,12 @@ verify_stack() {
   compose exec -T web curl -fsS --max-time 10 "http://127.0.0.1:3000/setup?token=$setup_token" >/dev/null
   compose exec -T controller curl -fsS --max-time 5 http://api:3001/health/controller >/dev/null
   compose exec -T bullmq curl -fsS --max-time 5 http://127.0.0.1:3002/admin/health >/dev/null
-  compose exec -T api sh -ceu 'command -v gh >/dev/null; command -v opencode >/dev/null'
-  compose exec -T web sh -ceu 'command -v opencode >/dev/null'
-  compose exec -T bullmq sh -ceu 'command -v opencode >/dev/null'
+
+  if [ "$release" = 'candidate' ]; then
+    compose exec -T api sh -ceu 'command -v gh >/dev/null; command -v opencode >/dev/null'
+    compose exec -T web sh -ceu 'command -v opencode >/dev/null'
+    compose exec -T bullmq sh -ceu 'command -v opencode >/dev/null'
+  fi
 }
 
 write_marker() {
@@ -239,7 +247,7 @@ validate_upgrade_and_rollback() {
 
   write_env baseline
   start_stack
-  verify_stack
+  verify_stack baseline
   write_marker
 
   printf 'Upgrading previous release to candidate\n'
@@ -251,7 +259,7 @@ validate_upgrade_and_rollback() {
   printf 'Rolling back candidate to previous release\n'
   write_env baseline
   start_stack
-  verify_stack
+  verify_stack baseline
   verify_marker
 
   printf 'Returning stack to candidate after rollback probe\n'


### PR DESCRIPTION
## Problem

Every develop publish since #114 fails at the **Deployment acceptance** gate, which blocks image publishing and nightly deploys (#115/#117/#119 are all stuck undeployed).

The gate's upgrade/rollback validation starts the **previous published release** (`develop-3f602c68`) as a baseline, and `verify_stack` asserts `command -v gh` / `command -v opencode` in the api/web/bullmq containers — checks #114 added alongside shipping those tools in the control-plane images. The baseline predates #114, so those binaries legitimately don't exist there and the gate fails one second after the baseline stack reports healthy (see the develop run: all containers Healthy at 19:52:16, failure at 19:52:17, right at the tool checks).

This can never self-heal: the baseline only advances when a publish succeeds, and no publish can succeed while the baseline lacks the tools.

## Fix

`verify_stack` takes a release argument (`candidate` default, `baseline` at the two baseline call sites in `validate_upgrade_and_rollback`). Baseline verification now proves only that the previous release still boots, migrates, and serves health checks; the runtime-tooling contract is asserted against the candidate alone — which is the image the contract is about.

## Testing

- `bash -n` syntax check; the change is two call-site arguments and a guarded block.
- The acceptance job itself only runs in the publish workflow (develop/main pushes), so the real verification is the first develop publish after this merges — it exercises the exact failing path (baseline `develop-3f602c68` → candidate upgrade → rollback). I'll watch that run.

Note: this is independent of #118 (GHCR login), which addressed the earlier `unauthorized` baseline pull that #119 also carried a fix for.