### PR TITLE
[Improve] Define upgrade/rollback policy and add an upgrade CI lane

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -184,35 +184,74 @@ jobs:
       - name: Restore an encrypted bundle onto empty volumes
         run: bash deploy/host/tests/backup-restore.integration.sh
 
-  docker-build:
-    name: Docker Build (${{ matrix.app }})
+  upgrade-compatibility:
+    name: Upgrade Compatibility
     needs: changes
     if: ${{ needs.changes.outputs.docs_only != 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+        with:
+          frozen-lockfile: 'true'
+          node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+      # Boots the previous published release from GHCR, applies this branch's
+      # migrations to it, and requires the previous release to stay healthy on
+      # the candidate schema (the expand/contract policy in deploy/README.md).
+      - name: Apply candidate migrations to the previous release
+        env:
+          BASELINE_CHANNEL: ${{ github.base_ref || github.ref_name }}
+        run: bash deploy/ci/upgrade-compatibility.sh
+
+  docker-build:
+    name: Docker Build (${{ matrix.app }}, ${{ matrix.arch }})
+    needs: changes
+    if: ${{ needs.changes.outputs.docs_only != 'true' }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
+      # Each arch builds natively, mirroring the publish workflow (no QEMU:
+      # rustc segfaults under emulation, rust-lang/rust#147026).
       matrix:
         include:
           - app: app
             dockerfile: .docker/app/Dockerfile
             target: runtime-app
+            arch: amd64
+            runner: blacksmith-4vcpu-ubuntu-2404
+          - app: app
+            dockerfile: .docker/app/Dockerfile
+            target: runtime-app
+            arch: arm64
+            runner: blacksmith-4vcpu-ubuntu-2404-arm
           - app: worker
             dockerfile: apps/worker/Dockerfile
             target: runtime
+            arch: amd64
+            runner: blacksmith-4vcpu-ubuntu-2404
+          - app: worker
+            dockerfile: apps/worker/Dockerfile
+            target: runtime
+            arch: arm64
+            runner: blacksmith-4vcpu-ubuntu-2404-arm
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Validate production Compose security contract
-        if: matrix.app == 'app'
+        if: matrix.app == 'app' && matrix.arch == 'amd64'
         run: deploy/scripts/validate-compose-security.sh
       - name: Set up Docker builder
         uses: useblacksmith/setup-docker-builder@47a5d0102cc44712a17a633c2599f755008cc40e # v1
-      - name: Build ${{ matrix.app }} Dockerfile
+      - name: Build ${{ matrix.app }} Dockerfile (${{ matrix.arch }})
         uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2
         with:
           context: .
           file: ${{ matrix.dockerfile }}
           target: ${{ matrix.target }}
+          platforms: linux/${{ matrix.arch }}
           push: false
           build-args: APP_ENV=development
 

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -81,6 +81,7 @@ roomote status              # service health
 roomote logs [service...]   # follow logs
 roomote setup-url           # re-print the tokenized /setup link
 roomote upgrade [version]   # upgrade or roll back by image tag
+roomote rollback            # return to the release before the last upgrade
 roomote backup              # encrypted recovery bundle in /opt/roomote/backups
 roomote restore <f> --yes   # restore configuration and data onto this host
 ```
@@ -115,6 +116,21 @@ restores the original `.env`, repopulates empty data volumes, pins the recorded
 image digests, restores PostgreSQL, and starts the recorded release. A wrong
 passphrase, checksum failure, missing local-MinIO data, or unavailable image
 identity fails before restored services are started.
+
+`roomote upgrade` first creates an encrypted pre-upgrade backup bundle under
+`/opt/roomote/backups` (skip with `--skip-backup`; supply a passphrase with
+`--backup-passphrase-file` or `ROOMOTE_BACKUP_PASSPHRASE`, otherwise one is
+generated next to the bundle). It then pulls the new images and applies
+database migrations before replacing any running service. Migrations apply in
+a single transaction, so a migration failure rolls the schema back, restores
+the previous deployment configuration, and leaves the previous release
+running. Because every schema change must keep the previous release working
+(see the compatibility policy in `deploy/README.md`), a bad release can be
+undone with `roomote rollback`, which re-deploys the release recorded before
+the last upgrade without touching the database; the pre-upgrade bundle plus
+`roomote restore` is the last-resort path that also rewinds data. The running
+application and schema versions are visible under Settings -> Deployment ->
+Diagnostics.
 
 `roomote upgrade` prunes old Roomote images after a successful upgrade. It
 keeps the current release plus the newest local Roomote image tags for a total

--- a/apps/docs/self-hosting.mdx
+++ b/apps/docs/self-hosting.mdx
@@ -60,6 +60,7 @@ The installer also sets up the `roomote` host CLI for common operations:
 
 ```sh
 roomote upgrade   # pull and roll out newer images
+roomote rollback  # return to the release before the last upgrade
 roomote backup    # create an encrypted deployment recovery bundle
 roomote logs      # tail service logs
 ```
@@ -86,6 +87,30 @@ roomote restore /path/to/backup.roomote --yes
 Restore verifies the encrypted bundle and checksums before replacing any
 state, restores the original `.env` (including `ENCRYPTION_KEY`), repopulates
 empty PostgreSQL/MinIO/Redis volumes, and starts the recorded Roomote release.
+
+## Upgrades and rollback
+
+`roomote upgrade` is designed so a bad release cannot strand your deployment:
+
+- **A backup comes first.** Every upgrade creates an encrypted pre-upgrade
+  bundle under `/opt/roomote/backups` before anything changes. Pass a
+  passphrase with `--backup-passphrase-file` (or `ROOMOTE_BACKUP_PASSPHRASE`);
+  otherwise one is generated and stored next to the bundle. Use
+  `--skip-backup` to opt out.
+- **Migrations run before services are replaced.** Database migrations apply
+  in a single transaction while the previous release keeps serving. If a
+  migration fails, the schema rolls back, the previous configuration is
+  restored, and the previous release stays up.
+- **Rollback is one command.** Every release's schema keeps the previous
+  release working, so `roomote rollback` re-deploys the prior release without
+  touching the database. `roomote upgrade <tag>` does the same for any
+  retained tag, and restoring the pre-upgrade bundle is the last-resort path
+  that also rewinds data.
+
+The supported rollback target is the release immediately before the current
+one. Check the running application version and applied schema migration at any
+time under **Settings → Deployment → Diagnostics**; both are also recorded in
+every backup bundle's manifest.
 
 ## Deployment modes
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -276,8 +276,17 @@ docker compose --env-file .env -f docker-compose.prod.yml stop controller || tru
 DOCKER_WORKER_IMAGE="$(awk -F= '/^(export[[:space:]]+)?DOCKER_WORKER_IMAGE=/ { sub(/^[^=]*=/, ""); print; exit }' .env)"
 docker pull "$DOCKER_WORKER_IMAGE"
 docker compose --env-file .env -f docker-compose.prod.yml pull
+docker compose --env-file .env -f docker-compose.prod.yml run --rm db-migrate
 docker compose --env-file .env -f docker-compose.prod.yml up -d --wait --wait-timeout 600
 ```
+
+Database migrations run as a dedicated one-shot step after images are pulled
+and before any running service is replaced. If the migration step fails, the
+deployer restarts the previous controller and exits with the previous release
+still serving; see the compatibility policy below for why that is always safe.
+The on-host `roomote upgrade` additionally creates an encrypted pre-upgrade
+backup and restores the previous deployment configuration files when the
+migration step fails.
 
 The Compose file defines container healthchecks for `web`, `api`, `controller`,
 `bullmq`, and `preview-proxy`. The controller probe uses the API's Redis
@@ -302,6 +311,116 @@ to remove any image used by a running or stopped container. Use
 to adjust rollback depth for a deployment. Retention is best-effort after a
 healthy rollout; a Docker cleanup failure prints a warning instead of failing
 the completed deploy or upgrade.
+
+## Upgrade And Migration Compatibility Policy
+
+This is the contract between releases, migrations, and the upgrade tooling.
+Schema changes that cannot satisfy it must be split across releases.
+
+### Expand/contract migrations
+
+Every migration must keep the previous release working against the new
+schema. Ship schema changes in two phases:
+
+- **Expand** (safe in any release): add tables, add nullable columns, add
+  columns with database-side defaults, add indexes, widen types, add enum
+  values. New code reads and writes the new shape; old code keeps working
+  because nothing it uses changed.
+- **Contract** (only after no supported version references the old shape):
+  drop or rename tables and columns, add `NOT NULL` to existing columns,
+  narrow types, remove enum values. A rename is an expand (add the new
+  column, dual-write, backfill) followed by a contract (drop the old column)
+  at least one release later.
+
+Long-running backfills do not belong in migrations. Run them as idempotent
+application code after the rollout so the migration step stays fast enough
+for the rollout timeout below.
+
+### Minimum rollback-compatible version
+
+The schema produced by release N must support the application code of the
+release immediately before it (N-1). The supported rollback target is
+therefore always the previously deployed release, without undoing
+migrations: roll the application back and leave the schema at N. Rolling
+back more than one release is not guaranteed by this policy; use the
+pre-upgrade backup bundle for that instead.
+
+### Pre-upgrade backup
+
+`roomote upgrade` creates an encrypted backup bundle (the same format as
+`roomote backup`) before it changes any deployment file or container. The
+passphrase comes from `--backup-passphrase-file`, then
+`ROOMOTE_BACKUP_PASSPHRASE`; with neither, the command generates one and
+stores it next to the bundle under `/opt/roomote/backups/`, in the same
+trust domain as `/opt/roomote/.env`. Move both off-host if the bundle
+should double as a disaster-recovery copy. `--skip-backup` opts out, and
+`roomote rollback` skips it by design so an unhealthy stack cannot block
+the rollback. The operator-run deployer does not back up implicitly; run
+`roomote-deploy backup` before production upgrades.
+
+### Migration lock and timeout behavior
+
+Migrations run as the one-shot `db-migrate` service from the release being
+deployed. Drizzle applies all pending migrations inside a single
+transaction, so a failed migration rolls the schema back to its previous
+state. There is no advisory lock and no statement timeout on the migration
+step itself; single-writer behavior comes from running one `db-migrate`
+container per deployment, so never run two upgrades against the same
+database concurrently. Every application service in the Compose stack waits
+on `db-migrate` completing successfully before it starts, and the rollout as
+a whole is bounded by `up --wait --wait-timeout 600`.
+
+### Failure behavior
+
+The upgrade sequence pulls images first, then runs migrations, and only then
+replaces running services. A migration failure aborts the upgrade with the
+previous release still serving: `roomote upgrade` restores the previous
+Compose, Caddy, and `.env` files and restarts the controller; the deployer
+restarts the controller and asks the operator to re-run with the previous
+tag. A failure after migrations succeeded (for example `up --wait` timing
+out) leaves the schema at the candidate version, which the previous release
+supports by the rule above, so `roomote rollback` or an upgrade to the
+previous tag recovers without touching the database.
+
+### Rollback path
+
+- `roomote rollback` re-deploys the release recorded in
+  `ROOMOTE_PREVIOUS_VERSION` by the last upgrade.
+- `roomote upgrade <previous-tag>` (or `roomote-deploy upgrade --version
+<previous-tag>`) is the explicit equivalent and works for any retained tag.
+- `roomote restore <bundle> --yes` with the pre-upgrade bundle is the
+  last-resort path and also rewinds the database and artifacts.
+
+Image retention keeps the current release plus the newest tags (default 3
+total), so the rollback image is normally still on the host. The restore
+path is exercised in CI on every non-docs change (the backup-restore job),
+and the rollback path is exercised against real images by the publish gate
+below.
+
+### Version visibility
+
+Settings -> Deployment -> Diagnostics surfaces the running application
+version (`Roomote version`, from the `RELEASE_VERSION` baked into the image)
+and the schema version (`Current migration`, the latest applied Drizzle
+migration hash). The same pair is recorded in every backup manifest as
+`roomoteVersion` and `schemaVersion`, and `/opt/roomote/.env` records
+`ROOMOTE_VERSION` plus the `ROOMOTE_PREVIOUS_VERSION` rollback target.
+
+### CI enforcement
+
+- **Upgrade Compatibility** (`.github/workflows/CI.yml`, every non-docs PR):
+  boots the previous published release from GHCR, applies the candidate
+  branch's migrations to its database, and requires the previous release to
+  stay healthy, including a cold restart, on the candidate schema
+  ([`deploy/ci/upgrade-compatibility.sh`](ci/upgrade-compatibility.sh)).
+- **Fresh-host Backup Restore** (every non-docs PR): restores an encrypted
+  bundle onto empty volumes
+  ([`deploy/host/tests/backup-restore.integration.sh`](host/tests/backup-restore.integration.sh)).
+- **Deployment acceptance** (`publish-ghcr.yml`, gates every image publish):
+  builds candidate images, upgrades the previous published release to the
+  candidate, rolls back, re-upgrades, launches a real Docker task, and
+  restores a backup onto fresh volumes
+  ([`deploy/ci/deployment-smoke.sh`](ci/deployment-smoke.sh)).
 
 ## Back Up a Deployment
 

--- a/deploy/ci/upgrade-compatibility.sh
+++ b/deploy/ci/upgrade-compatibility.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+#
+# PR-time upgrade-compatibility lane. Boots the previous published release
+# from GHCR, applies the candidate checkout's database migrations to it, and
+# requires the previous release to stay healthy — including a cold restart —
+# on the candidate schema. This enforces the expand/contract policy in
+# deploy/README.md before merge without building candidate images; the
+# publish-time deployment-acceptance gate (deploy/ci/deployment-smoke.sh)
+# covers the full upgrade -> rollback -> re-upgrade lifecycle with them.
+set -Eeuo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+baseline_channel="${BASELINE_CHANNEL:-develop}"
+baseline_registry="${BASELINE_IMAGE_REGISTRY:-ghcr.io}"
+baseline_namespace="${BASELINE_IMAGE_NAMESPACE:-roocodeinc}"
+project_name="${COMPOSE_PROJECT_NAME:-roomote-upgrade-ci}"
+postgres_port="${DEPLOYMENT_CI_POSTGRES_PORT:-57432}"
+redis_port="${DEPLOYMENT_CI_REDIS_PORT:-58379}"
+default_network="${ROOMOTE_DEFAULT_NETWORK:-${project_name}_default}"
+worker_network="${DOCKER_WORKER_NETWORK:-${project_name}_worker}"
+temporary_directory="$(mktemp -d)"
+env_file="$temporary_directory/deployment.env"
+
+# Only published channel aliases have a defined previous release. Anything
+# else (workflow_dispatch from a feature branch) validates against develop.
+case "$baseline_channel" in
+  develop | main) ;;
+  *)
+    printf 'No published channel for %s; using develop as the baseline\n' "$baseline_channel"
+    baseline_channel='develop'
+    ;;
+esac
+
+app_image="$baseline_registry/$baseline_namespace/roomote-app:$baseline_channel"
+worker_image="$baseline_registry/$baseline_namespace/roomote-worker:$baseline_channel"
+
+compose() {
+  docker compose \
+    --project-name "$project_name" \
+    --env-file "$env_file" \
+    -f "$repo_root/deploy/compose/docker-compose.prod.yml" \
+    -f "$repo_root/deploy/ci/docker-compose.ci.yml" \
+    "$@"
+}
+
+cleanup() {
+  compose down --volumes --remove-orphans >/dev/null 2>&1 || true
+  rm -rf "$temporary_directory"
+}
+trap cleanup EXIT
+
+report_failure() {
+  local exit_code="$?"
+  printf 'Upgrade compatibility test failed; final Compose state follows.\n' >&2
+  compose ps --all >&2 || true
+  compose logs --no-color --tail 200 >&2 || true
+  return "$exit_code"
+}
+trap report_failure ERR
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    printf 'required command not found: %s\n' "$1" >&2
+    exit 1
+  }
+}
+
+for command in docker openssl pnpm; do
+  require_command "$command"
+done
+
+docker_arch="$(docker info --format '{{.Architecture}}')"
+case "$docker_arch" in
+  amd64 | x86_64) platform='linux/amd64' ;;
+  arm64 | aarch64) platform='linux/arm64' ;;
+  *)
+    printf 'unsupported Docker architecture: %s\n' "$docker_arch" >&2
+    exit 1
+    ;;
+esac
+
+generate_keypair() {
+  local name="$1"
+  openssl ecparam -name prime256v1 -genkey -noout -out "$temporary_directory/$name-raw.pem" 2>/dev/null
+  openssl pkcs8 -topk8 -nocrypt \
+    -in "$temporary_directory/$name-raw.pem" \
+    -out "$temporary_directory/$name-private.pem" 2>/dev/null
+  openssl ec -in "$temporary_directory/$name-raw.pem" \
+    -pubout -out "$temporary_directory/$name-public.pem" 2>/dev/null
+}
+
+single_line_base64() {
+  base64 <"$1" | tr -d '\n'
+}
+
+generate_keypair job
+generate_keypair preview
+
+job_private="$(single_line_base64 "$temporary_directory/job-private.pem")"
+job_public="$(single_line_base64 "$temporary_directory/job-public.pem")"
+preview_private="$(single_line_base64 "$temporary_directory/preview-private.pem")"
+preview_public="$(single_line_base64 "$temporary_directory/preview-public.pem")"
+encryption_key="$(openssl rand -base64 32 | tr -d '\n')"
+artifact_signing_key="$(openssl rand -base64 32 | tr -d '\n')"
+dashboard_password="$(openssl rand -base64 24 | tr -d '\n')"
+s3_password="$(openssl rand -base64 32 | tr -d '\n')"
+setup_token="$(openssl rand -hex 24)"
+
+cat >"$env_file" <<EOF
+APP_ENV=production
+ARTIFACT_SIGNING_KEY=$artifact_signing_key
+CADDY_HTTP_PORT=19080
+CADDY_HTTPS_PORT=19443
+COMPOSE_PROFILES=local-postgres
+DASHBOARD_PASSWORD=$dashboard_password
+DATABASE_URL=postgres://postgres:roomote-postgres-password@postgres:5432/roomote
+DEFAULT_COMPUTE_PROVIDER=docker
+DEPLOYMENT_CI_POSTGRES_PORT=$postgres_port
+DEPLOYMENT_CI_REDIS_PORT=$redis_port
+DOCKER_WORKER_IMAGE=$worker_image
+DOCKER_WORKER_NETWORK=$worker_network
+DOCKER_WORKER_PLATFORM=$platform
+DOCKER_WORKER_RELEASE_PATH=/roomote/releases/worker-current.tar.gz
+ENCRYPTION_KEY=$encryption_key
+IMAGE_NAMESPACE=$baseline_namespace
+IMAGE_REGISTRY=$baseline_registry
+JOB_AUTH_PRIVATE_KEY=$job_private
+JOB_AUTH_PUBLIC_KEY=$job_public
+NEXT_PUBLIC_GITHUB_APP_SLUG=upgrade-ci
+POSTGRES_DB=roomote
+POSTGRES_PASSWORD=roomote-postgres-password
+POSTGRES_USER=postgres
+PREVIEW_AUTH_PRIVATE_KEY=$preview_private
+PREVIEW_AUTH_PUBLIC_KEY=$preview_public
+REDIS_URL=redis://redis:6379
+ROOMOTE_APP_DOMAIN=roomote.localhost
+ROOMOTE_APP_URL=http://roomote.localhost
+ROOMOTE_DEFAULT_NETWORK=$default_network
+ROOMOTE_PREVIEW_DOMAIN=preview.roomote.localhost
+ROOMOTE_VERSION=$baseline_channel
+S3_ACCESS_KEY_ID=roomote
+S3_BUCKET_ARTIFACTS=roomote-artifacts
+S3_ENDPOINT=http://minio:9000
+S3_PRESIGN_ENDPOINT=http://minio:9000
+S3_REGION=us-east-1
+S3_SECRET_ACCESS_KEY=$s3_password
+SETUP_TOKEN=$setup_token
+TRPC_URL=http://api:3001
+EOF
+
+verify_endpoints() {
+  compose exec -T api curl -fsS --max-time 5 http://127.0.0.1:3001/health/liveness >/dev/null
+  compose exec -T web curl -fsS --max-time 5 http://127.0.0.1:3000/health >/dev/null
+  compose exec -T web curl -fsS --max-time 10 "http://127.0.0.1:3000/setup?token=$setup_token" >/dev/null
+  compose exec -T controller curl -fsS --max-time 5 http://api:3001/health/controller >/dev/null
+  compose exec -T bullmq curl -fsS --max-time 5 http://127.0.0.1:3002/admin/health >/dev/null
+}
+
+applied_migration_count() {
+  compose exec -T postgres psql -Atq -U postgres -d roomote \
+    -c 'SELECT count(*) FROM drizzle.__drizzle_migrations'
+}
+
+write_marker() {
+  compose exec -T postgres psql -v ON_ERROR_STOP=1 -U postgres -d roomote <<'SQL'
+CREATE TABLE IF NOT EXISTS upgrade_ci_marker (
+  id integer PRIMARY KEY,
+  value text NOT NULL
+);
+INSERT INTO upgrade_ci_marker (id, value)
+VALUES (1, 'preserved')
+ON CONFLICT (id) DO UPDATE SET value = EXCLUDED.value;
+SQL
+}
+
+verify_marker() {
+  local value
+  value="$(compose exec -T postgres psql -At -U postgres -d roomote -c 'SELECT value FROM upgrade_ci_marker WHERE id = 1')"
+  [ "$value" = 'preserved' ] || {
+    printf 'upgrade marker was not preserved (got %s)\n' "$value" >&2
+    return 1
+  }
+}
+
+cd "$repo_root"
+
+printf 'Pulling previous release images (%s)\n' "$baseline_channel"
+docker pull --platform "$platform" "$app_image"
+docker pull --platform "$platform" "$worker_image"
+docker image inspect --format 'baseline app image: {{index .RepoDigests 0}}' "$app_image" || true
+
+printf 'Booting the previous release\n'
+compose up \
+  --detach \
+  --wait \
+  --wait-timeout 600 \
+  postgres redis minio minio-init db-migrate api web controller bullmq preview-proxy
+
+migration_container="$(compose ps --all --quiet db-migrate)"
+[ -n "$migration_container" ] || {
+  printf 'db-migrate container was not created\n' >&2
+  exit 1
+}
+migration_exit="$(docker inspect --format '{{.State.ExitCode}}' "$migration_container")"
+[ "$migration_exit" = '0' ] || {
+  printf 'baseline db-migrate exited with %s\n' "$migration_exit" >&2
+  exit 1
+}
+verify_endpoints
+write_marker
+baseline_migrations="$(applied_migration_count)"
+
+printf 'Applying candidate migrations to the previous release database\n'
+DATABASE_URL="postgres://postgres:roomote-postgres-password@127.0.0.1:$postgres_port/roomote" \
+  pnpm --filter @roomote/db db:migrate:standalone
+
+candidate_migrations="$(applied_migration_count)"
+[ "$candidate_migrations" -ge "$baseline_migrations" ] || {
+  printf 'migration journal shrank from %s to %s\n' "$baseline_migrations" "$candidate_migrations" >&2
+  exit 1
+}
+printf 'Applied migrations: %s baseline -> %s candidate\n' "$baseline_migrations" "$candidate_migrations"
+
+printf 'Verifying the previous release on the candidate schema\n'
+verify_endpoints
+verify_marker
+
+# A rollback is a cold start of the previous release against the candidate
+# schema, so restart the application services and require health again.
+printf 'Cold-restarting the previous release on the candidate schema\n'
+compose restart api web controller bullmq preview-proxy
+compose up \
+  --detach \
+  --wait \
+  --wait-timeout 300 \
+  api web controller bullmq preview-proxy
+verify_endpoints
+verify_marker
+
+printf 'Upgrade compatibility passed: %s stays healthy on the candidate schema\n' "$baseline_channel"

--- a/deploy/ci/validate-deployment-artifacts.mjs
+++ b/deploy/ci/validate-deployment-artifacts.mjs
@@ -255,6 +255,8 @@ for (const script of [
   'deploy/scripts/roomote-deploy',
   'deploy/scripts/upgrade.sh',
   'deploy/ci/deployment-smoke.sh',
+  'deploy/ci/upgrade-compatibility.sh',
+  'deploy/host/tests/backup-restore.integration.sh',
 ]) {
   execFileSync('bash', ['-n', join(root, script)], { stdio: 'pipe' });
 }

--- a/deploy/host/roomote
+++ b/deploy/host/roomote
@@ -17,10 +17,15 @@ Commands:
   status                 Show the state of every Roomote service
   logs [service...]      Follow logs (default: web api controller caddy)
   setup-url              Print the /setup link with the setup token
-  upgrade [version]      Upgrade (or roll back) to an image tag; defaults to
-                         the latest GitHub release
+  upgrade [version] [options]
+                         Upgrade (or roll back) to an image tag; defaults to
+                         the latest GitHub release. Creates an encrypted
+                         pre-upgrade backup and applies database migrations
+                         before replacing services (see roomote upgrade --help)
                          Set ROOMOTE_IMAGE_RETENTION_RELEASES to control how
                          many Roomote release tags are kept after upgrade
+  rollback               Re-deploy the release that was running before the
+                         last upgrade
   backup [options]       Create an encrypted deployment backup bundle
   restore <file> --yes   Restore a bundle, OVERWRITING deployment state
   restart [service...]   Restart services (default: all)
@@ -59,6 +64,22 @@ Options:
 
 ROOMOTE_BACKUP_PASSPHRASE may be used instead of --passphrase-file. If neither
 is set, an interactive terminal is required.
+EOF
+}
+
+upgrade_usage() {
+  cat <<'EOF'
+usage: roomote upgrade [version] [options]
+
+Options:
+  --skip-backup                   Do not create a pre-upgrade backup bundle
+  --backup-passphrase-file <file> Encrypt the pre-upgrade backup with this
+                                  passphrase instead of a generated one
+
+ROOMOTE_BACKUP_PASSPHRASE may be used instead of --backup-passphrase-file.
+Without either, upgrade generates a passphrase and stores it next to the
+bundle under /opt/roomote/backups; move both off-host if the bundle should
+also serve as a disaster-recovery copy.
 EOF
 }
 
@@ -414,10 +435,65 @@ resolve_latest_version() {
   printf '%s' "$latest"
 }
 
+# Encrypted pre-upgrade backup so every upgrade has a restore-tested rollback
+# point. Reuses cmd_backup, so the bundle format and consistency guarantees
+# match a manual `roomote backup`.
+pre_upgrade_backup() {
+  local previous_version="$1"
+  local passphrase_arg="$2"
+  local bundle passphrase_file
+
+  mkdir -p "$install_root/backups"
+  bundle="$install_root/backups/pre-upgrade-${previous_version:-unknown}-$(date +%F-%H%M%S).roomote"
+  log "Creating a pre-upgrade backup (skip with roomote upgrade --skip-backup)"
+  if [ -n "$passphrase_arg" ]; then
+    cmd_backup --passphrase-file "$passphrase_arg" --output "$bundle"
+  elif [ -n "${ROOMOTE_BACKUP_PASSPHRASE:-}" ]; then
+    cmd_backup --output "$bundle"
+  else
+    # No operator passphrase: generate one and keep it beside the bundle.
+    # Both stay in the host's existing trust domain (like /opt/roomote/.env);
+    # move them off-host to double as a disaster-recovery copy.
+    passphrase_file="$bundle.passphrase"
+    (umask 077 && openssl rand -base64 32 >"$passphrase_file")
+    log "Generated backup passphrase file $passphrase_file"
+    cmd_backup --passphrase-file "$passphrase_file" --output "$bundle"
+  fi
+  log "Pre-upgrade backup written to $bundle"
+}
+
 cmd_upgrade() {
-  local version="${1:-}"
+  local version=''
+  local skip_backup='false'
+  local backup_passphrase_arg=''
   local repo image_registry image_namespace previous_worker_image worker_image
-  local modal_base_image_ref fetch_ref app_domain
+  local modal_base_image_ref fetch_ref app_domain previous_version
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --skip-backup)
+        skip_backup='true'
+        shift
+        ;;
+      --backup-passphrase-file)
+        backup_passphrase_arg="${2:-}"
+        shift 2
+        ;;
+      --help | -h)
+        upgrade_usage
+        return
+        ;;
+      --*)
+        upgrade_usage >&2
+        die "unknown upgrade option: $1"
+        ;;
+      *)
+        [ -z "$version" ] || die "only one upgrade version may be given"
+        version="$1"
+        shift
+        ;;
+    esac
+  done
 
   repo="$(read_env_value ROOMOTE_REPO)"
   repo="${repo:-RooCodeInc/Roomote}"
@@ -426,6 +502,27 @@ cmd_upgrade() {
     log "Resolving the latest Roomote release"
     version="$(resolve_latest_version "$repo")"
     [ -n "$version" ] || die "could not resolve a release tag from github.com/$repo; pass a version explicitly"
+  fi
+
+  previous_version="$(read_env_value ROOMOTE_VERSION)"
+  if [ "$skip_backup" = 'true' ]; then
+    log "Skipping the pre-upgrade backup (--skip-backup)"
+  else
+    pre_upgrade_backup "$previous_version" "$backup_passphrase_arg"
+  fi
+
+  # Keep a copy of the current deployment files so a failed migration can put
+  # the previous release's configuration back exactly as it was. Deliberately
+  # not a local: the EXIT trap must still see it after bash unwinds function
+  # scope on a set -e failure in a nested call.
+  mkdir -p "$install_root/backups"
+  upgrade_rollback_dir="$(mktemp -d "$install_root/backups/.upgrade-staging.XXXXXX")"
+  chmod 700 "$upgrade_rollback_dir"
+  trap 'rm -rf "${upgrade_rollback_dir:-}"' EXIT
+  install -m 600 "$env_file" "$upgrade_rollback_dir/.env"
+  install -m 600 "$compose_file" "$upgrade_rollback_dir/docker-compose.prod.yml"
+  if [ -f "$install_root/caddy/Caddyfile" ]; then
+    install -m 600 "$install_root/caddy/Caddyfile" "$upgrade_rollback_dir/Caddyfile"
   fi
 
   image_registry="$(read_env_value IMAGE_REGISTRY)"
@@ -448,6 +545,11 @@ cmd_upgrade() {
   fetch_deploy_file "$repo" "$fetch_ref" deploy/caddy/Caddyfile "$install_root/caddy/Caddyfile"
 
   set_env_value ROOMOTE_VERSION "$version"
+  # Recorded for `roomote rollback`; skipped for same-version re-runs so a
+  # retry cannot overwrite the real rollback target with itself.
+  if [ -n "$previous_version" ] && [ "$previous_version" != "$version" ]; then
+    set_env_value ROOMOTE_PREVIOUS_VERSION "$previous_version"
+  fi
   set_env_value TRPC_URL "https://$app_domain/_roomote-api"
   set_env_value IMAGE_REGISTRY "$image_registry"
   set_env_value IMAGE_NAMESPACE "$image_namespace"
@@ -472,6 +574,22 @@ cmd_upgrade() {
   log "Pulling images for $version"
   docker pull "$worker_image"
   compose pull
+  # Migrations run before any running service is replaced. Drizzle applies
+  # all pending migrations in a single transaction, so a failure here rolls
+  # the schema back and the previous release keeps serving.
+  log "Applying database migrations for $version before replacing services"
+  if ! compose run --rm db-migrate; then
+    log "Migration failed; restoring the previous deployment configuration"
+    install -m 600 "$upgrade_rollback_dir/.env" "$env_file"
+    install -m 600 "$upgrade_rollback_dir/docker-compose.prod.yml" "$compose_file"
+    if [ -f "$upgrade_rollback_dir/Caddyfile" ]; then
+      install -m 600 "$upgrade_rollback_dir/Caddyfile" "$install_root/caddy/Caddyfile"
+    fi
+    compose start controller || true
+    die "database migrations for $version failed and were rolled back; the previous release${previous_version:+ ($previous_version)} is still running"
+  fi
+  rm -rf "$upgrade_rollback_dir"
+  trap - EXIT
   log "Starting Roomote $version"
   compose up -d --wait --wait-timeout 600
   systemctl enable roomote-compose.service >/dev/null 2>&1 || true
@@ -480,6 +598,19 @@ cmd_upgrade() {
     log "Warning: image retention failed; upgrade is still healthy"
   fi
   log "Upgrade to $version complete"
+}
+
+# Emergency path back to the release recorded by the last upgrade. Skips the
+# pre-upgrade backup on purpose: the bundle from the failed upgrade already
+# exists, and a backup against an unhealthy stack could block the rollback.
+cmd_rollback() {
+  local previous_version
+
+  [ "$#" -eq 0 ] || die "usage: roomote rollback"
+  previous_version="$(read_env_value ROOMOTE_PREVIOUS_VERSION)"
+  [ -n "$previous_version" ] || die "no previous release recorded in $env_file; run 'roomote upgrade <version>' with an explicit tag instead"
+  log "Rolling back to the previously deployed release $previous_version"
+  cmd_upgrade "$previous_version" --skip-backup
 }
 
 stop_task_workers() {
@@ -880,6 +1011,7 @@ case "$command" in
   logs) cmd_logs "$@" ;;
   setup-url) cmd_setup_url "$@" ;;
   upgrade) cmd_upgrade "$@" ;;
+  rollback) cmd_rollback "$@" ;;
   backup) cmd_backup "$@" ;;
   restore) cmd_restore "$@" ;;
   restart) compose restart "$@" ;;

--- a/deploy/scripts/upgrade.sh
+++ b/deploy/scripts/upgrade.sh
@@ -230,6 +230,16 @@ chmod 600 .env
 docker compose --env-file .env -f docker-compose.prod.yml config >/dev/null
 docker pull "$worker_image"
 docker compose --env-file .env -f docker-compose.prod.yml pull
+# Migrations run before any running service is replaced. Drizzle applies all
+# pending migrations in a single transaction, so a failure here rolls the
+# schema back while the previous release keeps serving.
+echo "Applying database migrations before replacing running services"
+if ! docker compose --env-file .env -f docker-compose.prod.yml run --rm db-migrate; then
+  echo "Database migrations failed and were rolled back; the previous release keeps serving." >&2
+  echo "Restarting the previous controller. Re-run roomote-deploy upgrade with the previous tag to restore deployment metadata, or fix the migration and retry." >&2
+  docker compose --env-file .env -f docker-compose.prod.yml start controller || true
+  exit 1
+fi
 docker compose --env-file .env -f docker-compose.prod.yml up -d --wait --wait-timeout 600
 systemctl enable roomote-compose.service
 REMOTE


### PR DESCRIPTION
Closes findings 10 and 4 of the pre-release architecture audit: the upgrade/migration compatibility contract is now written down, enforced by the upgrade tooling, and checked in CI before merge instead of only at publish time.

## 1. Upgrade and migration compatibility policy (docs)

New "Upgrade And Migration Compatibility Policy" section in `deploy/README.md`, with operator-facing summaries in `SELF_HOSTING.md` and `apps/docs/self-hosting.mdx`:

- **Expand/contract migration rules** — every migration must keep the previous release working; contractions ship at least one release after code stops referencing the old shape; long backfills stay out of migrations.
- **Minimum rollback-compatible version** — schema N supports application N-1; the supported rollback target is always the previous release, without undoing migrations.
- **Migration lock/timeout behavior** — one one-shot `db-migrate` container per deployment is the single writer; Drizzle applies all pending migrations in a single transaction (verified against `drizzle-orm` 0.45.2 source), so failures roll the schema back; the rollout is bounded by `up --wait --wait-timeout 600`; no advisory lock, so concurrent upgrades are documented as unsupported.
- **Failure behavior** — migrations run after pulls and before any running service is replaced, so a migration failure leaves the previous release serving.
- **Version visibility** — Settings → Deployment → Diagnostics already surfaces `Roomote version` (RELEASE_VERSION) and `Current migration` (Drizzle hash) from PR #75; the policy points at these plus the backup manifest's `roomoteVersion`/`schemaVersion` and the new `ROOMOTE_PREVIOUS_VERSION` env record. No code change was needed for this bullet.

## 2. Pre-upgrade backup and rollback path (`deploy/host/roomote`)

- `roomote upgrade` now creates an encrypted pre-upgrade bundle (same machinery as PR #111) before touching any deployment file. Passphrase precedence: `--backup-passphrase-file` → `ROOMOTE_BACKUP_PASSPHRASE` → generated and stored next to the bundle (same trust domain as `/opt/roomote/.env`, documented). `--skip-backup` opts out.
- Migrations now run as an explicit `compose run --rm db-migrate` gate after pulls and before `up`. On failure the CLI restores the saved `.env`/Compose/Caddyfile, restarts the previous controller, and exits with the previous release running.
- New `roomote rollback` re-deploys the release recorded in `ROOMOTE_PREVIOUS_VERSION` by the last upgrade (skips the backup by design so an unhealthy stack cannot block recovery).
- `deploy/scripts/upgrade.sh` (operator deployer) gets the same migrate-before-replace gate with a controller restart on failure, keeping the two upgrade tools' sequences aligned.
- Fixed in passing: the staging-dir EXIT trap uses a script-level variable because bash unwinds `local`s before running EXIT traps on `set -e` failures in nested calls (found while integration-testing the failure path; the same latent pattern exists in `cmd_backup`).

Verified with an ad-hoc fixture harness (modeled on `backup-restore.integration.sh`): pre-upgrade bundle created before any mutation; failed migration restores config, restarts the controller, and cleans staging; successful upgrade records the rollback target. The existing backup-restore integration test still passes.

## 3. Upgrade Compatibility CI lane (`deploy/ci/upgrade-compatibility.sh`)

New PR-time job in `CI.yml`, modeled on the backup-restore job: pulls the previous published release from GHCR (channel = PR base branch), boots the full stack with the production Compose file + CI overlay, verifies health and `/setup` endpoints, applies the candidate checkout's migrations via `db:migrate:standalone` (interchangeable with the image's runner — same journal), then requires the previous release to stay healthy on the candidate schema, including a cold restart (a rollback is a cold start of N-1 against schema N), with a data-preservation marker.

Ran locally end to end against the real `ghcr.io/roocodeinc` `develop` images: `Upgrade compatibility passed: develop stays healthy on the candidate schema`.

This complements rather than duplicates the publish gate (`deployment-acceptance` in `publish-ghcr.yml`, restored to blocking by #128): the PR lane catches migration-compatibility breaks before merge without building candidate images; the publish gate keeps covering the full upgrade → rollback → re-upgrade lifecycle with real candidate images.

## 4. Launch-task harness (audit finding: "not wired into CI")

Already wired: `deploy/ci/deployment-smoke.sh` runs `pnpm --filter @roomote/cloud-agents deployment:launch-docker-task` (`launch_docker_task`) inside the blocking `deployment-acceptance` publish gate, so every publish launches a real Docker task through the production controller. Wiring it into the PR-time lane as well would require building the candidate worker image on every PR; deliberately not duplicated here.

## 5. arm64

The PR-time `docker-build` job now builds both images for amd64 and arm64 on native runners (same runner class and no-QEMU rationale as the publish workflow), so arch-specific build breaks surface before merge instead of blocking the publish pipeline.

## Validation

- `bash -n` on all touched scripts (also enforced by `deployment:validate`, which now covers `upgrade-compatibility.sh` and the backup-restore test script)
- `pnpm deployment:validate`, `pnpm lint:fast`, `pnpm check-types:fast` — pass
- `pnpm knip` fails identically on a clean `origin/develop` checkout in this environment (unused-export findings in `packages/slack`/`packages/telemetry`) while develop CI is green at the same SHA, so it is environment-side and unrelated to this diff
- Integration: upgrade-flow fixture tests (A/B/C above), `backup-restore.integration.sh`, and a full local run of the new CI lane against GHCR `develop`
