### PR TITLE
Stream Docker project logs to a well-known file and add them to the Logs panel

### DIFF
--- a/apps/web/src/app/(sandbox)/task/[taskId]/hooks/use-log-files.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/hooks/use-log-files.ts
@@ -1,6 +1,8 @@
 import { useContext, useEffect, useMemo } from 'react';
 import { useStore } from 'zustand';
 
+import { getDockerProjectLogFilePath } from '@roomote/types';
+
 import { useEnvironment } from '@/hooks/environments';
 
 import type { LogfileInfo } from './use-sandbox-store';
@@ -41,18 +43,27 @@ export function useLogFiles(
   const environmentLogfiles = useMemo<LogfileInfo[]>(() => {
     const config = environment.data?.config;
 
-    if (!config?.repositories) {
+    if (!config) {
       return [];
     }
 
     const result: LogfileInfo[] = [];
 
-    for (const repo of config.repositories) {
+    for (const repo of config.repositories ?? []) {
       for (const cmd of repo.commands ?? []) {
         if (cmd.logfile) {
           result.push({ label: cmd.name, filePath: cmd.logfile });
         }
       }
+    }
+
+    // The worker streams each Docker project's Compose startup output and a
+    // live `docker compose logs --follow` feed into a well-known file.
+    for (const project of config.docker_projects ?? []) {
+      result.push({
+        label: `${project.name} (Docker)`,
+        filePath: getDockerProjectLogFilePath(project.name),
+      });
     }
 
     return result;

--- a/apps/worker/src/commands/setup/__tests__/docker-projects.test.ts
+++ b/apps/worker/src/commands/setup/__tests__/docker-projects.test.ts
@@ -6,6 +6,15 @@ import { TaskPayloadKind } from '@roomote/types';
 
 import type { StartupLogger } from '../../../logging';
 import { initializeDockerProjects } from '../workspace/docker-projects';
+import {
+  appendDockerProjectLog,
+  startDockerProjectLogFollower,
+} from '../workspace/docker-project-logs';
+
+vi.mock('../workspace/docker-project-logs', () => ({
+  appendDockerProjectLog: vi.fn().mockResolvedValue(undefined),
+  startDockerProjectLogFollower: vi.fn().mockResolvedValue(undefined),
+}));
 
 const logger = {
   userLog: { log: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -88,6 +97,22 @@ describe('initializeDockerProjects', () => {
       path.join(workspacePath, '.roomote', 'docker-projects'),
     );
     expect(generatedFiles).toContain('roomote-dev.ports.yaml');
+
+    expect(appendDockerProjectLog).toHaveBeenCalledWith(
+      'dev',
+      expect.stringContaining('Preparing Docker project dev'),
+    );
+    expect(startDockerProjectLogFollower).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectName: 'dev',
+        cwd: repositoryPath,
+        composeArgs: expect.arrayContaining([
+          'compose',
+          '--project-name',
+          'roomote-dev',
+        ]),
+      }),
+    );
   });
 
   it('generates a one-service Compose project for a Dockerfile', async () => {

--- a/apps/worker/src/commands/setup/__tests__/docker-projects.test.ts
+++ b/apps/worker/src/commands/setup/__tests__/docker-projects.test.ts
@@ -468,4 +468,61 @@ describe('initializeDockerProjects', () => {
     expect(appendedText).toContain('APP_SECRET=[redacted]');
     expect(appendedText).not.toContain('project-secret-value');
   });
+
+  it('keeps optional-project failure logging redacted', async () => {
+    await fs.writeFile(
+      path.join(repositoryPath, 'compose.yaml'),
+      'services:\n  web:\n    image: nginx:alpine\n',
+    );
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      if (args.includes('up')) {
+        throw new Error('compose failed: APP_SECRET=project-secret-value');
+      }
+      return { stdout: '' };
+    });
+
+    await expect(
+      initializeDockerProjects(
+        logger,
+        {
+          workspace: {
+            type: 'environment',
+            environmentId: 'env-1',
+            environmentConfig: {
+              name: 'Test',
+              repositories: [{ repository: 'acme/app' }],
+              docker_projects: [
+                {
+                  type: 'compose',
+                  name: 'optional',
+                  repository: 'acme/app',
+                  files: ['compose.yaml'],
+                  env: { APP_SECRET: '${PROJECT_SECRET}' },
+                  required: false,
+                },
+              ],
+            },
+          },
+          envVars: { PROJECT_SECRET: 'project-secret-value' },
+          taskRunType: TaskPayloadKind.StandardTask,
+        },
+        {
+          workspacePath,
+          repoPaths: { 'acme/app': repositoryPath },
+        },
+        runCommand,
+      ),
+    ).resolves.toBeUndefined();
+
+    const loggedText = [
+      ...vi.mocked(logger.userLog.warn).mock.calls,
+      ...vi.mocked(logger.debug.error).mock.calls,
+      ...vi.mocked(appendDockerProjectLog).mock.calls.map((call) => [call[1]]),
+    ]
+      .flat()
+      .map(String)
+      .join('\n');
+    expect(loggedText).toContain('APP_SECRET=[redacted]');
+    expect(loggedText).not.toContain('project-secret-value');
+  });
 });

--- a/apps/worker/src/commands/setup/__tests__/docker-projects.test.ts
+++ b/apps/worker/src/commands/setup/__tests__/docker-projects.test.ts
@@ -413,4 +413,59 @@ describe('initializeDockerProjects', () => {
     await expect(result).rejects.toThrow('APP_SECRET=[redacted]');
     await expect(result).rejects.not.toThrow('project-secret-value');
   });
+
+  it('redacts project values from failure output written to the project log', async () => {
+    await fs.writeFile(
+      path.join(repositoryPath, 'compose.yaml'),
+      'services:\n  web:\n    image: nginx:alpine\n',
+    );
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      if (args.includes('up')) {
+        // Compose stderr echoing a substituted project env value ends up on
+        // the thrown error message.
+        throw new Error('compose failed: APP_SECRET=project-secret-value');
+      }
+      return { stdout: '' };
+    });
+
+    const result = initializeDockerProjects(
+      logger,
+      {
+        workspace: {
+          type: 'environment',
+          environmentId: 'env-1',
+          environmentConfig: {
+            name: 'Test',
+            repositories: [{ repository: 'acme/app' }],
+            docker_projects: [
+              {
+                type: 'compose',
+                name: 'dev',
+                repository: 'acme/app',
+                files: ['compose.yaml'],
+                env: { APP_SECRET: '${PROJECT_SECRET}' },
+              },
+            ],
+          },
+        },
+        envVars: { PROJECT_SECRET: 'project-secret-value' },
+        taskRunType: TaskPayloadKind.StandardTask,
+      },
+      {
+        workspacePath,
+        repoPaths: { 'acme/app': repositoryPath },
+      },
+      runCommand,
+    );
+
+    await expect(result).rejects.toThrow('APP_SECRET=[redacted]');
+    await expect(result).rejects.not.toThrow('project-secret-value');
+
+    const appendedText = vi
+      .mocked(appendDockerProjectLog)
+      .mock.calls.map((call) => call[1])
+      .join('\n');
+    expect(appendedText).toContain('APP_SECRET=[redacted]');
+    expect(appendedText).not.toContain('project-secret-value');
+  });
 });

--- a/apps/worker/src/commands/setup/workspace/docker-project-logs.ts
+++ b/apps/worker/src/commands/setup/workspace/docker-project-logs.ts
@@ -1,0 +1,88 @@
+/**
+ * Per-project Docker log files.
+ *
+ * Each Docker project gets a well-known log file (see
+ * `getDockerProjectLogFilePath`) containing Compose startup output, failure
+ * diagnostics, and a live `docker compose logs --follow` stream, so the web
+ * Logs panel and the agent can follow container output without shelling into
+ * the sandbox.
+ */
+
+import { createWriteStream } from 'node:fs';
+import * as fs from 'node:fs/promises';
+
+import { execa } from 'execa';
+
+import {
+  DOCKER_PROJECT_LOGS_DIR,
+  getDockerProjectLogFilePath,
+} from '@roomote/types';
+
+export async function appendDockerProjectLog(
+  projectName: string,
+  text: string,
+): Promise<void> {
+  try {
+    await fs.mkdir(DOCKER_PROJECT_LOGS_DIR, { recursive: true });
+    await fs.appendFile(
+      getDockerProjectLogFilePath(projectName),
+      `${text}\n`,
+      'utf8',
+    );
+  } catch {
+    // The log file is a debugging aid for the Logs panel; failing to write it
+    // must never affect Docker project startup.
+  }
+}
+
+/**
+ * Stream container logs into the project's log file. Runs detached for the
+ * lifetime of the sandbox; only containers that exist when it starts are
+ * followed.
+ */
+export async function startDockerProjectLogFollower({
+  projectName,
+  composeArgs,
+  cwd,
+  env,
+}: {
+  projectName: string;
+  composeArgs: string[];
+  cwd: string;
+  env: Record<string, string>;
+}): Promise<void> {
+  const logFilePath = getDockerProjectLogFilePath(projectName);
+
+  try {
+    const logStream = createWriteStream(logFilePath, { flags: 'a' });
+    await new Promise<void>((resolve, reject) => {
+      logStream.once('open', () => resolve());
+      logStream.once('error', reject);
+    });
+
+    const subprocess = execa(
+      'docker',
+      [...composeArgs, 'logs', '--follow', '--no-color', '--timestamps'],
+      {
+        cwd,
+        env,
+        extendEnv: false,
+        detached: true,
+        reject: false,
+        stdin: 'ignore',
+        // The stream has an underlying file descriptor, so execa hands it to
+        // the child directly — no pumping through this process.
+        stdout: logStream,
+        stderr: logStream,
+      },
+    );
+    subprocess.unref();
+  } catch (error) {
+    await appendDockerProjectLog(
+      projectName,
+      `[roomote] Failed to start log follower: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}

--- a/apps/worker/src/commands/setup/workspace/docker-projects.ts
+++ b/apps/worker/src/commands/setup/workspace/docker-projects.ts
@@ -427,21 +427,29 @@ async function startDockerProject({
       commandOptions,
     );
     if (diagnostics) logger.debug.error(diagnostics);
+    // error.message includes Compose stderr, which can echo project env
+    // values or build args — redact before this lands in the Logs panel.
     await appendDockerProjectLog(
       resolved.project.name,
-      [
-        `[roomote] Docker project ${resolved.project.name} failed to start: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-        diagnostics,
-      ]
-        .filter(Boolean)
-        .join('\n\n'),
+      redactContainerDiagnostics(
+        [
+          `[roomote] Docker project ${resolved.project.name} failed to start: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          diagnostics,
+        ]
+          .filter(Boolean)
+          .join('\n\n'),
+        resolved.sensitiveValues,
+      ),
     );
     throw new Error(
-      [error instanceof Error ? error.message : String(error), diagnostics]
-        .filter(Boolean)
-        .join('\n\n'),
+      redactContainerDiagnostics(
+        [error instanceof Error ? error.message : String(error), diagnostics]
+          .filter(Boolean)
+          .join('\n\n'),
+        resolved.sensitiveValues,
+      ),
       { cause: error },
     );
   }
@@ -513,8 +521,10 @@ export async function initializeDockerProjects(
   }
 
   for (const project of projects) {
+    let resolved: ResolvedDockerProject | undefined;
+
     try {
-      const resolved = await resolveDockerProject({
+      resolved = await resolveDockerProject({
         project,
         config,
         preparedWorkspace,
@@ -523,17 +533,26 @@ export async function initializeDockerProjects(
       await startDockerProject({ logger, resolved, runCommand });
     } catch (error) {
       const message = `Docker project '${project.name}' failed to start: ${error instanceof Error ? error.message : String(error)}`;
+      // Before resolution succeeds no project env has been substituted, so
+      // there is nothing to redact; afterwards the error can carry Compose
+      // stderr echoing sensitive values.
+      const redactedMessage = resolved
+        ? redactContainerDiagnostics(message, resolved.sensitiveValues)
+        : message;
       if (project.required === false) {
         logger.userLog.warn(`${message} Continuing because it is optional.`);
         logger.debug.error(error);
         await appendDockerProjectLog(
           project.name,
-          `[roomote] ${message} Continuing because it is optional.`,
+          `[roomote] ${redactedMessage} Continuing because it is optional.`,
         );
         continue;
       }
 
-      await appendDockerProjectLog(project.name, `[roomote] ${message}`);
+      await appendDockerProjectLog(
+        project.name,
+        `[roomote] ${redactedMessage}`,
+      );
       throw new Error(message, { cause: error });
     }
   }

--- a/apps/worker/src/commands/setup/workspace/docker-projects.ts
+++ b/apps/worker/src/commands/setup/workspace/docker-projects.ts
@@ -8,7 +8,13 @@ import {
   type DockerProject,
   type EnvironmentConfig,
   isServicesEnabledTaskPayloadKind,
+  toComposeProjectName,
 } from '@roomote/types';
+
+import {
+  appendDockerProjectLog,
+  startDockerProjectLogFollower,
+} from './docker-project-logs';
 
 import { substituteEnvVars } from '../../../env';
 import type { StartupLogger } from '../../../logging';
@@ -130,14 +136,6 @@ function resolveWithin(root: string, relativePath: string): string {
   }
 
   return resolvedPath;
-}
-
-function toComposeProjectName(name: string): string {
-  return `roomote-${name}`
-    .toLowerCase()
-    .replace(/[^a-z0-9_-]+/g, '-')
-    .replace(/^[^a-z0-9]+/, '')
-    .slice(0, 63);
 }
 
 function findNamedPort(config: EnvironmentConfig, namedPort: string): number {
@@ -392,6 +390,10 @@ async function startDockerProject({
   logger.userLog.log(
     `Building and starting Docker project ${resolved.project.name}...`,
   );
+  await appendDockerProjectLog(
+    resolved.project.name,
+    `[roomote] Building and starting Docker project ${resolved.project.name} (compose project ${resolved.projectName})...`,
+  );
   const services =
     resolved.project.type === 'compose'
       ? (resolved.project.services ?? [])
@@ -425,6 +427,17 @@ async function startDockerProject({
       commandOptions,
     );
     if (diagnostics) logger.debug.error(diagnostics);
+    await appendDockerProjectLog(
+      resolved.project.name,
+      [
+        `[roomote] Docker project ${resolved.project.name} failed to start: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        diagnostics,
+      ]
+        .filter(Boolean)
+        .join('\n\n'),
+    );
     throw new Error(
       [error instanceof Error ? error.message : String(error), diagnostics]
         .filter(Boolean)
@@ -435,6 +448,28 @@ async function startDockerProject({
   if (startResult.stdout) logger.debug.log(startResult.stdout);
   if (startResult.stderr) logger.debug.log(startResult.stderr);
   logger.userLog.log(`Docker project ${resolved.project.name} is ready`);
+
+  const startOutput = [startResult.stdout, startResult.stderr]
+    .filter(Boolean)
+    .join('\n');
+
+  if (startOutput) {
+    await appendDockerProjectLog(
+      resolved.project.name,
+      redactContainerDiagnostics(startOutput, resolved.sensitiveValues),
+    );
+  }
+
+  await appendDockerProjectLog(
+    resolved.project.name,
+    `[roomote] Docker project ${resolved.project.name} is ready; following container logs below.`,
+  );
+  await startDockerProjectLogFollower({
+    projectName: resolved.project.name,
+    composeArgs: buildComposeArgs(resolved, []),
+    cwd: resolved.projectRoot,
+    env: resolved.env,
+  });
 }
 
 export async function initializeDockerProjects(
@@ -456,13 +491,25 @@ export async function initializeDockerProjects(
 
   const baseEnv = getDefinedEnv(options.envVars);
 
+  // Create each project's log file up front so the Logs panel can start
+  // tailing it (tail -f needs the file to exist) before startup output lands.
+  for (const project of projects) {
+    await appendDockerProjectLog(
+      project.name,
+      `[roomote] Preparing Docker project ${project.name}...`,
+    );
+  }
+
   try {
     await ensureDockerRuntime({ preparedWorkspace, baseEnv, runCommand });
   } catch (error) {
-    throw new Error(
-      `Docker Compose is not available in this task environment: ${error instanceof Error ? error.message : String(error)}`,
-      { cause: error },
-    );
+    const message = `Docker Compose is not available in this task environment: ${error instanceof Error ? error.message : String(error)}`;
+
+    for (const project of projects) {
+      await appendDockerProjectLog(project.name, `[roomote] ${message}`);
+    }
+
+    throw new Error(message, { cause: error });
   }
 
   for (const project of projects) {
@@ -479,9 +526,14 @@ export async function initializeDockerProjects(
       if (project.required === false) {
         logger.userLog.warn(`${message} Continuing because it is optional.`);
         logger.debug.error(error);
+        await appendDockerProjectLog(
+          project.name,
+          `[roomote] ${message} Continuing because it is optional.`,
+        );
         continue;
       }
 
+      await appendDockerProjectLog(project.name, `[roomote] ${message}`);
       throw new Error(message, { cause: error });
     }
   }

--- a/apps/worker/src/commands/setup/workspace/docker-projects.ts
+++ b/apps/worker/src/commands/setup/workspace/docker-projects.ts
@@ -540,8 +540,13 @@ export async function initializeDockerProjects(
         ? redactContainerDiagnostics(message, resolved.sensitiveValues)
         : message;
       if (project.required === false) {
-        logger.userLog.warn(`${message} Continuing because it is optional.`);
-        logger.debug.error(error);
+        logger.userLog.warn(
+          `${redactedMessage} Continuing because it is optional.`,
+        );
+        // Log the redacted message, not the Error: its cause chain still
+        // holds the original Compose error with unredacted stderr, and the
+        // startup logger serializes causes into harness.log.
+        logger.debug.error(redactedMessage);
         await appendDockerProjectLog(
           project.name,
           `[roomote] ${redactedMessage} Continuing because it is optional.`,

--- a/packages/types/src/environment-config.ts
+++ b/packages/types/src/environment-config.ts
@@ -183,6 +183,30 @@ export type DockerfileDockerProject = z.infer<
 export type DockerProject = z.infer<typeof dockerProjectSchema>;
 
 /**
+ * Normalize a configured Docker project name into the Compose project name
+ * the worker uses (`--project-name`). Shared with the web app so both sides
+ * derive identical log file paths.
+ */
+export function toComposeProjectName(name: string): string {
+  return `roomote-${name}`
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^[^a-z0-9]+/, '')
+    .slice(0, 63);
+}
+
+export const DOCKER_PROJECT_LOGS_DIR = '/tmp/roomote-docker-projects';
+
+/**
+ * Well-known sandbox path of a Docker project's log file. The worker writes
+ * Compose startup output, failure diagnostics, and a live `docker compose
+ * logs --follow` stream here; the web Logs panel tails it by this path.
+ */
+export function getDockerProjectLogFilePath(name: string): string {
+  return `${DOCKER_PROJECT_LOGS_DIR}/${toComposeProjectName(name)}.log`;
+}
+
+/**
  * Default ports for each service.
  */
 export const serviceDefaultPorts: Record<ServiceName, number> = {


### PR DESCRIPTION
## Problem

Docker projects had no standard log. `docker compose up` output went only to the worker's startup logger, container logs lived solely inside dockerd (reachable only via `docker compose logs` from a shell), and the task Logs panel listed just `harness.log` plus detached-command logfiles — nothing for Docker projects.

## Changes

**Worker**
- Each Docker project now gets a well-known log file at `/tmp/roomote-docker-projects/<compose-project>.log`, created up front so the Logs panel's `tail -f` finds it immediately.
- The file receives: a preparing/starting header, redacted Compose startup output, failure diagnostics (`compose ps` + recent logs) when startup fails, and — after a successful `up` — a detached `docker compose logs --follow --no-color --timestamps` stream for the sandbox's lifetime.
- Log writing lives in a separate `docker-project-logs` module with best-effort error handling, so it can never affect project startup (and is cleanly mockable in tests).

**Shared types**
- `toComposeProjectName` moves from the worker into `@roomote/types`, alongside new `getDockerProjectLogFilePath`, so the worker and web derive identical paths.

**Web**
- The Logs sidebar ("Logs in this environment") now lists one entry per configured `docker_project`, tailed over the existing `tailMulti` subscription.

## Testing

- Docker project tests now mock the log module (previously my first cut spawned real processes in tests — caught and fixed) and assert the follower starts with the right compose args.
- Full worker suite (1323 tests), typecheck (types/worker/web), lint, and knip all pass.