### PR TITLE
Improve Telegram reliability and attachment handling

### DIFF
--- a/.changeset/bright-telegram-attachments.md
+++ b/.changeset/bright-telegram-attachments.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': minor
+---
+
+Improve Telegram reliability with automatic slash-command registration, bounded Bot API retries, persistent bot identity caching, photo and document task inputs, and repairable connection diagnostics.

--- a/apps/api/src/handlers/telegram/__tests__/index.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/index.test.ts
@@ -9,6 +9,7 @@ const {
   taskRunsFindFirstMock,
   consumeLinkCodeMock,
   createForumTopicMock,
+  downloadFileMock,
   restoreLinkCodeMock,
   editMessageReplyMarkupMock,
   editMessageTextMock,
@@ -43,6 +44,7 @@ const {
   taskRunsFindFirstMock: vi.fn(),
   consumeLinkCodeMock: vi.fn(),
   createForumTopicMock: vi.fn(),
+  downloadFileMock: vi.fn(),
   restoreLinkCodeMock: vi.fn(),
   editMessageReplyMarkupMock: vi.fn(),
   editMessageTextMock: vi.fn(),
@@ -247,6 +249,7 @@ vi.mock('@roomote/communication/telegram-provider', () => ({
       addReaction: addReactionMock,
       answerCallbackQuery: answerCallbackQueryMock,
       createForumTopic: createForumTopicMock,
+      downloadFile: downloadFileMock,
       getBotInfo: getBotInfoMock,
       editMessageReplyMarkup: editMessageReplyMarkupMock,
       editMessageText: editMessageTextMock,
@@ -333,6 +336,11 @@ describe('Telegram webhook handler', () => {
     // later tests do not inherit stale values when the whole suite runs.
     authUsersFindFirstMock.mockReset();
     usersFindFirstMock.mockReset();
+    downloadFileMock.mockResolvedValue({
+      bytes: new Uint8Array([1, 2, 3]),
+      filePath: 'photos/example.jpg',
+      contentType: 'image/jpeg',
+    });
     taskRunsFindFirstMock.mockReset();
     telegramMappingsFindFirstMock.mockReset();
     consumeLinkCodeMock.mockReset();
@@ -647,6 +655,48 @@ describe('Telegram webhook handler', () => {
       runId: 77,
       userId: 'launch-owner-1',
     });
+  });
+
+  it('queues a captioned photo as an active-run follow-up', async () => {
+    mockTelegramLinkedSender();
+    taskRunsFindFirstMock.mockResolvedValueOnce({
+      id: 77,
+      status: 'running',
+      machineId: 'machine-1',
+      taskId: 'task-1',
+      payload: {},
+    });
+
+    const response = await postTelegramUpdate(
+      createTelegramUpdate({
+        message: {
+          text: undefined,
+          caption: 'What can you see here?',
+          photo: [
+            {
+              file_id: 'photo-large',
+              file_unique_id: 'photo-1',
+              width: 1280,
+              height: 720,
+            },
+          ],
+        },
+      }),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      queued: true,
+      runId: 77,
+    });
+    expect(queueCommunicationMessageMock).toHaveBeenCalledWith(
+      'telegram',
+      77,
+      expect.objectContaining({
+        text: 'What can you see here?',
+        images: ['data:image/jpeg;base64,AQID'],
+      }),
+    );
   });
 
   it('starts new Telegram tasks as the linked sender', async () => {
@@ -1699,7 +1749,7 @@ describe('Telegram webhook handler', () => {
     );
   });
 
-  it('launches immediately when routing confidence is high', async () => {
+  it('launches immediately from a captioned photo when routing confidence is high', async () => {
     mockTelegramLinkedSender('launch-owner-22');
     getAvailableEnvironmentsMock.mockResolvedValue([
       { id: 'env-1', name: 'Web App', repositoryNames: ['org/web'] },
@@ -1720,7 +1770,20 @@ describe('Telegram webhook handler', () => {
     });
 
     const response = await postTelegramUpdate(
-      createTelegramUpdate({ message: { text: 'fix the login bug' } }),
+      createTelegramUpdate({
+        message: {
+          text: undefined,
+          caption: 'fix the login bug',
+          photo: [
+            {
+              file_id: 'photo-large',
+              file_unique_id: 'photo-1',
+              width: 1280,
+              height: 720,
+            },
+          ],
+        },
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -1728,12 +1791,16 @@ describe('Telegram webhook handler', () => {
       started: true,
       runId: 88,
     });
+    expect(buildTelegramRoutingContextMock).toHaveBeenCalledWith(
+      expect.objectContaining({ images: ['data:image/jpeg;base64,AQID'] }),
+    );
     expect(enqueueTaskMock).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
           payload: expect.objectContaining({
             repo: 'org/web',
             environmentId: 'env-1',
+            images: ['data:image/jpeg;base64,AQID'],
           }),
         }),
       }),

--- a/apps/api/src/handlers/telegram/attachments.ts
+++ b/apps/api/src/handlers/telegram/attachments.ts
@@ -1,0 +1,80 @@
+import {
+  appendAttachmentTextsToPromptText,
+  isRoomoteTextExtractableAttachment,
+} from '@roomote/cloud-agents';
+import { extractPromptTextAttachments } from '@roomote/cloud-agents/server';
+import { TelegramCommunicationProvider } from '@roomote/communication/telegram-provider';
+import type { TelegramMessage } from '@roomote/communication/telegram-update';
+import { formatErrorForLog } from '@roomote/types';
+
+import type { QueuedTelegramCommunicationMessage } from './types.js';
+
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+const MAX_DOCUMENT_BYTES = 20 * 1024 * 1024;
+
+export async function attachTelegramMediaToQueuedMessage(input: {
+  message: TelegramMessage;
+  queuedMessage: QueuedTelegramCommunicationMessage;
+  botToken: string;
+}): Promise<QueuedTelegramCommunicationMessage> {
+  const provider = new TelegramCommunicationProvider({
+    botToken: input.botToken,
+  });
+  const images: string[] = [];
+  const attachmentTexts: string[] = [];
+
+  try {
+    const photo = input.message.photo?.at(-1);
+    if (photo) {
+      const downloaded = await provider.downloadFile(
+        photo.file_id,
+        MAX_IMAGE_BYTES,
+      );
+      const downloadedMimeType = downloaded.contentType?.split(';')[0];
+      const mimeType = downloadedMimeType?.startsWith('image/')
+        ? downloadedMimeType
+        : 'image/jpeg';
+      images.push(
+        `data:${mimeType};base64,${Buffer.from(downloaded.bytes).toString('base64')}`,
+      );
+    }
+
+    const document = input.message.document;
+    if (
+      document &&
+      isRoomoteTextExtractableAttachment({
+        filename: document.file_name,
+        mimeType: document.mime_type,
+      })
+    ) {
+      const downloaded = await provider.downloadFile(
+        document.file_id,
+        MAX_DOCUMENT_BYTES,
+      );
+      const extracted = await extractPromptTextAttachments([
+        {
+          filename: document.file_name ?? downloaded.filePath,
+          mimeType: document.mime_type ?? downloaded.contentType ?? undefined,
+          bytes: downloaded.bytes,
+        },
+      ]);
+      attachmentTexts.push(...extracted.attachmentTexts);
+      for (const warning of extracted.warnings) {
+        console.warn(`[telegram] Attachment extraction warning: ${warning}`);
+      }
+    }
+  } catch (error) {
+    console.warn(
+      `[telegram] Failed to process inbound attachment: ${formatErrorForLog(error)}`,
+    );
+  }
+
+  return {
+    ...input.queuedMessage,
+    text: appendAttachmentTextsToPromptText({
+      text: input.queuedMessage.text,
+      attachmentTexts,
+    }),
+    ...(images.length ? { images } : {}),
+  };
+}

--- a/apps/api/src/handlers/telegram/index.ts
+++ b/apps/api/src/handlers/telegram/index.ts
@@ -64,6 +64,7 @@ import {
   startNewTelegramTask,
 } from './task-orchestration.js';
 import type { QueuedTelegramCommunicationMessage } from './types.js';
+import { attachTelegramMediaToQueuedMessage } from './attachments.js';
 import {
   claimTelegramLinkNudge,
   claimTelegramUpdate,
@@ -266,7 +267,7 @@ telegram.post('/', async (c) => {
     return c.json({ ok: true, welcomed: true });
   }
 
-  const { botUsername } = await resolveTelegramRuntimeCredentials();
+  const { botToken, botUsername } = await resolveTelegramRuntimeCredentials();
 
   if (!senderUserId) {
     // Nudge the sender to link instead of silently dropping their message.
@@ -339,10 +340,22 @@ telegram.post('/', async (c) => {
     });
   }
 
-  const queuedMessage = telegramUpdateToQueuedCommunicationMessage(update, {
+  let queuedMessage = telegramUpdateToQueuedCommunicationMessage(update, {
     botUsername: botUsername ?? undefined,
     userId: senderUserId,
   }) as QueuedTelegramCommunicationMessage | null;
+
+  if (
+    queuedMessage &&
+    botToken &&
+    (message.photo?.length || message.document)
+  ) {
+    queuedMessage = await attachTelegramMediaToQueuedMessage({
+      message,
+      queuedMessage,
+      botToken,
+    });
+  }
 
   const metadata = getTelegramUpdateCommunicationMetadata(update);
   const conversation = {

--- a/apps/api/src/handlers/telegram/task-launch.ts
+++ b/apps/api/src/handlers/telegram/task-launch.ts
@@ -124,6 +124,9 @@ export async function launchTelegramTask(input: {
           ? { environmentId: input.workspace.environmentId }
           : {}),
         description: input.queuedMessage.text,
+        ...(input.queuedMessage.images?.length
+          ? { images: input.queuedMessage.images }
+          : {}),
         ...metadata,
         ...(createdTopic ? { telegramTaskTopic: true } : {}),
       },

--- a/apps/api/src/handlers/telegram/task-orchestration.ts
+++ b/apps/api/src/handlers/telegram/task-orchestration.ts
@@ -157,6 +157,9 @@ export async function startNewTelegramTask(input: {
         text: input.queuedMessage.text,
       },
     ],
+    ...(input.queuedMessage.images?.length
+      ? { images: input.queuedMessage.images }
+      : {}),
     apiBaseUrl: Env.TRPC_URL ?? Env.R_APP_URL,
   });
   const routingDecision = await routeTask(routingContext);

--- a/apps/docs/providers/communications/telegram.mdx
+++ b/apps/docs/providers/communications/telegram.mdx
@@ -17,9 +17,10 @@ Use `<public-url>` below for your stable public Roomote URL.
 ## Create a Telegram bot
 
 Message `@BotFather` in Telegram and create or select a bot. In the Roomote UI
-(**Settings > Communications > Telegram**), enter the bot token and optional
-username, then save. Roomote generates a webhook secret and registers the Bot
-API webhook for you.
+(**Settings > Communications > Telegram**), enter the bot token, then save.
+Roomote reads the bot identity from Telegram, generates a webhook secret,
+registers the Bot API webhook, and adds `/start` and `/new` to the bot's command
+menu for you.
 
 In BotFather, open **Bot Settings > Threaded Mode** and enable it. Roomote will
 then create a separate topic in your private bot chat for each new task. If
@@ -55,6 +56,8 @@ header, and outbound replies use `R_TELEGRAM_BOT_TOKEN`.
 When you save Telegram credentials in Roomote, the webhook is registered
 automatically at `<public-url>/api/webhooks/telegram` with the managed secret
 token and `allowed_updates` including `message` and `callback_query`.
+If the connection check reports a mismatch, delivery error, or stale update
+configuration, use **Repair** in Telegram settings to re-register it.
 
 If you are bootstrapping only from env vars and need to register manually
 before the first UI save:
@@ -87,6 +90,10 @@ up on tasks on their behalf.
 2. confirm Roomote starts a task and posts a Telegram reply with the task link
 3. confirm a new task opens in its own topic when Threaded Mode is enabled
 4. reply in that topic to send a follow-up
+
+Photos are passed to the task as image input. Supported text documents are
+downloaded server-side and their extracted content is added to the request;
+the bot token is never included in the task prompt or attachment URL.
 
 ## Local URL changes
 

--- a/apps/web/src/components/settings/CommsProviderSection.test.tsx
+++ b/apps/web/src/components/settings/CommsProviderSection.test.tsx
@@ -136,7 +136,10 @@ vi.mock('@tanstack/react-query', () => ({
       });
     },
   }),
-  useQueryClient: () => ({ setQueryData: vi.fn() }),
+  useQueryClient: () => ({
+    setQueryData: vi.fn(),
+    invalidateQueries: vi.fn(),
+  }),
 }));
 
 vi.mock('@/hooks/slack', () => ({
@@ -181,6 +184,12 @@ vi.mock('@/trpc/client', () => ({
   useTRPC: () => ({
     slack: {
       installation: { queryKey: () => ['slack', 'installation'] },
+    },
+    comms: {
+      status: { queryKey: () => ['comms', 'status'] },
+      repairTelegram: {
+        mutationOptions: (options: unknown) => options,
+      },
     },
     routerDebug: {
       getSettings: {

--- a/apps/web/src/components/settings/CommsProviderSection.tsx
+++ b/apps/web/src/components/settings/CommsProviderSection.tsx
@@ -27,6 +27,8 @@ type TelegramWebhookStatus = {
   registeredUrl: string | null;
   expectedUrl: string;
   lastErrorMessage: string | null;
+  pendingUpdateCount?: number;
+  lastErrorAtMs?: number | null;
 };
 type TelegramCommsProviderStatus = Omit<SetupAuthProviderStatus, 'id'> & {
   id: CommsProviderId;
@@ -488,6 +490,19 @@ export function CommsProviderSection({
   savePending,
   clearPending,
 }: CommsProviderSectionProps) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const repairTelegram = useMutation(
+    trpc.comms.repairTelegram.mutationOptions({
+      onSuccess: async () => {
+        toast.success('Telegram connection repaired');
+        await queryClient.invalidateQueries({
+          queryKey: trpc.comms.status.queryKey(),
+        });
+      },
+      onError: (error) => toast.error(error.message),
+    }),
+  );
   const isMicrosoftProvider = provider.id === 'microsoft';
   const teamsIntegrationStatus = useTeamsIntegrationStatus({
     enabled: isMicrosoftProvider,
@@ -743,7 +758,22 @@ export function CommsProviderSection({
                     provider.telegramWebhook.lastErrorMessage
                       ? ` Last delivery error: ${provider.telegramWebhook.lastErrorMessage}`
                       : ''}
+                    {(provider.telegramWebhook.pendingUpdateCount ?? 0) > 0
+                      ? ` ${provider.telegramWebhook.pendingUpdateCount} update${provider.telegramWebhook.pendingUpdateCount === 1 ? '' : 's'} waiting for delivery.`
+                      : ''}
                   </p>
+                  {provider.telegramWebhook.status !== 'connected' ? (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={repairTelegram.isPending}
+                      onClick={() => repairTelegram.mutate()}
+                    >
+                      <RefreshCw />
+                      {repairTelegram.isPending ? 'Repairing...' : 'Repair'}
+                    </Button>
+                  ) : null}
                 </div>
               )}
               {provider.id === 'telegram' && hasConfiguredValues && (

--- a/apps/web/src/trpc/commands/comms/index.test.ts
+++ b/apps/web/src/trpc/commands/comms/index.test.ts
@@ -13,6 +13,8 @@ const {
   mockResolveInvocationIdentities,
   mockResolveTelegramRuntimeCredentials,
   mockTelegramGetWebhookInfo,
+  mockTelegramRegisterCommands,
+  mockTelegramRegisterWebhook,
 } = vi.hoisted(() => ({
   mockDbDelete: vi.fn(() => ({
     where: vi.fn(async () => undefined),
@@ -30,6 +32,8 @@ const {
     botUsername: null as string | null,
   })),
   mockTelegramGetWebhookInfo: vi.fn(),
+  mockTelegramRegisterCommands: vi.fn(),
+  mockTelegramRegisterWebhook: vi.fn(),
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -61,7 +65,8 @@ vi.mock('@roomote/db/server', () => ({
 vi.mock('@roomote/communication/telegram-provider', () => ({
   TelegramCommunicationProvider: class {
     getWebhookInfo = mockTelegramGetWebhookInfo;
-    registerWebhook = vi.fn();
+    registerWebhook = mockTelegramRegisterWebhook;
+    registerCommands = mockTelegramRegisterCommands;
   },
 }));
 
@@ -87,6 +92,7 @@ import {
   classifyTelegramWebhookCheckError,
   clearCommsAuthConfigCommand,
   getCommsStatusCommand,
+  repairTelegramWebhookCommand,
   saveCommsAuthConfigCommand,
 } from './index';
 
@@ -220,6 +226,8 @@ describe('comms commands', () => {
         expectedUrl: 'https://app.example.com/api/webhooks/telegram',
         lastErrorMessage:
           'Telegram rejected the bot token. Check the token from BotFather and save again.',
+        pendingUpdateCount: 0,
+        lastErrorAtMs: null,
       });
     });
   });
@@ -448,6 +456,23 @@ describe('comms commands', () => {
       expect(username).toBeUndefined();
       expect(token?.savedValue).toBeNull();
     });
+  });
+
+  it('repairs the webhook and refreshes the slash command menu', async () => {
+    mockResolveTelegramRuntimeCredentials.mockResolvedValue({
+      botToken: 'token',
+      webhookSecret: 'secret',
+      botUsername: 'RoomoteBot',
+    });
+
+    await expect(
+      repairTelegramWebhookCommand(buildMockAuth()),
+    ).resolves.toEqual({ repaired: true });
+    expect(mockTelegramRegisterWebhook).toHaveBeenCalledWith({
+      url: 'https://app.example.com/api/webhooks/telegram',
+      secretToken: 'secret',
+    });
+    expect(mockTelegramRegisterCommands).toHaveBeenCalledOnce();
   });
 
   describe('clearCommsAuthConfigCommand', () => {

--- a/apps/web/src/trpc/commands/comms/index.ts
+++ b/apps/web/src/trpc/commands/comms/index.ts
@@ -64,6 +64,8 @@ type TelegramWebhookStatus = {
   registeredUrl: string | null;
   expectedUrl: string;
   lastErrorMessage: string | null;
+  pendingUpdateCount: number;
+  lastErrorAtMs: number | null;
 };
 
 const TELEGRAM_WEBHOOK_REQUIRED_UPDATES = ['message', 'callback_query'];
@@ -167,6 +169,8 @@ async function getTelegramWebhookStatus(): Promise<TelegramWebhookStatus | null>
         registeredUrl: null,
         expectedUrl,
         lastErrorMessage: info.lastErrorMessage,
+        pendingUpdateCount: info.pendingUpdateCount,
+        lastErrorAtMs: info.lastErrorAtMs,
       };
     }
 
@@ -176,6 +180,8 @@ async function getTelegramWebhookStatus(): Promise<TelegramWebhookStatus | null>
         registeredUrl: info.url,
         expectedUrl,
         lastErrorMessage: info.lastErrorMessage,
+        pendingUpdateCount: info.pendingUpdateCount,
+        lastErrorAtMs: info.lastErrorAtMs,
       };
     }
 
@@ -188,6 +194,8 @@ async function getTelegramWebhookStatus(): Promise<TelegramWebhookStatus | null>
       registeredUrl: info.url,
       expectedUrl,
       lastErrorMessage: info.lastErrorMessage,
+      pendingUpdateCount: info.pendingUpdateCount,
+      lastErrorAtMs: info.lastErrorAtMs,
     };
   } catch (error) {
     return {
@@ -195,6 +203,8 @@ async function getTelegramWebhookStatus(): Promise<TelegramWebhookStatus | null>
       registeredUrl: null,
       expectedUrl,
       lastErrorMessage: classifyTelegramWebhookCheckError(error),
+      pendingUpdateCount: 0,
+      lastErrorAtMs: null,
     };
   }
 }
@@ -222,10 +232,13 @@ async function registerTelegramWebhookBestEffort(): Promise<TelegramWebhookRegis
   });
 
   try {
-    await provider.registerWebhook({
-      url: buildExpectedTelegramWebhookUrl(),
-      secretToken: webhookSecret,
-    });
+    await Promise.all([
+      provider.registerWebhook({
+        url: buildExpectedTelegramWebhookUrl(),
+        secretToken: webhookSecret,
+      }),
+      provider.registerCommands(),
+    ]);
 
     return { registered: true, error: null };
   } catch (error) {
@@ -234,6 +247,15 @@ async function registerTelegramWebhookBestEffort(): Promise<TelegramWebhookRegis
       error: classifyTelegramWebhookCheckError(error),
     };
   }
+}
+
+export async function repairTelegramWebhookCommand(auth: UserAuthSuccess) {
+  assertAdmin(auth);
+  const result = await registerTelegramWebhookBestEffort();
+  if (!result.registered) {
+    throw new Error(result.error ?? 'Could not repair Telegram connection.');
+  }
+  return { repaired: true };
 }
 
 function withTelegramProvider(

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -237,6 +237,7 @@ import {
   getCommsStatusCommand,
   saveCommsAuthConfigCommand,
   clearCommsAuthConfigCommand,
+  repairTelegramWebhookCommand,
 } from '../commands/comms';
 import {
   getComputeStatusCommand,
@@ -1310,6 +1311,10 @@ export const appRouter = createRouter({
       .mutation(({ ctx: { auth }, input }) =>
         clearCommsAuthConfigCommand(auth, input),
       ),
+
+    repairTelegram: protectedProcedure.mutation(({ ctx: { auth } }) =>
+      repairTelegramWebhookCommand(auth),
+    ),
   }),
 
   compute: createRouter({

--- a/packages/communication/src/__tests__/mock-telegram-server.test.ts
+++ b/packages/communication/src/__tests__/mock-telegram-server.test.ts
@@ -75,6 +75,18 @@ describe('MockTelegramServer', () => {
     cleanups.push(fn);
   }
 
+  it('stores the configured slash command menu', async () => {
+    const { server, baseUrl } = await startServer();
+    onCleanup(() => server.stop());
+
+    await providerFor(baseUrl).registerCommands();
+
+    expect(server.getState().botCommands).toEqual([
+      { command: 'start', description: 'Show welcome and command help' },
+      { command: 'new', description: 'Start a fresh task' },
+    ]);
+  });
+
   it('creates topics in private chats when the bot has Threaded Mode enabled', async () => {
     const state = baseState();
     state.bot = { ...state.bot!, has_topics_enabled: true };

--- a/packages/communication/src/__tests__/telegram-provider.test.ts
+++ b/packages/communication/src/__tests__/telegram-provider.test.ts
@@ -52,6 +52,25 @@ describe('TelegramCommunicationProvider', () => {
     });
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
+
+  it('does not retry an ambiguous server error for message delivery', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ ok: false }, 500))
+      .mockResolvedValueOnce(
+        jsonResponse({ ok: true, result: { message_id: 99 } }),
+      );
+    const provider = new TelegramCommunicationProvider({
+      botToken: 'bot-token',
+      apiBaseUrl: 'https://telegram.example.test',
+      fetch: fetchMock as typeof fetch,
+    });
+
+    await expect(
+      provider.postMessage({ channelId: '123', text: 'hello' }),
+    ).rejects.toThrow('Telegram sendMessage failed (500)');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
   it('reads the private-chat topics capability from getMe', async () => {
     const fetchMock = vi
       .fn()

--- a/packages/communication/src/__tests__/telegram-provider.test.ts
+++ b/packages/communication/src/__tests__/telegram-provider.test.ts
@@ -13,6 +13,45 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 describe('TelegramCommunicationProvider', () => {
+  it('registers the supported slash commands', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ ok: true, result: true }));
+    const provider = new TelegramCommunicationProvider({
+      botToken: 'bot-token',
+      apiBaseUrl: 'https://telegram.example.test',
+      fetch: fetchMock as typeof fetch,
+    });
+
+    await provider.registerCommands();
+
+    expect(JSON.parse(fetchMock.mock.calls[0]![1]!.body as string)).toEqual({
+      commands: [
+        { command: 'start', description: 'Show welcome and command help' },
+        { command: 'new', description: 'Start a fresh task' },
+      ],
+    });
+  });
+
+  it('retries transient idempotent Bot API failures', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ ok: false }, 500))
+      .mockResolvedValueOnce(
+        jsonResponse({ ok: true, result: { has_topics_enabled: false } }),
+      );
+    const provider = new TelegramCommunicationProvider({
+      botToken: 'bot-token',
+      apiBaseUrl: 'https://telegram.example.test',
+      fetch: fetchMock as typeof fetch,
+      maxRetries: 1,
+    });
+
+    await expect(provider.getBotInfo()).resolves.toEqual({
+      hasTopicsEnabled: false,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
   it('reads the private-chat topics capability from getMe', async () => {
     const fetchMock = vi
       .fn()

--- a/packages/communication/src/__tests__/telegram-update.test.ts
+++ b/packages/communication/src/__tests__/telegram-update.test.ts
@@ -330,6 +330,30 @@ describe('Telegram update helpers', () => {
     ).toBe(true);
   });
 
+  it('treats an attachment-only private message as task input', () => {
+    const parsed = parseTelegramUpdate({
+      update_id: 4001,
+      message: {
+        message_id: 70,
+        chat: { id: 5, type: 'private' },
+        photo: [
+          {
+            file_id: 'photo-large',
+            file_unique_id: 'photo-1',
+            width: 1280,
+            height: 720,
+          },
+        ],
+      },
+    });
+
+    expect(parsed.success).toBe(true);
+    expect(isTelegramTaskEntryUpdate(parsed.data!)).toBe(true);
+    expect(
+      telegramUpdateToQueuedCommunicationMessage(parsed.data!),
+    ).toMatchObject({ text: 'Image attachment' });
+  });
+
   describe('getTelegramNewTaskCommand', () => {
     const buildUpdate = (
       text: string,

--- a/packages/communication/src/__tests__/telegram-update.test.ts
+++ b/packages/communication/src/__tests__/telegram-update.test.ts
@@ -354,6 +354,40 @@ describe('Telegram update helpers', () => {
     ).toMatchObject({ text: 'Image attachment' });
   });
 
+  it('strips bot mentions from group media captions', () => {
+    const buildCaptionUpdate = (caption: string) =>
+      parseTelegramUpdate({
+        update_id: 4002,
+        message: {
+          message_id: 71,
+          chat: { id: -1007, type: 'group', title: 'Engineering' },
+          caption,
+          caption_entities: [{ type: 'mention', offset: 0, length: 12 }],
+          photo: [
+            {
+              file_id: 'photo-large',
+              file_unique_id: 'photo-1',
+              width: 1280,
+              height: 720,
+            },
+          ],
+        },
+      }).data!;
+
+    expect(
+      telegramUpdateToQueuedCommunicationMessage(
+        buildCaptionUpdate('@roomote_bot what is this?'),
+        { botUsername: 'roomote_bot' },
+      ),
+    ).toMatchObject({ text: 'what is this?' });
+    expect(
+      telegramUpdateToQueuedCommunicationMessage(
+        buildCaptionUpdate('@roomote_bot'),
+        { botUsername: 'roomote_bot' },
+      ),
+    ).toMatchObject({ text: 'Image attachment' });
+  });
+
   describe('getTelegramNewTaskCommand', () => {
     const buildUpdate = (
       text: string,

--- a/packages/communication/src/mock-telegram-server.ts
+++ b/packages/communication/src/mock-telegram-server.ts
@@ -94,6 +94,7 @@ export type MockTelegramState = {
   webhook?: MockTelegramWebhookRegistration;
   callbackAnswers?: MockTelegramCallbackAnswer[];
   chatActions?: MockTelegramChatAction[];
+  botCommands?: Array<{ command: string; description: string }>;
   behavior?: MockTelegramBehavior;
 };
 
@@ -175,6 +176,7 @@ function normalizeState(state: MockTelegramState): MockTelegramState {
     })),
     callbackAnswers: [...(state.callbackAnswers ?? [])],
     chatActions: [...(state.chatActions ?? [])],
+    botCommands: [...(state.botCommands ?? [])],
   };
 }
 
@@ -566,6 +568,14 @@ export class MockTelegramServer {
           username: bot.username,
           ...(bot.has_topics_enabled ? { has_topics_enabled: true } : {}),
         });
+        return;
+      }
+
+      case 'setMyCommands': {
+        this.state.botCommands = Array.isArray(body.commands)
+          ? (body.commands as Array<{ command: string; description: string }>)
+          : [];
+        apiResult(response, true);
         return;
       }
 

--- a/packages/communication/src/telegram-provider.ts
+++ b/packages/communication/src/telegram-provider.ts
@@ -648,7 +648,8 @@ export class TelegramCommunicationProvider implements CommunicationProviderAdapt
         });
         if (
           attempt < this.maxRetries &&
-          (response.status === 429 || response.status >= 500)
+          (response.status === 429 ||
+            (options.retryNetworkErrors && response.status >= 500))
         ) {
           const body = (await response
             .clone()

--- a/packages/communication/src/telegram-provider.ts
+++ b/packages/communication/src/telegram-provider.ts
@@ -19,6 +19,8 @@ export type TelegramCommunicationProviderOptions = {
   botToken: string;
   apiBaseUrl?: string;
   fetch?: typeof fetch;
+  timeoutMs?: number;
+  maxRetries?: number;
 };
 
 export type TelegramForumTopic = {
@@ -42,7 +44,12 @@ type TelegramApiResponse =
       ok: false;
       description?: string;
       error_code?: number;
+      parameters?: { retry_after?: number };
     };
+
+const DEFAULT_TELEGRAM_TIMEOUT_MS = 10_000;
+const DEFAULT_TELEGRAM_MAX_RETRIES = 2;
+const TELEGRAM_RETRY_BASE_DELAY_MS = 250;
 
 function parsePositiveInteger(value: string | undefined): number | undefined {
   if (!value) {
@@ -84,10 +91,14 @@ export class TelegramCommunicationProvider implements CommunicationProviderAdapt
 
   private readonly apiBaseUrl: string;
   private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+  private readonly maxRetries: number;
 
   constructor(private readonly options: TelegramCommunicationProviderOptions) {
     this.apiBaseUrl = options.apiBaseUrl ?? getTelegramApiBaseUrl();
     this.fetchImpl = options.fetch ?? fetch;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TELEGRAM_TIMEOUT_MS;
+    this.maxRetries = options.maxRetries ?? DEFAULT_TELEGRAM_MAX_RETRIES;
   }
 
   async postMessage(
@@ -176,7 +187,7 @@ export class TelegramCommunicationProvider implements CommunicationProviderAdapt
     replyToMessageId?: number;
     replyMarkup?: TelegramInlineKeyboardMarkup;
   }): Promise<{ message_id: number; message_thread_id?: number }> {
-    const response = await this.fetchImpl(
+    const response = await this.fetchWithRetry(
       `${this.apiBaseUrl.replace(/\/$/, '')}/bot${this.options.botToken}/sendPhoto`,
       {
         method: 'POST',
@@ -197,6 +208,7 @@ export class TelegramCommunicationProvider implements CommunicationProviderAdapt
             : {}),
         }),
       },
+      { method: 'sendPhoto', retryNetworkErrors: false },
     );
     const parsed = (await response
       .json()
@@ -258,13 +270,14 @@ export class TelegramCommunicationProvider implements CommunicationProviderAdapt
             }
           : {}),
       };
-      const response = await this.fetchImpl(
+      const response = await this.fetchWithRetry(
         `${this.apiBaseUrl.replace(/\/$/, '')}/bot${this.options.botToken}/sendMessage`,
         {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
           body: JSON.stringify(body),
         },
+        { method: 'sendMessage', retryNetworkErrors: false },
       );
       const parsed = (await response
         .json()
@@ -336,7 +349,7 @@ export class TelegramCommunicationProvider implements CommunicationProviderAdapt
     let lastError: Error | null = null;
 
     for (const attempt of attempts) {
-      const response = await this.fetchImpl(
+      const response = await this.fetchWithRetry(
         `${this.apiBaseUrl.replace(/\/$/, '')}/bot${this.options.botToken}/editMessageText`,
         {
           method: 'POST',
@@ -352,6 +365,7 @@ export class TelegramCommunicationProvider implements CommunicationProviderAdapt
             },
           }),
         },
+        { method: 'editMessageText', retryNetworkErrors: true },
       );
       const parsed = (await response.json().catch(() => null)) as {
         ok?: boolean;
@@ -501,6 +515,52 @@ export class TelegramCommunicationProvider implements CommunicationProviderAdapt
     });
   }
 
+  /** Keep Telegram's slash-command picker in sync with supported commands. */
+  async registerCommands(): Promise<void> {
+    await this.callBotApi('setMyCommands', {
+      commands: [
+        { command: 'start', description: 'Show welcome and command help' },
+        { command: 'new', description: 'Start a fresh task' },
+      ],
+    });
+  }
+
+  /** Resolve and download a Telegram-hosted file without exposing the token. */
+  async downloadFile(
+    fileId: string,
+    maxBytes: number,
+  ): Promise<{
+    bytes: Uint8Array;
+    filePath: string;
+    contentType: string | null;
+  }> {
+    const file = (await this.callBotApi('getFile', {
+      file_id: fileId,
+    })) as { file_path?: string; file_size?: number };
+    if (!file.file_path) throw new Error('Telegram getFile returned no path.');
+    if (file.file_size && file.file_size > maxBytes) {
+      throw new Error(`Telegram file exceeds the ${maxBytes} byte limit.`);
+    }
+
+    const response = await this.fetchWithRetry(
+      `${this.apiBaseUrl.replace(/\/bot$/u, '').replace(/\/$/u, '')}/file/bot${this.options.botToken}/${file.file_path}`,
+      { method: 'GET' },
+      { method: 'downloadFile', retryNetworkErrors: true },
+    );
+    if (!response.ok) {
+      throw new Error(`Telegram downloadFile failed (${response.status}).`);
+    }
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.byteLength > maxBytes) {
+      throw new Error(`Telegram file exceeds the ${maxBytes} byte limit.`);
+    }
+    return {
+      bytes,
+      filePath: file.file_path,
+      contentType: response.headers.get('content-type'),
+    };
+  }
+
   async getWebhookInfo(): Promise<{
     url: string;
     pendingUpdateCount: number;
@@ -531,13 +591,14 @@ export class TelegramCommunicationProvider implements CommunicationProviderAdapt
     method: string,
     body: Record<string, unknown>,
   ): Promise<unknown> {
-    const response = await this.fetchImpl(
+    const response = await this.fetchWithRetry(
       `${this.apiBaseUrl.replace(/\/$/, '')}/bot${this.options.botToken}/${method}`,
       {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify(body),
       },
+      { method, retryNetworkErrors: this.isIdempotentMethod(method) },
     );
     const parsed = (await response.json().catch(() => null)) as {
       ok?: boolean;
@@ -554,6 +615,64 @@ export class TelegramCommunicationProvider implements CommunicationProviderAdapt
     }
 
     return parsed.result;
+  }
+
+  private isIdempotentMethod(method: string): boolean {
+    return [
+      'getMe',
+      'getFile',
+      'getWebhookInfo',
+      'setWebhook',
+      'setMyCommands',
+      'sendChatAction',
+      'editMessageText',
+      'editMessageReplyMarkup',
+      'editForumTopic',
+      'deleteMessage',
+      'setMessageReaction',
+      'answerCallbackQuery',
+    ].includes(method);
+  }
+
+  private async fetchWithRetry(
+    url: string,
+    init: RequestInit,
+    options: { method: string; retryNetworkErrors: boolean },
+  ): Promise<Response> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= this.maxRetries; attempt += 1) {
+      try {
+        const response = await this.fetchImpl(url, {
+          ...init,
+          signal: AbortSignal.timeout(this.timeoutMs),
+        });
+        if (
+          attempt < this.maxRetries &&
+          (response.status === 429 || response.status >= 500)
+        ) {
+          const body = (await response
+            .clone()
+            .json()
+            .catch(() => null)) as {
+            parameters?: { retry_after?: number };
+          } | null;
+          const delayMs = body?.parameters?.retry_after
+            ? body.parameters.retry_after * 1000
+            : TELEGRAM_RETRY_BASE_DELAY_MS * 2 ** attempt;
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+          continue;
+        }
+        return response;
+      } catch (error) {
+        lastError = error;
+        if (!options.retryNetworkErrors || attempt >= this.maxRetries)
+          throw error;
+        await new Promise((resolve) =>
+          setTimeout(resolve, TELEGRAM_RETRY_BASE_DELAY_MS * 2 ** attempt),
+        );
+      }
+    }
+    throw lastError ?? new Error(`Telegram ${options.method} failed.`);
   }
 
   async fetchThreadMessages(_input: {
@@ -599,7 +718,7 @@ export class TelegramCommunicationProvider implements CommunicationProviderAdapt
       });
     }
 
-    const response = await this.fetchImpl(
+    const response = await this.fetchWithRetry(
       `${this.apiBaseUrl.replace(/\/$/, '')}/bot${this.options.botToken}/setMessageReaction`,
       {
         method: 'POST',
@@ -610,6 +729,7 @@ export class TelegramCommunicationProvider implements CommunicationProviderAdapt
           reaction: [{ type: 'emoji', emoji }],
         }),
       },
+      { method: 'setMessageReaction', retryNetworkErrors: true },
     );
     const parsed = (await response.json().catch(() => null)) as {
       ok?: boolean;

--- a/packages/communication/src/telegram-update.ts
+++ b/packages/communication/src/telegram-update.ts
@@ -519,8 +519,15 @@ export function telegramUpdateToQueuedCommunicationMessage(
   }
 
   const sourceText = message.text ?? message.caption ?? '';
-  const text = sourceText
-    ? stripTelegramBotInvocation(sourceText, message, options)
+  const invocationMessage =
+    message.caption && !message.text
+      ? { ...message, entities: message.caption_entities }
+      : message;
+  const strippedText = sourceText
+    ? stripTelegramBotInvocation(sourceText, invocationMessage, options)
+    : '';
+  const text = strippedText
+    ? strippedText
     : message.photo?.length
       ? 'Image attachment'
       : message.document

--- a/packages/communication/src/telegram-update.ts
+++ b/packages/communication/src/telegram-update.ts
@@ -41,15 +41,39 @@ const telegramForumTopicCreatedSchema = z
   })
   .passthrough();
 
+const telegramPhotoSizeSchema = z
+  .object({
+    file_id: z.string(),
+    file_unique_id: z.string(),
+    width: z.number().int(),
+    height: z.number().int(),
+    file_size: z.number().int().optional(),
+  })
+  .passthrough();
+
+const telegramDocumentSchema = z
+  .object({
+    file_id: z.string(),
+    file_unique_id: z.string(),
+    file_name: z.string().optional(),
+    mime_type: z.string().optional(),
+    file_size: z.number().int().optional(),
+  })
+  .passthrough();
+
 const telegramMessageSchema = z
   .object({
     message_id: z.number().int(),
     message_thread_id: z.number().int().optional(),
     date: z.number().int().optional(),
     text: z.string().optional(),
+    caption: z.string().optional(),
+    photo: z.array(telegramPhotoSizeSchema).optional(),
+    document: telegramDocumentSchema.optional(),
     from: telegramUserSchema.optional(),
     chat: telegramChatSchema,
     entities: z.array(telegramMessageEntitySchema).optional(),
+    caption_entities: z.array(telegramMessageEntitySchema).optional(),
     forum_topic_created: telegramForumTopicCreatedSchema.optional(),
   })
   .passthrough();
@@ -326,13 +350,21 @@ export function isTelegramBotMentioned(
   message: TelegramMessage,
   options: TelegramBotMentionOptions = {},
 ): boolean {
-  const text = message.text ?? '';
+  const text = message.text ?? message.caption ?? '';
 
   if (!text) {
     return false;
   }
 
-  return Boolean(getTelegramInvocationEntity(text, message, options));
+  return Boolean(
+    getTelegramInvocationEntity(
+      text,
+      message.caption && !message.text
+        ? { ...message, entities: message.caption_entities }
+        : message,
+      options,
+    ),
+  );
 }
 
 /**
@@ -358,7 +390,10 @@ export function isTelegramTaskEntryUpdate(
 
   return Boolean(
     message &&
-    message.text &&
+    (message.text ||
+      message.caption ||
+      message.photo?.length ||
+      message.document) &&
     (isTelegramPrivateChat(message) ||
       isTelegramBotMentioned(message, options)),
   );
@@ -479,11 +514,18 @@ export function telegramUpdateToQueuedCommunicationMessage(
 ): QueuedCommunicationMessage | null {
   const message = getTelegramUpdateMessage(update);
 
-  if (!message?.text) {
+  if (!message) {
     return null;
   }
 
-  const text = stripTelegramBotInvocation(message.text, message, options);
+  const sourceText = message.text ?? message.caption ?? '';
+  const text = sourceText
+    ? stripTelegramBotInvocation(sourceText, message, options)
+    : message.photo?.length
+      ? 'Image attachment'
+      : message.document
+        ? `Document attachment${message.document.file_name ? `: ${message.document.file_name}` : ''}`
+        : '';
 
   if (!text) {
     return null;

--- a/packages/db/src/lib/telegram-runtime-credentials.test.ts
+++ b/packages/db/src/lib/telegram-runtime-credentials.test.ts
@@ -1,7 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { resolveEffectiveDeploymentEnvVarsMock } = vi.hoisted(() => ({
+const {
+  deploymentSettingsFindFirstMock,
+  deploymentSettingsUpdateSetMock,
+  deploymentSettingsUpdateWhereMock,
+  resolveEffectiveDeploymentEnvVarsMock,
+} = vi.hoisted(() => ({
+  deploymentSettingsFindFirstMock: vi.fn(),
+  deploymentSettingsUpdateSetMock: vi.fn(),
+  deploymentSettingsUpdateWhereMock: vi.fn(),
   resolveEffectiveDeploymentEnvVarsMock: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    query: {
+      deploymentSettings: { findFirst: deploymentSettingsFindFirstMock },
+    },
+    update: vi.fn(() => ({ set: deploymentSettingsUpdateSetMock })),
+  },
 }));
 
 vi.mock('./model-runtime-config', () => ({
@@ -22,6 +39,11 @@ describe('resolveTelegramRuntimeCredentials', () => {
     process.env.R_TELEGRAM_WEBHOOK_SECRET = 'secret';
     process.env.TELEGRAM_API_BASE_URL = 'https://telegram.example.test';
     resolveEffectiveDeploymentEnvVarsMock.mockResolvedValue({});
+    deploymentSettingsFindFirstMock.mockResolvedValue({ metadata: {} });
+    deploymentSettingsUpdateSetMock.mockReturnValue({
+      where: deploymentSettingsUpdateWhereMock,
+    });
+    deploymentSettingsUpdateWhereMock.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -50,6 +72,7 @@ describe('resolveTelegramRuntimeCredentials', () => {
       'https://telegram.example.test/bot123:token/getMe',
       expect.objectContaining({ method: 'POST' }),
     );
+    expect(deploymentSettingsUpdateSetMock).toHaveBeenCalledOnce();
   });
 
   it('keeps credentials usable when Telegram cannot resolve the username', async () => {

--- a/packages/db/src/lib/telegram-runtime-credentials.ts
+++ b/packages/db/src/lib/telegram-runtime-credentials.ts
@@ -1,3 +1,8 @@
+import { createHash } from 'node:crypto';
+import { eq, sql } from 'drizzle-orm';
+
+import { db } from '../db';
+import { deploymentSettings } from '../schema';
 import { resolveEffectiveDeploymentEnvVars } from './model-runtime-config';
 
 export type TelegramRuntimeCredentials = {
@@ -7,6 +12,8 @@ export type TelegramRuntimeCredentials = {
 };
 
 const CACHE_TTL_MS = 30_000;
+const BOT_INFO_TTL_MS = 24 * 60 * 60 * 1000;
+const BOT_INFO_METADATA_KEY = 'telegram_bot_info_cache';
 
 let cachedCredentials: {
   value: TelegramRuntimeCredentials;
@@ -39,6 +46,28 @@ async function resolveTelegramBotUsername(
 ): Promise<string | null> {
   if (!botToken) return null;
 
+  const tokenFingerprint = createHash('sha256').update(botToken).digest('hex');
+  const settings = await db.query.deploymentSettings.findFirst({
+    where: eq(deploymentSettings.id, 'default'),
+    columns: { metadata: true },
+  });
+  const cached = (settings?.metadata as Record<string, unknown> | undefined)?.[
+    BOT_INFO_METADATA_KEY
+  ] as
+    | { tokenFingerprint?: string; username?: string; fetchedAtMs?: number }
+    | undefined;
+  const matchingCachedUsername =
+    cached?.tokenFingerprint === tokenFingerprint && cached.username
+      ? cached.username
+      : null;
+  if (
+    matchingCachedUsername &&
+    typeof cached?.fetchedAtMs === 'number' &&
+    Date.now() - cached.fetchedAtMs < BOT_INFO_TTL_MS
+  ) {
+    return matchingCachedUsername;
+  }
+
   try {
     const apiBaseUrl =
       process.env.TELEGRAM_API_BASE_URL?.replace(/\/$/u, '') ??
@@ -47,6 +76,7 @@ async function resolveTelegramBotUsername(
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: '{}',
+      signal: AbortSignal.timeout(10_000),
     });
     const body = (await response.json().catch(() => null)) as {
       ok?: boolean;
@@ -54,9 +84,31 @@ async function resolveTelegramBotUsername(
     } | null;
     const username = body?.result?.username?.trim().replace(/^@/u, '');
 
-    return response.ok && body?.ok && username ? username : null;
+    if (!response.ok || !body?.ok || !username) {
+      return matchingCachedUsername;
+    }
+
+    try {
+      await db
+        .update(deploymentSettings)
+        .set({
+          metadata: sql`${deploymentSettings.metadata} || ${JSON.stringify({
+            [BOT_INFO_METADATA_KEY]: {
+              tokenFingerprint,
+              username,
+              fetchedAtMs: Date.now(),
+            },
+          })}::jsonb`,
+          updatedAt: new Date(),
+        })
+        .where(eq(deploymentSettings.id, 'default'));
+    } catch {
+      // Identity lookup still succeeded; persistence is only an optimization.
+    }
+
+    return username;
   } catch {
-    return null;
+    return matchingCachedUsername;
   }
 }
 


### PR DESCRIPTION
## Summary
- register `/start` and `/new` in Telegram's command menu and add bounded Bot API timeout/retry behavior
- persist token-fingerprinted bot identity metadata across restarts
- accept captioned and attachment-only photos plus supported text documents as task input without exposing bot credentials
- surface delivery diagnostics and add an explicit Telegram connection repair action
- update the mock Telegram harness, focused tests, and provider documentation

## Validation
- `pnpm lint:fast`
- `pnpm check-types:fast`
- `pnpm knip`
- focused Telegram communication tests (61 passed)
- Telegram webhook tests (47 passed)
- communication settings tests (39 passed)
