### PR TITLE
[Improve] Show background environment setup status on the running task

### DIFF
--- a/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/EnvironmentSetupBadge.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/EnvironmentSetupBadge.client.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { EnvironmentSetupBadge } from './EnvironmentSetupBadge';
+
+vi.mock('@/components/system', () => ({
+  BasicTooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  CircleX: () => <svg data-testid="circle-x" />,
+  Loader2: () => <svg data-testid="loader" />,
+  TriangleAlert: () => <svg data-testid="triangle-alert" />,
+}));
+
+describe('EnvironmentSetupBadge', () => {
+  it('renders nothing when environment setup never ran in the background', () => {
+    const { container } = render(
+      <EnvironmentSetupBadge
+        taskRun={{ environmentSetupState: null } as never}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing without a task run', () => {
+    const { container } = render(<EnvironmentSetupBadge taskRun={null} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when setup completed cleanly', () => {
+    const { container } = render(
+      <EnvironmentSetupBadge
+        taskRun={{ environmentSetupState: 'completed' } as never}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows a live indicator while background setup is running', () => {
+    render(
+      <EnvironmentSetupBadge
+        taskRun={{ environmentSetupState: 'running' } as never}
+      />,
+    );
+
+    expect(screen.getByText('Setting up environment')).toBeInTheDocument();
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+  });
+
+  it('shows a warning badge when setup finished with warnings', () => {
+    render(
+      <EnvironmentSetupBadge
+        taskRun={{ environmentSetupState: 'completed_with_warnings' } as never}
+      />,
+    );
+
+    expect(screen.getByText('Setup warnings')).toBeInTheDocument();
+    expect(screen.getByTestId('triangle-alert')).toBeInTheDocument();
+  });
+
+  it('shows a failure badge when setup failed', () => {
+    render(
+      <EnvironmentSetupBadge
+        taskRun={{ environmentSetupState: 'failed' } as never}
+      />,
+    );
+
+    expect(screen.getByText('Setup failed')).toBeInTheDocument();
+    expect(screen.getByTestId('circle-x')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/EnvironmentSetupBadge.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/EnvironmentSetupBadge.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import type { TaskRunDetail } from '@/lib/server';
+
+import {
+  BasicTooltip,
+  CircleX,
+  Loader2,
+  TriangleAlert,
+} from '@/components/system';
+
+interface EnvironmentSetupBadgeProps {
+  taskRun?: TaskRunDetail | null;
+}
+
+/**
+ * Compact status badge for background environment setup (repository setup
+ * commands and Docker projects). Environment setup can keep running after
+ * the agent has started, so this surfaces its live state next to the task
+ * status indicator. Renders nothing when setup never ran in the background
+ * (`environmentSetupState` is null) or finished cleanly.
+ */
+export function EnvironmentSetupBadge({ taskRun }: EnvironmentSetupBadgeProps) {
+  const state = taskRun?.environmentSetupState;
+
+  if (!state || state === 'completed') {
+    return null;
+  }
+
+  if (state === 'running') {
+    return (
+      <BasicTooltip content="Repository setup commands and Docker projects are still starting in the background.">
+        <div
+          role="status"
+          aria-live="polite"
+          className="text-muted-foreground flex cursor-default items-center gap-1.5 text-xs"
+        >
+          <Loader2 className="size-3.5 shrink-0 animate-spin" />
+          <span>Setting up environment</span>
+        </div>
+      </BasicTooltip>
+    );
+  }
+
+  if (state === 'completed_with_warnings') {
+    return (
+      <BasicTooltip content="Environment setup finished, but one or more setup steps reported warnings. Ask the agent to check the setup logs if something seems missing.">
+        <div
+          role="status"
+          className="text-warning-foreground flex cursor-default items-center gap-1.5 text-xs"
+        >
+          <TriangleAlert className="size-3.5 shrink-0" />
+          <span>Setup warnings</span>
+        </div>
+      </BasicTooltip>
+    );
+  }
+
+  return (
+    <BasicTooltip content="Background environment setup failed, so the workspace may be missing dependencies or services. Ask the agent to check the setup logs.">
+      <div
+        role="status"
+        className="text-destructive flex cursor-default items-center gap-1.5 text-xs"
+      >
+        <CircleX className="size-3.5 shrink-0" />
+        <span>Setup failed</span>
+      </div>
+    </BasicTooltip>
+  );
+}

--- a/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/TaskStatus.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/TaskStatus.tsx
@@ -7,6 +7,7 @@ import { TaskStatusIndicator } from '@/components/sandbox';
 import { BasicTooltip } from '@/components/system';
 import { useSandboxTaskStatusDisplay } from '../hooks/SandboxProvider';
 import { parseSleepDeadlineMs } from '../hooks/sleep-deadline';
+import { EnvironmentSetupBadge } from './EnvironmentSetupBadge';
 
 const MINUTE_MS = 60 * 1_000;
 function getDisplaySleepMinutes(ms: number): number {
@@ -76,6 +77,7 @@ export function TaskStatus({ taskRun }: TaskStatusProps) {
 
   return (
     <div className="flex items-center gap-3">
+      <EnvironmentSetupBadge taskRun={taskRun} />
       <TaskStatusIndicator phase={phase} lastErrorMessage={lastErrorMessage} />
       {!hasError &&
         showSleepBadge &&


### PR DESCRIPTION
## Problem

#333 makes background environment setup (repository setup commands and Docker projects) observable to the agent and the platform, but the web UI still says nothing: once the startup sequence hands off to the interactive view, the user can't tell whether setup is still running in the background, finished with warnings, or failed.

## Changes

Adds a compact `EnvironmentSetupBadge` next to the task status indicator above the prompt input, driven by the `environmentSetupState` field #333 added to the task run (already streamed to the client via the session query — no backend changes):

- `running` → muted spinner + "Setting up environment"
- `completed_with_warnings` → warning badge, tooltip suggests asking the agent to check the setup logs
- `failed` → destructive badge with the same pointer
- `completed` / `null` (setup never ran in the background) → renders nothing

State updates arrive through the session query's existing polling; no dedicated fast-poll was added since the badge is passive.

## Follow-ups (separate PRs)

Per-command startup progress driven by the `environmentRepositoryCommand` phase events, and a setup-logs viewer.

## Testing

- 6 new client tests covering all badge states plus the hidden cases
- `pnpm --filter web check-types` and `pnpm --filter web lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)