### PR TITLE
[Fix] Resume retained environments before the first agent session

### DIFF
--- a/apps/worker/src/commands/__tests__/resume.test.ts
+++ b/apps/worker/src/commands/__tests__/resume.test.ts
@@ -123,4 +123,39 @@ describe('resume', () => {
       }),
     );
   });
+
+  it('restores a retained environment before its first harness session', async () => {
+    executeTaskRunMock.mockImplementation(async ({ runFn }) => {
+      await runFn({
+        jobContext: {
+          taskRun: {
+            id: 44,
+            payloadKind: TaskPayloadKind.SnapshotResume,
+            taskId: 'task-44',
+          },
+          task: {},
+          envVars: {},
+          harnessSessionId: undefined,
+        },
+        workspace: {},
+        workspacePath: '/tmp/workspace',
+        usesSharedWorkspaceRoot: false,
+        callbacks: {},
+        context: {},
+        logger: {} as never,
+        workerEnv: {} as never,
+      });
+
+      return true;
+    });
+
+    await resume(44);
+
+    expect(runTaskMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: '',
+        harnessSessionId: undefined,
+      }),
+    );
+  });
 });

--- a/apps/worker/src/commands/resume.ts
+++ b/apps/worker/src/commands/resume.ts
@@ -78,7 +78,7 @@ export async function resume(runId: number): Promise<boolean> {
       // Seed callback context for resumed integrations before runTask starts.
       // onStart still runs for resume task runs, but it should reuse the existing
       // harness session rather than overwrite it.
-      if (isLinearResume || isSlackResume) {
+      if ((isLinearResume || isSlackResume) && jobContext.harnessSessionId) {
         context.sessionId = jobContext.harnessSessionId;
         context.parentTaskId = jobContext.harnessSessionId;
         context.taskId = jobContext.taskRun.taskId;

--- a/apps/worker/src/run-task/__tests__/wait-for-external-sleep-action.test.ts
+++ b/apps/worker/src/run-task/__tests__/wait-for-external-sleep-action.test.ts
@@ -188,7 +188,7 @@ describe('waitForExternalSleepAction', () => {
     expect(findRuntimeStateByIdMock).toHaveBeenCalledWith(790);
   });
 
-  it('skips jobs on non-snapshot-capable providers', async () => {
+  it('skips jobs without a managed compute provider', async () => {
     const logger = {
       runId: 123,
       filePath: '/tmp/test.log',
@@ -202,7 +202,7 @@ describe('waitForExternalSleepAction', () => {
       taskRun: {
         id: 123,
         payloadKind: TaskPayloadKind.GithubPrReviewFollowUp,
-        vendor: 'docker',
+        vendor: null,
         machineId: 'worker-123',
       } as never,
       logger,

--- a/packages/sdk/src/server/lib/task-runs/__tests__/dequeue-resume-task-run.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/dequeue-resume-task-run.test.ts
@@ -393,6 +393,39 @@ describe('dequeueResumeTaskRun', () => {
     expect(mockReleaseTaskRun).toHaveBeenCalledWith(resumeRun);
   });
 
+  it.each(['docker', 'blaxel'] as const)(
+    'resumes a retained %s environment before its first harness session',
+    async (vendor) => {
+      const resumeRun = makeSnapshotResumeRun(
+        { vendor },
+        { harnessSessionId: null },
+      );
+
+      mockTxExecute.mockResolvedValue([{ id: resumeRun.id }]);
+      mockTxFindFirstTaskRuns.mockResolvedValueOnce(resumeRun);
+
+      const result = await dequeueResumeTaskRun({ orgId: 'org-1' } as never, {
+        runId: resumeRun.id,
+      });
+
+      expect(result?.harnessSessionId).toBeUndefined();
+      expect(mockCancelTaskRun).not.toHaveBeenCalled();
+      expect(mockRecordSnapshotResumeEvent).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          runId: resumeRun.id,
+          eventType: 'started',
+          message: expect.stringContaining('before the first harness session'),
+          details: expect.objectContaining({
+            harnessSessionId: undefined,
+            sourceRunId: 99,
+            sourceSnapshotId: 'snap-1',
+          }),
+        }),
+      );
+    },
+  );
+
   it('invokes the bootstrap failure callback when resume bootstrap fails before startup', async () => {
     const resumeRun = makeSnapshotResumeRun({}, { harnessSessionId: null });
 

--- a/packages/sdk/src/server/lib/task-runs/dequeue-resume-task-run.ts
+++ b/packages/sdk/src/server/lib/task-runs/dequeue-resume-task-run.ts
@@ -5,6 +5,7 @@ import {
   type RequestedWorkKind,
   RunStatus,
   TaskPayloadKind,
+  isStandbyResumeCapableComputeProvider,
   resolveSourceControlProviderFromPayload,
 } from '@roomote/types';
 import {
@@ -52,11 +53,11 @@ type DequeueResumeTaskRunResult =
       setupOnboardingTask: boolean;
       gitAuthor: GitAuthor;
       /**
-       * The Roomote harness session ID that should be resumed.
-       * Resolved from tasks.harnessSessionId of the run's own task — resume
-       * runs share the task with the run they resume.
+       * The Roomote harness session ID that should be resumed, when one has
+       * started. Retained standby environments can be suspended before their
+       * first prompt creates a harness session.
        */
-      harnessSessionId: string;
+      harnessSessionId?: string;
       /**
        * The repo from the source task run's payload.
        * Used to determine the correct workspace path.
@@ -79,8 +80,9 @@ type DequeueResumeTaskRunResult =
  *
  * This function claims the run, validates it, and reads the persisted
  * harnessSessionId from the run's task (resume runs are rows on the same
- * task). The worker uses that harness session ID to resume the existing task
- * instead of starting a new one.
+ * task). The worker uses that harness session ID to resume an existing task.
+ * Retained standby environments may legitimately have no session yet when
+ * they were suspended before their first prompt.
  *
  * Unlike regular dequeue, this doesn't generate a prompt since we're resuming
  * an existing task with its own conversation history.
@@ -130,7 +132,7 @@ export const dequeueResumeTaskRun = async (
           orgAgentInstructions?: string;
           styleGuidance?: string;
           gitAuthor: GitAuthor;
-          harnessSessionId: string;
+          harnessSessionId?: string;
           sourceRepo?: string;
           sourceEnvironmentId?: string;
           sourceSelectedRepositories?: string[];
@@ -226,8 +228,10 @@ export const dequeueResumeTaskRun = async (
       // Resume runs share their task with the run they resume, so the
       // harness session lives on the run's own task row.
       const harnessSessionId = taskRun.task.harnessSessionId ?? null;
+      const canResumeWithoutHarnessSession =
+        isStandbyResumeCapableComputeProvider(taskRun.vendor);
 
-      if (!harnessSessionId) {
+      if (!harnessSessionId && !canResumeWithoutHarnessSession) {
         console.error(
           `${tag} Task ${taskRun.taskId} for resume run ${taskRun.id} has no harnessSessionId`,
         );
@@ -274,7 +278,9 @@ export const dequeueResumeTaskRun = async (
       const sourceEnvironmentId = resumePayload.environmentId;
       const sourceSelectedRepositories = resumePayload.selectedRepositories;
       console.log(
-        `${tag} Found harness session ID ${harnessSessionId} for resume run ${taskRun.id} (taskId=${taskRun.taskId}, sourceRunId=${sourceRunId}, repo=${sourceRepo}, environmentId=${sourceEnvironmentId})`,
+        harnessSessionId
+          ? `${tag} Found harness session ID ${harnessSessionId} for resume run ${taskRun.id} (taskId=${taskRun.taskId}, sourceRunId=${sourceRunId}, repo=${sourceRepo}, environmentId=${sourceEnvironmentId})`
+          : `${tag} Resuming retained ${taskRun.vendor} environment for run ${taskRun.id} before its first harness session (taskId=${taskRun.taskId}, sourceRunId=${sourceRunId}, repo=${sourceRepo}, environmentId=${sourceEnvironmentId})`,
       );
 
       // Fetch environment variables
@@ -335,7 +341,7 @@ export const dequeueResumeTaskRun = async (
         orgAgentInstructions: settings?.globalAgentInstructions ?? undefined,
         styleGuidance: settings?.styleGuidance ?? undefined,
         gitAuthor,
-        harnessSessionId,
+        harnessSessionId: harnessSessionId ?? undefined,
         sourceRepo,
         sourceEnvironmentId,
         sourceSelectedRepositories,
@@ -445,7 +451,9 @@ export const dequeueResumeTaskRun = async (
       runId: result.taskRun.id,
       taskId: result.taskRun.taskId,
       eventType: 'started',
-      message: `Snapshot resume bootstrap started with source session ${result.harnessSessionId}.`,
+      message: result.harnessSessionId
+        ? `Snapshot resume bootstrap started with source session ${result.harnessSessionId}.`
+        : 'Standby resume bootstrap started before the first harness session.',
       details: {
         stage: 'bootstrap',
         sourceRunId: result.taskRun.sourceRunId ?? null,


### PR DESCRIPTION
## Related issue

N/A — internal bug found during local Docker resume testing.

## Why this PR exists

- [x] I am a maintainer / this is internal Roomote work

## What changed

- Allow Docker and Blaxel standby environments to resume when they were suspended before their first harness session was created.
- Keep the existing harness-session requirement for providers that restore immutable snapshots.
- Avoid seeding integration callback context when there is no session yet.
- Add SDK and worker regression coverage for no-session standby resumes.

## How it was tested

- SDK resume tests: 12 passed.
- Worker resume tests: 3 passed.
- pnpm lint:fast passed.
- pnpm check-types:fast passed.
- Prettier check passed for all changed files.
- Manually retried local Docker task 0078xn19yoxxr: run 29 restored retained container roomote-worker-25, began heartbeats, and reached the editable Idle state without starting a new harness session.

## Checklist

- [x] The PR title follows the repo convention
- [x] This PR is small and scoped to one change
- [x] Fast lint and typecheck validation pass locally
- [x] I added tests and included manual validation above
- [x] I removed secrets, tokens, private keys, and customer data from code, logs, and screenshots
- [x] No changeset is needed for this bug fix