### PR TITLE
Fix compute provisioning tests for the r3 runtime schema bump

### DIFF
--- a/apps/web/src/trpc/commands/compute/compute-provisioning.test.ts
+++ b/apps/web/src/trpc/commands/compute/compute-provisioning.test.ts
@@ -1,3 +1,7 @@
+import {
+  WORKER_RUNTIME_SCHEMA_TAG,
+  WORKER_RUNTIME_SCHEMA_VERSION,
+} from '@roomote/types';
 import type {
   SetupNewComputeProvisioningState,
   SetupNewState,
@@ -30,16 +34,13 @@ vi.mock('@roomote/db/server', () => ({
   resolveComputeProviderEnvValues: mockResolveComputeProviderEnvValues,
 }));
 
-vi.mock('@roomote/compute-providers', () => ({
+// Keep the real templateRef derivations (they embed WORKER_RUNTIME_SCHEMA_TAG)
+// and mock only the provider-side build/register calls.
+vi.mock('@roomote/compute-providers', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@roomote/compute-providers')>()),
   buildBlaxelWorkerImage: vi.fn(),
   buildE2bWorkerTemplate: mockBuildE2bWorkerTemplate,
   registerDaytonaWorkerSnapshot: vi.fn(),
-  deriveBlaxelWorkerImageName: (imageRef: string) =>
-    `roomote-worker-${imageRef.slice(imageRef.lastIndexOf(':') + 1)}`,
-  deriveE2bWorkerTemplateRef: (imageRef: string) =>
-    `roomote-worker:${imageRef.slice(imageRef.lastIndexOf(':') + 1)}`,
-  deriveDaytonaWorkerSnapshotName: (imageRef: string) =>
-    `roomote-worker-${imageRef.slice(imageRef.lastIndexOf(':') + 1)}`,
 }));
 
 vi.mock('../environment-variables', () => ({
@@ -225,14 +226,14 @@ describe('prepareComputeProvisioningStart', () => {
       start: {
         provider: 'e2b',
         imageRef: 'registry.example.com/worker:tag',
-        templateRef: 'roomote-worker:tag',
+        templateRef: `roomote-worker:tag-${WORKER_RUNTIME_SCHEMA_TAG}`,
       },
     });
     expect(markPending).toHaveBeenCalledWith(
       expect.objectContaining({
         status: 'building',
         imageRef: 'registry.example.com/worker:tag',
-        templateRef: 'roomote-worker:tag',
+        templateRef: `roomote-worker:tag-${WORKER_RUNTIME_SCHEMA_TAG}`,
       }),
     );
   });
@@ -277,9 +278,9 @@ describe('prepareComputeProvisioningStart', () => {
       },
       existingState: {
         status: 'building',
-        runtimeSchemaVersion: 2,
+        runtimeSchemaVersion: WORKER_RUNTIME_SCHEMA_VERSION,
         imageRef: 'registry.example.com/worker:tag',
-        templateRef: 'roomote-worker-tag',
+        templateRef: `roomote-worker-tag-${WORKER_RUNTIME_SCHEMA_TAG}`,
         error: null,
         startedAt,
         finishedAt: null,
@@ -414,9 +415,9 @@ describe('prepareComputeProvisioningStart', () => {
       },
       existingState: {
         status: 'succeeded',
-        runtimeSchemaVersion: 2,
+        runtimeSchemaVersion: WORKER_RUNTIME_SCHEMA_VERSION,
         imageRef: 'registry.example.com/worker:tag',
-        templateRef: 'roomote-worker:tag',
+        templateRef: `roomote-worker:tag-${WORKER_RUNTIME_SCHEMA_TAG}`,
         error: null,
         startedAt: new Date().toISOString(),
         finishedAt: new Date().toISOString(),
@@ -483,13 +484,13 @@ describe('prepareComputeProvisioningStart', () => {
       start: {
         provider: 'e2b',
         imageRef: 'ghcr.io/roocodeinc/roomote-worker:develop',
-        templateRef: 'roomote-worker:develop',
+        templateRef: `roomote-worker:develop-${WORKER_RUNTIME_SCHEMA_TAG}`,
       },
     });
     expect(markPending).toHaveBeenCalledWith(
       expect.objectContaining({
         imageRef: 'ghcr.io/roocodeinc/roomote-worker:develop',
-        templateRef: 'roomote-worker:develop',
+        templateRef: `roomote-worker:develop-${WORKER_RUNTIME_SCHEMA_TAG}`,
       }),
     );
   });
@@ -503,15 +504,15 @@ describe('reconcileComputeProvisioningOnStartup', () => {
       'E2B_TEMPLATE_ID',
     ]);
     mockGetPersistedEnvironmentVariableValues.mockResolvedValue({
-      E2B_TEMPLATE_ID: 'roomote-worker:tag',
+      E2B_TEMPLATE_ID: `roomote-worker:tag-${WORKER_RUNTIME_SCHEMA_TAG}`,
     });
     const execute = vi.fn();
-    const { executor } = createExecutorMock({
+    const { captured, executor } = createExecutorMock({
       e2bTemplateBuild: {
         status: 'succeeded',
-        runtimeSchemaVersion: 2,
+        runtimeSchemaVersion: WORKER_RUNTIME_SCHEMA_VERSION,
         imageRef: 'registry.example.com/worker:tag',
-        templateRef: 'roomote-worker:tag',
+        templateRef: `roomote-worker:tag-${WORKER_RUNTIME_SCHEMA_TAG}`,
         error: null,
         startedAt: new Date().toISOString(),
         finishedAt: new Date().toISOString(),
@@ -524,6 +525,9 @@ describe('reconcileComputeProvisioningOnStartup', () => {
     await reconcileComputeProvisioningOnStartup();
 
     expect(execute).toHaveBeenCalledOnce();
+    // Current artifact: no pending claim written, no detached run started.
+    expect(captured.setupNewState).toBeUndefined();
+    expect(mockResolveComputeProviderEnvValues).not.toHaveBeenCalled();
   });
 });
 
@@ -542,9 +546,9 @@ describe('runComputeProvisioning', () => {
     const { captured, executor } = createExecutorMock({
       e2bTemplateBuild: {
         status: 'building',
-        runtimeSchemaVersion: 2,
+        runtimeSchemaVersion: WORKER_RUNTIME_SCHEMA_VERSION,
         imageRef: 'registry.example.com/worker:new',
-        templateRef: 'roomote-worker:new-r2',
+        templateRef: `roomote-worker:new-${WORKER_RUNTIME_SCHEMA_TAG}`,
         error: null,
         startedAt: new Date().toISOString(),
         finishedAt: null,

--- a/apps/web/src/trpc/commands/compute/index.test.ts
+++ b/apps/web/src/trpc/commands/compute/index.test.ts
@@ -1,4 +1,5 @@
 import type { FeatureFlag } from '@roomote/feature-flags';
+import { WORKER_RUNTIME_SCHEMA_TAG } from '@roomote/types';
 
 import type { UserAuthSuccess } from '@/types';
 
@@ -427,7 +428,7 @@ describe('compute commands', () => {
         provider: 'e2b',
         userId: 'compute-test-user',
         imageRef: 'registry.example.com/worker:tag',
-        templateRef: 'roomote-worker:tag-r2',
+        templateRef: `roomote-worker:tag-${WORKER_RUNTIME_SCHEMA_TAG}`,
       });
     });
 
@@ -447,7 +448,7 @@ describe('compute commands', () => {
         provider: 'daytona',
         userId: 'compute-test-user',
         imageRef: 'registry.example.com/worker:tag',
-        templateRef: 'roomote-worker-tag-r2',
+        templateRef: `roomote-worker-tag-${WORKER_RUNTIME_SCHEMA_TAG}`,
       });
     });
 
@@ -464,7 +465,7 @@ describe('compute commands', () => {
         provider: 'e2b',
         userId: 'compute-test-user',
         imageRef: 'registry.example.com/worker:tag',
-        templateRef: 'roomote-worker:tag-r2',
+        templateRef: `roomote-worker:tag-${WORKER_RUNTIME_SCHEMA_TAG}`,
       });
     });
 

--- a/apps/web/src/trpc/commands/setup-new/index.test.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.test.ts
@@ -191,7 +191,11 @@ import {
   saveSetupNewSourceControlProviderChoiceCommand,
   startSetupNewOnboardingTaskCommand,
 } from './index';
-import { TaskPayloadKind } from '@roomote/types';
+import {
+  TaskPayloadKind,
+  WORKER_RUNTIME_SCHEMA_TAG,
+  WORKER_RUNTIME_SCHEMA_VERSION,
+} from '@roomote/types';
 import { enqueueTask } from '@roomote/cloud-agents/server';
 import { TelegramCommunicationProvider } from '@roomote/communication/telegram-provider';
 import { resolveTelegramRuntimeCredentials } from '@roomote/db/server';
@@ -834,12 +838,12 @@ describe('setup-new compute config commands', () => {
       provider: 'e2b',
       userId: 'setup-test-user',
       imageRef: 'registry.example.com/worker:tag',
-      templateRef: 'roomote-worker:tag-r2',
+      templateRef: `roomote-worker:tag-${WORKER_RUNTIME_SCHEMA_TAG}`,
     });
     expect(result.setupNewState.e2bTemplateBuild).toMatchObject({
       status: 'building',
       imageRef: 'registry.example.com/worker:tag',
-      templateRef: 'roomote-worker:tag-r2',
+      templateRef: `roomote-worker:tag-${WORKER_RUNTIME_SCHEMA_TAG}`,
     });
   });
 
@@ -863,9 +867,9 @@ describe('setup-new compute config commands', () => {
               setupNewState: {
                 e2bTemplateBuild: {
                   status: 'building',
-                  runtimeSchemaVersion: 2,
+                  runtimeSchemaVersion: WORKER_RUNTIME_SCHEMA_VERSION,
                   imageRef: 'registry.example.com/worker:tag',
-                  templateRef: 'roomote-worker:tag-r2',
+                  templateRef: `roomote-worker:tag-${WORKER_RUNTIME_SCHEMA_TAG}`,
                   error: null,
                   startedAt: new Date().toISOString(),
                   finishedAt: null,
@@ -891,7 +895,7 @@ describe('setup-new compute config commands', () => {
     expect(mockRunComputeProvisioning).not.toHaveBeenCalled();
     expect(result.setupNewState.e2bTemplateBuild).toMatchObject({
       status: 'building',
-      templateRef: 'roomote-worker:tag-r2',
+      templateRef: `roomote-worker:tag-${WORKER_RUNTIME_SCHEMA_TAG}`,
     });
   });
 


### PR DESCRIPTION
## What

develop is red: #301 bumped `WORKER_RUNTIME_SCHEMA_VERSION` 2→3, but its merge CI path-filtered away the `apps/web` test suite, so seven stale test expectations surfaced only when later merges (#291) touched `apps/web` and made CI actually run them.

**No runtime bug** — #301 never touched the provisioning currency logic; verified against its diff. This is test-only:

- "Current" fixtures use `WORKER_RUNTIME_SCHEMA_VERSION` / `WORKER_RUNTIME_SCHEMA_TAG` instead of hardcoded `2` / `-r2`, so future bumps don't break them
- The compute-providers derivation stubs now `importOriginal`, so fixtures and assertions exercise the real templateRef derivations instead of hand-rolled suffix-less strings
- Two tests that kept passing after the bump for the wrong reason (fixtures silently became "stale", flipping them onto untested paths) are re-anchored to the current version with strengthened assertions

## Testing

- Full `apps/web` suite: 281 files / 1969 tests green (was 7 red on develop)
- `check-types:fast`, prettier clean

Unblocks develop and #305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)