### PR TITLE
Fix local hosted artifact uploads

### DIFF
--- a/.docker/caddy/Caddyfile
+++ b/.docker/caddy/Caddyfile
@@ -11,13 +11,23 @@
 # Intentionally out of scope compared to production:
 # - TLS: ngrok terminates TLS in front of this listener.
 # - Preview subdomains: the local preview proxy keeps its own port (18081).
-# - MinIO artifact routing: dev presigned S3 URLs point directly at MinIO.
 {
 	auto_https off
 }
 
 :18080 {
 	encode zstd gzip
+
+	@artifact_storage {
+		path /{$S3_BUCKET_ARTIFACTS:roomote-artifacts} /{$S3_BUCKET_ARTIFACTS:roomote-artifacts}/*
+	}
+
+	handle @artifact_storage {
+		reverse_proxy minio:9000 {
+			# Presigned S3 URLs sign the bucket path and Host header.
+			header_up Host {http.request.host}
+		}
+	}
 
 	@api {
 		path /_roomote-api /_roomote-api/*

--- a/LOCAL_DEVELOPMENT.md
+++ b/LOCAL_DEVELOPMENT.md
@@ -105,6 +105,13 @@ Roomote uses local defaults for development services:
 - MinIO API: `http://localhost:19000`
 - MinIO console: `http://localhost:19001`
 
+Roomote keeps server-side MinIO access on the local API port. Presigned
+artifact URLs default to `R_PUBLIC_URL`, and the local Caddy edge proxies the
+signed `/<bucket>/*` paths to MinIO. This lets E2B, Modal, Daytona, and other
+hosted workers upload artifacts through the same public edge they use for API
+callbacks. Set `S3_PRESIGN_ENDPOINT` explicitly only when using a separate
+worker-reachable object-storage endpoint.
+
 Start the database, Redis, and artifact-storage services:
 
 ```sh

--- a/apps/dev/src/services/__tests__/ecosystem.test.ts
+++ b/apps/dev/src/services/__tests__/ecosystem.test.ts
@@ -126,20 +126,40 @@ describe('ecosystem.config.js', () => {
     process.env = {
       ...originalEnv,
       R_PUBLIC_URL: 'https://roomote-example.ngrok.app',
+      S3_PRESIGN_ENDPOINT: undefined,
     };
 
     const apps = loadEcosystemApps();
     const webApp = apps.find((app) => app.name === 'roomote-web');
+    const apiApp = apps.find((app) => app.name === 'roomote-api');
 
     expect(webApp?.env).toMatchObject({
       R_PUBLIC_URL: 'https://roomote-example.ngrok.app',
       R_APP_URL: 'https://roomote-example.ngrok.app',
+      S3_PRESIGN_ENDPOINT: 'https://roomote-example.ngrok.app',
       SLACK_REDIRECT_URI:
         'https://roomote-example.ngrok.app/api/slack/callback',
       SLACK_AUTH_URI: 'https://roomote-example.ngrok.app/api/slack/auth',
       R_LINEAR_REDIRECT_URI:
         'https://roomote-example.ngrok.app/api/linear/callback',
     });
+    expect(apiApp?.env?.S3_PRESIGN_ENDPOINT).toBe(
+      'https://roomote-example.ngrok.app',
+    );
+  });
+
+  it('preserves an explicit artifact presign endpoint', () => {
+    process.env = {
+      ...originalEnv,
+      R_PUBLIC_URL: 'https://roomote-example.ngrok.app',
+      S3_PRESIGN_ENDPOINT: 'https://artifacts.example.com',
+    };
+
+    const apps = loadEcosystemApps();
+
+    expect(
+      apps.find((app) => app.name === 'roomote-api')?.env?.S3_PRESIGN_ENDPOINT,
+    ).toBe('https://artifacts.example.com');
   });
 
   it('does not include the deleted hosted listener in the PM2 app list', () => {

--- a/apps/docs/local-development.mdx
+++ b/apps/docs/local-development.mdx
@@ -35,6 +35,12 @@ service code, resolves your public callback URL, starts Postgres, Redis, and
 MinIO if needed, builds the local worker release archive, and starts the
 Roomote services.
 
+The public development edge also proxies signed artifact-storage paths to
+local MinIO. Hosted compute providers such as E2B, Modal, and Daytona can
+therefore upload screenshots and other artifacts without direct access to your
+machine's localhost ports. An explicit `S3_PRESIGN_ENDPOINT` continues to take
+precedence when you use separate object storage.
+
 Use a public HTTPS URL, such as an ngrok domain, when testing provider
 callbacks from source control or communications providers. Local-only URLs are
 fine for dashboard work that does not need external callbacks.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,8 @@ services:
   caddy-dev:
     container_name: roomote-caddy-dev
     image: caddy:2.10-alpine@sha256:4c6e91c6ed0e2fa03efd5b44747b625fec79bc9cd06ac5235a779726618e530d
+    environment:
+      S3_BUCKET_ARTIFACTS: ${S3_BUCKET_ARTIFACTS:-roomote-artifacts}
     ports:
       - '127.0.0.1:18080:18080'
     volumes:

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -37,6 +37,7 @@ const localPorts = {
   previewProxy: Number(process.env.ROOMOTE_PREVIEW_PROXY_PORT || 18081),
 };
 const publicUrl = process.env.R_PUBLIC_URL;
+const s3PresignEndpoint = process.env.S3_PRESIGN_ENDPOINT || publicUrl;
 
 const configuredModelProviderEnvKeysValue = process.env.R_MODEL_ENV_KEYS || '';
 const configuredModelProviderEnvKeys = configuredModelProviderEnvKeysValue
@@ -65,6 +66,10 @@ const defaultEnv = {
     (process.arch === 'arm64' ? 'linux/arm64' : 'linux/amd64'),
   R_PUBLIC_URL: publicUrl,
   R_APP_URL: publicUrl,
+  // Hosted workers cannot reach the host-local MinIO port. The local Caddy
+  // edge proxies signed bucket paths, so use the public edge for presigned
+  // artifact URLs unless the operator configured a separate reachable store.
+  S3_PRESIGN_ENDPOINT: s3PresignEndpoint,
   // Set by `pnpm dev` to `<public-url>/_roomote-api` so workers on hosted
   // compute providers reach the API through the Caddy dev edge, matching
   // the deployed TRPC_URL contract.


### PR DESCRIPTION
## Summary

- proxy signed artifact bucket paths through the local Caddy development edge
- default local `S3_PRESIGN_ENDPOINT` to `R_PUBLIC_URL` while preserving explicit overrides
- pass custom artifact bucket names to the Caddy container
- document artifact uploads from hosted compute providers in local development

## Root cause

Hosted workers could reach the local Roomote API through the public development edge, but artifact records returned presigned MinIO URLs using `localhost:19000`. From E2B, Modal, or Daytona, that hostname refers to the remote sandbox rather than the developer machine, so the object-storage PUT failed before Roomote could mark the artifact uploaded.

This mirrors the existing production Caddy contract: remote clients use the public Roomote origin for signed bucket paths, while Roomote services retain direct server-side access to MinIO.

## Validation

- targeted `@roomote/dev` ecosystem configuration tests
- `@roomote/dev` lint and TypeScript checks
- Caddy configuration validation
- Docker Compose configuration validation
- signed presigned-URL PUT through an isolated Caddy container into local MinIO (`200`)
- `pnpm lint:fast`
- `pnpm check-types:fast`
- `pnpm knip`
