### PR TITLE
Add native Blaxel standby resume

### DIFF
--- a/apps/bullmq/src/scheduled-jobs/__tests__/sleep-check.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/sleep-check.test.ts
@@ -6,6 +6,7 @@ const {
   mockCreateComputeProviderClient,
   mockGetComputeProviderCapabilities,
   mockDestroyInstance,
+  mockEnterStandby,
   mockGetInstanceStatus,
   mockCreateSnapshot,
   mockFinishRun,
@@ -14,6 +15,7 @@ const {
   mockCreateComputeProviderMutationEventRecorder,
   mockRecordTaskRunEvent,
   mockMarkTaskStartParallelCountEndedAt,
+  mockSyncTaskStateFromRuns,
   mockDbQueryTaskRunsFindFirst,
   captureBullMqMessageMock,
   transactionFn,
@@ -68,6 +70,7 @@ const {
     mockCreateComputeProviderClient: vi.fn() as AnyMock,
     mockGetComputeProviderCapabilities: vi.fn() as AnyMock,
     mockDestroyInstance: vi.fn() as AnyMock,
+    mockEnterStandby: vi.fn() as AnyMock,
     mockGetInstanceStatus: vi.fn() as AnyMock,
     mockCreateSnapshot: vi.fn() as AnyMock,
     mockFinishRun: vi.fn() as AnyMock,
@@ -76,6 +79,7 @@ const {
     mockCreateComputeProviderMutationEventRecorder: vi.fn() as AnyMock,
     mockRecordTaskRunEvent: vi.fn() as AnyMock,
     mockMarkTaskStartParallelCountEndedAt: vi.fn() as AnyMock,
+    mockSyncTaskStateFromRuns: vi.fn() as AnyMock,
     mockDbQueryTaskRunsFindFirst: vi.fn() as AnyMock,
     captureBullMqMessageMock: vi.fn() as AnyMock,
     transactionFn: vi.fn() as AnyMock,
@@ -140,6 +144,10 @@ vi.mock('@roomote/db/server', () => ({
     status: 'status',
     snapshotId: 'snapshotId',
     snapshotRequestedAt: 'snapshotRequestedAt',
+    snapshotCreatedAt: 'snapshotCreatedAt',
+    snapshotFailedAt: 'snapshotFailedAt',
+    sandboxCmdId: 'sandboxCmdId',
+    completedAt: 'completedAt',
     vendor: 'vendor',
     id: 'id',
     taskId: 'taskId',
@@ -157,6 +165,7 @@ vi.mock('@roomote/db/server', () => ({
   createComputeProviderMutationEventRecorder:
     mockCreateComputeProviderMutationEventRecorder,
   markTaskStartParallelCountEndedAt: mockMarkTaskStartParallelCountEndedAt,
+  syncTaskStateFromRuns: mockSyncTaskStateFromRuns,
   recordTaskRunEvent: mockRecordTaskRunEvent,
   resolveComputeProviderEnvValues: vi.fn().mockResolvedValue({}),
 }));
@@ -223,11 +232,16 @@ describe('sleepCheckJob', () => {
       }),
     );
     mockMarkTaskStartParallelCountEndedAt.mockResolvedValue(undefined);
+    mockSyncTaskStateFromRuns.mockResolvedValue(undefined);
     mockCreateComputeProviderClient.mockImplementation(() => ({
       destroyInstance: mockDestroyInstance,
+      enterStandby: mockEnterStandby,
       getInstanceStatus: mockGetInstanceStatus,
     }));
     mockDestroyInstance.mockResolvedValue({});
+    mockEnterStandby.mockImplementation(({ instanceId }) =>
+      Promise.resolve({ resumeHandle: instanceId }),
+    );
     mockGetComputeProviderCapabilities.mockImplementation(() => ({
       supportsSnapshots: true,
     }));
@@ -547,6 +561,58 @@ describe('sleepCheckJob', () => {
         sandboxId: 'modal-resume',
         snapshotIntentId: expect.stringMatching(/^due_sleep-6625-/),
         triggerPath: 'due_sleep',
+      }),
+    );
+  });
+
+  it('retains due Blaxel jobs on standby without creating a snapshot', async () => {
+    const mockJob = {
+      id: 6626,
+      machineId: 'roomote-blaxel-standby',
+      sandboxCmdId: 'worker-command-1',
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Idle,
+      taskPhase: 'waiting_for_prompt',
+      vendor: 'blaxel',
+      taskId: 'task-blaxel-1',
+      snapshotId: null,
+      sleepRequestedAt: null,
+      snapshotRequestedAt: null,
+    };
+
+    mockJobQueries({ dueJobs: [mockJob] });
+    mockGetInstanceStatus.mockResolvedValue({
+      status: 'running',
+      timeoutRemainingMs: 5 * 60 * 60 * 1_000,
+    });
+    returningFn.mockResolvedValue([{ id: 6626 }]);
+
+    await sleepCheckJob();
+
+    expect(mockCreateComputeProviderClient).toHaveBeenCalledWith({
+      provider: 'blaxel',
+      envFallback: {},
+    });
+    expect(mockEnterStandby).toHaveBeenCalledWith({
+      instanceId: 'roomote-blaxel-standby',
+      commandId: 'worker-command-1',
+    });
+    expect(mockCreateSnapshot).not.toHaveBeenCalled();
+    expect(mockDestroyInstance).not.toHaveBeenCalled();
+    expect(setFn).toHaveBeenCalledWith({
+      snapshotId: 'roomote-blaxel-standby',
+      snapshotCreatedAt: expect.any(Date),
+      snapshotFailedAt: null,
+      sleepAt: null,
+      taskPhase: null,
+      status: RunStatus.Completed,
+      completedAt: expect.any(Date),
+    });
+    expect(mockRecordMutation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'blaxel',
+        operation: 'enter_standby',
+        eventType: 'completed',
       }),
     );
   });

--- a/apps/bullmq/src/scheduled-jobs/sleep-check.ts
+++ b/apps/bullmq/src/scheduled-jobs/sleep-check.ts
@@ -3,7 +3,8 @@ import {
   type TaskPhase,
   RunStatus,
   sleepCheckManagedComputeProviders,
-  isSnapshotCapableComputeProvider,
+  isStandbyResumeCapableComputeProvider,
+  isTaskResumeCapableComputeProvider,
   isResumableTaskPayloadKind,
   ACTIVE_TASK_PHASES,
   SNAPSHOT_CHECK_THRESHOLD_MS,
@@ -29,7 +30,10 @@ import {
   resolveComputeProviderEnvValues,
   syncTaskStateFromRuns,
 } from '@roomote/db/server';
-import { createComputeProviderClient } from '@roomote/compute-providers';
+import {
+  createComputeProviderClient,
+  type ComputeProviderClient,
+} from '@roomote/compute-providers';
 import {
   createSnapshot,
   finishRun,
@@ -73,6 +77,7 @@ type SleepCheckJob = Pick<
   | 'vendor'
   | 'taskId'
   | 'snapshotRequestedAt'
+  | 'sandboxCmdId'
   | 'sleepAt'
   | 'sleepRequestedAt'
   | 'startedAt'
@@ -108,6 +113,7 @@ const SLEEP_CHECK_JOB_COLUMNS = {
   vendor: taskRuns.vendor,
   taskId: taskRuns.taskId,
   snapshotRequestedAt: taskRuns.snapshotRequestedAt,
+  sandboxCmdId: taskRuns.sandboxCmdId,
   sleepAt: taskRuns.sleepAt,
   sleepRequestedAt: taskRuns.sleepRequestedAt,
   startedAt: taskRuns.startedAt,
@@ -159,15 +165,14 @@ async function createSleepCheckClient(provider: ComputeProvider) {
 }
 
 /**
- * Whether the sleep action for this job can be a snapshot. Providers that are
- * not snapshot-capable (for example Docker) always fall through to the destroy
- * paths, even for job types that would be resumable on snapshot-capable
- * providers such as Modal, E2B, and Daytona.
+ * Whether the sleep action can preserve this task through either an immutable
+ * snapshot or a provider-native standby handle. Other providers fall through
+ * to the destroy paths.
  */
-function isSnapshotResumableSleepCandidate(job: SleepCheckJob): boolean {
+function isResumableSleepCandidate(job: SleepCheckJob): boolean {
   return (
     isResumableTaskPayloadKind(job.payloadKind) &&
-    isSnapshotCapableComputeProvider(job.vendor)
+    isTaskResumeCapableComputeProvider(job.vendor)
   );
 }
 
@@ -460,7 +465,7 @@ export const sleepCheckJob = async () => {
   }
 
   console.log(
-    `[sleepCheck] Done. Snapshots=${snapshotted}, shutdowns=${shutDown}, failed=${failed}, total=${candidateJobsByMachineId.size}`,
+    `[sleepCheck] Done. Preserved=${snapshotted}, shutdowns=${shutDown}, failed=${failed}, total=${candidateJobsByMachineId.size}`,
   );
 };
 
@@ -594,6 +599,140 @@ async function claimAndSnapshot(
   }
 }
 
+async function claimAndEnterStandby(
+  job: SleepCheckJob,
+  client: ComputeProviderClient,
+  path: SleepCheckPath,
+): Promise<'completed' | 'skipped' | 'error'> {
+  const requestedAt = new Date();
+  const [claimed] = await db
+    .update(taskRuns)
+    .set({ sleepRequestedAt: requestedAt })
+    .where(
+      and(
+        eq(taskRuns.id, job.id),
+        isNull(taskRuns.sleepRequestedAt),
+        isNull(taskRuns.snapshotRequestedAt),
+        isNull(taskRuns.snapshotId),
+      ),
+    )
+    .returning({ id: taskRuns.id });
+
+  if (!claimed) return 'skipped';
+
+  const recordMutation = createComputeProviderMutationEventRecorder(
+    db,
+    { runId: job.id, taskId: job.taskId },
+    { logPrefix: 'sleepCheck', logger: console },
+  );
+
+  await recordSleepCheckEvent(
+    job,
+    'decision',
+    `Claimed standby handoff for task run #${job.id}.`,
+    {
+      path,
+      decision: 'claim_standby',
+      claimedSleepRequestedAt: requestedAt.toISOString(),
+      ...buildSleepCheckDetails(job),
+    },
+  );
+
+  try {
+    if (!client.enterStandby) {
+      throw new Error(`${job.vendor} client does not support standby`);
+    }
+
+    await recordMutation({
+      provider: job.vendor!,
+      operation: 'enter_standby',
+      eventType: 'started',
+      instanceId: job.machineId!,
+      message: `Entering standby for instance ${job.machineId}.`,
+      details: { path, commandId: job.sandboxCmdId ?? null },
+    });
+    const result = await client.enterStandby({
+      instanceId: job.machineId!,
+      commandId: job.sandboxCmdId ?? undefined,
+    });
+    await recordMutation({
+      provider: job.vendor!,
+      operation: 'enter_standby',
+      eventType: 'completed',
+      instanceId: job.machineId!,
+      message: `Instance ${job.machineId} is ready to enter standby.`,
+      details: { path, resumeHandle: result.resumeHandle },
+    });
+
+    const completedAt = new Date();
+    await db.transaction(async (tx) => {
+      await tx
+        .update(taskRuns)
+        .set({
+          snapshotId: result.resumeHandle,
+          snapshotCreatedAt: completedAt,
+          snapshotFailedAt: null,
+          sleepAt: null,
+          taskPhase: null,
+          status: RunStatus.Completed,
+          completedAt,
+        })
+        .where(eq(taskRuns.id, job.id));
+      await syncTaskStateFromRuns(tx, job.taskId);
+      await markTaskStartParallelCountEndedAt(tx, {
+        runId: job.id,
+        endedAt: completedAt,
+      });
+    });
+
+    await recordSleepCheckEvent(
+      job,
+      'completed',
+      `Retained Blaxel sandbox ${job.machineId} on standby for task run #${job.id}.`,
+      {
+        path,
+        decision: 'standby_completed',
+        resumeHandle: result.resumeHandle,
+        ...buildSleepCheckDetails(job),
+      },
+    );
+
+    return 'completed';
+  } catch (error) {
+    await db
+      .update(taskRuns)
+      .set({ sleepRequestedAt: null })
+      .where(eq(taskRuns.id, job.id))
+      .catch(() => {});
+
+    await recordSleepCheckEvent(
+      job,
+      'failed',
+      `Standby handoff failed for task run #${job.id}.`,
+      {
+        path,
+        decision: 'standby_failed',
+        clearedSleepRequestedAt: true,
+        error: error instanceof Error ? error.message : String(error),
+        ...buildSleepCheckDetails(job),
+      },
+    );
+    return 'error';
+  }
+}
+
+async function claimResumableSleep(
+  job: SleepCheckJob,
+  client: ComputeProviderClient,
+  path: SleepCheckPath,
+): Promise<boolean> {
+  if (isStandbyResumeCapableComputeProvider(job.vendor)) {
+    return (await claimAndEnterStandby(job, client, path)) === 'completed';
+  }
+
+  return (await claimAndSnapshot(job, path)) === 'enqueued';
+}
+
 /**
  * Merge candidate jobs by machine ID while keeping the newest row per category.
  */
@@ -660,7 +799,7 @@ async function handleTimedSleepCandidate(params: {
   client: ReturnType<typeof createComputeProviderClient>;
 }): Promise<{ snapshotted: number; shutDown: number; failed: number }> {
   const { job, path, status, timeoutRemainingMs, client } = params;
-  const isResumable = isSnapshotResumableSleepCandidate(job);
+  const isResumable = isResumableSleepCandidate(job);
   const sleepRequestedAt = new Date();
 
   if (status === 'snapshotting') {
@@ -766,10 +905,14 @@ async function handleTimedSleepCandidate(params: {
   }
 
   if (isResumable) {
-    const result = await claimAndSnapshot(job, path);
+    const preserved = await claimResumableSleep(job, client, path);
 
-    if (result === 'enqueued') {
-      console.log(`[sleepCheck] Enqueued snapshot for task run #${job.id}`);
+    if (preserved) {
+      console.log(
+        isStandbyResumeCapableComputeProvider(job.vendor)
+          ? `[sleepCheck] Retained standby for task run #${job.id}`
+          : `[sleepCheck] Enqueued snapshot for task run #${job.id}`,
+      );
       return { snapshotted: 1, shutDown: 0, failed: 0 };
     }
 
@@ -969,7 +1112,7 @@ async function handleHeartbeatRecoveryCandidate(params: {
   config: HeartbeatRecoveryConfig;
 }): Promise<{ snapshotted: number; failed: number }> {
   const { job, status, client, config } = params;
-  const isResumable = isSnapshotResumableSleepCandidate(job);
+  const isResumable = isResumableSleepCandidate(job);
 
   if (status === 'snapshotting') {
     await recordSnapshotInProgressDecision({
@@ -1036,9 +1179,13 @@ async function handleHeartbeatRecoveryCandidate(params: {
   }
 
   if (isResumable) {
-    const result = await claimAndSnapshot(job, config.path);
-    if (result === 'enqueued') {
-      console.warn(config.snapshottedConsoleMessage(job.id));
+    const preserved = await claimResumableSleep(job, client, config.path);
+    if (preserved) {
+      console.warn(
+        isStandbyResumeCapableComputeProvider(job.vendor)
+          ? `[sleepCheck] Retained standby for ${describeSleepCheckPath(config.path).toLowerCase()} task run #${job.id}`
+          : config.snapshottedConsoleMessage(job.id),
+      );
       return { snapshotted: 1, failed: 0 };
     }
 

--- a/apps/controller/src/compute-providers/__tests__/spawn-blaxel-worker.test.ts
+++ b/apps/controller/src/compute-providers/__tests__/spawn-blaxel-worker.test.ts
@@ -1,0 +1,165 @@
+import type { TaskRun } from '@roomote/db/server';
+import { TaskPayloadKind } from '@roomote/types';
+
+const mockCreateBlaxelMachine = vi.fn();
+const mockRunCommand = vi.fn();
+const mockDestroyInstance = vi.fn();
+const mockEnterStandby = vi.fn();
+const mockRecordMutation = vi.fn();
+const mockUpdateTaskRunMachine = vi.fn();
+const mockGetNamedPortsForTaskRun = vi.fn();
+const mockStampTaskRunMilestone = vi.fn();
+
+vi.mock('@roomote/db/server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@roomote/db/server')>();
+  return {
+    ...actual,
+    db: {
+      ...actual.db,
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+      })),
+    },
+    createComputeProviderMutationEventRecorder: vi.fn(() => mockRecordMutation),
+  };
+});
+
+vi.mock('@roomote/sdk/server', () => ({
+  stampTaskRunMilestone: (...args: unknown[]) =>
+    mockStampTaskRunMilestone(...args),
+}));
+
+vi.mock('@roomote/compute-providers', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@roomote/compute-providers')>();
+  return {
+    ...actual,
+    createBlaxelMachine: (...args: unknown[]) =>
+      mockCreateBlaxelMachine(...args),
+    createComputeProviderClient: vi.fn(() => ({
+      runCommand: mockRunCommand,
+      destroyInstance: mockDestroyInstance,
+      enterStandby: mockEnterStandby,
+    })),
+    buildBlaxelWorkerEnv: vi.fn(() => ({ AUTH_TOKEN: 'auth-token' })),
+  };
+});
+
+vi.mock('../../utils', () => ({
+  getNamedPortsForTaskRun: (...args: unknown[]) =>
+    mockGetNamedPortsForTaskRun(...args),
+  shouldEnableAuthBypassForTaskRun: vi.fn(() => false),
+  updateTaskRunMachine: (...args: unknown[]) =>
+    mockUpdateTaskRunMachine(...args),
+}));
+
+vi.mock('../../sandbox-oidc', () => ({
+  primeEnvironmentOidcForMachine: vi.fn(),
+}));
+
+const { spawnBlaxelWorker } = await import('../spawn-blaxel-worker');
+
+describe('spawnBlaxelWorker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetNamedPortsForTaskRun.mockResolvedValue({
+      namedPorts: [],
+      environmentSnapshotId: undefined,
+      environmentConfig: undefined,
+    });
+    mockCreateBlaxelMachine.mockResolvedValue({
+      machineId: 'roomote-blaxel-standby',
+      sourceSnapshotId: 'roomote-blaxel-standby',
+      proxyPorts: {},
+      domain: vi.fn(),
+    });
+    mockRunCommand.mockResolvedValue({
+      exitCode: null,
+      commandId: 'worker-command-2',
+    });
+    mockEnterStandby.mockResolvedValue({
+      resumeHandle: 'roomote-blaxel-standby',
+    });
+  });
+
+  it('reconnects SnapshotResume runs using task standby mode', async () => {
+    await spawnBlaxelWorker(
+      {
+        id: 321,
+        taskId: 'task-321',
+        vendor: 'blaxel',
+        payloadKind: TaskPayloadKind.SnapshotResume,
+        sourceSnapshotId: 'roomote-blaxel-standby',
+        payload: { repo: 'test/repo' },
+      } as TaskRun,
+      'auth-token',
+      {
+        blaxelApiKey: 'key',
+        blaxelWorkspace: 'workspace',
+        blaxelImage: 'sandbox/roomote-worker:test',
+        blaxelTimeoutMs: 5 * 60 * 60 * 1_000,
+      },
+    );
+
+    expect(mockCreateBlaxelMachine).toHaveBeenCalledWith(
+      expect.objectContaining({
+        launchMode: 'task_standby',
+        resumeHandle: 'roomote-blaxel-standby',
+      }),
+    );
+    expect(mockStampTaskRunMilestone).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 321,
+        launchMode: 'task_standby',
+      }),
+    );
+    expect(mockUpdateTaskRunMachine).toHaveBeenCalledWith(
+      expect.objectContaining({
+        machineId: 'roomote-blaxel-standby',
+        sourceSnapshotId: 'roomote-blaxel-standby',
+      }),
+    );
+    expect(mockRunCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instanceId: 'roomote-blaxel-standby',
+        cmd: 'worker',
+        args: ['run', '321'],
+        detached: true,
+      }),
+    );
+  });
+
+  it('preserves the standby sandbox when launching the resumed worker fails', async () => {
+    mockRunCommand.mockResolvedValue({
+      exitCode: 17,
+      commandId: 'worker-command-failed',
+      stderr: 'worker failed',
+    });
+
+    await expect(
+      spawnBlaxelWorker(
+        {
+          id: 322,
+          taskId: 'task-322',
+          vendor: 'blaxel',
+          payloadKind: TaskPayloadKind.SnapshotResume,
+          sourceSnapshotId: 'roomote-blaxel-standby',
+          payload: { repo: 'test/repo' },
+        } as TaskRun,
+        'auth-token',
+        {
+          blaxelApiKey: 'key',
+          blaxelWorkspace: 'workspace',
+          blaxelImage: 'sandbox/roomote-worker:test',
+          blaxelTimeoutMs: 5 * 60 * 60 * 1_000,
+        },
+      ),
+    ).rejects.toThrow('Detached Blaxel worker exited with code 17');
+
+    expect(mockEnterStandby).toHaveBeenCalledWith({
+      instanceId: 'roomote-blaxel-standby',
+      commandId: 'worker-command-failed',
+    });
+    expect(mockDestroyInstance).not.toHaveBeenCalled();
+  });
+});

--- a/apps/controller/src/compute-providers/spawn-blaxel-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-blaxel-worker.ts
@@ -41,13 +41,27 @@ export async function spawnBlaxelWorker(
     blaxelTags?: Record<string, string>;
   },
 ): Promise<{ machineId: string; sandboxCmdId?: string }> {
-  if (
-    taskRun.payloadKind === TaskPayloadKind.SnapshotEnvironment ||
-    taskRun.payloadKind === TaskPayloadKind.SnapshotResume
-  ) {
+  if (taskRun.payloadKind === TaskPayloadKind.SnapshotEnvironment) {
     throw new NonRetryableSpawnError(
       'Blaxel does not support Roomote environment snapshots',
     );
+  }
+
+  let launchOptions:
+    | { launchMode: 'fresh' }
+    | { launchMode: 'task_standby'; resumeHandle: string };
+  if (taskRun.payloadKind === TaskPayloadKind.SnapshotResume) {
+    if (!taskRun.sourceSnapshotId) {
+      throw new NonRetryableSpawnError(
+        `SnapshotResume task run #${taskRun.id} missing sourceSnapshotId`,
+      );
+    }
+    launchOptions = {
+      launchMode: 'task_standby',
+      resumeHandle: taskRun.sourceSnapshotId,
+    };
+  } else {
+    launchOptions = { launchMode: 'fresh' };
   }
 
   const { namedPorts, environmentConfig } =
@@ -64,8 +78,9 @@ export async function spawnBlaxelWorker(
     : undefined;
   const environmentId = taskRun.payload.environmentId;
   const mutationContext = {
-    launchMode: 'fresh' as const,
-    sourceSnapshotId: null,
+    launchMode: launchOptions.launchMode,
+    sourceSnapshotId:
+      'resumeHandle' in launchOptions ? launchOptions.resumeHandle : null,
     ports: namedPorts.map(({ port }) => port),
   };
   const recordMutation = createComputeProviderMutationEventRecorder(
@@ -87,7 +102,7 @@ export async function spawnBlaxelWorker(
   await stampTaskRunMilestone({
     runId: taskRun.id,
     field: 'provisionStartedAt',
-    launchMode: 'fresh',
+    launchMode: launchOptions.launchMode,
   });
   const machine = await createBlaxelMachine({
     blaxelApiKey: config.blaxelApiKey,
@@ -102,8 +117,10 @@ export async function spawnBlaxelWorker(
     bootstrapTimeoutMs: 120_000,
     computeClient,
     onMutation: recordMutation,
+    ...launchOptions,
   });
 
+  let launchedCommandId: string | undefined;
   try {
     await updateTaskRunMachine({
       taskRun,
@@ -115,7 +132,7 @@ export async function spawnBlaxelWorker(
       explicitPrimaryPortName: getPrimaryPortFromConfig(
         environmentConfig?.ports,
       )?.name,
-      sourceSnapshotId: null,
+      sourceSnapshotId: machine.sourceSnapshotId ?? null,
       authBypassValue,
       authBypassHeaderName,
     });
@@ -131,7 +148,10 @@ export async function spawnBlaxelWorker(
         computeProvider: 'blaxel',
         computeProviderId: machine.machineId,
         runId: taskRun.id,
-        context: 'Fresh Blaxel launch',
+        context:
+          launchOptions.launchMode === 'task_standby'
+            ? 'Standby-resumed Blaxel launch'
+            : 'Fresh Blaxel launch',
       });
     }
 
@@ -164,6 +184,7 @@ export async function spawnBlaxelWorker(
       detached: true,
       signal: AbortSignal.timeout(60_000),
     });
+    launchedCommandId = result.commandId;
     if (result.exitCode !== null && result.exitCode !== 0) {
       throw new Error(
         `Detached Blaxel worker exited with code ${result.exitCode}: ${result.stderr ?? result.stdout ?? 'no output'}`,
@@ -191,11 +212,27 @@ export async function spawnBlaxelWorker(
       ...(result.commandId ? { sandboxCmdId: result.commandId } : {}),
     };
   } catch (error) {
-    await computeClient
-      .destroyInstance({ instanceId: machine.machineId })
-      .catch((cleanupError) => {
-        console.error('[spawnBlaxelWorker] Cleanup failed', cleanupError);
-      });
+    if (launchOptions.launchMode === 'task_standby') {
+      // This is the only copy of the task's mutable state. Preserve it for a
+      // controller retry instead of applying the fresh-launch cleanup rule.
+      await computeClient
+        .enterStandby?.({
+          instanceId: machine.machineId,
+          commandId: launchedCommandId,
+        })
+        .catch((cleanupError) => {
+          console.error(
+            '[spawnBlaxelWorker] Failed to restore standby after resume failure',
+            cleanupError,
+          );
+        });
+    } else {
+      await computeClient
+        .destroyInstance({ instanceId: machine.machineId })
+        .catch((cleanupError) => {
+          console.error('[spawnBlaxelWorker] Cleanup failed', cleanupError);
+        });
+    }
     throw error;
   }
 }

--- a/apps/docs/compute.mdx
+++ b/apps/docs/compute.mdx
@@ -37,13 +37,13 @@ You configure sandbox providers during setup and can change them later from
 
 Roomote supports local and hosted sandbox backends:
 
-| Provider                                                                            | Best for                                               | Notes                                                                           |
-| ----------------------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------- |
-| <IntegrationName href="/providers/compute/docker" icon="docker" name="Docker" />    | Local development and trusted single-host self-hosting | Runs task sandboxes as Docker containers on the same machine as the deployment. |
-| <IntegrationName href="/providers/compute/modal" icon="modal" name="Modal" />       | Hosted task sandboxes with snapshot support            | Uses a hosted runtime and can resume some sandboxes from snapshots.             |
-| <IntegrationName href="/providers/compute/e2b" icon="e2b" name="E2B" />             | Hosted task sandboxes with snapshot support            | Uses a hosted template created from the Roomote worker image.                   |
-| <IntegrationName href="/providers/compute/daytona" icon="daytona" name="Daytona" /> | Hosted task sandboxes with snapshot support            | Uses a registered worker snapshot and can resume some sandboxes from product snapshots. |
-| <IntegrationName href="/providers/compute/blaxel" icon="blaxel" name="Blaxel" />    | Hosted perpetual task sandboxes                        | Uses a Blaxel-built Roomote worker image with automatic standby; Roomote snapshots are not supported. |
+| Provider                                                                            | Best for                                               | Notes                                                                                                        |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| <IntegrationName href="/providers/compute/docker" icon="docker" name="Docker" />    | Local development and trusted single-host self-hosting | Runs task sandboxes as Docker containers on the same machine as the deployment.                              |
+| <IntegrationName href="/providers/compute/modal" icon="modal" name="Modal" />       | Hosted task sandboxes with snapshot support            | Uses a hosted runtime and can resume some sandboxes from snapshots.                                          |
+| <IntegrationName href="/providers/compute/e2b" icon="e2b" name="E2B" />             | Hosted task sandboxes with snapshot support            | Uses a hosted template created from the Roomote worker image.                                                |
+| <IntegrationName href="/providers/compute/daytona" icon="daytona" name="Daytona" /> | Hosted task sandboxes with snapshot support            | Uses a registered worker snapshot and can resume some sandboxes from product snapshots.                      |
+| <IntegrationName href="/providers/compute/blaxel" icon="blaxel" name="Blaxel" />    | Hosted perpetual task sandboxes                        | Resumable tasks retain their sandbox on automatic standby; reusable environment snapshots are not supported. |
 
 Docker is the default because it works well for local development and simple
 self-hosted deployments. Hosted providers are useful when you want task work to

--- a/apps/docs/providers/compute/blaxel.mdx
+++ b/apps/docs/providers/compute/blaxel.mdx
@@ -12,8 +12,9 @@ preview URLs, and starts the task worker as a keep-alive process.
 
 Use Blaxel when task work should run outside the Roomote host and you want
 provider-managed microVMs with automatic standby and fast wake-up. Blaxel does
-not currently support Roomote environment snapshots; snapshot-based task and
-environment workflows remain available with Modal, E2B, and Daytona.
+not currently support Roomote environment snapshots, but resumable tasks retain
+their existing Blaxel sandbox on standby. Reusable snapshot-based environment
+workflows remain available with Modal, E2B, and Daytona.
 
 ## Configuration
 
@@ -43,7 +44,17 @@ BLAXEL_REGION=us-pdx-1
 - Each exposed port receives a public Blaxel preview URL. Roomote's preview
   proxy remains the user-facing authentication layer.
 - The detached worker process uses Blaxel keep-alive while the task is active.
-- Roomote's sleep-check lifecycle destroys the sandbox when the task finishes.
+- When a resumable task goes to sleep, Roomote stops its worker, extends the
+  sandbox lifetime to seven days, and lets Blaxel move the sandbox to standby.
+  A follow-up reconnects to the same sandbox and launches a new worker without
+  reinstalling the workspace.
+- Non-resumable workflows are still destroyed when their sleep deadline is
+  reached. A standby sandbox is also deleted when its seven-day resume window
+  expires.
+
+Blaxel standby is intentionally separate from Roomote environment snapshots.
+A standby handle reconnects to one mutable sandbox; it cannot be cloned or
+reused as a clean environment template.
 
 ## Verify setup
 

--- a/apps/worker/src/run-task/__tests__/wait-for-external-sleep-action.test.ts
+++ b/apps/worker/src/run-task/__tests__/wait-for-external-sleep-action.test.ts
@@ -146,6 +146,48 @@ describe('waitForExternalSleepAction', () => {
     expect(findRuntimeStateByIdMock).toHaveBeenCalledWith(789);
   });
 
+  it('waits for BullMQ to retain a resumable Blaxel sandbox on standby', async () => {
+    findRuntimeStateByIdMock
+      .mockResolvedValueOnce({
+        sleepRequestedAt: new Date(),
+        snapshotRequestedAt: null,
+        snapshotCreatedAt: null,
+        snapshotFailedAt: null,
+        error: null,
+        status: RunStatus.Idle,
+      })
+      .mockResolvedValueOnce({
+        sleepRequestedAt: new Date(),
+        snapshotRequestedAt: null,
+        snapshotCreatedAt: new Date(),
+        snapshotFailedAt: null,
+        error: null,
+        status: RunStatus.Completed,
+      });
+
+    const logger = {
+      runId: 790,
+      filePath: '/tmp/test.log',
+      log: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const result = await waitForExternalSleepAction({
+      taskRun: {
+        id: 790,
+        payloadKind: TaskPayloadKind.StandardTask,
+        vendor: 'blaxel',
+        machineId: 'roomote-blaxel-790',
+      } as never,
+      logger,
+    });
+
+    expect(result).toEqual({ claimed: true, completed: true });
+    expect(findRuntimeStateByIdMock).toHaveBeenCalledWith(790);
+  });
+
   it('skips jobs on non-snapshot-capable providers', async () => {
     const logger = {
       runId: 123,

--- a/apps/worker/src/run-task/wait-for-external-sleep-action.ts
+++ b/apps/worker/src/run-task/wait-for-external-sleep-action.ts
@@ -3,7 +3,7 @@ import pWaitFor from 'p-wait-for';
 import {
   isExitedRunStatus,
   isSleepCheckManagedComputeProvider,
-  isSnapshotCapableComputeProvider,
+  isTaskResumeCapableComputeProvider,
   isResumableTaskPayloadKind,
 } from '@roomote/types';
 import { type DequeuedTaskRun, sdk } from '@roomote/sdk/client';
@@ -56,10 +56,11 @@ export async function waitForExternalSleepAction({
     return { claimed: false, completed: false };
   }
 
-  // Non-snapshot providers exit via destroy, never via snapshot.
+  // Resumable providers complete via either an immutable snapshot or a
+  // provider-native standby handle. Other providers exit via destroy.
   const isResumable =
     isResumableTaskPayloadKind(taskRun.payloadKind) &&
-    isSnapshotCapableComputeProvider(taskRun.vendor);
+    isTaskResumeCapableComputeProvider(taskRun.vendor);
   let sleepRequested = false;
 
   try {

--- a/packages/compute-providers/src/__tests__/adapters.contract.test.ts
+++ b/packages/compute-providers/src/__tests__/adapters.contract.test.ts
@@ -68,12 +68,14 @@ const {
   blaxelGetMock,
   blaxelListMock,
   blaxelDeleteMock,
+  blaxelUpdateTtlMock,
   blaxelSettingsMock,
 } = vi.hoisted(() => ({
   blaxelCreateMock: vi.fn(),
   blaxelGetMock: vi.fn(),
   blaxelListMock: vi.fn(),
   blaxelDeleteMock: vi.fn(),
+  blaxelUpdateTtlMock: vi.fn(),
   blaxelSettingsMock: vi.fn(),
 }));
 
@@ -84,6 +86,7 @@ vi.mock('@blaxel/core', () => ({
     get: blaxelGetMock,
     list: blaxelListMock,
     delete: blaxelDeleteMock,
+    updateTtl: blaxelUpdateTtlMock,
   },
 }));
 
@@ -115,6 +118,9 @@ describe('compute provider adapter contracts', () => {
         createIfNotExists: vi.fn().mockImplementation(async (preview) => ({
           spec: { url: `https://${preview.spec.port}.blaxel.test` },
         })),
+        create: vi.fn().mockImplementation(async (preview) => ({
+          spec: { url: `https://${preview.spec.port}.blaxel.test` },
+        })),
       },
       process: {
         exec: vi.fn().mockResolvedValue({
@@ -130,6 +136,7 @@ describe('compute provider adapter contracts', () => {
           stderr: '',
         }),
         logs: vi.fn().mockResolvedValue('hello'),
+        stop: vi.fn().mockResolvedValue(undefined),
       },
       fs: { writeBinary: vi.fn().mockResolvedValue(undefined) },
     };
@@ -141,6 +148,7 @@ describe('compute provider adapter contracts', () => {
       },
     });
     blaxelDeleteMock.mockResolvedValue(undefined);
+    blaxelUpdateTtlMock.mockResolvedValue(sandbox);
 
     const client = createComputeProviderClient({
       provider: 'blaxel',
@@ -156,6 +164,8 @@ describe('compute provider adapter contracts', () => {
       workspace: 'workspace',
     });
     expect(client.capabilities.supportsSnapshots).toBe(false);
+    expect(client.capabilities.supportsStandbyResume).toBe(true);
+    expect(client.capabilities.supportsResume).toBe(true);
 
     const created = await client.createInstance({ ports: [3000] });
     expect(created.domains).toEqual({
@@ -204,6 +214,34 @@ describe('compute provider adapter contracts', () => {
     await expect(
       client.createSnapshot({ instanceId: created.instanceId }),
     ).rejects.toThrow('does not support Roomote snapshots');
+    await expect(
+      client.enterStandby?.({
+        instanceId: created.instanceId,
+        commandId: 'cmd-1',
+      }),
+    ).resolves.toEqual({ resumeHandle: created.instanceId });
+    expect(blaxelUpdateTtlMock).toHaveBeenCalledWith(created.instanceId, '7d');
+    expect(sandbox.process.stop).toHaveBeenCalledWith('cmd-1');
+
+    await expect(
+      client.resumeFromStandby?.({
+        resumeHandle: created.instanceId,
+        ports: [3000],
+      }),
+    ).resolves.toMatchObject({
+      instanceId: created.instanceId,
+      sourceSnapshotId: created.instanceId,
+      status: 'running',
+      domains: { '3000': 'https://3000.blaxel.test' },
+    });
+    expect(blaxelUpdateTtlMock).toHaveBeenLastCalledWith(
+      created.instanceId,
+      '120s',
+    );
+    expect(sandbox.previews.create).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: { name: 'port-3000' } }),
+      true,
+    );
     await client.destroyInstance({ instanceId: created.instanceId });
     expect(blaxelDeleteMock).toHaveBeenCalledWith(created.instanceId);
   });

--- a/packages/compute-providers/src/adapters/blaxel.ts
+++ b/packages/compute-providers/src/adapters/blaxel.ts
@@ -18,6 +18,8 @@ import type {
   CreatedInstance,
   DestroyInstanceInput,
   DestroyInstanceResult,
+  EnterStandbyInput,
+  EnterStandbyResult,
   GetCommandOutputInput,
   GetInstanceDomainsInput,
   GetInstanceDomainsResult,
@@ -26,6 +28,7 @@ import type {
   InstanceSummary,
   ListInstancesInput,
   ResumeInstanceInput,
+  ResumeFromStandbyInput,
   RunCommandInput,
   RunCommandResult,
   StreamCommandOutputInput,
@@ -36,6 +39,7 @@ const STREAM_POLL_INTERVAL_MS = 1_000;
 const WORKLOAD_READY_RETRY_BUDGET_MS = 60_000;
 const WORKLOAD_READY_INITIAL_DELAY_MS = 500;
 const WORKLOAD_READY_MAX_DELAY_MS = 30_000;
+const BLAXEL_STANDBY_TTL = '7d';
 
 export class BlaxelClient implements ComputeProviderClient {
   public readonly vendor: ComputeProvider = 'blaxel';
@@ -146,6 +150,69 @@ export class BlaxelClient implements ComputeProviderClient {
       if (!isNotFound(error)) throw error;
     }
     return {};
+  }
+
+  public async enterStandby(
+    input: EnterStandbyInput,
+  ): Promise<EnterStandbyResult> {
+    throwIfAborted(input.signal);
+
+    await raceWithAbort({
+      promise: SandboxInstance.updateTtl(input.instanceId, BLAXEL_STANDBY_TTL),
+      signal: input.signal,
+      abortMessage: `Extending standby TTL for Blaxel sandbox ${input.instanceId} was aborted`,
+    });
+
+    if (input.commandId) {
+      const sandbox = await this.getSandbox(input.instanceId, input.signal);
+      try {
+        await retryWorkloadUnavailable({
+          operation: () =>
+            raceWithAbort({
+              promise: sandbox.process.stop(input.commandId!),
+              signal: input.signal,
+              abortMessage: `Stopping worker ${input.commandId} in Blaxel sandbox ${input.instanceId} was aborted`,
+            }),
+          signal: input.signal,
+          description: `stopping worker ${input.commandId} in Blaxel sandbox ${input.instanceId}`,
+        });
+      } catch (error) {
+        // The worker may have completed between the scheduler deciding to put
+        // the sandbox on standby and the stop request reaching Blaxel.
+        if (!isNotFound(error)) throw error;
+      }
+    }
+
+    return { resumeHandle: input.instanceId };
+  }
+
+  public async resumeFromStandby(
+    input: ResumeFromStandbyInput,
+  ): Promise<CreatedInstance> {
+    throwIfAborted(input.signal);
+
+    await raceWithAbort({
+      promise: SandboxInstance.updateTtl(
+        input.resumeHandle,
+        this.ttl() ?? null,
+      ),
+      signal: input.signal,
+      abortMessage: `Restoring active TTL for Blaxel sandbox ${input.resumeHandle} was aborted`,
+    });
+    const sandbox = await this.getSandbox(input.resumeHandle, input.signal);
+    const domains = await this.createPreviewDomains(
+      sandbox,
+      input.ports ?? [],
+      input.signal,
+      true,
+    );
+
+    return {
+      instanceId: input.resumeHandle,
+      sourceSnapshotId: input.resumeHandle,
+      status: 'running',
+      domains,
+    };
   }
 
   public async getInstanceDomains(
@@ -305,14 +372,23 @@ export class BlaxelClient implements ComputeProviderClient {
     sandbox: SandboxInstance,
     ports: number[],
     signal?: AbortSignal,
+    refresh = false,
   ): Promise<Record<string, string>> {
     const domains: Record<string, string> = {};
     for (const port of ports) {
       const preview = await raceWithAbort({
-        promise: sandbox.previews.createIfNotExists({
-          metadata: { name: `port-${port}` },
-          spec: { port, public: true, ttl: this.ttl() },
-        }),
+        promise: refresh
+          ? sandbox.previews.create(
+              {
+                metadata: { name: `port-${port}` },
+                spec: { port, public: true, ttl: this.ttl() },
+              },
+              true,
+            )
+          : sandbox.previews.createIfNotExists({
+              metadata: { name: `port-${port}` },
+              spec: { port, public: true, ttl: this.ttl() },
+            }),
         signal,
         abortMessage: `Creating Blaxel preview for port ${port} was aborted`,
       });

--- a/packages/compute-providers/src/blaxel/create-blaxel-machine.test.ts
+++ b/packages/compute-providers/src/blaxel/create-blaxel-machine.test.ts
@@ -1,0 +1,54 @@
+import { getWorkerRelease } from '../sandbox/worker-release-cache';
+
+import { createBlaxelMachine } from './create-blaxel-machine';
+
+vi.mock('../sandbox/worker-release-cache', () => ({
+  getWorkerRelease: vi.fn(),
+}));
+
+const mockGetWorkerRelease = vi.mocked(getWorkerRelease);
+
+describe('createBlaxelMachine', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reconnects task standby without reinstalling the shipped runtime', async () => {
+    const resumeFromStandby = vi.fn().mockResolvedValue({
+      instanceId: 'roomote-blaxel-standby',
+      sourceSnapshotId: 'roomote-blaxel-standby',
+      domains: {},
+    });
+    const writeFiles = vi.fn();
+    const runCommand = vi.fn();
+
+    const machine = await createBlaxelMachine({
+      blaxelApiKey: 'key',
+      blaxelWorkspace: 'workspace',
+      blaxelImage: 'sandbox/roomote-worker:test',
+      launchMode: 'task_standby',
+      resumeHandle: 'roomote-blaxel-standby',
+      computeClient: {
+        vendor: 'blaxel',
+        createInstance: vi.fn(),
+        resumeFromStandby,
+        writeFiles,
+        runCommand,
+        destroyInstance: vi.fn(),
+      },
+    });
+
+    expect(resumeFromStandby).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resumeHandle: 'roomote-blaxel-standby',
+      }),
+    );
+    expect(mockGetWorkerRelease).not.toHaveBeenCalled();
+    expect(writeFiles).not.toHaveBeenCalled();
+    expect(runCommand).not.toHaveBeenCalled();
+    expect(machine).toMatchObject({
+      machineId: 'roomote-blaxel-standby',
+      sourceSnapshotId: 'roomote-blaxel-standby',
+    });
+  });
+});

--- a/packages/compute-providers/src/blaxel/create-blaxel-machine.ts
+++ b/packages/compute-providers/src/blaxel/create-blaxel-machine.ts
@@ -1,4 +1,8 @@
-import { type NamedPort, SANDBOX_FILES_DIR } from '@roomote/types';
+import {
+  type ComputeProviderLaunchMode,
+  type NamedPort,
+  SANDBOX_FILES_DIR,
+} from '@roomote/types';
 
 import { generateProxyPorts, getExposedPorts } from '../environment-machine';
 import { createComputeProviderClient } from '../factory';
@@ -17,7 +21,12 @@ const WORKER_TARBALL_PATH = `${SANDBOX_FILES_DIR}/worker.tar.gz`;
 
 type BlaxelLifecycleClient = Pick<
   ComputeProviderClient,
-  'vendor' | 'createInstance' | 'writeFiles' | 'runCommand' | 'destroyInstance'
+  | 'vendor'
+  | 'createInstance'
+  | 'resumeFromStandby'
+  | 'writeFiles'
+  | 'runCommand'
+  | 'destroyInstance'
 >;
 
 export interface CreateBlaxelMachineOptions {
@@ -40,11 +49,19 @@ export interface CreateBlaxelMachineOptions {
 export interface BlaxelMachine {
   machineId: string;
   proxyPorts: Record<string, number>;
+  sourceSnapshotId?: string;
   domain: (port: number) => string;
 }
 
+export type BlaxelLaunchOptions =
+  | { launchMode: 'fresh'; resumeHandle?: undefined }
+  | { launchMode: 'task_standby'; resumeHandle: string };
+
+export type CreateBlaxelMachineParams = CreateBlaxelMachineOptions &
+  BlaxelLaunchOptions;
+
 export async function createBlaxelMachine(
-  options: CreateBlaxelMachineOptions,
+  options: CreateBlaxelMachineParams,
 ): Promise<BlaxelMachine> {
   const proxyPorts =
     options.proxyPorts ?? generateProxyPorts(options.namedPorts);
@@ -54,9 +71,12 @@ export async function createBlaxelMachine(
     : options.signal;
   throwIfAborted(createSignal);
 
-  const release = options.localTarballPath
-    ? loadLocalWorkerReleaseWithVersion(options.localTarballPath)
-    : await getWorkerRelease();
+  const release =
+    options.launchMode === 'fresh'
+      ? options.localTarballPath
+        ? loadLocalWorkerReleaseWithVersion(options.localTarballPath)
+        : await getWorkerRelease()
+      : undefined;
   const computeClient =
     options.computeClient ??
     createComputeProviderClient({
@@ -78,42 +98,80 @@ export async function createBlaxelMachine(
     | undefined;
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
     try {
+      const operation = options.resumeHandle
+        ? 'resume_from_standby'
+        : 'create_instance';
       await options.onMutation?.({
         provider: 'blaxel',
-        operation: 'create_instance',
+        operation,
         eventType: 'started',
-        message: 'Calling createInstance for Blaxel sandbox.',
-        details: { attempt, launchMode: 'fresh', ports },
-      });
-      created = await computeClient.createInstance({
-        ports,
-        tags: options.tags,
-        metadata: {
-          workerReleaseTag: `worker-v${release.version}`,
-          ...(options.timeoutMs
-            ? { timeoutMs: String(options.timeoutMs) }
-            : {}),
+        message: options.resumeHandle
+          ? `Calling resumeFromStandby for Blaxel sandbox ${options.resumeHandle}.`
+          : 'Calling createInstance for Blaxel sandbox.',
+        details: {
+          attempt,
+          launchMode: options.launchMode as ComputeProviderLaunchMode,
+          sourceSnapshotId: options.resumeHandle ?? null,
+          ports,
         },
-        signal: createSignal,
       });
+      if (options.resumeHandle) {
+        if (!computeClient.resumeFromStandby) {
+          throw new Error(
+            'Blaxel compute client does not support standby resume',
+          );
+        }
+        created = await computeClient.resumeFromStandby({
+          resumeHandle: options.resumeHandle,
+          ports,
+          tags: options.tags,
+          signal: createSignal,
+        });
+      } else {
+        created = await computeClient.createInstance({
+          ports,
+          tags: options.tags,
+          metadata: {
+            ...(release
+              ? { workerReleaseTag: `worker-v${release.version}` }
+              : {}),
+            ...(options.timeoutMs
+              ? { timeoutMs: String(options.timeoutMs) }
+              : {}),
+          },
+          signal: createSignal,
+        });
+      }
       await options.onMutation?.({
         provider: 'blaxel',
-        operation: 'create_instance',
+        operation,
         eventType: 'completed',
         instanceId: created.instanceId,
-        message: `createInstance completed for Blaxel sandbox ${created.instanceId}.`,
-        details: { attempt, launchMode: 'fresh', ports },
+        message: `${
+          options.resumeHandle ? 'resumeFromStandby' : 'createInstance'
+        } completed for Blaxel sandbox ${created.instanceId}.`,
+        details: {
+          attempt,
+          launchMode: options.launchMode as ComputeProviderLaunchMode,
+          sourceSnapshotId: options.resumeHandle ?? null,
+          ports,
+        },
       });
       break;
     } catch (error) {
       await options.onMutation?.({
         provider: 'blaxel',
-        operation: 'create_instance',
+        operation: options.resumeHandle
+          ? 'resume_from_standby'
+          : 'create_instance',
         eventType: 'failed',
-        message: 'createInstance failed for Blaxel sandbox.',
+        message: `${
+          options.resumeHandle ? 'resumeFromStandby' : 'createInstance'
+        } failed for Blaxel sandbox.`,
         details: {
           attempt,
-          launchMode: 'fresh',
+          launchMode: options.launchMode as ComputeProviderLaunchMode,
+          sourceSnapshotId: options.resumeHandle ?? null,
           ports,
           error: error instanceof Error ? error.message : String(error),
         },
@@ -124,63 +182,74 @@ export async function createBlaxelMachine(
   }
   if (!created) throw new Error('Failed to create Blaxel sandbox');
 
-  const bootstrapSignal = options.bootstrapTimeoutMs
-    ? AbortSignal.timeout(options.bootstrapTimeoutMs)
-    : options.signal;
-  try {
-    const { files } = loadSandboxBootstrapFiles(SANDBOX_FILES_DIR);
-    files.push({ path: WORKER_TARBALL_PATH, content: release.archive });
-    await options.onMutation?.({
-      provider: 'blaxel',
-      operation: 'write_files',
-      eventType: 'started',
-      instanceId: created.instanceId,
-      message: `Calling writeFiles for Blaxel sandbox ${created.instanceId}.`,
-      details: { launchMode: 'fresh', ports, fileCount: files.length },
-    });
-    await computeClient.writeFiles({
-      instanceId: created.instanceId,
-      files,
-      signal: bootstrapSignal,
-    });
-    await options.onMutation?.({
-      provider: 'blaxel',
-      operation: 'write_files',
-      eventType: 'completed',
-      instanceId: created.instanceId,
-      message: `writeFiles completed for Blaxel sandbox ${created.instanceId}.`,
-      details: { launchMode: 'fresh', ports, fileCount: files.length },
-    });
-    const install = await computeClient.runCommand({
-      instanceId: created.instanceId,
-      cmd: 'bash',
-      args: [INSTALL_SCRIPT_PATH],
-      // Blaxel's injected sandbox API runs commands as root even when the
-      // source image declares USER roomote. Point HOME back at the worker
-      // user's mise config so the image's pinned Node toolchain is active.
-      env: {
-        HOME: '/home/roomote',
-        WORKER_RELEASE_ARCHIVE_PATH: WORKER_TARBALL_PATH,
-      },
-      signal: bootstrapSignal,
-    });
-    if (install.exitCode !== 0) {
-      throw new Error(
-        `Blaxel worker install failed with exit code ${install.exitCode}: ${install.stderr ?? install.stdout ?? 'no output'}`,
-      );
-    }
-  } catch (error) {
-    await computeClient
-      .destroyInstance({ instanceId: created.instanceId })
-      .catch((cleanupError) => {
-        console.error('[createBlaxelMachine] Cleanup failed', cleanupError);
+  if (release) {
+    const bootstrapSignal = options.bootstrapTimeoutMs
+      ? AbortSignal.timeout(options.bootstrapTimeoutMs)
+      : options.signal;
+    try {
+      const { files } = loadSandboxBootstrapFiles(SANDBOX_FILES_DIR);
+      files.push({ path: WORKER_TARBALL_PATH, content: release.archive });
+      await options.onMutation?.({
+        provider: 'blaxel',
+        operation: 'write_files',
+        eventType: 'started',
+        instanceId: created.instanceId,
+        message: `Calling writeFiles for Blaxel sandbox ${created.instanceId}.`,
+        details: {
+          launchMode: options.launchMode,
+          ports,
+          fileCount: files.length,
+        },
       });
-    throw error;
+      await computeClient.writeFiles({
+        instanceId: created.instanceId,
+        files,
+        signal: bootstrapSignal,
+      });
+      await options.onMutation?.({
+        provider: 'blaxel',
+        operation: 'write_files',
+        eventType: 'completed',
+        instanceId: created.instanceId,
+        message: `writeFiles completed for Blaxel sandbox ${created.instanceId}.`,
+        details: {
+          launchMode: options.launchMode,
+          ports,
+          fileCount: files.length,
+        },
+      });
+      const install = await computeClient.runCommand({
+        instanceId: created.instanceId,
+        cmd: 'bash',
+        args: [INSTALL_SCRIPT_PATH],
+        // Blaxel's injected sandbox API runs commands as root even when the
+        // source image declares USER roomote. Point HOME back at the worker
+        // user's mise config so the image's pinned Node toolchain is active.
+        env: {
+          HOME: '/home/roomote',
+          WORKER_RELEASE_ARCHIVE_PATH: WORKER_TARBALL_PATH,
+        },
+        signal: bootstrapSignal,
+      });
+      if (install.exitCode !== 0) {
+        throw new Error(
+          `Blaxel worker install failed with exit code ${install.exitCode}: ${install.stderr ?? install.stdout ?? 'no output'}`,
+        );
+      }
+    } catch (error) {
+      await computeClient
+        .destroyInstance({ instanceId: created.instanceId })
+        .catch((cleanupError) => {
+          console.error('[createBlaxelMachine] Cleanup failed', cleanupError);
+        });
+      throw error;
+    }
   }
 
   return {
     machineId: created.instanceId,
     proxyPorts,
+    ...(options.resumeHandle ? { sourceSnapshotId: options.resumeHandle } : {}),
     domain: (port) => {
       const domain = created.domains?.[String(port)];
       if (!domain) {

--- a/packages/compute-providers/src/types.ts
+++ b/packages/compute-providers/src/types.ts
@@ -30,6 +30,22 @@ export interface ResumeInstanceInput extends CreateInstanceInput {
   sourceSnapshotId: string;
 }
 
+export interface EnterStandbyInput {
+  instanceId: string;
+  commandId?: string;
+  signal?: AbortSignal;
+}
+
+export interface EnterStandbyResult {
+  /** Opaque single-instance handle used to reconnect to this standby. */
+  resumeHandle: string;
+  usageObservation?: ComputeUsageObservation;
+}
+
+export interface ResumeFromStandbyInput extends CreateInstanceInput {
+  resumeHandle: string;
+}
+
 export interface CreatedInstance {
   instanceId: string;
   status?: ComputeInstanceStatus;
@@ -183,6 +199,8 @@ export interface ComputeProviderClient {
     input: FindSnapshotBySourceInstanceInput,
   ): Promise<SourceInstanceSnapshot | null>;
   resumeFromSnapshot(input: ResumeInstanceInput): Promise<CreatedInstance>;
+  enterStandby?(input: EnterStandbyInput): Promise<EnterStandbyResult>;
+  resumeFromStandby?(input: ResumeFromStandbyInput): Promise<CreatedInstance>;
 }
 
 export interface ModalConfig {

--- a/packages/types/src/compute-providers/capabilities.ts
+++ b/packages/types/src/compute-providers/capabilities.ts
@@ -14,6 +14,8 @@ export interface ComputeProviderCapabilities {
   supportsCommandOutputStreaming: boolean;
   supportsCommandOutputLookup: boolean;
   supportsSnapshots: boolean;
+  /** Can retain and later reconnect to the same suspended instance. */
+  supportsStandbyResume: boolean;
   supportsResume: boolean;
   supportsFileWrite: boolean;
 }
@@ -25,6 +27,7 @@ export const DOCKER_CAPABILITIES: ComputeProviderCapabilities = {
   supportsCommandOutputStreaming: false,
   supportsCommandOutputLookup: false,
   supportsSnapshots: false,
+  supportsStandbyResume: false,
   supportsResume: false,
   supportsFileWrite: false,
 };
@@ -36,6 +39,7 @@ export const MODAL_CAPABILITIES: ComputeProviderCapabilities = {
   supportsCommandOutputStreaming: false,
   supportsCommandOutputLookup: false,
   supportsSnapshots: true,
+  supportsStandbyResume: false,
   supportsResume: true,
   supportsFileWrite: true,
 };
@@ -47,6 +51,7 @@ export const DAYTONA_CAPABILITIES: ComputeProviderCapabilities = {
   supportsCommandOutputStreaming: true,
   supportsCommandOutputLookup: true,
   supportsSnapshots: true,
+  supportsStandbyResume: false,
   supportsResume: true,
   supportsFileWrite: true,
 };
@@ -58,6 +63,7 @@ export const E2B_CAPABILITIES: ComputeProviderCapabilities = {
   supportsCommandOutputStreaming: true,
   supportsCommandOutputLookup: true,
   supportsSnapshots: true,
+  supportsStandbyResume: false,
   supportsResume: true,
   supportsFileWrite: true,
 };
@@ -69,7 +75,8 @@ export const BLAXEL_CAPABILITIES: ComputeProviderCapabilities = {
   supportsCommandOutputStreaming: true,
   supportsCommandOutputLookup: true,
   supportsSnapshots: false,
-  supportsResume: false,
+  supportsStandbyResume: true,
+  supportsResume: true,
   supportsFileWrite: true,
 };
 

--- a/packages/types/src/compute-providers/compute-provider.ts
+++ b/packages/types/src/compute-providers/compute-provider.ts
@@ -27,9 +27,18 @@ export const snapshotCapableComputeProviders = [
 ] as const satisfies readonly ComputeProvider[];
 
 /**
+ * Providers that can retain and reconnect to the same suspended instance.
+ * Unlike snapshots, standby handles are single-instance and are not safe to
+ * use as reusable environment templates.
+ */
+export const standbyResumeCapableComputeProviders = [
+  'blaxel',
+] as const satisfies readonly ComputeProvider[];
+
+/**
  * Providers whose machine lifecycle is managed by the scheduled sleep-check
- * pipeline. Snapshot-capable providers get snapshot-or-destroy handling;
- * non-snapshot managed providers are always destroyed on sleep.
+ * pipeline. Snapshot-capable providers create immutable snapshots, standby
+ * providers retain their instance, and other managed providers are destroyed.
  */
 export const sleepCheckManagedComputeProviders = [
   ...snapshotCapableComputeProviders,
@@ -54,6 +63,20 @@ export const isSnapshotCapableComputeProvider = (
   snapshotCapableComputeProviders.includes(
     provider as (typeof snapshotCapableComputeProviders)[number],
   );
+
+export const isStandbyResumeCapableComputeProvider = (
+  provider: string | null | undefined,
+): provider is ComputeProvider =>
+  standbyResumeCapableComputeProviders.includes(
+    provider as (typeof standbyResumeCapableComputeProviders)[number],
+  );
+
+/** Providers that can preserve a resumable task across its sleep boundary. */
+export const isTaskResumeCapableComputeProvider = (
+  provider: string | null | undefined,
+): provider is ComputeProvider =>
+  isSnapshotCapableComputeProvider(provider) ||
+  isStandbyResumeCapableComputeProvider(provider);
 
 /**
  * Worker runtime labels. `sandbox` denotes the shared hosted-sandbox

--- a/packages/types/src/task-runs.ts
+++ b/packages/types/src/task-runs.ts
@@ -751,6 +751,7 @@ export const computeProviderLaunchModes = [
   'fresh',
   'environment_snapshot',
   'task_snapshot',
+  'task_standby',
 ] as const;
 
 export type ComputeProviderLaunchMode =
@@ -759,6 +760,8 @@ export type ComputeProviderLaunchMode =
 export const computeProviderMutationOperations = [
   'create_instance',
   'resume_from_snapshot',
+  'enter_standby',
+  'resume_from_standby',
   'destroy_instance',
   'write_files',
   'run_command',


### PR DESCRIPTION
## Summary

- add a distinct Blaxel standby-resume capability without treating standby as an immutable environment snapshot
- retain resumable task sandboxes for seven days, stop the active worker, and reconnect to the same sandbox on follow-up
- refresh active TTLs and preview URLs on resume, while preserving standby state when worker relaunch fails
- document the lifecycle distinction and add scheduler, worker, controller, adapter, and machine-level coverage

## Validation

- affected package suites: compute-providers, controller, BullMQ, worker, and types
- `pnpm lint:fast`
- `pnpm check-types:fast`
- `pnpm knip`
- live Blaxel smoke: detached worker stopped, sandbox idled for 20 seconds, same instance resumed, filesystem state preserved, sandbox cleaned up
