### PR TITLE
[Fix] Link GitHub account 404s when app credentials are stored in deployment env vars

### DIFF
--- a/apps/web/src/trpc/commands/github/mutations.test.ts
+++ b/apps/web/src/trpc/commands/github/mutations.test.ts
@@ -69,6 +69,7 @@ vi.stubGlobal('fetch', mockFetch);
 
 import {
   finishCreateGitHubAppManifestCommand,
+  startAuthenticateGitHubAccountCommand,
   startCreateGitHubInstallationCommand,
   startCreateGitHubAppManifestCommand,
 } from './mutations';
@@ -432,5 +433,54 @@ describe('GitHub App manifest commands', () => {
     });
     expect(mockDbTransaction).not.toHaveBeenCalled();
     expect(mockUpsertDeploymentEnvironmentVariables).not.toHaveBeenCalled();
+  });
+});
+
+describe('startAuthenticateGitHubAccountCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('builds the authorize URL from the deployment-resolved client id', async () => {
+    mockResolveDeploymentEnvVar.mockImplementation(async (name: string) =>
+      name === 'GITHUB_CLIENT_ID' ? 'Iv1.resolved-client' : null,
+    );
+
+    const result = await startAuthenticateGitHubAccountCommand(
+      buildMockAuth(),
+      { redirect: '/settings?tab=account' },
+    );
+
+    expect(result.success).toBe(true);
+
+    if (!result.success) {
+      return;
+    }
+
+    const url = new URL(result.url);
+    expect(`${url.origin}${url.pathname}`).toBe(
+      'https://github.com/login/oauth/authorize',
+    );
+    expect(url.searchParams.get('client_id')).toBe('Iv1.resolved-client');
+    expect(url.searchParams.get('scope')).toBe('read:user');
+    expect(url.searchParams.get('redirect_uri')).toBe(
+      'https://roomote.example.com/github/callback',
+    );
+    expect(decodeRecord(url.searchParams.get('state') ?? '')).toEqual({
+      redirect: '/settings?tab=account',
+      mode: 'auth',
+    });
+  });
+
+  it('refuses to link an account when no GitHub App client id is configured', async () => {
+    mockResolveDeploymentEnvVar.mockResolvedValue(null);
+
+    const result = await startAuthenticateGitHubAccountCommand(buildMockAuth());
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        'Configure a GitHub App for this deployment before linking your GitHub account. Create one or enter its credentials first.',
+    });
   });
 });

--- a/apps/web/src/trpc/commands/github/mutations.ts
+++ b/apps/web/src/trpc/commands/github/mutations.ts
@@ -343,9 +343,26 @@ async function getGitHubOAuthUser({
     }
   | { success: false; error: string }
 > {
+  const [clientId, clientSecret] = await Promise.all([
+    resolveDeploymentEnvVar('GITHUB_CLIENT_ID'),
+    resolveDeploymentEnvVar('GITHUB_CLIENT_SECRET'),
+  ]);
+
+  if (!clientId || !clientSecret) {
+    console.error(
+      `[${context}] GitHub App OAuth credentials are not configured.`,
+    );
+
+    return {
+      success: false,
+      error:
+        'GitHub App OAuth credentials are not configured for this deployment.',
+    };
+  }
+
   const params = new URLSearchParams({
-    client_id: Env.GITHUB_CLIENT_ID,
-    client_secret: Env.GITHUB_CLIENT_SECRET,
+    client_id: clientId,
+    client_secret: clientSecret,
     code,
   });
 
@@ -778,9 +795,19 @@ export async function startAuthenticateGitHubAccountCommand(
   state?: Record<string, string>,
 ): Promise<{ success: true; url: string } | { success: false; error: string }> {
   try {
+    const clientId = await resolveDeploymentEnvVar('GITHUB_CLIENT_ID');
+
+    if (!clientId) {
+      return {
+        success: false,
+        error:
+          'Configure a GitHub App for this deployment before linking your GitHub account. Create one or enter its credentials first.',
+      };
+    }
+
     const baseUrl = Env.ROOMOTE_APP_URL;
     const params = new URLSearchParams({
-      client_id: Env.GITHUB_CLIENT_ID,
+      client_id: clientId,
       scope: 'read:user',
       state: encodeRecord({ ...(state ?? {}), mode: 'auth' }),
     });


### PR DESCRIPTION
## Problem

Clicking **Link GitHub** (Settings → Linked accounts, onboarding, home onboarding card) redirected to `github.com/login/oauth/authorize?client_id=&...`, which GitHub 404s.

`startAuthenticateGitHubAccountCommand` built the authorize URL from `Env.GITHUB_CLIENT_ID`, which only reads process env and defaults to an empty string. Deployments that created their GitHub App through the in-product manifest flow store credentials encrypted in the `environment_variables` table, so the client id was empty at URL-build time.

`getGitHubOAuthUser` (the callback's code→token exchange, shared with OAuth-on-install linking) read both `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` the same way, so the callback would have failed even with a correct URL.

## Fix

- Resolve the client id via `resolveDeploymentEnvVar` (process env first, then DB-stored deployment credentials), matching the rest of the GitHub commands.
- When no client id is configured, return a clear error ("Configure a GitHub App for this deployment before linking your GitHub account...") instead of emitting a broken URL. The settings UI already toasts `result.error`.
- Same treatment for the client id + secret in `getGitHubOAuthUser`.

## Testing

- New unit tests: authorize URL built from the deployment-resolved client id; unconfigured deployments get the error result instead of a URL.
- All 11 tests in `mutations.test.ts` pass; typecheck, Prettier, ESLint clean.
- Verified at runtime against a dev deployment configured via the manifest flow (no `GITHUB_CLIENT_ID` in process env): the credentials now resolve from the DB and the link flow reaches GitHub's authorize page.