### PR TITLE
Run Modal setup tasks in VM runtime

### DIFF
--- a/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
+++ b/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
@@ -14,6 +14,7 @@ const mockCreateComputeProviderMutationEventRecorder = vi.fn(
 const mockUpdateWhere = vi.fn().mockResolvedValue(undefined);
 const mockUpdateSet = vi.fn(() => ({ where: mockUpdateWhere }));
 const mockDbUpdate = vi.fn(() => ({ set: mockUpdateSet }));
+const mockFindTask = vi.fn();
 const mockUpdateTaskRunMachine = vi.fn();
 const mockGetNamedPortsForTaskRun = vi.fn();
 const mockShouldEnableAuthBypassForTaskRun = vi.fn(
@@ -26,6 +27,7 @@ function mockTaskRun(
 ): TaskRun {
   return {
     id: 123,
+    taskId: 'task_123',
     vendor: 'modal',
     sourceSnapshotId: null,
     payload: { repo: 'test/repo' },
@@ -40,6 +42,12 @@ vi.mock('@roomote/db/server', async (importOriginal) => {
     ...actual,
     db: {
       ...actual.db,
+      query: {
+        ...actual.db.query,
+        tasks: {
+          findFirst: (...args: unknown[]) => mockFindTask(...args),
+        },
+      },
       update: () => mockDbUpdate(),
     },
     createComputeProviderMutationEventRecorder:
@@ -87,6 +95,7 @@ describe('spawnModalWorker', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockShouldEnableAuthBypassForTaskRun.mockReturnValue(true);
+    mockFindTask.mockResolvedValue({ workflow: 'standard' });
     delete process.env.PREVIEW_PROXY_BASE_URL;
 
     mockCreateModalMachine.mockResolvedValue({
@@ -175,6 +184,39 @@ describe('spawnModalWorker', () => {
       }),
     );
     expect(mockCreateModalMachine).toHaveBeenCalled();
+    expect(mockFindTask).not.toHaveBeenCalled();
+  });
+
+  it('uses a Modal VM sandbox for setup onboarding before an environment config exists', async () => {
+    mockFindTask.mockResolvedValue({ workflow: 'setup_onboarding' });
+
+    await spawnModalWorker(
+      mockTaskRun({
+        payloadKind: TaskPayloadKind.StandardTask,
+        payload: { repo: 'test/repo' },
+      }),
+      'auth_token',
+      {
+        deploymentSlug: 'roomote',
+        modalTokenId: 'token-id',
+        modalTokenSecret: 'token-secret',
+        modalBaseImageRef: 'image-ref',
+        modalTimeoutMs: 60_000,
+      },
+    );
+
+    expect(mockFindTask).toHaveBeenCalledOnce();
+    expect(mockCreateComputeProviderClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'modal',
+        config: expect.objectContaining({
+          vmRuntime: true,
+          cpu: 2,
+          memoryMiB: 4096,
+        }),
+      }),
+    );
+    expect(mockCreateModalMachine).toHaveBeenCalled();
   });
 
   it('primes environment OIDC before launching a fresh Modal worker when the environment defines OIDC targets', async () => {
@@ -219,6 +261,7 @@ describe('spawnModalWorker', () => {
       computeProvider: 'modal',
       computeProviderId: 'modal-machine-123',
       runId: 123,
+      taskId: 'task_123',
       context: 'Fresh Modal launch',
     });
   });

--- a/apps/controller/src/compute-providers/spawn-modal-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-modal-worker.ts
@@ -8,6 +8,7 @@ import {
   type TaskRun,
   createComputeProviderMutationEventRecorder,
   db,
+  tasks,
   taskRuns,
   eq,
 } from '@roomote/db/server';
@@ -113,6 +114,26 @@ function getWorkerLaunchArgs(taskRun: TaskRun, machineId: string): string[] {
     : [command, taskRun.id.toString()];
 }
 
+async function needsModalVmRuntime(
+  taskRun: TaskRun,
+  environmentConfig: Awaited<
+    ReturnType<typeof getNamedPortsForTaskRun>
+  >['environmentConfig'],
+): Promise<boolean> {
+  if (environmentConfig?.docker_projects?.length) {
+    return true;
+  }
+
+  const task = await db.query.tasks.findFirst({
+    where: eq(tasks.id, taskRun.taskId),
+    columns: { workflow: true },
+  });
+
+  // Environment setup must be able to discover and validate Docker projects
+  // before an environment config exists to advertise that requirement.
+  return task?.workflow === 'setup_onboarding';
+}
+
 export async function spawnModalWorker(
   taskRun: TaskRun,
   authToken: string,
@@ -161,7 +182,7 @@ export async function spawnModalWorker(
   const { namedPorts, environmentSnapshotId, environmentConfig } =
     await getNamedPortsForTaskRun(taskRun);
 
-  const needsVmRuntime = Boolean(environmentConfig?.docker_projects?.length);
+  const useVmRuntime = await needsModalVmRuntime(taskRun, environmentConfig);
 
   const shouldEnableAuthBypass = shouldEnableAuthBypassForTaskRun({
     environmentConfig,
@@ -251,7 +272,7 @@ export async function spawnModalWorker(
 
   const configuredResources = resolveConfiguredComputeProviderResources({
     provider: 'modal',
-    ...(needsVmRuntime
+    ...(useVmRuntime
       ? { configuredCpuCores: 2, configuredMemoryMiB: 4096 }
       : {}),
   });
@@ -271,7 +292,7 @@ export async function spawnModalWorker(
     ...(modalEcrOidcRoleArn ? { ecrOidcRoleArn: modalEcrOidcRoleArn } : {}),
     ...(modalEcrRegion ? { ecrRegion: modalEcrRegion } : {}),
     ...(parsedModalRegions ? { regions: parsedModalRegions } : {}),
-    ...(needsVmRuntime ? { vmRuntime: true } : {}),
+    ...(useVmRuntime ? { vmRuntime: true } : {}),
     ...(configuredResources.configuredCpuCores !== null
       ? { cpu: configuredResources.configuredCpuCores }
       : {}),


### PR DESCRIPTION
## What changed

- Select Modal VM runtime for `setup_onboarding` tasks before an environment configuration exists.
- Preserve the existing VM selection for environments that already declare Docker projects.
- Add regression coverage for setup onboarding and the existing Docker-project path.

## Why

Environment setup is responsible for discovering and validating Docker-based development workflows. The Modal launcher previously enabled VM runtime only when an existing environment config already declared `docker_projects`. New setup tasks do not have that config yet, so they launched in the standard gVisor sandbox where Docker is present but cannot start containers.

This change uses the task workflow as the bootstrap signal, allowing setup tasks to run Docker validation while keeping ordinary non-Docker tasks on the standard runtime.

## Validation

- Controller test suite: 102 passed, 2 skipped
- `pnpm --filter @roomote/controller check-types`
- `pnpm --filter @roomote/controller lint`
- `pnpm --filter @roomote/controller format:check`
- Pre-push `lint:fast`, `check-types:fast`, and `knip`
