### PR TITLE
[Feat] Create the Slack app from a pasted app configuration token

### DIFF
--- a/.agents/skills/mock-slack-testing/SKILL.md
+++ b/.agents/skills/mock-slack-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mock-slack-testing
-description: Run Roomote Slack integration flows through the existing mock Slack harness instead of a real Slack workspace. Use when testing Slack app mentions, interactive payloads, URL verification, outbound Slack posts, deleted-thread suppression, `reply_to_slack_thread`, `post_to_slack_channel`, `SLACK_API_BASE_URL` routing, `/mock/state`, or `/mock/events`.
+description: Run Roomote Slack integration flows through the existing mock Slack harness instead of a real Slack workspace. Use when testing Slack app mentions, interactive payloads, URL verification, outbound Slack posts, deleted-thread suppression, `reply_to_slack_thread`, `post_to_slack_channel`, Slack app creation via `apps.manifest.create`, `SLACK_API_BASE_URL` routing, `/mock/state`, or `/mock/events`.
 ---
 
 # Mock Slack Testing
@@ -129,6 +129,28 @@ curl -s http://127.0.0.1:3012/mock/state | jq '.messages'
 
 # Check if a specific thread reply was recorded
 curl -s http://127.0.0.1:3012/mock/state | jq '.messages[] | select(.thread_ts != null)'
+```
+
+## Testing Slack app creation (`apps.manifest.create`)
+
+The harness also mocks Slack's `apps.manifest.create` endpoint, which backs
+the setup flow where an admin pastes an app configuration token and Roomote
+creates the Slack app. Point the web server at the harness
+(`SLACK_API_BASE_URL=http://127.0.0.1:3012/api/`), then drive the setup UI or
+the `slack.createAppFromManifest` tRPC mutation.
+
+Optional state knobs:
+
+- `acceptedConfigTokens` — allowlist for config tokens; unknown tokens get
+  `{ "ok": false, "error": "invalid_auth" }`. Config tokens are a separate
+  token space from `acceptedBotTokens`.
+- `manifestCredentials` — `{ appId, clientId, clientSecret, signingSecret,
+  verificationToken }` overrides for the returned credentials.
+
+Created apps are recorded in mock state:
+
+```bash
+curl -s http://127.0.0.1:3012/mock/state | jq '.createdManifests'
 ```
 
 ## Scenario Selection

--- a/.changeset/slack-config-token-app-creation.md
+++ b/.changeset/slack-config-token-app-creation.md
@@ -1,0 +1,11 @@
+---
+'@roomote/web': minor
+---
+
+Slack setup can now create the Slack app for you: paste an app configuration
+token and Roomote creates the app through Slack's `apps.manifest.create` API,
+saves the client ID, client secret, and signing secret automatically, and
+advances straight to the Connect to Slack install step. Entering values
+manually and the prefilled-manifest path remain available as fallbacks, and
+the mock Slack harness now covers `apps.manifest.create` so the flow is
+testable without a real workspace.

--- a/apps/docs/providers/communications/slack.mdx
+++ b/apps/docs/providers/communications/slack.mdx
@@ -18,11 +18,25 @@ or configured for your self-hosted deployment.
 
 ## Fast path
 
-In `/setup`, choose **Create Slack app from manifest**. Roomote opens Slack's
-create-app flow with redirect URLs, webhook URLs, interactivity, scopes, and
-events prefilled for the current public URL.
+In `/setup`, paste a Slack **app configuration token** and Roomote creates the
+Slack app for you through Slack's `apps.manifest.create` API:
 
-After Slack creates the app:
+1. open [api.slack.com/apps](https://api.slack.com/apps) and click
+   **Generate Token** under **Your App Configuration Tokens**, picking the
+   workspace where Roomote should live
+2. paste the access token into Roomote setup and click **Create Slack app**
+
+Roomote creates the app with redirect URLs, webhook URLs, interactivity,
+scopes, and events preconfigured for the current public URL, then saves the
+**Client ID**, **Client Secret**, and **Signing Secret** automatically. The
+configuration token is used once to create the app and never stored. Finish
+the Slack install step so Roomote can receive events and post replies.
+
+### Alternative: prefilled manifest
+
+If you prefer not to use a configuration token, choose the **prefilled
+manifest** link instead. Roomote opens Slack's create-app flow with the same
+manifest prefilled. After Slack creates the app:
 
 1. copy **Client ID**, **Client Secret**, and **Signing Secret** from
    **Basic Information > App Credentials**

--- a/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
+++ b/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
@@ -295,6 +295,7 @@ type ProviderSetupExperienceProps = {
   clearedSavedValues: Record<string, boolean>;
   teamsAppPackageHref: string | null;
   showManualSlackValues: boolean;
+  createdSlackAppSettingsUrl?: string | null;
   createSlackAppPending?: boolean;
   showMicrosoftAdvancedConfig?: boolean;
   surface?: 'setup' | 'settings';
@@ -334,6 +335,38 @@ function ProviderSetupTitle({
 
 function SlackSetupExperience(props: ProviderSetupExperienceProps) {
   const [configToken, setConfigToken] = useState('');
+  const createdSlackAppSettingsUrl = props.createdSlackAppSettingsUrl ?? null;
+
+  if (createdSlackAppSettingsUrl) {
+    return (
+      <div className="relative w-full max-w-2xl space-y-4 py-2 md:py-0">
+        <ProviderSetupTitle surface={props.surface} text="Finish Slack app" />
+
+        <div className="space-y-4 max-w-xl">
+          <p>
+            Your Slack app is ready. Adding a logo is optional: open{' '}
+            <a
+              href={createdSlackAppSettingsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-foreground underline font-semibold"
+            >
+              the app
+            </a>
+            , scroll down to App icon, and upload{' '}
+            <a
+              href="/api/setup/roomote-logo"
+              download
+              className="text-foreground underline font-semibold"
+            >
+              the Roomote logo
+            </a>
+            .
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   if (
     !props.showManualSlackValues &&

--- a/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
+++ b/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
@@ -334,9 +334,6 @@ function ProviderSetupTitle({
 
 function SlackSetupExperience(props: ProviderSetupExperienceProps) {
   const [configToken, setConfigToken] = useState('');
-  const slackManifestPrefillUrl = buildSlackManifestPrefillUrl({
-    publicOrigin: props.publicOrigin,
-  });
 
   if (
     !props.showManualSlackValues &&
@@ -361,52 +358,57 @@ function SlackSetupExperience(props: ProviderSetupExperienceProps) {
       <div className="relative w-full max-w-2xl space-y-4 py-2 md:py-0">
         <ProviderSetupTitle surface={props.surface} text="Create Slack app" />
 
-        <div className="space-y-3 max-w-xl">
+        <div className="space-y-4 max-w-xl">
           <p>
             Because Roomote is self-hosted, we can&apos;t offer you an
-            out-of-the-box Slack app – you need your own. Paste an app
-            configuration token and Roomote creates the app for you.
+            out-of-the-box Slack app – you need your own. But with just an app
+            configuration token, we&apos;ll create it for you.
           </p>
-          <ol className="list-decimal space-y-1 pl-5 text-sm text-muted-foreground">
-            <li>
-              Open{' '}
-              <a
-                href="https://api.slack.com/apps"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-foreground underline font-semibold"
-              >
-                api.slack.com/apps
-                <ExternalLink className="inline size-3 -mt-1 ml-1" />
-              </a>{' '}
-              and click <span className="font-semibold">
-                Generate Token
-              </span>{' '}
-              under &quot;Your App Configuration Tokens&quot;, picking the
-              workspace where Roomote should live.
-            </li>
-            <li>Copy the access token and paste it here.</li>
-          </ol>
-        </div>
-
-        <div className="grid gap-2 md:grid-cols-[180px_minmax(0,1fr)] md:items-center max-w-xl">
-          <div className="text-sm font-medium">App configuration token</div>
-          <Input
-            secret
-            className="font-mono"
-            aria-label="App configuration token"
-            value={configToken}
-            onChange={(event) => setConfigToken(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter') {
-                event.preventDefault();
-                submitConfigToken();
-              }
-            }}
-            placeholder="xoxe.xoxp-..."
-            disabled={props.disabled || props.createSlackAppPending}
-            data-1p-ignore
-          />
+          <NumberedStep number={1}>
+            <p className="font-semibold">Get an app token.</p>
+            <div className="space-y-3 max-w-xl">
+              <p className="text-sm text-muted-foreground">
+                Go to the{' '}
+                <a
+                  href="https://api.slack.com/apps"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-foreground underline font-semibold"
+                >
+                  Slack Apps portal
+                  <ExternalLink className="inline size-3 -mt-1 ml-1" />
+                </a>{' '}
+                → Your App Configuration Tokens →{' '}
+                <span className="font-semibold">Generate Token</span>, picking
+                the workspace you want to connect.
+              </p>
+            </div>
+          </NumberedStep>
+          <NumberedStep number={2}>
+            <p className="font-semibold">Copy it....</p>
+            <p className="text-sm text-muted-foreground">
+              ...and paste it here:
+            </p>
+            <div className="grid gap-2 md:grid-cols-[180px_minmax(0,1fr)] md:items-center max-w-xl">
+              <div className="text-sm font-medium">Access token</div>
+              <Input
+                secret
+                className="font-mono"
+                aria-label="App configuration token"
+                value={configToken}
+                onChange={(event) => setConfigToken(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault();
+                    submitConfigToken();
+                  }
+                }}
+                placeholder="xoxe.xoxp-..."
+                disabled={props.disabled || props.createSlackAppPending}
+                data-1p-ignore
+              />
+            </div>
+          </NumberedStep>
         </div>
 
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center mt-8">
@@ -430,24 +432,9 @@ function SlackSetupExperience(props: ProviderSetupExperienceProps) {
             onClick={props.onShowManualSlackValues}
           >
             <Pencil />
-            Enter values manually
+            Create app manually
           </Button>
         </div>
-
-        <p className="text-sm text-muted-foreground max-w-xl">
-          Prefer not to use a configuration token? Create the app in
-          Slack&apos;s UI from a{' '}
-          <a
-            href={slackManifestPrefillUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-foreground underline"
-            onClick={props.onShowManualSlackValues}
-          >
-            prefilled manifest
-          </a>{' '}
-          and enter its credentials manually.
-        </p>
       </div>
     );
   }
@@ -626,6 +613,9 @@ function GenericSetupExperience(props: ProviderSetupExperienceProps) {
   const providerSetupLabel =
     providerSetupCopy?.setupLabel ?? `${props.provider.label} app`;
   const fields = getSetupVisibleFields(props.provider);
+  const slackManifestPrefillUrl = buildSlackManifestPrefillUrl({
+    publicOrigin: props.publicOrigin,
+  });
 
   return (
     <div className="relative w-full max-w-2xl space-y-5 py-2 md:py-0">
@@ -633,6 +623,21 @@ function GenericSetupExperience(props: ProviderSetupExperienceProps) {
         surface={props.surface}
         text={`Configure ${providerSetupLabel}`}
       />
+
+      <p className="text-sm text-muted-foreground max-w-xl">
+        Prefer not to use a configuration token? Create the app in Slack&apos;s
+        UI from a{' '}
+        <a
+          href={slackManifestPrefillUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-foreground underline"
+          onClick={props.onShowManualSlackValues}
+        >
+          prefilled manifest
+        </a>{' '}
+        and enter its credentials manually.
+      </p>
 
       <NumberedStep number={1} className="mt-6">
         <p className="font-semibold">

--- a/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
+++ b/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
@@ -373,10 +373,9 @@ function SlackSetupExperience(props: ProviderSetupExperienceProps) {
     !props.provider.runtimeSatisfied &&
     !props.provider.savedSatisfied
   ) {
+    const createSlackAppPending = props.createSlackAppPending === true;
     const createSlackAppDisabled =
-      !props.onCreateSlackApp ||
-      props.disabled ||
-      props.createSlackAppPending === true;
+      !props.onCreateSlackApp || props.disabled || createSlackAppPending;
     const submitConfigToken = () => {
       const normalizedConfigToken = configToken.trim();
 
@@ -437,7 +436,7 @@ function SlackSetupExperience(props: ProviderSetupExperienceProps) {
                   }
                 }}
                 placeholder="xoxe.xoxp-..."
-                disabled={props.disabled || props.createSlackAppPending}
+                disabled={props.disabled || createSlackAppPending}
                 data-1p-ignore
               />
             </div>
@@ -446,7 +445,12 @@ function SlackSetupExperience(props: ProviderSetupExperienceProps) {
 
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center mt-8">
           {props.onBack ? (
-            <Button type="button" variant="outline" onClick={props.onBack}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={props.onBack}
+              disabled={createSlackAppPending}
+            >
               <ArrowLeft />
               Back
             </Button>
@@ -456,13 +460,14 @@ function SlackSetupExperience(props: ProviderSetupExperienceProps) {
             onClick={submitConfigToken}
             disabled={createSlackAppDisabled || configToken.trim().length === 0}
           >
-            {props.createSlackAppPending ? <Spinner /> : <Sparkles />}
+            {createSlackAppPending ? <Spinner /> : <Sparkles />}
             Create Slack app
           </Button>
           <Button
             type="button"
             variant="outline"
             onClick={props.onShowManualSlackValues}
+            disabled={createSlackAppPending}
           >
             <Pencil />
             Create app manually
@@ -646,9 +651,12 @@ function GenericSetupExperience(props: ProviderSetupExperienceProps) {
   const providerSetupLabel =
     providerSetupCopy?.setupLabel ?? `${props.provider.label} app`;
   const fields = getSetupVisibleFields(props.provider);
-  const slackManifestPrefillUrl = buildSlackManifestPrefillUrl({
-    publicOrigin: props.publicOrigin,
-  });
+  const slackManifestPrefillUrl =
+    props.provider.id === 'slack'
+      ? buildSlackManifestPrefillUrl({
+          publicOrigin: props.publicOrigin,
+        })
+      : null;
 
   return (
     <div className="relative w-full max-w-2xl space-y-5 py-2 md:py-0">
@@ -657,20 +665,22 @@ function GenericSetupExperience(props: ProviderSetupExperienceProps) {
         text={`Configure ${providerSetupLabel}`}
       />
 
-      <p className="text-sm text-muted-foreground max-w-xl">
-        Prefer not to use a configuration token? Create the app in Slack&apos;s
-        UI from a{' '}
-        <a
-          href={slackManifestPrefillUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-foreground underline"
-          onClick={props.onShowManualSlackValues}
-        >
-          prefilled manifest
-        </a>{' '}
-        and enter its credentials manually.
-      </p>
+      {slackManifestPrefillUrl ? (
+        <p className="text-sm text-muted-foreground max-w-xl">
+          Prefer not to use a configuration token? Create the app in
+          Slack&apos;s UI from a{' '}
+          <a
+            href={slackManifestPrefillUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-foreground underline"
+            onClick={props.onShowManualSlackValues}
+          >
+            prefilled manifest
+          </a>{' '}
+          and enter its credentials manually.
+        </p>
+      ) : null}
 
       <NumberedStep number={1} className="mt-6">
         <p className="font-semibold">

--- a/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
+++ b/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import Link from 'next/link';
 import {
   MICROSOFT_SINGLE_APP_TEAMS_BOT_FIELD_SOURCES,
@@ -19,6 +20,7 @@ import {
   Button,
   Pencil,
   Sparkles,
+  Spinner,
 } from '@/components/system';
 
 import { StepTitle } from './StepTitle';
@@ -293,9 +295,11 @@ type ProviderSetupExperienceProps = {
   clearedSavedValues: Record<string, boolean>;
   teamsAppPackageHref: string | null;
   showManualSlackValues: boolean;
+  createSlackAppPending?: boolean;
   showMicrosoftAdvancedConfig?: boolean;
   surface?: 'setup' | 'settings';
   envVarsInfoNote?: React.ReactNode;
+  onCreateSlackApp?: (configToken: string) => void;
   onShowManualSlackValues: () => void;
   onToggleMicrosoftAdvancedConfig?: () => void;
   onValueChange: (envVarName: string, value: string) => void;
@@ -329,6 +333,7 @@ function ProviderSetupTitle({
 }
 
 function SlackSetupExperience(props: ProviderSetupExperienceProps) {
+  const [configToken, setConfigToken] = useState('');
   const slackManifestPrefillUrl = buildSlackManifestPrefillUrl({
     publicOrigin: props.publicOrigin,
   });
@@ -338,6 +343,20 @@ function SlackSetupExperience(props: ProviderSetupExperienceProps) {
     !props.provider.runtimeSatisfied &&
     !props.provider.savedSatisfied
   ) {
+    const createSlackAppDisabled =
+      !props.onCreateSlackApp ||
+      props.disabled ||
+      props.createSlackAppPending === true;
+    const submitConfigToken = () => {
+      const normalizedConfigToken = configToken.trim();
+
+      if (createSlackAppDisabled || !normalizedConfigToken) {
+        return;
+      }
+
+      props.onCreateSlackApp?.(normalizedConfigToken);
+    };
+
     return (
       <div className="relative w-full max-w-2xl space-y-4 py-2 md:py-0">
         <ProviderSetupTitle surface={props.surface} text="Create Slack app" />
@@ -345,12 +364,49 @@ function SlackSetupExperience(props: ProviderSetupExperienceProps) {
         <div className="space-y-3 max-w-xl">
           <p>
             Because Roomote is self-hosted, we can&apos;t offer you an
-            out-of-the-box Slack app – you need to create your own.
+            out-of-the-box Slack app – you need your own. Paste an app
+            configuration token and Roomote creates the app for you.
           </p>
-          <p>
-            Roomote can create it for you automatically, and then you can enter
-            the config values manually.
-          </p>
+          <ol className="list-decimal space-y-1 pl-5 text-sm text-muted-foreground">
+            <li>
+              Open{' '}
+              <a
+                href="https://api.slack.com/apps"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-foreground underline font-semibold"
+              >
+                api.slack.com/apps
+                <ExternalLink className="inline size-3 -mt-1 ml-1" />
+              </a>{' '}
+              and click <span className="font-semibold">
+                Generate Token
+              </span>{' '}
+              under &quot;Your App Configuration Tokens&quot;, picking the
+              workspace where Roomote should live.
+            </li>
+            <li>Copy the access token and paste it here.</li>
+          </ol>
+        </div>
+
+        <div className="grid gap-2 md:grid-cols-[180px_minmax(0,1fr)] md:items-center max-w-xl">
+          <div className="text-sm font-medium">App configuration token</div>
+          <Input
+            secret
+            className="font-mono"
+            aria-label="App configuration token"
+            value={configToken}
+            onChange={(event) => setConfigToken(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault();
+                submitConfigToken();
+              }
+            }}
+            placeholder="xoxe.xoxp-..."
+            disabled={props.disabled || props.createSlackAppPending}
+            data-1p-ignore
+          />
         </div>
 
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center mt-8">
@@ -360,16 +416,13 @@ function SlackSetupExperience(props: ProviderSetupExperienceProps) {
               Back
             </Button>
           ) : null}
-          <Button asChild>
-            <a
-              href={slackManifestPrefillUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={props.onShowManualSlackValues}
-            >
-              <Sparkles />
-              Create Slack app
-            </a>
+          <Button
+            type="button"
+            onClick={submitConfigToken}
+            disabled={createSlackAppDisabled || configToken.trim().length === 0}
+          >
+            {props.createSlackAppPending ? <Spinner /> : <Sparkles />}
+            Create Slack app
           </Button>
           <Button
             type="button"
@@ -380,6 +433,21 @@ function SlackSetupExperience(props: ProviderSetupExperienceProps) {
             Enter values manually
           </Button>
         </div>
+
+        <p className="text-sm text-muted-foreground max-w-xl">
+          Prefer not to use a configuration token? Create the app in
+          Slack&apos;s UI from a{' '}
+          <a
+            href={slackManifestPrefillUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-foreground underline"
+            onClick={props.onShowManualSlackValues}
+          >
+            prefilled manifest
+          </a>{' '}
+          and enter its credentials manually.
+        </p>
       </div>
     );
   }

--- a/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.client.test.tsx
@@ -6,7 +6,13 @@ import type {
   ReactNode,
   SVGProps,
 } from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { SetupAuthStatus } from '@roomote/types';
 
@@ -33,6 +39,7 @@ vi.mock('next/navigation', () => ({
 
 vi.mock('sonner', () => ({
   toast: {
+    success: vi.fn(),
     error: vi.fn(),
   },
 }));
@@ -409,20 +416,9 @@ describe('StepAuthEnvVars', () => {
       screen.getByRole('button', { name: /create slack app/i }),
     ).toBeDisabled();
 
-    // The prefilled-manifest link remains as a secondary escape hatch.
-    const link = screen.getByRole('link', { name: /prefilled manifest/i });
-    const url = new URL(link.getAttribute('href') ?? '');
-    expect(url.origin + url.pathname).toBe('https://api.slack.com/apps');
-    expect(url.searchParams.get('new_app')).toBe('1');
     expect(
-      JSON.parse(url.searchParams.get('manifest_json') ?? '{}'),
-    ).toMatchObject({
-      settings: {
-        event_subscriptions: {
-          request_url: 'https://roomote.example.com/api/webhooks/slack',
-        },
-      },
-    });
+      screen.getByRole('button', { name: /create app manually/i }),
+    ).toBeInTheDocument();
     expect(
       screen.queryByPlaceholderText('Slack Client ID'),
     ).not.toBeInTheDocument();
@@ -436,7 +432,23 @@ describe('StepAuthEnvVars', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('link', { name: /prefilled manifest/i }));
+    fireEvent.click(
+      screen.getByRole('button', { name: /create app manually/i }),
+    );
+
+    const link = screen.getByRole('link', { name: /prefilled manifest/i });
+    const url = new URL(link.getAttribute('href') ?? '');
+    expect(url.origin + url.pathname).toBe('https://api.slack.com/apps');
+    expect(url.searchParams.get('new_app')).toBe('1');
+    expect(
+      JSON.parse(url.searchParams.get('manifest_json') ?? '{}'),
+    ).toMatchObject({
+      settings: {
+        event_subscriptions: {
+          request_url: 'https://roomote.example.com/api/webhooks/slack',
+        },
+      },
+    });
 
     expect(screen.getByPlaceholderText('Slack Client ID')).toBeInTheDocument();
     expect(
@@ -447,7 +459,7 @@ describe('StepAuthEnvVars', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('creates the Slack app from a config token and continues setup', async () => {
+  it('creates the Slack app from a config token, shows optional icon guidance, and continues setup', async () => {
     const invalidateQueries = vi.fn();
     mockUseQueryClient.mockReturnValue({
       invalidateQueries,
@@ -470,7 +482,7 @@ describe('StepAuthEnvVars', () => {
       } as unknown as ReturnType<typeof useMutation>;
     });
 
-    render(
+    const { rerender } = render(
       <StepAuthEnvVars
         authSetup={buildAuthSetup('slack')}
         onContinue={vi.fn()}
@@ -487,13 +499,57 @@ describe('StepAuthEnvVars', () => {
     });
 
     // The first useMutation registered by the component is createSlackApp.
-    await recordedOptions[0]?.onSuccess?.({ success: true, appId: 'A1' });
+    await act(async () => {
+      await recordedOptions[0]?.onSuccess?.({
+        success: true,
+        appId: 'A1',
+        appSettingsUrl: 'https://api.slack.com/apps/A1',
+      });
+    });
 
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: ['setupNew.status'],
     });
-    // With the credentials persisted server-side, the step saves the provider
-    // choice with no manual values and advances.
+    expect(
+      await screen.findByRole('heading', { name: /finish slack app/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Your Slack app is ready/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /the Roomote logo/i }),
+    ).toHaveAttribute('href', '/api/setup/roomote-logo');
+    expect(screen.getByRole('link', { name: /the app/i })).toHaveAttribute(
+      'href',
+      'https://api.slack.com/apps/A1',
+    );
+    expect(
+      screen.queryByPlaceholderText('Slack Client ID'),
+    ).not.toBeInTheDocument();
+    expect(mutateAsync).not.toHaveBeenCalled();
+
+    const refreshedAuthSetup = buildAuthSetup('slack');
+    rerender(
+      <StepAuthEnvVars
+        authSetup={{
+          ...refreshedAuthSetup,
+          providers: refreshedAuthSetup.providers.map((provider) =>
+            provider.id === 'slack'
+              ? { ...provider, savedSatisfied: true, setupSatisfied: true }
+              : provider,
+          ),
+        }}
+        onContinue={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: /finish slack app/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText('Slack Client ID'),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
     expect(mutateAsync).toHaveBeenCalledWith({ provider: 'slack', values: {} });
   });
 
@@ -543,7 +599,7 @@ describe('StepAuthEnvVars', () => {
     );
 
     fireEvent.click(
-      screen.getByRole('button', { name: /enter values manually/i }),
+      screen.getByRole('button', { name: /create app manually/i }),
     );
 
     expect(screen.getByPlaceholderText('Slack Client ID')).toBeInTheDocument();
@@ -973,7 +1029,7 @@ describe('StepAuthEnvVars', () => {
     );
 
     fireEvent.click(
-      screen.getByRole('button', { name: /enter values manually/i }),
+      screen.getByRole('button', { name: /create app manually/i }),
     );
     fireEvent.change(screen.getByPlaceholderText('Slack Client ID'), {
       target: { value: 'client-id' },

--- a/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.client.test.tsx
@@ -48,6 +48,11 @@ vi.mock('@/lib/auth-client', () => ({
 
 vi.mock('@/trpc/client', () => ({
   useTRPC: () => ({
+    slack: {
+      createAppFromManifest: {
+        mutationOptions: (options: Record<string, unknown>) => options,
+      },
+    },
     setupNew: {
       saveAuthConfig: {
         mutationOptions: (options: Record<string, unknown>) => options,
@@ -58,6 +63,9 @@ vi.mock('@/trpc/client', () => ({
     },
     setupBootstrap: {
       saveAuthConfig: {
+        mutationOptions: (options: Record<string, unknown>) => options,
+      },
+      createSlackAppFromManifest: {
         mutationOptions: (options: Record<string, unknown>) => options,
       },
       status: {
@@ -382,7 +390,7 @@ describe('StepAuthEnvVars', () => {
     });
   });
 
-  it('defaults Slack to the manifest CTA and hides manual fields initially', () => {
+  it('defaults Slack to the config-token flow and hides manual fields initially', () => {
     render(
       <StepAuthEnvVars
         authSetup={buildAuthSetup('slack')}
@@ -390,14 +398,20 @@ describe('StepAuthEnvVars', () => {
       />,
     );
 
-    const link = screen.getByRole('link', {
-      name: /create slack app/i,
-    });
-    const url = new URL(link.getAttribute('href') ?? '');
-
     expect(
       screen.getByRole('heading', { name: /create slack app/i }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('App configuration token'),
+    ).toBeInTheDocument();
+    // The create action stays disabled until a token is entered.
+    expect(
+      screen.getByRole('button', { name: /create slack app/i }),
+    ).toBeDisabled();
+
+    // The prefilled-manifest link remains as a secondary escape hatch.
+    const link = screen.getByRole('link', { name: /prefilled manifest/i });
+    const url = new URL(link.getAttribute('href') ?? '');
     expect(url.origin + url.pathname).toBe('https://api.slack.com/apps');
     expect(url.searchParams.get('new_app')).toBe('1');
     expect(
@@ -414,7 +428,7 @@ describe('StepAuthEnvVars', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('shows the manual value form after opening the Slack app creation flow', () => {
+  it('shows the manual value form after opening the prefilled-manifest flow', () => {
     render(
       <StepAuthEnvVars
         authSetup={buildAuthSetup('slack')}
@@ -422,15 +436,102 @@ describe('StepAuthEnvVars', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('link', { name: /create slack app/i }));
+    fireEvent.click(screen.getByRole('link', { name: /prefilled manifest/i }));
 
     expect(screen.getByPlaceholderText('Slack Client ID')).toBeInTheDocument();
     expect(
       screen.getByPlaceholderText('Slack Client Secret'),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('link', { name: /create slack app/i }),
+      screen.queryByRole('button', { name: /create slack app/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it('creates the Slack app from a config token and continues setup', async () => {
+    const invalidateQueries = vi.fn();
+    mockUseQueryClient.mockReturnValue({
+      invalidateQueries,
+    } as unknown as ReturnType<typeof mockUseQueryClient>);
+
+    const recordedOptions: Array<{
+      onSuccess?: (result: unknown) => Promise<void> | void;
+    }> = [];
+    const mutate = vi.fn();
+    const mutateAsync = vi.fn(async (input) => input);
+    mockUseMutation.mockImplementation((options) => {
+      recordedOptions.push(
+        options as { onSuccess?: (result: unknown) => Promise<void> | void },
+      );
+
+      return {
+        mutate,
+        mutateAsync,
+        isPending: false,
+      } as unknown as ReturnType<typeof useMutation>;
+    });
+
+    render(
+      <StepAuthEnvVars
+        authSetup={buildAuthSetup('slack')}
+        onContinue={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('App configuration token'), {
+      target: { value: '  xoxe.xoxp-config-token  ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create slack app/i }));
+
+    expect(mutate).toHaveBeenCalledWith({
+      configToken: 'xoxe.xoxp-config-token',
+    });
+
+    // The first useMutation registered by the component is createSlackApp.
+    await recordedOptions[0]?.onSuccess?.({ success: true, appId: 'A1' });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['setupNew.status'],
+    });
+    // With the credentials persisted server-side, the step saves the provider
+    // choice with no manual values and advances.
+    expect(mutateAsync).toHaveBeenCalledWith({ provider: 'slack', values: {} });
+  });
+
+  it('surfaces Slack app creation failures without advancing', async () => {
+    const { toast } = await import('sonner');
+    const recordedOptions: Array<{
+      onSuccess?: (result: unknown) => Promise<void> | void;
+    }> = [];
+    const mutate = vi.fn();
+    const mutateAsync = vi.fn(async (input) => input);
+    mockUseMutation.mockImplementation((options) => {
+      recordedOptions.push(
+        options as { onSuccess?: (result: unknown) => Promise<void> | void },
+      );
+
+      return {
+        mutate,
+        mutateAsync,
+        isPending: false,
+      } as unknown as ReturnType<typeof useMutation>;
+    });
+
+    render(
+      <StepAuthEnvVars
+        authSetup={buildAuthSetup('slack')}
+        onContinue={vi.fn()}
+      />,
+    );
+
+    await recordedOptions[0]?.onSuccess?.({
+      success: false,
+      error: 'Slack rejected the app configuration token.',
+    });
+
+    expect(toast.error).toHaveBeenCalledWith(
+      'Slack rejected the app configuration token.',
+    );
+    expect(mutateAsync).not.toHaveBeenCalled();
   });
 
   it('reveals existing Slack inputs when entering values manually', () => {

--- a/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.tsx
@@ -69,6 +69,9 @@ export function StepAuthEnvVars({
   >({});
   const [showMicrosoftAdvancedConfig, setShowMicrosoftAdvancedConfig] =
     useState(false);
+  const [createdSlackAppSettingsUrl, setCreatedSlackAppSettingsUrl] = useState<
+    string | null
+  >(null);
   const createSlackApp = useMutation(
     (bootstrapMode
       ? trpc.setupBootstrap.createSlackAppFromManifest
@@ -85,14 +88,7 @@ export function StepAuthEnvVars({
             ? trpc.setupBootstrap.status.queryKey()
             : trpc.setupNew.status.queryKey(),
         });
-
-        try {
-          // The credentials are already persisted, so this records the
-          // provider choice and advances (or, in bootstrap mode, signs in).
-          await handleContinue();
-        } catch {
-          // saveAuthConfig's own onError already surfaced the failure.
-        }
+        setCreatedSlackAppSettingsUrl(result.appSettingsUrl);
       },
       onError: (error) => {
         toast.error(error.message);
@@ -156,6 +152,7 @@ export function StepAuthEnvVars({
     setEditingSavedValues({});
     setClearedSavedValues({});
     setShowMicrosoftAdvancedConfig(false);
+    setCreatedSlackAppSettingsUrl(null);
   }, [effectiveSelectedProviderId]);
 
   const selectedProvider = useMemo(
@@ -270,6 +267,7 @@ export function StepAuthEnvVars({
 
   useEffect(() => {
     setShowManualSlackValues(false);
+    setCreatedSlackAppSettingsUrl(null);
   }, [effectiveSelectedProviderId]);
 
   const selectedProviderRuntimeConfigured =
@@ -278,6 +276,8 @@ export function StepAuthEnvVars({
     selectedProvider.runtimeSatisfied;
   const selectedProviderHasEditableFields =
     visibleFields.some((field) => !field.runtimeSatisfied) ?? false;
+  const showingCreatedSlackAppStep =
+    selectedProvider?.id === 'slack' && createdSlackAppSettingsUrl !== null;
   // Slack "owns" the step actions only while its intro screen is shown, which
   // is the same condition SlackSetupExperience uses to render that intro. If a
   // saved (or runtime) config is being edited instead, the intro is hidden and
@@ -286,8 +286,12 @@ export function StepAuthEnvVars({
   const providerOwnsActions =
     selectedProvider?.id === 'slack' &&
     !showManualSlackValues &&
+    !showingCreatedSlackAppStep &&
     !selectedProvider.runtimeSatisfied &&
     !selectedProvider.savedSatisfied;
+  const continueDisabled = showingCreatedSlackAppStep
+    ? saveAuthConfig.isPending
+    : isActionDisabled;
 
   if (bootstrapMode && selectedProviderRuntimeConfigured) {
     return (
@@ -331,6 +335,7 @@ export function StepAuthEnvVars({
           clearedSavedValues={clearedSavedValues}
           teamsAppPackageHref={teamsAppPackageHref}
           showManualSlackValues={showManualSlackValues}
+          createdSlackAppSettingsUrl={createdSlackAppSettingsUrl}
           createSlackAppPending={
             createSlackApp.isPending || saveAuthConfig.isPending
           }
@@ -373,11 +378,11 @@ export function StepAuthEnvVars({
           <Button
             type="button"
             onClick={() => void handleContinue()}
-            disabled={isActionDisabled}
+            disabled={continueDisabled}
           >
             {saveAuthConfig.isPending
               ? 'Saving...'
-              : !selectedProviderHasEditableFields
+              : showingCreatedSlackAppStep || !selectedProviderHasEditableFields
                 ? 'Continue'
                 : bootstrapMode
                   ? 'Save and sign in'

--- a/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.tsx
@@ -69,6 +69,36 @@ export function StepAuthEnvVars({
   >({});
   const [showMicrosoftAdvancedConfig, setShowMicrosoftAdvancedConfig] =
     useState(false);
+  const createSlackApp = useMutation(
+    (bootstrapMode
+      ? trpc.setupBootstrap.createSlackAppFromManifest
+      : trpc.slack.createAppFromManifest
+    ).mutationOptions({
+      onSuccess: async (result) => {
+        if (!result.success) {
+          toast.error(result.error);
+          return;
+        }
+
+        await queryClient.invalidateQueries({
+          queryKey: bootstrapMode
+            ? trpc.setupBootstrap.status.queryKey()
+            : trpc.setupNew.status.queryKey(),
+        });
+
+        try {
+          // The credentials are already persisted, so this records the
+          // provider choice and advances (or, in bootstrap mode, signs in).
+          await handleContinue();
+        } catch {
+          // saveAuthConfig's own onError already surfaced the failure.
+        }
+      },
+      onError: (error) => {
+        toast.error(error.message);
+      },
+    }),
+  );
   const saveAuthConfig = useMutation(
     (bootstrapMode
       ? trpc.setupBootstrap.saveAuthConfig
@@ -301,7 +331,16 @@ export function StepAuthEnvVars({
           clearedSavedValues={clearedSavedValues}
           teamsAppPackageHref={teamsAppPackageHref}
           showManualSlackValues={showManualSlackValues}
+          createSlackAppPending={
+            createSlackApp.isPending || saveAuthConfig.isPending
+          }
           showMicrosoftAdvancedConfig={showMicrosoftAdvancedConfig}
+          onCreateSlackApp={(configToken) =>
+            createSlackApp.mutate({
+              configToken,
+              ...(bootstrapMode && setupToken ? { setupToken } : {}),
+            })
+          }
           onShowManualSlackValues={() => setShowManualSlackValues(true)}
           onToggleMicrosoftAdvancedConfig={() =>
             setShowMicrosoftAdvancedConfig((current) => !current)

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConnect.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConnect.tsx
@@ -48,7 +48,7 @@ function getTokenBackedConnectCopy({
   providerLabel: string;
 }): string {
   if (lockedByRuntime) {
-    return 'Connect to continue';
+    return "We've got all the config we need, just connect to continue.";
   }
 
   switch (provider) {
@@ -168,7 +168,7 @@ export function StepSourceControlConnect({
   const lockedByRuntime = providerStatus?.configSatisfiedByRuntimeEnv === true;
   const providerLabel = providerStatus?.label ?? provider;
   const githubCopy = lockedByRuntime
-    ? 'Connect to continue'
+    ? "We've got all the config we need, just connect to continue."
     : 'Connect the GitHub App to grant Roomote access to your repositories.';
 
   const tokenBackedCopy = getTokenBackedConnectCopy({

--- a/apps/web/src/components/settings/CommsProviderSection.test.tsx
+++ b/apps/web/src/components/settings/CommsProviderSection.test.tsx
@@ -128,6 +128,15 @@ vi.mock('@tanstack/react-query', () => ({
   }) => ({
     isPending: state.updateRouterDebugIsPending,
     mutate: (input: unknown) => {
+      if (input && typeof input === 'object' && 'configToken' in input) {
+        options.onSuccess?.({
+          success: true,
+          appId: 'A0NEWAPP',
+          appSettingsUrl: 'https://api.slack.com/apps/A0NEWAPP',
+        });
+        return;
+      }
+
       mutations.updateRouterDebug(input);
       options.onSuccess?.({
         routerDebugSlackChannelId:
@@ -572,11 +581,11 @@ describe('CommsProviderSection', () => {
         screen.getByLabelText('App configuration token'),
       ).toBeInTheDocument();
       expect(
-        screen.getByRole('link', { name: /prefilled manifest/ }),
+        screen.getByRole('button', { name: /Create app manually/ }),
       ).toBeInTheDocument();
 
       fireEvent.click(
-        screen.getByRole('button', { name: /Enter values manually/ }),
+        screen.getByRole('button', { name: /Create app manually/ }),
       );
 
       expect(
@@ -588,6 +597,32 @@ describe('CommsProviderSection', () => {
       expect(screen.getByText(/Create a new Slack app/)).toBeInTheDocument();
       expect(screen.getByText('Authorized redirect URLs')).toBeInTheDocument();
       expect(screen.getByText('Enter the values below:')).toBeInTheDocument();
+    });
+
+    it('shows logo actions after creating a Slack app from a config token', async () => {
+      render(
+        <CommsProviderSection
+          provider={buildSlackProvider()}
+          onSave={vi.fn()}
+          onClear={vi.fn()}
+          savePending={false}
+          clearPending={false}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Set it up' }));
+      fireEvent.change(screen.getByLabelText('App configuration token'), {
+        target: { value: 'xoxe.xoxp-config-token' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Create Slack app' }));
+
+      expect(
+        await screen.findByRole('link', { name: /the Roomote logo/i }),
+      ).toHaveAttribute('href', '/api/setup/roomote-logo');
+      expect(screen.getByRole('link', { name: /the app/i })).toHaveAttribute(
+        'href',
+        'https://api.slack.com/apps/A0NEWAPP',
+      );
     });
 
     it('shows numbered Microsoft setup with the settings env-var note', () => {

--- a/apps/web/src/components/settings/CommsProviderSection.test.tsx
+++ b/apps/web/src/components/settings/CommsProviderSection.test.tsx
@@ -83,6 +83,7 @@ const state = vi.hoisted(() => ({
   slackChannelsIsError: false,
   slackChannelsIsFetching: false,
   updateRouterDebugIsPending: false,
+  createSlackAppIsPending: false,
 }));
 
 const mutations = vi.hoisted(() => ({
@@ -123,10 +124,14 @@ vi.mock('@tanstack/react-query', () => ({
     };
   },
   useMutation: (options: {
+    mutationName?: string;
     onSuccess?: (settings: unknown) => void;
     onError?: (error: Error) => void;
   }) => ({
-    isPending: state.updateRouterDebugIsPending,
+    isPending:
+      options.mutationName === 'createSlackApp'
+        ? state.createSlackAppIsPending
+        : state.updateRouterDebugIsPending,
     mutate: (input: unknown) => {
       if (input && typeof input === 'object' && 'configToken' in input) {
         options.onSuccess?.({
@@ -194,7 +199,10 @@ vi.mock('@/trpc/client', () => ({
     slack: {
       installation: { queryKey: () => ['slack', 'installation'] },
       createAppFromManifest: {
-        mutationOptions: (options: unknown) => options,
+        mutationOptions: (options: unknown) => ({
+          ...(options as Record<string, unknown>),
+          mutationName: 'createSlackApp',
+        }),
       },
     },
     comms: {
@@ -202,6 +210,9 @@ vi.mock('@/trpc/client', () => ({
       repairTelegram: {
         mutationOptions: (options: unknown) => options,
       },
+    },
+    environmentVariables: {
+      list: { queryKey: () => ['environmentVariables', 'list'] },
     },
     routerDebug: {
       getSettings: {
@@ -555,6 +566,7 @@ describe('CommsProviderSection', () => {
     state.slackChannelsIsError = false;
     state.slackChannelsIsFetching = false;
     state.updateRouterDebugIsPending = false;
+    state.createSlackAppIsPending = false;
   });
 
   describe('numbered setup instructions', () => {
@@ -600,7 +612,7 @@ describe('CommsProviderSection', () => {
     });
 
     it('shows logo actions after creating a Slack app from a config token', async () => {
-      render(
+      const { rerender } = render(
         <CommsProviderSection
           provider={buildSlackProvider()}
           onSave={vi.fn()}
@@ -623,6 +635,49 @@ describe('CommsProviderSection', () => {
         'href',
         'https://api.slack.com/apps/A0NEWAPP',
       );
+
+      rerender(
+        <CommsProviderSection
+          provider={buildSlackProvider({
+            runtimeSatisfied: false,
+            savedSatisfied: true,
+            setupSatisfied: true,
+          })}
+          onSave={vi.fn()}
+          onClear={vi.fn()}
+          savePending={false}
+          clearPending={false}
+        />,
+      );
+
+      expect(screen.getByRole('link', { name: /the app/i })).toHaveAttribute(
+        'href',
+        'https://api.slack.com/apps/A0NEWAPP',
+      );
+    });
+
+    it('keeps alternate Slack setup actions disabled while app creation is pending', () => {
+      state.createSlackAppIsPending = true;
+
+      render(
+        <CommsProviderSection
+          provider={buildSlackProvider()}
+          onSave={vi.fn()}
+          onClear={vi.fn()}
+          savePending={false}
+          clearPending={false}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Set it up' }));
+
+      expect(screen.getByLabelText('App configuration token')).toBeDisabled();
+      expect(
+        screen.getByRole('button', { name: /Create Slack app/ }),
+      ).toBeDisabled();
+      expect(
+        screen.getByRole('button', { name: /Create app manually/ }),
+      ).toBeDisabled();
     });
 
     it('shows numbered Microsoft setup with the settings env-var note', () => {
@@ -692,6 +747,12 @@ describe('CommsProviderSection', () => {
       ).not.toBeInTheDocument();
       expect(
         screen.queryByPlaceholderText('Telegram Webhook Secret'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('link', { name: /prefilled manifest/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/Create the app in Slack/i),
       ).not.toBeInTheDocument();
       expect(screen.getByText('Telegram Bot Token')).toBeInTheDocument();
       expect(

--- a/apps/web/src/components/settings/CommsProviderSection.test.tsx
+++ b/apps/web/src/components/settings/CommsProviderSection.test.tsx
@@ -184,6 +184,9 @@ vi.mock('@/trpc/client', () => ({
   useTRPC: () => ({
     slack: {
       installation: { queryKey: () => ['slack', 'installation'] },
+      createAppFromManifest: {
+        mutationOptions: (options: unknown) => options,
+      },
     },
     comms: {
       status: { queryKey: () => ['comms', 'status'] },
@@ -563,7 +566,13 @@ describe('CommsProviderSection', () => {
         screen.queryByRole('heading', { name: 'Create Slack app' }),
       ).not.toBeInTheDocument();
       expect(
-        screen.getByRole('link', { name: 'Create Slack app' }),
+        screen.getByRole('button', { name: 'Create Slack app' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByLabelText('App configuration token'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: /prefilled manifest/ }),
       ).toBeInTheDocument();
 
       fireEvent.click(

--- a/apps/web/src/components/settings/CommsProviderSection.test.tsx
+++ b/apps/web/src/components/settings/CommsProviderSection.test.tsx
@@ -4,7 +4,7 @@ import type {
   ReactElement,
   ReactNode,
 } from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { CommsProviderSection } from './CommsProviderSection';
 
@@ -89,6 +89,7 @@ const state = vi.hoisted(() => ({
 const mutations = vi.hoisted(() => ({
   connectSlack: vi.fn(),
   disconnectSlack: vi.fn(),
+  invalidateQueries: vi.fn(),
   updateRouterDebug: vi.fn(),
   refetchSlackChannels: vi.fn(),
 }));
@@ -152,7 +153,7 @@ vi.mock('@tanstack/react-query', () => ({
   }),
   useQueryClient: () => ({
     setQueryData: vi.fn(),
-    invalidateQueries: vi.fn(),
+    invalidateQueries: mutations.invalidateQueries,
   }),
 }));
 
@@ -567,6 +568,7 @@ describe('CommsProviderSection', () => {
     state.slackChannelsIsFetching = false;
     state.updateRouterDebugIsPending = false;
     state.createSlackAppIsPending = false;
+    mutations.invalidateQueries.mockReset();
   });
 
   describe('numbered setup instructions', () => {
@@ -635,6 +637,14 @@ describe('CommsProviderSection', () => {
         'href',
         'https://api.slack.com/apps/A0NEWAPP',
       );
+      await waitFor(() => {
+        expect(mutations.invalidateQueries).toHaveBeenCalledWith({
+          queryKey: ['comms', 'status'],
+        });
+        expect(mutations.invalidateQueries).toHaveBeenCalledWith({
+          queryKey: ['environmentVariables', 'list'],
+        });
+      });
 
       rerender(
         <CommsProviderSection
@@ -654,6 +664,20 @@ describe('CommsProviderSection', () => {
         'href',
         'https://api.slack.com/apps/A0NEWAPP',
       );
+
+      rerender(
+        <CommsProviderSection
+          provider={buildSlackProvider()}
+          onSave={vi.fn()}
+          onClear={vi.fn()}
+          savePending={false}
+          clearPending={false}
+        />,
+      );
+
+      expect(
+        screen.queryByRole('link', { name: /the app/i }),
+      ).not.toBeInTheDocument();
     });
 
     it('keeps alternate Slack setup actions disabled while app creation is pending', () => {

--- a/apps/web/src/components/settings/CommsProviderSection.tsx
+++ b/apps/web/src/components/settings/CommsProviderSection.tsx
@@ -513,8 +513,9 @@ export function CommsProviderSection({
           return;
         }
 
+        setCreatedSlackAppSettingsUrl(result.appSettingsUrl);
         toast.success(
-          'Slack app created and credentials saved. Connect it to your workspace to finish.',
+          'Slack app created and credentials saved. Add the Roomote icon, then connect it to your workspace.',
         );
         await queryClient.invalidateQueries({
           queryKey: trpc.comms.status.queryKey(),
@@ -559,6 +560,9 @@ export function CommsProviderSection({
     Record<string, boolean>
   >({});
   const [showManualSlackValues, setShowManualSlackValues] = useState(false);
+  const [createdSlackAppSettingsUrl, setCreatedSlackAppSettingsUrl] = useState<
+    string | null
+  >(null);
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
 
   useEffect(() => {
@@ -566,6 +570,7 @@ export function CommsProviderSection({
     setEditingSavedValues({});
     setClearedSavedValues({});
     setShowManualSlackValues(false);
+    setCreatedSlackAppSettingsUrl(null);
     setRemoveDialogOpen(false);
     // nonSecretInitialValues is content-keyed to avoid identity-only resets.
     // eslint-disable-next-line react-hooks/exhaustive-deps -- content-keyed
@@ -731,6 +736,7 @@ export function CommsProviderSection({
               clearedSavedValues={clearedSavedValues}
               teamsAppPackageHref={teamsAppPackageHref}
               showManualSlackValues={showManualSlackValues}
+              createdSlackAppSettingsUrl={createdSlackAppSettingsUrl}
               createSlackAppPending={createSlackApp.isPending}
               surface="settings"
               envVarsInfoNote={

--- a/apps/web/src/components/settings/CommsProviderSection.tsx
+++ b/apps/web/src/components/settings/CommsProviderSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -501,9 +501,6 @@ export function CommsProviderSection({
         await queryClient.invalidateQueries({
           queryKey: trpc.comms.status.queryKey(),
         });
-        await queryClient.invalidateQueries({
-          queryKey: trpc.environmentVariables.list.queryKey(),
-        });
       },
       onError: (error) => toast.error(error.message),
     }),
@@ -522,6 +519,9 @@ export function CommsProviderSection({
         );
         await queryClient.invalidateQueries({
           queryKey: trpc.comms.status.queryKey(),
+        });
+        await queryClient.invalidateQueries({
+          queryKey: trpc.environmentVariables.list.queryKey(),
         });
       },
       onError: (error) => toast.error(error.message),
@@ -566,6 +566,10 @@ export function CommsProviderSection({
   const [createdSlackAppSettingsUrl, setCreatedSlackAppSettingsUrl] = useState<
     string | null
   >(null);
+  const previousConfiguredValues = useRef<{
+    providerId: CommsProviderId;
+    hasConfiguredValues: boolean;
+  } | null>(null);
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
 
   useEffect(() => {
@@ -582,10 +586,6 @@ export function CommsProviderSection({
     provider.savedSatisfied,
     nonSecretValuesKey,
   ]);
-
-  useEffect(() => {
-    setCreatedSlackAppSettingsUrl(null);
-  }, [provider.id]);
 
   useEffect(() => {
     setExpanded(
@@ -643,6 +643,25 @@ export function CommsProviderSection({
 
   const hasConfiguredValues =
     provider.runtimeSatisfied || provider.savedSatisfied;
+
+  useEffect(() => {
+    const previous = previousConfiguredValues.current;
+
+    if (
+      previous?.providerId !== provider.id ||
+      (provider.id === 'slack' &&
+        previous.hasConfiguredValues &&
+        !hasConfiguredValues)
+    ) {
+      setCreatedSlackAppSettingsUrl(null);
+    }
+
+    previousConfiguredValues.current = {
+      providerId: provider.id,
+      hasConfiguredValues,
+    };
+  }, [provider.id, hasConfiguredValues]);
+
   const hasEditableFields = visibleFields.some(
     (field) => !field.runtimeSatisfied,
   );

--- a/apps/web/src/components/settings/CommsProviderSection.tsx
+++ b/apps/web/src/components/settings/CommsProviderSection.tsx
@@ -505,6 +505,24 @@ export function CommsProviderSection({
       onError: (error) => toast.error(error.message),
     }),
   );
+  const createSlackApp = useMutation(
+    trpc.slack.createAppFromManifest.mutationOptions({
+      onSuccess: async (result) => {
+        if (!result.success) {
+          toast.error(result.error);
+          return;
+        }
+
+        toast.success(
+          'Slack app created and credentials saved. Connect it to your workspace to finish.',
+        );
+        await queryClient.invalidateQueries({
+          queryKey: trpc.comms.status.queryKey(),
+        });
+      },
+      onError: (error) => toast.error(error.message),
+    }),
+  );
   const isMicrosoftProvider = provider.id === 'microsoft';
   const teamsIntegrationStatus = useTeamsIntegrationStatus({
     enabled: isMicrosoftProvider,
@@ -713,6 +731,7 @@ export function CommsProviderSection({
               clearedSavedValues={clearedSavedValues}
               teamsAppPackageHref={teamsAppPackageHref}
               showManualSlackValues={showManualSlackValues}
+              createSlackAppPending={createSlackApp.isPending}
               surface="settings"
               envVarsInfoNote={
                 !provider.runtimeSatisfied && provider.id === 'telegram'
@@ -720,6 +739,9 @@ export function CommsProviderSection({
                   : !provider.runtimeSatisfied && provider.id === 'discord'
                     ? 'Roomote validates the token, derives the bot identity, and registers /new, /link, and /help when you save.'
                     : undefined
+              }
+              onCreateSlackApp={(configToken) =>
+                createSlackApp.mutate({ configToken })
               }
               onShowManualSlackValues={() => setShowManualSlackValues(true)}
               onValueChange={(envVarName, value) =>

--- a/apps/web/src/components/settings/CommsProviderSection.tsx
+++ b/apps/web/src/components/settings/CommsProviderSection.tsx
@@ -501,6 +501,9 @@ export function CommsProviderSection({
         await queryClient.invalidateQueries({
           queryKey: trpc.comms.status.queryKey(),
         });
+        await queryClient.invalidateQueries({
+          queryKey: trpc.environmentVariables.list.queryKey(),
+        });
       },
       onError: (error) => toast.error(error.message),
     }),
@@ -570,7 +573,6 @@ export function CommsProviderSection({
     setEditingSavedValues({});
     setClearedSavedValues({});
     setShowManualSlackValues(false);
-    setCreatedSlackAppSettingsUrl(null);
     setRemoveDialogOpen(false);
     // nonSecretInitialValues is content-keyed to avoid identity-only resets.
     // eslint-disable-next-line react-hooks/exhaustive-deps -- content-keyed
@@ -580,6 +582,10 @@ export function CommsProviderSection({
     provider.savedSatisfied,
     nonSecretValuesKey,
   ]);
+
+  useEffect(() => {
+    setCreatedSlackAppSettingsUrl(null);
+  }, [provider.id]);
 
   useEffect(() => {
     setExpanded(

--- a/apps/web/src/trpc/commands/setup-new/index.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.ts
@@ -138,6 +138,7 @@ import {
   prepareComputeProvisioningStart,
   runComputeProvisioning,
 } from '../compute/compute-provisioning';
+import { createSlackAppFromManifest } from '../slack/create-app-from-manifest';
 import {
   assertValidSourceControlConfigInput,
   saveSourceControlConfigValues,
@@ -2257,6 +2258,19 @@ export async function saveSetupBootstrapAuthConfigCommand(input: {
     values: input.values,
     actorUserId: null,
     requireBootstrapOpen: true,
+  });
+}
+
+export async function createSetupBootstrapSlackAppFromManifestCommand(input: {
+  configToken: string;
+  setupToken?: string;
+}) {
+  assertSetupTokenValid(await resolveSetupTokenInput(input.setupToken));
+  await assertSetupBootstrapOpen();
+
+  return createSlackAppFromManifest({
+    configToken: input.configToken,
+    actorUserId: null,
   });
 }
 

--- a/apps/web/src/trpc/commands/slack/create-app-from-manifest.test.ts
+++ b/apps/web/src/trpc/commands/slack/create-app-from-manifest.test.ts
@@ -1,0 +1,219 @@
+import type { FeatureFlag } from '@roomote/feature-flags';
+
+import type { UserAuthSuccess } from '@/types';
+
+const {
+  mockDbTransaction,
+  mockFetch,
+  mockUpsertDeploymentEnvironmentVariables,
+} = vi.hoisted(() => ({
+  mockDbTransaction: vi.fn(),
+  mockFetch: vi.fn(),
+  mockUpsertDeploymentEnvironmentVariables: vi.fn(),
+}));
+
+vi.mock('@roomote/slack', () => ({
+  buildSlackApiUrl: (path: string) => `https://slack.example.test/api/${path}`,
+}));
+
+vi.mock('@roomote/db/server', () => ({
+  db: {
+    transaction: mockDbTransaction,
+  },
+}));
+
+vi.mock('@/lib/server', () => ({
+  Env: {
+    R_APP_URL: 'https://roomote.example.com/',
+  },
+}));
+
+vi.mock('../environment-variables', () => ({
+  upsertDeploymentEnvironmentVariables:
+    mockUpsertDeploymentEnvironmentVariables,
+}));
+
+vi.stubGlobal('fetch', mockFetch);
+
+import { createSlackAppFromManifestCommand } from './create-app-from-manifest';
+
+function buildMockAuth(
+  overrides: Partial<UserAuthSuccess> = {},
+): UserAuthSuccess {
+  return {
+    success: true,
+    userType: 'user',
+    userId: 'slack-manifest-test-user',
+    isAdmin: true,
+    name: 'Slack Manifest Tester',
+    primaryEmail: 'slack@example.com',
+    featureFlags: {} as Record<FeatureFlag, boolean>,
+    resource: {
+      username: 'slack-manifest-tester',
+      fullName: 'Slack Manifest Tester',
+      firstName: 'Slack',
+      lastName: 'Tester',
+      primaryEmailAddress: { id: '1', emailAddress: 'slack@example.com' },
+      emailAddresses: [{ id: '1', emailAddress: 'slack@example.com' }],
+      imageUrl: 'https://example.com/avatar.png',
+      createdAt: new Date(),
+    },
+    ...overrides,
+  } as UserAuthSuccess;
+}
+
+function mockSlackResponse(body: unknown, status = 200) {
+  mockFetch.mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  });
+}
+
+describe('createSlackAppFromManifestCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbTransaction.mockImplementation(async (callback) =>
+      callback({ kind: 'tx' }),
+    );
+  });
+
+  it('rejects non-admin users without calling Slack', async () => {
+    const result = await createSlackAppFromManifestCommand(
+      buildMockAuth({ isAdmin: false }),
+      { configToken: 'xoxe.xoxp-token' },
+    );
+
+    expect(result).toEqual({ success: false, error: 'Unauthorized' });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('creates the app and persists the three Slack env vars in one transaction', async () => {
+    mockSlackResponse({
+      ok: true,
+      app_id: 'A0NEWAPP',
+      credentials: {
+        client_id: 'new-client-id',
+        client_secret: 'new-client-secret',
+        verification_token: 'new-verification-token',
+        signing_secret: 'new-signing-secret',
+      },
+      oauth_authorize_url: 'https://slack.com/oauth/v2/authorize?client_id=x',
+    });
+
+    const result = await createSlackAppFromManifestCommand(buildMockAuth(), {
+      configToken: '  xoxe.xoxp-token  ',
+    });
+
+    expect(result).toEqual({ success: true, appId: 'A0NEWAPP' });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://slack.example.test/api/apps.manifest.create');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      'Bearer xoxe.xoxp-token',
+    );
+
+    const body = JSON.parse(String(init.body)) as { manifest: string };
+    const manifest = JSON.parse(body.manifest);
+    expect(manifest).toMatchObject({
+      display_information: { name: 'Roomote' },
+      settings: {
+        event_subscriptions: {
+          request_url: 'https://roomote.example.com/api/webhooks/slack',
+        },
+      },
+    });
+
+    expect(mockDbTransaction).toHaveBeenCalledTimes(1);
+    expect(mockUpsertDeploymentEnvironmentVariables).toHaveBeenCalledWith(
+      { kind: 'tx' },
+      {
+        userId: 'slack-manifest-test-user',
+        values: [
+          { name: 'R_SLACK_CLIENT_ID', value: 'new-client-id' },
+          { name: 'R_SLACK_CLIENT_SECRET', value: 'new-client-secret' },
+          { name: 'R_SLACK_SIGNING_SECRET', value: 'new-signing-secret' },
+        ],
+      },
+    );
+  });
+
+  it('maps configuration-token failures to an actionable error', async () => {
+    mockSlackResponse({ ok: false, error: 'invalid_auth' });
+
+    const result = await createSlackAppFromManifestCommand(buildMockAuth(), {
+      configToken: 'xoxe.xoxp-expired',
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        'Slack rejected the app configuration token. Generate a fresh token at api.slack.com/apps and try again.',
+    });
+    expect(mockUpsertDeploymentEnvironmentVariables).not.toHaveBeenCalled();
+  });
+
+  it('surfaces structured manifest validation errors', async () => {
+    mockSlackResponse({
+      ok: false,
+      error: 'invalid_manifest',
+      errors: [
+        { message: 'invalid scope', pointer: '/oauth_config/scopes/bot' },
+        { message: 'missing bot user' },
+      ],
+    });
+
+    const result = await createSlackAppFromManifestCommand(buildMockAuth(), {
+      configToken: 'xoxe.xoxp-token',
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        'Slack rejected the generated app manifest: invalid scope (/oauth_config/scopes/bot); missing bot user',
+    });
+    expect(mockUpsertDeploymentEnvironmentVariables).not.toHaveBeenCalled();
+  });
+
+  it('fails when Slack omits credentials from a successful response', async () => {
+    mockSlackResponse({
+      ok: true,
+      app_id: 'A0NEWAPP',
+      credentials: {
+        client_id: 'new-client-id',
+      },
+    });
+
+    const result = await createSlackAppFromManifestCommand(buildMockAuth(), {
+      configToken: 'xoxe.xoxp-token',
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Slack returned an incomplete app creation response.',
+    });
+    expect(mockUpsertDeploymentEnvironmentVariables).not.toHaveBeenCalled();
+  });
+
+  it('fails with an HTTP error when the response body is not JSON', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: async () => {
+        throw new Error('not json');
+      },
+    });
+
+    const result = await createSlackAppFromManifestCommand(buildMockAuth(), {
+      configToken: 'xoxe.xoxp-token',
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Failed to create the Slack app (HTTP 502). Please try again.',
+    });
+    expect(mockUpsertDeploymentEnvironmentVariables).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/trpc/commands/slack/create-app-from-manifest.test.ts
+++ b/apps/web/src/trpc/commands/slack/create-app-from-manifest.test.ts
@@ -144,6 +144,88 @@ describe('createSlackAppFromManifestCommand', () => {
     );
   });
 
+  it('deletes the created Slack app when persisting credentials fails', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          app_id: 'A0NEWAPP',
+          credentials: {
+            client_id: 'new-client-id',
+            client_secret: 'new-client-secret',
+            verification_token: 'new-verification-token',
+            signing_secret: 'new-signing-secret',
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true }),
+      });
+    mockDbTransaction.mockRejectedValue(new Error('database is unavailable'));
+
+    const result = await createSlackAppFromManifestCommand(buildMockAuth(), {
+      configToken: 'xoxe.xoxp-token',
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        'Slack app credentials could not be saved. The Slack app was deleted automatically; try again when the issue is resolved.',
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const [deleteUrl, deleteInit] = mockFetch.mock.calls[1] as [
+      string,
+      RequestInit,
+    ];
+    expect(deleteUrl).toBe(
+      'https://slack.example.test/api/apps.manifest.delete',
+    );
+    expect(deleteInit.method).toBe('POST');
+    expect((deleteInit.headers as Record<string, string>).Authorization).toBe(
+      'Bearer xoxe.xoxp-token',
+    );
+    expect(JSON.parse(String(deleteInit.body))).toEqual({ app_id: 'A0NEWAPP' });
+  });
+
+  it('returns a recovery path when cleanup after persistence failure fails', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          app_id: 'A0NEWAPP',
+          credentials: {
+            client_id: 'new-client-id',
+            client_secret: 'new-client-secret',
+            verification_token: 'new-verification-token',
+            signing_secret: 'new-signing-secret',
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: false, error: 'app_not_found' }),
+      });
+    mockDbTransaction.mockRejectedValue(new Error('database is unavailable'));
+
+    const result = await createSlackAppFromManifestCommand(buildMockAuth(), {
+      configToken: 'xoxe.xoxp-token',
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        'Slack app credentials could not be saved. The Slack app A0NEWAPP was created but could not be deleted automatically; delete it from api.slack.com/apps before trying again.',
+    });
+  });
+
   it('maps configuration-token failures to an actionable error', async () => {
     mockSlackResponse({ ok: false, error: 'invalid_auth' });
 
@@ -196,7 +278,8 @@ describe('createSlackAppFromManifestCommand', () => {
 
     expect(result).toEqual({
       success: false,
-      error: 'Slack returned an incomplete app creation response.',
+      error:
+        'Slack returned an incomplete app creation response. The Slack app was deleted automatically; try again when the issue is resolved.',
     });
     expect(mockUpsertDeploymentEnvironmentVariables).not.toHaveBeenCalled();
   });

--- a/apps/web/src/trpc/commands/slack/create-app-from-manifest.test.ts
+++ b/apps/web/src/trpc/commands/slack/create-app-from-manifest.test.ts
@@ -226,6 +226,36 @@ describe('createSlackAppFromManifestCommand', () => {
     });
   });
 
+  it('returns a recovery path when cleanup rejects after persistence failure', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          app_id: 'A0NEWAPP',
+          credentials: {
+            client_id: 'new-client-id',
+            client_secret: 'new-client-secret',
+            verification_token: 'new-verification-token',
+            signing_secret: 'new-signing-secret',
+          },
+        }),
+      })
+      .mockRejectedValueOnce(new Error('network down'));
+    mockDbTransaction.mockRejectedValue(new Error('database is unavailable'));
+
+    const result = await createSlackAppFromManifestCommand(buildMockAuth(), {
+      configToken: 'xoxe.xoxp-token',
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        'Slack app credentials could not be saved. The Slack app A0NEWAPP was created but could not be deleted automatically; delete it from api.slack.com/apps before trying again.',
+    });
+  });
+
   it('maps configuration-token failures to an actionable error', async () => {
     mockSlackResponse({ ok: false, error: 'invalid_auth' });
 

--- a/apps/web/src/trpc/commands/slack/create-app-from-manifest.test.ts
+++ b/apps/web/src/trpc/commands/slack/create-app-from-manifest.test.ts
@@ -105,7 +105,11 @@ describe('createSlackAppFromManifestCommand', () => {
       configToken: '  xoxe.xoxp-token  ',
     });
 
-    expect(result).toEqual({ success: true, appId: 'A0NEWAPP' });
+    expect(result).toEqual({
+      success: true,
+      appId: 'A0NEWAPP',
+      appSettingsUrl: 'https://api.slack.com/apps/A0NEWAPP',
+    });
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];

--- a/apps/web/src/trpc/commands/slack/create-app-from-manifest.ts
+++ b/apps/web/src/trpc/commands/slack/create-app-from-manifest.ts
@@ -25,6 +25,11 @@ type SlackManifestCreateResponse = {
   oauth_authorize_url?: string;
 };
 
+type SlackManifestDeleteResponse = {
+  ok?: boolean;
+  error?: string;
+};
+
 type CreateSlackAppFromManifestResult =
   | { success: true; appId: string; appSettingsUrl: string }
   | { success: false; error: string };
@@ -61,6 +66,42 @@ function formatManifestErrors(
   }
 
   return `Slack rejected the generated app manifest: ${messages.join('; ')}`;
+}
+
+async function deleteSlackAppFromManifest({
+  configToken,
+  appId,
+}: {
+  configToken: string;
+  appId: string;
+}): Promise<{ success: true } | { success: false; error: string }> {
+  const response = await fetch(buildSlackApiUrl('apps.manifest.delete'), {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${configToken}`,
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+    body: JSON.stringify({ app_id: appId }),
+  });
+
+  let data: SlackManifestDeleteResponse | null = null;
+
+  try {
+    data = (await response.json()) as SlackManifestDeleteResponse;
+  } catch {
+    data = null;
+  }
+
+  if (data?.ok) {
+    return { success: true };
+  }
+
+  return {
+    success: false,
+    error: data?.error
+      ? `Slack returned an error while deleting the app: ${data.error}`
+      : `Failed to delete the Slack app after credential persistence failed (HTTP ${response.status}).`,
+  };
 }
 
 /**
@@ -146,23 +187,64 @@ export async function createSlackAppFromManifest({
     const clientSecret = data.credentials?.client_secret?.trim() ?? '';
     const signingSecret = data.credentials?.signing_secret?.trim() ?? '';
 
+    const cleanupCreatedApp = async (reason: string) => {
+      const cleanupResult = await deleteSlackAppFromManifest({
+        configToken: normalizedConfigToken,
+        appId,
+      });
+
+      if (!cleanupResult.success) {
+        console.error(
+          '[createSlackAppFromManifest] Failed to delete created Slack app:',
+          cleanupResult.error,
+        );
+
+        return {
+          success: false,
+          error: `${reason} The Slack app ${appId} was created but could not be deleted automatically; delete it from api.slack.com/apps before trying again.`,
+        } satisfies CreateSlackAppFromManifestResult;
+      }
+
+      return {
+        success: false,
+        error: `${reason} The Slack app was deleted automatically; try again when the issue is resolved.`,
+      } satisfies CreateSlackAppFromManifestResult;
+    };
+
     if (!appId || !clientId || !clientSecret || !signingSecret) {
+      if (appId) {
+        return await cleanupCreatedApp(
+          'Slack returned an incomplete app creation response.',
+        );
+      }
+
       return {
         success: false,
         error: 'Slack returned an incomplete app creation response.',
       };
     }
 
-    await db.transaction(async (tx) => {
-      await upsertDeploymentEnvironmentVariables(tx, {
-        userId: actorUserId,
-        values: [
-          { name: 'R_SLACK_CLIENT_ID', value: clientId },
-          { name: 'R_SLACK_CLIENT_SECRET', value: clientSecret },
-          { name: 'R_SLACK_SIGNING_SECRET', value: signingSecret },
-        ],
+    try {
+      await db.transaction(async (tx) => {
+        await upsertDeploymentEnvironmentVariables(tx, {
+          userId: actorUserId,
+          values: [
+            { name: 'R_SLACK_CLIENT_ID', value: clientId },
+            { name: 'R_SLACK_CLIENT_SECRET', value: clientSecret },
+            { name: 'R_SLACK_SIGNING_SECRET', value: signingSecret },
+          ],
+        });
       });
-    });
+    } catch (error) {
+      console.error(
+        '[createSlackAppFromManifest] Failed to persist Slack credentials:',
+        error,
+      );
+
+      return await cleanupCreatedApp(
+        'Slack app credentials could not be saved.',
+      );
+    }
 
     return {
       success: true,

--- a/apps/web/src/trpc/commands/slack/create-app-from-manifest.ts
+++ b/apps/web/src/trpc/commands/slack/create-app-from-manifest.ts
@@ -26,7 +26,7 @@ type SlackManifestCreateResponse = {
 };
 
 type CreateSlackAppFromManifestResult =
-  | { success: true; appId: string }
+  | { success: true; appId: string; appSettingsUrl: string }
   | { success: false; error: string };
 
 const CONFIG_TOKEN_ERRORS = new Set([
@@ -164,7 +164,11 @@ export async function createSlackAppFromManifest({
       });
     });
 
-    return { success: true, appId };
+    return {
+      success: true,
+      appId,
+      appSettingsUrl: `https://api.slack.com/apps/${encodeURIComponent(appId)}`,
+    };
   } catch (error) {
     console.error('[createSlackAppFromManifest] Unhandled error:', error);
 

--- a/apps/web/src/trpc/commands/slack/create-app-from-manifest.ts
+++ b/apps/web/src/trpc/commands/slack/create-app-from-manifest.ts
@@ -1,0 +1,190 @@
+import { buildSlackApiUrl } from '@roomote/slack';
+import { db } from '@roomote/db/server';
+
+import type { UserAuthSuccess } from '@/types';
+import { Env } from '@/lib/server';
+import { buildSlackAppManifest } from '@/lib/slack-app-manifest';
+import { upsertDeploymentEnvironmentVariables } from '../environment-variables';
+
+type SlackManifestCreateError = {
+  message?: string;
+  pointer?: string;
+};
+
+type SlackManifestCreateResponse = {
+  ok?: boolean;
+  error?: string;
+  errors?: SlackManifestCreateError[];
+  app_id?: string;
+  credentials?: {
+    client_id?: string;
+    client_secret?: string;
+    verification_token?: string;
+    signing_secret?: string;
+  };
+  oauth_authorize_url?: string;
+};
+
+type CreateSlackAppFromManifestResult =
+  | { success: true; appId: string }
+  | { success: false; error: string };
+
+const CONFIG_TOKEN_ERRORS = new Set([
+  'invalid_auth',
+  'not_authed',
+  'token_expired',
+  'token_revoked',
+  'token_rotated',
+]);
+
+const CONFIG_TOKEN_ERROR_MESSAGE =
+  'Slack rejected the app configuration token. Generate a fresh token at api.slack.com/apps and try again.';
+
+function formatManifestErrors(
+  errors: SlackManifestCreateError[] | undefined,
+): string | null {
+  const messages = (errors ?? [])
+    .map((error) => {
+      const message = error.message?.trim();
+
+      if (!message) {
+        return null;
+      }
+
+      const pointer = error.pointer?.trim();
+      return pointer ? `${message} (${pointer})` : message;
+    })
+    .filter((message): message is string => message !== null);
+
+  if (messages.length === 0) {
+    return null;
+  }
+
+  return `Slack rejected the generated app manifest: ${messages.join('; ')}`;
+}
+
+/**
+ * Creates a Slack app via `apps.manifest.create` using a user-supplied app
+ * configuration token, then persists the resulting credentials as deployment
+ * environment variables. The configuration token is used for this one call
+ * and never stored.
+ */
+export async function createSlackAppFromManifest({
+  configToken,
+  actorUserId,
+}: {
+  configToken: string;
+  actorUserId: string | null;
+}): Promise<CreateSlackAppFromManifestResult> {
+  try {
+    const normalizedConfigToken = configToken.trim();
+
+    if (!normalizedConfigToken) {
+      return {
+        success: false,
+        error: 'Enter a Slack app configuration token.',
+      };
+    }
+
+    const publicOrigin = Env.R_APP_URL?.trim();
+
+    if (!publicOrigin) {
+      return {
+        success: false,
+        error:
+          'The deployment public URL is not configured, so the Slack app manifest cannot be built.',
+      };
+    }
+
+    const manifest = buildSlackAppManifest({ publicOrigin });
+
+    const response = await fetch(buildSlackApiUrl('apps.manifest.create'), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${normalizedConfigToken}`,
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      body: JSON.stringify({ manifest: JSON.stringify(manifest) }),
+    });
+
+    let data: SlackManifestCreateResponse | null = null;
+
+    try {
+      data = (await response.json()) as SlackManifestCreateResponse;
+    } catch {
+      data = null;
+    }
+
+    if (!data) {
+      return {
+        success: false,
+        error: `Failed to create the Slack app (HTTP ${response.status}). Please try again.`,
+      };
+    }
+
+    if (!data.ok) {
+      if (data.error && CONFIG_TOKEN_ERRORS.has(data.error)) {
+        return { success: false, error: CONFIG_TOKEN_ERROR_MESSAGE };
+      }
+
+      const manifestError = formatManifestErrors(data.errors);
+
+      if (manifestError) {
+        return { success: false, error: manifestError };
+      }
+
+      return {
+        success: false,
+        error: data.error
+          ? `Slack returned an error: ${data.error}`
+          : 'Slack returned an unknown error while creating the app.',
+      };
+    }
+
+    const appId = data.app_id?.trim() ?? '';
+    const clientId = data.credentials?.client_id?.trim() ?? '';
+    const clientSecret = data.credentials?.client_secret?.trim() ?? '';
+    const signingSecret = data.credentials?.signing_secret?.trim() ?? '';
+
+    if (!appId || !clientId || !clientSecret || !signingSecret) {
+      return {
+        success: false,
+        error: 'Slack returned an incomplete app creation response.',
+      };
+    }
+
+    await db.transaction(async (tx) => {
+      await upsertDeploymentEnvironmentVariables(tx, {
+        userId: actorUserId,
+        values: [
+          { name: 'R_SLACK_CLIENT_ID', value: clientId },
+          { name: 'R_SLACK_CLIENT_SECRET', value: clientSecret },
+          { name: 'R_SLACK_SIGNING_SECRET', value: signingSecret },
+        ],
+      });
+    });
+
+    return { success: true, appId };
+  } catch (error) {
+    console.error('[createSlackAppFromManifest] Unhandled error:', error);
+
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export async function createSlackAppFromManifestCommand(
+  auth: UserAuthSuccess,
+  input: { configToken: string },
+): Promise<CreateSlackAppFromManifestResult> {
+  if (!auth.isAdmin) {
+    return { success: false, error: 'Unauthorized' };
+  }
+
+  return createSlackAppFromManifest({
+    configToken: input.configToken,
+    actorUserId: auth.userId,
+  });
+}

--- a/apps/web/src/trpc/commands/slack/create-app-from-manifest.ts
+++ b/apps/web/src/trpc/commands/slack/create-app-from-manifest.ts
@@ -188,15 +188,26 @@ export async function createSlackAppFromManifest({
     const signingSecret = data.credentials?.signing_secret?.trim() ?? '';
 
     const cleanupCreatedApp = async (reason: string) => {
-      const cleanupResult = await deleteSlackAppFromManifest({
-        configToken: normalizedConfigToken,
-        appId,
-      });
+      let cleanupResult: Awaited<
+        ReturnType<typeof deleteSlackAppFromManifest>
+      > | null = null;
 
-      if (!cleanupResult.success) {
+      try {
+        cleanupResult = await deleteSlackAppFromManifest({
+          configToken: normalizedConfigToken,
+          appId,
+        });
+      } catch (error) {
         console.error(
           '[createSlackAppFromManifest] Failed to delete created Slack app:',
-          cleanupResult.error,
+          error,
+        );
+      }
+
+      if (!cleanupResult?.success) {
+        console.error(
+          '[createSlackAppFromManifest] Failed to delete created Slack app:',
+          cleanupResult?.error ?? 'delete request failed',
         );
 
         return {

--- a/apps/web/src/trpc/commands/slack/index.ts
+++ b/apps/web/src/trpc/commands/slack/index.ts
@@ -34,6 +34,8 @@ import {
 } from '@/lib/server/slack-oauth-state';
 import { encodeRecord } from '@/lib/url-coder';
 
+export { createSlackAppFromManifestCommand } from './create-app-from-manifest';
+
 interface SlackOAuthResponse {
   ok: boolean;
   access_token?: string;

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -96,6 +96,7 @@ import {
 import {
   exchangeSlackOAuthCodeCommand,
   connectSlackAppCommand,
+  createSlackAppFromManifestCommand,
   disconnectSlackAppCommand,
   getSlackInstallationCommand,
   startAuthenticateSlackAccountCommand,
@@ -218,6 +219,7 @@ import {
 import {
   getSetupNewStatusCommand,
   getSetupBootstrapStatusCommand,
+  createSetupBootstrapSlackAppFromManifestCommand,
   saveSetupBootstrapAuthConfigCommand,
   saveSetupBootstrapAuthProviderChoiceCommand,
   saveSetupNewAuthConfigCommand,
@@ -884,6 +886,12 @@ export const appRouter = createRouter({
       .input(z.object({ redirectPath: z.string().optional() }).optional())
       .mutation(({ ctx: { auth }, input }) =>
         connectSlackAppCommand(auth, input),
+      ),
+
+    createAppFromManifest: protectedProcedure
+      .input(z.object({ configToken: z.string().trim().min(1) }))
+      .mutation(({ ctx: { auth }, input }) =>
+        createSlackAppFromManifestCommand(auth, input),
       ),
 
     disconnectApp: protectedProcedure.mutation(({ ctx: { auth } }) =>
@@ -1934,6 +1942,17 @@ export const appRouter = createRouter({
         }),
       )
       .mutation(({ input }) => saveSetupBootstrapAuthConfigCommand(input)),
+
+    createSlackAppFromManifest: publicProcedure
+      .input(
+        z.object({
+          configToken: z.string().trim().min(1),
+          setupToken: z.string().optional(),
+        }),
+      )
+      .mutation(({ input }) =>
+        createSetupBootstrapSlackAppFromManifestCommand(input),
+      ),
   }),
 
   deployment: createRouter({

--- a/packages/slack/src/__tests__/mock-slack-server.test.ts
+++ b/packages/slack/src/__tests__/mock-slack-server.test.ts
@@ -628,6 +628,86 @@ describe('MockSlackServer', () => {
     }
   });
 
+  it('rejects apps.manifest.create with invalid_manifest when a string manifest parses to a non-object', async () => {
+    const server = new MockSlackServer({
+      state: {
+        team: { id: 'T1', domain: 'mock-roomote' },
+        channels: [{ id: 'C1', name: 'product-debug', isMember: true }],
+        users: [{ id: 'U1', name: 'alex', displayName: 'Alex' }],
+      },
+    });
+
+    try {
+      await server.start();
+
+      for (const manifest of ['[]', '1', '"text"', 'null']) {
+        const response = await fetch(
+          `${server.baseUrl}/api/apps.manifest.create`,
+          {
+            method: 'POST',
+            headers: {
+              authorization: 'Bearer xoxe.xoxp-any-token',
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify({ manifest }),
+          },
+        );
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toEqual({
+          ok: false,
+          error: 'invalid_manifest',
+          errors: [
+            { message: 'manifest must be a JSON object', pointer: '/manifest' },
+          ],
+        });
+      }
+
+      expect(server.getState().createdManifests ?? []).toEqual([]);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('deletes an app through apps.manifest.delete with a config token', async () => {
+    const server = new MockSlackServer({
+      state: {
+        team: { id: 'T1', domain: 'mock-roomote' },
+        acceptedConfigTokens: ['xoxe.xoxp-config-token'],
+        channels: [{ id: 'C1', name: 'product-debug', isMember: true }],
+        users: [{ id: 'U1', name: 'alex', displayName: 'Alex' }],
+        createdManifests: [
+          {
+            appId: 'A0MANIFEST',
+            manifest: { display_information: { name: 'Roomote' } },
+          },
+        ],
+      },
+    });
+
+    try {
+      await server.start();
+
+      const response = await fetch(
+        `${server.baseUrl}/api/apps.manifest.delete`,
+        {
+          method: 'POST',
+          headers: {
+            authorization: 'Bearer xoxe.xoxp-config-token',
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({ app_id: 'A0MANIFEST' }),
+        },
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ ok: true });
+      expect(server.getState().createdManifests).toEqual([]);
+    } finally {
+      await server.stop();
+    }
+  });
+
   it('returns not_in_channel for conversations.members when the app is not in the channel', async () => {
     const server = new MockSlackServer({
       state: {

--- a/packages/slack/src/__tests__/mock-slack-server.test.ts
+++ b/packages/slack/src/__tests__/mock-slack-server.test.ts
@@ -489,6 +489,145 @@ describe('MockSlackServer', () => {
     }
   });
 
+  it('creates an app through apps.manifest.create with a config token and records the manifest', async () => {
+    const server = new MockSlackServer({
+      state: {
+        team: { id: 'T1', domain: 'mock-roomote' },
+        acceptedBotTokens: ['xoxb-mock-token'],
+        acceptedConfigTokens: ['xoxe.xoxp-config-token'],
+        manifestCredentials: {
+          appId: 'A0MANIFEST',
+          clientId: 'manifest-client-id',
+          clientSecret: 'manifest-client-secret',
+          signingSecret: 'manifest-signing-secret',
+        },
+        channels: [{ id: 'C1', name: 'product-debug', isMember: true }],
+        users: [{ id: 'U1', name: 'alex', displayName: 'Alex' }],
+      },
+    });
+
+    try {
+      await server.start();
+
+      const manifest = {
+        display_information: { name: 'Roomote' },
+        settings: {
+          event_subscriptions: {
+            request_url: 'https://roomote.example.com/api/webhooks/slack',
+          },
+        },
+      };
+
+      // Config-token routes must not require a bot token: the config token
+      // is the only credential on this request.
+      const response = await fetch(
+        `${server.baseUrl}/api/apps.manifest.create`,
+        {
+          method: 'POST',
+          headers: {
+            authorization: 'Bearer xoxe.xoxp-config-token',
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({ manifest: JSON.stringify(manifest) }),
+        },
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        ok: true,
+        app_id: 'A0MANIFEST',
+        credentials: {
+          client_id: 'manifest-client-id',
+          client_secret: 'manifest-client-secret',
+          verification_token: 'mock-manifest-verification-token',
+          signing_secret: 'manifest-signing-secret',
+        },
+        oauth_authorize_url:
+          'https://slack.com/oauth/v2/authorize?client_id=manifest-client-id',
+      });
+
+      expect(server.getState().createdManifests).toEqual([
+        { appId: 'A0MANIFEST', manifest },
+      ]);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('rejects apps.manifest.create with invalid_auth for an unknown config token', async () => {
+    const server = new MockSlackServer({
+      state: {
+        team: { id: 'T1', domain: 'mock-roomote' },
+        acceptedConfigTokens: ['xoxe.xoxp-config-token'],
+        channels: [{ id: 'C1', name: 'product-debug', isMember: true }],
+        users: [{ id: 'U1', name: 'alex', displayName: 'Alex' }],
+      },
+    });
+
+    try {
+      await server.start();
+
+      const response = await fetch(
+        `${server.baseUrl}/api/apps.manifest.create`,
+        {
+          method: 'POST',
+          headers: {
+            authorization: 'Bearer xoxe.xoxp-wrong-token',
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({ manifest: '{}' }),
+        },
+      );
+
+      // Real Slack reports Web API failures as HTTP 200 with ok=false.
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        ok: false,
+        error: 'invalid_auth',
+      });
+      expect(server.getState().createdManifests ?? []).toEqual([]);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('rejects apps.manifest.create with invalid_manifest when the manifest is not JSON', async () => {
+    const server = new MockSlackServer({
+      state: {
+        team: { id: 'T1', domain: 'mock-roomote' },
+        channels: [{ id: 'C1', name: 'product-debug', isMember: true }],
+        users: [{ id: 'U1', name: 'alex', displayName: 'Alex' }],
+      },
+    });
+
+    try {
+      await server.start();
+
+      const response = await fetch(
+        `${server.baseUrl}/api/apps.manifest.create`,
+        {
+          method: 'POST',
+          headers: {
+            authorization: 'Bearer xoxe.xoxp-any-token',
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({ manifest: 'not-json' }),
+        },
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        ok: false,
+        error: 'invalid_manifest',
+        errors: [
+          { message: 'manifest must be a JSON object', pointer: '/manifest' },
+        ],
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+
   it('returns not_in_channel for conversations.members when the app is not in the channel', async () => {
     const server = new MockSlackServer({
       state: {

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -16,6 +16,7 @@ export * from './manager-mcp-setup';
 export * from './request-user-input-blocks';
 export * from './request-user-input';
 export * from './router-debug';
+export * from './slack-api-base-url';
 export * from './slack-messages';
 export * from './slack-notifier';
 export * from './slack-system-messages';

--- a/packages/slack/src/mock-slack-server.ts
+++ b/packages/slack/src/mock-slack-server.ts
@@ -645,7 +645,15 @@ export class MockSlackServer {
 
         if (typeof manifestValue === 'string') {
           try {
-            manifest = JSON.parse(manifestValue) as JsonRecord;
+            const parsedManifest = JSON.parse(manifestValue);
+
+            if (
+              parsedManifest &&
+              typeof parsedManifest === 'object' &&
+              !Array.isArray(parsedManifest)
+            ) {
+              manifest = parsedManifest as JsonRecord;
+            }
           } catch {
             manifest = null;
           }
@@ -695,6 +703,31 @@ export class MockSlackServer {
           },
           oauth_authorize_url: `https://slack.com/oauth/v2/authorize?client_id=${encodeURIComponent(clientId)}`,
         });
+        return;
+      }
+
+      case 'POST apps.manifest.delete': {
+        // Real Slack reports Web API failures as HTTP 200 with `ok: false`.
+        if (!this.isConfigTokenAuthorized(request)) {
+          json(response, 200, { ok: false, error: 'invalid_auth' });
+          return;
+        }
+
+        const appId =
+          typeof jsonBody.app_id === 'string' ? jsonBody.app_id : '';
+        const createdManifests = this.state.createdManifests ?? [];
+        const nextCreatedManifests = createdManifests.filter(
+          (createdManifest) => createdManifest.appId !== appId,
+        );
+
+        if (!appId || nextCreatedManifests.length === createdManifests.length) {
+          json(response, 200, { ok: false, error: 'app_not_found' });
+          return;
+        }
+
+        this.state.createdManifests = nextCreatedManifests;
+
+        json(response, 200, { ok: true });
         return;
       }
 

--- a/packages/slack/src/mock-slack-server.ts
+++ b/packages/slack/src/mock-slack-server.ts
@@ -56,6 +56,19 @@ export type MockSlackTeam = {
   timezone?: string;
 };
 
+export type MockSlackManifestCredentials = {
+  appId?: string;
+  clientId?: string;
+  clientSecret?: string;
+  signingSecret?: string;
+  verificationToken?: string;
+};
+
+export type MockSlackCreatedManifest = {
+  appId: string;
+  manifest: Record<string, unknown>;
+};
+
 export type MockSlackState = {
   team: MockSlackTeam;
   acceptedBotTokens?: string[];
@@ -70,6 +83,17 @@ export type MockSlackState = {
   channels: MockSlackChannel[];
   users: MockSlackUser[];
   messages?: MockSlackStoredMessage[];
+  /**
+   * Bearer tokens accepted by app-config endpoints (`apps.manifest.create`).
+   * Slack app configuration tokens live in a different token space than bot
+   * tokens, so they get their own allowlist. Undefined accepts any token,
+   * mirroring `acceptedBotTokens`.
+   */
+  acceptedConfigTokens?: string[];
+  /** Credential overrides returned by `apps.manifest.create`. */
+  manifestCredentials?: MockSlackManifestCredentials;
+  /** Apps created through `apps.manifest.create`, oldest first. */
+  createdManifests?: MockSlackCreatedManifest[];
 };
 
 export type MockSlackRoomoteTarget = {
@@ -423,7 +447,12 @@ export class MockSlackServer {
       return;
     }
 
-    if (!this.isAuthorized(request)) {
+    // App-config endpoints authenticate with configuration tokens instead of
+    // bot tokens, so they skip the bot check and validate in their handler.
+    if (
+      url.pathname !== '/api/apps.manifest.create' &&
+      !this.isAuthorized(request)
+    ) {
       json(response, 401, { ok: false, error: 'invalid_auth' });
       return;
     }
@@ -433,6 +462,21 @@ export class MockSlackServer {
 
   private isAuthorized(request: IncomingMessage): boolean {
     const allowedTokens = this.state.acceptedBotTokens;
+    if (!allowedTokens?.length) {
+      return true;
+    }
+
+    const authorization = request.headers.authorization;
+    if (!authorization?.startsWith('Bearer ')) {
+      return false;
+    }
+
+    const token = authorization.slice('Bearer '.length).trim();
+    return allowedTokens.includes(token);
+  }
+
+  private isConfigTokenAuthorized(request: IncomingMessage): boolean {
+    const allowedTokens = this.state.acceptedConfigTokens;
     if (!allowedTokens?.length) {
       return true;
     }
@@ -585,6 +629,71 @@ export class MockSlackServer {
           ok: true,
           members: paginatedMembers,
           response_metadata: { next_cursor: nextCursor },
+        });
+        return;
+      }
+
+      case 'POST apps.manifest.create': {
+        // Real Slack reports Web API failures as HTTP 200 with `ok: false`.
+        if (!this.isConfigTokenAuthorized(request)) {
+          json(response, 200, { ok: false, error: 'invalid_auth' });
+          return;
+        }
+
+        const manifestValue = jsonBody.manifest;
+        let manifest: JsonRecord | null = null;
+
+        if (typeof manifestValue === 'string') {
+          try {
+            manifest = JSON.parse(manifestValue) as JsonRecord;
+          } catch {
+            manifest = null;
+          }
+        } else if (
+          manifestValue &&
+          typeof manifestValue === 'object' &&
+          !Array.isArray(manifestValue)
+        ) {
+          manifest = manifestValue as JsonRecord;
+        }
+
+        if (!manifest) {
+          json(response, 200, {
+            ok: false,
+            error: 'invalid_manifest',
+            errors: [
+              {
+                message: 'manifest must be a JSON object',
+                pointer: '/manifest',
+              },
+            ],
+          });
+          return;
+        }
+
+        const credentials = this.state.manifestCredentials ?? {};
+        const appId = credentials.appId ?? 'AMOCKMANIFEST';
+        const clientId = credentials.clientId ?? 'mock-manifest-client-id';
+
+        this.state.createdManifests = [
+          ...(this.state.createdManifests ?? []),
+          { appId, manifest },
+        ];
+
+        json(response, 200, {
+          ok: true,
+          app_id: appId,
+          credentials: {
+            client_id: clientId,
+            client_secret:
+              credentials.clientSecret ?? 'mock-manifest-client-secret',
+            verification_token:
+              credentials.verificationToken ??
+              'mock-manifest-verification-token',
+            signing_secret:
+              credentials.signingSecret ?? 'mock-manifest-signing-secret',
+          },
+          oauth_authorize_url: `https://slack.com/oauth/v2/authorize?client_id=${encodeURIComponent(clientId)}`,
         });
         return;
       }


### PR DESCRIPTION
## Why this PR exists

- [x] I am a maintainer / this is internal Roomote work

## What changed

Slack setup used to open a prefilled manifest in Slack's UI and then flip into manual mode so the user could copy three secrets across. From the user's chair, setup goes from "create app in one tab, hunt through Slack settings, three copy-pastes, save, connect" to "click Generate on one Slack page, paste one token, approve the install."

- The Slack setup step (wizard, bootstrap, and Settings → Communications) now shows one **App configuration token** field with a link to api.slack.com/apps and two lines of instructions.
- A new admin-gated tRPC command (`slack.createAppFromManifest`, plus a setup-token-gated `setupBootstrap.createSlackAppFromManifest` variant for the bootstrap wizard) builds the manifest with the existing `buildSlackAppManifest({ publicOrigin })`, POSTs it to Slack's `apps.manifest.create`, and on success upserts `R_SLACK_CLIENT_ID`, `R_SLACK_CLIENT_SECRET`, and `R_SLACK_SIGNING_SECRET` in one transaction (same pattern as the GitHub App manifest flow). The config token is used once and never stored.
- On success the UI advances straight to the Connect to Slack install step — no "now go find your credentials" interlude.
- Both escape hatches stay: **Enter values manually**, and the prefilled-manifest link as a secondary path for anyone who'd rather not generate a config token.
- Error handling maps cleanly to the token field: `invalid_auth`/expired-token errors get an actionable "generate a fresh token" message, and manifest problems surface Slack's structured `errors` array with pointers.
- The mock Slack harness gains a `POST apps.manifest.create` route with its own `acceptedConfigTokens` allowlist (config tokens are a different token space than bot tokens), optional `manifestCredentials` overrides, and created manifests recorded in `/mock/state`, so the whole flow is testable without a real workspace. The route is reachable via the existing `SLACK_API_BASE_URL` routing.
- Docs: the Slack provider page's "Fast path" now documents the token flow with the prefilled manifest as the alternative; the mock-slack-testing skill documents the new harness knobs.

## How it was tested

- New unit tests for the command: success (manifest content, routed URL, Bearer header, single-transaction upsert of the three env vars), token errors, structured manifest errors, incomplete credentials, non-JSON responses, and non-admin rejection.
- New mock-server tests: create with a config token + manifest recorded in state, `invalid_auth` for unknown config tokens (HTTP 200 + `ok: false`, matching real Slack), and `invalid_manifest` for malformed manifests.
- Updated/added UI tests for the wizard and Settings surfaces (token field shown by default, create button disabled until a token is entered, prefilled-manifest link flips to manual mode, token success invalidates status and advances, failures toast without advancing).
- 308 slack-package + 541 web tests in the affected areas pass; `pnpm lint`, `pnpm check-types`, and `pnpm knip` are clean.
- Not exercised: a live click-through against the full dev stack. The ordering risk around Slack probing the webhook before the signing secret persists is unchanged relative to the current flow (the app exists in Slack long before the secret lands today), and the API flow shrinks that window from minutes to milliseconds.

## Checklist

- [x] The PR title follows the repo convention: `[Fix]`, `[Feat]`, `[Improve]`, `[Refactor]`, `[Docs]`, or `[Chore]` followed by a user-facing description
- [x] This PR is small and scoped to one change
- [x] `pnpm lint` and `pnpm check-types` pass locally
- [x] I added tests or included a clear manual validation note above
- [x] I removed secrets, tokens, private keys, and customer data from code, logs, and screenshots
- [x] If this change should appear in the changelog, I ran `pnpm changeset`