### PR TITLE
Add automation target model and capability declarations

### DIFF
--- a/apps/api/src/handlers/slack/events/member-joined.ts
+++ b/apps/api/src/handlers/slack/events/member-joined.ts
@@ -54,6 +54,7 @@ async function syncManagerStarterAutomations(params: {
       schedule: { mode: settings.suggesterFrequency },
       instructions: settings.suggesterInstructions ?? null,
       targets: buildStarterAutomationTargets(settings.suggesterSlackChannelId),
+      managedTargetKinds: ['slack_channel'],
       updatedAt,
     }),
     upsertAutomation(db, {
@@ -62,6 +63,7 @@ async function syncManagerStarterAutomations(params: {
       schedule: { mode: settings.announcerFrequency },
       instructions: settings.announcerInstructions ?? null,
       targets: buildStarterAutomationTargets(settings.announcerSlackChannelId),
+      managedTargetKinds: ['slack_channel'],
       updatedAt,
     }),
     upsertAutomation(db, {

--- a/apps/web/src/trpc/commands/automations/settings-update.ts
+++ b/apps/web/src/trpc/commands/automations/settings-update.ts
@@ -791,6 +791,7 @@ export async function updateBackgroundAgentSettingsCommand(
           ...(row.launchCriteria ? { launchCriteria: row.launchCriteria } : {}),
         },
       })),
+      managedTargetKinds: ['slack_channel'],
       updatedAt: now,
     });
 
@@ -799,6 +800,7 @@ export async function updateBackgroundAgentSettingsCommand(
       enabled: effectiveManagerStatsFrequency !== 'off',
       schedule: { mode: effectiveManagerStatsFrequency },
       targets: buildSlackChannelTargets(managerStatsChannelResult.channelId),
+      managedTargetKinds: ['slack_channel'],
       updatedAt: now,
     });
 
@@ -816,6 +818,7 @@ export async function updateBackgroundAgentSettingsCommand(
           }),
         ),
       ],
+      managedTargetKinds: ['slack_channel', 'sentry_project'],
       updatedAt: now,
     });
 
@@ -826,6 +829,7 @@ export async function updateBackgroundAgentSettingsCommand(
       targets: buildSlackChannelTargets(
         dependabotTriageChannelResult.channelId,
       ),
+      managedTargetKinds: ['slack_channel'],
       updatedAt: now,
     });
 
@@ -834,6 +838,7 @@ export async function updateBackgroundAgentSettingsCommand(
       enabled: securityAuditorFrequency !== 'off',
       schedule: { mode: securityAuditorFrequency },
       targets: buildSlackChannelTargets(securityAuditorChannelResult.channelId),
+      managedTargetKinds: ['slack_channel'],
       updatedAt: now,
     });
 
@@ -844,6 +849,7 @@ export async function updateBackgroundAgentSettingsCommand(
       targets: buildSlackChannelTargets(
         codeQualityAuditorChannelResult.channelId,
       ),
+      managedTargetKinds: ['slack_channel'],
       updatedAt: now,
     });
 
@@ -852,6 +858,7 @@ export async function updateBackgroundAgentSettingsCommand(
       enabled: ciFailureTriageFrequency !== 'off',
       schedule: { mode: ciFailureTriageFrequency },
       targets: buildSlackChannelTargets(ciFailureTriageChannelResult.channelId),
+      managedTargetKinds: ['slack_channel'],
       updatedAt: now,
     });
 
@@ -864,6 +871,7 @@ export async function updateBackgroundAgentSettingsCommand(
       instructions: effectiveSuggesterInstructions,
       settings: suggesterAutomationSettings,
       targets: buildSlackChannelTargets(suggesterChannelResult.channelId),
+      managedTargetKinds: ['slack_channel'],
       updatedAt: now,
     });
 
@@ -875,6 +883,7 @@ export async function updateBackgroundAgentSettingsCommand(
       },
       instructions: normalizeOptionalText(input.announcerInstructions),
       targets: buildSlackChannelTargets(announcerChannelResult.channelId),
+      managedTargetKinds: ['slack_channel'],
       updatedAt: now,
     });
 
@@ -882,6 +891,7 @@ export async function updateBackgroundAgentSettingsCommand(
       key: 'platform_issue_alerts',
       enabled: platformIssueChannelResult.channelId != null,
       targets: buildSlackChannelTargets(platformIssueChannelResult.channelId),
+      managedTargetKinds: ['slack_channel'],
       updatedAt: now,
     });
   });

--- a/packages/db/src/lib/__tests__/upsert-automation-targets.test.ts
+++ b/packages/db/src/lib/__tests__/upsert-automation-targets.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { DatabaseOrTransaction } from '../../db';
+import { upsertAutomation } from '../automations';
+import type { AutomationTarget } from '@roomote/types';
+
+function buildFakeTx(existingTargets: AutomationTarget[] | null) {
+  const onConflictDoUpdate = vi.fn(async () => undefined);
+  const values = vi.fn(() => ({ onConflictDoUpdate }));
+  const insert = vi.fn(() => ({ values }));
+  const findFirst = vi.fn(async () =>
+    existingTargets === null ? undefined : { targets: existingTargets },
+  );
+
+  const tx = {
+    insert,
+    query: { automations: { findFirst } },
+  } as unknown as DatabaseOrTransaction;
+
+  return { tx, values, findFirst };
+}
+
+const teamsTarget: AutomationTarget = {
+  provider: 'teams',
+  targetKind: 'teams_channel',
+  externalRef: '19:conversation@thread.v2',
+};
+
+const slackTarget: AutomationTarget = {
+  provider: 'slack',
+  targetKind: 'slack_channel',
+  externalRef: 'C123',
+};
+
+describe('upsertAutomation target preservation', () => {
+  it('preserves targets of unmanaged kinds when managedTargetKinds is set', async () => {
+    const { tx, values } = buildFakeTx([
+      { ...slackTarget, externalRef: 'C_OLD' },
+      teamsTarget,
+    ]);
+
+    await upsertAutomation(tx, {
+      key: 'announcer',
+      enabled: true,
+      targets: [slackTarget],
+      managedTargetKinds: ['slack_channel'],
+    });
+
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targets: [teamsTarget, slackTarget],
+      }),
+    );
+  });
+
+  it('replaces targets wholesale when managedTargetKinds is omitted', async () => {
+    const { tx, values, findFirst } = buildFakeTx([teamsTarget]);
+
+    await upsertAutomation(tx, {
+      key: 'announcer',
+      enabled: true,
+      targets: [slackTarget],
+    });
+
+    expect(findFirst).not.toHaveBeenCalled();
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({ targets: [slackTarget] }),
+    );
+  });
+
+  it('clears managed kinds while preserving others when the new list is empty', async () => {
+    const { tx, values } = buildFakeTx([slackTarget, teamsTarget]);
+
+    await upsertAutomation(tx, {
+      key: 'announcer',
+      enabled: false,
+      targets: [],
+      managedTargetKinds: ['slack_channel'],
+    });
+
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({ targets: [teamsTarget] }),
+    );
+  });
+
+  it('handles a missing existing row', async () => {
+    const { tx, values } = buildFakeTx(null);
+
+    await upsertAutomation(tx, {
+      key: 'announcer',
+      enabled: true,
+      targets: [slackTarget],
+      managedTargetKinds: ['slack_channel'],
+    });
+
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({ targets: [slackTarget] }),
+    );
+  });
+});

--- a/packages/db/src/lib/automations.ts
+++ b/packages/db/src/lib/automations.ts
@@ -375,6 +375,13 @@ export type UpsertAutomationInput = {
   instructions?: string | null;
   settings?: Record<string, unknown>;
   targets?: AutomationTarget[];
+  /**
+   * Target kinds this write fully owns. When set alongside `targets`,
+   * existing targets of OTHER kinds are preserved instead of being replaced
+   * wholesale — so a Slack-only settings save cannot clobber teams/telegram
+   * targets configured elsewhere. Omit to keep full-replacement semantics.
+   */
+  managedTargetKinds?: readonly BackgroundAutomationTargetKind[];
   updatedAt?: Date;
 };
 
@@ -384,6 +391,20 @@ export async function upsertAutomation(
 ): Promise<void> {
   const now = input.updatedAt ?? new Date();
   const schedule = input.enabled ? (input.schedule ?? {}) : {};
+
+  let targets = input.targets;
+  if (input.targets !== undefined && input.managedTargetKinds !== undefined) {
+    const managedKinds = new Set(input.managedTargetKinds);
+    const existing = await tx.query.automations.findFirst({
+      columns: { targets: true },
+      where: eq(automations.key, input.key),
+    });
+    const preserved = (existing?.targets ?? []).filter(
+      (target) => !managedKinds.has(target.targetKind),
+    );
+    targets = [...preserved, ...input.targets];
+  }
+
   const values: typeof automations.$inferInsert = {
     key: input.key,
     internal: isInternalAutomationKey(input.key),
@@ -407,9 +428,9 @@ export async function upsertAutomation(
     set.instructions = input.instructions;
   }
 
-  if (input.targets !== undefined) {
-    values.targets = input.targets;
-    set.targets = input.targets;
+  if (targets !== undefined) {
+    values.targets = targets;
+    set.targets = targets;
   }
 
   await tx.insert(automations).values(values).onConflictDoUpdate({

--- a/packages/types/src/background-agents.ts
+++ b/packages/types/src/background-agents.ts
@@ -124,10 +124,15 @@ export function isBackgroundAutomationKey(
   return (BACKGROUND_AUTOMATION_KEYS as readonly string[]).includes(value);
 }
 
-export type BackgroundAutomationProvider = 'slack' | 'telegram' | 'sentry';
+export type BackgroundAutomationProvider =
+  | 'slack'
+  | 'teams'
+  | 'telegram'
+  | 'sentry';
 
 export type BackgroundAutomationTargetKind =
   | 'slack_channel'
+  | 'teams_channel'
   | 'telegram_chat'
   | 'sentry_project';
 

--- a/packages/types/src/background-automation-registry.ts
+++ b/packages/types/src/background-automation-registry.ts
@@ -11,6 +11,9 @@ import type {
   SentryTriageFrequency,
   SuggesterFrequency,
 } from './background-agents';
+import type { CommunicationProvider } from './communication';
+import { sourceControlProviders } from './source-control';
+import type { SourceControlProvider } from './source-control';
 import type { TaskSuggestionSource } from './task-runs';
 
 export const AUTO_RESPOND_CHANNELS_SETTINGS_HASH = 'auto-respond-channels';
@@ -58,6 +61,20 @@ export type TriggerableBackgroundAutomationDescriptor<
   manualTriggerRequirements: readonly BackgroundAutomationManualTriggerRequirement[];
   /** Whether the automation posts to the shared manager channel by default. */
   usesManagerChannel: boolean;
+  /**
+   * Comms surfaces the automation's shipped runner can report to today.
+   * Empty for automations that report elsewhere (e.g. PR comments). Expanded
+   * per-automation as runners generalize; settings gating and the automations
+   * page read this as the source of truth.
+   */
+  supportedCommunicationProviders: readonly CommunicationProvider[];
+  /**
+   * Source-control providers the automation's shipped runner works with
+   * today. Inherently-GitHub automations (Dependabot, GitHub Actions CI
+   * triage) stay ['github'] by design; others expand as their gates and
+   * scans go provider-neutral.
+   */
+  supportedSourceControlProviders: readonly SourceControlProvider[];
   scheduledSuggestionSource?: TaskSuggestionSource;
 };
 
@@ -109,6 +126,8 @@ export const TRIGGERABLE_BACKGROUND_AUTOMATION_DESCRIPTORS = [
     scheduleModes: CONFLICT_RESOLVER_SCHEDULE_MODES,
     manualTriggerRequirements: ['github', 'repository'],
     usesManagerChannel: false,
+    supportedCommunicationProviders: [],
+    supportedSourceControlProviders: ['github'],
   },
   {
     automationKey: 'suggester',
@@ -118,6 +137,8 @@ export const TRIGGERABLE_BACKGROUND_AUTOMATION_DESCRIPTORS = [
     // Provider-agnostic: suggestion scans work with any synced repository.
     manualTriggerRequirements: ['slack', 'repository'],
     usesManagerChannel: true,
+    supportedCommunicationProviders: ['slack'],
+    supportedSourceControlProviders: sourceControlProviders,
     scheduledSuggestionSource: 'suggest_ideas',
   },
   {
@@ -127,6 +148,8 @@ export const TRIGGERABLE_BACKGROUND_AUTOMATION_DESCRIPTORS = [
     scheduleModes: DAILY_WEEKLY_SCHEDULE_MODES,
     manualTriggerRequirements: ['slack', 'github'],
     usesManagerChannel: true,
+    supportedCommunicationProviders: ['slack'],
+    supportedSourceControlProviders: ['github'],
   },
   {
     automationKey: 'manager_stats',
@@ -135,6 +158,8 @@ export const TRIGGERABLE_BACKGROUND_AUTOMATION_DESCRIPTORS = [
     scheduleModes: MANAGER_STATS_SCHEDULE_MODES,
     manualTriggerRequirements: ['slack', 'github'],
     usesManagerChannel: true,
+    supportedCommunicationProviders: ['slack'],
+    supportedSourceControlProviders: ['github'],
   },
   {
     automationKey: 'sentry_triage',
@@ -143,6 +168,8 @@ export const TRIGGERABLE_BACKGROUND_AUTOMATION_DESCRIPTORS = [
     scheduleModes: DAILY_WEEKLY_SCHEDULE_MODES,
     manualTriggerRequirements: ['slack', 'sentry'],
     usesManagerChannel: true,
+    supportedCommunicationProviders: ['slack'],
+    supportedSourceControlProviders: sourceControlProviders,
     scheduledSuggestionSource: 'sentry_triage',
   },
   {
@@ -152,6 +179,8 @@ export const TRIGGERABLE_BACKGROUND_AUTOMATION_DESCRIPTORS = [
     scheduleModes: DAILY_WEEKLY_SCHEDULE_MODES,
     manualTriggerRequirements: ['slack', 'github', 'repository'],
     usesManagerChannel: true,
+    supportedCommunicationProviders: ['slack'],
+    supportedSourceControlProviders: ['github'],
     scheduledSuggestionSource: 'dependabot_triage',
   },
   {
@@ -161,6 +190,8 @@ export const TRIGGERABLE_BACKGROUND_AUTOMATION_DESCRIPTORS = [
     scheduleModes: HOURLY_AUDIT_SCHEDULE_MODES,
     manualTriggerRequirements: ['slack', 'github', 'repository'],
     usesManagerChannel: true,
+    supportedCommunicationProviders: ['slack'],
+    supportedSourceControlProviders: ['github'],
     scheduledSuggestionSource: 'security_auditor',
   },
   {
@@ -170,6 +201,8 @@ export const TRIGGERABLE_BACKGROUND_AUTOMATION_DESCRIPTORS = [
     scheduleModes: HOURLY_AUDIT_SCHEDULE_MODES,
     manualTriggerRequirements: ['slack', 'github', 'repository'],
     usesManagerChannel: true,
+    supportedCommunicationProviders: ['slack'],
+    supportedSourceControlProviders: ['github'],
     scheduledSuggestionSource: 'code_quality_auditor',
   },
   {
@@ -179,6 +212,8 @@ export const TRIGGERABLE_BACKGROUND_AUTOMATION_DESCRIPTORS = [
     scheduleModes: CI_FAILURE_TRIAGE_SCHEDULE_MODES,
     manualTriggerRequirements: ['slack', 'github', 'repository'],
     usesManagerChannel: true,
+    supportedCommunicationProviders: ['slack'],
+    supportedSourceControlProviders: ['github'],
     scheduledSuggestionSource: 'ci_failure_triage',
   },
 ] as const satisfies readonly TriggerableBackgroundAutomationDescriptor[];


### PR DESCRIPTION
## What

Fifth PR of the "automations on all comms channels" track (follows #280, #281, #284, #285). First PR of the automations side — pure model groundwork, no runner behavior changes.

- **`AutomationTarget` gains Teams**: `provider` union adds `'teams'`, `targetKind` adds `'teams_channel'` (telegram/sentry kinds already existed in the type).
- **Capability declarations on every automation descriptor**: `supportedCommunicationProviders` and `supportedSourceControlProviders` state what each shipped runner supports *today* — everything is `['slack']` comms-wise until the runner rewiring lands, `dependabot_triage`/`ci_failure_triage` stay `['github']` by design (Dependabot and GitHub Actions are GitHub products), and `suggester`/`sentry_triage` are already SCM-agnostic. These are the source of truth the destination gating (next PR) and the automations-page capability matrix (final PR) will read, updated per-automation as runners generalize.
- **Target preservation in the settings writer** — the real behavioral fix here. Every settings save previously rebuilt each automation's `targets` array wholesale from the Slack (+Sentry) inputs, which would silently wipe any Teams/Telegram target the moment one exists. `upsertAutomation` now takes `managedTargetKinds`: a save only replaces the kinds it owns and preserves the rest. All settings-update call sites declare their managed kinds (`slack_channel`, plus `sentry_project` for sentry_triage).

No behavior change for existing Slack/Sentry configurations — preservation only differs once non-Slack targets exist.

## Testing

- New unit tests for the `upsertAutomation` merge (preserve unmanaged kinds, wholesale replacement when unset, clearing managed kinds, missing row)
- Full local runs green: types (529), db (252), sdk (458), web (1947), api (905); lint/types/knip pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)