### PR TITLE
[Fix] Update Bitbucket Cloud auth and repo sync for API tokens and removed Atlassian APIs

### DIFF
--- a/apps/docs/environment-variables.mdx
+++ b/apps/docs/environment-variables.mdx
@@ -252,8 +252,8 @@ as per-task auth tokens or workspace paths.
 | `GITEA_CLIENT_ID`              | Optional     | Gitea OAuth client ID.                                                                           |
 | `GITEA_CLIENT_SECRET`          | Optional     | Gitea OAuth client secret.                                                                       |
 | `GITEA_WEBHOOK_SECRET`         | Optional     | Gitea webhook secret.                                                                            |
-| `BITBUCKET_TOKEN`              | Bitbucket    | Atlassian API token with Bitbucket scopes (legacy app passwords work until July 28, 2026).      |
-| `BITBUCKET_USERNAME`           | Bitbucket    | Atlassian account email that owns the API token (Bitbucket username for legacy app passwords).   |
+| `BITBUCKET_TOKEN`              | Bitbucket    | Atlassian API token with Bitbucket scopes.                                                       |
+| `BITBUCKET_USERNAME`           | Bitbucket    | Atlassian account email that owns the API token.                                                 |
 | `BITBUCKET_BASE_URL`           | Optional     | Bitbucket base URL. Defaults to `https://bitbucket.org` (Cloud only).                            |
 | `BITBUCKET_CLIENT_ID`          | Optional     | Bitbucket OAuth client ID for personal account linking.                                          |
 | `BITBUCKET_CLIENT_SECRET`      | Optional     | Bitbucket OAuth client secret for personal account linking.                                      |

--- a/apps/docs/environment-variables.mdx
+++ b/apps/docs/environment-variables.mdx
@@ -252,8 +252,8 @@ as per-task auth tokens or workspace paths.
 | `GITEA_CLIENT_ID`              | Optional     | Gitea OAuth client ID.                                                                           |
 | `GITEA_CLIENT_SECRET`          | Optional     | Gitea OAuth client secret.                                                                       |
 | `GITEA_WEBHOOK_SECRET`         | Optional     | Gitea webhook secret.                                                                            |
-| `BITBUCKET_TOKEN`              | Bitbucket    | Bitbucket Cloud app password.                                                                    |
-| `BITBUCKET_USERNAME`           | Bitbucket    | Bitbucket Cloud account username paired with the app password.                                   |
+| `BITBUCKET_TOKEN`              | Bitbucket    | Atlassian API token with Bitbucket scopes (legacy app passwords work until July 28, 2026).      |
+| `BITBUCKET_USERNAME`           | Bitbucket    | Atlassian account email that owns the API token (Bitbucket username for legacy app passwords).   |
 | `BITBUCKET_BASE_URL`           | Optional     | Bitbucket base URL. Defaults to `https://bitbucket.org` (Cloud only).                            |
 | `BITBUCKET_CLIENT_ID`          | Optional     | Bitbucket OAuth client ID for personal account linking.                                          |
 | `BITBUCKET_CLIENT_SECRET`      | Optional     | Bitbucket OAuth client secret for personal account linking.                                      |

--- a/apps/docs/providers/source-control/bitbucket.mdx
+++ b/apps/docs/providers/source-control/bitbucket.mdx
@@ -34,7 +34,7 @@ grant these scopes:
 | read:repository:bitbucket and write:repository:bitbucket | cloning, branch creation, and commits |
 | read:pullrequest:bitbucket and write:pullrequest:bitbucket | pull request workflows and comments |
 | read:webhook:bitbucket and write:webhook:bitbucket | automatic webhook setup during repository sync |
-| read:account:bitbucket | identity validation when saving credentials |
+| read:user:bitbucket | identity validation when saving credentials |
 
 Save the token and the Atlassian account email in setup, deployment env vars,
 or local `.env.local`:

--- a/apps/docs/providers/source-control/bitbucket.mdx
+++ b/apps/docs/providers/source-control/bitbucket.mdx
@@ -34,6 +34,7 @@ grant these scopes:
 | read:repository:bitbucket and write:repository:bitbucket | cloning, branch creation, and commits |
 | read:pullrequest:bitbucket and write:pullrequest:bitbucket | pull request workflows and comments |
 | read:webhook:bitbucket and write:webhook:bitbucket | automatic webhook setup during repository sync |
+| read:workspace:bitbucket | workspace discovery during repository sync |
 | read:user:bitbucket | identity validation when saving credentials |
 
 Save the token and the Atlassian account email in setup, deployment env vars,

--- a/apps/docs/providers/source-control/bitbucket.mdx
+++ b/apps/docs/providers/source-control/bitbucket.mdx
@@ -4,9 +4,16 @@ icon: 'https://api.iconify.design/simple-icons:bitbucket.svg?color=currentColor'
 description: Configure Bitbucket Cloud repository sync and pull request webhooks for Roomote.
 ---
 
-Bitbucket Cloud support uses a deployment-owned app password and username. This
-MVP covers Bitbucket Cloud only. Bitbucket Server and Data Center are not
-supported yet.
+Bitbucket Cloud support uses a deployment-owned Atlassian API token paired with
+the Atlassian account email. This MVP covers Bitbucket Cloud only. Bitbucket
+Server and Data Center are not supported yet.
+
+<Note>
+  Bitbucket Cloud app passwords are deprecated. Atlassian runs scheduled
+  brownouts from June 9, 2026 and removes app passwords permanently on July 28,
+  2026. Existing app-password configurations keep working until then, but new
+  setups should use API tokens with scopes.
+</Note>
 
 Repository sync can also create pull request webhooks, allowing Review Code
 automation and `@roomote` pull request comments to work for synced Bitbucket
@@ -14,24 +21,27 @@ Cloud repositories.
 
 Use `<public-url>` below for your stable public Roomote URL.
 
-## Create a Bitbucket app password
+## Create an Atlassian API token
 
 Create a dedicated Bitbucket Cloud bot or service account and give it access to
-the workspaces or repositories Roomote should use. Create an app password with
-these scopes:
+the workspaces or repositories Roomote should use. In that account's
+[Atlassian account settings](https://id.atlassian.com/manage-profile/security/api-tokens),
+choose **Create API token with scopes**, select **Bitbucket** as the app, and
+grant these scopes:
 
 | Scope | Needed for |
 | ----- | ---------- |
-| repository:read and repository:write | cloning, branch creation, and commits |
-| pullrequest:read and pullrequest:write | pull request workflows and comments |
-| webhook | automatic webhook setup during repository sync |
+| read:repository:bitbucket and write:repository:bitbucket | cloning, branch creation, and commits |
+| read:pullrequest:bitbucket and write:pullrequest:bitbucket | pull request workflows and comments |
+| read:webhook:bitbucket and write:webhook:bitbucket | automatic webhook setup during repository sync |
+| read:account:bitbucket | identity validation when saving credentials |
 
-Save the token, username, and optional base URL in setup, deployment env vars,
+Save the token and the Atlassian account email in setup, deployment env vars,
 or local `.env.local`:
 
 ```sh
-BITBUCKET_TOKEN=<bitbucket-app-password>
-BITBUCKET_USERNAME=<bitbucket-username>
+BITBUCKET_TOKEN=<atlassian-api-token>
+BITBUCKET_USERNAME=<atlassian-account-email>
 ```
 
 Optional values:
@@ -41,8 +51,12 @@ BITBUCKET_BASE_URL=https://bitbucket.org
 BITBUCKET_WEBHOOK_SECRET=<webhook-secret>
 ```
 
-`BITBUCKET_USERNAME` is required with `BITBUCKET_TOKEN` (it is the Bitbucket
-account username paired with the app password for Basic auth).
+`BITBUCKET_USERNAME` is required with `BITBUCKET_TOKEN`. For API tokens it is
+the Atlassian account email that owns the token (Bitbucket pairs it with the
+token for REST Basic auth). For git-over-HTTPS, Roomote automatically uses
+Bitbucket's static `x-bitbucket-api-token-auth` user, so no extra configuration
+is needed. Legacy app passwords keep the old semantics until Atlassian removes
+them: set `BITBUCKET_USERNAME` to the Bitbucket account username instead.
 `BITBUCKET_BASE_URL` defaults to `https://bitbucket.org`. Only Bitbucket Cloud
 is accepted; other hosts are rejected.
 

--- a/apps/docs/providers/source-control/bitbucket.mdx
+++ b/apps/docs/providers/source-control/bitbucket.mdx
@@ -8,13 +8,6 @@ Bitbucket Cloud support uses a deployment-owned Atlassian API token paired with
 the Atlassian account email. This MVP covers Bitbucket Cloud only. Bitbucket
 Server and Data Center are not supported yet.
 
-<Note>
-  Bitbucket Cloud app passwords are deprecated. Atlassian runs scheduled
-  brownouts from June 9, 2026 and removes app passwords permanently on July 28,
-  2026. Existing app-password configurations keep working until then, but new
-  setups should use API tokens with scopes.
-</Note>
-
 Repository sync can also create pull request webhooks, allowing Review Code
 automation and `@roomote` pull request comments to work for synced Bitbucket
 Cloud repositories.
@@ -52,12 +45,10 @@ BITBUCKET_BASE_URL=https://bitbucket.org
 BITBUCKET_WEBHOOK_SECRET=<webhook-secret>
 ```
 
-`BITBUCKET_USERNAME` is required with `BITBUCKET_TOKEN`. For API tokens it is
-the Atlassian account email that owns the token (Bitbucket pairs it with the
-token for REST Basic auth). For git-over-HTTPS, Roomote automatically uses
-Bitbucket's static `x-bitbucket-api-token-auth` user, so no extra configuration
-is needed. Legacy app passwords keep the old semantics until Atlassian removes
-them: set `BITBUCKET_USERNAME` to the Bitbucket account username instead.
+`BITBUCKET_USERNAME` is required with `BITBUCKET_TOKEN` and holds the Atlassian
+account email that owns the token (Bitbucket pairs the two for REST auth). For
+git-over-HTTPS, Roomote automatically uses Bitbucket's static
+`x-bitbucket-api-token-auth` user, so no extra configuration is needed.
 `BITBUCKET_BASE_URL` defaults to `https://bitbucket.org`. Only Bitbucket Cloud
 is accepted; other hosts are rejected.
 

--- a/apps/docs/source-control.mdx
+++ b/apps/docs/source-control.mdx
@@ -19,7 +19,7 @@ to review events or comments when the provider supports them.
 | -------- | -------- | ----------- |
 | <IntegrationName href="/providers/source-control/github" icon="github" name="GitHub" /> | GitHub-hosted repositories and pull request review workflows | GitHub App installation (default provider). |
 | <IntegrationName href="/providers/source-control/azure-devops" icon="azuredevops" name="Azure DevOps" /> | Azure DevOps repositories | Deployment-owned PAT and repository sync. |
-| <IntegrationName href="/providers/source-control/bitbucket" icon="bitbucket" name="Bitbucket" /> | Bitbucket Cloud repositories and pull request workflows | Deployment-owned app password and repository sync. |
+| <IntegrationName href="/providers/source-control/bitbucket" icon="bitbucket" name="Bitbucket" /> | Bitbucket Cloud repositories and pull request workflows | Deployment-owned Atlassian API token and repository sync. |
 | <IntegrationName href="/providers/source-control/gitea" icon="gitea" name="Gitea" /> | Self-hosted Gitea repositories | Deployment-owned token and repository sync. |
 | <IntegrationName href="/providers/source-control/gitlab" icon="gitlab" name="GitLab" /> | GitLab projects and merge request review workflows | Deployment-owned token and optional webhooks. |
 

--- a/apps/web/src/app/(onboarding)/setup/sourceControlSetupCopy.ts
+++ b/apps/web/src/app/(onboarding)/setup/sourceControlSetupCopy.ts
@@ -32,7 +32,7 @@ const SOURCE_CONTROL_SETUP_COPY: Record<
     creationHref: 'https://id.atlassian.com/manage-profile/security/api-tokens',
     setupLabel: 'Bitbucket API token',
     creationHint:
-      'Create an API token with scopes covering repository, pull request, and webhook read/write. Prefer a bot or service account that can administer repository webhooks; Roomote syncs repositories and configures pull request webhooks automatically. The Atlassian account email that owns the API token is required.',
+      'Create an API token with scopes covering repository, pull request, and webhook read/write, plus user read (read:user:bitbucket) so Roomote can validate the credentials. Prefer a bot or service account that can administer repository webhooks; Roomote syncs repositories and configures pull request webhooks automatically. The Atlassian account email that owns the API token is required.',
   },
   ado: {
     creationHref: 'https://dev.azure.com/_usersSettings/tokens',

--- a/apps/web/src/app/(onboarding)/setup/sourceControlSetupCopy.ts
+++ b/apps/web/src/app/(onboarding)/setup/sourceControlSetupCopy.ts
@@ -29,10 +29,10 @@ const SOURCE_CONTROL_SETUP_COPY: Record<
       'Create the token with repository access on the instance Roomote should use. Prefer a bot or service account that can administer repository webhooks; Roomote syncs repositories and configures pull request webhooks automatically.',
   },
   bitbucket: {
-    creationHref: 'https://bitbucket.org/account/settings/app-passwords/',
-    setupLabel: 'Bitbucket app password',
+    creationHref: 'https://id.atlassian.com/manage-profile/security/api-tokens',
+    setupLabel: 'Bitbucket API token',
     creationHint:
-      'Create the app password with repository, pull request, and webhook scopes. Prefer a bot or service account that can administer repository webhooks; Roomote syncs repositories and configures pull request webhooks automatically. The Bitbucket username associated with the app password is required.',
+      'Create an API token with scopes covering repository, pull request, and webhook read/write. Prefer a bot or service account that can administer repository webhooks; Roomote syncs repositories and configures pull request webhooks automatically. The Atlassian account email that owns the API token is required.',
   },
   ado: {
     creationHref: 'https://dev.azure.com/_usersSettings/tokens',

--- a/apps/web/src/app/(onboarding)/setup/sourceControlSetupCopy.ts
+++ b/apps/web/src/app/(onboarding)/setup/sourceControlSetupCopy.ts
@@ -32,7 +32,7 @@ const SOURCE_CONTROL_SETUP_COPY: Record<
     creationHref: 'https://id.atlassian.com/manage-profile/security/api-tokens',
     setupLabel: 'Bitbucket API token',
     creationHint:
-      'Create an API token with scopes covering repository, pull request, and webhook read/write, plus user read (read:user:bitbucket) so Roomote can validate the credentials. Prefer a bot or service account that can administer repository webhooks; Roomote syncs repositories and configures pull request webhooks automatically. The Atlassian account email that owns the API token is required.',
+      'Create an API token with scopes covering repository, pull request, and webhook read/write, plus workspace read (read:workspace:bitbucket) and user read (read:user:bitbucket) so Roomote can discover workspaces and validate the credentials. Prefer a bot or service account that can administer repository webhooks; Roomote syncs repositories and configures pull request webhooks automatically. The Atlassian account email that owns the API token is required.',
   },
   ado: {
     creationHref: 'https://dev.azure.com/_usersSettings/tokens',

--- a/apps/web/src/components/settings/SourceControl.tsx
+++ b/apps/web/src/components/settings/SourceControl.tsx
@@ -93,7 +93,7 @@ const TOKEN_PROVIDER_UI = {
   },
   bitbucket: {
     accessibleResource: 'repositories',
-    credentialName: 'app password',
+    credentialName: 'API token',
     repositoryTarget: '_bitbucket',
   },
   ado: {

--- a/apps/web/src/trpc/commands/source-control/index.ts
+++ b/apps/web/src/trpc/commands/source-control/index.ts
@@ -735,7 +735,7 @@ export async function assertValidSourceControlConfigInput(params: {
 
     if (!nextBitbucketUsername) {
       throw new Error(
-        'BITBUCKET_USERNAME is required with BITBUCKET_TOKEN for Bitbucket Cloud App Password authentication.',
+        'BITBUCKET_USERNAME is required with BITBUCKET_TOKEN. Set it to the Atlassian account email that owns the API token.',
       );
     }
 

--- a/packages/bitbucket/src/__tests__/api.test.ts
+++ b/packages/bitbucket/src/__tests__/api.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  BITBUCKET_API_TOKEN_GIT_USERNAME,
   buildBitbucketApiBaseUrl,
   buildBitbucketRepositoryValues,
+  getBitbucketGitUsername,
   normalizeBitbucketLinkedAccountKey,
 } from '../api';
 
@@ -55,6 +57,18 @@ describe('buildBitbucketRepositoryValues', () => {
       linkedByUserId: 'user-1',
     });
     expect(values.cloneUrl).toBe('https://bitbucket.org/acme/roomote.git');
+  });
+});
+
+describe('getBitbucketGitUsername', () => {
+  it('substitutes the static API-token git user when the identity is an Atlassian account email', () => {
+    expect(getBitbucketGitUsername('bot@example.com')).toBe(
+      BITBUCKET_API_TOKEN_GIT_USERNAME,
+    );
+  });
+
+  it('keeps the Bitbucket username for legacy app-password identities', () => {
+    expect(getBitbucketGitUsername('roomote-bot')).toBe('roomote-bot');
   });
 });
 

--- a/packages/bitbucket/src/__tests__/api.test.ts
+++ b/packages/bitbucket/src/__tests__/api.test.ts
@@ -5,8 +5,59 @@ import {
   buildBitbucketApiBaseUrl,
   buildBitbucketRepositoryValues,
   getBitbucketGitUsername,
+  listBitbucketRepositories,
   normalizeBitbucketLinkedAccountKey,
 } from '../api';
+
+describe('listBitbucketRepositories', () => {
+  it('discovers workspaces from memberships and lists repositories per workspace instead of the removed cross-workspace endpoint', async () => {
+    const requestedUrls: string[] = [];
+    const jsonResponse = (body: unknown) =>
+      new Response(JSON.stringify(body), { status: 200 });
+    const fetchImpl = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      requestedUrls.push(url);
+
+      if (url.includes('/user/permissions/workspaces')) {
+        return jsonResponse({
+          values: [
+            { workspace: { slug: 'acme' } },
+            { workspace: { slug: 'beta' } },
+          ],
+        });
+      }
+
+      if (url.includes('/repositories/acme')) {
+        return jsonResponse({
+          values: [{ uuid: '{r1}', name: 'one', full_name: 'acme/one' }],
+        });
+      }
+
+      if (url.includes('/repositories/beta')) {
+        return jsonResponse({
+          values: [{ uuid: '{r2}', name: 'two', full_name: 'beta/two' }],
+        });
+      }
+
+      throw new Error(`unexpected Bitbucket API url: ${url}`);
+    }) as typeof fetch;
+
+    const repositories = await listBitbucketRepositories({
+      token: 'api-token',
+      username: 'bot@example.com',
+      baseUrl: 'https://bitbucket.org',
+      fetchImpl,
+    });
+
+    expect(repositories.map((repository) => repository.full_name)).toEqual([
+      'acme/one',
+      'beta/two',
+    ]);
+    expect(
+      requestedUrls.some((url) => url.includes('/2.0/repositories?')),
+    ).toBe(false);
+  });
+});
 
 describe('buildBitbucketApiBaseUrl', () => {
   it('maps bitbucket.org product host to the Cloud 2.0 API host', () => {

--- a/packages/bitbucket/src/__tests__/api.test.ts
+++ b/packages/bitbucket/src/__tests__/api.test.ts
@@ -10,13 +10,11 @@ import {
 } from '../api';
 
 describe('listBitbucketRepositories', () => {
-  it('discovers workspaces from memberships and lists repositories per workspace instead of the removed cross-workspace endpoint', async () => {
-    const requestedUrls: string[] = [];
+  it('discovers workspaces from memberships and lists repositories per workspace', async () => {
     const jsonResponse = (body: unknown) =>
       new Response(JSON.stringify(body), { status: 200 });
     const fetchImpl = (async (input: RequestInfo | URL) => {
       const url = String(input);
-      requestedUrls.push(url);
 
       if (url.includes('/user/workspaces')) {
         return jsonResponse({
@@ -53,9 +51,6 @@ describe('listBitbucketRepositories', () => {
       'acme/one',
       'beta/two',
     ]);
-    expect(
-      requestedUrls.some((url) => url.includes('/2.0/repositories?')),
-    ).toBe(false);
   });
 });
 
@@ -118,7 +113,7 @@ describe('getBitbucketGitUsername', () => {
     );
   });
 
-  it('keeps the Bitbucket username for legacy app-password identities', () => {
+  it('keeps a non-email identity unchanged', () => {
     expect(getBitbucketGitUsername('roomote-bot')).toBe('roomote-bot');
   });
 });

--- a/packages/bitbucket/src/__tests__/api.test.ts
+++ b/packages/bitbucket/src/__tests__/api.test.ts
@@ -18,7 +18,7 @@ describe('listBitbucketRepositories', () => {
       const url = String(input);
       requestedUrls.push(url);
 
-      if (url.includes('/user/permissions/workspaces')) {
+      if (url.includes('/user/workspaces')) {
         return jsonResponse({
           values: [
             { workspace: { slug: 'acme' } },

--- a/packages/bitbucket/src/api.ts
+++ b/packages/bitbucket/src/api.ts
@@ -468,7 +468,7 @@ export async function validateBitbucketToken({
       return {
         status: 'invalid',
         error:
-          'Bitbucket rejected the credentials. Pair an Atlassian API token with the Atlassian account email (legacy app passwords pair with the Bitbucket username), and confirm the token is active with repository access.',
+          'Bitbucket rejected the credentials. Pair an Atlassian API token with the Atlassian account email (legacy app passwords pair with the Bitbucket username), and confirm the token is active and includes the read:user:bitbucket scope alongside repository access.',
       };
     }
 

--- a/packages/bitbucket/src/api.ts
+++ b/packages/bitbucket/src/api.ts
@@ -76,6 +76,18 @@ const bitbucketPaginatedRepositoriesSchema = z.object({
   next: z.string().nullable().optional(),
 });
 
+const bitbucketWorkspaceMembershipSchema = z.object({
+  workspace: z.object({
+    slug: z.string().optional(),
+    uuid: z.string().optional(),
+  }),
+});
+
+const bitbucketPaginatedWorkspaceMembershipsSchema = z.object({
+  values: z.array(bitbucketWorkspaceMembershipSchema),
+  next: z.string().nullable().optional(),
+});
+
 const bitbucketUserSchema = z.object({
   uuid: z.string().optional(),
   account_id: z.string().optional(),
@@ -497,36 +509,72 @@ export async function listBitbucketRepositories({
     fetchImpl,
   });
 
-  const repositoriesList: BitbucketRepository[] = [];
-  let nextUrl: string | null = buildBitbucketApiUrl(
+  // The cross-workspace GET /2.0/repositories?role=... listing was removed by
+  // Bitbucket on April 14, 2026 (changelog CHANGE-2770) and now returns 410
+  // Gone. Repositories must be listed per workspace, with workspaces
+  // discovered from the caller's memberships.
+  const workspaceSlugs: string[] = [];
+  let workspacesUrl: string | null = buildBitbucketApiUrl(
     auth.apiBaseUrl,
-    '/repositories',
-    {
-      role: 'member',
-      pagelen: BITBUCKET_REPOSITORIES_PER_PAGE,
-    },
+    '/user/permissions/workspaces',
+    { pagelen: BITBUCKET_REPOSITORIES_PER_PAGE },
   );
 
-  while (nextUrl) {
+  while (workspacesUrl) {
     const {
       data,
-    }: { data: z.infer<typeof bitbucketPaginatedRepositoriesSchema> } =
-      await requestBitbucketJson({
-        apiBaseUrl: auth.apiBaseUrl,
-        fetchImpl,
-        username: auth.username,
-        token: auth.token,
-        schema: bitbucketPaginatedRepositoriesSchema,
-        absoluteUrl: nextUrl,
-      });
+    }: {
+      data: z.infer<typeof bitbucketPaginatedWorkspaceMembershipsSchema>;
+    } = await requestBitbucketJson({
+      apiBaseUrl: auth.apiBaseUrl,
+      fetchImpl,
+      username: auth.username,
+      token: auth.token,
+      schema: bitbucketPaginatedWorkspaceMembershipsSchema,
+      absoluteUrl: workspacesUrl,
+    });
 
-    repositoriesList.push(...data.values);
+    for (const membership of data.values) {
+      const slug = membership.workspace.slug?.trim();
 
-    if (stopAfter !== undefined && repositoriesList.length >= stopAfter) {
-      return repositoriesList.slice(0, stopAfter);
+      if (slug) {
+        workspaceSlugs.push(slug);
+      }
     }
 
-    nextUrl = data.next ?? null;
+    workspacesUrl = data.next ?? null;
+  }
+
+  const repositoriesList: BitbucketRepository[] = [];
+
+  for (const workspaceSlug of workspaceSlugs) {
+    let nextUrl: string | null = buildBitbucketApiUrl(
+      auth.apiBaseUrl,
+      `/repositories/${encodeURIComponent(workspaceSlug)}`,
+      { pagelen: BITBUCKET_REPOSITORIES_PER_PAGE },
+    );
+
+    while (nextUrl) {
+      const {
+        data,
+      }: { data: z.infer<typeof bitbucketPaginatedRepositoriesSchema> } =
+        await requestBitbucketJson({
+          apiBaseUrl: auth.apiBaseUrl,
+          fetchImpl,
+          username: auth.username,
+          token: auth.token,
+          schema: bitbucketPaginatedRepositoriesSchema,
+          absoluteUrl: nextUrl,
+        });
+
+      repositoriesList.push(...data.values);
+
+      if (stopAfter !== undefined && repositoriesList.length >= stopAfter) {
+        return repositoriesList.slice(0, stopAfter);
+      }
+
+      nextUrl = data.next ?? null;
+    }
   }
 
   return repositoriesList;

--- a/packages/bitbucket/src/api.ts
+++ b/packages/bitbucket/src/api.ts
@@ -203,6 +203,18 @@ function buildAuthorizationHeader(username: string, token: string): string {
   return `Basic ${Buffer.from(`${username}:${token}`).toString('base64')}`;
 }
 
+/**
+ * Static username Bitbucket Cloud accepts for git-over-HTTPS when the secret
+ * is an Atlassian API token. API tokens pair with the Atlassian account email
+ * for REST calls, but git rejects the email form, so git credentials must use
+ * this documented static user instead.
+ */
+export const BITBUCKET_API_TOKEN_GIT_USERNAME = 'x-bitbucket-api-token-auth';
+
+export function getBitbucketGitUsername(username: string): string {
+  return username.includes('@') ? BITBUCKET_API_TOKEN_GIT_USERNAME : username;
+}
+
 function stripUuidBraces(value: string): string {
   return value.replace(/^\{|\}$/g, '');
 }
@@ -374,14 +386,12 @@ async function resolveAuthIdentity({
     };
   }
 
-  // Bitbucket App Passwords require the account username. Discover it from
-  // /user when the operator did not configure BITBUCKET_USERNAME — use a
-  // provisional "x" username is not valid for Basic auth discovery, so require
-  // username for the first call path only when we already have one. Instead,
-  // try OAuth-style Bearer if Basic username is missing? Cloud App Passwords
-  // need username. Force username environment for basic auth.
+  // Bitbucket Cloud Basic auth needs an identity alongside the secret: the
+  // Atlassian account email for API tokens, or the account username for
+  // legacy app passwords. There is no discovery endpoint that works without
+  // it, so the value must be configured up front.
   throw new Error(
-    'BITBUCKET_USERNAME is required with BITBUCKET_TOKEN (Bitbucket App Password username).',
+    'BITBUCKET_USERNAME is required with BITBUCKET_TOKEN. Set it to the Atlassian account email that owns the API token (or the Bitbucket username for a legacy app password).',
   );
 }
 
@@ -458,7 +468,7 @@ export async function validateBitbucketToken({
       return {
         status: 'invalid',
         error:
-          'Bitbucket rejected the token. Confirm the App Password is active and has repository access.',
+          'Bitbucket rejected the credentials. Pair an Atlassian API token with the Atlassian account email (legacy app passwords pair with the Bitbucket username), and confirm the token is active with repository access.',
       };
     }
 
@@ -1200,7 +1210,7 @@ export async function createTaskRunBitbucketCredentials(
     credentials: repositoriesList.map((repository) => ({
       host,
       repositoryFullName: repository.fullName,
-      username: auth.username,
+      username: getBitbucketGitUsername(auth.username),
       token: auth.token,
       originBaseUrl: auth.baseUrl,
     })),

--- a/packages/bitbucket/src/api.ts
+++ b/packages/bitbucket/src/api.ts
@@ -509,14 +509,15 @@ export async function listBitbucketRepositories({
     fetchImpl,
   });
 
-  // The cross-workspace GET /2.0/repositories?role=... listing was removed by
-  // Bitbucket on April 14, 2026 (changelog CHANGE-2770) and now returns 410
-  // Gone. Repositories must be listed per workspace, with workspaces
-  // discovered from the caller's memberships.
+  // Bitbucket removed all cross-workspace listings on April 14, 2026
+  // (changelog CHANGE-2770): GET /2.0/repositories?role=..., /2.0/workspaces,
+  // and /2.0/user/permissions/workspaces all return 410 Gone. The only
+  // supported membership enumeration is the newer GET /2.0/user/workspaces;
+  // repositories must then be listed per workspace.
   const workspaceSlugs: string[] = [];
   let workspacesUrl: string | null = buildBitbucketApiUrl(
     auth.apiBaseUrl,
-    '/user/permissions/workspaces',
+    '/user/workspaces',
     { pagelen: BITBUCKET_REPOSITORIES_PER_PAGE },
   );
 

--- a/packages/bitbucket/src/api.ts
+++ b/packages/bitbucket/src/api.ts
@@ -398,12 +398,11 @@ async function resolveAuthIdentity({
     };
   }
 
-  // Bitbucket Cloud Basic auth needs an identity alongside the secret: the
-  // Atlassian account email for API tokens, or the account username for
-  // legacy app passwords. There is no discovery endpoint that works without
-  // it, so the value must be configured up front.
+  // Bitbucket Cloud REST auth pairs the API token with the Atlassian account
+  // email. There is no discovery endpoint that works without it, so the value
+  // must be configured up front.
   throw new Error(
-    'BITBUCKET_USERNAME is required with BITBUCKET_TOKEN. Set it to the Atlassian account email that owns the API token (or the Bitbucket username for a legacy app password).',
+    'BITBUCKET_USERNAME is required with BITBUCKET_TOKEN. Set it to the Atlassian account email that owns the API token.',
   );
 }
 
@@ -480,7 +479,7 @@ export async function validateBitbucketToken({
       return {
         status: 'invalid',
         error:
-          'Bitbucket rejected the credentials. Pair an Atlassian API token with the Atlassian account email (legacy app passwords pair with the Bitbucket username), and confirm the token is active and includes the read:user:bitbucket scope alongside repository access.',
+          'Bitbucket rejected the credentials. Confirm the API token is active, is paired with the Atlassian account email that owns it, and includes the read:user:bitbucket scope alongside repository access.',
       };
     }
 

--- a/packages/types/src/setup-source-control-config.ts
+++ b/packages/types/src/setup-source-control-config.ts
@@ -311,13 +311,13 @@ function buildProviderFields(
         {
           envVarName: 'BITBUCKET_TOKEN',
           acceptedEnvVarNames: ['BITBUCKET_TOKEN'],
-          label: 'Bitbucket App Password',
+          label: 'Bitbucket API Token',
           secret: true,
         },
         {
           envVarName: 'BITBUCKET_USERNAME',
           acceptedEnvVarNames: ['BITBUCKET_USERNAME'],
-          label: 'Bitbucket Username',
+          label: 'Atlassian Account Email',
         },
         {
           envVarName: 'BITBUCKET_BASE_URL',


### PR DESCRIPTION
## Why

Bitbucket Cloud support landed in #158 but was built against Bitbucket's app-password auth and its cross-workspace repository listing. Both are gone before we ever shipped to a user: Atlassian is removing app passwords entirely on July 28, 2026 (brownouts are already running, and the app-password creation page now shows a removal warning), and the cross-workspace APIs were permanently removed on April 14, 2026 (changelog CHANGE-2770). A fresh Bitbucket setup against the current API fails at both credential validation and repository sync.

This PR makes the integration work against today's Bitbucket Cloud: Atlassian API tokens with scopes for auth, and per-workspace repository listing.

## How the new auth works

API tokens use different identities per surface:

- **REST API**: Basic auth with the Atlassian account **email** + token
- **Git over HTTPS**: the static `x-bitbucket-api-token-auth` user + token (email does not work for git)

So the config stays two required fields, now labeled **Bitbucket API Token** and **Atlassian Account Email**. The env var names (`BITBUCKET_TOKEN`, `BITBUCKET_USERNAME`) are unchanged since they are stored as deployment env vars. Task-run git credentials automatically substitute the static git user when the configured identity is an email.

## Repository sync after CHANGE-2770

`GET /2.0/repositories?role=member`, `/2.0/workspaces`, and `/2.0/user/permissions/workspaces` all return 410 Gone now. Sync enumerates workspaces via the only surviving membership endpoint, `GET /2.0/user/workspaces`, then lists `GET /2.0/repositories/{workspace}` per workspace.

## Required token scopes (documented in the provider docs and onboarding hint)

- `read:repository:bitbucket` + `write:repository:bitbucket` (clone, branches, commits)
- `read:pullrequest:bitbucket` + `write:pullrequest:bitbucket` (PR workflows and comments)
- `read:webhook:bitbucket` + `write:webhook:bitbucket` (automatic webhook setup)
- `read:workspace:bitbucket` (workspace discovery during sync)
- `read:user:bitbucket` (credential validation via `GET /2.0/user`)

Scopes cannot be edited after token creation, so the onboarding copy lists the full set up front. Error messages name the email pairing and the validation scope so a misconfigured token points at its own fix.

Unaffected: webhook HMAC verification, OAuth personal-account linking (already Bearer), clone-URL construction, and webhook-secret auto-generation.

## Validation

- Verified end-to-end against the live Bitbucket API and through the settings UI: credential validation, workspace discovery, and repository sync all succeed with a scoped API token (synced a real workspace repo).
- `@roomote/bitbucket` unit tests including new coverage for git-username substitution and per-workspace listing; web settings, source-control command, and onboarding test suites; `pnpm lint:fast` and `pnpm check-types:fast` all pass.

References: [App password deprecation notice](https://community.atlassian.com/forums/Bitbucket-articles/Deprecation-notice-Bitbucket-Cloud-app-password-brownout/ba-p/3237429), [Using API tokens](https://support.atlassian.com/bitbucket-cloud/docs/using-api-tokens/), [API token permissions](https://support.atlassian.com/bitbucket-cloud/docs/api-token-permissions/)
