### PR TITLE
[Feat] Record harness reconnect lifecycle as diagnostic breadcrumbs

### DIFF
--- a/apps/worker/src/run-task/__tests__/reconnectable-harness.test.ts
+++ b/apps/worker/src/run-task/__tests__/reconnectable-harness.test.ts
@@ -900,4 +900,96 @@ describe('ReconnectableHarness', () => {
       }),
     ]);
   });
+
+  describe('diagnostic breadcrumbs', () => {
+    it('records disconnect and reconnect breadcrumbs', async () => {
+      const harnesses = [new FakeHarness(), new FakeHarness()];
+      const record = vi.fn();
+      const reconnectableHarness = new ReconnectableHarness({
+        logger: createLogger(),
+        spawnHarness: async () => ({
+          harness: harnesses.shift()!,
+          subprocess: createSubprocess() as never,
+        }),
+        diagnosticEvents: { record },
+      });
+      const first = harnesses[0]!;
+
+      await reconnectableHarness.start();
+      first.emit('disconnected');
+
+      await vi.waitFor(() => {
+        expect(record).toHaveBeenCalledWith(
+          expect.objectContaining({ kind: 'harness_reconnected' }),
+        );
+      });
+      expect(record).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'harness_disconnected' }),
+      );
+
+      reconnectableHarness.dispose();
+    });
+
+    it('records exhaustion when reconnecting gives up', async () => {
+      const first = new FakeHarness();
+      let spawnedOnce = false;
+      const record = vi.fn();
+      const reconnectableHarness = new ReconnectableHarness({
+        logger: createLogger(),
+        maxReconnectAttempts: 1,
+        spawnHarness: async () => {
+          if (!spawnedOnce) {
+            spawnedOnce = true;
+            return { harness: first, subprocess: createSubprocess() as never };
+          }
+          throw new Error('spawn failed');
+        },
+        diagnosticEvents: { record },
+      });
+
+      await reconnectableHarness.start();
+      first.emit('disconnected');
+
+      await vi.waitFor(() => {
+        expect(record).toHaveBeenCalledWith(
+          expect.objectContaining({
+            kind: 'harness_reconnect_exhausted',
+            details: expect.objectContaining({ maxAttempts: 1 }),
+          }),
+        );
+      });
+
+      reconnectableHarness.dispose();
+    });
+
+    it('records external reconnect requests with their reason', async () => {
+      const harnesses = [new FakeHarness(), new FakeHarness()];
+      const record = vi.fn();
+      const reconnectableHarness = new ReconnectableHarness({
+        logger: createLogger(),
+        spawnHarness: async () => ({
+          harness: harnesses.shift()!,
+          subprocess: createSubprocess() as never,
+        }),
+        diagnosticEvents: { record },
+      });
+
+      await reconnectableHarness.start();
+      await reconnectableHarness.requestReconnect({
+        reason: 'environment variables updated',
+      });
+
+      expect(record).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'harness_restart_requested',
+          details: expect.objectContaining({
+            source: 'external',
+            reason: 'environment variables updated',
+          }),
+        }),
+      );
+
+      reconnectableHarness.dispose();
+    });
+  });
 });

--- a/apps/worker/src/run-task/create-harness.ts
+++ b/apps/worker/src/run-task/create-harness.ts
@@ -149,6 +149,7 @@ export async function createHarness({
   const reconnectableHarness = new ReconnectableHarness({
     logger,
     spawnHarness,
+    diagnosticEvents,
   });
   await reconnectableHarness.start({ initialSessionId: harnessSessionId });
   stampHarnessStarted();

--- a/apps/worker/src/run-task/diagnostic-events.ts
+++ b/apps/worker/src/run-task/diagnostic-events.ts
@@ -98,7 +98,7 @@ function sanitizeDetailValue(value: unknown, depth: number): unknown {
   return String(value);
 }
 
-interface DiagnosticEventRecorder {
+export interface DiagnosticEventRecorder {
   record(input: {
     kind: string;
     message: string;

--- a/apps/worker/src/run-task/reconnectable-harness.ts
+++ b/apps/worker/src/run-task/reconnectable-harness.ts
@@ -16,6 +16,7 @@ import {
 
 import type { Harness } from '../sandbox-server';
 import { markExpectedSubprocessExitIfAlive } from '../sandbox-server/lib/harnesses/opencode-server/expected-exit';
+import type { DiagnosticEventRecorder } from './diagnostic-events';
 import type {
   HarnessEvents,
   HarnessInferenceUsageEvent,
@@ -44,6 +45,8 @@ interface ReconnectableHarnessConfig {
     initialSessionId?: string;
   }) => Promise<SpawnHarnessResult>;
   maxReconnectAttempts?: number;
+  /** Durable breadcrumbs for harness lifecycle transitions; observer-only. */
+  diagnosticEvents?: DiagnosticEventRecorder;
 }
 
 interface BoundHarnessListeners {
@@ -109,6 +112,7 @@ export class ReconnectableHarness
   private readonly logger: HarnessLogger;
   private readonly spawnHarness: ReconnectableHarnessConfig['spawnHarness'];
   private readonly maxReconnectAttempts: number;
+  private readonly diagnosticEvents: DiagnosticEventRecorder | undefined;
 
   private currentHarness: Harness | null = null;
   private currentSubprocess: ResultPromise | null = null;
@@ -130,6 +134,7 @@ export class ReconnectableHarness
     this.spawnHarness = config.spawnHarness;
     this.maxReconnectAttempts =
       config.maxReconnectAttempts ?? DEFAULT_MAX_RECONNECT_ATTEMPTS;
+    this.diagnosticEvents = config.diagnosticEvents;
   }
 
   async start(options?: { initialSessionId?: string }): Promise<void> {
@@ -270,6 +275,16 @@ export class ReconnectableHarness
     this.logger.info(
       `[ReconnectableHarness] External reconnect requested: ${options.reason} (sessionId=${this.latestSessionId ?? 'none'}, afterCurrentTurn=${options.afterCurrentTurn === true})`,
     );
+    this.diagnosticEvents?.record({
+      kind: 'harness_restart_requested',
+      message: `External reconnect requested: ${options.reason}`,
+      details: {
+        source: 'external',
+        reason: options.reason,
+        sessionId: this.latestSessionId ?? null,
+        afterCurrentTurn: options.afterCurrentTurn === true,
+      },
+    });
 
     if (!this.currentHarness) {
       if (options.replayCommands?.length) {
@@ -329,6 +344,11 @@ export class ReconnectableHarness
         this.logger.warn(
           `[ReconnectableHarness] Underlying harness disconnected; attempting reconnect (sessionId=${this.latestSessionId ?? 'none'})`,
         );
+        this.diagnosticEvents?.record({
+          kind: 'harness_disconnected',
+          message: 'Underlying harness disconnected; attempting reconnect',
+          details: { sessionId: this.latestSessionId ?? null },
+        });
 
         this.captureReconnectQueuedMessages(harness);
         const subprocess = this.currentSubprocess;
@@ -344,6 +364,15 @@ export class ReconnectableHarness
         this.logger.warn(
           `[ReconnectableHarness] Underlying harness requested restart: ${request.reason} (sessionId=${request.sessionId ?? this.latestSessionId ?? 'none'})`,
         );
+        this.diagnosticEvents?.record({
+          kind: 'harness_restart_requested',
+          message: `Harness requested restart: ${request.reason}`,
+          details: {
+            source: 'harness',
+            reason: request.reason,
+            sessionId: request.sessionId ?? this.latestSessionId ?? null,
+          },
+        });
 
         void this.restartCurrentHarness(request);
       },
@@ -513,6 +542,15 @@ export class ReconnectableHarness
         this.logger.info(
           `[ReconnectableHarness] Reconnected harness on attempt ${attempt}/${this.maxReconnectAttempts} (sessionId=${this.latestSessionId ?? 'none'})`,
         );
+        this.diagnosticEvents?.record({
+          kind: 'harness_reconnected',
+          message: `Reconnected harness on attempt ${attempt}/${this.maxReconnectAttempts}`,
+          details: {
+            attempt,
+            maxAttempts: this.maxReconnectAttempts,
+            sessionId: this.latestSessionId ?? null,
+          },
+        });
         this.attachHarness(spawned);
         return;
       } catch (error) {
@@ -535,6 +573,14 @@ export class ReconnectableHarness
     }
 
     if (!this.disposed) {
+      this.diagnosticEvents?.record({
+        kind: 'harness_reconnect_exhausted',
+        message: `Gave up reconnecting after ${this.maxReconnectAttempts} attempts`,
+        details: {
+          maxAttempts: this.maxReconnectAttempts,
+          sessionId: this.latestSessionId ?? null,
+        },
+      });
       this.emit('disconnected');
     }
   }


### PR DESCRIPTION
PR 3 of the observability plan (rail #140, death certificate #145/#147). Four breadcrumbs on the diagnostic rail, recorded by `ReconnectableHarness`:

| kind | when | details |
| --- | --- | --- |
| `harness_disconnected` | underlying harness lost its event stream | sessionId |
| `harness_restart_requested` | deliberate restart (harness-initiated or external) | source, reason, sessionId |
| `harness_reconnected` | respawn succeeded | attempt, maxAttempts, sessionId |
| `harness_reconnect_exhausted` | gave up after max attempts | maxAttempts, sessionId |

Paired with the exit certificate, a process bounce is now fully reconstructable per task: certificate says *why the process died*, breadcrumbs say *what the worker did about it*. Deliberate restarts are labeled with their reason, so certificate-less restart breadcrumbs are self-explanatory.

## Guarantees
Same discipline as the rest of the rail: recorder injected as an optional dependency, all calls fire-and-forget through the never-throw recorder, zero behavior change to reconnect logic (verified by the existing 11 reconnect tests passing untouched). Events fire only on lifecycle transitions — nothing per-message or per-tool.

## Tests
3 new (disconnect→reconnect pair, exhaustion with attempt count, external request with reason). Full run-task + harnesses suites: **431 pass**; typecheck / eslint / prettier / knip clean.

Waiting for bot review + Dan before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)