### PR TITLE
[Fix] Preserve Azure DevOps repository identifiers in environments

### DIFF
--- a/apps/api/src/handlers/environments/__tests__/environment-write-auth.test.ts
+++ b/apps/api/src/handlers/environments/__tests__/environment-write-auth.test.ts
@@ -166,7 +166,13 @@ describe('createEnvironment attribution', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockEnvironmentsFindFirst.mockResolvedValue(null);
-    mockRepositoriesFindMany.mockResolvedValue([]);
+    mockRepositoriesFindMany.mockResolvedValue([
+      {
+        id: 'repo-1',
+        fullName: 'acme/app',
+        installationId: null,
+      },
+    ]);
   });
 
   it('attributes the write to the live acting user over the mint-time claim', async () => {
@@ -205,5 +211,76 @@ describe('createEnvironment attribution', () => {
       expect.anything(),
       expect.objectContaining({ createdByUserId: 'user-live' }),
     );
+  });
+
+  it('rejects a truncated Azure DevOps repository identifier', async () => {
+    mockRepositoriesFindMany.mockResolvedValueOnce([]);
+
+    const app = createApp({
+      userId: 'user-1',
+      tokenType: 'auth',
+      version: 1,
+    });
+    const response = await app.request(
+      new Request('http://localhost/environments', {
+        method: 'POST',
+        body: JSON.stringify({
+          config: {
+            name: 'ADO Test',
+            repositories: [{ repository: 'roomote/Test ADO' }],
+          },
+        }),
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Repositories are not linked to this deployment: roomote/Test ADO',
+    });
+    expect(mockEnvironmentInsertValues).not.toHaveBeenCalled();
+    expect(mockCreateSnapshot).not.toHaveBeenCalled();
+  });
+});
+
+describe('updateEnvironment repository validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnvironmentsFindFirst.mockResolvedValue({
+      id: 'env-1',
+      name: 'ADO Test',
+      description: null,
+      config: {
+        name: 'ADO Test',
+        repositories: [{ repository: 'roomote/Test ADO/Test ADO' }],
+      },
+      isEval: false,
+    });
+    mockRepositoriesFindMany.mockResolvedValue([]);
+  });
+
+  it('rejects an update with a truncated Azure DevOps repository identifier', async () => {
+    const app = createApp({
+      userId: 'user-1',
+      tokenType: 'auth',
+      version: 1,
+    });
+    const response = await app.request(
+      new Request('http://localhost/environments/env-1', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          config: {
+            name: 'ADO Test',
+            repositories: [{ repository: 'roomote/Test ADO' }],
+          },
+        }),
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Repositories are not linked to this deployment: roomote/Test ADO',
+    });
   });
 });

--- a/apps/api/src/handlers/environments/createEnvironment.ts
+++ b/apps/api/src/handlers/environments/createEnvironment.ts
@@ -14,6 +14,7 @@ import {
 import {
   type TaskPayload,
   environmentConfigSchema,
+  getMissingEnvironmentRepositoryError,
   getEnvironmentRepositoryInstallationError,
 } from '@roomote/types';
 
@@ -68,24 +69,6 @@ export function getEnvironmentRepositoryConfigError(
   }>,
 ): string | null {
   return getEnvironmentRepositoryInstallationError(repositoryRows);
-}
-
-export function getMissingEnvironmentRepositoryError(
-  repositoryNames: string[],
-  repositoryRows: Array<{ fullName: string }>,
-): string | null {
-  const linkedRepositoryNames = new Set(
-    repositoryRows.map((repository) => repository.fullName),
-  );
-  const missingRepositories = repositoryNames.filter(
-    (name) => !linkedRepositoryNames.has(name),
-  );
-
-  if (missingRepositories.length === 0) {
-    return null;
-  }
-
-  return `Repositories are not linked to this deployment: ${missingRepositories.join(', ')}`;
 }
 
 function extractRunId(auth: McpAuth): number | null {
@@ -330,7 +313,6 @@ export async function createEnvironment(
       success: true,
       environmentId: created.id,
       name: config.name,
-      missingRepositories: [],
     });
   } catch (error) {
     if (isEnvironmentNameUniqueViolation(error)) {

--- a/apps/api/src/handlers/environments/createEnvironment.ts
+++ b/apps/api/src/handlers/environments/createEnvironment.ts
@@ -70,6 +70,24 @@ export function getEnvironmentRepositoryConfigError(
   return getEnvironmentRepositoryInstallationError(repositoryRows);
 }
 
+export function getMissingEnvironmentRepositoryError(
+  repositoryNames: string[],
+  repositoryRows: Array<{ fullName: string }>,
+): string | null {
+  const linkedRepositoryNames = new Set(
+    repositoryRows.map((repository) => repository.fullName),
+  );
+  const missingRepositories = repositoryNames.filter(
+    (name) => !linkedRepositoryNames.has(name),
+  );
+
+  if (missingRepositories.length === 0) {
+    return null;
+  }
+
+  return `Repositories are not linked to this deployment: ${missingRepositories.join(', ')}`;
+}
+
 function extractRunId(auth: McpAuth): number | null {
   return 'runId' in auth.authContext ? auth.authContext.runId : null;
 }
@@ -256,9 +274,14 @@ export async function createEnvironment(
     }
 
     const repoMap = new Map(orgRepos.map((repo) => [repo.fullName, repo.id]));
-    const missingRepositories = repositoryNames.filter(
-      (name) => !repoMap.has(name),
+    const missingRepositoryError = getMissingEnvironmentRepositoryError(
+      repositoryNames,
+      orgRepos,
     );
+
+    if (missingRepositoryError) {
+      return c.json({ error: missingRepositoryError }, 400);
+    }
 
     const created = await db.transaction(async (tx) => {
       const inserted = await tx
@@ -307,7 +330,7 @@ export async function createEnvironment(
       success: true,
       environmentId: created.id,
       name: config.name,
-      missingRepositories,
+      missingRepositories: [],
     });
   } catch (error) {
     if (isEnvironmentNameUniqueViolation(error)) {

--- a/apps/api/src/handlers/environments/updateEnvironment.ts
+++ b/apps/api/src/handlers/environments/updateEnvironment.ts
@@ -19,6 +19,7 @@ import {
   EVAL_ENVIRONMENT_WRITE_ERROR,
   attachEnvironmentIdToTaskRun,
   getEnvironmentRepositoryConfigError,
+  getMissingEnvironmentRepositoryError,
   isEnvironmentNameUniqueViolation,
   resolveEnvironmentWriteUserId,
 } from './createEnvironment';
@@ -139,9 +140,15 @@ export async function updateEnvironment(
     }
 
     const repoMap = new Map(orgRepos.map((repo) => [repo.fullName, repo.id]));
-    const missingRepositories = repositoryNames.filter(
-      (name) => !repoMap.has(name),
+    const missingRepositoryError = getMissingEnvironmentRepositoryError(
+      repositoryNames,
+      orgRepos,
     );
+
+    if (missingRepositoryError) {
+      return c.json({ error: missingRepositoryError }, 400);
+    }
+
     const repositoryIds = repositoryNames
       .map((name) => repoMap.get(name))
       .filter((repositoryId): repositoryId is string => Boolean(repositoryId));
@@ -174,7 +181,7 @@ export async function updateEnvironment(
       success: true,
       environmentId: id,
       name: config.name,
-      missingRepositories,
+      missingRepositories: [],
     });
   } catch (error) {
     if (isEnvironmentNameUniqueViolation(error)) {

--- a/apps/api/src/handlers/environments/updateEnvironment.ts
+++ b/apps/api/src/handlers/environments/updateEnvironment.ts
@@ -9,7 +9,10 @@ import {
   repositories,
   updateEnvironmentDefinition,
 } from '@roomote/db/server';
-import { environmentConfigSchema } from '@roomote/types';
+import {
+  environmentConfigSchema,
+  getMissingEnvironmentRepositoryError,
+} from '@roomote/types';
 
 import type { Variables } from '../../types';
 import type { McpAuth } from '../mcp/middleware';
@@ -19,7 +22,6 @@ import {
   EVAL_ENVIRONMENT_WRITE_ERROR,
   attachEnvironmentIdToTaskRun,
   getEnvironmentRepositoryConfigError,
-  getMissingEnvironmentRepositoryError,
   isEnvironmentNameUniqueViolation,
   resolveEnvironmentWriteUserId,
 } from './createEnvironment';
@@ -181,7 +183,6 @@ export async function updateEnvironment(
       success: true,
       environmentId: id,
       name: config.name,
-      missingRepositories: [],
     });
   } catch (error) {
     if (isEnvironmentNameUniqueViolation(error)) {

--- a/apps/web/src/trpc/commands/environments/index.test.ts
+++ b/apps/web/src/trpc/commands/environments/index.test.ts
@@ -1,21 +1,24 @@
-const { mockEnqueueTask, mockGetRepositories } = vi.hoisted(() => ({
-  mockEnqueueTask: vi.fn().mockResolvedValue({
-    taskId: 'task-env-definition-1',
-    id: 'run-env-definition-1',
+const { mockDbSelect, mockEnqueueTask, mockGetRepositories } = vi.hoisted(
+  () => ({
+    mockDbSelect: vi.fn(),
+    mockEnqueueTask: vi.fn().mockResolvedValue({
+      taskId: 'task-env-definition-1',
+      id: 'run-env-definition-1',
+    }),
+    mockGetRepositories: vi.fn().mockResolvedValue([
+      {
+        id: 'repo-1',
+        fullName: 'acme/api',
+        installationId: 'installation-1',
+      },
+      {
+        id: 'repo-2',
+        fullName: 'acme/web',
+        installationId: 'installation-1',
+      },
+    ]),
   }),
-  mockGetRepositories: vi.fn().mockResolvedValue([
-    {
-      id: 'repo-1',
-      fullName: 'acme/api',
-      installationId: 'installation-1',
-    },
-    {
-      id: 'repo-2',
-      fullName: 'acme/web',
-      installationId: 'installation-1',
-    },
-  ]),
-}));
+);
 
 vi.mock('@roomote/cloud-agents/server', () => ({
   enqueueTask: mockEnqueueTask,
@@ -26,7 +29,9 @@ vi.mock('@roomote/db/server', () => ({
   and: vi.fn(),
   cancelTaskRunDirect: vi.fn(),
   createEnvironmentConfigVersionSnapshot: vi.fn(),
-  db: {},
+  db: {
+    select: mockDbSelect,
+  },
   desc: vi.fn(),
   environmentConfigVersions: {},
   environmentRepositoryMappings: {},
@@ -51,7 +56,11 @@ vi.mock('@/lib/server', () => ({
 
 import { TaskPayloadKind } from '@roomote/types';
 import type { UserAuthSuccess } from '@/types';
-import { startEnvironmentDefinitionTaskCommand } from './index';
+import {
+  createEnvironmentCommand,
+  startEnvironmentDefinitionTaskCommand,
+  updateEnvironmentCommand,
+} from './index';
 
 function buildMockAuth(): UserAuthSuccess {
   return {
@@ -113,5 +122,71 @@ describe('startEnvironmentDefinitionTaskCommand', () => {
         trigger: 'manual',
       }),
     );
+  });
+});
+
+describe('environment repository validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects create when a configured repository is not linked', async () => {
+    mockDbSelect
+      .mockReturnValueOnce({
+        from: () => ({ where: () => ({ limit: async () => [] }) }),
+      })
+      .mockReturnValueOnce({
+        from: () => ({ where: async () => [] }),
+      });
+
+    const result = await createEnvironmentCommand(buildMockAuth(), {
+      name: 'ADO Test',
+      config: {
+        name: 'ADO Test',
+        repositories: [{ repository: 'roomote/Test ADO' }],
+      },
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Repositories are not linked to this deployment: roomote/Test ADO',
+    });
+  });
+
+  it('rejects update when a configured repository is not linked', async () => {
+    mockDbSelect
+      .mockReturnValueOnce({
+        from: () => ({
+          where: () => ({
+            limit: async () => [
+              {
+                id: 'env-1',
+                name: 'ADO Test',
+                description: null,
+                config: {
+                  name: 'ADO Test',
+                  repositories: [{ repository: 'roomote/Test ADO/Test ADO' }],
+                },
+              },
+            ],
+          }),
+        }),
+      })
+      .mockReturnValueOnce({
+        from: () => ({ where: async () => [] }),
+      });
+
+    const result = await updateEnvironmentCommand(buildMockAuth(), {
+      id: 'env-1',
+      config: {
+        name: 'ADO Test',
+        repositories: [{ repository: 'roomote/Test ADO' }],
+      },
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Repositories are not linked to this deployment: roomote/Test ADO',
+    });
   });
 });

--- a/apps/web/src/trpc/commands/environments/index.ts
+++ b/apps/web/src/trpc/commands/environments/index.ts
@@ -32,6 +32,7 @@ import {
   type EnvironmentConfig,
   environmentConfigSchema,
   getEnvironmentRepositoryInstallationError,
+  getMissingEnvironmentRepositoryError,
   isExitedRunStatus,
   normalizeRepositorySelection,
 } from '@roomote/types';
@@ -372,14 +373,22 @@ export async function createEnvironmentCommand(
   }
 
   const configRepos = parseResult.data.repositories ?? [];
-  const repositoryRows = await getEnvironmentRepositoryRows(
-    getConfiguredRepositoryNames(parseResult.data),
-  );
+  const repositoryNames = getConfiguredRepositoryNames(parseResult.data);
+  const repositoryRows = await getEnvironmentRepositoryRows(repositoryNames);
   const repositoryConfigError =
     getEnvironmentRepositoryConfigError(repositoryRows);
 
   if (repositoryConfigError) {
     return { success: false, error: repositoryConfigError };
+  }
+
+  const missingRepositoryError = getMissingEnvironmentRepositoryError(
+    repositoryNames,
+    repositoryRows,
+  );
+
+  if (missingRepositoryError) {
+    return { success: false, error: missingRepositoryError };
   }
 
   const repoMap = new Map(repositoryRows.map((r) => [r.fullName, r.id]));
@@ -504,16 +513,25 @@ export async function updateEnvironmentCommand(
   }
 
   const configRepos = nextConfig?.repositories ?? [];
+  const repositoryNames =
+    input.config && nextConfig ? getConfiguredRepositoryNames(nextConfig) : [];
   const repositoryRows = input.config
-    ? await getEnvironmentRepositoryRows(
-        nextConfig ? getConfiguredRepositoryNames(nextConfig) : [],
-      )
+    ? await getEnvironmentRepositoryRows(repositoryNames)
     : [];
   const repositoryConfigError =
     getEnvironmentRepositoryConfigError(repositoryRows);
 
   if (repositoryConfigError) {
     return { success: false, error: repositoryConfigError };
+  }
+
+  const missingRepositoryError = getMissingEnvironmentRepositoryError(
+    repositoryNames,
+    repositoryRows,
+  );
+
+  if (missingRepositoryError) {
+    return { success: false, error: missingRepositoryError };
   }
 
   const repoMap = new Map(repositoryRows.map((r) => [r.fullName, r.id]));

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/create-environment.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/create-environment.test.ts
@@ -24,7 +24,6 @@ describe('handleCreateEnvironment', () => {
       success: true,
       environmentId: 'env-new',
       name: 'My Project',
-      missingRepositories: [],
     });
 
     const result = await handleCreateEnvironment(
@@ -45,15 +44,16 @@ repositories:
     expect(parsed.success).toBe(true);
     expect(parsed.environmentId).toBe('env-new');
     expect(parsed.name).toBe('My Project');
-    expect(parsed.missingRepositories).toEqual([]);
+    expect(parsed.message).toBe(
+      'Environment "My Project" created successfully.',
+    );
   });
 
-  it('applies name override and surfaces missing repository warnings', async () => {
+  it('applies a name override', async () => {
     vi.mocked(tasksApiClient.createEnvironment).mockResolvedValueOnce({
       success: true,
       environmentId: 'env-2',
       name: 'Renamed Project',
-      missingRepositories: ['owner/missing-repo'],
     });
 
     const result = await handleCreateEnvironment(
@@ -72,7 +72,9 @@ repositories:
 
     expect(parsed.success).toBe(true);
     expect(parsed.name).toBe('Renamed Project');
-    expect(parsed.missingRepositories).toEqual(['owner/missing-repo']);
+    expect(parsed.message).toBe(
+      'Environment "Renamed Project" created successfully.',
+    );
 
     expect(tasksApiClient.createEnvironment).toHaveBeenCalledWith(config, {
       config: expect.objectContaining({ name: 'Renamed Project' }),
@@ -132,7 +134,6 @@ describe('handleUpdateEnvironment', () => {
       success: true,
       environmentId: 'env-existing',
       name: 'My Project',
-      missingRepositories: [],
     });
 
     const result = await handleUpdateEnvironment(

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/tasks-api-client.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/tasks-api-client.test.ts
@@ -628,7 +628,6 @@ describe('createEnvironment', () => {
       success: true,
       environmentId: 'env-123',
       name: 'My Project',
-      missingRepositories: [],
     };
 
     global.fetch = vi.fn().mockResolvedValueOnce({
@@ -646,7 +645,6 @@ describe('createEnvironment', () => {
     expect(result.success).toBe(true);
     expect(result.environmentId).toBe('env-123');
     expect(result.name).toBe('My Project');
-    expect(result.missingRepositories).toEqual([]);
 
     const fetchCall = vi.mocked(fetch).mock.calls[0];
     expect(fetchCall?.[0]).toBe(
@@ -691,7 +689,6 @@ describe('updateEnvironment', () => {
       success: true,
       environmentId: 'env-123',
       name: 'Updated Project',
-      missingRepositories: [],
     };
 
     global.fetch = vi.fn().mockResolvedValueOnce({

--- a/apps/worker/src/mcp/roomote-mcp-server/create-environment.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/create-environment.ts
@@ -137,17 +137,10 @@ export async function handleCreateEnvironment(
       config: finalParse.data,
     });
 
-    const missingCount = result.missingRepositories.length;
-    const message =
-      missingCount > 0
-        ? `Environment "${result.name}" created. ${missingCount} repository mapping(s) were skipped because they are not linked to this deployment.`
-        : `Environment "${result.name}" created successfully.`;
-
     return successResult({
       environmentId: result.environmentId,
       name: result.name,
-      missingRepositories: result.missingRepositories,
-      message,
+      message: `Environment "${result.name}" created successfully.`,
     });
   } catch (error) {
     return catchError(error);
@@ -203,17 +196,10 @@ export async function handleUpdateEnvironment(
       config: finalParse.data,
     });
 
-    const missingCount = result.missingRepositories.length;
-    const message =
-      missingCount > 0
-        ? `Environment "${result.name}" updated. ${missingCount} repository mapping(s) were skipped because they are not linked to this deployment.`
-        : `Environment "${result.name}" updated successfully.`;
-
     return successResult({
       environmentId: result.environmentId,
       name: result.name,
-      missingRepositories: result.missingRepositories,
-      message,
+      message: `Environment "${result.name}" updated successfully.`,
     });
   } catch (error) {
     return catchError(error);

--- a/apps/worker/src/mcp/roomote-mcp-server/types.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/types.ts
@@ -100,14 +100,12 @@ export interface CreateEnvironmentResponse {
   success: boolean;
   environmentId: string;
   name: string;
-  missingRepositories: string[];
 }
 
 export interface UpdateEnvironmentResponse {
   success: boolean;
   environmentId: string;
   name: string;
-  missingRepositories: string[];
 }
 
 export interface SlackThreadReplyResponse {

--- a/packages/cloud-agents/src/server/workflows/__tests__/environmentSetupSkill.test.ts
+++ b/packages/cloud-agents/src/server/workflows/__tests__/environmentSetupSkill.test.ts
@@ -53,6 +53,23 @@ describe('environment-setup guidance', () => {
     );
   });
 
+  it('preserves exact repository identifiers including Azure DevOps segments', () => {
+    const skillContent = readSkillContent();
+
+    expect(skillContent).toContain(
+      'Use each provided repository identifier exactly as supplied by the task.',
+    );
+    expect(skillContent).toContain(
+      'Azure DevOps uses `organization/project/repository`.',
+    );
+    expect(skillContent).toContain(
+      'Copy each task-provided repository identifier verbatim into its matching `repositories[].repository` field.',
+    );
+    expect(skillContent).not.toContain(
+      'Use the provided repository identifier in `owner/repo` format',
+    );
+  });
+
   it('tells the agent how to discover and start supported worker services', () => {
     const skillContent = readSkillContent();
 

--- a/packages/cloud-agents/src/server/workflows/skills/standard/environment-setup/SKILL.md
+++ b/packages/cloud-agents/src/server/workflows/skills/standard/environment-setup/SKILL.md
@@ -21,11 +21,11 @@ You are an expert Roomote environment analyst. Analyze the already-checked-out r
         <title>Confirm target repository context</title>
         <description>Anchor analysis to explicit repository facts provided by the task.</description>
         <actions>
-          <action>Use the provided repository identifier in `owner/repo` format and default branch when available.</action>
+          <action>Use each provided repository identifier exactly as supplied by the task. Do not shorten, reconstruct, or infer it from the checkout directory. Repository identifiers may have more than two slash-separated segments; Azure DevOps uses `organization/project/repository`.</action>
           <action>If default branch is unknown, infer it from repository metadata; otherwise use the provided value.</action>
           <action>Treat the repositories named in the task or environment as already checked out and available in the current workspace; inspect and validate those existing checkouts instead of re-cloning them.</action>
           <action>Treat repository context as:
-- Repository: `<owner/repo>`
+- Repository: `<exact-provided-repository-identifier>`
 - Default branch: `<default-branch>`</action>
         </actions>
         <validation>The repository target and branch baseline are explicit before config drafting starts.</validation>
@@ -69,6 +69,7 @@ You are an expert Roomote environment analyst. Analyze the already-checked-out r
         <description>Create the smallest valid Roomote environment YAML from static evidence.</description>
         <actions>
           <action>Produce exactly one initial YAML config.</action>
+          <action>Copy each task-provided repository identifier verbatim into its matching `repositories[].repository` field. In particular, preserve all three `organization/project/repository` segments for Azure DevOps repositories.</action>
           <action>Use repository default branch unless strong evidence indicates a different branch.</action>
           <action>Assume the repositories listed in the environment already exist in the workspace; do not add repository clone commands or other duplicate checkout steps.</action>
           <action>Include only commands strongly supported by the repository.</action>
@@ -222,7 +223,7 @@ You are an expert Roomote environment analyst. Analyze the already-checked-out r
 </named_port_config>
 
 <repository_config>
-<field name="repository" required="true" type="owner/repo" />
+<field name="repository" required="true" type="exact task-provided slash-separated repository identifier (for example owner/repo or Azure DevOps organization/project/repository)" />
 <field name="branch" required="false" type="string" />
 <field name="tool_versions" required="false" type="Record<string, string>" />
 <field name="commands" required="false" type="Command[]" />
@@ -258,6 +259,7 @@ You are an expert Roomote environment analyst. Analyze the already-checked-out r
 <rule>Check each target repo's developer local-setup documentation before inferring sandbox setup commands from manifests, scripts, or CI.</rule>
 <rule>When repo-local setup docs and lower-level evidence disagree, prefer the documented local developer workflow unless direct runtime validation proves the docs are stale or incomplete.</rule>
 <rule>Treat repositories referenced by the task or environment as already checked out in the current workspace unless the user explicitly says otherwise.</rule>
+<rule>Preserve every task-provided repository identifier exactly in `repositories[].repository`; never shorten or reconstruct it from a checkout path. Azure DevOps identifiers must retain `organization/project/repository`.</rule>
 <rule>Never include the full environment YAML in your visible response or Slack reply. The environment is already persisted through manage_environments; re-dumping the config into the transcript is redundant and risks exposing secret values that were kept out of the conversation through request_environment_variables.</rule>
 <rule>Use repository default branch unless strong evidence supports another branch.</rule>
 <rule>Include only commands strongly supported by repository evidence.</rule>

--- a/packages/db/src/lib/__tests__/declarative-environments.test.ts
+++ b/packages/db/src/lib/__tests__/declarative-environments.test.ts
@@ -108,6 +108,7 @@ describe('declarative environments', () => {
     definitionsDir = await mkdtemp(
       path.join(tmpdir(), 'roomote-declarative-envs-'),
     );
+    await createLinkedRepository();
   });
 
   afterEach(async () => {
@@ -117,7 +118,6 @@ describe('declarative environments', () => {
 
   it('creates an environment from a directory file', async () => {
     const name = environmentName('create');
-    const repository = await createLinkedRepository();
 
     await writeFile(
       path.join(definitionsDir, 'create.yaml'),
@@ -130,7 +130,6 @@ describe('declarative environments', () => {
 
     expect(summary.created).toEqual([name]);
     expect(summary.skipped).toEqual([]);
-    expect(summary.missingRepositories).toEqual([]);
 
     const environment = await db.query.environments.findFirst({
       where: eq(environments.name, name),
@@ -154,9 +153,7 @@ describe('declarative environments', () => {
       where: eq(environmentRepositoryMappings.environmentId, environment!.id),
     });
 
-    expect(mappings.map((mapping) => mapping.repositoryId)).toEqual([
-      repository.id,
-    ]);
+    expect(mappings).toHaveLength(1);
   });
 
   it('applies inline multi-document YAML and dedupes by name against directory files', async () => {
@@ -231,9 +228,6 @@ describe('declarative environments', () => {
     const environment = await db.query.environments.findFirst({
       where: eq(environments.name, name),
     });
-
-    testUserId = randomUUID();
-    await userFactory.create({ id: testUserId });
 
     const editedConfig = environmentConfigSchema.parse({
       name,
@@ -374,9 +368,6 @@ describe('declarative environments', () => {
   });
 
   it('never touches user-owned or eval environments with the same name', async () => {
-    testUserId = randomUUID();
-    await userFactory.create({ id: testUserId });
-
     const userOwnedName = environmentName('user-owned');
     const evalName = environmentName('eval');
 
@@ -428,32 +419,46 @@ describe('declarative environments', () => {
     expect(userOwned?.declarativeSource).toBeNull();
   });
 
-  it('backfills repository mappings once a configured repository is linked', async () => {
+  it('skips definitions until every configured repository is linked', async () => {
     const name = environmentName('backfill');
+    await db
+      .delete(repositories)
+      .where(eq(repositories.fullName, 'declarative-test/example'));
     await writeFile(
       path.join(definitionsDir, 'backfill.yaml'),
       definitionYaml(name),
     );
 
     const first = await applyDeclarativeEnvironments({ dir: definitionsDir });
-    expect(first.missingRepositories).toEqual(['declarative-test/example']);
+    expect(first.created).toEqual([]);
+    expect(first.skipped).toEqual([
+      {
+        source: 'backfill.yaml',
+        reason:
+          'Repositories are not linked to this deployment: declarative-test/example',
+      },
+    ]);
+
+    const missingEnvironment = await db.query.environments.findFirst({
+      where: eq(environments.name, name),
+    });
+    expect(missingEnvironment).toBeUndefined();
+
+    const repository = await repositoryFactory.create({
+      fullName: 'declarative-test/example',
+      installationId: testInstallationId!,
+      linkedByUserId: testUserId,
+    });
+
+    const second = await applyDeclarativeEnvironments({ dir: definitionsDir });
+    expect(second.created).toEqual([name]);
+    expect(second.skipped).toEqual([]);
 
     const environment = await db.query.environments.findFirst({
       where: eq(environments.name, name),
     });
 
-    let mappings = await db.query.environmentRepositoryMappings.findMany({
-      where: eq(environmentRepositoryMappings.environmentId, environment!.id),
-    });
-    expect(mappings).toHaveLength(0);
-
-    const repository = await createLinkedRepository();
-
-    const second = await applyDeclarativeEnvironments({ dir: definitionsDir });
-    expect(second.updated).toEqual([name]);
-    expect(second.missingRepositories).toEqual([]);
-
-    mappings = await db.query.environmentRepositoryMappings.findMany({
+    const mappings = await db.query.environmentRepositoryMappings.findMany({
       where: eq(environmentRepositoryMappings.environmentId, environment!.id),
     });
     expect(mappings.map((mapping) => mapping.repositoryId)).toEqual([
@@ -478,7 +483,6 @@ describe('declarative environments', () => {
         skipped: [],
         orphaned: [],
         orphaningDeferred: false,
-        missingRepositories: [],
       };
 
       const apply = vi

--- a/packages/db/src/lib/declarative-environments.ts
+++ b/packages/db/src/lib/declarative-environments.ts
@@ -5,6 +5,7 @@ import type { EnvironmentConfig } from '@roomote/types';
 import {
   environmentConfigSchema,
   getEnvironmentRepositoryInstallationError,
+  getMissingEnvironmentRepositoryError,
 } from '@roomote/types';
 import { and, eq, inArray, isNotNull, notInArray } from 'drizzle-orm';
 import YAML from 'yaml';
@@ -124,8 +125,6 @@ export type DeclarativeEnvironmentsSummary = {
    * unknown. Existing declarative markers are left untouched in that case.
    */
   orphaningDeferred: boolean;
-  /** Configured repository names that are not linked to the deployment yet. */
-  missingRepositories: string[];
 };
 
 type ParsedDefinitions = {
@@ -376,7 +375,6 @@ async function resolveConfiguredRepositories(config: EnvironmentConfig) {
     repositoryIds: repositoryNames
       .map((name) => repoMap.get(name)?.id)
       .filter((id): id is string => Boolean(id)),
-    missingRepositories: repositoryNames.filter((name) => !repoMap.has(name)),
   };
 }
 
@@ -465,13 +463,10 @@ async function updateDeclarativeEnvironment(
 
 async function applyDefinition(
   definition: DeclarativeEnvironmentDefinition,
-): Promise<
-  | { outcome: ApplyOutcome; missingRepositories: string[] }
-  | { skip: DeclarativeEnvironmentSkip }
-> {
+): Promise<{ outcome: ApplyOutcome } | { skip: DeclarativeEnvironmentSkip }> {
   const { config, source } = definition;
 
-  const { repositoryRows, repositoryIds, missingRepositories } =
+  const { repositoryRows, repositoryIds } =
     await resolveConfiguredRepositories(config);
 
   const repositoryConfigError =
@@ -479,6 +474,15 @@ async function applyDefinition(
 
   if (repositoryConfigError) {
     return { skip: { source, reason: repositoryConfigError } };
+  }
+
+  const missingRepositoryError = getMissingEnvironmentRepositoryError(
+    config.repositories.map((repository) => repository.repository),
+    repositoryRows,
+  );
+
+  if (missingRepositoryError) {
+    return { skip: { source, reason: missingRepositoryError } };
   }
 
   const findExisting = () =>
@@ -497,7 +501,7 @@ async function applyDefinition(
   if (!existing) {
     try {
       await createDeclarativeEnvironment(definition, repositoryIds);
-      return { outcome: 'created', missingRepositories };
+      return { outcome: 'created' };
     } catch (error) {
       if (!isEnvironmentNameUniqueViolation(error)) {
         throw error;
@@ -533,7 +537,7 @@ async function applyDefinition(
     repositoryIds,
   );
 
-  return { outcome, missingRepositories };
+  return { outcome };
 }
 
 /**
@@ -577,7 +581,6 @@ export async function applyDeclarativeEnvironments(options: {
     skipped: [],
     orphaned: [],
     orphaningDeferred: false,
-    missingRepositories: [],
   };
 
   const { definitions, skipped, hasUnresolvedNames } =
@@ -589,8 +592,6 @@ export async function applyDeclarativeEnvironments(options: {
   // orphaned back to manual management.
   const declaredNames = definitions.map((definition) => definition.config.name);
 
-  const missingRepositories = new Set<string>();
-
   for (const definition of definitions) {
     try {
       const result = await applyDefinition(definition);
@@ -601,10 +602,6 @@ export async function applyDeclarativeEnvironments(options: {
       }
 
       summary[result.outcome].push(definition.config.name);
-
-      for (const missing of result.missingRepositories) {
-        missingRepositories.add(missing);
-      }
     } catch (error) {
       if (isMissingRelationError(error)) {
         throw error;
@@ -616,8 +613,6 @@ export async function applyDeclarativeEnvironments(options: {
       });
     }
   }
-
-  summary.missingRepositories = [...missingRepositories];
 
   if (hasUnresolvedNames) {
     // Part of the declared set could not be read or validated, so the names
@@ -717,14 +712,6 @@ export async function bootstrapDeclarativeEnvironments(
       '[declarative-environments] Deferred orphan reconciliation: part of ' +
         'the declared set could not be read or validated, so existing ' +
         'declarative markers were left untouched.',
-    );
-  }
-
-  if (summary.missingRepositories.length > 0) {
-    log(
-      '[declarative-environments] Configured repositories not linked to ' +
-        'this deployment yet (mappings will backfill once linked): ' +
-        summary.missingRepositories.join(', '),
     );
   }
 

--- a/packages/types/src/__tests__/command-schema.test.ts
+++ b/packages/types/src/__tests__/command-schema.test.ts
@@ -6,7 +6,28 @@ import {
   commandSchema,
   environmentConfigSchema,
   environmentRepositoryConfigSchema,
+  getMissingEnvironmentRepositoryError,
 } from '../environment-config';
+
+describe('getMissingEnvironmentRepositoryError', () => {
+  it('reports configured repositories that do not exactly match linked rows', () => {
+    expect(
+      getMissingEnvironmentRepositoryError(
+        ['roomote/Test ADO', 'roomote/Test ADO/Test ADO'],
+        [{ fullName: 'roomote/Test ADO/Test ADO' }],
+      ),
+    ).toBe('Repositories are not linked to this deployment: roomote/Test ADO');
+  });
+
+  it('returns null when every configured repository is linked', () => {
+    expect(
+      getMissingEnvironmentRepositoryError(
+        ['roomote/Test ADO/Test ADO'],
+        [{ fullName: 'roomote/Test ADO/Test ADO' }],
+      ),
+    ).toBeNull();
+  });
+});
 
 describe('commandSchema', () => {
   describe('YAML block scalar support', () => {

--- a/packages/types/src/environment-config.ts
+++ b/packages/types/src/environment-config.ts
@@ -819,6 +819,24 @@ export function getEnvironmentRepositoryInstallationError(
   return MULTI_INSTALLATION_ENVIRONMENT_REPOSITORIES_ERROR;
 }
 
+export function getMissingEnvironmentRepositoryError(
+  repositoryNames: string[],
+  repositoryRows: Array<{ fullName: string }>,
+): string | null {
+  const linkedRepositoryNames = new Set(
+    repositoryRows.map((repository) => repository.fullName),
+  );
+  const missingRepositories = repositoryNames.filter(
+    (name) => !linkedRepositoryNames.has(name),
+  );
+
+  if (missingRepositories.length === 0) {
+    return null;
+  }
+
+  return `Repositories are not linked to this deployment: ${missingRepositories.join(', ')}`;
+}
+
 export function getPrimaryPortFromConfig(
   ports: NamedPort[] | undefined,
 ): NamedPort | undefined {


### PR DESCRIPTION
## Related issue

N/A — internal bug found while testing Azure DevOps environment setup.

## Why this PR exists

- [x] I am a maintainer / this is internal Roomote work

Azure DevOps repositories use organization/project/repository identifiers. Environment setup could shorten that to organization/project, and the environment write API persisted the invalid configuration while reporting the missing mapping only as a warning.

## What changed

- Require the environment-setup workflow to copy task-provided repository identifiers verbatim, including all Azure DevOps segments.
- Reject environment creates and updates when any configured repository does not match an active linked repository.
- Add regressions for truncated Azure DevOps identifiers on both create and update paths.

## How it was tested

- Focused cloud-agents environment setup test: 10 passed
- Focused API environment write test: 13 passed
- Package-scoped ESLint and TypeScript checks for cloud-agents and API
- Full pre-push gate: lint:fast, check-types:fast, and knip
- git diff --check

## Checklist

- [x] The PR title follows the repo convention
- [x] This PR is small and scoped to one change
- [x] Relevant lint and type checks pass locally
- [x] I added tests or included a clear manual validation note above
- [x] I removed secrets, tokens, private keys, and customer data from code, logs, and screenshots
- [ ] If this change should appear in the changelog, I ran pnpm changeset