### PR TITLE
[Feat] Offer Discord destinations for suggester, announcer, and platform-issue alerts

### DIFF
--- a/.changeset/complete-discord-destinations.md
+++ b/.changeset/complete-discord-destinations.md
@@ -1,0 +1,8 @@
+---
+'@roomote/web': minor
+---
+
+Suggested-task summaries, announcer reports, and platform-issue alerts can now
+report to a Discord channel: their destination pickers offer Slack or Discord
+channels the same way the triage and auditor automations do, and platform-issue
+alerts deliver to the selected Discord channel.

--- a/apps/web/src/components/settings/automations/AutomationsSettings.client.test.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.client.test.tsx
@@ -649,6 +649,7 @@ describe('Automations selection helpers', () => {
       buildAutomationDiscordDestinationOptions({
         channels: [{ id: '111', name: 'general', label: '#general' }],
         selectedChannelId: null,
+        includeProviderSuffix: true,
       }),
     ).toEqual([
       {
@@ -664,6 +665,7 @@ describe('Automations selection helpers', () => {
       buildAutomationDiscordDestinationOptions({
         channels: [{ id: '111', name: 'general', label: '#general' }],
         selectedChannelId: '222',
+        includeProviderSuffix: true,
       }),
     ).toEqual([
       {
@@ -679,11 +681,33 @@ describe('Automations selection helpers', () => {
     ]);
   });
 
+  it('drops the provider suffix when Discord is the only connected provider', () => {
+    expect(
+      buildAutomationDiscordDestinationOptions({
+        channels: [{ id: '111', name: 'general', label: '#general' }],
+        selectedChannelId: '222',
+        includeProviderSuffix: false,
+      }),
+    ).toEqual([
+      {
+        id: `${DISCORD_DESTINATION_OPTION_PREFIX}222`,
+        name: '222',
+        label: '#222',
+      },
+      {
+        id: `${DISCORD_DESTINATION_OPTION_PREFIX}111`,
+        name: 'general',
+        label: '#general',
+      },
+    ]);
+  });
+
   it('does not duplicate a Discord option for a selection the catalog already lists', () => {
     expect(
       buildAutomationDiscordDestinationOptions({
         channels: [{ id: '111', name: 'general', label: '#general' }],
         selectedChannelId: '111',
+        includeProviderSuffix: true,
       }),
     ).toEqual([
       {

--- a/apps/web/src/components/settings/automations/AutomationsSettings.client.test.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.client.test.tsx
@@ -71,13 +71,16 @@ const baseFormState: FormState = {
   ciFailureTriageDiscordChannel: '',
   suggesterFrequency: 'off',
   suggesterSlackChannel: '',
+  suggesterDiscordChannel: '',
   suggesterInstructions: '',
   suggesterRoutingMode: DEFAULT_SUGGESTER_ROUTING_MODE,
   suggesterRoutingInstructions: '',
   announcerFrequency: 'off' as const,
   announcerSlackChannel: '',
+  announcerDiscordChannel: '',
   announcerInstructions: '',
   platformIssueSlackChannel: '',
+  platformIssueDiscordChannel: '',
 };
 
 describe('Automations selection helpers', () => {
@@ -754,15 +757,17 @@ describe('Automations selection helpers', () => {
     ).toBe(true);
   });
 
-  it('treats platform issue alerts as disabled without a selected Slack channel', () => {
+  it('treats platform issue alerts as disabled without a selected channel', () => {
     expect(
       isPlatformIssueAlertsEnabled({
         platformIssueSlackChannel: '',
+        platformIssueDiscordChannel: '',
       }),
     ).toBe(false);
     expect(
       isPlatformIssueAlertsEnabled({
         platformIssueSlackChannel: '   ',
+        platformIssueDiscordChannel: '   ',
       }),
     ).toBe(false);
   });
@@ -771,6 +776,16 @@ describe('Automations selection helpers', () => {
     expect(
       isPlatformIssueAlertsEnabled({
         platformIssueSlackChannel: 'C123',
+        platformIssueDiscordChannel: '',
+      }),
+    ).toBe(true);
+  });
+
+  it('treats platform issue alerts as enabled when a Discord channel is selected', () => {
+    expect(
+      isPlatformIssueAlertsEnabled({
+        platformIssueSlackChannel: '',
+        platformIssueDiscordChannel: '111222333444555666',
       }),
     ).toBe(true);
   });

--- a/apps/web/src/components/settings/automations/AutomationsSettings.render.client.test.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.render.client.test.tsx
@@ -517,7 +517,7 @@ describe('AutomationsSettings', () => {
     );
 
     expect(
-      screen.getByLabelText('Post alerts to this Slack channel'),
+      screen.getByLabelText('Post alerts to this channel'),
     ).toBeInTheDocument();
     expect(
       screen.getByText('#automation-reports (Discord)'),

--- a/apps/web/src/components/settings/automations/AutomationsSettings.render.client.test.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.render.client.test.tsx
@@ -82,13 +82,16 @@ const state = vi.hoisted(() => ({
         ciFailureTriageDiscordChannelId: null,
         suggesterFrequency: 'off' as const,
         suggesterSlackChannelId: null,
+        suggesterDiscordChannelId: null,
         suggesterInstructions: null,
         suggesterRoutingMode: 'manager_channel' as const,
         suggesterRoutingInstructions: null,
         announcerFrequency: 'off' as const,
         announcerSlackChannelId: null,
+        announcerDiscordChannelId: null,
         announcerInstructions: null,
         platformIssueSlackChannelId: null,
+        platformIssueDiscordChannelId: null,
       },
       slackChannelDisplayNames: {
         channelAutoStartSlackChannels: {
@@ -138,6 +141,7 @@ const state = vi.hoisted(() => ({
           'ci_failure_triage',
           'suggester',
           'announcer',
+          'platform_issue_alerts',
         ].map((key) => [
           key,
           {
@@ -373,6 +377,9 @@ describe('AutomationsSettings', () => {
     state.settingsQuery.data.capabilities.discordConnected = false;
     state.discordChannelsQuery.data.channels = [];
     state.settingsQuery.data.settings.managerStatsDiscordChannelId = null;
+    state.settingsQuery.data.settings.suggesterDiscordChannelId = null;
+    state.settingsQuery.data.settings.announcerDiscordChannelId = null;
+    state.settingsQuery.data.settings.platformIssueDiscordChannelId = null;
     state.settingsQuery.data.settings.managerSlackChannelId = 'C123MANAGER';
     state.settingsQuery.data.settings.managerStatsFrequency = 'off' as never;
     state.settingsQuery.data.settings.sentryTriageFrequency = 'off' as never;
@@ -486,6 +493,37 @@ describe('AutomationsSettings', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('offers the platform issue alerts destination picker with a saved Discord channel selected', async () => {
+    state.settingsQuery.data.capabilities.discordConnected = true;
+    state.discordChannelsQuery.data.channels = [
+      {
+        id: '111222333444555666',
+        name: 'automation-reports',
+        label: '#automation-reports',
+        guildId: 'guild-1',
+        guildName: 'Acme',
+      },
+    ];
+    (
+      state.settingsQuery.data.settings as Record<string, unknown>
+    ).platformIssueDiscordChannelId = '111222333444555666';
+
+    render(<AutomationsSettings />);
+
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: 'Expand Alert on Config Errors',
+      }),
+    );
+
+    expect(
+      screen.getByLabelText('Post alerts to this Slack channel'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('#automation-reports (Discord)'),
+    ).toBeInTheDocument();
+  });
+
   it('hides the launch mode picker when decision mode is disabled', async () => {
     render(<AutomationsSettings />);
 
@@ -533,9 +571,10 @@ describe('AutomationsSettings', () => {
     // Dependabot and CI failure triage stay GitHub-only; manager stats is
     // provider-neutral now and shows no source-control badge.
     expect((await screen.findAllByText('GitHub only')).length).toBe(2);
-    // Only the suggester is limited to Slack; CI failure triage posts to all
-    // configured communication providers after multi-comms support.
-    expect(screen.getAllByText('Slack only').length).toBe(1);
+    // The suggester supports Slack and Discord destinations; the other
+    // manager automations post to all configured communication providers.
+    expect(screen.queryByText('Slack only')).toBeNull();
+    expect(screen.getAllByText('Slack · Discord only').length).toBe(1);
     // conflict_resolver supports GitHub, GitLab, and Azure DevOps (no
     // Gitea/Bitbucket conflict signal).
     expect(

--- a/apps/web/src/components/settings/automations/AutomationsSettings.render.client.test.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.render.client.test.tsx
@@ -556,9 +556,7 @@ describe('AutomationsSettings', () => {
 
     expect(await screen.findByText('Summarize Merged PRs')).toBeInTheDocument();
     expect(
-      screen.getByText(
-        'Post a recurring digest of recently merged PRs to Slack.',
-      ),
+      screen.getByText('Post a recurring digest of recently merged PRs.'),
     ).toBeInTheDocument();
     expect(
       screen.getByText("Summary of Roomote's activity during the week"),

--- a/apps/web/src/components/settings/automations/AutomationsSettings.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.tsx
@@ -142,6 +142,9 @@ type FieldErrors = Partial<
     | 'securityAuditorDiscordChannel'
     | 'codeQualityAuditorDiscordChannel'
     | 'ciFailureTriageDiscordChannel'
+    | 'suggesterDiscordChannel'
+    | 'announcerDiscordChannel'
+    | 'platformIssueDiscordChannel'
     | 'sentryTriageProjectSlugs'
     | 'suggesterInstructions'
     | 'suggesterRoutingInstructions'
@@ -176,7 +179,10 @@ type AutomationSlackDestinationField =
   | 'dependabotTriageSlackChannel'
   | 'securityAuditorSlackChannel'
   | 'codeQualityAuditorSlackChannel'
-  | 'ciFailureTriageSlackChannel';
+  | 'ciFailureTriageSlackChannel'
+  | 'suggesterSlackChannel'
+  | 'announcerSlackChannel'
+  | 'platformIssueSlackChannel';
 
 const SLACK_DESTINATION_FIELD_AUTOMATION_KEYS = {
   managerStatsSlackChannel: 'manager_stats',
@@ -185,10 +191,25 @@ const SLACK_DESTINATION_FIELD_AUTOMATION_KEYS = {
   securityAuditorSlackChannel: 'security_auditor',
   codeQualityAuditorSlackChannel: 'code_quality_auditor',
   ciFailureTriageSlackChannel: 'ci_failure_triage',
+  suggesterSlackChannel: 'suggester',
+  announcerSlackChannel: 'announcer',
+  platformIssueSlackChannel: 'platform_issue_alerts',
 } as const satisfies Record<
   AutomationSlackDestinationField,
   BackgroundAutomationKey
 >;
+
+const SLACK_DESTINATION_FIELD_AUTOMATION_IDS = {
+  managerStatsSlackChannel: 'managerStats',
+  sentryTriageSlackChannel: 'sentryTriage',
+  dependabotTriageSlackChannel: 'dependabotTriage',
+  securityAuditorSlackChannel: 'securityAuditor',
+  codeQualityAuditorSlackChannel: 'codeQualityAuditor',
+  ciFailureTriageSlackChannel: 'ciFailureTriage',
+  suggesterSlackChannel: 'suggester',
+  announcerSlackChannel: 'announcer',
+  platformIssueSlackChannel: 'platformIssueAlerts',
+} as const satisfies Record<AutomationSlackDestinationField, AutomationId>;
 
 type AutomationDiscordDestinationField =
   | 'managerStatsDiscordChannel'
@@ -196,7 +217,10 @@ type AutomationDiscordDestinationField =
   | 'dependabotTriageDiscordChannel'
   | 'securityAuditorDiscordChannel'
   | 'codeQualityAuditorDiscordChannel'
-  | 'ciFailureTriageDiscordChannel';
+  | 'ciFailureTriageDiscordChannel'
+  | 'suggesterDiscordChannel'
+  | 'announcerDiscordChannel'
+  | 'platformIssueDiscordChannel';
 
 // The form field holding the same automation's Discord destination; the
 // destination picker is one-of, so selecting one provider clears the other.
@@ -207,6 +231,9 @@ const SLACK_TO_DISCORD_DESTINATION_FIELDS = {
   securityAuditorSlackChannel: 'securityAuditorDiscordChannel',
   codeQualityAuditorSlackChannel: 'codeQualityAuditorDiscordChannel',
   ciFailureTriageSlackChannel: 'ciFailureTriageDiscordChannel',
+  suggesterSlackChannel: 'suggesterDiscordChannel',
+  announcerSlackChannel: 'announcerDiscordChannel',
+  platformIssueSlackChannel: 'platformIssueDiscordChannel',
 } as const satisfies Record<
   AutomationSlackDestinationField,
   AutomationDiscordDestinationField
@@ -522,7 +549,8 @@ const AUTOMATION_DEFINITIONS: Record<AutomationId, AutomationDefinition> = {
   platformIssueAlerts: {
     id: 'platformIssueAlerts',
     label: 'Alert on Config Errors',
-    description: 'Alert on Slack when a task runs into admin-fixable issues.',
+    description:
+      'Alert on Slack or Discord when a task runs into admin-fixable issues.',
     icon: BellElectric,
   },
 };
@@ -689,15 +717,18 @@ function mapSettingsToFormState(
     suggesterFrequency: SuggesterFrequency;
     suggesterSlackChannelId: string | null;
     suggesterSlackChannelName?: string | null;
+    suggesterDiscordChannelId: string | null;
     suggesterInstructions: string | null;
     suggesterRoutingMode: SuggesterRoutingMode;
     suggesterRoutingInstructions: string | null;
     announcerFrequency: AnnouncerFrequency;
     announcerSlackChannelId: string | null;
     announcerSlackChannelName?: string | null;
+    announcerDiscordChannelId: string | null;
     announcerInstructions: string | null;
     platformIssueSlackChannelId: string | null;
     platformIssueSlackChannelName?: string | null;
+    platformIssueDiscordChannelId: string | null;
     securityAuditorSlackChannelId: string | null;
     securityAuditorSlackChannelName?: string | null;
     securityAuditorDiscordChannelId: string | null;
@@ -771,6 +802,7 @@ function mapSettingsToFormState(
       settings.suggesterSlackChannelName ??
       settings.suggesterSlackChannelId ??
       '',
+    suggesterDiscordChannel: settings.suggesterDiscordChannelId ?? '',
     suggesterInstructions: settings.suggesterInstructions ?? '',
     suggesterRoutingMode:
       settings.suggesterRoutingMode ?? DEFAULT_SUGGESTER_ROUTING_MODE,
@@ -780,11 +812,13 @@ function mapSettingsToFormState(
       settings.announcerSlackChannelName ??
       settings.announcerSlackChannelId ??
       '',
+    announcerDiscordChannel: settings.announcerDiscordChannelId ?? '',
     announcerInstructions: settings.announcerInstructions ?? '',
     platformIssueSlackChannel:
       settings.platformIssueSlackChannelName ??
       settings.platformIssueSlackChannelId ??
       '',
+    platformIssueDiscordChannel: settings.platformIssueDiscordChannelId ?? '',
     securityAuditorSlackChannel:
       settings.securityAuditorSlackChannelName ??
       settings.securityAuditorSlackChannelId ??
@@ -831,9 +865,18 @@ export function buildSlackWorkflowLaunchUrl(
 }
 
 export function isPlatformIssueAlertsEnabled(
-  formState: Pick<FormState, 'platformIssueSlackChannel'> | null | undefined,
+  formState:
+    | Pick<
+        FormState,
+        'platformIssueSlackChannel' | 'platformIssueDiscordChannel'
+      >
+    | null
+    | undefined,
 ): boolean {
-  return Boolean(formState?.platformIssueSlackChannel.trim());
+  return Boolean(
+    formState?.platformIssueSlackChannel.trim() ||
+    formState?.platformIssueDiscordChannel.trim(),
+  );
 }
 
 export function canSelectSentryTriageFrequency({
@@ -2312,20 +2355,7 @@ export function AutomationsSettings() {
               formValue: value,
               savedChannelId,
               warningChannelId,
-              isDirty:
-                isDirty[
-                  field === 'managerStatsSlackChannel'
-                    ? 'managerStats'
-                    : field === 'sentryTriageSlackChannel'
-                      ? 'sentryTriage'
-                      : field === 'dependabotTriageSlackChannel'
-                        ? 'dependabotTriage'
-                        : field === 'securityAuditorSlackChannel'
-                          ? 'securityAuditor'
-                          : field === 'codeQualityAuditorSlackChannel'
-                            ? 'codeQualityAuditor'
-                            : 'ciFailureTriage'
-                ],
+              isDirty: isDirty[SLACK_DESTINATION_FIELD_AUTOMATION_IDS[field]],
             })
           }
           error={fieldErrors[field] ?? fieldErrors[discordField]}
@@ -3322,11 +3352,21 @@ export function AutomationsSettings() {
                 <div className="space-y-5">
                   {!suggestionRoutingEnabled ? (
                     <>
-                      <AutomationReportsToLine
-                        destination={
-                          settingsQuery.data?.resolvedDestinations.suggester
-                        }
-                      />
+                      {renderSlackDestinationField({
+                        field: 'suggesterSlackChannel',
+                        inputId: 'suggester-slack-channel',
+                        label: 'Post suggestions to this Slack channel',
+                        helperText:
+                          'Choose where Roomote should post its suggestion digests.',
+                        savedChannelId:
+                          settingsQuery.data?.settings
+                            .suggesterSlackChannelId ?? null,
+                        savedDiscordChannelId:
+                          settingsQuery.data?.settings
+                            .suggesterDiscordChannelId ?? null,
+                        warningChannelId:
+                          slackChannelAccessWarnings.suggesterSlackChannel,
+                      })}
 
                       <div className="space-y-2">
                         <Label htmlFor="suggester-instructions">
@@ -3598,11 +3638,21 @@ If unclear, send to manager channel.`}
 
               {announcerIsEnabled ? (
                 <div className="space-y-5">
-                  <AutomationReportsToLine
-                    destination={
-                      settingsQuery.data?.resolvedDestinations.announcer
-                    }
-                  />
+                  {renderSlackDestinationField({
+                    field: 'announcerSlackChannel',
+                    inputId: 'announcer-slack-channel',
+                    label: 'Post summaries to this Slack channel',
+                    helperText:
+                      'Choose where Roomote should post merged-PR summaries.',
+                    savedChannelId:
+                      settingsQuery.data?.settings.announcerSlackChannelId ??
+                      null,
+                    savedDiscordChannelId:
+                      settingsQuery.data?.settings.announcerDiscordChannelId ??
+                      null,
+                    warningChannelId:
+                      slackChannelAccessWarnings.announcerSlackChannel,
+                  })}
 
                   <div className="space-y-2">
                     <Label htmlFor="announcer-instructions">
@@ -3964,6 +4014,44 @@ If unclear, send to manager channel.`}
                   </div>
                 </div>
               ) : null}
+            </div>
+          </AutomationCard>
+
+          <AutomationCard
+            automation={AUTOMATION_DEFINITIONS.platformIssueAlerts}
+            isOpen={openAutomationIds.has('platformIssueAlerts')}
+            onOpenChange={(open) =>
+              setAutomationOpen('platformIssueAlerts', open)
+            }
+            iconEnabled={iconEnabled.platformIssueAlerts}
+            footer={
+              <AutomationFooter
+                isDirty={isDirty.platformIssueAlerts}
+                isPending={
+                  updateMutation.isPending &&
+                  savingAutomation === 'platformIssueAlerts'
+                }
+                onSave={() => saveAgent('platformIssueAlerts')}
+                onReset={() => resetAgent('platformIssueAlerts')}
+              />
+            }
+          >
+            <div className="space-y-5">
+              {renderSlackDestinationField({
+                field: 'platformIssueSlackChannel',
+                inputId: 'platform-issue-slack-channel',
+                label: 'Post alerts to this Slack channel',
+                helperText:
+                  'Choose where Roomote should post configuration issues that need an admin. Leave empty to use the Manager Channel.',
+                savedChannelId:
+                  settingsQuery.data?.settings.platformIssueSlackChannelId ??
+                  null,
+                savedDiscordChannelId:
+                  settingsQuery.data?.settings.platformIssueDiscordChannelId ??
+                  null,
+                warningChannelId:
+                  slackChannelAccessWarnings.platformIssueSlackChannel,
+              })}
             </div>
           </AutomationCard>
 

--- a/apps/web/src/components/settings/automations/AutomationsSettings.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.tsx
@@ -2311,6 +2311,11 @@ export function AutomationsSettings() {
       const value = formState?.[field] ?? '';
       const discordValue = formState?.[discordField] ?? '';
       const showDiscordOptions = discordConnected || Boolean(discordValue);
+      // The historical labels say "Slack channel"; once Discord channels are
+      // offered in the same picker that wording reads as a bug.
+      const effectiveLabel = showDiscordOptions
+        ? label.replace(/ Slack channel$/u, ' channel')
+        : label;
       const options = [
         ...buildSlackDestinationOptions(value),
         ...(showDiscordOptions
@@ -2329,7 +2334,7 @@ export function AutomationsSettings() {
       return (
         <AutomationSlackDestinationInput
           inputId={inputId}
-          label={label}
+          label={effectiveLabel}
           helperText={helperText}
           value={selectedValue}
           options={options}

--- a/apps/web/src/components/settings/automations/AutomationsSettings.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.tsx
@@ -336,7 +336,7 @@ const CHANNEL_AUTO_START_LAUNCH_MODE_OPTIONS: ChannelAutoStartLaunchModeOption[]
 const TRIGGERABLE_AUTOMATION_DESCRIPTIONS = {
   conflict_resolver: 'Fix merge conflicts in open PRs.',
   suggester: 'Suggest valuable coding work to do.',
-  announcer: 'Post a recurring digest of recently merged PRs to Slack.',
+  announcer: 'Post a recurring digest of recently merged PRs.',
   manager_stats: "Summary of Roomote's activity during the week",
   sentry_triage: 'Scan Sentry issues and post a prioritized triage report.',
   dependabot_triage:

--- a/apps/web/src/components/settings/automations/AutomationsSettings.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.tsx
@@ -2347,8 +2347,7 @@ export function AutomationsSettings() {
           value={selectedValue}
           options={options}
           disabled={isManagerChannelSelectionDisabled({
-            slackConnected:
-              capabilities?.slackConnected === true || discordConnected,
+            slackConnected: slackConnected || discordConnected,
             isFetching:
               slackChannelsQuery.isFetching || discordChannelsQuery.isFetching,
             hasValue: Boolean(value.trim()) || Boolean(discordValue.trim()),
@@ -2400,7 +2399,7 @@ export function AutomationsSettings() {
     },
     [
       buildSlackDestinationOptions,
-      capabilities?.slackConnected,
+      slackConnected,
       discordChannelsQuery.data?.channels,
       discordChannelsQuery.isFetching,
       discordConnected,

--- a/apps/web/src/components/settings/automations/AutomationsSettings.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.tsx
@@ -1035,11 +1035,17 @@ export function buildManagerSlackChannelOptions(params: {
 export function buildAutomationDiscordDestinationOptions(params: {
   channels: Array<{ id: string; name: string; label: string }>;
   selectedChannelId: string | null | undefined;
+  /**
+   * The "(Discord)" suffix only disambiguates when Slack channels can appear
+   * in the same picker; on a Discord-only deployment it is noise.
+   */
+  includeProviderSuffix: boolean;
 }): SlackChannelOption[] {
+  const suffix = params.includeProviderSuffix ? ' (Discord)' : '';
   const options = params.channels.map((channel) => ({
     id: `${DISCORD_DESTINATION_OPTION_PREFIX}${channel.id}`,
     name: channel.name,
-    label: `${channel.label} (Discord)`,
+    label: `${channel.label}${suffix}`,
   }));
 
   const selectedChannelId = params.selectedChannelId?.trim();
@@ -1060,7 +1066,7 @@ export function buildAutomationDiscordDestinationOptions(params: {
     {
       id: selectedOptionId,
       name: selectedChannelId!,
-      label: `#${selectedChannelId} (Discord)`,
+      label: `#${selectedChannelId}${suffix}`,
     },
     ...options,
   ];
@@ -2289,6 +2295,7 @@ export function AutomationsSettings() {
     [slackChannelChoices],
   );
   const discordConnected = capabilities?.discordConnected === true;
+  const slackConnected = capabilities?.slackConnected === true;
   const renderSlackDestinationField = useCallback(
     ({
       field,
@@ -2322,6 +2329,7 @@ export function AutomationsSettings() {
           ? buildAutomationDiscordDestinationOptions({
               channels: discordChannelsQuery.data?.channels ?? [],
               selectedChannelId: discordValue || null,
+              includeProviderSuffix: slackConnected,
             })
           : []),
       ];

--- a/apps/web/src/components/settings/automations/formState.ts
+++ b/apps/web/src/components/settings/automations/formState.ts
@@ -73,13 +73,16 @@ export type FormState = {
   dependabotTriageDiscordChannel: string;
   suggesterFrequency: SuggesterFrequency;
   suggesterSlackChannel: string;
+  suggesterDiscordChannel: string;
   suggesterInstructions: string;
   suggesterRoutingMode: SuggesterRoutingMode;
   suggesterRoutingInstructions: string;
   announcerFrequency: AnnouncerFrequency;
   announcerSlackChannel: string;
+  announcerDiscordChannel: string;
   announcerInstructions: string;
   platformIssueSlackChannel: string;
+  platformIssueDiscordChannel: string;
   securityAuditorSlackChannel: string;
   securityAuditorDiscordChannel: string;
   codeQualityAuditorSlackChannel: string;
@@ -150,6 +153,7 @@ const DEPENDABOT_TRIAGE_FIELDS: Array<keyof FormState> = [
 const SUGGESTER_FIELDS: Array<keyof FormState> = [
   'suggesterFrequency',
   'suggesterSlackChannel',
+  'suggesterDiscordChannel',
   'suggesterInstructions',
   'suggesterRoutingMode',
   'suggesterRoutingInstructions',
@@ -158,11 +162,13 @@ const SUGGESTER_FIELDS: Array<keyof FormState> = [
 const ANNOUNCER_FIELDS: Array<keyof FormState> = [
   'announcerFrequency',
   'announcerSlackChannel',
+  'announcerDiscordChannel',
   'announcerInstructions',
 ];
 
 const PLATFORM_ISSUE_ALERT_FIELDS: Array<keyof FormState> = [
   'platformIssueSlackChannel',
+  'platformIssueDiscordChannel',
 ];
 
 const SCHEDULE_ONLY_AUTOMATION_FIELDS = Object.fromEntries(
@@ -311,15 +317,19 @@ export function buildAutomationSettingsSaveInput(
     ...buildScheduleOnlyAutomationSaveInput(stateToSave),
     suggesterFrequency: stateToSave.suggesterFrequency,
     suggesterSlackChannel: stateToSave.suggesterSlackChannel.trim() || null,
+    suggesterDiscordChannel: stateToSave.suggesterDiscordChannel.trim() || null,
     suggesterInstructions: stateToSave.suggesterInstructions.trim() || null,
     suggesterRoutingMode: stateToSave.suggesterRoutingMode,
     suggesterRoutingInstructions:
       stateToSave.suggesterRoutingInstructions.trim() || null,
     announcerFrequency: stateToSave.announcerFrequency,
     announcerSlackChannel: stateToSave.announcerSlackChannel.trim() || null,
+    announcerDiscordChannel: stateToSave.announcerDiscordChannel.trim() || null,
     announcerInstructions: stateToSave.announcerInstructions.trim() || null,
     platformIssueSlackChannel:
       stateToSave.platformIssueSlackChannel.trim() || null,
+    platformIssueDiscordChannel:
+      stateToSave.platformIssueDiscordChannel.trim() || null,
     securityAuditorSlackChannel:
       stateToSave.securityAuditorSlackChannel.trim() || null,
     securityAuditorDiscordChannel:

--- a/apps/web/src/trpc/commands/automations/__tests__/settings-update-discord.test.ts
+++ b/apps/web/src/trpc/commands/automations/__tests__/settings-update-discord.test.ts
@@ -476,6 +476,44 @@ describe('updateBackgroundAgentSettingsCommand Discord destinations', () => {
     }
   }, 15_000);
 
+  it('preserves a Discord target when an older client omits the optional field on a same-automation save', async () => {
+    await insertAvailableDiscordChannel({
+      guildId: 'guild-1',
+      channelId: 'D111',
+      channelName: 'automation-reports',
+    });
+
+    // A new client selects a Discord destination for platform issue alerts.
+    const first = await updateBackgroundAgentSettingsCommand(
+      adminAuth,
+      buildInput({
+        savingAutomation: 'platformIssueAlerts',
+        platformIssueDiscordChannel: 'D111',
+      }),
+    );
+    expect(first.success).toBe(true);
+
+    // An older client (deployed before the field existed) re-saves the same
+    // automation without ever sending platformIssueDiscordChannel. Omission
+    // must preserve the target, not clear it and disable the automation.
+    const input = buildInput({ savingAutomation: 'platformIssueAlerts' });
+    delete (input as Record<string, unknown>).platformIssueDiscordChannel;
+    const second = await updateBackgroundAgentSettingsCommand(adminAuth, input);
+
+    expect(second.success).toBe(true);
+    expect(await getAutomationTargets('platform_issue_alerts')).toEqual([
+      {
+        provider: 'discord',
+        targetKind: 'discord_channel',
+        externalRef: 'D111',
+      },
+    ]);
+    const automation = await db.query.automations.findFirst({
+      where: eq(automations.key, 'platform_issue_alerts'),
+    });
+    expect(automation?.enabled).toBe(true);
+  }, 15_000);
+
   it('preserves suggester, announcer, and platform issue Discord targets when saving an unrelated automation', async () => {
     await insertSlackInstallation();
     await insertAvailableDiscordChannel({

--- a/apps/web/src/trpc/commands/automations/__tests__/settings-update-discord.test.ts
+++ b/apps/web/src/trpc/commands/automations/__tests__/settings-update-discord.test.ts
@@ -497,7 +497,8 @@ describe('updateBackgroundAgentSettingsCommand Discord destinations', () => {
     // automation without ever sending platformIssueDiscordChannel. Omission
     // must preserve the target, not clear it and disable the automation.
     const input = buildInput({ savingAutomation: 'platformIssueAlerts' });
-    delete (input as Record<string, unknown>).platformIssueDiscordChannel;
+    delete (input as unknown as Record<string, unknown>)
+      .platformIssueDiscordChannel;
     const second = await updateBackgroundAgentSettingsCommand(adminAuth, input);
 
     expect(second.success).toBe(true);

--- a/apps/web/src/trpc/commands/automations/__tests__/settings-update-discord.test.ts
+++ b/apps/web/src/trpc/commands/automations/__tests__/settings-update-discord.test.ts
@@ -108,13 +108,16 @@ function buildInput(
     ciFailureTriageDiscordChannel: null,
     suggesterFrequency: 'off',
     suggesterSlackChannel: null,
+    suggesterDiscordChannel: null,
     suggesterInstructions: null,
     suggesterRoutingMode: 'manager_channel',
     suggesterRoutingInstructions: null,
     announcerFrequency: 'off',
     announcerSlackChannel: null,
+    announcerDiscordChannel: null,
     announcerInstructions: null,
     platformIssueSlackChannel: null,
+    platformIssueDiscordChannel: null,
     ...overrides,
   };
 }
@@ -345,5 +348,188 @@ describe('updateBackgroundAgentSettingsCommand Discord destinations', () => {
         externalRef: 'D222',
       },
     ]);
+  }, 15_000);
+
+  it('writes a suggester discord_channel target and clears its Slack one', async () => {
+    await insertAvailableDiscordChannel({
+      guildId: 'guild-1',
+      channelId: 'D111',
+      channelName: 'automation-reports',
+    });
+    await upsertAutomation(db, {
+      key: 'suggester',
+      enabled: true,
+      schedule: { mode: 'daily' },
+      targets: [
+        {
+          provider: 'slack',
+          targetKind: 'slack_channel',
+          externalRef: 'C123OLD',
+        },
+      ],
+    });
+
+    const result = await updateBackgroundAgentSettingsCommand(
+      adminAuth,
+      buildInput({
+        savingAutomation: 'suggester',
+        suggesterFrequency: 'daily',
+        suggesterDiscordChannel: 'D111',
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(await getAutomationTargets('suggester')).toEqual([
+      {
+        provider: 'discord',
+        targetKind: 'discord_channel',
+        externalRef: 'D111',
+      },
+    ]);
+
+    if (result.success) {
+      expect(result.settings.suggesterDiscordChannelId).toBe('D111');
+      expect(result.settings.suggesterSlackChannelId).toBeNull();
+    }
+  }, 15_000);
+
+  it('writes an announcer slack_channel target and clears its Discord one', async () => {
+    await insertSlackInstallation();
+    await insertAvailableDiscordChannel({
+      guildId: 'guild-1',
+      channelId: 'D111',
+      channelName: 'automation-reports',
+    });
+    await upsertAutomation(db, {
+      key: 'announcer',
+      enabled: true,
+      schedule: { mode: 'weekly' },
+      targets: [
+        {
+          provider: 'discord',
+          targetKind: 'discord_channel',
+          externalRef: 'D111',
+        },
+      ],
+    });
+
+    const result = await updateBackgroundAgentSettingsCommand(
+      adminAuth,
+      buildInput({
+        savingAutomation: 'announcer',
+        announcerFrequency: 'weekly',
+        announcerSlackChannel: 'C123456NEW',
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(await getAutomationTargets('announcer')).toEqual([
+      {
+        provider: 'slack',
+        targetKind: 'slack_channel',
+        externalRef: 'C123456NEW',
+      },
+    ]);
+
+    if (result.success) {
+      expect(result.settings.announcerSlackChannelId).toBe('C123456NEW');
+      expect(result.settings.announcerDiscordChannelId).toBeNull();
+    }
+  }, 15_000);
+
+  it('enables platform issue alerts with a Discord destination and prefers Discord over a submitted Slack channel', async () => {
+    await insertAvailableDiscordChannel({
+      guildId: 'guild-1',
+      channelId: 'D111',
+      channelName: 'automation-reports',
+    });
+
+    const result = await updateBackgroundAgentSettingsCommand(
+      adminAuth,
+      buildInput({
+        savingAutomation: 'platformIssueAlerts',
+        // Server-side one-of backstop: when both somehow arrive, Discord
+        // wins and the Slack value is dropped.
+        platformIssueSlackChannel: 'C123456NEW',
+        platformIssueDiscordChannel: 'D111',
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(await getAutomationTargets('platform_issue_alerts')).toEqual([
+      {
+        provider: 'discord',
+        targetKind: 'discord_channel',
+        externalRef: 'D111',
+      },
+    ]);
+
+    const automation = await db.query.automations.findFirst({
+      where: eq(automations.key, 'platform_issue_alerts'),
+    });
+
+    expect(automation?.enabled).toBe(true);
+
+    if (result.success) {
+      expect(result.settings.platformIssueDiscordChannelId).toBe('D111');
+      expect(result.settings.platformIssueSlackChannelId).toBeNull();
+    }
+  }, 15_000);
+
+  it('preserves suggester, announcer, and platform issue Discord targets when saving an unrelated automation', async () => {
+    await insertSlackInstallation();
+    await insertAvailableDiscordChannel({
+      guildId: 'guild-1',
+      channelId: 'D111',
+      channelName: 'automation-reports',
+    });
+
+    for (const key of [
+      'suggester',
+      'announcer',
+      'platform_issue_alerts',
+    ] as const) {
+      await upsertAutomation(db, {
+        key,
+        enabled: true,
+        ...(key === 'platform_issue_alerts'
+          ? {}
+          : { schedule: { mode: 'daily' } }),
+        targets: [
+          {
+            provider: 'discord',
+            targetKind: 'discord_channel',
+            externalRef: 'D111',
+          },
+        ],
+      });
+    }
+
+    const result = await updateBackgroundAgentSettingsCommand(
+      adminAuth,
+      buildInput({
+        savingAutomation: 'managerStats',
+        managerStatsFrequency: 'weekly',
+        managerStatsSlackChannel: 'C123456NEW',
+        suggesterFrequency: 'daily',
+        announcerFrequency: 'daily',
+      }),
+    );
+
+    expect(result.success).toBe(true);
+
+    for (const key of [
+      'suggester',
+      'announcer',
+      'platform_issue_alerts',
+    ] as const) {
+      expect(await getAutomationTargets(key)).toEqual([
+        {
+          provider: 'discord',
+          targetKind: 'discord_channel',
+          externalRef: 'D111',
+        },
+      ]);
+    }
   }, 15_000);
 });

--- a/apps/web/src/trpc/commands/automations/__tests__/settings-update-discord.test.ts
+++ b/apps/web/src/trpc/commands/automations/__tests__/settings-update-discord.test.ts
@@ -515,6 +515,44 @@ describe('updateBackgroundAgentSettingsCommand Discord destinations', () => {
     expect(automation?.enabled).toBe(true);
   }, 15_000);
 
+  it('clears the Discord target when a legacy client explicitly selects a Slack channel', async () => {
+    await insertSlackInstallation();
+    await insertAvailableDiscordChannel({
+      guildId: 'guild-1',
+      channelId: 'D111',
+      channelName: 'automation-reports',
+    });
+    const first = await updateBackgroundAgentSettingsCommand(
+      adminAuth,
+      buildInput({
+        savingAutomation: 'platformIssueAlerts',
+        platformIssueDiscordChannel: 'D111',
+      }),
+    );
+    expect(first.success).toBe(true);
+
+    // A pre-deploy client cannot send the Discord field, but choosing a
+    // Slack channel is an explicit destination choice: it must clear the
+    // Discord target rather than leaving both stored (a later current-client
+    // save would otherwise silently flip routing back to Discord).
+    const input = buildInput({
+      savingAutomation: 'platformIssueAlerts',
+      platformIssueSlackChannel: 'C123456NEW',
+    });
+    delete (input as unknown as Record<string, unknown>)
+      .platformIssueDiscordChannel;
+    const second = await updateBackgroundAgentSettingsCommand(adminAuth, input);
+
+    expect(second.success).toBe(true);
+    expect(await getAutomationTargets('platform_issue_alerts')).toEqual([
+      {
+        provider: 'slack',
+        targetKind: 'slack_channel',
+        externalRef: 'C123456NEW',
+      },
+    ]);
+  }, 15_000);
+
   it('preserves suggester, announcer, and platform issue Discord targets when saving an unrelated automation', async () => {
     await insertSlackInstallation();
     await insertAvailableDiscordChannel({

--- a/apps/web/src/trpc/commands/automations/settings-update.ts
+++ b/apps/web/src/trpc/commands/automations/settings-update.ts
@@ -114,20 +114,6 @@ function buildSuggesterAutomationSettings(params: {
   };
 }
 
-function buildSlackChannelTargets(
-  channelId: string | null,
-): AutomationTarget[] {
-  return channelId
-    ? [
-        {
-          provider: 'slack',
-          targetKind: 'slack_channel',
-          externalRef: channelId,
-        },
-      ]
-    : [];
-}
-
 /**
  * Channel targets for automations whose destination picker offers a Slack OR
  * a Discord channel. Combined with
@@ -388,6 +374,15 @@ export async function updateBackgroundAgentSettingsCommand(
   const ciFailureTriageDiscordChannel = shouldUpdateCiFailureTriage
     ? normalizeOptionalText(input.ciFailureTriageDiscordChannel)
     : null;
+  const suggesterDiscordChannel = shouldUpdateSuggester
+    ? normalizeOptionalText(input.suggesterDiscordChannel)
+    : null;
+  const announcerDiscordChannel = shouldUpdateAnnouncer
+    ? normalizeOptionalText(input.announcerDiscordChannel)
+    : null;
+  const platformIssueDiscordChannel = shouldUpdatePlatformIssueAlerts
+    ? normalizeOptionalText(input.platformIssueDiscordChannel)
+    : null;
   const managerStatsSlackChannel =
     shouldUpdateManagerStats && !managerStatsDiscordChannel
       ? normalizeOptionalText(input.managerStatsSlackChannel)
@@ -400,15 +395,18 @@ export async function updateBackgroundAgentSettingsCommand(
     shouldUpdateDependabotTriage && !dependabotTriageDiscordChannel
       ? normalizeOptionalText(input.dependabotTriageSlackChannel)
       : null;
-  const suggesterSlackChannel = shouldUpdateSuggester
-    ? normalizeOptionalText(input.suggesterSlackChannel)
-    : null;
-  const announcerSlackChannel = shouldUpdateAnnouncer
-    ? normalizeOptionalText(input.announcerSlackChannel)
-    : null;
-  const platformIssueSlackChannel = shouldUpdatePlatformIssueAlerts
-    ? normalizeOptionalText(input.platformIssueSlackChannel)
-    : null;
+  const suggesterSlackChannel =
+    shouldUpdateSuggester && !suggesterDiscordChannel
+      ? normalizeOptionalText(input.suggesterSlackChannel)
+      : null;
+  const announcerSlackChannel =
+    shouldUpdateAnnouncer && !announcerDiscordChannel
+      ? normalizeOptionalText(input.announcerSlackChannel)
+      : null;
+  const platformIssueSlackChannel =
+    shouldUpdatePlatformIssueAlerts && !platformIssueDiscordChannel
+      ? normalizeOptionalText(input.platformIssueSlackChannel)
+      : null;
   const securityAuditorSlackChannel =
     shouldUpdateSecurityAuditor && !securityAuditorDiscordChannel
       ? normalizeOptionalText(input.securityAuditorSlackChannel)
@@ -593,6 +591,9 @@ export async function updateBackgroundAgentSettingsCommand(
     securityAuditorDiscordResult,
     codeQualityAuditorDiscordResult,
     ciFailureTriageDiscordResult,
+    suggesterDiscordResult,
+    announcerDiscordResult,
+    platformIssueDiscordResult,
   ] = await Promise.all([
     shouldUpdateManagerStats
       ? resolveDiscordChannelId({
@@ -642,6 +643,30 @@ export async function updateBackgroundAgentSettingsCommand(
       : keepPersistedDiscordChannel(
           existingSettings?.ciFailureTriageDiscordChannelId,
         ),
+    shouldUpdateSuggester
+      ? resolveDiscordChannelId({
+          field: 'suggesterDiscordChannel',
+          input: suggesterDiscordChannel,
+        })
+      : keepPersistedDiscordChannel(
+          existingSettings?.suggesterDiscordChannelId,
+        ),
+    shouldUpdateAnnouncer
+      ? resolveDiscordChannelId({
+          field: 'announcerDiscordChannel',
+          input: announcerDiscordChannel,
+        })
+      : keepPersistedDiscordChannel(
+          existingSettings?.announcerDiscordChannelId,
+        ),
+    shouldUpdatePlatformIssueAlerts
+      ? resolveDiscordChannelId({
+          field: 'platformIssueDiscordChannel',
+          input: platformIssueDiscordChannel,
+        })
+      : keepPersistedDiscordChannel(
+          existingSettings?.platformIssueDiscordChannelId,
+        ),
   ]);
 
   for (const result of [
@@ -651,6 +676,9 @@ export async function updateBackgroundAgentSettingsCommand(
     securityAuditorDiscordResult,
     codeQualityAuditorDiscordResult,
     ciFailureTriageDiscordResult,
+    suggesterDiscordResult,
+    announcerDiscordResult,
+    platformIssueDiscordResult,
   ]) {
     if (result.error) {
       fieldErrors[result.error.field] = result.error.message;
@@ -826,20 +854,22 @@ export async function updateBackgroundAgentSettingsCommand(
       | 'suggesterSlackChannel'
       | 'announcerSlackChannel';
   }> = [
+    // A per-automation Discord destination satisfies the channel requirement
+    // just like a per-automation Slack channel does.
     {
       key: 'suggester',
       frequency: effectiveSuggesterFrequency,
-      channelId: suggesterChannelResult.channelId,
+      channelId:
+        suggesterChannelResult.channelId ?? suggesterDiscordResult.channelId,
       field: 'suggesterSlackChannel',
     },
     {
       key: 'announcer',
       frequency: effectiveAnnouncerFrequency,
-      channelId: announcerChannelResult.channelId,
+      channelId:
+        announcerChannelResult.channelId ?? announcerDiscordResult.channelId,
       field: 'announcerSlackChannel',
     },
-    // A per-automation Discord destination satisfies the channel requirement
-    // just like a per-automation Slack channel does.
     {
       key: 'manager_stats',
       frequency: effectiveManagerStatsFrequency,
@@ -1127,8 +1157,11 @@ export async function updateBackgroundAgentSettingsCommand(
       },
       instructions: effectiveSuggesterInstructions,
       settings: suggesterAutomationSettings,
-      targets: buildSlackChannelTargets(suggesterChannelResult.channelId),
-      managedTargetKinds: ['slack_channel'],
+      targets: buildDestinationChannelTargets(
+        suggesterChannelResult.channelId,
+        suggesterDiscordResult.channelId,
+      ),
+      managedTargetKinds: ['slack_channel', 'discord_channel'],
       updatedAt: now,
     });
 
@@ -1139,16 +1172,24 @@ export async function updateBackgroundAgentSettingsCommand(
         mode: effectiveAnnouncerFrequency,
       },
       instructions: normalizeOptionalText(input.announcerInstructions),
-      targets: buildSlackChannelTargets(announcerChannelResult.channelId),
-      managedTargetKinds: ['slack_channel'],
+      targets: buildDestinationChannelTargets(
+        announcerChannelResult.channelId,
+        announcerDiscordResult.channelId,
+      ),
+      managedTargetKinds: ['slack_channel', 'discord_channel'],
       updatedAt: now,
     });
 
     await upsertAutomation(tx, {
       key: 'platform_issue_alerts',
-      enabled: platformIssueChannelResult.channelId != null,
-      targets: buildSlackChannelTargets(platformIssueChannelResult.channelId),
-      managedTargetKinds: ['slack_channel'],
+      enabled:
+        platformIssueChannelResult.channelId != null ||
+        platformIssueDiscordResult.channelId != null,
+      targets: buildDestinationChannelTargets(
+        platformIssueChannelResult.channelId,
+        platformIssueDiscordResult.channelId,
+      ),
+      managedTargetKinds: ['slack_channel', 'discord_channel'],
       updatedAt: now,
     });
   });

--- a/apps/web/src/trpc/commands/automations/settings-update.ts
+++ b/apps/web/src/trpc/commands/automations/settings-update.ts
@@ -376,12 +376,20 @@ export async function updateBackgroundAgentSettingsCommand(
     : null;
   // These three Discord fields are optional in the API for deploy
   // compatibility: an older client that never sends them must preserve the
-  // persisted target, not clear it. Only an explicitly submitted value (set
-  // or null) goes through resolution below.
-  const suggesterDiscordProvided = input.suggesterDiscordChannel !== undefined;
-  const announcerDiscordProvided = input.announcerDiscordChannel !== undefined;
+  // persisted target, not clear it — UNLESS that client explicitly selected
+  // a Slack channel, which is a destination choice and must clear the
+  // Discord target it cannot see (otherwise both targets persist and a later
+  // current-client save would silently flip routing back to Discord). An
+  // empty Slack value expresses no choice and preserves the Discord target.
+  const suggesterDiscordProvided =
+    input.suggesterDiscordChannel !== undefined ||
+    normalizeOptionalText(input.suggesterSlackChannel) !== null;
+  const announcerDiscordProvided =
+    input.announcerDiscordChannel !== undefined ||
+    normalizeOptionalText(input.announcerSlackChannel) !== null;
   const platformIssueDiscordProvided =
-    input.platformIssueDiscordChannel !== undefined;
+    input.platformIssueDiscordChannel !== undefined ||
+    normalizeOptionalText(input.platformIssueSlackChannel) !== null;
   const suggesterDiscordChannel = shouldUpdateSuggester
     ? normalizeOptionalText(input.suggesterDiscordChannel)
     : null;

--- a/apps/web/src/trpc/commands/automations/settings-update.ts
+++ b/apps/web/src/trpc/commands/automations/settings-update.ts
@@ -374,6 +374,14 @@ export async function updateBackgroundAgentSettingsCommand(
   const ciFailureTriageDiscordChannel = shouldUpdateCiFailureTriage
     ? normalizeOptionalText(input.ciFailureTriageDiscordChannel)
     : null;
+  // These three Discord fields are optional in the API for deploy
+  // compatibility: an older client that never sends them must preserve the
+  // persisted target, not clear it. Only an explicitly submitted value (set
+  // or null) goes through resolution below.
+  const suggesterDiscordProvided = input.suggesterDiscordChannel !== undefined;
+  const announcerDiscordProvided = input.announcerDiscordChannel !== undefined;
+  const platformIssueDiscordProvided =
+    input.platformIssueDiscordChannel !== undefined;
   const suggesterDiscordChannel = shouldUpdateSuggester
     ? normalizeOptionalText(input.suggesterDiscordChannel)
     : null;
@@ -643,7 +651,7 @@ export async function updateBackgroundAgentSettingsCommand(
       : keepPersistedDiscordChannel(
           existingSettings?.ciFailureTriageDiscordChannelId,
         ),
-    shouldUpdateSuggester
+    shouldUpdateSuggester && suggesterDiscordProvided
       ? resolveDiscordChannelId({
           field: 'suggesterDiscordChannel',
           input: suggesterDiscordChannel,
@@ -651,7 +659,7 @@ export async function updateBackgroundAgentSettingsCommand(
       : keepPersistedDiscordChannel(
           existingSettings?.suggesterDiscordChannelId,
         ),
-    shouldUpdateAnnouncer
+    shouldUpdateAnnouncer && announcerDiscordProvided
       ? resolveDiscordChannelId({
           field: 'announcerDiscordChannel',
           input: announcerDiscordChannel,
@@ -659,7 +667,7 @@ export async function updateBackgroundAgentSettingsCommand(
       : keepPersistedDiscordChannel(
           existingSettings?.announcerDiscordChannelId,
         ),
-    shouldUpdatePlatformIssueAlerts
+    shouldUpdatePlatformIssueAlerts && platformIssueDiscordProvided
       ? resolveDiscordChannelId({
           field: 'platformIssueDiscordChannel',
           input: platformIssueDiscordChannel,

--- a/apps/web/src/trpc/commands/automations/types.ts
+++ b/apps/web/src/trpc/commands/automations/types.ts
@@ -43,6 +43,9 @@ export type BackgroundAgentFieldErrorKey =
   | 'securityAuditorDiscordChannel'
   | 'codeQualityAuditorDiscordChannel'
   | 'ciFailureTriageDiscordChannel'
+  | 'suggesterDiscordChannel'
+  | 'announcerDiscordChannel'
+  | 'platformIssueDiscordChannel'
   | 'sentryTriageProjectSlugs'
   | 'suggesterInstructions'
   | 'suggesterRoutingInstructions'
@@ -75,6 +78,9 @@ export type DiscordChannelFieldErrorKey = Extract<
   | 'securityAuditorDiscordChannel'
   | 'codeQualityAuditorDiscordChannel'
   | 'ciFailureTriageDiscordChannel'
+  | 'suggesterDiscordChannel'
+  | 'announcerDiscordChannel'
+  | 'platformIssueDiscordChannel'
 >;
 
 /** A Discord channel the automations destination picker can target. */
@@ -117,6 +123,9 @@ export interface SlackChannelDisplayNames {
 /**
  * Automations whose reports flow through the manager-channel destination
  * waterfall (own target -> Manager Channel -> primary conversation).
+ * platform_issue_alerts delivery only walks the first two levels (own
+ * target -> Manager Channel); it is included so the settings page can show
+ * its "Reports to" line.
  */
 export const MANAGER_REPORTING_AUTOMATION_KEYS = [
   'manager_stats',
@@ -127,6 +136,7 @@ export const MANAGER_REPORTING_AUTOMATION_KEYS = [
   'ci_failure_triage',
   'suggester',
   'announcer',
+  'platform_issue_alerts',
 ] as const satisfies readonly BackgroundAutomationKey[];
 
 export type ManagerReportingAutomationKey =
@@ -221,13 +231,16 @@ export interface UpdateBackgroundAgentSettingsInput extends ScheduleOnlyAutomati
   dependabotTriageDiscordChannel?: string | null;
   suggesterFrequency: SuggesterFrequency;
   suggesterSlackChannel: string | null;
+  suggesterDiscordChannel?: string | null;
   suggesterInstructions: string | null;
   suggesterRoutingMode?: SuggesterRoutingMode;
   suggesterRoutingInstructions?: string | null;
   announcerFrequency: AnnouncerFrequency;
   announcerSlackChannel: string | null;
+  announcerDiscordChannel?: string | null;
   announcerInstructions: string | null;
   platformIssueSlackChannel: string | null;
+  platformIssueDiscordChannel?: string | null;
   securityAuditorSlackChannel?: string | null;
   securityAuditorDiscordChannel?: string | null;
   codeQualityAuditorSlackChannel?: string | null;

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -461,13 +461,34 @@ const automationsRouter = createRouter({
         ...SCHEDULE_ONLY_FREQUENCY_FIELD_SHAPE,
         suggesterFrequency: z.enum(['off', 'daily', 'weekly']),
         suggesterSlackChannel: z.string().trim().min(1).max(160).nullable(),
+        suggesterDiscordChannel: z
+          .string()
+          .trim()
+          .min(1)
+          .max(160)
+          .nullable()
+          .optional(),
         suggesterInstructions: z.string().max(10_000).nullable(),
         suggesterRoutingMode: z.enum(SUGGESTER_ROUTING_MODES),
         suggesterRoutingInstructions: z.string().max(10_000).nullable(),
         announcerFrequency: z.enum(['off', 'daily', 'weekly']),
         announcerSlackChannel: z.string().trim().min(1).max(160).nullable(),
+        announcerDiscordChannel: z
+          .string()
+          .trim()
+          .min(1)
+          .max(160)
+          .nullable()
+          .optional(),
         announcerInstructions: z.string().max(8_000).nullable(),
         platformIssueSlackChannel: z.string().trim().min(1).max(160).nullable(),
+        platformIssueDiscordChannel: z
+          .string()
+          .trim()
+          .min(1)
+          .max(160)
+          .nullable()
+          .optional(),
         securityAuditorSlackChannel: z
           .string()
           .trim()

--- a/packages/db/src/lib/automations.ts
+++ b/packages/db/src/lib/automations.ts
@@ -714,6 +714,7 @@ export function normalizeBackgroundAgentSettings(
       isFrequencyOf(SUGGESTER_FREQUENCIES),
     ),
     suggesterSlackChannelId: getAutomationSlackChannelTarget(suggester),
+    suggesterDiscordChannelId: getAutomationDiscordChannelTarget(suggester),
     suggesterInstructions: suggester?.instructions ?? null,
     suggesterRoutingMode: getSuggesterRoutingMode(suggester),
     suggesterRoutingInstructions: getAutomationSettingText(
@@ -727,6 +728,7 @@ export function normalizeBackgroundAgentSettings(
       isFrequencyOf(ANNOUNCER_FREQUENCIES),
     ),
     announcerSlackChannelId: getAutomationSlackChannelTarget(announcer),
+    announcerDiscordChannelId: getAutomationDiscordChannelTarget(announcer),
     announcerInstructions: announcer?.instructions ?? null,
     announcerLastRunAt: announcer?.lastRunAt ?? null,
 
@@ -741,6 +743,8 @@ export function normalizeBackgroundAgentSettings(
 
     platformIssueSlackChannelId:
       getAutomationSlackChannelTarget(platformIssueAlerts),
+    platformIssueDiscordChannelId:
+      getAutomationDiscordChannelTarget(platformIssueAlerts),
 
     managerStatsFrequency: getAutomationFrequency(
       managerStats,

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -460,15 +460,18 @@ export type BackgroundAgentSettings = StoredBackgroundAgentSettings & {
   conflictResolverLastRunAt: Date | null;
   suggesterFrequency: SuggesterFrequency;
   suggesterSlackChannelId: string | null;
+  suggesterDiscordChannelId: string | null;
   suggesterInstructions: string | null;
   suggesterRoutingMode: SuggesterRoutingMode;
   suggesterRoutingInstructions: string | null;
   suggesterLastRunAt: Date | null;
   announcerFrequency: AnnouncerFrequency;
   announcerSlackChannelId: string | null;
+  announcerDiscordChannelId: string | null;
   announcerInstructions: string | null;
   announcerLastRunAt: Date | null;
   platformIssueSlackChannelId: string | null;
+  platformIssueDiscordChannelId: string | null;
   managerStatsFrequency: ManagerStatsFrequency;
   managerStatsSlackChannelId: string | null;
   managerStatsDiscordChannelId: string | null;

--- a/packages/sdk/src/server/lib/task-runs/__tests__/platform-issue-alert-delivery.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/platform-issue-alert-delivery.test.ts
@@ -1,0 +1,255 @@
+const {
+  mockCreateDiscordProvider,
+  mockDiscordPostMessage,
+  mockSlackPostMessage,
+} = vi.hoisted(() => ({
+  mockCreateDiscordProvider: vi.fn(),
+  mockDiscordPostMessage: vi.fn(),
+  mockSlackPostMessage: vi.fn(),
+}));
+
+vi.mock('../../discord-communication', () => ({
+  createDiscordCommunicationProviderFromRuntimeCredentials:
+    mockCreateDiscordProvider,
+}));
+
+// Keep the test hermetic: the Slack fallback path constructs a SlackNotifier
+// from the active installation and posts the alert through it.
+vi.mock('@roomote/slack', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@roomote/slack')>();
+
+  class MockSlackNotifier {
+    constructor(_token: string) {}
+
+    postMessage(...args: unknown[]) {
+      return mockSlackPostMessage(...args);
+    }
+  }
+
+  return { ...actual, SlackNotifier: MockSlackNotifier };
+});
+
+import {
+  db,
+  deploymentSettings,
+  eq,
+  slackInstallations,
+  taskFactory,
+  taskPlatformIssueReports,
+  taskRuns,
+  upsertAutomation,
+  users,
+} from '@roomote/db/server';
+import {
+  ACP_ENVELOPE_EVENT_TYPES,
+  TaskPayloadKind,
+  type AcpPersistedEnvelope,
+} from '@roomote/types';
+
+import { recordTaskMessageEnvelope } from '../record-task-message-envelope';
+
+const REPORT = {
+  title: 'Broken webhook secret',
+  summary: 'The GitHub webhook secret is rejected; deliveries are failing.',
+};
+
+let messageTs = 1_000;
+
+function buildReportEnvelope(): AcpPersistedEnvelope {
+  messageTs += 1;
+
+  return {
+    ts: messageTs,
+    eventType: ACP_ENVELOPE_EVENT_TYPES.ToolResult,
+    role: 'assistant',
+    protocol: 'roomote_runtime',
+    contentBlocks: [],
+    metadata: null,
+    payload: {
+      isMcp: true,
+      toolName: 'report_platform_issue',
+      output: JSON.stringify({ success: true, report: REPORT }),
+    },
+  };
+}
+
+async function seedTaskRun(taskId: string): Promise<number> {
+  await taskFactory.create({
+    id: taskId,
+    modelProvider: 'roomote',
+    model: 'test-model',
+    title: 'Platform issue task',
+    workflow: 'pr_review',
+    surface: 'github',
+    trigger: 'webhook',
+  });
+
+  const [run] = await db
+    .insert(taskRuns)
+    .values({
+      payloadKind: TaskPayloadKind.GithubPrReviewSync,
+      payload: { repo: 'owner/repo' },
+      taskId,
+    })
+    .returning({ id: taskRuns.id });
+
+  if (!run) {
+    throw new Error('Failed to seed task run');
+  }
+
+  return run.id;
+}
+
+async function findReportRow(taskId: string) {
+  return db.query.taskPlatformIssueReports.findFirst({
+    where: eq(taskPlatformIssueReports.taskId, taskId),
+    columns: { report: true, slackPostedAt: true },
+  });
+}
+
+describe('platform issue alert delivery', () => {
+  beforeEach(async () => {
+    process.env.R_APP_URL = 'https://app.example.com';
+    mockCreateDiscordProvider.mockReset();
+    mockDiscordPostMessage.mockReset();
+    mockSlackPostMessage.mockReset();
+    mockCreateDiscordProvider.mockResolvedValue({
+      postMessage: mockDiscordPostMessage,
+    });
+    mockDiscordPostMessage.mockResolvedValue({
+      provider: 'discord',
+      channelId: 'D111',
+      messageId: 'm1',
+    });
+    mockSlackPostMessage.mockResolvedValue('1727000000.000100');
+
+    await db.delete(taskPlatformIssueReports);
+    await db.delete(deploymentSettings);
+    await db.delete(slackInstallations);
+  });
+
+  it('posts the alert to the automation Discord channel when its own destination is Discord', async () => {
+    const taskId = 'task-platform-issue-discord';
+    const runId = await seedTaskRun(taskId);
+
+    await upsertAutomation(db, {
+      key: 'platform_issue_alerts',
+      enabled: true,
+      targets: [
+        {
+          provider: 'discord',
+          targetKind: 'discord_channel',
+          externalRef: 'D111',
+        },
+      ],
+    });
+
+    await recordTaskMessageEnvelope({
+      runId,
+      taskId,
+      envelope: buildReportEnvelope(),
+    });
+
+    expect(mockDiscordPostMessage).toHaveBeenCalledTimes(1);
+    const [post] = mockDiscordPostMessage.mock.calls[0] ?? [];
+    expect(post).toMatchObject({
+      channelId: 'D111',
+      textFormat: 'markdown',
+    });
+    expect(post.text).toContain(`**${REPORT.title}**`);
+    expect(post.text).toContain(REPORT.summary);
+    expect(post.text).toContain(
+      `[View task](https://app.example.com/task/${taskId}`,
+    );
+    expect(post.text).toContain('utm_source=discord');
+
+    // No Slack post: the Discord destination owns the alert.
+    expect(mockSlackPostMessage).not.toHaveBeenCalled();
+
+    const reportRow = await findReportRow(taskId);
+    expect(reportRow?.report).toEqual(REPORT);
+    expect(reportRow?.slackPostedAt).not.toBeNull();
+  });
+
+  it('keeps the Slack manager-channel fallback when no Discord destination is configured', async () => {
+    const taskId = 'task-platform-issue-slack';
+    const runId = await seedTaskRun(taskId);
+
+    await upsertAutomation(db, {
+      key: 'platform_issue_alerts',
+      enabled: false,
+      targets: [],
+    });
+    await db.insert(deploymentSettings).values({
+      id: 'default',
+      managerSlackChannelId: 'C999MANAGER',
+    });
+    await db
+      .insert(users)
+      .values({
+        id: 'user-admin',
+        name: 'Admin',
+        email: 'admin@example.com',
+        imageUrl: '',
+        entity: {},
+      })
+      .onConflictDoNothing();
+    await db.insert(slackInstallations).values({
+      teamId: 'T123',
+      teamName: 'Acme',
+      appId: 'A123',
+      botUserId: 'B123',
+      botAccessToken: 'xoxb-test',
+      scopes: { bot: ['chat:write'] },
+      installedByUserId: 'user-admin',
+      isActive: true,
+    });
+
+    await recordTaskMessageEnvelope({
+      runId,
+      taskId,
+      envelope: buildReportEnvelope(),
+    });
+
+    expect(mockDiscordPostMessage).not.toHaveBeenCalled();
+    expect(mockSlackPostMessage).toHaveBeenCalledTimes(1);
+    const [post] = mockSlackPostMessage.mock.calls[0] ?? [];
+    expect(post).toMatchObject({ channel: 'C999MANAGER' });
+    expect(post.text).toContain(`*${REPORT.title}*`);
+    expect(post.text).toContain('utm_source=slack');
+
+    const reportRow = await findReportRow(taskId);
+    expect(reportRow?.slackPostedAt).not.toBeNull();
+  });
+
+  it('leaves the report unposted when the Discord destination has no runtime credentials', async () => {
+    const taskId = 'task-platform-issue-no-creds';
+    const runId = await seedTaskRun(taskId);
+
+    await upsertAutomation(db, {
+      key: 'platform_issue_alerts',
+      enabled: true,
+      targets: [
+        {
+          provider: 'discord',
+          targetKind: 'discord_channel',
+          externalRef: 'D111',
+        },
+      ],
+    });
+    mockCreateDiscordProvider.mockResolvedValue(null);
+
+    await recordTaskMessageEnvelope({
+      runId,
+      taskId,
+      envelope: buildReportEnvelope(),
+    });
+
+    expect(mockDiscordPostMessage).not.toHaveBeenCalled();
+    expect(mockSlackPostMessage).not.toHaveBeenCalled();
+
+    const reportRow = await findReportRow(taskId);
+    expect(reportRow?.report).toEqual(REPORT);
+    expect(reportRow?.slackPostedAt).toBeNull();
+  });
+});

--- a/packages/sdk/src/server/lib/task-runs/record-task-message-envelope.ts
+++ b/packages/sdk/src/server/lib/task-runs/record-task-message-envelope.ts
@@ -26,7 +26,11 @@ import {
   setLatestSlackBotReply,
   trackSlackBotReply,
 } from '@roomote/slack';
-import { appendManagerSlackFooter } from '../manager-slack';
+import { createDiscordCommunicationProviderFromRuntimeCredentials } from '../discord-communication';
+import {
+  appendManagerSlackFooter,
+  degradeSlackMrkdwnToMarkdown,
+} from '../manager-slack';
 import {
   type AcpPersistedEnvelope,
   ACP_ENVELOPE_EVENT_TYPES,
@@ -153,17 +157,47 @@ function getPlatformIssueReportFromToolPayload(
   return parsedReport.data;
 }
 
-function buildPlatformIssueTaskUrl(taskId: string): string {
+function buildPlatformIssueTaskUrl(
+  taskId: string,
+  utmSource: 'slack' | 'discord',
+): string {
   const url = new URL(`/task/${taskId}`, process.env.R_APP_URL);
 
-  url.searchParams.set('utm_source', 'slack');
+  url.searchParams.set('utm_source', utmSource);
   url.searchParams.set('utm_medium', 'integration');
   url.searchParams.set('utm_campaign', 'platform_issue_alert');
 
   return url.toString();
 }
 
-async function maybeNotifyPlatformIssueToSlack(params: {
+function buildPlatformIssueAlertText(params: {
+  taskId: string;
+  report: { title: string; summary: string };
+  utmSource: 'slack' | 'discord';
+}): string {
+  const taskUrl = buildPlatformIssueTaskUrl(params.taskId, params.utmSource);
+
+  return appendManagerSlackFooter(
+    `Platform issue reported: *${params.report.title}*\n` +
+      `> ${params.report.summary}\n<${taskUrl}|View task>`,
+  );
+}
+
+// Marks the report row as delivered. slackPostedAt doubles as the
+// posted-anywhere marker so Discord deliveries also suppress re-posting.
+async function markPlatformIssueReportPosted(reportRowId: string) {
+  await db
+    .update(taskPlatformIssueReports)
+    .set({ slackPostedAt: new Date() })
+    .where(
+      and(
+        eq(taskPlatformIssueReports.id, reportRowId),
+        isNull(taskPlatformIssueReports.slackPostedAt),
+      ),
+    );
+}
+
+async function maybeNotifyPlatformIssue(params: {
   reportRowId: string;
   taskId: string;
   report: { title: string; summary: string };
@@ -184,6 +218,37 @@ async function maybeNotifyPlatformIssueToSlack(params: {
     }),
   ]);
 
+  // When the platform_issue_alerts automation's own destination target is a
+  // Discord channel, the alert belongs there instead of Slack.
+  const discordChannelId = settings.platformIssueDiscordChannelId;
+
+  if (discordChannelId) {
+    const discord =
+      await createDiscordCommunicationProviderFromRuntimeCredentials();
+
+    if (!discord) {
+      console.warn(
+        `[recordTaskMessageEnvelope] No Discord credentials, skipping platform issue Discord alert for task ${params.taskId}`,
+      );
+      return;
+    }
+
+    await discord.postMessage({
+      channelId: discordChannelId,
+      text: degradeSlackMrkdwnToMarkdown(
+        buildPlatformIssueAlertText({
+          taskId: params.taskId,
+          report: params.report,
+          utmSource: 'discord',
+        }),
+      ),
+      textFormat: 'markdown',
+    });
+
+    await markPlatformIssueReportPosted(params.reportRowId);
+    return;
+  }
+
   // Two-level fallback: the platform_issue_alerts automation target wins,
   // otherwise the deployment-wide manager channel.
   const channelId =
@@ -201,14 +266,14 @@ async function maybeNotifyPlatformIssueToSlack(params: {
   }
 
   const slack = new SlackNotifier(slackInstallation.botAccessToken);
-  const taskUrl = buildPlatformIssueTaskUrl(params.taskId);
 
   const messageTs = await slack.postMessage({
     channel: channelId,
-    text: appendManagerSlackFooter(
-      `Platform issue reported: *${params.report.title}*\n` +
-        `> ${params.report.summary}\n<${taskUrl}|View task>`,
-    ),
+    text: buildPlatformIssueAlertText({
+      taskId: params.taskId,
+      report: params.report,
+      utmSource: 'slack',
+    }),
     unfurl_links: false,
     unfurl_media: false,
   });
@@ -220,15 +285,7 @@ async function maybeNotifyPlatformIssueToSlack(params: {
     return;
   }
 
-  await db
-    .update(taskPlatformIssueReports)
-    .set({ slackPostedAt: new Date() })
-    .where(
-      and(
-        eq(taskPlatformIssueReports.id, params.reportRowId),
-        isNull(taskPlatformIssueReports.slackPostedAt),
-      ),
-    );
+  await markPlatformIssueReportPosted(params.reportRowId);
 }
 
 async function maybePersistPlatformIssueReport(params: {
@@ -282,7 +339,7 @@ async function maybePersistPlatformIssueReport(params: {
     return;
   }
 
-  await maybeNotifyPlatformIssueToSlack({
+  await maybeNotifyPlatformIssue({
     reportRowId: reportRow.id,
     taskId: reportRow.taskId,
     report: reportRow.report,

--- a/packages/types/src/__tests__/background-automation-registry.test.ts
+++ b/packages/types/src/__tests__/background-automation-registry.test.ts
@@ -78,6 +78,16 @@ describe('background automation registry', () => {
     });
   });
 
+  it('allows Slack and Discord destinations for the suggester', () => {
+    const descriptor =
+      getTriggerableBackgroundAutomationDescriptorByKey('suggester');
+
+    expect(descriptor?.supportedCommunicationProviders).toEqual([
+      'slack',
+      'discord',
+    ]);
+  });
+
   it('allows Teams, Telegram, and Discord destinations for CI failure triage Run now', () => {
     const descriptor =
       getTriggerableBackgroundAutomationDescriptorByKey('ci_failure_triage');

--- a/packages/types/src/background-automation-registry.ts
+++ b/packages/types/src/background-automation-registry.ts
@@ -139,7 +139,10 @@ export const TRIGGERABLE_BACKGROUND_AUTOMATION_DESCRIPTORS = [
     // Provider-agnostic: suggestion scans work with any synced repository.
     manualTriggerRequirements: ['slack', 'repository'],
     usesManagerChannel: true,
-    supportedCommunicationProviders: ['slack'],
+    // Scheduled suggestion delivery supports a per-automation Slack or
+    // Discord destination target; Teams/Telegram remain fallback-only
+    // surfaces without a configurable destination.
+    supportedCommunicationProviders: ['slack', 'discord'],
     supportedSourceControlProviders: sourceControlProviders,
     scheduledSuggestionSource: 'suggest_ideas',
   },


### PR DESCRIPTION
Completes #268's per-automation Discord destinations: the three destination fields that stayed Slack-only get the same one-of Slack-or-Discord picker as the six triage/auditor automations.

## Changes

- **suggester** — declares `discord` in its registry entry (capability badge becomes "Slack · Discord only"); scheduled suggestion summaries already routed to a targeted Discord channel via the destination waterfall, so only the write path + picker were missing. The experimental suggestion-routing-flag UI is untouched.
- **announcer** — picker added (delivery already worked via the communication adapter).
- **platform-issue alerts** — the real gap: it had **no Discord delivery at all** and, it turns out, no rendered settings card either — the `Alert on Config Errors` definition, dirty-tracking, and save wiring existed but nothing displayed it. This PR renders the card (picker-only, in Other automations) and adds Discord delivery in `record-task-message-envelope`: when the automation's own target is a Discord channel, the alert posts there via the runtime-credentials provider (best-effort, Slack path unchanged, `slackPostedAt` reused as the posted-anywhere marker so no migration).

One-of semantics, keep-persisted preservation, and validation mirror the existing six fields; the new zod inputs are optional so in-flight clients keep working across a deploy.

## Screenshots

_Captured on this branch against a dev deployment with one connected Discord server (Slack also connected, so options carry the "(Discord)" suffix — it is omitted on Discord-only deployments)._

**The combined destination picker — Discord channels alongside Slack in one searchable dropdown:**

<img width="1440" height="900" alt="download" src="https://github.com/user-attachments/assets/7687c6f6-504a-4519-b432-3bc4b3d86c5b" />

**A Discord channel selected as an automation's destination (provider-neutral label):**

<img width="1440" height="900" alt="download (1)" src="https://github.com/user-attachments/assets/5e2f4606-942d-417f-b40a-3efed119e0a4" />

**The "Slack · Discord only" capability badge on Suggest Ideas and the newly rendered Alert on Config Errors card:**

<img width="1440" height="900" alt="download (2)" src="https://github.com/user-attachments/assets/d6851661-1a4f-4967-ac36-e0282fcee900" />

**Alert on Config Errors expanded with a Discord channel selected — this automation previously had no Discord delivery and no settings card:**

<img width="1440" height="900" alt="download (3)" src="https://github.com/user-attachments/assets/0c222ced-3cb5-40dd-b5b5-539c34dfa74d" />

## Review note

Rendering the previously-orphaned platform-issue card is the one product-facing judgment call here — the alternative was a configurable Discord destination with no way to configure it. The card's label/description/icon all pre-existed.

## Validation

- Real-DB settings tests: discord save clears slack (and vice versa), unrelated saves preserve targets, platform-issue enablement counts a Discord channel — 8/8
- New platform-issue delivery tests: Discord target, Slack manager-channel fallback unchanged, missing Discord credentials leaves the report unposted — 3/3
- Full web automations UI/command suites (72), sdk task-runs (258+3), db (286), types (572) green; check-types 26/26, oxlint, format, knip pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
