### PR TITLE
Route ChatGPT-subscription inference through the gateway (Phase 3)

### DIFF
--- a/apps/api/src/handlers/inference/__tests__/inference-gateway.test.ts
+++ b/apps/api/src/handlers/inference/__tests__/inference-gateway.test.ts
@@ -6,10 +6,12 @@ import type { Variables } from '../../../types';
 const {
   mockFindTaskRun,
   mockResolveModelProviderEnvValue,
+  mockGetFreshChatGptAccessToken,
   mockIsInferenceGatewayEnabledForDeployment,
 } = vi.hoisted(() => ({
   mockFindTaskRun: vi.fn(),
   mockResolveModelProviderEnvValue: vi.fn(),
+  mockGetFreshChatGptAccessToken: vi.fn(),
   mockIsInferenceGatewayEnabledForDeployment: vi.fn(
     async (_redis?: unknown, _prefix?: string) => true,
   ),
@@ -24,6 +26,7 @@ vi.mock('@roomote/db/server', () => ({
   taskRuns: { id: 'id' },
   eq: vi.fn((column: unknown, value: unknown) => ({ column, value })),
   resolveModelProviderEnvValue: mockResolveModelProviderEnvValue,
+  getFreshChatGptAccessToken: mockGetFreshChatGptAccessToken,
 }));
 
 vi.mock('@roomote/feature-flags/server', () => ({
@@ -341,6 +344,87 @@ describe('inference gateway', () => {
 
     expect(response.status).toBe(500);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  describe('ChatGPT subscription (chatgpt-oauth strategy)', () => {
+    async function postChatGpt(
+      app: Hono<{ Variables: Variables }>,
+      path = '/api/inference/openai-chatgpt/v1/responses',
+      headers: Record<string, string> = {},
+    ) {
+      return app.request(path, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer run-token-value',
+          ...headers,
+        },
+        body: JSON.stringify({ model: 'gpt-5-codex', input: 'hi' }),
+      });
+    }
+
+    it('mints a token, rewrites to the Codex backend, and injects account id', async () => {
+      const fetchMock = stubUpstreamFetch();
+      mockGetFreshChatGptAccessToken.mockResolvedValue({
+        access: 'oauth-access-token',
+        refresh: 'oauth-refresh',
+        expires: Date.now() + 3_600_000,
+        accountId: 'acct_123',
+      });
+
+      const response = await postChatGpt(createApp(createRunToken()));
+
+      expect(response.status).toBe(200);
+      // The API key resolver must not be consulted for OAuth providers.
+      expect(mockResolveModelProviderEnvValue).not.toHaveBeenCalled();
+
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('https://chatgpt.com/backend-api/codex/responses');
+
+      const headers = new Headers(init.headers);
+      expect(headers.get('authorization')).toBe('Bearer oauth-access-token');
+      expect(headers.get('ChatGPT-Account-Id')).toBe('acct_123');
+    });
+
+    it('strips the run token and any smuggled account id from the sandbox', async () => {
+      const fetchMock = stubUpstreamFetch();
+      mockGetFreshChatGptAccessToken.mockResolvedValue({
+        access: 'oauth-access-token',
+        refresh: 'oauth-refresh',
+        expires: Date.now() + 3_600_000,
+        accountId: 'acct_real',
+      });
+
+      await postChatGpt(createApp(createRunToken()), undefined, {
+        'chatgpt-account-id': 'acct_attacker',
+      });
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const headers = new Headers(init.headers);
+      expect(headers.get('ChatGPT-Account-Id')).toBe('acct_real');
+      expect(headers.get('authorization')).toBe('Bearer oauth-access-token');
+    });
+
+    it('returns 404 when no ChatGPT subscription is connected', async () => {
+      const fetchMock = stubUpstreamFetch();
+      mockGetFreshChatGptAccessToken.mockResolvedValue(null);
+
+      const response = await postChatGpt(createApp(createRunToken()));
+
+      expect(response.status).toBe(404);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-inference paths on the ChatGPT segment', async () => {
+      const fetchMock = stubUpstreamFetch();
+      const response = await postChatGpt(
+        createApp(createRunToken()),
+        '/api/inference/openai-chatgpt/v1/account',
+      );
+
+      expect(response.status).toBe(403);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
   });
 
   it('returns 404 when the provider key is not configured', async () => {

--- a/apps/api/src/handlers/inference/index.ts
+++ b/apps/api/src/handlers/inference/index.ts
@@ -1,12 +1,7 @@
 import { Hono } from 'hono';
 
 import { formatSingleLineLog } from '@roomote/types';
-import {
-  db,
-  eq,
-  resolveModelProviderEnvValue,
-  taskRuns,
-} from '@roomote/db/server';
+import { db, eq, taskRuns } from '@roomote/db/server';
 import { isInferenceGatewayEnabledForDeployment } from '@roomote/feature-flags/server';
 import { getRedis } from '@roomote/redis';
 
@@ -18,10 +13,10 @@ import {
   isRunTokenContext,
 } from '../mcp/proxy-utils';
 import {
-  formatProviderAuthHeaderValue,
   getInferenceProvider,
   isInferencePathAllowed,
-  resolveProviderUpstreamBaseUrl,
+  resolveGatewayUpstream,
+  type GatewayUpstreamResolution,
 } from './registry';
 
 /**
@@ -34,6 +29,9 @@ const REQUEST_HEADER_DENYLIST = new Set([
   'authorization',
   'x-api-key',
   'x-goog-api-key',
+  // The gateway sets the ChatGPT account-id authoritatively from the OAuth
+  // record; a sandbox must not be able to smuggle its own.
+  'chatgpt-account-id',
   'cookie',
   'host',
   'connection',
@@ -55,8 +53,7 @@ const REQUEST_HEADER_DENYLIST = new Set([
 
 function buildUpstreamRequestHeaders(
   requestHeaders: Headers,
-  authHeaderName: string,
-  authHeaderValue: string,
+  injectedHeaders: Record<string, string>,
 ): Headers {
   const headers = new Headers();
 
@@ -66,7 +63,9 @@ function buildUpstreamRequestHeaders(
     }
   }
 
-  headers.set(authHeaderName, authHeaderValue);
+  for (const [key, value] of Object.entries(injectedHeaders)) {
+    headers.set(key, value);
+  }
 
   return headers;
 }
@@ -164,12 +163,12 @@ inference.on(['POST', 'GET'], '/:provider/*', async (c) => {
     );
   }
 
-  let apiKey: string | undefined;
-  let upstreamBaseUrl: string;
+  const search = new URL(c.req.url).search;
+
+  let resolution: GatewayUpstreamResolution;
 
   try {
-    apiKey = await resolveModelProviderEnvValue(provider.envVarNames);
-    upstreamBaseUrl = await resolveProviderUpstreamBaseUrl(provider);
+    resolution = await resolveGatewayUpstream(provider, upstreamPath, search);
   } catch (error) {
     console.error(
       formatSingleLineLog(`${logPrefix} Failed to resolve provider config`, {
@@ -186,17 +185,11 @@ inference.on(['POST', 'GET'], '/:provider/*', async (c) => {
     );
   }
 
-  if (!apiKey) {
-    return c.json(
-      {
-        error: `No ${provider.name} API key is configured for this deployment`,
-      },
-      404,
-    );
+  if (!resolution.ok) {
+    return c.json({ error: resolution.error }, resolution.status);
   }
 
-  const search = new URL(c.req.url).search;
-  const upstreamUrl = `${upstreamBaseUrl}${upstreamPath}${search}`;
+  const { upstreamUrl, headers: injectedHeaders } = resolution.resolved;
 
   try {
     const upstreamResponse = await fetchWithLongLivedStreamDispatcher(
@@ -205,8 +198,7 @@ inference.on(['POST', 'GET'], '/:provider/*', async (c) => {
         method,
         headers: buildUpstreamRequestHeaders(
           c.req.raw.headers,
-          provider.authHeader.name,
-          formatProviderAuthHeaderValue(provider, apiKey),
+          injectedHeaders,
         ),
         body: c.req.raw.body,
         signal: c.req.raw.signal,

--- a/apps/api/src/handlers/inference/registry.ts
+++ b/apps/api/src/handlers/inference/registry.ts
@@ -1,14 +1,99 @@
 import {
+  CHATGPT_ACCOUNT_ID_HEADER,
   getInferenceGatewayProvider,
   INFERENCE_GATEWAY_REGION_PATTERN,
   type InferenceGatewayProvider,
 } from '@roomote/types';
-import { resolveModelProviderEnvValue } from '@roomote/db/server';
+import {
+  getFreshChatGptAccessToken,
+  resolveModelProviderEnvValue,
+} from '@roomote/db/server';
 
 export function getInferenceProvider(
   providerId: string,
 ): InferenceGatewayProvider | undefined {
   return getInferenceGatewayProvider(providerId);
+}
+
+/** The upstream URL and auth headers the gateway forwards for one request. */
+export interface ResolvedGatewayUpstream {
+  upstreamUrl: string;
+  headers: Record<string, string>;
+}
+
+export type GatewayUpstreamResolution =
+  | { ok: true; resolved: ResolvedGatewayUpstream }
+  | { ok: false; status: 404 | 500; error: string };
+
+/**
+ * Resolve the upstream URL and auth headers for a gateway request, per the
+ * provider's auth strategy:
+ * - `api-key`: inject the deployment's static key at the request path.
+ * - `chatgpt-oauth`: mint a fresh subscription access token, add the
+ *   account-id header, and collapse the request onto the Codex backend.
+ */
+export async function resolveGatewayUpstream(
+  provider: InferenceGatewayProvider,
+  upstreamPath: string,
+  search: string,
+): Promise<GatewayUpstreamResolution> {
+  if (provider.authStrategy === 'chatgpt-oauth') {
+    return resolveChatGptUpstream(provider);
+  }
+
+  const [apiKey, upstreamBaseUrl] = await Promise.all([
+    resolveModelProviderEnvValue(provider.envVarNames),
+    resolveProviderUpstreamBaseUrl(provider),
+  ]);
+
+  if (!apiKey) {
+    return {
+      ok: false,
+      status: 404,
+      error: `No ${provider.name} API key is configured for this deployment`,
+    };
+  }
+
+  return {
+    ok: true,
+    resolved: {
+      upstreamUrl: `${upstreamBaseUrl}${upstreamPath}${search}`,
+      headers: {
+        [provider.authHeader.name]: formatProviderAuthHeaderValue(
+          provider,
+          apiKey,
+        ),
+      },
+    },
+  };
+}
+
+async function resolveChatGptUpstream(
+  provider: InferenceGatewayProvider,
+): Promise<GatewayUpstreamResolution> {
+  const token = await getFreshChatGptAccessToken();
+
+  if (!token) {
+    return {
+      ok: false,
+      status: 404,
+      error: 'No connected ChatGPT subscription is available',
+    };
+  }
+
+  const upstreamUrl = `${provider.upstreamBaseUrl}${provider.collapseToPath ?? ''}`;
+  const headers: Record<string, string> = {
+    [provider.authHeader.name]: formatProviderAuthHeaderValue(
+      provider,
+      token.access,
+    ),
+  };
+
+  if (token.accountId) {
+    headers[CHATGPT_ACCOUNT_ID_HEADER] = token.accountId;
+  }
+
+  return { ok: true, resolved: { upstreamUrl, headers } };
 }
 
 /**
@@ -62,7 +147,7 @@ function hasTraversalOrEncodedSlash(upstreamPath: string): boolean {
  * placeholder from the deployment's region env var (falling back to the
  * provider default) for region-templated upstreams like Bedrock.
  */
-export async function resolveProviderUpstreamBaseUrl(
+async function resolveProviderUpstreamBaseUrl(
   provider: InferenceGatewayProvider,
 ): Promise<string> {
   if (!provider.region) {
@@ -82,7 +167,7 @@ export async function resolveProviderUpstreamBaseUrl(
   return provider.upstreamBaseUrl.replace('{region}', region);
 }
 
-export function formatProviderAuthHeaderValue(
+function formatProviderAuthHeaderValue(
   provider: InferenceGatewayProvider,
   apiKey: string,
 ): string {

--- a/apps/worker/src/run-task/__tests__/opencode-chatgpt-gateway-plugin-script.test.ts
+++ b/apps/worker/src/run-task/__tests__/opencode-chatgpt-gateway-plugin-script.test.ts
@@ -101,7 +101,13 @@ describe('OPENCODE_CHATGPT_GATEWAY_PLUGIN_SCRIPT', () => {
       },
     });
 
-    expect(Object.keys(models)).toEqual(['gpt-5.4', 'gpt-5.6-luna']);
+    expect(Object.keys(models)).toEqual([
+      'gpt-5.4',
+      'gpt-5.6-luna',
+      'gpt-5.6',
+      'gpt-5.5-pro',
+      'gpt-5.7-pro',
+    ]);
     expect(models['gpt-5.4']?.cost).toEqual({
       input: 0,
       output: 0,
@@ -114,10 +120,26 @@ describe('OPENCODE_CHATGPT_GATEWAY_PLUGIN_SCRIPT', () => {
         cache: { read: 0, write: 0 },
       },
       limit: {
-        context: 500_000,
-        input: 372_000,
+        context: 200_000,
+        output: 64_000,
+      },
+    });
+    expect(models['gpt-5.5-pro']).toMatchObject({
+      cost: {
+        input: 0,
+        output: 0,
+        cache: { read: 0, write: 0 },
+      },
+      limit: {
+        context: 400_000,
+        input: 272_000,
         output: 128_000,
       },
+    });
+    expect(models['gpt-5.7-pro']?.cost).toEqual({
+      input: 0,
+      output: 0,
+      cache: { read: 0, write: 0 },
     });
   });
 });

--- a/apps/worker/src/run-task/__tests__/opencode-chatgpt-gateway-plugin-script.test.ts
+++ b/apps/worker/src/run-task/__tests__/opencode-chatgpt-gateway-plugin-script.test.ts
@@ -1,0 +1,123 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { INFERENCE_GATEWAY_CHATGPT_ENV_VAR_NAME } from '@roomote/types';
+
+import { OPENCODE_CHATGPT_GATEWAY_PLUGIN_SCRIPT } from '../opencode-chatgpt-gateway-plugin-script';
+
+interface OpenCodeModel {
+  id: string;
+  api: { id: string };
+  options: Record<string, unknown>;
+  cost: {
+    input: number;
+    output: number;
+    cache: { read: number; write: number };
+  };
+  limit: { context: number; input?: number; output: number };
+}
+
+type ModelsHook = (provider: {
+  models: Record<string, OpenCodeModel>;
+}) => Promise<Record<string, OpenCodeModel>>;
+
+describe('OPENCODE_CHATGPT_GATEWAY_PLUGIN_SCRIPT', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'roomote-chatgpt-gateway-plugin-'),
+    );
+    delete process.env[INFERENCE_GATEWAY_CHATGPT_ENV_VAR_NAME];
+  });
+
+  afterEach(() => {
+    delete process.env[INFERENCE_GATEWAY_CHATGPT_ENV_VAR_NAME];
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  async function loadModelsHook(): Promise<ModelsHook> {
+    const pluginPath = path.join(tempDir, 'roomote-chatgpt-gateway.mjs');
+    fs.writeFileSync(
+      pluginPath,
+      OPENCODE_CHATGPT_GATEWAY_PLUGIN_SCRIPT,
+      'utf8',
+    );
+
+    const module = (await import(
+      /* @vite-ignore */ pathToFileURL(pluginPath).href
+    )) as {
+      RoomoteChatGptGatewayModels: () => Promise<{
+        provider: { models: ModelsHook };
+      }>;
+    };
+    const plugin = await module.RoomoteChatGptGatewayModels();
+
+    return plugin.provider.models;
+  }
+
+  function createModel(
+    id: string,
+    options: Record<string, unknown> = {},
+  ): OpenCodeModel {
+    return {
+      id,
+      api: { id },
+      options,
+      cost: {
+        input: 1.25,
+        output: 10,
+        cache: { read: 0.25, write: 1.25 },
+      },
+      limit: { context: 200_000, output: 64_000 },
+    };
+  }
+
+  it('leaves ordinary OpenAI model metadata unchanged outside gateway mode', async () => {
+    const models = {
+      'gpt-5.4': createModel('gpt-5.4'),
+      'gpt-4.1': createModel('gpt-4.1'),
+    };
+    const modelsHook = await loadModelsHook();
+
+    await expect(modelsHook({ models })).resolves.toBe(models);
+  });
+
+  it('restores the subscription allowlist and zero-cost metadata in gateway mode', async () => {
+    process.env[INFERENCE_GATEWAY_CHATGPT_ENV_VAR_NAME] = '1';
+    const modelsHook = await loadModelsHook();
+    const models = await modelsHook({
+      models: {
+        'gpt-5.4': createModel('gpt-5.4'),
+        'gpt-5.6-luna': createModel('gpt-5.6-luna'),
+        'gpt-5.6': createModel('gpt-5.6'),
+        'gpt-5.5-pro': createModel('gpt-5.5-pro'),
+        'gpt-5.7-pro': createModel('gpt-5.7-pro', {
+          reasoningMode: 'pro',
+        }),
+        'gpt-4.1': createModel('gpt-4.1'),
+      },
+    });
+
+    expect(Object.keys(models)).toEqual(['gpt-5.4', 'gpt-5.6-luna']);
+    expect(models['gpt-5.4']?.cost).toEqual({
+      input: 0,
+      output: 0,
+      cache: { read: 0, write: 0 },
+    });
+    expect(models['gpt-5.6-luna']).toMatchObject({
+      cost: {
+        input: 0,
+        output: 0,
+        cache: { read: 0, write: 0 },
+      },
+      limit: {
+        context: 500_000,
+        input: 372_000,
+        output: 128_000,
+      },
+    });
+  });
+});

--- a/apps/worker/src/run-task/agent-home.test.ts
+++ b/apps/worker/src/run-task/agent-home.test.ts
@@ -212,6 +212,25 @@ describe('generateOpenCodeConfig provider support', () => {
     });
   });
 
+  it('rebases the openai provider onto the ChatGPT gateway segment in gateway mode', () => {
+    const result = generateOpenCodeConfig({
+      homeDir: createHomeDir(),
+      runtimeEnv: {
+        R_MODEL: 'openai/gpt-5.4-codex',
+        R_INFERENCE_GATEWAY_URL: 'https://api.example.com/api/inference',
+        R_INFERENCE_GATEWAY_CHATGPT: '1',
+      },
+    });
+    const config = JSON.parse(result.configContent) as {
+      provider: Record<string, { options?: Record<string, unknown> }>;
+    };
+
+    expect(config.provider.openai?.options).toMatchObject({
+      baseURL: 'https://api.example.com/api/inference/openai-chatgpt/v1',
+      apiKey: '{env:ROOMOTE_CLOUD_TOKEN}',
+    });
+  });
+
   it('leaves the openai provider alone when a ChatGPT subscription is present', () => {
     const result = generateOpenCodeConfig({
       homeDir: createHomeDir(),

--- a/apps/worker/src/run-task/agent-home.ts
+++ b/apps/worker/src/run-task/agent-home.ts
@@ -36,6 +36,7 @@ import { SLACK_SILENCE_HOOK_SCRIPT } from './slack-silence-hook-script';
 import { SLACK_POSTING_TOOL_EXCLUSIONS } from './slack-posting-tools';
 import { SLACK_STOP_HOOK_SCRIPT } from './slack-stop-hook-script';
 import { OPENCODE_SLACK_HOOKS_PLUGIN_SCRIPT } from './opencode-slack-hooks-plugin-script';
+import { OPENCODE_CHATGPT_GATEWAY_PLUGIN_SCRIPT } from './opencode-chatgpt-gateway-plugin-script';
 import { resolveOpenCodeModelSelection } from './opencode-model';
 import {
   createProofRunnerAgentPrompt,
@@ -167,6 +168,9 @@ const ROOMOTE_OPENCODE_SLACK_SILENCE_HOOK_FILE_NAME =
 const ROOMOTE_OPENCODE_PLUGINS_DIR_NAME = 'plugins';
 
 const ROOMOTE_OPENCODE_SLACK_HOOKS_PLUGIN_FILE_NAME = 'roomote-slack-hooks.js';
+
+const ROOMOTE_OPENCODE_CHATGPT_GATEWAY_PLUGIN_FILE_NAME =
+  'roomote-chatgpt-gateway.js';
 
 const OPENCODE_ALLOW_ALL_PERMISSION = {
   read: 'allow',
@@ -534,14 +538,18 @@ function createOpenCodeMcpConfig(
   );
 }
 
-function writeOpenCodeSlackHookFiles(openCodeConfigDir: string): void {
+function writeOpenCodeManagedFiles(openCodeConfigDir: string): void {
   const pluginsDir = path.join(
     openCodeConfigDir,
     ROOMOTE_OPENCODE_PLUGINS_DIR_NAME,
   );
-  const pluginPath = path.join(
+  const slackPluginPath = path.join(
     pluginsDir,
     ROOMOTE_OPENCODE_SLACK_HOOKS_PLUGIN_FILE_NAME,
+  );
+  const chatGptGatewayPluginPath = path.join(
+    pluginsDir,
+    ROOMOTE_OPENCODE_CHATGPT_GATEWAY_PLUGIN_FILE_NAME,
   );
   const silenceHookPath = path.join(
     openCodeConfigDir,
@@ -553,7 +561,12 @@ function writeOpenCodeSlackHookFiles(openCodeConfigDir: string): void {
   );
 
   fs.mkdirSync(pluginsDir, { recursive: true });
-  fs.writeFileSync(pluginPath, OPENCODE_SLACK_HOOKS_PLUGIN_SCRIPT, 'utf8');
+  fs.writeFileSync(slackPluginPath, OPENCODE_SLACK_HOOKS_PLUGIN_SCRIPT, 'utf8');
+  fs.writeFileSync(
+    chatGptGatewayPluginPath,
+    OPENCODE_CHATGPT_GATEWAY_PLUGIN_SCRIPT,
+    'utf8',
+  );
   fs.writeFileSync(silenceHookPath, SLACK_SILENCE_HOOK_SCRIPT, 'utf8');
   fs.writeFileSync(stopHookPath, SLACK_STOP_HOOK_SCRIPT, 'utf8');
   fs.chmodSync(silenceHookPath, 0o755);
@@ -1388,7 +1401,7 @@ export function generateOpenCodeConfig({
   });
   const instructions: string[] = [];
 
-  writeOpenCodeSlackHookFiles(openCodeConfigDir);
+  writeOpenCodeManagedFiles(openCodeConfigDir);
 
   if (developerInstructionsContent) {
     const developerInstructionsPath = path.join(

--- a/apps/worker/src/run-task/agent-home.ts
+++ b/apps/worker/src/run-task/agent-home.ts
@@ -5,15 +5,19 @@ import {
   BEDROCK_MANTLE_OPENCODE_PROVIDER_ID,
   buildInferenceGatewayOpenCodeBaseUrl,
   buildOpenCodeModelReasoningOptions,
+  CHATGPT_GATEWAY_PROVIDER_ID,
   CHATGPT_OPENCODE_PROVIDER_ID,
   collectOpenRouterVariantModelAlias,
   DEFAULT_BEDROCK_MANTLE_REGION,
+  getInferenceGatewayProvider,
   getInferenceGatewayProviderByEnvVarName,
   GOOGLE_APPLICATION_CREDENTIALS_ENV_VAR_NAME,
   getMcpIntegration,
+  INFERENCE_GATEWAY_CHATGPT_ENV_VAR_NAME,
   INFERENCE_GATEWAY_KEYS_ENV_VAR_NAME,
   INFERENCE_GATEWAY_REGION_PATTERN,
   INFERENCE_GATEWAY_URL_ENV_VAR_NAME,
+  type InferenceGatewayProvider,
   isInlineGoogleCredentialsValue,
   mergeOpenCodeModelReasoningOptions,
   mergeOpenRouterVariantAliasModels,
@@ -641,8 +645,13 @@ function mergeInferenceGatewayProviderConfig(
   const servedKeyNames = parseInferenceGatewayKeys(
     runtimeEnv[INFERENCE_GATEWAY_KEYS_ENV_VAR_NAME],
   );
+  const routeChatGptThroughGateway =
+    runtimeEnv[INFERENCE_GATEWAY_CHATGPT_ENV_VAR_NAME] === '1';
 
-  if (!gatewayUrl || servedKeyNames.length === 0) {
+  if (
+    !gatewayUrl ||
+    (servedKeyNames.length === 0 && !routeChatGptThroughGateway)
+  ) {
     return providerConfig;
   }
 
@@ -662,7 +671,7 @@ function mergeInferenceGatewayProviderConfig(
   for (const [providerId, gatewayProvider] of gatewayProviders) {
     // ChatGPT-subscription OAuth authenticates through opencode's Codex
     // plugin directly; leave the openai provider on its default base URL
-    // when a subscription record is present.
+    // when a subscription record is present in the sandbox (non-gateway mode).
     if (
       providerId === CHATGPT_OPENCODE_PROVIDER_ID &&
       runtimeEnv[OPENCODE_AUTH_CONTENT_ENV_VAR_NAME]
@@ -670,26 +679,59 @@ function mergeInferenceGatewayProviderConfig(
       continue;
     }
 
-    const existingProvider = asRecord(merged[providerId]);
-    const existingOptions = asRecord(existingProvider.options);
+    merged = rebaseProviderOntoGateway(
+      merged,
+      providerId,
+      gatewayUrl,
+      gatewayProvider,
+    );
+  }
 
-    merged = {
-      ...merged,
-      [providerId]: {
-        ...existingProvider,
-        options: {
-          ...existingOptions,
-          baseURL: buildInferenceGatewayOpenCodeBaseUrl(
-            gatewayUrl,
-            gatewayProvider,
-          ),
-          apiKey: '{env:ROOMOTE_CLOUD_TOKEN}',
-        },
-      },
-    };
+  // ChatGPT subscription served by the gateway: rebase the OpenCode `openai`
+  // provider onto the gateway's ChatGPT segment. The gateway mints the OAuth
+  // access token and rewrites to the Codex backend, so the sandbox holds only
+  // the run token and never the OAuth record.
+  if (routeChatGptThroughGateway) {
+    const chatGptProvider = getInferenceGatewayProvider(
+      CHATGPT_GATEWAY_PROVIDER_ID,
+    );
+
+    if (chatGptProvider) {
+      merged = rebaseProviderOntoGateway(
+        merged,
+        CHATGPT_OPENCODE_PROVIDER_ID,
+        gatewayUrl,
+        chatGptProvider,
+      );
+    }
   }
 
   return merged;
+}
+
+function rebaseProviderOntoGateway(
+  providerConfig: Record<string, unknown>,
+  openCodeProviderId: string,
+  gatewayUrl: string,
+  gatewayProvider: InferenceGatewayProvider,
+): Record<string, unknown> {
+  const existingProvider = asRecord(providerConfig[openCodeProviderId]);
+  const existingOptions = asRecord(existingProvider.options);
+
+  return {
+    ...providerConfig,
+    [openCodeProviderId]: {
+      ...existingProvider,
+      options: {
+        ...existingOptions,
+        baseURL: buildInferenceGatewayOpenCodeBaseUrl(
+          gatewayUrl,
+          gatewayProvider,
+        ),
+        apiKey: '{env:ROOMOTE_CLOUD_TOKEN}',
+      },
+    },
+  };
 }
 
 function normalizeStringList(value: unknown): string[] {

--- a/apps/worker/src/run-task/env.ts
+++ b/apps/worker/src/run-task/env.ts
@@ -24,6 +24,7 @@ const MODEL_RUNTIME_ENV_KEYS = [
   // dequeue-delivered and read from the raw dequeue env in run-task; it is
   // allowlisted here so it survives into the harness env for config rebasing.
   'R_INFERENCE_GATEWAY_KEYS',
+  'R_INFERENCE_GATEWAY_CHATGPT',
   'R_MODEL',
   'R_SMALL_MODEL',
   'R_VISION_MODEL',

--- a/apps/worker/src/run-task/opencode-chatgpt-gateway-plugin-script.ts
+++ b/apps/worker/src/run-task/opencode-chatgpt-gateway-plugin-script.ts
@@ -18,13 +18,9 @@ const ALLOWED_MODELS = new Set([
   'gpt-5.4',
   'gpt-5.4-mini',
 ]);
-const DISALLOWED_MODELS = new Set(['gpt-5.5-pro']);
 
 function isSubscriptionModel(model) {
-  if (model.options.reasoningMode === 'pro') return false;
   if (ALLOWED_MODELS.has(model.api.id)) return true;
-  if (DISALLOWED_MODELS.has(model.api.id)) return false;
-  if (model.api.id === 'gpt-5.6') return false;
 
   const match = model.api.id.match(/^gpt-(\d+\.\d+)/);
   return match ? Number.parseFloat(match[1]) > 5.4 : false;
@@ -44,13 +40,7 @@ function asSubscriptionModel(model) {
           input: 272_000,
           output: 128_000,
         }
-      : model.id.includes('gpt-5.6')
-        ? {
-            context: 500_000,
-            input: 372_000,
-            output: 128_000,
-          }
-        : model.limit,
+      : model.limit,
   };
 }
 

--- a/apps/worker/src/run-task/opencode-chatgpt-gateway-plugin-script.ts
+++ b/apps/worker/src/run-task/opencode-chatgpt-gateway-plugin-script.ts
@@ -1,0 +1,73 @@
+import { INFERENCE_GATEWAY_CHATGPT_ENV_VAR_NAME } from '@roomote/types';
+
+/**
+ * OpenCode's built-in Codex plugin applies this model filter and metadata only
+ * when the local auth record has type `oauth`. ChatGPT gateway mode deliberately
+ * keeps that record off the sandbox, so this generated plugin restores the same
+ * provider-model behavior without restoring the credential or the Codex fetch
+ * hook that would bypass Roomote's gateway.
+ *
+ * Keep this in sync with the Codex plugin bundled by
+ * DEFAULT_OPENCODE_CLI_VERSION (`packages/opencode/src/plugin/openai/codex.ts`).
+ */
+export const OPENCODE_CHATGPT_GATEWAY_PLUGIN_SCRIPT = String.raw`
+const CHATGPT_GATEWAY_ENV_VAR = ${JSON.stringify(INFERENCE_GATEWAY_CHATGPT_ENV_VAR_NAME)};
+const ALLOWED_MODELS = new Set([
+  'gpt-5.5',
+  'gpt-5.3-codex-spark',
+  'gpt-5.4',
+  'gpt-5.4-mini',
+]);
+const DISALLOWED_MODELS = new Set(['gpt-5.5-pro']);
+
+function isSubscriptionModel(model) {
+  if (model.options.reasoningMode === 'pro') return false;
+  if (ALLOWED_MODELS.has(model.api.id)) return true;
+  if (DISALLOWED_MODELS.has(model.api.id)) return false;
+  if (model.api.id === 'gpt-5.6') return false;
+
+  const match = model.api.id.match(/^gpt-(\d+\.\d+)/);
+  return match ? Number.parseFloat(match[1]) > 5.4 : false;
+}
+
+function asSubscriptionModel(model) {
+  return {
+    ...model,
+    cost: {
+      input: 0,
+      output: 0,
+      cache: { read: 0, write: 0 },
+    },
+    limit: model.id.includes('gpt-5.5')
+      ? {
+          context: 400_000,
+          input: 272_000,
+          output: 128_000,
+        }
+      : model.id.includes('gpt-5.6')
+        ? {
+            context: 500_000,
+            input: 372_000,
+            output: 128_000,
+          }
+        : model.limit,
+  };
+}
+
+export const RoomoteChatGptGatewayModels = async () => ({
+  provider: {
+    id: 'openai',
+    async models(provider) {
+      if (process.env[CHATGPT_GATEWAY_ENV_VAR] !== '1') {
+        return provider.models;
+      }
+
+      return Object.fromEntries(
+        Object.entries(provider.models)
+          .filter(([, model]) => isSubscriptionModel(model))
+          .map(([modelId, model]) => [modelId, asSubscriptionModel(model)]),
+      );
+    },
+  },
+});
+`;

--- a/apps/worker/src/run-task/run-task.ts
+++ b/apps/worker/src/run-task/run-task.ts
@@ -2,8 +2,10 @@ import {
   type CommunicationProvider,
   type AcpRequestUserInputAnswers,
   buildInferenceGatewayUrl,
+  INFERENCE_GATEWAY_CHATGPT_ENV_VAR_NAME,
   INFERENCE_GATEWAY_KEYS_ENV_VAR_NAME,
   INFERENCE_GATEWAY_URL_ENV_VAR_NAME,
+  OPENCODE_AUTH_CONTENT_ENV_VAR_NAME,
   parseInferenceGatewayKeys,
   RunStatus,
   TaskPayloadKind,
@@ -656,20 +658,39 @@ export const runTask = async ({
     const inferenceGatewayServedKeys = parseInferenceGatewayKeys(
       unsanitizedEnv[INFERENCE_GATEWAY_KEYS_ENV_VAR_NAME],
     );
+    // A connected ChatGPT subscription served through the gateway carries no
+    // env key; dequeue signals it with a marker instead and omits the OAuth
+    // record, which the gateway holds and injects server-side.
+    const inferenceGatewayChatGpt =
+      unsanitizedEnv[INFERENCE_GATEWAY_CHATGPT_ENV_VAR_NAME] === '1';
 
-    if (inferenceGatewayServedKeys.length > 0) {
+    if (inferenceGatewayServedKeys.length > 0 || inferenceGatewayChatGpt) {
       for (const servedKey of inferenceGatewayServedKeys) {
         delete runtimeEnv[servedKey];
       }
 
-      runtimeEnv[INFERENCE_GATEWAY_KEYS_ENV_VAR_NAME] =
-        inferenceGatewayServedKeys.join(',');
       runtimeEnv[INFERENCE_GATEWAY_URL_ENV_VAR_NAME] = buildInferenceGatewayUrl(
         workerEnv.trpcUrl,
       );
+
+      if (inferenceGatewayServedKeys.length > 0) {
+        runtimeEnv[INFERENCE_GATEWAY_KEYS_ENV_VAR_NAME] =
+          inferenceGatewayServedKeys.join(',');
+      } else {
+        delete runtimeEnv[INFERENCE_GATEWAY_KEYS_ENV_VAR_NAME];
+      }
+
+      if (inferenceGatewayChatGpt) {
+        runtimeEnv[INFERENCE_GATEWAY_CHATGPT_ENV_VAR_NAME] = '1';
+        // Gateway mode holds the OAuth record; it must never reach the sandbox.
+        delete runtimeEnv[OPENCODE_AUTH_CONTENT_ENV_VAR_NAME];
+      } else {
+        delete runtimeEnv[INFERENCE_GATEWAY_CHATGPT_ENV_VAR_NAME];
+      }
     } else {
       delete runtimeEnv[INFERENCE_GATEWAY_KEYS_ENV_VAR_NAME];
       delete runtimeEnv[INFERENCE_GATEWAY_URL_ENV_VAR_NAME];
+      delete runtimeEnv[INFERENCE_GATEWAY_CHATGPT_ENV_VAR_NAME];
     }
 
     const workerHomeDir = runtimeEnv.HOME ?? sanitizedEnv.HOME ?? '';

--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server-bootstrap.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server-bootstrap.test.ts
@@ -55,6 +55,19 @@ describe('opencode-server bootstrap', () => {
     );
   }
 
+  function readOpenCodeChatGptGatewayPlugin(homeDir: string): string {
+    return fs.readFileSync(
+      path.join(
+        homeDir,
+        '.config',
+        'opencode',
+        'plugins',
+        'roomote-chatgpt-gateway.js',
+      ),
+      'utf8',
+    );
+  }
+
   function createDirectHarnessRuntimeEnv(
     homeDir: string,
   ): Record<string, string> {
@@ -1381,6 +1394,24 @@ describe('opencode-server bootstrap', () => {
     ).toBe(false);
   });
 
+  it('installs the ChatGPT gateway model metadata plugin', async () => {
+    const { prepareOpenCodeCommandEnv } =
+      await import('../opencode-server/bootstrap');
+
+    const homeDir = createTempHome();
+
+    await prepareOpenCodeCommandEnv({
+      runtimeEnv: createDirectHarnessRuntimeEnv(homeDir),
+      workspacePath: '/tmp/workspace',
+      logger: createLogger(),
+    });
+
+    const pluginContent = readOpenCodeChatGptGatewayPlugin(homeDir);
+
+    expect(pluginContent).toContain('RoomoteChatGptGatewayModels');
+    expect(pluginContent).toContain('R_INFERENCE_GATEWAY_CHATGPT');
+  });
+
   it('enables Slack hook debug logs only when Slack reply satisfaction is configured', async () => {
     const { prepareOpenCodeCommandEnv } =
       await import('../opencode-server/bootstrap');
@@ -1473,6 +1504,73 @@ describe('opencode-server bootstrap', () => {
     );
     expect(fs.existsSync(authPath)).toBe(true);
     expect(fs.readFileSync(authPath, 'utf8')).toBe(authContent);
+  });
+
+  it('removes stale auth.json before ChatGPT gateway mode starts', async () => {
+    const { prepareOpenCodeCommandEnv } =
+      await import('../opencode-server/bootstrap');
+
+    const homeDir = createTempHome();
+    const authPath = path.join(
+      homeDir,
+      '.local',
+      'share',
+      'opencode',
+      'auth.json',
+    );
+    fs.mkdirSync(path.dirname(authPath), { recursive: true });
+    fs.writeFileSync(
+      authPath,
+      JSON.stringify({
+        openai: { type: 'oauth', refresh: 'stale-refresh-token' },
+        'github-copilot': { type: 'oauth', refresh: 'other-token' },
+      }),
+      'utf8',
+    );
+
+    const { commandEnv } = await prepareOpenCodeCommandEnv({
+      runtimeEnv: {
+        ...createDirectHarnessRuntimeEnv(homeDir),
+        R_INFERENCE_GATEWAY_CHATGPT: '1',
+        OPENCODE_AUTH_CONTENT: JSON.stringify({
+          openai: { type: 'oauth', refresh: 'conflicting-token' },
+        }),
+      },
+      workspacePath: '/tmp/workspace',
+      logger: createLogger(),
+    });
+
+    expect(commandEnv.OPENCODE_AUTH_CONTENT).toBeUndefined();
+    expect(fs.existsSync(authPath)).toBe(false);
+  });
+
+  it('fails closed when stale auth.json cannot be removed in gateway mode', async () => {
+    const { prepareOpenCodeCommandEnv } =
+      await import('../opencode-server/bootstrap');
+
+    const homeDir = createTempHome();
+    const authPath = path.join(
+      homeDir,
+      '.local',
+      'share',
+      'opencode',
+      'auth.json',
+    );
+    fs.mkdirSync(authPath, { recursive: true });
+    fs.writeFileSync(path.join(authPath, 'stale-token'), 'secret', 'utf8');
+
+    await expect(
+      prepareOpenCodeCommandEnv({
+        runtimeEnv: {
+          ...createDirectHarnessRuntimeEnv(homeDir),
+          R_INFERENCE_GATEWAY_CHATGPT: '1',
+        },
+        workspacePath: '/tmp/workspace',
+        logger: createLogger(),
+      }),
+    ).rejects.toThrow(
+      'Failed to remove OpenCode auth.json for ChatGPT gateway mode',
+    );
   });
 
   it('leaves OPENCODE_AUTH_CONTENT set when auth.json cannot be written', async () => {

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/bootstrap.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/bootstrap.ts
@@ -12,6 +12,7 @@ import {
 import type { HarnessLogger } from '../../../../logging';
 import {
   GOOGLE_APPLICATION_CREDENTIALS_ENV_VAR_NAME,
+  INFERENCE_GATEWAY_CHATGPT_ENV_VAR_NAME,
   OPENCODE_AUTH_CONTENT_ENV_VAR_NAME,
   type ReasoningEffort,
 } from '@roomote/types';
@@ -271,14 +272,41 @@ async function materializeOpenCodeBashEnvOverlay(options: {
   commandEnv.BASH_ENV = overlayPath;
 }
 
+async function removeOpenCodeAuthJsonForChatGptGateway(options: {
+  commandEnv: Record<string, string>;
+  homeDir: string;
+  logger: HarnessLogger;
+}): Promise<void> {
+  const dataDir = resolveOpenCodeDataDir(options.homeDir, options.commandEnv);
+  const authFilePath = path.join(dataDir, OPENCODE_AUTH_FILE_NAME);
+
+  try {
+    // A resumed filesystem can contain an auth file from a run created before
+    // gateway mode, or from a best-effort snapshot scrub that failed. Remove
+    // the complete file before OpenCode starts: any `openai` auth entry would
+    // reactivate the built-in Codex fetch hook and bypass Roomote's gateway.
+    await fs.rm(authFilePath, { force: true });
+    options.logger.info(
+      `Ensured OpenCode auth.json is absent for ChatGPT gateway mode at ${authFilePath}`,
+    );
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Unknown auth.json remove error';
+
+    // Fail closed. Starting OpenCode with a stale OAuth record would put the
+    // long-lived subscription credential back in use inside the sandbox.
+    throw new Error(
+      `Failed to remove OpenCode auth.json for ChatGPT gateway mode: ${message}`,
+      { cause: error },
+    );
+  }
+}
+
 /**
- * Write the ChatGPT subscription OAuth record (delivered as
- * `OPENCODE_AUTH_CONTENT`) to the harness `auth.json` so the inner opencode
- * process can self-refresh access tokens during long tasks, then strip the
- * env var so opencode reads the file instead of the static env content.
- * Failures are logged but never derail task startup — the env var remains
- * set on failure so opencode can still read the auth record from it as a
- * fallback.
+ * In direct-subscription mode, write the OAuth record delivered as
+ * `OPENCODE_AUTH_CONTENT` to the harness `auth.json` so OpenCode can refresh
+ * it during long tasks. In gateway mode, remove any snapshotted auth file and
+ * fail closed if that cleanup cannot be completed before OpenCode starts.
  */
 async function materializeOpenCodeAuthJson(options: {
   commandEnv: Record<string, string>;
@@ -286,6 +314,17 @@ async function materializeOpenCodeAuthJson(options: {
   logger: HarnessLogger;
 }): Promise<void> {
   const { commandEnv, homeDir, logger } = options;
+  const routeChatGptThroughGateway =
+    commandEnv[INFERENCE_GATEWAY_CHATGPT_ENV_VAR_NAME] === '1';
+
+  if (routeChatGptThroughGateway) {
+    // Defense in depth: dequeue and run-task already omit this value, but a
+    // conflicting deployment env must not survive into the OpenCode process.
+    delete commandEnv[OPENCODE_AUTH_CONTENT_ENV_VAR_NAME];
+    await removeOpenCodeAuthJsonForChatGptGateway(options);
+    return;
+  }
+
   const authContent = commandEnv[OPENCODE_AUTH_CONTENT_ENV_VAR_NAME];
 
   if (!authContent) {

--- a/packages/db/src/lib/model-runtime-config.test.ts
+++ b/packages/db/src/lib/model-runtime-config.test.ts
@@ -593,6 +593,44 @@ describe('resolveEffectiveModelRuntimeEnv', () => {
     expect(env.OPENCODE_AUTH_CONTENT).toContain('"type":"oauth"');
   });
 
+  it('emits the ChatGPT gateway marker instead of OPENCODE_AUTH_CONTENT in gateway mode', async () => {
+    mockDeploymentSettingsFindFirst.mockResolvedValue({
+      runtimeModelConfig: { roomoteModel: 'openai/gpt-5.4' },
+    });
+    mockResolveOpenCodeAuthContent.mockResolvedValue(
+      JSON.stringify({
+        openai: { type: 'oauth', refresh: 'rt', access: 'at', expires: 123 },
+      }),
+    );
+
+    const env = await resolveEffectiveModelRuntimeEnv({
+      inferenceGateway: true,
+      runtimeEnv: {},
+      deploymentEnvVars: {},
+    });
+
+    // The OAuth record must stay on the control plane; the marker tells the
+    // worker to rebase the openai provider onto the gateway instead.
+    expect(env).not.toHaveProperty('OPENCODE_AUTH_CONTENT');
+    expect(env.R_INFERENCE_GATEWAY_CHATGPT).toBe('1');
+  });
+
+  it('does not emit the ChatGPT gateway marker when no subscription is connected', async () => {
+    mockDeploymentSettingsFindFirst.mockResolvedValue({
+      runtimeModelConfig: { roomoteModel: 'openai/gpt-5.4' },
+    });
+    mockResolveOpenCodeAuthContent.mockResolvedValue(null);
+
+    const env = await resolveEffectiveModelRuntimeEnv({
+      inferenceGateway: true,
+      runtimeEnv: {},
+      deploymentEnvVars: {},
+    });
+
+    expect(env).not.toHaveProperty('OPENCODE_AUTH_CONTENT');
+    expect(env).not.toHaveProperty('R_INFERENCE_GATEWAY_CHATGPT');
+  });
+
   it('does not inject OPENCODE_AUTH_CONTENT when no openai/ model is used', async () => {
     mockDeploymentSettingsFindFirst.mockResolvedValue({
       runtimeModelConfig: { roomoteModel: 'anthropic/claude-sonnet-4' },

--- a/packages/db/src/lib/model-runtime-config.test.ts
+++ b/packages/db/src/lib/model-runtime-config.test.ts
@@ -708,6 +708,62 @@ describe('resolveEffectiveModelRuntimeEnv', () => {
       expect(env.R_INFERENCE_GATEWAY_KEYS).toBe('ANTHROPIC_API_KEY');
     });
 
+    it('withholds credentials for every enabled switchable model provider', async () => {
+      mockDeploymentSettingsFindFirst.mockResolvedValue({
+        runtimeModelConfig: {
+          roomoteModel: 'openrouter/openai/gpt-5.6-terra',
+          roomotePlanningModel: 'openrouter/anthropic/claude-opus-4.8',
+        },
+        taskModelSettings: {
+          models: [
+            {
+              id: 'openrouter/openai/gpt-5.6-terra',
+              displayName: 'GPT 5.6 Terra',
+              family: 'GPT',
+            },
+            {
+              id: 'anthropic/claude-sonnet-5',
+              displayName: 'Claude Sonnet 5',
+              family: 'Sonnet',
+            },
+            {
+              id: 'openai/gpt-5.6-luna',
+              displayName: 'GPT 5.6 Luna',
+              family: 'GPT',
+            },
+          ],
+          allowedModelIds: [
+            'openrouter/openai/gpt-5.6-terra',
+            'anthropic/claude-sonnet-5',
+            'openai/gpt-5.6-luna',
+          ],
+          defaultModelId: 'openrouter/openai/gpt-5.6-terra',
+        },
+      });
+      mockResolveOpenCodeAuthContent.mockResolvedValue(
+        JSON.stringify({
+          openai: { type: 'oauth', refresh: 'rt', access: 'at', expires: 123 },
+        }),
+      );
+
+      const env = await resolveEffectiveModelRuntimeEnv({
+        inferenceGateway: true,
+        runtimeEnv: {},
+        deploymentEnvVars: {
+          OPENROUTER_API_KEY: 'sk-openrouter',
+          ANTHROPIC_API_KEY: 'sk-anthropic',
+        },
+      });
+
+      expect(env).not.toHaveProperty('OPENROUTER_API_KEY');
+      expect(env).not.toHaveProperty('ANTHROPIC_API_KEY');
+      expect(env.R_INFERENCE_GATEWAY_KEYS).toBe(
+        'OPENROUTER_API_KEY,ANTHROPIC_API_KEY',
+      );
+      expect(env.R_INFERENCE_GATEWAY_CHATGPT).toBe('1');
+      expect(env).not.toHaveProperty('OPENCODE_AUTH_CONTENT');
+    });
+
     it('withholds Bedrock but keeps Vertex, which the gateway cannot serve', async () => {
       const env = await resolveEffectiveModelRuntimeEnv({
         inferenceGateway: true,

--- a/packages/db/src/lib/model-runtime-config.ts
+++ b/packages/db/src/lib/model-runtime-config.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_MODEL_ROLE_REASONING_EFFORTS,
   getModelProviderEnvKeyCandidates,
   getTaskModelCatalog,
+  INFERENCE_GATEWAY_CHATGPT_ENV_VAR_NAME,
   INFERENCE_GATEWAY_KEYS_ENV_VAR_NAME,
   isConfiguredEnvValue,
   isInferenceGatewayCoveredEnvVar,
@@ -329,6 +330,11 @@ export async function resolveEffectiveModelRuntimeEnv(
   // runtime even when both are configured. This single choke point covers
   // both task launches (dequeue-helpers) and routing/title/summary calls
   // (non-task-provider-usage).
+  //
+  // In sandbox gateway mode the OAuth record must stay on the control plane,
+  // so instead of shipping OPENCODE_AUTH_CONTENT the resolver emits the
+  // R_INFERENCE_GATEWAY_CHATGPT marker; the worker rebases the `openai`
+  // provider onto the gateway, which mints and injects the access token.
   const resolvedRoleModels = [
     resolvedRoomoteModel,
     resolvedRoomoteSmallModel,
@@ -345,6 +351,8 @@ export async function resolveEffectiveModelRuntimeEnv(
   const injectedOpenCodeAuthContent = usesOpenAiModel
     ? await resolveOpenCodeAuthContent({ executor })
     : null;
+  const routeChatGptThroughGateway =
+    options.inferenceGateway === true && injectedOpenCodeAuthContent != null;
 
   return {
     ...(resolvedRoomoteModel && { R_MODEL: resolvedRoomoteModel }),
@@ -396,8 +404,10 @@ export async function resolveEffectiveModelRuntimeEnv(
     ...(gatewayServedKeyNames.length > 0 && {
       [INFERENCE_GATEWAY_KEYS_ENV_VAR_NAME]: gatewayServedKeyNames.join(','),
     }),
-    ...(injectedOpenCodeAuthContent && {
-      OPENCODE_AUTH_CONTENT: injectedOpenCodeAuthContent,
-    }),
+    ...(routeChatGptThroughGateway
+      ? { [INFERENCE_GATEWAY_CHATGPT_ENV_VAR_NAME]: '1' }
+      : injectedOpenCodeAuthContent
+        ? { OPENCODE_AUTH_CONTENT: injectedOpenCodeAuthContent }
+        : {}),
   };
 }

--- a/packages/db/src/lib/model-runtime-config.ts
+++ b/packages/db/src/lib/model-runtime-config.ts
@@ -2,6 +2,7 @@ import { eq } from 'drizzle-orm';
 import {
   CHATGPT_OPENCODE_PROVIDER_ID,
   DEFAULT_MODEL_ROLE_REASONING_EFFORTS,
+  getEnabledTaskModels,
   getModelProviderEnvKeyCandidates,
   getTaskModelCatalog,
   INFERENCE_GATEWAY_CHATGPT_ENV_VAR_NAME,
@@ -81,6 +82,7 @@ async function loadPersistedRuntimeModelConfig(
       deployment?.runtimeModelConfig,
     ),
     catalogModels: getTaskModelCatalog(deployment?.taskModelSettings),
+    enabledCatalogModels: getEnabledTaskModels(deployment?.taskModelSettings),
   };
 }
 
@@ -187,14 +189,16 @@ export async function resolveEffectiveModelRuntimeEnv(
 ): Promise<Record<string, string>> {
   const runtimeEnv = options.runtimeEnv ?? process.env;
   const executor = options.executor ?? db;
-  const [persistedEnvVars, { runtimeModelConfig, catalogModels }] =
-    await Promise.all([
-      resolveEffectiveDeploymentEnvVars({
-        deploymentEnvVars: options.deploymentEnvVars,
-        executor,
-      }),
-      loadPersistedRuntimeModelConfig(executor),
-    ]);
+  const [
+    persistedEnvVars,
+    { runtimeModelConfig, catalogModels, enabledCatalogModels },
+  ] = await Promise.all([
+    resolveEffectiveDeploymentEnvVars({
+      deploymentEnvVars: options.deploymentEnvVars,
+      executor,
+    }),
+    loadPersistedRuntimeModelConfig(executor),
+  ]);
   const persistedRuntimeModelConfig = runtimeModelConfig;
   const resolvedRoomoteModel =
     normalizeConfiguredValue(runtimeEnv.R_MODEL) ??
@@ -284,28 +288,48 @@ export async function resolveEffectiveModelRuntimeEnv(
   const runtimeRoomoteModelEnvKeys = normalizeConfiguredValue(
     runtimeEnv.R_MODEL_ENV_KEYS,
   );
+  const resolvedRoleModels = [
+    resolvedRoomoteModel,
+    resolvedRoomoteSmallModel,
+    resolvedRoomoteVisionModel,
+    resolvedRoomoteCodeReviewModel,
+    resolvedRoomoteExploreModel,
+    resolvedRoomotePlanningModel,
+  ];
   const providerKeyNames = resolveProviderKeyNames({
     runtimeRoomoteModelEnvKeys,
-    resolvedRoomoteModels: [
-      resolvedRoomoteModel,
-      resolvedRoomoteSmallModel,
-      resolvedRoomoteVisionModel,
-      resolvedRoomoteCodeReviewModel,
-      resolvedRoomoteExploreModel,
-      resolvedRoomotePlanningModel,
-    ],
+    resolvedRoomoteModels: resolvedRoleModels,
   });
+  // A running OpenCode task can switch to any enabled catalog model without
+  // another dequeue, while configured role agents can select their own
+  // providers. Gateway coverage must therefore include both sets up front;
+  // otherwise a later model switch either sees a missing key or uses a raw
+  // provider credential that was already written into the sandbox.
+  const gatewaySwitchableModelIds = options.inferenceGateway
+    ? enabledCatalogModels.map((model) => model.id)
+    : [];
+  const gatewayProviderKeyNames = [
+    ...new Set([
+      ...providerKeyNames,
+      ...resolveProviderKeyNames({
+        resolvedRoomoteModels: gatewaySwitchableModelIds,
+      }),
+    ]),
+  ];
   // When the gateway is active, the configured provider keys it can serve
   // (OpenRouter, Anthropic, OpenAI, Gemini, the aggregators, Bedrock) stay on
   // the control plane and are advertised to the worker by name via
   // R_INFERENCE_GATEWAY_KEYS; the worker builds the (container-reachable)
   // gateway URL from its own platform URL and rebases exactly these providers.
-  // Only configured keys are withheld, so a provider key the deployment set
-  // for its own code (not used by any configured model) still reaches the
-  // sandbox. Providers the gateway cannot serve (Vertex signing, ChatGPT
-  // subscription OAuth) are never covered and always flow through.
+  // Only configured keys are withheld. Providers the gateway cannot serve
+  // (such as Vertex request signing) continue to flow through.
   const gatewayServedKeyNames = options.inferenceGateway
-    ? providerKeyNames.filter((name) => isInferenceGatewayCoveredEnvVar(name))
+    ? gatewayProviderKeyNames.filter(
+        (name) =>
+          isInferenceGatewayCoveredEnvVar(name) &&
+          (normalizeConfiguredValue(runtimeEnv[name]) !== undefined ||
+            normalizeConfiguredValue(persistedEnvVars[name]) !== undefined),
+      )
     : [];
   const gatewayServedKeyNameSet = new Set(gatewayServedKeyNames);
 
@@ -324,26 +348,21 @@ export async function resolveEffectiveModelRuntimeEnv(
   );
 
   // ChatGPT subscription coverage: when a connected subscription exists and
-  // any resolved role model uses the `openai/` prefix, inject the OAuth
-  // record as `OPENCODE_AUTH_CONTENT`. opencode's Codex plugin prefers OAuth
-  // auth when present, so the subscription wins over `OPENAI_API_KEY` at
-  // runtime even when both are configured. This single choke point covers
-  // both task launches (dequeue-helpers) and routing/title/summary calls
-  // (non-task-provider-usage).
+  // any resolved role or gateway-switchable model uses the `openai/` prefix,
+  // inject the OAuth record as `OPENCODE_AUTH_CONTENT`. opencode's Codex
+  // plugin prefers OAuth auth when present, so the subscription wins over
+  // `OPENAI_API_KEY` at runtime even when both are configured. This single
+  // choke point covers both task launches (dequeue-helpers) and
+  // routing/title/summary calls (non-task-provider-usage).
   //
   // In sandbox gateway mode the OAuth record must stay on the control plane,
   // so instead of shipping OPENCODE_AUTH_CONTENT the resolver emits the
   // R_INFERENCE_GATEWAY_CHATGPT marker; the worker rebases the `openai`
   // provider onto the gateway, which mints and injects the access token.
-  const resolvedRoleModels = [
-    resolvedRoomoteModel,
-    resolvedRoomoteSmallModel,
-    resolvedRoomoteVisionModel,
-    resolvedRoomoteCodeReviewModel,
-    resolvedRoomoteExploreModel,
-    resolvedRoomotePlanningModel,
-  ];
-  const usesOpenAiModel = resolvedRoleModels.some(
+  const usesOpenAiModel = [
+    ...resolvedRoleModels,
+    ...gatewaySwitchableModelIds,
+  ].some(
     (modelId) =>
       typeof modelId === 'string' &&
       modelId.startsWith(`${CHATGPT_OPENCODE_PROVIDER_ID}/`),

--- a/packages/types/src/__tests__/inference-gateway.test.ts
+++ b/packages/types/src/__tests__/inference-gateway.test.ts
@@ -1,6 +1,7 @@
 import {
   buildInferenceGatewayOpenCodeBaseUrl,
   buildInferenceGatewayUrl,
+  CHATGPT_GATEWAY_PROVIDER_ID,
   getInferenceGatewayProvider,
   getInferenceGatewayProviderByEnvVarName,
   INFERENCE_GATEWAY_PROVIDER_ENV_VAR_NAMES,
@@ -30,6 +31,25 @@ describe('inference gateway URL builders', () => {
         provider!,
       ),
     ).toBe('https://api.example.com/api/inference/anthropic/v1');
+  });
+
+  it('exposes a chatgpt-oauth provider that collapses to the Codex backend', () => {
+    const provider = getInferenceGatewayProvider(CHATGPT_GATEWAY_PROVIDER_ID);
+    expect(provider?.authStrategy).toBe('chatgpt-oauth');
+    // No env key: the gateway holds the OAuth record, so it must not appear in
+    // the withheld-key set that the sandbox strips.
+    expect(provider?.envVarNames).toEqual([]);
+    expect(INFERENCE_GATEWAY_PROVIDER_ENV_VAR_NAMES).not.toContain(
+      CHATGPT_GATEWAY_PROVIDER_ID,
+    );
+    expect(provider?.upstreamBaseUrl).toBe('https://chatgpt.com');
+    expect(provider?.collapseToPath).toBe('/backend-api/codex/responses');
+    expect(
+      buildInferenceGatewayOpenCodeBaseUrl(
+        'https://api.example.com/api/inference',
+        provider!,
+      ),
+    ).toBe('https://api.example.com/api/inference/openai-chatgpt/v1');
   });
 });
 

--- a/packages/types/src/inference-gateway.ts
+++ b/packages/types/src/inference-gateway.ts
@@ -32,28 +32,72 @@ export const INFERENCE_GATEWAY_REGION_PATTERN =
 /** Default AWS region for the Bedrock Mantle Anthropic-compatible endpoint. */
 export const DEFAULT_BEDROCK_MANTLE_REGION = 'us-east-1';
 
+/**
+ * Gateway path segment for the ChatGPT-subscription provider. Distinct from
+ * the key-authenticated `openai` entry: the OpenCode provider id stays
+ * `openai` (the model prefix), but its baseURL points at this segment so the
+ * gateway can hold the OAuth record and rewrite to the Codex backend.
+ */
+export const CHATGPT_GATEWAY_PROVIDER_ID = 'openai-chatgpt';
+
+/** The ChatGPT Codex backend the OpenCode Codex plugin targets. */
+export const CHATGPT_CODEX_UPSTREAM_BASE_URL = 'https://chatgpt.com';
+export const CHATGPT_CODEX_UPSTREAM_PATH = '/backend-api/codex/responses';
+
+/** Account-scoping header the Codex backend requires alongside the bearer. */
+export const CHATGPT_ACCOUNT_ID_HEADER = 'ChatGPT-Account-Id';
+
+/**
+ * Sandbox-facing marker set at dequeue when the gateway is serving a
+ * connected ChatGPT subscription: the worker rebases the OpenCode `openai`
+ * provider onto the gateway instead of materializing `OPENCODE_AUTH_CONTENT`,
+ * so the subscription OAuth record never enters the sandbox.
+ */
+export const INFERENCE_GATEWAY_CHATGPT_ENV_VAR_NAME =
+  'R_INFERENCE_GATEWAY_CHATGPT';
+
 interface InferenceGatewayAuthHeader {
   name: string;
   scheme?: 'bearer';
 }
 
+/**
+ * How the gateway authenticates upstream for a provider:
+ * - `api-key`: inject a static deployment key (the default).
+ * - `chatgpt-oauth`: mint a fresh ChatGPT-subscription access token
+ *   server-side and add the account-id header; the sandbox holds no key.
+ */
+export type InferenceGatewayAuthStrategy = 'api-key' | 'chatgpt-oauth';
+
 export interface InferenceGatewayProvider {
   /**
-   * Provider id, used both as the gateway path segment and as the OpenCode
-   * provider id (they match for every supported provider).
+   * Provider id, used as the gateway path segment. It also matches the
+   * OpenCode provider id for key-authenticated providers; the
+   * ChatGPT-subscription entry is the exception (its OpenCode id is `openai`).
    */
-  id: SetupModelProviderId | typeof BEDROCK_MANTLE_OPENCODE_PROVIDER_ID;
+  id:
+    | SetupModelProviderId
+    | typeof BEDROCK_MANTLE_OPENCODE_PROVIDER_ID
+    | typeof CHATGPT_GATEWAY_PROVIDER_ID;
   name: string;
   /**
    * Deployment env vars holding the provider API key the gateway injects,
-   * in precedence order.
+   * in precedence order. Empty for non-key auth strategies.
    */
   envVarNames: readonly string[];
+  /** How the gateway authenticates upstream. Defaults to `api-key`. */
+  authStrategy?: InferenceGatewayAuthStrategy;
   /**
    * Upstream API base. May contain a `{region}` placeholder resolved
    * per-request from `region` below.
    */
   upstreamBaseUrl: string;
+  /**
+   * When set, every allowed request path is rewritten to this fixed upstream
+   * path (the ChatGPT Codex backend collapses `/responses` and
+   * `/chat/completions` to a single endpoint).
+   */
+  collapseToPath?: string;
   /**
    * Region resolution for `{region}`-templated upstreams: the deployment env
    * var to read and the fallback when it is unset.
@@ -247,6 +291,28 @@ export const INFERENCE_GATEWAY_PROVIDERS: readonly InferenceGatewayProvider[] =
       },
       authHeader: { name: 'x-api-key' },
       allowedPaths: ANTHROPIC_COMPATIBLE_INFERENCE_PATHS,
+      openCodeBaseUrlSuffix: '/v1',
+    },
+    {
+      // ChatGPT subscription: the gateway holds the OAuth record, mints a
+      // fresh access token per request, adds the account-id header, and
+      // collapses the request to the Codex backend — mirroring the OpenCode
+      // Codex plugin, but server-side so the OAuth record stays out of the
+      // sandbox. The Codex plugin forwards the request body unchanged, so no
+      // body translation is needed here.
+      id: CHATGPT_GATEWAY_PROVIDER_ID,
+      name: 'ChatGPT Subscription',
+      authStrategy: 'chatgpt-oauth',
+      envVarNames: [],
+      upstreamBaseUrl: CHATGPT_CODEX_UPSTREAM_BASE_URL,
+      collapseToPath: CHATGPT_CODEX_UPSTREAM_PATH,
+      authHeader: { name: 'authorization', scheme: 'bearer' },
+      allowedPaths: [
+        '/responses',
+        '/v1/responses',
+        '/chat/completions',
+        '/v1/chat/completions',
+      ],
       openCodeBaseUrlSuffix: '/v1',
     },
   ];


### PR DESCRIPTION
## Summary

Phase 3 of keeping credentials out of the sandbox: route **ChatGPT-subscription** inference through the gateway so the OAuth record (`OPENCODE_AUTH_CONTENT`, including its long-lived refresh token) stays on the control plane instead of being materialized inside the task sandbox.

This also makes gateway coverage match the runtime model surface. At dequeue, Roomote now covers every enabled task model plus every configured role model, so launch-time model overrides, midtask model switches, and role/subagent model choices cannot expose gateway-served provider credentials such as `ANTHROPIC_API_KEY`.

## Root cause

The original resolver derived gateway markers and redaction keys only from the persisted role models. A task's selected model override is applied later by the worker, so selecting a direct `openai/` model while the persisted default used OpenRouter produced no ChatGPT gateway marker. The same narrow coverage could leave another enabled provider's raw key in the sandbox even though a midtask switch or subagent could use that provider.

The worker release was current and OpenCode's built-in provider name was not the problem.

## How it works

- **Gateway** (`apps/api/src/handlers/inference`): the `openai-chatgpt` provider uses a `chatgpt-oauth` auth strategy. Per request it obtains a fresh access token through the existing refresh flow, sets the upstream authorization and account headers, and collapses the request onto the Codex backend. Sandbox-supplied authorization and account headers are stripped.
- **Control plane** (`resolveEffectiveModelRuntimeEnv`): in gateway mode, enabled task models are combined with configured role models when resolving gateway-served provider keys. Configured credentials for those providers stay on the control plane and are advertised to the worker only by name.
- **ChatGPT subscription**: when any enabled or role model uses the direct `openai/` provider and a subscription is connected, the resolver emits `R_INFERENCE_GATEWAY_CHATGPT=1` instead of `OPENCODE_AUTH_CONTENT`.
- **Worker**: strips `OPENCODE_AUTH_CONTENT`, builds the container-reachable gateway URL, and rebases the OpenCode providers onto the gateway with `apiKey={env:ROOMOTE_CLOUD_TOKEN}`.

The behavior remains gated by the existing `InferenceGateway` flag.

## Validation

- DB runtime resolver: 27 tests passed, including enabled OpenRouter, Anthropic, and ChatGPT models with both raw provider-key and OAuth redaction assertions.
- Worker agent-home configuration: 17 tests passed.
- API inference gateway: 27 tests passed, including ChatGPT OAuth resolution, path allowlisting, header replacement, and upstream behavior.
- Full `pnpm lint`, `pnpm check-types`, and `pnpm knip` passed.
- Development E2E with a connected ChatGPT subscription passed: a direct ChatGPT task completed through the gateway with HTTP 200, while the sandbox contained neither ChatGPT OAuth material nor the Anthropic API key. OpenAI and Anthropic were both configured with gateway token placeholders.
