### PR TITLE
[Fix] Surface worker provisioning progress and failures on Settings > Sandboxes

### DIFF
--- a/.changeset/settings-sandboxes-provisioning-visibility.md
+++ b/.changeset/settings-sandboxes-provisioning-visibility.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Surface worker base-image provisioning on Settings → Sandboxes: the save button now reads "Provisioning..." while a run is in flight (matching the setup wizard), a failed run shows its error inline with a "Retry provisioning" action, and a note explains that provisioning can take a few minutes. Previously the page kept a generic "Saving..." spinner during the run and never displayed provisioning failures.

--- a/apps/web/src/components/settings/ComputeProviderSection.client.test.tsx
+++ b/apps/web/src/components/settings/ComputeProviderSection.client.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen } from '@testing-library/react';
+import type {
+  SetupComputeStatus,
+  SetupNewComputeProvisioningState,
+} from '@roomote/types';
+
+import { ComputeProviderSection } from './ComputeProviderSection';
+
+type ComputeProviderStatus = SetupComputeStatus['providers'][number];
+
+const apiKeyField: ComputeProviderStatus['fields'][number] = {
+  envVarName: 'E2B_API_KEY',
+  label: 'E2B API Key',
+  secret: true,
+  category: 'credential',
+  runtimeSatisfied: false,
+  savedSatisfied: true,
+  defaultSatisfied: false,
+  setupProvisionable: false,
+};
+
+const templateField: ComputeProviderStatus['fields'][number] = {
+  envVarName: 'E2B_TEMPLATE_ID',
+  label: 'Worker Template ID',
+  category: 'infrastructure',
+  runtimeSatisfied: false,
+  savedSatisfied: false,
+  defaultSatisfied: false,
+  setupProvisionable: true,
+};
+
+const provider: ComputeProviderStatus = {
+  provider: 'e2b',
+  label: 'E2B',
+  description: 'Hosted E2B sandboxes.',
+  supportsSnapshots: true,
+  fields: [apiKeyField, templateField],
+  runtimeConfigSatisfied: false,
+  savedConfigSatisfied: true,
+  configSatisfied: false,
+  infrastructureSatisfied: true,
+};
+
+function buildProvisioning(
+  overrides: Partial<SetupNewComputeProvisioningState>,
+): SetupNewComputeProvisioningState {
+  return {
+    status: 'building',
+    imageRef: 'ghcr.io/roocodeinc/roomote-worker:develop-abc12345',
+    templateRef: 'roomote-worker:develop-abc12345',
+    error: null,
+    startedAt: new Date().toISOString(),
+    finishedAt: null,
+    ...overrides,
+  };
+}
+
+function renderSection(provisioning: SetupNewComputeProvisioningState | null) {
+  return render(
+    <ComputeProviderSection
+      provider={provider}
+      isDefault={false}
+      provisioning={provisioning}
+      onSave={vi.fn()}
+      onClear={vi.fn()}
+      savePending={false}
+      clearPending={false}
+    />,
+  );
+}
+
+describe('ComputeProviderSection provisioning states', () => {
+  it('labels the action button Provisioning... and explains the wait while a run is building', () => {
+    renderSection(buildProvisioning({ status: 'building' }));
+
+    const button = screen.getByRole('button', { name: /Provisioning\.\.\./ });
+    expect(button).toBeDisabled();
+    expect(
+      screen.getByText(/Provisioning the worker base image/),
+    ).toBeInTheDocument();
+  });
+
+  it('surfaces the provisioning error and offers a retry after a failed run', () => {
+    renderSection(
+      buildProvisioning({
+        status: 'failed',
+        error: 'Access denied',
+        finishedAt: new Date().toISOString(),
+      }),
+    );
+
+    expect(
+      screen.getByText('Provisioning failed: Access denied'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Retry provisioning/ }),
+    ).toBeEnabled();
+  });
+
+  it('falls back to generic failure copy when the run recorded no error', () => {
+    renderSection(
+      buildProvisioning({
+        status: 'failed',
+        finishedAt: new Date().toISOString(),
+      }),
+    );
+
+    expect(
+      screen.getByText('Provisioning failed. Save to retry.'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the plain Save action when no provisioning run is tracked', () => {
+    renderSection(null);
+
+    expect(screen.getByRole('button', { name: /Save/ })).toBeInTheDocument();
+    expect(screen.queryByText(/Provisioning failed/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Provisioning the worker base image/),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/settings/ComputeProviderSection.tsx
+++ b/apps/web/src/components/settings/ComputeProviderSection.tsx
@@ -13,6 +13,9 @@ import {
 
 import { getComputeCredentialsHint } from '@/app/(onboarding)/setup/computeSetupCopy';
 import {
+  Alert,
+  AlertCircle,
+  AlertDescription,
   Badge,
   BrandIcon,
   Button,
@@ -182,6 +185,7 @@ export function ComputeProviderSection({
       !field.savedSatisfied,
   );
   const provisioningRunning = provisioning?.status === 'building';
+  const provisioningFailed = provisioning?.status === 'failed';
   // Credentials are already satisfied when a save can still start or retry
   // auto-provisioning without retyping values (existing installs that later
   // gain a registry-qualified worker image).
@@ -417,6 +421,23 @@ export function ComputeProviderSection({
               <EnvVarsInfoNote runtimeConfigured={runtimeConfigured} />
             )}
 
+            {provisioningFailed && (
+              <Alert variant="destructive" className="max-w-xl">
+                <AlertCircle />
+                <AlertDescription>
+                  {provisioning?.error
+                    ? `Provisioning failed: ${provisioning.error}`
+                    : 'Provisioning failed. Save to retry.'}
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {provisioningRunning && (
+              <p className="max-w-xl text-sm text-muted-foreground">
+                Provisioning the worker base image. This can take a few minutes.
+              </p>
+            )}
+
             {(hasSavedValues ||
               hasEditableFields ||
               canRetryProvisioning ||
@@ -450,9 +471,9 @@ export function ComputeProviderSection({
                       {savePending
                         ? 'Saving...'
                         : provisioningRunning
-                          ? 'Saving...'
+                          ? 'Provisioning...'
                           : canRetryProvisioning && !hasPendingValueChanges
-                            ? 'Save'
+                            ? 'Retry provisioning'
                             : 'Save'}
                       {savePending || provisioningRunning ? <Spinner /> : null}
                     </Button>


### PR DESCRIPTION
## Problem

Settings → Sandboxes already receives the detached worker base-image provisioning state and polls while a run is building, but presents none of it:

- While a run is in flight the save button shows a generic **"Saving..."** spinner (the setup wizard shows "Provisioning..." for the same state), so a multi-minute Daytona snapshot registration looks like a hung save.
- A **failed** run is never displayed. Real incident: saving a Daytona API key that lacked snapshot permissions returned "saved" in the UI while the registration died server-side with `Access denied` — the only evidence was in the web service logs.

## Change

`ComputeProviderSection` now matches the wizard's presentation:

- Button reads **"Provisioning..."** while `provisioning.status === 'building'`, with a note that the run can take a few minutes.
- A failed run renders its persisted error in a destructive alert (falling back to generic copy when no error was recorded), and the button reads **"Retry provisioning"** when credentials are already satisfied (this label branch existed but rendered "Save").

No data-flow changes — the page already polled and passed `provisioning`; this is presentation only.

## Testing

- New `ComputeProviderSection.client.test.tsx` covering the building, failed-with-error, failed-without-error, and idle states.
- `pnpm lint:fast`, `pnpm check-types:fast`, `pnpm knip` all pass.