### PR TITLE
Recover bounded provider turn errors

### DIFF
--- a/.changeset/recover-provider-turn-errors.md
+++ b/.changeset/recover-provider-turn-errors.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Recover from bounded model-provider turn errors, including safety-policy refusals, without immediately aborting the Roomote task.

--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
@@ -1971,6 +1971,16 @@ describe('OpenCodeServerHarness', () => {
         },
       });
 
+      // OpenCode reports the error before the failed runner reaches idle. The
+      // retry must remain queued until that boundary or it can be appended to
+      // the dying run without starting a fresh model loop.
+      expect(client.promptAsync).toHaveBeenCalledTimes(1);
+
+      await client.emit({
+        type: 'session.idle',
+        properties: { sessionID: 'ses_1' },
+      });
+
       await vi.waitFor(() => {
         expect(client.promptAsync).toHaveBeenCalledTimes(2);
       });
@@ -2042,6 +2052,13 @@ describe('OpenCodeServerHarness', () => {
       await client.emit({
         type: 'session.error',
         properties: { sessionID: 'ses_1', error: providerError },
+      });
+
+      expect(client.promptAsync).toHaveBeenCalledTimes(1);
+
+      await client.emit({
+        type: 'session.idle',
+        properties: { sessionID: 'ses_1' },
       });
 
       await vi.waitFor(() => {

--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
@@ -1852,7 +1852,7 @@ describe('OpenCodeServerHarness', () => {
     }
   });
 
-  it('clears queued prompts instead of draining them after a terminal session error', async () => {
+  it('immediately aborts and clears queued prompts for explicit non-retryable provider errors', async () => {
     const { client, harness } = createHarness();
     const taskEvents: TaskEvent[] = [];
 
@@ -1890,7 +1890,14 @@ describe('OpenCodeServerHarness', () => {
         type: 'session.error',
         properties: {
           sessionID: 'ses_1',
-          error: { message: 'boom' },
+          error: {
+            name: 'APIError',
+            data: {
+              message: 'The selected model is not available in your region.',
+              statusCode: 403,
+              isRetryable: false,
+            },
+          },
         },
       });
 
@@ -1901,6 +1908,161 @@ describe('OpenCodeServerHarness', () => {
       ).toBe(true);
       expect(harness.getQueuedMessages()).toEqual([]);
       expect(client.promptAsync).toHaveBeenCalledTimes(1);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it('retries a cyber policy refusal with safer framing without aborting the task', async () => {
+    const { client, harness } = createHarness();
+    const taskEvents: TaskEvent[] = [];
+    const persistedEnvelopes: AcpPersistedEnvelope[] = [];
+
+    harness.subscribe((event) => taskEvents.push(event));
+    harness.subscribeRuntimePersistedEnvelope((envelope) =>
+      persistedEnvelopes.push(envelope),
+    );
+
+    try {
+      await connectHarness(harness, client);
+
+      expect(
+        harness.sendCommand({
+          commandName: TaskCommandName.StartNewTask,
+          data: {
+            text: 'Review the change.',
+            visibleInTranscript: true,
+          },
+        }),
+      ).toBe(true);
+
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(1);
+      });
+
+      expect(
+        harness.sendCommand({
+          commandName: TaskCommandName.SendMessage,
+          data: {
+            text: 'Queued follow-up.',
+            visibleInTranscript: true,
+          },
+        }),
+      ).toBe(true);
+
+      await client.emit({
+        type: 'session.error',
+        properties: {
+          sessionID: 'ses_1',
+          error: {
+            name: 'UnknownError',
+            data: {
+              message: JSON.stringify({
+                type: 'error',
+                error: {
+                  type: 'invalid_request',
+                  code: 'cyber_policy',
+                  message:
+                    'This content was flagged for possible cybersecurity risk.',
+                },
+              }),
+            },
+          },
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(2);
+      });
+
+      const retryPrompt = client.promptAsync.mock.calls[1]?.[0] as
+        | {
+            request?: {
+              parts?: Array<{ type?: string; text?: string }>;
+            };
+          }
+        | undefined;
+      const retryPromptText = (retryPrompt?.request?.parts ?? [])
+        .map((part) => part.text)
+        .filter((text): text is string => typeof text === 'string')
+        .join('\n');
+
+      expect(retryPromptText).toContain('Continue the legitimate task');
+      expect(retryPromptText).toContain('Do not attempt to bypass the policy');
+      expect(
+        taskEvents.some(
+          (event) => event.eventName === TaskEventName.TaskAborted,
+        ),
+      ).toBe(false);
+      expect(
+        persistedEnvelopes.some(
+          (envelope) =>
+            envelope.eventType === ACP_ENVELOPE_EVENT_TYPES.AssistantMessage &&
+            String(envelope.payload.text ?? '').includes(
+              'Provider safety refusal; automatically retrying the turn',
+            ),
+        ),
+      ).toBe(true);
+      expect(
+        harness.getQueuedMessages().map((message) => message.text),
+      ).toEqual(['Queued follow-up.']);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it('retries an unknown provider error once before aborting', async () => {
+    const { client, harness } = createHarness();
+    const taskEvents: TaskEvent[] = [];
+
+    harness.subscribe((event) => taskEvents.push(event));
+
+    try {
+      await connectHarness(harness, client);
+
+      expect(
+        harness.sendCommand({
+          commandName: TaskCommandName.StartNewTask,
+          data: {
+            text: 'Start work.',
+            visibleInTranscript: true,
+          },
+        }),
+      ).toBe(true);
+
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(1);
+      });
+
+      const providerError = {
+        name: 'UnknownError',
+        data: { message: 'Upstream connection closed unexpectedly.' },
+      };
+
+      await client.emit({
+        type: 'session.error',
+        properties: { sessionID: 'ses_1', error: providerError },
+      });
+
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(2);
+      });
+      expect(
+        taskEvents.some(
+          (event) => event.eventName === TaskEventName.TaskAborted,
+        ),
+      ).toBe(false);
+
+      await client.emit({
+        type: 'session.error',
+        properties: { sessionID: 'ses_1', error: providerError },
+      });
+
+      expect(
+        taskEvents.some(
+          (event) => event.eventName === TaskEventName.TaskAborted,
+        ),
+      ).toBe(true);
     } finally {
       harness.dispose();
     }

--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
@@ -1977,13 +1977,28 @@ describe('OpenCodeServerHarness', () => {
       expect(client.promptAsync).toHaveBeenCalledTimes(1);
 
       await client.emit({
-        type: 'session.idle',
-        properties: { sessionID: 'ses_1' },
+        type: 'session.status',
+        properties: { sessionID: 'ses_1', status: { type: 'idle' } },
       });
 
       await vi.waitFor(() => {
         expect(client.promptAsync).toHaveBeenCalledTimes(2);
       });
+
+      // OpenCode emits this legacy idle event for the same transition after
+      // session.status(idle). It must be consumed instead of completing the
+      // recovery loop that was just started.
+      await client.emit({
+        type: 'session.idle',
+        properties: { sessionID: 'ses_1' },
+      });
+
+      expect(client.promptAsync).toHaveBeenCalledTimes(2);
+      expect(
+        taskEvents.some(
+          (event) => event.eventName === TaskEventName.TaskCompleted,
+        ),
+      ).toBe(false);
 
       const retryPrompt = client.promptAsync.mock.calls[1]?.[0] as
         | {

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
@@ -1535,6 +1535,7 @@ export class OpenCodeServerHarness
     null;
   private providerRateLimitRetryCount = 0;
   private providerErrorRecoveryCount = 0;
+  private providerErrorRecoveryQueuedPromptId: string | null = null;
   private currentWorkflowPhase: string | null = null;
   // Most recent packaged workflow skill loaded by the primary session's agent
   // via the OpenCode skill tool. Drives per-prompt agent selection so plan-mode
@@ -2034,6 +2035,7 @@ export class OpenCodeServerHarness
     command: StartNewTaskCommand,
   ): Promise<void> {
     this.prompts.clear();
+    this.clearProviderErrorRecoveryState();
     this.clearAllExecuteToolProgress();
     this.stopHookReminderCount = 0;
     this.currentWorkflowPhase = command.data.workflowPhase ?? null;
@@ -2092,7 +2094,8 @@ export class OpenCodeServerHarness
     if (
       command.data.queueOnly ||
       this.inFlight ||
-      this.isProviderRateLimitBackoffPending()
+      this.isProviderRateLimitBackoffPending() ||
+      this.providerErrorRecoveryQueuedPromptId !== null
     ) {
       // True native steering: OpenCode accepts prompt_async on a session with
       // an active turn and the loop picks the message up between steps — no
@@ -2162,9 +2165,14 @@ export class OpenCodeServerHarness
         // Steers use prioritize() so they usually jump the FIFO queue, but
         // during rate-limit backoff the invisible continue prompt must stay
         // first so we don't replay the user message before the automatic
-        // retry runs (and then drain a stale Continue afterward).
+        // retry runs (and then drain a stale Continue afterward). The same
+        // ordering applies while a provider-error retry awaits session idle.
         this.frontloadProviderRateLimitContinueIfQueued();
-        if (!this.isProviderRateLimitBackoffPending()) {
+        this.frontloadProviderErrorRecoveryIfQueued();
+        if (
+          !this.isProviderRateLimitBackoffPending() &&
+          this.providerErrorRecoveryQueuedPromptId === null
+        ) {
           await this.interruptForQueuedReplay();
         }
       }
@@ -2206,7 +2214,9 @@ export class OpenCodeServerHarness
     // explicit user cancel during the wait still leaves a cancel marker and
     // clears the automatic retry instead of silently dropping it.
     const hadActiveTurn =
-      hadInFlightOrPendingQuestion || this.isProviderRateLimitBackoffPending();
+      hadInFlightOrPendingQuestion ||
+      this.isProviderRateLimitBackoffPending() ||
+      this.providerErrorRecoveryQueuedPromptId !== null;
 
     // Aborting an in-flight turn makes OpenCode emit a MessageAbortedError on the
     // session.error event. For an explicit cancel that's expected, not a failure
@@ -2980,13 +2990,19 @@ export class OpenCodeServerHarness
       resolution,
     });
 
-    if (this.inFlight) {
+    if (this.inFlight || this.providerErrorRecoveryQueuedPromptId !== null) {
       const queuedId = this.prompts.enqueue({
         text: responseText,
         visibleInTranscript: false,
         userId: command.data.userId,
       });
       this.prompts.prioritize(queuedId);
+
+      if (this.providerErrorRecoveryQueuedPromptId !== null) {
+        this.frontloadProviderErrorRecoveryIfQueued();
+        return;
+      }
+
       await this.interruptForQueuedReplay();
       return;
     }
@@ -3501,6 +3517,10 @@ export class OpenCodeServerHarness
     }
 
     if (statusType === 'idle') {
+      if (await this.drainProviderErrorRecoveryAfterIdle()) {
+        return;
+      }
+
       await this.finishCurrentTurn();
     }
   }
@@ -3526,6 +3546,10 @@ export class OpenCodeServerHarness
 
     if (sessionId && !this.sessionId) {
       this.sessionId = sessionId;
+    }
+
+    if (await this.drainProviderErrorRecoveryAfterIdle()) {
+      return;
     }
 
     await this.finishCurrentTurn();
@@ -3628,8 +3652,7 @@ export class OpenCodeServerHarness
       visibleInTranscript: false,
     });
     this.prompts.prioritize(queuedId);
-
-    await this.drainQueuedPrompts();
+    this.providerErrorRecoveryQueuedPromptId = queuedId;
   }
 
   /**
@@ -3706,6 +3729,24 @@ export class OpenCodeServerHarness
     this.clearProviderRateLimitRetryTimer();
     this.providerRateLimitRetryCount = 0;
     this.providerErrorRecoveryCount = 0;
+    this.providerErrorRecoveryQueuedPromptId = null;
+  }
+
+  private async drainProviderErrorRecoveryAfterIdle(): Promise<boolean> {
+    const queuedPromptId = this.providerErrorRecoveryQueuedPromptId;
+
+    if (!queuedPromptId) {
+      return false;
+    }
+
+    // OpenCode emits session.error before the failed runner reaches idle. Do
+    // not submit the retry until that idle boundary or prompt_async can append
+    // it to the dying run without starting a fresh model loop.
+    this.providerErrorRecoveryQueuedPromptId = null;
+    this.inFlight = false;
+    this.prompts.prioritize(queuedPromptId);
+    await this.drainQueuedPrompts();
+    return true;
   }
 
   private frontloadProviderRateLimitContinueIfQueued(): void {
@@ -3722,6 +3763,12 @@ export class OpenCodeServerHarness
     }
 
     this.prompts.prioritize(continueQueuedId);
+  }
+
+  private frontloadProviderErrorRecoveryIfQueued(): void {
+    if (this.providerErrorRecoveryQueuedPromptId) {
+      this.prompts.prioritize(this.providerErrorRecoveryQueuedPromptId);
+    }
   }
 
   private isProviderRateLimitBackoffPending(): boolean {
@@ -4394,7 +4441,8 @@ export class OpenCodeServerHarness
     if (
       this.inFlight ||
       this.disposed ||
-      this.isProviderRateLimitBackoffPending()
+      this.isProviderRateLimitBackoffPending() ||
+      this.providerErrorRecoveryQueuedPromptId !== null
     ) {
       return;
     }

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
@@ -74,6 +74,11 @@ import {
   isOpenCodeProviderRateLimitError,
   resolveOpenCodeRateLimitRetryDelayMs,
 } from './provider-rate-limit';
+import {
+  formatOpenCodeProviderErrorRetryNoticeText,
+  getOpenCodeProviderErrorRecovery,
+  type OpenCodeProviderErrorRecovery,
+} from './provider-error-recovery';
 import type {
   OpenCodeEventPayload,
   OpenCodeGlobalEvent,
@@ -1529,6 +1534,7 @@ export class OpenCodeServerHarness
   private providerRateLimitRetryTimer: ReturnType<typeof setTimeout> | null =
     null;
   private providerRateLimitRetryCount = 0;
+  private providerErrorRecoveryCount = 0;
   private currentWorkflowPhase: string | null = null;
   // Most recent packaged workflow skill loaded by the primary session's agent
   // via the OpenCode skill tool. Drives per-prompt agent selection so plan-mode
@@ -1781,7 +1787,7 @@ export class OpenCodeServerHarness
     this.connected = false;
     this.clearReplayAbortErrorSuppression();
     this.clearQueuedPromptRetryTimer();
-    this.clearProviderRateLimitRetryState();
+    this.clearProviderErrorRecoveryState();
     this.clearAllExecuteToolProgress();
     void this.cleanupVisualAttachmentDirectories();
     this.rejectEventStreamReady?.(
@@ -2187,7 +2193,7 @@ export class OpenCodeServerHarness
       this.inFlight = false;
       this.prompts.clear();
       this.clearQueuedPromptRetryTimer();
-      this.clearProviderRateLimitRetryState();
+      this.clearProviderErrorRecoveryState();
       this.pendingUserInputRequests.clear();
       this.clearAllExecuteToolProgress();
       return;
@@ -2224,7 +2230,7 @@ export class OpenCodeServerHarness
     this.finalizedAssistantTurn = null;
     this.prompts.clear();
     this.clearQueuedPromptRetryTimer();
-    this.clearProviderRateLimitRetryState();
+    this.clearProviderErrorRecoveryState();
     // Abandoned questions get an explicit cancelled response so surfaces
     // that clear pending state on request_user_input_response (Slack,
     // Linear, the web store) drop them, and late answers are rejected via
@@ -3168,7 +3174,7 @@ export class OpenCodeServerHarness
     this.inFlight = false;
     this.prompts.clear();
     this.clearQueuedPromptRetryTimer();
-    this.clearProviderRateLimitRetryState();
+    this.clearProviderErrorRecoveryState();
     this.pendingUserInputRequests.clear();
     this.clearAllExecuteToolProgress();
     this.runtimeEvents.taskStarted(sessionId);
@@ -3546,13 +3552,21 @@ export class OpenCodeServerHarness
       return;
     }
 
-    if (
-      sessionId &&
-      isOpenCodeProviderRateLimitError(error) &&
-      this.providerRateLimitRetryCount < this.providerRateLimitMaxRetries
-    ) {
-      await this.recoverProviderRateLimit(sessionId, error);
-      return;
+    const isProviderRateLimit =
+      !!sessionId && isOpenCodeProviderRateLimitError(error);
+
+    if (sessionId && isProviderRateLimit) {
+      if (this.providerRateLimitRetryCount < this.providerRateLimitMaxRetries) {
+        await this.recoverProviderRateLimit(sessionId, error);
+        return;
+      }
+    } else if (sessionId) {
+      const recovery = getOpenCodeProviderErrorRecovery(error);
+
+      if (recovery && this.providerErrorRecoveryCount < recovery.maxRetries) {
+        await this.recoverProviderSessionError(sessionId, error, recovery);
+        return;
+      }
     }
 
     if (sessionId) {
@@ -3565,7 +3579,7 @@ export class OpenCodeServerHarness
       });
       this.prompts.clear();
       this.clearQueuedPromptRetryTimer();
-      this.clearProviderRateLimitRetryState();
+      this.clearProviderErrorRecoveryState();
       this.pendingUserInputRequests.clear();
       this.clearAllExecuteToolProgress();
       this.runtimeEvents.taskAborted(sessionId);
@@ -3573,6 +3587,49 @@ export class OpenCodeServerHarness
 
     await this.cleanupVisualAttachmentDirectories();
     this.inFlight = false;
+  }
+
+  /**
+   * Most provider session errors invalidate one model turn rather than the
+   * OpenCode session. Retry them in-place with a bounded invisible continue so
+   * a transient provider response cannot abort the enclosing Roomote task.
+   */
+  private async recoverProviderSessionError(
+    sessionId: string,
+    error: unknown,
+    recovery: OpenCodeProviderErrorRecovery,
+  ): Promise<void> {
+    this.providerErrorRecoveryCount += 1;
+    const attemptNumber = this.providerErrorRecoveryCount;
+
+    this.logger.warn(
+      `OpenCode recoverable provider error kind=${recovery.kind} sessionId=${sessionId} attempt=${attemptNumber}/${recovery.maxRetries}: ${JSON.stringify(error ?? {})}`,
+    );
+
+    this.runtimeEvents.assistantMessage({
+      sessionId,
+      text: formatOpenCodeProviderErrorRetryNoticeText({
+        kind: recovery.kind,
+        attemptNumber,
+        maxAttempts: recovery.maxRetries,
+      }),
+    });
+
+    // Keep partial output and visible queued follow-ups, but suppress trailing
+    // events from the rejected assistant message before submitting the
+    // invisible recovery prompt at the front of the queue.
+    this.suppressAssistantOutputUntilNextPrompt = true;
+    this.inFlight = false;
+    this.finalizedAssistantTurn = null;
+    this.clearAllExecuteToolProgress();
+
+    const queuedId = this.prompts.enqueue({
+      text: recovery.promptText,
+      visibleInTranscript: false,
+    });
+    this.prompts.prioritize(queuedId);
+
+    await this.drainQueuedPrompts();
   }
 
   /**
@@ -3645,9 +3702,10 @@ export class OpenCodeServerHarness
     this.providerRateLimitRetryTimer = null;
   }
 
-  private clearProviderRateLimitRetryState(): void {
+  private clearProviderErrorRecoveryState(): void {
     this.clearProviderRateLimitRetryTimer();
     this.providerRateLimitRetryCount = 0;
+    this.providerErrorRecoveryCount = 0;
   }
 
   private frontloadProviderRateLimitContinueIfQueued(): void {
@@ -4048,8 +4106,10 @@ export class OpenCodeServerHarness
     this.inFlight = false;
     this.finalizedAssistantTurn = null;
     // A completed turn means the model recovered past any prior rate-limit
-    // hop; reset so a later 429 gets a fresh automatic-retry budget.
+    // or provider-error hop; reset so a later failure gets a fresh bounded
+    // automatic-retry budget.
     this.providerRateLimitRetryCount = 0;
+    this.providerErrorRecoveryCount = 0;
     this.clearAllExecuteToolProgress({ keepBackgroundWatchdogs: true });
 
     if (sessionId) {

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
@@ -1536,6 +1536,7 @@ export class OpenCodeServerHarness
   private providerRateLimitRetryCount = 0;
   private providerErrorRecoveryCount = 0;
   private providerErrorRecoveryQueuedPromptId: string | null = null;
+  private ignoreNextProviderRecoverySessionIdle = false;
   private currentWorkflowPhase: string | null = null;
   // Most recent packaged workflow skill loaded by the primary session's agent
   // via the OpenCode skill tool. Drives per-prompt agent selection so plan-mode
@@ -3507,6 +3508,9 @@ export class OpenCodeServerHarness
     const statusType = asString(status?.type);
 
     if (statusType === 'busy' || statusType === 'retry') {
+      // If OpenCode omitted the paired session.idle event, do not let a stale
+      // guard consume the retry's eventual idle transition.
+      this.ignoreNextProviderRecoverySessionIdle = false;
       this.inFlight = true;
       // Status transitions prove the session is alive (e.g. a provider retry
       // loop), but not that the turn's loop advanced — a steer awaiting
@@ -3517,7 +3521,7 @@ export class OpenCodeServerHarness
     }
 
     if (statusType === 'idle') {
-      if (await this.drainProviderErrorRecoveryAfterIdle()) {
+      if (await this.drainProviderErrorRecoveryAfterIdle('session_status')) {
         return;
       }
 
@@ -3548,7 +3552,12 @@ export class OpenCodeServerHarness
       this.sessionId = sessionId;
     }
 
-    if (await this.drainProviderErrorRecoveryAfterIdle()) {
+    if (this.ignoreNextProviderRecoverySessionIdle) {
+      this.ignoreNextProviderRecoverySessionIdle = false;
+      return;
+    }
+
+    if (await this.drainProviderErrorRecoveryAfterIdle('session_idle')) {
       return;
     }
 
@@ -3730,9 +3739,12 @@ export class OpenCodeServerHarness
     this.providerRateLimitRetryCount = 0;
     this.providerErrorRecoveryCount = 0;
     this.providerErrorRecoveryQueuedPromptId = null;
+    this.ignoreNextProviderRecoverySessionIdle = false;
   }
 
-  private async drainProviderErrorRecoveryAfterIdle(): Promise<boolean> {
+  private async drainProviderErrorRecoveryAfterIdle(
+    source: 'session_status' | 'session_idle',
+  ): Promise<boolean> {
     const queuedPromptId = this.providerErrorRecoveryQueuedPromptId;
 
     if (!queuedPromptId) {
@@ -3743,6 +3755,10 @@ export class OpenCodeServerHarness
     // not submit the retry until that idle boundary or prompt_async can append
     // it to the dying run without starting a fresh model loop.
     this.providerErrorRecoveryQueuedPromptId = null;
+    // OpenCode 1.17 emits session.status(idle) followed by session.idle for a
+    // single transition. Consume that paired legacy event exactly once so it
+    // cannot finish the recovery turn that is about to start.
+    this.ignoreNextProviderRecoverySessionIdle = source === 'session_status';
     this.inFlight = false;
     this.prompts.prioritize(queuedPromptId);
     await this.drainQueuedPrompts();

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-error-recovery.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-error-recovery.test.ts
@@ -35,6 +35,18 @@ describe('getOpenCodeProviderErrorRecovery', () => {
     ).toMatchObject({ kind: 'provider_error', maxRetries: 1 });
   });
 
+  it('classifies native ContentFilterError payloads as policy refusals', () => {
+    const recovery = getOpenCodeProviderErrorRecovery({
+      name: 'ContentFilterError',
+      data: {
+        message: "The response was blocked by the provider's content filter",
+      },
+    });
+
+    expect(recovery).toMatchObject({ kind: 'policy_refusal', maxRetries: 2 });
+    expect(recovery?.promptText).toContain('Continue the legitimate task');
+  });
+
   it('does not retry explicit non-retryable configuration errors', () => {
     expect(
       getOpenCodeProviderErrorRecovery({

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-error-recovery.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-error-recovery.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { getOpenCodeProviderErrorRecovery } from './provider-error-recovery';
+
+describe('getOpenCodeProviderErrorRecovery', () => {
+  it('detects an UnknownError-wrapped cyber policy refusal', () => {
+    const recovery = getOpenCodeProviderErrorRecovery({
+      name: 'UnknownError',
+      data: {
+        message: JSON.stringify({
+          type: 'error',
+          error: {
+            type: 'invalid_request',
+            code: 'cyber_policy',
+            message:
+              'This content was flagged for possible cybersecurity risk.',
+          },
+        }),
+      },
+    });
+
+    expect(recovery).toMatchObject({ kind: 'policy_refusal', maxRetries: 2 });
+    expect(recovery?.promptText).toContain('Continue the legitimate task');
+    expect(recovery?.promptText).toContain(
+      'Do not attempt to bypass the policy',
+    );
+  });
+
+  it('treats unknown provider errors as recoverable once', () => {
+    expect(
+      getOpenCodeProviderErrorRecovery({
+        name: 'UnknownError',
+        data: { message: 'Upstream connection closed unexpectedly.' },
+      }),
+    ).toMatchObject({ kind: 'provider_error', maxRetries: 1 });
+  });
+
+  it('does not retry explicit non-retryable configuration errors', () => {
+    expect(
+      getOpenCodeProviderErrorRecovery({
+        name: 'APIError',
+        data: {
+          message: 'The selected model is not available in your region.',
+          statusCode: 403,
+          isRetryable: false,
+        },
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-error-recovery.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-error-recovery.ts
@@ -1,0 +1,198 @@
+import { asFiniteNumber, asRecord, asString } from '@roomote/types';
+
+const DEFAULT_OPENCODE_PROVIDER_ERROR_MAX_RETRIES = 1;
+const DEFAULT_OPENCODE_POLICY_REFUSAL_MAX_RETRIES = 2;
+
+const OPENCODE_PROVIDER_ERROR_RETRY_PROMPT_TEXT = [
+  'Continue. The previous model request failed due to a provider error and was automatically retried.',
+  'Resume from where you left off without restating the provider error.',
+].join(' ');
+
+const OPENCODE_POLICY_REFUSAL_RETRY_PROMPT_TEXT = [
+  'Continue the legitimate task. The previous model request was declined by the provider safety policy.',
+  'Do not attempt to bypass the policy or reproduce sensitive payloads, exploit strings, or operational instructions that may have triggered it.',
+  'Use a high-level summary or safer abstraction where needed, then resume from where you left off.',
+].join(' ');
+
+export type OpenCodeProviderErrorRecovery = {
+  kind: 'policy_refusal' | 'provider_error';
+  maxRetries: number;
+  promptText: string;
+};
+
+const POLICY_CODES = new Set([
+  'cyber_policy',
+  'content_policy',
+  'content_policy_violation',
+  'safety_policy',
+]);
+
+const TERMINAL_CODES = new Set([
+  'authentication_error',
+  'billing_error',
+  'context_length_exceeded',
+  'forbidden',
+  'insufficient_quota',
+  'invalid_api_key',
+  'invalid_model',
+  'model_not_found',
+  'permission_denied',
+  'unauthorized',
+]);
+
+const TERMINAL_STATUS_CODES = new Set([400, 401, 403, 404, 422]);
+
+function collectProviderErrorValues(error: unknown): unknown[] {
+  const pending: Array<{ value: unknown; depth: number }> = [
+    { value: error, depth: 0 },
+  ];
+  const collected: unknown[] = [];
+  const seen = new Set<object>();
+
+  while (pending.length > 0) {
+    const current = pending.shift();
+
+    if (!current || current.depth > 4) {
+      continue;
+    }
+
+    const { value, depth } = current;
+    collected.push(value);
+
+    if (typeof value === 'string') {
+      try {
+        pending.push({ value: JSON.parse(value) as unknown, depth: depth + 1 });
+      } catch {
+        // Not JSON; the raw text is still useful for marker detection below.
+      }
+      continue;
+    }
+
+    if (!value || typeof value !== 'object' || seen.has(value)) {
+      continue;
+    }
+
+    seen.add(value);
+
+    for (const nested of Object.values(value)) {
+      pending.push({ value: nested, depth: depth + 1 });
+    }
+  }
+
+  return collected;
+}
+
+function normalizeCode(value: unknown): string | undefined {
+  const code = asString(value)?.trim().toLowerCase();
+  return code || undefined;
+}
+
+function isPolicyRefusal(values: unknown[]): boolean {
+  for (const value of values) {
+    const record = asRecord(value);
+    const code = normalizeCode(record?.code);
+
+    if (code && POLICY_CODES.has(code)) {
+      return true;
+    }
+
+    if (typeof value === 'string') {
+      const lower = value.toLowerCase();
+
+      if (
+        lower.includes('cyber_policy') ||
+        lower.includes('content_policy_violation') ||
+        lower.includes('flagged for possible cybersecurity risk') ||
+        lower.includes('declined by the provider safety policy')
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function isExplicitlyTerminal(values: unknown[]): boolean {
+  for (const value of values) {
+    const record = asRecord(value);
+
+    if (record?.isRetryable === false) {
+      return true;
+    }
+
+    const statusCode =
+      asFiniteNumber(record?.statusCode) ?? asFiniteNumber(record?.status);
+
+    if (statusCode !== undefined && TERMINAL_STATUS_CODES.has(statusCode)) {
+      return true;
+    }
+
+    const code = normalizeCode(record?.code);
+
+    if (code && TERMINAL_CODES.has(code)) {
+      return true;
+    }
+
+    if (typeof value === 'string') {
+      const lower = value.toLowerCase();
+
+      if (
+        lower.includes('api key is missing') ||
+        lower.includes('invalid api key') ||
+        lower.includes('authentication failed') ||
+        lower.includes('model is not available') ||
+        lower.includes('model not found') ||
+        lower.includes('maximum context length') ||
+        lower.includes('insufficient quota')
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Provider session errors are recoverable by default because they normally
+ * invalidate one model turn, not the OpenCode session or Roomote task. Keep a
+ * small bounded retry budget, while explicit auth/configuration failures fail
+ * immediately instead of burning requests that cannot succeed.
+ */
+export function getOpenCodeProviderErrorRecovery(
+  error: unknown,
+): OpenCodeProviderErrorRecovery | null {
+  const values = collectProviderErrorValues(error);
+
+  if (isPolicyRefusal(values)) {
+    return {
+      kind: 'policy_refusal',
+      maxRetries: DEFAULT_OPENCODE_POLICY_REFUSAL_MAX_RETRIES,
+      promptText: OPENCODE_POLICY_REFUSAL_RETRY_PROMPT_TEXT,
+    };
+  }
+
+  if (isExplicitlyTerminal(values)) {
+    return null;
+  }
+
+  return {
+    kind: 'provider_error',
+    maxRetries: DEFAULT_OPENCODE_PROVIDER_ERROR_MAX_RETRIES,
+    promptText: OPENCODE_PROVIDER_ERROR_RETRY_PROMPT_TEXT,
+  };
+}
+
+export function formatOpenCodeProviderErrorRetryNoticeText(options: {
+  kind: OpenCodeProviderErrorRecovery['kind'];
+  attemptNumber: number;
+  maxAttempts: number;
+}): string {
+  const label =
+    options.kind === 'policy_refusal'
+      ? 'Provider safety refusal'
+      : 'Provider error';
+
+  return `${label}; automatically retrying the turn (attempt ${options.attemptNumber}/${options.maxAttempts}).`;
+}

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-error-recovery.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-error-recovery.ts
@@ -91,8 +91,9 @@ function isPolicyRefusal(values: unknown[]): boolean {
   for (const value of values) {
     const record = asRecord(value);
     const code = normalizeCode(record?.code);
+    const name = normalizeCode(record?.name);
 
-    if (code && POLICY_CODES.has(code)) {
+    if ((code && POLICY_CODES.has(code)) || name === 'contentfiltererror') {
       return true;
     }
 
@@ -103,6 +104,7 @@ function isPolicyRefusal(values: unknown[]): boolean {
         lower.includes('cyber_policy') ||
         lower.includes('content_policy_violation') ||
         lower.includes('flagged for possible cybersecurity risk') ||
+        lower.includes("blocked by the provider's content filter") ||
         lower.includes('declined by the provider safety policy')
       ) {
         return true;


### PR DESCRIPTION
## Summary

- treat most OpenCode provider `session.error` events as recoverable turn failures
- queue recovery until the failed OpenCode runner reaches idle, consume OpenCode’s paired idle notifications once, then start a fresh model loop
- retry unknown or transient provider errors once while preserving queued follow-ups
- retry safety-policy refusals twice with explicit safer framing that does not attempt to bypass provider policy
- recognize both provider policy codes and OpenCode's native `ContentFilterError`
- keep explicit authentication, configuration, quota, unavailable-model, and context errors terminal
- retain the existing specialized rate-limit backoff behavior

## Root cause

The OpenCode harness treated every non-rate-limit provider session error as a task abort. A single recoverable provider response could therefore terminate the enclosing Roomote run, including one-shot automation runs that are not snapshot-resumable.

OpenCode also reports `session.error` before the failed runner reaches idle. Submitting recovery immediately can append the prompt to the dying run without starting another model loop, so recovery now waits for that idle boundary.

## Impact

Transient provider errors and safety-policy refusals now get a bounded in-session recovery attempt instead of immediately ending the Roomote task. Persistent errors still terminate after the retry budget is exhausted, and clearly non-retryable failures fail immediately.

## Validation

- focused OpenCode harness tests (54 tests)
- full worker test suite (1,433 tests)
- worker TypeScript typecheck and lint
- repository pre-push checks, including oxlint, residual lint, fast typecheck, and knip

