### PR TITLE
[Fix] Blaxel Compose projects no longer pass the unsupported --wait flag

### DIFF
--- a/.changeset/blaxel-compose-wait-provider-env.md
+++ b/.changeset/blaxel-compose-wait-provider-env.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Blaxel Docker projects no longer pass the unsupported Compose `--wait` flag: the provider check now reads the worker's process environment, where the compute provider is actually set.

--- a/apps/worker/src/commands/setup/__tests__/docker-projects.test.ts
+++ b/apps/worker/src/commands/setup/__tests__/docker-projects.test.ts
@@ -35,6 +35,7 @@ describe('initializeDockerProjects', () => {
   });
 
   afterEach(async () => {
+    vi.unstubAllEnvs();
     await fs.rm(workspacePath, { recursive: true, force: true });
   });
 
@@ -268,6 +269,9 @@ describe('initializeDockerProjects', () => {
   });
 
   it('starts Blaxel projects without the unsupported healthcheck wait', async () => {
+    // The provider is injected into the worker's process env at sandbox
+    // creation; it never arrives through the job's envVars.
+    vi.stubEnv('COMPUTE_PROVIDER', 'blaxel');
     await fs.writeFile(
       path.join(repositoryPath, 'compose.yaml'),
       'services:\n  web:\n    image: nginx:alpine\n',
@@ -293,7 +297,7 @@ describe('initializeDockerProjects', () => {
             ],
           },
         },
-        envVars: { COMPUTE_PROVIDER: 'blaxel', PATH: '/usr/bin' },
+        envVars: { PATH: '/usr/bin' },
         taskRunType: TaskPayloadKind.StandardTask,
       },
       {

--- a/apps/worker/src/commands/setup/workspace/docker-projects.ts
+++ b/apps/worker/src/commands/setup/workspace/docker-projects.ts
@@ -19,6 +19,7 @@ import {
 import { substituteEnvVars } from '../../../env';
 import type { StartupLogger } from '../../../logging';
 
+import { resolveComputeProviderFromEnv } from './shared';
 import type { PrepareWorkspaceOptions, PrepareWorkspaceResult } from './types';
 
 const DEFAULT_STARTUP_TIMEOUT_SECONDS = 600;
@@ -398,7 +399,10 @@ async function startDockerProject({
     resolved.project.type === 'compose'
       ? (resolved.project.services ?? [])
       : [];
-  const waitForServices = resolved.env.COMPUTE_PROVIDER !== 'blaxel';
+  // The provider lives in the worker's process env (injected at sandbox
+  // creation), not in resolved.env, which only carries deployment and
+  // user-facing vars.
+  const waitForServices = resolveComputeProviderFromEnv() !== 'blaxel';
   if (!waitForServices) {
     logger.userLog.warn(
       'Blaxel does not support Docker healthchecks; continuing after Compose starts the services.',

--- a/apps/worker/src/commands/setup/workspace/shared.ts
+++ b/apps/worker/src/commands/setup/workspace/shared.ts
@@ -1,6 +1,10 @@
 import * as fs from 'node:fs';
 
-import { isComputeProvider, resolveWorkerRuntimePaths } from '@roomote/types';
+import {
+  type ComputeProvider,
+  isComputeProvider,
+  resolveWorkerRuntimePaths,
+} from '@roomote/types';
 
 import { substituteEnvVars } from '../../../env';
 import type { StartupLogger } from '../../../logging';
@@ -8,12 +12,25 @@ import { WorkspaceManager, type WorkspaceConfig } from '../../../workspace';
 
 import { timedStep } from '../logging';
 
-export function resolveRuntimePathsForWorker() {
+/**
+ * The compute provider that launched this worker. Providers inject
+ * COMPUTE_PROVIDER into the worker's process env at sandbox creation; it is
+ * not part of the deployment or user-facing env vars.
+ */
+export function resolveComputeProviderFromEnv(): ComputeProvider | undefined {
   const providerFromEnv =
     process.env.COMPUTE_PROVIDER ?? process.env.WORKER_TARGET;
 
-  if (providerFromEnv && isComputeProvider(providerFromEnv)) {
-    return resolveWorkerRuntimePaths({ provider: providerFromEnv });
+  return providerFromEnv && isComputeProvider(providerFromEnv)
+    ? providerFromEnv
+    : undefined;
+}
+
+export function resolveRuntimePathsForWorker() {
+  const provider = resolveComputeProviderFromEnv();
+
+  if (provider) {
+    return resolveWorkerRuntimePaths({ provider });
   }
 
   return resolveWorkerRuntimePaths({ existsSync: fs.existsSync });


### PR DESCRIPTION
## Related issue

Outstanding item on the v0.5.0 promote review checklist (PR #361): Blaxel Docker projects still pass Compose `--wait`, which the provider does not support. Internal maintainer work, no public issue.

## Why this PR exists

- [ ] A maintainer explicitly invited this PR in the linked issue or discussion
- [x] I am a maintainer / this is internal Roomote work

## What changed

The `--wait` gate in `startDockerProject` read `resolved.env.COMPUTE_PROVIDER`, but `resolved.env` only carries deployment and user-facing env vars. The compute provider is injected into the worker's **process** env at sandbox creation (`buildWorkerContextEnv`), which is where the sibling setup code already reads it. So on Blaxel the check always saw `undefined` and kept sending `--wait`.

- Extracted the existing provider-from-env logic in `setup/workspace/shared.ts` into an exported `resolveComputeProviderFromEnv()` helper and reused it in `resolveRuntimePathsForWorker`.
- The `--wait` gate in `docker-projects.ts` now uses that helper instead of `resolved.env`.
- Updated the Blaxel test to stub `process.env.COMPUTE_PROVIDER` instead of injecting it through the job `envVars`, which was masking the bug (the test injected the variable through a path production never takes). Verified the updated test fails against the previous source and passes with the fix.

## How it was tested

- `pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/worker exec vitest run src/commands/setup/__tests__/docker-projects.test.ts` (9 passed)
- Negative check: re-ran the updated test with the source change stashed; the Blaxel case fails as expected against the old code.
- `pnpm lint:fast` and `pnpm check-types:fast`

## Checklist

- [x] The PR title follows the repo convention: `[Fix]`, `[Feat]`, `[Improve]`, `[Refactor]`, `[Docs]`, or `[Chore]` followed by a user-facing description
- [x] This PR is small and scoped to one change
- [x] `pnpm lint` and `pnpm check-types` pass locally
- [x] I added tests or included a clear manual validation note above
- [x] I removed secrets, tokens, private keys, and customer data from code, logs, and screenshots
- [x] If this change should appear in the changelog, I ran `pnpm changeset`

## Impact

Blaxel-hosted Docker Compose projects start without the unsupported `--wait`/`--wait-timeout` flags, matching the behavior the existing warning message already promised. No change for other compute providers. Resolves one of the three outstanding items on the #361 review checklist; if v0.5.0 still needs it, cherry-pick onto `release/v0.5.0` after this merges to `develop`.