### PR TITLE
Resolve repositories host-aware via payload sourceControlHost

### DIFF
--- a/apps/api/src/handlers/ado/__tests__/getAdoAutomationTargets.test.ts
+++ b/apps/api/src/handlers/ado/__tests__/getAdoAutomationTargets.test.ts
@@ -1,5 +1,5 @@
 const {
-  mockRepositoriesFindFirst,
+  mockRepositoriesFindMany,
   mockAuthAccountsFindFirst,
   mockSelectWhere,
   mockGetReviewCodeAutomationSettings,
@@ -8,7 +8,7 @@ const {
   mockOr,
   mockDesc,
 } = vi.hoisted(() => ({
-  mockRepositoriesFindFirst: vi.fn(),
+  mockRepositoriesFindMany: vi.fn(),
   mockAuthAccountsFindFirst: vi.fn(),
   mockSelectWhere: vi.fn(),
   mockGetReviewCodeAutomationSettings: vi.fn(),
@@ -22,7 +22,7 @@ vi.mock('@roomote/db/server', () => ({
   db: {
     query: {
       repositories: {
-        findFirst: (arg: unknown) => mockRepositoriesFindFirst(arg),
+        findMany: (arg: unknown) => mockRepositoriesFindMany(arg),
       },
       authAccounts: {
         findFirst: (arg: unknown) => mockAuthAccountsFindFirst(arg),
@@ -79,11 +79,14 @@ describe('getAdoAutomationTargets', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    mockRepositoriesFindFirst.mockResolvedValue({
-      id: 'repo-1',
-      fullName: 'acme/Platform/backend',
-      linkedByUserId: 'repo-owner-1',
-    });
+    mockRepositoriesFindMany.mockResolvedValue([
+      {
+        id: 'repo-1',
+        fullName: 'acme/Platform/backend',
+        host: null,
+        linkedByUserId: 'repo-owner-1',
+      },
+    ]);
     mockSelectWhere.mockResolvedValue([{ environmentId: 'env-1' }]);
     mockAuthAccountsFindFirst.mockResolvedValue(null);
     mockGetReviewCodeAutomationSettings.mockResolvedValue({
@@ -234,6 +237,53 @@ describe('getAdoAutomationTargets', () => {
       code: 'account_link_required',
       message:
         'Azure DevOps user alice@acme.example is not linked to a Roomote user',
+    });
+  });
+  it('selects the repository row matching the webhook host among same-name rows', async () => {
+    mockRepositoriesFindMany.mockResolvedValue([
+      {
+        id: 'repo-host-a',
+        fullName: 'acme/Platform/backend',
+        host: 'ado.host-a.example',
+      },
+      {
+        id: 'repo-host-b',
+        fullName: 'acme/Platform/backend',
+        host: 'ado.host-b.example',
+      },
+    ]);
+
+    const result = await getAdoAutomationTargets({
+      workflow: 'pr_review',
+      payload,
+      webhookHost: 'ado.host-b.example',
+    });
+
+    expect(result).toMatchObject({
+      status: 'ok',
+      targets: [
+        {
+          id: 'ado:pr_review:repo-host-b',
+          repo: { id: 'repo-host-b', host: 'ado.host-b.example' },
+        },
+      ],
+    });
+  });
+
+  it('falls back to a legacy null-host row for a host-scoped lookup', async () => {
+    mockRepositoriesFindMany.mockResolvedValue([
+      { id: 'repo-legacy', fullName: 'acme/Platform/backend', host: null },
+    ]);
+
+    const result = await getAdoAutomationTargets({
+      workflow: 'pr_review',
+      payload,
+      webhookHost: 'ado.host-a.example',
+    });
+
+    expect(result).toMatchObject({
+      status: 'ok',
+      targets: [{ repo: { id: 'repo-legacy', host: null } }],
     });
   });
 });

--- a/apps/api/src/handlers/ado/__tests__/handleComment.test.ts
+++ b/apps/api/src/handlers/ado/__tests__/handleComment.test.ts
@@ -214,6 +214,60 @@ describe('handleAdoComment', () => {
     expect('sourceControlHost' in task.payload).toBe(false);
   });
 
+  it('selects and stamps the webhook host among same-name repositories on multiple hosts', async () => {
+    // Two active rows share the repository identity; only the host differs.
+    const rows = [
+      { id: 'repo-host-a', host: 'ado.host-a.example' },
+      { id: 'repo-host-b', host: 'ado.host-b.example' },
+    ];
+    mockGetAdoAutomationTargets.mockImplementation(
+      async ({ webhookHost }: { webhookHost?: string | null }) => {
+        const repo = rows.find((row) => row.host === webhookHost);
+        return repo
+          ? {
+              status: 'ok',
+              targets: [
+                {
+                  id: `ado:pr_review:${repo.id}`,
+                  settings: null,
+                  repo,
+                  repositoryIds: [repo.id],
+                  userId: 'user-1',
+                },
+              ],
+            }
+          : { status: 'error', message: 'no matching repository row' };
+      },
+    );
+
+    await handleAdoComment(
+      makeCommentPayload({
+        pullRequest: {
+          _links: {
+            web: {
+              href: 'https://ado.host-a.example/acme/Platform/_git/backend/pullrequest/42',
+            },
+          },
+        },
+      }),
+    );
+
+    // The handler derives the instance host from the webhook URL...
+    expect(mockGetAdoAutomationTargets).toHaveBeenCalledWith(
+      expect.objectContaining({ webhookHost: 'ado.host-a.example' }),
+    );
+    // ...and the launched payload pins the matching row's host.
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            sourceControlHost: 'ado.host-a.example',
+          }),
+        }),
+      }),
+    );
+  });
+
   it('stamps the repository host into mention review payloads when the repository row has one', async () => {
     mockGetAdoAutomationTargets.mockResolvedValue({
       status: 'ok',

--- a/apps/api/src/handlers/ado/__tests__/handleComment.test.ts
+++ b/apps/api/src/handlers/ado/__tests__/handleComment.test.ts
@@ -142,6 +142,7 @@ describe('handleAdoComment', () => {
         {
           id: 'ado:pr_review:repo-1',
           settings: null,
+          repo: { id: 'repo-1', host: null },
           repositoryIds: ['repo-1'],
           userId: 'user-1',
         },
@@ -203,6 +204,41 @@ describe('handleAdoComment', () => {
         threadId: '5',
         parentCommentId: 900,
         body: expect.stringContaining('started a pull request review task'),
+      }),
+    );
+    // A repository row without a recorded host omits the payload host field
+    // entirely so resolution falls back to (provider, fullName).
+    const [{ task }] = mockEnqueueTask.mock.calls[0]! as unknown as [
+      { task: { payload: Record<string, unknown> } },
+    ];
+    expect('sourceControlHost' in task.payload).toBe(false);
+  });
+
+  it('stamps the repository host into mention review payloads when the repository row has one', async () => {
+    mockGetAdoAutomationTargets.mockResolvedValue({
+      status: 'ok',
+      targets: [
+        {
+          id: 'ado:pr_review:repo-1',
+          settings: null,
+          repo: { id: 'repo-1', host: 'ado.example.com' },
+          repositoryIds: ['repo-1'],
+          userId: 'user-1',
+        },
+      ],
+    });
+
+    await handleAdoComment(makeCommentPayload());
+
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            sourceControlProvider: 'ado',
+            // Pins repository resolution to the webhook repository's host.
+            sourceControlHost: 'ado.example.com',
+          }),
+        }),
       }),
     );
   });

--- a/apps/api/src/handlers/ado/__tests__/handlePullRequest.test.ts
+++ b/apps/api/src/handlers/ado/__tests__/handlePullRequest.test.ts
@@ -178,6 +178,7 @@ describe('handleAdoPullRequest', () => {
         {
           id: 'ado:pr_review:repo-1',
           settings: null,
+          repo: { id: 'repo-1', host: null },
           repositoryIds: ['repo-1'],
           userId: 'user-1',
         },
@@ -238,6 +239,42 @@ describe('handleAdoPullRequest', () => {
       expect.objectContaining({
         launchClass: 'automation',
       }),
+    );
+    // A repository row without a recorded host omits the payload host field
+    // entirely so resolution falls back to (provider, fullName).
+    const [{ task }] = mockEnqueueTask.mock.calls[0]! as unknown as [
+      { task: { payload: Record<string, unknown> } },
+    ];
+    expect('sourceControlHost' in task.payload).toBe(false);
+  });
+
+  it('stamps the repository host into review payloads when the repository row has one', async () => {
+    mockGetAdoAutomationTargets.mockResolvedValue({
+      status: 'ok',
+      targets: [
+        {
+          id: 'ado:pr_review:repo-1',
+          settings: null,
+          repo: { id: 'repo-1', host: 'ado.example.com' },
+          repositoryIds: ['repo-1'],
+          userId: 'user-1',
+        },
+      ],
+    });
+
+    await handleAdoPullRequest(makePayload('git.pullrequest.created'));
+
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            sourceControlProvider: 'ado',
+            // Pins repository resolution to the webhook repository's host.
+            sourceControlHost: 'ado.example.com',
+          }),
+        }),
+      }),
+      expect.any(Object),
     );
   });
 

--- a/apps/api/src/handlers/ado/__tests__/handlePullRequest.test.ts
+++ b/apps/api/src/handlers/ado/__tests__/handlePullRequest.test.ts
@@ -248,6 +248,59 @@ describe('handleAdoPullRequest', () => {
     expect('sourceControlHost' in task.payload).toBe(false);
   });
 
+  it('selects and stamps the webhook host among same-name repositories on multiple hosts', async () => {
+    // Two active rows share the repository identity; only the host differs.
+    const rows = [
+      { id: 'repo-host-a', host: 'ado.host-a.example' },
+      { id: 'repo-host-b', host: 'ado.host-b.example' },
+    ];
+    mockGetAdoAutomationTargets.mockImplementation(
+      async ({ webhookHost }: { webhookHost?: string | null }) => {
+        const repo = rows.find((row) => row.host === webhookHost);
+        return repo
+          ? {
+              status: 'ok',
+              targets: [
+                {
+                  id: `ado:pr_review:${repo.id}`,
+                  settings: null,
+                  repo,
+                  repositoryIds: [repo.id],
+                  userId: 'user-1',
+                },
+              ],
+            }
+          : { status: 'error', message: 'no matching repository row' };
+      },
+    );
+
+    await handleAdoPullRequest(
+      makePayload('git.pullrequest.created', {
+        _links: {
+          web: {
+            href: 'https://ado.host-a.example/acme/Platform/_git/backend/pullrequest/42',
+          },
+        },
+      }),
+    );
+
+    // The handler derives the instance host from the webhook URL...
+    expect(mockGetAdoAutomationTargets).toHaveBeenCalledWith(
+      expect.objectContaining({ webhookHost: 'ado.host-a.example' }),
+    );
+    // ...and the launched payload pins the matching row's host.
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            sourceControlHost: 'ado.host-a.example',
+          }),
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
   it('stamps the repository host into review payloads when the repository row has one', async () => {
     mockGetAdoAutomationTargets.mockResolvedValue({
       status: 'ok',

--- a/apps/api/src/handlers/ado/getAdoAutomationTargets.ts
+++ b/apps/api/src/handlers/ado/getAdoAutomationTargets.ts
@@ -17,6 +17,7 @@ import {
   or,
 } from '@roomote/db/server';
 
+import { pickHostScopedRepository } from '../utils';
 import type { AdoIdentity, AdoPullRequestWebhook } from './types';
 
 type AdoAutomationWebhookContext = Pick<AdoPullRequestWebhook, 'resource'> & {
@@ -60,11 +61,18 @@ export function isRoomoteAdoIdentity(identityName: string): boolean {
 export async function getAdoAutomationTargets({
   workflow,
   payload,
+  webhookHost = null,
   ignoreAuthorPolicy = false,
   requireLinkedSenderAccount = false,
 }: {
   workflow: SourceControlAutomationWorkflow;
   payload: AdoAutomationWebhookContext;
+  /**
+   * Instance host derived from the webhook's own URLs. Scopes the repository
+   * lookup host-first (legacy NULL-host rows as fallback) so same-name
+   * repositories on other self-managed hosts are never selected.
+   */
+  webhookHost?: string | null;
   ignoreAuthorPolicy?: boolean;
   requireLinkedSenderAccount?: boolean;
 }): Promise<
@@ -89,7 +97,7 @@ export async function getAdoAutomationTargets({
   );
   const senderName = getAdoIdentityName(payload.commentAuthor);
 
-  const repo = await db.query.repositories.findFirst({
+  const repoRows = await db.query.repositories.findMany({
     where: and(
       eq(repositories.sourceControlProvider, 'ado'),
       eq(repositories.isActive, true),
@@ -101,6 +109,7 @@ export async function getAdoAutomationTargets({
         : eq(repositories.externalRepoId, repositoryId),
     ),
   });
+  const repo = pickHostScopedRepository(repoRows, webhookHost);
 
   if (!repo) {
     return {

--- a/apps/api/src/handlers/ado/handleComment.ts
+++ b/apps/api/src/handlers/ado/handleComment.ts
@@ -396,6 +396,10 @@ export async function handleAdoComment(
   const reviewPayload = {
     repo: repoFullName,
     sourceControlProvider: 'ado',
+    // Pin repository resolution to the webhook repository's host so
+    // same-name repositories on other hosts cannot be picked up. Legacy
+    // rows without a recorded host omit the field.
+    ...(target.repo.host ? { sourceControlHost: target.repo.host } : {}),
     prNumber: pullRequest.pullRequestId,
     prTitle: pullRequest.title,
     prUrl: getAdoPullRequestUrl({

--- a/apps/api/src/handlers/ado/handleComment.ts
+++ b/apps/api/src/handlers/ado/handleComment.ts
@@ -16,6 +16,7 @@ import {
 } from '@roomote/types';
 
 import type { WebhookResponse } from '../../types';
+import { toHostFromUrl } from '../utils';
 import {
   sendMessageToTask,
   steerMessageToTask,
@@ -287,6 +288,15 @@ export async function handleAdoComment(
       repositoryFullName: repoFullName,
       commentAuthor: author,
     },
+    // The PR web URL (or the account/collection base URL it is built from)
+    // carries the instance host, matching repositories.host.
+    webhookHost: toHostFromUrl(
+      getAdoPullRequestUrl({
+        resourceContainers: payload.resourceContainers,
+        pullRequest,
+        repositoryFullName: repoFullName,
+      }),
+    ),
     ignoreAuthorPolicy: true,
     requireLinkedSenderAccount: true,
   });

--- a/apps/api/src/handlers/ado/handlePullRequest.ts
+++ b/apps/api/src/handlers/ado/handlePullRequest.ts
@@ -28,6 +28,7 @@ import {
 import type { WebhookResponse } from '../../types';
 import { scheduleNotifyPullRequestTerminalStatus } from '../github/notifyPullRequestTerminalStatus';
 import { scheduleSourceControlPullRequestFactSync } from '../pull-request-fact-sync';
+import { toHostFromUrl } from '../utils';
 import {
   getAdoAutomationTargets,
   getAdoIdentityName,
@@ -333,6 +334,15 @@ export async function handleAdoPullRequest(
   const result = await getAdoAutomationTargets({
     workflow: 'pr_review',
     payload: { ...payload, repositoryFullName: repoFullName },
+    // The PR web URL (or the account/collection base URL it is built from)
+    // carries the instance host, matching repositories.host.
+    webhookHost: toHostFromUrl(
+      getAdoPullRequestUrl({
+        resourceContainers: payload.resourceContainers,
+        pullRequest,
+        repositoryFullName: repoFullName,
+      }),
+    ),
   });
 
   if (result.status === 'error') {

--- a/apps/api/src/handlers/ado/handlePullRequest.ts
+++ b/apps/api/src/handlers/ado/handlePullRequest.ts
@@ -387,7 +387,7 @@ export async function handleAdoPullRequest(
   const prAuthorName = getAdoIdentityName(pullRequest.createdBy);
   const prAuthorId = pullRequest.createdBy?.id?.trim() || prAuthorName;
 
-  const enqueued = await pMap(targets, async (_target) =>
+  const enqueued = await pMap(targets, async (target) =>
     enqueueTask(
       {
         task: {
@@ -395,6 +395,12 @@ export async function handleAdoPullRequest(
           payload: {
             repo: repoFullName,
             sourceControlProvider: 'ado',
+            // Pin repository resolution to the webhook repository's host so
+            // same-name repositories on other hosts cannot be picked up.
+            // Legacy rows without a recorded host omit the field.
+            ...(target.repo.host
+              ? { sourceControlHost: target.repo.host }
+              : {}),
             prNumber: pullRequest.pullRequestId,
             prTitle: pullRequest.title,
             prUrl,

--- a/apps/api/src/handlers/bitbucket/__tests__/handlePullRequest.test.ts
+++ b/apps/api/src/handlers/bitbucket/__tests__/handlePullRequest.test.ts
@@ -139,6 +139,61 @@ describe('handleBitbucketPullRequest', () => {
     expect('sourceControlHost' in task.payload).toBe(false);
   });
 
+  it('selects and stamps the webhook host among same-name repositories on multiple hosts', async () => {
+    // Two active rows share the repository identity; only the host differs.
+    const rows = [
+      { id: 'repo-host-a', host: 'bitbucket.host-a.example' },
+      { id: 'repo-host-b', host: 'bitbucket.host-b.example' },
+    ];
+    mockGetBitbucketAutomationTargets.mockImplementation(
+      async ({ webhookHost }: { webhookHost?: string | null }) => {
+        const repo = rows.find((row) => row.host === webhookHost);
+        return repo
+          ? {
+              status: 'ok',
+              targets: [
+                {
+                  id: `bitbucket:pr_review:${repo.id}`,
+                  settings: null,
+                  repo,
+                  repositoryIds: [repo.id],
+                  userId: 'user-1',
+                },
+              ],
+            }
+          : { status: 'error', message: 'no matching repository row' };
+      },
+    );
+
+    await handleBitbucketPullRequest(
+      makePayload({
+        state: 'OPEN',
+        links: {
+          html: {
+            href: 'https://bitbucket.host-a.example/acme/backend/pull-requests/42',
+          },
+        },
+      }),
+      'pullrequest:created',
+    );
+
+    // The handler derives the instance host from the webhook URL...
+    expect(mockGetBitbucketAutomationTargets).toHaveBeenCalledWith(
+      expect.objectContaining({ webhookHost: 'bitbucket.host-a.example' }),
+    );
+    // ...and the launched payload pins the matching row's host.
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            sourceControlHost: 'bitbucket.host-a.example',
+          }),
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
   it('stamps the repository host into review payloads when the repository row has one', async () => {
     mockGetBitbucketAutomationTargets.mockResolvedValue({
       status: 'ok',

--- a/apps/api/src/handlers/bitbucket/__tests__/handlePullRequest.test.ts
+++ b/apps/api/src/handlers/bitbucket/__tests__/handlePullRequest.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   mockEnqueueTask,
+  mockGetBitbucketAutomationTargets,
   mockUpdateTaskPrStatus,
   mockRecordPrStatusChangeInTaskHistory,
   mockRepositoriesFindFirst,
@@ -9,6 +10,7 @@ const {
   mockScheduleSourceControlPullRequestFactSync,
 } = vi.hoisted(() => ({
   mockEnqueueTask: vi.fn(),
+  mockGetBitbucketAutomationTargets: vi.fn(),
   mockUpdateTaskPrStatus: vi.fn(),
   mockRecordPrStatusChangeInTaskHistory: vi.fn(),
   mockRepositoriesFindFirst: vi.fn(),
@@ -53,6 +55,12 @@ vi.mock('../../pull-request-fact-sync', () => ({
     mockScheduleSourceControlPullRequestFactSync,
 }));
 
+vi.mock('../getBitbucketAutomationTargets', () => ({
+  getBitbucketAutomationTargets: mockGetBitbucketAutomationTargets,
+  getBitbucketUsername: (user?: { nickname?: string }) => user?.nickname,
+  getBitbucketUserAccountKey: () => null,
+}));
+
 import { handleBitbucketPullRequest } from '../handlePullRequest';
 import type { BitbucketPullRequestWebhook } from '../types';
 
@@ -88,6 +96,80 @@ describe('handleBitbucketPullRequest', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRepositoriesFindFirst.mockResolvedValue({ id: 'repo-row-1' });
+    mockGetBitbucketAutomationTargets.mockResolvedValue({
+      status: 'ok',
+      targets: [
+        {
+          id: 'bitbucket:pr_review:repo-1',
+          settings: null,
+          repo: { id: 'repo-1', host: null },
+          repositoryIds: ['repo-1'],
+          userId: 'user-1',
+        },
+      ],
+    });
+    mockEnqueueTask.mockResolvedValue({ id: 1234, taskId: 'task-1' });
+  });
+
+  it('enqueues a review without a payload host when the repository row has none', async () => {
+    await expect(
+      handleBitbucketPullRequest(
+        makePayload({ state: 'OPEN' }),
+        'pullrequest:created',
+      ),
+    ).resolves.toEqual({ status: 'ok', metadata: { ids: [1234] } });
+
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            repo: 'acme/backend',
+            sourceControlProvider: 'bitbucket',
+            prNumber: 42,
+          }),
+        }),
+      }),
+      expect.objectContaining({ launchClass: 'automation' }),
+    );
+    // A repository row without a recorded host omits the payload host field
+    // entirely so resolution falls back to (provider, fullName).
+    const [{ task }] = mockEnqueueTask.mock.calls[0]! as unknown as [
+      { task: { payload: Record<string, unknown> } },
+    ];
+    expect('sourceControlHost' in task.payload).toBe(false);
+  });
+
+  it('stamps the repository host into review payloads when the repository row has one', async () => {
+    mockGetBitbucketAutomationTargets.mockResolvedValue({
+      status: 'ok',
+      targets: [
+        {
+          id: 'bitbucket:pr_review:repo-1',
+          settings: null,
+          repo: { id: 'repo-1', host: 'bitbucket.example.com' },
+          repositoryIds: ['repo-1'],
+          userId: 'user-1',
+        },
+      ],
+    });
+
+    await handleBitbucketPullRequest(
+      makePayload({ state: 'OPEN' }),
+      'pullrequest:created',
+    );
+
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            sourceControlProvider: 'bitbucket',
+            // Pins repository resolution to the webhook repository's host.
+            sourceControlHost: 'bitbucket.example.com',
+          }),
+        }),
+      }),
+      expect.any(Object),
+    );
   });
 
   it('updates tracked PR status and schedules a fact upsert for merged pull requests', async () => {

--- a/apps/api/src/handlers/bitbucket/getBitbucketAutomationTargets.ts
+++ b/apps/api/src/handlers/bitbucket/getBitbucketAutomationTargets.ts
@@ -18,6 +18,7 @@ import {
 } from '@roomote/db/server';
 import { normalizeBitbucketLinkedAccountKey } from '@roomote/bitbucket';
 
+import { pickHostScopedRepository } from '../utils';
 import type {
   BitbucketPullRequestCommentWebhook,
   BitbucketPullRequestWebhook,
@@ -68,11 +69,18 @@ export function getBitbucketUserAccountKey(
 export async function getBitbucketAutomationTargets({
   workflow,
   payload,
+  webhookHost = null,
   ignoreAuthorPolicy = false,
   requireLinkedSenderAccount = false,
 }: {
   workflow: SourceControlAutomationWorkflow;
   payload: BitbucketAutomationWebhookContext;
+  /**
+   * Instance host derived from the webhook's own URLs. Scopes the repository
+   * lookup host-first (legacy NULL-host rows as fallback) so same-name
+   * repositories on other self-managed hosts are never selected.
+   */
+  webhookHost?: string | null;
   ignoreAuthorPolicy?: boolean;
   requireLinkedSenderAccount?: boolean;
 }): Promise<
@@ -94,7 +102,7 @@ export async function getBitbucketAutomationTargets({
   const senderUsername = getBitbucketUsername(sender) ?? authorUsername;
   let linkedSenderUserId: string | null = null;
 
-  const repo = await db.query.repositories.findFirst({
+  const repoRows = await db.query.repositories.findMany({
     where: and(
       eq(repositories.sourceControlProvider, 'bitbucket'),
       eq(repositories.isActive, true),
@@ -106,6 +114,7 @@ export async function getBitbucketAutomationTargets({
         : eq(repositories.externalRepoId, repositoryId),
     ),
   });
+  const repo = pickHostScopedRepository(repoRows, webhookHost);
 
   if (!repo) {
     return {

--- a/apps/api/src/handlers/bitbucket/handleComment.ts
+++ b/apps/api/src/handlers/bitbucket/handleComment.ts
@@ -379,6 +379,10 @@ export async function handleBitbucketComment(
   const reviewPayload = {
     repo: repoFullName,
     sourceControlProvider: 'bitbucket',
+    // Pin repository resolution to the webhook repository's host so
+    // same-name repositories on other hosts cannot be picked up. Legacy
+    // rows without a recorded host omit the field.
+    ...(target.repo.host ? { sourceControlHost: target.repo.host } : {}),
     prNumber,
     prTitle: pullRequest.title,
     prUrl,

--- a/apps/api/src/handlers/bitbucket/handleComment.ts
+++ b/apps/api/src/handlers/bitbucket/handleComment.ts
@@ -16,6 +16,7 @@ import {
 } from '@roomote/types';
 
 import type { WebhookResponse } from '../../types';
+import { toHostFromUrl } from '../utils';
 import { buildSourceControlAccountLinkRequiredMessage } from '../source-control-account-linking';
 import {
   sendMessageToTask,
@@ -271,6 +272,8 @@ export async function handleBitbucketComment(
       actor: payload.actor,
       commentAuthor: payload.comment.user,
     },
+    // The PR web URL carries the instance host, matching repositories.host.
+    webhookHost: toHostFromUrl(getBitbucketPullRequestUrl(payload)),
     ignoreAuthorPolicy: true,
     requireLinkedSenderAccount: true,
   });

--- a/apps/api/src/handlers/bitbucket/handlePullRequest.ts
+++ b/apps/api/src/handlers/bitbucket/handlePullRequest.ts
@@ -22,6 +22,7 @@ import {
 import type { WebhookResponse } from '../../types';
 import { scheduleNotifyPullRequestTerminalStatus } from '../github/notifyPullRequestTerminalStatus';
 import { scheduleSourceControlPullRequestFactSync } from '../pull-request-fact-sync';
+import { toHostFromUrl } from '../utils';
 import {
   getBitbucketAutomationTargets,
   getBitbucketUsername,
@@ -160,6 +161,8 @@ export async function handleBitbucketPullRequest(
   const result = await getBitbucketAutomationTargets({
     workflow: 'pr_review',
     payload,
+    // The PR web URL carries the instance host, matching repositories.host.
+    webhookHost: toHostFromUrl(getBitbucketPullRequestUrl(payload)),
   });
 
   if (result.status === 'error') {

--- a/apps/api/src/handlers/bitbucket/handlePullRequest.ts
+++ b/apps/api/src/handlers/bitbucket/handlePullRequest.ts
@@ -214,7 +214,7 @@ export async function handleBitbucketPullRequest(
   const prAuthorId =
     getBitbucketUserAccountKey(pullRequest.author) ?? prAuthorName;
 
-  const enqueued = await pMap(targets, async (_target) =>
+  const enqueued = await pMap(targets, async (target) =>
     enqueueTask(
       {
         task: {
@@ -222,6 +222,12 @@ export async function handleBitbucketPullRequest(
           payload: {
             repo: repoFullName,
             sourceControlProvider: 'bitbucket',
+            // Pin repository resolution to the webhook repository's host so
+            // same-name repositories on other hosts cannot be picked up.
+            // Legacy rows without a recorded host omit the field.
+            ...(target.repo.host
+              ? { sourceControlHost: target.repo.host }
+              : {}),
             prNumber,
             prTitle: pullRequest.title,
             prUrl,

--- a/apps/api/src/handlers/gitea/__tests__/getGiteaAutomationTargets.test.ts
+++ b/apps/api/src/handlers/gitea/__tests__/getGiteaAutomationTargets.test.ts
@@ -1,5 +1,5 @@
 const {
-  mockRepositoriesFindFirst,
+  mockRepositoriesFindMany,
   mockAuthAccountsFindFirst,
   mockSelectWhere,
   mockGetReviewCodeAutomationSettings,
@@ -8,7 +8,7 @@ const {
   mockOr,
   mockDesc,
 } = vi.hoisted(() => ({
-  mockRepositoriesFindFirst: vi.fn(),
+  mockRepositoriesFindMany: vi.fn(),
   mockAuthAccountsFindFirst: vi.fn(),
   mockSelectWhere: vi.fn(),
   mockGetReviewCodeAutomationSettings: vi.fn(),
@@ -22,7 +22,7 @@ vi.mock('@roomote/db/server', () => ({
   db: {
     query: {
       repositories: {
-        findFirst: (arg: unknown) => mockRepositoriesFindFirst(arg),
+        findMany: (arg: unknown) => mockRepositoriesFindMany(arg),
       },
       authAccounts: {
         findFirst: (arg: unknown) => mockAuthAccountsFindFirst(arg),
@@ -62,11 +62,14 @@ describe('getGiteaAutomationTargets', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    mockRepositoriesFindFirst.mockResolvedValue({
-      id: 'repo-1',
-      fullName: 'acme/backend',
-      linkedByUserId: 'repo-owner-1',
-    });
+    mockRepositoriesFindMany.mockResolvedValue([
+      {
+        id: 'repo-1',
+        fullName: 'acme/backend',
+        host: null,
+        linkedByUserId: 'repo-owner-1',
+      },
+    ]);
     mockAuthAccountsFindFirst.mockResolvedValue(null);
     mockSelectWhere.mockResolvedValue([{ environmentId: 'env-1' }]);
     mockGetReviewCodeAutomationSettings.mockResolvedValue({
@@ -217,6 +220,60 @@ describe('getGiteaAutomationTargets', () => {
       status: 'error',
       message:
         'no environment mapping associated with [gitea:42, acme/backend]',
+    });
+  });
+
+  it('selects the repository row matching the webhook host among same-name rows', async () => {
+    mockRepositoriesFindMany.mockResolvedValue([
+      {
+        id: 'repo-host-a',
+        fullName: 'acme/backend',
+        host: 'gitea.host-a.example',
+      },
+      {
+        id: 'repo-host-b',
+        fullName: 'acme/backend',
+        host: 'gitea.host-b.example',
+      },
+    ]);
+
+    const result = await getGiteaAutomationTargets({
+      workflow: 'pr_review',
+      payload: {
+        repository: { id: 42, full_name: 'acme/backend' },
+        sender: { id: 987, login: 'roomote-bot' },
+      },
+      webhookHost: 'gitea.host-b.example',
+    });
+
+    expect(result).toMatchObject({
+      status: 'ok',
+      targets: [
+        {
+          id: 'gitea:pr_review:repo-host-b',
+          repo: { id: 'repo-host-b', host: 'gitea.host-b.example' },
+        },
+      ],
+    });
+  });
+
+  it('falls back to a legacy null-host row for a host-scoped lookup', async () => {
+    mockRepositoriesFindMany.mockResolvedValue([
+      { id: 'repo-legacy', fullName: 'acme/backend', host: null },
+    ]);
+
+    const result = await getGiteaAutomationTargets({
+      workflow: 'pr_review',
+      payload: {
+        repository: { id: 42, full_name: 'acme/backend' },
+        sender: { id: 987, login: 'roomote-bot' },
+      },
+      webhookHost: 'gitea.host-a.example',
+    });
+
+    expect(result).toMatchObject({
+      status: 'ok',
+      targets: [{ repo: { id: 'repo-legacy', host: null } }],
     });
   });
 });

--- a/apps/api/src/handlers/gitea/__tests__/handleComment.test.ts
+++ b/apps/api/src/handlers/gitea/__tests__/handleComment.test.ts
@@ -178,6 +178,56 @@ describe('handleGiteaComment', () => {
     expect('sourceControlHost' in task.payload).toBe(false);
   });
 
+  it('selects and stamps the webhook host among same-name repositories on multiple hosts', async () => {
+    // Two active rows share the repository identity; only the host differs.
+    const rows = [
+      { id: 'repo-host-a', host: 'gitea.host-a.example' },
+      { id: 'repo-host-b', host: 'gitea.host-b.example' },
+    ];
+    mockGetGiteaAutomationTargets.mockImplementation(
+      async ({ webhookHost }: { webhookHost?: string | null }) => {
+        const repo = rows.find((row) => row.host === webhookHost);
+        return repo
+          ? {
+              status: 'ok',
+              targets: [
+                {
+                  id: `gitea:pr_review:${repo.id}`,
+                  settings: null,
+                  repo,
+                  repositoryIds: [repo.id],
+                  userId: 'user-1',
+                },
+              ],
+            }
+          : { status: 'error', message: 'no matching repository row' };
+      },
+    );
+
+    await handleGiteaComment(
+      makeCommentPayload({
+        pullRequest: {
+          html_url: 'https://gitea.host-a.example/acme/backend/pulls/42',
+        },
+      }),
+    );
+
+    // The handler derives the instance host from the webhook URL...
+    expect(mockGetGiteaAutomationTargets).toHaveBeenCalledWith(
+      expect.objectContaining({ webhookHost: 'gitea.host-a.example' }),
+    );
+    // ...and the launched payload pins the matching row's host.
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            sourceControlHost: 'gitea.host-a.example',
+          }),
+        }),
+      }),
+    );
+  });
+
   it('stamps the repository host into mention review payloads when the repository row has one', async () => {
     mockGetGiteaAutomationTargets.mockResolvedValue({
       status: 'ok',

--- a/apps/api/src/handlers/gitea/__tests__/handleComment.test.ts
+++ b/apps/api/src/handlers/gitea/__tests__/handleComment.test.ts
@@ -118,6 +118,7 @@ describe('handleGiteaComment', () => {
         {
           id: 'gitea:pr_review:repo-1',
           settings: null,
+          repo: { id: 'repo-1', host: null },
           repositoryIds: ['repo-1'],
           userId: 'user-1',
         },
@@ -167,6 +168,41 @@ describe('handleGiteaComment', () => {
         repositoryFullName: 'acme/backend',
         pullRequestNumber: 42,
         body: expect.stringContaining('I started a pull request review task'),
+      }),
+    );
+    // A repository row without a recorded host omits the payload host field
+    // entirely so resolution falls back to (provider, fullName).
+    const [{ task }] = mockEnqueueTask.mock.calls[0]! as unknown as [
+      { task: { payload: Record<string, unknown> } },
+    ];
+    expect('sourceControlHost' in task.payload).toBe(false);
+  });
+
+  it('stamps the repository host into mention review payloads when the repository row has one', async () => {
+    mockGetGiteaAutomationTargets.mockResolvedValue({
+      status: 'ok',
+      targets: [
+        {
+          id: 'gitea:pr_review:repo-1',
+          settings: null,
+          repo: { id: 'repo-1', host: 'git.example.com' },
+          repositoryIds: ['repo-1'],
+          userId: 'user-1',
+        },
+      ],
+    });
+
+    await handleGiteaComment(makeCommentPayload());
+
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            sourceControlProvider: 'gitea',
+            // Pins repository resolution to the webhook repository's host.
+            sourceControlHost: 'git.example.com',
+          }),
+        }),
       }),
     );
   });

--- a/apps/api/src/handlers/gitea/__tests__/handlePullRequest.test.ts
+++ b/apps/api/src/handlers/gitea/__tests__/handlePullRequest.test.ts
@@ -178,6 +178,55 @@ describe('handleGiteaPullRequest', () => {
     expect('sourceControlHost' in task.payload).toBe(false);
   });
 
+  it('selects and stamps the webhook host among same-name repositories on multiple hosts', async () => {
+    // Two active rows share the repository identity; only the host differs.
+    const rows = [
+      { id: 'repo-host-a', host: 'gitea.host-a.example' },
+      { id: 'repo-host-b', host: 'gitea.host-b.example' },
+    ];
+    mockGetGiteaAutomationTargets.mockImplementation(
+      async ({ webhookHost }: { webhookHost?: string | null }) => {
+        const repo = rows.find((row) => row.host === webhookHost);
+        return repo
+          ? {
+              status: 'ok',
+              targets: [
+                {
+                  id: `gitea:pr_review:${repo.id}`,
+                  settings: null,
+                  repo,
+                  repositoryIds: [repo.id],
+                  userId: 'user-1',
+                },
+              ],
+            }
+          : { status: 'error', message: 'no matching repository row' };
+      },
+    );
+
+    await handleGiteaPullRequest(
+      makePayload('opened', {
+        html_url: 'https://gitea.host-a.example/acme/backend/pulls/42',
+      }),
+    );
+
+    // The handler derives the instance host from the webhook URL...
+    expect(mockGetGiteaAutomationTargets).toHaveBeenCalledWith(
+      expect.objectContaining({ webhookHost: 'gitea.host-a.example' }),
+    );
+    // ...and the launched payload pins the matching row's host.
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            sourceControlHost: 'gitea.host-a.example',
+          }),
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
   it('stamps the repository host into review payloads when the repository row has one', async () => {
     mockGetGiteaAutomationTargets.mockResolvedValue({
       status: 'ok',

--- a/apps/api/src/handlers/gitea/__tests__/handlePullRequest.test.ts
+++ b/apps/api/src/handlers/gitea/__tests__/handlePullRequest.test.ts
@@ -114,6 +114,7 @@ describe('handleGiteaPullRequest', () => {
         {
           id: 'gitea:pr_review:repo-1',
           settings: null,
+          repo: { id: 'repo-1', host: null },
           repositoryIds: ['repo-1'],
           userId: 'user-1',
         },
@@ -168,6 +169,42 @@ describe('handleGiteaPullRequest', () => {
       expect.objectContaining({
         launchClass: 'automation',
       }),
+    );
+    // A repository row without a recorded host omits the payload host field
+    // entirely so resolution falls back to (provider, fullName).
+    const [{ task }] = mockEnqueueTask.mock.calls[0]! as unknown as [
+      { task: { payload: Record<string, unknown> } },
+    ];
+    expect('sourceControlHost' in task.payload).toBe(false);
+  });
+
+  it('stamps the repository host into review payloads when the repository row has one', async () => {
+    mockGetGiteaAutomationTargets.mockResolvedValue({
+      status: 'ok',
+      targets: [
+        {
+          id: 'gitea:pr_review:repo-1',
+          settings: null,
+          repo: { id: 'repo-1', host: 'git.example.com' },
+          repositoryIds: ['repo-1'],
+          userId: 'user-1',
+        },
+      ],
+    });
+
+    await handleGiteaPullRequest(makePayload('opened'));
+
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            sourceControlProvider: 'gitea',
+            // Pins repository resolution to the webhook repository's host.
+            sourceControlHost: 'git.example.com',
+          }),
+        }),
+      }),
+      expect.any(Object),
     );
   });
 

--- a/apps/api/src/handlers/gitea/getGiteaAutomationTargets.ts
+++ b/apps/api/src/handlers/gitea/getGiteaAutomationTargets.ts
@@ -16,6 +16,7 @@ import {
   or,
 } from '@roomote/db/server';
 
+import { pickHostScopedRepository } from '../utils';
 import type {
   GiteaPullRequestCommentWebhook,
   GiteaPullRequestWebhook,
@@ -58,11 +59,18 @@ function getGiteaUserId(user: GiteaUser | undefined): string | null {
 export async function getGiteaAutomationTargets({
   workflow,
   payload,
+  webhookHost = null,
   ignoreAuthorPolicy = false,
   requireLinkedSenderAccount = false,
 }: {
   workflow: SourceControlAutomationWorkflow;
   payload: GiteaAutomationWebhookContext;
+  /**
+   * Instance host derived from the webhook's own URLs. Scopes the repository
+   * lookup host-first (legacy NULL-host rows as fallback) so same-name
+   * repositories on other self-managed hosts are never selected.
+   */
+  webhookHost?: string | null;
   ignoreAuthorPolicy?: boolean;
   requireLinkedSenderAccount?: boolean;
 }): Promise<
@@ -84,7 +92,7 @@ export async function getGiteaAutomationTargets({
   const senderUsername = getGiteaUsername(sender) ?? authorUsername;
   let linkedSenderUserId: string | null = null;
 
-  const repo = await db.query.repositories.findFirst({
+  const repoRows = await db.query.repositories.findMany({
     where: and(
       eq(repositories.sourceControlProvider, 'gitea'),
       eq(repositories.isActive, true),
@@ -96,6 +104,7 @@ export async function getGiteaAutomationTargets({
         : eq(repositories.externalRepoId, repositoryId),
     ),
   });
+  const repo = pickHostScopedRepository(repoRows, webhookHost);
 
   if (!repo) {
     return {

--- a/apps/api/src/handlers/gitea/handleComment.ts
+++ b/apps/api/src/handlers/gitea/handleComment.ts
@@ -346,6 +346,10 @@ export async function handleGiteaComment(
   const reviewPayload = {
     repo: repoFullName,
     sourceControlProvider: 'gitea',
+    // Pin repository resolution to the webhook repository's host so
+    // same-name repositories on other hosts cannot be picked up. Legacy
+    // rows without a recorded host omit the field.
+    ...(target.repo.host ? { sourceControlHost: target.repo.host } : {}),
     prNumber: pullRequest.number,
     prTitle: pullRequest.title,
     prUrl,

--- a/apps/api/src/handlers/gitea/handleComment.ts
+++ b/apps/api/src/handlers/gitea/handleComment.ts
@@ -25,6 +25,7 @@ import {
   getGiteaUsername,
   isRoomoteGiteaUsername,
 } from './getGiteaAutomationTargets';
+import { toHostFromUrl } from '../utils';
 import type { GiteaPullRequestCommentWebhook } from './types';
 
 const GITEA_MENTION_HANDLE = '@roomote';
@@ -230,6 +231,14 @@ export async function handleGiteaComment(
       sender: payload.sender,
       commentAuthor: payload.comment.user,
     },
+    // The PR (or repository) web URL carries the instance host, matching
+    // repositories.host.
+    webhookHost: toHostFromUrl(
+      pullRequest.html_url ??
+        pullRequest.url ??
+        payload.repository.html_url ??
+        '',
+    ),
     ignoreAuthorPolicy: true,
     requireLinkedSenderAccount: true,
   });

--- a/apps/api/src/handlers/gitea/handlePullRequest.ts
+++ b/apps/api/src/handlers/gitea/handlePullRequest.ts
@@ -206,7 +206,7 @@ export async function handleGiteaPullRequest(
   const prAuthorId =
     pullRequest.user?.id != null ? String(pullRequest.user.id) : prAuthorName;
 
-  const enqueued = await pMap(targets, async (_target) =>
+  const enqueued = await pMap(targets, async (target) =>
     enqueueTask(
       {
         task: {
@@ -214,6 +214,12 @@ export async function handleGiteaPullRequest(
           payload: {
             repo: repoFullName,
             sourceControlProvider: 'gitea',
+            // Pin repository resolution to the webhook repository's host so
+            // same-name repositories on other hosts cannot be picked up.
+            // Legacy rows without a recorded host omit the field.
+            ...(target.repo.host
+              ? { sourceControlHost: target.repo.host }
+              : {}),
             prNumber: payload.number,
             prTitle: pullRequest.title,
             prUrl,

--- a/apps/api/src/handlers/gitea/handlePullRequest.ts
+++ b/apps/api/src/handlers/gitea/handlePullRequest.ts
@@ -22,6 +22,7 @@ import {
 import type { WebhookResponse } from '../../types';
 import { scheduleNotifyPullRequestTerminalStatus } from '../github/notifyPullRequestTerminalStatus';
 import { scheduleSourceControlPullRequestFactSync } from '../pull-request-fact-sync';
+import { toHostFromUrl } from '../utils';
 import {
   getGiteaAutomationTargets,
   getGiteaUsername,
@@ -155,6 +156,8 @@ export async function handleGiteaPullRequest(
   const result = await getGiteaAutomationTargets({
     workflow: 'pr_review',
     payload,
+    // The PR web URL carries the instance host, matching repositories.host.
+    webhookHost: toHostFromUrl(getPullRequestUrl(payload)),
   });
 
   if (result.status === 'error') {

--- a/apps/api/src/handlers/gitlab/__tests__/getGitLabAutomationTargets.test.ts
+++ b/apps/api/src/handlers/gitlab/__tests__/getGitLabAutomationTargets.test.ts
@@ -1,5 +1,5 @@
 const {
-  mockRepositoriesFindFirst,
+  mockRepositoriesFindMany,
   mockAuthAccountsFindFirst,
   mockSelectWhere,
   mockGetReviewCodeAutomationSettings,
@@ -8,7 +8,7 @@ const {
   mockOr,
   mockDesc,
 } = vi.hoisted(() => ({
-  mockRepositoriesFindFirst: vi.fn(),
+  mockRepositoriesFindMany: vi.fn(),
   mockAuthAccountsFindFirst: vi.fn(),
   mockSelectWhere: vi.fn(),
   mockGetReviewCodeAutomationSettings: vi.fn(),
@@ -22,7 +22,7 @@ vi.mock('@roomote/db/server', () => ({
   db: {
     query: {
       repositories: {
-        findFirst: (arg: unknown) => mockRepositoriesFindFirst(arg),
+        findMany: (arg: unknown) => mockRepositoriesFindMany(arg),
       },
       authAccounts: {
         findFirst: (arg: unknown) => mockAuthAccountsFindFirst(arg),
@@ -62,11 +62,14 @@ describe('getGitLabAutomationTargets', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    mockRepositoriesFindFirst.mockResolvedValue({
-      id: 'repo-1',
-      fullName: 'acme/backend',
-      linkedByUserId: 'repo-owner-1',
-    });
+    mockRepositoriesFindMany.mockResolvedValue([
+      {
+        id: 'repo-1',
+        fullName: 'acme/backend',
+        host: null,
+        linkedByUserId: 'repo-owner-1',
+      },
+    ]);
     mockAuthAccountsFindFirst.mockResolvedValue(null);
     mockSelectWhere.mockResolvedValue([{ environmentId: 'env-1' }]);
     mockGetReviewCodeAutomationSettings.mockResolvedValue({
@@ -148,6 +151,60 @@ describe('getGitLabAutomationTargets', () => {
       status: 'error',
       message:
         'no environment mapping associated with [gitlab:42, acme/backend]',
+    });
+  });
+
+  it('selects the repository row matching the webhook host among same-name rows', async () => {
+    mockRepositoriesFindMany.mockResolvedValue([
+      {
+        id: 'repo-host-a',
+        fullName: 'acme/backend',
+        host: 'gitlab.host-a.example',
+      },
+      {
+        id: 'repo-host-b',
+        fullName: 'acme/backend',
+        host: 'gitlab.host-b.example',
+      },
+    ]);
+
+    const result = await getGitLabAutomationTargets({
+      workflow: 'pr_review',
+      payload: {
+        project: { id: 42, path_with_namespace: 'acme/backend' },
+        user: { id: 987, username: 'roomote-bot' },
+      },
+      webhookHost: 'gitlab.host-b.example',
+    });
+
+    expect(result).toMatchObject({
+      status: 'ok',
+      targets: [
+        {
+          id: 'gitlab:pr_review:repo-host-b',
+          repo: { id: 'repo-host-b', host: 'gitlab.host-b.example' },
+        },
+      ],
+    });
+  });
+
+  it('falls back to a legacy null-host row for a host-scoped lookup', async () => {
+    mockRepositoriesFindMany.mockResolvedValue([
+      { id: 'repo-legacy', fullName: 'acme/backend', host: null },
+    ]);
+
+    const result = await getGitLabAutomationTargets({
+      workflow: 'pr_review',
+      payload: {
+        project: { id: 42, path_with_namespace: 'acme/backend' },
+        user: { id: 987, username: 'roomote-bot' },
+      },
+      webhookHost: 'gitlab.host-a.example',
+    });
+
+    expect(result).toMatchObject({
+      status: 'ok',
+      targets: [{ repo: { id: 'repo-legacy', host: null } }],
     });
   });
 });

--- a/apps/api/src/handlers/gitlab/__tests__/handleMergeRequest.test.ts
+++ b/apps/api/src/handlers/gitlab/__tests__/handleMergeRequest.test.ts
@@ -172,6 +172,55 @@ describe('handleGitLabMergeRequest', () => {
     expect('sourceControlHost' in task.payload).toBe(false);
   });
 
+  it('selects and stamps the webhook host among same-name repositories on multiple hosts', async () => {
+    // Two active rows share the repository identity; only the host differs.
+    const rows = [
+      { id: 'repo-host-a', host: 'gitlab.host-a.example' },
+      { id: 'repo-host-b', host: 'gitlab.host-b.example' },
+    ];
+    mockGetGitLabAutomationTargets.mockImplementation(
+      async ({ webhookHost }: { webhookHost?: string | null }) => {
+        const repo = rows.find((row) => row.host === webhookHost);
+        return repo
+          ? {
+              status: 'ok',
+              targets: [
+                {
+                  id: `gitlab:pr_review:${repo.id}`,
+                  settings: null,
+                  repo,
+                  repositoryIds: [repo.id],
+                  userId: 'user-1',
+                },
+              ],
+            }
+          : { status: 'error', message: 'no matching repository row' };
+      },
+    );
+
+    await handleGitLabMergeRequest(
+      makePayload('open', {
+        url: 'https://gitlab.host-a.example/acme/backend/-/merge_requests/42',
+      }),
+    );
+
+    // The handler derives the instance host from the webhook URL...
+    expect(mockGetGitLabAutomationTargets).toHaveBeenCalledWith(
+      expect.objectContaining({ webhookHost: 'gitlab.host-a.example' }),
+    );
+    // ...and the launched payload pins the matching row's host.
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            sourceControlHost: 'gitlab.host-a.example',
+          }),
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
   it('stamps the repository host into review payloads when the repository row has one', async () => {
     mockGetGitLabAutomationTargets.mockResolvedValue({
       status: 'ok',

--- a/apps/api/src/handlers/gitlab/__tests__/handleMergeRequest.test.ts
+++ b/apps/api/src/handlers/gitlab/__tests__/handleMergeRequest.test.ts
@@ -108,6 +108,7 @@ describe('handleGitLabMergeRequest', () => {
         {
           id: 'gitlab:pr_review:repo-1',
           settings: null,
+          repo: { id: 'repo-1', host: null },
           repositoryIds: ['repo-1'],
           userId: 'user-1',
         },
@@ -162,6 +163,42 @@ describe('handleGitLabMergeRequest', () => {
       expect.objectContaining({
         launchClass: 'automation',
       }),
+    );
+    // A repository row without a recorded host omits the payload host field
+    // entirely so resolution falls back to (provider, fullName).
+    const [{ task }] = mockEnqueueTask.mock.calls[0]! as unknown as [
+      { task: { payload: Record<string, unknown> } },
+    ];
+    expect('sourceControlHost' in task.payload).toBe(false);
+  });
+
+  it('stamps the repository host into review payloads when the repository row has one', async () => {
+    mockGetGitLabAutomationTargets.mockResolvedValue({
+      status: 'ok',
+      targets: [
+        {
+          id: 'gitlab:pr_review:repo-1',
+          settings: null,
+          repo: { id: 'repo-1', host: 'gitlab.example.com' },
+          repositoryIds: ['repo-1'],
+          userId: 'user-1',
+        },
+      ],
+    });
+
+    await handleGitLabMergeRequest(makePayload('open'));
+
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            sourceControlProvider: 'gitlab',
+            // Pins repository resolution to the webhook repository's host.
+            sourceControlHost: 'gitlab.example.com',
+          }),
+        }),
+      }),
+      expect.any(Object),
     );
   });
 

--- a/apps/api/src/handlers/gitlab/__tests__/handleNote.test.ts
+++ b/apps/api/src/handlers/gitlab/__tests__/handleNote.test.ts
@@ -115,6 +115,7 @@ describe('handleGitLabNote', () => {
         {
           id: 'gitlab:pr_review:repo-1',
           settings: null,
+          repo: { id: 'repo-1', host: null },
           repositoryIds: ['repo-1'],
           userId: 'user-1',
         },
@@ -168,6 +169,41 @@ describe('handleGitLabNote', () => {
         projectId: 123,
         mergeRequestIid: 42,
         body: expect.stringContaining('review task'),
+      }),
+    );
+    // A repository row without a recorded host omits the payload host field
+    // entirely so resolution falls back to (provider, fullName).
+    const [{ task }] = mockEnqueueTask.mock.calls[0]! as unknown as [
+      { task: { payload: Record<string, unknown> } },
+    ];
+    expect('sourceControlHost' in task.payload).toBe(false);
+  });
+
+  it('stamps the repository host into mention review payloads when the repository row has one', async () => {
+    mockGetGitLabAutomationTargets.mockResolvedValue({
+      status: 'ok',
+      targets: [
+        {
+          id: 'gitlab:pr_review:repo-1',
+          settings: null,
+          repo: { id: 'repo-1', host: 'gitlab.example.com' },
+          repositoryIds: ['repo-1'],
+          userId: 'user-1',
+        },
+      ],
+    });
+
+    await handleGitLabNote(makeNotePayload());
+
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            sourceControlProvider: 'gitlab',
+            // Pins repository resolution to the webhook repository's host.
+            sourceControlHost: 'gitlab.example.com',
+          }),
+        }),
       }),
     );
   });

--- a/apps/api/src/handlers/gitlab/__tests__/handleNote.test.ts
+++ b/apps/api/src/handlers/gitlab/__tests__/handleNote.test.ts
@@ -179,6 +179,56 @@ describe('handleGitLabNote', () => {
     expect('sourceControlHost' in task.payload).toBe(false);
   });
 
+  it('selects and stamps the webhook host among same-name repositories on multiple hosts', async () => {
+    // Two active rows share the repository identity; only the host differs.
+    const rows = [
+      { id: 'repo-host-a', host: 'gitlab.host-a.example' },
+      { id: 'repo-host-b', host: 'gitlab.host-b.example' },
+    ];
+    mockGetGitLabAutomationTargets.mockImplementation(
+      async ({ webhookHost }: { webhookHost?: string | null }) => {
+        const repo = rows.find((row) => row.host === webhookHost);
+        return repo
+          ? {
+              status: 'ok',
+              targets: [
+                {
+                  id: `gitlab:pr_review:${repo.id}`,
+                  settings: null,
+                  repo,
+                  repositoryIds: [repo.id],
+                  userId: 'user-1',
+                },
+              ],
+            }
+          : { status: 'error', message: 'no matching repository row' };
+      },
+    );
+
+    await handleGitLabNote(
+      makeNotePayload({
+        mergeRequest: {
+          url: 'https://gitlab.host-a.example/acme/backend/-/merge_requests/42',
+        },
+      }),
+    );
+
+    // The handler derives the instance host from the webhook URL...
+    expect(mockGetGitLabAutomationTargets).toHaveBeenCalledWith(
+      expect.objectContaining({ webhookHost: 'gitlab.host-a.example' }),
+    );
+    // ...and the launched payload pins the matching row's host.
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            sourceControlHost: 'gitlab.host-a.example',
+          }),
+        }),
+      }),
+    );
+  });
+
   it('stamps the repository host into mention review payloads when the repository row has one', async () => {
     mockGetGitLabAutomationTargets.mockResolvedValue({
       status: 'ok',

--- a/apps/api/src/handlers/gitlab/getGitLabAutomationTargets.ts
+++ b/apps/api/src/handlers/gitlab/getGitLabAutomationTargets.ts
@@ -16,6 +16,7 @@ import {
   or,
 } from '@roomote/db/server';
 
+import { pickHostScopedRepository } from '../utils';
 import type { GitLabMergeRequestWebhook } from './types';
 
 type GitLabAutomationWebhookContext = Pick<
@@ -39,11 +40,18 @@ export function isRoomoteGitLabUsername(username: string): boolean {
 export async function getGitLabAutomationTargets({
   workflow,
   payload,
+  webhookHost = null,
   ignoreAuthorPolicy = false,
   requireLinkedSenderAccount = false,
 }: {
   workflow: SourceControlAutomationWorkflow;
   payload: GitLabAutomationWebhookContext;
+  /**
+   * Instance host derived from the webhook's own URLs. Scopes the repository
+   * lookup host-first (legacy NULL-host rows as fallback) so same-name
+   * repositories on other self-managed hosts are never selected.
+   */
+  webhookHost?: string | null;
   ignoreAuthorPolicy?: boolean;
   requireLinkedSenderAccount?: boolean;
 }): Promise<
@@ -66,7 +74,7 @@ export async function getGitLabAutomationTargets({
   const authorUsername = payload.user?.username;
   let linkedSenderUserId: string | null = null;
 
-  const repo = await db.query.repositories.findFirst({
+  const repoRows = await db.query.repositories.findMany({
     where: and(
       eq(repositories.sourceControlProvider, 'gitlab'),
       eq(repositories.isActive, true),
@@ -78,6 +86,7 @@ export async function getGitLabAutomationTargets({
         : eq(repositories.externalRepoId, projectId),
     ),
   });
+  const repo = pickHostScopedRepository(repoRows, webhookHost);
 
   if (!repo) {
     return {

--- a/apps/api/src/handlers/gitlab/handleMergeRequest.ts
+++ b/apps/api/src/handlers/gitlab/handleMergeRequest.ts
@@ -22,6 +22,7 @@ import {
 import type { WebhookResponse } from '../../types';
 import { scheduleNotifyPullRequestTerminalStatus } from '../github/notifyPullRequestTerminalStatus';
 import { scheduleSourceControlPullRequestFactSync } from '../pull-request-fact-sync';
+import { toHostFromUrl } from '../utils';
 import { getGitLabAutomationTargets } from './getGitLabAutomationTargets';
 import type { GitLabMergeRequestWebhook } from './types';
 
@@ -160,6 +161,8 @@ export async function handleGitLabMergeRequest(
   const result = await getGitLabAutomationTargets({
     workflow: 'pr_review',
     payload,
+    // The MR web URL carries the instance host, matching repositories.host.
+    webhookHost: toHostFromUrl(mergeRequest.url),
   });
 
   if (result.status === 'error') {

--- a/apps/api/src/handlers/gitlab/handleMergeRequest.ts
+++ b/apps/api/src/handlers/gitlab/handleMergeRequest.ts
@@ -210,7 +210,7 @@ export async function handleGitLabMergeRequest(
     payload.user?.id != null ? String(payload.user.id) : payload.user?.username;
   const mrAuthorName = payload.user?.name ?? payload.user?.username;
 
-  const enqueued = await pMap(targets, async (_target) =>
+  const enqueued = await pMap(targets, async (target) =>
     enqueueTask(
       {
         task: {
@@ -218,6 +218,12 @@ export async function handleGitLabMergeRequest(
           payload: {
             repo: repoFullName,
             sourceControlProvider: 'gitlab',
+            // Pin repository resolution to the webhook repository's host so
+            // same-name repositories on other hosts cannot be picked up.
+            // Legacy rows without a recorded host omit the field.
+            ...(target.repo.host
+              ? { sourceControlHost: target.repo.host }
+              : {}),
             prNumber: mergeRequest.iid,
             prTitle: mergeRequest.title,
             prUrl: mergeRequest.url,

--- a/apps/api/src/handlers/gitlab/handleNote.ts
+++ b/apps/api/src/handlers/gitlab/handleNote.ts
@@ -24,6 +24,7 @@ import {
   isRoomoteGitLabUsername,
 } from './getGitLabAutomationTargets';
 import { buildSourceControlAccountLinkRequiredMessage } from '../source-control-account-linking';
+import { toHostFromUrl } from '../utils';
 import type { GitLabNoteWebhook } from './types';
 
 const GITLAB_MENTION_HANDLE = '@roomote';
@@ -244,6 +245,11 @@ export async function handleGitLabNote(
   const targetsResult = await getGitLabAutomationTargets({
     workflow: 'pr_review',
     payload,
+    // The MR (or project) web URL carries the instance host, matching
+    // repositories.host.
+    webhookHost: toHostFromUrl(
+      mergeRequest.url ?? payload.project.web_url ?? '',
+    ),
     ignoreAuthorPolicy: true,
     requireLinkedSenderAccount: true,
   });

--- a/apps/api/src/handlers/gitlab/handleNote.ts
+++ b/apps/api/src/handlers/gitlab/handleNote.ts
@@ -363,6 +363,10 @@ export async function handleGitLabNote(
   const reviewPayload = {
     repo: repoFullName,
     sourceControlProvider: 'gitlab',
+    // Pin repository resolution to the webhook repository's host so
+    // same-name repositories on other hosts cannot be picked up. Legacy
+    // rows without a recorded host omit the field.
+    ...(target.repo.host ? { sourceControlHost: target.repo.host } : {}),
     prNumber: mergeRequest.iid,
     prTitle: mergeRequest.title,
     prUrl,

--- a/apps/api/src/handlers/pull-request-fact-sync.ts
+++ b/apps/api/src/handlers/pull-request-fact-sync.ts
@@ -1,6 +1,8 @@
 import { upsertSourceControlPullRequestFactFromWebhook } from '@roomote/sdk/server';
 import type { SourceControlProvider } from '@roomote/types';
 
+import { toHostFromUrl } from './utils';
+
 /**
  * Fire-and-forget PR-fact upsert for non-GitHub provider webhooks, mirroring
  * the GitHub handler's syncPullRequestFact. Terminal PR events (merged or
@@ -66,19 +68,6 @@ export function scheduleSourceControlPullRequestFactSync(params: {
       }`,
     ),
   );
-}
-
-/**
- * Extract the source-control instance host from a webhook-provided PR URL.
- * Returns null for relative or unparseable URLs, in which case the fact
- * upsert falls back to unscoped (provider, full name) matching.
- */
-function toHostFromUrl(url: string): string | null {
-  try {
-    return new URL(url).host || null;
-  } catch {
-    return null;
-  }
 }
 
 /**

--- a/apps/api/src/handlers/utils.ts
+++ b/apps/api/src/handlers/utils.ts
@@ -7,3 +7,42 @@ export function logHandlerError(handlerName: string, error: unknown): void {
     error instanceof Error ? error.message : String(error),
   );
 }
+
+/**
+ * Extract the source-control instance host from a webhook-provided URL (for
+ * example a PR/MR web URL). `repositories.host` is derived from the same
+ * instance base URL, so this host scopes repository lookups and fact writes
+ * to the webhook's own instance instead of every same-name repository across
+ * self-managed hosts. Returns null for relative or unparseable URLs, in
+ * which case callers fall back to unscoped (provider, full name) matching.
+ */
+export function toHostFromUrl(url: string): string | null {
+  try {
+    return new URL(url).host || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pick the repository row matching the webhook's instance host, tiering like
+ * resolveRepositoryRow: rows whose `host` equals the webhook host win, then
+ * legacy rows with a NULL host (written before the host backfill). Without a
+ * webhook host the first row is kept (pre-host behavior). Multiple rows in
+ * the chosen tier are exotic — these lookups are external-id-first — so the
+ * first is taken; the launched task's own host-scoped resolveRepositoryRow
+ * is the loud backstop.
+ */
+export function pickHostScopedRepository<T extends { host: string | null }>(
+  rows: T[],
+  webhookHost: string | null,
+): T | undefined {
+  if (!webhookHost) {
+    return rows[0];
+  }
+
+  return (
+    rows.find((row) => row.host === webhookHost) ??
+    rows.find((row) => row.host === null)
+  );
+}

--- a/packages/db/src/lib/__tests__/github-branch-activity.test.ts
+++ b/packages/db/src/lib/__tests__/github-branch-activity.test.ts
@@ -572,7 +572,8 @@ describe('findActiveGitHubBranchWork', () => {
     });
 
     // A payload written before host stamping carries no sourceControlHost;
-    // it may be the same branch, so the host-scoped lookup still matches.
+    // with no linkage row recording a conflicting host, it may be the same
+    // branch, so the host-scoped lookup still matches.
     const result = await findActiveGitHubBranchWork({
       repoFullName,
       prNumber,
@@ -583,6 +584,108 @@ describe('findActiveGitHubBranchWork', () => {
 
     expect(result).toMatchObject({
       runId: unstampedRun.id,
+      match: 'branch',
+    });
+  });
+
+  it('does not let an unstamped payload suppress another host when the task linkage records a conflicting host', async () => {
+    const { user } = await createActor();
+    const repoFullName = 'owner/repo-host-conflicting-linkage';
+    const prNumber = 366;
+    const branchName = 'feature/host-conflicting-linkage';
+
+    // The task is pinned to host A by its linkage row, but its payload
+    // predates host stamping (no sourceControlHost).
+    const taskId = await createPrLinkedTask({
+      repoFullName,
+      prNumber,
+      userId: user.id,
+      sourceControlProvider: 'gitlab',
+      host: 'a.example.com',
+    });
+
+    const run = await runFactory.create({
+      actingUserId: user.id,
+      taskId,
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Running,
+      taskPhase: 'running',
+      payload: {
+        repo: repoFullName,
+        branch: branchName,
+        sourceControlProvider: 'gitlab',
+        description: 'Unstamped payload pinned to host A by linkage',
+      },
+    });
+
+    // A host-B lookup must not match on either tier: the linkage host
+    // excludes tier 1, and the conflicting linkage host disables the
+    // unstamped-payload tolerance on tier 2.
+    const hostBResult = await findActiveGitHubBranchWork({
+      repoFullName,
+      prNumber,
+      branchName,
+      sourceControlProvider: 'gitlab',
+      host: 'b.example.com',
+    });
+
+    expect(hostBResult).toBeNull();
+
+    // The host-A lookup still matches (tier 1, via the linkage row).
+    const hostAResult = await findActiveGitHubBranchWork({
+      repoFullName,
+      prNumber,
+      branchName,
+      sourceControlProvider: 'gitlab',
+      host: 'a.example.com',
+    });
+
+    expect(hostAResult).toMatchObject({
+      runId: run.id,
+      match: 'task_pull_request',
+    });
+  });
+
+  it('keeps the unstamped-payload tolerance when the task linkage has no recorded host', async () => {
+    const { user } = await createActor();
+    const repoFullName = 'owner/repo-host-null-linkage-branch';
+    const prNumber = 367;
+    const branchName = 'feature/host-null-linkage-branch';
+
+    // The linkage row references a different PR number so tier 1 cannot
+    // match; only the tier-2 branch fallback can. Its host is NULL, so it
+    // is not a conflicting pin.
+    const taskId = await createPrLinkedTask({
+      repoFullName,
+      prNumber: prNumber + 1,
+      userId: user.id,
+      sourceControlProvider: 'gitlab',
+    });
+
+    const run = await runFactory.create({
+      actingUserId: user.id,
+      taskId,
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Running,
+      taskPhase: 'running',
+      payload: {
+        repo: repoFullName,
+        branch: branchName,
+        sourceControlProvider: 'gitlab',
+        description: 'Unstamped payload with a null-host linkage',
+      },
+    });
+
+    const result = await findActiveGitHubBranchWork({
+      repoFullName,
+      prNumber,
+      branchName,
+      sourceControlProvider: 'gitlab',
+      host: 'a.example.com',
+    });
+
+    expect(result).toMatchObject({
+      runId: run.id,
       match: 'branch',
     });
   });

--- a/packages/db/src/lib/__tests__/github-branch-activity.test.ts
+++ b/packages/db/src/lib/__tests__/github-branch-activity.test.ts
@@ -31,12 +31,14 @@ async function createPrLinkedTask({
   userId,
   prSha,
   sourceControlProvider = 'github',
+  host,
 }: {
   repoFullName: string;
   prNumber: number;
   userId: string;
   prSha?: string;
   sourceControlProvider?: SourceControlProvider;
+  host?: string | null;
 }) {
   const task = await taskFactory.create({
     initiatorUserId: userId,
@@ -50,6 +52,7 @@ async function createPrLinkedTask({
     repository: repoFullName,
     prSha: prSha ?? null,
     sourceControlProvider,
+    host: host ?? null,
     status: 'open',
   });
 
@@ -65,6 +68,7 @@ async function createPrLinkedTaskRun({
   taskPhase,
   prSha,
   sourceControlProvider,
+  host,
 }: {
   repoFullName: string;
   prNumber: number;
@@ -74,6 +78,7 @@ async function createPrLinkedTaskRun({
   taskPhase?: string;
   prSha?: string;
   sourceControlProvider?: SourceControlProvider;
+  host?: string | null;
 }) {
   const taskId = await createPrLinkedTask({
     repoFullName,
@@ -81,6 +86,7 @@ async function createPrLinkedTaskRun({
     userId,
     prSha,
     sourceControlProvider,
+    host,
   });
 
   return runFactory.create({
@@ -398,6 +404,187 @@ describe('findActiveGitHubBranchWork', () => {
     });
 
     expect(adoResult).toBeNull();
+  });
+
+  it('host-scopes PR association matches, tolerating legacy null-host rows', async () => {
+    const { user } = await createActor();
+    const repoFullName = 'owner/repo-host-scope-pr';
+    const prNumber = 362;
+    const branchName = 'feature/host-scope-pr';
+
+    const hostARun = await createPrLinkedTaskRun({
+      repoFullName,
+      prNumber,
+      userId: user.id,
+      payloadKind: TaskPayloadKind.GithubPrReview,
+      status: RunStatus.Running,
+      taskPhase: 'running',
+      sourceControlProvider: 'gitlab',
+      host: 'gitlab.host-a.example',
+    });
+
+    // A same-name PR on another self-managed instance is a different PR:
+    // the host-A association must not suppress a host-B lookup.
+    const otherHostResult = await findActiveGitHubBranchWork({
+      repoFullName,
+      prNumber,
+      branchName,
+      sourceControlProvider: 'gitlab',
+      host: 'gitlab.host-b.example',
+    });
+
+    expect(otherHostResult).toBeNull();
+
+    // The same-host lookup still matches.
+    const sameHostResult = await findActiveGitHubBranchWork({
+      repoFullName,
+      prNumber,
+      branchName,
+      sourceControlProvider: 'gitlab',
+      host: 'gitlab.host-a.example',
+    });
+
+    expect(sameHostResult).toMatchObject({
+      runId: hostARun.id,
+      match: 'task_pull_request',
+    });
+
+    // A host-less lookup (legacy caller) is unchanged and still matches.
+    const hostlessResult = await findActiveGitHubBranchWork({
+      repoFullName,
+      prNumber,
+      branchName,
+      sourceControlProvider: 'gitlab',
+    });
+
+    expect(hostlessResult).toMatchObject({
+      runId: hostARun.id,
+      match: 'task_pull_request',
+    });
+  });
+
+  it('lets a legacy null-host PR association still suppress a host-scoped lookup', async () => {
+    const { user } = await createActor();
+    const repoFullName = 'owner/repo-host-scope-null-pr';
+    const prNumber = 363;
+
+    const legacyRun = await createPrLinkedTaskRun({
+      repoFullName,
+      prNumber,
+      userId: user.id,
+      payloadKind: TaskPayloadKind.GithubPrReview,
+      status: RunStatus.Running,
+      taskPhase: 'running',
+      sourceControlProvider: 'gitlab',
+    });
+
+    // A pre-backfill association row has no recorded host; it may be the
+    // same PR, so a host-scoped lookup still treats it as active work.
+    const result = await findActiveGitHubBranchWork({
+      repoFullName,
+      prNumber,
+      branchName: 'feature/host-scope-null-pr',
+      sourceControlProvider: 'gitlab',
+      host: 'gitlab.host-a.example',
+    });
+
+    expect(result).toMatchObject({
+      runId: legacyRun.id,
+      match: 'task_pull_request',
+    });
+  });
+
+  it('host-scopes branch payload matches by sourceControlHost', async () => {
+    const { user } = await createActor();
+    const repoFullName = 'owner/repo-host-scope-branch';
+    const prNumber = 364;
+    const branchName = 'feature/host-scope-branch';
+
+    const hostARun = await runFactory.create({
+      actingUserId: user.id,
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Running,
+      taskPhase: 'running',
+      payload: {
+        repo: repoFullName,
+        branch: branchName,
+        sourceControlProvider: 'gitlab',
+        sourceControlHost: 'gitlab.host-a.example',
+        description: 'GitLab work on the branch',
+      },
+    });
+
+    // A payload stamped for host A must not match a host-B lookup.
+    const otherHostResult = await findActiveGitHubBranchWork({
+      repoFullName,
+      prNumber,
+      branchName,
+      sourceControlProvider: 'gitlab',
+      host: 'gitlab.host-b.example',
+    });
+
+    expect(otherHostResult).toBeNull();
+
+    const sameHostResult = await findActiveGitHubBranchWork({
+      repoFullName,
+      prNumber,
+      branchName,
+      sourceControlProvider: 'gitlab',
+      host: 'gitlab.host-a.example',
+    });
+
+    expect(sameHostResult).toMatchObject({
+      runId: hostARun.id,
+      match: 'branch',
+    });
+
+    // A host-less lookup (legacy caller) is unchanged and still matches.
+    const hostlessResult = await findActiveGitHubBranchWork({
+      repoFullName,
+      prNumber,
+      branchName,
+      sourceControlProvider: 'gitlab',
+    });
+
+    expect(hostlessResult).toMatchObject({
+      runId: hostARun.id,
+      match: 'branch',
+    });
+  });
+
+  it('lets an unstamped branch payload still suppress a host-scoped lookup', async () => {
+    const { user } = await createActor();
+    const repoFullName = 'owner/repo-host-scope-unstamped';
+    const prNumber = 365;
+    const branchName = 'feature/host-scope-unstamped';
+
+    const unstampedRun = await runFactory.create({
+      actingUserId: user.id,
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Running,
+      taskPhase: 'running',
+      payload: {
+        repo: repoFullName,
+        branch: branchName,
+        sourceControlProvider: 'gitlab',
+        description: 'GitLab work on the branch',
+      },
+    });
+
+    // A payload written before host stamping carries no sourceControlHost;
+    // it may be the same branch, so the host-scoped lookup still matches.
+    const result = await findActiveGitHubBranchWork({
+      repoFullName,
+      prNumber,
+      branchName,
+      sourceControlProvider: 'gitlab',
+      host: 'gitlab.host-a.example',
+    });
+
+    expect(result).toMatchObject({
+      runId: unstampedRun.id,
+      match: 'branch',
+    });
   });
 
   it('ignores runs that are not actively running anymore', async () => {

--- a/packages/db/src/lib/github-branch-activity.ts
+++ b/packages/db/src/lib/github-branch-activity.ts
@@ -123,7 +123,11 @@ function pickActiveWork(
  * repository on another self-managed instance and must not match. Rows with
  * a NULL host and payloads without `sourceControlHost` (written before host
  * stamping) still match, mirroring the legacy tolerance in
- * resolveRepositoryRow. Without `host`, behavior is unchanged.
+ * resolveRepositoryRow — except that an unstamped payload does NOT match
+ * when the task's own `task_pull_requests` linkage records a conflicting
+ * host: the linkage pins the task to another instance, so the legacy
+ * fallback applies only when no conflicting linkage host is known. Without
+ * `host`, behavior is unchanged.
  */
 export async function findActiveGitHubBranchWork({
   repoFullName,
@@ -185,9 +189,22 @@ export async function findActiveGitHubBranchWork({
         )`,
         ...(host
           ? [
+              // An exactly-stamped payload always matches. An unstamped
+              // (legacy) payload matches only when the task has no linkage
+              // row recording a different host — such a row pins the task
+              // to another instance, so it must not suppress this host's
+              // lookup.
               sql`(
                 ${taskRuns.payload}->>'sourceControlHost' = ${host}
-                OR ${taskRuns.payload}->>'sourceControlHost' IS NULL
+                OR (
+                  ${taskRuns.payload}->>'sourceControlHost' IS NULL
+                  AND NOT EXISTS (
+                    SELECT 1 FROM ${taskPullRequests}
+                    WHERE ${taskPullRequests.taskId} = ${taskRuns.taskId}
+                      AND ${taskPullRequests.host} IS NOT NULL
+                      AND ${taskPullRequests.host} <> ${host}
+                  )
+                )
               )`,
             ]
           : []),

--- a/packages/db/src/lib/github-branch-activity.ts
+++ b/packages/db/src/lib/github-branch-activity.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, isNull, ne, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, ne, or, sql } from 'drizzle-orm';
 
 import {
   type TaskPayload,
@@ -117,17 +117,26 @@ function pickActiveWork(
  * PR association lives exclusively on `task_pull_requests` (populated at
  * enqueue for PR-triggered launches and at extraction time for agent-created
  * PRs), so PR matches are a `task_runs JOIN task_pull_requests` lookup.
+ *
+ * When a non-null `host` is given, both lookups are host-scoped: an
+ * association row or payload stamped with a different host is a same-name
+ * repository on another self-managed instance and must not match. Rows with
+ * a NULL host and payloads without `sourceControlHost` (written before host
+ * stamping) still match, mirroring the legacy tolerance in
+ * resolveRepositoryRow. Without `host`, behavior is unchanged.
  */
 export async function findActiveGitHubBranchWork({
   repoFullName,
   prNumber,
   branchName,
   sourceControlProvider = 'github',
+  host,
 }: {
   repoFullName: string;
   prNumber: number;
   branchName: string;
   sourceControlProvider?: SourceControlProvider;
+  host?: string | null;
 }): Promise<ActiveGitHubBranchWork | null> {
   const baseConditions = [
     inArray(taskRuns.status, [...ACTIVE_WORK_STATUSES]),
@@ -145,6 +154,9 @@ export async function findActiveGitHubBranchWork({
         eq(taskPullRequests.sourceControlProvider, sourceControlProvider),
         eq(taskPullRequests.repository, repoFullName),
         eq(taskPullRequests.prNumber, prNumber),
+        ...(host
+          ? [or(eq(taskPullRequests.host, host), isNull(taskPullRequests.host))]
+          : []),
       ),
     )
     .orderBy(desc(taskRuns.createdAt))
@@ -171,6 +183,14 @@ export async function findActiveGitHubBranchWork({
           ${taskRuns.payload}->>'branch' = ${branchName}
           OR ${taskRuns.payload}->>'headRef' = ${branchName}
         )`,
+        ...(host
+          ? [
+              sql`(
+                ${taskRuns.payload}->>'sourceControlHost' = ${host}
+                OR ${taskRuns.payload}->>'sourceControlHost' IS NULL
+              )`,
+            ]
+          : []),
       ),
     )
     .orderBy(desc(taskRuns.createdAt))

--- a/packages/sdk/src/server/automations/__tests__/conflict-scan.test.ts
+++ b/packages/sdk/src/server/automations/__tests__/conflict-scan.test.ts
@@ -623,7 +623,52 @@ describe('conflictScanJob', () => {
         }),
       }),
     );
+    // A legacy repository row without a recorded host omits the payload
+    // host field entirely so resolution falls back to (provider, fullName).
+    const [enqueueArg] = mockEnqueueTask.mock.calls[0]! as unknown as [
+      { task: { payload: Record<string, unknown> } },
+    ];
+    expect('sourceControlHost' in enqueueArg.task.payload).toBe(false);
     expect(result.launchedTaskId).toBe('task-9');
+  });
+
+  it('stamps the repository host into the conflict-resolution payload when the repo row has one', async () => {
+    mockIsRepoSkipped.mockReturnValue(false);
+    queueProviderNeutralRepo({
+      id: 'repo-1',
+      sourceControlProvider: 'gitlab',
+      host: 'gitlab.example.com',
+      installationId: null,
+      externalRepoId: '101',
+      fullName: 'acme/backend',
+      htmlUrl: 'https://gitlab.example.com/acme/backend',
+    });
+    mockListOpenPullRequests.mockResolvedValueOnce({
+      success: true,
+      provider: 'gitlab',
+      repositoryFullName: 'acme/backend',
+      pullRequests: [makePullRequestSummary()],
+      warnings: [],
+    });
+    mockEnqueueTask.mockResolvedValueOnce({ id: 9, taskId: 'task-9' });
+
+    await conflictScanJob();
+
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          type: 'github_pr_conflict_resolve',
+          payload: expect.objectContaining({
+            repo: 'acme/backend',
+            prNumber: 42,
+            sourceControlProvider: 'gitlab',
+            // The payload pins repository resolution to this repo's host so
+            // a same-name repository on another host cannot be picked up.
+            sourceControlHost: 'gitlab.example.com',
+          }),
+        }),
+      }),
+    );
   });
 
   it('falls back to a single-PR detail read when an ADO list row has no mergeable signal', async () => {

--- a/packages/sdk/src/server/automations/__tests__/conflict-scan.test.ts
+++ b/packages/sdk/src/server/automations/__tests__/conflict-scan.test.ts
@@ -124,6 +124,7 @@ vi.mock('@roomote/db/server', () => {
       sourceControlProvider: 'sourceControlProvider',
       repository: 'repository',
       prNumber: 'prNumber',
+      host: 'taskPullRequests.host',
     },
     taskRuns: {
       id: 'id',
@@ -139,11 +140,15 @@ vi.mock('@roomote/db/server', () => {
     isNull: vi.fn(),
     eq: vi.fn(),
     and: vi.fn(),
+    or: vi.fn(),
     inArray: vi.fn(),
   };
 });
 
 import { conflictScanJob } from '../conflict-scan';
+// The mocked condition builders let tests verify how the active-run dedup
+// guard scopes its query.
+import { eq as mockedEq, or as mockedOr } from '@roomote/db/server';
 
 describe('conflictScanJob', () => {
   beforeEach(() => {
@@ -592,7 +597,15 @@ describe('conflictScanJob', () => {
       prNumber: 42,
       branchName: 'feature/work',
       sourceControlProvider: 'gitlab',
+      host: null,
     });
+    // Without a recorded repo host, the active-run dedup guard does not
+    // constrain on the association host column.
+    expect(mockedEq).not.toHaveBeenCalledWith(
+      'taskPullRequests.host',
+      expect.anything(),
+    );
+    expect(mockedOr).not.toHaveBeenCalled();
     expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
@@ -624,11 +637,16 @@ describe('conflictScanJob', () => {
       }),
     );
     // A legacy repository row without a recorded host omits the payload
-    // host field entirely so resolution falls back to (provider, fullName).
+    // host field entirely so resolution falls back to (provider, fullName),
+    // and the task association carries no host either.
     const [enqueueArg] = mockEnqueueTask.mock.calls[0]! as unknown as [
-      { task: { payload: Record<string, unknown> } },
+      {
+        task: { payload: Record<string, unknown> };
+        prLinkage: Record<string, unknown>;
+      },
     ];
     expect('sourceControlHost' in enqueueArg.task.payload).toBe(false);
+    expect('host' in enqueueArg.prLinkage).toBe(false);
     expect(result.launchedTaskId).toBe('task-9');
   });
 
@@ -654,6 +672,24 @@ describe('conflictScanJob', () => {
 
     await conflictScanJob();
 
+    // The active-run dedup guard constrains on the association host column
+    // (exact host OR legacy NULL host), so an active run recorded for a
+    // same-name PR on a different host cannot suppress this launch.
+    expect(mockedEq).toHaveBeenCalledWith(
+      'taskPullRequests.host',
+      'gitlab.example.com',
+    );
+    expect(mockedOr).toHaveBeenCalled();
+
+    // The branch-activity guard receives the host for the same reason.
+    expect(mockFindActiveGitHubBranchWork).toHaveBeenCalledWith({
+      repoFullName: 'acme/backend',
+      prNumber: 42,
+      branchName: 'feature/work',
+      sourceControlProvider: 'gitlab',
+      host: 'gitlab.example.com',
+    });
+
     expect(mockEnqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
         task: expect.objectContaining({
@@ -666,6 +702,14 @@ describe('conflictScanJob', () => {
             // a same-name repository on another host cannot be picked up.
             sourceControlHost: 'gitlab.example.com',
           }),
+        }),
+        // The task association is host-scoped so later dedup lookups for a
+        // same-name PR on another host do not match this run.
+        prLinkage: expect.objectContaining({
+          provider: 'gitlab',
+          repository: 'acme/backend',
+          prNumber: 42,
+          host: 'gitlab.example.com',
         }),
       }),
     );

--- a/packages/sdk/src/server/automations/__tests__/merged-pr-audit-runner.test.ts
+++ b/packages/sdk/src/server/automations/__tests__/merged-pr-audit-runner.test.ts
@@ -291,11 +291,14 @@ describe('createMergedPullRequestAuditJob provider partitioning', () => {
     const [githubPayload, gitlabPayload] = enqueuedPayloads();
 
     // GitHub partition launches with the pre-partitioning payload shape: the
-    // provider field is absent entirely, not merely undefined.
+    // provider field is absent entirely, not merely undefined. Legacy
+    // partitions without a recorded host also omit the host field.
     expect('sourceControlProvider' in githubPayload!).toBe(false);
+    expect('sourceControlHost' in githubPayload!).toBe(false);
     expect(githubPayload!.selectedRepositories).toEqual(['acme/gh']);
 
     expect(gitlabPayload!.sourceControlProvider).toBe('gitlab');
+    expect('sourceControlHost' in gitlabPayload!).toBe(false);
     expect(gitlabPayload!.selectedRepositories).toEqual(['acme/gl']);
 
     // Each task's prompt manifest carries only its own provider's PRs.
@@ -391,9 +394,12 @@ describe('createMergedPullRequestAuditJob provider partitioning', () => {
     const [firstPayload, secondPayload] = enqueuedPayloads();
 
     // Hosts launch in lexicographic order: gitlab.com < gitlab.example.com.
+    // Each payload pins repository resolution to its partition host.
     expect(firstPayload!.sourceControlProvider).toBe('gitlab');
+    expect(firstPayload!.sourceControlHost).toBe('gitlab.com');
     expect(firstPayload!.selectedRepositories).toEqual(['acme/cloud']);
     expect(secondPayload!.sourceControlProvider).toBe('gitlab');
+    expect(secondPayload!.sourceControlHost).toBe('gitlab.example.com');
     expect(secondPayload!.selectedRepositories).toEqual(['acme/self-managed']);
 
     const manifests = buildPrompt.mock.calls.map(([params]) =>
@@ -402,7 +408,7 @@ describe('createMergedPullRequestAuditJob provider partitioning', () => {
     expect(manifests).toEqual([[2], [1]]);
   });
 
-  it('excludes same-name repositories on multiple hosts from every manifest, with a warning', async () => {
+  it('launches host-bearing same-name entries with the host stamped, skipping only legacy null-host collisions', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     try {
@@ -419,38 +425,45 @@ describe('createMergedPullRequestAuditJob provider partitioning', () => {
           repositoryFullName: 'acme/shared',
           host: 'gitlab.host-b.example',
         }),
+        // A legacy entry whose repository row has no recorded host: its
+        // launched task would resolve by (provider, fullName) alone, so a
+        // same-name collision still forces a skip.
         factRow({
           index: 2,
           provider: 'gitlab',
-          repositoryFullName: 'acme/unique',
-          host: 'gitlab.host-a.example',
+          repositoryFullName: 'acme/legacy',
         }),
       ]);
-      // acme/shared matches two active repository rows, so the launched
-      // task's (provider, fullName) lookup could resolve the wrong host.
+      // Both full names match two active repository rows each.
       mockSlackInstallationRows.mockResolvedValueOnce([
         { sourceControlProvider: 'gitlab', fullName: 'acme/shared' },
         { sourceControlProvider: 'gitlab', fullName: 'acme/shared' },
-        { sourceControlProvider: 'gitlab', fullName: 'acme/unique' },
+        { sourceControlProvider: 'gitlab', fullName: 'acme/legacy' },
+        { sourceControlProvider: 'gitlab', fullName: 'acme/legacy' },
       ]);
 
       const result = await job();
 
       expect(result.errors).toEqual([]);
-      // Only the unambiguous entry launches; no task can audit the wrong host.
-      expect(mockEnqueueTask).toHaveBeenCalledTimes(1);
+      // The host-bearing entries launch one task per host: each payload
+      // carries the host, so neither task can audit the wrong instance.
+      expect(mockEnqueueTask).toHaveBeenCalledTimes(2);
 
-      const [payload] = enqueuedPayloads();
-      expect(payload!.sourceControlProvider).toBe('gitlab');
-      expect(payload!.selectedRepositories).toEqual(['acme/unique']);
+      const [hostAPayload, hostBPayload] = enqueuedPayloads();
+      expect(hostAPayload!.sourceControlProvider).toBe('gitlab');
+      expect(hostAPayload!.sourceControlHost).toBe('gitlab.host-a.example');
+      expect(hostAPayload!.selectedRepositories).toEqual(['acme/shared']);
+      expect(hostBPayload!.sourceControlProvider).toBe('gitlab');
+      expect(hostBPayload!.sourceControlHost).toBe('gitlab.host-b.example');
+      expect(hostBPayload!.selectedRepositories).toEqual(['acme/shared']);
 
       const manifests = buildPrompt.mock.calls.map(([params]) =>
         params.mergedPullRequests.map((pullRequest) => pullRequest.prNumber),
       );
-      expect(manifests).toEqual([[3]]);
+      expect(manifests).toEqual([[1], [2]]);
 
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('skipping 2 merged PR entries'),
+        expect.stringContaining('skipping 1 merged PR entries'),
       );
     } finally {
       warnSpy.mockRestore();
@@ -461,14 +474,15 @@ describe('createMergedPullRequestAuditJob provider partitioning', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     try {
-      // 251 rows overflow the 250-row page; the gitlab half is ambiguous
-      // across two hosts and gets skipped, the github half launches.
+      // 251 rows overflow the 250-row page; the gitlab half has no recorded
+      // repository host and collides with a same-name row on another host,
+      // so it gets skipped; the github half launches.
       const rows = Array.from({ length: 251 }, (_, index) =>
         factRow({
           index,
           provider: index % 2 === 0 ? 'github' : 'gitlab',
           repositoryFullName: index % 2 === 0 ? 'acme/gh' : 'acme/shared',
-          host: index % 2 === 0 ? 'github.com' : 'gitlab.host-a.example',
+          ...(index % 2 === 0 ? { host: 'github.com' } : {}),
         }),
       );
       mockSlackInstallationRows.mockResolvedValueOnce(rows);
@@ -485,6 +499,8 @@ describe('createMergedPullRequestAuditJob provider partitioning', () => {
 
       const [payload] = enqueuedPayloads();
       expect('sourceControlProvider' in payload!).toBe(false);
+      // GitHub rows carry host github.com, so the payload pins it.
+      expect(payload!.sourceControlHost).toBe('github.com');
       expect(payload!.selectedRepositories).toEqual(['acme/gh']);
 
       // The cursor still covers the full 250-row page, including the skipped

--- a/packages/sdk/src/server/automations/conflict-scan.ts
+++ b/packages/sdk/src/server/automations/conflict-scan.ts
@@ -13,6 +13,7 @@ import {
   isNull,
   eq,
   and,
+  or,
   inArray,
   recordAutomationRunOutcome,
 } from '@roomote/db/server';
@@ -133,11 +134,18 @@ async function getActiveProviderNeutralRepos(): Promise<RepositoryRow[]> {
 /**
  * Check if there's already an active (pending/running) conflict resolution
  * run for the given PR.
+ *
+ * When a non-null `host` is given, association rows recorded for a
+ * different host do not suppress the launch: a same-name repository and PR
+ * number on another self-managed instance is a different PR. Rows with a
+ * NULL host (written before the host backfill) still suppress, mirroring
+ * the legacy tolerance in resolveRepositoryRow.
  */
 async function hasActiveResolutionRun(
   repoFullName: string,
   prNumber: number,
   sourceControlProvider: SourceControlProvider,
+  host?: string | null,
 ): Promise<boolean> {
   const activeStatuses = [RunStatus.Pending, RunStatus.Running];
 
@@ -152,6 +160,9 @@ async function hasActiveResolutionRun(
         eq(taskPullRequests.sourceControlProvider, sourceControlProvider),
         eq(taskPullRequests.repository, repoFullName),
         eq(taskPullRequests.prNumber, prNumber),
+        ...(host
+          ? [or(eq(taskPullRequests.host, host), isNull(taskPullRequests.host))]
+          : []),
         inArray(taskRuns.status, activeStatuses),
       ),
     )
@@ -597,8 +608,17 @@ async function scanProviderNeutralRepos({
           `${LOG_PREFIX} PR ${repo.fullName}#${pr.number} has conflicts`,
         );
 
-        // Check for existing active resolution run (dedup guard)
-        if (await hasActiveResolutionRun(repo.fullName, pr.number, provider)) {
+        // Check for existing active resolution run (dedup guard). The
+        // repo's host scopes both lookups so a same-name PR on another
+        // self-managed instance cannot suppress this one.
+        if (
+          await hasActiveResolutionRun(
+            repo.fullName,
+            pr.number,
+            provider,
+            repo.host,
+          )
+        ) {
           console.log(
             `${LOG_PREFIX} Active resolution run exists for ${repo.fullName}#${pr.number} — skipping`,
           );
@@ -610,6 +630,7 @@ async function scanProviderNeutralRepos({
           prNumber: pr.number,
           branchName: pr.sourceBranch,
           sourceControlProvider: provider,
+          host: repo.host,
         });
 
         if (activeBranchWork) {
@@ -660,6 +681,9 @@ async function scanProviderNeutralRepos({
             trigger: manualTrigger ? 'manual' : 'schedule',
             prLinkage: {
               provider,
+              // Host-scope the task association so later dedup lookups for
+              // a same-name PR on another host do not match this run.
+              ...(repo.host ? { host: repo.host } : {}),
               repository: repo.fullName,
               prNumber: pr.number,
               prUrl: pr.url,

--- a/packages/sdk/src/server/automations/conflict-scan.ts
+++ b/packages/sdk/src/server/automations/conflict-scan.ts
@@ -637,6 +637,10 @@ async function scanProviderNeutralRepos({
                 headRef: pr.sourceBranch,
                 baseRef: pr.targetBranch,
                 sourceControlProvider: provider,
+                // Pin repository resolution to this repo's host so
+                // same-name repositories on other hosts cannot be picked
+                // up. Legacy rows without a recorded host omit the field.
+                ...(repo.host ? { sourceControlHost: repo.host } : {}),
               },
             },
             initiator: {

--- a/packages/sdk/src/server/automations/merged-pr-audit-runner.ts
+++ b/packages/sdk/src/server/automations/merged-pr-audit-runner.ts
@@ -364,11 +364,13 @@ function repositoryIdentityKey(
 /**
  * Finds (provider, fullName) pairs in the manifest that match more than one
  * active repository row, i.e. same-name repositories linked from multiple
- * hosts (self-managed GitLab/Gitea/ADO instances). The launched task's
- * pull-request tools resolve repositories by (provider, fullName) alone --
- * see resolveRepositoryRow in
- * lib/pull-requests/source-control-pull-request-shared.ts -- so for these
- * pairs a task could silently audit the wrong host's repository.
+ * hosts (self-managed GitLab/Gitea/ADO instances). Manifest entries with a
+ * recorded repository host are safe despite the collision: their launched
+ * task carries `sourceControlHost` and resolveRepositoryRow (in
+ * lib/pull-requests/source-control-pull-request-shared.ts) resolves by
+ * (provider, fullName, host). Only legacy entries without a recorded host
+ * would still resolve by (provider, fullName) alone, so only those must be
+ * skipped when their identity collides.
  *
  * Ambiguity is checked against the repositories table rather than the
  * manifest itself: a same-name repository on another host is a resolution
@@ -514,27 +516,31 @@ async function processDeployment(
     });
     // The pull-request read/write tools bind each task to a single
     // source-control provider (resolved from the task payload) and look
-    // repositories up by (provider, fullName), so a manifest must never mix
-    // providers or hosts: one scan task launches per (provider, host) pair.
+    // repositories up by (provider, fullName, host), so a manifest must
+    // never mix providers or hosts: one scan task launches per
+    // (provider, host) pair, and the partition host is stamped into the
+    // task payload as `sourceControlHost`.
     //
-    // The task payload has no host field, so a launched task cannot tell the
-    // tools which host it means; a manifest entry is only safe when its
-    // (provider, fullName) resolves to exactly one active repository row.
-    // Entries whose full name is active on more than one host would let the
-    // task audit the wrong host's repository, so they are excluded from
-    // every launched manifest instead.
-    // TODO(follow-up): thread host disambiguation through the task payload
-    // and resolveRepositoryRow so same-name repositories on multiple hosts
-    // become auditable instead of skipped.
+    // Entries with a recorded repository host are therefore always safe,
+    // even when a same-name repository is active on another host. Only
+    // legacy entries whose repository row predates the host backfill
+    // (host still NULL) resolve by (provider, fullName) alone; when that
+    // identity collides with another active row the launched task could
+    // audit the wrong host's repository, so those entries are excluded
+    // from every launched manifest. They self-heal once the host backfill
+    // reaches their repository row.
     const ambiguousIdentities =
       await findAmbiguousRepositoryIdentities(mergedPullRequests);
     const auditablePullRequests = mergedPullRequests.filter(
       (pullRequest) =>
-        !ambiguousIdentities.has(
-          repositoryIdentityKey(
-            pullRequest.sourceControlProvider,
-            pullRequest.repositoryFullName,
-          ),
+        !(
+          pullRequest.repositoryHost === null &&
+          ambiguousIdentities.has(
+            repositoryIdentityKey(
+              pullRequest.sourceControlProvider,
+              pullRequest.repositoryFullName,
+            ),
+          )
         ),
     );
     const skippedAmbiguousCount =
@@ -542,7 +548,7 @@ async function processDeployment(
 
     if (skippedAmbiguousCount > 0) {
       console.warn(
-        `${logPrefix} Same-name repositories on multiple hosts are not yet auditable — skipping ${skippedAmbiguousCount} merged PR entries`,
+        `${logPrefix} Legacy repository rows without a recorded host cannot be disambiguated from same-name repositories on other hosts — skipping ${skippedAmbiguousCount} merged PR entries`,
       );
     }
 
@@ -576,7 +582,7 @@ async function processDeployment(
     let firstLaunchedTaskId: string | null = null;
 
     for (const partition of orderedPartitions) {
-      const { provider, pullRequests: partitionPullRequests } = partition;
+      const { provider, host, pullRequests: partitionPullRequests } = partition;
 
       const selectedRepositories = getSelectedRepositories(
         partitionPullRequests,
@@ -603,6 +609,11 @@ async function processDeployment(
             ...(provider === 'github'
               ? {}
               : { sourceControlProvider: provider }),
+            // The partition host pins repository resolution to this host so
+            // same-name repositories on other hosts cannot be picked up.
+            // Legacy partitions without a recorded host omit the field and
+            // resolve by (provider, fullName) alone.
+            ...(host ? { sourceControlHost: host } : {}),
             description: config.buildPrompt({
               channelId,
               destination,
@@ -642,9 +653,9 @@ async function processDeployment(
     // so advancing the cursor only after every partition has launched keeps
     // cursor coverage equal to the union of launched manifests plus the
     // deliberate exclusions. Skipped-ambiguous entries advance with the
-    // cursor by design: they are excluded until host disambiguation lands,
-    // and letting them pin the cursor would stall the scan on every later
-    // PR instead. If a partition launch throws, the run fails without
+    // cursor by design: they are excluded until the host backfill reaches
+    // their repository row, and letting them pin the cursor would stall the
+    // scan on every later PR instead. If a partition launch throws, the run fails without
     // advancing the cursor and the next run rescans the same page:
     // partitions that already launched are re-audited once rather than any
     // PR being skipped.

--- a/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-reads.test.ts
+++ b/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-reads.test.ts
@@ -70,7 +70,12 @@ vi.mock('@roomote/db/server', () => ({
   db: {
     query: {
       repositories: {
-        findFirst: (...args: unknown[]) => mockRepositoriesFindFirst(...args),
+        // resolveRepositoryRow queries with findMany; tests queue a single
+        // row (or null), adapted here to the list shape it expects.
+        findMany: async (...args: unknown[]) => {
+          const row = await mockRepositoriesFindFirst(...args);
+          return row == null ? [] : [row];
+        },
       },
       environments: {
         findFirst: (...args: unknown[]) => mockEnvironmentsFindFirst(...args),

--- a/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-shared.host.test.ts
+++ b/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-shared.host.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockRepositoriesFindMany } = vi.hoisted(() => ({
+  mockRepositoriesFindMany: vi.fn(),
+}));
+
+vi.mock('@roomote/gitlab', () => ({
+  isGitLabOAuthAccessToken: () => false,
+}));
+
+vi.mock('@roomote/db/server', () => ({
+  db: {
+    query: {
+      repositories: {
+        findMany: (...args: unknown[]) => mockRepositoriesFindMany(...args),
+      },
+      environments: {
+        findFirst: vi.fn(),
+      },
+    },
+  },
+  repositories: {
+    sourceControlProvider: 'repositories.sourceControlProvider',
+    fullName: 'repositories.fullName',
+    isActive: 'repositories.isActive',
+  },
+  environments: {
+    id: 'environments.id',
+  },
+  and: vi.fn((...conditions: unknown[]) => ({ type: 'and', conditions })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ type: 'eq', left, right })),
+}));
+
+import {
+  resolveRepositoryRow,
+  type RepositoryRow,
+} from '../source-control-pull-request-shared';
+
+function repositoryRow(params: {
+  id: string;
+  host: string | null;
+}): RepositoryRow {
+  return {
+    id: params.id,
+    sourceControlProvider: 'gitlab',
+    host: params.host,
+    installationId: null,
+    externalRepoId: `external-${params.id}`,
+    fullName: 'acme/backend',
+    htmlUrl: `https://${params.host ?? 'gitlab.com'}/acme/backend`,
+  };
+}
+
+describe('resolveRepositoryRow host scoping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('prefers the exact host match over a legacy null-host row', async () => {
+    const exactRow = repositoryRow({
+      id: 'repo-exact',
+      host: 'gitlab.example.com',
+    });
+    mockRepositoriesFindMany.mockResolvedValue([
+      repositoryRow({ id: 'repo-legacy', host: null }),
+      exactRow,
+      repositoryRow({ id: 'repo-other-host', host: 'gitlab.other.example' }),
+    ]);
+
+    await expect(
+      resolveRepositoryRow({
+        provider: 'gitlab',
+        repositoryFullName: 'acme/backend',
+        host: 'gitlab.example.com',
+      }),
+    ).resolves.toEqual(exactRow);
+  });
+
+  it('falls back to a legacy null-host row when no row matches the host exactly', async () => {
+    const legacyRow = repositoryRow({ id: 'repo-legacy', host: null });
+    mockRepositoriesFindMany.mockResolvedValue([
+      repositoryRow({ id: 'repo-other-host', host: 'gitlab.other.example' }),
+      legacyRow,
+    ]);
+
+    await expect(
+      resolveRepositoryRow({
+        provider: 'gitlab',
+        repositoryFullName: 'acme/backend',
+        host: 'gitlab.example.com',
+      }),
+    ).resolves.toEqual(legacyRow);
+  });
+
+  it('reports the host in the not-found error when no row qualifies for it', async () => {
+    mockRepositoriesFindMany.mockResolvedValue([
+      repositoryRow({ id: 'repo-other-host', host: 'gitlab.other.example' }),
+    ]);
+
+    await expect(
+      resolveRepositoryRow({
+        provider: 'gitlab',
+        repositoryFullName: 'acme/backend',
+        host: 'gitlab.example.com',
+      }),
+    ).rejects.toThrow(
+      'GitLab repository not found or inactive on gitlab.example.com: acme/backend',
+    );
+  });
+
+  it('rejects multiple candidates within the chosen host tier', async () => {
+    mockRepositoriesFindMany.mockResolvedValue([
+      repositoryRow({ id: 'repo-legacy-1', host: null }),
+      repositoryRow({ id: 'repo-legacy-2', host: null }),
+    ]);
+
+    await expect(
+      resolveRepositoryRow({
+        provider: 'gitlab',
+        repositoryFullName: 'acme/backend',
+        host: 'gitlab.example.com',
+      }),
+    ).rejects.toThrow(
+      'GitLab repository acme/backend matches more than one active repository on gitlab.example.com.',
+    );
+  });
+
+  it('rejects a multi-host identity when the caller provides no host', async () => {
+    mockRepositoriesFindMany.mockResolvedValue([
+      repositoryRow({ id: 'repo-b', host: 'gitlab.host-b.example' }),
+      repositoryRow({ id: 'repo-a', host: 'gitlab.host-a.example' }),
+      repositoryRow({ id: 'repo-legacy', host: null }),
+    ]);
+
+    await expect(
+      resolveRepositoryRow({
+        provider: 'gitlab',
+        repositoryFullName: 'acme/backend',
+      }),
+    ).rejects.toThrow(
+      'GitLab repository acme/backend is linked from multiple hosts ' +
+        '(gitlab.host-a.example, gitlab.host-b.example, unknown host); ' +
+        'the task payload must carry sourceControlHost to disambiguate.',
+    );
+  });
+
+  it('returns the single matching row unchanged when the caller provides no host', async () => {
+    const row = repositoryRow({ id: 'repo-only', host: 'gitlab.example.com' });
+    mockRepositoriesFindMany.mockResolvedValue([row]);
+
+    await expect(
+      resolveRepositoryRow({
+        provider: 'gitlab',
+        repositoryFullName: 'acme/backend',
+      }),
+    ).resolves.toEqual(row);
+  });
+
+  it('keeps the host-free not-found error message unchanged', async () => {
+    mockRepositoriesFindMany.mockResolvedValue([]);
+
+    await expect(
+      resolveRepositoryRow({
+        provider: 'gitlab',
+        repositoryFullName: 'acme/backend',
+      }),
+    ).rejects.toThrow('GitLab repository not found or inactive: acme/backend');
+  });
+});

--- a/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-writes.test.ts
+++ b/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-writes.test.ts
@@ -63,7 +63,12 @@ vi.mock('@roomote/db/server', () => ({
   db: {
     query: {
       repositories: {
-        findFirst: (...args: unknown[]) => mockRepositoriesFindFirst(...args),
+        // resolveRepositoryRow queries with findMany; tests queue a single
+        // row (or null), adapted here to the list shape it expects.
+        findMany: async (...args: unknown[]) => {
+          const row = await mockRepositoriesFindFirst(...args);
+          return row == null ? [] : [row];
+        },
       },
       environments: {
         findFirst: (...args: unknown[]) => mockEnvironmentsFindFirst(...args),

--- a/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-requests.test.ts
+++ b/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-requests.test.ts
@@ -78,7 +78,12 @@ vi.mock('@roomote/db/server', () => ({
   db: {
     query: {
       repositories: {
-        findFirst: (...args: unknown[]) => mockRepositoriesFindFirst(...args),
+        // resolveRepositoryRow queries with findMany; tests queue a single
+        // row (or null), adapted here to the list shape it expects.
+        findMany: async (...args: unknown[]) => {
+          const row = await mockRepositoriesFindFirst(...args);
+          return row == null ? [] : [row];
+        },
       },
       environments: {
         findFirst: (...args: unknown[]) => mockEnvironmentsFindFirst(...args),

--- a/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-reads.ts
+++ b/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-reads.ts
@@ -25,6 +25,7 @@ import { type TaskRun } from '@roomote/db/server';
 import {
   buildPullRequestUrl,
   getSourceControlProviderLabel,
+  resolveSourceControlHostFromPayload,
   resolveSourceControlProviderFromPayload,
   sourceControlProviderSchema,
   type SourceControlProvider,
@@ -595,9 +596,10 @@ export async function readSourceControlPullRequestForTaskRun({
   input: SourceControlPullRequestReadInput;
   fetchImpl?: FetchImpl;
 }): Promise<SourceControlPullRequestReadResult> {
-  const payloadProvider = resolveSourceControlProviderFromPayload(
-    getPayloadRecord(taskRun.payload),
-  );
+  const payloadRecord = getPayloadRecord(taskRun.payload);
+  const payloadProvider =
+    resolveSourceControlProviderFromPayload(payloadRecord);
+  const payloadHost = resolveSourceControlHostFromPayload(payloadRecord);
   const provider = input.sourceControlProvider ?? payloadProvider;
 
   if (provider !== payloadProvider) {
@@ -613,6 +615,7 @@ export async function readSourceControlPullRequestForTaskRun({
   const repository = await resolveRepositoryRow({
     provider,
     repositoryFullName: input.repositoryFullName,
+    host: payloadHost,
   });
 
   if (input.action === 'list_pull_requests') {

--- a/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-shared.ts
+++ b/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-shared.ts
@@ -43,14 +43,32 @@ export type RepositoryRow = {
  * in exactly one place.
  */
 
+/**
+ * Resolves the active repository row for a (provider, fullName) identity,
+ * optionally narrowed by source-control instance host.
+ *
+ * When `host` is provided (typically from the task payload's
+ * `sourceControlHost`), rows whose `host` matches exactly are preferred;
+ * when none match, rows with a NULL host still qualify so legacy rows
+ * written before the host backfill keep resolving (mirroring the scoping in
+ * `upsertSourceControlPullRequestFactFromWebhook`).
+ *
+ * Without a `host`, a (provider, fullName) identity active on more than one
+ * row is an error rather than an arbitrary pick: same-name repositories on
+ * multiple hosts (self-managed GitLab/Gitea/ADO instances) could otherwise
+ * silently resolve to the wrong instance. Launch sites disambiguate by
+ * stamping `sourceControlHost` into the task payload.
+ */
 export async function resolveRepositoryRow({
   provider,
   repositoryFullName,
+  host,
 }: {
   provider: SourceControlProvider;
   repositoryFullName: string;
+  host?: string;
 }): Promise<RepositoryRow> {
-  const repository = await db.query.repositories.findFirst({
+  const rows = await db.query.repositories.findMany({
     where: and(
       eq(repositories.sourceControlProvider, provider),
       eq(repositories.fullName, repositoryFullName),
@@ -67,7 +85,33 @@ export async function resolveRepositoryRow({
     },
   });
 
-  if (!repository) {
+  if (host !== undefined) {
+    const exactMatches = rows.filter((row) => row.host === host);
+    const candidates =
+      exactMatches.length > 0
+        ? exactMatches
+        : rows.filter((row) => row.host === null);
+
+    if (candidates.length === 0) {
+      throw new Error(
+        `${getSourceControlProviderLabel(
+          provider,
+        )} repository not found or inactive on ${host}: ${repositoryFullName}`,
+      );
+    }
+
+    if (candidates.length > 1) {
+      throw new Error(
+        `${getSourceControlProviderLabel(
+          provider,
+        )} repository ${repositoryFullName} matches more than one active repository on ${host}.`,
+      );
+    }
+
+    return candidates[0]!;
+  }
+
+  if (rows.length === 0) {
     throw new Error(
       `${getSourceControlProviderLabel(
         provider,
@@ -75,7 +119,20 @@ export async function resolveRepositoryRow({
     );
   }
 
-  return repository;
+  if (rows.length > 1) {
+    const hosts = [
+      ...new Set(rows.map((row) => row.host ?? 'unknown host')),
+    ].sort((left, right) => left.localeCompare(right));
+    throw new Error(
+      `${getSourceControlProviderLabel(
+        provider,
+      )} repository ${repositoryFullName} is linked from multiple hosts (${hosts.join(
+        ', ',
+      )}); the task payload must carry sourceControlHost to disambiguate.`,
+    );
+  }
+
+  return rows[0]!;
 }
 
 export async function assertRepositoryInTaskRunScope(

--- a/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-writes.ts
+++ b/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-writes.ts
@@ -24,6 +24,7 @@ import {
 import { type TaskRun } from '@roomote/db/server';
 import {
   getSourceControlProviderLabel,
+  resolveSourceControlHostFromPayload,
   resolveSourceControlProviderFromPayload,
   sourceControlProviderSchema,
   type SourceControlProvider,
@@ -239,9 +240,10 @@ export async function writeSourceControlPullRequestForTaskRun({
   const input = normalizeOptionalWriteIds(rawInput);
   assertWriteInputFields(input);
 
-  const payloadProvider = resolveSourceControlProviderFromPayload(
-    getPayloadRecord(taskRun.payload),
-  );
+  const payloadRecord = getPayloadRecord(taskRun.payload);
+  const payloadProvider =
+    resolveSourceControlProviderFromPayload(payloadRecord);
+  const payloadHost = resolveSourceControlHostFromPayload(payloadRecord);
   const provider = input.sourceControlProvider ?? payloadProvider;
 
   if (provider !== payloadProvider) {
@@ -257,6 +259,7 @@ export async function writeSourceControlPullRequestForTaskRun({
   const repository = await resolveRepositoryRow({
     provider,
     repositoryFullName: input.repositoryFullName,
+    host: payloadHost,
   });
 
   switch (provider) {

--- a/packages/sdk/src/server/lib/pull-requests/source-control-pull-requests.ts
+++ b/packages/sdk/src/server/lib/pull-requests/source-control-pull-requests.ts
@@ -37,6 +37,7 @@ import {
   getSourceControlProviderLabel,
   normalizePrBodyAttributionAppMention,
   prActions,
+  resolveSourceControlHostFromPayload,
   resolveSourceControlProviderFromPayload,
   sourceControlProviderSchema,
   type PrAction,
@@ -239,9 +240,10 @@ export async function createOrUpdateSourceControlPullRequestForTaskRun({
   input: SourceControlPullRequestMutationInput;
   fetchImpl?: FetchImpl;
 }): Promise<SourceControlPullRequestMutationResult> {
-  const payloadProvider = resolveSourceControlProviderFromPayload(
-    getPayloadRecord(taskRun.payload),
-  );
+  const payloadRecord = getPayloadRecord(taskRun.payload);
+  const payloadProvider =
+    resolveSourceControlProviderFromPayload(payloadRecord);
+  const payloadHost = resolveSourceControlHostFromPayload(payloadRecord);
   const provider = input.sourceControlProvider ?? payloadProvider;
 
   if (provider !== payloadProvider) {
@@ -257,6 +259,7 @@ export async function createOrUpdateSourceControlPullRequestForTaskRun({
   const repository = await resolveRepositoryRow({
     provider,
     repositoryFullName: input.repositoryFullName,
+    host: payloadHost,
   });
 
   const prAction = await resolveEffectivePrAction(taskRun);

--- a/packages/types/src/source-control.ts
+++ b/packages/types/src/source-control.ts
@@ -142,6 +142,21 @@ export function resolveSourceControlProviderFromPayload(payload: {
   return normalizeSourceControlProvider(payload.sourceControlProvider);
 }
 
+/**
+ * Reads the optional `sourceControlHost` field from a task payload. Returns
+ * the trimmed host, or undefined when the payload carries no usable host so
+ * repository resolution falls back to (provider, fullName) alone.
+ */
+export function resolveSourceControlHostFromPayload(payload: {
+  sourceControlHost?: unknown;
+}): string | undefined {
+  const host =
+    typeof payload.sourceControlHost === 'string'
+      ? payload.sourceControlHost.trim()
+      : '';
+  return host || undefined;
+}
+
 export function getSourceControlProviderLabel(
   provider: SourceControlProvider,
 ): string {

--- a/packages/types/src/task-runs.ts
+++ b/packages/types/src/task-runs.ts
@@ -864,6 +864,15 @@ const sharedTaskPayloadSchema = z.object({
   sourceControlProvider: sourceControlProviderSchema.optional(),
 
   /**
+   * Source-control instance host for repository resolution (for example
+   * `gitlab.example.com`), matching `repositories.host`. Stamped by launch
+   * sites that know the concrete host so same-name repositories on multiple
+   * hosts resolve unambiguously. Omitted payloads resolve by
+   * (provider, fullName) alone.
+   */
+  sourceControlHost: z.string().optional(),
+
+  /**
    * Per-launch PR delivery override. When present, pull requests created for
    * this run derive their draft/ready state from this action instead of the
    * deployment-wide PR delivery setting. Omitted for launches that follow the


### PR DESCRIPTION
## Problem

Merged-PR audit runs skip every repository whose `(provider, fullName)` identity is active on more than one host (same-named repositories on multiple self-managed GitLab/Gitea/ADO instances). The launched task's pull-request tools resolved repositories by `(provider, fullName)` alone, so an ambiguous entry could silently audit the wrong host's repository — the runner excluded them defensively with a warning (see the `TODO(follow-up)` this PR removes).

## Change

- **Task payload**: new optional `sourceControlHost` field on the shared task payload schema, documented to match `repositories.host`.
- **Launch sites**: the merged-PR audit runner already partitions launches by `(provider, host)`; each partition now stamps its host into the payload. The conflict scanner's provider-neutral path stamps the repository row's host the same way. Rows without a recorded host omit the field, preserving the legacy payload shape.
- **Resolution**: `resolveRepositoryRow` accepts the payload host. With a host it prefers exact `repositories.host` matches and falls back to rows with a NULL host (legacy rows written before the host backfill — same tolerance `upsertSourceControlPullRequestFactFromWebhook` already applies). Without a host, an identity active on multiple rows now throws a descriptive error listing the hosts instead of silently picking one.
- **Narrowed skip**: audit manifests now exclude only ambiguous entries whose repository row still has a NULL host; those self-heal once the host backfill reaches them. Everything with a recorded host becomes auditable.

Side effect: GitHub audit payloads now carry `sourceControlHost: 'github.com'` (uniform stamping, no GitHub special case). The field is optional, so historical payloads still validate.

## Testing

- New unit tests for `resolveRepositoryRow` host semantics: exact-match preference, NULL-host fallback, host-scoped not-found, same-tier ambiguity, and the no-host multi-host error.
- Audit-runner tests updated: host-bearing ambiguous entries launch with the host stamped; a legacy NULL-host colliding entry is still skipped; NULL-host partitions assert the field is absent.
- Conflict-scan tests cover stamped and omitted host.
- `pnpm check-types` and `pnpm lint:fast` pass; targeted sdk suite 107 tests green, types suite 550 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)