### PR TITLE
Fix local live preview auth cookies

### DIFF
--- a/apps/preview-proxy/src/__tests__/integration.test.ts
+++ b/apps/preview-proxy/src/__tests__/integration.test.ts
@@ -332,6 +332,36 @@ describe('preview-proxy integration', () => {
   });
 
   describe('auth callback state handling', () => {
+    it('sets a Secure partitioned auth cookie on local HTTP callbacks', async () => {
+      const { validateState, validateToken } = await import('../services/auth');
+
+      vi.mocked(validateState).mockResolvedValue({
+        redirectUri: 'http://task-web.roomotepreview.localhost:18081/',
+        runId: 1,
+      });
+      vi.mocked(validateToken).mockResolvedValue({
+        userId: 'user-1',
+        tokenType: 'pt',
+        version: 1,
+      });
+
+      const res = await request(server)
+        .get('/auth/callback?token=test-token&state=test-state')
+        .set('Host', 'task-web.roomotepreview.localhost:18081')
+        .set('x-forwarded-proto', 'http')
+        .redirects(0);
+
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toBe(
+        'http://task-web.roomotepreview.localhost:18081/',
+      );
+      expect(res.headers['set-cookie']).toEqual([
+        expect.stringContaining(
+          'preview_auth=test-token; Path=/; Max-Age=3600; HttpOnly; Secure; SameSite=None; Partitioned',
+        ),
+      ]);
+    });
+
     it('forwards nested callback when state is missing locally', async () => {
       const { validateState } = await import('../services/auth');
       const { tryNestedFallback } = await import('../lib/nested-routing');
@@ -806,6 +836,7 @@ describe('preview-proxy integration', () => {
       expect(authCookie).toBeDefined();
       expect(authCookie).toContain('preview_auth=');
       expect(authCookie).toContain('HttpOnly');
+      expect(authCookie).toContain('Secure');
       expect(authCookie).toContain('SameSite=None');
       expect(authCookie).toContain('Partitioned');
       expect(authCookie).toContain('Path=/');

--- a/apps/preview-proxy/src/handlers/auth-callback.ts
+++ b/apps/preview-proxy/src/handlers/auth-callback.ts
@@ -5,32 +5,8 @@ import { buildSetCookieHeader, getCookieDomain } from '../lib/cookies';
 import { tryNestedFallback } from '../lib/nested-routing';
 import { proxyRequest } from '../lib/proxy';
 import { logger, escapeForLog } from '../lib/logger';
-import { isLoopbackHostname } from '@roomote/types';
 import { config } from '../config';
 import type { AccessLogContext } from '../lib/access-log';
-
-/**
- * Determine if the Secure flag should be set on the cookie.
- * With SameSite=None, browsers silently reject cookies without Secure on
- * non-localhost HTTPS origins. Set Secure based on request protocol, not
- * just NODE_ENV, so staging/preview deploys work correctly.
- */
-function shouldSetSecure(req: IncomingMessage): boolean {
-  const forwardedProto = req.headers['x-forwarded-proto'];
-  if (typeof forwardedProto === 'string' && forwardedProto.length > 0) {
-    const protocol = forwardedProto.split(',')[0]!.trim();
-    return protocol === 'https';
-  }
-
-  // In production, always secure. In dev, check if host is localhost.
-  if (config.NODE_ENV === 'production') {
-    return true;
-  }
-
-  const host = req.headers.host || '';
-  const hostname = host.split(':')[0] || '';
-  return !isLoopbackHostname(hostname);
-}
 
 /**
  * Handle the /auth/callback route.
@@ -133,14 +109,15 @@ export async function handleAuthCallback(
 
   // Set cookie on the base domain so it works across all preview subdomains
   const cookieDomain = await getCookieDomain();
-  const secure = shouldSetSecure(req);
 
   const setCookieValue = buildSetCookieHeader(
     config.PREVIEW_AUTH_COOKIE_NAME,
     token,
     {
       httpOnly: true,
-      secure,
+      // SameSite=None and Partitioned cookies require Secure. Browsers
+      // treat localhost as a trustworthy origin for local development.
+      secure: true,
       sameSite: 'None',
       maxAge: parseInt(config.PREVIEW_TOKEN_TTL_SECONDS),
       path: '/',

--- a/apps/preview-proxy/src/handlers/http.ts
+++ b/apps/preview-proxy/src/handlers/http.ts
@@ -19,7 +19,6 @@ import {
   renderUnavailablePage,
 } from '../lib/error-pages';
 import { triggerAutoResume } from './auto-resume';
-import { isLoopbackHostname } from '@roomote/types';
 import { logger, escapeForLog } from '../lib/logger';
 import { config } from '../config';
 import type { AccessLogContext } from '../lib/access-log';
@@ -98,28 +97,6 @@ function getRequestProtocol(req: IncomingMessage): string {
   }
 
   return config.NODE_ENV === 'production' ? 'https' : 'http';
-}
-
-/**
- * Determine if the Secure flag should be set on the cookie.
- * With SameSite=None, browsers silently reject cookies without Secure on
- * non-localhost HTTPS origins.
- */
-function shouldSetSecure(req: IncomingMessage): boolean {
-  const forwardedProto = req.headers['x-forwarded-proto'];
-  if (typeof forwardedProto === 'string' && forwardedProto.length > 0) {
-    const protocol = forwardedProto.split(',')[0]!.trim();
-    return protocol === 'https';
-  }
-
-  // In production, always secure. In dev, check if host is localhost.
-  if (config.NODE_ENV === 'production') {
-    return true;
-  }
-
-  const host = req.headers.host || '';
-  const hostname = host.split(':')[0] || '';
-  return !isLoopbackHostname(hostname);
 }
 
 /**
@@ -524,14 +501,15 @@ async function resolveAuthAndProxy(
       const cleanUrl = `${protocol}://${host}${requestUrl.pathname}${requestUrl.search}`;
 
       // Set preview_auth cookie (replaces old preview_session)
-      const secure = shouldSetSecure(req);
       const cookieDomain = await getCookieDomain();
       const cookieValue = buildSetCookieHeader(
         config.PREVIEW_AUTH_COOKIE_NAME,
         inlineToken,
         {
           httpOnly: true,
-          secure,
+          // SameSite=None and Partitioned cookies require Secure. Browsers
+          // treat localhost as a trustworthy origin for local development.
+          secure: true,
           sameSite: 'None',
           maxAge: parseInt(config.PREVIEW_TOKEN_TTL_SECONDS),
           path: '/',


### PR DESCRIPTION
## Summary

- always mark preview authentication cookies as Secure when using SameSite=None and Partitioned
- apply the cookie contract to both iframe token bootstrap and auth callback flows
- add regression coverage for local HTTP preview callbacks and iframe authentication

## Validation

- 147 preview-proxy tests passed
- preview-proxy typecheck passed
- preview-proxy lint passed
- pre-push lint:fast, check-types:fast, and knip passed
- verified in Chrome that the ngrok-hosted Roomote page renders the local Sunny Acres preview in the side pane