### PR TITLE
Clarify Azure DevOps Entra setup

### DIFF
--- a/apps/web/src/app/(onboarding)/setup/AdoSourceControlConfig.tsx
+++ b/apps/web/src/app/(onboarding)/setup/AdoSourceControlConfig.tsx
@@ -131,7 +131,7 @@ export function AdoSourceControlInstructions({
           <p className="text-sm">
             Then go to{' '}
             <a
-              href="https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade"
+              href="https://entra.microsoft.com/#view/Microsoft_AAD_IAM/StartboardApplicationsMenuBlade/~/AppAppsPreview"
               target="_blank"
               rel="noopener noreferrer"
               className="font-semibold text-foreground underline"

--- a/apps/web/src/app/(onboarding)/setup/AdoSourceControlConfig.tsx
+++ b/apps/web/src/app/(onboarding)/setup/AdoSourceControlConfig.tsx
@@ -1,4 +1,4 @@
-import { Blocks, PlugZap, UserCog, UserKey } from 'lucide-react';
+import { Blocks, Cog, PlugZap, UserCog, UserKey } from 'lucide-react';
 import { InstructionUrl } from './ProviderSetupInstructions';
 
 type AdoAuthMode = 'pat' | 'entra' | 'delegated';
@@ -97,7 +97,12 @@ export function AdoSourceControlInstructions({
         Create a Microsoft Entra app.
       </p>
       <p className="text-sm">
-        Open{' '}
+        If you&apos;ve already created a Microsoft Entra app for Teams in this
+        tenant, you can reuse it{' '}
+        <span className="font-semibold">
+          after adding the Azure DevOps access below.
+        </span>{' '}
+        If not, open{' '}
         <a
           href="https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade"
           target="_blank"
@@ -107,16 +112,45 @@ export function AdoSourceControlInstructions({
           Azure App registrations
         </a>{' '}
         → New registration → Create an app in the Microsoft tenant that can
-        access your Azure DevOps organization. IF you&apos;ve created an app for
-        Teams, you can reuse it.
-        <br />
-        Make sure to add this Web Redirect URI:
+        access your Azure DevOps organization.
       </p>
-
-      <InstructionUrl
-        heading="Web redirect URI"
-        url={`${publicOrigin}/api/auth/oauth2/callback/ado`}
-      />
+      {authMode === 'delegated' && (
+        <>
+          <p className="text-sm">
+            In either case, add the specific web redirect URI below (under
+            Authentication):
+          </p>
+          <InstructionUrl
+            heading="Web redirect URI"
+            url={`${publicOrigin}/api/auth/oauth2/callback/ado`}
+          />
+        </>
+      )}
+      {authMode === 'entra' && (
+        <>
+          <p className="text-sm">
+            Then go to{' '}
+            <a
+              href="https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-semibold text-foreground underline"
+            >
+              Entra Enterprise Apps
+            </a>{' '}
+            → find the app you just created → copy the service principal object
+            ID.
+          </p>
+          <p className="text-sm">
+            In Azure DevOps, go to the organization →{' '}
+            <Cog className="inline mx-1" /> Organization Settings → Users → Add
+            users → paste the object ID.
+            <br />
+            Set the access to Basic, choose the right project/group membership →
+            Add.
+          </p>
+        </>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.client.test.tsx
@@ -384,7 +384,7 @@ describe('StepSourceControlConfig', () => {
       />,
     );
 
-    expect(screen.getByText('Azure DevOps Organization')).toBeInTheDocument();
+    expect(screen.getByText('ADO Organization (URL slug)')).toBeInTheDocument();
     expect(screen.getByText(/Microsoft Entra Client ID/)).toBeInTheDocument();
     expect(
       screen.queryByText(/Azure DevOps Access Token/),

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConfig.tsx
@@ -473,9 +473,9 @@ export function StepSourceControlConfig({
           )}
           {isAdo && adoAuthMode === 'entra' && (
             <p className="text-sm text-muted-foreground">
-              Create a client secret, add the application to the Azure DevOps
-              organization, and grant it access to the projects and repositories
-              Roomote should use.
+              Create a client secret, add the service principal to the Azure
+              DevOps organization, and grant it access to the projects and
+              repositories Roomote should use.
             </p>
           )}
 

--- a/apps/web/src/components/settings/SourceControlConfigForm.client.test.tsx
+++ b/apps/web/src/components/settings/SourceControlConfigForm.client.test.tsx
@@ -268,7 +268,7 @@ describe('SourceControlConfigForm', () => {
       />,
     );
 
-    expect(screen.getByText('Azure DevOps Organization')).toBeInTheDocument();
+    expect(screen.getByText('ADO Organization (URL slug)')).toBeInTheDocument();
     expect(screen.getByText(/Azure DevOps Access Token/)).toBeInTheDocument();
     expect(screen.getByText(/Azure DevOps Base URL/)).toBeInTheDocument();
     expect(screen.getByText(/Azure DevOps Username/)).toBeInTheDocument();

--- a/packages/types/src/setup-source-control-config.ts
+++ b/packages/types/src/setup-source-control-config.ts
@@ -308,7 +308,7 @@ function buildProviderFields(
         {
           envVarName: 'ADO_ORGANIZATION',
           acceptedEnvVarNames: ['ADO_ORGANIZATION'],
-          label: 'Azure DevOps Organization',
+          label: 'ADO Organization (URL slug)',
         },
         {
           envVarName: 'ADO_TOKEN',


### PR DESCRIPTION
## Summary
- clarify that an existing Teams Entra app can be reused after adding Azure DevOps access
- show the ADO OAuth redirect URI only for delegated auth setup
- clarify service principal setup copy and the ADO organization slug label

## Tests
- pnpm lint:fast
- pnpm check-types:fast
- pre-push hook: oxlint, residual lint, check-types:fast, knip