### PR TITLE
Prefer release worker image for Modal

### DIFF
--- a/packages/db/src/lib/__tests__/compute-runtime-config.test.ts
+++ b/packages/db/src/lib/__tests__/compute-runtime-config.test.ts
@@ -56,12 +56,31 @@ describe('resolveComputeProviderEnvValues', () => {
     );
   });
 
-  it('prefers a saved deployment env var over the derived worker image', async () => {
+  it('prefers the release-derived worker image over a saved Modal base image', async () => {
     const values = await resolveComputeProviderEnvValues('modal', {
       runtimeEnv: {
         MODAL_TOKEN_ID: 'id',
         MODAL_TOKEN_SECRET: 'secret',
         RELEASE_VERSION: 'v1.2.3',
+      },
+      executor: makeExecutor([
+        {
+          name: 'MODAL_BASE_IMAGE_REF',
+          value: 'registry.example.com/saved:tag',
+        },
+      ]),
+    });
+
+    expect(values.MODAL_BASE_IMAGE_REF).toBe(
+      'ghcr.io/roocodeinc/roomote-worker:v1.2.3',
+    );
+  });
+
+  it('uses a saved Modal base image when no runtime worker image is derivable', async () => {
+    const values = await resolveComputeProviderEnvValues('modal', {
+      runtimeEnv: {
+        MODAL_TOKEN_ID: 'id',
+        MODAL_TOKEN_SECRET: 'secret',
       },
       executor: makeExecutor([
         {

--- a/packages/db/src/lib/compute-runtime-config.ts
+++ b/packages/db/src/lib/compute-runtime-config.ts
@@ -5,6 +5,7 @@ import {
   SETUP_COMPUTE_PROVIDER_CATALOG,
   SETUP_COMPUTE_PROVIDER_IDS,
   SHARED_WORKER_IMAGE_ENV_VAR,
+  deriveModalBaseImageRefDefault,
   resolveDerivedModalBaseImageRef,
   deriveWorkerImageFromReleaseVersion,
   isRequiredComputeField,
@@ -176,11 +177,13 @@ export async function resolveDefaultComputeProvider(
 /**
  * Resolves the setup-catalog env values for one compute provider, preferring
  * the process env and falling back to encrypted deployment environment
- * variables saved during setup. For Modal, a still-missing base image ref
- * falls back to the deployment's effective worker image (the explicit
- * DOCKER_WORKER_IMAGE or the ref derived from the baked RELEASE_VERSION),
- * then the development-only GHCR latest image. The published worker image
- * doubles as the Modal base image.
+ * variables saved during setup. For Modal, an explicit process-level base
+ * image wins; otherwise the deployment's current worker image (the explicit
+ * DOCKER_WORKER_IMAGE or the ref derived from the baked RELEASE_VERSION)
+ * outranks a saved base image so upgrades cannot remain pinned to an older
+ * auto-derived worker image. Development finally falls back to the public
+ * GHCR channel image. The published worker image doubles as the Modal base
+ * image.
  */
 export async function resolveComputeProviderEnvValues(
   provider: ComputeProvider,
@@ -207,17 +210,33 @@ export async function resolveComputeProviderEnvValues(
   const resolvedValues: Partial<Record<string, string>> = {};
   const missingEnvVarNames: string[] = [];
 
+  const effectiveRuntimeWorkerImage =
+    runtimeEnv.DOCKER_WORKER_IMAGE?.trim() ||
+    deriveWorkerImageFromReleaseVersion(runtimeEnv) ||
+    undefined;
+  const runtimeManagedModalBaseImage =
+    provider === 'modal' && !runtimeEnv.MODAL_BASE_IMAGE_REF
+      ? deriveModalBaseImageRefDefault(effectiveRuntimeWorkerImage)
+      : null;
+
+  if (runtimeManagedModalBaseImage) {
+    resolvedValues.MODAL_BASE_IMAGE_REF = runtimeManagedModalBaseImage;
+  }
+
   for (const envVarName of envVarNames) {
     const runtimeValue = runtimeEnv[envVarName];
 
     if (runtimeValue) {
       resolvedValues[envVarName] = runtimeValue;
+    } else if (resolvedValues[envVarName]) {
+      continue;
     } else {
       missingEnvVarNames.push(envVarName);
     }
   }
 
   if (missingEnvVarNames.length > 0) {
+    const missingEnvVarNameSet = new Set(missingEnvVarNames);
     const encryptedEnvVars = await executor
       .select({
         name: environmentVariables.name,
@@ -227,6 +246,10 @@ export async function resolveComputeProviderEnvValues(
       .where(inArray(environmentVariables.name, missingEnvVarNames));
 
     for (const envVar of encryptedEnvVars) {
+      if (!missingEnvVarNameSet.has(envVar.name)) {
+        continue;
+      }
+
       const decryptedValue = await decryptSecrets<string>(envVar.value);
 
       if (decryptedValue === null) {
@@ -248,13 +271,9 @@ export async function resolveComputeProviderEnvValues(
   // workers back to a stale image. Development falls back to the public
   // latest image when no hosted image is derivable.
   if (provider === 'modal' && !resolvedValues.MODAL_BASE_IMAGE_REF) {
-    const effectiveWorkerImage =
-      runtimeEnv.DOCKER_WORKER_IMAGE?.trim() ||
-      deriveWorkerImageFromReleaseVersion(runtimeEnv) ||
-      undefined;
     const derivedBaseImageRef = resolveDerivedModalBaseImageRef({
       ...runtimeEnv,
-      DOCKER_WORKER_IMAGE: effectiveWorkerImage,
+      DOCKER_WORKER_IMAGE: effectiveRuntimeWorkerImage,
     });
 
     if (derivedBaseImageRef) {

--- a/packages/db/src/lib/compute-runtime-config.ts
+++ b/packages/db/src/lib/compute-runtime-config.ts
@@ -6,8 +6,8 @@ import {
   SETUP_COMPUTE_PROVIDER_IDS,
   SHARED_WORKER_IMAGE_ENV_VAR,
   deriveModalBaseImageRefDefault,
+  resolveEffectiveDockerWorkerImage,
   resolveDerivedModalBaseImageRef,
-  deriveWorkerImageFromReleaseVersion,
   isRequiredComputeField,
   isComputeProvider,
   normalizeDeploymentComputeConfig,
@@ -211,9 +211,7 @@ export async function resolveComputeProviderEnvValues(
   const missingEnvVarNames: string[] = [];
 
   const effectiveRuntimeWorkerImage =
-    runtimeEnv.DOCKER_WORKER_IMAGE?.trim() ||
-    deriveWorkerImageFromReleaseVersion(runtimeEnv) ||
-    undefined;
+    resolveEffectiveDockerWorkerImage(runtimeEnv) ?? undefined;
   const runtimeManagedModalBaseImage =
     provider === 'modal' && !runtimeEnv.MODAL_BASE_IMAGE_REF
       ? deriveModalBaseImageRefDefault(effectiveRuntimeWorkerImage)


### PR DESCRIPTION
## What changed

- Prefer an explicit or release-derived worker image over a previously saved Modal base image.
- Keep explicit Modal base-image overrides as the highest-priority setting.
- Preserve saved base-image fallback behavior when no runtime worker image can be derived.
- Add regression coverage for both precedence paths.

## Why

A previously auto-derived Modal base image could remain sticky across deployment upgrades. If runtime requirements changed, new sandboxes could boot an outdated worker image and exit before worker bootstrap.

## Validation

- Targeted compute runtime config tests (14 passing)
- `@roomote/db` typecheck, lint, and format check
- Repository pre-push lint, typecheck, and knip checks
- Verified the current release worker image contains Docker Engine and Compose
