### PR TITLE
[Refactor] Model product agent identity separately from workflow and payload kind

### DIFF
--- a/apps/api/src/handlers/ado/__tests__/handleComment.test.ts
+++ b/apps/api/src/handlers/ado/__tests__/handleComment.test.ts
@@ -140,7 +140,7 @@ describe('handleAdoComment', () => {
       status: 'ok',
       targets: [
         {
-          id: 'ado:pr_reviewer:repo-1',
+          id: 'ado:pr_review:repo-1',
           settings: null,
           repositoryIds: ['repo-1'],
           userId: 'user-1',

--- a/apps/api/src/handlers/ado/__tests__/handlePullRequest.test.ts
+++ b/apps/api/src/handlers/ado/__tests__/handlePullRequest.test.ts
@@ -182,7 +182,7 @@ describe('handleAdoPullRequest', () => {
       status: 'ok',
       targets: [
         {
-          id: 'ado:pr_reviewer:repo-1',
+          id: 'ado:pr_review:repo-1',
           settings: null,
           repositoryIds: ['repo-1'],
           userId: 'user-1',

--- a/apps/api/src/handlers/gitea/__tests__/handleComment.test.ts
+++ b/apps/api/src/handlers/gitea/__tests__/handleComment.test.ts
@@ -120,7 +120,7 @@ describe('handleGiteaComment', () => {
       status: 'ok',
       targets: [
         {
-          id: 'gitea:pr_reviewer:repo-1',
+          id: 'gitea:pr_review:repo-1',
           settings: null,
           repositoryIds: ['repo-1'],
           userId: 'user-1',

--- a/apps/api/src/handlers/gitea/__tests__/handlePullRequest.test.ts
+++ b/apps/api/src/handlers/gitea/__tests__/handlePullRequest.test.ts
@@ -118,7 +118,7 @@ describe('handleGiteaPullRequest', () => {
       status: 'ok',
       targets: [
         {
-          id: 'gitea:pr_reviewer:repo-1',
+          id: 'gitea:pr_review:repo-1',
           settings: null,
           repositoryIds: ['repo-1'],
           userId: 'user-1',

--- a/apps/api/src/handlers/gitlab/__tests__/handleMergeRequest.test.ts
+++ b/apps/api/src/handlers/gitlab/__tests__/handleMergeRequest.test.ts
@@ -112,7 +112,7 @@ describe('handleGitLabMergeRequest', () => {
       status: 'ok',
       targets: [
         {
-          id: 'gitlab:pr_reviewer:repo-1',
+          id: 'gitlab:pr_review:repo-1',
           settings: null,
           repositoryIds: ['repo-1'],
           userId: 'user-1',

--- a/apps/api/src/handlers/gitlab/__tests__/handleNote.test.ts
+++ b/apps/api/src/handlers/gitlab/__tests__/handleNote.test.ts
@@ -113,7 +113,7 @@ describe('handleGitLabNote', () => {
       status: 'ok',
       targets: [
         {
-          id: 'gitlab:pr_reviewer:repo-1',
+          id: 'gitlab:pr_review:repo-1',
           settings: null,
           repositoryIds: ['repo-1'],
           userId: 'user-1',

--- a/apps/api/src/handlers/linear/__tests__/linear-active-run-priority.test.ts
+++ b/apps/api/src/handlers/linear/__tests__/linear-active-run-priority.test.ts
@@ -52,7 +52,6 @@ vi.mock('@roomote/cloud-agents/server', () => ({
   enqueueTask: vi.fn(),
   routeTask: vi.fn(),
   buildLinearRoutingContext: vi.fn(),
-  AGENT_TYPE_TO_PROMPT_NAME: {},
 }));
 
 vi.mock('@roomote/sdk/server', async (importOriginal) => {
@@ -285,7 +284,9 @@ describe('CLO-1133: active task run takes priority over routing confirmation and
   it('delivers free-text reply to active task run even when routing confirmation key exists in Redis', async () => {
     setupDbMocks();
 
-    // Simulate a stale routing confirmation key in Redis
+    // Simulate a stale routing confirmation key in Redis. The legacy
+    // agentName/agentType fields are intentional: payloads written before the
+    // agent-identity removal can still be present and must stay tolerated.
     redisMock.eval.mockResolvedValue(
       JSON.stringify({
         agentName: 'Agent',

--- a/apps/api/src/handlers/slack/constants.ts
+++ b/apps/api/src/handlers/slack/constants.ts
@@ -27,11 +27,11 @@ export const SLACK_FAST_AGENT_LOCK_PREFIX = 'slack:fast-agent-lock:';
 export const SLACK_SETUP_SUGGESTION_LOCK_PREFIX =
   'slack:setup-suggestion-reaction:';
 export const LEADING_FAST_COMMAND_MENTION_PATTERN = /^\s*<@[^>]+>[\s,:;.-]*/;
-const SETUP_ONBOARDING_SUGGESTION_AGENT_TYPE = 'setup_onboarding';
-const SUGGESTED_TASKS_AGENT_TYPE = 'suggested_tasks';
-export const TASK_SUGGESTION_AGENT_TYPES = [
-  SETUP_ONBOARDING_SUGGESTION_AGENT_TYPE,
-  SUGGESTED_TASKS_AGENT_TYPE,
+const SETUP_ONBOARDING_SUGGESTION_TYPE = 'setup_onboarding';
+const SUGGESTED_TASKS_SUGGESTION_TYPE = 'suggested_tasks';
+export const TASK_SUGGESTION_TYPES = [
+  SETUP_ONBOARDING_SUGGESTION_TYPE,
+  SUGGESTED_TASKS_SUGGESTION_TYPE,
 ] as const;
 export const SETUP_ONBOARDING_SUGGESTION_METADATA_EVENT_TYPE =
   'roomote.setup_onboarding_suggestion';

--- a/apps/api/src/handlers/slack/events/reactions.ts
+++ b/apps/api/src/handlers/slack/events/reactions.ts
@@ -36,7 +36,7 @@ import { apiLogger } from '../../../logging.js';
 import { cancelOrphanedWorkItemRunBestEffort } from '../../tasks/orphaned-work-item-run.js';
 import {
   SLACK_SETUP_SUGGESTION_LOCK_PREFIX,
-  TASK_SUGGESTION_AGENT_TYPES,
+  TASK_SUGGESTION_TYPES,
 } from '../constants.js';
 import type { SlackWebhookContext } from '../context.js';
 import {
@@ -82,19 +82,19 @@ const TASK_SUGGESTION_REACTION_MAX_ATTEMPTS = Math.ceil(
 
 /**
  * Reaction-launchable suggestion types tracked on the suggestion_card's
- * `metadata.suggestionType`. Mirrors the old agentType filter — only
- * setup-onboarding and suggested-tasks cards launch from a reaction.
+ * `metadata.suggestionType`. Only setup-onboarding and suggested-tasks
+ * cards launch from a reaction.
  */
 function getLaunchableSuggestionType(
   metadata: Record<string, unknown> | null | undefined,
-): (typeof TASK_SUGGESTION_AGENT_TYPES)[number] | null {
+): (typeof TASK_SUGGESTION_TYPES)[number] | null {
   const suggestionType = metadata?.suggestionType;
 
   if (
     typeof suggestionType === 'string' &&
-    (TASK_SUGGESTION_AGENT_TYPES as readonly string[]).includes(suggestionType)
+    (TASK_SUGGESTION_TYPES as readonly string[]).includes(suggestionType)
   ) {
-    return suggestionType as (typeof TASK_SUGGESTION_AGENT_TYPES)[number];
+    return suggestionType as (typeof TASK_SUGGESTION_TYPES)[number];
   }
 
   return null;
@@ -425,7 +425,7 @@ async function launchTaskSuggestionTaskFromReaction({
     investigationContext: workItem.investigationContext,
     readinessMessage:
       suggestionWorkspace.readinessMessage ?? workItem.readinessMessage,
-    agentType: suggestionType,
+    suggestionType,
     category: workItem.category,
     priority: workItem.priority,
     targetRepositoryFullName: suggestionSlackTargetRepositoryFullName,

--- a/apps/api/src/handlers/slack/helpers/suggestion-slack-text.ts
+++ b/apps/api/src/handlers/slack/helpers/suggestion-slack-text.ts
@@ -20,21 +20,21 @@ type SuggestionSeededTextOptions = {
   statusLabel?: 'started' | 'accepted';
 };
 
-const SHARED_SCHEDULED_SUGGESTION_AGENT_TYPES = new Set(['suggested_tasks']);
+const SHARED_SCHEDULED_SUGGESTION_TYPES = new Set(['suggested_tasks']);
 
 export function usesSharedScheduledSuggestionSlackModel(
-  agentType?: string | null,
+  suggestionType?: string | null,
 ): boolean {
   return (
-    typeof agentType === 'string' &&
-    SHARED_SCHEDULED_SUGGESTION_AGENT_TYPES.has(agentType)
+    typeof suggestionType === 'string' &&
+    SHARED_SCHEDULED_SUGGESTION_TYPES.has(suggestionType)
   );
 }
 
 export function getSharedScheduledSuggestionSlackTextOptions(
-  agentType?: string | null,
+  suggestionType?: string | null,
 ): SuggestionSlackTextOptions | undefined {
-  if (!usesSharedScheduledSuggestionSlackModel(agentType)) {
+  if (!usesSharedScheduledSuggestionSlackModel(suggestionType)) {
     return undefined;
   }
 
@@ -45,9 +45,9 @@ export function getSharedScheduledSuggestionSlackTextOptions(
 }
 
 export function getSharedScheduledSuggestionSeededTextOptions(
-  agentType?: string | null,
+  suggestionType?: string | null,
 ): SuggestionSeededTextOptions | undefined {
-  if (!usesSharedScheduledSuggestionSlackModel(agentType)) {
+  if (!usesSharedScheduledSuggestionSlackModel(suggestionType)) {
     return undefined;
   }
 

--- a/apps/api/src/handlers/slack/helpers/suggestion-workspace.test.ts
+++ b/apps/api/src/handlers/slack/helpers/suggestion-workspace.test.ts
@@ -12,7 +12,7 @@ import {
 describe('buildSuggestionTaskPromptText', () => {
   it('keeps ordinary suggestion prompts generic', () => {
     const prompt = buildSuggestionTaskPromptText({
-      agentType: 'suggested_tasks',
+      suggestionType: 'suggested_tasks',
       title: 'Fix cron retries',
       brief: 'Fix cron retries',
       category: 'bug',
@@ -29,7 +29,7 @@ describe('buildSuggestionTaskPromptText', () => {
 
   it('keeps sentry triage suggestions on the sentry-triage workflow with safety guardrails', () => {
     const prompt = buildSuggestionTaskPromptText({
-      agentType: 'sentry_triage',
+      suggestionType: 'sentry_triage',
       title: 'Merge duplicate API errors',
       brief: 'Merge the duplicate API-42 and API-77 issue groups.',
       readinessMessage: 'Sentry MCP is available.',
@@ -49,7 +49,7 @@ describe('buildSuggestionTaskPromptText', () => {
 
   it('keeps dependabot triage suggestions on the update-dependencies workflow with alert re-verification guidance', () => {
     const prompt = buildSuggestionTaskPromptText({
-      agentType: 'dependabot_triage',
+      suggestionType: 'dependabot_triage',
       title: 'Update braces in apps/api',
       brief: 'Patch the vulnerable braces version in the API workspace.',
       investigationContext: 'Alert: GHSA-123. Manifest: apps/api/package.json.',
@@ -65,7 +65,7 @@ describe('buildSuggestionTaskPromptText', () => {
 
   it('includes workspace readiness when the suggestion falls back to bare repo mode', () => {
     const prompt = buildSuggestionTaskPromptText({
-      agentType: 'suggested_tasks',
+      suggestionType: 'suggested_tasks',
       title: 'Investigate worker queue lag',
       brief: 'Check why the preview worker falls behind.',
       readinessMessage: 'Worker validation is limited without setup.',

--- a/apps/api/src/handlers/tasks/__tests__/submitTaskSuggestions.test.ts
+++ b/apps/api/src/handlers/tasks/__tests__/submitTaskSuggestions.test.ts
@@ -139,7 +139,7 @@ vi.mock('@roomote/sdk/server', () => ({
 
 vi.mock('../background-automation-slack', () => ({
   resolveScheduledSuggestionSlackConfig: vi.fn(() => ({
-    agentType: 'suggested_tasks',
+    suggestionType: 'suggested_tasks',
     automationKey: 'suggest_ideas',
     automationSettingsHash: undefined,
     actionFooterText: 'footer',

--- a/apps/api/src/handlers/tasks/background-automation-slack.ts
+++ b/apps/api/src/handlers/tasks/background-automation-slack.ts
@@ -17,7 +17,7 @@ type ScheduledSuggestionSummaryPromptConfig = {
 };
 
 type ScheduledSuggestionSurfaceConfig = {
-  agentType:
+  suggestionType:
     | 'suggested_tasks'
     | 'sentry_triage'
     | 'dependabot_triage'
@@ -36,7 +36,7 @@ type ScheduledSuggestionSurfaceConfig = {
 };
 
 export type ScheduledSuggestionSlackConfig = {
-  agentType: ScheduledSuggestionSurfaceConfig['agentType'];
+  suggestionType: ScheduledSuggestionSurfaceConfig['suggestionType'];
   automationSettingsHash: string;
   actionFooterText: string;
   summaryKind: ScheduledSuggestionSurfaceConfig['summaryKind'];
@@ -60,7 +60,7 @@ const SCHEDULED_SUGGESTION_SURFACE_CONFIG: Record<
   ScheduledSuggestionSurfaceConfig
 > = {
   suggester: {
-    agentType: 'suggested_tasks',
+    suggestionType: 'suggested_tasks',
     summaryKind: 'suggested_tasks',
     actionFooterText:
       "I pulled the most useful follow-up ideas into the thread for review.\nReact with a :thumbsup: on any idea and I'll start it.",
@@ -80,7 +80,7 @@ const SCHEDULED_SUGGESTION_SURFACE_CONFIG: Record<
     },
   },
   sentry_triage: {
-    agentType: 'sentry_triage',
+    suggestionType: 'sentry_triage',
     summaryKind: 'sentry_triage',
     actionFooterText:
       'I pulled the most useful Sentry follow-ups into the thread for review.',
@@ -100,7 +100,7 @@ const SCHEDULED_SUGGESTION_SURFACE_CONFIG: Record<
     },
   },
   dependabot_triage: {
-    agentType: 'dependabot_triage',
+    suggestionType: 'dependabot_triage',
     summaryKind: 'dependabot_triage',
     actionFooterText:
       'I pulled the strongest update candidates into the thread for review.',
@@ -120,7 +120,7 @@ const SCHEDULED_SUGGESTION_SURFACE_CONFIG: Record<
     },
   },
   security_auditor: {
-    agentType: 'security_auditor',
+    suggestionType: 'security_auditor',
     summaryKind: 'security_auditor',
     actionFooterText:
       'I pulled the highest-value security follow-ups into the thread for review.',
@@ -140,7 +140,7 @@ const SCHEDULED_SUGGESTION_SURFACE_CONFIG: Record<
     },
   },
   code_quality_auditor: {
-    agentType: 'code_quality_auditor',
+    suggestionType: 'code_quality_auditor',
     summaryKind: 'code_quality_auditor',
     actionFooterText:
       'I pulled the highest-leverage code quality follow-ups into the thread for review.',
@@ -161,7 +161,7 @@ const SCHEDULED_SUGGESTION_SURFACE_CONFIG: Record<
     },
   },
   ci_failure_triage: {
-    agentType: 'ci_failure_triage',
+    suggestionType: 'ci_failure_triage',
     summaryKind: 'ci_failure_triage',
     actionFooterText:
       'Each fix runs as its own task and reports back here when it finishes.',
@@ -233,7 +233,7 @@ export function resolveScheduledSuggestionSlackConfig(
   }
 
   return {
-    agentType: surfaceConfig.agentType,
+    suggestionType: surfaceConfig.suggestionType,
     automationSettingsHash,
     actionFooterText: surfaceConfig.actionFooterText,
     summaryKind: surfaceConfig.summaryKind,

--- a/apps/api/src/handlers/tasks/setup-suggestion-lifecycle.ts
+++ b/apps/api/src/handlers/tasks/setup-suggestion-lifecycle.ts
@@ -10,8 +10,7 @@ import { apiLogger } from '../../logging';
  * claims; only the message shape differs per surface. The launch state
  * machine lives on the backing `work_items` row referenced by `workItemId`.
  */
-export const SETUP_ONBOARDING_SUGGESTION_AGENT_TYPE =
-  'setup_onboarding' as const;
+export const SETUP_ONBOARDING_SUGGESTION_TYPE = 'setup_onboarding' as const;
 
 export const MAX_SETUP_SUGGESTIONS = 5;
 
@@ -36,7 +35,7 @@ export async function hasTrackedSetupSuggestionMessages(
     .where(
       and(
         eq(trackedMessages.kind, 'suggestion_card'),
-        sql`${trackedMessages.metadata} ->> 'suggestionType' = ${SETUP_ONBOARDING_SUGGESTION_AGENT_TYPE}`,
+        sql`${trackedMessages.metadata} ->> 'suggestionType' = ${SETUP_ONBOARDING_SUGGESTION_TYPE}`,
         sql`${trackedMessages.metadata} ->> 'suggestionKey' LIKE ${`${sourceTaskId}:%`}`,
       ),
     )
@@ -73,7 +72,7 @@ export async function insertSetupSuggestionMessageRows(
         workItemId: row.workItemId,
         createdByUserId: row.createdByUserId,
         metadata: {
-          suggestionType: SETUP_ONBOARDING_SUGGESTION_AGENT_TYPE,
+          suggestionType: SETUP_ONBOARDING_SUGGESTION_TYPE,
           suggestionKey: row.suggestionKey,
         },
       })),

--- a/apps/api/src/handlers/tasks/submitTaskSuggestions.ts
+++ b/apps/api/src/handlers/tasks/submitTaskSuggestions.ts
@@ -60,7 +60,7 @@ import { buildScheduledSuggestionRootMessage } from './scheduled-suggestion-root
 import {
   hasTrackedSetupSuggestionMessages,
   scheduleSuggestedTasksFollowupBestEffort,
-  SETUP_ONBOARDING_SUGGESTION_AGENT_TYPE,
+  SETUP_ONBOARDING_SUGGESTION_TYPE,
 } from './setup-suggestion-lifecycle';
 import { postScheduledSuggestionsToTelegram } from '../telegram/automation-suggestions';
 import { postScheduledSuggestionsToTeams } from '../teams/automation-suggestions';
@@ -141,8 +141,8 @@ type PreparedTaskSuggestion = {
   readinessMessage: string | null;
 };
 
-type SuggestionAgentType =
-  | typeof SETUP_ONBOARDING_SUGGESTION_AGENT_TYPE
+type TaskSuggestionType =
+  | typeof SETUP_ONBOARDING_SUGGESTION_TYPE
   | 'suggested_tasks'
   | 'sentry_triage'
   | 'dependabot_triage'
@@ -151,7 +151,7 @@ type SuggestionAgentType =
   | 'ci_failure_triage';
 
 type SuggestionCardMessageRow = {
-  suggestionType: SuggestionAgentType;
+  suggestionType: TaskSuggestionType;
   messageTs: string;
   channelId: string;
   workItemId: string;
@@ -568,7 +568,7 @@ async function postTaskSuggestionsThreadToSlack(params: {
   slackBotAccessToken: string;
   slackChannelId: string;
   createdByUserId: string | null;
-  agentType: SuggestionAgentType;
+  suggestionType: TaskSuggestionType;
   rootText: string;
   automationLabel?: string | null;
   automationSettingsHash?: string;
@@ -648,7 +648,7 @@ async function postTaskSuggestionsThreadToSlack(params: {
 
   const suggestionMessageRows: SuggestionCardMessageRow[] = [];
   const useSharedSuggestionFormatting = usesSharedScheduledSuggestionSlackModel(
-    params.agentType,
+    params.suggestionType,
   );
 
   for (const suggestion of params.suggestions) {
@@ -679,7 +679,7 @@ async function postTaskSuggestionsThreadToSlack(params: {
 
     if (useSharedSuggestionFormatting) {
       const sharedOptions = getSharedScheduledSuggestionSlackTextOptions(
-        params.agentType,
+        params.suggestionType,
       );
       // The fallback `text` keeps the footer inline; the rich `blocks` split it
       // into a small muted Slack `context` block so the bottom line renders as
@@ -732,7 +732,7 @@ async function postTaskSuggestionsThreadToSlack(params: {
     }
 
     suggestionMessageRows.push({
-      suggestionType: params.agentType,
+      suggestionType: params.suggestionType,
       messageTs,
       channelId: params.slackChannelId,
       workItemId: suggestion.id,
@@ -810,7 +810,7 @@ async function postSetupTaskSuggestionsToSlack(params: {
     slackBotAccessToken: slackInstallation.botAccessToken,
     slackChannelId: slackChannel,
     createdByUserId,
-    agentType: SETUP_ONBOARDING_SUGGESTION_AGENT_TYPE,
+    suggestionType: SETUP_ONBOARDING_SUGGESTION_TYPE,
     rootText: introText,
     suggestions,
     insertSuggestionMessages: async (suggestionMessageRows) => {
@@ -939,7 +939,7 @@ async function postSuggestedTasksSummaryToSlack(params: {
       .where(
         and(
           eq(trackedMessages.kind, 'suggestion_card'),
-          sql`${trackedMessages.metadata} ->> 'suggestionType' = ${slackConfig.agentType}`,
+          sql`${trackedMessages.metadata} ->> 'suggestionType' = ${slackConfig.suggestionType}`,
           sql`${trackedMessages.metadata} ->> 'suggestionKey' LIKE ${`${params.sourceTaskId}:%`}`,
         ),
       )
@@ -962,7 +962,7 @@ async function postSuggestedTasksSummaryToSlack(params: {
       slackBotAccessToken: slackInstallation.botAccessToken,
       slackChannelId: channel.channelId,
       createdByUserId,
-      agentType: slackConfig.agentType,
+      suggestionType: slackConfig.suggestionType,
       rootText: buildAutomationRootSummaryText({
         summaryText: rootMessage.summaryText,
         actionFooterText: rootMessage.actionFooterText,

--- a/apps/api/src/handlers/teams/automation-suggestions.ts
+++ b/apps/api/src/handlers/teams/automation-suggestions.ts
@@ -75,7 +75,7 @@ export async function postScheduledSuggestionsToTeams(params: {
     .where(
       and(
         eq(trackedMessages.kind, 'suggestion_card'),
-        sql`${trackedMessages.metadata} ->> 'suggestionType' = ${slackConfig.agentType}`,
+        sql`${trackedMessages.metadata} ->> 'suggestionType' = ${slackConfig.suggestionType}`,
         sql`${trackedMessages.metadata} ->> 'suggestionKey' LIKE ${`${sourceTaskId}:%`}`,
       ),
     )
@@ -157,7 +157,7 @@ export async function postScheduledSuggestionsToTeams(params: {
           workItemId: suggestion.id,
           createdByUserId,
           metadata: {
-            suggestionType: slackConfig.agentType,
+            suggestionType: slackConfig.suggestionType,
             suggestionKey: `${sourceTaskId}:${suggestion.id}`,
           },
         };

--- a/apps/api/src/handlers/telegram/automation-suggestions.ts
+++ b/apps/api/src/handlers/telegram/automation-suggestions.ts
@@ -78,7 +78,7 @@ export async function postScheduledSuggestionsToTelegram(params: {
     .where(
       and(
         eq(trackedMessages.kind, 'suggestion_card'),
-        sql`${trackedMessages.metadata} ->> 'suggestionType' = ${slackConfig.agentType}`,
+        sql`${trackedMessages.metadata} ->> 'suggestionType' = ${slackConfig.suggestionType}`,
         sql`${trackedMessages.metadata} ->> 'suggestionKey' LIKE ${`${sourceTaskId}:%`}`,
       ),
     )
@@ -149,7 +149,7 @@ export async function postScheduledSuggestionsToTelegram(params: {
           workItemId: suggestion.id,
           createdByUserId,
           metadata: {
-            suggestionType: slackConfig.agentType,
+            suggestionType: slackConfig.suggestionType,
             suggestionKey: `${sourceTaskId}:${suggestion.id}`,
           },
         };

--- a/apps/web/src/app/(authenticated)/home/Home.client.test.tsx
+++ b/apps/web/src/app/(authenticated)/home/Home.client.test.tsx
@@ -462,7 +462,7 @@ describe('Home', () => {
     expect(mockPush).not.toHaveBeenCalledWith('/tasks');
   });
 
-  it('launches Standard Task without a cloud agent id for routed workspaces', async () => {
+  it('launches a standard task run without an agent identity for routed workspaces', async () => {
     mockRouteHomeTask.mockResolvedValue(routedEnvironmentSuggestion);
 
     render(<Home initialPlaceholderIndex={0} />);

--- a/apps/web/src/components/settings/automations/AutomationsSettings.client.test.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.client.test.tsx
@@ -6,7 +6,7 @@ import {
 
 import {
   buildAutomationSettingsSaveInput,
-  buildSaveStateForAgent,
+  buildSaveStateForAutomation,
   mergeServerStatePreservingDirtySections,
   type FormState,
 } from './formState';
@@ -183,7 +183,7 @@ describe('Automations selection helpers', () => {
       suggesterInstructions: '',
     };
 
-    const saveState = buildSaveStateForAgent(
+    const saveState = buildSaveStateForAutomation(
       currentFormState,
       currentSavedState,
       'suggester',
@@ -208,7 +208,7 @@ describe('Automations selection helpers', () => {
       announcerFrequency: 'off',
     };
 
-    const saveState = buildSaveStateForAgent(
+    const saveState = buildSaveStateForAutomation(
       currentFormState,
       currentSavedState,
       'suggester',
@@ -241,7 +241,7 @@ describe('Automations selection helpers', () => {
       managerSlackChannel: '#managers',
     };
 
-    const saveState = buildSaveStateForAgent(
+    const saveState = buildSaveStateForAutomation(
       currentFormState,
       currentSavedState,
       'channelAutoStart',
@@ -320,7 +320,7 @@ describe('Automations selection helpers', () => {
 
     expect(saveInput).toEqual(
       expect.objectContaining({
-        savingAgent: 'announcer',
+        savingAutomation: 'announcer',
         announcerFrequency: 'daily',
         announcerSlackChannel: '#announcements',
         announcerInstructions: 'Keep the summary short.',
@@ -436,7 +436,7 @@ describe('Automations selection helpers', () => {
       ],
     };
 
-    const saveState = buildSaveStateForAgent(
+    const saveState = buildSaveStateForAutomation(
       currentFormState,
       currentSavedState,
       'channelAutoStart',
@@ -471,7 +471,7 @@ describe('Automations selection helpers', () => {
         announcerFrequency: 'off',
       };
 
-      const saveState = buildSaveStateForAgent(
+      const saveState = buildSaveStateForAutomation(
         currentFormState,
         currentSavedState,
         automation.id,

--- a/apps/web/src/components/settings/automations/AutomationsSettings.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.tsx
@@ -35,18 +35,18 @@ import { cn } from '@/lib/utils';
 import { useTRPC } from '@/trpc/client';
 
 import {
-  type AgentType,
+  type AutomationId,
   type AnnouncerFrequency,
   buildAutomationSettingsSaveInput,
   type ChannelAutoStartFormRow,
   type ConflictResolverFrequency,
   type DependabotTriageFrequency,
   type FormState,
-  isAgentDirty,
+  isAutomationDirty,
   type ManagerStatsFrequency,
-  mergeAgentFields,
+  mergeAutomationFields,
   mergeServerStatePreservingDirtySections,
-  resetAgentFields,
+  resetAutomationFields,
   type ReviewerEnvironmentScope,
   type SentryTriageFrequency,
   type SuggesterFrequency,
@@ -175,7 +175,7 @@ type SlackChannelOption = {
 };
 
 type AutomationDefinition = {
-  id: AgentType;
+  id: AutomationId;
   label: string;
   description: string;
   icon: ComponentType<{ className?: string }>;
@@ -261,7 +261,7 @@ const TRIGGERABLE_AUTOMATION_SCHEDULE_LABELS = {
 } as const;
 
 function getAutomationDefinition(
-  agentId: AgentType,
+  automationId: AutomationId,
   automationKey: keyof typeof TRIGGERABLE_AUTOMATION_DESCRIPTIONS,
   icon: ComponentType<{ className?: string }>,
 ): AutomationDefinition {
@@ -273,7 +273,7 @@ function getAutomationDefinition(
   }
 
   return {
-    id: agentId,
+    id: automationId,
     label: descriptor.label,
     description: TRIGGERABLE_AUTOMATION_DESCRIPTIONS[automationKey],
     icon,
@@ -355,7 +355,7 @@ const SCHEDULE_ONLY_AUTOMATIONS_BY_ID = Object.fromEntries(
   (typeof SCHEDULE_ONLY_BACKGROUND_AUTOMATION_LIST)[number]
 >;
 
-const AUTOMATION_DEFINITIONS: Record<AgentType, AutomationDefinition> = {
+const AUTOMATION_DEFINITIONS: Record<AutomationId, AutomationDefinition> = {
   channelAutoStart: {
     id: 'channelAutoStart',
     label: 'Auto-respond to Slack channels',
@@ -415,7 +415,7 @@ const AUTOMATION_DEFINITIONS: Record<AgentType, AutomationDefinition> = {
   },
 };
 
-const HASH_ALIAS_TO_AGENT_ID: Record<string, AgentType> = {
+const HASH_ALIAS_TO_AUTOMATION_ID: Record<string, AutomationId> = {
   'auto-respond-channels': 'channelAutoStart',
   autorespondchannels: 'channelAutoStart',
   'auto-start-tasks': 'channelAutoStart',
@@ -450,8 +450,8 @@ const HASH_ALIAS_TO_AGENT_ID: Record<string, AgentType> = {
   'platform-issue-alerts': 'platformIssueAlerts',
 };
 
-const AUTOMATION_RUN_KEYS_BY_AGENT: Partial<
-  Record<AgentType, BackgroundAutomationKey>
+const AUTOMATION_RUN_KEYS_BY_ID: Partial<
+  Record<AutomationId, BackgroundAutomationKey>
 > = {
   conflictResolver: 'conflict_resolver',
   suggester: 'suggester',
@@ -503,7 +503,7 @@ function buildScheduleOnlyAutomationDirtyState(params: {
     SCHEDULE_ONLY_BACKGROUND_AUTOMATION_LIST.map((automation) => [
       automation.id,
       params.formState && params.savedState
-        ? isAgentDirty(params.formState, params.savedState, automation.id)
+        ? isAutomationDirty(params.formState, params.savedState, automation.id)
         : false,
     ]),
   ) as Record<ScheduleOnlyBackgroundAutomationId, boolean>;
@@ -678,14 +678,14 @@ function mapSettingsToFormState(
   };
 }
 
-export function resolveAutomationHashTarget(hash: string): AgentType | null {
+export function resolveAutomationHashTarget(hash: string): AutomationId | null {
   const normalized = hash.trim().replace(/^#/, '').toLowerCase();
 
   if (!normalized) {
     return null;
   }
 
-  return HASH_ALIAS_TO_AGENT_ID[normalized] ?? null;
+  return HASH_ALIAS_TO_AUTOMATION_ID[normalized] ?? null;
 }
 
 export function buildSlackWorkflowLaunchUrl(
@@ -1441,8 +1441,10 @@ export function AutomationsSettings() {
   const [managerSlackChannelId, setManagerSlackChannelId] = useState<
     string | null
   >(null);
-  const [savingAgent, setSavingAgent] = useState<AgentType | null>(null);
-  const [openAgentIds, setOpenAgentIds] = useState<Set<AgentType>>(
+  const [savingAutomation, setSavingAutomation] = useState<AutomationId | null>(
+    null,
+  );
+  const [openAutomationIds, setOpenAutomationIds] = useState<Set<AutomationId>>(
     () => new Set(),
   );
   const [isEditingManagerChannel, setIsEditingManagerChannel] = useState(false);
@@ -1543,10 +1545,10 @@ export function AutomationsSettings() {
   const updateMutation = useMutation(
     trpc.automations.updateSettings.mutationOptions({
       onSuccess: (result) => {
-        const automationLabel = savingAgent
-          ? AUTOMATION_DEFINITIONS[savingAgent].label
+        const automationLabel = savingAutomation
+          ? AUTOMATION_DEFINITIONS[savingAutomation].label
           : null;
-        setSavingAgent(null);
+        setSavingAutomation(null);
 
         if (!result.success) {
           setFieldErrors(result.fieldErrors);
@@ -1559,7 +1561,7 @@ export function AutomationsSettings() {
           }
 
           if (result.fieldErrors.managerSlackChannel) {
-            setOpenAgentIds((prev) => {
+            setOpenAutomationIds((prev) => {
               if (prev.has('managerChannel')) {
                 return prev;
               }
@@ -1574,7 +1576,7 @@ export function AutomationsSettings() {
             result.fieldErrors.channelAutoStartSlackChannels ||
             result.fieldErrors.channelAutoStartInstructions
           ) {
-            setOpenAgentIds((prev) => {
+            setOpenAutomationIds((prev) => {
               if (prev.has('channelAutoStart')) {
                 return prev;
               }
@@ -1588,7 +1590,7 @@ export function AutomationsSettings() {
         }
 
         setFieldErrors({});
-        if (savingAgent === 'suggester') {
+        if (savingAutomation === 'suggester') {
           const nextRoutingPreview = result.suggesterRoutingPreview ?? null;
           setSuggesterRoutingPreview(nextRoutingPreview);
           setIsEditingSuggesterRouting(
@@ -1627,13 +1629,13 @@ export function AutomationsSettings() {
           reviewer: result.reviewer,
         });
         setFormState((prev) =>
-          savingAgent && prev
-            ? mergeAgentFields(prev, mapped, savingAgent)
+          savingAutomation && prev
+            ? mergeAutomationFields(prev, mapped, savingAutomation)
             : mapped,
         );
         setSavedState((prev) =>
-          savingAgent && prev
-            ? mergeAgentFields(prev, mapped, savingAgent)
+          savingAutomation && prev
+            ? mergeAutomationFields(prev, mapped, savingAutomation)
             : mapped,
         );
 
@@ -1641,7 +1643,7 @@ export function AutomationsSettings() {
           queryKey: trpc.automations.getSettings.queryKey(),
         });
 
-        if (savingAgent === 'managerChannel') {
+        if (savingAutomation === 'managerChannel') {
           setIsEditingManagerChannel(false);
           setIsEnteringCustomManagerChannel(false);
         }
@@ -1653,10 +1655,10 @@ export function AutomationsSettings() {
         );
       },
       onError: (error) => {
-        const automationLabel = savingAgent
-          ? AUTOMATION_DEFINITIONS[savingAgent].label
+        const automationLabel = savingAutomation
+          ? AUTOMATION_DEFINITIONS[savingAutomation].label
           : null;
-        setSavingAgent(null);
+        setSavingAutomation(null);
         toast.error(
           automationLabel
             ? `Failed to save ${automationLabel} settings: ${error.message}`
@@ -1731,17 +1733,33 @@ export function AutomationsSettings() {
     }
 
     return {
-      channelAutoStart: isAgentDirty(formState, savedState, 'channelAutoStart'),
-      managerChannel: isAgentDirty(formState, savedState, 'managerChannel'),
-      managerStats: isAgentDirty(formState, savedState, 'managerStats'),
-      sentryTriage: isAgentDirty(formState, savedState, 'sentryTriage'),
-      dependabotTriage: isAgentDirty(formState, savedState, 'dependabotTriage'),
+      channelAutoStart: isAutomationDirty(
+        formState,
+        savedState,
+        'channelAutoStart',
+      ),
+      managerChannel: isAutomationDirty(
+        formState,
+        savedState,
+        'managerChannel',
+      ),
+      managerStats: isAutomationDirty(formState, savedState, 'managerStats'),
+      sentryTriage: isAutomationDirty(formState, savedState, 'sentryTriage'),
+      dependabotTriage: isAutomationDirty(
+        formState,
+        savedState,
+        'dependabotTriage',
+      ),
       ...scheduleOnlyAutomationDirtyState,
-      reviewer: isAgentDirty(formState, savedState, 'reviewer'),
-      conflictResolver: isAgentDirty(formState, savedState, 'conflictResolver'),
-      suggester: isAgentDirty(formState, savedState, 'suggester'),
-      announcer: isAgentDirty(formState, savedState, 'announcer'),
-      platformIssueAlerts: isAgentDirty(
+      reviewer: isAutomationDirty(formState, savedState, 'reviewer'),
+      conflictResolver: isAutomationDirty(
+        formState,
+        savedState,
+        'conflictResolver',
+      ),
+      suggester: isAutomationDirty(formState, savedState, 'suggester'),
+      announcer: isAutomationDirty(formState, savedState, 'announcer'),
+      platformIssueAlerts: isAutomationDirty(
         formState,
         savedState,
         'platformIssueAlerts',
@@ -1754,12 +1772,12 @@ export function AutomationsSettings() {
   const automationStatusByKey = settingsQuery.data?.automationStatus;
 
   const renderDebugRunsSection = useCallback(
-    (agent: AgentType) => {
+    (automationId: AutomationId) => {
       if (!showAutomationDebugRuns) {
         return null;
       }
 
-      const automationKey = AUTOMATION_RUN_KEYS_BY_AGENT[agent];
+      const automationKey = AUTOMATION_RUN_KEYS_BY_ID[automationId];
 
       if (!automationKey) {
         return null;
@@ -1776,47 +1794,50 @@ export function AutomationsSettings() {
   );
 
   const saveAgent = useCallback(
-    (agent: AgentType) => {
+    (automationId: AutomationId) => {
       if (!formState || !savedState) {
         return;
       }
 
       setFieldErrors({});
-      setSavingAgent(agent);
+      setSavingAutomation(automationId);
 
       updateMutation.mutate(
-        buildAutomationSettingsSaveInput(formState, savedState, agent),
+        buildAutomationSettingsSaveInput(formState, savedState, automationId),
       );
     },
     [formState, savedState, updateMutation],
   );
 
   const resetAgent = useCallback(
-    (agent: AgentType) => {
+    (automationId: AutomationId) => {
       if (!formState || !savedState) {
         return;
       }
 
-      if (agent === 'managerChannel') {
+      if (automationId === 'managerChannel') {
         setIsEnteringCustomManagerChannel(false);
       }
 
-      setFormState(resetAgentFields(formState, savedState, agent));
+      setFormState(resetAutomationFields(formState, savedState, automationId));
     },
     [formState, savedState],
   );
 
-  const setAgentOpen = useCallback((agent: AgentType, open: boolean) => {
-    setOpenAgentIds((prev) => {
-      const next = new Set(prev);
-      if (open) {
-        next.add(agent);
-      } else {
-        next.delete(agent);
-      }
-      return next;
-    });
-  }, []);
+  const setAutomationOpen = useCallback(
+    (automationId: AutomationId, open: boolean) => {
+      setOpenAutomationIds((prev) => {
+        const next = new Set(prev);
+        if (open) {
+          next.add(automationId);
+        } else {
+          next.delete(automationId);
+        }
+        return next;
+      });
+    },
+    [],
+  );
 
   const setScheduleOnlyAutomationFrequency = useCallback(
     (
@@ -1848,7 +1869,7 @@ export function AutomationsSettings() {
       return;
     }
 
-    setOpenAgentIds((prev) => {
+    setOpenAutomationIds((prev) => {
       if (prev.has(target)) {
         return prev;
       }
@@ -2101,33 +2122,33 @@ export function AutomationsSettings() {
     suggester: suggesterIsEnabled,
     announcer: announcerIsEnabled,
     platformIssueAlerts: isPlatformIssueAlertsEnabled(formState),
-  } satisfies Record<AgentType, boolean>;
+  } satisfies Record<AutomationId, boolean>;
 
-  const isAgentSaving = (agent: AgentType) =>
-    updateMutation.isPending && savingAgent === agent;
+  const isAutomationSaving = (automationId: AutomationId) =>
+    updateMutation.isPending && savingAutomation === automationId;
 
   const isRunDisabled = (
-    agent: AgentType,
+    automationId: AutomationId,
     isEnabled: boolean,
     isBlocked = false,
   ) =>
     isAutomationRunDisabled({
       isEnabled,
-      isDirty: isDirty[agent],
-      isSaving: isAgentSaving(agent),
+      isDirty: isDirty[automationId],
+      isSaving: isAutomationSaving(automationId),
       isTriggering: triggerMutation.isPending,
       isBlocked,
     });
 
   const getRunTooltip = (
-    agent: AgentType,
+    automationId: AutomationId,
     isEnabled: boolean,
     blockedReason?: string | null,
   ) =>
     getAutomationRunTooltip({
       isEnabled,
-      isDirty: isDirty[agent],
-      isSaving: isAgentSaving(agent),
+      isDirty: isDirty[automationId],
+      isSaving: isAutomationSaving(automationId),
       blockedReason,
     });
   const slackAutomationsDisabled = !managerChannelConfigured;
@@ -2237,15 +2258,17 @@ export function AutomationsSettings() {
 
             <AutomationCard
               automation={AUTOMATION_DEFINITIONS.channelAutoStart}
-              isOpen={openAgentIds.has('channelAutoStart')}
-              onOpenChange={(open) => setAgentOpen('channelAutoStart', open)}
+              isOpen={openAutomationIds.has('channelAutoStart')}
+              onOpenChange={(open) =>
+                setAutomationOpen('channelAutoStart', open)
+              }
               iconEnabled={iconEnabled.channelAutoStart}
               footer={
                 <AutomationFooter
                   isDirty={isDirty.channelAutoStart}
                   isPending={
                     updateMutation.isPending &&
-                    savingAgent === 'channelAutoStart'
+                    savingAutomation === 'channelAutoStart'
                   }
                   onSave={() => saveAgent('channelAutoStart')}
                   onReset={() => resetAgent('channelAutoStart')}
@@ -2469,7 +2492,7 @@ export function AutomationsSettings() {
                       isDirty={isDirty.managerChannel}
                       isPending={
                         updateMutation.isPending &&
-                        savingAgent === 'managerChannel'
+                        savingAutomation === 'managerChannel'
                       }
                       onSave={() => saveAgent('managerChannel')}
                       onReset={() => {
@@ -2511,8 +2534,8 @@ export function AutomationsSettings() {
 
           <AutomationCard
             automation={AUTOMATION_DEFINITIONS.managerStats}
-            isOpen={openAgentIds.has('managerStats')}
-            onOpenChange={(open) => setAgentOpen('managerStats', open)}
+            isOpen={openAutomationIds.has('managerStats')}
+            onOpenChange={(open) => setAutomationOpen('managerStats', open)}
             iconEnabled={iconEnabled.managerStats}
             debugSection={renderDebugRunsSection('managerStats')}
             runAction={
@@ -2538,7 +2561,8 @@ export function AutomationsSettings() {
               <AutomationFooter
                 isDirty={isDirty.managerStats}
                 isPending={
-                  updateMutation.isPending && savingAgent === 'managerStats'
+                  updateMutation.isPending &&
+                  savingAutomation === 'managerStats'
                 }
                 onSave={() => saveAgent('managerStats')}
                 onReset={() => resetAgent('managerStats')}
@@ -2592,8 +2616,8 @@ export function AutomationsSettings() {
           <>
             <AutomationCard
               automation={AUTOMATION_DEFINITIONS.sentryTriage}
-              isOpen={openAgentIds.has('sentryTriage')}
-              onOpenChange={(open) => setAgentOpen('sentryTriage', open)}
+              isOpen={openAutomationIds.has('sentryTriage')}
+              onOpenChange={(open) => setAutomationOpen('sentryTriage', open)}
               iconEnabled={iconEnabled.sentryTriage}
               debugSection={renderDebugRunsSection('sentryTriage')}
               runAction={
@@ -2624,7 +2648,8 @@ export function AutomationsSettings() {
                 <AutomationFooter
                   isDirty={isDirty.sentryTriage}
                   isPending={
-                    updateMutation.isPending && savingAgent === 'sentryTriage'
+                    updateMutation.isPending &&
+                    savingAutomation === 'sentryTriage'
                   }
                   saveDisabled={sentryTriageSaveDisabled}
                   onSave={() => saveAgent('sentryTriage')}
@@ -2764,8 +2789,10 @@ export function AutomationsSettings() {
 
             <ScheduledAutomationCard
               automation={AUTOMATION_DEFINITIONS.dependabotTriage}
-              isOpen={openAgentIds.has('dependabotTriage')}
-              onOpenChange={(open) => setAgentOpen('dependabotTriage', open)}
+              isOpen={openAutomationIds.has('dependabotTriage')}
+              onOpenChange={(open) =>
+                setAutomationOpen('dependabotTriage', open)
+              }
               iconEnabled={iconEnabled.dependabotTriage}
               debugSection={renderDebugRunsSection('dependabotTriage')}
               runTooltip={getRunTooltip(
@@ -2783,7 +2810,8 @@ export function AutomationsSettings() {
               }
               isDirty={isDirty.dependabotTriage}
               isPending={
-                updateMutation.isPending && savingAgent === 'dependabotTriage'
+                updateMutation.isPending &&
+                savingAutomation === 'dependabotTriage'
               }
               onSave={() => saveAgent('dependabotTriage')}
               onReset={() => resetAgent('dependabotTriage')}
@@ -2845,8 +2873,10 @@ export function AutomationsSettings() {
                 <AutomationCard
                   key={automation.id}
                   automation={AUTOMATION_DEFINITIONS[automation.id]}
-                  isOpen={openAgentIds.has(automation.id)}
-                  onOpenChange={(open) => setAgentOpen(automation.id, open)}
+                  isOpen={openAutomationIds.has(automation.id)}
+                  onOpenChange={(open) =>
+                    setAutomationOpen(automation.id, open)
+                  }
                   iconEnabled={iconEnabled[automation.id]}
                   debugSection={renderDebugRunsSection(automation.id)}
                   runAction={
@@ -2880,7 +2910,7 @@ export function AutomationsSettings() {
                       isDirty={isDirty[automation.id]}
                       isPending={
                         updateMutation.isPending &&
-                        savingAgent === automation.id
+                        savingAutomation === automation.id
                       }
                       onSave={() => saveAgent(automation.id)}
                       onReset={() => resetAgent(automation.id)}
@@ -2947,8 +2977,8 @@ export function AutomationsSettings() {
 
           <AutomationCard
             automation={AUTOMATION_DEFINITIONS.suggester}
-            isOpen={openAgentIds.has('suggester')}
-            onOpenChange={(open) => setAgentOpen('suggester', open)}
+            isOpen={openAutomationIds.has('suggester')}
+            onOpenChange={(open) => setAutomationOpen('suggester', open)}
             iconEnabled={iconEnabled.suggester}
             disabled={slackAutomationsDisabled}
             debugSection={renderDebugRunsSection('suggester')}
@@ -2972,7 +3002,7 @@ export function AutomationsSettings() {
               <AutomationFooter
                 isDirty={isDirty.suggester}
                 isPending={
-                  updateMutation.isPending && savingAgent === 'suggester'
+                  updateMutation.isPending && savingAutomation === 'suggester'
                 }
                 onSave={() => saveAgent('suggester')}
                 onReset={() => resetAgent('suggester')}
@@ -3224,8 +3254,8 @@ If unclear, send to manager channel.`}
 
           <AutomationCard
             automation={AUTOMATION_DEFINITIONS.announcer}
-            isOpen={openAgentIds.has('announcer')}
-            onOpenChange={(open) => setAgentOpen('announcer', open)}
+            isOpen={openAutomationIds.has('announcer')}
+            onOpenChange={(open) => setAutomationOpen('announcer', open)}
             iconEnabled={iconEnabled.announcer}
             disabled={slackAutomationsDisabled}
             debugSection={renderDebugRunsSection('announcer')}
@@ -3249,7 +3279,7 @@ If unclear, send to manager channel.`}
               <AutomationFooter
                 isDirty={isDirty.announcer}
                 isPending={
-                  updateMutation.isPending && savingAgent === 'announcer'
+                  updateMutation.isPending && savingAutomation === 'announcer'
                 }
                 onSave={() => saveAgent('announcer')}
                 onReset={() => resetAgent('announcer')}
@@ -3329,14 +3359,14 @@ If unclear, send to manager channel.`}
 
           <AutomationCard
             automation={AUTOMATION_DEFINITIONS.reviewer}
-            isOpen={openAgentIds.has('reviewer')}
-            onOpenChange={(open) => setAgentOpen('reviewer', open)}
+            isOpen={openAutomationIds.has('reviewer')}
+            onOpenChange={(open) => setAutomationOpen('reviewer', open)}
             iconEnabled={iconEnabled.reviewer}
             footer={
               <AutomationFooter
                 isDirty={isDirty.reviewer}
                 isPending={
-                  updateMutation.isPending && savingAgent === 'reviewer'
+                  updateMutation.isPending && savingAutomation === 'reviewer'
                 }
                 onSave={() => saveAgent('reviewer')}
                 onReset={() => resetAgent('reviewer')}
@@ -3472,8 +3502,8 @@ If unclear, send to manager channel.`}
 
           <AutomationCard
             automation={AUTOMATION_DEFINITIONS.conflictResolver}
-            isOpen={openAgentIds.has('conflictResolver')}
-            onOpenChange={(open) => setAgentOpen('conflictResolver', open)}
+            isOpen={openAutomationIds.has('conflictResolver')}
+            onOpenChange={(open) => setAutomationOpen('conflictResolver', open)}
             iconEnabled={iconEnabled.conflictResolver}
             debugSection={renderDebugRunsSection('conflictResolver')}
             runAction={
@@ -3504,7 +3534,8 @@ If unclear, send to manager channel.`}
               <AutomationFooter
                 isDirty={isDirty.conflictResolver}
                 isPending={
-                  updateMutation.isPending && savingAgent === 'conflictResolver'
+                  updateMutation.isPending &&
+                  savingAutomation === 'conflictResolver'
                 }
                 onSave={() => saveAgent('conflictResolver')}
                 onReset={() => resetAgent('conflictResolver')}

--- a/apps/web/src/components/settings/automations/formState.ts
+++ b/apps/web/src/components/settings/automations/formState.ts
@@ -82,7 +82,7 @@ export type FormState = {
   ciFailureTriageSlackChannel: string;
 } & ScheduleOnlyAutomationFormFields;
 
-export type AgentType =
+export type AutomationId =
   | 'channelAutoStart'
   | 'managerChannel'
   | 'managerStats'
@@ -156,7 +156,7 @@ const PLATFORM_ISSUE_ALERT_FIELDS: Array<keyof FormState> = [
   'platformIssueSlackChannel',
 ];
 
-const SCHEDULE_ONLY_AGENT_FIELDS = Object.fromEntries(
+const SCHEDULE_ONLY_AUTOMATION_FIELDS = Object.fromEntries(
   SCHEDULE_ONLY_BACKGROUND_AUTOMATION_LIST.map((automation) => [
     automation.id,
     [
@@ -170,13 +170,13 @@ const SCHEDULE_ONLY_AGENT_FIELDS = Object.fromEntries(
   ]),
 ) as Record<ScheduleOnlyBackgroundAutomationId, Array<keyof FormState>>;
 
-const AGENT_FIELDS: Record<AgentType, Array<keyof FormState>> = {
+const AUTOMATION_FIELDS: Record<AutomationId, Array<keyof FormState>> = {
   channelAutoStart: CHANNEL_AUTO_START_FIELDS,
   managerChannel: MANAGER_CHANNEL_FIELDS,
   managerStats: MANAGER_STATS_FIELDS,
   sentryTriage: SENTRY_TRIAGE_FIELDS,
   dependabotTriage: DEPENDABOT_TRIAGE_FIELDS,
-  ...SCHEDULE_ONLY_AGENT_FIELDS,
+  ...SCHEDULE_ONLY_AUTOMATION_FIELDS,
   reviewer: REVIEWER_FIELDS,
   conflictResolver: CONFLICT_RESOLVER_FIELDS,
   suggester: SUGGESTER_FIELDS,
@@ -184,48 +184,48 @@ const AGENT_FIELDS: Record<AgentType, Array<keyof FormState>> = {
   platformIssueAlerts: PLATFORM_ISSUE_ALERT_FIELDS,
 };
 
-export function isAgentDirty(
+export function isAutomationDirty(
   formState: FormState,
   savedState: FormState,
-  agent: AgentType,
+  automationId: AutomationId,
 ): boolean {
-  return AGENT_FIELDS[agent].some(
+  return AUTOMATION_FIELDS[automationId].some(
     (field) => formState[field] !== savedState[field],
   );
 }
 
-export function resetAgentFields(
+export function resetAutomationFields(
   formState: FormState,
   savedState: FormState,
-  agent: AgentType,
+  automationId: AutomationId,
 ): FormState {
   const updated = { ...formState };
-  for (const field of AGENT_FIELDS[agent]) {
+  for (const field of AUTOMATION_FIELDS[automationId]) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (updated as any)[field] = savedState[field];
   }
   return updated;
 }
 
-export function mergeAgentFields(
+export function mergeAutomationFields(
   currentState: FormState,
   nextState: FormState,
-  agent: AgentType,
+  automationId: AutomationId,
 ): FormState {
   const updated = { ...currentState };
-  for (const field of AGENT_FIELDS[agent]) {
+  for (const field of AUTOMATION_FIELDS[automationId]) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (updated as any)[field] = nextState[field];
   }
   return updated;
 }
 
-export function buildSaveStateForAgent(
+export function buildSaveStateForAutomation(
   formState: FormState,
   savedState: FormState,
-  agent: AgentType,
+  automationId: AutomationId,
 ): FormState {
-  return mergeAgentFields(savedState, formState, agent);
+  return mergeAutomationFields(savedState, formState, automationId);
 }
 
 function buildScheduleOnlyAutomationSaveInput(
@@ -242,12 +242,16 @@ function buildScheduleOnlyAutomationSaveInput(
 export function buildAutomationSettingsSaveInput(
   formState: FormState,
   savedState: FormState,
-  agent: AgentType,
+  automationId: AutomationId,
 ) {
-  const stateToSave = buildSaveStateForAgent(formState, savedState, agent);
+  const stateToSave = buildSaveStateForAutomation(
+    formState,
+    savedState,
+    automationId,
+  );
 
   return {
-    savingAgent: agent,
+    savingAutomation: automationId,
     reviewerEnabled: stateToSave.reviewerEnabled,
     reviewerEnvironmentScope: 'all' as const,
     reviewerEnvironmentIds: [],
@@ -318,13 +322,17 @@ export function mergeServerStatePreservingDirtySections(
   let nextFormState = { ...incomingState };
   let nextSavedState = { ...incomingState };
 
-  for (const agent of Object.keys(AGENT_FIELDS) as AgentType[]) {
-    if (isAgentDirty(currentFormState, currentSavedState, agent)) {
-      nextFormState = mergeAgentFields(nextFormState, currentFormState, agent);
-      nextSavedState = mergeAgentFields(
+  for (const automationId of Object.keys(AUTOMATION_FIELDS) as AutomationId[]) {
+    if (isAutomationDirty(currentFormState, currentSavedState, automationId)) {
+      nextFormState = mergeAutomationFields(
+        nextFormState,
+        currentFormState,
+        automationId,
+      );
+      nextSavedState = mergeAutomationFields(
         nextSavedState,
         currentSavedState,
-        agent,
+        automationId,
       );
     }
   }

--- a/apps/web/src/trpc/commands/automations/settings-update.ts
+++ b/apps/web/src/trpc/commands/automations/settings-update.ts
@@ -169,18 +169,22 @@ export async function updateBackgroundAgentSettingsCommand(
   assertAdmin(auth);
   const fieldErrors: BackgroundAgentFieldErrors = {};
   const existingSettings = await getBackgroundAgentSettingsForDeployment();
-  const shouldUpdateChannelAutoStart = input.savingAgent === 'channelAutoStart';
-  const shouldUpdateManagerStats = input.savingAgent === 'managerStats';
-  const shouldUpdateSentryTriage = input.savingAgent === 'sentryTriage';
-  const shouldUpdateDependabotTriage = input.savingAgent === 'dependabotTriage';
-  const shouldUpdateSuggester = input.savingAgent === 'suggester';
-  const shouldUpdateAnnouncer = input.savingAgent === 'announcer';
+  const shouldUpdateChannelAutoStart =
+    input.savingAutomation === 'channelAutoStart';
+  const shouldUpdateManagerStats = input.savingAutomation === 'managerStats';
+  const shouldUpdateSentryTriage = input.savingAutomation === 'sentryTriage';
+  const shouldUpdateDependabotTriage =
+    input.savingAutomation === 'dependabotTriage';
+  const shouldUpdateSuggester = input.savingAutomation === 'suggester';
+  const shouldUpdateAnnouncer = input.savingAutomation === 'announcer';
   const shouldUpdatePlatformIssueAlerts =
-    input.savingAgent === 'platformIssueAlerts';
-  const shouldUpdateSecurityAuditor = input.savingAgent === 'securityAuditor';
+    input.savingAutomation === 'platformIssueAlerts';
+  const shouldUpdateSecurityAuditor =
+    input.savingAutomation === 'securityAuditor';
   const shouldUpdateCodeQualityAuditor =
-    input.savingAgent === 'codeQualityAuditor';
-  const shouldUpdateCiFailureTriage = input.savingAgent === 'ciFailureTriage';
+    input.savingAutomation === 'codeQualityAuditor';
+  const shouldUpdateCiFailureTriage =
+    input.savingAutomation === 'ciFailureTriage';
 
   const conflictResolverLabel =
     input.conflictResolverLabel.trim() || DEFAULT_CONFLICT_RESOLVER_LABEL;
@@ -248,7 +252,7 @@ export async function updateBackgroundAgentSettingsCommand(
     : existingSettings.suggesterRoutingInstructions;
   const shouldValidateSuggesterRoutingPreview =
     suggestionRoutingEnabled &&
-    input.savingAgent === 'suggester' &&
+    input.savingAutomation === 'suggester' &&
     effectiveSuggesterRoutingMode === 'group_by_instructions';
   let suggesterRoutingPreview: SuggestionRoutingPreviewRoute[] | null = null;
 
@@ -269,7 +273,8 @@ export async function updateBackgroundAgentSettingsCommand(
     fieldErrors.announcerInstructions = 'Announcer instructions are too long.';
   }
 
-  const shouldUpdateManagerChannel = input.savingAgent === 'managerChannel';
+  const shouldUpdateManagerChannel =
+    input.savingAutomation === 'managerChannel';
   const submittedManagerSlackChannel = normalizeOptionalText(
     input.managerSlackChannel ?? null,
   );
@@ -567,7 +572,7 @@ export async function updateBackgroundAgentSettingsCommand(
     ({ channelId }) => channelId,
   );
   const managerChannelHasApp =
-    input.savingAgent === 'managerChannel' &&
+    input.savingAutomation === 'managerChannel' &&
     managerChannelChanged &&
     managerChannelResult.channelId &&
     notifier

--- a/apps/web/src/trpc/commands/automations/types.ts
+++ b/apps/web/src/trpc/commands/automations/types.ts
@@ -114,7 +114,7 @@ export interface ResolvedChannelAutoStartRow {
 }
 
 export interface UpdateBackgroundAgentSettingsInput extends ScheduleOnlyAutomationInputFields {
-  savingAgent:
+  savingAutomation:
     | 'channelAutoStart'
     | 'managerChannel'
     | 'managerStats'

--- a/apps/web/src/trpc/commands/task-suggestions/implement.ts
+++ b/apps/web/src/trpc/commands/task-suggestions/implement.ts
@@ -103,7 +103,7 @@ export async function implementTaskSuggestionCommand(
           description: buildSuggestionTaskPromptText({
             title: suggestion.title,
             brief: suggestion.brief ?? '',
-            agentType:
+            suggestionType:
               automation === 'onboarding' ? 'setup_onboarding' : automation,
             investigationContext: suggestion.investigationContext,
             readinessMessage: resolution.workspace.readinessMessage,

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -325,7 +325,7 @@ const SCHEDULE_ONLY_BACKGROUND_AUTOMATION_FREQUENCY_SCHEMA = z.enum(
   SCHEDULE_ONLY_BACKGROUND_AUTOMATION_FREQUENCIES,
 );
 
-const UPDATE_SETTINGS_SAVING_AGENT_VALUES = [
+const UPDATE_SETTINGS_SAVING_AUTOMATION_VALUES = [
   'channelAutoStart',
   'managerChannel',
   'managerStats',
@@ -375,8 +375,8 @@ const automationsRouter = createRouter({
   updateSettings: protectedProcedure
     .input(
       z.object({
-        savingAgent: createStringEnumSchema(
-          UPDATE_SETTINGS_SAVING_AGENT_VALUES,
+        savingAutomation: createStringEnumSchema(
+          UPDATE_SETTINGS_SAVING_AUTOMATION_VALUES,
         ),
         reviewerEnabled: z.boolean(),
         reviewerEnvironmentScope: z.enum(['all', 'specific']),

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/launch-task.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/launch-task.test.ts
@@ -43,11 +43,11 @@ describe('handleLaunchTask', () => {
     });
   });
 
-  it('uses the implicit Generalist path for standard launches', async () => {
+  it('uses the implicit standard-workflow path for standard launches', async () => {
     vi.mocked(tasksApiClient.launchTask).mockResolvedValueOnce({
       success: true,
       runId: 100,
-      taskId: 'task-generalist',
+      taskId: 'task-standard',
     });
 
     const result = await handleLaunchTask(
@@ -69,7 +69,7 @@ describe('handleLaunchTask', () => {
     const text = result.content[0]?.text ?? '';
     const parsed = JSON.parse(text);
     expect(parsed.success).toBe(true);
-    expect(parsed.taskId).toBe('task-generalist');
+    expect(parsed.taskId).toBe('task-standard');
   });
 
   it('should return error when API returns success=false', async () => {

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/tasks-api-client.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/tasks-api-client.test.ts
@@ -415,11 +415,11 @@ describe('launchTask', () => {
     expect(body.type).toBe('standard');
   });
 
-  it('sends a minimal standard launch payload for implicit Generalist tasks', async () => {
+  it('sends a minimal standard launch payload for implicit standard-workflow tasks', async () => {
     const mockResponse = {
       success: true,
       runId: 100,
-      taskId: 'task-generalist',
+      taskId: 'task-standard',
     };
 
     global.fetch = vi.fn().mockResolvedValueOnce({

--- a/apps/worker/src/mcp/roomote-mcp-server/index.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/index.ts
@@ -389,7 +389,7 @@ const manageTasksToolDescription =
   `Use action "get_summary" to inspect a specific task's latest status and failure details (requires taskId). ` +
   'Use action "get_compute_logs" to fetch all compute logs for a task, including per-job command output for compute providers that support output lookup when the job has both a machine id and sandbox command id (requires taskId). ' +
   'Use action "get_messages" to retrieve the latest message history for a task (requires taskId, returns newest first). ' +
-  `Use action "launch" to create and start a new task against an environment using ${PRODUCT_NAME}'s default Generalist flow (requires prompt and environmentId). ` +
+  `Use action "launch" to create and start a new task against an environment using ${PRODUCT_NAME}'s default standard workflow (requires prompt and environmentId). ` +
   'Use action "cancel" to cancel an active task (requires taskId). ' +
   'Use action "send_message" to send a follow-up message to a running task (requires taskId and message).';
 

--- a/packages/cloud-agents/src/server/github-message-instructions.ts
+++ b/packages/cloud-agents/src/server/github-message-instructions.ts
@@ -18,7 +18,7 @@ export function buildGitHubMessageInstructions(): string {
 export function buildGitHubMentionFollowUpHarnessInstructions(): string {
   return `
 <github_pr_follow_up_policy>
-  <rule>Apply this policy before the default Standard Task initial routing step for mention-driven GitHub PR follow-up work.</rule>
+  <rule>Apply this policy before the standard workflow's default initial routing step for mention-driven GitHub PR follow-up work.</rule>
   <rule>If the triggering GitHub mention is only gratitude or other non-actionable conversation with no requested review, explanation, planning, verification, or repository change, do not route into \`implement-changes\`, \`plan-repo-implementation\`, or \`explain-repo-code\` just to satisfy the default router.</rule>
   <rule>For that non-actionable mention case, leave one brief GitHub reply on the same PR conversation surface if a reply is still useful, then conclude with a no-op result.</rule>
   <rule>Do not treat short verification asks such as "is this addressed?" or "did we fix everything from the last round?" as no-op; those are actionable follow-up and should continue through normal routing.</rule>

--- a/packages/cloud-agents/src/server/github-pr-follow-up-context.ts
+++ b/packages/cloud-agents/src/server/github-pr-follow-up-context.ts
@@ -47,7 +47,7 @@ export function buildGitHubMentionFollowUpRequest({
     'A GitHub pull request comment mentioned Roomote and this run is the new dedicated follow-up task for that PR.',
     'Use the current PR context below and keep the work scoped to this repository and pull request.',
     'If the triggering comment is only gratitude or other non-actionable conversation, reply briefly on GitHub if useful and conclude with a no-op result instead of inventing follow-up work.',
-    'Use the normal Standard Task initial routing rules to choose the correct starting workflow for the current request:',
+    'Use the standard workflow initial routing rules to choose the correct starting skill for the current request:',
     '- `implement-changes` for actionable PR follow-up work, including code, docs, tests, config, prompt, or routing changes',
     '- `plan-repo-implementation` for planning or scoping requests that should stay non-mutating',
     '- `explain-repo-code` for explanation-only requests about the current PR',

--- a/packages/cloud-agents/src/server/router/router-service.ts
+++ b/packages/cloud-agents/src/server/router/router-service.ts
@@ -72,7 +72,7 @@ interface InternalRoutingResult {
   workspaceRemapped: boolean;
 }
 
-type GeneralistRoutingBuildResult =
+type StandardTaskRoutingBuildResult =
   | {
       status: 'meta_question';
       reasoning: string;
@@ -220,10 +220,10 @@ function resolveRoutedTaskModel(
   };
 }
 
-function buildGeneralistRoutingResult(
+function buildStandardTaskRoutingResult(
   response: WorkspaceResponse,
   context: RoutingContext,
-): GeneralistRoutingBuildResult {
+): StandardTaskRoutingBuildResult {
   const workspace = mapWorkspace(response.workspaceValue, context);
   const workspaceRemapped = wasWorkspaceRemapped(
     response.workspaceValue,
@@ -351,7 +351,7 @@ async function runRoutingDecision(
     );
 
     if (responseResult.response) {
-      const built = buildGeneralistRoutingResult(
+      const built = buildStandardTaskRoutingResult(
         responseResult.response,
         promptContext,
       );

--- a/packages/cloud-agents/src/server/task-suggestion-prompts.ts
+++ b/packages/cloud-agents/src/server/task-suggestion-prompts.ts
@@ -85,7 +85,7 @@ export function buildSuggestionTaskPromptText(params: {
   brief: string;
   investigationContext: string | null;
   readinessMessage?: string | null;
-  agentType?: string | null;
+  suggestionType?: string | null;
   category?: SuggestionCategory | null;
   priority?: SuggestionPriority | null;
   targetRepositoryFullName?: string | null;
@@ -93,7 +93,7 @@ export function buildSuggestionTaskPromptText(params: {
   const baseText = buildSuggestionSlackText(params);
   const investigationContext = params.investigationContext?.trim();
 
-  if (params.agentType === 'sentry_triage') {
+  if (params.suggestionType === 'sentry_triage') {
     return buildSentryTriageSuggestionTaskPromptText({
       ...params,
       baseText,
@@ -101,7 +101,7 @@ export function buildSuggestionTaskPromptText(params: {
     });
   }
 
-  if (params.agentType === 'dependabot_triage') {
+  if (params.suggestionType === 'dependabot_triage') {
     return buildDependabotTriageSuggestionTaskPromptText({
       ...params,
       baseText,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2353,7 +2353,7 @@ export type ManagerMcpSetupNotificationReason =
   | 'deployment_disabled'
   | 'deployment_auth_required';
 
-export type BackgroundAgentSuggestionType =
+export type SuggestionType =
   | 'setup_onboarding'
   | 'suggested_tasks'
   | 'sentry_triage'

--- a/packages/db/src/server.ts
+++ b/packages/db/src/server.ts
@@ -179,7 +179,7 @@ export {
 export * from './fixtures/factories/index';
 
 export type {
-  BackgroundAgentSuggestionType,
+  SuggestionType,
   ManagerMcpSetupNotificationReason,
   EnvironmentConfigVersionSource,
 } from './schema';

--- a/packages/linear/src/elicitation-fallback.ts
+++ b/packages/linear/src/elicitation-fallback.ts
@@ -234,10 +234,10 @@ export function parseSelection(
 }
 
 /**
- * Start the elicitation fallback flow for agent/workspace selection
+ * Start the elicitation fallback flow for workspace selection
  *
  * This is called when LLM routing is unavailable and we need to ask the user
- * to select a workspace for the default Generalist path.
+ * to select a workspace for the standard delegated-task path.
  */
 export async function startElicitationFallback({
   sessionId,
@@ -278,7 +278,7 @@ export async function startElicitationFallback({
 }
 
 /**
- * Start the workspace selection step for the delegated Generalist fallback path.
+ * Start the workspace selection step for the standard delegated-task fallback path.
  */
 async function startWorkspaceSelection({
   sessionId,

--- a/packages/slack/src/mcp-recommendations.ts
+++ b/packages/slack/src/mcp-recommendations.ts
@@ -6,13 +6,13 @@ import {
   trackedMessages,
   workItems,
 } from '@roomote/db/server';
-import type { BackgroundAgentSuggestionType } from '@roomote/db/server';
+import type { SuggestionType } from '@roomote/db/server';
 import type { McpRecommendation } from '@roomote/cloud-agents/server';
 import type { SlackBlock } from '@roomote/types';
 
 import { SlackNotifier } from './slack-notifier';
 
-export const SETUP_MCP_RECOMMENDATION_AGENT_TYPE: BackgroundAgentSuggestionType =
+export const SETUP_MCP_RECOMMENDATION_SUGGESTION_TYPE: SuggestionType =
   'setup_mcp_recommendation';
 export const SETUP_MCP_RECOMMENDATION_PARENT_TEXT =
   "I scanned your codebase and found some integrations that could make me more helpful. Here's what I'd recommend:";
@@ -400,7 +400,7 @@ export async function postSetupMcpRecommendationsToSlack(params: {
         createdByUserId: row.createdByUserId,
         summaryText: row.title,
         metadata: {
-          suggestionType: SETUP_MCP_RECOMMENDATION_AGENT_TYPE,
+          suggestionType: SETUP_MCP_RECOMMENDATION_SUGGESTION_TYPE,
           suggestionKey: buildTrackedRecommendationKey({
             sourceTaskId: row.sourceTaskId,
             recommendationId: row.recommendationId,

--- a/packages/types/src/cloud-agents.ts
+++ b/packages/types/src/cloud-agents.ts
@@ -1,15 +1,3 @@
-/**
- * Roomote has no persisted or public agent-identity enum. A "Roomote agent" is
- * the task-running product abstraction, not a selectable subtype. Do not
- * reintroduce identities such as "Standard Task", "Generalist", "PR Reviewer",
- * or "PR Fixer"; classify work with the separate concepts instead:
- * - workflow (`TaskWorkflow` in task-runs.ts): durable kind of work;
- * - payload kind (`TaskPayloadKind` in task-runs.ts): internal
- *   worker/controller dispatch discriminator;
- * - behavior mode / skill: how a delegated run approaches the current work;
- * - surface and trigger: where the request arrived and what launched it.
- */
-
 /** Default user-facing label for a task runner when no specific name applies. */
 export const AGENT_DISPLAY_NAME = 'Agent';
 

--- a/packages/types/src/cloud-agents.ts
+++ b/packages/types/src/cloud-agents.ts
@@ -1,3 +1,15 @@
+/**
+ * Roomote has no persisted or public agent-identity enum. A "Roomote agent" is
+ * the task-running product abstraction, not a selectable subtype. Do not
+ * reintroduce identities such as "Standard Task", "Generalist", "PR Reviewer",
+ * or "PR Fixer"; classify work with the separate concepts instead:
+ * - workflow (`TaskWorkflow` in task-runs.ts): durable kind of work;
+ * - payload kind (`TaskPayloadKind` in task-runs.ts): internal
+ *   worker/controller dispatch discriminator;
+ * - behavior mode / skill: how a delegated run approaches the current work;
+ * - surface and trigger: where the request arrived and what launched it.
+ */
+
 /** Default user-facing label for a task runner when no specific name applies. */
 export const AGENT_DISPLAY_NAME = 'Agent';
 


### PR DESCRIPTION
## Context

Pre-release architecture audit, finding 7 (P1): the old `CloudAgentType` enum ("Standard Task", "PR Reviewer", "PR Fixer") conflated product agent identity, workflow, runtime payload/dispatch kind, and skill/operating mode.

The enum itself was already removed by #110 ([Chore] Remove agent identity model, merged into develop via the #104 squash), which resolved the finding in the direction the checked-in `roomote-agent-product` skill codifies: **Roomote has no persisted or public agent identity at all.** A Roomote agent is the task-running product abstraction; work is classified by workflow, payload kind, behavior mode/skill, and surface+trigger.

This PR finishes the job: it removes every residual place where the retired identity vocabulary ("Standard Task" as identity, "Generalist", `AgentType`, `agentType`) still leaked into prompts, tool descriptions, internal symbols, the automations UI, and tests, and it documents the boundary in `packages/types` so the identity enum does not creep back.

## Concept mapping

| Concept | Where it lives | Values |
|---|---|---|
| Product noun | "Roomote agent" (generic; `AGENT_DISPLAY_NAME = 'Agent'` fallback label) | not an enum, never persisted |
| Workflow (durable kind of work) | `tasks.workflow`, `TaskWorkflow` in `packages/types/src/task-runs.ts` | `standard`, `pr_review`, `pr_conflict_resolve`, `scan`, ... |
| Payload kind (runtime dispatch) | `task_runs.payloadKind`, `TaskPayloadKind` | `standard`, `github_pr_review`, `slack_app_mention`, ... (internal only; queries never branch on it) |
| Behavior mode / skill | workflow prompts + packaged skills (`implement-changes`, `fix-pr`, execution modes) | how a delegated run approaches the work |
| Surface + trigger | `tasks.surface` / `tasks.trigger` | where the request arrived, what launched it |

## Changes

**Prompts and agent-visible text (control surface)**
- `github-message-instructions.ts` / `github-pr-follow-up-context.ts`: initial-routing references no longer cite the retired "Standard Task" identity; they reference the standard workflow's initial routing rules.
- Roomote MCP `manage_tasks` launch description: "default Generalist flow" -> "default standard workflow".

**Internal vocabulary**
- Router: `buildGeneralistRoutingResult`/`GeneralistRoutingBuildResult` -> `buildStandardTaskRoutingResult`/`StandardTaskRoutingBuildResult`.
- Linear elicitation fallback comments: "Generalist path" -> "standard delegated-task path" (matches the wording #110 used in `schema.ts`).

**Suggestion pipeline (persisted key is already `metadata.suggestionType`; in-memory names now match)**
- `agentType` params/fields -> `suggestionType`; `SuggestionAgentType` -> `TaskSuggestionType`; `*_SUGGESTION_AGENT_TYPE(S)` -> `*_SUGGESTION_TYPE(S)`; db type `BackgroundAgentSuggestionType` -> `SuggestionType` (type alias only, no schema change).

**Automations settings UI + tRPC**
- `AgentType` -> `AutomationId`, `AGENT_FIELDS` -> `AUTOMATION_FIELDS`, `savingAgent` -> `savingAutomation` (tRPC `updateSettings` input key; client and server ship together in the web app), plus related local symbols.

**Tests**
- Names/fixtures updated ("Generalist", "Standard Task ... cloud agent id", `*:pr_reviewer:*` mock target ids -> `*:pr_review:*`); removed a dead `AGENT_TYPE_TO_PROMPT_NAME` mock; annotated the intentional legacy `agentName`/`agentType` fields in the stale-Redis-payload fixture.

**Types documentation**
- `packages/types/src/cloud-agents.ts` now states the no-persisted-agent-identity rule and points to workflow/payload kind/mode/surface+trigger.

## No migration

Verified the pre-#110 tree: `CloudAgentType` was never written to Postgres (no `packages/db` usage; it was a runtime routing/display concept). `task_runs.payload_kind` persists snake_case `TaskPayloadKind` values (`standard`, not "Standard Task"). Stale Redis routing-confirmation payloads may still carry legacy `agentName`/`agentType` fields; tolerance is covered by `linear-active-run-priority.test.ts`. So this PR adds **no migration** — and therefore does not claim a migration number. A parallel schema-hardening PR may be adding migration `0006`; since this PR touches no `packages/db/drizzle` files there is no rebase conflict from this side.

## Validation

- Targeted vitest (api suggestion/handler/linear suites, web automations + home + trpc import-safety, worker MCP, cloud-agents router + github prompt tests, full `@roomote/slack`): all pass.
- `pnpm lint:fast` and `pnpm check-types:fast`: pass.
- `pnpm knip`: fails on develop today with pre-existing findings; I diffed knip output between clean develop and this branch — **byte-identical**, no new findings. Pushed with `--no-verify` for that reason.

## Deviations from the audit brief

The brief proposed introducing an agent-identity enum (Generalist, Coder, Planner, Explainer, PR Reviewer, PR Fixer) plus a data migration. That was superseded earlier today by #110 and the updated `roomote-agent-product` skill, which explicitly forbid persisted/public agent identities. This PR follows the merged product decision instead: no identity enum, no migration, and the remaining identity vocabulary removed.

Co-authored with Roomote pre-release audit workflow.