### PR TITLE
[Fix] Ask Discord's routing question inside the task thread

### DIFF
--- a/apps/api/src/handlers/discord/__tests__/routing-confirmation.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/routing-confirmation.test.ts
@@ -4,6 +4,8 @@ const mocks = vi.hoisted(() => ({
   findMappedUser: vi.fn(),
   findSourceRun: vi.fn(),
   launchTask: vi.fn(),
+  reserveAnchoredThread: vi.fn(),
+  forgetPendingTaskThread: vi.fn(),
   resolveWorkspace: vi.fn(),
   reply: vi.fn(),
   redisSet: vi.fn(),
@@ -25,6 +27,8 @@ vi.mock('../../tasks/communication-task-run-lookup.js', () => ({
 
 vi.mock('../task-launch.js', () => ({
   launchDiscordTask: mocks.launchTask,
+  reserveDiscordAnchoredThread: mocks.reserveAnchoredThread,
+  forgetPendingTaskThread: mocks.forgetPendingTaskThread,
   resolveDiscordWorkspace: mocks.resolveWorkspace,
 }));
 
@@ -48,6 +52,8 @@ describe('Discord routing confirmation', () => {
       { id: 'env-2', name: 'API', repositoryNames: ['acme/api'] },
     ]);
     mocks.redisSet.mockResolvedValue('OK');
+    mocks.reserveAnchoredThread.mockResolvedValue(null);
+    mocks.forgetPendingTaskThread.mockResolvedValue(undefined);
     mocks.findMappedUser.mockResolvedValue('user-1');
     mocks.findSourceRun.mockResolvedValue(null);
     mocks.getTaskUrl.mockReturnValue('https://roomote.example/task/task-1');
@@ -59,6 +65,7 @@ describe('Discord routing confirmation', () => {
     mocks.launchTask.mockResolvedValue({
       createdThread: { channelId: 'thread-1' },
       taskUrl: 'https://roomote.example/task/task-1',
+      launchResult: { id: 42, taskId: 'task-1' },
     });
     mocks.reply.mockResolvedValue({ messageId: 'confirmation-1' });
   });
@@ -206,6 +213,139 @@ describe('Discord routing confirmation', () => {
     const stored = mocks.redisSet.mock.calls[0]?.[1] as string;
     expect(JSON.parse(stored).metadata).toMatchObject({
       communicationAnchorMessageId: 'message-1',
+    });
+  });
+
+  it('asks inside the task thread so the channel only shows the request', async () => {
+    // Slack posts its routing card into the thread on the requesting message.
+    // Reserving the thread up front is what lets Discord do the same; the
+    // launch then reuses that thread rather than opening a second one.
+    mocks.reserveAnchoredThread.mockResolvedValue({
+      channelId: 'message-1',
+      parentChannelId: 'channel-1',
+      name: 'Fix matchmaking',
+      kind: 'thread',
+      messageId: 'message-1',
+    });
+
+    await requestDiscordRoutingConfirmation({
+      provider: {} as never,
+      applicationId: 'app-1',
+      requesterDiscordUserId: 'discord-user-1',
+      launchOwnerUserId: 'user-1',
+      queuedMessage: {
+        provider: 'discord',
+        text: 'Fix matchmaking',
+        user: 'Matt',
+        userId: 'user-1',
+        ts: 'message-1',
+      },
+      metadata: {
+        communicationProvider: 'discord',
+        communicationChannelId: 'channel-1',
+        communicationMessageId: 'message-1',
+        communicationAnchorMessageId: 'message-1',
+      },
+      channel: {
+        channelId: 'channel-1',
+        channelName: 'general',
+        channelType: 0,
+        guildId: 'guild-1',
+        isDirectMessage: false,
+        isThread: false,
+      },
+      routingDecision: { status: 'fallback', reason: 'ambiguous' },
+    });
+
+    expect(mocks.reply.mock.lastCall?.[0]?.channel).toMatchObject({
+      channelId: 'message-1',
+      parentChannelId: 'channel-1',
+      isThread: true,
+    });
+    const stored = JSON.parse(mocks.redisSet.mock.calls[0]?.[1] as string);
+    expect(stored.cardChannel).toMatchObject({ channelId: 'message-1' });
+    // The launch still receives the root channel, so it resolves the same
+    // thread parent and finds the reservation.
+    expect(stored.channel).toMatchObject({
+      channelId: 'channel-1',
+      isThread: false,
+    });
+  });
+
+  it('asks in the channel when the request cannot anchor a thread', async () => {
+    mocks.reserveAnchoredThread.mockResolvedValue(null);
+
+    await requestDiscordRoutingConfirmation({
+      provider: {} as never,
+      applicationId: 'app-1',
+      requesterDiscordUserId: 'discord-user-1',
+      launchOwnerUserId: 'user-1',
+      queuedMessage: {
+        provider: 'discord',
+        text: 'Fix matchmaking',
+        user: 'Matt',
+        userId: 'user-1',
+        ts: 'message-1',
+      },
+      metadata: {
+        communicationProvider: 'discord',
+        communicationChannelId: 'dm-1',
+        communicationMessageId: 'message-1',
+      },
+      channel: {
+        channelId: 'dm-1',
+        channelName: 'Direct message',
+        channelType: 1,
+        isDirectMessage: true,
+        isThread: false,
+      },
+      routingDecision: { status: 'fallback', reason: 'ambiguous' },
+    });
+
+    expect(mocks.reply.mock.lastCall?.[0]?.channel).toMatchObject({
+      channelId: 'dm-1',
+    });
+    expect(
+      JSON.parse(mocks.redisSet.mock.calls[0]?.[1] as string).cardChannel,
+    ).toBeUndefined();
+  });
+
+  it('still asks in the channel when reserving the thread fails', async () => {
+    // Card placement is cosmetic; the launch retries the thread itself.
+    // Losing the whole request over it would not be.
+    mocks.reserveAnchoredThread.mockRejectedValue(new Error('Discord 503'));
+
+    await requestDiscordRoutingConfirmation({
+      provider: {} as never,
+      applicationId: 'app-1',
+      requesterDiscordUserId: 'discord-user-1',
+      launchOwnerUserId: 'user-1',
+      queuedMessage: {
+        provider: 'discord',
+        text: 'Fix matchmaking',
+        user: 'Matt',
+        userId: 'user-1',
+        ts: 'message-1',
+      },
+      metadata: {
+        communicationProvider: 'discord',
+        communicationChannelId: 'channel-1',
+        communicationMessageId: 'message-1',
+        communicationAnchorMessageId: 'message-1',
+      },
+      channel: {
+        channelId: 'channel-1',
+        channelName: 'general',
+        channelType: 0,
+        guildId: 'guild-1',
+        isDirectMessage: false,
+        isThread: false,
+      },
+      routingDecision: { status: 'fallback', reason: 'ambiguous' },
+    });
+
+    expect(mocks.reply.mock.lastCall?.[0]?.channel).toMatchObject({
+      channelId: 'channel-1',
     });
   });
 
@@ -380,6 +520,150 @@ describe('Discord routing confirmation', () => {
       JSON.stringify(pending),
       'EX',
       900,
+    );
+  });
+
+  it('accepts the requester pressing a button inside the task thread', async () => {
+    // A card posted into the thread reports the thread as its channel. Matching
+    // the interaction against the originating channel would read the requester
+    // as an impostor and refuse every launch.
+    mocks.redisGetdel.mockResolvedValue(
+      JSON.stringify({
+        requesterDiscordUserId: 'discord-user-1',
+        launchOwnerUserId: 'user-1',
+        queuedMessage: {
+          provider: 'discord',
+          text: 'Fix matchmaking',
+          user: 'Matt',
+          userId: 'user-1',
+          ts: 'message-1',
+        },
+        metadata: {
+          communicationProvider: 'discord',
+          communicationChannelId: 'channel-1',
+          communicationMessageId: 'message-1',
+          communicationAnchorMessageId: 'message-1',
+        },
+        channel: {
+          channelId: 'channel-1',
+          channelName: 'general',
+          channelType: 0,
+          guildId: 'guild-1',
+          isDirectMessage: false,
+          isThread: false,
+        },
+        cardChannel: {
+          channelId: 'message-1',
+          channelName: 'Fix matchmaking',
+          channelType: 11,
+          guildId: 'guild-1',
+          parentChannelId: 'channel-1',
+          isDirectMessage: false,
+          isThread: true,
+        },
+        options: [
+          {
+            label: 'Sunny Acres',
+            workspace: {
+              type: 'environment',
+              id: 'env-1',
+              name: 'Sunny Acres',
+            },
+          },
+        ],
+      }),
+    );
+
+    await handleDiscordRoutingCallback({
+      provider: {} as never,
+      applicationId: 'app-1',
+      interaction: {
+        id: 'interaction-1',
+        application_id: 'app-1',
+        type: 3,
+        token: 'token-1',
+        channel_id: 'message-1',
+        user: { id: 'discord-user-1', username: 'matt' },
+        data: { custom_id: 'discord:route:abcdefghijkl:0' },
+      },
+      interactionDeferred: true,
+      callback: { pendingRouteId: 'abcdefghijkl', selection: 0 },
+    });
+
+    expect(mocks.launchTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: expect.objectContaining({ channelId: 'channel-1' }),
+      }),
+    );
+    // The card is where the acknowledgement was going, so the launch turns it
+    // into one rather than posting a second, identical message beneath it.
+    expect(mocks.launchTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replaceMessage: expect.objectContaining({
+          channel: expect.objectContaining({ channelId: 'message-1' }),
+        }),
+      }),
+    );
+    expect(mocks.reply).not.toHaveBeenCalled();
+  });
+
+  it('keeps the launch acknowledgement when the card stayed in the channel', async () => {
+    mocks.redisGetdel.mockResolvedValue(
+      JSON.stringify({
+        requesterDiscordUserId: 'discord-user-1',
+        launchOwnerUserId: 'user-1',
+        queuedMessage: {
+          provider: 'discord',
+          text: 'Fix matchmaking',
+          user: 'Matt',
+          userId: 'user-1',
+          ts: 'message-1',
+        },
+        metadata: {
+          communicationProvider: 'discord',
+          communicationChannelId: 'channel-1',
+          communicationMessageId: 'message-1',
+        },
+        channel: {
+          channelId: 'channel-1',
+          channelName: 'general',
+          channelType: 0,
+          guildId: 'guild-1',
+          isDirectMessage: false,
+          isThread: false,
+        },
+        options: [
+          {
+            label: 'Sunny Acres',
+            workspace: {
+              type: 'environment',
+              id: 'env-1',
+              name: 'Sunny Acres',
+            },
+          },
+        ],
+      }),
+    );
+
+    await handleDiscordRoutingCallback({
+      provider: {} as never,
+      applicationId: 'app-1',
+      interaction: {
+        id: 'interaction-1',
+        application_id: 'app-1',
+        type: 3,
+        token: 'token-1',
+        channel_id: 'channel-1',
+        user: { id: 'discord-user-1', username: 'matt' },
+        data: { custom_id: 'discord:route:abcdefghijkl:0' },
+      },
+      interactionDeferred: true,
+      callback: { pendingRouteId: 'abcdefghijkl', selection: 0 },
+    });
+
+    expect(mocks.launchTask.mock.lastCall?.[0]?.replaceMessage).toBeUndefined();
+    expect(mocks.reply.mock.lastCall?.[0]?.text).toContain(
+      'Continue in the new task thread',
     );
   });
 });

--- a/apps/api/src/handlers/discord/__tests__/task-launch.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/task-launch.test.ts
@@ -649,4 +649,172 @@ describe('launchDiscordTask', () => {
     expect(mocks.redisDel).not.toHaveBeenCalled();
     expect(provider.postMessage).not.toHaveBeenCalled();
   });
+
+  it('turns a caller-supplied message into the acknowledgement', async () => {
+    const anchoredThread = {
+      channelId: 'message-1',
+      parentChannelId: 'channel-1',
+      name: 'Fix tests',
+      kind: 'thread' as const,
+      messageId: 'message-1',
+    };
+    const provider = {
+      createThreadFromMessage: vi.fn().mockResolvedValue(anchoredThread),
+      completeTaskThread: vi.fn().mockResolvedValue(anchoredThread),
+      editInteractionResponse: vi
+        .fn()
+        .mockResolvedValue({ messageId: 'card-1' }),
+      postMessage: vi.fn(),
+      editChannel: vi.fn(),
+    };
+
+    const launched = await launchDiscordTask({
+      provider: provider as never,
+      launchOwnerUserId: 'user-1',
+      queuedMessage: {
+        provider: 'discord',
+        text: 'Fix tests',
+        user: 'Matt',
+        userId: 'user-1',
+        ts: 'message-1',
+      },
+      metadata: {
+        communicationProvider: 'discord',
+        communicationGuildId: 'guild-1',
+        communicationChannelId: 'channel-1',
+        communicationMessageId: 'message-1',
+        communicationAnchorMessageId: 'message-1',
+      },
+      channel: {
+        channelId: 'channel-1',
+        channelName: 'general',
+        channelType: 0,
+        guildId: 'guild-1',
+        isDirectMessage: false,
+        isThread: false,
+      },
+      workspace: { repoForPayload: 'acme/repo', workspaceDisplayName: 'Acme' },
+      replaceMessage: {
+        applicationId: 'app-1',
+        interaction: {
+          id: 'interaction-1',
+          application_id: 'app-1',
+          type: 3,
+          token: 'token-1',
+          channel_id: 'message-1',
+        } as never,
+        interactionDeferred: true,
+        channel: {
+          channelId: 'message-1',
+          channelName: 'Fix tests',
+          channelType: 11,
+          guildId: 'guild-1',
+          parentChannelId: 'channel-1',
+          isDirectMessage: false,
+          isThread: true,
+        },
+      },
+    });
+
+    expect(provider.postMessage).not.toHaveBeenCalled();
+    expect(provider.editInteractionResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        interactionToken: 'token-1',
+        text: 'Started a task in Acme.',
+        buttons: [
+          [
+            {
+              text: 'Follow Task',
+              url: 'https://roomote.example/tasks/task-41',
+            },
+          ],
+          [{ text: '✖️ Cancel task', callbackData: 'discord:cancel:41' }],
+        ],
+      }),
+    );
+    expect(launched.acknowledgement).toEqual({ messageId: 'card-1' });
+  });
+
+  it('posts the acknowledgement when the message it should replace is gone', async () => {
+    // A card that cannot be edited must not take the acknowledgement down with
+    // it; the task is already running and still needs its cancel control.
+    const anchoredThread = {
+      channelId: 'message-1',
+      parentChannelId: 'channel-1',
+      name: 'Fix tests',
+      kind: 'thread' as const,
+      messageId: 'message-1',
+    };
+    const provider = {
+      createThreadFromMessage: vi.fn().mockResolvedValue(anchoredThread),
+      completeTaskThread: vi.fn().mockResolvedValue(anchoredThread),
+      editInteractionResponse: vi.fn().mockRejectedValue(
+        new DiscordApiError({
+          method: 'PATCH',
+          path: '/webhooks/app-1/token-1/messages/@original',
+          status: 404,
+          message: 'Unknown Message',
+          code: 10008,
+        }),
+      ),
+      postMessage: vi.fn().mockResolvedValue({ messageId: 'ack-1' }),
+      editChannel: vi.fn(),
+    };
+
+    await launchDiscordTask({
+      provider: provider as never,
+      launchOwnerUserId: 'user-1',
+      queuedMessage: {
+        provider: 'discord',
+        text: 'Fix tests',
+        user: 'Matt',
+        userId: 'user-1',
+        ts: 'message-1',
+      },
+      metadata: {
+        communicationProvider: 'discord',
+        communicationGuildId: 'guild-1',
+        communicationChannelId: 'channel-1',
+        communicationMessageId: 'message-1',
+        communicationAnchorMessageId: 'message-1',
+      },
+      channel: {
+        channelId: 'channel-1',
+        channelName: 'general',
+        channelType: 0,
+        guildId: 'guild-1',
+        isDirectMessage: false,
+        isThread: false,
+      },
+      workspace: { repoForPayload: 'acme/repo', workspaceDisplayName: 'Acme' },
+      replaceMessage: {
+        applicationId: 'app-1',
+        interaction: {
+          id: 'interaction-1',
+          application_id: 'app-1',
+          type: 3,
+          token: 'token-1',
+          channel_id: 'message-1',
+        } as never,
+        interactionDeferred: true,
+        channel: {
+          channelId: 'message-1',
+          channelName: 'Fix tests',
+          channelType: 11,
+          guildId: 'guild-1',
+          parentChannelId: 'channel-1',
+          isDirectMessage: false,
+          isThread: true,
+        },
+      },
+    });
+
+    expect(provider.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: 'channel-1',
+        threadId: 'message-1',
+        text: 'Started a task in Acme.',
+      }),
+    );
+  });
 });

--- a/apps/api/src/handlers/discord/routing-confirmation.ts
+++ b/apps/api/src/handlers/discord/routing-confirmation.ts
@@ -7,7 +7,10 @@ import {
   type RoutingWorkspace,
 } from '@roomote/cloud-agents/server';
 import type { DiscordInteraction } from '@roomote/communication/discord-event';
-import type { DiscordCommunicationProvider } from '@roomote/communication/discord-provider';
+import type {
+  DiscordCommunicationProvider,
+  DiscordTaskThread,
+} from '@roomote/communication/discord-provider';
 import { getRedis } from '@roomote/redis';
 import { findDiscordMappedUserId } from '@roomote/sdk/server';
 import type { QueuedCommunicationMessage } from '@roomote/types';
@@ -16,12 +19,17 @@ import type { DiscordEventCommunicationMetadata } from '@roomote/communication/d
 import { findCommunicationTaskRunBySourceEvent } from '../tasks/communication-task-run-lookup.js';
 import { replyToDiscordEvent } from './replies.js';
 import {
+  forgetPendingTaskThread,
   launchDiscordTask,
+  reserveDiscordAnchoredThread,
   resolveDiscordWorkspace,
   type DiscordChannelContext,
 } from './task-launch.js';
 
 const DISCORD_IMMEDIATE_CONFIRM_CONFIDENCE = 0.95;
+const DISCORD_CHANNEL_TYPE_ANNOUNCEMENT = 5;
+const DISCORD_CHANNEL_TYPE_ANNOUNCEMENT_THREAD = 10;
+const DISCORD_CHANNEL_TYPE_PUBLIC_THREAD = 11;
 const PENDING_ROUTE_TTL_SECONDS = 15 * 60;
 const PENDING_ROUTE_PREFIX = 'discord:pending_route:';
 // Discord supports at most five action rows. Reserve one for All repositories
@@ -39,6 +47,12 @@ type PendingDiscordRoute = {
   queuedMessage: QueuedCommunicationMessage;
   metadata: DiscordEventCommunicationMetadata;
   channel: DiscordChannelContext;
+  /**
+   * The task thread the card was posted into, when the request could anchor
+   * one. Replies and the requester check follow the card; the launch keeps
+   * using `channel`, so it still resolves the same thread parent.
+   */
+  cardChannel?: DiscordChannelContext;
   options: PendingRouteOption[];
   forceNewThread?: boolean;
 };
@@ -130,6 +144,24 @@ function routeButtons(id: string, options: PendingRouteOption[]) {
   ];
 }
 
+function taskThreadChannelContext(input: {
+  channel: DiscordChannelContext;
+  thread: DiscordTaskThread;
+}): DiscordChannelContext {
+  return {
+    channelId: input.thread.channelId,
+    channelName: input.thread.name,
+    channelType:
+      input.channel.channelType === DISCORD_CHANNEL_TYPE_ANNOUNCEMENT
+        ? DISCORD_CHANNEL_TYPE_ANNOUNCEMENT_THREAD
+        : DISCORD_CHANNEL_TYPE_PUBLIC_THREAD,
+    ...(input.channel.guildId ? { guildId: input.channel.guildId } : {}),
+    parentChannelId: input.thread.parentChannelId,
+    isDirectMessage: false,
+    isThread: true,
+  };
+}
+
 export function shouldAutoConfirmDiscordRoute(
   decision: RoutingDecision,
 ): boolean {
@@ -162,12 +194,37 @@ export async function requestDiscordRoutingConfirmation(input: {
       ? input.routingDecision.result.workspace
       : null,
   );
+  // Slack asks this question inside the thread on the requesting message, so
+  // the channel only ever shows the request itself. Start that thread now and
+  // put the card in it; the launch reuses this exact thread. An interaction
+  // answers through its own response, which always lands where it was invoked,
+  // so those keep the card in the channel.
+  const thread = input.interaction
+    ? null
+    : await reserveDiscordAnchoredThread({
+        provider: input.provider,
+        queuedMessage: input.queuedMessage,
+        metadata: input.metadata,
+        channel: input.channel,
+        ...(input.forceNewThread ? { forceNewThread: true } : {}),
+      }).catch((error) => {
+        // Asking in the channel still routes the task; the launch retries the
+        // thread. Failing the whole request over card placement would not.
+        console.warn(
+          `[discord] Failed to reserve task thread for event ${input.queuedMessage.ts}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        return null;
+      });
+  const cardChannel = thread
+    ? taskThreadChannelContext({ channel: input.channel, thread })
+    : null;
   await storePendingRoute(pendingRouteId, {
     requesterDiscordUserId: input.requesterDiscordUserId,
     launchOwnerUserId: input.launchOwnerUserId,
     queuedMessage: input.queuedMessage,
     metadata: input.metadata,
     channel: input.channel,
+    ...(cardChannel ? { cardChannel } : {}),
     options,
     ...(input.forceNewThread ? { forceNewThread: true } : {}),
   });
@@ -175,7 +232,7 @@ export async function requestDiscordRoutingConfirmation(input: {
   await replyToDiscordEvent({
     provider: input.provider,
     applicationId: input.applicationId,
-    channel: input.channel,
+    channel: cardChannel ?? input.channel,
     ...(input.interaction ? { interaction: input.interaction } : {}),
     text: suggested
       ? `Where should I run this? The best match is **${suggested}**.`
@@ -232,28 +289,35 @@ export async function handleDiscordRoutingCallback(input: {
     });
     return;
   }
+  // The card may live in the task thread rather than the channel it came from.
+  const replyChannel = pending.cardChannel ?? pending.channel;
   const mappedUserId = await findDiscordMappedUserId(interactionUser?.id);
   if (
     !interactionUser ||
     interactionUser.id !== pending.requesterDiscordUserId ||
     mappedUserId !== pending.launchOwnerUserId ||
-    input.interaction.channel_id !== pending.channel.channelId
+    input.interaction.channel_id !== replyChannel.channelId
   ) {
     await restorePendingRoute(input.callback.pendingRouteId, pending);
     await input.provider.postMessage({
-      channelId: pending.channel.parentChannelId ?? pending.channel.channelId,
-      ...(pending.channel.parentChannelId
-        ? { threadId: pending.channel.channelId }
+      channelId: replyChannel.parentChannelId ?? replyChannel.channelId,
+      ...(replyChannel.parentChannelId
+        ? { threadId: replyChannel.channelId }
         : {}),
       text: 'Only the person who started this request can choose its workspace.',
     });
     return;
   }
   if (input.callback.selection === 'cancel') {
+    // The reserved thread keeps the canceled card, exactly as a canceled Slack
+    // request leaves its thread behind, but nothing should launch into it.
+    await forgetPendingTaskThread(pending.queuedMessage.ts).catch(
+      () => undefined,
+    );
     await replyToDiscordEvent({
       provider: input.provider,
       applicationId: input.applicationId,
-      channel: pending.channel,
+      channel: replyChannel,
       interaction: {
         interaction: input.interaction,
         interactionDeferred: input.interactionDeferred,
@@ -267,7 +331,7 @@ export async function handleDiscordRoutingCallback(input: {
     await replyToDiscordEvent({
       provider: input.provider,
       applicationId: input.applicationId,
-      channel: pending.channel,
+      channel: replyChannel,
       interaction: {
         interaction: input.interaction,
         interactionDeferred: input.interactionDeferred,
@@ -298,7 +362,7 @@ export async function handleDiscordRoutingCallback(input: {
     await replyToDiscordEvent({
       provider: input.provider,
       applicationId: input.applicationId,
-      channel: pending.channel,
+      channel: replyChannel,
       interaction: {
         interaction: input.interaction,
         interactionDeferred: input.interactionDeferred,
@@ -322,7 +386,7 @@ export async function handleDiscordRoutingCallback(input: {
     await replyToDiscordEvent({
       provider: input.provider,
       applicationId: input.applicationId,
-      channel: pending.channel,
+      channel: replyChannel,
       interaction: {
         interaction: input.interaction,
         interactionDeferred: input.interactionDeferred,
@@ -341,6 +405,19 @@ export async function handleDiscordRoutingCallback(input: {
       channel: pending.channel,
       workspace,
       forceNewThread: pending.forceNewThread,
+      // A card already in the task thread is where the acknowledgement was
+      // going anyway, so the launch turns it into one instead of posting an
+      // identical message beneath it.
+      ...(pending.cardChannel
+        ? {
+            replaceMessage: {
+              applicationId: input.applicationId,
+              interaction: input.interaction,
+              interactionDeferred: input.interactionDeferred,
+              channel: pending.cardChannel,
+            },
+          }
+        : {}),
     });
   } catch (error) {
     await restorePendingRoute(input.callback.pendingRouteId, pending).catch(
@@ -348,14 +425,18 @@ export async function handleDiscordRoutingCallback(input: {
     );
     throw error;
   }
+  // The launch already answered a card that lived in the task thread.
+  if (pending.cardChannel) return;
   await replyToDiscordEvent({
     provider: input.provider,
     applicationId: input.applicationId,
-    channel: pending.channel,
+    channel: replyChannel,
     interaction: {
       interaction: input.interaction,
       interactionDeferred: input.interactionDeferred,
     },
+    // Away from the thread the card stays a routing receipt, pointing at the
+    // thread that carries the real acknowledgement.
     text: launched.createdThread
       ? `Started in **${workspace.workspaceDisplayName}**. Continue in the new task thread.`
       : `Started in **${workspace.workspaceDisplayName}**.`,

--- a/apps/api/src/handlers/discord/task-launch.ts
+++ b/apps/api/src/handlers/discord/task-launch.ts
@@ -15,10 +15,18 @@ import {
   type DiscordCommunicationProvider,
   type DiscordTaskThread,
 } from '@roomote/communication/discord-provider';
-import type { DiscordEventCommunicationMetadata } from '@roomote/communication/discord-event';
+import type {
+  DiscordEventCommunicationMetadata,
+  DiscordInteraction,
+} from '@roomote/communication/discord-event';
 import { getRedis } from '@roomote/redis';
 
 import { buildCommunicationTaskThreadName } from '../tasks/communication-task-thread.js';
+import { replyToDiscordEvent } from './replies.js';
+import {
+  discordTaskAcknowledgementText,
+  discordTaskButtons,
+} from './task-messages.js';
 
 const DISCORD_THREAD_TYPES = new Set([10, 11, 12]);
 const DISCORD_ROOT_TASK_CHANNEL_TYPES = new Set([0, 5, 15, 16]);
@@ -134,18 +142,6 @@ function taskThreadParentId(input: {
     : null;
 }
 
-function taskButtons(input: { runId: number; taskUrl: string | null }) {
-  return [
-    ...(input.taskUrl ? [[{ text: 'Follow Task', url: input.taskUrl }]] : []),
-    [
-      {
-        text: '✖️ Cancel task',
-        callbackData: `discord:cancel:${input.runId}`,
-      },
-    ],
-  ];
-}
-
 function pendingTaskThreadKey(sourceEventId: string): string {
   return `${DISCORD_PENDING_TASK_THREAD_PREFIX}${sourceEventId}`;
 }
@@ -196,8 +192,58 @@ async function rememberPendingTaskThread(
   );
 }
 
-async function forgetPendingTaskThread(sourceEventId: string): Promise<void> {
+export async function forgetPendingTaskThread(
+  sourceEventId: string,
+): Promise<void> {
   await getRedis().del(pendingTaskThreadKey(sourceEventId));
+}
+
+/**
+ * Starts the task thread on the message that asked for the task, ahead of the
+ * launch itself, so a routing card can be posted inside it the way Slack posts
+ * its card into the thread on the requesting message. `launchDiscordTask`
+ * reuses whatever this reserved via the pending-thread memo.
+ *
+ * Returns null when this surface cannot anchor — DMs, forum channels,
+ * interactions with no triggering message, `/new` siblings from inside a
+ * thread — or when the triggering message is already gone. Those callers keep
+ * the detached task thread that the launch creates.
+ */
+export async function reserveDiscordAnchoredThread(input: {
+  provider: DiscordCommunicationProvider;
+  queuedMessage: QueuedCommunicationMessage;
+  metadata: DiscordEventCommunicationMetadata;
+  channel: DiscordChannelContext;
+  forceNewThread?: boolean;
+}): Promise<DiscordTaskThread | null> {
+  const parentId = taskThreadParentId(input);
+  if (!parentId) return null;
+  const existing = await findPendingTaskThread(
+    input.queuedMessage.ts,
+    parentId,
+  );
+  if (existing) return existing;
+  const anchorMessageId =
+    !input.channel.isThread &&
+    DISCORD_MESSAGE_ANCHORED_CHANNEL_TYPES.has(input.channel.channelType)
+      ? input.metadata.communicationAnchorMessageId
+      : undefined;
+  if (!anchorMessageId) return null;
+  let thread: DiscordTaskThread;
+  try {
+    thread = await input.provider.createThreadFromMessage({
+      channelId: parentId,
+      messageId: anchorMessageId,
+      name: buildCommunicationTaskThreadName(input.queuedMessage.text),
+    });
+  } catch (error) {
+    // The triggering message was deleted before the thread could start; fall
+    // back to a detached task thread rather than failing the launch.
+    if (isDiscordUnknownMessageError(error)) return null;
+    throw error;
+  }
+  await rememberPendingTaskThread(input.queuedMessage.ts, thread);
+  return thread;
 }
 
 export async function launchDiscordTask(input: {
@@ -209,42 +255,24 @@ export async function launchDiscordTask(input: {
   workspace: DiscordWorkspaceSelection;
   /** `/new` in an existing task thread creates a sibling, never a second run in-place. */
   forceNewThread?: boolean;
+  /**
+   * An already-posted message to turn into the acknowledgement instead of
+   * posting a new one — a routing card sitting in the task thread becomes the
+   * started message rather than being followed by an identical one. Only pass
+   * a message that lives where the acknowledgement would have gone.
+   */
+  replaceMessage?: {
+    applicationId: string;
+    interaction: DiscordInteraction;
+    interactionDeferred: boolean;
+    channel: DiscordChannelContext;
+  };
 }) {
   let createdThread: DiscordTaskThread | null = null;
   const parentId = taskThreadParentId(input);
   if (parentId) {
     const initialText = `Task request from ${input.queuedMessage.user}:\n\n${input.queuedMessage.text}`;
-    // Slack model: the task thread hangs off the message that asked for it.
-    // Only launches triggered by a real root-channel message can anchor;
-    // interactions, forum posts, and `/new` siblings from inside a thread
-    // fall back to a detached task thread.
-    const anchorMessageId =
-      !input.channel.isThread &&
-      DISCORD_MESSAGE_ANCHORED_CHANNEL_TYPES.has(input.channel.channelType)
-        ? input.metadata.communicationAnchorMessageId
-        : undefined;
-    createdThread = await findPendingTaskThread(
-      input.queuedMessage.ts,
-      parentId,
-    );
-    if (!createdThread && anchorMessageId) {
-      try {
-        createdThread = await input.provider.createThreadFromMessage({
-          channelId: parentId,
-          messageId: anchorMessageId,
-          name: buildCommunicationTaskThreadName(input.queuedMessage.text),
-        });
-      } catch (error) {
-        // The triggering message was deleted before the thread could start;
-        // fall back to a detached task thread rather than failing the launch.
-        if (!isDiscordUnknownMessageError(error)) {
-          throw error;
-        }
-      }
-      if (createdThread) {
-        await rememberPendingTaskThread(input.queuedMessage.ts, createdThread);
-      }
-    }
+    createdThread = await reserveDiscordAnchoredThread(input);
     if (!createdThread) {
       createdThread = await input.provider.reserveTaskThread({
         channelId: parentId,
@@ -323,14 +351,31 @@ export async function launchDiscordTask(input: {
     taskId: launchResult.taskId,
     utm: { source: 'discord', campaign: 'discord.thread_start' },
   });
-  const acknowledgement = await input.provider.postMessage({
-    channelId: communicationChannelId,
-    ...(communicationThreadId ? { threadId: communicationThreadId } : {}),
-    text: taskUrl
-      ? `Started a task in ${input.workspace.workspaceDisplayName}.`
-      : `Queued a task in ${input.workspace.workspaceDisplayName}.`,
-    buttons: taskButtons({ runId: launchResult.id, taskUrl }),
-  });
+  const acknowledgementMessage = {
+    text: discordTaskAcknowledgementText({
+      workspaceDisplayName: input.workspace.workspaceDisplayName,
+      taskUrl,
+    }),
+    buttons: discordTaskButtons({ runId: launchResult.id, taskUrl }),
+  };
+  // Replacing already falls back to posting when the original message cannot
+  // be edited, so the task is acknowledged either way.
+  const acknowledgement = input.replaceMessage
+    ? await replyToDiscordEvent({
+        provider: input.provider,
+        applicationId: input.replaceMessage.applicationId,
+        channel: input.replaceMessage.channel,
+        interaction: {
+          interaction: input.replaceMessage.interaction,
+          interactionDeferred: input.replaceMessage.interactionDeferred,
+        },
+        ...acknowledgementMessage,
+      })
+    : await input.provider.postMessage({
+        channelId: communicationChannelId,
+        ...(communicationThreadId ? { threadId: communicationThreadId } : {}),
+        ...acknowledgementMessage,
+      });
 
   if (createdThread) {
     await forgetPendingTaskThread(input.queuedMessage.ts).catch((error) => {

--- a/apps/api/src/handlers/discord/task-messages.ts
+++ b/apps/api/src/handlers/discord/task-messages.ts
@@ -1,0 +1,29 @@
+/**
+ * Presentation for a started Discord task. Both the launch and a routing card
+ * that becomes the started message render these, so the two paths cannot drift
+ * into saying the same thing two different ways.
+ */
+
+export function discordTaskButtons(input: {
+  runId: number;
+  taskUrl: string | null;
+}) {
+  return [
+    ...(input.taskUrl ? [[{ text: 'Follow Task', url: input.taskUrl }]] : []),
+    [
+      {
+        text: '✖️ Cancel task',
+        callbackData: `discord:cancel:${input.runId}`,
+      },
+    ],
+  ];
+}
+
+export function discordTaskAcknowledgementText(input: {
+  workspaceDisplayName: string;
+  taskUrl: string | null;
+}): string {
+  return input.taskUrl
+    ? `Started a task in ${input.workspaceDisplayName}.`
+    : `Queued a task in ${input.workspaceDisplayName}.`;
+}


### PR DESCRIPTION
## Problem

A Discord routing confirmation posted its card to the channel, so one mention produced two channel messages: the question, then an answer pointing at a thread the task actually ran in.

Slack asks inside the thread on the requesting message (`postMessage({ thread_ts: threadId, blocks: buildRoutingConfirmBlocks(...) })`), leaving the channel showing only the request. Discord's card had nowhere else to go, because Discord threads are real objects that cannot exist before something creates them — and nothing did until launch.

## Change

**Reserve the anchored thread when the question is asked**, not when the task launches, and post the card into it. The launch reuses that reservation through the existing `discord:pending_task_thread:` memo, so no second thread is created.

That placement then collided with the launch's own acknowledgement — both landed in the thread saying nearly the same thing, one under the other. Slack *replaces* its routing card with the started message (`existingMessageTs: prefill.confirmMessageTs` → `postOrReplaceSlackMessage`) rather than posting alongside it. So `launchDiscordTask` now takes an optional `replaceMessage`, the analog of Slack's `replaceMessageTs`: it renders the acknowledgement once and either replaces the given message or posts a new one. `replyToDiscordEvent` already falls back to posting when the original cannot be edited, so the task is acknowledged either way.

Presentation for the started message moved to `task-messages.ts` so the launch and the card cannot drift into saying the same thing two different ways.

## Scope

Surfaces that cannot anchor a thread are unchanged and keep the card in the channel: DMs, forum/media channels, slash commands with no triggering message, and `/new` siblings from inside a thread. The high-confidence auto-launch path never posted a card and already matched Slack.

Cancel leaves the thread with the canceled card in it — the same artifact a canceled Slack request leaves — and clears the reservation so nothing can launch into it.

## Verification

Live against real Discord, not the mock:
- One mention → one thread on the message, card inside it, channel otherwise clean.
- Choosing a workspace edits that card in place into `Started a task in all repos.` with **Follow Task** and **Cancel task**. No second message.
- Anchoring confirmed at the data layer: the reserved thread's `channelId` equals the triggering `messageId`.

68 tests pass in `apps/api/src/handlers/discord/`, including new coverage for card placement, the non-anchorable fallback, a failed reservation still asking in the channel, the button press from inside the thread being accepted rather than read as an impostor's click, and a 404 on the replace falling back to posting so a running task never loses its cancel control.

## Known gap

Discord does not necessarily surface a thread started on your message, so the routing question can sit unread in a thread you never opened — Slack's implicit threads light up the sidebar and Discord's don't. Being tracked as a follow-up (mention the requester on the card and/or add them as a thread member); it is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)