### PR TITLE
Fix provider-aware environment branch validation

### DIFF
--- a/apps/web/src/trpc/commands/environments/index.test.ts
+++ b/apps/web/src/trpc/commands/environments/index.test.ts
@@ -1,27 +1,37 @@
-const { mockDbSelect, mockEnqueueTask, mockGetRepositories } = vi.hoisted(
-  () => ({
-    mockDbSelect: vi.fn(),
-    mockEnqueueTask: vi.fn().mockResolvedValue({
-      taskId: 'task-env-definition-1',
-      id: 'run-env-definition-1',
-    }),
-    mockGetRepositories: vi.fn().mockResolvedValue([
-      {
-        id: 'repo-1',
-        fullName: 'acme/api',
-        installationId: 'installation-1',
-      },
-      {
-        id: 'repo-2',
-        fullName: 'acme/web',
-        installationId: 'installation-1',
-      },
-    ]),
+const {
+  mockCheckRepoAccess,
+  mockDbSelect,
+  mockEnqueueTask,
+  mockGetBranches,
+  mockGetRepositories,
+} = vi.hoisted(() => ({
+  mockCheckRepoAccess: vi.fn(),
+  mockDbSelect: vi.fn(),
+  mockEnqueueTask: vi.fn().mockResolvedValue({
+    taskId: 'task-env-definition-1',
+    id: 'run-env-definition-1',
   }),
-);
+  mockGetBranches: vi.fn(),
+  mockGetRepositories: vi.fn().mockResolvedValue([
+    {
+      id: 'repo-1',
+      fullName: 'acme/api',
+      installationId: 'installation-1',
+    },
+    {
+      id: 'repo-2',
+      fullName: 'acme/web',
+      installationId: 'installation-1',
+    },
+  ]),
+}));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
   enqueueTask: mockEnqueueTask,
+}));
+
+vi.mock('@roomote/github', () => ({
+  getBranches: mockGetBranches,
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -50,7 +60,7 @@ vi.mock('@roomote/db/server', () => ({
 }));
 
 vi.mock('@/lib/server', () => ({
-  checkRepoAccess: vi.fn(),
+  checkRepoAccess: mockCheckRepoAccess,
   getRepositories: mockGetRepositories,
 }));
 
@@ -60,6 +70,7 @@ import {
   createEnvironmentCommand,
   startEnvironmentDefinitionTaskCommand,
   updateEnvironmentCommand,
+  validateConfigCommand,
 } from './index';
 
 function buildMockAuth(): UserAuthSuccess {
@@ -187,6 +198,74 @@ describe('environment repository validation', () => {
     expect(result).toEqual({
       success: false,
       error: 'Repositories are not linked to this deployment: roomote/Test ADO',
+    });
+  });
+
+  it('does not validate Azure DevOps branches through GitHub', async () => {
+    mockDbSelect.mockReturnValueOnce({
+      from: () => ({
+        where: async () => [
+          {
+            id: 'repo-ado',
+            fullName: 'roomote/Test ADO/Test ADO',
+            installationId: null,
+            sourceControlProvider: 'ado',
+          },
+        ],
+      }),
+    });
+    mockCheckRepoAccess.mockResolvedValue(true);
+
+    const result = await validateConfigCommand(buildMockAuth(), {
+      config: {
+        name: 'ADO Test',
+        repositories: [
+          {
+            repository: 'roomote/Test ADO/Test ADO',
+            branch: 'main',
+          },
+        ],
+      },
+    });
+
+    expect(result).toEqual({ errors: [], warnings: [] });
+    expect(mockGetBranches).not.toHaveBeenCalled();
+  });
+
+  it('continues warning when a GitHub branch is missing', async () => {
+    mockDbSelect.mockReturnValueOnce({
+      from: () => ({
+        where: async () => [
+          {
+            id: 'repo-github',
+            fullName: 'roomote/roomote',
+            installationId: 'installation-1',
+            sourceControlProvider: 'github',
+          },
+        ],
+      }),
+    });
+    mockCheckRepoAccess.mockResolvedValue(true);
+    mockGetBranches.mockResolvedValue(['main']);
+
+    const result = await validateConfigCommand(buildMockAuth(), {
+      config: {
+        name: 'GitHub Test',
+        repositories: [
+          { repository: 'roomote/roomote', branch: 'missing-branch' },
+        ],
+      },
+    });
+
+    expect(result).toEqual({
+      errors: [],
+      warnings: [
+        "Branch 'missing-branch' was not found in 'roomote/roomote'. It may not exist yet.",
+      ],
+    });
+    expect(mockGetBranches).toHaveBeenCalledWith({
+      userId: 'user-1',
+      fullName: 'roomote/roomote',
     });
   });
 });

--- a/apps/web/src/trpc/commands/environments/index.ts
+++ b/apps/web/src/trpc/commands/environments/index.ts
@@ -873,8 +873,8 @@ export async function duplicateEnvironmentCommand(
 
 /**
  * Validates an environment configuration asynchronously against server-side
- * resources. Checks repository accessibility via the GitHub API (hard error)
- * and branch existence (soft warning).
+ * resources. Checks repository accessibility (hard error) and branch existence
+ * for providers with a branch-listing implementation (soft warning).
  */
 export async function validateConfigCommand(
   auth: UserAuthSuccess,
@@ -884,6 +884,10 @@ export async function validateConfigCommand(
 
   const errors: string[] = [];
   const warnings: string[] = [];
+  const repositoryProviders = new Map<
+    string,
+    (typeof repositories.$inferSelect)['sourceControlProvider']
+  >();
   const repositoryNames = [
     ...new Set(input.config.repositories.map((repo) => repo.repository)),
   ];
@@ -894,6 +898,7 @@ export async function validateConfigCommand(
         id: repositories.id,
         fullName: repositories.fullName,
         installationId: repositories.installationId,
+        sourceControlProvider: repositories.sourceControlProvider,
       })
       .from(repositories)
       .where(
@@ -908,6 +913,13 @@ export async function validateConfigCommand(
     if (repositoryConfigError) {
       errors.push(repositoryConfigError);
     }
+
+    for (const repository of dbRepos) {
+      repositoryProviders.set(
+        repository.fullName,
+        repository.sourceControlProvider,
+      );
+    }
   }
 
   await Promise.all(
@@ -921,8 +933,13 @@ export async function validateConfigCommand(
         return; // skip branch check if repo itself is inaccessible
       }
 
-      // If a branch is specified, check it exists
-      if (repo.branch) {
+      // Branch listing is currently implemented only for GitHub. Do not send
+      // repositories from other providers through the GitHub API: its
+      // provider-scoped lookup correctly returns no branches for those rows.
+      if (
+        repo.branch &&
+        repositoryProviders.get(repo.repository) === 'github'
+      ) {
         try {
           const branches = await GitHub.getBranches({
             userId,


### PR DESCRIPTION
## Summary

- use repository provider metadata during environment validation
- skip the GitHub-only branch lookup for Azure DevOps repositories
- retain the existing missing-branch warning for GitHub repositories
- add regression coverage for both provider paths

## Root cause

Environment validation sent every configured repository to `GitHub.getBranches`. That API intentionally scopes its lookup to GitHub repository rows, so a valid Azure DevOps repository returned an empty branch list and produced a false missing-branch warning.

## Impact

Azure DevOps environments no longer show a false branch warning. GitHub branch existence checks and warnings remain unchanged.

## Validation

- focused environment command Vitest suite (5 tests)
- `pnpm --filter @roomote/web check-types`
- `pnpm --filter @roomote/web lint`
- Prettier check for both changed files
- `git diff --check`
