### PR TITLE
Enable Docker projects on Modal VM sandboxes

### DIFF
--- a/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
+++ b/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
@@ -133,7 +133,7 @@ describe('spawnModalWorker', () => {
     );
   });
 
-  it('rejects environments with docker projects before starting Modal', async () => {
+  it('uses a right-sized Modal VM sandbox for environments with Docker projects', async () => {
     mockGetNamedPortsForTaskRun.mockResolvedValue({
       namedPorts: [{ name: 'SANDBOX_SERVER', port: 7777 }],
       environmentSnapshotId: undefined,
@@ -149,27 +149,32 @@ describe('spawnModalWorker', () => {
       },
     });
 
-    await expect(
-      spawnModalWorker(
-        mockTaskRun({
-          payloadKind: TaskPayloadKind.StandardTask,
-          payload: { repo: 'test/repo', environmentId: 'env_123' },
-        }),
-        'auth_token',
-        {
-          deploymentSlug: 'roomote',
-          modalTokenId: 'token-id',
-          modalTokenSecret: 'token-secret',
-          modalBaseImageRef: 'image-ref',
-          modalTimeoutMs: 60_000,
-        },
-      ),
-    ).rejects.toThrow(
-      'Modal does not currently support Docker Compose or Dockerfile projects',
+    await spawnModalWorker(
+      mockTaskRun({
+        payloadKind: TaskPayloadKind.StandardTask,
+        payload: { repo: 'test/repo', environmentId: 'env_123' },
+      }),
+      'auth_token',
+      {
+        deploymentSlug: 'roomote',
+        modalTokenId: 'token-id',
+        modalTokenSecret: 'token-secret',
+        modalBaseImageRef: 'image-ref',
+        modalTimeoutMs: 60_000,
+      },
     );
 
-    expect(mockCreateComputeProviderClient).not.toHaveBeenCalled();
-    expect(mockCreateModalMachine).not.toHaveBeenCalled();
+    expect(mockCreateComputeProviderClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'modal',
+        config: expect.objectContaining({
+          vmRuntime: true,
+          cpu: 2,
+          memoryMiB: 4096,
+        }),
+      }),
+    );
+    expect(mockCreateModalMachine).toHaveBeenCalled();
   });
 
   it('primes environment OIDC before launching a fresh Modal worker when the environment defines OIDC targets', async () => {

--- a/apps/controller/src/compute-providers/spawn-modal-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-modal-worker.ts
@@ -161,11 +161,7 @@ export async function spawnModalWorker(
   const { namedPorts, environmentSnapshotId, environmentConfig } =
     await getNamedPortsForTaskRun(taskRun);
 
-  if (environmentConfig?.docker_projects?.length) {
-    throw new NonRetryableSpawnError(
-      'Modal does not currently support Docker Compose or Dockerfile projects. Choose E2B, Daytona, Blaxel, or Local Docker for this environment.',
-    );
-  }
+  const needsVmRuntime = Boolean(environmentConfig?.docker_projects?.length);
 
   const shouldEnableAuthBypass = shouldEnableAuthBypassForTaskRun({
     environmentConfig,
@@ -255,6 +251,9 @@ export async function spawnModalWorker(
 
   const configuredResources = resolveConfiguredComputeProviderResources({
     provider: 'modal',
+    ...(needsVmRuntime
+      ? { configuredCpuCores: 2, configuredMemoryMiB: 4096 }
+      : {}),
   });
   const modalConfig = {
     tokenId: modalTokenId,
@@ -272,6 +271,7 @@ export async function spawnModalWorker(
     ...(modalEcrOidcRoleArn ? { ecrOidcRoleArn: modalEcrOidcRoleArn } : {}),
     ...(modalEcrRegion ? { ecrRegion: modalEcrRegion } : {}),
     ...(parsedModalRegions ? { regions: parsedModalRegions } : {}),
+    ...(needsVmRuntime ? { vmRuntime: true } : {}),
     ...(configuredResources.configuredCpuCores !== null
       ? { cpu: configuredResources.configuredCpuCores }
       : {}),

--- a/apps/docs/providers/compute/modal.mdx
+++ b/apps/docs/providers/compute/modal.mdx
@@ -48,7 +48,9 @@ to newly created or resumed sandboxes, not sandboxes that are already running.
 Environments with
 [Docker projects](/environments/definition#docker-projects) automatically
 use Modal's beta VM sandbox runtime so Docker and Docker Compose can run inside
-the task. Other Modal tasks continue to use the standard sandbox runtime.
+the task. Roomote starts Docker as the VM sandbox's primary service and requests
+2 CPU cores and 4 GiB of memory for these tasks. Other Modal tasks continue to
+use the standard sandbox runtime and its lower default resource request.
 Container builds and services share the task sandbox's CPU and memory.
 
 ## Verify setup

--- a/packages/compute-providers/src/adapters/modal.test.ts
+++ b/packages/compute-providers/src/adapters/modal.test.ts
@@ -463,6 +463,14 @@ describe('ModalClient', () => {
       { appId: 'app-123' },
       { imageId: 'img-123' },
       expect.objectContaining({
+        command: [
+          '/usr/bin/sudo',
+          '/usr/bin/env',
+          'DOCKER_INSECURE_NO_IPTABLES_RAW=1',
+          '/usr/bin/dockerd',
+          '--host=unix:///var/run/docker.sock',
+          '--log-level=error',
+        ],
         experimentalOptions: { vm_runtime: true },
       }),
     );
@@ -476,6 +484,14 @@ describe('ModalClient', () => {
       { appId: 'app-123' },
       { imageId: 'img-snap-123' },
       expect.objectContaining({
+        command: [
+          '/usr/bin/sudo',
+          '/usr/bin/env',
+          'DOCKER_INSECURE_NO_IPTABLES_RAW=1',
+          '/usr/bin/dockerd',
+          '--host=unix:///var/run/docker.sock',
+          '--log-level=error',
+        ],
         experimentalOptions: { vm_runtime: true },
       }),
     );
@@ -560,6 +576,56 @@ describe('ModalClient', () => {
 
     expect(Buffer.compare(Buffer.concat(chunks), content)).toBe(0);
     expect(closeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('streams VM file writes through exec instead of the filesystem API', async () => {
+    const writeBytesMock = vi.fn().mockResolvedValue(undefined);
+    const closeMock = vi.fn().mockResolvedValue(undefined);
+    const mkdirWaitMock = vi.fn().mockResolvedValue(0);
+    const writeWaitMock = vi.fn().mockResolvedValue(0);
+    const execMock = vi
+      .fn()
+      .mockResolvedValueOnce({ wait: mkdirWaitMock })
+      .mockResolvedValueOnce({
+        stdin: { writeBytes: writeBytesMock, close: closeMock },
+        stderr: { readText: vi.fn().mockResolvedValue('') },
+        wait: writeWaitMock,
+      });
+    const openMock = vi.fn();
+
+    sandboxFromIdMock.mockResolvedValue({
+      sandboxId: 'modal-vm-123',
+      exec: execMock,
+      open: openMock,
+    });
+
+    const client = new ModalClient({
+      tokenId: 'token-id',
+      tokenSecret: 'token-secret',
+      baseImageRef: MODAL_IMAGE_REF,
+      vmRuntime: true,
+    });
+    const content = Buffer.alloc(20 * 1024 * 1024 + 321, 7);
+
+    await client.writeFiles({
+      instanceId: 'modal-vm-123',
+      files: [{ path: '/sandbox/worker.tar.gz', content }],
+    });
+
+    expect(execMock).toHaveBeenNthCalledWith(1, ['mkdir', '-p', '/sandbox']);
+    expect(execMock).toHaveBeenNthCalledWith(
+      2,
+      ['/usr/bin/tee', '/sandbox/worker.tar.gz'],
+      {
+        mode: 'binary',
+        stdout: 'ignore',
+        stderr: 'pipe',
+      },
+    );
+    expect(writeBytesMock.mock.calls.length).toBeGreaterThan(1);
+    expect(closeMock).toHaveBeenCalledTimes(1);
+    expect(writeWaitMock).toHaveBeenCalledTimes(1);
+    expect(openMock).not.toHaveBeenCalled();
   });
 
   it('surfaces immediate detached-process exits so callers can clean up', async () => {

--- a/packages/compute-providers/src/adapters/modal.test.ts
+++ b/packages/compute-providers/src/adapters/modal.test.ts
@@ -628,6 +628,47 @@ describe('ModalClient', () => {
     expect(openMock).not.toHaveBeenCalled();
   });
 
+  it('closes VM write stdin and handles stderr rejection when streaming fails', async () => {
+    const writeBytesMock = vi
+      .fn()
+      .mockRejectedValue(new Error('chunk write failed'));
+    const closeMock = vi.fn().mockResolvedValue(undefined);
+    const execMock = vi
+      .fn()
+      .mockResolvedValueOnce({ wait: vi.fn().mockResolvedValue(0) })
+      .mockResolvedValueOnce({
+        stdin: { writeBytes: writeBytesMock, close: closeMock },
+        stderr: {
+          readText: vi.fn().mockRejectedValue(new Error('stderr read failed')),
+        },
+        wait: vi.fn().mockResolvedValue(0),
+      });
+
+    sandboxFromIdMock.mockResolvedValue({
+      sandboxId: 'modal-vm-123',
+      exec: execMock,
+      open: vi.fn(),
+    });
+
+    const client = new ModalClient({
+      tokenId: 'token-id',
+      tokenSecret: 'token-secret',
+      baseImageRef: MODAL_IMAGE_REF,
+      vmRuntime: true,
+    });
+
+    await expect(
+      client.writeFiles({
+        instanceId: 'modal-vm-123',
+        files: [
+          { path: '/sandbox/worker.tar.gz', content: Buffer.from('worker') },
+        ],
+      }),
+    ).rejects.toThrow('chunk write failed');
+
+    expect(closeMock).toHaveBeenCalledTimes(1);
+  });
+
   it('surfaces immediate detached-process exits so callers can clean up', async () => {
     const execMock = vi.fn().mockResolvedValue({
       stdout: { readText: vi.fn().mockResolvedValue('boot stdout') },

--- a/packages/compute-providers/src/adapters/modal.ts
+++ b/packages/compute-providers/src/adapters/modal.ts
@@ -44,6 +44,14 @@ import { normalizeModalRpcError } from '../modal/rpc-diagnostics';
 const DEFAULT_APP_NAME = 'roomote';
 
 const DEFAULT_MODAL_WORKDIR = '/sandbox';
+const MODAL_VM_DOCKER_COMMAND = [
+  '/usr/bin/sudo',
+  '/usr/bin/env',
+  'DOCKER_INSECURE_NO_IPTABLES_RAW=1',
+  '/usr/bin/dockerd',
+  '--host=unix:///var/run/docker.sock',
+  '--log-level=error',
+];
 
 const DEFAULT_MODAL_COMMAND_USER = 'roomote';
 
@@ -452,7 +460,10 @@ export class ModalClient implements ComputeProviderClient {
             ? { regions: this.config.regions }
             : {}),
           ...(this.config.vmRuntime
-            ? { experimentalOptions: { vm_runtime: true } }
+            ? {
+                command: MODAL_VM_DOCKER_COMMAND,
+                experimentalOptions: { vm_runtime: true },
+              }
             : {}),
         }),
         signal: input.signal,
@@ -728,6 +739,84 @@ export class ModalClient implements ComputeProviderClient {
       }
     }
 
+    if (this.config.vmRuntime) {
+      for (const file of input.files) {
+        try {
+          const process = await raceWithAbort({
+            promise: sandbox.exec(['/usr/bin/tee', file.path], {
+              mode: 'binary',
+              stdout: 'ignore',
+              stderr: 'pipe',
+            }),
+            signal: input.signal,
+            abortMessage: `Starting streamed write for ${file.path} on ${input.instanceId} was aborted`,
+          });
+          const stderrPromise = process.stderr.readText();
+
+          for (
+            let offset = 0;
+            offset < file.content.byteLength;
+            offset += MODAL_FILE_WRITE_CHUNK_BYTES
+          ) {
+            throwIfAborted(
+              input.signal,
+              `Writing ${file.path} on ${input.instanceId} was aborted`,
+            );
+
+            const chunkEnd = Math.min(
+              offset + MODAL_FILE_WRITE_CHUNK_BYTES,
+              file.content.byteLength,
+            );
+            const chunk = new Uint8Array(
+              file.content.buffer,
+              file.content.byteOffset + offset,
+              chunkEnd - offset,
+            );
+
+            await raceWithAbort({
+              promise: process.stdin.writeBytes(chunk),
+              signal: input.signal,
+              abortMessage: `Writing ${file.path} on ${input.instanceId} was aborted`,
+            });
+          }
+
+          await process.stdin.close();
+
+          const [exitCode, stderr] = await raceWithAbort({
+            promise: Promise.all([process.wait(), stderrPromise]),
+            signal: input.signal,
+            abortMessage: `Waiting for streamed write of ${file.path} on ${input.instanceId} was aborted`,
+          });
+
+          if (exitCode !== 0) {
+            throw new Error(
+              `Streamed write failed with exit code ${exitCode}${stderr ? `: ${stderr}` : ''}`,
+            );
+          }
+
+          console.log(
+            `[ModalClient] Wrote VM file ${file.path} (${file.content.byteLength} bytes)`,
+          );
+        } catch (error) {
+          if (isSandboxUnavailableError(error)) {
+            this.invalidateSandboxCache(input.instanceId);
+          }
+
+          console.error(
+            `[ModalClient] Failed to stream VM file ${file.path} ${JSON.stringify(
+              {
+                error: formatError(error),
+              },
+            )}`,
+          );
+
+          throw normalizeModalRpcError(error, 'write_files_exec');
+        }
+      }
+
+      return;
+    }
+
     for (const file of input.files) {
       try {
         const handle = await raceWithAbort({
@@ -918,7 +1007,10 @@ export class ModalClient implements ComputeProviderClient {
             ? { regions: this.config.regions }
             : {}),
           ...(this.config.vmRuntime
-            ? { experimentalOptions: { vm_runtime: true } }
+            ? {
+                command: MODAL_VM_DOCKER_COMMAND,
+                experimentalOptions: { vm_runtime: true },
+              }
             : {}),
         }),
         signal: input.signal,

--- a/packages/compute-providers/src/adapters/modal.ts
+++ b/packages/compute-providers/src/adapters/modal.ts
@@ -751,47 +751,64 @@ export class ModalClient implements ComputeProviderClient {
             signal: input.signal,
             abortMessage: `Starting streamed write for ${file.path} on ${input.instanceId} was aborted`,
           });
-          const stderrPromise = process.stderr.readText();
+          const stderrPromise = process.stderr.readText().then(
+            (value) => ({ value, error: undefined }),
+            (error: unknown) => ({ value: '', error }),
+          );
+          let stdinCloseStarted = false;
 
-          for (
-            let offset = 0;
-            offset < file.content.byteLength;
-            offset += MODAL_FILE_WRITE_CHUNK_BYTES
-          ) {
-            throwIfAborted(
-              input.signal,
-              `Writing ${file.path} on ${input.instanceId} was aborted`,
-            );
+          try {
+            for (
+              let offset = 0;
+              offset < file.content.byteLength;
+              offset += MODAL_FILE_WRITE_CHUNK_BYTES
+            ) {
+              throwIfAborted(
+                input.signal,
+                `Writing ${file.path} on ${input.instanceId} was aborted`,
+              );
 
-            const chunkEnd = Math.min(
-              offset + MODAL_FILE_WRITE_CHUNK_BYTES,
-              file.content.byteLength,
-            );
-            const chunk = new Uint8Array(
-              file.content.buffer,
-              file.content.byteOffset + offset,
-              chunkEnd - offset,
-            );
+              const chunkEnd = Math.min(
+                offset + MODAL_FILE_WRITE_CHUNK_BYTES,
+                file.content.byteLength,
+              );
+              const chunk = new Uint8Array(
+                file.content.buffer,
+                file.content.byteOffset + offset,
+                chunkEnd - offset,
+              );
 
-            await raceWithAbort({
-              promise: process.stdin.writeBytes(chunk),
+              await raceWithAbort({
+                promise: process.stdin.writeBytes(chunk),
+                signal: input.signal,
+                abortMessage: `Writing ${file.path} on ${input.instanceId} was aborted`,
+              });
+            }
+
+            stdinCloseStarted = true;
+            await process.stdin.close();
+
+            const [exitCode, stderrResult] = await raceWithAbort({
+              promise: Promise.all([process.wait(), stderrPromise]),
               signal: input.signal,
-              abortMessage: `Writing ${file.path} on ${input.instanceId} was aborted`,
+              abortMessage: `Waiting for streamed write of ${file.path} on ${input.instanceId} was aborted`,
             });
-          }
 
-          await process.stdin.close();
+            if (stderrResult.error !== undefined) {
+              throw stderrResult.error;
+            }
 
-          const [exitCode, stderr] = await raceWithAbort({
-            promise: Promise.all([process.wait(), stderrPromise]),
-            signal: input.signal,
-            abortMessage: `Waiting for streamed write of ${file.path} on ${input.instanceId} was aborted`,
-          });
-
-          if (exitCode !== 0) {
-            throw new Error(
-              `Streamed write failed with exit code ${exitCode}${stderr ? `: ${stderr}` : ''}`,
-            );
+            if (exitCode !== 0) {
+              throw new Error(
+                `Streamed write failed with exit code ${exitCode}${stderrResult.value ? `: ${stderrResult.value}` : ''}`,
+              );
+            }
+          } finally {
+            if (!stdinCloseStarted) {
+              await process.stdin.close().catch(() => {
+                // Best-effort cleanup if the streamed write path aborted.
+              });
+            }
           }
 
           console.log(

--- a/packages/types/src/__tests__/compute-provider-capabilities.test.ts
+++ b/packages/types/src/__tests__/compute-provider-capabilities.test.ts
@@ -1,7 +1,7 @@
 import { getComputeProviderCapabilities } from '../compute-providers/capabilities';
 
 describe('compute provider capabilities', () => {
-  it.each(['docker', 'daytona', 'e2b', 'blaxel'] as const)(
+  it.each(['docker', 'modal', 'daytona', 'e2b', 'blaxel'] as const)(
     'marks %s as supporting Docker projects',
     (provider) => {
       expect(
@@ -9,10 +9,4 @@ describe('compute provider capabilities', () => {
       ).toBe(true);
     },
   );
-
-  it('marks Modal as not supporting Docker projects', () => {
-    expect(getComputeProviderCapabilities('modal').supportsDockerProjects).toBe(
-      false,
-    );
-  });
 });

--- a/packages/types/src/compute-providers/capabilities.ts
+++ b/packages/types/src/compute-providers/capabilities.ts
@@ -45,7 +45,7 @@ export const MODAL_CAPABILITIES: ComputeProviderCapabilities = {
   supportsStandbyResume: false,
   supportsResume: true,
   supportsFileWrite: true,
-  supportsDockerProjects: false,
+  supportsDockerProjects: true,
 };
 
 export const DAYTONA_CAPABILITIES: ComputeProviderCapabilities = {


### PR DESCRIPTION
## Summary

- enable Docker Compose and Dockerfile projects on Modal using VM sandboxes
- run Docker as the sandbox's primary service with networking compatible with the Modal VM kernel
- stream worker files through sandbox exec for VM runtimes instead of relying on the failing filesystem write path
- request 2 CPU cores and 4 GiB of memory for Modal Docker workloads
- document the Modal Docker project behavior

## Root cause

Modal's standard sandbox runtime cannot host Docker projects. The VM runtime supports Docker, but the existing integration did not start a daemon, its filesystem API failed while transferring the worker bundle, and Docker's raw-table filtering was incompatible with the available VM kernel configuration.

## Impact

Environments configured with Docker Compose or a single Dockerfile can now run on Modal. Modal environments without Docker projects continue using the standard runtime and existing resource defaults.

## Validation

- live end-to-end validation of both a Compose project and a single-Dockerfile project
- Modal adapter tests
- controller Modal spawn tests
- compute-provider capability tests
- worker Docker project tests
- package TypeScript checks
- `pnpm lint:fast`
- `pnpm check-types:fast`
- `pnpm knip`
