### PR TITLE
Simplify models provider documentation

### DIFF
--- a/apps/docs/compute.mdx
+++ b/apps/docs/compute.mdx
@@ -37,13 +37,13 @@ You configure sandbox providers during setup and can change them later from
 
 Roomote supports local and hosted sandbox backends:
 
-| Provider                                                                            | Best for                                               | Notes                                                                                                        |
-| ----------------------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| <IntegrationName href="/providers/compute/docker" icon="docker" name="Docker" />    | Local development and trusted single-host self-hosting | Runs task sandboxes as Docker containers on the same machine as the deployment.                              |
-| <IntegrationName href="/providers/compute/modal" icon="modal" name="Modal" />       | Hosted task sandboxes with snapshot support            | Uses a hosted runtime and can resume some sandboxes from snapshots.                                          |
-| <IntegrationName href="/providers/compute/e2b" icon="e2b" name="E2B" />             | Hosted task sandboxes with snapshot support            | Uses a hosted template created from the Roomote worker image.                                                |
-| <IntegrationName href="/providers/compute/daytona" icon="daytona" name="Daytona" /> | Hosted task sandboxes with snapshot support            | Uses a registered worker snapshot and can resume some sandboxes from product snapshots.                      |
-| <IntegrationName href="/providers/compute/blaxel" icon="blaxel" name="Blaxel" />    | Hosted perpetual task sandboxes                        | Resumable tasks retain their sandbox on automatic standby; reusable environment snapshots are not supported. |
+| Provider                                                                            | Best for                                               | Notes                                                                           |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------- |
+| <IntegrationName href="/providers/compute/docker" icon="docker" name="Docker" />    | Local development and trusted single-host self-hosting | Runs task sandboxes as Docker containers on the same machine as the deployment. |
+| <IntegrationName href="/providers/compute/modal" icon="modal" name="Modal" />       | Hosted task sandboxes with snapshot support            | Uses a hosted runtime and can resume some sandboxes from snapshots.             |
+| <IntegrationName href="/providers/compute/e2b" icon="e2b" name="E2B" />             | Hosted task sandboxes with snapshot support            | Runs task sandboxes on E2B-managed infrastructure.                              |
+| <IntegrationName href="/providers/compute/daytona" icon="daytona" name="Daytona" /> | Hosted task sandboxes with snapshot support            | Supports environment and task-level snapshot flows.                             |
+| <IntegrationName href="/providers/compute/blaxel" icon="blaxel" name="Blaxel" />    | Hosted perpetual task sandboxes                        | Uses automatic standby for resumable tasks.                                     |
 
 Docker is the default because it works well for local development and simple
 self-hosted deployments. Hosted providers are useful when you want task work to
@@ -84,41 +84,8 @@ Hosted sandboxes are a better fit when:
 - you need snapshot-capable providers for faster resume flows
 - you are comfortable managing provider credentials and account-level limits
 
-The tradeoff is extra setup. Hosted providers need API credentials, network
-access back to your Roomote deployment, and a worker image or registered
-template that the provider can run.
-
-## Why worker images matter
-
-Every sandbox needs the same basic Roomote worker runtime: system packages,
-browser tooling, language tools, command helpers, and the small process that
-connects the sandbox back to Roomote.
-
-For Docker, that runtime comes from the worker Docker image available on the
-Roomote host.
-
-For hosted providers, the provider must be able to pull or start from a
-registry-qualified worker image. A local tag such as `roomote-worker:local`
-only exists on your machine, so a hosted provider cannot use it directly.
-
-Hosted deployments set that worker image via environment (for example
-`DOCKER_WORKER_IMAGE` or release image derivation). Hosted providers use it to
-derive the provider-specific artifact they need:
-
-- Modal can use the worker image as its base image.
-- E2B builds a provider template from the worker image.
-- Daytona registers a provider snapshot from the worker image.
-
-Those registered images, templates, and snapshots are important because they
-make task startup predictable. Instead of rebuilding the full runtime for every
-task, the provider starts from a known base that already has the tools Roomote
-expects. That usually means faster startup, fewer missing-package failures, and
-less drift between tasks.
-
-For production deployments, prefer an immutable image tag, such as a release
-tag or commit-based tag, instead of `latest`. Immutable tags make it much
-clearer which worker runtime a sandbox used and avoid surprise changes during
-debugging or upgrades.
+The tradeoff is extra setup. Hosted providers need API credentials and network
+access back to your Roomote deployment.
 
 ## Choosing a default provider
 
@@ -133,8 +100,8 @@ A practical path is:
    open previews
 3. Add a hosted provider from **Settings > Sandboxes** when the first task flow
    feels stable
-4. Set the hosted provider as the default only after its credentials and worker
-   image or registered artifact are healthy
+4. Set the hosted provider as the default only after its credentials and
+   connection are healthy
 
 Environment setup still matters no matter which provider you choose. The
 sandbox provider supplies the sandbox; the environment tells Roomote what to
@@ -144,11 +111,8 @@ put inside it.
 
 - **A hosted provider cannot start tasks.** Confirm its API credentials are
   saved and the deployment URL is reachable from the provider.
-- **The worker image is not accepted.** Use a registry-qualified image that the
-  hosted provider can pull, not a local-only Docker tag.
-- **Tasks start slowly.** Check whether the hosted provider has a registered
-  template or snapshot ready, and whether the environment setup commands are
-  doing more work than necessary.
+- **Tasks start slowly.** Check provider capacity and whether the environment
+  setup commands are doing more work than necessary.
 - **Docker tasks affect the deployment host.** Move heavier or concurrent work
   to a hosted provider, or give the host more CPU and memory.
 - **A task cannot run project commands.** Update the environment with missing

--- a/apps/docs/compute.mdx
+++ b/apps/docs/compute.mdx
@@ -37,18 +37,21 @@ You configure sandbox providers during setup and can change them later from
 
 Roomote supports local and hosted sandbox backends:
 
-| Provider                                                                            | Best for                                               | Notes                                                                           |
-| ----------------------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------- |
-| <IntegrationName href="/providers/compute/docker" icon="docker" name="Docker" />    | Local development and trusted single-host self-hosting | Runs task sandboxes as Docker containers on the same machine as the deployment. |
-| <IntegrationName href="/providers/compute/modal" icon="modal" name="Modal" />       | Hosted task sandboxes with snapshot support            | Uses a hosted runtime and can resume some sandboxes from snapshots.             |
-| <IntegrationName href="/providers/compute/e2b" icon="e2b" name="E2B" />             | Hosted task sandboxes with snapshot support            | Runs task sandboxes on E2B-managed infrastructure.                              |
-| <IntegrationName href="/providers/compute/daytona" icon="daytona" name="Daytona" /> | Hosted task sandboxes with snapshot support            | Supports environment and task-level snapshot flows.                             |
-| <IntegrationName href="/providers/compute/blaxel" icon="blaxel" name="Blaxel" />    | Hosted perpetual task sandboxes                        | Uses automatic standby for resumable tasks.                                     |
+| Provider                                                                            | Best for                                               | Notes                                                                   |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------ | ----------------------------------------------------------------------- |
+| <IntegrationName href="/providers/compute/docker" icon="docker" name="Docker" />    | Local development and trusted single-host self-hosting | Retains stopped task containers so resumable work can restart in place. |
+| <IntegrationName href="/providers/compute/modal" icon="modal" name="Modal" />       | Hosted task sandboxes with snapshot support            | Uses a hosted runtime and can resume some sandboxes from snapshots.     |
+| <IntegrationName href="/providers/compute/e2b" icon="e2b" name="E2B" />             | Hosted task sandboxes with snapshot support            | Runs task sandboxes on E2B-managed infrastructure.                      |
+| <IntegrationName href="/providers/compute/daytona" icon="daytona" name="Daytona" /> | Hosted task sandboxes with snapshot support            | Supports environment and task-level snapshot flows.                     |
+| <IntegrationName href="/providers/compute/blaxel" icon="blaxel" name="Blaxel" />    | Hosted perpetual task sandboxes                        | Uses automatic standby for resumable tasks.                             |
 
 Docker is the default because it works well for local development and simple
 self-hosted deployments. Hosted providers are useful when you want task work to
 run away from the Roomote server, scale beyond one host, or use provider-managed
 sandbox infrastructure.
+
+For resumable Docker tasks, Roomote retains the stopped container and writable
+workspace so a follow-up can restart in place on the same host.
 
 ## Local Docker versus hosted sandboxes
 
@@ -69,8 +72,7 @@ other local services. Docker also depends on a restricted socket proxy that
 can create and manage worker containers on the host. The proxy is still
 privileged infrastructure, but the controller does not receive the raw host
 socket and unrelated Docker API sections remain blocked. Docker is not a
-multi-host scheduler, and some resume or snapshot flows require a hosted
-provider.
+multi-host scheduler.
 
 Hosted providers move the task sandbox into a provider-managed environment.
 Roomote still controls the task, streams logs, and connects previews, but the
@@ -81,7 +83,6 @@ Hosted sandboxes are a better fit when:
 - several people may run tasks at the same time
 - tasks need more CPU, memory, or isolation than your Roomote host should provide
 - you want task sandboxes to be easier to start, stop, and recover
-- you need snapshot-capable providers for faster resume flows
 - you are comfortable managing provider credentials and account-level limits
 
 The tradeoff is extra setup. Hosted providers need API credentials and network
@@ -91,7 +92,8 @@ access back to your Roomote deployment.
 
 The default provider is the sandbox backend Roomote uses when a task does not
 explicitly choose one. New deployments can start with Docker, then add a hosted
-provider when concurrency, isolation, or snapshot support becomes important.
+provider when concurrency, isolation, or provider-managed infrastructure becomes
+important.
 
 A practical path is:
 

--- a/apps/docs/environment-variables.mdx
+++ b/apps/docs/environment-variables.mdx
@@ -76,7 +76,6 @@ For production and shared self-hosted deployments:
   `R_AUTO_GENERATE_KEYS=true` so Roomote generates and persists them.
 - Keep provider credentials in environment variables or a secret manager when
   they are controlled by the operator.
-- Prefer immutable worker image tags for hosted sandbox providers.
 - Avoid `SKIP_ENV_VALIDATION` outside build tooling or one-off diagnostics.
 
 ## Naming convention
@@ -192,7 +191,7 @@ as per-task auth tokens or workspace paths.
 | ------------------------------------ | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `DEFAULT_COMPUTE_PROVIDER`           | Optional          | Runtime default sandbox provider when no admin default is saved. Supported values are `docker`, `modal`, `e2b`, `daytona`, and `blaxel`. |
 | `EXCLUDED_COMPUTE_PROVIDERS`         | Optional          | Comma-separated provider IDs to hide or exclude from default selection.                                                                  |
-| `DOCKER_WORKER_IMAGE`                | Optional          | Worker image used by Docker and for hosted sandbox derivation. In production, prefer an immutable registry-qualified tag.                |
+| `DOCKER_WORKER_IMAGE`                | Optional          | Worker image used by Docker. In production, prefer an immutable registry-qualified tag.                                                  |
 | `ROOMOTE_WORKER_IMAGE_REPO`          | Optional          | Registry repository used to derive the worker image from `RELEASE_VERSION` when `DOCKER_WORKER_IMAGE` is unset.                          |
 | `DOCKER_WORKER_PLATFORM`             | Optional          | Docker worker platform. Defaults to the host architecture (`linux/arm64` on arm hosts, `linux/amd64` otherwise).                         |
 | `DOCKER_WORKER_NETWORK`              | Self-host Docker  | Docker network for worker containers in Compose/self-host mode.                                                                          |
@@ -209,26 +208,18 @@ as per-task auth tokens or workspace paths.
 | `DOCKER_STANDBY_MAX_AGE_HOURS`       | Optional          | Maximum age of a retained Docker task container. Defaults to `24`, capped at `168`.                                                      |
 | `MODAL_TOKEN_ID`                     | Modal             | Modal token ID. Can also be saved from **Settings > Sandboxes**.                                                                         |
 | `MODAL_TOKEN_SECRET`                 | Modal             | Modal token secret.                                                                                                                      |
-| `MODAL_BASE_IMAGE_REF`               | Modal             | Modal base image reference. Usually derived from the worker image; set only to pin a custom image.                                       |
 | `MODAL_ENDPOINT`                     | Optional          | Modal endpoint override.                                                                                                                 |
 | `MODAL_ENVIRONMENT`                  | Optional          | Modal environment name.                                                                                                                  |
 | `MODAL_APP_NAME`                     | Optional          | Modal app name override.                                                                                                                 |
-| `MODAL_REGISTRY_USERNAME`            | Private registry  | Registry username for private non-ECR image pulls.                                                                                       |
-| `MODAL_REGISTRY_PASSWORD`            | Private registry  | Registry password for private non-ECR image pulls.                                                                                       |
-| `MODAL_ECR_OIDC_ROLE_ARN`            | ECR               | AWS IAM role ARN used by Modal for ECR OIDC pulls.                                                                                       |
-| `MODAL_ECR_REGION`                   | ECR               | AWS region for Modal ECR OIDC pulls.                                                                                                     |
 | `MODAL_REGIONS`                      | Optional          | Comma-separated Modal sandbox placement regions (for example `us` or `us-west`). Unset keeps Modal default placement.                    |
 | `E2B_API_KEY`                        | E2B               | E2B API key. Can also be saved from **Settings > Sandboxes**.                                                                            |
-| `E2B_TEMPLATE_ID`                    | E2B               | Worker template ID. Usually provisioned from the worker image by Roomote.                                                                |
 | `E2B_DOMAIN`                         | Optional          | E2B domain for self-hosted or custom E2B clusters.                                                                                       |
 | `E2B_MAX_SANDBOX_TIMEOUT_MS`         | Optional          | Maximum E2B sandbox timeout Roomote will request. Defaults to one hour.                                                                  |
 | `DAYTONA_API_KEY`                    | Daytona           | Daytona API key. Can also be saved from **Settings > Sandboxes**.                                                                        |
 | `DAYTONA_API_URL`                    | Optional          | Daytona API URL override.                                                                                                                |
 | `DAYTONA_TARGET`                     | Optional          | Daytona target or region.                                                                                                                |
-| `DAYTONA_SNAPSHOT_NAME`              | Daytona           | Worker snapshot name. Usually registered from the worker image by Roomote.                                                               |
 | `BL_API_KEY`                         | Blaxel            | Blaxel API key. Can also be saved from **Settings > Sandboxes**.                                                                         |
 | `BL_WORKSPACE`                       | Blaxel            | Blaxel workspace name.                                                                                                                   |
-| `BLAXEL_IMAGE`                       | Blaxel            | Blaxel sandbox image in `sandbox/name:version` form. Roomote provisions it automatically when unset.                                     |
 | `BLAXEL_REGION`                      | Optional          | Blaxel sandbox placement region. Unset lets Blaxel choose the closest region.                                                            |
 | `BLAXEL_STANDBY_MAX_COUNT`           | Optional          | Maximum Blaxel standby sandboxes retained for resume. Defaults to `25`; `0` disables retention.                                          |
 | `BLAXEL_STANDBY_MAX_AGE_HOURS`       | Optional          | Maximum age of a Blaxel standby sandbox. Defaults to `168`, capped at `168`.                                                             |

--- a/apps/docs/models.mdx
+++ b/apps/docs/models.mdx
@@ -17,7 +17,7 @@ Configure models from **Settings > Models**.
 An inference provider is the service that hosts or routes model calls. Roomote
 supports providers such as OpenRouter, Vercel AI Gateway, Requesty, Baseten,
 Together AI, OpenAI, Anthropic, Moonshot AI, MiniMax, OpenCode, Amazon Bedrock,
-Google Vertex AI, Google Gemini, and xAI.
+Google Vertex AI, Google Gemini, xAI, and ChatGPT subscriptions.
 
 You can connect more than one inference provider in the same deployment. That
 lets you mix and match models by provider instead of betting the whole
@@ -37,42 +37,6 @@ in the setup wizard and from **Settings > Models**. You stay in control: you
 can disable or remove any of the added models, add more later, and reconnecting
 a provider never re-adds models you removed.
 
-### Amazon Bedrock
-
-Roomote connects Amazon Bedrock through the Bedrock Mantle endpoint used by
-AWS's current API-key console. Generate a short-term or long-term Bedrock API
-key in the AWS console, save it from **Settings > Models**, and set the AWS
-region where the key was created. Bedrock model IDs use the
-`bedrock-mantle/` prefix, for example:
-
-```text
-bedrock-mantle/anthropic.claude-haiku-4-5
-bedrock-mantle/anthropic.claude-sonnet-5
-```
-
-Short-term keys expire with the AWS console session (and after at most 12
-hours), so replace the saved key when it expires.
-
-### ChatGPT subscription
-
-Roomote also supports connecting a **ChatGPT (subscription)** provider, which
-runs tasks on a ChatGPT Plus or Pro subscription instead of an OpenAI API key.
-
-- From **Settings > Models**, choose **Add provider**, pick **ChatGPT
-  (subscription)** from the provider list, and choose **Connect ChatGPT**.
-  Roomote starts OpenAI's device-code flow and shows a code plus a
-  verification link.
-- Complete authorization in a browser. The subscription is stored encrypted
-  for the deployment and refreshed automatically.
-- Subscription models keep the `openai/` model ID prefix (for example
-  `openai/gpt-5.6-terra`), so they are selected and displayed like other OpenAI
-  models. Only models your subscription tier permits are available.
-- Once connected, the subscription's recommended models appear in
-  **Available Models** (toggled off until you enable one). You can also add
-  any other model by entering its slug, such as `gpt-5.6-terra`, with **ChatGPT
-  (subscription)** chosen as the provider — the model is stored with the
-  `openai/` prefix and can then be picked for the default model roles.
-
 The recommended set is a single curated list of models that ships with each
 Roomote release, so it is predictable for a given version. Every provider
 draws from the same list: a provider offers the subset it serves, under its
@@ -81,30 +45,6 @@ full recommended set for every connected provider: recommendations you have
 not enabled appear toggled off, and they cannot be deleted while their
 provider stays connected — turn a model off to stop using it. To go beyond the
 recommended set, add any model by its slug from the add-model field.
-
-If both an OpenAI API key and a ChatGPT subscription are configured, the
-subscription is used at runtime for `openai/` models. If the subscription's
-refresh token is revoked, Roomote marks the connection as errored and prompts
-you to reconnect from **Settings > Models**.
-
-## Model IDs
-
-Roomote model IDs include the provider prefix, such as:
-
-```text
-openrouter/openai/gpt-5.6-terra
-anthropic/claude-sonnet-5
-openai/gpt-5.6-terra
-vercel/openai/gpt-5.6-terra
-baseten/moonshotai/Kimi-K2.7-Code
-togetherai/deepseek-ai/DeepSeek-V4-Pro
-bedrock-mantle/anthropic.claude-sonnet-5
-```
-
-The prefix matters because two providers can expose similar model families with
-different routing, pricing, limits, or credentials. Keeping the provider in the
-model ID makes the task history and settings clearer when you use several
-providers at once.
 
 ## Env-based setup
 

--- a/apps/docs/providers/compute/blaxel.mdx
+++ b/apps/docs/providers/compute/blaxel.mdx
@@ -11,10 +11,7 @@ preview URLs, and starts the task worker as a keep-alive process.
 ## When to use Blaxel
 
 Use Blaxel when task work should run outside the Roomote host and you want
-provider-managed microVMs with automatic standby and fast wake-up. Blaxel does
-not currently support Roomote environment snapshots, but resumable tasks retain
-their existing Blaxel sandbox on standby. Reusable snapshot-based environment
-workflows remain available with Modal, E2B, and Daytona.
+provider-managed microVMs with automatic standby and fast wake-up.
 
 ## Configuration
 

--- a/apps/docs/providers/compute/blaxel.mdx
+++ b/apps/docs/providers/compute/blaxel.mdx
@@ -4,9 +4,9 @@ icon: '/logo/integrations/blaxel.svg'
 description: Run Roomote tasks in Blaxel perpetual sandboxes.
 ---
 
-Blaxel is a hosted sandbox provider. Roomote creates a sandbox from the worker
-image, installs the current worker release, exposes task ports through Blaxel
-preview URLs, and starts the task worker as a keep-alive process.
+Blaxel is a hosted sandbox provider. Roomote creates a sandbox, exposes task
+ports through Blaxel preview URLs, and starts the task worker as a keep-alive
+process.
 
 ## When to use Blaxel
 
@@ -42,7 +42,7 @@ and appear as locked values in Settings.
 
 ## Verify setup
 
-1. Save the API key and workspace name, then wait for image provisioning to finish.
+1. Save the API key and workspace name.
 2. Select Blaxel as the default sandbox provider.
 3. Start a small task and confirm logs reach the task view.
 4. Start a web app and verify its preview link.

--- a/apps/docs/providers/compute/blaxel.mdx
+++ b/apps/docs/providers/compute/blaxel.mdx
@@ -23,12 +23,6 @@ BL_API_KEY=...
 BL_WORKSPACE=my-workspace
 ```
 
-When you save the credentials, Roomote automatically imports the configured
-Roomote worker image and builds a [Blaxel sandbox image](https://docs.blaxel.ai/Sandboxes/Templates).
-The build injects Blaxel's sandbox API and saves the resulting immutable
-`sandbox/name:version` reference as `BLAXEL_IMAGE`. You may still provide
-`BLAXEL_IMAGE` through the process environment to use a prebuilt image.
-
 You can optionally select a region:
 
 ```sh

--- a/apps/docs/providers/compute/blaxel.mdx
+++ b/apps/docs/providers/compute/blaxel.mdx
@@ -40,33 +40,6 @@ Region and standby retention are also editable under **Settings > Sandboxes >
 Blaxel > Advanced settings**. Process environment variables take precedence
 and appear as locked values in Settings.
 
-## Runtime behavior
-
-- Roomote requests a Blaxel TTL matching the task timeout.
-- Fresh sandbox provisioning uses a stable task identity and Blaxel's
-  idempotent create API so controller retries reconnect instead of creating
-  duplicate sandboxes.
-- Each exposed port receives a public Blaxel preview URL. Roomote's preview
-  proxy remains the user-facing authentication layer. Existing preview
-  resources are reused across standby resumes.
-- The detached worker process uses Blaxel keep-alive while the task is active.
-- When Blaxel reports `WORKLOAD_UNAVAILABLE`, Roomote retries workload access
-  with bounded exponential backoff. Missing workloads, invalid routes, and
-  application-origin errors are handled separately rather than retried as
-  transient platform failures.
-- When a resumable task goes to sleep, Roomote stops its worker, extends the
-  sandbox lifetime to the configured standby age (seven days by default), and
-  lets Blaxel move the sandbox to standby.
-  A follow-up reconnects to the same sandbox and launches a new worker without
-  reinstalling the workspace.
-- Non-resumable workflows are still destroyed when their sleep deadline is
-  reached. A five-minute retention sweep deletes standby sandboxes that exceed
-  the configured count or age. A count of `0` disables Blaxel standby retention.
-
-Blaxel standby is intentionally separate from Roomote environment snapshots.
-A standby handle reconnects to one mutable sandbox; it cannot be cloned or
-reused as a clean environment template.
-
 ## Verify setup
 
 1. Save the API key and workspace name, then wait for image provisioning to finish.
@@ -77,7 +50,5 @@ reused as a clean environment template.
 ## Common issues
 
 - **Authentication fails.** Confirm the API key belongs to `BL_WORKSPACE`.
-- **The sandbox remains unavailable.** Confirm `BLAXEL_IMAGE` is a Blaxel-built
-  `sandbox/name:version` image, not a raw Docker registry reference.
 - **A preview has no URL.** Confirm the configured workspace can create public
   sandbox previews and that the requested ports are valid.

--- a/apps/docs/providers/compute/daytona.mdx
+++ b/apps/docs/providers/compute/daytona.mdx
@@ -1,12 +1,12 @@
 ---
 title: Daytona
 icon: '/logo/integrations/daytona.svg'
-description: Run Roomote tasks on Daytona-hosted sandboxes from a registered worker snapshot.
+description: Run Roomote tasks on Daytona-hosted sandboxes.
 ---
 
 Daytona is a hosted sandbox provider with straightforward API-key setup.
-Roomote starts task sandboxes from a registered worker snapshot, and supports
-environment and task-level filesystem snapshots for faster resume flows.
+It supports environment and task-level filesystem snapshots for faster resume
+flows.
 
 ## When to use Daytona
 
@@ -31,14 +31,6 @@ scopes are needed.
 DAYTONA_API_KEY=...
 ```
 
-Roomote registers the worker snapshot automatically from the configured worker
-image (`DOCKER_WORKER_IMAGE` or release derivation). You can also pin the
-snapshot as an env var:
-
-```sh
-DAYTONA_SNAPSHOT_NAME=roomote-worker-<tag>
-```
-
 Optional values:
 
 ```sh
@@ -49,30 +41,9 @@ DAYTONA_TARGET=...
 Use `DAYTONA_API_URL` for custom Daytona endpoints. Use `DAYTONA_TARGET` when
 your account or deployment needs a specific target or region.
 
-## Worker snapshot vs product snapshots
-
-Daytona uses the word "snapshot" for two Roomote concepts:
-
-1. **Worker base snapshot** (`DAYTONA_SNAPSHOT_NAME`) — the baked Roomote
-   worker image registered once per worker image tag. Fresh sandboxes boot from
-   this base.
-2. **Product snapshots** — filesystem captures of a running task or environment
-   setup, stored as named Daytona snapshots and used for env caching and
-   sleep/resume (same product behavior as Modal and E2B).
-
-The worker base snapshot should contain the Roomote worker runtime: system
-packages, browser tooling, language tools, command helpers, and the worker
-bootstrap used to connect back to Roomote.
-
-Settings and setup only collect the API key — not a snapshot name field.
-Roomote registers the worker snapshot from the worker image during setup when
-needed. For production, keep the worker image or base snapshot name pinned so
-task startup is predictable.
-
 ## Verify setup
 
-1. save `DAYTONA_API_KEY` (and let Roomote register the snapshot, or set
-   `DAYTONA_SNAPSHOT_NAME` in the deployment env)
+1. save `DAYTONA_API_KEY`
 2. select Daytona as the default sandbox provider
 3. start a small task from an environment
 4. confirm the task starts, streams logs, and can run project commands
@@ -80,10 +51,5 @@ task startup is predictable.
 
 ## Common issues
 
-- **Daytona reports a missing snapshot.** Confirm auto-provisioning finished,
-  or that `DAYTONA_SNAPSHOT_NAME` exists and is available to the configured
-  API key.
-- **Tasks start with missing tools.** Refresh the worker snapshot from the
-  current Roomote worker image.
 - **The provider starts in the wrong region or target.** Set
   `DAYTONA_TARGET` to the intended target.

--- a/apps/docs/providers/compute/docker.mdx
+++ b/apps/docs/providers/compute/docker.mdx
@@ -17,10 +17,11 @@ Use Docker when:
 - you are trying Roomote on one trusted host
 - task volume is modest enough for the host machine
 - you want the fewest external sandbox accounts and credentials
+- you want resumable tasks to restart the same workspace on the same host
 
 Move to a hosted provider when multiple users run heavier tasks, when task
-work should not compete with the Roomote server, or when you need snapshot
-resume support.
+work should not compete with the Roomote server, or when you need stronger
+provider-managed isolation.
 
 ## Configuration
 

--- a/apps/docs/providers/compute/e2b.mdx
+++ b/apps/docs/providers/compute/e2b.mdx
@@ -1,12 +1,11 @@
 ---
 title: E2B
 icon: '/logo/integrations/e2b.svg'
-description: Run Roomote tasks on E2B-hosted sandboxes using a Roomote worker template.
+description: Run Roomote tasks on E2B-hosted sandboxes.
 ---
 
 E2B is a hosted sandbox provider for running task sandboxes away from the
-Roomote server. Roomote uses an E2B template built from the Roomote worker
-runtime, then starts task sandboxes from that template.
+Roomote server.
 
 ## When to use E2B
 
@@ -26,14 +25,6 @@ as deployment env vars:
 E2B_API_KEY=...
 ```
 
-Roomote provisions the worker template automatically from the configured worker
-image (`DOCKER_WORKER_IMAGE` or release derivation). You can also pin the
-template as an env var:
-
-```sh
-E2B_TEMPLATE_ID=roomote-worker:<tag>
-```
-
 Optional values:
 
 ```sh
@@ -44,21 +35,9 @@ E2B_MAX_SANDBOX_TIMEOUT_MS=3600000
 Use `E2B_DOMAIN` only for self-hosted or custom E2B clusters. The default E2B
 domain is enough for standard hosted E2B.
 
-## Worker template expectations
-
-The E2B template should contain the Roomote worker runtime: system packages,
-browser tooling, language tools, command helpers, and the worker bootstrap used
-to connect back to Roomote.
-
-Settings and setup only collect the API key — not a template ID field. Roomote
-builds the template from the worker image during setup when needed. For
-production, keep the worker image or template version pinned so task startup is
-predictable.
-
 ## Verify setup
 
-1. save `E2B_API_KEY` (and let Roomote provision the template, or set
-   `E2B_TEMPLATE_ID` in the deployment env)
+1. save `E2B_API_KEY`
 2. select E2B as the default sandbox provider
 3. start a small task from an environment
 4. confirm the task starts, streams logs, and can run project commands
@@ -66,10 +45,5 @@ predictable.
 
 ## Common issues
 
-- **E2B reports a missing template.** Confirm auto-provisioning finished, or
-  that `E2B_TEMPLATE_ID` matches a template available to the configured API
-  key.
-- **Tasks start with missing tools.** Rebuild or refresh the worker template
-  from the current Roomote worker image.
 - **Preview links fail.** Confirm the deployment URL and preview proxy are
   reachable from hosted sandboxes.

--- a/apps/docs/providers/compute/modal.mdx
+++ b/apps/docs/providers/compute/modal.mdx
@@ -16,7 +16,7 @@ Use Modal when:
 - several people may run tasks at the same time
 - task work should not consume CPU or memory on the Roomote host
 - you want hosted sandboxes with snapshot support
-- you can provide Modal credentials and a worker image Modal can pull
+- you can provide Modal credentials
 
 ## Configuration
 
@@ -28,56 +28,26 @@ MODAL_TOKEN_ID=...
 MODAL_TOKEN_SECRET=...
 ```
 
-Modal also needs a base image. Roomote usually derives `MODAL_BASE_IMAGE_REF`
-from the shared worker image (`DOCKER_WORKER_IMAGE` or the derived release
-image):
-
-```sh
-DOCKER_WORKER_IMAGE=ghcr.io/roocodeinc/roomote-worker:<version>
-```
-
-Set `MODAL_BASE_IMAGE_REF` only when you need to pin a custom Modal base image:
-
-```sh
-MODAL_BASE_IMAGE_REF=ghcr.io/roocodeinc/roomote-worker:<version>
-```
-
 Optional values:
 
 ```sh
 MODAL_ENDPOINT=...
 MODAL_ENVIRONMENT=...
 MODAL_APP_NAME=...
-MODAL_REGISTRY_USERNAME=...
-MODAL_REGISTRY_PASSWORD=...
-MODAL_ECR_OIDC_ROLE_ARN=...
-MODAL_ECR_REGION=...
 # Optional sandbox placement; also available as Advanced infrastructure in
 # Settings > Sandboxes. Comma-separated Modal regions, for example us or us-west.
 MODAL_REGIONS=us
 ```
-
-Use the registry variables when Modal must pull from a private registry. For
-production, prefer immutable image tags such as a release or commit tag.
 
 `MODAL_REGIONS` is an optional comma-separated list of Modal container placement
 regions (for example `us`, `us-west`, or `us,eu`). When unset, Modal chooses
 placement. Prefer broader tokens such as `us` for capacity and cold-start
 behavior. Pinning a region can add a Modal pricing multiplier and only applies
 to newly created or resumed sandboxes, not sandboxes that are already running.
-Do not confuse `MODAL_REGIONS` with `MODAL_ECR_REGION`, which only controls AWS
-ECR image pulls.
-
-## Worker image expectations
-
-Hosted providers cannot use a local-only image tag such as
-`roomote-worker:local`. The worker image must be registry-qualified and
-reachable by Modal. If Modal cannot pull the image, tasks will fail before the
-worker runtime starts.
 
 ## Verify setup
 
-1. save Modal credentials and a registry-qualified worker image
+1. save Modal credentials
 2. select Modal as the default sandbox provider
 3. start a small task from an environment
 4. confirm the task starts, streams logs, and can run project commands
@@ -85,9 +55,5 @@ worker runtime starts.
 
 ## Common issues
 
-- **Modal cannot pull the worker image.** Use a registry-qualified image and
-  configure registry credentials or ECR OIDC settings when needed.
 - **Tasks fail immediately after launch.** Check `MODAL_TOKEN_ID`,
   `MODAL_TOKEN_SECRET`, and any Modal environment or endpoint overrides.
-- **The wrong worker runtime starts.** Pin `DOCKER_WORKER_IMAGE` or
-  `MODAL_BASE_IMAGE_REF` to an immutable tag.


### PR DESCRIPTION
## Summary

- add ChatGPT subscriptions to the inference provider overview
- remove the provider-specific Amazon Bedrock and ChatGPT subscription sections
- remove the Model IDs section
- streamline the Blaxel provider page by removing implementation-oriented runtime details
- remove base image, worker template, and worker base snapshot discussions across the sandbox docs while retaining user-facing snapshot and resume behavior
- clarify that resumable Docker tasks restart their retained container and workspace on the same host

## Validation

- `prettier --check apps/docs/compute.mdx apps/docs/environment-variables.mdx apps/docs/providers/compute/*.mdx apps/docs/models.mdx`
- `git diff --check`

The full Mintlify check was unavailable because the docs package dependencies are not installed in this checkout.