### PR TITLE
Promote v0.0.3 to production

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -27,8 +27,8 @@ Chores, docs-only, and pure-internal refactors can skip a changeset; they ride a
 ## How a release ships
 
 1. Merge code to `develop`. When pending changesets exist, CI keeps a **Release PR** open against `develop` that bumps versions and updates the root `CHANGELOG.md`.
-2. Merging that Release PR (or any push to `develop` whose version is untagged) opens or refreshes a **Promote PR** (`develop` → `main`).
-3. Merging the Promote PR with a **merge commit** (not squash) into `main` tags `vX.Y.Z`, then GHCR builds the matching images; the GitHub Release is created only after those images exist so `releases/latest` never points at a missing image set.
+2. Merging that Release PR (or any push to `develop` whose version is untagged) cuts a frozen `release/vX.Y.Z` branch at the version-bump commit and opens or refreshes a **Promote PR** (`release/vX.Y.Z` → `main`). Commits merged to `develop` after the version bump wait for the next release instead of riding along.
+3. Merging the Promote PR with a **merge commit** (not squash) into `main` tags `vX.Y.Z`, then GHCR builds the matching images; the GitHub Release is created only after those images exist so `releases/latest` never points at a missing image set. The `release/vX.Y.Z` branch can be deleted after the merge.
 
 Branch rules (must match GitHub rulesets):
 

--- a/.changeset/fix-first-release-publish-gate.md
+++ b/.changeset/fix-first-release-publish-gate.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Fix the release image publish gate so the first production release can ship: resolve the upgrade baseline from the latest GitHub release safely instead of leaking a 404 error into the image tag, and skip upgrade validation when no previous published release exists (fresh-install validation still runs).

--- a/.changeset/fix-first-release-publish-gate.md
+++ b/.changeset/fix-first-release-publish-gate.md
@@ -1,5 +1,0 @@
----
-'@roomote/web': patch
----
-
-Fix the release image publish gate so the first production release can ship: resolve the upgrade baseline from the latest GitHub release safely instead of leaking a 404 error into the image tag, and skip upgrade validation when no previous published release exists (fresh-install validation still runs).

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -186,35 +186,74 @@ jobs:
       - name: Restore an encrypted bundle onto empty volumes
         run: bash deploy/host/tests/backup-restore.integration.sh
 
-  docker-build:
-    name: Docker Build (${{ matrix.app }})
+  upgrade-compatibility:
+    name: Upgrade Compatibility
     needs: changes
     if: ${{ needs.changes.outputs.docs_only != 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+        with:
+          frozen-lockfile: 'true'
+          node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+      # Boots the previous published release from GHCR, applies this branch's
+      # migrations to it, and requires the previous release to stay healthy on
+      # the candidate schema (the expand/contract policy in deploy/README.md).
+      - name: Apply candidate migrations to the previous release
+        env:
+          BASELINE_CHANNEL: ${{ github.base_ref || github.ref_name }}
+        run: bash deploy/ci/upgrade-compatibility.sh
+
+  docker-build:
+    name: Docker Build (${{ matrix.app }}, ${{ matrix.arch }})
+    needs: changes
+    if: ${{ needs.changes.outputs.docs_only != 'true' }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
+      # Each arch builds natively, mirroring the publish workflow (no QEMU:
+      # rustc segfaults under emulation, rust-lang/rust#147026).
       matrix:
         include:
           - app: app
             dockerfile: .docker/app/Dockerfile
             target: runtime-app
+            arch: amd64
+            runner: blacksmith-4vcpu-ubuntu-2404
+          - app: app
+            dockerfile: .docker/app/Dockerfile
+            target: runtime-app
+            arch: arm64
+            runner: blacksmith-4vcpu-ubuntu-2404-arm
           - app: worker
             dockerfile: apps/worker/Dockerfile
             target: runtime
+            arch: amd64
+            runner: blacksmith-4vcpu-ubuntu-2404
+          - app: worker
+            dockerfile: apps/worker/Dockerfile
+            target: runtime
+            arch: arm64
+            runner: blacksmith-4vcpu-ubuntu-2404-arm
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Validate production Compose security contract
-        if: matrix.app == 'app'
+        if: matrix.app == 'app' && matrix.arch == 'amd64'
         run: deploy/scripts/validate-compose-security.sh
       - name: Set up Docker builder
         uses: useblacksmith/setup-docker-builder@47a5d0102cc44712a17a633c2599f755008cc40e # v1
-      - name: Build ${{ matrix.app }} Dockerfile
+      - name: Build ${{ matrix.app }} Dockerfile (${{ matrix.arch }})
         uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2
         with:
           context: .
           file: ${{ matrix.dockerfile }}
           target: ${{ matrix.target }}
+          platforms: linux/${{ matrix.arch }}
           push: false
           build-args: APP_ENV=development
 

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -170,21 +170,53 @@ jobs:
         shell: bash
         env:
           EXTRA_TAG: ${{ needs.prepare.outputs.extra_tag }}
+          CANDIDATE_VERSION: ${{ needs.prepare.outputs.version }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           baseline="$EXTRA_TAG"
-          if [ "$baseline" = 'latest' ]; then
-            baseline="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name 2>/dev/null || true)"
-            # v0.0.1 predates the current migration baseline. Use the prior
-            # main candidate for the first gated release; later releases use
-            # the immediately preceding immutable release tag.
-            if [ -z "$baseline" ] || [ "$baseline" = 'v0.0.1' ]; then
-              baseline='main'
+          if [ "$baseline" != 'develop' ]; then
+            # Release-channel runs (tag, main, manual dispatch) validate the
+            # upgrade path from the previous published release. gh prints the
+            # 404 error body to stdout, so only trust the output when the call
+            # succeeds; capturing it with `|| true` is how a JSON blob once
+            # became a docker tag.
+            if ! baseline="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name 2>/dev/null)"; then
+              baseline=''
             fi
-          elif [ -z "$baseline" ]; then
-            baseline='main'
+            # v0.0.1 predates the release pipeline and has no images. With no
+            # usable previous release, skip upgrade validation entirely: the
+            # smoke test still verifies a fresh install of the candidate.
+            if [ "$baseline" = 'v0.0.1' ]; then
+              echo "Latest release is legacy v0.0.1 (no images); skipping upgrade validation." >&2
+              baseline=''
+            fi
+            # Manual dispatch can re-publish an older version while a newer
+            # release is latest. Validating baseline→candidate would then be
+            # a downgrade dressed up as an upgrade (newer migrations, older
+            # code), so only keep the upgrade leg when the candidate is
+            # strictly newer than the baseline.
+            if [ -n "$baseline" ]; then
+              case "$CANDIDATE_VERSION" in
+                v[0-9]*)
+                  newest="$(printf '%s\n%s\n' "$baseline" "$CANDIDATE_VERSION" | sort -V | tail -n1)"
+                  if [ "$CANDIDATE_VERSION" = "$baseline" ] || [ "$newest" != "$CANDIDATE_VERSION" ]; then
+                    echo "Candidate $CANDIDATE_VERSION is not newer than latest release $baseline; skipping upgrade validation for re-publish." >&2
+                    baseline=''
+                  fi
+                  ;;
+              esac
+            fi
           fi
+          # Never let anything that is not a known channel or v* release tag
+          # reach `docker pull`.
+          case "$baseline" in
+            '' | develop | v[0-9]*) ;;
+            *)
+              echo "Ignoring unexpected baseline '$baseline'; skipping upgrade validation." >&2
+              baseline=''
+              ;;
+          esac
           echo "version=$baseline" >> "$GITHUB_OUTPUT"
       - name: Exercise deployment lifecycle
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,12 @@ on:
     branches:
       - develop
 
-# One release automation lane on develop: refresh the Version PR and the
-# develop→main promote PR without cancelling in-flight work.
+# One release automation lane on develop. Cancel superseded runs: every run
+# re-derives state from the live develop tip, so the newest push always redoes
+# the work and a stale queued run can never resurrect an outdated Version PR.
 concurrency:
   group: release-develop
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -28,6 +29,10 @@ jobs:
           # (first-time bootstrap still opens the PR; CI may need a re-run).
           token: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
+          # Work on the live develop tip, not the push SHA that triggered
+          # this run: a queued run that starts after more merges must not
+          # recreate a Version PR from an outdated snapshot.
+          ref: develop
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -55,8 +60,9 @@ jobs:
         with:
           token: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
+          ref: develop
 
-      - name: Open develop → main promote PR when version is releaseable
+      - name: Cut frozen release branch and open promote PR
         env:
           GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
         shell: bash
@@ -72,22 +78,30 @@ jobs:
             exit 0
           fi
 
-          pending="$(find .changeset -maxdepth 1 -type f -name '*.md' ! -iname 'README.md' 2>/dev/null | wc -l | tr -d ' ')"
-          if [ "${pending:-0}" -gt 0 ]; then
-            echo "Pending changesets remain; wait for the Version Packages PR to merge."
-            exit 0
-          fi
-
-          git fetch origin main develop --quiet
+          git fetch origin main --quiet
 
           if ! git show-ref --verify --quiet refs/remotes/origin/main; then
             echo "origin/main is missing; create main before promoting."
             exit 1
           fi
 
-          if [ "$(git rev-parse origin/main)" = "$(git rev-parse origin/develop)" ]; then
-            echo "main already matches develop tip."
+          # Freeze the release at the commit that introduced this version
+          # (the Version PR merge), not at the moving develop tip. Commits
+          # merged to develop after that point wait for the next cut instead
+          # of silently riding into this release.
+          bump_sha="$(node scripts/release/find-version-commit.mjs "$version" HEAD)"
+
+          if git merge-base --is-ancestor "$bump_sha" origin/main; then
+            echo "main already contains ${bump_sha}; nothing to promote."
             exit 0
+          fi
+
+          release_branch="release/${tag}"
+          if git ls-remote --exit-code --heads origin "$release_branch" >/dev/null 2>&1; then
+            echo "Release branch ${release_branch} already exists; leaving it frozen."
+          else
+            git push origin "${bump_sha}:refs/heads/${release_branch}"
+            echo "Cut ${release_branch} at ${bump_sha}"
           fi
 
           notes="$(node scripts/release/extract-changelog-section.mjs "$version" || true)"
@@ -95,10 +109,12 @@ jobs:
           {
             echo "## Promote ${tag}"
             echo
-            echo "develop is ahead of main and product version \`${version}\` is not tagged yet."
+            echo "Frozen at \`${bump_sha}\` — the commit where \`${version}\` was versioned. Commits merged to \`develop\` after that point ship in the next release."
             echo
             echo "- Merge this PR with a **merge commit** (do not squash or rebase)."
+            echo "- If multiple promote PRs are open, merge them in version order (oldest first)."
             echo "- Merging publishes a GitHub Release for \`${tag}\` and triggers the existing GHCR \`v*\` image publish (\`latest\` channel)."
+            echo "- The \`${release_branch}\` branch can be deleted after this PR merges."
             echo
             echo "### Changelog"
             echo
@@ -109,7 +125,7 @@ jobs:
             fi
           } > "$body_file"
 
-          existing="$(gh pr list --base main --head develop --state open --json number,url --jq '.[0].url // empty')"
+          existing="$(gh pr list --base main --head "$release_branch" --state open --json number,url --jq '.[0].url // empty')"
           if [ -n "$existing" ]; then
             echo "Promote PR already open: $existing"
             gh pr edit "$existing" --title "Promote ${tag} to production" --body-file "$body_file"
@@ -119,7 +135,7 @@ jobs:
 
           gh pr create \
             --base main \
-            --head develop \
+            --head "$release_branch" \
             --title "Promote ${tag} to production" \
             --body-file "$body_file"
           rm -f "$body_file"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file tracks product releases for Roomote (single monorepo version). Automated release entries are prepended by `pnpm run version`.
 
+## 0.0.3 (2026-07-11)
+
+### Patch changes
+
+- Fix the release image publish gate so the first production release can ship: resolve the upgrade baseline from the latest GitHub release safely instead of leaking a 404 error into the image tag, and skip upgrade validation when no previous published release exists (fresh-install validation still runs).
+
 ## 0.0.2 (2026-07-10)
 
 ### Patch changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,9 +49,10 @@ Any `@roomote/*` package selection is equivalent under the fixed group. See
 1. Merge work to `develop` (squash). When pending changesets exist, automation
    opens a **Release Roomote** Version PR that bumps lockstep versions and
    `CHANGELOG.md`.
-2. When the product version is untagged and no changesets remain, automation
-   opens or refreshes a **Promote `vX.Y.Z` to production** PR (`develop` →
-   `main`).
+2. When the product version is untagged, automation cuts a frozen
+   `release/vX.Y.Z` branch at the version-bump commit and opens or refreshes a
+   **Promote `vX.Y.Z` to production** PR (`release/vX.Y.Z` → `main`). Work
+   merged to `develop` after the version bump waits for the next release.
 3. Merge that promote PR with a **merge commit** (branch rules on `main` allow
    merge only; `develop` stays squash-only). Tagging (`vX.Y.Z`), GHCR image
    publish (`latest`), and the GitHub Release follow from `main` / tag workflows.

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -81,6 +81,7 @@ roomote status              # service health
 roomote logs [service...]   # follow logs
 roomote setup-url           # re-print the tokenized /setup link
 roomote upgrade [version]   # upgrade or roll back by image tag
+roomote rollback            # return to the release before the last upgrade
 roomote backup              # encrypted recovery bundle in /opt/roomote/backups
 roomote restore <f> --yes   # restore configuration and data onto this host
 ```
@@ -115,6 +116,21 @@ restores the original `.env`, repopulates empty data volumes, pins the recorded
 image digests, restores PostgreSQL, and starts the recorded release. A wrong
 passphrase, checksum failure, missing local-MinIO data, or unavailable image
 identity fails before restored services are started.
+
+`roomote upgrade` first creates an encrypted pre-upgrade backup bundle under
+`/opt/roomote/backups` (skip with `--skip-backup`; supply a passphrase with
+`--backup-passphrase-file` or `ROOMOTE_BACKUP_PASSPHRASE`, otherwise one is
+generated next to the bundle). It then pulls the new images and applies
+database migrations before replacing any running service. Migrations apply in
+a single transaction, so a migration failure rolls the schema back, restores
+the previous deployment configuration, and leaves the previous release
+running. Because every schema change must keep the previous release working
+(see the compatibility policy in `deploy/README.md`), a bad release can be
+undone with `roomote rollback`, which re-deploys the release recorded before
+the last upgrade without touching the database; the pre-upgrade bundle plus
+`roomote restore` is the last-resort path that also rewinds data. The running
+application and schema versions are visible under Settings -> Deployment ->
+Diagnostics.
 
 `roomote upgrade` prunes old Roomote images after a successful upgrade. It
 keeps the current release plus the newest local Roomote image tags for a total

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/api",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/api/src/handlers/__tests__/webhook-payload-redaction.test.ts
+++ b/apps/api/src/handlers/__tests__/webhook-payload-redaction.test.ts
@@ -1,0 +1,103 @@
+import {
+  isSensitiveWebhookPayloadKey,
+  redactWebhookPayload,
+} from '../webhook-payload-redaction';
+
+describe('isSensitiveWebhookPayloadKey', () => {
+  it.each([
+    'secret',
+    'token',
+    'password',
+    'credentials',
+    'authorization',
+    'api_key',
+    'apiKey',
+    'private_key',
+    'client_secret',
+    'clientSecret',
+    'webhook_secret',
+    'access_token',
+    'accessToken',
+    'refresh_token',
+    'id_token',
+    'auth-token',
+    'SECRET_TOKEN',
+  ])('flags %s', (key) => {
+    expect(isSensitiveWebhookPayloadKey(key)).toBe(true);
+  });
+
+  it.each([
+    'body',
+    'description',
+    'title',
+    'email',
+    'login',
+    'full_name',
+    'html_url',
+    'action',
+    'tokenizer', // 'token' must match as a whole segment, not a prefix.
+    'secretary',
+  ])('keeps %s', (key) => {
+    expect(isSensitiveWebhookPayloadKey(key)).toBe(false);
+  });
+});
+
+describe('redactWebhookPayload', () => {
+  it('masks sensitive keys at any depth and preserves everything else', () => {
+    const payload = {
+      action: 'created',
+      hook: {
+        id: 42,
+        config: {
+          url: 'https://example.com/webhook',
+          secret: 'hunter2',
+          insecure_ssl: '0',
+        },
+      },
+      installation: { id: 7 },
+      sender: { login: 'octocat', email: 'octo@example.com' },
+      items: [{ access_token: 'abc123' }, { note: 'keep me' }],
+    };
+
+    expect(redactWebhookPayload(payload)).toEqual({
+      action: 'created',
+      hook: {
+        id: 42,
+        config: {
+          url: 'https://example.com/webhook',
+          secret: '[REDACTED]',
+          insecure_ssl: '0',
+        },
+      },
+      installation: { id: 7 },
+      sender: { login: 'octocat', email: 'octo@example.com' },
+      items: [{ access_token: '[REDACTED]' }, { note: 'keep me' }],
+    });
+  });
+
+  it('redacts non-string secret values, including nested objects', () => {
+    expect(
+      redactWebhookPayload({
+        credentials: { user: 'u', pass: 'p' },
+        token: 12345,
+      }),
+    ).toEqual({ credentials: '[REDACTED]', token: '[REDACTED]' });
+  });
+
+  it('keeps null secret values as null', () => {
+    expect(redactWebhookPayload({ secret: null })).toEqual({ secret: null });
+  });
+
+  it('does not mutate the original payload', () => {
+    const payload = { config: { secret: 'hunter2' } };
+
+    redactWebhookPayload(payload);
+
+    expect(payload.config.secret).toBe('hunter2');
+  });
+
+  it('passes through non-object payloads', () => {
+    expect(redactWebhookPayload('raw-body')).toBe('raw-body');
+    expect(redactWebhookPayload(null)).toBeNull();
+  });
+});

--- a/apps/api/src/handlers/ado/__tests__/handleComment.test.ts
+++ b/apps/api/src/handlers/ado/__tests__/handleComment.test.ts
@@ -140,7 +140,7 @@ describe('handleAdoComment', () => {
       status: 'ok',
       targets: [
         {
-          id: 'ado:pr_reviewer:repo-1',
+          id: 'ado:pr_review:repo-1',
           settings: null,
           repositoryIds: ['repo-1'],
           userId: 'user-1',

--- a/apps/api/src/handlers/ado/__tests__/handlePullRequest.test.ts
+++ b/apps/api/src/handlers/ado/__tests__/handlePullRequest.test.ts
@@ -182,7 +182,7 @@ describe('handleAdoPullRequest', () => {
       status: 'ok',
       targets: [
         {
-          id: 'ado:pr_reviewer:repo-1',
+          id: 'ado:pr_review:repo-1',
           settings: null,
           repositoryIds: ['repo-1'],
           userId: 'user-1',

--- a/apps/api/src/handlers/gitea/__tests__/handleComment.test.ts
+++ b/apps/api/src/handlers/gitea/__tests__/handleComment.test.ts
@@ -120,7 +120,7 @@ describe('handleGiteaComment', () => {
       status: 'ok',
       targets: [
         {
-          id: 'gitea:pr_reviewer:repo-1',
+          id: 'gitea:pr_review:repo-1',
           settings: null,
           repositoryIds: ['repo-1'],
           userId: 'user-1',

--- a/apps/api/src/handlers/gitea/__tests__/handlePullRequest.test.ts
+++ b/apps/api/src/handlers/gitea/__tests__/handlePullRequest.test.ts
@@ -118,7 +118,7 @@ describe('handleGiteaPullRequest', () => {
       status: 'ok',
       targets: [
         {
-          id: 'gitea:pr_reviewer:repo-1',
+          id: 'gitea:pr_review:repo-1',
           settings: null,
           repositoryIds: ['repo-1'],
           userId: 'user-1',

--- a/apps/api/src/handlers/github/__tests__/recordWebhook.test.ts
+++ b/apps/api/src/handlers/github/__tests__/recordWebhook.test.ts
@@ -49,6 +49,35 @@ describe('recordWebhook', () => {
     expect(webhook!.error).toBeNull();
   });
 
+  it('stores the payload with sensitive fields redacted, untouched for the handler', async () => {
+    const deliveryId = `test-delivery-${Date.now()}-redaction`;
+    testDeliveryIds.push(deliveryId);
+
+    const payload = {
+      action: 'created',
+      hook: { config: { url: 'https://example.com', secret: 'hunter2' } },
+    };
+    let handlerPayloadSecret: string | undefined;
+
+    await recordWebhook(deliveryId, 'meta.created', payload, async () => {
+      // Handlers close over the original payload; redaction must only
+      // affect the stored copy.
+      handlerPayloadSecret = payload.hook.config.secret;
+      return { status: 'ok' };
+    });
+
+    const [webhook] = await db
+      .select()
+      .from(webhooks)
+      .where(eq(webhooks.deliveryId, deliveryId));
+
+    expect(handlerPayloadSecret).toBe('hunter2');
+    expect(webhook!.payload).toEqual({
+      action: 'created',
+      hook: { config: { url: 'https://example.com', secret: '[REDACTED]' } },
+    });
+  });
+
   it('records a non-GitHub provider when supplied', async () => {
     const deliveryId = `test-delivery-${Date.now()}-gitlab`;
     testDeliveryIds.push(deliveryId);

--- a/apps/api/src/handlers/github/recordWebhook.ts
+++ b/apps/api/src/handlers/github/recordWebhook.ts
@@ -2,6 +2,7 @@ import { db, webhooks as webhooksTable, eq } from '@roomote/db/server';
 import type { SourceControlProvider } from '@roomote/types';
 
 import type { WebhookResponse } from '../../types';
+import { redactWebhookPayload } from '../webhook-payload-redaction';
 
 /**
  * Records a webhook after executing the handler, setting status based on the response.
@@ -29,7 +30,9 @@ export async function recordWebhook<T>(
         deliveryId,
         provider,
         event,
-        payload,
+        // Only the stored copy is redacted; the handler still receives the
+        // original payload.
+        payload: redactWebhookPayload(payload),
         // No status timestamps set yet - will be updated after handler runs
       })
       .onConflictDoNothing()

--- a/apps/api/src/handlers/gitlab/__tests__/handleMergeRequest.test.ts
+++ b/apps/api/src/handlers/gitlab/__tests__/handleMergeRequest.test.ts
@@ -112,7 +112,7 @@ describe('handleGitLabMergeRequest', () => {
       status: 'ok',
       targets: [
         {
-          id: 'gitlab:pr_reviewer:repo-1',
+          id: 'gitlab:pr_review:repo-1',
           settings: null,
           repositoryIds: ['repo-1'],
           userId: 'user-1',

--- a/apps/api/src/handlers/gitlab/__tests__/handleNote.test.ts
+++ b/apps/api/src/handlers/gitlab/__tests__/handleNote.test.ts
@@ -113,7 +113,7 @@ describe('handleGitLabNote', () => {
       status: 'ok',
       targets: [
         {
-          id: 'gitlab:pr_reviewer:repo-1',
+          id: 'gitlab:pr_review:repo-1',
           settings: null,
           repositoryIds: ['repo-1'],
           userId: 'user-1',

--- a/apps/api/src/handlers/linear/__tests__/linear-active-run-priority.test.ts
+++ b/apps/api/src/handlers/linear/__tests__/linear-active-run-priority.test.ts
@@ -52,7 +52,6 @@ vi.mock('@roomote/cloud-agents/server', () => ({
   enqueueTask: vi.fn(),
   routeTask: vi.fn(),
   buildLinearRoutingContext: vi.fn(),
-  AGENT_TYPE_TO_PROMPT_NAME: {},
 }));
 
 vi.mock('@roomote/sdk/server', async (importOriginal) => {
@@ -285,7 +284,9 @@ describe('CLO-1133: active task run takes priority over routing confirmation and
   it('delivers free-text reply to active task run even when routing confirmation key exists in Redis', async () => {
     setupDbMocks();
 
-    // Simulate a stale routing confirmation key in Redis
+    // Simulate a stale routing confirmation key in Redis. The legacy
+    // agentName/agentType fields are intentional: payloads written before the
+    // agent-identity removal can still be present and must stay tolerated.
     redisMock.eval.mockResolvedValue(
       JSON.stringify({
         agentName: 'Agent',

--- a/apps/api/src/handlers/linear/recordWebhook.ts
+++ b/apps/api/src/handlers/linear/recordWebhook.ts
@@ -1,6 +1,7 @@
 import { db, webhooks as webhooksTable, eq } from '@roomote/db/server';
 
 import type { WebhookResponse } from '../../types';
+import { redactWebhookPayload } from '../webhook-payload-redaction';
 
 /**
  * Escape newline and carriage return characters to prevent log injection attacks.
@@ -41,7 +42,9 @@ export async function recordLinearWebhook<T>(
         deliveryId: webhookId,
         provider: 'linear',
         event,
-        payload,
+        // Only the stored copy is redacted; the handler still receives the
+        // original payload.
+        payload: redactWebhookPayload(payload),
         // No status timestamps set yet - will be updated after handler runs
       })
       .onConflictDoNothing()

--- a/apps/api/src/handlers/slack/constants.ts
+++ b/apps/api/src/handlers/slack/constants.ts
@@ -27,11 +27,11 @@ export const SLACK_FAST_AGENT_LOCK_PREFIX = 'slack:fast-agent-lock:';
 export const SLACK_SETUP_SUGGESTION_LOCK_PREFIX =
   'slack:setup-suggestion-reaction:';
 export const LEADING_FAST_COMMAND_MENTION_PATTERN = /^\s*<@[^>]+>[\s,:;.-]*/;
-const SETUP_ONBOARDING_SUGGESTION_AGENT_TYPE = 'setup_onboarding';
-const SUGGESTED_TASKS_AGENT_TYPE = 'suggested_tasks';
-export const TASK_SUGGESTION_AGENT_TYPES = [
-  SETUP_ONBOARDING_SUGGESTION_AGENT_TYPE,
-  SUGGESTED_TASKS_AGENT_TYPE,
+const SETUP_ONBOARDING_SUGGESTION_TYPE = 'setup_onboarding';
+const SUGGESTED_TASKS_SUGGESTION_TYPE = 'suggested_tasks';
+export const TASK_SUGGESTION_TYPES = [
+  SETUP_ONBOARDING_SUGGESTION_TYPE,
+  SUGGESTED_TASKS_SUGGESTION_TYPE,
 ] as const;
 export const SETUP_ONBOARDING_SUGGESTION_METADATA_EVENT_TYPE =
   'roomote.setup_onboarding_suggestion';

--- a/apps/api/src/handlers/slack/events/reactions.ts
+++ b/apps/api/src/handlers/slack/events/reactions.ts
@@ -36,7 +36,7 @@ import { apiLogger } from '../../../logging.js';
 import { cancelOrphanedWorkItemRunBestEffort } from '../../tasks/orphaned-work-item-run.js';
 import {
   SLACK_SETUP_SUGGESTION_LOCK_PREFIX,
-  TASK_SUGGESTION_AGENT_TYPES,
+  TASK_SUGGESTION_TYPES,
 } from '../constants.js';
 import type { SlackWebhookContext } from '../context.js';
 import {
@@ -82,19 +82,19 @@ const TASK_SUGGESTION_REACTION_MAX_ATTEMPTS = Math.ceil(
 
 /**
  * Reaction-launchable suggestion types tracked on the suggestion_card's
- * `metadata.suggestionType`. Mirrors the old agentType filter — only
- * setup-onboarding and suggested-tasks cards launch from a reaction.
+ * `metadata.suggestionType`. Only setup-onboarding and suggested-tasks
+ * cards launch from a reaction.
  */
 function getLaunchableSuggestionType(
   metadata: Record<string, unknown> | null | undefined,
-): (typeof TASK_SUGGESTION_AGENT_TYPES)[number] | null {
+): (typeof TASK_SUGGESTION_TYPES)[number] | null {
   const suggestionType = metadata?.suggestionType;
 
   if (
     typeof suggestionType === 'string' &&
-    (TASK_SUGGESTION_AGENT_TYPES as readonly string[]).includes(suggestionType)
+    (TASK_SUGGESTION_TYPES as readonly string[]).includes(suggestionType)
   ) {
-    return suggestionType as (typeof TASK_SUGGESTION_AGENT_TYPES)[number];
+    return suggestionType as (typeof TASK_SUGGESTION_TYPES)[number];
   }
 
   return null;
@@ -425,7 +425,7 @@ async function launchTaskSuggestionTaskFromReaction({
     investigationContext: workItem.investigationContext,
     readinessMessage:
       suggestionWorkspace.readinessMessage ?? workItem.readinessMessage,
-    agentType: suggestionType,
+    suggestionType,
     category: workItem.category,
     priority: workItem.priority,
     targetRepositoryFullName: suggestionSlackTargetRepositoryFullName,

--- a/apps/api/src/handlers/slack/helpers/suggestion-slack-text.ts
+++ b/apps/api/src/handlers/slack/helpers/suggestion-slack-text.ts
@@ -20,21 +20,21 @@ type SuggestionSeededTextOptions = {
   statusLabel?: 'started' | 'accepted';
 };
 
-const SHARED_SCHEDULED_SUGGESTION_AGENT_TYPES = new Set(['suggested_tasks']);
+const SHARED_SCHEDULED_SUGGESTION_TYPES = new Set(['suggested_tasks']);
 
 export function usesSharedScheduledSuggestionSlackModel(
-  agentType?: string | null,
+  suggestionType?: string | null,
 ): boolean {
   return (
-    typeof agentType === 'string' &&
-    SHARED_SCHEDULED_SUGGESTION_AGENT_TYPES.has(agentType)
+    typeof suggestionType === 'string' &&
+    SHARED_SCHEDULED_SUGGESTION_TYPES.has(suggestionType)
   );
 }
 
 export function getSharedScheduledSuggestionSlackTextOptions(
-  agentType?: string | null,
+  suggestionType?: string | null,
 ): SuggestionSlackTextOptions | undefined {
-  if (!usesSharedScheduledSuggestionSlackModel(agentType)) {
+  if (!usesSharedScheduledSuggestionSlackModel(suggestionType)) {
     return undefined;
   }
 
@@ -45,9 +45,9 @@ export function getSharedScheduledSuggestionSlackTextOptions(
 }
 
 export function getSharedScheduledSuggestionSeededTextOptions(
-  agentType?: string | null,
+  suggestionType?: string | null,
 ): SuggestionSeededTextOptions | undefined {
-  if (!usesSharedScheduledSuggestionSlackModel(agentType)) {
+  if (!usesSharedScheduledSuggestionSlackModel(suggestionType)) {
     return undefined;
   }
 

--- a/apps/api/src/handlers/slack/helpers/suggestion-workspace.test.ts
+++ b/apps/api/src/handlers/slack/helpers/suggestion-workspace.test.ts
@@ -12,7 +12,7 @@ import {
 describe('buildSuggestionTaskPromptText', () => {
   it('keeps ordinary suggestion prompts generic', () => {
     const prompt = buildSuggestionTaskPromptText({
-      agentType: 'suggested_tasks',
+      suggestionType: 'suggested_tasks',
       title: 'Fix cron retries',
       brief: 'Fix cron retries',
       category: 'bug',
@@ -29,7 +29,7 @@ describe('buildSuggestionTaskPromptText', () => {
 
   it('keeps sentry triage suggestions on the sentry-triage workflow with safety guardrails', () => {
     const prompt = buildSuggestionTaskPromptText({
-      agentType: 'sentry_triage',
+      suggestionType: 'sentry_triage',
       title: 'Merge duplicate API errors',
       brief: 'Merge the duplicate API-42 and API-77 issue groups.',
       readinessMessage: 'Sentry MCP is available.',
@@ -49,7 +49,7 @@ describe('buildSuggestionTaskPromptText', () => {
 
   it('keeps dependabot triage suggestions on the update-dependencies workflow with alert re-verification guidance', () => {
     const prompt = buildSuggestionTaskPromptText({
-      agentType: 'dependabot_triage',
+      suggestionType: 'dependabot_triage',
       title: 'Update braces in apps/api',
       brief: 'Patch the vulnerable braces version in the API workspace.',
       investigationContext: 'Alert: GHSA-123. Manifest: apps/api/package.json.',
@@ -65,7 +65,7 @@ describe('buildSuggestionTaskPromptText', () => {
 
   it('includes workspace readiness when the suggestion falls back to bare repo mode', () => {
     const prompt = buildSuggestionTaskPromptText({
-      agentType: 'suggested_tasks',
+      suggestionType: 'suggested_tasks',
       title: 'Investigate worker queue lag',
       brief: 'Check why the preview worker falls behind.',
       readinessMessage: 'Worker validation is limited without setup.',

--- a/apps/api/src/handlers/tasks/__tests__/submitTaskSuggestions.test.ts
+++ b/apps/api/src/handlers/tasks/__tests__/submitTaskSuggestions.test.ts
@@ -139,7 +139,7 @@ vi.mock('@roomote/sdk/server', () => ({
 
 vi.mock('../background-automation-slack', () => ({
   resolveScheduledSuggestionSlackConfig: vi.fn(() => ({
-    agentType: 'suggested_tasks',
+    suggestionType: 'suggested_tasks',
     automationKey: 'suggest_ideas',
     automationSettingsHash: undefined,
     actionFooterText: 'footer',

--- a/apps/api/src/handlers/tasks/background-automation-slack.ts
+++ b/apps/api/src/handlers/tasks/background-automation-slack.ts
@@ -17,7 +17,7 @@ type ScheduledSuggestionSummaryPromptConfig = {
 };
 
 type ScheduledSuggestionSurfaceConfig = {
-  agentType:
+  suggestionType:
     | 'suggested_tasks'
     | 'sentry_triage'
     | 'dependabot_triage'
@@ -36,7 +36,7 @@ type ScheduledSuggestionSurfaceConfig = {
 };
 
 export type ScheduledSuggestionSlackConfig = {
-  agentType: ScheduledSuggestionSurfaceConfig['agentType'];
+  suggestionType: ScheduledSuggestionSurfaceConfig['suggestionType'];
   automationSettingsHash: string;
   actionFooterText: string;
   summaryKind: ScheduledSuggestionSurfaceConfig['summaryKind'];
@@ -60,7 +60,7 @@ const SCHEDULED_SUGGESTION_SURFACE_CONFIG: Record<
   ScheduledSuggestionSurfaceConfig
 > = {
   suggester: {
-    agentType: 'suggested_tasks',
+    suggestionType: 'suggested_tasks',
     summaryKind: 'suggested_tasks',
     actionFooterText:
       "I pulled the most useful follow-up ideas into the thread for review.\nReact with a :thumbsup: on any idea and I'll start it.",
@@ -80,7 +80,7 @@ const SCHEDULED_SUGGESTION_SURFACE_CONFIG: Record<
     },
   },
   sentry_triage: {
-    agentType: 'sentry_triage',
+    suggestionType: 'sentry_triage',
     summaryKind: 'sentry_triage',
     actionFooterText:
       'I pulled the most useful Sentry follow-ups into the thread for review.',
@@ -100,7 +100,7 @@ const SCHEDULED_SUGGESTION_SURFACE_CONFIG: Record<
     },
   },
   dependabot_triage: {
-    agentType: 'dependabot_triage',
+    suggestionType: 'dependabot_triage',
     summaryKind: 'dependabot_triage',
     actionFooterText:
       'I pulled the strongest update candidates into the thread for review.',
@@ -120,7 +120,7 @@ const SCHEDULED_SUGGESTION_SURFACE_CONFIG: Record<
     },
   },
   security_auditor: {
-    agentType: 'security_auditor',
+    suggestionType: 'security_auditor',
     summaryKind: 'security_auditor',
     actionFooterText:
       'I pulled the highest-value security follow-ups into the thread for review.',
@@ -140,7 +140,7 @@ const SCHEDULED_SUGGESTION_SURFACE_CONFIG: Record<
     },
   },
   code_quality_auditor: {
-    agentType: 'code_quality_auditor',
+    suggestionType: 'code_quality_auditor',
     summaryKind: 'code_quality_auditor',
     actionFooterText:
       'I pulled the highest-leverage code quality follow-ups into the thread for review.',
@@ -161,7 +161,7 @@ const SCHEDULED_SUGGESTION_SURFACE_CONFIG: Record<
     },
   },
   ci_failure_triage: {
-    agentType: 'ci_failure_triage',
+    suggestionType: 'ci_failure_triage',
     summaryKind: 'ci_failure_triage',
     actionFooterText:
       'Each fix runs as its own task and reports back here when it finishes.',
@@ -233,7 +233,7 @@ export function resolveScheduledSuggestionSlackConfig(
   }
 
   return {
-    agentType: surfaceConfig.agentType,
+    suggestionType: surfaceConfig.suggestionType,
     automationSettingsHash,
     actionFooterText: surfaceConfig.actionFooterText,
     summaryKind: surfaceConfig.summaryKind,

--- a/apps/api/src/handlers/tasks/setup-suggestion-lifecycle.ts
+++ b/apps/api/src/handlers/tasks/setup-suggestion-lifecycle.ts
@@ -10,8 +10,7 @@ import { apiLogger } from '../../logging';
  * claims; only the message shape differs per surface. The launch state
  * machine lives on the backing `work_items` row referenced by `workItemId`.
  */
-export const SETUP_ONBOARDING_SUGGESTION_AGENT_TYPE =
-  'setup_onboarding' as const;
+export const SETUP_ONBOARDING_SUGGESTION_TYPE = 'setup_onboarding' as const;
 
 export const MAX_SETUP_SUGGESTIONS = 5;
 
@@ -36,7 +35,7 @@ export async function hasTrackedSetupSuggestionMessages(
     .where(
       and(
         eq(trackedMessages.kind, 'suggestion_card'),
-        sql`${trackedMessages.metadata} ->> 'suggestionType' = ${SETUP_ONBOARDING_SUGGESTION_AGENT_TYPE}`,
+        sql`${trackedMessages.metadata} ->> 'suggestionType' = ${SETUP_ONBOARDING_SUGGESTION_TYPE}`,
         sql`${trackedMessages.metadata} ->> 'suggestionKey' LIKE ${`${sourceTaskId}:%`}`,
       ),
     )
@@ -73,7 +72,7 @@ export async function insertSetupSuggestionMessageRows(
         workItemId: row.workItemId,
         createdByUserId: row.createdByUserId,
         metadata: {
-          suggestionType: SETUP_ONBOARDING_SUGGESTION_AGENT_TYPE,
+          suggestionType: SETUP_ONBOARDING_SUGGESTION_TYPE,
           suggestionKey: row.suggestionKey,
         },
       })),

--- a/apps/api/src/handlers/tasks/submitTaskSuggestions.ts
+++ b/apps/api/src/handlers/tasks/submitTaskSuggestions.ts
@@ -60,7 +60,7 @@ import { buildScheduledSuggestionRootMessage } from './scheduled-suggestion-root
 import {
   hasTrackedSetupSuggestionMessages,
   scheduleSuggestedTasksFollowupBestEffort,
-  SETUP_ONBOARDING_SUGGESTION_AGENT_TYPE,
+  SETUP_ONBOARDING_SUGGESTION_TYPE,
 } from './setup-suggestion-lifecycle';
 import { postScheduledSuggestionsToTelegram } from '../telegram/automation-suggestions';
 import { postScheduledSuggestionsToTeams } from '../teams/automation-suggestions';
@@ -141,8 +141,8 @@ type PreparedTaskSuggestion = {
   readinessMessage: string | null;
 };
 
-type SuggestionAgentType =
-  | typeof SETUP_ONBOARDING_SUGGESTION_AGENT_TYPE
+type TaskSuggestionType =
+  | typeof SETUP_ONBOARDING_SUGGESTION_TYPE
   | 'suggested_tasks'
   | 'sentry_triage'
   | 'dependabot_triage'
@@ -151,7 +151,7 @@ type SuggestionAgentType =
   | 'ci_failure_triage';
 
 type SuggestionCardMessageRow = {
-  suggestionType: SuggestionAgentType;
+  suggestionType: TaskSuggestionType;
   messageTs: string;
   channelId: string;
   workItemId: string;
@@ -568,7 +568,7 @@ async function postTaskSuggestionsThreadToSlack(params: {
   slackBotAccessToken: string;
   slackChannelId: string;
   createdByUserId: string | null;
-  agentType: SuggestionAgentType;
+  suggestionType: TaskSuggestionType;
   rootText: string;
   automationLabel?: string | null;
   automationSettingsHash?: string;
@@ -648,7 +648,7 @@ async function postTaskSuggestionsThreadToSlack(params: {
 
   const suggestionMessageRows: SuggestionCardMessageRow[] = [];
   const useSharedSuggestionFormatting = usesSharedScheduledSuggestionSlackModel(
-    params.agentType,
+    params.suggestionType,
   );
 
   for (const suggestion of params.suggestions) {
@@ -679,7 +679,7 @@ async function postTaskSuggestionsThreadToSlack(params: {
 
     if (useSharedSuggestionFormatting) {
       const sharedOptions = getSharedScheduledSuggestionSlackTextOptions(
-        params.agentType,
+        params.suggestionType,
       );
       // The fallback `text` keeps the footer inline; the rich `blocks` split it
       // into a small muted Slack `context` block so the bottom line renders as
@@ -732,7 +732,7 @@ async function postTaskSuggestionsThreadToSlack(params: {
     }
 
     suggestionMessageRows.push({
-      suggestionType: params.agentType,
+      suggestionType: params.suggestionType,
       messageTs,
       channelId: params.slackChannelId,
       workItemId: suggestion.id,
@@ -810,7 +810,7 @@ async function postSetupTaskSuggestionsToSlack(params: {
     slackBotAccessToken: slackInstallation.botAccessToken,
     slackChannelId: slackChannel,
     createdByUserId,
-    agentType: SETUP_ONBOARDING_SUGGESTION_AGENT_TYPE,
+    suggestionType: SETUP_ONBOARDING_SUGGESTION_TYPE,
     rootText: introText,
     suggestions,
     insertSuggestionMessages: async (suggestionMessageRows) => {
@@ -939,7 +939,7 @@ async function postSuggestedTasksSummaryToSlack(params: {
       .where(
         and(
           eq(trackedMessages.kind, 'suggestion_card'),
-          sql`${trackedMessages.metadata} ->> 'suggestionType' = ${slackConfig.agentType}`,
+          sql`${trackedMessages.metadata} ->> 'suggestionType' = ${slackConfig.suggestionType}`,
           sql`${trackedMessages.metadata} ->> 'suggestionKey' LIKE ${`${params.sourceTaskId}:%`}`,
         ),
       )
@@ -962,7 +962,7 @@ async function postSuggestedTasksSummaryToSlack(params: {
       slackBotAccessToken: slackInstallation.botAccessToken,
       slackChannelId: channel.channelId,
       createdByUserId,
-      agentType: slackConfig.agentType,
+      suggestionType: slackConfig.suggestionType,
       rootText: buildAutomationRootSummaryText({
         summaryText: rootMessage.summaryText,
         actionFooterText: rootMessage.actionFooterText,

--- a/apps/api/src/handlers/teams/automation-suggestions.ts
+++ b/apps/api/src/handlers/teams/automation-suggestions.ts
@@ -75,7 +75,7 @@ export async function postScheduledSuggestionsToTeams(params: {
     .where(
       and(
         eq(trackedMessages.kind, 'suggestion_card'),
-        sql`${trackedMessages.metadata} ->> 'suggestionType' = ${slackConfig.agentType}`,
+        sql`${trackedMessages.metadata} ->> 'suggestionType' = ${slackConfig.suggestionType}`,
         sql`${trackedMessages.metadata} ->> 'suggestionKey' LIKE ${`${sourceTaskId}:%`}`,
       ),
     )
@@ -157,7 +157,7 @@ export async function postScheduledSuggestionsToTeams(params: {
           workItemId: suggestion.id,
           createdByUserId,
           metadata: {
-            suggestionType: slackConfig.agentType,
+            suggestionType: slackConfig.suggestionType,
             suggestionKey: `${sourceTaskId}:${suggestion.id}`,
           },
         };

--- a/apps/api/src/handlers/telegram/automation-suggestions.ts
+++ b/apps/api/src/handlers/telegram/automation-suggestions.ts
@@ -78,7 +78,7 @@ export async function postScheduledSuggestionsToTelegram(params: {
     .where(
       and(
         eq(trackedMessages.kind, 'suggestion_card'),
-        sql`${trackedMessages.metadata} ->> 'suggestionType' = ${slackConfig.agentType}`,
+        sql`${trackedMessages.metadata} ->> 'suggestionType' = ${slackConfig.suggestionType}`,
         sql`${trackedMessages.metadata} ->> 'suggestionKey' LIKE ${`${sourceTaskId}:%`}`,
       ),
     )
@@ -149,7 +149,7 @@ export async function postScheduledSuggestionsToTelegram(params: {
           workItemId: suggestion.id,
           createdByUserId,
           metadata: {
-            suggestionType: slackConfig.agentType,
+            suggestionType: slackConfig.suggestionType,
             suggestionKey: `${sourceTaskId}:${suggestion.id}`,
           },
         };

--- a/apps/api/src/handlers/webhook-payload-redaction.ts
+++ b/apps/api/src/handlers/webhook-payload-redaction.ts
@@ -1,0 +1,76 @@
+/**
+ * Redaction for stored webhook payloads.
+ *
+ * Webhook rows in the `webhooks` table keep the full provider payload for
+ * auditing and debugging. Payloads can carry secret material (hook configs
+ * include the shared webhook secret, and some providers echo tokens back in
+ * the body), so clearly sensitive fields are masked before the payload is
+ * persisted. The redaction only affects the stored copy -- handlers receive
+ * the original payload. Retention is bounded separately by the WebhookCleanup
+ * scheduled job (see apps/bullmq).
+ *
+ * Redaction is key-based and intentionally conservative: it only masks keys
+ * that unambiguously hold credentials. Free-text fields (comment bodies, PR
+ * descriptions) are kept as-is because debugging depends on them.
+ */
+
+const REDACTED_VALUE = '[REDACTED]';
+
+/**
+ * Credential-bearing key names, compared against keys normalized to
+ * lowercase alphanumerics so snake_case, camelCase, and kebab-case variants
+ * all match (e.g. `client_secret`, `clientSecret`, `client-secret`).
+ */
+const SENSITIVE_KEY_NAMES = new Set([
+  'secret',
+  'secrets',
+  'token',
+  'password',
+  'passwd',
+  'credential',
+  'credentials',
+  'authorization',
+  'apikey',
+  'privatekey',
+]);
+
+/** Normalized suffixes that mark a key as credential-bearing (`webhook_secret`, `access_token`, ...). */
+const SENSITIVE_KEY_SUFFIXES = ['secret', 'token', 'password', 'apikey'];
+
+export function isSensitiveWebhookPayloadKey(key: string): boolean {
+  const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+  return (
+    SENSITIVE_KEY_NAMES.has(normalized) ||
+    SENSITIVE_KEY_SUFFIXES.some((suffix) => normalized.endsWith(suffix))
+  );
+}
+
+function redactValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactValue(entry));
+  }
+
+  if (value !== null && typeof value === 'object') {
+    const redacted: Record<string, unknown> = {};
+
+    for (const [key, entry] of Object.entries(value)) {
+      redacted[key] =
+        isSensitiveWebhookPayloadKey(key) && entry !== null
+          ? REDACTED_VALUE
+          : redactValue(entry);
+    }
+
+    return redacted;
+  }
+
+  return value;
+}
+
+/**
+ * Returns a deep copy of the payload with clearly sensitive fields replaced
+ * by `[REDACTED]`. Non-object payloads are returned unchanged.
+ */
+export function redactWebhookPayload<T>(payload: T): T {
+  return redactValue(payload) as T;
+}

--- a/apps/bullmq/package.json
+++ b/apps/bullmq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/bullmq",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/bullmq/src/scheduled-jobs/__tests__/webhook-cleanup.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/webhook-cleanup.test.ts
@@ -1,0 +1,44 @@
+const { mockDeleteExpiredWebhooks, mockDb } = vi.hoisted(() => ({
+  mockDeleteExpiredWebhooks: vi.fn(),
+  mockDb: { __brand: 'db' },
+}));
+
+vi.mock('@roomote/db/server', () => ({
+  db: mockDb,
+  deleteExpiredWebhooks: mockDeleteExpiredWebhooks,
+}));
+
+vi.mock('@roomote/env', () => ({
+  Env: { WEBHOOK_RETENTION_DAYS: 30 },
+}));
+
+import { webhookCleanupJob } from '../webhook-cleanup';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe('webhookCleanupJob', () => {
+  beforeEach(() => {
+    mockDeleteExpiredWebhooks.mockReset();
+    mockDeleteExpiredWebhooks.mockResolvedValue(0);
+  });
+
+  it('deletes rows older than WEBHOOK_RETENTION_DAYS', async () => {
+    const before = Date.now();
+    await webhookCleanupJob();
+    const after = Date.now();
+
+    expect(mockDeleteExpiredWebhooks).toHaveBeenCalledTimes(1);
+    const [database, options] = mockDeleteExpiredWebhooks.mock.calls[0]!;
+
+    expect(database).toBe(mockDb);
+    const cutoffMs = (options as { olderThan: Date }).olderThan.getTime();
+    expect(cutoffMs).toBeGreaterThanOrEqual(before - 30 * DAY_MS);
+    expect(cutoffMs).toBeLessThanOrEqual(after - 30 * DAY_MS);
+  });
+
+  it('propagates delete failures so BullMQ retries', async () => {
+    mockDeleteExpiredWebhooks.mockRejectedValue(new Error('db down'));
+
+    await expect(webhookCleanupJob()).rejects.toThrow('db down');
+  });
+});

--- a/apps/bullmq/src/scheduled-jobs/index.ts
+++ b/apps/bullmq/src/scheduled-jobs/index.ts
@@ -3,3 +3,4 @@ export { sleepCheckJob } from './sleep-check';
 export { refreshSnapshotsJob } from './refresh-snapshots';
 export { pullRequestAnalyticsSyncJob } from './pull-request-analytics-sync';
 export { instancePingJob } from './instance-ping';
+export { webhookCleanupJob } from './webhook-cleanup';

--- a/apps/bullmq/src/scheduled-jobs/webhook-cleanup.ts
+++ b/apps/bullmq/src/scheduled-jobs/webhook-cleanup.ts
@@ -1,0 +1,24 @@
+import { db, deleteExpiredWebhooks } from '@roomote/db/server';
+import { Env } from '@roomote/env';
+
+const LOG_PREFIX = '[webhookCleanup]';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Daily retention job for the `webhooks` audit table. Recorded webhook
+ * payloads are only needed for short-term debugging and idempotency, so rows
+ * older than WEBHOOK_RETENTION_DAYS (default 30) are deleted. Payload
+ * redaction at write time (apps/api webhook-payload-redaction) covers the
+ * window while rows are retained.
+ */
+export async function webhookCleanupJob(): Promise<void> {
+  const retentionDays = Env.WEBHOOK_RETENTION_DAYS;
+  const olderThan = new Date(Date.now() - retentionDays * MS_PER_DAY);
+
+  const deleted = await deleteExpiredWebhooks(db, { olderThan });
+
+  console.log(
+    `${LOG_PREFIX} deleted ${deleted} webhook rows older than ${retentionDays} days (before ${olderThan.toISOString()})`,
+  );
+}

--- a/apps/bullmq/src/scheduler.ts
+++ b/apps/bullmq/src/scheduler.ts
@@ -25,6 +25,7 @@ import {
   refreshSnapshotsJob,
   pullRequestAnalyticsSyncJob,
   instancePingJob,
+  webhookCleanupJob,
 } from './scheduled-jobs';
 
 const QUEUE_NAME = 'scheduled-jobs';
@@ -139,6 +140,11 @@ async function createJobs(queue: Queue): Promise<void> {
     { every: 24 * 60 * 60 * 1000 }, // Every 24 hours.
   );
 
+  await queue.upsertJobScheduler(
+    ScheduledJobName.WebhookCleanup,
+    { every: 24 * 60 * 60 * 1000 }, // Every 24 hours.
+  );
+
   const schedulers = await queue.getJobSchedulers();
   console.log('[createJobs] getJobSchedulers ->', schedulers);
 }
@@ -162,6 +168,8 @@ const runJobs = async (job: ScheduledJob): Promise<void> => {
       return pullRequestAnalyticsSyncJob(job.data ?? {});
     case ScheduledJobName.InstancePing:
       return instancePingJob();
+    case ScheduledJobName.WebhookCleanup:
+      return webhookCleanupJob();
     default:
       throw new Error(`Unknown job type: ${job.name}`);
   }

--- a/apps/bullmq/src/types.ts
+++ b/apps/bullmq/src/types.ts
@@ -9,6 +9,7 @@ export enum ScheduledJobName {
   SleepCheck = 'SleepCheck',
   PullRequestAnalyticsSync = 'PullRequestAnalyticsSync',
   InstancePing = 'InstancePing',
+  WebhookCleanup = 'WebhookCleanup',
 }
 
 /**

--- a/apps/controller/package.json
+++ b/apps/controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/controller",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/dev/package.json
+++ b/apps/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/dev",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/docs",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "scripts": {
     "dev": "mint dev",

--- a/apps/docs/self-hosting.mdx
+++ b/apps/docs/self-hosting.mdx
@@ -60,6 +60,7 @@ The installer also sets up the `roomote` host CLI for common operations:
 
 ```sh
 roomote upgrade   # pull and roll out newer images
+roomote rollback  # return to the release before the last upgrade
 roomote backup    # create an encrypted deployment recovery bundle
 roomote logs      # tail service logs
 ```
@@ -86,6 +87,30 @@ roomote restore /path/to/backup.roomote --yes
 Restore verifies the encrypted bundle and checksums before replacing any
 state, restores the original `.env` (including `ENCRYPTION_KEY`), repopulates
 empty PostgreSQL/MinIO/Redis volumes, and starts the recorded Roomote release.
+
+## Upgrades and rollback
+
+`roomote upgrade` is designed so a bad release cannot strand your deployment:
+
+- **A backup comes first.** Every upgrade creates an encrypted pre-upgrade
+  bundle under `/opt/roomote/backups` before anything changes. Pass a
+  passphrase with `--backup-passphrase-file` (or `ROOMOTE_BACKUP_PASSPHRASE`);
+  otherwise one is generated and stored next to the bundle. Use
+  `--skip-backup` to opt out.
+- **Migrations run before services are replaced.** Database migrations apply
+  in a single transaction while the previous release keeps serving. If a
+  migration fails, the schema rolls back, the previous configuration is
+  restored, and the previous release stays up.
+- **Rollback is one command.** Every release's schema keeps the previous
+  release working, so `roomote rollback` re-deploys the prior release without
+  touching the database. `roomote upgrade <tag>` does the same for any
+  retained tag, and restoring the pre-upgrade bundle is the last-resort path
+  that also rewinds data.
+
+The supported rollback target is the release immediately before the current
+one. Check the running application version and applied schema migration at any
+time under **Settings → Deployment → Diagnostics**; both are also recorded in
+every backup bundle's manifest.
 
 ## Deployment modes
 

--- a/apps/preview-proxy/package.json
+++ b/apps/preview-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/preview-proxy",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/web",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "scripts": {
     "format": "prettier --write .",

--- a/apps/web/src/app/(authenticated)/home/Home.client.test.tsx
+++ b/apps/web/src/app/(authenticated)/home/Home.client.test.tsx
@@ -462,7 +462,7 @@ describe('Home', () => {
     expect(mockPush).not.toHaveBeenCalledWith('/tasks');
   });
 
-  it('launches Standard Task without a cloud agent id for routed workspaces', async () => {
+  it('launches a standard task run without an agent identity for routed workspaces', async () => {
     mockRouteHomeTask.mockResolvedValue(routedEnvironmentSuggestion);
 
     render(<Home initialPlaceholderIndex={0} />);

--- a/apps/web/src/components/settings/automations/AutomationsSettings.client.test.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.client.test.tsx
@@ -6,7 +6,7 @@ import {
 
 import {
   buildAutomationSettingsSaveInput,
-  buildSaveStateForAgent,
+  buildSaveStateForAutomation,
   mergeServerStatePreservingDirtySections,
   type FormState,
 } from './formState';
@@ -183,7 +183,7 @@ describe('Automations selection helpers', () => {
       suggesterInstructions: '',
     };
 
-    const saveState = buildSaveStateForAgent(
+    const saveState = buildSaveStateForAutomation(
       currentFormState,
       currentSavedState,
       'suggester',
@@ -208,7 +208,7 @@ describe('Automations selection helpers', () => {
       announcerFrequency: 'off',
     };
 
-    const saveState = buildSaveStateForAgent(
+    const saveState = buildSaveStateForAutomation(
       currentFormState,
       currentSavedState,
       'suggester',
@@ -241,7 +241,7 @@ describe('Automations selection helpers', () => {
       managerSlackChannel: '#managers',
     };
 
-    const saveState = buildSaveStateForAgent(
+    const saveState = buildSaveStateForAutomation(
       currentFormState,
       currentSavedState,
       'channelAutoStart',
@@ -320,7 +320,7 @@ describe('Automations selection helpers', () => {
 
     expect(saveInput).toEqual(
       expect.objectContaining({
-        savingAgent: 'announcer',
+        savingAutomation: 'announcer',
         announcerFrequency: 'daily',
         announcerSlackChannel: '#announcements',
         announcerInstructions: 'Keep the summary short.',
@@ -436,7 +436,7 @@ describe('Automations selection helpers', () => {
       ],
     };
 
-    const saveState = buildSaveStateForAgent(
+    const saveState = buildSaveStateForAutomation(
       currentFormState,
       currentSavedState,
       'channelAutoStart',
@@ -471,7 +471,7 @@ describe('Automations selection helpers', () => {
         announcerFrequency: 'off',
       };
 
-      const saveState = buildSaveStateForAgent(
+      const saveState = buildSaveStateForAutomation(
         currentFormState,
         currentSavedState,
         automation.id,

--- a/apps/web/src/components/settings/automations/AutomationsSettings.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.tsx
@@ -35,18 +35,18 @@ import { cn } from '@/lib/utils';
 import { useTRPC } from '@/trpc/client';
 
 import {
-  type AgentType,
+  type AutomationId,
   type AnnouncerFrequency,
   buildAutomationSettingsSaveInput,
   type ChannelAutoStartFormRow,
   type ConflictResolverFrequency,
   type DependabotTriageFrequency,
   type FormState,
-  isAgentDirty,
+  isAutomationDirty,
   type ManagerStatsFrequency,
-  mergeAgentFields,
+  mergeAutomationFields,
   mergeServerStatePreservingDirtySections,
-  resetAgentFields,
+  resetAutomationFields,
   type ReviewerEnvironmentScope,
   type SentryTriageFrequency,
   type SuggesterFrequency,
@@ -175,7 +175,7 @@ type SlackChannelOption = {
 };
 
 type AutomationDefinition = {
-  id: AgentType;
+  id: AutomationId;
   label: string;
   description: string;
   icon: ComponentType<{ className?: string }>;
@@ -261,7 +261,7 @@ const TRIGGERABLE_AUTOMATION_SCHEDULE_LABELS = {
 } as const;
 
 function getAutomationDefinition(
-  agentId: AgentType,
+  automationId: AutomationId,
   automationKey: keyof typeof TRIGGERABLE_AUTOMATION_DESCRIPTIONS,
   icon: ComponentType<{ className?: string }>,
 ): AutomationDefinition {
@@ -273,7 +273,7 @@ function getAutomationDefinition(
   }
 
   return {
-    id: agentId,
+    id: automationId,
     label: descriptor.label,
     description: TRIGGERABLE_AUTOMATION_DESCRIPTIONS[automationKey],
     icon,
@@ -355,7 +355,7 @@ const SCHEDULE_ONLY_AUTOMATIONS_BY_ID = Object.fromEntries(
   (typeof SCHEDULE_ONLY_BACKGROUND_AUTOMATION_LIST)[number]
 >;
 
-const AUTOMATION_DEFINITIONS: Record<AgentType, AutomationDefinition> = {
+const AUTOMATION_DEFINITIONS: Record<AutomationId, AutomationDefinition> = {
   channelAutoStart: {
     id: 'channelAutoStart',
     label: 'Auto-respond to Slack channels',
@@ -415,7 +415,7 @@ const AUTOMATION_DEFINITIONS: Record<AgentType, AutomationDefinition> = {
   },
 };
 
-const HASH_ALIAS_TO_AGENT_ID: Record<string, AgentType> = {
+const HASH_ALIAS_TO_AUTOMATION_ID: Record<string, AutomationId> = {
   'auto-respond-channels': 'channelAutoStart',
   autorespondchannels: 'channelAutoStart',
   'auto-start-tasks': 'channelAutoStart',
@@ -450,8 +450,8 @@ const HASH_ALIAS_TO_AGENT_ID: Record<string, AgentType> = {
   'platform-issue-alerts': 'platformIssueAlerts',
 };
 
-const AUTOMATION_RUN_KEYS_BY_AGENT: Partial<
-  Record<AgentType, BackgroundAutomationKey>
+const AUTOMATION_RUN_KEYS_BY_ID: Partial<
+  Record<AutomationId, BackgroundAutomationKey>
 > = {
   conflictResolver: 'conflict_resolver',
   suggester: 'suggester',
@@ -503,7 +503,7 @@ function buildScheduleOnlyAutomationDirtyState(params: {
     SCHEDULE_ONLY_BACKGROUND_AUTOMATION_LIST.map((automation) => [
       automation.id,
       params.formState && params.savedState
-        ? isAgentDirty(params.formState, params.savedState, automation.id)
+        ? isAutomationDirty(params.formState, params.savedState, automation.id)
         : false,
     ]),
   ) as Record<ScheduleOnlyBackgroundAutomationId, boolean>;
@@ -678,14 +678,14 @@ function mapSettingsToFormState(
   };
 }
 
-export function resolveAutomationHashTarget(hash: string): AgentType | null {
+export function resolveAutomationHashTarget(hash: string): AutomationId | null {
   const normalized = hash.trim().replace(/^#/, '').toLowerCase();
 
   if (!normalized) {
     return null;
   }
 
-  return HASH_ALIAS_TO_AGENT_ID[normalized] ?? null;
+  return HASH_ALIAS_TO_AUTOMATION_ID[normalized] ?? null;
 }
 
 export function buildSlackWorkflowLaunchUrl(
@@ -1441,8 +1441,10 @@ export function AutomationsSettings() {
   const [managerSlackChannelId, setManagerSlackChannelId] = useState<
     string | null
   >(null);
-  const [savingAgent, setSavingAgent] = useState<AgentType | null>(null);
-  const [openAgentIds, setOpenAgentIds] = useState<Set<AgentType>>(
+  const [savingAutomation, setSavingAutomation] = useState<AutomationId | null>(
+    null,
+  );
+  const [openAutomationIds, setOpenAutomationIds] = useState<Set<AutomationId>>(
     () => new Set(),
   );
   const [isEditingManagerChannel, setIsEditingManagerChannel] = useState(false);
@@ -1543,10 +1545,10 @@ export function AutomationsSettings() {
   const updateMutation = useMutation(
     trpc.automations.updateSettings.mutationOptions({
       onSuccess: (result) => {
-        const automationLabel = savingAgent
-          ? AUTOMATION_DEFINITIONS[savingAgent].label
+        const automationLabel = savingAutomation
+          ? AUTOMATION_DEFINITIONS[savingAutomation].label
           : null;
-        setSavingAgent(null);
+        setSavingAutomation(null);
 
         if (!result.success) {
           setFieldErrors(result.fieldErrors);
@@ -1559,7 +1561,7 @@ export function AutomationsSettings() {
           }
 
           if (result.fieldErrors.managerSlackChannel) {
-            setOpenAgentIds((prev) => {
+            setOpenAutomationIds((prev) => {
               if (prev.has('managerChannel')) {
                 return prev;
               }
@@ -1574,7 +1576,7 @@ export function AutomationsSettings() {
             result.fieldErrors.channelAutoStartSlackChannels ||
             result.fieldErrors.channelAutoStartInstructions
           ) {
-            setOpenAgentIds((prev) => {
+            setOpenAutomationIds((prev) => {
               if (prev.has('channelAutoStart')) {
                 return prev;
               }
@@ -1588,7 +1590,7 @@ export function AutomationsSettings() {
         }
 
         setFieldErrors({});
-        if (savingAgent === 'suggester') {
+        if (savingAutomation === 'suggester') {
           const nextRoutingPreview = result.suggesterRoutingPreview ?? null;
           setSuggesterRoutingPreview(nextRoutingPreview);
           setIsEditingSuggesterRouting(
@@ -1627,13 +1629,13 @@ export function AutomationsSettings() {
           reviewer: result.reviewer,
         });
         setFormState((prev) =>
-          savingAgent && prev
-            ? mergeAgentFields(prev, mapped, savingAgent)
+          savingAutomation && prev
+            ? mergeAutomationFields(prev, mapped, savingAutomation)
             : mapped,
         );
         setSavedState((prev) =>
-          savingAgent && prev
-            ? mergeAgentFields(prev, mapped, savingAgent)
+          savingAutomation && prev
+            ? mergeAutomationFields(prev, mapped, savingAutomation)
             : mapped,
         );
 
@@ -1641,7 +1643,7 @@ export function AutomationsSettings() {
           queryKey: trpc.automations.getSettings.queryKey(),
         });
 
-        if (savingAgent === 'managerChannel') {
+        if (savingAutomation === 'managerChannel') {
           setIsEditingManagerChannel(false);
           setIsEnteringCustomManagerChannel(false);
         }
@@ -1653,10 +1655,10 @@ export function AutomationsSettings() {
         );
       },
       onError: (error) => {
-        const automationLabel = savingAgent
-          ? AUTOMATION_DEFINITIONS[savingAgent].label
+        const automationLabel = savingAutomation
+          ? AUTOMATION_DEFINITIONS[savingAutomation].label
           : null;
-        setSavingAgent(null);
+        setSavingAutomation(null);
         toast.error(
           automationLabel
             ? `Failed to save ${automationLabel} settings: ${error.message}`
@@ -1731,17 +1733,33 @@ export function AutomationsSettings() {
     }
 
     return {
-      channelAutoStart: isAgentDirty(formState, savedState, 'channelAutoStart'),
-      managerChannel: isAgentDirty(formState, savedState, 'managerChannel'),
-      managerStats: isAgentDirty(formState, savedState, 'managerStats'),
-      sentryTriage: isAgentDirty(formState, savedState, 'sentryTriage'),
-      dependabotTriage: isAgentDirty(formState, savedState, 'dependabotTriage'),
+      channelAutoStart: isAutomationDirty(
+        formState,
+        savedState,
+        'channelAutoStart',
+      ),
+      managerChannel: isAutomationDirty(
+        formState,
+        savedState,
+        'managerChannel',
+      ),
+      managerStats: isAutomationDirty(formState, savedState, 'managerStats'),
+      sentryTriage: isAutomationDirty(formState, savedState, 'sentryTriage'),
+      dependabotTriage: isAutomationDirty(
+        formState,
+        savedState,
+        'dependabotTriage',
+      ),
       ...scheduleOnlyAutomationDirtyState,
-      reviewer: isAgentDirty(formState, savedState, 'reviewer'),
-      conflictResolver: isAgentDirty(formState, savedState, 'conflictResolver'),
-      suggester: isAgentDirty(formState, savedState, 'suggester'),
-      announcer: isAgentDirty(formState, savedState, 'announcer'),
-      platformIssueAlerts: isAgentDirty(
+      reviewer: isAutomationDirty(formState, savedState, 'reviewer'),
+      conflictResolver: isAutomationDirty(
+        formState,
+        savedState,
+        'conflictResolver',
+      ),
+      suggester: isAutomationDirty(formState, savedState, 'suggester'),
+      announcer: isAutomationDirty(formState, savedState, 'announcer'),
+      platformIssueAlerts: isAutomationDirty(
         formState,
         savedState,
         'platformIssueAlerts',
@@ -1754,12 +1772,12 @@ export function AutomationsSettings() {
   const automationStatusByKey = settingsQuery.data?.automationStatus;
 
   const renderDebugRunsSection = useCallback(
-    (agent: AgentType) => {
+    (automationId: AutomationId) => {
       if (!showAutomationDebugRuns) {
         return null;
       }
 
-      const automationKey = AUTOMATION_RUN_KEYS_BY_AGENT[agent];
+      const automationKey = AUTOMATION_RUN_KEYS_BY_ID[automationId];
 
       if (!automationKey) {
         return null;
@@ -1776,47 +1794,50 @@ export function AutomationsSettings() {
   );
 
   const saveAgent = useCallback(
-    (agent: AgentType) => {
+    (automationId: AutomationId) => {
       if (!formState || !savedState) {
         return;
       }
 
       setFieldErrors({});
-      setSavingAgent(agent);
+      setSavingAutomation(automationId);
 
       updateMutation.mutate(
-        buildAutomationSettingsSaveInput(formState, savedState, agent),
+        buildAutomationSettingsSaveInput(formState, savedState, automationId),
       );
     },
     [formState, savedState, updateMutation],
   );
 
   const resetAgent = useCallback(
-    (agent: AgentType) => {
+    (automationId: AutomationId) => {
       if (!formState || !savedState) {
         return;
       }
 
-      if (agent === 'managerChannel') {
+      if (automationId === 'managerChannel') {
         setIsEnteringCustomManagerChannel(false);
       }
 
-      setFormState(resetAgentFields(formState, savedState, agent));
+      setFormState(resetAutomationFields(formState, savedState, automationId));
     },
     [formState, savedState],
   );
 
-  const setAgentOpen = useCallback((agent: AgentType, open: boolean) => {
-    setOpenAgentIds((prev) => {
-      const next = new Set(prev);
-      if (open) {
-        next.add(agent);
-      } else {
-        next.delete(agent);
-      }
-      return next;
-    });
-  }, []);
+  const setAutomationOpen = useCallback(
+    (automationId: AutomationId, open: boolean) => {
+      setOpenAutomationIds((prev) => {
+        const next = new Set(prev);
+        if (open) {
+          next.add(automationId);
+        } else {
+          next.delete(automationId);
+        }
+        return next;
+      });
+    },
+    [],
+  );
 
   const setScheduleOnlyAutomationFrequency = useCallback(
     (
@@ -1848,7 +1869,7 @@ export function AutomationsSettings() {
       return;
     }
 
-    setOpenAgentIds((prev) => {
+    setOpenAutomationIds((prev) => {
       if (prev.has(target)) {
         return prev;
       }
@@ -2101,33 +2122,33 @@ export function AutomationsSettings() {
     suggester: suggesterIsEnabled,
     announcer: announcerIsEnabled,
     platformIssueAlerts: isPlatformIssueAlertsEnabled(formState),
-  } satisfies Record<AgentType, boolean>;
+  } satisfies Record<AutomationId, boolean>;
 
-  const isAgentSaving = (agent: AgentType) =>
-    updateMutation.isPending && savingAgent === agent;
+  const isAutomationSaving = (automationId: AutomationId) =>
+    updateMutation.isPending && savingAutomation === automationId;
 
   const isRunDisabled = (
-    agent: AgentType,
+    automationId: AutomationId,
     isEnabled: boolean,
     isBlocked = false,
   ) =>
     isAutomationRunDisabled({
       isEnabled,
-      isDirty: isDirty[agent],
-      isSaving: isAgentSaving(agent),
+      isDirty: isDirty[automationId],
+      isSaving: isAutomationSaving(automationId),
       isTriggering: triggerMutation.isPending,
       isBlocked,
     });
 
   const getRunTooltip = (
-    agent: AgentType,
+    automationId: AutomationId,
     isEnabled: boolean,
     blockedReason?: string | null,
   ) =>
     getAutomationRunTooltip({
       isEnabled,
-      isDirty: isDirty[agent],
-      isSaving: isAgentSaving(agent),
+      isDirty: isDirty[automationId],
+      isSaving: isAutomationSaving(automationId),
       blockedReason,
     });
   const slackAutomationsDisabled = !managerChannelConfigured;
@@ -2237,15 +2258,17 @@ export function AutomationsSettings() {
 
             <AutomationCard
               automation={AUTOMATION_DEFINITIONS.channelAutoStart}
-              isOpen={openAgentIds.has('channelAutoStart')}
-              onOpenChange={(open) => setAgentOpen('channelAutoStart', open)}
+              isOpen={openAutomationIds.has('channelAutoStart')}
+              onOpenChange={(open) =>
+                setAutomationOpen('channelAutoStart', open)
+              }
               iconEnabled={iconEnabled.channelAutoStart}
               footer={
                 <AutomationFooter
                   isDirty={isDirty.channelAutoStart}
                   isPending={
                     updateMutation.isPending &&
-                    savingAgent === 'channelAutoStart'
+                    savingAutomation === 'channelAutoStart'
                   }
                   onSave={() => saveAgent('channelAutoStart')}
                   onReset={() => resetAgent('channelAutoStart')}
@@ -2469,7 +2492,7 @@ export function AutomationsSettings() {
                       isDirty={isDirty.managerChannel}
                       isPending={
                         updateMutation.isPending &&
-                        savingAgent === 'managerChannel'
+                        savingAutomation === 'managerChannel'
                       }
                       onSave={() => saveAgent('managerChannel')}
                       onReset={() => {
@@ -2511,8 +2534,8 @@ export function AutomationsSettings() {
 
           <AutomationCard
             automation={AUTOMATION_DEFINITIONS.managerStats}
-            isOpen={openAgentIds.has('managerStats')}
-            onOpenChange={(open) => setAgentOpen('managerStats', open)}
+            isOpen={openAutomationIds.has('managerStats')}
+            onOpenChange={(open) => setAutomationOpen('managerStats', open)}
             iconEnabled={iconEnabled.managerStats}
             debugSection={renderDebugRunsSection('managerStats')}
             runAction={
@@ -2538,7 +2561,8 @@ export function AutomationsSettings() {
               <AutomationFooter
                 isDirty={isDirty.managerStats}
                 isPending={
-                  updateMutation.isPending && savingAgent === 'managerStats'
+                  updateMutation.isPending &&
+                  savingAutomation === 'managerStats'
                 }
                 onSave={() => saveAgent('managerStats')}
                 onReset={() => resetAgent('managerStats')}
@@ -2592,8 +2616,8 @@ export function AutomationsSettings() {
           <>
             <AutomationCard
               automation={AUTOMATION_DEFINITIONS.sentryTriage}
-              isOpen={openAgentIds.has('sentryTriage')}
-              onOpenChange={(open) => setAgentOpen('sentryTriage', open)}
+              isOpen={openAutomationIds.has('sentryTriage')}
+              onOpenChange={(open) => setAutomationOpen('sentryTriage', open)}
               iconEnabled={iconEnabled.sentryTriage}
               debugSection={renderDebugRunsSection('sentryTriage')}
               runAction={
@@ -2624,7 +2648,8 @@ export function AutomationsSettings() {
                 <AutomationFooter
                   isDirty={isDirty.sentryTriage}
                   isPending={
-                    updateMutation.isPending && savingAgent === 'sentryTriage'
+                    updateMutation.isPending &&
+                    savingAutomation === 'sentryTriage'
                   }
                   saveDisabled={sentryTriageSaveDisabled}
                   onSave={() => saveAgent('sentryTriage')}
@@ -2764,8 +2789,10 @@ export function AutomationsSettings() {
 
             <ScheduledAutomationCard
               automation={AUTOMATION_DEFINITIONS.dependabotTriage}
-              isOpen={openAgentIds.has('dependabotTriage')}
-              onOpenChange={(open) => setAgentOpen('dependabotTriage', open)}
+              isOpen={openAutomationIds.has('dependabotTriage')}
+              onOpenChange={(open) =>
+                setAutomationOpen('dependabotTriage', open)
+              }
               iconEnabled={iconEnabled.dependabotTriage}
               debugSection={renderDebugRunsSection('dependabotTriage')}
               runTooltip={getRunTooltip(
@@ -2783,7 +2810,8 @@ export function AutomationsSettings() {
               }
               isDirty={isDirty.dependabotTriage}
               isPending={
-                updateMutation.isPending && savingAgent === 'dependabotTriage'
+                updateMutation.isPending &&
+                savingAutomation === 'dependabotTriage'
               }
               onSave={() => saveAgent('dependabotTriage')}
               onReset={() => resetAgent('dependabotTriage')}
@@ -2845,8 +2873,10 @@ export function AutomationsSettings() {
                 <AutomationCard
                   key={automation.id}
                   automation={AUTOMATION_DEFINITIONS[automation.id]}
-                  isOpen={openAgentIds.has(automation.id)}
-                  onOpenChange={(open) => setAgentOpen(automation.id, open)}
+                  isOpen={openAutomationIds.has(automation.id)}
+                  onOpenChange={(open) =>
+                    setAutomationOpen(automation.id, open)
+                  }
                   iconEnabled={iconEnabled[automation.id]}
                   debugSection={renderDebugRunsSection(automation.id)}
                   runAction={
@@ -2880,7 +2910,7 @@ export function AutomationsSettings() {
                       isDirty={isDirty[automation.id]}
                       isPending={
                         updateMutation.isPending &&
-                        savingAgent === automation.id
+                        savingAutomation === automation.id
                       }
                       onSave={() => saveAgent(automation.id)}
                       onReset={() => resetAgent(automation.id)}
@@ -2947,8 +2977,8 @@ export function AutomationsSettings() {
 
           <AutomationCard
             automation={AUTOMATION_DEFINITIONS.suggester}
-            isOpen={openAgentIds.has('suggester')}
-            onOpenChange={(open) => setAgentOpen('suggester', open)}
+            isOpen={openAutomationIds.has('suggester')}
+            onOpenChange={(open) => setAutomationOpen('suggester', open)}
             iconEnabled={iconEnabled.suggester}
             disabled={slackAutomationsDisabled}
             debugSection={renderDebugRunsSection('suggester')}
@@ -2972,7 +3002,7 @@ export function AutomationsSettings() {
               <AutomationFooter
                 isDirty={isDirty.suggester}
                 isPending={
-                  updateMutation.isPending && savingAgent === 'suggester'
+                  updateMutation.isPending && savingAutomation === 'suggester'
                 }
                 onSave={() => saveAgent('suggester')}
                 onReset={() => resetAgent('suggester')}
@@ -3224,8 +3254,8 @@ If unclear, send to manager channel.`}
 
           <AutomationCard
             automation={AUTOMATION_DEFINITIONS.announcer}
-            isOpen={openAgentIds.has('announcer')}
-            onOpenChange={(open) => setAgentOpen('announcer', open)}
+            isOpen={openAutomationIds.has('announcer')}
+            onOpenChange={(open) => setAutomationOpen('announcer', open)}
             iconEnabled={iconEnabled.announcer}
             disabled={slackAutomationsDisabled}
             debugSection={renderDebugRunsSection('announcer')}
@@ -3249,7 +3279,7 @@ If unclear, send to manager channel.`}
               <AutomationFooter
                 isDirty={isDirty.announcer}
                 isPending={
-                  updateMutation.isPending && savingAgent === 'announcer'
+                  updateMutation.isPending && savingAutomation === 'announcer'
                 }
                 onSave={() => saveAgent('announcer')}
                 onReset={() => resetAgent('announcer')}
@@ -3329,14 +3359,14 @@ If unclear, send to manager channel.`}
 
           <AutomationCard
             automation={AUTOMATION_DEFINITIONS.reviewer}
-            isOpen={openAgentIds.has('reviewer')}
-            onOpenChange={(open) => setAgentOpen('reviewer', open)}
+            isOpen={openAutomationIds.has('reviewer')}
+            onOpenChange={(open) => setAutomationOpen('reviewer', open)}
             iconEnabled={iconEnabled.reviewer}
             footer={
               <AutomationFooter
                 isDirty={isDirty.reviewer}
                 isPending={
-                  updateMutation.isPending && savingAgent === 'reviewer'
+                  updateMutation.isPending && savingAutomation === 'reviewer'
                 }
                 onSave={() => saveAgent('reviewer')}
                 onReset={() => resetAgent('reviewer')}
@@ -3472,8 +3502,8 @@ If unclear, send to manager channel.`}
 
           <AutomationCard
             automation={AUTOMATION_DEFINITIONS.conflictResolver}
-            isOpen={openAgentIds.has('conflictResolver')}
-            onOpenChange={(open) => setAgentOpen('conflictResolver', open)}
+            isOpen={openAutomationIds.has('conflictResolver')}
+            onOpenChange={(open) => setAutomationOpen('conflictResolver', open)}
             iconEnabled={iconEnabled.conflictResolver}
             debugSection={renderDebugRunsSection('conflictResolver')}
             runAction={
@@ -3504,7 +3534,8 @@ If unclear, send to manager channel.`}
               <AutomationFooter
                 isDirty={isDirty.conflictResolver}
                 isPending={
-                  updateMutation.isPending && savingAgent === 'conflictResolver'
+                  updateMutation.isPending &&
+                  savingAutomation === 'conflictResolver'
                 }
                 onSave={() => saveAgent('conflictResolver')}
                 onReset={() => resetAgent('conflictResolver')}

--- a/apps/web/src/components/settings/automations/formState.ts
+++ b/apps/web/src/components/settings/automations/formState.ts
@@ -82,7 +82,7 @@ export type FormState = {
   ciFailureTriageSlackChannel: string;
 } & ScheduleOnlyAutomationFormFields;
 
-export type AgentType =
+export type AutomationId =
   | 'channelAutoStart'
   | 'managerChannel'
   | 'managerStats'
@@ -156,7 +156,7 @@ const PLATFORM_ISSUE_ALERT_FIELDS: Array<keyof FormState> = [
   'platformIssueSlackChannel',
 ];
 
-const SCHEDULE_ONLY_AGENT_FIELDS = Object.fromEntries(
+const SCHEDULE_ONLY_AUTOMATION_FIELDS = Object.fromEntries(
   SCHEDULE_ONLY_BACKGROUND_AUTOMATION_LIST.map((automation) => [
     automation.id,
     [
@@ -170,13 +170,13 @@ const SCHEDULE_ONLY_AGENT_FIELDS = Object.fromEntries(
   ]),
 ) as Record<ScheduleOnlyBackgroundAutomationId, Array<keyof FormState>>;
 
-const AGENT_FIELDS: Record<AgentType, Array<keyof FormState>> = {
+const AUTOMATION_FIELDS: Record<AutomationId, Array<keyof FormState>> = {
   channelAutoStart: CHANNEL_AUTO_START_FIELDS,
   managerChannel: MANAGER_CHANNEL_FIELDS,
   managerStats: MANAGER_STATS_FIELDS,
   sentryTriage: SENTRY_TRIAGE_FIELDS,
   dependabotTriage: DEPENDABOT_TRIAGE_FIELDS,
-  ...SCHEDULE_ONLY_AGENT_FIELDS,
+  ...SCHEDULE_ONLY_AUTOMATION_FIELDS,
   reviewer: REVIEWER_FIELDS,
   conflictResolver: CONFLICT_RESOLVER_FIELDS,
   suggester: SUGGESTER_FIELDS,
@@ -184,48 +184,48 @@ const AGENT_FIELDS: Record<AgentType, Array<keyof FormState>> = {
   platformIssueAlerts: PLATFORM_ISSUE_ALERT_FIELDS,
 };
 
-export function isAgentDirty(
+export function isAutomationDirty(
   formState: FormState,
   savedState: FormState,
-  agent: AgentType,
+  automationId: AutomationId,
 ): boolean {
-  return AGENT_FIELDS[agent].some(
+  return AUTOMATION_FIELDS[automationId].some(
     (field) => formState[field] !== savedState[field],
   );
 }
 
-export function resetAgentFields(
+export function resetAutomationFields(
   formState: FormState,
   savedState: FormState,
-  agent: AgentType,
+  automationId: AutomationId,
 ): FormState {
   const updated = { ...formState };
-  for (const field of AGENT_FIELDS[agent]) {
+  for (const field of AUTOMATION_FIELDS[automationId]) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (updated as any)[field] = savedState[field];
   }
   return updated;
 }
 
-export function mergeAgentFields(
+export function mergeAutomationFields(
   currentState: FormState,
   nextState: FormState,
-  agent: AgentType,
+  automationId: AutomationId,
 ): FormState {
   const updated = { ...currentState };
-  for (const field of AGENT_FIELDS[agent]) {
+  for (const field of AUTOMATION_FIELDS[automationId]) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (updated as any)[field] = nextState[field];
   }
   return updated;
 }
 
-export function buildSaveStateForAgent(
+export function buildSaveStateForAutomation(
   formState: FormState,
   savedState: FormState,
-  agent: AgentType,
+  automationId: AutomationId,
 ): FormState {
-  return mergeAgentFields(savedState, formState, agent);
+  return mergeAutomationFields(savedState, formState, automationId);
 }
 
 function buildScheduleOnlyAutomationSaveInput(
@@ -242,12 +242,16 @@ function buildScheduleOnlyAutomationSaveInput(
 export function buildAutomationSettingsSaveInput(
   formState: FormState,
   savedState: FormState,
-  agent: AgentType,
+  automationId: AutomationId,
 ) {
-  const stateToSave = buildSaveStateForAgent(formState, savedState, agent);
+  const stateToSave = buildSaveStateForAutomation(
+    formState,
+    savedState,
+    automationId,
+  );
 
   return {
-    savingAgent: agent,
+    savingAutomation: automationId,
     reviewerEnabled: stateToSave.reviewerEnabled,
     reviewerEnvironmentScope: 'all' as const,
     reviewerEnvironmentIds: [],
@@ -318,13 +322,17 @@ export function mergeServerStatePreservingDirtySections(
   let nextFormState = { ...incomingState };
   let nextSavedState = { ...incomingState };
 
-  for (const agent of Object.keys(AGENT_FIELDS) as AgentType[]) {
-    if (isAgentDirty(currentFormState, currentSavedState, agent)) {
-      nextFormState = mergeAgentFields(nextFormState, currentFormState, agent);
-      nextSavedState = mergeAgentFields(
+  for (const automationId of Object.keys(AUTOMATION_FIELDS) as AutomationId[]) {
+    if (isAutomationDirty(currentFormState, currentSavedState, automationId)) {
+      nextFormState = mergeAutomationFields(
+        nextFormState,
+        currentFormState,
+        automationId,
+      );
+      nextSavedState = mergeAutomationFields(
         nextSavedState,
         currentSavedState,
-        agent,
+        automationId,
       );
     }
   }

--- a/apps/web/src/trpc/commands/automations/settings-update.ts
+++ b/apps/web/src/trpc/commands/automations/settings-update.ts
@@ -169,18 +169,22 @@ export async function updateBackgroundAgentSettingsCommand(
   assertAdmin(auth);
   const fieldErrors: BackgroundAgentFieldErrors = {};
   const existingSettings = await getBackgroundAgentSettingsForDeployment();
-  const shouldUpdateChannelAutoStart = input.savingAgent === 'channelAutoStart';
-  const shouldUpdateManagerStats = input.savingAgent === 'managerStats';
-  const shouldUpdateSentryTriage = input.savingAgent === 'sentryTriage';
-  const shouldUpdateDependabotTriage = input.savingAgent === 'dependabotTriage';
-  const shouldUpdateSuggester = input.savingAgent === 'suggester';
-  const shouldUpdateAnnouncer = input.savingAgent === 'announcer';
+  const shouldUpdateChannelAutoStart =
+    input.savingAutomation === 'channelAutoStart';
+  const shouldUpdateManagerStats = input.savingAutomation === 'managerStats';
+  const shouldUpdateSentryTriage = input.savingAutomation === 'sentryTriage';
+  const shouldUpdateDependabotTriage =
+    input.savingAutomation === 'dependabotTriage';
+  const shouldUpdateSuggester = input.savingAutomation === 'suggester';
+  const shouldUpdateAnnouncer = input.savingAutomation === 'announcer';
   const shouldUpdatePlatformIssueAlerts =
-    input.savingAgent === 'platformIssueAlerts';
-  const shouldUpdateSecurityAuditor = input.savingAgent === 'securityAuditor';
+    input.savingAutomation === 'platformIssueAlerts';
+  const shouldUpdateSecurityAuditor =
+    input.savingAutomation === 'securityAuditor';
   const shouldUpdateCodeQualityAuditor =
-    input.savingAgent === 'codeQualityAuditor';
-  const shouldUpdateCiFailureTriage = input.savingAgent === 'ciFailureTriage';
+    input.savingAutomation === 'codeQualityAuditor';
+  const shouldUpdateCiFailureTriage =
+    input.savingAutomation === 'ciFailureTriage';
 
   const conflictResolverLabel =
     input.conflictResolverLabel.trim() || DEFAULT_CONFLICT_RESOLVER_LABEL;
@@ -248,7 +252,7 @@ export async function updateBackgroundAgentSettingsCommand(
     : existingSettings.suggesterRoutingInstructions;
   const shouldValidateSuggesterRoutingPreview =
     suggestionRoutingEnabled &&
-    input.savingAgent === 'suggester' &&
+    input.savingAutomation === 'suggester' &&
     effectiveSuggesterRoutingMode === 'group_by_instructions';
   let suggesterRoutingPreview: SuggestionRoutingPreviewRoute[] | null = null;
 
@@ -269,7 +273,8 @@ export async function updateBackgroundAgentSettingsCommand(
     fieldErrors.announcerInstructions = 'Announcer instructions are too long.';
   }
 
-  const shouldUpdateManagerChannel = input.savingAgent === 'managerChannel';
+  const shouldUpdateManagerChannel =
+    input.savingAutomation === 'managerChannel';
   const submittedManagerSlackChannel = normalizeOptionalText(
     input.managerSlackChannel ?? null,
   );
@@ -567,7 +572,7 @@ export async function updateBackgroundAgentSettingsCommand(
     ({ channelId }) => channelId,
   );
   const managerChannelHasApp =
-    input.savingAgent === 'managerChannel' &&
+    input.savingAutomation === 'managerChannel' &&
     managerChannelChanged &&
     managerChannelResult.channelId &&
     notifier

--- a/apps/web/src/trpc/commands/automations/types.ts
+++ b/apps/web/src/trpc/commands/automations/types.ts
@@ -114,7 +114,7 @@ export interface ResolvedChannelAutoStartRow {
 }
 
 export interface UpdateBackgroundAgentSettingsInput extends ScheduleOnlyAutomationInputFields {
-  savingAgent:
+  savingAutomation:
     | 'channelAutoStart'
     | 'managerChannel'
     | 'managerStats'

--- a/apps/web/src/trpc/commands/github/mutations.test.ts
+++ b/apps/web/src/trpc/commands/github/mutations.test.ts
@@ -69,6 +69,7 @@ vi.stubGlobal('fetch', mockFetch);
 
 import {
   finishCreateGitHubAppManifestCommand,
+  startAuthenticateGitHubAccountCommand,
   startCreateGitHubInstallationCommand,
   startCreateGitHubAppManifestCommand,
 } from './mutations';
@@ -432,5 +433,54 @@ describe('GitHub App manifest commands', () => {
     });
     expect(mockDbTransaction).not.toHaveBeenCalled();
     expect(mockUpsertDeploymentEnvironmentVariables).not.toHaveBeenCalled();
+  });
+});
+
+describe('startAuthenticateGitHubAccountCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('builds the authorize URL from the deployment-resolved client id', async () => {
+    mockResolveDeploymentEnvVar.mockImplementation(async (name: string) =>
+      name === 'GITHUB_CLIENT_ID' ? 'Iv1.resolved-client' : null,
+    );
+
+    const result = await startAuthenticateGitHubAccountCommand(
+      buildMockAuth(),
+      { redirect: '/settings?tab=account' },
+    );
+
+    expect(result.success).toBe(true);
+
+    if (!result.success) {
+      return;
+    }
+
+    const url = new URL(result.url);
+    expect(`${url.origin}${url.pathname}`).toBe(
+      'https://github.com/login/oauth/authorize',
+    );
+    expect(url.searchParams.get('client_id')).toBe('Iv1.resolved-client');
+    expect(url.searchParams.get('scope')).toBe('read:user');
+    expect(url.searchParams.get('redirect_uri')).toBe(
+      'https://roomote.example.com/github/callback',
+    );
+    expect(decodeRecord(url.searchParams.get('state') ?? '')).toEqual({
+      redirect: '/settings?tab=account',
+      mode: 'auth',
+    });
+  });
+
+  it('refuses to link an account when no GitHub App client id is configured', async () => {
+    mockResolveDeploymentEnvVar.mockResolvedValue(null);
+
+    const result = await startAuthenticateGitHubAccountCommand(buildMockAuth());
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        'Configure a GitHub App for this deployment before linking your GitHub account. Create one or enter its credentials first.',
+    });
   });
 });

--- a/apps/web/src/trpc/commands/github/mutations.ts
+++ b/apps/web/src/trpc/commands/github/mutations.ts
@@ -343,9 +343,26 @@ async function getGitHubOAuthUser({
     }
   | { success: false; error: string }
 > {
+  const [clientId, clientSecret] = await Promise.all([
+    resolveDeploymentEnvVar('GITHUB_CLIENT_ID'),
+    resolveDeploymentEnvVar('GITHUB_CLIENT_SECRET'),
+  ]);
+
+  if (!clientId || !clientSecret) {
+    console.error(
+      `[${context}] GitHub App OAuth credentials are not configured.`,
+    );
+
+    return {
+      success: false,
+      error:
+        'GitHub App OAuth credentials are not configured for this deployment.',
+    };
+  }
+
   const params = new URLSearchParams({
-    client_id: Env.GITHUB_CLIENT_ID,
-    client_secret: Env.GITHUB_CLIENT_SECRET,
+    client_id: clientId,
+    client_secret: clientSecret,
     code,
   });
 
@@ -778,9 +795,19 @@ export async function startAuthenticateGitHubAccountCommand(
   state?: Record<string, string>,
 ): Promise<{ success: true; url: string } | { success: false; error: string }> {
   try {
+    const clientId = await resolveDeploymentEnvVar('GITHUB_CLIENT_ID');
+
+    if (!clientId) {
+      return {
+        success: false,
+        error:
+          'Configure a GitHub App for this deployment before linking your GitHub account. Create one or enter its credentials first.',
+      };
+    }
+
     const baseUrl = Env.ROOMOTE_APP_URL;
     const params = new URLSearchParams({
-      client_id: Env.GITHUB_CLIENT_ID,
+      client_id: clientId,
       scope: 'read:user',
       state: encodeRecord({ ...(state ?? {}), mode: 'auth' }),
     });

--- a/apps/web/src/trpc/commands/task-suggestions/implement.ts
+++ b/apps/web/src/trpc/commands/task-suggestions/implement.ts
@@ -103,7 +103,7 @@ export async function implementTaskSuggestionCommand(
           description: buildSuggestionTaskPromptText({
             title: suggestion.title,
             brief: suggestion.brief ?? '',
-            agentType:
+            suggestionType:
               automation === 'onboarding' ? 'setup_onboarding' : automation,
             investigationContext: suggestion.investigationContext,
             readinessMessage: resolution.workspace.readinessMessage,

--- a/apps/web/src/trpc/commands/tasks/run-events.ts
+++ b/apps/web/src/trpc/commands/tasks/run-events.ts
@@ -1,4 +1,4 @@
-import { asc, db, eq, taskRunEvents } from '@roomote/db/server';
+import { db, desc, eq, taskRunEvents } from '@roomote/db/server';
 
 const MAX_RUN_EVENTS = 500;
 
@@ -20,8 +20,11 @@ export async function getTaskRunEventsCommand(input: { taskId: string }) {
     })
     .from(taskRunEvents)
     .where(eq(taskRunEvents.taskId, input.taskId))
-    .orderBy(asc(taskRunEvents.createdAt))
+    // Newest first under the limit: diagnostics cluster at the end of a run,
+    // and a busy task must never push them out of the window. Reversed after
+    // the query so callers still get chronological order.
+    .orderBy(desc(taskRunEvents.createdAt))
     .limit(MAX_RUN_EVENTS);
 
-  return { events };
+  return { events: events.reverse() };
 }

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -326,7 +326,7 @@ const SCHEDULE_ONLY_BACKGROUND_AUTOMATION_FREQUENCY_SCHEMA = z.enum(
   SCHEDULE_ONLY_BACKGROUND_AUTOMATION_FREQUENCIES,
 );
 
-const UPDATE_SETTINGS_SAVING_AGENT_VALUES = [
+const UPDATE_SETTINGS_SAVING_AUTOMATION_VALUES = [
   'channelAutoStart',
   'managerChannel',
   'managerStats',
@@ -376,8 +376,8 @@ const automationsRouter = createRouter({
   updateSettings: protectedProcedure
     .input(
       z.object({
-        savingAgent: createStringEnumSchema(
-          UPDATE_SETTINGS_SAVING_AGENT_VALUES,
+        savingAutomation: createStringEnumSchema(
+          UPDATE_SETTINGS_SAVING_AUTOMATION_VALUES,
         ),
         reviewerEnabled: z.boolean(),
         reviewerEnvironmentScope: z.enum(['all', 'specific']),

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/worker",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/launch-task.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/launch-task.test.ts
@@ -43,11 +43,11 @@ describe('handleLaunchTask', () => {
     });
   });
 
-  it('uses the implicit Generalist path for standard launches', async () => {
+  it('uses the implicit standard-workflow path for standard launches', async () => {
     vi.mocked(tasksApiClient.launchTask).mockResolvedValueOnce({
       success: true,
       runId: 100,
-      taskId: 'task-generalist',
+      taskId: 'task-standard',
     });
 
     const result = await handleLaunchTask(
@@ -69,7 +69,7 @@ describe('handleLaunchTask', () => {
     const text = result.content[0]?.text ?? '';
     const parsed = JSON.parse(text);
     expect(parsed.success).toBe(true);
-    expect(parsed.taskId).toBe('task-generalist');
+    expect(parsed.taskId).toBe('task-standard');
   });
 
   it('should return error when API returns success=false', async () => {

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/tasks-api-client.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/tasks-api-client.test.ts
@@ -415,11 +415,11 @@ describe('launchTask', () => {
     expect(body.type).toBe('standard');
   });
 
-  it('sends a minimal standard launch payload for implicit Generalist tasks', async () => {
+  it('sends a minimal standard launch payload for implicit standard-workflow tasks', async () => {
     const mockResponse = {
       success: true,
       runId: 100,
-      taskId: 'task-generalist',
+      taskId: 'task-standard',
     };
 
     global.fetch = vi.fn().mockResolvedValueOnce({

--- a/apps/worker/src/mcp/roomote-mcp-server/index.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/index.ts
@@ -389,7 +389,7 @@ const manageTasksToolDescription =
   `Use action "get_summary" to inspect a specific task's latest status and failure details (requires taskId). ` +
   'Use action "get_compute_logs" to fetch all compute logs for a task, including per-job command output for compute providers that support output lookup when the job has both a machine id and sandbox command id (requires taskId). ' +
   'Use action "get_messages" to retrieve the latest message history for a task (requires taskId, returns newest first). ' +
-  `Use action "launch" to create and start a new task against an environment using ${PRODUCT_NAME}'s default Generalist flow (requires prompt and environmentId). ` +
+  `Use action "launch" to create and start a new task against an environment using ${PRODUCT_NAME}'s default standard workflow (requires prompt and environmentId). ` +
   'Use action "cancel" to cancel an active task (requires taskId). ' +
   'Use action "send_message" to send a follow-up message to a running task (requires taskId and message).';
 

--- a/apps/worker/src/run-task/__tests__/diagnostic-events.test.ts
+++ b/apps/worker/src/run-task/__tests__/diagnostic-events.test.ts
@@ -51,6 +51,14 @@ describe('redactSecrets', () => {
     expect(output).toContain('api_key: [redacted]');
   });
 
+  it('keeps an identifying prefix on hash-shaped values', () => {
+    const sha = 'a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0';
+    const output = redactSecrets(`checked out commit ${sha}`);
+
+    expect(output).toContain('a1b2c3d4…[redacted]');
+    expect(output).not.toContain(sha);
+  });
+
   it('leaves ordinary log text alone', () => {
     const text =
       'OpenCode server exited with code 137 after 512s; last request POST /session/prompt';
@@ -96,6 +104,24 @@ describe('createDiagnosticEventRecorder', () => {
     expect(call.details.exitCode).toBe(137);
     expect((call.details.stderrTail as string).length).toBeLessThan(4_100);
     expect(call.details.stderrTail as string).toContain('[truncated]');
+  });
+
+  it('does not let caller details override the recorder kind', () => {
+    const recorder = createDiagnosticEventRecorder({
+      runId: 7,
+      logger: createLogger(),
+    });
+
+    recorder.record({
+      kind: 'harness_exit',
+      message: 'ok',
+      details: { kind: 'spoofed' },
+    });
+
+    const call = mockRecordEvent.mock.calls[0]?.[0] as {
+      details: Record<string, unknown>;
+    };
+    expect(call.details.kind).toBe('harness_exit');
   });
 
   it('never throws when persistence fails', async () => {

--- a/apps/worker/src/run-task/__tests__/reconnectable-harness.test.ts
+++ b/apps/worker/src/run-task/__tests__/reconnectable-harness.test.ts
@@ -900,4 +900,96 @@ describe('ReconnectableHarness', () => {
       }),
     ]);
   });
+
+  describe('diagnostic breadcrumbs', () => {
+    it('records disconnect and reconnect breadcrumbs', async () => {
+      const harnesses = [new FakeHarness(), new FakeHarness()];
+      const record = vi.fn();
+      const reconnectableHarness = new ReconnectableHarness({
+        logger: createLogger(),
+        spawnHarness: async () => ({
+          harness: harnesses.shift()!,
+          subprocess: createSubprocess() as never,
+        }),
+        diagnosticEvents: { record },
+      });
+      const first = harnesses[0]!;
+
+      await reconnectableHarness.start();
+      first.emit('disconnected');
+
+      await vi.waitFor(() => {
+        expect(record).toHaveBeenCalledWith(
+          expect.objectContaining({ kind: 'harness_reconnected' }),
+        );
+      });
+      expect(record).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'harness_disconnected' }),
+      );
+
+      reconnectableHarness.dispose();
+    });
+
+    it('records exhaustion when reconnecting gives up', async () => {
+      const first = new FakeHarness();
+      let spawnedOnce = false;
+      const record = vi.fn();
+      const reconnectableHarness = new ReconnectableHarness({
+        logger: createLogger(),
+        maxReconnectAttempts: 1,
+        spawnHarness: async () => {
+          if (!spawnedOnce) {
+            spawnedOnce = true;
+            return { harness: first, subprocess: createSubprocess() as never };
+          }
+          throw new Error('spawn failed');
+        },
+        diagnosticEvents: { record },
+      });
+
+      await reconnectableHarness.start();
+      first.emit('disconnected');
+
+      await vi.waitFor(() => {
+        expect(record).toHaveBeenCalledWith(
+          expect.objectContaining({
+            kind: 'harness_reconnect_exhausted',
+            details: expect.objectContaining({ maxAttempts: 1 }),
+          }),
+        );
+      });
+
+      reconnectableHarness.dispose();
+    });
+
+    it('records external reconnect requests with their reason', async () => {
+      const harnesses = [new FakeHarness(), new FakeHarness()];
+      const record = vi.fn();
+      const reconnectableHarness = new ReconnectableHarness({
+        logger: createLogger(),
+        spawnHarness: async () => ({
+          harness: harnesses.shift()!,
+          subprocess: createSubprocess() as never,
+        }),
+        diagnosticEvents: { record },
+      });
+
+      await reconnectableHarness.start();
+      await reconnectableHarness.requestReconnect({
+        reason: 'environment variables updated',
+      });
+
+      expect(record).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'harness_restart_requested',
+          details: expect.objectContaining({
+            source: 'external',
+            reason: 'environment variables updated',
+          }),
+        }),
+      );
+
+      reconnectableHarness.dispose();
+    });
+  });
 });

--- a/apps/worker/src/run-task/create-harness.ts
+++ b/apps/worker/src/run-task/create-harness.ts
@@ -14,8 +14,11 @@ import {
 } from '../commands/setup/setup-mcps';
 import type { HarnessLogger } from '../logging';
 
+import { captureWorkerException } from '../monitoring/sentry';
+
 import type { RunTaskCallbacks, RunTaskContext } from './types';
 import { buildHarnessCommandEnv } from './harnesses';
+import { createDiagnosticEventRecorder } from './diagnostic-events';
 import { ReconnectableHarness } from './reconnectable-harness';
 import { subscribeHarnessCallbacks } from './subscribe-harness-callbacks';
 
@@ -75,6 +78,11 @@ export async function createHarness({
       .catch(() => {});
   };
 
+  const diagnosticEvents = createDiagnosticEventRecorder({
+    runId: taskRun.id,
+    logger,
+  });
+
   const spawnHarness = async (options?: {
     initialSessionId?: string;
   }): Promise<{ harness: Harness; subprocess: ResultPromise }> => {
@@ -107,6 +115,34 @@ export async function createHarness({
     return await startOpenCodeServerHarness({
       ...commonOptions,
       developerInstructionsContent,
+      onUnexpectedExit: (certificate) => {
+        const summary = `OpenCode server exited unexpectedly (code=${
+          certificate.exitCode ?? 'none'
+        }, signal=${certificate.signal ?? 'none'}) after ${Math.round(
+          certificate.uptimeMs / 1000,
+        )}s`;
+
+        diagnosticEvents.record({
+          kind: 'opencode_unexpected_exit',
+          message: summary,
+          details: {
+            exitCode: certificate.exitCode,
+            signal: certificate.signal,
+            uptimeMs: certificate.uptimeMs,
+            memory: certificate.memory,
+            outputTail: certificate.outputTail,
+          },
+        });
+        captureWorkerException(new Error(summary), {
+          runId: taskRun.id,
+          taskId: taskRun.taskId ?? undefined,
+          component: 'createHarness',
+          stage: 'opencode_unexpected_exit',
+          exitCode: certificate.exitCode,
+          signal: certificate.signal,
+          uptimeMs: certificate.uptimeMs,
+        });
+      },
     });
   };
 

--- a/apps/worker/src/run-task/create-harness.ts
+++ b/apps/worker/src/run-task/create-harness.ts
@@ -149,6 +149,7 @@ export async function createHarness({
   const reconnectableHarness = new ReconnectableHarness({
     logger,
     spawnHarness,
+    diagnosticEvents,
   });
   await reconnectableHarness.start({ initialSessionId: harnessSessionId });
   stampHarnessStarted();

--- a/apps/worker/src/run-task/create-harness.ts
+++ b/apps/worker/src/run-task/create-harness.ts
@@ -129,7 +129,7 @@ export async function createHarness({
             exitCode: certificate.exitCode,
             signal: certificate.signal,
             uptimeMs: certificate.uptimeMs,
-            memory: certificate.memory,
+            memoryAfterExit: certificate.memoryAfterExit,
             outputTail: certificate.outputTail,
           },
         });

--- a/apps/worker/src/run-task/diagnostic-events.ts
+++ b/apps/worker/src/run-task/diagnostic-events.ts
@@ -98,7 +98,7 @@ function sanitizeDetailValue(value: unknown, depth: number): unknown {
   return String(value);
 }
 
-interface DiagnosticEventRecorder {
+export interface DiagnosticEventRecorder {
   record(input: {
     kind: string;
     message: string;

--- a/apps/worker/src/run-task/diagnostic-events.ts
+++ b/apps/worker/src/run-task/diagnostic-events.ts
@@ -20,12 +20,18 @@ const SECRET_PATTERNS: RegExp[] = [
   /\bBearer\s+[A-Za-z0-9._~+/-]{8,}=*/gi,
   // JWTs.
   /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{5,}/g,
-  // Long opaque hex/base64 runs (token-shaped strings).
-  /\b[A-Fa-f0-9]{40,}\b/g,
-  /\b[A-Za-z0-9+/]{48,}={0,2}\b/g,
   // key=value / key: value assignments for credential-ish names, including
   // prefixed forms like DATABASE_PASSWORD or GITHUB_TOKEN.
   /([\w-]*(?:token|secret|password|passwd|api[_-]?key|authorization))(\s*[:=]\s*)\S+/gi,
+];
+
+// Long opaque hex/base64 runs are token-shaped, but they are also what git
+// SHAs and content digests look like — post-mortem evidence this rail exists
+// to preserve. These keep an 8-character prefix: enough to identify a commit
+// or digest, far too little to reconstruct a credential.
+const HASH_SHAPED_PATTERNS: RegExp[] = [
+  /\b[A-Fa-f0-9]{40,}\b/g,
+  /\b[A-Za-z0-9+/]{48,}={0,2}\b/g,
 ];
 
 export function redactSecrets(text: string): string {
@@ -40,6 +46,13 @@ export function redactSecrets(text: string): string {
 
       return '[redacted]';
     });
+  }
+
+  for (const pattern of HASH_SHAPED_PATTERNS) {
+    redacted = redacted.replace(
+      pattern,
+      (match) => `${match.slice(0, 8)}…[redacted]`,
+    );
   }
 
   return redacted;
@@ -101,11 +114,13 @@ export function createDiagnosticEventRecorder(options: {
     record(input) {
       try {
         const details = {
-          kind: input.kind,
           ...(sanitizeDetailValue(input.details ?? {}, 0) as Record<
             string,
             unknown
           >),
+          // Last so a caller-supplied details.kind can never override the
+          // recorder's classification.
+          kind: input.kind,
         };
 
         void sdk.taskRuns

--- a/apps/worker/src/run-task/reconnectable-harness.ts
+++ b/apps/worker/src/run-task/reconnectable-harness.ts
@@ -16,6 +16,7 @@ import {
 
 import type { Harness } from '../sandbox-server';
 import { markExpectedSubprocessExitIfAlive } from '../sandbox-server/lib/harnesses/opencode-server/expected-exit';
+import type { DiagnosticEventRecorder } from './diagnostic-events';
 import type {
   HarnessEvents,
   HarnessInferenceUsageEvent,
@@ -44,6 +45,8 @@ interface ReconnectableHarnessConfig {
     initialSessionId?: string;
   }) => Promise<SpawnHarnessResult>;
   maxReconnectAttempts?: number;
+  /** Durable breadcrumbs for harness lifecycle transitions; observer-only. */
+  diagnosticEvents?: DiagnosticEventRecorder;
 }
 
 interface BoundHarnessListeners {
@@ -109,6 +112,7 @@ export class ReconnectableHarness
   private readonly logger: HarnessLogger;
   private readonly spawnHarness: ReconnectableHarnessConfig['spawnHarness'];
   private readonly maxReconnectAttempts: number;
+  private readonly diagnosticEvents: DiagnosticEventRecorder | undefined;
 
   private currentHarness: Harness | null = null;
   private currentSubprocess: ResultPromise | null = null;
@@ -130,6 +134,7 @@ export class ReconnectableHarness
     this.spawnHarness = config.spawnHarness;
     this.maxReconnectAttempts =
       config.maxReconnectAttempts ?? DEFAULT_MAX_RECONNECT_ATTEMPTS;
+    this.diagnosticEvents = config.diagnosticEvents;
   }
 
   async start(options?: { initialSessionId?: string }): Promise<void> {
@@ -270,6 +275,16 @@ export class ReconnectableHarness
     this.logger.info(
       `[ReconnectableHarness] External reconnect requested: ${options.reason} (sessionId=${this.latestSessionId ?? 'none'}, afterCurrentTurn=${options.afterCurrentTurn === true})`,
     );
+    this.diagnosticEvents?.record({
+      kind: 'harness_restart_requested',
+      message: `External reconnect requested: ${options.reason}`,
+      details: {
+        source: 'external',
+        reason: options.reason,
+        sessionId: this.latestSessionId ?? null,
+        afterCurrentTurn: options.afterCurrentTurn === true,
+      },
+    });
 
     if (!this.currentHarness) {
       if (options.replayCommands?.length) {
@@ -329,6 +344,11 @@ export class ReconnectableHarness
         this.logger.warn(
           `[ReconnectableHarness] Underlying harness disconnected; attempting reconnect (sessionId=${this.latestSessionId ?? 'none'})`,
         );
+        this.diagnosticEvents?.record({
+          kind: 'harness_disconnected',
+          message: 'Underlying harness disconnected; attempting reconnect',
+          details: { sessionId: this.latestSessionId ?? null },
+        });
 
         this.captureReconnectQueuedMessages(harness);
         const subprocess = this.currentSubprocess;
@@ -344,6 +364,15 @@ export class ReconnectableHarness
         this.logger.warn(
           `[ReconnectableHarness] Underlying harness requested restart: ${request.reason} (sessionId=${request.sessionId ?? this.latestSessionId ?? 'none'})`,
         );
+        this.diagnosticEvents?.record({
+          kind: 'harness_restart_requested',
+          message: `Harness requested restart: ${request.reason}`,
+          details: {
+            source: 'harness',
+            reason: request.reason,
+            sessionId: request.sessionId ?? this.latestSessionId ?? null,
+          },
+        });
 
         void this.restartCurrentHarness(request);
       },
@@ -513,6 +542,15 @@ export class ReconnectableHarness
         this.logger.info(
           `[ReconnectableHarness] Reconnected harness on attempt ${attempt}/${this.maxReconnectAttempts} (sessionId=${this.latestSessionId ?? 'none'})`,
         );
+        this.diagnosticEvents?.record({
+          kind: 'harness_reconnected',
+          message: `Reconnected harness on attempt ${attempt}/${this.maxReconnectAttempts}`,
+          details: {
+            attempt,
+            maxAttempts: this.maxReconnectAttempts,
+            sessionId: this.latestSessionId ?? null,
+          },
+        });
         this.attachHarness(spawned);
         return;
       } catch (error) {
@@ -535,6 +573,14 @@ export class ReconnectableHarness
     }
 
     if (!this.disposed) {
+      this.diagnosticEvents?.record({
+        kind: 'harness_reconnect_exhausted',
+        message: `Gave up reconnecting after ${this.maxReconnectAttempts} attempts`,
+        details: {
+          maxAttempts: this.maxReconnectAttempts,
+          sessionId: this.latestSessionId ?? null,
+        },
+      });
       this.emit('disconnected');
     }
   }

--- a/apps/worker/src/run-task/reconnectable-harness.ts
+++ b/apps/worker/src/run-task/reconnectable-harness.ts
@@ -15,6 +15,7 @@ import {
 } from '@roomote/types';
 
 import type { Harness } from '../sandbox-server';
+import { markExpectedSubprocessExitIfAlive } from '../sandbox-server/lib/harnesses/opencode-server/expected-exit';
 import type {
   HarnessEvents,
   HarnessInferenceUsageEvent,
@@ -449,6 +450,9 @@ export class ReconnectableHarness
     }
 
     try {
+      // A live process killed here is deliberate teardown; one that already
+      // exited died on its own and keeps its death certificate.
+      markExpectedSubprocessExitIfAlive(subprocess);
       const terminated = subprocess.kill('SIGTERM');
       this.logger.info(
         `[ReconnectableHarness] Terminated subprocess during ${reason} sentSignal=${terminated}`,

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/exit-certificate.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/exit-certificate.test.ts
@@ -1,0 +1,54 @@
+import { createOpenCodeExitCertificateCollector } from './exit-certificate';
+
+describe('createOpenCodeExitCertificateCollector', () => {
+  it('captures exit facts with the tagged output tail', () => {
+    const collector = createOpenCodeExitCertificateCollector();
+
+    collector.appendLine('stdout', 'server listening');
+    collector.appendLine('stderr', 'panic: something broke');
+
+    const certificate = collector.build({ exitCode: 137, signal: 'SIGKILL' });
+
+    expect(certificate.exitCode).toBe(137);
+    expect(certificate.signal).toBe('SIGKILL');
+    expect(certificate.uptimeMs).toBeGreaterThanOrEqual(0);
+    expect(certificate.outputTail).toEqual([
+      '[stdout] server listening',
+      '[stderr] panic: something broke',
+    ]);
+  });
+
+  it('keeps only the most recent lines and caps line length', () => {
+    const collector = createOpenCodeExitCertificateCollector();
+
+    for (let i = 0; i < 80; i += 1) {
+      collector.appendLine('stderr', `line ${i} ${'x'.repeat(400)}`);
+    }
+
+    const certificate = collector.build({ exitCode: 1, signal: null });
+
+    expect(certificate.outputTail).toHaveLength(50);
+    expect(certificate.outputTail[0]).toContain('line 30');
+    expect(certificate.outputTail[49]).toContain('line 79');
+    for (const line of certificate.outputTail) {
+      expect(line.length).toBeLessThanOrEqual(320);
+    }
+  });
+
+  it('skips blank lines and never fails on missing memory accounting', () => {
+    const collector = createOpenCodeExitCertificateCollector();
+
+    collector.appendLine('stdout', '   ');
+    collector.appendLine('stdout', '');
+
+    const certificate = collector.build({ exitCode: null, signal: 'SIGTERM' });
+
+    expect(certificate.outputTail).toEqual([]);
+    // /proc/meminfo may not exist on the test host; the snapshot is either a
+    // complete reading or null, never a throw.
+    if (certificate.memory !== null) {
+      expect(certificate.memory.memTotalKb).toBeGreaterThan(0);
+      expect(certificate.memory.workerRssBytes).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/exit-certificate.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/exit-certificate.test.ts
@@ -46,9 +46,9 @@ describe('createOpenCodeExitCertificateCollector', () => {
     expect(certificate.outputTail).toEqual([]);
     // /proc/meminfo may not exist on the test host; the snapshot is either a
     // complete reading or null, never a throw.
-    if (certificate.memory !== null) {
-      expect(certificate.memory.memTotalKb).toBeGreaterThan(0);
-      expect(certificate.memory.workerRssBytes).toBeGreaterThan(0);
+    if (certificate.memoryAfterExit !== null) {
+      expect(certificate.memoryAfterExit.memTotalKb).toBeGreaterThan(0);
+      expect(certificate.memoryAfterExit.workerRssBytes).toBeGreaterThan(0);
     }
   });
 });

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/exit-certificate.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/exit-certificate.ts
@@ -1,0 +1,88 @@
+import { readFileSync } from 'node:fs';
+
+// Death certificate for the OpenCode server subprocess. The sandbox and its
+// logs are gone by the time anyone investigates, so the facts that identify
+// the killer are collected while the process runs and handed to the caller
+// the moment it exits: exit code and signal (137 = killed for memory), the
+// last output lines, uptime, and a memory snapshot taken at the instant of
+// death. Collection is bounded: a fixed-size line ring with per-line caps, so
+// the cost per output line is constant regardless of how chatty the process
+// is.
+const MAX_TAIL_LINES = 50;
+const MAX_LINE_CHARS = 300;
+
+export interface OpenCodeExitCertificate {
+  exitCode: number | null;
+  signal: string | null;
+  uptimeMs: number;
+  outputTail: string[];
+  memory: {
+    memTotalKb: number;
+    memAvailableKb: number;
+    workerRssBytes: number;
+  } | null;
+}
+
+function readMemorySnapshot(): OpenCodeExitCertificate['memory'] {
+  try {
+    const meminfo = readFileSync('/proc/meminfo', 'utf8');
+    const readKb = (field: string): number | null => {
+      const match = meminfo.match(new RegExp(`^${field}:\\s+(\\d+) kB`, 'm'));
+      return match?.[1] ? Number.parseInt(match[1], 10) : null;
+    };
+    const memTotalKb = readKb('MemTotal');
+    const memAvailableKb = readKb('MemAvailable');
+
+    if (memTotalKb === null || memAvailableKb === null) {
+      return null;
+    }
+
+    return {
+      memTotalKb,
+      memAvailableKb,
+      workerRssBytes: process.memoryUsage().rss,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function createOpenCodeExitCertificateCollector(): {
+  appendLine(stream: 'stdout' | 'stderr', line: string): void;
+  build(input: {
+    exitCode: number | null;
+    signal: string | null;
+  }): OpenCodeExitCertificate;
+} {
+  const startedAtMs = Date.now();
+  const tail: string[] = [];
+
+  return {
+    appendLine(stream, line) {
+      const trimmed = line.trim();
+
+      if (!trimmed) {
+        return;
+      }
+
+      const capped =
+        trimmed.length > MAX_LINE_CHARS
+          ? `${trimmed.slice(0, MAX_LINE_CHARS)}…`
+          : trimmed;
+
+      tail.push(`[${stream}] ${capped}`);
+      if (tail.length > MAX_TAIL_LINES) {
+        tail.shift();
+      }
+    },
+    build(input) {
+      return {
+        exitCode: input.exitCode,
+        signal: input.signal,
+        uptimeMs: Date.now() - startedAtMs,
+        outputTail: [...tail],
+        memory: readMemorySnapshot(),
+      };
+    },
+  };
+}

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/exit-certificate.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/exit-certificate.ts
@@ -4,10 +4,10 @@ import { readFileSync } from 'node:fs';
 // logs are gone by the time anyone investigates, so the facts that identify
 // the killer are collected while the process runs and handed to the caller
 // the moment it exits: exit code and signal (137 = killed for memory), the
-// last output lines, uptime, and a memory snapshot taken at the instant of
-// death. Collection is bounded: a fixed-size line ring with per-line caps, so
-// the cost per output line is constant regardless of how chatty the process
-// is.
+// last output lines, uptime, and a sandbox memory reading taken just after
+// the exit. Collection is bounded: a fixed-size line ring with per-line caps,
+// so the cost per output line is constant regardless of how chatty the
+// process is.
 const MAX_TAIL_LINES = 50;
 const MAX_LINE_CHARS = 300;
 
@@ -16,14 +16,18 @@ export interface OpenCodeExitCertificate {
   signal: string | null;
   uptimeMs: number;
   outputTail: string[];
-  memory: {
+  // Sandbox-wide memory observed just after the exit — by then the kernel has
+  // reclaimed the dead process's pages, so an OOM kill can already look
+  // recovered here; the exit code/signal is the authoritative OOM signal.
+  // workerRssBytes is the surviving sandbox-server process, not the victim.
+  memoryAfterExit: {
     memTotalKb: number;
     memAvailableKb: number;
     workerRssBytes: number;
   } | null;
 }
 
-function readMemorySnapshot(): OpenCodeExitCertificate['memory'] {
+function readMemorySnapshot(): OpenCodeExitCertificate['memoryAfterExit'] {
   try {
     const meminfo = readFileSync('/proc/meminfo', 'utf8');
     const readKb = (field: string): number | null => {
@@ -81,7 +85,7 @@ export function createOpenCodeExitCertificateCollector(): {
         signal: input.signal,
         uptimeMs: Date.now() - startedAtMs,
         outputTail: [...tail],
-        memory: readMemorySnapshot(),
+        memoryAfterExit: readMemorySnapshot(),
       };
     },
   };

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/expected-exit.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/expected-exit.test.ts
@@ -1,0 +1,30 @@
+import {
+  isExpectedSubprocessExit,
+  markExpectedSubprocessExitIfAlive,
+} from './expected-exit';
+
+describe('markExpectedSubprocessExitIfAlive', () => {
+  it('marks a live subprocess as an expected exit', () => {
+    const subprocess = { exitCode: null, killed: false };
+
+    expect(markExpectedSubprocessExitIfAlive(subprocess)).toBe(true);
+    expect(isExpectedSubprocessExit(subprocess)).toBe(true);
+  });
+
+  it('does not mark a subprocess that already exited on its own', () => {
+    // A crash surfaces as a disconnect first, and the disconnect cleanup then
+    // kills the (already dead) process. That teardown must not suppress the
+    // crash's death certificate.
+    const crashed = { exitCode: 137, killed: false };
+
+    expect(markExpectedSubprocessExitIfAlive(crashed)).toBe(false);
+    expect(isExpectedSubprocessExit(crashed)).toBe(false);
+  });
+
+  it('does not mark a subprocess that was already signalled', () => {
+    const signalled = { exitCode: null, killed: true };
+
+    expect(markExpectedSubprocessExitIfAlive(signalled)).toBe(false);
+    expect(isExpectedSubprocessExit(signalled)).toBe(false);
+  });
+});

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/expected-exit.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/expected-exit.ts
@@ -1,0 +1,28 @@
+// Deliberate subprocess terminations (reconnects, restarts, teardown) must
+// not be certified as unexpected exits: they would pollute the death-
+// certificate signal and page Sentry on every routine restart. Callers that
+// kill an OpenCode subprocess on purpose mark it here first; the exit
+// certification checks the mark before recording anything.
+const expectedExits = new WeakSet<object>();
+
+/**
+ * Marks the subprocess as deliberately terminated — but only while it is
+ * still alive. A process that already exited died on its own: the teardown
+ * that follows a crash-induced disconnect must not retroactively suppress
+ * the very certificate the crash should produce.
+ */
+export function markExpectedSubprocessExitIfAlive(subprocess: {
+  exitCode: number | null;
+  killed: boolean;
+}): boolean {
+  if (subprocess.exitCode !== null || subprocess.killed) {
+    return false;
+  }
+
+  expectedExits.add(subprocess);
+  return true;
+}
+
+export function isExpectedSubprocessExit(subprocess: object): boolean {
+  return expectedExits.has(subprocess);
+}

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/start.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/start.ts
@@ -13,6 +13,7 @@ import {
   createOpenCodeExitCertificateCollector,
   type OpenCodeExitCertificate,
 } from './exit-certificate';
+import { isExpectedSubprocessExit } from './expected-exit';
 import { OpenCodeServerHarness } from './harness';
 
 interface StartOpenCodeServerHarnessOptions {
@@ -120,7 +121,6 @@ function waitForOpenCodeServerUrl(options: {
   stderr: NodeJS.ReadableStream;
   logger: HarnessLogger;
   timeoutMs: number;
-  onLine?: (stream: 'stdout' | 'stderr', line: string) => void;
 }): Promise<string> {
   const log = createPrefixedLogger(options.logger, '[opencode-server]');
   const stdoutLog = createPrefixedLogger(
@@ -180,7 +180,6 @@ function waitForOpenCodeServerUrl(options: {
         stdoutLog.info(line);
       }
 
-      options.onLine?.('stdout', line);
       maybeResolve('stdout', line);
     };
 
@@ -189,7 +188,6 @@ function waitForOpenCodeServerUrl(options: {
         stderrLog.info(line);
       }
 
-      options.onLine?.('stderr', line);
       maybeResolve('stderr', line);
     };
 
@@ -256,11 +254,33 @@ export async function startOpenCodeServerHarness({
     }
 
     if (onUnexpectedExit) {
+      // The certificate needs the process's last words, not its first: these
+      // readers stay attached for the whole subprocess lifetime, independent
+      // of the startup URL wait and its listener lifecycle.
+      const stdoutTailReader = readline.createInterface({
+        input: subprocess.stdout,
+        crlfDelay: Infinity,
+      });
+      const stderrTailReader = readline.createInterface({
+        input: subprocess.stderr,
+        crlfDelay: Infinity,
+      });
+      stdoutTailReader.on('line', (line) =>
+        exitCertificate.appendLine('stdout', line),
+      );
+      stderrTailReader.on('line', (line) =>
+        exitCertificate.appendLine('stderr', line),
+      );
+
+      const spawnedSubprocess = subprocess;
       const certifyExit = (input: {
         exitCode: number | null;
         signal: string | null;
       }) => {
-        if (cancelSignal.aborted) {
+        if (
+          cancelSignal.aborted ||
+          isExpectedSubprocessExit(spawnedSubprocess)
+        ) {
           return;
         }
 
@@ -313,7 +333,6 @@ export async function startOpenCodeServerHarness({
         stderr: subprocess.stderr,
         logger,
         timeoutMs: 30_000,
-        onLine: (stream, line) => exitCertificate.appendLine(stream, line),
       }),
       subprocess.then(
         () => {

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/start.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/start.ts
@@ -9,6 +9,10 @@ import { createPrefixedLogger, describeUnknownError } from '../logging';
 
 import { prepareOpenCodeCommandEnv } from './bootstrap';
 import { OpenCodeServerClient } from './client';
+import {
+  createOpenCodeExitCertificateCollector,
+  type OpenCodeExitCertificate,
+} from './exit-certificate';
 import { OpenCodeServerHarness } from './harness';
 
 interface StartOpenCodeServerHarnessOptions {
@@ -20,6 +24,12 @@ interface StartOpenCodeServerHarnessOptions {
   initialSessionId?: string;
   modelOverride?: string;
   developerInstructionsContent?: string;
+  /**
+   * Invoked when the OpenCode server subprocess exits while the task was not
+   * being cancelled — the death certificate for post-mortems. Observer-only:
+   * failures inside the callback must not affect the harness lifecycle.
+   */
+  onUnexpectedExit?: (certificate: OpenCodeExitCertificate) => void;
   beforeQueuedPrompt?: (input: { userId?: string }) => Promise<void | {
     shouldReconnect: boolean;
     shouldBlockPrompt?: boolean;
@@ -110,6 +120,7 @@ function waitForOpenCodeServerUrl(options: {
   stderr: NodeJS.ReadableStream;
   logger: HarnessLogger;
   timeoutMs: number;
+  onLine?: (stream: 'stdout' | 'stderr', line: string) => void;
 }): Promise<string> {
   const log = createPrefixedLogger(options.logger, '[opencode-server]');
   const stdoutLog = createPrefixedLogger(
@@ -169,6 +180,7 @@ function waitForOpenCodeServerUrl(options: {
         stdoutLog.info(line);
       }
 
+      options.onLine?.('stdout', line);
       maybeResolve('stdout', line);
     };
 
@@ -177,6 +189,7 @@ function waitForOpenCodeServerUrl(options: {
         stderrLog.info(line);
       }
 
+      options.onLine?.('stderr', line);
       maybeResolve('stderr', line);
     };
 
@@ -194,6 +207,7 @@ export async function startOpenCodeServerHarness({
   initialSessionId,
   modelOverride,
   developerInstructionsContent,
+  onUnexpectedExit,
   beforeQueuedPrompt,
 }: StartOpenCodeServerHarnessOptions): Promise<StartOpenCodeServerHarnessResult> {
   const log = createPrefixedLogger(logger, '[opencode-server]');
@@ -224,6 +238,7 @@ export async function startOpenCodeServerHarness({
   );
 
   let subprocess: ResultPromise | null = null;
+  const exitCertificate = createOpenCodeExitCertificateCollector();
 
   try {
     subprocess = execa(resolved.command, resolved.args, {
@@ -237,6 +252,49 @@ export async function startOpenCodeServerHarness({
     if (!subprocess.stdout || !subprocess.stderr) {
       throw new Error(
         'OpenCode server subprocess is missing stdout or stderr.',
+      );
+    }
+
+    if (onUnexpectedExit) {
+      const certifyExit = (input: {
+        exitCode: number | null;
+        signal: string | null;
+      }) => {
+        if (cancelSignal.aborted) {
+          return;
+        }
+
+        try {
+          onUnexpectedExit(exitCertificate.build(input));
+        } catch (error) {
+          log.warn(
+            `Failed to report unexpected OpenCode server exit: ${describeUnknownError(error)}`,
+          );
+        }
+      };
+
+      void subprocess.then(
+        (result) =>
+          certifyExit({
+            exitCode: result.exitCode ?? null,
+            signal: result.signal ?? null,
+          }),
+        (error: unknown) => {
+          const execaError = error as {
+            exitCode?: number;
+            signal?: string;
+            isCanceled?: boolean;
+          };
+
+          if (execaError?.isCanceled) {
+            return;
+          }
+
+          certifyExit({
+            exitCode: execaError?.exitCode ?? null,
+            signal: execaError?.signal ?? null,
+          });
+        },
       );
     }
 
@@ -255,6 +313,7 @@ export async function startOpenCodeServerHarness({
         stderr: subprocess.stderr,
         logger,
         timeoutMs: 30_000,
+        onLine: (stream, line) => exitCertificate.appendLine(stream, line),
       }),
       subprocess.then(
         () => {

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -276,8 +276,17 @@ docker compose --env-file .env -f docker-compose.prod.yml stop controller || tru
 DOCKER_WORKER_IMAGE="$(awk -F= '/^(export[[:space:]]+)?DOCKER_WORKER_IMAGE=/ { sub(/^[^=]*=/, ""); print; exit }' .env)"
 docker pull "$DOCKER_WORKER_IMAGE"
 docker compose --env-file .env -f docker-compose.prod.yml pull
+docker compose --env-file .env -f docker-compose.prod.yml run --rm db-migrate
 docker compose --env-file .env -f docker-compose.prod.yml up -d --wait --wait-timeout 600
 ```
+
+Database migrations run as a dedicated one-shot step after images are pulled
+and before any running service is replaced. If the migration step fails, the
+deployer restarts the previous controller and exits with the previous release
+still serving; see the compatibility policy below for why that is always safe.
+The on-host `roomote upgrade` additionally creates an encrypted pre-upgrade
+backup and restores the previous deployment configuration files when the
+migration step fails.
 
 The Compose file defines container healthchecks for `web`, `api`, `controller`,
 `bullmq`, and `preview-proxy`. The controller probe uses the API's Redis
@@ -302,6 +311,116 @@ to remove any image used by a running or stopped container. Use
 to adjust rollback depth for a deployment. Retention is best-effort after a
 healthy rollout; a Docker cleanup failure prints a warning instead of failing
 the completed deploy or upgrade.
+
+## Upgrade And Migration Compatibility Policy
+
+This is the contract between releases, migrations, and the upgrade tooling.
+Schema changes that cannot satisfy it must be split across releases.
+
+### Expand/contract migrations
+
+Every migration must keep the previous release working against the new
+schema. Ship schema changes in two phases:
+
+- **Expand** (safe in any release): add tables, add nullable columns, add
+  columns with database-side defaults, add indexes, widen types, add enum
+  values. New code reads and writes the new shape; old code keeps working
+  because nothing it uses changed.
+- **Contract** (only after no supported version references the old shape):
+  drop or rename tables and columns, add `NOT NULL` to existing columns,
+  narrow types, remove enum values. A rename is an expand (add the new
+  column, dual-write, backfill) followed by a contract (drop the old column)
+  at least one release later.
+
+Long-running backfills do not belong in migrations. Run them as idempotent
+application code after the rollout so the migration step stays fast enough
+for the rollout timeout below.
+
+### Minimum rollback-compatible version
+
+The schema produced by release N must support the application code of the
+release immediately before it (N-1). The supported rollback target is
+therefore always the previously deployed release, without undoing
+migrations: roll the application back and leave the schema at N. Rolling
+back more than one release is not guaranteed by this policy; use the
+pre-upgrade backup bundle for that instead.
+
+### Pre-upgrade backup
+
+`roomote upgrade` creates an encrypted backup bundle (the same format as
+`roomote backup`) before it changes any deployment file or container. The
+passphrase comes from `--backup-passphrase-file`, then
+`ROOMOTE_BACKUP_PASSPHRASE`; with neither, the command generates one and
+stores it next to the bundle under `/opt/roomote/backups/`, in the same
+trust domain as `/opt/roomote/.env`. Move both off-host if the bundle
+should double as a disaster-recovery copy. `--skip-backup` opts out, and
+`roomote rollback` skips it by design so an unhealthy stack cannot block
+the rollback. The operator-run deployer does not back up implicitly; run
+`roomote-deploy backup` before production upgrades.
+
+### Migration lock and timeout behavior
+
+Migrations run as the one-shot `db-migrate` service from the release being
+deployed. Drizzle applies all pending migrations inside a single
+transaction, so a failed migration rolls the schema back to its previous
+state. There is no advisory lock and no statement timeout on the migration
+step itself; single-writer behavior comes from running one `db-migrate`
+container per deployment, so never run two upgrades against the same
+database concurrently. Every application service in the Compose stack waits
+on `db-migrate` completing successfully before it starts, and the rollout as
+a whole is bounded by `up --wait --wait-timeout 600`.
+
+### Failure behavior
+
+The upgrade sequence pulls images first, then runs migrations, and only then
+replaces running services. A migration failure aborts the upgrade with the
+previous release still serving: `roomote upgrade` restores the previous
+Compose, Caddy, and `.env` files and restarts the controller; the deployer
+restarts the controller and asks the operator to re-run with the previous
+tag. A failure after migrations succeeded (for example `up --wait` timing
+out) leaves the schema at the candidate version, which the previous release
+supports by the rule above, so `roomote rollback` or an upgrade to the
+previous tag recovers without touching the database.
+
+### Rollback path
+
+- `roomote rollback` re-deploys the release recorded in
+  `ROOMOTE_PREVIOUS_VERSION` by the last upgrade.
+- `roomote upgrade <previous-tag>` (or `roomote-deploy upgrade --version
+<previous-tag>`) is the explicit equivalent and works for any retained tag.
+- `roomote restore <bundle> --yes` with the pre-upgrade bundle is the
+  last-resort path and also rewinds the database and artifacts.
+
+Image retention keeps the current release plus the newest tags (default 3
+total), so the rollback image is normally still on the host. The restore
+path is exercised in CI on every non-docs change (the backup-restore job),
+and the rollback path is exercised against real images by the publish gate
+below.
+
+### Version visibility
+
+Settings -> Deployment -> Diagnostics surfaces the running application
+version (`Roomote version`, from the `RELEASE_VERSION` baked into the image)
+and the schema version (`Current migration`, the latest applied Drizzle
+migration hash). The same pair is recorded in every backup manifest as
+`roomoteVersion` and `schemaVersion`, and `/opt/roomote/.env` records
+`ROOMOTE_VERSION` plus the `ROOMOTE_PREVIOUS_VERSION` rollback target.
+
+### CI enforcement
+
+- **Upgrade Compatibility** (`.github/workflows/CI.yml`, every non-docs PR):
+  boots the previous published release from GHCR, applies the candidate
+  branch's migrations to its database, and requires the previous release to
+  stay healthy, including a cold restart, on the candidate schema
+  ([`deploy/ci/upgrade-compatibility.sh`](ci/upgrade-compatibility.sh)).
+- **Fresh-host Backup Restore** (every non-docs PR): restores an encrypted
+  bundle onto empty volumes
+  ([`deploy/host/tests/backup-restore.integration.sh`](host/tests/backup-restore.integration.sh)).
+- **Deployment acceptance** (`publish-ghcr.yml`, gates every image publish):
+  builds candidate images, upgrades the previous published release to the
+  candidate, rolls back, re-upgrades, launches a real Docker task, and
+  restores a backup onto fresh volumes
+  ([`deploy/ci/deployment-smoke.sh`](ci/deployment-smoke.sh)).
 
 ## Back Up a Deployment
 

--- a/deploy/ci/upgrade-compatibility.sh
+++ b/deploy/ci/upgrade-compatibility.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+#
+# PR-time upgrade-compatibility lane. Boots the previous published release
+# from GHCR, applies the candidate checkout's database migrations to it, and
+# requires the previous release to stay healthy — including a cold restart —
+# on the candidate schema. This enforces the expand/contract policy in
+# deploy/README.md before merge without building candidate images; the
+# publish-time deployment-acceptance gate (deploy/ci/deployment-smoke.sh)
+# covers the full upgrade -> rollback -> re-upgrade lifecycle with them.
+set -Eeuo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+baseline_channel="${BASELINE_CHANNEL:-develop}"
+baseline_registry="${BASELINE_IMAGE_REGISTRY:-ghcr.io}"
+baseline_namespace="${BASELINE_IMAGE_NAMESPACE:-roocodeinc}"
+project_name="${COMPOSE_PROJECT_NAME:-roomote-upgrade-ci}"
+postgres_port="${DEPLOYMENT_CI_POSTGRES_PORT:-57432}"
+redis_port="${DEPLOYMENT_CI_REDIS_PORT:-58379}"
+default_network="${ROOMOTE_DEFAULT_NETWORK:-${project_name}_default}"
+worker_network="${DOCKER_WORKER_NETWORK:-${project_name}_worker}"
+temporary_directory="$(mktemp -d)"
+env_file="$temporary_directory/deployment.env"
+
+# Only published channel aliases have a defined previous release. Anything
+# else (workflow_dispatch from a feature branch) validates against develop.
+case "$baseline_channel" in
+  develop | main) ;;
+  *)
+    printf 'No published channel for %s; using develop as the baseline\n' "$baseline_channel"
+    baseline_channel='develop'
+    ;;
+esac
+
+app_image="$baseline_registry/$baseline_namespace/roomote-app:$baseline_channel"
+worker_image="$baseline_registry/$baseline_namespace/roomote-worker:$baseline_channel"
+
+compose() {
+  docker compose \
+    --project-name "$project_name" \
+    --env-file "$env_file" \
+    -f "$repo_root/deploy/compose/docker-compose.prod.yml" \
+    -f "$repo_root/deploy/ci/docker-compose.ci.yml" \
+    "$@"
+}
+
+cleanup() {
+  compose down --volumes --remove-orphans >/dev/null 2>&1 || true
+  rm -rf "$temporary_directory"
+}
+trap cleanup EXIT
+
+report_failure() {
+  local exit_code="$?"
+  printf 'Upgrade compatibility test failed; final Compose state follows.\n' >&2
+  compose ps --all >&2 || true
+  compose logs --no-color --tail 200 >&2 || true
+  return "$exit_code"
+}
+trap report_failure ERR
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    printf 'required command not found: %s\n' "$1" >&2
+    exit 1
+  }
+}
+
+for command in docker openssl pnpm; do
+  require_command "$command"
+done
+
+docker_arch="$(docker info --format '{{.Architecture}}')"
+case "$docker_arch" in
+  amd64 | x86_64) platform='linux/amd64' ;;
+  arm64 | aarch64) platform='linux/arm64' ;;
+  *)
+    printf 'unsupported Docker architecture: %s\n' "$docker_arch" >&2
+    exit 1
+    ;;
+esac
+
+generate_keypair() {
+  local name="$1"
+  openssl ecparam -name prime256v1 -genkey -noout -out "$temporary_directory/$name-raw.pem" 2>/dev/null
+  openssl pkcs8 -topk8 -nocrypt \
+    -in "$temporary_directory/$name-raw.pem" \
+    -out "$temporary_directory/$name-private.pem" 2>/dev/null
+  openssl ec -in "$temporary_directory/$name-raw.pem" \
+    -pubout -out "$temporary_directory/$name-public.pem" 2>/dev/null
+}
+
+single_line_base64() {
+  base64 <"$1" | tr -d '\n'
+}
+
+generate_keypair job
+generate_keypair preview
+
+job_private="$(single_line_base64 "$temporary_directory/job-private.pem")"
+job_public="$(single_line_base64 "$temporary_directory/job-public.pem")"
+preview_private="$(single_line_base64 "$temporary_directory/preview-private.pem")"
+preview_public="$(single_line_base64 "$temporary_directory/preview-public.pem")"
+encryption_key="$(openssl rand -base64 32 | tr -d '\n')"
+artifact_signing_key="$(openssl rand -base64 32 | tr -d '\n')"
+dashboard_password="$(openssl rand -base64 24 | tr -d '\n')"
+s3_password="$(openssl rand -base64 32 | tr -d '\n')"
+setup_token="$(openssl rand -hex 24)"
+
+cat >"$env_file" <<EOF
+APP_ENV=production
+ARTIFACT_SIGNING_KEY=$artifact_signing_key
+CADDY_HTTP_PORT=19080
+CADDY_HTTPS_PORT=19443
+COMPOSE_PROFILES=local-postgres
+DASHBOARD_PASSWORD=$dashboard_password
+DATABASE_URL=postgres://postgres:roomote-postgres-password@postgres:5432/roomote
+DEFAULT_COMPUTE_PROVIDER=docker
+DEPLOYMENT_CI_POSTGRES_PORT=$postgres_port
+DEPLOYMENT_CI_REDIS_PORT=$redis_port
+DOCKER_WORKER_IMAGE=$worker_image
+DOCKER_WORKER_NETWORK=$worker_network
+DOCKER_WORKER_PLATFORM=$platform
+DOCKER_WORKER_RELEASE_PATH=/roomote/releases/worker-current.tar.gz
+ENCRYPTION_KEY=$encryption_key
+IMAGE_NAMESPACE=$baseline_namespace
+IMAGE_REGISTRY=$baseline_registry
+JOB_AUTH_PRIVATE_KEY=$job_private
+JOB_AUTH_PUBLIC_KEY=$job_public
+NEXT_PUBLIC_GITHUB_APP_SLUG=upgrade-ci
+POSTGRES_DB=roomote
+POSTGRES_PASSWORD=roomote-postgres-password
+POSTGRES_USER=postgres
+PREVIEW_AUTH_PRIVATE_KEY=$preview_private
+PREVIEW_AUTH_PUBLIC_KEY=$preview_public
+REDIS_URL=redis://redis:6379
+ROOMOTE_APP_DOMAIN=roomote.localhost
+ROOMOTE_APP_URL=http://roomote.localhost
+ROOMOTE_DEFAULT_NETWORK=$default_network
+ROOMOTE_PREVIEW_DOMAIN=preview.roomote.localhost
+ROOMOTE_VERSION=$baseline_channel
+S3_ACCESS_KEY_ID=roomote
+S3_BUCKET_ARTIFACTS=roomote-artifacts
+S3_ENDPOINT=http://minio:9000
+S3_PRESIGN_ENDPOINT=http://minio:9000
+S3_REGION=us-east-1
+S3_SECRET_ACCESS_KEY=$s3_password
+SETUP_TOKEN=$setup_token
+TRPC_URL=http://api:3001
+EOF
+
+verify_endpoints() {
+  compose exec -T api curl -fsS --max-time 5 http://127.0.0.1:3001/health/liveness >/dev/null
+  compose exec -T web curl -fsS --max-time 5 http://127.0.0.1:3000/health >/dev/null
+  compose exec -T web curl -fsS --max-time 10 "http://127.0.0.1:3000/setup?token=$setup_token" >/dev/null
+  compose exec -T controller curl -fsS --max-time 5 http://api:3001/health/controller >/dev/null
+  compose exec -T bullmq curl -fsS --max-time 5 http://127.0.0.1:3002/admin/health >/dev/null
+}
+
+applied_migration_count() {
+  compose exec -T postgres psql -Atq -U postgres -d roomote \
+    -c 'SELECT count(*) FROM drizzle.__drizzle_migrations'
+}
+
+write_marker() {
+  compose exec -T postgres psql -v ON_ERROR_STOP=1 -U postgres -d roomote <<'SQL'
+CREATE TABLE IF NOT EXISTS upgrade_ci_marker (
+  id integer PRIMARY KEY,
+  value text NOT NULL
+);
+INSERT INTO upgrade_ci_marker (id, value)
+VALUES (1, 'preserved')
+ON CONFLICT (id) DO UPDATE SET value = EXCLUDED.value;
+SQL
+}
+
+verify_marker() {
+  local value
+  value="$(compose exec -T postgres psql -At -U postgres -d roomote -c 'SELECT value FROM upgrade_ci_marker WHERE id = 1')"
+  [ "$value" = 'preserved' ] || {
+    printf 'upgrade marker was not preserved (got %s)\n' "$value" >&2
+    return 1
+  }
+}
+
+cd "$repo_root"
+
+printf 'Pulling previous release images (%s)\n' "$baseline_channel"
+docker pull --platform "$platform" "$app_image"
+docker pull --platform "$platform" "$worker_image"
+docker image inspect --format 'baseline app image: {{index .RepoDigests 0}}' "$app_image" || true
+
+printf 'Booting the previous release\n'
+compose up \
+  --detach \
+  --wait \
+  --wait-timeout 600 \
+  postgres redis minio minio-init db-migrate api web controller bullmq preview-proxy
+
+migration_container="$(compose ps --all --quiet db-migrate)"
+[ -n "$migration_container" ] || {
+  printf 'db-migrate container was not created\n' >&2
+  exit 1
+}
+migration_exit="$(docker inspect --format '{{.State.ExitCode}}' "$migration_container")"
+[ "$migration_exit" = '0' ] || {
+  printf 'baseline db-migrate exited with %s\n' "$migration_exit" >&2
+  exit 1
+}
+verify_endpoints
+write_marker
+baseline_migrations="$(applied_migration_count)"
+
+printf 'Applying candidate migrations to the previous release database\n'
+DATABASE_URL="postgres://postgres:roomote-postgres-password@127.0.0.1:$postgres_port/roomote" \
+  pnpm --filter @roomote/db db:migrate:standalone
+
+candidate_migrations="$(applied_migration_count)"
+[ "$candidate_migrations" -ge "$baseline_migrations" ] || {
+  printf 'migration journal shrank from %s to %s\n' "$baseline_migrations" "$candidate_migrations" >&2
+  exit 1
+}
+printf 'Applied migrations: %s baseline -> %s candidate\n' "$baseline_migrations" "$candidate_migrations"
+
+printf 'Verifying the previous release on the candidate schema\n'
+verify_endpoints
+verify_marker
+
+# A rollback is a cold start of the previous release against the candidate
+# schema, so restart the application services and require health again.
+printf 'Cold-restarting the previous release on the candidate schema\n'
+compose restart api web controller bullmq preview-proxy
+compose up \
+  --detach \
+  --wait \
+  --wait-timeout 300 \
+  api web controller bullmq preview-proxy
+verify_endpoints
+verify_marker
+
+printf 'Upgrade compatibility passed: %s stays healthy on the candidate schema\n' "$baseline_channel"

--- a/deploy/ci/validate-deployment-artifacts.mjs
+++ b/deploy/ci/validate-deployment-artifacts.mjs
@@ -255,6 +255,8 @@ for (const script of [
   'deploy/scripts/roomote-deploy',
   'deploy/scripts/upgrade.sh',
   'deploy/ci/deployment-smoke.sh',
+  'deploy/ci/upgrade-compatibility.sh',
+  'deploy/host/tests/backup-restore.integration.sh',
 ]) {
   execFileSync('bash', ['-n', join(root, script)], { stdio: 'pipe' });
 }

--- a/deploy/host/roomote
+++ b/deploy/host/roomote
@@ -17,10 +17,15 @@ Commands:
   status                 Show the state of every Roomote service
   logs [service...]      Follow logs (default: web api controller caddy)
   setup-url              Print the /setup link with the setup token
-  upgrade [version]      Upgrade (or roll back) to an image tag; defaults to
-                         the latest GitHub release
+  upgrade [version] [options]
+                         Upgrade (or roll back) to an image tag; defaults to
+                         the latest GitHub release. Creates an encrypted
+                         pre-upgrade backup and applies database migrations
+                         before replacing services (see roomote upgrade --help)
                          Set ROOMOTE_IMAGE_RETENTION_RELEASES to control how
                          many Roomote release tags are kept after upgrade
+  rollback               Re-deploy the release that was running before the
+                         last upgrade
   backup [options]       Create an encrypted deployment backup bundle
   restore <file> --yes   Restore a bundle, OVERWRITING deployment state
   restart [service...]   Restart services (default: all)
@@ -59,6 +64,22 @@ Options:
 
 ROOMOTE_BACKUP_PASSPHRASE may be used instead of --passphrase-file. If neither
 is set, an interactive terminal is required.
+EOF
+}
+
+upgrade_usage() {
+  cat <<'EOF'
+usage: roomote upgrade [version] [options]
+
+Options:
+  --skip-backup                   Do not create a pre-upgrade backup bundle
+  --backup-passphrase-file <file> Encrypt the pre-upgrade backup with this
+                                  passphrase instead of a generated one
+
+ROOMOTE_BACKUP_PASSPHRASE may be used instead of --backup-passphrase-file.
+Without either, upgrade generates a passphrase and stores it next to the
+bundle under /opt/roomote/backups; move both off-host if the bundle should
+also serve as a disaster-recovery copy.
 EOF
 }
 
@@ -414,10 +435,65 @@ resolve_latest_version() {
   printf '%s' "$latest"
 }
 
+# Encrypted pre-upgrade backup so every upgrade has a restore-tested rollback
+# point. Reuses cmd_backup, so the bundle format and consistency guarantees
+# match a manual `roomote backup`.
+pre_upgrade_backup() {
+  local previous_version="$1"
+  local passphrase_arg="$2"
+  local bundle passphrase_file
+
+  mkdir -p "$install_root/backups"
+  bundle="$install_root/backups/pre-upgrade-${previous_version:-unknown}-$(date +%F-%H%M%S).roomote"
+  log "Creating a pre-upgrade backup (skip with roomote upgrade --skip-backup)"
+  if [ -n "$passphrase_arg" ]; then
+    cmd_backup --passphrase-file "$passphrase_arg" --output "$bundle"
+  elif [ -n "${ROOMOTE_BACKUP_PASSPHRASE:-}" ]; then
+    cmd_backup --output "$bundle"
+  else
+    # No operator passphrase: generate one and keep it beside the bundle.
+    # Both stay in the host's existing trust domain (like /opt/roomote/.env);
+    # move them off-host to double as a disaster-recovery copy.
+    passphrase_file="$bundle.passphrase"
+    (umask 077 && openssl rand -base64 32 >"$passphrase_file")
+    log "Generated backup passphrase file $passphrase_file"
+    cmd_backup --passphrase-file "$passphrase_file" --output "$bundle"
+  fi
+  log "Pre-upgrade backup written to $bundle"
+}
+
 cmd_upgrade() {
-  local version="${1:-}"
+  local version=''
+  local skip_backup='false'
+  local backup_passphrase_arg=''
   local repo image_registry image_namespace previous_worker_image worker_image
-  local modal_base_image_ref fetch_ref app_domain
+  local modal_base_image_ref fetch_ref app_domain previous_version
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --skip-backup)
+        skip_backup='true'
+        shift
+        ;;
+      --backup-passphrase-file)
+        backup_passphrase_arg="${2:-}"
+        shift 2
+        ;;
+      --help | -h)
+        upgrade_usage
+        return
+        ;;
+      --*)
+        upgrade_usage >&2
+        die "unknown upgrade option: $1"
+        ;;
+      *)
+        [ -z "$version" ] || die "only one upgrade version may be given"
+        version="$1"
+        shift
+        ;;
+    esac
+  done
 
   repo="$(read_env_value ROOMOTE_REPO)"
   repo="${repo:-RooCodeInc/Roomote}"
@@ -426,6 +502,27 @@ cmd_upgrade() {
     log "Resolving the latest Roomote release"
     version="$(resolve_latest_version "$repo")"
     [ -n "$version" ] || die "could not resolve a release tag from github.com/$repo; pass a version explicitly"
+  fi
+
+  previous_version="$(read_env_value ROOMOTE_VERSION)"
+  if [ "$skip_backup" = 'true' ]; then
+    log "Skipping the pre-upgrade backup (--skip-backup)"
+  else
+    pre_upgrade_backup "$previous_version" "$backup_passphrase_arg"
+  fi
+
+  # Keep a copy of the current deployment files so a failed migration can put
+  # the previous release's configuration back exactly as it was. Deliberately
+  # not a local: the EXIT trap must still see it after bash unwinds function
+  # scope on a set -e failure in a nested call.
+  mkdir -p "$install_root/backups"
+  upgrade_rollback_dir="$(mktemp -d "$install_root/backups/.upgrade-staging.XXXXXX")"
+  chmod 700 "$upgrade_rollback_dir"
+  trap 'rm -rf "${upgrade_rollback_dir:-}"' EXIT
+  install -m 600 "$env_file" "$upgrade_rollback_dir/.env"
+  install -m 600 "$compose_file" "$upgrade_rollback_dir/docker-compose.prod.yml"
+  if [ -f "$install_root/caddy/Caddyfile" ]; then
+    install -m 600 "$install_root/caddy/Caddyfile" "$upgrade_rollback_dir/Caddyfile"
   fi
 
   image_registry="$(read_env_value IMAGE_REGISTRY)"
@@ -448,6 +545,11 @@ cmd_upgrade() {
   fetch_deploy_file "$repo" "$fetch_ref" deploy/caddy/Caddyfile "$install_root/caddy/Caddyfile"
 
   set_env_value ROOMOTE_VERSION "$version"
+  # Recorded for `roomote rollback`; skipped for same-version re-runs so a
+  # retry cannot overwrite the real rollback target with itself.
+  if [ -n "$previous_version" ] && [ "$previous_version" != "$version" ]; then
+    set_env_value ROOMOTE_PREVIOUS_VERSION "$previous_version"
+  fi
   set_env_value TRPC_URL "https://$app_domain/_roomote-api"
   set_env_value IMAGE_REGISTRY "$image_registry"
   set_env_value IMAGE_NAMESPACE "$image_namespace"
@@ -472,6 +574,22 @@ cmd_upgrade() {
   log "Pulling images for $version"
   docker pull "$worker_image"
   compose pull
+  # Migrations run before any running service is replaced. Drizzle applies
+  # all pending migrations in a single transaction, so a failure here rolls
+  # the schema back and the previous release keeps serving.
+  log "Applying database migrations for $version before replacing services"
+  if ! compose run --rm db-migrate; then
+    log "Migration failed; restoring the previous deployment configuration"
+    install -m 600 "$upgrade_rollback_dir/.env" "$env_file"
+    install -m 600 "$upgrade_rollback_dir/docker-compose.prod.yml" "$compose_file"
+    if [ -f "$upgrade_rollback_dir/Caddyfile" ]; then
+      install -m 600 "$upgrade_rollback_dir/Caddyfile" "$install_root/caddy/Caddyfile"
+    fi
+    compose start controller || true
+    die "database migrations for $version failed and were rolled back; the previous release${previous_version:+ ($previous_version)} is still running"
+  fi
+  rm -rf "$upgrade_rollback_dir"
+  trap - EXIT
   log "Starting Roomote $version"
   compose up -d --wait --wait-timeout 600
   systemctl enable roomote-compose.service >/dev/null 2>&1 || true
@@ -480,6 +598,19 @@ cmd_upgrade() {
     log "Warning: image retention failed; upgrade is still healthy"
   fi
   log "Upgrade to $version complete"
+}
+
+# Emergency path back to the release recorded by the last upgrade. Skips the
+# pre-upgrade backup on purpose: the bundle from the failed upgrade already
+# exists, and a backup against an unhealthy stack could block the rollback.
+cmd_rollback() {
+  local previous_version
+
+  [ "$#" -eq 0 ] || die "usage: roomote rollback"
+  previous_version="$(read_env_value ROOMOTE_PREVIOUS_VERSION)"
+  [ -n "$previous_version" ] || die "no previous release recorded in $env_file; run 'roomote upgrade <version>' with an explicit tag instead"
+  log "Rolling back to the previously deployed release $previous_version"
+  cmd_upgrade "$previous_version" --skip-backup
 }
 
 stop_task_workers() {
@@ -880,6 +1011,7 @@ case "$command" in
   logs) cmd_logs "$@" ;;
   setup-url) cmd_setup_url "$@" ;;
   upgrade) cmd_upgrade "$@" ;;
+  rollback) cmd_rollback "$@" ;;
   backup) cmd_backup "$@" ;;
   restore) cmd_restore "$@" ;;
   restart) compose restart "$@" ;;

--- a/deploy/scripts/upgrade.sh
+++ b/deploy/scripts/upgrade.sh
@@ -230,6 +230,16 @@ chmod 600 .env
 docker compose --env-file .env -f docker-compose.prod.yml config >/dev/null
 docker pull "$worker_image"
 docker compose --env-file .env -f docker-compose.prod.yml pull
+# Migrations run before any running service is replaced. Drizzle applies all
+# pending migrations in a single transaction, so a failure here rolls the
+# schema back while the previous release keeps serving.
+echo "Applying database migrations before replacing running services"
+if ! docker compose --env-file .env -f docker-compose.prod.yml run --rm db-migrate; then
+  echo "Database migrations failed and were rolled back; the previous release keeps serving." >&2
+  echo "Restarting the previous controller. Re-run roomote-deploy upgrade with the previous tag to restore deployment metadata, or fix the migration and retry." >&2
+  docker compose --env-file .env -f docker-compose.prod.yml start controller || true
+  exit 1
+fi
 docker compose --env-file .env -f docker-compose.prod.yml up -d --wait --wait-timeout 600
 systemctl enable roomote-compose.service
 REMOTE

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roomote",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "license": "FCL-1.0-ALv2",
   "packageManager": "pnpm@10.29.3",
   "engines": {

--- a/packages/ado/package.json
+++ b/packages/ado/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/ado",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "exports": "./src/index.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/auth",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/cloud-agents/package.json
+++ b/packages/cloud-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/cloud-agents",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/cloud-agents/src/index.ts
+++ b/packages/cloud-agents/src/index.ts
@@ -16,7 +16,7 @@ export {
 export * from './style-guidance';
 export {
   DEFAULT_STANDARD_TASK_MODEL,
-  DEFAULT_STANDARD_TASK_PROVIDER,
+  DEFAULT_STANDARD_TASK_MODEL_PROVIDER,
   DEFAULT_STANDARD_TASK_REASONING_EFFORT,
 } from './task-runtime-defaults';
 export {

--- a/packages/cloud-agents/src/server/github-message-instructions.ts
+++ b/packages/cloud-agents/src/server/github-message-instructions.ts
@@ -18,7 +18,7 @@ export function buildGitHubMessageInstructions(): string {
 export function buildGitHubMentionFollowUpHarnessInstructions(): string {
   return `
 <github_pr_follow_up_policy>
-  <rule>Apply this policy before the default Standard Task initial routing step for mention-driven GitHub PR follow-up work.</rule>
+  <rule>Apply this policy before the standard workflow's default initial routing step for mention-driven GitHub PR follow-up work.</rule>
   <rule>If the triggering GitHub mention is only gratitude or other non-actionable conversation with no requested review, explanation, planning, verification, or repository change, do not route into \`implement-changes\`, \`plan-repo-implementation\`, or \`explain-repo-code\` just to satisfy the default router.</rule>
   <rule>For that non-actionable mention case, leave one brief GitHub reply on the same PR conversation surface if a reply is still useful, then conclude with a no-op result.</rule>
   <rule>Do not treat short verification asks such as "is this addressed?" or "did we fix everything from the last round?" as no-op; those are actionable follow-up and should continue through normal routing.</rule>

--- a/packages/cloud-agents/src/server/github-pr-follow-up-context.ts
+++ b/packages/cloud-agents/src/server/github-pr-follow-up-context.ts
@@ -47,7 +47,7 @@ export function buildGitHubMentionFollowUpRequest({
     'A GitHub pull request comment mentioned Roomote and this run is the new dedicated follow-up task for that PR.',
     'Use the current PR context below and keep the work scoped to this repository and pull request.',
     'If the triggering comment is only gratitude or other non-actionable conversation, reply briefly on GitHub if useful and conclude with a no-op result instead of inventing follow-up work.',
-    'Use the normal Standard Task initial routing rules to choose the correct starting workflow for the current request:',
+    'Use the standard workflow initial routing rules to choose the correct starting skill for the current request:',
     '- `implement-changes` for actionable PR follow-up work, including code, docs, tests, config, prompt, or routing changes',
     '- `plan-repo-implementation` for planning or scoping requests that should stay non-mutating',
     '- `explain-repo-code` for explanation-only requests about the current PR',

--- a/packages/cloud-agents/src/server/router/router-service.ts
+++ b/packages/cloud-agents/src/server/router/router-service.ts
@@ -72,7 +72,7 @@ interface InternalRoutingResult {
   workspaceRemapped: boolean;
 }
 
-type GeneralistRoutingBuildResult =
+type StandardTaskRoutingBuildResult =
   | {
       status: 'meta_question';
       reasoning: string;
@@ -220,10 +220,10 @@ function resolveRoutedTaskModel(
   };
 }
 
-function buildGeneralistRoutingResult(
+function buildStandardTaskRoutingResult(
   response: WorkspaceResponse,
   context: RoutingContext,
-): GeneralistRoutingBuildResult {
+): StandardTaskRoutingBuildResult {
   const workspace = mapWorkspace(response.workspaceValue, context);
   const workspaceRemapped = wasWorkspaceRemapped(
     response.workspaceValue,
@@ -351,7 +351,7 @@ async function runRoutingDecision(
     );
 
     if (responseResult.response) {
-      const built = buildGeneralistRoutingResult(
+      const built = buildStandardTaskRoutingResult(
         responseResult.response,
         promptContext,
       );

--- a/packages/cloud-agents/src/server/task-run-queue.ts
+++ b/packages/cloud-agents/src/server/task-run-queue.ts
@@ -61,7 +61,7 @@ import type { MetadataRecord } from '@roomote/feature-flags/server';
 import { type Redis, getRedis } from '@roomote/redis';
 import { captureEvent } from '@roomote/telemetry/server';
 import { generateTaskRunTitle, hasDeterministicTaskRunTitle } from '../utils';
-import { DEFAULT_STANDARD_TASK_PROVIDER } from '../task-runtime-defaults';
+import { DEFAULT_STANDARD_TASK_MODEL_PROVIDER } from '../task-runtime-defaults';
 import { evaluateCommitAuthor } from './authorship-rules';
 import { findLatestGithubIdentityForUser } from './commit-author';
 import { resolveEffectiveHarnessModelState } from './harness-model-overrides';
@@ -1323,7 +1323,7 @@ async function enqueueFreshLaunch(
         linearIssueId: input.channels?.linearIssueId ?? null,
         linearOrganizationId: input.channels?.linearOrganizationId ?? null,
         harness: targetHarness,
-        provider: DEFAULT_STANDARD_TASK_PROVIDER,
+        modelProvider: DEFAULT_STANDARD_TASK_MODEL_PROVIDER,
         model: effectiveTaskModel,
         title,
         ...(hasDeterministicTaskRunTitle(taskWithHarnessOverrides.type)

--- a/packages/cloud-agents/src/server/task-suggestion-prompts.ts
+++ b/packages/cloud-agents/src/server/task-suggestion-prompts.ts
@@ -85,7 +85,7 @@ export function buildSuggestionTaskPromptText(params: {
   brief: string;
   investigationContext: string | null;
   readinessMessage?: string | null;
-  agentType?: string | null;
+  suggestionType?: string | null;
   category?: SuggestionCategory | null;
   priority?: SuggestionPriority | null;
   targetRepositoryFullName?: string | null;
@@ -93,7 +93,7 @@ export function buildSuggestionTaskPromptText(params: {
   const baseText = buildSuggestionSlackText(params);
   const investigationContext = params.investigationContext?.trim();
 
-  if (params.agentType === 'sentry_triage') {
+  if (params.suggestionType === 'sentry_triage') {
     return buildSentryTriageSuggestionTaskPromptText({
       ...params,
       baseText,
@@ -101,7 +101,7 @@ export function buildSuggestionTaskPromptText(params: {
     });
   }
 
-  if (params.agentType === 'dependabot_triage') {
+  if (params.suggestionType === 'dependabot_triage') {
     return buildDependabotTriageSuggestionTaskPromptText({
       ...params,
       baseText,

--- a/packages/cloud-agents/src/task-runtime-defaults.ts
+++ b/packages/cloud-agents/src/task-runtime-defaults.ts
@@ -1,3 +1,3 @@
-export const DEFAULT_STANDARD_TASK_PROVIDER = 'opencode';
+export const DEFAULT_STANDARD_TASK_MODEL_PROVIDER = 'opencode';
 export const DEFAULT_STANDARD_TASK_MODEL = 'roomote-model-default';
 export const DEFAULT_STANDARD_TASK_REASONING_EFFORT = 'high';

--- a/packages/communication/package.json
+++ b/packages/communication/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/communication",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/compute-providers/package.json
+++ b/packages/compute-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/compute-providers",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/config-eslint/package.json
+++ b/packages/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/config-eslint",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/config-typescript/package.json
+++ b/packages/config-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/config-typescript",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "publishConfig": {
     "access": "public"

--- a/packages/db/drizzle/0006_schema_hardening.sql
+++ b/packages/db/drizzle/0006_schema_hardening.sql
@@ -1,0 +1,19 @@
+ALTER TABLE "tasks" RENAME COLUMN "provider" TO "model_provider";--> statement-breakpoint
+ALTER TABLE "webhooks" DROP CONSTRAINT "webhooks_delivery_id_unique";--> statement-breakpoint
+DROP INDEX "repositories_provider_external_repo_unique";--> statement-breakpoint
+DROP INDEX "repositories_provider_full_name_unique";--> statement-breakpoint
+DROP INDEX "webhooks_provider_idx";--> statement-breakpoint
+CREATE UNIQUE INDEX "repositories_provider_host_external_repo_unique" ON "repositories" USING btree ("source_control_provider",coalesce("host", ''),"external_repo_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "repositories_provider_host_full_name_unique" ON "repositories" USING btree ("source_control_provider",coalesce("host", ''),"full_name");--> statement-breakpoint
+CREATE UNIQUE INDEX "webhooks_provider_delivery_id_unique" ON "webhooks" USING btree ("provider","delivery_id");--> statement-breakpoint
+ALTER TABLE "task_runs" ADD CONSTRAINT "task_runs_kind_check" CHECK ("task_runs"."kind" in ('fresh', 'resume'));--> statement-breakpoint
+ALTER TABLE "task_runs" ADD CONSTRAINT "task_runs_harness_check" CHECK ("task_runs"."harness" in ('opencode-server'));--> statement-breakpoint
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_workflow_check" CHECK ("tasks"."workflow" in ('standard', 'pr_review', 'pr_conflict_resolve', 'scan', 'mcp_recommendations', 'setup_onboarding', 'env_snapshot', 'eval'));--> statement-breakpoint
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_surface_check" CHECK ("tasks"."surface" in ('web', 'api', 'slack', 'teams', 'telegram', 'linear', 'github', 'gitlab', 'gitea', 'ado', 'system'));--> statement-breakpoint
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_trigger_check" CHECK ("tasks"."trigger" in ('message', 'webhook', 'schedule', 'manual'));--> statement-breakpoint
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_visibility_check" CHECK ("tasks"."visibility" in ('visible', 'hidden'));--> statement-breakpoint
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_state_check" CHECK ("tasks"."state" in ('active', 'completed', 'failed', 'canceled'));--> statement-breakpoint
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_harness_check" CHECK ("tasks"."harness" in ('opencode-server'));--> statement-breakpoint
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_requested_work_kind_check" CHECK ("tasks"."requested_work_kind" in ('question', 'plan', 'implement', 'unknown'));--> statement-breakpoint
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_requested_work_kind_source_check" CHECK ("tasks"."requested_work_kind_source" in ('explicit_bootstrap', 'task_tool', 'llm_classifier', 'inherited', 'system_default'));--> statement-breakpoint
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_commit_author_kind_check" CHECK ("tasks"."commit_author_kind" IS NULL OR "tasks"."commit_author_kind" in ('roomote', 'user', 'external'));

--- a/packages/db/drizzle/meta/0006_snapshot.json
+++ b/packages/db/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,9002 @@
+{
+  "id": "1f801177-23f6-4126-8c82-54a1f86d647b",
+  "prevId": "b6ae50ef-9b3b-4385-a0db-571c4e6f2820",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_accounts": {
+      "name": "auth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_accounts_user_id_idx": {
+          "name": "auth_accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_accounts_provider_account_unique": {
+          "name": "auth_accounts_provider_account_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_accounts_user_id_auth_users_id_fk": {
+          "name": "auth_accounts_user_id_auth_users_id_fk",
+          "tableFrom": "auth_accounts",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_sessions_token_unique": {
+          "name": "auth_sessions_token_unique",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_sessions_user_id_idx": {
+          "name": "auth_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_sessions_user_id_auth_users_id_fk": {
+          "name": "auth_sessions_user_id_auth_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_users": {
+      "name": "auth_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_users_email_unique": {
+          "name": "auth_users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_users_created_at_idx": {
+          "name": "auth_users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verifications": {
+      "name": "auth_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_verifications_identifier_idx": {
+          "name": "auth_verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automations": {
+      "name": "automations",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "internal": {
+          "name": "internal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "targets": {
+          "name": "targets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_succeeded_at": {
+          "name": "last_succeeded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failed_at": {
+          "name": "last_failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scan_cursor": {
+          "name": "scan_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compute_provider_usage": {
+      "name": "compute_provider_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_usage_id": {
+          "name": "provider_usage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_kind": {
+          "name": "auth_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "launch_mode": {
+          "name": "launch_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_action": {
+          "name": "lifecycle_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "measurement_source": {
+          "name": "measurement_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_vcpus": {
+          "name": "configured_vcpus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configured_cpu_cores": {
+          "name": "configured_cpu_cores",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configured_memory_mib": {
+          "name": "configured_memory_mib",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wall_clock_duration_ms": {
+          "name": "wall_clock_duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_cpu_duration_ms": {
+          "name": "active_cpu_duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_memory_mib_milliseconds": {
+          "name": "observed_memory_mib_milliseconds",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network_ingress_bytes": {
+          "name": "network_ingress_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network_egress_bytes": {
+          "name": "network_egress_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "compute_provider_usage_provider_usage_id_unique": {
+          "name": "compute_provider_usage_provider_usage_id_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_usage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "compute_provider_usage_run_id_idx": {
+          "name": "compute_provider_usage_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "compute_provider_usage_task_id_idx": {
+          "name": "compute_provider_usage_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "compute_provider_usage_created_at_idx": {
+          "name": "compute_provider_usage_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compute_provider_usage_run_id_task_runs_id_fk": {
+          "name": "compute_provider_usage_run_id_task_runs_id_fk",
+          "tableFrom": "compute_provider_usage",
+          "tableTo": "task_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "compute_provider_usage_task_id_tasks_id_fk": {
+          "name": "compute_provider_usage_task_id_tasks_id_fk",
+          "tableFrom": "compute_provider_usage",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compute_provider_usage_samples": {
+      "name": "compute_provider_usage_samples",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_usage_id": {
+          "name": "provider_usage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sampled_at": {
+          "name": "sampled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_usage_ns_total": {
+          "name": "cpu_usage_ns_total",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_usage_bytes": {
+          "name": "memory_usage_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_peak_usage_bytes": {
+          "name": "memory_peak_usage_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "compute_provider_usage_samples_provider_usage_sampled_at_unique": {
+          "name": "compute_provider_usage_samples_provider_usage_sampled_at_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_usage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sampled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "compute_provider_usage_samples_run_id_idx": {
+          "name": "compute_provider_usage_samples_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "compute_provider_usage_samples_task_id_idx": {
+          "name": "compute_provider_usage_samples_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "compute_provider_usage_samples_created_at_idx": {
+          "name": "compute_provider_usage_samples_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compute_provider_usage_samples_run_id_task_runs_id_fk": {
+          "name": "compute_provider_usage_samples_run_id_task_runs_id_fk",
+          "tableFrom": "compute_provider_usage_samples",
+          "tableTo": "task_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "compute_provider_usage_samples_task_id_tasks_id_fk": {
+          "name": "compute_provider_usage_samples_task_id_tasks_id_fk",
+          "tableFrom": "compute_provider_usage_samples",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_mcp_enablements": {
+      "name": "deployment_mcp_enablements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "mcp_id": {
+          "name": "mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enabled_by_user_id": {
+          "name": "enabled_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_tools": {
+          "name": "disabled_tools",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "deployment_mcp_enablements_enabled_by_user_id_users_id_fk": {
+          "name": "deployment_mcp_enablements_enabled_by_user_id_users_id_fk",
+          "tableFrom": "deployment_mcp_enablements",
+          "tableTo": "users",
+          "columnsFrom": ["enabled_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "deployment_mcp_enablements_mcp_unique": {
+          "name": "deployment_mcp_enablements_mcp_unique",
+          "nullsNotDistinct": false,
+          "columns": ["mcp_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_secrets": {
+      "name": "deployment_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deployment_secrets_name_unique": {
+          "name": "deployment_secrets_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "task_model_settings": {
+          "name": "task_model_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "router_debug_slack_channel_id": {
+          "name": "router_debug_slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_model_config": {
+          "name": "runtime_model_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_compute_config": {
+          "name": "runtime_compute_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_policy": {
+          "name": "access_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_key": {
+          "name": "license_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_analytics_id": {
+          "name": "instance_analytics_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_known_version": {
+          "name": "latest_known_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_version_checked_at": {
+          "name": "latest_version_checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_completed_at": {
+          "name": "setup_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_new_state": {
+          "name": "setup_new_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_onboarding_stage": {
+          "name": "slack_onboarding_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manager_slack_channel_id": {
+          "name": "manager_slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_agent_instructions": {
+          "name": "global_agent_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorship_instructions": {
+          "name": "authorship_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compiled_authorship_rules": {
+          "name": "compiled_authorship_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "compiled_authorship_issues": {
+          "name": "compiled_authorship_issues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "compiled_authorship_at": {
+          "name": "compiled_authorship_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "style_guidance": {
+          "name": "style_guidance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_summon_emoji": {
+          "name": "slack_summon_emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_ack_emoji": {
+          "name": "slack_ack_emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eyes'"
+        },
+        "slack_completion_emoji": {
+          "name": "slack_completion_emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'white_check_mark'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.environment_config_versions": {
+      "name": "environment_config_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "environment_config_versions_environment_id_idx": {
+          "name": "environment_config_versions_environment_id_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "environment_config_versions_environment_version_unique": {
+          "name": "environment_config_versions_environment_version_unique",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "environment_config_versions_environment_id_environments_id_fk": {
+          "name": "environment_config_versions_environment_id_environments_id_fk",
+          "tableFrom": "environment_config_versions",
+          "tableTo": "environments",
+          "columnsFrom": ["environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "environment_config_versions_created_by_user_id_users_id_fk": {
+          "name": "environment_config_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "environment_config_versions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.environment_repository_mappings": {
+      "name": "environment_repository_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "env_repo_mappings_env_id_idx": {
+          "name": "env_repo_mappings_env_id_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "env_repo_mappings_repo_id_idx": {
+          "name": "env_repo_mappings_repo_id_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "environment_repository_mappings_environment_id_environments_id_fk": {
+          "name": "environment_repository_mappings_environment_id_environments_id_fk",
+          "tableFrom": "environment_repository_mappings",
+          "tableTo": "environments",
+          "columnsFrom": ["environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "environment_repository_mappings_repository_id_repositories_id_fk": {
+          "name": "environment_repository_mappings_repository_id_repositories_id_fk",
+          "tableFrom": "environment_repository_mappings",
+          "tableTo": "repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "env_repo_mappings_unique": {
+          "name": "env_repo_mappings_unique",
+          "nullsNotDistinct": false,
+          "columns": ["environment_id", "repository_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.environment_snapshots": {
+      "name": "environment_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_created_at": {
+          "name": "snapshot_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_expires_at": {
+          "name": "snapshot_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_status": {
+          "name": "snapshot_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "environment_snapshots_environment_id_idx": {
+          "name": "environment_snapshots_environment_id_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "environment_snapshots_env_provider_unique": {
+          "name": "environment_snapshots_env_provider_unique",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"environment_snapshots\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "environment_snapshots_environment_id_environments_id_fk": {
+          "name": "environment_snapshots_environment_id_environments_id_fk",
+          "tableFrom": "environment_snapshots",
+          "tableTo": "environments",
+          "columnsFrom": ["environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.environment_variables": {
+      "name": "environment_variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_by_user_id": {
+          "name": "last_updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "environment_variables_user_id_idx": {
+          "name": "environment_variables_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "environment_variables_name_unique": {
+          "name": "environment_variables_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "environment_variables_user_id_users_id_fk": {
+          "name": "environment_variables_user_id_users_id_fk",
+          "tableFrom": "environment_variables",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "environment_variables_created_by_user_id_users_id_fk": {
+          "name": "environment_variables_created_by_user_id_users_id_fk",
+          "tableFrom": "environment_variables",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "environment_variables_last_updated_by_user_id_users_id_fk": {
+          "name": "environment_variables_last_updated_by_user_id_users_id_fk",
+          "tableFrom": "environment_variables",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.environments": {
+      "name": "environments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_eval": {
+          "name": "is_eval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "declarative_source": {
+          "name": "declarative_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_created_at": {
+          "name": "snapshot_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_expires_at": {
+          "name": "snapshot_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_status": {
+          "name": "snapshot_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "environments_user_id_idx": {
+          "name": "environments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "environments_created_by_user_id_idx": {
+          "name": "environments_created_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "environments_snapshot_expires_at_idx": {
+          "name": "environments_snapshot_expires_at_idx",
+          "columns": [
+            {
+              "expression": "snapshot_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "environments_name_unique": {
+          "name": "environments_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "environments_user_id_users_id_fk": {
+          "name": "environments_user_id_users_id_fk",
+          "tableFrom": "environments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "environments_created_by_user_id_users_id_fk": {
+          "name": "environments_created_by_user_id_users_id_fk",
+          "tableFrom": "environments",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "members_count": {
+          "name": "members_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_account_login_idx": {
+          "name": "github_installations_account_login_idx",
+          "columns": [
+            {
+              "expression": "account_login",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_deployment_installation_unique": {
+          "name": "github_installations_deployment_installation_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_user_id_users_id_fk": {
+          "name": "github_installations_user_id_users_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installations_installed_by_user_id_users_id_fk": {
+          "name": "github_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "users",
+          "columnsFrom": ["installed_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_pending_installations": {
+      "name": "github_pending_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_pending_installations_requested_by_user_id_idx": {
+          "name": "github_pending_installations_requested_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "requested_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_pending_installations_user_id_users_id_fk": {
+          "name": "github_pending_installations_user_id_users_id_fk",
+          "tableFrom": "github_pending_installations",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_pending_installations_requested_by_user_id_users_id_fk": {
+          "name": "github_pending_installations_requested_by_user_id_users_id_fk",
+          "tableFrom": "github_pending_installations",
+          "tableTo": "users",
+          "columnsFrom": ["requested_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_user_mappings": {
+      "name": "github_user_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_login": {
+          "name": "github_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_user_mappings_github_login_idx": {
+          "name": "github_user_mappings_github_login_idx",
+          "columns": [
+            {
+              "expression": "github_login",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_user_mappings_user_id_idx": {
+          "name": "github_user_mappings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_user_mappings_user_id_users_id_fk": {
+          "name": "github_user_mappings_user_id_users_id_fk",
+          "tableFrom": "github_user_mappings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "github_user_mappings_unique": {
+          "name": "github_user_mappings_unique",
+          "nullsNotDistinct": false,
+          "columns": ["github_user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invites_token_hash_unique": {
+          "name": "invites_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_created_at_idx": {
+          "name": "invites_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_invited_by_user_id_users_id_fk": {
+          "name": "invites_invited_by_user_id_users_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "users",
+          "columnsFrom": ["invited_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.linear_pending_selections": {
+      "name": "linear_pending_selections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linear_organization_id": {
+          "name": "linear_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step": {
+          "name": "step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'awaiting_workspace'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_repo": {
+          "name": "selected_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_options": {
+          "name": "workspace_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "linear_pending_selections_expires_at_idx": {
+          "name": "linear_pending_selections_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "linear_pending_selections_step_idx": {
+          "name": "linear_pending_selections_step_idx",
+          "columns": [
+            {
+              "expression": "step",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "linear_pending_selections_user_id_users_id_fk": {
+          "name": "linear_pending_selections_user_id_users_id_fk",
+          "tableFrom": "linear_pending_selections",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "linear_pending_selections_session_id_unique": {
+          "name": "linear_pending_selections_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["session_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_connections": {
+      "name": "mcp_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_id": {
+          "name": "mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_role": {
+          "name": "connection_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auth_status": {
+          "name": "auth_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_connections_user_id_idx": {
+          "name": "mcp_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_connections_role_idx": {
+          "name": "mcp_connections_role_idx",
+          "columns": [
+            {
+              "expression": "mcp_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_connections_user_id_users_id_fk": {
+          "name": "mcp_connections_user_id_users_id_fk",
+          "tableFrom": "mcp_connections",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_connections_user_mcp_id_unique": {
+          "name": "mcp_connections_user_mcp_id_unique",
+          "nullsNotDistinct": true,
+          "columns": ["user_id", "mcp_id", "connection_role"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_replays": {
+      "name": "mcp_oauth_replays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_id": {
+          "name": "mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_role": {
+          "name": "connection_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "redirect_to": {
+          "name": "redirect_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_replays_connection_id_idx": {
+          "name": "mcp_oauth_replays_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_oauth_replays_user_id_idx": {
+          "name": "mcp_oauth_replays_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_oauth_replays_expires_at_idx": {
+          "name": "mcp_oauth_replays_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_replays_connection_id_mcp_connections_id_fk": {
+          "name": "mcp_oauth_replays_connection_id_mcp_connections_id_fk",
+          "tableFrom": "mcp_oauth_replays",
+          "tableTo": "mcp_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_replays_user_id_users_id_fk": {
+          "name": "mcp_oauth_replays_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_replays",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_replays_token_unique": {
+          "name": "mcp_oauth_replays_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.microsoft_auth_user_mappings": {
+      "name": "microsoft_auth_user_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_account_id": {
+          "name": "auth_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "microsoft_tenant_id": {
+          "name": "microsoft_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "microsoft_aad_object_id": {
+          "name": "microsoft_aad_object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "microsoft_auth_user_mappings_user_id_idx": {
+          "name": "microsoft_auth_user_mappings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "microsoft_auth_user_mappings_account_id_idx": {
+          "name": "microsoft_auth_user_mappings_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "microsoft_auth_user_mappings_auth_account_idx": {
+          "name": "microsoft_auth_user_mappings_auth_account_idx",
+          "columns": [
+            {
+              "expression": "auth_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "microsoft_auth_user_mappings_aad_object_unique": {
+          "name": "microsoft_auth_user_mappings_aad_object_unique",
+          "columns": [
+            {
+              "expression": "microsoft_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "microsoft_aad_object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "microsoft_auth_user_mappings_auth_account_id_auth_accounts_id_fk": {
+          "name": "microsoft_auth_user_mappings_auth_account_id_auth_accounts_id_fk",
+          "tableFrom": "microsoft_auth_user_mappings",
+          "tableTo": "auth_accounts",
+          "columnsFrom": ["auth_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "microsoft_auth_user_mappings_user_id_auth_users_id_fk": {
+          "name": "microsoft_auth_user_mappings_user_id_auth_users_id_fk",
+          "tableFrom": "microsoft_auth_user_mappings",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_state": {
+      "name": "oauth_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replay_token": {
+          "name": "replay_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_state_connection_id_idx": {
+          "name": "oauth_state_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_state_replay_token_idx": {
+          "name": "oauth_state_replay_token_idx",
+          "columns": [
+            {
+              "expression": "replay_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_state_expires_at_idx": {
+          "name": "oauth_state_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_state_connection_id_mcp_connections_id_fk": {
+          "name": "oauth_state_connection_id_mcp_connections_id_fk",
+          "tableFrom": "oauth_state",
+          "tableTo": "mcp_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pull_request_facts": {
+      "name": "pull_request_facts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_control_provider": {
+          "name": "source_control_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "external_pull_request_id": {
+          "name": "external_pull_request_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_remote": {
+          "name": "created_at_remote",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at_remote": {
+          "name": "updated_at_remote",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_at_remote": {
+          "name": "closed_at_remote",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at_remote": {
+          "name": "merged_at_remote",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pull_request_facts_deployment_repo_pr_unique": {
+          "name": "pull_request_facts_deployment_repo_pr_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pull_request_facts_deployment_created_idx": {
+          "name": "pull_request_facts_deployment_created_idx",
+          "columns": [
+            {
+              "expression": "created_at_remote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pull_request_facts_deployment_repo_created_idx": {
+          "name": "pull_request_facts_deployment_repo_created_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_remote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pull_request_facts_deployment_state_created_idx": {
+          "name": "pull_request_facts_deployment_state_created_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_remote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pull_request_facts_deployment_author_created_idx": {
+          "name": "pull_request_facts_deployment_author_created_idx",
+          "columns": [
+            {
+              "expression": "author_login",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_remote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pull_request_facts_deployment_updated_idx": {
+          "name": "pull_request_facts_deployment_updated_idx",
+          "columns": [
+            {
+              "expression": "updated_at_remote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pull_request_facts_repository_id_repositories_id_fk": {
+          "name": "pull_request_facts_repository_id_repositories_id_fk",
+          "tableFrom": "pull_request_facts",
+          "tableTo": "repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pull_request_facts_source_control_provider_check": {
+          "name": "pull_request_facts_source_control_provider_check",
+          "value": "\"pull_request_facts\".\"source_control_provider\" in ('github', 'gitlab', 'gitea', 'ado')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pull_request_sync_states": {
+      "name": "pull_request_sync_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_incremental_updated_at": {
+          "name": "last_incremental_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_completed_at": {
+          "name": "backfill_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cooldown_until": {
+          "name": "cooldown_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_successful_sync_at": {
+          "name": "last_successful_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempted_sync_at": {
+          "name": "last_attempted_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pull_request_sync_states_repo_unique": {
+          "name": "pull_request_sync_states_repo_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pull_request_sync_states_deployment_updated_idx": {
+          "name": "pull_request_sync_states_deployment_updated_idx",
+          "columns": [
+            {
+              "expression": "last_successful_sync_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pull_request_sync_states_cooldown_idx": {
+          "name": "pull_request_sync_states_cooldown_idx",
+          "columns": [
+            {
+              "expression": "cooldown_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pull_request_sync_states_repository_id_repositories_id_fk": {
+          "name": "pull_request_sync_states_repository_id_repositories_id_fk",
+          "tableFrom": "pull_request_sync_states",
+          "tableTo": "repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repositories": {
+      "name": "repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_control_provider": {
+          "name": "source_control_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_repo_id": {
+          "name": "external_repo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "clone_url": {
+          "name": "clone_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "linked_by_user_id": {
+          "name": "linked_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repositories_source_control_provider_idx": {
+          "name": "repositories_source_control_provider_idx",
+          "columns": [
+            {
+              "expression": "source_control_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositories_installation_id_idx": {
+          "name": "repositories_installation_id_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositories_full_name_idx": {
+          "name": "repositories_full_name_idx",
+          "columns": [
+            {
+              "expression": "full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositories_provider_host_full_name_idx": {
+          "name": "repositories_provider_host_full_name_idx",
+          "columns": [
+            {
+              "expression": "source_control_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositories_deployment_active_installation_idx": {
+          "name": "repositories_deployment_active_installation_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositories_deployment_github_repo_unique": {
+          "name": "repositories_deployment_github_repo_unique",
+          "columns": [
+            {
+              "expression": "github_repo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositories_provider_host_external_repo_unique": {
+          "name": "repositories_provider_host_external_repo_unique",
+          "columns": [
+            {
+              "expression": "source_control_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"host\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_repo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositories_provider_host_full_name_unique": {
+          "name": "repositories_provider_host_full_name_unique",
+          "columns": [
+            {
+              "expression": "source_control_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"host\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repositories_installation_id_github_installations_id_fk": {
+          "name": "repositories_installation_id_github_installations_id_fk",
+          "tableFrom": "repositories",
+          "tableTo": "github_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repositories_user_id_users_id_fk": {
+          "name": "repositories_user_id_users_id_fk",
+          "tableFrom": "repositories",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repositories_linked_by_user_id_users_id_fk": {
+          "name": "repositories_linked_by_user_id_users_id_fk",
+          "tableFrom": "repositories",
+          "tableTo": "users",
+          "columnsFrom": ["linked_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "repositories_source_control_provider_check": {
+          "name": "repositories_source_control_provider_check",
+          "value": "\"repositories\".\"source_control_provider\" in ('github', 'gitlab', 'gitea', 'ado')"
+        },
+        "repositories_github_shape_check": {
+          "name": "repositories_github_shape_check",
+          "value": "\"repositories\".\"source_control_provider\" != 'github' OR (\"repositories\".\"installation_id\" IS NOT NULL AND \"repositories\".\"github_repo_id\" IS NOT NULL)"
+        },
+        "repositories_gitlab_shape_check": {
+          "name": "repositories_gitlab_shape_check",
+          "value": "\"repositories\".\"source_control_provider\" != 'gitlab' OR \"repositories\".\"external_repo_id\" IS NOT NULL"
+        },
+        "repositories_gitea_shape_check": {
+          "name": "repositories_gitea_shape_check",
+          "value": "\"repositories\".\"source_control_provider\" != 'gitea' OR \"repositories\".\"external_repo_id\" IS NOT NULL"
+        },
+        "repositories_ado_shape_check": {
+          "name": "repositories_ado_shape_check",
+          "value": "\"repositories\".\"source_control_provider\" != 'ado' OR \"repositories\".\"external_repo_id\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sandbox_oidc_targets": {
+      "name": "sandbox_oidc_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compute_provider": {
+          "name": "compute_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compute_provider_id": {
+          "name": "compute_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_file": {
+          "name": "token_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aws_role_arn": {
+          "name": "aws_role_arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aws_region": {
+          "name": "aws_region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_at": {
+          "name": "refresh_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sandbox_oidc_targets_environment_id_idx": {
+          "name": "sandbox_oidc_targets_environment_id_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sandbox_oidc_targets_run_id_idx": {
+          "name": "sandbox_oidc_targets_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sandbox_oidc_targets_refresh_at_idx": {
+          "name": "sandbox_oidc_targets_refresh_at_idx",
+          "columns": [
+            {
+              "expression": "refresh_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sandbox_oidc_targets_provider_target_file_unique": {
+          "name": "sandbox_oidc_targets_provider_target_file_unique",
+          "columns": [
+            {
+              "expression": "compute_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "compute_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token_file",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_oidc_targets_environment_id_environments_id_fk": {
+          "name": "sandbox_oidc_targets_environment_id_environments_id_fk",
+          "tableFrom": "sandbox_oidc_targets",
+          "tableTo": "environments",
+          "columnsFrom": ["environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sandbox_oidc_targets_run_id_task_runs_id_fk": {
+          "name": "sandbox_oidc_targets_run_id_task_runs_id_fk",
+          "tableFrom": "sandbox_oidc_targets",
+          "tableTo": "task_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sandbox_oidc_targets_owner_required": {
+          "name": "sandbox_oidc_targets_owner_required",
+          "value": "run_id IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.setup_qualification_blocks": {
+      "name": "setup_qualification_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'blocked'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_domain": {
+          "name": "email_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_account_login": {
+          "name": "github_account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_account_type": {
+          "name": "github_account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_blocked_at": {
+          "name": "first_blocked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_blocked_at": {
+          "name": "last_blocked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifted_by_admin_user_id": {
+          "name": "lifted_by_admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifted_by_admin_email": {
+          "name": "lifted_by_admin_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "setup_qualification_blocks_deployment_user_reason_unique": {
+          "name": "setup_qualification_blocks_deployment_user_reason_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setup_qualification_blocks_deployment_status_idx": {
+          "name": "setup_qualification_blocks_deployment_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setup_qualification_blocks_user_status_idx": {
+          "name": "setup_qualification_blocks_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "setup_qualification_blocks_user_id_users_id_fk": {
+          "name": "setup_qualification_blocks_user_id_users_id_fk",
+          "tableFrom": "setup_qualification_blocks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_auth_tokens": {
+      "name": "slack_auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_team_id": {
+          "name": "slack_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_ts": {
+          "name": "thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_text": {
+          "name": "original_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_auth_tokens_expires_at_idx": {
+          "name": "slack_auth_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_auth_tokens_token_unique": {
+          "name": "slack_auth_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_conversation_messages": {
+      "name": "slack_conversation_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_team_id": {
+          "name": "slack_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_slack_user_id": {
+          "name": "subject_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_user_id": {
+          "name": "sender_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_slack_user_id": {
+          "name": "sender_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_kind": {
+          "name": "conversation_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_ts": {
+          "name": "thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_ts": {
+          "name": "message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_at": {
+          "name": "message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_kind": {
+          "name": "author_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_quick_answer_id": {
+          "name": "slack_quick_answer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_conversation_messages_deployment_user_message_at_idx": {
+          "name": "slack_conversation_messages_deployment_user_message_at_idx",
+          "columns": [
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_conversation_messages_deployment_user_thread_idx": {
+          "name": "slack_conversation_messages_deployment_user_thread_idx",
+          "columns": [
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_conversation_messages_task_id_idx": {
+          "name": "slack_conversation_messages_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_conversation_messages_run_id_idx": {
+          "name": "slack_conversation_messages_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_conversation_messages_team_channel_message_unique": {
+          "name": "slack_conversation_messages_team_channel_message_unique",
+          "columns": [
+            {
+              "expression": "slack_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_conversation_messages_subject_user_id_users_id_fk": {
+          "name": "slack_conversation_messages_subject_user_id_users_id_fk",
+          "tableFrom": "slack_conversation_messages",
+          "tableTo": "users",
+          "columnsFrom": ["subject_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_conversation_messages_sender_user_id_users_id_fk": {
+          "name": "slack_conversation_messages_sender_user_id_users_id_fk",
+          "tableFrom": "slack_conversation_messages",
+          "tableTo": "users",
+          "columnsFrom": ["sender_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "slack_conversation_messages_task_id_tasks_id_fk": {
+          "name": "slack_conversation_messages_task_id_tasks_id_fk",
+          "tableFrom": "slack_conversation_messages",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "slack_conversation_messages_run_id_task_runs_id_fk": {
+          "name": "slack_conversation_messages_run_id_task_runs_id_fk",
+          "tableFrom": "slack_conversation_messages",
+          "tableTo": "task_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "slack_conversation_messages_slack_quick_answer_id_slack_quick_answers_id_fk": {
+          "name": "slack_conversation_messages_slack_quick_answer_id_slack_quick_answers_id_fk",
+          "tableFrom": "slack_conversation_messages",
+          "tableTo": "slack_quick_answers",
+          "columnsFrom": ["slack_quick_answer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_installation_channels": {
+      "name": "slack_installation_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_installation_channels_installation_id_idx": {
+          "name": "slack_installation_channels_installation_id_idx",
+          "columns": [
+            {
+              "expression": "slack_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_installation_channels_slack_installation_id_slack_installations_id_fk": {
+          "name": "slack_installation_channels_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "slack_installation_channels",
+          "tableTo": "slack_installations",
+          "columnsFrom": ["slack_installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_installation_channels_unique": {
+          "name": "slack_installation_channels_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slack_installation_id", "channel_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_installations": {
+      "name": "slack_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_domain": {
+          "name": "team_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enterprise_id": {
+          "name": "enterprise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enterprise_name": {
+          "name": "enterprise_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_name": {
+          "name": "bot_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_name": {
+          "name": "app_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_access_token": {
+          "name": "bot_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_access_token": {
+          "name": "user_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bot'"
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_count_snapshot": {
+          "name": "member_count_snapshot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_count_snapshot_at": {
+          "name": "member_count_snapshot_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_installations_bot_user_id_idx": {
+          "name": "slack_installations_bot_user_id_idx",
+          "columns": [
+            {
+              "expression": "bot_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_active_idx": {
+          "name": "slack_installations_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_installations_installed_by_user_id_users_id_fk": {
+          "name": "slack_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "users",
+          "columnsFrom": ["installed_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_installations_team_id_unique": {
+          "name": "slack_installations_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["team_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_quick_answers": {
+      "name": "slack_quick_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel": {
+          "name": "slack_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_quick_answers_deployment_channel_thread_unique": {
+          "name": "slack_quick_answers_deployment_channel_thread_unique",
+          "columns": [
+            {
+              "expression": "slack_channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_quick_answers_deployment_user_idx": {
+          "name": "slack_quick_answers_deployment_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_quick_answers_user_id_users_id_fk": {
+          "name": "slack_quick_answers_user_id_users_id_fk",
+          "tableFrom": "slack_quick_answers",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_user_mappings": {
+      "name": "slack_user_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_team_id": {
+          "name": "slack_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_user_mappings_user_id_idx": {
+          "name": "slack_user_mappings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_user_mappings_user_id_users_id_fk": {
+          "name": "slack_user_mappings_user_id_users_id_fk",
+          "tableFrom": "slack_user_mappings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_user_mappings_unique": {
+          "name": "slack_user_mappings_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slack_user_id", "slack_team_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_artifacts": {
+      "name": "task_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_type": {
+          "name": "artifact_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded": {
+          "name": "uploaded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_artifacts_task_id_idx": {
+          "name": "task_artifacts_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_artifacts_run_id_idx": {
+          "name": "task_artifacts_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_artifacts_uploaded_idx": {
+          "name": "task_artifacts_uploaded_idx",
+          "columns": [
+            {
+              "expression": "uploaded",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_artifacts_created_at_idx": {
+          "name": "task_artifacts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_artifacts_path_idx": {
+          "name": "task_artifacts_path_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_artifacts_task_id_tasks_id_fk": {
+          "name": "task_artifacts_task_id_tasks_id_fk",
+          "tableFrom": "task_artifacts",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_artifacts_run_id_task_runs_id_fk": {
+          "name": "task_artifacts_run_id_task_runs_id_fk",
+          "tableFrom": "task_artifacts",
+          "tableTo": "task_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_artifacts_task_id_path_version_unique": {
+          "name": "task_artifacts_task_id_path_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["task_id", "path", "version"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_inference_usage_events": {
+      "name": "task_inference_usage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'opencode'"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness_session_id": {
+          "name": "harness_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "context_tokens": {
+          "name": "context_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_micro_usd": {
+          "name": "cost_micro_usd",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_created_at": {
+          "name": "message_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_completed_at": {
+          "name": "message_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_inference_usage_events_session_message_unique": {
+          "name": "task_inference_usage_events_session_message_unique",
+          "columns": [
+            {
+              "expression": "harness_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_inference_usage_events_task_id_idx": {
+          "name": "task_inference_usage_events_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_inference_usage_events_run_id_idx": {
+          "name": "task_inference_usage_events_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_inference_usage_events_created_at_idx": {
+          "name": "task_inference_usage_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_inference_usage_events_task_id_tasks_id_fk": {
+          "name": "task_inference_usage_events_task_id_tasks_id_fk",
+          "tableFrom": "task_inference_usage_events",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_inference_usage_events_run_id_task_runs_id_fk": {
+          "name": "task_inference_usage_events_run_id_task_runs_id_fk",
+          "tableFrom": "task_inference_usage_events",
+          "tableTo": "task_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_messages": {
+      "name": "task_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ts": {
+          "name": "ts",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_messages_task_id_ts_idx": {
+          "name": "task_messages_task_id_ts_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_messages_run_id_idx": {
+          "name": "task_messages_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_messages_created_at_idx": {
+          "name": "task_messages_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_messages_run_id_task_runs_id_fk": {
+          "name": "task_messages_run_id_task_runs_id_fk",
+          "tableFrom": "task_messages",
+          "tableTo": "task_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_messages_task_id_tasks_id_fk": {
+          "name": "task_messages_task_id_tasks_id_fk",
+          "tableFrom": "task_messages",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_messages_user_id_users_id_fk": {
+          "name": "task_messages_user_id_users_id_fk",
+          "tableFrom": "task_messages",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_messages_task_protocol_ts_event_type_unique": {
+          "name": "task_messages_task_protocol_ts_event_type_unique",
+          "nullsNotDistinct": false,
+          "columns": ["task_id", "protocol", "ts", "event_type"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_pins": {
+      "name": "task_pins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_pins_deployment_user_task_unique": {
+          "name": "task_pins_deployment_user_task_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_pins_deployment_user_updated_at_idx": {
+          "name": "task_pins_deployment_user_updated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_pins_task_id_idx": {
+          "name": "task_pins_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_pins_task_id_tasks_id_fk": {
+          "name": "task_pins_task_id_tasks_id_fk",
+          "tableFrom": "task_pins",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_pins_user_id_users_id_fk": {
+          "name": "task_pins_user_id_users_id_fk",
+          "tableFrom": "task_pins",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_platform_issue_reports": {
+      "name": "task_platform_issue_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_message_id": {
+          "name": "task_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report": {
+          "name": "report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_posted_at": {
+          "name": "slack_posted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_platform_issue_reports_created_at_idx": {
+          "name": "task_platform_issue_reports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_platform_issue_reports_task_id_created_at_idx": {
+          "name": "task_platform_issue_reports_task_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_platform_issue_reports_run_id_created_at_idx": {
+          "name": "task_platform_issue_reports_run_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_platform_issue_reports_task_message_id_unique": {
+          "name": "task_platform_issue_reports_task_message_id_unique",
+          "columns": [
+            {
+              "expression": "task_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_platform_issue_reports_task_id_tasks_id_fk": {
+          "name": "task_platform_issue_reports_task_id_tasks_id_fk",
+          "tableFrom": "task_platform_issue_reports",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_platform_issue_reports_run_id_task_runs_id_fk": {
+          "name": "task_platform_issue_reports_run_id_task_runs_id_fk",
+          "tableFrom": "task_platform_issue_reports",
+          "tableTo": "task_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_platform_issue_reports_task_message_id_task_messages_id_fk": {
+          "name": "task_platform_issue_reports_task_message_id_task_messages_id_fk",
+          "tableFrom": "task_platform_issue_reports",
+          "tableTo": "task_messages",
+          "columnsFrom": ["task_message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_pull_requests": {
+      "name": "task_pull_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_control_provider": {
+          "name": "source_control_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_title": {
+          "name": "pr_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_sha": {
+          "name": "pr_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_base_ref": {
+          "name": "pr_base_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_base_sha": {
+          "name": "pr_base_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_reaction_id": {
+          "name": "github_reaction_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_check_run_id": {
+          "name": "github_check_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_review_comment_id": {
+          "name": "github_review_comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_pull_requests_task_id_idx": {
+          "name": "task_pull_requests_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_pull_requests_repository_id_idx": {
+          "name": "task_pull_requests_repository_id_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_pull_requests_provider_repository_pr_number_idx": {
+          "name": "task_pull_requests_provider_repository_pr_number_idx",
+          "columns": [
+            {
+              "expression": "source_control_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_pull_requests_task_id_tasks_id_fk": {
+          "name": "task_pull_requests_task_id_tasks_id_fk",
+          "tableFrom": "task_pull_requests",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_pull_requests_repository_id_repositories_id_fk": {
+          "name": "task_pull_requests_repository_id_repositories_id_fk",
+          "tableFrom": "task_pull_requests",
+          "tableTo": "repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_pull_requests_task_pr_unique": {
+          "name": "task_pull_requests_task_pr_unique",
+          "nullsNotDistinct": false,
+          "columns": ["task_id", "pr_url"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "task_pull_requests_source_control_provider_check": {
+          "name": "task_pull_requests_source_control_provider_check",
+          "value": "\"task_pull_requests\".\"source_control_provider\" in ('github', 'gitlab', 'gitea', 'ado')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.task_run_events": {
+      "name": "task_run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_run_events_run_id_created_at_idx": {
+          "name": "task_run_events_run_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_run_events_task_id_created_at_idx": {
+          "name": "task_run_events_task_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_run_events_created_at_idx": {
+          "name": "task_run_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_run_events_source_created_at_idx": {
+          "name": "task_run_events_source_created_at_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_run_events_run_id_task_runs_id_fk": {
+          "name": "task_run_events_run_id_task_runs_id_fk",
+          "tableFrom": "task_run_events",
+          "tableTo": "task_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_run_events_task_id_tasks_id_fk": {
+          "name": "task_run_events_task_id_tasks_id_fk",
+          "tableFrom": "task_run_events",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_runs": {
+      "name": "task_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "task_runs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fresh'"
+        },
+        "source_run_id": {
+          "name": "source_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acting_user_id": {
+          "name": "acting_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_kind": {
+          "name": "payload_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'opencode-server'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "queue_scope": {
+          "name": "queue_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_phase": {
+          "name": "task_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log": {
+          "name": "log",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifacts": {
+          "name": "artifacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_cmd_id": {
+          "name": "sandbox_cmd_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_domain": {
+          "name": "machine_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_domains": {
+          "name": "machine_domains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initial_paths": {
+          "name": "initial_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_port_name": {
+          "name": "primary_port_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_server_url": {
+          "name": "sandbox_server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_ports": {
+          "name": "proxy_ports",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worker_release_tag": {
+          "name": "worker_release_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worker_version": {
+          "name": "worker_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worker_commit": {
+          "name": "worker_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configured_vcpus": {
+          "name": "configured_vcpus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configured_cpu_cores": {
+          "name": "configured_cpu_cores",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configured_memory_mib": {
+          "name": "configured_memory_mib",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_requested_at": {
+          "name": "snapshot_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_created_at": {
+          "name": "snapshot_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_failed_at": {
+          "name": "snapshot_failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keepalive_ms": {
+          "name": "keepalive_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sleep_at": {
+          "name": "sleep_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sleep_requested_at": {
+          "name": "sleep_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worker_heartbeat_at": {
+          "name": "worker_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_snapshot_id": {
+          "name": "source_snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_bypass_value": {
+          "name": "auth_bypass_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_bypass_header_name": {
+          "name": "auth_bypass_header_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dequeued_at": {
+          "name": "dequeued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provision_started_at": {
+          "name": "provision_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provision_ready_at": {
+          "name": "provision_ready_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_completed_at": {
+          "name": "setup_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness_started_at": {
+          "name": "harness_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_task_started_at": {
+          "name": "runtime_task_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_assistant_output_at": {
+          "name": "first_assistant_output_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "launch_mode": {
+          "name": "launch_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "task_runs_task_id_idx": {
+          "name": "task_runs_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_queue_scope_idx": {
+          "name": "task_runs_queue_scope_idx",
+          "columns": [
+            {
+              "expression": "queue_scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_acting_user_id_idx": {
+          "name": "task_runs_acting_user_id_idx",
+          "columns": [
+            {
+              "expression": "acting_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_snapshot_id_idx": {
+          "name": "task_runs_snapshot_id_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_sleep_at_idx": {
+          "name": "task_runs_sleep_at_idx",
+          "columns": [
+            {
+              "expression": "sleep_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_worker_heartbeat_at_idx": {
+          "name": "task_runs_worker_heartbeat_at_idx",
+          "columns": [
+            {
+              "expression": "worker_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_sleep_check_due_idx": {
+          "name": "task_runs_sleep_check_due_idx",
+          "columns": [
+            {
+              "expression": "sleep_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"task_runs\".\"status\" IN ('running', 'idle') AND \"task_runs\".\"machine_id\" IS NOT NULL AND \"task_runs\".\"sleep_at\" IS NOT NULL AND \"task_runs\".\"sleep_requested_at\" IS NULL AND \"task_runs\".\"snapshot_id\" IS NULL AND \"task_runs\".\"snapshot_requested_at\" IS NULL AND \"task_runs\".\"vendor\" IN ('modal', 'daytona', 'e2b')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_sleep_check_stale_worker_idx": {
+          "name": "task_runs_sleep_check_stale_worker_idx",
+          "columns": [
+            {
+              "expression": "worker_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"task_runs\".\"status\" IN ('running', 'idle') AND \"task_runs\".\"machine_id\" IS NOT NULL AND \"task_runs\".\"worker_heartbeat_at\" IS NOT NULL AND \"task_runs\".\"sleep_requested_at\" IS NULL AND \"task_runs\".\"snapshot_id\" IS NULL AND \"task_runs\".\"snapshot_requested_at\" IS NULL AND \"task_runs\".\"vendor\" IN ('modal', 'daytona', 'e2b')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_sleep_check_active_idx": {
+          "name": "task_runs_sleep_check_active_idx",
+          "columns": [
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"task_runs\".\"status\" IN ('running', 'idle') AND \"task_runs\".\"machine_id\" IS NOT NULL AND \"task_runs\".\"sleep_requested_at\" IS NULL AND \"task_runs\".\"snapshot_id\" IS NULL AND \"task_runs\".\"snapshot_requested_at\" IS NULL AND \"task_runs\".\"vendor\" IN ('modal', 'daytona', 'e2b')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_source_snapshot_id_idx": {
+          "name": "task_runs_source_snapshot_id_idx",
+          "columns": [
+            {
+              "expression": "source_snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_source_run_id_idx": {
+          "name": "task_runs_source_run_id_idx",
+          "columns": [
+            {
+              "expression": "source_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_first_assistant_output_at_idx": {
+          "name": "task_runs_first_assistant_output_at_idx",
+          "columns": [
+            {
+              "expression": "first_assistant_output_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_runs_task_id_tasks_id_fk": {
+          "name": "task_runs_task_id_tasks_id_fk",
+          "tableFrom": "task_runs",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_runs_source_run_id_task_runs_id_fk": {
+          "name": "task_runs_source_run_id_task_runs_id_fk",
+          "tableFrom": "task_runs",
+          "tableTo": "task_runs",
+          "columnsFrom": ["source_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "task_runs_acting_user_id_users_id_fk": {
+          "name": "task_runs_acting_user_id_users_id_fk",
+          "tableFrom": "task_runs",
+          "tableTo": "users",
+          "columnsFrom": ["acting_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "task_runs_kind_check": {
+          "name": "task_runs_kind_check",
+          "value": "\"task_runs\".\"kind\" in ('fresh', 'resume')"
+        },
+        "task_runs_harness_check": {
+          "name": "task_runs_harness_check",
+          "value": "\"task_runs\".\"harness\" in ('opencode-server')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.task_slack_reply_details": {
+      "name": "task_slack_reply_details",
+      "schema": "",
+      "columns": {
+        "detail_id": {
+          "name": "detail_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings": {
+          "name": "findings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_slack_reply_details_task_id_idx": {
+          "name": "task_slack_reply_details_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_slack_reply_details_deployment_task_detail_unique": {
+          "name": "task_slack_reply_details_deployment_task_detail_unique",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_slack_reply_details_task_id_tasks_id_fk": {
+          "name": "task_slack_reply_details_task_id_tasks_id_fk",
+          "tableFrom": "task_slack_reply_details",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_start_parallel_counts": {
+      "name": "task_start_parallel_counts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_kind": {
+          "name": "payload_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parallel_count": {
+          "name": "parallel_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_window_seconds": {
+          "name": "activity_window_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_start_parallel_counts_run_id_unique": {
+          "name": "task_start_parallel_counts_run_id_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_start_parallel_counts_task_id_started_at_idx": {
+          "name": "task_start_parallel_counts_task_id_started_at_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_start_parallel_counts_started_at_idx": {
+          "name": "task_start_parallel_counts_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_start_parallel_counts_task_id_tasks_id_fk": {
+          "name": "task_start_parallel_counts_task_id_tasks_id_fk",
+          "tableFrom": "task_start_parallel_counts",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_start_parallel_counts_run_id_task_runs_id_fk": {
+          "name": "task_start_parallel_counts_run_id_task_runs_id_fk",
+          "tableFrom": "task_start_parallel_counts",
+          "tableTo": "task_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'visible'"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "initiator_kind": {
+          "name": "initiator_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiator_user_id": {
+          "name": "initiator_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiator_automation": {
+          "name": "initiator_automation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_external_id": {
+          "name": "actor_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_display_name": {
+          "name": "actor_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_kind": {
+          "name": "commit_author_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_user_id": {
+          "name": "commit_author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_login": {
+          "name": "commit_author_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_external_id": {
+          "name": "commit_author_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_assignee_login": {
+          "name": "pr_assignee_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_session_id": {
+          "name": "linear_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_issue_id": {
+          "name": "linear_issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_organization_id": {
+          "name": "linear_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'opencode-server'"
+        },
+        "harness_session_id": {
+          "name": "harness_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_edited_by_user_at": {
+          "name": "title_edited_by_user_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "llm_title_checkpoint": {
+          "name": "llm_title_checkpoint",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_prompt": {
+          "name": "draft_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_work_kind": {
+          "name": "requested_work_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "requested_work_kind_source": {
+          "name": "requested_work_kind_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system_default'"
+        },
+        "requested_work_kind_confidence": {
+          "name": "requested_work_kind_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness_instructions": {
+          "name": "harness_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compute_duration_ms": {
+          "name": "compute_duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_at": {
+          "name": "activity_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_url": {
+          "name": "repository_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_name": {
+          "name": "repository_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasks_initiator_user_id_idx": {
+          "name": "tasks_initiator_user_id_idx",
+          "columns": [
+            {
+              "expression": "initiator_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_initiator_automation_idx": {
+          "name": "tasks_initiator_automation_idx",
+          "columns": [
+            {
+              "expression": "initiator_automation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_workflow_idx": {
+          "name": "tasks_workflow_idx",
+          "columns": [
+            {
+              "expression": "workflow",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_visibility_activity_at_idx": {
+          "name": "tasks_visibility_activity_at_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_harness_session_id_idx": {
+          "name": "tasks_harness_session_id_idx",
+          "columns": [
+            {
+              "expression": "harness_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_timestamp_idx": {
+          "name": "tasks_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_deployment_activity_at_idx": {
+          "name": "tasks_deployment_activity_at_idx",
+          "columns": [
+            {
+              "expression": "activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_created_at_idx": {
+          "name": "tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_initiator_user_id_users_id_fk": {
+          "name": "tasks_initiator_user_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": ["initiator_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_initiator_automation_automations_key_fk": {
+          "name": "tasks_initiator_automation_automations_key_fk",
+          "tableFrom": "tasks",
+          "tableTo": "automations",
+          "columnsFrom": ["initiator_automation"],
+          "columnsTo": ["key"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_commit_author_user_id_users_id_fk": {
+          "name": "tasks_commit_author_user_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": ["commit_author_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tasks_initiator_shape_check": {
+          "name": "tasks_initiator_shape_check",
+          "value": "(\"tasks\".\"initiator_kind\" = 'user' AND \"tasks\".\"initiator_automation\" IS NULL AND (\"tasks\".\"initiator_user_id\" IS NOT NULL OR \"tasks\".\"actor_external_id\" IS NOT NULL)) OR (\"tasks\".\"initiator_kind\" = 'automation' AND \"tasks\".\"initiator_automation\" IS NOT NULL AND \"tasks\".\"initiator_user_id\" IS NULL)"
+        },
+        "tasks_workflow_check": {
+          "name": "tasks_workflow_check",
+          "value": "\"tasks\".\"workflow\" in ('standard', 'pr_review', 'pr_conflict_resolve', 'scan', 'mcp_recommendations', 'setup_onboarding', 'env_snapshot', 'eval')"
+        },
+        "tasks_surface_check": {
+          "name": "tasks_surface_check",
+          "value": "\"tasks\".\"surface\" in ('web', 'api', 'slack', 'teams', 'telegram', 'linear', 'github', 'gitlab', 'gitea', 'ado', 'system')"
+        },
+        "tasks_trigger_check": {
+          "name": "tasks_trigger_check",
+          "value": "\"tasks\".\"trigger\" in ('message', 'webhook', 'schedule', 'manual')"
+        },
+        "tasks_visibility_check": {
+          "name": "tasks_visibility_check",
+          "value": "\"tasks\".\"visibility\" in ('visible', 'hidden')"
+        },
+        "tasks_state_check": {
+          "name": "tasks_state_check",
+          "value": "\"tasks\".\"state\" in ('active', 'completed', 'failed', 'canceled')"
+        },
+        "tasks_harness_check": {
+          "name": "tasks_harness_check",
+          "value": "\"tasks\".\"harness\" in ('opencode-server')"
+        },
+        "tasks_requested_work_kind_check": {
+          "name": "tasks_requested_work_kind_check",
+          "value": "\"tasks\".\"requested_work_kind\" in ('question', 'plan', 'implement', 'unknown')"
+        },
+        "tasks_requested_work_kind_source_check": {
+          "name": "tasks_requested_work_kind_source_check",
+          "value": "\"tasks\".\"requested_work_kind_source\" in ('explicit_bootstrap', 'task_tool', 'llm_classifier', 'inherited', 'system_default')"
+        },
+        "tasks_commit_author_kind_check": {
+          "name": "tasks_commit_author_kind_check",
+          "value": "\"tasks\".\"commit_author_kind\" IS NULL OR \"tasks\".\"commit_author_kind\" in ('roomote', 'user', 'external')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.teams_installations": {
+      "name": "teams_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_type": {
+          "name": "conversation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_app_id": {
+          "name": "bot_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_name": {
+          "name": "bot_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_url": {
+          "name": "service_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teams_installations_tenant_id_idx": {
+          "name": "teams_installations_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "teams_installations_team_id_idx": {
+          "name": "teams_installations_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "teams_installations_conversation_id_idx": {
+          "name": "teams_installations_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "teams_installations_active_idx": {
+          "name": "teams_installations_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_installations_installation_key_unique": {
+          "name": "teams_installations_installation_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["installation_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams_user_mappings": {
+      "name": "teams_user_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "teams_user_id": {
+          "name": "teams_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams_tenant_id": {
+          "name": "teams_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams_aad_object_id": {
+          "name": "teams_aad_object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teams_user_mappings_aad_object_idx": {
+          "name": "teams_user_mappings_aad_object_idx",
+          "columns": [
+            {
+              "expression": "teams_aad_object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "teams_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "teams_user_mappings_user_id_idx": {
+          "name": "teams_user_mappings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_user_mappings_user_id_users_id_fk": {
+          "name": "teams_user_mappings_user_id_users_id_fk",
+          "tableFrom": "teams_user_mappings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_user_mappings_unique": {
+          "name": "teams_user_mappings_unique",
+          "nullsNotDistinct": false,
+          "columns": ["teams_user_id", "teams_tenant_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_mappings": {
+      "name": "telegram_user_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_username": {
+          "name": "telegram_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "telegram_user_mappings_user_id_idx": {
+          "name": "telegram_user_mappings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_user_mappings_user_id_users_id_fk": {
+          "name": "telegram_user_mappings_user_id_users_id_fk",
+          "tableFrom": "telegram_user_mappings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_user_mappings_unique": {
+          "name": "telegram_user_mappings_unique",
+          "nullsNotDistinct": false,
+          "columns": ["telegram_user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_messages": {
+      "name": "tracked_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_ts": {
+          "name": "message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_ts": {
+          "name": "thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "automation_key": {
+          "name": "automation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_text": {
+          "name": "summary_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tracked_messages_kind_dedupe_key_unique": {
+          "name": "tracked_messages_kind_dedupe_key_unique",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tracked_messages_work_item_id_idx": {
+          "name": "tracked_messages_work_item_id_idx",
+          "columns": [
+            {
+              "expression": "work_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tracked_messages_channel_message_idx": {
+          "name": "tracked_messages_channel_message_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tracked_messages_automation_channel_posted_idx": {
+          "name": "tracked_messages_automation_channel_posted_idx",
+          "columns": [
+            {
+              "expression": "automation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "posted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tracked_messages_work_item_id_work_items_id_fk": {
+          "name": "tracked_messages_work_item_id_work_items_id_fk",
+          "tableFrom": "tracked_messages",
+          "tableTo": "work_items",
+          "columnsFrom": ["work_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tracked_messages_automation_key_automations_key_fk": {
+          "name": "tracked_messages_automation_key_automations_key_fk",
+          "tableFrom": "tracked_messages",
+          "tableTo": "automations",
+          "columnsFrom": ["automation_key"],
+          "columnsTo": ["key"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tracked_messages_created_by_user_id_users_id_fk": {
+          "name": "tracked_messages_created_by_user_id_users_id_fk",
+          "tableFrom": "tracked_messages",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_api_keys": {
+      "name": "user_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_api_keys_user_id_idx": {
+          "name": "user_api_keys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_api_keys_user_deployment_provider_unique": {
+          "name": "user_api_keys_user_deployment_provider_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_api_keys_user_id_users_id_fk": {
+          "name": "user_api_keys_user_id_users_id_fk",
+          "tableFrom": "user_api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "analytics_id": {
+          "name": "analytics_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by_invite_id": {
+          "name": "invited_by_invite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_analytics_id_unique_idx": {
+          "name": "users_analytics_id_unique_idx",
+          "columns": [
+            {
+              "expression": "analytics_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "succeeded_at": {
+          "name": "succeeded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhooks_provider_delivery_id_unique": {
+          "name": "webhooks_provider_delivery_id_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhooks_event_idx": {
+          "name": "webhooks_event_idx",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhooks_created_at_idx": {
+          "name": "webhooks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "webhooks_status_exclusive": {
+          "name": "webhooks_status_exclusive",
+          "value": "(\n        (succeeded_at IS NOT NULL)::int +\n        (failed_at IS NOT NULL)::int\n      ) <= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.work_items": {
+      "name": "work_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_key": {
+          "name": "automation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_task_id": {
+          "name": "source_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_by_user_id": {
+          "name": "selected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_work_item_id": {
+          "name": "source_work_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brief": {
+          "name": "brief",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_prompt": {
+          "name": "execution_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "investigation_context": {
+          "name": "investigation_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_kind": {
+          "name": "action_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_ids": {
+          "name": "repository_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "target_repository_full_name": {
+          "name": "target_repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_environment_id": {
+          "name": "target_environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_readiness": {
+          "name": "workspace_readiness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readiness_message": {
+          "name": "readiness_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "launch_claimed_at": {
+          "name": "launch_claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "launched_task_id": {
+          "name": "launched_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "launched_at": {
+          "name": "launched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "launch_error": {
+          "name": "launch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "work_items_source_task_idx": {
+          "name": "work_items_source_task_idx",
+          "columns": [
+            {
+              "expression": "source_task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_items_kind_status_idx": {
+          "name": "work_items_kind_status_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_items_automation_key_fingerprint_idx": {
+          "name": "work_items_automation_key_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "automation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_items_fingerprint_idx": {
+          "name": "work_items_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_items_launched_task_id_idx": {
+          "name": "work_items_launched_task_id_idx",
+          "columns": [
+            {
+              "expression": "launched_task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_items_source_task_kind_sort_order_unique": {
+          "name": "work_items_source_task_kind_sort_order_unique",
+          "columns": [
+            {
+              "expression": "source_task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_items_automation_key_automations_key_fk": {
+          "name": "work_items_automation_key_automations_key_fk",
+          "tableFrom": "work_items",
+          "tableTo": "automations",
+          "columnsFrom": ["automation_key"],
+          "columnsTo": ["key"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "work_items_source_task_id_tasks_id_fk": {
+          "name": "work_items_source_task_id_tasks_id_fk",
+          "tableFrom": "work_items",
+          "tableTo": "tasks",
+          "columnsFrom": ["source_task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_items_selected_by_user_id_users_id_fk": {
+          "name": "work_items_selected_by_user_id_users_id_fk",
+          "tableFrom": "work_items",
+          "tableTo": "users",
+          "columnsFrom": ["selected_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "work_items_source_work_item_id_work_items_id_fk": {
+          "name": "work_items_source_work_item_id_work_items_id_fk",
+          "tableFrom": "work_items",
+          "tableTo": "work_items",
+          "columnsFrom": ["source_work_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "work_items_target_environment_id_environments_id_fk": {
+          "name": "work_items_target_environment_id_environments_id_fk",
+          "tableFrom": "work_items",
+          "tableTo": "environments",
+          "columnsFrom": ["target_environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "work_items_launched_task_id_tasks_id_fk": {
+          "name": "work_items_launched_task_id_tasks_id_fk",
+          "tableFrom": "work_items",
+          "tableTo": "tasks",
+          "columnsFrom": ["launched_task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1783712152138,
       "tag": "0005_powerful_doctor_octopus",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1783716055364,
+      "tag": "0006_schema_hardening",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/db",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/db/src/__tests__/schema-constraints.test.ts
+++ b/packages/db/src/__tests__/schema-constraints.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Real-database coverage for the schema-hardening constraints: the durable
+ * task/run classification CHECKs, the provider-scoped webhook delivery key,
+ * and the host-aware repository uniqueness. Runs against the real test
+ * database so Postgres parses every identifier and enforces the constraints
+ * (mocked-db tests cannot prove any of this).
+ *
+ * The classification loops iterate the exported vocabulary constants from
+ * @roomote/types, so adding a value to a constant without extending the
+ * matching CHECK constraint (schema.ts + migration) fails here.
+ */
+import { randomUUID } from 'node:crypto';
+
+import {
+  TASK_WORKFLOWS,
+  TASK_SURFACES,
+  TASK_TRIGGERS,
+  TASK_VISIBILITIES,
+  TASK_STATES,
+  COMMIT_AUTHOR_KINDS,
+  RUN_KINDS,
+  codingHarnesses,
+  requestedWorkKinds,
+  requestedWorkKindSources,
+  type CodingHarness,
+  type RunKind,
+} from '@roomote/types';
+
+import {
+  db,
+  inArray,
+  repositories,
+  repositoryFactory,
+  runFactory,
+  taskFactory,
+  tasks,
+  userFactory,
+  users,
+  webhooks,
+} from '../server';
+
+const createdTaskIds: string[] = [];
+const createdUserIds: string[] = [];
+const createdRepositoryIds: string[] = [];
+const createdWebhookIds: string[] = [];
+
+afterAll(async () => {
+  if (createdWebhookIds.length > 0) {
+    await db.delete(webhooks).where(inArray(webhooks.id, createdWebhookIds));
+  }
+
+  if (createdRepositoryIds.length > 0) {
+    await db
+      .delete(repositories)
+      .where(inArray(repositories.id, createdRepositoryIds));
+  }
+
+  if (createdTaskIds.length > 0) {
+    // task_runs cascade from tasks.
+    await db.delete(tasks).where(inArray(tasks.id, createdTaskIds));
+  }
+
+  if (createdUserIds.length > 0) {
+    await db.delete(users).where(inArray(users.id, createdUserIds));
+  }
+});
+
+async function createTask(overrides: Parameters<typeof taskFactory.create>[0]) {
+  const task = await taskFactory.create(overrides);
+  createdTaskIds.push(task.id);
+  return task;
+}
+
+/**
+ * Asserts the promise rejects with a Postgres violation of the named
+ * constraint. Drizzle wraps driver errors in DrizzleQueryError, so the
+ * constraint name lives on the cause chain rather than the top-level message.
+ */
+async function expectConstraintViolation(
+  promise: Promise<unknown>,
+  constraintName: string,
+): Promise<void> {
+  const error = await promise.then(
+    () => {
+      throw new Error(
+        `Expected a rejection violating "${constraintName}", but the query succeeded`,
+      );
+    },
+    (caught: unknown) => caught,
+  );
+
+  const details: string[] = [];
+  let current: unknown = error;
+
+  while (current instanceof Error) {
+    details.push(current.message);
+
+    const pgError = current as { constraint_name?: unknown };
+    if (typeof pgError.constraint_name === 'string') {
+      details.push(pgError.constraint_name);
+    }
+
+    current = current.cause;
+  }
+
+  expect(details.join('\n')).toContain(constraintName);
+}
+
+describe('tasks classification CHECK constraints', () => {
+  it('accepts every value of every classification vocabulary', async () => {
+    for (const workflow of TASK_WORKFLOWS) {
+      await createTask({ workflow });
+    }
+
+    for (const surface of TASK_SURFACES) {
+      await createTask({ surface });
+    }
+
+    for (const trigger of TASK_TRIGGERS) {
+      await createTask({ trigger });
+    }
+
+    for (const visibility of TASK_VISIBILITIES) {
+      await createTask({ visibility });
+    }
+
+    for (const state of TASK_STATES) {
+      await createTask({ state });
+    }
+
+    for (const harness of codingHarnesses) {
+      await createTask({ harness });
+    }
+
+    for (const requestedWorkKind of requestedWorkKinds) {
+      await createTask({ requestedWorkKind });
+    }
+
+    for (const requestedWorkKindSource of requestedWorkKindSources) {
+      await createTask({ requestedWorkKindSource });
+    }
+
+    for (const commitAuthorKind of COMMIT_AUTHOR_KINDS) {
+      await createTask({ commitAuthorKind });
+    }
+  });
+
+  it.each([
+    ['workflow', 'tasks_workflow_check'],
+    ['surface', 'tasks_surface_check'],
+    ['trigger', 'tasks_trigger_check'],
+    ['visibility', 'tasks_visibility_check'],
+    ['state', 'tasks_state_check'],
+    ['harness', 'tasks_harness_check'],
+    ['requestedWorkKind', 'tasks_requested_work_kind_check'],
+    ['requestedWorkKindSource', 'tasks_requested_work_kind_source_check'],
+    ['commitAuthorKind', 'tasks_commit_author_kind_check'],
+  ] as const)(
+    'rejects an unknown %s value via %s',
+    async (field, constraintName) => {
+      const overrides = {
+        [field]: 'not-a-real-vocabulary-value',
+      } as unknown as Parameters<typeof taskFactory.create>[0];
+
+      await expectConstraintViolation(createTask(overrides), constraintName);
+    },
+  );
+});
+
+describe('task_runs classification CHECK constraints', () => {
+  it('accepts every run kind and harness', async () => {
+    for (const kind of RUN_KINDS) {
+      const task = await createTask({});
+      await runFactory.create({ kind, taskId: task.id });
+    }
+
+    for (const harness of codingHarnesses) {
+      const task = await createTask({});
+      await runFactory.create({ harness, taskId: task.id });
+    }
+  });
+
+  it('rejects unknown run kinds and harnesses', async () => {
+    const task = await createTask({});
+
+    await expectConstraintViolation(
+      runFactory.create({ kind: 'bogus' as RunKind, taskId: task.id }),
+      'task_runs_kind_check',
+    );
+
+    await expectConstraintViolation(
+      runFactory.create({
+        harness: 'bogus' as CodingHarness,
+        taskId: task.id,
+      }),
+      'task_runs_harness_check',
+    );
+  });
+});
+
+describe('webhooks provider-scoped delivery ids', () => {
+  async function insertWebhook(provider: string, deliveryId: string) {
+    const [row] = await db
+      .insert(webhooks)
+      .values({ provider, deliveryId, event: 'test.event', payload: {} })
+      .returning({ id: webhooks.id });
+
+    if (row) {
+      createdWebhookIds.push(row.id);
+    }
+
+    return row;
+  }
+
+  it('allows the same delivery id on different providers', async () => {
+    const deliveryId = `delivery-${randomUUID()}`;
+
+    await expect(insertWebhook('github', deliveryId)).resolves.toBeDefined();
+    await expect(insertWebhook('linear', deliveryId)).resolves.toBeDefined();
+  });
+
+  it('rejects a duplicate (provider, delivery id) pair', async () => {
+    const deliveryId = `delivery-${randomUUID()}`;
+
+    await insertWebhook('github', deliveryId);
+    await expectConstraintViolation(
+      insertWebhook('github', deliveryId),
+      'webhooks_provider_delivery_id_unique',
+    );
+  });
+
+  it('dedupes via untargeted ON CONFLICT DO NOTHING like recordWebhook', async () => {
+    const deliveryId = `delivery-${randomUUID()}`;
+    await insertWebhook('gitlab', deliveryId);
+
+    const conflicted = await db
+      .insert(webhooks)
+      .values({
+        provider: 'gitlab',
+        deliveryId,
+        event: 'test.event',
+        payload: {},
+      })
+      .onConflictDoNothing()
+      .returning({ id: webhooks.id });
+
+    expect(conflicted).toEqual([]);
+  });
+});
+
+describe('repositories host-aware uniqueness', () => {
+  async function createGitLabRepository(overrides: {
+    linkedByUserId: string;
+    fullName: string;
+    externalRepoId: string;
+    host: string | null;
+  }) {
+    const repository = await repositoryFactory.create({
+      sourceControlProvider: 'gitlab',
+      ...overrides,
+    });
+    createdRepositoryIds.push(repository.id);
+    return repository;
+  }
+
+  it('scopes fullName and externalRepoId collisions to the host', async () => {
+    const user = await userFactory.create();
+    createdUserIds.push(user.id);
+
+    const fullName = `group/app-${randomUUID()}`;
+    const externalRepoId = `${Date.now()}`;
+
+    // Identical fullName AND externalRepoId on two self-managed hosts: legal.
+    await createGitLabRepository({
+      linkedByUserId: user.id,
+      fullName,
+      externalRepoId,
+      host: 'gitlab.alpha.example.com',
+    });
+    await createGitLabRepository({
+      linkedByUserId: user.id,
+      fullName,
+      externalRepoId,
+      host: 'gitlab.beta.example.com',
+    });
+
+    // Same host + fullName: still rejected.
+    await expectConstraintViolation(
+      createGitLabRepository({
+        linkedByUserId: user.id,
+        fullName,
+        externalRepoId: `${externalRepoId}-other`,
+        host: 'gitlab.alpha.example.com',
+      }),
+      'repositories_provider_host_full_name_unique',
+    );
+
+    // Same host + externalRepoId: still rejected.
+    await expectConstraintViolation(
+      createGitLabRepository({
+        linkedByUserId: user.id,
+        fullName: `${fullName}-other`,
+        externalRepoId,
+        host: 'gitlab.alpha.example.com',
+      }),
+      'repositories_provider_host_external_repo_unique',
+    );
+  });
+
+  it('keeps un-backfilled NULL-host rows colliding with each other', async () => {
+    const user = await userFactory.create();
+    createdUserIds.push(user.id);
+
+    const fullName = `group/legacy-${randomUUID()}`;
+
+    await createGitLabRepository({
+      linkedByUserId: user.id,
+      fullName,
+      externalRepoId: `${Date.now()}`,
+      host: null,
+    });
+
+    // NULL hosts are coalesced to '' inside the unique index, so a second
+    // NULL-host row with the same fullName must fail exactly like it did
+    // before host joined the key.
+    await expectConstraintViolation(
+      createGitLabRepository({
+        linkedByUserId: user.id,
+        fullName,
+        externalRepoId: `${Date.now()}-other`,
+        host: null,
+      }),
+      'repositories_provider_host_full_name_unique',
+    );
+  });
+});

--- a/packages/db/src/__tests__/webhook-retention.test.ts
+++ b/packages/db/src/__tests__/webhook-retention.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Real-database coverage for the webhook retention delete used by the
+ * WebhookCleanup scheduled job (apps/bullmq). Runs against the real test
+ * database so Postgres parses the batched delete-with-subquery.
+ */
+import { randomUUID } from 'node:crypto';
+
+import { db, deleteExpiredWebhooks, inArray, webhooks } from '../server';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const createdWebhookIds: string[] = [];
+
+async function insertWebhookRecordedAt(createdAt: Date): Promise<string> {
+  const [row] = await db
+    .insert(webhooks)
+    .values({
+      provider: 'github',
+      deliveryId: `retention-${randomUUID()}`,
+      event: 'test.event',
+      payload: {},
+      createdAt,
+    })
+    .returning({ id: webhooks.id });
+
+  if (!row) {
+    throw new Error('Failed to insert webhook fixture');
+  }
+
+  createdWebhookIds.push(row.id);
+  return row.id;
+}
+
+async function remainingIds(ids: string[]): Promise<string[]> {
+  const rows = await db
+    .select({ id: webhooks.id })
+    .from(webhooks)
+    .where(inArray(webhooks.id, ids));
+
+  return rows.map((row) => row.id);
+}
+
+afterEach(async () => {
+  if (createdWebhookIds.length > 0) {
+    await db.delete(webhooks).where(inArray(webhooks.id, createdWebhookIds));
+    createdWebhookIds.length = 0;
+  }
+});
+
+describe('deleteExpiredWebhooks', () => {
+  it('deletes rows older than the cutoff and keeps newer ones', async () => {
+    const now = Date.now();
+    const oldIds = await Promise.all([
+      insertWebhookRecordedAt(new Date(now - 40 * DAY_MS)),
+      insertWebhookRecordedAt(new Date(now - 31 * DAY_MS)),
+    ]);
+    const recentId = await insertWebhookRecordedAt(new Date(now - 1 * DAY_MS));
+
+    const deleted = await deleteExpiredWebhooks(db, {
+      olderThan: new Date(now - 30 * DAY_MS),
+    });
+
+    expect(deleted).toBeGreaterThanOrEqual(2);
+    expect(await remainingIds(oldIds)).toEqual([]);
+    expect(await remainingIds([recentId])).toEqual([recentId]);
+  });
+
+  it('drains everything past the cutoff across multiple batches', async () => {
+    const now = Date.now();
+    const oldIds = await Promise.all(
+      Array.from({ length: 5 }, (_, index) =>
+        insertWebhookRecordedAt(new Date(now - (31 + index) * DAY_MS)),
+      ),
+    );
+
+    const deleted = await deleteExpiredWebhooks(db, {
+      olderThan: new Date(now - 30 * DAY_MS),
+      batchSize: 2,
+    });
+
+    expect(deleted).toBeGreaterThanOrEqual(5);
+    expect(await remainingIds(oldIds)).toEqual([]);
+  });
+
+  it('rejects a non-positive batch size', async () => {
+    await expect(
+      deleteExpiredWebhooks(db, { olderThan: new Date(), batchSize: 0 }),
+    ).rejects.toThrow('batchSize must be a positive integer');
+  });
+});

--- a/packages/db/src/fixtures/factories/repository.factory.ts
+++ b/packages/db/src/fixtures/factories/repository.factory.ts
@@ -89,6 +89,9 @@ export const repositoryFactory = Factory.define<
         fullRepoName,
       ),
     htmlUrl: htmlUrl ?? `https://${sourceControlHost}/${fullRepoName}`,
+    // Production sync paths always stamp a non-null host; mirror that here so
+    // factory rows exercise the host-aware unique indexes like real rows.
+    host: sourceControlHost,
     private: false,
     defaultBranch: 'main',
     permissions: {},

--- a/packages/db/src/fixtures/factories/task.factory.ts
+++ b/packages/db/src/fixtures/factories/task.factory.ts
@@ -42,7 +42,7 @@ export const taskFactory = Factory.define<
     // did not supply a real user row.
     actorExternalId:
       actorExternalId ?? (initiatorUserId ? null : faker.string.uuid()),
-    provider: 'openai',
+    modelProvider: 'openai',
     model: 'gpt-4',
     timestamp: resolvedTimestamp,
     activityAt: activityAt ?? resolvedTimestamp,

--- a/packages/db/src/lib/__tests__/tasks.test.ts
+++ b/packages/db/src/lib/__tests__/tasks.test.ts
@@ -55,7 +55,7 @@ function mockDb(impl: (...args: unknown[]) => unknown) {
 
 const baseValues = {
   title: 'Test Task',
-  provider: 'anthropic',
+  modelProvider: 'anthropic',
   model: 'claude-sonnet-4-20250514',
   timestamp: 1_700_000_000,
   workflow: 'standard',

--- a/packages/db/src/lib/instance-report.ts
+++ b/packages/db/src/lib/instance-report.ts
@@ -170,13 +170,13 @@ export async function collectInstanceReportStats(
       .groupBy(tasks.harness),
     db
       .select({
-        provider: tasks.provider,
+        provider: tasks.modelProvider,
         model: tasks.model,
         total: count(),
       })
       .from(tasks)
       .where(gte(tasks.createdAt, since))
-      .groupBy(tasks.provider, tasks.model),
+      .groupBy(tasks.modelProvider, tasks.model),
     db
       .select({
         input: sum(taskInferenceUsageEvents.inputTokens),

--- a/packages/db/src/lib/webhook-retention.ts
+++ b/packages/db/src/lib/webhook-retention.ts
@@ -1,0 +1,56 @@
+import { inArray, lt } from 'drizzle-orm';
+
+import type { DatabaseOrTransaction } from '../db';
+import { webhooks } from '../schema';
+
+const DEFAULT_DELETE_BATCH_SIZE = 5_000;
+
+export interface DeleteExpiredWebhooksOptions {
+  /** Rows recorded strictly before this instant are deleted. */
+  olderThan: Date;
+  /**
+   * Rows deleted per DELETE statement. The first cleanup run on a
+   * long-lived deployment can face months of accumulated rows, so the
+   * delete is chunked to keep individual statements (and their locks)
+   * bounded.
+   */
+  batchSize?: number;
+}
+
+/**
+ * Deletes recorded webhook rows older than the cutoff, in batches, and
+ * returns the number of rows removed. Used by the WebhookCleanup scheduled
+ * job (apps/bullmq) with a cutoff derived from WEBHOOK_RETENTION_DAYS.
+ */
+export async function deleteExpiredWebhooks(
+  database: DatabaseOrTransaction,
+  {
+    olderThan,
+    batchSize = DEFAULT_DELETE_BATCH_SIZE,
+  }: DeleteExpiredWebhooksOptions,
+): Promise<number> {
+  if (!Number.isInteger(batchSize) || batchSize <= 0) {
+    throw new Error(`batchSize must be a positive integer, got ${batchSize}`);
+  }
+
+  let totalDeleted = 0;
+
+  while (true) {
+    const expiredBatch = database
+      .select({ id: webhooks.id })
+      .from(webhooks)
+      .where(lt(webhooks.createdAt, olderThan))
+      .limit(batchSize);
+
+    const deleted = await database
+      .delete(webhooks)
+      .where(inArray(webhooks.id, expiredBatch))
+      .returning({ id: webhooks.id });
+
+    totalDeleted += deleted.length;
+
+    if (deleted.length < batchSize) {
+      return totalDeleted;
+    }
+  }
+}

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -550,7 +550,10 @@ export const tasks = pgTable(
 
     harnessSessionId: text('harness_session_id'), // Assigned by Harness.
 
-    provider: text('provider').notNull(),
+    // Inference provider that served this task's LLM, paired with `model`.
+    // Renamed from the ambiguous `provider` (this deployment also has
+    // source-control, communication, and compute providers).
+    modelProvider: text('model_provider').notNull(),
     title: text('title').notNull(),
     titleEditedByUserAt: timestamp('title_edited_by_user_at'),
     llmTitleCheckpoint: integer('llm_title_checkpoint').notNull().default(0),
@@ -609,6 +612,44 @@ export const tasks = pgTable(
     check(
       'tasks_initiator_shape_check',
       sql`(${table.initiatorKind} = 'user' AND ${table.initiatorAutomation} IS NULL AND (${table.initiatorUserId} IS NOT NULL OR ${table.actorExternalId} IS NOT NULL)) OR (${table.initiatorKind} = 'automation' AND ${table.initiatorAutomation} IS NOT NULL AND ${table.initiatorUserId} IS NULL)`,
+    ),
+    // Durable classification vocabularies. Source of truth: the exported
+    // constants in @roomote/types (TASK_WORKFLOWS, TASK_SURFACES, ...);
+    // schema-constraints.test.ts asserts every constant value is accepted so
+    // the lists below cannot silently drift. Extending a vocabulary requires
+    // updating the constant, this check, and a migration.
+    check(
+      'tasks_workflow_check',
+      sql`${table.workflow} in ('standard', 'pr_review', 'pr_conflict_resolve', 'scan', 'mcp_recommendations', 'setup_onboarding', 'env_snapshot', 'eval')`,
+    ),
+    check(
+      'tasks_surface_check',
+      sql`${table.surface} in ('web', 'api', 'slack', 'teams', 'telegram', 'linear', 'github', 'gitlab', 'gitea', 'ado', 'system')`,
+    ),
+    check(
+      'tasks_trigger_check',
+      sql`${table.trigger} in ('message', 'webhook', 'schedule', 'manual')`,
+    ),
+    check(
+      'tasks_visibility_check',
+      sql`${table.visibility} in ('visible', 'hidden')`,
+    ),
+    check(
+      'tasks_state_check',
+      sql`${table.state} in ('active', 'completed', 'failed', 'canceled')`,
+    ),
+    check('tasks_harness_check', sql`${table.harness} in ('opencode-server')`),
+    check(
+      'tasks_requested_work_kind_check',
+      sql`${table.requestedWorkKind} in ('question', 'plan', 'implement', 'unknown')`,
+    ),
+    check(
+      'tasks_requested_work_kind_source_check',
+      sql`${table.requestedWorkKindSource} in ('explicit_bootstrap', 'task_tool', 'llm_classifier', 'inherited', 'system_default')`,
+    ),
+    check(
+      'tasks_commit_author_kind_check',
+      sql`${table.commitAuthorKind} IS NULL OR ${table.commitAuthorKind} in ('roomote', 'user', 'external')`,
     ),
   ],
 );
@@ -1004,6 +1045,13 @@ export const taskRuns = pgTable(
     index('task_runs_source_run_id_idx').on(table.sourceRunId),
     index('task_runs_first_assistant_output_at_idx').on(
       table.firstAssistantOutputAt,
+    ),
+    // Durable classification vocabularies; see the tasks table checks. Source
+    // of truth: RUN_KINDS / codingHarnesses in @roomote/types.
+    check('task_runs_kind_check', sql`${table.kind} in ('fresh', 'resume')`),
+    check(
+      'task_runs_harness_check',
+      sql`${table.harness} in ('opencode-server')`,
     ),
   ],
 );
@@ -1720,12 +1768,20 @@ export const repositories = pgTable(
     uniqueIndex('repositories_deployment_github_repo_unique').on(
       table.githubRepoId,
     ),
-    uniqueIndex('repositories_provider_external_repo_unique').on(
+    // Host participates in repository identity: self-managed GitLab/Gitea/ADO
+    // instances can legitimately reuse the same fullName or externalRepoId, so
+    // uniqueness is scoped to (provider, host, ...). NULL hosts (historical,
+    // un-backfilled rows) are coalesced to '' so they keep colliding with each
+    // other exactly like before host joined the key -- a plain column index
+    // would treat NULLs as distinct and silently weaken the constraint.
+    uniqueIndex('repositories_provider_host_external_repo_unique').on(
       table.sourceControlProvider,
+      sql`coalesce(${table.host}, '')`,
       table.externalRepoId,
     ),
-    uniqueIndex('repositories_provider_full_name_unique').on(
+    uniqueIndex('repositories_provider_host_full_name_unique').on(
       table.sourceControlProvider,
+      sql`coalesce(${table.host}, '')`,
       table.fullName,
     ),
     check(
@@ -2519,7 +2575,7 @@ export const webhooks = pgTable(
   'webhooks',
   {
     id: uuid('id').primaryKey().defaultRandom(),
-    deliveryId: text('delivery_id').notNull().unique(),
+    deliveryId: text('delivery_id').notNull(),
     provider: text('provider').notNull(),
     event: text('event').notNull(),
     payload: jsonb('payload').notNull(),
@@ -2529,7 +2585,16 @@ export const webhooks = pgTable(
     createdAt: timestamp('created_at').notNull().defaultNow(),
   },
   (table) => [
-    index('webhooks_provider_idx').on(table.provider),
+    // Delivery ids are only unique within a provider (GitHub GUIDs, Linear
+    // delivery ids, sha256-of-body fallbacks, ...), so dedupe per provider
+    // instead of globally. The recordWebhook helpers rely on this via an
+    // untargeted ON CONFLICT DO NOTHING.
+    uniqueIndex('webhooks_provider_delivery_id_unique').on(
+      table.provider,
+      table.deliveryId,
+    ),
+    // No separate provider index: the unique index above leads with provider
+    // and serves provider-only scans.
     index('webhooks_event_idx').on(table.event),
     index('webhooks_created_at_idx').on(table.createdAt),
     check(

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2353,7 +2353,7 @@ export type ManagerMcpSetupNotificationReason =
   | 'deployment_disabled'
   | 'deployment_auth_required';
 
-export type BackgroundAgentSuggestionType =
+export type SuggestionType =
   | 'setup_onboarding'
   | 'suggested_tasks'
   | 'sentry_triage'

--- a/packages/db/src/server.ts
+++ b/packages/db/src/server.ts
@@ -73,6 +73,7 @@ export * from './lib/repositories';
 export * from './lib/telemetry-ids';
 export * from './lib/instance-report';
 export * from './lib/invocation-identities';
+export * from './lib/webhook-retention';
 
 export {
   users,

--- a/packages/db/src/server.ts
+++ b/packages/db/src/server.ts
@@ -179,7 +179,7 @@ export {
 export * from './fixtures/factories/index';
 
 export type {
-  BackgroundAgentSuggestionType,
+  SuggestionType,
   ManagerMcpSetupNotificationReason,
   EnvironmentConfigVersionSource,
 } from './schema';

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/env",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -213,6 +213,9 @@ const serverSchema = {
   ROOMOTE_ALLOWED_EMAILS: z.string().optional(),
   PREVIEW_TOKEN_TTL_SECONDS: z.coerce.number().int().positive().default(3600),
   SLACK_API_TIMEOUT_MS: z.coerce.number().int().positive().default(10_000),
+  // How long recorded webhook payloads are kept before the WebhookCleanup
+  // scheduled job (apps/bullmq) deletes them.
+  WEBHOOK_RETENTION_DAYS: z.coerce.number().int().positive().default(30),
   API_EXTERNAL_REQUEST_TIMEOUT_MS: z.coerce
     .number()
     .int()

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/feature-flags",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/gitea/package.json
+++ b/packages/gitea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/gitea",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "exports": "./src/index.ts",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/github",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "exports": "./src/index.ts",

--- a/packages/gitlab/package.json
+++ b/packages/gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/gitlab",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "exports": "./src/index.ts",

--- a/packages/linear/package.json
+++ b/packages/linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/linear",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/linear/src/elicitation-fallback.ts
+++ b/packages/linear/src/elicitation-fallback.ts
@@ -234,10 +234,10 @@ export function parseSelection(
 }
 
 /**
- * Start the elicitation fallback flow for agent/workspace selection
+ * Start the elicitation fallback flow for workspace selection
  *
  * This is called when LLM routing is unavailable and we need to ask the user
- * to select a workspace for the default Generalist path.
+ * to select a workspace for the standard delegated-task path.
  */
 export async function startElicitationFallback({
   sessionId,
@@ -278,7 +278,7 @@ export async function startElicitationFallback({
 }
 
 /**
- * Start the workspace selection step for the delegated Generalist fallback path.
+ * Start the workspace selection step for the standard delegated-task fallback path.
  */
 async function startWorkspaceSelection({
   sessionId,

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/redis",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "exports": "./src/index.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/sdk",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/sdk/src/server/lib/task-runs/__tests__/task-title-refresh.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/task-title-refresh.test.ts
@@ -38,7 +38,7 @@ async function seedTaskWithPrompt({
 }) {
   await taskFactory.create({
     id: taskId,
-    provider: 'roomote',
+    modelProvider: 'roomote',
     model: 'test-model',
     title,
     llmTitleCheckpoint,

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/slack",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/slack/src/mcp-recommendations.ts
+++ b/packages/slack/src/mcp-recommendations.ts
@@ -6,13 +6,13 @@ import {
   trackedMessages,
   workItems,
 } from '@roomote/db/server';
-import type { BackgroundAgentSuggestionType } from '@roomote/db/server';
+import type { SuggestionType } from '@roomote/db/server';
 import type { McpRecommendation } from '@roomote/cloud-agents/server';
 import type { SlackBlock } from '@roomote/types';
 
 import { SlackNotifier } from './slack-notifier';
 
-export const SETUP_MCP_RECOMMENDATION_AGENT_TYPE: BackgroundAgentSuggestionType =
+export const SETUP_MCP_RECOMMENDATION_SUGGESTION_TYPE: SuggestionType =
   'setup_mcp_recommendation';
 export const SETUP_MCP_RECOMMENDATION_PARENT_TEXT =
   "I scanned your codebase and found some integrations that could make me more helpful. Here's what I'd recommend:";
@@ -400,7 +400,7 @@ export async function postSetupMcpRecommendationsToSlack(params: {
         createdByUserId: row.createdByUserId,
         summaryText: row.title,
         metadata: {
-          suggestionType: SETUP_MCP_RECOMMENDATION_AGENT_TYPE,
+          suggestionType: SETUP_MCP_RECOMMENDATION_SUGGESTION_TYPE,
           suggestionKey: buildTrackedRecommendationKey({
             sourceTaskId: row.sourceTaskId,
             recommendationId: row.recommendationId,

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/telemetry",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roomote/types",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "exports": "./src/index.ts",

--- a/scripts/release/__tests__/lib.test.mjs
+++ b/scripts/release/__tests__/lib.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -6,6 +7,7 @@ import { describe, it } from 'node:test'
 import {
   computeNextVersion,
   extractChangelogSection,
+  findVersionCommit,
   insertChangelogSection,
   parsePendingChangesets,
 } from '../lib.mjs'
@@ -103,5 +105,51 @@ This file tracks product releases for Roomote (single monorepo version). Automat
       '## 1.0.0\n\n- Boot\n',
     )
     assert.match(onlyTitle, /Intro only\.\n\n## 1\.0\.0/)
+  })
+
+  it('findVersionCommit returns the commit that introduced the tip version', () => {
+    const root = mkdtempSync(join(tmpdir(), 'roomote-version-commit-'))
+    const git = (...args) =>
+      execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim()
+    try {
+      git('init', '--quiet', '--initial-branch=develop')
+      git('config', 'user.name', 'Test')
+      git('config', 'user.email', 'test@example.com')
+
+      const commit = (message) => {
+        git('add', '-A')
+        git('commit', '--quiet', '-m', message)
+        return git('rev-parse', 'HEAD')
+      }
+      const setPkg = (fields) =>
+        writeFileSync(
+          join(root, 'package.json'),
+          JSON.stringify({ name: 'roomote', ...fields }, null, 2),
+        )
+
+      setPkg({ version: '0.0.1' })
+      commit('initial 0.0.1')
+
+      writeFileSync(join(root, 'other.txt'), 'unrelated\n')
+      commit('unrelated change')
+
+      setPkg({ version: '0.0.2' })
+      const bumpSha = commit('chore(release): version roomote 0.0.2')
+
+      setPkg({ version: '0.0.2', dependencies: { left: '1.0.0' } })
+      commit('dep change keeps version')
+
+      writeFileSync(join(root, 'other.txt'), 'rider feature\n')
+      commit('rider feature after the bump')
+
+      // The bump commit, not the tip or the later package.json touch.
+      assert.equal(findVersionCommit({ cwd: root, version: '0.0.2' }), bumpSha)
+      // A superseded version is no longer contiguous from the tip.
+      assert.equal(findVersionCommit({ cwd: root, version: '0.0.1' }), null)
+      // Unknown versions resolve to nothing.
+      assert.equal(findVersionCommit({ cwd: root, version: '9.9.9' }), null)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 })

--- a/scripts/release/find-version-commit.mjs
+++ b/scripts/release/find-version-commit.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * Print the commit SHA that introduced a product version (the Version PR
+ * merge commit). Used by the Release workflow to freeze the promote PR at
+ * the versioned commit instead of the moving develop tip.
+ *
+ * Usage: node scripts/release/find-version-commit.mjs <version> [ref]
+ * Prints the full SHA to stdout, or exits 1 when the version is not the
+ * contiguous tip version of the ref.
+ */
+
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { findVersionCommit } from './lib.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '../..');
+
+const version = process.argv[2];
+const ref = process.argv[3] || 'HEAD';
+
+if (!version) {
+  console.error(
+    'Usage: node scripts/release/find-version-commit.mjs <version> [ref]',
+  );
+  process.exit(1);
+}
+
+const sha = findVersionCommit({ cwd: repoRoot, version, ref });
+if (!sha) {
+  console.error(
+    `No commit introducing version ${version} found from ${ref}; is ${version} the current version on that ref?`,
+  );
+  process.exit(1);
+}
+process.stdout.write(`${sha}\n`);

--- a/scripts/release/lib.mjs
+++ b/scripts/release/lib.mjs
@@ -3,6 +3,7 @@
  * Root package name is `roomote`; workspace packages use `@roomote/*`.
  */
 
+import { execFileSync } from 'node:child_process';
 import { readdirSync, readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -174,4 +175,45 @@ export function extractChangelogSection(changelogMarkdown, version) {
     }
   }
   return lines.slice(start, end).join('\n').trim();
+}
+
+/**
+ * Find the commit that introduced the given product version on a ref.
+ *
+ * Walks commits that touched the root package.json from the tip of `ref`
+ * backwards, and returns the oldest contiguous commit whose version equals
+ * `version` — i.e. the Version PR merge commit that bumped to it. Returns
+ * null when the tip of `ref` is not on `version` (the version is stale) or
+ * the version never appears.
+ *
+ * Versions only change in commits that touch package.json, so the oldest
+ * contiguous match from the tip is exactly the commit that introduced it.
+ *
+ * @param {{ cwd: string, version: string, ref?: string }} options
+ * @returns {string | null} full commit SHA or null
+ */
+export function findVersionCommit({ cwd, version, ref = 'HEAD' }) {
+  const git = (args) =>
+    execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+  const shas = git(['rev-list', ref, '--', 'package.json'])
+    .split('\n')
+    .filter(Boolean);
+
+  let candidate = null;
+  for (const sha of shas) {
+    let commitVersion = null;
+    try {
+      commitVersion = JSON.parse(git(['show', `${sha}:package.json`])).version;
+    } catch {
+      break;
+    }
+    if (commitVersion !== version) break;
+    candidate = sha;
+  }
+  return candidate;
 }


### PR DESCRIPTION
## Promote v0.0.3

Frozen at `ddb6f567fcc1b0054f375683cd899937766c0be9` — the commit where `0.0.3` was versioned. Commits merged to `develop` after that point ship in the next release.

- Merge this PR with a **merge commit** (do not squash or rebase).
- If multiple promote PRs are open, merge them in version order (oldest first).
- Merging publishes a GitHub Release for `v0.0.3` and triggers the existing GHCR `v*` image publish (`latest` channel).
- The `release/v0.0.3` branch can be deleted after this PR merges.

### Changelog

## 0.0.3 (2026-07-11)

### Patch changes

- Fix the release image publish gate so the first production release can ship: resolve the upgrade baseline from the latest GitHub release safely instead of leaking a 404 error into the image tag, and skip upgrade validation when no previous published release exists (fresh-install validation still runs).
