### PR TITLE
Add shared communication provider factories

### DIFF
--- a/apps/api/src/handlers/mcp/__tests__/communication-thread-replies.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/communication-thread-replies.test.ts
@@ -54,6 +54,13 @@ vi.mock('@roomote/communication/thread-reply-footer-state', () => ({
 
 vi.mock('@roomote/sdk/server', () => ({
   createTeamsCommunicationProviderFromRuntimeCredentials: vi.fn(),
+  createTelegramCommunicationProviderFromRuntimeCredentials: vi.fn(async () => {
+    const { botToken } = await resolveTelegramRuntimeCredentialsMock();
+
+    return botToken
+      ? { postMessage: postMessageMock, sendChatAction: sendChatActionMock }
+      : null;
+  }),
 }));
 
 vi.mock('@roomote/slack', () => ({

--- a/apps/api/src/handlers/mcp/__tests__/slack-reaction-add.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/slack-reaction-add.test.ts
@@ -88,6 +88,9 @@ vi.mock('@roomote/sdk/server', () => ({
   buildSignedArtifactRawUrl: vi.fn(),
   createTeamsCommunicationProviderFromRuntimeCredentials:
     createTeamsCommunicationProviderMock,
+  createTelegramCommunicationProviderFromRuntimeCredentials: vi.fn(
+    async () => ({ addReaction: telegramAddReactionMock }),
+  ),
   currentEpochSeconds: vi.fn(),
   findSlackConversationSubjectByUserId: vi.fn(),
   recordSlackConversationMessageBestEffort: vi.fn(),

--- a/apps/api/src/handlers/mcp/communication-thread-replies.ts
+++ b/apps/api/src/handlers/mcp/communication-thread-replies.ts
@@ -1,10 +1,8 @@
 import {
-  TeamsCommunicationProvider,
-  TelegramCommunicationProvider,
   UnsupportedCommunicationOperationError,
   getLatestInboundMessageId,
+  type TelegramCommunicationProvider,
 } from '@roomote/communication';
-import { resolveTelegramRuntimeCredentials } from '@roomote/db/server';
 import {
   getCommunicationChannelFromTaskPayload,
   getCommunicationMessageIdFromTaskPayload,
@@ -12,7 +10,10 @@ import {
   getCommunicationServiceUrlFromTaskPayload,
   getCommunicationThreadIdFromTaskPayload,
 } from '@roomote/types';
-import { createTeamsCommunicationProviderFromRuntimeCredentials } from '@roomote/sdk/server';
+import {
+  createTeamsCommunicationProviderFromRuntimeCredentials as createTeamsCommunicationProvider,
+  createTelegramCommunicationProviderFromRuntimeCredentials as createTelegramCommunicationProvider,
+} from '@roomote/sdk/server';
 
 import { THREAD_REPLY_FOOTER_LOCK_TIMEOUT_MESSAGE } from './chat-reply-helpers';
 import {
@@ -60,20 +61,6 @@ function startTelegramTypingHeartbeat(
   timer.unref?.();
 
   return () => clearInterval(timer);
-}
-
-async function createTeamsCommunicationProvider(): Promise<TeamsCommunicationProvider | null> {
-  return createTeamsCommunicationProviderFromRuntimeCredentials();
-}
-
-async function createTelegramCommunicationProvider(): Promise<TelegramCommunicationProvider | null> {
-  const { botToken } = await resolveTelegramRuntimeCredentials();
-
-  if (!botToken) {
-    return null;
-  }
-
-  return new TelegramCommunicationProvider({ botToken });
 }
 
 async function sendTeamsThreadReply(params: {

--- a/apps/api/src/handlers/tasks/__tests__/submitAutomationWorkItems.test.ts
+++ b/apps/api/src/handlers/tasks/__tests__/submitAutomationWorkItems.test.ts
@@ -31,6 +31,11 @@ vi.mock('../automation-work-items/teams.js', () => ({
   postLateBoundWorkItemFailureToTeams: vi.fn(async () => undefined),
 }));
 
+vi.mock('../automation-work-items/telegram.js', () => ({
+  resolveAutomationTelegramTarget: vi.fn(async () => null),
+  postLateBoundWorkItemFailureToTelegram: vi.fn(async () => undefined),
+}));
+
 vi.mock('@roomote/db/server', () => ({
   and: vi.fn((...args) => ({ type: 'and', args })),
   asc: vi.fn(),

--- a/apps/api/src/handlers/teams/__tests__/index.test.ts
+++ b/apps/api/src/handlers/teams/__tests__/index.test.ts
@@ -232,11 +232,16 @@ vi.mock('@roomote/communication/teams-provider', () => ({
 }));
 
 vi.mock('@roomote/sdk/server', () => ({
-  createTeamsCommunicationProviderFromRuntimeCredentials: vi.fn(async () => ({
-    postDirectMessage: postDirectMessageMock,
-    postMessage: postMessageMock,
-    processImageAttachments: processImageAttachmentsMock,
-  })),
+  createTeamsCommunicationProviderFromRuntimeCredentials: vi.fn(async () =>
+    envMock.R_TEAMS_BOT_APP_ID && envMock.R_TEAMS_BOT_APP_PASSWORD
+      ? {
+          postDirectMessage: postDirectMessageMock,
+          postMessage: postMessageMock,
+          fetchMessageImageDataUrls: fetchMessageImageDataUrlsMock,
+          processImageAttachments: processImageAttachmentsMock,
+        }
+      : null,
+  ),
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({

--- a/apps/api/src/handlers/teams/index.ts
+++ b/apps/api/src/handlers/teams/index.ts
@@ -22,7 +22,7 @@ import {
   buildSnapshotResumeAcknowledgementText,
   buildTaskLaunchAcknowledgementText,
 } from '@roomote/communication/chat-messages';
-import { TeamsCommunicationProvider } from '@roomote/communication/teams-provider';
+import type { TeamsCommunicationProvider } from '@roomote/communication/teams-provider';
 import { createTeamsCommunicationProviderFromRuntimeCredentials } from '@roomote/sdk/server';
 import {
   exchangeMicrosoftDelegatedGraphToken,
@@ -617,28 +617,13 @@ function teamsActivityHasHostedContentHint(activity: TeamsActivity): boolean {
 async function createTeamsCommunicationProviderWithGraph(
   userId: string,
 ): Promise<TeamsCommunicationProvider | null> {
-  const credentials = await resolveTeamsBotRuntimeCredentials();
-
-  if (!credentials.botAppId || !credentials.botAppPassword) {
-    return null;
-  }
-
   const graphTokenProvider = createDelegatedTeamsGraphTokenProvider(userId);
 
   if (!graphTokenProvider) {
     return null;
   }
 
-  return new TeamsCommunicationProvider({
-    appId: credentials.botAppId,
-    appPassword: credentials.botAppPassword,
-    ...(credentials.botTenantId ? { tenantId: credentials.botTenantId } : {}),
-    ...(credentials.botTokenEndpoint
-      ? { tokenEndpoint: credentials.botTokenEndpoint }
-      : {}),
-    ...(credentials.botOauthScope
-      ? { oauthScope: credentials.botOauthScope }
-      : {}),
+  return createTeamsCommunicationProviderFromRuntimeCredentials({
     graphTokenProvider,
   });
 }

--- a/apps/api/src/handlers/telegram/__tests__/index.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/index.test.ts
@@ -234,6 +234,20 @@ vi.mock('@roomote/communication/messages', () => ({
 }));
 
 vi.mock('@roomote/sdk/server', () => ({
+  createTelegramCommunicationProviderFromRuntimeCredentials: vi.fn(async () =>
+    envMock.R_TELEGRAM_BOT_TOKEN
+      ? {
+          addReaction: addReactionMock,
+          answerCallbackQuery: answerCallbackQueryMock,
+          createForumTopic: createForumTopicMock,
+          downloadFile: downloadFileMock,
+          getBotInfo: getBotInfoMock,
+          editMessageReplyMarkup: editMessageReplyMarkupMock,
+          editMessageText: editMessageTextMock,
+          postMessage: postMessageMock,
+        }
+      : null,
+  ),
   enqueueTelegramSuggestedTasksOnboardingFollowup: vi.fn(),
   consumeTelegramLinkCode: consumeLinkCodeMock,
   restoreTelegramLinkCode: restoreLinkCodeMock,

--- a/apps/api/src/handlers/telegram/replies.ts
+++ b/apps/api/src/handlers/telegram/replies.ts
@@ -1,18 +1,8 @@
 import type { CommunicationMessageButton } from '@roomote/communication';
-import { TelegramCommunicationProvider } from '@roomote/communication/telegram-provider';
 import { resolveTelegramRuntimeCredentials } from '@roomote/db/server';
+import { createTelegramCommunicationProviderFromRuntimeCredentials as createTelegramCommunicationProvider } from '@roomote/sdk/server';
 
 import { apiLogger } from '../../logging.js';
-
-async function createTelegramCommunicationProvider(): Promise<TelegramCommunicationProvider | null> {
-  const { botToken } = await resolveTelegramRuntimeCredentials();
-
-  if (!botToken) {
-    return null;
-  }
-
-  return new TelegramCommunicationProvider({ botToken });
-}
 
 const TELEGRAM_BOT_INFO_CACHE_TTL_MS = 5 * 60 * 1000;
 let privateTopicsCapabilityCache:
@@ -32,10 +22,12 @@ export async function telegramPrivateTopicsEnabledBestEffort(): Promise<boolean>
     return privateTopicsCapabilityCache.enabled;
   }
 
+  const provider = await createTelegramCommunicationProvider();
+
+  if (!provider) return false;
+
   try {
-    const { hasTopicsEnabled } = await new TelegramCommunicationProvider({
-      botToken,
-    }).getBotInfo();
+    const { hasTopicsEnabled } = await provider.getBotInfo();
     privateTopicsCapabilityCache = {
       botToken,
       enabled: hasTopicsEnabled,

--- a/apps/bullmq/src/jobs/pr-review-notification.test.ts
+++ b/apps/bullmq/src/jobs/pr-review-notification.test.ts
@@ -79,6 +79,9 @@ vi.mock('@roomote/sdk/server', () => ({
   schedulePrReviewNotificationJob: mockSchedule,
   createTeamsCommunicationProviderFromRuntimeCredentials:
     mockCreateTeamsProvider,
+  createTelegramCommunicationProviderFromRuntimeCredentials: vi.fn(
+    async () => ({ postMessage: mockTelegramPostMessage }),
+  ),
   preparePrReviewNotificationDelivery: mockPrepareDelivery,
   recordPrReviewNotificationDeliveryBestEffort: mockRecordDelivery,
 }));

--- a/apps/bullmq/src/jobs/pr-review-notification.ts
+++ b/apps/bullmq/src/jobs/pr-review-notification.ts
@@ -1,6 +1,5 @@
 import { Job } from 'bullmq';
 
-import { TelegramCommunicationProvider } from '@roomote/communication/telegram-provider';
 import {
   and,
   db,
@@ -10,11 +9,11 @@ import {
   taskPullRequests,
   taskRuns,
 } from '@roomote/db/server';
-import { Env } from '@roomote/env';
 import {
   PR_REVIEW_NOTIFICATION_DEFER_MS,
   PR_REVIEW_NOTIFICATION_MAX_DEFERRALS,
   createTeamsCommunicationProviderFromRuntimeCredentials,
+  createTelegramCommunicationProviderFromRuntimeCredentials,
   type PrReviewNotificationRequest,
   type PrReviewNotificationRoute,
   consumePendingPrReviewActivity,
@@ -95,16 +94,15 @@ async function postTelegramNotification({
   route: Extract<PrReviewNotificationRoute, { provider: 'telegram' }>;
   text: string;
 }): Promise<void> {
-  if (!Env.R_TELEGRAM_BOT_TOKEN) {
+  const provider =
+    await createTelegramCommunicationProviderFromRuntimeCredentials();
+
+  if (!provider) {
     console.warn(
       '[PrReviewNotification] Telegram bot token is not configured, skipping',
     );
     return;
   }
-
-  const provider = new TelegramCommunicationProvider({
-    botToken: Env.R_TELEGRAM_BOT_TOKEN,
-  });
 
   await provider.postMessage({
     channelId: route.channelId,

--- a/apps/bullmq/src/jobs/telegram-suggested-tasks-onboarding-followup.test.ts
+++ b/apps/bullmq/src/jobs/telegram-suggested-tasks-onboarding-followup.test.ts
@@ -25,6 +25,10 @@ vi.mock('@roomote/sdk/server', async () => {
   const { z } = await import('zod');
 
   return {
+    createTelegramCommunicationProviderFromRuntimeCredentials: vi.fn(
+      async () =>
+        envMock.R_TELEGRAM_BOT_TOKEN ? { postMessage: postMessageMock } : null,
+    ),
     telegramSuggestedTasksOnboardingFollowupRequestSchema: z.object({
       chatId: z.string(),
       threadId: z.string().optional(),

--- a/apps/bullmq/src/jobs/telegram-suggested-tasks-onboarding-followup.ts
+++ b/apps/bullmq/src/jobs/telegram-suggested-tasks-onboarding-followup.ts
@@ -1,9 +1,10 @@
 import { Job } from 'bullmq';
 
 import { buildSuggestedTasksFollowupReminderText } from '@roomote/communication/chat-messages';
-import { TelegramCommunicationProvider } from '@roomote/communication/telegram-provider';
-import { resolveTelegramRuntimeCredentials } from '@roomote/db/server';
-import { telegramSuggestedTasksOnboardingFollowupRequestSchema } from '@roomote/sdk/server';
+import {
+  createTelegramCommunicationProviderFromRuntimeCredentials,
+  telegramSuggestedTasksOnboardingFollowupRequestSchema,
+} from '@roomote/sdk/server';
 
 import {
   buildSuggestedTasksSettingsUrl,
@@ -24,16 +25,15 @@ export const telegramSuggestedTasksOnboardingFollowupJob = async (
     label: 'TelegramSuggestedTasksOnboardingFollowup',
     requestSchema: telegramSuggestedTasksOnboardingFollowupRequestSchema,
     send: async (data) => {
-      const { botToken } = await resolveTelegramRuntimeCredentials();
+      const provider =
+        await createTelegramCommunicationProviderFromRuntimeCredentials();
 
-      if (!botToken) {
+      if (!provider) {
         console.warn(
           '[TelegramSuggestedTasksOnboardingFollowup] Telegram bot token is not configured, skipping',
         );
         return;
       }
-
-      const provider = new TelegramCommunicationProvider({ botToken });
 
       await provider.postMessage({
         channelId: data.chatId,

--- a/apps/web/src/trpc/commands/comms/index.test.ts
+++ b/apps/web/src/trpc/commands/comms/index.test.ts
@@ -62,12 +62,18 @@ vi.mock('@roomote/db/server', () => ({
   invalidateTeamsBotRuntimeCredentialsCache: vi.fn(),
 }));
 
-vi.mock('@roomote/communication/telegram-provider', () => ({
-  TelegramCommunicationProvider: class {
-    getWebhookInfo = mockTelegramGetWebhookInfo;
-    registerWebhook = mockTelegramRegisterWebhook;
-    registerCommands = mockTelegramRegisterCommands;
-  },
+vi.mock('@roomote/sdk/server', () => ({
+  createTelegramCommunicationProviderFromRuntimeCredentials: vi.fn(async () => {
+    const { botToken } = await mockResolveTelegramRuntimeCredentials();
+
+    return botToken
+      ? {
+          getWebhookInfo: mockTelegramGetWebhookInfo,
+          registerWebhook: mockTelegramRegisterWebhook,
+          registerCommands: mockTelegramRegisterCommands,
+        }
+      : null;
+  }),
 }));
 
 vi.mock('@/lib/server/env', () => ({

--- a/apps/web/src/trpc/commands/comms/index.ts
+++ b/apps/web/src/trpc/commands/comms/index.ts
@@ -12,7 +12,7 @@ import {
   isNull,
   type DatabaseOrTransaction,
 } from '@roomote/db/server';
-import { TelegramCommunicationProvider } from '@roomote/communication/telegram-provider';
+import { createTelegramCommunicationProviderFromRuntimeCredentials } from '@roomote/sdk/server';
 
 import { Env } from '@/lib/server/env';
 import {
@@ -139,17 +139,16 @@ export function classifyTelegramWebhookCheckError(error: unknown): string {
 }
 
 async function getTelegramWebhookStatus(): Promise<TelegramWebhookStatus | null> {
-  const { botToken } = await resolveTelegramRuntimeCredentials();
+  const provider =
+    await createTelegramCommunicationProviderFromRuntimeCredentials({
+      fetch: createTelegramBotApiFetch(),
+    });
 
-  if (!botToken) {
+  if (!provider) {
     return null;
   }
 
   const expectedUrl = buildExpectedTelegramWebhookUrl();
-  const provider = new TelegramCommunicationProvider({
-    botToken,
-    fetch: createTelegramBotApiFetch(),
-  });
 
   try {
     const rawInfo = await provider.getWebhookInfo();
@@ -217,19 +216,18 @@ type TelegramWebhookRegistrationResult = {
 async function registerTelegramWebhookBestEffort(): Promise<TelegramWebhookRegistrationResult> {
   invalidateTelegramRuntimeCredentialsCache();
 
-  const { botToken, webhookSecret } = await resolveTelegramRuntimeCredentials();
+  const { webhookSecret } = await resolveTelegramRuntimeCredentials();
+  const provider =
+    await createTelegramCommunicationProviderFromRuntimeCredentials({
+      fetch: createTelegramBotApiFetch(),
+    });
 
-  if (!botToken || !webhookSecret) {
+  if (!provider || !webhookSecret) {
     return {
       registered: false,
       error: 'Telegram bot token or webhook secret is not configured.',
     };
   }
-
-  const provider = new TelegramCommunicationProvider({
-    botToken,
-    fetch: createTelegramBotApiFetch(),
-  });
 
   try {
     await Promise.all([

--- a/packages/communication/src/teams-provider.ts
+++ b/packages/communication/src/teams-provider.ts
@@ -749,18 +749,25 @@ export type TeamsBotEnvConfig = {
   R_TEAMS_BOT_OAUTH_SCOPE?: string;
 };
 
+export type TeamsCommunicationProviderExtraOptions = Pick<
+  TeamsCommunicationProviderOptions,
+  'graphTokenProvider' | 'serviceUrl' | 'graphBaseUrl'
+>;
+
 /**
  * Builds a `TeamsCommunicationProvider` from Teams bot env configuration, or
  * returns `null` when the required bot credentials are not configured.
  */
 export function createTeamsCommunicationProviderFromEnv(
   env: TeamsBotEnvConfig,
+  extraOptions?: TeamsCommunicationProviderExtraOptions,
 ): TeamsCommunicationProvider | null {
   if (!env.R_TEAMS_BOT_APP_ID || !env.R_TEAMS_BOT_APP_PASSWORD) {
     return null;
   }
 
   return new TeamsCommunicationProvider({
+    ...extraOptions,
     appId: env.R_TEAMS_BOT_APP_ID,
     appPassword: env.R_TEAMS_BOT_APP_PASSWORD,
     ...(env.R_TEAMS_BOT_TENANT_ID

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -90,6 +90,8 @@ export {
 
 export { createTeamsCommunicationProviderFromRuntimeCredentials } from './lib/teams-communication';
 
+export { createTelegramCommunicationProviderFromRuntimeCredentials } from './lib/telegram-communication';
+
 export {
   findTelegramPrimaryChatId,
   TELEGRAM_PRIMARY_CHAT_ENV_VAR_NAME,

--- a/packages/sdk/src/server/lib/__tests__/telegram-communication.test.ts
+++ b/packages/sdk/src/server/lib/__tests__/telegram-communication.test.ts
@@ -1,0 +1,66 @@
+const { mockResolveTelegramRuntimeCredentials, mockTelegramProvider } =
+  vi.hoisted(() => ({
+    mockResolveTelegramRuntimeCredentials: vi.fn(),
+    mockTelegramProvider: vi.fn(),
+  }));
+
+vi.mock('@roomote/db/server', () => ({
+  resolveTelegramRuntimeCredentials: mockResolveTelegramRuntimeCredentials,
+}));
+
+vi.mock('@roomote/communication/telegram-provider', () => ({
+  TelegramCommunicationProvider: mockTelegramProvider,
+}));
+
+import { createTelegramCommunicationProviderFromRuntimeCredentials } from '../telegram-communication';
+
+describe('createTelegramCommunicationProviderFromRuntimeCredentials', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when no bot token is configured', async () => {
+    mockResolveTelegramRuntimeCredentials.mockResolvedValue({
+      botToken: null,
+      webhookSecret: null,
+      botUsername: null,
+    });
+
+    await expect(
+      createTelegramCommunicationProviderFromRuntimeCredentials(),
+    ).resolves.toBeNull();
+    expect(mockTelegramProvider).not.toHaveBeenCalled();
+  });
+
+  it('builds a provider from the resolved bot token', async () => {
+    mockResolveTelegramRuntimeCredentials.mockResolvedValue({
+      botToken: '123:abc',
+      webhookSecret: null,
+      botUsername: 'roomote_bot',
+    });
+
+    const provider =
+      await createTelegramCommunicationProviderFromRuntimeCredentials();
+
+    expect(provider).toBeInstanceOf(mockTelegramProvider);
+    expect(mockTelegramProvider).toHaveBeenCalledWith({ botToken: '123:abc' });
+  });
+
+  it('passes a custom fetch through to the provider', async () => {
+    mockResolveTelegramRuntimeCredentials.mockResolvedValue({
+      botToken: '123:abc',
+      webhookSecret: null,
+      botUsername: null,
+    });
+    const customFetch = vi.fn();
+
+    await createTelegramCommunicationProviderFromRuntimeCredentials({
+      fetch: customFetch as unknown as typeof fetch,
+    });
+
+    expect(mockTelegramProvider).toHaveBeenCalledWith({
+      botToken: '123:abc',
+      fetch: customFetch,
+    });
+  });
+});

--- a/packages/sdk/src/server/lib/teams-communication.ts
+++ b/packages/sdk/src/server/lib/teams-communication.ts
@@ -2,6 +2,7 @@ import {
   createTeamsCommunicationProviderFromEnv,
   type TeamsBotEnvConfig,
   type TeamsCommunicationProvider,
+  type TeamsCommunicationProviderExtraOptions,
 } from '@roomote/communication/teams-provider';
 import {
   resolveTeamsBotRuntimeCredentials,
@@ -35,10 +36,13 @@ function teamsBotEnvConfigFromCredentials(
  * credentials (env vars, settings-UI values, or the Microsoft sign-in app
  * doubling as the bot app), or `null` when no bot is configured.
  */
-export async function createTeamsCommunicationProviderFromRuntimeCredentials(): Promise<TeamsCommunicationProvider | null> {
+export async function createTeamsCommunicationProviderFromRuntimeCredentials(
+  extraOptions?: TeamsCommunicationProviderExtraOptions,
+): Promise<TeamsCommunicationProvider | null> {
   const credentials = await resolveTeamsBotRuntimeCredentials();
 
   return createTeamsCommunicationProviderFromEnv(
     teamsBotEnvConfigFromCredentials(credentials),
+    extraOptions,
   );
 }

--- a/packages/sdk/src/server/lib/telegram-communication.ts
+++ b/packages/sdk/src/server/lib/telegram-communication.ts
@@ -1,0 +1,27 @@
+import { TelegramCommunicationProvider } from '@roomote/communication/telegram-provider';
+import { resolveTelegramRuntimeCredentials } from '@roomote/db/server';
+
+type TelegramCommunicationProviderRuntimeOptions = {
+  /** Custom fetch, e.g. a base-URL-rewriting fetch for webhook admin calls. */
+  fetch?: typeof fetch;
+};
+
+/**
+ * Builds a `TelegramCommunicationProvider` from the resolved runtime
+ * credentials (env vars, or values saved from the comms settings UI), or
+ * `null` when no bot token is configured.
+ */
+export async function createTelegramCommunicationProviderFromRuntimeCredentials(
+  options?: TelegramCommunicationProviderRuntimeOptions,
+): Promise<TelegramCommunicationProvider | null> {
+  const { botToken } = await resolveTelegramRuntimeCredentials();
+
+  if (!botToken) {
+    return null;
+  }
+
+  return new TelegramCommunicationProvider({
+    botToken,
+    ...(options?.fetch ? { fetch: options.fetch } : {}),
+  });
+}


### PR DESCRIPTION
## What

First PR of the "automations on all comms channels" track: hoists ad-hoc Teams/Telegram communication-adapter construction into shared runtime-credential factories in `@roomote/sdk/server`.

- **New `createTelegramCommunicationProviderFromRuntimeCredentials`** — resolves the bot token the standard way (env vars first, comms-settings-UI values as fallback) and returns a ready provider or `null`. Replaces five duplicated resolve→null-check→construct blocks across the API handlers (`telegram/replies`, `mcp/communication-thread-replies`), bullmq jobs (`pr-review-notification`, `telegram-suggested-tasks-onboarding-followup`), and the comms settings trpc commands. Accepts a `fetch` override for the webhook admin calls.
- **`createTeamsCommunicationProviderFromRuntimeCredentials` now takes extra provider options** (`graphTokenProvider`, `serviceUrl`, `graphBaseUrl`), so the Teams delegated-Graph path in the Teams webhook handler uses the shared factory instead of hand-building the provider from raw credentials.

Call sites that receive a token as input (Telegram webhook attachment download, setup-new kickoff fallback) intentionally keep constructing providers directly — they aren't duplicating credential resolution.

## Behavior note

PR-review Telegram notifications previously read the bot token from process env only (`Env.R_TELEGRAM_BOT_TOKEN`); via the shared factory they now also honor a token saved from the comms settings UI, matching every other Telegram outbound path.

Everything else is a pure refactor with no behavior change.

## Why

Groundwork for routing automations (and other outbound flows) through the provider-agnostic communication adapters instead of hardcoded Slack paths. Next up: a generic destination + channel-waterfall resolver built on these factories.

## Testing

- New unit tests for the Telegram factory (`packages/sdk/src/server/lib/__tests__/telegram-communication.test.ts`)
- Updated mocks in the affected handler/job/trpc tests; full runs green: api handlers (178), bullmq jobs, web comms trpc, communication package (137)
- `pnpm lint:fast`, `pnpm check-types:fast`, `pnpm knip` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)