### PR TITLE
[Fix] OpenCode SDK server fails to start on Railway: root-owned HOME artifacts in the inference image

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -282,19 +282,21 @@ FROM runtime-base AS runtime-inference-base
 
 ARG OPENCODE_CLI_VERSION=1.17.8
 
-# The install and version check run as root with the image's HOME=/tmp, which
-# bakes root-owned /tmp/.npm and /tmp/.local (OpenCode's data dir) into the
-# layer. The runtime user shares that HOME and must be able to create those
-# paths itself — on hosts that run the raw image without a tmpfs over /tmp
-# (e.g. Railway), leftover root-owned dirs make OpenCode's log open fail with
-# PermissionDenied and the SDK server exits before ready. Strip them in the
-# same layer.
-RUN npm install --prefix /opt/opencode-cli --no-save --no-package-lock \
+# The install and version check run as root; with the image's HOME=/tmp they
+# would bake root-owned dotdirs (npm cache, OpenCode's data/config/cache
+# dirs) into the layer. The runtime user shares that HOME and must be able to
+# create those paths itself — on hosts that run the raw image without a tmpfs
+# over /tmp (e.g. Railway), leftover root-owned dirs make OpenCode's log open
+# fail with PermissionDenied and the SDK server exits before ready. Run the
+# whole step under a disposable HOME and remove it, so no dotdir allowlist
+# needs maintaining.
+RUN export HOME=/tmp/opencode-build \
+  && npm install --prefix /opt/opencode-cli --no-save --no-package-lock \
     "opencode-ai@${OPENCODE_CLI_VERSION}" \
   && test -x /opt/opencode-cli/node_modules/.bin/opencode \
   && test "$(/opt/opencode-cli/node_modules/.bin/opencode --version)" = "${OPENCODE_CLI_VERSION}" \
   && ln -sf /opt/opencode-cli/node_modules/.bin/opencode /usr/local/bin/opencode \
-  && rm -rf /tmp/.npm /tmp/.local /tmp/.cache
+  && rm -rf /tmp/opencode-build
 
 # GitHub PR prompt generation still uses the gh CLI in the API process. Keep
 # the installer isolated so only API-bearing runtime targets receive it.

--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -282,11 +282,19 @@ FROM runtime-base AS runtime-inference-base
 
 ARG OPENCODE_CLI_VERSION=1.17.8
 
+# The install and version check run as root with the image's HOME=/tmp, which
+# bakes root-owned /tmp/.npm and /tmp/.local (OpenCode's data dir) into the
+# layer. The runtime user shares that HOME and must be able to create those
+# paths itself — on hosts that run the raw image without a tmpfs over /tmp
+# (e.g. Railway), leftover root-owned dirs make OpenCode's log open fail with
+# PermissionDenied and the SDK server exits before ready. Strip them in the
+# same layer.
 RUN npm install --prefix /opt/opencode-cli --no-save --no-package-lock \
     "opencode-ai@${OPENCODE_CLI_VERSION}" \
   && test -x /opt/opencode-cli/node_modules/.bin/opencode \
   && test "$(/opt/opencode-cli/node_modules/.bin/opencode --version)" = "${OPENCODE_CLI_VERSION}" \
-  && ln -sf /opt/opencode-cli/node_modules/.bin/opencode /usr/local/bin/opencode
+  && ln -sf /opt/opencode-cli/node_modules/.bin/opencode /usr/local/bin/opencode \
+  && rm -rf /tmp/.npm /tmp/.local /tmp/.cache
 
 # GitHub PR prompt generation still uses the gh CLI in the API process. Keep
 # the installer isolated so only API-bearing runtime targets receive it.

--- a/deploy/ci/deployment-smoke.sh
+++ b/deploy/ci/deployment-smoke.sh
@@ -213,9 +213,15 @@ verify_stack() {
   compose exec -T bullmq curl -fsS --max-time 5 http://127.0.0.1:3002/admin/health >/dev/null
 
   if [ "$release" = 'candidate' ]; then
-    compose exec -T api sh -ceu 'command -v gh >/dev/null; command -v opencode >/dev/null'
-    compose exec -T web sh -ceu 'command -v opencode >/dev/null'
-    compose exec -T bullmq sh -ceu 'command -v opencode >/dev/null'
+    # Execute OpenCode (not just locate it) as the container user: startup
+    # writes state under HOME, so this catches images the runtime user cannot
+    # actually run it in. Note the Compose stack mounts a fresh tmpfs over
+    # /tmp, so root-owned HOME artifacts baked into the image layer are masked
+    # here and only bite hosts that run the raw image (e.g. Railway); that
+    # case is prevented at the Dockerfile layer instead.
+    compose exec -T api sh -ceu 'command -v gh >/dev/null; opencode --version >/dev/null'
+    compose exec -T web sh -ceu 'opencode --version >/dev/null'
+    compose exec -T bullmq sh -ceu 'opencode --version >/dev/null'
   fi
 }
 


### PR DESCRIPTION
## Problem

On nightly (Railway), the LLM router falls back on every request, and task title refresh / work-kind classification fail:

```
[LLM Router] Routing fallback ... reason="OpenCode SDK server exited before it was ready ... code 1"
PermissionDenied: FileSystem.open (/tmp/.local/share/opencode/log/opencode.log)
```

Root cause: `runtime-inference-base` (#114) installs OpenCode and runs `opencode --version` **as root** with the image's `HOME=/tmp`. That bakes root-owned `/tmp/.npm` and `/tmp/.local/share/opencode/` into the image layer. The final stage runs as the hardened non-root `roomote-app` user (#105) with the same `HOME`, which cannot write inside those root-owned directories, so the in-process OpenCode SDK server dies at startup.

Why nothing caught it:
- **Compose deployments** (and the deployment acceptance smoke test) mount a fresh tmpfs over `/tmp`, masking the baked artifacts entirely — the skew only bites hosts that run the raw image, i.e. Railway.
- The smoke test's tool check was `command -v opencode`, which locates the binary without executing it.
- #114 was never deployed to Railway until the publish pipeline unblocked today (#125), so the first production exposure was `develop-f68732c7` at 20:10 UTC.

## Fix

- `.docker/app/Dockerfile`: remove `/tmp/.npm`, `/tmp/.local`, and `/tmp/.cache` in the same `RUN` layer that installs and version-checks OpenCode, so the image ships a pristine `/tmp` and the runtime user creates its own `HOME` state.
- `deploy/ci/deployment-smoke.sh`: the candidate check now executes `opencode --version` as the container user instead of just locating it. This verifies runtime executability (startup writes state under `HOME`); the comment documents that the tmpfs masks the raw-image case, which the Dockerfile layer now prevents.

## Testing

- `bash -n` on the smoke script. Local Docker daemon is unhealthy on this machine, so the image build is validated by this PR's Docker Build checks and, post-merge, by the (re-armed) deployment acceptance gate on the develop publish run.
- Verification on nightly after deploy: api logs should show no `PermissionDenied ... opencode.log`, and `[LLM Router]` lines should stop reporting `phase="fallback"` with the SDK-server-exit reason.