### PR TITLE
Release Roomote 0.3.1

### DIFF
--- a/.changeset/bright-bedrock-mantle.md
+++ b/.changeset/bright-bedrock-mantle.md
@@ -1,5 +1,0 @@
----
-'@roomote/web': patch
----
-
-Route Amazon Bedrock API keys through the Mantle endpoint and clarify Mantle key setup in model settings.

--- a/.changeset/github-mention-word-boundaries.md
+++ b/.changeset/github-mention-word-boundaries.md
@@ -1,5 +1,0 @@
----
-'@roomote/web': patch
----
-
-GitHub app @mention detection requires word boundaries so longer lookalike logins and emails containing the configured slug no longer falsely trigger agent replies.

--- a/.changeset/mobile-pr-filter-align.md
+++ b/.changeset/mobile-pr-filter-align.md
@@ -1,5 +1,0 @@
----
-'@roomote/web': patch
----
-
-Task filter PR-repo labels left-align correctly in the mobile filter sheet instead of sitting awkwardly centered.

--- a/.changeset/quiet-vertex-credentials.md
+++ b/.changeset/quiet-vertex-credentials.md
@@ -1,5 +1,0 @@
----
-'@roomote/worker': patch
----
-
-Materialize pasted Google Vertex service-account credentials before OpenCode starts so Vertex models work across worker paths without exposing credential JSON in provider errors.

--- a/.changeset/slack-proof-auto-post-flag.md
+++ b/.changeset/slack-proof-auto-post-flag.md
@@ -1,5 +1,0 @@
----
-'@roomote/web': patch
----
-
-Visual-proof auto-post to Slack is actually gated by the SlackProofAutoPost experimental flag; when the flag is off, proof is no longer auto-posted and agents must share uploaded screenshots through explicit chat replies.

--- a/.changeset/task-history-pr-status.md
+++ b/.changeset/task-history-pr-status.md
@@ -1,5 +1,0 @@
----
-'@roomote/web': patch
----
-
-Task history records when a linked pull request is merged or closed as an out-of-band status message agents can resurface (GitHub, GitLab, Gitea, Bitbucket, and Azure DevOps), using provider-native PR references.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This file tracks product releases for Roomote (single monorepo version). Automated release entries are prepended by `pnpm run version`.
 
+## 0.3.1 (2026-07-12)
+
+### Patch changes
+
+- Route Amazon Bedrock API keys through the Mantle endpoint and clarify Mantle key setup in model settings.
+- GitHub app @mention detection requires word boundaries so longer lookalike logins and emails containing the configured slug no longer falsely trigger agent replies.
+- Task filter PR-repo labels left-align correctly in the mobile filter sheet instead of sitting awkwardly centered.
+- Materialize pasted Google Vertex service-account credentials before OpenCode starts so Vertex models work across worker paths without exposing credential JSON in provider errors.
+- Visual-proof auto-post to Slack is actually gated by the SlackProofAutoPost experimental flag; when the flag is off, proof is no longer auto-posted and agents must share uploaded screenshots through explicit chat replies.
+- Task history records when a linked pull request is merged or closed as an out-of-band status message agents can resurface (GitHub, GitLab, Gitea, Bitbucket, and Azure DevOps), using provider-native PR references.
+
 ## 0.3.0 (2026-07-12)
 
 ### Minor changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roomote",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "FCL-1.0-ALv2",
   "packageManager": "pnpm@10.29.3",
   "engines": {


### PR DESCRIPTION
Automated Version PR: bumps the product version to `0.3.1` and folds the pending changesets into the root `CHANGELOG.md`.

- **Squash-merge** this PR into `develop` to cut the release.
- The frozen `release/v0.3.1` promote PR to `main` opens automatically after the merge.
- New changesets on `develop` refresh this PR automatically.

## 0.3.1 (2026-07-12)

### Patch changes

- Route Amazon Bedrock API keys through the Mantle endpoint and clarify Mantle key setup in model settings.
- GitHub app @mention detection requires word boundaries so longer lookalike logins and emails containing the configured slug no longer falsely trigger agent replies.
- Task filter PR-repo labels left-align correctly in the mobile filter sheet instead of sitting awkwardly centered.
- Materialize pasted Google Vertex service-account credentials before OpenCode starts so Vertex models work across worker paths without exposing credential JSON in provider errors.
- Visual-proof auto-post to Slack is actually gated by the SlackProofAutoPost experimental flag; when the flag is off, proof is no longer auto-posted and agents must share uploaded screenshots through explicit chat replies.
- Task history records when a linked pull request is merged or closed as an out-of-band status message agents can resurface (GitHub, GitLab, Gitea, Bitbucket, and Azure DevOps), using provider-native PR references.
