### PR TITLE
Promote v0.8.1 to production

### DIFF
--- a/.agents/skills/mock-telegram-testing/SKILL.md
+++ b/.agents/skills/mock-telegram-testing/SKILL.md
@@ -160,7 +160,7 @@ See `references/scenarios.md` for the full user-journey catalog. Common picks:
 - **`unlinked-sender`** — message from an unmapped Telegram user is nudged and dropped
 - **`long-reply-chunking`** — worker reply over 4096 chars splits into multiple messages
 - **`cancel-button`** — callback_query cancels the running job
-- **`routing-confirmation`** — low-confidence route posts a workspace picker; Nevermind is the zero-side-effect live-test path
+- **`routing-confirmation`** — low-confidence route posts a workspace picker; Never mind is the zero-side-effect live-test path
 
 LLM-judged eval scenarios live in `packages/communication/evals/scenarios/` and run via `pnpm --filter @roomote/communication eval:telegram-scenario`.
 

--- a/.agents/skills/mock-telegram-testing/references/scenarios.md
+++ b/.agents/skills/mock-telegram-testing/references/scenarios.md
@@ -117,12 +117,12 @@ When the router is unsure (confidence < 0.95, workspace remapped, or all-reposit
 - Expect: webhook responds `confirmationPending: true`; a compact card "Planning to run this in **{suggested}** — starting in ~5s." with one row of buttons: ✅ Yes (`route_ok:<id>`) and ✖️ Nope (`route_alt:<id>`). Router `fallback` skips the Yes/Nope step and shows the picker directly ("could not confidently pick a workspace") with no auto-start.
 - Click paths:
   - ✅ Yes → callback answered `Starting in {workspace}.`, the card is edited in place to "Starting in **{workspace}**." (keyboard removed), task launched.
-  - ✖️ Nope → the same message is edited into the picker ("Okay — where should I run this?" + one button per workspace + ✖️ Nevermind), re-keyed under a fresh pending-route id so the 5s timer can never fire the suggestion afterwards. The picker waits — no timer.
+  - ✖️ Nope → the same message is edited into the picker ("Okay — where should I run this?" + one button per workspace + ✖️ Never mind), re-keyed under a fresh pending-route id so the 5s timer can never fire the suggestion afterwards. The picker waits — no timer.
   - Picker choice (`route_pick:<id>:<n>`) → same as Yes but with the chosen workspace.
-  - ✖️ Nevermind (`route_no:<id>`) → callback answered `Okay — not starting a task.`, card finalized, nothing launches (the safe path for live testing: Nope → Nevermind).
+  - ✖️ Never mind (`route_no:<id>`) → callback answered `Okay — not starting a task.`, card finalized, nothing launches (the safe path for live testing: Nope → Never mind).
   - No click → the Yes/Nope card auto-starts the suggestion after ~5s (card edited to "Starting in **{workspace}**." when the timer fires); pickers just expire (15-min Redis TTL).
   - Click from a different Telegram user → `Only the requester can choose a workspace for this task.` and the pending choice is NOT consumed.
-- Assert: state `.messages` (card text edited through the stages, final `reply_markup` empty), `.callbackAnswers`; DB `cloud_jobs` for the launch (or its absence after Nevermind).
+- Assert: state `.messages` (card text edited through the stages, final `reply_markup` empty), `.callbackAnswers`; DB `cloud_jobs` for the launch (or its absence after Never mind).
 - Note: the pending choice is one-shot (`GETDEL`) — a second click on a stale card gets `This choice expired — send the request again.` The 5s window is too short to tap from a phone notification; that is intentional — Nope is for users watching the chat, and the started message's cancel button covers everyone else.
 
 ## 16. suggestion-button

--- a/.changeset/recover-provider-turn-errors.md
+++ b/.changeset/recover-provider-turn-errors.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Recover from bounded model-provider turn errors, including safety-policy refusals, without immediately aborting the Roomote task.

--- a/.changeset/recover-provider-turn-errors.md
+++ b/.changeset/recover-provider-turn-errors.md
@@ -1,5 +1,0 @@
----
-'@roomote/web': patch
----
-
-Recover from bounded model-provider turn errors, including safety-policy refusals, without immediately aborting the Roomote task.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This file tracks product releases for Roomote (single monorepo version). Automated release entries are prepended by `pnpm run version`.
 
+## 0.8.1 (2026-07-17)
+
+### Patch changes
+
+- Clarify Review Code wording and section ordering on the Automations settings page so source-code, Slack, manager, and meta automations are easier to scan.
+- Create account and other credential fields no longer block password managers, so 1Password can offer to generate and save passwords on signup.
+- Task log tails again allow intentional `/tmp` paths such as harness and environment log files, while still blocking absolute paths outside that boundary.
+- Spell cancel buttons as **Never mind** (two words) on Slack, Discord, and Telegram task and workspace pickers.
+- Recover from bounded model-provider turn errors, including safety-policy refusals, without immediately aborting the Roomote task.
+- Slack transcript decoding no longer crashes with a stack overflow when a thread contains a long sequence of thread-activity blocks.
+
 ## 0.8.0 (2026-07-17)
 
 ### Minor changes

--- a/apps/api/src/handlers/discord/__tests__/routing-confirmation.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/routing-confirmation.test.ts
@@ -394,7 +394,7 @@ describe('Discord routing confirmation', () => {
       'All repositories',
     );
     expect(buttons.at(-1)).toEqual([
-      expect.objectContaining({ text: 'Nevermind' }),
+      expect.objectContaining({ text: 'Never mind' }),
     ]);
   });
 

--- a/apps/api/src/handlers/discord/routing-confirmation.ts
+++ b/apps/api/src/handlers/discord/routing-confirmation.ts
@@ -33,7 +33,7 @@ const DISCORD_CHANNEL_TYPE_PUBLIC_THREAD = 11;
 const PENDING_ROUTE_TTL_SECONDS = 15 * 60;
 const PENDING_ROUTE_PREFIX = 'discord:pending_route:';
 // Discord supports at most five action rows. Reserve one for All repositories
-// and one for Nevermind so every stored option is also visible and actionable.
+// and one for Never mind so every stored option is also visible and actionable.
 const MAX_ENVIRONMENT_OPTIONS = 3;
 
 type PendingRouteOption = {
@@ -140,7 +140,7 @@ function routeButtons(id: string, options: PendingRouteOption[]) {
         callbackData: `discord:route:${id}:${index}`,
       },
     ]),
-    [{ text: 'Nevermind', callbackData: `discord:route:${id}:cancel` }],
+    [{ text: 'Never mind', callbackData: `discord:route:${id}:cancel` }],
   ];
 }
 

--- a/apps/api/src/handlers/telegram/__tests__/index.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/index.test.ts
@@ -1758,7 +1758,7 @@ describe('Telegram webhook handler', () => {
         buttons: [
           [expect.objectContaining({ text: 'Web App' })],
           [expect.objectContaining({ text: 'All repositories' })],
-          [expect.objectContaining({ text: '✖️ Nevermind' })],
+          [expect.objectContaining({ text: '✖️ Never mind' })],
         ],
       }),
     );
@@ -1976,7 +1976,7 @@ describe('Telegram webhook handler', () => {
           ],
           [
             expect.objectContaining({
-              text: '✖️ Nevermind',
+              text: '✖️ Never mind',
               callbackData: expect.stringMatching(/^route_no:[\w-]+$/),
             }),
           ],
@@ -2079,7 +2079,7 @@ describe('Telegram webhook handler', () => {
     );
   });
 
-  it('dismisses the confirmation without launching when Nevermind is clicked', async () => {
+  it('dismisses the confirmation without launching when Never mind is clicked', async () => {
     mockTelegramLinkedSender('launch-owner-25');
     const pending = JSON.stringify({
       launchOwnerUserId: 'launch-owner-25',

--- a/apps/api/src/handlers/telegram/routing-confirmation.ts
+++ b/apps/api/src/handlers/telegram/routing-confirmation.ts
@@ -228,7 +228,7 @@ function buildPickerButtons(
     ]),
     [
       {
-        text: '✖️ Nevermind',
+        text: '✖️ Never mind',
         callbackData: buildTelegramRouteNoCallbackData(pendingRouteId),
       },
     ],

--- a/apps/web/src/components/settings/automations/AutomationsSettings.render.client.test.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.render.client.test.tsx
@@ -589,6 +589,16 @@ describe('AutomationsSettings', () => {
     expect(screen.queryByText('All source control')).toBeNull();
   });
 
+  it('renders the Source Code and Meta automation sections', async () => {
+    render(<AutomationsSettings />);
+
+    expect(
+      await screen.findByText('Source Code automations'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Meta automations')).toBeInTheDocument();
+    expect(screen.queryByText('Other automations')).toBeNull();
+  });
+
   it('reflects the reviewer all-author setting in the review scope copy', async () => {
     state.settingsQuery.data.reviewer.enabled = true;
     state.settingsQuery.data.reviewer.reviewAllPullRequestAuthors = true;
@@ -598,13 +608,13 @@ describe('AutomationsSettings', () => {
     await openReviewerCard();
 
     expect(
-      screen.getByRole('switch', { name: /review prs from other authors/i }),
+      screen.getByRole('switch', { name: /review prs not created by/i }),
     ).toBeChecked();
     expect(
-      screen.getByText(/all pull requests in connected repositories/),
+      screen.getByText(/Automatically review new PRs and follow-up commits/i),
     ).toBeInTheDocument();
     expect(
-      screen.queryByText(/pull requests opened by Roomote/),
+      screen.queryByText(/Which PRs get reviewed/i),
     ).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/components/settings/automations/AutomationsSettings.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.tsx
@@ -2269,9 +2269,6 @@ export function AutomationsSettings() {
         slackChannelAccessWarnings.channelAutoStartSlackChannels,
       isDirty: isDirty.channelAutoStart,
     });
-  const slackWorkflowLaunchUrl = buildSlackWorkflowLaunchUrl(
-    capabilities?.slackWorkspaceDomain,
-  );
   const showManagerChannelMigrationNote =
     !formState?.managerSlackChannel &&
     new Set(
@@ -4239,45 +4236,6 @@ If unclear, send to manager channel.`}
               })}
             </div>
           </AutomationCard>
-
-          {!slackAutomationsDisabled ? (
-            <Alert variant="light">
-              <Lightbulb className="mt-0.5 size-5 shrink-0 text-foreground" />
-              <AlertTitle>Wanna automate even more?</AlertTitle>
-              <AlertDescription>
-                <div>
-                  <p className="text-muted-foreground">
-                    Just use Slack&apos;s own{' '}
-                    <a
-                      href={slackWorkflowLaunchUrl}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="text-foreground underline underline-offset-4 hover:text-foreground/80"
-                    >
-                      workflows
-                    </a>
-                    , finishing with{' '}
-                    <span className="font-medium text-foreground">
-                      {slackAppMention}
-                    </span>{' '}
-                    mentions, to get it working on whatever you want. Some
-                    ideas:
-                  </p>
-                  <ul className="list-disc space-y-1 pl-5 pt-1 text-sm text-muted-foreground">
-                    <li>
-                      Pipe operational requests from a ticketing system into
-                      Roomote tasks
-                    </li>
-                    <li>
-                      Get diagnostics (or PRs) for bugs posted onto a bugs
-                      channel
-                    </li>
-                    <li>Enable feature flags as requests come in</li>
-                  </ul>
-                </div>
-              </AlertDescription>
-            </Alert>
-          ) : null}
         </div>
       )}
     </div>

--- a/apps/web/src/components/settings/automations/AutomationsSettings.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.tsx
@@ -2181,22 +2181,14 @@ export function AutomationsSettings() {
     commsStatus.data?.invocationIdentities.find(
       (identity) => identity.provider === 'slack',
     ) ?? null;
-  const githubInvocationIdentity =
-    commsStatus.data?.invocationIdentities.find(
-      (identity) => identity.provider === 'github',
-    ) ?? null;
   const slackAppMention =
     slackInvocationIdentity?.mentionText ??
     slackInvocationIdentity?.nativeMention ??
     'the Slack app';
-  const githubAppMention =
-    githubInvocationIdentity?.mentionText ?? 'the GitHub app';
   const channelAutoStartLaunchModeOptions =
     CHANNEL_AUTO_START_LAUNCH_MODE_OPTIONS;
   const showChannelAutoStartLaunchModePicker = false;
   const reviewerIsEnabled = formState?.reviewerEnabled ?? false;
-  const reviewerReviewsAllPrs =
-    formState?.reviewerReviewAllPullRequestAuthors ?? false;
   const conflictResolverIsEnabled =
     formState?.conflictResolverFrequency !== 'off';
   const channelAutoStartIsEnabled = hasConfiguredChannelAutoStartRows(
@@ -2560,6 +2552,711 @@ export function AutomationsSettings() {
         <div className="space-y-4">
           <div className="space-y-3">
             <h2 className="text-base font-semibold text-foreground">
+              Source Code automations
+            </h2>
+
+            <AutomationCard
+              automation={AUTOMATION_DEFINITIONS.reviewer}
+              isOpen={openAutomationIds.has('reviewer')}
+              onOpenChange={(open) => setAutomationOpen('reviewer', open)}
+              iconEnabled={iconEnabled.reviewer}
+              footer={
+                <AutomationFooter
+                  isDirty={isDirty.reviewer}
+                  isPending={
+                    updateMutation.isPending && savingAutomation === 'reviewer'
+                  }
+                  onSave={() => saveAgent('reviewer')}
+                  onReset={() => resetAgent('reviewer')}
+                />
+              }
+            >
+              <div className="space-y-5">
+                <div className="flex items-center gap-2">
+                  <Switch
+                    id="reviewer-enabled"
+                    checked={formState.reviewerEnabled}
+                    onCheckedChange={(reviewerEnabled) =>
+                      setFormState((prev) =>
+                        prev ? { ...prev, reviewerEnabled } : prev,
+                      )
+                    }
+                  />
+                  <Label htmlFor="reviewer-enabled" className="text-sm">
+                    Allow {PRODUCT_NAME} to review PRs
+                  </Label>
+                </div>
+
+                {reviewerIsEnabled ? (
+                  <div className="space-y-6 pt-1">
+                    <div className="flex items-start gap-2">
+                      <Switch
+                        className="mt-1"
+                        checked={formState.reviewerReviewOnCommit}
+                        onCheckedChange={(reviewerReviewOnCommit) =>
+                          setFormState((prev) =>
+                            prev ? { ...prev, reviewerReviewOnCommit } : prev,
+                          )
+                        }
+                      />
+                      <div className="space-y-1">
+                        <p className="text-sm font-medium">
+                          Automatically review new PRs and follow-up commits.
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          Disable to only get reviews by asking @-mentioning{' '}
+                          {PRODUCT_NAME}
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="flex items-start gap-2">
+                      <Switch
+                        className="mt-1"
+                        checked={formState.reviewerReviewDraftPrs}
+                        onCheckedChange={(reviewerReviewDraftPrs) =>
+                          setFormState((prev) =>
+                            prev ? { ...prev, reviewerReviewDraftPrs } : prev,
+                          )
+                        }
+                      />
+                      <div className="space-y-1">
+                        <p className="text-sm font-medium">Review draft PRs</p>
+                        <p className="text-xs text-muted-foreground">
+                          Turn off to only automatically review PRs marked as
+                          ready (and save tokens)
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="flex items-start gap-2">
+                      <Switch
+                        className="mt-1"
+                        aria-label={`Review PRs not created by ${PRODUCT_NAME}`}
+                        checked={formState.reviewerReviewAllPullRequestAuthors}
+                        onCheckedChange={(
+                          reviewerReviewAllPullRequestAuthors,
+                        ) =>
+                          setFormState((prev) =>
+                            prev
+                              ? {
+                                  ...prev,
+                                  reviewerReviewAllPullRequestAuthors,
+                                }
+                              : prev,
+                          )
+                        }
+                      />
+                      <div className="space-y-1">
+                        <p className="text-sm font-medium">
+                          Review PRs not created by {PRODUCT_NAME}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          Include pull requests opened by people or others
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            </AutomationCard>
+
+            <AutomationCard
+              automation={AUTOMATION_DEFINITIONS.conflictResolver}
+              isOpen={openAutomationIds.has('conflictResolver')}
+              onOpenChange={(open) =>
+                setAutomationOpen('conflictResolver', open)
+              }
+              iconEnabled={iconEnabled.conflictResolver}
+              debugSection={renderDebugRunsSection('conflictResolver')}
+              runAction={
+                <BasicTooltip
+                  content={getRunTooltip(
+                    'conflictResolver',
+                    conflictResolverIsEnabled,
+                  )}
+                >
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() =>
+                      triggerMutation.mutate({
+                        automationKey: 'conflict_resolver',
+                      })
+                    }
+                    disabled={isRunDisabled(
+                      'conflictResolver',
+                      conflictResolverIsEnabled,
+                    )}
+                  >
+                    <Play />
+                  </Button>
+                </BasicTooltip>
+              }
+              footer={
+                <AutomationFooter
+                  isDirty={isDirty.conflictResolver}
+                  isPending={
+                    updateMutation.isPending &&
+                    savingAutomation === 'conflictResolver'
+                  }
+                  onSave={() => saveAgent('conflictResolver')}
+                  onReset={() => resetAgent('conflictResolver')}
+                />
+              }
+            >
+              <div className="space-y-5">
+                <Select
+                  value={formState.conflictResolverFrequency}
+                  onValueChange={(value) =>
+                    setFormState((prev) =>
+                      prev
+                        ? {
+                            ...prev,
+                            conflictResolverFrequency:
+                              value as ConflictResolverFrequency,
+                          }
+                        : prev,
+                    )
+                  }
+                >
+                  <SelectTrigger
+                    id="conflict-resolver-frequency"
+                    aria-label="Resolve PR Conflicts schedule"
+                    className="w-full md:w-56"
+                  >
+                    <SelectValue placeholder="Select a schedule" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {CONFLICT_RESOLVER_FREQUENCY_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+
+                {conflictResolverIsEnabled ? (
+                  <div className="space-y-5">
+                    <div className="space-y-2">
+                      <Label htmlFor="conflict-resolver-max-pr-age">
+                        PR age cap
+                      </Label>
+                      <Select
+                        value={String(formState.conflictResolverMaxPrAgeDays)}
+                        onValueChange={(value) =>
+                          setFormState((prev) =>
+                            prev
+                              ? {
+                                  ...prev,
+                                  conflictResolverMaxPrAgeDays: Number(
+                                    value,
+                                  ) as ConflictResolverMaxPrAgeDays,
+                                }
+                              : prev,
+                          )
+                        }
+                      >
+                        <SelectTrigger
+                          id="conflict-resolver-max-pr-age"
+                          aria-label="Resolve PR Conflicts PR age cap"
+                          className="w-full md:w-56"
+                        >
+                          <SelectValue placeholder="Select a cap" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {CONFLICT_RESOLVER_MAX_PR_AGE_OPTIONS.map(
+                            (option) => (
+                              <SelectItem
+                                key={option.value}
+                                value={String(option.value)}
+                              >
+                                {option.label}
+                              </SelectItem>
+                            ),
+                          )}
+                        </SelectContent>
+                      </Select>
+                      <p className="text-xs text-muted-foreground md:max-w-120">
+                        Sets the maximum PR age that Resolve PR Conflicts will
+                        consider. Labeled PRs older than this are skipped.
+                      </p>
+                      {fieldErrors.conflictResolverMaxPrAgeDays ? (
+                        <p className="text-xs text-destructive">
+                          {fieldErrors.conflictResolverMaxPrAgeDays}
+                        </p>
+                      ) : null}
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label htmlFor="conflict-label">Auto-resolve label</Label>
+                      <Input
+                        id="conflict-label"
+                        value={formState.conflictResolverLabel}
+                        onChange={(event) =>
+                          setFormState((prev) =>
+                            prev
+                              ? {
+                                  ...prev,
+                                  conflictResolverLabel: event.target.value,
+                                }
+                              : prev,
+                          )
+                        }
+                        placeholder="roomote:auto-resolve-conflicts"
+                        className="max-w-80"
+                      />
+                      <p className="text-xs text-muted-foreground md:max-w-120">
+                        Make sure this label exists in your repos. It will be
+                        added automatically to all new agent PRs. Remove it
+                        whenever you do not want conflicts resolved.
+                      </p>
+                      {fieldErrors.conflictResolverLabel ? (
+                        <p className="text-xs text-destructive">
+                          {fieldErrors.conflictResolverLabel}
+                        </p>
+                      ) : null}
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label htmlFor="conflict-resolver-instructions">
+                        Additional instructions
+                      </Label>
+                      <Textarea
+                        id="conflict-resolver-instructions"
+                        value={formState.conflictResolverInstructions}
+                        onChange={(event) =>
+                          setFormState((prev) =>
+                            prev
+                              ? {
+                                  ...prev,
+                                  conflictResolverInstructions:
+                                    event.target.value,
+                                }
+                              : prev,
+                          )
+                        }
+                        rows={4}
+                        placeholder="Optional guidance for conflict resolution strategy and priorities"
+                      />
+                      {fieldErrors.conflictResolverInstructions ? (
+                        <p className="text-xs text-destructive">
+                          {fieldErrors.conflictResolverInstructions}
+                        </p>
+                      ) : null}
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            </AutomationCard>
+
+            {(
+              [
+                'ciFailureTriage',
+              ] as const satisfies readonly ScheduleOnlyBackgroundAutomationId[]
+            ).map((automationId) => {
+              const automation = SCHEDULE_ONLY_AUTOMATIONS_BY_ID[automationId];
+              const automationUi =
+                SCHEDULE_ONLY_AUTOMATION_UI_DEFINITIONS[automation.id];
+              const frequency = formState[automation.frequencyField];
+              const isEnabled =
+                scheduleOnlyAutomationEnabledState[automation.id];
+              const blockedReason =
+                scheduleOnlyAutomationBlockedReasons[automation.id];
+              const fieldId = `${automation.automationKey.replaceAll('_', '-')}-frequency`;
+
+              return (
+                <AutomationCard
+                  key={automation.id}
+                  automation={AUTOMATION_DEFINITIONS[automation.id]}
+                  isOpen={openAutomationIds.has(automation.id)}
+                  onOpenChange={(open) =>
+                    setAutomationOpen(automation.id, open)
+                  }
+                  iconEnabled={iconEnabled[automation.id]}
+                  debugSection={renderDebugRunsSection(automation.id)}
+                  runAction={
+                    <BasicTooltip
+                      content={getRunTooltip(
+                        automation.id,
+                        isEnabled,
+                        blockedReason,
+                      )}
+                    >
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() =>
+                          triggerMutation.mutate({
+                            automationKey: automation.automationKey,
+                          })
+                        }
+                        disabled={isRunDisabled(
+                          automation.id,
+                          isEnabled,
+                          blockedReason != null,
+                        )}
+                      >
+                        <Play />
+                      </Button>
+                    </BasicTooltip>
+                  }
+                  footer={
+                    <AutomationFooter
+                      isDirty={isDirty[automation.id]}
+                      isPending={
+                        updateMutation.isPending &&
+                        savingAutomation === automation.id
+                      }
+                      onSave={() => saveAgent(automation.id)}
+                      onReset={() => resetAgent(automation.id)}
+                    />
+                  }
+                >
+                  <ScheduleOnlyAutomationContent
+                    automationLabel={automation.label}
+                    control={
+                      automationUi.control.kind === 'schedule'
+                        ? {
+                            ...automationUi.control,
+                            scheduleOptions:
+                              SCHEDULE_ONLY_AUTOMATION_FREQUENCY_OPTIONS,
+                          }
+                        : automationUi.control
+                    }
+                    details={automationUi.details}
+                    frequency={frequency}
+                    isEnabled={isEnabled}
+                    disabled={false}
+                    fieldId={fieldId}
+                    onFrequencyChange={(nextFrequency) =>
+                      setScheduleOnlyAutomationFrequency(
+                        automation.id,
+                        nextFrequency,
+                      )
+                    }
+                  >
+                    {renderSlackDestinationField({
+                      field:
+                        automation.id === 'securityAuditor'
+                          ? 'securityAuditorSlackChannel'
+                          : automation.id === 'codeQualityAuditor'
+                            ? 'codeQualityAuditorSlackChannel'
+                            : 'ciFailureTriageSlackChannel',
+                      inputId: `${automation.id}-slack-channel`,
+                      label: 'Post follow-up work to this Slack channel',
+                      helperText:
+                        automation.id === 'ciFailureTriage'
+                          ? 'Choose where Roomote should post CI failure triage work.'
+                          : 'Choose where Roomote should post actionable follow-up work.',
+                      savedChannelId:
+                        automation.id === 'securityAuditor'
+                          ? (settingsQuery.data?.settings
+                              .securityAuditorSlackChannelId ?? null)
+                          : automation.id === 'codeQualityAuditor'
+                            ? (settingsQuery.data?.settings
+                                .codeQualityAuditorSlackChannelId ?? null)
+                            : (settingsQuery.data?.settings
+                                .ciFailureTriageSlackChannelId ?? null),
+                      savedDiscordChannelId:
+                        automation.id === 'securityAuditor'
+                          ? (settingsQuery.data?.settings
+                              .securityAuditorDiscordChannelId ?? null)
+                          : automation.id === 'codeQualityAuditor'
+                            ? (settingsQuery.data?.settings
+                                .codeQualityAuditorDiscordChannelId ?? null)
+                            : (settingsQuery.data?.settings
+                                .ciFailureTriageDiscordChannelId ?? null),
+                      warningChannelId:
+                        automation.id === 'securityAuditor'
+                          ? slackChannelAccessWarnings.securityAuditorSlackChannel
+                          : automation.id === 'codeQualityAuditor'
+                            ? slackChannelAccessWarnings.codeQualityAuditorSlackChannel
+                            : slackChannelAccessWarnings.ciFailureTriageSlackChannel,
+                    })}
+                  </ScheduleOnlyAutomationContent>
+                </AutomationCard>
+              );
+            })}
+
+            <ScheduledAutomationCard
+              automation={AUTOMATION_DEFINITIONS.dependabotTriage}
+              isOpen={openAutomationIds.has('dependabotTriage')}
+              onOpenChange={(open) =>
+                setAutomationOpen('dependabotTriage', open)
+              }
+              iconEnabled={iconEnabled.dependabotTriage}
+              debugSection={renderDebugRunsSection('dependabotTriage')}
+              runTooltip={getRunTooltip(
+                'dependabotTriage',
+                dependabotTriageIsEnabled,
+                dependabotTriageBlockedReason,
+              )}
+              runDisabled={isRunDisabled(
+                'dependabotTriage',
+                dependabotTriageIsEnabled,
+                dependabotTriageBlockedReason != null,
+              )}
+              onRun={() =>
+                triggerMutation.mutate({ automationKey: 'dependabot_triage' })
+              }
+              isDirty={isDirty.dependabotTriage}
+              isPending={
+                updateMutation.isPending &&
+                savingAutomation === 'dependabotTriage'
+              }
+              onSave={() => saveAgent('dependabotTriage')}
+              onReset={() => resetAgent('dependabotTriage')}
+              frequency={formState.dependabotTriageFrequency}
+              onFrequencyChange={(frequency) =>
+                setFormState((prev) =>
+                  prev
+                    ? {
+                        ...prev,
+                        dependabotTriageFrequency: frequency,
+                      }
+                    : prev,
+                )
+              }
+              scheduleOptions={
+                SENTRY_TRIAGE_FREQUENCY_OPTIONS as Array<{
+                  value: DependabotTriageFrequency;
+                  label: string;
+                }>
+              }
+              selectId="dependabot-triage-frequency"
+              selectAriaLabel="Triage Dependabot Alerts schedule"
+            >
+              <div className="space-y-5">
+                {dependabotTriageIsEnabled
+                  ? renderSlackDestinationField({
+                      field: 'dependabotTriageSlackChannel',
+                      inputId: 'dependabot-triage-slack-channel',
+                      label: 'Post follow-up work to this Slack channel',
+                      helperText:
+                        'Choose where Roomote should post actionable Dependabot follow-up work.',
+                      savedChannelId:
+                        settingsQuery.data?.settings
+                          .dependabotTriageSlackChannelId ?? null,
+                      savedDiscordChannelId:
+                        settingsQuery.data?.settings
+                          .dependabotTriageDiscordChannelId ?? null,
+                      warningChannelId:
+                        slackChannelAccessWarnings.dependabotTriageSlackChannel,
+                    })
+                  : null}
+
+                <p className="text-xs text-muted-foreground md:max-w-160">
+                  Scans current open Dependabot alerts across active
+                  repositories and suggests tightly scoped dependency update
+                  tasks instead of opening PRs directly.
+                </p>
+              </div>
+            </ScheduledAutomationCard>
+
+            <ScheduledAutomationCard
+              automation={AUTOMATION_DEFINITIONS.codeqlTriage}
+              isOpen={openAutomationIds.has('codeqlTriage')}
+              onOpenChange={(open) => setAutomationOpen('codeqlTriage', open)}
+              iconEnabled={iconEnabled.codeqlTriage}
+              debugSection={renderDebugRunsSection('codeqlTriage')}
+              runTooltip={getRunTooltip(
+                'codeqlTriage',
+                codeqlTriageIsEnabled,
+                codeqlTriageBlockedReason,
+              )}
+              runDisabled={isRunDisabled(
+                'codeqlTriage',
+                codeqlTriageIsEnabled,
+                codeqlTriageBlockedReason != null,
+              )}
+              onRun={() =>
+                triggerMutation.mutate({ automationKey: 'codeql_triage' })
+              }
+              isDirty={isDirty.codeqlTriage}
+              isPending={
+                updateMutation.isPending && savingAutomation === 'codeqlTriage'
+              }
+              onSave={() => saveAgent('codeqlTriage')}
+              onReset={() => resetAgent('codeqlTriage')}
+              frequency={formState.codeqlTriageFrequency}
+              onFrequencyChange={(frequency) =>
+                setFormState((prev) =>
+                  prev
+                    ? {
+                        ...prev,
+                        codeqlTriageFrequency: frequency,
+                      }
+                    : prev,
+                )
+              }
+              scheduleOptions={
+                SENTRY_TRIAGE_FREQUENCY_OPTIONS as Array<{
+                  value: CodeqlTriageFrequency;
+                  label: string;
+                }>
+              }
+              selectId="codeql-triage-frequency"
+              selectAriaLabel="Triage CodeQL Alerts schedule"
+            >
+              <div className="space-y-5">
+                {codeqlTriageIsEnabled
+                  ? renderSlackDestinationField({
+                      field: 'codeqlTriageSlackChannel',
+                      inputId: 'codeql-triage-slack-channel',
+                      label: 'Post follow-up work to this Slack channel',
+                      helperText:
+                        'Choose where Roomote should post actionable CodeQL follow-up work.',
+                      savedChannelId:
+                        settingsQuery.data?.settings
+                          .codeqlTriageSlackChannelId ?? null,
+                      savedDiscordChannelId:
+                        settingsQuery.data?.settings
+                          .codeqlTriageDiscordChannelId ?? null,
+                      warningChannelId:
+                        slackChannelAccessWarnings.codeqlTriageSlackChannel,
+                    })
+                  : null}
+
+                <p className="text-xs text-muted-foreground md:max-w-160">
+                  Scans current open code-scanning/CodeQL alerts across active
+                  repositories and launches implement-changes follow-up tasks
+                  instead of opening PRs in the scan itself.
+                </p>
+              </div>
+            </ScheduledAutomationCard>
+
+            {(
+              [
+                'codeQualityAuditor',
+                'securityAuditor',
+              ] as const satisfies readonly ScheduleOnlyBackgroundAutomationId[]
+            ).map((automationId) => {
+              const automation = SCHEDULE_ONLY_AUTOMATIONS_BY_ID[automationId];
+              const automationUi =
+                SCHEDULE_ONLY_AUTOMATION_UI_DEFINITIONS[automation.id];
+              const frequency = formState[automation.frequencyField];
+              const isEnabled =
+                scheduleOnlyAutomationEnabledState[automation.id];
+              const blockedReason =
+                scheduleOnlyAutomationBlockedReasons[automation.id];
+              const fieldId = `${automation.automationKey.replaceAll('_', '-')}-frequency`;
+
+              return (
+                <AutomationCard
+                  key={automation.id}
+                  automation={AUTOMATION_DEFINITIONS[automation.id]}
+                  isOpen={openAutomationIds.has(automation.id)}
+                  onOpenChange={(open) =>
+                    setAutomationOpen(automation.id, open)
+                  }
+                  iconEnabled={iconEnabled[automation.id]}
+                  debugSection={renderDebugRunsSection(automation.id)}
+                  runAction={
+                    <BasicTooltip
+                      content={getRunTooltip(
+                        automation.id,
+                        isEnabled,
+                        blockedReason,
+                      )}
+                    >
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() =>
+                          triggerMutation.mutate({
+                            automationKey: automation.automationKey,
+                          })
+                        }
+                        disabled={isRunDisabled(
+                          automation.id,
+                          isEnabled,
+                          blockedReason != null,
+                        )}
+                      >
+                        <Play />
+                      </Button>
+                    </BasicTooltip>
+                  }
+                  footer={
+                    <AutomationFooter
+                      isDirty={isDirty[automation.id]}
+                      isPending={
+                        updateMutation.isPending &&
+                        savingAutomation === automation.id
+                      }
+                      onSave={() => saveAgent(automation.id)}
+                      onReset={() => resetAgent(automation.id)}
+                    />
+                  }
+                >
+                  <ScheduleOnlyAutomationContent
+                    automationLabel={automation.label}
+                    control={
+                      automationUi.control.kind === 'schedule'
+                        ? {
+                            ...automationUi.control,
+                            scheduleOptions:
+                              SCHEDULE_ONLY_AUTOMATION_FREQUENCY_OPTIONS,
+                          }
+                        : automationUi.control
+                    }
+                    details={automationUi.details}
+                    frequency={frequency}
+                    isEnabled={isEnabled}
+                    disabled={false}
+                    fieldId={fieldId}
+                    onFrequencyChange={(nextFrequency) =>
+                      setScheduleOnlyAutomationFrequency(
+                        automation.id,
+                        nextFrequency,
+                      )
+                    }
+                  >
+                    {renderSlackDestinationField({
+                      field:
+                        automation.id === 'securityAuditor'
+                          ? 'securityAuditorSlackChannel'
+                          : automation.id === 'codeQualityAuditor'
+                            ? 'codeQualityAuditorSlackChannel'
+                            : 'ciFailureTriageSlackChannel',
+                      inputId: `${automation.id}-slack-channel`,
+                      label: 'Post follow-up work to this Slack channel',
+                      helperText:
+                        automation.id === 'ciFailureTriage'
+                          ? 'Choose where Roomote should post CI failure triage work.'
+                          : 'Choose where Roomote should post actionable follow-up work.',
+                      savedChannelId:
+                        automation.id === 'securityAuditor'
+                          ? (settingsQuery.data?.settings
+                              .securityAuditorSlackChannelId ?? null)
+                          : automation.id === 'codeQualityAuditor'
+                            ? (settingsQuery.data?.settings
+                                .codeQualityAuditorSlackChannelId ?? null)
+                            : (settingsQuery.data?.settings
+                                .ciFailureTriageSlackChannelId ?? null),
+                      savedDiscordChannelId:
+                        automation.id === 'securityAuditor'
+                          ? (settingsQuery.data?.settings
+                              .securityAuditorDiscordChannelId ?? null)
+                          : automation.id === 'codeQualityAuditor'
+                            ? (settingsQuery.data?.settings
+                                .codeQualityAuditorDiscordChannelId ?? null)
+                            : (settingsQuery.data?.settings
+                                .ciFailureTriageDiscordChannelId ?? null),
+                      warningChannelId:
+                        automation.id === 'securityAuditor'
+                          ? slackChannelAccessWarnings.securityAuditorSlackChannel
+                          : automation.id === 'codeQualityAuditor'
+                            ? slackChannelAccessWarnings.codeQualityAuditorSlackChannel
+                            : slackChannelAccessWarnings.ciFailureTriageSlackChannel,
+                    })}
+                  </ScheduleOnlyAutomationContent>
+                </AutomationCard>
+              );
+            })}
+
+            <h2 className="pt-2 text-base font-semibold text-foreground">
               Slack automations
             </h2>
 
@@ -2923,454 +3620,181 @@ export function AutomationsSettings() {
             </div>
           </AutomationCard>
 
-          <>
-            <AutomationCard
-              automation={AUTOMATION_DEFINITIONS.sentryTriage}
-              isOpen={openAutomationIds.has('sentryTriage')}
-              onOpenChange={(open) => setAutomationOpen('sentryTriage', open)}
-              iconEnabled={iconEnabled.sentryTriage}
-              debugSection={renderDebugRunsSection('sentryTriage')}
-              runAction={
-                <BasicTooltip
-                  content={getRunTooltip(
+          <AutomationCard
+            automation={AUTOMATION_DEFINITIONS.sentryTriage}
+            isOpen={openAutomationIds.has('sentryTriage')}
+            onOpenChange={(open) => setAutomationOpen('sentryTriage', open)}
+            iconEnabled={iconEnabled.sentryTriage}
+            debugSection={renderDebugRunsSection('sentryTriage')}
+            runAction={
+              <BasicTooltip
+                content={getRunTooltip(
+                  'sentryTriage',
+                  sentryTriageIsEnabled,
+                  sentryTriageBlockedReason,
+                )}
+              >
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() =>
+                    triggerMutation.mutate({ automationKey: 'sentry_triage' })
+                  }
+                  disabled={isRunDisabled(
                     'sentryTriage',
                     sentryTriageIsEnabled,
-                    sentryTriageBlockedReason,
+                    sentryTriageBlockedReason != null,
                   )}
                 >
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() =>
-                      triggerMutation.mutate({ automationKey: 'sentry_triage' })
-                    }
-                    disabled={isRunDisabled(
-                      'sentryTriage',
-                      sentryTriageIsEnabled,
-                      sentryTriageBlockedReason != null,
-                    )}
-                  >
-                    <Play />
-                  </Button>
-                </BasicTooltip>
-              }
-              footer={
-                <AutomationFooter
-                  isDirty={isDirty.sentryTriage}
-                  isPending={
-                    updateMutation.isPending &&
-                    savingAutomation === 'sentryTriage'
-                  }
-                  saveDisabled={sentryTriageSaveDisabled}
-                  onSave={() => saveAgent('sentryTriage')}
-                  onReset={() => resetAgent('sentryTriage')}
-                />
-              }
-            >
-              <div className="space-y-5">
-                <Select
-                  value={formState.sentryTriageFrequency}
-                  onValueChange={(value) => {
-                    const frequency = value as SentryTriageFrequency;
+                  <Play />
+                </Button>
+              </BasicTooltip>
+            }
+            footer={
+              <AutomationFooter
+                isDirty={isDirty.sentryTriage}
+                isPending={
+                  updateMutation.isPending &&
+                  savingAutomation === 'sentryTriage'
+                }
+                saveDisabled={sentryTriageSaveDisabled}
+                onSave={() => saveAgent('sentryTriage')}
+                onReset={() => resetAgent('sentryTriage')}
+              />
+            }
+          >
+            <div className="space-y-5">
+              <Select
+                value={formState.sentryTriageFrequency}
+                onValueChange={(value) => {
+                  const frequency = value as SentryTriageFrequency;
 
-                    if (
-                      !canSelectSentryTriageFrequency({
-                        sentryConnected: sentryConnected,
-                        frequency,
-                      })
-                    ) {
-                      toast.error(
-                        'Configure Sentry in Settings > Integrations before enabling Triage Sentry Issues.',
-                      );
-                      return;
-                    }
-
-                    setFormState((prev) =>
-                      prev
-                        ? {
-                            ...prev,
-                            sentryTriageFrequency: frequency,
-                          }
-                        : prev,
+                  if (
+                    !canSelectSentryTriageFrequency({
+                      sentryConnected: sentryConnected,
+                      frequency,
+                    })
+                  ) {
+                    toast.error(
+                      'Configure Sentry in Settings > Integrations before enabling Triage Sentry Issues.',
                     );
-                  }}
-                >
-                  <SelectTrigger
-                    id="sentry-triage-frequency"
-                    aria-label="Triage Sentry Issues schedule"
-                    className="w-full md:w-56"
-                  >
-                    <SelectValue placeholder="Select a schedule" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {SENTRY_TRIAGE_FREQUENCY_OPTIONS.map((option) => (
-                      <SelectItem
-                        key={option.value}
-                        value={option.value}
-                        disabled={
-                          !canSelectSentryTriageFrequency({
-                            sentryConnected: sentryConnected,
-                            frequency: option.value,
-                          })
-                        }
-                      >
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-
-                {!sentryConnected ? (
-                  <Alert variant="light" className="md:max-w-160">
-                    <AlertCircle className="mt-0.5 size-4 shrink-0" />
-                    <AlertTitle>Connect Sentry first</AlertTitle>
-                    <AlertDescription>
-                      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-                        <span>
-                          Connect the workspace Sentry integration before
-                          enabling scheduled Sentry triage.
-                        </span>
-                        <Button asChild size="sm" variant="outline">
-                          <a
-                            href={`${SETTINGS_PATHS.integrations}?highlight=sentry-mcp`}
-                          >
-                            Configure Sentry
-                          </a>
-                        </Button>
-                      </div>
-                    </AlertDescription>
-                  </Alert>
-                ) : null}
-
-                {sentryTriageIsEnabled ? (
-                  <div className="space-y-5">
-                    {renderSlackDestinationField({
-                      field: 'sentryTriageSlackChannel',
-                      inputId: 'sentry-triage-slack-channel',
-                      label: 'Post follow-up work to this Slack channel',
-                      helperText:
-                        'Choose where Roomote should post actionable Sentry follow-up work.',
-                      savedChannelId:
-                        settingsQuery.data?.settings
-                          .sentryTriageSlackChannelId ?? null,
-                      savedDiscordChannelId:
-                        settingsQuery.data?.settings
-                          .sentryTriageDiscordChannelId ?? null,
-                      warningChannelId:
-                        slackChannelAccessWarnings.sentryTriageSlackChannel,
-                    })}
-
-                    <p className="text-xs text-muted-foreground md:max-w-160">
-                      Requires Sentry to be configured in Settings &gt;
-                      Integrations.
-                    </p>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="sentry-triage-projects">
-                        Project slugs
-                      </Label>
-                      <Textarea
-                        id="sentry-triage-projects"
-                        value={formState.sentryTriageProjectSlugs}
-                        onChange={(event) =>
-                          setFormState((prev) =>
-                            prev
-                              ? {
-                                  ...prev,
-                                  sentryTriageProjectSlugs: event.target.value,
-                                }
-                              : prev,
-                          )
-                        }
-                        rows={3}
-                        placeholder="Optional, one Sentry project slug per line"
-                      />
-                      <p className="text-xs text-muted-foreground md:max-w-160">
-                        Leave blank to scan all projects available to the Sentry
-                        token.
-                      </p>
-                      {fieldErrors.sentryTriageProjectSlugs ? (
-                        <p className="text-xs text-destructive">
-                          {fieldErrors.sentryTriageProjectSlugs}
-                        </p>
-                      ) : null}
-                    </div>
-                  </div>
-                ) : null}
-              </div>
-            </AutomationCard>
-
-            <ScheduledAutomationCard
-              automation={AUTOMATION_DEFINITIONS.dependabotTriage}
-              isOpen={openAutomationIds.has('dependabotTriage')}
-              onOpenChange={(open) =>
-                setAutomationOpen('dependabotTriage', open)
-              }
-              iconEnabled={iconEnabled.dependabotTriage}
-              debugSection={renderDebugRunsSection('dependabotTriage')}
-              runTooltip={getRunTooltip(
-                'dependabotTriage',
-                dependabotTriageIsEnabled,
-                dependabotTriageBlockedReason,
-              )}
-              runDisabled={isRunDisabled(
-                'dependabotTriage',
-                dependabotTriageIsEnabled,
-                dependabotTriageBlockedReason != null,
-              )}
-              onRun={() =>
-                triggerMutation.mutate({ automationKey: 'dependabot_triage' })
-              }
-              isDirty={isDirty.dependabotTriage}
-              isPending={
-                updateMutation.isPending &&
-                savingAutomation === 'dependabotTriage'
-              }
-              onSave={() => saveAgent('dependabotTriage')}
-              onReset={() => resetAgent('dependabotTriage')}
-              frequency={formState.dependabotTriageFrequency}
-              onFrequencyChange={(frequency) =>
-                setFormState((prev) =>
-                  prev
-                    ? {
-                        ...prev,
-                        dependabotTriageFrequency: frequency,
-                      }
-                    : prev,
-                )
-              }
-              scheduleOptions={
-                SENTRY_TRIAGE_FREQUENCY_OPTIONS as Array<{
-                  value: DependabotTriageFrequency;
-                  label: string;
-                }>
-              }
-              selectId="dependabot-triage-frequency"
-              selectAriaLabel="Triage Dependabot Alerts schedule"
-            >
-              <div className="space-y-5">
-                {dependabotTriageIsEnabled
-                  ? renderSlackDestinationField({
-                      field: 'dependabotTriageSlackChannel',
-                      inputId: 'dependabot-triage-slack-channel',
-                      label: 'Post follow-up work to this Slack channel',
-                      helperText:
-                        'Choose where Roomote should post actionable Dependabot follow-up work.',
-                      savedChannelId:
-                        settingsQuery.data?.settings
-                          .dependabotTriageSlackChannelId ?? null,
-                      savedDiscordChannelId:
-                        settingsQuery.data?.settings
-                          .dependabotTriageDiscordChannelId ?? null,
-                      warningChannelId:
-                        slackChannelAccessWarnings.dependabotTriageSlackChannel,
-                    })
-                  : null}
-
-                <p className="text-xs text-muted-foreground md:max-w-160">
-                  Scans current open Dependabot alerts across active
-                  repositories and suggests tightly scoped dependency update
-                  tasks instead of opening PRs directly.
-                </p>
-              </div>
-            </ScheduledAutomationCard>
-
-            <ScheduledAutomationCard
-              automation={AUTOMATION_DEFINITIONS.codeqlTriage}
-              isOpen={openAutomationIds.has('codeqlTriage')}
-              onOpenChange={(open) => setAutomationOpen('codeqlTriage', open)}
-              iconEnabled={iconEnabled.codeqlTriage}
-              debugSection={renderDebugRunsSection('codeqlTriage')}
-              runTooltip={getRunTooltip(
-                'codeqlTriage',
-                codeqlTriageIsEnabled,
-                codeqlTriageBlockedReason,
-              )}
-              runDisabled={isRunDisabled(
-                'codeqlTriage',
-                codeqlTriageIsEnabled,
-                codeqlTriageBlockedReason != null,
-              )}
-              onRun={() =>
-                triggerMutation.mutate({ automationKey: 'codeql_triage' })
-              }
-              isDirty={isDirty.codeqlTriage}
-              isPending={
-                updateMutation.isPending && savingAutomation === 'codeqlTriage'
-              }
-              onSave={() => saveAgent('codeqlTriage')}
-              onReset={() => resetAgent('codeqlTriage')}
-              frequency={formState.codeqlTriageFrequency}
-              onFrequencyChange={(frequency) =>
-                setFormState((prev) =>
-                  prev
-                    ? {
-                        ...prev,
-                        codeqlTriageFrequency: frequency,
-                      }
-                    : prev,
-                )
-              }
-              scheduleOptions={
-                SENTRY_TRIAGE_FREQUENCY_OPTIONS as Array<{
-                  value: CodeqlTriageFrequency;
-                  label: string;
-                }>
-              }
-              selectId="codeql-triage-frequency"
-              selectAriaLabel="Triage CodeQL Alerts schedule"
-            >
-              <div className="space-y-5">
-                {codeqlTriageIsEnabled
-                  ? renderSlackDestinationField({
-                      field: 'codeqlTriageSlackChannel',
-                      inputId: 'codeql-triage-slack-channel',
-                      label: 'Post follow-up work to this Slack channel',
-                      helperText:
-                        'Choose where Roomote should post actionable CodeQL follow-up work.',
-                      savedChannelId:
-                        settingsQuery.data?.settings
-                          .codeqlTriageSlackChannelId ?? null,
-                      savedDiscordChannelId:
-                        settingsQuery.data?.settings
-                          .codeqlTriageDiscordChannelId ?? null,
-                      warningChannelId:
-                        slackChannelAccessWarnings.codeqlTriageSlackChannel,
-                    })
-                  : null}
-
-                <p className="text-xs text-muted-foreground md:max-w-160">
-                  Scans current open code-scanning/CodeQL alerts across active
-                  repositories and launches implement-changes follow-up tasks
-                  instead of opening PRs in the scan itself.
-                </p>
-              </div>
-            </ScheduledAutomationCard>
-
-            {SCHEDULE_ONLY_BACKGROUND_AUTOMATION_LIST.map((automation) => {
-              const automationUi =
-                SCHEDULE_ONLY_AUTOMATION_UI_DEFINITIONS[automation.id];
-              const frequency = formState[automation.frequencyField];
-              const isEnabled =
-                scheduleOnlyAutomationEnabledState[automation.id];
-              const blockedReason =
-                scheduleOnlyAutomationBlockedReasons[automation.id];
-              const fieldId = `${automation.automationKey.replaceAll('_', '-')}-frequency`;
-
-              return (
-                <AutomationCard
-                  key={automation.id}
-                  automation={AUTOMATION_DEFINITIONS[automation.id]}
-                  isOpen={openAutomationIds.has(automation.id)}
-                  onOpenChange={(open) =>
-                    setAutomationOpen(automation.id, open)
+                    return;
                   }
-                  iconEnabled={iconEnabled[automation.id]}
-                  debugSection={renderDebugRunsSection(automation.id)}
-                  runAction={
-                    <BasicTooltip
-                      content={getRunTooltip(
-                        automation.id,
-                        isEnabled,
-                        blockedReason,
-                      )}
+
+                  setFormState((prev) =>
+                    prev
+                      ? {
+                          ...prev,
+                          sentryTriageFrequency: frequency,
+                        }
+                      : prev,
+                  );
+                }}
+              >
+                <SelectTrigger
+                  id="sentry-triage-frequency"
+                  aria-label="Triage Sentry Issues schedule"
+                  className="w-full md:w-56"
+                >
+                  <SelectValue placeholder="Select a schedule" />
+                </SelectTrigger>
+                <SelectContent>
+                  {SENTRY_TRIAGE_FREQUENCY_OPTIONS.map((option) => (
+                    <SelectItem
+                      key={option.value}
+                      value={option.value}
+                      disabled={
+                        !canSelectSentryTriageFrequency({
+                          sentryConnected: sentryConnected,
+                          frequency: option.value,
+                        })
+                      }
                     >
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() =>
-                          triggerMutation.mutate({
-                            automationKey: automation.automationKey,
-                          })
-                        }
-                        disabled={isRunDisabled(
-                          automation.id,
-                          isEnabled,
-                          blockedReason != null,
-                        )}
-                      >
-                        <Play />
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              {!sentryConnected ? (
+                <Alert variant="light" className="md:max-w-160">
+                  <AlertCircle className="mt-0.5 size-4 shrink-0" />
+                  <AlertTitle>Connect Sentry first</AlertTitle>
+                  <AlertDescription>
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                      <span>
+                        Connect the workspace Sentry integration before enabling
+                        scheduled Sentry triage.
+                      </span>
+                      <Button asChild size="sm" variant="outline">
+                        <a
+                          href={`${SETTINGS_PATHS.integrations}?highlight=sentry-mcp`}
+                        >
+                          Configure Sentry
+                        </a>
                       </Button>
-                    </BasicTooltip>
-                  }
-                  footer={
-                    <AutomationFooter
-                      isDirty={isDirty[automation.id]}
-                      isPending={
-                        updateMutation.isPending &&
-                        savingAutomation === automation.id
+                    </div>
+                  </AlertDescription>
+                </Alert>
+              ) : null}
+
+              {sentryTriageIsEnabled ? (
+                <div className="space-y-5">
+                  {renderSlackDestinationField({
+                    field: 'sentryTriageSlackChannel',
+                    inputId: 'sentry-triage-slack-channel',
+                    label: 'Post follow-up work to this Slack channel',
+                    helperText:
+                      'Choose where Roomote should post actionable Sentry follow-up work.',
+                    savedChannelId:
+                      settingsQuery.data?.settings.sentryTriageSlackChannelId ??
+                      null,
+                    savedDiscordChannelId:
+                      settingsQuery.data?.settings
+                        .sentryTriageDiscordChannelId ?? null,
+                    warningChannelId:
+                      slackChannelAccessWarnings.sentryTriageSlackChannel,
+                  })}
+
+                  <p className="text-xs text-muted-foreground md:max-w-160">
+                    Requires Sentry to be configured in Settings &gt;
+                    Integrations.
+                  </p>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="sentry-triage-projects">
+                      Project slugs
+                    </Label>
+                    <Textarea
+                      id="sentry-triage-projects"
+                      value={formState.sentryTriageProjectSlugs}
+                      onChange={(event) =>
+                        setFormState((prev) =>
+                          prev
+                            ? {
+                                ...prev,
+                                sentryTriageProjectSlugs: event.target.value,
+                              }
+                            : prev,
+                        )
                       }
-                      onSave={() => saveAgent(automation.id)}
-                      onReset={() => resetAgent(automation.id)}
+                      rows={3}
+                      placeholder="Optional, one Sentry project slug per line"
                     />
-                  }
-                >
-                  <ScheduleOnlyAutomationContent
-                    automationLabel={automation.label}
-                    control={
-                      automationUi.control.kind === 'schedule'
-                        ? {
-                            ...automationUi.control,
-                            scheduleOptions:
-                              SCHEDULE_ONLY_AUTOMATION_FREQUENCY_OPTIONS,
-                          }
-                        : automationUi.control
-                    }
-                    details={automationUi.details}
-                    frequency={frequency}
-                    isEnabled={isEnabled}
-                    disabled={false}
-                    fieldId={fieldId}
-                    onFrequencyChange={(nextFrequency) =>
-                      setScheduleOnlyAutomationFrequency(
-                        automation.id,
-                        nextFrequency,
-                      )
-                    }
-                  >
-                    {renderSlackDestinationField({
-                      field:
-                        automation.id === 'securityAuditor'
-                          ? 'securityAuditorSlackChannel'
-                          : automation.id === 'codeQualityAuditor'
-                            ? 'codeQualityAuditorSlackChannel'
-                            : 'ciFailureTriageSlackChannel',
-                      inputId: `${automation.id}-slack-channel`,
-                      label: 'Post follow-up work to this Slack channel',
-                      helperText:
-                        automation.id === 'ciFailureTriage'
-                          ? 'Choose where Roomote should post CI failure triage work.'
-                          : 'Choose where Roomote should post actionable follow-up work.',
-                      savedChannelId:
-                        automation.id === 'securityAuditor'
-                          ? (settingsQuery.data?.settings
-                              .securityAuditorSlackChannelId ?? null)
-                          : automation.id === 'codeQualityAuditor'
-                            ? (settingsQuery.data?.settings
-                                .codeQualityAuditorSlackChannelId ?? null)
-                            : (settingsQuery.data?.settings
-                                .ciFailureTriageSlackChannelId ?? null),
-                      savedDiscordChannelId:
-                        automation.id === 'securityAuditor'
-                          ? (settingsQuery.data?.settings
-                              .securityAuditorDiscordChannelId ?? null)
-                          : automation.id === 'codeQualityAuditor'
-                            ? (settingsQuery.data?.settings
-                                .codeQualityAuditorDiscordChannelId ?? null)
-                            : (settingsQuery.data?.settings
-                                .ciFailureTriageDiscordChannelId ?? null),
-                      warningChannelId:
-                        automation.id === 'securityAuditor'
-                          ? slackChannelAccessWarnings.securityAuditorSlackChannel
-                          : automation.id === 'codeQualityAuditor'
-                            ? slackChannelAccessWarnings.codeQualityAuditorSlackChannel
-                            : slackChannelAccessWarnings.ciFailureTriageSlackChannel,
-                    })}
-                  </ScheduleOnlyAutomationContent>
-                </AutomationCard>
-              );
-            })}
-          </>
+                    <p className="text-xs text-muted-foreground md:max-w-160">
+                      Leave blank to scan all projects available to the Sentry
+                      token.
+                    </p>
+                    {fieldErrors.sentryTriageProjectSlugs ? (
+                      <p className="text-xs text-destructive">
+                        {fieldErrors.sentryTriageProjectSlugs}
+                      </p>
+                    ) : null}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </AutomationCard>
 
           <AutomationCard
             automation={AUTOMATION_DEFINITIONS.suggester}
@@ -3775,336 +4199,8 @@ If unclear, send to manager channel.`}
           </AutomationCard>
 
           <h2 className="pt-2 text-base font-semibold text-foreground">
-            Other automations
+            Meta automations
           </h2>
-
-          <AutomationCard
-            automation={AUTOMATION_DEFINITIONS.reviewer}
-            isOpen={openAutomationIds.has('reviewer')}
-            onOpenChange={(open) => setAutomationOpen('reviewer', open)}
-            iconEnabled={iconEnabled.reviewer}
-            footer={
-              <AutomationFooter
-                isDirty={isDirty.reviewer}
-                isPending={
-                  updateMutation.isPending && savingAutomation === 'reviewer'
-                }
-                onSave={() => saveAgent('reviewer')}
-                onReset={() => resetAgent('reviewer')}
-              />
-            }
-          >
-            <div className="space-y-5">
-              <div className="flex items-center gap-2">
-                <Switch
-                  id="reviewer-enabled"
-                  checked={formState.reviewerEnabled}
-                  onCheckedChange={(reviewerEnabled) =>
-                    setFormState((prev) =>
-                      prev ? { ...prev, reviewerEnabled } : prev,
-                    )
-                  }
-                />
-                <Label htmlFor="reviewer-enabled" className="text-sm">
-                  Enable Code Reviews
-                </Label>
-              </div>
-
-              {reviewerIsEnabled ? (
-                <div className="space-y-5">
-                  <Alert variant="light" className="md:max-w-160">
-                    <Info className="mt-0.5 size-4 shrink-0 text-foreground" />
-                    <AlertTitle>Which PRs get reviewed?</AlertTitle>
-                    <AlertDescription>
-                      <div className="space-y-2 text-muted-foreground">
-                        <p>
-                          When background auto-review is on, reviews run on{' '}
-                          {reviewerReviewsAllPrs
-                            ? 'all pull requests in connected repositories'
-                            : `pull requests opened by ${PRODUCT_NAME}`}
-                          {formState.reviewerReviewOnCommit
-                            ? ' as they open or receive new commits.'
-                            : '. Right now, Review Code only runs when someone mentions it on a PR.'}
-                        </p>
-                        {formState.reviewerReviewOnCommit ? (
-                          <p>
-                            {formState.reviewerReviewDraftPrs
-                              ? 'Draft PRs are included in automatic reviews.'
-                              : 'Draft PRs wait until they are marked ready for review.'}
-                          </p>
-                        ) : null}
-                        <p>
-                          {reviewerReviewsAllPrs
-                            ? 'You can also comment'
-                            : 'For PRs outside that scope, comment'}{' '}
-                          <span className="font-medium text-foreground">
-                            {githubAppMention} review this PR
-                          </span>{' '}
-                          to request an on-demand review.
-                        </p>
-                      </div>
-                    </AlertDescription>
-                  </Alert>
-
-                  <div className="space-y-6 pt-3">
-                    <div className="flex items-start gap-2">
-                      <Switch
-                        className="mt-1"
-                        checked={formState.reviewerReviewOnCommit}
-                        onCheckedChange={(reviewerReviewOnCommit) =>
-                          setFormState((prev) =>
-                            prev ? { ...prev, reviewerReviewOnCommit } : prev,
-                          )
-                        }
-                      />
-                      <div className="space-y-1">
-                        <p className="text-sm font-medium">
-                          Auto-review on open and new commits
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          Turn this off to keep Review Code background work
-                          disabled.
-                        </p>
-                      </div>
-                    </div>
-
-                    <div className="flex items-start gap-2">
-                      <Switch
-                        className="mt-1"
-                        aria-label="Review PRs from other authors"
-                        checked={formState.reviewerReviewAllPullRequestAuthors}
-                        onCheckedChange={(
-                          reviewerReviewAllPullRequestAuthors,
-                        ) =>
-                          setFormState((prev) =>
-                            prev
-                              ? {
-                                  ...prev,
-                                  reviewerReviewAllPullRequestAuthors,
-                                }
-                              : prev,
-                          )
-                        }
-                      />
-                      <div className="space-y-1">
-                        <p className="text-sm font-medium">
-                          Review PRs from other authors
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          Include pull requests opened by people or bots outside
-                          {` ${PRODUCT_NAME}`} in automatic reviews.
-                        </p>
-                      </div>
-                    </div>
-
-                    <div className="flex items-start gap-2">
-                      <Switch
-                        className="mt-1"
-                        checked={formState.reviewerReviewDraftPrs}
-                        onCheckedChange={(reviewerReviewDraftPrs) =>
-                          setFormState((prev) =>
-                            prev ? { ...prev, reviewerReviewDraftPrs } : prev,
-                          )
-                        }
-                      />
-                      <div className="space-y-1">
-                        <p className="text-sm font-medium">Review draft PRs</p>
-                        <p className="text-xs text-muted-foreground">
-                          Keep draft pull requests in scope before they are
-                          marked ready for review when Review Code is enabled.
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              ) : null}
-            </div>
-          </AutomationCard>
-
-          <AutomationCard
-            automation={AUTOMATION_DEFINITIONS.conflictResolver}
-            isOpen={openAutomationIds.has('conflictResolver')}
-            onOpenChange={(open) => setAutomationOpen('conflictResolver', open)}
-            iconEnabled={iconEnabled.conflictResolver}
-            debugSection={renderDebugRunsSection('conflictResolver')}
-            runAction={
-              <BasicTooltip
-                content={getRunTooltip(
-                  'conflictResolver',
-                  conflictResolverIsEnabled,
-                )}
-              >
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() =>
-                    triggerMutation.mutate({
-                      automationKey: 'conflict_resolver',
-                    })
-                  }
-                  disabled={isRunDisabled(
-                    'conflictResolver',
-                    conflictResolverIsEnabled,
-                  )}
-                >
-                  <Play />
-                </Button>
-              </BasicTooltip>
-            }
-            footer={
-              <AutomationFooter
-                isDirty={isDirty.conflictResolver}
-                isPending={
-                  updateMutation.isPending &&
-                  savingAutomation === 'conflictResolver'
-                }
-                onSave={() => saveAgent('conflictResolver')}
-                onReset={() => resetAgent('conflictResolver')}
-              />
-            }
-          >
-            <div className="space-y-5">
-              <Select
-                value={formState.conflictResolverFrequency}
-                onValueChange={(value) =>
-                  setFormState((prev) =>
-                    prev
-                      ? {
-                          ...prev,
-                          conflictResolverFrequency:
-                            value as ConflictResolverFrequency,
-                        }
-                      : prev,
-                  )
-                }
-              >
-                <SelectTrigger
-                  id="conflict-resolver-frequency"
-                  aria-label="Resolve PR Conflicts schedule"
-                  className="w-full md:w-56"
-                >
-                  <SelectValue placeholder="Select a schedule" />
-                </SelectTrigger>
-                <SelectContent>
-                  {CONFLICT_RESOLVER_FREQUENCY_OPTIONS.map((option) => (
-                    <SelectItem key={option.value} value={option.value}>
-                      {option.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-
-              {conflictResolverIsEnabled ? (
-                <div className="space-y-5">
-                  <div className="space-y-2">
-                    <Label htmlFor="conflict-resolver-max-pr-age">
-                      PR age cap
-                    </Label>
-                    <Select
-                      value={String(formState.conflictResolverMaxPrAgeDays)}
-                      onValueChange={(value) =>
-                        setFormState((prev) =>
-                          prev
-                            ? {
-                                ...prev,
-                                conflictResolverMaxPrAgeDays: Number(
-                                  value,
-                                ) as ConflictResolverMaxPrAgeDays,
-                              }
-                            : prev,
-                        )
-                      }
-                    >
-                      <SelectTrigger
-                        id="conflict-resolver-max-pr-age"
-                        aria-label="Resolve PR Conflicts PR age cap"
-                        className="w-full md:w-56"
-                      >
-                        <SelectValue placeholder="Select a cap" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {CONFLICT_RESOLVER_MAX_PR_AGE_OPTIONS.map((option) => (
-                          <SelectItem
-                            key={option.value}
-                            value={String(option.value)}
-                          >
-                            {option.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    <p className="text-xs text-muted-foreground md:max-w-120">
-                      Sets the maximum PR age that Resolve PR Conflicts will
-                      consider. Labeled PRs older than this are skipped.
-                    </p>
-                    {fieldErrors.conflictResolverMaxPrAgeDays ? (
-                      <p className="text-xs text-destructive">
-                        {fieldErrors.conflictResolverMaxPrAgeDays}
-                      </p>
-                    ) : null}
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="conflict-label">Auto-resolve label</Label>
-                    <Input
-                      id="conflict-label"
-                      value={formState.conflictResolverLabel}
-                      onChange={(event) =>
-                        setFormState((prev) =>
-                          prev
-                            ? {
-                                ...prev,
-                                conflictResolverLabel: event.target.value,
-                              }
-                            : prev,
-                        )
-                      }
-                      placeholder="roomote:auto-resolve-conflicts"
-                      className="max-w-80"
-                    />
-                    <p className="text-xs text-muted-foreground md:max-w-120">
-                      Make sure this label exists in your repos. It will be
-                      added automatically to all new agent PRs. Remove it
-                      whenever you do not want conflicts resolved.
-                    </p>
-                    {fieldErrors.conflictResolverLabel ? (
-                      <p className="text-xs text-destructive">
-                        {fieldErrors.conflictResolverLabel}
-                      </p>
-                    ) : null}
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="conflict-resolver-instructions">
-                      Additional instructions
-                    </Label>
-                    <Textarea
-                      id="conflict-resolver-instructions"
-                      value={formState.conflictResolverInstructions}
-                      onChange={(event) =>
-                        setFormState((prev) =>
-                          prev
-                            ? {
-                                ...prev,
-                                conflictResolverInstructions:
-                                  event.target.value,
-                              }
-                            : prev,
-                        )
-                      }
-                      rows={4}
-                      placeholder="Optional guidance for conflict resolution strategy and priorities"
-                    />
-                    {fieldErrors.conflictResolverInstructions ? (
-                      <p className="text-xs text-destructive">
-                        {fieldErrors.conflictResolverInstructions}
-                      </p>
-                    ) : null}
-                  </div>
-                </div>
-              ) : null}
-            </div>
-          </AutomationCard>
 
           <AutomationCard
             automation={AUTOMATION_DEFINITIONS.platformIssueAlerts}

--- a/apps/web/src/components/system/primitives/input.test.tsx
+++ b/apps/web/src/components/system/primitives/input.test.tsx
@@ -12,6 +12,44 @@ describe('Input', () => {
     expect(input).toHaveAttribute('data-op-ignore', 'true');
   });
 
+  it('keeps password-manager overlays off for secret inputs without credential autocomplete', () => {
+    render(<Input secret aria-label="API key" defaultValue="sk-test" />);
+
+    const input = screen.getByLabelText('API key');
+
+    expect(input).toHaveAttribute('autocomplete', 'new-password');
+    expect(input).toHaveAttribute('data-1p-ignore');
+    expect(input).toHaveAttribute('data-op-ignore', 'true');
+  });
+
+  it.each([
+    ['new-password', 'Password', true],
+    ['current-password', 'Password', true],
+    ['email', 'Email', false],
+    ['name', 'Name', false],
+    ['username', 'Username', false],
+    ['nickname', 'Nickname', false],
+    ['one-time-code', 'OTP', false],
+    ['section-signup new-password', 'Password', true],
+  ] as const)(
+    'allows password managers for explicit %s autocomplete',
+    (autoComplete, label, secret) => {
+      render(
+        <Input
+          secret={secret}
+          autoComplete={autoComplete}
+          aria-label={label}
+        />,
+      );
+
+      const input = screen.getByLabelText(label);
+
+      expect(input).toHaveAttribute('autocomplete', autoComplete);
+      expect(input).not.toHaveAttribute('data-1p-ignore');
+      expect(input).not.toHaveAttribute('data-op-ignore');
+    },
+  );
+
   it('renders a built-in show and hide control for secret inputs', () => {
     render(<Input secret aria-label="API key" defaultValue="sk-test" />);
 

--- a/apps/web/src/components/system/primitives/input.tsx
+++ b/apps/web/src/components/system/primitives/input.tsx
@@ -20,6 +20,16 @@ const PASSWORD_STRENGTH_CLASSES = [
   'bg-accent-bright-foreground',
 ] as const;
 
+const CREDENTIAL_AUTOCOMPLETE_TOKENS = new Set([
+  'name',
+  'email',
+  'username',
+  'nickname',
+  'new-password',
+  'current-password',
+  'one-time-code',
+]);
+
 function getInputValue(
   value: InputProps['value'] | InputProps['defaultValue'],
 ) {
@@ -34,6 +44,20 @@ function getInputValue(
   return '';
 }
 
+function shouldIgnorePasswordManagers(
+  autoComplete: React.HTMLInputAutoCompleteAttribute | undefined,
+  hasExplicitAutoComplete: boolean,
+) {
+  if (!hasExplicitAutoComplete || autoComplete == null || autoComplete === '') {
+    return true;
+  }
+
+  return !String(autoComplete)
+    .toLowerCase()
+    .split(/\s+/)
+    .some((token) => CREDENTIAL_AUTOCOMPLETE_TOKENS.has(token));
+}
+
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   (
     {
@@ -46,6 +70,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       value,
       defaultValue,
       onChange,
+      autoComplete: autoCompleteProp,
       ...props
     },
     ref,
@@ -55,8 +80,13 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       getInputValue(defaultValue),
     );
     const inputType = secret ? (showSecretValue ? 'text' : 'password') : type;
+    const hasExplicitAutoComplete = autoCompleteProp !== undefined;
     const autoComplete =
-      props.autoComplete ?? (secret ? 'new-password' : undefined);
+      autoCompleteProp ?? (secret ? 'new-password' : undefined);
+    const ignorePasswordManagers = shouldIgnorePasswordManagers(
+      autoCompleteProp,
+      hasExplicitAutoComplete,
+    );
     const strengthValue =
       value === undefined ? inputValue : getInputValue(value);
     const hasMatch = match !== undefined;
@@ -103,8 +133,9 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           secret && 'pr-10',
           className,
         )}
-        data-1p-ignore
-        data-op-ignore="true"
+        {...(ignorePasswordManagers
+          ? { 'data-1p-ignore': true, 'data-op-ignore': 'true' as const }
+          : {})}
         autoComplete={autoComplete}
         disabled={disabled}
         value={value}

--- a/apps/worker/src/sandbox-server/lib/__tests__/command-executor.test.ts
+++ b/apps/worker/src/sandbox-server/lib/__tests__/command-executor.test.ts
@@ -103,6 +103,24 @@ describe('CommandExecutor', () => {
       ).toThrow('Path traversal not allowed');
     });
 
+    it('should allow absolute paths under /tmp', () => {
+      const handle = CommandExecutor.tailStream('/tmp/harness.log', {
+        cwd: testCwd,
+        onChunk: () => {},
+      });
+
+      handle.kill();
+    });
+
+    it('should reject absolute paths outside /tmp', () => {
+      expect(() =>
+        CommandExecutor.tailStream('/etc/passwd', {
+          cwd: testCwd,
+          onChunk: () => {},
+        }),
+      ).toThrow('Absolute paths outside /tmp are not allowed');
+    });
+
     it('should reject shell metacharacters in path', () => {
       expect(() =>
         CommandExecutor.tailStream('file;rm -rf /', {

--- a/apps/worker/src/sandbox-server/lib/__tests__/tail-file-path.test.ts
+++ b/apps/worker/src/sandbox-server/lib/__tests__/tail-file-path.test.ts
@@ -1,0 +1,126 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  assertSafeTailFilePath,
+  resolveSafeTailFilePath,
+} from '../tail-file-path';
+
+describe('resolveSafeTailFilePath', () => {
+  it('allows workspace-relative paths unchanged', () => {
+    expect(resolveSafeTailFilePath('logs/app.log')).toBe('logs/app.log');
+    expect(resolveSafeTailFilePath('package.json')).toBe('package.json');
+  });
+
+  it('allows absolute paths under /tmp used by harness and docker logs', () => {
+    expect(() => resolveSafeTailFilePath('/tmp/harness.log')).not.toThrow();
+    expect(() =>
+      resolveSafeTailFilePath('/tmp/roomote-docker-projects/roomote-api.log'),
+    ).not.toThrow();
+    expect(() => resolveSafeTailFilePath('/tmp/server.log')).not.toThrow();
+  });
+
+  it('rejects empty paths', () => {
+    expect(() => resolveSafeTailFilePath('')).toThrow('Path cannot be empty');
+    expect(() => resolveSafeTailFilePath('   ')).toThrow(
+      'Path cannot be empty',
+    );
+  });
+
+  it('rejects path traversal', () => {
+    expect(() => resolveSafeTailFilePath('../etc/passwd')).toThrow(
+      'Path traversal not allowed',
+    );
+    expect(() => resolveSafeTailFilePath('/tmp/../etc/passwd')).toThrow(
+      'Path traversal not allowed',
+    );
+  });
+
+  it('rejects absolute paths outside /tmp', () => {
+    expect(() => resolveSafeTailFilePath('/etc/passwd')).toThrow(
+      'Absolute paths outside /tmp are not allowed',
+    );
+    expect(() => resolveSafeTailFilePath('/var/log/syslog')).toThrow(
+      'Absolute paths outside /tmp are not allowed',
+    );
+    expect(() => resolveSafeTailFilePath('/tmp')).toThrow(
+      'Absolute paths outside /tmp are not allowed',
+    );
+  });
+
+  it('rejects shell metacharacters', () => {
+    expect(() => resolveSafeTailFilePath('file;rm -rf /')).toThrow(
+      'Invalid characters in path',
+    );
+    expect(() => resolveSafeTailFilePath('$(whoami)')).toThrow(
+      'Invalid characters in path',
+    );
+  });
+
+  it('rejects control characters including DEL', () => {
+    expect(() => resolveSafeTailFilePath('logs/\x00app.log')).toThrow(
+      'Control characters not allowed in path',
+    );
+    expect(() => resolveSafeTailFilePath('logs/\x7fapp.log')).toThrow(
+      'Control characters not allowed in path',
+    );
+  });
+
+  it('rejects /tmp-relative symlinks that resolve outside /tmp', () => {
+    // Create the target outside /tmp (workspace path), not under os.tmpdir().
+    const dir = fs.mkdtempSync(path.join(process.cwd(), 'tail-path-escape-'));
+    const outside = path.join(dir, 'secret.txt');
+    fs.writeFileSync(outside, 'nope\n');
+    const link = path.join('/tmp', `roomote-tail-escape-${process.pid}.link`);
+
+    try {
+      fs.symlinkSync(outside, link);
+
+      expect(() => resolveSafeTailFilePath(link)).toThrow(
+        'Absolute paths outside /tmp are not allowed',
+      );
+    } finally {
+      fs.rmSync(link, { force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns the real path for /tmp targets that exist', () => {
+    const target = path.join('/tmp', `roomote-tail-real-${process.pid}.log`);
+    fs.writeFileSync(target, 'ok\n');
+    const link = path.join('/tmp', `roomote-tail-real-${process.pid}.link`);
+
+    try {
+      fs.symlinkSync(target, link);
+
+      expect(resolveSafeTailFilePath(link)).toBe(
+        fs.realpathSync.native(target),
+      );
+    } finally {
+      fs.rmSync(link, { force: true });
+      fs.rmSync(target, { force: true });
+    }
+  });
+
+  it('allows not-yet-created absolute logfiles whose parent stays under /tmp', () => {
+    const missing = path.join(
+      '/tmp',
+      `roomote-tail-missing-${process.pid}`,
+      'nested',
+      'app.log',
+    );
+
+    expect(resolveSafeTailFilePath(missing)).toBe(
+      path.posix.normalize(missing),
+    );
+  });
+});
+
+describe('assertSafeTailFilePath', () => {
+  it('delegates validation', () => {
+    expect(() => assertSafeTailFilePath('logs/app.log')).not.toThrow();
+    expect(() => assertSafeTailFilePath('/etc/passwd')).toThrow(
+      'Absolute paths outside /tmp are not allowed',
+    );
+  });
+});

--- a/apps/worker/src/sandbox-server/lib/command-executor.ts
+++ b/apps/worker/src/sandbox-server/lib/command-executor.ts
@@ -5,6 +5,7 @@ import { execa, type ExecaError } from 'execa';
 import type { CommandExecutionResult, StreamChunk } from '../types';
 
 import { DEFAULT_COMMAND_TIMEOUT } from '../trpc';
+import { resolveSafeTailFilePath } from './tail-file-path';
 
 interface ExecuteOptions {
   /** Working directory */
@@ -101,25 +102,11 @@ export class CommandExecutor {
     filePath: string,
     options: ExecuteStreamOptions,
   ): StreamHandle {
-    if (!filePath) {
-      throw new Error('Path cannot be empty');
-    }
+    // Resolve absolute /tmp paths (and their symlink targets) before tailing so
+    // the check and the stream use the same path.
+    const safePath = resolveSafeTailFilePath(filePath);
 
-    // Confine tails to paths under the working directory. Absolute paths
-    // would otherwise bypass the ".."-only check and read host files.
-    if (path.isAbsolute(filePath)) {
-      throw new Error('Absolute paths are not allowed');
-    }
-
-    if (filePath.includes('..')) {
-      throw new Error('Path traversal not allowed');
-    }
-
-    if (/[;`$|&<>(){}]/.test(filePath)) {
-      throw new Error('Invalid characters in path');
-    }
-
-    return this.runCommandStream(['tail', '-f', '--', filePath], options);
+    return this.runCommandStream(['tail', '-f', '--', safePath], options);
   }
 
   /**

--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
@@ -1852,7 +1852,7 @@ describe('OpenCodeServerHarness', () => {
     }
   });
 
-  it('clears queued prompts instead of draining them after a terminal session error', async () => {
+  it('immediately aborts and clears queued prompts for explicit non-retryable provider errors', async () => {
     const { client, harness } = createHarness();
     const taskEvents: TaskEvent[] = [];
 
@@ -1890,7 +1890,14 @@ describe('OpenCodeServerHarness', () => {
         type: 'session.error',
         properties: {
           sessionID: 'ses_1',
-          error: { message: 'boom' },
+          error: {
+            name: 'APIError',
+            data: {
+              message: 'The selected model is not available in your region.',
+              statusCode: 403,
+              isRetryable: false,
+            },
+          },
         },
       });
 
@@ -1901,6 +1908,193 @@ describe('OpenCodeServerHarness', () => {
       ).toBe(true);
       expect(harness.getQueuedMessages()).toEqual([]);
       expect(client.promptAsync).toHaveBeenCalledTimes(1);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it('retries a cyber policy refusal with safer framing without aborting the task', async () => {
+    const { client, harness } = createHarness();
+    const taskEvents: TaskEvent[] = [];
+    const persistedEnvelopes: AcpPersistedEnvelope[] = [];
+
+    harness.subscribe((event) => taskEvents.push(event));
+    harness.subscribeRuntimePersistedEnvelope((envelope) =>
+      persistedEnvelopes.push(envelope),
+    );
+
+    try {
+      await connectHarness(harness, client);
+
+      expect(
+        harness.sendCommand({
+          commandName: TaskCommandName.StartNewTask,
+          data: {
+            text: 'Review the change.',
+            visibleInTranscript: true,
+          },
+        }),
+      ).toBe(true);
+
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(1);
+      });
+
+      expect(
+        harness.sendCommand({
+          commandName: TaskCommandName.SendMessage,
+          data: {
+            text: 'Queued follow-up.',
+            visibleInTranscript: true,
+          },
+        }),
+      ).toBe(true);
+
+      await client.emit({
+        type: 'session.error',
+        properties: {
+          sessionID: 'ses_1',
+          error: {
+            name: 'UnknownError',
+            data: {
+              message: JSON.stringify({
+                type: 'error',
+                error: {
+                  type: 'invalid_request',
+                  code: 'cyber_policy',
+                  message:
+                    'This content was flagged for possible cybersecurity risk.',
+                },
+              }),
+            },
+          },
+        },
+      });
+
+      // OpenCode reports the error before the failed runner reaches idle. The
+      // retry must remain queued until that boundary or it can be appended to
+      // the dying run without starting a fresh model loop.
+      expect(client.promptAsync).toHaveBeenCalledTimes(1);
+
+      await client.emit({
+        type: 'session.status',
+        properties: { sessionID: 'ses_1', status: { type: 'idle' } },
+      });
+
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(2);
+      });
+
+      // OpenCode emits this legacy idle event for the same transition after
+      // session.status(idle). It must be consumed instead of completing the
+      // recovery loop that was just started.
+      await client.emit({
+        type: 'session.idle',
+        properties: { sessionID: 'ses_1' },
+      });
+
+      expect(client.promptAsync).toHaveBeenCalledTimes(2);
+      expect(
+        taskEvents.some(
+          (event) => event.eventName === TaskEventName.TaskCompleted,
+        ),
+      ).toBe(false);
+
+      const retryPrompt = client.promptAsync.mock.calls[1]?.[0] as
+        | {
+            request?: {
+              parts?: Array<{ type?: string; text?: string }>;
+            };
+          }
+        | undefined;
+      const retryPromptText = (retryPrompt?.request?.parts ?? [])
+        .map((part) => part.text)
+        .filter((text): text is string => typeof text === 'string')
+        .join('\n');
+
+      expect(retryPromptText).toContain('Continue the legitimate task');
+      expect(retryPromptText).toContain('Do not attempt to bypass the policy');
+      expect(
+        taskEvents.some(
+          (event) => event.eventName === TaskEventName.TaskAborted,
+        ),
+      ).toBe(false);
+      expect(
+        persistedEnvelopes.some(
+          (envelope) =>
+            envelope.eventType === ACP_ENVELOPE_EVENT_TYPES.AssistantMessage &&
+            String(envelope.payload.text ?? '').includes(
+              'Provider safety refusal; automatically retrying the turn',
+            ),
+        ),
+      ).toBe(true);
+      expect(
+        harness.getQueuedMessages().map((message) => message.text),
+      ).toEqual(['Queued follow-up.']);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it('retries an unknown provider error once before aborting', async () => {
+    const { client, harness } = createHarness();
+    const taskEvents: TaskEvent[] = [];
+
+    harness.subscribe((event) => taskEvents.push(event));
+
+    try {
+      await connectHarness(harness, client);
+
+      expect(
+        harness.sendCommand({
+          commandName: TaskCommandName.StartNewTask,
+          data: {
+            text: 'Start work.',
+            visibleInTranscript: true,
+          },
+        }),
+      ).toBe(true);
+
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(1);
+      });
+
+      const providerError = {
+        name: 'UnknownError',
+        data: { message: 'Upstream connection closed unexpectedly.' },
+      };
+
+      await client.emit({
+        type: 'session.error',
+        properties: { sessionID: 'ses_1', error: providerError },
+      });
+
+      expect(client.promptAsync).toHaveBeenCalledTimes(1);
+
+      await client.emit({
+        type: 'session.idle',
+        properties: { sessionID: 'ses_1' },
+      });
+
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(2);
+      });
+      expect(
+        taskEvents.some(
+          (event) => event.eventName === TaskEventName.TaskAborted,
+        ),
+      ).toBe(false);
+
+      await client.emit({
+        type: 'session.error',
+        properties: { sessionID: 'ses_1', error: providerError },
+      });
+
+      expect(
+        taskEvents.some(
+          (event) => event.eventName === TaskEventName.TaskAborted,
+        ),
+      ).toBe(true);
     } finally {
       harness.dispose();
     }

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
@@ -74,6 +74,11 @@ import {
   isOpenCodeProviderRateLimitError,
   resolveOpenCodeRateLimitRetryDelayMs,
 } from './provider-rate-limit';
+import {
+  formatOpenCodeProviderErrorRetryNoticeText,
+  getOpenCodeProviderErrorRecovery,
+  type OpenCodeProviderErrorRecovery,
+} from './provider-error-recovery';
 import type {
   OpenCodeEventPayload,
   OpenCodeGlobalEvent,
@@ -1529,6 +1534,9 @@ export class OpenCodeServerHarness
   private providerRateLimitRetryTimer: ReturnType<typeof setTimeout> | null =
     null;
   private providerRateLimitRetryCount = 0;
+  private providerErrorRecoveryCount = 0;
+  private providerErrorRecoveryQueuedPromptId: string | null = null;
+  private ignoreNextProviderRecoverySessionIdle = false;
   private currentWorkflowPhase: string | null = null;
   // Most recent packaged workflow skill loaded by the primary session's agent
   // via the OpenCode skill tool. Drives per-prompt agent selection so plan-mode
@@ -1781,7 +1789,7 @@ export class OpenCodeServerHarness
     this.connected = false;
     this.clearReplayAbortErrorSuppression();
     this.clearQueuedPromptRetryTimer();
-    this.clearProviderRateLimitRetryState();
+    this.clearProviderErrorRecoveryState();
     this.clearAllExecuteToolProgress();
     void this.cleanupVisualAttachmentDirectories();
     this.rejectEventStreamReady?.(
@@ -2028,6 +2036,7 @@ export class OpenCodeServerHarness
     command: StartNewTaskCommand,
   ): Promise<void> {
     this.prompts.clear();
+    this.clearProviderErrorRecoveryState();
     this.clearAllExecuteToolProgress();
     this.stopHookReminderCount = 0;
     this.currentWorkflowPhase = command.data.workflowPhase ?? null;
@@ -2086,7 +2095,8 @@ export class OpenCodeServerHarness
     if (
       command.data.queueOnly ||
       this.inFlight ||
-      this.isProviderRateLimitBackoffPending()
+      this.isProviderRateLimitBackoffPending() ||
+      this.providerErrorRecoveryQueuedPromptId !== null
     ) {
       // True native steering: OpenCode accepts prompt_async on a session with
       // an active turn and the loop picks the message up between steps — no
@@ -2156,9 +2166,14 @@ export class OpenCodeServerHarness
         // Steers use prioritize() so they usually jump the FIFO queue, but
         // during rate-limit backoff the invisible continue prompt must stay
         // first so we don't replay the user message before the automatic
-        // retry runs (and then drain a stale Continue afterward).
+        // retry runs (and then drain a stale Continue afterward). The same
+        // ordering applies while a provider-error retry awaits session idle.
         this.frontloadProviderRateLimitContinueIfQueued();
-        if (!this.isProviderRateLimitBackoffPending()) {
+        this.frontloadProviderErrorRecoveryIfQueued();
+        if (
+          !this.isProviderRateLimitBackoffPending() &&
+          this.providerErrorRecoveryQueuedPromptId === null
+        ) {
           await this.interruptForQueuedReplay();
         }
       }
@@ -2187,7 +2202,7 @@ export class OpenCodeServerHarness
       this.inFlight = false;
       this.prompts.clear();
       this.clearQueuedPromptRetryTimer();
-      this.clearProviderRateLimitRetryState();
+      this.clearProviderErrorRecoveryState();
       this.pendingUserInputRequests.clear();
       this.clearAllExecuteToolProgress();
       return;
@@ -2200,7 +2215,9 @@ export class OpenCodeServerHarness
     // explicit user cancel during the wait still leaves a cancel marker and
     // clears the automatic retry instead of silently dropping it.
     const hadActiveTurn =
-      hadInFlightOrPendingQuestion || this.isProviderRateLimitBackoffPending();
+      hadInFlightOrPendingQuestion ||
+      this.isProviderRateLimitBackoffPending() ||
+      this.providerErrorRecoveryQueuedPromptId !== null;
 
     // Aborting an in-flight turn makes OpenCode emit a MessageAbortedError on the
     // session.error event. For an explicit cancel that's expected, not a failure
@@ -2224,7 +2241,7 @@ export class OpenCodeServerHarness
     this.finalizedAssistantTurn = null;
     this.prompts.clear();
     this.clearQueuedPromptRetryTimer();
-    this.clearProviderRateLimitRetryState();
+    this.clearProviderErrorRecoveryState();
     // Abandoned questions get an explicit cancelled response so surfaces
     // that clear pending state on request_user_input_response (Slack,
     // Linear, the web store) drop them, and late answers are rejected via
@@ -2974,13 +2991,19 @@ export class OpenCodeServerHarness
       resolution,
     });
 
-    if (this.inFlight) {
+    if (this.inFlight || this.providerErrorRecoveryQueuedPromptId !== null) {
       const queuedId = this.prompts.enqueue({
         text: responseText,
         visibleInTranscript: false,
         userId: command.data.userId,
       });
       this.prompts.prioritize(queuedId);
+
+      if (this.providerErrorRecoveryQueuedPromptId !== null) {
+        this.frontloadProviderErrorRecoveryIfQueued();
+        return;
+      }
+
       await this.interruptForQueuedReplay();
       return;
     }
@@ -3168,7 +3191,7 @@ export class OpenCodeServerHarness
     this.inFlight = false;
     this.prompts.clear();
     this.clearQueuedPromptRetryTimer();
-    this.clearProviderRateLimitRetryState();
+    this.clearProviderErrorRecoveryState();
     this.pendingUserInputRequests.clear();
     this.clearAllExecuteToolProgress();
     this.runtimeEvents.taskStarted(sessionId);
@@ -3485,6 +3508,9 @@ export class OpenCodeServerHarness
     const statusType = asString(status?.type);
 
     if (statusType === 'busy' || statusType === 'retry') {
+      // If OpenCode omitted the paired session.idle event, do not let a stale
+      // guard consume the retry's eventual idle transition.
+      this.ignoreNextProviderRecoverySessionIdle = false;
       this.inFlight = true;
       // Status transitions prove the session is alive (e.g. a provider retry
       // loop), but not that the turn's loop advanced — a steer awaiting
@@ -3495,6 +3521,10 @@ export class OpenCodeServerHarness
     }
 
     if (statusType === 'idle') {
+      if (await this.drainProviderErrorRecoveryAfterIdle('session_status')) {
+        return;
+      }
+
       await this.finishCurrentTurn();
     }
   }
@@ -3522,6 +3552,15 @@ export class OpenCodeServerHarness
       this.sessionId = sessionId;
     }
 
+    if (this.ignoreNextProviderRecoverySessionIdle) {
+      this.ignoreNextProviderRecoverySessionIdle = false;
+      return;
+    }
+
+    if (await this.drainProviderErrorRecoveryAfterIdle('session_idle')) {
+      return;
+    }
+
     await this.finishCurrentTurn();
   }
 
@@ -3546,13 +3585,21 @@ export class OpenCodeServerHarness
       return;
     }
 
-    if (
-      sessionId &&
-      isOpenCodeProviderRateLimitError(error) &&
-      this.providerRateLimitRetryCount < this.providerRateLimitMaxRetries
-    ) {
-      await this.recoverProviderRateLimit(sessionId, error);
-      return;
+    const isProviderRateLimit =
+      !!sessionId && isOpenCodeProviderRateLimitError(error);
+
+    if (sessionId && isProviderRateLimit) {
+      if (this.providerRateLimitRetryCount < this.providerRateLimitMaxRetries) {
+        await this.recoverProviderRateLimit(sessionId, error);
+        return;
+      }
+    } else if (sessionId) {
+      const recovery = getOpenCodeProviderErrorRecovery(error);
+
+      if (recovery && this.providerErrorRecoveryCount < recovery.maxRetries) {
+        await this.recoverProviderSessionError(sessionId, error, recovery);
+        return;
+      }
     }
 
     if (sessionId) {
@@ -3565,7 +3612,7 @@ export class OpenCodeServerHarness
       });
       this.prompts.clear();
       this.clearQueuedPromptRetryTimer();
-      this.clearProviderRateLimitRetryState();
+      this.clearProviderErrorRecoveryState();
       this.pendingUserInputRequests.clear();
       this.clearAllExecuteToolProgress();
       this.runtimeEvents.taskAborted(sessionId);
@@ -3573,6 +3620,48 @@ export class OpenCodeServerHarness
 
     await this.cleanupVisualAttachmentDirectories();
     this.inFlight = false;
+  }
+
+  /**
+   * Most provider session errors invalidate one model turn rather than the
+   * OpenCode session. Retry them in-place with a bounded invisible continue so
+   * a transient provider response cannot abort the enclosing Roomote task.
+   */
+  private async recoverProviderSessionError(
+    sessionId: string,
+    error: unknown,
+    recovery: OpenCodeProviderErrorRecovery,
+  ): Promise<void> {
+    this.providerErrorRecoveryCount += 1;
+    const attemptNumber = this.providerErrorRecoveryCount;
+
+    this.logger.warn(
+      `OpenCode recoverable provider error kind=${recovery.kind} sessionId=${sessionId} attempt=${attemptNumber}/${recovery.maxRetries}: ${JSON.stringify(error ?? {})}`,
+    );
+
+    this.runtimeEvents.assistantMessage({
+      sessionId,
+      text: formatOpenCodeProviderErrorRetryNoticeText({
+        kind: recovery.kind,
+        attemptNumber,
+        maxAttempts: recovery.maxRetries,
+      }),
+    });
+
+    // Keep partial output and visible queued follow-ups, but suppress trailing
+    // events from the rejected assistant message before submitting the
+    // invisible recovery prompt at the front of the queue.
+    this.suppressAssistantOutputUntilNextPrompt = true;
+    this.inFlight = false;
+    this.finalizedAssistantTurn = null;
+    this.clearAllExecuteToolProgress();
+
+    const queuedId = this.prompts.enqueue({
+      text: recovery.promptText,
+      visibleInTranscript: false,
+    });
+    this.prompts.prioritize(queuedId);
+    this.providerErrorRecoveryQueuedPromptId = queuedId;
   }
 
   /**
@@ -3645,9 +3734,35 @@ export class OpenCodeServerHarness
     this.providerRateLimitRetryTimer = null;
   }
 
-  private clearProviderRateLimitRetryState(): void {
+  private clearProviderErrorRecoveryState(): void {
     this.clearProviderRateLimitRetryTimer();
     this.providerRateLimitRetryCount = 0;
+    this.providerErrorRecoveryCount = 0;
+    this.providerErrorRecoveryQueuedPromptId = null;
+    this.ignoreNextProviderRecoverySessionIdle = false;
+  }
+
+  private async drainProviderErrorRecoveryAfterIdle(
+    source: 'session_status' | 'session_idle',
+  ): Promise<boolean> {
+    const queuedPromptId = this.providerErrorRecoveryQueuedPromptId;
+
+    if (!queuedPromptId) {
+      return false;
+    }
+
+    // OpenCode emits session.error before the failed runner reaches idle. Do
+    // not submit the retry until that idle boundary or prompt_async can append
+    // it to the dying run without starting a fresh model loop.
+    this.providerErrorRecoveryQueuedPromptId = null;
+    // OpenCode 1.17 emits session.status(idle) followed by session.idle for a
+    // single transition. Consume that paired legacy event exactly once so it
+    // cannot finish the recovery turn that is about to start.
+    this.ignoreNextProviderRecoverySessionIdle = source === 'session_status';
+    this.inFlight = false;
+    this.prompts.prioritize(queuedPromptId);
+    await this.drainQueuedPrompts();
+    return true;
   }
 
   private frontloadProviderRateLimitContinueIfQueued(): void {
@@ -3664,6 +3779,12 @@ export class OpenCodeServerHarness
     }
 
     this.prompts.prioritize(continueQueuedId);
+  }
+
+  private frontloadProviderErrorRecoveryIfQueued(): void {
+    if (this.providerErrorRecoveryQueuedPromptId) {
+      this.prompts.prioritize(this.providerErrorRecoveryQueuedPromptId);
+    }
   }
 
   private isProviderRateLimitBackoffPending(): boolean {
@@ -4048,8 +4169,10 @@ export class OpenCodeServerHarness
     this.inFlight = false;
     this.finalizedAssistantTurn = null;
     // A completed turn means the model recovered past any prior rate-limit
-    // hop; reset so a later 429 gets a fresh automatic-retry budget.
+    // or provider-error hop; reset so a later failure gets a fresh bounded
+    // automatic-retry budget.
     this.providerRateLimitRetryCount = 0;
+    this.providerErrorRecoveryCount = 0;
     this.clearAllExecuteToolProgress({ keepBackgroundWatchdogs: true });
 
     if (sessionId) {
@@ -4334,7 +4457,8 @@ export class OpenCodeServerHarness
     if (
       this.inFlight ||
       this.disposed ||
-      this.isProviderRateLimitBackoffPending()
+      this.isProviderRateLimitBackoffPending() ||
+      this.providerErrorRecoveryQueuedPromptId !== null
     ) {
       return;
     }

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-error-recovery.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-error-recovery.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { getOpenCodeProviderErrorRecovery } from './provider-error-recovery';
+
+describe('getOpenCodeProviderErrorRecovery', () => {
+  it('detects an UnknownError-wrapped cyber policy refusal', () => {
+    const recovery = getOpenCodeProviderErrorRecovery({
+      name: 'UnknownError',
+      data: {
+        message: JSON.stringify({
+          type: 'error',
+          error: {
+            type: 'invalid_request',
+            code: 'cyber_policy',
+            message:
+              'This content was flagged for possible cybersecurity risk.',
+          },
+        }),
+      },
+    });
+
+    expect(recovery).toMatchObject({ kind: 'policy_refusal', maxRetries: 2 });
+    expect(recovery?.promptText).toContain('Continue the legitimate task');
+    expect(recovery?.promptText).toContain(
+      'Do not attempt to bypass the policy',
+    );
+  });
+
+  it('treats unknown provider errors as recoverable once', () => {
+    expect(
+      getOpenCodeProviderErrorRecovery({
+        name: 'UnknownError',
+        data: { message: 'Upstream connection closed unexpectedly.' },
+      }),
+    ).toMatchObject({ kind: 'provider_error', maxRetries: 1 });
+  });
+
+  it('classifies native ContentFilterError payloads as policy refusals', () => {
+    const recovery = getOpenCodeProviderErrorRecovery({
+      name: 'ContentFilterError',
+      data: {
+        message: "The response was blocked by the provider's content filter",
+      },
+    });
+
+    expect(recovery).toMatchObject({ kind: 'policy_refusal', maxRetries: 2 });
+    expect(recovery?.promptText).toContain('Continue the legitimate task');
+  });
+
+  it('does not retry explicit non-retryable configuration errors', () => {
+    expect(
+      getOpenCodeProviderErrorRecovery({
+        name: 'APIError',
+        data: {
+          message: 'The selected model is not available in your region.',
+          statusCode: 403,
+          isRetryable: false,
+        },
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-error-recovery.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-error-recovery.ts
@@ -1,0 +1,200 @@
+import { asFiniteNumber, asRecord, asString } from '@roomote/types';
+
+const DEFAULT_OPENCODE_PROVIDER_ERROR_MAX_RETRIES = 1;
+const DEFAULT_OPENCODE_POLICY_REFUSAL_MAX_RETRIES = 2;
+
+const OPENCODE_PROVIDER_ERROR_RETRY_PROMPT_TEXT = [
+  'Continue. The previous model request failed due to a provider error and was automatically retried.',
+  'Resume from where you left off without restating the provider error.',
+].join(' ');
+
+const OPENCODE_POLICY_REFUSAL_RETRY_PROMPT_TEXT = [
+  'Continue the legitimate task. The previous model request was declined by the provider safety policy.',
+  'Do not attempt to bypass the policy or reproduce sensitive payloads, exploit strings, or operational instructions that may have triggered it.',
+  'Use a high-level summary or safer abstraction where needed, then resume from where you left off.',
+].join(' ');
+
+export type OpenCodeProviderErrorRecovery = {
+  kind: 'policy_refusal' | 'provider_error';
+  maxRetries: number;
+  promptText: string;
+};
+
+const POLICY_CODES = new Set([
+  'cyber_policy',
+  'content_policy',
+  'content_policy_violation',
+  'safety_policy',
+]);
+
+const TERMINAL_CODES = new Set([
+  'authentication_error',
+  'billing_error',
+  'context_length_exceeded',
+  'forbidden',
+  'insufficient_quota',
+  'invalid_api_key',
+  'invalid_model',
+  'model_not_found',
+  'permission_denied',
+  'unauthorized',
+]);
+
+const TERMINAL_STATUS_CODES = new Set([400, 401, 403, 404, 422]);
+
+function collectProviderErrorValues(error: unknown): unknown[] {
+  const pending: Array<{ value: unknown; depth: number }> = [
+    { value: error, depth: 0 },
+  ];
+  const collected: unknown[] = [];
+  const seen = new Set<object>();
+
+  while (pending.length > 0) {
+    const current = pending.shift();
+
+    if (!current || current.depth > 4) {
+      continue;
+    }
+
+    const { value, depth } = current;
+    collected.push(value);
+
+    if (typeof value === 'string') {
+      try {
+        pending.push({ value: JSON.parse(value) as unknown, depth: depth + 1 });
+      } catch {
+        // Not JSON; the raw text is still useful for marker detection below.
+      }
+      continue;
+    }
+
+    if (!value || typeof value !== 'object' || seen.has(value)) {
+      continue;
+    }
+
+    seen.add(value);
+
+    for (const nested of Object.values(value)) {
+      pending.push({ value: nested, depth: depth + 1 });
+    }
+  }
+
+  return collected;
+}
+
+function normalizeCode(value: unknown): string | undefined {
+  const code = asString(value)?.trim().toLowerCase();
+  return code || undefined;
+}
+
+function isPolicyRefusal(values: unknown[]): boolean {
+  for (const value of values) {
+    const record = asRecord(value);
+    const code = normalizeCode(record?.code);
+    const name = normalizeCode(record?.name);
+
+    if ((code && POLICY_CODES.has(code)) || name === 'contentfiltererror') {
+      return true;
+    }
+
+    if (typeof value === 'string') {
+      const lower = value.toLowerCase();
+
+      if (
+        lower.includes('cyber_policy') ||
+        lower.includes('content_policy_violation') ||
+        lower.includes('flagged for possible cybersecurity risk') ||
+        lower.includes("blocked by the provider's content filter") ||
+        lower.includes('declined by the provider safety policy')
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function isExplicitlyTerminal(values: unknown[]): boolean {
+  for (const value of values) {
+    const record = asRecord(value);
+
+    if (record?.isRetryable === false) {
+      return true;
+    }
+
+    const statusCode =
+      asFiniteNumber(record?.statusCode) ?? asFiniteNumber(record?.status);
+
+    if (statusCode !== undefined && TERMINAL_STATUS_CODES.has(statusCode)) {
+      return true;
+    }
+
+    const code = normalizeCode(record?.code);
+
+    if (code && TERMINAL_CODES.has(code)) {
+      return true;
+    }
+
+    if (typeof value === 'string') {
+      const lower = value.toLowerCase();
+
+      if (
+        lower.includes('api key is missing') ||
+        lower.includes('invalid api key') ||
+        lower.includes('authentication failed') ||
+        lower.includes('model is not available') ||
+        lower.includes('model not found') ||
+        lower.includes('maximum context length') ||
+        lower.includes('insufficient quota')
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Provider session errors are recoverable by default because they normally
+ * invalidate one model turn, not the OpenCode session or Roomote task. Keep a
+ * small bounded retry budget, while explicit auth/configuration failures fail
+ * immediately instead of burning requests that cannot succeed.
+ */
+export function getOpenCodeProviderErrorRecovery(
+  error: unknown,
+): OpenCodeProviderErrorRecovery | null {
+  const values = collectProviderErrorValues(error);
+
+  if (isPolicyRefusal(values)) {
+    return {
+      kind: 'policy_refusal',
+      maxRetries: DEFAULT_OPENCODE_POLICY_REFUSAL_MAX_RETRIES,
+      promptText: OPENCODE_POLICY_REFUSAL_RETRY_PROMPT_TEXT,
+    };
+  }
+
+  if (isExplicitlyTerminal(values)) {
+    return null;
+  }
+
+  return {
+    kind: 'provider_error',
+    maxRetries: DEFAULT_OPENCODE_PROVIDER_ERROR_MAX_RETRIES,
+    promptText: OPENCODE_PROVIDER_ERROR_RETRY_PROMPT_TEXT,
+  };
+}
+
+export function formatOpenCodeProviderErrorRetryNoticeText(options: {
+  kind: OpenCodeProviderErrorRecovery['kind'];
+  attemptNumber: number;
+  maxAttempts: number;
+}): string {
+  const label =
+    options.kind === 'policy_refusal'
+      ? 'Provider safety refusal'
+      : 'Provider error';
+
+  return `${label}; automatically retrying the turn (attempt ${options.attemptNumber}/${options.maxAttempts}).`;
+}

--- a/apps/worker/src/sandbox-server/lib/tail-file-path.ts
+++ b/apps/worker/src/sandbox-server/lib/tail-file-path.ts
@@ -1,0 +1,138 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const TMP_ROOT = '/tmp';
+
+/**
+ * Validate a path accepted by sandbox log tails and return the path that
+ * should be passed to `tail`.
+ *
+ * Allowed:
+ * - workspace-relative paths (resolved against the sandbox cwd by the tail
+ *   process)
+ * - absolute paths confined under `/tmp` after realpath resolution — used for
+ *   harness.log, Docker project logs, and environment detached `logfile`s
+ *
+ * For absolute paths, the canonical target must remain under `/tmp` so a
+ * symlink such as `/tmp/link -> /etc/passwd` cannot bypass the boundary.
+ * When the file does not exist yet (common for followed logfiles), the
+ * deepest existing ancestor is realpath'd and remaining segments are
+ * re-joined, then re-checked under `/tmp`.
+ *
+ * Rejected: path traversal, shell metacharacters, and absolute paths outside
+ * `/tmp` (which would otherwise let clients read host files via `tail`).
+ */
+export function resolveSafeTailFilePath(filePath: string): string {
+  assertCommonPathRules(filePath);
+
+  if (!path.isAbsolute(filePath)) {
+    return filePath;
+  }
+
+  // Normalize so `/tmp/../etc/passwd` is rejected before resolution-work.
+  const normalized = path.posix.normalize(filePath);
+
+  if (!isStrictlyUnderTmp(normalized)) {
+    throw new Error('Absolute paths outside /tmp are not allowed');
+  }
+
+  const resolved = resolveAbsoluteUnderTmp(normalized);
+
+  if (!isStrictlyUnderTmp(resolved)) {
+    throw new Error('Absolute paths outside /tmp are not allowed');
+  }
+
+  return resolved;
+}
+
+/**
+ * Validate only (does not rewrite the path). Prefer
+ * `resolveSafeTailFilePath` when the resolved path will be passed to `tail`.
+ */
+export function assertSafeTailFilePath(filePath: string): void {
+  resolveSafeTailFilePath(filePath);
+}
+
+function assertCommonPathRules(filePath: string): void {
+  if (!filePath || filePath.trim() === '') {
+    throw new Error('Path cannot be empty');
+  }
+
+  if (filePath.includes('..')) {
+    throw new Error('Path traversal not allowed');
+  }
+
+  if (/[;|&$`"'\\<>(){}[\]*?!#~]/.test(filePath)) {
+    throw new Error('Invalid characters in path');
+  }
+
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f\x7f]/.test(filePath)) {
+    throw new Error('Control characters not allowed in path');
+  }
+}
+
+function isStrictlyUnderTmp(absolutePath: string): boolean {
+  // Require a path *inside* /tmp (not bare `/tmp` itself).
+  return absolutePath.startsWith(`${TMP_ROOT}/`);
+}
+
+function isTmpRootOrBelow(absolutePath: string): boolean {
+  return absolutePath === TMP_ROOT || isStrictlyUnderTmp(absolutePath);
+}
+
+/**
+ * realpath the target when it exists. For not-yet-created logfiles, realpath
+ * the deepest existing ancestor, re-join missing segments, and re-validate.
+ */
+function resolveAbsoluteUnderTmp(normalized: string): string {
+  try {
+    return fs.realpathSync.native(normalized);
+  } catch (error) {
+    if (!isEnoent(error)) {
+      throw error;
+    }
+  }
+
+  const missingSegments: string[] = [];
+  let current = normalized;
+
+  while (current !== '/' && !fs.existsSync(current)) {
+    missingSegments.unshift(path.posix.basename(current));
+    const parent = path.posix.dirname(current);
+
+    if (parent === current) {
+      break;
+    }
+
+    current = parent;
+  }
+
+  // Existing ancestor may be `/tmp` itself when the logfile has not been
+  // created yet.
+  if (!isTmpRootOrBelow(current) || !fs.existsSync(current)) {
+    throw new Error('Absolute paths outside /tmp are not allowed');
+  }
+
+  const realBase = fs.realpathSync.native(current);
+
+  if (!isTmpRootOrBelow(realBase)) {
+    throw new Error('Absolute paths outside /tmp are not allowed');
+  }
+
+  if (missingSegments.length === 0) {
+    return realBase;
+  }
+
+  // Join with posix so we never reintroduce platform separators under /tmp.
+  return path.posix.join(realBase, ...missingSegments);
+}
+
+function isEnoent(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: unknown }).code === 'ENOENT'
+  );
+}

--- a/apps/worker/src/sandbox-server/procedures/tailMulti.ts
+++ b/apps/worker/src/sandbox-server/procedures/tailMulti.ts
@@ -1,6 +1,5 @@
 import { TRPCError } from '@trpc/server';
 import { observable } from '@trpc/server/observable';
-import path from 'node:path';
 import { z } from 'zod';
 
 import type { TaggedStreamChunk } from '../types';
@@ -8,41 +7,17 @@ import type { TaggedStreamChunk } from '../types';
 import { publicProcedure } from '../trpc';
 
 import { CommandExecutor, type StreamHandle } from '../lib/command-executor';
+import { resolveSafeTailFilePath } from '../lib/tail-file-path';
 
 function validateFilePath(filePath: string): void {
-  if (!filePath || filePath.trim() === '') {
+  try {
+    // Validate only; CommandExecutor.tailStream resolves again immediately
+    // before spawn so the checked path matches the path passed to `tail`.
+    resolveSafeTailFilePath(filePath);
+  } catch (error) {
     throw new TRPCError({
       code: 'BAD_REQUEST',
-      message: 'Path cannot be empty',
-    });
-  }
-
-  if (path.isAbsolute(filePath)) {
-    throw new TRPCError({
-      code: 'BAD_REQUEST',
-      message: 'Absolute paths are not allowed',
-    });
-  }
-
-  if (filePath.includes('..')) {
-    throw new TRPCError({
-      code: 'BAD_REQUEST',
-      message: 'Path traversal not allowed',
-    });
-  }
-
-  if (/[;|&$`"'\\<>(){}[\]*?!#~]/.test(filePath)) {
-    throw new TRPCError({
-      code: 'BAD_REQUEST',
-      message: 'Invalid characters in path',
-    });
-  }
-
-  // eslint-disable-next-line no-control-regex
-  if (/[\x00-\x1f]/.test(filePath)) {
-    throw new TRPCError({
-      code: 'BAD_REQUEST',
-      message: 'Control characters not allowed in path',
+      message: error instanceof Error ? error.message : 'Invalid path',
     });
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roomote",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "FCL-1.0-ALv2",
   "packageManager": "pnpm@10.29.3",
   "engines": {

--- a/packages/communication/src/__tests__/mock-telegram-server.test.ts
+++ b/packages/communication/src/__tests__/mock-telegram-server.test.ts
@@ -328,7 +328,7 @@ describe('MockTelegramServer', () => {
       text: 'Okay — where should I run this?',
       buttons: [
         [{ text: 'web-app', callbackData: 'route_pick:def456UVW012:0' }],
-        [{ text: '✖️ Nevermind', callbackData: 'route_no:def456UVW012' }],
+        [{ text: '✖️ Never mind', callbackData: 'route_no:def456UVW012' }],
       ],
     });
 
@@ -339,7 +339,7 @@ describe('MockTelegramServer', () => {
     expect(message?.reply_markup).toEqual({
       inline_keyboard: [
         [{ text: 'web-app', callback_data: 'route_pick:def456UVW012:0' }],
-        [{ text: '✖️ Nevermind', callback_data: 'route_no:def456UVW012' }],
+        [{ text: '✖️ Never mind', callback_data: 'route_no:def456UVW012' }],
       ],
     });
 

--- a/packages/slack/src/block-kit.ts
+++ b/packages/slack/src/block-kit.ts
@@ -1385,7 +1385,7 @@ export async function showTaskConfiguration({
         },
         {
           type: 'button',
-          text: { type: 'plain_text', text: 'Nevermind', emoji: true },
+          text: { type: 'plain_text', text: 'Never mind', emoji: true },
           action_id: 'nevermind_task',
         },
       ],
@@ -2952,7 +2952,7 @@ export async function handleRoutingRejectNo(payload: SlackInteractivePayload) {
 }
 
 /**
- * Handles the "Nevermind" button click on the manual selection UI.
+ * Handles the "Never mind" button click on the manual selection UI.
  * Cleans up pending state and replaces the selection message with
  * a cancellation confirmation so the user knows the task was dropped.
  */

--- a/packages/types/src/__tests__/acp.test.ts
+++ b/packages/types/src/__tests__/acp.test.ts
@@ -252,6 +252,25 @@ describe('normalizeTranscriptUserText', () => {
     ).toBe(true);
   });
 
+  it('handles thousands of sequential valid thread_activity blocks without stack overflow', () => {
+    const blocks = Array.from(
+      { length: 2000 },
+      (_, i) =>
+        `<thread_activity>\nUser ${i}: passive note\n</thread_activity>`,
+    );
+    const activityOnly = blocks.join('\n\n');
+    const withMessage = `${activityOnly}\n\n<slack_message>\nlatest question\n</slack_message>`;
+
+    expect(
+      resolveAcpTranscriptVisibility({
+        eventType: 'roomote_runtime.user_prompt',
+        contentBlocks: [{ type: 'text', text: activityOnly }],
+      }),
+    ).toBe(false);
+    expect(normalizeTranscriptUserText(activityOnly)).toBe(activityOnly);
+    expect(normalizeTranscriptUserText(withMessage)).toBe('latest question');
+  });
+
   it('strips thread_activity that appears after thread_context', () => {
     expect(
       normalizeTranscriptUserText(

--- a/packages/types/src/acp.ts
+++ b/packages/types/src/acp.ts
@@ -1346,185 +1346,380 @@ function findStructuralClose(
 }
 
 function matchesThreadActivityOnlyFrom(text: string, index: number): boolean {
-  if (index === text.length) {
-    return true;
+  const openTag = '<thread_activity>';
+  const closeTag = '</thread_activity>';
+
+  // Iterative DFS with explicit close backtracking so long sequences of valid
+  // thread_activity blocks cannot overflow the call stack.
+  const alternateCloseFrom: number[] = [];
+  let pos = index;
+
+  while (true) {
+    if (pos === text.length) {
+      return true;
+    }
+
+    if (!text.startsWith(openTag, pos)) {
+      if (!advanceToNextCloseAlternate()) {
+        return false;
+      }
+      continue;
+    }
+
+    const closeIndex = text.indexOf(closeTag, pos + openTag.length);
+    if (closeIndex === -1) {
+      if (!advanceToNextCloseAlternate()) {
+        return false;
+      }
+      continue;
+    }
+
+    alternateCloseFrom.push(closeIndex + 1);
+    pos = skipAsciiWhitespace(text, closeIndex + closeTag.length);
   }
 
-  const openTag = '<thread_activity>';
-  if (!text.startsWith(openTag, index)) {
+  function advanceToNextCloseAlternate(): boolean {
+    while (alternateCloseFrom.length > 0) {
+      const nextFrom = alternateCloseFrom[alternateCloseFrom.length - 1]!;
+      const closeIndex = text.indexOf(closeTag, nextFrom);
+      if (closeIndex === -1) {
+        alternateCloseFrom.pop();
+        continue;
+      }
+
+      alternateCloseFrom[alternateCloseFrom.length - 1] = closeIndex + 1;
+      pos = skipAsciiWhitespace(text, closeIndex + closeTag.length);
+      return true;
+    }
+
     return false;
   }
-
-  const afterOpen = index + openTag.length;
-  const closeTag = '</thread_activity>';
-  const found = findStructuralClose(
-    text,
-    afterOpen,
-    closeTag,
-    (_close, afterClose) => matchesThreadActivityOnlyFrom(text, afterClose),
-  );
-
-  return found !== null;
 }
 
 function isSlackThreadActivityOnlyBlock(text: string): boolean {
   return text.length > 0 && matchesThreadActivityOnlyFrom(text, 0);
 }
 
-type SlackTranscriptParseStage =
-  | 'leading_activity'
-  | 'thread_context'
-  | 'trailing_activity'
-  | 'replying_to'
-  | 'slack_turn_policy'
-  | 'slack_message';
+/**
+ * Extract slack_message content from:
+ *   thread_activity* thread_context? thread_activity*
+ *   replying_to? slack_turn_policy? slack_message
+ *
+ * Implemented as the original recursive descent with per-(pos, phase) memoization,
+ * executed on an explicit heap stack so thousands of sequential activity blocks
+ * neither overflow the call stack nor O(n^2) re-scan.
+ */
+function extractSlackTranscriptMessageContent(text: string): string | null {
+  return parseSlackTranscriptFrom(text, 0);
+}
 
-function consumeNewlineWrappedBlockForStage(
-  text: string,
-  index: number,
-  tagName: string,
-  allowAttributes: boolean,
-  continueFrom: (afterClose: number) => string | null,
-): string | null {
-  const afterOpen = matchOpenTag(text, index, tagName, allowAttributes);
-  if (afterOpen === null || text[afterOpen] !== '\n') {
+function extractSlackMessageAt(text: string, index: number): string | null {
+  const afterOpen = matchOpenTag(text, index, 'slack_message', true);
+  if (afterOpen === null) {
     return null;
   }
 
-  const closeMarker = `\n</${tagName}>`;
+  let contentStart = afterOpen;
+  if (text[contentStart] === '\n') {
+    contentStart += 1;
+  }
+
+  const closeTag = '</slack_message>';
   const found = findStructuralClose(
     text,
-    afterOpen + 1,
-    closeMarker,
-    (_close, afterClose) => continueFrom(afterClose) !== null,
+    contentStart,
+    closeTag,
+    (_close, afterClose) => afterClose === text.length,
   );
   if (found === null) {
     return null;
   }
 
-  return continueFrom(found.afterClose);
+  let contentEnd = found.closeIndex;
+  if (contentEnd > contentStart && text[contentEnd - 1] === '\n') {
+    contentEnd -= 1;
+  }
+
+  return text.slice(contentStart, contentEnd);
 }
 
-function parseSlackTranscriptMessage(
-  text: string,
-  index: number,
-  stage: SlackTranscriptParseStage,
-): string | null {
-  switch (stage) {
-    case 'leading_activity': {
-      const consumed = consumeNewlineWrappedBlockForStage(
-        text,
-        index,
-        'thread_activity',
-        false,
-        (afterClose) =>
-          parseSlackTranscriptMessage(text, afterClose, 'leading_activity'),
-      );
-      if (consumed !== null) {
-        return consumed;
-      }
-
-      return parseSlackTranscriptMessage(text, index, 'thread_context');
+function parseSlackRestFrom(text: string, index: number): string | null {
+  const afterReplyingOpen = matchOpenTag(text, index, 'replying_to', true);
+  if (afterReplyingOpen !== null && text[afterReplyingOpen] === '\n') {
+    const closeMarker = '\n</replying_to>';
+    const found = findStructuralClose(
+      text,
+      afterReplyingOpen + 1,
+      closeMarker,
+      (_close, afterClose) => parseSlackRestAfterReplying(afterClose) !== null,
+    );
+    if (found !== null) {
+      return parseSlackRestAfterReplying(found.afterClose);
     }
+  }
 
-    case 'thread_context': {
-      const consumed = consumeNewlineWrappedBlockForStage(
-        text,
-        index,
-        'thread_context',
-        false,
-        (afterClose) =>
-          parseSlackTranscriptMessage(text, afterClose, 'trailing_activity'),
-      );
-      if (consumed !== null) {
-        return consumed;
-      }
+  return parseSlackRestAfterReplying(index);
 
-      return parseSlackTranscriptMessage(text, index, 'trailing_activity');
-    }
-
-    case 'trailing_activity': {
-      const consumed = consumeNewlineWrappedBlockForStage(
-        text,
-        index,
-        'thread_activity',
-        false,
-        (afterClose) =>
-          parseSlackTranscriptMessage(text, afterClose, 'trailing_activity'),
-      );
-      if (consumed !== null) {
-        return consumed;
-      }
-
-      return parseSlackTranscriptMessage(text, index, 'replying_to');
-    }
-
-    case 'replying_to': {
-      const consumed = consumeNewlineWrappedBlockForStage(
-        text,
-        index,
-        'replying_to',
-        true,
-        (afterClose) =>
-          parseSlackTranscriptMessage(text, afterClose, 'slack_turn_policy'),
-      );
-      if (consumed !== null) {
-        return consumed;
-      }
-
-      return parseSlackTranscriptMessage(text, index, 'slack_turn_policy');
-    }
-
-    case 'slack_turn_policy': {
-      const consumed = consumeNewlineWrappedBlockForStage(
-        text,
-        index,
-        'slack_turn_policy',
-        true,
-        (afterClose) =>
-          parseSlackTranscriptMessage(text, afterClose, 'slack_message'),
-      );
-      if (consumed !== null) {
-        return consumed;
-      }
-
-      return parseSlackTranscriptMessage(text, index, 'slack_message');
-    }
-
-    case 'slack_message': {
-      const afterOpen = matchOpenTag(text, index, 'slack_message', true);
-      if (afterOpen === null) {
-        return null;
-      }
-
-      let contentStart = afterOpen;
-      if (text[contentStart] === '\n') {
-        contentStart += 1;
-      }
-
-      const closeTag = '</slack_message>';
+  function parseSlackRestAfterReplying(at: number): string | null {
+    const afterPolicyOpen = matchOpenTag(text, at, 'slack_turn_policy', true);
+    if (afterPolicyOpen !== null && text[afterPolicyOpen] === '\n') {
+      const closeMarker = '\n</slack_turn_policy>';
       const found = findStructuralClose(
         text,
-        contentStart,
-        closeTag,
-        (_close, afterClose) => afterClose === text.length,
+        afterPolicyOpen + 1,
+        closeMarker,
+        (_close, afterClose) =>
+          extractSlackMessageAt(text, afterClose) !== null,
       );
-      if (found === null) {
-        return null;
+      if (found !== null) {
+        return extractSlackMessageAt(text, found.afterClose);
       }
-
-      let contentEnd = found.closeIndex;
-      if (contentEnd > contentStart && text[contentEnd - 1] === '\n') {
-        contentEnd -= 1;
-      }
-
-      return text.slice(contentStart, contentEnd);
     }
+
+    return extractSlackMessageAt(text, at);
   }
 }
 
-function extractSlackTranscriptMessageContent(text: string): string | null {
-  return parseSlackTranscriptMessage(text, 0, 'leading_activity');
+function parseSlackTranscriptFrom(text: string, start: number): string | null {
+  // phase: 0 = pre-context (leading activities), 1 = post-context (trailing + rest)
+  type Frame = {
+    pos: number;
+    phase: 0 | 1;
+    /** 0 init/activity; 1 scanning activity closes; 2 after child (activity or post); 3 scanning context closes; 4 rest */
+    mode: 0 | 1 | 2 | 3 | 4;
+    scanFrom: number;
+    childPos: number;
+    childPhase: 0 | 1;
+  };
+
+  const stride = text.length + 1;
+  const memo = new Map<number, string | null>();
+  const keyOf = (pos: number, phase: 0 | 1) => phase * stride + pos;
+
+  const stack: Frame[] = [
+    {
+      pos: start,
+      phase: 0,
+      mode: 0,
+      scanFrom: 0,
+      childPos: 0,
+      childPhase: 0,
+    },
+  ];
+  let lastResult: string | null = null;
+
+  while (stack.length > 0) {
+    const frame = stack[stack.length - 1]!;
+    const key = keyOf(frame.pos, frame.phase);
+
+    if (frame.mode === 0) {
+      if (memo.has(key)) {
+        lastResult = memo.get(key)!;
+        stack.pop();
+        continue;
+      }
+
+      // Prefer one thread_activity whose remainder solves in the same phase.
+      const afterOpen = matchOpenTag(text, frame.pos, 'thread_activity', false);
+      if (afterOpen !== null && text[afterOpen] === '\n') {
+        frame.scanFrom = afterOpen + 1;
+        frame.mode = 1;
+        continue;
+      }
+
+      // No activity open at this pos.
+      if (frame.phase === 0) {
+        // Optional thread_context, else post phase at same pos.
+        const ctxOpen = matchOpenTag(text, frame.pos, 'thread_context', false);
+        if (ctxOpen !== null && text[ctxOpen] === '\n') {
+          frame.scanFrom = ctxOpen + 1;
+          frame.mode = 3;
+          continue;
+        }
+        frame.childPos = frame.pos;
+        frame.childPhase = 1;
+        frame.mode = 2;
+        const childKey = keyOf(frame.childPos, 1);
+        if (memo.has(childKey)) {
+          lastResult = memo.get(childKey)!;
+        } else {
+          stack.push({
+            pos: frame.childPos,
+            phase: 1,
+            mode: 0,
+            scanFrom: 0,
+            childPos: 0,
+            childPhase: 0,
+          });
+        }
+        continue;
+      }
+
+      // phase post: fall through to rest.
+      frame.mode = 4;
+      continue;
+    }
+
+    if (frame.mode === 1) {
+      const closeMarker = '\n</thread_activity>';
+      const closeIndex = text.indexOf(closeMarker, frame.scanFrom);
+      if (closeIndex === -1) {
+        // No more activity closes — fall through like mode 0 without activity.
+        if (frame.phase === 0) {
+          const ctxOpen = matchOpenTag(
+            text,
+            frame.pos,
+            'thread_context',
+            false,
+          );
+          if (ctxOpen !== null && text[ctxOpen] === '\n') {
+            frame.scanFrom = ctxOpen + 1;
+            frame.mode = 3;
+            continue;
+          }
+          frame.childPos = frame.pos;
+          frame.childPhase = 1;
+          frame.mode = 2;
+          const childKey = keyOf(frame.childPos, 1);
+          if (memo.has(childKey)) {
+            lastResult = memo.get(childKey)!;
+          } else {
+            stack.push({
+              pos: frame.childPos,
+              phase: 1,
+              mode: 0,
+              scanFrom: 0,
+              childPos: 0,
+              childPhase: 0,
+            });
+          }
+          continue;
+        }
+        frame.mode = 4;
+        continue;
+      }
+
+      frame.childPos = skipAsciiWhitespace(
+        text,
+        closeIndex + closeMarker.length,
+      );
+      frame.childPhase = frame.phase;
+      frame.scanFrom = closeIndex + 1;
+      frame.mode = 2;
+
+      const childKey = keyOf(frame.childPos, frame.childPhase);
+      if (memo.has(childKey)) {
+        lastResult = memo.get(childKey)!;
+      } else {
+        stack.push({
+          pos: frame.childPos,
+          phase: frame.childPhase,
+          mode: 0,
+          scanFrom: 0,
+          childPos: 0,
+          childPhase: 0,
+        });
+      }
+      continue;
+    }
+
+    if (frame.mode === 2) {
+      // Child finished in lastResult.
+      if (lastResult !== null) {
+        memo.set(key, lastResult);
+        stack.pop();
+        continue;
+      }
+
+      // Child failed. If we were probing activity closes, try next close;
+      // if we were probing context, try next context close; if post-at-pos failed, done.
+      // Distinguish via childPhase and whether scan is activity vs context:
+      // activity probe uses childPhase === frame.phase and scan on activity closes.
+      // We need a flag: use mode transitions carefully.
+
+      // Heuristic: if scanFrom was activity (mode came from 1), resume mode 1.
+      // If from context (mode 3), resume mode 3.
+      // If from post-at-pos fallback (childPos === pos && childPhase === 1 && phase === 0), fail.
+      if (
+        frame.phase === 0 &&
+        frame.childPhase === 1 &&
+        frame.childPos === frame.pos
+      ) {
+        memo.set(key, null);
+        lastResult = null;
+        stack.pop();
+        continue;
+      }
+
+      if (frame.childPhase === frame.phase) {
+        // activity child failed — next activity close
+        frame.mode = 1;
+        continue;
+      }
+
+      // context child failed — next context close
+      frame.mode = 3;
+      continue;
+    }
+
+    if (frame.mode === 3) {
+      const closeMarker = '\n</thread_context>';
+      const closeIndex = text.indexOf(closeMarker, frame.scanFrom);
+      if (closeIndex === -1) {
+        // No more context — post at same position.
+        frame.childPos = frame.pos;
+        frame.childPhase = 1;
+        frame.mode = 2;
+        const childKey = keyOf(frame.childPos, 1);
+        if (memo.has(childKey)) {
+          lastResult = memo.get(childKey)!;
+        } else {
+          stack.push({
+            pos: frame.childPos,
+            phase: 1,
+            mode: 0,
+            scanFrom: 0,
+            childPos: 0,
+            childPhase: 0,
+          });
+        }
+        continue;
+      }
+
+      frame.childPos = skipAsciiWhitespace(
+        text,
+        closeIndex + closeMarker.length,
+      );
+      frame.childPhase = 1;
+      frame.scanFrom = closeIndex + 1;
+      frame.mode = 2;
+
+      const childKey = keyOf(frame.childPos, 1);
+      if (memo.has(childKey)) {
+        lastResult = memo.get(childKey)!;
+      } else {
+        stack.push({
+          pos: frame.childPos,
+          phase: 1,
+          mode: 0,
+          scanFrom: 0,
+          childPos: 0,
+          childPhase: 0,
+        });
+      }
+      continue;
+    }
+
+    // mode 4: rest
+    {
+      const result = parseSlackRestFrom(text, frame.pos);
+      memo.set(key, result);
+      lastResult = result;
+      stack.pop();
+    }
+  }
+
+  return memo.get(keyOf(start, 0)) ?? null;
 }
 
 function extractCommunicationTranscriptMessage(text: string): string | null {


### PR DESCRIPTION
## Promote v0.8.1

Frozen at `0fc063342ecdb8b35e4990ece19df51086cd0a10` — the commit where `0.8.1` was versioned. Commits merged to `develop` after that point ship in the next release.

- Merge this PR with a **merge commit** (do not squash or rebase).
- If multiple promote PRs are open, merge them in version order (oldest first).
- Merging publishes a GitHub Release for `v0.8.1` and triggers the existing GHCR `v*` image publish (`latest` channel).
- The `release/v0.8.1` branch can be deleted after this PR merges.

### Changelog

## 0.8.1 (2026-07-17)

### Patch changes

- Clarify Review Code wording and section ordering on the Automations settings page so source-code, Slack, manager, and meta automations are easier to scan.
- Create account and other credential fields no longer block password managers, so 1Password can offer to generate and save passwords on signup.
- Task log tails again allow intentional `/tmp` paths such as harness and environment log files, while still blocking absolute paths outside that boundary.
- Spell cancel buttons as **Never mind** (two words) on Slack, Discord, and Telegram task and workspace pickers.
- Recover from bounded model-provider turn errors, including safety-policy refusals, without immediately aborting the Roomote task.
- Slack transcript decoding no longer crashes with a stack overflow when a thread contains a long sequence of thread-activity blocks.
