### PR TITLE
[Fix] Allow unbounded sandbox disk in the deployment smoke test

### DIFF
--- a/deploy/ci/deployment-smoke.sh
+++ b/deploy/ci/deployment-smoke.sh
@@ -109,6 +109,10 @@ DATABASE_URL=postgres://postgres:roomote-postgres-password@postgres:5432/roomote
 DEFAULT_COMPUTE_PROVIDER=docker
 DEPLOYMENT_CI_POSTGRES_PORT=$postgres_port
 DEPLOYMENT_CI_REDIS_PORT=$redis_port
+# CI runners are ephemeral and their Docker storage drivers cannot enforce
+# --storage-opt size quotas, so accept unbounded writable layers here. Real
+# deployments keep the fail-closed default.
+DOCKER_WORKER_ALLOW_UNBOUNDED_DISK=true
 DOCKER_WORKER_IMAGE=localhost/roomote/roomote-worker:$version
 DOCKER_WORKER_NETWORK=$worker_network
 DOCKER_WORKER_PLATFORM=$platform


### PR DESCRIPTION
## Problem

The publish gate for develop failed at **Deployment acceptance (amd64)**: https://github.com/RooCodeInc/Roomote/actions/runs/29121015943/job/86456179496

```
Error: Docker task 1 failed before a sandbox was launched: Docker storage driver cannot
enforce writable-layer limit 20g. Refusing to start an unbounded task. Configure a
quota-capable Docker data root or set DOCKER_WORKER_ALLOW_UNBOUNDED_DISK=true to
explicitly accept the host disk-exhaustion risk.
```

#109 made the controller fail closed when `--storage-opt size` cannot be enforced. CI runners use overlay2 without project quotas, so the candidate controller refused to launch the smoke test's Docker task probe. PR CI never catches this because it only runs `deployment:validate`; the full smoke test runs only in the publish workflow.

## Fix

Opt the smoke-test env into `DOCKER_WORKER_ALLOW_UNBOUNDED_DISK=true` — the escape hatch #109 shipped for exactly this case. Runners are ephemeral, so an unbounded writable layer has no real disk-exhaustion blast radius there. Real deployments keep the fail-closed default (`false` in all compose files).

The controller still passes the 20g quota first and takes the documented warn-and-retry-without-quota path, so the retry code also gets exercised by the gate.

## Verification

- `bash -n` on the modified script.
- Rendered the CI compose stack (`docker-compose.prod.yml` + `docker-compose.ci.yml`) with an env file written by the updated `write_env` and confirmed the controller service resolves `DOCKER_WORKER_ALLOW_UNBOUNDED_DISK: "true"` with `DOCKER_WORKER_DISK_LIMIT: 20g` still set.
- The publish workflow on merge re-runs the full acceptance gate end to end.