### PR TITLE
[Fix] Blank continue action when revisiting a saved Slack setup

### DIFF
--- a/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.client.test.tsx
@@ -457,6 +457,51 @@ describe('StepAuthEnvVars', () => {
     ).toHaveAttribute('href', '/api/setup/roomote-logo');
   });
 
+  it('offers a continue action when a saved Slack config is revisited', () => {
+    const authSetup = buildAuthSetup('slack');
+    const savedSlackAuthSetup: SetupAuthStatus = {
+      ...authSetup,
+      providers: authSetup.providers.map((provider) =>
+        provider.id === 'slack'
+          ? {
+              ...provider,
+              savedSatisfied: true,
+              setupSatisfied: true,
+              fields: provider.fields.map((field) => ({
+                ...field,
+                savedSatisfied: true,
+                savedValue:
+                  field.envVarName === 'R_SLACK_CLIENT_ID'
+                    ? '11040692082085.11578538885334'
+                    : field.savedValue,
+              })),
+            }
+          : provider,
+      ),
+    };
+
+    render(
+      <StepAuthEnvVars
+        authSetup={savedSlackAuthSetup}
+        selectedProviderId="slack"
+        onContinue={vi.fn()}
+      />,
+    );
+
+    // Saved Slack skips the "Create Slack app" intro and shows the value form.
+    expect(screen.getByText('Enter the values below:')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /create slack app/i }),
+    ).not.toBeInTheDocument();
+
+    // The intro is what "owns" the Slack action buttons, so once it is hidden
+    // the step itself must still render an action button — otherwise the user
+    // is stranded on a page with no way to continue.
+    expect(
+      screen.getByRole('button', { name: /continue/i }),
+    ).toBeInTheDocument();
+  });
+
   it('keeps Microsoft setup focused on the single app values', () => {
     render(
       <StepAuthEnvVars

--- a/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.tsx
@@ -253,10 +253,16 @@ export function StepAuthEnvVars({
     selectedProvider.runtimeSatisfied;
   const selectedProviderHasEditableFields =
     visibleFields.some((field) => !field.runtimeSatisfied) ?? false;
+  // Slack "owns" the step actions only while its intro screen is shown, which
+  // is the same condition SlackSetupExperience uses to render that intro. If a
+  // saved (or runtime) config is being edited instead, the intro is hidden and
+  // this step must render its own action button — otherwise there is no way to
+  // continue. Keep this in sync with SlackSetupExperience's intro guard.
   const providerOwnsActions =
     selectedProvider?.id === 'slack' &&
     !showManualSlackValues &&
-    !selectedProvider.runtimeSatisfied;
+    !selectedProvider.runtimeSatisfied &&
+    !selectedProvider.savedSatisfied;
 
   if (bootstrapMode && selectedProviderRuntimeConfigured) {
     return (


### PR DESCRIPTION
## Problem

The setup auth step renders the filled-in Slack credential fields but nothing below them — no way to continue, in Chrome and Safari alike. Reads as a "blank page" below the form.

## Root cause

Two conditions that must mirror each other drifted apart in e36f573:

- `SlackSetupExperience` shows its intro screen (which owns the Create Slack app / Enter values manually / Back buttons) only when `!showManualSlackValues && !runtimeSatisfied && !savedSatisfied`.
- `StepAuthEnvVars` suppresses its own action button whenever `providerOwnsActions` is true — but that check was missing the `!savedSatisfied` clause.

So with Slack already configured (`savedSatisfied`), the intro is skipped and the value form is shown, yet `StepAuthEnvVars` still believes the intro owns the actions → no button rendered anywhere, user is stranded. Deterministic, hence identical in every browser.

## Fix

Add the missing `!selectedProvider.savedSatisfied` clause to `providerOwnsActions`, with a comment tying it to the intro guard it must stay in sync with. The saved-Slack revisit now renders an enabled **Continue** button.

## Verification

- New regression test (saved-Slack revisit) fails without the fix, passes with it
- `StepAuthEnvVars.client.test.tsx`: 17/17 pass
- `@roomote/web` typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)