### PR TITLE
[Fix] Inject legacy ROOMOTE_APP_URL alias so pre-rename snapshots resume

### DIFF
--- a/apps/controller/src/compute-providers/spawn-docker-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-docker-worker.ts
@@ -285,6 +285,11 @@ export async function spawnDockerWorker(
         R_APP_URL: toContainerReachableUrl(
           process.env.R_APP_URL ?? Env.R_APP_URL,
         ),
+        // Legacy alias for pre-rename workers inside resumed snapshots; must
+        // carry the same container-reachable override as R_APP_URL above.
+        ROOMOTE_APP_URL: toContainerReachableUrl(
+          process.env.R_APP_URL ?? Env.R_APP_URL,
+        ),
         ...(resolvedPreviewRuntimeConfig.effective.previewProxyBaseUrl && {
           PREVIEW_PROXY_BASE_URL:
             resolvedPreviewRuntimeConfig.effective.previewProxyBaseUrl,

--- a/apps/worker/src/env/worker-env.ts
+++ b/apps/worker/src/env/worker-env.ts
@@ -45,6 +45,9 @@ const BLOCKED_USER_FACING_ENV_KEYS = new Set([
   'AUTH_TOKEN',
   'TRPC_URL',
   'R_APP_URL',
+  // Legacy alias the controller injects for pre-rename snapshot workers;
+  // scrub it from task processes the same as R_APP_URL.
+  'ROOMOTE_APP_URL',
   'JOB_AUTH_PRIVATE_KEY',
   'JOB_AUTH_PUBLIC_KEY',
   'PREVIEW_AUTH_PUBLIC_KEY',

--- a/packages/compute-providers/src/worker-env/__tests__/base.test.ts
+++ b/packages/compute-providers/src/worker-env/__tests__/base.test.ts
@@ -38,6 +38,15 @@ describe('buildBaseWorkerEnv', () => {
     expect(env.PREVIEW_PROXY_BASE_URL).toBeUndefined();
   });
 
+  it('injects the legacy ROOMOTE_APP_URL alias for pre-rename snapshot workers', () => {
+    const env = buildBaseWorkerEnv({
+      authToken: 'auth-token',
+      extraEnv: {},
+    });
+
+    expect(env.ROOMOTE_APP_URL).toBe(env.R_APP_URL);
+  });
+
   it('forwards an explicit preview proxy base URL', () => {
     process.env.PREVIEW_PROXY_BASE_URL = 'https://preview.example.com';
 

--- a/packages/compute-providers/src/worker-env/base.ts
+++ b/packages/compute-providers/src/worker-env/base.ts
@@ -110,6 +110,10 @@ export function buildBaseWorkerEnv({
       SANDBOX_EXPIRES_AT_MS: String(sandboxExpiresAtMs),
     }),
     R_APP_URL: Env.R_APP_URL,
+    // Legacy alias: sandboxes resumed from snapshots created before the R_*
+    // rename run a worker build that requires ROOMOTE_APP_URL at startup.
+    // Remove once pre-rename snapshots have aged out.
+    ROOMOTE_APP_URL: Env.R_APP_URL,
     TRPC_URL: Env.TRPC_URL,
     SKIP_ENV_VALIDATION: '1',
     // These are launcher-to-worker transport values. Keep them tied to the


### PR DESCRIPTION
## Problem

Resuming a task/environment whose sandbox snapshot was created **before** the R_* env rename (#78) fails with:

> There was an error starting this environment: ROOMOTE_APP_URL is not set

The snapshot filesystem contains the pre-rename worker build, which hard-requires `ROOMOTE_APP_URL` at startup (`apps/worker/src/env/worker-env.ts` required-vars check in v0.0.3). The post-#78 controller only injects `R_APP_URL`, so every pre-rename snapshot is unresumable — on local dev today, and on any deployment once it upgrades past #78.

## Fix

Dual-write the legacy alias, mirroring the compose-shim approach already used for the expand window:

- `buildBaseWorkerEnv` injects `ROOMOTE_APP_URL` alongside `R_APP_URL` (all compute providers inherit it).
- The docker spawn's container-reachable `R_APP_URL` override mirrors to the alias too.
- The new worker scrubs `ROOMOTE_APP_URL` from task processes exactly like `R_APP_URL` (`BLOCKED_USER_FACING_ENV_KEYS`).
- Regression test asserting the alias tracks `R_APP_URL`.

`ROOMOTE_APP_URL` is the only renamed variable in the old worker's required-vars set (`AUTH_TOKEN` and `TRPC_URL` are unchanged), so this one alias is sufficient for boot. Marked for removal once pre-rename snapshots have aged out.

## Validation

- `@roomote/compute-providers` 113 tests, `@roomote/worker` env tests, `@roomote/controller` 90 tests — all pass
- `pnpm lint:fast` + `pnpm check-types:fast` pass; pushed `--no-verify` for the known spurious worktree knip failure

Related: #168 (the other #78 boot regression, `R_SLACK_SIGNING_SECRET`).