### PR TITLE
Promote v0.7.1 to production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file tracks product releases for Roomote (single monorepo version). Automated release entries are prepended by `pnpm run version`.
 
+## 0.7.1 (2026-07-16)
+
+### Patch changes
+
+- On cloud-enabled deployments, the homepage launcher no longer shows the sandbox (compute provider) chooser, matching Settings and keeping provider selection managed by the deployment default.
+- Model settings autocomplete is more responsive: suggestions update sooner, stay visible while new results load, support fuzzy matches from the first character, and no longer show model-resolution errors behind an open suggestion list.
+
 ## 0.7.0 (2026-07-16)
 
 ### Minor changes

--- a/apps/web/src/app/(authenticated)/home/Home.client.test.tsx
+++ b/apps/web/src/app/(authenticated)/home/Home.client.test.tsx
@@ -14,6 +14,7 @@ import { AUTO_WORKSPACE_VALUE } from '@/components/tasks/constants';
 
 let currentSearchParams = '';
 let currentFeatureFlags: Record<string, boolean> = {};
+let currentCloudEnabled = false;
 let currentShowDebugUI = false;
 let currentShowDebugUILoading = false;
 let currentGitHubInstallations = [{ id: 'installation-1' }];
@@ -67,6 +68,7 @@ vi.mock('@/hooks/useUser', () => ({
     isAdmin: true,
     name: 'Test User',
     primaryEmail: 'test@example.com',
+    cloudEnabled: currentCloudEnabled,
     featureFlags: currentFeatureFlags,
     resource: {
       username: 'tester',
@@ -332,6 +334,7 @@ describe('Home', () => {
   beforeEach(() => {
     currentSearchParams = '';
     currentFeatureFlags = {};
+    currentCloudEnabled = false;
     currentShowDebugUI = false;
     currentShowDebugUILoading = false;
     currentGitHubInstallations = [{ id: 'installation-1' }];
@@ -800,10 +803,45 @@ describe('Home', () => {
     );
   });
 
-  it('always shows the compute provider selector', () => {
+  it('shows the compute provider selector outside cloud mode', () => {
     render(<Home initialPlaceholderIndex={0} />);
 
     expect(screen.getByLabelText('Sandbox provider')).toBeInTheDocument();
+  });
+
+  it('hides the compute provider selector when cloud mode is enabled', () => {
+    currentCloudEnabled = true;
+
+    render(<Home initialPlaceholderIndex={0} />);
+
+    expect(screen.queryByLabelText('Sandbox provider')).not.toBeInTheDocument();
+  });
+
+  it('uses the default compute provider for launches when cloud mode hides selection', async () => {
+    currentCloudEnabled = true;
+
+    render(
+      <Home
+        initialPlaceholderIndex={0}
+        defaultComputeProvider="modal"
+        availableComputeProviders={['modal', 'docker']}
+      />,
+    );
+
+    expect(screen.queryByLabelText('Sandbox provider')).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Use single-repo environment' }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Submit prompt' }));
+
+    await waitFor(() => {
+      expect(mockCreateStandardTaskRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          computeProvider: 'modal',
+        }),
+      );
+    });
   });
 
   it('uses only configured sandbox providers for selection and launch', async () => {

--- a/apps/web/src/app/(authenticated)/home/Home.tsx
+++ b/apps/web/src/app/(authenticated)/home/Home.tsx
@@ -24,6 +24,7 @@ import { cn } from '@/lib/utils';
 import { useEnvironments } from '@/hooks/environments';
 import { useGitHubInstallations } from '@/hooks/github';
 import { useShowDebugUI } from '@/hooks/useShowDebugUI';
+import { useAuthorizedUser } from '@/hooks/useUser';
 import { useLaunchTaskModels } from '@/hooks/task-models/useLaunchTaskModels';
 import {
   type WorkspaceSelection,
@@ -102,6 +103,7 @@ export function Home({
   const router = useRouter();
   const githubInstallations = useGitHubInstallations();
   const environments = useEnvironments();
+  const { cloudEnabled } = useAuthorizedUser();
 
   const { isDebugUIVisible } = useShowDebugUI();
   const canSelectBranch = isDebugUIVisible;
@@ -603,7 +605,7 @@ export function Home({
                 onValueChange={setSelectedModelOverrideId}
               />
 
-              {computeProviderDescriptors.length > 1 && (
+              {!cloudEnabled && computeProviderDescriptors.length > 1 && (
                 <Select
                   value={selectedComputeProvider}
                   onValueChange={(value) =>

--- a/apps/web/src/components/settings/ModelSettingsSection.test.tsx
+++ b/apps/web/src/components/settings/ModelSettingsSection.test.tsx
@@ -14,6 +14,10 @@ const settingsData = vi.hoisted(() => ({
 const providerSetupData = vi.hoisted(() => ({
   current: null as Record<string, unknown> | null,
 }));
+const suggestionData = vi.hoisted(() => ({
+  current: undefined as Record<string, unknown> | null | undefined,
+}));
+const suggestionQueryError = vi.hoisted(() => ({ current: false }));
 const lookupMutateAsyncMock = vi.hoisted(() => vi.fn());
 const updateMutateAsyncMock = vi.hoisted(() => vi.fn());
 const refreshMutateAsyncMock = vi.hoisted(() => vi.fn());
@@ -23,13 +27,18 @@ vi.mock('@tanstack/react-query', () => ({
     const isProviderSetup =
       Array.isArray(options?.queryKey) &&
       options.queryKey[1] === 'providerSetup';
+    const isSuggestions =
+      Array.isArray(options?.queryKey) && options.queryKey[1] === 'suggest';
     const data = isProviderSetup
       ? providerSetupData.current
-      : settingsData.current;
+      : isSuggestions && suggestionData.current !== undefined
+        ? suggestionData.current
+        : settingsData.current;
 
     return {
       data,
       isPending: data === null,
+      isError: isSuggestions && suggestionQueryError.current,
     };
   },
   useMutation: (options?: { mutationKey?: unknown[] }) => {
@@ -334,6 +343,8 @@ describe('ModelSettingsSection', () => {
     refreshMutateAsyncMock.mockReset();
     settingsData.current = null;
     providerSetupData.current = buildProviderSetupData();
+    suggestionData.current = undefined;
+    suggestionQueryError.current = false;
     // cmdk scrolls the highlighted command item into view; jsdom does not
     // implement scrollIntoView.
     window.HTMLElement.prototype.scrollIntoView = vi.fn();
@@ -597,7 +608,7 @@ describe('ModelSettingsSection', () => {
     ).toHaveTextContent('Anthropic');
   });
 
-  it('shows provider-scoped suggestions after two characters and lets keyboard selection fill the slug', async () => {
+  it('shows provider-scoped suggestions after one character and lets keyboard selection fill the slug', async () => {
     settingsData.current = buildSettingsData();
     providerSetupData.current = buildProviderSetupData({
       connectedProviderIds: ['anthropic'],
@@ -609,7 +620,7 @@ describe('ModelSettingsSection', () => {
 
     try {
       const input = screen.getByLabelText('New model slug');
-      fireEvent.change(input, { target: { value: 'cl' } });
+      fireEvent.change(input, { target: { value: 'c' } });
 
       await act(async () => {
         vi.advanceTimersByTime(500);
@@ -622,7 +633,112 @@ describe('ModelSettingsSection', () => {
     }
   });
 
-  it('does not show suggestions before two characters', () => {
+  it('keeps suggestions visible while a replacement query is loading', async () => {
+    settingsData.current = buildSettingsData();
+    providerSetupData.current = buildProviderSetupData({
+      connectedProviderIds: ['anthropic'],
+    });
+    suggestionData.current = {
+      suggestions: [
+        { slug: 'claude-sonnet-4', displayName: 'Claude Sonnet 4' },
+      ],
+    };
+    vi.useFakeTimers();
+
+    try {
+      renderModelSettingsSection();
+
+      const input = screen.getByLabelText('New model slug');
+      fireEvent.change(input, { target: { value: 'c' } });
+      await act(async () => {
+        vi.advanceTimersByTime(150);
+      });
+      expect(screen.getByText('Claude Sonnet 4')).toBeInTheDocument();
+
+      suggestionData.current = null;
+      fireEvent.change(input, { target: { value: 'cl' } });
+      await act(async () => {
+        vi.advanceTimersByTime(150);
+      });
+
+      expect(screen.getByText('Claude Sonnet 4')).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears suggestions when a replacement query fails', async () => {
+    settingsData.current = buildSettingsData();
+    providerSetupData.current = buildProviderSetupData({
+      connectedProviderIds: ['anthropic'],
+    });
+    suggestionData.current = {
+      suggestions: [
+        { slug: 'claude-sonnet-4', displayName: 'Claude Sonnet 4' },
+      ],
+    };
+    vi.useFakeTimers();
+
+    try {
+      renderModelSettingsSection();
+
+      const input = screen.getByLabelText('New model slug');
+      fireEvent.change(input, { target: { value: 'c' } });
+      await act(async () => {
+        vi.advanceTimersByTime(150);
+      });
+      expect(screen.getByText('Claude Sonnet 4')).toBeInTheDocument();
+
+      suggestionData.current = null;
+      suggestionQueryError.current = true;
+      fireEvent.change(input, { target: { value: 'cl' } });
+      await act(async () => {
+        vi.advanceTimersByTime(150);
+      });
+
+      expect(screen.queryByText('Claude Sonnet 4')).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('hides lookup errors while matching suggestions are open', async () => {
+    const data = buildSettingsData();
+    settingsData.current = {
+      ...data,
+      suggestions: [
+        { slug: 'claude-sonnet-4', displayName: 'Claude Sonnet 4' },
+      ],
+    };
+    providerSetupData.current = buildProviderSetupData({
+      connectedProviderIds: ['anthropic'],
+    });
+    lookupMutateAsyncMock.mockRejectedValue(new Error('Not found'));
+    vi.useFakeTimers();
+
+    try {
+      renderModelSettingsSection();
+
+      fireEvent.change(screen.getByLabelText('New model slug'), {
+        target: { value: 'cl' },
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(screen.getByText('Claude Sonnet 4')).toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          'Could not resolve this model from the provider. Check the slug.',
+        ),
+      ).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not show suggestions before a character is entered', () => {
     settingsData.current = buildSettingsData();
     providerSetupData.current = buildProviderSetupData({
       connectedProviderIds: ['anthropic'],
@@ -631,7 +747,7 @@ describe('ModelSettingsSection', () => {
     renderModelSettingsSection();
 
     fireEvent.change(screen.getByLabelText('New model slug'), {
-      target: { value: 'c' },
+      target: { value: '' },
     });
 
     expect(screen.queryByText('Suggestions')).not.toBeInTheDocument();

--- a/apps/web/src/components/settings/ModelSettingsSection.tsx
+++ b/apps/web/src/components/settings/ModelSettingsSection.tsx
@@ -749,6 +749,7 @@ export function ModelSettingsSection({
   );
   const lookupRequestRef = useRef(0);
   const suggestionRequestRef = useRef(0);
+  const suggestionProviderRef = useRef<SetupModelProviderId | null>(null);
   const selectedSuggestionSlugRef = useRef<string | null>(null);
   const lookupMutateAsyncRef = useRef(lookupMutation.mutateAsync);
   const saveTimeoutRef = useRef<number | null>(null);
@@ -803,9 +804,9 @@ export function ModelSettingsSection({
     [sortedConnectedProviders, newModelProvider],
   );
   const normalizedNewModelId = newModelId.trim();
-  const debouncedSuggestionQuery = useDebouncedValue(normalizedNewModelId, 500);
+  const debouncedSuggestionQuery = useDebouncedValue(normalizedNewModelId, 150);
   const shouldShowSuggestions =
-    suggestionState.suggestions.length > 0 && normalizedNewModelId.length >= 2;
+    suggestionState.suggestions.length > 0 && normalizedNewModelId.length >= 1;
   const suggestionsQuery = useQuery(
     trpc.taskModels.suggest.queryOptions(
       {
@@ -815,7 +816,7 @@ export function ModelSettingsSection({
       {
         enabled:
           activeNewModelProvider !== null &&
-          debouncedSuggestionQuery.length >= 2,
+          debouncedSuggestionQuery.length >= 1,
       },
     ),
   );
@@ -836,9 +837,32 @@ export function ModelSettingsSection({
   }, [lookupMutation.mutateAsync]);
 
   useEffect(() => {
-    if (!activeNewModelProvider || debouncedSuggestionQuery.length < 2) {
+    const providerId = activeNewModelProvider?.id ?? null;
+
+    if (
+      suggestionProviderRef.current !== null &&
+      suggestionProviderRef.current !== providerId
+    ) {
+      setSuggestionState(EMPTY_SUGGESTION_STATE);
+    }
+
+    suggestionProviderRef.current = providerId;
+  }, [activeNewModelProvider]);
+
+  useEffect(() => {
+    if (!activeNewModelProvider || debouncedSuggestionQuery.length < 1) {
       suggestionRequestRef.current += 1;
       setSuggestionState(EMPTY_SUGGESTION_STATE);
+      return;
+    }
+
+    if (suggestionsQuery.isError) {
+      suggestionRequestRef.current += 1;
+      setSuggestionState(EMPTY_SUGGESTION_STATE);
+      return;
+    }
+
+    if (!suggestionsQuery.data) {
       return;
     }
 
@@ -875,7 +899,8 @@ export function ModelSettingsSection({
   }, [
     activeNewModelProvider,
     debouncedSuggestionQuery,
-    suggestionsQuery.data?.suggestions,
+    suggestionsQuery.data,
+    suggestionsQuery.isError,
   ]);
 
   useEffect(() => {
@@ -1944,11 +1969,13 @@ export function ModelSettingsSection({
                     </div>
                   )}
                 </div>
-                {pendingLookup.message && pendingLookup.status === 'error' && (
-                  <p className="text-xs text-destructive">
-                    {pendingLookup.message}
-                  </p>
-                )}
+                {pendingLookup.message &&
+                  pendingLookup.status === 'error' &&
+                  !shouldShowSuggestions && (
+                    <p className="text-xs text-destructive">
+                      {pendingLookup.message}
+                    </p>
+                  )}
               </>
             ) : (
               <p className="text-sm text-muted-foreground">

--- a/apps/web/src/trpc/commands/task-models/index.ts
+++ b/apps/web/src/trpc/commands/task-models/index.ts
@@ -1242,7 +1242,7 @@ export async function suggestTaskModelsCommand(
   const provider = getSetupModelProvider(input.providerId);
   const query = input.query.trim();
 
-  if (query.length < 2) {
+  if (query.length < 1) {
     return { suggestions: [] };
   }
 
@@ -1311,6 +1311,7 @@ export async function refreshTaskModelMetadataCommand(
 
   const catalog = await fetchModelsDevCatalog(
     AbortSignal.timeout(MODEL_METADATA_FETCH_TIMEOUT_MS),
+    { forceRefresh: true },
   );
   if (!catalog) {
     return {

--- a/apps/web/src/trpc/commands/task-models/models-dev.test.ts
+++ b/apps/web/src/trpc/commands/task-models/models-dev.test.ts
@@ -4,6 +4,7 @@ import {
   fetchModelsDevCatalog,
   lookupModelMetadataFromCatalog,
   resolveModelsDevSlug,
+  suggestModelsFromCatalog,
   type ModelsDevCatalog,
 } from './models-dev';
 
@@ -368,5 +369,27 @@ describe('fetchModelsDevCatalog', () => {
     controller.abort();
     const result = await fetchModelsDevCatalog(controller.signal);
     expect(result).toBeNull();
+  });
+});
+
+describe('suggestModelsFromCatalog', () => {
+  it('finds model names with a fuzzy query', () => {
+    const catalog = buildCatalog({
+      providers: {
+        openrouter: {
+          models: {
+            'moonshotai/kimi-k3': { name: 'Kimi K3' },
+          },
+        },
+      },
+    });
+
+    expect(
+      suggestModelsFromCatalog({
+        catalog,
+        providerId: 'openrouter',
+        query: 'km3',
+      }),
+    ).toEqual([{ slug: 'moonshotai/kimi-k3', displayName: 'Kimi K3' }]);
   });
 });

--- a/apps/web/src/trpc/commands/task-models/models-dev.ts
+++ b/apps/web/src/trpc/commands/task-models/models-dev.ts
@@ -6,6 +6,11 @@ import {
 
 const MODELS_DEV_CATALOG_URL = 'https://models.dev/catalog.json';
 const BEDROCK_MANTLE_PROVIDER_PREFIX = 'bedrock-mantle/';
+const MODELS_DEV_CATALOG_CACHE_TTL_MS = 5 * 60 * 1_000;
+
+let cachedModelsDevCatalog:
+  | { catalog: ModelsDevCatalog; expiresAt: number }
+  | undefined;
 
 type ModelsDevModalities = {
   input?: string[];
@@ -140,7 +145,22 @@ function extractMetadataFromEntry(
 
 export async function fetchModelsDevCatalog(
   signal?: AbortSignal,
+  options?: { forceRefresh?: boolean },
 ): Promise<ModelsDevCatalog | null> {
+  if (signal?.aborted) {
+    return null;
+  }
+
+  const cachedCatalog = cachedModelsDevCatalog;
+
+  if (
+    !options?.forceRefresh &&
+    cachedCatalog &&
+    cachedCatalog.expiresAt > Date.now()
+  ) {
+    return cachedCatalog.catalog;
+  }
+
   try {
     const response = await fetch(MODELS_DEV_CATALOG_URL, { signal });
     if (!response.ok) {
@@ -160,11 +180,16 @@ export async function fetchModelsDevCatalog(
       }
       gatewayModelsByLowerSlug[gatewayProviderId] = byLowerSlug;
     }
-    return {
+    const catalog = {
       models: payload.models ?? {},
       providers,
       gatewayModelsByLowerSlug,
     };
+    cachedModelsDevCatalog = {
+      catalog,
+      expiresAt: Date.now() + MODELS_DEV_CATALOG_CACHE_TTL_MS,
+    };
+    return catalog;
   } catch {
     return null;
   }
@@ -277,7 +302,7 @@ export function suggestModelsFromCatalog(options: {
 }): ModelsDevSuggestion[] {
   const normalizedQuery = options.query.trim().toLowerCase();
 
-  if (normalizedQuery.length < 2) {
+  if (normalizedQuery.length < 1) {
     return [];
   }
 
@@ -304,6 +329,18 @@ export function suggestModelsFromCatalog(options: {
         rank = 4;
       } else if (lowerName.includes(normalizedQuery)) {
         rank = 5;
+      } else {
+        const fuzzySlugRank = getFuzzyMatchRank(lowerSlug, normalizedQuery);
+        const fuzzyNameRank = getFuzzyMatchRank(lowerName, normalizedQuery);
+
+        if (fuzzySlugRank !== null || fuzzyNameRank !== null) {
+          rank =
+            6 +
+            Math.min(
+              fuzzySlugRank ?? Number.POSITIVE_INFINITY,
+              fuzzyNameRank ?? Number.POSITIVE_INFINITY,
+            );
+        }
       }
 
       if (rank === null) {
@@ -343,4 +380,29 @@ export function suggestModelsFromCatalog(options: {
     })
     .slice(0, options.limit ?? 8)
     .map(({ slug, displayName }) => ({ slug, displayName }));
+}
+
+function getFuzzyMatchRank(candidate: string, query: string): number | null {
+  let candidateIndex = 0;
+  let previousMatchIndex = -1;
+  let rank = 0;
+
+  for (const queryCharacter of query) {
+    const matchIndex = candidate.indexOf(queryCharacter, candidateIndex);
+
+    if (matchIndex === -1) {
+      return null;
+    }
+
+    if (previousMatchIndex >= 0) {
+      rank += matchIndex - previousMatchIndex - 1;
+    } else {
+      rank += matchIndex;
+    }
+
+    previousMatchIndex = matchIndex;
+    candidateIndex = matchIndex + 1;
+  }
+
+  return rank;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roomote",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "FCL-1.0-ALv2",
   "packageManager": "pnpm@10.29.3",
   "engines": {


### PR DESCRIPTION
## Promote v0.7.1

Frozen at `c80e66663d4c49dcb690bfaef2f89b5ae616c59d` — the commit where `0.7.1` was versioned. Commits merged to `develop` after that point ship in the next release.

- Merge this PR with a **merge commit** (do not squash or rebase).
- If multiple promote PRs are open, merge them in version order (oldest first).
- Merging publishes a GitHub Release for `v0.7.1` and triggers the existing GHCR `v*` image publish (`latest` channel).
- The `release/v0.7.1` branch can be deleted after this PR merges.

### Changelog

## 0.7.1 (2026-07-16)

### Patch changes

- On cloud-enabled deployments, the homepage launcher no longer shows the sandbox (compute provider) chooser, matching Settings and keeping provider selection managed by the deployment default.
- Model settings autocomplete is more responsive: suggestions update sooner, stay visible while new results load, support fuzzy matches from the first character, and no longer show model-resolution errors behind an open suggestion list.
