### PR TITLE
[Chore] Make the deployment acceptance gate non-blocking for publishes

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -137,6 +137,10 @@ jobs:
           echo "app_env=$app_env" >> "$GITHUB_OUTPUT"
           echo "extra_tag=$extra_tag" >> "$GITHUB_OUTPUT"
 
+  # TEMPORARILY NON-GATING (Jul 2026): this job still runs and fails visibly,
+  # but `build` no longer depends on it, so publishes proceed while the smoke
+  # test is being stabilized. Restore `deployment-acceptance` to build.needs
+  # once it is reliable.
   deployment-acceptance:
     name: Deployment acceptance (amd64)
     needs: prepare
@@ -194,7 +198,7 @@ jobs:
 
   build:
     name: Build ${{ matrix.app }} (${{ matrix.arch }})
-    needs: [prepare, deployment-acceptance]
+    needs: prepare
     if: ${{ needs.prepare.outputs.docs_only != 'true' }}
     runs-on: ${{ matrix.runner }}
     permissions:


### PR DESCRIPTION
Per Matt: the smoke test keeps blocking develop publishes (and nightly deploys) on gate-side issues, so make it non-blocking while it gets stabilized.

- `build` no longer depends on `deployment-acceptance`; publishes and the ops dispatch proceed regardless of the gate's outcome.
- The acceptance job itself still runs on every publish and fails visibly (the workflow run shows red), so the signal is preserved while it is being debugged.
- A workflow comment marks this as temporary; restoring `deployment-acceptance` to `build.needs` re-enables gating.

Context: #125 fixed the baseline-tooling deadlock, but its own publish run had not yet proven the gate reliable and further merges keep queueing behind it.