### PR TITLE
[Fix] Accept Discord button clicks and keep their task threads anchored

### DIFF
--- a/apps/api/src/handlers/discord/__tests__/index.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/index.test.ts
@@ -319,6 +319,8 @@ describe('Discord Gateway event handler', () => {
           communicationProvider: 'discord',
           communicationChannelId: 'dm-1',
           communicationMessageId: 'message-1',
+          // A real channel message carries an anchor for its task thread.
+          communicationAnchorMessageId: 'message-1',
         },
       }),
     );

--- a/apps/api/src/handlers/discord/__tests__/routing-confirmation.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/routing-confirmation.test.ts
@@ -158,6 +158,57 @@ describe('Discord routing confirmation', () => {
     );
   });
 
+  it('carries the thread anchor through the pending route to the launch', async () => {
+    // A confirmation card defers the launch to a button interaction, which
+    // has no message of its own. The anchor from the original mention must
+    // survive the round trip or the task thread silently detaches.
+    await requestDiscordRoutingConfirmation({
+      provider: {} as never,
+      applicationId: 'app-1',
+      requesterDiscordUserId: 'discord-user-1',
+      launchOwnerUserId: 'user-1',
+      queuedMessage: {
+        provider: 'discord',
+        text: 'Fix matchmaking',
+        user: 'Matt',
+        userId: 'user-1',
+        ts: 'message-1',
+      },
+      metadata: {
+        communicationProvider: 'discord',
+        communicationChannelId: 'channel-1',
+        communicationMessageId: 'message-1',
+        communicationAnchorMessageId: 'message-1',
+      },
+      channel: {
+        channelId: 'channel-1',
+        channelName: 'general',
+        channelType: 0,
+        guildId: 'guild-1',
+        isDirectMessage: false,
+        isThread: false,
+      },
+      routingDecision: {
+        status: 'routed',
+        result: {
+          workspace: { type: 'environment', id: 'env-1', name: 'Sunny Acres' },
+          reasoning: 'likely',
+          debug: {
+            phase: 'direct',
+            toolsUsed: [],
+            needsExternalLookup: false,
+            confidence: 0.7,
+          },
+        },
+      },
+    });
+
+    const stored = mocks.redisSet.mock.calls[0]?.[1] as string;
+    expect(JSON.parse(stored).metadata).toMatchObject({
+      communicationAnchorMessageId: 'message-1',
+    });
+  });
+
   it('keeps every stored route visible within Discord action-row limits', async () => {
     mocks.getAvailableEnvironments.mockResolvedValue(
       Array.from({ length: 6 }, (_, index) => ({

--- a/apps/api/src/handlers/discord/index.ts
+++ b/apps/api/src/handlers/discord/index.ts
@@ -169,6 +169,9 @@ async function processDiscordGatewayEvent(event: DiscordGatewayEvent) {
   const metadata = discordMetadataForChannel({
     channel,
     messageId: event.payload.id,
+    // Only a real channel message provides an anchor for the task thread;
+    // interactions (slash commands, buttons) do not.
+    ...(message?.id ? { anchorMessageId: message.id } : {}),
   });
 
   if (interaction?.type === 3) {

--- a/apps/api/src/handlers/discord/task-launch.ts
+++ b/apps/api/src/handlers/discord/task-launch.ts
@@ -66,6 +66,12 @@ export async function resolveDiscordChannelContext(
 export function discordMetadataForChannel(input: {
   channel: DiscordChannelContext;
   messageId: string;
+  /**
+   * The real channel message that triggered the event — set only for
+   * message events. Interactions have no message a task thread could
+   * anchor to, so launches from them keep detached threads.
+   */
+  anchorMessageId?: string;
 }): DiscordEventCommunicationMetadata {
   return {
     communicationProvider: 'discord',
@@ -77,6 +83,9 @@ export function discordMetadataForChannel(input: {
     communicationMessageId: input.messageId,
     ...(input.channel.guildId
       ? { communicationGuildId: input.channel.guildId }
+      : {}),
+    ...(input.anchorMessageId
+      ? { communicationAnchorMessageId: input.anchorMessageId }
       : {}),
   };
 }

--- a/packages/communication/src/__tests__/discord-event.test.ts
+++ b/packages/communication/src/__tests__/discord-event.test.ts
@@ -230,3 +230,30 @@ describe('Discord Gateway event normalization', () => {
     expect(discordEventToQueuedCommunicationMessage(help)).toBeNull();
   });
 });
+
+describe('component interaction envelopes', () => {
+  it('accepts the numeric data.id Discord sends for real button clicks', () => {
+    const result = parseDiscordGatewayEvent({
+      eventId: 'interaction-1',
+      eventType: 'INTERACTION_CREATE',
+      payload: {
+        id: 'interaction-1',
+        application_id: 'app-1',
+        type: 3,
+        token: 'token-1',
+        guild_id: 'guild-1',
+        channel_id: 'channel-1',
+        member: { user: { id: 'user-1', username: 'dan' } },
+        // Real component interactions carry the numeric layout id of the
+        // pressed component, not a snowflake string.
+        data: {
+          id: 2,
+          custom_id: 'discord:route:abcdefghijkl:0',
+          component_type: 2,
+        },
+      },
+      receivedAt: '2026-07-16T18:40:15.343Z',
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/communication/src/discord-event.ts
+++ b/packages/communication/src/discord-event.ts
@@ -92,7 +92,11 @@ export const discordInteractionSchema = z
       .optional(),
     data: z
       .object({
-        id: z.string().optional(),
+        // Slash commands carry the command's snowflake here (a string);
+        // component interactions carry the numeric layout id of the pressed
+        // component. Real button clicks were rejected as invalid while the
+        // string-only shape was assumed.
+        id: z.union([z.string(), z.number()]).optional(),
         name: z.string().optional(),
         type: z.number().int().optional(),
         options: z.array(discordInteractionOptionSchema).optional(),


### PR DESCRIPTION
Two defects found while dogfooding the routing-confirmation flow against a real Discord bot.

## Every button click was silently discarded
The envelope schema typed `data.id` as a **string**, but Discord sends the pressed component's **numeric layout id** there — only slash commands send a snowflake string, which is exactly why `/link` worked while `All repositories` did nothing at all. Every component interaction failed validation with `invalid_discord_event` (400) and was quarantined to the dead-letter stream. Now both shapes are accepted.

## Confirmed launches detached their task thread
When routing needs a confirmation card, the launch happens on the **button interaction**, which has no message of its own — so the anchor from the original mention was lost and the task thread fell back to detached (visible as "Roomotedev started a thread" instead of a thread on the requester's message). The API now stamps the anchor from the triggering message; it rides along in the pending route and survives the round trip to the confirmed launch.

Interactions genuinely have no anchor of their own, so `/new` and suggestion-card buttons keep their detached threads by design.

## Validation
- api discord suite 61/61, communication discord-event 8/8 (new: numeric `data.id` envelope parses; anchor survives the pending-route round trip)
- check-types 26/26, oxlint, format, knip green
- Verified live: mention → card → click → task launches, thread created, early-title rename, cancel button all working

Found by the same dogfooding session as #432 and #438 — three real Discord-contract bugs the mock harness structurally could not catch, because it encoded our assumptions about Discord rather than Discord's actual behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)