### PR TITLE
[Fix] OpenCode turns wedged by a stalled model stream never see follow-ups

### DIFF
--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server-stall-watchdogs.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server-stall-watchdogs.test.ts
@@ -1,0 +1,577 @@
+import {
+  ACP_ENVELOPE_EVENT_TYPES,
+  TaskEventName,
+  type AcpPersistedEnvelope,
+  type TaskEvent,
+} from '@roomote/types';
+
+import { TaskCommandName } from '../../harness';
+import type { OpenCodeServerClient } from '../opencode-server/client';
+import { OpenCodeServerHarness } from '../opencode-server/harness';
+import type {
+  OpenCodeGlobalEvent,
+  OpenCodeSessionMessage,
+} from '../opencode-server/types';
+
+const TEST_OPENCODE_MODEL = 'test-provider/main-model';
+const STEER_PICKUP_TIMEOUT_MS = 5_000;
+const TURN_STALL_TIMEOUT_MS = 60_000;
+const STEER_TEXT = 'Use this newer instruction instead.';
+
+class FakeOpenCodeServerClient {
+  private eventHandler:
+    | ((event: OpenCodeGlobalEvent) => void | Promise<void>)
+    | undefined;
+
+  health = vi.fn(async () => ({ healthy: true as const, version: 'test' }));
+  createSession = vi.fn(async () => ({ id: 'ses_1', title: 'test' }));
+  promptAsync = vi.fn(async (_options: unknown) => undefined);
+  messages = vi.fn(async () => [] as OpenCodeSessionMessage[]);
+  message = vi.fn<() => Promise<OpenCodeSessionMessage>>();
+  abort = vi.fn(async (_options: { sessionId: string }) => true);
+  streamEvents = vi.fn(
+    async (options: {
+      signal: AbortSignal;
+      onEvent: (event: OpenCodeGlobalEvent) => void | Promise<void>;
+    }) => {
+      this.eventHandler = options.onEvent;
+
+      await new Promise<void>((resolve) => {
+        if (options.signal.aborted) {
+          resolve();
+          return;
+        }
+
+        options.signal.addEventListener('abort', () => resolve(), {
+          once: true,
+        });
+      });
+    },
+  );
+
+  async emit(event: OpenCodeGlobalEvent): Promise<void> {
+    if (!this.eventHandler) {
+      throw new Error('OpenCode event stream is not subscribed.');
+    }
+
+    await this.eventHandler(event);
+  }
+}
+
+function createLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+function createHarness(client = new FakeOpenCodeServerClient()) {
+  const logger = createLogger();
+  const harness = new OpenCodeServerHarness({
+    client: client as unknown as OpenCodeServerClient,
+    workspacePath: '/tmp/workspace',
+    logger,
+    model: TEST_OPENCODE_MODEL,
+    eventStreamReadyTimeoutMs: 100,
+    steerPickupTimeoutMs: STEER_PICKUP_TIMEOUT_MS,
+    turnStallTimeoutMs: TURN_STALL_TIMEOUT_MS,
+  });
+
+  return { client, harness, logger };
+}
+
+async function connectHarness(
+  harness: OpenCodeServerHarness,
+  client: FakeOpenCodeServerClient,
+): Promise<void> {
+  const connectPromise = harness.connect();
+
+  await vi.waitFor(() => {
+    expect(client.streamEvents).toHaveBeenCalledTimes(1);
+  });
+  await client.emit({ type: 'server.connected' });
+  await connectPromise;
+}
+
+async function startTask(
+  client: FakeOpenCodeServerClient,
+  harness: OpenCodeServerHarness,
+): Promise<void> {
+  harness.sendCommand({
+    commandName: TaskCommandName.StartNewTask,
+    data: { text: 'Start work.', visibleInTranscript: true },
+  });
+  await vi.waitFor(() => {
+    expect(client.promptAsync).toHaveBeenCalledTimes(1);
+  });
+}
+
+async function injectSteer(
+  client: FakeOpenCodeServerClient,
+  harness: OpenCodeServerHarness,
+): Promise<void> {
+  harness.sendCommand({
+    commandName: TaskCommandName.SendMessage,
+    data: {
+      text: STEER_TEXT,
+      autoSteerWhenQueued: true,
+      visibleInTranscript: true,
+    },
+  });
+  await vi.waitFor(() => {
+    expect(client.promptAsync).toHaveBeenCalledTimes(2);
+  });
+  expect(client.abort).not.toHaveBeenCalled();
+}
+
+function assistantTextPartEvent(): OpenCodeGlobalEvent {
+  return {
+    type: 'message.part.updated',
+    properties: {
+      info: { id: 'msg_a1', role: 'assistant' },
+      part: {
+        id: 'prt_a1',
+        sessionID: 'ses_1',
+        messageID: 'msg_a1',
+        type: 'text',
+        text: 'Working on it.',
+      },
+    },
+  };
+}
+
+function mcpToolPart(status: string) {
+  return {
+    id: 'prt_mcp_1',
+    sessionID: 'ses_1',
+    messageID: 'msg_a1',
+    type: 'tool',
+    tool: 'mcp__browser__long_capture',
+    callID: 'call_mcp_1',
+    state: { status, input: {} },
+  };
+}
+
+function assistantMessageWithParts(
+  parts: Array<Record<string, unknown>>,
+): OpenCodeSessionMessage {
+  return {
+    info: {
+      id: 'msg_a1',
+      sessionID: 'ses_1',
+      role: 'assistant',
+      time: { created: 1 },
+    },
+    parts,
+  } as unknown as OpenCodeSessionMessage;
+}
+
+function suppressedAbortErrorEvent(): OpenCodeGlobalEvent {
+  return {
+    type: 'session.error',
+    properties: {
+      sessionID: 'ses_1',
+      error: { name: 'MessageAbortedError', data: { message: 'Aborted' } },
+    },
+  };
+}
+
+describe('OpenCode steer pickup watchdog', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('escalates a silently dropped native steer to abort-and-replay', async () => {
+    const { client, harness } = createHarness();
+    const taskEvents: TaskEvent[] = [];
+    const persistedEnvelopes: AcpPersistedEnvelope[] = [];
+    harness.subscribe((event) => taskEvents.push(event));
+    harness.subscribeRuntimePersistedEnvelope((envelope) =>
+      persistedEnvelopes.push(envelope),
+    );
+
+    try {
+      await connectHarness(harness, client);
+      vi.useFakeTimers();
+      await startTask(client, harness);
+      await injectSteer(client, harness);
+
+      // The injection succeeded, but the turn is wedged inside a stalled LLM
+      // stream: no events arrive at all, so OpenCode never reaches the loop
+      // step boundary that would read the injected prompt.
+      await vi.advanceTimersByTimeAsync(STEER_PICKUP_TIMEOUT_MS);
+
+      expect(client.abort).toHaveBeenCalledTimes(1);
+      expect(client.abort).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: 'ses_1' }),
+      );
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(3);
+      });
+      expect(client.promptAsync.mock.calls[2]?.[0]).toMatchObject({
+        sessionId: 'ses_1',
+        request: {
+          parts: [{ type: 'text', text: STEER_TEXT }],
+        },
+      });
+
+      // The steer's user prompt was already persisted visibly at injection
+      // time; the escalated replay must not add a duplicate visible entry.
+      const steerPrompts = persistedEnvelopes.filter(
+        (envelope) =>
+          envelope.eventType === ACP_ENVELOPE_EVENT_TYPES.UserPrompt &&
+          envelope.contentBlocks.some(
+            (block) => block.type === 'text' && block.text === STEER_TEXT,
+          ),
+      );
+      expect(steerPrompts).toHaveLength(2);
+      expect(
+        steerPrompts.filter(
+          (envelope) => envelope.visibleInTranscript !== false,
+        ),
+      ).toHaveLength(1);
+
+      // The abort is the harness's own doing: the MessageAbortedError it
+      // provokes must not become a terminal abort.
+      await client.emit(suppressedAbortErrorEvent());
+      expect(
+        taskEvents.some(
+          (event) => event.eventName === TaskEventName.TaskAborted,
+        ),
+      ).toBe(false);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it('does not escalate a steer once the turn shows progress', async () => {
+    const { client, harness } = createHarness();
+
+    try {
+      await connectHarness(harness, client);
+      vi.useFakeTimers();
+      await startTask(client, harness);
+      await injectSteer(client, harness);
+
+      // Turn progress after the injection: the loop is alive and will reach
+      // the injected prompt at its next step boundary on its own.
+      await client.emit(assistantTextPartEvent());
+
+      await vi.advanceTimersByTimeAsync(STEER_PICKUP_TIMEOUT_MS * 3);
+
+      expect(client.abort).not.toHaveBeenCalled();
+      expect(client.promptAsync).toHaveBeenCalledTimes(2);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it('does not escalate a steer after the turn completes', async () => {
+    const { client, harness } = createHarness();
+
+    try {
+      await connectHarness(harness, client);
+      vi.useFakeTimers();
+      await startTask(client, harness);
+      await injectSteer(client, harness);
+
+      await client.emit({
+        type: 'session.idle',
+        properties: { sessionID: 'ses_1' },
+      });
+
+      await vi.advanceTimersByTimeAsync(STEER_PICKUP_TIMEOUT_MS * 3);
+
+      expect(client.abort).not.toHaveBeenCalled();
+      expect(client.promptAsync).toHaveBeenCalledTimes(2);
+    } finally {
+      harness.dispose();
+    }
+  });
+});
+
+describe('OpenCode turn stall watchdog', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('aborts a wedged turn, surfaces a retryable error, and ends the task', async () => {
+    const { client, harness } = createHarness();
+    const taskEvents: TaskEvent[] = [];
+    const persistedEnvelopes: AcpPersistedEnvelope[] = [];
+    harness.subscribe((event) => taskEvents.push(event));
+    harness.subscribeRuntimePersistedEnvelope((envelope) =>
+      persistedEnvelopes.push(envelope),
+    );
+
+    try {
+      await connectHarness(harness, client);
+      vi.useFakeTimers();
+      await startTask(client, harness);
+      // Re-baseline the activity clock (startTask's waitFor advances fake
+      // time a little) so the window boundary below is exact.
+      await client.emit(assistantTextPartEvent());
+
+      await vi.advanceTimersByTimeAsync(TURN_STALL_TIMEOUT_MS - 1);
+      expect(client.abort).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.waitFor(() => {
+        expect(client.abort).toHaveBeenCalledTimes(1);
+      });
+      expect(client.abort).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: 'ses_1' }),
+      );
+
+      // A retryable stall notice lands in the transcript.
+      expect(
+        persistedEnvelopes.some((envelope) =>
+          envelope.contentBlocks.some(
+            (block) =>
+              block.type === 'text' &&
+              typeof block.text === 'string' &&
+              block.text.includes('safe to retry'),
+          ),
+        ),
+      ).toBe(true);
+
+      // With nothing queued the task reaches a terminal state instead of
+      // hanging "running" until the sandbox hard deadline.
+      expect(
+        taskEvents.filter(
+          (event) => event.eventName === TaskEventName.TaskAborted,
+        ),
+      ).toHaveLength(1);
+
+      // The MessageAbortedError provoked by the recovery abort stays
+      // suppressed instead of surfacing a second error or terminal abort.
+      await client.emit(suppressedAbortErrorEvent());
+      expect(
+        persistedEnvelopes.some((envelope) =>
+          envelope.contentBlocks.some(
+            (block) =>
+              block.type === 'text' &&
+              typeof block.text === 'string' &&
+              block.text.includes('provider returned an error'),
+          ),
+        ),
+      ).toBe(false);
+      expect(
+        taskEvents.filter(
+          (event) => event.eventName === TaskEventName.TaskAborted,
+        ),
+      ).toHaveLength(1);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it('delivers queued follow-ups after recovering a wedged turn', async () => {
+    const { client, harness } = createHarness();
+    const taskEvents: TaskEvent[] = [];
+    harness.subscribe((event) => taskEvents.push(event));
+
+    try {
+      await connectHarness(harness, client);
+      vi.useFakeTimers();
+      await startTask(client, harness);
+
+      harness.sendCommand({
+        commandName: TaskCommandName.SendMessage,
+        data: { text: 'Queued follow-up.', visibleInTranscript: true },
+      });
+      await vi.waitFor(() => {
+        expect(harness.getQueuedMessages()).toHaveLength(1);
+      });
+
+      await vi.advanceTimersByTimeAsync(TURN_STALL_TIMEOUT_MS);
+
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(2);
+      });
+      expect(client.abort).toHaveBeenCalledTimes(1);
+      expect(client.promptAsync.mock.calls[1]?.[0]).toMatchObject({
+        sessionId: 'ses_1',
+        request: {
+          parts: [{ type: 'text', text: 'Queued follow-up.' }],
+        },
+      });
+      expect(harness.getQueuedMessages()).toEqual([]);
+      // The run continues on the fresh turn; recovery is not a terminal
+      // abort when there is queued work to deliver.
+      expect(
+        taskEvents.some(
+          (event) => event.eventName === TaskEventName.TaskAborted,
+        ),
+      ).toBe(false);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it('measures the stall window from the latest session activity', async () => {
+    const { client, harness } = createHarness();
+
+    try {
+      await connectHarness(harness, client);
+      vi.useFakeTimers();
+      await startTask(client, harness);
+
+      await vi.advanceTimersByTimeAsync(TURN_STALL_TIMEOUT_MS / 2);
+      await client.emit(assistantTextPartEvent());
+
+      // The original deadline passes without firing…
+      await vi.advanceTimersByTimeAsync(TURN_STALL_TIMEOUT_MS - 1_000);
+      expect(client.abort).not.toHaveBeenCalled();
+
+      // …but a full quiet window after the last activity does fire.
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.waitFor(() => {
+        expect(client.abort).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it('never fires while a tracked execute tool is running', async () => {
+    const { client, harness } = createHarness();
+
+    try {
+      await connectHarness(harness, client);
+      vi.useFakeTimers();
+      await startTask(client, harness);
+
+      await client.emit({
+        type: 'message.part.updated',
+        properties: {
+          info: { id: 'msg_a1', role: 'assistant' },
+          part: {
+            id: 'prt_bash_1',
+            sessionID: 'ses_1',
+            messageID: 'msg_a1',
+            type: 'tool',
+            tool: 'bash',
+            callID: 'call_bash_1',
+            state: { status: 'running', input: { command: 'pnpm build' } },
+          },
+        },
+      });
+
+      // A long command emits no events while it runs; the in-memory tracker
+      // defers the stall check without even a server round-trip.
+      await vi.advanceTimersByTimeAsync(TURN_STALL_TIMEOUT_MS * 3);
+
+      expect(client.abort).not.toHaveBeenCalled();
+      expect(client.messages).not.toHaveBeenCalled();
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it('defers to a server-side running tool part and recovers once it settles silently', async () => {
+    const { client, harness } = createHarness();
+
+    try {
+      await connectHarness(harness, client);
+      vi.useFakeTimers();
+      await startTask(client, harness);
+
+      // An MCP tool starts running and its part update is the last event to
+      // arrive. MCP tools have no local tracker, so only the server-side
+      // verification can tell this apart from a stalled stream.
+      await client.emit({
+        type: 'message.part.updated',
+        properties: {
+          info: { id: 'msg_a1', role: 'assistant' },
+          part: mcpToolPart('running'),
+        },
+      });
+      client.messages.mockResolvedValue([
+        assistantMessageWithParts([mcpToolPart('running')]),
+      ]);
+
+      await vi.advanceTimersByTimeAsync(TURN_STALL_TIMEOUT_MS * 3);
+
+      expect(client.abort).not.toHaveBeenCalled();
+      expect(client.messages).toHaveBeenCalled();
+
+      // The tool finishes but OpenCode then goes silent — the wedge
+      // signature. The next verification finds no running tool and recovers.
+      client.messages.mockResolvedValue([
+        assistantMessageWithParts([mcpToolPart('completed')]),
+      ]);
+      await vi.advanceTimersByTimeAsync(TURN_STALL_TIMEOUT_MS);
+
+      await vi.waitFor(() => {
+        expect(client.abort).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it('never recovers when verification cannot reach the server', async () => {
+    const { client, harness, logger } = createHarness();
+
+    try {
+      await connectHarness(harness, client);
+      vi.useFakeTimers();
+      await startTask(client, harness);
+
+      client.messages.mockRejectedValue(new Error('connection reset'));
+
+      await vi.advanceTimersByTimeAsync(TURN_STALL_TIMEOUT_MS * 3);
+
+      expect(client.abort).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Could not verify'),
+      );
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it('never fires while a question awaits the user', async () => {
+    const { client, harness } = createHarness();
+
+    try {
+      await connectHarness(harness, client);
+      vi.useFakeTimers();
+      await startTask(client, harness);
+
+      await client.emit({
+        type: 'message.part.updated',
+        properties: {
+          info: { id: 'msg_a1', role: 'assistant' },
+          part: {
+            id: 'prt_q1',
+            sessionID: 'ses_1',
+            messageID: 'msg_a1',
+            type: 'tool',
+            tool: 'question',
+            callID: 'call_q1',
+            state: {
+              status: 'running',
+              input: {
+                questions: [
+                  { id: 'q1', header: 'Choice', question: 'Which option?' },
+                ],
+              },
+            },
+          },
+        },
+      });
+      expect(harness.getPendingUserInputRequests()).toHaveLength(1);
+
+      // A pending question legitimately waits on the user indefinitely.
+      await vi.advanceTimersByTimeAsync(TURN_STALL_TIMEOUT_MS * 3);
+
+      expect(client.abort).not.toHaveBeenCalled();
+      expect(client.messages).not.toHaveBeenCalled();
+    } finally {
+      harness.dispose();
+    }
+  });
+});

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
@@ -82,6 +82,8 @@ interface OpenCodeServerHarnessOptions {
   executeToolProgressInitialDelayMs?: number;
   executeToolProgressIntervalMs?: number;
   stopHookReminderStallTimeoutMs?: number;
+  steerPickupTimeoutMs?: number;
+  turnStallTimeoutMs?: number;
   subagentSettlementGraceMs?: number;
   queuedPromptRetryDelayMs?: number;
   mcpServerNames?: string[];
@@ -143,6 +145,20 @@ interface FinalizedAssistantTurn {
   messageId: string;
   text: string;
   tokenUsage: Record<string, unknown>;
+}
+
+// A prompt natively injected into an active turn (prompt_async, no abort)
+// with no evidence yet that OpenCode's loop picked it up. Retained so a
+// pickup stall can replay the same content through the queued
+// abort-and-replay path. clientMessageId is deliberately not retained: the
+// injection already persisted the visible user prompt under that id, and the
+// invisible replay must not collide with it.
+interface PendingSteerPickup {
+  text: string;
+  images?: string[];
+  userId?: string;
+  userName?: string;
+  userImageUrl?: string;
 }
 
 interface OpenCodeSlackStopHookDecision {
@@ -226,6 +242,29 @@ const MAX_OPENCODE_STOP_HOOK_REMINDERS = 3;
 // turn re-entry (or teardown) clears it first via clearAllExecuteToolProgress,
 // so it only ever fires on a genuine silence.
 const OPENCODE_STOP_HOOK_REMINDER_STALL_TIMEOUT_MS = 10 * 60_000;
+// A natively steered prompt (prompt_async into an active turn) is only read
+// by OpenCode between loop steps. When the turn's current LLM stream request
+// has silently stalled (observed live: `message=stream providerID=...` with
+// no further loop step, no session.idle, no session.error), the loop never
+// reaches another step boundary, so the injection call succeeds but the
+// prompt sits unseen forever. This window bounds how long a successful
+// injection may go with zero turn progress before the steer escalates to the
+// queue + abort-and-replay path that failed injections already take. Any
+// turn progress disarms it — a live turn reaches its next step boundary, and
+// with it the injected prompt, on its own.
+const DEFAULT_OPENCODE_STEER_PICKUP_TIMEOUT_MS = 90_000;
+// Fail-safe for a turn wedged inside a single LLM stream request. A stalled
+// stream emits nothing — no message events, no session.idle, no
+// session.error — so nothing else bounds the turn and the task hangs
+// "running" until the sandbox hard deadline. If an in-flight turn produces
+// no OpenCode session events for this window, and verification against
+// OpenCode's own message state shows no tool part still running (long tool
+// executions legitimately emit no events), the turn is treated as wedged:
+// aborted, a retryable error surfaced to the transcript, and queued prompts
+// drained. Deliberately generous: platform-API MCP calls are bounded at 120s
+// and artifact transfers at 600s, so a quiet-but-alive turn either shows a
+// running tool part or completes well inside this window.
+const DEFAULT_OPENCODE_TURN_STALL_TIMEOUT_MS = 15 * 60_000;
 const EXPECTED_REPLAY_ABORT_SUPPRESSION_MS = 10_000;
 const DEFAULT_EXECUTE_TOOL_PROGRESS_INITIAL_DELAY_MS = 15_000;
 const DEFAULT_EXECUTE_TOOL_PROGRESS_INTERVAL_MS = 30_000;
@@ -1027,6 +1066,14 @@ function formatOpenCodeSessionErrorText(error: unknown): string {
   }`;
 }
 
+function formatOpenCodeTurnStallErrorText(stallTimeoutMs: number): string {
+  const minutes = Math.max(1, Math.round(stallTimeoutMs / 60_000));
+
+  return `The session stopped responding mid-turn: no activity arrived from the model for about ${minutes} minute${
+    minutes === 1 ? '' : 's'
+  }, so the stalled turn was aborted. This is usually a transient provider stall and is safe to retry.`;
+}
+
 function formatOpenCodeUserInputResponsePrompt(options: {
   request: HarnessPendingUserInputRequest;
   answers: AcpRequestUserInputAnswers;
@@ -1433,6 +1480,8 @@ export class OpenCodeServerHarness
   private readonly executeToolProgressInitialDelayMs: number;
   private readonly executeToolProgressIntervalMs: number;
   private readonly stopHookReminderStallTimeoutMs: number;
+  private readonly steerPickupTimeoutMs: number;
+  private readonly turnStallTimeoutMs: number;
   private readonly subagentSettlementGraceMs: number;
   private readonly queuedPromptRetryDelayMs: number;
   private readonly streamedPartText = new Map<string, string>();
@@ -1483,6 +1532,10 @@ export class OpenCodeServerHarness
   private stopHookReminderCount = 0;
   private stopHookReminderStallTimer: ReturnType<typeof setTimeout> | null =
     null;
+  private steerPickupTimer: ReturnType<typeof setTimeout> | null = null;
+  private pendingSteerPickups: PendingSteerPickup[] = [];
+  private turnStallTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastTurnEventAtMs = 0;
   private resolveEventStreamReady: (() => void) | undefined;
   private rejectEventStreamReady: ((error: unknown) => void) | undefined;
   private finalizedAssistantTurn: FinalizedAssistantTurn | null = null;
@@ -1525,6 +1578,10 @@ export class OpenCodeServerHarness
     this.stopHookReminderStallTimeoutMs =
       options.stopHookReminderStallTimeoutMs ??
       OPENCODE_STOP_HOOK_REMINDER_STALL_TIMEOUT_MS;
+    this.steerPickupTimeoutMs =
+      options.steerPickupTimeoutMs ?? DEFAULT_OPENCODE_STEER_PICKUP_TIMEOUT_MS;
+    this.turnStallTimeoutMs =
+      options.turnStallTimeoutMs ?? DEFAULT_OPENCODE_TURN_STALL_TIMEOUT_MS;
     this.subagentSettlementGraceMs =
       options.subagentSettlementGraceMs ?? DEFAULT_SUBAGENT_SETTLEMENT_GRACE_MS;
     this.queuedPromptRetryDelayMs =
@@ -1958,6 +2015,21 @@ export class OpenCodeServerHarness
             ...command.data,
             text,
           });
+          // Injection succeeding does not mean delivery: OpenCode only reads
+          // injected prompts between loop steps, and a turn stalled inside a
+          // single LLM stream request never reaches one. Watch for turn
+          // progress and escalate to abort-and-replay if none arrives.
+          this.armSteerPickupWatchdog({
+            text,
+            ...(command.data.images ? { images: command.data.images } : {}),
+            ...(command.data.userId ? { userId: command.data.userId } : {}),
+            ...(command.data.userName
+              ? { userName: command.data.userName }
+              : {}),
+            ...(command.data.userImageUrl
+              ? { userImageUrl: command.data.userImageUrl }
+              : {}),
+          });
           return;
         } catch (error) {
           this.logger.warn(
@@ -2189,6 +2261,11 @@ export class OpenCodeServerHarness
     // error, queued replay, dispose) also means the awaited reminder response
     // either arrived or is moot, so disarm the pending fail-safe.
     this.clearStopHookReminderStall();
+    // The steer-pickup and turn-stall watchdogs share it too: every teardown
+    // point here ends the turn they were guarding, and any new turn re-arms
+    // them on prompt submission.
+    this.clearSteerPickupWatchdog();
+    this.clearTurnStallWatchdog();
     // Subagent run tracking shares the same lifecycle: every teardown point
     // that clears execute-tool heartbeats (turn finish, cancel, session error,
     // queued replay, dispose) must also drop pending subagent trackers.
@@ -3060,6 +3137,8 @@ export class OpenCodeServerHarness
       this.inFlight = false;
       throw error;
     }
+
+    this.armTurnStallWatchdog();
   }
 
   private async handleEvent(rawEvent: OpenCodeGlobalEvent): Promise<void> {
@@ -3081,6 +3160,10 @@ export class OpenCodeServerHarness
     const sessionId = eventSessionId(payload);
 
     if (sessionId && this.sessionId && sessionId !== this.sessionId) {
+      // Child-session events are turn progress for the parent too: they mean
+      // OpenCode is alive executing a spawn the in-flight turn is waiting on.
+      this.noteTurnProgress();
+
       // Child-session (subagent) events are otherwise dropped here; fold tool
       // activity into the parent spawn row and record hidden inference usage
       // before returning. A child session going idle or erroring is its
@@ -3128,6 +3211,13 @@ export class OpenCodeServerHarness
 
     if (statusType === 'busy' || statusType === 'retry') {
       this.inFlight = true;
+      // Status transitions prove the session is alive (e.g. a provider retry
+      // loop), but not that the turn's loop advanced — a steer awaiting
+      // pickup stays armed.
+      this.noteTurnActivity();
+      if (!this.turnStallTimer) {
+        this.scheduleTurnStallCheck(this.turnStallTimeoutMs);
+      }
       return;
     }
 
@@ -3235,8 +3325,13 @@ export class OpenCodeServerHarness
       messageRole === 'user' ||
       (messageId && this.submittedUserMessageIds.has(messageId))
     ) {
+      // Parts of a submitted user message arrive from the submission itself
+      // (prompt_async persists the message immediately), so they say nothing
+      // about the turn's loop advancing and must not count as progress.
       return;
     }
+
+    this.noteTurnProgress();
 
     if (
       this.suppressAssistantOutputUntilNextPrompt &&
@@ -3535,6 +3630,8 @@ export class OpenCodeServerHarness
       return;
     }
 
+    this.noteTurnProgress();
+
     if (info.sessionID && !this.sessionId) {
       this.sessionId = info.sessionID;
     }
@@ -3647,6 +3744,257 @@ export class OpenCodeServerHarness
     this.runtimeEvents.taskCompleted(sessionId, undefined);
 
     await this.drainQueuedPrompts();
+  }
+
+  private armSteerPickupWatchdog(steer: PendingSteerPickup): void {
+    this.pendingSteerPickups.push(steer);
+
+    if (this.steerPickupTimer) {
+      clearTimeout(this.steerPickupTimer);
+    }
+
+    const timer = setTimeout(() => {
+      void this.handleSteerPickupStall().catch((error: unknown) => {
+        this.logger.error(
+          `OpenCode steer pickup escalation failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      });
+    }, this.steerPickupTimeoutMs);
+    timer.unref?.();
+    this.steerPickupTimer = timer;
+  }
+
+  private clearSteerPickupWatchdog(): void {
+    if (this.steerPickupTimer) {
+      clearTimeout(this.steerPickupTimer);
+      this.steerPickupTimer = null;
+    }
+
+    if (this.pendingSteerPickups.length > 0) {
+      this.pendingSteerPickups = [];
+    }
+  }
+
+  /**
+   * Fires when a successfully injected mid-turn steer saw no turn progress
+   * within the pickup window: the turn is presumed stalled inside a single
+   * LLM stream request, where OpenCode never reaches the loop step boundary
+   * that would read the injection. Escalate to the queue + prioritize +
+   * abort-and-replay path that failed injections already take, so the steer
+   * actually lands. The replays are queued invisibly because the injection
+   * already persisted each steer's visible user prompt.
+   */
+  private async handleSteerPickupStall(): Promise<void> {
+    this.steerPickupTimer = null;
+    const pending = this.pendingSteerPickups;
+    this.pendingSteerPickups = [];
+
+    if (this.disposed || pending.length === 0 || !this.inFlight) {
+      return;
+    }
+
+    this.logger.warn(
+      `OpenCode showed no turn progress within ${this.steerPickupTimeoutMs}ms of a native mid-turn steer injection; escalating ${pending.length} steer(s) to abort-and-replay so they land.`,
+    );
+
+    const queuedIds = pending.map((steer) =>
+      this.prompts.enqueue({
+        ...steer,
+        visibleInTranscript: false,
+      }),
+    );
+
+    // Front-load the replayed steers while preserving their send order.
+    for (const queuedId of [...queuedIds].reverse()) {
+      this.prompts.prioritize(queuedId);
+    }
+
+    await this.interruptForQueuedReplay();
+  }
+
+  /** Any session event that proves the OpenCode session is alive. */
+  private noteTurnActivity(): void {
+    this.lastTurnEventAtMs = Date.now();
+  }
+
+  /**
+   * Evidence the in-flight turn is actually advancing (assistant message or
+   * part activity, child-session activity). Beyond refreshing the stall
+   * window this disarms the steer-pickup watchdog: a turn that is making
+   * progress reaches its next loop step — and with it any injected prompt —
+   * on its own.
+   */
+  private noteTurnProgress(): void {
+    this.noteTurnActivity();
+    this.clearSteerPickupWatchdog();
+  }
+
+  private armTurnStallWatchdog(): void {
+    this.noteTurnActivity();
+    this.scheduleTurnStallCheck(this.turnStallTimeoutMs);
+  }
+
+  private scheduleTurnStallCheck(delayMs: number): void {
+    this.clearTurnStallWatchdog();
+    const timer = setTimeout(() => {
+      void this.handleTurnStallCheck().catch((error: unknown) => {
+        this.logger.error(
+          `OpenCode turn stall check failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      });
+    }, delayMs);
+    timer.unref?.();
+    this.turnStallTimer = timer;
+  }
+
+  private clearTurnStallWatchdog(): void {
+    if (this.turnStallTimer) {
+      clearTimeout(this.turnStallTimer);
+      this.turnStallTimer = null;
+    }
+  }
+
+  /**
+   * A turn wedged inside a single LLM stream request emits nothing: no
+   * message events, no session.idle, no session.error. Left alone it hangs
+   * "running" until the sandbox hard deadline and natively injected steers
+   * are never read. This check fires after `turnStallTimeoutMs` of event
+   * silence on an in-flight turn and treats the session as wedged — but only
+   * after ruling out every quiet-but-alive state:
+   *
+   * - execute tools and subagent runs legitimately emit no events while they
+   *   work (both tracked in-memory);
+   * - a pending question tool waits on the user indefinitely;
+   * - any tool part still `running` on the latest assistant message —
+   *   verified against OpenCode's own state, since MCP tools have no local
+   *   tracker — means the turn is inside a tool execution, not a stream.
+   *
+   * A failed verification lookup proves nothing and never recovers: a false
+   * abort kills real work while an extra wait only delays an already-wedged
+   * turn, so every margin leans toward waiting (same bias as
+   * recoverUnsettledSpawn).
+   */
+  private async handleTurnStallCheck(): Promise<void> {
+    this.turnStallTimer = null;
+    const sessionId = this.sessionId;
+
+    if (this.disposed || !this.inFlight || !sessionId) {
+      return;
+    }
+
+    const idleMs = Date.now() - this.lastTurnEventAtMs;
+
+    if (idleMs < this.turnStallTimeoutMs) {
+      this.scheduleTurnStallCheck(this.turnStallTimeoutMs - idleMs);
+      return;
+    }
+
+    if (
+      this.pendingUserInputRequests.size > 0 ||
+      this.activeExecuteToolProgress.size > 0 ||
+      this.activeSubagentWatchdogs.size > 0
+    ) {
+      this.scheduleTurnStallCheck(this.turnStallTimeoutMs);
+      return;
+    }
+
+    let verifiedNoRunningTool = false;
+
+    try {
+      const messages = await this.client.messages({
+        sessionId,
+        limit: 20,
+        signal: this.eventAbortController.signal,
+      });
+      const latestAssistantMessage = [...messages]
+        .reverse()
+        .find((message) => message.info.role === 'assistant');
+
+      verifiedNoRunningTool = !latestAssistantMessage?.parts.some(
+        (part) =>
+          part.type === 'tool' &&
+          (part as OpenCodeToolPart).state?.status === 'running',
+      );
+    } catch (error) {
+      this.logger.warn(
+        `Could not verify OpenCode session ${sessionId} before recovering a stalled turn; leaving it running: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+
+    // The verification round-tripped: re-check that nothing moved meanwhile.
+    if (this.disposed || !this.inFlight || this.turnStallTimer) {
+      return;
+    }
+
+    if (!verifiedNoRunningTool) {
+      this.scheduleTurnStallCheck(this.turnStallTimeoutMs);
+      return;
+    }
+
+    const idleAfterVerifyMs = Date.now() - this.lastTurnEventAtMs;
+
+    if (idleAfterVerifyMs < this.turnStallTimeoutMs) {
+      this.scheduleTurnStallCheck(this.turnStallTimeoutMs - idleAfterVerifyMs);
+      return;
+    }
+
+    await this.recoverWedgedTurn(sessionId);
+  }
+
+  /**
+   * Terminal recovery for a wedged turn, mirroring handleSessionError's
+   * teardown around an intentional abort: stop the stuck request
+   * (suppressing the MessageAbortedError the abort provokes), keep the
+   * partial output the turn produced, surface a retryable error to the
+   * transcript, and either drain queued prompts onto a fresh turn or — with
+   * nothing queued — abort the task so it reaches a terminal, retryable
+   * state instead of hanging until the sandbox deadline.
+   */
+  private async recoverWedgedTurn(sessionId: string): Promise<void> {
+    this.logger.error(
+      `OpenCode turn produced no session events for ${this.turnStallTimeoutMs}ms with no tool running; treating the session as wedged and aborting the turn sessionId=${sessionId}`,
+    );
+
+    this.armReplayAbortErrorSuppression();
+
+    try {
+      await this.client.abort({
+        sessionId,
+        signal: this.eventAbortController.signal,
+      });
+    } catch (error) {
+      this.logger.warn(
+        `Failed to abort wedged OpenCode session ${sessionId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+
+    // Keep whatever partial output the wedged turn streamed, ordered before
+    // the stall notice, and drop the trailing finalize/part events the abort
+    // provokes for the dead message.
+    await this.flushAssistantMessageForCancel(sessionId);
+    this.suppressAssistantOutputUntilNextPrompt = true;
+    this.runtimeEvents.assistantMessage({
+      sessionId,
+      text: formatOpenCodeTurnStallErrorText(this.turnStallTimeoutMs),
+    });
+    this.inFlight = false;
+    this.finalizedAssistantTurn = null;
+    this.clearAllExecuteToolProgress();
+
+    if (this.prompts.hasQueuedMessages()) {
+      await this.drainQueuedPrompts();
+      return;
+    }
+
+    this.runtimeEvents.taskAborted(sessionId);
   }
 
   private async finalizeAssistantMessage(

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/start.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/start.ts
@@ -360,6 +360,12 @@ export async function startOpenCodeServerHarness({
       stopHookReminderStallTimeoutMs: parseTimeoutMs(
         process.env.ROOMOTE_STOP_HOOK_REMINDER_STALL_TIMEOUT_MS,
       ),
+      steerPickupTimeoutMs: parseTimeoutMs(
+        process.env.ROOMOTE_OPENCODE_STEER_PICKUP_TIMEOUT_MS,
+      ),
+      turnStallTimeoutMs: parseTimeoutMs(
+        process.env.ROOMOTE_OPENCODE_TURN_STALL_TIMEOUT_MS,
+      ),
       subagentSettlementGraceMs: parseTimeoutMs(
         process.env.ROOMOTE_SUBAGENT_SETTLEMENT_GRACE_MS,
       ),


### PR DESCRIPTION
## What changed

Nightly task `185unvkkk9ixp` (run 239) sat "running" for hours and ignored every follow-up. The turn had stalled inside a single LLM stream request (log signature: `message=stream providerID=openrouter ...` with no subsequent `loop ... step=N`, no `session.idle`, no `session.error`). A stalled stream emits no events at all, so nothing bounded the turn until the 5h sandbox hard deadline. Follow-ups were silently lost: native mid-turn steering succeeds at injection (`prompt_async`), but OpenCode only reads injected prompts between loop steps, and the wedged loop never reaches one. The abort-and-replay fallback only triggered when injection *threw*, never when it succeeded and was dropped.

Two watchdogs in the opencode-server harness, both modeled on the existing stop-hook reminder stall fail-safe:

**Steer pickup watchdog** (90s default, `ROOMOTE_OPENCODE_STEER_PICKUP_TIMEOUT_MS`)
- Armed after every successful native mid-turn injection.
- Disarmed by any turn progress: assistant message/part events, child-session activity. Deliberately *not* disarmed by the injection's own user-message events or bare `session.status`, so a wedged stream can't self-disarm it.
- On expiry with zero progress, the steer escalates to the queue + prioritize + `interruptForQueuedReplay` path that failed injections already take. The replay is queued invisibly (the visible user prompt persisted at injection; `clientMessageId` is dropped so the replay can't collide with that envelope).
- The `pendingUserInputRequests` guard in the native steer path is untouched: a pending question still routes straight to abort-and-replay.

**Turn stall watchdog** (15m default, `ROOMOTE_OPENCODE_TURN_STALL_TIMEOUT_MS`)
- An in-flight turn with no session events (`message.part.updated`, `message.updated`, `session.status`, child-session events) for the window is treated as wedged — but only after ruling out every quiet-but-alive state: pending question, tracked execute tool, active subagent run, and, verified against OpenCode's own message state, any tool part still `running` on the latest assistant message. The server-side check is what protects long MCP calls that have no local tracker — the leg #84's 120s platform-API ceiling doesn't reach. A failed verification lookup never recovers (same bias as `recoverUnsettledSpawn`).
- Recovery aborts the turn with `MessageAbortedError` suppression, flushes partial output at the stall point, surfaces a "transient provider stall, safe to retry" notice to the transcript, then drains queued prompts onto a fresh turn — or with nothing queued emits `taskAborted` so the task reaches a terminal state instead of burning to the sandbox deadline.

Known residual gap: if a steer is injected, the turn shows some progress (disarming the pickup watchdog), and the stream then stalls before the next step boundary, the injected prompt can be lost inside OpenCode — but the turn stall watchdog still unwedges the task within its window.

## How it was tested

- New test file `opencode-server-stall-watchdogs.test.ts` (10 tests, fake-client + fake-timers pattern matching the subagent watchdog tests): steer escalation replays the exact text with no duplicate visible transcript entry and no terminal abort; disarm on progress and turn completion; wedge recovery surfaces the retryable error and `TaskAborted`; queued follow-ups delivered after recovery; stall window measured from last activity; never-fires cases for running execute tools (in-memory fast path, no server round-trip), server-side running MCP parts (plus recovery once the tool settles silently), unreachable verification, and pending questions.
- Full `src/sandbox-server` suite: 311/311 pass (includes all 63 existing opencode harness tests). run-task harness tests: 77/77 pass.
- `pnpm lint` and `pnpm check-types` pass across all workspaces.
- Note: `pnpm knip` currently fails on develop itself (unused files/deps in `apps/dev`, `packages/db`, `packages/telemetry`, `packages/slack` — none touched here), so the push bypassed the pre-push hook for that check only; `lint:fast` and `check-types:fast` were run manually and pass.

## Checklist

- [x] The PR title follows the repo convention: `[Fix]`, `[Feat]`, `[Improve]`, `[Refactor]`, `[Docs]`, or `[Chore]` followed by a user-facing description
- [x] This PR is small and scoped to one change
- [x] `pnpm lint` and `pnpm check-types` pass locally
- [x] I added tests or included a clear manual validation note above
- [x] I removed secrets, tokens, private keys, and customer data from code, logs, and screenshots
- [ ] If this change should appear in the changelog, I ran `pnpm changeset` (skipped — internal worker reliability fix, matching #84 which shipped without one)