### PR TITLE
Support Docker Compose and Dockerfile environment projects

### DIFF
--- a/apps/controller/src/compute-providers/__tests__/docker-sandbox-security.test.ts
+++ b/apps/controller/src/compute-providers/__tests__/docker-sandbox-security.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   attachDockerEgressPolicy,
+  buildDockerTaskDaemonResourceArgs,
   buildDockerWorkerResourceArgs,
   cleanupStaleDockerSandboxes,
   getDockerTaskNetworkName,
   isUnsupportedDockerDiskLimitError,
   prepareDockerTaskNetwork,
+  removeDockerSandboxResources,
   restoreDockerStandbyNetworking,
   type DockerCommand,
 } from '../docker-sandbox-security';
@@ -56,6 +58,46 @@ describe('buildDockerWorkerResourceArgs', () => {
         logMaxFiles: 3,
       }),
     ).not.toContain('--storage-opt');
+  });
+});
+
+describe('buildDockerTaskDaemonResourceArgs', () => {
+  it('bounds the daemon without dropping networking capabilities it needs', () => {
+    const args = buildDockerTaskDaemonResourceArgs({
+      cpuLimit: 2,
+      memoryLimit: '4g',
+      pidsLimit: 512,
+      diskLimit: '20g',
+      logMaxSize: '10m',
+      logMaxFiles: 3,
+    });
+
+    expect(args).toContain('--pids-limit');
+    expect(args).not.toContain('--cap-drop');
+    expect(args).not.toContain('--storage-opt');
+  });
+});
+
+describe('removeDockerSandboxResources', () => {
+  it('removes the task Docker daemon and shared workspace volume', async () => {
+    const runDocker = vi.fn<DockerCommand>().mockResolvedValue('');
+
+    await removeDockerSandboxResources(
+      {
+        containerName: 'roomote-worker-42',
+        taskNetwork: 'roomote-task-42',
+      },
+      runDocker,
+    );
+
+    expect(runDocker).toHaveBeenCalledWith(
+      ['rm', '-f', 'roomote-worker-42-docker'],
+      { allowFailure: true },
+    );
+    expect(runDocker).toHaveBeenCalledWith(
+      ['volume', 'rm', '-f', 'roomote-worker-42-workspace'],
+      { allowFailure: true },
+    );
   });
 });
 

--- a/apps/controller/src/compute-providers/__tests__/spawn-daytona-worker.test.ts
+++ b/apps/controller/src/compute-providers/__tests__/spawn-daytona-worker.test.ts
@@ -1,0 +1,134 @@
+import type { TaskRun } from '@roomote/db/server';
+import { TaskPayloadKind } from '@roomote/types';
+
+const mockCreateDaytonaMachine = vi.fn();
+const mockRunCommand = vi.fn();
+const mockRecordMutation = vi.fn();
+const mockCreateComputeProviderClient = vi.fn((_arg?: unknown) => ({
+  runCommand: mockRunCommand,
+}));
+const mockUpdateWhere = vi.fn().mockResolvedValue(undefined);
+const mockUpdateSet = vi.fn(() => ({ where: mockUpdateWhere }));
+const mockDbUpdate = vi.fn(() => ({ set: mockUpdateSet }));
+const mockUpdateTaskRunMachine = vi.fn();
+const mockGetNamedPortsForTaskRun = vi.fn();
+const mockPrimeEnvironmentOidcForMachine = vi.fn();
+
+vi.mock('@roomote/db/server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@roomote/db/server')>();
+
+  return {
+    ...actual,
+    db: {
+      ...actual.db,
+      update: () => mockDbUpdate(),
+    },
+    createComputeProviderMutationEventRecorder: vi.fn(() => mockRecordMutation),
+  };
+});
+
+vi.mock('@roomote/compute-providers', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@roomote/compute-providers')>();
+
+  return {
+    ...actual,
+    createDaytonaMachine: (...args: unknown[]) =>
+      mockCreateDaytonaMachine(...args),
+    createComputeProviderClient: (arg: unknown) =>
+      mockCreateComputeProviderClient(arg),
+    buildComputeProviderMutationDetails: vi.fn(
+      (_context: unknown, details: Record<string, unknown> = {}) => details,
+    ),
+    buildDaytonaWorkerEnv: vi.fn(() => ({ AUTH_TOKEN: 'auth_token' })),
+    cleanupDaytonaInstance: vi.fn(),
+    resolveAuthBypassHeaderName: vi.fn(() => undefined),
+    resolveAuthBypassValue: vi.fn(() => undefined),
+  };
+});
+
+vi.mock('../../utils', () => ({
+  getNamedPortsForTaskRun: (...args: unknown[]) =>
+    mockGetNamedPortsForTaskRun(...args),
+  shouldEnableAuthBypassForTaskRun: vi.fn(() => false),
+  updateTaskRunMachine: (...args: unknown[]) =>
+    mockUpdateTaskRunMachine(...args),
+}));
+
+vi.mock('../../sandbox-oidc', () => ({
+  primeEnvironmentOidcForMachine: (...args: unknown[]) =>
+    mockPrimeEnvironmentOidcForMachine(...args),
+}));
+
+const { spawnDaytonaWorker } = await import('../spawn-daytona-worker');
+
+describe('spawnDaytonaWorker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateDaytonaMachine.mockResolvedValue({
+      machineId: 'daytona-machine-123',
+      domain: vi.fn().mockReturnValue('daytona.example.com'),
+      proxyPorts: {},
+    });
+    mockRunCommand.mockResolvedValue({
+      exitCode: null,
+      commandId: 'cmd_123',
+    });
+    mockUpdateTaskRunMachine.mockResolvedValue(undefined);
+    mockPrimeEnvironmentOidcForMachine.mockResolvedValue(undefined);
+  });
+
+  it('launches environments with container projects', async () => {
+    mockGetNamedPortsForTaskRun.mockResolvedValue({
+      namedPorts: [{ name: 'SANDBOX_SERVER', port: 7777 }],
+      environmentSnapshotId: undefined,
+      environmentConfig: {
+        container_projects: [
+          {
+            name: 'app',
+            type: 'compose',
+            repository: 'test/repo',
+            files: ['compose.yaml'],
+          },
+        ],
+      },
+    });
+
+    const result = await spawnDaytonaWorker(
+      {
+        id: 123,
+        taskId: 'task_123',
+        vendor: 'daytona',
+        sourceSnapshotId: null,
+        payloadKind: TaskPayloadKind.StandardTask,
+        payload: { repo: 'test/repo', environmentId: 'env_123' },
+      } as unknown as TaskRun,
+      'auth_token',
+      {
+        deploymentSlug: 'roomote',
+        daytonaApiKey: 'api-key',
+        daytonaSnapshotName: 'worker-snapshot',
+        daytonaTimeoutMs: 60_000,
+      },
+    );
+
+    expect(mockCreateDaytonaMachine).toHaveBeenCalledWith(
+      expect.objectContaining({
+        daytonaSnapshotName: 'worker-snapshot',
+        launchMode: 'fresh',
+      }),
+    );
+    expect(mockRunCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instanceId: 'daytona-machine-123',
+        cmd: 'worker',
+        args: ['run', '123'],
+        detached: true,
+      }),
+    );
+    expect(result).toEqual({
+      machineId: 'daytona-machine-123',
+      sandboxCmdId: 'cmd_123',
+    });
+  });
+});

--- a/apps/controller/src/compute-providers/__tests__/spawn-docker-worker.test.ts
+++ b/apps/controller/src/compute-providers/__tests__/spawn-docker-worker.test.ts
@@ -5,6 +5,7 @@ import {
   buildDockerSandboxServerUrl,
   getDockerWorkerCommand,
   resolveDockerWorkerOwnershipTargetFromLookup,
+  resumeDockerTaskDaemon,
   shouldRetryDockerWorkerWithoutDiskLimit,
   shouldAutoRemoveDockerWorkerContainer,
   toContainerReachableUrl,
@@ -61,6 +62,19 @@ describe('getDockerWorkerCommand', () => {
       'resume',
     );
     expect(getDockerWorkerCommand(TaskPayloadKind.StandardTask)).toBe('run');
+  });
+});
+
+describe('resumeDockerTaskDaemon', () => {
+  it('tolerates a missing retained daemon container', async () => {
+    const runDocker = vi.fn().mockResolvedValue('');
+
+    await resumeDockerTaskDaemon('roomote-worker-42-docker', runDocker);
+
+    expect(runDocker).toHaveBeenCalledWith(
+      ['start', 'roomote-worker-42-docker'],
+      { allowFailure: true },
+    );
   });
 });
 

--- a/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
+++ b/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
@@ -133,6 +133,46 @@ describe('spawnModalWorker', () => {
     );
   });
 
+  it('uses Modal VM sandboxes for environments with container projects', async () => {
+    mockGetNamedPortsForTaskRun.mockResolvedValue({
+      namedPorts: [{ name: 'SANDBOX_SERVER', port: 7777 }],
+      environmentSnapshotId: undefined,
+      environmentConfig: {
+        container_projects: [
+          {
+            name: 'app',
+            type: 'compose',
+            repository: 'test/repo',
+            files: ['compose.yaml'],
+          },
+        ],
+      },
+    });
+
+    await spawnModalWorker(
+      mockTaskRun({
+        payloadKind: TaskPayloadKind.StandardTask,
+        payload: { repo: 'test/repo', environmentId: 'env_123' },
+      }),
+      'auth_token',
+      {
+        deploymentSlug: 'roomote',
+        modalTokenId: 'token-id',
+        modalTokenSecret: 'token-secret',
+        modalBaseImageRef: 'image-ref',
+        modalTimeoutMs: 60_000,
+      },
+    );
+
+    expect(mockCreateComputeProviderClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'modal',
+        config: expect.objectContaining({ vmRuntime: true }),
+      }),
+    );
+    expect(mockCreateModalMachine).toHaveBeenCalled();
+  });
+
   it('primes environment OIDC before launching a fresh Modal worker when the environment defines OIDC targets', async () => {
     mockGetNamedPortsForTaskRun.mockResolvedValue({
       namedPorts: [{ name: 'SANDBOX_SERVER', port: 7777 }],

--- a/apps/controller/src/compute-providers/docker-sandbox-security.ts
+++ b/apps/controller/src/compute-providers/docker-sandbox-security.ts
@@ -103,6 +103,18 @@ export function getDockerWorkerContainerName(taskRunId: number): string {
   return `${WORKER_CONTAINER_PREFIX}${taskRunId}`;
 }
 
+export function getDockerTaskDaemonContainerName(
+  workerContainerName: string,
+): string {
+  return `${workerContainerName}-docker`;
+}
+
+export function getDockerTaskWorkspaceVolumeName(
+  workerContainerName: string,
+): string {
+  return `${workerContainerName}-workspace`;
+}
+
 export function buildDockerWorkerLabels(params: {
   taskRunId: number;
   autoRemove: boolean;
@@ -143,6 +155,27 @@ export function buildDockerWorkerResourceArgs(
     'NET_ADMIN',
     '--cap-drop',
     'NET_RAW',
+  ];
+}
+
+export function buildDockerTaskDaemonResourceArgs(
+  limits: DockerWorkerResourceLimits,
+): string[] {
+  return [
+    '--cpus',
+    String(limits.cpuLimit),
+    '--memory',
+    limits.memoryLimit,
+    '--memory-swap',
+    limits.memoryLimit,
+    '--pids-limit',
+    String(limits.pidsLimit),
+    '--log-driver',
+    'json-file',
+    '--log-opt',
+    `max-size=${limits.logMaxSize}`,
+    '--log-opt',
+    `max-file=${limits.logMaxFiles}`,
   ];
 }
 
@@ -348,7 +381,20 @@ export async function removeDockerSandboxResources(
     ['rm', '-f', getEgressPolicyHelperContainerName(params.containerName)],
     { allowFailure: true },
   );
+  await runDocker(
+    ['rm', '-f', getDockerTaskDaemonContainerName(params.containerName)],
+    { allowFailure: true },
+  );
   await runDocker(['rm', '-f', params.containerName], { allowFailure: true });
+  await runDocker(
+    [
+      'volume',
+      'rm',
+      '-f',
+      getDockerTaskWorkspaceVolumeName(params.containerName),
+    ],
+    { allowFailure: true },
+  );
   await removeDockerTaskNetwork(params.taskNetwork, runDocker);
 }
 

--- a/apps/controller/src/compute-providers/spawn-daytona-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-daytona-worker.ts
@@ -135,6 +135,12 @@ export async function spawnDaytonaWorker(
   const { namedPorts, environmentSnapshotId, environmentConfig } =
     await getNamedPortsForTaskRun(taskRun);
 
+  if (environmentConfig?.container_projects?.length) {
+    throw new NonRetryableSpawnError(
+      'Daytona does not support environment container projects. Use Docker, E2B, or Blaxel for this environment.',
+    );
+  }
+
   const shouldEnableAuthBypass = shouldEnableAuthBypassForTaskRun({
     environmentConfig,
     namedPorts,

--- a/apps/controller/src/compute-providers/spawn-daytona-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-daytona-worker.ts
@@ -135,12 +135,6 @@ export async function spawnDaytonaWorker(
   const { namedPorts, environmentSnapshotId, environmentConfig } =
     await getNamedPortsForTaskRun(taskRun);
 
-  if (environmentConfig?.container_projects?.length) {
-    throw new NonRetryableSpawnError(
-      'Daytona does not support environment container projects. Use Docker, E2B, or Blaxel for this environment.',
-    );
-  }
-
   const shouldEnableAuthBypass = shouldEnableAuthBypassForTaskRun({
     environmentConfig,
     namedPorts,

--- a/apps/controller/src/compute-providers/spawn-docker-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-docker-worker.ts
@@ -320,7 +320,7 @@ export async function spawnDockerWorker(
     }
 
     if (isStandbyResume && usesContainerProjects) {
-      await docker(['start', taskDaemonContainerName]);
+      await resumeDockerTaskDaemon(taskDaemonContainerName);
     }
 
     const portMap = controlNetwork
@@ -440,6 +440,13 @@ export async function spawnDockerWorker(
     }
     throw error;
   }
+}
+
+export async function resumeDockerTaskDaemon(
+  containerName: string,
+  runDocker: typeof docker = docker,
+): Promise<void> {
+  await runDocker(['start', containerName], { allowFailure: true });
 }
 
 export function shouldRetryDockerWorkerWithoutDiskLimit(params: {

--- a/apps/controller/src/compute-providers/spawn-docker-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-docker-worker.ts
@@ -32,10 +32,13 @@ import {
 import { resolveFromWorkspaceRoot } from '../repo-paths';
 import {
   attachDockerEgressPolicy,
+  buildDockerTaskDaemonResourceArgs,
   buildDockerWorkerLabels,
   buildDockerWorkerResourceArgs,
   docker,
   getDockerTaskNetworkName,
+  getDockerTaskDaemonContainerName,
+  getDockerTaskWorkspaceVolumeName,
   getDockerWorkerContainerName,
   isUnsupportedDockerDiskLimitError,
   prepareDockerTaskNetwork,
@@ -52,6 +55,7 @@ const DOCKER_WORKER_ROOT = '/sandbox';
 const DOCKER_INSTALL_WORKER_SCRIPT = `${DOCKER_WORKER_ROOT}/install-worker.sh`;
 const DOCKER_WORKER_START_TIMEOUT_MS = 15_000;
 const DOCKER_WORKER_START_POLL_MS = 500;
+const DOCKER_TASK_DAEMON_IMAGE = 'docker:28-dind';
 
 export async function spawnDockerWorker(
   taskRun: TaskRun,
@@ -130,6 +134,13 @@ export async function spawnDockerWorker(
     ? taskRun.sourceSnapshotId!
     : getDockerWorkerContainerName(taskRun.id);
   const sourceRunId = getDockerSourceRunId(containerName);
+  const usesContainerProjects = Boolean(
+    environmentConfig?.container_projects?.length,
+  );
+  const taskDaemonContainerName =
+    getDockerTaskDaemonContainerName(containerName);
+  const taskWorkspaceVolumeName =
+    getDockerTaskWorkspaceVolumeName(containerName);
   const controlNetwork = config.network?.trim();
   const portArgs = controlNetwork
     ? []
@@ -187,6 +198,9 @@ export async function spawnDockerWorker(
           ? ['--add-host', 'host.docker.internal:host-gateway']
           : []),
         ...portArgs,
+        ...(usesContainerProjects
+          ? ['--volume', `${taskWorkspaceVolumeName}:${DOCKER_WORKER_ROOT}`]
+          : []),
         config.image,
         DOCKER_CONTAINER_READY_COMMAND,
         ...DOCKER_CONTAINER_READY_ARGS,
@@ -206,6 +220,18 @@ export async function spawnDockerWorker(
         platform: config.platform,
       });
     } else {
+      if (usesContainerProjects) {
+        await docker([
+          'volume',
+          'create',
+          ...buildDockerWorkerLabels({
+            taskRunId: taskRun.id,
+            autoRemove: autoRemoveContainer,
+          }),
+          taskWorkspaceVolumeName,
+        ]);
+      }
+
       try {
         containerId = await startContainer(config.diskLimit);
       } catch (error) {
@@ -264,6 +290,37 @@ export async function spawnDockerWorker(
         'bash',
         DOCKER_INSTALL_WORKER_SCRIPT,
       ]);
+
+      if (usesContainerProjects) {
+        await docker([
+          'run',
+          '-d',
+          ...(autoRemoveContainer ? ['--rm'] : []),
+          '--name',
+          taskDaemonContainerName,
+          '--platform',
+          config.platform,
+          '--network',
+          `container:${containerName}`,
+          '--privileged',
+          '--env',
+          'DOCKER_TLS_CERTDIR=',
+          ...buildDockerTaskDaemonResourceArgs(config),
+          ...buildDockerWorkerLabels({
+            taskRunId: taskRun.id,
+            autoRemove: autoRemoveContainer,
+          }),
+          '--volume',
+          `${taskWorkspaceVolumeName}:${DOCKER_WORKER_ROOT}`,
+          DOCKER_TASK_DAEMON_IMAGE,
+          '--host=tcp://0.0.0.0:2375',
+          '--tls=false',
+        ]);
+      }
+    }
+
+    if (isStandbyResume && usesContainerProjects) {
+      await docker(['start', taskDaemonContainerName]);
     }
 
     const portMap = controlNetwork
@@ -335,6 +392,10 @@ export async function spawnDockerWorker(
         ...(resolvedPreviewRuntimeConfig.effective.roomotePreviewDomain && {
           ROOMOTE_PREVIEW_DOMAIN:
             resolvedPreviewRuntimeConfig.effective.roomotePreviewDomain,
+        }),
+        ...(usesContainerProjects && {
+          DOCKER_HOST: 'tcp://127.0.0.1:2375',
+          DOCKER_TLS_CERTDIR: '',
         }),
       },
     });

--- a/apps/controller/src/compute-providers/spawn-modal-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-modal-worker.ts
@@ -163,7 +163,7 @@ export async function spawnModalWorker(
 
   if (environmentConfig?.container_projects?.length) {
     throw new NonRetryableSpawnError(
-      'Modal does not support environment container projects. Use Docker, E2B, or Blaxel for this environment.',
+      'Modal does not support environment container projects. Use Docker, Daytona, E2B, or Blaxel for this environment.',
     );
   }
 

--- a/apps/controller/src/compute-providers/spawn-modal-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-modal-worker.ts
@@ -161,11 +161,7 @@ export async function spawnModalWorker(
   const { namedPorts, environmentSnapshotId, environmentConfig } =
     await getNamedPortsForTaskRun(taskRun);
 
-  if (environmentConfig?.container_projects?.length) {
-    throw new NonRetryableSpawnError(
-      'Modal does not support environment container projects. Use Docker, Daytona, E2B, or Blaxel for this environment.',
-    );
-  }
+  const needsVmRuntime = Boolean(environmentConfig?.container_projects?.length);
 
   const shouldEnableAuthBypass = shouldEnableAuthBypassForTaskRun({
     environmentConfig,
@@ -273,6 +269,7 @@ export async function spawnModalWorker(
     ...(modalEcrOidcRoleArn ? { ecrOidcRoleArn: modalEcrOidcRoleArn } : {}),
     ...(modalEcrRegion ? { ecrRegion: modalEcrRegion } : {}),
     ...(parsedModalRegions ? { regions: parsedModalRegions } : {}),
+    ...(needsVmRuntime ? { vmRuntime: true } : {}),
     ...(configuredResources.configuredCpuCores !== null
       ? { cpu: configuredResources.configuredCpuCores }
       : {}),

--- a/apps/controller/src/compute-providers/spawn-modal-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-modal-worker.ts
@@ -161,6 +161,12 @@ export async function spawnModalWorker(
   const { namedPorts, environmentSnapshotId, environmentConfig } =
     await getNamedPortsForTaskRun(taskRun);
 
+  if (environmentConfig?.container_projects?.length) {
+    throw new NonRetryableSpawnError(
+      'Modal does not support environment container projects. Use Docker, E2B, or Blaxel for this environment.',
+    );
+  }
+
   const shouldEnableAuthBypass = shouldEnableAuthBypassForTaskRun({
     environmentConfig,
     namedPorts,

--- a/apps/dev/src/services/__tests__/docker.test.ts
+++ b/apps/dev/src/services/__tests__/docker.test.ts
@@ -1,9 +1,14 @@
+import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import Docker from 'dockerode';
 import { execa } from 'execa';
 
-import { DockerService } from '../docker';
+import {
+  DockerService,
+  WORKER_IMAGE_SCHEMA_LABEL,
+  WORKER_IMAGE_SCHEMA_VERSION,
+} from '../docker';
 
 vi.mock('execa', () => ({
   execa: vi.fn(),
@@ -344,6 +349,17 @@ describe('DockerService.ensureWorkerImage', () => {
     process.env = originalEnv;
   });
 
+  it('keeps the worker Dockerfile schema marker in sync with the reuse check', async () => {
+    const dockerfile = await readFile(
+      path.resolve(process.cwd(), '../worker/Dockerfile'),
+      'utf8',
+    );
+
+    expect(dockerfile).toContain(
+      `LABEL ${WORKER_IMAGE_SCHEMA_LABEL}="${WORKER_IMAGE_SCHEMA_VERSION}"`,
+    );
+  });
+
   it('builds the local worker image for the default Docker platform when missing', async () => {
     const rootDir = path.resolve(process.cwd(), '../..');
 
@@ -356,6 +372,8 @@ describe('DockerService.ensureWorkerImage', () => {
     expect(execa).toHaveBeenCalledWith('docker', [
       'image',
       'inspect',
+      '--format',
+      `{{ index .Config.Labels "${WORKER_IMAGE_SCHEMA_LABEL}" }}`,
       'roomote-worker:local',
     ]);
     expect(execa).toHaveBeenCalledWith(
@@ -374,8 +392,86 @@ describe('DockerService.ensureWorkerImage', () => {
     );
   });
 
-  it('reuses an existing worker image when required networking tools are available', async () => {
-    vi.mocked(execa).mockResolvedValue({} as Awaited<ReturnType<typeof execa>>);
+  it('reuses an existing worker image when its schema and required tools are current', async () => {
+    vi.mocked(execa)
+      .mockResolvedValueOnce({
+        stdout: `${WORKER_IMAGE_SCHEMA_VERSION}\n`,
+      } as Awaited<ReturnType<typeof execa>>)
+      .mockResolvedValueOnce({} as Awaited<ReturnType<typeof execa>>);
+
+    await DockerService.ensureWorkerImage(false);
+
+    expect(execa).toHaveBeenCalledWith('docker', [
+      'image',
+      'inspect',
+      '--format',
+      `{{ index .Config.Labels "${WORKER_IMAGE_SCHEMA_LABEL}" }}`,
+      'roomote-worker:local',
+    ]);
+    expect(execa).toHaveBeenCalledWith('docker', [
+      'run',
+      '--rm',
+      '--platform',
+      process.arch === 'arm64' ? 'linux/arm64' : 'linux/amd64',
+      '--entrypoint',
+      '/bin/sh',
+      'roomote-worker:local',
+      '-c',
+      'test -x /usr/sbin/ip && /usr/sbin/ip -Version >/dev/null && command -v docker >/dev/null && docker --version >/dev/null && docker compose version >/dev/null',
+    ]);
+    expect(execa).not.toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining(['build']),
+      expect.anything(),
+    );
+  });
+
+  it.each([
+    ['missing', '<no value>\n'],
+    ['outdated', '0\n'],
+  ])(
+    'rebuilds an existing worker image with a %s schema',
+    async (_, schema) => {
+      const rootDir = path.resolve(process.cwd(), '../..');
+
+      vi.mocked(execa)
+        .mockResolvedValueOnce({
+          stdout: schema,
+        } as Awaited<ReturnType<typeof execa>>)
+        .mockResolvedValueOnce({} as Awaited<ReturnType<typeof execa>>);
+
+      await DockerService.ensureWorkerImage(false);
+
+      expect(execa).not.toHaveBeenCalledWith(
+        'docker',
+        expect.arrayContaining(['run']),
+      );
+      expect(execa).toHaveBeenCalledWith(
+        'docker',
+        [
+          'build',
+          '--platform',
+          process.arch === 'arm64' ? 'linux/arm64' : 'linux/amd64',
+          '-f',
+          'apps/worker/Dockerfile',
+          '-t',
+          'roomote-worker:local',
+          '.',
+        ],
+        { cwd: rootDir },
+      );
+    },
+  );
+
+  it('rebuilds a current worker image that lacks Docker Compose', async () => {
+    const rootDir = path.resolve(process.cwd(), '../..');
+
+    vi.mocked(execa)
+      .mockResolvedValueOnce({
+        stdout: `${WORKER_IMAGE_SCHEMA_VERSION}\n`,
+      } as Awaited<ReturnType<typeof execa>>)
+      .mockRejectedValueOnce(new Error('docker compose is missing'))
+      .mockResolvedValueOnce({} as Awaited<ReturnType<typeof execa>>);
 
     await DockerService.ensureWorkerImage(false);
 
@@ -388,25 +484,8 @@ describe('DockerService.ensureWorkerImage', () => {
       '/bin/sh',
       'roomote-worker:local',
       '-c',
-      'test -x /usr/sbin/ip && /usr/sbin/ip -Version >/dev/null',
+      'test -x /usr/sbin/ip && /usr/sbin/ip -Version >/dev/null && command -v docker >/dev/null && docker --version >/dev/null && docker compose version >/dev/null',
     ]);
-    expect(execa).not.toHaveBeenCalledWith(
-      'docker',
-      expect.arrayContaining(['build']),
-      expect.anything(),
-    );
-  });
-
-  it('rebuilds an existing worker image that lacks required networking tools', async () => {
-    const rootDir = path.resolve(process.cwd(), '../..');
-
-    vi.mocked(execa)
-      .mockResolvedValueOnce({} as Awaited<ReturnType<typeof execa>>)
-      .mockRejectedValueOnce(new Error('ip is missing'))
-      .mockResolvedValueOnce({} as Awaited<ReturnType<typeof execa>>);
-
-    await DockerService.ensureWorkerImage(false);
-
     expect(execa).toHaveBeenCalledWith(
       'docker',
       [
@@ -437,6 +516,8 @@ describe('DockerService.ensureWorkerImage', () => {
     expect(execa).toHaveBeenCalledWith('docker', [
       'image',
       'inspect',
+      '--format',
+      `{{ index .Config.Labels "${WORKER_IMAGE_SCHEMA_LABEL}" }}`,
       'custom-worker:test',
     ]);
     expect(execa).toHaveBeenCalledWith(

--- a/apps/dev/src/services/__tests__/docker.test.ts
+++ b/apps/dev/src/services/__tests__/docker.test.ts
@@ -356,7 +356,10 @@ describe('DockerService.ensureWorkerImage', () => {
     );
 
     expect(dockerfile).toContain(
-      `LABEL ${WORKER_IMAGE_SCHEMA_LABEL}="${WORKER_IMAGE_SCHEMA_VERSION}"`,
+      `ARG ROOMOTE_WORKER_RUNTIME_SCHEMA_VERSION=${WORKER_IMAGE_SCHEMA_VERSION}`,
+    );
+    expect(dockerfile).toContain(
+      `LABEL ${WORKER_IMAGE_SCHEMA_LABEL}="\${ROOMOTE_WORKER_RUNTIME_SCHEMA_VERSION}"`,
     );
   });
 
@@ -382,6 +385,8 @@ describe('DockerService.ensureWorkerImage', () => {
         'build',
         '--platform',
         process.arch === 'arm64' ? 'linux/arm64' : 'linux/amd64',
+        '--build-arg',
+        `ROOMOTE_WORKER_RUNTIME_SCHEMA_VERSION=${WORKER_IMAGE_SCHEMA_VERSION}`,
         '-f',
         'apps/worker/Dockerfile',
         '-t',
@@ -452,6 +457,8 @@ describe('DockerService.ensureWorkerImage', () => {
           'build',
           '--platform',
           process.arch === 'arm64' ? 'linux/arm64' : 'linux/amd64',
+          '--build-arg',
+          `ROOMOTE_WORKER_RUNTIME_SCHEMA_VERSION=${WORKER_IMAGE_SCHEMA_VERSION}`,
           '-f',
           'apps/worker/Dockerfile',
           '-t',
@@ -492,6 +499,8 @@ describe('DockerService.ensureWorkerImage', () => {
         'build',
         '--platform',
         process.arch === 'arm64' ? 'linux/arm64' : 'linux/amd64',
+        '--build-arg',
+        `ROOMOTE_WORKER_RUNTIME_SCHEMA_VERSION=${WORKER_IMAGE_SCHEMA_VERSION}`,
         '-f',
         'apps/worker/Dockerfile',
         '-t',
@@ -526,6 +535,8 @@ describe('DockerService.ensureWorkerImage', () => {
         'build',
         '--platform',
         'linux/arm64',
+        '--build-arg',
+        `ROOMOTE_WORKER_RUNTIME_SCHEMA_VERSION=${WORKER_IMAGE_SCHEMA_VERSION}`,
         '-f',
         'apps/worker/Dockerfile',
         '-t',

--- a/apps/dev/src/services/docker.ts
+++ b/apps/dev/src/services/docker.ts
@@ -3,10 +3,13 @@ import path from 'path';
 import { execa } from 'execa';
 import ora from 'ora';
 import Docker from 'dockerode';
+import { WORKER_RUNTIME_SCHEMA_VERSION } from '@roomote/types';
 
 export const WORKER_IMAGE_SCHEMA_LABEL =
   'dev.roomote.worker-image.schema-version';
-export const WORKER_IMAGE_SCHEMA_VERSION = '1';
+export const WORKER_IMAGE_SCHEMA_VERSION = String(
+  WORKER_RUNTIME_SCHEMA_VERSION,
+);
 
 export class DockerService {
   private static readonly CURRENT_COMPOSE_PROJECT = 'roomote';
@@ -82,6 +85,8 @@ export class DockerService {
           'build',
           '--platform',
           platform,
+          '--build-arg',
+          `ROOMOTE_WORKER_RUNTIME_SCHEMA_VERSION=${WORKER_IMAGE_SCHEMA_VERSION}`,
           '-f',
           'apps/worker/Dockerfile',
           '-t',

--- a/apps/dev/src/services/docker.ts
+++ b/apps/dev/src/services/docker.ts
@@ -4,6 +4,10 @@ import { execa } from 'execa';
 import ora from 'ora';
 import Docker from 'dockerode';
 
+export const WORKER_IMAGE_SCHEMA_LABEL =
+  'dev.roomote.worker-image.schema-version';
+export const WORKER_IMAGE_SCHEMA_VERSION = '1';
+
 export class DockerService {
   private static readonly CURRENT_COMPOSE_PROJECT = 'roomote';
   private static readonly REQUIRED_CONTAINERS = [
@@ -61,7 +65,7 @@ export class DockerService {
     const rootDir = path.resolve(process.cwd(), '../..');
 
     if (
-      (await this.hasImage(image)) &&
+      (await this.hasCurrentWorkerImageSchema(image)) &&
       (await this.hasRequiredWorkerImageTools(image, platform))
     ) {
       return;
@@ -280,10 +284,19 @@ export class DockerService {
     }
   }
 
-  private static async hasImage(image: string): Promise<boolean> {
+  private static async hasCurrentWorkerImageSchema(
+    image: string,
+  ): Promise<boolean> {
     try {
-      await execa('docker', ['image', 'inspect', image]);
-      return true;
+      const result = await execa('docker', [
+        'image',
+        'inspect',
+        '--format',
+        `{{ index .Config.Labels "${WORKER_IMAGE_SCHEMA_LABEL}" }}`,
+        image,
+      ]);
+
+      return result.stdout?.trim() === WORKER_IMAGE_SCHEMA_VERSION;
     } catch (_error) {
       return false;
     }
@@ -303,7 +316,7 @@ export class DockerService {
         '/bin/sh',
         image,
         '-c',
-        'test -x /usr/sbin/ip && /usr/sbin/ip -Version >/dev/null',
+        'test -x /usr/sbin/ip && /usr/sbin/ip -Version >/dev/null && command -v docker >/dev/null && docker --version >/dev/null && docker compose version >/dev/null',
       ]);
       return true;
     } catch (_error) {

--- a/apps/docs/environments.mdx
+++ b/apps/docs/environments.mdx
@@ -147,7 +147,7 @@ live preview. Compose mappings also identify the service that owns the port.
 Startup is required by default; mark a project optional only when tasks can
 still work usefully without it.
 
-Container projects currently require the Docker, E2B, or Blaxel sandbox
+Container projects currently require the Docker, Daytona, E2B, or Blaxel sandbox
 provider. They are isolated with the task and are removed when the task sandbox
 is destroyed. They are still customer-controlled code, so review Compose files
 and Dockerfiles with the same care as repository setup scripts.

--- a/apps/docs/environments.mdx
+++ b/apps/docs/environments.mdx
@@ -147,10 +147,10 @@ live preview. Compose mappings also identify the service that owns the port.
 Startup is required by default; mark a project optional only when tasks can
 still work usefully without it.
 
-Container projects currently require the Docker, Daytona, E2B, or Blaxel sandbox
-provider. They are isolated with the task and are removed when the task sandbox
-is destroyed. They are still customer-controlled code, so review Compose files
-and Dockerfiles with the same care as repository setup scripts.
+Container projects are supported by all sandbox providers. They are isolated
+with the task and are removed when the task sandbox is destroyed. They are still
+customer-controlled code, so review Compose files and Dockerfiles with the same
+care as repository setup scripts.
 
 ## Set tool versions at the right level
 

--- a/apps/docs/environments.mdx
+++ b/apps/docs/environments.mdx
@@ -74,6 +74,8 @@ workspace:
   MariaDB, ClickHouse, or the AWS CLI before repository setup commands run.
 - **Repositories** choose the repositories to clone, optional branches,
   repository-specific tool fallbacks, and setup commands for each repository.
+- **Containers** build and start an existing Docker Compose project or a single
+  Dockerfile from one of the selected repositories.
 - **Environment Variables** provide values that tasks can read.
 - **Environment `.tool-versions`** writes a shared `.tool-versions` file at
   the workspace root.
@@ -131,6 +133,24 @@ task, and include the exact command, package, or path when it matters.
 Use **Don't block setup even if it fails** only for helpful-but-optional
 steps. If the app cannot run without the command, let setup fail so the issue
 is visible.
+
+## Use an existing Docker setup
+
+If the repository already defines its development dependencies in Docker, add
+a **Container project** instead of duplicating that setup as Roomote-managed
+services. A project can use one or more Compose files or build a single
+Dockerfile. Roomote starts it after the repository is cloned and waits for its
+services to become healthy before repository setup commands run.
+
+Map container ports to named environment ports when a service should have a
+live preview. Compose mappings also identify the service that owns the port.
+Startup is required by default; mark a project optional only when tasks can
+still work usefully without it.
+
+Container projects currently require the Docker, E2B, or Blaxel sandbox
+provider. They are isolated with the task and are removed when the task sandbox
+is destroyed. They are still customer-controlled code, so review Compose files
+and Dockerfiles with the same care as repository setup scripts.
 
 ## Set tool versions at the right level
 

--- a/apps/docs/environments/definition.mdx
+++ b/apps/docs/environments/definition.mdx
@@ -297,7 +297,7 @@ container_projects:
 ```
 
 All paths must be relative and stay inside the selected repository. Container
-projects are supported by the Docker, E2B, and Blaxel sandbox providers.
+projects are supported by the Docker, Daytona, E2B, and Blaxel sandbox providers.
 
 ## Ports
 

--- a/apps/docs/environments/definition.mdx
+++ b/apps/docs/environments/definition.mdx
@@ -297,7 +297,8 @@ container_projects:
 ```
 
 All paths must be relative and stay inside the selected repository. Container
-projects are supported by the Docker, Daytona, E2B, and Blaxel sandbox providers.
+projects are supported by all sandbox providers. Modal runs them in its beta VM
+sandbox runtime.
 
 ## Ports
 

--- a/apps/docs/environments/definition.mdx
+++ b/apps/docs/environments/definition.mdx
@@ -1,7 +1,7 @@
 ---
 title: Environment definition
 icon: file-code
-description: "Understand the environment definition YAML: the schema, how it relates to Dev Containers, and how to write your own by hand or with a coding agent."
+description: 'Understand the environment definition YAML: the schema, how it relates to Dev Containers, and how to write your own by hand or with a coding agent.'
 ---
 
 An environment definition is the YAML document that describes a Roomote
@@ -21,8 +21,8 @@ clean sandbox. The environment definition is what turns that empty sandbox into
 a workspace grounded in your product. It is applied in a predictable order:
 
 1. shared workspace tool versions are installed
-2. requested services (databases, caches) are started
-3. each repository is cloned onto the workspace, at its chosen branch
+2. requested services (databases, caches) are started while repositories clone
+3. configured container projects are built and started from cloned repositories
 4. each repository's setup commands run, in order
 5. named ports become live previews, and agent instructions are attached to
    every task
@@ -38,14 +38,14 @@ definition will feel familiar. Both describe a development workspace as a
 version-controllable, declarative file so that anyone (or any agent) gets the
 same setup. The concepts map closely:
 
-| Concept | Dev Container (`devcontainer.json`) | Roomote environment definition |
-| --- | --- | --- |
-| Base machine | [`image` / `build`](https://containers.dev/implementors/json_reference/#image-specific) | Provided by the [sandbox provider](/compute) worker image, not set here |
-| Extra tooling | [`features`](https://containers.dev/features) | `services` and `tool_versions` |
-| Setup steps | [`onCreateCommand` / `postCreateCommand`](https://containers.dev/implementors/json_reference/#lifecycle-scripts) | Repository `commands` |
-| Forwarded ports | [`forwardPorts` / `portsAttributes`](https://containers.dev/implementors/json_reference/#port-attributes) | `ports` |
-| Workspace env vars | [`containerEnv` / `remoteEnv`](https://containers.dev/implementors/json_reference/#variables-in-devcontainer-json) | `env` (and per-command `env`) |
-| Tool customizations | [`customizations`](https://containers.dev/supporting-tools) | `agentInstructions`, `mcpServers`, `skills` |
+| Concept             | Dev Container (`devcontainer.json`)                                                                                | Roomote environment definition                                          |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
+| Base machine        | [`image` / `build`](https://containers.dev/implementors/json_reference/#image-specific)                            | Provided by the [sandbox provider](/compute) worker image, not set here |
+| Extra tooling       | [`features`](https://containers.dev/features)                                                                      | `services` and `tool_versions`                                          |
+| Setup steps         | [`onCreateCommand` / `postCreateCommand`](https://containers.dev/implementors/json_reference/#lifecycle-scripts)   | Repository `commands`                                                   |
+| Forwarded ports     | [`forwardPorts` / `portsAttributes`](https://containers.dev/implementors/json_reference/#port-attributes)          | `ports`                                                                 |
+| Workspace env vars  | [`containerEnv` / `remoteEnv`](https://containers.dev/implementors/json_reference/#variables-in-devcontainer-json) | `env` (and per-command `env`)                                           |
+| Tool customizations | [`customizations`](https://containers.dev/supporting-tools)                                                        | `agentInstructions`, `mcpServers`, `skills`                             |
 
 The important difference: **Roomote uses its own schema and does not read
 `devcontainer.json`.** The comparison is conceptual. If a repository already has
@@ -108,6 +108,20 @@ repositories:
       - name: Install dependencies
         run: pnpm install
 
+# Start an existing Compose project after acme/web is cloned.
+container_projects:
+  - type: compose
+    name: app
+    repository: acme/web
+    files:
+      - compose.yaml
+    services:
+      - web
+    ports:
+      - named_port: WEB
+        service: web
+        container_port: 3000
+
 # Named ports exposed as human-facing previews.
 ports:
   - name: WEB
@@ -126,24 +140,25 @@ agentInstructions: |
 
 ## Top-level fields
 
-| Field | Type | Required | Notes |
-| --- | --- | --- | --- |
-| `name` | string | yes | Environment name, 1–100 characters. |
-| `description` | string | no | Short summary, up to 500 characters. |
-| `repositories` | list | yes | At least one repository. See [Repositories](#repositories). |
-| `initialUrl` | string | no | Absolute URL or `about:blank` that the preview surface opens first. |
-| `agentInstructions` | string | no | Guidance attached to every task, up to 10,000 characters. |
-| `tool_versions` | map | no | Tools installed at the shared workspace root via mise. |
-| `env` | map | no | Workspace environment variables available to every task. |
-| `services` | list | no | Managed services to start. See [Services](#services). |
-| `ports` | list | no | Named preview ports. See [Ports](#ports). |
-| `previews_enabled` | boolean | no | Explicitly enable or disable live previews without deleting port definitions. |
-| `oidc` | map | no | Sandbox OIDC targets. See [OIDC](#oidc). |
-| `mcpServers` | map | no | Custom MCP servers for this environment. See [MCP servers](#mcp-servers). |
-| `skills` | map | no | Installable skills by `owner/repo`. See [Skills](#skills). |
-| `manualSkills` | list | no | Inline skills defined in the environment. See [Skills](#skills). |
-| `auth_bypass_header` | boolean or string | no | Header-based auth bypass control for exposed authenticated previews. A fixed string secret must be at least 8 characters. |
-| `auth_bypass_header_name` | string | no | Custom bypass header name. Defaults to `x-bypass-roomote-auth`. |
+| Field                     | Type              | Required | Notes                                                                                                                     |
+| ------------------------- | ----------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `name`                    | string            | yes      | Environment name, 1–100 characters.                                                                                       |
+| `description`             | string            | no       | Short summary, up to 500 characters.                                                                                      |
+| `repositories`            | list              | yes      | At least one repository. See [Repositories](#repositories).                                                               |
+| `initialUrl`              | string            | no       | Absolute URL or `about:blank` that the preview surface opens first.                                                       |
+| `agentInstructions`       | string            | no       | Guidance attached to every task, up to 10,000 characters.                                                                 |
+| `tool_versions`           | map               | no       | Tools installed at the shared workspace root via mise.                                                                    |
+| `env`                     | map               | no       | Workspace environment variables available to every task.                                                                  |
+| `services`                | list              | no       | Managed services to start. See [Services](#services).                                                                     |
+| `container_projects`      | list              | no       | Existing Compose or Dockerfile projects to build and start. See [Container projects](#container-projects).                |
+| `ports`                   | list              | no       | Named preview ports. See [Ports](#ports).                                                                                 |
+| `previews_enabled`        | boolean           | no       | Explicitly enable or disable live previews without deleting port definitions.                                             |
+| `oidc`                    | map               | no       | Sandbox OIDC targets. See [OIDC](#oidc).                                                                                  |
+| `mcpServers`              | map               | no       | Custom MCP servers for this environment. See [MCP servers](#mcp-servers).                                                 |
+| `skills`                  | map               | no       | Installable skills by `owner/repo`. See [Skills](#skills).                                                                |
+| `manualSkills`            | list              | no       | Inline skills defined in the environment. See [Skills](#skills).                                                          |
+| `auth_bypass_header`      | boolean or string | no       | Header-based auth bypass control for exposed authenticated previews. A fixed string secret must be at least 8 characters. |
+| `auth_bypass_header_name` | string            | no       | Custom bypass header name. Defaults to `x-bypass-roomote-auth`.                                                           |
 
 ### Basics
 
@@ -157,12 +172,12 @@ opens first, so point it at the app entry a reviewer would expect, for example
 `repositories` is a required list with at least one entry. Each repository is
 cloned onto the shared workspace.
 
-| Field | Type | Required | Notes |
-| --- | --- | --- | --- |
-| `repository` | string | yes | `owner/repo` format. |
-| `branch` | string | no | Branch to check out. Defaults to the repository's default branch. |
-| `tool_versions` | map | no | Repo-local tool fallbacks installed via mise. |
-| `commands` | list | no | Setup commands for this repository. See [Commands](#commands). |
+| Field           | Type   | Required | Notes                                                             |
+| --------------- | ------ | -------- | ----------------------------------------------------------------- |
+| `repository`    | string | yes      | `owner/repo` format.                                              |
+| `branch`        | string | no       | Branch to check out. Defaults to the repository's default branch. |
+| `tool_versions` | map    | no       | Repo-local tool fallbacks installed via mise.                     |
+| `commands`      | list   | no       | Setup commands for this repository. See [Commands](#commands).    |
 
 Keep the first environment focused. One repository, or a small set that must be
 cloned together, sets up faster and is easier to debug than a large multi-repo
@@ -178,18 +193,18 @@ is cloned. Commands are the durable setup steps a teammate would run after
 cloning: installing dependencies, generating code, running migrations, and
 starting long-running services.
 
-| Field | Type | Required | Notes |
-| --- | --- | --- | --- |
-| `name` | string | yes | Human-readable label for the step. |
-| `run` | string | yes | The shell command to run. |
-| `env` | map | no | Command-specific environment variables, merged over workspace `env`. |
-| `working_dir` | string | no | Directory to run the command in. |
-| `cwd` | string | no | Alias for `working_dir`. |
-| `timeout` | number | no | Seconds before the command is killed. Defaults to `600`. |
-| `retries` | integer | no | Extra attempts for a failing command, with a 1-second delay. Use only for idempotent commands. Defaults to `0`. |
-| `continue_on_error` | boolean | no | When `true`, setup continues even if this command fails. Defaults to `false`. |
-| `detached` | boolean | no | Run in the background under supervision. Use for long-running servers. Defaults to `false`. |
-| `logfile` | string | no | Path to capture stdout and stderr. Used with `detached: true`. |
+| Field               | Type    | Required | Notes                                                                                                           |
+| ------------------- | ------- | -------- | --------------------------------------------------------------------------------------------------------------- |
+| `name`              | string  | yes      | Human-readable label for the step.                                                                              |
+| `run`               | string  | yes      | The shell command to run.                                                                                       |
+| `env`               | map     | no       | Command-specific environment variables, merged over workspace `env`.                                            |
+| `working_dir`       | string  | no       | Directory to run the command in.                                                                                |
+| `cwd`               | string  | no       | Alias for `working_dir`.                                                                                        |
+| `timeout`           | number  | no       | Seconds before the command is killed. Defaults to `600`.                                                        |
+| `retries`           | integer | no       | Extra attempts for a failing command, with a 1-second delay. Use only for idempotent commands. Defaults to `0`. |
+| `continue_on_error` | boolean | no       | When `true`, setup continues even if this command fails. Defaults to `false`.                                   |
+| `detached`          | boolean | no       | Run in the background under supervision. Use for long-running servers. Defaults to `false`.                     |
+| `logfile`           | string  | no       | Path to capture stdout and stderr. Used with `detached: true`.                                                  |
 
 Guidance:
 
@@ -207,22 +222,82 @@ is either a service name string or an object with a name and a custom `port`.
 
 Supported services:
 
-| Service | Default port |
-| --- | --- |
-| `redis6`, `redis7` | 6379 |
-| `postgres15`, `postgres16`, `postgres17` | 5432 |
-| `mysql8`, `mariadb10` | 3306 |
-| `clickhouse` | 9000 |
-| `aws` | CLI tool, no port |
+| Service                                  | Default port      |
+| ---------------------------------------- | ----------------- |
+| `redis6`, `redis7`                       | 6379              |
+| `postgres15`, `postgres16`, `postgres17` | 5432              |
+| `mysql8`, `mariadb10`                    | 3306              |
+| `clickhouse`                             | 9000              |
+| `aws`                                    | CLI tool, no port |
 
 ```yaml
 services:
-  - postgres16          # default port 5432
+  - postgres16 # default port 5432
   - name: redis7
-    port: 6380          # custom port
+    port: 6380 # custom port
 ```
 
 A service name cannot collide with a port name in the same environment.
+
+## Container projects
+
+`container_projects` runs container definitions already owned by a configured
+repository. Roomote validates the Compose model, builds images, starts services
+with `docker compose up --wait`, and treats startup as required unless
+`required: false` is set.
+
+Common fields:
+
+| Field                     | Type                      | Required | Notes                                                                      |
+| ------------------------- | ------------------------- | -------- | -------------------------------------------------------------------------- |
+| `type`                    | `compose` or `dockerfile` | yes      | Selects the source format.                                                 |
+| `name`                    | string                    | yes      | Unique project name.                                                       |
+| `repository`              | string                    | yes      | Must exactly match a repository in this environment.                       |
+| `working_dir`             | string                    | no       | Relative directory inside the repository. Defaults to `.`.                 |
+| `env`                     | map                       | no       | Variables passed to Compose. Deployment-variable references are supported. |
+| `ports`                   | list                      | no       | Maps container ports to names from the top-level `ports` list.             |
+| `required`                | boolean                   | no       | Fail task startup when the project fails. Defaults to `true`.              |
+| `startup_timeout_seconds` | integer                   | no       | Build and health-wait timeout. Defaults to 600, maximum 3600.              |
+
+For `type: compose`, `files` is a required list of relative Compose file paths.
+Optional `profiles` enables Compose profiles, and optional `services` limits
+startup to those services. Each port mapping requires `named_port`, `service`,
+and `container_port`.
+
+```yaml
+container_projects:
+  - type: compose
+    name: development
+    repository: acme/web
+    working_dir: infra/local
+    files: [compose.yaml, compose.override.yaml]
+    profiles: [development]
+    ports:
+      - named_port: WEB
+        service: web
+        container_port: 3000
+```
+
+For `type: dockerfile`, Roomote generates a one-service Compose project.
+`context` defaults to `.`, `dockerfile` defaults to `Dockerfile`, and `target`,
+`build_args`, and `command` are optional. Dockerfile port mappings omit
+`service` because the generated service is implicit.
+
+```yaml
+container_projects:
+  - type: dockerfile
+    name: web
+    repository: acme/web
+    context: .
+    dockerfile: Dockerfile
+    target: development
+    ports:
+      - named_port: WEB
+        container_port: 3000
+```
+
+All paths must be relative and stay inside the selected repository. Container
+projects are supported by the Docker, E2B, and Blaxel sandbox providers.
 
 ## Ports
 
@@ -231,17 +306,17 @@ A service name cannot collide with a port name in the same environment.
 a preview URL and a corresponding `ROOMOTE_<NAME>_HOST` environment variable
 inside the sandbox.
 
-| Field | Type | Required | Notes |
-| --- | --- | --- | --- |
-| `name` | string | yes | Starts with a letter; letters, numbers, and underscores only. Case-insensitive and unique. `SANDBOX_SERVER` and `EDITOR` are reserved. |
-| `port` | number | yes | The listening port, 1024–65535. |
-| `primary` | boolean | no | Marks the main preview surface. At most one port may be primary. |
-| `initial_path` | string | no | Path the preview opens first. Must start with `/`. |
-| `proxied` | boolean | no | Whether the port is served through the preview proxy. Defaults to proxied. |
-| `unauthenticated` | boolean | no | Allow access without the normal preview auth. |
-| `auth_bypass_paths` | list | no | Up to 20 paths (each starting with `/`) that skip preview auth. |
-| `subdomain` | string | no | DNS-safe subdomain prefix for the preview host. |
-| `wildcard_prefix` | boolean | no | Serve wildcard subdomains under the port. |
+| Field               | Type    | Required | Notes                                                                                                                                  |
+| ------------------- | ------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`              | string  | yes      | Starts with a letter; letters, numbers, and underscores only. Case-insensitive and unique. `SANDBOX_SERVER` and `EDITOR` are reserved. |
+| `port`              | number  | yes      | The listening port, 1024–65535.                                                                                                        |
+| `primary`           | boolean | no       | Marks the main preview surface. At most one port may be primary.                                                                       |
+| `initial_path`      | string  | no       | Path the preview opens first. Must start with `/`.                                                                                     |
+| `proxied`           | boolean | no       | Whether the port is served through the preview proxy. Defaults to proxied.                                                             |
+| `unauthenticated`   | boolean | no       | Allow access without the normal preview auth.                                                                                          |
+| `auth_bypass_paths` | list    | no       | Up to 20 paths (each starting with `/`) that skip preview auth.                                                                        |
+| `subdomain`         | string  | no       | DNS-safe subdomain prefix for the preview host.                                                                                        |
+| `wildcard_prefix`   | boolean | no       | Serve wildcard subdomains under the port.                                                                                              |
 
 Limits: at most 10 proxied ports and at most 2 non-proxied ports per
 environment.

--- a/apps/docs/providers/compute/blaxel.mdx
+++ b/apps/docs/providers/compute/blaxel.mdx
@@ -40,6 +40,11 @@ Region and standby retention are also editable under **Settings > Sandboxes >
 Blaxel > Advanced settings**. Process environment variables take precedence
 and appear as locked values in Settings.
 
+Roomote's provisioned Blaxel worker image includes Docker, Docker Compose, and
+the legacy iptables backend required for
+[container projects](/environments/definition#container-projects). Container
+builds and services share the task sandbox's memory allocation.
+
 ## Verify setup
 
 1. Save the API key and workspace name.

--- a/apps/docs/providers/compute/daytona.mdx
+++ b/apps/docs/providers/compute/daytona.mdx
@@ -41,6 +41,13 @@ DAYTONA_TARGET=...
 Use `DAYTONA_API_URL` for custom Daytona endpoints. Use `DAYTONA_TARGET` when
 your account or deployment needs a specific target or region.
 
+Roomote's Daytona worker snapshot includes Docker and Docker Compose, so
+environments can run
+[container projects](/environments/definition#container-projects). Daytona
+runs these through Docker-in-Docker inside the task sandbox. Container builds
+and services share the sandbox's resources; allocate at least 2 vCPU and 4 GiB
+of memory for typical multi-container projects.
+
 ## Verify setup
 
 1. save `DAYTONA_API_KEY`
@@ -53,3 +60,5 @@ your account or deployment needs a specific target or region.
 
 - **The provider starts in the wrong region or target.** Set
   `DAYTONA_TARGET` to the intended target.
+- **Container startup is slow or runs out of memory.** Increase the Daytona
+  sandbox resources; Docker-in-Docker adds daemon and image-build overhead.

--- a/apps/docs/providers/compute/docker.mdx
+++ b/apps/docs/providers/compute/docker.mdx
@@ -68,6 +68,13 @@ The controller reconciles replacement API and preview-proxy containers onto
 running task networks, removes empty task networks periodically, and reaps
 stale provisioning containers after a restart.
 
+Environments that use [container projects](/environments/definition#container-projects)
+also receive a dedicated Docker daemon and workspace volume. Customer Compose
+services share the task's network namespace so configured preview ports keep
+the same task-scoped routing, while their Docker control plane is not exposed
+to other tasks. The daemon, inner containers, network, and workspace volume are
+stopped or removed with the task lifecycle.
+
 Workers default to 2 CPUs, 4 GiB of memory with no additional swap, 512 PIDs,
 a requested 20 GiB writable-layer quota, and three 10 MiB JSON log files. The
 variables above can tune those bounds. Writable-layer quotas require a Docker

--- a/apps/docs/providers/compute/e2b.mdx
+++ b/apps/docs/providers/compute/e2b.mdx
@@ -35,6 +35,11 @@ E2B_MAX_SANDBOX_TIMEOUT_MS=3600000
 Use `E2B_DOMAIN` only for self-hosted or custom E2B clusters. The default E2B
 domain is enough for standard hosted E2B.
 
+Roomote's provisioned E2B worker template includes Docker and Docker Compose,
+so environments can run [container projects](/environments/definition#container-projects).
+Container builds share the task's CPU and memory; use an appropriately sized
+sandbox for larger images or multi-service stacks.
+
 ## Verify setup
 
 1. save `E2B_API_KEY`

--- a/apps/docs/providers/compute/modal.mdx
+++ b/apps/docs/providers/compute/modal.mdx
@@ -45,6 +45,12 @@ placement. Prefer broader tokens such as `us` for capacity and cold-start
 behavior. Pinning a region can add a Modal pricing multiplier and only applies
 to newly created or resumed sandboxes, not sandboxes that are already running.
 
+Environments with
+[container projects](/environments/definition#container-projects) automatically
+use Modal's beta VM sandbox runtime so Docker and Docker Compose can run inside
+the task. Other Modal tasks continue to use the standard sandbox runtime.
+Container builds and services share the task sandbox's CPU and memory.
+
 ## Verify setup
 
 1. save Modal credentials

--- a/apps/web/src/app/(onboarding)/setup/StepComputeConfig.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepComputeConfig.tsx
@@ -121,6 +121,13 @@ export function StepComputeConfig({
           effectiveSelectedProviderId,
         )
       : null;
+  const selectedProvider = useMemo(
+    () =>
+      computeSetup.providers.find(
+        (provider) => provider.provider === effectiveSelectedProviderId,
+      ),
+    [computeSetup.providers, effectiveSelectedProviderId],
+  );
   const saveComputeConfig = useMutation(
     trpc.setupNew.saveComputeConfig.mutationOptions({
       onSuccess: async (result) => {
@@ -137,7 +144,10 @@ export function StepComputeConfig({
               )
             : null;
 
-        if (resultProvisioning?.status === 'building') {
+        if (
+          resultProvisioning?.status === 'building' &&
+          !selectedProvider?.configSatisfied
+        ) {
           setAwaitingTemplateBuild(true);
           return;
         }
@@ -159,10 +169,13 @@ export function StepComputeConfig({
 
   // Re-attach to an in-flight build (e.g. after a page reload mid-build).
   useEffect(() => {
-    if (templateBuild?.status === 'building') {
+    if (
+      templateBuild?.status === 'building' &&
+      !selectedProvider?.configSatisfied
+    ) {
       setAwaitingTemplateBuild(true);
     }
-  }, [templateBuild?.status]);
+  }, [selectedProvider?.configSatisfied, templateBuild?.status]);
 
   useEffect(() => {
     if (!awaitingTemplateBuild) {
@@ -183,14 +196,6 @@ export function StepComputeConfig({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [awaitingTemplateBuild, templateBuild?.status]);
-
-  const selectedProvider = useMemo(
-    () =>
-      computeSetup.providers.find(
-        (provider) => provider.provider === effectiveSelectedProviderId,
-      ),
-    [computeSetup.providers, effectiveSelectedProviderId],
-  );
 
   const credentialFields =
     selectedProvider?.fields.filter(isComputeCredentialField) ?? [];

--- a/apps/web/src/components/settings/ComputeProviderSection.client.test.tsx
+++ b/apps/web/src/components/settings/ComputeProviderSection.client.test.tsx
@@ -46,6 +46,7 @@ function buildProvisioning(
 ): SetupNewComputeProvisioningState {
   return {
     status: 'building',
+    runtimeSchemaVersion: 1,
     imageRef: 'ghcr.io/roocodeinc/roomote-worker:develop-abc12345',
     templateRef: 'roomote-worker:develop-abc12345',
     error: null,
@@ -55,10 +56,13 @@ function buildProvisioning(
   };
 }
 
-function renderSection(provisioning: SetupNewComputeProvisioningState | null) {
+function renderSection(
+  provisioning: SetupNewComputeProvisioningState | null,
+  providerOverride: ComputeProviderStatus = provider,
+) {
   return render(
     <ComputeProviderSection
-      provider={provider}
+      provider={providerOverride}
       isDefault={false}
       provisioning={provisioning}
       onSave={vi.fn()}
@@ -76,8 +80,19 @@ describe('ComputeProviderSection provisioning states', () => {
     const button = screen.getByRole('button', { name: /Provisioning\.\.\./ });
     expect(button).toBeDisabled();
     expect(
-      screen.getByText(/Provisioning the worker base image/),
+      screen.getByText(/must finish before this provider can run tasks/),
     ).toBeInTheDocument();
+  });
+
+  it('explains that a rebuild is non-blocking when an older artifact is active', () => {
+    renderSection(buildProvisioning({ status: 'building' }), {
+      ...provider,
+      configSatisfied: true,
+    });
+
+    expect(
+      screen.getByText(/Updating the worker base image in the background/),
+    ).toHaveTextContent(/existing tasks keep using the current image/);
   });
 
   it('surfaces the provisioning error and offers a retry after a failed run', () => {

--- a/apps/web/src/components/settings/ComputeProviderSection.client.test.tsx
+++ b/apps/web/src/components/settings/ComputeProviderSection.client.test.tsx
@@ -46,7 +46,7 @@ function buildProvisioning(
 ): SetupNewComputeProvisioningState {
   return {
     status: 'building',
-    runtimeSchemaVersion: 1,
+    runtimeSchemaVersion: 2,
     imageRef: 'ghcr.io/roocodeinc/roomote-worker:develop-abc12345',
     templateRef: 'roomote-worker:develop-abc12345',
     error: null,

--- a/apps/web/src/components/settings/ComputeProviderSection.tsx
+++ b/apps/web/src/components/settings/ComputeProviderSection.tsx
@@ -199,6 +199,7 @@ export function ComputeProviderSection({
       !field.savedSatisfied,
   );
   const provisioningRunning = provisioning?.status === 'building';
+  const provisioningRefresh = provisioningRunning && provider.configSatisfied;
   const provisioningFailed = provisioning?.status === 'failed';
   // Credentials are already satisfied when a save can still start or retry
   // auto-provisioning without retyping values (existing installs that later
@@ -523,8 +524,9 @@ export function ComputeProviderSection({
 
               {provisioningRunning && (
                 <p className="max-w-xl text-sm text-muted-foreground">
-                  Provisioning the worker base image. This can take a few
-                  minutes.
+                  {provisioningRefresh
+                    ? 'Updating the worker base image in the background. This can take several minutes; existing tasks keep using the current image until the replacement is ready.'
+                    : 'Provisioning the worker base image. This can take several minutes and must finish before this provider can run tasks.'}
                 </p>
               )}
 

--- a/apps/web/src/components/settings/environments/ContainerProjectListEditor.client.test.tsx
+++ b/apps/web/src/components/settings/environments/ContainerProjectListEditor.client.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { ContainerProjectListEditor } from './ContainerProjectListEditor';
+
+describe('ContainerProjectListEditor', () => {
+  it('adds a Compose project tied to the first configured repository', () => {
+    const onChange = vi.fn();
+    render(
+      <ContainerProjectListEditor
+        repositories={[{ repository: 'acme/web' }]}
+        ports={[{ name: 'WEB', port: 3000 }]}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /Add container project/i }),
+    );
+
+    expect(onChange).toHaveBeenCalledWith([
+      {
+        type: 'compose',
+        name: 'app1',
+        repository: 'acme/web',
+        files: ['compose.yaml'],
+        required: true,
+      },
+    ]);
+  });
+
+  it('adds a named preview mapping for a Dockerfile', () => {
+    const onChange = vi.fn();
+    render(
+      <ContainerProjectListEditor
+        projects={[
+          {
+            type: 'dockerfile',
+            name: 'web',
+            repository: 'acme/web',
+          },
+        ]}
+        repositories={[{ repository: 'acme/web' }]}
+        ports={[{ name: 'WEB', port: 3000 }]}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Map preview port/i }));
+
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({
+        type: 'dockerfile',
+        ports: [
+          {
+            named_port: 'WEB',
+            container_port: 3000,
+          },
+        ],
+      }),
+    ]);
+  });
+});

--- a/apps/web/src/components/settings/environments/ContainerProjectListEditor.tsx
+++ b/apps/web/src/components/settings/environments/ContainerProjectListEditor.tsx
@@ -1,0 +1,459 @@
+'use client';
+
+import type {
+  ContainerProject,
+  ContainerProjectPort,
+  EnvironmentRepositoryConfig,
+  NamedPort,
+} from '@roomote/types';
+
+import {
+  Button,
+  Checkbox,
+  Input,
+  Label,
+  Plus,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Trash2,
+} from '@/components/system';
+
+import { FieldShell } from './VisualEnvironmentEditor.layout';
+
+function splitList(value: string): string[] | undefined {
+  const values = value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return values.length > 0 ? values : undefined;
+}
+
+export function ContainerProjectListEditor({
+  projects,
+  repositories,
+  ports,
+  onChange,
+}: {
+  projects?: ContainerProject[];
+  repositories: EnvironmentRepositoryConfig[];
+  ports?: NamedPort[];
+  onChange: (projects: ContainerProject[] | undefined) => void;
+}) {
+  const updateProject = (index: number, project: ContainerProject) => {
+    const next = [...(projects ?? [])];
+    next[index] = project;
+    onChange(next);
+  };
+
+  return (
+    <div className="space-y-4">
+      {(projects ?? []).map((project, index) => (
+        <div
+          key={`${project.name}-${index}`}
+          className="space-y-4 rounded-lg border border-border/70 bg-background/60 p-4"
+        >
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-sm font-medium">
+              {project.name || `Container project ${index + 1}`}
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label={`Remove container project ${index + 1}`}
+              onClick={() => {
+                const next = (projects ?? []).filter(
+                  (_, projectIndex) => projectIndex !== index,
+                );
+                onChange(next.length > 0 ? next : undefined);
+              }}
+            >
+              <Trash2 />
+            </Button>
+          </div>
+
+          <div className="grid gap-3 md:grid-cols-2">
+            <FieldShell>
+              <Label htmlFor={`container-project-name-${index}`}>Name</Label>
+              <Input
+                id={`container-project-name-${index}`}
+                value={project.name}
+                placeholder="app"
+                onChange={(event) =>
+                  updateProject(index, {
+                    ...project,
+                    name: event.target.value,
+                  })
+                }
+              />
+            </FieldShell>
+
+            <FieldShell>
+              <Label>Source</Label>
+              <Select
+                value={project.type}
+                onValueChange={(type) => {
+                  const common = {
+                    name: project.name,
+                    repository: project.repository,
+                    ...(project.working_dir
+                      ? { working_dir: project.working_dir }
+                      : {}),
+                    ...(project.env ? { env: project.env } : {}),
+                    ...(project.ports ? { ports: project.ports } : {}),
+                    ...(project.required !== undefined
+                      ? { required: project.required }
+                      : {}),
+                    ...(project.startup_timeout_seconds
+                      ? {
+                          startup_timeout_seconds:
+                            project.startup_timeout_seconds,
+                        }
+                      : {}),
+                  };
+                  updateProject(
+                    index,
+                    type === 'compose'
+                      ? { ...common, type: 'compose', files: ['compose.yaml'] }
+                      : { ...common, type: 'dockerfile' },
+                  );
+                }}
+              >
+                <SelectTrigger aria-label="Container source">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="compose">Docker Compose</SelectItem>
+                  <SelectItem value="dockerfile">Dockerfile</SelectItem>
+                </SelectContent>
+              </Select>
+            </FieldShell>
+
+            <FieldShell>
+              <Label>Repository</Label>
+              <Select
+                value={project.repository}
+                onValueChange={(repository) =>
+                  updateProject(index, { ...project, repository })
+                }
+              >
+                <SelectTrigger aria-label="Container project repository">
+                  <SelectValue placeholder="Select repository" />
+                </SelectTrigger>
+                <SelectContent>
+                  {repositories
+                    .filter((repository) => repository.repository)
+                    .map((repository) => (
+                      <SelectItem
+                        key={repository.repository}
+                        value={repository.repository}
+                      >
+                        {repository.repository}
+                      </SelectItem>
+                    ))}
+                </SelectContent>
+              </Select>
+            </FieldShell>
+
+            <FieldShell>
+              <Label htmlFor={`container-project-working-dir-${index}`}>
+                Working directory
+              </Label>
+              <Input
+                id={`container-project-working-dir-${index}`}
+                value={project.working_dir ?? ''}
+                placeholder="."
+                onChange={(event) => {
+                  const workingDir = event.target.value.trim();
+                  const next = { ...project };
+                  if (workingDir) next.working_dir = workingDir;
+                  else delete next.working_dir;
+                  updateProject(index, next);
+                }}
+              />
+            </FieldShell>
+
+            {project.type === 'compose' ? (
+              <>
+                <FieldShell>
+                  <Label htmlFor={`container-project-files-${index}`}>
+                    Compose files
+                  </Label>
+                  <Input
+                    id={`container-project-files-${index}`}
+                    value={project.files.join(', ')}
+                    placeholder="compose.yaml"
+                    onChange={(event) =>
+                      updateProject(index, {
+                        ...project,
+                        files: splitList(event.target.value) ?? [],
+                      })
+                    }
+                  />
+                </FieldShell>
+                <FieldShell>
+                  <Label htmlFor={`container-project-services-${index}`}>
+                    Services (optional)
+                  </Label>
+                  <Input
+                    id={`container-project-services-${index}`}
+                    value={project.services?.join(', ') ?? ''}
+                    placeholder="web, api"
+                    onChange={(event) => {
+                      const services = splitList(event.target.value);
+                      const next = { ...project };
+                      if (services) next.services = services;
+                      else delete next.services;
+                      updateProject(index, next);
+                    }}
+                  />
+                </FieldShell>
+                <FieldShell>
+                  <Label htmlFor={`container-project-profiles-${index}`}>
+                    Profiles (optional)
+                  </Label>
+                  <Input
+                    id={`container-project-profiles-${index}`}
+                    value={project.profiles?.join(', ') ?? ''}
+                    placeholder="development"
+                    onChange={(event) => {
+                      const profiles = splitList(event.target.value);
+                      const next = { ...project };
+                      if (profiles) next.profiles = profiles;
+                      else delete next.profiles;
+                      updateProject(index, next);
+                    }}
+                  />
+                </FieldShell>
+              </>
+            ) : (
+              <>
+                <FieldShell>
+                  <Label htmlFor={`container-project-context-${index}`}>
+                    Build context
+                  </Label>
+                  <Input
+                    id={`container-project-context-${index}`}
+                    value={project.context ?? ''}
+                    placeholder="."
+                    onChange={(event) => {
+                      const context = event.target.value.trim();
+                      const next = { ...project };
+                      if (context) next.context = context;
+                      else delete next.context;
+                      updateProject(index, next);
+                    }}
+                  />
+                </FieldShell>
+                <FieldShell>
+                  <Label htmlFor={`container-project-dockerfile-${index}`}>
+                    Dockerfile path
+                  </Label>
+                  <Input
+                    id={`container-project-dockerfile-${index}`}
+                    value={project.dockerfile ?? ''}
+                    placeholder="Dockerfile"
+                    onChange={(event) => {
+                      const dockerfile = event.target.value.trim();
+                      const next = { ...project };
+                      if (dockerfile) next.dockerfile = dockerfile;
+                      else delete next.dockerfile;
+                      updateProject(index, next);
+                    }}
+                  />
+                </FieldShell>
+                <FieldShell>
+                  <Label htmlFor={`container-project-target-${index}`}>
+                    Build target (optional)
+                  </Label>
+                  <Input
+                    id={`container-project-target-${index}`}
+                    value={project.target ?? ''}
+                    onChange={(event) => {
+                      const target = event.target.value.trim();
+                      const next = { ...project };
+                      if (target) next.target = target;
+                      else delete next.target;
+                      updateProject(index, next);
+                    }}
+                  />
+                </FieldShell>
+              </>
+            )}
+          </div>
+
+          <ContainerPortMappings
+            project={project}
+            ports={ports}
+            onChange={(projectPorts) => {
+              const next = { ...project };
+              if (projectPorts.length > 0) next.ports = projectPorts;
+              else delete next.ports;
+              updateProject(index, next);
+            }}
+          />
+
+          <label className="flex items-center gap-2 text-sm">
+            <Checkbox
+              checked={project.required !== false}
+              onCheckedChange={(checked) =>
+                updateProject(index, {
+                  ...project,
+                  required: checked === true,
+                })
+              }
+            />
+            Fail environment startup if this project cannot start
+          </label>
+        </div>
+      ))}
+
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={!repositories.some((repository) => repository.repository)}
+        onClick={() => {
+          const repository =
+            repositories.find((candidate) => candidate.repository)
+              ?.repository ?? '';
+          onChange([
+            ...(projects ?? []),
+            {
+              type: 'compose',
+              name: `app${(projects?.length ?? 0) + 1}`,
+              repository,
+              files: ['compose.yaml'],
+              required: true,
+            },
+          ]);
+        }}
+      >
+        <Plus />
+        Add container project
+      </Button>
+    </div>
+  );
+}
+
+function ContainerPortMappings({
+  project,
+  ports,
+  onChange,
+}: {
+  project: ContainerProject;
+  ports?: NamedPort[];
+  onChange: (ports: ContainerProjectPort[]) => void;
+}) {
+  const mappings = project.ports ?? [];
+  return (
+    <div className="space-y-2">
+      <Label>Preview port mappings</Label>
+      {mappings.map((mapping, index) => (
+        <div
+          key={`${mapping.named_port}-${index}`}
+          className="grid gap-2 md:grid-cols-[1fr_1fr_1fr_auto]"
+        >
+          <Select
+            value={mapping.named_port}
+            onValueChange={(namedPort) =>
+              onChange(
+                mappings.map((current, currentIndex) =>
+                  currentIndex === index
+                    ? { ...current, named_port: namedPort }
+                    : current,
+                ),
+              )
+            }
+          >
+            <SelectTrigger aria-label="Environment port">
+              <SelectValue placeholder="Environment port" />
+            </SelectTrigger>
+            <SelectContent>
+              {(ports ?? []).map((port) => (
+                <SelectItem key={port.name} value={port.name}>
+                  {port.name} ({port.port})
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {project.type === 'compose' ? (
+            <Input
+              aria-label="Compose service"
+              value={mapping.service ?? ''}
+              placeholder="Compose service"
+              onChange={(event) =>
+                onChange(
+                  mappings.map((current, currentIndex) =>
+                    currentIndex === index
+                      ? { ...current, service: event.target.value }
+                      : current,
+                  ),
+                )
+              }
+            />
+          ) : (
+            <div />
+          )}
+          <Input
+            aria-label="Container port"
+            type="number"
+            min={1}
+            max={65535}
+            value={mapping.container_port}
+            placeholder="3000"
+            onChange={(event) =>
+              onChange(
+                mappings.map((current, currentIndex) =>
+                  currentIndex === index
+                    ? {
+                        ...current,
+                        container_port: Number(event.target.value),
+                      }
+                    : current,
+                ),
+              )
+            }
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label={`Remove port mapping ${index + 1}`}
+            onClick={() =>
+              onChange(
+                mappings.filter((_, mappingIndex) => mappingIndex !== index),
+              )
+            }
+          >
+            <Trash2 />
+          </Button>
+        </div>
+      ))}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={!ports?.length}
+        onClick={() => {
+          const firstPort = ports?.[0];
+          if (!firstPort) return;
+          onChange([
+            ...mappings,
+            {
+              named_port: firstPort.name,
+              ...(project.type === 'compose' ? { service: '' } : {}),
+              container_port: firstPort.port,
+            },
+          ]);
+        }}
+      >
+        <Plus />
+        Map preview port
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/environments/EnvironmentPreview.tsx
+++ b/apps/web/src/components/settings/environments/EnvironmentPreview.tsx
@@ -4,6 +4,7 @@ import type { ComponentType, ReactNode } from 'react';
 
 import {
   Badge,
+  Container,
   Database,
   GitBranch,
   Globe,
@@ -90,6 +91,31 @@ export function EnvironmentPreviewContent({
           ))}
         </div>
       </PreviewSection>
+
+      {config.container_projects?.length ? (
+        <PreviewSection icon={Container} title="Containers">
+          <div className="space-y-2">
+            {config.container_projects.map((project) => (
+              <div
+                key={project.name}
+                className="flex flex-wrap items-center gap-2 rounded border border-border/70 px-3 py-2 text-sm"
+              >
+                <span className="font-medium">{project.name}</span>
+                <Badge variant="secondary">
+                  {project.type === 'compose' ? 'Docker Compose' : 'Dockerfile'}
+                </Badge>
+                <code className="font-mono text-xs text-muted-foreground">
+                  {project.repository}
+                  {project.working_dir ? `/${project.working_dir}` : ''}
+                </code>
+                {project.required === false ? (
+                  <Badge variant="outline">optional</Badge>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        </PreviewSection>
+      ) : null}
 
       {hasRecordEntries(config.env) ? (
         <PreviewSection icon={KeyRound} title="Environment Variables">

--- a/apps/web/src/components/settings/environments/VisualEnvironmentEditor.tsx
+++ b/apps/web/src/components/settings/environments/VisualEnvironmentEditor.tsx
@@ -11,6 +11,7 @@ import {
 import {
   Button,
   Checkbox,
+  Container,
   Database,
   GitBranch,
   Globe,
@@ -31,6 +32,7 @@ import {
 } from '@/components/system';
 
 import { KeyValueListEditor } from './KeyValueListEditor';
+import { ContainerProjectListEditor } from './ContainerProjectListEditor';
 import { PortListEditor } from './PortListEditor';
 import { RepositoryEditor } from './RepositoryEditor';
 import { FieldShell, SectionShell } from './VisualEnvironmentEditor.layout';
@@ -334,6 +336,31 @@ export function VisualEnvironmentEditor({
             />
           ))}
         </div>
+      </SectionShell>
+
+      <SectionShell
+        icon={Container}
+        title="Containers"
+        defaultOpen={Boolean(config.container_projects?.length)}
+      >
+        <p className="mb-4 text-sm text-muted-foreground">
+          Build and start an existing Docker Compose project or Dockerfile after
+          its repository is ready. Projects run inside this task&apos;s isolated
+          environment.
+        </p>
+        <ContainerProjectListEditor
+          projects={config.container_projects}
+          repositories={config.repositories}
+          ports={config.ports}
+          onChange={(next) =>
+            onChange(
+              updateEnvironmentConfig(config, (draft) => {
+                if (next) draft.container_projects = next;
+                else delete draft.container_projects;
+              }),
+            )
+          }
+        />
       </SectionShell>
 
       <SectionShell

--- a/apps/web/src/components/settings/environments/YamlEnvironmentEditor.test.ts
+++ b/apps/web/src/components/settings/environments/YamlEnvironmentEditor.test.ts
@@ -80,6 +80,56 @@ describe('configToYaml', () => {
     expect(yaml).toContain('tool_versions:');
   });
 
+  it('preserves container projects when serializing environment config', () => {
+    const config: EnvironmentConfig = {
+      name: 'Container Projects Env',
+      repositories: [{ repository: 'Roomote/example-app' }],
+      ports: [
+        {
+          name: 'WEBAPP',
+          port: 3000,
+        },
+      ],
+      container_projects: [
+        {
+          name: 'compose-app',
+          type: 'compose',
+          repository: 'Roomote/example-app',
+          working_dir: 'deploy',
+          files: ['compose.yaml', 'compose.override.yaml'],
+          profiles: ['development'],
+          services: ['web'],
+          env: { NODE_ENV: 'development' },
+          ports: [
+            {
+              named_port: 'WEBAPP',
+              service: 'web',
+              container_port: 3000,
+            },
+          ],
+          required: true,
+          startup_timeout_seconds: 120,
+        },
+        {
+          name: 'worker-image',
+          type: 'dockerfile',
+          repository: 'Roomote/example-app',
+          context: '.',
+          dockerfile: 'Dockerfile.worker',
+          target: 'development',
+          build_args: { NODE_VERSION: '22' },
+          command: ['pnpm', 'worker'],
+        },
+      ],
+    };
+
+    const yaml = configToYaml(config);
+    const parsed = YAML.parse(yaml);
+
+    expect(parsed.container_projects).toEqual(config.container_projects);
+    expect(yaml).toContain('container_projects:');
+  });
+
   it('preserves manualSkills when serializing environment config', () => {
     const config: EnvironmentConfig = {
       name: 'Manual Skills Env',

--- a/apps/web/src/components/settings/environments/YamlEnvironmentEditor.tsx
+++ b/apps/web/src/components/settings/environments/YamlEnvironmentEditor.tsx
@@ -90,6 +90,26 @@ ${repoLines}
 #   - redis7
 #   - postgres16
 
+# Optional: Build and start a Docker Compose project or a single Dockerfile
+# after its repository is cloned. Paths are relative to the selected repo.
+# container_projects:
+#   - type: compose
+#     name: app
+#     repository: owner/repo-name
+#     files:
+#       - compose.yaml
+#     services:
+#       - web
+#     ports:
+#       - named_port: WEB
+#         service: web
+#         container_port: 3000
+#   - type: dockerfile
+#     name: worker
+#     repository: owner/repo-name
+#     context: .
+#     dockerfile: Dockerfile
+
 # Optional: Install extra skills during environment setup.
 # Group skills by owner/repo source.
 # skills:

--- a/apps/web/src/components/settings/environments/yaml-utils.ts
+++ b/apps/web/src/components/settings/environments/yaml-utils.ts
@@ -87,6 +87,10 @@ export function configToYaml(config: EnvironmentConfig): string {
     });
   }
 
+  if (config.container_projects && config.container_projects.length > 0) {
+    cleanConfig.container_projects = config.container_projects;
+  }
+
   if (config.services && config.services.length > 0) {
     cleanConfig.services = config.services;
   }

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -15,6 +15,21 @@ export async function register() {
       await import('@/lib/server/bootstrap-runtime-env');
 
     await bootstrapWebRuntimeEnv();
+
+    // Non-fatal, detached reconciliation of E2B/Daytona/Blaxel artifacts.
+    // A release image or worker-runtime schema change creates a replacement
+    // artifact and atomically activates it only after the build succeeds.
+    void import('@/trpc/commands/compute/compute-provisioning')
+      .then(({ reconcileComputeProvisioningOnStartup }) =>
+        reconcileComputeProvisioningOnStartup(),
+      )
+      .catch((error) => {
+        console.error(
+          `[instrumentation] Hosted worker artifact reconciliation failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      });
   }
 
   const environment = resolveWebSentryEnvironment();

--- a/apps/web/src/trpc/commands/compute/compute-provisioning.test.ts
+++ b/apps/web/src/trpc/commands/compute/compute-provisioning.test.ts
@@ -85,7 +85,7 @@ const STALE_STARTED_AT = '2026-07-03T00:00:00.000Z';
 
 const staleBuildingEntry: SetupNewComputeProvisioningState = {
   status: 'building',
-  runtimeSchemaVersion: 1,
+  runtimeSchemaVersion: 2,
   imageRef: 'registry.example.com/worker:old',
   templateRef: 'roomote-worker-old',
   error: null,
@@ -105,7 +105,7 @@ describe('persistComputeProvisioning', () => {
       'daytona',
       {
         status: 'building',
-        runtimeSchemaVersion: 1,
+        runtimeSchemaVersion: 2,
         imageRef: 'registry.example.com/worker:new',
         templateRef: 'roomote-worker-new',
         error: null,
@@ -130,7 +130,7 @@ describe('persistComputeProvisioning', () => {
       'daytona',
       {
         status: 'failed',
-        runtimeSchemaVersion: 1,
+        runtimeSchemaVersion: 2,
         imageRef: 'registry.example.com/worker:old',
         templateRef: null,
         error: 'boom',
@@ -158,7 +158,7 @@ describe('persistComputeProvisioning', () => {
       'e2b',
       {
         status: 'building',
-        runtimeSchemaVersion: 1,
+        runtimeSchemaVersion: 2,
         imageRef: 'registry.example.com/worker:new',
         templateRef: 'roomote-worker:new',
         error: null,
@@ -277,7 +277,7 @@ describe('prepareComputeProvisioningStart', () => {
       },
       existingState: {
         status: 'building',
-        runtimeSchemaVersion: 1,
+        runtimeSchemaVersion: 2,
         imageRef: 'registry.example.com/worker:tag',
         templateRef: 'roomote-worker-tag',
         error: null,
@@ -325,7 +325,7 @@ describe('prepareComputeProvisioningStart', () => {
       },
       existingState: {
         status: 'succeeded',
-        runtimeSchemaVersion: 1,
+        runtimeSchemaVersion: 2,
         imageRef: 'registry.example.com/worker:old',
         templateRef: 'roomote-worker:old',
         error: null,
@@ -414,7 +414,7 @@ describe('prepareComputeProvisioningStart', () => {
       },
       existingState: {
         status: 'succeeded',
-        runtimeSchemaVersion: 1,
+        runtimeSchemaVersion: 2,
         imageRef: 'registry.example.com/worker:tag',
         templateRef: 'roomote-worker:tag',
         error: null,
@@ -509,7 +509,7 @@ describe('reconcileComputeProvisioningOnStartup', () => {
     const { executor } = createExecutorMock({
       e2bTemplateBuild: {
         status: 'succeeded',
-        runtimeSchemaVersion: 1,
+        runtimeSchemaVersion: 2,
         imageRef: 'registry.example.com/worker:tag',
         templateRef: 'roomote-worker:tag',
         error: null,
@@ -533,7 +533,7 @@ describe('runComputeProvisioning', () => {
       E2B_API_KEY: 'key',
     });
     mockBuildE2bWorkerTemplate.mockResolvedValue({
-      templateRef: 'roomote-worker:old-r1',
+      templateRef: 'roomote-worker:old-r2',
       templateId: 'template-id',
       buildId: 'build-id',
       tags: [],
@@ -542,9 +542,9 @@ describe('runComputeProvisioning', () => {
     const { captured, executor } = createExecutorMock({
       e2bTemplateBuild: {
         status: 'building',
-        runtimeSchemaVersion: 1,
+        runtimeSchemaVersion: 2,
         imageRef: 'registry.example.com/worker:new',
-        templateRef: 'roomote-worker:new-r1',
+        templateRef: 'roomote-worker:new-r2',
         error: null,
         startedAt: new Date().toISOString(),
         finishedAt: null,
@@ -558,7 +558,7 @@ describe('runComputeProvisioning', () => {
       provider: 'e2b',
       userId: null,
       imageRef: 'registry.example.com/worker:old',
-      templateRef: 'roomote-worker:old-r1',
+      templateRef: 'roomote-worker:old-r2',
     });
 
     expect(execute).toHaveBeenCalledOnce();

--- a/apps/web/src/trpc/commands/compute/compute-provisioning.test.ts
+++ b/apps/web/src/trpc/commands/compute/compute-provisioning.test.ts
@@ -3,16 +3,36 @@ import type {
   SetupNewState,
 } from '@roomote/types';
 
+const {
+  mockDbTransaction,
+  mockGetPersistedEnvironmentVariableNames,
+  mockGetPersistedEnvironmentVariableValues,
+  mockBuildE2bWorkerTemplate,
+  mockResolveComputeProviderEnvValues,
+  mockUpsertDeploymentEnvironmentVariables,
+} = vi.hoisted(() => ({
+  mockDbTransaction: vi.fn(),
+  mockGetPersistedEnvironmentVariableNames: vi.fn(),
+  mockGetPersistedEnvironmentVariableValues: vi.fn(),
+  mockBuildE2bWorkerTemplate: vi.fn(),
+  mockResolveComputeProviderEnvValues: vi.fn(),
+  mockUpsertDeploymentEnvironmentVariables: vi.fn(),
+}));
+
 vi.mock('@roomote/db/server', () => ({
-  db: {},
+  db: { transaction: mockDbTransaction },
   deploymentSettings: { id: 'deployment_settings.id' },
   eq: vi.fn(),
-  resolveComputeProviderEnvValues: vi.fn(),
+  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+  })),
+  resolveComputeProviderEnvValues: mockResolveComputeProviderEnvValues,
 }));
 
 vi.mock('@roomote/compute-providers', () => ({
   buildBlaxelWorkerImage: vi.fn(),
-  buildE2bWorkerTemplate: vi.fn(),
+  buildE2bWorkerTemplate: mockBuildE2bWorkerTemplate,
   registerDaytonaWorkerSnapshot: vi.fn(),
   deriveBlaxelWorkerImageName: (imageRef: string) =>
     `roomote-worker-${imageRef.slice(imageRef.lastIndexOf(':') + 1)}`,
@@ -23,12 +43,19 @@ vi.mock('@roomote/compute-providers', () => ({
 }));
 
 vi.mock('../environment-variables', () => ({
-  upsertDeploymentEnvironmentVariables: vi.fn(),
+  getPersistedEnvironmentVariableNames:
+    mockGetPersistedEnvironmentVariableNames,
+  getPersistedEnvironmentVariableValues:
+    mockGetPersistedEnvironmentVariableValues,
+  upsertDeploymentEnvironmentVariables:
+    mockUpsertDeploymentEnvironmentVariables,
 }));
 
 import {
   persistComputeProvisioning,
   prepareComputeProvisioningStart,
+  reconcileComputeProvisioningOnStartup,
+  runComputeProvisioning,
 } from './compute-provisioning';
 
 function createExecutorMock(existingState: Partial<SetupNewState>) {
@@ -58,6 +85,7 @@ const STALE_STARTED_AT = '2026-07-03T00:00:00.000Z';
 
 const staleBuildingEntry: SetupNewComputeProvisioningState = {
   status: 'building',
+  runtimeSchemaVersion: 1,
   imageRef: 'registry.example.com/worker:old',
   templateRef: 'roomote-worker-old',
   error: null,
@@ -77,6 +105,7 @@ describe('persistComputeProvisioning', () => {
       'daytona',
       {
         status: 'building',
+        runtimeSchemaVersion: 1,
         imageRef: 'registry.example.com/worker:new',
         templateRef: 'roomote-worker-new',
         error: null,
@@ -101,6 +130,7 @@ describe('persistComputeProvisioning', () => {
       'daytona',
       {
         status: 'failed',
+        runtimeSchemaVersion: 1,
         imageRef: 'registry.example.com/worker:old',
         templateRef: null,
         error: 'boom',
@@ -128,6 +158,7 @@ describe('persistComputeProvisioning', () => {
       'e2b',
       {
         status: 'building',
+        runtimeSchemaVersion: 1,
         imageRef: 'registry.example.com/worker:new',
         templateRef: 'roomote-worker:new',
         error: null,
@@ -246,6 +277,7 @@ describe('prepareComputeProvisioningStart', () => {
       },
       existingState: {
         status: 'building',
+        runtimeSchemaVersion: 1,
         imageRef: 'registry.example.com/worker:tag',
         templateRef: 'roomote-worker-tag',
         error: null,
@@ -259,6 +291,143 @@ describe('prepareComputeProvisioningStart', () => {
     expect(result).toEqual({
       fieldPending: true,
       provisionable: true,
+      start: null,
+    });
+    expect(markPending).not.toHaveBeenCalled();
+  });
+
+  it('rebuilds a saved artifact when its worker image is from an older release', async () => {
+    const markPending = vi.fn();
+    const result = await prepareComputeProvisioningStart({
+      provider: 'e2b',
+      providerStatus: {
+        provider: 'e2b',
+        label: 'E2B',
+        description: '',
+        supportsSnapshots: true,
+        comment: 'Recommended',
+        runtimeConfigSatisfied: false,
+        savedConfigSatisfied: true,
+        configSatisfied: true,
+        infrastructureSatisfied: true,
+        fields: [
+          {
+            envVarName: 'E2B_TEMPLATE_ID',
+            label: 'Worker Template ID',
+            category: 'infrastructure',
+            advanced: true,
+            runtimeSatisfied: false,
+            savedSatisfied: true,
+            defaultSatisfied: false,
+            setupProvisionable: true,
+          },
+        ],
+      },
+      existingState: {
+        status: 'succeeded',
+        runtimeSchemaVersion: 1,
+        imageRef: 'registry.example.com/worker:old',
+        templateRef: 'roomote-worker:old',
+        error: null,
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date().toISOString(),
+      },
+      dockerWorkerImage: 'registry.example.com/worker:new',
+      markPending,
+    });
+
+    expect(result.start).toMatchObject({
+      provider: 'e2b',
+      imageRef: 'registry.example.com/worker:new',
+    });
+    expect(markPending).toHaveBeenCalledOnce();
+  });
+
+  it('rebuilds a saved artifact when the runtime schema metadata is missing', async () => {
+    const markPending = vi.fn();
+    const result = await prepareComputeProvisioningStart({
+      provider: 'e2b',
+      providerStatus: {
+        provider: 'e2b',
+        label: 'E2B',
+        description: '',
+        supportsSnapshots: true,
+        comment: 'Recommended',
+        runtimeConfigSatisfied: false,
+        savedConfigSatisfied: true,
+        configSatisfied: true,
+        infrastructureSatisfied: true,
+        fields: [
+          {
+            envVarName: 'E2B_TEMPLATE_ID',
+            label: 'Worker Template ID',
+            category: 'infrastructure',
+            advanced: true,
+            runtimeSatisfied: false,
+            savedSatisfied: true,
+            defaultSatisfied: false,
+            setupProvisionable: true,
+          },
+        ],
+      },
+      existingState: {
+        status: 'succeeded',
+        imageRef: 'registry.example.com/worker:tag',
+        templateRef: 'roomote-worker:tag',
+        error: null,
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date().toISOString(),
+      } as SetupNewComputeProvisioningState,
+      dockerWorkerImage: 'registry.example.com/worker:tag',
+      markPending,
+    });
+
+    expect(result.start).not.toBeNull();
+  });
+
+  it('keeps a saved artifact when image and runtime schema are current', async () => {
+    const markPending = vi.fn();
+    const result = await prepareComputeProvisioningStart({
+      provider: 'e2b',
+      providerStatus: {
+        provider: 'e2b',
+        label: 'E2B',
+        description: '',
+        supportsSnapshots: true,
+        comment: 'Recommended',
+        runtimeConfigSatisfied: false,
+        savedConfigSatisfied: true,
+        configSatisfied: true,
+        infrastructureSatisfied: true,
+        fields: [
+          {
+            envVarName: 'E2B_TEMPLATE_ID',
+            label: 'Worker Template ID',
+            category: 'infrastructure',
+            advanced: true,
+            runtimeSatisfied: false,
+            savedSatisfied: true,
+            defaultSatisfied: false,
+            setupProvisionable: true,
+          },
+        ],
+      },
+      existingState: {
+        status: 'succeeded',
+        runtimeSchemaVersion: 1,
+        imageRef: 'registry.example.com/worker:tag',
+        templateRef: 'roomote-worker:tag',
+        error: null,
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date().toISOString(),
+      },
+      dockerWorkerImage: 'registry.example.com/worker:tag',
+      markPending,
+    });
+
+    expect(result).toEqual({
+      fieldPending: false,
+      provisionable: false,
       start: null,
     });
     expect(markPending).not.toHaveBeenCalled();
@@ -323,5 +492,77 @@ describe('prepareComputeProvisioningStart', () => {
         templateRef: 'roomote-worker:latest',
       }),
     );
+  });
+});
+
+describe('reconcileComputeProvisioningOnStartup', () => {
+  it('takes a deployment-wide claim and skips an already-current artifact', async () => {
+    vi.stubEnv('DOCKER_WORKER_IMAGE', 'registry.example.com/worker:tag');
+    mockGetPersistedEnvironmentVariableNames.mockResolvedValue([
+      'E2B_API_KEY',
+      'E2B_TEMPLATE_ID',
+    ]);
+    mockGetPersistedEnvironmentVariableValues.mockResolvedValue({
+      E2B_TEMPLATE_ID: 'roomote-worker:tag',
+    });
+    const execute = vi.fn();
+    const { executor } = createExecutorMock({
+      e2bTemplateBuild: {
+        status: 'succeeded',
+        runtimeSchemaVersion: 1,
+        imageRef: 'registry.example.com/worker:tag',
+        templateRef: 'roomote-worker:tag',
+        error: null,
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date().toISOString(),
+      },
+    });
+    const tx = executor as unknown as { execute: typeof execute };
+    tx.execute = execute;
+    mockDbTransaction.mockImplementation(async (callback) => callback(tx));
+
+    await reconcileComputeProvisioningOnStartup();
+
+    expect(execute).toHaveBeenCalledOnce();
+  });
+});
+
+describe('runComputeProvisioning', () => {
+  it('does not activate an artifact after a newer desired build supersedes it', async () => {
+    mockResolveComputeProviderEnvValues.mockResolvedValue({
+      E2B_API_KEY: 'key',
+    });
+    mockBuildE2bWorkerTemplate.mockResolvedValue({
+      templateRef: 'roomote-worker:old-r1',
+      templateId: 'template-id',
+      buildId: 'build-id',
+      tags: [],
+    });
+    const execute = vi.fn();
+    const { captured, executor } = createExecutorMock({
+      e2bTemplateBuild: {
+        status: 'building',
+        runtimeSchemaVersion: 1,
+        imageRef: 'registry.example.com/worker:new',
+        templateRef: 'roomote-worker:new-r1',
+        error: null,
+        startedAt: new Date().toISOString(),
+        finishedAt: null,
+      },
+    });
+    const tx = executor as unknown as { execute: typeof execute };
+    tx.execute = execute;
+    mockDbTransaction.mockImplementation(async (callback) => callback(tx));
+
+    await runComputeProvisioning({
+      provider: 'e2b',
+      userId: null,
+      imageRef: 'registry.example.com/worker:old',
+      templateRef: 'roomote-worker:old-r1',
+    });
+
+    expect(execute).toHaveBeenCalledOnce();
+    expect(mockUpsertDeploymentEnvironmentVariables).not.toHaveBeenCalled();
+    expect(captured.setupNewState).toBeUndefined();
   });
 });

--- a/apps/web/src/trpc/commands/compute/compute-provisioning.ts
+++ b/apps/web/src/trpc/commands/compute/compute-provisioning.ts
@@ -2,6 +2,7 @@ import {
   db,
   deploymentSettings,
   eq,
+  sql,
   resolveComputeProviderEnvValues,
   type DatabaseOrTransaction,
 } from '@roomote/db/server';
@@ -15,16 +16,23 @@ import {
 } from '@roomote/compute-providers';
 import {
   isSetupNewComputeProvisioningStale,
+  buildSetupComputeStatus,
+  NON_SECRET_COMPUTE_ENV_VAR_NAMES,
   normalizeSetupNewState,
   resolveDerivedModalBaseImageRef,
   SETUP_COMPUTE_PROVISIONING_STALE_MS,
   SETUP_COMPUTE_PROVISIONING_STATE_FIELDS,
+  WORKER_RUNTIME_SCHEMA_VERSION,
   type SetupComputeProviderStatus,
   type SetupNewComputeProvisioningState,
   type SetupProvisionableComputeProvider,
 } from '@roomote/types';
 
-import { upsertDeploymentEnvironmentVariables } from '../environment-variables';
+import {
+  getPersistedEnvironmentVariableNames,
+  getPersistedEnvironmentVariableValues,
+  upsertDeploymentEnvironmentVariables,
+} from '../environment-variables';
 
 /**
  * Shared worker base-image provisioning used by both the setup wizard and
@@ -146,6 +154,28 @@ export async function getPersistedComputeProvisioning(
   return state[SETUP_COMPUTE_PROVISIONING_STATE_FIELDS[provider]];
 }
 
+/** Serializes desired-state transitions and terminal result publication. */
+export async function acquireComputeProvisioningLock(
+  provider: SetupProvisionableComputeProvider,
+  executor: DatabaseOrTransaction,
+): Promise<void> {
+  await executor.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtext(${`compute-provisioning:${provider}`}))`,
+  );
+}
+
+function isCurrentComputeProvisioningAttempt(
+  current: SetupNewComputeProvisioningState | null,
+  expected: { imageRef: string; templateRef: string },
+): boolean {
+  return (
+    current?.status === 'building' &&
+    current.runtimeSchemaVersion === WORKER_RUNTIME_SCHEMA_VERSION &&
+    current.imageRef === expected.imageRef &&
+    current.templateRef === expected.templateRef
+  );
+}
+
 export async function persistComputeProvisioning(
   provider: SetupProvisionableComputeProvider,
   provisioning: SetupNewComputeProvisioningState,
@@ -210,12 +240,11 @@ function planComputeProvisioning({
     (field) => field.envVarName === config.envVarName,
   );
 
-  const artifactPending =
-    !!artifactField &&
-    !artifactField.runtimeSatisfied &&
-    !artifactField.savedSatisfied;
-
-  if (!artifactPending) {
+  // A process-env artifact is operator-managed and always wins. Saved
+  // artifacts are Roomote-managed, so they are current only when the
+  // persisted successful build matches both the desired worker image and the
+  // runtime schema. Missing version metadata intentionally forces one rebuild.
+  if (!artifactField || artifactField.runtimeSatisfied) {
     return { artifactPending: false, provisionable: false, runToStart: null };
   }
 
@@ -227,15 +256,33 @@ function planComputeProvisioning({
   });
 
   if (!workerImageRef) {
-    return { artifactPending: true, provisionable: false, runToStart: null };
+    return {
+      artifactPending: !artifactField.savedSatisfied,
+      provisionable: false,
+      runToStart: null,
+    };
+  }
+
+  const managedArtifactCurrent =
+    artifactField.savedSatisfied &&
+    existingState?.status === 'succeeded' &&
+    existingState.imageRef === workerImageRef &&
+    existingState.runtimeSchemaVersion === WORKER_RUNTIME_SCHEMA_VERSION;
+
+  if (managedArtifactCurrent) {
+    return { artifactPending: false, provisionable: false, runToStart: null };
   }
 
   const runInFlight =
     existingState?.status === 'building' &&
+    existingState.imageRef === workerImageRef &&
+    existingState.runtimeSchemaVersion === WORKER_RUNTIME_SCHEMA_VERSION &&
     !isSetupNewComputeProvisioningStale(existingState);
 
   return {
-    artifactPending: true,
+    // A saved artifact remains usable while its replacement builds. Only
+    // first-time provisioning blocks setup/task readiness.
+    artifactPending: !artifactField.savedSatisfied,
     provisionable: true,
     runToStart: runInFlight
       ? null
@@ -255,6 +302,7 @@ export function createPendingComputeProvisioning({
 }): SetupNewComputeProvisioningState {
   return {
     status: 'building',
+    runtimeSchemaVersion: WORKER_RUNTIME_SCHEMA_VERSION,
     imageRef,
     templateRef,
     error: null,
@@ -380,12 +428,15 @@ export async function runComputeProvisioning({
   templateRef,
 }: {
   provider: SetupProvisionableComputeProvider;
-  userId: string;
+  userId: string | null;
   imageRef: string;
   templateRef: string;
 }): Promise<void> {
   const config = PROVISIONING_PROVIDERS[provider];
-  const claimKey = `${provider}:${templateRef}`;
+  // The image ref is part of the desired build identity. Two registries can
+  // use the same tag/template name, and a newer desired image must not be
+  // suppressed by an older in-process build with that name.
+  const claimKey = `${provider}:${imageRef}:${templateRef}`;
 
   if (activeProvisioningClaims.has(claimKey)) {
     console.warn(
@@ -413,7 +464,19 @@ export async function runComputeProvisioning({
       templateRef,
     );
 
-    await db.transaction(async (tx) => {
+    const activated = await db.transaction(async (tx) => {
+      await acquireComputeProvisioningLock(provider, tx);
+      const current = await getPersistedComputeProvisioning(provider, tx);
+
+      if (
+        !isCurrentComputeProvisioningAttempt(current, {
+          imageRef,
+          templateRef,
+        })
+      ) {
+        return false;
+      }
+
       await upsertDeploymentEnvironmentVariables(tx, {
         userId,
         values: [{ name: config.envVarName, value: artifactRef }],
@@ -423,6 +486,7 @@ export async function runComputeProvisioning({
         provider,
         {
           status: 'succeeded',
+          runtimeSchemaVersion: WORKER_RUNTIME_SCHEMA_VERSION,
           imageRef,
           templateRef: artifactRef,
           error: null,
@@ -431,7 +495,18 @@ export async function runComputeProvisioning({
         },
         tx,
       );
+
+      return true;
     });
+
+    if (!activated) {
+      console.warn(
+        `[runComputeProvisioning] Ignoring superseded successful build ${JSON.stringify(
+          { provider, imageRef, templateRef, artifactRef },
+        )}`,
+      );
+      return;
+    }
 
     console.log(
       `[runComputeProvisioning] Provisioning succeeded ${JSON.stringify({
@@ -451,23 +526,123 @@ export async function runComputeProvisioning({
       })}`,
     );
 
-    await persistComputeProvisioning(provider, {
-      status: 'failed',
-      imageRef,
-      templateRef: null,
-      error: message,
-      startedAt: new Date().toISOString(),
-      finishedAt: new Date().toISOString(),
-    }).catch((persistError) => {
-      console.error(
-        `[runComputeProvisioning] Failed to persist provisioning failure: ${
-          persistError instanceof Error
-            ? persistError.message
-            : String(persistError)
-        }`,
-      );
-    });
+    await db
+      .transaction(async (tx) => {
+        await acquireComputeProvisioningLock(provider, tx);
+        const current = await getPersistedComputeProvisioning(provider, tx);
+
+        if (
+          !isCurrentComputeProvisioningAttempt(current, {
+            imageRef,
+            templateRef,
+          })
+        ) {
+          console.warn(
+            `[runComputeProvisioning] Ignoring superseded failed build ${JSON.stringify(
+              { provider, imageRef, templateRef },
+            )}`,
+          );
+          return;
+        }
+
+        await persistComputeProvisioning(
+          provider,
+          {
+            status: 'failed',
+            runtimeSchemaVersion: WORKER_RUNTIME_SCHEMA_VERSION,
+            imageRef,
+            templateRef: null,
+            error: message,
+            startedAt: new Date().toISOString(),
+            finishedAt: new Date().toISOString(),
+          },
+          tx,
+        );
+      })
+      .catch((persistError) => {
+        console.error(
+          `[runComputeProvisioning] Failed to persist provisioning failure: ${
+            persistError instanceof Error
+              ? persistError.message
+              : String(persistError)
+          }`,
+        );
+      });
   } finally {
     activeProvisioningClaims.delete(claimKey);
+  }
+}
+
+/**
+ * Reconciles Roomote-managed hosted artifacts at web-process startup. The
+ * build itself remains detached: startup only records an idempotent pending
+ * claim, and the old active artifact stays configured until the replacement
+ * succeeds. Task creation therefore continues to use the last known-good
+ * artifact during a rollout.
+ */
+export async function reconcileComputeProvisioningOnStartup(): Promise<void> {
+  const [persistedEnvVarNames, persistedEnvVarValues] = await Promise.all([
+    getPersistedEnvironmentVariableNames(),
+    getPersistedEnvironmentVariableValues([
+      ...NON_SECRET_COMPUTE_ENV_VAR_NAMES,
+    ]),
+  ]);
+  const status = buildSetupComputeStatus({
+    runtimeEnv: process.env,
+    persistedEnvVarNames,
+    persistedEnvVarValues,
+  });
+
+  for (const provider of Object.keys(
+    PROVISIONING_PROVIDERS,
+  ) as SetupProvisionableComputeProvider[]) {
+    try {
+      const providerStatus = status.providers.find(
+        (candidate) => candidate.provider === provider,
+      );
+
+      if (!providerStatus) continue;
+
+      const credentialsAvailable = providerStatus.fields
+        .filter(
+          (field) =>
+            field.category === 'credential' && field.required !== false,
+        )
+        .every((field) => field.runtimeSatisfied || field.savedSatisfied);
+
+      if (!credentialsAvailable) continue;
+
+      const start = await db.transaction(async (tx) => {
+        // Multiple web replicas can start on the same release. Serialize the
+        // read/claim transition so only one process records and launches the
+        // deterministic provider build.
+        await acquireComputeProvisioningLock(provider, tx);
+        const existingState = await getPersistedComputeProvisioning(
+          provider,
+          tx,
+        );
+        const prepared = await prepareComputeProvisioningStart({
+          provider,
+          providerStatus,
+          existingState,
+          dockerWorkerImage: process.env.DOCKER_WORKER_IMAGE,
+          runtimeEnv: process.env,
+          markPending: (nextState) =>
+            persistComputeProvisioning(provider, nextState, tx),
+        });
+
+        return prepared.start;
+      });
+
+      if (start) {
+        void runComputeProvisioning({ userId: null, ...start });
+      }
+    } catch (error) {
+      console.error(
+        `[reconcileComputeProvisioningOnStartup] Failed to reconcile ${provider}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
   }
 }

--- a/apps/web/src/trpc/commands/compute/index.test.ts
+++ b/apps/web/src/trpc/commands/compute/index.test.ts
@@ -12,6 +12,7 @@ const {
   mockGetPersistedEnvironmentVariableValues,
   mockResolveSavedWorkerImage,
   mockRunComputeProvisioning,
+  mockAcquireComputeProvisioningLock,
 } = vi.hoisted(() => ({
   mockDbSelect: vi.fn(),
   mockDbInsert: vi.fn(),
@@ -24,6 +25,7 @@ const {
   mockGetPersistedEnvironmentVariableValues: vi.fn().mockResolvedValue({}),
   mockResolveSavedWorkerImage: vi.fn().mockResolvedValue(null),
   mockRunComputeProvisioning: vi.fn().mockResolvedValue(undefined),
+  mockAcquireComputeProvisioningLock: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('./compute-provisioning', async (importOriginal) => {
@@ -32,6 +34,7 @@ vi.mock('./compute-provisioning', async (importOriginal) => {
 
   return {
     ...actual,
+    acquireComputeProvisioningLock: mockAcquireComputeProvisioningLock,
     runComputeProvisioning: mockRunComputeProvisioning,
   };
 });
@@ -424,7 +427,7 @@ describe('compute commands', () => {
         provider: 'e2b',
         userId: 'compute-test-user',
         imageRef: 'registry.example.com/worker:tag',
-        templateRef: 'roomote-worker:tag',
+        templateRef: 'roomote-worker:tag-r1',
       });
     });
 
@@ -444,7 +447,7 @@ describe('compute commands', () => {
         provider: 'daytona',
         userId: 'compute-test-user',
         imageRef: 'registry.example.com/worker:tag',
-        templateRef: 'roomote-worker-tag',
+        templateRef: 'roomote-worker-tag-r1',
       });
     });
 
@@ -461,7 +464,7 @@ describe('compute commands', () => {
         provider: 'e2b',
         userId: 'compute-test-user',
         imageRef: 'registry.example.com/worker:tag',
-        templateRef: 'roomote-worker:tag',
+        templateRef: 'roomote-worker:tag-r1',
       });
     });
 

--- a/apps/web/src/trpc/commands/compute/index.test.ts
+++ b/apps/web/src/trpc/commands/compute/index.test.ts
@@ -427,7 +427,7 @@ describe('compute commands', () => {
         provider: 'e2b',
         userId: 'compute-test-user',
         imageRef: 'registry.example.com/worker:tag',
-        templateRef: 'roomote-worker:tag-r1',
+        templateRef: 'roomote-worker:tag-r2',
       });
     });
 
@@ -447,7 +447,7 @@ describe('compute commands', () => {
         provider: 'daytona',
         userId: 'compute-test-user',
         imageRef: 'registry.example.com/worker:tag',
-        templateRef: 'roomote-worker-tag-r1',
+        templateRef: 'roomote-worker-tag-r2',
       });
     });
 
@@ -464,7 +464,7 @@ describe('compute commands', () => {
         provider: 'e2b',
         userId: 'compute-test-user',
         imageRef: 'registry.example.com/worker:tag',
-        templateRef: 'roomote-worker:tag-r1',
+        templateRef: 'roomote-worker:tag-r2',
       });
     });
 

--- a/apps/web/src/trpc/commands/compute/index.ts
+++ b/apps/web/src/trpc/commands/compute/index.ts
@@ -40,6 +40,7 @@ import {
   upsertDeploymentEnvironmentVariables,
 } from '../environment-variables';
 import {
+  acquireComputeProvisioningLock,
   getPersistedComputeProvisioning,
   persistComputeProvisioning,
   prepareComputeProvisioningStart,
@@ -328,6 +329,7 @@ export async function saveComputeConfigCommand(
         );
 
       if (credentialsAvailable) {
+        await acquireComputeProvisioningLock(provisionableProvider, tx);
         const existingState = await getPersistedComputeProvisioning(
           provisionableProvider,
           tx,

--- a/apps/web/src/trpc/commands/environments/index.test.ts
+++ b/apps/web/src/trpc/commands/environments/index.test.ts
@@ -1,27 +1,37 @@
-const { mockDbSelect, mockEnqueueTask, mockGetRepositories } = vi.hoisted(
-  () => ({
-    mockDbSelect: vi.fn(),
-    mockEnqueueTask: vi.fn().mockResolvedValue({
-      taskId: 'task-env-definition-1',
-      id: 'run-env-definition-1',
-    }),
-    mockGetRepositories: vi.fn().mockResolvedValue([
-      {
-        id: 'repo-1',
-        fullName: 'acme/api',
-        installationId: 'installation-1',
-      },
-      {
-        id: 'repo-2',
-        fullName: 'acme/web',
-        installationId: 'installation-1',
-      },
-    ]),
+const {
+  mockCheckRepoAccess,
+  mockDbSelect,
+  mockEnqueueTask,
+  mockGetBranches,
+  mockGetRepositories,
+} = vi.hoisted(() => ({
+  mockCheckRepoAccess: vi.fn(),
+  mockDbSelect: vi.fn(),
+  mockEnqueueTask: vi.fn().mockResolvedValue({
+    taskId: 'task-env-definition-1',
+    id: 'run-env-definition-1',
   }),
-);
+  mockGetBranches: vi.fn(),
+  mockGetRepositories: vi.fn().mockResolvedValue([
+    {
+      id: 'repo-1',
+      fullName: 'acme/api',
+      installationId: 'installation-1',
+    },
+    {
+      id: 'repo-2',
+      fullName: 'acme/web',
+      installationId: 'installation-1',
+    },
+  ]),
+}));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
   enqueueTask: mockEnqueueTask,
+}));
+
+vi.mock('@roomote/github', () => ({
+  getBranches: mockGetBranches,
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -50,7 +60,7 @@ vi.mock('@roomote/db/server', () => ({
 }));
 
 vi.mock('@/lib/server', () => ({
-  checkRepoAccess: vi.fn(),
+  checkRepoAccess: mockCheckRepoAccess,
   getRepositories: mockGetRepositories,
 }));
 
@@ -60,6 +70,7 @@ import {
   createEnvironmentCommand,
   startEnvironmentDefinitionTaskCommand,
   updateEnvironmentCommand,
+  validateConfigCommand,
 } from './index';
 
 function buildMockAuth(): UserAuthSuccess {
@@ -187,6 +198,74 @@ describe('environment repository validation', () => {
     expect(result).toEqual({
       success: false,
       error: 'Repositories are not linked to this deployment: roomote/Test ADO',
+    });
+  });
+
+  it('does not validate Azure DevOps branches through GitHub', async () => {
+    mockDbSelect.mockReturnValueOnce({
+      from: () => ({
+        where: async () => [
+          {
+            id: 'repo-ado',
+            fullName: 'roomote/Test ADO/Test ADO',
+            installationId: null,
+            sourceControlProvider: 'ado',
+          },
+        ],
+      }),
+    });
+    mockCheckRepoAccess.mockResolvedValue(true);
+
+    const result = await validateConfigCommand(buildMockAuth(), {
+      config: {
+        name: 'ADO Test',
+        repositories: [
+          {
+            repository: 'roomote/Test ADO/Test ADO',
+            branch: 'main',
+          },
+        ],
+      },
+    });
+
+    expect(result).toEqual({ errors: [], warnings: [] });
+    expect(mockGetBranches).not.toHaveBeenCalled();
+  });
+
+  it('continues warning when a GitHub branch is missing', async () => {
+    mockDbSelect.mockReturnValueOnce({
+      from: () => ({
+        where: async () => [
+          {
+            id: 'repo-github',
+            fullName: 'roomote/roomote',
+            installationId: 'installation-1',
+            sourceControlProvider: 'github',
+          },
+        ],
+      }),
+    });
+    mockCheckRepoAccess.mockResolvedValue(true);
+    mockGetBranches.mockResolvedValue(['main']);
+
+    const result = await validateConfigCommand(buildMockAuth(), {
+      config: {
+        name: 'GitHub Test',
+        repositories: [
+          { repository: 'roomote/roomote', branch: 'missing-branch' },
+        ],
+      },
+    });
+
+    expect(result).toEqual({
+      errors: [],
+      warnings: [
+        "Branch 'missing-branch' was not found in 'roomote/roomote'. It may not exist yet.",
+      ],
+    });
+    expect(mockGetBranches).toHaveBeenCalledWith({
+      userId: 'user-1',
+      fullName: 'roomote/roomote',
     });
   });
 });

--- a/apps/web/src/trpc/commands/environments/index.ts
+++ b/apps/web/src/trpc/commands/environments/index.ts
@@ -873,8 +873,8 @@ export async function duplicateEnvironmentCommand(
 
 /**
  * Validates an environment configuration asynchronously against server-side
- * resources. Checks repository accessibility via the GitHub API (hard error)
- * and branch existence (soft warning).
+ * resources. Checks repository accessibility (hard error) and branch existence
+ * for providers with a branch-listing implementation (soft warning).
  */
 export async function validateConfigCommand(
   auth: UserAuthSuccess,
@@ -884,6 +884,10 @@ export async function validateConfigCommand(
 
   const errors: string[] = [];
   const warnings: string[] = [];
+  const repositoryProviders = new Map<
+    string,
+    (typeof repositories.$inferSelect)['sourceControlProvider']
+  >();
   const repositoryNames = [
     ...new Set(input.config.repositories.map((repo) => repo.repository)),
   ];
@@ -894,6 +898,7 @@ export async function validateConfigCommand(
         id: repositories.id,
         fullName: repositories.fullName,
         installationId: repositories.installationId,
+        sourceControlProvider: repositories.sourceControlProvider,
       })
       .from(repositories)
       .where(
@@ -908,6 +913,13 @@ export async function validateConfigCommand(
     if (repositoryConfigError) {
       errors.push(repositoryConfigError);
     }
+
+    for (const repository of dbRepos) {
+      repositoryProviders.set(
+        repository.fullName,
+        repository.sourceControlProvider,
+      );
+    }
   }
 
   await Promise.all(
@@ -921,8 +933,13 @@ export async function validateConfigCommand(
         return; // skip branch check if repo itself is inaccessible
       }
 
-      // If a branch is specified, check it exists
-      if (repo.branch) {
+      // Branch listing is currently implemented only for GitHub. Do not send
+      // repositories from other providers through the GitHub API: its
+      // provider-scoped lookup correctly returns no branches for those rows.
+      if (
+        repo.branch &&
+        repositoryProviders.get(repo.repository) === 'github'
+      ) {
         try {
           const branches = await GitHub.getBranches({
             userId,

--- a/apps/web/src/trpc/commands/setup-new/index.test.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.test.ts
@@ -11,6 +11,7 @@ const {
   mockGetSetupBootstrapState,
   mockSetupTokenState,
   mockRunComputeProvisioning,
+  mockAcquireComputeProvisioningLock,
   mockResolveSavedWorkerImage,
   mockResolveGiteaBaseUrl,
   mockValidateGiteaToken,
@@ -26,6 +27,7 @@ const {
     inviteCookieToken: null as string | null,
   },
   mockRunComputeProvisioning: vi.fn().mockResolvedValue(undefined),
+  mockAcquireComputeProvisioningLock: vi.fn().mockResolvedValue(undefined),
   mockResolveSavedWorkerImage: vi.fn().mockResolvedValue(null),
   mockResolveGiteaBaseUrl: vi
     .fn()
@@ -39,6 +41,7 @@ vi.mock('../compute/compute-provisioning', async (importOriginal) => {
 
   return {
     ...actual,
+    acquireComputeProvisioningLock: mockAcquireComputeProvisioningLock,
     runComputeProvisioning: mockRunComputeProvisioning,
   };
 });
@@ -831,12 +834,12 @@ describe('setup-new compute config commands', () => {
       provider: 'e2b',
       userId: 'setup-test-user',
       imageRef: 'registry.example.com/worker:tag',
-      templateRef: 'roomote-worker:tag',
+      templateRef: 'roomote-worker:tag-r1',
     });
     expect(result.setupNewState.e2bTemplateBuild).toMatchObject({
       status: 'building',
       imageRef: 'registry.example.com/worker:tag',
-      templateRef: 'roomote-worker:tag',
+      templateRef: 'roomote-worker:tag-r1',
     });
   });
 
@@ -860,8 +863,9 @@ describe('setup-new compute config commands', () => {
               setupNewState: {
                 e2bTemplateBuild: {
                   status: 'building',
+                  runtimeSchemaVersion: 1,
                   imageRef: 'registry.example.com/worker:tag',
-                  templateRef: 'roomote-worker:tag',
+                  templateRef: 'roomote-worker:tag-r1',
                   error: null,
                   startedAt: new Date().toISOString(),
                   finishedAt: null,
@@ -887,7 +891,7 @@ describe('setup-new compute config commands', () => {
     expect(mockRunComputeProvisioning).not.toHaveBeenCalled();
     expect(result.setupNewState.e2bTemplateBuild).toMatchObject({
       status: 'building',
-      templateRef: 'roomote-worker:tag',
+      templateRef: 'roomote-worker:tag-r1',
     });
   });
 

--- a/apps/web/src/trpc/commands/setup-new/index.test.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.test.ts
@@ -834,12 +834,12 @@ describe('setup-new compute config commands', () => {
       provider: 'e2b',
       userId: 'setup-test-user',
       imageRef: 'registry.example.com/worker:tag',
-      templateRef: 'roomote-worker:tag-r1',
+      templateRef: 'roomote-worker:tag-r2',
     });
     expect(result.setupNewState.e2bTemplateBuild).toMatchObject({
       status: 'building',
       imageRef: 'registry.example.com/worker:tag',
-      templateRef: 'roomote-worker:tag-r1',
+      templateRef: 'roomote-worker:tag-r2',
     });
   });
 
@@ -863,9 +863,9 @@ describe('setup-new compute config commands', () => {
               setupNewState: {
                 e2bTemplateBuild: {
                   status: 'building',
-                  runtimeSchemaVersion: 1,
+                  runtimeSchemaVersion: 2,
                   imageRef: 'registry.example.com/worker:tag',
-                  templateRef: 'roomote-worker:tag-r1',
+                  templateRef: 'roomote-worker:tag-r2',
                   error: null,
                   startedAt: new Date().toISOString(),
                   finishedAt: null,
@@ -891,7 +891,7 @@ describe('setup-new compute config commands', () => {
     expect(mockRunComputeProvisioning).not.toHaveBeenCalled();
     expect(result.setupNewState.e2bTemplateBuild).toMatchObject({
       status: 'building',
-      templateRef: 'roomote-worker:tag-r1',
+      templateRef: 'roomote-worker:tag-r2',
     });
   });
 

--- a/apps/web/src/trpc/commands/setup-new/index.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.ts
@@ -126,6 +126,7 @@ import {
   savePersistedRuntimeComputeConfig,
 } from '../compute';
 import {
+  acquireComputeProvisioningLock,
   createPendingComputeProvisioning,
   prepareComputeProvisioningStart,
   runComputeProvisioning,
@@ -1539,6 +1540,10 @@ export async function saveSetupNewComputeConfigCommand(
         imageRef: string;
         templateRef: string;
       } | null = null;
+
+      if (isSetupProvisionableComputeProvider(input.provider)) {
+        await acquireComputeProvisioningLock(input.provider, tx);
+      }
 
       await purgeSavedDeploymentWorkerImage(tx);
 

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -252,4 +252,8 @@ RUN sudo apt-get update \
   && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iproute2 \
   && sudo rm -rf /var/lib/apt/lists/*
 
+# Bump when local worker prerequisites change so dev startup rebuilds stale
+# cached images before launching tasks.
+LABEL dev.roomote.worker-image.schema-version="1"
+
 WORKDIR /sandbox

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -23,10 +23,13 @@ RUN apt-get update \
     ca-certificates \
     bubblewrap \
     curl \
+    docker.io \
+    docker-compose-v2 \
     unzip \
     jq \
     git \
     inotify-tools \
+    iptables \
     gnupg \
     netcat-openbsd \
     tar \
@@ -63,6 +66,9 @@ RUN apt-get update \
     libxrandr2 \
     libxss1 \
   && ln -sf "$(command -v python3)" /usr/local/bin/python \
+  && update-alternatives --set iptables /usr/sbin/iptables-legacy \
+  && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy \
+  && docker compose version \
   && rm -rf /var/lib/apt/lists/*
 
 ENV LANG=en_US.UTF-8
@@ -100,7 +106,7 @@ RUN ARCH="$(dpkg --print-architecture)" \
 
 # Create user 'roomote' and grant passwordless sudo.
 RUN useradd -m -s /bin/bash roomote \
-  && usermod -aG sudo roomote \
+  && usermod -aG sudo,docker roomote \
   && echo 'roomote ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/roomote \
   && chmod 0440 /etc/sudoers.d/roomote
 

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -254,7 +254,7 @@ RUN sudo apt-get update \
 
 # Shared with WORKER_RUNTIME_SCHEMA_VERSION in @roomote/types. Local builds
 # pass this explicitly; the default keeps direct/release Docker builds labeled.
-ARG ROOMOTE_WORKER_RUNTIME_SCHEMA_VERSION=1
+ARG ROOMOTE_WORKER_RUNTIME_SCHEMA_VERSION=2
 LABEL dev.roomote.worker-image.schema-version="${ROOMOTE_WORKER_RUNTIME_SCHEMA_VERSION}"
 
 WORKDIR /sandbox

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -252,8 +252,9 @@ RUN sudo apt-get update \
   && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iproute2 \
   && sudo rm -rf /var/lib/apt/lists/*
 
-# Bump when local worker prerequisites change so dev startup rebuilds stale
-# cached images before launching tasks.
-LABEL dev.roomote.worker-image.schema-version="1"
+# Shared with WORKER_RUNTIME_SCHEMA_VERSION in @roomote/types. Local builds
+# pass this explicitly; the default keeps direct/release Docker builds labeled.
+ARG ROOMOTE_WORKER_RUNTIME_SCHEMA_VERSION=1
+LABEL dev.roomote.worker-image.schema-version="${ROOMOTE_WORKER_RUNTIME_SCHEMA_VERSION}"
 
 WORKDIR /sandbox

--- a/apps/worker/src/commands/__tests__/setup.test.ts
+++ b/apps/worker/src/commands/__tests__/setup.test.ts
@@ -14,6 +14,7 @@ const {
   mockInstallNodePty,
   mockInstallEmojiFont,
   mockInitializeWorkspaceRepositories,
+  mockInitializeContainerProjects,
   mockInitializeWorkspaceServices,
   mockInitializeSystemWorkspaceServices,
   mockInitializeEnvironmentWorkspaceServices,
@@ -39,6 +40,7 @@ const {
     mockInstallNodePty: vi.fn(),
     mockInstallEmojiFont: vi.fn(),
     mockInitializeWorkspaceRepositories: vi.fn(),
+    mockInitializeContainerProjects: vi.fn(),
     mockInitializeWorkspaceServices: vi.fn(),
     mockInitializeSystemWorkspaceServices: vi.fn(),
     mockInitializeEnvironmentWorkspaceServices: vi.fn(),
@@ -92,6 +94,7 @@ vi.mock('../setup/logging', () => ({
 
 vi.mock('../setup/workspace', () => ({
   initializeRepositories: mockInitializeWorkspaceRepositories,
+  initializeContainerProjects: mockInitializeContainerProjects,
   initializeAllServices: mockInitializeWorkspaceServices,
   initializeSystemServices: mockInitializeSystemWorkspaceServices,
   initializeEnvironmentServices: mockInitializeEnvironmentWorkspaceServices,
@@ -146,6 +149,7 @@ describe('setup mode behavior', () => {
     mockInitializeWorkspaceRepositories.mockResolvedValue({
       workspacePath: '/tmp/workspace',
     });
+    mockInitializeContainerProjects.mockResolvedValue(undefined);
     mockInitializeWorkspaceServices.mockResolvedValue({
       services: [],
       env: {},
@@ -212,6 +216,15 @@ describe('setup mode behavior', () => {
       installPythonOrder ?? 0,
     );
     expect(mockInitializeWorkspaceRepositories).toHaveBeenCalledTimes(1);
+    expect(mockInitializeContainerProjects).toHaveBeenCalledTimes(1);
+    expect(mockInitializeContainerProjects).toHaveBeenCalledWith(
+      logger,
+      expect.objectContaining({
+        cleanupLegacyPaths: false,
+        envVars: { BASE: 'base', FOO: 'bar' },
+      }),
+      { workspacePath: '/tmp/workspace' },
+    );
     expect(mockInitializeWorkspaceRepositories).toHaveBeenCalledWith(logger, {
       ...workspaceOptions,
       cleanupLegacyPaths: false,
@@ -252,6 +265,7 @@ describe('setup mode behavior', () => {
     expect(mockInstallNodePty).not.toHaveBeenCalled();
     expect(mockInstallEmojiFont).not.toHaveBeenCalled();
     expect(mockInitializeWorkspaceServices).not.toHaveBeenCalled();
+    expect(mockInitializeContainerProjects).not.toHaveBeenCalled();
     expect(mockInitializeSystemWorkspaceServices).not.toHaveBeenCalled();
     expect(mockSetupOrganizationEnvironment).not.toHaveBeenCalled();
     expect(mockSetUserEnv).toHaveBeenCalledWith({
@@ -271,13 +285,19 @@ describe('setup mode behavior', () => {
     const initializeRepositoriesOrder =
       mockInitializeWorkspaceRepositories.mock.invocationCallOrder[0];
     const installPythonOrder = mockInstallPython.mock.invocationCallOrder[0];
+    const initializeContainerProjectsOrder =
+      mockInitializeContainerProjects.mock.invocationCallOrder[0];
     const setupOrganizationEnvironmentOrder =
       mockSetupOrganizationEnvironment.mock.invocationCallOrder[0];
 
     expect(initializeRepositoriesOrder).toBeDefined();
     expect(installPythonOrder).toBeDefined();
+    expect(initializeContainerProjectsOrder).toBeDefined();
     expect(setupOrganizationEnvironmentOrder).toBeDefined();
     expect(initializeRepositoriesOrder ?? 0).toBeLessThan(
+      initializeContainerProjectsOrder ?? 0,
+    );
+    expect(initializeContainerProjectsOrder ?? 0).toBeLessThan(
       installPythonOrder ?? 0,
     );
     expect(installPythonOrder ?? 0).toBeLessThan(

--- a/apps/worker/src/commands/setup.ts
+++ b/apps/worker/src/commands/setup.ts
@@ -35,6 +35,7 @@ import {
   ensurePython3,
   installPython,
   initializeRepositories,
+  initializeContainerProjects,
   initializeAllServices,
   installOrganizationEnvironmentSkills,
   executeOrganizationEnvironmentRepositoryCommands,
@@ -323,6 +324,20 @@ async function runSetup({
     () => Promise.all(systemSetup),
     recordPhase,
   );
+
+  if (initializeRepositoriesResult) {
+    await timedStep(
+      logger,
+      'initializeContainerProjects',
+      () =>
+        initializeContainerProjects(
+          logger,
+          workspaceOptions,
+          initializeRepositoriesResult!,
+        ),
+      recordPhase,
+    );
+  }
 
   await timedStep(
     logger,

--- a/apps/worker/src/commands/setup/__tests__/container-projects.test.ts
+++ b/apps/worker/src/commands/setup/__tests__/container-projects.test.ts
@@ -139,6 +139,52 @@ describe('initializeContainerProjects', () => {
     expect(generated).toContain('Dockerfile');
   });
 
+  it('starts a fallback Docker daemon without leaving a rejecting detached subprocess', async () => {
+    await fs.writeFile(
+      path.join(repositoryPath, 'compose.yaml'),
+      'services:\n  web:\n    image: nginx:alpine\n',
+    );
+    const runCommand = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Docker daemon is unavailable'))
+      .mockResolvedValue({ stdout: '' });
+
+    await initializeContainerProjects(
+      logger,
+      {
+        workspace: {
+          type: 'environment',
+          environmentId: 'env-1',
+          environmentConfig: {
+            name: 'Test',
+            repositories: [{ repository: 'acme/app' }],
+            container_projects: [
+              {
+                type: 'compose',
+                name: 'dev',
+                repository: 'acme/app',
+                files: ['compose.yaml'],
+              },
+            ],
+          },
+        },
+        envVars: { PATH: '/usr/bin' },
+        taskRunType: TaskPayloadKind.StandardTask,
+      },
+      {
+        workspacePath,
+        repoPaths: { 'acme/app': repositoryPath },
+      },
+      runCommand,
+    );
+
+    expect(runCommand).toHaveBeenCalledWith(
+      'sudo',
+      ['sh', '-c', expect.stringContaining('nohup dockerd')],
+      expect.not.objectContaining({ detached: true }),
+    );
+  });
+
   it('continues when an optional project fails', async () => {
     await fs.writeFile(
       path.join(repositoryPath, 'compose.yaml'),

--- a/apps/worker/src/commands/setup/__tests__/container-projects.test.ts
+++ b/apps/worker/src/commands/setup/__tests__/container-projects.test.ts
@@ -1,0 +1,189 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { TaskPayloadKind } from '@roomote/types';
+
+import type { StartupLogger } from '../../../logging';
+import { initializeContainerProjects } from '../workspace/container-projects';
+
+const logger = {
+  userLog: { log: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  debug: { log: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+} as unknown as StartupLogger;
+
+describe('initializeContainerProjects', () => {
+  let workspacePath: string;
+  let repositoryPath: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    workspacePath = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'roomote-compose-'),
+    );
+    repositoryPath = path.join(workspacePath, 'app');
+    await fs.mkdir(repositoryPath, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(workspacePath, { recursive: true, force: true });
+  });
+
+  it('validates and starts an existing Compose project after repository cloning', async () => {
+    await fs.writeFile(
+      path.join(repositoryPath, 'compose.yaml'),
+      'services:\n  web:\n    image: nginx:alpine\n',
+    );
+    const runCommand = vi.fn().mockResolvedValue({ stdout: '' });
+
+    await initializeContainerProjects(
+      logger,
+      {
+        workspace: {
+          type: 'environment',
+          environmentId: 'env-1',
+          environmentConfig: {
+            name: 'Test',
+            repositories: [{ repository: 'acme/app' }],
+            ports: [{ name: 'WEB', port: 3000 }],
+            container_projects: [
+              {
+                type: 'compose',
+                name: 'dev',
+                repository: 'acme/app',
+                files: ['compose.yaml'],
+                ports: [
+                  {
+                    named_port: 'WEB',
+                    service: 'web',
+                    container_port: 80,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        envVars: { PATH: '/usr/bin' },
+        taskRunType: TaskPayloadKind.StandardTask,
+      },
+      {
+        workspacePath,
+        repoPaths: { 'acme/app': repositoryPath },
+      },
+      runCommand,
+    );
+
+    expect(runCommand).toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining(['config', '--quiet']),
+      expect.objectContaining({ cwd: repositoryPath }),
+    );
+    expect(runCommand).toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining(['up', '--detach', '--build', '--wait']),
+      expect.objectContaining({ cwd: repositoryPath }),
+    );
+
+    const generatedFiles = await fs.readdir(
+      path.join(workspacePath, '.roomote', 'container-projects'),
+    );
+    expect(generatedFiles).toContain('roomote-dev.ports.yaml');
+  });
+
+  it('generates a one-service Compose project for a Dockerfile', async () => {
+    await fs.writeFile(
+      path.join(repositoryPath, 'Dockerfile'),
+      'FROM nginx:alpine\n',
+    );
+    const runCommand = vi.fn().mockResolvedValue({ stdout: '' });
+
+    await initializeContainerProjects(
+      logger,
+      {
+        workspace: {
+          type: 'environment',
+          environmentId: 'env-1',
+          environmentConfig: {
+            name: 'Test',
+            repositories: [{ repository: 'acme/app' }],
+            container_projects: [
+              {
+                type: 'dockerfile',
+                name: 'web',
+                repository: 'acme/app',
+              },
+            ],
+          },
+        },
+        envVars: {},
+        taskRunType: TaskPayloadKind.StandardTask,
+      },
+      {
+        workspacePath,
+        repoPaths: { 'acme/app': repositoryPath },
+      },
+      runCommand,
+    );
+
+    const generated = await fs.readFile(
+      path.join(
+        workspacePath,
+        '.roomote',
+        'container-projects',
+        'roomote-web.dockerfile.yaml',
+      ),
+      'utf8',
+    );
+    expect(generated).toContain('services:');
+    expect(generated).toContain('app:');
+    expect(generated).toContain('Dockerfile');
+  });
+
+  it('continues when an optional project fails', async () => {
+    await fs.writeFile(
+      path.join(repositoryPath, 'compose.yaml'),
+      'services: {}\n',
+    );
+    const runCommand = vi
+      .fn()
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error('invalid compose'));
+
+    await expect(
+      initializeContainerProjects(
+        logger,
+        {
+          workspace: {
+            type: 'environment',
+            environmentId: 'env-1',
+            environmentConfig: {
+              name: 'Test',
+              repositories: [{ repository: 'acme/app' }],
+              container_projects: [
+                {
+                  type: 'compose',
+                  name: 'optional',
+                  repository: 'acme/app',
+                  files: ['compose.yaml'],
+                  required: false,
+                },
+              ],
+            },
+          },
+          envVars: {},
+          taskRunType: TaskPayloadKind.StandardTask,
+        },
+        {
+          workspacePath,
+          repoPaths: { 'acme/app': repositoryPath },
+        },
+        runCommand,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(logger.userLog.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Continuing because it is optional'),
+    );
+  });
+});

--- a/apps/worker/src/commands/setup/__tests__/container-projects.test.ts
+++ b/apps/worker/src/commands/setup/__tests__/container-projects.test.ts
@@ -186,4 +186,57 @@ describe('initializeContainerProjects', () => {
       expect.stringContaining('Continuing because it is optional'),
     );
   });
+
+  it('redacts project values without redacting the base command environment', async () => {
+    await fs.writeFile(
+      path.join(repositoryPath, 'compose.yaml'),
+      'services:\n  web:\n    image: nginx:alpine\n',
+    );
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      if (args.includes('up')) throw new Error('compose failed');
+      if (args.includes('ps')) {
+        return {
+          stdout: 'PATH=/opt/roomote/bin APP_SECRET=project-secret-value',
+        };
+      }
+      return { stdout: '' };
+    });
+
+    const result = initializeContainerProjects(
+      logger,
+      {
+        workspace: {
+          type: 'environment',
+          environmentId: 'env-1',
+          environmentConfig: {
+            name: 'Test',
+            repositories: [{ repository: 'acme/app' }],
+            container_projects: [
+              {
+                type: 'compose',
+                name: 'dev',
+                repository: 'acme/app',
+                files: ['compose.yaml'],
+                env: { APP_SECRET: '${PROJECT_SECRET}' },
+              },
+            ],
+          },
+        },
+        envVars: {
+          PATH: '/opt/roomote/bin',
+          PROJECT_SECRET: 'project-secret-value',
+        },
+        taskRunType: TaskPayloadKind.StandardTask,
+      },
+      {
+        workspacePath,
+        repoPaths: { 'acme/app': repositoryPath },
+      },
+      runCommand,
+    );
+
+    await expect(result).rejects.toThrow('PATH=/opt/roomote/bin');
+    await expect(result).rejects.toThrow('APP_SECRET=[redacted]');
+    await expect(result).rejects.not.toThrow('project-secret-value');
+  });
 });

--- a/apps/worker/src/commands/setup/index.ts
+++ b/apps/worker/src/commands/setup/index.ts
@@ -16,6 +16,7 @@ export {
   type PrepareWorkspaceOptions,
   type PrepareWorkspaceResult,
   initializeRepositories,
+  initializeContainerProjects,
   initializeAllServices,
   installOrganizationEnvironmentSkills,
   executeOrganizationEnvironmentRepositoryCommands,

--- a/apps/worker/src/commands/setup/workspace.ts
+++ b/apps/worker/src/commands/setup/workspace.ts
@@ -9,6 +9,7 @@ export {
   setupOrganizationEnvironment,
 } from './workspace/environment-commands';
 export { initializeRepositories } from './workspace/repositories';
+export { initializeContainerProjects } from './workspace/container-projects';
 export {
   initializeAllServices,
   initializeSystemServices,

--- a/apps/worker/src/commands/setup/workspace/container-projects.ts
+++ b/apps/worker/src/commands/setup/workspace/container-projects.ts
@@ -1,0 +1,469 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import { execa } from 'execa';
+import YAML from 'yaml';
+
+import {
+  type ContainerProject,
+  type EnvironmentConfig,
+  isServicesEnabledTaskPayloadKind,
+} from '@roomote/types';
+
+import { substituteEnvVars } from '../../../env';
+import type { StartupLogger } from '../../../logging';
+
+import type { PrepareWorkspaceOptions, PrepareWorkspaceResult } from './types';
+
+const DEFAULT_STARTUP_TIMEOUT_SECONDS = 600;
+
+interface ContainerCommandOptions {
+  cwd: string;
+  env: Record<string, string>;
+  timeoutMs?: number;
+  detached?: boolean;
+}
+
+type ContainerCommandRunner = (
+  command: string,
+  args: string[],
+  options: ContainerCommandOptions,
+) => Promise<{ stdout?: string; stderr?: string }>;
+
+const runContainerCommand: ContainerCommandRunner = async (
+  command,
+  args,
+  options,
+) => {
+  const subprocess = execa(command, args, {
+    cwd: options.cwd,
+    env: options.env,
+    extendEnv: false,
+    detached: options.detached,
+    reject: true,
+    stdio: options.detached ? 'ignore' : 'pipe',
+    timeout: options.timeoutMs,
+  });
+
+  if (options.detached) {
+    subprocess.unref();
+    return {};
+  }
+
+  const result = await subprocess;
+
+  return { stdout: result.stdout, stderr: result.stderr };
+};
+
+interface ResolvedContainerProject {
+  project: ContainerProject;
+  projectName: string;
+  projectRoot: string;
+  composeFiles: string[];
+  env: Record<string, string>;
+}
+
+async function ensureDockerRuntime({
+  preparedWorkspace,
+  baseEnv,
+  runCommand,
+}: {
+  preparedWorkspace: PrepareWorkspaceResult;
+  baseEnv: Record<string, string>;
+  runCommand: ContainerCommandRunner;
+}): Promise<void> {
+  const commandOptions = {
+    cwd: preparedWorkspace.workspacePath,
+    env: baseEnv,
+    timeoutMs: 30_000,
+  };
+
+  try {
+    await runCommand('docker', ['info'], commandOptions);
+  } catch (initialError) {
+    if (!baseEnv.DOCKER_HOST) {
+      await runCommand(
+        'sudo',
+        ['dockerd', '--host=unix:///var/run/docker.sock', '--log-level=error'],
+        { ...commandOptions, timeoutMs: undefined, detached: true },
+      );
+    }
+
+    let lastError: unknown = initialError;
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      try {
+        await runCommand('docker', ['info'], commandOptions);
+        lastError = undefined;
+        break;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    if (lastError) throw lastError;
+  }
+
+  await runCommand('docker', ['compose', 'version'], commandOptions);
+}
+
+function getDefinedEnv(
+  env: Record<string, string | undefined>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(env).filter(
+      (entry): entry is [string, string] => entry[1] !== undefined,
+    ),
+  );
+}
+
+function resolveWithin(root: string, relativePath: string): string {
+  const resolvedRoot = path.resolve(root);
+  const resolvedPath = path.resolve(resolvedRoot, relativePath);
+  const relative = path.relative(resolvedRoot, resolvedPath);
+
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Path escapes the selected repository: ${relativePath}`);
+  }
+
+  return resolvedPath;
+}
+
+function toComposeProjectName(name: string): string {
+  return `roomote-${name}`
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^[^a-z0-9]+/, '')
+    .slice(0, 63);
+}
+
+function findNamedPort(config: EnvironmentConfig, namedPort: string): number {
+  const port = config.ports?.find(
+    (candidate) => candidate.name.toUpperCase() === namedPort.toUpperCase(),
+  );
+
+  if (!port) {
+    throw new Error(`Environment port '${namedPort}' is not configured`);
+  }
+
+  return port.port;
+}
+
+function buildPortOverrides(
+  project: ContainerProject,
+  config: EnvironmentConfig,
+): Record<string, { ports: Array<{ target: number; published: number }> }> {
+  const services: Record<
+    string,
+    { ports: Array<{ target: number; published: number }> }
+  > = {};
+
+  for (const mapping of project.ports ?? []) {
+    const serviceName = project.type === 'compose' ? mapping.service : 'app';
+    if (!serviceName) {
+      throw new Error(
+        `Compose project '${project.name}' port '${mapping.named_port}' is missing a service`,
+      );
+    }
+
+    const service = (services[serviceName] ??= { ports: [] });
+    service.ports.push({
+      target: mapping.container_port,
+      published: findNamedPort(config, mapping.named_port),
+    });
+  }
+
+  return services;
+}
+
+async function writeGeneratedComposeFile({
+  preparedWorkspace,
+  project,
+  contents,
+  suffix,
+}: {
+  preparedWorkspace: PrepareWorkspaceResult;
+  project: ContainerProject;
+  contents: unknown;
+  suffix: string;
+}): Promise<string> {
+  const outputDirectory = path.join(
+    preparedWorkspace.workspacePath,
+    '.roomote',
+    'container-projects',
+  );
+  await fs.mkdir(outputDirectory, { recursive: true });
+  const outputPath = path.join(
+    outputDirectory,
+    `${toComposeProjectName(project.name)}.${suffix}.yaml`,
+  );
+  await fs.writeFile(outputPath, YAML.stringify(contents), 'utf8');
+  return outputPath;
+}
+
+async function resolveContainerProject({
+  project,
+  config,
+  preparedWorkspace,
+  baseEnv,
+}: {
+  project: ContainerProject;
+  config: EnvironmentConfig;
+  preparedWorkspace: PrepareWorkspaceResult;
+  baseEnv: Record<string, string>;
+}): Promise<ResolvedContainerProject> {
+  const repositoryRoot = preparedWorkspace.repoPaths?.[project.repository];
+  if (!repositoryRoot) {
+    throw new Error(
+      `Prepared repository path missing for container project '${project.name}': ${project.repository}`,
+    );
+  }
+
+  const projectRoot = resolveWithin(repositoryRoot, project.working_dir ?? '.');
+  const projectEnv = project.env ? substituteEnvVars(project.env, baseEnv) : {};
+  const env = {
+    ...baseEnv,
+    ...projectEnv,
+    COMPOSE_PROJECT_NAME: toComposeProjectName(project.name),
+  };
+
+  if (project.type === 'compose') {
+    const composeFiles = project.files.map((file) =>
+      resolveWithin(projectRoot, file),
+    );
+    await Promise.all(composeFiles.map((file) => fs.access(file)));
+
+    const portOverrides = buildPortOverrides(project, config);
+    if (Object.keys(portOverrides).length > 0) {
+      composeFiles.push(
+        await writeGeneratedComposeFile({
+          preparedWorkspace,
+          project,
+          contents: { services: portOverrides },
+          suffix: 'ports',
+        }),
+      );
+    }
+
+    return {
+      project,
+      projectName: env.COMPOSE_PROJECT_NAME,
+      projectRoot,
+      composeFiles,
+      env,
+    };
+  }
+
+  const contextPath = resolveWithin(projectRoot, project.context ?? '.');
+  const dockerfilePath = resolveWithin(
+    projectRoot,
+    project.dockerfile ?? 'Dockerfile',
+  );
+  await Promise.all([fs.access(contextPath), fs.access(dockerfilePath)]);
+
+  const build: Record<string, unknown> = {
+    context: contextPath,
+    dockerfile: path.relative(contextPath, dockerfilePath),
+  };
+  if (project.target) build.target = project.target;
+  if (project.build_args) build.args = project.build_args;
+
+  const service: Record<string, unknown> = { build };
+  if (Object.keys(projectEnv).length > 0) service.environment = projectEnv;
+  if (project.command) service.command = project.command;
+
+  const generatedServices = buildPortOverrides(project, config);
+  if (generatedServices.app) service.ports = generatedServices.app.ports;
+
+  const composeFile = await writeGeneratedComposeFile({
+    preparedWorkspace,
+    project,
+    contents: { services: { app: service } },
+    suffix: 'dockerfile',
+  });
+
+  return {
+    project,
+    projectName: env.COMPOSE_PROJECT_NAME,
+    projectRoot,
+    composeFiles: [composeFile],
+    env,
+  };
+}
+
+function buildComposeArgs(
+  resolved: ResolvedContainerProject,
+  subcommand: string[],
+): string[] {
+  const args = ['compose', '--project-name', resolved.projectName];
+
+  for (const file of resolved.composeFiles) args.push('--file', file);
+  if (resolved.project.type === 'compose') {
+    for (const profile of resolved.project.profiles ?? []) {
+      args.push('--profile', profile);
+    }
+  }
+
+  return [...args, ...subcommand];
+}
+
+function redactContainerDiagnostics(
+  value: string,
+  env: Record<string, string>,
+): string {
+  let redacted = value;
+  for (const secret of Object.values(env)) {
+    if (secret.length >= 8)
+      redacted = redacted.replaceAll(secret, '[redacted]');
+  }
+  return redacted.slice(-12_000);
+}
+
+async function collectContainerDiagnostics(
+  resolved: ResolvedContainerProject,
+  runCommand: ContainerCommandRunner,
+  commandOptions: ContainerCommandOptions,
+): Promise<string> {
+  const sections: string[] = [];
+  for (const [label, command] of [
+    ['Compose status', ['ps', '--all']],
+    ['Recent Compose logs', ['logs', '--no-color', '--tail', '100']],
+  ] as const) {
+    try {
+      const result = await runCommand(
+        'docker',
+        buildComposeArgs(resolved, [...command]),
+        { ...commandOptions, timeoutMs: 30_000 },
+      );
+      const output = [result.stdout, result.stderr].filter(Boolean).join('\n');
+      if (output) {
+        sections.push(
+          `${label}:\n${redactContainerDiagnostics(output, resolved.env)}`,
+        );
+      }
+    } catch {
+      // The original startup error is more useful than a secondary diagnostic
+      // collection failure.
+    }
+  }
+  return sections.join('\n\n');
+}
+
+async function startContainerProject({
+  logger,
+  resolved,
+  runCommand,
+}: {
+  logger: StartupLogger;
+  resolved: ResolvedContainerProject;
+  runCommand: ContainerCommandRunner;
+}): Promise<void> {
+  const timeoutSeconds =
+    resolved.project.startup_timeout_seconds ?? DEFAULT_STARTUP_TIMEOUT_SECONDS;
+  const commandOptions = {
+    cwd: resolved.projectRoot,
+    env: resolved.env,
+    timeoutMs: timeoutSeconds * 1_000,
+  };
+
+  logger.userLog.log(
+    `Validating container project ${resolved.project.name}...`,
+  );
+  const configResult = await runCommand(
+    'docker',
+    buildComposeArgs(resolved, ['config', '--quiet']),
+    commandOptions,
+  );
+  if (configResult.stdout) logger.debug.log(configResult.stdout);
+
+  logger.userLog.log(
+    `Building and starting container project ${resolved.project.name}...`,
+  );
+  const services =
+    resolved.project.type === 'compose'
+      ? (resolved.project.services ?? [])
+      : [];
+  let startResult: Awaited<ReturnType<ContainerCommandRunner>>;
+  try {
+    startResult = await runCommand(
+      'docker',
+      buildComposeArgs(resolved, [
+        'up',
+        '--detach',
+        '--build',
+        '--remove-orphans',
+        '--wait',
+        '--wait-timeout',
+        String(timeoutSeconds),
+        ...services,
+      ]),
+      commandOptions,
+    );
+  } catch (error) {
+    const diagnostics = await collectContainerDiagnostics(
+      resolved,
+      runCommand,
+      commandOptions,
+    );
+    if (diagnostics) logger.debug.error(diagnostics);
+    throw new Error(
+      [error instanceof Error ? error.message : String(error), diagnostics]
+        .filter(Boolean)
+        .join('\n\n'),
+      { cause: error },
+    );
+  }
+  if (startResult.stdout) logger.debug.log(startResult.stdout);
+  if (startResult.stderr) logger.debug.log(startResult.stderr);
+  logger.userLog.log(`Container project ${resolved.project.name} is ready`);
+}
+
+export async function initializeContainerProjects(
+  logger: StartupLogger,
+  options: PrepareWorkspaceOptions,
+  preparedWorkspace: PrepareWorkspaceResult,
+  runCommand: ContainerCommandRunner = runContainerCommand,
+): Promise<void> {
+  if (
+    options.workspace.type !== 'environment' ||
+    !isServicesEnabledTaskPayloadKind(options.taskRunType)
+  ) {
+    return;
+  }
+
+  const config = options.workspace.environmentConfig;
+  const projects = config.container_projects ?? [];
+  if (projects.length === 0) return;
+
+  const baseEnv = getDefinedEnv(options.envVars);
+
+  try {
+    await ensureDockerRuntime({ preparedWorkspace, baseEnv, runCommand });
+  } catch (error) {
+    throw new Error(
+      `Docker Compose is not available in this task environment: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+
+  for (const project of projects) {
+    try {
+      const resolved = await resolveContainerProject({
+        project,
+        config,
+        preparedWorkspace,
+        baseEnv,
+      });
+      await startContainerProject({ logger, resolved, runCommand });
+    } catch (error) {
+      const message = `Container project '${project.name}' failed to start: ${error instanceof Error ? error.message : String(error)}`;
+      if (project.required === false) {
+        logger.userLog.warn(`${message} Continuing because it is optional.`);
+        logger.debug.error(error);
+        continue;
+      }
+
+      throw new Error(message, { cause: error });
+    }
+  }
+}

--- a/apps/worker/src/commands/setup/workspace/container-projects.ts
+++ b/apps/worker/src/commands/setup/workspace/container-projects.ts
@@ -61,6 +61,7 @@ interface ResolvedContainerProject {
   projectRoot: string;
   composeFiles: string[];
   env: Record<string, string>;
+  sensitiveValues: string[];
 }
 
 async function ensureDockerRuntime({
@@ -251,8 +252,13 @@ async function resolveContainerProject({
       projectRoot,
       composeFiles,
       env,
+      sensitiveValues: Object.values(projectEnv),
     };
   }
+
+  const buildArgs = project.build_args
+    ? substituteEnvVars(project.build_args, baseEnv)
+    : {};
 
   const contextPath = resolveWithin(projectRoot, project.context ?? '.');
   const dockerfilePath = resolveWithin(
@@ -266,7 +272,7 @@ async function resolveContainerProject({
     dockerfile: path.relative(contextPath, dockerfilePath),
   };
   if (project.target) build.target = project.target;
-  if (project.build_args) build.args = project.build_args;
+  if (Object.keys(buildArgs).length > 0) build.args = buildArgs;
 
   const service: Record<string, unknown> = { build };
   if (Object.keys(projectEnv).length > 0) service.environment = projectEnv;
@@ -288,6 +294,10 @@ async function resolveContainerProject({
     projectRoot,
     composeFiles: [composeFile],
     env,
+    sensitiveValues: [
+      ...Object.values(projectEnv),
+      ...Object.values(buildArgs),
+    ],
   };
 }
 
@@ -309,10 +319,10 @@ function buildComposeArgs(
 
 function redactContainerDiagnostics(
   value: string,
-  env: Record<string, string>,
+  sensitiveValues: string[],
 ): string {
   let redacted = value;
-  for (const secret of Object.values(env)) {
+  for (const secret of sensitiveValues) {
     if (secret.length >= 8)
       redacted = redacted.replaceAll(secret, '[redacted]');
   }
@@ -338,7 +348,10 @@ async function collectContainerDiagnostics(
       const output = [result.stdout, result.stderr].filter(Boolean).join('\n');
       if (output) {
         sections.push(
-          `${label}:\n${redactContainerDiagnostics(output, resolved.env)}`,
+          `${label}:\n${redactContainerDiagnostics(
+            output,
+            resolved.sensitiveValues,
+          )}`,
         );
       }
     } catch {

--- a/apps/worker/src/commands/setup/workspace/container-projects.ts
+++ b/apps/worker/src/commands/setup/workspace/container-projects.ts
@@ -21,7 +21,6 @@ interface ContainerCommandOptions {
   cwd: string;
   env: Record<string, string>;
   timeoutMs?: number;
-  detached?: boolean;
 }
 
 type ContainerCommandRunner = (
@@ -39,16 +38,10 @@ const runContainerCommand: ContainerCommandRunner = async (
     cwd: options.cwd,
     env: options.env,
     extendEnv: false,
-    detached: options.detached,
     reject: true,
-    stdio: options.detached ? 'ignore' : 'pipe',
+    stdio: 'pipe',
     timeout: options.timeoutMs,
   });
-
-  if (options.detached) {
-    subprocess.unref();
-    return {};
-  }
 
   const result = await subprocess;
 
@@ -85,8 +78,12 @@ async function ensureDockerRuntime({
     if (!baseEnv.DOCKER_HOST) {
       await runCommand(
         'sudo',
-        ['dockerd', '--host=unix:///var/run/docker.sock', '--log-level=error'],
-        { ...commandOptions, timeoutMs: undefined, detached: true },
+        [
+          'sh',
+          '-c',
+          'nohup dockerd --host=unix:///var/run/docker.sock --log-level=error >/tmp/roomote-dockerd.log 2>&1 </dev/null &',
+        ],
+        commandOptions,
       );
     }
 

--- a/apps/worker/src/env/__tests__/worker-env.test.ts
+++ b/apps/worker/src/env/__tests__/worker-env.test.ts
@@ -302,6 +302,19 @@ describe('WorkerEnv', () => {
       expect(env.appEnv).toBe('production');
     });
 
+    it('should preserve the task-scoped Docker daemon endpoint', () => {
+      const env = WorkerEnv.fromProcessEnv({
+        HOME: '/home/worker',
+        PATH: '/usr/bin',
+        AUTH_TOKEN: 'my-auth-token',
+        TRPC_URL: 'https://trpc.example.com',
+        R_APP_URL: 'https://api.example.com',
+        DOCKER_HOST: 'tcp://127.0.0.1:2375',
+      } as NodeJS.ProcessEnv);
+
+      expect(env.buildUserFacingEnv().DOCKER_HOST).toBe('tcp://127.0.0.1:2375');
+    });
+
     it('should keep sandbox auth validation working after process.env cleanup', async () => {
       const { privateKey, publicKey } = generateKeyPairSync('ec', {
         namedCurve: 'P-256',

--- a/apps/worker/src/env/worker-env.ts
+++ b/apps/worker/src/env/worker-env.ts
@@ -36,6 +36,9 @@ const SYSTEM_KEYS = [
   'PNPM_HOME',
   'NODE_ENV',
   'COREPACK_ENABLE_DOWNLOAD_PROMPT',
+  // Container-project tasks use a task-scoped Docker daemon. Keep its endpoint
+  // available to setup commands, agent shells, and follow-up processes.
+  'DOCKER_HOST',
 ];
 
 // Capture worker-only config from the launcher, then scrub it from process.env

--- a/apps/worker/src/run-task/__tests__/sandbox-instruction.test.ts
+++ b/apps/worker/src/run-task/__tests__/sandbox-instruction.test.ts
@@ -64,6 +64,15 @@ describe('sanitizeEnvironmentConfigForPrompt', () => {
         },
       ],
       services: ['postgres17', { name: 'redis7', port: 6380 }],
+      container_projects: [
+        {
+          type: 'compose',
+          name: 'app',
+          repository: 'owner/repo',
+          files: ['compose.yaml'],
+          env: { COMPOSE_SECRET: 'do-not-print' },
+        },
+      ],
     };
 
     expect(sanitizeEnvironmentConfigForPrompt(environmentConfig)).toEqual({
@@ -111,6 +120,14 @@ describe('sanitizeEnvironmentConfigForPrompt', () => {
         },
       ],
       services: ['postgres17', { name: 'redis7', port: 6380 }],
+      container_projects: [
+        {
+          type: 'compose',
+          name: 'app',
+          repository: 'owner/repo',
+          files: ['compose.yaml'],
+        },
+      ],
     });
   });
 });

--- a/apps/worker/src/run-task/sandbox-instruction.ts
+++ b/apps/worker/src/run-task/sandbox-instruction.ts
@@ -1,5 +1,6 @@
 import type {
   Command,
+  ContainerProject,
   EnvironmentConfig,
   EnvironmentRepositoryConfig,
   NamedPort,
@@ -12,6 +13,36 @@ function withDefinedEntries<T extends Record<string, unknown>>(
 ): Record<string, unknown> {
   return Object.fromEntries(
     Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
+  );
+}
+
+function sanitizeContainerProjectForPrompt(
+  project: ContainerProject,
+): Record<string, unknown> {
+  const common = {
+    type: project.type,
+    name: project.name,
+    repository: project.repository,
+    working_dir: project.working_dir,
+    ports: project.ports,
+    required: project.required,
+  };
+
+  return withDefinedEntries(
+    project.type === 'compose'
+      ? {
+          ...common,
+          files: project.files,
+          profiles: project.profiles,
+          services: project.services,
+        }
+      : {
+          ...common,
+          context: project.context,
+          dockerfile: project.dockerfile,
+          target: project.target,
+          command: project.command,
+        },
   );
 }
 
@@ -90,6 +121,9 @@ export function sanitizeEnvironmentConfigForPrompt(
       sanitizeRepositoryForPrompt,
     ),
     services: environmentConfig.services?.map(sanitizeServiceForPrompt),
+    container_projects: environmentConfig.container_projects?.map(
+      sanitizeContainerProjectForPrompt,
+    ),
   });
 }
 
@@ -162,6 +196,13 @@ export function buildSandboxInstruction(
     if (hasDetachedCommands(environmentConfig)) {
       lines.push(
         'Any command marked `detached: true` was started in the background under PM2 supervision. Check its `logfile` and `pm2 status` before starting another copy.',
+      );
+    }
+
+    if (environmentConfig.container_projects?.length) {
+      lines.push(
+        '',
+        'Configured container projects were built and started with Docker Compose before your task began. Use `docker compose` with the configured project files when inspecting them, and do not start duplicate copies.',
       );
     }
 

--- a/packages/cloud-agents/src/server/workflows/__tests__/environmentSetupSkill.test.ts
+++ b/packages/cloud-agents/src/server/workflows/__tests__/environmentSetupSkill.test.ts
@@ -142,6 +142,22 @@ describe('environment-setup guidance', () => {
     expect(skillContent).toContain('<named_port_config>');
   });
 
+  it('uses and validates checked-in Compose or Dockerfile projects', () => {
+    const skillContent = readSkillContent();
+
+    expect(skillContent).toContain(
+      'prefer a top-level `container_projects` entry over translating its containers into Roomote-managed `services` or detached repository commands',
+    );
+    expect(skillContent).toContain(
+      'run `docker compose config --quiet` against the selected files or an equivalent generated one-service Compose model',
+    );
+    expect(skillContent).toContain(
+      '<field name="container_projects" required="false" type="ContainerProject[]" />',
+    );
+    expect(skillContent).toContain('<container_project_config>');
+    expect(skillContent).toContain('<container_project_port>');
+  });
+
   it('launches a follow-up verification task after persisting the environment', () => {
     const skillContent = readSkillContent();
 

--- a/packages/cloud-agents/src/server/workflows/skills/standard/environment-setup/SKILL.md
+++ b/packages/cloud-agents/src/server/workflows/skills/standard/environment-setup/SKILL.md
@@ -84,6 +84,8 @@ You are an expert Roomote environment analyst. Analyze the already-checked-out r
           <action>For long-running service commands (for example `dev`, `start`, `serve`, `preview`, watchers), set `detached: true` and include a `logfile` path.</action>
           <action>Do not wrap long-running commands in `pm2 start` yourself. Roomote runs environment repository commands marked `detached: true` under PM2 supervision, so the `run` value should be the foreground command the app normally uses.</action>
           <action>Include only services clearly required by the repository.</action>
+          <action>When a checked-in Docker Compose project or Dockerfile is the repository's supported development startup path, prefer a top-level `container_projects` entry over translating its containers into Roomote-managed `services` or detached repository commands. Reference the exact task-provided repository identifier and only relative paths that stay inside that repository.</action>
+          <action>For Compose, include the smallest evidence-backed `files`, `profiles`, and `services` selection. For a single Dockerfile, include evidence-backed `context`, `dockerfile`, `target`, `build_args`, and `command` values. Do not copy secrets or literal credentials from Compose files into the environment definition.</action>
           <action>Include `tool_versions` only when clearly discoverable.</action>
           <action>When the repository exposes a browser UI or a stable localhost landing page, populate `initialUrl` with the best validated absolute URL so the shared live browser does not start at `about:blank`.</action>
           <action>When a validated localhost HTTP surface is meant for humans in a browser (particularly a web app UI), also add a matching top-level `ports` entry so Roomote publishes a shareable preview URL and a `ROOMOTE_<NAME>_HOST` environment variable for it: use a short uppercase `name` such as `WEB`, set `port` to the validated listening port (named ports must fall in the 1024-65535 range), set `initial_path` when a specific landing path is better than `/`, and mark the main surface `primary: true` when more than one port is configured.</action>
@@ -115,6 +117,7 @@ You are an expert Roomote environment analyst. Analyze the already-checked-out r
 8. When the test failure instead appears to be a clearly pre-existing repository or unit-test failure outside environment-setup scope, record the exact command and failure, keep the suite referenced in `agentInstructions`, and continue only if install/start/localhost validation is otherwise sufficient.
 9. If the app exposes an HTTP UI, set `initialUrl` to the best validated absolute localhost URL (or keep `about:blank` only when no better landing page exists), confirm that localhost URL through loopback HTTP reachability and startup evidence, and record the exact URL plus the evidence used. Do not use direct browser automation from `environment-setup`.
 10. When the config includes a `ports` entry for a validated HTTP surface, confirm its `port` number matches the actual validated listening port and that any `initial_path` responds successfully over loopback.
+10a. When the config includes `container_projects`, run `docker compose config --quiet` against the selected files or an equivalent generated one-service Compose model, start the selected services, wait for readiness, and confirm mapped HTTP ports over loopback. Capture `docker compose ps --all` and recent service logs when startup fails.
 11. If the app exposes only an HTTP API or a non-browser surface, verify localhost reachability using loopback addresses only.
 12. If any command in the draft config fails or cannot be confirmed, either revise or remove that command from the YAML, or report the exact blocker; do not leave unrun or unconfirmed commands in the final config.
 13. As soon as repository evidence or early validation makes it clear that specific environment variables or secrets will be required and values are unavailable, request them immediately instead of waiting for a later failure.
@@ -212,7 +215,37 @@ You are an expert Roomote environment analyst. Analyze the already-checked-out r
 <field name="env" required="false" type="Record<string, string>" />
 <field name="ports" required="false" type="NamedPort[]" />
 <field name="services" required="false" type="ServiceConfig[]" />
+<field name="container_projects" required="false" type="ContainerProject[]" />
 </top_level_fields>
+
+<container_project_config>
+<field name="type" required="true" type="compose | dockerfile" />
+<field name="name" required="true" type="unique string starting with a letter" />
+<field name="repository" required="true" type="exact identifier from repositories[].repository" />
+<field name="working_dir" required="false" type="relative repository path" />
+<field name="env" required="false" type="Record<string, string>" />
+<field name="ports" required="false" type="ContainerProjectPort[]" />
+<field name="required" required="false" type="boolean (defaults true)" />
+<field name="startup_timeout_seconds" required="false" type="integer (1-3600)" />
+<compose_fields>
+<field name="files" required="true" type="relative path[]" min_items="1" />
+<field name="profiles" required="false" type="string[]" />
+<field name="services" required="false" type="string[]" />
+</compose_fields>
+<dockerfile_fields>
+<field name="context" required="false" type="relative path (defaults .)" />
+<field name="dockerfile" required="false" type="relative path (defaults Dockerfile)" />
+<field name="target" required="false" type="string" />
+<field name="build_args" required="false" type="Record<string, string>" />
+<field name="command" required="false" type="string[]" />
+</dockerfile_fields>
+</container_project_config>
+
+<container_project_port>
+<field name="named_port" required="true" type="name from the top-level ports list" />
+<field name="service" required="for compose" type="Compose service name" />
+<field name="container_port" required="true" type="integer (1-65535)" />
+</container_project_port>
 
 <named_port_config>
 <note>Each named port publishes a shareable live-preview URL for the environment and exposes a matching ROOMOTE host environment variable inside the sandbox (for example a port named WEB yields the `ROOMOTE_WEB_HOST` variable). Configure one entry per validated human-facing HTTP surface, particularly web app UIs.</note>
@@ -272,6 +305,8 @@ You are an expert Roomote environment analyst. Analyze the already-checked-out r
 <rule>When setup logic needs conditional or multiline behavior, prefer multiple simple command entries or one explicit shell wrapper command over raw multiline shell fragments.</rule>
 <rule>Prefer runtime-only configuration file modifications outside the git repository when possible to avoid unstaged repo changes.</rule>
 <rule>Include only services clearly required by repository evidence.</rule>
+<rule>Use `container_projects` only when a checked-in Compose project or Dockerfile is the evidence-backed development path, and validate the exact model before persistence.</rule>
+<rule>All container project paths must be relative and stay inside the selected configured repository.</rule>
 <rule>Include `tool_versions` only when clearly discoverable.</rule>
 <rule>When a repository exposes a browser UI or stable localhost landing page, set `initialUrl` to the best validated absolute URL unless `about:blank` is intentionally required.</rule>
 <rule>When a validated human-facing HTTP surface exists (particularly a web app UI), configure a matching top-level `ports` entry so the environment publishes a shareable preview URL for it; keep the `ports` list limited to validated human-facing surfaces and confirm each configured port number against the actual validated listening port.</rule>

--- a/packages/compute-providers/src/adapters/docker.ts
+++ b/packages/compute-providers/src/adapters/docker.ts
@@ -32,6 +32,14 @@ import type {
 const execFileAsync = promisify(execFile);
 const DOCKER_WORKER_CONTAINER_PREFIX = 'roomote-worker-';
 
+function getTaskDaemonContainerName(instanceId: string): string {
+  return `${instanceId}-docker`;
+}
+
+function getTaskWorkspaceVolumeName(instanceId: string): string {
+  return `${instanceId}-workspace`;
+}
+
 async function docker(
   args: string[],
   options: { signal?: AbortSignal; allowFailure?: boolean } = {},
@@ -92,6 +100,10 @@ export class DockerClient implements ComputeProviderClient {
       signal: input.signal,
       allowFailure: true,
     });
+    await docker(['rm', '-f', getTaskDaemonContainerName(input.instanceId)], {
+      signal: input.signal,
+      allowFailure: true,
+    });
     await docker(['rm', '-f', input.instanceId], {
       signal: input.signal,
       allowFailure: true,
@@ -102,12 +114,26 @@ export class DockerClient implements ComputeProviderClient {
         allowFailure: true,
       });
     }
+    await docker(
+      ['volume', 'rm', '-f', getTaskWorkspaceVolumeName(input.instanceId)],
+      {
+        signal: input.signal,
+        allowFailure: true,
+      },
+    );
     return {};
   }
 
   public async enterStandby(
     input: EnterStandbyInput,
   ): Promise<EnterStandbyResult> {
+    await docker(
+      ['stop', '--time', '10', getTaskDaemonContainerName(input.instanceId)],
+      {
+        signal: input.signal,
+        allowFailure: true,
+      },
+    );
     await docker(['stop', '--time', '10', input.instanceId], {
       signal: input.signal,
     });
@@ -118,6 +144,10 @@ export class DockerClient implements ComputeProviderClient {
     input: ResumeFromStandbyInput,
   ): Promise<CreatedInstance> {
     await docker(['start', input.resumeHandle], { signal: input.signal });
+    await docker(['start', getTaskDaemonContainerName(input.resumeHandle)], {
+      signal: input.signal,
+      allowFailure: true,
+    });
     return {
       instanceId: input.resumeHandle,
       sourceSnapshotId: input.resumeHandle,

--- a/packages/compute-providers/src/adapters/modal.test.ts
+++ b/packages/compute-providers/src/adapters/modal.test.ts
@@ -444,6 +444,43 @@ describe('ModalClient', () => {
     );
   });
 
+  it('uses the VM runtime for fresh and resumed Docker sandboxes', async () => {
+    sandboxCreateMock.mockResolvedValue({
+      sandboxId: 'modal-123',
+      tunnels: vi.fn().mockResolvedValue({}),
+    });
+
+    const client = new ModalClient({
+      tokenId: 'token-id',
+      tokenSecret: 'token-secret',
+      baseImageRef: MODAL_IMAGE_REF,
+      vmRuntime: true,
+    });
+
+    await client.createInstance({ ports: [3000] });
+
+    expect(sandboxCreateMock).toHaveBeenLastCalledWith(
+      { appId: 'app-123' },
+      { imageId: 'img-123' },
+      expect.objectContaining({
+        experimentalOptions: { vm_runtime: true },
+      }),
+    );
+
+    await client.resumeFromSnapshot({
+      sourceSnapshotId: 'img-snap-123',
+      ports: [3000],
+    });
+
+    expect(sandboxCreateMock).toHaveBeenLastCalledWith(
+      { appId: 'app-123' },
+      { imageId: 'img-snap-123' },
+      expect.objectContaining({
+        experimentalOptions: { vm_runtime: true },
+      }),
+    );
+  });
+
   it('uses the longer snapshot deadline and normalizes Modal snapshot RPC failures', async () => {
     const snapshotFilesystemMock = vi
       .fn()

--- a/packages/compute-providers/src/adapters/modal.ts
+++ b/packages/compute-providers/src/adapters/modal.ts
@@ -451,6 +451,9 @@ export class ModalClient implements ComputeProviderClient {
           ...(this.config.regions?.length
             ? { regions: this.config.regions }
             : {}),
+          ...(this.config.vmRuntime
+            ? { experimentalOptions: { vm_runtime: true } }
+            : {}),
         }),
         signal: input.signal,
         abortMessage: 'Creating a Modal sandbox was aborted',
@@ -913,6 +916,9 @@ export class ModalClient implements ComputeProviderClient {
             : {}),
           ...(this.config.regions?.length
             ? { regions: this.config.regions }
+            : {}),
+          ...(this.config.vmRuntime
+            ? { experimentalOptions: { vm_runtime: true } }
             : {}),
         }),
         signal: input.signal,

--- a/packages/compute-providers/src/blaxel/build-blaxel-image.test.ts
+++ b/packages/compute-providers/src/blaxel/build-blaxel-image.test.ts
@@ -33,7 +33,7 @@ describe('Blaxel worker image provisioning', () => {
 
   it('derives a deterministic resource name from the Blaxel image hash', () => {
     expect(deriveBlaxelWorkerImageName('ghcr.io/roomote/worker:v1')).toBe(
-      'roomote-worker-abc123',
+      'roomote-worker-abc123-r1',
     );
   });
 
@@ -49,7 +49,7 @@ describe('Blaxel worker image provisioning', () => {
         imageRef: 'ghcr.io/roomote/worker:v1',
       }),
     ).resolves.toEqual({
-      imageName: 'roomote-worker-abc123',
+      imageName: 'roomote-worker-abc123-r1',
       imageRef: 'sandbox/roomote-worker:version',
     });
 
@@ -58,8 +58,8 @@ describe('Blaxel worker image provisioning', () => {
       workspace: 'workspace',
     });
     expect(mockBuild).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'roomote-worker-abc123' }),
+      expect.objectContaining({ name: 'roomote-worker-abc123-r1' }),
     );
-    expect(mockDelete).toHaveBeenCalledWith('roomote-worker-abc123');
+    expect(mockDelete).toHaveBeenCalledWith('roomote-worker-abc123-r1');
   });
 });

--- a/packages/compute-providers/src/blaxel/build-blaxel-image.test.ts
+++ b/packages/compute-providers/src/blaxel/build-blaxel-image.test.ts
@@ -33,7 +33,7 @@ describe('Blaxel worker image provisioning', () => {
 
   it('derives a deterministic resource name from the Blaxel image hash', () => {
     expect(deriveBlaxelWorkerImageName('ghcr.io/roomote/worker:v1')).toBe(
-      'roomote-worker-abc123-r1',
+      'roomote-worker-abc123-r2',
     );
   });
 
@@ -49,7 +49,7 @@ describe('Blaxel worker image provisioning', () => {
         imageRef: 'ghcr.io/roomote/worker:v1',
       }),
     ).resolves.toEqual({
-      imageName: 'roomote-worker-abc123-r1',
+      imageName: 'roomote-worker-abc123-r2',
       imageRef: 'sandbox/roomote-worker:version',
     });
 
@@ -58,8 +58,8 @@ describe('Blaxel worker image provisioning', () => {
       workspace: 'workspace',
     });
     expect(mockBuild).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'roomote-worker-abc123-r1' }),
+      expect.objectContaining({ name: 'roomote-worker-abc123-r2' }),
     );
-    expect(mockDelete).toHaveBeenCalledWith('roomote-worker-abc123-r1');
+    expect(mockDelete).toHaveBeenCalledWith('roomote-worker-abc123-r2');
   });
 });

--- a/packages/compute-providers/src/blaxel/build-blaxel-image.test.ts
+++ b/packages/compute-providers/src/blaxel/build-blaxel-image.test.ts
@@ -21,7 +21,13 @@ import {
 describe('Blaxel worker image provisioning', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockFromRegistry.mockReturnValue({ hash: 'abc123', build: mockBuild });
+    const image = {
+      hash: 'abc123',
+      build: mockBuild,
+      runCommands: vi.fn(),
+    };
+    image.runCommands.mockReturnValue(image);
+    mockFromRegistry.mockReturnValue(image);
     mockDelete.mockResolvedValue(undefined);
   });
 

--- a/packages/compute-providers/src/blaxel/build-blaxel-image.ts
+++ b/packages/compute-providers/src/blaxel/build-blaxel-image.ts
@@ -20,6 +20,14 @@ export interface BuiltBlaxelWorkerImage {
   imageName: string;
 }
 
+function createBlaxelWorkerImage(imageRef: string): ImageInstance {
+  return ImageInstance.fromRegistry(imageRef).runCommands(
+    'sudo update-alternatives --set iptables /usr/sbin/iptables-legacy',
+    'sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy',
+    'sudo docker compose version',
+  );
+}
+
 export function deriveBlaxelWorkerImageName(imageRef: string): string {
   if (!imageRef.includes('/')) {
     throw new Error(
@@ -27,7 +35,7 @@ export function deriveBlaxelWorkerImageName(imageRef: string): string {
     );
   }
 
-  const image = ImageInstance.fromRegistry(imageRef);
+  const image = createBlaxelWorkerImage(imageRef);
   return `${BLAXEL_WORKER_IMAGE_NAME_PREFIX}-${image.hash}`;
 }
 
@@ -41,7 +49,7 @@ export async function buildBlaxelWorkerImage(
 ): Promise<BuiltBlaxelWorkerImage> {
   const imageName =
     options.imageName ?? deriveBlaxelWorkerImageName(options.imageRef);
-  const image = ImageInstance.fromRegistry(options.imageRef);
+  const image = createBlaxelWorkerImage(options.imageRef);
 
   settings.setConfig({
     apiKey: options.apiKey,

--- a/packages/compute-providers/src/blaxel/build-blaxel-image.ts
+++ b/packages/compute-providers/src/blaxel/build-blaxel-image.ts
@@ -1,4 +1,5 @@
 import { ImageInstance, SandboxInstance, settings } from '@blaxel/core';
+import { WORKER_RUNTIME_SCHEMA_TAG } from '@roomote/types';
 
 export const BLAXEL_WORKER_IMAGE_NAME_PREFIX = 'roomote-worker';
 
@@ -36,7 +37,7 @@ export function deriveBlaxelWorkerImageName(imageRef: string): string {
   }
 
   const image = createBlaxelWorkerImage(imageRef);
-  return `${BLAXEL_WORKER_IMAGE_NAME_PREFIX}-${image.hash}`;
+  return `${BLAXEL_WORKER_IMAGE_NAME_PREFIX}-${image.hash}-${WORKER_RUNTIME_SCHEMA_TAG}`;
 }
 
 /**

--- a/packages/compute-providers/src/daytona/register-daytona-snapshot.ts
+++ b/packages/compute-providers/src/daytona/register-daytona-snapshot.ts
@@ -1,4 +1,5 @@
 import { Daytona } from '@daytonaio/sdk';
+import { WORKER_RUNTIME_SCHEMA_TAG } from '@roomote/types';
 
 /**
  * Default name prefix for the Roomote worker base snapshot. The suffix is
@@ -14,7 +15,7 @@ export function deriveDaytonaWorkerSnapshotName(imageRef: string): string {
 
   const sanitizedTag = imageTag.toLowerCase().replace(/[^a-z0-9._-]/g, '-');
 
-  return `${DAYTONA_WORKER_SNAPSHOT_NAME_PREFIX}-${sanitizedTag}`;
+  return `${DAYTONA_WORKER_SNAPSHOT_NAME_PREFIX}-${sanitizedTag}-${WORKER_RUNTIME_SCHEMA_TAG}`;
 }
 
 export interface RegisterDaytonaWorkerSnapshotOptions {
@@ -30,7 +31,7 @@ export interface RegisterDaytonaWorkerSnapshotOptions {
    * registration has no per-call registry credentials.
    */
   imageRef: string;
-  /** Overrides the derived `roomote-worker-<image-tag>` snapshot name. */
+  /** Overrides `roomote-worker-<image-tag>-r<schema>`. */
   snapshotName?: string;
   onLog?: (chunk: string) => void;
 }

--- a/packages/compute-providers/src/e2b/build-e2b-template.ts
+++ b/packages/compute-providers/src/e2b/build-e2b-template.ts
@@ -1,4 +1,5 @@
 import { Template, type LogEntry } from 'e2b';
+import { WORKER_RUNTIME_SCHEMA_TAG } from '@roomote/types';
 
 /**
  * Default template name for the Roomote worker base template. The tag is
@@ -25,7 +26,7 @@ export interface BuildE2bWorkerTemplateOptions {
    * Docker tags are rejected up front.
    */
   imageRef: string;
-  /** Overrides the derived `roomote-worker:<image-tag>` template reference. */
+  /** Overrides the derived `roomote-worker:<image-tag>-r<schema>` reference. */
   templateRef?: string;
   cpuCount?: number;
   memoryMB?: number;
@@ -48,7 +49,7 @@ export function deriveE2bWorkerTemplateRef(imageRef: string): string {
     ? imageRef.slice(imageRef.lastIndexOf(':') + 1)
     : 'latest';
 
-  return `${E2B_WORKER_TEMPLATE_NAME}:${imageTag}`;
+  return `${E2B_WORKER_TEMPLATE_NAME}:${imageTag}-${WORKER_RUNTIME_SCHEMA_TAG}`;
 }
 
 /**

--- a/packages/compute-providers/src/e2b/build-e2b-template.ts
+++ b/packages/compute-providers/src/e2b/build-e2b-template.ts
@@ -85,12 +85,14 @@ export async function buildE2bWorkerTemplate(
     })}`,
   );
 
-  const template = Template().fromImage(
-    imageRef,
-    registryUsername && registryPassword
-      ? { username: registryUsername, password: registryPassword }
-      : undefined,
-  );
+  const template = Template()
+    .fromImage(
+      imageRef,
+      registryUsername && registryPassword
+        ? { username: registryUsername, password: registryPassword }
+        : undefined,
+    )
+    .runCmd('sudo docker compose version');
 
   const buildInfo = await Template.build(template, templateRef, {
     apiKey,

--- a/packages/compute-providers/src/types.ts
+++ b/packages/compute-providers/src/types.ts
@@ -242,6 +242,8 @@ export interface ModalConfig {
   memoryMiB?: number;
   /** Hard memory cap in MiB (e.g. 16384 for 16 GB). */
   memoryLimitMiB?: number;
+  /** Use Modal's VM sandbox runtime for nested Docker workloads. */
+  vmRuntime?: boolean;
 }
 
 export interface DockerConfig {

--- a/packages/compute-providers/src/worker-artifact-version.test.ts
+++ b/packages/compute-providers/src/worker-artifact-version.test.ts
@@ -1,0 +1,16 @@
+import { deriveDaytonaWorkerSnapshotName } from './daytona';
+import { deriveE2bWorkerTemplateRef } from './e2b';
+
+describe('hosted worker artifact versioning', () => {
+  it('includes the runtime schema in E2B template refs', () => {
+    expect(deriveE2bWorkerTemplateRef('ghcr.io/roomote/worker:v1.2.3')).toBe(
+      'roomote-worker:v1.2.3-r1',
+    );
+  });
+
+  it('includes the runtime schema in Daytona snapshot names', () => {
+    expect(
+      deriveDaytonaWorkerSnapshotName('ghcr.io/roomote/worker:v1.2.3'),
+    ).toBe('roomote-worker-v1.2.3-r1');
+  });
+});

--- a/packages/compute-providers/src/worker-artifact-version.test.ts
+++ b/packages/compute-providers/src/worker-artifact-version.test.ts
@@ -4,13 +4,13 @@ import { deriveE2bWorkerTemplateRef } from './e2b';
 describe('hosted worker artifact versioning', () => {
   it('includes the runtime schema in E2B template refs', () => {
     expect(deriveE2bWorkerTemplateRef('ghcr.io/roomote/worker:v1.2.3')).toBe(
-      'roomote-worker:v1.2.3-r1',
+      'roomote-worker:v1.2.3-r2',
     );
   });
 
   it('includes the runtime schema in Daytona snapshot names', () => {
     expect(
       deriveDaytonaWorkerSnapshotName('ghcr.io/roomote/worker:v1.2.3'),
-    ).toBe('roomote-worker-v1.2.3-r1');
+    ).toBe('roomote-worker-v1.2.3-r2');
   });
 });

--- a/packages/compute-providers/src/worker-env/e2b.test.ts
+++ b/packages/compute-providers/src/worker-env/e2b.test.ts
@@ -15,5 +15,16 @@ describe('buildE2bWorkerEnv', () => {
     expect(env.ROOMOTE_WORKER_COMPUTE_FINGERPRINT_KIND).toBe('base-image');
     expect(env.ROOMOTE_WORKER_DEPLOYMENT_SLUG).toBe('roomote');
     expect(env.ROOMOTE_WORKER_ENVIRONMENT_ID).toBe('env_123');
+    expect(env.DOCKER_HOST).toBe('tcp://127.0.0.1:2375');
+  });
+
+  it('preserves a custom Docker endpoint for self-hosted E2B', () => {
+    const env = buildE2bWorkerEnv({
+      authToken: 'auth-token',
+      templateId: 'roomote-worker',
+      extraEnv: { DOCKER_HOST: 'tcp://docker.internal:2375' },
+    });
+
+    expect(env.DOCKER_HOST).toBe('tcp://docker.internal:2375');
   });
 });

--- a/packages/compute-providers/src/worker-env/e2b.ts
+++ b/packages/compute-providers/src/worker-env/e2b.ts
@@ -24,6 +24,10 @@ export function buildE2bWorkerEnv({
       deploymentSlug,
       environmentId,
     }),
+    // E2B's Docker-enabled sandbox runtime exposes its daemon over this
+    // loopback endpoint rather than the default Unix socket. Keep an explicit
+    // caller override for self-hosted/custom E2B environments.
+    DOCKER_HOST: extraEnv?.DOCKER_HOST ?? 'tcp://127.0.0.1:2375',
     MISE_DATA_DIR: '/opt/mise',
     MISE_CACHE_DIR: '/opt/mise/cache',
   };

--- a/packages/types/src/__tests__/compute-provider-capabilities.test.ts
+++ b/packages/types/src/__tests__/compute-provider-capabilities.test.ts
@@ -1,0 +1,18 @@
+import { getComputeProviderCapabilities } from '../compute-providers/capabilities';
+
+describe('compute provider capabilities', () => {
+  it.each(['docker', 'daytona', 'e2b', 'blaxel'] as const)(
+    'marks %s as supporting container projects',
+    (provider) => {
+      expect(
+        getComputeProviderCapabilities(provider).supportsContainerProjects,
+      ).toBe(true);
+    },
+  );
+
+  it('keeps Modal container projects disabled until VM sandboxes are supported', () => {
+    expect(
+      getComputeProviderCapabilities('modal').supportsContainerProjects,
+    ).toBe(false);
+  });
+});

--- a/packages/types/src/__tests__/compute-provider-capabilities.test.ts
+++ b/packages/types/src/__tests__/compute-provider-capabilities.test.ts
@@ -1,7 +1,7 @@
 import { getComputeProviderCapabilities } from '../compute-providers/capabilities';
 
 describe('compute provider capabilities', () => {
-  it.each(['docker', 'daytona', 'e2b', 'blaxel'] as const)(
+  it.each(['docker', 'modal', 'daytona', 'e2b', 'blaxel'] as const)(
     'marks %s as supporting container projects',
     (provider) => {
       expect(
@@ -9,10 +9,4 @@ describe('compute provider capabilities', () => {
       ).toBe(true);
     },
   );
-
-  it('keeps Modal container projects disabled until VM sandboxes are supported', () => {
-    expect(
-      getComputeProviderCapabilities('modal').supportsContainerProjects,
-    ).toBe(false);
-  });
 });

--- a/packages/types/src/__tests__/container-projects-schema.test.ts
+++ b/packages/types/src/__tests__/container-projects-schema.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import { environmentConfigSchema } from '../environment-config';
+
+const baseConfig = {
+  name: 'Container environment',
+  repositories: [{ repository: 'acme/app' }],
+  ports: [{ name: 'WEB', port: 3000 }],
+};
+
+describe('container project environment schema', () => {
+  it('accepts a Compose project tied to a configured repository and port', () => {
+    const result = environmentConfigSchema.safeParse({
+      ...baseConfig,
+      container_projects: [
+        {
+          type: 'compose',
+          name: 'development',
+          repository: 'acme/app',
+          files: ['compose.yaml', 'compose.local.yaml'],
+          profiles: ['agent'],
+          ports: [{ named_port: 'WEB', service: 'web', container_port: 3000 }],
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a Dockerfile project', () => {
+    const result = environmentConfigSchema.safeParse({
+      ...baseConfig,
+      container_projects: [
+        {
+          type: 'dockerfile',
+          name: 'api',
+          repository: 'acme/app',
+          context: 'services/api',
+          dockerfile: 'services/api/Dockerfile.dev',
+          build_args: { NODE_ENV: 'development' },
+          ports: [{ named_port: 'WEB', container_port: 3000 }],
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects repositories, named ports, and paths outside the environment', () => {
+    const result = environmentConfigSchema.safeParse({
+      ...baseConfig,
+      container_projects: [
+        {
+          type: 'compose',
+          name: 'development',
+          repository: 'acme/other',
+          files: ['../compose.yaml'],
+          ports: [
+            { named_port: 'MISSING', service: 'web', container_port: 3000 },
+          ],
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    const messages = result.error?.issues.map((issue) => issue.message) ?? [];
+    expect(messages).toContain('Path must stay within the selected repository');
+    expect(messages).toContain(
+      "Container project repository 'acme/other' is not configured in this environment",
+    );
+    expect(messages).toContain(
+      "Container project port 'MISSING' is not configured in the environment ports list",
+    );
+  });
+
+  it('requires Compose port mappings to name a service', () => {
+    const result = environmentConfigSchema.safeParse({
+      ...baseConfig,
+      container_projects: [
+        {
+          type: 'compose',
+          name: 'development',
+          repository: 'acme/app',
+          files: ['compose.yaml'],
+          ports: [{ named_port: 'WEB', container_port: 3000 }],
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.map((issue) => issue.message)).toContain(
+      'Compose port mappings require a service name',
+    );
+  });
+
+  it('requires unique project names and named port ownership', () => {
+    const result = environmentConfigSchema.safeParse({
+      ...baseConfig,
+      container_projects: [
+        {
+          type: 'dockerfile',
+          name: 'api',
+          repository: 'acme/app',
+          ports: [{ named_port: 'WEB', container_port: 3000 }],
+        },
+        {
+          type: 'dockerfile',
+          name: 'API',
+          repository: 'acme/app',
+          ports: [{ named_port: 'web', container_port: 3001 }],
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    const messages = result.error?.issues.map((issue) => issue.message) ?? [];
+    expect(messages).toContain('Duplicate container project name: API');
+    expect(messages).toContain(
+      "Environment port 'web' can only be mapped by one container project",
+    );
+  });
+});

--- a/packages/types/src/compute-providers/capabilities.ts
+++ b/packages/types/src/compute-providers/capabilities.ts
@@ -58,7 +58,7 @@ export const DAYTONA_CAPABILITIES: ComputeProviderCapabilities = {
   supportsStandbyResume: false,
   supportsResume: true,
   supportsFileWrite: true,
-  supportsContainerProjects: false,
+  supportsContainerProjects: true,
 };
 
 export const E2B_CAPABILITIES: ComputeProviderCapabilities = {

--- a/packages/types/src/compute-providers/capabilities.ts
+++ b/packages/types/src/compute-providers/capabilities.ts
@@ -18,6 +18,8 @@ export interface ComputeProviderCapabilities {
   supportsStandbyResume: boolean;
   supportsResume: boolean;
   supportsFileWrite: boolean;
+  /** Can run customer-owned Docker Compose and Dockerfile projects. */
+  supportsContainerProjects: boolean;
 }
 
 export const DOCKER_CAPABILITIES: ComputeProviderCapabilities = {
@@ -30,6 +32,7 @@ export const DOCKER_CAPABILITIES: ComputeProviderCapabilities = {
   supportsStandbyResume: true,
   supportsResume: true,
   supportsFileWrite: false,
+  supportsContainerProjects: true,
 };
 
 export const MODAL_CAPABILITIES: ComputeProviderCapabilities = {
@@ -42,6 +45,7 @@ export const MODAL_CAPABILITIES: ComputeProviderCapabilities = {
   supportsStandbyResume: false,
   supportsResume: true,
   supportsFileWrite: true,
+  supportsContainerProjects: false,
 };
 
 export const DAYTONA_CAPABILITIES: ComputeProviderCapabilities = {
@@ -54,6 +58,7 @@ export const DAYTONA_CAPABILITIES: ComputeProviderCapabilities = {
   supportsStandbyResume: false,
   supportsResume: true,
   supportsFileWrite: true,
+  supportsContainerProjects: false,
 };
 
 export const E2B_CAPABILITIES: ComputeProviderCapabilities = {
@@ -66,6 +71,7 @@ export const E2B_CAPABILITIES: ComputeProviderCapabilities = {
   supportsStandbyResume: false,
   supportsResume: true,
   supportsFileWrite: true,
+  supportsContainerProjects: true,
 };
 
 export const BLAXEL_CAPABILITIES: ComputeProviderCapabilities = {
@@ -78,6 +84,7 @@ export const BLAXEL_CAPABILITIES: ComputeProviderCapabilities = {
   supportsStandbyResume: true,
   supportsResume: true,
   supportsFileWrite: true,
+  supportsContainerProjects: true,
 };
 
 export function getComputeProviderCapabilities(

--- a/packages/types/src/compute-providers/capabilities.ts
+++ b/packages/types/src/compute-providers/capabilities.ts
@@ -45,7 +45,7 @@ export const MODAL_CAPABILITIES: ComputeProviderCapabilities = {
   supportsStandbyResume: false,
   supportsResume: true,
   supportsFileWrite: true,
-  supportsContainerProjects: false,
+  supportsContainerProjects: true,
 };
 
 export const DAYTONA_CAPABILITIES: ComputeProviderCapabilities = {

--- a/packages/types/src/environment-config.ts
+++ b/packages/types/src/environment-config.ts
@@ -102,6 +102,89 @@ export const serviceConfigSchema = z.union([
 export type ServiceConfig = z.infer<typeof serviceConfigSchema>;
 
 /**
+ * Container projects run customer-owned Docker Compose or Dockerfile services
+ * inside the task sandbox after their repository has been prepared.
+ */
+const containerProjectNameSchema = z
+  .string()
+  .min(1, 'Container project name is required')
+  .max(50)
+  .regex(
+    /^[a-zA-Z][a-zA-Z0-9_-]*$/,
+    'Container project name must start with a letter and contain only letters, numbers, underscores, and hyphens',
+  );
+
+const containerProjectRelativePathSchema = z
+  .string()
+  .min(1)
+  .refine(
+    (value) =>
+      !value.startsWith('/') &&
+      !value.startsWith('~') &&
+      !/^[a-zA-Z]:[\\/]/.test(value),
+    { message: 'Path must be relative to the selected repository' },
+  )
+  .refine(
+    (value) => !value.split(/[\\/]/).some((segment) => segment === '..'),
+    { message: 'Path must stay within the selected repository' },
+  );
+
+export const containerProjectPortSchema = z.object({
+  /** Name of an entry in the environment's top-level `ports` list. */
+  named_port: z.string().min(1),
+  /** Compose service that owns the container port. Omitted for Dockerfiles. */
+  service: z.string().min(1).optional(),
+  container_port: z.number().int().min(1).max(65535),
+});
+
+const containerProjectCommonShape = {
+  name: containerProjectNameSchema,
+  repository: z
+    .string()
+    .regex(
+      /^[^/]+(?:\/[^/]+)+$/,
+      'Must reference a configured slash-separated repository name',
+    ),
+  working_dir: containerProjectRelativePathSchema.optional(),
+  env: z.record(z.string()).optional(),
+  ports: z.array(containerProjectPortSchema).optional(),
+  required: z.boolean().optional(),
+  startup_timeout_seconds: z.number().int().positive().max(3600).optional(),
+};
+
+export const composeContainerProjectSchema = z.object({
+  ...containerProjectCommonShape,
+  type: z.literal('compose'),
+  files: z.array(containerProjectRelativePathSchema).min(1),
+  profiles: z.array(z.string().min(1)).optional(),
+  services: z.array(z.string().min(1)).optional(),
+});
+
+export const dockerfileContainerProjectSchema = z.object({
+  ...containerProjectCommonShape,
+  type: z.literal('dockerfile'),
+  context: containerProjectRelativePathSchema.optional(),
+  dockerfile: containerProjectRelativePathSchema.optional(),
+  target: z.string().min(1).optional(),
+  build_args: z.record(z.string()).optional(),
+  command: z.array(z.string()).min(1).optional(),
+});
+
+export const containerProjectSchema = z.discriminatedUnion('type', [
+  composeContainerProjectSchema,
+  dockerfileContainerProjectSchema,
+]);
+
+export type ContainerProjectPort = z.infer<typeof containerProjectPortSchema>;
+export type ComposeContainerProject = z.infer<
+  typeof composeContainerProjectSchema
+>;
+export type DockerfileContainerProject = z.infer<
+  typeof dockerfileContainerProjectSchema
+>;
+export type ContainerProject = z.infer<typeof containerProjectSchema>;
+
+/**
  * Default ports for each service.
  */
 export const serviceDefaultPorts: Record<ServiceName, number> = {
@@ -554,6 +637,11 @@ export const environmentConfigSchema = z
       .optional()
       .transform(filterLegacyServices),
     /**
+     * Customer-owned Docker Compose projects or Dockerfiles to start after
+     * their repositories have been prepared.
+     */
+    container_projects: z.array(containerProjectSchema).optional(),
+    /**
      * Optional sandbox OIDC targets for this environment.
      * Tokens are minted by Roomote, written into the sandbox filesystem, and
      * refreshed externally while the sandbox stays active.
@@ -743,6 +831,83 @@ export const environmentConfigSchema = z
           });
         }
       }
+    }
+
+    if (data.container_projects && data.container_projects.length > 0) {
+      const configuredRepositories = new Set(
+        data.repositories.map((repository) => repository.repository),
+      );
+      const configuredPortNames = new Set(
+        (data.ports ?? []).map((port) => port.name.toUpperCase()),
+      );
+      const seenProjectNames = new Set<string>();
+      const seenNamedPorts = new Set<string>();
+
+      data.container_projects.forEach((project, projectIndex) => {
+        const normalizedProjectName = project.name.toLowerCase();
+        if (seenProjectNames.has(normalizedProjectName)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Duplicate container project name: ${project.name}`,
+            path: ['container_projects', projectIndex, 'name'],
+          });
+        }
+        seenProjectNames.add(normalizedProjectName);
+
+        if (!configuredRepositories.has(project.repository)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Container project repository '${project.repository}' is not configured in this environment`,
+            path: ['container_projects', projectIndex, 'repository'],
+          });
+        }
+
+        project.ports?.forEach((port, portIndex) => {
+          const normalizedPortName = port.named_port.toUpperCase();
+          if (!configuredPortNames.has(normalizedPortName)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: `Container project port '${port.named_port}' is not configured in the environment ports list`,
+              path: [
+                'container_projects',
+                projectIndex,
+                'ports',
+                portIndex,
+                'named_port',
+              ],
+            });
+          }
+
+          if (seenNamedPorts.has(normalizedPortName)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: `Environment port '${port.named_port}' can only be mapped by one container project`,
+              path: [
+                'container_projects',
+                projectIndex,
+                'ports',
+                portIndex,
+                'named_port',
+              ],
+            });
+          }
+          seenNamedPorts.add(normalizedPortName);
+
+          if (project.type === 'compose' && !port.service) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: 'Compose port mappings require a service name',
+              path: [
+                'container_projects',
+                projectIndex,
+                'ports',
+                portIndex,
+                'service',
+              ],
+            });
+          }
+        });
+      });
     }
   });
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -62,3 +62,4 @@ export * from './task-messages';
 export * from './timeout-observability';
 export * from './user-display-name';
 export * from './user-role';
+export * from './worker-runtime-version';

--- a/packages/types/src/setup-new.ts
+++ b/packages/types/src/setup-new.ts
@@ -17,6 +17,8 @@ import type { SourceControlProvider } from './source-control';
  */
 export type SetupNewComputeProvisioningState = {
   status: 'building' | 'succeeded' | 'failed';
+  /** Worker runtime contract used to build this provider artifact. */
+  runtimeSchemaVersion: number;
   imageRef: string;
   /** Provider-side artifact reference (template, snapshot, or image ref). */
   templateRef: string | null;

--- a/packages/types/src/worker-runtime-version.ts
+++ b/packages/types/src/worker-runtime-version.ts
@@ -1,0 +1,9 @@
+/**
+ * Compatibility version for the tools and operating-system capabilities baked
+ * into Roomote worker images. Bump this when an existing image tag or hosted
+ * provider artifact must be rebuilt because the runtime contract changed.
+ */
+export const WORKER_RUNTIME_SCHEMA_VERSION = 1;
+
+/** Stable string used in Docker labels and provider-side resource names. */
+export const WORKER_RUNTIME_SCHEMA_TAG = `r${WORKER_RUNTIME_SCHEMA_VERSION}`;

--- a/packages/types/src/worker-runtime-version.ts
+++ b/packages/types/src/worker-runtime-version.ts
@@ -3,7 +3,7 @@
  * into Roomote worker images. Bump this when an existing image tag or hosted
  * provider artifact must be rebuilt because the runtime contract changed.
  */
-export const WORKER_RUNTIME_SCHEMA_VERSION = 1;
+export const WORKER_RUNTIME_SCHEMA_VERSION = 2;
 
 /** Stable string used in Docker labels and provider-side resource names. */
 export const WORKER_RUNTIME_SCHEMA_TAG = `r${WORKER_RUNTIME_SCHEMA_VERSION}`;


### PR DESCRIPTION
## Summary

- add typed environment configuration and visual editing for existing Docker Compose projects and single Dockerfiles
- start container projects after repository cloning with health waits, port mappings, redacted diagnostics, and agent-visible runtime context
- add task-scoped Docker-in-Docker lifecycle support for the local Docker provider and validate hosted provider worker artifacts
- support container projects on Modal VM sandboxes, Daytona, E2B, and Blaxel
- update environment setup guidance and public documentation

## Why

Customers often already have a working Compose or Dockerfile-based development environment. This lets Roomote reuse that setup directly instead of duplicating containers as managed services or handwritten startup commands.

## Runtime and security

- local Docker tasks receive a dedicated daemon and shared workspace volume that follow the task lifecycle
- container project paths are constrained to configured repositories
- environment and build values are excluded from agent-visible configuration, and startup diagnostics redact environment values
- supported providers are Docker, Modal, Daytona, E2B, and Blaxel
- Modal uses its beta VM sandbox runtime only for environments with container projects

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm check-types`
- `pnpm lint:fast`
- `pnpm check-types:fast`
- `pnpm knip`
- focused schema, worker, controller, provider, UI, and workflow tests
- real nested-Docker smoke test covering Dockerfile build, Compose startup and health, port publishing, HTTP response, and cleanup
- worker Dockerfile build check and Ubuntu Docker package availability
