### PR TITLE
Scope reusable PR follow-up owner branch fallback by source-control provider

### DIFF
--- a/packages/db/src/lib/__tests__/github-branch-activity.test.ts
+++ b/packages/db/src/lib/__tests__/github-branch-activity.test.ts
@@ -826,6 +826,102 @@ describe('findReusableGitHubPrFollowUpOwner', () => {
       delivery: 'resume',
     });
   });
+
+  it('does not let a GitHub branch owner claim follow-ups for another provider', async () => {
+    const { user } = await createActor();
+    const repoFullName = 'owner/repo-owner-cross-provider';
+    const prNumber = 552;
+    const branchName = 'feature/owner-cross-provider';
+
+    // Legacy GitHub payload: no sourceControlProvider field, which defaults
+    // to 'github' at runtime.
+    const githubRun = await runFactory.create({
+      actingUserId: user.id,
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Running,
+      taskPhase: 'running',
+      payload: {
+        repo: repoFullName,
+        branch: branchName,
+        description: 'GitHub work on the branch',
+      },
+    });
+
+    // A GitLab follow-up for the same repository fullName + branch must not
+    // attach to the GitHub run.
+    const gitlabResult = await findReusableGitHubPrFollowUpOwner({
+      repoFullName,
+      prNumber,
+      branchName,
+      sourceControlProvider: 'gitlab',
+    });
+
+    expect(gitlabResult).toBeNull();
+
+    // The default (GitHub) lookup still matches the legacy payload.
+    const githubResult = await findReusableGitHubPrFollowUpOwner({
+      repoFullName,
+      prNumber,
+      branchName,
+    });
+
+    expect(githubResult).toMatchObject({
+      runId: githubRun.id,
+      match: 'branch',
+      delivery: 'attach',
+    });
+  });
+
+  it('matches provider-tagged branch owners only for the same provider', async () => {
+    const { user } = await createActor();
+    const repoFullName = 'owner/repo-owner-gitlab-branch';
+    const prNumber = 553;
+    const branchName = 'feature/owner-gitlab-branch';
+
+    const gitlabRun = await runFactory.create({
+      actingUserId: user.id,
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Running,
+      taskPhase: 'running',
+      payload: {
+        repo: repoFullName,
+        branch: branchName,
+        sourceControlProvider: 'gitlab',
+        description: 'GitLab work on the branch',
+      },
+    });
+
+    const gitlabResult = await findReusableGitHubPrFollowUpOwner({
+      repoFullName,
+      prNumber,
+      branchName,
+      sourceControlProvider: 'gitlab',
+    });
+
+    expect(gitlabResult).toMatchObject({
+      runId: gitlabRun.id,
+      match: 'branch',
+      delivery: 'attach',
+    });
+
+    // The GitLab-tagged run must not claim GitHub or ADO follow-ups.
+    const githubResult = await findReusableGitHubPrFollowUpOwner({
+      repoFullName,
+      prNumber,
+      branchName,
+    });
+
+    expect(githubResult).toBeNull();
+
+    const adoResult = await findReusableGitHubPrFollowUpOwner({
+      repoFullName,
+      prNumber,
+      branchName,
+      sourceControlProvider: 'ado',
+    });
+
+    expect(adoResult).toBeNull();
+  });
 });
 
 describe('findActiveGitHubPrReviewTask', () => {

--- a/packages/db/src/lib/github-branch-activity.ts
+++ b/packages/db/src/lib/github-branch-activity.ts
@@ -243,6 +243,7 @@ export async function findReusableGitHubPrFollowUpOwner({
     .where(
       and(
         ...baseConditions,
+        payloadProviderCondition(sourceControlProvider),
         sql`${taskRuns.payload}->>'repo' = ${repoFullName}`,
         sql`(
           ${taskRuns.payload}->>'branch' = ${branchName}


### PR DESCRIPTION
## Summary

`findReusableGitHubPrFollowUpOwner` decides whether an incoming PR/MR follow-up comment attaches to (or snapshot-resumes) an existing task instead of launching a new one. Its payload `repo`/`branch` fallback query was not scoped by source-control provider, so a same-named repo full name + branch on another provider could cross-match GitHub work and vice versa — e.g. a GitLab MR follow-up attaching to a task actually working on the identically-named GitHub repo/branch. This is the same latent mismatch #320 fixed in the sibling `findActiveGitHubBranchWork`.

## Changes

- Add `payloadProviderCondition(sourceControlProvider)` (the helper introduced in #320) to the branch fallback query in `findReusableGitHubPrFollowUpOwner`. Legacy payloads that omit `sourceControlProvider` continue to be treated as `'github'`, so existing GitHub flows are unchanged.
- Add cross-provider non-match tests mirroring the ones added for `findActiveGitHubBranchWork` in #320: an untagged (legacy GitHub) branch owner is not claimed by a GitLab lookup but still matches the default GitHub lookup, and a `gitlab`-tagged owner matches only GitLab lookups.

No caller changes needed — the `sourceControlProvider` param (default `'github'`) already existed and all provider-specific callers already pass it; only this fallback query was missing the condition. The `task_pull_requests` join path was already provider-scoped.

## Validation

- `@roomote/db` vitest suite: 261/261 passed (24/24 in `github-branch-activity.test.ts`, including the 2 new tests)
- `@roomote/sdk` vitest suite: 488/488 passed
- `tsc --noEmit`, ESLint, and Prettier clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)