### PR TITLE
Recover stalled worker bootstraps promptly

### DIFF
--- a/apps/controller/src/BaseController.ts
+++ b/apps/controller/src/BaseController.ts
@@ -9,6 +9,7 @@ import {
   resolveComputeProviderTarget,
   SANDBOX_ORPHAN_SCAN_INTERVAL_MS,
   SANDBOX_TIMEOUT_MS,
+  WORKER_BOOTSTRAP_CLAIM_TIMEOUT_MS,
 } from '@roomote/types';
 import { createRunToken } from '@roomote/auth';
 import { Env } from '@roomote/env';
@@ -23,7 +24,10 @@ import {
   updatePendingEnvironmentSnapshot,
   eq,
   and,
+  asc,
   isNull,
+  isNotNull,
+  lt,
 } from '@roomote/db/server';
 import { dequeueTaskRun } from '@roomote/cloud-agents/server';
 import { finishRun } from '@roomote/sdk/server';
@@ -105,6 +109,7 @@ export abstract class BaseController {
     this.watchLocalArtifacts();
 
     let lastOrphanCheckAt = 0;
+    let lastWorkerBootstrapCheckAt = 0;
     const orphanCheckInterval = SANDBOX_ORPHAN_SCAN_INTERVAL_MS;
 
     console.log('Looping for task runs...');
@@ -119,6 +124,16 @@ export abstract class BaseController {
           'EX',
           this.HEARTBEAT_TTL_SECONDS,
         );
+
+        const iterationNow = Date.now();
+
+        if (
+          iterationNow - lastWorkerBootstrapCheckAt >
+          SANDBOX_ORPHAN_SCAN_INTERVAL_MS
+        ) {
+          lastWorkerBootstrapCheckAt = iterationNow;
+          await this.failTimedOutWorkerBootstrap();
+        }
 
         if (this.inFlightSpawns.size >= this.MAX_CONCURRENT_SPAWNS) {
           await new Promise((resolve) => setTimeout(resolve, 1_000));
@@ -508,6 +523,145 @@ export abstract class BaseController {
       `[BaseController] ❌ Error spawning ${taskRun.payloadKind} worker for task run #${taskRun.id}: ${errorMessage}`,
     );
 
+    await this.finishFailedTaskRun(taskRun, errorMessage);
+
+    throw error;
+  }
+
+  /**
+   * Atomically claims a detached worker exit as a bootstrap failure. The
+   * worker's own dequeue transition races this conditional update, so a late
+   * process exit cannot overwrite a run that reached processing.
+   *
+   * Returns true when the exit was claimed and provider cleanup is safe.
+   */
+  protected async handleWorkerExitBeforeStart(
+    taskRun: TaskRun,
+    exitCode: number,
+  ): Promise<boolean> {
+    const errorMessage = `Worker process exited before claiming task run (exit code ${exitCode})`;
+    return this.claimWorkerBootstrapFailure(taskRun, errorMessage, {
+      message: 'Detached worker exited before claiming its task run',
+      signal: 'worker-bootstrap-exit',
+      exitCode,
+    });
+  }
+
+  protected async failTimedOutWorkerBootstrap(): Promise<boolean> {
+    const taskRun = await db.query.taskRuns.findFirst({
+      where: and(
+        eq(taskRuns.status, RunStatus.Dequeued),
+        isNotNull(taskRuns.provisionReadyAt),
+        lt(
+          taskRuns.provisionReadyAt,
+          new Date(Date.now() - WORKER_BOOTSTRAP_CLAIM_TIMEOUT_MS),
+        ),
+        isNull(taskRuns.startedAt),
+        isNull(taskRuns.workerHeartbeatAt),
+        isNull(taskRuns.canceledAt),
+      ),
+      orderBy: [asc(taskRuns.provisionReadyAt)],
+    });
+
+    if (!taskRun) {
+      return false;
+    }
+
+    // provisionReadyAt is stamped before the final worker handoff. Do not let
+    // the watchdog race a launch that this controller is still actively
+    // completing (for example, environment OIDC priming).
+    if (this.inFlightSpawns.has(taskRun.id)) {
+      return false;
+    }
+
+    const timeoutSeconds = Math.round(
+      WORKER_BOOTSTRAP_CLAIM_TIMEOUT_MS / 1_000,
+    );
+    const errorMessage = `Worker did not claim task run within ${timeoutSeconds} seconds after the environment became ready`;
+
+    return this.claimWorkerBootstrapFailure(taskRun, errorMessage, {
+      message: 'Worker did not claim its task run after provisioning',
+      signal: 'worker-bootstrap-timeout',
+    });
+  }
+
+  private async claimWorkerBootstrapFailure(
+    taskRun: TaskRun,
+    errorMessage: string,
+    diagnostic: {
+      message: string;
+      signal: string;
+      exitCode?: number;
+    },
+  ): Promise<boolean> {
+    const now = new Date();
+    const claimed = await db
+      .update(taskRuns)
+      .set({
+        status: RunStatus.Failed,
+        error: errorMessage,
+        completedAt: now,
+      })
+      .where(
+        and(
+          eq(taskRuns.id, taskRun.id),
+          eq(taskRuns.status, RunStatus.Dequeued),
+          isNull(taskRuns.startedAt),
+          isNull(taskRuns.workerHeartbeatAt),
+          isNull(taskRuns.canceledAt),
+        ),
+      )
+      .returning({ id: taskRuns.id });
+
+    if (claimed.length === 0) {
+      console.log(
+        `[BaseController] Ignoring worker bootstrap failure for task run #${taskRun.id} because the run already advanced`,
+      );
+      return false;
+    }
+
+    captureControllerMessage(
+      diagnostic.message,
+      {
+        runId: taskRun.id,
+        payloadKind: taskRun.payloadKind,
+        provider: taskRun.vendor,
+        ...(diagnostic.exitCode === undefined
+          ? {}
+          : { exitCode: diagnostic.exitCode }),
+        phase: 'worker_bootstrap',
+      },
+      {
+        component: 'worker-lifecycle',
+        signal: diagnostic.signal,
+      },
+    );
+
+    console.error(
+      `[BaseController] ❌ ${errorMessage} for task run #${taskRun.id}`,
+    );
+
+    try {
+      await this.finishFailedTaskRun(taskRun, errorMessage);
+    } catch (error) {
+      captureControllerException(error, {
+        runId: taskRun.id,
+        payloadKind: taskRun.payloadKind,
+        provider: taskRun.vendor,
+        phase: 'worker_bootstrap_finalize',
+      });
+      console.error(
+        `[BaseController] Failed to complete bootstrap-failure side effects for task run #${taskRun.id}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    return true;
+  }
+
+  private async finishFailedTaskRun(
+    taskRun: TaskRun,
+    errorMessage: string,
+  ): Promise<void> {
     // Use the centralized termination path so all side-effects (email, Slack,
     // Linear notifications, lock release, etc.) are applied consistently.
     await finishRun({
@@ -540,7 +694,5 @@ export abstract class BaseController {
         });
       }
     }
-
-    throw error;
   }
 }

--- a/apps/controller/src/BaseController.ts
+++ b/apps/controller/src/BaseController.ts
@@ -28,6 +28,7 @@ import {
   isNull,
   isNotNull,
   lt,
+  sql,
 } from '@roomote/db/server';
 import { dequeueTaskRun } from '@roomote/cloud-agents/server';
 import { finishRun } from '@roomote/sdk/server';
@@ -38,6 +39,8 @@ import {
   captureControllerMessage,
 } from './monitoring/sentry';
 import { resolveFromWorkspaceRoot } from './repo-paths';
+
+type WorkerBootstrapExitDisposition = 'ignore' | 'restart' | 'failed';
 
 export abstract class BaseController {
   private static readonly SOURCE_DIR = path.dirname(
@@ -66,6 +69,9 @@ export abstract class BaseController {
 
   /** Track in-flight spawn operations by run ID. */
   private inFlightSpawns = new Map<number, Promise<void>>();
+
+  /** Bootstrap retries waiting for a spawn slot or the previous spawn unwind. */
+  private pendingWorkerBootstrapRestarts = new Map<number, TaskRun>();
 
   /** Watches local release artifacts for changes (local dev only). */
   private artifactWatchers: fs.FSWatcher[] = [];
@@ -133,6 +139,30 @@ export abstract class BaseController {
         ) {
           lastWorkerBootstrapCheckAt = iterationNow;
           await this.failTimedOutWorkerBootstrap();
+        }
+
+        const pendingRestart = this.pendingWorkerBootstrapRestarts
+          .values()
+          .next().value;
+
+        if (
+          pendingRestart &&
+          this.inFlightSpawns.size < this.MAX_CONCURRENT_SPAWNS &&
+          !this.inFlightSpawns.has(pendingRestart.id)
+        ) {
+          this.pendingWorkerBootstrapRestarts.delete(pendingRestart.id);
+
+          if (this.spawnWorkerInBackground(pendingRestart)) {
+            console.log(
+              `[BaseController] Retrying worker bootstrap for task run #${pendingRestart.id}`,
+            );
+            continue;
+          }
+
+          this.pendingWorkerBootstrapRestarts.set(
+            pendingRestart.id,
+            pendingRestart,
+          );
         }
 
         if (this.inFlightSpawns.size >= this.MAX_CONCURRENT_SPAWNS) {
@@ -538,13 +568,60 @@ export abstract class BaseController {
   protected async handleWorkerExitBeforeStart(
     taskRun: TaskRun,
     exitCode: number,
-  ): Promise<boolean> {
+  ): Promise<WorkerBootstrapExitDisposition> {
+    if (await this.claimWorkerBootstrapRestart(taskRun, exitCode)) {
+      return 'restart';
+    }
+
     const errorMessage = `Worker process exited before claiming task run (exit code ${exitCode})`;
-    return this.claimWorkerBootstrapFailure(taskRun, errorMessage, {
-      message: 'Detached worker exited before claiming its task run',
-      signal: 'worker-bootstrap-exit',
-      exitCode,
-    });
+    const failed = await this.claimWorkerBootstrapFailure(
+      taskRun,
+      errorMessage,
+      {
+        message: 'Detached worker exited before claiming its task run',
+        signal: 'worker-bootstrap-exit',
+        exitCode,
+      },
+    );
+
+    return failed ? 'failed' : 'ignore';
+  }
+
+  protected scheduleWorkerBootstrapRestart(taskRun: TaskRun): void {
+    const restartRun: TaskRun = {
+      ...taskRun,
+      status: RunStatus.Pending,
+      dequeuedAt: null,
+      machineId: null,
+      machineDomain: null,
+      machineDomains: null,
+      primaryPortName: null,
+      sandboxServerUrl: null,
+      sandboxCmdId: null,
+      proxyPorts: null,
+      provisionStartedAt: null,
+      provisionReadyAt: null,
+    };
+
+    if (!this.isRunning) {
+      this.pendingWorkerBootstrapRestarts.set(taskRun.id, restartRun);
+      console.log(
+        `[BaseController] Queued worker bootstrap retry for task run #${taskRun.id} while the controller is stopped`,
+      );
+      return;
+    }
+
+    if (this.spawnWorkerInBackground(restartRun)) {
+      console.log(
+        `[BaseController] Retrying worker bootstrap for task run #${taskRun.id}`,
+      );
+      return;
+    }
+
+    this.pendingWorkerBootstrapRestarts.set(taskRun.id, restartRun);
+    console.log(
+      `[BaseController] Queued worker bootstrap retry for task run #${taskRun.id}`,
+    );
   }
 
   protected async failTimedOutWorkerBootstrap(): Promise<boolean> {
@@ -654,6 +731,98 @@ export abstract class BaseController {
         `[BaseController] Failed to complete bootstrap-failure side effects for task run #${taskRun.id}: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
+
+    return true;
+  }
+
+  private async claimWorkerBootstrapRestart(
+    taskRun: TaskRun,
+    exitCode: number,
+  ): Promise<boolean> {
+    const claimed = await db.transaction(async (tx) => {
+      const [lockedRun] = await tx.execute<{ id: number }>(sql`
+        SELECT id
+        FROM task_runs
+        WHERE id = ${taskRun.id}
+          AND status = ${RunStatus.Dequeued}
+          AND started_at IS NULL
+          AND worker_heartbeat_at IS NULL
+          AND canceled_at IS NULL
+        FOR UPDATE
+      `);
+
+      if (!lockedRun) {
+        return false;
+      }
+
+      const [previousRestart] = await tx.execute<{ id: string }>(sql`
+        SELECT id
+        FROM task_run_events
+        WHERE run_id = ${taskRun.id}
+          AND source = 'run_lifecycle'
+          AND details ->> 'stage' = 'worker_bootstrap_restart'
+        LIMIT 1
+      `);
+
+      if (previousRestart) {
+        return false;
+      }
+
+      await tx
+        .update(taskRuns)
+        .set({
+          status: RunStatus.Pending,
+          dequeuedAt: null,
+          machineId: null,
+          machineDomain: null,
+          machineDomains: null,
+          primaryPortName: null,
+          sandboxServerUrl: null,
+          sandboxCmdId: null,
+          proxyPorts: null,
+          provisionStartedAt: null,
+          provisionReadyAt: null,
+        })
+        .where(eq(taskRuns.id, taskRun.id));
+
+      await recordTaskRunLifecycleEvent(tx, {
+        runId: taskRun.id,
+        taskId: taskRun.taskId,
+        eventType: 'decision',
+        message:
+          'Controller scheduled one fresh sandbox after a worker bootstrap exit.',
+        details: {
+          stage: 'worker_bootstrap_restart',
+          status: RunStatus.Pending,
+          provider: taskRun.vendor ?? null,
+          previousMachineId: taskRun.machineId ?? null,
+          exitCode,
+          restartAttempt: 1,
+        },
+      });
+
+      return true;
+    });
+
+    if (!claimed) {
+      return false;
+    }
+
+    captureControllerMessage(
+      'Controller scheduled a fresh sandbox after worker bootstrap failure',
+      {
+        runId: taskRun.id,
+        payloadKind: taskRun.payloadKind,
+        provider: taskRun.vendor,
+        exitCode,
+        restartAttempt: 1,
+        phase: 'worker_bootstrap',
+      },
+      {
+        component: 'worker-lifecycle',
+        signal: 'worker-bootstrap-restart',
+      },
+    );
 
     return true;
   }

--- a/apps/controller/src/BaseController.ts
+++ b/apps/controller/src/BaseController.ts
@@ -18,9 +18,11 @@ import {
   type TaskRun,
   db,
   taskRuns,
+  taskRunEvents,
   buildPendingEnvironmentSnapshotMatchForTaskRun,
   recordTaskRunLifecycleEvent,
   resolveDefaultComputeProvider,
+  syncTaskStateFromRuns,
   updatePendingEnvironmentSnapshot,
   eq,
   and,
@@ -72,6 +74,9 @@ export abstract class BaseController {
 
   /** Bootstrap retries waiting for a spawn slot or the previous spawn unwind. */
   private pendingWorkerBootstrapRestarts = new Map<number, TaskRun>();
+
+  /** Prevent this controller from recovering a retry before cleanup finishes. */
+  private workerBootstrapRestartsAwaitingCleanup = new Set<number>();
 
   /** Watches local release artifacts for changes (local dev only). */
   private artifactWatchers: fs.FSWatcher[] = [];
@@ -138,7 +143,8 @@ export abstract class BaseController {
           SANDBOX_ORPHAN_SCAN_INTERVAL_MS
         ) {
           lastWorkerBootstrapCheckAt = iterationNow;
-          await this.failTimedOutWorkerBootstrap();
+          await this.recoverPersistedWorkerBootstrapRestarts();
+          await this.failTimedOutWorkerBootstraps();
         }
 
         const pendingRestart = this.pendingWorkerBootstrapRestarts
@@ -570,6 +576,7 @@ export abstract class BaseController {
     exitCode: number,
   ): Promise<WorkerBootstrapExitDisposition> {
     if (await this.claimWorkerBootstrapRestart(taskRun, exitCode)) {
+      this.workerBootstrapRestartsAwaitingCleanup.add(taskRun.id);
       return 'restart';
     }
 
@@ -588,6 +595,8 @@ export abstract class BaseController {
   }
 
   protected scheduleWorkerBootstrapRestart(taskRun: TaskRun): void {
+    this.workerBootstrapRestartsAwaitingCleanup.delete(taskRun.id);
+
     const restartRun: TaskRun = {
       ...taskRun,
       status: RunStatus.Pending,
@@ -624,8 +633,8 @@ export abstract class BaseController {
     );
   }
 
-  protected async failTimedOutWorkerBootstrap(): Promise<boolean> {
-    const taskRun = await db.query.taskRuns.findFirst({
+  protected async failTimedOutWorkerBootstraps(): Promise<number> {
+    const overdueRuns = await db.query.taskRuns.findMany({
       where: and(
         eq(taskRuns.status, RunStatus.Dequeued),
         isNotNull(taskRuns.provisionReadyAt),
@@ -640,26 +649,62 @@ export abstract class BaseController {
       orderBy: [asc(taskRuns.provisionReadyAt)],
     });
 
-    if (!taskRun) {
-      return false;
-    }
-
-    // provisionReadyAt is stamped before the final worker handoff. Do not let
-    // the watchdog race a launch that this controller is still actively
-    // completing (for example, environment OIDC priming).
-    if (this.inFlightSpawns.has(taskRun.id)) {
-      return false;
-    }
-
     const timeoutSeconds = Math.round(
       WORKER_BOOTSTRAP_CLAIM_TIMEOUT_MS / 1_000,
     );
     const errorMessage = `Worker did not claim task run within ${timeoutSeconds} seconds after the environment became ready`;
+    let failedCount = 0;
 
-    return this.claimWorkerBootstrapFailure(taskRun, errorMessage, {
-      message: 'Worker did not claim its task run after provisioning',
-      signal: 'worker-bootstrap-timeout',
+    for (const taskRun of overdueRuns) {
+      // provisionReadyAt is stamped before the final worker handoff. Do not
+      // let the watchdog race a launch that this controller is still actively
+      // completing (for example, environment OIDC priming).
+      if (this.inFlightSpawns.has(taskRun.id)) {
+        continue;
+      }
+
+      if (
+        await this.claimWorkerBootstrapFailure(taskRun, errorMessage, {
+          message: 'Worker did not claim its task run after provisioning',
+          signal: 'worker-bootstrap-timeout',
+        })
+      ) {
+        failedCount += 1;
+      }
+    }
+
+    return failedCount;
+  }
+
+  protected async recoverPersistedWorkerBootstrapRestarts(): Promise<number> {
+    const scheduledRuns = await db.query.taskRuns.findMany({
+      where: and(
+        eq(taskRuns.status, RunStatus.Pending),
+        isNull(taskRuns.startedAt),
+        isNull(taskRuns.canceledAt),
+        sql`EXISTS (
+          SELECT 1
+          FROM ${taskRunEvents}
+          WHERE ${taskRunEvents.runId} = ${taskRuns.id}
+            AND ${taskRunEvents.source} = 'run_lifecycle'
+            AND ${taskRunEvents.details} ->> 'stage' = 'worker_bootstrap_restart'
+        )`,
+      ),
+      orderBy: [asc(taskRuns.createdAt)],
     });
+
+    let recoveredCount = 0;
+
+    for (const taskRun of scheduledRuns) {
+      if (this.workerBootstrapRestartsAwaitingCleanup.has(taskRun.id)) {
+        continue;
+      }
+
+      this.scheduleWorkerBootstrapRestart(taskRun);
+      recoveredCount += 1;
+    }
+
+    return recoveredCount;
   }
 
   private async claimWorkerBootstrapFailure(
@@ -672,25 +717,37 @@ export abstract class BaseController {
     },
   ): Promise<boolean> {
     const now = new Date();
-    const claimed = await db
-      .update(taskRuns)
-      .set({
-        status: RunStatus.Failed,
-        error: errorMessage,
-        completedAt: now,
-      })
-      .where(
-        and(
-          eq(taskRuns.id, taskRun.id),
-          eq(taskRuns.status, RunStatus.Dequeued),
-          isNull(taskRuns.startedAt),
-          isNull(taskRuns.workerHeartbeatAt),
-          isNull(taskRuns.canceledAt),
-        ),
-      )
-      .returning({ id: taskRuns.id });
+    const claimed = await db.transaction(async (tx) => {
+      const updatedRuns = await tx
+        .update(taskRuns)
+        .set({
+          status: RunStatus.Failed,
+          error: errorMessage,
+          completedAt: now,
+        })
+        .where(
+          and(
+            eq(taskRuns.id, taskRun.id),
+            eq(taskRuns.status, RunStatus.Dequeued),
+            isNull(taskRuns.startedAt),
+            isNull(taskRuns.workerHeartbeatAt),
+            isNull(taskRuns.canceledAt),
+          ),
+        )
+        .returning({ id: taskRuns.id });
 
-    if (claimed.length === 0) {
+      if (updatedRuns.length === 0) {
+        return false;
+      }
+
+      // Keep the task projection durable with the terminal run transition.
+      // finishRun repeats this sync while applying notifications and cleanup,
+      // but a later side-effect failure cannot leave the task active forever.
+      await syncTaskStateFromRuns(tx, taskRun.taskId);
+      return true;
+    });
+
+    if (!claimed) {
       console.log(
         `[BaseController] Ignoring worker bootstrap failure for task run #${taskRun.id} because the run already advanced`,
       );

--- a/apps/controller/src/RoomoteController.ts
+++ b/apps/controller/src/RoomoteController.ts
@@ -141,6 +141,7 @@ export class RoomoteController extends BaseController {
           localTarballPath: this.localWorkerReleasePath,
           onWorkerExit: ({ exitCode }) =>
             this.handleWorkerExitBeforeStart(taskRun, exitCode),
+          onWorkerRestart: () => this.scheduleWorkerBootstrapRestart(taskRun),
         });
         return;
       }

--- a/apps/controller/src/RoomoteController.ts
+++ b/apps/controller/src/RoomoteController.ts
@@ -139,6 +139,8 @@ export class RoomoteController extends BaseController {
           modalVmMemoryMiB: Env.MODAL_VM_MEMORY_MIB,
           modalTimeoutMs: timeoutMs,
           localTarballPath: this.localWorkerReleasePath,
+          onWorkerExit: ({ exitCode }) =>
+            this.handleWorkerExitBeforeStart(taskRun, exitCode),
         });
         return;
       }

--- a/apps/controller/src/__tests__/BaseController.test.ts
+++ b/apps/controller/src/__tests__/BaseController.test.ts
@@ -188,6 +188,8 @@ function resetControllerMocks() {
   mockRecordTaskRunLifecycleEvent.mockResolvedValue(undefined);
   mockRedisSet.mockResolvedValue('OK');
   mockUpdatePendingEnvironmentSnapshot.mockResolvedValue(true);
+  mockDbExecute.mockReset().mockResolvedValue([]);
+  mockDbTransaction.mockReset();
   mockUpdateWhere.mockReset().mockReturnValue({
     returning: vi.fn().mockResolvedValue([{}]),
   });
@@ -504,42 +506,79 @@ describe('BaseController.handleWorkerExitBeforeStart', () => {
     mockUpdateWhere.mockReturnValue({
       returning: vi.fn().mockResolvedValue([{ id: 42 }]),
     });
+    mockDbTransaction.mockImplementation(
+      async (callback: (tx: unknown) => Promise<unknown>) =>
+        callback({
+          execute: (...args: unknown[]) => mockDbExecute(...args),
+          update: (...args: unknown[]) => mockDbUpdate(...args),
+        }),
+    );
     controller = new TestController();
   });
 
-  it('fails a dequeued run immediately when its worker exits before starting', async () => {
+  it('schedules one fresh sandbox when the first worker exits before starting', async () => {
+    mockDbExecute.mockResolvedValueOnce([{ id: 42 }]).mockResolvedValueOnce([]);
     const job = makeTaskRun({
       id: 42,
       status: RunStatus.Dequeued,
+      machineId: 'sandbox-old',
       startedAt: null,
       workerHeartbeatAt: null,
     });
 
     await expect(
       controller.testHandleWorkerExitBeforeStart(job, 1),
-    ).resolves.toBe(true);
+    ).resolves.toBe('restart');
 
     expect(mockDbUpdateSet).toHaveBeenCalledWith(
       expect.objectContaining({
-        status: RunStatus.Failed,
-        error: 'Worker process exited before claiming task run (exit code 1)',
-        completedAt: expect.any(Date),
+        status: RunStatus.Pending,
+        machineId: null,
+        provisionStartedAt: null,
+        provisionReadyAt: null,
       }),
     );
+    expect(mockFinishRun).not.toHaveBeenCalled();
+    expect(mockRecordTaskRunLifecycleEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        runId: 42,
+        details: expect.objectContaining({
+          stage: 'worker_bootstrap_restart',
+          restartAttempt: 1,
+          previousMachineId: 'sandbox-old',
+        }),
+      }),
+    );
+    expect(mockCaptureControllerMessage).toHaveBeenCalledWith(
+      'Controller scheduled a fresh sandbox after worker bootstrap failure',
+      expect.objectContaining({
+        runId: 42,
+        exitCode: 1,
+        restartAttempt: 1,
+        phase: 'worker_bootstrap',
+      }),
+      expect.objectContaining({ signal: 'worker-bootstrap-restart' }),
+    );
+  });
+
+  it('fails the run when the replacement worker also exits before starting', async () => {
+    mockDbExecute
+      .mockResolvedValueOnce([{ id: 42 }])
+      .mockResolvedValueOnce([{ id: 'restart-event' }]);
+
+    await expect(
+      controller.testHandleWorkerExitBeforeStart(
+        makeTaskRun({ id: 42, status: RunStatus.Dequeued }),
+        1,
+      ),
+    ).resolves.toBe('failed');
+
     expect(mockFinishRun).toHaveBeenCalledWith({
       id: 42,
       status: RunStatus.Failed,
       error: 'Worker process exited before claiming task run (exit code 1)',
     });
-    expect(mockCaptureControllerMessage).toHaveBeenCalledWith(
-      'Detached worker exited before claiming its task run',
-      expect.objectContaining({
-        runId: 42,
-        exitCode: 1,
-        phase: 'worker_bootstrap',
-      }),
-      expect.objectContaining({ signal: 'worker-bootstrap-exit' }),
-    );
   });
 
   it('ignores an exit when the run already advanced', async () => {
@@ -552,7 +591,7 @@ describe('BaseController.handleWorkerExitBeforeStart', () => {
       0,
     );
 
-    expect(claimed).toBe(false);
+    expect(claimed).toBe('ignore');
     expect(mockFinishRun).not.toHaveBeenCalled();
     expect(mockCaptureControllerMessage).not.toHaveBeenCalled();
   });
@@ -586,6 +625,9 @@ describe('BaseController.handleWorkerExitBeforeStart', () => {
   });
 
   it('keeps the claimed failure durable when finalization side effects fail', async () => {
+    mockDbExecute
+      .mockResolvedValueOnce([{ id: 44 }])
+      .mockResolvedValueOnce([{ id: 'restart-event' }]);
     mockFinishRun.mockRejectedValueOnce(new Error('notification failed'));
 
     await expect(
@@ -593,7 +635,7 @@ describe('BaseController.handleWorkerExitBeforeStart', () => {
         makeTaskRun({ id: 44, status: RunStatus.Dequeued }),
         1,
       ),
-    ).resolves.toBe(true);
+    ).resolves.toBe('failed');
 
     expect(mockCaptureControllerException).toHaveBeenCalledWith(
       expect.objectContaining({ message: 'notification failed' }),

--- a/apps/controller/src/__tests__/BaseController.test.ts
+++ b/apps/controller/src/__tests__/BaseController.test.ts
@@ -11,17 +11,20 @@ const {
   mockCaptureControllerException,
   mockCaptureControllerMessage,
   mockTaskRunsFindFirst,
+  mockTaskRunsFindMany,
   mockOrgsFindFirst,
   mockDequeueTaskRun,
   mockGetOrphanedTaskRun,
   mockRecordTaskRunLifecycleEvent,
   mockRedisSet,
   mockUpdateWhere,
+  mockSyncTaskStateFromRuns,
 } = vi.hoisted(() => ({
   mockFinishRun: vi.fn().mockResolvedValue(undefined),
   mockCaptureControllerException: vi.fn(),
   mockCaptureControllerMessage: vi.fn(),
   mockTaskRunsFindFirst: vi.fn(),
+  mockTaskRunsFindMany: vi.fn(),
   mockOrgsFindFirst: vi.fn(),
   mockDequeueTaskRun: vi.fn().mockResolvedValue(null),
   mockGetOrphanedTaskRun: vi.fn().mockResolvedValue(null),
@@ -30,6 +33,7 @@ const {
   mockUpdateWhere: vi.fn().mockReturnValue({
     returning: vi.fn().mockResolvedValue([{}]),
   }),
+  mockSyncTaskStateFromRuns: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@roomote/sdk/server', () => ({
@@ -59,6 +63,7 @@ vi.mock('@roomote/db/server', async () => {
       query: {
         taskRuns: {
           findFirst: (...args: unknown[]) => mockTaskRunsFindFirst(...args),
+          findMany: (...args: unknown[]) => mockTaskRunsFindMany(...args),
         },
         orgs: { findFirst: (...args: unknown[]) => mockOrgsFindFirst(...args) },
       },
@@ -70,6 +75,8 @@ vi.mock('@roomote/db/server', async () => {
     recordTaskRunLifecycleEvent: (...args: unknown[]) =>
       mockRecordTaskRunLifecycleEvent(...args),
     resolveDefaultComputeProvider: vi.fn().mockResolvedValue('docker'),
+    syncTaskStateFromRuns: (...args: unknown[]) =>
+      mockSyncTaskStateFromRuns(...args),
     updatePendingEnvironmentSnapshot: (...args: unknown[]) =>
       mockUpdatePendingEnvironmentSnapshot(...args),
   };
@@ -145,8 +152,12 @@ class TestController extends BaseController {
     return this.handleWorkerExitBeforeStart(taskRun, exitCode);
   }
 
-  public async testFailTimedOutWorkerBootstrap() {
-    return this.failTimedOutWorkerBootstrap();
+  public async testFailTimedOutWorkerBootstraps() {
+    return this.failTimedOutWorkerBootstraps();
+  }
+
+  public async testRecoverPersistedWorkerBootstrapRestarts() {
+    return this.recoverPersistedWorkerBootstrapRestarts();
   }
 }
 
@@ -183,11 +194,13 @@ function makeTaskRun(overrides: Partial<TaskRun> = {}): TaskRun {
 
 function resetControllerMocks() {
   mockTaskRunsFindFirst.mockResolvedValue(null);
+  mockTaskRunsFindMany.mockResolvedValue([]);
   mockDequeueTaskRun.mockResolvedValue(null);
   mockGetOrphanedTaskRun.mockResolvedValue(null);
   mockRecordTaskRunLifecycleEvent.mockResolvedValue(undefined);
   mockRedisSet.mockResolvedValue('OK');
   mockUpdatePendingEnvironmentSnapshot.mockResolvedValue(true);
+  mockSyncTaskStateFromRuns.mockResolvedValue(undefined);
   mockDbExecute.mockReset().mockResolvedValue([]);
   mockDbTransaction.mockReset();
   mockUpdateWhere.mockReset().mockReturnValue({
@@ -596,8 +609,8 @@ describe('BaseController.handleWorkerExitBeforeStart', () => {
     expect(mockCaptureControllerMessage).not.toHaveBeenCalled();
   });
 
-  it('fails a provisioned run when no worker claims it before the watchdog', async () => {
-    mockTaskRunsFindFirst.mockResolvedValueOnce(
+  it('fails every provisioned run due in the same watchdog scan', async () => {
+    mockTaskRunsFindMany.mockResolvedValueOnce([
       makeTaskRun({
         id: 43,
         status: RunStatus.Dequeued,
@@ -605,23 +618,38 @@ describe('BaseController.handleWorkerExitBeforeStart', () => {
         startedAt: null,
         workerHeartbeatAt: null,
       }),
+      makeTaskRun({
+        id: 45,
+        status: RunStatus.Dequeued,
+        provisionReadyAt: new Date(Date.now() - 4 * 60_000),
+        startedAt: null,
+        workerHeartbeatAt: null,
+      }),
+    ]);
+
+    await expect(controller.testFailTimedOutWorkerBootstraps()).resolves.toBe(
+      2,
     );
 
-    await expect(controller.testFailTimedOutWorkerBootstrap()).resolves.toBe(
-      true,
+    expect(mockFinishRun).toHaveBeenCalledTimes(2);
+    expect(mockFinishRun).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 43, status: RunStatus.Failed }),
     );
+    expect(mockFinishRun).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 45, status: RunStatus.Failed }),
+    );
+    expect(mockSyncTaskStateFromRuns).toHaveBeenCalledTimes(2);
+  });
 
-    expect(mockFinishRun).toHaveBeenCalledWith({
-      id: 43,
-      status: RunStatus.Failed,
-      error:
-        'Worker did not claim task run within 120 seconds after the environment became ready',
-    });
-    expect(mockCaptureControllerMessage).toHaveBeenCalledWith(
-      'Worker did not claim its task run after provisioning',
-      expect.objectContaining({ runId: 43, phase: 'worker_bootstrap' }),
-      expect.objectContaining({ signal: 'worker-bootstrap-timeout' }),
-    );
+  it('recovers every persisted bootstrap restart after controller state is lost', async () => {
+    mockTaskRunsFindMany.mockResolvedValueOnce([
+      makeTaskRun({ id: 46, status: RunStatus.Pending }),
+      makeTaskRun({ id: 47, status: RunStatus.Pending }),
+    ]);
+
+    await expect(
+      controller.testRecoverPersistedWorkerBootstrapRestarts(),
+    ).resolves.toBe(2);
   });
 
   it('keeps the claimed failure durable when finalization side effects fail', async () => {
@@ -643,6 +671,13 @@ describe('BaseController.handleWorkerExitBeforeStart', () => {
         runId: 44,
         phase: 'worker_bootstrap_finalize',
       }),
+    );
+    expect(mockSyncTaskStateFromRuns).toHaveBeenCalledWith(
+      expect.anything(),
+      'task-1',
+    );
+    expect(mockSyncTaskStateFromRuns.mock.invocationCallOrder[0]).toBeLessThan(
+      mockFinishRun.mock.invocationCallOrder[0] ?? Infinity,
     );
   });
 });

--- a/apps/controller/src/__tests__/BaseController.test.ts
+++ b/apps/controller/src/__tests__/BaseController.test.ts
@@ -69,6 +69,7 @@ vi.mock('@roomote/db/server', async () => {
     },
     recordTaskRunLifecycleEvent: (...args: unknown[]) =>
       mockRecordTaskRunLifecycleEvent(...args),
+    resolveDefaultComputeProvider: vi.fn().mockResolvedValue('docker'),
     updatePendingEnvironmentSnapshot: (...args: unknown[]) =>
       mockUpdatePendingEnvironmentSnapshot(...args),
   };
@@ -136,6 +137,17 @@ class TestController extends BaseController {
   public async testDequeueTaskRun(taskRun: TaskRun) {
     return this.dequeueTaskRun(taskRun);
   }
+
+  public async testHandleWorkerExitBeforeStart(
+    taskRun: TaskRun,
+    exitCode: number,
+  ) {
+    return this.handleWorkerExitBeforeStart(taskRun, exitCode);
+  }
+
+  public async testFailTimedOutWorkerBootstrap() {
+    return this.failTimedOutWorkerBootstrap();
+  }
 }
 
 class SaturatedTestController extends TestController {
@@ -176,7 +188,7 @@ function resetControllerMocks() {
   mockRecordTaskRunLifecycleEvent.mockResolvedValue(undefined);
   mockRedisSet.mockResolvedValue('OK');
   mockUpdatePendingEnvironmentSnapshot.mockResolvedValue(true);
-  mockUpdateWhere.mockReturnValue({
+  mockUpdateWhere.mockReset().mockReturnValue({
     returning: vi.fn().mockResolvedValue([{}]),
   });
 }
@@ -480,5 +492,115 @@ describe('BaseController.dequeueTaskRun', () => {
 
     expect(result).toBeNull();
     expect(mockRecordTaskRunLifecycleEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('BaseController.handleWorkerExitBeforeStart', () => {
+  let controller: TestController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetControllerMocks();
+    mockUpdateWhere.mockReturnValue({
+      returning: vi.fn().mockResolvedValue([{ id: 42 }]),
+    });
+    controller = new TestController();
+  });
+
+  it('fails a dequeued run immediately when its worker exits before starting', async () => {
+    const job = makeTaskRun({
+      id: 42,
+      status: RunStatus.Dequeued,
+      startedAt: null,
+      workerHeartbeatAt: null,
+    });
+
+    await expect(
+      controller.testHandleWorkerExitBeforeStart(job, 1),
+    ).resolves.toBe(true);
+
+    expect(mockDbUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: RunStatus.Failed,
+        error: 'Worker process exited before claiming task run (exit code 1)',
+        completedAt: expect.any(Date),
+      }),
+    );
+    expect(mockFinishRun).toHaveBeenCalledWith({
+      id: 42,
+      status: RunStatus.Failed,
+      error: 'Worker process exited before claiming task run (exit code 1)',
+    });
+    expect(mockCaptureControllerMessage).toHaveBeenCalledWith(
+      'Detached worker exited before claiming its task run',
+      expect.objectContaining({
+        runId: 42,
+        exitCode: 1,
+        phase: 'worker_bootstrap',
+      }),
+      expect.objectContaining({ signal: 'worker-bootstrap-exit' }),
+    );
+  });
+
+  it('ignores an exit when the run already advanced', async () => {
+    mockUpdateWhere.mockReturnValueOnce({
+      returning: vi.fn().mockResolvedValue([]),
+    });
+
+    const claimed = await controller.testHandleWorkerExitBeforeStart(
+      makeTaskRun({ id: 42, status: RunStatus.Processing }),
+      0,
+    );
+
+    expect(claimed).toBe(false);
+    expect(mockFinishRun).not.toHaveBeenCalled();
+    expect(mockCaptureControllerMessage).not.toHaveBeenCalled();
+  });
+
+  it('fails a provisioned run when no worker claims it before the watchdog', async () => {
+    mockTaskRunsFindFirst.mockResolvedValueOnce(
+      makeTaskRun({
+        id: 43,
+        status: RunStatus.Dequeued,
+        provisionReadyAt: new Date(Date.now() - 3 * 60_000),
+        startedAt: null,
+        workerHeartbeatAt: null,
+      }),
+    );
+
+    await expect(controller.testFailTimedOutWorkerBootstrap()).resolves.toBe(
+      true,
+    );
+
+    expect(mockFinishRun).toHaveBeenCalledWith({
+      id: 43,
+      status: RunStatus.Failed,
+      error:
+        'Worker did not claim task run within 120 seconds after the environment became ready',
+    });
+    expect(mockCaptureControllerMessage).toHaveBeenCalledWith(
+      'Worker did not claim its task run after provisioning',
+      expect.objectContaining({ runId: 43, phase: 'worker_bootstrap' }),
+      expect.objectContaining({ signal: 'worker-bootstrap-timeout' }),
+    );
+  });
+
+  it('keeps the claimed failure durable when finalization side effects fail', async () => {
+    mockFinishRun.mockRejectedValueOnce(new Error('notification failed'));
+
+    await expect(
+      controller.testHandleWorkerExitBeforeStart(
+        makeTaskRun({ id: 44, status: RunStatus.Dequeued }),
+        1,
+      ),
+    ).resolves.toBe(true);
+
+    expect(mockCaptureControllerException).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'notification failed' }),
+      expect.objectContaining({
+        runId: 44,
+        phase: 'worker_bootstrap_finalize',
+      }),
+    );
   });
 });

--- a/apps/controller/src/__tests__/RoomoteController.test.ts
+++ b/apps/controller/src/__tests__/RoomoteController.test.ts
@@ -491,6 +491,7 @@ describe('RoomoteController', () => {
         modalRegions: 'us,us-west',
         modalVmMemoryMiB: 8192,
         onWorkerExit: expect.any(Function),
+        onWorkerRestart: expect.any(Function),
       }),
     );
   });

--- a/apps/controller/src/__tests__/RoomoteController.test.ts
+++ b/apps/controller/src/__tests__/RoomoteController.test.ts
@@ -78,6 +78,12 @@ vi.mock('@roomote/db/server', async () => {
 
   return {
     ...actual,
+    resolveComputeProviderEnvValues: vi.fn(
+      async (
+        _provider: unknown,
+        options: { runtimeEnv: Record<string, unknown> },
+      ) => options.runtimeEnv,
+    ),
     db: {
       query: {
         ...actual.db.query,
@@ -484,6 +490,7 @@ describe('RoomoteController', () => {
         modalRegistryPassword: 'ghcr-token',
         modalRegions: 'us,us-west',
         modalVmMemoryMiB: 8192,
+        onWorkerExit: expect.any(Function),
       }),
     );
   });

--- a/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
+++ b/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
@@ -363,6 +363,45 @@ describe('spawnModalWorker', () => {
     );
   });
 
+  it('restarts when an immediate detached exit is claimed as the first bootstrap failure', async () => {
+    const onWorkerExit = vi.fn().mockResolvedValue('restart');
+    const onWorkerRestart = vi.fn();
+    mockRunCommand.mockResolvedValue({
+      exitCode: 1,
+      commandId: undefined,
+      stderr: 'worker failed before claim\n',
+    });
+
+    await expect(
+      spawnModalWorker(
+        mockTaskRun({
+          payloadKind: TaskPayloadKind.StandardTask,
+          payload: { repo: 'test/repo', environmentId: 'env_1' },
+        }),
+        'auth_token',
+        {
+          deploymentSlug: 'roomote',
+          modalTokenId: 'token-id',
+          modalTokenSecret: 'token-secret',
+          modalBaseImageRef: 'ghcr.io/roomote/modal-worker:test',
+          modalVmMemoryMiB: 8192,
+          modalTimeoutMs: 60_000,
+          onWorkerExit,
+          onWorkerRestart,
+        },
+      ),
+    ).resolves.toEqual({ machineId: 'modal-machine-123' });
+
+    expect(onWorkerExit).toHaveBeenCalledWith({ exitCode: 1 });
+    expect(mockCleanupModalInstance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instanceId: 'modal-machine-123',
+        phase: 'spawn_worker',
+      }),
+    );
+    expect(onWorkerRestart).toHaveBeenCalledOnce();
+  });
+
   it('cleans up when a later detached exit is claimed as a bootstrap failure', async () => {
     const onWorkerExit = vi.fn().mockResolvedValue('restart');
     const onWorkerRestart = vi.fn();

--- a/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
+++ b/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
@@ -429,9 +429,9 @@ describe('spawnModalWorker', () => {
     const runCommandInput = mockRunCommand.mock.calls[0]?.[0] as {
       onExit?: (event: { exitCode: number }) => Promise<void>;
     };
-    await expect(
-      runCommandInput.onExit?.({ exitCode: 1 }),
-    ).rejects.toThrow('cleanup unavailable');
+    await expect(runCommandInput.onExit?.({ exitCode: 1 })).rejects.toThrow(
+      'cleanup unavailable',
+    );
 
     expect(onWorkerRestart).toHaveBeenCalledOnce();
   });

--- a/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
+++ b/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
@@ -330,6 +330,70 @@ describe('spawnModalWorker', () => {
     );
   });
 
+  it('cleans up when a later detached exit is claimed as a bootstrap failure', async () => {
+    const onWorkerExit = vi.fn().mockResolvedValue(true);
+
+    await spawnModalWorker(
+      mockTaskRun({
+        payloadKind: TaskPayloadKind.StandardTask,
+        payload: { repo: 'test/repo', environmentId: 'env_1' },
+      }),
+      'auth_token',
+      {
+        deploymentSlug: 'roomote',
+        modalTokenId: 'token-id',
+        modalTokenSecret: 'token-secret',
+        modalBaseImageRef: 'ghcr.io/roomote/modal-worker:test',
+        modalVmMemoryMiB: 8192,
+        modalTimeoutMs: 60_000,
+        onWorkerExit,
+      },
+    );
+
+    const runCommandInput = mockRunCommand.mock.calls[0]?.[0] as {
+      onExit?: (event: { exitCode: number }) => Promise<void>;
+    };
+    await runCommandInput.onExit?.({ exitCode: 1 });
+
+    expect(onWorkerExit).toHaveBeenCalledWith({ exitCode: 1 });
+    expect(mockCleanupModalInstance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instanceId: 'modal-machine-123',
+        phase: 'worker_bootstrap_exit',
+        onMutation: expect.any(Function),
+      }),
+    );
+  });
+
+  it('leaves the sandbox alone when a detached exit belongs to an advanced run', async () => {
+    const onWorkerExit = vi.fn().mockResolvedValue(false);
+
+    await spawnModalWorker(
+      mockTaskRun({
+        payloadKind: TaskPayloadKind.StandardTask,
+        payload: { repo: 'test/repo', environmentId: 'env_1' },
+      }),
+      'auth_token',
+      {
+        deploymentSlug: 'roomote',
+        modalTokenId: 'token-id',
+        modalTokenSecret: 'token-secret',
+        modalBaseImageRef: 'ghcr.io/roomote/modal-worker:test',
+        modalVmMemoryMiB: 8192,
+        modalTimeoutMs: 60_000,
+        onWorkerExit,
+      },
+    );
+
+    const runCommandInput = mockRunCommand.mock.calls[0]?.[0] as {
+      onExit?: (event: { exitCode: number }) => Promise<void>;
+    };
+    await runCommandInput.onExit?.({ exitCode: 0 });
+
+    expect(onWorkerExit).toHaveBeenCalledWith({ exitCode: 0 });
+    expect(mockCleanupModalInstance).not.toHaveBeenCalled();
+  });
+
   it('does not resolve or persist a bypass when no exposed surface needs one', async () => {
     mockShouldEnableAuthBypassForTaskRun.mockReturnValue(false);
 

--- a/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
+++ b/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
@@ -331,7 +331,8 @@ describe('spawnModalWorker', () => {
   });
 
   it('cleans up when a later detached exit is claimed as a bootstrap failure', async () => {
-    const onWorkerExit = vi.fn().mockResolvedValue(true);
+    const onWorkerExit = vi.fn().mockResolvedValue('restart');
+    const onWorkerRestart = vi.fn();
 
     await spawnModalWorker(
       mockTaskRun({
@@ -347,6 +348,7 @@ describe('spawnModalWorker', () => {
         modalVmMemoryMiB: 8192,
         modalTimeoutMs: 60_000,
         onWorkerExit,
+        onWorkerRestart,
       },
     );
 
@@ -363,10 +365,11 @@ describe('spawnModalWorker', () => {
         onMutation: expect.any(Function),
       }),
     );
+    expect(onWorkerRestart).toHaveBeenCalledOnce();
   });
 
   it('leaves the sandbox alone when a detached exit belongs to an advanced run', async () => {
-    const onWorkerExit = vi.fn().mockResolvedValue(false);
+    const onWorkerExit = vi.fn().mockResolvedValue('ignore');
 
     await spawnModalWorker(
       mockTaskRun({

--- a/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
+++ b/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
@@ -330,6 +330,39 @@ describe('spawnModalWorker', () => {
     );
   });
 
+  it('cleans up when a detached worker exits with code zero during launch', async () => {
+    mockRunCommand.mockResolvedValue({
+      exitCode: 0,
+      commandId: undefined,
+      stdout: 'worker stopped before claim\n',
+    });
+
+    await expect(
+      spawnModalWorker(
+        mockTaskRun({
+          payloadKind: TaskPayloadKind.StandardTask,
+          payload: { repo: 'test/repo', environmentId: 'env_1' },
+        }),
+        'auth_token',
+        {
+          deploymentSlug: 'roomote',
+          modalTokenId: 'token-id',
+          modalTokenSecret: 'token-secret',
+          modalBaseImageRef: 'ghcr.io/roomote/modal-worker:test',
+          modalVmMemoryMiB: 8192,
+          modalTimeoutMs: 60_000,
+        },
+      ),
+    ).rejects.toThrow('Detached "worker run" exited immediately with code 0');
+
+    expect(mockCleanupModalInstance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instanceId: 'modal-machine-123',
+        phase: 'spawn_worker',
+      }),
+    );
+  });
+
   it('cleans up when a later detached exit is claimed as a bootstrap failure', async () => {
     const onWorkerExit = vi.fn().mockResolvedValue('restart');
     const onWorkerRestart = vi.fn();
@@ -365,6 +398,41 @@ describe('spawnModalWorker', () => {
         onMutation: expect.any(Function),
       }),
     );
+    expect(onWorkerRestart).toHaveBeenCalledOnce();
+  });
+
+  it('restarts after a claimed exit even when sandbox cleanup fails', async () => {
+    const onWorkerExit = vi.fn().mockResolvedValue('restart');
+    const onWorkerRestart = vi.fn();
+    mockCleanupModalInstance.mockRejectedValueOnce(
+      new Error('cleanup unavailable'),
+    );
+
+    await spawnModalWorker(
+      mockTaskRun({
+        payloadKind: TaskPayloadKind.StandardTask,
+        payload: { repo: 'test/repo', environmentId: 'env_1' },
+      }),
+      'auth_token',
+      {
+        deploymentSlug: 'roomote',
+        modalTokenId: 'token-id',
+        modalTokenSecret: 'token-secret',
+        modalBaseImageRef: 'ghcr.io/roomote/modal-worker:test',
+        modalVmMemoryMiB: 8192,
+        modalTimeoutMs: 60_000,
+        onWorkerExit,
+        onWorkerRestart,
+      },
+    );
+
+    const runCommandInput = mockRunCommand.mock.calls[0]?.[0] as {
+      onExit?: (event: { exitCode: number }) => Promise<void>;
+    };
+    await expect(
+      runCommandInput.onExit?.({ exitCode: 1 }),
+    ).rejects.toThrow('cleanup unavailable');
+
     expect(onWorkerRestart).toHaveBeenCalledOnce();
   });
 

--- a/apps/controller/src/compute-providers/spawn-modal-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-modal-worker.ts
@@ -142,10 +142,13 @@ export async function spawnModalWorker(
     deploymentSlug?: string;
     modalTags?: Record<string, string>;
     /**
-     * Returns true when the controller claimed the exit as a pre-start
-     * bootstrap failure and the now-unused sandbox should be destroyed.
+     * Classifies a post-launch exit so the provider can clean up before an
+     * optional fresh launch is scheduled.
      */
-    onWorkerExit?: (event: { exitCode: number }) => Promise<boolean>;
+    onWorkerExit?: (event: {
+      exitCode: number;
+    }) => Promise<'ignore' | 'restart' | 'failed'>;
+    onWorkerRestart?: () => void;
   },
 ): Promise<{
   machineId: string;
@@ -170,6 +173,7 @@ export async function spawnModalWorker(
     deploymentSlug,
     modalTags,
     onWorkerExit,
+    onWorkerRestart,
   } = config;
   const parsedModalRegions = parseModalRegions(modalRegions);
   const environmentId = taskRun.payload.environmentId;
@@ -428,9 +432,9 @@ export async function spawnModalWorker(
       ...(onWorkerExit
         ? {
             onExit: async ({ exitCode }: { exitCode: number }) => {
-              const shouldCleanup = await onWorkerExit({ exitCode });
+              const disposition = await onWorkerExit({ exitCode });
 
-              if (!shouldCleanup) {
+              if (disposition === 'ignore') {
                 return;
               }
 
@@ -445,6 +449,10 @@ export async function spawnModalWorker(
                 onMutation: recordMutation,
                 ...mutationContext,
               });
+
+              if (disposition === 'restart') {
+                onWorkerRestart?.();
+              }
             },
           }
         : {}),

--- a/apps/controller/src/compute-providers/spawn-modal-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-modal-worker.ts
@@ -438,27 +438,35 @@ export async function spawnModalWorker(
                 return;
               }
 
-              await cleanupModalInstance({
-                computeClient,
-                instanceId: machine.machineId,
-                phase: 'worker_bootstrap_exit',
-                error: new Error(
-                  `Detached worker exited before task run #${taskRun.id} started (exit code ${exitCode})`,
-                ),
-                logPrefix: 'spawnModalWorker',
-                onMutation: recordMutation,
-                ...mutationContext,
-              });
-
-              if (disposition === 'restart') {
-                onWorkerRestart?.();
+              try {
+                await cleanupModalInstance({
+                  computeClient,
+                  instanceId: machine.machineId,
+                  phase: 'worker_bootstrap_exit',
+                  error: new Error(
+                    `Detached worker exited before task run #${taskRun.id} started (exit code ${exitCode})`,
+                  ),
+                  logPrefix: 'spawnModalWorker',
+                  onMutation: recordMutation,
+                  ...mutationContext,
+                });
+              } finally {
+                // The restart decision is already durable. Do not strand it if
+                // provider cleanup fails; the new worker can still be launched
+                // and the orphaned sandbox remains covered by orphan recovery.
+                if (disposition === 'restart') {
+                  onWorkerRestart?.();
+                }
               }
             },
           }
         : {}),
     });
 
-    if (result.exitCode !== null && result.exitCode !== 0) {
+    // A detached worker must remain alive long enough to claim the run. Even
+    // exit code 0 during the grace period means no worker owns the task, so
+    // route it through the normal launch-failure cleanup path.
+    if (result.exitCode !== null) {
       throw buildDetachedWorkerExitError(command, result);
     }
 

--- a/apps/controller/src/compute-providers/spawn-modal-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-modal-worker.ts
@@ -349,6 +349,8 @@ export async function spawnModalWorker(
   const command = getWorkerLaunchCommand(taskRun);
   const args = getWorkerLaunchArgs(taskRun, machine.machineId);
 
+  let immediateExitDisposition: 'restart' | 'failed' | undefined;
+
   try {
     await updateTaskRunMachine({
       taskRun,
@@ -463,11 +465,25 @@ export async function spawnModalWorker(
         : {}),
     });
 
-    // A detached worker must remain alive long enough to claim the run. Even
-    // exit code 0 during the grace period means no worker owns the task, so
-    // route it through the normal launch-failure cleanup path.
+    // A detached worker must remain alive long enough to claim the run. Route
+    // grace-period exits through the same classifier as later exits so the
+    // first bootstrap failure gets its one durable replacement.
     if (result.exitCode !== null) {
-      throw buildDetachedWorkerExitError(command, result);
+      const exitError = buildDetachedWorkerExitError(command, result);
+
+      if (onWorkerExit) {
+        const disposition = await onWorkerExit({ exitCode: result.exitCode });
+
+        if (disposition !== 'ignore') {
+          immediateExitDisposition = disposition;
+          throw exitError;
+        }
+
+        // The worker claimed the run before exiting, so its normal lifecycle
+        // owns terminal state and sandbox cleanup from this point onward.
+      } else {
+        throw exitError;
+      }
     }
 
     await recordMutation({
@@ -519,6 +535,34 @@ export async function spawnModalWorker(
         error: error instanceof Error ? error.message : String(error),
       }),
     });
+
+    if (immediateExitDisposition) {
+      try {
+        await cleanupModalInstance({
+          computeClient,
+          instanceId: machine.machineId,
+          phase: 'spawn_worker',
+          error,
+          logPrefix: 'spawnModalWorker',
+          onMutation: recordMutation,
+          ...mutationContext,
+        });
+      } catch (cleanupError) {
+        console.error(
+          `[spawnModalWorker] Cleanup failed after classified bootstrap exit for task run #${taskRun.id}`,
+          cleanupError,
+        );
+      } finally {
+        if (immediateExitDisposition === 'restart') {
+          onWorkerRestart?.();
+        }
+      }
+
+      // The controller already committed either Pending for a retry or Failed
+      // for the exhausted retry budget. Avoid terminally failing it again in
+      // BaseController.handleSpawnTaskRunError.
+      return { machineId: machine.machineId };
+    }
 
     await cleanupModalInstance({
       computeClient,

--- a/apps/controller/src/compute-providers/spawn-modal-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-modal-worker.ts
@@ -141,6 +141,11 @@ export async function spawnModalWorker(
     localTarballPath?: string;
     deploymentSlug?: string;
     modalTags?: Record<string, string>;
+    /**
+     * Returns true when the controller claimed the exit as a pre-start
+     * bootstrap failure and the now-unused sandbox should be destroyed.
+     */
+    onWorkerExit?: (event: { exitCode: number }) => Promise<boolean>;
   },
 ): Promise<{
   machineId: string;
@@ -164,6 +169,7 @@ export async function spawnModalWorker(
     localTarballPath,
     deploymentSlug,
     modalTags,
+    onWorkerExit,
   } = config;
   const parsedModalRegions = parseModalRegions(modalRegions);
   const environmentId = taskRun.payload.environmentId;
@@ -419,6 +425,29 @@ export async function spawnModalWorker(
       }),
       detached: true,
       signal: AbortSignal.timeout(60_000),
+      ...(onWorkerExit
+        ? {
+            onExit: async ({ exitCode }: { exitCode: number }) => {
+              const shouldCleanup = await onWorkerExit({ exitCode });
+
+              if (!shouldCleanup) {
+                return;
+              }
+
+              await cleanupModalInstance({
+                computeClient,
+                instanceId: machine.machineId,
+                phase: 'worker_bootstrap_exit',
+                error: new Error(
+                  `Detached worker exited before task run #${taskRun.id} started (exit code ${exitCode})`,
+                ),
+                logPrefix: 'spawnModalWorker',
+                onMutation: recordMutation,
+                ...mutationContext,
+              });
+            },
+          }
+        : {}),
     });
 
     if (result.exitCode !== null && result.exitCode !== 0) {

--- a/packages/compute-providers/src/adapters/modal.test.ts
+++ b/packages/compute-providers/src/adapters/modal.test.ts
@@ -70,6 +70,7 @@ describe('ModalClient', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     (
       ModalClient as unknown as {
         sandboxCache: { clear: () => void };
@@ -713,6 +714,51 @@ describe('ModalClient', () => {
         },
       }),
     );
+  });
+
+  it('reports a detached-process exit observed after launch', async () => {
+    vi.useFakeTimers();
+    let resolveExit!: (exitCode: number) => void;
+    const waitPromise = new Promise<number>((resolve) => {
+      resolveExit = resolve;
+    });
+    const onExit = vi.fn().mockResolvedValue(undefined);
+    const execMock = vi.fn().mockResolvedValue({
+      stdout: new ReadableStream<string>({ start: () => undefined }),
+      stderr: new ReadableStream<string>({ start: () => undefined }),
+      wait: vi.fn().mockReturnValue(waitPromise),
+    });
+
+    sandboxFromIdMock.mockResolvedValue({
+      sandboxId: 'modal-123',
+      exec: execMock,
+    });
+
+    const client = new ModalClient({
+      tokenId: 'token-id',
+      tokenSecret: 'token-secret',
+      baseImageRef: MODAL_IMAGE_REF,
+    });
+
+    const launchPromise = client.runCommand({
+      instanceId: 'modal-123',
+      cmd: 'worker',
+      args: ['run', '123'],
+      detached: true,
+      onExit,
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(launchPromise).resolves.toEqual({
+      commandId: undefined,
+      exitCode: null,
+    });
+
+    resolveExit(1);
+    await vi.waitFor(() => {
+      expect(onExit).toHaveBeenCalledWith({ exitCode: 1 });
+    });
+    vi.useRealTimers();
   });
 
   it('normalizes Modal exec failures into structured errors', async () => {

--- a/packages/compute-providers/src/adapters/modal.ts
+++ b/packages/compute-providers/src/adapters/modal.ts
@@ -631,6 +631,7 @@ export class ModalClient implements ComputeProviderClient {
         process.stdout,
         process.stderr,
         waitPromise,
+        input.onExit,
       );
 
       return { commandId: undefined, exitCode: null };
@@ -1245,6 +1246,7 @@ function streamInBackground(
   stdout: ReadableStream<string>,
   stderr: ReadableStream<string>,
   waitPromise: Promise<number>,
+  onExit?: (event: { exitCode: number }) => void | Promise<void>,
 ): void {
   const pipeStream = async (
     stream: ReadableStream<string>,
@@ -1287,12 +1289,14 @@ function streamInBackground(
     pipeStream(stdout, 'stdout'),
     pipeStream(stderr, 'stderr'),
     waitPromise
-      .then((exitCode) => {
+      .then(async (exitCode) => {
         console.log(`[${label}] Detached process exited with code ${exitCode}`);
+
+        await onExit?.({ exitCode });
       })
       .catch((error) => {
         const msg = error instanceof Error ? error.message : String(error);
-        console.warn(`[${label}] Detached process wait error: ${msg}`);
+        console.warn(`[${label}] Detached process exit handler error: ${msg}`);
       }),
   ]).catch(() => {
     // Swallow — individual handlers already log.

--- a/packages/compute-providers/src/types.ts
+++ b/packages/compute-providers/src/types.ts
@@ -74,6 +74,12 @@ export interface DestroyInstanceResult {
 
 export type OutputCallback = (event: CommandOutputEvent) => void;
 
+export interface CommandExitEvent {
+  exitCode: number;
+}
+
+export type ExitCallback = (event: CommandExitEvent) => void | Promise<void>;
+
 export interface RunCommandInput {
   instanceId: string;
   cmd: string;
@@ -83,6 +89,8 @@ export interface RunCommandInput {
   detached?: boolean;
   signal?: AbortSignal;
   onOutput?: OutputCallback;
+  /** Called when a detached command exits after launch has been reported. */
+  onExit?: ExitCallback;
 }
 
 export interface RunCommandResult {

--- a/packages/sdk/src/client/index.test.ts
+++ b/packages/sdk/src/client/index.test.ts
@@ -343,11 +343,9 @@ describe('createWorkerFetchWithRetry', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it('gives the dequeue claim a longer default retry budget than other callbacks', async () => {
+  it('bounds the dequeue claim retry budget so the controller can replace a broken sandbox', async () => {
     const fetchMock = vi
       .fn<typeof fetch>()
-      .mockRejectedValueOnce(new TypeError('fetch failed'))
-      .mockRejectedValueOnce(new TypeError('fetch failed'))
       .mockRejectedValueOnce(new TypeError('fetch failed'))
       .mockRejectedValueOnce(new TypeError('fetch failed'))
       .mockRejectedValueOnce(new TypeError('fetch failed'))
@@ -371,7 +369,7 @@ describe('createWorkerFetchWithRetry', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(fetchMock).toHaveBeenCalledTimes(6);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 
   it('retries the resume claim on transport failure', async () => {

--- a/packages/sdk/src/client/index.ts
+++ b/packages/sdk/src/client/index.ts
@@ -84,10 +84,11 @@ export interface WorkerQueryRetryOptions {
 // freshly (re)started proxy can briefly answer 5xx or without a JSON
 // content-type before its upstreams settle. Claiming is idempotent server-side
 // (FOR UPDATE SKIP LOCKED returns nothing on a second attempt), so these paths
-// get a longer budget (~31s of backoff) instead of failing the whole job on
-// one bad response.
+// get a bounded startup budget (~7s of backoff). If the claim still cannot
+// reach the API, the worker exits and the controller can replace the sandbox
+// once instead of keeping a broken network path alive for another ~24s.
 const WORKER_STARTUP_MUTATION_RETRY_OPTIONS: WorkerQueryRetryOptions = {
-  maxAttempts: 6,
+  maxAttempts: 4,
   baseDelayMs: 1_000,
 };
 

--- a/packages/types/src/sandbox-spawn.ts
+++ b/packages/types/src/sandbox-spawn.ts
@@ -27,6 +27,11 @@ export const SANDBOX_SPAWN_RETRY_DELAY_MS = 5_000;
 
 export const SANDBOX_ORPHAN_SCAN_INTERVAL_MS = 30_000;
 
+// Once infrastructure is ready, a healthy worker should claim its run within
+// seconds. Keep this separate from the full spawn envelope so a dead worker
+// does not leave the UI in "booting environment" until orphan recovery.
+export const WORKER_BOOTSTRAP_CLAIM_TIMEOUT_MS = 2 * MINUTE;
+
 function getExponentialBackoffTotalMs(
   retryCount: number,
   initialDelayMs: number,


### PR DESCRIPTION
## What changed

- propagate post-launch detached worker exits from compute providers into the controller
- bound worker claim retries to four attempts (about seven seconds of backoff)
- clean up the failed sandbox and launch one fresh replacement before terminally failing
- persist the single-restart budget as a lifecycle event so controller restarts cannot reset it
- fail runs that remain unclaimed after their environment is ready instead of waiting for the full orphan-recovery window
- add a two-minute provider-neutral bootstrap watchdog
- atomically guard the failure transition so a late exit cannot overwrite a run that already started
- clean up Modal sandboxes when a detached exit is claimed as a bootstrap failure
- process every overdue bootstrap in each watchdog scan
- commit terminal run state and the owning task projection in one transaction
- recover persisted bootstrap restarts immediately after a controller restart
- treat every grace-period detached exit, including exit code zero, as a launch failure with cleanup

## Why

Detached worker processes could exit after the provider launch call had already returned successfully. The exit was visible in controller logs, but it was not connected to task lifecycle state, leaving affected runs presented as booting until orphan recovery.

## Impact

Transient startup connectivity gets one fresh network path without allowing an unbounded restart loop. A replacement that also fails becomes visible promptly, and the existing long orphan-recovery timeout remains as a final safety net for broader provisioning failures.

## Validation

- `pnpm --filter @roomote/compute-providers check-types`
- `pnpm --filter @roomote/controller check-types`
- `pnpm --filter @roomote/types check-types`
- `pnpm --filter @roomote/sdk check-types`
- `pnpm --filter @roomote/compute-providers lint`
- `pnpm --filter @roomote/controller lint`
- ESLint on the modified SDK client files
- focused Vitest suites for the SDK retry client, Modal adapter, Modal spawn path, base controller, provider dispatch, and sandbox timeout constants (97 tests)
