### PR TITLE
Reconcile versioned worker artifacts

### DIFF
--- a/apps/dev/src/services/__tests__/docker.test.ts
+++ b/apps/dev/src/services/__tests__/docker.test.ts
@@ -356,7 +356,10 @@ describe('DockerService.ensureWorkerImage', () => {
     );
 
     expect(dockerfile).toContain(
-      `LABEL ${WORKER_IMAGE_SCHEMA_LABEL}="${WORKER_IMAGE_SCHEMA_VERSION}"`,
+      `ARG ROOMOTE_WORKER_RUNTIME_SCHEMA_VERSION=${WORKER_IMAGE_SCHEMA_VERSION}`,
+    );
+    expect(dockerfile).toContain(
+      `LABEL ${WORKER_IMAGE_SCHEMA_LABEL}="\${ROOMOTE_WORKER_RUNTIME_SCHEMA_VERSION}"`,
     );
   });
 
@@ -382,6 +385,8 @@ describe('DockerService.ensureWorkerImage', () => {
         'build',
         '--platform',
         process.arch === 'arm64' ? 'linux/arm64' : 'linux/amd64',
+        '--build-arg',
+        `ROOMOTE_WORKER_RUNTIME_SCHEMA_VERSION=${WORKER_IMAGE_SCHEMA_VERSION}`,
         '-f',
         'apps/worker/Dockerfile',
         '-t',
@@ -452,6 +457,8 @@ describe('DockerService.ensureWorkerImage', () => {
           'build',
           '--platform',
           process.arch === 'arm64' ? 'linux/arm64' : 'linux/amd64',
+          '--build-arg',
+          `ROOMOTE_WORKER_RUNTIME_SCHEMA_VERSION=${WORKER_IMAGE_SCHEMA_VERSION}`,
           '-f',
           'apps/worker/Dockerfile',
           '-t',
@@ -492,6 +499,8 @@ describe('DockerService.ensureWorkerImage', () => {
         'build',
         '--platform',
         process.arch === 'arm64' ? 'linux/arm64' : 'linux/amd64',
+        '--build-arg',
+        `ROOMOTE_WORKER_RUNTIME_SCHEMA_VERSION=${WORKER_IMAGE_SCHEMA_VERSION}`,
         '-f',
         'apps/worker/Dockerfile',
         '-t',
@@ -526,6 +535,8 @@ describe('DockerService.ensureWorkerImage', () => {
         'build',
         '--platform',
         'linux/arm64',
+        '--build-arg',
+        `ROOMOTE_WORKER_RUNTIME_SCHEMA_VERSION=${WORKER_IMAGE_SCHEMA_VERSION}`,
         '-f',
         'apps/worker/Dockerfile',
         '-t',

--- a/apps/dev/src/services/docker.ts
+++ b/apps/dev/src/services/docker.ts
@@ -3,10 +3,13 @@ import path from 'path';
 import { execa } from 'execa';
 import ora from 'ora';
 import Docker from 'dockerode';
+import { WORKER_RUNTIME_SCHEMA_VERSION } from '@roomote/types';
 
 export const WORKER_IMAGE_SCHEMA_LABEL =
   'dev.roomote.worker-image.schema-version';
-export const WORKER_IMAGE_SCHEMA_VERSION = '1';
+export const WORKER_IMAGE_SCHEMA_VERSION = String(
+  WORKER_RUNTIME_SCHEMA_VERSION,
+);
 
 export class DockerService {
   private static readonly CURRENT_COMPOSE_PROJECT = 'roomote';
@@ -82,6 +85,8 @@ export class DockerService {
           'build',
           '--platform',
           platform,
+          '--build-arg',
+          `ROOMOTE_WORKER_RUNTIME_SCHEMA_VERSION=${WORKER_IMAGE_SCHEMA_VERSION}`,
           '-f',
           'apps/worker/Dockerfile',
           '-t',

--- a/apps/web/src/app/(onboarding)/setup/StepComputeConfig.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepComputeConfig.tsx
@@ -121,6 +121,13 @@ export function StepComputeConfig({
           effectiveSelectedProviderId,
         )
       : null;
+  const selectedProvider = useMemo(
+    () =>
+      computeSetup.providers.find(
+        (provider) => provider.provider === effectiveSelectedProviderId,
+      ),
+    [computeSetup.providers, effectiveSelectedProviderId],
+  );
   const saveComputeConfig = useMutation(
     trpc.setupNew.saveComputeConfig.mutationOptions({
       onSuccess: async (result) => {
@@ -137,7 +144,10 @@ export function StepComputeConfig({
               )
             : null;
 
-        if (resultProvisioning?.status === 'building') {
+        if (
+          resultProvisioning?.status === 'building' &&
+          !selectedProvider?.configSatisfied
+        ) {
           setAwaitingTemplateBuild(true);
           return;
         }
@@ -159,10 +169,13 @@ export function StepComputeConfig({
 
   // Re-attach to an in-flight build (e.g. after a page reload mid-build).
   useEffect(() => {
-    if (templateBuild?.status === 'building') {
+    if (
+      templateBuild?.status === 'building' &&
+      !selectedProvider?.configSatisfied
+    ) {
       setAwaitingTemplateBuild(true);
     }
-  }, [templateBuild?.status]);
+  }, [selectedProvider?.configSatisfied, templateBuild?.status]);
 
   useEffect(() => {
     if (!awaitingTemplateBuild) {
@@ -183,14 +196,6 @@ export function StepComputeConfig({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [awaitingTemplateBuild, templateBuild?.status]);
-
-  const selectedProvider = useMemo(
-    () =>
-      computeSetup.providers.find(
-        (provider) => provider.provider === effectiveSelectedProviderId,
-      ),
-    [computeSetup.providers, effectiveSelectedProviderId],
-  );
 
   const credentialFields =
     selectedProvider?.fields.filter(isComputeCredentialField) ?? [];

--- a/apps/web/src/components/settings/ComputeProviderSection.client.test.tsx
+++ b/apps/web/src/components/settings/ComputeProviderSection.client.test.tsx
@@ -46,6 +46,7 @@ function buildProvisioning(
 ): SetupNewComputeProvisioningState {
   return {
     status: 'building',
+    runtimeSchemaVersion: 1,
     imageRef: 'ghcr.io/roocodeinc/roomote-worker:develop-abc12345',
     templateRef: 'roomote-worker:develop-abc12345',
     error: null,
@@ -55,10 +56,13 @@ function buildProvisioning(
   };
 }
 
-function renderSection(provisioning: SetupNewComputeProvisioningState | null) {
+function renderSection(
+  provisioning: SetupNewComputeProvisioningState | null,
+  providerOverride: ComputeProviderStatus = provider,
+) {
   return render(
     <ComputeProviderSection
-      provider={provider}
+      provider={providerOverride}
       isDefault={false}
       provisioning={provisioning}
       onSave={vi.fn()}
@@ -76,8 +80,19 @@ describe('ComputeProviderSection provisioning states', () => {
     const button = screen.getByRole('button', { name: /Provisioning\.\.\./ });
     expect(button).toBeDisabled();
     expect(
-      screen.getByText(/Provisioning the worker base image/),
+      screen.getByText(/must finish before this provider can run tasks/),
     ).toBeInTheDocument();
+  });
+
+  it('explains that a rebuild is non-blocking when an older artifact is active', () => {
+    renderSection(buildProvisioning({ status: 'building' }), {
+      ...provider,
+      configSatisfied: true,
+    });
+
+    expect(
+      screen.getByText(/Updating the worker base image in the background/),
+    ).toHaveTextContent(/existing tasks keep using the current image/);
   });
 
   it('surfaces the provisioning error and offers a retry after a failed run', () => {

--- a/apps/web/src/components/settings/ComputeProviderSection.tsx
+++ b/apps/web/src/components/settings/ComputeProviderSection.tsx
@@ -199,6 +199,7 @@ export function ComputeProviderSection({
       !field.savedSatisfied,
   );
   const provisioningRunning = provisioning?.status === 'building';
+  const provisioningRefresh = provisioningRunning && provider.configSatisfied;
   const provisioningFailed = provisioning?.status === 'failed';
   // Credentials are already satisfied when a save can still start or retry
   // auto-provisioning without retyping values (existing installs that later
@@ -523,8 +524,9 @@ export function ComputeProviderSection({
 
               {provisioningRunning && (
                 <p className="max-w-xl text-sm text-muted-foreground">
-                  Provisioning the worker base image. This can take a few
-                  minutes.
+                  {provisioningRefresh
+                    ? 'Updating the worker base image in the background. This can take several minutes; existing tasks keep using the current image until the replacement is ready.'
+                    : 'Provisioning the worker base image. This can take several minutes and must finish before this provider can run tasks.'}
                 </p>
               )}
 

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -15,6 +15,21 @@ export async function register() {
       await import('@/lib/server/bootstrap-runtime-env');
 
     await bootstrapWebRuntimeEnv();
+
+    // Non-fatal, detached reconciliation of E2B/Daytona/Blaxel artifacts.
+    // A release image or worker-runtime schema change creates a replacement
+    // artifact and atomically activates it only after the build succeeds.
+    void import('@/trpc/commands/compute/compute-provisioning')
+      .then(({ reconcileComputeProvisioningOnStartup }) =>
+        reconcileComputeProvisioningOnStartup(),
+      )
+      .catch((error) => {
+        console.error(
+          `[instrumentation] Hosted worker artifact reconciliation failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      });
   }
 
   const environment = resolveWebSentryEnvironment();

--- a/apps/web/src/trpc/commands/compute/compute-provisioning.test.ts
+++ b/apps/web/src/trpc/commands/compute/compute-provisioning.test.ts
@@ -7,10 +7,16 @@ const {
   mockDbTransaction,
   mockGetPersistedEnvironmentVariableNames,
   mockGetPersistedEnvironmentVariableValues,
+  mockBuildE2bWorkerTemplate,
+  mockResolveComputeProviderEnvValues,
+  mockUpsertDeploymentEnvironmentVariables,
 } = vi.hoisted(() => ({
   mockDbTransaction: vi.fn(),
   mockGetPersistedEnvironmentVariableNames: vi.fn(),
   mockGetPersistedEnvironmentVariableValues: vi.fn(),
+  mockBuildE2bWorkerTemplate: vi.fn(),
+  mockResolveComputeProviderEnvValues: vi.fn(),
+  mockUpsertDeploymentEnvironmentVariables: vi.fn(),
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -21,12 +27,12 @@ vi.mock('@roomote/db/server', () => ({
     strings,
     values,
   })),
-  resolveComputeProviderEnvValues: vi.fn(),
+  resolveComputeProviderEnvValues: mockResolveComputeProviderEnvValues,
 }));
 
 vi.mock('@roomote/compute-providers', () => ({
   buildBlaxelWorkerImage: vi.fn(),
-  buildE2bWorkerTemplate: vi.fn(),
+  buildE2bWorkerTemplate: mockBuildE2bWorkerTemplate,
   registerDaytonaWorkerSnapshot: vi.fn(),
   deriveBlaxelWorkerImageName: (imageRef: string) =>
     `roomote-worker-${imageRef.slice(imageRef.lastIndexOf(':') + 1)}`,
@@ -41,13 +47,15 @@ vi.mock('../environment-variables', () => ({
     mockGetPersistedEnvironmentVariableNames,
   getPersistedEnvironmentVariableValues:
     mockGetPersistedEnvironmentVariableValues,
-  upsertDeploymentEnvironmentVariables: vi.fn(),
+  upsertDeploymentEnvironmentVariables:
+    mockUpsertDeploymentEnvironmentVariables,
 }));
 
 import {
   persistComputeProvisioning,
   prepareComputeProvisioningStart,
   reconcileComputeProvisioningOnStartup,
+  runComputeProvisioning,
 } from './compute-provisioning';
 
 function createExecutorMock(existingState: Partial<SetupNewState>) {
@@ -516,5 +524,45 @@ describe('reconcileComputeProvisioningOnStartup', () => {
     await reconcileComputeProvisioningOnStartup();
 
     expect(execute).toHaveBeenCalledOnce();
+  });
+});
+
+describe('runComputeProvisioning', () => {
+  it('does not activate an artifact after a newer desired build supersedes it', async () => {
+    mockResolveComputeProviderEnvValues.mockResolvedValue({
+      E2B_API_KEY: 'key',
+    });
+    mockBuildE2bWorkerTemplate.mockResolvedValue({
+      templateRef: 'roomote-worker:old-r1',
+      templateId: 'template-id',
+      buildId: 'build-id',
+      tags: [],
+    });
+    const execute = vi.fn();
+    const { captured, executor } = createExecutorMock({
+      e2bTemplateBuild: {
+        status: 'building',
+        runtimeSchemaVersion: 1,
+        imageRef: 'registry.example.com/worker:new',
+        templateRef: 'roomote-worker:new-r1',
+        error: null,
+        startedAt: new Date().toISOString(),
+        finishedAt: null,
+      },
+    });
+    const tx = executor as unknown as { execute: typeof execute };
+    tx.execute = execute;
+    mockDbTransaction.mockImplementation(async (callback) => callback(tx));
+
+    await runComputeProvisioning({
+      provider: 'e2b',
+      userId: null,
+      imageRef: 'registry.example.com/worker:old',
+      templateRef: 'roomote-worker:old-r1',
+    });
+
+    expect(execute).toHaveBeenCalledOnce();
+    expect(mockUpsertDeploymentEnvironmentVariables).not.toHaveBeenCalled();
+    expect(captured.setupNewState).toBeUndefined();
   });
 });

--- a/apps/web/src/trpc/commands/compute/compute-provisioning.test.ts
+++ b/apps/web/src/trpc/commands/compute/compute-provisioning.test.ts
@@ -3,10 +3,24 @@ import type {
   SetupNewState,
 } from '@roomote/types';
 
+const {
+  mockDbTransaction,
+  mockGetPersistedEnvironmentVariableNames,
+  mockGetPersistedEnvironmentVariableValues,
+} = vi.hoisted(() => ({
+  mockDbTransaction: vi.fn(),
+  mockGetPersistedEnvironmentVariableNames: vi.fn(),
+  mockGetPersistedEnvironmentVariableValues: vi.fn(),
+}));
+
 vi.mock('@roomote/db/server', () => ({
-  db: {},
+  db: { transaction: mockDbTransaction },
   deploymentSettings: { id: 'deployment_settings.id' },
   eq: vi.fn(),
+  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+  })),
   resolveComputeProviderEnvValues: vi.fn(),
 }));
 
@@ -23,12 +37,17 @@ vi.mock('@roomote/compute-providers', () => ({
 }));
 
 vi.mock('../environment-variables', () => ({
+  getPersistedEnvironmentVariableNames:
+    mockGetPersistedEnvironmentVariableNames,
+  getPersistedEnvironmentVariableValues:
+    mockGetPersistedEnvironmentVariableValues,
   upsertDeploymentEnvironmentVariables: vi.fn(),
 }));
 
 import {
   persistComputeProvisioning,
   prepareComputeProvisioningStart,
+  reconcileComputeProvisioningOnStartup,
 } from './compute-provisioning';
 
 function createExecutorMock(existingState: Partial<SetupNewState>) {
@@ -58,6 +77,7 @@ const STALE_STARTED_AT = '2026-07-03T00:00:00.000Z';
 
 const staleBuildingEntry: SetupNewComputeProvisioningState = {
   status: 'building',
+  runtimeSchemaVersion: 1,
   imageRef: 'registry.example.com/worker:old',
   templateRef: 'roomote-worker-old',
   error: null,
@@ -77,6 +97,7 @@ describe('persistComputeProvisioning', () => {
       'daytona',
       {
         status: 'building',
+        runtimeSchemaVersion: 1,
         imageRef: 'registry.example.com/worker:new',
         templateRef: 'roomote-worker-new',
         error: null,
@@ -101,6 +122,7 @@ describe('persistComputeProvisioning', () => {
       'daytona',
       {
         status: 'failed',
+        runtimeSchemaVersion: 1,
         imageRef: 'registry.example.com/worker:old',
         templateRef: null,
         error: 'boom',
@@ -128,6 +150,7 @@ describe('persistComputeProvisioning', () => {
       'e2b',
       {
         status: 'building',
+        runtimeSchemaVersion: 1,
         imageRef: 'registry.example.com/worker:new',
         templateRef: 'roomote-worker:new',
         error: null,
@@ -246,6 +269,7 @@ describe('prepareComputeProvisioningStart', () => {
       },
       existingState: {
         status: 'building',
+        runtimeSchemaVersion: 1,
         imageRef: 'registry.example.com/worker:tag',
         templateRef: 'roomote-worker-tag',
         error: null,
@@ -259,6 +283,143 @@ describe('prepareComputeProvisioningStart', () => {
     expect(result).toEqual({
       fieldPending: true,
       provisionable: true,
+      start: null,
+    });
+    expect(markPending).not.toHaveBeenCalled();
+  });
+
+  it('rebuilds a saved artifact when its worker image is from an older release', async () => {
+    const markPending = vi.fn();
+    const result = await prepareComputeProvisioningStart({
+      provider: 'e2b',
+      providerStatus: {
+        provider: 'e2b',
+        label: 'E2B',
+        description: '',
+        supportsSnapshots: true,
+        comment: 'Recommended',
+        runtimeConfigSatisfied: false,
+        savedConfigSatisfied: true,
+        configSatisfied: true,
+        infrastructureSatisfied: true,
+        fields: [
+          {
+            envVarName: 'E2B_TEMPLATE_ID',
+            label: 'Worker Template ID',
+            category: 'infrastructure',
+            advanced: true,
+            runtimeSatisfied: false,
+            savedSatisfied: true,
+            defaultSatisfied: false,
+            setupProvisionable: true,
+          },
+        ],
+      },
+      existingState: {
+        status: 'succeeded',
+        runtimeSchemaVersion: 1,
+        imageRef: 'registry.example.com/worker:old',
+        templateRef: 'roomote-worker:old',
+        error: null,
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date().toISOString(),
+      },
+      dockerWorkerImage: 'registry.example.com/worker:new',
+      markPending,
+    });
+
+    expect(result.start).toMatchObject({
+      provider: 'e2b',
+      imageRef: 'registry.example.com/worker:new',
+    });
+    expect(markPending).toHaveBeenCalledOnce();
+  });
+
+  it('rebuilds a saved artifact when the runtime schema metadata is missing', async () => {
+    const markPending = vi.fn();
+    const result = await prepareComputeProvisioningStart({
+      provider: 'e2b',
+      providerStatus: {
+        provider: 'e2b',
+        label: 'E2B',
+        description: '',
+        supportsSnapshots: true,
+        comment: 'Recommended',
+        runtimeConfigSatisfied: false,
+        savedConfigSatisfied: true,
+        configSatisfied: true,
+        infrastructureSatisfied: true,
+        fields: [
+          {
+            envVarName: 'E2B_TEMPLATE_ID',
+            label: 'Worker Template ID',
+            category: 'infrastructure',
+            advanced: true,
+            runtimeSatisfied: false,
+            savedSatisfied: true,
+            defaultSatisfied: false,
+            setupProvisionable: true,
+          },
+        ],
+      },
+      existingState: {
+        status: 'succeeded',
+        imageRef: 'registry.example.com/worker:tag',
+        templateRef: 'roomote-worker:tag',
+        error: null,
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date().toISOString(),
+      } as SetupNewComputeProvisioningState,
+      dockerWorkerImage: 'registry.example.com/worker:tag',
+      markPending,
+    });
+
+    expect(result.start).not.toBeNull();
+  });
+
+  it('keeps a saved artifact when image and runtime schema are current', async () => {
+    const markPending = vi.fn();
+    const result = await prepareComputeProvisioningStart({
+      provider: 'e2b',
+      providerStatus: {
+        provider: 'e2b',
+        label: 'E2B',
+        description: '',
+        supportsSnapshots: true,
+        comment: 'Recommended',
+        runtimeConfigSatisfied: false,
+        savedConfigSatisfied: true,
+        configSatisfied: true,
+        infrastructureSatisfied: true,
+        fields: [
+          {
+            envVarName: 'E2B_TEMPLATE_ID',
+            label: 'Worker Template ID',
+            category: 'infrastructure',
+            advanced: true,
+            runtimeSatisfied: false,
+            savedSatisfied: true,
+            defaultSatisfied: false,
+            setupProvisionable: true,
+          },
+        ],
+      },
+      existingState: {
+        status: 'succeeded',
+        runtimeSchemaVersion: 1,
+        imageRef: 'registry.example.com/worker:tag',
+        templateRef: 'roomote-worker:tag',
+        error: null,
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date().toISOString(),
+      },
+      dockerWorkerImage: 'registry.example.com/worker:tag',
+      markPending,
+    });
+
+    expect(result).toEqual({
+      fieldPending: false,
+      provisionable: false,
       start: null,
     });
     expect(markPending).not.toHaveBeenCalled();
@@ -323,5 +484,37 @@ describe('prepareComputeProvisioningStart', () => {
         templateRef: 'roomote-worker:latest',
       }),
     );
+  });
+});
+
+describe('reconcileComputeProvisioningOnStartup', () => {
+  it('takes a deployment-wide claim and skips an already-current artifact', async () => {
+    vi.stubEnv('DOCKER_WORKER_IMAGE', 'registry.example.com/worker:tag');
+    mockGetPersistedEnvironmentVariableNames.mockResolvedValue([
+      'E2B_API_KEY',
+      'E2B_TEMPLATE_ID',
+    ]);
+    mockGetPersistedEnvironmentVariableValues.mockResolvedValue({
+      E2B_TEMPLATE_ID: 'roomote-worker:tag',
+    });
+    const execute = vi.fn();
+    const { executor } = createExecutorMock({
+      e2bTemplateBuild: {
+        status: 'succeeded',
+        runtimeSchemaVersion: 1,
+        imageRef: 'registry.example.com/worker:tag',
+        templateRef: 'roomote-worker:tag',
+        error: null,
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date().toISOString(),
+      },
+    });
+    const tx = executor as unknown as { execute: typeof execute };
+    tx.execute = execute;
+    mockDbTransaction.mockImplementation(async (callback) => callback(tx));
+
+    await reconcileComputeProvisioningOnStartup();
+
+    expect(execute).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/src/trpc/commands/compute/compute-provisioning.ts
+++ b/apps/web/src/trpc/commands/compute/compute-provisioning.ts
@@ -2,6 +2,7 @@ import {
   db,
   deploymentSettings,
   eq,
+  sql,
   resolveComputeProviderEnvValues,
   type DatabaseOrTransaction,
 } from '@roomote/db/server';
@@ -15,16 +16,23 @@ import {
 } from '@roomote/compute-providers';
 import {
   isSetupNewComputeProvisioningStale,
+  buildSetupComputeStatus,
+  NON_SECRET_COMPUTE_ENV_VAR_NAMES,
   normalizeSetupNewState,
   resolveDerivedModalBaseImageRef,
   SETUP_COMPUTE_PROVISIONING_STALE_MS,
   SETUP_COMPUTE_PROVISIONING_STATE_FIELDS,
+  WORKER_RUNTIME_SCHEMA_VERSION,
   type SetupComputeProviderStatus,
   type SetupNewComputeProvisioningState,
   type SetupProvisionableComputeProvider,
 } from '@roomote/types';
 
-import { upsertDeploymentEnvironmentVariables } from '../environment-variables';
+import {
+  getPersistedEnvironmentVariableNames,
+  getPersistedEnvironmentVariableValues,
+  upsertDeploymentEnvironmentVariables,
+} from '../environment-variables';
 
 /**
  * Shared worker base-image provisioning used by both the setup wizard and
@@ -210,12 +218,11 @@ function planComputeProvisioning({
     (field) => field.envVarName === config.envVarName,
   );
 
-  const artifactPending =
-    !!artifactField &&
-    !artifactField.runtimeSatisfied &&
-    !artifactField.savedSatisfied;
-
-  if (!artifactPending) {
+  // A process-env artifact is operator-managed and always wins. Saved
+  // artifacts are Roomote-managed, so they are current only when the
+  // persisted successful build matches both the desired worker image and the
+  // runtime schema. Missing version metadata intentionally forces one rebuild.
+  if (!artifactField || artifactField.runtimeSatisfied) {
     return { artifactPending: false, provisionable: false, runToStart: null };
   }
 
@@ -227,15 +234,33 @@ function planComputeProvisioning({
   });
 
   if (!workerImageRef) {
-    return { artifactPending: true, provisionable: false, runToStart: null };
+    return {
+      artifactPending: !artifactField.savedSatisfied,
+      provisionable: false,
+      runToStart: null,
+    };
+  }
+
+  const managedArtifactCurrent =
+    artifactField.savedSatisfied &&
+    existingState?.status === 'succeeded' &&
+    existingState.imageRef === workerImageRef &&
+    existingState.runtimeSchemaVersion === WORKER_RUNTIME_SCHEMA_VERSION;
+
+  if (managedArtifactCurrent) {
+    return { artifactPending: false, provisionable: false, runToStart: null };
   }
 
   const runInFlight =
     existingState?.status === 'building' &&
+    existingState.imageRef === workerImageRef &&
+    existingState.runtimeSchemaVersion === WORKER_RUNTIME_SCHEMA_VERSION &&
     !isSetupNewComputeProvisioningStale(existingState);
 
   return {
-    artifactPending: true,
+    // A saved artifact remains usable while its replacement builds. Only
+    // first-time provisioning blocks setup/task readiness.
+    artifactPending: !artifactField.savedSatisfied,
     provisionable: true,
     runToStart: runInFlight
       ? null
@@ -255,6 +280,7 @@ export function createPendingComputeProvisioning({
 }): SetupNewComputeProvisioningState {
   return {
     status: 'building',
+    runtimeSchemaVersion: WORKER_RUNTIME_SCHEMA_VERSION,
     imageRef,
     templateRef,
     error: null,
@@ -380,7 +406,7 @@ export async function runComputeProvisioning({
   templateRef,
 }: {
   provider: SetupProvisionableComputeProvider;
-  userId: string;
+  userId: string | null;
   imageRef: string;
   templateRef: string;
 }): Promise<void> {
@@ -423,6 +449,7 @@ export async function runComputeProvisioning({
         provider,
         {
           status: 'succeeded',
+          runtimeSchemaVersion: WORKER_RUNTIME_SCHEMA_VERSION,
           imageRef,
           templateRef: artifactRef,
           error: null,
@@ -453,6 +480,7 @@ export async function runComputeProvisioning({
 
     await persistComputeProvisioning(provider, {
       status: 'failed',
+      runtimeSchemaVersion: WORKER_RUNTIME_SCHEMA_VERSION,
       imageRef,
       templateRef: null,
       error: message,
@@ -469,5 +497,81 @@ export async function runComputeProvisioning({
     });
   } finally {
     activeProvisioningClaims.delete(claimKey);
+  }
+}
+
+/**
+ * Reconciles Roomote-managed hosted artifacts at web-process startup. The
+ * build itself remains detached: startup only records an idempotent pending
+ * claim, and the old active artifact stays configured until the replacement
+ * succeeds. Task creation therefore continues to use the last known-good
+ * artifact during a rollout.
+ */
+export async function reconcileComputeProvisioningOnStartup(): Promise<void> {
+  const [persistedEnvVarNames, persistedEnvVarValues] = await Promise.all([
+    getPersistedEnvironmentVariableNames(),
+    getPersistedEnvironmentVariableValues([
+      ...NON_SECRET_COMPUTE_ENV_VAR_NAMES,
+    ]),
+  ]);
+  const status = buildSetupComputeStatus({
+    runtimeEnv: process.env,
+    persistedEnvVarNames,
+    persistedEnvVarValues,
+  });
+
+  for (const provider of Object.keys(
+    PROVISIONING_PROVIDERS,
+  ) as SetupProvisionableComputeProvider[]) {
+    try {
+      const providerStatus = status.providers.find(
+        (candidate) => candidate.provider === provider,
+      );
+
+      if (!providerStatus) continue;
+
+      const credentialsAvailable = providerStatus.fields
+        .filter(
+          (field) =>
+            field.category === 'credential' && field.required !== false,
+        )
+        .every((field) => field.runtimeSatisfied || field.savedSatisfied);
+
+      if (!credentialsAvailable) continue;
+
+      const start = await db.transaction(async (tx) => {
+        // Multiple web replicas can start on the same release. Serialize the
+        // read/claim transition so only one process records and launches the
+        // deterministic provider build.
+        await tx.execute(
+          sql`SELECT pg_advisory_xact_lock(hashtext(${`compute-provisioning:${provider}`}))`,
+        );
+        const existingState = await getPersistedComputeProvisioning(
+          provider,
+          tx,
+        );
+        const prepared = await prepareComputeProvisioningStart({
+          provider,
+          providerStatus,
+          existingState,
+          dockerWorkerImage: process.env.DOCKER_WORKER_IMAGE,
+          runtimeEnv: process.env,
+          markPending: (nextState) =>
+            persistComputeProvisioning(provider, nextState, tx),
+        });
+
+        return prepared.start;
+      });
+
+      if (start) {
+        void runComputeProvisioning({ userId: null, ...start });
+      }
+    } catch (error) {
+      console.error(
+        `[reconcileComputeProvisioningOnStartup] Failed to reconcile ${provider}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
   }
 }

--- a/apps/web/src/trpc/commands/compute/compute-provisioning.ts
+++ b/apps/web/src/trpc/commands/compute/compute-provisioning.ts
@@ -154,6 +154,28 @@ export async function getPersistedComputeProvisioning(
   return state[SETUP_COMPUTE_PROVISIONING_STATE_FIELDS[provider]];
 }
 
+/** Serializes desired-state transitions and terminal result publication. */
+export async function acquireComputeProvisioningLock(
+  provider: SetupProvisionableComputeProvider,
+  executor: DatabaseOrTransaction,
+): Promise<void> {
+  await executor.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtext(${`compute-provisioning:${provider}`}))`,
+  );
+}
+
+function isCurrentComputeProvisioningAttempt(
+  current: SetupNewComputeProvisioningState | null,
+  expected: { imageRef: string; templateRef: string },
+): boolean {
+  return (
+    current?.status === 'building' &&
+    current.runtimeSchemaVersion === WORKER_RUNTIME_SCHEMA_VERSION &&
+    current.imageRef === expected.imageRef &&
+    current.templateRef === expected.templateRef
+  );
+}
+
 export async function persistComputeProvisioning(
   provider: SetupProvisionableComputeProvider,
   provisioning: SetupNewComputeProvisioningState,
@@ -411,7 +433,10 @@ export async function runComputeProvisioning({
   templateRef: string;
 }): Promise<void> {
   const config = PROVISIONING_PROVIDERS[provider];
-  const claimKey = `${provider}:${templateRef}`;
+  // The image ref is part of the desired build identity. Two registries can
+  // use the same tag/template name, and a newer desired image must not be
+  // suppressed by an older in-process build with that name.
+  const claimKey = `${provider}:${imageRef}:${templateRef}`;
 
   if (activeProvisioningClaims.has(claimKey)) {
     console.warn(
@@ -439,7 +464,19 @@ export async function runComputeProvisioning({
       templateRef,
     );
 
-    await db.transaction(async (tx) => {
+    const activated = await db.transaction(async (tx) => {
+      await acquireComputeProvisioningLock(provider, tx);
+      const current = await getPersistedComputeProvisioning(provider, tx);
+
+      if (
+        !isCurrentComputeProvisioningAttempt(current, {
+          imageRef,
+          templateRef,
+        })
+      ) {
+        return false;
+      }
+
       await upsertDeploymentEnvironmentVariables(tx, {
         userId,
         values: [{ name: config.envVarName, value: artifactRef }],
@@ -458,7 +495,18 @@ export async function runComputeProvisioning({
         },
         tx,
       );
+
+      return true;
     });
+
+    if (!activated) {
+      console.warn(
+        `[runComputeProvisioning] Ignoring superseded successful build ${JSON.stringify(
+          { provider, imageRef, templateRef, artifactRef },
+        )}`,
+      );
+      return;
+    }
 
     console.log(
       `[runComputeProvisioning] Provisioning succeeded ${JSON.stringify({
@@ -478,23 +526,48 @@ export async function runComputeProvisioning({
       })}`,
     );
 
-    await persistComputeProvisioning(provider, {
-      status: 'failed',
-      runtimeSchemaVersion: WORKER_RUNTIME_SCHEMA_VERSION,
-      imageRef,
-      templateRef: null,
-      error: message,
-      startedAt: new Date().toISOString(),
-      finishedAt: new Date().toISOString(),
-    }).catch((persistError) => {
-      console.error(
-        `[runComputeProvisioning] Failed to persist provisioning failure: ${
-          persistError instanceof Error
-            ? persistError.message
-            : String(persistError)
-        }`,
-      );
-    });
+    await db
+      .transaction(async (tx) => {
+        await acquireComputeProvisioningLock(provider, tx);
+        const current = await getPersistedComputeProvisioning(provider, tx);
+
+        if (
+          !isCurrentComputeProvisioningAttempt(current, {
+            imageRef,
+            templateRef,
+          })
+        ) {
+          console.warn(
+            `[runComputeProvisioning] Ignoring superseded failed build ${JSON.stringify(
+              { provider, imageRef, templateRef },
+            )}`,
+          );
+          return;
+        }
+
+        await persistComputeProvisioning(
+          provider,
+          {
+            status: 'failed',
+            runtimeSchemaVersion: WORKER_RUNTIME_SCHEMA_VERSION,
+            imageRef,
+            templateRef: null,
+            error: message,
+            startedAt: new Date().toISOString(),
+            finishedAt: new Date().toISOString(),
+          },
+          tx,
+        );
+      })
+      .catch((persistError) => {
+        console.error(
+          `[runComputeProvisioning] Failed to persist provisioning failure: ${
+            persistError instanceof Error
+              ? persistError.message
+              : String(persistError)
+          }`,
+        );
+      });
   } finally {
     activeProvisioningClaims.delete(claimKey);
   }
@@ -543,9 +616,7 @@ export async function reconcileComputeProvisioningOnStartup(): Promise<void> {
         // Multiple web replicas can start on the same release. Serialize the
         // read/claim transition so only one process records and launches the
         // deterministic provider build.
-        await tx.execute(
-          sql`SELECT pg_advisory_xact_lock(hashtext(${`compute-provisioning:${provider}`}))`,
-        );
+        await acquireComputeProvisioningLock(provider, tx);
         const existingState = await getPersistedComputeProvisioning(
           provider,
           tx,

--- a/apps/web/src/trpc/commands/compute/index.test.ts
+++ b/apps/web/src/trpc/commands/compute/index.test.ts
@@ -12,6 +12,7 @@ const {
   mockGetPersistedEnvironmentVariableValues,
   mockResolveSavedWorkerImage,
   mockRunComputeProvisioning,
+  mockAcquireComputeProvisioningLock,
 } = vi.hoisted(() => ({
   mockDbSelect: vi.fn(),
   mockDbInsert: vi.fn(),
@@ -24,6 +25,7 @@ const {
   mockGetPersistedEnvironmentVariableValues: vi.fn().mockResolvedValue({}),
   mockResolveSavedWorkerImage: vi.fn().mockResolvedValue(null),
   mockRunComputeProvisioning: vi.fn().mockResolvedValue(undefined),
+  mockAcquireComputeProvisioningLock: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('./compute-provisioning', async (importOriginal) => {
@@ -32,6 +34,7 @@ vi.mock('./compute-provisioning', async (importOriginal) => {
 
   return {
     ...actual,
+    acquireComputeProvisioningLock: mockAcquireComputeProvisioningLock,
     runComputeProvisioning: mockRunComputeProvisioning,
   };
 });

--- a/apps/web/src/trpc/commands/compute/index.test.ts
+++ b/apps/web/src/trpc/commands/compute/index.test.ts
@@ -424,7 +424,7 @@ describe('compute commands', () => {
         provider: 'e2b',
         userId: 'compute-test-user',
         imageRef: 'registry.example.com/worker:tag',
-        templateRef: 'roomote-worker:tag',
+        templateRef: 'roomote-worker:tag-r1',
       });
     });
 
@@ -444,7 +444,7 @@ describe('compute commands', () => {
         provider: 'daytona',
         userId: 'compute-test-user',
         imageRef: 'registry.example.com/worker:tag',
-        templateRef: 'roomote-worker-tag',
+        templateRef: 'roomote-worker-tag-r1',
       });
     });
 
@@ -461,7 +461,7 @@ describe('compute commands', () => {
         provider: 'e2b',
         userId: 'compute-test-user',
         imageRef: 'registry.example.com/worker:tag',
-        templateRef: 'roomote-worker:tag',
+        templateRef: 'roomote-worker:tag-r1',
       });
     });
 

--- a/apps/web/src/trpc/commands/compute/index.ts
+++ b/apps/web/src/trpc/commands/compute/index.ts
@@ -40,6 +40,7 @@ import {
   upsertDeploymentEnvironmentVariables,
 } from '../environment-variables';
 import {
+  acquireComputeProvisioningLock,
   getPersistedComputeProvisioning,
   persistComputeProvisioning,
   prepareComputeProvisioningStart,
@@ -328,6 +329,7 @@ export async function saveComputeConfigCommand(
         );
 
       if (credentialsAvailable) {
+        await acquireComputeProvisioningLock(provisionableProvider, tx);
         const existingState = await getPersistedComputeProvisioning(
           provisionableProvider,
           tx,

--- a/apps/web/src/trpc/commands/setup-new/index.test.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.test.ts
@@ -831,12 +831,12 @@ describe('setup-new compute config commands', () => {
       provider: 'e2b',
       userId: 'setup-test-user',
       imageRef: 'registry.example.com/worker:tag',
-      templateRef: 'roomote-worker:tag',
+      templateRef: 'roomote-worker:tag-r1',
     });
     expect(result.setupNewState.e2bTemplateBuild).toMatchObject({
       status: 'building',
       imageRef: 'registry.example.com/worker:tag',
-      templateRef: 'roomote-worker:tag',
+      templateRef: 'roomote-worker:tag-r1',
     });
   });
 
@@ -860,8 +860,9 @@ describe('setup-new compute config commands', () => {
               setupNewState: {
                 e2bTemplateBuild: {
                   status: 'building',
+                  runtimeSchemaVersion: 1,
                   imageRef: 'registry.example.com/worker:tag',
-                  templateRef: 'roomote-worker:tag',
+                  templateRef: 'roomote-worker:tag-r1',
                   error: null,
                   startedAt: new Date().toISOString(),
                   finishedAt: null,
@@ -887,7 +888,7 @@ describe('setup-new compute config commands', () => {
     expect(mockRunComputeProvisioning).not.toHaveBeenCalled();
     expect(result.setupNewState.e2bTemplateBuild).toMatchObject({
       status: 'building',
-      templateRef: 'roomote-worker:tag',
+      templateRef: 'roomote-worker:tag-r1',
     });
   });
 

--- a/apps/web/src/trpc/commands/setup-new/index.test.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.test.ts
@@ -11,6 +11,7 @@ const {
   mockGetSetupBootstrapState,
   mockSetupTokenState,
   mockRunComputeProvisioning,
+  mockAcquireComputeProvisioningLock,
   mockResolveSavedWorkerImage,
   mockResolveGiteaBaseUrl,
   mockValidateGiteaToken,
@@ -26,6 +27,7 @@ const {
     inviteCookieToken: null as string | null,
   },
   mockRunComputeProvisioning: vi.fn().mockResolvedValue(undefined),
+  mockAcquireComputeProvisioningLock: vi.fn().mockResolvedValue(undefined),
   mockResolveSavedWorkerImage: vi.fn().mockResolvedValue(null),
   mockResolveGiteaBaseUrl: vi
     .fn()
@@ -39,6 +41,7 @@ vi.mock('../compute/compute-provisioning', async (importOriginal) => {
 
   return {
     ...actual,
+    acquireComputeProvisioningLock: mockAcquireComputeProvisioningLock,
     runComputeProvisioning: mockRunComputeProvisioning,
   };
 });

--- a/apps/web/src/trpc/commands/setup-new/index.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.ts
@@ -126,6 +126,7 @@ import {
   savePersistedRuntimeComputeConfig,
 } from '../compute';
 import {
+  acquireComputeProvisioningLock,
   createPendingComputeProvisioning,
   prepareComputeProvisioningStart,
   runComputeProvisioning,
@@ -1539,6 +1540,10 @@ export async function saveSetupNewComputeConfigCommand(
         imageRef: string;
         templateRef: string;
       } | null = null;
+
+      if (isSetupProvisionableComputeProvider(input.provider)) {
+        await acquireComputeProvisioningLock(input.provider, tx);
+      }
 
       await purgeSavedDeploymentWorkerImage(tx);
 

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -252,8 +252,9 @@ RUN sudo apt-get update \
   && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iproute2 \
   && sudo rm -rf /var/lib/apt/lists/*
 
-# Bump when local worker prerequisites change so dev startup rebuilds stale
-# cached images before launching tasks.
-LABEL dev.roomote.worker-image.schema-version="1"
+# Shared with WORKER_RUNTIME_SCHEMA_VERSION in @roomote/types. Local builds
+# pass this explicitly; the default keeps direct/release Docker builds labeled.
+ARG ROOMOTE_WORKER_RUNTIME_SCHEMA_VERSION=1
+LABEL dev.roomote.worker-image.schema-version="${ROOMOTE_WORKER_RUNTIME_SCHEMA_VERSION}"
 
 WORKDIR /sandbox

--- a/packages/compute-providers/src/blaxel/build-blaxel-image.test.ts
+++ b/packages/compute-providers/src/blaxel/build-blaxel-image.test.ts
@@ -33,7 +33,7 @@ describe('Blaxel worker image provisioning', () => {
 
   it('derives a deterministic resource name from the Blaxel image hash', () => {
     expect(deriveBlaxelWorkerImageName('ghcr.io/roomote/worker:v1')).toBe(
-      'roomote-worker-abc123',
+      'roomote-worker-abc123-r1',
     );
   });
 
@@ -49,7 +49,7 @@ describe('Blaxel worker image provisioning', () => {
         imageRef: 'ghcr.io/roomote/worker:v1',
       }),
     ).resolves.toEqual({
-      imageName: 'roomote-worker-abc123',
+      imageName: 'roomote-worker-abc123-r1',
       imageRef: 'sandbox/roomote-worker:version',
     });
 
@@ -58,8 +58,8 @@ describe('Blaxel worker image provisioning', () => {
       workspace: 'workspace',
     });
     expect(mockBuild).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'roomote-worker-abc123' }),
+      expect.objectContaining({ name: 'roomote-worker-abc123-r1' }),
     );
-    expect(mockDelete).toHaveBeenCalledWith('roomote-worker-abc123');
+    expect(mockDelete).toHaveBeenCalledWith('roomote-worker-abc123-r1');
   });
 });

--- a/packages/compute-providers/src/blaxel/build-blaxel-image.ts
+++ b/packages/compute-providers/src/blaxel/build-blaxel-image.ts
@@ -1,4 +1,5 @@
 import { ImageInstance, SandboxInstance, settings } from '@blaxel/core';
+import { WORKER_RUNTIME_SCHEMA_TAG } from '@roomote/types';
 
 export const BLAXEL_WORKER_IMAGE_NAME_PREFIX = 'roomote-worker';
 
@@ -36,7 +37,7 @@ export function deriveBlaxelWorkerImageName(imageRef: string): string {
   }
 
   const image = createBlaxelWorkerImage(imageRef);
-  return `${BLAXEL_WORKER_IMAGE_NAME_PREFIX}-${image.hash}`;
+  return `${BLAXEL_WORKER_IMAGE_NAME_PREFIX}-${image.hash}-${WORKER_RUNTIME_SCHEMA_TAG}`;
 }
 
 /**

--- a/packages/compute-providers/src/daytona/register-daytona-snapshot.ts
+++ b/packages/compute-providers/src/daytona/register-daytona-snapshot.ts
@@ -1,4 +1,5 @@
 import { Daytona } from '@daytonaio/sdk';
+import { WORKER_RUNTIME_SCHEMA_TAG } from '@roomote/types';
 
 /**
  * Default name prefix for the Roomote worker base snapshot. The suffix is
@@ -14,7 +15,7 @@ export function deriveDaytonaWorkerSnapshotName(imageRef: string): string {
 
   const sanitizedTag = imageTag.toLowerCase().replace(/[^a-z0-9._-]/g, '-');
 
-  return `${DAYTONA_WORKER_SNAPSHOT_NAME_PREFIX}-${sanitizedTag}`;
+  return `${DAYTONA_WORKER_SNAPSHOT_NAME_PREFIX}-${sanitizedTag}-${WORKER_RUNTIME_SCHEMA_TAG}`;
 }
 
 export interface RegisterDaytonaWorkerSnapshotOptions {
@@ -30,7 +31,7 @@ export interface RegisterDaytonaWorkerSnapshotOptions {
    * registration has no per-call registry credentials.
    */
   imageRef: string;
-  /** Overrides the derived `roomote-worker-<image-tag>` snapshot name. */
+  /** Overrides `roomote-worker-<image-tag>-r<schema>`. */
   snapshotName?: string;
   onLog?: (chunk: string) => void;
 }

--- a/packages/compute-providers/src/e2b/build-e2b-template.ts
+++ b/packages/compute-providers/src/e2b/build-e2b-template.ts
@@ -1,4 +1,5 @@
 import { Template, type LogEntry } from 'e2b';
+import { WORKER_RUNTIME_SCHEMA_TAG } from '@roomote/types';
 
 /**
  * Default template name for the Roomote worker base template. The tag is
@@ -25,7 +26,7 @@ export interface BuildE2bWorkerTemplateOptions {
    * Docker tags are rejected up front.
    */
   imageRef: string;
-  /** Overrides the derived `roomote-worker:<image-tag>` template reference. */
+  /** Overrides the derived `roomote-worker:<image-tag>-r<schema>` reference. */
   templateRef?: string;
   cpuCount?: number;
   memoryMB?: number;
@@ -48,7 +49,7 @@ export function deriveE2bWorkerTemplateRef(imageRef: string): string {
     ? imageRef.slice(imageRef.lastIndexOf(':') + 1)
     : 'latest';
 
-  return `${E2B_WORKER_TEMPLATE_NAME}:${imageTag}`;
+  return `${E2B_WORKER_TEMPLATE_NAME}:${imageTag}-${WORKER_RUNTIME_SCHEMA_TAG}`;
 }
 
 /**

--- a/packages/compute-providers/src/worker-artifact-version.test.ts
+++ b/packages/compute-providers/src/worker-artifact-version.test.ts
@@ -1,0 +1,16 @@
+import { deriveDaytonaWorkerSnapshotName } from './daytona';
+import { deriveE2bWorkerTemplateRef } from './e2b';
+
+describe('hosted worker artifact versioning', () => {
+  it('includes the runtime schema in E2B template refs', () => {
+    expect(deriveE2bWorkerTemplateRef('ghcr.io/roomote/worker:v1.2.3')).toBe(
+      'roomote-worker:v1.2.3-r1',
+    );
+  });
+
+  it('includes the runtime schema in Daytona snapshot names', () => {
+    expect(
+      deriveDaytonaWorkerSnapshotName('ghcr.io/roomote/worker:v1.2.3'),
+    ).toBe('roomote-worker-v1.2.3-r1');
+  });
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -62,3 +62,4 @@ export * from './task-messages';
 export * from './timeout-observability';
 export * from './user-display-name';
 export * from './user-role';
+export * from './worker-runtime-version';

--- a/packages/types/src/setup-new.ts
+++ b/packages/types/src/setup-new.ts
@@ -17,6 +17,8 @@ import type { SourceControlProvider } from './source-control';
  */
 export type SetupNewComputeProvisioningState = {
   status: 'building' | 'succeeded' | 'failed';
+  /** Worker runtime contract used to build this provider artifact. */
+  runtimeSchemaVersion: number;
   imageRef: string;
   /** Provider-side artifact reference (template, snapshot, or image ref). */
   templateRef: string | null;

--- a/packages/types/src/worker-runtime-version.ts
+++ b/packages/types/src/worker-runtime-version.ts
@@ -1,0 +1,9 @@
+/**
+ * Compatibility version for the tools and operating-system capabilities baked
+ * into Roomote worker images. Bump this when an existing image tag or hosted
+ * provider artifact must be rebuilt because the runtime contract changed.
+ */
+export const WORKER_RUNTIME_SCHEMA_VERSION = 1;
+
+/** Stable string used in Docker labels and provider-side resource names. */
+export const WORKER_RUNTIME_SCHEMA_TAG = `r${WORKER_RUNTIME_SCHEMA_VERSION}`;


### PR DESCRIPTION
## What changed

- define one worker runtime schema version shared by local Docker and hosted provider artifacts
- rebuild stale local worker images when their schema or Docker/Compose capabilities are outdated
- version E2B templates, Daytona snapshots, and Blaxel images by worker release and runtime schema
- reconcile managed hosted artifacts during web startup with a PostgreSQL advisory claim
- keep the previous hosted artifact active until its replacement succeeds
- distinguish blocking first-time provisioning from non-blocking background refreshes in setup and Settings copy

## Why

Worker images were reused based on existence and incomplete capability checks. A cached image or previously provisioned hosted artifact could therefore survive a runtime prerequisite change and launch tasks without required tools such as Docker Compose.

## Impact

Existing hosted installations refresh artifacts in the background and continue using the last known-good artifact during the build. First-time provider provisioning still blocks until an artifact exists. Local development startup rebuilds a stale image before launching workers.

## Validation

- full `@roomote/types` test suite: 539 tests
- full `@roomote/compute-providers` test suite: 143 tests
- full `@roomote/dev` test suite: 76 tests
- full `@roomote/web` test suite: 1,956 tests
- package lint and TypeScript checks
- focused hosted reconciliation, setup-state, Settings copy, and local Docker invalidation tests