### PR TITLE
Surface-scope automation tracked messages and add button parity

### DIFF
--- a/apps/api/src/handlers/github/handleWorkflowRunCompleted.ts
+++ b/apps/api/src/handlers/github/handleWorkflowRunCompleted.ts
@@ -283,6 +283,7 @@ export async function handleWorkflowRunCompleted(
     // replies feed the automation's feedback context.
     try {
       await upsertBackgroundAutomationSlackThread(db, {
+        surface: 'slack',
         automationKey: 'ci_failure_triage',
         slackChannelId: channelId,
         threadTs: announcementTs,

--- a/apps/api/src/handlers/mcp/slack.ts
+++ b/apps/api/src/handlers/mcp/slack.ts
@@ -451,6 +451,7 @@ async function refreshTrackedAutomationThreadRootFooter(params: {
   // stamp (tasks.initiator_automation).
   const [trackedThread, boundTask] = await Promise.all([
     findBackgroundAutomationSlackThread({
+      surface: 'slack',
       slackChannelId: params.channel,
       threadTs: params.threadTs,
     }),

--- a/apps/api/src/handlers/slack/helpers/conversation-log.ts
+++ b/apps/api/src/handlers/slack/helpers/conversation-log.ts
@@ -111,6 +111,7 @@ export async function findRoomoteOwnedSlackThread(params: {
   }
 
   const trackedAutomationThread = await findBackgroundAutomationSlackThread({
+    surface: 'slack',
     slackChannelId: params.channelId,
     threadTs: params.threadTs,
   });
@@ -191,6 +192,7 @@ export async function findTrackedBackgroundAutomationSlackThread(params: {
   threadTs: string;
 }) {
   return findBackgroundAutomationSlackThread({
+    surface: 'slack',
     slackChannelId: params.channelId,
     threadTs: params.threadTs,
   });

--- a/apps/api/src/handlers/tasks/automation-work-items/launch.ts
+++ b/apps/api/src/handlers/tasks/automation-work-items/launch.ts
@@ -277,6 +277,7 @@ export async function launchActWorkItems(params: {
         linkedTaskId
       ) {
         await updateBackgroundAutomationSlackThreadMetadata(db, {
+          surface: 'slack',
           slackChannelId: params.chatTarget.channelId,
           threadTs: params.chatTarget.threadTs,
           metadata: {

--- a/apps/api/src/handlers/tasks/automation-work-items/slack.ts
+++ b/apps/api/src/handlers/tasks/automation-work-items/slack.ts
@@ -133,6 +133,7 @@ export async function bindLateSlackThreadToTask(params: {
     }
 
     await upsertBackgroundAutomationSlackThread(tx, {
+      surface: 'slack',
       automationKey: automationWorkItem.automationKey,
       slackChannelId: params.channelId,
       threadTs: params.threadTs,

--- a/apps/api/src/handlers/tasks/submitTaskSuggestions.ts
+++ b/apps/api/src/handlers/tasks/submitTaskSuggestions.ts
@@ -1017,6 +1017,7 @@ async function postSuggestedTasksSummaryToSlack(params: {
 
     if (postResult && shouldTrackAutomationThread) {
       await upsertBackgroundAutomationSlackThread(tx, {
+        surface: 'slack',
         automationKey: slackConfig.automationKey,
         slackChannelId: channel.channelId,
         threadTs: postResult.rootMessageTs,

--- a/packages/communication/src/__tests__/teams-provider.test.ts
+++ b/packages/communication/src/__tests__/teams-provider.test.ts
@@ -92,6 +92,81 @@ describe('TeamsCommunicationProvider', () => {
     );
   });
 
+  it('degrades link buttons to trailing markdown links and drops callback buttons', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          access_token: 'bot-token',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: 'activity-response' }));
+    const provider = new TeamsCommunicationProvider({
+      appId: 'bot-app-id',
+      appPassword: 'bot-secret',
+      tokenEndpoint: 'https://login.example.test/token',
+      fetch: fetchMock as typeof fetch,
+    });
+
+    await provider.postMessage({
+      channelId: '19:conversation@thread.v2',
+      text: 'root summary',
+      textFormat: 'markdown',
+      serviceUrl: 'https://smba.trafficmanager.net/amer/',
+      buttons: [
+        [
+          { text: 'Go to task', url: 'https://app.example.com/task/1' },
+          { text: 'Retry', callbackData: 'retry' },
+        ],
+      ],
+    });
+
+    const activityBody = JSON.parse(
+      fetchMock.mock.calls[1]?.[1]?.body as string,
+    );
+    expect(activityBody.text).toBe(
+      'root summary\n\n[Go to task](https://app.example.com/task/1)',
+    );
+    expect(activityBody.textFormat).toBe('markdown');
+  });
+
+  it('degrades link buttons to label: url lines for non-markdown messages', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          access_token: 'bot-token',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: 'activity-response' }));
+    const provider = new TeamsCommunicationProvider({
+      appId: 'bot-app-id',
+      appPassword: 'bot-secret',
+      tokenEndpoint: 'https://login.example.test/token',
+      fetch: fetchMock as typeof fetch,
+    });
+
+    await provider.postMessage({
+      channelId: '19:conversation@thread.v2',
+      text: 'root summary',
+      serviceUrl: 'https://smba.trafficmanager.net/amer/',
+      buttons: [
+        [{ text: 'Go to task', url: 'https://app.example.com/task/1' }],
+      ],
+    });
+
+    const activityBody = JSON.parse(
+      fetchMock.mock.calls[1]?.[1]?.body as string,
+    );
+    expect(activityBody.text).toBe(
+      'root summary\n\nGo to task: https://app.example.com/task/1',
+    );
+  });
+
   it('requires a serviceUrl for outbound Teams messages', async () => {
     const provider = new TeamsCommunicationProvider({
       appId: 'bot-app-id',

--- a/packages/communication/src/teams-provider.ts
+++ b/packages/communication/src/teams-provider.ts
@@ -115,6 +115,35 @@ function toPromptImageDataUrl(input: {
     : null;
 }
 
+/**
+ * Teams has no validated outbound card renderer here, so generic message
+ * buttons degrade to trailing links: markdown links for markdown messages,
+ * `label: url` lines otherwise. Callback buttons have no Teams handler and
+ * are dropped.
+ */
+function appendTeamsButtonLinks(
+  input: CommunicationPostMessageInput,
+): string | undefined {
+  const linkButtons = (input.buttons ?? [])
+    .flat()
+    .filter((button): button is { text: string; url: string } =>
+      Boolean(button.url),
+    );
+
+  if (linkButtons.length === 0) {
+    return input.text;
+  }
+
+  const links =
+    input.textFormat === 'markdown'
+      ? linkButtons
+          .map((button) => `[${button.text}](${button.url})`)
+          .join(' · ')
+      : linkButtons.map((button) => `${button.text}: ${button.url}`).join('\n');
+
+  return input.text ? `${input.text}\n\n${links}` : links;
+}
+
 export class TeamsCommunicationProvider implements CommunicationProviderAdapter {
   readonly provider = 'teams' as const;
 
@@ -148,11 +177,12 @@ export class TeamsCommunicationProvider implements CommunicationProviderAdapter 
         name: image.altText,
       })) ?? [];
     const attachments = [...(input.attachments ?? []), ...imageAttachments];
+    const text = appendTeamsButtonLinks(input);
 
     const result = await this.client.sendActivity({
       serviceUrl,
       conversationId: input.channelId,
-      ...(input.text !== undefined ? { text: input.text } : {}),
+      ...(text !== undefined ? { text } : {}),
       ...(input.textFormat ? { textFormat: input.textFormat } : {}),
       ...((input.replyToMessageId ?? input.threadId)
         ? { replyToActivityId: input.replyToMessageId ?? input.threadId }

--- a/packages/db/src/lib/background-automation-slack-threads.ts
+++ b/packages/db/src/lib/background-automation-slack-threads.ts
@@ -2,7 +2,10 @@ import { and, desc, eq, gte, inArray } from 'drizzle-orm';
 
 import { type DatabaseOrTransaction, db } from '../db';
 import { slackConversationMessages, trackedMessages } from '../schema';
-import type { BackgroundAutomationKey } from '@roomote/types';
+import type {
+  BackgroundAutomationKey,
+  TrackedMessageSurface,
+} from '@roomote/types';
 
 export type BackgroundAutomationThreadFeedback = {
   threadTs: string;
@@ -12,7 +15,7 @@ export type BackgroundAutomationThreadFeedback = {
 };
 
 /**
- * Automation Slack root threads are tracked_messages rows of kind
+ * Automation root threads are tracked_messages rows of kind
  * 'automation_thread', deduped on `${channelId}:${threadTs}`.
  */
 function automationThreadDedupeKey(params: {
@@ -25,6 +28,7 @@ function automationThreadDedupeKey(params: {
 export async function upsertBackgroundAutomationSlackThread(
   tx: DatabaseOrTransaction,
   params: {
+    surface: TrackedMessageSurface;
     automationKey: BackgroundAutomationKey;
     slackChannelId: string;
     threadTs: string;
@@ -39,7 +43,7 @@ export async function upsertBackgroundAutomationSlackThread(
   await tx
     .insert(trackedMessages)
     .values({
-      surface: 'slack',
+      surface: params.surface,
       kind: 'automation_thread',
       dedupeKey,
       channelId: params.slackChannelId,
@@ -93,11 +97,13 @@ function toBackgroundAutomationSlackThreadRow(row: {
 }
 
 export async function findBackgroundAutomationSlackThread(params: {
+  surface: TrackedMessageSurface;
   slackChannelId: string;
   threadTs: string;
 }): Promise<BackgroundAutomationSlackThreadRow | undefined> {
   const row = await db.query.trackedMessages.findFirst({
     where: and(
+      eq(trackedMessages.surface, params.surface),
       eq(trackedMessages.kind, 'automation_thread'),
       eq(trackedMessages.dedupeKey, automationThreadDedupeKey(params)),
     ),
@@ -118,6 +124,7 @@ export async function findBackgroundAutomationSlackThread(params: {
 export async function updateBackgroundAutomationSlackThreadMetadata(
   tx: DatabaseOrTransaction,
   params: {
+    surface: TrackedMessageSurface;
     slackChannelId: string;
     threadTs: string;
     metadata: Record<string, unknown>;
@@ -132,6 +139,7 @@ export async function updateBackgroundAutomationSlackThreadMetadata(
     .from(trackedMessages)
     .where(
       and(
+        eq(trackedMessages.surface, params.surface),
         eq(trackedMessages.kind, 'automation_thread'),
         eq(trackedMessages.dedupeKey, dedupeKey),
       ),
@@ -153,6 +161,7 @@ export async function updateBackgroundAutomationSlackThreadMetadata(
     })
     .where(
       and(
+        eq(trackedMessages.surface, params.surface),
         eq(trackedMessages.kind, 'automation_thread'),
         eq(trackedMessages.dedupeKey, dedupeKey),
       ),
@@ -162,6 +171,7 @@ export async function updateBackgroundAutomationSlackThreadMetadata(
 }
 
 export async function listRecentBackgroundAutomationThreadFeedback(params: {
+  surface: TrackedMessageSurface;
   automationKey: BackgroundAutomationKey;
   slackChannelId: string;
   since?: Date;
@@ -176,6 +186,7 @@ export async function listRecentBackgroundAutomationThreadFeedback(params: {
     .from(trackedMessages)
     .where(
       and(
+        eq(trackedMessages.surface, params.surface),
         eq(trackedMessages.kind, 'automation_thread'),
         eq(trackedMessages.automationKey, params.automationKey),
         eq(trackedMessages.channelId, params.slackChannelId),
@@ -193,6 +204,9 @@ export async function listRecentBackgroundAutomationThreadFeedback(params: {
     return [];
   }
 
+  // Reply harvesting reads the persisted Slack conversation log, so threads
+  // tracked on other surfaces resolve with empty feedbackMessages until those
+  // surfaces get an equivalent reply source.
   const feedbackRows = await db
     .select({
       threadTs: slackConversationMessages.threadTs,

--- a/packages/sdk/src/server/automations/announcer.ts
+++ b/packages/sdk/src/server/automations/announcer.ts
@@ -332,6 +332,7 @@ export async function announcerJob(
       }
 
       await upsertBackgroundAutomationSlackThread(db, {
+        surface: 'slack',
         automationKey: 'announcer',
         slackChannelId: channelId,
         threadTs: ts,

--- a/packages/sdk/src/server/automations/automation-thread-feedback.ts
+++ b/packages/sdk/src/server/automations/automation-thread-feedback.ts
@@ -111,6 +111,7 @@ async function loadAutomationThreadFeedbackEntries(params: {
   );
 
   return listRecentBackgroundAutomationThreadFeedback({
+    surface: 'slack',
     automationKey: params.automationKey,
     slackChannelId: params.slackChannelId,
     since,

--- a/packages/slack/src/__tests__/communication-provider.test.ts
+++ b/packages/slack/src/__tests__/communication-provider.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { SlackCommunicationProvider } from '../communication-provider';
+import type { SlackNotifier } from '../slack-notifier';
+
+function buildProvider(postMessageMock: ReturnType<typeof vi.fn>) {
+  return new SlackCommunicationProvider({
+    postMessage: postMessageMock,
+  } as unknown as SlackNotifier);
+}
+
+describe('SlackCommunicationProvider.postMessage', () => {
+  it('posts plain text without synthesizing blocks', async () => {
+    const postMessageMock = vi.fn().mockResolvedValue('111.222');
+
+    await expect(
+      buildProvider(postMessageMock).postMessage({
+        channelId: 'C123',
+        text: 'hello',
+      }),
+    ).resolves.toEqual({
+      provider: 'slack',
+      channelId: 'C123',
+      messageId: '111.222',
+    });
+
+    expect(postMessageMock).toHaveBeenCalledWith({
+      channel: 'C123',
+      text: 'hello',
+      unfurl_links: false,
+      unfurl_media: false,
+    });
+  });
+
+  it('renders link buttons as an actions block and keeps the body visible', async () => {
+    const postMessageMock = vi.fn().mockResolvedValue('111.222');
+
+    await buildProvider(postMessageMock).postMessage({
+      channelId: 'C123',
+      text: 'root summary',
+      buttons: [
+        [
+          { text: 'Go to task', url: 'https://app.example.com/task/1' },
+          { text: 'Retry', callbackData: 'retry' },
+        ],
+      ],
+    });
+
+    expect(postMessageMock).toHaveBeenCalledWith({
+      channel: 'C123',
+      text: 'root summary',
+      blocks: [
+        {
+          type: 'section',
+          text: { type: 'mrkdwn', text: 'root summary' },
+        },
+        {
+          type: 'actions',
+          elements: [
+            {
+              type: 'button',
+              action_id: 'communication_link_button_0',
+              text: { type: 'plain_text', text: 'Go to task', emoji: false },
+              url: 'https://app.example.com/task/1',
+            },
+          ],
+        },
+      ],
+      unfurl_links: false,
+      unfurl_media: false,
+    });
+  });
+
+  it('ignores callback-only buttons entirely', async () => {
+    const postMessageMock = vi.fn().mockResolvedValue('111.222');
+
+    await buildProvider(postMessageMock).postMessage({
+      channelId: 'C123',
+      text: 'hello',
+      buttons: [[{ text: 'Retry', callbackData: 'retry' }]],
+    });
+
+    expect(postMessageMock).toHaveBeenCalledWith({
+      channel: 'C123',
+      text: 'hello',
+      unfurl_links: false,
+      unfurl_media: false,
+    });
+  });
+
+  it('appends the actions block after caller-provided blocks without wrapping text', async () => {
+    const postMessageMock = vi.fn().mockResolvedValue('111.222');
+    const callerBlock = { type: 'section', text: { type: 'mrkdwn', text: 'x' } };
+
+    await buildProvider(postMessageMock).postMessage({
+      channelId: 'C123',
+      text: 'fallback',
+      blocks: [callerBlock],
+      buttons: [[{ text: 'Open', url: 'https://example.com' }]],
+    });
+
+    const call = postMessageMock.mock.calls[0]?.[0];
+    expect(call.blocks[0]).toBe(callerBlock);
+    expect(call.blocks[1]).toMatchObject({ type: 'actions' });
+    expect(call.blocks).toHaveLength(2);
+  });
+
+  it('throws when Slack returns no message timestamp', async () => {
+    const postMessageMock = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      buildProvider(postMessageMock).postMessage({
+        channelId: 'C123',
+        text: 'hello',
+      }),
+    ).rejects.toThrow('Slack chat.postMessage returned no message timestamp');
+  });
+});

--- a/packages/slack/src/__tests__/communication-provider.test.ts
+++ b/packages/slack/src/__tests__/communication-provider.test.ts
@@ -90,7 +90,10 @@ describe('SlackCommunicationProvider.postMessage', () => {
 
   it('appends the actions block after caller-provided blocks without wrapping text', async () => {
     const postMessageMock = vi.fn().mockResolvedValue('111.222');
-    const callerBlock = { type: 'section', text: { type: 'mrkdwn', text: 'x' } };
+    const callerBlock = {
+      type: 'section',
+      text: { type: 'mrkdwn', text: 'x' },
+    };
 
     await buildProvider(postMessageMock).postMessage({
       channelId: 'C123',

--- a/packages/slack/src/communication-provider.ts
+++ b/packages/slack/src/communication-provider.ts
@@ -1,6 +1,7 @@
 import type {
   CommunicationChannelMessagesResult,
   CommunicationMessage,
+  CommunicationMessageButton,
   CommunicationPostMessageInput,
   CommunicationPostMessageResult,
   CommunicationProviderAdapter,
@@ -40,6 +41,28 @@ function normalizeSlackMessage(
   };
 }
 
+/**
+ * Renders generic message buttons as one Block Kit actions block. Slack can
+ * only render link buttons generically; callback buttons need a registered
+ * interaction handler, so they are dropped here.
+ */
+function buildSlackButtonActionsBlock(
+  buttons: CommunicationMessageButton[][] | undefined,
+): Record<string, unknown> | null {
+  const elements = (buttons ?? [])
+    .flat()
+    .filter((button) => button.url)
+    .slice(0, 25)
+    .map((button, index) => ({
+      type: 'button',
+      action_id: `communication_link_button_${index}`,
+      text: { type: 'plain_text', text: button.text, emoji: false },
+      url: button.url,
+    }));
+
+  return elements.length > 0 ? { type: 'actions', elements } : null;
+}
+
 export class SlackCommunicationProvider implements CommunicationProviderAdapter {
   readonly provider = 'slack' as const;
 
@@ -54,7 +77,19 @@ export class SlackCommunicationProvider implements CommunicationProviderAdapter 
         image_url: image.url,
         alt_text: image.altText,
       })) ?? [];
-    const blocks = [...(input.blocks ?? []), ...imageBlocks];
+    const actionsBlock = buildSlackButtonActionsBlock(input.buttons);
+    // Once any block is present Slack demotes `text` to notification fallback,
+    // so a text-plus-buttons message keeps its body via a section block.
+    const bodyBlocks =
+      input.blocks ??
+      (actionsBlock && input.text
+        ? [{ type: 'section', text: { type: 'mrkdwn', text: input.text } }]
+        : []);
+    const blocks = [
+      ...bodyBlocks,
+      ...imageBlocks,
+      ...(actionsBlock ? [actionsBlock] : []),
+    ];
     const messageId = await this.slack.postMessage({
       channel: input.channelId,
       ...(input.threadId ? { thread_ts: input.threadId } : {}),


### PR DESCRIPTION
## What

Third PR of the "automations on all comms channels" track (follows #280, #281).

- **Automation tracked messages carry an explicit surface.** `upsertBackgroundAutomationSlackThread` takes a `TrackedMessageSurface`, and every automation-thread lookup (`find`, `updateMetadata`, `listRecentFeedback`) filters on it — so once Teams/Telegram rows exist they can never collide with Slack rows on a shared dedupe key. All nine current call sites pass `'slack'`; zero behavior change today.
- **Generic message buttons render on every adapter.** Slack renders link buttons as a Block Kit actions block (and wraps the text body in a section block so it stays visible once blocks are present); Teams degrades them to trailing links (markdown links, or `label: url` lines for plain text) since there's no validated outbound card renderer; Telegram already rendered inline keyboards. Callback-only buttons are dropped on Slack/Teams because no generic interaction handler exists for them — the automation root footer only uses URL buttons, so this covers the automation use case on all three providers.

## Scope discovery worth knowing

The original plan for this PR included "route the thread-feedback loop through adapter `fetchThreadMessages`". Exploration showed that's the wrong move: the feedback loop deliberately reads the **persisted** Slack conversation log (`slackConversationMessages`), not the live API — no rate limits, works offline. Teams does have Graph-backed live thread reads and Telegram's Bot API can't read history at all (typed `UnsupportedCommunicationOperationError`), so the right per-surface feedback source is a PR-6 decision made against a real Teams validation, not something to guess here. The reply harvest keeps its Slack source with an inline note; non-Slack threads resolve with empty feedback until then.

## Testing

- New Slack adapter test suite (button rendering, section wrapping, callback-button dropping, coordinate result, no-timestamp throw)
- New Teams provider tests for both button degradation modes
- Full local runs green: communication (139), slack (284), db (248), sdk (458), api (897), bullmq (100); lint/types/knip pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)