### PR TITLE
Fail orphaned setup work items terminally

### DIFF
--- a/apps/web/src/trpc/commands/setup-new/index.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.ts
@@ -930,13 +930,35 @@ export async function launchQueuedSetupTasksIfReady({
     claimedTasks.map(async (queuedTask) => {
       let launchResult: Awaited<ReturnType<typeof enqueueTask>>;
 
-      try {
-        if (!queuedTask.selectedByUserId) {
-          throw new Error(
-            `Queued setup task ${queuedTask.id} has no selecting user.`,
-          );
-        }
+      if (!queuedTask.selectedByUserId) {
+        const failedAt = new Date();
+        const launchError = 'Queued setup task has no selecting user.';
 
+        await db
+          .update(workItems)
+          .set({
+            status: 'failed',
+            failedAt,
+            launchError,
+            launchClaimedAt: null,
+            updatedAt: failedAt,
+          })
+          .where(
+            and(
+              eq(workItems.id, queuedTask.id),
+              eq(workItems.kind, 'onboarding'),
+              eq(workItems.status, 'launching'),
+              eq(workItems.launchClaimedAt, queuedTask.claimedAt),
+            ),
+          );
+
+        console.warn(
+          `[setup-new] onboarding work item ${queuedTask.id} cannot launch: ${launchError}`,
+        );
+        return;
+      }
+
+      try {
         launchResult = await enqueueTask({
           task: {
             type: TaskPayloadKind.StandardTask,

--- a/apps/web/src/trpc/commands/setup-new/launch-lifecycle.test.ts
+++ b/apps/web/src/trpc/commands/setup-new/launch-lifecycle.test.ts
@@ -175,13 +175,17 @@ describe('launchQueuedSetupTasksIfReady (fenced onboarding-queue launch)', () =>
     launchClaimedAt?: Date | null;
     sourceWorkItemId?: string | null;
     launchedTaskId?: string | null;
+    selectedByUserId?: string | null;
   }): Promise<string> {
     const [row] = await db
       .insert(workItems)
       .values({
         kind: 'onboarding',
         sourceTaskId: setupOnboardingTaskId,
-        selectedByUserId,
+        selectedByUserId:
+          overrides?.selectedByUserId === undefined
+            ? selectedByUserId
+            : overrides.selectedByUserId,
         sourceWorkItemId: overrides?.sourceWorkItemId ?? null,
         title: 'Queued onboarding task',
         executionPrompt: 'Do the queued onboarding work.',
@@ -231,6 +235,8 @@ describe('launchQueuedSetupTasksIfReady (fenced onboarding-queue launch)', () =>
         launchedAt: workItems.launchedAt,
         targetEnvironmentId: workItems.targetEnvironmentId,
         dismissedAt: workItems.dismissedAt,
+        failedAt: workItems.failedAt,
+        launchError: workItems.launchError,
       })
       .from(workItems)
       .where(eq(workItems.id, id))
@@ -517,6 +523,34 @@ describe('launchQueuedSetupTasksIfReady (fenced onboarding-queue launch)', () =>
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('enqueue failed'),
       );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('terminally fails an orphaned item instead of retrying it', async () => {
+    const onboardingId = await seedOnboardingItem({
+      sortOrder: 0,
+      selectedByUserId: null,
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      await launch();
+
+      const row = await readRow(onboardingId);
+      expect(row?.status).toBe('failed');
+      expect(row?.failedAt).not.toBeNull();
+      expect(row?.launchError).toBe('Queued setup task has no selecting user.');
+      expect(row?.launchClaimedAt).toBeNull();
+      expect(mockEnqueueTask).not.toHaveBeenCalled();
+
+      // Failed work items are not claimable, so later readiness passes leave
+      // the item terminal instead of producing an infinite retry loop.
+      await launch();
+      expect(mockEnqueueTask).not.toHaveBeenCalled();
+      expect((await readRow(onboardingId))?.status).toBe('failed');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
     } finally {
       warnSpy.mockRestore();
     }


### PR DESCRIPTION
## Summary

- transition onboarding work items with no selecting user from `launching` to terminal `failed`
- fence the failure update with the work item ID, kind, status, and claim timestamp
- add lifecycle coverage proving later readiness passes do not reclaim the failed item

## Validation

- `pnpm --filter @roomote/web check-types`
- `pnpm --filter @roomote/web lint`
- pre-push `lint:fast`, `check-types:fast`, and `knip`

The focused real-database lifecycle test was attempted, but the shared test Postgres returned a `global/pg_filenode.map` I/O error. Shared infrastructure was not restarted.