### PR TITLE
Simplify release preparation to two PRs

### DIFF
--- a/.agents/skills/changeset-release-pr/SKILL.md
+++ b/.agents/skills/changeset-release-pr/SKILL.md
@@ -1,18 +1,30 @@
 ---
 name: changeset-release-pr
-description: 'Put together a changeset release PR for Roomote: review what merged to develop since the last release, confirm patch/minor/major with the user when unspecified, and author concise changeset release notes that drive the automated Release Roomote Version PR. Use when asked to prep a release, cut a release PR, or write release notes for the next version.'
+description: 'Prepare the next Roomote release PR: review what merged to develop, fill missing release notes, confirm patch/minor/major when unspecified, run the product version script, and open the final version-and-changelog PR. Use when asked to prep, cut, or write notes for a release.'
 ---
 
 # Changeset Release PR
 
-Use this skill to assemble the release notes that ship the next Roomote version. The deliverable is a normal PR against `develop` that adds pending changeset files under `.changeset/` — nothing else. CI does the actual version bump.
+Use this skill to prepare the single release PR that cuts the next Roomote
+version. The deliverable is a normal PR against `develop` containing the root
+version bump, final `CHANGELOG.md` entry, and deletion of every consumed pending
+changeset. Merging it makes CI open the frozen Promote PR to `main`.
 
 ## How releases work here
 
-- Roomote has a **single product version**: the root `package.json` `version` field. Workspace package versions are frozen and meaningless (all packages are private).
-- Changesets are an **authoring format only**. `pnpm run version` (`scripts/release/apply-version.mjs`) folds pending `.changeset/*.md` files into the root `CHANGELOG.md`, bumps the root version by the highest pending level, and deletes the consumed files. `changeset version` itself is never run.
-- `.github/workflows/release.yml` runs on every push to `develop`. Whenever pending changesets exist, it keeps a **"Release Roomote <version>"** Version PR open against `develop` (branch `changeset-release/develop`, force-pushed by CI). Merging that Version PR cuts a frozen `release/vX.Y.Z` branch and a Promote PR to `main`, which tags and publishes on merge.
-- Therefore "putting together a release PR" means **authoring the changeset files and opening a PR that adds them to `develop`**. Once that PR merges, CI opens or refreshes the real Version PR automatically.
+- Roomote has a **single product version**: the root `package.json` `version`
+  field. Workspace package versions are frozen and meaningless because every
+  workspace package is private.
+- Changesets are an **authoring format only**. Feature PRs may add them ahead of
+  time; this skill creates any missing notes locally before versioning.
+- `pnpm run version` (`scripts/release/apply-version.mjs`) folds all pending
+  `.changeset/*.md` files into the root `CHANGELOG.md`, bumps the root version by
+  the highest pending level, and deletes the consumed files. `changeset version`
+  itself is never run.
+- `.github/workflows/release.yml` does not create another Version PR. After the
+  release PR merges to `develop`, it freezes `release/vX.Y.Z` at that merge and
+  opens the Promote PR to `main`. Merging the Promote PR tags and publishes the
+  release.
 
 Full details: `.changeset/README.md` and `CONTRIBUTING.md#product-releases`.
 
@@ -20,19 +32,23 @@ Full details: `.changeset/README.md` and `CONTRIBUTING.md#product-releases`.
 
 ### 1. Establish the last release reference point
 
-Cross-check three signals; they should agree:
+Cross-check three signals; they should normally agree:
 
 ```bash
-git tag --sort=-creatordate | head -5          # e.g. v0.0.4
-node -p "require('./package.json').version"    # e.g. 0.0.4
-head -10 CHANGELOG.md                          # top section: ## 0.0.4 (YYYY-MM-DD)
+git tag --sort=-creatordate | head -5
+node -p "require('./package.json').version"
+head -10 CHANGELOG.md
 ```
 
-Use the `v<version>` tag as the diff base when it exists. If the root version is ahead of the newest tag (a Version PR merged but the Promote PR has not shipped yet), use the version-bump commit on `develop` instead — resolve it with the repo's own tool:
+Use the `v<version>` tag as the diff base when it exists. If the root version is
+ahead of the newest tag because a release PR merged but its Promote PR has not
+shipped yet, use the version-bump commit on `develop` as the next diff base:
 
 ```bash
 node scripts/release/find-version-commit.mjs <version> origin/develop
 ```
+
+Call out the unshipped release and do not merge a later Promote PR before it.
 
 ### 2. Collect what changed since then
 
@@ -43,37 +59,43 @@ git fetch origin develop
 git log v<last>..origin/develop --oneline --first-parent
 ```
 
-For anything ambiguous, pull the PR body with `gh pr view <number>` to understand the user-facing impact.
+For anything ambiguous, read the PR body with `gh pr view <number>` to identify
+the user-facing or operator-facing impact.
 
-### 3. Subtract what already has a changeset
+### 3. Subtract existing pending changesets
 
 ```bash
-ls .changeset/*.md   # ignore README.md
+find .changeset -maxdepth 1 -type f -name '*.md' ! -iname 'README.md' -print
 ```
 
-Changes already covered by a pending changeset must not get a second note. Read the pending files so wording and bump levels stay consistent with what you add.
+Read every pending file. A change already covered by a pending changeset must
+not receive a duplicate note.
 
 ### 4. Classify the remaining changes
 
-- **Include**: user-visible or operator-visible changes — new capabilities, behavior changes, fixes to visible symptoms, notable performance or UX improvements.
-- **Skip**: chores, docs-only changes, CI/infra tweaks, pure-internal refactors, and dependency bumps with no visible effect. They ride along with the release without a note.
+- **Include** user-visible or operator-visible capabilities, behavior changes,
+  fixes to visible symptoms, and notable performance or UX improvements.
+- **Skip** chores, docs-only changes, CI or infrastructure tweaks, internal
+  refactors, and dependency bumps with no visible effect. They ship without a
+  changelog bullet.
 
 ### 5. Confirm the bump level
 
-If the user already said patch/minor/major, use it. **Otherwise ask** — do not guess silently. Present the choice with a recommendation derived from the actual changes:
+If the user specified patch, minor, or major, use it. Otherwise ask and include
+a recommendation based on the actual changes:
 
 - **patch** — bug fixes and small non-breaking changes only
-- **minor** — new capabilities that stay backward compatible
+- **minor** — backward-compatible new capabilities
 - **major** — breaking behavior changes
 
-Two mechanics to state when asking:
+Explain that the highest level across all pending changesets determines the
+single product version. If an existing pending changeset is higher than the
+user's choice, say that the higher bump will win. Individual notes may carry
+different levels and are grouped by level in the changelog.
 
-- The release script applies the **highest level across all pending changesets** to the single product version. If an already-pending changeset carries a higher level than the user picks, the release will bump by that higher level anyway — say so.
-- Individual changesets may carry different levels (e.g. features as `minor`, fixes as `patch`); the CHANGELOG groups bullets under `### Major changes`, `### Minor changes`, and `### Patch changes` accordingly, and the overall bump is still the highest present.
+### 6. Author missing changesets locally
 
-### 6. Author the changeset files
-
-One file per logical release note, `.changeset/<descriptive-slug>.md`:
+Create one `.changeset/<descriptive-slug>.md` file per logical release note:
 
 ```markdown
 ---
@@ -83,27 +105,74 @@ One file per logical release note, `.changeset/<descriptive-slug>.md`:
 One concise, user-facing summary of the change.
 ```
 
-- **Frontmatter is bump-level only.** Always use exactly one package line: `'@roomote/web': <major|minor|patch>`. Do **not** list multiple packages, invent package maps from the PR diff, or try to mirror changed workspaces — workspace package versions are frozen, and `scripts/release/lib.mjs` ignores package names entirely (it only reads each note’s highest level for CHANGELOG grouping and the max level across notes for the root product bump). Listing real packages still looks like an inaccurate accounting in review.
-- Preview the next product version with standard semver/`scripts/release` math before writing the PR body: from `X.Y.Z`, **patch → X.Y.(Z+1)**, **minor → X.(Y+1).0**, **major → (X+1).0.0**. Example: `0.0.4` + minor = **`0.1.0`**, not `0.0.5`.
-- Each summary becomes **one CHANGELOG bullet**, and the release script collapses all whitespace to a single line. Write one tight paragraph; no headings, lists, or line breaks that matter.
-- Write for a user or operator reading release notes: lead with what changed or what now works, name the surface (e.g. "Settings → Sandboxes", "Slack tasks"), and mention the previous broken behavior for fixes. See any existing `.changeset/*.md` file for tone.
-- Group closely related PRs into one note when they ship a single user-facing story; otherwise keep notes separate.
+- Always use exactly one package line: `'@roomote/web': <level>`. Package names
+  are ignored by the release script; the frontmatter carries only bump level.
+- Each summary becomes one changelog bullet. Write one tight paragraph with no
+  headings or nested lists.
+- Lead with what changed or now works, name the affected product surface, and
+  mention the previous symptom when describing a fix.
+- Group closely related PRs when they form one user-facing story. Otherwise keep
+  their notes separate.
+- These newly authored files are temporary release inputs. `pnpm run version`
+  consumes them before the release branch is committed.
 
-### 7. Open the PR
+### 7. Generate and verify the release
 
-Commit only the new `.changeset/*.md` files on a feature branch and open a PR against `develop` through the normal delivery path. In the PR body include:
+Start from the current `origin/develop` tip. If `develop` advances before the
+release PR merges, rebuild the release artifacts from the new tip and repeat the
+audit; do not merely merge the new commits into an already-generated release
+branch, because their changesets and notes would not have been consumed.
 
-- the expected next version (current version bumped by the highest pending level),
-- the drafted release-note bullets grouped by level (a preview of the CHANGELOG section),
-- a note that merging this PR makes CI open or refresh the **Release Roomote <version>** Version PR, which is what actually bumps the version and updates `CHANGELOG.md`.
+Run the repository-owned version command; never hand-edit the output:
+
+```bash
+pnpm run version
+```
+
+Then verify:
+
+- `package.json` contains the expected next version using ordinary semver
+  (`patch` increments patch, `minor` increments minor and zeros patch, `major`
+  increments major and zeros minor and patch)
+- the new top `CHANGELOG.md` section contains every intended note under the
+  correct bump-level heading
+- every pending changeset was consumed and `.changeset/README.md` remains
+- workspace package versions did not change
+- the diff contains only release artifacts: root `package.json`,
+  `CHANGELOG.md`, and deletions of changesets that already existed on the base
+  branch. Locally created missing changesets normally leave no final diff because
+  they are created and consumed in the same working tree.
+
+Run the release-script tests and the repository's appropriate static checks
+before opening the PR.
+
+### 8. Open the release PR
+
+Commit the generated release artifacts on a feature branch and open a PR against
+`develop` titled **Release Roomote X.Y.Z**. The PR body should include:
+
+- the previous and next product versions
+- the final changelog bullets grouped by bump level
+- validation performed
+- a note that squash-merging the PR cuts the release and automatically opens
+  the frozen **Promote vX.Y.Z to production** PR against `main`
 
 ## Guardrails
 
-- Never edit `CHANGELOG.md` or the root `package.json` version by hand, and never commit the output of `pnpm run version` — the CI Version PR owns both.
-- Never push to `changeset-release/develop` or `release/v*` branches; CI force-pushes and freezes them.
+- Never edit `CHANGELOG.md` or the root version by hand; generate both with
+  `pnpm run version`, review the result, and commit that output in the release
+  PR.
+- Never run or commit `changeset version` output.
+- Never push to `release/v*`; CI owns frozen release branches.
+- Never merge an out-of-date release PR. Regenerate it from the latest
+  `develop` so every commit included in the cut was part of the release audit.
 - Never bump versions in workspace `package.json` files.
-- Do not create the "Release Roomote" Version PR or the Promote PR manually.
-- Ask for the bump level when it was not specified; recommend one, but let the user decide.
-- Do not write notes for changes that already have a pending changeset, and do not pad the changelog with internal noise.
-- Do not multi-package-attribute changesets or free-associate package names with PR file paths; always emit a single `'@roomote/web': <level>` frontmatter line.
-- When stating the expected next version in a release PR body or chat, use the actual scripted bump (`scripts/release/lib.mjs` `computeNextVersion` / ordinary semver: minor zeros the patch).
+- Do not create the Promote PR manually.
+- Ask for the bump level when unspecified; recommend one but let the user
+  decide.
+- Do not duplicate existing pending notes or pad the changelog with internal
+  noise.
+- Do not multi-package-attribute changesets; always emit one
+  `'@roomote/web': <level>` line.
+- Use the actual version produced by `scripts/release/lib.mjs`; do not guess
+  semver in the PR title or body.

--- a/.agents/skills/changeset-release-pr/agents/openai.yaml
+++ b/.agents/skills/changeset-release-pr/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: 'Changeset Release PR'
-  short_description: 'Assemble release-note changesets for the next Roomote version'
-  default_prompt: 'Use $changeset-release-pr to review what merged to develop since the last release, confirm the patch/minor/major bump with me if I have not specified it, and open a PR adding concise changeset release notes.'
+  short_description: 'Prepare the final version and changelog PR for Roomote'
+  default_prompt: 'Use $changeset-release-pr to review what merged to develop, confirm the bump when unspecified, fill missing release notes, generate the version and changelog, and open the final release PR.'

--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -27,13 +27,24 @@ Chores, docs-only, and pure-internal refactors can skip a changeset; they ride a
 
 ## How a release ships
 
-1. Merge code to `develop`. When pending changesets exist, CI keeps a **Release Roomote** Version PR open against `develop` that bumps the root version and updates the root `CHANGELOG.md` (nothing else).
-2. Merging that Version PR (or any push to `develop` whose version is untagged) cuts a frozen `release/vX.Y.Z` branch at the version-bump commit and opens or refreshes a **Promote PR** (`release/vX.Y.Z` → `main`). Commits merged to `develop` after the version bump wait for the next release instead of riding along.
-3. Merging the Promote PR with a **merge commit** (not squash) into `main` tags `vX.Y.Z`, then GHCR builds the matching images; the GitHub Release is created only after those images exist so `releases/latest` never points at a missing image set. The `release/vX.Y.Z` branch can be deleted after the merge.
+1. Merge code to `develop`, including changesets with user-visible changes when
+   practical. Pending changesets accumulate until a maintainer cuts a release.
+2. Use the `changeset-release-pr` skill to audit changes since the last release,
+   fill any missing notes, and run `pnpm run version`. It opens one **Release
+   Roomote X.Y.Z** PR against `develop` containing the root version bump, final
+   `CHANGELOG.md` section, and consumed changeset deletions.
+3. Squash-merge that release PR. CI cuts a frozen `release/vX.Y.Z` branch at the
+   version-bump commit and opens or refreshes a **Promote PR**
+   (`release/vX.Y.Z` → `main`). Commits merged to `develop` afterward wait for
+   the next release instead of riding along.
+4. Merge the Promote PR with a **merge commit** (not squash) into `main` to tag
+   `vX.Y.Z`. GHCR builds the matching images, and the GitHub Release is created
+   only after those images exist so `releases/latest` never points at a missing
+   image set. The `release/vX.Y.Z` branch can be deleted after the merge.
 
 Branch rules (must match GitHub rulesets):
 
-- **`develop`**: squash-only merges for feature and Version PRs.
+- **`develop`**: squash-only merges for feature and release PRs.
 - **`main`**: merge-commit-only so promote PRs keep shared history with `develop`.
 
 Maintainers: product tagging requires repository secret `RELEASE_BOT_TOKEN` (see `.github/workflows/tag-release.yml`). Contributor overview: [CONTRIBUTING.md](../CONTRIBUTING.md#product-releases).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,9 @@ on:
     branches:
       - develop
 
-# One release automation lane on develop. Cancel superseded runs: every run
-# re-derives state from the live develop tip, so the newest push always redoes
-# the work and a stale queued run can never resurrect an outdated Version PR.
+# Every push re-checks the live develop version. Tagged versions are no-ops;
+# an untagged version means a maintainer merged a release PR and is ready for
+# the frozen promotion gate.
 concurrency:
   group: release-develop
   cancel-in-progress: true
@@ -17,106 +17,9 @@ permissions:
   pull-requests: write
 
 jobs:
-  version:
-    name: Version PR
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          # Prefer RELEASE_BOT_TOKEN so the Version PR triggers CI when it is
-          # opened. Fall back to GITHUB_TOKEN when the secret is not yet set
-          # (first-time bootstrap still opens the PR; CI may need a re-run).
-          token: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
-          # Work on the live develop tip, not the push SHA that triggered
-          # this run: a queued run that starts after more merges must not
-          # recreate a Version PR from an outdated snapshot.
-          ref: develop
-
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment
-        with:
-          frozen-lockfile: 'true'
-
-      - name: Create, refresh, or close the Version PR
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
-          HUSKY: '0'
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          branch='changeset-release/develop'
-
-          close_stale_version_pr() {
-            local existing
-            existing="$(gh pr list --base develop --head "$branch" --state open --json number --jq '.[0].number // empty')"
-            if [ -n "$existing" ]; then
-              gh pr close "$existing" --comment 'No versionable changesets remain on develop; closing this stale Version PR.' --delete-branch || true
-            fi
-          }
-
-          pending="$(find .changeset -maxdepth 1 -type f -name '*.md' ! -iname 'README.md' 2>/dev/null | wc -l | tr -d ' ')"
-
-          if [ "${pending:-0}" -eq 0 ]; then
-            close_stale_version_pr
-            echo "No pending changesets; nothing to version."
-            exit 0
-          fi
-
-          pnpm run version
-          version="$(node -p "require('./package.json').version")"
-
-          # Rebuild the branch from the live develop tip on every run so the
-          # Version PR is always a single fresh commit and never drifts.
-          git checkout -B "$branch"
-          git add package.json CHANGELOG.md .changeset
-          if git diff --cached --quiet; then
-            # Changeset files exist but none carry a valid bump (for example
-            # an empty changeset); there is nothing to version yet, and any
-            # previously opened Version PR no longer reflects a real release.
-            close_stale_version_pr
-            echo "No versionable changesets; nothing to commit."
-            exit 0
-          fi
-          git commit -m "chore(release): version roomote ${version}"
-          git push --force origin "$branch"
-
-          notes="$(node scripts/release/extract-changelog-section.mjs "$version" || true)"
-          body_file="$(mktemp)"
-          {
-            echo "Automated Version PR: bumps the product version to \`${version}\` and folds the pending changesets into the root \`CHANGELOG.md\`."
-            echo
-            echo "- **Squash-merge** this PR into \`develop\` to cut the release."
-            echo "- The frozen \`release/v${version}\` promote PR to \`main\` opens automatically after the merge."
-            echo "- New changesets on \`develop\` refresh this PR automatically."
-            echo
-            if [ -n "$notes" ]; then
-              echo "$notes"
-            fi
-          } > "$body_file"
-
-          existing="$(gh pr list --base develop --head "$branch" --state open --json number --jq '.[0].number // empty')"
-          if [ -n "$existing" ]; then
-            echo "Version PR already open: #$existing"
-            gh pr edit "$existing" --title "Release Roomote ${version}" --body-file "$body_file"
-          else
-            gh pr create \
-              --base develop \
-              --head "$branch" \
-              --title "Release Roomote ${version}" \
-              --body-file "$body_file"
-          fi
-          rm -f "$body_file"
-
   promote:
     name: Open or refresh Promote PR
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: version
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -148,10 +51,9 @@ jobs:
             exit 1
           fi
 
-          # Freeze the release at the commit that introduced this version
-          # (the Version PR merge), not at the moving develop tip. Commits
-          # merged to develop after that point wait for the next cut instead
-          # of silently riding into this release.
+          # Freeze the release at the commit that introduced this version (the
+          # release PR merge), not at the moving develop tip. Commits merged to
+          # develop afterward wait for the next release.
           bump_sha="$(node scripts/release/find-version-commit.mjs "$version" HEAD)"
 
           if git merge-base --is-ancestor "$bump_sha" origin/main; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,14 +50,16 @@ See [`.changeset/README.md`](.changeset/README.md).
 
 ### How a release ships
 
-1. Merge work to `develop` (squash). When pending changesets exist, automation
-   opens a **Release Roomote** Version PR that bumps the root version and
-   `CHANGELOG.md` (nothing else).
-2. When the product version is untagged, automation cuts a frozen
-   `release/vX.Y.Z` branch at the version-bump commit and opens or refreshes a
-   **Promote `vX.Y.Z` to production** PR (`release/vX.Y.Z` → `main`). Work
-   merged to `develop` after the version bump waits for the next release.
-3. Merge that promote PR with a **merge commit** (branch rules on `main` allow
+1. Merge work to `develop` (squash), adding changesets for user-visible changes
+   when practical.
+2. A maintainer uses the `changeset-release-pr` skill to audit missing notes,
+   run `pnpm run version`, and open one **Release Roomote X.Y.Z** PR containing
+   the final version bump and `CHANGELOG.md` entry.
+3. Squash-merge that release PR. Automation cuts a frozen `release/vX.Y.Z`
+   branch at the version-bump commit and opens or refreshes a **Promote
+   `vX.Y.Z` to production** PR (`release/vX.Y.Z` → `main`). Work merged to
+   `develop` afterward waits for the next release.
+4. Merge that promote PR with a **merge commit** (branch rules on `main` allow
    merge only; `develop` stays squash-only). Tagging (`vX.Y.Z`), GHCR image
    publish (`latest`), and the GitHub Release follow from `main` / tag workflows.
    Product tagging requires the `RELEASE_BOT_TOKEN` repository secret.

--- a/scripts/release/__tests__/workflow.test.mjs
+++ b/scripts/release/__tests__/workflow.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import YAML from 'yaml';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+test('release workflow keeps promotion as the only automated PR gate', () => {
+  const workflow = YAML.parse(
+    readFileSync(join(repoRoot, '.github/workflows/release.yml'), 'utf8'),
+  );
+
+  assert.deepEqual(Object.keys(workflow.jobs), ['promote']);
+  assert.equal(workflow.jobs.promote.needs, undefined);
+
+  const promoteScript = workflow.jobs.promote.steps.find(
+    (step) => typeof step.run === 'string',
+  )?.run;
+  assert.match(promoteScript, /find-version-commit\.mjs/);
+  assert.match(promoteScript, /gh pr create/);
+});

--- a/scripts/release/apply-version.mjs
+++ b/scripts/release/apply-version.mjs
@@ -8,7 +8,7 @@
  * consumed changeset files. Workspace package versions are never touched.
  *
  * Usage: node scripts/release/apply-version.mjs
- * Runs as `pnpm run version` from the Release workflow's Version PR job.
+ * Runs as `pnpm run version` while preparing the release PR.
  */
 
 import { dirname, join } from 'node:path';

--- a/scripts/release/find-version-commit.mjs
+++ b/scripts/release/find-version-commit.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /**
- * Print the commit SHA that introduced a product version (the Version PR
- * merge commit). Used by the Release workflow to freeze the promote PR at
- * the versioned commit instead of the moving develop tip.
+ * Print the commit SHA that introduced a product version (the release PR merge
+ * commit). Used by the Release workflow to freeze the promote PR at the
+ * versioned commit instead of the moving develop tip.
  *
  * Usage: node scripts/release/find-version-commit.mjs <version> [ref]
  * Prints the full SHA to stdout, or exits 1 when the version is not the

--- a/scripts/release/lib.mjs
+++ b/scripts/release/lib.mjs
@@ -183,7 +183,7 @@ export function extractChangelogSection(changelogMarkdown, version) {
  *
  * Walks commits that touched the root package.json from the tip of `ref`
  * backwards, and returns the oldest contiguous commit whose version equals
- * `version` — i.e. the Version PR merge commit that bumped to it. Returns
+ * `version` — i.e. the release PR merge commit that bumped to it. Returns
  * null when the tip of `ref` is not on `version` (the version is stale) or
  * the version never appears.
  *


### PR DESCRIPTION
## Summary

- make the release skill generate the final version and changelog PR directly
- remove automated Version PR generation from the release workflow
- keep the frozen Promote PR as the production gate to `main`
- update release documentation and script terminology for the two-PR flow
- add a regression test that requires promotion to remain the only automated PR job

## New flow

1. The release skill audits changes, fills missing notes, runs `pnpm run version`, and opens **Release Roomote X.Y.Z** against `develop`.
2. Merging that PR makes CI freeze the versioned commit and open **Promote vX.Y.Z to production** against `main`.

If `develop` advances before the release PR merges, the skill now requires regenerating the release from the latest tip so unaudited changes cannot ride along.

## Validation

- `pnpm test:release-scripts` (8 tests)
- parsed `release.yml` and verified the standalone `promote` job
- `bash -n` against the embedded promotion script
- skill `quick_validate.py`
- Prettier on all changed files
- `pnpm lint:fast`
- `pnpm check-types:fast`
- `pnpm knip`

No changeset: this changes internal release automation and contributor guidance, not shipped product behavior.