### PR TITLE
[Fix] Require word boundaries when matching GitHub app mentions

### DIFF
--- a/apps/api/src/handlers/github/__tests__/isMention.test.ts
+++ b/apps/api/src/handlers/github/__tests__/isMention.test.ts
@@ -79,6 +79,42 @@ describe('isMention', () => {
     ).toBe(false);
   });
 
+  it('returns false for a longer login that starts with the slug', () => {
+    expect(
+      isMention({
+        body: 'cc @roomote-fan on this one',
+        user: { login: 'testuser' },
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false for email addresses containing the slug', () => {
+    expect(
+      isMention({
+        body: 'forwarded from grace@roomote.onmicrosoft.com',
+        user: { login: 'testuser' },
+      }),
+    ).toBe(false);
+  });
+
+  it('returns true when the mention is followed by punctuation', () => {
+    expect(
+      isMention({
+        body: 'thanks @roomote!',
+        user: { login: 'testuser' },
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true when the mention starts the comment', () => {
+    expect(
+      isMention({
+        body: '@roomote please rerun the review',
+        user: { login: 'testuser' },
+      }),
+    ).toBe(true);
+  });
+
   describe('with a database-configured app slug', () => {
     beforeEach(() => {
       setConfiguredGitHubAppSlugCache({

--- a/apps/api/src/handlers/github/isMention.ts
+++ b/apps/api/src/handlers/github/isMention.ts
@@ -3,6 +3,9 @@ import {
   Schemas as GitHubSchemas,
 } from '@roomote/github';
 
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 export const isMention = (comment: {
   body: string;
   user: { login: string } | null;
@@ -11,10 +14,16 @@ export const isMention = (comment: {
     return false;
   }
 
+  // GitHub only treats `@name` as a mention when it stands alone; a bare
+  // substring check would also fire on longer logins (`@<slug>-fan`) and on
+  // email addresses (`grace@<slug>.example.com`).
+  const mentionPattern = new RegExp(
+    `(^|[^\\w.-])@${escapeRegExp(getEffectiveGitHubAppSlug())}(?![\\w-])`,
+    'i',
+  );
+
   return (
-    comment.body
-      .toLowerCase()
-      .includes(`@${getEffectiveGitHubAppSlug().toLowerCase()}`) &&
+    mentionPattern.test(comment.body) &&
     !GitHubSchemas.isRoomoteGitHubLogin(comment.user.login)
   );
 };


### PR DESCRIPTION
GitHub delivers no dedicated mention event for apps, so mention detection string-matches comment bodies. The previous `includes()` check also fired on longer logins that merely start with the configured slug (`@<slug>-fan`) and on email addresses containing it (`grace@<slug>.example.com`) — the same failure mode the ADO handler fixed in `getAdoAutomationTargets`.

`isMention` now requires the mention to stand alone the way GitHub's own rendering does: preceded by start-of-string or a non-handle character, and not followed by a handle character. Case-insensitivity and the configured-slug derivation (env + DB override) are unchanged.

Validation: isMention + GitHub webhook handler suites green (20 tests, including new regressions for lookalike logins, embedded emails, punctuation boundaries, and comment-start mentions); `@roomote/api` check-types and prettier clean.