### PR TITLE
Release Roomote 0.1.1

### DIFF
--- a/.changeset/bitbucket-pr-mention-routing.md
+++ b/.changeset/bitbucket-pr-mention-routing.md
@@ -1,5 +1,0 @@
----
-'@roomote/web': patch
----
-
-Bitbucket pull request @mentions now look up active review tasks only within the Bitbucket source-control provider and prefer stable account id/uuid for bot self-detection (with username preferred over nickname), so comment routing is less likely to hit the wrong provider’s task or loop on bot self-replies when nickname and username differ.

--- a/.changeset/diagnostics-mobile-label-stack.md
+++ b/.changeset/diagnostics-mobile-label-stack.md
@@ -1,5 +1,0 @@
----
-'@roomote/web': patch
----
-
-Settings → Misc → Diagnostics stacks each label above its value on small screens, so timestamps, versions, and hashes stay readable instead of wrapping one character per line in the old two-column layout.

--- a/.changeset/pr-footer-configured-github-app-slug.md
+++ b/.changeset/pr-footer-configured-github-app-slug.md
@@ -1,5 +1,0 @@
----
-'@roomote/web': patch
----
-
-GitHub pull request provenance footers (“Follow up by mentioning @…”) now use the deployment’s configured GitHub App slug at write time when one is set, instead of hardcoding `@roomote` whenever prompt-time resolution fell through to the schema default.

--- a/.changeset/render-deploy-main-image-channel.md
+++ b/.changeset/render-deploy-main-image-channel.md
@@ -1,5 +1,0 @@
----
-'@roomote/web': patch
----
-
-The one-click Deploy to Render Blueprint now pulls `ghcr.io/roocodeinc/roomote-app:main` for app services instead of `:develop`, so new Render installs track the stable main image channel (aligned with Railway’s primary deploy button).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file tracks product releases for Roomote (single monorepo version). Automated release entries are prepended by `pnpm run version`.
 
+## 0.1.1 (2026-07-11)
+
+### Patch changes
+
+- Bitbucket pull request @mentions now look up active review tasks only within the Bitbucket source-control provider and prefer stable account id/uuid for bot self-detection (with username preferred over nickname), so comment routing is less likely to hit the wrong provider’s task or loop on bot self-replies when nickname and username differ.
+- Settings → Misc → Diagnostics stacks each label above its value on small screens, so timestamps, versions, and hashes stay readable instead of wrapping one character per line in the old two-column layout.
+- GitHub pull request provenance footers (“Follow up by mentioning @…”) now use the deployment’s configured GitHub App slug at write time when one is set, instead of hardcoding `@roomote` whenever prompt-time resolution fell through to the schema default.
+- The one-click Deploy to Render Blueprint now pulls `ghcr.io/roocodeinc/roomote-app:main` for app services instead of `:develop`, so new Render installs track the stable main image channel (aligned with Railway’s primary deploy button).
+
 ## 0.1.0 (2026-07-11)
 
 ### Minor changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roomote",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "FCL-1.0-ALv2",
   "packageManager": "pnpm@10.29.3",
   "engines": {


### PR DESCRIPTION
Automated Version PR: bumps the product version to `0.1.1` and folds the pending changesets into the root `CHANGELOG.md`.

- **Squash-merge** this PR into `develop` to cut the release.
- The frozen `release/v0.1.1` promote PR to `main` opens automatically after the merge.
- New changesets on `develop` refresh this PR automatically.

## 0.1.1 (2026-07-11)

### Patch changes

- Bitbucket pull request @mentions now look up active review tasks only within the Bitbucket source-control provider and prefer stable account id/uuid for bot self-detection (with username preferred over nickname), so comment routing is less likely to hit the wrong provider’s task or loop on bot self-replies when nickname and username differ.
- Settings → Misc → Diagnostics stacks each label above its value on small screens, so timestamps, versions, and hashes stay readable instead of wrapping one character per line in the old two-column layout.
- GitHub pull request provenance footers (“Follow up by mentioning @…”) now use the deployment’s configured GitHub App slug at write time when one is set, instead of hardcoding `@roomote` whenever prompt-time resolution fell through to the schema default.
- The one-click Deploy to Render Blueprint now pulls `ghcr.io/roocodeinc/roomote-app:main` for app services instead of `:develop`, so new Render installs track the stable main image channel (aligned with Railway’s primary deploy button).
