### PR TITLE
Start Docker projects without blocking task startup

### DIFF
--- a/apps/worker/src/commands/__tests__/setup.test.ts
+++ b/apps/worker/src/commands/__tests__/setup.test.ts
@@ -352,7 +352,7 @@ describe('setup mode behavior', () => {
     });
   });
 
-  it('can continue after minimal environment setup while repository commands run in the background', async () => {
+  it('can continue after minimal environment setup while Docker projects and repository commands run in the background', async () => {
     const deferredBackgroundWarnings = [
       {
         message:
@@ -360,6 +360,14 @@ describe('setup mode behavior', () => {
       },
     ];
     let releaseBackgroundSetup: (() => void) | undefined;
+    let releaseDockerProjects: (() => void) | undefined;
+
+    mockInitializeDockerProjects.mockImplementationOnce(
+      async () =>
+        await new Promise<void>((resolve) => {
+          releaseDockerProjects = resolve;
+        }),
+    );
 
     mockExecuteOrganizationEnvironmentRepositoryCommands.mockImplementationOnce(
       async () => {
@@ -375,10 +383,11 @@ describe('setup mode behavior', () => {
       workspace: environmentWorkspaceOptions,
       logger,
       workerEnv: mockWorkerEnv,
-      backgroundOrganizationEnvironmentSetup: true,
+      backgroundEnvironmentSetup: true,
     });
 
     expect(mockSetupOrganizationEnvironment).not.toHaveBeenCalled();
+    expect(mockInitializeDockerProjects).toHaveBeenCalledTimes(1);
     expect(mockInstallOrganizationEnvironmentSkills).toHaveBeenCalledWith(
       logger,
       expect.objectContaining({
@@ -387,35 +396,81 @@ describe('setup mode behavior', () => {
     );
     expect(
       mockExecuteOrganizationEnvironmentRepositoryCommands,
-    ).toHaveBeenCalledWith(
-      logger,
-      expect.objectContaining({
-        environment: environmentWorkspaceOptions.workspace,
-        continueRepositoryCommandFailures: true,
-      }),
+    ).not.toHaveBeenCalled();
+    expect(result.preparedWorkspace?.environmentSetupWarnings).toEqual([
+      {
+        message:
+          'Environment setup is still running in the background. Docker projects may still be building or waiting for health checks, and repository setup commands may still be installing dependencies or preparing services.',
+      },
+    ]);
+    expect(result.backgroundEnvironmentSetup).toBeDefined();
+
+    releaseDockerProjects?.();
+    await vi.waitFor(() => {
+      expect(
+        mockExecuteOrganizationEnvironmentRepositoryCommands,
+      ).toHaveBeenCalledWith(
+        logger,
+        expect.objectContaining({
+          environment: environmentWorkspaceOptions.workspace,
+          continueRepositoryCommandFailures: true,
+        }),
+      );
+    });
+    releaseBackgroundSetup?.();
+    await expect(result.backgroundEnvironmentSetup).resolves.toEqual(
+      deferredBackgroundWarnings,
     );
     expect(result.preparedWorkspace?.environmentSetupWarnings).toEqual([
       {
         message:
-          'Environment setup is still running in the background. Repository setup commands may still be installing dependencies or preparing services.',
-      },
-    ]);
-    expect(result.backgroundOrganizationEnvironmentSetup).toBeDefined();
-
-    releaseBackgroundSetup?.();
-    await expect(
-      result.backgroundOrganizationEnvironmentSetup,
-    ).resolves.toEqual(deferredBackgroundWarnings);
-    expect(result.preparedWorkspace?.environmentSetupWarnings).toEqual([
-      {
-        message:
-          'Environment setup is still running in the background. Repository setup commands may still be installing dependencies or preparing services.',
+          'Environment setup is still running in the background. Docker projects may still be building or waiting for health checks, and repository setup commands may still be installing dependencies or preparing services.',
       },
       {
         message:
           'Optional environment command "pnpm install" failed for owner/repo: Command failed with exit code 1',
       },
     ]);
+  });
+
+  it('reports a background Docker project failure without failing task startup', async () => {
+    mockInitializeDockerProjects.mockRejectedValueOnce(
+      new Error('backend failed its health check'),
+    );
+
+    const result = await setup({
+      mode: 'full',
+      workspace: environmentWorkspaceOptions,
+      logger,
+      workerEnv: mockWorkerEnv,
+      backgroundEnvironmentSetup: true,
+    });
+
+    await expect(result.backgroundEnvironmentSetup).resolves.toEqual([
+      {
+        message:
+          'Background Docker project setup failed: backend failed its health check',
+      },
+    ]);
+    expect(result.preparedWorkspace?.environmentSetupWarnings).toContainEqual({
+      message:
+        'Background Docker project setup failed: backend failed its health check',
+    });
+  });
+
+  it('keeps Docker project failures blocking when background setup is disabled', async () => {
+    mockInitializeDockerProjects.mockRejectedValueOnce(
+      new Error('backend failed its health check'),
+    );
+
+    await expect(
+      setup({
+        mode: 'full',
+        workspace: environmentWorkspaceOptions,
+        logger,
+        workerEnv: mockWorkerEnv,
+      }),
+    ).rejects.toThrow('backend failed its health check');
   });
 
   it('continues after environment service startup failures for standard tasks', async () => {

--- a/apps/worker/src/commands/setup.ts
+++ b/apps/worker/src/commands/setup.ts
@@ -60,18 +60,18 @@ interface SetupOptions {
   logger: StartupLogger;
   workerEnv: WorkerEnv;
   recordPhase?: PhaseRecorder;
-  backgroundOrganizationEnvironmentSetup?: boolean;
+  backgroundEnvironmentSetup?: boolean;
 }
 
 interface SetupResult {
   preparedWorkspace?: PrepareWorkspaceResult;
   workerEnv: WorkerEnv;
-  backgroundOrganizationEnvironmentSetup?: Promise<EnvironmentSetupWarning[]>;
+  backgroundEnvironmentSetup?: Promise<EnvironmentSetupWarning[]>;
 }
 
 interface RunSetupResult {
   preparedWorkspace?: PrepareWorkspaceResult;
-  backgroundOrganizationEnvironmentSetup?: Promise<EnvironmentSetupWarning[]>;
+  backgroundEnvironmentSetup?: Promise<EnvironmentSetupWarning[]>;
 }
 
 function shouldContinueEnvironmentSetupFailures({
@@ -101,7 +101,7 @@ function buildEnvironmentServicesWarning(error: unknown): string {
 }
 
 function buildBackgroundEnvironmentSetupWarning(): string {
-  return 'Environment setup is still running in the background. Repository setup commands may still be installing dependencies or preparing services.';
+  return 'Environment setup is still running in the background. Docker projects may still be building or waiting for health checks, and repository setup commands may still be installing dependencies or preparing services.';
 }
 
 /**
@@ -114,7 +114,7 @@ export async function setup({
   logger,
   workerEnv,
   recordPhase,
-  backgroundOrganizationEnvironmentSetup = false,
+  backgroundEnvironmentSetup = false,
 }: SetupOptions): Promise<SetupResult> {
   const setupStartedAt = Date.now();
   const harness = resolveWorkerCodingHarness(workspaceOpts.harness);
@@ -142,7 +142,7 @@ export async function setup({
     },
   };
   let result: PrepareWorkspaceResult | undefined;
-  let backgroundOrganizationEnvironmentSetupPromise:
+  let backgroundEnvironmentSetupPromise:
     | Promise<EnvironmentSetupWarning[]>
     | undefined;
 
@@ -165,11 +165,10 @@ export async function setup({
       workspaceOptions,
       initializeServicesFn: initializeAllServices,
       recordPhase,
-      backgroundOrganizationEnvironmentSetup,
+      backgroundEnvironmentSetup,
     });
     result = setupResult.preparedWorkspace;
-    backgroundOrganizationEnvironmentSetupPromise =
-      setupResult.backgroundOrganizationEnvironmentSetup;
+    backgroundEnvironmentSetupPromise = setupResult.backgroundEnvironmentSetup;
   }
 
   logger.userLog.log(
@@ -194,8 +193,7 @@ export async function setup({
   return {
     preparedWorkspace: result,
     workerEnv,
-    backgroundOrganizationEnvironmentSetup:
-      backgroundOrganizationEnvironmentSetupPromise,
+    backgroundEnvironmentSetup: backgroundEnvironmentSetupPromise,
   };
 }
 
@@ -204,9 +202,9 @@ async function runSetup({
   workspaceOptions,
   initializeServicesFn,
   recordPhase,
-  backgroundOrganizationEnvironmentSetup = false,
+  backgroundEnvironmentSetup = false,
 }: SetupExecutionContext & {
-  backgroundOrganizationEnvironmentSetup?: boolean;
+  backgroundEnvironmentSetup?: boolean;
 }): Promise<RunSetupResult> {
   const environmentSetupWarnings: EnvironmentSetupWarning[] = [];
   const continueEnvironmentSetupFailures =
@@ -272,6 +270,10 @@ async function runSetup({
   );
 
   let initializeRepositoriesResult: PrepareWorkspaceResult | undefined;
+  const backgroundSetupTasks: Array<Promise<EnvironmentSetupWarning[]>> = [];
+  let backgroundDockerProjectsTask:
+    | Promise<EnvironmentSetupWarning[]>
+    | undefined;
 
   const systemSetup: Promise<void>[] = [
     timedStep(
@@ -326,17 +328,54 @@ async function runSetup({
   );
 
   if (initializeRepositoriesResult) {
-    await timedStep(
-      logger,
-      'initializeDockerProjects',
-      () =>
-        initializeDockerProjects(
+    const initializeDockerProjectsTask = async (): Promise<
+      EnvironmentSetupWarning[]
+    > => {
+      try {
+        await initializeDockerProjects(
           logger,
           workspaceOptions,
           initializeRepositoriesResult!,
-        ),
-      recordPhase,
-    );
+        );
+        return [];
+      } catch (error) {
+        if (!backgroundEnvironmentSetup) {
+          throw error;
+        }
+
+        const warning = `Background Docker project setup failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`;
+        const warningDetails = { message: warning };
+        environmentSetupWarnings.push(warningDetails);
+        logger.userLog.warn(
+          `${warning} Continuing without a fully configured environment.`,
+        );
+        logger.debug.warn(
+          `Background Docker project setup failed:\n${formatEnvironmentSetupErrorDetails(
+            error,
+          )}`,
+        );
+        return [warningDetails];
+      }
+    };
+
+    const dockerProjectsStep = () =>
+      timedStep(
+        logger,
+        backgroundEnvironmentSetup
+          ? 'initializeDockerProjects (background)'
+          : 'initializeDockerProjects',
+        initializeDockerProjectsTask,
+        recordPhase,
+      );
+
+    if (backgroundEnvironmentSetup) {
+      backgroundDockerProjectsTask = dockerProjectsStep();
+      backgroundSetupTasks.push(backgroundDockerProjectsTask);
+    } else {
+      await dockerProjectsStep();
+    }
   }
 
   await timedStep(
@@ -345,10 +384,6 @@ async function runSetup({
     () => installPython(logger),
     recordPhase,
   );
-
-  let backgroundOrganizationEnvironmentSetupPromise:
-    | Promise<EnvironmentSetupWarning[]>
-    | undefined;
 
   await timedStep(
     logger,
@@ -360,7 +395,7 @@ async function runSetup({
         return;
       }
 
-      if (!backgroundOrganizationEnvironmentSetup) {
+      if (!backgroundEnvironmentSetup) {
         const warnings =
           (await setupOrganizationEnvironment(logger, {
             environment: workspace,
@@ -382,50 +417,62 @@ async function runSetup({
         preparedWorkspace: initializeRepositoriesResult,
       });
 
-      const backgroundWarning = buildBackgroundEnvironmentSetupWarning();
-      environmentSetupWarnings.push({ message: backgroundWarning });
-      logger.userLog.log(
-        'Continuing task startup while environment repository commands finish in the background',
-      );
+      backgroundSetupTasks.push(
+        timedStep(
+          logger,
+          'setupOrganizationEnvironmentCommands (background)',
+          async () => {
+            try {
+              await backgroundDockerProjectsTask;
+              const warnings =
+                await executeOrganizationEnvironmentRepositoryCommands(logger, {
+                  environment: workspace,
+                  envVars: workspaceOptions.envVars,
+                  userEnvVars: workspaceOptions.userEnvVars,
+                  preparedWorkspace: initializeRepositoriesResult,
+                  continueRepositoryCommandFailures: true,
+                });
 
-      backgroundOrganizationEnvironmentSetupPromise = timedStep(
-        logger,
-        'setupOrganizationEnvironmentCommands (background)',
-        async () => {
-          try {
-            const warnings =
-              await executeOrganizationEnvironmentRepositoryCommands(logger, {
-                environment: workspace,
-                envVars: workspaceOptions.envVars,
-                userEnvVars: workspaceOptions.userEnvVars,
-                preparedWorkspace: initializeRepositoriesResult,
-                continueRepositoryCommandFailures: true,
-              });
-
-            environmentSetupWarnings.push(...warnings);
-            return warnings;
-          } catch (error) {
-            const warning = `Background environment setup failed unexpectedly: ${
-              error instanceof Error ? error.message : String(error)
-            }`;
-            const warningDetails = { message: warning };
-            environmentSetupWarnings.push(warningDetails);
-            logger.userLog.warn(
-              `${warning} Continuing without a fully configured environment.`,
-            );
-            logger.debug.warn(
-              `Background environment setup failed unexpectedly:\n${formatEnvironmentSetupErrorDetails(
-                error,
-              )}`,
-            );
-            return [warningDetails];
-          }
-        },
-        recordPhase,
+              environmentSetupWarnings.push(...warnings);
+              return warnings;
+            } catch (error) {
+              const warning = `Background environment setup failed unexpectedly: ${
+                error instanceof Error ? error.message : String(error)
+              }`;
+              const warningDetails = { message: warning };
+              environmentSetupWarnings.push(warningDetails);
+              logger.userLog.warn(
+                `${warning} Continuing without a fully configured environment.`,
+              );
+              logger.debug.warn(
+                `Background environment setup failed unexpectedly:\n${formatEnvironmentSetupErrorDetails(
+                  error,
+                )}`,
+              );
+              return [warningDetails];
+            }
+          },
+          recordPhase,
+        ),
       );
     },
     recordPhase,
   );
+
+  let backgroundEnvironmentSetupPromise:
+    | Promise<EnvironmentSetupWarning[]>
+    | undefined;
+
+  if (backgroundSetupTasks.length > 0) {
+    const backgroundWarning = buildBackgroundEnvironmentSetupWarning();
+    environmentSetupWarnings.push({ message: backgroundWarning });
+    logger.userLog.log(
+      'Continuing task startup while Docker projects and environment repository commands finish in the background',
+    );
+    backgroundEnvironmentSetupPromise = Promise.all(backgroundSetupTasks).then(
+      (warnings) => warnings.flat(),
+    );
+  }
 
   if (initializeRepositoriesResult && environmentSetupWarnings.length > 0) {
     initializeRepositoriesResult.environmentSetupWarnings =
@@ -434,7 +481,6 @@ async function runSetup({
 
   return {
     preparedWorkspace: initializeRepositoriesResult,
-    backgroundOrganizationEnvironmentSetup:
-      backgroundOrganizationEnvironmentSetupPromise,
+    backgroundEnvironmentSetup: backgroundEnvironmentSetupPromise,
   };
 }

--- a/apps/worker/src/commands/utils/execute-task-run.test.ts
+++ b/apps/worker/src/commands/utils/execute-task-run.test.ts
@@ -370,7 +370,7 @@ describe('executeTaskRun', () => {
     );
   });
 
-  it('starts eligible environment-backed tasks before repository commands finish', async () => {
+  it('starts eligible environment-backed tasks before background environment setup finishes', async () => {
     let releaseBackgroundSetup: (() => void) | undefined;
     const runFn = vi.fn().mockResolvedValue({
       status: RunStatus.Idle,
@@ -383,11 +383,11 @@ describe('executeTaskRun', () => {
         environmentSetupWarnings: [
           {
             message:
-              'Environment setup is still running in the background. Repository setup commands may still be installing dependencies or preparing services.',
+              'Environment setup is still running in the background. Docker projects may still be building or waiting for health checks, and repository setup commands may still be installing dependencies or preparing services.',
           },
         ],
       },
-      backgroundOrganizationEnvironmentSetup: new Promise((resolve) => {
+      backgroundEnvironmentSetup: new Promise((resolve) => {
         releaseBackgroundSetup = () =>
           resolve([
             {
@@ -435,7 +435,7 @@ describe('executeTaskRun', () => {
     expect(finalizeJobMock).not.toHaveBeenCalled();
     expect(setupMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        backgroundOrganizationEnvironmentSetup: true,
+        backgroundEnvironmentSetup: true,
       }),
     );
 
@@ -498,7 +498,7 @@ describe('executeTaskRun', () => {
 
     expect(setupMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        backgroundOrganizationEnvironmentSetup: false,
+        backgroundEnvironmentSetup: false,
       }),
     );
   });
@@ -544,7 +544,7 @@ describe('executeTaskRun', () => {
 
     expect(setupMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        backgroundOrganizationEnvironmentSetup: false,
+        backgroundEnvironmentSetup: false,
       }),
     );
   });
@@ -589,7 +589,7 @@ describe('executeTaskRun', () => {
 
     expect(setupMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        backgroundOrganizationEnvironmentSetup: false,
+        backgroundEnvironmentSetup: false,
       }),
     );
   });

--- a/apps/worker/src/commands/utils/execute-task-run.ts
+++ b/apps/worker/src/commands/utils/execute-task-run.ts
@@ -501,8 +501,7 @@ export async function executeTaskRun<TPrepared extends PreparedTaskRunBase>({
 
     const {
       preparedWorkspace,
-      backgroundOrganizationEnvironmentSetup:
-        backgroundOrganizationEnvironmentSetupPromise,
+      backgroundEnvironmentSetup: backgroundEnvironmentSetupPromise,
     } = await recordWorkerPhase({
       label: 'setupWorkspace',
       recordWorkerRuntimeEvent,
@@ -510,7 +509,7 @@ export async function executeTaskRun<TPrepared extends PreparedTaskRunBase>({
         payloadKind: taskRun.payloadKind,
         setupMode,
         workspaceType: workspace.type,
-        backgroundOrganizationEnvironmentSetup: runEnvironmentSetupInBackground,
+        backgroundEnvironmentSetup: runEnvironmentSetupInBackground,
       },
       fn: async () =>
         await setup({
@@ -531,8 +530,7 @@ export async function executeTaskRun<TPrepared extends PreparedTaskRunBase>({
           },
           logger: startupLogger,
           workerEnv: currentWorkerEnv,
-          backgroundOrganizationEnvironmentSetup:
-            runEnvironmentSetupInBackground,
+          backgroundEnvironmentSetup: runEnvironmentSetupInBackground,
           recordPhase: ({
             label,
             startedAtMs,
@@ -557,7 +555,7 @@ export async function executeTaskRun<TPrepared extends PreparedTaskRunBase>({
     backgroundEnvironmentSetupController =
       new BackgroundEnvironmentSetupController({
         taskRun,
-        backgroundSetupPromise: backgroundOrganizationEnvironmentSetupPromise,
+        backgroundSetupPromise: backgroundEnvironmentSetupPromise,
         recordWorkerRuntimeEvent,
       });
 

--- a/apps/worker/src/run-task/__tests__/sandbox-instruction.test.ts
+++ b/apps/worker/src/run-task/__tests__/sandbox-instruction.test.ts
@@ -151,6 +151,15 @@ describe('buildSandboxInstruction', () => {
       'They may still be building or waiting for health checks when your task begins.',
     );
     expect(instruction).toContain(
+      'Run `docker compose ls` to find each Roomote-managed project name and its config files',
+    );
+    expect(instruction).toContain(
+      '`docker compose --project-name <name> --file <file> ... ps`',
+    );
+    expect(instruction).toContain(
+      'repeat `--file` for every listed config file',
+    );
+    expect(instruction).not.toContain(
       'Inspect them with `docker compose ps` and `docker compose logs`',
     );
     expect(instruction).not.toContain(

--- a/apps/worker/src/run-task/__tests__/sandbox-instruction.test.ts
+++ b/apps/worker/src/run-task/__tests__/sandbox-instruction.test.ts
@@ -133,6 +133,31 @@ describe('sanitizeEnvironmentConfigForPrompt', () => {
 });
 
 describe('buildSandboxInstruction', () => {
+  it('tells the agent that Docker project startup may still be running', () => {
+    const instruction = buildSandboxInstruction(false, {
+      name: 'Sandbox',
+      repositories: [{ repository: 'owner/repo' }],
+      docker_projects: [
+        {
+          type: 'compose',
+          name: 'app',
+          repository: 'owner/repo',
+          files: ['compose.yaml'],
+        },
+      ],
+    });
+
+    expect(instruction).toContain(
+      'They may still be building or waiting for health checks when your task begins.',
+    );
+    expect(instruction).toContain(
+      'Inspect them with `docker compose ps` and `docker compose logs`',
+    );
+    expect(instruction).not.toContain(
+      'were built and started with Docker Compose before your task began',
+    );
+  });
+
   it('does not leak non-whitelisted or secret fields into the serialized JSON block', () => {
     const environmentConfig: EnvironmentConfig = {
       name: 'Sandbox',

--- a/apps/worker/src/run-task/sandbox-instruction.ts
+++ b/apps/worker/src/run-task/sandbox-instruction.ts
@@ -202,7 +202,7 @@ export function buildSandboxInstruction(
     if (environmentConfig.docker_projects?.length) {
       lines.push(
         '',
-        'Roomote starts configured Docker projects with Docker Compose during environment setup. They may still be building or waiting for health checks when your task begins. Inspect them with `docker compose ps` and `docker compose logs`, wait for the existing startup when necessary, and do not start duplicate copies.',
+        'Roomote starts configured Docker projects with Docker Compose during environment setup. They may still be building or waiting for health checks when your task begins. Run `docker compose ls` to find each Roomote-managed project name and its config files, then inspect it with `docker compose --project-name <name> --file <file> ... ps` or `docker compose --project-name <name> --file <file> ... logs` (repeat `--file` for every listed config file). If a configured project is not listed yet, wait for the existing startup rather than starting a duplicate copy.',
       );
     }
 

--- a/apps/worker/src/run-task/sandbox-instruction.ts
+++ b/apps/worker/src/run-task/sandbox-instruction.ts
@@ -202,7 +202,7 @@ export function buildSandboxInstruction(
     if (environmentConfig.docker_projects?.length) {
       lines.push(
         '',
-        'Configured Docker projects were built and started with Docker Compose before your task began. Use `docker compose` with the configured project files when inspecting them, and do not start duplicate copies.',
+        'Roomote starts configured Docker projects with Docker Compose during environment setup. They may still be building or waiting for health checks when your task begins. Inspect them with `docker compose ps` and `docker compose logs`, wait for the existing startup when necessary, and do not start duplicate copies.',
       );
     }
 


### PR DESCRIPTION
## What changed

- Let eligible environment-backed tasks start while configured Docker projects build and wait for health checks in the background.
- Preserve setup ordering by waiting for Docker project startup before running background repository setup commands.
- Keep onboarding setup blocking so environment creation still verifies readiness before completion.
- Report background Docker failures as environment readiness warnings and tell the agent that Compose startup may still be in progress.

## Why

Docker image builds and service health checks can take several minutes. They should not prevent an ordinary task from starting when the agent can make progress while those services initialize.

## Validation

- Worker test suite: 137 files and 1,323 tests passing
- Worker lint and typecheck
- Repository `lint:fast`, `check-types:fast`, and `knip` checks
- Pre-push validation passed