### PR TITLE
[Chore] Update fixtures

### DIFF
--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
@@ -170,13 +170,13 @@ describe('StepSourceControlConfig', () => {
     );
 
     fireEvent.change(screen.getByLabelText('GitHub organization (optional)'), {
-      target: { value: ' roovetgit ' },
+      target: { value: ' example-org ' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Create GitHub App' }));
 
     expect(createGitHubAppManifestMock).toHaveBeenCalledWith({
       redirect: '/setup?step=source-control-connect',
-      organization: 'roovetgit',
+      organization: 'example-org',
     });
   });
 

--- a/apps/web/src/components/layout/side-nav/SideNav.client.test.tsx
+++ b/apps/web/src/components/layout/side-nav/SideNav.client.test.tsx
@@ -683,7 +683,7 @@ describe('SideNav quick access tasks', () => {
       { id: 'env-1', name: 'Maxolen Staging' },
       { id: 'env-2', name: 'CC Environment' },
       { id: 'env-3', name: 'Roomote Dev' },
-      { id: 'env-4', name: 'LogSharp' },
+      { id: 'env-4', name: 'Sandbox' },
       { id: 'env-5', name: 'QA' },
       { id: 'env-6', name: 'Prod' },
     ];

--- a/apps/web/src/lib/server/auth.test.ts
+++ b/apps/web/src/lib/server/auth.test.ts
@@ -119,7 +119,7 @@ describe('getAuth', () => {
       adoBaseUrl: 'https://dev.azure.com',
       adoClientId: 'ado-client-id',
       adoClientSecret: 'ado-client-secret',
-      adoOrganization: 'roo-vet',
+      adoOrganization: 'ado-organization',
       adoTenantId: 'roomote-tenant-id',
       gitlabBaseUrl: undefined,
       gitlabClientId: undefined,

--- a/apps/web/src/trpc/commands/github/mutations.test.ts
+++ b/apps/web/src/trpc/commands/github/mutations.test.ts
@@ -207,7 +207,7 @@ describe('GitHub App manifest commands', () => {
         mode: 'github-app-manifest',
         redirect: '/setup?step=source-control-connect',
       },
-      'roovetgit',
+      'example-org',
     );
 
     expect(result.success).toBe(true);
@@ -218,7 +218,7 @@ describe('GitHub App manifest commands', () => {
 
     const postTarget = new URL(result.postTarget);
     expect(`${postTarget.origin}${postTarget.pathname}`).toBe(
-      'https://github.com/organizations/roovetgit/settings/apps/new',
+      'https://github.com/organizations/example-org/settings/apps/new',
     );
     expect(decodeRecord(postTarget.searchParams.get('state') ?? '')).toEqual({
       mode: 'github-app-manifest',

--- a/packages/github/src/__tests__/task-run-token.test.ts
+++ b/packages/github/src/__tests__/task-run-token.test.ts
@@ -92,13 +92,13 @@ describe('createTaskRunGitHubToken', () => {
   it('uses the selected repositories installation for scoped multi-repo tasks', async () => {
     mockFindMany.mockResolvedValue([
       {
-        fullName: 'LogSharpDoo/ViradaBMS-BE',
-        installationId: 'install-logsharpdoo',
+        fullName: 'ExampleOrg/example-backend',
+        installationId: 'install-exampleorg',
         githubRepoId: 101,
       },
       {
-        fullName: 'LogSharpDoo/ViradaBMS-React',
-        installationId: 'install-logsharpdoo',
+        fullName: 'ExampleOrg/example-frontend',
+        installationId: 'install-exampleorg',
         githubRepoId: 102,
       },
     ]);
@@ -108,8 +108,8 @@ describe('createTaskRunGitHubToken', () => {
         buildTaskRun({
           repo: '__all_repositories__',
           selectedRepositories: [
-            'LogSharpDoo/ViradaBMS-BE',
-            'LogSharpDoo/ViradaBMS-React',
+            'ExampleOrg/example-backend',
+            'ExampleOrg/example-frontend',
           ],
         } as TaskRun['payload']),
       ),
@@ -118,7 +118,7 @@ describe('createTaskRunGitHubToken', () => {
     expect(mockFindFirst).not.toHaveBeenCalled();
     expect(mockCreateGitHubToken).toHaveBeenCalledWith({
       type: 'installationId',
-      installationId: 'install-logsharpdoo',
+      installationId: 'install-exampleorg',
       repositoryIds: [101, 102],
     });
   });


### PR DESCRIPTION
## What changed

Follow-up to #192: replaces the remaining real-world identifiers that sweep missed in five test files with fictional placeholder data, ahead of the repo going public.

- `packages/github/src/__tests__/task-run-token.test.ts`: the multi-repo token test now uses `ExampleOrg/example-backend` / `ExampleOrg/example-frontend` with `install-exampleorg`, matching the `Roomote/example-app` + `install-roomote` convention already used by the neighboring environment test.
- `apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx` and `apps/web/src/trpc/commands/github/mutations.test.ts`: the GitHub organization fixture is now `example-org` (including the `github.com/organizations/example-org/settings/apps/new` manifest URL assertion).
- `apps/web/src/lib/server/auth.test.ts`: `adoOrganization` is now `ado-organization`, matching the descriptive placeholder style of the surrounding config (`ado-client-id`, `ado-client-secret`).
- `apps/web/src/components/layout/side-nav/SideNav.client.test.tsx`: the `env-4` environment name is now `Sandbox`.

No production code changes; string literals in test fixtures only.

## How it was tested

- A case-insensitive grep for the internally tracked identifier list returns zero hits on this branch.
- Targeted Vitest runs for all five affected test files pass (6 tests in `@roomote/github`, 38 across the four `@roomote/web` files).
- `pnpm lint:fast` and `pnpm check-types:fast` pass locally; Knip is green in this PR's CI.

## Checklist

- [x] The PR title follows the repo convention: `[Fix]`, `[Feat]`, `[Improve]`, `[Refactor]`, `[Docs]`, or `[Chore]` followed by a user-facing description
- [x] This PR is small and scoped to one change
- [x] `pnpm lint` and `pnpm check-types` pass locally
- [x] I added tests or included a clear manual validation note above
- [x] I removed secrets, tokens, private keys, and customer data from code, logs, and screenshots
- [ ] If this change should appear in the changelog, I ran `pnpm changeset` (not needed: test-fixture text only)