### PR TITLE
Fix Blaxel standby resume preview conflicts

### DIFF
--- a/packages/compute-providers/src/__tests__/adapters.contract.test.ts
+++ b/packages/compute-providers/src/__tests__/adapters.contract.test.ts
@@ -115,6 +115,11 @@ describe('compute provider adapter contracts', () => {
       expiresIn: 120,
       wait: vi.fn().mockResolvedValue(undefined),
       previews: {
+        delete: vi.fn().mockImplementation(async (previewName) => {
+          if (previewName === 'port-4000') {
+            throw { code: 404, error: 'Resource not found' };
+          }
+        }),
         createIfNotExists: vi.fn().mockImplementation(async (preview) => ({
           spec: { url: `https://${preview.spec.port}.blaxel.test` },
         })),
@@ -226,21 +231,25 @@ describe('compute provider adapter contracts', () => {
     await expect(
       client.resumeFromStandby?.({
         resumeHandle: created.instanceId,
-        ports: [3000],
+        ports: [3000, 4000],
       }),
     ).resolves.toMatchObject({
       instanceId: created.instanceId,
       sourceSnapshotId: created.instanceId,
       status: 'running',
-      domains: { '3000': 'https://3000.blaxel.test' },
+      domains: {
+        '3000': 'https://3000.blaxel.test',
+        '4000': 'https://4000.blaxel.test',
+      },
     });
     expect(blaxelUpdateTtlMock).toHaveBeenLastCalledWith(
       created.instanceId,
       '120s',
     );
+    expect(sandbox.previews.delete).toHaveBeenCalledWith('port-3000');
+    expect(sandbox.previews.delete).toHaveBeenCalledWith('port-4000');
     expect(sandbox.previews.create).toHaveBeenCalledWith(
       expect.objectContaining({ metadata: { name: 'port-3000' } }),
-      true,
     );
     await client.destroyInstance({ instanceId: created.instanceId });
     expect(blaxelDeleteMock).toHaveBeenCalledWith(created.instanceId);

--- a/packages/compute-providers/src/adapters/blaxel.ts
+++ b/packages/compute-providers/src/adapters/blaxel.ts
@@ -4,6 +4,8 @@ import { SandboxInstance, settings } from '@blaxel/core';
 import {
   BLAXEL_CAPABILITIES as BLAXEL_CAPABILITIES_VALUE,
   type ComputeProvider,
+  extractErrorDetails,
+  serializeError,
 } from '@roomote/types';
 
 import { raceWithAbort, sleepWithSignal, throwIfAborted } from '../modal/abort';
@@ -376,17 +378,26 @@ export class BlaxelClient implements ComputeProviderClient {
   ): Promise<Record<string, string>> {
     const domains: Record<string, string> = {};
     for (const port of ports) {
+      const previewName = `port-${port}`;
+      if (refresh) {
+        try {
+          await raceWithAbort({
+            promise: sandbox.previews.delete(previewName),
+            signal,
+            abortMessage: `Deleting Blaxel preview for port ${port} was aborted`,
+          });
+        } catch (error) {
+          if (!isNotFound(error)) throw error;
+        }
+      }
       const preview = await raceWithAbort({
         promise: refresh
-          ? sandbox.previews.create(
-              {
-                metadata: { name: `port-${port}` },
-                spec: { port, public: true, ttl: this.ttl() },
-              },
-              true,
-            )
+          ? sandbox.previews.create({
+              metadata: { name: previewName },
+              spec: { port, public: true, ttl: this.ttl() },
+            })
           : sandbox.previews.createIfNotExists({
-              metadata: { name: `port-${port}` },
+              metadata: { name: previewName },
               spec: { port, public: true, ttl: this.ttl() },
             }),
         signal,
@@ -444,9 +455,11 @@ function shellQuote(value: string): string {
 }
 
 function isNotFound(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  const value = `${error.name} ${error.message}`.toLowerCase();
-  return value.includes('404') || value.includes('not found');
+  const details = extractErrorDetails(error);
+  const value = serializeError(error).message.toLowerCase();
+  return (
+    details.code === 404 || value.includes('404') || value.includes('not found')
+  );
 }
 
 async function retryWorkloadUnavailable<T>(options: {
@@ -479,10 +492,7 @@ async function retryWorkloadUnavailable<T>(options: {
 }
 
 function isWorkloadUnavailable(error: unknown): boolean {
-  const value =
-    error instanceof Error
-      ? `${error.name} ${error.message}`.toLowerCase()
-      : String(error).toLowerCase();
+  const value = serializeError(error).message.toLowerCase();
   return (
     value.includes('workload_unavailable') ||
     value.includes('currently not available')

--- a/packages/compute-providers/src/blaxel/create-blaxel-machine.test.ts
+++ b/packages/compute-providers/src/blaxel/create-blaxel-machine.test.ts
@@ -51,4 +51,47 @@ describe('createBlaxelMachine', () => {
       sourceSnapshotId: 'roomote-blaxel-standby',
     });
   });
+
+  it('preserves messages from plain Blaxel API errors', async () => {
+    vi.useFakeTimers();
+    try {
+      const onMutation = vi.fn();
+      const resumeFromStandby = vi
+        .fn()
+        .mockRejectedValue({ code: 409, error: 'Resource already exists' });
+
+      const result = createBlaxelMachine({
+        blaxelApiKey: 'key',
+        blaxelWorkspace: 'workspace',
+        blaxelImage: 'sandbox/roomote-worker:test',
+        launchMode: 'task_standby',
+        resumeHandle: 'roomote-blaxel-standby',
+        onMutation,
+        computeClient: {
+          vendor: 'blaxel',
+          createInstance: vi.fn(),
+          resumeFromStandby,
+          writeFiles: vi.fn(),
+          runCommand: vi.fn(),
+          destroyInstance: vi.fn(),
+        },
+      });
+      const rejection = expect(result).rejects.toThrow(
+        'Resource already exists',
+      );
+
+      await vi.advanceTimersByTimeAsync(6_000);
+      await rejection;
+      expect(onMutation).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          eventType: 'failed',
+          details: expect.objectContaining({
+            error: 'Resource already exists',
+          }),
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/compute-providers/src/blaxel/create-blaxel-machine.ts
+++ b/packages/compute-providers/src/blaxel/create-blaxel-machine.ts
@@ -2,6 +2,7 @@ import {
   type ComputeProviderLaunchMode,
   type NamedPort,
   SANDBOX_FILES_DIR,
+  serializeError,
 } from '@roomote/types';
 
 import { generateProxyPorts, getExposedPorts } from '../environment-machine';
@@ -159,6 +160,7 @@ export async function createBlaxelMachine(
       });
       break;
     } catch (error) {
+      const errorMessage = serializeError(error).message;
       await options.onMutation?.({
         provider: 'blaxel',
         operation: options.resumeHandle
@@ -173,10 +175,13 @@ export async function createBlaxelMachine(
           launchMode: options.launchMode as ComputeProviderLaunchMode,
           sourceSnapshotId: options.resumeHandle ?? null,
           ports,
-          error: error instanceof Error ? error.message : String(error),
+          error: errorMessage,
         },
       });
-      if (isAbortError(error) || attempt === MAX_RETRIES) throw error;
+      if (isAbortError(error)) throw error;
+      if (attempt === MAX_RETRIES) {
+        throw error instanceof Error ? error : new Error(errorMessage);
+      }
       await sleepWithSignal(2_000 * 2 ** (attempt - 1), createSignal);
     }
   }

--- a/packages/types/src/__tests__/error-utils.test.ts
+++ b/packages/types/src/__tests__/error-utils.test.ts
@@ -14,4 +14,10 @@ describe('serializeError', () => {
       message: 'The operation was aborted due to timeout',
     });
   });
+
+  it('uses the error field from generated API client errors', () => {
+    expect(
+      serializeError({ code: 409, error: 'Resource already exists' }),
+    ).toEqual({ message: 'Resource already exists' });
+  });
 });

--- a/packages/types/src/error-utils.ts
+++ b/packages/types/src/error-utils.ts
@@ -64,6 +64,12 @@ function getErrorLikeMessage(error: unknown): string {
     return error.message;
   }
 
+  // Several generated API clients (including Blaxel's) reject with a plain
+  // object shaped like { code, error } instead of an Error instance.
+  if (isRecord(error) && typeof error.error === 'string') {
+    return error.error;
+  }
+
   return String(error);
 }
 


### PR DESCRIPTION
## Summary
- delete and recreate Blaxel preview endpoints when resuming a retained sandbox
- recognize Blaxel plain-object API errors and surface useful messages instead of `[object Object]`
- cover existing and missing preview endpoints plus structured resume failures

## Production diagnosis
Task run #408 restored the sandbox TTL, then Blaxel rejected the forced preview refresh with `{ code: 409, error: "Resource already exists" }`. The SDK returned a plain object, which Roomote stringified as `[object Object]`.

## Validation
- focused `@roomote/types` and `@roomote/compute-providers` Vitest suites
- package TypeScript and ESLint checks
- `pnpm format:check`
- `pnpm lint:fast`
- `pnpm check-types:fast`
- `pnpm knip`
- live resume of the retained production Blaxel sandbox returned fresh URLs for ports 4200 and 56721