### PR TITLE
Prevent false local artifact uploads

### DIFF
--- a/apps/dev/src/services/__tests__/docker.test.ts
+++ b/apps/dev/src/services/__tests__/docker.test.ts
@@ -35,7 +35,8 @@ describe('DockerService.checkContainers', () => {
     vi.useRealTimers();
   });
 
-  it('does nothing when base infra containers are already running', async () => {
+  it('recreates the local edge when base infra containers are already running', async () => {
+    const expectedCwd = path.resolve(process.cwd(), '../..');
     const listContainers = vi
       .fn()
       .mockResolvedValueOnce([
@@ -58,9 +59,23 @@ describe('DockerService.checkContainers', () => {
       } as unknown as Docker;
     } as unknown as typeof Docker);
 
+    vi.mocked(execa).mockResolvedValue({} as Awaited<ReturnType<typeof execa>>);
+
     await DockerService.checkContainers(false);
 
-    expect(execa).not.toHaveBeenCalled();
+    expect(execa).toHaveBeenCalledWith(
+      'docker',
+      ['compose', 'up', 'caddy-dev', '-d', '--force-recreate', '--wait'],
+      expect.objectContaining({
+        cwd: expectedCwd,
+        extendEnv: false,
+      }),
+    );
+    expect(execa).not.toHaveBeenCalledWith(
+      'pnpm',
+      ['infra:up'],
+      expect.anything(),
+    );
   });
 
   it('starts full infra when redis is missing', async () => {

--- a/apps/dev/src/services/docker.ts
+++ b/apps/dev/src/services/docker.ts
@@ -145,7 +145,7 @@ export class DockerService {
     stopSelfHost.succeed();
   }
 
-  static async checkContainers(_verbose: boolean): Promise<void> {
+  static async checkContainers(verbose: boolean): Promise<void> {
     const checkContainers = ora('Checking Docker containers').start();
     const rootDir = path.resolve(process.cwd(), '../..');
 
@@ -157,23 +157,39 @@ export class DockerService {
       .filter(([_, isRunning]) => !isRunning)
       .map(([name]) => name);
 
+    if (missing.length > 0) {
+      checkContainers.warn();
+
+      ora(`Starting Docker containers: ${missing.join(', ')}`).info();
+
+      await execa('pnpm', ['infra:up'], {
+        stdio: 'inherit',
+        cwd: path.resolve(process.cwd(), '../..'),
+        env: this.getInfraUpEnv(),
+        extendEnv: false,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 5_000));
+    }
+
+    // Caddy loads its config only when the container starts. Recreate the
+    // local edge on every dev startup so routing and environment changes from
+    // the checkout cannot be masked by an already-running stale container.
+    await execa(
+      'docker',
+      ['compose', 'up', 'caddy-dev', '-d', '--force-recreate', '--wait'],
+      {
+        cwd: rootDir,
+        env: this.getInfraUpEnv(),
+        extendEnv: false,
+        ...(verbose && { stdio: 'inherit' }),
+      },
+    );
+
     if (missing.length === 0) {
       checkContainers.succeed();
       return;
     }
-
-    checkContainers.warn();
-
-    ora(`Starting Docker containers: ${missing.join(', ')}`).info();
-
-    await execa('pnpm', ['infra:up'], {
-      stdio: 'inherit',
-      cwd: path.resolve(process.cwd(), '../..'),
-      env: this.getInfraUpEnv(),
-      extendEnv: false,
-    });
-
-    await new Promise((resolve) => setTimeout(resolve, 5_000));
 
     // startContainers.succeed();
 

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/api-client.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/api-client.test.ts
@@ -302,7 +302,10 @@ describe('uploadToPresignedUrl', () => {
   afterEach(() => vi.restoreAllMocks());
 
   it('should PUT content to presigned URL', async () => {
-    global.fetch = vi.fn().mockResolvedValueOnce({ ok: true });
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      headers: new Headers({ etag: '"artifact-etag"' }),
+    });
 
     const content = Buffer.from('hello');
     await uploadToPresignedUrl(
@@ -337,6 +340,23 @@ describe('uploadToPresignedUrl', () => {
         'text/plain',
       ),
     ).rejects.toThrow('Failed to upload to S3: 500 Internal Server Error');
+  });
+
+  it('rejects a non-S3 success response without an ETag', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      headers: new Headers({ 'content-type': 'text/html' }),
+    });
+
+    await expect(
+      uploadToPresignedUrl(
+        'https://s3.example.com/upload',
+        Buffer.from('x'),
+        'text/plain',
+      ),
+    ).rejects.toThrow(
+      'Failed to upload to S3: successful response did not include an ETag',
+    );
   });
 });
 
@@ -384,7 +404,10 @@ describe('uploadArtifact', () => {
           rawUrl: 'https://test-api.example.com/api/artifacts/art-1/raw',
         }),
       })
-      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ etag: '"artifact-etag"' }),
+      })
       .mockResolvedValueOnce({ ok: true });
     global.fetch = fetchMock;
 
@@ -418,7 +441,10 @@ describe('uploadArtifact', () => {
           artifactType: 'general',
         }),
       })
-      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ etag: '"artifact-etag"' }),
+      })
       .mockResolvedValueOnce({ ok: true });
     global.fetch = fetchMock;
 

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/create-plan.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/create-plan.test.ts
@@ -5,6 +5,11 @@ import { tmpdir } from 'node:os';
 import { handleCreatePlan } from '../create-plan.js';
 import type { ArtifactConfig } from '../types.js';
 
+const successfulS3UploadResponse = () => ({
+  ok: true,
+  headers: new Headers({ etag: '"artifact-etag"' }),
+});
+
 describe('handleCreatePlan', () => {
   const originalEnv = process.env;
   let testDir: string;
@@ -39,7 +44,7 @@ describe('handleCreatePlan', () => {
           rawUrl: 'https://test-api.example.com/api/artifacts/art-1/raw',
         }),
       })
-      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce(successfulS3UploadResponse())
       .mockResolvedValueOnce({ ok: true });
     global.fetch = fetchMock;
 
@@ -85,7 +90,7 @@ describe('handleCreatePlan', () => {
           rawUrl: 'https://test-api.example.com/api/artifacts/art-1/raw',
         }),
       })
-      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce(successfulS3UploadResponse())
       .mockResolvedValueOnce({ ok: true });
     global.fetch = fetchMock;
 
@@ -116,7 +121,7 @@ describe('handleCreatePlan', () => {
           rawUrl: 'https://test-api.example.com/api/artifacts/art-1/raw',
         }),
       })
-      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce(successfulS3UploadResponse())
       .mockResolvedValueOnce({ ok: true });
     global.fetch = fetchMock;
 

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/upload.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/upload.test.ts
@@ -7,6 +7,11 @@ import { handleUpload } from '../upload.js';
 import { resetPostedProofThreadsForTest } from '../chat-proof-auto-post.js';
 import type { ArtifactConfig } from '../types.js';
 
+const successfulS3UploadResponse = () => ({
+  ok: true,
+  headers: new Headers({ etag: '"artifact-etag"' }),
+});
+
 describe('handleUpload', () => {
   let testDir: string;
   const originalSlackChannel = process.env.ROOMOTE_SLACK_CHANNEL;
@@ -83,7 +88,7 @@ describe('handleUpload', () => {
           artifactType: 'general',
         }),
       })
-      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce(successfulS3UploadResponse())
       .mockResolvedValueOnce({ ok: true });
     global.fetch = fetchMock;
 
@@ -156,7 +161,7 @@ describe('handleUpload', () => {
           rawUrl: 'https://test-api.example.com/api/artifacts/art-1/raw',
         }),
       })
-      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce(successfulS3UploadResponse())
       .mockResolvedValueOnce({ ok: true });
     global.fetch = fetchMock;
 
@@ -194,7 +199,7 @@ describe('handleUpload', () => {
           rawUrl: 'https://test-api.example.com/api/artifacts/art-proof/raw',
         }),
       })
-      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce(successfulS3UploadResponse())
       .mockResolvedValueOnce({ ok: true })
       .mockResolvedValueOnce({
         ok: true,
@@ -259,7 +264,7 @@ describe('handleUpload', () => {
           rawUrl: 'https://test-api.example.com/api/artifacts/art-proof/raw',
         }),
       })
-      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce(successfulS3UploadResponse())
       .mockResolvedValueOnce({ ok: true })
       .mockResolvedValueOnce({
         ok: true,
@@ -310,7 +315,7 @@ describe('handleUpload', () => {
           rawUrl: 'https://test-api.example.com/api/artifacts/art-proof/raw',
         }),
       })
-      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce(successfulS3UploadResponse())
       .mockResolvedValueOnce({ ok: true })
       .mockResolvedValueOnce({
         ok: false,
@@ -362,7 +367,7 @@ describe('handleUpload', () => {
           rawUrl: 'https://test-api.example.com/api/artifacts/art-proof/raw',
         }),
       })
-      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce(successfulS3UploadResponse())
       .mockResolvedValueOnce({ ok: true });
     global.fetch = fetchMock;
 
@@ -399,7 +404,7 @@ describe('handleUpload', () => {
           rawUrl: 'https://test-api.example.com/api/artifacts/art-proof/raw',
         }),
       })
-      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce(successfulS3UploadResponse())
       .mockResolvedValueOnce({ ok: true });
     global.fetch = fetchMock;
 
@@ -437,7 +442,7 @@ describe('handleUpload', () => {
           rawUrl: 'https://test-api.example.com/api/artifacts/art-proof/raw',
         }),
       })
-      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce(successfulS3UploadResponse())
       .mockResolvedValueOnce({ ok: true })
       .mockResolvedValueOnce({
         ok: true,
@@ -454,7 +459,7 @@ describe('handleUpload', () => {
           rawUrl: 'https://test-api.example.com/api/artifacts/art-proof-2/raw',
         }),
       })
-      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce(successfulS3UploadResponse())
       .mockResolvedValueOnce({ ok: true });
     global.fetch = fetchMock;
 
@@ -516,7 +521,7 @@ describe('handleUpload', () => {
           artifactType: 'visual-proof',
         }),
       })
-      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce(successfulS3UploadResponse())
       .mockResolvedValueOnce({ ok: true })
       .mockResolvedValueOnce({
         ok: true,
@@ -532,7 +537,7 @@ describe('handleUpload', () => {
           artifactType: 'visual-proof',
         }),
       })
-      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce(successfulS3UploadResponse())
       .mockResolvedValueOnce({ ok: true })
       .mockResolvedValueOnce({
         ok: true,
@@ -595,7 +600,7 @@ describe('handleUpload', () => {
           artifactType: 'visual-proof',
         }),
       })
-      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce(successfulS3UploadResponse())
       .mockResolvedValueOnce({ ok: true })
       .mockResolvedValueOnce({
         ok: true,
@@ -648,7 +653,7 @@ describe('handleUpload', () => {
             rawUrl: 'https://test-api.example.com/api/artifacts/art-2/raw',
           }),
         })
-        .mockResolvedValueOnce({ ok: true })
+        .mockResolvedValueOnce(successfulS3UploadResponse())
         .mockResolvedValueOnce({ ok: true });
       global.fetch = fetchMock;
 

--- a/apps/worker/src/mcp/roomote-mcp-server/api-client.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/api-client.ts
@@ -169,6 +169,12 @@ export async function uploadToPresignedUrl(
       `Failed to upload to S3: ${response.status} ${response.statusText}`,
     );
   }
+
+  if (!response.headers.get('etag')) {
+    throw new Error(
+      'Failed to upload to S3: successful response did not include an ETag',
+    );
+  }
 }
 
 /**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
     ports:
       - '127.0.0.1:18080:18080'
     volumes:
-      - ./.docker/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./.docker/caddy:/etc/caddy:ro
     extra_hosts:
       - 'host.docker.internal:host-gateway'
 


### PR DESCRIPTION
## Summary

- recreate the local Caddy edge on every `pnpm dev` startup so routing and environment changes cannot remain hidden behind a stale container
- mount the Caddy config directory instead of a single file so atomic file replacements are visible through Docker Desktop
- require an S3 `ETag` before treating a presigned upload response as successful

## Root cause

Follow-up to #344. Local PM2 services received the new public artifact presign endpoint, but the already-running Caddy container was considered healthy and skipped by startup reconciliation. Artifact PUTs therefore fell through to the web app. Its `200` HTML response passed the worker's status-only check, so Roomote marked an artifact uploaded even though MinIO never received the object. The sidebar later loaded the same HTML fallback instead of image bytes.

The existing false-positive artifact cannot be recovered because its object was never stored, but fresh captures work after the local edge is reconciled.

## Validation

- `@roomote/dev` Docker and ecosystem tests: 20 passed
- `@roomote/worker` artifact API client tests: 26 passed
- `@roomote/dev` and `@roomote/worker` TypeScript checks
- `@roomote/dev` and `@roomote/worker` lint
- worker production build
- Docker Compose configuration validation
- Caddy configuration validation after forced recreation
- signed PUT and GET through the live public development edge (`200`, matching bytes, S3 `ETag` present)
- `pnpm lint:fast`
- `pnpm check-types:fast`
- `pnpm knip`
