### PR TITLE
Expose R_LICENSE_KEY in Railway template

### DIFF
--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -45,10 +45,11 @@ Compose paths in [SELF_HOSTING.md](../../SELF_HOSTING.md) instead.
 - **Provider credentials live in the app, not the template.** The template
   ships with zero required deploy-time inputs. Modal tokens and the model
   provider API key are entered in the `/setup` wizard (or Settings) after
-  first boot and stored encrypted in Postgres. The one optional prompt on
-  the deploy screen is `R_APP_URL`, for deployers who want a custom
-  domain from the start (see
-  [Attaching a custom domain](#attaching-a-custom-domain)).
+  first boot and stored encrypted in Postgres. Optional deploy-screen inputs
+  are `R_APP_URL`, for deployers who want a custom domain from the start (see
+  [Attaching a custom domain](#attaching-a-custom-domain)), and
+  `R_LICENSE_KEY`, for operators provisioning a paid-seat license. An env
+  license key takes precedence over a key stored through **Settings > Users**.
 - **Live previews are off by default, but the proxy ships ready.** Preview
   subdomains need a wildcard domain, and Railway-generated service domains
   are single-label. The `preview-proxy` service is part of the template and
@@ -147,6 +148,7 @@ ROOMOTE_DOCKER_LOAD_ENV_FILE=false
 R_AUTO_GENERATE_KEYS=true
 ENCRYPTION_KEY=${{secret(32)}}
 R_DISCORD_GATEWAY_SECRET=${{secret(32)}}
+R_LICENSE_KEY=
 ARTIFACT_SIGNING_KEY=${{secret(32)}}
 DASHBOARD_PASSWORD=${{secret(24)}}
 S3_SECRET_ACCESS_KEY=${{secret(32)}}
@@ -177,6 +179,7 @@ ROOMOTE_DOCKER_LOAD_ENV_FILE=${{api.ROOMOTE_DOCKER_LOAD_ENV_FILE}}
 R_AUTO_GENERATE_KEYS=${{api.R_AUTO_GENERATE_KEYS}}
 ENCRYPTION_KEY=${{api.ENCRYPTION_KEY}}
 R_DISCORD_GATEWAY_SECRET=${{api.R_DISCORD_GATEWAY_SECRET}}
+R_LICENSE_KEY=${{api.R_LICENSE_KEY}}
 ARTIFACT_SIGNING_KEY=${{api.ARTIFACT_SIGNING_KEY}}
 DASHBOARD_PASSWORD=${{api.DASHBOARD_PASSWORD}}
 S3_SECRET_ACCESS_KEY=${{api.S3_SECRET_ACCESS_KEY}}

--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -226,8 +226,8 @@ Notes:
 
 - `R_APP_URL` on api is the **single canonical-origin knob**: it is the
   URL users browse, and web/controller/bullmq/preview-proxy reference
-  `${{api.R_APP_URL}}` rather than repeating the value. It is also the
-  template's one optional deploy-time prompt — the deploy screen shows it
+  `${{api.R_APP_URL}}` rather than repeating the value. It is also one of the
+  template's optional deploy-time prompts — the deploy screen shows it
   pre-filled with the generated-domain reference so a custom domain can be
   entered before first boot. Do not set `R_PUBLIC_URL` — it is
   optional and the app falls back to `R_APP_URL` everywhere it would
@@ -322,7 +322,7 @@ logs a warning when creation fails).
 By default the template boots on Railway-generated domains, and
 `R_APP_URL` — the origin users browse — derives from the web service's
 generated domain. A custom domain can be set either at deploy time (through
-the template's one optional prompt) or after deploy (a one-variable edit).
+the `R_APP_URL` prompt) or after deploy (a one-variable edit).
 Setting it at deploy time is preferable when you already own the domain:
 everything the setup wizard registers — in particular the GitHub App's OAuth
 callback and webhook URLs — derives from the canonical origin, so getting it

--- a/deploy/railway/template.yaml
+++ b/deploy/railway/template.yaml
@@ -38,11 +38,12 @@
 # - Zero required deploy-time inputs. Modal tokens and model provider keys
 #   are entered in the /setup wizard after first boot and stored encrypted
 #   in Postgres. Auth keypairs come from R_AUTO_GENERATE_KEYS=true.
-#   The one optional deploy-time prompt is R_APP_URL on api (see the
-#   annotation on that variable): deployers who already own a domain
-#   override the pre-filled default with https://<their-domain> before the
-#   first deploy instead of editing the variable after hitting 403
-#   "Invalid origin" errors.
+#   The optional deploy-time prompts are R_APP_URL on api (see the annotation
+#   on that variable), for deployers who already own a domain, and
+#   R_LICENSE_KEY, for operators provisioning a paid-seat license. Override
+#   the pre-filled R_APP_URL default with https://<their-domain> before the
+#   first deploy instead of editing the variable after hitting 403 "Invalid
+#   origin" errors.
 # - The api service must be publicly reachable: hosted sandboxes workers and
 #   GitHub webhooks call `TRPC_URL` directly.
 # - Both published images are public on GHCR: Railway pulls roomote-app and
@@ -157,8 +158,8 @@ services:
       EXCLUDED_COMPUTE_PROVIDERS: docker
       DATABASE_URL: ${{Postgres.DATABASE_URL}}
       REDIS_URL: ${{Redis.REDIS_URL}}
-      # The single canonical-origin knob, and the template's one (optional)
-      # deploy-time prompt. In the Template Composer, give this variable the
+      # The single canonical-origin knob and one of the template's optional
+      # deploy-time prompts. In the Template Composer, give this variable the
       # description below so Railway surfaces it on the deploy screen with
       # the reference default pre-filled. Leaving the default keeps the
       # Railway-generated domain; overriding it with https://<domain> sets a

--- a/deploy/railway/template.yaml
+++ b/deploy/railway/template.yaml
@@ -132,6 +132,8 @@ services:
       ENCRYPTION_KEY: ${{secret(32)}}
       # Transport secret between BullMQ Discord Gateway and API.
       R_DISCORD_GATEWAY_SECRET: ${{secret(32)}}
+      # Optional paid-seat license key; takes precedence over Settings > Users.
+      R_LICENSE_KEY: ''
       R_DISCORD_BOT_TOKEN: '' # optional; Discord can also be configured after boot in Settings
       ARTIFACT_SIGNING_KEY: ${{secret(32)}}
       DASHBOARD_PASSWORD: ${{secret(24)}}
@@ -188,6 +190,7 @@ services:
       R_AUTO_GENERATE_KEYS: ${{api.R_AUTO_GENERATE_KEYS}}
       ENCRYPTION_KEY: ${{api.ENCRYPTION_KEY}}
       R_DISCORD_GATEWAY_SECRET: ${{api.R_DISCORD_GATEWAY_SECRET}}
+      R_LICENSE_KEY: ${{api.R_LICENSE_KEY}}
       R_DISCORD_BOT_TOKEN: ${{api.R_DISCORD_BOT_TOKEN}}
       ARTIFACT_SIGNING_KEY: ${{api.ARTIFACT_SIGNING_KEY}}
       DASHBOARD_PASSWORD: ${{api.DASHBOARD_PASSWORD}}


### PR DESCRIPTION
## Summary

- add the optional `R_LICENSE_KEY` input to the Railway API service
- share the configured value with the app services
- document Railway configuration and environment precedence

## Why

The application already supports deployment-provided license keys, but the Railway template did not expose that setting. This completes deployment-template parity for Railway operators.

## Validation

- `pnpm deployment:validate`
- repository pre-push checks