### PR TITLE
[Improve] Make Slack MCP setup a non-blocking suggestion

### DIFF
--- a/apps/api/src/handlers/slack/dispatch/interactive.ts
+++ b/apps/api/src/handlers/slack/dispatch/interactive.ts
@@ -11,8 +11,6 @@ import {
   handleNevermind,
   handleRoutingConfirmOk,
   handleRoutingRejectNo,
-  handleSlackMcpSetupConfigure,
-  handleSlackMcpSetupIgnore,
   handleRetryFailedTask,
   handleTaskConfiguration,
   MANAGER_MCP_SETUP_CONFIGURE_ACTION_ID,
@@ -197,12 +195,6 @@ export async function handleSlackInteractivePayload(
       break;
     case actionId === 'routing_confirm_no':
       await handleRoutingRejectNo(interactivePayload);
-      break;
-    case actionId === 'mcp_setup_configure':
-      await handleSlackMcpSetupConfigure(interactivePayload);
-      break;
-    case actionId === 'mcp_setup_ignore':
-      await handleSlackMcpSetupIgnore(interactivePayload);
       break;
     case actionId === MANAGER_MCP_SETUP_CONFIGURE_ACTION_ID:
       await handleManagerMcpSetupConfigure(interactivePayload);

--- a/apps/api/src/handlers/slack/events/auto-route-fallback.test.ts
+++ b/apps/api/src/handlers/slack/events/auto-route-fallback.test.ts
@@ -53,7 +53,7 @@ describe('auto-route-fallback', () => {
       userMapping: { userId: 'user_123' },
       slack: {},
       skipRouting: true,
-      skipMcpSetupInterrupt: true,
+      skipMcpSetupSuggestion: true,
       processingReactionName: 'eyes',
     });
   });

--- a/apps/api/src/handlers/slack/events/auto-route-fallback.ts
+++ b/apps/api/src/handlers/slack/events/auto-route-fallback.ts
@@ -60,7 +60,7 @@ export async function showManualPickerForAutoRouteFallback(params: {
     userMapping: params.userMapping as SlackUserMapping,
     slack: params.slack,
     skipRouting: true,
-    skipMcpSetupInterrupt: true,
+    skipMcpSetupSuggestion: true,
     processingReactionName: params.processingReactionName,
   });
 

--- a/apps/api/src/handlers/slack/events/message-entry-unmentioned-routing.test.ts
+++ b/apps/api/src/handlers/slack/events/message-entry-unmentioned-routing.test.ts
@@ -3,14 +3,12 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 const {
   fetchThreadMessagesMock,
   hasPendingRoutingConfirmationMock,
-  hasPendingSlackMcpSetupInterruptMock,
   findRoomoteOwnedSlackThreadMock,
   markSlackThreadExplicitMentionRequiredMock,
   getSlackThreadReplyFooterMessageTsMock,
 } = vi.hoisted(() => ({
   fetchThreadMessagesMock: vi.fn(),
   hasPendingRoutingConfirmationMock: vi.fn(),
-  hasPendingSlackMcpSetupInterruptMock: vi.fn(),
   findRoomoteOwnedSlackThreadMock: vi.fn(),
   markSlackThreadExplicitMentionRequiredMock: vi.fn(),
   getSlackThreadReplyFooterMessageTsMock: vi.fn(),
@@ -32,7 +30,6 @@ vi.mock('@roomote/cloud-agents', () => ({
 vi.mock('@roomote/slack', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@roomote/slack')>()),
   hasPendingRoutingConfirmation: hasPendingRoutingConfirmationMock,
-  hasPendingSlackMcpSetupInterrupt: hasPendingSlackMcpSetupInterruptMock,
   markSlackThreadExplicitMentionRequired:
     markSlackThreadExplicitMentionRequiredMock,
   getSlackThreadReplyFooterMessageTs: getSlackThreadReplyFooterMessageTsMock,
@@ -113,7 +110,6 @@ describe('shouldRouteUnmentionedSlackThreadReplyToAgent', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     hasPendingRoutingConfirmationMock.mockResolvedValue(false);
-    hasPendingSlackMcpSetupInterruptMock.mockResolvedValue(false);
     findRoomoteOwnedSlackThreadMock.mockResolvedValue({
       userId: 'user-1',
       slackUserId: 'U111',

--- a/apps/api/src/handlers/slack/events/message-entry.ts
+++ b/apps/api/src/handlers/slack/events/message-entry.ts
@@ -12,13 +12,11 @@ import { SLACK_AUTO_CONFIRM_TIMEOUT_MS } from '@roomote/cloud-agents/server';
 import {
   autoConfirmRouting,
   collectAndExtractThreadAttachmentTexts,
-  clearPendingSlackMcpSetupInterrupt,
   collectAndProcessThreadImages,
   fetchThreadMessagesSafe,
   findActiveSlackTaskRun,
   formatSlackRoutingWaitReplyText,
   hasPendingRoutingConfirmation,
-  hasPendingSlackMcpSetupInterrupt,
   getSlackThreadReplyFooterMessageTs,
   isTargetSlackBotMessage,
   markSlackThreadExplicitMentionRequired,
@@ -524,25 +522,20 @@ export async function shouldRouteUnmentionedSlackThreadReplyToAgent(params: {
     return { shouldRoute: false };
   }
 
-  const [pendingRoutingConfirmation, pendingMcpSetupInterrupt] =
-    await Promise.all([
-      hasPendingRoutingConfirmation(event.thread_ts),
-      hasPendingSlackMcpSetupInterrupt(event.thread_ts),
-    ]);
+  const pendingRoutingConfirmation = await hasPendingRoutingConfirmation(
+    event.thread_ts,
+  );
   let roomoteThreadMatch: Awaited<
     ReturnType<typeof findRoomoteOwnedSlackThread>
   > | null = null;
 
   let eligibilityReason:
     | 'pending-routing-confirmation'
-    | 'pending-mcp-setup-interrupt'
     | 'roomote-owned-thread'
     | null = null;
 
   if (pendingRoutingConfirmation) {
     eligibilityReason = 'pending-routing-confirmation';
-  } else if (pendingMcpSetupInterrupt) {
-    eligibilityReason = 'pending-mcp-setup-interrupt';
   } else {
     roomoteThreadMatch = await findRoomoteOwnedSlackThread({
       teamId,
@@ -1440,7 +1433,7 @@ async function processAutomatedAppMentionTask(params: {
         ...(attachmentTexts.length > 0
           ? { processedAttachmentTexts: attachmentTexts }
           : {}),
-        skipMcpSetupInterrupt: true,
+        skipMcpSetupSuggestion: true,
         ...(videoDescriptions.length > 0
           ? { processedVideoDescriptions: videoDescriptions }
           : {}),
@@ -1717,13 +1710,6 @@ export async function handleSlackEntryEvent(params: {
 
     if (followUpOutcome.kind !== 'fresh') {
       return;
-    }
-
-    const pendingMcpSetupInterrupt =
-      await hasPendingSlackMcpSetupInterrupt(threadId);
-
-    if (pendingMcpSetupInterrupt) {
-      await clearPendingSlackMcpSetupInterrupt(threadId);
     }
 
     const pendingConfirmation = await hasPendingRoutingConfirmation(threadId);

--- a/packages/slack/src/__tests__/mcp-setup-suggestion.test.ts
+++ b/packages/slack/src/__tests__/mcp-setup-suggestion.test.ts
@@ -4,7 +4,6 @@ const {
   routeTaskMock,
   repositoriesFindManyMock,
   environmentsFindManyMock,
-  selectLimitMock,
   hasMessageInThreadMock,
   fetchThreadMessagesMock,
   normalizeIncomingTextMock,
@@ -15,6 +14,7 @@ const {
   redisGetMock,
   redisHsetMock,
   redisEvalMock,
+  deliveryTrackerTrackMock,
   deliveryTrackerCommitMock,
   maybeNotifyManagerChannelForMcpSetupRequirementMock,
 } = vi.hoisted(() => ({
@@ -23,7 +23,6 @@ const {
   routeTaskMock: vi.fn(),
   repositoriesFindManyMock: vi.fn(),
   environmentsFindManyMock: vi.fn(),
-  selectLimitMock: vi.fn(),
   hasMessageInThreadMock: vi.fn(),
   fetchThreadMessagesMock: vi.fn(),
   normalizeIncomingTextMock: vi.fn(),
@@ -34,6 +33,7 @@ const {
   redisGetMock: vi.fn(),
   redisHsetMock: vi.fn(),
   redisEvalMock: vi.fn(),
+  deliveryTrackerTrackMock: vi.fn(),
   deliveryTrackerCommitMock: vi.fn(),
   maybeNotifyManagerChannelForMcpSetupRequirementMock: vi.fn(),
 }));
@@ -84,7 +84,7 @@ vi.mock('@roomote/db/server', () => ({
     select: vi.fn(() => ({
       from: vi.fn(() => ({
         where: vi.fn(() => ({
-          limit: selectLimitMock,
+          limit: vi.fn(),
         })),
       })),
     })),
@@ -117,7 +117,7 @@ vi.mock('@roomote/redis', () => ({
 vi.mock('../slack-thread-delivery-tracker', () => ({
   SlackThreadDeliveryTracker: vi.fn().mockImplementation(function () {
     return {
-      track: vi.fn(),
+      track: deliveryTrackerTrackMock,
       trackAll: vi.fn(),
       commit: deliveryTrackerCommitMock,
     };
@@ -156,18 +156,25 @@ vi.mock('../manager-mcp-setup', () => ({
 }));
 
 import { SlackNotifier } from '../slack-notifier';
+import { showTaskConfiguration } from '../block-kit';
 import {
-  handleSlackMcpSetupConfigure,
-  handleSlackMcpSetupIgnore,
-  showTaskConfiguration,
-} from '../block-kit';
+  buildSlackMcpSetupSuggestionBlocks,
+  buildSlackMcpSetupSuggestionText,
+} from '../mcp-setup-suggestion';
 
-describe('Slack MCP setup interruption flow', () => {
-  const fetchMock = vi.fn();
+const SETUP_REQUIREMENT = {
+  serviceId: 'notion',
+  serviceName: 'Notion',
+  reason: 'user_auth_required',
+  canConfigure: true,
+  settingsUrl:
+    'https://app.example.com/settings/personal?service=notion&source=slack-mcp-interrupt',
+  copyVariant: 'user_auth_required',
+} as const;
 
+describe('Slack MCP setup suggestion flow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.stubGlobal('fetch', fetchMock);
     repositoriesFindManyMock.mockResolvedValue([
       {
         name: 'App Repo',
@@ -207,24 +214,12 @@ describe('Slack MCP setup interruption flow', () => {
     });
   });
 
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  it('posts an interrupt instead of routing when setup is required', async () => {
-    detectSlackMcpSetupRequirementMock.mockResolvedValue({
-      serviceId: 'notion',
-      serviceName: 'Notion',
-      reason: 'user_auth_required',
-      canConfigure: true,
-      settingsUrl:
-        'https://app.example.com/settings/personal?service=notion&source=slack-mcp-interrupt',
-      copyVariant: 'user_auth_required',
-    });
+  it('posts a non-blocking suggestion and keeps routing when setup is required', async () => {
+    detectSlackMcpSetupRequirementMock.mockResolvedValue(SETUP_REQUIREMENT);
 
     const slack = new SlackNotifier('xoxb-test');
 
-    const result = await showTaskConfiguration({
+    await showTaskConfiguration({
       event: {
         type: 'app_mention',
         channel: 'C123',
@@ -241,38 +236,36 @@ describe('Slack MCP setup interruption flow', () => {
       slack: slack as never,
     });
 
-    expect(result).toEqual({ routingUsed: false, threadId: '111.222' });
     expect(detectSlackMcpSetupRequirementMock).toHaveBeenCalledWith(
       '<@BOT> review https://www.notion.so/acme/spec-123',
       expect.objectContaining({
         userId: 'user_1',
       }),
     );
-    expect(fetchThreadMessagesMock).not.toHaveBeenCalled();
-    expect(routeTaskMock).not.toHaveBeenCalled();
     expect(postMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        blocks: expect.arrayContaining([
-          expect.objectContaining({ type: 'section' }),
+        channel: 'C123',
+        thread_ts: '111.222',
+        blocks: [
           expect.objectContaining({
-            type: 'actions',
-            elements: expect.arrayContaining([
+            type: 'context',
+            elements: [
               expect.objectContaining({
-                action_id: 'mcp_setup_configure',
-                value: expect.any(String),
+                type: 'mrkdwn',
+                text: expect.stringContaining('link your Notion account'),
               }),
-              expect.objectContaining({
-                action_id: 'mcp_setup_ignore',
-                value: expect.any(String),
-              }),
-            ]),
+            ],
           }),
-        ]),
+        ],
       }),
     );
+    expect(deliveryTrackerTrackMock).toHaveBeenCalledWith('999.000');
+    // Routing must proceed despite the missing setup.
+    expect(buildSlackRoutingContextMock).toHaveBeenCalledTimes(1);
+    expect(routeTaskMock).toHaveBeenCalledTimes(1);
   });
 
-  it('notifies the manager channel when org setup is required while keeping the requester prompt', async () => {
+  it('notifies the manager channel while continuing the task', async () => {
     const setupRequirement = {
       serviceId: 'sentry',
       serviceName: 'Sentry',
@@ -286,7 +279,7 @@ describe('Slack MCP setup interruption flow', () => {
 
     const slack = new SlackNotifier('xoxb-test');
 
-    const result = await showTaskConfiguration({
+    await showTaskConfiguration({
       event: {
         type: 'app_mention',
         channel: 'C123',
@@ -303,7 +296,6 @@ describe('Slack MCP setup interruption flow', () => {
       slack: slack as never,
     });
 
-    expect(result).toEqual({ routingUsed: false, threadId: '111.222' });
     expect(
       maybeNotifyManagerChannelForMcpSetupRequirementMock,
     ).toHaveBeenCalledWith({
@@ -312,200 +304,131 @@ describe('Slack MCP setup interruption flow', () => {
       requirement: setupRequirement,
       slack,
     });
-    expect(postMessageMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        channel: 'C123',
-        thread_ts: '111.222',
-        blocks: expect.arrayContaining([
-          expect.objectContaining({
-            type: 'actions',
-            elements: expect.arrayContaining([
-              expect.objectContaining({ action_id: 'mcp_setup_configure' }),
-            ]),
-          }),
-        ]),
-      }),
-    );
+    expect(routeTaskMock).toHaveBeenCalledTimes(1);
   });
 
-  it('clears the interrupt and replaces the prompt after Configure', async () => {
-    redisEvalMock.mockResolvedValueOnce(
-      JSON.stringify({
-        copyVariant: 'user_auth_required',
-        nonce: 'nonce-123',
-      }),
-    );
+  it('does not post a suggestion when no setup is required', async () => {
+    detectSlackMcpSetupRequirementMock.mockResolvedValue(null);
 
-    await handleSlackMcpSetupConfigure({
-      type: 'block_actions',
-      team: { id: 'T123', domain: 'acme' },
-      user: { id: 'U123', name: 'alice' },
-      channel: { id: 'C123', name: 'general' },
-      message: { ts: '111.222' },
-      actions: [
-        {
-          type: 'button',
-          action_id: 'mcp_setup_configure',
-          text: { text: 'Configure' },
-          value: 'nonce-123',
-        },
-      ],
-      state: { values: {} },
-      response_url: 'https://slack.test/response',
-      trigger_id: 'trigger-123',
+    const slack = new SlackNotifier('xoxb-test');
+
+    await showTaskConfiguration({
+      event: {
+        type: 'app_mention',
+        channel: 'C123',
+        user: 'U123',
+        text: '<@BOT> review this please',
+        ts: '111.222',
+      },
+      slackInstallation: {
+        teamId: 'T123',
+      } as never,
+      userMapping: {
+        userId: 'user_1',
+      } as never,
+      slack: slack as never,
     });
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://slack.test/response',
-      expect.objectContaining({
-        method: 'POST',
-        body: expect.stringContaining(
-          'Finish setup in the web app, then send this request again.',
-        ),
-      }),
-    );
-    expect(redisEvalMock).toHaveBeenCalledWith(
-      expect.any(String),
-      1,
-      'slack:mcp-setup-interrupt:111.222',
-      'nonce-123',
-      'U123',
-    );
+    expect(
+      maybeNotifyManagerChannelForMcpSetupRequirementMock,
+    ).not.toHaveBeenCalled();
+    const suggestionPosts = postMessageMock.mock.calls.filter((call) => {
+      const message = call[0] as { blocks?: Array<{ type?: string }> };
+      return message.blocks?.some((block) => block.type === 'context');
+    });
+    expect(suggestionPosts).toHaveLength(0);
+    expect(routeTaskMock).toHaveBeenCalledTimes(1);
   });
 
-  it('continues into the normal routing path when Ignore is clicked', async () => {
-    detectSlackMcpSetupRequirementMock.mockResolvedValue(null);
-    redisEvalMock.mockResolvedValueOnce(
-      JSON.stringify({
-        threadId: '111.222',
-        teamId: 'T123',
-        slackUserId: 'U123',
-        channel: 'C123',
-        originalEvent: {
+  it('keeps routing when setup detection fails', async () => {
+    const consoleWarnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+    try {
+      detectSlackMcpSetupRequirementMock.mockRejectedValue(
+        new Error('detection down'),
+      );
+
+      const slack = new SlackNotifier('xoxb-test');
+
+      await showTaskConfiguration({
+        event: {
           type: 'app_mention',
           channel: 'C123',
           user: 'U123',
-          text: '<@BOT> ignore and continue',
+          text: '<@BOT> review https://www.notion.so/acme/spec-123',
           ts: '111.222',
         },
-        normalizedTaskText: '<@BOT> ignore and continue',
-        serviceId: 'notion',
-        serviceName: 'Notion',
-        reason: 'user_auth_required',
-        canConfigure: true,
-        settingsUrl:
-          'https://app.example.com/settings/personal?service=notion&source=slack-mcp-interrupt',
-        copyVariant: 'user_auth_required',
-        originalMessageTs: '111.222',
-        nonce: 'nonce-123',
-      }),
-    );
-    selectLimitMock
-      .mockResolvedValueOnce([
-        {
+        slackInstallation: {
           teamId: 'T123',
-          botAccessToken: 'xoxb-test',
-        },
-      ])
-      .mockResolvedValueOnce([
-        {
+        } as never,
+        userMapping: {
           userId: 'user_1',
-        },
-      ]);
+        } as never,
+        slack: slack as never,
+      });
 
-    await handleSlackMcpSetupIgnore({
-      type: 'block_actions',
-      team: { id: 'T123', domain: 'acme' },
-      user: { id: 'U123', name: 'alice' },
-      channel: { id: 'C123', name: 'general' },
-      message: { ts: '111.222' },
-      actions: [
-        {
-          type: 'button',
-          action_id: 'mcp_setup_ignore',
-          text: { text: 'Ignore' },
-          value: 'nonce-123',
-        },
-      ],
-      state: { values: {} },
-      response_url: 'https://slack.test/response',
-      trigger_id: 'trigger-123',
+      expect(routeTaskMock).toHaveBeenCalledTimes(1);
+      expect(
+        maybeNotifyManagerChannelForMcpSetupRequirementMock,
+      ).not.toHaveBeenCalled();
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
+  });
+});
+
+describe('buildSlackMcpSetupSuggestionText', () => {
+  it.each([
+    [
+      'user_auth_required',
+      '<https://app.example.com/settings|link your Zero account>',
+    ],
+    [
+      'deployment_disabled_admin',
+      '<https://app.example.com/settings|enable the Zero integration>',
+    ],
+    [
+      'deployment_auth_required_admin',
+      '<https://app.example.com/settings|finish connecting Zero>',
+    ],
+    ['deployment_disabled_non_admin', 'ask a'],
+    ['deployment_auth_required_non_admin', 'ask a'],
+  ] as const)('renders the %s variant', (copyVariant, expected) => {
+    const text = buildSlackMcpSetupSuggestionText({
+      serviceId: 'zero',
+      serviceName: 'Zero',
+      settingsUrl: 'https://app.example.com/settings',
+      copyVariant,
     });
 
-    expect(detectSlackMcpSetupRequirementMock).not.toHaveBeenCalled();
-    expect(buildSlackRoutingContextMock).toHaveBeenCalledTimes(1);
-    expect(updateMessageMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        channel: 'C123',
-        ts: '111.222',
-      }),
-    );
-    expect(redisEvalMock).toHaveBeenCalledWith(
-      expect.any(String),
-      1,
-      'slack:mcp-setup-interrupt:111.222',
-      'nonce-123',
-      'U123',
-    );
+    expect(text).toContain('That looks like a Zero link');
+    expect(text).toContain(expected);
   });
 
-  it('ignores stale Configure clicks when nonce does not match', async () => {
-    redisEvalMock.mockResolvedValueOnce(null);
-
-    await handleSlackMcpSetupConfigure({
-      type: 'block_actions',
-      team: { id: 'T123', domain: 'acme' },
-      user: { id: 'U123', name: 'alice' },
-      channel: { id: 'C123', name: 'general' },
-      message: { ts: '111.222' },
-      actions: [
-        {
-          type: 'button',
-          action_id: 'mcp_setup_configure',
-          text: { text: 'Configure' },
-          value: 'stale-nonce',
-        },
-      ],
-      state: { values: {} },
-      response_url: 'https://slack.test/response',
-      trigger_id: 'trigger-123',
+  it('builds a single context block', () => {
+    const blocks = buildSlackMcpSetupSuggestionBlocks({
+      serviceId: 'zero',
+      serviceName: 'Zero',
+      settingsUrl: 'https://app.example.com/settings',
+      copyVariant: 'user_auth_required',
     });
 
-    expect(fetchMock).not.toHaveBeenCalled();
-    expect(selectLimitMock).not.toHaveBeenCalled();
-  });
-
-  it('ignores Ignore clicks from other Slack users', async () => {
-    redisEvalMock.mockResolvedValueOnce(null);
-
-    await handleSlackMcpSetupIgnore({
-      type: 'block_actions',
-      team: { id: 'T123', domain: 'acme' },
-      user: { id: 'U999', name: 'teammate' },
-      channel: { id: 'C123', name: 'general' },
-      message: { ts: '111.222' },
-      actions: [
-        {
-          type: 'button',
-          action_id: 'mcp_setup_ignore',
-          text: { text: 'Ignore' },
-          value: 'nonce-123',
-        },
-      ],
-      state: { values: {} },
-      response_url: 'https://slack.test/response',
-      trigger_id: 'trigger-123',
-    });
-
-    expect(redisEvalMock).toHaveBeenCalledWith(
-      expect.any(String),
-      1,
-      'slack:mcp-setup-interrupt:111.222',
-      'nonce-123',
-      'U999',
-    );
-    expect(selectLimitMock).not.toHaveBeenCalled();
-    expect(buildSlackRoutingContextMock).not.toHaveBeenCalled();
-    expect(updateMessageMock).not.toHaveBeenCalled();
+    expect(blocks).toEqual([
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: buildSlackMcpSetupSuggestionText({
+              serviceId: 'zero',
+              serviceName: 'Zero',
+              settingsUrl: 'https://app.example.com/settings',
+              copyVariant: 'user_auth_required',
+            }),
+          },
+        ],
+      },
+    ]);
   });
 });

--- a/packages/slack/src/__tests__/mcp-setup-suggestion.test.ts
+++ b/packages/slack/src/__tests__/mcp-setup-suggestion.test.ts
@@ -307,6 +307,41 @@ describe('Slack MCP setup suggestion flow', () => {
     expect(routeTaskMock).toHaveBeenCalledTimes(1);
   });
 
+  it('does not post a suggestion when routing resolves to a platform answer', async () => {
+    detectSlackMcpSetupRequirementMock.mockResolvedValue(SETUP_REQUIREMENT);
+    routeTaskMock.mockResolvedValue({
+      status: 'platform_answer',
+      result: { answer: 'Roomote supports Notion via MCP.' },
+    });
+
+    const slack = new SlackNotifier('xoxb-test');
+
+    await showTaskConfiguration({
+      event: {
+        type: 'app_mention',
+        channel: 'C123',
+        user: 'U123',
+        text: '<@BOT> does Roomote support https://www.notion.so?',
+        ts: '111.222',
+      },
+      slackInstallation: {
+        teamId: 'T123',
+      } as never,
+      userMapping: {
+        userId: 'user_1',
+      } as never,
+      slack: slack as never,
+    });
+
+    const suggestionPosts = postMessageMock.mock.calls.filter((call) =>
+      JSON.stringify(call[0]).includes('That looks like a'),
+    );
+    expect(suggestionPosts).toHaveLength(0);
+    expect(
+      maybeNotifyManagerChannelForMcpSetupRequirementMock,
+    ).not.toHaveBeenCalled();
+  });
+
   it('does not post a suggestion when no setup is required', async () => {
     detectSlackMcpSetupRequirementMock.mockResolvedValue(null);
 

--- a/packages/slack/src/__tests__/start-auto-routed-slack-task.test.ts
+++ b/packages/slack/src/__tests__/start-auto-routed-slack-task.test.ts
@@ -1312,6 +1312,51 @@ describe('startAutoRoutedSlackTask', () => {
     }
   });
 
+  it('does not repeat the setup suggestion when a follow-up reuses an active run', async () => {
+    detectSlackMcpSetupRequirementMock.mockResolvedValue({
+      serviceId: 'linear',
+      serviceName: 'Linear',
+      reason: 'user_auth_required',
+      canConfigure: true,
+      settingsUrl: 'https://app.example.com/settings/personal?service=linear',
+      copyVariant: 'user_auth_required',
+    });
+    startSlackAppMentionTaskMock.mockResolvedValue({
+      id: 88,
+      taskId: 'task_existing',
+      reusedExistingRun: true,
+    });
+    getTaskUrlMock.mockReturnValue(
+      'https://app.example.com/task/task_existing',
+    );
+
+    const slack = {
+      hasMessageInThread: vi.fn().mockResolvedValue(true),
+      normalizeIncomingText: vi
+        .fn()
+        .mockImplementation(async (text: string) => text),
+      fetchThreadMessages: vi.fn().mockResolvedValue([]),
+      postMessage: vi.fn().mockResolvedValue('130.000'),
+    };
+
+    const result = await startAutoRoutedSlackTask({
+      slackInstallation: { orgId: 'org_1' } as never,
+      slack: slack as never,
+      initiator: { kind: 'user' as const, userId: 'user_installer' },
+      trigger: 'message' as const,
+      launchUserId: 'user_installer',
+      slackUserId: 'UINSTALLER',
+      channel: 'C123',
+      prompt: 'Also check https://linear.app/acme/issue/OPS-123',
+      threadTs: '120.000',
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({ status: 'started', runId: 88 }),
+    );
+    expect(slack.postMessage).not.toHaveBeenCalled();
+  });
+
   it('starts the task without detection when the setup suggestion is skipped', async () => {
     detectSlackMcpSetupRequirementMock.mockResolvedValue({
       serviceId: 'linear',

--- a/packages/slack/src/__tests__/start-auto-routed-slack-task.test.ts
+++ b/packages/slack/src/__tests__/start-auto-routed-slack-task.test.ts
@@ -1208,7 +1208,111 @@ describe('startAutoRoutedSlackTask', () => {
     );
   });
 
-  it('bypasses the MCP setup blocker when requested for automated launches', async () => {
+  it('starts the task and posts a setup suggestion when MCP setup is missing', async () => {
+    detectSlackMcpSetupRequirementMock.mockResolvedValue({
+      serviceId: 'linear',
+      serviceName: 'Linear',
+      reason: 'user_auth_required',
+      canConfigure: true,
+      settingsUrl: 'https://app.example.com/settings/personal?service=linear',
+      copyVariant: 'user_auth_required',
+    });
+
+    const slack = {
+      hasMessageInThread: vi.fn().mockResolvedValue(true),
+      normalizeIncomingText: vi
+        .fn()
+        .mockImplementation(async (text: string) => text),
+      fetchThreadMessages: vi.fn().mockResolvedValue([]),
+      postMessage: vi.fn().mockResolvedValue('130.000'),
+    };
+
+    const result = await startAutoRoutedSlackTask({
+      slackInstallation: { orgId: 'org_1' } as never,
+      slack: slack as never,
+      initiator: { kind: 'user' as const, userId: 'user_installer' },
+      trigger: 'message' as const,
+      launchUserId: 'user_installer',
+      slackUserId: 'UINSTALLER',
+      channel: 'C123',
+      prompt: 'Investigate https://linear.app/acme/issue/OPS-123',
+      threadTs: '120.000',
+    });
+
+    expect(routeTaskMock).toHaveBeenCalled();
+    expect(startSlackAppMentionTaskMock).toHaveBeenCalled();
+    expect(result).toEqual({
+      status: 'started',
+      threadId: '120.000',
+      runId: 77,
+      taskId: 'task_77',
+      taskUrl: 'https://app.example.com/task/task_77',
+    });
+    expect(slack.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: 'C123',
+        thread_ts: '120.000',
+        blocks: [
+          expect.objectContaining({
+            type: 'context',
+            elements: [
+              expect.objectContaining({
+                text: expect.stringContaining(
+                  '<https://app.example.com/settings/personal?service=linear|link your Linear account>',
+                ),
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+    expect(trackMock).toHaveBeenCalledWith('130.000');
+  });
+
+  it('never fails the started task when the setup suggestion cannot be posted', async () => {
+    const consoleWarnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+    try {
+      detectSlackMcpSetupRequirementMock.mockResolvedValue({
+        serviceId: 'linear',
+        serviceName: 'Linear',
+        reason: 'user_auth_required',
+        canConfigure: true,
+        settingsUrl: 'https://app.example.com/settings/personal?service=linear',
+        copyVariant: 'user_auth_required',
+      });
+
+      const slack = {
+        hasMessageInThread: vi.fn().mockResolvedValue(true),
+        normalizeIncomingText: vi
+          .fn()
+          .mockImplementation(async (text: string) => text),
+        fetchThreadMessages: vi.fn().mockResolvedValue([]),
+        postMessage: vi.fn().mockRejectedValue(new Error('slack down')),
+      };
+
+      const result = await startAutoRoutedSlackTask({
+        slackInstallation: { orgId: 'org_1' } as never,
+        slack: slack as never,
+        initiator: { kind: 'user' as const, userId: 'user_installer' },
+        trigger: 'message' as const,
+        launchUserId: 'user_installer',
+        slackUserId: 'UINSTALLER',
+        channel: 'C123',
+        prompt: 'Investigate https://linear.app/acme/issue/OPS-123',
+        threadTs: '120.000',
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({ status: 'started', runId: 77 }),
+      );
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
+  });
+
+  it('starts the task without detection when the setup suggestion is skipped', async () => {
     detectSlackMcpSetupRequirementMock.mockResolvedValue({
       serviceId: 'linear',
       serviceName: 'Linear',
@@ -1236,7 +1340,7 @@ describe('startAutoRoutedSlackTask', () => {
       channel: 'C123',
       prompt: 'Investigate https://linear.app/acme/issue/OPS-123',
       threadTs: '120.000',
-      skipMcpSetupInterrupt: true,
+      skipMcpSetupSuggestion: true,
     });
 
     expect(detectSlackMcpSetupRequirementMock).not.toHaveBeenCalled();

--- a/packages/slack/src/block-kit.ts
+++ b/packages/slack/src/block-kit.ts
@@ -44,6 +44,7 @@ import {
   type RoutingDebugInfo,
   type RoutingResult,
   type RoutingWorkspace,
+  type SlackMcpSetupRequirement,
   detectSlackMcpSetupRequirement,
   routeTask,
   classifyFollowUp,
@@ -882,10 +883,13 @@ export async function showTaskConfiguration({
     if (!skipRouting) {
       try {
         // Missing MCP setup never blocks the task. When the message links to
-        // a service without a usable connection, post a small suggestion in
-        // the thread, ping the manager channel, and keep going.
+        // a service without a usable connection, a small suggestion is posted
+        // in the thread (after routing decides a task flow is happening) and
+        // the manager channel is pinged.
+        let setupRequirement: SlackMcpSetupRequirement | null = null;
+
         if (!skipMcpSetupSuggestion) {
-          const setupRequirement = await detectSlackMcpSetupRequirement(
+          setupRequirement = await detectSlackMcpSetupRequirement(
             taskDescription,
             {
               userId: userMapping.userId,
@@ -897,30 +901,6 @@ export async function showTaskConfiguration({
             );
             return null;
           });
-
-          if (setupRequirement) {
-            void maybeNotifyManagerChannelForMcpSetupRequirement({
-              triggeredByUserId: userMapping.userId,
-              triggeredBySlackUserId: event.user,
-              requirement: setupRequirement,
-              slack,
-            }).catch((error) => {
-              console.warn(
-                `[SlackMcpSetup] Failed to notify manager channel: ${error instanceof Error ? error.message : String(error)}`,
-              );
-            });
-
-            const suggestionTs = await postSlackMcpSetupSuggestion({
-              slack,
-              channel: event.channel,
-              threadId,
-              suggestion: setupRequirement,
-            });
-
-            if (suggestionTs) {
-              deliveryTracker.track(suggestionTs);
-            }
-          }
         }
 
         // Fetch thread messages for context if this is a reply in a thread
@@ -1002,6 +982,33 @@ export async function showTaskConfiguration({
           }
 
           return { routingUsed: false, threadId };
+        }
+
+        // A task flow is proceeding (routed or manual picker) — surface the
+        // non-blocking setup suggestion now, so it never shows on pure Q&A
+        // platform answers.
+        if (setupRequirement) {
+          void maybeNotifyManagerChannelForMcpSetupRequirement({
+            triggeredByUserId: userMapping.userId,
+            triggeredBySlackUserId: event.user,
+            requirement: setupRequirement,
+            slack,
+          }).catch((error) => {
+            console.warn(
+              `[SlackMcpSetup] Failed to notify manager channel: ${error instanceof Error ? error.message : String(error)}`,
+            );
+          });
+
+          const suggestionTs = await postSlackMcpSetupSuggestion({
+            slack,
+            channel: event.channel,
+            threadId,
+            suggestion: setupRequirement,
+          });
+
+          if (suggestionTs) {
+            deliveryTracker.track(suggestionTs);
+          }
         }
 
         if (decision.status === 'routed') {

--- a/packages/slack/src/block-kit.ts
+++ b/packages/slack/src/block-kit.ts
@@ -44,7 +44,6 @@ import {
   type RoutingDebugInfo,
   type RoutingResult,
   type RoutingWorkspace,
-  type SlackMcpSetupRequirement,
   detectSlackMcpSetupRequirement,
   routeTask,
   classifyFollowUp,
@@ -73,6 +72,7 @@ import {
 } from './started-message-blocks';
 import { appendSlackVideoDescriptionsToText } from './video-descriptions';
 import { maybeNotifyManagerChannelForMcpSetupRequirement } from './manager-mcp-setup';
+import { postSlackMcpSetupSuggestion } from './mcp-setup-suggestion';
 import {
   finishRoutedStart,
   getSlackStartedMessageFollowUrl,
@@ -99,8 +99,6 @@ const MAX_TEXT_LENGTH = 75;
  * Redis key prefix for storing LLM routing pre-fill data for auto-confirm.
  */
 const ROUTING_PREFILL_PREFIX = 'routing_prefill:';
-const MCP_SETUP_INTERRUPT_PREFIX = 'slack:mcp-setup-interrupt:';
-const MCP_SETUP_INTERRUPT_TTL_SECONDS = 15 * 60;
 const SLACK_AUTH_NO_RESUME_SENTINEL = '__roomote:no-resume__';
 
 function formatSlackCode(value: string): string {
@@ -340,27 +338,6 @@ return val
 `;
 
 /**
- * Lua script to atomically GET + DEL an MCP setup interruption only when
- * the stored nonce and Slack user both match the interactive action.
- *
- * KEYS[1] = the interruption key
- * ARGV[1] = the expected nonce
- * ARGV[2] = the expected Slack user id
- *
- * Returns the stored JSON string if nonce + user match, nil otherwise.
- */
-const CLAIM_MCP_SETUP_INTERRUPT_LUA = `
-local val = redis.call('get', KEYS[1])
-if not val then return nil end
-local ok, data = pcall(cjson.decode, val)
-if not ok then return nil end
-if data.nonce ~= ARGV[1] then return nil end
-if data.slackUserId ~= ARGV[2] then return nil end
-redis.call('del', KEYS[1])
-return val
-`;
-
-/**
  * Data stored in Redis for a pending Slack routing confirmation.
  */
 interface RoutingPrefillData {
@@ -394,23 +371,6 @@ interface RoutingConfirmActionValue {
 
 interface RetryFailedTaskActionValue {
   runId: number;
-}
-
-interface PendingSlackMcpSetupInterruptData {
-  threadId: string;
-  teamId: string;
-  slackUserId: string;
-  channel: string;
-  originalEvent: SlackEvent;
-  normalizedTaskText: string;
-  serviceId: string;
-  serviceName: string;
-  reason: SlackMcpSetupRequirement['reason'];
-  canConfigure: boolean;
-  settingsUrl: string;
-  copyVariant: SlackMcpSetupRequirement['copyVariant'];
-  originalMessageTs: string;
-  nonce: string;
 }
 
 export function getSlackRoutingAutoConfirmDelayMs(
@@ -537,26 +497,6 @@ function parseRetryFailedTaskActionValue(
 }
 
 /**
- * Atomically claims Slack MCP setup interruption data only if the nonce
- * and clicking Slack user from the interactive action match the stored
- * interruption data.
- */
-async function claimSlackMcpSetupInterruptWithNonce(
-  threadId: string,
-  expectedNonce: string,
-  expectedSlackUserId: string,
-): Promise<string | null> {
-  const result = await getRedis().eval(
-    CLAIM_MCP_SETUP_INTERRUPT_LUA,
-    1,
-    getSlackMcpSetupInterruptKey(threadId),
-    expectedNonce,
-    expectedSlackUserId,
-  );
-  return result as string | null;
-}
-
-/**
  * Checks if there is a pending routing confirmation for a thread.
  * Used to detect whether an incoming message is a correction to a routing suggestion.
  */
@@ -569,25 +509,6 @@ export async function hasPendingRoutingConfirmation(
   return exists === 1;
 }
 
-function getSlackMcpSetupInterruptKey(threadId: string): string {
-  return `${MCP_SETUP_INTERRUPT_PREFIX}${threadId}`;
-}
-
-export async function hasPendingSlackMcpSetupInterrupt(
-  threadId: string,
-): Promise<boolean> {
-  const exists = await getRedis().exists(
-    getSlackMcpSetupInterruptKey(threadId),
-  );
-  return exists === 1;
-}
-
-export async function clearPendingSlackMcpSetupInterrupt(
-  threadId: string,
-): Promise<void> {
-  await getRedis().del(getSlackMcpSetupInterruptKey(threadId));
-}
-
 /**
  * Truncate text to a maximum length, adding ellipsis if needed.
  * Slack Block Kit has a character limit for text fields in options.
@@ -598,84 +519,6 @@ function truncateText(text: string, maxLength = MAX_TEXT_LENGTH): string {
   }
 
   return text.slice(0, maxLength - 3) + '...';
-}
-
-function buildSlackMcpSetupInterruptBlocks(
-  data: Pick<
-    PendingSlackMcpSetupInterruptData,
-    | 'serviceName'
-    | 'reason'
-    | 'canConfigure'
-    | 'settingsUrl'
-    | 'copyVariant'
-    | 'nonce'
-  >,
-): SlackBlock[] {
-  const secondaryText =
-    data.copyVariant === 'deployment_disabled_non_admin'
-      ? `To do that, please ask a ${PRODUCT_NAME} admin to enable it in the web app.`
-      : data.copyVariant === 'deployment_auth_required_non_admin'
-        ? `To do that, please ask a ${PRODUCT_NAME} admin to connect it in the web app.`
-        : data.copyVariant === 'deployment_disabled_admin'
-          ? 'To do that, please enable it in the web app.'
-          : data.copyVariant === 'deployment_auth_required_admin'
-            ? 'To do that, please finish connecting it in the web app.'
-            : 'To do that, please enable it in the web app and then link your account.';
-
-  return [
-    {
-      type: 'section',
-      text: {
-        type: 'mrkdwn',
-        text: `That seems like a ${data.serviceName} link.\nWant me to be able to read it?\n*${secondaryText}*`,
-      },
-    },
-    {
-      type: 'actions',
-      block_id: 'mcp_setup_interrupt',
-      elements: [
-        {
-          type: 'button',
-          action_id: 'mcp_setup_configure',
-          text: {
-            type: 'plain_text',
-            text: data.canConfigure ? 'Configure' : 'Open settings',
-            emoji: false,
-          },
-          url: data.settingsUrl,
-          style: 'primary',
-          value: data.nonce,
-        },
-        {
-          type: 'button',
-          action_id: 'mcp_setup_ignore',
-          text: { type: 'plain_text', text: 'Nah, keep going', emoji: true },
-          value: data.nonce,
-        },
-      ],
-    },
-  ];
-}
-
-function buildSlackMcpSetupFollowUpBlocks(
-  copyVariant: PendingSlackMcpSetupInterruptData['copyVariant'],
-): SlackBlock[] {
-  const text =
-    copyVariant === 'deployment_disabled_non_admin'
-      ? 'Ask an admin to finish setup in the web app, then send this request again.'
-      : copyVariant === 'deployment_auth_required_non_admin'
-        ? 'Ask an admin to connect it in the web app, then send this request again.'
-        : 'Finish setup in the web app, then send this request again.';
-
-  return [
-    {
-      type: 'section',
-      text: {
-        type: 'mrkdwn',
-        text,
-      },
-    },
-  ];
 }
 
 function buildPlatformAnswerMessage(
@@ -931,7 +774,7 @@ export async function showTaskConfiguration({
   userMapping,
   slack,
   skipRouting,
-  skipMcpSetupInterrupt,
+  skipMcpSetupSuggestion,
   replaceMessageTs,
   processingReactionName,
 }: {
@@ -940,7 +783,7 @@ export async function showTaskConfiguration({
   userMapping: SlackUserMapping;
   slack: SlackNotifier;
   skipRouting?: boolean;
-  skipMcpSetupInterrupt?: boolean;
+  skipMcpSetupSuggestion?: boolean;
   /** When provided, update this message instead of posting a new one. */
   replaceMessageTs?: string;
   processingReactionName?: string;
@@ -1038,14 +881,22 @@ export async function showTaskConfiguration({
 
     if (!skipRouting) {
       try {
-        if (!skipMcpSetupInterrupt) {
+        // Missing MCP setup never blocks the task. When the message links to
+        // a service without a usable connection, post a small suggestion in
+        // the thread, ping the manager channel, and keep going.
+        if (!skipMcpSetupSuggestion) {
           const setupRequirement = await detectSlackMcpSetupRequirement(
             taskDescription,
             {
               userId: userMapping.userId,
               apiBaseUrl: Env.R_APP_URL,
             },
-          );
+          ).catch((error) => {
+            console.warn(
+              `[SlackMcpSetup] Setup detection failed for thread ${threadId}: ${error instanceof Error ? error.message : String(error)}`,
+            );
+            return null;
+          });
 
           if (setupRequirement) {
             void maybeNotifyManagerChannelForMcpSetupRequirement({
@@ -1059,41 +910,16 @@ export async function showTaskConfiguration({
               );
             });
 
-            const interruptData: PendingSlackMcpSetupInterruptData = {
-              threadId,
-              teamId: slackInstallation.teamId,
-              slackUserId: event.user,
-              channel: event.channel,
-              originalEvent: event,
-              normalizedTaskText: taskDescription,
-              serviceId: setupRequirement.serviceId,
-              serviceName: setupRequirement.serviceName,
-              reason: setupRequirement.reason,
-              canConfigure: setupRequirement.canConfigure,
-              settingsUrl: setupRequirement.settingsUrl,
-              copyVariant: setupRequirement.copyVariant,
-              originalMessageTs: event.ts,
-              nonce: randomUUID(),
-            };
-
-            await redis.set(
-              getSlackMcpSetupInterruptKey(threadId),
-              JSON.stringify(interruptData),
-              'EX',
-              MCP_SETUP_INTERRUPT_TTL_SECONDS,
-            );
-
-            await postOrReplaceSlackMessage({
+            const suggestionTs = await postSlackMcpSetupSuggestion({
               slack,
               channel: event.channel,
               threadId,
-              replaceMessageTs,
-              message: {
-                blocks: buildSlackMcpSetupInterruptBlocks(interruptData),
-              },
+              suggestion: setupRequirement,
             });
 
-            return { routingUsed: false, threadId };
+            if (suggestionTs) {
+              deliveryTracker.track(suggestionTs);
+            }
           }
         }
 
@@ -1567,124 +1393,6 @@ export async function showTaskConfiguration({
   } finally {
     await deliveryTracker.commit();
   }
-}
-
-export async function handleSlackMcpSetupConfigure(
-  payload: SlackInteractivePayload,
-) {
-  const threadId = payload.message.thread_ts || payload.message.ts;
-  const expectedNonce =
-    payload.actions[0]?.type === 'button'
-      ? (payload.actions[0].value ?? undefined)
-      : undefined;
-
-  if (!expectedNonce) {
-    console.warn(
-      `[SlackMcpSetupConfigure] Missing nonce for thread ${threadId}; ignoring stale or malformed action`,
-    );
-    return;
-  }
-
-  const interruptJson = await claimSlackMcpSetupInterruptWithNonce(
-    threadId,
-    expectedNonce,
-    payload.user.id,
-  );
-
-  if (!interruptJson) {
-    return;
-  }
-
-  let interrupt: PendingSlackMcpSetupInterruptData;
-  try {
-    interrupt = JSON.parse(interruptJson) as PendingSlackMcpSetupInterruptData;
-  } catch {
-    console.error(
-      `[SlackMcpSetupConfigure] Failed to parse interrupt data for thread ${threadId}`,
-    );
-    return;
-  }
-
-  await postSlackInteractiveResponse(payload.response_url, {
-    replace_original: true,
-    blocks: buildSlackMcpSetupFollowUpBlocks(interrupt.copyVariant),
-  });
-}
-
-export async function handleSlackMcpSetupIgnore(
-  payload: SlackInteractivePayload,
-) {
-  const teamId = payload.team.id;
-  const threadId = payload.message.thread_ts || payload.message.ts;
-  const expectedNonce =
-    payload.actions[0]?.type === 'button'
-      ? (payload.actions[0].value ?? undefined)
-      : undefined;
-
-  if (!expectedNonce) {
-    console.warn(
-      `[SlackMcpSetupIgnore] Missing nonce for thread ${threadId}; ignoring stale or malformed action`,
-    );
-    return;
-  }
-
-  const interruptJson = await claimSlackMcpSetupInterruptWithNonce(
-    threadId,
-    expectedNonce,
-    payload.user.id,
-  );
-
-  if (!interruptJson) {
-    return;
-  }
-
-  let interrupt: PendingSlackMcpSetupInterruptData;
-  try {
-    interrupt = JSON.parse(interruptJson) as PendingSlackMcpSetupInterruptData;
-  } catch {
-    console.error(
-      `[SlackMcpSetupIgnore] Failed to parse interrupt data for thread ${threadId}`,
-    );
-    return;
-  }
-
-  const [slackInstallation] = await db
-    .select()
-    .from(slackInstallations)
-    .where(eq(slackInstallations.teamId, teamId))
-    .limit(1);
-
-  if (!slackInstallation) {
-    console.error('[SlackMcpSetupIgnore] Slack installation not found');
-    return;
-  }
-
-  const [userMapping] = await db
-    .select()
-    .from(slackUserMappings)
-    .where(
-      and(
-        eq(slackUserMappings.slackUserId, interrupt.originalEvent.user),
-        eq(slackUserMappings.slackTeamId, teamId),
-      ),
-    )
-    .limit(1);
-
-  if (!userMapping) {
-    console.error('[SlackMcpSetupIgnore] User mapping not found');
-    return;
-  }
-
-  const slack = new SlackNotifier(slackInstallation.botAccessToken);
-
-  await showTaskConfiguration({
-    event: interrupt.originalEvent,
-    slackInstallation,
-    userMapping,
-    slack,
-    skipMcpSetupInterrupt: true,
-    replaceMessageTs: payload.message.ts,
-  });
 }
 
 export async function handleTaskConfiguration(

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -11,6 +11,7 @@ export * from './handle-followup-answer';
 export * from './interactive-response';
 export * from './markdown-converter';
 export * from './mcp-recommendations';
+export * from './mcp-setup-suggestion';
 export * from './manager-mcp-setup';
 export * from './request-user-input-blocks';
 export * from './request-user-input';

--- a/packages/slack/src/mcp-setup-suggestion.ts
+++ b/packages/slack/src/mcp-setup-suggestion.ts
@@ -1,0 +1,74 @@
+import { PRODUCT_NAME, type SlackBlock } from '@roomote/types';
+import type { SlackMcpSetupRequirement } from '@roomote/cloud-agents/server';
+
+import type { SlackNotifier } from './slack-notifier';
+
+export type SlackMcpSetupSuggestion = Pick<
+  SlackMcpSetupRequirement,
+  'serviceId' | 'serviceName' | 'settingsUrl' | 'copyVariant'
+>;
+
+export function buildSlackMcpSetupSuggestionText(
+  suggestion: SlackMcpSetupSuggestion,
+): string {
+  const { serviceName, settingsUrl, copyVariant } = suggestion;
+  const action =
+    copyVariant === 'deployment_disabled_non_admin'
+      ? `ask a ${PRODUCT_NAME} admin to enable the ${serviceName} integration`
+      : copyVariant === 'deployment_auth_required_non_admin'
+        ? `ask a ${PRODUCT_NAME} admin to finish connecting ${serviceName}`
+        : copyVariant === 'deployment_disabled_admin'
+          ? `<${settingsUrl}|enable the ${serviceName} integration>`
+          : copyVariant === 'deployment_auth_required_admin'
+            ? `<${settingsUrl}|finish connecting ${serviceName}>`
+            : `<${settingsUrl}|link your ${serviceName} account>`;
+
+  return `That looks like a ${serviceName} link. I don't have ${serviceName} access yet, so I'll work without it — ${action} if you want me to be able to use it.`;
+}
+
+export function buildSlackMcpSetupSuggestionBlocks(
+  suggestion: SlackMcpSetupSuggestion,
+): SlackBlock[] {
+  return [
+    {
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: buildSlackMcpSetupSuggestionText(suggestion),
+        },
+      ],
+    },
+  ];
+}
+
+/**
+ * Posts a small, non-blocking thread reply nudging the user to finish MCP
+ * setup for a service their message linked to. Failures are swallowed so a
+ * missed suggestion can never affect the task itself.
+ */
+export async function postSlackMcpSetupSuggestion({
+  slack,
+  channel,
+  threadId,
+  suggestion,
+}: {
+  slack: SlackNotifier;
+  channel: string;
+  threadId: string;
+  suggestion: SlackMcpSetupSuggestion;
+}): Promise<string | undefined> {
+  try {
+    return await slack.postMessage({
+      channel,
+      thread_ts: threadId,
+      text: buildSlackMcpSetupSuggestionText(suggestion),
+      blocks: buildSlackMcpSetupSuggestionBlocks(suggestion),
+    });
+  } catch (error) {
+    console.warn(
+      `[SlackMcpSetupSuggestion] Failed to post ${suggestion.serviceId} setup suggestion in ${channel}:${threadId}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return undefined;
+  }
+}

--- a/packages/slack/src/mcp-setup-suggestion.ts
+++ b/packages/slack/src/mcp-setup-suggestion.ts
@@ -23,7 +23,7 @@ export function buildSlackMcpSetupSuggestionText(
             ? `<${settingsUrl}|finish connecting ${serviceName}>`
             : `<${settingsUrl}|link your ${serviceName} account>`;
 
-  return `That looks like a ${serviceName} link. I don't have ${serviceName} access yet, so I'll work without it — ${action} if you want me to be able to use it.`;
+  return `That looks like a ${serviceName} link. I don't have ${serviceName} access yet — ${action} if you want me to be able to use it.`;
 }
 
 export function buildSlackMcpSetupSuggestionBlocks(

--- a/packages/slack/src/start-auto-routed-slack-task.ts
+++ b/packages/slack/src/start-auto-routed-slack-task.ts
@@ -496,26 +496,9 @@ export async function startAutoRoutedSlackTask({
       threadMessages?.map((message) => message.ts) ?? [],
     );
 
-    const postSetupSuggestion = async () => {
-      if (!setupSuggestion) {
-        return;
-      }
-
-      const suggestionTs = await postSlackMcpSetupSuggestion({
-        slack,
-        channel,
-        threadId,
-        suggestion: setupSuggestion,
-      });
-
-      if (suggestionTs) {
-        deliveryTracker?.track(suggestionTs);
-      }
-    };
-
+    // Follow-ups that reuse an active run skip the suggestion so repeated
+    // messages with the same link don't stack identical nudges.
     if (taskRun.reusedExistingRun) {
-      await postSetupSuggestion();
-
       return {
         status: 'started',
         threadId,
@@ -551,7 +534,18 @@ export async function startAutoRoutedSlackTask({
       slack,
     });
 
-    await postSetupSuggestion();
+    if (setupSuggestion) {
+      const suggestionTs = await postSlackMcpSetupSuggestion({
+        slack,
+        channel,
+        threadId,
+        suggestion: setupSuggestion,
+      });
+
+      if (suggestionTs) {
+        deliveryTracker.track(suggestionTs);
+      }
+    }
 
     return {
       status: 'started',

--- a/packages/slack/src/start-auto-routed-slack-task.ts
+++ b/packages/slack/src/start-auto-routed-slack-task.ts
@@ -23,12 +23,14 @@ import {
   getTaskUrl,
   routeTask,
   type RoutingResult,
+  type SlackMcpSetupRequirement,
 } from '@roomote/cloud-agents/server';
 
 import {
   mapRoutingWorkspaceToSelectionValue,
   resolveWorkspace,
 } from './block-kit';
+import { postSlackMcpSetupSuggestion } from './mcp-setup-suggestion';
 import { finishRoutedStart } from './started-message';
 import { SlackNotifier } from './slack-notifier';
 import { getPromptReadyThreadMessages } from './prompt-ready-thread-messages';
@@ -45,7 +47,6 @@ type SlackTaskStartFailureCode =
   | 'source_message_missing'
   | 'source_message_inaccessible'
   | 'launch_message_failed'
-  | 'mcp_setup_required'
   | 'routing_fallback'
   | 'workspace_unavailable';
 
@@ -143,7 +144,7 @@ export async function startAutoRoutedSlackTask({
   harness,
   model,
   reasoningEffort,
-  skipMcpSetupInterrupt = false,
+  skipMcpSetupSuggestion = false,
   channelAutoStartLaunchMode:
     _channelAutoStartLaunchMode = DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
 }: {
@@ -186,7 +187,7 @@ export async function startAutoRoutedSlackTask({
   harness?: string;
   model?: string;
   reasoningEffort?: ReasoningEffort;
-  skipMcpSetupInterrupt?: boolean;
+  skipMcpSetupSuggestion?: boolean;
   channelAutoStartLaunchMode?: ChannelAutoStartLaunchMode;
 }): Promise<StartAutoRoutedSlackTaskResult> {
   let threadId = threadTs ?? '';
@@ -233,23 +234,21 @@ export async function startAutoRoutedSlackTask({
       await slack.normalizeIncomingText(stripLeadingRawSlackMention(prompt)),
     );
 
-    if (!skipMcpSetupInterrupt && launchUserId) {
-      const setupRequirement = await detectSlackMcpSetupRequirement(
-        taskDescription,
-        {
-          userId: launchUserId,
-          apiBaseUrl: Env.R_APP_URL,
-        },
-      );
+    // Missing MCP setup never blocks the launch; when the message links to a
+    // service without a usable connection, a small suggestion is posted after
+    // the task starts instead.
+    let setupSuggestion: SlackMcpSetupRequirement | null = null;
 
-      if (setupRequirement) {
-        return {
-          status: 'not_started',
-          code: 'mcp_setup_required',
-          threadId,
-          message: `Task was not started because ${setupRequirement.serviceName} still needs Slack MCP setup.`,
-        };
-      }
+    if (!skipMcpSetupSuggestion && launchUserId) {
+      setupSuggestion = await detectSlackMcpSetupRequirement(taskDescription, {
+        userId: launchUserId,
+        apiBaseUrl: Env.R_APP_URL,
+      }).catch((error) => {
+        console.warn(
+          `[startAutoRoutedSlackTask] MCP setup detection failed for ${channel}:${threadId}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        return null;
+      });
     }
 
     let threadMessages: SlackThreadMessage[] | undefined;
@@ -497,7 +496,26 @@ export async function startAutoRoutedSlackTask({
       threadMessages?.map((message) => message.ts) ?? [],
     );
 
+    const postSetupSuggestion = async () => {
+      if (!setupSuggestion) {
+        return;
+      }
+
+      const suggestionTs = await postSlackMcpSetupSuggestion({
+        slack,
+        channel,
+        threadId,
+        suggestion: setupSuggestion,
+      });
+
+      if (suggestionTs) {
+        deliveryTracker?.track(suggestionTs);
+      }
+    };
+
     if (taskRun.reusedExistingRun) {
+      await postSetupSuggestion();
+
       return {
         status: 'started',
         threadId,
@@ -532,6 +550,8 @@ export async function startAutoRoutedSlackTask({
       routingDebug: decision.result.debug,
       slack,
     });
+
+    await postSetupSuggestion();
 
     return {
       status: 'started',


### PR DESCRIPTION
## Problem

When a Slack message linked to a service whose MCP integration wasn't set up (Zero, Linear, Vercel, ...), Roomote refused to start the task:

- The **@mention path** posted a blocking Configure / "Nah, keep going" prompt and waited.
- The **channel auto-start path** returned a bare *"Task was not started because Zero still needs Slack MCP setup."* with no buttons, no settings link, and no way to proceed — follow-ups like "Please do it tho" went into a void.

Real-world trigger: a request to grab a favicon from zero.xyz was blocked because the URL matched the Zero integration's domain, even though the task didn't need Zero's MCP at all.

## Change

The task now **always starts**. Detection still runs, but surfaces as a small context-block reply in the thread — *"That looks like a Zero link. I don't have Zero access yet — link your Zero account if you want me to be able to use it."* — posted after the task launches (auto-start path) or once routing decides a task flow is proceeding (mention path). The manager-channel notification is preserved.

Details:
- Suggestion never posts on pure Q&A platform answers, and never repeats when a follow-up reuses an active run.
- Detection or posting failures are swallowed and can never affect the launch.
- Removed the now-unused interrupt machinery: Redis pending-interrupt state + nonce-claim Lua, `mcp_setup_configure` / `mcp_setup_ignore` interactive handlers, resume-after-setup flow, the `mcp_setup_required` failure code, and the pending-interrupt follow-up eligibility in message entry.

## Testing

- `packages/slack` full suite: 287 passed (new suites for the suggestion flow, copy variants, reused-run suppression, platform-answer suppression, post-failure resilience).
- `apps/api` Slack handler suites: 94 passed.
- `tsc --noEmit` clean on both workspaces; prettier/eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)