### PR TITLE
Right-size sandbox memory for Docker workloads

### DIFF
--- a/apps/controller/src/RoomoteController.ts
+++ b/apps/controller/src/RoomoteController.ts
@@ -105,6 +105,7 @@ export class RoomoteController extends BaseController {
           modalEcrOidcRoleArn: Env.MODAL_ECR_OIDC_ROLE_ARN,
           modalEcrRegion: Env.MODAL_ECR_REGION,
           modalRegions: resolvedEnv.MODAL_REGIONS,
+          modalVmMemoryMiB: Env.MODAL_VM_MEMORY_MIB,
           modalTimeoutMs: timeoutMs,
           localTarballPath: this.localWorkerReleasePath,
         });

--- a/apps/controller/src/__tests__/RoomoteController.test.ts
+++ b/apps/controller/src/__tests__/RoomoteController.test.ts
@@ -21,6 +21,7 @@ const {
     MODAL_ECR_OIDC_ROLE_ARN: undefined,
     MODAL_ECR_REGION: undefined,
     MODAL_REGIONS: undefined,
+    MODAL_VM_MEMORY_MIB: 8192,
     TRPC_URL: 'http://localhost:13001',
     DOCKER_WORKER_IMAGE: 'roomote-worker:local',
     DOCKER_WORKER_PLATFORM: 'linux/amd64',
@@ -114,6 +115,7 @@ describe('RoomoteController', () => {
     mockEnv.MODAL_ECR_OIDC_ROLE_ARN = undefined;
     mockEnv.MODAL_ECR_REGION = undefined;
     mockEnv.MODAL_REGIONS = undefined;
+    mockEnv.MODAL_VM_MEMORY_MIB = 8192;
     mockEnv.TRPC_URL = 'http://localhost:13001';
     mockEnv.DOCKER_WORKER_IMAGE = 'roomote-worker:local';
     mockEnv.DOCKER_WORKER_PLATFORM = 'linux/amd64';
@@ -478,6 +480,7 @@ describe('RoomoteController', () => {
         modalRegistryUsername: 'ghcr-user',
         modalRegistryPassword: 'ghcr-token',
         modalRegions: 'us,us-west',
+        modalVmMemoryMiB: 8192,
       }),
     );
   });

--- a/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
+++ b/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
@@ -128,6 +128,7 @@ describe('spawnModalWorker', () => {
         modalTokenSecret: 'token-secret',
         modalBaseImageRef: 'image-ref',
         modalRegions: ' us , us-west ',
+        modalVmMemoryMiB: 8192,
         modalTimeoutMs: 60_000,
       },
     );
@@ -169,6 +170,7 @@ describe('spawnModalWorker', () => {
         modalTokenId: 'token-id',
         modalTokenSecret: 'token-secret',
         modalBaseImageRef: 'image-ref',
+        modalVmMemoryMiB: 12_288,
         modalTimeoutMs: 60_000,
       },
     );
@@ -179,7 +181,7 @@ describe('spawnModalWorker', () => {
         config: expect.objectContaining({
           vmRuntime: true,
           cpu: 2,
-          memoryMiB: 4096,
+          memoryMiB: 12_288,
         }),
       }),
     );
@@ -201,6 +203,7 @@ describe('spawnModalWorker', () => {
         modalTokenId: 'token-id',
         modalTokenSecret: 'token-secret',
         modalBaseImageRef: 'image-ref',
+        modalVmMemoryMiB: 8192,
         modalTimeoutMs: 60_000,
       },
     );
@@ -212,7 +215,7 @@ describe('spawnModalWorker', () => {
         config: expect.objectContaining({
           vmRuntime: true,
           cpu: 2,
-          memoryMiB: 4096,
+          memoryMiB: 8192,
         }),
       }),
     );
@@ -244,6 +247,7 @@ describe('spawnModalWorker', () => {
         modalTokenId: 'token-id',
         modalTokenSecret: 'token-secret',
         modalBaseImageRef: 'image-ref',
+        modalVmMemoryMiB: 8192,
         modalTimeoutMs: 60_000,
       },
     );
@@ -286,6 +290,7 @@ describe('spawnModalWorker', () => {
           modalTokenId: 'token-id',
           modalTokenSecret: 'token-secret',
           modalBaseImageRef: 'ghcr.io/roomote/modal-worker:test',
+          modalVmMemoryMiB: 8192,
           modalTimeoutMs: 60_000,
         },
       ),
@@ -347,6 +352,7 @@ describe('spawnModalWorker', () => {
         modalTokenId: 'token-id',
         modalTokenSecret: 'token-secret',
         modalBaseImageRef: 'ghcr.io/roomote/modal-worker:test',
+        modalVmMemoryMiB: 8192,
         modalTimeoutMs: 60_000,
       },
     );
@@ -379,6 +385,7 @@ describe('spawnModalWorker', () => {
         modalTokenId: 'token-id',
         modalTokenSecret: 'token-secret',
         modalBaseImageRef: 'ghcr.io/roomote/modal-worker:test',
+        modalVmMemoryMiB: 8192,
         modalTimeoutMs: 60_000,
       },
     );
@@ -410,6 +417,7 @@ describe('spawnModalWorker', () => {
         modalTokenId: 'token-id',
         modalTokenSecret: 'token-secret',
         modalBaseImageRef: 'ghcr.io/roomote/modal-worker:test',
+        modalVmMemoryMiB: 8192,
         modalTimeoutMs: 60_000,
       },
     );
@@ -443,6 +451,7 @@ describe('spawnModalWorker', () => {
           modalTokenId: 'token-id',
           modalTokenSecret: 'token-secret',
           modalBaseImageRef: 'ghcr.io/roomote/modal-worker:test',
+          modalVmMemoryMiB: 8192,
           modalTimeoutMs: 60_000,
         },
       ),

--- a/apps/controller/src/compute-providers/spawn-modal-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-modal-worker.ts
@@ -150,6 +150,8 @@ export async function spawnModalWorker(
     modalEcrRegion?: string;
     /** Comma-separated Modal placement region tokens (`MODAL_REGIONS`). */
     modalRegions?: string;
+    /** Memory allocation for VM sandboxes that run nested Docker workloads. */
+    modalVmMemoryMiB: number;
     modalTimeoutMs: number;
     localTarballPath?: string;
     deploymentSlug?: string;
@@ -171,6 +173,7 @@ export async function spawnModalWorker(
     modalEcrOidcRoleArn,
     modalEcrRegion,
     modalRegions,
+    modalVmMemoryMiB,
     modalTimeoutMs,
     localTarballPath,
     deploymentSlug,
@@ -273,7 +276,7 @@ export async function spawnModalWorker(
   const configuredResources = resolveConfiguredComputeProviderResources({
     provider: 'modal',
     ...(useVmRuntime
-      ? { configuredCpuCores: 2, configuredMemoryMiB: 4096 }
+      ? { configuredCpuCores: 2, configuredMemoryMiB: modalVmMemoryMiB }
       : {}),
   });
   const modalConfig = {

--- a/apps/docs/environment-variables.mdx
+++ b/apps/docs/environment-variables.mdx
@@ -219,6 +219,7 @@ as per-task auth tokens or workspace paths.
 | `MODAL_ENVIRONMENT`                  | Optional          | Modal environment name.                                                                                                                  |
 | `MODAL_APP_NAME`                     | Optional          | Modal app name override.                                                                                                                 |
 | `MODAL_REGIONS`                      | Optional          | Comma-separated Modal sandbox placement regions (for example `us` or `us-west`). Unset keeps Modal default placement.                    |
+| `MODAL_VM_MEMORY_MIB`                | Optional          | Memory allocated to Modal VM sandboxes used for nested Docker workloads. Defaults to `8192` MiB.                                         |
 | `E2B_API_KEY`                        | E2B               | E2B API key. Can also be saved from **Settings > Sandboxes**.                                                                            |
 | `E2B_DOMAIN`                         | Optional          | E2B domain for self-hosted or custom E2B clusters.                                                                                       |
 | `E2B_MAX_SANDBOX_TIMEOUT_MS`         | Optional          | Maximum E2B sandbox timeout Roomote will request. Defaults to one hour.                                                                  |

--- a/packages/env/src/__tests__/index.test.ts
+++ b/packages/env/src/__tests__/index.test.ts
@@ -102,6 +102,7 @@ describe('Env', () => {
       expect(env.DOCKER_WORKER_LOG_MAX_SIZE).toBe('10m');
       expect(env.DOCKER_WORKER_LOG_MAX_FILES).toBe(3);
       expect(env.DOCKER_WORKER_EGRESS_POLICY).toBe('internet');
+      expect(env.MODAL_VM_MEMORY_MIB).toBe(8192);
       expect(env.DOCKER_STANDBY_MAX_COUNT).toBe(10);
       expect(env.DOCKER_STANDBY_MAX_AGE_HOURS).toBe(24);
       expect(env.BLAXEL_STANDBY_MAX_COUNT).toBe(25);
@@ -145,6 +146,15 @@ describe('Env', () => {
     expect(
       createRoomoteEnv(runtimeEnv).DOCKER_WORKER_ALLOW_UNBOUNDED_DISK,
     ).toBe(true);
+  });
+
+  it('allows the Modal VM memory allocation to be overridden', () => {
+    const env = createRoomoteEnv({
+      ...process.env,
+      MODAL_VM_MEMORY_MIB: '12288',
+    });
+
+    expect(env.MODAL_VM_MEMORY_MIB).toBe(12_288);
   });
 
   it('derives DOCKER_WORKER_IMAGE from the baked release version', () => {

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -1,6 +1,7 @@
 import { createEnv } from '@t3-oss/env-nextjs';
 import {
   DEFAULT_LOCAL_DOCKER_WORKER_IMAGE,
+  MODAL_VM_DEFAULT_MEMORY_MIB,
   resolveEffectiveDockerWorkerImage,
 } from '@roomote/types';
 import { z } from 'zod';
@@ -205,6 +206,11 @@ const serverSchema = {
   MODAL_ECR_OIDC_ROLE_ARN: z.string().optional(),
   MODAL_ECR_REGION: z.string().optional(),
   MODAL_REGIONS: z.string().optional(),
+  MODAL_VM_MEMORY_MIB: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(MODAL_VM_DEFAULT_MEMORY_MIB),
   DAYTONA_API_KEY: z.string().optional(),
   DAYTONA_API_URL: z.string().url().optional(),
   DAYTONA_TARGET: z.string().optional(),
@@ -410,6 +416,7 @@ const OPTIONAL_NON_EMPTY_KEYS = new Set([
   'MODAL_ECR_OIDC_ROLE_ARN',
   'MODAL_ECR_REGION',
   'MODAL_REGIONS',
+  'MODAL_VM_MEMORY_MIB',
   'DAYTONA_API_KEY',
   'DAYTONA_API_URL',
   'DAYTONA_TARGET',

--- a/packages/types/src/compute-providers/worker-runtime.ts
+++ b/packages/types/src/compute-providers/worker-runtime.ts
@@ -14,6 +14,9 @@ export const SANDBOX_MEMORY_MIB_PER_VCPU = 2_048;
 export const SANDBOX_DEFAULT_MEMORY_MIB =
   SANDBOX_DEFAULT_VCPUS * SANDBOX_MEMORY_MIB_PER_VCPU;
 
+/** Default memory for Modal VM sandboxes that run nested Docker workloads. */
+export const MODAL_VM_DEFAULT_MEMORY_MIB = 8_192;
+
 export const SANDBOX_FILES_DIR = '/sandbox';
 
 export const SANDBOX_SNAPSHOT_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;


### PR DESCRIPTION
## What changed

- Centralize task sandbox memory policy at 8 GiB for nested Docker workloads and 4 GiB otherwise.
- Apply dynamic sizing to Modal, Daytona, and Blaxel sandbox launches.
- Keep the E2B template fixed at 8 GiB because its resources are selected at template build time.
- Give the local Docker provider a 4 GiB worker and an independently configurable 8 GiB nested-Docker daemon.
- Add `MODAL_VM_MEMORY_MIB` and `DOCKER_TASK_DAEMON_MEMORY_LIMIT` overrides.
- Ensure setup tasks receive Docker before an environment definition exists.
- Document and test provider behavior.

## Why

Nested Docker Compose workloads can saturate a 4 GiB allocation during image builds and multi-service startup, leaving too little memory for reliable readiness checks and agent execution. Ordinary tasks do not need that higher baseline.

## Validation

- Controller focused tests: 59 passing
- Compute provider adapter contract tests: 10 passing
- Environment tests: 58 passing
- Repository `lint:fast`, `check-types:fast`, and `knip` checks
- Pre-push validation passed
