### PR TITLE
Add generic communication adapter dispatch

### DIFF
--- a/apps/bullmq/src/jobs/pr-review-notification.test.ts
+++ b/apps/bullmq/src/jobs/pr-review-notification.test.ts
@@ -3,7 +3,6 @@ import { z } from 'zod';
 const {
   mockFindFirstTaskRun,
   mockFindFirstTaskPullRequest,
-  mockFindFirstSlackInstallation,
   mockConsumePending,
   mockRequeuePending,
   mockSchedule,
@@ -11,12 +10,10 @@ const {
   mockRecordDelivery,
   mockPostMessage,
   mockTeamsPostMessage,
-  mockCreateTeamsProvider,
   mockTelegramPostMessage,
 } = vi.hoisted(() => ({
   mockFindFirstTaskRun: vi.fn(),
   mockFindFirstTaskPullRequest: vi.fn(),
-  mockFindFirstSlackInstallation: vi.fn(),
   mockConsumePending: vi.fn(),
   mockRequeuePending: vi.fn(),
   mockSchedule: vi.fn(),
@@ -24,7 +21,6 @@ const {
   mockRecordDelivery: vi.fn(),
   mockPostMessage: vi.fn(),
   mockTeamsPostMessage: vi.fn(),
-  mockCreateTeamsProvider: vi.fn(),
   mockTelegramPostMessage: vi.fn(),
 }));
 
@@ -38,10 +34,6 @@ vi.mock('@roomote/db/server', () => ({
         findFirst: (...args: unknown[]) =>
           mockFindFirstTaskPullRequest(...args),
       },
-      slackInstallations: {
-        findFirst: (...args: unknown[]) =>
-          mockFindFirstSlackInstallation(...args),
-      },
     },
   },
   and: vi.fn(() => 'and-condition'),
@@ -52,15 +44,6 @@ vi.mock('@roomote/db/server', () => ({
     taskId: 'taskId',
     repository: 'repository',
     prNumber: 'prNumber',
-  },
-  slackInstallations: { isActive: 'isActive' },
-}));
-
-vi.mock('@roomote/env', () => ({
-  Env: {
-    R_TEAMS_BOT_APP_ID: 'teams-app',
-    R_TEAMS_BOT_APP_PASSWORD: 'teams-secret',
-    R_TELEGRAM_BOT_TOKEN: 'telegram-token',
   },
 }));
 
@@ -77,25 +60,16 @@ vi.mock('@roomote/sdk/server', () => ({
   consumePendingPrReviewActivity: mockConsumePending,
   requeuePendingPrReviewActivity: mockRequeuePending,
   schedulePrReviewNotificationJob: mockSchedule,
-  createTeamsCommunicationProviderFromRuntimeCredentials:
-    mockCreateTeamsProvider,
-  createTelegramCommunicationProviderFromRuntimeCredentials: vi.fn(
-    async () => ({ postMessage: mockTelegramPostMessage }),
+  getCommunicationProviderAdapter: vi.fn(
+    async (provider: 'slack' | 'teams' | 'telegram') =>
+      ({
+        slack: { postMessage: mockPostMessage },
+        teams: { postMessage: mockTeamsPostMessage },
+        telegram: { postMessage: mockTelegramPostMessage },
+      })[provider],
   ),
   preparePrReviewNotificationDelivery: mockPrepareDelivery,
   recordPrReviewNotificationDeliveryBestEffort: mockRecordDelivery,
-}));
-
-vi.mock('@roomote/slack', () => ({
-  SlackNotifier: class MockSlackNotifier {
-    postMessage = mockPostMessage;
-  },
-}));
-
-vi.mock('@roomote/communication/telegram-provider', () => ({
-  TelegramCommunicationProvider: class MockTelegramProvider {
-    postMessage = mockTelegramPostMessage;
-  },
 }));
 
 import type { Job } from 'bullmq';
@@ -132,9 +106,6 @@ describe('prReviewNotificationJob', () => {
       taskPhase: 'waiting_for_prompt',
     });
     mockFindFirstTaskPullRequest.mockResolvedValue({ status: 'open' });
-    mockFindFirstSlackInstallation.mockResolvedValue({
-      botAccessToken: 'xoxb-token',
-    });
     mockConsumePending.mockResolvedValue(events);
     mockPrepareDelivery.mockResolvedValue({
       post: true,
@@ -146,12 +117,22 @@ describe('prReviewNotificationJob', () => {
       text: 'formatted-message',
     });
     mockRecordDelivery.mockResolvedValue(undefined);
-    mockPostMessage.mockResolvedValue('999.888');
-    mockCreateTeamsProvider.mockReturnValue({
-      postMessage: mockTeamsPostMessage,
+    mockPostMessage.mockResolvedValue({
+      provider: 'slack',
+      channelId: 'C123',
+      messageId: '999.888',
+      threadId: '111.222',
     });
-    mockTeamsPostMessage.mockResolvedValue({ provider: 'teams' });
-    mockTelegramPostMessage.mockResolvedValue({ provider: 'telegram' });
+    mockTeamsPostMessage.mockResolvedValue({
+      provider: 'teams',
+      channelId: '19:abc',
+      messageId: 'activity-1',
+    });
+    mockTelegramPostMessage.mockResolvedValue({
+      provider: 'telegram',
+      channelId: '12345',
+      messageId: '901',
+    });
   });
 
   it('posts the aggregated notification to the originating Slack thread when the task is idle', async () => {
@@ -169,11 +150,9 @@ describe('prReviewNotificationJob', () => {
       events,
     });
     expect(mockPostMessage).toHaveBeenCalledWith({
-      channel: 'C123',
-      thread_ts: '111.222',
+      channelId: 'C123',
+      threadId: '111.222',
       text: 'formatted-message',
-      unfurl_links: false,
-      unfurl_media: false,
     });
     expect(mockRecordDelivery).toHaveBeenCalledWith({
       runId: 1,

--- a/apps/bullmq/src/jobs/pr-review-notification.ts
+++ b/apps/bullmq/src/jobs/pr-review-notification.ts
@@ -1,7 +1,14 @@
 import { Job } from 'bullmq';
 
 import type { CommunicationPostMessageInput } from '@roomote/communication';
-import { and, db, desc, eq, taskPullRequests, taskRuns } from '@roomote/db/server';
+import {
+  and,
+  db,
+  desc,
+  eq,
+  taskPullRequests,
+  taskRuns,
+} from '@roomote/db/server';
 import {
   PR_REVIEW_NOTIFICATION_DEFER_MS,
   PR_REVIEW_NOTIFICATION_MAX_DEFERRALS,

--- a/apps/bullmq/src/jobs/pr-review-notification.ts
+++ b/apps/bullmq/src/jobs/pr-review-notification.ts
@@ -1,19 +1,11 @@
 import { Job } from 'bullmq';
 
-import {
-  and,
-  db,
-  desc,
-  eq,
-  slackInstallations,
-  taskPullRequests,
-  taskRuns,
-} from '@roomote/db/server';
+import type { CommunicationPostMessageInput } from '@roomote/communication';
+import { and, db, desc, eq, taskPullRequests, taskRuns } from '@roomote/db/server';
 import {
   PR_REVIEW_NOTIFICATION_DEFER_MS,
   PR_REVIEW_NOTIFICATION_MAX_DEFERRALS,
-  createTeamsCommunicationProviderFromRuntimeCredentials,
-  createTelegramCommunicationProviderFromRuntimeCredentials,
+  getCommunicationProviderAdapter,
   type PrReviewNotificationRequest,
   type PrReviewNotificationRoute,
   consumePendingPrReviewActivity,
@@ -23,92 +15,38 @@ import {
   requeuePendingPrReviewActivity,
   schedulePrReviewNotificationJob,
 } from '@roomote/sdk/server';
-import { SlackNotifier } from '@roomote/slack';
 import { isTaskExecutingTurn } from '@roomote/types';
 
 type PrReviewNotificationJob = Job<PrReviewNotificationRequest, void, string>;
 
-async function postSlackNotification({
-  route,
-  text,
-}: {
-  route: Extract<PrReviewNotificationRoute, { provider: 'slack' }>;
-  text: string;
-}): Promise<string | null> {
-  const slackInstallation = await db.query.slackInstallations.findFirst({
-    where: eq(slackInstallations.isActive, true),
-    columns: { botAccessToken: true },
-  });
-
-  if (!slackInstallation) {
-    console.warn(
-      '[PrReviewNotification] No active Slack installation, skipping',
-    );
-    return null;
+function buildPrReviewNotificationPostInput(
+  route: PrReviewNotificationRoute,
+  text: string,
+): CommunicationPostMessageInput {
+  switch (route.provider) {
+    case 'slack':
+      return {
+        channelId: route.channelId,
+        threadId: route.threadId,
+        text,
+      };
+    case 'teams':
+      return {
+        channelId: route.channelId,
+        serviceUrl: route.serviceUrl,
+        ...(route.threadId
+          ? { threadId: route.threadId, replyToMessageId: route.threadId }
+          : {}),
+        text,
+        textFormat: 'markdown',
+      };
+    case 'telegram':
+      return {
+        channelId: route.channelId,
+        ...(route.threadId ? { threadId: route.threadId } : {}),
+        text,
+      };
   }
-
-  const notifier = new SlackNotifier(slackInstallation.botAccessToken);
-  const messageTs = await notifier.postMessage({
-    channel: route.channelId,
-    thread_ts: route.threadId,
-    text,
-    unfurl_links: false,
-    unfurl_media: false,
-  });
-
-  return typeof messageTs === 'string' && messageTs ? messageTs : null;
-}
-
-async function postTeamsNotification({
-  route,
-  text,
-}: {
-  route: Extract<PrReviewNotificationRoute, { provider: 'teams' }>;
-  text: string;
-}): Promise<void> {
-  const provider =
-    await createTeamsCommunicationProviderFromRuntimeCredentials();
-
-  if (!provider) {
-    console.warn(
-      '[PrReviewNotification] Teams bot credentials are not configured, skipping',
-    );
-    return;
-  }
-
-  await provider.postMessage({
-    channelId: route.channelId,
-    serviceUrl: route.serviceUrl,
-    ...(route.threadId
-      ? { threadId: route.threadId, replyToMessageId: route.threadId }
-      : {}),
-    text,
-    textFormat: 'markdown',
-  });
-}
-
-async function postTelegramNotification({
-  route,
-  text,
-}: {
-  route: Extract<PrReviewNotificationRoute, { provider: 'telegram' }>;
-  text: string;
-}): Promise<void> {
-  const provider =
-    await createTelegramCommunicationProviderFromRuntimeCredentials();
-
-  if (!provider) {
-    console.warn(
-      '[PrReviewNotification] Telegram bot token is not configured, skipping',
-    );
-    return;
-  }
-
-  await provider.postMessage({
-    channelId: route.channelId,
-    ...(route.threadId ? { threadId: route.threadId } : {}),
-    text,
-  });
 }
 
 async function postPrReviewNotification({
@@ -118,16 +56,20 @@ async function postPrReviewNotification({
   route: PrReviewNotificationRoute;
   text: string;
 }): Promise<string | null> {
-  switch (route.provider) {
-    case 'slack':
-      return postSlackNotification({ route, text });
-    case 'teams':
-      await postTeamsNotification({ route, text });
-      return null;
-    case 'telegram':
-      await postTelegramNotification({ route, text });
-      return null;
+  const adapter = await getCommunicationProviderAdapter(route.provider);
+
+  if (!adapter) {
+    console.warn(
+      `[PrReviewNotification] ${route.provider} is not connected, skipping`,
+    );
+    return null;
   }
+
+  const result = await adapter.postMessage(
+    buildPrReviewNotificationPostInput(route, text),
+  );
+
+  return route.provider === 'slack' ? result.messageId : null;
 }
 
 /**

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -92,6 +92,8 @@ export { createTeamsCommunicationProviderFromRuntimeCredentials } from './lib/te
 
 export { createTelegramCommunicationProviderFromRuntimeCredentials } from './lib/telegram-communication';
 
+export { getCommunicationProviderAdapter } from './lib/communication-providers';
+
 export {
   findTelegramPrimaryChatId,
   TELEGRAM_PRIMARY_CHAT_ENV_VAR_NAME,

--- a/packages/sdk/src/server/lib/__tests__/communication-providers.test.ts
+++ b/packages/sdk/src/server/lib/__tests__/communication-providers.test.ts
@@ -1,0 +1,82 @@
+const {
+  mockFindFirstSlackInstallation,
+  mockSlackNotifier,
+  mockSlackCommunicationProvider,
+  mockCreateTeamsProvider,
+  mockCreateTelegramProvider,
+} = vi.hoisted(() => ({
+  mockFindFirstSlackInstallation: vi.fn(),
+  mockSlackNotifier: vi.fn(),
+  mockSlackCommunicationProvider: vi.fn(),
+  mockCreateTeamsProvider: vi.fn(),
+  mockCreateTelegramProvider: vi.fn(),
+}));
+
+vi.mock('@roomote/db/server', () => ({
+  db: {
+    query: {
+      slackInstallations: { findFirst: mockFindFirstSlackInstallation },
+    },
+  },
+  eq: vi.fn((left: unknown, right: unknown) => ({ eq: [left, right] })),
+  slackInstallations: { isActive: 'isActive' },
+}));
+
+vi.mock('@roomote/slack', () => ({
+  SlackNotifier: mockSlackNotifier,
+  SlackCommunicationProvider: mockSlackCommunicationProvider,
+}));
+
+vi.mock('../teams-communication', () => ({
+  createTeamsCommunicationProviderFromRuntimeCredentials:
+    mockCreateTeamsProvider,
+}));
+
+vi.mock('../telegram-communication', () => ({
+  createTelegramCommunicationProviderFromRuntimeCredentials:
+    mockCreateTelegramProvider,
+}));
+
+import { getCommunicationProviderAdapter } from '../communication-providers';
+
+describe('getCommunicationProviderAdapter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('builds a Slack adapter from the active installation', async () => {
+    mockFindFirstSlackInstallation.mockResolvedValue({
+      botAccessToken: 'xoxb-token',
+    });
+
+    const adapter = await getCommunicationProviderAdapter('slack');
+
+    expect(adapter).toBeInstanceOf(mockSlackCommunicationProvider);
+    expect(mockSlackNotifier).toHaveBeenCalledWith('xoxb-token');
+  });
+
+  it('returns null for Slack when no installation is active', async () => {
+    mockFindFirstSlackInstallation.mockResolvedValue(undefined);
+
+    await expect(getCommunicationProviderAdapter('slack')).resolves.toBeNull();
+    expect(mockSlackCommunicationProvider).not.toHaveBeenCalled();
+  });
+
+  it('dispatches Teams to the shared Teams factory', async () => {
+    const teamsAdapter = { provider: 'teams' };
+    mockCreateTeamsProvider.mockResolvedValue(teamsAdapter);
+
+    await expect(getCommunicationProviderAdapter('teams')).resolves.toBe(
+      teamsAdapter,
+    );
+  });
+
+  it('dispatches Telegram to the shared Telegram factory', async () => {
+    mockCreateTelegramProvider.mockResolvedValue(null);
+
+    await expect(
+      getCommunicationProviderAdapter('telegram'),
+    ).resolves.toBeNull();
+    expect(mockCreateTelegramProvider).toHaveBeenCalled();
+  });
+});

--- a/packages/sdk/src/server/lib/communication-providers.ts
+++ b/packages/sdk/src/server/lib/communication-providers.ts
@@ -1,0 +1,44 @@
+import type { CommunicationProviderAdapter } from '@roomote/communication';
+import { db, eq, slackInstallations } from '@roomote/db/server';
+import { SlackCommunicationProvider, SlackNotifier } from '@roomote/slack';
+import type { CommunicationProvider } from '@roomote/types';
+
+import { createTeamsCommunicationProviderFromRuntimeCredentials } from './teams-communication';
+import { createTelegramCommunicationProviderFromRuntimeCredentials } from './telegram-communication';
+
+/**
+ * Builds a `SlackCommunicationProvider` from the deployment's active Slack
+ * installation, or `null` when Slack is not connected.
+ */
+async function createSlackCommunicationProviderFromInstallation(): Promise<SlackCommunicationProvider | null> {
+  const installation = await db.query.slackInstallations.findFirst({
+    where: eq(slackInstallations.isActive, true),
+    columns: { botAccessToken: true },
+  });
+
+  if (!installation?.botAccessToken) {
+    return null;
+  }
+
+  return new SlackCommunicationProvider(
+    new SlackNotifier(installation.botAccessToken),
+  );
+}
+
+/**
+ * Resolves the outbound communication adapter for a provider from the
+ * deployment's runtime credentials, or `null` when that provider is not
+ * connected.
+ */
+export async function getCommunicationProviderAdapter(
+  provider: CommunicationProvider,
+): Promise<CommunicationProviderAdapter | null> {
+  switch (provider) {
+    case 'slack':
+      return createSlackCommunicationProviderFromInstallation();
+    case 'teams':
+      return createTeamsCommunicationProviderFromRuntimeCredentials();
+    case 'telegram':
+      return createTelegramCommunicationProviderFromRuntimeCredentials();
+  }
+}


### PR DESCRIPTION
## What

Second PR of the "automations on all comms channels" track (follows #280).

- **`getCommunicationProviderAdapter(provider)`** in `@roomote/sdk/server`: resolves a ready `CommunicationProviderAdapter` for `slack` / `teams` / `telegram` from the deployment's runtime credentials, returning `null` when the provider isn't connected.
- **Slack finally gets an adapter factory.** `SlackCommunicationProvider` existed but was constructed nowhere; the new factory builds it from the active Slack installation's bot token. Teams and Telegram dispatch to the shared factories from #280.
- **First consumer: the PR-review notification job.** Its hand-rolled per-provider switch (raw `SlackNotifier` + provider classes + three near-identical "not configured, skipping" blocks) becomes one adapter-dispatch path. Per-route input differences (Teams `serviceUrl` + markdown + `replyToMessageId`, Telegram plain text) live in a small input builder, so the delivery path itself is provider-agnostic.

## Behavior notes

- Slack delivery input is unchanged (`SlackCommunicationProvider` sets the same `unfurl_links/unfurl_media: false` the job set by hand).
- One edge-case change: if Slack's `chat.postMessage` returns no timestamp, the adapter throws (job retries with events requeued) where the old code silently recorded the delivery without a `messageTs`. The retry is the more correct behavior.

## Scope note

The plan's "destination + waterfall resolver" piece intentionally moves forward one PR: a destination resolver with no non-Slack targets to resolve would ship as dead exports (knip-blocked) and speculative shape. It lands with the automation target model, which is its first real consumer.

## Testing

- New unit tests for the adapter dispatch (Slack installation gating + Teams/Telegram delegation)
- PR-review notification job tests rewritten against the adapter seam; all 12 pass
- Full local runs green: sdk (458), bullmq (100), api (897); `lint:fast`, `check-types:fast`, `knip` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)