### PR TITLE
Create a Telegram topic for each task

### DIFF
--- a/.agents/skills/mock-telegram-testing/SKILL.md
+++ b/.agents/skills/mock-telegram-testing/SKILL.md
@@ -7,7 +7,7 @@ description: Run Roomote Telegram integration flows through the checked-in mock 
 
 Use this skill to exercise Roomote's Telegram integration against the checked-in mock Telegram harness. Do not invent another fake Telegram stack and do not fall back to a real Telegram bot unless the user explicitly asks for that parity test.
 
-Telegram has no threads: conversation continuity is inferred from **chat id (+ forum topic id) → active cloud job**, with `/new` and `/done` as the explicit escape hatches after a task completes. That continuity logic is the highest-value thing to test here.
+Telegram continuity is inferred from **chat id (+ forum topic id) → active cloud job**. Private bot chats can have topics when Threaded Mode is enabled in BotFather, and forum supergroups can have topics when the bot has Manage Topics rights. `/new` and `/done` are the explicit escape hatches after a task completes. That continuity logic is the highest-value thing to test here.
 
 ## Quick Reference
 
@@ -22,7 +22,7 @@ Telegram has no threads: conversation continuity is inferred from **chat id (+ f
 | Example scenario              | `packages/communication/scripts/mock-telegram.example.json` |
 | Webhook secret source         | `Env.R_TELEGRAM_WEBHOOK_SECRET` from dotenvx                |
 | Mock bot identity             | `roomote_mock_bot` (id `7000000001`)                        |
-| Mock linked user              | Telegram user id `111000111` (`grace_mock`)                   |
+| Mock linked user              | Telegram user id `111000111` (`grace_mock`)                 |
 
 ## Step 1: Seed the database
 

--- a/.agents/skills/mock-telegram-testing/SKILL.md
+++ b/.agents/skills/mock-telegram-testing/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: mock-telegram-testing
-description: Run Roomote Telegram integration flows through the checked-in mock Telegram Bot API harness instead of a real Telegram bot. Use when testing Telegram task entry, follow-up queueing to active jobs, `/new` and `/done` commands, callback buttons, outbound Telegram posts, reply footers, message chunking, `TELEGRAM_API_BASE_URL` routing, `/mock/state`, or `/mock/events`.
+description: Run Roomote Telegram integration flows through the checked-in mock Telegram Bot API harness instead of a real Telegram bot. Use when testing Telegram task entry, follow-up queueing to active jobs, the `/new` command, callback buttons, outbound Telegram posts, reply footers, message chunking, `TELEGRAM_API_BASE_URL` routing, `/mock/state`, or `/mock/events`.
 ---
 
 # Mock Telegram Testing
 
 Use this skill to exercise Roomote's Telegram integration against the checked-in mock Telegram harness. Do not invent another fake Telegram stack and do not fall back to a real Telegram bot unless the user explicitly asks for that parity test.
 
-Telegram continuity is inferred from **chat id (+ forum topic id) → active cloud job**. Private bot chats can have topics when Threaded Mode is enabled in BotFather, and forum supergroups can have topics when the bot has Manage Topics rights. `/new` and `/done` are the explicit escape hatches after a task completes. That continuity logic is the highest-value thing to test here.
+Telegram continuity is inferred from **chat id (+ forum topic id) → active cloud job**. Private bot chats can have topics when Threaded Mode is enabled in BotFather, and forum supergroups can have topics when the bot has Manage Topics rights. `/new` is the explicit escape hatch after a task completes. That continuity logic is the highest-value thing to test here.
 
 ## Quick Reference
 

--- a/.agents/skills/mock-telegram-testing/references/scenarios.md
+++ b/.agents/skills/mock-telegram-testing/references/scenarios.md
@@ -2,7 +2,7 @@
 
 Each scenario lists the updates to inject, the expected observable behavior, and where to assert it. "State" means `GET http://127.0.0.1:3013/mock/state`; "DB" means the `cloud_jobs` table. Bot messages have `from.is_bot == true`.
 
-Because Telegram has no threads, the core product invariant under test is: **one chat (or forum topic) maps to at most one active conversation**, continuity comes from the active-job lookup, and `/new`/`/done` are the only ways to break out early.
+The core product invariant under test is: **one chat (or forum topic) maps to at most one active conversation**, continuity comes from the active-job lookup, and `/new` is the way to break out early.
 
 ## 1. private-fast-answer
 
@@ -29,13 +29,13 @@ A second message arrives in the same chat while the job is active.
 - Assert: state shows the second inbound message with a reaction but no new task-start ack; DB still has one active job for the chat.
 - Regression risk: if active-job lookup breaks, every follow-up silently launches a parallel task — the worst UX failure this surface has.
 
-## 4. new-task-command / done-command
+## 4. new-task-command
 
-After a task completes, the next plain message resumes its snapshot; `/new` or `/done` must force a fresh task instead.
+After a task completes, the next plain message resumes its snapshot; `/new` must force a fresh task instead.
 
 - Inject: complete a task in the chat (or seed a Completed job with a resumable snapshot), then `message` with text `/new upgrade the login tests to vitest 4`.
 - Expect: a fresh task launch (new job id), not a snapshot resume; the `/new` invocation is stripped from the queued task text.
-- Variants: `/done <req>`; group forms `/new@roomote_mock_bot <req>` and `@roomote_mock_bot /new <req>`; a mid-sentence `/new` must NOT trigger (it is ordinary text); `/new` while a job is still running is refused with an echo-back so the user can resend.
+- Variants: group forms `/new@roomote_mock_bot <req>` and `@roomote_mock_bot /new <req>`; a mid-sentence `/new` must NOT trigger (it is ordinary text); `/new` while a job is still running is refused with an echo-back so the user can resend.
 - Assert: DB (new job vs `SnapshotResume` payload); state for the refusal echo.
 
 ## 5. group-mention-gating

--- a/.agents/skills/mock-telegram-testing/references/scenarios.md
+++ b/.agents/skills/mock-telegram-testing/references/scenarios.md
@@ -17,8 +17,8 @@ A linked user DMs `!fast <question>`.
 A linked user DMs a work request.
 
 - Inject: `message` in private chat, text `fix the flaky login test in apps/web`.
-- Expect: eyes ack; a task-started message with a follow-task URL button and a `cancel_task:<jobId>` cancel button; a new cloud job whose payload carries `communicationProvider: 'telegram'`, `communicationChannelId: '111000111'`.
-- Assert: state (started message with `reply_markup.inline_keyboard`); DB payload fields.
+- Expect: eyes ack; a task-started message with a follow-task URL button and a `cancel_task:<jobId>` cancel button; a new cloud job whose payload carries `communicationProvider: 'telegram'`, `communicationChannelId: '111000111'`. If Telegram created an implicit topic named `New Chat`, its title is replaced with Roomote's canonical early task title.
+- Assert: state (started message with `reply_markup.inline_keyboard`, implicit topic renamed); DB payload fields.
 
 ## 3. followup-to-active-job (the no-threads core case)
 

--- a/apps/api/src/handlers/telegram/__tests__/callback-actions.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/callback-actions.test.ts
@@ -89,13 +89,14 @@ import { handleTelegramCallbackQuery } from '../callback-actions.js';
 const WORK_ITEM_ID = 'work-item-1';
 const CLAIMED_AT = new Date('2026-07-01T12:00:00.000Z');
 
-function buildSuggestionQuery(): TelegramCallbackQuery {
+function buildSuggestionQuery(threadId?: number): TelegramCallbackQuery {
   return {
     id: 'callback-1',
     from: { id: 42, is_bot: false, first_name: 'Matt' },
     data: `idea:${WORK_ITEM_ID}`,
     message: {
       message_id: 100,
+      ...(threadId ? { message_thread_id: threadId } : {}),
       date: 0,
       chat: { id: 555, type: 'private' },
     },
@@ -121,6 +122,23 @@ beforeEach(() => {
 });
 
 describe('handleTelegramCallbackQuery suggestion launch lifecycle', () => {
+  it('starts a suggestion in a fresh topic while preserving its source topic for fallback', async () => {
+    startNewTelegramTaskMock.mockResolvedValue({
+      status: 'started',
+      launchResult: { id: 7, taskId: 'task-1' },
+    });
+
+    await handleTelegramCallbackQuery(buildSuggestionQuery(44));
+
+    expect(startNewTelegramTaskMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        forceNewTopic: true,
+        queuedMessage: expect.objectContaining({ threadTs: '44' }),
+        metadata: expect.objectContaining({ communicationThreadId: '44' }),
+      }),
+    );
+  });
+
   it('finalizes the work item with the task id and the claim token on success', async () => {
     startNewTelegramTaskMock.mockResolvedValue({
       status: 'started',

--- a/apps/api/src/handlers/telegram/__tests__/index.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/index.test.ts
@@ -16,6 +16,7 @@ const {
   environmentsFindFirstMock,
   envMock,
   getAvailableEnvironmentsMock,
+  getBotInfoMock,
   getTaskUrlMock,
   insertMock,
   insertOnConflictDoNothingMock,
@@ -48,6 +49,7 @@ const {
   enqueueTaskMock: vi.fn(),
   environmentsFindFirstMock: vi.fn(),
   getAvailableEnvironmentsMock: vi.fn(),
+  getBotInfoMock: vi.fn(),
   envMock: {
     R_APP_URL: 'https://app.example.com',
     R_TELEGRAM_BOT_TOKEN: 'bot-token' as string | undefined,
@@ -246,6 +248,7 @@ vi.mock('@roomote/communication/telegram-provider', () => ({
       addReaction: addReactionMock,
       answerCallbackQuery: answerCallbackQueryMock,
       createForumTopic: createForumTopicMock,
+      getBotInfo: getBotInfoMock,
       editMessageReplyMarkup: editMessageReplyMarkupMock,
       editMessageText: editMessageTextMock,
       postMessage: postMessageMock,
@@ -356,6 +359,7 @@ describe('Telegram webhook handler', () => {
     createForumTopicMock.mockRejectedValue(
       new Error('Bad Request: chat is not a forum'),
     );
+    getBotInfoMock.mockResolvedValue({ hasTopicsEnabled: true });
     insertMock.mockReturnValue({ values: insertValuesMock });
     insertValuesMock.mockReturnValue({
       onConflictDoNothing: insertOnConflictDoNothingMock,
@@ -849,6 +853,45 @@ describe('Telegram webhook handler', () => {
         text: expect.stringContaining('Reconnected this Telegram chat'),
       }),
     );
+  });
+
+  it('does not silently resume a completed task from a user-owned forum topic', async () => {
+    mockTelegramLinkedSender('launch-owner-4');
+    taskRunsFindFirstMock.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      id: 55,
+      status: 'completed',
+      taskId: 'task-old',
+      payload: {
+        repo: 'RooCodeInc/Roomote',
+        communicationProvider: 'telegram',
+        communicationChannelId: '-100222',
+        communicationThreadId: '77',
+      },
+      snapshotId: 'snapshot-1',
+      snapshotCreatedAt: new Date(),
+    });
+
+    const response = await postTelegramUpdate(
+      createTelegramUpdate({
+        message: {
+          message_thread_id: 77,
+          text: 'ordinary group chatter',
+          chat: {
+            id: -100222,
+            type: 'supergroup',
+            title: 'Engineering',
+            is_forum: true,
+          },
+        },
+      }),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      queued: false,
+      reason: 'not_task_entry',
+    });
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
   });
 
   it('/new bypasses a resumable snapshot and starts a fresh task', async () => {

--- a/apps/api/src/handlers/telegram/__tests__/index.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/index.test.ts
@@ -878,37 +878,6 @@ describe('Telegram webhook handler', () => {
     expect(routeTaskMock).toHaveBeenCalled();
   });
 
-  it('/done works as an alias for /new', async () => {
-    mockTelegramLinkedSender('launch-owner-6');
-    taskRunsFindFirstMock.mockResolvedValueOnce(null);
-
-    const response = await postTelegramUpdate(
-      createTelegramUpdate({
-        message: {
-          text: '/done run the test suite',
-          entities: [{ type: 'bot_command', offset: 0, length: 5 }],
-        },
-      }),
-    );
-
-    await expect(response.json()).resolves.toEqual({
-      ok: true,
-      started: true,
-      runId: 88,
-    });
-    expect(enqueueTaskMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        task: expect.objectContaining({
-          type: 'standard',
-          payload: expect.objectContaining({
-            description: 'run the test suite',
-          }),
-        }),
-      }),
-      expect.objectContaining({ launchClass: 'human' }),
-    );
-  });
-
   it('replies with a usage hint for a bare /new with no description', async () => {
     mockTelegramLinkedSender('launch-owner-7');
 
@@ -973,7 +942,7 @@ describe('Telegram webhook handler', () => {
     );
   });
 
-  it('names the command sent and echoes the request in the refusal', async () => {
+  it('echoes the /new request in the active-task refusal', async () => {
     mockTelegramLinkedSender('launch-owner-8');
     taskRunsFindFirstMock.mockResolvedValueOnce({
       id: 77,
@@ -986,8 +955,8 @@ describe('Telegram webhook handler', () => {
     const response = await postTelegramUpdate(
       createTelegramUpdate({
         message: {
-          text: '/done update the README instead',
-          entities: [{ type: 'bot_command', offset: 0, length: 5 }],
+          text: '/new update the README instead',
+          entities: [{ type: 'bot_command', offset: 0, length: 4 }],
         },
       }),
     );
@@ -999,12 +968,12 @@ describe('Telegram webhook handler', () => {
     });
     expect(postMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        text: expect.stringContaining('/done update the README instead'),
+        text: expect.stringContaining('/new update the README instead'),
       }),
     );
   });
 
-  it('queues a mid-sentence /done as an ordinary follow-up to the active task', async () => {
+  it('queues a mid-sentence slash token as an ordinary follow-up', async () => {
     mockTelegramLinkedSender('launch-owner-9');
     taskRunsFindFirstMock.mockResolvedValueOnce({
       id: 77,
@@ -1017,8 +986,8 @@ describe('Telegram webhook handler', () => {
     const response = await postTelegramUpdate(
       createTelegramUpdate({
         message: {
-          text: 'ping me when you are /done with the build',
-          entities: [{ type: 'bot_command', offset: 21, length: 5 }],
+          text: 'check the /status route in the build',
+          entities: [{ type: 'bot_command', offset: 10, length: 7 }],
         },
       }),
     );
@@ -1035,7 +1004,7 @@ describe('Telegram webhook handler', () => {
         userId: 'launch-owner-9',
         // The mid-sentence command is message content: delivered verbatim,
         // not spliced out of the follow-up text.
-        text: 'ping me when you are /done with the build',
+        text: 'check the /status route in the build',
       }),
     );
     expect(enqueueTaskMock).not.toHaveBeenCalled();
@@ -1106,7 +1075,6 @@ describe('Telegram webhook handler', () => {
     expect(welcomeText).toContain('`/start`');
     expect(welcomeText).toContain('`/new <request>`');
     expect(welcomeText).not.toContain('`/start <request>`');
-    expect(welcomeText).not.toContain('`/done <request>`');
   });
 
   it('welcomes bare /start commands from an unlinked sender', async () => {

--- a/apps/api/src/handlers/telegram/__tests__/index.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/index.test.ts
@@ -384,6 +384,33 @@ describe('Telegram webhook handler', () => {
     postMessageMock.mockResolvedValue({ messageId: 'telegram-response' });
   });
 
+  it('remembers implicit Telegram topics so the task title can replace New Chat', async () => {
+    const response = await postTelegramUpdate(
+      createTelegramUpdate({
+        message: {
+          text: undefined,
+          message_thread_id: 77,
+          forum_topic_created: {
+            name: 'New Chat',
+            is_name_implicit: true,
+          },
+        },
+      }),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      implicitTopicRemembered: true,
+    });
+    expect(redisSetMock).toHaveBeenCalledWith(
+      'telegram:implicit-topic:222:77',
+      '1',
+      'EX',
+      60 * 60,
+    );
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
+  });
+
   it('nudges an unlinked sender to link and drops the message', async () => {
     const response = await postTelegramUpdate(createTelegramUpdate());
 

--- a/apps/api/src/handlers/telegram/__tests__/index.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/index.test.ts
@@ -8,6 +8,7 @@ const {
   buildTelegramRoutingContextMock,
   taskRunsFindFirstMock,
   consumeLinkCodeMock,
+  createForumTopicMock,
   restoreLinkCodeMock,
   editMessageReplyMarkupMock,
   editMessageTextMock,
@@ -40,6 +41,7 @@ const {
   buildTelegramRoutingContextMock: vi.fn(),
   taskRunsFindFirstMock: vi.fn(),
   consumeLinkCodeMock: vi.fn(),
+  createForumTopicMock: vi.fn(),
   restoreLinkCodeMock: vi.fn(),
   editMessageReplyMarkupMock: vi.fn(),
   editMessageTextMock: vi.fn(),
@@ -243,6 +245,7 @@ vi.mock('@roomote/communication/telegram-provider', () => ({
     return {
       addReaction: addReactionMock,
       answerCallbackQuery: answerCallbackQueryMock,
+      createForumTopic: createForumTopicMock,
       editMessageReplyMarkup: editMessageReplyMarkupMock,
       editMessageText: editMessageTextMock,
       postMessage: postMessageMock,
@@ -350,6 +353,9 @@ describe('Telegram webhook handler', () => {
     taskRunsFindFirstMock.mockResolvedValue(null);
     telegramMappingsFindFirstMock.mockResolvedValue(null);
     consumeLinkCodeMock.mockResolvedValue(null);
+    createForumTopicMock.mockRejectedValue(
+      new Error('Bad Request: chat is not a forum'),
+    );
     insertMock.mockReturnValue({ values: insertValuesMock });
     insertValuesMock.mockReturnValue({
       onConflictDoNothing: insertOnConflictDoNothingMock,
@@ -616,6 +622,10 @@ describe('Telegram webhook handler', () => {
 
   it('starts new Telegram tasks as the linked sender', async () => {
     mockTelegramLinkedSender('launch-owner-2');
+    createForumTopicMock.mockResolvedValueOnce({
+      messageThreadId: '77',
+      name: 'please check this',
+    });
     taskRunsFindFirstMock
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null);
@@ -650,7 +660,8 @@ describe('Telegram webhook handler', () => {
             description: 'please check this',
             communicationProvider: 'telegram',
             communicationChannelId: '222',
-            communicationMessageId: '456',
+            communicationThreadId: '77',
+            communicationMessageId: 'telegram-response',
           }),
         }),
         initiator: { kind: 'user', userId: 'launch-owner-2' },
@@ -662,14 +673,24 @@ describe('Telegram webhook handler', () => {
         launchClass: 'human',
       }),
     );
-    expect(postMessageMock).toHaveBeenCalledWith(
+    expect(postMessageMock).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         channelId: '222',
-        replyToMessageId: '456',
+        threadId: '77',
+        text: 'Task request from Ada Lovelace:\n\nplease check this',
+      }),
+    );
+    expect(postMessageMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        channelId: '222',
+        threadId: '77',
+        replyToMessageId: 'telegram-response',
         text: expect.stringContaining('Started a task'),
       }),
     );
-    const postedCall = postMessageMock.mock.calls[0]![0] as {
+    const postedCall = postMessageMock.mock.calls[1]![0] as {
       text: string;
       buttons?: { text: string; url?: string; callbackData?: string }[][];
     };

--- a/apps/api/src/handlers/telegram/__tests__/index.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/index.test.ts
@@ -1104,9 +1104,9 @@ describe('Telegram webhook handler', () => {
     const welcomeText = postMessageMock.mock.calls[0]?.[0].text as string;
     expect(welcomeText).toContain('*Available commands*');
     expect(welcomeText).toContain('`/start`');
-    expect(welcomeText).toContain('`/start <request>`');
     expect(welcomeText).toContain('`/new <request>`');
-    expect(welcomeText).toContain('`/done <request>`');
+    expect(welcomeText).not.toContain('`/start <request>`');
+    expect(welcomeText).not.toContain('`/done <request>`');
   });
 
   it('welcomes bare /start commands from an unlinked sender', async () => {

--- a/apps/api/src/handlers/telegram/__tests__/index.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/index.test.ts
@@ -1101,6 +1101,12 @@ describe('Telegram webhook handler', () => {
         textFormat: 'markdown',
       }),
     );
+    const welcomeText = postMessageMock.mock.calls[0]?.[0].text as string;
+    expect(welcomeText).toContain('*Available commands*');
+    expect(welcomeText).toContain('`/start`');
+    expect(welcomeText).toContain('`/start <request>`');
+    expect(welcomeText).toContain('`/new <request>`');
+    expect(welcomeText).toContain('`/done <request>`');
   });
 
   it('welcomes bare /start commands from an unlinked sender', async () => {

--- a/apps/api/src/handlers/telegram/__tests__/task-launch.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/task-launch.test.ts
@@ -1,15 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
+  consumeTelegramImplicitTopicMock,
   createTelegramForumTopicBestEffortMock,
+  editTelegramForumTopicBestEffortMock,
   enqueueTaskMock,
   getTaskUrlMock,
   postTelegramMessageBestEffortMock,
+  rememberTelegramImplicitTopicMock,
 } = vi.hoisted(() => ({
+  consumeTelegramImplicitTopicMock: vi.fn(),
   createTelegramForumTopicBestEffortMock: vi.fn(),
+  editTelegramForumTopicBestEffortMock: vi.fn(),
   enqueueTaskMock: vi.fn(),
   getTaskUrlMock: vi.fn(),
   postTelegramMessageBestEffortMock: vi.fn(),
+  rememberTelegramImplicitTopicMock: vi.fn(),
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
@@ -25,7 +31,13 @@ vi.mock('@roomote/db/server', () => ({
 
 vi.mock('../replies.js', () => ({
   createTelegramForumTopicBestEffort: createTelegramForumTopicBestEffortMock,
+  editTelegramForumTopicBestEffort: editTelegramForumTopicBestEffortMock,
   postTelegramMessageBestEffort: postTelegramMessageBestEffortMock,
+}));
+
+vi.mock('../webhook-gate.js', () => ({
+  consumeTelegramImplicitTopic: consumeTelegramImplicitTopicMock,
+  rememberTelegramImplicitTopic: rememberTelegramImplicitTopicMock,
 }));
 
 import {
@@ -40,6 +52,9 @@ describe('Telegram task topic launch', () => {
     enqueueTaskMock.mockResolvedValue({ id: 'run-1', taskId: 'task-1' });
     getTaskUrlMock.mockReturnValue('https://roomote.example.test/tasks/task-1');
     postTelegramMessageBestEffortMock.mockResolvedValue({ messageId: '900' });
+    consumeTelegramImplicitTopicMock.mockResolvedValue(false);
+    editTelegramForumTopicBestEffortMock.mockResolvedValue(true);
+    rememberTelegramImplicitTopicMock.mockResolvedValue(undefined);
   });
 
   it('uses a newly created topic as the task conversation', async () => {
@@ -83,7 +98,7 @@ describe('Telegram task topic launch', () => {
           }),
         }),
       }),
-      { launchClass: 'human' },
+      expect.objectContaining({ launchClass: 'human' }),
     );
     const enqueuedPayload = enqueueTaskMock.mock.calls[0]?.[0].task.payload;
     expect(enqueuedPayload.communicationMessageId).toBe('900');
@@ -100,6 +115,21 @@ describe('Telegram task topic launch', () => {
         replyToMessageId: '900',
       }),
     );
+
+    const onEarlyTitleGenerated = enqueueTaskMock.mock.calls[0]?.[1]
+      .onEarlyTitleGenerated as (input: {
+      title: string;
+      taskRun: { taskId: string };
+    }) => Promise<void>;
+    await onEarlyTitleGenerated({
+      title: 'Fix flaky login tests',
+      taskRun: { taskId: 'task-1' },
+    });
+    expect(editTelegramForumTopicBestEffortMock).toHaveBeenCalledWith({
+      chatId: '111000111',
+      threadId: '77',
+      name: 'Fix flaky login tests',
+    });
   });
 
   it('falls back to the source chat when topic creation is unavailable', async () => {
@@ -135,7 +165,7 @@ describe('Telegram task topic launch', () => {
           }),
         }),
       }),
-      { launchClass: 'human' },
+      expect.objectContaining({ launchClass: 'human' }),
     );
     expect(postTelegramMessageBestEffortMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -143,6 +173,53 @@ describe('Telegram task topic launch', () => {
         replyToMessageId: '42',
       }),
     );
+  });
+
+  it('renames only existing topics that Telegram marked as implicit', async () => {
+    consumeTelegramImplicitTopicMock.mockResolvedValue(true);
+
+    await launchTelegramTask({
+      launchOwnerUserId: 'user-1',
+      queuedMessage: {
+        provider: 'telegram',
+        user: 'Grace',
+        userId: 'user-1',
+        text: 'Fix the flaky login test',
+        ts: '42',
+        channel: '111000111',
+        threadTs: '77',
+      },
+      metadata: {
+        communicationProvider: 'telegram',
+        communicationChannelId: '111000111',
+        communicationThreadId: '77',
+        communicationMessageId: '42',
+      },
+      workspace: {
+        repoForPayload: 'roomote/roomote',
+        workspaceDisplayName: 'Roomote',
+      },
+    });
+
+    const onEarlyTitleGenerated = enqueueTaskMock.mock.calls[0]?.[1]
+      .onEarlyTitleGenerated as (input: {
+      title: string;
+      taskRun: { taskId: string };
+    }) => Promise<void>;
+    await onEarlyTitleGenerated({
+      title: 'Fix flaky login tests',
+      taskRun: { taskId: 'task-1' },
+    });
+
+    expect(consumeTelegramImplicitTopicMock).toHaveBeenCalledWith({
+      chatId: '111000111',
+      threadId: '77',
+    });
+    expect(editTelegramForumTopicBestEffortMock).toHaveBeenCalledWith({
+      chatId: '111000111',
+      threadId: '77',
+      name: 'Fix flaky login tests',
+    });
   });
 
   it('creates topics only for eligible new task conversations', () => {

--- a/apps/api/src/handlers/telegram/__tests__/task-launch.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/task-launch.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  createTelegramForumTopicBestEffortMock,
+  enqueueTaskMock,
+  getTaskUrlMock,
+  postTelegramMessageBestEffortMock,
+} = vi.hoisted(() => ({
+  createTelegramForumTopicBestEffortMock: vi.fn(),
+  enqueueTaskMock: vi.fn(),
+  getTaskUrlMock: vi.fn(),
+  postTelegramMessageBestEffortMock: vi.fn(),
+}));
+
+vi.mock('@roomote/cloud-agents/server', () => ({
+  enqueueTask: enqueueTaskMock,
+  getTaskUrl: getTaskUrlMock,
+}));
+
+vi.mock('@roomote/db/server', () => ({
+  db: { query: { environments: { findFirst: vi.fn() } } },
+  environments: { id: 'id' },
+  eq: vi.fn(),
+}));
+
+vi.mock('../replies.js', () => ({
+  createTelegramForumTopicBestEffort: createTelegramForumTopicBestEffortMock,
+  postTelegramMessageBestEffort: postTelegramMessageBestEffortMock,
+}));
+
+import {
+  buildTelegramTaskTopicName,
+  launchTelegramTask,
+  shouldCreateTelegramTaskTopic,
+} from '../task-launch';
+
+describe('Telegram task topic launch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    enqueueTaskMock.mockResolvedValue({ id: 'run-1', taskId: 'task-1' });
+    getTaskUrlMock.mockReturnValue('https://roomote.example.test/tasks/task-1');
+    postTelegramMessageBestEffortMock.mockResolvedValue({ messageId: '900' });
+  });
+
+  it('uses a newly created topic as the task conversation', async () => {
+    createTelegramForumTopicBestEffortMock.mockResolvedValue({
+      threadId: '77',
+    });
+
+    await launchTelegramTask({
+      launchOwnerUserId: 'user-1',
+      queuedMessage: {
+        provider: 'telegram',
+        user: 'Grace',
+        userId: 'user-1',
+        text: 'Fix the flaky login test',
+        ts: '42',
+        channel: '111000111',
+      },
+      metadata: {
+        communicationProvider: 'telegram',
+        communicationChannelId: '111000111',
+        communicationMessageId: '42',
+      },
+      workspace: {
+        repoForPayload: 'roomote/roomote',
+        workspaceDisplayName: 'Roomote',
+      },
+      createTopicForTask: true,
+    });
+
+    expect(createTelegramForumTopicBestEffortMock).toHaveBeenCalledWith({
+      chatId: '111000111',
+      name: 'Fix the flaky login test',
+    });
+    expect(enqueueTaskMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            communicationProvider: 'telegram',
+            communicationChannelId: '111000111',
+            communicationThreadId: '77',
+          }),
+        }),
+      }),
+      { launchClass: 'human' },
+    );
+    const enqueuedPayload = enqueueTaskMock.mock.calls[0]?.[0].task.payload;
+    expect(enqueuedPayload.communicationMessageId).toBe('900');
+    expect(postTelegramMessageBestEffortMock).toHaveBeenNthCalledWith(1, {
+      chatId: '111000111',
+      threadId: '77',
+      text: 'Task request from Grace:\n\nFix the flaky login test',
+    });
+    expect(postTelegramMessageBestEffortMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        chatId: '111000111',
+        threadId: '77',
+        replyToMessageId: '900',
+      }),
+    );
+  });
+
+  it('falls back to the source chat when topic creation is unavailable', async () => {
+    createTelegramForumTopicBestEffortMock.mockResolvedValue(null);
+
+    await launchTelegramTask({
+      launchOwnerUserId: 'user-1',
+      queuedMessage: {
+        provider: 'telegram',
+        user: 'Grace',
+        userId: 'user-1',
+        text: 'Fix the flaky login test',
+        ts: '42',
+        channel: '111000111',
+      },
+      metadata: {
+        communicationProvider: 'telegram',
+        communicationChannelId: '111000111',
+        communicationMessageId: '42',
+      },
+      workspace: {
+        repoForPayload: 'roomote/roomote',
+        workspaceDisplayName: 'Roomote',
+      },
+      createTopicForTask: true,
+    });
+
+    expect(enqueueTaskMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            communicationMessageId: '42',
+          }),
+        }),
+      }),
+      { launchClass: 'human' },
+    );
+    expect(postTelegramMessageBestEffortMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId: '111000111',
+        replyToMessageId: '42',
+      }),
+    );
+  });
+
+  it('creates topics only for eligible new task conversations', () => {
+    expect(shouldCreateTelegramTaskTopic({ chatType: 'private' })).toBe(true);
+    expect(
+      shouldCreateTelegramTaskTopic({
+        chatType: 'supergroup',
+        isForum: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldCreateTelegramTaskTopic({
+        chatType: 'private',
+        threadId: '77',
+      }),
+    ).toBe(false);
+    expect(
+      shouldCreateTelegramTaskTopic({
+        chatType: 'private',
+        threadId: '77',
+        forceNewTopic: true,
+      }),
+    ).toBe(true);
+    expect(shouldCreateTelegramTaskTopic({ chatType: 'group' })).toBe(false);
+  });
+
+  it('normalizes and truncates task topic names', () => {
+    expect(buildTelegramTaskTopicName('  Fix\n\nlogin   tests  ')).toBe(
+      'Fix login tests',
+    );
+    expect(buildTelegramTaskTopicName('x'.repeat(200))).toHaveLength(96);
+    expect(buildTelegramTaskTopicName('   ')).toBe('Roomote task');
+  });
+});

--- a/apps/api/src/handlers/telegram/__tests__/task-launch.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/task-launch.test.ts
@@ -223,7 +223,13 @@ describe('Telegram task topic launch', () => {
   });
 
   it('creates topics only for eligible new task conversations', () => {
-    expect(shouldCreateTelegramTaskTopic({ chatType: 'private' })).toBe(true);
+    expect(
+      shouldCreateTelegramTaskTopic({
+        chatType: 'private',
+        privateTopicsEnabled: true,
+      }),
+    ).toBe(true);
+    expect(shouldCreateTelegramTaskTopic({ chatType: 'private' })).toBe(false);
     expect(
       shouldCreateTelegramTaskTopic({
         chatType: 'supergroup',
@@ -234,6 +240,7 @@ describe('Telegram task topic launch', () => {
       shouldCreateTelegramTaskTopic({
         chatType: 'private',
         threadId: '77',
+        privateTopicsEnabled: true,
       }),
     ).toBe(false);
     expect(
@@ -241,6 +248,7 @@ describe('Telegram task topic launch', () => {
         chatType: 'private',
         threadId: '77',
         forceNewTopic: true,
+        privateTopicsEnabled: true,
       }),
     ).toBe(true);
     expect(shouldCreateTelegramTaskTopic({ chatType: 'group' })).toBe(false);

--- a/apps/api/src/handlers/telegram/__tests__/task-run-lookup.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/task-run-lookup.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { whereMock } = vi.hoisted(() => ({
+  whereMock: vi.fn(),
+}));
+
+vi.mock('@roomote/db/server', () => {
+  const chain = {
+    from: vi.fn(),
+    innerJoin: vi.fn(),
+    where: whereMock,
+    orderBy: vi.fn(),
+    limit: vi.fn(async () => []),
+  };
+  chain.from.mockReturnValue(chain);
+  chain.innerJoin.mockReturnValue(chain);
+  chain.where.mockReturnValue(chain);
+  chain.orderBy.mockReturnValue(chain);
+
+  return {
+    and: vi.fn((...conditions: unknown[]) => ({ conditions })),
+    db: { select: vi.fn(() => chain) },
+    desc: vi.fn((value: unknown) => value),
+    eq: vi.fn((left: unknown, right: unknown) => ({ left, right })),
+    inArray: vi.fn((left: unknown, right: unknown) => ({ left, right })),
+    isNull: vi.fn((value: unknown) => ({ isNull: value })),
+    sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
+      strings: Array.from(strings),
+      values,
+    })),
+    taskRuns: {
+      actingUserId: 'taskRuns.actingUserId',
+      canceledAt: 'taskRuns.canceledAt',
+      createdAt: 'taskRuns.createdAt',
+      id: 'taskRuns.id',
+      machineId: 'taskRuns.machineId',
+      payload: 'taskRuns.payload',
+      payloadKind: 'taskRuns.payloadKind',
+      port: 'taskRuns.port',
+      snapshotCreatedAt: 'taskRuns.snapshotCreatedAt',
+      snapshotId: 'taskRuns.snapshotId',
+      status: 'taskRuns.status',
+      taskId: 'taskRuns.taskId',
+    },
+    tasks: {
+      id: 'tasks.id',
+      initiatorUserId: 'tasks.initiatorUserId',
+    },
+  };
+});
+
+import { findActiveTelegramTaskRun } from '../task-run-lookup';
+
+describe('Telegram task run topic lookup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('requires an absent task topic for a root-chat lookup', async () => {
+    await findActiveTelegramTaskRun({ chatId: '111000111' });
+
+    const where = whereMock.mock.calls[0]?.[0] as {
+      conditions: Array<{ strings?: string[] }>;
+    };
+    const threadCondition = where.conditions.find((condition) =>
+      condition.strings?.join('').includes('communicationThreadId'),
+    );
+
+    expect(threadCondition?.strings?.join('')).toContain('IS NULL');
+  });
+
+  it('requires an exact topic for a topic lookup', async () => {
+    await findActiveTelegramTaskRun({ chatId: '111000111', threadId: '77' });
+
+    const where = whereMock.mock.calls[0]?.[0] as {
+      conditions: Array<{ strings?: string[]; values?: unknown[] }>;
+    };
+    const threadCondition = where.conditions.find((condition) =>
+      condition.strings?.join('').includes('communicationThreadId'),
+    );
+
+    expect(threadCondition?.strings?.join('')).not.toContain('IS NULL');
+    expect(threadCondition?.values).toContain('77');
+  });
+});

--- a/apps/api/src/handlers/telegram/callback-actions.ts
+++ b/apps/api/src/handlers/telegram/callback-actions.ts
@@ -129,6 +129,9 @@ async function handleCancelTaskCallback(params: {
 
     await postTelegramMessageBestEffort({
       chatId,
+      ...(message.message_thread_id !== undefined
+        ? { threadId: String(message.message_thread_id) }
+        : {}),
       replyToMessageId: String(message.message_id),
       text: canceled
         ? 'Canceled the task.'
@@ -193,6 +196,10 @@ async function handleSuggestionLaunchCallback(params: {
       : []),
   ].join('\n');
   const messageId = String(message.message_id);
+  const threadId =
+    message.message_thread_id === undefined
+      ? undefined
+      : String(message.message_thread_id);
   const queuedMessage: QueuedTelegramCommunicationMessage = {
     provider: 'telegram',
     text: promptText,
@@ -200,6 +207,7 @@ async function handleSuggestionLaunchCallback(params: {
     userId: senderUserId,
     ts: messageId,
     channel: chatId,
+    ...(threadId ? { threadTs: threadId } : {}),
   };
 
   // The claim's `launchClaimedAt` is this launcher's fencing token; thread it
@@ -215,10 +223,12 @@ async function handleSuggestionLaunchCallback(params: {
       metadata: {
         communicationProvider: 'telegram',
         communicationChannelId: chatId,
+        ...(threadId ? { communicationThreadId: threadId } : {}),
         communicationMessageId: messageId,
       },
       // The button click already is the explicit start signal.
       skipRoutingConfirmation: true,
+      forceNewTopic: true,
     });
 
     if (started.status === 'started') {

--- a/apps/api/src/handlers/telegram/index.ts
+++ b/apps/api/src/handlers/telegram/index.ts
@@ -10,6 +10,7 @@ import {
   getTelegramUpdateCommunicationMetadata,
   getTelegramUpdateMessage,
   getTelegramNewTaskCommand,
+  isTelegramImplicitTopicCreatedMessage,
   isTelegramPrivateChat,
   isTelegramStartCommand,
   isTelegramTaskEntryUpdate,
@@ -64,6 +65,7 @@ import type { QueuedTelegramCommunicationMessage } from './types.js';
 import {
   claimTelegramLinkNudge,
   claimTelegramUpdate,
+  rememberTelegramImplicitTopic,
   verifyTelegramWebhookSecret,
 } from './webhook-gate.js';
 
@@ -134,6 +136,15 @@ telegram.post('/', async (c) => {
       `[telegram] Skipping duplicate Telegram update ${update.update_id}`,
     );
     return c.json({ ok: true, duplicate: true });
+  }
+
+  if (isTelegramImplicitTopicCreatedMessage(message)) {
+    const implicitThreadId = message.message_thread_id ?? message.message_id;
+    await rememberTelegramImplicitTopic({
+      chatId: String(message.chat.id),
+      threadId: String(implicitThreadId),
+    });
+    return c.json({ ok: true, implicitTopicRemembered: true });
   }
 
   // Account linking: a bare link code (or /start <code> from the deep link)

--- a/apps/api/src/handlers/telegram/index.ts
+++ b/apps/api/src/handlers/telegram/index.ts
@@ -46,9 +46,7 @@ const TELEGRAM_WELCOME_MESSAGE = [
   [
     '*Available commands*',
     '`/start` — show this welcome message.',
-    '`/start <request>` — start a task with the request.',
     '`/new <request>` — start a fresh task instead of resuming the previous one; when topics are available, it opens a new topic.',
-    '`/done <request>` — alias for `/new`.',
   ].join('\n'),
 ].join('\n\n');
 

--- a/apps/api/src/handlers/telegram/index.ts
+++ b/apps/api/src/handlers/telegram/index.ts
@@ -327,10 +327,10 @@ telegram.post('/', async (c) => {
     threadId: metadata.communicationThreadId,
   };
 
-  // `/new` and `/done` are explicit "start a fresh task" signals. Telegram has
-  // no threads, so without these the next message after a task completes would
-  // resume the previous task's snapshot. These commands skip the resume path
-  // below and launch a new StandardTask.
+  // `/new` and `/done` are explicit "start a fresh task" signals. In a plain
+  // chat (or an existing topic), the next message after completion would
+  // otherwise resume the previous snapshot. These commands skip that resume
+  // path and, when topics are available, create a new task topic.
   const newTaskCommand = getTelegramNewTaskCommand(update, {
     botUsername: botUsername ?? undefined,
   });
@@ -410,12 +410,17 @@ telegram.post('/', async (c) => {
     return c.json({ ok: true, ignored: 'unsupported_update' });
   }
 
-  if (
-    !newTaskCommand &&
-    !isTelegramTaskEntryUpdate(update, {
-      botUsername: botUsername ?? undefined,
-    })
-  ) {
+  const isTaskEntry = isTelegramTaskEntryUpdate(update, {
+    botUsername: botUsername ?? undefined,
+  });
+  // A completed task topic is already an explicit Roomote conversation, so a
+  // follow-up there can resume without requiring another group @mention.
+  const completedRun =
+    !newTaskCommand && (isTaskEntry || metadata.communicationThreadId)
+      ? await findCompletedTelegramTaskRunWithSnapshot(conversation)
+      : null;
+
+  if (!newTaskCommand && !isTaskEntry && !completedRun) {
     apiLogger.debug(
       `[telegram] Ignoring Telegram message without active task run or task entry signal for chat ${metadata.communicationChannelId} thread ${metadata.communicationThreadId ?? 'unknown'}`,
     );
@@ -434,12 +439,6 @@ telegram.post('/', async (c) => {
     chatId: metadata.communicationChannelId,
     messageId: metadata.communicationMessageId,
   });
-
-  // `/new` and `/done` exist to skip snapshot resume; only plain messages
-  // reconnect to a completed task's snapshot.
-  const completedRun = newTaskCommand
-    ? null
-    : await findCompletedTelegramTaskRunWithSnapshot(conversation);
 
   if (completedRun) {
     try {
@@ -476,6 +475,7 @@ telegram.post('/', async (c) => {
     launchOwnerUserId: senderUserId,
     queuedMessage,
     metadata,
+    forceNewTopic: Boolean(newTaskCommand),
   });
 
   if (launch.status === 'replied_inline') {

--- a/apps/api/src/handlers/telegram/index.ts
+++ b/apps/api/src/handlers/telegram/index.ts
@@ -42,7 +42,14 @@ import {
 
 const TELEGRAM_WELCOME_MESSAGE = [
   "👋 Hi, I'm Roomote. Message me here to start tasks in your connected repos — I'll route your request, reply with progress, and post results (including screenshots) right in this chat.",
-  'Try something like *"Fix the flaky auth test"* or *"What changed in the repo this week?"*. While a task is running you can send follow-ups here, and every started task has a cancel button. Telegram has no threads, so after a task finishes send `/new <request>` (or `/done <request>`) to start a fresh task instead of resuming the previous one.',
+  'Try something like *"Fix the flaky auth test"* or *"What changed in the repo this week?"*. While a task is running you can send follow-ups in its chat or topic, and every started task has a cancel button.',
+  [
+    '*Available commands*',
+    '`/start` — show this welcome message.',
+    '`/start <request>` — start a task with the request.',
+    '`/new <request>` — start a fresh task instead of resuming the previous one; when topics are available, it opens a new topic.',
+    '`/done <request>` — alias for `/new`.',
+  ].join('\n'),
 ].join('\n\n');
 
 const TELEGRAM_WELCOME_LINK_NUDGE =

--- a/apps/api/src/handlers/telegram/index.ts
+++ b/apps/api/src/handlers/telegram/index.ts
@@ -429,11 +429,16 @@ telegram.post('/', async (c) => {
   const isTaskEntry = isTelegramTaskEntryUpdate(update, {
     botUsername: botUsername ?? undefined,
   });
-  // A completed task topic is already an explicit Roomote conversation, so a
-  // follow-up there can resume without requiring another group @mention.
-  const completedRun =
+  // Only task-owned topics are explicit Roomote conversations. A user-owned
+  // forum topic still requires a group @mention before an old task resumes.
+  const completedRunCandidate =
     !newTaskCommand && (isTaskEntry || metadata.communicationThreadId)
       ? await findCompletedTelegramTaskRunWithSnapshot(conversation)
+      : null;
+  const completedRun =
+    completedRunCandidate &&
+    (isTaskEntry || completedRunCandidate.payload.telegramTaskTopic === true)
+      ? completedRunCandidate
       : null;
 
   if (!newTaskCommand && !isTaskEntry && !completedRun) {

--- a/apps/api/src/handlers/telegram/index.ts
+++ b/apps/api/src/handlers/telegram/index.ts
@@ -332,10 +332,10 @@ telegram.post('/', async (c) => {
     threadId: metadata.communicationThreadId,
   };
 
-  // `/new` and `/done` are explicit "start a fresh task" signals. In a plain
-  // chat (or an existing topic), the next message after completion would
-  // otherwise resume the previous snapshot. These commands skip that resume
-  // path and, when topics are available, create a new task topic.
+  // `/new` is an explicit "start a fresh task" signal. In a plain chat (or an
+  // existing topic), the next message after completion would otherwise resume
+  // the previous snapshot. This command skips that resume path and, when
+  // topics are available, creates a new task topic.
   const newTaskCommand = getTelegramNewTaskCommand(update, {
     botUsername: botUsername ?? undefined,
   });

--- a/apps/api/src/handlers/telegram/replies.ts
+++ b/apps/api/src/handlers/telegram/replies.ts
@@ -54,6 +54,39 @@ export async function postTelegramMessageBestEffort(input: {
   }
 }
 
+export async function createTelegramForumTopicBestEffort(input: {
+  chatId: string;
+  name: string;
+}): Promise<{ threadId: string } | null> {
+  const provider = await createTelegramCommunicationProvider();
+
+  if (!provider) {
+    apiLogger.warn(
+      '[telegram] Skipping Telegram topic creation because bot token is not configured',
+    );
+    return null;
+  }
+
+  try {
+    const topic = await provider.createForumTopic({
+      channelId: input.chatId,
+      name: input.name,
+    });
+
+    return { threadId: topic.messageThreadId };
+  } catch (error) {
+    // Topic creation is an enhancement over the existing chat flow. A bot
+    // without private-chat Threaded Mode, or without manage-topics rights in
+    // a forum supergroup, must still be able to launch the task normally.
+    apiLogger.warn(
+      `[telegram] Could not create a task topic; falling back to the current chat: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return null;
+  }
+}
+
 /** Replace the text and keyboard of a bot message (cards, status lines). */
 export async function editTelegramMessageBestEffort(input: {
   chatId: string;

--- a/apps/api/src/handlers/telegram/replies.ts
+++ b/apps/api/src/handlers/telegram/replies.ts
@@ -87,6 +87,34 @@ export async function createTelegramForumTopicBestEffort(input: {
   }
 }
 
+export async function editTelegramForumTopicBestEffort(input: {
+  chatId: string;
+  threadId: string;
+  name: string;
+}): Promise<boolean> {
+  const provider = await createTelegramCommunicationProvider();
+
+  if (!provider) {
+    return false;
+  }
+
+  try {
+    await provider.editForumTopic({
+      channelId: input.chatId,
+      threadId: input.threadId,
+      name: input.name,
+    });
+    return true;
+  } catch (error) {
+    apiLogger.warn(
+      `[telegram] Failed to rename implicit task topic: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return false;
+  }
+}
+
 /** Replace the text and keyboard of a bot message (cards, status lines). */
 export async function editTelegramMessageBestEffort(input: {
   chatId: string;

--- a/apps/api/src/handlers/telegram/replies.ts
+++ b/apps/api/src/handlers/telegram/replies.ts
@@ -14,6 +14,42 @@ async function createTelegramCommunicationProvider(): Promise<TelegramCommunicat
   return new TelegramCommunicationProvider({ botToken });
 }
 
+const TELEGRAM_BOT_INFO_CACHE_TTL_MS = 5 * 60 * 1000;
+let privateTopicsCapabilityCache:
+  | { botToken: string; enabled: boolean; expiresAt: number }
+  | undefined;
+
+export async function telegramPrivateTopicsEnabledBestEffort(): Promise<boolean> {
+  const { botToken } = await resolveTelegramRuntimeCredentials();
+
+  if (!botToken) return false;
+
+  const now = Date.now();
+  if (
+    privateTopicsCapabilityCache?.botToken === botToken &&
+    privateTopicsCapabilityCache.expiresAt > now
+  ) {
+    return privateTopicsCapabilityCache.enabled;
+  }
+
+  try {
+    const { hasTopicsEnabled } = await new TelegramCommunicationProvider({
+      botToken,
+    }).getBotInfo();
+    privateTopicsCapabilityCache = {
+      botToken,
+      enabled: hasTopicsEnabled,
+      expiresAt: now + TELEGRAM_BOT_INFO_CACHE_TTL_MS,
+    };
+    return hasTopicsEnabled;
+  } catch (error) {
+    apiLogger.debug(
+      `[telegram] Could not read bot topic capabilities: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return false;
+  }
+}
+
 export async function postTelegramMessageBestEffort(input: {
   chatId: string;
   threadId?: string;
@@ -78,7 +114,7 @@ export async function createTelegramForumTopicBestEffort(input: {
     // Topic creation is an enhancement over the existing chat flow. A bot
     // without private-chat Threaded Mode, or without manage-topics rights in
     // a forum supergroup, must still be able to launch the task normally.
-    apiLogger.warn(
+    apiLogger.debug(
       `[telegram] Could not create a task topic; falling back to the current chat: ${
         error instanceof Error ? error.message : String(error)
       }`,

--- a/apps/api/src/handlers/telegram/routing-confirmation.ts
+++ b/apps/api/src/handlers/telegram/routing-confirmation.ts
@@ -65,6 +65,7 @@ type PendingTelegramRoute = {
   launchOwnerUserId: string;
   queuedMessage: QueuedTelegramCommunicationMessage;
   metadata: TelegramUpdateCommunicationMetadata;
+  createTopicForTask?: boolean;
   options: PendingTelegramRouteOption[];
   /**
    * Index into `options` of the router's suggestion. Null once the card is
@@ -342,6 +343,7 @@ async function autoConfirmTelegramRouting(
     queuedMessage: pending.queuedMessage,
     metadata: pending.metadata,
     workspace,
+    createTopicForTask: pending.createTopicForTask,
   });
 }
 
@@ -363,6 +365,7 @@ export async function maybeRequestTelegramRoutingConfirmation(input: {
   launchOwnerUserId: string;
   queuedMessage: QueuedTelegramCommunicationMessage;
   metadata: TelegramUpdateCommunicationMetadata;
+  createTopicForTask?: boolean;
 }): Promise<{ pendingRouteId: string } | null> {
   const routed =
     input.routingDecision.status === 'routed'
@@ -393,6 +396,7 @@ export async function maybeRequestTelegramRoutingConfirmation(input: {
       launchOwnerUserId: input.launchOwnerUserId,
       queuedMessage: input.queuedMessage,
       metadata: input.metadata,
+      createTopicForTask: input.createTopicForTask,
       options,
       suggestedIndex,
     };
@@ -481,6 +485,7 @@ async function switchToWorkspacePicker(params: {
     // message so the user is not stuck.
     const posted = await postTelegramMessageBestEffort({
       chatId: params.chatId,
+      threadId: params.claimed.metadata.communicationThreadId,
       replyToMessageId: params.messageId,
       text: PICKER_TEXT,
       buttons: buildPickerButtons(nextId, nextPending.options),
@@ -603,6 +608,9 @@ export async function handleTelegramRoutingCallback(params: {
     });
     await postTelegramMessageBestEffort({
       chatId,
+      ...(message.message_thread_id !== undefined
+        ? { threadId: String(message.message_thread_id) }
+        : {}),
       replyToMessageId: String(message.message_id),
       text: 'Could not start the task — that workspace is no longer available. Send the request again.',
     });
@@ -625,6 +633,7 @@ export async function handleTelegramRoutingCallback(params: {
       queuedMessage: claimed.queuedMessage,
       metadata: claimed.metadata,
       workspace,
+      createTopicForTask: claimed.createTopicForTask,
     });
   } catch (error) {
     apiLogger.warn(
@@ -634,6 +643,9 @@ export async function handleTelegramRoutingCallback(params: {
     );
     await postTelegramMessageBestEffort({
       chatId,
+      ...(message.message_thread_id !== undefined
+        ? { threadId: String(message.message_thread_id) }
+        : {}),
       replyToMessageId: String(message.message_id),
       text: 'Could not start the task — send the request again.',
     });

--- a/apps/api/src/handlers/telegram/task-launch.ts
+++ b/apps/api/src/handlers/telegram/task-launch.ts
@@ -14,8 +14,13 @@ import {
 import { buildTelegramCancelTaskCallbackData } from './callback-data.js';
 import {
   createTelegramForumTopicBestEffort,
+  editTelegramForumTopicBestEffort,
   postTelegramMessageBestEffort,
 } from './replies.js';
+import {
+  consumeTelegramImplicitTopic,
+  rememberTelegramImplicitTopic,
+} from './webhook-gate.js';
 import type {
   QueuedTelegramCommunicationMessage,
   TelegramWorkspaceSelection,
@@ -81,12 +86,15 @@ export async function launchTelegramTask(input: {
   workspace: TelegramWorkspaceSelection;
   createTopicForTask?: boolean;
 }) {
+  const topicName = buildTelegramTaskTopicName(input.queuedMessage.text);
   const createdTopic = input.createTopicForTask
     ? await createTelegramForumTopicBestEffort({
         chatId: input.metadata.communicationChannelId,
-        name: buildTelegramTaskTopicName(input.queuedMessage.text),
+        name: topicName,
       })
     : null;
+  const titleThreadId =
+    createdTopic?.threadId ?? input.metadata.communicationThreadId;
   const topicRootMessage = createdTopic
     ? await postTelegramMessageBestEffort({
         chatId: input.metadata.communicationChannelId,
@@ -126,6 +134,35 @@ export async function launchTelegramTask(input: {
     },
     {
       launchClass: 'human',
+      ...(titleThreadId
+        ? {
+            onEarlyTitleGenerated: async ({ title }: { title: string }) => {
+              const shouldRename =
+                Boolean(createdTopic) ||
+                (await consumeTelegramImplicitTopic({
+                  chatId: metadata.communicationChannelId,
+                  threadId: titleThreadId,
+                }));
+
+              if (!shouldRename) {
+                return;
+              }
+
+              const renamed = await editTelegramForumTopicBestEffort({
+                chatId: metadata.communicationChannelId,
+                threadId: titleThreadId,
+                name: buildTelegramTaskTopicName(title),
+              });
+
+              if (!renamed && !createdTopic) {
+                await rememberTelegramImplicitTopic({
+                  chatId: metadata.communicationChannelId,
+                  threadId: titleThreadId,
+                });
+              }
+            },
+          }
+        : {}),
     },
   );
 

--- a/apps/api/src/handlers/telegram/task-launch.ts
+++ b/apps/api/src/handlers/telegram/task-launch.ts
@@ -64,11 +64,14 @@ export async function resolveTelegramWorkspace(
 export function shouldCreateTelegramTaskTopic(input: {
   chatType: string;
   isForum?: boolean;
+  privateTopicsEnabled?: boolean;
   threadId?: string;
   forceNewTopic?: boolean;
 }): boolean {
   const supportsTopics =
-    input.chatType.toLowerCase() === 'private' || input.isForum === true;
+    (input.chatType.toLowerCase() === 'private' &&
+      input.privateTopicsEnabled === true) ||
+    input.isForum === true;
 
   return supportsTopics && (!input.threadId || input.forceNewTopic === true);
 }
@@ -122,6 +125,7 @@ export async function launchTelegramTask(input: {
           : {}),
         description: input.queuedMessage.text,
         ...metadata,
+        ...(createdTopic ? { telegramTaskTopic: true } : {}),
       },
     };
   const launchResult = await enqueueTask(

--- a/apps/api/src/handlers/telegram/task-launch.ts
+++ b/apps/api/src/handlers/telegram/task-launch.ts
@@ -12,7 +12,10 @@ import {
 } from '@roomote/cloud-agents/server';
 
 import { buildTelegramCancelTaskCallbackData } from './callback-data.js';
-import { postTelegramMessageBestEffort } from './replies.js';
+import {
+  createTelegramForumTopicBestEffort,
+  postTelegramMessageBestEffort,
+} from './replies.js';
 import type {
   QueuedTelegramCommunicationMessage,
   TelegramWorkspaceSelection,
@@ -53,6 +56,18 @@ export async function resolveTelegramWorkspace(
   };
 }
 
+export function shouldCreateTelegramTaskTopic(input: {
+  chatType: string;
+  isForum?: boolean;
+  threadId?: string;
+  forceNewTopic?: boolean;
+}): boolean {
+  const supportsTopics =
+    input.chatType.toLowerCase() === 'private' || input.isForum === true;
+
+  return supportsTopics && (!input.threadId || input.forceNewTopic === true);
+}
+
 /**
  * Enqueue a standard task for a Telegram request and post the
  * task-started message (with follow/cancel buttons) back to the chat. Shared
@@ -64,7 +79,31 @@ export async function launchTelegramTask(input: {
   queuedMessage: QueuedTelegramCommunicationMessage;
   metadata: TelegramUpdateCommunicationMetadata;
   workspace: TelegramWorkspaceSelection;
+  createTopicForTask?: boolean;
 }) {
+  const createdTopic = input.createTopicForTask
+    ? await createTelegramForumTopicBestEffort({
+        chatId: input.metadata.communicationChannelId,
+        name: buildTelegramTaskTopicName(input.queuedMessage.text),
+      })
+    : null;
+  const topicRootMessage = createdTopic
+    ? await postTelegramMessageBestEffort({
+        chatId: input.metadata.communicationChannelId,
+        threadId: createdTopic.threadId,
+        text: `Task request from ${input.queuedMessage.user}:\n\n${input.queuedMessage.text}`,
+      })
+    : null;
+  const metadata = createdTopic
+    ? {
+        communicationProvider: input.metadata.communicationProvider,
+        communicationChannelId: input.metadata.communicationChannelId,
+        communicationThreadId: createdTopic.threadId,
+        ...(topicRootMessage
+          ? { communicationMessageId: topicRootMessage.messageId }
+          : {}),
+      }
+    : input.metadata;
   const task: Extract<TaskSpec, { type: typeof TaskPayloadKind.StandardTask }> =
     {
       type: TaskPayloadKind.StandardTask,
@@ -74,7 +113,7 @@ export async function launchTelegramTask(input: {
           ? { environmentId: input.workspace.environmentId }
           : {}),
         description: input.queuedMessage.text,
-        ...input.metadata,
+        ...metadata,
       },
     };
   const launchResult = await enqueueTask(
@@ -96,9 +135,13 @@ export async function launchTelegramTask(input: {
   });
 
   await postTelegramMessageBestEffort({
-    chatId: input.metadata.communicationChannelId,
-    threadId: input.metadata.communicationThreadId,
-    replyToMessageId: input.metadata.communicationMessageId,
+    chatId: metadata.communicationChannelId,
+    threadId: metadata.communicationThreadId,
+    // The source message is in the previous topic (usually General), so only
+    // the mirrored request can be used as a reply anchor in the new topic.
+    replyToMessageId: createdTopic
+      ? topicRootMessage?.messageId
+      : metadata.communicationMessageId,
     text: taskUrl
       ? `Started a task in ${input.workspace.workspaceDisplayName}.`
       : `Queued a task in ${input.workspace.workspaceDisplayName}.`,
@@ -114,4 +157,17 @@ export async function launchTelegramTask(input: {
   });
 
   return launchResult;
+}
+
+const TELEGRAM_TASK_TOPIC_NAME_MAX_LENGTH = 96;
+
+export function buildTelegramTaskTopicName(description: string): string {
+  const normalized = description.replace(/\s+/gu, ' ').trim();
+  const characters = Array.from(normalized || 'Roomote task');
+
+  return characters.length > TELEGRAM_TASK_TOPIC_NAME_MAX_LENGTH
+    ? `${characters
+        .slice(0, TELEGRAM_TASK_TOPIC_NAME_MAX_LENGTH - 1)
+        .join('')}…`
+    : characters.join('');
 }

--- a/apps/api/src/handlers/telegram/task-orchestration.ts
+++ b/apps/api/src/handlers/telegram/task-orchestration.ts
@@ -19,7 +19,10 @@ import {
 
 import type { CompletedTelegramTaskRun } from './task-run-lookup.js';
 import { maybeRequestTelegramRoutingConfirmation } from './routing-confirmation.js';
-import { postTelegramMessageBestEffort } from './replies.js';
+import {
+  postTelegramMessageBestEffort,
+  telegramPrivateTopicsEnabledBestEffort,
+} from './replies.js';
 import {
   launchTelegramTask,
   resolveTelegramWorkspace,
@@ -75,6 +78,9 @@ export async function resumeTelegramTaskFromSnapshot(input: {
     threadId: input.metadata.communicationThreadId,
     messageId: input.metadata.communicationMessageId,
   });
+  if (completedPayload.telegramTaskTopic === true) {
+    resumePayload.telegramTaskTopic = true;
+  }
   restoreSnapshotResumeVisiblePromptFields(resumePayload, completedPayload);
 
   // Resumes never create tasks and never re-attribute; the resuming human
@@ -126,9 +132,15 @@ export async function startNewTelegramTask(input: {
   /** Start a new task topic even when the command came from an older topic. */
   forceNewTopic?: boolean;
 }) {
+  const needsPrivateTopicCapability =
+    input.message.chat.type.toLowerCase() === 'private' &&
+    (!input.metadata.communicationThreadId || input.forceNewTopic === true);
   const createTopicForTask = shouldCreateTelegramTaskTopic({
     chatType: input.message.chat.type,
     isForum: input.message.chat.is_forum,
+    privateTopicsEnabled: needsPrivateTopicCapability
+      ? await telegramPrivateTopicsEnabledBestEffort()
+      : false,
     threadId: input.metadata.communicationThreadId,
     forceNewTopic: input.forceNewTopic,
   });

--- a/apps/api/src/handlers/telegram/task-orchestration.ts
+++ b/apps/api/src/handlers/telegram/task-orchestration.ts
@@ -20,7 +20,11 @@ import {
 import type { CompletedTelegramTaskRun } from './task-run-lookup.js';
 import { maybeRequestTelegramRoutingConfirmation } from './routing-confirmation.js';
 import { postTelegramMessageBestEffort } from './replies.js';
-import { launchTelegramTask, resolveTelegramWorkspace } from './task-launch.js';
+import {
+  launchTelegramTask,
+  resolveTelegramWorkspace,
+  shouldCreateTelegramTaskTopic,
+} from './task-launch.js';
 import type {
   QueuedTelegramCommunicationMessage,
   TelegramConversationRef,
@@ -119,7 +123,15 @@ export async function startNewTelegramTask(input: {
    * expressed explicit intent (for example a suggestion button click).
    */
   skipRoutingConfirmation?: boolean;
+  /** Start a new task topic even when the command came from an older topic. */
+  forceNewTopic?: boolean;
 }) {
+  const createTopicForTask = shouldCreateTelegramTaskTopic({
+    chatType: input.message.chat.type,
+    isForum: input.message.chat.is_forum,
+    threadId: input.metadata.communicationThreadId,
+    forceNewTopic: input.forceNewTopic,
+  });
   const routingContext = await buildTelegramRoutingContext({
     userId: input.launchOwnerUserId,
     taskDescription: input.queuedMessage.text,
@@ -158,6 +170,7 @@ export async function startNewTelegramTask(input: {
       launchOwnerUserId: input.launchOwnerUserId,
       queuedMessage: input.queuedMessage,
       metadata: input.metadata,
+      createTopicForTask,
     });
 
     if (confirmation) {
@@ -186,6 +199,7 @@ export async function startNewTelegramTask(input: {
     queuedMessage: input.queuedMessage,
     metadata: input.metadata,
     workspace,
+    createTopicForTask,
   });
 
   return {

--- a/apps/api/src/handlers/telegram/task-run-lookup.ts
+++ b/apps/api/src/handlers/telegram/task-run-lookup.ts
@@ -63,7 +63,7 @@ function buildTelegramTaskRunMatchConditions(input: TelegramConversationRef) {
   const conversationMatch = sql`${taskRuns.payload}->>'communicationChannelId' = ${input.chatId}`;
   const threadMatch = input.threadId
     ? sql`${taskRuns.payload}->>'communicationThreadId' = ${input.threadId}`
-    : undefined;
+    : sql`${taskRuns.payload}->>'communicationThreadId' IS NULL`;
 
   return { telegramProviderMatch, conversationMatch, threadMatch };
 }

--- a/apps/api/src/handlers/telegram/webhook-gate.ts
+++ b/apps/api/src/handlers/telegram/webhook-gate.ts
@@ -5,6 +5,35 @@ import { getRedis } from '@roomote/redis';
 
 const TELEGRAM_UPDATE_DEDUP_PREFIX = 'telegram:update:';
 const TELEGRAM_UPDATE_DEDUP_TTL_SECONDS = 5 * 60;
+const TELEGRAM_IMPLICIT_TOPIC_PREFIX = 'telegram:implicit-topic:';
+const TELEGRAM_IMPLICIT_TOPIC_TTL_SECONDS = 60 * 60;
+
+function implicitTopicKey(chatId: string, threadId: string): string {
+  return `${TELEGRAM_IMPLICIT_TOPIC_PREFIX}${chatId}:${threadId}`;
+}
+
+export async function rememberTelegramImplicitTopic(input: {
+  chatId: string;
+  threadId: string;
+}): Promise<void> {
+  const redis = getRedis();
+  await redis.set(
+    implicitTopicKey(input.chatId, input.threadId),
+    '1',
+    'EX',
+    TELEGRAM_IMPLICIT_TOPIC_TTL_SECONDS,
+  );
+}
+
+export async function consumeTelegramImplicitTopic(input: {
+  chatId: string;
+  threadId: string;
+}): Promise<boolean> {
+  const redis = getRedis();
+  return Boolean(
+    await redis.getdel(implicitTopicKey(input.chatId, input.threadId)),
+  );
+}
 
 function safeCompareSecret(
   expected: string | undefined,

--- a/apps/docs/providers/communications/telegram.mdx
+++ b/apps/docs/providers/communications/telegram.mdx
@@ -21,6 +21,18 @@ Message `@BotFather` in Telegram and create or select a bot. In the Roomote UI
 username, then save. Roomote generates a webhook secret and registers the Bot
 API webhook for you.
 
+In BotFather, open **Bot Settings > Threaded Mode** and enable it. Roomote will
+then create a separate topic in your private bot chat for each new task. If
+Threaded Mode is unavailable or disabled, Roomote falls back to the existing
+single-chat flow. Telegram's Bot Developer Terms currently withhold a 15% fee
+from Stars purchases made through a bot while private-chat topics are enabled.
+
+For a shared team chat, create a Telegram supergroup, enable topics, then add
+the Roomote bot as an administrator with **Manage Topics** permission. Telegram
+requires a user to create the group and enable topics; the Bot API cannot do
+those provisioning steps. Once configured, Roomote can create task topics in
+the forum automatically.
+
 For self-hosted env-var configuration instead of the UI:
 
 ```sh
@@ -73,7 +85,8 @@ up on tasks on their behalf.
 
 1. send a direct message to the bot, or mention the bot in a group
 2. confirm Roomote starts a task and posts a Telegram reply with the task link
-3. reply in the same Telegram chat or forum topic to send a follow-up
+3. confirm a new task opens in its own topic when Threaded Mode is enabled
+4. reply in that topic to send a follow-up
 
 ## Local URL changes
 

--- a/apps/docs/providers/communications/telegram.mdx
+++ b/apps/docs/providers/communications/telegram.mdx
@@ -26,6 +26,8 @@ then create a separate topic in your private bot chat for each new task. If
 Threaded Mode is unavailable or disabled, Roomote falls back to the existing
 single-chat flow. Telegram's Bot Developer Terms currently withhold a 15% fee
 from Stars purchases made through a bot while private-chat topics are enabled.
+When Telegram initially labels an implicit topic **New Chat**, Roomote replaces
+it with the same generated title shown for the task in the web app.
 
 For a shared team chat, create a Telegram supergroup, enable topics, then add
 the Roomote bot as an administrator with **Manage Topics** permission. Telegram

--- a/apps/web/src/app/(onboarding)/setup/ProviderSetupInstructions.tsx
+++ b/apps/web/src/app/(onboarding)/setup/ProviderSetupInstructions.tsx
@@ -134,6 +134,12 @@ export function ProviderSetupInstructions({
         <InstructionText heading="Bot token">
           Copy the bot token BotFather replies with into the field below.
         </InstructionText>
+        <InstructionText heading="Threaded Mode">
+          In BotFather, open Bot Settings → Threaded Mode and turn it on. This
+          lets Roomote create a separate private-chat topic for every task.
+          Telegram withholds a 15% fee from Stars purchases while this mode is
+          enabled.
+        </InstructionText>
         <InstructionText heading="Webhook">
           Roomote registers the webhook automatically when you save.
         </InstructionText>

--- a/apps/web/src/components/settings/CommsProviderSection.test.tsx
+++ b/apps/web/src/components/settings/CommsProviderSection.test.tsx
@@ -635,6 +635,7 @@ describe('CommsProviderSection', () => {
       expect(screen.getByText(/Create a new Telegram bot/)).toBeInTheDocument();
       expect(screen.getByText('Create bot')).toBeInTheDocument();
       expect(screen.getByText('Bot token')).toBeInTheDocument();
+      expect(screen.getByText('Threaded Mode')).toBeInTheDocument();
       expect(screen.getByText('Webhook')).toBeInTheDocument();
       expect(screen.getByText('Enter the values below:')).toBeInTheDocument();
       expect(

--- a/packages/cloud-agents/src/server/task-run-queue.ts
+++ b/packages/cloud-agents/src/server/task-run-queue.ts
@@ -753,6 +753,14 @@ export interface EnqueueTaskOptions {
    */
   skipEarlyTitleGeneration?: boolean;
   /**
+   * Best-effort surface callback after the canonical early LLM title is
+   * generated. The task title is persisted before this callback runs.
+   */
+  onEarlyTitleGenerated?: (input: {
+    taskRun: TaskRun;
+    title: string;
+  }) => Promise<void> | void;
+  /**
    * Runs inside the run-creation transaction after the new run row is
    * inserted and before the transaction commits.
    */
@@ -1442,6 +1450,21 @@ async function enqueueFreshLaunch(
               lt(tasks.llmTitleCheckpoint, 1),
             ),
           );
+
+        if (shouldPersistGeneratedTitle && options.onEarlyTitleGenerated) {
+          try {
+            await options.onEarlyTitleGenerated({
+              taskRun,
+              title: generatedTitle,
+            });
+          } catch (error) {
+            console.warn(
+              `[enqueueTask] Early-title callback failed for task ${taskRun.taskId}: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            );
+          }
+        }
       } catch (error) {
         console.warn(
           `[enqueueTask] Failed to generate early LLM title for task ${taskRun.taskId}: ${

--- a/packages/communication/scripts/run-mock-telegram.ts
+++ b/packages/communication/scripts/run-mock-telegram.ts
@@ -43,6 +43,7 @@ const configSchema = z.object({
         id: z.number().int(),
         username: z.string().min(1),
         first_name: z.string().min(1),
+        has_topics_enabled: z.boolean().optional(),
       })
       .optional(),
     acceptedBotTokens: z.array(z.string().min(1)).optional(),

--- a/packages/communication/src/__tests__/mock-telegram-server.test.ts
+++ b/packages/communication/src/__tests__/mock-telegram-server.test.ts
@@ -523,8 +523,8 @@ describe('computeTelegramEntities', () => {
   });
 
   it('marks mid-sentence commands the way Telegram does', () => {
-    expect(computeTelegramEntities('try running /done later')).toEqual([
-      { type: 'bot_command', offset: 12, length: 5 },
+    expect(computeTelegramEntities('try running /status later')).toEqual([
+      { type: 'bot_command', offset: 12, length: 7 },
     ]);
   });
 

--- a/packages/communication/src/__tests__/mock-telegram-server.test.ts
+++ b/packages/communication/src/__tests__/mock-telegram-server.test.ts
@@ -90,6 +90,11 @@ describe('MockTelegramServer', () => {
       threadId: topic.messageThreadId,
       text: 'Task started.',
     });
+    await providerFor(baseUrl).editForumTopic({
+      channelId: '111000111',
+      threadId: topic.messageThreadId,
+      name: 'Fix flaky login tests',
+    });
 
     expect(topic.name).toBe('Fix the flaky login test');
     expect(Number(topic.messageThreadId)).toBeGreaterThan(0);
@@ -97,7 +102,7 @@ describe('MockTelegramServer', () => {
       expect.objectContaining({
         chat_id: '111000111',
         message_thread_id: Number(topic.messageThreadId),
-        forum_topic_created: { name: 'Fix the flaky login test' },
+        forum_topic_created: { name: 'Fix flaky login tests' },
       }),
     );
     expect(server.getState().messages).toContainEqual(

--- a/packages/communication/src/__tests__/mock-telegram-server.test.ts
+++ b/packages/communication/src/__tests__/mock-telegram-server.test.ts
@@ -75,6 +75,52 @@ describe('MockTelegramServer', () => {
     cleanups.push(fn);
   }
 
+  it('creates topics in private chats when the bot has Threaded Mode enabled', async () => {
+    const state = baseState();
+    state.bot = { ...state.bot!, has_topics_enabled: true };
+    const { server, baseUrl } = await startServer(state);
+    onCleanup(() => server.stop());
+
+    const topic = await providerFor(baseUrl).createForumTopic({
+      channelId: '111000111',
+      name: 'Fix the flaky login test',
+    });
+    await providerFor(baseUrl).postMessage({
+      channelId: '111000111',
+      threadId: topic.messageThreadId,
+      text: 'Task started.',
+    });
+
+    expect(topic.name).toBe('Fix the flaky login test');
+    expect(Number(topic.messageThreadId)).toBeGreaterThan(0);
+    expect(server.getState().messages).toContainEqual(
+      expect.objectContaining({
+        chat_id: '111000111',
+        message_thread_id: Number(topic.messageThreadId),
+        forum_topic_created: { name: 'Fix the flaky login test' },
+      }),
+    );
+    expect(server.getState().messages).toContainEqual(
+      expect.objectContaining({
+        chat_id: '111000111',
+        message_thread_id: Number(topic.messageThreadId),
+        text: 'Task started.',
+      }),
+    );
+  });
+
+  it('rejects private-chat topic creation when Threaded Mode is disabled', async () => {
+    const { server, baseUrl } = await startServer();
+    onCleanup(() => server.stop());
+
+    await expect(
+      providerFor(baseUrl).createForumTopic({
+        channelId: '111000111',
+        name: 'Fix the flaky login test',
+      }),
+    ).rejects.toThrow('chat is not a forum');
+  });
+
   it('stores a bot message posted through the real provider and anchors the reply', async () => {
     const { server, baseUrl } = await startServer();
     onCleanup(() => server.stop());

--- a/packages/communication/src/__tests__/telegram-provider.test.ts
+++ b/packages/communication/src/__tests__/telegram-provider.test.ts
@@ -13,6 +13,44 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 describe('TelegramCommunicationProvider', () => {
+  it('creates Telegram forum topics for task conversations', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse({
+        ok: true,
+        result: {
+          message_thread_id: 77,
+          name: 'Fix the flaky login test',
+        },
+      }),
+    );
+    const provider = new TelegramCommunicationProvider({
+      botToken: 'bot-token',
+      apiBaseUrl: 'https://telegram.example.test',
+      fetch: fetchMock as typeof fetch,
+    });
+
+    await expect(
+      provider.createForumTopic({
+        channelId: '123',
+        name: 'Fix the flaky login test',
+      }),
+    ).resolves.toEqual({
+      messageThreadId: '77',
+      name: 'Fix the flaky login test',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://telegram.example.test/botbot-token/createForumTopic',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          chat_id: '123',
+          name: 'Fix the flaky login test',
+        }),
+      }),
+    );
+  });
+
   it('sends Telegram messages through the Bot API', async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(
       jsonResponse({

--- a/packages/communication/src/__tests__/telegram-provider.test.ts
+++ b/packages/communication/src/__tests__/telegram-provider.test.ts
@@ -13,6 +13,27 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 describe('TelegramCommunicationProvider', () => {
+  it('reads the private-chat topics capability from getMe', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({ ok: true, result: { has_topics_enabled: true } }),
+      );
+    const provider = new TelegramCommunicationProvider({
+      botToken: 'bot-token',
+      apiBaseUrl: 'https://telegram.example.test',
+      fetch: fetchMock as typeof fetch,
+    });
+
+    await expect(provider.getBotInfo()).resolves.toEqual({
+      hasTopicsEnabled: true,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://telegram.example.test/botbot-token/getMe',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
   it('creates Telegram forum topics for task conversations', async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(
       jsonResponse({

--- a/packages/communication/src/__tests__/telegram-provider.test.ts
+++ b/packages/communication/src/__tests__/telegram-provider.test.ts
@@ -51,6 +51,38 @@ describe('TelegramCommunicationProvider', () => {
     );
   });
 
+  it('renames Telegram forum topics', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse({
+        ok: true,
+        result: true,
+      }),
+    );
+    const provider = new TelegramCommunicationProvider({
+      botToken: 'bot-token',
+      apiBaseUrl: 'https://telegram.example.test',
+      fetch: fetchMock as typeof fetch,
+    });
+
+    await provider.editForumTopic({
+      channelId: '123',
+      threadId: '77',
+      name: 'Fix flaky login tests',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://telegram.example.test/botbot-token/editForumTopic',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          chat_id: '123',
+          message_thread_id: 77,
+          name: 'Fix flaky login tests',
+        }),
+      }),
+    );
+  });
+
   it('sends Telegram messages through the Bot API', async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(
       jsonResponse({

--- a/packages/communication/src/__tests__/telegram-update.test.ts
+++ b/packages/communication/src/__tests__/telegram-update.test.ts
@@ -257,13 +257,13 @@ describe('Telegram update helpers', () => {
     // neither stripped from the queued text nor treated specially.
     expect(
       telegramUpdateToQueuedCommunicationMessage(
-        buildUpdate('ping me when you are /done with the build', 'private', [
-          { type: 'bot_command', offset: 21, length: 5 },
+        buildUpdate('ping me when you are /status with the build', 'private', [
+          { type: 'bot_command', offset: 21, length: 7 },
         ]),
         { botUsername: 'roomote_bot' },
       ),
     ).toMatchObject({
-      text: 'ping me when you are /done with the build',
+      text: 'ping me when you are /status with the build',
     });
 
     expect(
@@ -363,7 +363,7 @@ describe('Telegram update helpers', () => {
       ).toEqual({ command: 'new', text: 'fix the flaky auth test' });
     });
 
-    it('detects /done as an alias for /new', () => {
+    it('does not recognize the removed /done alias', () => {
       expect(
         getTelegramNewTaskCommand(
           parse(
@@ -372,7 +372,7 @@ describe('Telegram update helpers', () => {
             ]),
           ),
         ),
-      ).toEqual({ command: 'done', text: 'run the tests' });
+      ).toBeNull();
     });
 
     it('is case-insensitive on the command name', () => {
@@ -399,19 +399,7 @@ describe('Telegram update helpers', () => {
       ).toEqual({ command: 'new', text: '' });
     });
 
-    it('ignores /new and /done mentioned mid-sentence', () => {
-      expect(
-        getTelegramNewTaskCommand(
-          parse(
-            buildUpdate(
-              'ping me when you are /done with the build',
-              'private',
-              [{ type: 'bot_command', offset: 21, length: 5 }],
-            ),
-          ),
-        ),
-      ).toBeNull();
-
+    it('ignores /new mentioned mid-sentence', () => {
       expect(
         getTelegramNewTaskCommand(
           parse(

--- a/packages/communication/src/mock-telegram-server.ts
+++ b/packages/communication/src/mock-telegram-server.ts
@@ -40,7 +40,7 @@ export type MockTelegramStoredMessage = {
   reply_to_message_id?: number;
   reply_markup?: unknown;
   link_preview_disabled?: boolean;
-  forum_topic_created?: { name: string };
+  forum_topic_created?: { name: string; is_name_implicit?: boolean };
   reactions: string[];
 };
 
@@ -615,6 +615,30 @@ export class MockTelegramServer {
           message_thread_id: messageThreadId,
           name,
         });
+        return;
+      }
+
+      case 'editForumTopic': {
+        const topic = (this.state.messages ?? []).find(
+          (message) =>
+            message.chat_id === String(body.chat_id) &&
+            message.message_thread_id === Number(body.message_thread_id) &&
+            message.forum_topic_created !== undefined,
+        );
+
+        if (!topic?.forum_topic_created) {
+          apiError(response, 400, 'Bad Request: topic not found');
+          return;
+        }
+
+        const name = String(body.name ?? '').trim();
+        if (!name || name.length > 128) {
+          apiError(response, 400, 'Bad Request: invalid topic name');
+          return;
+        }
+
+        topic.forum_topic_created = { name };
+        apiResult(response, true);
         return;
       }
 

--- a/packages/communication/src/mock-telegram-server.ts
+++ b/packages/communication/src/mock-telegram-server.ts
@@ -40,6 +40,7 @@ export type MockTelegramStoredMessage = {
   reply_to_message_id?: number;
   reply_markup?: unknown;
   link_preview_disabled?: boolean;
+  forum_topic_created?: { name: string };
   reactions: string[];
 };
 
@@ -47,6 +48,8 @@ export type MockTelegramBot = {
   id: number;
   username: string;
   first_name: string;
+  /** Mirrors getMe.has_topics_enabled for private-chat Threaded Mode. */
+  has_topics_enabled?: boolean;
 };
 
 export type MockTelegramWebhookRegistration = {
@@ -561,6 +564,56 @@ export class MockTelegramServer {
           is_bot: true,
           first_name: bot.first_name,
           username: bot.username,
+          ...(bot.has_topics_enabled ? { has_topics_enabled: true } : {}),
+        });
+        return;
+      }
+
+      case 'createForumTopic': {
+        const chat = this.findChat(body.chat_id);
+        const bot = this.state.bot ?? DEFAULT_BOT;
+
+        if (!chat) {
+          apiError(response, 400, 'Bad Request: chat not found');
+          return;
+        }
+
+        if (
+          (chat.type === 'private' && !bot.has_topics_enabled) ||
+          (chat.type !== 'private' && !chat.is_forum)
+        ) {
+          apiError(response, 400, 'Bad Request: chat is not a forum');
+          return;
+        }
+
+        const name = String(body.name ?? '').trim();
+        if (!name || name.length > 128) {
+          apiError(response, 400, 'Bad Request: invalid topic name');
+          return;
+        }
+
+        const messageThreadId = this.nextMessageId();
+        this.state.messages = [
+          ...(this.state.messages ?? []),
+          {
+            message_id: messageThreadId,
+            chat_id: String(chat.id),
+            date: Math.floor(Date.now() / 1000),
+            from: {
+              id: bot.id,
+              is_bot: true,
+              first_name: bot.first_name,
+              username: bot.username,
+            },
+            message_thread_id: messageThreadId,
+            forum_topic_created: { name },
+            reactions: [],
+          },
+        ];
+
+        apiResult(response, {
+          message_thread_id: messageThreadId,
+          name,
         });
         return;
       }
@@ -896,6 +949,9 @@ export class MockTelegramServer {
         : {}),
       ...(stored.reply_to_message_id !== undefined
         ? { reply_to_message_id: stored.reply_to_message_id }
+        : {}),
+      ...(stored.forum_topic_created !== undefined
+        ? { forum_topic_created: stored.forum_topic_created }
         : {}),
     };
   }

--- a/packages/communication/src/telegram-provider.ts
+++ b/packages/communication/src/telegram-provider.ts
@@ -26,6 +26,10 @@ export type TelegramForumTopic = {
   name: string;
 };
 
+export type TelegramBotInfo = {
+  hasTopicsEnabled: boolean;
+};
+
 type TelegramApiResponse =
   | {
       ok: true;
@@ -407,6 +411,18 @@ export class TelegramCommunicationProvider implements CommunicationProviderAdapt
       action: input.action ?? 'typing',
       ...(threadId ? { message_thread_id: threadId } : {}),
     });
+  }
+
+  /**
+   * Read the bot capability flag Telegram exposes for private-chat Threaded
+   * Mode. This avoids probing createForumTopic for bots that have it disabled.
+   */
+  async getBotInfo(): Promise<TelegramBotInfo> {
+    const result = (await this.callBotApi('getMe', {})) as {
+      has_topics_enabled?: boolean;
+    };
+
+    return { hasTopicsEnabled: result.has_topics_enabled === true };
   }
 
   /**

--- a/packages/communication/src/telegram-provider.ts
+++ b/packages/communication/src/telegram-provider.ts
@@ -437,6 +437,25 @@ export class TelegramCommunicationProvider implements CommunicationProviderAdapt
     };
   }
 
+  /** Rename an existing forum topic, including private-chat bot topics. */
+  async editForumTopic(input: {
+    channelId: string;
+    threadId: string;
+    name: string;
+  }): Promise<void> {
+    const threadId = parsePositiveInteger(input.threadId);
+
+    if (!threadId) {
+      throw new Error('Telegram editForumTopic requires a valid thread id.');
+    }
+
+    await this.callBotApi('editForumTopic', {
+      chat_id: input.channelId,
+      message_thread_id: threadId,
+      name: input.name,
+    });
+  }
+
   /** Delete a message the bot sent (Bot API allows this within 48 hours). */
   async deleteMessage(input: {
     channelId: string;

--- a/packages/communication/src/telegram-provider.ts
+++ b/packages/communication/src/telegram-provider.ts
@@ -21,6 +21,11 @@ export type TelegramCommunicationProviderOptions = {
   fetch?: typeof fetch;
 };
 
+export type TelegramForumTopic = {
+  messageThreadId: string;
+  name: string;
+};
+
 type TelegramApiResponse =
   | {
       ok: true;
@@ -402,6 +407,34 @@ export class TelegramCommunicationProvider implements CommunicationProviderAdapt
       action: input.action ?? 'typing',
       ...(threadId ? { message_thread_id: threadId } : {}),
     });
+  }
+
+  /**
+   * Create a task-owned topic in a forum supergroup or a private chat whose
+   * bot has Threaded Mode enabled in BotFather.
+   */
+  async createForumTopic(input: {
+    channelId: string;
+    name: string;
+  }): Promise<TelegramForumTopic> {
+    const result = (await this.callBotApi('createForumTopic', {
+      chat_id: input.channelId,
+      name: input.name,
+    })) as {
+      message_thread_id?: number;
+      name?: string;
+    };
+
+    if (!Number.isSafeInteger(result.message_thread_id)) {
+      throw new Error(
+        'Telegram createForumTopic returned no message_thread_id.',
+      );
+    }
+
+    return {
+      messageThreadId: String(result.message_thread_id),
+      name: result.name ?? input.name,
+    };
   }
 
   /** Delete a message the bot sent (Bot API allows this within 48 hours). */

--- a/packages/communication/src/telegram-update.ts
+++ b/packages/communication/src/telegram-update.ts
@@ -20,6 +20,7 @@ const telegramChatSchema = z
     username: z.string().optional(),
     first_name: z.string().optional(),
     last_name: z.string().optional(),
+    is_forum: z.boolean().optional(),
   })
   .passthrough();
 
@@ -365,9 +366,9 @@ function isNewTaskCommandName(
  * plus the task description with the invocation stripped. Returns `null` when
  * the update is not one of those commands.
  *
- * Telegram chats have no threads, so after a task completes the next message
- * in the same chat would otherwise resume the previous task's snapshot. These
- * commands force a fresh task launch instead.
+ * After a task completes, the next message in the same chat/topic would
+ * otherwise resume its snapshot. These commands force a fresh task launch
+ * instead (and the launch path can create a fresh Telegram topic).
  *
  * The command must lead the message — a `/new` or `/done` mentioned
  * mid-sentence is ordinary text, not a command. The only prefix allowed before

--- a/packages/communication/src/telegram-update.ts
+++ b/packages/communication/src/telegram-update.ts
@@ -32,6 +32,15 @@ const telegramMessageEntitySchema = z
   })
   .passthrough();
 
+const telegramForumTopicCreatedSchema = z
+  .object({
+    name: z.string(),
+    icon_color: z.number().int().optional(),
+    icon_custom_emoji_id: z.string().optional(),
+    is_name_implicit: z.boolean().optional(),
+  })
+  .passthrough();
+
 const telegramMessageSchema = z
   .object({
     message_id: z.number().int(),
@@ -41,6 +50,7 @@ const telegramMessageSchema = z
     from: telegramUserSchema.optional(),
     chat: telegramChatSchema,
     entities: z.array(telegramMessageEntitySchema).optional(),
+    forum_topic_created: telegramForumTopicCreatedSchema.optional(),
   })
   .passthrough();
 
@@ -133,6 +143,12 @@ export function getTelegramMessageThreadId(
   return message.message_thread_id === undefined
     ? undefined
     : String(message.message_thread_id);
+}
+
+export function isTelegramImplicitTopicCreatedMessage(
+  message: TelegramMessage,
+): boolean {
+  return message.forum_topic_created?.is_name_implicit === true;
 }
 
 export function formatTelegramUser(message: TelegramMessage): string {

--- a/packages/communication/src/telegram-update.ts
+++ b/packages/communication/src/telegram-update.ts
@@ -348,7 +348,7 @@ export function isTelegramTaskEntryUpdate(
   );
 }
 
-export const TELEGRAM_NEW_TASK_COMMANDS = ['new', 'done'] as const;
+export const TELEGRAM_NEW_TASK_COMMANDS = ['new'] as const;
 
 export type TelegramNewTaskCommand = {
   command: (typeof TELEGRAM_NEW_TASK_COMMANDS)[number];
@@ -362,17 +362,16 @@ function isNewTaskCommandName(
 }
 
 /**
- * Detects an explicit `/new` or `/done` command and returns the command name
- * plus the task description with the invocation stripped. Returns `null` when
- * the update is not one of those commands.
+ * Detects an explicit `/new` command and returns the command name plus the task
+ * description with the invocation stripped. Returns `null` for other updates.
  *
  * After a task completes, the next message in the same chat/topic would
- * otherwise resume its snapshot. These commands force a fresh task launch
+ * otherwise resume its snapshot. This command forces a fresh task launch
  * instead (and the launch path can create a fresh Telegram topic).
  *
- * The command must lead the message — a `/new` or `/done` mentioned
- * mid-sentence is ordinary text, not a command. The only prefix allowed before
- * the command is a mention of this bot, so both group forms work:
+ * The command must lead the message — a `/new` mentioned mid-sentence is
+ * ordinary text, not a command. The only prefix allowed before the command is
+ * a mention of this bot, so both group forms work:
  * `/new@<botUsername> <text>` and `@<botUsername> /new <text>`. A bare `/new`
  * from another member, or one suffixed for another bot, does not hijack the
  * chat.

--- a/packages/types/src/task-runs.ts
+++ b/packages/types/src/task-runs.ts
@@ -963,6 +963,8 @@ const sharedTaskPayloadSchema = z.object({
   communicationChannelId: z.string().optional(),
   communicationThreadId: z.string().optional(),
   communicationMessageId: z.string().optional(),
+  /** True when the Telegram topic was created specifically for this task. */
+  telegramTaskTopic: z.boolean().optional(),
 
   /**
    * Optional Slack routing metadata for non-Slack task types that still own a


### PR DESCRIPTION
## Summary

- create a Telegram forum topic after task routing and persist it as the task conversation
- support private bot Threaded Mode and user-provisioned forum supergroups, with fallback to the existing chat flow
- isolate root chats from topic-bound runs and preserve topic context across resumes and callbacks
- extend the mock Telegram harness, setup guidance, public docs, and focused coverage

## Telegram limitation

The Bot API cannot create a supergroup or enable forum mode. Private-chat topics require Threaded Mode to be enabled in BotFather. Shared supergroups must be created by a user, have topics enabled, and grant the bot Manage Topics permission.

## Validation

- communication Telegram tests: 55 passed
- API Telegram tests: 59 passed
- web settings tests: 18 passed
- communication, API, and web typechecks passed
- communication, API, and web lint passed
- repo-wide fast lint, fast typechecks, and Knip passed during push
- Mint docs validation passed