### PR TITLE
[Fix] Address review findings on the diagnostic rail and death certificate

### DIFF
--- a/apps/web/src/trpc/commands/tasks/run-events.ts
+++ b/apps/web/src/trpc/commands/tasks/run-events.ts
@@ -1,4 +1,4 @@
-import { asc, db, eq, taskRunEvents } from '@roomote/db/server';
+import { db, desc, eq, taskRunEvents } from '@roomote/db/server';
 
 const MAX_RUN_EVENTS = 500;
 
@@ -20,8 +20,11 @@ export async function getTaskRunEventsCommand(input: { taskId: string }) {
     })
     .from(taskRunEvents)
     .where(eq(taskRunEvents.taskId, input.taskId))
-    .orderBy(asc(taskRunEvents.createdAt))
+    // Newest first under the limit: diagnostics cluster at the end of a run,
+    // and a busy task must never push them out of the window. Reversed after
+    // the query so callers still get chronological order.
+    .orderBy(desc(taskRunEvents.createdAt))
     .limit(MAX_RUN_EVENTS);
 
-  return { events };
+  return { events: events.reverse() };
 }

--- a/apps/worker/src/run-task/__tests__/diagnostic-events.test.ts
+++ b/apps/worker/src/run-task/__tests__/diagnostic-events.test.ts
@@ -51,6 +51,14 @@ describe('redactSecrets', () => {
     expect(output).toContain('api_key: [redacted]');
   });
 
+  it('keeps an identifying prefix on hash-shaped values', () => {
+    const sha = 'a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0';
+    const output = redactSecrets(`checked out commit ${sha}`);
+
+    expect(output).toContain('a1b2c3d4…[redacted]');
+    expect(output).not.toContain(sha);
+  });
+
   it('leaves ordinary log text alone', () => {
     const text =
       'OpenCode server exited with code 137 after 512s; last request POST /session/prompt';
@@ -96,6 +104,24 @@ describe('createDiagnosticEventRecorder', () => {
     expect(call.details.exitCode).toBe(137);
     expect((call.details.stderrTail as string).length).toBeLessThan(4_100);
     expect(call.details.stderrTail as string).toContain('[truncated]');
+  });
+
+  it('does not let caller details override the recorder kind', () => {
+    const recorder = createDiagnosticEventRecorder({
+      runId: 7,
+      logger: createLogger(),
+    });
+
+    recorder.record({
+      kind: 'harness_exit',
+      message: 'ok',
+      details: { kind: 'spoofed' },
+    });
+
+    const call = mockRecordEvent.mock.calls[0]?.[0] as {
+      details: Record<string, unknown>;
+    };
+    expect(call.details.kind).toBe('harness_exit');
   });
 
   it('never throws when persistence fails', async () => {

--- a/apps/worker/src/run-task/create-harness.ts
+++ b/apps/worker/src/run-task/create-harness.ts
@@ -129,7 +129,7 @@ export async function createHarness({
             exitCode: certificate.exitCode,
             signal: certificate.signal,
             uptimeMs: certificate.uptimeMs,
-            memory: certificate.memory,
+            memoryAfterExit: certificate.memoryAfterExit,
             outputTail: certificate.outputTail,
           },
         });

--- a/apps/worker/src/run-task/diagnostic-events.ts
+++ b/apps/worker/src/run-task/diagnostic-events.ts
@@ -20,12 +20,18 @@ const SECRET_PATTERNS: RegExp[] = [
   /\bBearer\s+[A-Za-z0-9._~+/-]{8,}=*/gi,
   // JWTs.
   /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{5,}/g,
-  // Long opaque hex/base64 runs (token-shaped strings).
-  /\b[A-Fa-f0-9]{40,}\b/g,
-  /\b[A-Za-z0-9+/]{48,}={0,2}\b/g,
   // key=value / key: value assignments for credential-ish names, including
   // prefixed forms like DATABASE_PASSWORD or GITHUB_TOKEN.
   /([\w-]*(?:token|secret|password|passwd|api[_-]?key|authorization))(\s*[:=]\s*)\S+/gi,
+];
+
+// Long opaque hex/base64 runs are token-shaped, but they are also what git
+// SHAs and content digests look like — post-mortem evidence this rail exists
+// to preserve. These keep an 8-character prefix: enough to identify a commit
+// or digest, far too little to reconstruct a credential.
+const HASH_SHAPED_PATTERNS: RegExp[] = [
+  /\b[A-Fa-f0-9]{40,}\b/g,
+  /\b[A-Za-z0-9+/]{48,}={0,2}\b/g,
 ];
 
 export function redactSecrets(text: string): string {
@@ -40,6 +46,13 @@ export function redactSecrets(text: string): string {
 
       return '[redacted]';
     });
+  }
+
+  for (const pattern of HASH_SHAPED_PATTERNS) {
+    redacted = redacted.replace(
+      pattern,
+      (match) => `${match.slice(0, 8)}…[redacted]`,
+    );
   }
 
   return redacted;
@@ -101,11 +114,13 @@ export function createDiagnosticEventRecorder(options: {
     record(input) {
       try {
         const details = {
-          kind: input.kind,
           ...(sanitizeDetailValue(input.details ?? {}, 0) as Record<
             string,
             unknown
           >),
+          // Last so a caller-supplied details.kind can never override the
+          // recorder's classification.
+          kind: input.kind,
         };
 
         void sdk.taskRuns

--- a/apps/worker/src/run-task/reconnectable-harness.ts
+++ b/apps/worker/src/run-task/reconnectable-harness.ts
@@ -15,7 +15,7 @@ import {
 } from '@roomote/types';
 
 import type { Harness } from '../sandbox-server';
-import { markExpectedSubprocessExit } from '../sandbox-server/lib/harnesses/opencode-server/expected-exit';
+import { markExpectedSubprocessExitIfAlive } from '../sandbox-server/lib/harnesses/opencode-server/expected-exit';
 import type {
   HarnessEvents,
   HarnessInferenceUsageEvent,
@@ -450,7 +450,9 @@ export class ReconnectableHarness
     }
 
     try {
-      markExpectedSubprocessExit(subprocess);
+      // A live process killed here is deliberate teardown; one that already
+      // exited died on its own and keeps its death certificate.
+      markExpectedSubprocessExitIfAlive(subprocess);
       const terminated = subprocess.kill('SIGTERM');
       this.logger.info(
         `[ReconnectableHarness] Terminated subprocess during ${reason} sentSignal=${terminated}`,

--- a/apps/worker/src/run-task/reconnectable-harness.ts
+++ b/apps/worker/src/run-task/reconnectable-harness.ts
@@ -15,6 +15,7 @@ import {
 } from '@roomote/types';
 
 import type { Harness } from '../sandbox-server';
+import { markExpectedSubprocessExit } from '../sandbox-server/lib/harnesses/opencode-server/expected-exit';
 import type {
   HarnessEvents,
   HarnessInferenceUsageEvent,
@@ -449,6 +450,7 @@ export class ReconnectableHarness
     }
 
     try {
+      markExpectedSubprocessExit(subprocess);
       const terminated = subprocess.kill('SIGTERM');
       this.logger.info(
         `[ReconnectableHarness] Terminated subprocess during ${reason} sentSignal=${terminated}`,

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/exit-certificate.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/exit-certificate.test.ts
@@ -46,9 +46,9 @@ describe('createOpenCodeExitCertificateCollector', () => {
     expect(certificate.outputTail).toEqual([]);
     // /proc/meminfo may not exist on the test host; the snapshot is either a
     // complete reading or null, never a throw.
-    if (certificate.memory !== null) {
-      expect(certificate.memory.memTotalKb).toBeGreaterThan(0);
-      expect(certificate.memory.workerRssBytes).toBeGreaterThan(0);
+    if (certificate.memoryAfterExit !== null) {
+      expect(certificate.memoryAfterExit.memTotalKb).toBeGreaterThan(0);
+      expect(certificate.memoryAfterExit.workerRssBytes).toBeGreaterThan(0);
     }
   });
 });

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/exit-certificate.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/exit-certificate.ts
@@ -4,10 +4,10 @@ import { readFileSync } from 'node:fs';
 // logs are gone by the time anyone investigates, so the facts that identify
 // the killer are collected while the process runs and handed to the caller
 // the moment it exits: exit code and signal (137 = killed for memory), the
-// last output lines, uptime, and a memory snapshot taken at the instant of
-// death. Collection is bounded: a fixed-size line ring with per-line caps, so
-// the cost per output line is constant regardless of how chatty the process
-// is.
+// last output lines, uptime, and a sandbox memory reading taken just after
+// the exit. Collection is bounded: a fixed-size line ring with per-line caps,
+// so the cost per output line is constant regardless of how chatty the
+// process is.
 const MAX_TAIL_LINES = 50;
 const MAX_LINE_CHARS = 300;
 
@@ -16,14 +16,18 @@ export interface OpenCodeExitCertificate {
   signal: string | null;
   uptimeMs: number;
   outputTail: string[];
-  memory: {
+  // Sandbox-wide memory observed just after the exit — by then the kernel has
+  // reclaimed the dead process's pages, so an OOM kill can already look
+  // recovered here; the exit code/signal is the authoritative OOM signal.
+  // workerRssBytes is the surviving sandbox-server process, not the victim.
+  memoryAfterExit: {
     memTotalKb: number;
     memAvailableKb: number;
     workerRssBytes: number;
   } | null;
 }
 
-function readMemorySnapshot(): OpenCodeExitCertificate['memory'] {
+function readMemorySnapshot(): OpenCodeExitCertificate['memoryAfterExit'] {
   try {
     const meminfo = readFileSync('/proc/meminfo', 'utf8');
     const readKb = (field: string): number | null => {
@@ -81,7 +85,7 @@ export function createOpenCodeExitCertificateCollector(): {
         signal: input.signal,
         uptimeMs: Date.now() - startedAtMs,
         outputTail: [...tail],
-        memory: readMemorySnapshot(),
+        memoryAfterExit: readMemorySnapshot(),
       };
     },
   };

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/expected-exit.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/expected-exit.test.ts
@@ -1,0 +1,30 @@
+import {
+  isExpectedSubprocessExit,
+  markExpectedSubprocessExitIfAlive,
+} from './expected-exit';
+
+describe('markExpectedSubprocessExitIfAlive', () => {
+  it('marks a live subprocess as an expected exit', () => {
+    const subprocess = { exitCode: null, killed: false };
+
+    expect(markExpectedSubprocessExitIfAlive(subprocess)).toBe(true);
+    expect(isExpectedSubprocessExit(subprocess)).toBe(true);
+  });
+
+  it('does not mark a subprocess that already exited on its own', () => {
+    // A crash surfaces as a disconnect first, and the disconnect cleanup then
+    // kills the (already dead) process. That teardown must not suppress the
+    // crash's death certificate.
+    const crashed = { exitCode: 137, killed: false };
+
+    expect(markExpectedSubprocessExitIfAlive(crashed)).toBe(false);
+    expect(isExpectedSubprocessExit(crashed)).toBe(false);
+  });
+
+  it('does not mark a subprocess that was already signalled', () => {
+    const signalled = { exitCode: null, killed: true };
+
+    expect(markExpectedSubprocessExitIfAlive(signalled)).toBe(false);
+    expect(isExpectedSubprocessExit(signalled)).toBe(false);
+  });
+});

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/expected-exit.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/expected-exit.ts
@@ -5,8 +5,22 @@
 // certification checks the mark before recording anything.
 const expectedExits = new WeakSet<object>();
 
-export function markExpectedSubprocessExit(subprocess: object): void {
+/**
+ * Marks the subprocess as deliberately terminated — but only while it is
+ * still alive. A process that already exited died on its own: the teardown
+ * that follows a crash-induced disconnect must not retroactively suppress
+ * the very certificate the crash should produce.
+ */
+export function markExpectedSubprocessExitIfAlive(subprocess: {
+  exitCode: number | null;
+  killed: boolean;
+}): boolean {
+  if (subprocess.exitCode !== null || subprocess.killed) {
+    return false;
+  }
+
   expectedExits.add(subprocess);
+  return true;
 }
 
 export function isExpectedSubprocessExit(subprocess: object): boolean {

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/expected-exit.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/expected-exit.ts
@@ -1,0 +1,14 @@
+// Deliberate subprocess terminations (reconnects, restarts, teardown) must
+// not be certified as unexpected exits: they would pollute the death-
+// certificate signal and page Sentry on every routine restart. Callers that
+// kill an OpenCode subprocess on purpose mark it here first; the exit
+// certification checks the mark before recording anything.
+const expectedExits = new WeakSet<object>();
+
+export function markExpectedSubprocessExit(subprocess: object): void {
+  expectedExits.add(subprocess);
+}
+
+export function isExpectedSubprocessExit(subprocess: object): boolean {
+  return expectedExits.has(subprocess);
+}

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/start.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/start.ts
@@ -13,6 +13,7 @@ import {
   createOpenCodeExitCertificateCollector,
   type OpenCodeExitCertificate,
 } from './exit-certificate';
+import { isExpectedSubprocessExit } from './expected-exit';
 import { OpenCodeServerHarness } from './harness';
 
 interface StartOpenCodeServerHarnessOptions {
@@ -120,7 +121,6 @@ function waitForOpenCodeServerUrl(options: {
   stderr: NodeJS.ReadableStream;
   logger: HarnessLogger;
   timeoutMs: number;
-  onLine?: (stream: 'stdout' | 'stderr', line: string) => void;
 }): Promise<string> {
   const log = createPrefixedLogger(options.logger, '[opencode-server]');
   const stdoutLog = createPrefixedLogger(
@@ -180,7 +180,6 @@ function waitForOpenCodeServerUrl(options: {
         stdoutLog.info(line);
       }
 
-      options.onLine?.('stdout', line);
       maybeResolve('stdout', line);
     };
 
@@ -189,7 +188,6 @@ function waitForOpenCodeServerUrl(options: {
         stderrLog.info(line);
       }
 
-      options.onLine?.('stderr', line);
       maybeResolve('stderr', line);
     };
 
@@ -256,11 +254,33 @@ export async function startOpenCodeServerHarness({
     }
 
     if (onUnexpectedExit) {
+      // The certificate needs the process's last words, not its first: these
+      // readers stay attached for the whole subprocess lifetime, independent
+      // of the startup URL wait and its listener lifecycle.
+      const stdoutTailReader = readline.createInterface({
+        input: subprocess.stdout,
+        crlfDelay: Infinity,
+      });
+      const stderrTailReader = readline.createInterface({
+        input: subprocess.stderr,
+        crlfDelay: Infinity,
+      });
+      stdoutTailReader.on('line', (line) =>
+        exitCertificate.appendLine('stdout', line),
+      );
+      stderrTailReader.on('line', (line) =>
+        exitCertificate.appendLine('stderr', line),
+      );
+
+      const spawnedSubprocess = subprocess;
       const certifyExit = (input: {
         exitCode: number | null;
         signal: string | null;
       }) => {
-        if (cancelSignal.aborted) {
+        if (
+          cancelSignal.aborted ||
+          isExpectedSubprocessExit(spawnedSubprocess)
+        ) {
           return;
         }
 
@@ -313,7 +333,6 @@ export async function startOpenCodeServerHarness({
         stderr: subprocess.stderr,
         logger,
         timeoutMs: 30_000,
-        onLine: (stream, line) => exitCertificate.appendLine(stream, line),
       }),
       subprocess.then(
         () => {


### PR DESCRIPTION
Follow-up addressing all outstanding openmote review findings on #140 and #145 (merged before the reviews were read — my miss).

| Finding | Fix |
| --- | --- |
| 🔴 #141/#145-1: deliberate reconnects/restarts certified as unexpected exits + Sentry alert on every routine reconnect | `terminateSubprocess` marks the subprocess (WeakSet) before killing; certification skips marked exits. All deliberate teardown paths funnel through that one method. |
| 🟡 #141-2: death tail silently depended on the URL-wait never detaching its line listeners | Dedicated lifetime readers feed the ring; the `onLine` coupling is removed. |
| 🟡 #140-1: reader returned the *oldest* 500 events, dropping end-of-run diagnostics on busy tasks | Query descending with the limit, reverse to chronological before returning. |
| 🟢 #140-2: caller `details.kind` could override the recorder's classification | `kind` is applied last. |
| 🟢 #140-3: 40-hex git SHAs / digests fully redacted, blunting post-mortem value | Hash-shaped values keep an 8-char identifying prefix (`a1b2c3d4…[redacted]`); real key formats (sk-/ghp_/JWT/assignments) remain fully redacted. |
| 🟢 #145-2: "memory at the instant of death" overstated what's captured | Renamed to `memoryAfterExit` with honest docs: sandbox-wide reading after reclaim, worker RSS is the witness; exit code/signal is the authoritative OOM signal. |

## Tests
Two new (hash-prefix redaction, kind-override guard); full run-task + harnesses suites: **425 pass**; typecheck (worker+web) / eslint / prettier / knip clean.

Waiting for bot review + Dan before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)