### PR TITLE
Use the develop worker image automatically in local development

### DIFF
--- a/apps/web/src/trpc/commands/compute/compute-provisioning.test.ts
+++ b/apps/web/src/trpc/commands/compute/compute-provisioning.test.ts
@@ -482,14 +482,14 @@ describe('prepareComputeProvisioningStart', () => {
       provisionable: true,
       start: {
         provider: 'e2b',
-        imageRef: 'ghcr.io/roocodeinc/roomote-worker:latest',
-        templateRef: 'roomote-worker:latest',
+        imageRef: 'ghcr.io/roocodeinc/roomote-worker:develop',
+        templateRef: 'roomote-worker:develop',
       },
     });
     expect(markPending).toHaveBeenCalledWith(
       expect.objectContaining({
-        imageRef: 'ghcr.io/roocodeinc/roomote-worker:latest',
-        templateRef: 'roomote-worker:latest',
+        imageRef: 'ghcr.io/roocodeinc/roomote-worker:develop',
+        templateRef: 'roomote-worker:develop',
       }),
     );
   });

--- a/packages/compute-providers/src/__tests__/factory.test.ts
+++ b/packages/compute-providers/src/__tests__/factory.test.ts
@@ -183,7 +183,7 @@ describe('createComputeProviderClient', () => {
 
       expect(modalClientMock).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          baseImageRef: 'ghcr.io/roocodeinc/roomote-worker:latest',
+          baseImageRef: 'ghcr.io/roocodeinc/roomote-worker:develop',
         }),
       );
 

--- a/packages/db/src/lib/__tests__/compute-runtime-config.test.ts
+++ b/packages/db/src/lib/__tests__/compute-runtime-config.test.ts
@@ -136,7 +136,7 @@ describe('resolveComputeProviderEnvValues', () => {
     });
 
     expect(values.MODAL_BASE_IMAGE_REF).toBe(
-      'ghcr.io/roocodeinc/roomote-worker:latest',
+      'ghcr.io/roocodeinc/roomote-worker:develop',
     );
   });
 

--- a/packages/types/src/setup-compute-config.test.ts
+++ b/packages/types/src/setup-compute-config.test.ts
@@ -793,7 +793,7 @@ describe('resolveDerivedModalBaseImageRef', () => {
 
   it('falls back to the development Modal image when no hosted image is configured', () => {
     expect(resolveDerivedModalBaseImageRef({ NODE_ENV: 'development' })).toBe(
-      DEVELOPMENT_MODAL_BASE_IMAGE_REF,
+      'ghcr.io/roocodeinc/roomote-worker:develop',
     );
     expect(
       resolveDerivedModalBaseImageRef({

--- a/packages/types/src/setup-compute-config.ts
+++ b/packages/types/src/setup-compute-config.ts
@@ -565,8 +565,11 @@ function isConfiguredEnvValue(
  */
 const DEFAULT_WORKER_IMAGE_REPOSITORY = 'ghcr.io/roocodeinc/roomote-worker';
 
+// Source checkouts do not have a baked RELEASE_VERSION. Follow the published
+// development channel automatically for hosted providers; operators can pin
+// any registry-qualified image with DOCKER_WORKER_IMAGE.
 export const DEVELOPMENT_MODAL_BASE_IMAGE_REF =
-  'ghcr.io/roocodeinc/roomote-worker:latest';
+  'ghcr.io/roocodeinc/roomote-worker:develop';
 
 /**
  * Derives the published worker image ref for the running app release:


### PR DESCRIPTION
## Summary

- use the published `roomote-worker:develop` channel automatically for hosted providers in source development
- keep registry-qualified `DOCKER_WORKER_IMAGE` values as the explicit operator override
- preserve immutable `RELEASE_VERSION`-derived images for packaged deployments
- update cross-package regression coverage for provisioning and Modal configuration

## Why

Source development previously fell back to `roomote-worker:latest`. The published development worker is released on the `develop` channel, while some hosted providers reject `:latest` outright. This caused automatic E2B and Daytona provisioning to fail unless developers manually configured an image in `.env.local`.

With this change, local development follows the published development channel automatically and no Settings field or persisted image override is needed.

## Validation

- 2,912 tests across `@roomote/types`, `@roomote/db`, `@roomote/compute-providers`, and `@roomote/web`
- package lint and TypeScript checks
- pre-push `lint:fast`, `check-types:fast`, and Knip gates