### PR TITLE
[Fix] Allow Docker proxy volume operations

### DIFF
--- a/apps/docs/providers/compute/docker.mdx
+++ b/apps/docs/providers/compute/docker.mdx
@@ -116,7 +116,7 @@ preview proxy.
 
 Docker sandboxes require the Roomote controller to create and manage worker
 containers. Production Compose routes those operations through an internal
-socket proxy that allows only the container, exec, image, and network API
+socket proxy that allows only the container, exec, image, network, and volume API
 sections Roomote needs; the controller does not mount the raw socket. Treat the
 proxy and Docker host as trusted infrastructure, and do not use Docker
 sandboxes as a multi-tenant isolation boundary for untrusted operators or

--- a/deploy/ci/validate-deployment-artifacts.mjs
+++ b/deploy/ci/validate-deployment-artifacts.mjs
@@ -29,6 +29,16 @@ function commandText(command) {
   return String(command ?? '');
 }
 
+function normalizedEnvironment(environment) {
+  return JSON.stringify(
+    Object.fromEntries(
+      Object.entries(environment ?? {}).sort(([left], [right]) =>
+        left.localeCompare(right),
+      ),
+    ),
+  );
+}
+
 const composeEnv = {
   ...process.env,
   R_APP_ENV: 'production',
@@ -177,6 +187,9 @@ assert(
   'render: api must run migrations before deploy',
 );
 
+const productionCompose = YAML.parse(
+  read('deploy/compose/docker-compose.prod.yml'),
+);
 const coolify = YAML.parse(read('deploy/coolify/docker-compose.yaml'));
 for (const [name, contract] of Object.entries(catalog.runtimeServices)) {
   const service = coolify.services?.[name];
@@ -192,6 +205,17 @@ for (const [name, contract] of Object.entries(catalog.runtimeServices)) {
     );
   }
 }
+assert(
+  coolify.services?.['docker-proxy']?.environment?.VOLUMES === '1',
+  'coolify: Docker proxy must allow managed workspace volume operations',
+);
+assert(
+  normalizedEnvironment(coolify.services?.['docker-proxy']?.environment) ===
+    normalizedEnvironment(
+      productionCompose.services?.['docker-proxy']?.environment,
+    ),
+  'coolify: Docker proxy environment must match production Compose',
+);
 
 const fly = parseToml(read('deploy/fly/fly.toml'));
 for (const [name, contract] of Object.entries(catalog.runtimeServices)) {

--- a/deploy/compose/docker-compose.prod.yml
+++ b/deploy/compose/docker-compose.prod.yml
@@ -310,6 +310,7 @@ services:
       EXEC: '1'
       IMAGES: '1'
       NETWORKS: '1'
+      VOLUMES: '1'
       POST: '1'
       EVENTS: '0'
     volumes:

--- a/deploy/coolify/docker-compose.yaml
+++ b/deploy/coolify/docker-compose.yaml
@@ -131,6 +131,7 @@ services:
       EXEC: '1'
       IMAGES: '1'
       NETWORKS: '1'
+      VOLUMES: '1'
       POST: '1'
       EVENTS: '0'
     volumes:

--- a/deploy/scripts/validate-compose-security.sh
+++ b/deploy/scripts/validate-compose-security.sh
@@ -57,7 +57,8 @@ jq -e '
     "EXEC": "1",
     "IMAGES": "1",
     "NETWORKS": "1",
-    "POST": "1"
+    "POST": "1",
+    "VOLUMES": "1"
   }) and
 
   ([[


### PR DESCRIPTION
## Summary

- allow the production Docker socket proxy to access the Volumes API section
- extend the Compose security contract to require that permission

## Root cause

Docker task provisioning creates a managed workspace volume before starting a worker. The production socket proxy allowed write requests generally, but did not enable the `VOLUMES` API section, so `POST /volumes/create` returned `403 Forbidden` before worker startup.

## Impact

Self-hosted deployments using the production Compose artifact can create and remove managed task workspace volumes through the isolated Docker proxy while unrelated Docker API sections remain denied.

## Validation

- `bash deploy/scripts/validate-compose-security.sh`
- `pnpm deployment:validate`
- pre-push checks: oxlint, residual lint, `check-types:fast`, and knip
- live create/delete probe through the controller-to-proxy Docker API path
