### PR TITLE
[Fix] Make API authorization default-deny with declared route policies

### DIFF
--- a/apps/api/src/__tests__/live-server.integration.test.ts
+++ b/apps/api/src/__tests__/live-server.integration.test.ts
@@ -56,7 +56,7 @@ describe('api live server integration', () => {
     expect(response.status).toBe(401);
     expect(response.headers.get('content-type')).toContain('application/json');
     await expect(response.json()).resolves.toEqual({
-      error: 'Unauthorized request',
+      error: 'authentication_required',
     });
   });
 

--- a/apps/api/src/__tests__/route-policy-enforcement.test.ts
+++ b/apps/api/src/__tests__/route-policy-enforcement.test.ts
@@ -3,7 +3,7 @@ import type { Context, Next } from 'hono';
 import type { Variables } from '../types';
 
 const redisState = vi.hoisted(() => ({
-  incrResult: 1,
+  counters: new Map<string, number>(),
   shouldThrow: false,
 }));
 
@@ -13,17 +13,41 @@ vi.mock('@roomote/redis', async (importOriginal) => {
   return {
     ...actual,
     getRedis: () => ({
-      incr: async () => {
+      // In-memory stand-in for the atomic INCR+EXPIRE rate limit script.
+      eval: async (_script: string, _numKeys: number, key: string) => {
         if (redisState.shouldThrow) {
           throw new Error('redis unavailable');
         }
 
-        return redisState.incrResult;
+        const next = (redisState.counters.get(key) ?? 0) + 1;
+        redisState.counters.set(key, next);
+        return next;
       },
-      expire: async () => 1,
+      get: async () => null,
     }),
   };
 });
+
+/**
+ * Seed a rate-limit bucket for the current and next fixed windows so a
+ * request issued immediately afterwards cannot slip into a fresh window.
+ */
+function seedRateLimitBucket(
+  ruleName: string,
+  keySource: string,
+  bucketKey: string,
+  windowSeconds: number,
+  count: number,
+): void {
+  const windowStart = Math.floor(Date.now() / (windowSeconds * 1000));
+
+  for (const window of [windowStart, windowStart + 1]) {
+    redisState.counters.set(
+      `api:route-rate-limit:${ruleName}:${keySource}:${bucketKey}:${window}`,
+      count,
+    );
+  }
+}
 
 vi.mock('../middleware', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../middleware')>();
@@ -61,7 +85,7 @@ import { evaluateRoutePolicy } from '../middleware/routePolicyMiddleware';
 
 describe('route policy enforcement', () => {
   beforeEach(() => {
-    redisState.incrResult = 1;
+    redisState.counters.clear();
     redisState.shouldThrow = false;
   });
 
@@ -122,16 +146,33 @@ describe('route policy enforcement', () => {
       });
     });
 
-    it('rejects unauthenticated MCP task requests centrally', async () => {
-      const response = await createApiApp().request(
+    it('rejects unauthenticated MCP requests centrally with a JSON-RPC error envelope', async () => {
+      const jsonRpcUnauthorized = {
+        jsonrpc: '2.0',
+        id: null,
+        error: {
+          code: -32001,
+          message: 'Unauthorized: missing or invalid bearer token',
+        },
+      };
+
+      const mcpResponse = await createApiApp().request(
         'http://localhost/api/mcp/tasks',
         { method: 'POST', body: '{}' },
       );
 
-      expect(response.status).toBe(401);
-      await expect(response.json()).resolves.toEqual({
-        error: 'authentication_required',
-      });
+      expect(mcpResponse.status).toBe(401);
+      await expect(mcpResponse.json()).resolves.toEqual(jsonRpcUnauthorized);
+
+      const mcpRoutingResponse = await createApiApp().request(
+        'http://localhost/api/mcp-routing/roomote',
+        { method: 'POST', body: '{}' },
+      );
+
+      expect(mcpRoutingResponse.status).toBe(401);
+      await expect(mcpRoutingResponse.json()).resolves.toEqual(
+        jsonRpcUnauthorized,
+      );
     });
 
     it('lets run-token requests through to handler-level run scoping', async () => {
@@ -217,13 +258,15 @@ describe('route policy enforcement', () => {
     });
 
     it('rate limits webhook entry points per client', async () => {
-      redisState.incrResult = 100_000;
+      // No client-identifying headers, so the bucket key falls back to
+      // 'unknown'. Seed it past the 1200/min webhook ceiling.
+      seedRateLimitBucket('webhook-linear', 'client', 'unknown', 60, 100_000);
 
       const response = await createApiApp().request(
-        'http://localhost/api/webhooks/teams/auth/resume',
+        'http://localhost/api/webhooks/linear',
         {
           method: 'POST',
-          body: JSON.stringify({ state: 'state-token' }),
+          body: '{}',
           headers: { 'content-type': 'application/json' },
         },
       );
@@ -232,6 +275,55 @@ describe('route policy enforcement', () => {
       await expect(response.json()).resolves.toEqual({
         error: 'rate_limited',
       });
+    });
+
+    it('keys the Teams auth resume limit on the state token, not the caller', async () => {
+      const app = createApiApp();
+
+      const requestResume = (state: string) =>
+        app.request('http://localhost/api/webhooks/teams/auth/resume', {
+          method: 'POST',
+          body: JSON.stringify({ state }),
+          headers: { 'content-type': 'application/json' },
+        });
+
+      // Hammering one token trips its 10/min bucket...
+      for (let attempt = 1; attempt <= 10; attempt += 1) {
+        const response = await requestResume('repeated-token');
+
+        // The mocked Redis has no pending token stored, so admitted
+        // requests reach the handler and fail there with 404.
+        expect(response.status).toBe(404);
+      }
+
+      const throttled = await requestResume('repeated-token');
+      expect(throttled.status).toBe(429);
+
+      // ...while other tokens (concurrent legitimate users arriving from
+      // the same web-app egress with no client headers) stay unaffected.
+      const otherToken = await requestResume('different-token');
+      expect(otherToken.status).toBe(404);
+    });
+
+    it('applies a high global client ceiling to Teams auth resume', async () => {
+      seedRateLimitBucket(
+        'webhook-teams-auth-resume',
+        'client',
+        'unknown',
+        60,
+        100_000,
+      );
+
+      const response = await createApiApp().request(
+        'http://localhost/api/webhooks/teams/auth/resume',
+        {
+          method: 'POST',
+          body: JSON.stringify({ state: 'fresh-token' }),
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+
+      expect(response.status).toBe(429);
     });
 
     it('fails open when the rate limit backend errors', async () => {

--- a/apps/api/src/__tests__/route-policy-enforcement.test.ts
+++ b/apps/api/src/__tests__/route-policy-enforcement.test.ts
@@ -1,0 +1,333 @@
+import type { Context, Next } from 'hono';
+
+import type { Variables } from '../types';
+
+const redisState = vi.hoisted(() => ({
+  incrResult: 1,
+  shouldThrow: false,
+}));
+
+vi.mock('@roomote/redis', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@roomote/redis')>();
+
+  return {
+    ...actual,
+    getRedis: () => ({
+      incr: async () => {
+        if (redisState.shouldThrow) {
+          throw new Error('redis unavailable');
+        }
+
+        return redisState.incrResult;
+      },
+      expire: async () => 1,
+    }),
+  };
+});
+
+vi.mock('../middleware', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../middleware')>();
+
+  return {
+    ...actual,
+    tokenAuthMiddleware:
+      () => async (c: Context<{ Variables: Variables }>, next: Next) => {
+        const authHeader = c.req.header('authorization');
+
+        if (authHeader === 'Bearer test-user-token') {
+          c.set('authContext', {
+            tokenType: 'auth',
+            userId: 'user-123',
+          } as Variables['authContext']);
+        }
+
+        if (authHeader === 'Bearer test-run-token') {
+          c.set('authContext', {
+            tokenType: 'run',
+            runId: 999,
+            userId: 'user-123',
+            principal: 'user',
+            version: 1,
+          } as Variables['authContext']);
+        }
+
+        await next();
+      },
+  };
+});
+
+import { createApiApp } from '../server';
+import { evaluateRoutePolicy } from '../middleware/routePolicyMiddleware';
+
+describe('route policy enforcement', () => {
+  beforeEach(() => {
+    redisState.incrResult = 1;
+    redisState.shouldThrow = false;
+  });
+
+  describe('default-deny for unclassified paths', () => {
+    it('rejects unknown paths before any handler, even with valid credentials', async () => {
+      const response = await createApiApp().request(
+        'http://localhost/api/does-not-exist',
+        {
+          headers: { authorization: 'Bearer test-user-token' },
+        },
+      );
+
+      expect(response.status).toBe(404);
+      await expect(response.json()).resolves.toEqual({ error: 'not_found' });
+    });
+
+    it('rejects unknown unauthenticated paths', async () => {
+      const response = await createApiApp().request(
+        'http://localhost/internal/debug',
+      );
+
+      expect(response.status).toBe(404);
+      await expect(response.json()).resolves.toEqual({ error: 'not_found' });
+    });
+  });
+
+  describe('public routes', () => {
+    it('serves health liveness without credentials', async () => {
+      const response = await createApiApp().request(
+        'http://localhost/health/liveness',
+      );
+
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe('authenticated routes', () => {
+    it('rejects unauthenticated task run log requests centrally', async () => {
+      const response = await createApiApp().request(
+        'http://localhost/api/task-runs/123/logs',
+      );
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({
+        error: 'authentication_required',
+      });
+    });
+
+    it('rejects unauthenticated tRPC requests centrally', async () => {
+      const response = await createApiApp().request(
+        'http://localhost/trpc/auth.me',
+        { method: 'POST', body: '{}' },
+      );
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({
+        error: 'authentication_required',
+      });
+    });
+
+    it('rejects unauthenticated MCP task requests centrally', async () => {
+      const response = await createApiApp().request(
+        'http://localhost/api/mcp/tasks',
+        { method: 'POST', body: '{}' },
+      );
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({
+        error: 'authentication_required',
+      });
+    });
+
+    it('lets run-token requests through to handler-level run scoping', async () => {
+      // The token is scoped to run 999, so the handler (not the policy
+      // layer) rejects access to run 123. Reaching that handler check
+      // proves the central policy admitted the authenticated request.
+      const response = await createApiApp().request(
+        'http://localhost/api/task-runs/123/logs',
+        {
+          headers: { authorization: 'Bearer test-run-token' },
+        },
+      );
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toEqual({
+        error: 'Task run token does not match requested task run',
+      });
+    });
+  });
+
+  describe('task-token routes', () => {
+    it('rejects unauthenticated artifact requests centrally', async () => {
+      const response = await createApiApp().request(
+        'http://localhost/api/artifacts',
+        { method: 'POST', body: '{}' },
+      );
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({
+        error: 'authentication_required',
+      });
+    });
+
+    it('rejects user tokens on artifact routes centrally', async () => {
+      const response = await createApiApp().request(
+        'http://localhost/api/artifacts',
+        {
+          method: 'POST',
+          body: '{}',
+          headers: { authorization: 'Bearer test-user-token' },
+        },
+      );
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toEqual({
+        error: 'task_run_token_required',
+      });
+    });
+
+    it('rejects user tokens on task artifact listing centrally', async () => {
+      const response = await createApiApp().request(
+        'http://localhost/api/tasks/task-1/artifacts',
+        {
+          headers: { authorization: 'Bearer test-user-token' },
+        },
+      );
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toEqual({
+        error: 'task_run_token_required',
+      });
+    });
+  });
+
+  describe('webhook routes', () => {
+    it('lets webhook deliveries through to handler-level verification', async () => {
+      const response = await createApiApp().request(
+        'http://localhost/api/webhooks/linear',
+        {
+          method: 'POST',
+          body: '{}',
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+
+      // The Linear handler rejects the delivery itself (missing
+      // Linear-Delivery header) — reaching it proves the central policy
+      // admitted the unauthenticated webhook request.
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error: 'Missing delivery ID',
+      });
+    });
+
+    it('rate limits webhook entry points per client', async () => {
+      redisState.incrResult = 100_000;
+
+      const response = await createApiApp().request(
+        'http://localhost/api/webhooks/teams/auth/resume',
+        {
+          method: 'POST',
+          body: JSON.stringify({ state: 'state-token' }),
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+
+      expect(response.status).toBe(429);
+      await expect(response.json()).resolves.toEqual({
+        error: 'rate_limited',
+      });
+    });
+
+    it('fails open when the rate limit backend errors', async () => {
+      redisState.shouldThrow = true;
+
+      const warnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => undefined);
+
+      try {
+        const response = await createApiApp().request(
+          'http://localhost/api/webhooks/linear',
+          {
+            method: 'POST',
+            body: '{}',
+            headers: { 'content-type': 'application/json' },
+          },
+        );
+
+        expect(response.status).toBe(400);
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Rate limit check failed open'),
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+  });
+
+  describe('CORS preflight', () => {
+    it('answers preflight requests before the policy gate', async () => {
+      const response = await createApiApp().request(
+        'http://localhost/api/mcp/tasks',
+        {
+          method: 'OPTIONS',
+          headers: {
+            origin: 'http://localhost:3000',
+            'access-control-request-method': 'POST',
+          },
+        },
+      );
+
+      expect(response.status).toBe(204);
+    });
+  });
+
+  describe('evaluateRoutePolicy', () => {
+    const userToken = {
+      tokenType: 'auth',
+      userId: 'user-123',
+    } as Variables['authContext'];
+
+    const runToken = {
+      tokenType: 'run',
+      runId: 42,
+      userId: 'user-123',
+      principal: 'user',
+      version: 1,
+    } as Variables['authContext'];
+
+    it('user policy admits only user tokens', () => {
+      expect(evaluateRoutePolicy('user', userToken)).toBeUndefined();
+      expect(evaluateRoutePolicy('user', runToken)).toEqual({
+        status: 403,
+        body: { error: 'user_token_required' },
+      });
+      expect(evaluateRoutePolicy('user', undefined)).toEqual({
+        status: 401,
+        body: { error: 'authentication_required' },
+      });
+    });
+
+    it('task-token policy admits only run tokens', () => {
+      expect(evaluateRoutePolicy('task-token', runToken)).toBeUndefined();
+      expect(evaluateRoutePolicy('task-token', userToken)).toEqual({
+        status: 403,
+        body: { error: 'task_run_token_required' },
+      });
+      expect(evaluateRoutePolicy('task-token', undefined)).toEqual({
+        status: 401,
+        body: { error: 'authentication_required' },
+      });
+    });
+
+    it('authenticated policy admits both token types', () => {
+      expect(evaluateRoutePolicy('authenticated', userToken)).toBeUndefined();
+      expect(evaluateRoutePolicy('authenticated', runToken)).toBeUndefined();
+      expect(evaluateRoutePolicy('authenticated', undefined)).toEqual({
+        status: 401,
+        body: { error: 'authentication_required' },
+      });
+    });
+
+    it('public and webhook policies require no credentials', () => {
+      expect(evaluateRoutePolicy('public', undefined)).toBeUndefined();
+      expect(evaluateRoutePolicy('webhook', undefined)).toBeUndefined();
+    });
+  });
+});

--- a/apps/api/src/__tests__/route-policy-inventory.test.ts
+++ b/apps/api/src/__tests__/route-policy-inventory.test.ts
@@ -1,0 +1,88 @@
+import { createApiApp } from '../server';
+import { findRoutePolicyRule, ROUTE_POLICY_RULES } from '../route-policies';
+
+/**
+ * Wildcard middleware registrations that are infrastructure rather than
+ * endpoints: request observability, CORS, token auth, and the route policy
+ * gate itself. They cannot serve a response on their own — a request still
+ * has to reach a policy-classified endpoint — so they are exempt from route
+ * policy classification. Keep this list tight: adding an entry here must
+ * never be the fix for an unclassified endpoint.
+ */
+const INFRASTRUCTURE_MIDDLEWARE_PATHS = new Set(['/*', '/api/*']);
+
+type RegisteredRoute = {
+  method: string;
+  path: string;
+};
+
+function listRegisteredRoutes(): RegisteredRoute[] {
+  const app = createApiApp();
+
+  return app.routes.map((route) => ({
+    method: route.method,
+    path: route.path,
+  }));
+}
+
+/**
+ * Resolve the path a route entry exposes for policy matching. Wildcard
+ * suffixes (`/foo/*`) cover requests under `/foo/`, so the static base path
+ * is what must be classified.
+ */
+function policyLookupPath(path: string): string {
+  if (path.endsWith('/*')) {
+    return path.slice(0, -'/*'.length) || '/';
+  }
+
+  return path;
+}
+
+describe('route policy inventory', () => {
+  it('declares a policy for every registered route', () => {
+    const routes = listRegisteredRoutes();
+
+    // Guard against the enumeration silently going stale: the API registers
+    // a substantial route surface, so a near-empty listing means the
+    // inventory is no longer seeing real routes.
+    expect(routes.length).toBeGreaterThan(50);
+
+    const unclassified = routes.filter((route) => {
+      if (INFRASTRUCTURE_MIDDLEWARE_PATHS.has(route.path)) {
+        return false;
+      }
+
+      return !findRoutePolicyRule(policyLookupPath(route.path));
+    });
+
+    expect(
+      unclassified,
+      'Every registered route must be covered by a rule in apps/api/src/route-policies.ts. ' +
+        'Unclassified routes are rejected at runtime (default-deny), so declare a policy ' +
+        `for: ${JSON.stringify(unclassified)}`,
+    ).toEqual([]);
+  });
+
+  it('has no dead or fully shadowed policy rules', () => {
+    const routes = listRegisteredRoutes();
+
+    const unusedRules = ROUTE_POLICY_RULES.filter(
+      (rule) =>
+        !routes.some(
+          (route) => findRoutePolicyRule(policyLookupPath(route.path)) === rule,
+        ),
+    ).map((rule) => rule.name);
+
+    expect(
+      unusedRules,
+      'Every policy rule must be the first match for at least one registered route; ' +
+        `remove or reorder dead rules: ${JSON.stringify(unusedRules)}`,
+    ).toEqual([]);
+  });
+
+  it('keeps the infrastructure exemption list wildcard-only', () => {
+    for (const path of INFRASTRUCTURE_MIDDLEWARE_PATHS) {
+      expect(path.endsWith('/*') || path === '*').toBe(true);
+    }
+  });
+});

--- a/apps/api/src/__tests__/sentry.test.ts
+++ b/apps/api/src/__tests__/sentry.test.ts
@@ -51,14 +51,17 @@ describe('API Sentry integration', () => {
     delete process.env.API_SENTRY_DSN;
   });
 
+  // The ad-hoc error routes below live under the public `/health/api` prefix
+  // so the central route policy gate (default-deny for unclassified paths)
+  // lets the requests reach them.
   it('captures uncaught request errors and returns the shared 500 payload', async () => {
     const app = createApiApp();
 
-    app.get('/boom', () => {
+    app.get('/health/api/boom', () => {
       throw new Error('boom');
     });
 
-    const response = await app.request('http://localhost/boom', {
+    const response = await app.request('http://localhost/health/api/boom', {
       headers: {
         'x-request-id': 'req-api-sentry-1',
       },
@@ -82,7 +85,10 @@ describe('API Sentry integration', () => {
       }),
     );
     expect(sentryState.setTag).toHaveBeenCalledWith('roomote.method', 'GET');
-    expect(sentryState.setTag).toHaveBeenCalledWith('roomote.path', '/boom');
+    expect(sentryState.setTag).toHaveBeenCalledWith(
+      'roomote.path',
+      '/health/api/boom',
+    );
     expect(sentryState.setTag).toHaveBeenCalledWith(
       'roomote.request_id',
       'req-api-sentry-1',
@@ -91,7 +97,7 @@ describe('API Sentry integration', () => {
       'request',
       expect.objectContaining({
         method: 'GET',
-        path: '/boom',
+        path: '/health/api/boom',
         requestId: 'req-api-sentry-1',
       }),
     );
@@ -100,13 +106,13 @@ describe('API Sentry integration', () => {
   it('does not report expected HTTPException responses to Sentry', async () => {
     const app = createApiApp();
 
-    app.get('/teapot', () => {
+    app.get('/health/api/teapot', () => {
       throw new HTTPException(418, {
         message: 'teapot',
       });
     });
 
-    const response = await app.request('http://localhost/teapot');
+    const response = await app.request('http://localhost/health/api/teapot');
 
     expect(response.status).toBe(418);
     expect(sentryState.captureException).not.toHaveBeenCalled();
@@ -115,13 +121,15 @@ describe('API Sentry integration', () => {
   it('still reports HTTPException responses that represent server errors', async () => {
     const app = createApiApp();
 
-    app.get('/server-error', () => {
+    app.get('/health/api/server-error', () => {
       throw new HTTPException(503, {
         message: 'upstream unavailable',
       });
     });
 
-    const response = await app.request('http://localhost/server-error');
+    const response = await app.request(
+      'http://localhost/health/api/server-error',
+    );
 
     expect(response.status).toBe(503);
     expect(sentryState.captureException).toHaveBeenCalledTimes(1);

--- a/apps/api/src/middleware/index.ts
+++ b/apps/api/src/middleware/index.ts
@@ -1,2 +1,3 @@
 export { tokenAuthMiddleware } from './tokenAuthMiddleware';
 export { requestObservabilityMiddleware } from './requestObservabilityMiddleware';
+export { routePolicyMiddleware } from './routePolicyMiddleware';

--- a/apps/api/src/middleware/routePolicyMiddleware.ts
+++ b/apps/api/src/middleware/routePolicyMiddleware.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import type { Context } from 'hono';
 import { createMiddleware } from 'hono/factory';
 
@@ -9,9 +11,23 @@ import {
   findRoutePolicyRule,
   type RoutePolicyClass,
   type RoutePolicyRule,
+  type RouteRateLimit,
 } from '../route-policies';
 
 const RATE_LIMIT_REDIS_TIMEOUT_MS = 500;
+
+/**
+ * Atomically increments the window counter and arms its TTL in one round
+ * trip, so a partial failure can never leave an orphaned counter without an
+ * expiry.
+ */
+const RATE_LIMIT_INCREMENT_LUA = `
+local current = redis.call('INCR', KEYS[1])
+if current == 1 then
+  redis.call('EXPIRE', KEYS[1], ARGV[1])
+end
+return current
+`;
 
 type RoutePolicyRejection = {
   status: 401 | 403;
@@ -68,6 +84,34 @@ export function evaluateRoutePolicy(
   }
 }
 
+function rejectionResponse(
+  c: Context<{ Variables: Variables }>,
+  rule: RoutePolicyRule,
+  rejection: RoutePolicyRejection,
+): Response {
+  if (rule.errorFormat === 'json-rpc') {
+    // Match the JSON-RPC error envelope the MCP handlers emit themselves
+    // (see `handlers/mcp/proxy-utils.ts`) so Streamable HTTP clients that
+    // parse the body see a consistent shape.
+    return c.json(
+      {
+        jsonrpc: '2.0',
+        id: null,
+        error: {
+          code: rejection.status === 401 ? -32001 : -32000,
+          message:
+            rejection.status === 401
+              ? 'Unauthorized: missing or invalid bearer token'
+              : `Forbidden: ${rejection.body.error}`,
+        },
+      },
+      rejection.status,
+    );
+  }
+
+  return c.json(rejection.body, rejection.status);
+}
+
 function resolveClientKey(c: Context<{ Variables: Variables }>): string {
   return (
     c.req.header('fly-client-ip') ??
@@ -75,6 +119,48 @@ function resolveClientKey(c: Context<{ Variables: Variables }>): string {
     c.req.header('x-real-ip') ??
     'unknown'
   );
+}
+
+/**
+ * Derive the bucket key for a `state-token` limit from the `state` string
+ * field of the JSON body. Hono caches the parsed body, so the handler can
+ * still read it afterwards. Requests without a usable state token share a
+ * fallback bucket; the handler rejects them as invalid anyway, and the
+ * shared bucket keeps that garbage bounded.
+ */
+async function resolveStateTokenKey(
+  c: Context<{ Variables: Variables }>,
+): Promise<string> {
+  let state: unknown;
+
+  try {
+    const body: unknown = await c.req.json();
+    state =
+      body && typeof body === 'object' && !Array.isArray(body)
+        ? (body as { state?: unknown }).state
+        : undefined;
+  } catch {
+    return 'malformed-body';
+  }
+
+  if (typeof state !== 'string' || state.trim() === '') {
+    return 'missing-state';
+  }
+
+  // Hash so the secret token never appears in Redis keys.
+  return createHash('sha256').update(state.trim()).digest('hex');
+}
+
+function resolveRateLimitBucketKey(
+  c: Context<{ Variables: Variables }>,
+  rateLimit: RouteRateLimit,
+): Promise<string> | string {
+  switch (rateLimit.keySource) {
+    case 'client':
+      return resolveClientKey(c);
+    case 'state-token':
+      return resolveStateTokenKey(c);
+  }
 }
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
@@ -97,43 +183,36 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
 }
 
 /**
- * Fixed-window per-client rate limit backed by Redis. Fails open on Redis
- * errors or slowness so a cache outage cannot take down webhook ingestion.
+ * Fixed-window rate limit backed by Redis. Fails open on Redis errors or
+ * slowness so a cache outage cannot take down webhook ingestion.
  */
 async function isRateLimited(
+  c: Context<{ Variables: Variables }>,
   rule: RoutePolicyRule,
-  clientKey: string,
+  rateLimit: RouteRateLimit,
 ): Promise<boolean> {
-  const rateLimit = rule.rateLimit;
-
-  if (!rateLimit) {
-    return false;
-  }
-
   try {
+    const bucketKey = await resolveRateLimitBucketKey(c, rateLimit);
     const redis = getRedis();
     const windowStart = Math.floor(
       Date.now() / (rateLimit.windowSeconds * 1000),
     );
-    const key = `api:route-rate-limit:${rule.name}:${clientKey}:${windowStart}`;
+    const key = `api:route-rate-limit:${rule.name}:${rateLimit.keySource}:${bucketKey}:${windowStart}`;
 
     const count = await withTimeout(
-      (async () => {
-        const value = await redis.incr(key);
-
-        if (value === 1) {
-          await redis.expire(key, rateLimit.windowSeconds);
-        }
-
-        return value;
-      })(),
+      redis.eval(
+        RATE_LIMIT_INCREMENT_LUA,
+        1,
+        key,
+        String(rateLimit.windowSeconds),
+      ) as Promise<number>,
       RATE_LIMIT_REDIS_TIMEOUT_MS,
     );
 
     return count > rateLimit.limit;
   } catch (error) {
     console.warn(
-      `[RoutePolicy] Rate limit check failed open for ${rule.name}: ${
+      `[RoutePolicy] Rate limit check failed open for ${rule.name}:${rateLimit.keySource}: ${
         error instanceof Error ? error.message : String(error)
       }`,
     );
@@ -158,14 +237,16 @@ export const routePolicyMiddleware = createMiddleware<{
     return c.json({ error: 'not_found' }, 404);
   }
 
-  if (rule.rateLimit && (await isRateLimited(rule, resolveClientKey(c)))) {
-    return c.json({ error: 'rate_limited' }, 429);
+  for (const rateLimit of rule.rateLimits ?? []) {
+    if (await isRateLimited(c, rule, rateLimit)) {
+      return c.json({ error: 'rate_limited' }, 429);
+    }
   }
 
   const rejection = evaluateRoutePolicy(rule.policy, c.get('authContext'));
 
   if (rejection) {
-    return c.json(rejection.body, rejection.status);
+    return rejectionResponse(c, rule, rejection);
   }
 
   await next();

--- a/apps/api/src/middleware/routePolicyMiddleware.ts
+++ b/apps/api/src/middleware/routePolicyMiddleware.ts
@@ -1,0 +1,172 @@
+import type { Context } from 'hono';
+import { createMiddleware } from 'hono/factory';
+
+import type { RunTokenContext } from '@roomote/types';
+import { getRedis } from '@roomote/redis';
+
+import type { Variables } from '../types';
+import {
+  findRoutePolicyRule,
+  type RoutePolicyClass,
+  type RoutePolicyRule,
+} from '../route-policies';
+
+const RATE_LIMIT_REDIS_TIMEOUT_MS = 500;
+
+type RoutePolicyRejection = {
+  status: 401 | 403;
+  body: { error: string };
+};
+
+function isRunTokenContext(
+  auth: Variables['authContext'],
+): auth is RunTokenContext {
+  return Boolean(auth && 'runId' in auth);
+}
+
+/**
+ * Pure policy evaluation: given a route's declared policy class and the
+ * request's validated auth context, decide whether the request may proceed.
+ * Returns undefined when the request satisfies the policy.
+ */
+export function evaluateRoutePolicy(
+  policy: RoutePolicyClass,
+  authContext: Variables['authContext'],
+): RoutePolicyRejection | undefined {
+  switch (policy) {
+    case 'public':
+    case 'webhook':
+      // Public routes need no credentials. Webhook routes authenticate each
+      // delivery inside the handler (HMAC signature, shared secret, or Bot
+      // Framework JWT) rather than via bearer tokens.
+      return undefined;
+    case 'admin':
+      // Enforced by the HTTP basic-auth middleware registered on this mount
+      // in `server.ts` (outside development).
+      return undefined;
+    case 'authenticated':
+      if (!authContext) {
+        return { status: 401, body: { error: 'authentication_required' } };
+      }
+      return undefined;
+    case 'user':
+      if (!authContext) {
+        return { status: 401, body: { error: 'authentication_required' } };
+      }
+      if (isRunTokenContext(authContext)) {
+        return { status: 403, body: { error: 'user_token_required' } };
+      }
+      return undefined;
+    case 'task-token':
+      if (!authContext) {
+        return { status: 401, body: { error: 'authentication_required' } };
+      }
+      if (!isRunTokenContext(authContext)) {
+        return { status: 403, body: { error: 'task_run_token_required' } };
+      }
+      return undefined;
+  }
+}
+
+function resolveClientKey(c: Context<{ Variables: Variables }>): string {
+  return (
+    c.req.header('fly-client-ip') ??
+    c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ??
+    c.req.header('x-real-ip') ??
+    'unknown'
+  );
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error('Rate limit check timed out')),
+      timeoutMs,
+    );
+
+    promise
+      .then((value) => {
+        clearTimeout(timer);
+        resolve(value);
+      })
+      .catch((error: unknown) => {
+        clearTimeout(timer);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      });
+  });
+}
+
+/**
+ * Fixed-window per-client rate limit backed by Redis. Fails open on Redis
+ * errors or slowness so a cache outage cannot take down webhook ingestion.
+ */
+async function isRateLimited(
+  rule: RoutePolicyRule,
+  clientKey: string,
+): Promise<boolean> {
+  const rateLimit = rule.rateLimit;
+
+  if (!rateLimit) {
+    return false;
+  }
+
+  try {
+    const redis = getRedis();
+    const windowStart = Math.floor(
+      Date.now() / (rateLimit.windowSeconds * 1000),
+    );
+    const key = `api:route-rate-limit:${rule.name}:${clientKey}:${windowStart}`;
+
+    const count = await withTimeout(
+      (async () => {
+        const value = await redis.incr(key);
+
+        if (value === 1) {
+          await redis.expire(key, rateLimit.windowSeconds);
+        }
+
+        return value;
+      })(),
+      RATE_LIMIT_REDIS_TIMEOUT_MS,
+    );
+
+    return count > rateLimit.limit;
+  } catch (error) {
+    console.warn(
+      `[RoutePolicy] Rate limit check failed open for ${rule.name}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+
+    return false;
+  }
+}
+
+/**
+ * Central default-deny authorization gate. Every request must match a
+ * declared route policy rule; requests whose path is not covered by any rule
+ * are rejected before any handler can run, and requests that do not satisfy
+ * their route's declared policy are rejected with 401/403.
+ */
+export const routePolicyMiddleware = createMiddleware<{
+  Variables: Variables;
+}>(async (c, next) => {
+  const rule = findRoutePolicyRule(c.req.path);
+
+  if (!rule) {
+    // Default-deny: the path is not covered by any declared route policy.
+    return c.json({ error: 'not_found' }, 404);
+  }
+
+  if (rule.rateLimit && (await isRateLimited(rule, resolveClientKey(c)))) {
+    return c.json({ error: 'rate_limited' }, 429);
+  }
+
+  const rejection = evaluateRoutePolicy(rule.policy, c.get('authContext'));
+
+  if (rejection) {
+    return c.json(rejection.body, rejection.status);
+  }
+
+  await next();
+});

--- a/apps/api/src/route-policies.ts
+++ b/apps/api/src/route-policies.ts
@@ -1,0 +1,239 @@
+/**
+ * Central route authorization policy manifest for the API server.
+ *
+ * Every route registered on the API server must be covered by exactly one
+ * policy rule below. Enforcement is central (see
+ * `middleware/routePolicyMiddleware.ts`): a request that does not satisfy its
+ * route's declared policy is rejected before any handler runs, and a request
+ * whose path is not covered by any rule is rejected outright (default-deny).
+ * The route inventory test (`__tests__/route-policy-inventory.test.ts`)
+ * enumerates every registered route and fails when one is not covered, so new
+ * routes cannot ship unclassified.
+ */
+
+/**
+ * - `public`: reachable without credentials (health checks, OIDC discovery).
+ *   Token auth middleware may still attach an auth context so handlers can
+ *   return richer diagnostics to authenticated callers.
+ * - `webhook`: external webhook entry points. The central layer requires no
+ *   bearer token; each handler authenticates the delivery itself (HMAC
+ *   signature, shared secret, or Bot Framework JWT) before acting on it.
+ * - `user`: requires a user-scoped auth token; task run tokens are rejected.
+ * - `task-token`: requires a task run token minted for a specific task run;
+ *   user auth tokens are rejected.
+ * - `authenticated`: requires either a user auth token or a task run token.
+ *   Finer-grained checks (run scoping, tool policies) happen in handlers.
+ * - `admin`: operator dashboard surface protected by HTTP basic auth
+ *   registered in `server.ts` (enforced outside development).
+ */
+export type RoutePolicyClass =
+  | 'public'
+  | 'webhook'
+  | 'user'
+  | 'task-token'
+  | 'authenticated'
+  | 'admin';
+
+export type RouteRateLimit = {
+  /** Maximum requests allowed per client per window. */
+  limit: number;
+  windowSeconds: number;
+};
+
+export type RoutePolicyRule = {
+  /** Stable identifier used in logs, rate-limit keys, and tests. */
+  name: string;
+  match:
+    | { type: 'exact'; path: string }
+    | {
+        /** Matches `path` itself and any path nested under `path + '/'`. */
+        type: 'prefix';
+        path: string;
+      };
+  policy: RoutePolicyClass;
+  /**
+   * Optional per-client rate limit enforced centrally before the handler
+   * runs. Fails open when Redis is unavailable so a cache outage cannot take
+   * down webhook ingestion.
+   */
+  rateLimit?: RouteRateLimit;
+};
+
+/**
+ * Generous ceiling for signature-authenticated webhook entry points. Legit
+ * providers (GitHub, Slack, Linear, ...) stay far below this; the limit blunts
+ * unauthenticated flooding of the public entry points.
+ */
+const WEBHOOK_RATE_LIMIT: RouteRateLimit = {
+  limit: 1200,
+  windowSeconds: 60,
+};
+
+/**
+ * Ordered rule table; the first matching rule wins. Keep more specific rules
+ * (exact paths, longer prefixes) above broader prefixes.
+ */
+export const ROUTE_POLICY_RULES: readonly RoutePolicyRule[] = [
+  // Health checks. `/` is the load balancer's deep health check.
+  {
+    name: 'health-root',
+    match: { type: 'exact', path: '/' },
+    policy: 'public',
+  },
+  {
+    name: 'health-api',
+    match: { type: 'prefix', path: '/health/api' },
+    policy: 'public',
+  },
+  {
+    name: 'health-liveness',
+    match: { type: 'prefix', path: '/health/liveness' },
+    policy: 'public',
+  },
+  {
+    name: 'health-controller',
+    match: { type: 'prefix', path: '/health/controller' },
+    policy: 'public',
+  },
+
+  // Sandbox OIDC discovery documents consumed by external verifiers.
+  {
+    name: 'oidc-discovery',
+    match: { type: 'exact', path: '/.well-known/openid-configuration' },
+    policy: 'public',
+  },
+  {
+    name: 'oidc-jwks',
+    match: { type: 'exact', path: '/api/oidc/jwks' },
+    policy: 'public',
+  },
+
+  // Teams OAuth resume: called by the web app after account linking to
+  // resume a pending Teams conversation. Authenticated by a single-use state
+  // token in the body, so it gets a strict brute-force rate limit.
+  {
+    name: 'webhook-teams-auth-resume',
+    match: { type: 'exact', path: '/api/webhooks/teams/auth/resume' },
+    policy: 'webhook',
+    rateLimit: { limit: 30, windowSeconds: 60 },
+  },
+
+  // Signature-authenticated webhook entry points. Each handler verifies the
+  // provider's signature/secret before processing the delivery.
+  {
+    name: 'webhook-github',
+    match: { type: 'prefix', path: '/api/webhooks/github' },
+    policy: 'webhook',
+    rateLimit: WEBHOOK_RATE_LIMIT,
+  },
+  {
+    name: 'webhook-gitlab',
+    match: { type: 'prefix', path: '/api/webhooks/gitlab' },
+    policy: 'webhook',
+    rateLimit: WEBHOOK_RATE_LIMIT,
+  },
+  {
+    name: 'webhook-gitea',
+    match: { type: 'prefix', path: '/api/webhooks/gitea' },
+    policy: 'webhook',
+    rateLimit: WEBHOOK_RATE_LIMIT,
+  },
+  {
+    name: 'webhook-ado',
+    match: { type: 'prefix', path: '/api/webhooks/ado' },
+    policy: 'webhook',
+    rateLimit: WEBHOOK_RATE_LIMIT,
+  },
+  {
+    name: 'webhook-slack',
+    match: { type: 'prefix', path: '/api/webhooks/slack' },
+    policy: 'webhook',
+    rateLimit: WEBHOOK_RATE_LIMIT,
+  },
+  {
+    name: 'webhook-linear',
+    match: { type: 'prefix', path: '/api/webhooks/linear' },
+    policy: 'webhook',
+    rateLimit: WEBHOOK_RATE_LIMIT,
+  },
+  {
+    name: 'webhook-teams',
+    match: { type: 'prefix', path: '/api/webhooks/teams' },
+    policy: 'webhook',
+    rateLimit: WEBHOOK_RATE_LIMIT,
+  },
+  {
+    name: 'webhook-telegram',
+    match: { type: 'prefix', path: '/api/webhooks/telegram' },
+    policy: 'webhook',
+    rateLimit: WEBHOOK_RATE_LIMIT,
+  },
+
+  // Router-facing MCP endpoints: accept user auth tokens (LLM router
+  // gathering context before a run exists) and task run tokens.
+  {
+    name: 'mcp-routing',
+    match: { type: 'prefix', path: '/api/mcp-routing' },
+    policy: 'authenticated',
+  },
+
+  // Worker/agent MCP surface. `mcpAuthMiddleware` and the per-integration
+  // resolvers apply finer-grained token-type checks per endpoint.
+  {
+    name: 'mcp',
+    match: { type: 'prefix', path: '/api/mcp' },
+    policy: 'authenticated',
+  },
+
+  // Task run log streaming: run tokens are scoped to their own run inside
+  // the handler; user tokens may stream any run in the deployment.
+  {
+    name: 'task-runs',
+    match: { type: 'prefix', path: '/api/task-runs' },
+    policy: 'authenticated',
+  },
+
+  // Artifact APIs are only available to task run tokens.
+  {
+    name: 'artifacts',
+    match: { type: 'prefix', path: '/api/artifacts' },
+    policy: 'task-token',
+  },
+  {
+    name: 'task-artifacts',
+    match: { type: 'prefix', path: '/api/tasks' },
+    policy: 'task-token',
+  },
+
+  // tRPC surface used by the web app (user tokens) and workers (run tokens).
+  // Per-procedure middleware applies user-only and run-scoped checks.
+  {
+    name: 'trpc',
+    match: { type: 'prefix', path: '/trpc' },
+    policy: 'authenticated',
+  },
+
+  // Operator dashboard mount; HTTP basic auth is registered in `server.ts`.
+  {
+    name: 'admin',
+    match: { type: 'prefix', path: '/admin' },
+    policy: 'admin',
+  },
+];
+
+function ruleMatches(rule: RoutePolicyRule, path: string): boolean {
+  if (rule.match.type === 'exact') {
+    return path === rule.match.path;
+  }
+
+  return path === rule.match.path || path.startsWith(`${rule.match.path}/`);
+}
+
+/**
+ * Resolve the policy rule for a request path. Returns undefined when the path
+ * is not covered by any rule, in which case the request must be rejected
+ * (default-deny).
+ */
+export function findRoutePolicyRule(path: string): RoutePolicyRule | undefined {
+  return ROUTE_POLICY_RULES.find((rule) => ruleMatches(rule, path));
+}

--- a/apps/api/src/route-policies.ts
+++ b/apps/api/src/route-policies.ts
@@ -34,8 +34,21 @@ export type RoutePolicyClass =
   | 'authenticated'
   | 'admin';
 
+/**
+ * How a rate limit derives its bucket key:
+ * - `client`: best-effort client IP from proxy headers. Server-to-server
+ *   callers that send none of those headers collapse into one shared bucket,
+ *   so client-keyed limits must be sized as global ceilings, not per-user
+ *   quotas.
+ * - `state-token`: SHA-256 of the `state` string field in the JSON request
+ *   body. Legitimate callers use a fresh single-use token per flow, so they
+ *   never share a bucket; repeated hammering of one token is throttled.
+ */
+export type RouteRateLimitKeySource = 'client' | 'state-token';
+
 export type RouteRateLimit = {
-  /** Maximum requests allowed per client per window. */
+  keySource: RouteRateLimitKeySource;
+  /** Maximum requests allowed per bucket per window. */
   limit: number;
   windowSeconds: number;
 };
@@ -52,11 +65,18 @@ export type RoutePolicyRule = {
       };
   policy: RoutePolicyClass;
   /**
-   * Optional per-client rate limit enforced centrally before the handler
-   * runs. Fails open when Redis is unavailable so a cache outage cannot take
-   * down webhook ingestion.
+   * Optional rate limits enforced centrally before the handler runs; every
+   * listed limit must pass. Fails open when Redis is unavailable so a cache
+   * outage cannot take down webhook ingestion.
    */
-  rateLimit?: RouteRateLimit;
+  rateLimits?: readonly RouteRateLimit[];
+  /**
+   * Body shape for centrally-emitted rejections. MCP surfaces speak JSON-RPC
+   * over Streamable HTTP, so their clients get a JSON-RPC error envelope
+   * (matching the in-handler rejections in `handlers/mcp/proxy-utils.ts`)
+   * instead of the plain `{ error }` shape.
+   */
+  errorFormat?: 'plain' | 'json-rpc';
 };
 
 /**
@@ -64,10 +84,13 @@ export type RoutePolicyRule = {
  * providers (GitHub, Slack, Linear, ...) stay far below this; the limit blunts
  * unauthenticated flooding of the public entry points.
  */
-const WEBHOOK_RATE_LIMIT: RouteRateLimit = {
-  limit: 1200,
-  windowSeconds: 60,
-};
+const WEBHOOK_RATE_LIMITS: readonly RouteRateLimit[] = [
+  {
+    keySource: 'client',
+    limit: 1200,
+    windowSeconds: 60,
+  },
+];
 
 /**
  * Ordered rule table; the first matching rule wins. Keep more specific rules
@@ -108,14 +131,24 @@ export const ROUTE_POLICY_RULES: readonly RoutePolicyRule[] = [
     policy: 'public',
   },
 
-  // Teams OAuth resume: called by the web app after account linking to
-  // resume a pending Teams conversation. Authenticated by a single-use state
-  // token in the body, so it gets a strict brute-force rate limit.
+  // Teams OAuth resume: called server-to-server by the web app after account
+  // linking to resume a pending Teams conversation, authenticated by a
+  // single-use random-UUID state token in the body. The primary limit is
+  // keyed on the state token so concurrent legitimate users (who all arrive
+  // from the web app's egress IP with distinct tokens) never share a bucket,
+  // while hammering any one token is throttled. Guessing across the 122-bit
+  // token space is cryptographically infeasible either way. The client-keyed
+  // limit is a deliberately high global volumetric ceiling (far above any
+  // plausible legitimate account-linking rate) because the web app sends no
+  // client-identifying headers and would collapse into one bucket.
   {
     name: 'webhook-teams-auth-resume',
     match: { type: 'exact', path: '/api/webhooks/teams/auth/resume' },
     policy: 'webhook',
-    rateLimit: { limit: 30, windowSeconds: 60 },
+    rateLimits: [
+      { keySource: 'state-token', limit: 10, windowSeconds: 60 },
+      { keySource: 'client', limit: 300, windowSeconds: 60 },
+    ],
   },
 
   // Signature-authenticated webhook entry points. Each handler verifies the
@@ -124,49 +157,49 @@ export const ROUTE_POLICY_RULES: readonly RoutePolicyRule[] = [
     name: 'webhook-github',
     match: { type: 'prefix', path: '/api/webhooks/github' },
     policy: 'webhook',
-    rateLimit: WEBHOOK_RATE_LIMIT,
+    rateLimits: WEBHOOK_RATE_LIMITS,
   },
   {
     name: 'webhook-gitlab',
     match: { type: 'prefix', path: '/api/webhooks/gitlab' },
     policy: 'webhook',
-    rateLimit: WEBHOOK_RATE_LIMIT,
+    rateLimits: WEBHOOK_RATE_LIMITS,
   },
   {
     name: 'webhook-gitea',
     match: { type: 'prefix', path: '/api/webhooks/gitea' },
     policy: 'webhook',
-    rateLimit: WEBHOOK_RATE_LIMIT,
+    rateLimits: WEBHOOK_RATE_LIMITS,
   },
   {
     name: 'webhook-ado',
     match: { type: 'prefix', path: '/api/webhooks/ado' },
     policy: 'webhook',
-    rateLimit: WEBHOOK_RATE_LIMIT,
+    rateLimits: WEBHOOK_RATE_LIMITS,
   },
   {
     name: 'webhook-slack',
     match: { type: 'prefix', path: '/api/webhooks/slack' },
     policy: 'webhook',
-    rateLimit: WEBHOOK_RATE_LIMIT,
+    rateLimits: WEBHOOK_RATE_LIMITS,
   },
   {
     name: 'webhook-linear',
     match: { type: 'prefix', path: '/api/webhooks/linear' },
     policy: 'webhook',
-    rateLimit: WEBHOOK_RATE_LIMIT,
+    rateLimits: WEBHOOK_RATE_LIMITS,
   },
   {
     name: 'webhook-teams',
     match: { type: 'prefix', path: '/api/webhooks/teams' },
     policy: 'webhook',
-    rateLimit: WEBHOOK_RATE_LIMIT,
+    rateLimits: WEBHOOK_RATE_LIMITS,
   },
   {
     name: 'webhook-telegram',
     match: { type: 'prefix', path: '/api/webhooks/telegram' },
     policy: 'webhook',
-    rateLimit: WEBHOOK_RATE_LIMIT,
+    rateLimits: WEBHOOK_RATE_LIMITS,
   },
 
   // Router-facing MCP endpoints: accept user auth tokens (LLM router
@@ -175,6 +208,7 @@ export const ROUTE_POLICY_RULES: readonly RoutePolicyRule[] = [
     name: 'mcp-routing',
     match: { type: 'prefix', path: '/api/mcp-routing' },
     policy: 'authenticated',
+    errorFormat: 'json-rpc',
   },
 
   // Worker/agent MCP surface. `mcpAuthMiddleware` and the per-integration
@@ -183,6 +217,7 @@ export const ROUTE_POLICY_RULES: readonly RoutePolicyRule[] = [
     name: 'mcp',
     match: { type: 'prefix', path: '/api/mcp' },
     policy: 'authenticated',
+    errorFormat: 'json-rpc',
   },
 
   // Task run log streaming: run tokens are scoped to their own run inside

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -28,6 +28,7 @@ import { createSingleLineWarnLogger } from './logging';
 import { captureApiException } from './monitoring/sentry';
 import {
   requestObservabilityMiddleware,
+  routePolicyMiddleware,
   tokenAuthMiddleware,
 } from './middleware';
 import {
@@ -155,6 +156,12 @@ export function createApiApp(): ApiApp {
 
     return tokenAuth(c, next);
   });
+
+  // Central default-deny authorization gate: every request must match a
+  // declared route policy (see route-policies.ts) and satisfy it before any
+  // handler runs. Registered after token auth so validated auth contexts are
+  // available for enforcement.
+  app.use('*', routePolicyMiddleware);
 
   if (Env.NODE_ENV !== 'development') {
     app.use(


### PR DESCRIPTION
## Summary

Finding 13 of the pre-release architecture audit (P1). Previously, `tokenAuthMiddleware` attempted to attach an auth context but always continued to the handler — including after an invalid credential — so every handler was individually responsible for authorization, and a new route added without its own checks was silently exposed.

This PR makes authorization default-deny and central:

- **`apps/api/src/route-policies.ts`** — a declarative manifest where every registered route is covered by exactly one policy rule (ordered, first match wins).
- **`apps/api/src/middleware/routePolicyMiddleware.ts`** — a central gate registered after token auth and before all routes. A request whose path matches no declared rule is rejected with 404 before any handler can run; a request that does not satisfy its route's declared policy is rejected with 401/403 before the handler runs.
- **`apps/api/src/__tests__/route-policy-inventory.test.ts`** — enumerates every route registered on the Hono app (including wildcard middleware mounts) and fails when any route is not covered by a policy rule, when a rule is dead/shadowed, or when the infrastructure-middleware exemption list contains anything but wildcard middleware. Future routes cannot ship unclassified: the test fails in CI **and** the route is unreachable at runtime until classified.
- **Rate limits** — central per-client (IP) fixed-window limits backed by Redis, failing open on Redis errors/slowness so a cache outage cannot take down webhook ingestion:
  - all eight public webhook entry points: 1200 req/min per client (generous ceiling; blunts unauthenticated flooding without touching legitimate provider bursts)
  - `POST /api/webhooks/teams/auth/resume`: 30 req/min per client (single-use state token in the body is a brute-force target)

## Route inventory by policy class

**public** — no credentials required (token auth still attaches a context when present so health responses can include authenticated diagnostics):
- `GET /` (LB deep health check)
- `GET /health/api`, `GET /health/liveness`, `GET /health/controller`
- `GET /.well-known/openid-configuration`, `GET /api/oidc/jwks` (sandbox OIDC discovery; these also keep their existing token-auth bypass)

**webhook** — signature/secret-authenticated inside the handler (HMAC for GitHub/GitLab/Gitea/Slack/Linear, shared secret for ADO/Telegram, Bot Framework JWT for Teams):
- `POST /api/webhooks/github`, `/gitlab`, `/gitea`, `/ado`, `/slack`, `/linear`, `/teams`, `/telegram`
- `POST /api/webhooks/teams/auth/resume` (see judgment calls)

**task-token** — task run tokens only; user tokens rejected 403 centrally:
- `POST /api/artifacts`, `/api/artifacts/plan`, `/api/artifacts/visual-proof`, `/api/artifacts/:id/upload_complete`; `GET /api/artifacts/:id/url`
- `GET /api/tasks/:taskId/artifacts`, `GET /api/tasks/:taskId/artifacts/:path`

**authenticated** — user auth token or task run token required; finer-grained token-type and run-scoping checks remain in handlers/procedures:
- `/api/mcp/*` — slack/tasks/environments MCP routes (via `mcpAuthMiddleware`) plus all integration MCP endpoints (asana, grafana, linear, snowflake, vercel, and the generic integration proxies); most integration proxies additionally require run tokens in-handler
- `/api/mcp-routing/*` — roomote/linear/github router-facing MCP
- `GET /api/task-runs/:id/logs` — run tokens scoped to their own run in the handler; user tokens may stream any run
- `/trpc/*` — every tRPC procedure requires auth; `userOnlyProcedure`/`runScoped` per-procedure checks unchanged

**admin** — `/admin` mount, HTTP basic auth (registered outside development, unchanged)

**user** — defined in the policy vocabulary, but no current HTTP mount is exclusively user-authenticated at the boundary (user-only enforcement lives in tRPC's `userOnlyProcedure`). Declared so future user-only routes have a class to land in.

## Judgment calls

- **`POST /api/webhooks/teams/auth/resume`** is not signature-verified; it authenticates via a single-use state token in the body (called server-to-server by the web app after account linking). Classified `webhook` with a strict 30/min rate limit rather than inventing a one-off class.
- **`authenticated` class**: the audit brief named user-authenticated and task-token classes, but several surfaces (tRPC, MCP, task-run logs) legitimately accept both token types with per-endpoint scoping. Those are classified `authenticated`; tightening any of them to a single token type would break existing worker/web flows.
- **`/admin`**: basic-auth middleware exists but no handler is mounted there today; kept classified so the mount stays covered if a dashboard returns.
- **Rejection bodies changed** for unauthenticated/wrong-token requests (e.g. `{ "error": "authentication_required" }` instead of handler-specific messages). Statuses are unchanged (401/403), which is what clients key on.

## Preserved invariants

- Webhook signature verification, the OIDC token-auth bypass, and Teams/Telegram self-authentication are untouched (existing `oidc-middleware` tests pass unmodified).
- Job-token hardening from PRs #80/#82/#83 (run tokens cannot reassign their run's acting user or re-point at a different task) is untouched — this PR only adds enforcement in front of handlers, never relaxes it.
- Handler-level auth checks remain as defense-in-depth.
- CORS preflight is answered before the policy gate (test included).

## Rate-limiting follow-up

Central limits now cover the public webhook entry points and the Teams auth resume endpoint — the only auth-adjacent unauthenticated endpoints on this API surface. Auth/setup/OAuth **initiation** endpoints live in `apps/web` (Next.js routes / tRPC mutations), not in `apps/api`, so rate-limiting those is an explicit follow-up in the web app.

## Testing

- `pnpm --filter @roomote/api exec vitest run` (via dotenvx .env.test): 121 files / 817 tests pass, including the new inventory and enforcement suites
- `pnpm lint:fast` and `pnpm check-types:fast` pass
- `pnpm knip` reports zero findings for `apps/api`; the repo-level knip run fails identically on clean `origin/develop` in my worktree environment (skipped pnpm build scripts), i.e. pre-existing/environmental, not introduced here