### PR TITLE
Point docs GitHub links to main

### DIFF
--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -54,5 +54,5 @@ source-available, with each release converting to Apache-2.0 two years after it
 is published. A deployment is free for up to 10 registered users;
 adding more users requires a paid license key entered in Settings → Users. The
 license prohibits disabling or circumventing the license key functionality. See
-the [LICENSE](https://github.com/RooCodeInc/Roomote/blob/develop/LICENSE)
+the [LICENSE](https://github.com/RooCodeInc/Roomote/blob/main/LICENSE)
 file for details.

--- a/apps/docs/local-development.mdx
+++ b/apps/docs/local-development.mdx
@@ -9,7 +9,7 @@ checkout. If you want to operate Roomote for a team, start with
 [Self-hosting](/self-hosting) instead.
 
 The full contributor walkthrough lives in the repository
-[LOCAL_DEVELOPMENT.md](https://github.com/RooCodeInc/Roomote/blob/develop/LOCAL_DEVELOPMENT.md).
+[LOCAL_DEVELOPMENT.md](https://github.com/RooCodeInc/Roomote/blob/main/LOCAL_DEVELOPMENT.md).
 
 ## Prerequisites
 

--- a/apps/docs/self-hosting.mdx
+++ b/apps/docs/self-hosting.mdx
@@ -6,7 +6,7 @@ description: Run Roomote on your own server with the one-command installer or Do
 
 Roomote is designed to run well on a single host behind a Caddy reverse proxy.
 The canonical, always up-to-date operator guide lives in
-[`SELF_HOSTING.md`](https://github.com/RooCodeInc/Roomote/blob/develop/SELF_HOSTING.md)
+[`SELF_HOSTING.md`](https://github.com/RooCodeInc/Roomote/blob/main/SELF_HOSTING.md)
 in the repository; this page summarizes the public setup path and the checks
 that usually matter first.
 


### PR DESCRIPTION
## Summary

- update the self-hosting guide link from `develop` to `main`
- update the local-development guide link from `develop` to `main`
- update the license link from `develop` to `main`

## Validation

- confirmed all three targets exist on `origin/main`
- confirmed no GitHub URL under `apps/docs` retains a `/develop/` branch segment
- `prettier --check` on all changed MDX files
- `git diff --check`