### PR TITLE
Show capability badges only for limited automations

### DIFF
--- a/apps/web/src/components/settings/automations/AutomationsSettings.render.client.test.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.render.client.test.tsx
@@ -454,20 +454,21 @@ describe('AutomationsSettings', () => {
     ).toBeInTheDocument();
   });
 
-  it('shows capability badges from the shared automation descriptors', async () => {
+  it('shows exception-only capability badges from the shared descriptors', async () => {
     render(<AutomationsSettings />);
 
-    // Generalized manager automations support every chat surface.
-    expect((await screen.findAllByText('All chat channels')).length).toBe(6);
-    // Suggester, announcer, Sentry triage, and both merged-PR auditors scan
-    // any source control provider.
-    expect(screen.getAllByText('All source control').length).toBe(5);
     // Dependabot/CI triage and manager stats stay GitHub-only.
-    expect(screen.getAllByText('GitHub only').length).toBe(3);
-    // conflict_resolver now supports GitHub, GitLab, and Azure DevOps
-    expect(screen.getAllByText('GitHub · GitLab · Azure DevOps').length).toBe(
-      1,
-    );
+    expect((await screen.findAllByText('GitHub only')).length).toBe(3);
+    // Suggester and CI failure triage still report to Slack only.
+    expect(screen.getAllByText('Slack only').length).toBe(2);
+    // conflict_resolver supports GitHub, GitLab, and Azure DevOps (no
+    // Gitea/Bitbucket conflict signal).
+    expect(
+      screen.getAllByText('GitHub · GitLab · Azure DevOps only').length,
+    ).toBe(1);
+    // Full coverage shows nothing — absence of a warning is the signal.
+    expect(screen.queryByText('All chat channels')).toBeNull();
+    expect(screen.queryByText('All source control')).toBeNull();
   });
 
   it('reflects the reviewer all-author setting in the review scope copy', async () => {

--- a/apps/web/src/components/settings/automations/AutomationsSettings.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.tsx
@@ -295,9 +295,10 @@ const TRIGGERABLE_AUTOMATION_SCHEDULE_LABELS = {
 } as const;
 
 /**
- * Informational capability badges derived from the automation descriptor:
- * which chat surfaces its reports can go to and which source-control
- * providers its scans work with today.
+ * Exception-only capability badges derived from the automation descriptor:
+ * a badge appears only when an automation is LIMITED relative to full
+ * provider coverage. Full coverage (or no applicable surface at all) shows
+ * nothing — the absence of a warning is the signal.
  */
 function getAutomationCapabilityBadges(
   automationKey: BackgroundAutomationKey,
@@ -311,24 +312,23 @@ function getAutomationCapabilityBadges(
 
   const comms: readonly CommunicationProvider[] =
     descriptor.supportedCommunicationProviders;
-  const showCommsBadge =
-    comms.length > 1 || comms.some((provider) => provider !== 'slack');
-  const commsBadge = showCommsBadge
-    ? comms.length === communicationProviders.length
-      ? 'All chat channels'
-      : comms.map(getCommunicationProviderDisplayName).join(' · ')
+  const commsLimited =
+    comms.length > 0 && comms.length < communicationProviders.length;
+  const commsBadge = commsLimited
+    ? comms.length === 1 && comms[0] === 'slack'
+      ? 'Slack only'
+      : `${comms.map(getCommunicationProviderDisplayName).join(' · ')} only`
     : undefined;
 
   const scm: readonly SourceControlProvider[] =
     descriptor.supportedSourceControlProviders;
-  const scmBadge =
-    scm.length === 0
-      ? undefined
-      : scm.length === sourceControlProviders.length
-        ? 'All source control'
-        : scm.length === 1 && scm[0] === 'github'
-          ? 'GitHub only'
-          : scm.map(getSourceControlProviderLabel).join(' · ');
+  const scmLimited =
+    scm.length > 0 && scm.length < sourceControlProviders.length;
+  const scmBadge = scmLimited
+    ? scm.length === 1 && scm[0] === 'github'
+      ? 'GitHub only'
+      : `${scm.map(getSourceControlProviderLabel).join(' · ')} only`
+    : undefined;
 
   return {
     ...(commsBadge ? { commsBadge } : {}),


### PR DESCRIPTION
## What

Small UI follow-up to #319/#320/#325. Now that most automations support every provider, the affirmative "All chat channels" / "All source control" badges had become wallpaper — a dozen pills saying "everything's fine."

Badges are now **exception-only**: an automation gets a badge only when it's limited relative to full coverage ("GitHub only", "Slack only", "GitHub · GitLab · Azure DevOps only"), and full coverage shows nothing. The absence of a warning is the signal.

No registry or behavior changes — purely the badge rendering rule and its test.

## Testing

- Render test rewritten for the exception-only rule (3× GitHub only, 2× Slack only, 1× partial-list badge, zero affirmative badges)
- Full web suite green (1989); lint/types clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)