### PR TITLE
[Fix] Recognize managed-role mentions of the Discord bot

### DIFF
--- a/apps/discord-gateway/package.json
+++ b/apps/discord-gateway/package.json
@@ -28,6 +28,7 @@
     "discord.js": "^14.22.1"
   },
   "devDependencies": {
+    "@roomote/communication": "workspace:*",
     "@roomote/config-eslint": "workspace:^",
     "@roomote/config-typescript": "workspace:^",
     "@types/node": "^24.10.13",

--- a/apps/discord-gateway/src/dispatch.test.ts
+++ b/apps/discord-gateway/src/dispatch.test.ts
@@ -1,5 +1,7 @@
 import { Routes } from 'discord.js';
 
+import { parseDiscordGatewayEvent } from '@roomote/communication/discord-event';
+
 import { handleGatewayDispatch } from './dispatch';
 import type { DiscordInboundEnvelope } from './inbound-queue';
 
@@ -46,6 +48,131 @@ describe('handleGatewayDispatch', () => {
       payload,
       receivedAt: '2026-07-12T12:00:00.000Z',
     });
+  });
+
+  it('normalizes a managed-role mention into a canonical bot mention', async () => {
+    const enqueue = vi.fn().mockResolvedValue(true);
+    const rest = { post: vi.fn() };
+    // Discord's autocomplete resolved the bot by its managed role: user
+    // mentions are empty and only mention_roles carries the reference.
+    const payload = {
+      id: 'message-role-1',
+      channel_id: 'channel-1',
+      guild_id: 'guild-1',
+      content: '<@&bot-role-1> are you there?',
+      author: { id: 'user-1', username: 'dan', bot: false },
+      mentions: [],
+      mention_roles: ['bot-role-1'],
+    };
+
+    await expect(
+      handleGatewayDispatch(
+        { t: 'MESSAGE_CREATE', d: payload },
+        {
+          enqueue,
+          rest,
+          now,
+          getBotUserId: () => 'bot-1',
+          getBotUsername: () => 'RoomoteBot',
+          getBotRoleId: (guildId) =>
+            guildId === 'guild-1' ? 'bot-role-1' : undefined,
+        },
+      ),
+    ).resolves.toBe('enqueued');
+
+    const envelope = enqueue.mock.calls[0]?.[0] as DiscordInboundEnvelope;
+    const normalized = envelope.payload as {
+      content?: string;
+      mentions?: Array<{ id?: string; username?: string; bot?: boolean }>;
+    };
+    expect(normalized.content).toBe('<@bot-1> are you there?');
+    expect(normalized.mentions).toEqual([
+      { id: 'bot-1', username: 'RoomoteBot', bot: true },
+    ]);
+
+    // The normalized envelope must satisfy the API's real event schema —
+    // this is the contract that quarantined events when the injected
+    // mention was a bare id.
+    const parsed = parseDiscordGatewayEvent({
+      eventId: envelope.eventId,
+      eventType: envelope.eventType,
+      payload: envelope.payload,
+      receivedAt: envelope.receivedAt,
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('ignores mentions of roles that are not the bot managed role', async () => {
+    const enqueue = vi.fn();
+    const rest = { post: vi.fn() };
+
+    await expect(
+      handleGatewayDispatch(
+        {
+          t: 'MESSAGE_CREATE',
+          d: {
+            id: 'message-role-2',
+            channel_id: 'channel-1',
+            guild_id: 'guild-1',
+            content: '<@&some-team-role> morning everyone',
+            author: { id: 'user-1', username: 'dan', bot: false },
+            mentions: [],
+            mention_roles: ['some-team-role'],
+          },
+        },
+        {
+          enqueue,
+          rest,
+          now,
+          getBotUserId: () => 'bot-1',
+          getBotUsername: () => 'RoomoteBot',
+          getBotRoleId: () => 'bot-role-1',
+          getCachedChannel: () => ({
+            id: 'channel-1',
+            type: 0,
+            isThread: false,
+          }),
+        },
+      ),
+    ).resolves.toBe('ignored');
+
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('keeps the user-mention-only behavior when the bot role is unknown', async () => {
+    const enqueue = vi.fn();
+    const rest = { post: vi.fn() };
+
+    await expect(
+      handleGatewayDispatch(
+        {
+          t: 'MESSAGE_CREATE',
+          d: {
+            id: 'message-role-3',
+            channel_id: 'channel-1',
+            guild_id: 'guild-1',
+            content: '<@&bot-role-1> hello',
+            author: { id: 'user-1', username: 'dan', bot: false },
+            mentions: [],
+            mention_roles: ['bot-role-1'],
+          },
+        },
+        {
+          enqueue,
+          rest,
+          now,
+          getBotUserId: () => 'bot-1',
+          getBotUsername: () => 'RoomoteBot',
+          getCachedChannel: () => ({
+            id: 'channel-1',
+            type: 0,
+            isThread: false,
+          }),
+        },
+      ),
+    ).resolves.toBe('ignored');
+
+    expect(enqueue).not.toHaveBeenCalled();
   });
 
   it('drops unmentioned guild root messages before they reach the queue', async () => {

--- a/apps/discord-gateway/src/dispatch.ts
+++ b/apps/discord-gateway/src/dispatch.ts
@@ -17,7 +17,8 @@ type RawMessage = {
   guild_id?: string;
   content?: string;
   author?: { bot?: boolean };
-  mentions?: Array<{ id?: string }>;
+  mentions?: Array<{ id?: string; username?: string; bot?: boolean }>;
+  mention_roles?: string[];
 };
 
 type RawInteraction = {
@@ -34,6 +35,9 @@ type DispatchDependencies = {
   getCachedChannel?: (
     channelId: string,
   ) => DiscordCachedMessageChannel | undefined;
+  /** The bot's managed role id for a guild, when known. */
+  getBotRoleId?: (guildId: string) => string | null | undefined;
+  getBotUsername?: () => string | undefined;
   /**
    * Forward an unmentioned guild message when Gateway channel metadata could
    * not be resolved. The durable API consumer performs its own authoritative
@@ -52,6 +56,30 @@ export type DiscordCachedMessageChannel = {
   name?: string;
   isThread: boolean;
 };
+
+function isBotRoleMentioned(message: RawMessage, botRoleId: string): boolean {
+  return (
+    message.mention_roles?.includes(botRoleId) === true ||
+    message.content?.includes(`<@&${botRoleId}>`) === true
+  );
+}
+
+function normalizeBotRoleMention(
+  message: RawMessage,
+  botRoleId: string,
+  bot: { id: string; username: string },
+): RawMessage {
+  const mentions = message.mentions ?? [];
+  return {
+    ...message,
+    content: message.content?.replaceAll(`<@&${botRoleId}>`, `<@${bot.id}>`),
+    // The injected entry must satisfy the API's full user schema, not just
+    // carry an id.
+    mentions: mentions.some((mention) => mention.id === bot.id)
+      ? mentions
+      : [...mentions, { id: bot.id, username: bot.username, bot: true }],
+  };
+}
 
 function isBotMentioned(
   message: RawMessage,
@@ -162,7 +190,7 @@ export async function handleGatewayDispatch(
   }
 
   if (eventType === 'MESSAGE_CREATE') {
-    const message = packet.d as RawMessage;
+    let message = packet.d as RawMessage;
     if (!message.id || message.author?.bot) {
       return 'ignored';
     }
@@ -171,6 +199,26 @@ export async function handleGatewayDispatch(
       ? dependencies.getCachedChannel?.(message.channel_id)
       : undefined;
     const botUserId = dependencies.getBotUserId?.();
+    // Discord's mention autocomplete often resolves a bot by its managed
+    // role (same name as the bot), which arrives as mention_roles +
+    // <@&role> content with an empty user-mention list. Normalize that form
+    // to a canonical user mention so every downstream consumer (entry
+    // gating, mention stripping) sees one shape.
+    const botRoleId = message.guild_id
+      ? dependencies.getBotRoleId?.(message.guild_id)
+      : undefined;
+    const botUsername = dependencies.getBotUsername?.();
+    if (
+      botUserId &&
+      botUsername &&
+      botRoleId &&
+      isBotRoleMentioned(message, botRoleId)
+    ) {
+      message = normalizeBotRoleMention(message, botRoleId, {
+        id: botUserId,
+        username: botUsername,
+      });
+    }
     // Discord sends every message from subscribed guild channels. Root
     // channels only start Roomote work when the bot is mentioned, while DMs
     // and task threads retain natural follow-ups without an extra mention.

--- a/apps/discord-gateway/src/gateway-session.ts
+++ b/apps/discord-gateway/src/gateway-session.ts
@@ -74,7 +74,9 @@ export class DiscordGatewaySession {
   private manager: GatewayManager | null = null;
   private resumeStore: DiscordGatewayResumeStore | null = null;
   private channelCache = new DiscordGatewayChannelCache();
+  private botRoleIds = new Map<string, string | null>();
   private botUserId: string | undefined;
+  private botUsername: string | undefined;
   private expectedShardIds = new Set<number>();
   private connectedShardIds = new Set<number>();
   private dispatchState: DispatchConnectionState | null = null;
@@ -95,7 +97,9 @@ export class DiscordGatewaySession {
     }
 
     this.botUserId = identity.id;
+    this.botUsername = identity.username;
     this.channelCache = new DiscordGatewayChannelCache();
+    this.botRoleIds = new Map();
     this.connectedShardIds.clear();
     const dispatchState: DispatchConnectionState = {
       abortController: new AbortController(),
@@ -140,9 +144,20 @@ export class DiscordGatewaySession {
       dispatchState.pendingDispatches += 1;
       try {
         this.channelCache.ingest(data);
+        this.ingestBotRole(data);
         let enqueueUnknownGuildChannel = false;
         if (data.t === 'MESSAGE_CREATE') {
           const message = data.d as RawMessageDispatch;
+          if (message.guild_id && !this.botRoleIds.has(message.guild_id)) {
+            // Resumed sessions never replay GUILD_CREATE, so learn the bot's
+            // managed role lazily; a role mention cannot be classified
+            // without it. Failures are retried on the next guild message.
+            await this.fetchBotRole(message.guild_id, rest).catch((error) =>
+              this.status.update({
+                lastError: `Discord role lookup failed: ${error instanceof Error ? error.message : String(error)}`,
+              }),
+            );
+          }
           if (message.guild_id && message.channel_id) {
             try {
               const channel = await this.channelCache.fetch(
@@ -163,6 +178,8 @@ export class DiscordGatewaySession {
         }
 
         await handleGatewayDispatch(data, {
+          getBotRoleId: (guildId) => this.botRoleIds.get(guildId),
+          getBotUsername: () => this.botUsername,
           rest,
           getBotUserId: () => this.botUserId,
           getCachedChannel: (channelId) => this.channelCache.get(channelId),
@@ -329,6 +346,34 @@ export class DiscordGatewaySession {
 
   needsReconnect(): boolean {
     return this.reconnectRequired;
+  }
+
+  /** Learns the bot's managed role id from GUILD_CREATE role tags. */
+  private ingestBotRole(packet: { t?: string; d?: unknown }): void {
+    if (packet.t !== 'GUILD_CREATE' || !this.botUserId) return;
+    const guild = packet.d as {
+      id?: string;
+      roles?: Array<{ id?: string; tags?: { bot_id?: string } }>;
+    };
+    if (!guild.id) return;
+    const managedRole = guild.roles?.find(
+      (role) => role.tags?.bot_id === this.botUserId,
+    );
+    this.botRoleIds.set(guild.id, managedRole?.id ?? null);
+  }
+
+  private async fetchBotRole(
+    guildId: string,
+    rest: Pick<REST, 'get'>,
+  ): Promise<void> {
+    if (!this.botUserId) return;
+    const roles = (await rest.get(
+      `/guilds/${guildId}/roles` as `/${string}`,
+    )) as Array<{ id?: string; tags?: { bot_id?: string } }>;
+    const managedRole = roles.find(
+      (role) => role.tags?.bot_id === this.botUserId,
+    );
+    this.botRoleIds.set(guildId, managedRole?.id ?? null);
   }
 
   private markReconnectRequired(state: DispatchConnectionState): void {

--- a/packages/communication/src/mock-discord-server.ts
+++ b/packages/communication/src/mock-discord-server.ts
@@ -434,7 +434,11 @@ export class MockDiscordServer {
         (1n << 38n);
       return jsonResponse([
         { id: this.guildId, permissions: '0' },
-        { id: 'role-roomote', permissions: String(allNeeded) },
+        {
+          id: 'role-roomote',
+          permissions: String(allNeeded),
+          tags: { bot_id: this.bot.id },
+        },
       ]);
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -420,6 +420,9 @@ importers:
         specifier: ^14.22.1
         version: 14.26.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     devDependencies:
+      '@roomote/communication':
+        specifier: workspace:*
+        version: link:../../packages/communication
       '@roomote/config-eslint':
         specifier: workspace:^
         version: link:../../packages/config-eslint


### PR DESCRIPTION
Discord's mention autocomplete frequently resolves a bot by its **managed role** (same name as the bot). Such messages carry `mention_roles` + `<@&role>` content with an **empty user-mention list**, and the gateway classified every one as not-a-mention — the bot was silently unreachable for any user whose client picked the role variant. Found live while dogfooding: every `@Roomotedev` mention arrived and was dropped.

## Fix
- The session learns the bot's managed role per guild from `GUILD_CREATE` role tags, with a lazy `GET /guilds/{id}/roles` fallback for **resumed** sessions (which never replay `GUILD_CREATE`)
- Role mentions are **normalized at the gateway** into a canonical user mention (content rewritten to `<@bot>`, schema-complete user entry injected) so downstream entry gating and mention stripping work unchanged
- New contract test: the normalized envelope must parse with the API's real `discordGatewayEventSchema` — the first injection attempt used a bare `{id}` and the API 400'd the events into the dead-letter stream (which is how #410's DLQ visibility surfaced it)
- The mock's managed role now carries its `tags.bot_id` so the harness can exercise this path

## Validation
- 78/78 discord-gateway tests (3 new: normalization + schema contract, foreign-role ignored, unknown-role fallback)
- check-types 26/26, oxlint, format, knip green
- Verified live against real Discord end-to-end during dogfooding

🤖 Generated with [Claude Code](https://claude.com/claude-code)