### PR TITLE
[Fix] Mock setTrustedRunActingUser in Teams/Telegram handler tests

### DIFF
--- a/apps/api/src/handlers/teams/__tests__/index.test.ts
+++ b/apps/api/src/handlers/teams/__tests__/index.test.ts
@@ -25,6 +25,7 @@ const {
   queueCommunicationMessageMock,
   redisSetMock,
   routeTaskMock,
+  setTrustedRunActingUserMock,
   shouldRouteUnmentionedReplyMock,
   teamsInstallationsTable,
   teamsUserMappingsTable,
@@ -76,6 +77,7 @@ const {
   queueCommunicationMessageMock: vi.fn(),
   redisSetMock: vi.fn(),
   routeTaskMock: vi.fn(),
+  setTrustedRunActingUserMock: vi.fn(),
   shouldRouteUnmentionedReplyMock: vi.fn(),
   teamsInstallationsTable: {
     installationKey: 'installationKey',
@@ -106,6 +108,7 @@ vi.mock('@roomote/redis', () => ({
 
 vi.mock('@roomote/db/server', () => ({
   and: vi.fn((...conditions: unknown[]) => ({ and: conditions })),
+  setTrustedRunActingUser: setTrustedRunActingUserMock,
   resolveTeamsBotRuntimeCredentials: vi.fn(async () => ({
     botAppId: envMock.TEAMS_BOT_APP_ID?.trim() || null,
     botAppPassword: envMock.TEAMS_BOT_APP_PASSWORD?.trim() || null,
@@ -446,6 +449,10 @@ describe('Teams webhook handler', () => {
       channel: '19:conversation@thread.v2',
       threadTs: 'activity-root',
     });
+    expect(setTrustedRunActingUserMock).toHaveBeenCalledWith({
+      runId: 77,
+      userId: 'mapped-user-1',
+    });
   });
 
   it('queues untagged Teams thread replies for matching active task runs using the root thread id', async () => {
@@ -716,6 +723,10 @@ describe('Teams webhook handler', () => {
       ts: 'activity-2',
       channel: '19:conversation@thread.v2',
       threadTs: 'activity-root',
+    });
+    expect(setTrustedRunActingUserMock).toHaveBeenCalledWith({
+      runId: 77,
+      userId: 'microsoft-user-1',
     });
   });
 

--- a/apps/api/src/handlers/telegram/__tests__/index.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/index.test.ts
@@ -27,6 +27,7 @@ const {
   redisSetMock,
   routeTaskMock,
   setLatestInboundMessageIdMock,
+  setTrustedRunActingUserMock,
   stopTaskRunMock,
   updateMock,
   updateReturningMock,
@@ -64,6 +65,7 @@ const {
   redisSetMock: vi.fn(),
   routeTaskMock: vi.fn(),
   setLatestInboundMessageIdMock: vi.fn(),
+  setTrustedRunActingUserMock: vi.fn(),
   stopTaskRunMock: vi.fn(),
   updateMock: vi.fn(),
   updateReturningMock: vi.fn(),
@@ -86,6 +88,7 @@ vi.mock('@roomote/redis', () => ({
 
 vi.mock('@roomote/db/server', () => ({
   and: vi.fn((...conditions: unknown[]) => ({ and: conditions })),
+  setTrustedRunActingUser: setTrustedRunActingUserMock,
   authUsers: {
     id: 'authUserId',
   },
@@ -605,6 +608,10 @@ describe('Telegram webhook handler', () => {
       77,
       '456',
     );
+    expect(setTrustedRunActingUserMock).toHaveBeenCalledWith({
+      runId: 77,
+      userId: 'launch-owner-1',
+    });
   });
 
   it('starts new Telegram tasks as the linked sender', async () => {
@@ -1346,6 +1353,10 @@ describe('Telegram webhook handler', () => {
       55,
       expect.objectContaining({ userId: 'linked-user-9' }),
     );
+    expect(setTrustedRunActingUserMock).toHaveBeenCalledWith({
+      runId: 55,
+      userId: 'linked-user-9',
+    });
   });
 
   it('does not attribute a stale linked mapping that points at a removed user', async () => {


### PR DESCRIPTION
## Related issue

Internal test hygiene, no issue.

## Why this PR exists

- [x] I am a maintainer / this is internal Roomote work

## What changed

The Teams and Telegram `index.test.ts` suites mock `@roomote/db/server` but did not export `setTrustedRunActingUser`. Every active-run message test therefore hit a vitest missing-export error inside `syncActingUserForInboundMessage`, which the handler swallows by design as a "Non-fatal actingUserId sync failure" log line. Tests passed, but the actingUserId sync path was never exercised and the suite emitted 12 noisy error lines per run.

- Export a hoisted `setTrustedRunActingUserMock` (`vi.fn()`) from the `vi.mock('@roomote/db/server')` factories in both files
- Assert the mock is called with the expected `{ runId, userId }` in four active-run flows: the Teams queue and Microsoft-AAD-linking tests, and the Telegram queue and linked-sender-over-launch-owner attribution tests

The other seven test files that mock `@roomote/db/server` never reach this code path, so they were left unchanged.

## How it was tested

`pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/api exec vitest run src/handlers/teams src/handlers/telegram` — 160/160 tests pass across 14 files, with zero "Non-fatal actingUserId sync failure" / missing-export lines (previously 12).

## Checklist

- [x] The PR title follows the repo convention: `[Fix]`, `[Feat]`, `[Improve]`, `[Refactor]`, `[Docs]`, or `[Chore]` followed by a user-facing description
- [x] This PR is small and scoped to one change
- [x] `pnpm lint` and `pnpm check-types` pass locally
- [x] I added tests or included a clear manual validation note above
- [x] I removed secrets, tokens, private keys, and customer data from code, logs, and screenshots
- [ ] If this change should appear in the changelog, I ran `pnpm changeset` (test-only change, no changeset)