### PR TITLE
[Fix] Install Zero CLI into its own npm prefix so it cannot prune sandbox runtime packages

### DIFF
--- a/apps/worker/src/commands/setup/__tests__/agent-clis.test.ts
+++ b/apps/worker/src/commands/setup/__tests__/agent-clis.test.ts
@@ -216,7 +216,7 @@ describe('installZeroCli', () => {
     expect(mockWriteFileSync).not.toHaveBeenCalled();
   });
 
-  it('installs only the zero package when missing', async () => {
+  it('installs zero into its own prefix so npm cannot prune the shared sandbox packages', async () => {
     mockExeca
       .mockResolvedValueOnce(versionResult(MISE_NPM_PATH))
       .mockRejectedValueOnce(new Error('spawn zero ENOENT'))
@@ -232,7 +232,7 @@ describe('installZeroCli', () => {
       [
         'install',
         '--prefix',
-        '/sandbox',
+        '/sandbox/zero-cli',
         '--no-save',
         '--no-package-lock',
         `@zeroxyz/cli@${DEFAULT_ZERO_CLI_VERSION}`,
@@ -243,7 +243,7 @@ describe('installZeroCli', () => {
     );
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       path.join(os.homedir(), '.local', 'bin', 'zero'),
-      '#!/bin/bash\nexec "/sandbox/node_modules/.bin/zero" "$@"\n',
+      '#!/bin/bash\nexec "/sandbox/zero-cli/node_modules/.bin/zero" "$@"\n',
       'utf8',
     );
   });

--- a/apps/worker/src/commands/setup/agent-clis.ts
+++ b/apps/worker/src/commands/setup/agent-clis.ts
@@ -14,6 +14,7 @@ import {
   getZeroCliPackageSpec,
   resolveExpectedOpenCodeCliVersion,
   resolveExpectedZeroCliVersion,
+  resolveZeroCliInstallRoot,
   usesSharedSandboxRuntimePackages,
   ZERO_CLI_PACKAGE_NAME,
 } from './shared-runtime-packages';
@@ -280,7 +281,7 @@ export async function installZeroCli(
   }
 
   const installStartedAt = Date.now();
-  const installRoot = runtimePaths.sandboxRootDir;
+  const installRoot = resolveZeroCliInstallRoot(runtimePaths);
   const installedBinaryPath = resolveInstalledBinaryPath({
     installRoot,
     command: installer.command,

--- a/apps/worker/src/commands/setup/shared-runtime-packages.ts
+++ b/apps/worker/src/commands/setup/shared-runtime-packages.ts
@@ -49,3 +49,14 @@ export function getZeroCliPackageSpec(
 ): string {
   return `${ZERO_CLI_PACKAGE_NAME}@${resolveExpectedZeroCliVersion(env)}`;
 }
+
+/**
+ * The Zero CLI must install into its own npm prefix: `npm install --no-save`
+ * reifies the prefix's node_modules down to just the requested package, so
+ * sharing the sandbox root would delete opencode-ai/node-pty (and vice versa).
+ */
+export function resolveZeroCliInstallRoot(
+  runtimePaths: WorkerRuntimePaths,
+): string {
+  return `${runtimePaths.sandboxRootDir}/zero-cli`;
+}


### PR DESCRIPTION
## Problem

Enabling the Zero integration breaks every subsequent task at environment start:

```
Command failed with exit code 127: opencode serve --hostname 127.0.0.1 --port 33175 ...
/home/roomote/.local/bin/opencode: line 2: /sandbox/node_modules/.bin/opencode: No such file or directory
```

### Root cause

With npm 7+, `npm install --prefix <dir> --no-save <pkg>` reifies the prefix's `node_modules` down to just the requested package's tree — everything else is pruned. (Verified empirically: installing package A then package B this way silently deletes A.)

The worker image bakes `opencode-ai` + `node-pty` into `/sandbox/node_modules`, with `~/.local/bin/opencode` as a shim pointing at `/sandbox/node_modules/.bin/opencode`. When Zero is enabled, `installZeroCli` runs at task start (`run-task.ts`) — before the harness launches `opencode serve` — and installs `@zeroxyz/cli` into that same `/sandbox` prefix. npm prunes `opencode-ai` and `node-pty`, the shim's target vanishes, and `opencode serve` exits 127.

`installAgentClis` already guards against this hazard for its own package set (that's why `getSharedSandboxRuntimePackageSpecs` installs `opencode-ai` and `node-pty` in a single npm command); `installZeroCli` didn't follow the pattern.

## Fix

Install the Zero CLI into a dedicated prefix, `/sandbox/zero-cli`, so the two installs can't reify each other away in either direction. The `~/.local/bin/zero` wrapper now points at `/sandbox/zero-cli/node_modules/.bin/zero`. A new `resolveZeroCliInstallRoot` helper documents the constraint so the prefixes don't get reunified later.

No migration needed: fresh sandboxes start from the baked image with opencode intact, and older sandboxes with `zero` at the legacy location keep working (the version check passes through the existing wrapper).

## Validation

- `agent-clis` unit tests updated to pin the dedicated prefix and wrapper target; all pass
- `lint`, `check-types`, `knip` clean (pre-push hooks)
- Reproduced the npm prune behavior and confirmed the nested-prefix layout isolates installs both ways using a scratch npm prefix