### PR TITLE
[Fix] Snapshot credentials persist after task sleep

### DIFF
--- a/apps/worker/src/commands/snapshot.ts
+++ b/apps/worker/src/commands/snapshot.ts
@@ -17,6 +17,7 @@ import {
 
 import { setup } from './setup';
 import { injectEnvVars } from './utils/env-vars';
+import { scrubSandboxSecretsBeforeSnapshot } from './utils/scrub-sandbox-secrets';
 import { findRuntimeEnvironmentConfig } from './utils/workspace-config';
 
 /**
@@ -107,6 +108,12 @@ export async function snapshot({
       id: runId,
       status: RunStatus.Running,
     });
+
+    // The provider snapshots the entire filesystem, so drop credential
+    // material (env.sh exports, git tokens, OpenCode auth files) now that
+    // setup is done. Task runs launched from the snapshot re-inject env vars
+    // and tokens at startup.
+    scrubSandboxSecretsBeforeSnapshot();
 
     // Enqueue snapshot request via SDK.
     const { enqueued } = await sdk.taskRuns.createSnapshot({

--- a/apps/worker/src/commands/utils/scrub-sandbox-secrets.test.ts
+++ b/apps/worker/src/commands/utils/scrub-sandbox-secrets.test.ts
@@ -1,0 +1,118 @@
+import * as fs from 'fs';
+
+import { scrubSandboxSecretsBeforeSnapshot } from './scrub-sandbox-secrets';
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+
+  return {
+    ...actual,
+    existsSync: vi.fn(() => false),
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+    chmodSync: vi.fn(),
+    rmSync: vi.fn(),
+  };
+});
+
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+
+  return {
+    ...actual,
+    homedir: vi.fn(() => '/home/testuser'),
+  };
+});
+
+const COMMON_ENV_PATH = '/home/testuser/.roomote/env.sh';
+
+const EXPECTED_REMOVED_PATHS = [
+  '/home/testuser/.roomote/gh-token',
+  '/home/testuser/.roomote/source-control-repository-credentials.tsv',
+  '/home/testuser/.roomote/gitlab-token',
+  '/home/testuser/.roomote/gitlab-repository-credentials.tsv',
+  '/home/testuser/.local/share/opencode/auth.json',
+  '/home/testuser/.local/share/opencode/google-application-credentials.json',
+];
+
+function findWrite(path: string) {
+  return [...vi.mocked(fs.writeFileSync).mock.calls]
+    .reverse()
+    .find((call) => call[0] === path);
+}
+
+describe('scrubSandboxSecretsBeforeSnapshot', () => {
+  const originalXdgDataHome = process.env.XDG_DATA_HOME;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.XDG_DATA_HOME;
+  });
+
+  afterAll(() => {
+    if (originalXdgDataHome !== undefined) {
+      process.env.XDG_DATA_HOME = originalXdgDataHome;
+    } else {
+      delete process.env.XDG_DATA_HOME;
+    }
+  });
+
+  it('rewrites the common env file without any env var exports', () => {
+    scrubSandboxSecretsBeforeSnapshot();
+
+    const write = findWrite(COMMON_ENV_PATH);
+    expect(write).toBeDefined();
+
+    const content = String(write?.[1]);
+    const exportLines = content
+      .split('\n')
+      .filter((line) => line.trim().startsWith('export '));
+
+    // Only scaffolding survives: the recursion guard and the gh wrapper PATH
+    // prepend. No deployment env vars (inference keys, etc.) remain.
+    for (const line of exportLines) {
+      expect(line).toMatch(/export (__ROOMOTE_ENV_LOADED|PATH)=/);
+    }
+  });
+
+  it('removes git tokens and OpenCode credential files', () => {
+    scrubSandboxSecretsBeforeSnapshot();
+
+    for (const path of EXPECTED_REMOVED_PATHS) {
+      expect(fs.rmSync).toHaveBeenCalledWith(path, { force: true });
+    }
+  });
+
+  it('respects XDG_DATA_HOME when locating OpenCode credential files', () => {
+    process.env.XDG_DATA_HOME = '/custom/data';
+
+    scrubSandboxSecretsBeforeSnapshot();
+
+    expect(fs.rmSync).toHaveBeenCalledWith('/custom/data/opencode/auth.json', {
+      force: true,
+    });
+    expect(fs.rmSync).toHaveBeenCalledWith(
+      '/custom/data/opencode/google-application-credentials.json',
+      { force: true },
+    );
+  });
+
+  it('continues scrubbing and warns instead of throwing when a step fails', () => {
+    vi.mocked(fs.writeFileSync).mockImplementation(() => {
+      throw new Error('disk full');
+    });
+
+    const logger = { info: vi.fn(), warn: vi.fn() };
+
+    expect(() => scrubSandboxSecretsBeforeSnapshot(logger)).not.toThrow();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('disk full'),
+    );
+
+    // Later steps still ran despite the env-file failure.
+    for (const path of EXPECTED_REMOVED_PATHS) {
+      expect(fs.rmSync).toHaveBeenCalledWith(path, { force: true });
+    }
+  });
+});

--- a/apps/worker/src/commands/utils/scrub-sandbox-secrets.test.ts
+++ b/apps/worker/src/commands/utils/scrub-sandbox-secrets.test.ts
@@ -97,6 +97,33 @@ describe('scrubSandboxSecretsBeforeSnapshot', () => {
     );
   });
 
+  it('uses the task runtime home for OpenCode credentials', () => {
+    scrubSandboxSecretsBeforeSnapshot(undefined, {
+      homeDir: '/workspace/.roomote-runtime-home',
+      runtimeEnv: {},
+    });
+
+    expect(fs.rmSync).toHaveBeenCalledWith(
+      '/workspace/.roomote-runtime-home/.local/share/opencode/auth.json',
+      { force: true },
+    );
+    expect(fs.rmSync).toHaveBeenCalledWith(
+      '/workspace/.roomote-runtime-home/.local/share/opencode/google-application-credentials.json',
+      { force: true },
+    );
+  });
+
+  it('uses task-specific XDG_DATA_HOME for OpenCode credentials', () => {
+    scrubSandboxSecretsBeforeSnapshot(undefined, {
+      homeDir: '/workspace/.roomote-runtime-home',
+      runtimeEnv: { XDG_DATA_HOME: '/task/data' },
+    });
+
+    expect(fs.rmSync).toHaveBeenCalledWith('/task/data/opencode/auth.json', {
+      force: true,
+    });
+  });
+
   it('continues scrubbing and warns instead of throwing when a step fails', () => {
     vi.mocked(fs.writeFileSync).mockImplementation(() => {
       throw new Error('disk full');

--- a/apps/worker/src/commands/utils/scrub-sandbox-secrets.ts
+++ b/apps/worker/src/commands/utils/scrub-sandbox-secrets.ts
@@ -1,0 +1,77 @@
+import { rmSync } from 'fs';
+import { homedir } from 'os';
+
+import {
+  ensureSourceControlTokenEnvFiles,
+  removeSourceControlCredentialFiles,
+} from '../../lib/github-token';
+import { resolveOpenCodeCredentialFilePaths } from '../../run-task/agent-home';
+
+import { writeCommonEnvFile } from './env-vars';
+
+interface ScrubLogger {
+  info(message: string): void;
+  warn(message: string): void;
+}
+
+function runScrubStep(
+  step: string,
+  logger: ScrubLogger,
+  scrub: () => void,
+): void {
+  try {
+    scrub();
+  } catch (error) {
+    logger.warn(
+      `[scrubSandboxSecrets] Failed to ${step}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
+/**
+ * Remove secret material from the sandbox filesystem before a filesystem
+ * snapshot is taken. Compute providers snapshot the entire filesystem, so
+ * anything left on disk here persists in the snapshot image at the provider
+ * and survives key rotation in the database.
+ *
+ * Everything scrubbed below is re-materialized from the dequeue/resume
+ * response at the next run start (`injectEnvVars` plus the OpenCode
+ * bootstrap), so restored sandboxes never rely on snapshotted credential
+ * state:
+ * - `~/.roomote/env.sh` holds plaintext exports of all deployment env vars,
+ *   including inference provider keys, pasted Google service-account JSON,
+ *   and the ChatGPT subscription OAuth record.
+ * - `~/.roomote/gh-token` and the source-control credentials TSV hold git
+ *   provider tokens.
+ * - The OpenCode data dir holds the materialized `auth.json` and Google
+ *   service-account JSON.
+ */
+export function scrubSandboxSecretsBeforeSnapshot(
+  logger: ScrubLogger = console,
+): void {
+  logger.info(
+    '[scrubSandboxSecrets] Removing credential material before filesystem snapshot',
+  );
+
+  runScrubStep('rewrite common env file without env vars', logger, () => {
+    // Recreate the static token env scripts first: env.sh sources them, and
+    // this also guarantees ~/.roomote exists.
+    ensureSourceControlTokenEnvFiles();
+    writeCommonEnvFile({});
+  });
+
+  runScrubStep('remove source-control credential files', logger, () =>
+    removeSourceControlCredentialFiles(),
+  );
+
+  runScrubStep('remove OpenCode credential files', logger, () => {
+    for (const filePath of resolveOpenCodeCredentialFilePaths(
+      homedir(),
+      process.env,
+    )) {
+      rmSync(filePath, { force: true });
+    }
+  });
+}

--- a/apps/worker/src/commands/utils/scrub-sandbox-secrets.ts
+++ b/apps/worker/src/commands/utils/scrub-sandbox-secrets.ts
@@ -14,6 +14,11 @@ interface ScrubLogger {
   warn(message: string): void;
 }
 
+interface OpenCodeRuntime {
+  homeDir?: string;
+  runtimeEnv?: Record<string, string | undefined>;
+}
+
 function runScrubStep(
   step: string,
   logger: ScrubLogger,
@@ -50,6 +55,7 @@ function runScrubStep(
  */
 export function scrubSandboxSecretsBeforeSnapshot(
   logger: ScrubLogger = console,
+  openCodeRuntime: OpenCodeRuntime = {},
 ): void {
   logger.info(
     '[scrubSandboxSecrets] Removing credential material before filesystem snapshot',
@@ -68,8 +74,8 @@ export function scrubSandboxSecretsBeforeSnapshot(
 
   runScrubStep('remove OpenCode credential files', logger, () => {
     for (const filePath of resolveOpenCodeCredentialFilePaths(
-      homedir(),
-      process.env,
+      openCodeRuntime.homeDir ?? homedir(),
+      openCodeRuntime.runtimeEnv ?? process.env,
     )) {
       rmSync(filePath, { force: true });
     }

--- a/apps/worker/src/lib/github-token.ts
+++ b/apps/worker/src/lib/github-token.ts
@@ -226,6 +226,26 @@ function ensureAdoTokenEnvFile(): string {
   return ADO_TOKEN_ENV_FILE_PATH;
 }
 
+/**
+ * Delete the on-disk source-control credential material (the GitHub token
+ * file and scoped repository credentials). Called before filesystem
+ * snapshots so tokens never persist inside snapshot images; the injection
+ * path recreates these files at the next run start. The credential helper,
+ * gh wrapper, and token env scripts all tolerate missing files.
+ */
+export function removeSourceControlCredentialFiles(): void {
+  const credentialFilePaths = [
+    GH_TOKEN_FILE_PATH,
+    SOURCE_CONTROL_CREDENTIALS_FILE_PATH,
+    LEGACY_GITLAB_TOKEN_FILE_PATH,
+    LEGACY_GITLAB_CREDENTIALS_FILE_PATH,
+  ];
+
+  for (const filePath of credentialFilePaths) {
+    rmSync(filePath, { force: true });
+  }
+}
+
 function ensureSourceControlGitConfigFile(): void {
   ensureGhTokenDirectory();
   if (!existsSync(SOURCE_CONTROL_GIT_CONFIG_PATH)) {

--- a/apps/worker/src/run-task/agent-home.ts
+++ b/apps/worker/src/run-task/agent-home.ts
@@ -48,6 +48,8 @@ const OPENCODE_CONFIG_DIR_NAME = 'opencode';
 const GOOGLE_APPLICATION_CREDENTIALS_FILE_NAME =
   'google-application-credentials.json';
 
+export const OPENCODE_AUTH_FILE_NAME = 'auth.json';
+
 const OPENROUTER_PROVIDER_ID = 'openrouter';
 
 const BEDROCK_MANTLE_PROVIDER_ID = 'bedrock-mantle';
@@ -1408,7 +1410,7 @@ export function generateOpenCodeConfig({
  */
 export function resolveOpenCodeDataDir(
   homeDir: string,
-  runtimeEnv: Record<string, string>,
+  runtimeEnv: Record<string, string | undefined>,
 ): string {
   const xdgDataHome = runtimeEnv.XDG_DATA_HOME?.trim();
 
@@ -1416,6 +1418,24 @@ export function resolveOpenCodeDataDir(
     xdgDataHome || path.join(homeDir, '.local', 'share'),
     OPENCODE_CONFIG_DIR_NAME,
   );
+}
+
+/**
+ * Credential files materialized under the OpenCode data dir for a run: the
+ * ChatGPT subscription `auth.json` and the inline Google service-account
+ * JSON. Deleted before filesystem snapshots; both are re-materialized from
+ * the dequeue/resume env at the next run start.
+ */
+export function resolveOpenCodeCredentialFilePaths(
+  homeDir: string,
+  runtimeEnv: Record<string, string | undefined>,
+): string[] {
+  const dataDir = resolveOpenCodeDataDir(homeDir, runtimeEnv);
+
+  return [
+    path.join(dataDir, OPENCODE_AUTH_FILE_NAME),
+    path.join(dataDir, GOOGLE_APPLICATION_CREDENTIALS_FILE_NAME),
+  ];
 }
 
 /**

--- a/apps/worker/src/run-task/run-task.ts
+++ b/apps/worker/src/run-task/run-task.ts
@@ -53,6 +53,7 @@ import { awaitSubprocess } from './subprocess';
 import { resolveStatus } from './resolve-status';
 import { getDefaultKeepaliveMs } from './completion';
 import { waitForExternalSleepAction } from './wait-for-external-sleep-action';
+import { scrubSandboxSecretsBeforeSnapshot } from '../commands/utils/scrub-sandbox-secrets';
 import {
   buildWorkerRuntimeStateDetails,
   buildWorkerTaskEventDetails,
@@ -1862,13 +1863,20 @@ export const runTask = async ({
       );
     }
 
-    const { claimed: sleepActionTriggered } =
-      skipExternalSleepAction || skipSleepAfterTerminalCancel
-        ? { claimed: false }
-        : await waitForExternalSleepAction({
-            taskRun,
-            logger,
-          });
+    let sleepActionTriggered = false;
+
+    if (!skipExternalSleepAction && !skipSleepAfterTerminalCancel) {
+      // BullMQ may claim the sleep action and snapshot the filesystem while
+      // the handoff helper polls below. The harness has already shut down, so
+      // drop on-disk credential material first; resume re-injects it from the
+      // dequeue response.
+      scrubSandboxSecretsBeforeSnapshot(logger);
+
+      ({ claimed: sleepActionTriggered } = await waitForExternalSleepAction({
+        taskRun,
+        logger,
+      }));
+    }
 
     // Fallback: check for pending Linear messages that arrived during the snapshot
     // window. In practice, the provider runtime is torn down during or

--- a/apps/worker/src/run-task/run-task.ts
+++ b/apps/worker/src/run-task/run-task.ts
@@ -1870,7 +1870,7 @@ export const runTask = async ({
       // the handoff helper polls below. The harness has already shut down, so
       // drop on-disk credential material first; resume re-injects it from the
       // dequeue response.
-      scrubSandboxSecretsBeforeSnapshot(logger);
+      scrubSandboxSecretsBeforeSnapshot(logger, { homeDir, runtimeEnv });
 
       ({ claimed: sleepActionTriggered } = await waitForExternalSleepAction({
         taskRun,

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/bootstrap.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/bootstrap.ts
@@ -4,6 +4,7 @@ import { promises as fs } from 'node:fs';
 
 import {
   generateOpenCodeConfig,
+  OPENCODE_AUTH_FILE_NAME,
   resolveOpenCodeDataDir,
   ROOMOTE_OPENCODE_SLACK_STOP_HOOK_FILE_NAME,
   type OpenCodeConfigMcpServer,
@@ -294,7 +295,7 @@ async function materializeOpenCodeAuthJson(options: {
   try {
     const dataDir = resolveOpenCodeDataDir(homeDir, commandEnv);
     await fs.mkdir(dataDir, { recursive: true });
-    const authFilePath = path.join(dataDir, 'auth.json');
+    const authFilePath = path.join(dataDir, OPENCODE_AUTH_FILE_NAME);
     await fs.writeFile(authFilePath, authContent, { mode: 0o600 });
     delete commandEnv[OPENCODE_AUTH_CONTENT_ENV_VAR_NAME];
     logger.info(


### PR DESCRIPTION
> Opened on behalf of Matt Rubens. [View the task](https://roomote.roomote.ai/task/1vuvfycuv8ur1?utm_source=github-comment&utm_medium=link&utm_campaign=github_pr_review_follow_up) or mention @roomote-roomote for follow-up asks.

## What changed

Worker snapshots now scrub credential material after setup and before sleep or environment snapshots. The sleep-time scrubber resolves OpenCode credential paths from the task runtime home and task runtime environment, including `XDG_DATA_HOME`, so it removes the files the OpenCode bootstrap actually materializes.

## Why this change was made

Snapshot images include the sandbox filesystem. Resolving paths from the worker process could leave task-scoped OpenCode authentication and Google credential files in a snapshot.

## Impact

Snapshot resumes continue to re-materialize credentials from the task payload, while saved snapshot images no longer retain the task-scoped OpenCode credential files.