### PR TITLE
Request a sandbox-server scrub before queue-triggered snapshots

### DIFF
--- a/apps/bullmq/src/jobs/snapshot.test.ts
+++ b/apps/bullmq/src/jobs/snapshot.test.ts
@@ -22,6 +22,7 @@ const {
   mockDrainLinearMessagesToResumeRun,
   mockDrainSlackMessagesToResumeRun,
   mockRecordComputeProviderUsage,
+  mockWithSandboxServerRpcClient,
   mockMarkTaskStartParallelCountEndedAt,
   mockSyncTaskStateFromRuns,
   transactionFn,
@@ -57,6 +58,7 @@ const {
     mockDrainLinearMessagesToResumeRun: vi.fn() as AnyMock,
     mockDrainSlackMessagesToResumeRun: vi.fn() as AnyMock,
     mockRecordComputeProviderUsage: vi.fn() as AnyMock,
+    mockWithSandboxServerRpcClient: vi.fn() as AnyMock,
     mockMarkTaskStartParallelCountEndedAt: vi.fn() as AnyMock,
     mockSyncTaskStateFromRuns: vi.fn() as AnyMock,
     transactionFn: vi.fn() as AnyMock,
@@ -145,6 +147,7 @@ vi.mock('@roomote/slack', () => ({
 
 vi.mock('@roomote/sdk/server', () => ({
   recordComputeProviderUsage: mockRecordComputeProviderUsage,
+  withSandboxServerRpcClient: mockWithSandboxServerRpcClient,
 }));
 
 vi.mock('../monitoring/sentry', () => ({
@@ -193,6 +196,7 @@ describe('snapshotJob', () => {
       linearOrganizationId: null,
     });
     mockFindSnapshotBySourceInstance.mockResolvedValue(null);
+    mockWithSandboxServerRpcClient.mockResolvedValue(undefined);
     mockDrainLinearMessagesToResumeRun.mockResolvedValue({ resumed: false });
     mockDrainSlackMessagesToResumeRun.mockResolvedValue({ resumed: false });
   });
@@ -238,6 +242,19 @@ describe('snapshotJob', () => {
     );
     expect(mockRecordTaskRunEvent).toHaveBeenNthCalledWith(
       3,
+      expect.anything(),
+      expect.objectContaining({
+        runId: 123,
+        source: 'snapshot_queue',
+        eventType: 'decision',
+        details: expect.objectContaining({
+          decision: 'pre_snapshot_scrub_skipped',
+          reason: 'no_sandbox_server_url',
+        }),
+      }),
+    );
+    expect(mockRecordTaskRunEvent).toHaveBeenNthCalledWith(
+      4,
       expect.anything(),
       expect.objectContaining({
         runId: 123,
@@ -301,6 +318,118 @@ describe('snapshotJob', () => {
         source: 'snapshot_queue',
       },
     });
+  });
+
+  it('requests a sandbox-server scrub before creating the snapshot', async () => {
+    mockFindFirst.mockResolvedValue({
+      ...baseTaskRun,
+      sandboxServerUrl: 'https://sandbox.example.test',
+    });
+    mockGetInstanceStatus.mockResolvedValue({ status: 'running' });
+    mockCreateSnapshot.mockResolvedValue({ snapshotId: 'snap_scrubbed' });
+
+    await snapshotJob({
+      data: { runId: 123, sandboxId: 'sb-scrub' },
+    } as never);
+
+    expect(mockWithSandboxServerRpcClient).toHaveBeenCalledTimes(1);
+    expect(mockWithSandboxServerRpcClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 123,
+        userId: null,
+        sandboxServerUrl: 'https://sandbox.example.test',
+        timeoutMs: expect.any(Number),
+        call: expect.any(Function),
+      }),
+    );
+
+    const scrubOrder =
+      mockWithSandboxServerRpcClient.mock.invocationCallOrder[0] ?? 0;
+    const createSnapshotOrder =
+      mockCreateSnapshot.mock.invocationCallOrder[0] ?? 0;
+    expect(scrubOrder).toBeLessThan(createSnapshotOrder);
+
+    // The RPC callback invokes the scrub mutation on the sandbox client.
+    const scrubMutate = vi.fn().mockResolvedValue({ success: true });
+    await mockWithSandboxServerRpcClient.mock.calls[0]?.[0].call({
+      commands: { scrubSnapshotSecrets: { mutate: scrubMutate } },
+    });
+    expect(scrubMutate).toHaveBeenCalledTimes(1);
+
+    expect(mockRecordTaskRunEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        runId: 123,
+        source: 'snapshot_queue',
+        eventType: 'decision',
+        details: expect.objectContaining({
+          decision: 'pre_snapshot_scrub_completed',
+        }),
+      }),
+    );
+  });
+
+  it('continues the snapshot when the sandbox-server scrub is unavailable', async () => {
+    mockFindFirst.mockResolvedValue({
+      ...baseTaskRun,
+      sandboxServerUrl: 'https://sandbox.example.test',
+    });
+    mockGetInstanceStatus.mockResolvedValue({ status: 'running' });
+    mockWithSandboxServerRpcClient.mockRejectedValue(
+      new Error('sandbox server unreachable'),
+    );
+    mockCreateSnapshot.mockResolvedValue({ snapshotId: 'snap_no_scrub' });
+
+    await snapshotJob({
+      data: { runId: 123, sandboxId: 'sb-scrub-down' },
+    } as never);
+
+    expect(mockCreateSnapshot).toHaveBeenCalledTimes(1);
+    expect(mockRecordTaskRunEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        runId: 123,
+        source: 'snapshot_queue',
+        eventType: 'decision',
+        details: expect.objectContaining({
+          decision: 'pre_snapshot_scrub_unavailable',
+          error: 'sandbox server unreachable',
+        }),
+      }),
+    );
+    expect(mockRecordTaskRunEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        runId: 123,
+        source: 'snapshot_queue',
+        eventType: 'completed',
+        details: expect.objectContaining({ snapshotId: 'snap_no_scrub' }),
+      }),
+    );
+  });
+
+  it('skips the scrub request when the run has no sandbox server URL', async () => {
+    mockGetInstanceStatus.mockResolvedValue({ status: 'running' });
+    mockCreateSnapshot.mockResolvedValue({ snapshotId: 'snap_no_url' });
+
+    await snapshotJob({
+      data: { runId: 123, sandboxId: 'sb-no-url' },
+    } as never);
+
+    expect(mockWithSandboxServerRpcClient).not.toHaveBeenCalled();
+    expect(mockRecordTaskRunEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        runId: 123,
+        source: 'snapshot_queue',
+        eventType: 'decision',
+        details: expect.objectContaining({
+          decision: 'pre_snapshot_scrub_skipped',
+          reason: 'no_sandbox_server_url',
+        }),
+      }),
+    );
+    expect(mockCreateSnapshot).toHaveBeenCalledTimes(1);
   });
 
   it('marks the linked task completed when requested by completion-on-snapshot metadata', async () => {
@@ -542,7 +671,7 @@ describe('snapshotJob', () => {
       }),
     );
     expect(mockRecordTaskRunEvent).toHaveBeenNthCalledWith(
-      4,
+      5,
       expect.anything(),
       expect.objectContaining({
         runId: 123,

--- a/apps/bullmq/src/jobs/snapshot.test.ts
+++ b/apps/bullmq/src/jobs/snapshot.test.ts
@@ -950,6 +950,103 @@ describe('snapshotJob', () => {
     );
   });
 
+  it('asks the sandbox to restore credentials when a terminal failure leaves it running', async () => {
+    mockFindFirst.mockResolvedValue({
+      ...baseTaskRun,
+      sandboxServerUrl: 'https://sandbox.example.test',
+    });
+    mockGetInstanceStatus.mockResolvedValue({ status: 'running' });
+    mockCreateSnapshot.mockRejectedValue(new Error('permanent failure'));
+
+    await expect(
+      snapshotJob({
+        data: { runId: 123, sandboxId: 'sb-restore' },
+        id: 'snapshot-123',
+        attemptsMade: 2,
+        opts: { attempts: 3 },
+      } as never),
+    ).rejects.toMatchObject({ name: 'UnrecoverableError' });
+
+    // First RPC scrubs before the attempt, second restores after the
+    // terminal failure.
+    expect(mockWithSandboxServerRpcClient).toHaveBeenCalledTimes(2);
+    const restoreMutate = vi.fn().mockResolvedValue({ success: true });
+    await mockWithSandboxServerRpcClient.mock.calls[1]?.[0].call({
+      commands: { restoreScrubbedCredentials: { mutate: restoreMutate } },
+    });
+    expect(restoreMutate).toHaveBeenCalledTimes(1);
+
+    expect(mockRecordTaskRunEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        runId: 123,
+        source: 'snapshot_queue',
+        eventType: 'decision',
+        details: expect.objectContaining({
+          decision: 'post_failure_credential_restore_completed',
+        }),
+      }),
+    );
+  });
+
+  it('records an unavailable credential restore without changing the failure outcome', async () => {
+    mockFindFirst.mockResolvedValue({
+      ...baseTaskRun,
+      sandboxServerUrl: 'https://sandbox.example.test',
+    });
+    mockGetInstanceStatus.mockResolvedValue({ status: 'running' });
+    mockCreateSnapshot.mockRejectedValue(new Error('permanent failure'));
+    // Scrub RPC succeeds, restore RPC fails.
+    mockWithSandboxServerRpcClient
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('sandbox server unreachable'));
+
+    await expect(
+      snapshotJob({
+        data: { runId: 123, sandboxId: 'sb-restore-down' },
+        id: 'snapshot-123',
+        attemptsMade: 2,
+        opts: { attempts: 3 },
+      } as never),
+    ).rejects.toMatchObject({ name: 'UnrecoverableError' });
+
+    expect(mockRecordTaskRunEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        runId: 123,
+        source: 'snapshot_queue',
+        eventType: 'decision',
+        details: expect.objectContaining({
+          decision: 'post_failure_credential_restore_unavailable',
+          error: 'sandbox server unreachable',
+        }),
+      }),
+    );
+    expect(setFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshotRequestedAt: null,
+        sleepRequestedAt: null,
+        snapshotFailedAt: expect.any(Date),
+      }),
+    );
+  });
+
+  it('does not request a credential restore when the run has no sandbox server URL', async () => {
+    mockGetInstanceStatus.mockResolvedValue({ status: 'running' });
+    mockCreateSnapshot.mockRejectedValue(new Error('permanent failure'));
+
+    await expect(
+      snapshotJob({
+        data: { runId: 123, sandboxId: 'sb-restore-no-url' },
+        id: 'snapshot-123',
+        attemptsMade: 2,
+        opts: { attempts: 3 },
+      } as never),
+    ).rejects.toMatchObject({ name: 'UnrecoverableError' });
+
+    expect(mockWithSandboxServerRpcClient).not.toHaveBeenCalled();
+  });
+
   it('does not retry permanent createSnapshot failures when attempts remain', async () => {
     mockGetInstanceStatus.mockResolvedValue({ status: 'running' });
     mockCreateSnapshot.mockRejectedValue(

--- a/apps/bullmq/src/jobs/snapshot.ts
+++ b/apps/bullmq/src/jobs/snapshot.ts
@@ -52,7 +52,7 @@ export interface SnapshotJobData {
 type SnapshotJob = Job<SnapshotJobData, void, string>;
 
 const SNAPSHOT_RECONCILE_TIMEOUT_MS = 60_000;
-const PRE_SNAPSHOT_SCRUB_RPC_TIMEOUT_MS = 10_000;
+const SANDBOX_CREDENTIAL_RPC_TIMEOUT_MS = 10_000;
 const SNAPSHOT_RECONCILE_INTERVAL_MS = 2_000;
 const SNAPSHOT_RECONCILE_SINCE_SKEW_MS = 10_000;
 const TRANSIENT_SNAPSHOT_FAILURE_STATUSES = new Set([408, 409, 425, 429]);
@@ -477,6 +477,19 @@ export const snapshotJob = async (job: SnapshotJob): Promise<void> => {
           },
         });
 
+        // The pre-snapshot scrub removed on-disk credentials and quiesced
+        // credential writers, but this snapshot attempt is being abandoned
+        // and the sandbox may still be running. Ask it to restore credential
+        // state so a surviving task can keep working.
+        await requestPostFailureCredentialRestore({
+          taskRun,
+          instanceId,
+          queueAttempt,
+          queueJobId,
+          snapshotIntentId,
+          triggerPath,
+        });
+
         // Mark the environment snapshot as failed so the UI stops showing "Snapshotting..."
         if (taskRun.payloadKind === TaskPayloadKind.SnapshotEnvironment) {
           const environmentId = taskRun.payload.environmentId;
@@ -789,7 +802,7 @@ async function requestPreSnapshotScrub(input: {
       // Platform automation with no human actor.
       userId: null,
       sandboxServerUrl: taskRun.sandboxServerUrl,
-      timeoutMs: PRE_SNAPSHOT_SCRUB_RPC_TIMEOUT_MS,
+      timeoutMs: SANDBOX_CREDENTIAL_RPC_TIMEOUT_MS,
       call: (client) => client.commands.scrubSnapshotSecrets.mutate(),
     });
 
@@ -813,6 +826,70 @@ async function requestPreSnapshotScrub(input: {
       details: {
         ...baseDetails,
         decision: 'pre_snapshot_scrub_unavailable',
+        error: errorMessage,
+      },
+    });
+  }
+}
+
+/**
+ * After a terminal snapshot failure leaves the sandbox running, ask the
+ * sandbox server to restore the credential state the pre-snapshot scrub
+ * removed (release the credential write barrier, rewrite token files and
+ * env vars) so the surviving task can keep working. Best-effort only:
+ * failures are recorded as run events and never affect the failure handling.
+ */
+async function requestPostFailureCredentialRestore(input: {
+  taskRun: TaskRun;
+  instanceId: string;
+  queueAttempt: number;
+  queueJobId: string | null;
+  snapshotIntentId: string;
+  triggerPath: string | null;
+}): Promise<void> {
+  const { taskRun, instanceId } = input;
+  const baseDetails = {
+    queueJobId: input.queueJobId,
+    queueAttempt: input.queueAttempt,
+    snapshotIntentId: input.snapshotIntentId,
+    triggerPath: input.triggerPath,
+    sandboxId: instanceId,
+  };
+
+  if (!taskRun.sandboxServerUrl) {
+    return;
+  }
+
+  try {
+    await withSandboxServerRpcClient({
+      runId: taskRun.id,
+      // Platform automation with no human actor.
+      userId: null,
+      sandboxServerUrl: taskRun.sandboxServerUrl,
+      timeoutMs: SANDBOX_CREDENTIAL_RPC_TIMEOUT_MS,
+      call: (client) => client.commands.restoreScrubbedCredentials.mutate(),
+    });
+
+    await recordSnapshotQueueEvent(taskRun, {
+      eventType: 'decision',
+      message: `Sandbox ${instanceId} restored credential state after the abandoned snapshot.`,
+      details: {
+        ...baseDetails,
+        decision: 'post_failure_credential_restore_completed',
+      },
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    console.warn(
+      `[SnapshotQueue] Post-failure credential restore unavailable for task run #${taskRun.id}: ${errorMessage}`,
+    );
+    await recordSnapshotQueueEvent(taskRun, {
+      eventType: 'decision',
+      message: `Credential restore was unavailable for sandbox ${instanceId} after the abandoned snapshot.`,
+      details: {
+        ...baseDetails,
+        decision: 'post_failure_credential_restore_unavailable',
         error: errorMessage,
       },
     });

--- a/apps/bullmq/src/jobs/snapshot.ts
+++ b/apps/bullmq/src/jobs/snapshot.ts
@@ -35,6 +35,7 @@ import {
   type SourceInstanceSnapshot,
 } from '@roomote/compute-providers';
 import { drainLinearMessagesToResumeRun } from '@roomote/linear';
+import { withSandboxServerRpcClient } from '@roomote/sdk/server';
 import { drainSlackMessagesToResumeRun } from '@roomote/slack';
 import { z } from 'zod';
 
@@ -51,6 +52,7 @@ export interface SnapshotJobData {
 type SnapshotJob = Job<SnapshotJobData, void, string>;
 
 const SNAPSHOT_RECONCILE_TIMEOUT_MS = 60_000;
+const PRE_SNAPSHOT_SCRUB_RPC_TIMEOUT_MS = 10_000;
 const SNAPSHOT_RECONCILE_INTERVAL_MS = 2_000;
 const SNAPSHOT_RECONCILE_SINCE_SKEW_MS = 10_000;
 const TRANSIENT_SNAPSHOT_FAILURE_STATUSES = new Set([408, 409, 425, 429]);
@@ -305,6 +307,15 @@ export const snapshotJob = async (job: SnapshotJob): Promise<void> => {
   }
 
   if (!snapshotResult) {
+    await requestPreSnapshotScrub({
+      taskRun,
+      instanceId,
+      queueAttempt,
+      queueJobId,
+      snapshotIntentId,
+      triggerPath,
+    });
+
     try {
       await recordMutation({
         provider,
@@ -731,6 +742,82 @@ export const snapshotJob = async (job: SnapshotJob): Promise<void> => {
     }
   }
 };
+
+/**
+ * Ask the sandbox server to drop worker-managed credential files before the
+ * provider snapshots the filesystem. Worker-cooperative paths (the snapshot
+ * command and the sleep handoff) already scrub on their own; this covers
+ * queue-triggered snapshots where the worker never ran its pre-snapshot
+ * scrub, such as the heartbeat-recovery paths. The scrub is idempotent and
+ * everything it removes is re-materialized at the next run start, so it is
+ * requested on every snapshot. Best-effort only: failures are recorded as
+ * run events and never block the snapshot.
+ */
+async function requestPreSnapshotScrub(input: {
+  taskRun: TaskRun;
+  instanceId: string;
+  queueAttempt: number;
+  queueJobId: string | null;
+  snapshotIntentId: string;
+  triggerPath: string | null;
+}): Promise<void> {
+  const { taskRun, instanceId } = input;
+  const baseDetails = {
+    queueJobId: input.queueJobId,
+    queueAttempt: input.queueAttempt,
+    snapshotIntentId: input.snapshotIntentId,
+    triggerPath: input.triggerPath,
+    sandboxId: instanceId,
+  };
+
+  if (!taskRun.sandboxServerUrl) {
+    await recordSnapshotQueueEvent(taskRun, {
+      eventType: 'decision',
+      message: `Skipped pre-snapshot scrub for sandbox ${instanceId} because the run has no sandbox server URL.`,
+      details: {
+        ...baseDetails,
+        decision: 'pre_snapshot_scrub_skipped',
+        reason: 'no_sandbox_server_url',
+      },
+    });
+    return;
+  }
+
+  try {
+    await withSandboxServerRpcClient({
+      runId: taskRun.id,
+      // Platform automation with no human actor.
+      userId: null,
+      sandboxServerUrl: taskRun.sandboxServerUrl,
+      timeoutMs: PRE_SNAPSHOT_SCRUB_RPC_TIMEOUT_MS,
+      call: (client) => client.commands.scrubSnapshotSecrets.mutate(),
+    });
+
+    await recordSnapshotQueueEvent(taskRun, {
+      eventType: 'decision',
+      message: `Sandbox ${instanceId} scrubbed worker-managed credential files before the snapshot.`,
+      details: {
+        ...baseDetails,
+        decision: 'pre_snapshot_scrub_completed',
+      },
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    console.warn(
+      `[SnapshotQueue] Pre-snapshot scrub unavailable for task run #${taskRun.id}: ${errorMessage}`,
+    );
+    await recordSnapshotQueueEvent(taskRun, {
+      eventType: 'decision',
+      message: `Pre-snapshot scrub was unavailable for sandbox ${instanceId}; continuing with the snapshot.`,
+      details: {
+        ...baseDetails,
+        decision: 'pre_snapshot_scrub_unavailable',
+        error: errorMessage,
+      },
+    });
+  }
+}
 
 async function recordSnapshotQueueEvent(
   taskRun: TaskRun,

--- a/apps/worker/src/commands/snapshot.ts
+++ b/apps/worker/src/commands/snapshot.ts
@@ -113,7 +113,7 @@ export async function snapshot({
     // material (env.sh exports, git tokens, OpenCode auth files) now that
     // setup is done. Task runs launched from the snapshot re-inject env vars
     // and tokens at startup.
-    scrubSandboxSecretsBeforeSnapshot();
+    await scrubSandboxSecretsBeforeSnapshot();
 
     // Enqueue snapshot request via SDK.
     const { enqueued } = await sdk.taskRuns.createSnapshot({

--- a/apps/worker/src/commands/utils/scrub-sandbox-secrets.test.ts
+++ b/apps/worker/src/commands/utils/scrub-sandbox-secrets.test.ts
@@ -1,5 +1,10 @@
 import * as fs from 'fs';
 
+import {
+  isCredentialWriteBarrierEngaged,
+  resetCredentialWriteBarrierForTesting,
+} from '../../lib/credential-write-barrier';
+
 import { scrubSandboxSecretsBeforeSnapshot } from './scrub-sandbox-secrets';
 
 vi.mock('fs', async (importOriginal) => {
@@ -46,6 +51,7 @@ describe('scrubSandboxSecretsBeforeSnapshot', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    resetCredentialWriteBarrierForTesting();
     delete process.env.XDG_DATA_HOME;
   });
 
@@ -57,8 +63,8 @@ describe('scrubSandboxSecretsBeforeSnapshot', () => {
     }
   });
 
-  it('rewrites the common env file without any env var exports', () => {
-    scrubSandboxSecretsBeforeSnapshot();
+  it('rewrites the common env file without any env var exports', async () => {
+    await scrubSandboxSecretsBeforeSnapshot();
 
     const write = findWrite(COMMON_ENV_PATH);
     expect(write).toBeDefined();
@@ -75,18 +81,18 @@ describe('scrubSandboxSecretsBeforeSnapshot', () => {
     }
   });
 
-  it('removes git tokens and OpenCode credential files', () => {
-    scrubSandboxSecretsBeforeSnapshot();
+  it('removes git tokens and OpenCode credential files', async () => {
+    await scrubSandboxSecretsBeforeSnapshot();
 
     for (const path of EXPECTED_REMOVED_PATHS) {
       expect(fs.rmSync).toHaveBeenCalledWith(path, { force: true });
     }
   });
 
-  it('respects XDG_DATA_HOME when locating OpenCode credential files', () => {
+  it('respects XDG_DATA_HOME when locating OpenCode credential files', async () => {
     process.env.XDG_DATA_HOME = '/custom/data';
 
-    scrubSandboxSecretsBeforeSnapshot();
+    await scrubSandboxSecretsBeforeSnapshot();
 
     expect(fs.rmSync).toHaveBeenCalledWith('/custom/data/opencode/auth.json', {
       force: true,
@@ -97,8 +103,8 @@ describe('scrubSandboxSecretsBeforeSnapshot', () => {
     );
   });
 
-  it('uses the task runtime home for OpenCode credentials', () => {
-    scrubSandboxSecretsBeforeSnapshot(undefined, {
+  it('uses the task runtime home for OpenCode credentials', async () => {
+    await scrubSandboxSecretsBeforeSnapshot(undefined, {
       homeDir: '/workspace/.roomote-runtime-home',
       runtimeEnv: {},
     });
@@ -113,8 +119,8 @@ describe('scrubSandboxSecretsBeforeSnapshot', () => {
     );
   });
 
-  it('uses task-specific XDG_DATA_HOME for OpenCode credentials', () => {
-    scrubSandboxSecretsBeforeSnapshot(undefined, {
+  it('uses task-specific XDG_DATA_HOME for OpenCode credentials', async () => {
+    await scrubSandboxSecretsBeforeSnapshot(undefined, {
       homeDir: '/workspace/.roomote-runtime-home',
       runtimeEnv: { XDG_DATA_HOME: '/task/data' },
     });
@@ -124,22 +130,37 @@ describe('scrubSandboxSecretsBeforeSnapshot', () => {
     });
   });
 
-  it('continues scrubbing and warns instead of throwing when a step fails', () => {
-    vi.mocked(fs.writeFileSync).mockImplementation(() => {
+  it('continues scrubbing, warns, and reports the failed step when a step fails', async () => {
+    vi.mocked(fs.writeFileSync).mockImplementationOnce(() => {
       throw new Error('disk full');
     });
 
     const logger = { info: vi.fn(), warn: vi.fn() };
 
-    expect(() => scrubSandboxSecretsBeforeSnapshot(logger)).not.toThrow();
+    const { failedSteps } = await scrubSandboxSecretsBeforeSnapshot(logger);
 
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('disk full'),
     );
+    expect(failedSteps).toEqual(['rewrite common env file without env vars']);
 
     // Later steps still ran despite the env-file failure.
     for (const path of EXPECTED_REMOVED_PATHS) {
       expect(fs.rmSync).toHaveBeenCalledWith(path, { force: true });
     }
+  });
+
+  it('reports no failed steps on success', async () => {
+    const { failedSteps } = await scrubSandboxSecretsBeforeSnapshot();
+
+    expect(failedSteps).toEqual([]);
+  });
+
+  it('engages the credential write barrier before scrubbing', async () => {
+    expect(isCredentialWriteBarrierEngaged()).toBe(false);
+
+    await scrubSandboxSecretsBeforeSnapshot();
+
+    expect(isCredentialWriteBarrierEngaged()).toBe(true);
   });
 });

--- a/apps/worker/src/commands/utils/scrub-sandbox-secrets.ts
+++ b/apps/worker/src/commands/utils/scrub-sandbox-secrets.ts
@@ -1,6 +1,7 @@
 import { rmSync } from 'fs';
 import { homedir } from 'os';
 
+import { engageCredentialWriteBarrier } from '../../lib/credential-write-barrier';
 import {
   ensureSourceControlTokenEnvFiles,
   removeSourceControlCredentialFiles,
@@ -19,19 +20,26 @@ interface OpenCodeRuntime {
   runtimeEnv?: Record<string, string | undefined>;
 }
 
+interface ScrubSandboxSecretsResult {
+  /** Human-readable names of scrub steps that failed. Empty on full success. */
+  failedSteps: string[];
+}
+
 function runScrubStep(
   step: string,
   logger: ScrubLogger,
   scrub: () => void,
-): void {
+): boolean {
   try {
     scrub();
+    return true;
   } catch (error) {
     logger.warn(
       `[scrubSandboxSecrets] Failed to ${step}: ${
         error instanceof Error ? error.message : String(error)
       }`,
     );
+    return false;
   }
 }
 
@@ -53,26 +61,38 @@ function runScrubStep(
  * - The OpenCode data dir holds the materialized `auth.json` and Google
  *   service-account JSON.
  */
-export function scrubSandboxSecretsBeforeSnapshot(
+export async function scrubSandboxSecretsBeforeSnapshot(
   logger: ScrubLogger = console,
   openCodeRuntime: OpenCodeRuntime = {},
-): void {
+): Promise<ScrubSandboxSecretsResult> {
   logger.info(
     '[scrubSandboxSecrets] Removing credential material before filesystem snapshot',
   );
 
-  runScrubStep('rewrite common env file without env vars', logger, () => {
+  // Quiesce credential writers (token refresh loop, env reloads) and wait for
+  // in-flight writes to settle so nothing re-materializes files between this
+  // scrub and the provider snapshot.
+  await engageCredentialWriteBarrier();
+
+  const failedSteps: string[] = [];
+  const trackScrubStep = (step: string, scrub: () => void): void => {
+    if (!runScrubStep(step, logger, scrub)) {
+      failedSteps.push(step);
+    }
+  };
+
+  trackScrubStep('rewrite common env file without env vars', () => {
     // Recreate the static token env scripts first: env.sh sources them, and
     // this also guarantees ~/.roomote exists.
     ensureSourceControlTokenEnvFiles();
     writeCommonEnvFile({});
   });
 
-  runScrubStep('remove source-control credential files', logger, () =>
+  trackScrubStep('remove source-control credential files', () =>
     removeSourceControlCredentialFiles(),
   );
 
-  runScrubStep('remove OpenCode credential files', logger, () => {
+  trackScrubStep('remove OpenCode credential files', () => {
     for (const filePath of resolveOpenCodeCredentialFilePaths(
       openCodeRuntime.homeDir ?? homedir(),
       openCodeRuntime.runtimeEnv ?? process.env,
@@ -80,4 +100,6 @@ export function scrubSandboxSecretsBeforeSnapshot(
       rmSync(filePath, { force: true });
     }
   });
+
+  return { failedSteps };
 }

--- a/apps/worker/src/lib/credential-write-barrier.test.ts
+++ b/apps/worker/src/lib/credential-write-barrier.test.ts
@@ -1,0 +1,71 @@
+import {
+  engageCredentialWriteBarrier,
+  isCredentialWriteBarrierEngaged,
+  resetCredentialWriteBarrierForTesting,
+  runUnlessCredentialWriteBarrier,
+} from './credential-write-barrier';
+
+describe('credential write barrier', () => {
+  beforeEach(() => {
+    resetCredentialWriteBarrierForTesting();
+  });
+
+  it('runs writes and returns their result while disengaged', async () => {
+    const result = await runUnlessCredentialWriteBarrier(async () => 'written');
+
+    expect(result).toBe('written');
+    expect(isCredentialWriteBarrierEngaged()).toBe(false);
+  });
+
+  it('skips writes without invoking them once engaged', async () => {
+    await engageCredentialWriteBarrier();
+
+    const work = vi.fn(async () => 'written');
+    const result = await runUnlessCredentialWriteBarrier(work);
+
+    expect(result).toBeNull();
+    expect(work).not.toHaveBeenCalled();
+  });
+
+  it('waits for in-flight writes to settle before engaging', async () => {
+    let finishWrite!: () => void;
+    let writeSettled = false;
+
+    const pendingWrite = runUnlessCredentialWriteBarrier(
+      () =>
+        new Promise<void>((resolve) => {
+          finishWrite = () => {
+            writeSettled = true;
+            resolve();
+          };
+        }),
+    );
+
+    let engaged = false;
+    const engagement = engageCredentialWriteBarrier().then(() => {
+      engaged = true;
+    });
+
+    // The barrier must not report engaged-and-drained while a write is
+    // still pending.
+    await Promise.resolve();
+    expect(engaged).toBe(false);
+    expect(isCredentialWriteBarrierEngaged()).toBe(true);
+
+    finishWrite();
+    await engagement;
+    await pendingWrite;
+
+    expect(engaged).toBe(true);
+    expect(writeSettled).toBe(true);
+  });
+
+  it('drains failed writes without rejecting the engagement', async () => {
+    const failingWrite = runUnlessCredentialWriteBarrier(async () => {
+      throw new Error('write exploded');
+    });
+
+    await expect(engageCredentialWriteBarrier()).resolves.toBeUndefined();
+    await expect(failingWrite).rejects.toThrow('write exploded');
+  });
+});

--- a/apps/worker/src/lib/credential-write-barrier.test.ts
+++ b/apps/worker/src/lib/credential-write-barrier.test.ts
@@ -1,6 +1,7 @@
 import {
   engageCredentialWriteBarrier,
   isCredentialWriteBarrierEngaged,
+  releaseCredentialWriteBarrier,
   resetCredentialWriteBarrierForTesting,
   runUnlessCredentialWriteBarrier,
 } from './credential-write-barrier';
@@ -58,6 +59,18 @@ describe('credential write barrier', () => {
 
     expect(engaged).toBe(true);
     expect(writeSettled).toBe(true);
+  });
+
+  it('allows writes again after the barrier is released', async () => {
+    await engageCredentialWriteBarrier();
+    releaseCredentialWriteBarrier();
+
+    const work = vi.fn(async () => 'written');
+    const result = await runUnlessCredentialWriteBarrier(work);
+
+    expect(result).toBe('written');
+    expect(work).toHaveBeenCalledTimes(1);
+    expect(isCredentialWriteBarrierEngaged()).toBe(false);
   });
 
   it('drains failed writes without rejecting the engagement', async () => {

--- a/apps/worker/src/lib/credential-write-barrier.ts
+++ b/apps/worker/src/lib/credential-write-barrier.ts
@@ -1,14 +1,15 @@
 /**
- * One-way latch that quiesces credential-file writers before a filesystem
- * snapshot. The pre-snapshot scrub engages the barrier and waits for in-flight
- * writes to drain; once engaged, later writers (the source-control token
- * refresh loop, deployment env reloads) skip their file writes so they cannot
+ * Latch that quiesces credential-file writers before a filesystem snapshot.
+ * The pre-snapshot scrub engages the barrier and waits for in-flight writes
+ * to drain; while engaged, writers (the source-control token refresh loop,
+ * deployment env reloads) skip their file writes so they cannot
  * re-materialize credentials between the scrub and the provider snapshot.
  *
- * The latch never releases: after a snapshot request the sandbox is either
- * completed and torn down or resumed from the snapshot with credentials
- * re-injected at run start, so no writer has a legitimate reason to run again
- * in this process.
+ * The barrier stays engaged for the normal snapshot lifecycle — the sandbox
+ * is completed and torn down, or resumed from the snapshot with credentials
+ * re-injected at run start. When a snapshot terminally fails and the sandbox
+ * keeps running, the credential restore path releases the barrier so the
+ * surviving task can refresh tokens and reload its environment again.
  */
 
 let engaged = false;
@@ -29,6 +30,14 @@ export async function engageCredentialWriteBarrier(): Promise<void> {
   while (inFlightWrites.size > 0) {
     await Promise.allSettled([...inFlightWrites]);
   }
+}
+
+/**
+ * Re-enable credential writes after a snapshot attempt is abandoned with the
+ * sandbox still running.
+ */
+export function releaseCredentialWriteBarrier(): void {
+  engaged = false;
 }
 
 /**

--- a/apps/worker/src/lib/credential-write-barrier.ts
+++ b/apps/worker/src/lib/credential-write-barrier.ts
@@ -1,0 +1,60 @@
+/**
+ * One-way latch that quiesces credential-file writers before a filesystem
+ * snapshot. The pre-snapshot scrub engages the barrier and waits for in-flight
+ * writes to drain; once engaged, later writers (the source-control token
+ * refresh loop, deployment env reloads) skip their file writes so they cannot
+ * re-materialize credentials between the scrub and the provider snapshot.
+ *
+ * The latch never releases: after a snapshot request the sandbox is either
+ * completed and torn down or resumed from the snapshot with credentials
+ * re-injected at run start, so no writer has a legitimate reason to run again
+ * in this process.
+ */
+
+let engaged = false;
+const inFlightWrites = new Set<Promise<unknown>>();
+
+export function isCredentialWriteBarrierEngaged(): boolean {
+  return engaged;
+}
+
+/**
+ * Engage the barrier and wait for already-started credential writes to
+ * settle. New writes started after this call are skipped by
+ * `runUnlessCredentialWriteBarrier`.
+ */
+export async function engageCredentialWriteBarrier(): Promise<void> {
+  engaged = true;
+
+  while (inFlightWrites.size > 0) {
+    await Promise.allSettled([...inFlightWrites]);
+  }
+}
+
+/**
+ * Run a credential write unless the barrier is engaged. Returns `null`
+ * (without invoking `work`) when the write was skipped. While the returned
+ * promise is pending, `engageCredentialWriteBarrier` waits for it.
+ */
+export async function runUnlessCredentialWriteBarrier<T>(
+  work: () => Promise<T>,
+): Promise<T | null> {
+  if (engaged) {
+    return null;
+  }
+
+  const write = work();
+  inFlightWrites.add(write);
+
+  try {
+    return await write;
+  } finally {
+    inFlightWrites.delete(write);
+  }
+}
+
+/** Test-only: reset module state between test cases. */
+export function resetCredentialWriteBarrierForTesting(): void {
+  engaged = false;
+  inFlightWrites.clear();
+}

--- a/apps/worker/src/lib/index.ts
+++ b/apps/worker/src/lib/index.ts
@@ -1,3 +1,4 @@
+export { runUnlessCredentialWriteBarrier } from './credential-write-barrier';
 export {
   ADO_TOKEN_ENV_FILE_PATH,
   applySourceControlTokenMetadata,

--- a/apps/worker/src/run-task/agent-home.test.ts
+++ b/apps/worker/src/run-task/agent-home.test.ts
@@ -1,8 +1,19 @@
-import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { generateOpenCodeConfig } from './agent-home';
+import {
+  generateOpenCodeConfig,
+  rematerializeOpenCodeCredentialFiles,
+} from './agent-home';
 
 describe('generateOpenCodeConfig provider support', () => {
   const tempDirs: string[] = [];
@@ -170,5 +181,139 @@ describe('generateOpenCodeConfig provider support', () => {
     expect(runtimeEnv.GOOGLE_APPLICATION_CREDENTIALS).toBe(
       '/run/secrets/google-credentials.json',
     );
+  });
+});
+
+describe('rematerializeOpenCodeCredentialFiles', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  function createHomeDir(): string {
+    const homeDir = mkdtempSync(join(tmpdir(), 'roomote-opencode-restore-'));
+    tempDirs.push(homeDir);
+    return homeDir;
+  }
+
+  function createLogger() {
+    return { info: vi.fn(), warn: vi.fn() };
+  }
+
+  it('rewrites the Google credentials and auth files from env values', () => {
+    const homeDir = createHomeDir();
+    const credentialsJson = JSON.stringify({
+      type: 'service_account',
+      project_id: 'vertex-project',
+    });
+    const authJson = JSON.stringify({ openai: { type: 'oauth' } });
+
+    const { failedSteps } = rematerializeOpenCodeCredentialFiles({
+      homeDir,
+      runtimeEnv: {
+        GOOGLE_APPLICATION_CREDENTIALS: credentialsJson,
+        OPENCODE_AUTH_CONTENT: authJson,
+      },
+      logger: createLogger(),
+    });
+
+    expect(failedSteps).toEqual([]);
+
+    const dataDir = join(homeDir, '.local', 'share', 'opencode');
+    expect(
+      readFileSync(
+        join(dataDir, 'google-application-credentials.json'),
+        'utf8',
+      ),
+    ).toBe(credentialsJson);
+    expect(readFileSync(join(dataDir, 'auth.json'), 'utf8')).toBe(authJson);
+    expect(
+      statSync(join(dataDir, 'google-application-credentials.json')).mode &
+        0o777,
+    ).toBe(0o600);
+    expect(statSync(join(dataDir, 'auth.json')).mode & 0o777).toBe(0o600);
+  });
+
+  it('does not rewrite the caller env or write files for absent values', () => {
+    const homeDir = createHomeDir();
+    const runtimeEnv = {
+      GOOGLE_APPLICATION_CREDENTIALS: '/run/secrets/google-credentials.json',
+    };
+
+    const { failedSteps } = rematerializeOpenCodeCredentialFiles({
+      homeDir,
+      runtimeEnv,
+      logger: createLogger(),
+    });
+
+    expect(failedSteps).toEqual([]);
+    // A file-path value is not inline JSON, so nothing is written.
+    expect(
+      existsSync(
+        join(
+          homeDir,
+          '.local',
+          'share',
+          'opencode',
+          'google-application-credentials.json',
+        ),
+      ),
+    ).toBe(false);
+    expect(
+      existsSync(join(homeDir, '.local', 'share', 'opencode', 'auth.json')),
+    ).toBe(false);
+    expect(runtimeEnv.GOOGLE_APPLICATION_CREDENTIALS).toBe(
+      '/run/secrets/google-credentials.json',
+    );
+  });
+
+  it('respects the task XDG data dir when rewriting files', () => {
+    const homeDir = createHomeDir();
+    const dataHome = join(homeDir, 'xdg-data');
+    const credentialsJson = JSON.stringify({ type: 'service_account' });
+
+    const { failedSteps } = rematerializeOpenCodeCredentialFiles({
+      homeDir,
+      runtimeEnv: {
+        XDG_DATA_HOME: dataHome,
+        GOOGLE_APPLICATION_CREDENTIALS: credentialsJson,
+      },
+      logger: createLogger(),
+    });
+
+    expect(failedSteps).toEqual([]);
+    expect(
+      readFileSync(
+        join(dataHome, 'opencode', 'google-application-credentials.json'),
+        'utf8',
+      ),
+    ).toBe(credentialsJson);
+  });
+
+  it('reports failed steps instead of throwing on write failures', () => {
+    const homeDir = createHomeDir();
+    // Occupy the data-dir path with a file so mkdir fails.
+    const dataParent = join(homeDir, '.local', 'share');
+    mkdirSync(dataParent, { recursive: true });
+    writeFileSync(join(dataParent, 'opencode'), 'not a directory');
+
+    const logger = createLogger();
+    const { failedSteps } = rematerializeOpenCodeCredentialFiles({
+      homeDir,
+      runtimeEnv: {
+        GOOGLE_APPLICATION_CREDENTIALS: JSON.stringify({ type: 'sa' }),
+        OPENCODE_AUTH_CONTENT: '{}',
+      },
+      logger,
+    });
+
+    expect(failedSteps).toEqual([
+      'rewrite Google application credentials file',
+      'rewrite OpenCode auth file',
+    ]);
+    expect(logger.warn).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/worker/src/run-task/agent-home.ts
+++ b/apps/worker/src/run-task/agent-home.ts
@@ -13,6 +13,7 @@ import {
   renderManualSkillMarkdown,
   resolveOpenRouterVariantModelAlias,
   OPENCODE_ARCHITECT_AGENT,
+  OPENCODE_AUTH_CONTENT_ENV_VAR_NAME,
   type EnvironmentManualSkill,
   type OpenRouterVariantModelAlias,
   type ReasoningEffort,
@@ -1436,6 +1437,61 @@ export function resolveOpenCodeCredentialFilePaths(
     path.join(dataDir, OPENCODE_AUTH_FILE_NAME),
     path.join(dataDir, GOOGLE_APPLICATION_CREDENTIALS_FILE_NAME),
   ];
+}
+
+/**
+ * Rewrite the OpenCode credential files the pre-snapshot scrub removed, for
+ * a sandbox that survived an abandoned snapshot attempt. Normally these files
+ * are materialized once during harness bootstrap and the running harness
+ * keeps pointing at their paths (Google's auth library re-reads
+ * GOOGLE_APPLICATION_CREDENTIALS per token mint, and OpenCode persists OAuth
+ * refreshes back to auth.json), so restoring the same paths from the
+ * deployment's current env values heals the live harness without a restart.
+ * Files whose source env value is absent are skipped.
+ */
+export function rematerializeOpenCodeCredentialFiles(options: {
+  homeDir: string;
+  runtimeEnv: Record<string, string>;
+  logger: { info(message: string): void; warn(message: string): void };
+}): { failedSteps: string[] } {
+  const failedSteps: string[] = [];
+  // materializeInlineGoogleCredentials rewrites the env value to the file
+  // path; work on a copy so the caller's env is untouched.
+  const env = { ...options.runtimeEnv };
+
+  try {
+    materializeInlineGoogleCredentials(env, options.homeDir);
+  } catch (error) {
+    options.logger.warn(
+      `[rematerializeOpenCodeCredentialFiles] Failed to rewrite Google application credentials file: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    failedSteps.push('rewrite Google application credentials file');
+  }
+
+  const authContent = env[OPENCODE_AUTH_CONTENT_ENV_VAR_NAME];
+
+  if (authContent) {
+    try {
+      const dataDir = resolveOpenCodeDataDir(options.homeDir, env);
+      fs.mkdirSync(dataDir, { recursive: true, mode: 0o700 });
+      fs.writeFileSync(
+        path.join(dataDir, OPENCODE_AUTH_FILE_NAME),
+        authContent,
+        { encoding: 'utf8', mode: 0o600 },
+      );
+    } catch (error) {
+      options.logger.warn(
+        `[rematerializeOpenCodeCredentialFiles] Failed to rewrite OpenCode auth file: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      failedSteps.push('rewrite OpenCode auth file');
+    }
+  }
+
+  return { failedSteps };
 }
 
 /**

--- a/apps/worker/src/run-task/polling/github-token-refresh.test.ts
+++ b/apps/worker/src/run-task/polling/github-token-refresh.test.ts
@@ -1,0 +1,94 @@
+import {
+  engageCredentialWriteBarrier,
+  resetCredentialWriteBarrierForTesting,
+} from '../../lib/credential-write-barrier';
+
+import { createGitHubTokenRefreshInterval } from './github-token-refresh';
+
+const {
+  mockRefreshGitHubTokenWithMetadata,
+  mockApplyMetadata,
+  mockEnsureFiles,
+} = vi.hoisted(() => ({
+  mockRefreshGitHubTokenWithMetadata: vi.fn(),
+  mockApplyMetadata: vi.fn(),
+  mockEnsureFiles: vi.fn(),
+}));
+
+vi.mock('@roomote/sdk/client', () => ({
+  sdk: {
+    taskRuns: {
+      refreshGitHubTokenWithMetadata: mockRefreshGitHubTokenWithMetadata,
+    },
+  },
+}));
+
+vi.mock('../../lib', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib')>();
+
+  return {
+    ...actual,
+    applySourceControlTokenMetadata: mockApplyMetadata,
+    ensureSourceControlTokenEnvFiles: mockEnsureFiles,
+  };
+});
+
+function createLogger() {
+  return {
+    log: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  } as never;
+}
+
+async function flushAsync() {
+  for (let i = 0; i < 10; i += 1) {
+    await Promise.resolve();
+  }
+}
+
+describe('createGitHubTokenRefreshInterval', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCredentialWriteBarrierForTesting();
+    mockRefreshGitHubTokenWithMetadata.mockResolvedValue({
+      provider: 'github',
+      source: 'app',
+      expiresAt: null,
+      nextRefreshAt: new Date(Date.now() + 45 * 60 * 1000).toISOString(),
+    });
+  });
+
+  it('refreshes and writes token files while the barrier is disengaged', async () => {
+    const interval = createGitHubTokenRefreshInterval({
+      runId: 7,
+      logger: createLogger(),
+    });
+
+    await flushAsync();
+    clearInterval(interval);
+
+    expect(mockRefreshGitHubTokenWithMetadata).toHaveBeenCalledWith({
+      runId: 7,
+    });
+    expect(mockEnsureFiles).toHaveBeenCalled();
+    expect(mockApplyMetadata).toHaveBeenCalled();
+  });
+
+  it('skips refreshes once the credential write barrier is engaged', async () => {
+    await engageCredentialWriteBarrier();
+
+    const interval = createGitHubTokenRefreshInterval({
+      runId: 7,
+      logger: createLogger(),
+    });
+
+    await flushAsync();
+    clearInterval(interval);
+
+    expect(mockRefreshGitHubTokenWithMetadata).not.toHaveBeenCalled();
+    expect(mockEnsureFiles).not.toHaveBeenCalled();
+    expect(mockApplyMetadata).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker/src/run-task/polling/github-token-refresh.ts
+++ b/apps/worker/src/run-task/polling/github-token-refresh.ts
@@ -13,10 +13,10 @@ const DEFAULT_GITHUB_TOKEN_REFRESH_INTERVAL_MS = 45 * 60 * 1000;
 
 interface GitHubTokenRefreshOptions {
   runId: number;
-  logger: HarnessLogger;
+  logger: Pick<HarnessLogger, 'info' | 'error'>;
 }
 
-async function refreshGitHubToken({
+export async function refreshGitHubToken({
   runId,
   logger,
 }: GitHubTokenRefreshOptions): Promise<

--- a/apps/worker/src/run-task/polling/github-token-refresh.ts
+++ b/apps/worker/src/run-task/polling/github-token-refresh.ts
@@ -3,6 +3,7 @@ import { sdk } from '@roomote/sdk/client';
 import {
   applySourceControlTokenMetadata,
   ensureSourceControlTokenEnvFiles,
+  runUnlessCredentialWriteBarrier,
 } from '../../lib';
 import type { HarnessLogger } from '../../logging';
 
@@ -79,8 +80,16 @@ export function createGitHubTokenRefreshInterval(
 
     refreshInFlight = true;
     try {
-      const result = await refreshGitHubToken(options);
-      nextRefreshAtMs = result.nextRefreshAtMs;
+      // Skipped once the pre-snapshot credential scrub engages its barrier:
+      // a refresh completing after the scrub would write token files back
+      // onto the filesystem right before the provider snapshots it.
+      const result = await runUnlessCredentialWriteBarrier(() =>
+        refreshGitHubToken(options),
+      );
+
+      if (result) {
+        nextRefreshAtMs = result.nextRefreshAtMs;
+      }
     } finally {
       refreshInFlight = false;
     }

--- a/apps/worker/src/run-task/run-task.ts
+++ b/apps/worker/src/run-task/run-task.ts
@@ -1663,6 +1663,7 @@ export const runTask = async ({
         mcpTaskEnv.ROOMOTE_SLACK_REPLY_SATISFACTION_STATE_FILE,
       codingHarness: harnessType,
       workerEnv,
+      taskRuntime: { homeDir, runtimeEnv },
       allowTerminal: runtimeEnv.ROOMOTE_TASK_TERMINAL === 'true',
       prepareActorScopedTurn,
       validateToken,
@@ -1870,7 +1871,7 @@ export const runTask = async ({
       // the handoff helper polls below. The harness has already shut down, so
       // drop on-disk credential material first; resume re-injects it from the
       // dequeue response.
-      scrubSandboxSecretsBeforeSnapshot(logger, { homeDir, runtimeEnv });
+      await scrubSandboxSecretsBeforeSnapshot(logger, { homeDir, runtimeEnv });
 
       ({ claimed: sleepActionTriggered } = await waitForExternalSleepAction({
         taskRun,

--- a/apps/worker/src/sandbox-server/procedures/__tests__/reloadDeploymentEnvVars.test.ts
+++ b/apps/worker/src/sandbox-server/procedures/__tests__/reloadDeploymentEnvVars.test.ts
@@ -1,6 +1,10 @@
 import type { RunTokenContext } from '@roomote/types';
 
 import { WorkerEnv } from '../../../env';
+import {
+  engageCredentialWriteBarrier,
+  resetCredentialWriteBarrierForTesting,
+} from '../../../lib/credential-write-barrier';
 import { appRouter } from '../../routers';
 import type { Context } from '../../trpc';
 
@@ -101,6 +105,7 @@ function createCaller(workerEnv?: WorkerEnv, runId = 1) {
 describe('reloadDeploymentEnvVars procedure', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetCredentialWriteBarrierForTesting();
     mockGetResolvedRuntimeEnvVars.mockResolvedValue({
       OPENAI_API_KEY: 'new-openai-key',
       ANTHROPIC_API_KEY: 'new-anthropic-key',
@@ -174,5 +179,19 @@ describe('reloadDeploymentEnvVars procedure', () => {
     ).rejects.toMatchObject({
       message: 'Worker environment is not available for live reload',
     });
+  });
+
+  it('rejects without writing env files once the credential write barrier is engaged', async () => {
+    await engageCredentialWriteBarrier();
+
+    const { caller } = createCaller(createWorkerEnv());
+
+    await expect(
+      caller.commands.reloadDeploymentEnvVars(),
+    ).rejects.toMatchObject({
+      message:
+        'Environment reload is unavailable while the sandbox prepares for a snapshot',
+    });
+    expect(mockInjectEnvVars).not.toHaveBeenCalled();
   });
 });

--- a/apps/worker/src/sandbox-server/procedures/__tests__/restoreScrubbedCredentials.test.ts
+++ b/apps/worker/src/sandbox-server/procedures/__tests__/restoreScrubbedCredentials.test.ts
@@ -8,16 +8,30 @@ import {
 import { appRouter } from '../../routers';
 import type { Context } from '../../trpc';
 
-const { mockRefreshGitHubToken, mockApplyDeploymentEnvVarsReload } = vi.hoisted(
-  () => ({
-    mockRefreshGitHubToken: vi.fn(),
-    mockApplyDeploymentEnvVarsReload: vi.fn(),
-  }),
-);
+const {
+  mockRefreshGitHubToken,
+  mockApplyDeploymentEnvVarsReload,
+  mockRematerializeOpenCodeCredentialFiles,
+} = vi.hoisted(() => ({
+  mockRefreshGitHubToken: vi.fn(),
+  mockApplyDeploymentEnvVarsReload: vi.fn(),
+  mockRematerializeOpenCodeCredentialFiles: vi.fn(),
+}));
 
 vi.mock('../../../run-task/polling/github-token-refresh', () => ({
   refreshGitHubToken: mockRefreshGitHubToken,
 }));
+
+vi.mock('../../../run-task/agent-home', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../run-task/agent-home')>();
+
+  return {
+    ...actual,
+    rematerializeOpenCodeCredentialFiles:
+      mockRematerializeOpenCodeCredentialFiles,
+  };
+});
 
 vi.mock('../reloadDeploymentEnvVars', async (importOriginal) => {
   const actual =
@@ -29,11 +43,16 @@ vi.mock('../reloadDeploymentEnvVars', async (importOriginal) => {
   };
 });
 
-function createCaller(options: { workerEnv?: unknown } = { workerEnv: {} }) {
+function createCaller(
+  options: { workerEnv?: unknown; taskRuntime?: Context['taskRuntime'] } = {
+    workerEnv: {},
+  },
+) {
   const ctx = {
     workingDirectory: '/tmp',
     harness: { isConnected: true },
     workerEnv: options.workerEnv,
+    taskRuntime: options.taskRuntime,
     auth: {
       runId: 1,
       userId: null,
@@ -57,14 +76,32 @@ describe('restoreScrubbedCredentials procedure', () => {
       expiresAt: null,
     });
     mockApplyDeploymentEnvVarsReload.mockResolvedValue({
-      success: true,
       names: ['OPENAI_API_KEY'],
+      envVars: { OPENAI_API_KEY: 'fresh-openai-key' },
+    });
+    mockRematerializeOpenCodeCredentialFiles.mockReturnValue({
+      failedSteps: [],
     });
   });
 
-  it('releases the barrier and re-materializes token files and env vars', async () => {
+  it('releases the barrier and re-materializes token files, env vars, and OpenCode credentials', async () => {
     await engageCredentialWriteBarrier();
-    const caller = createCaller();
+    const caller = createCaller({
+      workerEnv: {},
+      taskRuntime: {
+        homeDir: '/workspace/.roomote-runtime-home',
+        runtimeEnv: {
+          XDG_DATA_HOME: '/task/data',
+          // Bootstrap already rewrote this to a file path; the fresh
+          // deployment value must win in the merged env.
+          GOOGLE_APPLICATION_CREDENTIALS: '/task/data/opencode/google.json',
+        },
+      },
+    });
+    mockApplyDeploymentEnvVarsReload.mockResolvedValue({
+      names: ['GOOGLE_APPLICATION_CREDENTIALS'],
+      envVars: { GOOGLE_APPLICATION_CREDENTIALS: '{"type":"sa"}' },
+    });
 
     const result = await caller.commands.restoreScrubbedCredentials();
 
@@ -76,6 +113,26 @@ describe('restoreScrubbedCredentials procedure', () => {
     expect(mockApplyDeploymentEnvVarsReload).toHaveBeenCalledWith(
       expect.objectContaining({ runId: 1 }),
     );
+    expect(mockRematerializeOpenCodeCredentialFiles).toHaveBeenCalledWith({
+      homeDir: '/workspace/.roomote-runtime-home',
+      runtimeEnv: {
+        XDG_DATA_HOME: '/task/data',
+        GOOGLE_APPLICATION_CREDENTIALS: '{"type":"sa"}',
+      },
+      logger: console,
+    });
+  });
+
+  it('fails when rewriting OpenCode credential files fails', async () => {
+    mockRematerializeOpenCodeCredentialFiles.mockReturnValue({
+      failedSteps: ['rewrite Google application credentials file'],
+    });
+    const caller = createCaller();
+
+    await expect(caller.commands.restoreScrubbedCredentials()).rejects.toThrow(
+      'rewrite Google application credentials file',
+    );
+    expect(isCredentialWriteBarrierEngaged()).toBe(false);
   });
 
   it('fails when the token refresh could not produce a token', async () => {

--- a/apps/worker/src/sandbox-server/procedures/__tests__/restoreScrubbedCredentials.test.ts
+++ b/apps/worker/src/sandbox-server/procedures/__tests__/restoreScrubbedCredentials.test.ts
@@ -1,0 +1,109 @@
+import type { RunTokenContext } from '@roomote/types';
+
+import {
+  engageCredentialWriteBarrier,
+  isCredentialWriteBarrierEngaged,
+  resetCredentialWriteBarrierForTesting,
+} from '../../../lib/credential-write-barrier';
+import { appRouter } from '../../routers';
+import type { Context } from '../../trpc';
+
+const { mockRefreshGitHubToken, mockApplyDeploymentEnvVarsReload } = vi.hoisted(
+  () => ({
+    mockRefreshGitHubToken: vi.fn(),
+    mockApplyDeploymentEnvVarsReload: vi.fn(),
+  }),
+);
+
+vi.mock('../../../run-task/polling/github-token-refresh', () => ({
+  refreshGitHubToken: mockRefreshGitHubToken,
+}));
+
+vi.mock('../reloadDeploymentEnvVars', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../reloadDeploymentEnvVars')>();
+
+  return {
+    ...actual,
+    applyDeploymentEnvVarsReload: mockApplyDeploymentEnvVarsReload,
+  };
+});
+
+function createCaller(options: { workerEnv?: unknown } = { workerEnv: {} }) {
+  const ctx = {
+    workingDirectory: '/tmp',
+    harness: { isConnected: true },
+    workerEnv: options.workerEnv,
+    auth: {
+      runId: 1,
+      userId: null,
+      principal: 'deployment',
+      tokenType: 'run',
+      version: 1,
+    } satisfies RunTokenContext,
+    runId: 1,
+  } as unknown as Context;
+
+  return appRouter.createCaller(ctx);
+}
+
+describe('restoreScrubbedCredentials procedure', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCredentialWriteBarrierForTesting();
+    mockRefreshGitHubToken.mockResolvedValue({
+      nextRefreshAtMs: Date.now() + 60_000,
+      source: 'app',
+      expiresAt: null,
+    });
+    mockApplyDeploymentEnvVarsReload.mockResolvedValue({
+      success: true,
+      names: ['OPENAI_API_KEY'],
+    });
+  });
+
+  it('releases the barrier and re-materializes token files and env vars', async () => {
+    await engageCredentialWriteBarrier();
+    const caller = createCaller();
+
+    const result = await caller.commands.restoreScrubbedCredentials();
+
+    expect(result).toEqual({ success: true });
+    expect(isCredentialWriteBarrierEngaged()).toBe(false);
+    expect(mockRefreshGitHubToken).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: 1 }),
+    );
+    expect(mockApplyDeploymentEnvVarsReload).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: 1 }),
+    );
+  });
+
+  it('fails when the token refresh could not produce a token', async () => {
+    mockRefreshGitHubToken.mockResolvedValue({
+      nextRefreshAtMs: Date.now() + 60_000,
+      source: null,
+      expiresAt: null,
+    });
+    const caller = createCaller();
+
+    await expect(caller.commands.restoreScrubbedCredentials()).rejects.toThrow(
+      'refresh source-control token files',
+    );
+    // The barrier is still released so scheduled refreshes can recover later.
+    expect(isCredentialWriteBarrierEngaged()).toBe(false);
+  });
+
+  it('fails when the env reload fails but still releases the barrier', async () => {
+    await engageCredentialWriteBarrier();
+    mockApplyDeploymentEnvVarsReload.mockRejectedValue(
+      new Error('reload exploded'),
+    );
+    const caller = createCaller();
+
+    await expect(caller.commands.restoreScrubbedCredentials()).rejects.toThrow(
+      'reload deployment env vars',
+    );
+    expect(isCredentialWriteBarrierEngaged()).toBe(false);
+    expect(mockRefreshGitHubToken).toHaveBeenCalled();
+  });
+});

--- a/apps/worker/src/sandbox-server/procedures/__tests__/scrubSnapshotSecrets.test.ts
+++ b/apps/worker/src/sandbox-server/procedures/__tests__/scrubSnapshotSecrets.test.ts
@@ -1,0 +1,76 @@
+import type { RunTokenContext } from '@roomote/types';
+
+import { appRouter } from '../../routers';
+import type { Context } from '../../trpc';
+
+const { mockScrubSandboxSecretsBeforeSnapshot } = vi.hoisted(() => ({
+  mockScrubSandboxSecretsBeforeSnapshot: vi.fn(),
+}));
+
+vi.mock('../../../commands/utils/scrub-sandbox-secrets', () => ({
+  scrubSandboxSecretsBeforeSnapshot: mockScrubSandboxSecretsBeforeSnapshot,
+}));
+
+function createCaller(
+  options: { harnessLogger?: Context['harnessLogger'] } = {},
+) {
+  const ctx = {
+    workingDirectory: '/tmp',
+    harness: { isConnected: true },
+    harnessLogger: options.harnessLogger,
+    auth: {
+      runId: 1,
+      userId: null,
+      principal: 'deployment',
+      tokenType: 'run',
+      version: 1,
+    } satisfies RunTokenContext,
+    runId: 1,
+  } as unknown as Context;
+
+  return appRouter.createCaller(ctx);
+}
+
+describe('scrubSnapshotSecrets procedure', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('runs the pre-snapshot scrub with the harness logger', async () => {
+    const harnessLogger = {
+      log: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as NonNullable<Context['harnessLogger']>;
+    const caller = createCaller({ harnessLogger });
+
+    const result = await caller.commands.scrubSnapshotSecrets();
+
+    expect(result).toEqual({ success: true });
+    expect(mockScrubSandboxSecretsBeforeSnapshot).toHaveBeenCalledTimes(1);
+    expect(mockScrubSandboxSecretsBeforeSnapshot).toHaveBeenCalledWith(
+      harnessLogger,
+    );
+  });
+
+  it('falls back to console when no harness logger is available', async () => {
+    const caller = createCaller();
+
+    const result = await caller.commands.scrubSnapshotSecrets();
+
+    expect(result).toEqual({ success: true });
+    expect(mockScrubSandboxSecretsBeforeSnapshot).toHaveBeenCalledWith(console);
+  });
+
+  it('propagates scrub failures to the caller', async () => {
+    mockScrubSandboxSecretsBeforeSnapshot.mockImplementation(() => {
+      throw new Error('scrub exploded');
+    });
+    const caller = createCaller();
+
+    await expect(caller.commands.scrubSnapshotSecrets()).rejects.toThrow(
+      'scrub exploded',
+    );
+  });
+});

--- a/apps/worker/src/sandbox-server/procedures/__tests__/scrubSnapshotSecrets.test.ts
+++ b/apps/worker/src/sandbox-server/procedures/__tests__/scrubSnapshotSecrets.test.ts
@@ -12,12 +12,16 @@ vi.mock('../../../commands/utils/scrub-sandbox-secrets', () => ({
 }));
 
 function createCaller(
-  options: { harnessLogger?: Context['harnessLogger'] } = {},
+  options: {
+    harnessLogger?: Context['harnessLogger'];
+    taskRuntime?: Context['taskRuntime'];
+  } = {},
 ) {
   const ctx = {
     workingDirectory: '/tmp',
     harness: { isConnected: true },
     harnessLogger: options.harnessLogger,
+    taskRuntime: options.taskRuntime,
     auth: {
       runId: 1,
       userId: null,
@@ -34,16 +38,23 @@ function createCaller(
 describe('scrubSnapshotSecrets procedure', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockScrubSandboxSecretsBeforeSnapshot.mockResolvedValue({
+      failedSteps: [],
+    });
   });
 
-  it('runs the pre-snapshot scrub with the harness logger', async () => {
+  it('runs the pre-snapshot scrub with the harness logger and task runtime', async () => {
     const harnessLogger = {
       log: vi.fn(),
       info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
     } as unknown as NonNullable<Context['harnessLogger']>;
-    const caller = createCaller({ harnessLogger });
+    const taskRuntime = {
+      homeDir: '/workspace/.roomote-runtime-home',
+      runtimeEnv: { XDG_DATA_HOME: '/task/data' },
+    };
+    const caller = createCaller({ harnessLogger, taskRuntime });
 
     const result = await caller.commands.scrubSnapshotSecrets();
 
@@ -51,22 +62,37 @@ describe('scrubSnapshotSecrets procedure', () => {
     expect(mockScrubSandboxSecretsBeforeSnapshot).toHaveBeenCalledTimes(1);
     expect(mockScrubSandboxSecretsBeforeSnapshot).toHaveBeenCalledWith(
       harnessLogger,
+      taskRuntime,
     );
   });
 
-  it('falls back to console when no harness logger is available', async () => {
+  it('falls back to console and worker defaults without task runtime context', async () => {
     const caller = createCaller();
 
     const result = await caller.commands.scrubSnapshotSecrets();
 
     expect(result).toEqual({ success: true });
-    expect(mockScrubSandboxSecretsBeforeSnapshot).toHaveBeenCalledWith(console);
+    expect(mockScrubSandboxSecretsBeforeSnapshot).toHaveBeenCalledWith(
+      console,
+      {},
+    );
+  });
+
+  it('fails the mutation when scrub steps fail so callers do not record success', async () => {
+    mockScrubSandboxSecretsBeforeSnapshot.mockResolvedValue({
+      failedSteps: ['remove OpenCode credential files'],
+    });
+    const caller = createCaller();
+
+    await expect(caller.commands.scrubSnapshotSecrets()).rejects.toThrow(
+      'Pre-snapshot scrub failed to remove OpenCode credential files',
+    );
   });
 
   it('propagates scrub failures to the caller', async () => {
-    mockScrubSandboxSecretsBeforeSnapshot.mockImplementation(() => {
-      throw new Error('scrub exploded');
-    });
+    mockScrubSandboxSecretsBeforeSnapshot.mockRejectedValue(
+      new Error('scrub exploded'),
+    );
     const caller = createCaller();
 
     await expect(caller.commands.scrubSnapshotSecrets()).rejects.toThrow(

--- a/apps/worker/src/sandbox-server/procedures/index.ts
+++ b/apps/worker/src/sandbox-server/procedures/index.ts
@@ -14,6 +14,7 @@ export { answerUserInputRequest } from './answerUserInputRequest';
 export { touchKeepalive } from './touchKeepalive';
 export { reloadDeploymentEnvVars } from './reloadDeploymentEnvVars';
 export { scrubSnapshotSecrets } from './scrubSnapshotSecrets';
+export { restoreScrubbedCredentials } from './restoreScrubbedCredentials';
 
 // Queries
 export { getRuntimeState } from './getRuntimeState';

--- a/apps/worker/src/sandbox-server/procedures/index.ts
+++ b/apps/worker/src/sandbox-server/procedures/index.ts
@@ -13,6 +13,7 @@ export { deleteQueuedPrompt } from './deleteQueuedPrompt';
 export { answerUserInputRequest } from './answerUserInputRequest';
 export { touchKeepalive } from './touchKeepalive';
 export { reloadDeploymentEnvVars } from './reloadDeploymentEnvVars';
+export { scrubSnapshotSecrets } from './scrubSnapshotSecrets';
 
 // Queries
 export { getRuntimeState } from './getRuntimeState';

--- a/apps/worker/src/sandbox-server/procedures/reloadDeploymentEnvVars.ts
+++ b/apps/worker/src/sandbox-server/procedures/reloadDeploymentEnvVars.ts
@@ -25,13 +25,15 @@ function omitKeys(
 /**
  * Fetch the deployment's current env vars and rewrite the sandbox env
  * (env.sh, runtime env, harness command env) from them. Shared by the live
- * reload mutation and the post-snapshot-failure credential restore.
+ * reload mutation and the post-snapshot-failure credential restore. The
+ * returned `envVars` carry raw values and must never be returned to RPC
+ * callers.
  */
 export async function applyDeploymentEnvVarsReload(input: {
   runId: number;
   workerEnv: WorkerEnv;
   harness: Harness;
-}): Promise<{ success: true; names: string[] }> {
+}): Promise<{ names: string[]; envVars: Record<string, string> }> {
   const { runId, workerEnv, harness } = input;
 
   const [freshEnvVars, taskRun] = await Promise.all([
@@ -69,10 +71,10 @@ export async function applyDeploymentEnvVarsReload(input: {
   });
 
   return {
-    success: true,
     names: Object.keys(freshEnvVars).sort((left, right) =>
       left.localeCompare(right),
     ),
+    envVars: freshEnvVars,
   };
 }
 
@@ -109,6 +111,7 @@ export const reloadDeploymentEnvVars = publicProcedure.mutation(
       });
     }
 
-    return reloadResult;
+    // Only the names leave the sandbox; the raw values stay in-process.
+    return { success: true as const, names: reloadResult.names };
   },
 );

--- a/apps/worker/src/sandbox-server/procedures/reloadDeploymentEnvVars.ts
+++ b/apps/worker/src/sandbox-server/procedures/reloadDeploymentEnvVars.ts
@@ -3,6 +3,7 @@ import { TRPCError } from '@trpc/server';
 import { sdk } from '@roomote/sdk/client';
 
 import { injectEnvVars } from '../../commands/utils/env-vars';
+import { runUnlessCredentialWriteBarrier } from '../../lib';
 
 import { publicProcedure } from '../trpc';
 
@@ -35,45 +36,62 @@ export const reloadDeploymentEnvVars = publicProcedure.mutation(
       });
     }
 
-    const [freshEnvVars, taskRun] = await Promise.all([
-      sdk.taskRuns.getResolvedRuntimeEnvVars({ runId: ctx.runId }),
-      sdk.taskRuns.findFirstById(ctx.runId),
-    ]);
+    const { runId, workerEnv, harness } = ctx;
 
-    if (!taskRun) {
+    // Wrapped in the credential write barrier: the reload rewrites env.sh,
+    // which must not happen between the pre-snapshot scrub and the provider
+    // filesystem snapshot.
+    const reloadResult = await runUnlessCredentialWriteBarrier(async () => {
+      const [freshEnvVars, taskRun] = await Promise.all([
+        sdk.taskRuns.getResolvedRuntimeEnvVars({ runId }),
+        sdk.taskRuns.findFirstById(runId),
+      ]);
+
+      if (!taskRun) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Task run not found',
+        });
+      }
+
+      const currentRuntimeEnv = workerEnv.getRuntimeEnv();
+      const nextRuntimeEnv: Record<string, string> = { ...freshEnvVars };
+
+      await injectEnvVars(nextRuntimeEnv, taskRun, {
+        previewProxyBaseUrl: workerEnv.previewProxyBaseUrl,
+        previewProxySubdomainSuffix: workerEnv.previewProxySubdomainSuffix,
+        syncSourceControlTokenFiles: false,
+      });
+
+      workerEnv.setRuntimeEnv(nextRuntimeEnv);
+
+      const currentCommandEnv = harness.getCommandEnv?.() ?? {};
+      const baseCommandEnv = omitKeys(
+        currentCommandEnv,
+        Object.keys(currentRuntimeEnv),
+      );
+
+      harness.setCommandEnv?.({
+        ...baseCommandEnv,
+        ...nextRuntimeEnv,
+      });
+
+      return {
+        success: true,
+        names: Object.keys(freshEnvVars).sort((left, right) =>
+          left.localeCompare(right),
+        ),
+      };
+    });
+
+    if (!reloadResult) {
       throw new TRPCError({
-        code: 'NOT_FOUND',
-        message: 'Task run not found',
+        code: 'PRECONDITION_FAILED',
+        message:
+          'Environment reload is unavailable while the sandbox prepares for a snapshot',
       });
     }
 
-    const currentRuntimeEnv = ctx.workerEnv.getRuntimeEnv();
-    const nextRuntimeEnv: Record<string, string> = { ...freshEnvVars };
-
-    await injectEnvVars(nextRuntimeEnv, taskRun, {
-      previewProxyBaseUrl: ctx.workerEnv.previewProxyBaseUrl,
-      previewProxySubdomainSuffix: ctx.workerEnv.previewProxySubdomainSuffix,
-      syncSourceControlTokenFiles: false,
-    });
-
-    ctx.workerEnv.setRuntimeEnv(nextRuntimeEnv);
-
-    const currentCommandEnv = ctx.harness.getCommandEnv?.() ?? {};
-    const baseCommandEnv = omitKeys(
-      currentCommandEnv,
-      Object.keys(currentRuntimeEnv),
-    );
-
-    ctx.harness.setCommandEnv?.({
-      ...baseCommandEnv,
-      ...nextRuntimeEnv,
-    });
-
-    return {
-      success: true,
-      names: Object.keys(freshEnvVars).sort((left, right) =>
-        left.localeCompare(right),
-      ),
-    };
+    return reloadResult;
   },
 );

--- a/apps/worker/src/sandbox-server/procedures/reloadDeploymentEnvVars.ts
+++ b/apps/worker/src/sandbox-server/procedures/reloadDeploymentEnvVars.ts
@@ -3,8 +3,10 @@ import { TRPCError } from '@trpc/server';
 import { sdk } from '@roomote/sdk/client';
 
 import { injectEnvVars } from '../../commands/utils/env-vars';
+import type { WorkerEnv } from '../../env';
 import { runUnlessCredentialWriteBarrier } from '../../lib';
 
+import type { Harness } from '../lib/harness';
 import { publicProcedure } from '../trpc';
 
 function omitKeys(
@@ -18,6 +20,60 @@ function omitKeys(
   }
 
   return nextEnv;
+}
+
+/**
+ * Fetch the deployment's current env vars and rewrite the sandbox env
+ * (env.sh, runtime env, harness command env) from them. Shared by the live
+ * reload mutation and the post-snapshot-failure credential restore.
+ */
+export async function applyDeploymentEnvVarsReload(input: {
+  runId: number;
+  workerEnv: WorkerEnv;
+  harness: Harness;
+}): Promise<{ success: true; names: string[] }> {
+  const { runId, workerEnv, harness } = input;
+
+  const [freshEnvVars, taskRun] = await Promise.all([
+    sdk.taskRuns.getResolvedRuntimeEnvVars({ runId }),
+    sdk.taskRuns.findFirstById(runId),
+  ]);
+
+  if (!taskRun) {
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: 'Task run not found',
+    });
+  }
+
+  const currentRuntimeEnv = workerEnv.getRuntimeEnv();
+  const nextRuntimeEnv: Record<string, string> = { ...freshEnvVars };
+
+  await injectEnvVars(nextRuntimeEnv, taskRun, {
+    previewProxyBaseUrl: workerEnv.previewProxyBaseUrl,
+    previewProxySubdomainSuffix: workerEnv.previewProxySubdomainSuffix,
+    syncSourceControlTokenFiles: false,
+  });
+
+  workerEnv.setRuntimeEnv(nextRuntimeEnv);
+
+  const currentCommandEnv = harness.getCommandEnv?.() ?? {};
+  const baseCommandEnv = omitKeys(
+    currentCommandEnv,
+    Object.keys(currentRuntimeEnv),
+  );
+
+  harness.setCommandEnv?.({
+    ...baseCommandEnv,
+    ...nextRuntimeEnv,
+  });
+
+  return {
+    success: true,
+    names: Object.keys(freshEnvVars).sort((left, right) =>
+      left.localeCompare(right),
+    ),
+  };
 }
 
 export const reloadDeploymentEnvVars = publicProcedure.mutation(
@@ -41,48 +97,9 @@ export const reloadDeploymentEnvVars = publicProcedure.mutation(
     // Wrapped in the credential write barrier: the reload rewrites env.sh,
     // which must not happen between the pre-snapshot scrub and the provider
     // filesystem snapshot.
-    const reloadResult = await runUnlessCredentialWriteBarrier(async () => {
-      const [freshEnvVars, taskRun] = await Promise.all([
-        sdk.taskRuns.getResolvedRuntimeEnvVars({ runId }),
-        sdk.taskRuns.findFirstById(runId),
-      ]);
-
-      if (!taskRun) {
-        throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'Task run not found',
-        });
-      }
-
-      const currentRuntimeEnv = workerEnv.getRuntimeEnv();
-      const nextRuntimeEnv: Record<string, string> = { ...freshEnvVars };
-
-      await injectEnvVars(nextRuntimeEnv, taskRun, {
-        previewProxyBaseUrl: workerEnv.previewProxyBaseUrl,
-        previewProxySubdomainSuffix: workerEnv.previewProxySubdomainSuffix,
-        syncSourceControlTokenFiles: false,
-      });
-
-      workerEnv.setRuntimeEnv(nextRuntimeEnv);
-
-      const currentCommandEnv = harness.getCommandEnv?.() ?? {};
-      const baseCommandEnv = omitKeys(
-        currentCommandEnv,
-        Object.keys(currentRuntimeEnv),
-      );
-
-      harness.setCommandEnv?.({
-        ...baseCommandEnv,
-        ...nextRuntimeEnv,
-      });
-
-      return {
-        success: true,
-        names: Object.keys(freshEnvVars).sort((left, right) =>
-          left.localeCompare(right),
-        ),
-      };
-    });
+    const reloadResult = await runUnlessCredentialWriteBarrier(() =>
+      applyDeploymentEnvVarsReload({ runId, workerEnv, harness }),
+    );
 
     if (!reloadResult) {
       throw new TRPCError({

--- a/apps/worker/src/sandbox-server/procedures/restoreScrubbedCredentials.ts
+++ b/apps/worker/src/sandbox-server/procedures/restoreScrubbedCredentials.ts
@@ -1,0 +1,70 @@
+import { TRPCError } from '@trpc/server';
+
+import { releaseCredentialWriteBarrier } from '../../lib/credential-write-barrier';
+import { refreshGitHubToken } from '../../run-task/polling/github-token-refresh';
+
+import { applyDeploymentEnvVarsReload } from './reloadDeploymentEnvVars';
+import { publicProcedure } from '../trpc';
+
+/**
+ * Recover a sandbox that survived an abandoned snapshot attempt. The
+ * pre-snapshot scrub removed on-disk credential material and engaged the
+ * credential write barrier; if the provider snapshot then terminally fails
+ * while the sandbox keeps running, the snapshot queue calls this so the
+ * still-live task can keep working: release the barrier, re-materialize the
+ * source-control token files, and rewrite the sandbox env from the
+ * deployment's current env vars.
+ *
+ * Harness-managed credential files (e.g. the OpenCode auth file) are not
+ * rewritten here: the running harness already holds its credentials in
+ * memory, and any new run start re-materializes them from the dequeue
+ * response.
+ */
+export const restoreScrubbedCredentials = publicProcedure.mutation(
+  async ({ ctx }) => {
+    if (!ctx.runId) {
+      throw new TRPCError({
+        code: 'PRECONDITION_FAILED',
+        message: 'Task run context is required',
+      });
+    }
+
+    const { runId, workerEnv, harness } = ctx;
+    const logger = ctx.harnessLogger ?? console;
+
+    releaseCredentialWriteBarrier();
+
+    const failedSteps: string[] = [];
+
+    // Writes the token env files and refreshed token/credential files.
+    const tokenRefresh = await refreshGitHubToken({ runId, logger });
+
+    if (!tokenRefresh.source) {
+      failedSteps.push('refresh source-control token files');
+    }
+
+    if (workerEnv) {
+      try {
+        await applyDeploymentEnvVarsReload({ runId, workerEnv, harness });
+      } catch (error) {
+        logger.warn(
+          `[restoreScrubbedCredentials] Failed to reload deployment env vars: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        failedSteps.push('reload deployment env vars');
+      }
+    } else {
+      failedSteps.push('reload deployment env vars (worker env unavailable)');
+    }
+
+    if (failedSteps.length > 0) {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: `Credential restore failed to ${failedSteps.join('; ')}`,
+      });
+    }
+
+    return { success: true };
+  },
+);

--- a/apps/worker/src/sandbox-server/procedures/restoreScrubbedCredentials.ts
+++ b/apps/worker/src/sandbox-server/procedures/restoreScrubbedCredentials.ts
@@ -1,6 +1,9 @@
+import { homedir } from 'os';
+
 import { TRPCError } from '@trpc/server';
 
 import { releaseCredentialWriteBarrier } from '../../lib/credential-write-barrier';
+import { rematerializeOpenCodeCredentialFiles } from '../../run-task/agent-home';
 import { refreshGitHubToken } from '../../run-task/polling/github-token-refresh';
 
 import { applyDeploymentEnvVarsReload } from './reloadDeploymentEnvVars';
@@ -12,13 +15,10 @@ import { publicProcedure } from '../trpc';
  * credential write barrier; if the provider snapshot then terminally fails
  * while the sandbox keeps running, the snapshot queue calls this so the
  * still-live task can keep working: release the barrier, re-materialize the
- * source-control token files, and rewrite the sandbox env from the
- * deployment's current env vars.
- *
- * Harness-managed credential files (e.g. the OpenCode auth file) are not
- * rewritten here: the running harness already holds its credentials in
- * memory, and any new run start re-materializes them from the dequeue
- * response.
+ * source-control token files, rewrite the sandbox env from the deployment's
+ * current env vars, and rewrite the OpenCode credential files (the running
+ * harness keeps pointing at their bootstrap-time paths, so restoring the
+ * same paths heals it without a restart).
  */
 export const restoreScrubbedCredentials = publicProcedure.mutation(
   async ({ ctx }) => {
@@ -45,7 +45,25 @@ export const restoreScrubbedCredentials = publicProcedure.mutation(
 
     if (workerEnv) {
       try {
-        await applyDeploymentEnvVarsReload({ runId, workerEnv, harness });
+        const { envVars } = await applyDeploymentEnvVarsReload({
+          runId,
+          workerEnv,
+          harness,
+        });
+
+        // Task runtime env first for path resolution (HOME/XDG_DATA_HOME);
+        // fresh deployment values win so the raw credential contents come
+        // from the deployment, not the bootstrap-time rewrites.
+        const openCodeRestore = rematerializeOpenCodeCredentialFiles({
+          homeDir: ctx.taskRuntime?.homeDir ?? homedir(),
+          runtimeEnv: {
+            ...normalizeEnv(ctx.taskRuntime?.runtimeEnv),
+            ...envVars,
+          },
+          logger,
+        });
+
+        failedSteps.push(...openCodeRestore.failedSteps);
       } catch (error) {
         logger.warn(
           `[restoreScrubbedCredentials] Failed to reload deployment env vars: ${
@@ -68,3 +86,17 @@ export const restoreScrubbedCredentials = publicProcedure.mutation(
     return { success: true };
   },
 );
+
+function normalizeEnv(
+  env: Record<string, string | undefined> | undefined,
+): Record<string, string> {
+  const normalized: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(env ?? {})) {
+    if (value !== undefined) {
+      normalized[key] = value;
+    }
+  }
+
+  return normalized;
+}

--- a/apps/worker/src/sandbox-server/procedures/scrubSnapshotSecrets.ts
+++ b/apps/worker/src/sandbox-server/procedures/scrubSnapshotSecrets.ts
@@ -1,3 +1,5 @@
+import { TRPCError } from '@trpc/server';
+
 import { scrubSandboxSecretsBeforeSnapshot } from '../../commands/utils/scrub-sandbox-secrets';
 
 import { publicProcedure } from '../trpc';
@@ -9,10 +11,25 @@ import { publicProcedure } from '../trpc';
  * pre-snapshot scrub (for example recovery snapshots of a run that did not
  * reach the sleep handoff). The scrub is idempotent and everything it removes
  * is re-materialized from the dequeue/resume response at the next run start.
+ *
+ * Uses the task runtime home/env from the server context so harness
+ * credential files under a task-scoped HOME are found, and reports partial
+ * scrub failures as an error so the caller does not treat an incomplete
+ * scrub as a completed one.
  */
 export const scrubSnapshotSecrets = publicProcedure.mutation(
   async ({ ctx }) => {
-    scrubSandboxSecretsBeforeSnapshot(ctx.harnessLogger ?? console);
+    const { failedSteps } = await scrubSandboxSecretsBeforeSnapshot(
+      ctx.harnessLogger ?? console,
+      ctx.taskRuntime ?? {},
+    );
+
+    if (failedSteps.length > 0) {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: `Pre-snapshot scrub failed to ${failedSteps.join('; ')}`,
+      });
+    }
 
     return { success: true };
   },

--- a/apps/worker/src/sandbox-server/procedures/scrubSnapshotSecrets.ts
+++ b/apps/worker/src/sandbox-server/procedures/scrubSnapshotSecrets.ts
@@ -1,0 +1,19 @@
+import { scrubSandboxSecretsBeforeSnapshot } from '../../commands/utils/scrub-sandbox-secrets';
+
+import { publicProcedure } from '../trpc';
+
+/**
+ * Server-initiated variant of the pre-snapshot scrub. The snapshot queue
+ * calls this best-effort before asking the compute provider for a filesystem
+ * snapshot, covering trigger paths where the worker never runs its own
+ * pre-snapshot scrub (for example recovery snapshots of a run that did not
+ * reach the sleep handoff). The scrub is idempotent and everything it removes
+ * is re-materialized from the dequeue/resume response at the next run start.
+ */
+export const scrubSnapshotSecrets = publicProcedure.mutation(
+  async ({ ctx }) => {
+    scrubSandboxSecretsBeforeSnapshot(ctx.harnessLogger ?? console);
+
+    return { success: true };
+  },
+);

--- a/apps/worker/src/sandbox-server/routers/commands.ts
+++ b/apps/worker/src/sandbox-server/routers/commands.ts
@@ -18,6 +18,7 @@ import {
   touchKeepalive,
   reloadDeploymentEnvVars,
   scrubSnapshotSecrets,
+  restoreScrubbedCredentials,
 } from '../procedures';
 
 export const commandsRouter = router({
@@ -38,4 +39,5 @@ export const commandsRouter = router({
   touchKeepalive,
   reloadDeploymentEnvVars,
   scrubSnapshotSecrets,
+  restoreScrubbedCredentials,
 });

--- a/apps/worker/src/sandbox-server/routers/commands.ts
+++ b/apps/worker/src/sandbox-server/routers/commands.ts
@@ -17,6 +17,7 @@ import {
   cancelTask,
   touchKeepalive,
   reloadDeploymentEnvVars,
+  scrubSnapshotSecrets,
 } from '../procedures';
 
 export const commandsRouter = router({
@@ -36,4 +37,5 @@ export const commandsRouter = router({
   cancelTask,
   touchKeepalive,
   reloadDeploymentEnvVars,
+  scrubSnapshotSecrets,
 });

--- a/apps/worker/src/sandbox-server/server.ts
+++ b/apps/worker/src/sandbox-server/server.ts
@@ -100,6 +100,7 @@ export function createServer({
   taskRunTaskId,
   slackReplySatisfactionStateFile,
   codingHarness,
+  taskRuntime,
   prepareActorScopedTurn,
 }: {
   /** Port to listen on. */
@@ -126,6 +127,11 @@ export function createServer({
   slackReplySatisfactionStateFile?: string;
   /** Effective coding harness for the current worker session. */
   codingHarness?: CodingHarness;
+  /** Task runtime home/env for locating harness credential files. */
+  taskRuntime?: {
+    homeDir: string;
+    runtimeEnv: Record<string, string | undefined>;
+  };
   /** Refresh actor-scoped integrations before delivering the next turn. */
   prepareActorScopedTurn?: (
     targetUserId?: string,
@@ -153,6 +159,7 @@ export function createServer({
     slackReplySatisfactionStateFile,
     codingHarness,
     workerEnv,
+    taskRuntime,
     prepareActorScopedTurn,
   });
 

--- a/apps/worker/src/sandbox-server/trpc.ts
+++ b/apps/worker/src/sandbox-server/trpc.ts
@@ -44,6 +44,16 @@ export interface Context {
   workerEnv?: WorkerEnv;
 
   /**
+   * Task runtime home and env, used to locate harness credential files (e.g.
+   * the OpenCode data dir) for the pre-snapshot scrub. These can differ from
+   * the worker process home/env when the run uses a task-scoped HOME.
+   */
+  taskRuntime?: {
+    homeDir: string;
+    runtimeEnv: Record<string, string | undefined>;
+  };
+
+  /**
    * Refresh actor-scoped integrations before delivering the next turn.
    * Returns `false` when the turn must not be delivered (default `block`
    * mismatch policy: the API's trusted pre-delivery actor sync did not put

--- a/packages/sdk/src/sandbox-router.ts
+++ b/packages/sdk/src/sandbox-router.ts
@@ -253,6 +253,7 @@ export interface SandboxServerRpcClient {
     >;
     touchKeepalive: SandboxMutation<undefined, SandboxSuccessResult>;
     reloadDeploymentEnvVars: SandboxMutation<undefined, SandboxSuccessResult>;
+    scrubSnapshotSecrets: SandboxMutation<undefined, SandboxSuccessResult>;
   };
 }
 

--- a/packages/sdk/src/sandbox-router.ts
+++ b/packages/sdk/src/sandbox-router.ts
@@ -254,6 +254,10 @@ export interface SandboxServerRpcClient {
     touchKeepalive: SandboxMutation<undefined, SandboxSuccessResult>;
     reloadDeploymentEnvVars: SandboxMutation<undefined, SandboxSuccessResult>;
     scrubSnapshotSecrets: SandboxMutation<undefined, SandboxSuccessResult>;
+    restoreScrubbedCredentials: SandboxMutation<
+      undefined,
+      SandboxSuccessResult
+    >;
   };
 }
 


### PR DESCRIPTION
Follow-up to #445.

#445 scrubs worker-managed credential files before the snapshots the worker itself initiates (the environment-snapshot command and the sleep handoff). The snapshot queue can also snapshot a sandbox whose worker never ran that step — for example the sleep-check recovery paths that snapshot a resumable run after a missed heartbeat.

This adds a `scrubSnapshotSecrets` sandbox-server procedure that runs the same pre-snapshot scrub, and has the BullMQ snapshot job call it best-effort (10s timeout) before asking the compute provider for a filesystem snapshot:

- The scrub is idempotent and everything it removes is re-materialized from the dequeue/resume response at the next run start, so it is requested on every queue-triggered snapshot regardless of trigger path.
- Failures never block the snapshot: no sandbox server URL, an unreachable sandbox server, or an RPC error are recorded as task-run decision events (`pre_snapshot_scrub_skipped` / `pre_snapshot_scrub_unavailable`) and the job proceeds.

Tests cover the new procedure (scrub invoked with the harness logger, errors propagate) and the snapshot job behavior (scrub requested before `createSnapshot`, snapshot continues when the scrub is unavailable, skip path when the run has no sandbox server URL).
