### PR TITLE
[Fix] Route Amazon Bedrock API keys through Mantle

### DIFF
--- a/.changeset/bright-bedrock-mantle.md
+++ b/.changeset/bright-bedrock-mantle.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Route Amazon Bedrock API keys through the Mantle endpoint and clarify Mantle key setup in model settings.

--- a/apps/docs/environment-variables.mdx
+++ b/apps/docs/environment-variables.mdx
@@ -179,8 +179,8 @@ as per-task auth tokens or workspace paths.
 | `OPENCODE_API_KEY`                     | Provider key | OpenCode Zen / Go API key.                                                                                                              |
 | `GEMINI_API_KEY`                       | Provider key | Google Gemini API key. Can also be saved from **Settings > Models**.                                                                    |
 | `GOOGLE_GENERATIVE_AI_API_KEY`         | Provider key | Alternate Google/Gemini provider key forwarded when configured or inferred.                                                             |
-| `AWS_BEARER_TOKEN_BEDROCK`             | Provider key | Amazon Bedrock API key (bearer token). Can also be saved from **Settings > Models**.                                                    |
-| `AWS_REGION`                           | Provider key | AWS region for Amazon Bedrock models. Defaults to `us-east-1` at the runtime when unset.                                                |
+| `AWS_BEARER_TOKEN_BEDROCK`             | Provider key | Amazon Bedrock Mantle API key. Can also be saved from **Settings > Models**.                                                            |
+| `AWS_REGION`                           | Provider key | AWS region where the Bedrock API key was created. Defaults to `us-east-1` at runtime when unset.                                        |
 | `GOOGLE_APPLICATION_CREDENTIALS`       | Provider key | Google Vertex AI service account credentials: a file path, or pasted JSON contents that Roomote materializes to a file for the runtime. |
 | `GOOGLE_VERTEX_PROJECT`                | Provider key | Google Cloud project ID for Vertex AI models.                                                                                           |
 | `GOOGLE_VERTEX_LOCATION`               | Provider key | Vertex AI location. Defaults to `us-central1` at the runtime when unset.                                                                |

--- a/apps/docs/models.mdx
+++ b/apps/docs/models.mdx
@@ -37,6 +37,22 @@ in the setup wizard and from **Settings > Models**. You stay in control: you
 can disable or remove any of the added models, add more later, and reconnecting
 a provider never re-adds models you removed.
 
+### Amazon Bedrock
+
+Roomote connects Amazon Bedrock through the Bedrock Mantle endpoint used by
+AWS's current API-key console. Generate a short-term or long-term Bedrock API
+key in the AWS console, save it from **Settings > Models**, and set the AWS
+region where the key was created. Bedrock model IDs use the
+`bedrock-mantle/` prefix, for example:
+
+```text
+bedrock-mantle/anthropic.claude-haiku-4-5
+bedrock-mantle/anthropic.claude-sonnet-5
+```
+
+Short-term keys expire with the AWS console session (and after at most 12
+hours), so replace the saved key when it expires.
+
 ### ChatGPT subscription
 
 Roomote also supports connecting a **ChatGPT (subscription)** provider, which
@@ -82,6 +98,7 @@ openai/gpt-5.6-terra
 vercel/openai/gpt-5.6-terra
 baseten/moonshotai/Kimi-K2.7-Code
 togetherai/deepseek-ai/DeepSeek-V4-Pro
+bedrock-mantle/anthropic.claude-sonnet-5
 ```
 
 The prefix matters because two providers can expose similar model families with

--- a/apps/web/src/components/settings/InferenceProviderSection.test.tsx
+++ b/apps/web/src/components/settings/InferenceProviderSection.test.tsx
@@ -139,7 +139,12 @@ function buildProviderSetup(
                 id: 'amazon-bedrock' as SetupModelProviderId,
                 label: 'Amazon Bedrock',
                 envVarName: 'AWS_BEARER_TOKEN_BEDROCK',
-                envVarLabel: 'Bedrock API key',
+                envVarLabel: 'Mantle API key',
+                credentialHelp: {
+                  text: 'Paste a key generated from the Bedrock Mantle API-key console. Switch the AWS console to the same region you enter below before generating it.',
+                  href: 'https://us-east-1.console.aws.amazon.com/bedrock-mantle/api-keys',
+                  linkLabel: 'Open AWS Bedrock API keys',
+                },
                 additionalEnvFields: [
                   {
                     envVarName: 'AWS_REGION',
@@ -149,8 +154,7 @@ function buildProviderSetup(
                     placeholder: 'us-east-1',
                   },
                 ],
-                defaultRoomoteModel:
-                  'amazon-bedrock/global.anthropic.claude-sonnet-5',
+                defaultRoomoteModel: 'bedrock-mantle/anthropic.claude-sonnet-5',
                 authKind: 'api-key' as const,
                 suggestedTaskModels: [],
                 runtimeApiKeySatisfied: false,
@@ -415,12 +419,12 @@ describe('InferenceProviderSection', () => {
 
     fireEvent.click(
       screen.getByRole('button', {
-        name: 'Edit Amazon Bedrock Bedrock API key',
+        name: 'Edit Amazon Bedrock Mantle API key',
       }),
     );
 
     expect(
-      screen.getByLabelText('New Bedrock API key for Amazon Bedrock'),
+      screen.getByLabelText('New Mantle API key for Amazon Bedrock'),
     ).toHaveValue('');
     expect(screen.getByLabelText('AWS region for Amazon Bedrock')).toHaveValue(
       'us-west-2',
@@ -451,7 +455,7 @@ describe('InferenceProviderSection', () => {
 
     fireEvent.click(
       screen.getByRole('button', {
-        name: 'Edit Amazon Bedrock Bedrock API key',
+        name: 'Edit Amazon Bedrock Mantle API key',
       }),
     );
 
@@ -547,12 +551,18 @@ describe('InferenceProviderSection', () => {
       screen.getByRole('combobox', { name: 'Provider to add' }),
     ).toHaveTextContent('Amazon Bedrock');
     expect(
-      screen.getByLabelText('Bedrock API key for Amazon Bedrock'),
+      screen.getByLabelText('Mantle API key for Amazon Bedrock'),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Open AWS Bedrock API keys' }),
+    ).toHaveAttribute(
+      'href',
+      'https://us-east-1.console.aws.amazon.com/bedrock-mantle/api-keys',
+    );
 
     await act(async () => {
       fireEvent.change(
-        screen.getByLabelText('Bedrock API key for Amazon Bedrock'),
+        screen.getByLabelText('Mantle API key for Amazon Bedrock'),
         { target: { value: 'bedrock-key' } },
       );
       fireEvent.change(screen.getByLabelText('AWS region for Amazon Bedrock'), {

--- a/apps/web/src/components/settings/InferenceProviderSection.tsx
+++ b/apps/web/src/components/settings/InferenceProviderSection.tsx
@@ -321,16 +321,32 @@ function ProviderCredentialsDialog({
                     <span className="text-sm font-medium">
                       {primaryCredentialLabel}
                     </span>
-                    <Input
-                      secret
-                      className="font-mono"
-                      value={apiKey}
-                      onChange={(event) => setApiKey(event.target.value)}
-                      placeholder={`${primaryCredentialLabel} for ${selectedProvider.label}`}
-                      disabled={isSaving}
-                      aria-label={`${mode === 'edit' ? 'New ' : ''}${primaryCredentialLabel} for ${selectedProvider.label}`}
-                      data-1p-ignore
-                    />
+                    <div className="space-y-1.5">
+                      <Input
+                        secret
+                        className="font-mono"
+                        value={apiKey}
+                        onChange={(event) => setApiKey(event.target.value)}
+                        placeholder={`${primaryCredentialLabel} for ${selectedProvider.label}`}
+                        disabled={isSaving}
+                        aria-label={`${mode === 'edit' ? 'New ' : ''}${primaryCredentialLabel} for ${selectedProvider.label}`}
+                        data-1p-ignore
+                      />
+                      {selectedProvider.credentialHelp ? (
+                        <p className="text-xs text-muted-foreground">
+                          {selectedProvider.credentialHelp.text}{' '}
+                          <a
+                            className="font-medium underline underline-offset-2 hover:text-foreground"
+                            href={selectedProvider.credentialHelp.href}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            {selectedProvider.credentialHelp.linkLabel}
+                          </a>
+                          .
+                        </p>
+                      ) : null}
+                    </div>
                   </div>
                   {additionalEnvFields.map((field) => (
                     <div

--- a/apps/web/src/trpc/commands/task-models/models-dev.test.ts
+++ b/apps/web/src/trpc/commands/task-models/models-dev.test.ts
@@ -66,6 +66,12 @@ describe('resolveModelsDevSlug', () => {
       'zai-org/GLM-5.2',
     );
   });
+
+  it('maps Bedrock Mantle model ids to their models.dev lab slugs', () => {
+    expect(
+      resolveModelsDevSlug('bedrock-mantle/anthropic.claude-haiku-4-5'),
+    ).toBe('anthropic/claude-haiku-4-5');
+  });
 });
 
 describe('lookupModelMetadataFromCatalog', () => {
@@ -190,6 +196,40 @@ describe('lookupModelMetadataFromCatalog', () => {
     expect(result.metadata.inputPricePerToken).toBe(5 / 1_000_000);
     expect(result.metadata.outputPricePerToken).toBe(25 / 1_000_000);
     expect(result.displayName).toBe('Claude Opus 4.7');
+  });
+
+  it('resolves Bedrock Mantle metadata through the underlying model lab', () => {
+    const catalog = buildCatalog({
+      models: {
+        'anthropic/claude-sonnet-5': {
+          name: 'Claude Sonnet 5',
+          modalities: { input: ['text', 'image', 'pdf'] },
+          limit: { context: 200000 },
+        },
+      },
+      providers: {
+        anthropic: {
+          models: {
+            'anthropic/claude-sonnet-5': {
+              cost: { input: 3, output: 15 },
+            },
+          },
+        },
+      },
+    });
+
+    const result = lookupModelMetadataFromCatalog(
+      catalog,
+      'bedrock-mantle/anthropic.claude-sonnet-5',
+    );
+
+    expect(result.metadata).toEqual({
+      contextWindow: 200000,
+      inputTypes: ['text', 'image', 'pdf'],
+      inputPricePerToken: 3 / 1_000_000,
+      outputPricePerToken: 15 / 1_000_000,
+    });
+    expect(result.displayName).toBe('Claude Sonnet 5');
   });
 
   it('prefers the vercel gateway entry for vercel-routed models', () => {

--- a/apps/web/src/trpc/commands/task-models/models-dev.ts
+++ b/apps/web/src/trpc/commands/task-models/models-dev.ts
@@ -5,6 +5,7 @@ import {
 } from '@roomote/types';
 
 const MODELS_DEV_CATALOG_URL = 'https://models.dev/catalog.json';
+const BEDROCK_MANTLE_PROVIDER_PREFIX = 'bedrock-mantle/';
 
 type ModelsDevModalities = {
   input?: string[];
@@ -173,6 +174,8 @@ export async function fetchModelsDevCatalog(
  * Resolves the models.dev catalog slug for a Roomote task model id.
  * Strips a leading gateway provider prefix (`openrouter/`, `vercel/`,
  * `requesty/`, `baseten/`, `togetherai/`) and any leading `~` alias marker.
+ * Mantle's `lab.model` identifiers are converted to models.dev's `lab/model`
+ * slugs so metadata continues to resolve through the underlying model lab.
  */
 export function resolveModelsDevSlug(modelId: string): string {
   let slug = modelId;
@@ -185,6 +188,13 @@ export function resolveModelsDevSlug(modelId: string): string {
   }
   if (slug.startsWith('~')) {
     slug = slug.slice(1);
+  }
+  if (slug.startsWith(BEDROCK_MANTLE_PROVIDER_PREFIX)) {
+    const mantleModelId = slug.slice(BEDROCK_MANTLE_PROVIDER_PREFIX.length);
+    const labSeparatorIndex = mantleModelId.indexOf('.');
+    if (labSeparatorIndex > 0) {
+      return `${mantleModelId.slice(0, labSeparatorIndex)}/${mantleModelId.slice(labSeparatorIndex + 1)}`;
+    }
   }
   return slug;
 }

--- a/apps/worker/src/run-task/agent-home.test.ts
+++ b/apps/worker/src/run-task/agent-home.test.ts
@@ -1,0 +1,80 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { generateOpenCodeConfig } from './agent-home';
+
+describe('generateOpenCodeConfig Amazon Bedrock support', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  function createHomeDir(): string {
+    const homeDir = mkdtempSync(join(tmpdir(), 'roomote-bedrock-'));
+    tempDirs.push(homeDir);
+    return homeDir;
+  }
+
+  it('routes Bedrock models through the Mantle Anthropic endpoint', () => {
+    const result = generateOpenCodeConfig({
+      homeDir: createHomeDir(),
+      runtimeEnv: {
+        R_MODEL: 'bedrock-mantle/anthropic.claude-haiku-4-5',
+        R_MODEL_REASONING_EFFORT: 'high',
+        AWS_BEARER_TOKEN_BEDROCK: 'bedrock-key',
+        AWS_REGION: 'us-west-2',
+      },
+    });
+    const config = JSON.parse(result.configContent) as {
+      provider: Record<string, unknown>;
+    };
+
+    expect(config.provider['bedrock-mantle']).toMatchObject({
+      npm: '@ai-sdk/anthropic',
+      name: 'Amazon Bedrock',
+      options: {
+        baseURL: 'https://bedrock-mantle.us-west-2.api.aws/anthropic/v1',
+        apiKey: '{env:AWS_BEARER_TOKEN_BEDROCK}',
+      },
+      models: {
+        'anthropic.claude-haiku-4-5': {
+          options: {
+            thinking: { type: 'enabled', budgetTokens: 16_000 },
+          },
+        },
+      },
+    });
+    expect(result.configContent).not.toContain('bedrock-key');
+  });
+
+  it('defaults Bedrock Mantle to us-east-1', () => {
+    const result = generateOpenCodeConfig({
+      homeDir: createHomeDir(),
+      runtimeEnv: {
+        R_MODEL: 'bedrock-mantle/anthropic.claude-sonnet-5',
+        AWS_BEARER_TOKEN_BEDROCK: 'bedrock-key',
+      },
+    });
+
+    expect(result.configContent).toContain(
+      'https://bedrock-mantle.us-east-1.api.aws/anthropic/v1',
+    );
+  });
+
+  it('rejects invalid AWS regions before building a provider URL', () => {
+    expect(() =>
+      generateOpenCodeConfig({
+        homeDir: createHomeDir(),
+        runtimeEnv: {
+          R_MODEL: 'bedrock-mantle/anthropic.claude-sonnet-5',
+          AWS_BEARER_TOKEN_BEDROCK: 'bedrock-key',
+          AWS_REGION: 'https://example.com',
+        },
+      }),
+    ).toThrow('AWS_REGION must be a valid AWS region');
+  });
+});

--- a/apps/worker/src/run-task/agent-home.ts
+++ b/apps/worker/src/run-task/agent-home.ts
@@ -45,6 +45,12 @@ const OPENCODE_CONFIG_DIR_NAME = 'opencode';
 
 const OPENROUTER_PROVIDER_ID = 'openrouter';
 
+const BEDROCK_MANTLE_PROVIDER_ID = 'bedrock-mantle';
+
+const DEFAULT_BEDROCK_MANTLE_REGION = 'us-east-1';
+
+const AWS_REGION_PATTERN = /^[a-z]{2}(?:-[a-z0-9]+)+-\d+$/u;
+
 /**
  * OpenRouter identifies the calling application through the `HTTP-Referer`
  * and `X-Title` request headers rather than the standard `User-Agent`.
@@ -540,6 +546,68 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? { ...(value as Record<string, unknown>) }
     : {};
+}
+
+function mergeBedrockMantleProviderConfig(
+  providerConfig: Record<string, unknown>,
+  runtimeEnv: Record<string, string>,
+  modelIds: Array<string | undefined>,
+): Record<string, unknown> {
+  const mantleModelIds = [
+    ...new Set(
+      modelIds.flatMap((modelId) => {
+        const prefix = `${BEDROCK_MANTLE_PROVIDER_ID}/`;
+        const normalized = modelId?.trim();
+
+        return normalized?.startsWith(prefix)
+          ? [normalized.slice(prefix.length)]
+          : [];
+      }),
+    ),
+  ];
+
+  if (mantleModelIds.length === 0) {
+    return providerConfig;
+  }
+
+  const region = runtimeEnv.AWS_REGION?.trim() || DEFAULT_BEDROCK_MANTLE_REGION;
+
+  if (!AWS_REGION_PATTERN.test(region)) {
+    throw new Error(
+      `AWS_REGION must be a valid AWS region for Amazon Bedrock. Received "${region}".`,
+    );
+  }
+
+  const existingProvider = asRecord(providerConfig[BEDROCK_MANTLE_PROVIDER_ID]);
+  const existingOptions = asRecord(existingProvider.options);
+  const existingModels = asRecord(existingProvider.models);
+  const models = Object.fromEntries(
+    mantleModelIds.map((modelId) => [
+      modelId,
+      {
+        name: modelId,
+        ...asRecord(existingModels[modelId]),
+      },
+    ]),
+  );
+
+  return {
+    ...providerConfig,
+    [BEDROCK_MANTLE_PROVIDER_ID]: {
+      ...existingProvider,
+      npm: '@ai-sdk/anthropic',
+      name: 'Amazon Bedrock',
+      options: {
+        ...existingOptions,
+        baseURL: `https://bedrock-mantle.${region}.api.aws/anthropic/v1`,
+        apiKey: '{env:AWS_BEARER_TOKEN_BEDROCK}',
+      },
+      models: {
+        ...existingModels,
+        ...models,
+      },
+    },
+  };
 }
 
 function normalizeStringList(value: unknown): string[] {
@@ -1046,9 +1114,18 @@ function resolveModelBackedOpenCodeConfig(
     );
   }
 
-  const providerConfig = mergeOpenRouterVariantAliasModels(
-    providerReasoningConfig,
-    variantAliases,
+  const providerConfig = mergeBedrockMantleProviderConfig(
+    mergeOpenRouterVariantAliasModels(providerReasoningConfig, variantAliases),
+    runtimeEnv,
+    [
+      effectiveCodingModel,
+      model,
+      smallModel,
+      visionModel,
+      codeReviewModel,
+      exploreModel,
+      planningModel,
+    ],
   );
 
   return {

--- a/packages/db/src/lib/model-runtime-config.test.ts
+++ b/packages/db/src/lib/model-runtime-config.test.ts
@@ -540,7 +540,7 @@ describe('resolveEffectiveModelRuntimeEnv', () => {
   it('forwards every declared env var for multi-credential providers', async () => {
     mockDeploymentSettingsFindFirst.mockResolvedValue({
       runtimeModelConfig: {
-        roomoteModel: 'amazon-bedrock/global.anthropic.claude-sonnet-5',
+        roomoteModel: 'bedrock-mantle/anthropic.claude-sonnet-5',
         roomoteSmallModel: 'google-vertex/gemini-3.5-flash',
       },
     });
@@ -556,7 +556,7 @@ describe('resolveEffectiveModelRuntimeEnv', () => {
     });
 
     expect(env).toMatchObject({
-      R_MODEL: 'amazon-bedrock/global.anthropic.claude-sonnet-5',
+      R_MODEL: 'bedrock-mantle/anthropic.claude-sonnet-5',
       R_SMALL_MODEL: 'google-vertex/gemini-3.5-flash',
       R_MODEL_ENV_KEYS:
         'AWS_BEARER_TOKEN_BEDROCK,AWS_REGION,GOOGLE_APPLICATION_CREDENTIALS,GOOGLE_VERTEX_PROJECT,GOOGLE_VERTEX_LOCATION',

--- a/packages/types/src/__tests__/opencode-reasoning.test.ts
+++ b/packages/types/src/__tests__/opencode-reasoning.test.ts
@@ -36,6 +36,17 @@ describe('buildOpenCodeModelReasoningOptions', () => {
     });
   });
 
+  it('maps Bedrock Mantle models to Anthropic extended-thinking budgets', () => {
+    expect(
+      buildOpenCodeModelReasoningOptions(
+        'bedrock-mantle/anthropic.claude-sonnet-5',
+        'high',
+      ),
+    ).toEqual({
+      thinking: { type: 'enabled', budgetTokens: 16_000 },
+    });
+  });
+
   it('uses the generic reasoningEffort option for other providers', () => {
     expect(buildOpenCodeModelReasoningOptions('openai/gpt-5.4', 'low')).toEqual(
       { reasoningEffort: 'low' },

--- a/packages/types/src/model-provider-config.test.ts
+++ b/packages/types/src/model-provider-config.test.ts
@@ -215,9 +215,14 @@ describe('SETUP_MODEL_PROVIDER_CATALOG', () => {
 
   it('keeps recommended-model slugs and default models under each provider prefix', () => {
     for (const provider of SETUP_MODEL_PROVIDER_CATALOG) {
-      // The ChatGPT subscription serves models under the openai/ prefix.
+      // ChatGPT serves openai/ models; the Bedrock setup surface serves the
+      // worker's custom bedrock-mantle/ OpenCode provider.
       const expectedPrefix =
-        provider.id === 'chatgpt' ? 'openai/' : `${provider.id}/`;
+        provider.id === 'chatgpt'
+          ? 'openai/'
+          : provider.id === 'amazon-bedrock'
+            ? 'bedrock-mantle/'
+            : `${provider.id}/`;
 
       expect(provider.defaultRoomoteModel.startsWith(expectedPrefix)).toBe(
         true,
@@ -239,8 +244,13 @@ describe('SETUP_MODEL_PROVIDER_CATALOG', () => {
     expect(bedrockProvider).toMatchObject({
       label: 'Amazon Bedrock',
       envVarName: 'AWS_BEARER_TOKEN_BEDROCK',
-      envVarLabel: 'Bedrock API key',
-      defaultRoomoteModel: 'amazon-bedrock/global.anthropic.claude-sonnet-5',
+      envVarLabel: 'Mantle API key',
+      credentialHelp: {
+        text: 'Paste a key generated from the Bedrock Mantle API-key console. Switch the AWS console to the same region you enter below before generating it.',
+        href: 'https://us-east-1.console.aws.amazon.com/bedrock-mantle/api-keys',
+        linkLabel: 'Open AWS Bedrock API keys',
+      },
+      defaultRoomoteModel: 'bedrock-mantle/anthropic.claude-sonnet-5',
     });
     expect(bedrockProvider?.additionalEnvFields).toEqual([
       {
@@ -397,6 +407,9 @@ describe('getModelProviderEnvKeyCandidates', () => {
   it('includes every declared env var for multi-credential providers', () => {
     expect(
       getModelProviderEnvKeyCandidates({ providerId: 'amazon-bedrock' }),
+    ).toEqual(['AWS_BEARER_TOKEN_BEDROCK', 'AWS_REGION']);
+    expect(
+      getModelProviderEnvKeyCandidates({ providerId: 'bedrock-mantle' }),
     ).toEqual(['AWS_BEARER_TOKEN_BEDROCK', 'AWS_REGION']);
     expect(
       getModelProviderEnvKeyCandidates({ providerId: 'google-vertex' }),
@@ -764,10 +777,10 @@ describe('buildSetupModelStatus multi-credential providers', () => {
     });
   });
 
-  it('treats a persisted amazon-bedrock model with saved credentials as satisfied', () => {
+  it('treats a persisted Bedrock Mantle model with saved credentials as satisfied', () => {
     const status = buildSetupModelStatus({
       persistedModelConfig: {
-        roomoteModel: 'amazon-bedrock/global.anthropic.claude-sonnet-5',
+        roomoteModel: 'bedrock-mantle/anthropic.claude-sonnet-5',
       },
       persistedEnvVarNames: ['AWS_BEARER_TOKEN_BEDROCK'],
     });

--- a/packages/types/src/model-provider-config.ts
+++ b/packages/types/src/model-provider-config.ts
@@ -67,6 +67,12 @@ export type SetupModelProviderDescriptor = {
    * (e.g. Vertex takes a service account JSON). Defaults to "API key".
    */
   envVarLabel?: string;
+  /** Optional guidance rendered below the primary credential input. */
+  credentialHelp?: {
+    text: string;
+    href: string;
+    linkLabel: string;
+  };
   /**
    * Additional credential values collected when connecting the provider.
    * Every `required` field must be configured (saved or via runtime env)
@@ -229,14 +235,18 @@ export const SETUP_MODEL_PROVIDER_CATALOG = [
     }),
   },
   {
-    // Provider id matches the models.dev/opencode `amazon-bedrock` provider
-    // so `amazon-bedrock/<model>` slugs resolve at runtime. Auth uses a
-    // Bedrock API key (bearer token); operators using ambient AWS access
-    // keys can forward them with `R_MODEL_ENV_KEYS` instead.
+    // Bedrock's current console issues API keys for the Mantle endpoint. The
+    // worker registers this as a custom Anthropic-compatible OpenCode provider
+    // so these keys do not fall through to OpenCode's legacy AWS SDK provider.
     id: 'amazon-bedrock',
     label: 'Amazon Bedrock',
     envVarName: 'AWS_BEARER_TOKEN_BEDROCK',
-    envVarLabel: 'Bedrock API key',
+    envVarLabel: 'Mantle API key',
+    credentialHelp: {
+      text: 'Paste a key generated from the Bedrock Mantle API-key console. Switch the AWS console to the same region you enter below before generating it.',
+      href: 'https://us-east-1.console.aws.amazon.com/bedrock-mantle/api-keys',
+      linkLabel: 'Open AWS Bedrock API keys',
+    },
     additionalEnvFields: [
       {
         envVarName: 'AWS_REGION',
@@ -246,14 +256,13 @@ export const SETUP_MODEL_PROVIDER_CATALOG = [
         placeholder: 'us-east-1',
       },
     ],
-    defaultRoomoteModel: 'amazon-bedrock/global.anthropic.claude-sonnet-5',
+    defaultRoomoteModel: 'bedrock-mantle/anthropic.claude-sonnet-5',
     authKind: 'api-key',
     suggestedTaskModels: mapRecommendedTaskModels({
-      'claude-fable-5': 'amazon-bedrock/global.anthropic.claude-fable-5',
-      'claude-haiku-4-5':
-        'amazon-bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0',
-      'claude-opus-4-8': 'amazon-bedrock/global.anthropic.claude-opus-4-8',
-      'claude-sonnet-5': 'amazon-bedrock/global.anthropic.claude-sonnet-5',
+      'claude-fable-5': 'bedrock-mantle/anthropic.claude-fable-5',
+      'claude-haiku-4-5': 'bedrock-mantle/anthropic.claude-haiku-4-5',
+      'claude-opus-4-8': 'bedrock-mantle/anthropic.claude-opus-4-8',
+      'claude-sonnet-5': 'bedrock-mantle/anthropic.claude-sonnet-5',
     }),
   },
   {
@@ -331,6 +340,7 @@ export const SETUP_MODEL_PROVIDER_CATALOG = [
 ] as const satisfies readonly SetupModelProviderDescriptor[];
 
 const EXTRA_MODEL_PROVIDER_ENV_KEYS_BY_PROVIDER = {
+  'bedrock-mantle': ['AWS_BEARER_TOKEN_BEDROCK', 'AWS_REGION'],
   gemini: ['GOOGLE_GENERATIVE_AI_API_KEY', 'GEMINI_API_KEY'],
   google: ['GOOGLE_GENERATIVE_AI_API_KEY'],
   mistral: ['MISTRAL_API_KEY'],
@@ -560,7 +570,9 @@ export function getModelProviderLabel(
   }
 
   const provider = SETUP_MODEL_PROVIDER_BY_ID.get(
-    providerId as SetupModelProviderId,
+    (providerId === 'bedrock-mantle'
+      ? 'amazon-bedrock'
+      : providerId) as SetupModelProviderId,
   );
 
   if (provider) {
@@ -597,6 +609,10 @@ export function resolveSetupModelProviderIdFromModel(
 
   if (!providerId) {
     return null;
+  }
+
+  if (providerId === 'bedrock-mantle') {
+    return 'amazon-bedrock';
   }
 
   return SETUP_MODEL_PROVIDER_BY_ID.has(providerId as SetupModelProviderId)

--- a/packages/types/src/opencode-reasoning.ts
+++ b/packages/types/src/opencode-reasoning.ts
@@ -67,6 +67,7 @@ export function buildOpenCodeModelReasoningOptions(
       return { reasoning: { effort } };
     }
     case 'anthropic':
+    case 'bedrock-mantle':
       return {
         thinking: {
           type: 'enabled',

--- a/packages/types/src/task-models.test.ts
+++ b/packages/types/src/task-models.test.ts
@@ -50,12 +50,6 @@ describe('normalizeTaskModelId', () => {
     );
   });
 
-  it('migrates legacy Bedrock Runtime model ids to Bedrock Mantle', () => {
-    expect(
-      normalizeTaskModelId('amazon-bedrock/global.anthropic.claude-sonnet-5'),
-    ).toBe('bedrock-mantle/anthropic.claude-sonnet-5');
-  });
-
   it('leaves fully-qualified openrouter ids unchanged', () => {
     expect(normalizeTaskModelId('openrouter/openai/gpt-5.4')).toBe(
       'openrouter/openai/gpt-5.4',

--- a/packages/types/src/task-models.test.ts
+++ b/packages/types/src/task-models.test.ts
@@ -40,14 +40,20 @@ describe('normalizeTaskModelId', () => {
       'opencode/big-pickle',
     );
     expect(
-      normalizeTaskModelId('amazon-bedrock/global.anthropic.claude-sonnet-5'),
-    ).toBe('amazon-bedrock/global.anthropic.claude-sonnet-5');
+      normalizeTaskModelId('bedrock-mantle/anthropic.claude-sonnet-5'),
+    ).toBe('bedrock-mantle/anthropic.claude-sonnet-5');
     expect(normalizeTaskModelId('google-vertex/gemini-3.5-flash')).toBe(
       'google-vertex/gemini-3.5-flash',
     );
     expect(normalizeTaskModelId('google/gemini-3.5-flash')).toBe(
       'google/gemini-3.5-flash',
     );
+  });
+
+  it('migrates legacy Bedrock Runtime model ids to Bedrock Mantle', () => {
+    expect(
+      normalizeTaskModelId('amazon-bedrock/global.anthropic.claude-sonnet-5'),
+    ).toBe('bedrock-mantle/anthropic.claude-sonnet-5');
   });
 
   it('leaves fully-qualified openrouter ids unchanged', () => {

--- a/packages/types/src/task-models.ts
+++ b/packages/types/src/task-models.ts
@@ -35,25 +35,6 @@ const DIRECT_TASK_MODEL_PROVIDER_ID_SET = new Set<string>([
   'bedrock-mantle',
 ]);
 
-const LEGACY_BEDROCK_MODEL_IDS = new Map<string, string>([
-  [
-    'amazon-bedrock/global.anthropic.claude-fable-5',
-    'bedrock-mantle/anthropic.claude-fable-5',
-  ],
-  [
-    'amazon-bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0',
-    'bedrock-mantle/anthropic.claude-haiku-4-5',
-  ],
-  [
-    'amazon-bedrock/global.anthropic.claude-opus-4-8',
-    'bedrock-mantle/anthropic.claude-opus-4-8',
-  ],
-  [
-    'amazon-bedrock/global.anthropic.claude-sonnet-5',
-    'bedrock-mantle/anthropic.claude-sonnet-5',
-  ],
-]);
-
 /**
  * Gateway providers route models from many labs under a single provider
  * prefix (e.g. `openrouter/z-ai/glm-5.2`, `vercel/openai/gpt-5.6-terra`,
@@ -201,11 +182,6 @@ export function getTaskModelProviderId(modelId: string): string | null {
 
 export function normalizeTaskModelId(modelId: string): string {
   const trimmedModelId = modelId.trim();
-  const migratedBedrockModelId = LEGACY_BEDROCK_MODEL_IDS.get(trimmedModelId);
-
-  if (migratedBedrockModelId) {
-    return migratedBedrockModelId;
-  }
 
   if (
     trimmedModelId &&

--- a/packages/types/src/task-models.ts
+++ b/packages/types/src/task-models.ts
@@ -30,9 +30,29 @@ export const DIRECT_TASK_MODEL_PROVIDER_IDS = [
   'xai',
 ] as const;
 
-const DIRECT_TASK_MODEL_PROVIDER_ID_SET = new Set<string>(
-  DIRECT_TASK_MODEL_PROVIDER_IDS,
-);
+const DIRECT_TASK_MODEL_PROVIDER_ID_SET = new Set<string>([
+  ...DIRECT_TASK_MODEL_PROVIDER_IDS,
+  'bedrock-mantle',
+]);
+
+const LEGACY_BEDROCK_MODEL_IDS = new Map<string, string>([
+  [
+    'amazon-bedrock/global.anthropic.claude-fable-5',
+    'bedrock-mantle/anthropic.claude-fable-5',
+  ],
+  [
+    'amazon-bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0',
+    'bedrock-mantle/anthropic.claude-haiku-4-5',
+  ],
+  [
+    'amazon-bedrock/global.anthropic.claude-opus-4-8',
+    'bedrock-mantle/anthropic.claude-opus-4-8',
+  ],
+  [
+    'amazon-bedrock/global.anthropic.claude-sonnet-5',
+    'bedrock-mantle/anthropic.claude-sonnet-5',
+  ],
+]);
 
 /**
  * Gateway providers route models from many labs under a single provider
@@ -181,6 +201,11 @@ export function getTaskModelProviderId(modelId: string): string | null {
 
 export function normalizeTaskModelId(modelId: string): string {
   const trimmedModelId = modelId.trim();
+  const migratedBedrockModelId = LEGACY_BEDROCK_MODEL_IDS.get(trimmedModelId);
+
+  if (migratedBedrockModelId) {
+    return migratedBedrockModelId;
+  }
 
   if (
     trimmedModelId &&


### PR DESCRIPTION
## Why this PR exists

- [x] I am a maintainer / this is internal Roomote work

Amazon Bedrock keys generated by the current AWS console authenticate against Bedrock Mantle, while Roomote was routing them through OpenCode's legacy Bedrock Runtime provider.

## What changed

- Route Amazon Bedrock models through a custom Anthropic-compatible OpenCode provider at the regional Bedrock Mantle endpoint.
- Preserve the existing `amazon-bedrock` settings identity while migrating legacy Runtime model IDs to `bedrock-mantle/` IDs.
- Apply Anthropic thinking options to Mantle-backed Claude models.
- Label the credential as a Mantle API key and link directly to the AWS key console with matching-region guidance.
- Document the Mantle model IDs and add a patch changeset.

## How it was tested

- Focused Vitest coverage: 144 tests passed across types, worker, web, and database packages.
- `pnpm lint`
- `pnpm check-types`
- Pre-push `pnpm lint:fast`, `pnpm check-types:fast`, and `pnpm knip`
- Local OpenCode probe returned `OPENCODE_MANTLE_OK`.
- Live Roomote task using `bedrock-mantle/anthropic.claude-haiku-4-5` returned `BEDROCK_MANTLE_OK`.
- Verified the updated provider dialog in Chrome.

## Checklist

- [x] The PR title follows the repo convention
- [x] This PR is small and scoped to one change
- [x] `pnpm lint` and `pnpm check-types` pass locally
- [x] I added tests and included manual validation above
- [x] I removed secrets, tokens, private keys, and customer data from the diff
- [x] I ran `pnpm changeset`
