### PR TITLE
[Feat] Record a death certificate when the OpenCode server exits unexpectedly

### DIFF
--- a/apps/worker/src/run-task/create-harness.ts
+++ b/apps/worker/src/run-task/create-harness.ts
@@ -14,8 +14,11 @@ import {
 } from '../commands/setup/setup-mcps';
 import type { HarnessLogger } from '../logging';
 
+import { captureWorkerException } from '../monitoring/sentry';
+
 import type { RunTaskCallbacks, RunTaskContext } from './types';
 import { buildHarnessCommandEnv } from './harnesses';
+import { createDiagnosticEventRecorder } from './diagnostic-events';
 import { ReconnectableHarness } from './reconnectable-harness';
 import { subscribeHarnessCallbacks } from './subscribe-harness-callbacks';
 
@@ -75,6 +78,11 @@ export async function createHarness({
       .catch(() => {});
   };
 
+  const diagnosticEvents = createDiagnosticEventRecorder({
+    runId: taskRun.id,
+    logger,
+  });
+
   const spawnHarness = async (options?: {
     initialSessionId?: string;
   }): Promise<{ harness: Harness; subprocess: ResultPromise }> => {
@@ -107,6 +115,34 @@ export async function createHarness({
     return await startOpenCodeServerHarness({
       ...commonOptions,
       developerInstructionsContent,
+      onUnexpectedExit: (certificate) => {
+        const summary = `OpenCode server exited unexpectedly (code=${
+          certificate.exitCode ?? 'none'
+        }, signal=${certificate.signal ?? 'none'}) after ${Math.round(
+          certificate.uptimeMs / 1000,
+        )}s`;
+
+        diagnosticEvents.record({
+          kind: 'opencode_unexpected_exit',
+          message: summary,
+          details: {
+            exitCode: certificate.exitCode,
+            signal: certificate.signal,
+            uptimeMs: certificate.uptimeMs,
+            memory: certificate.memory,
+            outputTail: certificate.outputTail,
+          },
+        });
+        captureWorkerException(new Error(summary), {
+          runId: taskRun.id,
+          taskId: taskRun.taskId ?? undefined,
+          component: 'createHarness',
+          stage: 'opencode_unexpected_exit',
+          exitCode: certificate.exitCode,
+          signal: certificate.signal,
+          uptimeMs: certificate.uptimeMs,
+        });
+      },
     });
   };
 

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/exit-certificate.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/exit-certificate.test.ts
@@ -1,0 +1,54 @@
+import { createOpenCodeExitCertificateCollector } from './exit-certificate';
+
+describe('createOpenCodeExitCertificateCollector', () => {
+  it('captures exit facts with the tagged output tail', () => {
+    const collector = createOpenCodeExitCertificateCollector();
+
+    collector.appendLine('stdout', 'server listening');
+    collector.appendLine('stderr', 'panic: something broke');
+
+    const certificate = collector.build({ exitCode: 137, signal: 'SIGKILL' });
+
+    expect(certificate.exitCode).toBe(137);
+    expect(certificate.signal).toBe('SIGKILL');
+    expect(certificate.uptimeMs).toBeGreaterThanOrEqual(0);
+    expect(certificate.outputTail).toEqual([
+      '[stdout] server listening',
+      '[stderr] panic: something broke',
+    ]);
+  });
+
+  it('keeps only the most recent lines and caps line length', () => {
+    const collector = createOpenCodeExitCertificateCollector();
+
+    for (let i = 0; i < 80; i += 1) {
+      collector.appendLine('stderr', `line ${i} ${'x'.repeat(400)}`);
+    }
+
+    const certificate = collector.build({ exitCode: 1, signal: null });
+
+    expect(certificate.outputTail).toHaveLength(50);
+    expect(certificate.outputTail[0]).toContain('line 30');
+    expect(certificate.outputTail[49]).toContain('line 79');
+    for (const line of certificate.outputTail) {
+      expect(line.length).toBeLessThanOrEqual(320);
+    }
+  });
+
+  it('skips blank lines and never fails on missing memory accounting', () => {
+    const collector = createOpenCodeExitCertificateCollector();
+
+    collector.appendLine('stdout', '   ');
+    collector.appendLine('stdout', '');
+
+    const certificate = collector.build({ exitCode: null, signal: 'SIGTERM' });
+
+    expect(certificate.outputTail).toEqual([]);
+    // /proc/meminfo may not exist on the test host; the snapshot is either a
+    // complete reading or null, never a throw.
+    if (certificate.memory !== null) {
+      expect(certificate.memory.memTotalKb).toBeGreaterThan(0);
+      expect(certificate.memory.workerRssBytes).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/exit-certificate.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/exit-certificate.ts
@@ -1,0 +1,88 @@
+import { readFileSync } from 'node:fs';
+
+// Death certificate for the OpenCode server subprocess. The sandbox and its
+// logs are gone by the time anyone investigates, so the facts that identify
+// the killer are collected while the process runs and handed to the caller
+// the moment it exits: exit code and signal (137 = killed for memory), the
+// last output lines, uptime, and a memory snapshot taken at the instant of
+// death. Collection is bounded: a fixed-size line ring with per-line caps, so
+// the cost per output line is constant regardless of how chatty the process
+// is.
+const MAX_TAIL_LINES = 50;
+const MAX_LINE_CHARS = 300;
+
+export interface OpenCodeExitCertificate {
+  exitCode: number | null;
+  signal: string | null;
+  uptimeMs: number;
+  outputTail: string[];
+  memory: {
+    memTotalKb: number;
+    memAvailableKb: number;
+    workerRssBytes: number;
+  } | null;
+}
+
+function readMemorySnapshot(): OpenCodeExitCertificate['memory'] {
+  try {
+    const meminfo = readFileSync('/proc/meminfo', 'utf8');
+    const readKb = (field: string): number | null => {
+      const match = meminfo.match(new RegExp(`^${field}:\\s+(\\d+) kB`, 'm'));
+      return match?.[1] ? Number.parseInt(match[1], 10) : null;
+    };
+    const memTotalKb = readKb('MemTotal');
+    const memAvailableKb = readKb('MemAvailable');
+
+    if (memTotalKb === null || memAvailableKb === null) {
+      return null;
+    }
+
+    return {
+      memTotalKb,
+      memAvailableKb,
+      workerRssBytes: process.memoryUsage().rss,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function createOpenCodeExitCertificateCollector(): {
+  appendLine(stream: 'stdout' | 'stderr', line: string): void;
+  build(input: {
+    exitCode: number | null;
+    signal: string | null;
+  }): OpenCodeExitCertificate;
+} {
+  const startedAtMs = Date.now();
+  const tail: string[] = [];
+
+  return {
+    appendLine(stream, line) {
+      const trimmed = line.trim();
+
+      if (!trimmed) {
+        return;
+      }
+
+      const capped =
+        trimmed.length > MAX_LINE_CHARS
+          ? `${trimmed.slice(0, MAX_LINE_CHARS)}…`
+          : trimmed;
+
+      tail.push(`[${stream}] ${capped}`);
+      if (tail.length > MAX_TAIL_LINES) {
+        tail.shift();
+      }
+    },
+    build(input) {
+      return {
+        exitCode: input.exitCode,
+        signal: input.signal,
+        uptimeMs: Date.now() - startedAtMs,
+        outputTail: [...tail],
+        memory: readMemorySnapshot(),
+      };
+    },
+  };
+}

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/start.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/start.ts
@@ -9,6 +9,10 @@ import { createPrefixedLogger, describeUnknownError } from '../logging';
 
 import { prepareOpenCodeCommandEnv } from './bootstrap';
 import { OpenCodeServerClient } from './client';
+import {
+  createOpenCodeExitCertificateCollector,
+  type OpenCodeExitCertificate,
+} from './exit-certificate';
 import { OpenCodeServerHarness } from './harness';
 
 interface StartOpenCodeServerHarnessOptions {
@@ -20,6 +24,12 @@ interface StartOpenCodeServerHarnessOptions {
   initialSessionId?: string;
   modelOverride?: string;
   developerInstructionsContent?: string;
+  /**
+   * Invoked when the OpenCode server subprocess exits while the task was not
+   * being cancelled — the death certificate for post-mortems. Observer-only:
+   * failures inside the callback must not affect the harness lifecycle.
+   */
+  onUnexpectedExit?: (certificate: OpenCodeExitCertificate) => void;
   beforeQueuedPrompt?: (input: { userId?: string }) => Promise<void | {
     shouldReconnect: boolean;
     shouldBlockPrompt?: boolean;
@@ -110,6 +120,7 @@ function waitForOpenCodeServerUrl(options: {
   stderr: NodeJS.ReadableStream;
   logger: HarnessLogger;
   timeoutMs: number;
+  onLine?: (stream: 'stdout' | 'stderr', line: string) => void;
 }): Promise<string> {
   const log = createPrefixedLogger(options.logger, '[opencode-server]');
   const stdoutLog = createPrefixedLogger(
@@ -169,6 +180,7 @@ function waitForOpenCodeServerUrl(options: {
         stdoutLog.info(line);
       }
 
+      options.onLine?.('stdout', line);
       maybeResolve('stdout', line);
     };
 
@@ -177,6 +189,7 @@ function waitForOpenCodeServerUrl(options: {
         stderrLog.info(line);
       }
 
+      options.onLine?.('stderr', line);
       maybeResolve('stderr', line);
     };
 
@@ -194,6 +207,7 @@ export async function startOpenCodeServerHarness({
   initialSessionId,
   modelOverride,
   developerInstructionsContent,
+  onUnexpectedExit,
   beforeQueuedPrompt,
 }: StartOpenCodeServerHarnessOptions): Promise<StartOpenCodeServerHarnessResult> {
   const log = createPrefixedLogger(logger, '[opencode-server]');
@@ -224,6 +238,7 @@ export async function startOpenCodeServerHarness({
   );
 
   let subprocess: ResultPromise | null = null;
+  const exitCertificate = createOpenCodeExitCertificateCollector();
 
   try {
     subprocess = execa(resolved.command, resolved.args, {
@@ -237,6 +252,49 @@ export async function startOpenCodeServerHarness({
     if (!subprocess.stdout || !subprocess.stderr) {
       throw new Error(
         'OpenCode server subprocess is missing stdout or stderr.',
+      );
+    }
+
+    if (onUnexpectedExit) {
+      const certifyExit = (input: {
+        exitCode: number | null;
+        signal: string | null;
+      }) => {
+        if (cancelSignal.aborted) {
+          return;
+        }
+
+        try {
+          onUnexpectedExit(exitCertificate.build(input));
+        } catch (error) {
+          log.warn(
+            `Failed to report unexpected OpenCode server exit: ${describeUnknownError(error)}`,
+          );
+        }
+      };
+
+      void subprocess.then(
+        (result) =>
+          certifyExit({
+            exitCode: result.exitCode ?? null,
+            signal: result.signal ?? null,
+          }),
+        (error: unknown) => {
+          const execaError = error as {
+            exitCode?: number;
+            signal?: string;
+            isCanceled?: boolean;
+          };
+
+          if (execaError?.isCanceled) {
+            return;
+          }
+
+          certifyExit({
+            exitCode: execaError?.exitCode ?? null,
+            signal: execaError?.signal ?? null,
+          });
+        },
       );
     }
 
@@ -255,6 +313,7 @@ export async function startOpenCodeServerHarness({
         stderr: subprocess.stderr,
         logger,
         timeoutMs: 30_000,
+        onLine: (stream, line) => exitCertificate.appendLine(stream, line),
       }),
       subprocess.then(
         () => {


### PR DESCRIPTION
PR 2 of the observability pair — #140 (the diagnostic rail) is merged; this is the first producer on it. Replaces #141, which GitHub auto-closed when the stacked base branch was deleted.

## What
The worker keeps a bounded ring (last 50 lines, 300 chars each) of the OpenCode subprocess's output while it runs. If the process exits while the task is **not** being cancelled, it records one durable `opencode_unexpected_exit` diagnostic event: exit code, signal, uptime, output tail, and a `/proc/meminfo` + worker-RSS snapshot taken at the instant of death — plus a Sentry capture so we get alerted. Reconnect-spawned processes are certified individually.

This is the fact that decides the open mystery: exit 137 = killed for memory (the 128 MiB request theory), a panic stack = OpenCode bug, clean exit = something else. The last two investigations couldn't make that distinction because the evidence died with the sandbox.

## Guarantees (per the requirements)
- **Performance:** constant cost per output line (ring append with caps); certification work happens only on unexpected exits.
- **Behavior:** observer-only. The exit hook cannot alter the harness lifecycle — cancellation-driven exits are excluded, callback failures are caught and logged, reconnect behavior is untouched.
- **Privacy:** the output tail flows through the rail's secret scrubbing (keys, bearer tokens, JWTs, credential assignments) and per-line/message caps before persisting; memory snapshot is numbers only.

## Tests
Collector: exit facts + tagged tail, ring/line caps, blank-line and missing-`/proc` safety. Full harnesses + run-task suites: **423 tests pass**; typecheck / eslint / prettier / knip clean.

Not auto-merged — ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
