### PR TITLE
Prevent stale Discord routes from blocking events

### DIFF
--- a/apps/api/src/handlers/discord/__tests__/index.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/index.test.ts
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => ({
   addReaction: vi.fn(),
   channelAutoStart: vi.fn(),
   findPendingRoutingReply: vi.fn(),
+  hasPendingRouteCallback: vi.fn(),
   handleRoutingReply: vi.fn(),
   attachOutOfBand: vi.fn(),
   releaseOutOfBand: vi.fn(),
@@ -75,6 +76,7 @@ vi.mock('../channel-auto-start.js', () => ({
 
 vi.mock('../routing-confirmation.js', () => ({
   findDiscordPendingRoutingReply: mocks.findPendingRoutingReply,
+  hasPendingDiscordRouteCallback: mocks.hasPendingRouteCallback,
   handleDiscordRoutingReply: mocks.handleRoutingReply,
 }));
 
@@ -199,6 +201,7 @@ describe('Discord Gateway event handler', () => {
     mocks.component.mockResolvedValue('handled');
     mocks.channelAutoStart.mockResolvedValue(false);
     mocks.findPendingRoutingReply.mockResolvedValue(null);
+    mocks.hasPendingRouteCallback.mockResolvedValue(null);
     mocks.handleRoutingReply.mockResolvedValue(false);
     mocks.attachOutOfBand.mockImplementation(
       async ({ message }: { message: Record<string, unknown> }) => ({
@@ -963,5 +966,65 @@ describe('Discord Gateway event handler', () => {
       interactionDeferred: true,
       channel: expect.objectContaining({ channelId: 'dm-1' }),
     });
+  });
+
+  it('acknowledges a routing interaction whose pending state expired', async () => {
+    mocks.hasPendingRouteCallback.mockResolvedValue(false);
+    const interaction = {
+      id: 'interaction-route-expired',
+      application_id: 'app-1',
+      type: 3,
+      token: 'interaction-token',
+      channel_id: 'channel-1',
+      member: {
+        user: { id: 'discord-user-1', username: 'matt' },
+      },
+      data: {
+        custom_id: 'discord:route:abcdefghijkl:0',
+        component_type: 2,
+      },
+    };
+
+    const response = await postEvent(
+      envelope(interaction, 'INTERACTION_CREATE'),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      ignored: 'expired_routing_interaction',
+    });
+    expect(mocks.resolveProvider).not.toHaveBeenCalled();
+    expect(mocks.getChannel).not.toHaveBeenCalled();
+    expect(mocks.component).not.toHaveBeenCalled();
+    expect(mocks.completeEvent).toHaveBeenCalledWith({
+      eventType: 'INTERACTION_CREATE',
+      eventId: 'interaction-route-expired',
+      token: 'claim-token',
+    });
+    expect(mocks.releaseEvent).not.toHaveBeenCalled();
+  });
+
+  it('dispatches a routing interaction while its pending state exists', async () => {
+    mocks.hasPendingRouteCallback.mockResolvedValue(true);
+    const interaction = {
+      id: 'interaction-route-live',
+      application_id: 'app-1',
+      type: 3,
+      token: 'interaction-token',
+      channel_id: 'dm-1',
+      user: { id: 'discord-user-1', username: 'matt' },
+      data: {
+        custom_id: 'discord:route:abcdefghijkl:0',
+        component_type: 2,
+      },
+    };
+
+    const response = await postEvent(
+      envelope(interaction, 'INTERACTION_CREATE'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.component).toHaveBeenCalledOnce();
   });
 });

--- a/apps/api/src/handlers/discord/__tests__/routing-confirmation.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/routing-confirmation.test.ts
@@ -56,6 +56,7 @@ vi.mock('../replies.js', () => ({ replyToDiscordEvent: mocks.reply }));
 
 import {
   findDiscordPendingRoutingReply,
+  hasPendingDiscordRouteCallback,
   handleDiscordRoutingReply,
   handleDiscordRoutingCallback,
   requestDiscordRoutingConfirmation,
@@ -119,6 +120,50 @@ describe('Discord routing confirmation', () => {
       launchResult: { id: 42, taskId: 'task-1' },
     });
     mocks.reply.mockResolvedValue({ messageId: 'confirmation-1' });
+  });
+
+  it('checks whether a routing button still has pending state', async () => {
+    mocks.redisGet
+      .mockResolvedValueOnce(JSON.stringify({ options: [] }))
+      .mockResolvedValueOnce(null);
+
+    await expect(
+      hasPendingDiscordRouteCallback('discord:route:abcdefghijkl:0'),
+    ).resolves.toBe(true);
+    await expect(
+      hasPendingDiscordRouteCallback('discord:route:mnopqrstuvwx:cancel'),
+    ).resolves.toBe(false);
+    await expect(
+      hasPendingDiscordRouteCallback('discord:cancel:17'),
+    ).resolves.toBeNull();
+
+    expect(mocks.redisGet.mock.calls).toEqual([
+      ['discord:pending_route:abcdefghijkl'],
+      ['discord:pending_route:mnopqrstuvwx'],
+    ]);
+  });
+
+  it('treats an expired routing choice reply as best effort', async () => {
+    mocks.redisGetdel.mockResolvedValue(null);
+    mocks.reply.mockRejectedValueOnce(new Error('interaction expired'));
+
+    await expect(
+      handleDiscordRoutingCallback({
+        provider: {} as never,
+        applicationId: 'app-1',
+        interaction: {
+          id: 'interaction-1',
+          application_id: 'app-1',
+          type: 3,
+          token: 'token-1',
+          channel_id: 'channel-1',
+          user: { id: 'discord-user-1', username: 'matt' },
+          data: { custom_id: 'discord:route:abcdefghijkl:0' },
+        },
+        interactionDeferred: true,
+        callback: { pendingRouteId: 'abcdefghijkl', selection: 0 },
+      }),
+    ).resolves.toBeUndefined();
   });
 
   it('auto-confirms only high-confidence, unremapped routes', () => {

--- a/apps/api/src/handlers/discord/index.ts
+++ b/apps/api/src/handlers/discord/index.ts
@@ -60,6 +60,7 @@ import {
 import { replyToDiscordEvent } from './replies.js';
 import {
   findDiscordPendingRoutingReply,
+  hasPendingDiscordRouteCallback,
   handleDiscordRoutingReply,
 } from './routing-confirmation.js';
 import {
@@ -160,9 +161,18 @@ async function refreshDiscordUserMappingBestEffort(input: {
 }
 
 async function processDiscordGatewayEvent(event: DiscordGatewayEvent) {
-  const resolved = await resolveDiscordProvider();
   const interaction = getDiscordInteractionCreate(event);
   const message = getDiscordMessageCreate(event);
+  if (interaction?.type === 3) {
+    const routePending = await hasPendingDiscordRouteCallback(
+      interaction.data?.custom_id,
+    );
+    if (routePending === false) {
+      return { ok: true, ignored: 'expired_routing_interaction' };
+    }
+  }
+
+  const resolved = await resolveDiscordProvider();
   const channelId = interaction?.channel_id ?? message?.channel_id;
   if (!channelId) {
     return { ok: true, ignored: 'missing_channel' };
@@ -615,6 +625,9 @@ discord.post('/events', async (c) => {
       // stream entry without applying its poison-event attempt cap.
       return c.json({ ok: false, error: 'discord_api_unavailable' }, 503);
     }
+    apiLogger.error(
+      `[discord] Unhandled error while processing ${eventRef.eventType} event ${eventRef.eventId}: ${error instanceof Error ? error.message : String(error)}`,
+    );
     throw error;
   }
 });

--- a/apps/api/src/handlers/discord/routing-confirmation.ts
+++ b/apps/api/src/handlers/discord/routing-confirmation.ts
@@ -864,6 +864,22 @@ export function parseDiscordRouteCallbackData(
   };
 }
 
+/**
+ * Check whether a component interaction still points at actionable routing
+ * state. The Gateway delivers events in order, so an expired button must be
+ * acknowledged before any Discord API lookup can let it poison the queue.
+ * `null` means the component is not a routing callback.
+ */
+export async function hasPendingDiscordRouteCallback(
+  value: string | undefined,
+): Promise<boolean | null> {
+  const callback = parseDiscordRouteCallbackData(value);
+  if (!callback) return null;
+  return Boolean(
+    await getRedis().get(pendingRouteKey(callback.pendingRouteId)),
+  );
+}
+
 export async function handleDiscordRoutingCallback(input: {
   provider: DiscordCommunicationProvider;
   applicationId: string;
@@ -885,6 +901,9 @@ export async function handleDiscordRoutingCallback(input: {
     isThread: false,
   };
   if (!pending) {
+    // Another delivery may have claimed the route after the intake preflight.
+    // The click is terminal once its state is gone; an expired interaction
+    // token or inaccessible fallback channel must not block newer events.
     await replyToDiscordEvent({
       provider: input.provider,
       applicationId: input.applicationId,
@@ -894,6 +913,10 @@ export async function handleDiscordRoutingCallback(input: {
         interactionDeferred: input.interactionDeferred,
       },
       text: 'That routing choice is no longer available.',
+    }).catch((error) => {
+      apiLogger.warn(
+        `[discord] Could not acknowledge expired routing choice ${input.callback.pendingRouteId}: ${error instanceof Error ? error.message : String(error)}`,
+      );
     });
     return;
   }


### PR DESCRIPTION
## Summary

- acknowledge expired or duplicate Discord routing-button events before provider and channel lookups
- make the missing-routing-state reply best-effort to cover claim races
- log unexpected Discord event failures with event metadata
- add regression coverage for expired, live, and raced routing interactions

## Root cause

Discord Gateway events are delivered from an ordered durable stream. A routing-button interaction can remain queued after its pending routing state expires. Processing that stale interaction may fail while resolving Discord state or replying through an expired interaction, producing a 5xx response. Because the Gateway retains infrastructure failures, that single entry can block every newer event behind it.

The API now checks the pending route state at intake and acknowledges stale interactions without touching Discord. If the state disappears after that preflight, the explanatory reply cannot fail the event.

## Impact

A stale routing button can no longer poison Discord event delivery, and future unexpected failures will be visible in application logs.

## Validation

- `pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/api exec vitest run src/handlers/discord/__tests__/index.test.ts src/handlers/discord/__tests__/routing-confirmation.test.ts` (49 tests)
- `pnpm --filter @roomote/api check-types:fast`
- targeted ESLint for the four changed files
- `oxfmt --check` for the four changed files
- `git diff --check`
