### PR TITLE
Refresh worker runtime on task snapshot resume

### DIFF
--- a/.changeset/refresh-task-snapshot-worker.md
+++ b/.changeset/refresh-task-snapshot-worker.md
@@ -1,0 +1,5 @@
+---
+"@roomote/web": patch
+---
+
+Refresh the shipped worker runtime when restoring task snapshots so snapshots created by an older release remain compatible with current runtime protocols such as the inference gateway.

--- a/.docker/sandbox/install-worker.sh
+++ b/.docker/sandbox/install-worker.sh
@@ -12,14 +12,15 @@
 #
 # Installation modes:
 #
-#   Vercel Sandbox (production + local dev):
+#   Hosted sandbox (production + local dev):
 #     - Controller uploads this script + archive to /sandbox/worker.tar.gz
 #     - This script installs from the uploaded worker release archive
 #
-#   Vercel Sandbox (snapshot resume):
+#   Hosted sandbox (snapshot resume):
 #     - Environment snapshot launches restore a cached sandbox first, then run
 #       this script to refresh the shipped Roomote worker/runtime in place
-#     - Task snapshot launches preserve exact state and skip this script
+#     - Task snapshot launches also refresh the shipped worker/runtime while
+#       preserving repositories, harness sessions, and other snapshot state
 #
 # Build worker release archive: ./scripts/build-worker-release.sh <version>
 

--- a/packages/compute-providers/src/daytona/create-daytona-machine.ts
+++ b/packages/compute-providers/src/daytona/create-daytona-machine.ts
@@ -114,13 +114,15 @@ export async function createDaytonaMachine(
 
   let tarball: Buffer | undefined;
   let version: string | undefined;
-  const shouldInstallShippedRuntime = launchMode !== 'task_snapshot';
 
-  if (shouldInstallShippedRuntime && localTarballPath) {
+  // A task snapshot owns repository and harness-session state, but its worker
+  // must speak the current API/runtime protocol (for example inference-gateway
+  // env markers). Refresh only the shipped worker directory after restore.
+  if (localTarballPath) {
     const localRelease = loadLocalWorkerReleaseWithVersion(localTarballPath);
     tarball = localRelease.archive;
     version = localRelease.version;
-  } else if (shouldInstallShippedRuntime) {
+  } else {
     const release = await getWorkerRelease();
     tarball = release.archive;
     version = release.version;
@@ -314,25 +316,6 @@ export async function createDaytonaMachine(
 
   if (!createdMachine) {
     throw new Error('Failed to create Daytona instance');
-  }
-
-  if (!shouldInstallShippedRuntime) {
-    return {
-      machineId: createdMachine.instanceId,
-      proxyPorts,
-      ...(sourceSnapshotId ? { sourceSnapshotId } : {}),
-      domain: (port: number) => {
-        const fromResponse = createdMachine.domains?.[port.toString()];
-
-        if (fromResponse) {
-          return fromResponse;
-        }
-
-        throw new Error(
-          `No Daytona preview link resolved for port ${port} on ${createdMachine.instanceId}`,
-        );
-      },
-    };
   }
 
   // Start the bootstrap timeout only after instance creation succeeds, so cold

--- a/packages/compute-providers/src/e2b/create-e2b-machine.ts
+++ b/packages/compute-providers/src/e2b/create-e2b-machine.ts
@@ -113,13 +113,15 @@ export async function createE2bMachine(
 
   let tarball: Buffer | undefined;
   let version: string | undefined;
-  const shouldInstallShippedRuntime = launchMode !== 'task_snapshot';
 
-  if (shouldInstallShippedRuntime && localTarballPath) {
+  // A task snapshot owns repository and harness-session state, but its worker
+  // must speak the current API/runtime protocol (for example inference-gateway
+  // env markers). Refresh only the shipped worker directory after restore.
+  if (localTarballPath) {
     const localRelease = loadLocalWorkerReleaseWithVersion(localTarballPath);
     tarball = localRelease.archive;
     version = localRelease.version;
-  } else if (shouldInstallShippedRuntime) {
+  } else {
     const release = await getWorkerRelease();
     tarball = release.archive;
     version = release.version;
@@ -314,17 +316,6 @@ export async function createE2bMachine(
 
   if (!createdMachine) {
     throw new Error('Failed to create E2B instance');
-  }
-
-  if (!shouldInstallShippedRuntime) {
-    return {
-      machineId: createdMachine.instanceId,
-      proxyPorts,
-      ...(sourceSnapshotId ? { sourceSnapshotId } : {}),
-      domain: (port: number) =>
-        createdMachine.domains?.[port.toString()] ??
-        fallbackDomain(createdMachine.instanceId, port),
-    };
   }
 
   // Start the bootstrap timeout only after instance creation succeeds, so cold

--- a/packages/compute-providers/src/modal/create-modal-machine.test.ts
+++ b/packages/compute-providers/src/modal/create-modal-machine.test.ts
@@ -218,9 +218,20 @@ describe('createModalMachine', () => {
     );
   });
 
-  it('preserves task snapshot runtime state without reinstalling the shipped worker', async () => {
+  it('refreshes the shipped worker without replacing task snapshot state', async () => {
     const runCommand = vi.fn().mockResolvedValue({ exitCode: 0, stdout: 'ok' });
     const writeFiles = vi.fn().mockResolvedValue(undefined);
+    const resumeFromSnapshot = vi.fn().mockResolvedValue({
+      instanceId: 'modal-123',
+      domains: {},
+      sourceSnapshotId: 'snap-task-123',
+    });
+
+    mockGetWorkerRelease.mockResolvedValue({
+      archive: Buffer.from('worker-release'),
+      tag: 'worker-v1.2.3',
+      version: '1.2.3',
+    });
 
     await createModalMachine({
       modalTokenId: 'token-id',
@@ -231,20 +242,36 @@ describe('createModalMachine', () => {
       computeClient: {
         vendor: 'modal',
         createInstance: vi.fn(),
-        resumeFromSnapshot: vi.fn().mockResolvedValue({
-          instanceId: 'modal-123',
-          domains: {},
-          sourceSnapshotId: 'snap-task-123',
-        }),
+        resumeFromSnapshot,
         writeFiles,
         runCommand,
         destroyInstance: vi.fn(),
       },
     });
 
-    expect(mockGetWorkerRelease).not.toHaveBeenCalled();
-    expect(writeFiles).not.toHaveBeenCalled();
-    expect(runCommand).not.toHaveBeenCalled();
+    expect(mockGetWorkerRelease).toHaveBeenCalledTimes(1);
+    expect(resumeFromSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceSnapshotId: 'snap-task-123',
+        metadata: expect.objectContaining({
+          workerReleaseTag: 'worker-v1.2.3',
+        }),
+      }),
+    );
+    expect(writeFiles).toHaveBeenCalledWith(
+      expect.objectContaining({
+        files: expect.arrayContaining([
+          expect.objectContaining({ path: '/sandbox/worker.tar.gz' }),
+        ]),
+      }),
+    );
+    expect(runCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: {
+          WORKER_RELEASE_ARCHIVE_PATH: '/sandbox/worker.tar.gz',
+        },
+      }),
+    );
   });
 
   it('ignores non-bootstrap files in the local Modal files directory', async () => {

--- a/packages/compute-providers/src/modal/create-modal-machine.ts
+++ b/packages/compute-providers/src/modal/create-modal-machine.ts
@@ -131,13 +131,15 @@ export async function createModalMachine(
 
   let tarball: Buffer | undefined;
   let version: string | undefined;
-  const shouldInstallShippedRuntime = launchMode !== 'task_snapshot';
 
-  if (shouldInstallShippedRuntime && localTarballPath) {
+  // A task snapshot owns repository and harness-session state, but its worker
+  // must speak the current API/runtime protocol (for example inference-gateway
+  // env markers). Refresh only the shipped worker directory after restore.
+  if (localTarballPath) {
     const localRelease = loadLocalWorkerReleaseWithVersion(localTarballPath);
     tarball = localRelease.archive;
     version = localRelease.version;
-  } else if (shouldInstallShippedRuntime) {
+  } else {
     const release = await getWorkerRelease();
     tarball = release.archive;
     version = release.version;
@@ -344,25 +346,6 @@ export async function createModalMachine(
 
   if (!createdMachine) {
     throw new Error('Failed to create modal instance');
-  }
-
-  if (!shouldInstallShippedRuntime) {
-    return {
-      machineId: createdMachine.instanceId,
-      proxyPorts,
-      ...(sourceSnapshotId ? { sourceSnapshotId } : {}),
-      domain: (port: number) => {
-        const fromResponse =
-          createdMachine.domains?.[port.toString()] ??
-          createdMachine.domains?.[`${port}`];
-
-        if (fromResponse) {
-          return fromResponse;
-        }
-
-        return `https://${createdMachine.instanceId}-${port}.modal.run`;
-      },
-    };
   }
 
   // Start the bootstrap timeout only after instance creation succeeds, so cold

--- a/packages/compute-providers/src/task-snapshot-runtime-refresh.test.ts
+++ b/packages/compute-providers/src/task-snapshot-runtime-refresh.test.ts
@@ -1,0 +1,134 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { createDaytonaMachine } from './daytona/create-daytona-machine';
+import { createE2bMachine } from './e2b/create-e2b-machine';
+import { getWorkerRelease } from './sandbox/worker-release-cache';
+
+vi.mock('./sandbox/worker-release-cache', () => ({
+  getWorkerRelease: vi.fn(),
+}));
+
+const mockGetWorkerRelease = vi.mocked(getWorkerRelease);
+
+describe('task snapshot worker runtime refresh', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshot-runtime-'));
+    fs.writeFileSync(
+      path.join(tempDir, 'install-browser-agent.sh'),
+      '#!/bin/bash\n',
+    );
+    fs.writeFileSync(path.join(tempDir, 'install-worker.sh'), '#!/bin/bash\n');
+    process.env.LOCAL_SANDBOX_FILES_DIR = tempDir;
+    mockGetWorkerRelease.mockResolvedValue({
+      archive: Buffer.from('worker-release'),
+      tag: 'worker-v1.2.3',
+      version: '1.2.3',
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.LOCAL_SANDBOX_FILES_DIR;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('refreshes the E2B worker after restoring a task snapshot', async () => {
+    const resumeFromSnapshot = vi.fn().mockResolvedValue({
+      instanceId: 'e2b-123',
+      domains: {},
+      sourceSnapshotId: 'snap-task-123',
+    });
+    const writeFiles = vi.fn().mockResolvedValue(undefined);
+    const runCommand = vi.fn().mockResolvedValue({ exitCode: 0 });
+
+    await createE2bMachine({
+      e2bApiKey: 'e2b-key',
+      e2bTemplateId: 'template-123',
+      launchMode: 'task_snapshot',
+      sourceSnapshotId: 'snap-task-123',
+      computeClient: {
+        vendor: 'e2b',
+        createInstance: vi.fn(),
+        resumeFromSnapshot,
+        writeFiles,
+        runCommand,
+        destroyInstance: vi.fn(),
+      },
+    });
+
+    expectTaskSnapshotRuntimeRefresh({
+      resumeFromSnapshot,
+      writeFiles,
+      runCommand,
+    });
+  });
+
+  it('refreshes the Daytona worker after restoring a task snapshot', async () => {
+    const resumeFromSnapshot = vi.fn().mockResolvedValue({
+      instanceId: 'daytona-123',
+      domains: {},
+      sourceSnapshotId: 'snap-task-123',
+    });
+    const writeFiles = vi.fn().mockResolvedValue(undefined);
+    const runCommand = vi.fn().mockResolvedValue({ exitCode: 0 });
+
+    await createDaytonaMachine({
+      daytonaApiKey: 'daytona-key',
+      daytonaSnapshotName: 'snapshot-123',
+      launchMode: 'task_snapshot',
+      sourceSnapshotId: 'snap-task-123',
+      computeClient: {
+        vendor: 'daytona',
+        createInstance: vi.fn(),
+        resumeFromSnapshot,
+        writeFiles,
+        runCommand,
+        destroyInstance: vi.fn(),
+      },
+    });
+
+    expectTaskSnapshotRuntimeRefresh({
+      resumeFromSnapshot,
+      writeFiles,
+      runCommand,
+    });
+  });
+});
+
+function expectTaskSnapshotRuntimeRefresh({
+  resumeFromSnapshot,
+  writeFiles,
+  runCommand,
+}: {
+  resumeFromSnapshot: ReturnType<typeof vi.fn>;
+  writeFiles: ReturnType<typeof vi.fn>;
+  runCommand: ReturnType<typeof vi.fn>;
+}): void {
+  expect(mockGetWorkerRelease).toHaveBeenCalledTimes(1);
+  expect(resumeFromSnapshot).toHaveBeenCalledWith(
+    expect.objectContaining({
+      sourceSnapshotId: 'snap-task-123',
+      metadata: expect.objectContaining({
+        workerReleaseTag: 'worker-v1.2.3',
+      }),
+    }),
+  );
+  expect(writeFiles).toHaveBeenCalledWith(
+    expect.objectContaining({
+      files: expect.arrayContaining([
+        expect.objectContaining({ path: '/sandbox/worker.tar.gz' }),
+      ]),
+    }),
+  );
+  expect(runCommand).toHaveBeenCalledWith(
+    expect.objectContaining({
+      env: {
+        WORKER_RELEASE_ARCHIVE_PATH: '/sandbox/worker.tar.gz',
+      },
+    }),
+  );
+}


### PR DESCRIPTION
## Summary

- refresh the shipped Roomote worker after restoring task snapshots
- preserve repositories, harness sessions, and other snapshot-owned state
- apply the compatibility refresh consistently to Modal, E2B, and Daytona
- add regression coverage for each snapshot-capable hosted provider

## Root cause

Task snapshots restored the worker version captured when the snapshot was created. When the API/worker protocol changed, an older restored worker could no longer interpret the current dequeue contract.

## Impact

Snapshots created by an older Roomote release can resume using the current worker/runtime protocol without discarding saved task state.

## Validation

- compute-provider test suite (157 tests)
- controller snapshot launch tests
- compute-provider typecheck and lint
- shell syntax validation
- repository pre-push checks
