### PR TITLE
[Improve] Simplify Azure DevOps setup

### DIFF
--- a/.changeset/gentle-ado-setup.md
+++ b/.changeset/gentle-ado-setup.md
@@ -2,4 +2,4 @@
 '@roomote/web': patch
 ---
 
-Guide Azure DevOps setup through organization-first PAT creation, add a dedicated Microsoft Entra account-linking step with Microsoft Teams app reuse guidance, hide advanced credentials by default, and allow saved optional source-control settings to be cleared.
+Guide Azure DevOps setup through organization-first PAT creation, require Microsoft Entra account linking for Azure DevOps Services, automatically reuse existing Microsoft or Teams app credentials, hide advanced credentials by default, and allow saved optional source-control settings to be cleared.

--- a/.changeset/gentle-ado-setup.md
+++ b/.changeset/gentle-ado-setup.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Guide Azure DevOps setup through organization-first PAT creation, hide advanced credentials by default, and allow saved optional source-control settings to be cleared.

--- a/.changeset/gentle-ado-setup.md
+++ b/.changeset/gentle-ado-setup.md
@@ -2,4 +2,4 @@
 '@roomote/web': patch
 ---
 
-Guide Azure DevOps setup through organization-first PAT creation, require Microsoft Entra account linking for Azure DevOps Services, automatically reuse existing Microsoft or Teams app credentials, hide advanced credentials by default, and allow saved optional source-control settings to be cleared.
+Guide Azure DevOps setup through organization-first PAT creation, require Microsoft Entra account linking for Azure DevOps Services, automatically reuse existing Microsoft or Teams app credentials, clarify when a tenant ID is required, hide advanced credentials by default, and allow saved optional source-control settings to be cleared.

--- a/.changeset/gentle-ado-setup.md
+++ b/.changeset/gentle-ado-setup.md
@@ -2,4 +2,4 @@
 '@roomote/web': patch
 ---
 
-Guide Azure DevOps setup through organization-first PAT creation, hide advanced credentials by default, and allow saved optional source-control settings to be cleared.
+Guide Azure DevOps setup through organization-first PAT creation, add a dedicated Microsoft Entra account-linking step with Microsoft Teams app reuse guidance, hide advanced credentials by default, and allow saved optional source-control settings to be cleared.

--- a/apps/docs/environment-variables.mdx
+++ b/apps/docs/environment-variables.mdx
@@ -264,7 +264,7 @@ as per-task auth tokens or workspace paths.
 | `ADO_USERNAME`                 | Optional     | Azure DevOps username.                                                                           |
 | `ADO_CLIENT_ID`                | Optional     | Microsoft Entra client ID for Azure DevOps OAuth.                                                |
 | `ADO_CLIENT_SECRET`            | Optional     | Microsoft Entra client secret for Azure DevOps OAuth.                                            |
-| `ADO_TENANT_ID`                | Optional     | Microsoft Entra tenant ID for Azure DevOps OAuth. `R_MICROSOFT_TENANT_ID` is also accepted.      |
+| `ADO_TENANT_ID`                | Optional     | Microsoft Entra tenant ID for Azure DevOps OAuth. Defaults to the `common` tenant.               |
 | `ADO_WEBHOOK_SECRET`           | Optional     | Azure DevOps webhook secret.                                                                     |
 
 ### Communications and sign-in
@@ -294,7 +294,7 @@ as per-task auth tokens or workspace paths.
 | `R_SLACK_CLIENT_SECRET`        | Slack sign-in     | Slack sign-in client secret. `R_SLACK_CLIENT_SECRET` is also accepted.           |
 | `R_MICROSOFT_CLIENT_ID`        | Microsoft sign-in | Microsoft OAuth client ID.                                                       |
 | `R_MICROSOFT_CLIENT_SECRET`    | Microsoft sign-in | Microsoft OAuth client secret.                                                   |
-| `R_MICROSOFT_TENANT_ID`        | Microsoft sign-in | Microsoft tenant ID. Also accepted as the Azure DevOps tenant ID fallback.       |
+| `R_MICROSOFT_TENANT_ID`        | Microsoft sign-in | Microsoft tenant ID.                                                             |
 | `R_ALLOWED_EMAILS`             | Optional          | Comma-separated email allowlist for deployments that restrict sign-in by email.  |
 
 ### Integrations

--- a/apps/docs/environment-variables.mdx
+++ b/apps/docs/environment-variables.mdx
@@ -229,43 +229,43 @@ as per-task auth tokens or workspace paths.
 
 ### Source control providers
 
-| Env var                        | Required     | Used for                                                                                         |
-| ------------------------------ | ------------ | ------------------------------------------------------------------------------------------------ |
-| `R_GITHUB_APP_SLUG`            | GitHub       | GitHub App slug.                                                                                 |
-| `R_GITHUB_APP_ID`              | GitHub       | GitHub App ID.                                                                                   |
-| `R_GITHUB_APP_PRIVATE_KEY`     | GitHub       | Raw GitHub App private key PEM, usually with newlines escaped as `\\n`.                          |
-| `R_GITHUB_CLIENT_ID`           | GitHub       | GitHub OAuth client ID.                                                                          |
-| `R_GITHUB_CLIENT_SECRET`       | GitHub       | GitHub OAuth client secret.                                                                      |
-| `R_GITHUB_WEBHOOK_SECRET`      | GitHub       | GitHub webhook secret.                                                                           |
-| `GITHUB_MCP_SERVER_URL`        | Optional     | GitHub MCP server URL override.                                                                  |
-| `GITHUB_AUTOMATED_SKIP_REPOS`  | Optional     | Repository skip list for automated GitHub processing.                                            |
-| `GITHUB_AUTOMATED_SKIP_OWNERS` | Optional     | Owner skip list for automated GitHub processing.                                                 |
-| `GITLAB_TOKEN`                 | GitLab       | GitLab personal access token for source-control setup.                                           |
-| `GITLAB_BASE_URL`              | Optional     | GitLab base URL for self-managed GitLab.                                                         |
-| `GITLAB_CLIENT_ID`             | Optional     | GitLab OAuth application ID for personal account linking and merge request comment triggers.     |
-| `GITLAB_CLIENT_SECRET`         | Optional     | GitLab OAuth application secret for personal account linking and merge request comment triggers. |
-| `GITLAB_WEBHOOK_SIGNING_TOKEN` | Optional     | GitLab webhook signing token.                                                                    |
-| `GITLAB_WEBHOOK_SECRET`        | Optional     | GitLab webhook secret.                                                                           |
-| `GITEA_BASE_URL`               | Gitea        | Gitea base URL.                                                                                  |
-| `GITEA_TOKEN`                  | Gitea        | Gitea access token.                                                                              |
-| `GITEA_USERNAME`               | Optional     | Gitea username.                                                                                  |
-| `GITEA_CLIENT_ID`              | Optional     | Gitea OAuth client ID.                                                                           |
-| `GITEA_CLIENT_SECRET`          | Optional     | Gitea OAuth client secret.                                                                       |
-| `GITEA_WEBHOOK_SECRET`         | Optional     | Gitea webhook secret.                                                                            |
-| `BITBUCKET_TOKEN`              | Bitbucket    | Atlassian API token with Bitbucket scopes.                                                       |
-| `BITBUCKET_USERNAME`           | Bitbucket    | Atlassian account email that owns the API token.                                                 |
-| `BITBUCKET_BASE_URL`           | Optional     | Bitbucket base URL. Defaults to `https://bitbucket.org` (Cloud only).                            |
-| `BITBUCKET_CLIENT_ID`          | Optional     | Bitbucket OAuth client ID for personal account linking.                                          |
-| `BITBUCKET_CLIENT_SECRET`      | Optional     | Bitbucket OAuth client secret for personal account linking.                                      |
-| `BITBUCKET_WEBHOOK_SECRET`     | Optional     | Bitbucket webhook secret.                                                                        |
-| `ADO_ORGANIZATION`             | Azure DevOps | Azure DevOps organization.                                                                       |
-| `ADO_TOKEN`                    | Azure DevOps | Azure DevOps access token.                                                                       |
-| `ADO_BASE_URL`                 | Optional     | Azure DevOps base URL.                                                                           |
-| `ADO_USERNAME`                 | Optional     | Azure DevOps username.                                                                           |
-| `ADO_CLIENT_ID`                | Optional     | Microsoft Entra client ID for Azure DevOps OAuth.                                                |
-| `ADO_CLIENT_SECRET`            | Optional     | Microsoft Entra client secret for Azure DevOps OAuth.                                            |
-| `ADO_TENANT_ID`                | Optional     | Microsoft Entra tenant ID for Azure DevOps OAuth. Defaults to the `common` tenant.               |
-| `ADO_WEBHOOK_SECRET`           | Optional     | Azure DevOps webhook secret.                                                                     |
+| Env var                        | Required     | Used for                                                                                                |
+| ------------------------------ | ------------ | ------------------------------------------------------------------------------------------------------- |
+| `R_GITHUB_APP_SLUG`            | GitHub       | GitHub App slug.                                                                                        |
+| `R_GITHUB_APP_ID`              | GitHub       | GitHub App ID.                                                                                          |
+| `R_GITHUB_APP_PRIVATE_KEY`     | GitHub       | Raw GitHub App private key PEM, usually with newlines escaped as `\\n`.                                 |
+| `R_GITHUB_CLIENT_ID`           | GitHub       | GitHub OAuth client ID.                                                                                 |
+| `R_GITHUB_CLIENT_SECRET`       | GitHub       | GitHub OAuth client secret.                                                                             |
+| `R_GITHUB_WEBHOOK_SECRET`      | GitHub       | GitHub webhook secret.                                                                                  |
+| `GITHUB_MCP_SERVER_URL`        | Optional     | GitHub MCP server URL override.                                                                         |
+| `GITHUB_AUTOMATED_SKIP_REPOS`  | Optional     | Repository skip list for automated GitHub processing.                                                   |
+| `GITHUB_AUTOMATED_SKIP_OWNERS` | Optional     | Owner skip list for automated GitHub processing.                                                        |
+| `GITLAB_TOKEN`                 | GitLab       | GitLab personal access token for source-control setup.                                                  |
+| `GITLAB_BASE_URL`              | Optional     | GitLab base URL for self-managed GitLab.                                                                |
+| `GITLAB_CLIENT_ID`             | Optional     | GitLab OAuth application ID for personal account linking and merge request comment triggers.            |
+| `GITLAB_CLIENT_SECRET`         | Optional     | GitLab OAuth application secret for personal account linking and merge request comment triggers.        |
+| `GITLAB_WEBHOOK_SIGNING_TOKEN` | Optional     | GitLab webhook signing token.                                                                           |
+| `GITLAB_WEBHOOK_SECRET`        | Optional     | GitLab webhook secret.                                                                                  |
+| `GITEA_BASE_URL`               | Gitea        | Gitea base URL.                                                                                         |
+| `GITEA_TOKEN`                  | Gitea        | Gitea access token.                                                                                     |
+| `GITEA_USERNAME`               | Optional     | Gitea username.                                                                                         |
+| `GITEA_CLIENT_ID`              | Optional     | Gitea OAuth client ID.                                                                                  |
+| `GITEA_CLIENT_SECRET`          | Optional     | Gitea OAuth client secret.                                                                              |
+| `GITEA_WEBHOOK_SECRET`         | Optional     | Gitea webhook secret.                                                                                   |
+| `BITBUCKET_TOKEN`              | Bitbucket    | Atlassian API token with Bitbucket scopes.                                                              |
+| `BITBUCKET_USERNAME`           | Bitbucket    | Atlassian account email that owns the API token.                                                        |
+| `BITBUCKET_BASE_URL`           | Optional     | Bitbucket base URL. Defaults to `https://bitbucket.org` (Cloud only).                                   |
+| `BITBUCKET_CLIENT_ID`          | Optional     | Bitbucket OAuth client ID for personal account linking.                                                 |
+| `BITBUCKET_CLIENT_SECRET`      | Optional     | Bitbucket OAuth client secret for personal account linking.                                             |
+| `BITBUCKET_WEBHOOK_SECRET`     | Optional     | Bitbucket webhook secret.                                                                               |
+| `ADO_ORGANIZATION`             | Azure DevOps | Azure DevOps organization.                                                                              |
+| `ADO_TOKEN`                    | Azure DevOps | Azure DevOps access token.                                                                              |
+| `ADO_BASE_URL`                 | Optional     | Azure DevOps base URL.                                                                                  |
+| `ADO_USERNAME`                 | Optional     | Azure DevOps username.                                                                                  |
+| `ADO_CLIENT_ID`                | Optional     | Microsoft Entra client ID for Azure DevOps OAuth. Falls back to `R_MICROSOFT_CLIENT_ID`.                |
+| `ADO_CLIENT_SECRET`            | Optional     | Microsoft Entra client secret for Azure DevOps OAuth. Falls back to `R_MICROSOFT_CLIENT_SECRET`.        |
+| `ADO_TENANT_ID`                | Optional     | Microsoft Entra tenant ID for Azure DevOps OAuth. Falls back to `R_MICROSOFT_TENANT_ID`, then `common`. |
+| `ADO_WEBHOOK_SECRET`           | Optional     | Azure DevOps webhook secret.                                                                            |
 
 ### Communications and sign-in
 

--- a/apps/docs/environment-variables.mdx
+++ b/apps/docs/environment-variables.mdx
@@ -229,43 +229,43 @@ as per-task auth tokens or workspace paths.
 
 ### Source control providers
 
-| Env var                        | Required     | Used for                                                                                                |
-| ------------------------------ | ------------ | ------------------------------------------------------------------------------------------------------- |
-| `R_GITHUB_APP_SLUG`            | GitHub       | GitHub App slug.                                                                                        |
-| `R_GITHUB_APP_ID`              | GitHub       | GitHub App ID.                                                                                          |
-| `R_GITHUB_APP_PRIVATE_KEY`     | GitHub       | Raw GitHub App private key PEM, usually with newlines escaped as `\\n`.                                 |
-| `R_GITHUB_CLIENT_ID`           | GitHub       | GitHub OAuth client ID.                                                                                 |
-| `R_GITHUB_CLIENT_SECRET`       | GitHub       | GitHub OAuth client secret.                                                                             |
-| `R_GITHUB_WEBHOOK_SECRET`      | GitHub       | GitHub webhook secret.                                                                                  |
-| `GITHUB_MCP_SERVER_URL`        | Optional     | GitHub MCP server URL override.                                                                         |
-| `GITHUB_AUTOMATED_SKIP_REPOS`  | Optional     | Repository skip list for automated GitHub processing.                                                   |
-| `GITHUB_AUTOMATED_SKIP_OWNERS` | Optional     | Owner skip list for automated GitHub processing.                                                        |
-| `GITLAB_TOKEN`                 | GitLab       | GitLab personal access token for source-control setup.                                                  |
-| `GITLAB_BASE_URL`              | Optional     | GitLab base URL for self-managed GitLab.                                                                |
-| `GITLAB_CLIENT_ID`             | Optional     | GitLab OAuth application ID for personal account linking and merge request comment triggers.            |
-| `GITLAB_CLIENT_SECRET`         | Optional     | GitLab OAuth application secret for personal account linking and merge request comment triggers.        |
-| `GITLAB_WEBHOOK_SIGNING_TOKEN` | Optional     | GitLab webhook signing token.                                                                           |
-| `GITLAB_WEBHOOK_SECRET`        | Optional     | GitLab webhook secret.                                                                                  |
-| `GITEA_BASE_URL`               | Gitea        | Gitea base URL.                                                                                         |
-| `GITEA_TOKEN`                  | Gitea        | Gitea access token.                                                                                     |
-| `GITEA_USERNAME`               | Optional     | Gitea username.                                                                                         |
-| `GITEA_CLIENT_ID`              | Optional     | Gitea OAuth client ID.                                                                                  |
-| `GITEA_CLIENT_SECRET`          | Optional     | Gitea OAuth client secret.                                                                              |
-| `GITEA_WEBHOOK_SECRET`         | Optional     | Gitea webhook secret.                                                                                   |
-| `BITBUCKET_TOKEN`              | Bitbucket    | Atlassian API token with Bitbucket scopes.                                                              |
-| `BITBUCKET_USERNAME`           | Bitbucket    | Atlassian account email that owns the API token.                                                        |
-| `BITBUCKET_BASE_URL`           | Optional     | Bitbucket base URL. Defaults to `https://bitbucket.org` (Cloud only).                                   |
-| `BITBUCKET_CLIENT_ID`          | Optional     | Bitbucket OAuth client ID for personal account linking.                                                 |
-| `BITBUCKET_CLIENT_SECRET`      | Optional     | Bitbucket OAuth client secret for personal account linking.                                             |
-| `BITBUCKET_WEBHOOK_SECRET`     | Optional     | Bitbucket webhook secret.                                                                               |
-| `ADO_ORGANIZATION`             | Azure DevOps | Azure DevOps organization.                                                                              |
-| `ADO_TOKEN`                    | Azure DevOps | Azure DevOps access token.                                                                              |
-| `ADO_BASE_URL`                 | Optional     | Azure DevOps base URL.                                                                                  |
-| `ADO_USERNAME`                 | Optional     | Azure DevOps username.                                                                                  |
-| `ADO_CLIENT_ID`                | Optional     | Microsoft Entra client ID for Azure DevOps OAuth. Falls back to `R_MICROSOFT_CLIENT_ID`.                |
-| `ADO_CLIENT_SECRET`            | Optional     | Microsoft Entra client secret for Azure DevOps OAuth. Falls back to `R_MICROSOFT_CLIENT_SECRET`.        |
-| `ADO_TENANT_ID`                | Optional     | Microsoft Entra tenant ID for Azure DevOps OAuth. Falls back to `R_MICROSOFT_TENANT_ID`, then `common`. |
-| `ADO_WEBHOOK_SECRET`           | Optional     | Azure DevOps webhook secret.                                                                            |
+| Env var                        | Required     | Used for                                                                                                                                         |
+| ------------------------------ | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `R_GITHUB_APP_SLUG`            | GitHub       | GitHub App slug.                                                                                                                                 |
+| `R_GITHUB_APP_ID`              | GitHub       | GitHub App ID.                                                                                                                                   |
+| `R_GITHUB_APP_PRIVATE_KEY`     | GitHub       | Raw GitHub App private key PEM, usually with newlines escaped as `\\n`.                                                                          |
+| `R_GITHUB_CLIENT_ID`           | GitHub       | GitHub OAuth client ID.                                                                                                                          |
+| `R_GITHUB_CLIENT_SECRET`       | GitHub       | GitHub OAuth client secret.                                                                                                                      |
+| `R_GITHUB_WEBHOOK_SECRET`      | GitHub       | GitHub webhook secret.                                                                                                                           |
+| `GITHUB_MCP_SERVER_URL`        | Optional     | GitHub MCP server URL override.                                                                                                                  |
+| `GITHUB_AUTOMATED_SKIP_REPOS`  | Optional     | Repository skip list for automated GitHub processing.                                                                                            |
+| `GITHUB_AUTOMATED_SKIP_OWNERS` | Optional     | Owner skip list for automated GitHub processing.                                                                                                 |
+| `GITLAB_TOKEN`                 | GitLab       | GitLab personal access token for source-control setup.                                                                                           |
+| `GITLAB_BASE_URL`              | Optional     | GitLab base URL for self-managed GitLab.                                                                                                         |
+| `GITLAB_CLIENT_ID`             | Optional     | GitLab OAuth application ID for personal account linking and merge request comment triggers.                                                     |
+| `GITLAB_CLIENT_SECRET`         | Optional     | GitLab OAuth application secret for personal account linking and merge request comment triggers.                                                 |
+| `GITLAB_WEBHOOK_SIGNING_TOKEN` | Optional     | GitLab webhook signing token.                                                                                                                    |
+| `GITLAB_WEBHOOK_SECRET`        | Optional     | GitLab webhook secret.                                                                                                                           |
+| `GITEA_BASE_URL`               | Gitea        | Gitea base URL.                                                                                                                                  |
+| `GITEA_TOKEN`                  | Gitea        | Gitea access token.                                                                                                                              |
+| `GITEA_USERNAME`               | Optional     | Gitea username.                                                                                                                                  |
+| `GITEA_CLIENT_ID`              | Optional     | Gitea OAuth client ID.                                                                                                                           |
+| `GITEA_CLIENT_SECRET`          | Optional     | Gitea OAuth client secret.                                                                                                                       |
+| `GITEA_WEBHOOK_SECRET`         | Optional     | Gitea webhook secret.                                                                                                                            |
+| `BITBUCKET_TOKEN`              | Bitbucket    | Atlassian API token with Bitbucket scopes.                                                                                                       |
+| `BITBUCKET_USERNAME`           | Bitbucket    | Atlassian account email that owns the API token.                                                                                                 |
+| `BITBUCKET_BASE_URL`           | Optional     | Bitbucket base URL. Defaults to `https://bitbucket.org` (Cloud only).                                                                            |
+| `BITBUCKET_CLIENT_ID`          | Optional     | Bitbucket OAuth client ID for personal account linking.                                                                                          |
+| `BITBUCKET_CLIENT_SECRET`      | Optional     | Bitbucket OAuth client secret for personal account linking.                                                                                      |
+| `BITBUCKET_WEBHOOK_SECRET`     | Optional     | Bitbucket webhook secret.                                                                                                                        |
+| `ADO_ORGANIZATION`             | Azure DevOps | Azure DevOps organization.                                                                                                                       |
+| `ADO_TOKEN`                    | Azure DevOps | Azure DevOps access token.                                                                                                                       |
+| `ADO_BASE_URL`                 | Optional     | Azure DevOps base URL.                                                                                                                           |
+| `ADO_USERNAME`                 | Optional     | Azure DevOps username.                                                                                                                           |
+| `ADO_CLIENT_ID`                | Optional     | Microsoft Entra client ID for Azure DevOps OAuth. Falls back to `R_MICROSOFT_CLIENT_ID`.                                                         |
+| `ADO_CLIENT_SECRET`            | Optional     | Microsoft Entra client secret for Azure DevOps OAuth. Falls back to `R_MICROSOFT_CLIENT_SECRET`.                                                 |
+| `ADO_TENANT_ID`                | Conditional  | Microsoft Entra tenant ID for Azure DevOps OAuth. Required unless the app is multi-tenant; falls back to `R_MICROSOFT_TENANT_ID`, then `common`. |
+| `ADO_WEBHOOK_SECRET`           | Optional     | Azure DevOps webhook secret.                                                                                                                     |
 
 ### Communications and sign-in
 

--- a/apps/docs/providers/source-control/azure-devops.mdx
+++ b/apps/docs/providers/source-control/azure-devops.mdx
@@ -8,8 +8,8 @@ Azure DevOps uses two separate credentials:
 
 - a deployment-owned personal access token (PAT) lets Roomote sync and work in
   repositories
-- optional Microsoft Entra OAuth identifies individual Roomote users when they
-  start work from pull request comments
+- Microsoft Entra OAuth identifies individual Roomote users when they start
+  work from pull request comments
 
 ## Create an Azure DevOps PAT
 
@@ -38,9 +38,9 @@ ADO_USERNAME=ado
 
 ## Link individual user accounts
 
-Account linking is optional for repository sync and manual tasks. It is
-required for pull request comment triggers so Roomote can verify which user
-made the comment.
+Roomote requires account linking when setting up Azure DevOps Services so the
+integration is ready for pull request comment triggers. Azure DevOps Server
+uses the PAT flow without Microsoft Entra account linking.
 
 1. Open [Microsoft Entra app registrations](https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade)
    and create or select an app registration.
@@ -52,14 +52,16 @@ made the comment.
 
 3. Under **API permissions**, add the Azure DevOps delegated
    `user_impersonation` permission.
-4. Create a client secret, then enter the application ID and secret in the
-   Azure DevOps account-linking section during setup or in Settings.
-5. Select **Link my Azure DevOps account** and complete Microsoft sign-in.
+4. For a new app, create a client secret, then enter the application ID and
+   secret in the Azure DevOps account-linking section during setup or in
+   Settings.
+5. Select **Save and link account** and complete Microsoft sign-in.
 
 If Microsoft Teams or Microsoft sign-in is already configured, you can reuse
 that Microsoft Entra app registration. Add the Azure DevOps redirect URI and
-permission to the existing app, then use the same client ID, client secret, and
-tenant ID for Azure DevOps.
+permission to the existing app. Roomote automatically reuses the stored
+Microsoft client ID, client secret, and tenant ID when Azure DevOps-specific
+values are not configured, so you do not need to re-enter the secret.
 
 The equivalent environment variables are:
 
@@ -69,9 +71,8 @@ ADO_CLIENT_SECRET=<microsoft-entra-client-secret>
 ADO_TENANT_ID=<microsoft-entra-tenant-id>
 ```
 
-`ADO_TENANT_ID` is optional and defaults to Microsoft&apos;s `common` tenant. If
-you reuse the Teams app registration, enter its tenant ID here when the app is
-single-tenant.
+`ADO_TENANT_ID` is optional. It reuses `R_MICROSOFT_TENANT_ID` when available,
+then defaults to Microsoft&apos;s `common` tenant.
 
 ## Sync repositories
 
@@ -97,5 +98,4 @@ credential helper instead of exporting `ADO_TOKEN` into task shells.
 2. create or update an environment from a synced repository
 3. start a small task and confirm Roomote can clone the repository
 4. confirm Roomote can push a branch when the task produces changes
-5. if account linking is enabled, link your Azure DevOps account and trigger a
-   small task from a pull request comment
+5. for Azure DevOps Services, trigger a small task from a pull request comment

--- a/apps/docs/providers/source-control/azure-devops.mdx
+++ b/apps/docs/providers/source-control/azure-devops.mdx
@@ -71,8 +71,9 @@ ADO_CLIENT_SECRET=<microsoft-entra-client-secret>
 ADO_TENANT_ID=<microsoft-entra-tenant-id>
 ```
 
-`ADO_TENANT_ID` is optional. It reuses `R_MICROSOFT_TENANT_ID` when available,
-then defaults to Microsoft&apos;s `common` tenant.
+`ADO_TENANT_ID` is required unless the Entra app supports multiple tenants. It
+reuses `R_MICROSOFT_TENANT_ID` when available, then defaults to Microsoft&apos;s
+`common` tenant for multi-tenant apps.
 
 ## Sync repositories
 

--- a/apps/docs/providers/source-control/azure-devops.mdx
+++ b/apps/docs/providers/source-control/azure-devops.mdx
@@ -1,13 +1,15 @@
 ---
 title: Azure DevOps
 icon: 'https://api.iconify.design/simple-icons:azuredevops.svg?color=currentColor'
-description: Configure Azure DevOps repository sync for Roomote.
+description: Connect Azure DevOps repositories and user accounts to Roomote.
 ---
 
-Azure DevOps support uses a deployment-owned personal access token and
-organization. There is no self-serve OAuth installation flow, service hook
-ingestion, or Review Code automation path yet, so an operator provides Azure
-DevOps credentials and syncs repositories from Settings.
+Azure DevOps uses two separate credentials:
+
+- a deployment-owned personal access token (PAT) lets Roomote sync and work in
+  repositories
+- optional Microsoft Entra OAuth identifies individual Roomote users when they
+  start work from pull request comments
 
 ## Create an Azure DevOps PAT
 
@@ -34,6 +36,43 @@ ADO_USERNAME=ado
 `ADO_BASE_URL` defaults to `https://dev.azure.com`. `ADO_USERNAME` defaults to
 `ado` and is used as the Git-over-HTTPS username paired with the PAT.
 
+## Link individual user accounts
+
+Account linking is optional for repository sync and manual tasks. It is
+required for pull request comment triggers so Roomote can verify which user
+made the comment.
+
+1. Open [Microsoft Entra app registrations](https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade)
+   and create or select an app registration.
+2. Add this **Web** redirect URI, replacing the origin with your Roomote URL:
+
+   ```text
+   https://<your-roomote-origin>/api/auth/oauth2/callback/ado
+   ```
+
+3. Under **API permissions**, add the Azure DevOps delegated
+   `user_impersonation` permission.
+4. Create a client secret, then enter the application ID and secret in the
+   Azure DevOps account-linking section during setup or in Settings.
+5. Select **Link my Azure DevOps account** and complete Microsoft sign-in.
+
+If Microsoft Teams or Microsoft sign-in is already configured, you can reuse
+that Microsoft Entra app registration. Add the Azure DevOps redirect URI and
+permission to the existing app, then use the same client ID, client secret, and
+tenant ID for Azure DevOps.
+
+The equivalent environment variables are:
+
+```sh
+ADO_CLIENT_ID=<microsoft-entra-application-id>
+ADO_CLIENT_SECRET=<microsoft-entra-client-secret>
+ADO_TENANT_ID=<microsoft-entra-tenant-id>
+```
+
+`ADO_TENANT_ID` is optional and defaults to Microsoft&apos;s `common` tenant. If
+you reuse the Teams app registration, enter its tenant ID here when the app is
+single-tenant.
+
 ## Sync repositories
 
 After the Azure DevOps values are available, open Settings, go to the
@@ -44,18 +83,13 @@ button. Roomote lists repositories from:
 https://dev.azure.com/<organization>/_apis/git/repositories?api-version=7.1
 ```
 
-Roomote stores the results as Azure DevOps repository rows.
+Roomote stores the results as Azure DevOps repository rows and configures pull
+request service hooks when the deployment has a publicly reachable URL.
 
 Azure DevOps-backed tasks clone from the synced repository row, so sync must
 run before launching an Azure DevOps-backed task. Worker tasks write
 host- and clone-path-scoped Azure DevOps credentials into the file-backed Git
 credential helper instead of exporting `ADO_TOKEN` into task shells.
-
-## Current limits
-
-Azure DevOps service hook ingestion and Review Code automation are not
-implemented yet. Azure DevOps support currently covers repository sync and
-Azure DevOps-backed manual or environment launches.
 
 ## Verify setup
 
@@ -63,3 +97,5 @@ Azure DevOps-backed manual or environment launches.
 2. create or update an environment from a synced repository
 3. start a small task and confirm Roomote can clone the repository
 4. confirm Roomote can push a branch when the task produces changes
+5. if account linking is enabled, link your Azure DevOps account and trigger a
+   small task from a pull request comment

--- a/apps/docs/source-control.mdx
+++ b/apps/docs/source-control.mdx
@@ -15,13 +15,13 @@ to review events or comments when the provider supports them.
 
 ## Supported providers
 
-| Provider | Best for | Setup model |
-| -------- | -------- | ----------- |
-| <IntegrationName href="/providers/source-control/github" icon="github" name="GitHub" /> | GitHub-hosted repositories and pull request review workflows | GitHub App installation (default provider). |
-| <IntegrationName href="/providers/source-control/azure-devops" icon="azuredevops" name="Azure DevOps" /> | Azure DevOps repositories | Deployment-owned PAT and repository sync. |
-| <IntegrationName href="/providers/source-control/bitbucket" icon="bitbucket" name="Bitbucket" /> | Bitbucket Cloud repositories and pull request workflows | Deployment-owned Atlassian API token and repository sync. |
-| <IntegrationName href="/providers/source-control/gitea" icon="gitea" name="Gitea" /> | Self-hosted Gitea repositories | Deployment-owned token and repository sync. |
-| <IntegrationName href="/providers/source-control/gitlab" icon="gitlab" name="GitLab" /> | GitLab projects and merge request review workflows | Deployment-owned token and optional webhooks. |
+| Provider                                                                                                 | Best for                                                     | Setup model                                                                          |
+| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| <IntegrationName href="/providers/source-control/github" icon="github" name="GitHub" />                  | GitHub-hosted repositories and pull request review workflows | GitHub App installation (default provider).                                          |
+| <IntegrationName href="/providers/source-control/azure-devops" icon="azuredevops" name="Azure DevOps" /> | Azure DevOps repositories                                    | Deployment-owned PAT, repository sync, and optional Microsoft Entra account linking. |
+| <IntegrationName href="/providers/source-control/bitbucket" icon="bitbucket" name="Bitbucket" />         | Bitbucket Cloud repositories and pull request workflows      | Deployment-owned Atlassian API token and repository sync.                            |
+| <IntegrationName href="/providers/source-control/gitea" icon="gitea" name="Gitea" />                     | Self-hosted Gitea repositories                               | Deployment-owned token and repository sync.                                          |
+| <IntegrationName href="/providers/source-control/gitlab" icon="gitlab" name="GitLab" />                  | GitLab projects and merge request review workflows           | Deployment-owned token and optional webhooks.                                        |
 
 ## Setup checklist
 

--- a/apps/docs/source-control.mdx
+++ b/apps/docs/source-control.mdx
@@ -15,13 +15,13 @@ to review events or comments when the provider supports them.
 
 ## Supported providers
 
-| Provider                                                                                                 | Best for                                                     | Setup model                                                                          |
-| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
-| <IntegrationName href="/providers/source-control/github" icon="github" name="GitHub" />                  | GitHub-hosted repositories and pull request review workflows | GitHub App installation (default provider).                                          |
-| <IntegrationName href="/providers/source-control/azure-devops" icon="azuredevops" name="Azure DevOps" /> | Azure DevOps repositories                                    | Deployment-owned PAT, repository sync, and optional Microsoft Entra account linking. |
-| <IntegrationName href="/providers/source-control/bitbucket" icon="bitbucket" name="Bitbucket" />         | Bitbucket Cloud repositories and pull request workflows      | Deployment-owned Atlassian API token and repository sync.                            |
-| <IntegrationName href="/providers/source-control/gitea" icon="gitea" name="Gitea" />                     | Self-hosted Gitea repositories                               | Deployment-owned token and repository sync.                                          |
-| <IntegrationName href="/providers/source-control/gitlab" icon="gitlab" name="GitLab" />                  | GitLab projects and merge request review workflows           | Deployment-owned token and optional webhooks.                                        |
+| Provider                                                                                                 | Best for                                                     | Setup model                                                                 |
+| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| <IntegrationName href="/providers/source-control/github" icon="github" name="GitHub" />                  | GitHub-hosted repositories and pull request review workflows | GitHub App installation (default provider).                                 |
+| <IntegrationName href="/providers/source-control/azure-devops" icon="azuredevops" name="Azure DevOps" /> | Azure DevOps repositories                                    | Deployment-owned PAT, repository sync, and Microsoft Entra account linking. |
+| <IntegrationName href="/providers/source-control/bitbucket" icon="bitbucket" name="Bitbucket" />         | Bitbucket Cloud repositories and pull request workflows      | Deployment-owned Atlassian API token and repository sync.                   |
+| <IntegrationName href="/providers/source-control/gitea" icon="gitea" name="Gitea" />                     | Self-hosted Gitea repositories                               | Deployment-owned token and repository sync.                                 |
+| <IntegrationName href="/providers/source-control/gitlab" icon="gitlab" name="GitLab" />                  | GitLab projects and merge request review workflows           | Deployment-owned token and optional webhooks.                               |
 
 ## Setup checklist
 

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
@@ -4,16 +4,21 @@ import {
   type SetupSourceControlStatus,
 } from '@roomote/types';
 
-const { createGitHubAppManifestMock, mutateAsyncMock, saveMutationOptionsRef } =
-  vi.hoisted(() => ({
-    createGitHubAppManifestMock: vi.fn(),
-    mutateAsyncMock: vi.fn(),
-    saveMutationOptionsRef: {
-      current: null as {
-        mutationFn?: (variables: unknown) => Promise<unknown>;
-      } | null,
-    },
-  }));
+const {
+  authenticateAdoAccountMock,
+  createGitHubAppManifestMock,
+  mutateAsyncMock,
+  saveMutationOptionsRef,
+} = vi.hoisted(() => ({
+  authenticateAdoAccountMock: vi.fn(),
+  createGitHubAppManifestMock: vi.fn(),
+  mutateAsyncMock: vi.fn(),
+  saveMutationOptionsRef: {
+    current: null as {
+      mutationFn?: (variables: unknown) => Promise<unknown>;
+    } | null,
+  },
+}));
 
 vi.mock('@tanstack/react-query', () => ({
   useMutation: (options: typeof saveMutationOptionsRef.current) => {
@@ -45,6 +50,17 @@ vi.mock('@/trpc/client', () => ({
 vi.mock('@/hooks/github', () => ({
   useCreateGitHubAppManifest: () => ({
     mutate: createGitHubAppManifestMock,
+    isPending: false,
+  }),
+}));
+
+vi.mock('@/hooks/linked-accounts', () => ({
+  useAdoLinkedAccount: () => ({
+    data: { configured: false, account: null },
+    isPending: false,
+  }),
+  useAuthenticateAdoAccount: () => ({
+    mutate: authenticateAdoAccountMock,
     isPending: false,
   }),
 }));
@@ -454,7 +470,7 @@ describe('StepSourceControlConfig', () => {
     },
   );
 
-  it('keeps optional Azure DevOps fields behind advanced options', () => {
+  it('separates Azure DevOps account linking from advanced options', () => {
     render(
       <StepSourceControlConfig
         sourceControlSetup={buildSetupSourceControlStatus({
@@ -484,6 +500,17 @@ describe('StepSourceControlConfig', () => {
     expect(screen.getByText('Azure DevOps Base URL (optional)')).toBeVisible();
     expect(screen.getByText('Azure DevOps Username (optional)')).toBeVisible();
     expect(
+      screen.queryByText('Microsoft Entra Client ID (optional)'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText('Azure DevOps Webhook Secret (optional)'),
+    ).toBeVisible();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Set up account linking' }),
+    );
+
+    expect(
       screen.getByText('Microsoft Entra Client ID (optional)'),
     ).toBeVisible();
     expect(
@@ -493,7 +520,10 @@ describe('StepSourceControlConfig', () => {
       screen.getByText('Microsoft Entra Tenant ID (optional)'),
     ).toBeVisible();
     expect(
-      screen.getByText('Azure DevOps Webhook Secret (optional)'),
+      screen.getByText(/If Microsoft Teams or Microsoft sign-in/),
+    ).toBeVisible();
+    expect(
+      screen.getByText(/\/api\/auth\/oauth2\/callback\/ado$/),
     ).toBeVisible();
   });
 

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
@@ -378,7 +378,7 @@ describe('StepSourceControlConfig', () => {
       screen.getByText(/Use only letters, numbers, and hyphens/),
     ).toBeVisible();
     expect(
-      screen.getByRole('button', { name: 'Save and continue' }),
+      screen.getByRole('button', { name: 'Save and link account' }),
     ).toBeDisabled();
   });
 
@@ -489,9 +489,7 @@ describe('StepSourceControlConfig', () => {
     expect(
       screen.queryByLabelText(/Azure DevOps Base URL/),
     ).not.toBeInTheDocument();
-    expect(
-      screen.queryByText('Microsoft Entra Client ID'),
-    ).not.toBeInTheDocument();
+    expect(screen.getByText('Microsoft Entra Client ID')).toBeVisible();
 
     fireEvent.click(
       screen.getByRole('button', { name: 'Show advanced options' }),
@@ -499,23 +497,13 @@ describe('StepSourceControlConfig', () => {
 
     expect(screen.getByText('Azure DevOps Base URL (optional)')).toBeVisible();
     expect(screen.getByText('Azure DevOps Username (optional)')).toBeVisible();
-    expect(
-      screen.queryByText('Microsoft Entra Client ID (optional)'),
-    ).not.toBeInTheDocument();
+    expect(screen.getByText('Microsoft Entra Client ID')).toBeVisible();
     expect(
       screen.getByText('Azure DevOps Webhook Secret (optional)'),
     ).toBeVisible();
 
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Set up account linking' }),
-    );
-
-    expect(
-      screen.getByText('Microsoft Entra Client ID (optional)'),
-    ).toBeVisible();
-    expect(
-      screen.getByText('Microsoft Entra Client Secret (optional)'),
-    ).toBeVisible();
+    expect(screen.getByText('Microsoft Entra Client ID')).toBeVisible();
+    expect(screen.getByText('Microsoft Entra Client Secret')).toBeVisible();
     expect(
       screen.getByText('Microsoft Entra Tenant ID (optional)'),
     ).toBeVisible();
@@ -527,7 +515,7 @@ describe('StepSourceControlConfig', () => {
     ).toBeVisible();
   });
 
-  it('saves the organization and PAT together', () => {
+  it('requires OAuth setup and saves it with the organization and PAT', () => {
     render(
       <StepSourceControlConfig
         sourceControlSetup={buildSetupSourceControlStatus({
@@ -545,11 +533,24 @@ describe('StepSourceControlConfig', () => {
     fireEvent.change(screen.getByLabelText('Azure DevOps Access Token'), {
       target: { value: 'ado-pat' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Save and continue' }));
+    expect(
+      screen.getByRole('button', { name: 'Save and link account' }),
+    ).toBeDisabled();
+    fireEvent.change(screen.getByLabelText('Microsoft Entra Client ID'), {
+      target: { value: 'client-id' },
+    });
+    fireEvent.change(screen.getByLabelText('Microsoft Entra Client Secret'), {
+      target: { value: 'client-secret' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Save and link account' }),
+    );
 
     expect(mutateAsyncMock).toHaveBeenCalledWith({
       provider: 'ado',
       values: {
+        ADO_CLIENT_ID: 'client-id',
+        ADO_CLIENT_SECRET: 'client-secret',
         ADO_ORGANIZATION: 'acme',
         ADO_TOKEN: 'ado-pat',
       },

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
@@ -1,23 +1,26 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import type { SetupSourceControlStatus } from '@roomote/types';
+import {
+  buildSetupSourceControlStatus,
+  type SetupSourceControlStatus,
+} from '@roomote/types';
 
-const { createGitHubAppManifestMock, saveMutationOptionsRef } = vi.hoisted(
-  () => ({
+const { createGitHubAppManifestMock, mutateAsyncMock, saveMutationOptionsRef } =
+  vi.hoisted(() => ({
     createGitHubAppManifestMock: vi.fn(),
+    mutateAsyncMock: vi.fn(),
     saveMutationOptionsRef: {
       current: null as {
         mutationFn?: (variables: unknown) => Promise<unknown>;
       } | null,
     },
-  }),
-);
+  }));
 
 vi.mock('@tanstack/react-query', () => ({
   useMutation: (options: typeof saveMutationOptionsRef.current) => {
     saveMutationOptionsRef.current = options;
 
     return {
-      mutateAsync: vi.fn(),
+      mutateAsync: mutateAsyncMock,
       isPending: false,
     };
   },
@@ -120,6 +123,7 @@ function buildSourceControlSetup(
 describe('StepSourceControlConfig', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mutateAsyncMock.mockResolvedValue(undefined);
   });
 
   it('defaults GitHub setup to the manifest CTA', () => {
@@ -215,5 +219,310 @@ describe('StepSourceControlConfig', () => {
     expect(
       screen.queryByRole('button', { name: 'Create GitHub App' }),
     ).not.toBeInTheDocument();
+  });
+
+  it('asks for the Azure DevOps organization before showing PAT setup', () => {
+    render(
+      <StepSourceControlConfig
+        sourceControlSetup={buildSetupSourceControlStatus({
+          selectedProvider: 'ado',
+        })}
+        selectedProviderId="ado"
+        onContinue={vi.fn()}
+      />,
+    );
+
+    const organizationInput = screen.getByLabelText(
+      'Azure DevOps Organization',
+    );
+    const continueButton = screen.getByRole('button', { name: 'Continue' });
+
+    expect(organizationInput).toBeInTheDocument();
+    expect(continueButton).toBeDisabled();
+    expect(
+      screen.queryByLabelText('Azure DevOps Access Token'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Create Azure DevOps PAT' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/Azure DevOps Base URL/),
+    ).not.toBeInTheDocument();
+
+    fireEvent.change(organizationInput, { target: { value: ' acme ' } });
+
+    expect(continueButton).toBeEnabled();
+  });
+
+  it('rejects organization URLs and malformed cloud organization names', () => {
+    render(
+      <StepSourceControlConfig
+        sourceControlSetup={buildSetupSourceControlStatus({
+          selectedProvider: 'ado',
+        })}
+        selectedProviderId="ado"
+        onContinue={vi.fn()}
+      />,
+    );
+
+    const organizationInput = screen.getByLabelText(
+      'Azure DevOps Organization',
+    );
+    const continueButton = screen.getByRole('button', { name: 'Continue' });
+
+    fireEvent.change(organizationInput, {
+      target: { value: 'https://dev.azure.com/acme' },
+    });
+
+    expect(organizationInput).toHaveAttribute('aria-invalid', 'true');
+    expect(continueButton).toBeDisabled();
+    expect(
+      screen.getByText(/Use only letters, numbers, and hyphens/),
+    ).toBeVisible();
+
+    fireEvent.change(organizationInput, {
+      target: { value: 'acme org' },
+    });
+
+    expect(continueButton).toBeDisabled();
+  });
+
+  it('uses PAT instructions instead of a cloud link for Azure DevOps Server', () => {
+    render(
+      <StepSourceControlConfig
+        sourceControlSetup={buildSetupSourceControlStatus({
+          selectedProvider: 'ado',
+        })}
+        selectedProviderId="ado"
+        onContinue={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Using Azure DevOps Server?' }),
+    );
+    fireEvent.change(screen.getByLabelText(/Azure DevOps Base URL/), {
+      target: { value: 'https://ado.example.com/tfs' },
+    });
+    fireEvent.change(screen.getByLabelText('Azure DevOps Organization'), {
+      target: { value: 'Default Collection' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    expect(
+      screen.getByRole('link', { name: 'View PAT setup instructions' }),
+    ).toHaveAttribute(
+      'href',
+      'https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops',
+    );
+    expect(
+      screen.queryByRole('link', { name: 'Create Azure DevOps PAT' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/Azure DevOps Base URL/),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Show advanced options' }),
+    );
+    expect(screen.getByLabelText(/Azure DevOps Base URL/)).toHaveValue(
+      'https://ado.example.com/tfs',
+    );
+
+    fireEvent.change(screen.getByLabelText('Azure DevOps Access Token'), {
+      target: { value: 'ado-pat' },
+    });
+    expect(
+      screen.getByRole('button', { name: 'Save and continue' }),
+    ).toBeEnabled();
+
+    fireEvent.change(screen.getByLabelText(/Azure DevOps Base URL/), {
+      target: { value: 'ado.example.com' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Hide advanced options' }),
+    );
+    expect(
+      screen.getByText('Enter a valid HTTP or HTTPS Azure DevOps Server URL.'),
+    ).toBeVisible();
+    expect(
+      screen.getByRole('button', { name: 'Show advanced options' }),
+    ).toHaveAttribute('aria-describedby', 'setup-ado-advanced-options-error');
+    expect(
+      screen.getByRole('button', { name: 'Save and continue' }),
+    ).toBeDisabled();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Show advanced options' }),
+    );
+    fireEvent.change(screen.getByLabelText(/Azure DevOps Base URL/), {
+      target: { value: '' },
+    });
+    expect(
+      screen.getByText(/Use only letters, numbers, and hyphens/),
+    ).toBeVisible();
+    expect(
+      screen.getByRole('button', { name: 'Save and continue' }),
+    ).toBeDisabled();
+  });
+
+  it('links to PAT creation for the entered organization and can go back', () => {
+    const onBack = vi.fn();
+
+    render(
+      <StepSourceControlConfig
+        sourceControlSetup={buildSetupSourceControlStatus({
+          selectedProvider: 'ado',
+        })}
+        selectedProviderId="ado"
+        onContinue={vi.fn()}
+        onBack={onBack}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Azure DevOps Organization'), {
+      target: { value: ' acme ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    expect(
+      screen.getByRole('link', { name: 'Create Azure DevOps PAT' }),
+    ).toHaveAttribute(
+      'href',
+      'https://dev.azure.com/acme/_usersSettings/tokens',
+    );
+    expect(
+      screen.getByLabelText('Azure DevOps Access Token'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('acme')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+
+    expect(screen.getByLabelText('Azure DevOps Organization')).toHaveValue(
+      'acme',
+    );
+    expect(onBack).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: 'saved',
+      status: buildSetupSourceControlStatus({
+        selectedProvider: 'ado',
+        persistedEnvVarNames: ['ADO_ORGANIZATION'],
+        persistedEnvVarValues: { ADO_ORGANIZATION: 'saved-org' },
+      }),
+      organization: 'saved-org',
+    },
+    {
+      name: 'runtime',
+      status: buildSetupSourceControlStatus({
+        selectedProvider: 'ado',
+        runtimeEnv: { ADO_ORGANIZATION: 'runtime-org' },
+      }),
+      organization: 'runtime-org',
+    },
+  ])(
+    'uses a $name organization for the PAT link',
+    ({ name, status, organization }) => {
+      render(
+        <StepSourceControlConfig
+          sourceControlSetup={status}
+          selectedProviderId="ado"
+          onContinue={vi.fn()}
+        />,
+      );
+
+      expect(
+        screen.getByRole('link', { name: 'Create Azure DevOps PAT' }),
+      ).toHaveAttribute(
+        'href',
+        `https://dev.azure.com/${organization}/_usersSettings/tokens`,
+      );
+
+      if (name === 'runtime') {
+        expect(
+          screen.queryByRole('button', { name: 'Change organization' }),
+        ).not.toBeInTheDocument();
+        expect(
+          screen.getByText('Managed by runtime configuration'),
+        ).toBeVisible();
+        expect(
+          screen.queryByRole('button', { name: 'Back' }),
+        ).not.toBeInTheDocument();
+      }
+    },
+  );
+
+  it('keeps optional Azure DevOps fields behind advanced options', () => {
+    render(
+      <StepSourceControlConfig
+        sourceControlSetup={buildSetupSourceControlStatus({
+          selectedProvider: 'ado',
+        })}
+        selectedProviderId="ado"
+        onContinue={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Azure DevOps Organization'), {
+      target: { value: 'acme' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    expect(
+      screen.queryByLabelText(/Azure DevOps Base URL/),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Microsoft Entra Client ID'),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Show advanced options' }),
+    );
+
+    expect(screen.getByText('Azure DevOps Base URL (optional)')).toBeVisible();
+    expect(screen.getByText('Azure DevOps Username (optional)')).toBeVisible();
+    expect(
+      screen.getByText('Microsoft Entra Client ID (optional)'),
+    ).toBeVisible();
+    expect(
+      screen.getByText('Microsoft Entra Client Secret (optional)'),
+    ).toBeVisible();
+    expect(
+      screen.getByText('Microsoft Entra Tenant ID (optional)'),
+    ).toBeVisible();
+    expect(
+      screen.getByText('Azure DevOps Webhook Secret (optional)'),
+    ).toBeVisible();
+  });
+
+  it('saves the organization and PAT together', () => {
+    render(
+      <StepSourceControlConfig
+        sourceControlSetup={buildSetupSourceControlStatus({
+          selectedProvider: 'ado',
+        })}
+        selectedProviderId="ado"
+        onContinue={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Azure DevOps Organization'), {
+      target: { value: ' acme ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    fireEvent.change(screen.getByLabelText('Azure DevOps Access Token'), {
+      target: { value: 'ado-pat' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save and continue' }));
+
+    expect(mutateAsyncMock).toHaveBeenCalledWith({
+      provider: 'ado',
+      values: {
+        ADO_ORGANIZATION: 'acme',
+        ADO_TOKEN: 'ado-pat',
+      },
+    });
   });
 });

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
@@ -505,7 +505,12 @@ describe('StepSourceControlConfig', () => {
     expect(screen.getByText('Microsoft Entra Client ID')).toBeVisible();
     expect(screen.getByText('Microsoft Entra Client Secret')).toBeVisible();
     expect(
-      screen.getByText('Microsoft Entra Tenant ID (optional)'),
+      screen.getByText(
+        'Microsoft Entra Tenant ID (required unless multi-tenant)',
+      ),
+    ).toBeVisible();
+    expect(
+      screen.getByText(/tenant ID is required unless the app supports/),
     ).toBeVisible();
     expect(
       screen.getByText(/If Microsoft Teams or Microsoft sign-in/),

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.tsx
@@ -15,6 +15,7 @@ import {
   getAdoOAuthValidationError,
   getEffectiveAdoBaseUrl,
   getEffectiveAdoOrganization,
+  isAdoOAuthReady,
 } from '@/components/source-control/AdoSourceControlConfigFields';
 import {
   ArrowLeft,
@@ -37,6 +38,7 @@ import {
 import {
   getAdoBaseUrlValidationError,
   getAdoOrganizationValidationError,
+  isAdoCloudBaseUrl,
 } from '@/lib/ado';
 
 import { StepTitle } from './StepTitle';
@@ -102,7 +104,6 @@ export function StepSourceControlConfig({
   const [adoOrganizationConfirmed, setAdoOrganizationConfirmed] =
     useState(false);
   const [adoAdvancedExpanded, setAdoAdvancedExpanded] = useState(false);
-  const [adoOauthExpanded, setAdoOauthExpanded] = useState(false);
   const adoPostSaveActionRef = useRef<'continue' | 'link'>('continue');
   const adoLinkedAccount = useAdoLinkedAccount({
     enabled: effectiveSelectedProviderId === 'ado',
@@ -182,7 +183,6 @@ export function StepSourceControlConfig({
     setGithubOrganization('');
     setAdoOrganizationConfirmed(hasConfiguredAdoOrganization);
     setAdoAdvancedExpanded(false);
-    setAdoOauthExpanded(false);
     setManifestForm(null);
   }, [
     effectiveSelectedProviderId,
@@ -248,9 +248,14 @@ export function StepSourceControlConfig({
     adoBaseUrl,
   );
   const adoBaseUrlValidationError = getAdoBaseUrlValidationError(adoBaseUrl);
-  const adoOAuthValidationError = isAdo
+  const usesAdoCloud = isAdo && isAdoCloudBaseUrl(adoBaseUrl);
+  const adoOAuthValidationError = usesAdoCloud
     ? getAdoOAuthValidationError(selectedProvider.fields, values)
     : null;
+  const adoOAuthReady = usesAdoCloud
+    ? isAdoOAuthReady(selectedProvider.fields, values)
+    : true;
+  const adoAccountLinked = Boolean(adoLinkedAccount.data?.account);
   const canConfirmAdoOrganization =
     adoOrganizationValidationError === null &&
     adoBaseUrlValidationError === null;
@@ -399,11 +404,14 @@ export function StepSourceControlConfig({
         return;
       }
 
+      adoPostSaveActionRef.current =
+        usesAdoCloud && !adoAccountLinked ? 'link' : 'continue';
       void handleContinue();
     };
     const isAdoActionDisabled = adoOrganizationConfirmed
       ? isSaveActionDisabled ||
         authenticateAdoAccount.isPending ||
+        !adoOAuthReady ||
         adoOrganizationValidationError !== null ||
         adoBaseUrlValidationError !== null ||
         adoOAuthValidationError !== null
@@ -419,11 +427,9 @@ export function StepSourceControlConfig({
           editingSavedValues={editingSavedValues}
           organizationConfirmed={adoOrganizationConfirmed}
           advancedExpanded={adoAdvancedExpanded}
-          oauthExpanded={adoOauthExpanded}
           oauthCallbackUrl={adoRedirectUri}
-          oauthAccountLinked={Boolean(adoLinkedAccount.data?.account)}
+          oauthAccountLinked={adoAccountLinked}
           oauthAccountStatePending={adoLinkedAccount.isPending}
-          oauthLinkPending={authenticateAdoAccount.isPending}
           disabled={
             saveSourceControlConfig.isPending ||
             authenticateAdoAccount.isPending
@@ -446,14 +452,6 @@ export function StepSourceControlConfig({
             setAdoOrganizationConfirmed(false);
           }}
           onAdvancedExpandedChange={setAdoAdvancedExpanded}
-          onOauthExpandedChange={setAdoOauthExpanded}
-          onLinkAccount={() =>
-            authenticateAdoAccount.mutate('/setup?step=source-control-connect')
-          }
-          onSaveAndLinkAccount={() => {
-            adoPostSaveActionRef.current = 'link';
-            void handleContinue();
-          }}
         />
 
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
@@ -493,9 +491,13 @@ export function StepSourceControlConfig({
             {adoOrganizationConfirmed
               ? saveSourceControlConfig.isPending
                 ? 'Saving...'
-                : canContinueWithoutNewValues
-                  ? 'Continue'
-                  : 'Save and continue'
+                : usesAdoCloud && !adoAccountLinked
+                  ? canContinueWithoutNewValues
+                    ? 'Link account'
+                    : 'Save and link account'
+                  : canContinueWithoutNewValues
+                    ? 'Continue'
+                    : 'Save and continue'
               : 'Continue'}
             {saveSourceControlConfig.isPending ? <Spinner /> : <ArrowRight />}
           </Button>

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.tsx
@@ -11,6 +11,11 @@ import type {
 
 import { useTRPC } from '@/trpc/client';
 import {
+  AdoSourceControlConfigFields,
+  getEffectiveAdoBaseUrl,
+  getEffectiveAdoOrganization,
+} from '@/components/source-control/AdoSourceControlConfigFields';
+import {
   ArrowLeft,
   ArrowRight,
   Button,
@@ -24,6 +29,10 @@ import {
   Spinner,
 } from '@/components/system';
 import { useCreateGitHubAppManifest } from '@/hooks/github';
+import {
+  getAdoBaseUrlValidationError,
+  getAdoOrganizationValidationError,
+} from '@/lib/ado';
 
 import { StepTitle } from './StepTitle';
 import { getSourceControlSetupCopy } from './sourceControlSetupCopy';
@@ -85,6 +94,9 @@ export function StepSourceControlConfig({
   >({});
   const [showManualGitHubValues, setShowManualGitHubValues] = useState(false);
   const [githubOrganization, setGithubOrganization] = useState('');
+  const [adoOrganizationConfirmed, setAdoOrganizationConfirmed] =
+    useState(false);
+  const [adoAdvancedExpanded, setAdoAdvancedExpanded] = useState(false);
   const [manifestForm, setManifestForm] =
     useState<GitHubAppManifestForm | null>(null);
   const manifestFormRef = useRef<HTMLFormElement | null>(null);
@@ -139,14 +151,27 @@ export function StepSourceControlConfig({
   const [values, setValues] = useState<Record<string, string>>(
     () => nonSecretInitialValues,
   );
+  const hasConfiguredAdoOrganization =
+    selectedProvider?.provider === 'ado' &&
+    selectedProvider.fields.some(
+      (field) =>
+        field.envVarName === 'ADO_ORGANIZATION' &&
+        (field.runtimeSatisfied || field.savedSatisfied),
+    );
 
   useEffect(() => {
     setValues(nonSecretInitialValues);
     setEditingSavedValues({});
     setShowManualGitHubValues(false);
     setGithubOrganization('');
+    setAdoOrganizationConfirmed(hasConfiguredAdoOrganization);
+    setAdoAdvancedExpanded(false);
     setManifestForm(null);
-  }, [effectiveSelectedProviderId, nonSecretInitialValues]);
+  }, [
+    effectiveSelectedProviderId,
+    hasConfiguredAdoOrganization,
+    nonSecretInitialValues,
+  ]);
 
   useEffect(() => {
     if (manifestForm) {
@@ -161,7 +186,7 @@ export function StepSourceControlConfig({
         field.savedSatisfied,
     ) ?? false;
 
-  const isActionDisabled =
+  const isSaveActionDisabled =
     saveSourceControlConfig.isPending ||
     !selectedProvider ||
     selectedProvider.fields.some((field) => {
@@ -194,6 +219,21 @@ export function StepSourceControlConfig({
   const isGitHubManifestDefault =
     selectedProvider?.provider === 'github' && !showManualGitHubValues;
   const isGitLab = selectedProvider?.provider === 'gitlab';
+  const isAdo = selectedProvider?.provider === 'ado';
+  const adoOrganization = isAdo
+    ? getEffectiveAdoOrganization(selectedProvider.fields, values)
+    : '';
+  const adoBaseUrl = isAdo
+    ? getEffectiveAdoBaseUrl(selectedProvider.fields, values)
+    : '';
+  const adoOrganizationValidationError = getAdoOrganizationValidationError(
+    adoOrganization,
+    adoBaseUrl,
+  );
+  const adoBaseUrlValidationError = getAdoBaseUrlValidationError(adoBaseUrl);
+  const canConfirmAdoOrganization =
+    adoOrganizationValidationError === null &&
+    adoBaseUrlValidationError === null;
   const publicOrigin =
     typeof window === 'undefined'
       ? 'https://your-deployment-url'
@@ -306,6 +346,113 @@ export function StepSourceControlConfig({
           >
             <Pencil />
             Enter values manually
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (isAdo && selectedProvider) {
+    const isAdoOrganizationRuntimeManaged =
+      selectedProvider.fields.find(
+        (field) => field.envVarName === 'ADO_ORGANIZATION',
+      )?.runtimeSatisfied === true;
+    const handleAdoAction = () => {
+      if (!adoOrganizationConfirmed) {
+        if (!canConfirmAdoOrganization) {
+          return;
+        }
+
+        const organizationField = selectedProvider.fields.find(
+          (field) => field.envVarName === 'ADO_ORGANIZATION',
+        );
+
+        if (!organizationField?.runtimeSatisfied) {
+          setValues((current) => ({
+            ...current,
+            ADO_ORGANIZATION: adoOrganization,
+          }));
+        }
+        setAdoAdvancedExpanded(false);
+        setAdoOrganizationConfirmed(true);
+        return;
+      }
+
+      void handleContinue();
+    };
+    const isAdoActionDisabled = adoOrganizationConfirmed
+      ? isSaveActionDisabled ||
+        adoOrganizationValidationError !== null ||
+        adoBaseUrlValidationError !== null
+      : saveSourceControlConfig.isPending || !canConfirmAdoOrganization;
+
+    return (
+      <div className="relative w-full max-w-2xl space-y-6 py-2 md:py-0">
+        <StepTitle text="Connect Azure DevOps" />
+
+        <AdoSourceControlConfigFields
+          fields={selectedProvider.fields}
+          values={values}
+          editingSavedValues={editingSavedValues}
+          organizationConfirmed={adoOrganizationConfirmed}
+          advancedExpanded={adoAdvancedExpanded}
+          disabled={saveSourceControlConfig.isPending}
+          idPrefix="setup-ado"
+          onValueChange={(envVarName, value) =>
+            setValues((current) => ({
+              ...current,
+              [envVarName]: value,
+            }))
+          }
+          onEditingSavedValueChange={(envVarName, editing) =>
+            setEditingSavedValues((current) => ({
+              ...current,
+              [envVarName]: editing,
+            }))
+          }
+          onEditOrganization={() => {
+            setAdoAdvancedExpanded(false);
+            setAdoOrganizationConfirmed(false);
+          }}
+          onAdvancedExpandedChange={setAdoAdvancedExpanded}
+        />
+
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          {onBack ||
+          (adoOrganizationConfirmed && !isAdoOrganizationRuntimeManaged) ? (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                if (
+                  adoOrganizationConfirmed &&
+                  !isAdoOrganizationRuntimeManaged
+                ) {
+                  setAdoAdvancedExpanded(false);
+                  setAdoOrganizationConfirmed(false);
+                } else {
+                  onBack?.();
+                }
+              }}
+              disabled={saveSourceControlConfig.isPending}
+            >
+              <ArrowLeft />
+              Back
+            </Button>
+          ) : null}
+          <Button
+            type="button"
+            onClick={handleAdoAction}
+            disabled={isAdoActionDisabled}
+          >
+            {adoOrganizationConfirmed
+              ? saveSourceControlConfig.isPending
+                ? 'Saving...'
+                : canContinueWithoutNewValues
+                  ? 'Continue'
+                  : 'Save and continue'
+              : 'Continue'}
+            {saveSourceControlConfig.isPending ? <Spinner /> : <ArrowRight />}
           </Button>
         </div>
       </div>
@@ -505,7 +652,7 @@ export function StepSourceControlConfig({
         <Button
           type="button"
           onClick={() => void handleContinue()}
-          disabled={isActionDisabled}
+          disabled={isSaveActionDisabled}
         >
           {saveSourceControlConfig.isPending
             ? 'Saving...'

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.tsx
@@ -12,6 +12,7 @@ import type {
 import { useTRPC } from '@/trpc/client';
 import {
   AdoSourceControlConfigFields,
+  getAdoOAuthValidationError,
   getEffectiveAdoBaseUrl,
   getEffectiveAdoOrganization,
 } from '@/components/source-control/AdoSourceControlConfigFields';
@@ -29,6 +30,10 @@ import {
   Spinner,
 } from '@/components/system';
 import { useCreateGitHubAppManifest } from '@/hooks/github';
+import {
+  useAdoLinkedAccount,
+  useAuthenticateAdoAccount,
+} from '@/hooks/linked-accounts';
 import {
   getAdoBaseUrlValidationError,
   getAdoOrganizationValidationError,
@@ -97,6 +102,12 @@ export function StepSourceControlConfig({
   const [adoOrganizationConfirmed, setAdoOrganizationConfirmed] =
     useState(false);
   const [adoAdvancedExpanded, setAdoAdvancedExpanded] = useState(false);
+  const [adoOauthExpanded, setAdoOauthExpanded] = useState(false);
+  const adoPostSaveActionRef = useRef<'continue' | 'link'>('continue');
+  const adoLinkedAccount = useAdoLinkedAccount({
+    enabled: effectiveSelectedProviderId === 'ado',
+  });
+  const authenticateAdoAccount = useAuthenticateAdoAccount();
   const [manifestForm, setManifestForm] =
     useState<GitHubAppManifestForm | null>(null);
   const manifestFormRef = useRef<HTMLFormElement | null>(null);
@@ -106,7 +117,12 @@ export function StepSourceControlConfig({
         await queryClient.invalidateQueries({
           queryKey: trpc.setupNew.status.queryKey(),
         });
-        onContinue();
+        if (adoPostSaveActionRef.current === 'link') {
+          adoPostSaveActionRef.current = 'continue';
+          authenticateAdoAccount.mutate('/setup?step=source-control-connect');
+        } else {
+          onContinue();
+        }
       },
       onError: (error) => {
         toast.error(error.message);
@@ -166,6 +182,7 @@ export function StepSourceControlConfig({
     setGithubOrganization('');
     setAdoOrganizationConfirmed(hasConfiguredAdoOrganization);
     setAdoAdvancedExpanded(false);
+    setAdoOauthExpanded(false);
     setManifestForm(null);
   }, [
     effectiveSelectedProviderId,
@@ -231,6 +248,9 @@ export function StepSourceControlConfig({
     adoBaseUrl,
   );
   const adoBaseUrlValidationError = getAdoBaseUrlValidationError(adoBaseUrl);
+  const adoOAuthValidationError = isAdo
+    ? getAdoOAuthValidationError(selectedProvider.fields, values)
+    : null;
   const canConfirmAdoOrganization =
     adoOrganizationValidationError === null &&
     adoBaseUrlValidationError === null;
@@ -239,6 +259,7 @@ export function StepSourceControlConfig({
       ? 'https://your-deployment-url'
       : window.location.origin;
   const gitlabRedirectUri = `${publicOrigin}/api/auth/oauth2/callback/gitlab`;
+  const adoRedirectUri = `${publicOrigin}/api/auth/oauth2/callback/ado`;
   const typedGitLabBaseUrl =
     values['GITLAB_BASE_URL']?.trim().replace(/\/+$/, '') ?? '';
   const configuredGitLabBaseUrl =
@@ -382,8 +403,10 @@ export function StepSourceControlConfig({
     };
     const isAdoActionDisabled = adoOrganizationConfirmed
       ? isSaveActionDisabled ||
+        authenticateAdoAccount.isPending ||
         adoOrganizationValidationError !== null ||
-        adoBaseUrlValidationError !== null
+        adoBaseUrlValidationError !== null ||
+        adoOAuthValidationError !== null
       : saveSourceControlConfig.isPending || !canConfirmAdoOrganization;
 
     return (
@@ -396,7 +419,15 @@ export function StepSourceControlConfig({
           editingSavedValues={editingSavedValues}
           organizationConfirmed={adoOrganizationConfirmed}
           advancedExpanded={adoAdvancedExpanded}
-          disabled={saveSourceControlConfig.isPending}
+          oauthExpanded={adoOauthExpanded}
+          oauthCallbackUrl={adoRedirectUri}
+          oauthAccountLinked={Boolean(adoLinkedAccount.data?.account)}
+          oauthAccountStatePending={adoLinkedAccount.isPending}
+          oauthLinkPending={authenticateAdoAccount.isPending}
+          disabled={
+            saveSourceControlConfig.isPending ||
+            authenticateAdoAccount.isPending
+          }
           idPrefix="setup-ado"
           onValueChange={(envVarName, value) =>
             setValues((current) => ({
@@ -415,6 +446,14 @@ export function StepSourceControlConfig({
             setAdoOrganizationConfirmed(false);
           }}
           onAdvancedExpandedChange={setAdoAdvancedExpanded}
+          onOauthExpandedChange={setAdoOauthExpanded}
+          onLinkAccount={() =>
+            authenticateAdoAccount.mutate('/setup?step=source-control-connect')
+          }
+          onSaveAndLinkAccount={() => {
+            adoPostSaveActionRef.current = 'link';
+            void handleContinue();
+          }}
         />
 
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
@@ -434,7 +473,10 @@ export function StepSourceControlConfig({
                   onBack?.();
                 }
               }}
-              disabled={saveSourceControlConfig.isPending}
+              disabled={
+                saveSourceControlConfig.isPending ||
+                authenticateAdoAccount.isPending
+              }
             >
               <ArrowLeft />
               Back
@@ -442,7 +484,10 @@ export function StepSourceControlConfig({
           ) : null}
           <Button
             type="button"
-            onClick={handleAdoAction}
+            onClick={() => {
+              adoPostSaveActionRef.current = 'continue';
+              handleAdoAction();
+            }}
             disabled={isAdoActionDisabled}
           >
             {adoOrganizationConfirmed

--- a/apps/web/src/app/(onboarding)/setup/sourceControlSetupCopy.ts
+++ b/apps/web/src/app/(onboarding)/setup/sourceControlSetupCopy.ts
@@ -35,7 +35,8 @@ const SOURCE_CONTROL_SETUP_COPY: Record<
       'Create an API token with scopes covering repository, pull request, and webhook read/write, plus workspace read (read:workspace:bitbucket) and user read (read:user:bitbucket) so Roomote can discover workspaces and validate the credentials. Prefer a bot or service account that can administer repository webhooks; Roomote syncs repositories and configures pull request webhooks automatically. The Atlassian account email that owns the API token is required.',
   },
   ado: {
-    creationHref: 'https://dev.azure.com/_usersSettings/tokens',
+    creationHref:
+      'https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops',
     setupLabel: 'Azure DevOps personal access token',
     setupLabelArticle: 'an',
     creationHint:

--- a/apps/web/src/components/settings/SourceControl.test.tsx
+++ b/apps/web/src/components/settings/SourceControl.test.tsx
@@ -577,7 +577,7 @@ describe('SourceControl settings', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('shows ADO setup instructions when required config is not satisfied', () => {
+  it('shows the org-first ADO config when required config is not satisfied', () => {
     state.adoRepositories = [];
     state.configProviders = [
       { provider: 'github', configSatisfied: true },
@@ -599,8 +599,10 @@ describe('SourceControl settings', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Set it up' }));
 
     expect(
-      screen.getByRole('link', { name: /Azure DevOps personal access token/ }),
-    ).toHaveAttribute('href', 'https://dev.azure.com/_usersSettings/tokens');
+      screen.queryByRole('link', {
+        name: /Azure DevOps personal access token/,
+      }),
+    ).not.toBeInTheDocument();
     expect(screen.getByTestId('source-control-config-ado')).toBeInTheDocument();
   });
 

--- a/apps/web/src/components/settings/SourceControl.tsx
+++ b/apps/web/src/components/settings/SourceControl.tsx
@@ -667,7 +667,7 @@ function SourceControlProviderBlock({
                 onShowManualValues={() => setShowManualGitHubValues(true)}
                 onHideManualValues={() => setShowManualGitHubValues(false)}
               />
-            ) : (
+            ) : provider === 'ado' && configForm ? null : (
               <ProviderSetupInstructions provider={provider} title={title} />
             )
           ) : null}

--- a/apps/web/src/components/settings/SourceControlConfigForm.client.test.tsx
+++ b/apps/web/src/components/settings/SourceControlConfigForm.client.test.tsx
@@ -5,7 +5,10 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react';
-import type { SetupSourceControlStatus } from '@roomote/types';
+import {
+  buildSetupSourceControlStatus,
+  type SetupSourceControlStatus,
+} from '@roomote/types';
 
 const { mutateMock, mutationOptionsRef, invalidateQueriesMock } = vi.hoisted(
   () => ({
@@ -213,6 +216,131 @@ describe('SourceControlConfigForm', () => {
       expect(screen.queryByDisplayValue('new-secret-value')).toBeNull();
       expect(screen.getByDisplayValue(MASKED_VALUE)).toBeInTheDocument();
       expect(screen.getByDisplayValue('saved-slug')).toBeInTheDocument();
+    });
+  });
+
+  it('uses the organization-first Azure DevOps setup flow', () => {
+    render(
+      <SourceControlConfigForm
+        provider="ado"
+        configStatus={buildSetupSourceControlStatus({
+          selectedProvider: 'ado',
+        })}
+      />,
+    );
+
+    expect(
+      screen.getByLabelText('Azure DevOps Organization'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('Azure DevOps Access Token'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Create Azure DevOps PAT' }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Azure DevOps Organization'), {
+      target: { value: 'acme' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    expect(
+      screen.getByRole('link', { name: 'Create Azure DevOps PAT' }),
+    ).toHaveAttribute(
+      'href',
+      'https://dev.azure.com/acme/_usersSettings/tokens',
+    );
+    expect(
+      screen.getByLabelText('Azure DevOps Access Token'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/Azure DevOps Base URL/),
+    ).not.toBeInTheDocument();
+
+    const advancedOptionsButton = screen.getByRole('button', {
+      name: 'Show advanced options',
+    });
+    expect(advancedOptionsButton).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(advancedOptionsButton);
+
+    expect(screen.getByText('Azure DevOps Base URL (optional)')).toBeVisible();
+    expect(advancedOptionsButton).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('builds the Azure DevOps PAT link from a runtime organization', () => {
+    render(
+      <SourceControlConfigForm
+        provider="ado"
+        configStatus={buildSetupSourceControlStatus({
+          selectedProvider: 'ado',
+          runtimeEnv: { ADO_ORGANIZATION: 'runtime-org' },
+        })}
+      />,
+    );
+
+    expect(
+      screen.getByRole('link', { name: 'Create Azure DevOps PAT' }),
+    ).toHaveAttribute(
+      'href',
+      'https://dev.azure.com/runtime-org/_usersSettings/tokens',
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Change organization' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('Managed by runtime configuration')).toBeVisible();
+  });
+
+  it('does not send a custom Azure DevOps Server user to the cloud PAT page', () => {
+    render(
+      <SourceControlConfigForm
+        provider="ado"
+        configStatus={buildSetupSourceControlStatus({
+          selectedProvider: 'ado',
+          runtimeEnv: {
+            ADO_ORGANIZATION: 'Default Collection',
+            ADO_BASE_URL: 'https://ado.example.com/tfs',
+          },
+        })}
+      />,
+    );
+
+    expect(
+      screen.getByRole('link', { name: 'View PAT setup instructions' }),
+    ).toHaveAttribute(
+      'href',
+      'https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops',
+    );
+    expect(
+      screen.queryByRole('link', { name: 'Create Azure DevOps PAT' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('saves Azure DevOps organization and PAT together', () => {
+    render(
+      <SourceControlConfigForm
+        provider="ado"
+        configStatus={buildSetupSourceControlStatus({
+          selectedProvider: 'ado',
+        })}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Azure DevOps Organization'), {
+      target: { value: ' acme ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    fireEvent.change(screen.getByLabelText('Azure DevOps Access Token'), {
+      target: { value: 'ado-pat' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save configuration' }));
+
+    expect(mutateMock).toHaveBeenCalledWith({
+      provider: 'ado',
+      values: {
+        ADO_ORGANIZATION: 'acme',
+        ADO_TOKEN: 'ado-pat',
+      },
     });
   });
 });

--- a/apps/web/src/components/settings/SourceControlConfigForm.client.test.tsx
+++ b/apps/web/src/components/settings/SourceControlConfigForm.client.test.tsx
@@ -10,18 +10,22 @@ import {
   type SetupSourceControlStatus,
 } from '@roomote/types';
 
-const { mutateMock, mutationOptionsRef, invalidateQueriesMock } = vi.hoisted(
-  () => ({
-    mutateMock: vi.fn(),
-    mutationOptionsRef: {
-      current: null as {
-        onSuccess?: () => Promise<void> | void;
-        onError?: (error: Error) => void;
-      } | null,
-    },
-    invalidateQueriesMock: vi.fn(async () => undefined),
-  }),
-);
+const {
+  authenticateAdoAccountMock,
+  mutateMock,
+  mutationOptionsRef,
+  invalidateQueriesMock,
+} = vi.hoisted(() => ({
+  authenticateAdoAccountMock: vi.fn(),
+  mutateMock: vi.fn(),
+  mutationOptionsRef: {
+    current: null as {
+      onSuccess?: () => Promise<void> | void;
+      onError?: (error: Error) => void;
+    } | null,
+  },
+  invalidateQueriesMock: vi.fn(async () => undefined),
+}));
 
 vi.mock('@tanstack/react-query', () => ({
   useMutation: (options: typeof mutationOptionsRef.current) => {
@@ -53,6 +57,17 @@ vi.mock('@/trpc/client', () => ({
         queryKey: () => ['sourceControl.repositories'],
       },
     },
+  }),
+}));
+
+vi.mock('@/hooks/linked-accounts', () => ({
+  useAdoLinkedAccount: () => ({
+    data: { configured: false, account: null },
+    isPending: false,
+  }),
+  useAuthenticateAdoAccount: () => ({
+    mutate: authenticateAdoAccountMock,
+    isPending: false,
   }),
 }));
 
@@ -342,5 +357,86 @@ describe('SourceControlConfigForm', () => {
         ADO_TOKEN: 'ado-pat',
       },
     });
+  });
+
+  it('saves OAuth credentials and immediately starts account linking', async () => {
+    render(
+      <SourceControlConfigForm
+        provider="ado"
+        configStatus={buildSetupSourceControlStatus({
+          selectedProvider: 'ado',
+        })}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Azure DevOps Organization'), {
+      target: { value: 'acme' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    fireEvent.change(screen.getByLabelText('Azure DevOps Access Token'), {
+      target: { value: 'ado-pat' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Set up account linking' }),
+    );
+
+    fireEvent.change(screen.getByLabelText(/Microsoft Entra Client ID/), {
+      target: { value: 'client-id' },
+    });
+    expect(
+      screen.getByText(/Enter both the Microsoft Entra application/),
+    ).toBeVisible();
+    fireEvent.change(screen.getByLabelText(/Microsoft Entra Client Secret/), {
+      target: { value: 'client-secret' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Save and link my account' }),
+    );
+
+    expect(mutateMock).toHaveBeenCalledWith({
+      provider: 'ado',
+      values: {
+        ADO_CLIENT_ID: 'client-id',
+        ADO_CLIENT_SECRET: 'client-secret',
+        ADO_ORGANIZATION: 'acme',
+        ADO_TOKEN: 'ado-pat',
+      },
+    });
+
+    await act(async () => {
+      await mutationOptionsRef.current?.onSuccess?.();
+    });
+
+    expect(authenticateAdoAccountMock).toHaveBeenCalledWith(
+      '/settings?service=ado',
+    );
+  });
+
+  it('links directly when Azure DevOps OAuth is already configured', () => {
+    render(
+      <SourceControlConfigForm
+        provider="ado"
+        configStatus={buildSetupSourceControlStatus({
+          selectedProvider: 'ado',
+          runtimeEnv: {
+            ADO_CLIENT_ID: 'client-id',
+            ADO_CLIENT_SECRET: 'client-secret',
+            ADO_ORGANIZATION: 'acme',
+            ADO_TOKEN: 'ado-pat',
+          },
+        })}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Set up account linking' }),
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Link my Azure DevOps account' }),
+    );
+
+    expect(authenticateAdoAccountMock).toHaveBeenCalledWith(
+      '/settings?service=ado',
+    );
   });
 });

--- a/apps/web/src/components/settings/SourceControlConfigForm.client.test.tsx
+++ b/apps/web/src/components/settings/SourceControlConfigForm.client.test.tsx
@@ -331,7 +331,7 @@ describe('SourceControlConfigForm', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('saves Azure DevOps organization and PAT together', () => {
+  it('requires OAuth when saving an Azure DevOps cloud configuration', () => {
     render(
       <SourceControlConfigForm
         provider="ado"
@@ -348,11 +348,24 @@ describe('SourceControlConfigForm', () => {
     fireEvent.change(screen.getByLabelText('Azure DevOps Access Token'), {
       target: { value: 'ado-pat' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Save configuration' }));
+    expect(
+      screen.getByRole('button', { name: 'Save and link account' }),
+    ).toBeDisabled();
+    fireEvent.change(screen.getByLabelText('Microsoft Entra Client ID'), {
+      target: { value: 'client-id' },
+    });
+    fireEvent.change(screen.getByLabelText('Microsoft Entra Client Secret'), {
+      target: { value: 'client-secret' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Save and link account' }),
+    );
 
     expect(mutateMock).toHaveBeenCalledWith({
       provider: 'ado',
       values: {
+        ADO_CLIENT_ID: 'client-id',
+        ADO_CLIENT_SECRET: 'client-secret',
         ADO_ORGANIZATION: 'acme',
         ADO_TOKEN: 'ado-pat',
       },
@@ -376,10 +389,6 @@ describe('SourceControlConfigForm', () => {
     fireEvent.change(screen.getByLabelText('Azure DevOps Access Token'), {
       target: { value: 'ado-pat' },
     });
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Set up account linking' }),
-    );
-
     fireEvent.change(screen.getByLabelText(/Microsoft Entra Client ID/), {
       target: { value: 'client-id' },
     });
@@ -390,7 +399,7 @@ describe('SourceControlConfigForm', () => {
       target: { value: 'client-secret' },
     });
     fireEvent.click(
-      screen.getByRole('button', { name: 'Save and link my account' }),
+      screen.getByRole('button', { name: 'Save and link account' }),
     );
 
     expect(mutateMock).toHaveBeenCalledWith({
@@ -412,28 +421,31 @@ describe('SourceControlConfigForm', () => {
     );
   });
 
-  it('links directly when Azure DevOps OAuth is already configured', () => {
+  it('reuses existing Microsoft setup before linking the Azure DevOps account', async () => {
     render(
       <SourceControlConfigForm
         provider="ado"
         configStatus={buildSetupSourceControlStatus({
           selectedProvider: 'ado',
           runtimeEnv: {
-            ADO_CLIENT_ID: 'client-id',
-            ADO_CLIENT_SECRET: 'client-secret',
             ADO_ORGANIZATION: 'acme',
             ADO_TOKEN: 'ado-pat',
+            R_MICROSOFT_CLIENT_ID: 'client-id',
+            R_MICROSOFT_CLIENT_SECRET: 'client-secret',
+            R_MICROSOFT_TENANT_ID: 'tenant-id',
           },
         })}
       />,
     );
 
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Set up account linking' }),
-    );
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Link my Azure DevOps account' }),
-    );
+    expect(
+      screen.getByText(/found your existing Microsoft setup/),
+    ).toBeVisible();
+    fireEvent.click(screen.getByRole('button', { name: 'Link account' }));
+
+    await act(async () => {
+      await mutationOptionsRef.current?.onSuccess?.();
+    });
 
     expect(authenticateAdoAccountMock).toHaveBeenCalledWith(
       '/settings?service=ado',

--- a/apps/web/src/components/settings/SourceControlConfigForm.tsx
+++ b/apps/web/src/components/settings/SourceControlConfigForm.tsx
@@ -6,7 +6,16 @@ import { toast } from 'sonner';
 import type { SetupSourceControlStatus } from '@roomote/types';
 
 import { useTRPC } from '@/trpc/client';
+import {
+  AdoSourceControlConfigFields,
+  getEffectiveAdoBaseUrl,
+  getEffectiveAdoOrganization,
+} from '@/components/source-control/AdoSourceControlConfigFields';
 import { Button, Check, Input, Spinner } from '@/components/system';
+import {
+  getAdoBaseUrlValidationError,
+  getAdoOrganizationValidationError,
+} from '@/lib/ado';
 
 const MASKED_VALUE = '••••••••••••••••••••••••••••';
 
@@ -95,6 +104,16 @@ export function SourceControlConfigForm({
   const [editingSavedValues, setEditingSavedValues] = useState<
     Record<string, boolean>
   >({});
+  const [adoOrganizationConfirmed, setAdoOrganizationConfirmed] =
+    useState(false);
+  const [adoAdvancedExpanded, setAdoAdvancedExpanded] = useState(false);
+  const hasConfiguredAdoOrganization =
+    provider === 'ado' &&
+    providerStatus?.fields.some(
+      (field) =>
+        field.envVarName === 'ADO_ORGANIZATION' &&
+        (field.runtimeSatisfied || field.savedSatisfied),
+    ) === true;
 
   const saveConfig = useMutation(
     trpc.sourceControl.saveConfig.mutationOptions({
@@ -111,6 +130,7 @@ export function SourceControlConfigForm({
           withoutSecretFieldValues(providerStatus?.fields ?? [], current),
         );
         setEditingSavedValues({});
+        setAdoAdvancedExpanded(false);
         toast.success(
           saveSuccessMessage ?? 'Source-control configuration saved.',
         );
@@ -125,13 +145,15 @@ export function SourceControlConfigForm({
   useEffect(() => {
     setValues(nonSecretInitialValues);
     setEditingSavedValues({});
-  }, [provider, nonSecretInitialValues]);
+    setAdoOrganizationConfirmed(hasConfiguredAdoOrganization);
+    setAdoAdvancedExpanded(false);
+  }, [hasConfiguredAdoOrganization, provider, nonSecretInitialValues]);
 
   if (!providerStatus) {
     return null;
   }
 
-  const isActionDisabled =
+  const isSaveActionDisabled =
     saveConfig.isPending ||
     providerStatus.fields.some((field) => {
       const nextValue = values[field.envVarName]?.trim() ?? '';
@@ -142,6 +164,28 @@ export function SourceControlConfigForm({
         nextValue.length === 0
       );
     });
+  const isAdo = provider === 'ado';
+  const adoOrganization = isAdo
+    ? getEffectiveAdoOrganization(providerStatus.fields, values)
+    : '';
+  const adoBaseUrl = isAdo
+    ? getEffectiveAdoBaseUrl(providerStatus.fields, values)
+    : '';
+  const adoOrganizationValidationError = getAdoOrganizationValidationError(
+    adoOrganization,
+    adoBaseUrl,
+  );
+  const adoBaseUrlValidationError = getAdoBaseUrlValidationError(adoBaseUrl);
+  const canConfirmAdoOrganization =
+    adoOrganizationValidationError === null &&
+    adoBaseUrlValidationError === null;
+  const isActionDisabled =
+    isAdo && !adoOrganizationConfirmed
+      ? saveConfig.isPending || !canConfirmAdoOrganization
+      : isSaveActionDisabled ||
+        (isAdo &&
+          (adoOrganizationValidationError !== null ||
+            adoBaseUrlValidationError !== null));
 
   const hasNewValues = providerStatus.fields.some((field) => {
     if (field.runtimeSatisfied) {
@@ -154,87 +198,147 @@ export function SourceControlConfigForm({
     return nextValue.length > 0;
   });
 
+  const handleAction = () => {
+    if (isAdo && !adoOrganizationConfirmed) {
+      if (!canConfirmAdoOrganization) {
+        return;
+      }
+
+      const organizationField = providerStatus.fields.find(
+        (field) => field.envVarName === 'ADO_ORGANIZATION',
+      );
+
+      if (!organizationField?.runtimeSatisfied) {
+        setValues((current) => ({
+          ...current,
+          ADO_ORGANIZATION: adoOrganization,
+        }));
+      }
+      setAdoAdvancedExpanded(false);
+      setAdoOrganizationConfirmed(true);
+      return;
+    }
+
+    saveConfig.mutate({ provider, values });
+  };
+
   return (
     <div className="space-y-4">
       <div className="space-y-2">
-        {providerStatus.fields.map((field) => {
-          const value = values[field.envVarName] ?? '';
-          const isSecretField = isSecretSourceControlField(field);
-          const shouldShowSavedValueMask =
-            isSecretField &&
-            !field.runtimeSatisfied &&
-            field.savedSatisfied &&
-            value.length === 0 &&
-            !editingSavedValues[field.envVarName];
+        {isAdo ? (
+          <AdoSourceControlConfigFields
+            fields={providerStatus.fields}
+            values={values}
+            editingSavedValues={editingSavedValues}
+            organizationConfirmed={adoOrganizationConfirmed}
+            advancedExpanded={adoAdvancedExpanded}
+            disabled={saveConfig.isPending}
+            compact
+            idPrefix="settings-ado"
+            onValueChange={(envVarName, value) =>
+              setValues((current) => ({
+                ...current,
+                [envVarName]: value,
+              }))
+            }
+            onEditingSavedValueChange={(envVarName, editing) =>
+              setEditingSavedValues((current) => ({
+                ...current,
+                [envVarName]: editing,
+              }))
+            }
+            onEditOrganization={() => {
+              setAdoAdvancedExpanded(false);
+              setAdoOrganizationConfirmed(false);
+            }}
+            onAdvancedExpandedChange={setAdoAdvancedExpanded}
+          />
+        ) : (
+          providerStatus.fields.map((field) => {
+            const value = values[field.envVarName] ?? '';
+            const isSecretField = isSecretSourceControlField(field);
+            const shouldShowSavedValueMask =
+              isSecretField &&
+              !field.runtimeSatisfied &&
+              field.savedSatisfied &&
+              value.length === 0 &&
+              !editingSavedValues[field.envVarName];
 
-          return (
-            <div
-              key={field.envVarName}
-              className="grid max-w-xl gap-2 md:grid-cols-[180px_minmax(0,1fr)] md:items-center"
-            >
-              <div className="text-sm font-medium">
-                {field.label}
-                {field.required === false ? ' (optional)' : ''}
-              </div>
-              <div className="flex items-center gap-2">
-                <Input
-                  secret={isSecretField && !field.runtimeSatisfied}
-                  type={isSecretField ? undefined : 'text'}
-                  className="font-mono"
-                  value={
-                    isSecretField && field.runtimeSatisfied
-                      ? MASKED_VALUE
-                      : shouldShowSavedValueMask
+            return (
+              <div
+                key={field.envVarName}
+                className="grid max-w-xl gap-2 md:grid-cols-[180px_minmax(0,1fr)] md:items-center"
+              >
+                <div className="text-sm font-medium">
+                  {field.label}
+                  {field.required === false ? ' (optional)' : ''}
+                </div>
+                <div className="flex items-center gap-2">
+                  <Input
+                    secret={isSecretField && !field.runtimeSatisfied}
+                    type={isSecretField ? undefined : 'text'}
+                    className="font-mono"
+                    value={
+                      isSecretField && field.runtimeSatisfied
                         ? MASKED_VALUE
-                        : field.runtimeSatisfied && !isSecretField
-                          ? (field.savedValue ?? value)
-                          : value
-                  }
-                  onFocus={() => {
-                    if (shouldShowSavedValueMask) {
-                      setEditingSavedValues((current) => ({
-                        ...current,
-                        [field.envVarName]: true,
-                      }));
+                        : shouldShowSavedValueMask
+                          ? MASKED_VALUE
+                          : field.runtimeSatisfied && !isSecretField
+                            ? (field.savedValue ?? value)
+                            : value
                     }
-                  }}
-                  onBlur={() => {
-                    if (
-                      isSecretField &&
-                      field.savedSatisfied &&
-                      value.length === 0
-                    ) {
-                      setEditingSavedValues((current) => ({
+                    onFocus={() => {
+                      if (shouldShowSavedValueMask) {
+                        setEditingSavedValues((current) => ({
+                          ...current,
+                          [field.envVarName]: true,
+                        }));
+                      }
+                    }}
+                    onBlur={() => {
+                      if (
+                        isSecretField &&
+                        field.savedSatisfied &&
+                        value.length === 0
+                      ) {
+                        setEditingSavedValues((current) => ({
+                          ...current,
+                          [field.envVarName]: false,
+                        }));
+                      }
+                    }}
+                    onChange={(event) =>
+                      setValues((current) => ({
                         ...current,
-                        [field.envVarName]: false,
-                      }));
+                        [field.envVarName]: event.target.value,
+                      }))
                     }
-                  }}
-                  onChange={(event) =>
-                    setValues((current) => ({
-                      ...current,
-                      [field.envVarName]: event.target.value,
-                    }))
-                  }
-                  placeholder={field.runtimeSatisfied ? '' : field.envVarName}
-                  disabled={saveConfig.isPending || field.runtimeSatisfied}
-                  data-1p-ignore
-                />
-                {(field.runtimeSatisfied || field.savedSatisfied) && <Check />}
+                    placeholder={field.runtimeSatisfied ? '' : field.envVarName}
+                    disabled={saveConfig.isPending || field.runtimeSatisfied}
+                    data-1p-ignore
+                  />
+                  {(field.runtimeSatisfied || field.savedSatisfied) && (
+                    <Check />
+                  )}
+                </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          })
+        )}
       </div>
       <div className="flex items-center gap-2">
         <Button
           type="button"
           size="sm"
-          onClick={() => saveConfig.mutate({ provider, values })}
+          onClick={handleAction}
           disabled={isActionDisabled}
         >
           {saveConfig.isPending ? <Spinner /> : null}
-          {hasNewValues ? 'Save configuration' : 'Save'}
+          {isAdo && !adoOrganizationConfirmed
+            ? 'Continue'
+            : hasNewValues
+              ? 'Save configuration'
+              : 'Save'}
         </Button>
       </div>
     </div>

--- a/apps/web/src/components/settings/SourceControlConfigForm.tsx
+++ b/apps/web/src/components/settings/SourceControlConfigForm.tsx
@@ -11,11 +11,13 @@ import {
   getAdoOAuthValidationError,
   getEffectiveAdoBaseUrl,
   getEffectiveAdoOrganization,
+  isAdoOAuthReady,
 } from '@/components/source-control/AdoSourceControlConfigFields';
 import { Button, Check, Input, Spinner } from '@/components/system';
 import {
   getAdoBaseUrlValidationError,
   getAdoOrganizationValidationError,
+  isAdoCloudBaseUrl,
 } from '@/lib/ado';
 import {
   useAdoLinkedAccount,
@@ -112,7 +114,6 @@ export function SourceControlConfigForm({
   const [adoOrganizationConfirmed, setAdoOrganizationConfirmed] =
     useState(false);
   const [adoAdvancedExpanded, setAdoAdvancedExpanded] = useState(false);
-  const [adoOauthExpanded, setAdoOauthExpanded] = useState(false);
   const adoPostSaveActionRef = useRef<'save' | 'link'>('save');
   const adoLinkedAccount = useAdoLinkedAccount({ enabled: provider === 'ado' });
   const authenticateAdoAccount = useAuthenticateAdoAccount();
@@ -140,7 +141,6 @@ export function SourceControlConfigForm({
         );
         setEditingSavedValues({});
         setAdoAdvancedExpanded(false);
-        setAdoOauthExpanded(false);
         toast.success(
           saveSuccessMessage ?? 'Source-control configuration saved.',
         );
@@ -161,7 +161,6 @@ export function SourceControlConfigForm({
     setEditingSavedValues({});
     setAdoOrganizationConfirmed(hasConfiguredAdoOrganization);
     setAdoAdvancedExpanded(false);
-    setAdoOauthExpanded(false);
   }, [hasConfiguredAdoOrganization, provider, nonSecretInitialValues]);
 
   if (!providerStatus) {
@@ -191,9 +190,14 @@ export function SourceControlConfigForm({
     adoBaseUrl,
   );
   const adoBaseUrlValidationError = getAdoBaseUrlValidationError(adoBaseUrl);
-  const adoOAuthValidationError = isAdo
+  const usesAdoCloud = isAdo && isAdoCloudBaseUrl(adoBaseUrl);
+  const adoOAuthValidationError = usesAdoCloud
     ? getAdoOAuthValidationError(providerStatus.fields, values)
     : null;
+  const adoOAuthReady = usesAdoCloud
+    ? isAdoOAuthReady(providerStatus.fields, values)
+    : true;
+  const adoAccountLinked = Boolean(adoLinkedAccount.data?.account);
   const canConfirmAdoOrganization =
     adoOrganizationValidationError === null &&
     adoBaseUrlValidationError === null;
@@ -242,6 +246,8 @@ export function SourceControlConfigForm({
       return;
     }
 
+    adoPostSaveActionRef.current =
+      usesAdoCloud && !adoAccountLinked ? 'link' : 'save';
     saveConfig.mutate({ provider, values });
   };
 
@@ -255,11 +261,9 @@ export function SourceControlConfigForm({
             editingSavedValues={editingSavedValues}
             organizationConfirmed={adoOrganizationConfirmed}
             advancedExpanded={adoAdvancedExpanded}
-            oauthExpanded={adoOauthExpanded}
             oauthCallbackUrl={adoRedirectUri}
-            oauthAccountLinked={Boolean(adoLinkedAccount.data?.account)}
+            oauthAccountLinked={adoAccountLinked}
             oauthAccountStatePending={adoLinkedAccount.isPending}
-            oauthLinkPending={authenticateAdoAccount.isPending}
             disabled={saveConfig.isPending || authenticateAdoAccount.isPending}
             compact
             idPrefix="settings-ado"
@@ -280,14 +284,6 @@ export function SourceControlConfigForm({
               setAdoOrganizationConfirmed(false);
             }}
             onAdvancedExpandedChange={setAdoAdvancedExpanded}
-            onOauthExpandedChange={setAdoOauthExpanded}
-            onLinkAccount={() =>
-              authenticateAdoAccount.mutate('/settings?service=ado')
-            }
-            onSaveAndLinkAccount={() => {
-              adoPostSaveActionRef.current = 'link';
-              saveConfig.mutate({ provider, values });
-            }}
           />
         ) : (
           providerStatus.fields.map((field) => {
@@ -373,15 +369,22 @@ export function SourceControlConfigForm({
           disabled={
             isActionDisabled ||
             authenticateAdoAccount.isPending ||
-            adoOAuthValidationError !== null
+            (isAdo && adoOrganizationConfirmed && !adoOAuthReady) ||
+            (isAdo &&
+              adoOrganizationConfirmed &&
+              adoOAuthValidationError !== null)
           }
         >
           {saveConfig.isPending ? <Spinner /> : null}
           {isAdo && !adoOrganizationConfirmed
             ? 'Continue'
-            : hasNewValues
-              ? 'Save configuration'
-              : 'Save'}
+            : usesAdoCloud && !adoAccountLinked
+              ? hasNewValues
+                ? 'Save and link account'
+                : 'Link account'
+              : hasNewValues
+                ? 'Save configuration'
+                : 'Save'}
         </Button>
       </div>
     </div>

--- a/apps/web/src/components/settings/SourceControlConfigForm.tsx
+++ b/apps/web/src/components/settings/SourceControlConfigForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import type { SetupSourceControlStatus } from '@roomote/types';
@@ -8,6 +8,7 @@ import type { SetupSourceControlStatus } from '@roomote/types';
 import { useTRPC } from '@/trpc/client';
 import {
   AdoSourceControlConfigFields,
+  getAdoOAuthValidationError,
   getEffectiveAdoBaseUrl,
   getEffectiveAdoOrganization,
 } from '@/components/source-control/AdoSourceControlConfigFields';
@@ -16,6 +17,10 @@ import {
   getAdoBaseUrlValidationError,
   getAdoOrganizationValidationError,
 } from '@/lib/ado';
+import {
+  useAdoLinkedAccount,
+  useAuthenticateAdoAccount,
+} from '@/hooks/linked-accounts';
 
 const MASKED_VALUE = '••••••••••••••••••••••••••••';
 
@@ -107,6 +112,10 @@ export function SourceControlConfigForm({
   const [adoOrganizationConfirmed, setAdoOrganizationConfirmed] =
     useState(false);
   const [adoAdvancedExpanded, setAdoAdvancedExpanded] = useState(false);
+  const [adoOauthExpanded, setAdoOauthExpanded] = useState(false);
+  const adoPostSaveActionRef = useRef<'save' | 'link'>('save');
+  const adoLinkedAccount = useAdoLinkedAccount({ enabled: provider === 'ado' });
+  const authenticateAdoAccount = useAuthenticateAdoAccount();
   const hasConfiguredAdoOrganization =
     provider === 'ado' &&
     providerStatus?.fields.some(
@@ -131,10 +140,15 @@ export function SourceControlConfigForm({
         );
         setEditingSavedValues({});
         setAdoAdvancedExpanded(false);
+        setAdoOauthExpanded(false);
         toast.success(
           saveSuccessMessage ?? 'Source-control configuration saved.',
         );
         onSaved?.();
+        if (adoPostSaveActionRef.current === 'link') {
+          adoPostSaveActionRef.current = 'save';
+          authenticateAdoAccount.mutate('/settings?service=ado');
+        }
       },
       onError: (error) => {
         toast.error(error.message);
@@ -147,6 +161,7 @@ export function SourceControlConfigForm({
     setEditingSavedValues({});
     setAdoOrganizationConfirmed(hasConfiguredAdoOrganization);
     setAdoAdvancedExpanded(false);
+    setAdoOauthExpanded(false);
   }, [hasConfiguredAdoOrganization, provider, nonSecretInitialValues]);
 
   if (!providerStatus) {
@@ -176,6 +191,9 @@ export function SourceControlConfigForm({
     adoBaseUrl,
   );
   const adoBaseUrlValidationError = getAdoBaseUrlValidationError(adoBaseUrl);
+  const adoOAuthValidationError = isAdo
+    ? getAdoOAuthValidationError(providerStatus.fields, values)
+    : null;
   const canConfirmAdoOrganization =
     adoOrganizationValidationError === null &&
     adoBaseUrlValidationError === null;
@@ -186,6 +204,11 @@ export function SourceControlConfigForm({
         (isAdo &&
           (adoOrganizationValidationError !== null ||
             adoBaseUrlValidationError !== null));
+  const publicOrigin =
+    typeof window === 'undefined'
+      ? 'https://your-deployment-url'
+      : window.location.origin;
+  const adoRedirectUri = `${publicOrigin}/api/auth/oauth2/callback/ado`;
 
   const hasNewValues = providerStatus.fields.some((field) => {
     if (field.runtimeSatisfied) {
@@ -232,7 +255,12 @@ export function SourceControlConfigForm({
             editingSavedValues={editingSavedValues}
             organizationConfirmed={adoOrganizationConfirmed}
             advancedExpanded={adoAdvancedExpanded}
-            disabled={saveConfig.isPending}
+            oauthExpanded={adoOauthExpanded}
+            oauthCallbackUrl={adoRedirectUri}
+            oauthAccountLinked={Boolean(adoLinkedAccount.data?.account)}
+            oauthAccountStatePending={adoLinkedAccount.isPending}
+            oauthLinkPending={authenticateAdoAccount.isPending}
+            disabled={saveConfig.isPending || authenticateAdoAccount.isPending}
             compact
             idPrefix="settings-ado"
             onValueChange={(envVarName, value) =>
@@ -252,6 +280,14 @@ export function SourceControlConfigForm({
               setAdoOrganizationConfirmed(false);
             }}
             onAdvancedExpandedChange={setAdoAdvancedExpanded}
+            onOauthExpandedChange={setAdoOauthExpanded}
+            onLinkAccount={() =>
+              authenticateAdoAccount.mutate('/settings?service=ado')
+            }
+            onSaveAndLinkAccount={() => {
+              adoPostSaveActionRef.current = 'link';
+              saveConfig.mutate({ provider, values });
+            }}
           />
         ) : (
           providerStatus.fields.map((field) => {
@@ -330,8 +366,15 @@ export function SourceControlConfigForm({
         <Button
           type="button"
           size="sm"
-          onClick={handleAction}
-          disabled={isActionDisabled}
+          onClick={() => {
+            adoPostSaveActionRef.current = 'save';
+            handleAction();
+          }}
+          disabled={
+            isActionDisabled ||
+            authenticateAdoAccount.isPending ||
+            adoOAuthValidationError !== null
+          }
         >
           {saveConfig.isPending ? <Spinner /> : null}
           {isAdo && !adoOrganizationConfirmed

--- a/apps/web/src/components/source-control/AdoSourceControlConfigFields.tsx
+++ b/apps/web/src/components/source-control/AdoSourceControlConfigFields.tsx
@@ -99,23 +99,16 @@ export function getAdoOAuthValidationError(
     values,
   );
 
+  if (!clientIdSatisfied && !clientSecretSatisfied) {
+    return 'Enter the Microsoft Entra application (client) ID and client secret to continue.';
+  }
+
   return clientIdSatisfied !== clientSecretSatisfied
     ? 'Enter both the Microsoft Entra application (client) ID and client secret.'
     : null;
 }
 
-function isAdoOAuthConfigured(fields: readonly SourceControlField[]) {
-  return [ADO_CLIENT_ID_ENV_VAR, ADO_CLIENT_SECRET_ENV_VAR].every(
-    (envVarName) => {
-      const field = fields.find(
-        (candidate) => candidate.envVarName === envVarName,
-      );
-      return field?.runtimeSatisfied === true || field?.savedSatisfied === true;
-    },
-  );
-}
-
-function isAdoOAuthReady(
+export function isAdoOAuthReady(
   fields: readonly SourceControlField[],
   values: Record<string, string>,
 ) {
@@ -134,11 +127,9 @@ export function AdoSourceControlConfigFields({
   editingSavedValues,
   organizationConfirmed,
   advancedExpanded,
-  oauthExpanded,
   oauthCallbackUrl,
   oauthAccountLinked,
   oauthAccountStatePending,
-  oauthLinkPending,
   disabled,
   compact = false,
   idPrefix,
@@ -146,20 +137,15 @@ export function AdoSourceControlConfigFields({
   onEditingSavedValueChange,
   onEditOrganization,
   onAdvancedExpandedChange,
-  onOauthExpandedChange,
-  onLinkAccount,
-  onSaveAndLinkAccount,
 }: {
   fields: readonly SourceControlField[];
   values: Record<string, string>;
   editingSavedValues: Record<string, boolean>;
   organizationConfirmed: boolean;
   advancedExpanded: boolean;
-  oauthExpanded: boolean;
   oauthCallbackUrl: string;
   oauthAccountLinked: boolean;
   oauthAccountStatePending: boolean;
-  oauthLinkPending: boolean;
   disabled: boolean;
   compact?: boolean;
   idPrefix: string;
@@ -167,9 +153,6 @@ export function AdoSourceControlConfigFields({
   onEditingSavedValueChange: (envVarName: string, editing: boolean) => void;
   onEditOrganization: () => void;
   onAdvancedExpandedChange: (expanded: boolean) => void;
-  onOauthExpandedChange: (expanded: boolean) => void;
-  onLinkAccount: () => void;
-  onSaveAndLinkAccount: () => void;
 }) {
   const organizationField = fields.find(
     (field) => field.envVarName === ADO_ORGANIZATION_ENV_VAR,
@@ -182,6 +165,14 @@ export function AdoSourceControlConfigFields({
   );
   const oauthFields = fields.filter((field) =>
     ADO_OAUTH_ENV_VARS.has(field.envVarName),
+  );
+  const reusesMicrosoftApp = [
+    ADO_CLIENT_ID_ENV_VAR,
+    ADO_CLIENT_SECRET_ENV_VAR,
+  ].every((envVarName) =>
+    oauthFields
+      .find((field) => field.envVarName === envVarName)
+      ?.satisfiedByEnvVarName?.startsWith('R_MICROSOFT_'),
   );
   const advancedFields = fields.filter(
     (field) =>
@@ -204,17 +195,15 @@ export function AdoSourceControlConfigFields({
     ? buildAdoPersonalAccessTokenUrl(organization)
     : ADO_PAT_DOCUMENTATION_URL;
   const advancedContentId = `${idPrefix}-advanced-options`;
-  const oauthContentId = `${idPrefix}-oauth-options`;
   const serverContentId = `${idPrefix}-server-options`;
   const serverCollapsedErrorId = `${idPrefix}-server-options-error`;
   const advancedCollapsedErrorId = `${idPrefix}-advanced-options-error`;
   const oauthValidationError = getAdoOAuthValidationError(fields, values);
-  const oauthConfigured = isAdoOAuthConfigured(fields);
-  const oauthReady = isAdoOAuthReady(fields, values);
 
   const renderField = (
     field: SourceControlField,
     validationError: string | null = null,
+    optional = field.required === false,
   ) => {
     const value = values[field.envVarName] ?? '';
     const isSecretField = isSecretSourceControlField(field);
@@ -238,7 +227,7 @@ export function AdoSourceControlConfigFields({
       >
         <Label htmlFor={inputId} className="text-sm font-medium">
           {field.label}
-          {field.required === false ? ' (optional)' : ''}
+          {optional ? ' (optional)' : ''}
         </Label>
         <div className="space-y-1">
           <div className="flex items-center gap-2">
@@ -416,107 +405,84 @@ export function AdoSourceControlConfigFields({
       {tokenField ? renderField(tokenField) : null}
 
       {usesAdoCloud && oauthFields.length > 0 ? (
-        <div className="space-y-3 border-t pt-6">
+        <div className="space-y-4 border-t pt-6">
           <div className="space-y-1 max-w-xl">
-            <p className="font-semibold">Optional: link user accounts</p>
+            <p className="font-semibold">Set up user account linking</p>
             <p className="text-sm text-muted-foreground">
               The PAT connects this Roomote deployment to Azure DevOps. OAuth
-              separately identifies each user, which is required when they start
-              Roomote work from pull request comments.
+              separately identifies each user. Both are required to finish Azure
+              DevOps setup and let users start Roomote work from pull request
+              comments.
             </p>
           </div>
-          <button
-            type="button"
-            className="cursor-pointer text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
-            onClick={() => onOauthExpandedChange(!oauthExpanded)}
-            disabled={disabled || oauthLinkPending}
-            aria-expanded={oauthExpanded}
-            aria-controls={oauthContentId}
-          >
-            {oauthExpanded
-              ? 'Hide account linking setup'
-              : 'Set up account linking'}
-            <ChevronDown
-              className={`${oauthExpanded ? 'rotate-180' : ''} inline size-4 transition-all`}
-            />
-          </button>
-          {oauthExpanded ? (
-            <div id={oauthContentId} className="space-y-4">
-              <div className="space-y-2 max-w-xl text-sm text-muted-foreground">
-                <p>
-                  Create a Microsoft Entra app registration. If Microsoft Teams
-                  or Microsoft sign-in is already configured, you can reuse that
-                  app: add the callback below and grant the delegated Azure
-                  DevOps <code>user_impersonation</code> permission.
-                </p>
-                <Button
-                  asChild
-                  variant="outline"
-                  size={compact ? 'sm' : 'default'}
-                >
-                  <a
-                    href={ENTRA_APP_REGISTRATIONS_URL}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Open Microsoft Entra app registrations
-                    <ExternalLink />
-                  </a>
-                </Button>
-                <p>Configure this Web redirect URI:</p>
-                <p className="flex items-center gap-1">
-                  <code className="break-all text-foreground">
-                    {oauthCallbackUrl}
-                  </code>
-                  <CopyIconButton
-                    content={oauthCallbackUrl}
-                    tooltip="Copy redirect URI"
-                  />
-                </p>
-                <p>
-                  Paste the application ID and client secret below. The tenant
-                  ID is optional; use the same tenant as Teams when applicable.
-                </p>
-              </div>
-              <div className="space-y-2">
-                {oauthFields.map((field) => renderField(field))}
-              </div>
-              {oauthValidationError ? (
-                <p className="text-sm text-destructive" role="alert">
-                  {oauthValidationError}
+          <div className="space-y-4">
+            <div className="space-y-2 max-w-xl text-sm text-muted-foreground">
+              {reusesMicrosoftApp ? (
+                <p className="rounded-md border bg-muted/40 p-3 text-foreground">
+                  Roomote found your existing Microsoft setup and will reuse its
+                  Entra app credentials. You only need to add the callback and
+                  Azure DevOps permission below, then link your account.
                 </p>
               ) : null}
-              {oauthAccountStatePending ? (
-                <p className="flex items-center gap-2 text-sm text-muted-foreground">
-                  <Spinner /> Checking linked account…
-                </p>
-              ) : oauthAccountLinked ? (
-                <p className="flex items-center gap-2 text-sm">
-                  <Check /> Your Azure DevOps account is linked.
-                </p>
-              ) : oauthConfigured ? (
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={onLinkAccount}
-                  disabled={disabled || oauthLinkPending}
+              <p>
+                Create a Microsoft Entra app registration. If Microsoft Teams or
+                Microsoft sign-in is already configured, you can reuse that app:
+                add the callback below and grant the delegated Azure DevOps{' '}
+                <code>user_impersonation</code> permission.
+              </p>
+              <Button
+                asChild
+                variant="outline"
+                size={compact ? 'sm' : 'default'}
+              >
+                <a
+                  href={ENTRA_APP_REGISTRATIONS_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
                 >
-                  {oauthLinkPending ? <Spinner /> : null}
-                  Link my Azure DevOps account
-                </Button>
-              ) : oauthReady && !oauthValidationError ? (
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={onSaveAndLinkAccount}
-                  disabled={disabled || oauthLinkPending}
-                >
-                  {disabled || oauthLinkPending ? <Spinner /> : null}
-                  Save and link my account
-                </Button>
-              ) : null}
+                  Open Microsoft Entra app registrations
+                  <ExternalLink />
+                </a>
+              </Button>
+              <p>Configure this Web redirect URI:</p>
+              <p className="flex items-center gap-1">
+                <code className="break-all text-foreground">
+                  {oauthCallbackUrl}
+                </code>
+                <CopyIconButton
+                  content={oauthCallbackUrl}
+                  tooltip="Copy redirect URI"
+                />
+              </p>
+              <p>
+                Paste the application ID and client secret below. The tenant ID
+                is optional; use the same tenant as Teams when applicable.
+              </p>
             </div>
-          ) : null}
+            <div className="space-y-2">
+              {oauthFields.map((field) =>
+                renderField(
+                  field,
+                  null,
+                  field.envVarName === ADO_TENANT_ID_ENV_VAR,
+                ),
+              )}
+            </div>
+            {oauthValidationError ? (
+              <p className="text-sm text-destructive" role="alert">
+                {oauthValidationError}
+              </p>
+            ) : null}
+            {oauthAccountStatePending ? (
+              <p className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Spinner /> Checking linked account…
+              </p>
+            ) : oauthAccountLinked ? (
+              <p className="flex items-center gap-2 text-sm">
+                <Check /> Your Azure DevOps account is linked.
+              </p>
+            ) : null}
+          </div>
         </div>
       ) : null}
 

--- a/apps/web/src/components/source-control/AdoSourceControlConfigFields.tsx
+++ b/apps/web/src/components/source-control/AdoSourceControlConfigFields.tsx
@@ -6,9 +6,11 @@ import {
   Button,
   Check,
   ChevronDown,
+  CopyIconButton,
   ExternalLink,
   Input,
   Label,
+  Spinner,
 } from '@/components/system';
 import {
   ADO_PAT_DOCUMENTATION_URL,
@@ -23,6 +25,16 @@ const MASKED_VALUE = '•••••••••••••••••••�
 const ADO_ORGANIZATION_ENV_VAR = 'ADO_ORGANIZATION';
 const ADO_TOKEN_ENV_VAR = 'ADO_TOKEN';
 const ADO_BASE_URL_ENV_VAR = 'ADO_BASE_URL';
+const ADO_CLIENT_ID_ENV_VAR = 'ADO_CLIENT_ID';
+const ADO_CLIENT_SECRET_ENV_VAR = 'ADO_CLIENT_SECRET';
+const ADO_TENANT_ID_ENV_VAR = 'ADO_TENANT_ID';
+const ADO_OAUTH_ENV_VARS = new Set([
+  ADO_CLIENT_ID_ENV_VAR,
+  ADO_CLIENT_SECRET_ENV_VAR,
+  ADO_TENANT_ID_ENV_VAR,
+]);
+const ENTRA_APP_REGISTRATIONS_URL =
+  'https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade';
 
 type SourceControlField =
   SetupSourceControlStatus['providers'][number]['fields'][number];
@@ -63,12 +75,70 @@ export function getEffectiveAdoBaseUrl(
   ).trim();
 }
 
+function isFieldSatisfied(
+  field: SourceControlField | undefined,
+  values: Record<string, string>,
+) {
+  return (
+    field?.runtimeSatisfied === true ||
+    field?.savedSatisfied === true ||
+    (field ? (values[field.envVarName]?.trim().length ?? 0) > 0 : false)
+  );
+}
+
+export function getAdoOAuthValidationError(
+  fields: readonly SourceControlField[],
+  values: Record<string, string>,
+): string | null {
+  const clientIdSatisfied = isFieldSatisfied(
+    fields.find((field) => field.envVarName === ADO_CLIENT_ID_ENV_VAR),
+    values,
+  );
+  const clientSecretSatisfied = isFieldSatisfied(
+    fields.find((field) => field.envVarName === ADO_CLIENT_SECRET_ENV_VAR),
+    values,
+  );
+
+  return clientIdSatisfied !== clientSecretSatisfied
+    ? 'Enter both the Microsoft Entra application (client) ID and client secret.'
+    : null;
+}
+
+function isAdoOAuthConfigured(fields: readonly SourceControlField[]) {
+  return [ADO_CLIENT_ID_ENV_VAR, ADO_CLIENT_SECRET_ENV_VAR].every(
+    (envVarName) => {
+      const field = fields.find(
+        (candidate) => candidate.envVarName === envVarName,
+      );
+      return field?.runtimeSatisfied === true || field?.savedSatisfied === true;
+    },
+  );
+}
+
+function isAdoOAuthReady(
+  fields: readonly SourceControlField[],
+  values: Record<string, string>,
+) {
+  return [ADO_CLIENT_ID_ENV_VAR, ADO_CLIENT_SECRET_ENV_VAR].every(
+    (envVarName) =>
+      isFieldSatisfied(
+        fields.find((field) => field.envVarName === envVarName),
+        values,
+      ),
+  );
+}
+
 export function AdoSourceControlConfigFields({
   fields,
   values,
   editingSavedValues,
   organizationConfirmed,
   advancedExpanded,
+  oauthExpanded,
+  oauthCallbackUrl,
+  oauthAccountLinked,
+  oauthAccountStatePending,
+  oauthLinkPending,
   disabled,
   compact = false,
   idPrefix,
@@ -76,12 +146,20 @@ export function AdoSourceControlConfigFields({
   onEditingSavedValueChange,
   onEditOrganization,
   onAdvancedExpandedChange,
+  onOauthExpandedChange,
+  onLinkAccount,
+  onSaveAndLinkAccount,
 }: {
   fields: readonly SourceControlField[];
   values: Record<string, string>;
   editingSavedValues: Record<string, boolean>;
   organizationConfirmed: boolean;
   advancedExpanded: boolean;
+  oauthExpanded: boolean;
+  oauthCallbackUrl: string;
+  oauthAccountLinked: boolean;
+  oauthAccountStatePending: boolean;
+  oauthLinkPending: boolean;
   disabled: boolean;
   compact?: boolean;
   idPrefix: string;
@@ -89,6 +167,9 @@ export function AdoSourceControlConfigFields({
   onEditingSavedValueChange: (envVarName: string, editing: boolean) => void;
   onEditOrganization: () => void;
   onAdvancedExpandedChange: (expanded: boolean) => void;
+  onOauthExpandedChange: (expanded: boolean) => void;
+  onLinkAccount: () => void;
+  onSaveAndLinkAccount: () => void;
 }) {
   const organizationField = fields.find(
     (field) => field.envVarName === ADO_ORGANIZATION_ENV_VAR,
@@ -99,10 +180,14 @@ export function AdoSourceControlConfigFields({
   const baseUrlField = fields.find(
     (field) => field.envVarName === ADO_BASE_URL_ENV_VAR,
   );
+  const oauthFields = fields.filter((field) =>
+    ADO_OAUTH_ENV_VARS.has(field.envVarName),
+  );
   const advancedFields = fields.filter(
     (field) =>
       field.envVarName !== ADO_ORGANIZATION_ENV_VAR &&
-      field.envVarName !== ADO_TOKEN_ENV_VAR,
+      field.envVarName !== ADO_TOKEN_ENV_VAR &&
+      !ADO_OAUTH_ENV_VARS.has(field.envVarName),
   );
   const organization = getEffectiveAdoOrganization(fields, values);
   const baseUrl = getEffectiveAdoBaseUrl(fields, values);
@@ -119,9 +204,13 @@ export function AdoSourceControlConfigFields({
     ? buildAdoPersonalAccessTokenUrl(organization)
     : ADO_PAT_DOCUMENTATION_URL;
   const advancedContentId = `${idPrefix}-advanced-options`;
+  const oauthContentId = `${idPrefix}-oauth-options`;
   const serverContentId = `${idPrefix}-server-options`;
   const serverCollapsedErrorId = `${idPrefix}-server-options-error`;
   const advancedCollapsedErrorId = `${idPrefix}-advanced-options-error`;
+  const oauthValidationError = getAdoOAuthValidationError(fields, values);
+  const oauthConfigured = isAdoOAuthConfigured(fields);
+  const oauthReady = isAdoOAuthReady(fields, values);
 
   const renderField = (
     field: SourceControlField,
@@ -326,6 +415,111 @@ export function AdoSourceControlConfigFields({
 
       {tokenField ? renderField(tokenField) : null}
 
+      {usesAdoCloud && oauthFields.length > 0 ? (
+        <div className="space-y-3 border-t pt-6">
+          <div className="space-y-1 max-w-xl">
+            <p className="font-semibold">Optional: link user accounts</p>
+            <p className="text-sm text-muted-foreground">
+              The PAT connects this Roomote deployment to Azure DevOps. OAuth
+              separately identifies each user, which is required when they start
+              Roomote work from pull request comments.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="cursor-pointer text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
+            onClick={() => onOauthExpandedChange(!oauthExpanded)}
+            disabled={disabled || oauthLinkPending}
+            aria-expanded={oauthExpanded}
+            aria-controls={oauthContentId}
+          >
+            {oauthExpanded
+              ? 'Hide account linking setup'
+              : 'Set up account linking'}
+            <ChevronDown
+              className={`${oauthExpanded ? 'rotate-180' : ''} inline size-4 transition-all`}
+            />
+          </button>
+          {oauthExpanded ? (
+            <div id={oauthContentId} className="space-y-4">
+              <div className="space-y-2 max-w-xl text-sm text-muted-foreground">
+                <p>
+                  Create a Microsoft Entra app registration. If Microsoft Teams
+                  or Microsoft sign-in is already configured, you can reuse that
+                  app: add the callback below and grant the delegated Azure
+                  DevOps <code>user_impersonation</code> permission.
+                </p>
+                <Button
+                  asChild
+                  variant="outline"
+                  size={compact ? 'sm' : 'default'}
+                >
+                  <a
+                    href={ENTRA_APP_REGISTRATIONS_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Open Microsoft Entra app registrations
+                    <ExternalLink />
+                  </a>
+                </Button>
+                <p>Configure this Web redirect URI:</p>
+                <p className="flex items-center gap-1">
+                  <code className="break-all text-foreground">
+                    {oauthCallbackUrl}
+                  </code>
+                  <CopyIconButton
+                    content={oauthCallbackUrl}
+                    tooltip="Copy redirect URI"
+                  />
+                </p>
+                <p>
+                  Paste the application ID and client secret below. The tenant
+                  ID is optional; use the same tenant as Teams when applicable.
+                </p>
+              </div>
+              <div className="space-y-2">
+                {oauthFields.map((field) => renderField(field))}
+              </div>
+              {oauthValidationError ? (
+                <p className="text-sm text-destructive" role="alert">
+                  {oauthValidationError}
+                </p>
+              ) : null}
+              {oauthAccountStatePending ? (
+                <p className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <Spinner /> Checking linked account…
+                </p>
+              ) : oauthAccountLinked ? (
+                <p className="flex items-center gap-2 text-sm">
+                  <Check /> Your Azure DevOps account is linked.
+                </p>
+              ) : oauthConfigured ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={onLinkAccount}
+                  disabled={disabled || oauthLinkPending}
+                >
+                  {oauthLinkPending ? <Spinner /> : null}
+                  Link my Azure DevOps account
+                </Button>
+              ) : oauthReady && !oauthValidationError ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={onSaveAndLinkAccount}
+                  disabled={disabled || oauthLinkPending}
+                >
+                  {disabled || oauthLinkPending ? <Spinner /> : null}
+                  Save and link my account
+                </Button>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
       {advancedFields.length > 0 ? (
         <div className="space-y-3">
           <button
@@ -351,8 +545,8 @@ export function AdoSourceControlConfigFields({
           {advancedExpanded ? (
             <div id={advancedContentId} className="space-y-2">
               <p className="max-w-xl text-sm text-muted-foreground">
-                Optional settings for custom hosts, Git credentials, personal
-                account linking, and webhook verification.
+                Optional settings for custom hosts, Git credentials, and webhook
+                verification.
               </p>
               {advancedFields.map((field) =>
                 renderField(

--- a/apps/web/src/components/source-control/AdoSourceControlConfigFields.tsx
+++ b/apps/web/src/components/source-control/AdoSourceControlConfigFields.tsx
@@ -1,0 +1,378 @@
+'use client';
+
+import type { SetupSourceControlStatus } from '@roomote/types';
+
+import {
+  Button,
+  Check,
+  ChevronDown,
+  ExternalLink,
+  Input,
+  Label,
+} from '@/components/system';
+import {
+  ADO_PAT_DOCUMENTATION_URL,
+  buildAdoPersonalAccessTokenUrl,
+  getAdoBaseUrlValidationError,
+  getAdoOrganizationValidationError,
+  isAdoCloudBaseUrl,
+  normalizeAdoOrganization,
+} from '@/lib/ado';
+
+const MASKED_VALUE = '••••••••••••••••••••••••••••';
+const ADO_ORGANIZATION_ENV_VAR = 'ADO_ORGANIZATION';
+const ADO_TOKEN_ENV_VAR = 'ADO_TOKEN';
+const ADO_BASE_URL_ENV_VAR = 'ADO_BASE_URL';
+
+type SourceControlField =
+  SetupSourceControlStatus['providers'][number]['fields'][number];
+
+function isSecretSourceControlField(field: Pick<SourceControlField, 'secret'>) {
+  return field.secret === true;
+}
+
+function fieldInputId(idPrefix: string, field: SourceControlField) {
+  return `${idPrefix}-${field.envVarName.toLowerCase().replaceAll('_', '-')}`;
+}
+
+export function getEffectiveAdoOrganization(
+  fields: readonly SourceControlField[],
+  values: Record<string, string>,
+): string {
+  const organizationField = fields.find(
+    (field) => field.envVarName === ADO_ORGANIZATION_ENV_VAR,
+  );
+  const organization =
+    values[ADO_ORGANIZATION_ENV_VAR] ?? organizationField?.savedValue ?? '';
+
+  return normalizeAdoOrganization(organization);
+}
+
+export function getEffectiveAdoBaseUrl(
+  fields: readonly SourceControlField[],
+  values: Record<string, string>,
+): string {
+  const baseUrlField = fields.find(
+    (field) => field.envVarName === ADO_BASE_URL_ENV_VAR,
+  );
+
+  return (
+    values[ADO_BASE_URL_ENV_VAR] ??
+    baseUrlField?.savedValue ??
+    ''
+  ).trim();
+}
+
+export function AdoSourceControlConfigFields({
+  fields,
+  values,
+  editingSavedValues,
+  organizationConfirmed,
+  advancedExpanded,
+  disabled,
+  compact = false,
+  idPrefix,
+  onValueChange,
+  onEditingSavedValueChange,
+  onEditOrganization,
+  onAdvancedExpandedChange,
+}: {
+  fields: readonly SourceControlField[];
+  values: Record<string, string>;
+  editingSavedValues: Record<string, boolean>;
+  organizationConfirmed: boolean;
+  advancedExpanded: boolean;
+  disabled: boolean;
+  compact?: boolean;
+  idPrefix: string;
+  onValueChange: (envVarName: string, value: string) => void;
+  onEditingSavedValueChange: (envVarName: string, editing: boolean) => void;
+  onEditOrganization: () => void;
+  onAdvancedExpandedChange: (expanded: boolean) => void;
+}) {
+  const organizationField = fields.find(
+    (field) => field.envVarName === ADO_ORGANIZATION_ENV_VAR,
+  );
+  const tokenField = fields.find(
+    (field) => field.envVarName === ADO_TOKEN_ENV_VAR,
+  );
+  const baseUrlField = fields.find(
+    (field) => field.envVarName === ADO_BASE_URL_ENV_VAR,
+  );
+  const advancedFields = fields.filter(
+    (field) =>
+      field.envVarName !== ADO_ORGANIZATION_ENV_VAR &&
+      field.envVarName !== ADO_TOKEN_ENV_VAR,
+  );
+  const organization = getEffectiveAdoOrganization(fields, values);
+  const baseUrl = getEffectiveAdoBaseUrl(fields, values);
+  const usesAdoCloud = isAdoCloudBaseUrl(baseUrl);
+  const organizationValidationError = getAdoOrganizationValidationError(
+    organization,
+    baseUrl,
+  );
+  const visibleOrganizationValidationError = organization
+    ? organizationValidationError
+    : null;
+  const baseUrlValidationError = getAdoBaseUrlValidationError(baseUrl);
+  const patCreationUrl = usesAdoCloud
+    ? buildAdoPersonalAccessTokenUrl(organization)
+    : ADO_PAT_DOCUMENTATION_URL;
+  const advancedContentId = `${idPrefix}-advanced-options`;
+  const serverContentId = `${idPrefix}-server-options`;
+  const serverCollapsedErrorId = `${idPrefix}-server-options-error`;
+  const advancedCollapsedErrorId = `${idPrefix}-advanced-options-error`;
+
+  const renderField = (
+    field: SourceControlField,
+    validationError: string | null = null,
+  ) => {
+    const value = values[field.envVarName] ?? '';
+    const isSecretField = isSecretSourceControlField(field);
+    const shouldShowSavedValueMask =
+      isSecretField &&
+      !field.runtimeSatisfied &&
+      field.savedSatisfied &&
+      value.length === 0 &&
+      !editingSavedValues[field.envVarName];
+    const inputId = fieldInputId(idPrefix, field);
+    const errorId = `${inputId}-error`;
+
+    return (
+      <div
+        key={field.envVarName}
+        className={`grid max-w-xl gap-2 ${
+          compact
+            ? 'md:grid-cols-[180px_minmax(0,1fr)]'
+            : 'md:grid-cols-[200px_minmax(0,1fr)]'
+        } md:items-center`}
+      >
+        <Label htmlFor={inputId} className="text-sm font-medium">
+          {field.label}
+          {field.required === false ? ' (optional)' : ''}
+        </Label>
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <Input
+              id={inputId}
+              secret={isSecretField && !field.runtimeSatisfied}
+              type={isSecretField ? undefined : 'text'}
+              className="font-mono"
+              value={
+                isSecretField && field.runtimeSatisfied
+                  ? MASKED_VALUE
+                  : shouldShowSavedValueMask
+                    ? MASKED_VALUE
+                    : field.runtimeSatisfied && !isSecretField
+                      ? (field.savedValue ?? value)
+                      : value
+              }
+              onFocus={() => {
+                if (shouldShowSavedValueMask) {
+                  onEditingSavedValueChange(field.envVarName, true);
+                }
+              }}
+              onBlur={() => {
+                if (
+                  isSecretField &&
+                  field.savedSatisfied &&
+                  value.length === 0
+                ) {
+                  onEditingSavedValueChange(field.envVarName, false);
+                }
+              }}
+              onChange={(event) =>
+                onValueChange(field.envVarName, event.target.value)
+              }
+              placeholder={field.runtimeSatisfied ? '' : field.envVarName}
+              disabled={disabled || field.runtimeSatisfied}
+              aria-invalid={validationError ? true : undefined}
+              aria-describedby={validationError ? errorId : undefined}
+              data-1p-ignore
+            />
+            {(field.runtimeSatisfied || field.savedSatisfied) && <Check />}
+          </div>
+          {validationError ? (
+            <p id={errorId} className="text-sm text-destructive">
+              {validationError}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    );
+  };
+
+  if (!organizationConfirmed) {
+    return (
+      <div className="space-y-4">
+        <div className="space-y-1 max-w-xl">
+          <p className="font-semibold">
+            {usesAdoCloud
+              ? 'Enter your Azure DevOps organization.'
+              : 'Enter your Azure DevOps Server project collection.'}
+          </p>
+          <p className="text-sm text-muted-foreground">
+            {usesAdoCloud ? (
+              <>
+                Use the organization name from your{' '}
+                <code>https://dev.azure.com/&lt;organization&gt;</code> URL.
+              </>
+            ) : (
+              'Use the collection name shown in your Azure DevOps Server web portal URL.'
+            )}
+          </p>
+        </div>
+        {organizationField
+          ? renderField(organizationField, visibleOrganizationValidationError)
+          : null}
+        {baseUrlField ? (
+          <div className="space-y-3">
+            <button
+              type="button"
+              className="cursor-pointer text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
+              onClick={() => onAdvancedExpandedChange(!advancedExpanded)}
+              disabled={disabled}
+              aria-expanded={advancedExpanded}
+              aria-controls={serverContentId}
+              aria-describedby={
+                !advancedExpanded && baseUrlValidationError
+                  ? serverCollapsedErrorId
+                  : undefined
+              }
+            >
+              {advancedExpanded
+                ? 'Hide Azure DevOps Server options'
+                : 'Using Azure DevOps Server?'}
+              <ChevronDown
+                className={`${advancedExpanded ? 'rotate-180' : ''} inline size-4 transition-all`}
+              />
+            </button>
+            {advancedExpanded ? (
+              <div id={serverContentId} className="space-y-3">
+                <p className="max-w-xl text-sm text-muted-foreground">
+                  Enter the web portal URL for your self-hosted Azure DevOps
+                  Server. The organization field should contain its project
+                  collection name.
+                </p>
+                {renderField(baseUrlField, baseUrlValidationError)}
+              </div>
+            ) : baseUrlValidationError ? (
+              <p
+                id={serverCollapsedErrorId}
+                className="text-sm text-destructive"
+              >
+                {baseUrlValidationError}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1 max-w-xl">
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          <span className="text-muted-foreground">Organization</span>
+          <code className="ph-no-capture">{organization}</code>
+          {organizationField?.runtimeSatisfied ? (
+            <span className="text-muted-foreground">
+              Managed by runtime configuration
+            </span>
+          ) : (
+            <Button
+              type="button"
+              size="xs"
+              variant="ghost"
+              onClick={onEditOrganization}
+              disabled={disabled}
+            >
+              Change organization
+            </Button>
+          )}
+        </div>
+        {organizationValidationError ? (
+          <p className="text-sm text-destructive">
+            {organizationValidationError}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="space-y-3 max-w-xl">
+        <div className="space-y-1">
+          <p className="font-semibold">
+            {usesAdoCloud
+              ? 'Create a personal access token.'
+              : 'Create a personal access token in Azure DevOps Server.'}
+          </p>
+          <p className="text-sm text-muted-foreground">
+            {usesAdoCloud
+              ? 'Create the PAT with Code read & write access and permission to manage service hook subscriptions, then paste it below.'
+              : 'Open the PAT instructions, then create a token from your server user settings and paste it below.'}
+          </p>
+        </div>
+        {patCreationUrl ? (
+          <Button asChild variant="outline" size={compact ? 'sm' : 'default'}>
+            <a href={patCreationUrl} target="_blank" rel="noopener noreferrer">
+              {usesAdoCloud
+                ? 'Create Azure DevOps PAT'
+                : 'View PAT setup instructions'}
+              <ExternalLink />
+            </a>
+          </Button>
+        ) : null}
+      </div>
+
+      {tokenField ? renderField(tokenField) : null}
+
+      {advancedFields.length > 0 ? (
+        <div className="space-y-3">
+          <button
+            type="button"
+            className="cursor-pointer text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
+            onClick={() => onAdvancedExpandedChange(!advancedExpanded)}
+            disabled={disabled}
+            aria-expanded={advancedExpanded}
+            aria-controls={advancedContentId}
+            aria-describedby={
+              !advancedExpanded && baseUrlValidationError
+                ? advancedCollapsedErrorId
+                : undefined
+            }
+          >
+            {advancedExpanded
+              ? 'Hide advanced options'
+              : 'Show advanced options'}
+            <ChevronDown
+              className={`${advancedExpanded ? 'rotate-180' : ''} inline size-4 transition-all`}
+            />
+          </button>
+          {advancedExpanded ? (
+            <div id={advancedContentId} className="space-y-2">
+              <p className="max-w-xl text-sm text-muted-foreground">
+                Optional settings for custom hosts, Git credentials, personal
+                account linking, and webhook verification.
+              </p>
+              {advancedFields.map((field) =>
+                renderField(
+                  field,
+                  field.envVarName === ADO_BASE_URL_ENV_VAR
+                    ? baseUrlValidationError
+                    : null,
+                ),
+              )}
+            </div>
+          ) : baseUrlValidationError ? (
+            <p
+              id={advancedCollapsedErrorId}
+              className="text-sm text-destructive"
+            >
+              {baseUrlValidationError}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/source-control/AdoSourceControlConfigFields.tsx
+++ b/apps/web/src/components/source-control/AdoSourceControlConfigFields.tsx
@@ -203,7 +203,10 @@ export function AdoSourceControlConfigFields({
   const renderField = (
     field: SourceControlField,
     validationError: string | null = null,
-    optional = field.required === false,
+    qualifier:
+      | 'optional'
+      | 'required-unless-multi-tenant'
+      | null = field.required === false ? 'optional' : null,
   ) => {
     const value = values[field.envVarName] ?? '';
     const isSecretField = isSecretSourceControlField(field);
@@ -227,7 +230,11 @@ export function AdoSourceControlConfigFields({
       >
         <Label htmlFor={inputId} className="text-sm font-medium">
           {field.label}
-          {optional ? ' (optional)' : ''}
+          {qualifier === 'optional'
+            ? ' (optional)'
+            : qualifier === 'required-unless-multi-tenant'
+              ? ' (required unless multi-tenant)'
+              : ''}
         </Label>
         <div className="space-y-1">
           <div className="flex items-center gap-2">
@@ -456,7 +463,8 @@ export function AdoSourceControlConfigFields({
               </p>
               <p>
                 Paste the application ID and client secret below. The tenant ID
-                is optional; use the same tenant as Teams when applicable.
+                is required unless the app supports multiple tenants. If you
+                reuse the Teams app, use its tenant ID.
               </p>
             </div>
             <div className="space-y-2">
@@ -464,7 +472,9 @@ export function AdoSourceControlConfigFields({
                 renderField(
                   field,
                   null,
-                  field.envVarName === ADO_TENANT_ID_ENV_VAR,
+                  field.envVarName === ADO_TENANT_ID_ENV_VAR
+                    ? 'required-unless-multi-tenant'
+                    : null,
                 ),
               )}
             </div>

--- a/apps/web/src/hooks/linked-accounts/useAdoLinkedAccount.ts
+++ b/apps/web/src/hooks/linked-accounts/useAdoLinkedAccount.ts
@@ -2,8 +2,12 @@ import { useQuery } from '@tanstack/react-query';
 
 import { useTRPC } from '@/trpc/client';
 
-export const useAdoLinkedAccount = () => {
+export const useAdoLinkedAccount = (options?: { enabled?: boolean }) => {
   const trpc = useTRPC();
 
-  return useQuery(trpc.linkedAccounts.ado.queryOptions());
+  return useQuery(
+    trpc.linkedAccounts.ado.queryOptions(undefined, {
+      enabled: options?.enabled ?? true,
+    }),
+  );
 };

--- a/apps/web/src/lib/ado.test.ts
+++ b/apps/web/src/lib/ado.test.ts
@@ -1,0 +1,78 @@
+import {
+  buildAdoPersonalAccessTokenUrl,
+  getAdoBaseUrlValidationError,
+  getAdoOrganizationValidationError,
+  isAdoCloudBaseUrl,
+  normalizeAdoOrganization,
+} from './ado';
+
+describe('Azure DevOps setup helpers', () => {
+  it('normalizes an organization slug', () => {
+    expect(normalizeAdoOrganization(' /acme/ ')).toBe('acme');
+  });
+
+  it('builds an organization-scoped PAT URL', () => {
+    expect(buildAdoPersonalAccessTokenUrl('Acme-Org')).toBe(
+      'https://dev.azure.com/Acme-Org/_usersSettings/tokens',
+    );
+  });
+
+  it.each([
+    '',
+    '   ',
+    '.',
+    '..',
+    'acme org',
+    'acme/org',
+    'https://dev.azure.com/acme',
+    '-acme',
+    'acme-',
+    'a'.repeat(50),
+  ])('rejects an unsafe organization %j', (value) => {
+    expect(buildAdoPersonalAccessTokenUrl(value)).toBeNull();
+  });
+
+  it('accepts Azure DevOps Server collection names only with a custom host', () => {
+    expect(
+      getAdoOrganizationValidationError(
+        'Default Collection',
+        'https://ado.example.com/tfs',
+      ),
+    ).toBeNull();
+    expect(
+      getAdoOrganizationValidationError(
+        'Default Collection',
+        'https://dev.azure.com',
+      ),
+    ).not.toBeNull();
+    expect(
+      getAdoOrganizationValidationError(
+        'collection/name',
+        'https://ado.example.com/tfs',
+      ),
+    ).not.toBeNull();
+  });
+
+  it('recognizes only the default cloud URL as Azure DevOps Services', () => {
+    expect(isAdoCloudBaseUrl('')).toBe(true);
+    expect(isAdoCloudBaseUrl('https://dev.azure.com/')).toBe(true);
+    expect(isAdoCloudBaseUrl('https://dev.azure.com:444')).toBe(false);
+    expect(isAdoCloudBaseUrl('https://ado.example.com/tfs')).toBe(false);
+  });
+
+  it('validates custom Azure DevOps Server URLs', () => {
+    expect(
+      getAdoBaseUrlValidationError('https://ado.example.com/tfs'),
+    ).toBeNull();
+    expect(getAdoBaseUrlValidationError('ado.example.com')).not.toBeNull();
+    expect(
+      getAdoBaseUrlValidationError('ftp://ado.example.com'),
+    ).not.toBeNull();
+    expect(
+      getAdoBaseUrlValidationError('https://ado.example.com/tfs?view=mine'),
+    ).not.toBeNull();
+    expect(
+      getAdoBaseUrlValidationError('https://ado.example.com/tfs#tokens'),
+    ).not.toBeNull();
+  });
+});

--- a/apps/web/src/lib/ado.ts
+++ b/apps/web/src/lib/ado.ts
@@ -1,0 +1,105 @@
+export const ADO_CLOUD_BASE_URL = 'https://dev.azure.com';
+export const ADO_PAT_DOCUMENTATION_URL =
+  'https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops';
+
+const ADO_CLOUD_ORGANIZATION_PATTERN =
+  /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,47}[A-Za-z0-9])?$/;
+const ADO_SERVER_COLLECTION_FORBIDDEN_CHARACTERS = '\\/:*?"<>;#${},+=[]|';
+
+export function normalizeAdoOrganization(organization: string): string {
+  return organization.trim().replace(/^\/+|\/+$/g, '');
+}
+
+export function getAdoBaseUrlValidationError(baseUrl: string): string | null {
+  const normalizedBaseUrl = baseUrl.trim();
+
+  if (!normalizedBaseUrl) {
+    return null;
+  }
+
+  try {
+    const url = new URL(normalizedBaseUrl);
+
+    if (
+      !['http:', 'https:'].includes(url.protocol) ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash
+    ) {
+      return 'Enter a valid HTTP or HTTPS Azure DevOps Server URL.';
+    }
+  } catch {
+    return 'Enter a valid HTTP or HTTPS Azure DevOps Server URL.';
+  }
+
+  return null;
+}
+
+export function isAdoCloudBaseUrl(baseUrl: string): boolean {
+  const normalizedBaseUrl = baseUrl.trim();
+
+  if (!normalizedBaseUrl) {
+    return true;
+  }
+
+  try {
+    const url = new URL(normalizedBaseUrl);
+    return (
+      url.origin === ADO_CLOUD_BASE_URL &&
+      (url.pathname === '/' || url.pathname === '') &&
+      !url.search &&
+      !url.hash &&
+      !url.username &&
+      !url.password
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function getAdoOrganizationValidationError(
+  organization: string,
+  baseUrl = '',
+): string | null {
+  const normalizedOrganization = normalizeAdoOrganization(organization);
+
+  if (!normalizedOrganization) {
+    return 'Enter your Azure DevOps organization.';
+  }
+
+  if (isAdoCloudBaseUrl(baseUrl)) {
+    return ADO_CLOUD_ORGANIZATION_PATTERN.test(normalizedOrganization)
+      ? null
+      : 'Use only letters, numbers, and hyphens, start and end with a letter or number, and use fewer than 50 characters.';
+  }
+
+  if (
+    normalizedOrganization.length > 64 ||
+    Array.from(normalizedOrganization).some(
+      (character) =>
+        character.charCodeAt(0) < 32 ||
+        ADO_SERVER_COLLECTION_FORBIDDEN_CHARACTERS.includes(character),
+    ) ||
+    normalizedOrganization.startsWith('_') ||
+    normalizedOrganization.startsWith('.') ||
+    normalizedOrganization.endsWith('.') ||
+    normalizedOrganization.includes('..')
+  ) {
+    return 'Enter a valid Azure DevOps Server project collection name.';
+  }
+
+  return null;
+}
+
+export function buildAdoPersonalAccessTokenUrl(
+  organization: string,
+): string | null {
+  const normalizedOrganization = normalizeAdoOrganization(organization);
+
+  if (getAdoOrganizationValidationError(normalizedOrganization) !== null) {
+    return null;
+  }
+
+  return `${ADO_CLOUD_BASE_URL}/${normalizedOrganization}/_usersSettings/tokens`;
+}

--- a/apps/web/src/lib/server/auth-provider-config.client.test.ts
+++ b/apps/web/src/lib/server/auth-provider-config.client.test.ts
@@ -129,19 +129,21 @@ describe('resolveAuthProviderConfig', () => {
     expect(config.adoBaseUrl).toBe('https://dev.azure.example.com');
   });
 
-  it('does not use the Microsoft tenant for Azure DevOps Entra linking when no ADO tenant is configured', async () => {
+  it('reuses Microsoft credentials for Azure DevOps Entra linking when ADO credentials are not configured', async () => {
     const config = await resolveAuthProviderConfig({
       runtimeEnv: {},
       deploymentEnvVars: {
+        R_MICROSOFT_CLIENT_ID: 'microsoft-client-id',
+        R_MICROSOFT_CLIENT_SECRET: 'microsoft-client-secret',
         R_MICROSOFT_TENANT_ID: 'microsoft-tenant-id',
-        ADO_CLIENT_ID: 'ado-client-id',
-        ADO_CLIENT_SECRET: 'ado-client-secret',
         ADO_ORGANIZATION: 'ado-org',
       },
     });
 
-    expect(config.enabledProviders).toEqual([]);
-    expect(config.adoTenantId).toBeNull();
+    expect(config.enabledProviders).toEqual(['microsoft']);
+    expect(config.adoClientId).toBe('microsoft-client-id');
+    expect(config.adoClientSecret).toBe('microsoft-client-secret');
+    expect(config.adoTenantId).toBe('microsoft-tenant-id');
   });
 
   it('bootstraps the web runtime before resolving default deployment env vars', async () => {

--- a/apps/web/src/lib/server/auth-provider-config.ts
+++ b/apps/web/src/lib/server/auth-provider-config.ts
@@ -130,12 +130,14 @@ export async function resolveAuthProviderConfig(
     readConfiguredValue(runtimeEnv, deploymentEnvVars, 'BITBUCKET_BASE_URL') ??
     null;
   const adoClientId =
-    readConfiguredValue(runtimeEnv, deploymentEnvVars, 'ADO_CLIENT_ID') ?? null;
+    readConfiguredValue(runtimeEnv, deploymentEnvVars, 'ADO_CLIENT_ID') ??
+    microsoftClientId;
   const adoClientSecret =
     readConfiguredValue(runtimeEnv, deploymentEnvVars, 'ADO_CLIENT_SECRET') ??
-    null;
+    microsoftClientSecret;
   const adoTenantId =
-    readConfiguredValue(runtimeEnv, deploymentEnvVars, 'ADO_TENANT_ID') ?? null;
+    readConfiguredValue(runtimeEnv, deploymentEnvVars, 'ADO_TENANT_ID') ??
+    microsoftTenantId;
   const adoOrganization =
     readConfiguredValue(runtimeEnv, deploymentEnvVars, 'ADO_ORGANIZATION') ??
     null;

--- a/apps/web/src/trpc/commands/environment-variables/index.test.ts
+++ b/apps/web/src/trpc/commands/environment-variables/index.test.ts
@@ -2,8 +2,9 @@ import type { FeatureFlag } from '@roomote/feature-flags';
 
 import type { UserAuthSuccess } from '@/types';
 
-const { mockFinalChain } = vi.hoisted(() => ({
+const { mockFinalChain, mockInArray } = vi.hoisted(() => ({
   mockFinalChain: vi.fn(),
+  mockInArray: vi.fn(),
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -19,12 +20,16 @@ vi.mock('@roomote/db/server', () => ({
   environmentVariables: { name: 'env.name', userId: 'env.user_id' },
   eq: vi.fn(),
   desc: vi.fn(),
-  inArray: vi.fn(),
+  inArray: mockInArray,
   not: vi.fn(),
   getTableColumns: () => ({ id: 'env.id', name: 'env.name' }),
 }));
 
-import { createEnvVarCommand, getEnvVarsCommand } from './index';
+import {
+  createEnvVarCommand,
+  deleteDeploymentEnvironmentVariables,
+  getEnvVarsCommand,
+} from './index';
 
 function buildMockAuth(
   overrides: Partial<UserAuthSuccess> = {},
@@ -69,6 +74,27 @@ describe('environment-variables commands', () => {
       await getEnvVarsCommand(buildMockAuth());
 
       expect(mockFinalChain).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('deleteDeploymentEnvironmentVariables', () => {
+    it('deletes each named deployment value once', async () => {
+      const where = vi.fn().mockResolvedValue(undefined);
+      const executor = {
+        delete: vi.fn(() => ({ where })),
+      } as unknown as Parameters<
+        typeof deleteDeploymentEnvironmentVariables
+      >[0];
+
+      await deleteDeploymentEnvironmentVariables(executor, [
+        ' ADO_BASE_URL ',
+        'ADO_BASE_URL',
+        '',
+      ]);
+
+      expect(mockInArray).toHaveBeenCalledWith('env.name', ['ADO_BASE_URL']);
+      expect(executor.delete).toHaveBeenCalledTimes(1);
+      expect(where).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apps/web/src/trpc/commands/environment-variables/index.ts
+++ b/apps/web/src/trpc/commands/environment-variables/index.ts
@@ -148,6 +148,23 @@ export async function upsertDeploymentEnvironmentVariables(
   }
 }
 
+export async function deleteDeploymentEnvironmentVariables(
+  tx: DatabaseOrTransaction,
+  names: string[],
+) {
+  const uniqueNames = Array.from(
+    new Set(names.map((name) => name.trim()).filter(Boolean)),
+  );
+
+  if (uniqueNames.length === 0) {
+    return;
+  }
+
+  await tx
+    .delete(environmentVariables)
+    .where(inArray(environmentVariables.name, uniqueNames));
+}
+
 export async function getEnvVarsCommand(auth: UserAuthSuccess) {
   assertAdmin(auth);
 

--- a/apps/web/src/trpc/commands/source-control/index.test.ts
+++ b/apps/web/src/trpc/commands/source-control/index.test.ts
@@ -14,6 +14,7 @@ const {
   mockResolveAdoOrganization,
   mockValidateAdoToken,
   mockValidateGiteaToken,
+  mockDeleteDeploymentEnvironmentVariables,
   mockEnv,
 } = vi.hoisted(() => ({
   mockEnsureAdoServiceHooksForRepositories: vi.fn(),
@@ -29,6 +30,7 @@ const {
   mockResolveAdoOrganization: vi.fn(),
   mockValidateAdoToken: vi.fn(),
   mockValidateGiteaToken: vi.fn(),
+  mockDeleteDeploymentEnvironmentVariables: vi.fn(),
   mockEnv: {
     R_APP_URL: 'https://roomote.example.com',
     TRPC_URL: 'http://localhost:3000/trpc',
@@ -91,12 +93,15 @@ vi.mock('../environment-variables', () => ({
       throw new Error('Unauthorized');
     }
   },
+  deleteDeploymentEnvironmentVariables:
+    mockDeleteDeploymentEnvironmentVariables,
   upsertDeploymentEnvironmentVariables:
     mockUpsertDeploymentEnvironmentVariables,
 }));
 
 import {
   assertValidSourceControlConfigInput,
+  saveSourceControlConfigValues,
   syncRepositoriesCommand,
 } from './index';
 
@@ -159,6 +164,34 @@ describe('source-control commands', () => {
     mockValidateGiteaToken.mockResolvedValue({ status: 'valid' });
     mockResolveAdoOrganization.mockResolvedValue(null);
     mockValidateAdoToken.mockResolvedValue({ status: 'valid' });
+  });
+
+  it('clears a submitted blank optional source-control value', async () => {
+    const executor = {
+      select: () => ({
+        from: () =>
+          Promise.resolve([
+            { name: 'ADO_ORGANIZATION' },
+            { name: 'ADO_TOKEN' },
+            { name: 'ADO_BASE_URL' },
+          ]),
+      }),
+    } as unknown as Parameters<
+      typeof saveSourceControlConfigValues
+    >[0]['executor'];
+
+    await saveSourceControlConfigValues({
+      executor,
+      actorUserId: 'source-control-user',
+      provider: 'ado',
+      values: { ADO_BASE_URL: '' },
+    });
+
+    expect(mockDeleteDeploymentEnvironmentVariables).toHaveBeenCalledWith(
+      executor,
+      ['ADO_BASE_URL'],
+    );
+    expect(mockUpsertDeploymentEnvironmentVariables).not.toHaveBeenCalled();
   });
 
   it('syncs Gitea repositories and configures pull request webhooks', async () => {
@@ -341,6 +374,23 @@ describe('source-control commands', () => {
       token: 'ado-token',
       organization: 'acme',
       baseUrl: undefined,
+    });
+  });
+
+  it('validates a new Azure DevOps token against cloud when clearing a saved Server URL', async () => {
+    await assertValidSourceControlConfigInput({
+      provider: 'ado',
+      values: {
+        ADO_ORGANIZATION: 'acme',
+        ADO_TOKEN: 'ado-token',
+        ADO_BASE_URL: '',
+      },
+    });
+
+    expect(mockValidateAdoToken).toHaveBeenCalledWith({
+      token: 'ado-token',
+      organization: 'acme',
+      baseUrl: 'https://dev.azure.com',
     });
   });
 

--- a/apps/web/src/trpc/commands/source-control/index.ts
+++ b/apps/web/src/trpc/commands/source-control/index.ts
@@ -27,11 +27,13 @@ import {
 
 import type { UserAuthSuccess } from '@/types';
 
+import { ADO_CLOUD_BASE_URL } from '@/lib/ado';
 import { getRepositories } from '@/lib/server';
 import { Env } from '@/lib/server/env';
 
 import {
   assertAdmin,
+  deleteDeploymentEnvironmentVariables,
   getPersistedEnvironmentVariableValues,
   upsertDeploymentEnvironmentVariables,
 } from '../environment-variables';
@@ -644,6 +646,25 @@ export async function saveSourceControlConfigValues(params: {
       },
     ];
   });
+  const submittedValues = params.values ?? {};
+  const envVarNamesToClear = providerStatus.fields.flatMap((field) => {
+    const wasSubmitted = Object.prototype.hasOwnProperty.call(
+      submittedValues,
+      field.envVarName,
+    );
+    const nextValue = submittedValues[field.envVarName]?.trim() ?? '';
+
+    if (
+      field.required !== false ||
+      !field.savedSatisfied ||
+      !wasSubmitted ||
+      nextValue
+    ) {
+      return [];
+    }
+
+    return [field.envVarName];
+  });
 
   const hasMissingRequiredValue = providerStatus.fields.some((field) => {
     const nextValue = params.values?.[field.envVarName]?.trim() ?? '';
@@ -667,6 +688,13 @@ export async function saveSourceControlConfigValues(params: {
       userId: params.actorUserId,
       values: valuesToSave,
     });
+  }
+
+  if (envVarNamesToClear.length > 0) {
+    await deleteDeploymentEnvironmentVariables(
+      params.executor,
+      envVarNamesToClear,
+    );
   }
 
   return providerStatus;
@@ -759,10 +787,18 @@ export async function assertValidSourceControlConfigInput(params: {
       return;
     }
 
+    const adoBaseUrlWasSubmitted = Object.prototype.hasOwnProperty.call(
+      params.values ?? {},
+      'ADO_BASE_URL',
+    );
+    const submittedAdoBaseUrl = params.values?.['ADO_BASE_URL']?.trim() ?? '';
+
     const validation = await Ado.validateAdoToken({
       token: nextAdoToken,
       organization: nextAdoOrganization,
-      baseUrl: params.values?.['ADO_BASE_URL']?.trim() || undefined,
+      baseUrl: adoBaseUrlWasSubmitted
+        ? submittedAdoBaseUrl || ADO_CLOUD_BASE_URL
+        : undefined,
     });
 
     if (validation.status === 'invalid') {

--- a/packages/types/src/setup-source-control-config.test.ts
+++ b/packages/types/src/setup-source-control-config.test.ts
@@ -175,7 +175,7 @@ describe('buildSetupSourceControlStatus', () => {
     expect(status.lockReason).toBe('runtime_env');
   });
 
-  it('does not require optional fields to satisfy config', () => {
+  it('requires OAuth fields for Azure DevOps Services configuration', () => {
     const status = buildSetupSourceControlStatus({
       runtimeEnv: {
         ADO_ORGANIZATION: 'my-org',
@@ -184,7 +184,7 @@ describe('buildSetupSourceControlStatus', () => {
     });
 
     const ado = status.providers.find((p) => p.provider === 'ado');
-    expect(ado).toMatchObject({ configSatisfied: true });
+    expect(ado).toMatchObject({ configSatisfied: false });
     const optionalBaseUrl = ado?.fields.find(
       (f) => f.envVarName === 'ADO_BASE_URL',
     );
@@ -268,6 +268,20 @@ describe('buildSetupSourceControlStatus', () => {
     });
   });
 
+  it('does not require OAuth fields for Azure DevOps Server configuration', () => {
+    const status = buildSetupSourceControlStatus({
+      runtimeEnv: {
+        ADO_BASE_URL: 'https://ado.example.com/tfs',
+        ADO_ORGANIZATION: 'Default Collection',
+        ADO_TOKEN: 'ado-token',
+      },
+    });
+
+    expect(
+      status.providers.find((provider) => provider.provider === 'ado'),
+    ).toMatchObject({ configSatisfied: true });
+  });
+
   it('marks config unsatisfied when a required field is missing', () => {
     const status = buildSetupSourceControlStatus({
       runtimeEnv: { ADO_ORGANIZATION: 'my-org' },
@@ -318,12 +332,46 @@ describe('buildSetupSourceControlStatus', () => {
     expect(status.connectedProvider).toBe('github');
   });
 
-  it('does not accept env var aliases in setup fields', () => {
+  it('only accepts Microsoft app aliases for Azure DevOps OAuth fields', () => {
     for (const provider of SETUP_SOURCE_CONTROL_PROVIDER_CATALOG) {
       for (const field of provider.fields) {
-        expect(field.acceptedEnvVarNames).toEqual([field.envVarName]);
+        const expectedAliases: Partial<Record<string, string>> = {
+          ADO_CLIENT_ID: 'R_MICROSOFT_CLIENT_ID',
+          ADO_CLIENT_SECRET: 'R_MICROSOFT_CLIENT_SECRET',
+          ADO_TENANT_ID: 'R_MICROSOFT_TENANT_ID',
+        };
+        const alias = expectedAliases[field.envVarName];
+        expect(field.acceptedEnvVarNames).toEqual(
+          alias ? [field.envVarName, alias] : [field.envVarName],
+        );
       }
     }
+  });
+
+  it('recognizes existing Microsoft credentials as Azure DevOps OAuth configuration', () => {
+    const status = buildSetupSourceControlStatus({
+      runtimeEnv: {
+        R_MICROSOFT_CLIENT_ID: 'microsoft-client-id',
+        R_MICROSOFT_CLIENT_SECRET: 'microsoft-client-secret',
+        R_MICROSOFT_TENANT_ID: 'microsoft-tenant-id',
+      },
+    });
+    const ado = status.providers.find(
+      (provider) => provider.provider === 'ado',
+    );
+
+    expect(
+      ado?.fields.find((field) => field.envVarName === 'ADO_CLIENT_ID'),
+    ).toMatchObject({
+      runtimeSatisfied: true,
+      satisfiedByEnvVarName: 'R_MICROSOFT_CLIENT_ID',
+    });
+    expect(
+      ado?.fields.find((field) => field.envVarName === 'ADO_CLIENT_SECRET'),
+    ).toMatchObject({
+      runtimeSatisfied: true,
+      satisfiedByEnvVarName: 'R_MICROSOFT_CLIENT_SECRET',
+    });
   });
 
   it('reports setup satisfied by runtime env when the connected provider is runtime-configured', () => {

--- a/packages/types/src/setup-source-control-config.ts
+++ b/packages/types/src/setup-source-control-config.ts
@@ -123,6 +123,27 @@ const DEFAULT_SETUP_SOURCE_CONTROL_PROVIDER_DESCRIPTOR: SetupSourceControlProvid
     (descriptor) => descriptor.provider === DEFAULT_SOURCE_CONTROL_PROVIDER,
   )!;
 
+const ADO_CLOUD_REQUIRED_OAUTH_ENV_VAR_NAMES = new Set([
+  'ADO_CLIENT_ID',
+  'ADO_CLIENT_SECRET',
+]);
+
+function isAdoCloudConfiguration(fields: SetupSourceControlFieldStatus[]) {
+  const baseUrl = fields
+    .find((field) => field.envVarName === 'ADO_BASE_URL')
+    ?.savedValue?.trim();
+
+  if (!baseUrl) {
+    return true;
+  }
+
+  try {
+    return new URL(baseUrl).hostname.toLowerCase() === 'dev.azure.com';
+  } catch {
+    return false;
+  }
+}
+
 export function getSetupSourceControlProvider(
   provider: SourceControlProvider,
 ): SetupSourceControlProviderDescriptor {
@@ -281,20 +302,23 @@ function buildProviderFields(
         },
         {
           envVarName: 'ADO_CLIENT_ID',
-          acceptedEnvVarNames: ['ADO_CLIENT_ID'],
+          acceptedEnvVarNames: ['ADO_CLIENT_ID', 'R_MICROSOFT_CLIENT_ID'],
           label: 'Microsoft Entra Client ID',
           required: false,
         },
         {
           envVarName: 'ADO_CLIENT_SECRET',
-          acceptedEnvVarNames: ['ADO_CLIENT_SECRET'],
+          acceptedEnvVarNames: [
+            'ADO_CLIENT_SECRET',
+            'R_MICROSOFT_CLIENT_SECRET',
+          ],
           label: 'Microsoft Entra Client Secret',
           secret: true,
           required: false,
         },
         {
           envVarName: 'ADO_TENANT_ID',
-          acceptedEnvVarNames: ['ADO_TENANT_ID'],
+          acceptedEnvVarNames: ['ADO_TENANT_ID', 'R_MICROSOFT_TENANT_ID'],
           label: 'Microsoft Entra Tenant ID',
           required: false,
         },
@@ -393,7 +417,14 @@ export function buildSetupSourceControlStatus(input: {
       };
     });
 
-    const requiredFields = fields.filter(isRequiredField);
+    const requiresAdoCloudOAuth =
+      descriptor.provider === 'ado' && isAdoCloudConfiguration(fields);
+    const requiredFields = fields.filter(
+      (field) =>
+        isRequiredField(field) ||
+        (requiresAdoCloudOAuth &&
+          ADO_CLOUD_REQUIRED_OAUTH_ENV_VAR_NAMES.has(field.envVarName)),
+    );
     const runtimeConfigSatisfied = requiredFields.every(
       (field) => field.runtimeSatisfied,
     );


### PR DESCRIPTION
## Related issue

N/A — internal Roomote work requested by a maintainer.

## Why this PR exists

- [ ] A maintainer explicitly invited this PR in the linked issue or discussion
- [x] I am a maintainer / this is internal Roomote work

## What changed

- guide Azure DevOps setup through validated organization entry before PAT creation
- build the PAT creation link from the organization instead of using the broken organization-less URL
- require Microsoft Entra account linking for Azure DevOps Services and immediately start the link flow after saving
- show the exact Azure DevOps OAuth callback, Entra app registration link, and delegated permission guidance
- automatically reuse existing Microsoft sign-in or Teams app credentials, including the stored secret, while keeping Azure DevOps-specific values as overrides
- keep Azure DevOps Server on its PAT-only path and hide unrelated advanced settings by default
- update public Azure DevOps and environment-variable documentation

## How it was tested

- 55 focused web Vitest tests covering setup UI, save-and-link behavior, Microsoft credential reuse, auth-provider resolution, ADO helpers, and source-control persistence
- 18 focused `@roomote/types` Vitest tests covering conditional Azure DevOps Services OAuth requirements and Microsoft aliases
- `pnpm lint:fast`
- `pnpm check-types:fast`
- `pnpm knip`
- `git diff --check`

## Checklist

- [x] The PR title follows the repo convention: `[Fix]`, `[Feat]`, `[Improve]`, `[Refactor]`, `[Docs]`, or `[Chore]` followed by a user-facing description
- [x] This PR is scoped to the Azure DevOps setup and account-linking flow
- [x] Lint, type checking, and knip pass locally
- [x] I added focused tests
- [x] I removed secrets, tokens, private keys, and customer data from code, logs, and screenshots
- [x] The user-facing change has a changeset