### PR TITLE
[Feat] Apply provider-recommended model defaults in setup and settings

### DIFF
--- a/.changeset/provider-recommended-model-defaults.md
+++ b/.changeset/provider-recommended-model-defaults.md
@@ -1,0 +1,5 @@
+---
+"@roomote/web": minor
+---
+
+Inference providers now carry recommended per-role model defaults (helper, vision, code review, explore, planning). Connecting a provider in the setup wizard applies its recommended defaults automatically, and a "Use recommended" action on the Default Models card in Settings > Models re-applies them at any time.

--- a/.changeset/provider-recommended-model-defaults.md
+++ b/.changeset/provider-recommended-model-defaults.md
@@ -2,4 +2,4 @@
 "@roomote/web": minor
 ---
 
-Inference providers now carry recommended per-role model defaults (helper, vision, code review, explore, planning). Connecting a provider in the setup wizard applies its recommended defaults automatically, and a "Use recommended" action on the Default Models card in Settings > Models re-applies them at any time. Google Vertex AI now defaults to Claude models (Sonnet 5 coding, Haiku 4.5 helper/explore, Opus 4.8 review/planning). Requesty is no longer offered for new connections; existing Requesty connections keep working.
+Inference providers now carry recommended per-role model defaults (helper, vision, code review, explore, planning). Connecting a provider in the setup wizard applies its recommended defaults automatically, and a "Use recommended" action on the Default Models card in Settings > Models re-applies them at any time. Google Vertex AI now defaults to Claude models (Sonnet 5 coding, Haiku 4.5 helper/explore, Opus 4.8 review/planning), and Google Gemini defaults to Gemini 3.1 Pro for coding with Flash for helper/explore. Requesty is no longer offered for new connections; existing Requesty connections keep working.

--- a/.changeset/provider-recommended-model-defaults.md
+++ b/.changeset/provider-recommended-model-defaults.md
@@ -2,4 +2,4 @@
 "@roomote/web": minor
 ---
 
-Inference providers now carry recommended per-role model defaults (helper, vision, code review, explore, planning). Connecting a provider in the setup wizard applies its recommended defaults automatically, and a "Use recommended" action on the Default Models card in Settings > Models re-applies them at any time.
+Inference providers now carry recommended per-role model defaults (helper, vision, code review, explore, planning). Connecting a provider in the setup wizard applies its recommended defaults automatically, and a "Use recommended" action on the Default Models card in Settings > Models re-applies them at any time. Google Vertex AI now defaults to Claude models (Sonnet 5 coding, Haiku 4.5 helper/explore, Opus 4.8 review/planning). Requesty is no longer offered for new connections; existing Requesty connections keep working.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ cleans up after itself.
    your account directly. No API key needed, no separate billing. Roomote uses
    the models included in your subscription.
 2. **API keys (BYOK).** Paste a key from OpenRouter, Anthropic, OpenAI, xAI,
-   Google Gemini, Amazon Bedrock, Google Vertex AI, Vercel AI Gateway, Requesty,
+   Google Gemini, Amazon Bedrock, Google Vertex AI, Vercel AI Gateway,
    Baseten, Together AI, Moonshot AI (Kimi), MiniMax, or OpenCode Zen / Go.
 
 **Sandbox compute:** Modal, E2B, Daytona, Blaxel, and Local Docker.
@@ -238,7 +238,7 @@ it runs.
 **What models does it support?**
 Two options. Connect your ChatGPT Plus or Pro subscription directly (no API key
 needed), or paste an API key from OpenRouter, Anthropic, OpenAI, xAI, Google
-Gemini, Amazon Bedrock, Google Vertex AI, Vercel AI Gateway, Requesty, Baseten,
+Gemini, Amazon Bedrock, Google Vertex AI, Vercel AI Gateway, Baseten,
 Together AI, Moonshot AI (Kimi), MiniMax, or OpenCode Zen / Go.
 
 **What sandboxes does it support?**

--- a/apps/docs/models.mdx
+++ b/apps/docs/models.mdx
@@ -46,6 +46,22 @@ not enabled appear toggled off, and they cannot be deleted while their
 provider stays connected — turn a model off to stop using it. To go beyond the
 recommended set, add any model by its slug from the add-model field.
 
+### Recommended default models
+
+Providers also carry recommended defaults for the model roles below — for
+example a strong model for planning and code review and a fast, low-cost model
+for helper and explore work. Connecting a provider in the setup wizard applies
+its recommended defaults automatically, so a fresh deployment starts with a
+sensible split instead of one model for everything.
+
+From **Settings > Models**, the **Use recommended** button on the Default
+Models card re-applies a connected provider's recommended defaults at any
+time. It is an apply-once action, not a lock: it sets the role selections (and
+enables any recommended models that are missing), and you can adjust every
+role afterward. Roles a provider has no specific recommendation for are set to
+**Same as coding model**, and roles managed by environment variables are left
+untouched.
+
 ## Env-based setup
 
 Most deployments should configure providers from **Settings > Models**. Use

--- a/apps/docs/models.mdx
+++ b/apps/docs/models.mdx
@@ -15,7 +15,7 @@ Configure models from **Settings > Models**.
 ## Inference providers
 
 An inference provider is the service that hosts or routes model calls. Roomote
-supports providers such as OpenRouter, Vercel AI Gateway, Requesty, Baseten,
+supports providers such as OpenRouter, Vercel AI Gateway, Baseten,
 Together AI, OpenAI, Anthropic, Moonshot AI, MiniMax, OpenCode, Amazon Bedrock,
 Google Vertex AI, Google Gemini, xAI, and ChatGPT subscriptions.
 

--- a/apps/web/src/app/(onboarding)/setup/StepInferenceProvider.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepInferenceProvider.client.test.tsx
@@ -258,6 +258,36 @@ describe('StepInferenceProvider ChatGPT subscription', () => {
     setupQueryMocks({ chatgptConnected: false });
   });
 
+  it('renders provider credential help below the API key field', () => {
+    render(
+      <StepInferenceProvider
+        modelSetup={buildModelSetup({
+          providers: [
+            {
+              ...openrouterProviderStatus(),
+              credentialHelp: {
+                text: 'Enable Claude in Model Garden first.',
+                href: 'https://example.com/model-garden',
+                linkLabel: 'Open Model Garden',
+              },
+            },
+            chatgptProviderStatus(false),
+          ],
+        })}
+        onContinue={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText('Enable Claude in Model Garden first.', {
+        exact: false,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Open Model Garden' }),
+    ).toHaveAttribute('href', 'https://example.com/model-garden');
+  });
+
   it('renders the ChatGPT connect UI instead of an API key field', () => {
     render(
       <StepInferenceProvider

--- a/apps/web/src/app/(onboarding)/setup/StepInferenceProvider.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepInferenceProvider.tsx
@@ -5,7 +5,6 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import {
   CHATGPT_SUBSCRIPTION_PROVIDER_ID,
-  SETUP_MODEL_PROVIDER_CATALOG,
   type SetupModelProviderId,
   type SetupModelStatus,
 } from '@roomote/types';
@@ -146,12 +145,14 @@ export function StepInferenceProvider({
   const primaryCredentialLabel =
     selectedProviderStatus?.envVarLabel ?? 'API key';
   const additionalEnvFields = selectedProviderStatus?.additionalEnvFields ?? [];
-  const sortedModelProviderCatalog = useMemo(
+  // The server status list already excludes hidden providers that are not
+  // connected, so the picker only offers providers that can be selected.
+  const sortedModelProviders = useMemo(
     () =>
-      [...SETUP_MODEL_PROVIDER_CATALOG].sort((left, right) =>
+      [...modelSetup.providers].sort((left, right) =>
         left.label.localeCompare(right.label),
       ),
-    [],
+    [modelSetup.providers],
   );
   const shouldShowSavedValueMask =
     !hasRuntimeProviderKey &&
@@ -202,7 +203,7 @@ export function StepInferenceProvider({
             <SelectValue placeholder="Choose a provider" />
           </SelectTrigger>
           <SelectContent>
-            {sortedModelProviderCatalog.map((provider) => (
+            {sortedModelProviders.map((provider) => (
               <SelectItem key={provider.id} value={provider.id}>
                 {provider.label}
               </SelectItem>

--- a/apps/web/src/app/(onboarding)/setup/StepInferenceProvider.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepInferenceProvider.tsx
@@ -239,6 +239,21 @@ export function StepInferenceProvider({
         {(hasRuntimeProviderKey || hasSavedProviderKey) && <Check />}
       </div>
 
+      {selectedProviderStatus?.credentialHelp && !hasRuntimeProviderKey ? (
+        <p className="max-w-lg text-xs text-muted-foreground">
+          {selectedProviderStatus.credentialHelp.text}{' '}
+          <a
+            className="font-medium underline underline-offset-2 hover:text-foreground"
+            href={selectedProviderStatus.credentialHelp.href}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {selectedProviderStatus.credentialHelp.linkLabel}
+          </a>
+          .
+        </p>
+      ) : null}
+
       {isChatGptProvider && !hasRuntimeProviderKey ? (
         <div className="flex max-w-lg items-center gap-3">
           {chatgptConnected ? (

--- a/apps/web/src/components/settings/ModelSettingsSection.test.tsx
+++ b/apps/web/src/components/settings/ModelSettingsSection.test.tsx
@@ -88,16 +88,22 @@ vi.mock('@/components/settings', () => ({
   Section: ({
     children,
     title,
+    action,
   }: {
     children: React.ReactNode;
     title?: string;
+    action?: React.ReactNode;
   }) => (
-    <section data-testid={`section-${title ?? 'untitled'}`}>{children}</section>
+    <section data-testid={`section-${title ?? 'untitled'}`}>
+      {action}
+      {children}
+    </section>
   ),
 }));
 
 import type {
   ReasoningEffort,
+  RecommendedRoleModels,
   SetupModelProviderId,
   TaskModelMetadata,
 } from '@roomote/types';
@@ -248,6 +254,7 @@ function buildProviderSetupData(
       string,
       Array<{ id: string; displayName: string }>
     >;
+    recommendedRoleModelsByProvider?: Record<string, RecommendedRoleModels>;
   } = {},
 ) {
   const connectedProviderIds = overrides.connectedProviderIds ?? [
@@ -256,6 +263,8 @@ function buildProviderSetupData(
   ];
   const suggestedTaskModelsByProvider =
     overrides.suggestedTaskModelsByProvider ?? {};
+  const recommendedRoleModelsByProvider =
+    overrides.recommendedRoleModelsByProvider ?? {};
   const buildProvider = (
     id: SetupModelProviderId,
     label: string,
@@ -267,6 +276,7 @@ function buildProviderSetupData(
     defaultRoomoteModel: `${id}/default-model`,
     authKind: 'api-key' as const,
     suggestedTaskModels: suggestedTaskModelsByProvider[id] ?? [],
+    recommendedRoleModels: recommendedRoleModelsByProvider[id],
     runtimeApiKeySatisfied: false,
     savedApiKeySatisfied: connectedProviderIds.includes(id),
     additionalEnvValues: {},
@@ -324,6 +334,9 @@ describe('ModelSettingsSection', () => {
     refreshMutateAsyncMock.mockReset();
     settingsData.current = null;
     providerSetupData.current = buildProviderSetupData();
+    // cmdk scrolls the highlighted command item into view; jsdom does not
+    // implement scrollIntoView.
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
 
     lookupMutateAsyncMock.mockResolvedValue({
       modelId: 'anthropic/claude-sonnet-4',
@@ -697,6 +710,139 @@ describe('ModelSettingsSection', () => {
     expect(
       screen.getByRole('button', { name: 'Delete GLM 5.2' }),
     ).toBeInTheDocument();
+  });
+
+  it('applies the recommended defaults for a single connected provider from the header action', async () => {
+    settingsData.current = buildSettingsData();
+    providerSetupData.current = buildProviderSetupData({
+      connectedProviderIds: ['anthropic'],
+      suggestedTaskModelsByProvider: {
+        anthropic: [
+          {
+            id: 'anthropic/claude-haiku-4-5',
+            displayName: 'Claude Haiku 4.5',
+          },
+          { id: 'anthropic/claude-opus-4-8', displayName: 'Claude Opus 4.8' },
+        ],
+      },
+      recommendedRoleModelsByProvider: {
+        anthropic: {
+          helper: 'anthropic/claude-haiku-4-5',
+          codeReview: 'anthropic/claude-opus-4-8',
+          explore: 'anthropic/claude-haiku-4-5',
+          planning: 'anthropic/claude-opus-4-8',
+        },
+      },
+    });
+
+    renderModelSettingsSection();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use recommended' }));
+
+    await waitFor(() => {
+      expect(updateMutateAsyncMock).toHaveBeenCalledTimes(1);
+    });
+
+    // The macro resets every role to the provider's recommendation (coding =
+    // provider default; vision is unset, so "Same as coding model")...
+    expect(updateMutateAsyncMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultModelId: 'anthropic/default-model',
+        helperModelId: 'anthropic/claude-haiku-4-5',
+        visionModelId: null,
+        codeReviewModelId: 'anthropic/claude-opus-4-8',
+        exploreModelId: 'anthropic/claude-haiku-4-5',
+        planningModelId: 'anthropic/claude-opus-4-8',
+      }),
+    );
+
+    // ...and adds + enables any recommended models missing from the list.
+    const payload = updateMutateAsyncMock.mock.calls[0]![0] as {
+      models: Array<{ id: string }>;
+      allowedModelIds: string[];
+    };
+    const recommendedModelIds = [
+      'anthropic/default-model',
+      'anthropic/claude-haiku-4-5',
+      'anthropic/claude-opus-4-8',
+    ];
+    expect(payload.models.map((model) => model.id)).toEqual(
+      expect.arrayContaining(recommendedModelIds),
+    );
+    expect(payload.allowedModelIds).toEqual(
+      expect.arrayContaining(recommendedModelIds),
+    );
+  });
+
+  it('offers a provider picker for recommended defaults when several providers are connected', async () => {
+    settingsData.current = buildSettingsData();
+    providerSetupData.current = buildProviderSetupData({
+      recommendedRoleModelsByProvider: {
+        openrouter: {
+          helper: 'openrouter/z-ai/glm-5.2',
+        },
+      },
+    });
+
+    renderModelSettingsSection();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use recommended' }));
+    fireEvent.click(await screen.findByRole('option', { name: 'OpenRouter' }));
+
+    await waitFor(() => {
+      expect(updateMutateAsyncMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(updateMutateAsyncMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultModelId: 'openrouter/default-model',
+        helperModelId: 'openrouter/z-ai/glm-5.2',
+        visionModelId: null,
+        codeReviewModelId: null,
+        exploreModelId: null,
+        planningModelId: null,
+      }),
+    );
+  });
+
+  it('leaves env-managed roles untouched when applying recommended defaults', async () => {
+    settingsData.current = buildSettingsData({
+      helperManagedByEnv: true,
+      helperEffectiveModelId: 'openrouter/openai/gpt-5.4-mini',
+    });
+    providerSetupData.current = buildProviderSetupData({
+      connectedProviderIds: ['anthropic'],
+      suggestedTaskModelsByProvider: {
+        anthropic: [
+          {
+            id: 'anthropic/claude-haiku-4-5',
+            displayName: 'Claude Haiku 4.5',
+          },
+        ],
+      },
+      recommendedRoleModelsByProvider: {
+        anthropic: {
+          helper: 'anthropic/claude-haiku-4-5',
+        },
+      },
+    });
+
+    renderModelSettingsSection();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use recommended' }));
+
+    await waitFor(() => {
+      expect(updateMutateAsyncMock).toHaveBeenCalledTimes(1);
+    });
+
+    // The helper model is env-managed, so the macro keeps the persisted
+    // helper selection (null) instead of the recommendation.
+    expect(updateMutateAsyncMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultModelId: 'anthropic/default-model',
+        helperModelId: null,
+      }),
+    );
   });
 
   it('composes openai/ model ids when the ChatGPT provider is selected', async () => {

--- a/apps/web/src/components/settings/ModelSettingsSection.tsx
+++ b/apps/web/src/components/settings/ModelSettingsSection.tsx
@@ -56,6 +56,7 @@ import {
   DEFAULT_MODEL_ROLE_REASONING_EFFORTS,
   REASONING_EFFORT_OPTIONS,
   SETUP_MODEL_PROVIDER_CATALOG,
+  buildRecommendedDeploymentModelConfig,
   getModelProviderLabel,
   getSetupModelProvider,
   getTaskModelProviderId,
@@ -66,6 +67,7 @@ import type {
   SetupModelProviderId,
   SetupModelProviderStatus,
   TaskModelMetadata,
+  TaskModelRole,
 } from '@roomote/types';
 
 type EditableTaskModel = {
@@ -80,8 +82,6 @@ type EditableRuntimeModelOption = {
   displayName: string;
   family?: string;
 };
-
-type TaskModelRole = keyof typeof DEFAULT_MODEL_ROLE_REASONING_EFFORTS;
 
 type TaskModelRoleDraft = {
   modelId: string | null;
@@ -380,6 +380,73 @@ function TaskModelRoleEditor({
         </div>
       </div>
     </div>
+  );
+}
+
+/**
+ * The "Use recommended" header action for the Default Models section. With a
+ * single connected provider it applies that provider's recommended defaults
+ * directly; with several it opens a picker so the operator chooses whose
+ * recommendations to apply.
+ */
+function UseRecommendedDefaultsAction({
+  providers,
+  onApply,
+}: {
+  providers: SetupModelProviderStatus[];
+  onApply: (provider: SetupModelProviderStatus) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [onlyProvider] = providers;
+
+  if (providers.length === 0) {
+    return null;
+  }
+
+  if (providers.length === 1 && onlyProvider) {
+    return (
+      <BasicTooltip
+        content={`Reset the default models to the recommended ${onlyProvider.label} defaults.`}
+      >
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onApply(onlyProvider)}
+        >
+          Use recommended
+        </Button>
+      </BasicTooltip>
+    );
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm">
+          Use recommended
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-64 p-0">
+        <Command>
+          <CommandList>
+            <CommandGroup heading="Apply recommended defaults from">
+              {providers.map((provider) => (
+                <CommandItem
+                  key={provider.id}
+                  value={provider.label}
+                  onSelect={() => {
+                    setOpen(false);
+                    onApply(provider);
+                  }}
+                >
+                  {provider.label}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -1453,6 +1520,84 @@ export function ModelSettingsSection({
     toast.success('Task model removed.');
   };
 
+  // "Use recommended" is an apply-once macro: it resets the default-model
+  // roles to the provider's recommended defaults (adding and enabling any
+  // recommended models that are missing) through the normal draft/save flow.
+  const applyRecommendedDefaults = (provider: SetupModelProviderStatus) => {
+    const recommended = buildRecommendedDeploymentModelConfig(provider);
+    const recommendedRoleModelIds: Record<TaskModelRole, string | null> = {
+      coding: recommended.roomoteModel,
+      helper: recommended.roomoteSmallModel,
+      vision: recommended.roomoteVisionModel,
+      codeReview: recommended.roomoteCodeReviewModel,
+      explore: recommended.roomoteExploreModel,
+      planning: recommended.roomotePlanningModel,
+    };
+    const suggestionsById = new Map(
+      provider.suggestedTaskModels.map((suggestion) => [
+        suggestion.id,
+        suggestion,
+      ]),
+    );
+    const nextModels = [...models];
+    const nextEnabledModelIds = [...enabledModelIds];
+
+    for (const modelId of Object.values(recommendedRoleModelIds)) {
+      if (!modelId) {
+        continue;
+      }
+
+      if (!nextModels.some((model) => model.id === modelId)) {
+        const suggestion = suggestionsById.get(modelId);
+        nextModels.push({
+          id: modelId,
+          displayName:
+            suggestion?.displayName || (modelId.split('/').at(-1) ?? modelId),
+          family: suggestion?.family,
+          metadata: null,
+        });
+      }
+
+      if (!nextEnabledModelIds.includes(modelId)) {
+        nextEnabledModelIds.push(modelId);
+      }
+    }
+
+    const nextRoles = cloneTaskModelRoleDrafts(roleDrafts);
+
+    for (const role of TASK_MODEL_ROLE_ORDER) {
+      const status =
+        settingsData?.runtimeModels[TASK_MODEL_ROLE_RUNTIME_KEYS[role]];
+
+      // Env-managed selections are not editable from the UI, so the macro
+      // leaves them untouched.
+      if (status?.managedByEnv) {
+        continue;
+      }
+
+      nextRoles[role] = {
+        modelId:
+          role === 'coding'
+            ? (recommendedRoleModelIds.coding ?? roleDrafts.coding.modelId)
+            : recommendedRoleModelIds[role],
+        reasoningEffort: status?.reasoningManagedByEnv
+          ? roleDrafts[role].reasoningEffort
+          : null,
+      };
+    }
+
+    suppressNextSaveSuccessToast();
+    applyDraftUpdates(
+      {
+        models: nextModels,
+        enabledModelIds: nextEnabledModelIds,
+        roles: nextRoles,
+      },
+      0,
+    );
+    toast.success(`Applied the recommended ${provider.label} default models.`);
+  };
+
   const handleRefreshMetadata = async () => {
     const result = await refreshMetadataMutation.mutateAsync();
     if (!result.success) {
@@ -1492,7 +1637,16 @@ export function ModelSettingsSection({
 
   return (
     <div className="space-y-6">
-      <Section icon={Brain} title="Default Models">
+      <Section
+        icon={Brain}
+        title="Default Models"
+        action={
+          <UseRecommendedDefaultsAction
+            providers={sortedConnectedProviders}
+            onApply={applyRecommendedDefaults}
+          />
+        }
+      >
         <div className="divide-y divide-background">
           {TASK_MODEL_ROLE_CONFIGS.map((config) => {
             const status =

--- a/apps/web/src/trpc/commands/setup-new/index.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.ts
@@ -43,6 +43,7 @@ import {
   recordSlackConversationMessageBestEffort,
 } from '@roomote/sdk/server';
 import {
+  buildRecommendedDeploymentModelConfig,
   buildSetupAuthStatus,
   buildSetupComputeStatus,
   buildSetupModelStatus,
@@ -1492,9 +1493,10 @@ export async function saveSetupNewModelConfigCommand(
       modelProvider: input.provider,
       lastInteractedByUserId: userId,
     });
-    const runtimeModelConfig = normalizeDeploymentModelConfig({
-      roomoteModel: provider.defaultRoomoteModel,
-    });
+    // Connecting a provider applies its recommended per-role model defaults:
+    // the provider's default coding model plus any recommended helper,
+    // vision, code review, explore, and planning models.
+    const runtimeModelConfig = buildRecommendedDeploymentModelConfig(provider);
 
     // Mirror the models settings page: connecting a provider the deployment
     // has no models for yet auto-adds its recommended models so the first

--- a/packages/types/src/model-provider-config.test.ts
+++ b/packages/types/src/model-provider-config.test.ts
@@ -316,7 +316,7 @@ describe('SETUP_MODEL_PROVIDER_CATALOG', () => {
     expect(googleProvider).toMatchObject({
       label: 'Google Gemini',
       envVarName: 'GEMINI_API_KEY',
-      defaultRoomoteModel: 'google/gemini-3.5-flash',
+      defaultRoomoteModel: 'google/gemini-3.1-pro-preview',
     });
   });
 

--- a/packages/types/src/model-provider-config.test.ts
+++ b/packages/types/src/model-provider-config.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildRecommendedDeploymentModelConfig,
   buildSetupModelStatus,
   collectSetupModelProviderCredentialValues,
   createEmptyDeploymentModelConfig,
@@ -6,11 +7,13 @@ import {
   DEFAULT_TASK_MODEL_ID,
   getModelProviderEnvKeyCandidates,
   getReasoningEffortLabel,
+  getSetupModelProvider,
   isInlineGoogleCredentialsValue,
   normalizeDeploymentModelConfig,
   REASONING_EFFORT_OPTIONS,
   SETUP_MODEL_PROVIDER_CATALOG,
   type ReasoningEffort,
+  type SetupModelProviderDescriptor,
 } from './index';
 
 describe('normalizeDeploymentModelConfig', () => {
@@ -236,6 +239,26 @@ describe('SETUP_MODEL_PROVIDER_CATALOG', () => {
     }
   });
 
+  it('only recommends role models from the provider suggested catalog', () => {
+    const providers: readonly SetupModelProviderDescriptor[] =
+      SETUP_MODEL_PROVIDER_CATALOG;
+
+    for (const provider of providers) {
+      const suggestedModelIds = new Set(
+        provider.suggestedTaskModels.map((suggestion) => suggestion.id),
+      );
+
+      for (const [role, modelId] of Object.entries(
+        provider.recommendedRoleModels ?? {},
+      )) {
+        expect(
+          modelId !== undefined && suggestedModelIds.has(modelId),
+          `${provider.id} recommends ${modelId} for ${role}, which is not in its suggestedTaskModels`,
+        ).toBe(true);
+      }
+    }
+  });
+
   it('maps Amazon Bedrock to a Bedrock API key plus an optional AWS region', () => {
     const bedrockProvider = SETUP_MODEL_PROVIDER_CATALOG.find(
       (provider) => provider.id === 'amazon-bedrock',
@@ -358,6 +381,36 @@ describe('SETUP_MODEL_PROVIDER_CATALOG', () => {
       envVarName: 'TOGETHER_API_KEY',
       defaultRoomoteModel: 'togetherai/deepseek-ai/DeepSeek-V4-Pro',
       authKind: 'api-key',
+    });
+  });
+});
+
+describe('buildRecommendedDeploymentModelConfig', () => {
+  it('maps the provider default to coding and recommended models to their roles', () => {
+    expect(
+      buildRecommendedDeploymentModelConfig(getSetupModelProvider('anthropic')),
+    ).toEqual({
+      roomoteModel: 'anthropic/claude-sonnet-5',
+      roomoteSmallModel: 'anthropic/claude-haiku-4-5',
+      roomoteVisionModel: null,
+      roomoteCodeReviewModel: 'anthropic/claude-opus-4-8',
+      roomoteExploreModel: 'anthropic/claude-haiku-4-5',
+      roomotePlanningModel: 'anthropic/claude-opus-4-8',
+      roomoteModelReasoningEffort: null,
+      roomoteSmallModelReasoningEffort: null,
+      roomoteVisionModelReasoningEffort: null,
+      roomoteCodeReviewModelReasoningEffort: null,
+      roomoteExploreModelReasoningEffort: null,
+      roomotePlanningModelReasoningEffort: null,
+    });
+  });
+
+  it('recommends only the coding default for providers without a role mapping', () => {
+    expect(
+      buildRecommendedDeploymentModelConfig(getSetupModelProvider('xai')),
+    ).toEqual({
+      ...createEmptyDeploymentModelConfig(),
+      roomoteModel: 'xai/grok-4.5',
     });
   });
 });

--- a/packages/types/src/model-provider-config.test.ts
+++ b/packages/types/src/model-provider-config.test.ts
@@ -295,7 +295,7 @@ describe('SETUP_MODEL_PROVIDER_CATALOG', () => {
       label: 'Google Vertex AI',
       envVarName: 'GOOGLE_APPLICATION_CREDENTIALS',
       envVarLabel: 'Service account JSON',
-      defaultRoomoteModel: 'google-vertex/gemini-3.5-flash',
+      defaultRoomoteModel: 'google-vertex/claude-sonnet-5@default',
     });
     expect(
       vertexProvider?.additionalEnvFields?.map((field) => ({
@@ -346,7 +346,7 @@ describe('SETUP_MODEL_PROVIDER_CATALOG', () => {
     expect(chatgptProvider?.envVarName).toBeUndefined();
   });
 
-  it('maps Requesty to the REQUESTY_API_KEY env var', () => {
+  it('maps Requesty to the REQUESTY_API_KEY env var and hides it from new connections', () => {
     const requestyProvider = SETUP_MODEL_PROVIDER_CATALOG.find(
       (provider) => provider.id === 'requesty',
     );
@@ -355,7 +355,25 @@ describe('SETUP_MODEL_PROVIDER_CATALOG', () => {
       label: 'Requesty',
       envVarName: 'REQUESTY_API_KEY',
       defaultRoomoteModel: 'requesty/anthropic/claude-haiku-4-5',
+      hidden: true,
     });
+  });
+
+  it('excludes hidden providers from the setup status unless they are connected', () => {
+    const unconnected = buildSetupModelStatus({});
+
+    expect(
+      unconnected.providers.some((provider) => provider.id === 'requesty'),
+    ).toBe(false);
+
+    const connected = buildSetupModelStatus({
+      persistedEnvVarNames: ['REQUESTY_API_KEY'],
+    });
+    const requestyStatus = connected.providers.find(
+      (provider) => provider.id === 'requesty',
+    );
+
+    expect(requestyStatus?.savedApiKeySatisfied).toBe(true);
   });
 
   it('maps Baseten to the BASETEN_API_KEY env var', () => {

--- a/packages/types/src/model-provider-config.test.ts
+++ b/packages/types/src/model-provider-config.test.ts
@@ -296,6 +296,11 @@ describe('SETUP_MODEL_PROVIDER_CATALOG', () => {
       envVarName: 'GOOGLE_APPLICATION_CREDENTIALS',
       envVarLabel: 'Service account JSON',
       defaultRoomoteModel: 'google-vertex/claude-sonnet-5@default',
+      credentialHelp: {
+        text: 'Roomote defaults to Anthropic Claude models on Vertex. Enable Claude in Model Garden for this project (and confirm your location serves it) before connecting, or switch models afterward from Settings > Models.',
+        href: 'https://console.cloud.google.com/vertex-ai/model-garden',
+        linkLabel: 'Open Vertex AI Model Garden',
+      },
     });
     expect(
       vertexProvider?.additionalEnvFields?.map((field) => ({

--- a/packages/types/src/model-provider-config.ts
+++ b/packages/types/src/model-provider-config.ts
@@ -41,6 +41,32 @@ export type SetupModelProviderId = (typeof SETUP_MODEL_PROVIDER_IDS)[number];
 export type SetupModelProviderAuthKind = 'api-key' | 'oauth';
 
 /**
+ * The default-model roles a deployment configures: one model per kind of
+ * work. `coding` drives new task launches; every other role falls back to
+ * the coding model at runtime when unset.
+ */
+export type TaskModelRole =
+  | 'coding'
+  | 'helper'
+  | 'vision'
+  | 'codeReview'
+  | 'explore'
+  | 'planning';
+
+/**
+ * A provider's recommended default models for the non-coding roles. The
+ * coding role's recommendation is always the provider's
+ * `defaultRoomoteModel`, so it is intentionally not part of this map; roles
+ * left unset are recommended to follow the coding model ("same as coding"
+ * at runtime). Every id must be one of the provider's `suggestedTaskModels`
+ * so applying recommendations never points a role at a model outside the
+ * provider's curated catalog.
+ */
+export type RecommendedRoleModels = Partial<
+  Record<Exclude<TaskModelRole, 'coding'>, string>
+>;
+
+/**
  * An additional credential value a provider needs beyond its primary API-key
  * env var (`envVarName`), such as an AWS region or a GCP project id. The
  * connect UI renders one input per field; `required` fields also participate
@@ -82,6 +108,15 @@ export type SetupModelProviderDescriptor = {
   defaultRoomoteModel: string;
   authKind: SetupModelProviderAuthKind;
   suggestedTaskModels: readonly SuggestedTaskModel[];
+  /**
+   * Recommended per-role default models, applied when the provider is
+   * connected during setup and by the models settings page's
+   * "Use recommended" action (see
+   * `buildRecommendedDeploymentModelConfig`). Providers without a mapping
+   * recommend `defaultRoomoteModel` for coding and "same as coding" for
+   * every other role.
+   */
+  recommendedRoleModels?: RecommendedRoleModels;
 };
 
 export const DEFAULT_SETUP_MODEL_PROVIDER_ID: SetupModelProviderId =
@@ -99,6 +134,13 @@ export const SETUP_MODEL_PROVIDER_CATALOG = [
     suggestedTaskModels: mapRecommendedTaskModels(
       OPENROUTER_RECOMMENDED_TASK_MODEL_SLUGS,
     ),
+    recommendedRoleModels: {
+      helper: 'openrouter/google/gemini-3.5-flash',
+      vision: 'openrouter/google/gemini-3.1-pro-preview',
+      codeReview: 'openrouter/anthropic/claude-opus-4.8',
+      explore: 'openrouter/google/gemini-3.5-flash',
+      planning: 'openrouter/anthropic/claude-opus-4.8',
+    },
   },
   {
     id: 'vercel',
@@ -125,6 +167,13 @@ export const SETUP_MODEL_PROVIDER_CATALOG = [
       'mimo-v2-5': 'vercel/xiaomi/mimo-v2.5',
       'grok-4-5': 'vercel/xai/grok-4.5',
     }),
+    recommendedRoleModels: {
+      helper: 'vercel/google/gemini-3.5-flash',
+      vision: 'vercel/google/gemini-3.1-pro-preview',
+      codeReview: 'vercel/anthropic/claude-opus-4.8',
+      explore: 'vercel/google/gemini-3.5-flash',
+      planning: 'vercel/anthropic/claude-opus-4.8',
+    },
   },
   {
     id: 'requesty',
@@ -178,6 +227,12 @@ export const SETUP_MODEL_PROVIDER_CATALOG = [
       'gpt-5-6-terra': 'openai/gpt-5.6-terra',
       'gpt-5-6-luna': 'openai/gpt-5.6-luna',
     }),
+    recommendedRoleModels: {
+      helper: 'openai/gpt-5.6-luna',
+      codeReview: 'openai/gpt-5.6-sol',
+      explore: 'openai/gpt-5.6-luna',
+      planning: 'openai/gpt-5.6-sol',
+    },
   },
   {
     id: 'anthropic',
@@ -191,6 +246,12 @@ export const SETUP_MODEL_PROVIDER_CATALOG = [
       'claude-opus-4-8': 'anthropic/claude-opus-4-8',
       'claude-sonnet-5': 'anthropic/claude-sonnet-5',
     }),
+    recommendedRoleModels: {
+      helper: 'anthropic/claude-haiku-4-5',
+      codeReview: 'anthropic/claude-opus-4-8',
+      explore: 'anthropic/claude-haiku-4-5',
+      planning: 'anthropic/claude-opus-4-8',
+    },
   },
   {
     id: 'moonshotai',
@@ -233,6 +294,16 @@ export const SETUP_MODEL_PROVIDER_CATALOG = [
       'minimax-m3': 'opencode/minimax-m3',
       'grok-4-5': 'opencode/grok-4.5',
     }),
+    // The default coding model (big-pickle) is OpenCode's own routed model,
+    // so vision gets an explicit multimodal recommendation instead of the
+    // usual same-as-coding fallback.
+    recommendedRoleModels: {
+      helper: 'opencode/gemini-3.5-flash',
+      vision: 'opencode/claude-sonnet-5',
+      codeReview: 'opencode/claude-opus-4-8',
+      explore: 'opencode/gemini-3.5-flash',
+      planning: 'opencode/claude-opus-4-8',
+    },
   },
   {
     // Bedrock's current console issues API keys for the Mantle endpoint. The
@@ -264,6 +335,12 @@ export const SETUP_MODEL_PROVIDER_CATALOG = [
       'claude-opus-4-8': 'bedrock-mantle/anthropic.claude-opus-4-8',
       'claude-sonnet-5': 'bedrock-mantle/anthropic.claude-sonnet-5',
     }),
+    recommendedRoleModels: {
+      helper: 'bedrock-mantle/anthropic.claude-haiku-4-5',
+      codeReview: 'bedrock-mantle/anthropic.claude-opus-4-8',
+      explore: 'bedrock-mantle/anthropic.claude-haiku-4-5',
+      planning: 'bedrock-mantle/anthropic.claude-opus-4-8',
+    },
   },
   {
     // Provider id matches the models.dev/opencode `google-vertex` provider.
@@ -299,6 +376,13 @@ export const SETUP_MODEL_PROVIDER_CATALOG = [
       'gemini-3-1-pro': 'google-vertex/gemini-3.1-pro-preview',
       'gemini-3-5-flash': 'google-vertex/gemini-3.5-flash',
     }),
+    // Gemini-only recommendations: Claude models on Vertex often require
+    // separate Model Garden enablement, so they are suggested but not
+    // recommended defaults.
+    recommendedRoleModels: {
+      codeReview: 'google-vertex/gemini-3.1-pro-preview',
+      planning: 'google-vertex/gemini-3.1-pro-preview',
+    },
   },
   {
     // Provider id matches the models.dev/opencode `google` provider (Gemini
@@ -312,6 +396,10 @@ export const SETUP_MODEL_PROVIDER_CATALOG = [
       'gemini-3-1-pro': 'google/gemini-3.1-pro-preview',
       'gemini-3-5-flash': 'google/gemini-3.5-flash',
     }),
+    recommendedRoleModels: {
+      codeReview: 'google/gemini-3.1-pro-preview',
+      planning: 'google/gemini-3.1-pro-preview',
+    },
   },
   {
     // Provider id matches the models.dev/opencode `xai` provider so
@@ -336,6 +424,12 @@ export const SETUP_MODEL_PROVIDER_CATALOG = [
       'gpt-5-6-terra': 'openai/gpt-5.6-terra',
       'gpt-5-6-luna': 'openai/gpt-5.6-luna',
     }),
+    recommendedRoleModels: {
+      helper: 'openai/gpt-5.6-luna',
+      codeReview: 'openai/gpt-5.6-sol',
+      explore: 'openai/gpt-5.6-luna',
+      planning: 'openai/gpt-5.6-sol',
+    },
   },
 ] as const satisfies readonly SetupModelProviderDescriptor[];
 
@@ -455,7 +549,7 @@ export const DEFAULT_MODEL_ROLE_REASONING_EFFORTS = {
   codeReview: 'high',
   explore: 'low',
   planning: 'high',
-} as const satisfies Record<string, ReasoningEffort>;
+} as const satisfies Record<TaskModelRole, ReasoningEffort>;
 
 export type SetupModelProviderStatus = SetupModelProviderDescriptor & {
   runtimeApiKeySatisfied: boolean;
@@ -537,6 +631,33 @@ export function normalizeDeploymentModelConfig(
       value?.roomotePlanningModelReasoningEffort,
     ),
   };
+}
+
+/**
+ * Resolves a provider's recommended default-model configuration: the
+ * provider's default model for the coding role plus its recommended
+ * non-coding role models, with unset roles left null so they follow the
+ * coding model at runtime. Reasoning efforts stay null so the shared
+ * per-role defaults (`DEFAULT_MODEL_ROLE_REASONING_EFFORTS`) apply. Used
+ * when a provider is connected during setup and by the models settings
+ * page's "Use recommended" action.
+ */
+export function buildRecommendedDeploymentModelConfig(
+  provider: Pick<
+    SetupModelProviderDescriptor,
+    'defaultRoomoteModel' | 'recommendedRoleModels'
+  >,
+): DeploymentModelConfig {
+  const roleModels = provider.recommendedRoleModels ?? {};
+
+  return normalizeDeploymentModelConfig({
+    roomoteModel: provider.defaultRoomoteModel,
+    roomoteSmallModel: roleModels.helper,
+    roomoteVisionModel: roleModels.vision,
+    roomoteCodeReviewModel: roleModels.codeReview,
+    roomoteExploreModel: roleModels.explore,
+    roomotePlanningModel: roleModels.planning,
+  });
 }
 
 export function normalizeOptionalReasoningEffort(

--- a/packages/types/src/model-provider-config.ts
+++ b/packages/types/src/model-provider-config.ts
@@ -109,6 +109,14 @@ export type SetupModelProviderDescriptor = {
   authKind: SetupModelProviderAuthKind;
   suggestedTaskModels: readonly SuggestedTaskModel[];
   /**
+   * Hides the provider from the setup wizard and settings connect surfaces
+   * unless it is already connected (saved or runtime env). The catalog entry
+   * stays registered so existing connections keep working: model-id
+   * resolution, credential env-var forwarding, and provider labels are
+   * unaffected.
+   */
+  hidden?: boolean;
+  /**
    * Recommended per-role default models, applied when the provider is
    * connected during setup and by the models settings page's
    * "Use recommended" action (see
@@ -134,9 +142,10 @@ export const SETUP_MODEL_PROVIDER_CATALOG = [
     suggestedTaskModels: mapRecommendedTaskModels(
       OPENROUTER_RECOMMENDED_TASK_MODEL_SLUGS,
     ),
+    // Vision is unset: the recommended coding model is multimodal, so image
+    // work follows the coding model ("same as coding").
     recommendedRoleModels: {
       helper: 'openrouter/google/gemini-3.5-flash',
-      vision: 'openrouter/google/gemini-3.1-pro-preview',
       codeReview: 'openrouter/anthropic/claude-opus-4.8',
       explore: 'openrouter/google/gemini-3.5-flash',
       planning: 'openrouter/anthropic/claude-opus-4.8',
@@ -167,9 +176,10 @@ export const SETUP_MODEL_PROVIDER_CATALOG = [
       'mimo-v2-5': 'vercel/xiaomi/mimo-v2.5',
       'grok-4-5': 'vercel/xai/grok-4.5',
     }),
+    // Vision is unset: the recommended coding model is multimodal, so image
+    // work follows the coding model ("same as coding").
     recommendedRoleModels: {
       helper: 'vercel/google/gemini-3.5-flash',
-      vision: 'vercel/google/gemini-3.1-pro-preview',
       codeReview: 'vercel/anthropic/claude-opus-4.8',
       explore: 'vercel/google/gemini-3.5-flash',
       planning: 'vercel/anthropic/claude-opus-4.8',
@@ -186,6 +196,10 @@ export const SETUP_MODEL_PROVIDER_CATALOG = [
     suggestedTaskModels: mapRecommendedTaskModels({
       'claude-haiku-4-5': 'requesty/anthropic/claude-haiku-4-5',
     }),
+    // Hidden from new connections for now: the catalog above resolves too
+    // few recommended models to seed a useful default list. Existing
+    // connections keep working.
+    hidden: true,
   },
   {
     id: 'baseten',
@@ -367,7 +381,7 @@ export const SETUP_MODEL_PROVIDER_CATALOG = [
         placeholder: 'us-central1',
       },
     ],
-    defaultRoomoteModel: 'google-vertex/gemini-3.5-flash',
+    defaultRoomoteModel: 'google-vertex/claude-sonnet-5@default',
     authKind: 'api-key',
     suggestedTaskModels: mapRecommendedTaskModels({
       'claude-haiku-4-5': 'google-vertex/claude-haiku-4-5@20251001',
@@ -376,12 +390,13 @@ export const SETUP_MODEL_PROVIDER_CATALOG = [
       'gemini-3-1-pro': 'google-vertex/gemini-3.1-pro-preview',
       'gemini-3-5-flash': 'google-vertex/gemini-3.5-flash',
     }),
-    // Gemini-only recommendations: Claude models on Vertex often require
-    // separate Model Garden enablement, so they are suggested but not
-    // recommended defaults.
+    // Mirrors the Anthropic/Bedrock split. Claude models on Vertex may
+    // require Model Garden enablement in the GCP project.
     recommendedRoleModels: {
-      codeReview: 'google-vertex/gemini-3.1-pro-preview',
-      planning: 'google-vertex/gemini-3.1-pro-preview',
+      helper: 'google-vertex/claude-haiku-4-5@20251001',
+      codeReview: 'google-vertex/claude-opus-4-8@default',
+      explore: 'google-vertex/claude-haiku-4-5@20251001',
+      planning: 'google-vertex/claude-opus-4-8@default',
     },
   },
   {
@@ -934,58 +949,67 @@ export function buildSetupModelStatus(input: {
     persistedProviderId ??
     DEFAULT_SETUP_MODEL_PROVIDER_ID;
 
-  const providers = SETUP_MODEL_PROVIDER_CATALOG.map((provider) => {
-    if (provider.authKind === 'oauth') {
-      // OAuth providers carry no env var. Satisfaction comes from the
-      // connection flag passed in by the caller (chatgptConnected).
+  const providers = SETUP_MODEL_PROVIDER_CATALOG.map(
+    (provider): SetupModelProviderStatus => {
+      if (provider.authKind === 'oauth') {
+        // OAuth providers carry no env var. Satisfaction comes from the
+        // connection flag passed in by the caller (chatgptConnected).
+        return {
+          ...provider,
+          additionalEnvValues: {},
+          runtimeApiKeySatisfied: false,
+          savedApiKeySatisfied: chatgptConnected,
+        };
+      }
+
+      // Multi-credential providers (e.g. Bedrock, Vertex) are satisfied only
+      // when every required env var is configured. Runtime satisfaction is
+      // runtime-env-only; saved satisfaction allows mixed sources (the
+      // effective model runtime env resolves each key runtime-first with a DB
+      // fallback) as long as at least one required value is actually saved.
+      const requiredEnvVarNames =
+        getSetupModelProviderRequiredEnvVarNames(provider);
+      const hasRequiredEnvVars = requiredEnvVarNames.length > 0;
+      const isRuntimeConfigured = (name: string) =>
+        isConfiguredEnvValue(runtimeEnv[name]);
+      const isPersisted = (name: string) => persistedEnvVarNameSet.has(name);
+      const additionalEnvValues = Object.fromEntries(
+        getSetupModelProviderAdditionalEnvFields(provider)
+          .filter((field) => !field.secret)
+          .map((field) => {
+            const runtimeValue = normalizeOptionalString(
+              runtimeEnv[field.envVarName],
+            );
+            const persistedValue = normalizeOptionalString(
+              input.persistedEnvVarValues?.[field.envVarName],
+            );
+
+            return [field.envVarName, runtimeValue ?? persistedValue];
+          })
+          .filter((entry): entry is [string, string] => entry[1] !== null),
+      );
+
       return {
         ...provider,
-        additionalEnvValues: {},
-        runtimeApiKeySatisfied: false,
-        savedApiKeySatisfied: chatgptConnected,
+        additionalEnvValues,
+        runtimeApiKeySatisfied:
+          hasRequiredEnvVars && requiredEnvVarNames.every(isRuntimeConfigured),
+        savedApiKeySatisfied:
+          hasRequiredEnvVars &&
+          requiredEnvVarNames.every(
+            (name) => isPersisted(name) || isRuntimeConfigured(name),
+          ) &&
+          requiredEnvVarNames.some(isPersisted),
       };
-    }
-
-    // Multi-credential providers (e.g. Bedrock, Vertex) are satisfied only
-    // when every required env var is configured. Runtime satisfaction is
-    // runtime-env-only; saved satisfaction allows mixed sources (the
-    // effective model runtime env resolves each key runtime-first with a DB
-    // fallback) as long as at least one required value is actually saved.
-    const requiredEnvVarNames =
-      getSetupModelProviderRequiredEnvVarNames(provider);
-    const hasRequiredEnvVars = requiredEnvVarNames.length > 0;
-    const isRuntimeConfigured = (name: string) =>
-      isConfiguredEnvValue(runtimeEnv[name]);
-    const isPersisted = (name: string) => persistedEnvVarNameSet.has(name);
-    const additionalEnvValues = Object.fromEntries(
-      getSetupModelProviderAdditionalEnvFields(provider)
-        .filter((field) => !field.secret)
-        .map((field) => {
-          const runtimeValue = normalizeOptionalString(
-            runtimeEnv[field.envVarName],
-          );
-          const persistedValue = normalizeOptionalString(
-            input.persistedEnvVarValues?.[field.envVarName],
-          );
-
-          return [field.envVarName, runtimeValue ?? persistedValue];
-        })
-        .filter((entry): entry is [string, string] => entry[1] !== null),
-    );
-
-    return {
-      ...provider,
-      additionalEnvValues,
-      runtimeApiKeySatisfied:
-        hasRequiredEnvVars && requiredEnvVarNames.every(isRuntimeConfigured),
-      savedApiKeySatisfied:
-        hasRequiredEnvVars &&
-        requiredEnvVarNames.every(
-          (name) => isPersisted(name) || isRuntimeConfigured(name),
-        ) &&
-        requiredEnvVarNames.some(isPersisted),
-    };
-  });
+    },
+  ).filter(
+    // Hidden providers are not offered for new connections but stay listed
+    // (and manageable) while they are connected.
+    (provider) =>
+      !provider.hidden ||
+      provider.runtimeApiKeySatisfied ||
+      provider.savedApiKeySatisfied,
+  );
 
   const runtimeProviderStatus = providers.find(
     (provider) => provider.id === runtimeKnownProviderId,

--- a/packages/types/src/model-provider-config.ts
+++ b/packages/types/src/model-provider-config.ts
@@ -365,6 +365,11 @@ export const SETUP_MODEL_PROVIDER_CATALOG = [
     label: 'Google Vertex AI',
     envVarName: 'GOOGLE_APPLICATION_CREDENTIALS',
     envVarLabel: 'Service account JSON',
+    credentialHelp: {
+      text: 'Roomote defaults to Anthropic Claude models on Vertex. Enable Claude in Model Garden for this project (and confirm your location serves it) before connecting, or switch models afterward from Settings > Models.',
+      href: 'https://console.cloud.google.com/vertex-ai/model-garden',
+      linkLabel: 'Open Vertex AI Model Garden',
+    },
     additionalEnvFields: [
       {
         envVarName: 'GOOGLE_VERTEX_PROJECT',

--- a/packages/types/src/model-provider-config.ts
+++ b/packages/types/src/model-provider-config.ts
@@ -405,15 +405,17 @@ export const SETUP_MODEL_PROVIDER_CATALOG = [
     id: 'google',
     label: 'Google Gemini',
     envVarName: 'GEMINI_API_KEY',
-    defaultRoomoteModel: 'google/gemini-3.5-flash',
+    defaultRoomoteModel: 'google/gemini-3.1-pro-preview',
     authKind: 'api-key',
     suggestedTaskModels: mapRecommendedTaskModels({
       'gemini-3-1-pro': 'google/gemini-3.1-pro-preview',
       'gemini-3-5-flash': 'google/gemini-3.5-flash',
     }),
+    // Pro is the coding default, and code review and planning follow it via
+    // "same as coding"; Flash covers the high-volume cheap roles.
     recommendedRoleModels: {
-      codeReview: 'google/gemini-3.1-pro-preview',
-      planning: 'google/gemini-3.1-pro-preview',
+      helper: 'google/gemini-3.5-flash',
+      explore: 'google/gemini-3.5-flash',
     },
   },
   {


### PR DESCRIPTION
## Summary

Replaces the single generic model default with provider-specific recommended defaults per model role. Each inference provider in the setup catalog can now declare recommended models for the non-coding roles (helper, vision, code review, explore, planning); the coding recommendation is always the provider's existing `defaultRoomoteModel`, so there is one source of truth per slot.

- **Data structure**: an optional `recommendedRoleModels` map on each `SETUP_MODEL_PROVIDER_CATALOG` entry, plus a shared `buildRecommendedDeploymentModelConfig()` resolver. Roles left unset mean "same as coding", so single-model providers get a valid recommendation by omitting the field entirely. A catalog test enforces that every recommended id is in that provider's `suggestedTaskModels`.
- **Setup flow**: connecting a provider in the setup wizard now persists the full recommended role split instead of only the coding model. The existing recommended-model auto-add already seeds these models into the catalog.
- **Settings**: a "Use recommended" action on the Default Models card re-applies a connected provider's recommendations at any time (direct button for one connected provider, a small picker for several). It is implemented client-side through the existing draft/autosave flow — no new tRPC route — and it adds/enables missing recommended models, resets unset roles to "Same as coding model", and skips env-managed roles.

The recommendations follow one pattern: a fast low-cost model for helper + explore, the provider's default coder for coding, and a strong reasoning model for code review + planning. Vision is only set explicitly when the recommended coding model is not known to be multimodal (currently just OpenCode). Google Vertex AI now mirrors the Anthropic/Bedrock split (Claude Sonnet 5 coding default, Haiku 4.5 helper/explore, Opus 4.8 review/planning). Mappings are deliberately easy to edit in code.

**Requesty is hidden from new connections** via a new `hidden` catalog flag: it no longer appears in the setup wizard or settings connect surfaces unless already connected. The catalog entry stays registered, so existing Requesty deployments keep working (model-id resolution, credential env-var forwarding, labels, and managing/deleting the saved key). The setup wizard's provider picker now renders from the server-filtered status list instead of the raw catalog to support this.

Intentionally **not** built (future preset system can layer on top of `RecommendedRoleModels`): saved user presets, a preset picker at task start, or any multi-level preset management UX. This behaves as an apply-once macro.

## Test plan

- New types tests: resolver behavior (mapped provider, fallback-only provider), the suggested-catalog membership invariant across all providers, and hidden-provider filtering in `buildSetupModelStatus` (excluded when unconnected, listed when connected).
- New UI tests: single-provider apply from the header action, multi-provider picker, and env-managed roles staying untouched.
- Existing suites green: `packages/types` (556), settings components + setup step + task-models and setup-new commands (450), `model-runtime-config` (20).
- `pnpm lint`, `pnpm check-types`, and `pnpm knip` all pass.

Note: `saveSetupNewModelConfigCommand`'s wiring has no direct test — the command isn't covered by the existing setup-new test harness and the change is a one-line delegation to the unit-tested resolver.

Docs: added a "Recommended default models" section to `apps/docs/models.mdx`; removed Requesty from the provider lists in `models.mdx` and the README.