### PR TITLE
Fix Docker task startup with typed retention settings

### DIFF
--- a/apps/controller/src/RoomoteController.ts
+++ b/apps/controller/src/RoomoteController.ts
@@ -68,8 +68,9 @@ export class RoomoteController extends BaseController {
     // Credentials resolve from the runtime env first and fall back to the
     // encrypted deployment env vars saved by the setup flow.
     const resolvedEnv = await resolveComputeProviderEnvValues(provider, {
-      // Env only holds string values for the catalog credential keys.
-      runtimeEnv: Env as unknown as Partial<Record<string, string | undefined>>,
+      // The validated env includes typed numeric policy values; the resolver
+      // normalizes scalars before combining them with saved string values.
+      runtimeEnv: Env,
     });
 
     switch (provider) {

--- a/packages/db/src/lib/__tests__/compute-runtime-config.test.ts
+++ b/packages/db/src/lib/__tests__/compute-runtime-config.test.ts
@@ -154,9 +154,9 @@ describe('resolveComputeProviderEnvValues', () => {
     expect(values.MODAL_BASE_IMAGE_REF).toBeUndefined();
   });
 
-  it('resolves saved Docker standby settings with runtime values taking precedence', async () => {
+  it('normalizes typed Docker standby settings with runtime values taking precedence', async () => {
     const values = await resolveComputeProviderEnvValues('docker', {
-      runtimeEnv: { DOCKER_STANDBY_MAX_COUNT: '7' },
+      runtimeEnv: { DOCKER_STANDBY_MAX_COUNT: 7 },
       executor: makeExecutor([
         { name: 'DOCKER_STANDBY_MAX_AGE_HOURS', value: '18' },
       ]),

--- a/packages/db/src/lib/compute-runtime-config.ts
+++ b/packages/db/src/lib/compute-runtime-config.ts
@@ -22,6 +22,21 @@ import { stringifyDecryptedEnvVarValue } from './environment-variables';
 
 const DEFAULT_DEPLOYMENT_ID = 'default';
 
+type ComputeRuntimeEnv = Partial<Record<string, unknown>>;
+
+function normalizeComputeRuntimeEnvValue(value: unknown): string | undefined {
+  switch (typeof value) {
+    case 'string':
+      return value.trim() || undefined;
+    case 'number':
+    case 'boolean':
+    case 'bigint':
+      return String(value);
+    default:
+      return undefined;
+  }
+}
+
 async function loadPersistedRuntimeComputeConfig(
   executor: DatabaseOrTransaction = db,
 ) {
@@ -159,11 +174,17 @@ export async function resolveDefaultComputeProvider(
 export async function resolveComputeProviderEnvValues(
   provider: ComputeProvider,
   options: {
-    runtimeEnv?: Partial<Record<string, string | undefined>>;
+    runtimeEnv?: ComputeRuntimeEnv;
     executor?: DatabaseOrTransaction;
   } = {},
 ): Promise<Partial<Record<string, string>>> {
-  const runtimeEnv = options.runtimeEnv ?? process.env;
+  const rawRuntimeEnv = options.runtimeEnv ?? process.env;
+  const runtimeEnv = Object.fromEntries(
+    Object.entries(rawRuntimeEnv).flatMap(([name, value]) => {
+      const normalized = normalizeComputeRuntimeEnvValue(value);
+      return normalized === undefined ? [] : [[name, normalized]];
+    }),
+  );
   const executor = options.executor ?? db;
   const descriptor = getSetupComputeProvider(provider);
   const envVarNames = descriptor.fields.map((field) => field.envVarName);
@@ -176,7 +197,7 @@ export async function resolveComputeProviderEnvValues(
   const missingEnvVarNames: string[] = [];
 
   for (const envVarName of envVarNames) {
-    const runtimeValue = runtimeEnv[envVarName]?.trim();
+    const runtimeValue = runtimeEnv[envVarName];
 
     if (runtimeValue) {
       resolvedValues[envVarName] = runtimeValue;


### PR DESCRIPTION
## Summary
- normalize typed validated runtime env scalars before compute-provider resolution
- remove the unsafe string-only cast in the controller
- cover numeric Docker standby defaults with a regression test

## Validation
- targeted DB compute runtime tests
- targeted controller tests
- lint:fast
- check-types:fast
- knip
- local controller rebuilt and restarted cleanly