### PR TITLE
Release Roomote 0.0.5

### DIFF
--- a/.changeset/settings-sandboxes-provisioning-visibility.md
+++ b/.changeset/settings-sandboxes-provisioning-visibility.md
@@ -1,5 +1,0 @@
----
-'@roomote/web': patch
----
-
-Surface worker base-image provisioning on Settings → Sandboxes: the save button now reads "Provisioning..." while a run is in flight (matching the setup wizard), a failed run shows its error inline with a "Retry provisioning" action, and a note explains that provisioning can take a few minutes. Previously the page kept a generic "Saving..." spinner during the run and never displayed provisioning failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file tracks product releases for Roomote (single monorepo version). Automated release entries are prepended by `pnpm run version`.
 
+## 0.0.5 (2026-07-11)
+
+### Patch changes
+
+- Surface worker base-image provisioning on Settings → Sandboxes: the save button now reads "Provisioning..." while a run is in flight (matching the setup wizard), a failed run shows its error inline with a "Retry provisioning" action, and a note explains that provisioning can take a few minutes. Previously the page kept a generic "Saving..." spinner during the run and never displayed provisioning failures.
+
 ## 0.0.4 (2026-07-11)
 
 ### Patch changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roomote",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "license": "FCL-1.0-ALv2",
   "packageManager": "pnpm@10.29.3",
   "engines": {


### PR DESCRIPTION
Automated Version PR: bumps the product version to `0.0.5` and folds the pending changesets into the root `CHANGELOG.md`.

- **Squash-merge** this PR into `develop` to cut the release.
- The frozen `release/v0.0.5` promote PR to `main` opens automatically after the merge.
- New changesets on `develop` refresh this PR automatically.

## 0.0.5 (2026-07-11)

### Patch changes

- Surface worker base-image provisioning on Settings → Sandboxes: the save button now reads "Provisioning..." while a run is in flight (matching the setup wizard), a failed run shows its error inline with a "Retry provisioning" action, and a note explains that provisioning can take a few minutes. Previously the page kept a generic "Saving..." spinner during the run and never displayed provisioning failures.
