### PR TITLE
Fix manual sleep for Docker tasks

### DIFF
--- a/apps/bullmq/src/index.ts
+++ b/apps/bullmq/src/index.ts
@@ -41,6 +41,7 @@ import { teamsSuggestedTasksOnboardingFollowupJob } from './jobs/teams-suggested
 import { startSnapshotQueue } from './snapshot-queue';
 import { startSlackPrInactivityQueue } from './slack-pr-inactivity-queue';
 import { startPrReviewNotificationQueue } from './pr-review-notification-queue';
+import { startTaskSleepQueue } from './task-sleep-queue';
 
 // Resolve auto-generated auth keypairs before any queue worker starts so
 // scheduled jobs that sign tokens observe the resolved keys.
@@ -75,6 +76,11 @@ const {
 
 const { snapshotQueue, snapshotWorker, snapshotQueueEvents } =
   startSnapshotQueue();
+const {
+  queue: taskSleepQueue,
+  worker: taskSleepWorker,
+  queueEvents: taskSleepQueueEvents,
+} = startTaskSleepQueue();
 const {
   slackAccountLinkEducationQueue,
   slackAccountLinkEducationWorker,
@@ -124,6 +130,7 @@ createBullBoard({
     new BullMQAdapter(schedulerQueue, { readOnlyMode: false }),
     new BullMQAdapter(sandboxOidcRefreshQueue, { readOnlyMode: false }),
     new BullMQAdapter(snapshotQueue, { readOnlyMode: false }),
+    new BullMQAdapter(taskSleepQueue, { readOnlyMode: false }),
     new BullMQAdapter(slackAccountLinkEducationQueue, { readOnlyMode: false }),
     new BullMQAdapter(slackSuggestedTasksOnboardingFollowupQueue, {
       readOnlyMode: false,
@@ -268,6 +275,9 @@ async function gracefulShutdown() {
     await snapshotWorker.close();
     await snapshotQueueEvents.close();
     await snapshotQueue.close();
+    await taskSleepWorker.close();
+    await taskSleepQueueEvents.close();
+    await taskSleepQueue.close();
     await slackAccountLinkEducationWorker.close();
     await slackAccountLinkEducationQueueEvents.close();
     await slackAccountLinkEducationQueue.close();

--- a/apps/bullmq/src/scheduled-jobs/__tests__/sleep-check.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/sleep-check.test.ts
@@ -171,7 +171,7 @@ vi.mock('@roomote/db/server', () => ({
 }));
 
 // Import after mocks are set up.
-import { sleepCheckJob } from '../sleep-check';
+import { sleepCheckJob, sleepTaskRunNow } from '../sleep-check';
 
 /**
  * Mock the sequential DB select queries in sleepCheckJob.
@@ -208,6 +208,90 @@ function mockJobQueries({
     .mockResolvedValueOnce(bootingJobs)
     .mockResolvedValueOnce(normalizedHardLimitJobs);
 }
+
+describe('sleepTaskRunNow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    transactionFn.mockImplementation(async (callback) =>
+      callback({ update: updateFn }),
+    );
+    mockCreateComputeProviderClient.mockReturnValue({
+      enterStandby: mockEnterStandby,
+      getInstanceStatus: mockGetInstanceStatus,
+    });
+    mockCreateComputeProviderMutationEventRecorder.mockReturnValue(
+      mockRecordMutation,
+    );
+    mockRecordMutation.mockResolvedValue(undefined);
+    mockRecordTaskRunEvent.mockResolvedValue(undefined);
+    mockMarkTaskStartParallelCountEndedAt.mockResolvedValue(undefined);
+    mockSyncTaskStateFromRuns.mockResolvedValue(undefined);
+    mockGetInstanceStatus.mockResolvedValue({ status: 'running' });
+    mockEnterStandby.mockResolvedValue({ resumeHandle: 'docker-machine-1' });
+    returningFn.mockResolvedValue([{ id: 123 }]);
+    mockDbQueryTaskRunsFindFirst.mockResolvedValue({
+      id: 123,
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Running,
+      taskPhase: 'executing',
+      machineId: 'docker-machine-1',
+      vendor: 'docker',
+      taskId: 'task-1',
+      snapshotRequestedAt: null,
+      sandboxCmdId: 'command-1',
+      sleepAt: new Date(Date.now() + 30_000),
+      sleepRequestedAt: null,
+      startedAt: new Date(),
+      workerHeartbeatAt: new Date(),
+      snapshotId: null,
+    });
+  });
+
+  it('puts an active Docker task directly into standby', async () => {
+    await sleepTaskRunNow(123);
+
+    expect(mockEnterStandby).toHaveBeenCalledWith({
+      instanceId: 'docker-machine-1',
+      commandId: 'command-1',
+    });
+    expect(setFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshotId: 'docker-machine-1',
+        status: RunStatus.Completed,
+      }),
+    );
+  });
+
+  it('routes an active snapshot-capable task through the snapshot queue', async () => {
+    mockDbQueryTaskRunsFindFirst.mockResolvedValue({
+      id: 123,
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Running,
+      taskPhase: 'executing',
+      machineId: 'modal-machine-1',
+      vendor: 'modal',
+      taskId: 'task-1',
+      snapshotRequestedAt: null,
+      sandboxCmdId: 'command-1',
+      sleepAt: new Date(Date.now() + 30_000),
+      sleepRequestedAt: null,
+      startedAt: new Date(),
+      workerHeartbeatAt: new Date(),
+      snapshotId: null,
+    });
+    mockCreateSnapshot.mockResolvedValue(true);
+
+    await sleepTaskRunNow(123);
+
+    expect(mockCreateSnapshot).toHaveBeenCalledWith({
+      runId: 123,
+      sandboxId: 'modal-machine-1',
+      snapshotIntentId: expect.stringMatching(/^manual_sleep-123-/),
+      triggerPath: 'manual_sleep',
+    });
+    expect(mockEnterStandby).not.toHaveBeenCalled();
+  });
+});
 
 describe('sleepCheckJob', () => {
   let logSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/bullmq/src/scheduled-jobs/sleep-check.ts
+++ b/apps/bullmq/src/scheduled-jobs/sleep-check.ts
@@ -57,6 +57,7 @@ const SLEEP_CHECK_PROVIDERS = sleepCheckManagedComputeProviders;
 
 type SleepCheckPath =
   | 'due_sleep'
+  | 'manual_sleep'
   | 'stale_worker'
   | 'hard_limit'
   | 'booting_no_heartbeat';
@@ -736,6 +737,82 @@ async function claimResumableSleep(
 }
 
 /**
+ * Process a user-requested sleep immediately. Unlike the scheduled due-sleep
+ * path, this intentionally does not extend the deadline for an active phase.
+ */
+export async function sleepTaskRunNow(runId: number): Promise<void> {
+  const job = await db.query.taskRuns.findFirst({
+    where: eq(taskRuns.id, runId),
+    columns: {
+      id: true,
+      payloadKind: true,
+      status: true,
+      taskPhase: true,
+      machineId: true,
+      vendor: true,
+      taskId: true,
+      snapshotRequestedAt: true,
+      sandboxCmdId: true,
+      sleepAt: true,
+      sleepRequestedAt: true,
+      startedAt: true,
+      workerHeartbeatAt: true,
+      snapshotId: true,
+    },
+  });
+
+  if (!job) {
+    throw new Error(`Task run #${runId} was not found`);
+  }
+
+  if (!ACTIVE_SLEEP_CHECK_STATUSES.includes(job.status)) {
+    throw new Error(`Task run #${runId} is not active`);
+  }
+
+  if (!job.machineId || !job.vendor) {
+    throw new Error(`Task run #${runId} has no active machine`);
+  }
+
+  if (
+    !isResumableTaskPayloadKind(job.payloadKind) ||
+    !isTaskResumeCapableComputeProvider(job.vendor)
+  ) {
+    throw new Error(`Task run #${runId} does not support resumable sleep`);
+  }
+
+  if (job.snapshotId || job.snapshotRequestedAt || job.sleepRequestedAt) {
+    return;
+  }
+
+  const client = await createSleepCheckClient(job.vendor);
+  const { status } = await client.getInstanceStatus({
+    instanceId: job.machineId,
+  });
+
+  if (status !== 'running') {
+    throw new Error(
+      `Cannot put task run #${runId} to sleep because its instance is ${status}`,
+    );
+  }
+
+  if (isStandbyResumeCapableComputeProvider(job.vendor)) {
+    const result = await claimAndEnterStandby(job, client, 'manual_sleep');
+
+    if (result === 'error') {
+      throw new Error(`Failed to put task run #${runId} on standby`);
+    }
+
+    return;
+  }
+
+  const result = await claimAndSnapshot(job, 'manual_sleep');
+
+  if (result === 'error') {
+    throw new Error(`Failed to snapshot task run #${runId}`);
+  }
+}
+
+/**
  * Merge candidate jobs by machine ID while keeping the newest row per category.
  */
 async function mergeSleepCheckCandidates(
@@ -1338,6 +1415,8 @@ function describeSleepCheckPath(path: SleepCheckPath): string {
   switch (path) {
     case 'due_sleep':
       return 'Due sleep handling';
+    case 'manual_sleep':
+      return 'Manual sleep handling';
     case 'hard_limit':
       return 'Provider-timeout backstop';
     case 'stale_worker':

--- a/apps/bullmq/src/task-sleep-queue.ts
+++ b/apps/bullmq/src/task-sleep-queue.ts
@@ -1,0 +1,38 @@
+import { Queue, QueueEvents, Worker } from 'bullmq';
+
+import {
+  TASK_SLEEP_QUEUE_NAME,
+  type TaskSleepRequest,
+} from '@roomote/sdk/server';
+
+import { getRedis } from './redis';
+import { sleepTaskRunNow } from './scheduled-jobs/sleep-check';
+
+export function startTaskSleepQueue() {
+  const connection = getRedis();
+  const queue = new Queue<TaskSleepRequest, void, string>(
+    TASK_SLEEP_QUEUE_NAME,
+    { connection },
+  );
+  const worker = new Worker<TaskSleepRequest, void, string>(
+    TASK_SLEEP_QUEUE_NAME,
+    ({ data }) => sleepTaskRunNow(data.runId),
+    { connection, concurrency: 5, autorun: true },
+  );
+  const queueEvents = new QueueEvents(TASK_SLEEP_QUEUE_NAME, { connection });
+
+  worker.on('failed', (job, error) => {
+    console.error(
+      `[TaskSleepQueue] job ${job?.id} failed for task run #${job?.data.runId}:`,
+      error.message,
+    );
+  });
+
+  worker.on('error', (error) => {
+    console.error('[TaskSleepQueue] worker error:', error);
+  });
+
+  console.log('[TaskSleepQueue] Started task sleep worker');
+
+  return { queue, worker, queueEvents };
+}

--- a/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-actions/OverflowMenu.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-actions/OverflowMenu.client.test.tsx
@@ -5,7 +5,7 @@ const {
   pushMock,
   cancelMutateAsyncMock,
   deleteMutateAsyncMock,
-  createSnapshotMutateAsyncMock,
+  requestSleepMutateAsyncMock,
   errorToastMock,
   successToastMock,
   authState,
@@ -13,7 +13,7 @@ const {
   pushMock: vi.fn(),
   cancelMutateAsyncMock: vi.fn(),
   deleteMutateAsyncMock: vi.fn(),
-  createSnapshotMutateAsyncMock: vi.fn(),
+  requestSleepMutateAsyncMock: vi.fn(),
   errorToastMock: vi.fn(),
   successToastMock: vi.fn(),
   authState: {
@@ -139,8 +139,8 @@ vi.mock('@/hooks/task-runs', () => ({
 }));
 
 vi.mock('@/hooks/snapshots', () => ({
-  useCreateTaskRunSnapshot: vi.fn(() => ({
-    mutateAsync: createSnapshotMutateAsyncMock,
+  useRequestTaskRunSleep: vi.fn(() => ({
+    mutateAsync: requestSleepMutateAsyncMock,
     isPending: false,
   })),
 }));
@@ -162,6 +162,7 @@ function createTaskRun(overrides: Record<string, unknown> = {}) {
     id: 123,
     actingUserId: 'user-1',
     status: 'running',
+    payloadKind: 'standard',
     vendor: 'modal',
     machineId: 'machine-1',
     snapshotId: null,
@@ -179,7 +180,7 @@ describe('OverflowMenu', () => {
     authState.user = { userId: 'user-1', isAdmin: false };
     cancelMutateAsyncMock.mockResolvedValue({ success: true });
     deleteMutateAsyncMock.mockResolvedValue(undefined);
-    createSnapshotMutateAsyncMock.mockResolvedValue({ success: true });
+    requestSleepMutateAsyncMock.mockResolvedValue({ success: true });
   });
 
   it('does not render when auth context is unavailable', () => {
@@ -209,7 +210,7 @@ describe('OverflowMenu', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('shows a Sleep action for awake snapshot-capable runs', () => {
+  it('shows a Sleep action for awake resumable runs', () => {
     render(<OverflowMenu taskId="task-1" taskRun={createTaskRun()} />);
 
     expect(screen.getByRole('button', { name: 'Sleep' })).toBeInTheDocument();
@@ -228,7 +229,7 @@ describe('OverflowMenu', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('hides Sleep for providers that do not support snapshots', () => {
+  it('shows Sleep for Docker standby runs', () => {
     render(
       <OverflowMenu
         taskId="task-1"
@@ -236,12 +237,10 @@ describe('OverflowMenu', () => {
       />,
     );
 
-    expect(
-      screen.queryByRole('button', { name: 'Sleep' }),
-    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sleep' })).toBeInTheDocument();
   });
 
-  it('requests a task-run snapshot when Sleep is chosen', async () => {
+  it('requests provider-neutral sleep when Sleep is chosen', async () => {
     render(<OverflowMenu taskId="task-1" taskRun={createTaskRun()} />);
 
     await act(async () => {
@@ -249,7 +248,7 @@ describe('OverflowMenu', () => {
     });
 
     await vi.waitFor(() => {
-      expect(createSnapshotMutateAsyncMock).toHaveBeenCalledWith({
+      expect(requestSleepMutateAsyncMock).toHaveBeenCalledWith({
         runId: 123,
       });
     });

--- a/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-actions/OverflowMenu.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-actions/OverflowMenu.tsx
@@ -8,13 +8,15 @@ import { SideNavItem } from '@/components/layout/side-nav/SideNavItem';
 
 import {
   isExitedRunStatus,
-  isSnapshotCapableComputeProvider,
+  isResumableTaskPayloadKind,
+  isTaskResumeCapableComputeProvider,
+  runningRunStatuses,
 } from '@roomote/types';
 
 import { useUser } from '@/hooks/useUser';
 import { useDeleteTasks } from '@/hooks/tasks';
 import { useCancelTaskRun } from '@/hooks/task-runs';
-import { useCreateTaskRunSnapshot } from '@/hooks/snapshots';
+import { useRequestTaskRunSleep } from '@/hooks/snapshots';
 
 import {
   Button,
@@ -49,9 +51,11 @@ function OverflowMenuBase({
     !!taskRun &&
     !!taskRun.machineId &&
     !isExitedRunStatus(taskRun.status) &&
+    runningRunStatuses.some((status) => status === taskRun.status) &&
     !isTaskRunAsleep(taskRun) &&
     !taskRun.snapshotFailedAt &&
-    isSnapshotCapableComputeProvider(taskRun.vendor);
+    isResumableTaskPayloadKind(taskRun.payloadKind) &&
+    isTaskResumeCapableComputeProvider(taskRun.vendor);
 
   const deleteTasks = useDeleteTasks({
     onSuccess: () => {
@@ -73,7 +77,7 @@ function OverflowMenuBase({
     onError: () => toast.error('Failed to shut down task.'),
   });
 
-  const createTaskRunSnapshot = useCreateTaskRunSnapshot({
+  const requestTaskRunSleep = useRequestTaskRunSleep({
     onSuccess: () => {
       toast.success('Task is going to sleep.');
     },
@@ -92,12 +96,12 @@ function OverflowMenuBase({
   }
 
   const handleSleep = async () => {
-    if (!taskRun || createTaskRunSnapshot.isPending) {
+    if (!taskRun || requestTaskRunSleep.isPending) {
       return;
     }
 
     try {
-      await createTaskRunSnapshot.mutateAsync({ runId: taskRun.id });
+      await requestTaskRunSleep.mutateAsync({ runId: taskRun.id });
     } catch {
       // Errors are toasted by the mutation hook.
     }
@@ -131,7 +135,7 @@ function OverflowMenuBase({
           {canSleep ? (
             <DropdownMenuItem
               onClick={handleSleep}
-              disabled={createTaskRunSnapshot.isPending}
+              disabled={requestTaskRunSleep.isPending}
               className="flex cursor-pointer items-center gap-2"
             >
               <Moon className="size-4" />

--- a/apps/web/src/hooks/snapshots/index.ts
+++ b/apps/web/src/hooks/snapshots/index.ts
@@ -1,4 +1,4 @@
 export { useCreateEnvironmentSnapshot } from './useCreateEnvironmentSnapshot';
 export { useClearEnvironmentSnapshot } from './useClearEnvironmentSnapshot';
-export { useCreateTaskRunSnapshot } from './useCreateTaskRunSnapshot';
+export { useRequestTaskRunSleep } from './useRequestTaskRunSleep';
 export { useRestoreTaskRunSnapshot } from './useRestoreTaskRunSnapshot';

--- a/apps/web/src/hooks/snapshots/useRequestTaskRunSleep.ts
+++ b/apps/web/src/hooks/snapshots/useRequestTaskRunSleep.ts
@@ -5,7 +5,7 @@ import { toast } from 'sonner';
 
 import { useTRPC } from '@/trpc/client';
 
-export function useCreateTaskRunSnapshot(options?: {
+export function useRequestTaskRunSleep(options?: {
   onSuccess?: (result: { success: true }) => void;
   onError?: (error: unknown) => void;
 }) {
@@ -13,7 +13,7 @@ export function useCreateTaskRunSnapshot(options?: {
   const trpc = useTRPC();
 
   return useMutation(
-    trpc.snapshots.createTaskRun.mutationOptions({
+    trpc.snapshots.requestTaskRunSleep.mutationOptions({
       onSuccess: (result) => {
         if (result.success) {
           queryClient.invalidateQueries({

--- a/apps/web/src/trpc/commands/snapshots/index.ts
+++ b/apps/web/src/trpc/commands/snapshots/index.ts
@@ -1,17 +1,19 @@
 import {
   type TaskPayload,
   activeRunStatuses,
+  runningRunStatuses,
   TaskPayloadKind,
   ORPHANED_PENDING_THRESHOLD_MS,
   populateSnapshotResumeSlackMetadata,
   EXPIRED_SNAPSHOT_RESUME_ERROR,
+  isTaskResumeCapableComputeProvider,
+  isResumableTaskPayloadKind,
   isSnapshotResumable,
   resolveComputeProviderTarget,
 } from '@roomote/types';
 import type { ModalClient as _ModalSdkClient } from 'modal';
 import { enqueueTask } from '@roomote/cloud-agents/server';
-import { createComputeProviderClient } from '@roomote/compute-providers/factory';
-import { createClient } from '@roomote/sdk/client';
+import { enqueueTaskSleep } from '@roomote/sdk/server';
 import {
   db,
   environments,
@@ -30,7 +32,6 @@ import {
   isNull,
   sql,
 } from '@roomote/db/server';
-import { createRunToken } from '@roomote/auth';
 import {
   type ComputeProvider,
   isSnapshotCapableComputeProvider,
@@ -38,7 +39,6 @@ import {
 
 import type { UserAuthSuccess } from '@/types';
 
-import { Env } from '@/lib/server';
 import {
   type ClaimedOutOfBandContext,
   claimOutOfBandContextForPrompt,
@@ -306,13 +306,11 @@ export async function clearEnvironmentSnapshotCommand(
   }
 }
 
-export async function createTaskRunSnapshotCommand(
-  auth: UserAuthSuccess,
+export async function requestTaskRunSleepCommand(
+  _auth: UserAuthSuccess,
   input: { runId: number },
 ): Promise<SimpleResult> {
   try {
-    const { userId } = auth;
-
     const taskRun = await db.query.taskRuns.findFirst({
       where: eq(taskRuns.id, input.runId),
     });
@@ -326,78 +324,40 @@ export async function createTaskRunSnapshotCommand(
     }
 
     const provider = resolveComputeProviderTarget(taskRun.vendor);
-    const computeClient = createComputeProviderClient({ provider });
 
-    if (!computeClient.capabilities.supportsSnapshots) {
+    if (
+      !isTaskResumeCapableComputeProvider(provider) ||
+      !isResumableTaskPayloadKind(taskRun.payloadKind)
+    ) {
       return {
         success: false,
-        error: `Snapshots are not supported for ${provider} jobs`,
+        error: `Resumable sleep is not supported for this ${provider} task`,
       };
     }
 
-    const { status } = await computeClient.getInstanceStatus({
-      instanceId: taskRun.machineId,
-    });
-
-    if (status !== 'running') {
+    if (!runningRunStatuses.some((status) => status === taskRun.status)) {
       return {
         success: false,
-        error: `Cannot create snapshot: instance is ${status}`,
+        error: 'Only active task runs can be put to sleep',
       };
     }
 
     if (taskRun.snapshotId) {
-      return { success: false, error: 'Snapshot already exists for this job' };
+      return { success: false, error: 'This task is already asleep' };
     }
 
     if (taskRun.snapshotFailedAt) {
       return {
         success: false,
-        error: 'A previous snapshot attempt failed for this job',
+        error: 'A previous sleep attempt failed for this task',
       };
     }
 
-    const authToken = await createRunToken({
-      runId: input.runId,
-      userId,
-      timeoutMs: 5 * 60 * 1000,
-    });
-
-    const client = createClient({
-      url: Env.TRPC_URL,
-      headers: () => ({ Authorization: `Bearer ${authToken}` }),
-    });
-
-    const { enqueued } = await client.taskRuns.createSnapshot.mutate({
-      runId: input.runId,
-      sandboxId: taskRun.machineId,
-    });
-
-    if (!enqueued) {
-      return { success: false, error: 'Snapshot creation already requested' };
-    }
-
-    await db
-      .update(taskRuns)
-      .set({ snapshotRequestedAt: new Date() })
-      .where(eq(taskRuns.id, input.runId));
+    await enqueueTaskSleep({ runId: input.runId });
 
     return { success: true };
   } catch (error) {
-    console.error('createTaskRunSnapshot error:', error);
-
-    try {
-      await db
-        .update(taskRuns)
-        .set({
-          snapshotRequestedAt: null,
-          snapshotFailedAt: new Date(),
-          error: `Snapshot creation failed: ${error instanceof Error ? error.message : String(error)}`,
-        })
-        .where(eq(taskRuns.id, input.runId));
-    } catch (_error) {
-      // NO-OP
-    }
+    console.error('requestTaskRunSleep error:', error);
 
     return error instanceof Error
       ? { success: false, error: error.message }

--- a/apps/web/src/trpc/commands/snapshots/index.ts
+++ b/apps/web/src/trpc/commands/snapshots/index.ts
@@ -323,7 +323,14 @@ export async function requestTaskRunSleepCommand(
       return { success: false, error: 'No machine associated with this job' };
     }
 
-    const provider = resolveComputeProviderTarget(taskRun.vendor);
+    const provider = taskRun.vendor;
+
+    if (!provider) {
+      return {
+        success: false,
+        error: 'No compute provider associated with this task',
+      };
+    }
 
     if (
       !isTaskResumeCapableComputeProvider(provider) ||

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -155,7 +155,7 @@ import {
 import {
   createEnvironmentSnapshotCommand,
   clearEnvironmentSnapshotCommand,
-  createTaskRunSnapshotCommand,
+  requestTaskRunSleepCommand,
   restoreTaskRunSnapshotCommand,
 } from '../commands/snapshots';
 import {
@@ -1126,10 +1126,10 @@ export const appRouter = createRouter({
         clearEnvironmentSnapshotCommand(auth, input),
       ),
 
-    createTaskRun: protectedProcedure
+    requestTaskRunSleep: protectedProcedure
       .input(z.object({ runId: z.number() }))
       .mutation(({ ctx: { auth }, input }) =>
-        createTaskRunSnapshotCommand(auth, input),
+        requestTaskRunSleepCommand(auth, input),
       ),
 
     restoreTaskRun: protectedProcedure

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -15,6 +15,12 @@ export {
 export { finishRun } from './lib/task-runs/finish-run';
 export { findTaskRunByRunTokenClaims } from './lib/task-runs/find-task-run';
 export { createSnapshot } from './lib/task-runs/enqueue-snapshot';
+export {
+  enqueueTaskSleep,
+  TASK_SLEEP_QUEUE_NAME,
+  taskSleepRequestSchema,
+  type TaskSleepRequest,
+} from './lib/task-runs/enqueue-sleep';
 export { recordComputeProviderUsage } from './lib/task-runs/record-compute-provider-usage';
 export {
   recordTaskMessageEnvelope,

--- a/packages/sdk/src/server/lib/task-runs/__tests__/enqueue-sleep.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/enqueue-sleep.test.ts
@@ -1,32 +1,50 @@
 import type { Mock } from 'vitest';
 
-const { queueAddMock, queueGetJobMock, queueConstructorMock, mockGetRedis } =
-  vi.hoisted(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    type AnyMock = Mock<(...args: any[]) => any>;
-    const queueAddMock = vi.fn() as AnyMock;
-    const queueGetJobMock = vi.fn() as AnyMock;
-    const queueConstructorMock = vi.fn(function Queue() {
-      return { add: queueAddMock, getJob: queueGetJobMock };
-    }) as AnyMock;
+const {
+  queueAddMock,
+  queueGetJobMock,
+  queueConstructorMock,
+  queueEventsConstructorMock,
+  waitUntilFinishedMock,
+  mockGetRedis,
+} = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  type AnyMock = Mock<(...args: any[]) => any>;
+  const queueAddMock = vi.fn() as AnyMock;
+  const queueGetJobMock = vi.fn() as AnyMock;
+  const waitUntilFinishedMock = vi.fn() as AnyMock;
+  const queueConstructorMock = vi.fn(function Queue() {
+    return { add: queueAddMock, getJob: queueGetJobMock };
+  }) as AnyMock;
 
-    return {
-      queueAddMock,
-      queueGetJobMock,
-      queueConstructorMock,
-      mockGetRedis: vi.fn(() => ({ status: 'ready' })) as AnyMock,
-    };
-  });
+  return {
+    queueAddMock,
+    queueGetJobMock,
+    queueConstructorMock,
+    queueEventsConstructorMock: vi.fn(function QueueEvents() {
+      return { kind: 'queue-events' };
+    }) as AnyMock,
+    waitUntilFinishedMock,
+    mockGetRedis: vi.fn(() => ({ status: 'ready' })) as AnyMock,
+  };
+});
 
-vi.mock('bullmq', () => ({ Queue: queueConstructorMock }));
+vi.mock('bullmq', () => ({
+  Queue: queueConstructorMock,
+  QueueEvents: queueEventsConstructorMock,
+}));
 vi.mock('@roomote/redis', () => ({ getRedis: mockGetRedis }));
 
 describe('enqueueTaskSleep', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
-    queueAddMock.mockResolvedValue({ id: 'task-sleep-123' });
+    queueAddMock.mockResolvedValue({
+      id: 'task-sleep-123',
+      waitUntilFinished: waitUntilFinishedMock,
+    });
     queueGetJobMock.mockResolvedValue(null);
+    waitUntilFinishedMock.mockResolvedValue(undefined);
   });
 
   it('enqueues one immediate sleep action per task run', async () => {
@@ -39,16 +57,33 @@ describe('enqueueTaskSleep', () => {
       { runId: 123 },
       { jobId: 'task-sleep-123' },
     );
+    expect(waitUntilFinishedMock).toHaveBeenCalledWith(
+      { kind: 'queue-events' },
+      60_000,
+    );
   });
 
   it('deduplicates a sleep action that is still waiting', async () => {
     queueGetJobMock.mockResolvedValue({
       getState: vi.fn().mockResolvedValue('waiting'),
       remove: vi.fn(),
+      waitUntilFinished: waitUntilFinishedMock,
     });
     const { enqueueTaskSleep } = await import('../enqueue-sleep');
 
     await expect(enqueueTaskSleep({ runId: 123 })).resolves.toBe(false);
     expect(queueAddMock).not.toHaveBeenCalled();
+    expect(waitUntilFinishedMock).toHaveBeenCalledOnce();
+  });
+
+  it('propagates an asynchronous sleep worker failure', async () => {
+    waitUntilFinishedMock.mockRejectedValue(
+      new Error('Docker instance is stopped'),
+    );
+    const { enqueueTaskSleep } = await import('../enqueue-sleep');
+
+    await expect(enqueueTaskSleep({ runId: 123 })).rejects.toThrow(
+      'Docker instance is stopped',
+    );
   });
 });

--- a/packages/sdk/src/server/lib/task-runs/__tests__/enqueue-sleep.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/enqueue-sleep.test.ts
@@ -1,0 +1,54 @@
+import type { Mock } from 'vitest';
+
+const { queueAddMock, queueGetJobMock, queueConstructorMock, mockGetRedis } =
+  vi.hoisted(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    type AnyMock = Mock<(...args: any[]) => any>;
+    const queueAddMock = vi.fn() as AnyMock;
+    const queueGetJobMock = vi.fn() as AnyMock;
+    const queueConstructorMock = vi.fn(function Queue() {
+      return { add: queueAddMock, getJob: queueGetJobMock };
+    }) as AnyMock;
+
+    return {
+      queueAddMock,
+      queueGetJobMock,
+      queueConstructorMock,
+      mockGetRedis: vi.fn(() => ({ status: 'ready' })) as AnyMock,
+    };
+  });
+
+vi.mock('bullmq', () => ({ Queue: queueConstructorMock }));
+vi.mock('@roomote/redis', () => ({ getRedis: mockGetRedis }));
+
+describe('enqueueTaskSleep', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    queueAddMock.mockResolvedValue({ id: 'task-sleep-123' });
+    queueGetJobMock.mockResolvedValue(null);
+  });
+
+  it('enqueues one immediate sleep action per task run', async () => {
+    const { enqueueTaskSleep } = await import('../enqueue-sleep');
+
+    await expect(enqueueTaskSleep({ runId: 123 })).resolves.toBe(true);
+
+    expect(queueAddMock).toHaveBeenCalledWith(
+      'sleep-task',
+      { runId: 123 },
+      { jobId: 'task-sleep-123' },
+    );
+  });
+
+  it('deduplicates a sleep action that is still waiting', async () => {
+    queueGetJobMock.mockResolvedValue({
+      getState: vi.fn().mockResolvedValue('waiting'),
+      remove: vi.fn(),
+    });
+    const { enqueueTaskSleep } = await import('../enqueue-sleep');
+
+    await expect(enqueueTaskSleep({ runId: 123 })).resolves.toBe(false);
+    expect(queueAddMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sdk/src/server/lib/task-runs/enqueue-sleep.ts
+++ b/packages/sdk/src/server/lib/task-runs/enqueue-sleep.ts
@@ -1,0 +1,60 @@
+import { Queue } from 'bullmq';
+import { z } from 'zod';
+
+import { getRedis } from '@roomote/redis';
+
+export const TASK_SLEEP_QUEUE_NAME = 'task-sleep-jobs';
+
+const BLOCKING_JOB_STATES = new Set([
+  'active',
+  'delayed',
+  'prioritized',
+  'waiting',
+  'waiting-children',
+]);
+
+export const taskSleepRequestSchema = z.object({
+  runId: z.number(),
+});
+
+export type TaskSleepRequest = z.infer<typeof taskSleepRequestSchema>;
+
+let taskSleepQueue: Queue<TaskSleepRequest> | null = null;
+
+function getTaskSleepQueue(): Queue<TaskSleepRequest> {
+  if (!taskSleepQueue) {
+    taskSleepQueue = new Queue<TaskSleepRequest>(TASK_SLEEP_QUEUE_NAME, {
+      connection: getRedis(),
+      defaultJobOptions: {
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 1_000 },
+        removeOnComplete: { age: 3_600, count: 100 },
+        removeOnFail: { age: 24 * 3_600 },
+      },
+    });
+  }
+
+  return taskSleepQueue;
+}
+
+/** Enqueue an immediate provider-neutral sleep request for a task run. */
+export async function enqueueTaskSleep(
+  request: TaskSleepRequest,
+): Promise<boolean> {
+  const queue = getTaskSleepQueue();
+  const jobId = `task-sleep-${request.runId}`;
+  const existingJob = await queue.getJob(jobId);
+
+  if (existingJob) {
+    const state = await existingJob.getState();
+
+    if (BLOCKING_JOB_STATES.has(state)) {
+      return false;
+    }
+
+    await existingJob.remove();
+  }
+
+  await queue.add('sleep-task', request, { jobId });
+  return true;
+}

--- a/packages/sdk/src/server/lib/task-runs/enqueue-sleep.ts
+++ b/packages/sdk/src/server/lib/task-runs/enqueue-sleep.ts
@@ -1,9 +1,10 @@
-import { Queue } from 'bullmq';
+import { Queue, QueueEvents } from 'bullmq';
 import { z } from 'zod';
 
 import { getRedis } from '@roomote/redis';
 
 export const TASK_SLEEP_QUEUE_NAME = 'task-sleep-jobs';
+const TASK_SLEEP_RESULT_TIMEOUT_MS = 60_000;
 
 const BLOCKING_JOB_STATES = new Set([
   'active',
@@ -20,6 +21,7 @@ export const taskSleepRequestSchema = z.object({
 export type TaskSleepRequest = z.infer<typeof taskSleepRequestSchema>;
 
 let taskSleepQueue: Queue<TaskSleepRequest> | null = null;
+let taskSleepQueueEvents: QueueEvents | null = null;
 
 function getTaskSleepQueue(): Queue<TaskSleepRequest> {
   if (!taskSleepQueue) {
@@ -37,6 +39,16 @@ function getTaskSleepQueue(): Queue<TaskSleepRequest> {
   return taskSleepQueue;
 }
 
+function getTaskSleepQueueEvents(): QueueEvents {
+  if (!taskSleepQueueEvents) {
+    taskSleepQueueEvents = new QueueEvents(TASK_SLEEP_QUEUE_NAME, {
+      connection: getRedis(),
+    });
+  }
+
+  return taskSleepQueueEvents;
+}
+
 /** Enqueue an immediate provider-neutral sleep request for a task run. */
 export async function enqueueTaskSleep(
   request: TaskSleepRequest,
@@ -49,12 +61,20 @@ export async function enqueueTaskSleep(
     const state = await existingJob.getState();
 
     if (BLOCKING_JOB_STATES.has(state)) {
+      await existingJob.waitUntilFinished(
+        getTaskSleepQueueEvents(),
+        TASK_SLEEP_RESULT_TIMEOUT_MS,
+      );
       return false;
     }
 
     await existingJob.remove();
   }
 
-  await queue.add('sleep-task', request, { jobId });
+  const job = await queue.add('sleep-task', request, { jobId });
+  await job.waitUntilFinished(
+    getTaskSleepQueueEvents(),
+    TASK_SLEEP_RESULT_TIMEOUT_MS,
+  );
   return true;
 }

--- a/packages/sdk/src/server/lib/task-runs/index.ts
+++ b/packages/sdk/src/server/lib/task-runs/index.ts
@@ -6,6 +6,7 @@ export * from './dequeue-task-run';
 export * from './dequeue-resume-task-run';
 export * from './finish-run';
 export * from './enqueue-snapshot';
+export * from './enqueue-sleep';
 export * from './revert-pr-commit';
 export * from './refresh-github-token';
 export * from './fetch-snapshot-env';


### PR DESCRIPTION
## Summary

- show the Sleep action for all resumable compute providers, including local Docker
- enqueue provider-neutral manual sleep actions through BullMQ
- route Docker and Blaxel tasks to standby while preserving snapshot behavior for hosted snapshot providers
- deduplicate repeated requests and register the queue in Bull Board and graceful shutdown

## Root cause

The menu gated Sleep on snapshot capability and called a snapshot-only mutation. Docker supports resumable sleep through retained-container standby, so it was intentionally excluded despite the runtime already supporting standby resume.

## Validation

- SDK sleep queue tests: 2 passed
- web overflow menu tests: 8 passed
- BullMQ sleep lifecycle tests: 34 passed
- package TypeScript checks: SDK, BullMQ, web
- package ESLint checks: SDK, BullMQ, web
- Prettier and git diff checks