### PR TITLE
[Chore] Run the deployment acceptance gate concurrently with image builds

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -192,9 +192,14 @@ jobs:
           CANDIDATE_VERSION: ${{ needs.prepare.outputs.version }}
         run: pnpm deployment:smoke
 
+  # Builds run concurrently with the acceptance gate: the gate builds its own
+  # local images for the smoke test, so nothing here depends on it. The gate
+  # instead blocks `publish` — builds only push untagged per-arch digests, and
+  # nothing is consumable until publish assembles the tagged manifests, so a
+  # failed gate still prevents any image from shipping.
   build:
     name: Build ${{ matrix.app }} (${{ matrix.arch }})
-    needs: [prepare, deployment-acceptance]
+    needs: prepare
     if: ${{ needs.prepare.outputs.docs_only != 'true' }}
     runs-on: ${{ matrix.runner }}
     permissions:
@@ -280,7 +285,7 @@ jobs:
 
   publish:
     name: Publish ${{ matrix.app }} manifest
-    needs: [prepare, build]
+    needs: [prepare, build, deployment-acceptance]
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

Merge-to-nightly latency is ~12 minutes plus per-branch queueing: the acceptance gate (~5 min) runs strictly before the build matrix (~5.5 min on the arm64 app critical path), even though the gate builds its own local images for the smoke test and consumes nothing from the build jobs.

## Change

- `build` no longer depends on `deployment-acceptance`; the two run concurrently.
- `publish` now depends on `[prepare, build, deployment-acceptance]`.

Protection is unchanged: build jobs only push untagged per-arch digests, and nothing is consumable until `publish` assembles the tagged manifests — which still cannot happen unless the gate passes. Expected wall clock drops to ~max(gate, builds) + manifests ≈ 7 minutes.

`docs_only` skip behavior is unchanged: when the gate is skipped, builds are also skipped by the same condition, so `publish` skips exactly as before.