### PR TITLE
fix: use adaptive thinking for Anthropic models that reject extended-thinking budgets

### DIFF
--- a/packages/types/src/__tests__/opencode-reasoning.test.ts
+++ b/packages/types/src/__tests__/opencode-reasoning.test.ts
@@ -28,18 +28,81 @@ describe('buildOpenCodeModelReasoningOptions', () => {
     ).toEqual({ reasoning: { effort: 'high' } });
   });
 
-  it('maps Anthropic direct models to extended-thinking budgets', () => {
+  it('maps pre-adaptive Anthropic models to extended-thinking budgets', () => {
     expect(
       buildOpenCodeModelReasoningOptions('anthropic/claude-sonnet-4', 'high'),
     ).toEqual({
       thinking: { type: 'enabled', budgetTokens: 16_000 },
     });
+    expect(
+      buildOpenCodeModelReasoningOptions(
+        'anthropic/claude-sonnet-4-5-20250929',
+        'medium',
+      ),
+    ).toEqual({
+      thinking: { type: 'enabled', budgetTokens: 8_000 },
+    });
+    expect(
+      buildOpenCodeModelReasoningOptions('anthropic/claude-haiku-4-5', 'low'),
+    ).toEqual({
+      thinking: { type: 'enabled', budgetTokens: 4_000 },
+    });
+    expect(
+      buildOpenCodeModelReasoningOptions('anthropic/claude-opus-4-5', 'high'),
+    ).toEqual({
+      thinking: { type: 'enabled', budgetTokens: 16_000 },
+    });
   });
 
-  it('maps Bedrock Mantle models to Anthropic extended-thinking budgets', () => {
+  it('maps adaptive-thinking Anthropic models to adaptive with effort', () => {
+    expect(
+      buildOpenCodeModelReasoningOptions('anthropic/claude-sonnet-5', 'xhigh'),
+    ).toEqual({
+      thinking: { type: 'adaptive', display: 'summarized' },
+      effort: 'xhigh',
+    });
+    expect(
+      buildOpenCodeModelReasoningOptions('anthropic/claude-opus-4-8', 'high'),
+    ).toEqual({
+      thinking: { type: 'adaptive', display: 'summarized' },
+      effort: 'high',
+    });
+    expect(
+      buildOpenCodeModelReasoningOptions('anthropic/claude-fable-5', 'medium'),
+    ).toEqual({
+      thinking: { type: 'adaptive', display: 'summarized' },
+      effort: 'medium',
+    });
+  });
+
+  it('clamps xhigh to high for the Anthropic 4.6 family', () => {
+    expect(
+      buildOpenCodeModelReasoningOptions('anthropic/claude-opus-4-6', 'xhigh'),
+    ).toEqual({
+      thinking: { type: 'adaptive' },
+      effort: 'high',
+    });
+    expect(
+      buildOpenCodeModelReasoningOptions('anthropic/claude-sonnet-4-6', 'high'),
+    ).toEqual({
+      thinking: { type: 'adaptive' },
+      effort: 'high',
+    });
+  });
+
+  it('maps Bedrock Mantle models like the Anthropic provider', () => {
     expect(
       buildOpenCodeModelReasoningOptions(
         'bedrock-mantle/anthropic.claude-sonnet-5',
+        'high',
+      ),
+    ).toEqual({
+      thinking: { type: 'adaptive', display: 'summarized' },
+      effort: 'high',
+    });
+    expect(
+      buildOpenCodeModelReasoningOptions(
+        'bedrock-mantle/anthropic.claude-haiku-4-5',
         'high',
       ),
     ).toEqual({

--- a/packages/types/src/opencode-reasoning.ts
+++ b/packages/types/src/opencode-reasoning.ts
@@ -3,7 +3,8 @@ import type { ReasoningEffort } from './task-runs';
 /**
  * Maps a Roomote reasoning effort to the Anthropic extended-thinking token
  * budgets OpenCode uses for its own built-in variants (`high` ~16k tokens,
- * `max` ~32k tokens).
+ * `max` ~32k tokens). Only applies to models predating adaptive thinking —
+ * see `resolveAnthropicThinkingMode`.
  */
 const ANTHROPIC_THINKING_BUDGET_TOKENS: Record<ReasoningEffort, number> = {
   low: 4_000,
@@ -11,6 +12,108 @@ const ANTHROPIC_THINKING_BUDGET_TOKENS: Record<ReasoningEffort, number> = {
   high: 16_000,
   xhigh: 31_999,
 };
+
+/**
+ * How an Anthropic model expects reasoning to be configured:
+ *
+ * - `adaptive` — Opus 4.7+, Sonnet 5+, and Fable/Mythos reject
+ *   `thinking.type: "enabled"` with a 400 and take
+ *   `thinking.type: "adaptive"` plus an `effort` (including `xhigh`). These
+ *   models also default thinking display to "omitted" (empty thinking
+ *   blocks), so we force `display: "summarized"`.
+ * - `adaptive-no-xhigh` — the 4.6 family accepts adaptive thinking but not
+ *   the `xhigh` effort, and already defaults display to "summarized".
+ * - `budget` — older models (Sonnet 4.5, Haiku 4.5, Opus 4.5, ...) still use
+ *   `thinking.type: "enabled"` with a token budget.
+ */
+type AnthropicThinkingMode = 'adaptive' | 'adaptive-no-xhigh' | 'budget';
+
+/**
+ * Parses the `<family>-<major>[-<minor>]` version out of an Anthropic model
+ * id, accepting `.` or `-` separators, dated suffixes
+ * (`claude-sonnet-4-5-20250929`), Bedrock's `anthropic.` prefix, and the
+ * inverted legacy ordering (`claude-3-5-sonnet`).
+ */
+function parseAnthropicModelVersion(
+  modelID: string,
+  family: 'opus' | 'sonnet',
+): { major: number; minor: number } | null {
+  const pattern = new RegExp(
+    `${family}-(\\d+)(?:[.-](\\d+))?(?:[.@-]|$)|claude-(\\d+)(?:[.-](\\d+))?-${family}(?:[.@-]|$)`,
+    'iu',
+  );
+  const match = pattern.exec(modelID);
+
+  if (!match) {
+    return null;
+  }
+
+  return {
+    major: Number(match[1] ?? match[3]),
+    minor: Number(match[2] ?? match[4] ?? 0),
+  };
+}
+
+function resolveAnthropicThinkingMode(modelID: string): AnthropicThinkingMode {
+  const id = modelID.toLowerCase();
+
+  if (id.includes('fable') || id.includes('mythos')) {
+    return 'adaptive';
+  }
+
+  const opus = parseAnthropicModelVersion(id, 'opus');
+
+  if (opus) {
+    if (opus.major > 4 || (opus.major === 4 && opus.minor >= 7)) {
+      return 'adaptive';
+    }
+
+    return opus.major === 4 && opus.minor === 6
+      ? 'adaptive-no-xhigh'
+      : 'budget';
+  }
+
+  const sonnet = parseAnthropicModelVersion(id, 'sonnet');
+
+  if (sonnet) {
+    if (sonnet.major >= 5) {
+      return 'adaptive';
+    }
+
+    return sonnet.major === 4 && sonnet.minor === 6
+      ? 'adaptive-no-xhigh'
+      : 'budget';
+  }
+
+  return 'budget';
+}
+
+function buildAnthropicReasoningOptions(
+  modelID: string,
+  reasoningEffort: ReasoningEffort,
+): Record<string, unknown> {
+  const mode = resolveAnthropicThinkingMode(modelID);
+
+  if (mode === 'budget') {
+    return {
+      thinking: {
+        type: 'enabled',
+        budgetTokens: ANTHROPIC_THINKING_BUDGET_TOKENS[reasoningEffort],
+      },
+    };
+  }
+
+  return {
+    thinking: {
+      type: 'adaptive',
+      ...(mode === 'adaptive' ? { display: 'summarized' } : {}),
+    },
+    effort:
+      mode === 'adaptive-no-xhigh' && reasoningEffort === 'xhigh'
+        ? 'high'
+        : reasoningEffort,
+  };
+}
 
 export function splitTaskModelId(
   modelId: string,
@@ -38,8 +141,9 @@ function isOpenAiStyleOpenRouterModel(modelID: string): boolean {
  * Builds the OpenCode per-model `options` payload that applies a reasoning
  * effort for the given `provider/model` id. The option keys mirror the
  * provider-specific shapes OpenCode uses for its own built-in reasoning
- * variants: OpenRouter takes `reasoning.effort`, Anthropic takes an
- * extended-thinking budget, and OpenAI-compatible providers take
+ * variants: OpenRouter takes `reasoning.effort`, Anthropic takes adaptive
+ * thinking with an effort (or an extended-thinking budget on models
+ * predating adaptive thinking), and OpenAI-compatible providers take
  * `reasoningEffort`.
  *
  * Returns `null` when the model id cannot be parsed.
@@ -68,12 +172,7 @@ export function buildOpenCodeModelReasoningOptions(
     }
     case 'anthropic':
     case 'bedrock-mantle':
-      return {
-        thinking: {
-          type: 'enabled',
-          budgetTokens: ANTHROPIC_THINKING_BUDGET_TOKENS[reasoningEffort],
-        },
-      };
+      return buildAnthropicReasoningOptions(selection.modelID, reasoningEffort);
     default:
       return { reasoningEffort };
   }


### PR DESCRIPTION
## Problem

Tasks running on the direct `anthropic/` provider (or `bedrock-mantle/`) with a newer Claude model fail on the first model call:

> The provider returned an error: "thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.

`buildOpenCodeModelReasoningOptions` maps every Anthropic-provider model's reasoning effort to `thinking: { type: 'enabled', budgetTokens }`. Opus 4.7+, Sonnet 5+, and Fable/Mythos removed that parameter from the API and reject it with a 400, so any deployment whose configured role model is one of those (which is what the provider defaults and suggestions now recommend) fails on every task.

This is easy to miss in ad-hoc testing: a per-task model override only has a reasoning effort attached when it matches the deployment's configured coding model, so picking an Anthropic model in the task launcher works fine while the same model configured as the default coding model fails. Reproduced both ways locally.

## Fix

Resolve a per-model thinking mode for the `anthropic`/`bedrock-mantle` providers (both register OpenCode's `@ai-sdk/anthropic` provider, so they share one option shape):

- **Opus 4.7+, Sonnet 5+, Fable/Mythos** → `{ thinking: { type: 'adaptive', display: 'summarized' }, effort }`. `display: 'summarized'` is forced because these models default thinking display to `omitted` (empty thinking blocks). This matches the shape OpenCode 1.17.8's own variant builder emits for adaptive-capable models, so the pinned CLI's bundled AI SDK supports it.
- **Opus 4.6 / Sonnet 4.6** → adaptive without the display override (already defaults to summarized), with `xhigh` clamped to `high` (no `xhigh` on the 4.6 family) — mirroring the existing OpenRouter clamp.
- **Older models** (Sonnet 4.5, Haiku 4.5, Opus 4.5, ...) → unchanged extended-thinking budgets, which they still require.

Version parsing accepts `.`/`-` separators, dated suffixes (`claude-sonnet-4-5-20250929`), Bedrock's `anthropic.` prefix, and the inverted legacy ordering (`claude-3-5-sonnet`).

## Validation

- New unit tests for the adaptive mapping, 4.6 clamp, Bedrock Mantle ids, dated legacy ids, and the unchanged budget path; full `@roomote/types` suite (575) and worker `agent-home` tests pass; `pnpm lint` + `pnpm check-types` clean.
- Reproduced end-to-end locally: configured the deployment coding model to an Anthropic-provider Sonnet 5 and hit the exact 400 above on the first model call of a task.