### PR TITLE
Make the announcer source-control-neutral

### DIFF
--- a/packages/sdk/src/server/automations/announcer.ts
+++ b/packages/sdk/src/server/automations/announcer.ts
@@ -21,7 +21,7 @@ import { SUMMARIZE_MERGED_PRS_SETTINGS_HASH } from '@roomote/types';
 import { SlackNotifier } from '@roomote/slack';
 
 import { loadAutomationThreadFeedbackContext } from './automation-thread-feedback';
-import { hasActiveGitHubInstallation } from './github-deployment-scope';
+import { hasAnyActiveRepository } from './github-deployment-scope';
 import { buildAutomationRootSummaryMessage } from '../lib/manager-slack';
 import { isRunDue, resolveSlackWorkspaceTimezone } from './scheduling-utils';
 import {
@@ -55,7 +55,9 @@ const WINDOW_DAYS: Record<AnnouncerFrequency, number> = {
 const MAX_DETAIL_MESSAGE_CHARS = 3_000;
 
 async function findEligibleDeployments(): Promise<DeploymentContext[]> {
-  if (!(await hasActiveGitHubInstallation())) {
+  // Merged-PR data comes from the provider-neutral taskPullRequests table,
+  // so any active repository qualifies regardless of source-control provider.
+  if (!(await hasAnyActiveRepository())) {
     return [];
   }
 
@@ -224,7 +226,8 @@ export async function announcerJob(
   const eligibleDeployments = await findEligibleDeployments();
 
   if (eligibleDeployments.length === 0) {
-    result.skippedReason = 'GitHub and Slack must both be connected.';
+    result.skippedReason =
+      'An active repository and Slack must both be connected.';
   }
 
   let processed = 0;

--- a/packages/types/src/background-automation-registry.ts
+++ b/packages/types/src/background-automation-registry.ts
@@ -146,10 +146,11 @@ export const TRIGGERABLE_BACKGROUND_AUTOMATION_DESCRIPTORS = [
     label: 'Summarize Merged PRs',
     availability: 'stable',
     scheduleModes: DAILY_WEEKLY_SCHEDULE_MODES,
-    manualTriggerRequirements: ['slack', 'github'],
+    // Merged-PR summaries read the provider-neutral taskPullRequests table.
+    manualTriggerRequirements: ['slack', 'repository'],
     usesManagerChannel: true,
     supportedCommunicationProviders: ['slack'],
-    supportedSourceControlProviders: ['github'],
+    supportedSourceControlProviders: sourceControlProviders,
   },
   {
     automationKey: 'manager_stats',


### PR DESCRIPTION
## What

Seventh PR of the "automations everywhere" track — the "all source control" half, honestly sliced.

**The announcer (Summarize Merged PRs) now works with every source-control provider.** Its merged-PR query already read the provider-neutral `taskPullRequests` table — which GitLab/Gitea/ADO/Bitbucket webhooks all populate via `updateTaskPrStatus` — and had no `github` filter. The only GitHub coupling was the eligibility gate. Changes:

- Runner gate: `hasActiveGitHubInstallation()` → `hasAnyActiveRepository()`; skip message updated
- Manual-trigger requirement: `['slack','github']` → `['slack','repository']` (the neutral check that already exists)
- Registry: `supportedSourceControlProviders` → all providers

## Why the other three stay GitHub-only (scope discovery)

The plan assumed all four "de-GitHub-able" automations were gate changes. Exploration says otherwise:

- **security_auditor / code_quality_auditor** read `pullRequestFacts`, which has exactly one writer — the GitHub facts sync. Widening their filter would change nothing: there are zero non-GitHub rows. Real fix = per-provider facts sync (backfill + incremental + webhook upsert), one shared workstream for both auditors.
- **conflict_resolver** enumerates open PRs via the GitHub API. The provider-neutral PR layer supports single-PR reads (including per-provider mergeable/conflict state — except Bitbucket, which exposes none) but has **no list-open-PRs primitive**. Real fix = new enumeration API per provider plus generalizing the launch payload off `GithubPrConflictResolve`.

Both are tracked as future work in the plan; their registry declarations stay `['github']`, which is what the upcoming automations-page capability matrix will render.

## Testing

- Full local runs green: types (529), sdk (458), web (1947), api (906); lint/types/knip pass
- Note: the announcer's Slack-side posting is untouched (its comms generalization is the separate 6b follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)