### PR TITLE
Fix cost analytics cutoff encoding

### DIFF
--- a/apps/web/src/lib/server/analytics/cost-rows.test.ts
+++ b/apps/web/src/lib/server/analytics/cost-rows.test.ts
@@ -1,0 +1,51 @@
+import { db, inArray, llmUsageEvents } from '@roomote/db/server';
+
+import type { UserAuthSuccess } from '@/types';
+
+import { getCostAnalyticsRows } from './cost-rows';
+
+describe('getCostAnalyticsRows', () => {
+  const usageEventIds: string[] = [];
+
+  afterEach(async () => {
+    if (usageEventIds.length === 0) {
+      return;
+    }
+
+    await db
+      .delete(llmUsageEvents)
+      .where(inArray(llmUsageEvents.id, usageEventIds));
+    usageEventIds.length = 0;
+  });
+
+  it('encodes finite time-period cutoffs and excludes older usage', async () => {
+    const now = new Date('2026-07-16T16:00:00.000Z');
+    const insertedEvents = await db
+      .insert(llmUsageEvents)
+      .values([
+        {
+          eventKey: `cost-analytics-recent-${crypto.randomUUID()}`,
+          costSource: 'missing',
+          costMicroUsd: 1_000_000,
+          messageCompletedAt: new Date('2026-07-15T12:00:00.000Z'),
+        },
+        {
+          eventKey: `cost-analytics-old-${crypto.randomUUID()}`,
+          costSource: 'missing',
+          costMicroUsd: 2_000_000,
+          messageCompletedAt: new Date('2026-07-01T12:00:00.000Z'),
+        },
+      ])
+      .returning({ id: llmUsageEvents.id });
+    const recentEvent = insertedEvents[0]!;
+    const oldEvent = insertedEvents[1]!;
+
+    usageEventIds.push(recentEvent.id, oldEvent.id);
+
+    const rows = await getCostAnalyticsRows({} as UserAuthSuccess, 7, now);
+    const rowIds = new Set(rows.map((row) => row.id));
+
+    expect(rowIds.has(recentEvent.id)).toBe(true);
+    expect(rowIds.has(oldEvent.id)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/server/analytics/cost-rows.ts
+++ b/apps/web/src/lib/server/analytics/cost-rows.ts
@@ -36,7 +36,10 @@ export async function getCostAnalyticsRows(
 ): Promise<AnalyticsRow[]> {
   const cutoff = getTimeCutoff(timePeriod, now);
   const usageCutoffCondition = cutoff
-    ? sql`coalesce(${llmUsageEvents.messageCompletedAt}, ${llmUsageEvents.createdAt}) >= ${cutoff}`
+    ? sql`coalesce(${llmUsageEvents.messageCompletedAt}, ${llmUsageEvents.createdAt}) >= ${sql.param(
+        cutoff,
+        llmUsageEvents.createdAt,
+      )}`
     : undefined;
   const usageRows = await db
     .select({


### PR DESCRIPTION
## Summary

- encode the cost analytics time cutoff with the Drizzle timestamp column encoder
- add database-backed regression coverage for finite time-period filtering

## Root cause

The cost analytics query interpolated a JavaScript `Date` into an untyped raw SQL parameter. postgres.js could not serialize that value and rejected the query before execution, causing the analytics chart and filter procedures to return 500 responses.

## Impact

Cost analytics can load normally for finite periods such as the default seven-day view, while preserving SQL-side filtering.

## Validation

- targeted web Vitest regression test
- `@roomote/web` TypeScript check
- focused formatting and oxlint checks
- pre-push oxlint, residual lint, fast type checks, and knip
