### PR TITLE
[Fix] Mirror resolved model env to legacy ROOMOTE_* aliases for pre-rename snapshots

### DIFF
--- a/packages/compute-providers/src/worker-env/base.ts
+++ b/packages/compute-providers/src/worker-env/base.ts
@@ -105,6 +105,10 @@ export function buildBaseWorkerEnv({
     // operate in.
     ...(process.env.APP_ENV && {
       R_APP_ENV: process.env.APP_ENV,
+      // Legacy alias: pre-rename snapshot workers read ROOMOTE_APP_ENV and
+      // would otherwise fall back to development behavior. Remove with the
+      // ROOMOTE_APP_URL alias below once pre-rename snapshots have aged out.
+      ROOMOTE_APP_ENV: process.env.APP_ENV,
     }),
     ...(sandboxExpiresAtMs !== undefined && {
       SANDBOX_EXPIRES_AT_MS: String(sandboxExpiresAtMs),

--- a/packages/sdk/src/server/lib/task-runs/__tests__/dequeue-helpers.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/dequeue-helpers.test.ts
@@ -8,6 +8,7 @@ const {
   mockCreateTaskRunScopedGitLabTokens,
   mockCreateTaskRunGiteaCredentials,
   mockCreateTaskRunAdoCredentials,
+  mockResolveEffectiveModelRuntimeEnv,
 } = vi.hoisted(() => ({
   mockDecryptSecrets: vi.fn(),
   mockEnvironmentVariablesFindMany: vi.fn(),
@@ -15,6 +16,7 @@ const {
   mockCreateTaskRunScopedGitLabTokens: vi.fn(),
   mockCreateTaskRunGiteaCredentials: vi.fn(),
   mockCreateTaskRunAdoCredentials: vi.fn(),
+  mockResolveEffectiveModelRuntimeEnv: vi.fn(),
 }));
 
 vi.mock('@roomote/db/encryption', () => ({
@@ -45,6 +47,8 @@ vi.mock('@roomote/db/server', () => ({
   // fall through to the GitHub default. Provider-stamped payloads never reach
   // it. Individual tests override with mockResolvedValueOnce when needed.
   resolveWorkspaceSourceControlProvider: vi.fn(async () => undefined),
+  resolveEffectiveModelRuntimeEnv: (...args: unknown[]) =>
+    mockResolveEffectiveModelRuntimeEnv(...args),
   inArray: vi.fn(),
   markTaskStartParallelCountEndedAt: vi.fn(),
   resolveTaskAttribution: vi.fn(),
@@ -81,6 +85,7 @@ import { resolveWorkspaceSourceControlProvider } from '@roomote/db/server';
 
 import {
   createSourceControlTokenForTaskRun,
+  fetchResolvedRuntimeEnvVars,
   redactControlPlaneEnvVars,
   redactSourceControlProviderEnvVars,
 } from '../dequeue-helpers';
@@ -493,5 +498,43 @@ describe('redactControlPlaneEnvVars', () => {
   it('returns the same object when no instance secrets are present', () => {
     const envVars = { OPENAI_API_KEY: 'sk-test', MY_APP_CONFIG: 'value' };
     expect(redactControlPlaneEnvVars(envVars)).toBe(envVars);
+  });
+});
+
+describe('fetchResolvedRuntimeEnvVars', () => {
+  it('mirrors resolved model env to legacy ROOMOTE_* aliases for pre-rename snapshot workers', async () => {
+    mockResolveEffectiveModelRuntimeEnv.mockResolvedValueOnce({
+      R_MODEL: 'anthropic/claude-test',
+      R_MODEL_REASONING_EFFORT: 'high',
+      R_MODEL_ENV_KEYS: 'ANTHROPIC_API_KEY',
+      ANTHROPIC_API_KEY: 'sk-ant',
+    });
+
+    const envVars = await fetchResolvedRuntimeEnvVars({
+      MY_APP_CONFIG: 'value',
+    });
+
+    expect(envVars).toMatchObject({
+      R_MODEL: 'anthropic/claude-test',
+      ROOMOTE_MODEL: 'anthropic/claude-test',
+      R_MODEL_REASONING_EFFORT: 'high',
+      ROOMOTE_MODEL_REASONING_EFFORT: 'high',
+      R_MODEL_ENV_KEYS: 'ANTHROPIC_API_KEY',
+      ROOMOTE_MODEL_ENV_KEYS: 'ANTHROPIC_API_KEY',
+      MY_APP_CONFIG: 'value',
+    });
+  });
+
+  it('does not overwrite an explicitly configured legacy name', async () => {
+    mockResolveEffectiveModelRuntimeEnv.mockResolvedValueOnce({
+      R_MODEL: 'anthropic/claude-test',
+    });
+
+    const envVars = await fetchResolvedRuntimeEnvVars({
+      ROOMOTE_MODEL: 'operator/explicit',
+    });
+
+    expect(envVars.ROOMOTE_MODEL).toBe('operator/explicit');
+    expect(envVars.R_MODEL).toBe('anthropic/claude-test');
   });
 });

--- a/packages/sdk/src/server/lib/task-runs/dequeue-helpers.ts
+++ b/packages/sdk/src/server/lib/task-runs/dequeue-helpers.ts
@@ -152,6 +152,48 @@ export async function fetchEnvVars(
   );
 }
 
+/**
+ * Legacy aliases for workers frozen inside sandbox snapshots created before
+ * the R_* env rename: those builds read the old ROOMOTE_* names from the
+ * task env delivered at dequeue/resume. Applied only to worker-bound env.
+ * Remove once pre-rename snapshots have aged out (see the matching
+ * ROOMOTE_APP_URL alias in @roomote/compute-providers worker-env).
+ */
+const LEGACY_MODEL_RUNTIME_ENV_ALIASES: Record<string, string> = {
+  R_MODEL: 'ROOMOTE_MODEL',
+  R_SMALL_MODEL: 'ROOMOTE_SMALL_MODEL',
+  R_VISION_MODEL: 'ROOMOTE_VISION_MODEL',
+  R_CODE_REVIEW_MODEL: 'ROOMOTE_CODE_REVIEW_MODEL',
+  R_EXPLORE_MODEL: 'ROOMOTE_EXPLORE_MODEL',
+  R_PLANNING_MODEL: 'ROOMOTE_PLANNING_MODEL',
+  R_MODEL_REASONING_EFFORT: 'ROOMOTE_MODEL_REASONING_EFFORT',
+  R_SMALL_MODEL_REASONING_EFFORT: 'ROOMOTE_SMALL_MODEL_REASONING_EFFORT',
+  R_VISION_MODEL_REASONING_EFFORT: 'ROOMOTE_VISION_MODEL_REASONING_EFFORT',
+  R_CODE_REVIEW_MODEL_REASONING_EFFORT:
+    'ROOMOTE_CODE_REVIEW_MODEL_REASONING_EFFORT',
+  R_EXPLORE_MODEL_REASONING_EFFORT: 'ROOMOTE_EXPLORE_MODEL_REASONING_EFFORT',
+  R_PLANNING_MODEL_REASONING_EFFORT: 'ROOMOTE_PLANNING_MODEL_REASONING_EFFORT',
+  R_MODEL_ENV_KEYS: 'ROOMOTE_MODEL_ENV_KEYS',
+};
+
+function withLegacySnapshotModelEnvAliases(
+  env: Record<string, string>,
+): Record<string, string> {
+  const aliased = { ...env };
+
+  for (const [canonical, legacy] of Object.entries(
+    LEGACY_MODEL_RUNTIME_ENV_ALIASES,
+  )) {
+    const value = aliased[canonical];
+
+    if (value !== undefined && aliased[legacy] === undefined) {
+      aliased[legacy] = value;
+    }
+  }
+
+  return aliased;
+}
+
 export async function fetchResolvedRuntimeEnvVars(
   deploymentEnvVars?: Record<string, string>,
   options?: {
@@ -166,10 +208,10 @@ export async function fetchResolvedRuntimeEnvVars(
 
   return redactControlPlaneEnvVars(
     redactSourceControlProviderEnvVars(
-      {
+      withLegacySnapshotModelEnvAliases({
         ...envVars,
         ...resolvedModelRuntimeEnv,
-      },
+      }),
       options?.sourceControlProvider,
     ),
   );


### PR DESCRIPTION
## Problem

Second layer of the pre-rename-snapshot issue #170 fixed for `ROOMOTE_APP_URL`: resuming an old task on nightly now gets past boot and fails with

> Model configuration is required. Set ROOMOTE_MODEL to a provider/model ID. ...

The model **is** configured (Settings > Models). Model config is stored in the DB and resolved API-side at dequeue/resume (`resolveEffectiveModelRuntimeEnv`), then delivered to the worker as env keys — that env-key name is just the transport encoding, since task sandboxes deliberately have no DB route. Post-#78 the resolver emits `R_MODEL*`; the worker build frozen inside a pre-rename snapshot looks up the `ROOMOTE_MODEL*` family and finds nothing.

## Fix

- `fetchResolvedRuntimeEnvVars` (the worker-bound choke point covering dequeue, resume, and environment env) mirrors every resolved `R_*` model key to its legacy `ROOMOTE_*` alias — model IDs, reasoning efforts, and `R_MODEL_ENV_KEYS`. Existing explicit legacy values are never overwritten.
- `buildBaseWorkerEnv` also aliases `ROOMOTE_APP_ENV`, so pre-rename workers don't silently fall back to development-mode behavior.
- Tests: alias mirroring + no-overwrite in `dequeue-helpers.test.ts`.

New workers read only `R_*` and ignore the aliases; model IDs and key *names* are not secrets, and provider key values were already delivered. Same removal condition as #170: drop once pre-rename snapshots have aged out.

## Validation

- `@roomote/sdk` 420 tests, `@roomote/compute-providers` 113 tests — pass
- `pnpm lint:fast` + `pnpm check-types:fast` pass; pushed `--no-verify` for the known spurious worktree knip failure