### PR TITLE
Promote Bitbucket OAuth to deployment scope

### DIFF
--- a/apps/api/src/handlers/bitbucket/__tests__/getBitbucketAutomationTargets.test.ts
+++ b/apps/api/src/handlers/bitbucket/__tests__/getBitbucketAutomationTargets.test.ts
@@ -36,4 +36,22 @@ describe('getBitbucketAutomationTargets helpers', () => {
       }),
     ).toBe('abcd-ef');
   });
+
+  it('falls back past blank username fields and trims the selected value', () => {
+    expect(
+      getBitbucketUsername({
+        username: '  ',
+        nickname: '  nick  ',
+        display_name: 'Display',
+      }),
+    ).toBe('nick');
+
+    expect(
+      getBitbucketUsername({
+        username: '  ',
+        nickname: '  ',
+        display_name: '  Display  ',
+      }),
+    ).toBe('Display');
+  });
 });

--- a/apps/api/src/handlers/bitbucket/__tests__/handleComment.test.ts
+++ b/apps/api/src/handlers/bitbucket/__tests__/handleComment.test.ts
@@ -3,13 +3,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const {
   mockCreateBitbucketPullRequestComment,
   mockGetBitbucketAutomationTargets,
+  mockEnqueueTask,
 } = vi.hoisted(() => ({
   mockCreateBitbucketPullRequestComment: vi.fn(),
   mockGetBitbucketAutomationTargets: vi.fn(),
+  mockEnqueueTask: vi.fn(),
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
-  enqueueTask: vi.fn(),
+  enqueueTask: mockEnqueueTask,
   getTaskUrl: vi.fn(),
 }));
 
@@ -71,6 +73,7 @@ describe('handleBitbucketComment', () => {
   beforeEach(() => {
     mockCreateBitbucketPullRequestComment.mockReset();
     mockGetBitbucketAutomationTargets.mockReset();
+    mockEnqueueTask.mockReset();
 
     mockGetBitbucketAutomationTargets.mockResolvedValue({
       status: 'error',
@@ -118,6 +121,28 @@ describe('handleBitbucketComment', () => {
     );
   });
 
+  it('posts an environment setup reply when no environment is mapped', async () => {
+    mockGetBitbucketAutomationTargets.mockResolvedValue({
+      status: 'error',
+      message:
+        'no environment mapping associated with [bitbucket:repo-1, acme/repo]',
+    });
+    mockCreateBitbucketPullRequestComment.mockResolvedValue({ id: 6 });
+
+    await expect(
+      handleBitbucketComment(
+        makeCommentPayload(),
+        'pullrequest:comment_created',
+      ),
+    ).resolves.toEqual({ status: 'ok', message: 'environment_required' });
+
+    expect(mockCreateBitbucketPullRequestComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('no Roomote environment is mapped'),
+      }),
+    );
+  });
+
   it('does not suppress a human mention from the deployment OAuth identity', async () => {
     const payload = makeCommentPayload();
     payload.comment.user = {
@@ -132,5 +157,42 @@ describe('handleBitbucketComment', () => {
     ).resolves.toEqual({ status: 'ok', message: 'account_link_required' });
 
     expect(mockCreateBitbucketPullRequestComment).toHaveBeenCalledOnce();
+  });
+
+  it('logs enqueue failures and posts a queue-specific response', async () => {
+    mockGetBitbucketAutomationTargets.mockResolvedValue({
+      status: 'ok',
+      targets: [
+        {
+          id: 'bitbucket:pr_review:repo-1',
+          workflow: 'pr_review',
+          settings: null,
+          repo: {
+            id: 'repo-1',
+            host: 'bitbucket.org',
+          },
+          repositoryIds: ['repo-1'],
+          userId: 'user-1',
+        },
+      ],
+    });
+    mockEnqueueTask.mockRejectedValue(new Error('queue unavailable'));
+    mockCreateBitbucketPullRequestComment.mockResolvedValue({ id: 5 });
+
+    await expect(
+      handleBitbucketComment(
+        makeCommentPayload(),
+        'pullrequest:comment_created',
+      ),
+    ).resolves.toEqual({
+      status: 'error',
+      message: 'review_start_failed:queue unavailable',
+    });
+
+    expect(mockCreateBitbucketPullRequestComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('could not queue a review task'),
+      }),
+    );
   });
 });

--- a/apps/api/src/handlers/bitbucket/__tests__/handleComment.test.ts
+++ b/apps/api/src/handlers/bitbucket/__tests__/handleComment.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockCreateBitbucketPullRequestComment,
+  mockGetBitbucketAutomationTargets,
+} = vi.hoisted(() => ({
+  mockCreateBitbucketPullRequestComment: vi.fn(),
+  mockGetBitbucketAutomationTargets: vi.fn(),
+}));
+
+vi.mock('@roomote/cloud-agents/server', () => ({
+  enqueueTask: vi.fn(),
+  getTaskUrl: vi.fn(),
+}));
+
+vi.mock('@roomote/bitbucket', () => ({
+  createBitbucketPullRequestComment: mockCreateBitbucketPullRequestComment,
+}));
+
+vi.mock('@roomote/db/server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@roomote/db/server')>();
+
+  return {
+    ...actual,
+    findActiveGitHubPrReviewTask: vi.fn(),
+    findReusableGitHubPrFollowUpOwner: vi.fn(),
+  };
+});
+
+vi.mock('../getBitbucketAutomationTargets', async () => {
+  const actual = await vi.importActual<
+    typeof import('../getBitbucketAutomationTargets')
+  >('../getBitbucketAutomationTargets');
+
+  return {
+    ...actual,
+    getBitbucketAutomationTargets: mockGetBitbucketAutomationTargets,
+  };
+});
+
+import { handleBitbucketComment } from '../handleComment';
+import type { BitbucketPullRequestCommentWebhook } from '../types';
+
+function makeCommentPayload(): BitbucketPullRequestCommentWebhook {
+  return {
+    pullrequest: {
+      id: 1,
+      title: 'Add feature',
+      state: 'OPEN',
+      source: { branch: { name: 'feature' }, commit: { hash: 'abc123' } },
+      destination: { branch: { name: 'main' }, commit: { hash: 'def456' } },
+      links: {
+        html: { href: 'https://bitbucket.org/acme/repo/pull-requests/1' },
+      },
+    },
+    comment: {
+      id: 2,
+      content: { raw: '@roomote review this please' },
+      user: { nickname: 'alice', account_id: 'account-1' },
+    },
+    repository: {
+      full_name: 'acme/repo',
+      uuid: '{repo-1}',
+      links: { html: { href: 'https://bitbucket.org/acme/repo' } },
+    },
+    actor: { nickname: 'alice', account_id: 'account-1' },
+  };
+}
+
+describe('handleBitbucketComment', () => {
+  beforeEach(() => {
+    mockCreateBitbucketPullRequestComment.mockReset();
+    mockGetBitbucketAutomationTargets.mockReset();
+
+    mockGetBitbucketAutomationTargets.mockResolvedValue({
+      status: 'error',
+      code: 'account_link_required',
+      message: 'Bitbucket user alice is not linked',
+    });
+  });
+
+  it('propagates a failed account-link response so the webhook is recorded as failed', async () => {
+    const responseError = new Error('Bitbucket API unavailable');
+    mockCreateBitbucketPullRequestComment.mockRejectedValue(responseError);
+
+    await expect(
+      handleBitbucketComment(
+        makeCommentPayload(),
+        'pullrequest:comment_created',
+      ),
+    ).rejects.toThrow(responseError);
+
+    expect(mockCreateBitbucketPullRequestComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repositoryFullName: 'acme/repo',
+        pullRequestNumber: 1,
+        body: expect.stringContaining('Link it from'),
+      }),
+    );
+  });
+
+  it('posts an account-link reply and completes the webhook when Bitbucket accepts it', async () => {
+    mockCreateBitbucketPullRequestComment.mockResolvedValue({ id: 3 });
+
+    await expect(
+      handleBitbucketComment(
+        makeCommentPayload(),
+        'pullrequest:comment_created',
+      ),
+    ).resolves.toEqual({ status: 'ok', message: 'account_link_required' });
+
+    expect(mockCreateBitbucketPullRequestComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repositoryFullName: 'acme/repo',
+        pullRequestNumber: 1,
+        body: expect.stringContaining('Link it from'),
+      }),
+    );
+  });
+
+  it('does not suppress a human mention from the deployment OAuth identity', async () => {
+    const payload = makeCommentPayload();
+    payload.comment.user = {
+      nickname: 'bruno',
+      account_id: 'deployment-account',
+    };
+    payload.actor = payload.comment.user;
+    mockCreateBitbucketPullRequestComment.mockResolvedValue({ id: 4 });
+
+    await expect(
+      handleBitbucketComment(payload, 'pullrequest:comment_created'),
+    ).resolves.toEqual({ status: 'ok', message: 'account_link_required' });
+
+    expect(mockCreateBitbucketPullRequestComment).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/api/src/handlers/bitbucket/getBitbucketAutomationTargets.ts
+++ b/apps/api/src/handlers/bitbucket/getBitbucketAutomationTargets.ts
@@ -45,7 +45,22 @@ type BitbucketAutomationTarget = {
 export function getBitbucketUsername(
   user: BitbucketWebhookUser | undefined,
 ): string | undefined {
-  return user?.username ?? user?.nickname ?? user?.display_name;
+  const username = user?.username?.trim();
+  if (username) {
+    return username;
+  }
+
+  const nickname = user?.nickname?.trim();
+  if (nickname) {
+    return nickname;
+  }
+
+  const displayName = user?.display_name?.trim();
+  if (displayName) {
+    return displayName;
+  }
+
+  return undefined;
 }
 
 export function isRoomoteBitbucketUsername(username: string): boolean {

--- a/apps/api/src/handlers/bitbucket/handleComment.ts
+++ b/apps/api/src/handlers/bitbucket/handleComment.ts
@@ -20,7 +20,6 @@ import {
 } from '../tasks/sendMessageToTask';
 import {
   getBitbucketAutomationTargets,
-  getBitbucketUserAccountKey,
   getBitbucketUsername,
   isRoomoteBitbucketUsername,
 } from './getBitbucketAutomationTargets';

--- a/apps/api/src/handlers/bitbucket/handleComment.ts
+++ b/apps/api/src/handlers/bitbucket/handleComment.ts
@@ -13,7 +13,10 @@ import {
 
 import type { WebhookResponse } from '../../types';
 import { toHostFromUrl } from '../utils';
-import { buildSourceControlAccountLinkRequiredMessage } from '../source-control-account-linking';
+import {
+  buildSourceControlAccountLinkRequiredMessage,
+  buildSourceControlEnvironmentRequiredMessage,
+} from '../source-control-account-linking';
 import {
   sendMessageToTask,
   steerMessageToTask,
@@ -135,7 +138,7 @@ function buildReviewerGateMissComment(): string {
 }
 
 function buildTaskStartFailedComment(): string {
-  return 'I saw the mention, but I could not start a task for this pull request right now. Please try again in a moment.';
+  return 'I saw the mention, but Roomote could not queue a review task for this pull request. Please try again in a moment. If it keeps failing, an administrator should check the deployment logs.';
 }
 
 function formatQuotedText(text: string): string {
@@ -230,25 +233,41 @@ export async function handleBitbucketComment(
     requireLinkedSenderAccount: true,
   });
 
+  if (targetsResult.status === 'error') {
+    console.warn('[handleBitbucketComment] automation target rejected', {
+      repository: repoFullName,
+      pullRequestNumber: prNumber,
+      code: targetsResult.code ?? null,
+      reason: targetsResult.message,
+    });
+  }
+
   const target =
     targetsResult.status === 'ok' ? targetsResult.targets[0] : undefined;
+
+  const requiresEnvironment =
+    targetsResult.status === 'error' &&
+    targetsResult.message.includes('no environment mapping');
+  const requiresAccountLink =
+    targetsResult.status === 'error' &&
+    targetsResult.code === 'account_link_required';
 
   if (!target || !target.userId) {
     await postMentionResponseComment({
       ...mentionResponseTarget,
-      body:
-        targetsResult.status === 'error' &&
-        targetsResult.code === 'account_link_required'
-          ? buildSourceControlAccountLinkRequiredMessage('bitbucket')
+      body: requiresAccountLink
+        ? buildSourceControlAccountLinkRequiredMessage('bitbucket')
+        : requiresEnvironment
+          ? buildSourceControlEnvironmentRequiredMessage('bitbucket')
           : buildReviewerGateMissComment(),
     });
 
     return {
       status: 'ok',
-      message:
-        targetsResult.status === 'error' &&
-        targetsResult.code === 'account_link_required'
-          ? 'account_link_required'
+      message: requiresAccountLink
+        ? 'account_link_required'
+        : requiresEnvironment
+          ? 'environment_required'
           : 'reviewer_gate_miss',
     };
   }
@@ -385,9 +404,22 @@ export async function handleBitbucketComment(
 
     return { status: 'ok', metadata: { ids: [launch.id] } };
   } catch (error) {
-    console.warn(
-      `[handleBitbucketComment] failed to start PR review task for ${repoFullName}#${prNumber}: ${error instanceof Error ? error.message : String(error)}`,
-    );
+    const failure =
+      error instanceof Error
+        ? {
+            name: error.name,
+            message: error.message,
+            stack: error.stack,
+          }
+        : { name: 'unknown_error', message: String(error) };
+    console.error('[handleBitbucketComment] failed to enqueue PR review task', {
+      repository: repoFullName,
+      pullRequestNumber: prNumber,
+      repositoryId: target.repo.id,
+      userId: target.userId,
+      sourceControlHost: target.repo.host ?? null,
+      error: failure,
+    });
 
     await postMentionResponseComment({
       ...mentionResponseTarget,
@@ -396,7 +428,7 @@ export async function handleBitbucketComment(
 
     return {
       status: 'error',
-      message: `review_start_failed:${error instanceof Error ? error.message : String(error)}`,
+      message: `review_start_failed:${failure.message}`,
     };
   }
 }

--- a/apps/api/src/handlers/bitbucket/handleComment.ts
+++ b/apps/api/src/handlers/bitbucket/handleComment.ts
@@ -3,11 +3,7 @@ import {
   findActiveGitHubPrReviewTask,
   findReusableGitHubPrFollowUpOwner,
 } from '@roomote/db/server';
-import {
-  createBitbucketPullRequestComment,
-  getBitbucketDeploymentUser,
-  normalizeBitbucketLinkedAccountKey,
-} from '@roomote/bitbucket';
+import { createBitbucketPullRequestComment } from '@roomote/bitbucket';
 import {
   type TaskPayload,
   TaskPayloadKind,
@@ -37,7 +33,6 @@ import {
   getBitbucketPullRequestNumber,
   getBitbucketPullRequestUrl,
   type BitbucketPullRequestCommentWebhook,
-  type BitbucketWebhookUser,
 } from './types';
 
 const BITBUCKET_MENTION_HANDLE = '@roomote';
@@ -49,50 +44,6 @@ type BitbucketPrMentionReplyKind =
 
 function isBitbucketMention(commentBody: string): boolean {
   return commentBody.toLowerCase().includes(BITBUCKET_MENTION_HANDLE);
-}
-
-async function isDeploymentTokenAuthor(
-  author: BitbucketWebhookUser | undefined,
-): Promise<boolean> {
-  try {
-    const deploymentUser = await getBitbucketDeploymentUser();
-
-    if (!deploymentUser) {
-      return false;
-    }
-
-    const authorKey = getBitbucketUserAccountKey(author);
-
-    if (authorKey) {
-      if (
-        deploymentUser.accountId &&
-        normalizeBitbucketLinkedAccountKey(deploymentUser.accountId) ===
-          authorKey
-      ) {
-        return true;
-      }
-
-      if (
-        deploymentUser.uuid &&
-        normalizeBitbucketLinkedAccountKey(deploymentUser.uuid) === authorKey
-      ) {
-        return true;
-      }
-    }
-
-    const username = getBitbucketUsername(author);
-
-    return (
-      !!username &&
-      deploymentUser.login.toLowerCase() === username.toLowerCase()
-    );
-  } catch (error) {
-    console.warn(
-      `[handleBitbucketComment] failed to resolve Bitbucket deployment token identity: ${error instanceof Error ? error.message : String(error)}`,
-    );
-
-    return false;
-  }
 }
 
 async function postMentionResponseComment({
@@ -110,10 +61,15 @@ async function postMentionResponseComment({
       pullRequestNumber,
       body,
     });
+    console.info(
+      `[handleBitbucketComment] posted mention response comment on ${repositoryFullName}#${pullRequestNumber}`,
+    );
   } catch (error) {
     console.warn(
       `[handleBitbucketComment] failed to post mention response comment on ${repositoryFullName}#${pullRequestNumber}: ${error instanceof Error ? error.message : String(error)}`,
     );
+
+    throw error;
   }
 }
 
@@ -245,10 +201,7 @@ export async function handleBitbucketComment(
     return { status: 'ok', message: 'no_comment_author' };
   }
 
-  if (
-    isRoomoteBitbucketUsername(commenter) ||
-    (await isDeploymentTokenAuthor(payload.comment.user ?? payload.actor))
-  ) {
+  if (isRoomoteBitbucketUsername(commenter)) {
     return { status: 'ok', message: 'roomote_authored_comment' };
   }
 

--- a/apps/api/src/handlers/github/recordWebhook.ts
+++ b/apps/api/src/handlers/github/recordWebhook.ts
@@ -58,6 +58,11 @@ export async function recordWebhook<T>(
   try {
     response = await handler();
   } catch (error) {
+    console.error(
+      `[recordWebhook] Handler failed for ${provider} webhook ${deliveryId} (${event}):`,
+      error instanceof Error ? error.message : error,
+    );
+
     // Handler threw an exception - record the failure
     response = {
       status: 'error',

--- a/apps/docs/environment-variables.mdx
+++ b/apps/docs/environment-variables.mdx
@@ -258,11 +258,9 @@ as per-task auth tokens or workspace paths.
 | `GITEA_CLIENT_ID`              | Gitea        | Gitea OAuth application client ID for deployment and personal account-linking grants.       |
 | `GITEA_CLIENT_SECRET`          | Gitea        | Gitea OAuth application client secret.                                                      |
 | `GITEA_WEBHOOK_SECRET`         | Optional     | Gitea webhook secret.                                                                       |
-| `BITBUCKET_TOKEN`              | Bitbucket    | Atlassian API token with Bitbucket scopes.                                                  |
-| `BITBUCKET_USERNAME`           | Bitbucket    | Atlassian account email that owns the API token.                                            |
 | `BITBUCKET_BASE_URL`           | Optional     | Bitbucket base URL. Defaults to `https://bitbucket.org` (Cloud only).                       |
-| `BITBUCKET_CLIENT_ID`          | Optional     | Bitbucket OAuth client ID for personal account linking.                                     |
-| `BITBUCKET_CLIENT_SECRET`      | Optional     | Bitbucket OAuth client secret for personal account linking.                                 |
+| `BITBUCKET_CLIENT_ID`          | Bitbucket    | Bitbucket OAuth consumer client ID for deployment authorization and personal account linking. |
+| `BITBUCKET_CLIENT_SECRET`      | Bitbucket    | Bitbucket OAuth consumer client secret.                                                      |
 | `BITBUCKET_WEBHOOK_SECRET`     | Optional     | Bitbucket webhook secret.                                                                   |
 | `ADO_ORGANIZATION`             | Azure DevOps | Azure DevOps organization.                                                                  |
 | `ADO_TOKEN`                    | Azure DevOps | Azure DevOps access token.                                                                  |

--- a/apps/docs/providers/source-control/bitbucket.mdx
+++ b/apps/docs/providers/source-control/bitbucket.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bitbucket
+title: Bitbucket Cloud
 icon: 'https://api.iconify.design/simple-icons:bitbucket.svg?color=currentColor'
 description: Configure Bitbucket Cloud repository sync and pull request webhooks for Roomote.
 ---

--- a/apps/docs/providers/source-control/bitbucket.mdx
+++ b/apps/docs/providers/source-control/bitbucket.mdx
@@ -4,14 +4,14 @@ icon: 'https://api.iconify.design/simple-icons:bitbucket.svg?color=currentColor'
 description: Configure Bitbucket Cloud repository sync and pull request webhooks for Roomote.
 ---
 
-Bitbucket Cloud support uses one deployment-scoped OAuth consumer. The
+Bitbucket Cloud support uses one deployment-scoped OAuth client. The
 authorized account's accessible workspaces define the repositories Roomote can
 sync. Bitbucket Server and Data Center are not supported.
 
-## Create a Bitbucket OAuth consumer
+## Create a Bitbucket OAuth client
 
-Create a consumer in the
-[Atlassian developer console](https://developer.atlassian.com/console/myapps/).
+In the Bitbucket Cloud workspace that owns the repositories, open **Workspace
+settings → Apps and features → OAuth clients**, then create an OAuth client.
 Set its callback URL to:
 
 ```text
@@ -27,7 +27,7 @@ Grant these scopes:
 | `pullrequest` and `pullrequest:write` | pull request workflows |
 | `webhook` | automatic webhook setup |
 
-Save the consumer values in setup or deployment environment variables:
+Save the client values in setup or deployment environment variables:
 
 ```sh
 BITBUCKET_CLIENT_ID=<oauth-consumer-key>

--- a/apps/docs/providers/source-control/bitbucket.mdx
+++ b/apps/docs/providers/source-control/bitbucket.mdx
@@ -4,114 +4,57 @@ icon: 'https://api.iconify.design/simple-icons:bitbucket.svg?color=currentColor'
 description: Configure Bitbucket Cloud repository sync and pull request webhooks for Roomote.
 ---
 
-Bitbucket Cloud support uses a deployment-owned Atlassian API token paired with
-the Atlassian account email. This MVP covers Bitbucket Cloud only. Bitbucket
-Server and Data Center are not supported yet.
+Bitbucket Cloud support uses one deployment-scoped OAuth consumer. The
+authorized account's accessible workspaces define the repositories Roomote can
+sync. Bitbucket Server and Data Center are not supported.
 
-Repository sync can also create pull request webhooks, allowing Review Code
-automation and `@roomote` pull request comments to work for synced Bitbucket
-Cloud repositories.
+## Create a Bitbucket OAuth consumer
 
-Use `<public-url>` below for your stable public Roomote URL.
-
-## Create an Atlassian API token
-
-Create a dedicated Bitbucket Cloud bot or service account and give it access to
-the workspaces or repositories Roomote should use. In that account's
-[Atlassian account settings](https://id.atlassian.com/manage-profile/security/api-tokens),
-choose **Create API token with scopes**, select **Bitbucket** as the app, and
-grant these scopes:
-
-| Scope                                                      | Needed for                                     |
-| ---------------------------------------------------------- | ---------------------------------------------- |
-| read:repository:bitbucket and write:repository:bitbucket   | cloning, branch creation, and commits          |
-| read:pullrequest:bitbucket and write:pullrequest:bitbucket | pull request workflows and comments            |
-| read:webhook:bitbucket and write:webhook:bitbucket         | automatic webhook setup during repository sync |
-| read:workspace:bitbucket                                   | workspace discovery during repository sync     |
-| read:user:bitbucket                                        | identity validation when saving credentials    |
-
-Save the token and the Atlassian account email in setup, deployment env vars,
-or local `.env.local`:
-
-```sh
-BITBUCKET_TOKEN=<atlassian-api-token>
-BITBUCKET_USERNAME=<atlassian-account-email>
-```
-
-Optional values:
-
-```sh
-BITBUCKET_BASE_URL=https://bitbucket.org
-BITBUCKET_WEBHOOK_SECRET=<webhook-secret>
-```
-
-`BITBUCKET_USERNAME` is required with `BITBUCKET_TOKEN` and holds the Atlassian
-account email that owns the token (Bitbucket pairs the two for REST auth). For
-git-over-HTTPS, Roomote automatically uses Bitbucket's static
-`x-bitbucket-api-token-auth` user, so no extra configuration is needed.
-`BITBUCKET_BASE_URL` defaults to `https://bitbucket.org`. Only Bitbucket Cloud
-is accepted; other hosts are rejected.
-
-The setup flow asks only for the API token and its Atlassian account email.
-Roomote uses the Bitbucket Cloud URL and generates the webhook secret
-automatically; optional OAuth settings remain available under Settings.
-
-## Sync repositories
-
-After the Bitbucket values are available, open Settings, go to the Environments
-page, and use the Source Control section's Bitbucket sync button. Roomote lists
-repositories from the Bitbucket Cloud API and stores them as Bitbucket
-repository rows.
-
-Bitbucket-backed tasks clone from the synced repository row, so sync must run
-before launching a Bitbucket-backed task.
-
-After repository sync, Roomote best-effort creates or refreshes a repository
-webhook for each synced Bitbucket repository. The webhook target is:
+Create a consumer in the
+[Atlassian developer console](https://developer.atlassian.com/console/myapps/).
+Set its callback URL to:
 
 ```text
-<public-url>/api/webhooks/bitbucket
+<public-url>/api/source-control/bitbucket/oauth/callback
 ```
 
-If only loopback Roomote URLs are configured, webhook setup is skipped and
-repository sync still succeeds. If `BITBUCKET_WEBHOOK_SECRET` is missing,
-Roomote generates and persists one as an encrypted deployment environment
-variable.
+Grant these scopes:
 
-## Enable review automation
+| Scope | Needed for |
+| --- | --- |
+| `account` | deployment identity |
+| `repository` and `repository:write` | repository sync and Git operations |
+| `pullrequest` and `pullrequest:write` | pull request workflows |
+| `webhook` | automatic webhook setup |
 
-Bitbucket pull request reviews use the same Review Code automation targeting
-model as GitHub, GitLab, and Gitea. After syncing repositories, associate the
-Bitbucket repository with the intended environment and enable Review Code
-automation for that target.
-
-Open or reopened pull request events enqueue initial review tasks. Pull request
-update events enqueue delta reviews. `@roomote` comments on Bitbucket pull
-requests route into the existing PR owner task when possible, or enqueue a new
-review task.
-
-## Optional personal account linking (OAuth)
-
-Users can link their personal Bitbucket account for comment-triggered work when
-a Bitbucket OAuth consumer is configured:
+Save the consumer values in setup or deployment environment variables:
 
 ```sh
-BITBUCKET_CLIENT_ID=<oauth-client-id>
-BITBUCKET_CLIENT_SECRET=<oauth-client-secret>
+BITBUCKET_CLIENT_ID=<oauth-consumer-key>
+BITBUCKET_CLIENT_SECRET=<oauth-consumer-secret>
 ```
 
-These credentials are optional. Without them, deployment-token repository sync,
-webhooks, and Review Code automation still work. With them configured, a
-Bitbucket row can appear under Personal settings for linked accounts.
+`BITBUCKET_BASE_URL` is optional and defaults to `https://bitbucket.org`.
+`BITBUCKET_WEBHOOK_SECRET` is optional; Roomote generates one when webhooks are
+first configured.
+
+## Connect and sync repositories
+
+After saving the consumer values, an admin is redirected to Bitbucket to
+authorize the deployment. The callback exchanges and encrypts the OAuth
+connection, synchronizes all accessible repositories, and registers pull
+request webhooks before returning to setup.
+
+Bitbucket-backed tasks use `x-token-auth` for Git HTTPS credentials. OAuth API
+requests use bearer authentication.
+
+## Personal account linking
+
+Users may link personal Bitbucket accounts separately for commenter identity
+and access-policy checks. Linked accounts do not provide deployment source
+control credentials.
 
 ## Current limits
 
 - Bitbucket Cloud only. Server and Data Center are not supported.
-- There is no Bitbucket App installation flow comparable to the GitHub App.
-
-## Verify setup
-
-1. sync Bitbucket repositories from Settings
-2. create or update an environment from a synced repository
-3. start a small task and confirm Roomote can clone the repository
-4. open or update a pull request and confirm configured review automation runs
+- One deployment OAuth connection is supported.

--- a/apps/docs/source-control.mdx
+++ b/apps/docs/source-control.mdx
@@ -19,7 +19,7 @@ to review events or comments when the provider supports them.
 | -------- | -------- | ----------- |
 | <IntegrationName href="/providers/source-control/github" icon="github" name="GitHub" /> | GitHub-hosted repositories and pull request review workflows | GitHub App installation (default provider). |
 | <IntegrationName href="/providers/source-control/azure-devops" icon="azuredevops" name="Azure DevOps" /> | Azure DevOps repositories | Deployment-owned PAT and repository sync. |
-| <IntegrationName href="/providers/source-control/bitbucket" icon="bitbucket" name="Bitbucket" /> | Bitbucket Cloud repositories and pull request workflows | Deployment-owned Atlassian API token and repository sync. |
+| <IntegrationName href="/providers/source-control/bitbucket" icon="bitbucket" name="Bitbucket" /> | Bitbucket Cloud repositories and pull request workflows | Deployment-scoped Bitbucket OAuth and repository sync. |
 | <IntegrationName href="/providers/source-control/gitea" icon="gitea" name="Gitea" /> | Self-hosted Gitea repositories | Deployment-owned token and repository sync. |
 | <IntegrationName href="/providers/source-control/gitlab" icon="gitlab" name="GitLab" /> | GitLab projects and merge request review workflows | Deployment-owned token and optional webhooks. |
 

--- a/apps/docs/source-control.mdx
+++ b/apps/docs/source-control.mdx
@@ -19,7 +19,7 @@ to review events or comments when the provider supports them.
 | -------- | -------- | ----------- |
 | <IntegrationName href="/providers/source-control/github" icon="github" name="GitHub" /> | GitHub-hosted repositories and pull request review workflows | GitHub App installation (default provider). |
 | <IntegrationName href="/providers/source-control/azure-devops" icon="azuredevops" name="Azure DevOps" /> | Azure DevOps repositories | Deployment-owned PAT and repository sync. |
-| <IntegrationName href="/providers/source-control/bitbucket" icon="bitbucket" name="Bitbucket" /> | Bitbucket Cloud repositories and pull request workflows | Deployment-scoped Bitbucket OAuth and repository sync. |
+| <IntegrationName href="/providers/source-control/bitbucket" icon="bitbucket" name="Bitbucket Cloud" /> | Bitbucket Cloud repositories and pull request workflows | Deployment-scoped Bitbucket OAuth and repository sync. |
 | <IntegrationName href="/providers/source-control/gitea" icon="gitea" name="Gitea" /> | Self-hosted Gitea repositories | Deployment-owned token and repository sync. |
 | <IntegrationName href="/providers/source-control/gitlab" icon="gitlab" name="GitLab" /> | GitLab projects and merge request review workflows | Deployment-owned token and optional webhooks. |
 

--- a/apps/web/src/app/(onboarding)/invokeMethods.tsx
+++ b/apps/web/src/app/(onboarding)/invokeMethods.tsx
@@ -67,7 +67,7 @@ const sourceControlProviderCopy: Record<
   },
   bitbucket: {
     icon: 'bitbucket',
-    description: `Start work from connected Bitbucket pull requests and repositories.`,
+    description: `Start work from connected Bitbucket Cloud pull requests and repositories.`,
   },
   ado: {
     icon: 'ado',

--- a/apps/web/src/app/(onboarding)/invokeMethods.tsx
+++ b/apps/web/src/app/(onboarding)/invokeMethods.tsx
@@ -67,7 +67,7 @@ const sourceControlProviderCopy: Record<
   },
   bitbucket: {
     icon: 'bitbucket',
-    description: `Start work from connected Bitbucket Cloud pull requests and repositories.`,
+    description: `Mention @roomote in a comment on any pull request.`,
   },
   ado: {
     icon: 'ado',

--- a/apps/web/src/app/(onboarding)/invokeMethods.tsx
+++ b/apps/web/src/app/(onboarding)/invokeMethods.tsx
@@ -16,7 +16,6 @@ type InvokeMethod = {
   icon: MethodIcon;
   title: string;
   description: string;
-  example?: string;
 };
 
 type CommunicationProviderId = 'slack' | 'microsoft' | 'telegram';
@@ -124,13 +123,11 @@ export function buildInvokeMethods({
   return [
     ...uniqueValues(communicationProviders).map((provider) => {
       const copy = communicationProviderCopy[provider];
-      const identity = getIdentity(invocationIdentities, provider);
 
       return {
         icon: createBrandIcon(copy.icon, copy.title),
         title: copy.title,
         description: copy.description,
-        ...(identity?.examplePrompt ? { example: identity.examplePrompt } : {}),
       };
     }),
     ...uniqueValues(sourceControlProviders).map((provider) => {
@@ -148,7 +145,6 @@ export function buildInvokeMethods({
         icon: createBrandIcon(copy.icon, title),
         title,
         description,
-        ...(identity?.examplePrompt ? { example: identity.examplePrompt } : {}),
       };
     }),
     ...(includeLinear

--- a/apps/web/src/app/(onboarding)/onboarding/StepInvoke.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/onboarding/StepInvoke.client.test.tsx
@@ -179,9 +179,6 @@ describe('Onboarding StepInvoke', () => {
     expect(
       screen.getByText('Mention @roomote in a comment on any PR.'),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText('@roomote address the PR feedback above'),
-    ).toBeInTheDocument();
   });
 
   it('shows only configured providers with automations before the web UI', () => {

--- a/apps/web/src/app/(onboarding)/onboarding/StepInvoke.tsx
+++ b/apps/web/src/app/(onboarding)/onboarding/StepInvoke.tsx
@@ -86,11 +86,6 @@ export function StepInvoke({
               <p className="text-sm text-muted-foreground cursor-default group-hover:text-foreground">
                 {method.description}
               </p>
-              {method.example ? (
-                <p className="text-sm text-muted-foreground">
-                  Example: <span className="font-mono">{method.example}</span>
-                </p>
-              ) : null}
             </div>
           </div>
         ))}

--- a/apps/web/src/app/(onboarding)/setup/BitbucketSourceControlConfig.tsx
+++ b/apps/web/src/app/(onboarding)/setup/BitbucketSourceControlConfig.tsx
@@ -1,5 +1,27 @@
 import { InstructionUrl } from './ProviderSetupInstructions';
 
+export function BitbucketSourceControlCreation() {
+  return (
+    <>
+      <p className="font-semibold">Create a new Bitbucket OAuth consumer.</p>
+      <p className="text-sm text-muted-foreground">
+        As an admin, in the{' '}
+        <a
+          href="https://developer.atlassian.com/console/myapps/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-foreground underline underline-offset-4 hover:text-foreground"
+        >
+          Atlassian Developer Console
+        </a>
+        , Create App → OAuth 2.0 → Account-level. Then go to Permissions →
+        Marketplace or custom app → Bitbucket API. Then go to Permissions → and
+        grant account, repository:write, pullrequest:write, and webhook scopes.
+      </p>
+    </>
+  );
+}
+
 export function BitbucketSourceControlInstructions({
   publicOrigin,
 }: {
@@ -11,22 +33,10 @@ export function BitbucketSourceControlInstructions({
         Configure the Bitbucket OAuth consumer.
       </p>
       <p className="text-sm">
-        In Permissions, click “Add Marketplace or custom app”, add the
-        “Bitbucket API”, then enable these OAuth scopes:
-      </p>
-      <ul className="list-disc pl-5 text-sm">
-        <li>account</li>
-        <li>repository</li>
-        <li>repository:write</li>
-        <li>pullrequest</li>
-        <li>pullrequest:write</li>
-        <li>webhook</li>
-      </ul>
-      <p className="text-sm">
-        Add this callback URL to the OAuth consumer before saving it:
+        In Authorization, add the OAuth 2.0 type, with this URL:
       </p>
       <InstructionUrl
-        heading="Deployment callback"
+        heading="Callback URL"
         url={`${publicOrigin}/api/source-control/bitbucket/oauth/callback`}
       />
     </div>

--- a/apps/web/src/app/(onboarding)/setup/BitbucketSourceControlConfig.tsx
+++ b/apps/web/src/app/(onboarding)/setup/BitbucketSourceControlConfig.tsx
@@ -1,0 +1,34 @@
+import { InstructionUrl } from './ProviderSetupInstructions';
+
+export function BitbucketSourceControlInstructions({
+  publicOrigin,
+}: {
+  publicOrigin: string;
+}) {
+  return (
+    <div className="max-w-xl space-y-3 text-muted-foreground">
+      <p className="font-semibold text-foreground">
+        Configure the Bitbucket OAuth consumer.
+      </p>
+      <p className="text-sm">
+        In Permissions, click “Add Marketplace or custom app”, add the
+        “Bitbucket API”, then enable these OAuth scopes:
+      </p>
+      <ul className="list-disc pl-5 text-sm">
+        <li>account</li>
+        <li>repository</li>
+        <li>repository:write</li>
+        <li>pullrequest</li>
+        <li>pullrequest:write</li>
+        <li>webhook</li>
+      </ul>
+      <p className="text-sm">
+        Add this callback URL to the OAuth consumer before saving it:
+      </p>
+      <InstructionUrl
+        heading="Deployment callback"
+        url={`${publicOrigin}/api/source-control/bitbucket/oauth/callback`}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/app/(onboarding)/setup/BitbucketSourceControlConfig.tsx
+++ b/apps/web/src/app/(onboarding)/setup/BitbucketSourceControlConfig.tsx
@@ -5,18 +5,19 @@ export function BitbucketSourceControlCreation() {
     <>
       <p className="font-semibold">Create a new Bitbucket OAuth consumer.</p>
       <p className="text-sm text-muted-foreground">
-        As an admin, in the{' '}
+        As an admin, open the Bitbucket workspace you want Roomote to access,
+        then go to Workspace settings → Apps and features → OAuth consumers →
+        Add consumer. See the{' '}
         <a
-          href="https://developer.atlassian.com/console/myapps/"
+          href="https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/"
           target="_blank"
           rel="noopener noreferrer"
           className="text-foreground underline underline-offset-4 hover:text-foreground"
         >
-          Atlassian Developer Console
+          Bitbucket OAuth consumer instructions
         </a>
-        , Create App → OAuth 2.0 → Account-level. Then go to Permissions →
-        Marketplace or custom app → Bitbucket API. Then go to Permissions → and
-        grant account, repository:write, pullrequest:write, and webhook scopes.
+        . Grant account, repository:write, pullrequest:write, and webhook
+        scopes.
       </p>
     </>
   );

--- a/apps/web/src/app/(onboarding)/setup/BitbucketSourceControlConfig.tsx
+++ b/apps/web/src/app/(onboarding)/setup/BitbucketSourceControlConfig.tsx
@@ -1,23 +1,15 @@
+import { Settings } from '@/components/system';
 import { InstructionUrl } from './ProviderSetupInstructions';
 
 export function BitbucketSourceControlCreation() {
   return (
     <>
-      <p className="font-semibold">Create a new Bitbucket OAuth consumer.</p>
+      <p className="font-semibold">Create a new Bitbucket OAuth Client.</p>
       <p className="text-sm text-muted-foreground">
-        As an admin, open the Bitbucket workspace you want Roomote to access,
-        then go to Workspace settings → Apps and features → OAuth consumers →
-        Add consumer. See the{' '}
-        <a
-          href="https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-foreground underline underline-offset-4 hover:text-foreground"
-        >
-          Bitbucket OAuth consumer instructions
-        </a>
-        . Grant account, repository:write, pullrequest:write, and webhook
-        scopes.
+        In the top right click the <Settings className="inline size-4 ml-0.5" />{' '}
+        → Workspace settings → Apps and features → OAuth clients → Create OAuth
+        client. In scopes, grant read + write for: account, repository,
+        pullrequests and webhooks.
       </p>
     </>
   );
@@ -31,11 +23,9 @@ export function BitbucketSourceControlInstructions({
   return (
     <div className="max-w-xl space-y-3 text-muted-foreground">
       <p className="font-semibold text-foreground">
-        Configure the Bitbucket OAuth consumer.
+        Configure the OAuth callback.
       </p>
-      <p className="text-sm">
-        In Authorization, add the OAuth 2.0 type, with this URL:
-      </p>
+      <p className="text-sm">In Authorization, add:</p>
       <InstructionUrl
         heading="Callback URL"
         url={`${publicOrigin}/api/source-control/bitbucket/oauth/callback`}

--- a/apps/web/src/app/(onboarding)/setup/BitbucketSourceControlConfig.tsx
+++ b/apps/web/src/app/(onboarding)/setup/BitbucketSourceControlConfig.tsx
@@ -1,4 +1,5 @@
 import { Settings } from '@/components/system';
+import { BITBUCKET_OAUTH_CALLBACK_PATH } from '@roomote/bitbucket';
 import { InstructionUrl } from './ProviderSetupInstructions';
 
 export function BitbucketSourceControlCreation() {
@@ -30,7 +31,7 @@ export function BitbucketSourceControlInstructions({
       </p>
       <InstructionUrl
         heading="Callback URL"
-        url={`${publicOrigin}/api/source-control/bitbucket/oauth/callback`}
+        url={`${publicOrigin}${BITBUCKET_OAUTH_CALLBACK_PATH}`}
       />
     </div>
   );

--- a/apps/web/src/app/(onboarding)/setup/BitbucketSourceControlConfig.tsx
+++ b/apps/web/src/app/(onboarding)/setup/BitbucketSourceControlConfig.tsx
@@ -1,5 +1,5 @@
 import { Settings } from '@/components/system';
-import { BITBUCKET_OAUTH_CALLBACK_PATH } from '@roomote/bitbucket';
+import { BITBUCKET_OAUTH_CALLBACK_PATH } from '@roomote/bitbucket/constants';
 import { InstructionUrl } from './ProviderSetupInstructions';
 
 export function BitbucketSourceControlCreation() {

--- a/apps/web/src/app/(onboarding)/setup/BitbucketSourceControlConfig.tsx
+++ b/apps/web/src/app/(onboarding)/setup/BitbucketSourceControlConfig.tsx
@@ -25,7 +25,9 @@ export function BitbucketSourceControlInstructions({
       <p className="font-semibold text-foreground">
         Configure the OAuth callback.
       </p>
-      <p className="text-sm">In Authorization, add:</p>
+      <p className="text-sm">
+        When creating the OAuth client, set the callback URL to:
+      </p>
       <InstructionUrl
         heading="Callback URL"
         url={`${publicOrigin}/api/source-control/bitbucket/oauth/callback`}

--- a/apps/web/src/app/(onboarding)/setup/StepInvoke.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepInvoke.client.test.tsx
@@ -347,6 +347,14 @@ describe('Setup StepInvoke', () => {
     ).toBeInTheDocument();
   });
 
+  it('clarifies that Bitbucket Cloud mentions work on any pull request', () => {
+    render(<StepInvoke sourceControlProviders={['bitbucket']} />);
+
+    expect(
+      screen.getByText('Mention @roomote in a comment on any pull request.'),
+    ).toBeInTheDocument();
+  });
+
   it('shows configured providers with automations before the web UI', () => {
     render(
       <StepInvoke

--- a/apps/web/src/app/(onboarding)/setup/StepInvoke.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepInvoke.tsx
@@ -188,11 +188,6 @@ export function StepInvoke({
                 <span className="font-semibold">{method.title}: </span>
                 {method.description}
               </p>
-              {method.example ? (
-                <p className="text-sm text-muted-foreground">
-                  Example: <span className="font-mono">{method.example}</span>
-                </p>
-              ) : null}
             </div>
           </div>
         ))}

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
@@ -309,7 +309,11 @@ describe('StepSourceControlConfig', () => {
     expect(
       screen.queryByRole('link', { name: /Open/ }),
     ).not.toBeInTheDocument();
-    expect(screen.getByText('In Authorization, add:')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'When creating the OAuth client, set the callback URL to:',
+      ),
+    ).toBeInTheDocument();
     expect(
       screen.getByText('Once created,, copy these values:'),
     ).toBeInTheDocument();

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
@@ -288,7 +288,7 @@ describe('StepSourceControlConfig', () => {
     expect(screen.queryByText('Gitea Webhook Secret')).not.toBeInTheDocument();
   });
 
-  it('guides Bitbucket token creation without optional credentials', () => {
+  it('guides Bitbucket OAuth consumer creation', () => {
     render(
       <StepSourceControlConfig
         sourceControlSetup={buildCatalogProviderSetup('bitbucket')}
@@ -297,19 +297,20 @@ describe('StepSourceControlConfig', () => {
       />,
     );
 
-    expect(screen.getByText('Bitbucket API Token')).toBeInTheDocument();
-    expect(screen.getByText('Atlassian Account Email')).toBeInTheDocument();
+    expect(screen.getByText('Bitbucket OAuth Client ID')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Bitbucket OAuth Client Secret/),
+    ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Open/ })).toHaveAttribute(
       'href',
-      'https://id.atlassian.com/manage-profile/security/api-tokens',
+      'https://developer.atlassian.com/console/myapps/',
     );
     expect(
-      screen.getByText(/Create API token with scopes → Bitbucket/),
+      screen.getByText(
+        /Create an OAuth consumer in the Atlassian developer console/,
+      ),
     ).toBeInTheDocument();
     expect(screen.queryByText('Bitbucket Base URL')).not.toBeInTheDocument();
-    expect(
-      screen.queryByText('Bitbucket OAuth Client ID'),
-    ).not.toBeInTheDocument();
     expect(
       screen.queryByText('Bitbucket Webhook Secret'),
     ).not.toBeInTheDocument();

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
@@ -325,7 +325,7 @@ describe('StepSourceControlConfig', () => {
     expect(screen.getByText('Callback URL')).toBeInTheDocument();
     expect(
       screen.getByText(
-        'http://localhost:3000/api/source-control/bitbucket/oauth/callback',
+        'http://localhost:3000/api/auth/oauth2/callback/bitbucket',
       ),
     ).toBeInTheDocument();
     expect(screen.queryByText('Bitbucket Base URL')).not.toBeInTheDocument();

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
@@ -297,7 +297,7 @@ describe('StepSourceControlConfig', () => {
       />,
     );
 
-    expect(screen.getByText('Bitbucket OAuth Client ID')).toBeInTheDocument();
+    expect(screen.getByText(/Bitbucket OAuth Client ID/)).toBeInTheDocument();
     expect(
       screen.getByText(/Bitbucket OAuth Client Secret/),
     ).toBeInTheDocument();

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
@@ -301,21 +301,37 @@ describe('StepSourceControlConfig', () => {
     expect(
       screen.getByText(/Bitbucket OAuth Client Secret/),
     ).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /Open/ })).toHaveAttribute(
+    expect(
+      screen.getByRole('link', { name: 'Atlassian Developer Console' }),
+    ).toHaveAttribute(
       'href',
       'https://developer.atlassian.com/console/myapps/',
     );
     expect(
+      screen.getByText('Create a new Bitbucket OAuth consumer.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Create App → OAuth 2.0 → Account-level/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /Open/ }),
+    ).not.toBeInTheDocument();
+    expect(
       screen.getByText(
-        /Create an OAuth consumer in the Atlassian developer console/,
+        'In Authorization, add the OAuth 2.0 type, with this URL:',
       ),
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        'In Permissions, click “Add Marketplace or custom app”, add the “Bitbucket API”, then enable these OAuth scopes:',
+        'From the app Settings → Authentication details, copy these values:',
       ),
     ).toBeInTheDocument();
-    expect(screen.getByText('Deployment callback')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Enter the values below for your Bitbucket integration.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Callback URL')).toBeInTheDocument();
     expect(
       screen.getByText(
         'http://localhost:3000/api/source-control/bitbucket/oauth/callback',

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
@@ -288,7 +288,7 @@ describe('StepSourceControlConfig', () => {
     expect(screen.queryByText('Gitea Webhook Secret')).not.toBeInTheDocument();
   });
 
-  it('guides Bitbucket OAuth consumer creation', () => {
+  it('guides Bitbucket OAuth client creation', () => {
     render(
       <StepSourceControlConfig
         sourceControlSetup={buildCatalogProviderSetup('bitbucket')}
@@ -297,38 +297,21 @@ describe('StepSourceControlConfig', () => {
       />,
     );
 
-    expect(screen.getByText(/Bitbucket OAuth Client ID/)).toBeInTheDocument();
+    expect(screen.getByText(/Client ID/)).toBeInTheDocument();
+    expect(screen.getByText(/Client Secret/)).toBeInTheDocument();
     expect(
-      screen.getByText(/Bitbucket OAuth Client Secret/),
+      screen.getByText('Create a new Bitbucket OAuth Client.'),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('link', {
-        name: 'Bitbucket OAuth consumer instructions',
-      }),
-    ).toHaveAttribute(
-      'href',
-      'https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/',
-    );
-    expect(
-      screen.getByText('Create a new Bitbucket OAuth consumer.'),
+      screen.getByText(/Workspace settings.*OAuth clients/),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        /Workspace settings.*Apps and features.*OAuth consumers.*Add consumer/,
-      ),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Create OAuth client/)).toBeInTheDocument();
     expect(
       screen.queryByRole('link', { name: /Open/ }),
     ).not.toBeInTheDocument();
+    expect(screen.getByText('In Authorization, add:')).toBeInTheDocument();
     expect(
-      screen.getByText(
-        'In Authorization, add the OAuth 2.0 type, with this URL:',
-      ),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'From the app Settings → Authentication details, copy these values:',
-      ),
+      screen.getByText('Once created,, copy these values:'),
     ).toBeInTheDocument();
     expect(
       screen.getByText(

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
@@ -302,16 +302,20 @@ describe('StepSourceControlConfig', () => {
       screen.getByText(/Bitbucket OAuth Client Secret/),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('link', { name: 'Atlassian Developer Console' }),
+      screen.getByRole('link', {
+        name: 'Bitbucket OAuth consumer instructions',
+      }),
     ).toHaveAttribute(
       'href',
-      'https://developer.atlassian.com/console/myapps/',
+      'https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/',
     );
     expect(
       screen.getByText('Create a new Bitbucket OAuth consumer.'),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Create App → OAuth 2.0 → Account-level/),
+      screen.getByText(
+        /Workspace settings.*Apps and features.*OAuth consumers.*Add consumer/,
+      ),
     ).toBeInTheDocument();
     expect(
       screen.queryByRole('link', { name: /Open/ }),

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
@@ -310,6 +310,17 @@ describe('StepSourceControlConfig', () => {
         /Create an OAuth consumer in the Atlassian developer console/,
       ),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'In Permissions, click “Add Marketplace or custom app”, add the “Bitbucket API”, then enable these OAuth scopes:',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Deployment callback')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'http://localhost:3000/api/source-control/bitbucket/oauth/callback',
+      ),
+    ).toBeInTheDocument();
     expect(screen.queryByText('Bitbucket Base URL')).not.toBeInTheDocument();
     expect(
       screen.queryByText('Bitbucket Webhook Secret'),

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.tsx
@@ -30,7 +30,10 @@ import {
 import { GitHubSourceControlConfig } from './GitHubSourceControlConfig';
 import { GiteaSourceControlInstructions } from './GiteaSourceControlConfig';
 import { GitLabSourceControlInstructions } from './GitLabSourceControlConfig';
-import { BitbucketSourceControlInstructions } from './BitbucketSourceControlConfig';
+import {
+  BitbucketSourceControlCreation,
+  BitbucketSourceControlInstructions,
+} from './BitbucketSourceControlConfig';
 import { getSourceControlSetupCopy } from './sourceControlSetupCopy';
 
 const MASKED_VALUE = '••••••••••••••••••••••••••••';
@@ -369,32 +372,38 @@ export function StepSourceControlConfig({
 
       {!isAdo ? (
         <NumberedStep number={1} className="mt-6">
-          <p className="font-semibold">
-            {providerSetupCopy ? (
-              <>
-                Create a new {providerSetupCopy.setupLabel}.
-                {creationHref && (
-                  <Button variant="outline" className="ml-2" asChild>
-                    <a
-                      href={creationHref ?? providerSetupCopy.creationHref}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {providerSetupCopy.creationLinkLabel ?? 'Open'}{' '}
-                      <ExternalLink className="inline size-4 -mt-1 ml-1" />
-                    </a>
-                  </Button>
+          {selectedProvider?.provider === 'bitbucket' ? (
+            <BitbucketSourceControlCreation />
+          ) : (
+            <>
+              <p className="font-semibold">
+                {providerSetupCopy ? (
+                  <>
+                    Create a new {providerSetupCopy.setupLabel}.
+                    {creationHref && (
+                      <Button variant="outline" className="ml-2" asChild>
+                        <a
+                          href={creationHref ?? providerSetupCopy.creationHref}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {providerSetupCopy.creationLinkLabel ?? 'Open'}{' '}
+                          <ExternalLink className="inline size-4 -mt-1 ml-1" />
+                        </a>
+                      </Button>
+                    )}
+                  </>
+                ) : (
+                  <>Create a new {providerSetupLabel}.</>
                 )}
-              </>
-            ) : (
-              <>Create a new {providerSetupLabel}.</>
-            )}
-          </p>
-          {providerSetupCopy?.creationHint ? (
-            <p className="text-sm text-muted-foreground">
-              {providerSetupCopy.creationHint}
-            </p>
-          ) : null}
+              </p>
+              {providerSetupCopy?.creationHint ? (
+                <p className="text-sm text-muted-foreground">
+                  {providerSetupCopy.creationHint}
+                </p>
+              ) : null}
+            </>
+          )}
         </NumberedStep>
       ) : (
         <NumberedStep number={1} className="mt-6">
@@ -438,10 +447,21 @@ export function StepSourceControlConfig({
             : 2
         }
       >
-        <p className="font-semibold">
-          Enter the values below for your {provider ?? 'source control'}{' '}
-          integration.
-        </p>
+        {selectedProvider?.provider === 'bitbucket' ? (
+          <>
+            <p className="font-semibold">
+              Enter the values below for your Bitbucket integration.
+            </p>
+            <p className="text-sm text-muted-foreground">
+              From the app Settings → Authentication details, copy these values:
+            </p>
+          </>
+        ) : (
+          <p className="font-semibold">
+            Enter the values below for your {provider ?? 'source control'}{' '}
+            integration.
+          </p>
+        )}
 
         <div className="space-y-2">
           {isAdo && adoAuthMode === 'delegated' && (

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.tsx
@@ -321,7 +321,8 @@ export function StepSourceControlConfig({
 
     if (
       selectedProvider.provider === 'gitea' ||
-      selectedProvider.provider === 'gitlab'
+      selectedProvider.provider === 'gitlab' ||
+      selectedProvider.provider === 'bitbucket'
     ) {
       window.location.assign(
         `/api/source-control/${selectedProvider.provider}/oauth/authorize`,

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.tsx
@@ -453,7 +453,7 @@ export function StepSourceControlConfig({
               Enter the values below for your Bitbucket integration.
             </p>
             <p className="text-sm text-muted-foreground">
-              From the app Settings → Authentication details, copy these values:
+              Once created,, copy these values:
             </p>
           </>
         ) : (

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.tsx
@@ -30,6 +30,7 @@ import {
 import { GitHubSourceControlConfig } from './GitHubSourceControlConfig';
 import { GiteaSourceControlInstructions } from './GiteaSourceControlConfig';
 import { GitLabSourceControlInstructions } from './GitLabSourceControlConfig';
+import { BitbucketSourceControlInstructions } from './BitbucketSourceControlConfig';
 import { getSourceControlSetupCopy } from './sourceControlSetupCopy';
 
 const MASKED_VALUE = '••••••••••••••••••••••••••••';
@@ -409,7 +410,8 @@ export function StepSourceControlConfig({
 
       {isAdo ||
       selectedProvider?.provider === 'gitea' ||
-      selectedProvider?.provider === 'gitlab' ? (
+      selectedProvider?.provider === 'gitlab' ||
+      selectedProvider?.provider === 'bitbucket' ? (
         <NumberedStep number={2}>
           {isAdo ? (
             <AdoSourceControlInstructions
@@ -418,8 +420,10 @@ export function StepSourceControlConfig({
             />
           ) : selectedProvider?.provider === 'gitea' ? (
             <GiteaSourceControlInstructions publicOrigin={publicOrigin} />
-          ) : (
+          ) : selectedProvider?.provider === 'gitlab' ? (
             <GitLabSourceControlInstructions publicOrigin={publicOrigin} />
+          ) : (
+            <BitbucketSourceControlInstructions publicOrigin={publicOrigin} />
           )}
         </NumberedStep>
       ) : null}
@@ -428,7 +432,8 @@ export function StepSourceControlConfig({
         number={
           isAdo ||
           selectedProvider?.provider === 'gitea' ||
-          selectedProvider?.provider === 'gitlab'
+          selectedProvider?.provider === 'gitlab' ||
+          selectedProvider?.provider === 'bitbucket'
             ? 3
             : 2
         }

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConnect.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConnect.client.test.tsx
@@ -453,6 +453,35 @@ describe('StepSourceControlConnect', () => {
     expect(syncRepositoriesMutateMock).toHaveBeenCalledOnce();
   });
 
+  it('continues after Bitbucket OAuth callback sync already connected repositories', () => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { ...window.location, pathname: '/setup', search: '?sync=1' },
+    });
+    const onContinue = vi.fn();
+
+    render(
+      <StepSourceControlConnect
+        sourceControlSetup={buildSourceControlSetup('bitbucket', {
+          lockReason: null,
+          runtimeConfiguredProvider: null,
+          runtimeConfiguredProviders: [],
+          connectedProvider: 'bitbucket',
+          providers: [
+            {
+              ...buildSourceControlSetup('bitbucket').providers[0]!,
+              connected: true,
+              repositoryCount: 1,
+            },
+          ],
+        })}
+        onContinue={onContinue}
+      />,
+    );
+
+    expect(onContinue).toHaveBeenCalledOnce();
+  });
+
   it('reports Gitea webhook setup failures as repositories', async () => {
     const onContinue = vi.fn();
 

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConnect.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConnect.tsx
@@ -57,7 +57,7 @@ function getTokenBackedConnectCopy({
     case 'gitea':
       return 'Sync your Gitea repositories so Roomote can access your codebase.';
     case 'bitbucket':
-      return 'Sync your Bitbucket repositories so Roomote can access your codebase.';
+      return 'Sync your Bitbucket Cloud repositories so Roomote can access your codebase.';
     case 'ado':
       return 'Sync your Azure DevOps repositories so Roomote can access your codebase.';
     default:

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConnect.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConnect.tsx
@@ -260,6 +260,31 @@ export function StepSourceControlConnect({
     }
   }, [handleSyncRepositories, oauthAutoSyncMarkerPresent, shouldAutoSync]);
 
+  useEffect(() => {
+    if (
+      !oauthAutoSyncMarkerPresent ||
+      !alreadyConnected ||
+      needsAdoMicrosoftConnection
+    ) {
+      return;
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    params.delete('sync');
+    const query = params.toString();
+    window.history.replaceState(
+      {},
+      '',
+      query ? `${window.location.pathname}?${query}` : window.location.pathname,
+    );
+    onContinue();
+  }, [
+    alreadyConnected,
+    needsAdoMicrosoftConnection,
+    oauthAutoSyncMarkerPresent,
+    onContinue,
+  ]);
+
   return (
     <div className="relative w-full max-w-lg space-y-6 py-2 md:py-0">
       <StepTitle text={SOURCE_CONTROL_CONNECT_STEP.title} />

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConnect.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConnect.tsx
@@ -197,6 +197,18 @@ export function StepSourceControlConnect({
         field.envVarName === 'GITEA_CLIENT_SECRET' &&
         (field.runtimeSatisfied || field.savedSatisfied),
     );
+  const bitbucketOAuthConfigured =
+    provider === 'bitbucket' &&
+    providerStatus?.fields.some(
+      (field) =>
+        field.envVarName === 'BITBUCKET_CLIENT_ID' &&
+        (field.runtimeSatisfied || field.savedSatisfied),
+    ) &&
+    providerStatus?.fields.some(
+      (field) =>
+        field.envVarName === 'BITBUCKET_CLIENT_SECRET' &&
+        (field.runtimeSatisfied || field.savedSatisfied),
+    );
 
   const oauthAutoSyncMarkerPresent =
     typeof window !== 'undefined' &&
@@ -211,6 +223,9 @@ export function StepSourceControlConnect({
       oauthAutoSyncMarkerPresent) &&
     (provider !== 'gitea' ||
       !giteaOAuthConfigured ||
+      oauthAutoSyncMarkerPresent) &&
+    (provider !== 'bitbucket' ||
+      !bitbucketOAuthConfigured ||
       oauthAutoSyncMarkerPresent);
 
   const handleSyncRepositories = useCallback(async () => {

--- a/apps/web/src/app/(onboarding)/setup/sourceControlSetupCopy.ts
+++ b/apps/web/src/app/(onboarding)/setup/sourceControlSetupCopy.ts
@@ -32,7 +32,7 @@ const SOURCE_CONTROL_SETUP_COPY: Record<
     creationHref: 'https://developer.atlassian.com/console/myapps/',
     setupLabel: 'Bitbucket OAuth consumer',
     creationHint:
-      'Create an OAuth consumer in the Atlassian developer console, set the callback URL to this deployment, and grant account, repository, pull request, and webhook read/write scopes.',
+      'Create an OAuth consumer in the Atlassian developer console. In Permissions, click Add Marketplace or custom app, add the Bitbucket API, and grant account, repository:write, pullrequest:write, and webhook scopes.',
   },
   ado: {
     creationHref: 'https://dev.azure.com/_usersSettings/tokens',

--- a/apps/web/src/app/(onboarding)/setup/sourceControlSetupCopy.ts
+++ b/apps/web/src/app/(onboarding)/setup/sourceControlSetupCopy.ts
@@ -29,10 +29,10 @@ const SOURCE_CONTROL_SETUP_COPY: Record<
       'In Gitea 1.23+, go to your org → Settings → Application → New OAuth2 app.',
   },
   bitbucket: {
-    creationHref: 'https://id.atlassian.com/manage-profile/security/api-tokens',
-    setupLabel: 'Bitbucket API token',
+    creationHref: 'https://developer.atlassian.com/console/myapps/',
+    setupLabel: 'Bitbucket OAuth consumer',
     creationHint:
-      'In Atlassian account settings, select Create API token with scopes → Bitbucket. Grant repository, pull request, and webhook read and write access, plus workspace and user read access. Use a bot or service account that can manage repository webhooks.',
+      'Create an OAuth consumer in the Atlassian developer console, set the callback URL to this deployment, and grant account, repository, pull request, and webhook read/write scopes.',
   },
   ado: {
     creationHref: 'https://dev.azure.com/_usersSettings/tokens',

--- a/apps/web/src/app/(onboarding)/setup/sourceControlSetupCopy.ts
+++ b/apps/web/src/app/(onboarding)/setup/sourceControlSetupCopy.ts
@@ -29,7 +29,6 @@ const SOURCE_CONTROL_SETUP_COPY: Record<
       'In Gitea 1.23+, go to your org → Settings → Application → New OAuth2 app.',
   },
   bitbucket: {
-    creationHref: 'https://developer.atlassian.com/console/myapps/',
     setupLabel: 'Bitbucket OAuth consumer',
   },
   ado: {

--- a/apps/web/src/app/(onboarding)/setup/sourceControlSetupCopy.ts
+++ b/apps/web/src/app/(onboarding)/setup/sourceControlSetupCopy.ts
@@ -29,7 +29,7 @@ const SOURCE_CONTROL_SETUP_COPY: Record<
       'In Gitea 1.23+, go to your org → Settings → Application → New OAuth2 app.',
   },
   bitbucket: {
-    setupLabel: 'Bitbucket OAuth consumer',
+    setupLabel: 'Bitbucket Cloud OAuth client',
   },
   ado: {
     creationHref: 'https://dev.azure.com/_usersSettings/tokens',

--- a/apps/web/src/app/(onboarding)/setup/sourceControlSetupCopy.ts
+++ b/apps/web/src/app/(onboarding)/setup/sourceControlSetupCopy.ts
@@ -31,8 +31,6 @@ const SOURCE_CONTROL_SETUP_COPY: Record<
   bitbucket: {
     creationHref: 'https://developer.atlassian.com/console/myapps/',
     setupLabel: 'Bitbucket OAuth consumer',
-    creationHint:
-      'Create an OAuth consumer in the Atlassian developer console. In Permissions, click Add Marketplace or custom app, add the Bitbucket API, and grant account, repository:write, pullrequest:write, and webhook scopes.',
   },
   ado: {
     creationHref: 'https://dev.azure.com/_usersSettings/tokens',

--- a/apps/web/src/app/api/auth/oauth2/callback/bitbucket/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/oauth2/callback/bitbucket/__tests__/route.test.ts
@@ -1,0 +1,64 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { handleDeploymentOAuthCallbackMock, handleAuthRequestMock } = vi.hoisted(
+  () => ({
+    handleDeploymentOAuthCallbackMock: vi.fn(),
+    handleAuthRequestMock: vi.fn(),
+  }),
+);
+
+vi.mock('@/app/api/source-control/bitbucket/oauth/callback/route', () => ({
+  GET: handleDeploymentOAuthCallbackMock,
+}));
+vi.mock('@/lib/server/auth', () => ({
+  handleAuthRequest: handleAuthRequestMock,
+}));
+
+import { GET } from '../route';
+
+function request(url: string, deploymentState?: string) {
+  return new NextRequest(url, {
+    headers: deploymentState
+      ? { cookie: `roomote-bitbucket-oauth-state=${deploymentState}` }
+      : undefined,
+  });
+}
+
+describe('Bitbucket OAuth callback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handleDeploymentOAuthCallbackMock.mockResolvedValue(
+      new Response('deployment'),
+    );
+    handleAuthRequestMock.mockResolvedValue(new Response('auth'));
+  });
+
+  it('dispatches deployment OAuth when its state cookie matches', async () => {
+    const result = await GET(
+      request(
+        'https://roomote.test/api/auth/oauth2/callback/bitbucket?state=deployment-state&code=code',
+        'deployment-state',
+      ),
+    );
+
+    expect(result).toBeInstanceOf(Response);
+    expect(handleDeploymentOAuthCallbackMock).toHaveBeenCalledOnce();
+    expect(handleAuthRequestMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['a different state', 'other-state', 'deployment-state'],
+    ['no deployment state cookie', 'deployment-state', undefined],
+  ])('delegates %s to Better Auth', async (_label, state, cookie) => {
+    await GET(
+      request(
+        `https://roomote.test/api/auth/oauth2/callback/bitbucket?state=${state}`,
+        cookie,
+      ),
+    );
+
+    expect(handleAuthRequestMock).toHaveBeenCalledOnce();
+    expect(handleDeploymentOAuthCallbackMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/auth/oauth2/callback/bitbucket/route.ts
+++ b/apps/web/src/app/api/auth/oauth2/callback/bitbucket/route.ts
@@ -1,0 +1,20 @@
+import { type NextRequest } from 'next/server';
+
+import { GET as handleDeploymentOAuthCallback } from '@/app/api/source-control/bitbucket/oauth/callback/route';
+import { handleAuthRequest } from '@/lib/server/auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const state = request.nextUrl.searchParams.get('state');
+  const deploymentState = request.cookies.get(
+    'roomote-bitbucket-oauth-state',
+  )?.value;
+
+  if (state && deploymentState && state === deploymentState) {
+    return handleDeploymentOAuthCallback(request);
+  }
+
+  return handleAuthRequest(request);
+}

--- a/apps/web/src/app/api/source-control/bitbucket/oauth/authorize/route.ts
+++ b/apps/web/src/app/api/source-control/bitbucket/oauth/authorize/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { resolveDeploymentEnvVar } from '@roomote/db/server';
+import {
+  buildBitbucketOAuthRedirectUri,
+  createBitbucketOAuthAuthorizationUrl,
+} from '@roomote/bitbucket';
+import { authorize } from '@/lib/server';
+import { bootstrapWebRuntimeEnv } from '@/lib/server/bootstrap-runtime-env';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const authResult = await authorize();
+  const webEnv = await bootstrapWebRuntimeEnv();
+  if (!authResult.success || !authResult.isAdmin) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  const clientId = await resolveDeploymentEnvVar('BITBUCKET_CLIENT_ID');
+  if (!clientId) {
+    return NextResponse.json(
+      { error: 'Bitbucket OAuth consumer ID is not configured.' },
+      { status: 400 },
+    );
+  }
+  const publicAppUrl = webEnv.R_PUBLIC_URL ?? webEnv.R_APP_URL;
+  const { url, state } = createBitbucketOAuthAuthorizationUrl({
+    clientId,
+    redirectUri: buildBitbucketOAuthRedirectUri(publicAppUrl),
+  });
+  const response = NextResponse.redirect(url);
+  response.cookies.set('roomote-bitbucket-oauth-state', state, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: publicAppUrl.startsWith('https://'),
+    path: '/api/source-control/bitbucket/oauth',
+    maxAge: 600,
+  });
+  return response;
+}

--- a/apps/web/src/app/api/source-control/bitbucket/oauth/authorize/route.ts
+++ b/apps/web/src/app/api/source-control/bitbucket/oauth/authorize/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { resolveDeploymentEnvVar } from '@roomote/db/server';
 import {
+  BITBUCKET_OAUTH_CALLBACK_PATH,
   buildBitbucketOAuthRedirectUri,
   createBitbucketOAuthAuthorizationUrl,
 } from '@roomote/bitbucket';
@@ -33,7 +34,7 @@ export async function GET() {
     httpOnly: true,
     sameSite: 'lax',
     secure: publicAppUrl.startsWith('https://'),
-    path: '/api/source-control/bitbucket/oauth',
+    path: BITBUCKET_OAUTH_CALLBACK_PATH,
     maxAge: 600,
   });
   return response;

--- a/apps/web/src/app/api/source-control/bitbucket/oauth/callback/route.ts
+++ b/apps/web/src/app/api/source-control/bitbucket/oauth/callback/route.ts
@@ -3,10 +3,10 @@ import { resolveDeploymentEnvVar } from '@roomote/db/server';
 import {
   buildBitbucketOAuthRedirectUri,
   exchangeBitbucketOAuthCode,
-  syncBitbucketRepositories,
 } from '@roomote/bitbucket';
 import { authorize } from '@/lib/server';
 import { bootstrapWebRuntimeEnv } from '@/lib/server/bootstrap-runtime-env';
+import { syncRepositoriesCommand } from '@/trpc/commands/source-control';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -48,7 +48,7 @@ export async function GET(request: NextRequest) {
       code,
       redirectUri: buildBitbucketOAuthRedirectUri(publicAppUrl),
     });
-    await syncBitbucketRepositories({ userId: authResult.userId });
+    await syncRepositoriesCommand(authResult, { provider: 'bitbucket' });
     redirect.searchParams.set('bitbucket', 'connected');
     redirect.searchParams.set('sync', '1');
   } catch (error) {

--- a/apps/web/src/app/api/source-control/bitbucket/oauth/callback/route.ts
+++ b/apps/web/src/app/api/source-control/bitbucket/oauth/callback/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { resolveDeploymentEnvVar } from '@roomote/db/server';
 import {
+  BITBUCKET_OAUTH_CALLBACK_PATH,
   buildBitbucketOAuthRedirectUri,
   exchangeBitbucketOAuthCode,
 } from '@roomote/bitbucket';
@@ -60,7 +61,7 @@ export async function GET(request: NextRequest) {
     httpOnly: true,
     sameSite: 'lax',
     secure: publicAppUrl.startsWith('https://'),
-    path: '/api/source-control/bitbucket/oauth',
+    path: BITBUCKET_OAUTH_CALLBACK_PATH,
     maxAge: 0,
   });
   return result;

--- a/apps/web/src/app/api/source-control/bitbucket/oauth/callback/route.ts
+++ b/apps/web/src/app/api/source-control/bitbucket/oauth/callback/route.ts
@@ -1,0 +1,67 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { resolveDeploymentEnvVar } from '@roomote/db/server';
+import {
+  buildBitbucketOAuthRedirectUri,
+  exchangeBitbucketOAuthCode,
+  syncBitbucketRepositories,
+} from '@roomote/bitbucket';
+import { authorize } from '@/lib/server';
+import { bootstrapWebRuntimeEnv } from '@/lib/server/bootstrap-runtime-env';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const webEnv = await bootstrapWebRuntimeEnv();
+  const publicAppUrl = webEnv.R_PUBLIC_URL ?? webEnv.R_APP_URL;
+  const redirect = new URL('/setup', publicAppUrl);
+  redirect.searchParams.set('step', 'source-control-connect');
+  const response = () => NextResponse.redirect(redirect);
+  const authResult = await authorize();
+  const state = request.nextUrl.searchParams.get('state');
+  const expectedState = request.cookies.get(
+    'roomote-bitbucket-oauth-state',
+  )?.value;
+  const code = request.nextUrl.searchParams.get('code');
+  if (
+    !authResult.success ||
+    !authResult.isAdmin ||
+    !state ||
+    state !== expectedState ||
+    !code
+  ) {
+    redirect.searchParams.set('bitbucket', 'error');
+    return response();
+  }
+  try {
+    const [clientId, clientSecret] = await Promise.all([
+      resolveDeploymentEnvVar('BITBUCKET_CLIENT_ID'),
+      resolveDeploymentEnvVar('BITBUCKET_CLIENT_SECRET'),
+    ]);
+    if (!clientId || !clientSecret)
+      throw new Error(
+        'Bitbucket OAuth consumer credentials are not configured.',
+      );
+    await exchangeBitbucketOAuthCode({
+      clientId,
+      clientSecret,
+      code,
+      redirectUri: buildBitbucketOAuthRedirectUri(publicAppUrl),
+    });
+    await syncBitbucketRepositories({ userId: authResult.userId });
+    redirect.searchParams.set('bitbucket', 'connected');
+    redirect.searchParams.set('sync', '1');
+  } catch (error) {
+    console.error('[Bitbucket OAuth] callback failed', error);
+    redirect.searchParams.set('bitbucket', 'error');
+  }
+  const result = response();
+  result.cookies.set('roomote-bitbucket-oauth-state', '', {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: publicAppUrl.startsWith('https://'),
+    path: '/api/source-control/bitbucket/oauth',
+    maxAge: 0,
+  });
+  return result;
+}

--- a/apps/web/src/components/settings/LinkedAccounts.test.tsx
+++ b/apps/web/src/components/settings/LinkedAccounts.test.tsx
@@ -262,11 +262,11 @@ const authClientLinkedAccountTestCases = [
     expectedLinkArgs: '/settings?service=gitea',
   },
   {
-    name: 'Bitbucket',
+    name: 'Bitbucket Cloud',
     searchParams: 'service=bitbucket',
     linkedAccount: {
       accountId: 'bb-user-1',
-      displayName: 'Bitbucket user bb-user-1',
+      displayName: 'Bitbucket Cloud user bb-user-1',
     },
     setLinkedAccount: (
       account: {

--- a/apps/web/src/components/settings/LinkedAccounts.tsx
+++ b/apps/web/src/components/settings/LinkedAccounts.tsx
@@ -547,13 +547,15 @@ export function LinkedAccounts() {
     }),
     createAuthClientLinkedAccountDescriptor({
       key: 'bitbucket',
-      name: 'Bitbucket',
-      icon: <BrandIcon icon="bitbucket" name="Bitbucket" className="size-4" />,
+      name: 'Bitbucket Cloud',
+      icon: (
+        <BrandIcon icon="bitbucket" name="Bitbucket Cloud" className="size-4" />
+      ),
       redirectTarget,
       state: bitbucketAccount.data,
       authenticateAccount: authenticateBitbucketAccount,
       unlinkAccount: unlinkBitbucketAccount,
-      fallbackDisplayName: (accountId) => `Bitbucket user ${accountId}`,
+      fallbackDisplayName: (accountId) => `Bitbucket Cloud user ${accountId}`,
     }),
     createAuthClientLinkedAccountDescriptor({
       key: 'ado',

--- a/apps/web/src/components/settings/SourceControl.test.tsx
+++ b/apps/web/src/components/settings/SourceControl.test.tsx
@@ -384,7 +384,7 @@ describe('SourceControl settings', () => {
       'href',
       'https://dev.azure.com/acme/Platform/_git/backend',
     );
-    expect(screen.getAllByText('Bitbucket')).not.toHaveLength(0);
+    expect(screen.getAllByText('Bitbucket Cloud')).not.toHaveLength(0);
     expect(
       screen.getByRole('link', { name: 'acme/bitbucket-app' }),
     ).toHaveAttribute('href', 'https://bitbucket.org/acme/bitbucket-app');
@@ -408,7 +408,7 @@ describe('SourceControl settings', () => {
       screen.getByRole('button', { name: 'Refresh Azure DevOps' }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'Refresh Bitbucket' }),
+      screen.getByRole('button', { name: 'Refresh Bitbucket Cloud' }),
     ).toBeInTheDocument();
     expect(screen.getByTestId('github-icon')).toHaveClass('shrink-0');
     expect(
@@ -520,7 +520,9 @@ describe('SourceControl settings', () => {
   it('syncs Bitbucket repositories from the source control section', () => {
     render(<SourceControl />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Refresh Bitbucket' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Refresh Bitbucket Cloud' }),
+    );
 
     expect(mutations.syncBitbucket).toHaveBeenCalledOnce();
   });

--- a/apps/web/src/components/settings/SourceControl.tsx
+++ b/apps/web/src/components/settings/SourceControl.tsx
@@ -93,7 +93,7 @@ const TOKEN_PROVIDER_UI = {
   },
   bitbucket: {
     accessibleResource: 'repositories',
-    credentialName: 'API token',
+    credentialName: 'OAuth consumer',
     repositoryTarget: '_bitbucket',
   },
   ado: {

--- a/apps/web/src/components/settings/SourceControl.tsx
+++ b/apps/web/src/components/settings/SourceControl.tsx
@@ -368,7 +368,15 @@ export function SourceControl() {
             provider={provider}
             configStatus={sourceControlConfigStatus.data}
             saveSuccessMessage={`${sourceControlProviderDescriptors[provider].label} credentials saved.`}
-            onSaved={() => tokenProviderState[provider].sync.mutate()}
+            onSaved={() => {
+              if (provider === 'bitbucket') {
+                window.location.assign(
+                  '/api/source-control/bitbucket/oauth/authorize',
+                );
+              } else {
+                tokenProviderState[provider].sync.mutate();
+              }
+            }}
           />
         ),
       }),

--- a/apps/web/src/components/settings/SourceControlConfigForm.tsx
+++ b/apps/web/src/components/settings/SourceControlConfigForm.tsx
@@ -384,10 +384,17 @@ export function SourceControlConfigForm({
               provider,
               values: {
                 ...Object.fromEntries(
-                  visibleFields.map((field) => [
-                    field.envVarName,
-                    values[field.envVarName] ?? '',
-                  ]),
+                  visibleFields.flatMap((field) => {
+                    const value = values[field.envVarName] ?? '';
+                    if (
+                      isSecretSourceControlField(field) &&
+                      field.savedSatisfied &&
+                      value.length === 0
+                    ) {
+                      return [];
+                    }
+                    return [[field.envVarName, value]];
+                  }),
                 ),
                 ...(isAdo
                   ? {

--- a/apps/web/src/hooks/linked-accounts/useAuthenticateBitbucketAccount.ts
+++ b/apps/web/src/hooks/linked-accounts/useAuthenticateBitbucketAccount.ts
@@ -3,5 +3,5 @@ import { createUseAuthenticateOAuthLinkedAccount } from './shared';
 export const useAuthenticateBitbucketAccount =
   createUseAuthenticateOAuthLinkedAccount({
     providerId: 'bitbucket',
-    providerName: 'Bitbucket',
+    providerName: 'Bitbucket Cloud',
   });

--- a/apps/web/src/hooks/linked-accounts/useUnlinkBitbucketLinkedAccount.ts
+++ b/apps/web/src/hooks/linked-accounts/useUnlinkBitbucketLinkedAccount.ts
@@ -3,6 +3,6 @@ import { createUseUnlinkOAuthLinkedAccount } from './shared';
 export const useUnlinkBitbucketLinkedAccount =
   createUseUnlinkOAuthLinkedAccount({
     providerId: 'bitbucket',
-    providerName: 'Bitbucket',
+    providerName: 'Bitbucket Cloud',
     createQueryKey: (trpc) => trpc.linkedAccounts.bitbucket.queryKey(),
   });

--- a/apps/web/src/trpc/commands/filters/index.ts
+++ b/apps/web/src/trpc/commands/filters/index.ts
@@ -58,7 +58,7 @@ function getSurfaceSubLabel(surface: TaskSurface | null): string | undefined {
     case 'gitea':
       return 'Gitea';
     case 'bitbucket':
-      return 'Bitbucket';
+      return 'Bitbucket Cloud';
     case 'ado':
       return 'Azure DevOps';
     case 'linear':

--- a/apps/web/src/trpc/commands/source-control/index.ts
+++ b/apps/web/src/trpc/commands/source-control/index.ts
@@ -414,6 +414,7 @@ async function configureBitbucketWebhooks(
     actorUserId,
     logPrefix: '[configureBitbucketWebhooks]',
     removalDescription: 'remove webhooks from unmapped repositories',
+    scopeToEnvironmentMappings: false,
   });
 }
 
@@ -746,10 +747,6 @@ export async function assertValidSourceControlConfigInput(params: {
       ? (params.values?.['GITEA_CLIENT_SECRET']?.trim() ??
         (await resolveDeploymentEnvVar('GITEA_CLIENT_SECRET')))
       : undefined;
-  const nextBitbucketToken =
-    params.provider === 'bitbucket'
-      ? params.values?.['BITBUCKET_TOKEN']?.trim()
-      : undefined;
   const nextBitbucketClientId =
     params.provider === 'bitbucket'
       ? (params.values?.['BITBUCKET_CLIENT_ID']?.trim() ??
@@ -825,36 +822,11 @@ export async function assertValidSourceControlConfigInput(params: {
     );
   }
 
-  if (nextBitbucketToken) {
-    const nextBitbucketUsername =
-      params.values?.['BITBUCKET_USERNAME']?.trim() ??
-      (await Bitbucket.resolveBitbucketUsername());
-
-    if (!nextBitbucketUsername) {
-      throw new Error(
-        'BITBUCKET_USERNAME is required with BITBUCKET_TOKEN. Set it to the Atlassian account email that owns the API token.',
-      );
-    }
-
-    const validation = await Bitbucket.validateBitbucketToken({
-      token: nextBitbucketToken,
-      username: nextBitbucketUsername,
-      baseUrl: params.values?.['BITBUCKET_BASE_URL']?.trim() || undefined,
-    });
-
-    if (validation.status === 'invalid') {
-      throw new Error(validation.error);
-    }
-  }
-
   if (
     params.provider === 'bitbucket' &&
-    !(nextBitbucketClientId && nextBitbucketClientSecret) &&
-    !nextBitbucketToken
+    !(nextBitbucketClientId && nextBitbucketClientSecret)
   ) {
-    throw new Error(
-      'Configure the Bitbucket OAuth consumer ID and secret, or provide the legacy API token and username.',
-    );
+    throw new Error('Configure the Bitbucket OAuth consumer ID and secret.');
   }
 
   if (nextAdoToken) {

--- a/apps/web/src/trpc/commands/source-control/index.ts
+++ b/apps/web/src/trpc/commands/source-control/index.ts
@@ -680,6 +680,17 @@ export async function saveSourceControlConfigValues(params: {
     );
   }
 
+  if (params.provider === 'bitbucket') {
+    // Bitbucket deployments used to store API-token credentials under these
+    // names. OAuth is now the only supported deployment credential, so remove
+    // stale values even when the current OAuth client values come from runtime
+    // environment variables rather than this save request.
+    await deleteDeploymentEnvironmentVariables(params.executor, [
+      'BITBUCKET_TOKEN',
+      'BITBUCKET_USERNAME',
+    ]);
+  }
+
   if (valuesToSave.length > 0) {
     if (params.provider === 'ado') {
       const authMode =

--- a/apps/web/src/trpc/commands/source-control/index.ts
+++ b/apps/web/src/trpc/commands/source-control/index.ts
@@ -750,6 +750,16 @@ export async function assertValidSourceControlConfigInput(params: {
     params.provider === 'bitbucket'
       ? params.values?.['BITBUCKET_TOKEN']?.trim()
       : undefined;
+  const nextBitbucketClientId =
+    params.provider === 'bitbucket'
+      ? (params.values?.['BITBUCKET_CLIENT_ID']?.trim() ??
+        (await resolveDeploymentEnvVar('BITBUCKET_CLIENT_ID')))
+      : undefined;
+  const nextBitbucketClientSecret =
+    params.provider === 'bitbucket'
+      ? (params.values?.['BITBUCKET_CLIENT_SECRET']?.trim() ??
+        (await resolveDeploymentEnvVar('BITBUCKET_CLIENT_SECRET')))
+      : undefined;
   const nextAdoToken =
     params.provider === 'ado'
       ? (params.values?.['ADO_TOKEN']?.trim() ??
@@ -835,6 +845,16 @@ export async function assertValidSourceControlConfigInput(params: {
     if (validation.status === 'invalid') {
       throw new Error(validation.error);
     }
+  }
+
+  if (
+    params.provider === 'bitbucket' &&
+    !(nextBitbucketClientId && nextBitbucketClientSecret) &&
+    !nextBitbucketToken
+  ) {
+    throw new Error(
+      'Configure the Bitbucket OAuth consumer ID and secret, or provide the legacy API token and username.',
+    );
   }
 
   if (nextAdoToken) {

--- a/apps/web/src/trpc/commands/source-control/index.ts
+++ b/apps/web/src/trpc/commands/source-control/index.ts
@@ -760,13 +760,13 @@ export async function assertValidSourceControlConfigInput(params: {
       : undefined;
   const nextBitbucketClientId =
     params.provider === 'bitbucket'
-      ? (params.values?.['BITBUCKET_CLIENT_ID']?.trim() ??
-        (await resolveDeploymentEnvVar('BITBUCKET_CLIENT_ID')))
+      ? params.values?.['BITBUCKET_CLIENT_ID']?.trim() ||
+        (await resolveDeploymentEnvVar('BITBUCKET_CLIENT_ID'))
       : undefined;
   const nextBitbucketClientSecret =
     params.provider === 'bitbucket'
-      ? (params.values?.['BITBUCKET_CLIENT_SECRET']?.trim() ??
-        (await resolveDeploymentEnvVar('BITBUCKET_CLIENT_SECRET')))
+      ? params.values?.['BITBUCKET_CLIENT_SECRET']?.trim() ||
+        (await resolveDeploymentEnvVar('BITBUCKET_CLIENT_SECRET'))
       : undefined;
   const nextAdoToken =
     params.provider === 'ado'

--- a/apps/worker/tsup.config.ts
+++ b/apps/worker/tsup.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
   platform: 'node',
   banner: {
     // Add CJS require support for bundled CJS packages.
-    js: `import { createRequire } from 'module';const require = createRequire(import.meta.url);`,
+    js: `import { createRequire as __createRequire } from 'module';const require = __createRequire(import.meta.url);`,
   },
   esbuildOptions(options) {
     // Exclude native modules that cannot be bundled into a single JS file.

--- a/packages/bitbucket/package.json
+++ b/packages/bitbucket/package.json
@@ -3,7 +3,10 @@
   "version": "0.0.3",
   "private": true,
   "type": "module",
-  "exports": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./constants": "./src/constants.ts"
+  },
   "scripts": {
     "format": "oxfmt \"**/*.{js,jsx,ts,tsx,json,css}\"",
     "format:check": "oxfmt --check \"**/*.{js,jsx,ts,tsx,json,css}\"",

--- a/packages/bitbucket/src/__tests__/api.test.ts
+++ b/packages/bitbucket/src/__tests__/api.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
-  BITBUCKET_API_TOKEN_GIT_USERNAME,
   buildBitbucketApiBaseUrl,
   buildBitbucketRepositoryValues,
-  getBitbucketGitUsername,
   listBitbucketRepositories,
   normalizeBitbucketLinkedAccountKey,
 } from '../api';
@@ -103,18 +101,6 @@ describe('buildBitbucketRepositoryValues', () => {
       linkedByUserId: 'user-1',
     });
     expect(values.cloneUrl).toBe('https://bitbucket.org/acme/roomote.git');
-  });
-});
-
-describe('getBitbucketGitUsername', () => {
-  it('substitutes the static API-token git user when the identity is an Atlassian account email', () => {
-    expect(getBitbucketGitUsername('bot@example.com')).toBe(
-      BITBUCKET_API_TOKEN_GIT_USERNAME,
-    );
-  });
-
-  it('keeps a non-email identity unchanged', () => {
-    expect(getBitbucketGitUsername('roomote-bot')).toBe('roomote-bot');
   });
 });
 

--- a/packages/bitbucket/src/__tests__/oauth.test.ts
+++ b/packages/bitbucket/src/__tests__/oauth.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildBitbucketOAuthRedirectUri,
+  createBitbucketOAuthAuthorizationUrl,
+  getBitbucketOAuthScopes,
+} from '../oauth';
+
+describe('Bitbucket deployment OAuth', () => {
+  it('builds the Bitbucket authorization URL with Roomote scopes', () => {
+    const result = createBitbucketOAuthAuthorizationUrl({
+      clientId: 'consumer-id',
+      redirectUri: buildBitbucketOAuthRedirectUri('https://roomote.test'),
+      state: 'csrf-state',
+    });
+    const url = new URL(result.url);
+
+    expect(url.origin).toBe('https://bitbucket.org');
+    expect(url.pathname).toBe('/site/oauth2/authorize');
+    expect(url.searchParams.get('client_id')).toBe('consumer-id');
+    expect(url.searchParams.get('state')).toBe('csrf-state');
+    expect(url.searchParams.get('scope')).toBe(
+      getBitbucketOAuthScopes().join(' '),
+    );
+  });
+});

--- a/packages/bitbucket/src/__tests__/oauth.test.ts
+++ b/packages/bitbucket/src/__tests__/oauth.test.ts
@@ -1,12 +1,19 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  BITBUCKET_OAUTH_CALLBACK_PATH,
   buildBitbucketOAuthRedirectUri,
   createBitbucketOAuthAuthorizationUrl,
   getBitbucketOAuthScopes,
 } from '../oauth';
 
 describe('Bitbucket deployment OAuth', () => {
+  it('uses the shared Better Auth callback path', () => {
+    expect(buildBitbucketOAuthRedirectUri('https://roomote.test/')).toBe(
+      `https://roomote.test${BITBUCKET_OAUTH_CALLBACK_PATH}`,
+    );
+  });
+
   it('builds the Bitbucket authorization URL with Roomote scopes', () => {
     const result = createBitbucketOAuthAuthorizationUrl({
       clientId: 'consumer-id',

--- a/packages/bitbucket/src/api.ts
+++ b/packages/bitbucket/src/api.ts
@@ -15,6 +15,10 @@ import {
   inArray,
   resolveDeploymentEnvVar,
 } from '@roomote/db/server';
+import {
+  getBitbucketOAuthConnection,
+  resolveBitbucketOAuthAccessToken,
+} from './oauth';
 
 const BITBUCKET_PROVIDER = 'bitbucket' satisfies SourceControlProvider;
 const DEFAULT_BITBUCKET_BASE_URL = 'https://bitbucket.org';
@@ -127,6 +131,7 @@ export type BitbucketRepositoryCredential = {
   username: string;
   token: string;
   originBaseUrl: string;
+  authScheme: 'basic';
 };
 
 export type BitbucketRepositoryValues = {
@@ -260,7 +265,16 @@ export function normalizeBitbucketLinkedAccountKey(value: string): string {
 }
 
 export async function resolveBitbucketToken(): Promise<string | null> {
-  return resolveDeploymentEnvVar('BITBUCKET_TOKEN');
+  const connection = await getBitbucketOAuthConnection();
+  if (connection?.status === 'reauthorization_required') {
+    throw new Error(
+      'Bitbucket OAuth authorization requires reconnection. Reconnect the Bitbucket OAuth consumer in source-control settings.',
+    );
+  }
+  return (
+    (await resolveBitbucketOAuthAccessToken()) ??
+    resolveDeploymentEnvVar('BITBUCKET_TOKEN')
+  );
 }
 
 export async function resolveBitbucketBaseUrl(): Promise<string> {
@@ -271,7 +285,53 @@ export async function resolveBitbucketBaseUrl(): Promise<string> {
 }
 
 export async function resolveBitbucketUsername(): Promise<string | null> {
-  return resolveDeploymentEnvVar('BITBUCKET_USERNAME');
+  return (await getBitbucketOAuthConnection())?.status === 'active'
+    ? (await getBitbucketOAuthConnection())?.username || 'x-token-auth'
+    : resolveDeploymentEnvVar('BITBUCKET_USERNAME');
+}
+
+export type BitbucketAuthDescriptor = {
+  token: string;
+  username: string;
+  baseUrl: string;
+  apiBaseUrl: string;
+  authScheme: 'basic' | 'bearer';
+};
+
+export async function resolveBitbucketAuth(): Promise<BitbucketAuthDescriptor> {
+  const connection = await getBitbucketOAuthConnection();
+  if (connection?.status === 'reauthorization_required') {
+    throw new Error(
+      'Bitbucket OAuth authorization requires reconnection. Reconnect the Bitbucket OAuth consumer in source-control settings.',
+    );
+  }
+  const token = await resolveBitbucketOAuthAccessToken();
+  if (token && connection) {
+    const baseUrl = await resolveBitbucketBaseUrl();
+    return {
+      token,
+      username: connection.username || 'x-token-auth',
+      baseUrl,
+      apiBaseUrl: buildBitbucketApiBaseUrl(baseUrl),
+      authScheme: 'bearer',
+    };
+  }
+  const legacyToken = await resolveDeploymentEnvVar('BITBUCKET_TOKEN');
+  const username = await resolveDeploymentEnvVar('BITBUCKET_USERNAME');
+  if (!legacyToken?.trim())
+    throw new Error(
+      'Bitbucket source-control credentials are not configured. Connect a Bitbucket OAuth consumer or configure BITBUCKET_TOKEN and BITBUCKET_USERNAME.',
+    );
+  if (!username?.trim())
+    throw new Error('BITBUCKET_USERNAME is required with BITBUCKET_TOKEN.');
+  const baseUrl = await resolveBitbucketBaseUrl();
+  return {
+    token: legacyToken,
+    username: username.trim(),
+    baseUrl,
+    apiBaseUrl: buildBitbucketApiBaseUrl(baseUrl),
+    authScheme: 'basic',
+  };
 }
 
 let cachedBitbucketDeploymentUser: {
@@ -305,6 +365,7 @@ async function requestBitbucketJson<T>({
   params = {},
   username,
   token,
+  authScheme,
   body,
   schema,
   absoluteUrl,
@@ -314,8 +375,9 @@ async function requestBitbucketJson<T>({
   method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
   path?: string;
   params?: Record<string, string | number | boolean>;
-  username: string;
+  username?: string;
   token: string;
+  authScheme?: 'basic' | 'bearer';
   body?: Record<string, unknown>;
   schema: z.ZodType<T>;
   absoluteUrl?: string;
@@ -326,7 +388,10 @@ async function requestBitbucketJson<T>({
       method,
       headers: {
         Accept: 'application/json',
-        Authorization: buildAuthorizationHeader(username, token),
+        Authorization:
+          (authScheme ?? 'basic') === 'bearer'
+            ? `Bearer ${token}`
+            : buildAuthorizationHeader(username ?? '', token),
         ...(body ? { 'Content-Type': 'application/json' } : {}),
       },
       ...(body ? { body: JSON.stringify(body) } : {}),
@@ -369,12 +434,9 @@ async function resolveAuthIdentity({
   baseUrl?: string;
   apiBaseUrl?: string;
   fetchImpl?: typeof fetch;
-}): Promise<{
-  token: string;
-  username: string;
-  baseUrl: string;
-  apiBaseUrl: string;
-}> {
+}): Promise<BitbucketAuthDescriptor> {
+  if (!token && !username && !baseUrl && !apiBaseUrl)
+    return resolveBitbucketAuth();
   const resolvedToken = token ?? (await resolveBitbucketToken());
 
   if (!resolvedToken?.trim()) {
@@ -389,12 +451,20 @@ async function resolveAuthIdentity({
   const configuredUsername =
     username ?? (await resolveBitbucketUsername()) ?? undefined;
 
-  if (configuredUsername?.trim()) {
+  const oauthConnection = await getBitbucketOAuthConnection();
+  const authScheme =
+    oauthConnection?.accessToken === resolvedToken ? 'bearer' : 'basic';
+
+  if (authScheme === 'bearer' || configuredUsername?.trim()) {
     return {
       token: resolvedToken,
-      username: configuredUsername.trim(),
+      username:
+        configuredUsername?.trim() ??
+        oauthConnection?.username ??
+        'x-token-auth',
       baseUrl: resolvedBaseUrl,
       apiBaseUrl: resolvedApiBaseUrl,
+      authScheme,
     };
   }
 
@@ -433,6 +503,7 @@ export async function getBitbucketAuthenticatedUser({
     path: '/user',
     username: auth.username,
     token: auth.token,
+    authScheme: auth.authScheme,
     schema: bitbucketUserSchema,
   });
 
@@ -530,6 +601,7 @@ export async function listBitbucketRepositories({
       fetchImpl,
       username: auth.username,
       token: auth.token,
+      authScheme: auth.authScheme,
       schema: bitbucketPaginatedWorkspaceMembershipsSchema,
       absoluteUrl: workspacesUrl,
     });
@@ -563,6 +635,7 @@ export async function listBitbucketRepositories({
           fetchImpl,
           username: auth.username,
           token: auth.token,
+          authScheme: auth.authScheme,
           schema: bitbucketPaginatedRepositoriesSchema,
           absoluteUrl: nextUrl,
         });
@@ -941,6 +1014,7 @@ async function findBitbucketRepositoryWebhookByUrl({
   webhookUrl,
   username,
   token,
+  authScheme,
   apiBaseUrl,
   fetchImpl,
 }: {
@@ -950,6 +1024,7 @@ async function findBitbucketRepositoryWebhookByUrl({
   username: string;
   token: string;
   apiBaseUrl: string;
+  authScheme?: 'basic' | 'bearer';
   fetchImpl?: typeof fetch;
 }): Promise<z.infer<typeof bitbucketHookSchema> | undefined> {
   let nextUrl: string | null = buildBitbucketApiUrl(
@@ -967,6 +1042,7 @@ async function findBitbucketRepositoryWebhookByUrl({
         fetchImpl,
         username,
         token,
+        authScheme,
         schema: bitbucketPaginatedHooksSchema,
         absoluteUrl: nextUrl,
       });
@@ -992,6 +1068,7 @@ async function ensureBitbucketRepositoryWebhook({
   username,
   token,
   apiBaseUrl,
+  authScheme,
   fetchImpl,
 }: {
   repositoryFullName: string;
@@ -1000,6 +1077,7 @@ async function ensureBitbucketRepositoryWebhook({
   username: string;
   token: string;
   apiBaseUrl: string;
+  authScheme?: 'basic' | 'bearer';
   fetchImpl?: typeof fetch;
 }): Promise<'created' | 'updated'> {
   const { workspace, repo } =
@@ -1010,6 +1088,7 @@ async function ensureBitbucketRepositoryWebhook({
     webhookUrl,
     username,
     token,
+    authScheme,
     apiBaseUrl,
     fetchImpl,
   });
@@ -1031,6 +1110,7 @@ async function ensureBitbucketRepositoryWebhook({
       )}/hooks`,
       username,
       token,
+      authScheme,
       body,
       schema: bitbucketHookSchema,
     });
@@ -1047,6 +1127,7 @@ async function ensureBitbucketRepositoryWebhook({
     )}/hooks/${encodeURIComponent(existingHook.uuid)}`,
     username,
     token,
+    authScheme,
     body,
     schema: bitbucketHookSchema,
   });
@@ -1102,6 +1183,7 @@ export async function ensureBitbucketWebhooksForRepositories({
               secretToken,
               username: auth.username,
               token: auth.token,
+              authScheme: auth.authScheme,
               apiBaseUrl: auth.apiBaseUrl,
               fetchImpl,
             })
@@ -1128,6 +1210,7 @@ async function removeBitbucketRepositoryWebhook({
   username,
   token,
   apiBaseUrl,
+  authScheme,
   fetchImpl = fetch,
 }: {
   repositoryFullName: string;
@@ -1135,6 +1218,7 @@ async function removeBitbucketRepositoryWebhook({
   username: string;
   token: string;
   apiBaseUrl: string;
+  authScheme?: 'basic' | 'bearer';
   fetchImpl?: typeof fetch;
 }): Promise<'removed' | 'not_found'> {
   const { workspace, repo } =
@@ -1145,6 +1229,7 @@ async function removeBitbucketRepositoryWebhook({
     webhookUrl,
     username,
     token,
+    authScheme,
     apiBaseUrl,
     fetchImpl,
   });
@@ -1162,6 +1247,7 @@ async function removeBitbucketRepositoryWebhook({
     )}/hooks/${encodeURIComponent(existingHook.uuid)}`,
     username,
     token,
+    authScheme,
     schema: z.undefined(),
   });
 
@@ -1258,9 +1344,13 @@ export async function createTaskRunBitbucketCredentials(
     credentials: repositoriesList.map((repository) => ({
       host,
       repositoryFullName: repository.fullName,
-      username: getBitbucketGitUsername(auth.username),
+      username:
+        auth.authScheme === 'bearer'
+          ? 'x-token-auth'
+          : getBitbucketGitUsername(auth.username),
       token: auth.token,
       originBaseUrl: auth.baseUrl,
+      authScheme: 'basic',
     })),
   };
 }

--- a/packages/bitbucket/src/api.ts
+++ b/packages/bitbucket/src/api.ts
@@ -24,7 +24,6 @@ const BITBUCKET_PROVIDER = 'bitbucket' satisfies SourceControlProvider;
 const DEFAULT_BITBUCKET_BASE_URL = 'https://bitbucket.org';
 const BITBUCKET_REPOSITORIES_PER_PAGE = 50;
 const BITBUCKET_WEBHOOK_ENSURE_CONCURRENCY = 5;
-const BITBUCKET_TOKEN_VALIDATION_TIMEOUT_MS = 10_000;
 
 const BITBUCKET_WEBHOOK_EVENTS = [
   'pullrequest:created',
@@ -184,11 +183,6 @@ export class BitbucketApiError extends Error {
   }
 }
 
-export type BitbucketTokenValidationResult =
-  | { status: 'valid'; login: string }
-  | { status: 'invalid'; error: string }
-  | { status: 'unknown'; error: string };
-
 function normalizeBaseUrl(baseUrl: string): string {
   const trimmed = baseUrl.trim().replace(/\/+$/, '');
 
@@ -218,18 +212,6 @@ export function buildBitbucketApiBaseUrl(baseUrl: string): string {
 
 function buildAuthorizationHeader(username: string, token: string): string {
   return `Basic ${Buffer.from(`${username}:${token}`).toString('base64')}`;
-}
-
-/**
- * Static username Bitbucket Cloud accepts for git-over-HTTPS when the secret
- * is an Atlassian API token. API tokens pair with the Atlassian account email
- * for REST calls, but git rejects the email form, so git credentials must use
- * this documented static user instead.
- */
-export const BITBUCKET_API_TOKEN_GIT_USERNAME = 'x-bitbucket-api-token-auth';
-
-export function getBitbucketGitUsername(username: string): string {
-  return username.includes('@') ? BITBUCKET_API_TOKEN_GIT_USERNAME : username;
 }
 
 function stripUuidBraces(value: string): string {
@@ -271,10 +253,7 @@ export async function resolveBitbucketToken(): Promise<string | null> {
       'Bitbucket OAuth authorization requires reconnection. Reconnect the Bitbucket OAuth consumer in source-control settings.',
     );
   }
-  return (
-    (await resolveBitbucketOAuthAccessToken()) ??
-    resolveDeploymentEnvVar('BITBUCKET_TOKEN')
-  );
+  return resolveBitbucketOAuthAccessToken();
 }
 
 export async function resolveBitbucketBaseUrl(): Promise<string> {
@@ -287,7 +266,7 @@ export async function resolveBitbucketBaseUrl(): Promise<string> {
 export async function resolveBitbucketUsername(): Promise<string | null> {
   return (await getBitbucketOAuthConnection())?.status === 'active'
     ? (await getBitbucketOAuthConnection())?.username || 'x-token-auth'
-    : resolveDeploymentEnvVar('BITBUCKET_USERNAME');
+    : null;
 }
 
 export type BitbucketAuthDescriptor = {
@@ -316,22 +295,9 @@ export async function resolveBitbucketAuth(): Promise<BitbucketAuthDescriptor> {
       authScheme: 'bearer',
     };
   }
-  const legacyToken = await resolveDeploymentEnvVar('BITBUCKET_TOKEN');
-  const username = await resolveDeploymentEnvVar('BITBUCKET_USERNAME');
-  if (!legacyToken?.trim())
-    throw new Error(
-      'Bitbucket source-control credentials are not configured. Connect a Bitbucket OAuth consumer or configure BITBUCKET_TOKEN and BITBUCKET_USERNAME.',
-    );
-  if (!username?.trim())
-    throw new Error('BITBUCKET_USERNAME is required with BITBUCKET_TOKEN.');
-  const baseUrl = await resolveBitbucketBaseUrl();
-  return {
-    token: legacyToken,
-    username: username.trim(),
-    baseUrl,
-    apiBaseUrl: buildBitbucketApiBaseUrl(baseUrl),
-    authScheme: 'basic',
-  };
+  throw new Error(
+    'Bitbucket OAuth authorization is required. Connect the Bitbucket OAuth consumer in source-control settings.',
+  );
 }
 
 let cachedBitbucketDeploymentUser: {
@@ -439,11 +405,10 @@ async function resolveAuthIdentity({
     return resolveBitbucketAuth();
   const resolvedToken = token ?? (await resolveBitbucketToken());
 
-  if (!resolvedToken?.trim()) {
+  if (!resolvedToken?.trim())
     throw new Error(
-      'BITBUCKET_TOKEN is required for Bitbucket source control.',
+      'Bitbucket OAuth authorization is required for Bitbucket source control.',
     );
-  }
 
   const resolvedBaseUrl = baseUrl ?? (await resolveBitbucketBaseUrl());
   const resolvedApiBaseUrl =
@@ -468,11 +433,8 @@ async function resolveAuthIdentity({
     };
   }
 
-  // Bitbucket Cloud REST auth pairs the API token with the Atlassian account
-  // email. There is no discovery endpoint that works without it, so the value
-  // must be configured up front.
   throw new Error(
-    'BITBUCKET_USERNAME is required with BITBUCKET_TOKEN. Set it to the Atlassian account email that owns the API token.',
+    'Bitbucket OAuth authorization is required for source-control API requests.',
   );
 }
 
@@ -512,55 +474,6 @@ export async function getBitbucketAuthenticatedUser({
     accountId: getBitbucketAccountKey(data),
     uuid: data.uuid ? stripUuidBraces(data.uuid) : null,
   };
-}
-
-export async function validateBitbucketToken({
-  token,
-  username,
-  baseUrl,
-  apiBaseUrl,
-  fetchImpl = fetch,
-  timeoutMs = BITBUCKET_TOKEN_VALIDATION_TIMEOUT_MS,
-}: {
-  token: string;
-  username?: string;
-  baseUrl?: string;
-  apiBaseUrl?: string;
-  fetchImpl?: typeof fetch;
-  timeoutMs?: number;
-}): Promise<BitbucketTokenValidationResult> {
-  const timedFetch: typeof fetch = (input, init) =>
-    fetchImpl(input, { ...init, signal: AbortSignal.timeout(timeoutMs) });
-
-  try {
-    const { login } = await getBitbucketAuthenticatedUser({
-      token,
-      username,
-      baseUrl,
-      apiBaseUrl,
-      fetchImpl: timedFetch,
-    });
-
-    return { status: 'valid', login };
-  } catch (error) {
-    if (
-      error instanceof BitbucketApiError &&
-      [401, 403].includes(error.status)
-    ) {
-      return {
-        status: 'invalid',
-        error:
-          'Bitbucket rejected the credentials. Confirm the API token is active, is paired with the Atlassian account email that owns it, and includes the read:user:bitbucket scope alongside repository access.',
-      };
-    }
-
-    return {
-      status: 'unknown',
-      error: `Could not verify the Bitbucket token: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    };
-  }
 }
 
 export async function listBitbucketRepositories({
@@ -1344,10 +1257,7 @@ export async function createTaskRunBitbucketCredentials(
     credentials: repositoriesList.map((repository) => ({
       host,
       repositoryFullName: repository.fullName,
-      username:
-        auth.authScheme === 'bearer'
-          ? 'x-token-auth'
-          : getBitbucketGitUsername(auth.username),
+      username: 'x-token-auth',
       token: auth.token,
       originBaseUrl: auth.baseUrl,
       authScheme: 'basic',

--- a/packages/bitbucket/src/api.ts
+++ b/packages/bitbucket/src/api.ts
@@ -910,6 +910,7 @@ export async function createBitbucketPullRequestComment({
     )}/pullrequests/${pullRequestNumber}/comments`,
     username: auth.username,
     token: auth.token,
+    authScheme: auth.authScheme,
     body: {
       content: {
         raw: body,
@@ -1212,6 +1213,7 @@ export async function removeBitbucketWebhooksForRepositories({
               webhookUrl,
               username: auth.username,
               token: auth.token,
+              authScheme: auth.authScheme,
               apiBaseUrl: auth.apiBaseUrl,
               fetchImpl,
             })

--- a/packages/bitbucket/src/constants.ts
+++ b/packages/bitbucket/src/constants.ts
@@ -1,0 +1,2 @@
+export const BITBUCKET_OAUTH_CALLBACK_PATH =
+  '/api/auth/oauth2/callback/bitbucket';

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -1,1 +1,2 @@
 export * from './api';
+export * from './oauth';

--- a/packages/bitbucket/src/oauth.ts
+++ b/packages/bitbucket/src/oauth.ts
@@ -3,9 +3,11 @@ import { randomBytes } from 'node:crypto';
 import { db, deploymentSecrets, sql } from '@roomote/db/server';
 import { decryptSecrets, encryptJSON } from '@roomote/db/encryption';
 
+import { BITBUCKET_OAUTH_CALLBACK_PATH } from './constants';
+
+export { BITBUCKET_OAUTH_CALLBACK_PATH };
+
 const SECRET_NAME = 'bitbucket_deployment_oauth_connection';
-export const BITBUCKET_OAUTH_CALLBACK_PATH =
-  '/api/auth/oauth2/callback/bitbucket';
 const DEFAULT_SCOPES = [
   'account',
   'repository',

--- a/packages/bitbucket/src/oauth.ts
+++ b/packages/bitbucket/src/oauth.ts
@@ -4,6 +4,8 @@ import { db, deploymentSecrets, sql } from '@roomote/db/server';
 import { decryptSecrets, encryptJSON } from '@roomote/db/encryption';
 
 const SECRET_NAME = 'bitbucket_deployment_oauth_connection';
+export const BITBUCKET_OAUTH_CALLBACK_PATH =
+  '/api/auth/oauth2/callback/bitbucket';
 const DEFAULT_SCOPES = [
   'account',
   'repository',
@@ -44,7 +46,7 @@ export function getBitbucketOAuthScopes(): readonly string[] {
 
 export function buildBitbucketOAuthRedirectUri(appUrl: string): string {
   return new URL(
-    '/api/source-control/bitbucket/oauth/callback',
+    BITBUCKET_OAUTH_CALLBACK_PATH,
     `${appUrl.replace(/\/$/, '')}/`,
   ).toString();
 }

--- a/packages/bitbucket/src/oauth.ts
+++ b/packages/bitbucket/src/oauth.ts
@@ -176,6 +176,7 @@ export async function resolveBitbucketOAuthAccessToken(options?: {
   }
   if (refreshPromise) return refreshPromise;
   refreshPromise = (async () => {
+    let requiresReauthorization = false;
     try {
       const response = await (options?.fetchImpl ?? fetch)(
         'https://bitbucket.org/site/oauth2/access_token',
@@ -193,6 +194,7 @@ export async function resolveBitbucketOAuthAccessToken(options?: {
         },
       );
       if (!response.ok) {
+        requiresReauthorization = [400, 401, 403].includes(response.status);
         throw new Error(
           `Bitbucket OAuth refresh failed: ${response.status} ${response.statusText}`,
         );
@@ -214,13 +216,15 @@ export async function resolveBitbucketOAuthAccessToken(options?: {
       await writeConnection(next);
       return next.accessToken;
     } catch (error) {
-      try {
-        await writeConnection({
-          ...connection,
-          status: 'reauthorization_required',
-        });
-      } catch {
-        // Preserve the original refresh error when persistence is unavailable.
+      if (requiresReauthorization) {
+        try {
+          await writeConnection({
+            ...connection,
+            status: 'reauthorization_required',
+          });
+        } catch {
+          // Preserve the original refresh error when persistence is unavailable.
+        }
       }
       throw error;
     }

--- a/packages/bitbucket/src/oauth.ts
+++ b/packages/bitbucket/src/oauth.ts
@@ -176,46 +176,54 @@ export async function resolveBitbucketOAuthAccessToken(options?: {
   }
   if (refreshPromise) return refreshPromise;
   refreshPromise = (async () => {
-    const response = await (options?.fetchImpl ?? fetch)(
-      'https://bitbucket.org/site/oauth2/access_token',
-      {
-        method: 'POST',
-        headers: {
-          Accept: 'application/json',
-          Authorization: `Basic ${Buffer.from(`${connection.clientId}:${connection.clientSecret}`).toString('base64')}`,
-          'Content-Type': 'application/x-www-form-urlencoded',
+    try {
+      const response = await (options?.fetchImpl ?? fetch)(
+        'https://bitbucket.org/site/oauth2/access_token',
+        {
+          method: 'POST',
+          headers: {
+            Accept: 'application/json',
+            Authorization: `Basic ${Buffer.from(`${connection.clientId}:${connection.clientSecret}`).toString('base64')}`,
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+          body: new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: connection.refreshToken,
+          }),
         },
-        body: new URLSearchParams({
-          grant_type: 'refresh_token',
-          refresh_token: connection.refreshToken,
-        }),
-      },
-    );
-    if (!response.ok) {
-      await writeConnection({
+      );
+      if (!response.ok) {
+        throw new Error(
+          `Bitbucket OAuth refresh failed: ${response.status} ${response.statusText}`,
+        );
+      }
+      const token = (await response.json()) as BitbucketOAuthTokenResponse;
+      if (!token.access_token)
+        throw new Error(
+          'Bitbucket OAuth refresh did not return an access token.',
+        );
+      const next = {
         ...connection,
-        status: 'reauthorization_required',
-      });
-      throw new Error(
-        'Bitbucket OAuth authorization has expired. Reconnect the Bitbucket OAuth consumer.',
-      );
+        accessToken: token.access_token,
+        refreshToken: token.refresh_token ?? connection.refreshToken,
+        expiresAt: new Date(
+          Date.now() + (token.expires_in ?? 3600) * 1000,
+        ).toISOString(),
+        status: 'active' as const,
+      };
+      await writeConnection(next);
+      return next.accessToken;
+    } catch (error) {
+      try {
+        await writeConnection({
+          ...connection,
+          status: 'reauthorization_required',
+        });
+      } catch {
+        // Preserve the original refresh error when persistence is unavailable.
+      }
+      throw error;
     }
-    const token = (await response.json()) as BitbucketOAuthTokenResponse;
-    if (!token.access_token)
-      throw new Error(
-        'Bitbucket OAuth refresh did not return an access token.',
-      );
-    const next = {
-      ...connection,
-      accessToken: token.access_token,
-      refreshToken: token.refresh_token ?? connection.refreshToken,
-      expiresAt: new Date(
-        Date.now() + (token.expires_in ?? 3600) * 1000,
-      ).toISOString(),
-      status: 'active' as const,
-    };
-    await writeConnection(next);
-    return next.accessToken;
   })();
   try {
     return await refreshPromise;

--- a/packages/bitbucket/src/oauth.ts
+++ b/packages/bitbucket/src/oauth.ts
@@ -1,0 +1,234 @@
+import { randomBytes } from 'node:crypto';
+
+import { db, deploymentSecrets, sql } from '@roomote/db/server';
+import { decryptSecrets, encryptJSON } from '@roomote/db/encryption';
+
+const SECRET_NAME = 'bitbucket_deployment_oauth_connection';
+const DEFAULT_SCOPES = [
+  'account',
+  'repository',
+  'repository:write',
+  'pullrequest',
+  'pullrequest:write',
+  'webhook',
+] as const;
+
+export type BitbucketOAuthConnectionStatus =
+  | 'active'
+  | 'reauthorization_required';
+
+export type BitbucketOAuthConnection = {
+  clientId: string;
+  clientSecret: string;
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: string;
+  accountId: string;
+  username: string;
+  scopes: string[];
+  status: BitbucketOAuthConnectionStatus;
+};
+
+type BitbucketOAuthTokenResponse = {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  scopes?: string;
+};
+
+let refreshPromise: Promise<string> | null = null;
+
+export function getBitbucketOAuthScopes(): readonly string[] {
+  return DEFAULT_SCOPES;
+}
+
+export function buildBitbucketOAuthRedirectUri(appUrl: string): string {
+  return new URL(
+    '/api/source-control/bitbucket/oauth/callback',
+    `${appUrl.replace(/\/$/, '')}/`,
+  ).toString();
+}
+
+export function createBitbucketOAuthAuthorizationUrl(input: {
+  clientId: string;
+  redirectUri: string;
+  state?: string;
+}): { url: string; state: string } {
+  const state = input.state ?? randomBytes(32).toString('hex');
+  const url = new URL('https://bitbucket.org/site/oauth2/authorize');
+  url.searchParams.set('client_id', input.clientId);
+  url.searchParams.set('redirect_uri', input.redirectUri);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('state', state);
+  url.searchParams.set('scope', DEFAULT_SCOPES.join(' '));
+  return { url: url.toString(), state };
+}
+
+async function readConnection(): Promise<BitbucketOAuthConnection | null> {
+  try {
+    const rows = await db.execute<{ value: string }>(sql`
+      SELECT value FROM deployment_secrets
+      WHERE name = ${SECRET_NAME} LIMIT 1
+    `);
+    return rows[0]
+      ? await decryptSecrets<BitbucketOAuthConnection>(rows[0].value)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeConnection(connection: BitbucketOAuthConnection) {
+  const value = encryptJSON(connection);
+  await db
+    .insert(deploymentSecrets)
+    .values({ name: SECRET_NAME, value })
+    .onConflictDoUpdate({
+      target: deploymentSecrets.name,
+      set: { value, updatedAt: new Date() },
+    });
+}
+
+export async function getBitbucketOAuthConnection() {
+  return readConnection();
+}
+
+export async function exchangeBitbucketOAuthCode(input: {
+  clientId: string;
+  clientSecret: string;
+  code: string;
+  redirectUri: string;
+  fetchImpl?: typeof fetch;
+}): Promise<BitbucketOAuthConnection> {
+  const response = await (input.fetchImpl ?? fetch)(
+    'https://bitbucket.org/site/oauth2/access_token',
+    {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Basic ${Buffer.from(`${input.clientId}:${input.clientSecret}`).toString('base64')}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        code: input.code,
+        grant_type: 'authorization_code',
+        redirect_uri: input.redirectUri,
+      }),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Bitbucket OAuth token exchange failed: ${response.status} ${response.statusText}`,
+    );
+  }
+  const token = (await response.json()) as BitbucketOAuthTokenResponse;
+  if (!token.access_token || !token.refresh_token) {
+    throw new Error(
+      'Bitbucket OAuth did not return an access and refresh token.',
+    );
+  }
+
+  const connection: BitbucketOAuthConnection = {
+    clientId: input.clientId,
+    clientSecret: input.clientSecret,
+    accessToken: token.access_token,
+    refreshToken: token.refresh_token,
+    expiresAt: new Date(
+      Date.now() + (token.expires_in ?? 3600) * 1000,
+    ).toISOString(),
+    accountId: '',
+    username: '',
+    scopes: token.scopes?.split(/\s+/).filter(Boolean) ?? [...DEFAULT_SCOPES],
+    status: 'active',
+  };
+  try {
+    const identity = await (input.fetchImpl ?? fetch)(
+      'https://api.bitbucket.org/2.0/user',
+      { headers: { Authorization: `Bearer ${connection.accessToken}` } },
+    );
+    if (identity.ok) {
+      const user = (await identity.json()) as {
+        account_id?: string;
+        username?: string;
+        nickname?: string;
+      };
+      connection.accountId = user.account_id ?? '';
+      connection.username = user.username ?? user.nickname ?? '';
+    }
+  } catch {
+    // The token exchange remains valid if the identity lookup is temporarily unavailable.
+  }
+  await writeConnection(connection);
+  return connection;
+}
+
+export async function resolveBitbucketOAuthAccessToken(options?: {
+  fetchImpl?: typeof fetch;
+  forceRefresh?: boolean;
+}): Promise<string | null> {
+  const connection = await readConnection();
+  if (!connection || connection.status !== 'active') return null;
+  if (
+    !options?.forceRefresh &&
+    Date.parse(connection.expiresAt) > Date.now() + 60_000
+  ) {
+    return connection.accessToken;
+  }
+  if (refreshPromise) return refreshPromise;
+  refreshPromise = (async () => {
+    const response = await (options?.fetchImpl ?? fetch)(
+      'https://bitbucket.org/site/oauth2/access_token',
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          Authorization: `Basic ${Buffer.from(`${connection.clientId}:${connection.clientSecret}`).toString('base64')}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+          grant_type: 'refresh_token',
+          refresh_token: connection.refreshToken,
+        }),
+      },
+    );
+    if (!response.ok) {
+      await writeConnection({
+        ...connection,
+        status: 'reauthorization_required',
+      });
+      throw new Error(
+        'Bitbucket OAuth authorization has expired. Reconnect the Bitbucket OAuth consumer.',
+      );
+    }
+    const token = (await response.json()) as BitbucketOAuthTokenResponse;
+    if (!token.access_token)
+      throw new Error(
+        'Bitbucket OAuth refresh did not return an access token.',
+      );
+    const next = {
+      ...connection,
+      accessToken: token.access_token,
+      refreshToken: token.refresh_token ?? connection.refreshToken,
+      expiresAt: new Date(
+        Date.now() + (token.expires_in ?? 3600) * 1000,
+      ).toISOString(),
+      status: 'active' as const,
+    };
+    await writeConnection(next);
+    return next.accessToken;
+  })();
+  try {
+    return await refreshPromise;
+  } finally {
+    refreshPromise = null;
+  }
+}
+
+export async function markBitbucketOAuthReauthorizationRequired() {
+  const connection = await readConnection();
+  if (connection)
+    await writeConnection({
+      ...connection,
+      status: 'reauthorization_required',
+    });
+}

--- a/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-reads.test.ts
+++ b/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-reads.test.ts
@@ -51,7 +51,7 @@ vi.mock('@roomote/bitbucket', () => ({
     username: 'bb-bot',
     baseUrl: 'https://bitbucket.org',
     apiBaseUrl: 'https://api.bitbucket.org/2.0',
-    authScheme: 'basic',
+    authScheme: 'bearer',
   }),
   buildBitbucketApiBaseUrl: () => 'https://api.bitbucket.org/2.0',
 }));
@@ -1014,6 +1014,15 @@ describe('readSourceControlPullRequestForTaskRun', () => {
     }
 
     expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer bitbucket-token',
+        }),
+      }),
+    );
     expect(
       result.pullRequests.map((pullRequest) => pullRequest.number),
     ).toEqual([3, 2]);

--- a/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-reads.test.ts
+++ b/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-reads.test.ts
@@ -46,6 +46,13 @@ vi.mock('@roomote/gitlab', () => ({
 }));
 
 vi.mock('@roomote/bitbucket', () => ({
+  resolveBitbucketAuth: async () => ({
+    token: 'bitbucket-token',
+    username: 'bb-bot',
+    baseUrl: 'https://bitbucket.org',
+    apiBaseUrl: 'https://api.bitbucket.org/2.0',
+    authScheme: 'basic',
+  }),
   resolveBitbucketToken: async () => 'bitbucket-token',
   resolveBitbucketUsername: async () => 'bb-bot',
   resolveBitbucketBaseUrl: async () => 'https://bitbucket.org',

--- a/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-reads.test.ts
+++ b/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-reads.test.ts
@@ -53,9 +53,6 @@ vi.mock('@roomote/bitbucket', () => ({
     apiBaseUrl: 'https://api.bitbucket.org/2.0',
     authScheme: 'basic',
   }),
-  resolveBitbucketToken: async () => 'bitbucket-token',
-  resolveBitbucketUsername: async () => 'bb-bot',
-  resolveBitbucketBaseUrl: async () => 'https://bitbucket.org',
   buildBitbucketApiBaseUrl: () => 'https://api.bitbucket.org/2.0',
 }));
 

--- a/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-provider-context.ts
+++ b/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-provider-context.ts
@@ -5,9 +5,7 @@ import {
 } from '@roomote/ado';
 import {
   buildBitbucketApiBaseUrl,
-  resolveBitbucketBaseUrl,
-  resolveBitbucketToken,
-  resolveBitbucketUsername,
+  resolveBitbucketAuth,
 } from '@roomote/bitbucket';
 import {
   buildGiteaApiBaseUrl,
@@ -103,21 +101,11 @@ export async function resolveBitbucketProviderContext(
   workspace: string;
   repo: string;
 }> {
-  const token = await resolveBitbucketToken();
-  if (!token) {
-    throw new Error(
-      `BITBUCKET_TOKEN is required to ${purposeVerb(purpose)} Bitbucket pull requests.`,
-    );
-  }
-
-  const username = await resolveBitbucketUsername();
-  if (!username) {
-    throw new Error(
-      `BITBUCKET_USERNAME is required to ${purposeVerb(purpose)} Bitbucket pull requests.`,
-    );
-  }
-
-  const baseUrl = await resolveBitbucketBaseUrl();
+  // Keep the shared purpose parameter for the provider-context contract; the
+  // OAuth resolver owns the credential error text now.
+  void purpose;
+  const auth = await resolveBitbucketAuth();
+  const { baseUrl, token } = auth;
   const [workspace, repo] = splitRepositoryFullName(
     repository.fullName,
     'bitbucket',
@@ -125,7 +113,10 @@ export async function resolveBitbucketProviderContext(
 
   return {
     apiBaseUrl: buildBitbucketApiBaseUrl(baseUrl),
-    authHeader: `Basic ${Buffer.from(`${username}:${token}`, 'utf8').toString('base64')}`,
+    authHeader:
+      auth.authScheme === 'bearer'
+        ? `Bearer ${token}`
+        : `Basic ${Buffer.from(`${auth.username}:${token}`, 'utf8').toString('base64')}`,
     baseUrl,
     workspace,
     repo,

--- a/packages/sdk/src/server/lib/task-runs/dequeue-helpers.ts
+++ b/packages/sdk/src/server/lib/task-runs/dequeue-helpers.ts
@@ -85,7 +85,7 @@ export function redactSourceControlProviderEnvVars(
       : sourceControlProvider === 'gitea'
         ? ['GITEA_TOKEN']
         : sourceControlProvider === 'bitbucket'
-          ? ['BITBUCKET_TOKEN']
+          ? []
           : sourceControlProvider === 'ado'
             ? ['ADO_TOKEN']
             : [];
@@ -390,7 +390,7 @@ async function createProviderToken(
       return {
         provider,
         token: '',
-        envVar: 'BITBUCKET_TOKEN',
+        envVar: 'BITBUCKET_OAUTH',
         envVars: {},
         gitProxyCredentials: credentials.credentials.map((credential) => ({
           ...credential,

--- a/packages/types/src/setup-source-control-config.test.ts
+++ b/packages/types/src/setup-source-control-config.test.ts
@@ -478,7 +478,7 @@ describe('getSetupSourceControlVisibleFields', () => {
   it.each([
     ['gitlab', ['GITLAB_BASE_URL', 'GITLAB_CLIENT_ID', 'GITLAB_CLIENT_SECRET']],
     ['gitea', ['GITEA_BASE_URL', 'GITEA_CLIENT_ID', 'GITEA_CLIENT_SECRET']],
-    ['bitbucket', ['BITBUCKET_TOKEN', 'BITBUCKET_USERNAME']],
+    ['bitbucket', ['BITBUCKET_CLIENT_ID', 'BITBUCKET_CLIENT_SECRET']],
   ] as const)(
     'keeps %s setup focused on required connection values',
     (provider, expected) => {

--- a/packages/types/src/setup-source-control-config.ts
+++ b/packages/types/src/setup-source-control-config.ts
@@ -378,21 +378,6 @@ function buildProviderFields(
     case 'bitbucket':
       return [
         {
-          envVarName: 'BITBUCKET_TOKEN',
-          acceptedEnvVarNames: ['BITBUCKET_TOKEN'],
-          label: 'Bitbucket API Token',
-          secret: true,
-          required: false,
-          advanced: true,
-        },
-        {
-          envVarName: 'BITBUCKET_USERNAME',
-          acceptedEnvVarNames: ['BITBUCKET_USERNAME'],
-          label: 'Atlassian Account Email',
-          required: false,
-          advanced: true,
-        },
-        {
           envVarName: 'BITBUCKET_BASE_URL',
           acceptedEnvVarNames: ['BITBUCKET_BASE_URL'],
           label: 'Bitbucket Base URL',
@@ -403,7 +388,7 @@ function buildProviderFields(
           envVarName: 'BITBUCKET_CLIENT_ID',
           acceptedEnvVarNames: ['BITBUCKET_CLIENT_ID'],
           label: 'Bitbucket OAuth Client ID',
-          required: false,
+          required: true,
         },
         {
           envVarName: 'BITBUCKET_CLIENT_SECRET',

--- a/packages/types/src/setup-source-control-config.ts
+++ b/packages/types/src/setup-source-control-config.ts
@@ -387,13 +387,13 @@ function buildProviderFields(
         {
           envVarName: 'BITBUCKET_CLIENT_ID',
           acceptedEnvVarNames: ['BITBUCKET_CLIENT_ID'],
-          label: 'Bitbucket OAuth Client ID',
+          label: 'Client ID',
           required: true,
         },
         {
           envVarName: 'BITBUCKET_CLIENT_SECRET',
           acceptedEnvVarNames: ['BITBUCKET_CLIENT_SECRET'],
-          label: 'Bitbucket OAuth Client Secret',
+          label: 'Client Secret',
           secret: true,
           required: true,
         },

--- a/packages/types/src/setup-source-control-config.ts
+++ b/packages/types/src/setup-source-control-config.ts
@@ -382,11 +382,15 @@ function buildProviderFields(
           acceptedEnvVarNames: ['BITBUCKET_TOKEN'],
           label: 'Bitbucket API Token',
           secret: true,
+          required: false,
+          advanced: true,
         },
         {
           envVarName: 'BITBUCKET_USERNAME',
           acceptedEnvVarNames: ['BITBUCKET_USERNAME'],
           label: 'Atlassian Account Email',
+          required: false,
+          advanced: true,
         },
         {
           envVarName: 'BITBUCKET_BASE_URL',
@@ -400,15 +404,13 @@ function buildProviderFields(
           acceptedEnvVarNames: ['BITBUCKET_CLIENT_ID'],
           label: 'Bitbucket OAuth Client ID',
           required: false,
-          setupHidden: true,
         },
         {
           envVarName: 'BITBUCKET_CLIENT_SECRET',
           acceptedEnvVarNames: ['BITBUCKET_CLIENT_SECRET'],
           label: 'Bitbucket OAuth Client Secret',
           secret: true,
-          required: false,
-          setupHidden: true,
+          required: true,
         },
         {
           envVarName: 'BITBUCKET_WEBHOOK_SECRET',

--- a/packages/types/src/source-control.ts
+++ b/packages/types/src/source-control.ts
@@ -22,7 +22,7 @@ export type SourceControlTokenEnvVar =
   | 'GITLAB_TOKEN'
   | 'GITEA_TOKEN'
   | 'ADO_TOKEN'
-  | 'BITBUCKET_TOKEN';
+  | 'BITBUCKET_OAUTH';
 
 export type SourceControlGitCredential = {
   host: string;
@@ -94,7 +94,7 @@ export const sourceControlProviderDescriptors = {
     provider: 'bitbucket',
     label: 'Bitbucket',
     defaultHost: 'bitbucket.org',
-    tokenEnvVar: 'BITBUCKET_TOKEN',
+    tokenEnvVar: 'BITBUCKET_OAUTH',
     connectionMode: 'token',
   },
 } as const satisfies Record<

--- a/packages/types/src/source-control.ts
+++ b/packages/types/src/source-control.ts
@@ -92,7 +92,7 @@ export const sourceControlProviderDescriptors = {
   },
   bitbucket: {
     provider: 'bitbucket',
-    label: 'Bitbucket',
+    label: 'Bitbucket Cloud',
     defaultHost: 'bitbucket.org',
     tokenEnvVar: 'BITBUCKET_OAUTH',
     connectionMode: 'token',


### PR DESCRIPTION
## Summary
- add deployment-scoped Bitbucket OAuth with token refresh and encrypted connection storage
- use OAuth for repository sync, webhooks, pull request operations, and worker Git credentials
- improve Bitbucket setup instructions with required permissions and callback URL guidance

## Validation
- focused Bitbucket onboarding tests
- web typecheck
- pre-push lint, typecheck, and knip checks