### PR TITLE
Fix Blaxel standby worker resume command

### DIFF
--- a/apps/controller/src/compute-providers/__tests__/spawn-blaxel-worker.test.ts
+++ b/apps/controller/src/compute-providers/__tests__/spawn-blaxel-worker.test.ts
@@ -123,7 +123,7 @@ describe('spawnBlaxelWorker', () => {
       expect.objectContaining({
         instanceId: 'roomote-blaxel-standby',
         cmd: 'worker',
-        args: ['run', '321'],
+        args: ['resume', '321'],
         detached: true,
       }),
     );

--- a/apps/controller/src/compute-providers/spawn-blaxel-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-blaxel-worker.ts
@@ -155,7 +155,9 @@ export async function spawnBlaxelWorker(
       });
     }
 
-    const args = ['run', taskRun.id.toString()];
+    const workerCommand =
+      taskRun.payloadKind === TaskPayloadKind.SnapshotResume ? 'resume' : 'run';
+    const args = [workerCommand, taskRun.id.toString()];
     await recordMutation({
       provider: 'blaxel',
       operation: 'run_command',


### PR DESCRIPTION
## Summary
- launch `worker resume` for Blaxel SnapshotResume runs instead of `worker run`
- retain `worker run` for fresh Blaxel launches
- update the Blaxel controller regression test to assert the resume command

## Production diagnosis
Run #410 successfully restored the retained Blaxel sandbox and launched its worker. The launcher hardcoded `worker run 410`, which called the fresh dequeue path and attempted to generate a prompt for the `snapshot_resume` payload. Other snapshot-backed providers use `worker resume` for this payload kind.

## Validation
- focused `spawn-blaxel-worker` Vitest suite
- `@roomote/controller` TypeScript and ESLint checks
- `pnpm format:check`
- `pnpm lint:fast`
- `pnpm check-types:fast`
- `pnpm knip`