### PR TITLE
Show automation destinations and provider capabilities on the automations page

### DIFF
--- a/apps/docs/automations.mdx
+++ b/apps/docs/automations.mdx
@@ -89,6 +89,22 @@ Set **Automation output** first. This is the shared Slack channel for
 manager-facing posts, suggestions, summaries, and setup alerts. Invite Roomote
 to that channel before you save it.
 
+Each automation card shows a **Reports to** line with the destination the next
+run will use and which setting produced it. Reports go to the automation's own
+channel when one is set, otherwise to the shared Manager Channel. When Slack
+is not connected at all, reports fall back automatically to your primary
+Microsoft Teams conversation or the configured Telegram chat (see
+[Communications](/communications#supported-providers) for connecting those
+surfaces).
+
+Cards also show capability badges for what each automation supports today:
+the chat surfaces it can report to and the source-control providers it works
+with. Triage Dependabot Alerts and CI Failure Triage are GitHub-only by
+nature. The Security Auditor, Code Quality Auditor, and Resolve PR Conflicts
+automations currently support GitHub only, while Suggest Ideas, Summarize
+Merged PRs, and Triage Sentry Issues work with any connected source-control
+provider.
+
 **Code Quality Auditor** inspects recently merged PR diffs and only posts
 high-confidence maintainability issues worth a real follow-up task. It is
 meant to catch confusing abstractions, file bloat, brittle branching, and other

--- a/apps/web/src/components/settings/automations/AutomationsSettings.render.client.test.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.render.client.test.tsx
@@ -121,6 +121,31 @@ const state = vi.hoisted(() => ({
         relayReviewResultsToTask: false,
         relayUsers: [],
       },
+      resolvedDestinations: Object.fromEntries(
+        [
+          'manager_stats',
+          'sentry_triage',
+          'dependabot_triage',
+          'security_auditor',
+          'code_quality_auditor',
+          'ci_failure_triage',
+          'suggester',
+          'announcer',
+        ].map((key) => [
+          key,
+          {
+            provider: 'slack',
+            channelId: 'C123MANAGER',
+            source: 'manager_channel',
+            displayName: '#roomote-managers',
+          } as {
+            provider: string;
+            channelId: string;
+            source: string;
+            displayName: string | null;
+          } | null,
+        ]),
+      ),
       recentRuns: {},
       automationStatus: {},
     },
@@ -331,6 +356,16 @@ describe('AutomationsSettings', () => {
     state.settingsQuery.data.reviewer.reviewDraftPrs = true;
     state.settingsQuery.data.reviewer.relayReviewResultsToTask = false;
     state.settingsQuery.data.reviewer.relayUsers = [];
+    for (const key of Object.keys(
+      state.settingsQuery.data.resolvedDestinations,
+    )) {
+      state.settingsQuery.data.resolvedDestinations[key] = {
+        provider: 'slack',
+        channelId: 'C123MANAGER',
+        source: 'manager_channel',
+        displayName: '#roomote-managers',
+      };
+    }
     window.location.hash = '';
     Element.prototype.scrollIntoView = vi.fn();
   });
@@ -342,6 +377,11 @@ describe('AutomationsSettings', () => {
     state.settingsQuery.data.settings.sentryTriageFrequency = 'daily' as never;
     state.settingsQuery.data.settings.dependabotTriageFrequency =
       'daily' as never;
+    for (const key of Object.keys(
+      state.settingsQuery.data.resolvedDestinations,
+    )) {
+      state.settingsQuery.data.resolvedDestinations[key] = null;
+    }
 
     render(<AutomationsSettings />);
 
@@ -367,6 +407,10 @@ describe('AutomationsSettings', () => {
     expect(
       screen.getAllByText('Select a Slack channel').length,
     ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText('Reports to: not configured — set a Manager Channel.')
+        .length,
+    ).toBeGreaterThan(1);
   });
 
   it('hides the launch mode picker when decision mode is disabled', async () => {
@@ -410,6 +454,17 @@ describe('AutomationsSettings', () => {
     ).toBeInTheDocument();
   });
 
+  it('shows capability badges from the shared automation descriptors', async () => {
+    render(<AutomationsSettings />);
+
+    // Generalized manager automations support every chat surface.
+    expect((await screen.findAllByText('All chat channels')).length).toBe(6);
+    // Suggester, announcer, and Sentry triage scan any source control provider.
+    expect(screen.getAllByText('All source control').length).toBe(3);
+    // Dependabot/CI triage, auditors, manager stats, and conflict resolver.
+    expect(screen.getAllByText('GitHub only').length).toBe(6);
+  });
+
   it('reflects the reviewer all-author setting in the review scope copy', async () => {
     state.settingsQuery.data.reviewer.enabled = true;
     state.settingsQuery.data.reviewer.reviewAllPullRequestAuthors = true;
@@ -436,7 +491,9 @@ describe('AutomationsSettings', () => {
     await openSuggesterCard();
 
     expect(
-      screen.getByText('Posts to the Manager Channel.'),
+      screen.getByText(
+        'Reports to #roomote-managers (Slack) — Manager Channel',
+      ),
     ).toBeInTheDocument();
     expect(
       screen.getByPlaceholderText(managerInstructionsPlaceholder),

--- a/apps/web/src/components/settings/automations/AutomationsSettings.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.tsx
@@ -8,11 +8,16 @@ import { toast } from 'sonner';
 import { FeatureFlag } from '@roomote/feature-flags';
 import {
   type BackgroundAutomationKey,
+  type CommunicationProvider,
+  communicationProviders,
   CONFLICT_RESOLUTION_MAX_PR_AGE_DAYS_OPTIONS,
   DEFAULT_CHANNEL_AUTO_START_LAUNCH_MODE,
   DEFAULT_CONFLICT_RESOLUTION_MAX_PR_AGE_DAYS,
   DEFAULT_SUGGESTER_ROUTING_MODE,
+  getCommunicationProviderDisplayName,
+  getSourceControlProviderLabel,
   getTriggerableBackgroundAutomationDescriptorByKey,
+  sourceControlProviders,
   type ChannelAutoStartLaunchMode,
   type ConflictResolverMaxPrAgeDays,
   PRODUCT_NAME,
@@ -20,6 +25,7 @@ import {
   type ScheduleOnlyBackgroundAutomationFrequency,
   type ScheduleOnlyBackgroundAutomationFrequencyField,
   type ScheduleOnlyBackgroundAutomationId,
+  type SourceControlProvider,
   type SuggesterRoutingMode,
   type TaskState,
   type TaskTrigger,
@@ -166,6 +172,18 @@ type AutomationSlackDestinationField =
   | 'codeQualityAuditorSlackChannel'
   | 'ciFailureTriageSlackChannel';
 
+const SLACK_DESTINATION_FIELD_AUTOMATION_KEYS = {
+  managerStatsSlackChannel: 'manager_stats',
+  sentryTriageSlackChannel: 'sentry_triage',
+  dependabotTriageSlackChannel: 'dependabot_triage',
+  securityAuditorSlackChannel: 'security_auditor',
+  codeQualityAuditorSlackChannel: 'code_quality_auditor',
+  ciFailureTriageSlackChannel: 'ci_failure_triage',
+} as const satisfies Record<
+  AutomationSlackDestinationField,
+  BackgroundAutomationKey
+>;
+
 type SlackChannelOption = {
   id: string;
   name: string;
@@ -180,6 +198,22 @@ type AutomationDefinition = {
   description: string;
   icon: ComponentType<{ className?: string }>;
   availability?: 'stable' | 'beta';
+  /** Compact label for the chat surfaces the automation can report to. */
+  commsBadge?: string;
+  /** Compact label for the source-control providers the automation supports. */
+  scmBadge?: string;
+};
+
+/**
+ * Where an automation's next run will report, as resolved server-side through
+ * the destination waterfall (own target -> Manager Channel -> primary
+ * conversation).
+ */
+type ResolvedAutomationDestinationSummary = {
+  provider: CommunicationProvider;
+  channelId: string;
+  source: 'automation_target' | 'manager_channel' | 'primary_conversation';
+  displayName: string | null;
 };
 
 /**
@@ -260,6 +294,48 @@ const TRIGGERABLE_AUTOMATION_SCHEDULE_LABELS = {
   weekly: 'Once a week',
 } as const;
 
+/**
+ * Informational capability badges derived from the automation descriptor:
+ * which chat surfaces its reports can go to and which source-control
+ * providers its scans work with today.
+ */
+function getAutomationCapabilityBadges(
+  automationKey: BackgroundAutomationKey,
+): Pick<AutomationDefinition, 'commsBadge' | 'scmBadge'> {
+  const descriptor =
+    getTriggerableBackgroundAutomationDescriptorByKey(automationKey);
+
+  if (!descriptor) {
+    return {};
+  }
+
+  const comms: readonly CommunicationProvider[] =
+    descriptor.supportedCommunicationProviders;
+  const showCommsBadge =
+    comms.length > 1 || comms.some((provider) => provider !== 'slack');
+  const commsBadge = showCommsBadge
+    ? comms.length === communicationProviders.length
+      ? 'All chat channels'
+      : comms.map(getCommunicationProviderDisplayName).join(' · ')
+    : undefined;
+
+  const scm: readonly SourceControlProvider[] =
+    descriptor.supportedSourceControlProviders;
+  const scmBadge =
+    scm.length === 0
+      ? undefined
+      : scm.length === sourceControlProviders.length
+        ? 'All source control'
+        : scm.length === 1 && scm[0] === 'github'
+          ? 'GitHub only'
+          : scm.map(getSourceControlProviderLabel).join(' · ');
+
+  return {
+    ...(commsBadge ? { commsBadge } : {}),
+    ...(scmBadge ? { scmBadge } : {}),
+  };
+}
+
 function getAutomationDefinition(
   automationId: AutomationId,
   automationKey: keyof typeof TRIGGERABLE_AUTOMATION_DESCRIPTIONS,
@@ -278,6 +354,7 @@ function getAutomationDefinition(
     description: TRIGGERABLE_AUTOMATION_DESCRIPTIONS[automationKey],
     icon,
     availability: descriptor.availability,
+    ...getAutomationCapabilityBadges(automationKey),
   };
 }
 
@@ -338,6 +415,7 @@ const SCHEDULE_ONLY_AUTOMATION_DEFINITIONS = Object.fromEntries(
         SCHEDULE_ONLY_AUTOMATION_UI_DEFINITIONS[automation.id].description,
       icon: SCHEDULE_ONLY_AUTOMATION_UI_DEFINITIONS[automation.id].icon,
       availability: automation.availability,
+      ...getAutomationCapabilityBadges(automation.automationKey),
     },
   ]),
 ) as unknown as Record<
@@ -1015,6 +1093,37 @@ function SlackChannelAccessWarning({
   );
 }
 
+const DESTINATION_SOURCE_LABELS: Record<
+  ResolvedAutomationDestinationSummary['source'],
+  string
+> = {
+  automation_target: "this automation's channel",
+  manager_channel: 'Manager Channel',
+  primary_conversation: 'primary conversation (automatic)',
+};
+
+function AutomationReportsToLine({
+  destination,
+}: {
+  destination: ResolvedAutomationDestinationSummary | null | undefined;
+}) {
+  if (!destination) {
+    return (
+      <p className="text-xs text-muted-foreground md:max-w-160">
+        Reports to: not configured — set a Manager Channel.
+      </p>
+    );
+  }
+
+  return (
+    <p className="text-xs text-muted-foreground md:max-w-160">
+      Reports to {destination.displayName ?? destination.channelId} (
+      {getCommunicationProviderDisplayName(destination.provider)}) —{' '}
+      {DESTINATION_SOURCE_LABELS[destination.source]}
+    </p>
+  );
+}
+
 function AutomationSlackDestinationInput({
   inputId,
   label,
@@ -1025,6 +1134,7 @@ function AutomationSlackDestinationInput({
   showWarning,
   slackAppMention,
   error,
+  destination,
   onChange,
 }: {
   inputId: string;
@@ -1036,6 +1146,7 @@ function AutomationSlackDestinationInput({
   showWarning: boolean;
   slackAppMention: string;
   error?: string;
+  destination: ResolvedAutomationDestinationSummary | null | undefined;
   onChange: (value: string | null) => void;
 }) {
   return (
@@ -1059,6 +1170,7 @@ function AutomationSlackDestinationInput({
           {helperText}
         </p>
       ) : null}
+      <AutomationReportsToLine destination={destination} />
       {showWarning ? (
         <SlackChannelAccessWarning slackAppMention={slackAppMention} />
       ) : null}
@@ -1316,6 +1428,16 @@ function AutomationTitle({ automation }: { automation: AutomationDefinition }) {
       <span>{automation.label}</span>
       {automation.availability === 'beta' ? (
         <Badge variant="secondary">Beta</Badge>
+      ) : null}
+      {automation.commsBadge ? (
+        <Badge variant="outline" className="font-normal text-muted-foreground">
+          {automation.commsBadge}
+        </Badge>
+      ) : null}
+      {automation.scmBadge ? (
+        <Badge variant="outline" className="font-normal text-muted-foreground">
+          {automation.scmBadge}
+        </Badge>
       ) : null}
     </span>
   );
@@ -2066,6 +2188,11 @@ export function AutomationsSettings() {
           value={value || null}
           options={buildSlackDestinationOptions(value)}
           disabled={getSlackDestinationSelectionDisabled(value, savedChannelId)}
+          destination={
+            settingsQuery.data?.resolvedDestinations[
+              SLACK_DESTINATION_FIELD_AUTOMATION_KEYS[field]
+            ]
+          }
           slackAppMention={slackAppMention}
           showWarning={shouldShowManagerSlackChannelWarning({
             formValue: value,
@@ -2106,6 +2233,7 @@ export function AutomationsSettings() {
       formState,
       getSlackDestinationSelectionDisabled,
       isDirty,
+      settingsQuery.data,
       slackAppMention,
     ],
   );
@@ -3044,9 +3172,11 @@ export function AutomationsSettings() {
                 <div className="space-y-5">
                   {!suggestionRoutingEnabled ? (
                     <>
-                      <p className="text-xs text-muted-foreground md:max-w-160">
-                        Posts to the Manager Channel.
-                      </p>
+                      <AutomationReportsToLine
+                        destination={
+                          settingsQuery.data?.resolvedDestinations.suggester
+                        }
+                      />
 
                       <div className="space-y-2">
                         <Label htmlFor="suggester-instructions">
@@ -3318,9 +3448,11 @@ If unclear, send to manager channel.`}
 
               {announcerIsEnabled ? (
                 <div className="space-y-5">
-                  <p className="text-xs text-muted-foreground md:max-w-160">
-                    Posts to the Manager Channel.
-                  </p>
+                  <AutomationReportsToLine
+                    destination={
+                      settingsQuery.data?.resolvedDestinations.announcer
+                    }
+                  />
 
                   <div className="space-y-2">
                     <Label htmlFor="announcer-instructions">

--- a/apps/web/src/trpc/commands/automations/index.ts
+++ b/apps/web/src/trpc/commands/automations/index.ts
@@ -9,5 +9,8 @@ export type {
 export { getBackgroundAgentSettingsCommand } from './settings-read';
 export { updateBackgroundAgentSettingsCommand } from './settings-update';
 export { listSlackChannelsCommand } from './slack-channels';
-export type { SlackChannelDisplayNames } from './types';
+export type {
+  ResolvedAutomationDestinations,
+  SlackChannelDisplayNames,
+} from './types';
 export { triggerAutomationCommand } from './trigger-agent';

--- a/apps/web/src/trpc/commands/automations/settings-read.ts
+++ b/apps/web/src/trpc/commands/automations/settings-read.ts
@@ -8,11 +8,17 @@ import {
 import {
   db,
   desc,
+  getAutomationRuntime,
   getBackgroundAgentSettingsForDeployment,
   inArray,
   listAutomations,
   tasks,
 } from '@roomote/db/server';
+import {
+  findTeamsConversationDisplayName,
+  resolveAutomationRuntimeDestination,
+  type ResolvedAutomationDestination,
+} from '@roomote/sdk/server';
 import { resolveConfiguredGitHubAppSlug } from '@roomote/github';
 import { SlackNotifier } from '@roomote/slack';
 
@@ -37,7 +43,11 @@ import {
   getSlackChannelDisplayNames,
   REQUIRED_BACKGROUND_AGENT_SCOPES,
 } from './slack-channels';
-import type { SlackChannelDisplayNames } from './types';
+import {
+  MANAGER_REPORTING_AUTOMATION_KEYS,
+  type ResolvedAutomationDestinations,
+  type SlackChannelDisplayNames,
+} from './types';
 
 /**
  * Automation run history is the tasks the automation launched
@@ -150,6 +160,65 @@ async function buildAutomationStatus(): Promise<
   return status;
 }
 
+async function resolveDestinationDisplayName(
+  destination: ResolvedAutomationDestination,
+  notifier: SlackNotifier | null,
+): Promise<string | null> {
+  if (destination.provider === 'slack') {
+    const channelName = notifier
+      ? await notifier.getChannelName(destination.channelId)
+      : null;
+
+    return channelName ? `#${channelName}` : null;
+  }
+
+  if (destination.provider === 'teams') {
+    return findTeamsConversationDisplayName(destination.channelId);
+  }
+
+  // Telegram chats have no reliable display name; the UI shows the chat id.
+  return null;
+}
+
+/**
+ * Resolves, per manager-reporting automation, where its next run will report
+ * (destination waterfall: own target -> Manager Channel -> primary
+ * conversation) so the settings page can show a "Reports to" line.
+ */
+async function resolveAutomationDestinations(params: {
+  slackConnected: boolean;
+  notifier: SlackNotifier | null;
+}): Promise<ResolvedAutomationDestinations> {
+  const entries = await Promise.all(
+    MANAGER_REPORTING_AUTOMATION_KEYS.map(async (key) => {
+      const runtime = await getAutomationRuntime(key);
+      const destination = await resolveAutomationRuntimeDestination({
+        runtime,
+        slackConnected: params.slackConnected,
+      });
+
+      if (!destination) {
+        return [key, null] as const;
+      }
+
+      return [
+        key,
+        {
+          provider: destination.provider,
+          channelId: destination.channelId,
+          source: destination.source,
+          displayName: await resolveDestinationDisplayName(
+            destination,
+            params.notifier,
+          ),
+        },
+      ] as const;
+    }),
+  );
+
+  return Object.fromEntries(entries) as ResolvedAutomationDestinations;
+}
+
 export async function getBackgroundAgentSettingsCommand(
   auth: UserAuthSuccess,
 ): Promise<{
@@ -190,6 +259,7 @@ export async function getBackgroundAgentSettingsCommand(
     ciFailureTriageSlackChannel: string | null;
   };
   slackChannelDisplayNames: SlackChannelDisplayNames;
+  resolvedDestinations: ResolvedAutomationDestinations;
   recentRuns: Partial<
     Record<BackgroundAutomationKey, AutomationTaskRunSummary[]>
   >;
@@ -267,6 +337,10 @@ export async function getBackgroundAgentSettingsCommand(
     ciFailureTriageSlackChannelId:
       visibleSettings.ciFailureTriageSlackChannelId,
   });
+  const resolvedDestinations = await resolveAutomationDestinations({
+    slackConnected: Boolean(slackInstallation?.isActive),
+    notifier,
+  });
 
   // The reviewer mapping derives its managed-login list synchronously from
   // the cached configured app slug.
@@ -292,6 +366,7 @@ export async function getBackgroundAgentSettingsCommand(
     },
     slackChannelAccessWarnings,
     slackChannelDisplayNames,
+    resolvedDestinations,
     recentRuns,
     automationStatus: status,
   };

--- a/apps/web/src/trpc/commands/automations/types.ts
+++ b/apps/web/src/trpc/commands/automations/types.ts
@@ -1,6 +1,8 @@
 import type {
   AnnouncerFrequency,
+  BackgroundAutomationKey,
   ChannelAutoStartLaunchMode,
+  CommunicationProvider,
   ConflictResolverMaxPrAgeDays,
   ConflictResolverFrequency,
   DependabotTriageFrequency,
@@ -86,6 +88,42 @@ export interface SlackChannelDisplayNames {
   codeQualityAuditorSlackChannel: string | null;
   ciFailureTriageSlackChannel: string | null;
 }
+
+/**
+ * Automations whose reports flow through the manager-channel destination
+ * waterfall (own target -> Manager Channel -> primary conversation).
+ */
+export const MANAGER_REPORTING_AUTOMATION_KEYS = [
+  'manager_stats',
+  'sentry_triage',
+  'dependabot_triage',
+  'security_auditor',
+  'code_quality_auditor',
+  'ci_failure_triage',
+  'suggester',
+  'announcer',
+] as const satisfies readonly BackgroundAutomationKey[];
+
+export type ManagerReportingAutomationKey =
+  (typeof MANAGER_REPORTING_AUTOMATION_KEYS)[number];
+
+/**
+ * Where an automation's next run will report, resolved through the runtime
+ * destination waterfall, plus which waterfall level produced it and a
+ * human-readable channel name when one is resolvable.
+ */
+export interface ResolvedAutomationDestinationSummary {
+  provider: CommunicationProvider;
+  channelId: string;
+  source: 'automation_target' | 'manager_channel' | 'primary_conversation';
+  /** e.g. "#eng-managers" (Slack) or a Teams channel/team name; null when unknown. */
+  displayName: string | null;
+}
+
+export type ResolvedAutomationDestinations = Record<
+  ManagerReportingAutomationKey,
+  ResolvedAutomationDestinationSummary | null
+>;
 
 export interface ChannelAutoStartInputRow {
   // Canonical Slack channel ID persisted for this row. When present and valid it

--- a/packages/db/src/lib/automations.ts
+++ b/packages/db/src/lib/automations.ts
@@ -228,6 +228,8 @@ export function resolveAutomationSlackChannelId(
 export type AutomationDestination = {
   provider: 'slack' | 'teams' | 'telegram';
   channelId: string;
+  /** Which waterfall level produced this destination. */
+  source: 'automation_target' | 'manager_channel';
 };
 
 const DESTINATION_TARGET_KINDS = [
@@ -255,12 +257,16 @@ export function resolveAutomationDestination(
     )[0];
 
     if (channelId) {
-      return { provider, channelId };
+      return { provider, channelId, source: 'automation_target' };
     }
   }
 
   return managerSlackChannelId
-    ? { provider: 'slack', channelId: managerSlackChannelId }
+    ? {
+        provider: 'slack',
+        channelId: managerSlackChannelId,
+        source: 'manager_channel',
+      }
     : null;
 }
 

--- a/packages/sdk/src/server/automations/__tests__/destination.test.ts
+++ b/packages/sdk/src/server/automations/__tests__/destination.test.ts
@@ -95,10 +95,20 @@ describe('resolveAutomationRuntimeDestination', () => {
   it('returns a slack destination as-is', async () => {
     await expect(
       resolveAutomationRuntimeDestination({
-        runtime: { destination: { provider: 'slack', channelId: 'C123' } },
+        runtime: {
+          destination: {
+            provider: 'slack',
+            channelId: 'C123',
+            source: 'manager_channel',
+          },
+        },
         slackConnected: true,
       }),
-    ).resolves.toEqual({ provider: 'slack', channelId: 'C123' });
+    ).resolves.toEqual({
+      provider: 'slack',
+      channelId: 'C123',
+      source: 'manager_channel',
+    });
   });
 
   it('resolves the serviceUrl for a teams destination', async () => {
@@ -109,7 +119,11 @@ describe('resolveAutomationRuntimeDestination', () => {
     await expect(
       resolveAutomationRuntimeDestination({
         runtime: {
-          destination: { provider: 'teams', channelId: '19:conv@thread.v2' },
+          destination: {
+            provider: 'teams',
+            channelId: '19:conv@thread.v2',
+            source: 'automation_target',
+          },
         },
         slackConnected: false,
       }),
@@ -117,6 +131,7 @@ describe('resolveAutomationRuntimeDestination', () => {
       provider: 'teams',
       channelId: '19:conv@thread.v2',
       serviceUrl: 'https://smba.example/amer/',
+      source: 'automation_target',
     });
   });
 
@@ -126,7 +141,11 @@ describe('resolveAutomationRuntimeDestination', () => {
     await expect(
       resolveAutomationRuntimeDestination({
         runtime: {
-          destination: { provider: 'teams', channelId: '19:conv@thread.v2' },
+          destination: {
+            provider: 'teams',
+            channelId: '19:conv@thread.v2',
+            source: 'automation_target',
+          },
         },
         slackConnected: false,
       }),
@@ -159,6 +178,7 @@ describe('resolveAutomationRuntimeDestination', () => {
       provider: 'teams',
       channelId: '19:primary@thread.v2',
       serviceUrl: 'https://smba.example/amer/',
+      source: 'primary_conversation',
     });
   });
 
@@ -171,7 +191,11 @@ describe('resolveAutomationRuntimeDestination', () => {
         runtime: { destination: null },
         slackConnected: false,
       }),
-    ).resolves.toEqual({ provider: 'telegram', channelId: '-100123' });
+    ).resolves.toEqual({
+      provider: 'telegram',
+      channelId: '-100123',
+      source: 'primary_conversation',
+    });
   });
 });
 
@@ -181,6 +205,7 @@ describe('payload fields and prompt context', () => {
       buildDestinationTaskPayloadFields({
         provider: 'slack',
         channelId: 'C123',
+        source: 'manager_channel',
       }),
     ).toEqual({});
   });
@@ -191,6 +216,7 @@ describe('payload fields and prompt context', () => {
         provider: 'teams',
         channelId: '19:conv@thread.v2',
         serviceUrl: 'https://smba.example/amer/',
+        source: 'automation_target',
       }),
     ).toEqual({
       communicationProvider: 'teams',
@@ -201,14 +227,22 @@ describe('payload fields and prompt context', () => {
 
   it('builds surface-correct prompt context', () => {
     expect(
-      buildDestinationPromptContext({ provider: 'slack', channelId: 'C1' }),
+      buildDestinationPromptContext({
+        provider: 'slack',
+        channelId: 'C1',
+        source: 'manager_channel',
+      }),
     ).toEqual({
       channelTag: 'slack_channel_id',
       postToolName: 'post_to_slack_channel',
       surfaceLabel: 'Slack',
     });
     expect(
-      buildDestinationPromptContext({ provider: 'telegram', channelId: '1' }),
+      buildDestinationPromptContext({
+        provider: 'telegram',
+        channelId: '1',
+        source: 'automation_target',
+      }),
     ).toEqual({
       channelTag: 'channel_id',
       postToolName: 'post_to_channel',

--- a/packages/sdk/src/server/automations/destination.ts
+++ b/packages/sdk/src/server/automations/destination.ts
@@ -20,6 +20,8 @@ export type ResolvedAutomationDestination = {
   channelId: string;
   /** Bot Framework serviceUrl; present for Teams destinations. */
   serviceUrl?: string;
+  /** Which waterfall level produced this destination. */
+  source: 'automation_target' | 'manager_channel' | 'primary_conversation';
 };
 
 /**
@@ -47,6 +49,30 @@ export async function listConnectedCommunicationProviders(): Promise<
       : []),
     ...(telegramCredentials.botToken ? (['telegram'] as const) : []),
   ];
+}
+
+/**
+ * Human-readable name for a Teams destination conversation: the channel name
+ * when known, else the team name. Null when the conversation is unknown.
+ */
+export async function findTeamsConversationDisplayName(
+  conversationId: string,
+): Promise<string | null> {
+  const [row] = await db
+    .select({
+      channelName: teamsInstallations.channelName,
+      teamName: teamsInstallations.teamName,
+    })
+    .from(teamsInstallations)
+    .where(
+      and(
+        eq(teamsInstallations.conversationId, conversationId),
+        eq(teamsInstallations.isActive, true),
+      ),
+    )
+    .limit(1);
+
+  return row?.channelName ?? row?.teamName ?? null;
 }
 
 async function findTeamsConversationServiceUrl(
@@ -104,12 +130,17 @@ export async function resolveAutomationRuntimeDestination(params: {
       provider: 'teams',
       channelId: teamsConversation.conversationId,
       serviceUrl: teamsConversation.serviceUrl,
+      source: 'primary_conversation',
     };
   }
 
   const telegramChatId = await findTelegramPrimaryChatId();
   if (telegramChatId) {
-    return { provider: 'telegram', channelId: telegramChatId };
+    return {
+      provider: 'telegram',
+      channelId: telegramChatId,
+      source: 'primary_conversation',
+    };
   }
 
   return null;

--- a/packages/sdk/src/server/automations/index.ts
+++ b/packages/sdk/src/server/automations/index.ts
@@ -9,6 +9,7 @@ export { sentryTriageJob } from './sentry-triage';
 export { suggesterJob } from './suggester';
 export { getAutomationRunner, runAutomationNow } from './run-now';
 export {
+  findTeamsConversationDisplayName,
   listConnectedCommunicationProviders,
   resolveAutomationRuntimeDestination,
   type ResolvedAutomationDestination,


### PR DESCRIPTION
## What

Final PR of the "automations everywhere" track (follows #280, #281, #284, #285, #289, #291, #293, #305). This is the piece from the original ask: *"maybe at least show it on the automations page."*

- **"Reports to" line on every manager-reporting automation card**: resolved destination with display name and the waterfall level that produced it — `Reports to #eng-managers (Slack) — Manager Channel`, `— this automation's channel`, or `— primary conversation (automatic)`; a clear "not configured — set a Manager Channel" fallback otherwise. The destination resolvers now attribute the winning waterfall level, and the settings read exposes per-automation resolved destinations (Slack names via the notifier, Teams via `teamsInstallations` channel/team name, Telegram as raw chat id).
- **Capability badges** next to each automation title, from the registry declarations: "All chat channels" for the six generalized reporters, per-provider names otherwise; "All source control" / "GitHub only" for the SCM side — so the honestly-still-GitHub-only automations (Dependabot, CI failure triage, the auditors, conflict resolver) say so instead of implying otherwise.
- **Docs**: `apps/docs/automations.mdx` documents the reporting waterfall and badges.

## Draft status

Held as draft pending the live Teams / mock-Telegram validation of the destination pipeline (#291/#305) running in a separate session — this PR is what makes those paths user-visible, so the claim gets verified before it ships.

## Testing

- Render tests: destination line (configured + not-configured), badge counts per automation
- Full suites green: web (1987), sdk (476), types (545), db (257); lint/types/knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)