### PR TITLE
[Improve] Poll and notify while a GitHub install request is pending

### DIFF
--- a/apps/api/src/handlers/github/__tests__/handleInstallationCreated.test.ts
+++ b/apps/api/src/handlers/github/__tests__/handleInstallationCreated.test.ts
@@ -1,0 +1,76 @@
+const { mockCompletePendingGitHubInstallation, mockSendUserDirectMessage } =
+  vi.hoisted(() => ({
+    mockCompletePendingGitHubInstallation: vi.fn(),
+    mockSendUserDirectMessage: vi.fn(),
+  }));
+
+vi.mock('@roomote/github', () => ({
+  completePendingGitHubInstallation: mockCompletePendingGitHubInstallation,
+}));
+
+vi.mock('@roomote/sdk/server', () => ({
+  sendUserDirectMessageBestEffort: mockSendUserDirectMessage,
+}));
+
+vi.mock('@roomote/env', () => ({
+  Env: { R_APP_URL: 'https://roomote.example.com' },
+}));
+
+import { handleInstallationCreated } from '../handleInstallationCreated';
+import type { WebhookInstallationCreated } from '../types';
+
+const payload = {
+  installation: { id: 42 },
+} as unknown as WebhookInstallationCreated;
+
+describe('handleInstallationCreated', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSendUserDirectMessage.mockResolvedValue(['slack']);
+  });
+
+  it('notifies the requesting user after completing a pending installation', async () => {
+    mockCompletePendingGitHubInstallation.mockResolvedValue({
+      success: true,
+      githubInstallation: { accountLogin: 'acme-inc' },
+      repositories: [],
+      requestedByUserId: 'user-1',
+    });
+
+    const response = await handleInstallationCreated(payload);
+
+    expect(response).toEqual({ status: 'ok' });
+    expect(mockCompletePendingGitHubInstallation).toHaveBeenCalledWith(42);
+    expect(mockSendUserDirectMessage).toHaveBeenCalledWith({
+      userId: 'user-1',
+      text: 'Your GitHub installation request for acme-inc was approved, and Roomote is now connected. Continue setup here: https://roomote.example.com/setup',
+      logContext: 'handleInstallationCreated',
+    });
+  });
+
+  it('does not notify when completion fails', async () => {
+    mockCompletePendingGitHubInstallation.mockResolvedValue({
+      success: false,
+      error: 'sync failed',
+    });
+
+    const response = await handleInstallationCreated(payload);
+
+    expect(response).toEqual({ status: 'ok' });
+    expect(mockSendUserDirectMessage).not.toHaveBeenCalled();
+  });
+
+  it('still acks the webhook when completion throws', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockCompletePendingGitHubInstallation.mockRejectedValue(
+      new Error('Pending GitHub installation not found'),
+    );
+
+    const response = await handleInstallationCreated(payload);
+
+    expect(response).toEqual({ status: 'ok' });
+    expect(mockSendUserDirectMessage).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+});

--- a/apps/api/src/handlers/github/handleInstallationCreated.ts
+++ b/apps/api/src/handlers/github/handleInstallationCreated.ts
@@ -1,14 +1,36 @@
 import { completePendingGitHubInstallation } from '@roomote/github';
+import { sendUserDirectMessageBestEffort } from '@roomote/sdk/server';
+import { Env } from '@roomote/env';
 
 import type { WebhookResponse } from '../../types';
 
 import type { WebhookInstallationCreated } from './types';
 
+function buildInstallationApprovedMessage(accountLogin: string): string {
+  const setupUrl = new URL('/setup', Env.R_APP_URL).toString();
+
+  return `Your GitHub installation request for ${accountLogin} was approved, and Roomote is now connected. Continue setup here: ${setupUrl}`;
+}
+
 export async function handleInstallationCreated(
   payload: WebhookInstallationCreated,
 ): Promise<WebhookResponse> {
   try {
-    await completePendingGitHubInstallation(payload.installation.id);
+    const result = await completePendingGitHubInstallation(
+      payload.installation.id,
+    );
+
+    if (result.success) {
+      // The requester was waiting on a GitHub org owner's approval; let them
+      // know on whichever chat integrations they have linked.
+      await sendUserDirectMessageBestEffort({
+        userId: result.requestedByUserId,
+        text: buildInstallationApprovedMessage(
+          result.githubInstallation.accountLogin,
+        ),
+        logContext: 'handleInstallationCreated',
+      });
+    }
   } catch (error) {
     console.error(
       `[handleInstallationCreated] Failed to complete pending GitHub installation: ${error instanceof Error ? error.message : String(error)}`,

--- a/apps/web/src/app/(centered)/github/callback/GitHubCallbackPage.tsx
+++ b/apps/web/src/app/(centered)/github/callback/GitHubCallbackPage.tsx
@@ -238,26 +238,29 @@ export default function Page() {
 
   return (
     <div className="flex flex-col items-center justify-center gap-2">
-      <div className="flex items-center justify-center gap-2">
-        {isLoading ? (
-          <Github className="animate-pulse" />
-        ) : isInstallRequested || isInstalled || isAuthenticated ? (
-          <CircleCheck className="text-green-500" />
-        ) : (
-          <CircleX className="text-rose-500" />
-        )}
-        <div className="text-sm">
-          {isInstallRequested
-            ? 'GitHub Link Requested'
-            : isAuthenticated
+      {/* The pending-request card carries its own explanation, so the status
+          header (and its success check) would just be a misleading tick while
+          the request is still awaiting approval. */}
+      {!isInstallRequested && (
+        <div className="flex items-center justify-center gap-2">
+          {isLoading ? (
+            <Github className="animate-pulse" />
+          ) : isInstalled || isAuthenticated ? (
+            <CircleCheck className="text-green-500" />
+          ) : (
+            <CircleX className="text-rose-500" />
+          )}
+          <div className="text-sm">
+            {isAuthenticated
               ? 'GitHub Account Linked'
               : isInstalled
                 ? 'GitHub Linked'
                 : error
                   ? 'Error'
                   : 'GitHub Linking...'}
+          </div>
         </div>
-      </div>
+      )}
       {error && (
         <>
           <Alert variant="destructive">

--- a/apps/web/src/app/(centered)/github/callback/GitHubCallbackPage.tsx
+++ b/apps/web/src/app/(centered)/github/callback/GitHubCallbackPage.tsx
@@ -46,12 +46,11 @@ import {
   useFinishAuthenticateGitHubAccount,
   useFinishCreateGitHubAppManifest,
   useFinishCreateGitHubInstallation,
-  useGitHubPendingInstallations,
-  useResolvePendingGitHubInstallations,
   useSyncGitHubInstallation,
 } from '@/hooks/github';
 
 import { Alert, AlertDescription, Button } from '@/components/system';
+import { GitHubInstallRequestPending } from '@/components/github/GitHubInstallRequestPending';
 
 export default function Page() {
   const router = useRouter();
@@ -63,9 +62,6 @@ export default function Page() {
   const [isInstalled, setIsInstalled] = useState(false);
   const [isInstallRequested, setIsInstallRequested] = useState(false);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
-  const [manualCheckMessage, setManualCheckMessage] = useState<string | null>(
-    null,
-  );
   const [error, setError] = useState<string | null>(null);
   useRedirectToSignIn(authStatus === 'signed-out');
 
@@ -159,43 +155,11 @@ export default function Page() {
     },
   });
 
-  // While the install request awaits an org owner's approval, poll for the
-  // webhook-driven completion (which deletes the pending row) so the user can
-  // continue without manually revisiting setup.
-  const pendingInstallations = useGitHubPendingInstallations({
-    enabled: isInstallRequested,
-    refetchInterval: 10_000,
-  });
-
-  const resolvePendingInstallations = useResolvePendingGitHubInstallations({
-    onSuccess: (result) => {
-      if (result.success && result.completed > 0) {
-        setIsInstallRequested(false);
-        setIsInstalled(true);
-        navigateFromState();
-      } else if (result.success) {
-        setManualCheckMessage(
-          'Not approved yet. Hang tight, this page keeps checking on its own.',
-        );
-      } else {
-        setManualCheckMessage(result.error);
-      }
-    },
-    onError: (error) => {
-      setManualCheckMessage(error.message);
-    },
-  });
-
-  const isInstallRequestApproved =
-    isInstallRequested && pendingInstallations.data?.pending === false;
-
-  useEffect(() => {
-    if (isInstallRequestApproved) {
-      setIsInstallRequested(false);
-      setIsInstalled(true);
-      navigateFromState();
-    }
-  }, [isInstallRequestApproved, navigateFromState]);
+  const handleInstallApproved = useCallback(() => {
+    setIsInstallRequested(false);
+    setIsInstalled(true);
+    navigateFromState();
+  }, [navigateFromState]);
 
   const hasHandledCallback = useRef(false);
 
@@ -317,44 +281,18 @@ export default function Page() {
         </>
       )}
       {isInstallRequested && (
-        <Alert className="w-sm">
-          <AlertDescription>
-            <div className="flex flex-col gap-4">
-              <div>
-                Your request is pending approval from a GitHub organization
-                owner. You can wait here and we&apos;ll continue automatically
-                once it&apos;s approved.
-              </div>
-              {manualCheckMessage && (
-                <div className="text-muted-foreground">
-                  {manualCheckMessage}
-                </div>
-              )}
-              <div className="flex items-center gap-2 self-center">
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  disabled={resolvePendingInstallations.isPending}
-                  onClick={() => {
-                    setManualCheckMessage(null);
-                    resolvePendingInstallations.mutate();
-                  }}
-                >
-                  {resolvePendingInstallations.isPending
-                    ? 'Checking...'
-                    : 'Check now'}
-                </Button>
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => router.push('/')}
-                >
-                  <Home />
-                </Button>
-              </div>
-            </div>
-          </AlertDescription>
-        </Alert>
+        <GitHubInstallRequestPending
+          onApproved={handleInstallApproved}
+          footer={
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => router.push('/')}
+            >
+              <Home />
+            </Button>
+          }
+        />
       )}
     </div>
   );

--- a/apps/web/src/app/(centered)/github/callback/GitHubCallbackPage.tsx
+++ b/apps/web/src/app/(centered)/github/callback/GitHubCallbackPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { z } from 'zod';
 import {
@@ -46,6 +46,8 @@ import {
   useFinishAuthenticateGitHubAccount,
   useFinishCreateGitHubAppManifest,
   useFinishCreateGitHubInstallation,
+  useGitHubPendingInstallations,
+  useResolvePendingGitHubInstallations,
   useSyncGitHubInstallation,
 } from '@/hooks/github';
 
@@ -61,6 +63,9 @@ export default function Page() {
   const [isInstalled, setIsInstalled] = useState(false);
   const [isInstallRequested, setIsInstallRequested] = useState(false);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [manualCheckMessage, setManualCheckMessage] = useState<string | null>(
+    null,
+  );
   const [error, setError] = useState<string | null>(null);
   useRedirectToSignIn(authStatus === 'signed-out');
 
@@ -74,7 +79,7 @@ export default function Page() {
     ? '/setup?step=source-control-config'
     : '/settings';
 
-  const navigateFromState = () => {
+  const navigateFromState = useCallback(() => {
     const encodedState = params.get('state');
     const decodedState = decodeOAuthState(encodedState);
 
@@ -87,7 +92,7 @@ export default function Page() {
       !redirect.includes('://');
 
     router.push(isValidRedirect ? redirect : '/settings');
-  };
+  }, [params, router]);
 
   const finishAuthentication = useFinishAuthenticateGitHubAccount({
     onSuccess: (result) => {
@@ -153,6 +158,44 @@ export default function Page() {
       setError(error.message);
     },
   });
+
+  // While the install request awaits an org owner's approval, poll for the
+  // webhook-driven completion (which deletes the pending row) so the user can
+  // continue without manually revisiting setup.
+  const pendingInstallations = useGitHubPendingInstallations({
+    enabled: isInstallRequested,
+    refetchInterval: 10_000,
+  });
+
+  const resolvePendingInstallations = useResolvePendingGitHubInstallations({
+    onSuccess: (result) => {
+      if (result.success && result.completed > 0) {
+        setIsInstallRequested(false);
+        setIsInstalled(true);
+        navigateFromState();
+      } else if (result.success) {
+        setManualCheckMessage(
+          'Not approved yet. Hang tight, this page keeps checking on its own.',
+        );
+      } else {
+        setManualCheckMessage(result.error);
+      }
+    },
+    onError: (error) => {
+      setManualCheckMessage(error.message);
+    },
+  });
+
+  const isInstallRequestApproved =
+    isInstallRequested && pendingInstallations.data?.pending === false;
+
+  useEffect(() => {
+    if (isInstallRequestApproved) {
+      setIsInstallRequested(false);
+      setIsInstalled(true);
+      navigateFromState();
+    }
+  }, [isInstallRequestApproved, navigateFromState]);
 
   const hasHandledCallback = useRef(false);
 
@@ -278,10 +321,29 @@ export default function Page() {
           <AlertDescription>
             <div className="flex flex-col gap-4">
               <div>
-                Your request is pending admin approval. Upon approval
-                you&apos;ll be able to continue.
+                Your request is pending approval from a GitHub organization
+                owner. You can wait here and we&apos;ll continue automatically
+                once it&apos;s approved.
               </div>
-              <div className="self-center">
+              {manualCheckMessage && (
+                <div className="text-muted-foreground">
+                  {manualCheckMessage}
+                </div>
+              )}
+              <div className="flex items-center gap-2 self-center">
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  disabled={resolvePendingInstallations.isPending}
+                  onClick={() => {
+                    setManualCheckMessage(null);
+                    resolvePendingInstallations.mutate();
+                  }}
+                >
+                  {resolvePendingInstallations.isPending
+                    ? 'Checking...'
+                    : 'Check now'}
+                </Button>
                 <Button
                   variant="secondary"
                   size="sm"

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConnect.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConnect.client.test.tsx
@@ -277,6 +277,38 @@ describe('StepSourceControlConnect', () => {
     await waitFor(() => expect(onContinue).toHaveBeenCalled());
   });
 
+  it('advances when a pending request transitions to approved without falling back to the connect CTA', async () => {
+    pendingInstallationsDataRef.current = { pending: true };
+    const onContinue = vi.fn();
+
+    const { rerender } = render(
+      <StepSourceControlConnect
+        sourceControlSetup={buildSourceControlSetup('github')}
+        onContinue={onContinue}
+      />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /Connect to GitHub/i }),
+    ).not.toBeInTheDocument();
+
+    // Polling reports the org owner approved: the shared query flips to
+    // pending:false. The step must advance rather than unmount the pending UI
+    // and snap back to the connect CTA.
+    pendingInstallationsDataRef.current = { pending: false };
+    rerender(
+      <StepSourceControlConnect
+        sourceControlSetup={buildSourceControlSetup('github')}
+        onContinue={onContinue}
+      />,
+    );
+
+    await waitFor(() => expect(onContinue).toHaveBeenCalled());
+    expect(
+      screen.queryByRole('button', { name: /Connect to GitHub/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it('keeps the connect CTA when no GitHub install request is pending', () => {
     pendingInstallationsDataRef.current = { pending: false };
 

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConnect.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConnect.client.test.tsx
@@ -1,5 +1,5 @@
 import type { ButtonHTMLAttributes, ReactNode, SVGProps } from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type {
   SetupSourceControlStatus,
   SourceControlProvider,
@@ -14,6 +14,7 @@ const {
   toastInfoMock,
   toastWarningMock,
   authenticateAdoMutateMock,
+  pendingInstallationsDataRef,
 } = vi.hoisted(() => ({
   createInstallationMutateMock: vi.fn(),
   syncRepositoriesMutateMock: vi.fn(),
@@ -44,6 +45,9 @@ const {
   toastInfoMock: vi.fn(),
   toastWarningMock: vi.fn(),
   authenticateAdoMutateMock: vi.fn(),
+  pendingInstallationsDataRef: {
+    current: undefined as { pending: boolean } | undefined,
+  },
 }));
 
 vi.mock('@tanstack/react-query', async () => {
@@ -95,6 +99,20 @@ vi.mock('@/hooks/github/useCreateGitHubInstallation', () => ({
     mutate: createInstallationMutateMock,
     isPending: false,
   }),
+}));
+
+vi.mock('@/hooks/github', () => ({
+  useGitHubPendingInstallations: () => ({
+    data: pendingInstallationsDataRef.current,
+  }),
+}));
+
+vi.mock('@/components/github/GitHubInstallRequestPending', () => ({
+  GitHubInstallRequestPending: ({ onApproved }: { onApproved: () => void }) => (
+    <button type="button" onClick={() => onApproved()}>
+      github-install-request-pending
+    </button>
+  ),
 }));
 
 vi.mock('@/hooks/source-control/useSyncRepositories', () => ({
@@ -195,6 +213,7 @@ describe('StepSourceControlConnect', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     syncRepositoriesOptionsRef.current = null;
+    pendingInstallationsDataRef.current = undefined;
     ensureQueryDataMock.mockResolvedValue({
       sourceControlSetup: {
         providers: [
@@ -230,6 +249,50 @@ describe('StepSourceControlConnect', () => {
     expect(createInstallationMutateMock).toHaveBeenCalledWith(
       '/setup?step=source-control-connect',
     );
+  });
+
+  it('shows the pending-request UI instead of the connect CTA when a GitHub install request is pending', async () => {
+    pendingInstallationsDataRef.current = { pending: true };
+    const onContinue = vi.fn();
+
+    render(
+      <StepSourceControlConnect
+        sourceControlSetup={buildSourceControlSetup('github')}
+        onContinue={onContinue}
+      />,
+    );
+
+    expect(
+      screen.getByText(/github-install-request-pending/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Connect to GitHub/i }),
+    ).not.toBeInTheDocument();
+
+    // Approval advances the wizard.
+    fireEvent.click(
+      screen.getByRole('button', { name: /github-install-request-pending/i }),
+    );
+
+    await waitFor(() => expect(onContinue).toHaveBeenCalled());
+  });
+
+  it('keeps the connect CTA when no GitHub install request is pending', () => {
+    pendingInstallationsDataRef.current = { pending: false };
+
+    render(
+      <StepSourceControlConnect
+        sourceControlSetup={buildSourceControlSetup('github')}
+        onContinue={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: /Connect to GitHub/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/github-install-request-pending/i),
+    ).not.toBeInTheDocument();
   });
 
   it('renders the runtime-configured token-backed sync CTA', () => {

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConnect.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConnect.tsx
@@ -18,6 +18,8 @@ import {
   Spinner,
 } from '@/components/system';
 import { useCreateGitHubInstallation } from '@/hooks/github/useCreateGitHubInstallation';
+import { useGitHubPendingInstallations } from '@/hooks/github';
+import { GitHubInstallRequestPending } from '@/components/github/GitHubInstallRequestPending';
 import {
   useAdoLinkedAccount,
   useAuthenticateAdoAccount,
@@ -155,6 +157,29 @@ export function StepSourceControlConnect({
   );
 
   const alreadyConnected = providerStatus?.connected === true;
+
+  // A non-owner can't install the GitHub App themselves; they request it and
+  // wait for an org owner to approve. Surface that pending state here too, so a
+  // user who returns to setup (rather than the OAuth callback) isn't dropped
+  // back onto a bare "Connect to GitHub" button that restarts the request.
+  const githubPendingInstallations = useGitHubPendingInstallations({
+    enabled: provider === 'github' && !alreadyConnected,
+  });
+  const githubInstallPending =
+    provider === 'github' &&
+    !alreadyConnected &&
+    githubPendingInstallations.data?.pending === true;
+
+  const handleGitHubInstallApproved = useCallback(async () => {
+    await queryClient.invalidateQueries({
+      queryKey: trpc.setupNew.status.queryKey(),
+    });
+    await queryClient.invalidateQueries({
+      queryKey: trpc.sourceControl.repositories.queryKey(),
+    });
+
+    onContinue();
+  }, [onContinue, queryClient, trpc]);
   const adoAuthMode = providerStatus?.fields.find(
     (field) => field.envVarName === 'ADO_AUTH_MODE',
   )?.savedValue;
@@ -353,6 +378,13 @@ export function StepSourceControlConnect({
               </Button>
             )}
           </SetupFooter>
+        </div>
+      ) : provider === 'github' && githubInstallPending ? (
+        <div className="space-y-4">
+          <GitHubInstallRequestPending
+            onApproved={handleGitHubInstallApproved}
+          />
+          <SetupFooter onBack={onBack} />
         </div>
       ) : provider === 'github' ? (
         <div className="space-y-4">

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConnect.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConnect.tsx
@@ -165,12 +165,18 @@ export function StepSourceControlConnect({
   const githubPendingInstallations = useGitHubPendingInstallations({
     enabled: provider === 'github' && !alreadyConnected,
   });
-  const githubInstallPending =
+  const githubInstallRequestPending =
     provider === 'github' &&
     !alreadyConnected &&
     githubPendingInstallations.data?.pending === true;
 
+  const advancedAfterApprovalRef = useRef(false);
   const handleGitHubInstallApproved = useCallback(async () => {
+    if (advancedAfterApprovalRef.current) {
+      return;
+    }
+    advancedAfterApprovalRef.current = true;
+
     await queryClient.invalidateQueries({
       queryKey: trpc.setupNew.status.queryKey(),
     });
@@ -180,6 +186,39 @@ export function StepSourceControlConnect({
 
     onContinue();
   }, [onContinue, queryClient, trpc]);
+
+  // The parent and `GitHubInstallRequestPending` share one pending-install
+  // query, so when polling flips `pending` to false the parent would unmount
+  // the child before its approval effect could advance the wizard. Latch that
+  // we saw a pending request and own the pending -> approved transition here so
+  // approval reliably continues instead of snapping back to "Connect to GitHub".
+  const [sawInstallRequestPending, setSawInstallRequestPending] =
+    useState(false);
+  useEffect(() => {
+    if (githubInstallRequestPending) {
+      setSawInstallRequestPending(true);
+    }
+  }, [githubInstallRequestPending]);
+
+  useEffect(() => {
+    if (
+      sawInstallRequestPending &&
+      provider === 'github' &&
+      githubPendingInstallations.data?.pending === false
+    ) {
+      void handleGitHubInstallApproved();
+    }
+  }, [
+    githubPendingInstallations.data?.pending,
+    handleGitHubInstallApproved,
+    provider,
+    sawInstallRequestPending,
+  ]);
+
+  const showGitHubInstallPending =
+    provider === 'github' &&
+    !alreadyConnected &&
+    (githubInstallRequestPending || sawInstallRequestPending);
   const adoAuthMode = providerStatus?.fields.find(
     (field) => field.envVarName === 'ADO_AUTH_MODE',
   )?.savedValue;
@@ -379,7 +418,7 @@ export function StepSourceControlConnect({
             )}
           </SetupFooter>
         </div>
-      ) : provider === 'github' && githubInstallPending ? (
+      ) : provider === 'github' && showGitHubInstallPending ? (
         <div className="space-y-4">
           <GitHubInstallRequestPending
             onApproved={handleGitHubInstallApproved}

--- a/apps/web/src/components/github/GitHubInstallRequestPending.client.test.tsx
+++ b/apps/web/src/components/github/GitHubInstallRequestPending.client.test.tsx
@@ -1,0 +1,123 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const { pendingInstallationsDataRef, resolveMutateMock, resolveOptionsRef } =
+  vi.hoisted(() => ({
+    pendingInstallationsDataRef: {
+      current: undefined as { pending: boolean } | undefined,
+    },
+    resolveMutateMock: vi.fn(),
+    resolveOptionsRef: {
+      current: null as {
+        onSuccess?: (result: {
+          success: boolean;
+          pending?: number;
+          completed?: number;
+          error?: string;
+        }) => void;
+        onError?: (error: Error) => void;
+      } | null,
+    },
+  }));
+
+vi.mock('@/hooks/github', () => ({
+  useGitHubPendingInstallations: () => ({
+    data: pendingInstallationsDataRef.current,
+  }),
+  useResolvePendingGitHubInstallations: (options: unknown) => {
+    resolveOptionsRef.current = options as NonNullable<
+      typeof resolveOptionsRef.current
+    >;
+
+    return { mutate: resolveMutateMock, isPending: false };
+  },
+}));
+
+vi.mock('@/components/system', () => ({
+  Alert: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  AlertDescription: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  Button: ({
+    children,
+    ...props
+  }: { children: ReactNode } & ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type={props.type ?? 'button'} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+import { GitHubInstallRequestPending } from './GitHubInstallRequestPending';
+
+describe('GitHubInstallRequestPending', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pendingInstallationsDataRef.current = { pending: true };
+    resolveOptionsRef.current = null;
+  });
+
+  it('calls onApproved once when polling reports the request is no longer pending', async () => {
+    const onApproved = vi.fn();
+    pendingInstallationsDataRef.current = { pending: false };
+
+    render(<GitHubInstallRequestPending onApproved={onApproved} />);
+
+    await waitFor(() => expect(onApproved).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not call onApproved while the request is still pending', () => {
+    const onApproved = vi.fn();
+
+    render(<GitHubInstallRequestPending onApproved={onApproved} />);
+
+    expect(onApproved).not.toHaveBeenCalled();
+    expect(screen.getByText(/pending approval/i)).toBeInTheDocument();
+  });
+
+  it('resolves on demand and advances when a request completes', () => {
+    const onApproved = vi.fn();
+
+    render(<GitHubInstallRequestPending onApproved={onApproved} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Check now/i }));
+    expect(resolveMutateMock).toHaveBeenCalledTimes(1);
+
+    resolveOptionsRef.current?.onSuccess?.({
+      success: true,
+      pending: 0,
+      completed: 1,
+    });
+
+    expect(onApproved).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces a not-approved-yet message when the manual check finds nothing', async () => {
+    const onApproved = vi.fn();
+
+    render(<GitHubInstallRequestPending onApproved={onApproved} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Check now/i }));
+    resolveOptionsRef.current?.onSuccess?.({
+      success: true,
+      pending: 1,
+      completed: 0,
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/Not approved yet/i)).toBeInTheDocument(),
+    );
+    expect(onApproved).not.toHaveBeenCalled();
+  });
+
+  it('renders the provided footer', () => {
+    render(
+      <GitHubInstallRequestPending
+        onApproved={vi.fn()}
+        footer={<span>footer-slot</span>}
+      />,
+    );
+
+    expect(screen.getByText('footer-slot')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/github/GitHubInstallRequestPending.tsx
+++ b/apps/web/src/components/github/GitHubInstallRequestPending.tsx
@@ -69,7 +69,7 @@ export function GitHubInstallRequestPending({
   return (
     <Alert className="w-sm">
       <AlertDescription>
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4 text-center">
           <div>
             Your request is pending approval from a GitHub organization owner.
             You can wait here and we&apos;ll continue automatically once

--- a/apps/web/src/components/github/GitHubInstallRequestPending.tsx
+++ b/apps/web/src/components/github/GitHubInstallRequestPending.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+
+import { Alert, AlertDescription, Button } from '@/components/system';
+import {
+  useGitHubPendingInstallations,
+  useResolvePendingGitHubInstallations,
+} from '@/hooks/github';
+
+/**
+ * Shown while a GitHub App installation request awaits approval from an
+ * organization owner. Polls for the webhook-driven completion (which deletes
+ * the pending row) so the user continues automatically once it lands, and
+ * offers a manual re-check that asks GitHub directly — covering the case where
+ * the `installation.created` webhook never reached this deployment.
+ */
+export function GitHubInstallRequestPending({
+  onApproved,
+  footer,
+}: {
+  onApproved: () => void;
+  footer?: ReactNode;
+}) {
+  const [manualCheckMessage, setManualCheckMessage] = useState<string | null>(
+    null,
+  );
+
+  const pendingInstallations = useGitHubPendingInstallations({
+    refetchInterval: 10_000,
+  });
+
+  const hasApprovedRef = useRef(false);
+  const handleApproved = useCallback(() => {
+    if (hasApprovedRef.current) {
+      return;
+    }
+
+    hasApprovedRef.current = true;
+    onApproved();
+  }, [onApproved]);
+
+  const resolvePendingInstallations = useResolvePendingGitHubInstallations({
+    onSuccess: (result) => {
+      if (result.success && result.completed > 0) {
+        handleApproved();
+      } else if (result.success) {
+        setManualCheckMessage(
+          'Not approved yet. Hang tight, this page keeps checking on its own.',
+        );
+      } else {
+        setManualCheckMessage(result.error);
+      }
+    },
+    onError: (error) => {
+      setManualCheckMessage(error.message);
+    },
+  });
+
+  const isApproved = pendingInstallations.data?.pending === false;
+
+  useEffect(() => {
+    if (isApproved) {
+      handleApproved();
+    }
+  }, [handleApproved, isApproved]);
+
+  return (
+    <Alert className="w-sm">
+      <AlertDescription>
+        <div className="flex flex-col gap-4">
+          <div>
+            Your request is pending approval from a GitHub organization owner.
+            You can wait here and we&apos;ll continue automatically once
+            it&apos;s approved.
+          </div>
+          {manualCheckMessage && (
+            <div className="text-muted-foreground">{manualCheckMessage}</div>
+          )}
+          <div className="flex items-center gap-2 self-center">
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled={resolvePendingInstallations.isPending}
+              onClick={() => {
+                setManualCheckMessage(null);
+                resolvePendingInstallations.mutate();
+              }}
+            >
+              {resolvePendingInstallations.isPending
+                ? 'Checking...'
+                : 'Check now'}
+            </Button>
+            {footer}
+          </div>
+        </div>
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/apps/web/src/hooks/github/index.ts
+++ b/apps/web/src/hooks/github/index.ts
@@ -1,4 +1,6 @@
 export * from './useGitHubInstallations';
+export * from './useGitHubPendingInstallations';
+export * from './useResolvePendingGitHubInstallations';
 export * from './useCreateGitHubAppManifest';
 export * from './useCreateGitHubInstallation';
 export * from './useEnableGitHubApp';

--- a/apps/web/src/hooks/github/useGitHubPendingInstallations.ts
+++ b/apps/web/src/hooks/github/useGitHubPendingInstallations.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { useTRPC } from '@/trpc/client';
+
+export const useGitHubPendingInstallations = (options?: {
+  enabled?: boolean;
+  refetchInterval?: number;
+}) => {
+  const trpc = useTRPC();
+
+  return useQuery({
+    ...trpc.github.pendingInstallations.queryOptions(),
+    ...options,
+  });
+};

--- a/apps/web/src/hooks/github/useResolvePendingGitHubInstallations.client.test.tsx
+++ b/apps/web/src/hooks/github/useResolvePendingGitHubInstallations.client.test.tsx
@@ -1,0 +1,114 @@
+import { renderHook } from '@testing-library/react';
+
+const {
+  invalidateQueriesMock,
+  resolvePendingInstallationsMock,
+  mutationOptionsRef,
+  queryKeys,
+} = vi.hoisted(() => ({
+  invalidateQueriesMock: vi.fn(),
+  resolvePendingInstallationsMock: vi.fn(),
+  mutationOptionsRef: {
+    current: null as {
+      mutationFn: () => Promise<unknown>;
+      onSuccess?: (
+        data: unknown,
+        variables: void,
+        onMutateResult: unknown,
+        context: unknown,
+      ) => void;
+    } | null,
+  },
+  queryKeys: {
+    pendingInstallations: ['github.pendingInstallations'],
+    githubInstallations: ['github.installations'],
+    sourceControlRepositories: ['sourceControl.repositories'],
+  },
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useMutation: (options: typeof mutationOptionsRef.current) => {
+    mutationOptionsRef.current = options;
+
+    return {
+      mutateAsync: async () => {
+        const data = await options?.mutationFn();
+        options?.onSuccess?.(data, undefined, undefined, undefined);
+        return data;
+      },
+      isPending: false,
+    };
+  },
+  useQueryClient: () => ({
+    invalidateQueries: invalidateQueriesMock,
+  }),
+}));
+
+vi.mock('@/trpc/client', () => ({
+  useTRPC: () => ({
+    github: {
+      pendingInstallations: {
+        queryKey: () => queryKeys.pendingInstallations,
+      },
+      installations: {
+        queryKey: () => queryKeys.githubInstallations,
+      },
+    },
+    sourceControl: {
+      repositories: {
+        queryKey: () => queryKeys.sourceControlRepositories,
+      },
+    },
+  }),
+  useTRPCClient: () => ({
+    github: {
+      resolvePendingInstallations: {
+        mutate: resolvePendingInstallationsMock,
+      },
+    },
+  }),
+}));
+
+import { useResolvePendingGitHubInstallations } from './useResolvePendingGitHubInstallations';
+
+describe('useResolvePendingGitHubInstallations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolvePendingInstallationsMock.mockResolvedValue({
+      success: true,
+      pending: 0,
+      completed: 1,
+    });
+  });
+
+  it('invalidates the pending, installation, and repository queries before caller success handling', async () => {
+    const onSuccess = vi.fn();
+    const { result } = renderHook(() =>
+      useResolvePendingGitHubInstallations({ onSuccess }),
+    );
+
+    await result.current.mutateAsync();
+
+    expect(resolvePendingInstallationsMock).toHaveBeenCalledTimes(1);
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: queryKeys.pendingInstallations,
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: queryKeys.githubInstallations,
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: queryKeys.sourceControlRepositories,
+    });
+    // The caller-supplied onSuccess must still run — the internal wrapper must
+    // not be clobbered by spreading caller options over it.
+    expect(onSuccess).toHaveBeenCalledWith(
+      { success: true, pending: 0, completed: 1 },
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(invalidateQueriesMock.mock.invocationCallOrder[0]).toBeLessThan(
+      onSuccess.mock.invocationCallOrder[0]!,
+    );
+  });
+});

--- a/apps/web/src/hooks/github/useResolvePendingGitHubInstallations.ts
+++ b/apps/web/src/hooks/github/useResolvePendingGitHubInstallations.ts
@@ -1,0 +1,48 @@
+import {
+  type UseMutationOptions,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query';
+
+import { useTRPC, useTRPCClient } from '@/trpc/client';
+
+type Data = Awaited<
+  ReturnType<
+    ReturnType<
+      typeof useTRPCClient
+    >['github']['resolvePendingInstallations']['mutate']
+  >
+>;
+
+type UseResolvePendingGitHubInstallationsOptions = Omit<
+  UseMutationOptions<Data, Error>,
+  'mutationFn'
+>;
+
+export const useResolvePendingGitHubInstallations = (
+  options?: UseResolvePendingGitHubInstallationsOptions,
+) => {
+  const trpc = useTRPC();
+  const trpcClient = useTRPCClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => trpcClient.github.resolvePendingInstallations.mutate(),
+    onSuccess: (data, variables, onMutateResult, context) => {
+      queryClient.invalidateQueries({
+        queryKey: trpc.github.pendingInstallations.queryKey(),
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: trpc.github.installations.queryKey(),
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: trpc.sourceControl.repositories.queryKey(),
+      });
+
+      options?.onSuccess?.(data, variables, onMutateResult, context);
+    },
+    ...options,
+  });
+};

--- a/apps/web/src/hooks/github/useResolvePendingGitHubInstallations.ts
+++ b/apps/web/src/hooks/github/useResolvePendingGitHubInstallations.ts
@@ -28,6 +28,7 @@ export const useResolvePendingGitHubInstallations = (
 
   return useMutation({
     mutationFn: () => trpcClient.github.resolvePendingInstallations.mutate(),
+    ...options,
     onSuccess: (data, variables, onMutateResult, context) => {
       queryClient.invalidateQueries({
         queryKey: trpc.github.pendingInstallations.queryKey(),
@@ -43,6 +44,5 @@ export const useResolvePendingGitHubInstallations = (
 
       options?.onSuccess?.(data, variables, onMutateResult, context);
     },
-    ...options,
   });
 };

--- a/apps/web/src/trpc/commands/github/index.ts
+++ b/apps/web/src/trpc/commands/github/index.ts
@@ -3,6 +3,7 @@ import * as GitHub from '@roomote/github';
 import {
   db,
   githubInstallations,
+  githubPendingInstallations,
   repositories,
   eq,
   and,
@@ -15,6 +16,17 @@ export async function getGitHubInstallationsCommand(_auth: UserAuthSuccess) {
   return db.query.githubInstallations.findMany({
     where: isNull(githubInstallations.suspendedAt),
   });
+}
+
+export async function getGitHubPendingInstallationsCommand(
+  auth: UserAuthSuccess,
+) {
+  const pending = await db.query.githubPendingInstallations.findMany({
+    where: eq(githubPendingInstallations.requestedByUserId, auth.userId),
+    columns: { id: true },
+  });
+
+  return { pending: pending.length > 0 };
 }
 
 export async function getBranchesCommand(
@@ -79,6 +91,7 @@ export {
   startCreateGitHubAppManifestCommand,
   enableGitHubAppCommand,
   finishCreateGitHubInstallationCommand,
+  resolvePendingGitHubInstallationsCommand,
   finishCreateGitHubAppManifestCommand,
   startAuthenticateGitHubAccountCommand,
   finishAuthenticateGitHubAccountCommand,

--- a/apps/web/src/trpc/commands/github/mutations.test.ts
+++ b/apps/web/src/trpc/commands/github/mutations.test.ts
@@ -7,11 +7,13 @@ const {
   mockDbTransaction,
   mockFetch,
   mockResolveDeploymentEnvVar,
+  mockResolvePendingGitHubInstallations,
   mockUpsertDeploymentEnvironmentVariables,
 } = vi.hoisted(() => ({
   mockDbTransaction: vi.fn(),
   mockFetch: vi.fn(),
   mockResolveDeploymentEnvVar: vi.fn(),
+  mockResolvePendingGitHubInstallations: vi.fn(),
   mockUpsertDeploymentEnvironmentVariables: vi.fn(),
 }));
 
@@ -25,6 +27,7 @@ vi.mock('@roomote/auth', () => ({
 
 vi.mock('@roomote/github', () => ({
   getAppOctokit: vi.fn(),
+  resolvePendingGitHubInstallations: mockResolvePendingGitHubInstallations,
 }));
 
 vi.mock('@roomote/sdk/client', () => ({
@@ -69,6 +72,7 @@ vi.stubGlobal('fetch', mockFetch);
 
 import {
   finishCreateGitHubAppManifestCommand,
+  resolvePendingGitHubInstallationsCommand,
   startAuthenticateGitHubAccountCommand,
   startCreateGitHubInstallationCommand,
   startCreateGitHubAppManifestCommand,
@@ -435,6 +439,47 @@ describe('GitHub App manifest commands', () => {
     });
     expect(mockDbTransaction).not.toHaveBeenCalled();
     expect(mockUpsertDeploymentEnvironmentVariables).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolvePendingGitHubInstallationsCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('refuses non-admin users', async () => {
+    const result = await resolvePendingGitHubInstallationsCommand(
+      buildMockAuth({ isAdmin: false }),
+    );
+
+    expect(result).toEqual({ success: false, error: 'Unauthorized' });
+    expect(mockResolvePendingGitHubInstallations).not.toHaveBeenCalled();
+  });
+
+  it('returns the resolution counts on success', async () => {
+    mockResolvePendingGitHubInstallations.mockResolvedValue({
+      pending: 0,
+      completed: 1,
+    });
+
+    const result =
+      await resolvePendingGitHubInstallationsCommand(buildMockAuth());
+
+    expect(result).toEqual({ success: true, pending: 0, completed: 1 });
+  });
+
+  it('reports a failure when resolution throws', async () => {
+    mockResolvePendingGitHubInstallations.mockRejectedValue(
+      new Error('GitHub API unavailable'),
+    );
+
+    const result =
+      await resolvePendingGitHubInstallationsCommand(buildMockAuth());
+
+    expect(result).toEqual({
+      success: false,
+      error: 'GitHub API unavailable',
+    });
   });
 });
 

--- a/apps/web/src/trpc/commands/github/mutations.test.ts
+++ b/apps/web/src/trpc/commands/github/mutations.test.ts
@@ -456,16 +456,20 @@ describe('resolvePendingGitHubInstallationsCommand', () => {
     expect(mockResolvePendingGitHubInstallations).not.toHaveBeenCalled();
   });
 
-  it('returns the resolution counts on success', async () => {
+  it('returns the resolution counts on success and scopes to the requesting user', async () => {
     mockResolvePendingGitHubInstallations.mockResolvedValue({
       pending: 0,
       completed: 1,
     });
 
-    const result =
-      await resolvePendingGitHubInstallationsCommand(buildMockAuth());
+    const result = await resolvePendingGitHubInstallationsCommand(
+      buildMockAuth({ userId: 'requesting-user' }),
+    );
 
     expect(result).toEqual({ success: true, pending: 0, completed: 1 });
+    expect(mockResolvePendingGitHubInstallations).toHaveBeenCalledWith({
+      userId: 'requesting-user',
+    });
   });
 
   it('reports a failure when resolution throws', async () => {

--- a/apps/web/src/trpc/commands/github/mutations.ts
+++ b/apps/web/src/trpc/commands/github/mutations.ts
@@ -773,6 +773,13 @@ export async function finishCreateGitHubInstallationCommand(
     }
 
     try {
+      // A user can only be waiting on their latest request; drop older rows
+      // (retries, abandoned attempts) so they can't keep the pending state
+      // alive after this request is approved.
+      await db
+        .delete(githubPendingInstallations)
+        .where(eq(githubPendingInstallations.requestedByUserId, auth.userId));
+
       const [pendingInstallation] = await db
         .insert(githubPendingInstallations)
         .values({
@@ -805,6 +812,33 @@ export async function finishCreateGitHubInstallationCommand(
   } catch (error) {
     console.error(
       '[finishCreateGitHubInstallationCommand] Unhandled error:',
+      error,
+    );
+
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export async function resolvePendingGitHubInstallationsCommand(
+  auth: UserAuthSuccess,
+): Promise<
+  | { success: true; pending: number; completed: number }
+  | { success: false; error: string }
+> {
+  if (!auth.isAdmin) {
+    return getUnauthorizedResult();
+  }
+
+  try {
+    const result = await GitHub.resolvePendingGitHubInstallations();
+
+    return { success: true, ...result };
+  } catch (error) {
+    console.error(
+      '[resolvePendingGitHubInstallationsCommand] Unhandled error:',
       error,
     );
 

--- a/apps/web/src/trpc/commands/github/mutations.ts
+++ b/apps/web/src/trpc/commands/github/mutations.ts
@@ -833,7 +833,9 @@ export async function resolvePendingGitHubInstallationsCommand(
   }
 
   try {
-    const result = await GitHub.resolvePendingGitHubInstallations();
+    const result = await GitHub.resolvePendingGitHubInstallations({
+      userId: auth.userId,
+    });
 
     return { success: true, ...result };
   } catch (error) {

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -65,6 +65,7 @@ import {
 } from '../commands/artifacts';
 import {
   getGitHubInstallationsCommand,
+  getGitHubPendingInstallationsCommand,
   getBranchesCommand,
   getCollaboratorsCommand,
   getIssuesCommand,
@@ -74,6 +75,7 @@ import {
   enableGitHubAppCommand,
   finishCreateGitHubInstallationCommand,
   finishCreateGitHubAppManifestCommand,
+  resolvePendingGitHubInstallationsCommand,
   startAuthenticateGitHubAccountCommand,
   finishAuthenticateGitHubAccountCommand,
   syncGitHubInstallationCommand,
@@ -765,6 +767,14 @@ export const appRouter = createRouter({
   github: createRouter({
     installations: protectedProcedure.query(({ ctx: { auth } }) =>
       getGitHubInstallationsCommand(auth),
+    ),
+
+    pendingInstallations: protectedProcedure.query(({ ctx: { auth } }) =>
+      getGitHubPendingInstallationsCommand(auth),
+    ),
+
+    resolvePendingInstallations: protectedProcedure.mutation(
+      ({ ctx: { auth } }) => resolvePendingGitHubInstallationsCommand(auth),
     ),
 
     branches: protectedProcedure

--- a/packages/github/src/api.ts
+++ b/packages/github/src/api.ts
@@ -993,9 +993,62 @@ export async function completePendingGitHubInstallation(
         `[completePendingGitHubInstallation] Failed to delete pending GitHub installation: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
+
+    return { ...result, requestedByUserId: userId };
   }
 
   return result;
+}
+
+/**
+ * Complete any pending GitHub installations whose installation requests have
+ * since been approved on GitHub. This covers the case where the
+ * `installation.created` webhook never reached this deployment (for example a
+ * misconfigured webhook URL), leaving the requester stuck on "pending".
+ */
+export async function resolvePendingGitHubInstallations(): Promise<{
+  pending: number;
+  completed: number;
+}> {
+  const pendingGitHubInstallations =
+    await db.query.githubPendingInstallations.findMany();
+
+  if (pendingGitHubInstallations.length === 0) {
+    return { pending: 0, completed: 0 };
+  }
+
+  const installations = await getGitHubInstallations();
+
+  let completed = 0;
+
+  for (const pendingGitHubInstallation of pendingGitHubInstallations) {
+    // The pending row's `appId` holds the id of the GitHub account the
+    // installation was requested for.
+    const installation = installations.find(
+      ({ account }) => account?.id === pendingGitHubInstallation.appId,
+    );
+
+    if (!installation) {
+      continue;
+    }
+
+    try {
+      const result = await completePendingGitHubInstallation(installation.id);
+
+      if (result.success) {
+        completed += 1;
+      }
+    } catch (error) {
+      console.error(
+        `[resolvePendingGitHubInstallations] Failed to complete pending GitHub installation: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  return {
+    pending: pendingGitHubInstallations.length - completed,
+    completed,
+  };
 }
 
 async function suspendGitHubInstallation({

--- a/packages/github/src/api.ts
+++ b/packages/github/src/api.ts
@@ -1001,17 +1001,26 @@ export async function completePendingGitHubInstallation(
 }
 
 /**
- * Complete any pending GitHub installations whose installation requests have
- * since been approved on GitHub. This covers the case where the
+ * Complete the requesting user's pending GitHub installations whose requests
+ * have since been approved on GitHub. This covers the case where the
  * `installation.created` webhook never reached this deployment (for example a
  * misconfigured webhook URL), leaving the requester stuck on "pending".
+ *
+ * Scoped to a single user so one user's manual re-check can never complete (or
+ * report as approved) another user's request.
  */
-export async function resolvePendingGitHubInstallations(): Promise<{
+export async function resolvePendingGitHubInstallations({
+  userId,
+}: {
+  userId: string;
+}): Promise<{
   pending: number;
   completed: number;
 }> {
   const pendingGitHubInstallations =
-    await db.query.githubPendingInstallations.findMany();
+    await db.query.githubPendingInstallations.findMany({
+      where: eq(githubPendingInstallations.requestedByUserId, userId),
+    });
 
   if (pendingGitHubInstallations.length === 0) {
     return { pending: 0, completed: 0 };

--- a/packages/github/src/api.ts
+++ b/packages/github/src/api.ts
@@ -957,6 +957,39 @@ export async function getGitHubInstallations(options?: PaginateOptions) {
   return installations;
 }
 
+// Sync the installation for the requester recorded on this specific pending
+// row, then delete that row. Callers pass the exact row they intend to
+// complete so completion is never re-resolved by the non-unique account id.
+async function completePendingGitHubInstallationRow(
+  pendingGitHubInstallation: typeof githubPendingInstallations.$inferSelect,
+  installationId: number,
+) {
+  const { id: pendingId, requestedByUserId: userId } =
+    pendingGitHubInstallation;
+
+  const result = await syncGitHubInstallation({
+    userId,
+    installationId,
+  });
+
+  if (result.success) {
+    try {
+      // Clean up the pending GitHub installation upon successful completion.
+      await db
+        .delete(githubPendingInstallations)
+        .where(eq(githubPendingInstallations.id, pendingId));
+    } catch (error) {
+      console.error(
+        `[completePendingGitHubInstallation] Failed to delete pending GitHub installation: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    return { ...result, requestedByUserId: userId };
+  }
+
+  return result;
+}
+
 export async function completePendingGitHubInstallation(
   installationId: number,
 ) {
@@ -975,29 +1008,10 @@ export async function completePendingGitHubInstallation(
     throw new Error('Pending GitHub installation not found');
   }
 
-  const { requestedByUserId: userId } = pendingGitHubInstallation;
-
-  const result = await syncGitHubInstallation({
-    userId,
+  return completePendingGitHubInstallationRow(
+    pendingGitHubInstallation,
     installationId,
-  });
-
-  if (result.success) {
-    try {
-      // Clean up the pending GitHub installation upon successful completion.
-      await db
-        .delete(githubPendingInstallations)
-        .where(eq(githubPendingInstallations.id, pendingGitHubInstallation.id));
-    } catch (error) {
-      console.error(
-        `[completePendingGitHubInstallation] Failed to delete pending GitHub installation: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
-
-    return { ...result, requestedByUserId: userId };
-  }
-
-  return result;
+  );
 }
 
 /**
@@ -1042,7 +1056,12 @@ export async function resolvePendingGitHubInstallations({
     }
 
     try {
-      const result = await completePendingGitHubInstallation(installation.id);
+      // Complete this exact row (not a re-lookup by account id), so a shared
+      // organization between two requesters can't complete the other's row.
+      const result = await completePendingGitHubInstallationRow(
+        pendingGitHubInstallation,
+        installation.id,
+      );
 
       if (result.success) {
         completed += 1;

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -152,6 +152,11 @@ export {
 } from './lib/teams-primary-conversation';
 
 export {
+  sendUserDirectMessageBestEffort,
+  type UserDirectMessageProvider,
+} from './lib/user-direct-message';
+
+export {
   SLACK_PR_INACTIVITY_DELAY_MS,
   SLACK_PR_INACTIVITY_QUEUE_NAME,
   enqueueSlackPrInactivityCheck,

--- a/packages/sdk/src/server/lib/user-direct-message.test.ts
+++ b/packages/sdk/src/server/lib/user-direct-message.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockOpenConversation,
+  mockPostDirectMessage,
+  mockSlackInstallationsFindMany,
+  mockSlackPostMessage,
+  mockSlackUserMappingsFindFirst,
+  mockTeamsUserMappingsFindFirst,
+  mockTelegramPostMessage,
+  mockTelegramUserMappingsFindFirst,
+} = vi.hoisted(() => ({
+  mockOpenConversation: vi.fn(),
+  mockPostDirectMessage: vi.fn(),
+  mockSlackInstallationsFindMany: vi.fn(),
+  mockSlackPostMessage: vi.fn(),
+  mockSlackUserMappingsFindFirst: vi.fn(),
+  mockTeamsUserMappingsFindFirst: vi.fn(),
+  mockTelegramPostMessage: vi.fn(),
+  mockTelegramUserMappingsFindFirst: vi.fn(),
+}));
+
+vi.mock('@roomote/db/server', () => ({
+  db: {
+    query: {
+      slackInstallations: { findMany: mockSlackInstallationsFindMany },
+      slackUserMappings: { findFirst: mockSlackUserMappingsFindFirst },
+      teamsUserMappings: { findFirst: mockTeamsUserMappingsFindFirst },
+      telegramUserMappings: { findFirst: mockTelegramUserMappingsFindFirst },
+    },
+  },
+  and: vi.fn(),
+  eq: vi.fn(),
+  slackInstallations: {},
+  slackUserMappings: {},
+  teamsUserMappings: {},
+  telegramUserMappings: {},
+}));
+
+vi.mock('@roomote/slack', () => ({
+  SlackNotifier: vi.fn().mockImplementation(function () {
+    return {
+      openConversation: mockOpenConversation,
+      postMessage: mockSlackPostMessage,
+    };
+  }),
+}));
+
+vi.mock('./teams-communication', () => ({
+  createTeamsCommunicationProviderFromRuntimeCredentials: vi.fn(async () => ({
+    postDirectMessage: mockPostDirectMessage,
+  })),
+}));
+
+vi.mock('./telegram-communication', () => ({
+  createTelegramCommunicationProviderFromRuntimeCredentials: vi.fn(
+    async () => ({ postMessage: mockTelegramPostMessage }),
+  ),
+}));
+
+vi.mock('./teams-primary-conversation', () => ({
+  findTeamsPrimaryConversation: vi.fn(async () => ({
+    conversationId: 'conversation-1',
+    serviceUrl: 'https://smba.example.com/amer/',
+    conversationType: 'personal',
+  })),
+}));
+
+import { createTelegramCommunicationProviderFromRuntimeCredentials } from './telegram-communication';
+import { sendUserDirectMessageBestEffort } from './user-direct-message';
+
+describe('sendUserDirectMessageBestEffort', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockSlackInstallationsFindMany.mockResolvedValue([
+      { botAccessToken: 'xoxb-token', teamId: 'T123' },
+    ]);
+    mockSlackUserMappingsFindFirst.mockResolvedValue({ slackUserId: 'U123' });
+    mockOpenConversation.mockResolvedValue('D123');
+    mockSlackPostMessage.mockResolvedValue('1720000000.000100');
+
+    mockTeamsUserMappingsFindFirst.mockResolvedValue({
+      teamsUserId: 'teams-user-1',
+      teamsTenantId: 'tenant-1',
+    });
+    mockPostDirectMessage.mockResolvedValue({ messageId: 'teams-message-1' });
+
+    mockTelegramUserMappingsFindFirst.mockResolvedValue({
+      telegramChatId: '424242',
+    });
+    mockTelegramPostMessage.mockResolvedValue({ messageId: '77' });
+  });
+
+  it('sends the message on every provider with a linked identity', async () => {
+    const delivered = await sendUserDirectMessageBestEffort({
+      userId: 'user-1',
+      text: 'Your GitHub installation request was approved.',
+      logContext: 'test',
+    });
+
+    expect(delivered).toEqual(['slack', 'teams', 'telegram']);
+
+    expect(mockOpenConversation).toHaveBeenCalledWith('U123');
+    expect(mockSlackPostMessage).toHaveBeenCalledWith({
+      channel: 'D123',
+      text: 'Your GitHub installation request was approved.',
+    });
+
+    expect(mockPostDirectMessage).toHaveBeenCalledWith({
+      serviceUrl: 'https://smba.example.com/amer/',
+      tenantId: 'tenant-1',
+      userId: 'teams-user-1',
+      text: 'Your GitHub installation request was approved.',
+      textFormat: 'markdown',
+    });
+
+    expect(mockTelegramPostMessage).toHaveBeenCalledWith({
+      channelId: '424242',
+      text: 'Your GitHub installation request was approved.',
+      textFormat: 'markdown',
+    });
+  });
+
+  it('skips providers the user has not linked without failing the rest', async () => {
+    mockSlackUserMappingsFindFirst.mockResolvedValue(undefined);
+    mockTeamsUserMappingsFindFirst.mockResolvedValue(undefined);
+
+    const delivered = await sendUserDirectMessageBestEffort({
+      userId: 'user-1',
+      text: 'hello',
+      logContext: 'test',
+    });
+
+    expect(delivered).toEqual(['telegram']);
+    expect(mockSlackPostMessage).not.toHaveBeenCalled();
+    expect(mockPostDirectMessage).not.toHaveBeenCalled();
+  });
+
+  it('skips a provider whose credentials are not configured', async () => {
+    vi.mocked(
+      createTelegramCommunicationProviderFromRuntimeCredentials,
+    ).mockResolvedValueOnce(null);
+
+    const delivered = await sendUserDirectMessageBestEffort({
+      userId: 'user-1',
+      text: 'hello',
+      logContext: 'test',
+    });
+
+    expect(delivered).toEqual(['slack', 'teams']);
+    expect(mockTelegramPostMessage).not.toHaveBeenCalled();
+  });
+
+  it('swallows a provider error and still delivers the others', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mockSlackPostMessage.mockRejectedValue(new Error('slack is down'));
+
+    const delivered = await sendUserDirectMessageBestEffort({
+      userId: 'user-1',
+      text: 'hello',
+      logContext: 'test',
+    });
+
+    expect(delivered).toEqual(['teams', 'telegram']);
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[test] Failed to send Slack DM: slack is down',
+    );
+
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/sdk/src/server/lib/user-direct-message.ts
+++ b/packages/sdk/src/server/lib/user-direct-message.ts
@@ -1,0 +1,182 @@
+import {
+  and,
+  db,
+  eq,
+  slackInstallations,
+  slackUserMappings,
+  teamsUserMappings,
+  telegramUserMappings,
+} from '@roomote/db/server';
+import { SlackNotifier } from '@roomote/slack';
+
+import { createTeamsCommunicationProviderFromRuntimeCredentials } from './teams-communication';
+import { createTelegramCommunicationProviderFromRuntimeCredentials } from './telegram-communication';
+import { findTeamsPrimaryConversation } from './teams-primary-conversation';
+
+export type UserDirectMessageProvider = 'slack' | 'teams' | 'telegram';
+
+function formatError(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function sendSlackUserDirectMessage(
+  userId: string,
+  text: string,
+  logContext: string,
+): Promise<boolean> {
+  try {
+    const installations = await db.query.slackInstallations.findMany({
+      where: eq(slackInstallations.isActive, true),
+      columns: { botAccessToken: true, teamId: true },
+    });
+
+    for (const installation of installations) {
+      const mapping = await db.query.slackUserMappings.findFirst({
+        where: and(
+          eq(slackUserMappings.userId, userId),
+          eq(slackUserMappings.slackTeamId, installation.teamId),
+        ),
+        columns: { slackUserId: true },
+      });
+
+      if (!mapping) {
+        continue;
+      }
+
+      const slack = new SlackNotifier(installation.botAccessToken);
+      const dmChannelId = await slack.openConversation(mapping.slackUserId);
+
+      if (!dmChannelId) {
+        continue;
+      }
+
+      const messageTs = await slack.postMessage({
+        channel: dmChannelId,
+        text,
+      });
+
+      if (messageTs) {
+        return true;
+      }
+    }
+  } catch (error) {
+    console.warn(
+      `[${logContext}] Failed to send Slack DM: ${formatError(error)}`,
+    );
+  }
+
+  return false;
+}
+
+async function sendTeamsUserDirectMessage(
+  userId: string,
+  text: string,
+  logContext: string,
+): Promise<boolean> {
+  try {
+    const mapping = await db.query.teamsUserMappings.findFirst({
+      where: eq(teamsUserMappings.userId, userId),
+      columns: { teamsUserId: true, teamsTenantId: true },
+    });
+
+    if (!mapping) {
+      return false;
+    }
+
+    // Proactive DMs need a service URL, which lives on installations rather
+    // than user mappings; the primary conversation's URL covers the tenant.
+    const conversation = await findTeamsPrimaryConversation();
+
+    if (!conversation) {
+      return false;
+    }
+
+    const provider =
+      await createTeamsCommunicationProviderFromRuntimeCredentials();
+
+    if (!provider) {
+      return false;
+    }
+
+    await provider.postDirectMessage({
+      serviceUrl: conversation.serviceUrl,
+      tenantId: mapping.teamsTenantId,
+      userId: mapping.teamsUserId,
+      text,
+      textFormat: 'markdown',
+    });
+
+    return true;
+  } catch (error) {
+    console.warn(
+      `[${logContext}] Failed to send Teams DM: ${formatError(error)}`,
+    );
+
+    return false;
+  }
+}
+
+async function sendTelegramUserDirectMessage(
+  userId: string,
+  text: string,
+  logContext: string,
+): Promise<boolean> {
+  try {
+    const mapping = await db.query.telegramUserMappings.findFirst({
+      where: eq(telegramUserMappings.userId, userId),
+      columns: { telegramChatId: true },
+    });
+
+    if (!mapping) {
+      return false;
+    }
+
+    const provider =
+      await createTelegramCommunicationProviderFromRuntimeCredentials();
+
+    if (!provider) {
+      return false;
+    }
+
+    await provider.postMessage({
+      channelId: mapping.telegramChatId,
+      text,
+      textFormat: 'markdown',
+    });
+
+    return true;
+  } catch (error) {
+    console.warn(
+      `[${logContext}] Failed to send Telegram DM: ${formatError(error)}`,
+    );
+
+    return false;
+  }
+}
+
+/**
+ * Best-effort DM to a Roomote user on every chat integration that is both
+ * connected on this deployment and linked to the user. Failures are logged
+ * and swallowed; returns the providers that accepted the message.
+ */
+export async function sendUserDirectMessageBestEffort({
+  userId,
+  text,
+  logContext,
+}: {
+  userId: string;
+  text: string;
+  logContext: string;
+}): Promise<UserDirectMessageProvider[]> {
+  const [slack, teams, telegram] = await Promise.all([
+    sendSlackUserDirectMessage(userId, text, logContext),
+    sendTeamsUserDirectMessage(userId, text, logContext),
+    sendTelegramUserDirectMessage(userId, text, logContext),
+  ]);
+
+  return [
+    ...(slack ? (['slack'] as const) : []),
+    ...(teams ? (['teams'] as const) : []),
+    ...(telegram ? (['telegram'] as const) : []),
+  ];
+}


### PR DESCRIPTION
## Problem

When someone who isn't a GitHub org owner goes through setup and requests the GitHub App on an org they can't install on themselves, GitHub returns them to the callback with `setup_action=request` and we record a pending installation. Today the callback dead-ends on a static "pending admin approval" screen: no polling, no way to know when the request is approved, and no recovery path if the `installation.created` webhook never reaches the deployment. And if the user leaves and returns to `/setup` while still pending, they land on a bare "Connect to GitHub" button that just restarts the request.

## Changes

- **Poll + auto-continue:** while the pending screen is showing, it polls a new `github.pendingInstallations` query. When an org owner approves (the webhook deletes the pending row), it continues automatically to wherever the flow was headed.
- **"Check now" button:** wired to a new `github.resolvePendingInstallations` mutation that queries GitHub's installations directly and completes any pending request that's already been approved. This also rescues the case where the webhook never arrived.
- **Shared pending UI on both entry points:** the poll/"Check now" UI lives in a shared `GitHubInstallRequestPending` component, rendered both on the OAuth callback and on the setup wizard's `source-control-connect` step. A user who returns to `/setup` while pending now sees the same auto-continuing, re-checkable state instead of a bare "Connect to GitHub" button.
- **DM on approval:** when the webhook completes a pending installation, the requester gets a DM on whichever chat integrations they have connected and linked (Slack, Teams, Telegram), pointing them back to `/setup`. Unlinked or unconfigured providers are skipped; one provider failing doesn't block the others.
- **Stale-row cleanup:** recording a new install request clears the user's older pending rows so an abandoned/retried request can't keep the pending state alive forever.
- Copy updated to reference approval from a GitHub organization owner rather than the vague "admin approval".

## Tests

- `resolvePendingGitHubInstallationsCommand`: admin gate, success passthrough, error handling.
- `sendUserDirectMessageBestEffort`: all-providers delivery, unlinked-provider skip, unconfigured-provider skip, failure isolation.
- `handleInstallationCreated`: notifies on success, does not notify on failure/throw, still acks the webhook.
- `GitHubInstallRequestPending`: poll-driven approval fires once, still-pending renders the wait state, manual re-check completes / reports not-yet, footer slot renders.
- `StepSourceControlConnect`: pending request swaps the connect CTA for the pending UI and advances on approval; no pending request keeps the connect CTA.

`pnpm lint`, `pnpm check-types`, and `pnpm knip` all clean.

## Not covered

- No live end-to-end run, since the approval round-trip needs a real GitHub org owner.
- An email fallback for deployments with no chat integration would be a natural follow-up.