### PR TITLE
Add Telegram to communication onboarding

### DIFF
--- a/apps/api/src/handlers/mcp/__tests__/communication-thread-replies.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/communication-thread-replies.test.ts
@@ -293,6 +293,18 @@ describe('maybeSendCommunicationThreadReply (Telegram)', () => {
     );
   });
 
+  it('does not post the managed live-preview footer in Telegram', async () => {
+    await maybeSendCommunicationThreadReply({
+      taskRun: telegramTaskRun,
+      parsedBody: { text: 'done', images: [] },
+    });
+
+    expect(postMessageMock).toHaveBeenCalledTimes(1);
+    expect(postMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'done' }),
+    );
+  });
+
   it('delivers the reply even if the typing action fails', async () => {
     sendChatActionMock.mockRejectedValue(new Error('typing failed'));
 

--- a/apps/api/src/handlers/mcp/communication-thread-replies.ts
+++ b/apps/api/src/handlers/mcp/communication-thread-replies.ts
@@ -25,12 +25,10 @@ import {
 
 const LOG_CONTEXT = 'communicationThreadReplies';
 const TEAMS_THREAD_REPLY_FOOTER_LOCK_PREFIX = 'teams:thread_reply_footer_lock:';
-const TELEGRAM_THREAD_REPLY_FOOTER_LOCK_PREFIX =
-  'telegram:thread_reply_footer_lock:';
 
 // Telegram clears a chat action after ~5s; re-send inside that window so the
 // "typing…" indicator spans the whole reply delivery (chunks, photo fetch,
-// footer) instead of lapsing partway through.
+// message delivery) instead of lapsing partway through.
 const TELEGRAM_TYPING_HEARTBEAT_MS = 4_000;
 
 /**
@@ -303,13 +301,6 @@ async function sendTelegramThreadReply(params: {
       textFormat: 'markdown',
       images,
     });
-
-    await postTelegramThreadReplyFooterBestEffort({
-      provider,
-      taskRun: params.taskRun,
-      channelId,
-      threadId,
-    });
   } finally {
     stopTyping();
   }
@@ -454,59 +445,6 @@ async function addTeamsReaction(params: {
         }`,
       }),
       { status: 502 },
-    );
-  }
-}
-
-async function postTelegramThreadReplyFooterBestEffort(params: {
-  provider: TelegramCommunicationProvider;
-  taskRun: CommunicationReplyTaskRun;
-  channelId: string;
-  threadId: string | null;
-}): Promise<void> {
-  const footerText = await buildCommunicationThreadReplyFooterTextBestEffort({
-    provider: 'telegram',
-    providerLabel: 'Telegram',
-    taskRun: params.taskRun,
-    logContext: LOG_CONTEXT,
-  });
-
-  if (!footerText) {
-    return;
-  }
-
-  const footerStateThreadId = params.threadId ?? 'root';
-
-  try {
-    await deliverManagedThreadReplyFooter({
-      provider: 'telegram',
-      providerLabel: 'Telegram',
-      channelId: params.channelId,
-      footerStateThreadId,
-      lockKey: `${TELEGRAM_THREAD_REPLY_FOOTER_LOCK_PREFIX}${params.channelId}:${footerStateThreadId}`,
-      runId: params.taskRun.id,
-      logContext: LOG_CONTEXT,
-      postReplyWithFooter: async () => ({
-        ...(await params.provider.postMessage({
-          channelId: params.channelId,
-          ...(params.threadId ? { threadId: params.threadId } : {}),
-          text: footerText,
-          textFormat: 'markdown',
-        })),
-        textWithoutFooter: '',
-      }),
-      clearPreviousFooter: async (previousFooterRecord) => {
-        await params.provider.deleteMessage({
-          channelId: params.channelId,
-          messageId: previousFooterRecord.messageId,
-        });
-      },
-    });
-  } catch (error) {
-    console.error(
-      `[${LOG_CONTEXT}] Failed to post Telegram reply footer for task run ${params.taskRun.id}: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
     );
   }
 }

--- a/apps/api/src/handlers/tasks/automation-work-items/__tests__/telegram.test.ts
+++ b/apps/api/src/handlers/tasks/automation-work-items/__tests__/telegram.test.ts
@@ -1,12 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { credentialsMock, findPrimaryChatMock, selectLimitMock } = vi.hoisted(
-  () => ({
-    credentialsMock: vi.fn(),
-    findPrimaryChatMock: vi.fn(),
-    selectLimitMock: vi.fn(),
-  }),
-);
+const {
+  credentialsMock,
+  findPrimaryChatMock,
+  postMessageMock,
+  selectLimitMock,
+} = vi.hoisted(() => ({
+  credentialsMock: vi.fn(),
+  findPrimaryChatMock: vi.fn(),
+  postMessageMock: vi.fn(),
+  selectLimitMock: vi.fn(),
+}));
 
 vi.mock('@roomote/db/server', () => ({
   slackInstallations: { id: 'id', isActive: 'isActive' },
@@ -26,14 +30,17 @@ vi.mock('../../../telegram/primary-chat.js', () => ({
 }));
 
 vi.mock('../../../telegram/replies.js', () => ({
-  postTelegramMessageBestEffort: vi.fn(),
+  postTelegramMessageInNewTopicBestEffort: postMessageMock,
 }));
 
 vi.mock('../../../slack/helpers/suggestion-workspace.js', () => ({
   buildSuggestionBadgePrefix: vi.fn(() => ''),
 }));
 
-import { resolveAutomationTelegramTarget } from '../telegram';
+import {
+  postLateBoundWorkItemFailureToTelegram,
+  resolveAutomationTelegramTarget,
+} from '../telegram';
 
 describe('resolveAutomationTelegramTarget', () => {
   beforeEach(() => {
@@ -71,5 +78,26 @@ describe('resolveAutomationTelegramTarget', () => {
 
     findPrimaryChatMock.mockResolvedValueOnce(null);
     await expect(resolveAutomationTelegramTarget()).resolves.toBeNull();
+  });
+
+  it('posts automation launch failures in their own topic', async () => {
+    await postLateBoundWorkItemFailureToTelegram({
+      chatId: '8846357662',
+      workItem: {
+        id: 'work-1',
+        title: 'Fix the flaky test',
+        brief: 'Investigate and fix it.',
+        category: null,
+        priority: null,
+      } as never,
+      reason: 'No environment was available.',
+    });
+
+    expect(postMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId: '8846357662',
+        topicName: 'Fix the flaky test',
+      }),
+    );
   });
 });

--- a/apps/api/src/handlers/tasks/automation-work-items/telegram.ts
+++ b/apps/api/src/handlers/tasks/automation-work-items/telegram.ts
@@ -6,7 +6,7 @@ import {
 } from '@roomote/db/server';
 
 import { findTelegramPrimaryChatId } from '../../telegram/primary-chat.js';
-import { postTelegramMessageBestEffort } from '../../telegram/replies.js';
+import { postTelegramMessageInNewTopicBestEffort } from '../../telegram/replies.js';
 import { buildSuggestionBadgePrefix } from '../../slack/helpers/suggestion-workspace.js';
 import type { PersistedAutomationWorkItem } from './types.js';
 
@@ -62,8 +62,9 @@ export async function postLateBoundWorkItemFailureToTelegram(params: {
     `An automation queued this work item, but the execution task failed to launch: ${params.reason}`,
   ].join('\n');
 
-  await postTelegramMessageBestEffort({
+  await postTelegramMessageInNewTopicBestEffort({
     chatId: params.chatId,
+    topicName: params.workItem.title,
     text,
     textFormat: 'markdown',
   });

--- a/apps/api/src/handlers/telegram/__tests__/automation-suggestions.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/automation-suggestions.test.ts
@@ -60,7 +60,7 @@ vi.mock('../primary-chat.js', () => ({
 }));
 
 vi.mock('../replies.js', () => ({
-  postTelegramMessageBestEffort: postTelegramMessageBestEffortMock,
+  postTelegramMessageInNewTopicBestEffort: postTelegramMessageBestEffortMock,
 }));
 
 vi.mock('../../tasks/scheduled-suggestion-root-summary.js', () => ({
@@ -89,7 +89,10 @@ describe('postScheduledSuggestionsToTelegram', () => {
       onConflictDoNothing: insertOnConflictDoNothingMock,
     });
     insertOnConflictDoNothingMock.mockResolvedValue(undefined);
-    postTelegramMessageBestEffortMock.mockResolvedValue({ messageId: '950' });
+    postTelegramMessageBestEffortMock.mockResolvedValue({
+      messageId: '950',
+      threadId: '88',
+    });
     buildRootMessageMock.mockResolvedValue({
       summaryText: 'I triaged the latest Sentry issues.',
       actionFooterText: 'footer',
@@ -112,12 +115,14 @@ describe('postScheduledSuggestionsToTelegram', () => {
 
     expect(postTelegramMessageBestEffortMock).toHaveBeenCalledTimes(1);
     const posted = postTelegramMessageBestEffortMock.mock.calls[0]![0] as {
+      topicName: string;
       text: string;
       buttons: Array<Array<{ callbackData?: string }>>;
     };
 
     expect(posted.text).toContain('I triaged the latest Sentry issues.');
     expect(posted.text).toContain('Fix crash');
+    expect(posted.topicName).toBe('Suggested tasks');
     expect(posted.buttons).toEqual([
       [expect.objectContaining({ callbackData: 'idea:aaa' })],
       [expect.objectContaining({ callbackData: 'idea:bbb' })],

--- a/apps/api/src/handlers/telegram/__tests__/index.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/index.test.ts
@@ -1297,7 +1297,10 @@ describe('Telegram webhook handler', () => {
     expect(postMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
         channelId: '222',
-        text: expect.stringContaining('Linked!'),
+        text: expect.stringMatching(
+          /Linked![\s\S]*Available commands[\s\S]*\/start[\s\S]*\/new <request>/,
+        ),
+        textFormat: 'markdown',
       }),
     );
   });

--- a/apps/api/src/handlers/telegram/__tests__/setup-suggestions.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/setup-suggestions.test.ts
@@ -77,7 +77,7 @@ vi.mock('../primary-chat.js', () => ({
 }));
 
 vi.mock('../replies.js', () => ({
-  postTelegramMessageBestEffort: postTelegramMessageBestEffortMock,
+  postTelegramMessageInNewTopicBestEffort: postTelegramMessageBestEffortMock,
 }));
 
 import { postSetupTaskSuggestionsToTelegram } from '../setup-suggestions';
@@ -93,7 +93,10 @@ describe('postSetupTaskSuggestionsToTelegram', () => {
       onConflictDoNothing: insertOnConflictDoNothingMock,
     });
     insertOnConflictDoNothingMock.mockResolvedValue(undefined);
-    postTelegramMessageBestEffortMock.mockResolvedValue({ messageId: '900' });
+    postTelegramMessageBestEffortMock.mockResolvedValue({
+      messageId: '900',
+      threadId: '77',
+    });
     enqueueFollowupMock.mockResolvedValue({ enqueued: true, jobId: 'job-1' });
   });
 
@@ -109,12 +112,14 @@ describe('postSetupTaskSuggestionsToTelegram', () => {
 
     expect(postTelegramMessageBestEffortMock).toHaveBeenCalledTimes(1);
     const posted = postTelegramMessageBestEffortMock.mock.calls[0]![0] as {
+      topicName: string;
       text: string;
       buttons: Array<Array<{ text: string; callbackData?: string }>>;
     };
 
     expect(posted.text).toContain('First idea');
     expect(posted.text).toContain('Second idea');
+    expect(posted.topicName).toBe('Suggested tasks');
     expect(posted.buttons).toEqual([
       [{ text: '▶️ Start idea 1', callbackData: 'idea:aaa' }],
       [{ text: '▶️ Start idea 2', callbackData: 'idea:bbb' }],
@@ -170,6 +175,7 @@ describe('postSetupTaskSuggestionsToTelegram', () => {
 
     expect(enqueueFollowupMock).toHaveBeenCalledWith({
       chatId: '8846357662',
+      threadId: '77',
       introMessageId: '900',
       sourceTaskId: 'task-1',
     });

--- a/apps/api/src/handlers/telegram/automation-suggestions.ts
+++ b/apps/api/src/handlers/telegram/automation-suggestions.ts
@@ -12,7 +12,7 @@ import { apiLogger } from '../../logging.js';
 import { resolveScheduledSuggestionSlackConfig } from '../tasks/background-automation-slack.js';
 import { buildScheduledSuggestionRootMessage } from '../tasks/scheduled-suggestion-root-summary.js';
 import { findTelegramPrimaryChatId } from './primary-chat.js';
-import { postTelegramMessageBestEffort } from './replies.js';
+import { postTelegramMessageInNewTopicBestEffort } from './replies.js';
 
 const MAX_TELEGRAM_AUTOMATION_SUGGESTIONS = 5;
 
@@ -121,9 +121,9 @@ export async function postScheduledSuggestionsToTelegram(params: {
       },
     ],
   );
-
-  const posted = await postTelegramMessageBestEffort({
+  const posted = await postTelegramMessageInNewTopicBestEffort({
     chatId,
+    topicName: 'Suggested tasks',
     text: messageLines.join('\n'),
     textFormat: 'markdown',
     buttons,

--- a/apps/api/src/handlers/telegram/index.ts
+++ b/apps/api/src/handlers/telegram/index.ts
@@ -41,14 +41,16 @@ import {
   postTelegramMessageBestEffort,
 } from './replies.js';
 
+const TELEGRAM_COMMAND_HELP = [
+  '*Available commands*',
+  '`/start` — show this welcome message.',
+  '`/new <request>` — start a fresh task instead of resuming the previous one; when topics are available, it opens a new topic.',
+].join('\n');
+
 const TELEGRAM_WELCOME_MESSAGE = [
   "👋 Hi, I'm Roomote. Message me here to start tasks in your connected repos — I'll route your request, reply with progress, and post results (including screenshots) right in this chat.",
   'Try something like *"Fix the flaky auth test"* or *"What changed in the repo this week?"*. While a task is running you can send follow-ups in its chat or topic, and every started task has a cancel button.',
-  [
-    '*Available commands*',
-    '`/start` — show this welcome message.',
-    '`/new <request>` — start a fresh task instead of resuming the previous one; when topics are available, it opens a new topic.',
-  ].join('\n'),
+  TELEGRAM_COMMAND_HELP,
 ].join('\n\n');
 
 const TELEGRAM_WELCOME_LINK_NUDGE =
@@ -206,7 +208,12 @@ telegram.post('/', async (c) => {
       });
       await postTelegramMessageBestEffort({
         chatId,
-        text: '✅ Linked! This Telegram account is now connected to your Roomote account — tasks you start here are attributed to you, and Roomote can reach you in this chat.',
+        text: [
+          '✅ Linked! This Telegram account is now connected to your Roomote account. Tasks you start here are attributed to you, and Roomote can reach you in this chat.',
+          'Send a request to start a task, or use:',
+          TELEGRAM_COMMAND_HELP,
+        ].join('\n\n'),
+        textFormat: 'markdown',
       });
 
       return c.json({ ok: true, linked: true });

--- a/apps/api/src/handlers/telegram/replies.ts
+++ b/apps/api/src/handlers/telegram/replies.ts
@@ -123,6 +123,28 @@ export async function createTelegramForumTopicBestEffort(input: {
   }
 }
 
+export async function postTelegramMessageInNewTopicBestEffort(input: {
+  chatId: string;
+  topicName: string;
+  text: string;
+  textFormat?: 'plain' | 'markdown';
+  buttons?: CommunicationMessageButton[][];
+}): Promise<{ messageId: string; threadId?: string } | null> {
+  const topic = await createTelegramForumTopicBestEffort({
+    chatId: input.chatId,
+    name: input.topicName,
+  });
+  const posted = await postTelegramMessageBestEffort({
+    chatId: input.chatId,
+    ...(topic ? { threadId: topic.threadId } : {}),
+    text: input.text,
+    ...(input.textFormat ? { textFormat: input.textFormat } : {}),
+    ...(input.buttons ? { buttons: input.buttons } : {}),
+  });
+
+  return posted ? { messageId: posted.messageId, ...(topic ?? {}) } : null;
+}
+
 export async function editTelegramForumTopicBestEffort(input: {
   chatId: string;
   threadId: string;

--- a/apps/api/src/handlers/telegram/setup-suggestions.ts
+++ b/apps/api/src/handlers/telegram/setup-suggestions.ts
@@ -24,7 +24,7 @@ import {
   type SetupSuggestionSummary,
 } from '../tasks/setup-suggestion-lifecycle.js';
 import { findTelegramPrimaryChatId } from './primary-chat.js';
-import { postTelegramMessageBestEffort } from './replies.js';
+import { postTelegramMessageInNewTopicBestEffort } from './replies.js';
 
 const SUGGESTION_CALLBACK_PREFIX = 'idea:';
 
@@ -99,9 +99,9 @@ export async function postSetupTaskSuggestionsToTelegram(params: {
       },
     ],
   );
-
-  const posted = await postTelegramMessageBestEffort({
+  const posted = await postTelegramMessageInNewTopicBestEffort({
     chatId,
+    topicName: 'Suggested tasks',
     text: introLines.join('\n'),
     textFormat: 'markdown',
     buttons,
@@ -132,6 +132,7 @@ export async function postSetupTaskSuggestionsToTelegram(params: {
     enqueue: () =>
       enqueueTelegramSuggestedTasksOnboardingFollowup({
         chatId,
+        ...(posted.threadId ? { threadId: posted.threadId } : {}),
         introMessageId: posted.messageId,
         sourceTaskId,
       }),

--- a/apps/bullmq/src/jobs/telegram-suggested-tasks-onboarding-followup.test.ts
+++ b/apps/bullmq/src/jobs/telegram-suggested-tasks-onboarding-followup.test.ts
@@ -27,6 +27,7 @@ vi.mock('@roomote/sdk/server', async () => {
   return {
     telegramSuggestedTasksOnboardingFollowupRequestSchema: z.object({
       chatId: z.string(),
+      threadId: z.string().optional(),
       introMessageId: z.string(),
       sourceTaskId: z.string(),
     }),
@@ -57,6 +58,7 @@ describe('telegramSuggestedTasksOnboardingFollowupJob', () => {
     await telegramSuggestedTasksOnboardingFollowupJob(
       buildJob({
         chatId: '8846357662',
+        threadId: '77',
         introMessageId: '900',
         sourceTaskId: 'task-1',
       }),
@@ -65,6 +67,7 @@ describe('telegramSuggestedTasksOnboardingFollowupJob', () => {
     expect(postMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
         channelId: '8846357662',
+        threadId: '77',
         replyToMessageId: '900',
         textFormat: 'markdown',
         buttons: [

--- a/apps/bullmq/src/jobs/telegram-suggested-tasks-onboarding-followup.ts
+++ b/apps/bullmq/src/jobs/telegram-suggested-tasks-onboarding-followup.ts
@@ -37,6 +37,7 @@ export const telegramSuggestedTasksOnboardingFollowupJob = async (
 
       await provider.postMessage({
         channelId: data.chatId,
+        ...(data.threadId ? { threadId: data.threadId } : {}),
         replyToMessageId: data.introMessageId,
         text: buildSuggestedTasksFollowupReminderText(),
         textFormat: 'markdown',

--- a/apps/web/src/app/(onboarding)/setup/ProviderSetupInstructions.tsx
+++ b/apps/web/src/app/(onboarding)/setup/ProviderSetupInstructions.tsx
@@ -140,9 +140,6 @@ export function ProviderSetupInstructions({
           Telegram withholds a 15% fee from Stars purchases while this mode is
           enabled.
         </InstructionText>
-        <InstructionText heading="Webhook">
-          Roomote registers the webhook automatically when you save.
-        </InstructionText>
       </div>
     );
   }

--- a/apps/web/src/app/(onboarding)/setup/StepAuthProvider.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepAuthProvider.client.test.tsx
@@ -37,6 +37,16 @@ describe('StepAuthProvider', () => {
     expect(onContinue).not.toHaveBeenCalled();
   });
 
+  it('offers Telegram in the signed-in communication provider chooser', () => {
+    const onContinue = vi.fn();
+
+    render(<StepAuthProvider onContinue={onContinue} includeTelegram={true} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /telegram/i }));
+
+    expect(onContinue).toHaveBeenCalledWith('telegram');
+  });
+
   it('continues when clicking Slack', () => {
     const onContinue = vi.fn();
 

--- a/apps/web/src/app/(onboarding)/setup/StepAuthProvider.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepAuthProvider.tsx
@@ -12,16 +12,25 @@ import { StepTitle } from './StepTitle';
 import { getSetupStepDefinition } from './types';
 
 const AUTH_PROVIDER_STEP = getSetupStepDefinition('auth-provider');
+export type CommunicationProviderChoice = SetupAuthProviderId | 'telegram';
 
 export function StepAuthProvider({
   onContinue,
   onBack,
   onSkip,
+  includeTelegram = false,
 }: {
-  onContinue: (provider: SetupAuthProviderId) => void;
+  onContinue: (provider: CommunicationProviderChoice) => void;
   onBack?: () => void;
   onSkip?: () => void;
+  includeTelegram?: boolean;
 }) {
+  const providers = includeTelegram
+    ? [
+        ...SETUP_AUTH_PROVIDER_CATALOG,
+        { id: 'telegram' as const, label: 'Telegram' },
+      ]
+    : SETUP_AUTH_PROVIDER_CATALOG;
   return (
     <div className="relative w-full max-w-2xl space-y-6 py-2 md:py-0">
       <StepTitle text={AUTH_PROVIDER_STEP.title} />
@@ -33,12 +42,12 @@ export function StepAuthProvider({
         </p>
 
         <div className="space-y-0.5 max-w-sm">
-          {SETUP_AUTH_PROVIDER_CATALOG.map((provider) => {
+          {providers.map((provider) => {
             return (
               <Button
                 key={provider.id}
                 type="button"
-                onClick={() => onContinue(provider.id as SetupAuthProviderId)}
+                onClick={() => onContinue(provider.id)}
                 className={cn(
                   'group flex w-full py-5',
                   'hover:text-accent-foreground hover:bg-foreground',

--- a/apps/web/src/app/(onboarding)/setup/StepInvoke.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepInvoke.tsx
@@ -35,10 +35,18 @@ export function StepInvoke({
   const queryClient = useQueryClient();
   const environments = useEnvironments();
   const commsStatus = useQuery(trpc.comms.status.queryOptions());
+  const effectiveCommunicationProviders = [
+    ...communicationProviders,
+    ...(commsStatus.data?.providers?.some(
+      (provider) => provider.id === 'telegram' && provider.setupSatisfied,
+    ) && !communicationProviders.includes('telegram')
+      ? (['telegram'] as const)
+      : []),
+  ];
   const [anonymousAnalyticsEnabled, setAnonymousAnalyticsEnabled] =
     useState(true);
   const methods = buildInvokeMethods({
-    communicationProviders,
+    communicationProviders: effectiveCommunicationProviders,
     sourceControlProviders,
     includeLinear,
     invocationIdentities: commsStatus.data?.invocationIdentities,

--- a/apps/web/src/app/(onboarding)/setup/StepTelegramSetup.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepTelegramSetup.client.test.tsx
@@ -1,0 +1,104 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const { invalidateQueriesMock, toastWarningMock } = vi.hoisted(() => ({
+  invalidateQueriesMock: vi.fn().mockResolvedValue(undefined),
+  toastWarningMock: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), warning: toastWarningMock },
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({
+    data: {
+      providers: [
+        {
+          id: 'telegram',
+          label: 'Telegram',
+          fields: [
+            {
+              envVarName: 'R_TELEGRAM_BOT_TOKEN',
+              acceptedEnvVarNames: ['R_TELEGRAM_BOT_TOKEN'],
+              label: 'Telegram Bot Token',
+              secret: true,
+              runtimeSatisfied: true,
+              savedSatisfied: false,
+              satisfiedByEnvVarName: 'R_TELEGRAM_BOT_TOKEN',
+            },
+          ],
+          runtimeSatisfied: true,
+          savedSatisfied: false,
+          setupSatisfied: false,
+        },
+      ],
+    },
+    isLoading: false,
+    isError: false,
+  }),
+  useMutation: (options: {
+    onSuccess: (result: unknown) => Promise<void>;
+  }) => ({
+    isPending: false,
+    mutate: () =>
+      void options.onSuccess({
+        telegramWebhook: { registered: false, error: 'network unavailable' },
+      }),
+  }),
+  useQueryClient: () => ({ invalidateQueries: invalidateQueriesMock }),
+}));
+
+vi.mock('@/trpc/client', () => ({
+  useTRPC: () => ({
+    comms: {
+      status: {
+        queryOptions: () => ({}),
+        queryKey: () => ['comms.status'],
+      },
+      saveAuthConfig: { mutationOptions: (options: unknown) => options },
+    },
+    linkedAccounts: {
+      telegram: { queryKey: () => ['linkedAccounts.telegram'] },
+    },
+  }),
+}));
+
+vi.mock('@/hooks/linked-accounts', () => ({
+  useTelegramLinkedAccount: () => ({ data: { mapping: null } }),
+}));
+
+vi.mock('@/components/settings/TelegramLinkAccountStep', () => ({
+  TelegramLinkAccountStep: () => <div>Link Telegram account</div>,
+}));
+
+vi.mock('./ProviderSetupExperience', () => ({
+  ProviderSetupExperience: () => <div>Telegram setup form</div>,
+  getSetupVisibleFields: (provider: { fields: unknown[] }) => provider.fields,
+  getSetupEffectiveFieldValue: () => 'configured-token',
+  getSetupSubmitValues: () => ({}),
+}));
+
+import { StepTelegramSetup } from './StepTelegramSetup';
+
+describe('StepTelegramSetup', () => {
+  it('warns about webhook failure and refreshes linking state after save', async () => {
+    render(<StepTelegramSetup onContinue={vi.fn()} onBack={vi.fn()} />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Save and link account' }),
+    );
+
+    await waitFor(() => {
+      expect(toastWarningMock).toHaveBeenCalledWith(
+        expect.stringContaining('network unavailable'),
+      );
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: ['comms.status'],
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: ['linkedAccounts.telegram'],
+    });
+    expect(screen.getByText('Link Telegram account')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(onboarding)/setup/StepTelegramSetup.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepTelegramSetup.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { useTRPC } from '@/trpc/client';
+import { ArrowLeft, ArrowRight, Button, Spinner } from '@/components/system';
+import { TelegramLinkAccountStep } from '@/components/settings/TelegramLinkAccountStep';
+import { useTelegramLinkedAccount } from '@/hooks/linked-accounts';
+
+import {
+  getSetupEffectiveFieldValue,
+  getSetupSubmitValues,
+  getSetupVisibleFields,
+  ProviderSetupExperience,
+} from './ProviderSetupExperience';
+import { StepTitle } from './StepTitle';
+
+export function StepTelegramSetup({
+  onContinue,
+  onBack,
+}: {
+  onContinue: () => void;
+  onBack: () => void;
+}) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const status = useQuery(trpc.comms.status.queryOptions());
+  const telegramAccount = useTelegramLinkedAccount({ refetchInterval: 2_000 });
+  const [credentialsSaved, setCredentialsSaved] = useState(false);
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [editingSavedValues, setEditingSavedValues] = useState<
+    Record<string, boolean>
+  >({});
+  const [clearedSavedValues, setClearedSavedValues] = useState<
+    Record<string, boolean>
+  >({});
+  const provider = useMemo(
+    () => status.data?.providers.find((item) => item.id === 'telegram') ?? null,
+    [status.data?.providers],
+  );
+  const visibleFields = getSetupVisibleFields(provider);
+  const save = useMutation(
+    trpc.comms.saveAuthConfig.mutationOptions({
+      onSuccess: async (result) => {
+        await Promise.all([
+          queryClient.invalidateQueries({
+            queryKey: trpc.comms.status.queryKey(),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: trpc.linkedAccounts.telegram.queryKey(),
+          }),
+        ]);
+        if (result.telegramWebhook && !result.telegramWebhook.registered) {
+          toast.warning(
+            `Telegram was saved, but Roomote could not connect the bot: ${result.telegramWebhook.error ?? 'unknown error'}`,
+          );
+        }
+        setCredentialsSaved(true);
+      },
+      onError: (error) => toast.error(error.message),
+    }),
+  );
+  const isConfigured = credentialsSaved || provider?.setupSatisfied === true;
+  const isActionDisabled =
+    save.isPending ||
+    status.isLoading ||
+    !provider ||
+    visibleFields.some((field) => {
+      const value = getSetupEffectiveFieldValue({
+        provider,
+        field,
+        values,
+      }).trim();
+      return (
+        field.required !== false &&
+        !field.runtimeSatisfied &&
+        !field.savedSatisfied &&
+        value.length === 0
+      );
+    });
+
+  return (
+    <div className="relative w-full max-w-2xl space-y-5 py-2 md:py-0">
+      {provider && !isConfigured ? (
+        <ProviderSetupExperience
+          provider={provider}
+          values={values}
+          publicOrigin={
+            typeof window === 'undefined'
+              ? 'https://your-deployment-url'
+              : window.location.origin
+          }
+          disabled={save.isPending}
+          editingSavedValues={editingSavedValues}
+          clearedSavedValues={clearedSavedValues}
+          teamsAppPackageHref={null}
+          showManualSlackValues={false}
+          onShowManualSlackValues={() => undefined}
+          onBack={onBack}
+          onValueChange={(envVarName, value) =>
+            setValues((current) => ({ ...current, [envVarName]: value }))
+          }
+          onEditingSavedValueChange={(envVarName, editing) =>
+            setEditingSavedValues((current) => ({
+              ...current,
+              [envVarName]: editing,
+            }))
+          }
+          onClearedSavedValueChange={(envVarName, cleared) =>
+            setClearedSavedValues((current) => ({
+              ...current,
+              [envVarName]: cleared,
+            }))
+          }
+        />
+      ) : provider && isConfigured ? (
+        <div className="space-y-4">
+          <StepTitle text="Link your Telegram account" />
+          <p>
+            Open the bot and send the prefilled link command so Telegram lets
+            Roomote message you and tasks are attributed to your account.
+          </p>
+          <TelegramLinkAccountStep pollUntilLinked autoGenerate />
+        </div>
+      ) : status.isError ? (
+        <p className="text-sm text-destructive">
+          Unable to load Telegram setup. Refresh and try again.
+        </p>
+      ) : (
+        <Spinner />
+      )}
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center mt-8">
+        <Button type="button" variant="outline" onClick={onBack}>
+          <ArrowLeft />
+          Back
+        </Button>
+        <Button
+          type="button"
+          disabled={
+            isConfigured ? !telegramAccount.data?.mapping : isActionDisabled
+          }
+          onClick={() => {
+            if (isConfigured) {
+              onContinue();
+              return;
+            }
+            if (!provider) return;
+            save.mutate({
+              provider: 'telegram',
+              values: getSetupSubmitValues({ provider, values }),
+            });
+          }}
+        >
+          {save.isPending
+            ? 'Saving...'
+            : isConfigured
+              ? 'Continue'
+              : 'Save and link account'}
+          {save.isPending ? <Spinner /> : <ArrowRight />}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(onboarding)/setup/hooks.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/hooks.client.test.tsx
@@ -807,6 +807,23 @@ describe('useSetupFlow', () => {
     });
   });
 
+  it('skips the communication provider chooser after Telegram setup completes', async () => {
+    markSetupWelcomeSeen();
+    setupSessionState.session = {
+      ...setupSessionState.session,
+      communicationStep: {
+        state: 'completed',
+      },
+    };
+    mockStatus();
+
+    const { result } = renderHook(() => useSetupFlow());
+
+    await waitFor(() => {
+      expect(result.current.step).toBe('env-vars');
+    });
+  });
+
   it('skips the communication connect step when the session marks it skipped', async () => {
     setupSessionState.session = {
       ...setupSessionState.session,

--- a/apps/web/src/app/(onboarding)/setup/hooks.ts
+++ b/apps/web/src/app/(onboarding)/setup/hooks.ts
@@ -239,8 +239,9 @@ export function useSetupFlow(
   const setupSession = useSetupAsyncSession({
     currentTaskId: status?.setupNewState.onboardingTaskId ?? null,
   });
-  const communicationStepSkipped =
-    setupSession.session.communicationStep.state === 'skipped';
+  const communicationStepResolved =
+    setupSession.session.communicationStep.state === 'skipped' ||
+    setupSession.session.communicationStep.state === 'completed';
   const hasUnlockedPostOnboardingFlow = useCallback(() => {
     if (!setupSession.session.onboardingTask.postOnboardingUnlocked) {
       return false;
@@ -324,7 +325,7 @@ export function useSetupFlow(
               (hasSeenSetupWelcome() || hasRealProgress(status)))
           );
         case 'auth-provider':
-          return communicationStepSkipped || effectiveAuthProvider !== null;
+          return communicationStepResolved || effectiveAuthProvider !== null;
         case 'auth-env-vars':
           return (
             effectiveAuthProvider === null ||
@@ -386,7 +387,7 @@ export function useSetupFlow(
           return computeProviderStatus?.configSatisfied ?? false;
         }
         case 'slack':
-          if (communicationStepSkipped) {
+          if (communicationStepResolved) {
             return true;
           }
 
@@ -423,7 +424,7 @@ export function useSetupFlow(
       }
     },
     [
-      communicationStepSkipped,
+      communicationStepResolved,
       hasOnboardingProgress,
       hasPostOnboardingAccess,
       hasUnlockedPostOnboardingFlow,

--- a/apps/web/src/app/(onboarding)/setup/page.tsx
+++ b/apps/web/src/app/(onboarding)/setup/page.tsx
@@ -7,7 +7,6 @@ import { toast } from 'sonner';
 import {
   isComputeCredentialField,
   type ComputeProvider,
-  type SetupAuthProviderId,
   type SourceControlProvider,
 } from '@roomote/types';
 
@@ -29,7 +28,11 @@ import { StepAuthEnvVars } from './StepAuthEnvVars';
 import { StepBootstrapAccount } from './StepBootstrapAccount';
 import { StepBootstrapEmailPassword } from './StepBootstrapEmailPassword';
 import { StepSetupToken } from './StepSetupToken';
-import { StepAuthProvider } from './StepAuthProvider';
+import {
+  StepAuthProvider,
+  type CommunicationProviderChoice,
+} from './StepAuthProvider';
+import { StepTelegramSetup } from './StepTelegramSetup';
 import { StepInferenceProvider } from './StepInferenceProvider';
 import { StepComputeProvider } from './StepComputeProvider';
 import { StepComputeConfig } from './StepComputeConfig';
@@ -102,7 +105,7 @@ export default function SetupPage() {
     getInitialBootstrapStep,
   );
   const [pendingAuthProvider, setPendingAuthProvider] =
-    useState<SetupAuthProviderId | null>(null);
+    useState<CommunicationProviderChoice | null>(null);
   const [pendingSourceControlProvider, setPendingSourceControlProvider] =
     useState<SourceControlProvider | null>(null);
   const [pendingComputeProvider, setPendingComputeProvider] =
@@ -151,7 +154,8 @@ export default function SetupPage() {
     isError,
   } = useSetupFlow({
     enabled: isSignedIn && isAdmin,
-    pendingAuthProvider,
+    pendingAuthProvider:
+      pendingAuthProvider === 'telegram' ? null : pendingAuthProvider,
   });
   const saveSourceControlProviderChoice = useMutation(
     trpc.setupNew.saveSourceControlProviderChoice.mutationOptions({
@@ -202,7 +206,7 @@ export default function SetupPage() {
   ).some((task) => task.suggestionId !== null);
   const bootstrapAuthProvider = getBootstrapAuthProvider(
     bootstrapStatus?.authSetup,
-    pendingAuthProvider,
+    pendingAuthProvider === 'telegram' ? null : pendingAuthProvider,
   );
   const setupRetryReason = status ? getSetupRetryReason(status) : null;
   const shouldEvaluateSetupRedirect = isSignedIn && isAdmin;
@@ -278,7 +282,7 @@ export default function SetupPage() {
 
       return getNextBootstrapStep(
         bootstrapStatus.authSetup,
-        pendingAuthProvider,
+        pendingAuthProvider === 'telegram' ? null : pendingAuthProvider,
       );
     });
   }, [bootstrapStatus, isSignedIn, pendingAuthProvider, router]);
@@ -353,6 +357,7 @@ export default function SetupPage() {
         {bootstrapStep === 'auth-provider' && (
           <StepAuthProvider
             onContinue={(provider) => {
+              if (provider === 'telegram') return;
               setPendingAuthProvider(provider);
               setBootstrapStep('auth-env-vars');
             }}
@@ -403,6 +408,7 @@ export default function SetupPage() {
       {step === 'welcome' && <StepWelcome onContinue={goToNextStep} />}
       {step === 'auth-provider' && (
         <StepAuthProvider
+          includeTelegram
           onContinue={(provider) => {
             setPendingAuthProvider(provider);
             goToStep('auth-env-vars');
@@ -413,18 +419,28 @@ export default function SetupPage() {
           }}
         />
       )}
-      {step === 'auth-env-vars' && (
-        <StepAuthEnvVars
-          authSetup={status.authSetup}
-          selectedProviderId={pendingAuthProvider}
-          onContinue={() => {
-            setPendingAuthProvider(null);
-            goToNextStep();
-          }}
-          onBack={() => goToStep('auth-provider')}
-          bootstrapMode={false}
-        />
-      )}
+      {step === 'auth-env-vars' &&
+        (pendingAuthProvider === 'telegram' ? (
+          <StepTelegramSetup
+            onContinue={() => {
+              setupSession.setCommunicationStepState('completed');
+              setPendingAuthProvider(null);
+              goToNextStep();
+            }}
+            onBack={() => goToStep('auth-provider')}
+          />
+        ) : (
+          <StepAuthEnvVars
+            authSetup={status.authSetup}
+            selectedProviderId={pendingAuthProvider}
+            onContinue={() => {
+              setPendingAuthProvider(null);
+              goToNextStep();
+            }}
+            onBack={() => goToStep('auth-provider')}
+            bootstrapMode={false}
+          />
+        ))}
       {step === 'env-vars' && (
         <StepInferenceProvider
           modelSetup={status.modelSetup}

--- a/apps/web/src/components/settings/CommsProviderSection.test.tsx
+++ b/apps/web/src/components/settings/CommsProviderSection.test.tsx
@@ -629,7 +629,7 @@ describe('CommsProviderSection', () => {
       expect(screen.getByText('Create bot')).toBeInTheDocument();
       expect(screen.getByText('Bot token')).toBeInTheDocument();
       expect(screen.getByText('Threaded Mode')).toBeInTheDocument();
-      expect(screen.getByText('Webhook')).toBeInTheDocument();
+      expect(screen.queryByText('Webhook')).not.toBeInTheDocument();
       expect(screen.getByText('Enter the values below:')).toBeInTheDocument();
       expect(
         screen.getByText(/Roomote generates a webhook secret automatically/),

--- a/apps/web/src/components/settings/TelegramLinkAccountStep.test.tsx
+++ b/apps/web/src/components/settings/TelegramLinkAccountStep.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen, waitFor } from '@testing-library/react';
+
+const { createLinkCodeMock, telegramAccountMock } = vi.hoisted(() => ({
+  createLinkCodeMock: vi.fn(),
+  telegramAccountMock: vi.fn(),
+}));
+
+vi.mock('@/hooks/linked-accounts', () => ({
+  useCreateTelegramLinkCode: () => ({
+    isPending: false,
+    mutate: createLinkCodeMock,
+  }),
+  useTelegramLinkedAccount: telegramAccountMock,
+}));
+
+import { TelegramLinkAccountStep } from './TelegramLinkAccountStep';
+
+describe('TelegramLinkAccountStep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    telegramAccountMock.mockReturnValue({
+      data: { configured: true, mapping: null },
+    });
+    createLinkCodeMock.mockImplementation(
+      (_input: undefined, options: { onSuccess: (result: unknown) => void }) =>
+        options.onSuccess({
+          code: 'link-example-code',
+          expiresInSeconds: 600,
+          deepLink: 'https://t.me/roomote_bot?start=link-example-code',
+        }),
+    );
+  });
+
+  it('automatically generates the onboarding link and uses the shared copy control', async () => {
+    render(<TelegramLinkAccountStep autoGenerate pollUntilLinked />);
+
+    await waitFor(() => expect(createLinkCodeMock).toHaveBeenCalledOnce());
+    expect(screen.getByText('link-example-code')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Copy Telegram link code' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /Open the bot in Telegram/i }),
+    ).toHaveAttribute(
+      'href',
+      'https://t.me/roomote_bot?start=link-example-code',
+    );
+  });
+});

--- a/apps/web/src/components/settings/TelegramLinkAccountStep.tsx
+++ b/apps/web/src/components/settings/TelegramLinkAccountStep.tsx
@@ -1,8 +1,14 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-import { Button, Check, ExternalLink, LucideLink } from '@/components/system';
+import {
+  Button,
+  Check,
+  CopyIconButton,
+  ExternalLink,
+  LucideLink,
+} from '@/components/system';
 import {
   useCreateTelegramLinkCode,
   useTelegramLinkedAccount,
@@ -13,14 +19,39 @@ import {
  * account. The deep link opens the bot with `/start <code>`, so one tap
  * covers first contact, primary-chat capture, and account linking.
  */
-export function TelegramLinkAccountStep() {
-  const telegramAccount = useTelegramLinkedAccount();
+export function TelegramLinkAccountStep({
+  pollUntilLinked = false,
+  autoGenerate = false,
+}: {
+  pollUntilLinked?: boolean;
+  autoGenerate?: boolean;
+} = {}) {
+  const telegramAccount = useTelegramLinkedAccount({
+    refetchInterval: pollUntilLinked ? 2_000 : false,
+  });
   const createTelegramLinkCode = useCreateTelegramLinkCode();
   const [linkCode, setLinkCode] = useState<{
     code: string;
     expiresInSeconds: number;
     deepLink: string | null;
   } | null>(null);
+  const autoGenerateStarted = useRef(false);
+
+  useEffect(() => {
+    if (
+      !autoGenerate ||
+      autoGenerateStarted.current ||
+      telegramAccount.data?.mapping ||
+      telegramAccount.data?.configured !== true
+    ) {
+      return;
+    }
+
+    autoGenerateStarted.current = true;
+    createTelegramLinkCode.mutate(undefined, {
+      onSuccess: (result) => setLinkCode(result),
+    });
+  }, [autoGenerate, createTelegramLinkCode, telegramAccount.data]);
 
   if (!telegramAccount.data?.configured) {
     return null;
@@ -46,19 +77,25 @@ export function TelegramLinkAccountStep() {
   return (
     <div className="space-y-2 mt-4">
       {linkCode ? (
-        <>
+        <div className="max-w-sm space-y-3">
           <p className="text-sm">
             Send this code to the bot within{' '}
             {Math.round(linkCode.expiresInSeconds / 60)} minutes to link your
             Telegram account:
           </p>
-          <p>
-            <code className="rounded bg-muted px-2 py-1 font-mono text-sm select-all ph-no-capture">
+          <div className="flex h-10 w-full items-center gap-2 rounded-md border border-black px-3">
+            <code className="min-w-0 grow truncate font-mono text-sm select-all ph-no-capture">
               {linkCode.code}
             </code>
-          </p>
+            <CopyIconButton
+              aria-label="Copy Telegram link code"
+              content={linkCode.code}
+              tooltip="Copy link code"
+              className="shrink-0"
+            />
+          </div>
           {linkCode.deepLink && (
-            <Button asChild variant="outline" size="sm">
+            <Button asChild className="w-full">
               <a
                 href={linkCode.deepLink}
                 target="_blank"
@@ -69,7 +106,9 @@ export function TelegramLinkAccountStep() {
               </a>
             </Button>
           )}
-        </>
+        </div>
+      ) : createTelegramLinkCode.isPending ? (
+        <p className="text-sm">Generating your Telegram link…</p>
       ) : (
         <>
           <p className="text-sm">

--- a/apps/web/src/hooks/linked-accounts/useTelegramLinkedAccount.ts
+++ b/apps/web/src/hooks/linked-accounts/useTelegramLinkedAccount.ts
@@ -2,8 +2,14 @@ import { useQuery } from '@tanstack/react-query';
 
 import { useTRPC } from '@/trpc/client';
 
-export const useTelegramLinkedAccount = () => {
+export const useTelegramLinkedAccount = (options?: {
+  refetchInterval?: number | false;
+}) => {
   const trpc = useTRPC();
 
-  return useQuery(trpc.linkedAccounts.telegram.queryOptions());
+  return useQuery(
+    trpc.linkedAccounts.telegram.queryOptions(undefined, {
+      refetchInterval: options?.refetchInterval,
+    }),
+  );
 };

--- a/apps/web/src/trpc/commands/setup-new/index.test.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.test.ts
@@ -1059,6 +1059,10 @@ describe('setup-new onboarding task start command', () => {
       channelId: '8846357662',
       messageId: '900',
     }));
+    const telegramCreateForumTopic = vi.fn(async () => ({
+      messageThreadId: '77',
+      name: 'Set up Roomote',
+    }));
 
     vi.mocked(resolveTelegramRuntimeCredentials).mockResolvedValue({
       botToken: 'bot-token',
@@ -1070,6 +1074,8 @@ describe('setup-new onboarding task start command', () => {
       this: unknown,
     ) {
       return {
+        getBotInfo: vi.fn(async () => ({ hasTopicsEnabled: true })),
+        createForumTopic: telegramCreateForumTopic,
         postMessage: telegramPostMessage,
       } as unknown as TelegramCommunicationProvider;
     });
@@ -1078,8 +1084,15 @@ describe('setup-new onboarding task start command', () => {
 
     expect(result.taskId).toBe('task-onboarding-1');
     expect(telegramPostMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ channelId: '8846357662' }),
+      expect.objectContaining({
+        channelId: '8846357662',
+        threadId: '77',
+      }),
     );
+    expect(telegramCreateForumTopic).toHaveBeenCalledWith({
+      channelId: '8846357662',
+      name: 'Set up Roomote',
+    });
     expect(SlackNotifier).not.toHaveBeenCalled();
     expect(enqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1091,6 +1104,8 @@ describe('setup-new onboarding task start command', () => {
             communicationProvider: 'telegram',
             communicationChannelId: '8846357662',
             communicationMessageId: '900',
+            communicationThreadId: '77',
+            telegramTaskTopic: true,
           }),
         }),
         initiator: { kind: 'user', userId: 'setup-test-user' },
@@ -1106,7 +1121,7 @@ describe('setup-new onboarding task start command', () => {
           slackChannel: null,
           chatHandoffProvider: 'telegram',
           chatHandoffChannelId: '8846357662',
-          chatHandoffThreadId: '900',
+          chatHandoffThreadId: '77',
           chatHandoffServiceUrl: null,
         }),
       }),

--- a/apps/web/src/trpc/commands/setup-new/index.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.ts
@@ -914,11 +914,7 @@ export async function launchQueuedSetupTasksIfReady({
       ? {
           communicationProvider: nonSlackChatHandoffProvider,
           communicationChannelId: chatHandoffChannelId,
-          // Telegram treats communicationThreadId as a forum-topic
-          // message_thread_id, which the private primary chat does not have,
-          // so only Teams threads starter-task replies under the kickoff
-          // message.
-          ...(nonSlackChatHandoffProvider === 'teams' && chatHandoffThreadId
+          ...(chatHandoffThreadId
             ? { communicationThreadId: chatHandoffThreadId }
             : {}),
           ...(chatHandoffServiceUrl
@@ -2251,13 +2247,30 @@ export async function startSetupNewOnboardingTaskCommand(
         const kickoffMessage = buildSetupKickoffText();
         let kickoffMessageId: string | null = null;
         let kickoffChannelId: string | null = null;
+        let kickoffThreadId: string | null = null;
 
         if (fallbackTarget.provider === 'telegram') {
           const telegram = new TelegramCommunicationProvider({
             botToken: fallbackTarget.botToken,
           });
+          try {
+            const { hasTopicsEnabled } = await telegram.getBotInfo();
+            if (hasTopicsEnabled) {
+              const topic = await telegram.createForumTopic({
+                channelId: fallbackTarget.chatId,
+                name: 'Set up Roomote',
+              });
+              kickoffThreadId = topic.messageThreadId;
+            }
+          } catch (error) {
+            console.warn(
+              '[setup-new] Could not create a Telegram topic for the setup task; falling back to the primary chat.',
+              error,
+            );
+          }
           const posted = await telegram.postMessage({
             channelId: fallbackTarget.chatId,
+            ...(kickoffThreadId ? { threadId: kickoffThreadId } : {}),
             text: kickoffMessage,
             textFormat: 'markdown',
           });
@@ -2317,6 +2330,12 @@ export async function startSetupNewOnboardingTaskCommand(
                 communicationProvider: fallbackTarget.provider,
                 communicationChannelId: kickoffChannelId,
                 communicationMessageId: kickoffMessageId,
+                ...(kickoffThreadId
+                  ? {
+                      communicationThreadId: kickoffThreadId,
+                      telegramTaskTopic: true,
+                    }
+                  : {}),
                 ...(fallbackTarget.provider === 'teams'
                   ? {
                       communicationThreadId: kickoffMessageId,
@@ -2349,7 +2368,9 @@ export async function startSetupNewOnboardingTaskCommand(
               slackThreadTs: null,
               chatHandoffProvider: fallbackTarget.provider,
               chatHandoffChannelId: kickoffChannelId,
-              chatHandoffThreadId: kickoffMessageId,
+              chatHandoffThreadId:
+                kickoffThreadId ??
+                (fallbackTarget.provider === 'teams' ? kickoffMessageId : null),
               chatHandoffServiceUrl:
                 fallbackTarget.provider === 'teams'
                   ? fallbackTarget.serviceUrl

--- a/packages/communication/src/__tests__/mock-telegram-server.test.ts
+++ b/packages/communication/src/__tests__/mock-telegram-server.test.ts
@@ -126,7 +126,7 @@ describe('MockTelegramServer', () => {
     ).rejects.toThrow('chat is not a forum');
   });
 
-  it('stores a bot message posted through the real provider and anchors the reply', async () => {
+  it('stores a bot message without quoting the inbound message', async () => {
     const { server, baseUrl } = await startServer();
     onCleanup(() => server.stop());
 
@@ -143,11 +143,11 @@ describe('MockTelegramServer', () => {
     const botMessage = messages.find((m) => m.from.is_bot);
     expect(botMessage).toBeDefined();
     expect(botMessage?.text).toBe('On it — taking a look now.');
-    expect(botMessage?.reply_to_message_id).toBe(1000);
+    expect(botMessage?.reply_to_message_id).toBeUndefined();
     expect(result.messageId).toBe(String(botMessage?.message_id));
   });
 
-  it('splits long markdown into multiple messages under the 4096 limit with reply on first and buttons on last', async () => {
+  it('splits long markdown into multiple unquoted messages with buttons on the last', async () => {
     const { server, baseUrl } = await startServer();
     onCleanup(() => server.stop());
 
@@ -174,9 +174,8 @@ describe('MockTelegramServer', () => {
       );
     }
 
-    expect(botMessages[0]?.reply_to_message_id).toBe(1000);
     expect(
-      botMessages.slice(1).every((m) => m.reply_to_message_id === undefined),
+      botMessages.every((message) => message.reply_to_message_id === undefined),
     ).toBe(true);
 
     const withButtons = botMessages.filter((m) => m.reply_markup !== undefined);

--- a/packages/communication/src/__tests__/telegram-provider.test.ts
+++ b/packages/communication/src/__tests__/telegram-provider.test.ts
@@ -104,7 +104,7 @@ describe('TelegramCommunicationProvider', () => {
     );
   });
 
-  it('sends Telegram messages through the Bot API', async () => {
+  it('sends topic messages without duplicative reply quotes', async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(
       jsonResponse({
         ok: true,
@@ -146,10 +146,6 @@ describe('TelegramCommunicationProvider', () => {
             is_disabled: true,
           },
           message_thread_id: 7,
-          reply_parameters: {
-            message_id: 42,
-            allow_sending_without_reply: true,
-          },
         }),
       }),
     );
@@ -262,7 +258,7 @@ describe('TelegramCommunicationProvider', () => {
       (fetchMock.mock.calls[1]?.[1] as RequestInit).body as string,
     ) as { reply_parameters?: unknown };
 
-    expect(firstBody.reply_parameters).toBeDefined();
+    expect(firstBody.reply_parameters).toBeUndefined();
     expect(secondBody.reply_parameters).toBeUndefined();
   });
 
@@ -338,7 +334,7 @@ describe('TelegramCommunicationProvider', () => {
       (fetchMock.mock.calls[0]?.[1] as RequestInit).body as string,
     ) as { reply_parameters?: { message_id: number } };
 
-    expect(photoBody.reply_parameters?.message_id).toBe(42);
+    expect(photoBody.reply_parameters).toBeUndefined();
   });
 
   it('falls back to a link message when sendPhoto fails', async () => {

--- a/packages/communication/src/telegram-provider.ts
+++ b/packages/communication/src/telegram-provider.ts
@@ -101,7 +101,10 @@ export class TelegramCommunicationProvider implements CommunicationProviderAdapt
     }
 
     const threadId = parsePositiveInteger(input.threadId);
-    const replyToMessageId = parsePositiveInteger(input.replyToMessageId);
+    // Telegram's chronological chat already provides enough context. Quoting
+    // every inbound message duplicates the transcript and overwhelms both
+    // topic and non-topic conversations.
+    const replyToMessageId = undefined;
     const useMarkdown = input.textFormat === 'markdown';
     const chunks: Array<{ markdown: string; html: string | null }> = text
       ? useMarkdown

--- a/packages/sdk/src/server/lib/suggested-tasks-onboarding-followup.ts
+++ b/packages/sdk/src/server/lib/suggested-tasks-onboarding-followup.ts
@@ -138,6 +138,7 @@ export const TELEGRAM_SUGGESTED_TASKS_ONBOARDING_FOLLOWUP_QUEUE_NAME =
 
 export const telegramSuggestedTasksOnboardingFollowupRequestSchema = z.object({
   chatId: z.string(),
+  threadId: z.string().optional(),
   introMessageId: z.string(),
   sourceTaskId: z.string(),
 });


### PR DESCRIPTION
## Summary
- add Telegram alongside Slack and Microsoft Teams in the signed-in communication provider chooser
- route Telegram into the guided BotFather and token-only setup experience
- save Telegram credentials and register the webhook through the existing communications setup command
- continue onboarding without treating Telegram as an authentication provider

## Validation
- focused onboarding tests
- web TypeScript check
- web lint
- pre-push lint, typecheck, and knip gates