### PR TITLE
Fix stale local Docker workers and tunneled live sessions

### DIFF
--- a/.docker/caddy/Caddyfile
+++ b/.docker/caddy/Caddyfile
@@ -31,6 +31,22 @@
 		}
 	}
 
+	# Route the sandbox-server transport through the same public origin as the
+	# web app. A browser opened through ngrok cannot connect to the worker's
+	# loopback-only published port directly because 127.0.0.1 would refer to the
+	# browser device. The preview proxy resolves the task's current worker port
+	# after Caddy translates this path route into its normal virtual host.
+	@local_sandbox path_regexp local_sandbox ^/_roomote-sandbox/([a-z0-9]+)(/.*)$
+
+	handle @local_sandbox {
+		rewrite * {re.local_sandbox.2}
+		reverse_proxy host.docker.internal:18081 {
+			header_up Host {re.local_sandbox.1}-sandbox-server.roomotepreview.localhost:18081
+			lb_try_duration 10s
+			lb_try_interval 250ms
+		}
+	}
+
 	handle {
 		reverse_proxy host.docker.internal:13000 {
 			lb_try_duration 10s

--- a/apps/controller/src/compute-providers/__tests__/spawn-docker-worker.test.ts
+++ b/apps/controller/src/compute-providers/__tests__/spawn-docker-worker.test.ts
@@ -108,7 +108,17 @@ describe('buildDockerSandboxServerUrl', () => {
     ).toBe('https://task123456789-sandbox-server.preview.roomote.example.com');
   });
 
-  it('keeps local Docker workers on their direct published URL path', () => {
+  it('routes local Docker sandbox transport through the public app origin', () => {
+    expect(
+      buildDockerSandboxServerUrl({
+        taskId: 'task123456789',
+        publicAppUrl: 'https://roomote-example.ngrok.app/',
+        previewProxyBaseUrl: 'https://preview.roomote.example.com',
+      }),
+    ).toBe('https://roomote-example.ngrok.app/_roomote-sandbox/task123456789');
+  });
+
+  it('keeps the direct published URL fallback without a public app origin', () => {
     expect(
       buildDockerSandboxServerUrl({
         taskId: 'task123456789',

--- a/apps/controller/src/compute-providers/spawn-docker-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-docker-worker.ts
@@ -272,6 +272,7 @@ export async function spawnDockerWorker(
     const sandboxServerUrl = buildDockerSandboxServerUrl({
       network: controlNetwork ? dockerNetwork : undefined,
       taskId: taskRun.taskId,
+      publicAppUrl: process.env.R_PUBLIC_URL || process.env.R_APP_URL,
       previewProxyBaseUrl:
         resolvedPreviewRuntimeConfig.effective.previewProxyBaseUrl ?? undefined,
     });
@@ -476,17 +477,26 @@ async function hasTaskRunStarted(runId: number): Promise<boolean> {
 export function buildDockerSandboxServerUrl(params: {
   network?: string;
   taskId?: string | null;
+  publicAppUrl?: string;
   previewProxyBaseUrl?: string;
 }): string | undefined {
-  if (!params.network || !params.taskId || !params.previewProxyBaseUrl) {
+  if (!params.taskId) {
     return undefined;
   }
 
-  return buildPreviewProxyUrl(
-    params.taskId,
-    portNameToSlug(SANDBOX_SERVER_NAMED_PORT.name),
-    params.previewProxyBaseUrl,
-  );
+  if (params.network && params.previewProxyBaseUrl) {
+    return buildPreviewProxyUrl(
+      params.taskId,
+      portNameToSlug(SANDBOX_SERVER_NAMED_PORT.name),
+      params.previewProxyBaseUrl,
+    );
+  }
+
+  if (!params.network && params.publicAppUrl) {
+    return `${params.publicAppUrl.replace(/\/+$/, '')}/_roomote-sandbox/${params.taskId}`;
+  }
+
+  return undefined;
 }
 
 async function getPublishedPorts(

--- a/apps/dev/src/services/__tests__/docker.test.ts
+++ b/apps/dev/src/services/__tests__/docker.test.ts
@@ -374,6 +374,55 @@ describe('DockerService.ensureWorkerImage', () => {
     );
   });
 
+  it('reuses an existing worker image when required networking tools are available', async () => {
+    vi.mocked(execa).mockResolvedValue({} as Awaited<ReturnType<typeof execa>>);
+
+    await DockerService.ensureWorkerImage(false);
+
+    expect(execa).toHaveBeenCalledWith('docker', [
+      'run',
+      '--rm',
+      '--platform',
+      process.arch === 'arm64' ? 'linux/arm64' : 'linux/amd64',
+      '--entrypoint',
+      '/bin/sh',
+      'roomote-worker:local',
+      '-c',
+      'test -x /usr/sbin/ip && /usr/sbin/ip -Version >/dev/null',
+    ]);
+    expect(execa).not.toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining(['build']),
+      expect.anything(),
+    );
+  });
+
+  it('rebuilds an existing worker image that lacks required networking tools', async () => {
+    const rootDir = path.resolve(process.cwd(), '../..');
+
+    vi.mocked(execa)
+      .mockResolvedValueOnce({} as Awaited<ReturnType<typeof execa>>)
+      .mockRejectedValueOnce(new Error('ip is missing'))
+      .mockResolvedValueOnce({} as Awaited<ReturnType<typeof execa>>);
+
+    await DockerService.ensureWorkerImage(false);
+
+    expect(execa).toHaveBeenCalledWith(
+      'docker',
+      [
+        'build',
+        '--platform',
+        process.arch === 'arm64' ? 'linux/arm64' : 'linux/amd64',
+        '-f',
+        'apps/worker/Dockerfile',
+        '-t',
+        'roomote-worker:local',
+        '.',
+      ],
+      { cwd: rootDir },
+    );
+  });
+
   it('honors custom Docker worker image and platform settings', async () => {
     const rootDir = path.resolve(process.cwd(), '../..');
     process.env.DOCKER_WORKER_IMAGE = 'custom-worker:test';

--- a/apps/dev/src/services/docker.ts
+++ b/apps/dev/src/services/docker.ts
@@ -60,7 +60,10 @@ export class DockerService {
       process.env.DOCKER_WORKER_PLATFORM ?? this.DEFAULT_WORKER_PLATFORM;
     const rootDir = path.resolve(process.cwd(), '../..');
 
-    if (await this.hasImage(image)) {
+    if (
+      (await this.hasImage(image)) &&
+      (await this.hasRequiredWorkerImageTools(image, platform))
+    ) {
       return;
     }
 
@@ -280,6 +283,28 @@ export class DockerService {
   private static async hasImage(image: string): Promise<boolean> {
     try {
       await execa('docker', ['image', 'inspect', image]);
+      return true;
+    } catch (_error) {
+      return false;
+    }
+  }
+
+  private static async hasRequiredWorkerImageTools(
+    image: string,
+    platform: string,
+  ): Promise<boolean> {
+    try {
+      await execa('docker', [
+        'run',
+        '--rm',
+        '--platform',
+        platform,
+        '--entrypoint',
+        '/bin/sh',
+        image,
+        '-c',
+        'test -x /usr/sbin/ip && /usr/sbin/ip -Version >/dev/null',
+      ]);
       return true;
     } catch (_error) {
       return false;


### PR DESCRIPTION
## Summary
- validate that an existing local worker image contains the networking tools required by Docker egress isolation
- rebuild stale images from the current worker Dockerfile before launching tasks
- route local Docker sandbox-server HTTP and WebSocket traffic through the public app edge so phones and other ngrok clients do not receive a loopback URL
- cover compatible images, stale images, public sandbox routing, and direct fallback behavior with unit tests

## Validation
- `pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/dev exec vitest run src/services/__tests__/docker.test.ts`
- `pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/controller exec vitest run src/compute-providers/__tests__/spawn-docker-worker.test.ts`
- `pnpm lint:fast`
- `pnpm check-types:fast`
- `pnpm knip`
- validated and reloaded the local Caddy configuration
- local Docker task run #25 connected through `https://openroomote-matt.ngrok.app`, including a successful WebSocket upgrade (101), runtime-state request (200), and signed-in Chrome UI showing `Idle` with no connection error