### PR TITLE
Harden Blaxel sandbox lifecycle

### DIFF
--- a/apps/controller/src/compute-providers/__tests__/spawn-blaxel-worker.test.ts
+++ b/apps/controller/src/compute-providers/__tests__/spawn-blaxel-worker.test.ts
@@ -103,6 +103,7 @@ describe('spawnBlaxelWorker', () => {
 
     expect(mockCreateBlaxelMachine).toHaveBeenCalledWith(
       expect.objectContaining({
+        idempotencyKey: 'roomote-task-task-321',
         launchMode: 'task_standby',
         resumeHandle: 'roomote-blaxel-standby',
       }),

--- a/apps/controller/src/compute-providers/spawn-blaxel-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-blaxel-worker.ts
@@ -108,6 +108,7 @@ export async function spawnBlaxelWorker(
     blaxelApiKey: config.blaxelApiKey,
     blaxelWorkspace: config.blaxelWorkspace,
     blaxelImage: config.blaxelImage,
+    idempotencyKey: `roomote-task-${taskRun.taskId}`,
     blaxelRegion: config.blaxelRegion,
     namedPorts,
     tags: config.blaxelTags,

--- a/apps/docs/providers/compute/blaxel.mdx
+++ b/apps/docs/providers/compute/blaxel.mdx
@@ -52,9 +52,17 @@ and appear as locked values in Settings.
 ## Runtime behavior
 
 - Roomote requests a Blaxel TTL matching the task timeout.
+- Fresh sandbox provisioning uses a stable task identity and Blaxel's
+  idempotent create API so controller retries reconnect instead of creating
+  duplicate sandboxes.
 - Each exposed port receives a public Blaxel preview URL. Roomote's preview
-  proxy remains the user-facing authentication layer.
+  proxy remains the user-facing authentication layer. Existing preview
+  resources are reused across standby resumes.
 - The detached worker process uses Blaxel keep-alive while the task is active.
+- When Blaxel reports `WORKLOAD_UNAVAILABLE`, Roomote retries workload access
+  with bounded exponential backoff. Missing workloads, invalid routes, and
+  application-origin errors are handled separately rather than retried as
+  transient platform failures.
 - When a resumable task goes to sleep, Roomote stops its worker, extends the
   sandbox lifetime to the configured standby age (seven days by default), and
   lets Blaxel move the sandbox to standby.

--- a/packages/compute-providers/src/__tests__/adapters.contract.test.ts
+++ b/packages/compute-providers/src/__tests__/adapters.contract.test.ts
@@ -65,6 +65,7 @@ vi.mock('e2b', () => ({
 
 const {
   blaxelCreateMock,
+  blaxelCreateIfNotExistsMock,
   blaxelGetMock,
   blaxelListMock,
   blaxelDeleteMock,
@@ -72,6 +73,7 @@ const {
   blaxelSettingsMock,
 } = vi.hoisted(() => ({
   blaxelCreateMock: vi.fn(),
+  blaxelCreateIfNotExistsMock: vi.fn(),
   blaxelGetMock: vi.fn(),
   blaxelListMock: vi.fn(),
   blaxelDeleteMock: vi.fn(),
@@ -83,6 +85,7 @@ vi.mock('@blaxel/core', () => ({
   settings: { setConfig: blaxelSettingsMock },
   SandboxInstance: {
     create: blaxelCreateMock,
+    createIfNotExists: blaxelCreateIfNotExistsMock,
     get: blaxelGetMock,
     list: blaxelListMock,
     delete: blaxelDeleteMock,
@@ -249,10 +252,13 @@ describe('compute provider adapter contracts', () => {
       created.instanceId,
       '120s',
     );
-    expect(sandbox.previews.delete).toHaveBeenCalledWith('port-3000');
-    expect(sandbox.previews.delete).toHaveBeenCalledWith('port-4000');
-    expect(sandbox.previews.create).toHaveBeenCalledWith(
-      expect.objectContaining({ metadata: { name: 'port-3000' } }),
+    expect(sandbox.previews.delete).not.toHaveBeenCalled();
+    expect(sandbox.previews.create).not.toHaveBeenCalled();
+    expect(sandbox.previews.createIfNotExists).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: { name: 'port-3000' },
+        spec: { port: 3000, public: true },
+      }),
     );
     await client.destroyInstance({ instanceId: created.instanceId });
     expect(blaxelDeleteMock).toHaveBeenCalledWith(created.instanceId);
@@ -281,6 +287,65 @@ describe('compute provider adapter contracts', () => {
     const createdName = blaxelCreateMock.mock.calls[0]?.[0]?.name;
     expect(createdName).toEqual(expect.any(String));
     expect(blaxelDeleteMock).toHaveBeenCalledWith(createdName);
+  });
+
+  it('creates Blaxel sandboxes idempotently from a stable external key', async () => {
+    const sandbox = {
+      metadata: { name: 'roomote-stable' },
+      wait: vi.fn().mockResolvedValue(undefined),
+      previews: {
+        createIfNotExists: vi.fn().mockResolvedValue({
+          spec: { url: 'https://3000.blaxel.test' },
+        }),
+      },
+    };
+    blaxelCreateIfNotExistsMock.mockResolvedValue(sandbox);
+
+    const client = createComputeProviderClient({
+      provider: 'blaxel',
+      config: {
+        apiKey: 'key',
+        workspace: 'workspace',
+        image: 'sandbox/roomote-worker:version',
+        timeoutMs: 120_000,
+      },
+    });
+
+    const created = await client.createInstance({
+      idempotencyKey: 'roomote-task-run:123',
+      ports: [3000],
+    });
+
+    expect(created.instanceId).toMatch(/^roomote-[a-f0-9]{32}$/);
+    expect(blaxelCreateMock).not.toHaveBeenCalled();
+    expect(blaxelCreateIfNotExistsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: created.instanceId,
+        externalId: 'roomote-task-run:123',
+      }),
+    );
+  });
+
+  it('retains an idempotently-created Blaxel sandbox when readiness fails', async () => {
+    const sandbox = {
+      metadata: { name: 'roomote-stable' },
+      wait: vi.fn().mockRejectedValue(new Error('deployment failed')),
+    };
+    blaxelCreateIfNotExistsMock.mockResolvedValue(sandbox);
+
+    const client = createComputeProviderClient({
+      provider: 'blaxel',
+      config: {
+        apiKey: 'key',
+        workspace: 'workspace',
+        image: 'sandbox/roomote-worker:version',
+      },
+    });
+
+    await expect(
+      client.createInstance({ idempotencyKey: 'roomote-task-run:123' }),
+    ).rejects.toThrow('deployment failed');
+    expect(blaxelDeleteMock).not.toHaveBeenCalled();
   });
 
   it('cleans up a Blaxel sandbox that resolves after create is aborted', async () => {
@@ -339,6 +404,95 @@ describe('compute provider adapter contracts', () => {
 
       await expect(writePromise).resolves.toBeUndefined();
       expect(writeBinary).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('retries Blaxel command launch while the workload data plane is starting', async () => {
+    vi.useFakeTimers();
+    try {
+      const exec = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new Error(
+            '404 {"error":{"code":"WORKLOAD_UNAVAILABLE","origin":"platform","retryable":true}}',
+          ),
+        )
+        .mockResolvedValue({
+          name: 'command-1',
+          status: 'running',
+          exitCode: null,
+        });
+      blaxelGetMock.mockResolvedValue({ process: { exec } });
+      const client = createComputeProviderClient({
+        provider: 'blaxel',
+        config: {
+          apiKey: 'key',
+          workspace: 'workspace',
+          image: 'ghcr.io/roomote/worker:test',
+        },
+      });
+
+      const commandPromise = client.runCommand({
+        instanceId: 'sandbox-1',
+        cmd: 'worker',
+        args: ['resume', '123'],
+        detached: true,
+      });
+      await vi.advanceTimersByTimeAsync(500);
+
+      await expect(commandPromise).resolves.toMatchObject({
+        commandId: 'command-1',
+        exitCode: null,
+      });
+      expect(exec).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('retries Blaxel standby TTL and preview recovery while the workload is starting', async () => {
+    vi.useFakeTimers();
+    try {
+      const unavailable = new Error(
+        '404 {"error":{"code":"WORKLOAD_UNAVAILABLE","origin":"platform","retryable":true}}',
+      );
+      const createIfNotExists = vi
+        .fn()
+        .mockRejectedValueOnce(unavailable)
+        .mockResolvedValue({ spec: { url: 'https://3000.blaxel.test' } });
+      const sandbox = {
+        metadata: { name: 'sandbox-1' },
+        previews: { createIfNotExists },
+      };
+      blaxelUpdateTtlMock
+        .mockRejectedValueOnce(unavailable)
+        .mockResolvedValue(sandbox);
+      blaxelGetMock.mockResolvedValue(sandbox);
+      const client = createComputeProviderClient({
+        provider: 'blaxel',
+        config: {
+          apiKey: 'key',
+          workspace: 'workspace',
+          image: 'ghcr.io/roomote/worker:test',
+          timeoutMs: 120_000,
+        },
+      });
+
+      const resumePromise = client.resumeFromStandby?.({
+        resumeHandle: 'sandbox-1',
+        ports: [3000],
+      });
+      await vi.advanceTimersByTimeAsync(500);
+      await vi.advanceTimersByTimeAsync(500);
+
+      await expect(resumePromise).resolves.toMatchObject({
+        instanceId: 'sandbox-1',
+        domains: { '3000': 'https://3000.blaxel.test' },
+      });
+      expect(blaxelUpdateTtlMock).toHaveBeenCalledTimes(2);
+      expect(createIfNotExists).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/compute-providers/src/adapters/blaxel.ts
+++ b/packages/compute-providers/src/adapters/blaxel.ts
@@ -1,11 +1,9 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 
 import { SandboxInstance, settings } from '@blaxel/core';
 import {
   BLAXEL_CAPABILITIES as BLAXEL_CAPABILITIES_VALUE,
   type ComputeProvider,
-  extractErrorDetails,
-  serializeError,
 } from '@roomote/types';
 
 import { raceWithAbort, sleepWithSignal, throwIfAborted } from '../modal/abort';
@@ -36,6 +34,10 @@ import type {
   StreamCommandOutputInput,
   WriteFileInput,
 } from '../types';
+import {
+  isBlaxelResourceNotFound,
+  isBlaxelWorkloadUnavailable,
+} from '../blaxel/errors';
 
 const STREAM_POLL_INTERVAL_MS = 1_000;
 const WORKLOAD_READY_RETRY_BUDGET_MS = 60_000;
@@ -96,26 +98,37 @@ export class BlaxelClient implements ComputeProviderClient {
     input: CreateInstanceInput,
   ): Promise<CreatedInstance> {
     throwIfAborted(input.signal);
-    const name = `roomote-${randomUUID()}`.slice(0, 49);
+    const isIdempotent = Boolean(input.idempotencyKey);
+    const name = input.idempotencyKey
+      ? deriveBlaxelSandboxName(input.idempotencyKey)
+      : `roomote-${randomUUID()}`.slice(0, 49);
     const ttl = this.ttl();
+    const createInput = {
+      name,
+      image: this.config.image,
+      memory: this.config.memoryMiB,
+      region: this.config.region,
+      ttl,
+      ...(input.idempotencyKey ? { externalId: input.idempotencyKey } : {}),
+      labels: { ...(input.metadata ?? {}), ...(input.tags ?? {}) },
+      ports: input.ports?.map((target) => ({ target, protocol: 'HTTP' })),
+    };
     const sandbox = await raceWithAbort({
-      promise: SandboxInstance.create({
-        name,
-        image: this.config.image,
-        memory: this.config.memoryMiB,
-        region: this.config.region,
-        ttl,
-        labels: { ...(input.metadata ?? {}), ...(input.tags ?? {}) },
-        ports: input.ports?.map((target) => ({ target, protocol: 'HTTP' })),
-      }),
+      promise: isIdempotent
+        ? SandboxInstance.createIfNotExists(createInput)
+        : SandboxInstance.create(createInput),
       signal: input.signal,
       abortMessage: `Creating Blaxel sandbox ${name} was aborted`,
-      onLateResolve: async (lateSandbox) => {
-        await this.cleanupSandboxAfterFailure(
-          lateSandbox.metadata.name || name,
-          'create_instance_late_abort',
-        );
-      },
+      ...(!isIdempotent
+        ? {
+            onLateResolve: async (lateSandbox: SandboxInstance) => {
+              await this.cleanupSandboxAfterFailure(
+                lateSandbox.metadata.name || name,
+                'create_instance_late_abort',
+              );
+            },
+          }
+        : {}),
     });
 
     try {
@@ -131,10 +144,14 @@ export class BlaxelClient implements ComputeProviderClient {
       );
       return { instanceId: name, status: 'running', domains };
     } catch (error) {
-      await this.cleanupSandboxAfterFailure(
-        name,
-        'create_instance_post_create',
-      );
+      // Idempotently-created sandboxes are retained for the controller's next
+      // attempt. Their TTL still bounds orphan lifetime if the task is canceled.
+      if (!isIdempotent) {
+        await this.cleanupSandboxAfterFailure(
+          name,
+          'create_instance_post_create',
+        );
+      }
       throw error;
     }
   }
@@ -159,15 +176,21 @@ export class BlaxelClient implements ComputeProviderClient {
   ): Promise<EnterStandbyResult> {
     throwIfAborted(input.signal);
 
-    await raceWithAbort({
-      promise: SandboxInstance.updateTtl(
-        input.instanceId,
-        `${Math.ceil(
-          (this.config.standbyTtlMs ?? DEFAULT_BLAXEL_STANDBY_TTL_MS) / 1_000,
-        )}s`,
-      ),
+    await retryWorkloadUnavailable({
+      operation: () =>
+        raceWithAbort({
+          promise: SandboxInstance.updateTtl(
+            input.instanceId,
+            `${Math.ceil(
+              (this.config.standbyTtlMs ?? DEFAULT_BLAXEL_STANDBY_TTL_MS) /
+                1_000,
+            )}s`,
+          ),
+          signal: input.signal,
+          abortMessage: `Extending standby TTL for Blaxel sandbox ${input.instanceId} was aborted`,
+        }),
       signal: input.signal,
-      abortMessage: `Extending standby TTL for Blaxel sandbox ${input.instanceId} was aborted`,
+      description: `extending standby TTL for Blaxel sandbox ${input.instanceId}`,
     });
 
     if (input.commandId) {
@@ -198,20 +221,24 @@ export class BlaxelClient implements ComputeProviderClient {
   ): Promise<CreatedInstance> {
     throwIfAborted(input.signal);
 
-    await raceWithAbort({
-      promise: SandboxInstance.updateTtl(
-        input.resumeHandle,
-        this.ttl() ?? null,
-      ),
+    await retryWorkloadUnavailable({
+      operation: () =>
+        raceWithAbort({
+          promise: SandboxInstance.updateTtl(
+            input.resumeHandle,
+            this.ttl() ?? null,
+          ),
+          signal: input.signal,
+          abortMessage: `Restoring active TTL for Blaxel sandbox ${input.resumeHandle} was aborted`,
+        }),
       signal: input.signal,
-      abortMessage: `Restoring active TTL for Blaxel sandbox ${input.resumeHandle} was aborted`,
+      description: `restoring active TTL for Blaxel sandbox ${input.resumeHandle}`,
     });
     const sandbox = await this.getSandbox(input.resumeHandle, input.signal);
     const domains = await this.createPreviewDomains(
       sandbox,
       input.ports ?? [],
       input.signal,
-      true,
     );
 
     return {
@@ -241,29 +268,34 @@ export class BlaxelClient implements ComputeProviderClient {
     const command = [input.cmd, ...(input.args ?? [])]
       .map(shellQuote)
       .join(' ');
-    const process = await raceWithAbort({
-      promise: sandbox.process.exec({
-        name,
-        command,
-        env: input.env,
-        workingDir: input.cwd,
-        waitForCompletion: !input.detached,
-        // Disable Blaxel's default provider-side timeout. Callers bound
-        // synchronous execution through their AbortSignal, while detached
-        // worker processes remain alive until Roomote tears down the sandbox.
-        timeout: 0,
-        ...(input.detached ? { keepAlive: true } : {}),
-        ...(input.onOutput
-          ? {
-              onStdout: (data: string) =>
-                input.onOutput?.({ stream: 'stdout', data }),
-              onStderr: (data: string) =>
-                input.onOutput?.({ stream: 'stderr', data }),
-            }
-          : {}),
-      }),
+    const process = await retryWorkloadUnavailable({
+      operation: () =>
+        raceWithAbort({
+          promise: sandbox.process.exec({
+            name,
+            command,
+            env: input.env,
+            workingDir: input.cwd,
+            waitForCompletion: !input.detached,
+            // Disable Blaxel's default provider-side timeout. Callers bound
+            // synchronous execution through their AbortSignal, while detached
+            // worker processes remain alive until Roomote tears down the sandbox.
+            timeout: 0,
+            ...(input.detached ? { keepAlive: true } : {}),
+            ...(input.onOutput
+              ? {
+                  onStdout: (data: string) =>
+                    input.onOutput?.({ stream: 'stdout', data }),
+                  onStderr: (data: string) =>
+                    input.onOutput?.({ stream: 'stderr', data }),
+                }
+              : {}),
+          }),
+          signal: input.signal,
+          abortMessage: `Running command in Blaxel sandbox ${input.instanceId} was aborted`,
+        }),
       signal: input.signal,
-      abortMessage: `Running command in Blaxel sandbox ${input.instanceId} was aborted`,
+      description: `running command ${name} in Blaxel sandbox ${input.instanceId}`,
     });
     return {
       commandId: process.name || name,
@@ -281,10 +313,15 @@ export class BlaxelClient implements ComputeProviderClient {
     let stderrLength = 0;
     while (true) {
       throwIfAborted(input.signal);
-      const process = await raceWithAbort({
-        promise: sandbox.process.get(input.commandId),
+      const process = await retryWorkloadUnavailable({
+        operation: () =>
+          raceWithAbort({
+            promise: sandbox.process.get(input.commandId),
+            signal: input.signal,
+            abortMessage: `Streaming Blaxel command ${input.commandId} was aborted`,
+          }),
         signal: input.signal,
-        abortMessage: `Streaming Blaxel command ${input.commandId} was aborted`,
+        description: `reading command ${input.commandId} in Blaxel sandbox ${input.instanceId}`,
       });
       if (process.stdout.length > stdoutLength) {
         yield { stream: 'stdout', data: process.stdout.slice(stdoutLength) };
@@ -301,15 +338,20 @@ export class BlaxelClient implements ComputeProviderClient {
 
   public async getCommandOutput(input: GetCommandOutputInput): Promise<string> {
     const sandbox = await this.getSandbox(input.instanceId, input.signal);
-    return raceWithAbort({
-      promise: sandbox.process.logs(
-        input.commandId,
-        input.stream === 'both' || input.stream === undefined
-          ? 'all'
-          : input.stream,
-      ),
+    return retryWorkloadUnavailable({
+      operation: () =>
+        raceWithAbort({
+          promise: sandbox.process.logs(
+            input.commandId,
+            input.stream === 'both' || input.stream === undefined
+              ? 'all'
+              : input.stream,
+          ),
+          signal: input.signal,
+          abortMessage: `Reading Blaxel command ${input.commandId} output was aborted`,
+        }),
       signal: input.signal,
-      abortMessage: `Reading Blaxel command ${input.commandId} output was aborted`,
+      description: `reading command ${input.commandId} output in Blaxel sandbox ${input.instanceId}`,
     });
   }
 
@@ -343,10 +385,15 @@ export class BlaxelClient implements ComputeProviderClient {
   }
 
   private getSandbox(instanceId: string, signal?: AbortSignal) {
-    return raceWithAbort({
-      promise: SandboxInstance.get(instanceId),
+    return retryWorkloadUnavailable({
+      operation: () =>
+        raceWithAbort({
+          promise: SandboxInstance.get(instanceId),
+          signal,
+          abortMessage: `Connecting to Blaxel sandbox ${instanceId} was aborted`,
+        }),
       signal,
-      abortMessage: `Connecting to Blaxel sandbox ${instanceId} was aborted`,
+      description: `connecting to Blaxel sandbox ${instanceId}`,
     });
   }
 
@@ -379,34 +426,24 @@ export class BlaxelClient implements ComputeProviderClient {
     sandbox: SandboxInstance,
     ports: number[],
     signal?: AbortSignal,
-    refresh = false,
   ): Promise<Record<string, string>> {
     const domains: Record<string, string> = {};
     for (const port of ports) {
       const previewName = `port-${port}`;
-      if (refresh) {
-        try {
-          await raceWithAbort({
-            promise: sandbox.previews.delete(previewName),
-            signal,
-            abortMessage: `Deleting Blaxel preview for port ${port} was aborted`,
-          });
-        } catch (error) {
-          if (!isNotFound(error)) throw error;
-        }
-      }
-      const preview = await raceWithAbort({
-        promise: refresh
-          ? sandbox.previews.create({
+      const preview = await retryWorkloadUnavailable({
+        operation: () =>
+          raceWithAbort({
+            promise: sandbox.previews.createIfNotExists({
               metadata: { name: previewName },
-              spec: { port, public: true, ttl: this.ttl() },
-            })
-          : sandbox.previews.createIfNotExists({
-              metadata: { name: previewName },
-              spec: { port, public: true, ttl: this.ttl() },
+              // The child preview follows the parent sandbox lifecycle. Giving
+              // it a shorter TTL forces destructive refreshes after standby.
+              spec: { port, public: true },
             }),
+            signal,
+            abortMessage: `Creating Blaxel preview for port ${port} was aborted`,
+          }),
         signal,
-        abortMessage: `Creating Blaxel preview for port ${port} was aborted`,
+        description: `creating preview ${previewName} for Blaxel sandbox ${sandbox.metadata.name}`,
       });
       if (!preview.spec.url) {
         throw new Error(
@@ -460,11 +497,7 @@ function shellQuote(value: string): string {
 }
 
 function isNotFound(error: unknown): boolean {
-  const details = extractErrorDetails(error);
-  const value = serializeError(error).message.toLowerCase();
-  return (
-    details.code === 404 || value.includes('404') || value.includes('not found')
-  );
+  return isBlaxelResourceNotFound(error);
 }
 
 async function retryWorkloadUnavailable<T>(options: {
@@ -480,7 +513,7 @@ async function retryWorkloadUnavailable<T>(options: {
     try {
       return await options.operation();
     } catch (error) {
-      if (!isWorkloadUnavailable(error)) throw error;
+      if (!isBlaxelWorkloadUnavailable(error)) throw error;
 
       const elapsedMs = Date.now() - startedAt;
       const remainingMs = WORKLOAD_READY_RETRY_BUDGET_MS - elapsedMs;
@@ -496,10 +529,7 @@ async function retryWorkloadUnavailable<T>(options: {
   }
 }
 
-function isWorkloadUnavailable(error: unknown): boolean {
-  const value = serializeError(error).message.toLowerCase();
-  return (
-    value.includes('workload_unavailable') ||
-    value.includes('currently not available')
-  );
+export function deriveBlaxelSandboxName(idempotencyKey: string): string {
+  const digest = createHash('sha256').update(idempotencyKey).digest('hex');
+  return `roomote-${digest.slice(0, 32)}`;
 }

--- a/packages/compute-providers/src/blaxel/create-blaxel-machine.test.ts
+++ b/packages/compute-providers/src/blaxel/create-blaxel-machine.test.ts
@@ -52,15 +52,47 @@ describe('createBlaxelMachine', () => {
     });
   });
 
-  it('preserves messages from plain Blaxel API errors', async () => {
-    vi.useFakeTimers();
-    try {
-      const onMutation = vi.fn();
-      const resumeFromStandby = vi
-        .fn()
-        .mockRejectedValue({ code: 409, error: 'Resource already exists' });
+  it('forwards the stable provisioning key to fresh sandbox creation', async () => {
+    mockGetWorkerRelease.mockResolvedValue({
+      archive: Buffer.from('worker'),
+      tag: 'worker-vtest',
+      version: 'test',
+    });
+    const createInstance = vi.fn().mockResolvedValue({
+      instanceId: 'roomote-stable',
+      domains: {},
+    });
+    const runCommand = vi.fn().mockResolvedValue({ exitCode: 0 });
 
-      const result = createBlaxelMachine({
+    await createBlaxelMachine({
+      blaxelApiKey: 'key',
+      blaxelWorkspace: 'workspace',
+      blaxelImage: 'sandbox/roomote-worker:test',
+      idempotencyKey: 'roomote-task-run:42',
+      launchMode: 'fresh',
+      computeClient: {
+        vendor: 'blaxel',
+        createInstance,
+        resumeFromStandby: vi.fn(),
+        writeFiles: vi.fn(),
+        runCommand,
+        destroyInstance: vi.fn(),
+      },
+    });
+
+    expect(createInstance).toHaveBeenCalledWith(
+      expect.objectContaining({ idempotencyKey: 'roomote-task-run:42' }),
+    );
+  });
+
+  it('preserves messages from plain Blaxel API errors', async () => {
+    const onMutation = vi.fn();
+    const resumeFromStandby = vi
+      .fn()
+      .mockRejectedValue({ code: 409, error: 'Resource already exists' });
+
+    await expect(
+      createBlaxelMachine({
         blaxelApiKey: 'key',
         blaxelWorkspace: 'workspace',
         blaxelImage: 'sandbox/roomote-worker:test',
@@ -75,23 +107,45 @@ describe('createBlaxelMachine', () => {
           runCommand: vi.fn(),
           destroyInstance: vi.fn(),
         },
-      });
-      const rejection = expect(result).rejects.toThrow(
-        'Resource already exists',
+      }),
+    ).rejects.toThrow('Resource already exists');
+    expect(resumeFromStandby).toHaveBeenCalledTimes(1);
+    expect(onMutation).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        eventType: 'failed',
+        details: expect.objectContaining({
+          error: 'Resource already exists',
+        }),
+      }),
+    );
+  });
+
+  it('does not multiply an exhausted workload-unavailable retry budget', async () => {
+    const resumeFromStandby = vi
+      .fn()
+      .mockRejectedValue(
+        new Error(
+          '404 {"error":{"code":"WORKLOAD_UNAVAILABLE","origin":"platform","retryable":true}}',
+        ),
       );
 
-      await vi.advanceTimersByTimeAsync(6_000);
-      await rejection;
-      expect(onMutation).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          eventType: 'failed',
-          details: expect.objectContaining({
-            error: 'Resource already exists',
-          }),
-        }),
-      );
-    } finally {
-      vi.useRealTimers();
-    }
+    await expect(
+      createBlaxelMachine({
+        blaxelApiKey: 'key',
+        blaxelWorkspace: 'workspace',
+        blaxelImage: 'sandbox/roomote-worker:test',
+        launchMode: 'task_standby',
+        resumeHandle: 'roomote-blaxel-standby',
+        computeClient: {
+          vendor: 'blaxel',
+          createInstance: vi.fn(),
+          resumeFromStandby,
+          writeFiles: vi.fn(),
+          runCommand: vi.fn(),
+          destroyInstance: vi.fn(),
+        },
+      }),
+    ).rejects.toThrow('WORKLOAD_UNAVAILABLE');
+    expect(resumeFromStandby).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/compute-providers/src/blaxel/create-blaxel-machine.ts
+++ b/packages/compute-providers/src/blaxel/create-blaxel-machine.ts
@@ -15,6 +15,7 @@ import type {
   ComputeProviderClient,
   ComputeProviderMutationObserver,
 } from '../types';
+import { shouldRetryBlaxelLifecycleError } from './errors';
 
 const MAX_RETRIES = 3;
 const INSTALL_SCRIPT_PATH = `${SANDBOX_FILES_DIR}/install-worker.sh`;
@@ -34,6 +35,7 @@ export interface CreateBlaxelMachineOptions {
   blaxelApiKey: string;
   blaxelWorkspace: string;
   blaxelImage: string;
+  idempotencyKey?: string;
   blaxelRegion?: string;
   namedPorts?: NamedPort[];
   proxyPorts?: Record<string, number>;
@@ -130,6 +132,7 @@ export async function createBlaxelMachine(
         });
       } else {
         created = await computeClient.createInstance({
+          idempotencyKey: options.idempotencyKey,
           ports,
           tags: options.tags,
           metadata: {
@@ -179,7 +182,7 @@ export async function createBlaxelMachine(
         },
       });
       if (isAbortError(error)) throw error;
-      if (attempt === MAX_RETRIES) {
+      if (attempt === MAX_RETRIES || !shouldRetryBlaxelLifecycleError(error)) {
         throw error instanceof Error ? error : new Error(errorMessage);
       }
       await sleepWithSignal(2_000 * 2 ** (attempt - 1), createSignal);

--- a/packages/compute-providers/src/blaxel/errors.test.ts
+++ b/packages/compute-providers/src/blaxel/errors.test.ts
@@ -1,0 +1,105 @@
+import {
+  getBlaxelErrorDetails,
+  isBlaxelResourceNotFound,
+  isBlaxelWorkloadUnavailable,
+  shouldRetryBlaxelLifecycleError,
+} from './errors';
+
+describe('Blaxel structured errors', () => {
+  it('parses platform errors embedded in SDK error messages', () => {
+    const error = new Error(
+      '404 {"error":{"code":"WORKLOAD_UNAVAILABLE","message":"not ready","origin":"platform","retryable":true,"status":404}}',
+    );
+
+    expect(getBlaxelErrorDetails(error)).toMatchObject({
+      code: 'WORKLOAD_UNAVAILABLE',
+      message: 'not ready',
+      origin: 'platform',
+      retryable: true,
+      status: 404,
+    });
+    expect(isBlaxelWorkloadUnavailable(error)).toBe(true);
+    expect(shouldRetryBlaxelLifecycleError(error)).toBe(false);
+  });
+
+  it('recognizes a missing sandbox record', () => {
+    expect(
+      isBlaxelResourceNotFound({
+        error: {
+          code: 'WORKLOAD_NOT_FOUND',
+          origin: 'platform',
+          status: 404,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('does not treat route or application 404s as missing sandboxes', () => {
+    expect(
+      isBlaxelResourceNotFound({
+        error: { code: 'ROUTE_NOT_FOUND', origin: 'platform', status: 404 },
+      }),
+    ).toBe(false);
+    expect(
+      isBlaxelResourceNotFound({
+        error: { code: 404, origin: 'application', message: 'not found' },
+      }),
+    ).toBe(false);
+  });
+
+  it('does not retry lifecycle operations for application-origin errors', () => {
+    expect(
+      shouldRetryBlaxelLifecycleError({
+        error: { code: 404, origin: 'application', message: 'not found' },
+      }),
+    ).toBe(false);
+  });
+
+  it('honors an explicit non-retryable workload response', () => {
+    expect(
+      isBlaxelWorkloadUnavailable({
+        error: {
+          code: 'WORKLOAD_UNAVAILABLE',
+          origin: 'platform',
+          retryable: false,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('does not retry deterministic client errors', () => {
+    const error = new Error(
+      '400 {"error":{"status":400,"message":"metadata.externalId is invalid","origin":"platform"}}',
+    );
+
+    expect(shouldRetryBlaxelLifecycleError(error)).toBe(false);
+  });
+
+  it.each([408, 429])('allows retryable client status %s', (status) => {
+    const error = new Error(
+      `${status} {"error":{"status":${status},"message":"try again","origin":"platform","retryable":true}}`,
+    );
+
+    expect(shouldRetryBlaxelLifecycleError(error)).toBe(true);
+  });
+
+  it('reads structured details from a wrapped SDK error cause', () => {
+    expect(
+      getBlaxelErrorDetails(
+        new Error('request failed', {
+          cause: {
+            error: {
+              code: 'WORKLOAD_NOT_FOUND',
+              origin: 'platform',
+              status: 404,
+            },
+          },
+        }),
+      ),
+    ).toMatchObject({
+      code: 'WORKLOAD_NOT_FOUND',
+      origin: 'platform',
+      status: 404,
+    });
+  });
+});

--- a/packages/compute-providers/src/blaxel/errors.ts
+++ b/packages/compute-providers/src/blaxel/errors.ts
@@ -1,0 +1,182 @@
+import { extractErrorDetails, serializeError } from '@roomote/types';
+
+export interface BlaxelErrorDetails {
+  code?: string | number;
+  message: string;
+  origin?: string;
+  retryable?: boolean;
+  status?: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function parseEmbeddedJson(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== 'string') return null;
+
+  const jsonStart = value.indexOf('{');
+  if (jsonStart < 0) return null;
+
+  try {
+    const parsed: unknown = JSON.parse(value.slice(jsonStart));
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function unwrapErrorPayload(value: unknown): Record<string, unknown> | null {
+  if (!isRecord(value)) return null;
+  return isRecord(value.error) ? value.error : value;
+}
+
+function readHeaderOrigin(value: unknown): string | undefined {
+  if (!isRecord(value)) return undefined;
+
+  for (const [name, headerValue] of Object.entries(value)) {
+    if (
+      name.toLowerCase() === 'x-blaxel-source' &&
+      typeof headerValue === 'string'
+    ) {
+      return headerValue;
+    }
+  }
+
+  return undefined;
+}
+
+/** Normalizes Blaxel SDK errors, including JSON embedded in Error messages. */
+export function getBlaxelErrorDetails(error: unknown): BlaxelErrorDetails {
+  const extracted = extractErrorDetails(error);
+  const extractedCause = isRecord(extracted.cause)
+    ? extracted.cause
+    : undefined;
+  const directCause = isRecord(error) ? error.cause : undefined;
+  const serialized = serializeError(error);
+  const candidates = [
+    unwrapErrorPayload(error),
+    unwrapErrorPayload(directCause),
+    unwrapErrorPayload(extracted.responseJson),
+    unwrapErrorPayload(extractedCause?.responseJson),
+    unwrapErrorPayload(extractedCause),
+    unwrapErrorPayload(parseEmbeddedJson(extracted.responseText)),
+    unwrapErrorPayload(parseEmbeddedJson(extractedCause?.responseText)),
+    unwrapErrorPayload(parseEmbeddedJson(extractedCause?.message)),
+    unwrapErrorPayload(parseEmbeddedJson(serialized.message)),
+  ].filter((candidate): candidate is Record<string, unknown> =>
+    Boolean(candidate),
+  );
+
+  let code: string | number | undefined;
+  let message = serialized.message;
+  let origin =
+    readHeaderOrigin(extracted.responseHeaders) ??
+    readHeaderOrigin(extractedCause?.responseHeaders);
+  let retryable: boolean | undefined;
+  let status: number | undefined;
+
+  for (const candidate of candidates) {
+    if (
+      code === undefined &&
+      (typeof candidate.code === 'string' || typeof candidate.code === 'number')
+    ) {
+      code = candidate.code;
+    }
+    if (typeof candidate.message === 'string') message = candidate.message;
+    if (origin === undefined && typeof candidate.origin === 'string') {
+      origin = candidate.origin;
+    }
+    if (retryable === undefined && typeof candidate.retryable === 'boolean') {
+      retryable = candidate.retryable;
+    }
+    if (status === undefined && typeof candidate.status === 'number') {
+      status = candidate.status;
+    }
+  }
+
+  if (code === undefined) {
+    const extractedCode = extracted.code;
+    if (
+      typeof extractedCode === 'string' ||
+      typeof extractedCode === 'number'
+    ) {
+      code = extractedCode;
+    }
+  }
+  if (status === undefined && typeof extracted.responseStatus === 'number') {
+    status = extracted.responseStatus;
+  }
+
+  return { code, message, origin, retryable, status };
+}
+
+function hasPlatformOrigin(details: BlaxelErrorDetails): boolean {
+  return (
+    details.origin === undefined || details.origin.toLowerCase() === 'platform'
+  );
+}
+
+export function isBlaxelWorkloadUnavailable(error: unknown): boolean {
+  const details = getBlaxelErrorDetails(error);
+  return (
+    details.code === 'WORKLOAD_UNAVAILABLE' &&
+    details.retryable !== false &&
+    hasPlatformOrigin(details)
+  );
+}
+
+export function isBlaxelResourceNotFound(error: unknown): boolean {
+  const details = getBlaxelErrorDetails(error);
+
+  if (!hasPlatformOrigin(details)) return false;
+  if (details.code === 'WORKLOAD_NOT_FOUND') return true;
+  if (typeof details.code === 'string') return false;
+
+  return (
+    details.code === 404 ||
+    details.status === 404 ||
+    details.message.toLowerCase().includes('not found')
+  );
+}
+
+/** Whether the outer lifecycle retry may safely repeat this operation. */
+export function shouldRetryBlaxelLifecycleError(error: unknown): boolean {
+  const details = getBlaxelErrorDetails(error);
+
+  if (details.retryable === false) return false;
+
+  if (
+    details.origin !== undefined &&
+    details.origin.toLowerCase() !== 'platform'
+  ) {
+    return false;
+  }
+
+  if (
+    ['WORKLOAD_UNAVAILABLE', 'WORKLOAD_NOT_FOUND', 'ROUTE_NOT_FOUND'].includes(
+      String(details.code),
+    )
+  ) {
+    return false;
+  }
+
+  const httpStatus =
+    details.status ??
+    (typeof details.code === 'number' &&
+    details.code >= 100 &&
+    details.code <= 599
+      ? details.code
+      : undefined);
+  if (
+    httpStatus !== undefined &&
+    httpStatus >= 400 &&
+    httpStatus < 500 &&
+    httpStatus !== 408 &&
+    httpStatus !== 429
+  ) {
+    return false;
+  }
+
+  return true;
+}

--- a/packages/compute-providers/src/blaxel/index.ts
+++ b/packages/compute-providers/src/blaxel/index.ts
@@ -1,2 +1,3 @@
 export * from './build-blaxel-image';
 export * from './create-blaxel-machine';
+export * from './errors';

--- a/packages/compute-providers/src/types.ts
+++ b/packages/compute-providers/src/types.ts
@@ -20,6 +20,8 @@ import type { ComputeProviderCapabilities } from '@roomote/types';
 export type { ComputeProviderCapabilities } from '@roomote/types';
 
 export interface CreateInstanceInput {
+  /** Stable caller-owned key used by providers that support idempotent create. */
+  idempotencyKey?: string;
   ports?: number[];
   metadata?: Record<string, string>;
   tags?: Record<string, string>;


### PR DESCRIPTION
## Summary

- normalize Blaxel structured errors and apply bounded sequential retries across readiness-sensitive operations
- use deterministic external IDs with idempotent sandbox creation
- reuse preview resources across standby/resume instead of deleting and recreating them
- document the lifecycle behavior and add contract coverage

## Validation

- full repository test suite
- `pnpm lint`
- `pnpm check-types:fast`
- `pnpm knip`
- focused compute-provider tests (23 passing)
- focused controller tests (2 passing)
- live local Blaxel smoke test through ngrok: fresh provision, retained standby, and same-machine resume

## Live findings fixed

- sanitize deterministic external IDs to Blaxel-compatible alphanumeric/hyphen values
- fail deterministic 4xx lifecycle errors immediately while preserving retry behavior for 408/429 and retryable server/network failures