### PR TITLE
[Improve] Make Telegram task topic handoffs explicit

### DIFF
--- a/apps/api/src/handlers/telegram/__tests__/index.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/index.test.ts
@@ -1828,7 +1828,7 @@ describe('Telegram webhook handler', () => {
     );
     expect(postMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        text: 'Started a task in Web App.',
+        text: "Started a task in Web App here because I couldn't create a new Telegram topic. If this keeps happening, check Threaded Mode or the bot's Manage Topics permission.",
       }),
     );
   });

--- a/apps/api/src/handlers/telegram/__tests__/task-launch.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/task-launch.test.ts
@@ -74,7 +74,7 @@ describe('Telegram task topic launch', () => {
       },
       metadata: {
         communicationProvider: 'telegram',
-        communicationChannelId: '111000111',
+        communicationChannelId: '-100111000111',
         communicationMessageId: '42',
       },
       workspace: {
@@ -85,7 +85,7 @@ describe('Telegram task topic launch', () => {
     });
 
     expect(createTelegramForumTopicBestEffortMock).toHaveBeenCalledWith({
-      chatId: '111000111',
+      chatId: '-100111000111',
       name: 'Fix the flaky login test',
     });
     expect(enqueueTaskMock).toHaveBeenCalledWith(
@@ -93,7 +93,7 @@ describe('Telegram task topic launch', () => {
         task: expect.objectContaining({
           payload: expect.objectContaining({
             communicationProvider: 'telegram',
-            communicationChannelId: '111000111',
+            communicationChannelId: '-100111000111',
             communicationThreadId: '77',
           }),
         }),
@@ -103,18 +103,36 @@ describe('Telegram task topic launch', () => {
     const enqueuedPayload = enqueueTaskMock.mock.calls[0]?.[0].task.payload;
     expect(enqueuedPayload.communicationMessageId).toBe('900');
     expect(postTelegramMessageBestEffortMock).toHaveBeenNthCalledWith(1, {
-      chatId: '111000111',
+      chatId: '-100111000111',
       threadId: '77',
       text: 'Task request from Grace:\n\nFix the flaky login test',
     });
     expect(postTelegramMessageBestEffortMock).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        chatId: '111000111',
+        chatId: '-100111000111',
         threadId: '77',
         replyToMessageId: '900',
       }),
     );
+    expect(postTelegramMessageBestEffortMock).toHaveBeenNthCalledWith(3, {
+      chatId: '-100111000111',
+      threadId: undefined,
+      replyToMessageId: '42',
+      text: 'Started “Fix the flaky login test” in a new topic.',
+      buttons: [
+        [
+          {
+            text: 'Open topic',
+            url: 'https://t.me/c/111000111/77/900',
+          },
+          {
+            text: 'Follow Task',
+            url: 'https://roomote.example.test/tasks/task-1',
+          },
+        ],
+      ],
+    });
 
     const onEarlyTitleGenerated = enqueueTaskMock.mock.calls[0]?.[1]
       .onEarlyTitleGenerated as (input: {
@@ -126,9 +144,52 @@ describe('Telegram task topic launch', () => {
       taskRun: { taskId: 'task-1' },
     });
     expect(editTelegramForumTopicBestEffortMock).toHaveBeenCalledWith({
-      chatId: '111000111',
+      chatId: '-100111000111',
       threadId: '77',
       name: 'Fix flaky login tests',
+    });
+  });
+
+  it('names the new topic in private chats where Telegram cannot deep-link it', async () => {
+    createTelegramForumTopicBestEffortMock.mockResolvedValue({
+      threadId: '77',
+    });
+
+    await launchTelegramTask({
+      launchOwnerUserId: 'user-1',
+      queuedMessage: {
+        provider: 'telegram',
+        user: 'Grace',
+        userId: 'user-1',
+        text: 'Fix the flaky login test',
+        ts: '42',
+        channel: '111000111',
+      },
+      metadata: {
+        communicationProvider: 'telegram',
+        communicationChannelId: '111000111',
+        communicationMessageId: '42',
+      },
+      workspace: {
+        repoForPayload: 'roomote/roomote',
+        workspaceDisplayName: 'Roomote',
+      },
+      createTopicForTask: true,
+    });
+
+    expect(postTelegramMessageBestEffortMock).toHaveBeenNthCalledWith(3, {
+      chatId: '111000111',
+      threadId: undefined,
+      replyToMessageId: '42',
+      text: "Started “Fix the flaky login test” in a new topic. Open it from Telegram's topic list.",
+      buttons: [
+        [
+          {
+            text: 'Follow Task',
+            url: 'https://roomote.example.test/tasks/task-1',
+          },
+        ],
+      ],
     });
   });
 
@@ -171,6 +232,7 @@ describe('Telegram task topic launch', () => {
       expect.objectContaining({
         chatId: '111000111',
         replyToMessageId: '42',
+        text: "Started a task in Roomote here because I couldn't create a new Telegram topic. If this keeps happening, check Threaded Mode or the bot's Manage Topics permission.",
       }),
     );
   });

--- a/apps/api/src/handlers/telegram/task-launch.ts
+++ b/apps/api/src/handlers/telegram/task-launch.ts
@@ -1,6 +1,7 @@
 import type { TelegramUpdateCommunicationMetadata } from '@roomote/communication/telegram-update';
 import {
   ALL_REPOSITORIES,
+  buildTelegramMessagePermalink,
   TaskPayloadKind,
   type TaskSpec,
 } from '@roomote/types';
@@ -179,7 +180,7 @@ export async function launchTelegramTask(input: {
     utm: { source: 'telegram', campaign: 'telegram.thread_start' },
   });
 
-  await postTelegramMessageBestEffort({
+  const taskAcknowledgement = await postTelegramMessageBestEffort({
     chatId: metadata.communicationChannelId,
     threadId: metadata.communicationThreadId,
     // The source message is in the previous topic (usually General), so only
@@ -187,9 +188,11 @@ export async function launchTelegramTask(input: {
     replyToMessageId: createdTopic
       ? topicRootMessage?.messageId
       : metadata.communicationMessageId,
-    text: taskUrl
-      ? `Started a task in ${input.workspace.workspaceDisplayName}.`
-      : `Queued a task in ${input.workspace.workspaceDisplayName}.`,
+    text: buildTelegramTaskAcknowledgementText({
+      workspaceDisplayName: input.workspace.workspaceDisplayName,
+      started: Boolean(taskUrl),
+      topicCreationFailed: Boolean(input.createTopicForTask && !createdTopic),
+    }),
     buttons: [
       ...(taskUrl ? [[{ text: 'Follow Task', url: taskUrl }]] : []),
       [
@@ -201,7 +204,44 @@ export async function launchTelegramTask(input: {
     ],
   });
 
+  if (createdTopic) {
+    const topicUrl = buildTelegramMessagePermalink({
+      chatId: input.metadata.communicationChannelId,
+      threadId: createdTopic.threadId,
+      messageId:
+        topicRootMessage?.messageId ?? taskAcknowledgement?.messageId ?? null,
+    });
+
+    await postTelegramMessageBestEffort({
+      chatId: input.metadata.communicationChannelId,
+      threadId: input.metadata.communicationThreadId,
+      replyToMessageId: input.metadata.communicationMessageId,
+      text: topicUrl
+        ? `Started “${topicName}” in a new topic.`
+        : `Started “${topicName}” in a new topic. Open it from Telegram's topic list.`,
+      buttons: [
+        [
+          ...(topicUrl ? [{ text: 'Open topic', url: topicUrl }] : []),
+          ...(taskUrl ? [{ text: 'Follow Task', url: taskUrl }] : []),
+        ],
+      ].filter((row) => row.length > 0),
+    });
+  }
+
   return launchResult;
+}
+
+function buildTelegramTaskAcknowledgementText(input: {
+  workspaceDisplayName: string;
+  started: boolean;
+  topicCreationFailed: boolean;
+}): string {
+  const action = input.started ? 'Started' : 'Queued';
+  const base = `${action} a task in ${input.workspaceDisplayName}`;
+
+  return input.topicCreationFailed
+    ? `${base} here because I couldn't create a new Telegram topic. If this keeps happening, check Threaded Mode or the bot's Manage Topics permission.`
+    : `${base}.`;
 }
 
 const TELEGRAM_TASK_TOPIC_NAME_MAX_LENGTH = 96;

--- a/apps/docs/providers/communications/telegram.mdx
+++ b/apps/docs/providers/communications/telegram.mdx
@@ -24,9 +24,11 @@ menu for you.
 
 In BotFather, open **Bot Settings > Threaded Mode** and enable it. Roomote will
 then create a separate topic in your private bot chat for each new task. If
-Threaded Mode is unavailable or disabled, Roomote falls back to the existing
-single-chat flow. Telegram's Bot Developer Terms currently withhold a 15% fee
-from Stars purchases made through a bot while private-chat topics are enabled.
+Threaded Mode is unavailable or disabled, Roomote uses the existing single-chat
+flow. When a new topic opens, Roomote replies in the source conversation with
+its name; open it from Telegram's topic list. Telegram's Bot Developer Terms
+currently withhold a 15% fee from Stars purchases made through a bot while
+private-chat topics are enabled.
 When Telegram initially labels an implicit topic **New Chat**, Roomote replaces
 it with the same generated title shown for the task in the web app.
 
@@ -34,7 +36,10 @@ For a shared team chat, create a Telegram supergroup, enable topics, then add
 the Roomote bot as an administrator with **Manage Topics** permission. Telegram
 requires a user to create the group and enable topics; the Bot API cannot do
 those provisioning steps. Once configured, Roomote can create task topics in
-the forum automatically.
+the forum automatically. The source conversation receives an **Open topic**
+button so the handoff is visible instead of relying on the topic list alone.
+If Telegram rejects topic creation, Roomote starts the task in the source
+conversation and explains that Threaded Mode or **Manage Topics** needs attention.
 
 For self-hosted env-var configuration instead of the UI:
 

--- a/packages/communication/src/__tests__/telegram-update.test.ts
+++ b/packages/communication/src/__tests__/telegram-update.test.ts
@@ -230,6 +230,86 @@ describe('Telegram update helpers', () => {
     });
   });
 
+  it('accepts Telegram bot profile links as group mentions', () => {
+    const parsed = parseTelegramUpdate({
+      update_id: 1006,
+      message: {
+        message_id: 47,
+        text: '@roomote_bot what changed this week?',
+        from: {
+          id: 123,
+          first_name: 'Ada',
+          username: 'ada',
+        },
+        chat: {
+          id: -100456,
+          type: 'supergroup',
+          title: 'Engineering',
+          is_forum: true,
+        },
+        entities: [
+          {
+            type: 'text_link',
+            offset: 0,
+            length: 12,
+            url: 'https://t.me/roomote_bot',
+          },
+        ],
+      },
+    });
+
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) {
+      return;
+    }
+
+    expect(
+      isTelegramTaskEntryUpdate(parsed.data, {
+        botUsername: 'roomote_bot',
+      }),
+    ).toBe(true);
+    expect(
+      telegramUpdateToQueuedCommunicationMessage(parsed.data, {
+        botUsername: 'roomote_bot',
+        userId: 'user-1',
+      }),
+    ).toMatchObject({
+      text: 'what changed this week?',
+      userId: 'user-1',
+    });
+  });
+
+  it('does not treat a text link to another Telegram account as a bot mention', () => {
+    const parsed = parseTelegramUpdate({
+      update_id: 1007,
+      message: {
+        message_id: 48,
+        text: '@roomote_bot run the tests',
+        chat: {
+          id: -100456,
+          type: 'supergroup',
+          title: 'Engineering',
+          is_forum: true,
+        },
+        entities: [
+          {
+            type: 'text_link',
+            offset: 0,
+            length: 12,
+            url: 'https://t.me/not_roomote',
+          },
+        ],
+      },
+    });
+
+    expect(parsed.success).toBe(true);
+    expect(
+      isTelegramTaskEntryUpdate(parsed.data!, {
+        botUsername: 'roomote_bot',
+      }),
+    ).toBe(false);
+  });
+
   it('treats a bot command as an invocation only when it leads the message', () => {
     const buildUpdate = (
       text: string,

--- a/packages/communication/src/telegram-update.ts
+++ b/packages/communication/src/telegram-update.ts
@@ -29,6 +29,7 @@ const telegramMessageEntitySchema = z
     type: z.string(),
     offset: z.number().int(),
     length: z.number().int(),
+    url: z.string().optional(),
   })
   .passthrough();
 
@@ -281,6 +282,59 @@ function isMatchingBotMention(
 
 type TelegramMessageEntity = z.infer<typeof telegramMessageEntitySchema>;
 
+function isMatchingBotTextLink(
+  entityText: string,
+  entity: TelegramMessageEntity,
+  options: TelegramBotMentionOptions,
+): boolean {
+  const botUsername = normalizeTelegramBotUsername(options.botUsername);
+  const entityUrl = entity.url;
+
+  if (
+    !botUsername ||
+    typeof entityUrl !== 'string' ||
+    !isMatchingBotMention(entityText, options)
+  ) {
+    return false;
+  }
+
+  try {
+    const url = new URL(entityUrl);
+    const hostname = url.hostname.toLowerCase();
+    const linkedUsername = url.pathname
+      .split('/')
+      .filter(Boolean)[0]
+      ?.toLowerCase();
+
+    return (
+      url.protocol === 'https:' &&
+      ['t.me', 'www.t.me', 'telegram.me', 'www.telegram.me'].includes(
+        hostname,
+      ) &&
+      linkedUsername === botUsername
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isMatchingBotInvocationEntity(
+  text: string,
+  entity: TelegramMessageEntity,
+  options: TelegramBotMentionOptions,
+): boolean {
+  const entityText = readEntityText(text, entity);
+
+  if (entity.type === 'mention') {
+    return isMatchingBotMention(entityText, options);
+  }
+
+  return (
+    entity.type === 'text_link' &&
+    isMatchingBotTextLink(entityText, entity, options)
+  );
+}
+
 function findLeadingBotMentionBefore(
   text: string,
   entities: TelegramMessageEntity[],
@@ -289,9 +343,8 @@ function findLeadingBotMentionBefore(
 ): TelegramMessageEntity | undefined {
   return entities.find(
     (candidate) =>
-      candidate.type === 'mention' &&
       candidate.offset + candidate.length <= offset &&
-      isMatchingBotMention(readEntityText(text, candidate), options),
+      isMatchingBotInvocationEntity(text, candidate, options),
   );
 }
 
@@ -331,8 +384,8 @@ function getTelegramInvocationEntity(
   return entities.find((entity) => {
     const entityText = readEntityText(text, entity);
 
-    if (entity.type === 'mention') {
-      return isMatchingBotMention(entityText, options);
+    if (entity.type === 'mention' || entity.type === 'text_link') {
+      return isMatchingBotInvocationEntity(text, entity, options);
     }
 
     if (entity.type === 'bot_command') {


### PR DESCRIPTION
## Summary

- reply in the source Telegram conversation when a task moves into a new topic
- link directly to the new forum topic when Telegram exposes a permalink
- explain same-chat fallback when Telegram rejects topic creation
- recognize Telegram bot-profile links as group invocations
- document the resulting private-chat and forum-supergroup behavior

## Behavior

Before, the source message received an eyes reaction and the task topic appeared silently. A topic creation failure also silently started the task in the source chat.

After, the source conversation names the new topic and offers Open topic and Follow Task actions. If topic creation fails, the started message says why the task remained in the current conversation and points to Threaded Mode or Manage Topics.

The first preview shows the forum-supergroup variant. Private bot topics receive the same handoff, but direct users to Telegram's topic list instead of showing an Open topic deep link.

### Topic handoff

<img width="664" height="453" alt="Before and after: Telegram task topic handoff" src="https://github.com/user-attachments/assets/9d8b41d8-fd9c-4005-8196-ae091fb26433" />

### Inside the task topic

<img width="671" height="438" alt="Before and after: messages inside the Telegram task topic" src="https://github.com/user-attachments/assets/51fb349f-fe1b-4102-ad07-539734cf6ead" />

### Topic creation fallback

<img width="657" height="480" alt="Before and after: Telegram topic creation permission failure" src="https://github.com/user-attachments/assets/089c3928-5908-4115-8ad3-27b23c6e6e1c" />

### Real example

<img width="727" height="239" alt="image" src="https://github.com/user-attachments/assets/77827429-b8ac-46fc-a1e8-f91ca0b78281" />


## Validation

- 169 communication package tests, including the Telegram mock provider and server
- 79 Telegram API handler tests
- communication and API typechecks
- communication lint
- API production build
- formatting checks
- Mintlify build validation and broken-link check
