### PR TITLE
[Fix] Scope Zero MCP link detection to product surfaces

### DIFF
--- a/.docker/caddy/Caddyfile
+++ b/.docker/caddy/Caddyfile
@@ -25,7 +25,7 @@
 
 	handle @api {
 		uri strip_prefix /_roomote-api
-		reverse_proxy host.docker.internal:13101 {
+		reverse_proxy host.docker.internal:13001 {
 			lb_try_duration 10s
 			lb_try_interval 250ms
 		}
@@ -48,7 +48,7 @@
 	}
 
 	handle {
-		reverse_proxy host.docker.internal:13100 {
+		reverse_proxy host.docker.internal:13000 {
 			lb_try_duration 10s
 			lb_try_interval 250ms
 		}

--- a/.docker/caddy/Caddyfile
+++ b/.docker/caddy/Caddyfile
@@ -25,7 +25,7 @@
 
 	handle @api {
 		uri strip_prefix /_roomote-api
-		reverse_proxy host.docker.internal:13001 {
+		reverse_proxy host.docker.internal:13101 {
 			lb_try_duration 10s
 			lb_try_interval 250ms
 		}
@@ -48,7 +48,7 @@
 	}
 
 	handle {
-		reverse_proxy host.docker.internal:13000 {
+		reverse_proxy host.docker.internal:13100 {
 			lb_try_duration 10s
 			lb_try_interval 250ms
 		}

--- a/packages/cloud-agents/src/server/router/__tests__/slack-mcp-setup-matching.test.ts
+++ b/packages/cloud-agents/src/server/router/__tests__/slack-mcp-setup-matching.test.ts
@@ -1,0 +1,87 @@
+vi.mock('@roomote/db/server', () => ({
+  and: vi.fn(),
+  db: {},
+  eq: vi.fn(),
+  isNull: vi.fn(),
+  mcpConnections: {},
+  deploymentMcpEnablements: {},
+}));
+
+import {
+  extractUrlsFromSlackText,
+  matchSlackMcpSetupService,
+} from '../slack-mcp-setup';
+
+function matchServiceIdForUrl(url: string): string | null {
+  const [extracted] = extractUrlsFromSlackText(url);
+
+  if (!extracted) {
+    return null;
+  }
+
+  return matchSlackMcpSetupService(extracted)?.id ?? null;
+}
+
+describe('matchSlackMcpSetupService', () => {
+  describe('zero', () => {
+    it.each([
+      'https://zero.xyz/c/stablephone-call-9dc16e0e',
+      'https://www.zero.xyz/c/some-capability',
+      'https://zero.xyz/browse',
+      'https://zero.xyz/browse/audio',
+      'https://www.zero.xyz/profile',
+      'https://zero.xyz/profile/wallet',
+      'https://mcp.zero.xyz',
+      'https://mcp.zero.xyz/anything',
+    ])('matches the Zero product surface %s', (url) => {
+      expect(matchServiceIdForUrl(url)).toBe('zero');
+    });
+
+    it.each([
+      'https://www.zero.xyz/',
+      'https://zero.xyz',
+      'https://zero.xyz/faq',
+      'https://zero.xyz/security',
+      'https://zero.xyz/getlisted',
+      'https://zero.xyz/terms-of-service',
+      'https://zero.xyz/SKILL.md',
+      'https://zero.xyz/browsers',
+      'https://zero.xyz/customers',
+      'https://withzero.ai/',
+    ])('does not match the marketing surface %s', (url) => {
+      expect(matchServiceIdForUrl(url)).toBeNull();
+    });
+  });
+
+  describe('other services stay unaffected', () => {
+    it.each([
+      ['https://linear.app/acme/issue/OPS-123', 'linear'],
+      ['https://www.notion.so/acme/spec-123', 'notion'],
+      ['https://acme.atlassian.net/browse/OPS-1', 'jira'],
+      ['https://my-app.vercel.app/anything', 'vercel'],
+      ['https://vercel.com/acme-team/my-app', 'vercel'],
+    ])('matches %s to %s', (url, serviceId) => {
+      expect(matchServiceIdForUrl(url)).toBe(serviceId);
+    });
+
+    it.each(['https://vercel.com/pricing', 'https://example.com/zero.xyz'])(
+      'does not match %s',
+      (url) => {
+        expect(matchServiceIdForUrl(url)).toBeNull();
+      },
+    );
+  });
+});
+
+describe('extractUrlsFromSlackText', () => {
+  it('extracts plain and Slack-formatted URLs with normalized host and path', () => {
+    const urls = extractUrlsFromSlackText(
+      'grab the favicon from https://www.zero.xyz/ and check [Zero](https://zero.xyz/c/ABC).',
+    );
+
+    expect(urls).toEqual([
+      expect.objectContaining({ hostname: 'www.zero.xyz', pathname: '/' }),
+      expect.objectContaining({ hostname: 'zero.xyz', pathname: '/c/abc' }),
+    ]);
+  });
+});

--- a/packages/cloud-agents/src/server/router/__tests__/slack-mcp-setup-matching.test.ts
+++ b/packages/cloud-agents/src/server/router/__tests__/slack-mcp-setup-matching.test.ts
@@ -33,13 +33,14 @@ describe('matchSlackMcpSetupService', () => {
       'https://zero.xyz/profile/wallet',
       'https://mcp.zero.xyz',
       'https://mcp.zero.xyz/anything',
-    ])('matches the Zero product surface %s', (url) => {
+      'https://www.zero.xyz/',
+      'https://zero.xyz',
+      'https://withzero.ai/',
+    ])('matches the Zero product surface or homepage %s', (url) => {
       expect(matchServiceIdForUrl(url)).toBe('zero');
     });
 
     it.each([
-      'https://www.zero.xyz/',
-      'https://zero.xyz',
       'https://zero.xyz/faq',
       'https://zero.xyz/security',
       'https://zero.xyz/getlisted',
@@ -47,8 +48,8 @@ describe('matchSlackMcpSetupService', () => {
       'https://zero.xyz/SKILL.md',
       'https://zero.xyz/browsers',
       'https://zero.xyz/customers',
-      'https://withzero.ai/',
-    ])('does not match the marketing surface %s', (url) => {
+      'https://withzero.ai/pricing',
+    ])('does not match the deep marketing page %s', (url) => {
       expect(matchServiceIdForUrl(url)).toBeNull();
     });
   });

--- a/packages/types/src/mcp-service-detection.ts
+++ b/packages/types/src/mcp-service-detection.ts
@@ -72,6 +72,10 @@ const VERCEL_PROJECT_TAB_PATH_REGEX = new RegExp(
   `^/(?!(?:${VERCEL_PUBLIC_SITE_ROOT_SEGMENT_PATTERN})(?:/|$))[^/]+/[^/]+/(?:analytics|deployments|domains|functions|logs|observability|settings|storage|usage)(?:/|$)`,
 );
 
+// Zero product surfaces: capability pages (/c/<id>), the service directory
+// (/browse), and the wallet/profile page. The rest of zero.xyz is marketing.
+const ZERO_APP_PATH_REGEX = /^\/(?:c|browse|profile)(?:\/|$)/;
+
 export const SLACK_MCP_SETUP_SERVICES: SlackMcpSetupServiceDefinition[] = [
   {
     id: 'asana',
@@ -221,7 +225,16 @@ export const SLACK_MCP_SETUP_SERVICES: SlackMcpSetupServiceDefinition[] = [
     id: 'zero',
     name: 'Zero',
     availabilityKind: 'curated_oauth',
-    hostSuffixes: ['zero.xyz', 'withzero.ai'],
+    hostSuffixes: ['zero.xyz'],
+    hostRules: [
+      {
+        hostSuffix: 'mcp.zero.xyz',
+      },
+      {
+        hostSuffix: 'zero.xyz',
+        pathRegexes: [ZERO_APP_PATH_REGEX],
+      },
+    ],
     deploymentSettingsPath: '/settings/integrations',
     userSettingsPath: '/settings/personal',
   },

--- a/packages/types/src/mcp-service-detection.ts
+++ b/packages/types/src/mcp-service-detection.ts
@@ -73,8 +73,11 @@ const VERCEL_PROJECT_TAB_PATH_REGEX = new RegExp(
 );
 
 // Zero product surfaces: capability pages (/c/<id>), the service directory
-// (/browse), and the wallet/profile page. The rest of zero.xyz is marketing.
+// (/browse), and the wallet/profile page. The bare homepage also matches — a
+// pasted zero.xyz root link still reads as "about Zero" — but deep marketing
+// pages (/faq, /security, /getlisted, ...) do not.
 const ZERO_APP_PATH_REGEX = /^\/(?:c|browse|profile)(?:\/|$)/;
+const HOMEPAGE_PATH_REGEX = /^\/$/;
 
 export const SLACK_MCP_SETUP_SERVICES: SlackMcpSetupServiceDefinition[] = [
   {
@@ -225,14 +228,18 @@ export const SLACK_MCP_SETUP_SERVICES: SlackMcpSetupServiceDefinition[] = [
     id: 'zero',
     name: 'Zero',
     availabilityKind: 'curated_oauth',
-    hostSuffixes: ['zero.xyz'],
+    hostSuffixes: ['zero.xyz', 'withzero.ai'],
     hostRules: [
       {
         hostSuffix: 'mcp.zero.xyz',
       },
       {
         hostSuffix: 'zero.xyz',
-        pathRegexes: [ZERO_APP_PATH_REGEX],
+        pathRegexes: [HOMEPAGE_PATH_REGEX, ZERO_APP_PATH_REGEX],
+      },
+      {
+        hostSuffix: 'withzero.ai',
+        pathRegexes: [HOMEPAGE_PATH_REGEX],
       },
     ],
     deploymentSettingsPath: '/settings/integrations',


### PR DESCRIPTION
## Problem

The Zero entry in the Slack MCP setup detection catalog matched **any** URL on `zero.xyz` or `withzero.ai` — no path or host rules. Casual mentions of marketing pages triggered setup detection (originally a hard block; a stray suggestion since #282).

## Change

Following the Vercel entry's `hostRules` pattern, Zero now matches its product surfaces plus the bare homepage:

| URL | Matches? |
|---|---|
| `zero.xyz/c/<capability-id>` | ✅ capability pages |
| `zero.xyz/browse[/...]` | ✅ service directory |
| `zero.xyz/profile[/...]` | ✅ wallet/funding |
| `mcp.zero.xyz/...` | ✅ MCP connector host |
| `zero.xyz/` and `withzero.ai/` homepages | ✅ still a clear "about Zero" signal |
| `/faq`, `/security`, `/getlisted`, `/terms-of-service`, `/SKILL.md` | ❌ deep marketing pages |

URL structure verified against zero.xyz's live nav and the checked-in Zero skill (which references `www.zero.xyz/profile` for funding and `mcp.zero.xyz` for auth).

## Testing

- New test file `slack-mcp-setup-matching.test.ts` — first direct coverage of `extractUrlsFromSlackText` + `matchSlackMcpSetupService`: 27 cases covering the Zero product/homepage/marketing split and regression checks for Linear/Notion/Jira/Vercel matching.
- `@roomote/types` full suite (529 passed), worker zero-gating tests, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)