### PR TITLE
Add native theming for presentational widgets

### DIFF
--- a/.changeset/native-widget-themes.md
+++ b/.changeset/native-widget-themes.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': minor
+---
+
+Make presentational widgets follow the selected Roomote theme and provide native layout classes and CSS variables for agent-generated UI.

--- a/apps/docs/tasks.mdx
+++ b/apps/docs/tasks.mdx
@@ -44,6 +44,20 @@ detail to review the work. Presentational widgets remain available in the task
 transcript; when an agent provides a text fallback, Roomote also sends that
 fallback to the originating Slack, Teams, Telegram, or Discord conversation.
 
+### Native widget styling
+
+Roomote widgets inherit the task view's selected light or dark theme. Agents can
+use the built-in `rw-card`, `rw-stack`, `rw-row`, `rw-grid`, `rw-stat`,
+`rw-badge`, `rw-callout`, and `rw-muted` classes for common layouts without
+supplying custom CSS.
+
+When a widget needs a custom layout, its CSS can use Roomote's `--rw-*` theme
+variables. The main variables are `--rw-background`, `--rw-surface`,
+`--rw-surface-muted`, `--rw-text`, `--rw-text-muted`, `--rw-border`,
+`--rw-primary`, `--rw-accent`, `--rw-success`, `--rw-warning`, and
+`--rw-danger`. This keeps the result visually consistent with Roomote and lets
+the same widget adapt when the viewer changes themes.
+
 ## Review the evidence
 
 Roomote is most useful when it can show its work. For implementation tasks,

--- a/apps/docs/tasks.mdx
+++ b/apps/docs/tasks.mdx
@@ -58,6 +58,10 @@ variables. The main variables are `--rw-background`, `--rw-surface`,
 `--rw-danger`. This keeps the result visually consistent with Roomote and lets
 the same widget adapt when the viewer changes themes.
 
+Widgets work best as compact visual summaries. Agents should keep labels and
+datasets concise, choose a height that fits the expected content without
+scrolling, and use normal task narration or an artifact for longer material.
+
 ## Review the evidence
 
 Roomote is most useful when it can show its work. For implementation tasks,

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/ShowWidgetPreview.stories.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/ShowWidgetPreview.stories.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { ShowWidgetPreview } from './ShowWidgetPreview';
+import type { ShowWidgetPayload } from './show-widget-tool-result';
+
+const meta: Meta<typeof ShowWidgetPreview> = {
+  title: 'Surfaces/Task Workspace/ACP/ShowWidgetPreview',
+  component: ShowWidgetPreview,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="mx-auto w-full max-w-3xl text-foreground">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const nativeWidget: ShowWidgetPayload = {
+  title: 'Release readiness',
+  height: 410,
+  textFallback: 'Release readiness: 18 checks passed; staging is ready.',
+  css: null,
+  html: `
+    <div class="rw-stack">
+      <div class="rw-row">
+        <span class="rw-badge rw-badge--success">Ready</span>
+        <span class="rw-muted">Updated just now</span>
+      </div>
+      <div>
+        <div class="rw-kicker">Deployment overview</div>
+        <h2>Staging is ready to review</h2>
+        <p class="rw-muted">All required checks passed and the preview is healthy.</p>
+      </div>
+      <div class="rw-grid">
+        <div class="rw-stat">
+          <span class="rw-stat__label">Checks</span>
+          <span class="rw-stat__value">18 / 18</span>
+        </div>
+        <div class="rw-stat">
+          <span class="rw-stat__label">Response time</span>
+          <span class="rw-stat__value">124 ms</span>
+        </div>
+        <div class="rw-stat">
+          <span class="rw-stat__label">Revision</span>
+          <span class="rw-stat__value"><code>7d9c4f1</code></span>
+        </div>
+      </div>
+      <div class="rw-callout rw-callout--success">
+        The deployment matches the expected configuration.
+      </div>
+    </div>
+  `,
+};
+
+export const RoomotePrimitives: Story = {
+  args: {
+    widget: nativeWidget,
+  },
+};
+
+export const CustomLayoutUsingTokens: Story = {
+  args: {
+    widget: {
+      title: 'Queue health',
+      height: 350,
+      textFallback: 'Queue health is stable at 72% throughput.',
+      html: `
+        <div class="meter-card">
+          <div class="rw-row heading">
+            <div>
+              <div class="rw-kicker">Live capacity</div>
+              <h2>Queue health</h2>
+            </div>
+            <span class="rw-badge rw-badge--accent">Stable</span>
+          </div>
+          <div class="meter"><span></span></div>
+          <div class="rw-row legend">
+            <strong>72%</strong>
+            <span class="rw-muted">36 of 50 workers active</span>
+          </div>
+        </div>
+      `,
+      css: `
+        .meter-card {
+          background: var(--rw-surface);
+          border: 1px solid var(--rw-border);
+          border-radius: var(--rw-radius-lg);
+          padding: var(--rw-space-6);
+        }
+        .heading { justify-content: space-between; }
+        .heading h2 { margin-top: var(--rw-space-1); }
+        .meter {
+          height: 16px;
+          margin: var(--rw-space-6) 0 var(--rw-space-3);
+          overflow: hidden;
+          border-radius: 999px;
+          background: var(--rw-surface-muted);
+        }
+        .meter span {
+          display: block;
+          width: 72%;
+          height: 100%;
+          border-radius: inherit;
+          background: var(--rw-accent);
+        }
+        .legend { justify-content: space-between; }
+        .legend strong { color: var(--rw-accent); font-size: 1.5rem; }
+      `,
+    },
+  },
+};
+
+export const SemanticHtmlDefaults: Story = {
+  args: {
+    widget: {
+      title: 'Plan comparison',
+      height: 360,
+      textFallback: 'Option B is recommended.',
+      css: null,
+      html: `
+        <h2>Plan comparison</h2>
+        <p>Both options satisfy the requirement, with different tradeoffs.</p>
+        <table>
+          <thead><tr><th>Option</th><th>Effort</th><th>Risk</th></tr></thead>
+          <tbody>
+            <tr><td>Incremental</td><td>2 days</td><td>Low</td></tr>
+            <tr><td>Replacement</td><td>5 days</td><td>Medium</td></tr>
+          </tbody>
+        </table>
+        <blockquote>Recommendation: start incrementally and validate usage.</blockquote>
+      `,
+    },
+  },
+};

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/ShowWidgetPreview.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/ShowWidgetPreview.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import {
   buildShowWidgetSrcDoc,
+  readShowWidgetHostTheme,
+  type ShowWidgetHostTheme,
   type ShowWidgetPayload,
 } from './show-widget-tool-result';
 
@@ -17,17 +19,50 @@ interface ShowWidgetPreviewProps {
  * forms, top-navigation, or same-origin access).
  */
 export function ShowWidgetPreview({ widget }: ShowWidgetPreviewProps) {
-  const srcDoc = useMemo(() => buildShowWidgetSrcDoc(widget), [widget]);
+  const hostRef = useRef<HTMLDivElement>(null);
+  const [hostTheme, setHostTheme] = useState<ShowWidgetHostTheme | null>(null);
+  const srcDoc = useMemo(
+    () => buildShowWidgetSrcDoc(widget, hostTheme ?? undefined),
+    [hostTheme, widget],
+  );
   const label = widget.title?.trim() || 'Widget';
 
+  useLayoutEffect(() => {
+    const host = hostRef.current;
+    if (!host) {
+      return;
+    }
+
+    const syncTheme = () => setHostTheme(readShowWidgetHostTheme(host));
+    const observer = new MutationObserver(syncTheme);
+
+    syncTheme();
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'style'],
+    });
+    if (document.body !== document.documentElement) {
+      observer.observe(document.body, {
+        attributes: true,
+        attributeFilter: ['class', 'style'],
+      });
+    }
+
+    return () => observer.disconnect();
+  }, []);
+
   return (
-    <div className="mt-2 overflow-hidden rounded-lg border border-border bg-card">
+    <div
+      ref={hostRef}
+      className="mt-2 overflow-hidden rounded-lg border border-border bg-card"
+    >
       {widget.title ? (
         <div className="border-b border-border px-3 py-1.5 text-xs font-medium text-muted-foreground">
           {widget.title}
         </div>
       ) : null}
       <iframe
+        key={hostTheme?.colorScheme ?? 'initial'}
         title={label}
         srcDoc={srcDoc}
         sandbox=""

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/ShowWidgetPreview.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/ShowWidgetPreview.tsx
@@ -1,13 +1,12 @@
 'use client';
 
-import { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useMemo } from 'react';
 
 import {
   buildShowWidgetSrcDoc,
-  readShowWidgetHostTheme,
-  type ShowWidgetHostTheme,
   type ShowWidgetPayload,
 } from './show-widget-tool-result';
+import { useShowWidgetHostTheme } from './use-show-widget-host-theme';
 
 interface ShowWidgetPreviewProps {
   widget: ShowWidgetPayload;
@@ -19,37 +18,12 @@ interface ShowWidgetPreviewProps {
  * forms, top-navigation, or same-origin access).
  */
 export function ShowWidgetPreview({ widget }: ShowWidgetPreviewProps) {
-  const hostRef = useRef<HTMLDivElement>(null);
-  const [hostTheme, setHostTheme] = useState<ShowWidgetHostTheme | null>(null);
+  const { hostRef, hostTheme, hostThemeKey } = useShowWidgetHostTheme();
   const srcDoc = useMemo(
     () => buildShowWidgetSrcDoc(widget, hostTheme ?? undefined),
     [hostTheme, widget],
   );
   const label = widget.title?.trim() || 'Widget';
-
-  useLayoutEffect(() => {
-    const host = hostRef.current;
-    if (!host) {
-      return;
-    }
-
-    const syncTheme = () => setHostTheme(readShowWidgetHostTheme(host));
-    const observer = new MutationObserver(syncTheme);
-
-    syncTheme();
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ['class', 'style'],
-    });
-    if (document.body !== document.documentElement) {
-      observer.observe(document.body, {
-        attributes: true,
-        attributeFilter: ['class', 'style'],
-      });
-    }
-
-    return () => observer.disconnect();
-  }, []);
 
   return (
     <div
@@ -62,7 +36,7 @@ export function ShowWidgetPreview({ widget }: ShowWidgetPreviewProps) {
         </div>
       ) : null}
       <iframe
-        key={hostTheme?.colorScheme ?? 'initial'}
+        key={hostThemeKey}
         title={label}
         srcDoc={srcDoc}
         sandbox=""

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/AcpToolMessage.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/AcpToolMessage.client.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import type { ReactNode } from 'react';
 
 import { Bot, Eye, Search, SquarePen, Wrench } from '@/components/system';
@@ -446,9 +452,7 @@ describe('AcpToolMessage', () => {
     expect(frame.tagName).toBe('IFRAME');
     expect(frame).toHaveAttribute('sandbox', '');
     expect(frame.getAttribute('srcdoc') ?? '').toContain('<p>Ready</p>');
-    expect(frame.getAttribute('srcdoc') ?? '').toContain(
-      'color-scheme: light dark',
-    );
+    expect(frame.getAttribute('srcdoc') ?? '').toContain('color-scheme: light');
   });
 
   it('opens the artifact viewer when session path is known', () => {
@@ -548,6 +552,53 @@ describe('AcpToolMessage', () => {
       'tmp/capture-visual-proof/proof.png',
       1,
     );
+  });
+
+  it('remounts show_widget when the selected Roomote theme changes', async () => {
+    render(
+      <AcpToolMessage
+        msg={buildResultMessage('mcp', {
+          title: 'show_widget',
+          isMcp: true,
+          mcpServerName: 'roomote',
+          mcpToolName: 'show_widget',
+          serverName: 'roomote',
+          toolName: 'show_widget',
+          output: JSON.stringify({
+            success: true,
+            shown: true,
+            title: 'Theme preview',
+            html: '<div class="rw-card">Ready</div>',
+            css: null,
+            height: 240,
+            textFallback: 'Ready',
+          }),
+        })}
+      />,
+    );
+
+    const lightFrame = screen.getByTitle('Theme preview');
+    expect(lightFrame.getAttribute('srcdoc') ?? '').toContain(
+      'data-theme="light"',
+    );
+
+    await act(async () => {
+      document.body.classList.add('dark');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    await waitFor(() => {
+      const darkFrame = screen.getByTitle('Theme preview');
+      expect(darkFrame).not.toBe(lightFrame);
+      expect(darkFrame.getAttribute('srcdoc') ?? '').toContain(
+        'data-theme="dark"',
+      );
+    });
+
+    await act(async () => {
+      document.body.classList.remove('dark');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
   });
 
   it('keeps subagent results without session artifacts as plain rows', () => {

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/show-widget-theme.client.test.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/show-widget-theme.client.test.ts
@@ -1,0 +1,44 @@
+import {
+  getShowWidgetHostThemeKey,
+  readShowWidgetHostTheme,
+} from '../show-widget-theme';
+
+describe('show widget host theme', () => {
+  it('copies Roomote host tokens and its selected color scheme', () => {
+    const host = document.createElement('div');
+    host.className = 'dark';
+    host.style.setProperty('--background', '#101010');
+    host.style.setProperty('--card', '#080808');
+    host.style.setProperty('--foreground', '#fefefe');
+    host.style.setProperty('--accent-foreground', '#d8fb2b');
+    document.body.append(host);
+
+    const theme = readShowWidgetHostTheme(host);
+
+    expect(theme).toMatchObject({
+      colorScheme: 'dark',
+      background: '#101010',
+      surface: '#080808',
+      text: '#fefefe',
+      accent: '#d8fb2b',
+    });
+
+    host.remove();
+  });
+
+  it('changes the iframe identity when any resolved token changes', () => {
+    const host = document.createElement('div');
+    host.style.setProperty('--card', '#ffffff');
+    document.body.append(host);
+
+    const firstTheme = readShowWidgetHostTheme(host);
+    host.style.setProperty('--card', '#f5f5f5');
+    const secondTheme = readShowWidgetHostTheme(host);
+
+    expect(getShowWidgetHostThemeKey(firstTheme)).not.toBe(
+      getShowWidgetHostThemeKey(secondTheme),
+    );
+
+    host.remove();
+  });
+});

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/show-widget-tool-result.client.test.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/show-widget-tool-result.client.test.ts
@@ -1,10 +1,9 @@
 import {
   buildShowWidgetSrcDoc,
-  readShowWidgetHostTheme,
   resolveShowWidgetForToolMessage,
   SHOW_WIDGET_TOOL_NAME,
-  type ShowWidgetHostTheme,
 } from '../show-widget-tool-result';
+import type { ShowWidgetHostTheme } from '../show-widget-theme';
 import type { AcpToolCallUiMessage, AcpToolResultUiMessage } from '../types';
 
 function buildResult(
@@ -256,29 +255,5 @@ describe('buildShowWidgetSrcDoc', () => {
     expect(doc).not.toContain('</style><script>');
     expect(doc).not.toContain('<script>');
     expect(doc).toContain('p{color:red}');
-  });
-});
-
-describe('readShowWidgetHostTheme', () => {
-  it('copies Roomote host tokens and its selected color scheme', () => {
-    const host = document.createElement('div');
-    host.className = 'dark';
-    host.style.setProperty('--background', '#101010');
-    host.style.setProperty('--card', '#080808');
-    host.style.setProperty('--foreground', '#fefefe');
-    host.style.setProperty('--accent-foreground', '#d8fb2b');
-    document.body.append(host);
-
-    const theme = readShowWidgetHostTheme(host);
-
-    expect(theme).toMatchObject({
-      colorScheme: 'dark',
-      background: '#101010',
-      surface: '#080808',
-      text: '#fefefe',
-      accent: '#d8fb2b',
-    });
-
-    host.remove();
   });
 });

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/show-widget-tool-result.client.test.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/show-widget-tool-result.client.test.ts
@@ -1,7 +1,9 @@
 import {
   buildShowWidgetSrcDoc,
+  readShowWidgetHostTheme,
   resolveShowWidgetForToolMessage,
   SHOW_WIDGET_TOOL_NAME,
+  type ShowWidgetHostTheme,
 } from '../show-widget-tool-result';
 import type { AcpToolCallUiMessage, AcpToolResultUiMessage } from '../types';
 
@@ -180,7 +182,50 @@ describe('buildShowWidgetSrcDoc', () => {
     expect(doc).toContain("default-src 'none'");
     expect(doc).toContain('p{font-weight:700}');
     expect(doc).toContain('<p>Hello</p>');
-    expect(doc).toContain('color-scheme: light dark');
+    expect(doc).toContain('color-scheme: light');
+    expect(doc).toContain('--rw-surface: #fafaf9');
+    expect(doc).toContain('.rw-card');
+    expect(doc).toContain('data-theme="light"');
+  });
+
+  it('injects the resolved host theme before custom widget CSS', () => {
+    const darkTheme: ShowWidgetHostTheme = {
+      colorScheme: 'dark',
+      background: 'oklch(0.2 0 0)',
+      surface: 'oklch(0.1 0 0)',
+      surfaceMuted: 'oklch(0.3 0 0)',
+      text: 'white',
+      textMuted: 'lightgray',
+      border: 'gray',
+      primary: 'lime',
+      primaryForeground: 'black',
+      accent: 'chartreuse',
+      success: 'teal',
+      warning: 'orange',
+      danger: 'red',
+      codeBackground: '#222',
+      radius: '8px',
+      fontSans: 'Test Sans, sans-serif',
+      fontMono: 'Test Mono, monospace',
+    };
+    const doc = buildShowWidgetSrcDoc(
+      {
+        title: 'Themed card',
+        html: '<div class="rw-card">Ready</div>',
+        css: '.rw-card { outline-color: var(--rw-accent); }',
+        height: 240,
+        textFallback: null,
+      },
+      darkTheme,
+    );
+
+    expect(doc).toContain('data-theme="dark"');
+    expect(doc).toContain('color-scheme: dark');
+    expect(doc).toContain('--rw-background: oklch(0.2 0 0)');
+    expect(doc).toContain('--rw-primary: lime');
+    expect(doc.indexOf('--rw-primary: lime')).toBeLessThan(
+      doc.indexOf('outline-color: var(--rw-accent)'),
+    );
   });
 
   it('always wraps fragments under a controlled head so remote shells cannot re-enter', () => {
@@ -195,7 +240,7 @@ describe('buildShowWidgetSrcDoc', () => {
     expect(doc).toContain("default-src 'none'");
     expect(doc).toContain('<b>x</b>');
     expect(doc).toMatch(
-      /^<!DOCTYPE html><html><head><meta charset="utf-8">[\s\S]*<\/head><body>/,
+      /^<!DOCTYPE html><html data-theme="light"><head><meta charset="utf-8">[\s\S]*<\/head><body>/,
     );
   });
 
@@ -211,5 +256,29 @@ describe('buildShowWidgetSrcDoc', () => {
     expect(doc).not.toContain('</style><script>');
     expect(doc).not.toContain('<script>');
     expect(doc).toContain('p{color:red}');
+  });
+});
+
+describe('readShowWidgetHostTheme', () => {
+  it('copies Roomote host tokens and its selected color scheme', () => {
+    const host = document.createElement('div');
+    host.className = 'dark';
+    host.style.setProperty('--background', '#101010');
+    host.style.setProperty('--card', '#080808');
+    host.style.setProperty('--foreground', '#fefefe');
+    host.style.setProperty('--accent-foreground', '#d8fb2b');
+    document.body.append(host);
+
+    const theme = readShowWidgetHostTheme(host);
+
+    expect(theme).toMatchObject({
+      colorScheme: 'dark',
+      background: '#101010',
+      surface: '#080808',
+      text: '#fefefe',
+      accent: '#d8fb2b',
+    });
+
+    host.remove();
   });
 });

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/show-widget-styles.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/show-widget-styles.ts
@@ -1,0 +1,179 @@
+/**
+ * Versioned presentation vocabulary for sandboxed Roomote widgets. These
+ * styles are serialized into srcDoc because the iframe cannot inherit CSS from
+ * the task view. Keep public selectors and --rw-* variables backward compatible.
+ */
+export const SHOW_WIDGET_DEFAULT_CSS = `
+:root {
+  --rw-background: #ffffff;
+  --rw-surface: #fafaf9;
+  --rw-surface-muted: #f5f5f4;
+  --rw-text: #1c1917;
+  --rw-text-muted: #57534e;
+  --rw-border: #e7e5e4;
+  --rw-primary: #1c1917;
+  --rw-primary-foreground: #ffffff;
+  --rw-accent: #0f766e;
+  --rw-success: #0f766e;
+  --rw-warning: #b45309;
+  --rw-danger: #dc2626;
+  --rw-code-background: #f5f5f4;
+  --rw-radius-sm: 0.2rem;
+  --rw-radius-md: 0.3rem;
+  --rw-radius-lg: 0.55rem;
+  --rw-font-sans: ui-sans-serif, system-ui, sans-serif;
+  --rw-font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+  --rw-space-1: 0.25rem;
+  --rw-space-2: 0.5rem;
+  --rw-space-3: 0.75rem;
+  --rw-space-4: 1rem;
+  --rw-space-6: 1.5rem;
+
+  /* Backward-compatible aliases for widgets created before the theme API. */
+  --rw-fg: var(--rw-text);
+  --rw-muted: var(--rw-text-muted);
+  --rw-bg: var(--rw-background);
+  --rw-card: var(--rw-surface);
+  --rw-code-bg: var(--rw-code-background);
+}
+*, *::before, *::after { box-sizing: border-box; }
+html, body {
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--rw-text);
+  font: 14px/1.5 var(--rw-font-sans);
+}
+body {
+  padding: var(--rw-space-4);
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+}
+h1, h2, h3, h4, h5, h6 {
+  margin: 0 0 0.6em;
+  line-height: 1.25;
+  font-weight: 600;
+}
+h1 { font-size: 1.35rem; }
+h2 { font-size: 1.2rem; }
+h3 { font-size: 1.05rem; }
+p, ul, ol, pre, table, blockquote {
+  margin: 0 0 0.75em;
+}
+ul, ol { padding-left: 1.25em; }
+a { color: var(--rw-accent); }
+hr { border: 0; border-top: 1px solid var(--rw-border); margin: var(--rw-space-4) 0; }
+code, kbd, samp {
+  font-family: var(--rw-font-mono);
+  font-size: 0.9em;
+  background: var(--rw-code-background);
+  border-radius: var(--rw-radius-sm);
+  padding: 0.1em 0.35em;
+}
+pre {
+  background: var(--rw-code-background);
+  border: 1px solid var(--rw-border);
+  border-radius: var(--rw-radius-lg);
+  padding: 10px 12px;
+  overflow: auto;
+}
+pre code {
+  background: transparent;
+  padding: 0;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95em;
+}
+th, td {
+  border-bottom: 1px solid var(--rw-border);
+  padding: var(--rw-space-2) var(--rw-space-3);
+  text-align: left;
+  vertical-align: top;
+}
+th { color: var(--rw-text-muted); font-size: 0.85em; font-weight: 600; }
+blockquote {
+  border-left: 3px solid var(--rw-border);
+  margin-left: 0;
+  padding: 0.2em 0 0.2em 0.9em;
+  color: var(--rw-muted);
+}
+img, svg, video {
+  max-width: 100%;
+  height: auto;
+}
+.rw-stack { display: flex; flex-direction: column; gap: var(--rw-space-3); }
+.rw-row, .row {
+  display: flex;
+  gap: var(--rw-space-2);
+  flex-wrap: wrap;
+  align-items: center;
+}
+.rw-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(180px, 100%), 1fr));
+  gap: var(--rw-space-3);
+}
+.rw-card, .card, .panel {
+  background: var(--rw-surface);
+  border: 1px solid var(--rw-border);
+  border-radius: var(--rw-radius-lg);
+  padding: var(--rw-space-4);
+}
+.rw-muted, .muted { color: var(--rw-text-muted); }
+.rw-kicker {
+  color: var(--rw-text-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.rw-badge, .badge {
+  display: inline-block;
+  border: 1px solid var(--rw-border);
+  border-radius: 999px;
+  padding: 0.1em 0.55em;
+  font-size: 0.85em;
+  color: var(--rw-text-muted);
+  background: var(--rw-surface-muted);
+}
+.rw-badge--accent { color: var(--rw-accent); border-color: var(--rw-accent); }
+.rw-badge--success { color: var(--rw-success); border-color: var(--rw-success); }
+.rw-badge--warning { color: var(--rw-warning); border-color: var(--rw-warning); }
+.rw-badge--danger { color: var(--rw-danger); border-color: var(--rw-danger); }
+.rw-stat {
+  display: flex;
+  min-height: 88px;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: var(--rw-space-2);
+  background: var(--rw-surface);
+  border: 1px solid var(--rw-border);
+  border-radius: var(--rw-radius-lg);
+  padding: var(--rw-space-4);
+}
+.rw-stat__label { color: var(--rw-text-muted); font-size: 0.85em; }
+.rw-stat__value { font-size: 1.5rem; font-weight: 650; line-height: 1.1; }
+.rw-callout {
+  border-left: 3px solid var(--rw-accent);
+  background: var(--rw-surface-muted);
+  border-radius: var(--rw-radius-md);
+  padding: var(--rw-space-3) var(--rw-space-4);
+}
+.rw-callout--success { border-left-color: var(--rw-success); }
+.rw-callout--warning { border-left-color: var(--rw-warning); }
+.rw-callout--danger { border-left-color: var(--rw-danger); }
+.rw-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+  border: 1px solid var(--rw-primary);
+  border-radius: var(--rw-radius-md);
+  padding: var(--rw-space-2) var(--rw-space-3);
+  color: var(--rw-primary-foreground);
+  background: var(--rw-primary);
+  font: 600 0.9rem/1 var(--rw-font-sans);
+}
+`.trim();

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/show-widget-styles.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/show-widget-styles.ts
@@ -36,7 +36,7 @@ export const SHOW_WIDGET_DEFAULT_CSS = `
   --rw-card: var(--rw-surface);
   --rw-code-bg: var(--rw-code-background);
 }
-*, *::before, *::after { box-sizing: border-box; }
+*, *::before, *::after { box-sizing: border-box; min-width: 0; }
 html, body {
   margin: 0;
   padding: 0;
@@ -46,6 +46,7 @@ html, body {
 }
 body {
   padding: var(--rw-space-4);
+  overflow-x: hidden;
   word-wrap: break-word;
   overflow-wrap: anywhere;
 }
@@ -75,7 +76,9 @@ pre {
   border: 1px solid var(--rw-border);
   border-radius: var(--rw-radius-lg);
   padding: 10px 12px;
-  overflow: auto;
+  overflow: hidden;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 pre code {
   background: transparent;
@@ -84,6 +87,7 @@ pre code {
 table {
   width: 100%;
   border-collapse: collapse;
+  table-layout: fixed;
   font-size: 0.95em;
 }
 th, td {
@@ -91,6 +95,7 @@ th, td {
   padding: var(--rw-space-2) var(--rw-space-3);
   text-align: left;
   vertical-align: top;
+  overflow-wrap: anywhere;
 }
 th { color: var(--rw-text-muted); font-size: 0.85em; font-weight: 600; }
 blockquote {

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/show-widget-theme.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/show-widget-theme.ts
@@ -1,0 +1,150 @@
+export type ShowWidgetHostTheme = {
+  colorScheme: 'light' | 'dark';
+  background: string;
+  surface: string;
+  surfaceMuted: string;
+  text: string;
+  textMuted: string;
+  border: string;
+  primary: string;
+  primaryForeground: string;
+  accent: string;
+  success: string;
+  warning: string;
+  danger: string;
+  codeBackground: string;
+  radius: string;
+  fontSans: string;
+  fontMono: string;
+};
+
+export const DEFAULT_SHOW_WIDGET_HOST_THEME: ShowWidgetHostTheme = {
+  colorScheme: 'light',
+  background: '#ffffff',
+  surface: '#fafaf9',
+  surfaceMuted: '#f5f5f4',
+  text: '#1c1917',
+  textMuted: '#57534e',
+  border: '#e7e5e4',
+  primary: '#1c1917',
+  primaryForeground: '#ffffff',
+  accent: '#0f766e',
+  success: '#0f766e',
+  warning: '#b45309',
+  danger: '#dc2626',
+  codeBackground: '#f5f5f4',
+  radius: '0.3rem',
+  fontSans:
+    'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  fontMono: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+};
+
+const DARK_SHOW_WIDGET_HOST_THEME: ShowWidgetHostTheme = {
+  colorScheme: 'dark',
+  background: '#1c1c1b',
+  surface: '#000000',
+  surfaceMuted: '#292929',
+  text: '#ffffff',
+  textMuted: '#a3a3a3',
+  border: '#737373',
+  primary: '#d8fb2b',
+  primaryForeground: '#000000',
+  accent: '#d8fb2b',
+  success: '#2bd1b6',
+  warning: '#ecb63a',
+  danger: '#de3d3d',
+  codeBackground: '#292929',
+  radius: '0.3rem',
+  fontSans: DEFAULT_SHOW_WIDGET_HOST_THEME.fontSans,
+  fontMono: DEFAULT_SHOW_WIDGET_HOST_THEME.fontMono,
+};
+
+function readHostValue(
+  styles: CSSStyleDeclaration,
+  property: string,
+  fallback: string,
+): string {
+  return styles.getPropertyValue(property).trim() || fallback;
+}
+
+/**
+ * Resolve Roomote's computed tokens at the element that hosts the iframe. CSS
+ * custom properties do not cross iframe boundaries, so the resolved values
+ * become the explicit theme contract for the generated document.
+ */
+export function readShowWidgetHostTheme(element: Element): ShowWidgetHostTheme {
+  const styles = getComputedStyle(element);
+  const documentElement = element.ownerDocument.documentElement;
+  const body = element.ownerDocument.body;
+  const colorScheme =
+    styles.colorScheme === 'dark' ||
+    element.closest('.dark') !== null ||
+    documentElement.classList.contains('dark') ||
+    body?.classList.contains('dark')
+      ? 'dark'
+      : 'light';
+  const fallback =
+    colorScheme === 'dark'
+      ? DARK_SHOW_WIDGET_HOST_THEME
+      : DEFAULT_SHOW_WIDGET_HOST_THEME;
+
+  return {
+    colorScheme,
+    background: readHostValue(styles, '--background', fallback.background),
+    surface: readHostValue(styles, '--card', fallback.surface),
+    surfaceMuted: readHostValue(styles, '--muted', fallback.surfaceMuted),
+    text: readHostValue(styles, '--foreground', fallback.text),
+    textMuted: readHostValue(styles, '--muted-foreground', fallback.textMuted),
+    border: readHostValue(styles, '--border', fallback.border),
+    primary: readHostValue(styles, '--primary', fallback.primary),
+    primaryForeground: readHostValue(
+      styles,
+      '--primary-foreground',
+      fallback.primaryForeground,
+    ),
+    accent: readHostValue(styles, '--accent-foreground', fallback.accent),
+    success: readHostValue(styles, '--chart-2', fallback.success),
+    warning: readHostValue(styles, '--warning', fallback.warning),
+    danger: readHostValue(styles, '--destructive', fallback.danger),
+    codeBackground: readHostValue(styles, '--muted', fallback.codeBackground),
+    radius: readHostValue(styles, '--radius', fallback.radius),
+    fontSans: readHostValue(styles, '--font-sans', fallback.fontSans),
+    fontMono: readHostValue(styles, '--font-mono', fallback.fontMono),
+  };
+}
+
+function sanitizeCssValue(value: string): string {
+  return value.replace(/[<>{};]/g, '').trim();
+}
+
+export function buildShowWidgetHostThemeCss(
+  theme: ShowWidgetHostTheme,
+): string {
+  const token = (value: string) => sanitizeCssValue(value);
+
+  return `:root {
+  color-scheme: ${theme.colorScheme};
+  --rw-background: ${token(theme.background)};
+  --rw-surface: ${token(theme.surface)};
+  --rw-surface-muted: ${token(theme.surfaceMuted)};
+  --rw-text: ${token(theme.text)};
+  --rw-text-muted: ${token(theme.textMuted)};
+  --rw-border: ${token(theme.border)};
+  --rw-primary: ${token(theme.primary)};
+  --rw-primary-foreground: ${token(theme.primaryForeground)};
+  --rw-accent: ${token(theme.accent)};
+  --rw-success: ${token(theme.success)};
+  --rw-warning: ${token(theme.warning)};
+  --rw-danger: ${token(theme.danger)};
+  --rw-code-background: ${token(theme.codeBackground)};
+  --rw-radius-sm: max(0px, calc(${token(theme.radius)} - 2px));
+  --rw-radius-md: ${token(theme.radius)};
+  --rw-radius-lg: calc(${token(theme.radius)} + 4px);
+  --rw-font-sans: ${token(theme.fontSans)};
+  --rw-font-mono: ${token(theme.fontMono)};
+}`;
+}
+
+export function getShowWidgetHostThemeKey(theme: ShowWidgetHostTheme): string {
+  return JSON.stringify(theme);
+}

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/show-widget-tool-result.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/show-widget-tool-result.ts
@@ -15,6 +15,119 @@ export type ShowWidgetPayload = {
   textFallback: string | null;
 };
 
+export type ShowWidgetHostTheme = {
+  colorScheme: 'light' | 'dark';
+  background: string;
+  surface: string;
+  surfaceMuted: string;
+  text: string;
+  textMuted: string;
+  border: string;
+  primary: string;
+  primaryForeground: string;
+  accent: string;
+  success: string;
+  warning: string;
+  danger: string;
+  codeBackground: string;
+  radius: string;
+  fontSans: string;
+  fontMono: string;
+};
+
+const LIGHT_WIDGET_THEME: ShowWidgetHostTheme = {
+  colorScheme: 'light',
+  background: '#ffffff',
+  surface: '#fafaf9',
+  surfaceMuted: '#f5f5f4',
+  text: '#1c1917',
+  textMuted: '#57534e',
+  border: '#e7e5e4',
+  primary: '#1c1917',
+  primaryForeground: '#ffffff',
+  accent: '#0f766e',
+  success: '#0f766e',
+  warning: '#b45309',
+  danger: '#dc2626',
+  codeBackground: '#f5f5f4',
+  radius: '0.3rem',
+  fontSans:
+    'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  fontMono: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+};
+
+const DARK_WIDGET_THEME: ShowWidgetHostTheme = {
+  colorScheme: 'dark',
+  background: '#1c1c1b',
+  surface: '#000000',
+  surfaceMuted: '#292929',
+  text: '#ffffff',
+  textMuted: '#a3a3a3',
+  border: '#737373',
+  primary: '#d8fb2b',
+  primaryForeground: '#000000',
+  accent: '#d8fb2b',
+  success: '#2bd1b6',
+  warning: '#ecb63a',
+  danger: '#de3d3d',
+  codeBackground: '#292929',
+  radius: '0.3rem',
+  fontSans: LIGHT_WIDGET_THEME.fontSans,
+  fontMono: LIGHT_WIDGET_THEME.fontMono,
+};
+
+function readHostValue(
+  styles: CSSStyleDeclaration,
+  property: string,
+  fallback: string,
+): string {
+  return styles.getPropertyValue(property).trim() || fallback;
+}
+
+/**
+ * Resolve the widget theme from the element that hosts the iframe. CSS custom
+ * properties do not cross iframe boundaries, so the resolved values are copied
+ * into the generated document.
+ */
+export function readShowWidgetHostTheme(element: Element): ShowWidgetHostTheme {
+  const styles = getComputedStyle(element);
+  const documentElement = element.ownerDocument.documentElement;
+  const body = element.ownerDocument.body;
+  const colorScheme =
+    styles.colorScheme === 'dark' ||
+    element.closest('.dark') !== null ||
+    documentElement.classList.contains('dark') ||
+    body?.classList.contains('dark')
+      ? 'dark'
+      : 'light';
+  const fallback =
+    colorScheme === 'dark' ? DARK_WIDGET_THEME : LIGHT_WIDGET_THEME;
+
+  return {
+    colorScheme,
+    background: readHostValue(styles, '--background', fallback.background),
+    surface: readHostValue(styles, '--card', fallback.surface),
+    surfaceMuted: readHostValue(styles, '--muted', fallback.surfaceMuted),
+    text: readHostValue(styles, '--foreground', fallback.text),
+    textMuted: readHostValue(styles, '--muted-foreground', fallback.textMuted),
+    border: readHostValue(styles, '--border', fallback.border),
+    primary: readHostValue(styles, '--primary', fallback.primary),
+    primaryForeground: readHostValue(
+      styles,
+      '--primary-foreground',
+      fallback.primaryForeground,
+    ),
+    accent: readHostValue(styles, '--accent-foreground', fallback.accent),
+    success: readHostValue(styles, '--chart-2', fallback.success),
+    warning: readHostValue(styles, '--warning', fallback.warning),
+    danger: readHostValue(styles, '--destructive', fallback.danger),
+    codeBackground: readHostValue(styles, '--muted', fallback.codeBackground),
+    radius: readHostValue(styles, '--radius', fallback.radius),
+    fontSans: readHostValue(styles, '--font-sans', fallback.fontSans),
+    fontMono: readHostValue(styles, '--font-mono', fallback.fontMono),
+  };
+}
+
 function asNonEmptyString(value: unknown): string | null {
   if (typeof value !== 'string') {
     return null;
@@ -173,35 +286,47 @@ export function resolveShowWidgetForToolMessage(
  */
 const SHOW_WIDGET_DEFAULT_CSS = `
 :root {
-  color-scheme: light dark;
-  --rw-fg: #1c1917;
-  --rw-muted: #57534e;
+  --rw-background: #ffffff;
+  --rw-surface: #fafaf9;
+  --rw-surface-muted: #f5f5f4;
+  --rw-text: #1c1917;
+  --rw-text-muted: #57534e;
   --rw-border: #e7e5e4;
-  --rw-bg: #ffffff;
-  --rw-card: #fafaf9;
+  --rw-primary: #1c1917;
+  --rw-primary-foreground: #ffffff;
   --rw-accent: #0f766e;
-  --rw-code-bg: #f5f5f4;
+  --rw-success: #0f766e;
+  --rw-warning: #b45309;
+  --rw-danger: #dc2626;
+  --rw-code-background: #f5f5f4;
+  --rw-radius-sm: 0.2rem;
+  --rw-radius-md: 0.3rem;
+  --rw-radius-lg: 0.55rem;
+  --rw-font-sans: ui-sans-serif, system-ui, sans-serif;
+  --rw-font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+  --rw-space-1: 0.25rem;
+  --rw-space-2: 0.5rem;
+  --rw-space-3: 0.75rem;
+  --rw-space-4: 1rem;
+  --rw-space-6: 1.5rem;
+
+  /* Backward-compatible aliases for widgets created before the theme API. */
+  --rw-fg: var(--rw-text);
+  --rw-muted: var(--rw-text-muted);
+  --rw-bg: var(--rw-background);
+  --rw-card: var(--rw-surface);
+  --rw-code-bg: var(--rw-code-background);
 }
-@media (prefers-color-scheme: dark) {
-  :root {
-    --rw-fg: #f5f5f4;
-    --rw-muted: #a8a29e;
-    --rw-border: #44403c;
-    --rw-bg: #1c1917;
-    --rw-card: #292524;
-    --rw-accent: #2dd4bf;
-    --rw-code-bg: #292524;
-  }
-}
+*, *::before, *::after { box-sizing: border-box; }
 html, body {
   margin: 0;
   padding: 0;
   background: transparent;
-  color: var(--rw-fg);
-  font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  color: var(--rw-text);
+  font: 14px/1.5 var(--rw-font-sans);
 }
 body {
-  padding: 12px 14px;
+  padding: var(--rw-space-4);
   word-wrap: break-word;
   overflow-wrap: anywhere;
 }
@@ -218,17 +343,18 @@ p, ul, ol, pre, table, blockquote {
 }
 ul, ol { padding-left: 1.25em; }
 a { color: var(--rw-accent); }
+hr { border: 0; border-top: 1px solid var(--rw-border); margin: var(--rw-space-4) 0; }
 code, kbd, samp {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--rw-font-mono);
   font-size: 0.9em;
-  background: var(--rw-code-bg);
-  border-radius: 4px;
+  background: var(--rw-code-background);
+  border-radius: var(--rw-radius-sm);
   padding: 0.1em 0.35em;
 }
 pre {
-  background: var(--rw-code-bg);
+  background: var(--rw-code-background);
   border: 1px solid var(--rw-border);
-  border-radius: 8px;
+  border-radius: var(--rw-radius-lg);
   padding: 10px 12px;
   overflow: auto;
 }
@@ -242,12 +368,12 @@ table {
   font-size: 0.95em;
 }
 th, td {
-  border: 1px solid var(--rw-border);
-  padding: 6px 8px;
+  border-bottom: 1px solid var(--rw-border);
+  padding: var(--rw-space-2) var(--rw-space-3);
   text-align: left;
   vertical-align: top;
 }
-th { background: var(--rw-card); font-weight: 600; }
+th { color: var(--rw-text-muted); font-size: 0.85em; font-weight: 600; }
 blockquote {
   border-left: 3px solid var(--rw-border);
   margin-left: 0;
@@ -258,26 +384,120 @@ img, svg, video {
   max-width: 100%;
   height: auto;
 }
-.card, .panel {
-  background: var(--rw-card);
-  border: 1px solid var(--rw-border);
-  border-radius: 10px;
-  padding: 12px;
+.rw-stack { display: flex; flex-direction: column; gap: var(--rw-space-3); }
+.rw-row, .row {
+  display: flex;
+  gap: var(--rw-space-2);
+  flex-wrap: wrap;
+  align-items: center;
 }
-.muted { color: var(--rw-muted); }
-.row { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
-.badge {
+.rw-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(180px, 100%), 1fr));
+  gap: var(--rw-space-3);
+}
+.rw-card, .card, .panel {
+  background: var(--rw-surface);
+  border: 1px solid var(--rw-border);
+  border-radius: var(--rw-radius-lg);
+  padding: var(--rw-space-4);
+}
+.rw-muted, .muted { color: var(--rw-text-muted); }
+.rw-kicker {
+  color: var(--rw-text-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.rw-badge, .badge {
   display: inline-block;
   border: 1px solid var(--rw-border);
   border-radius: 999px;
   padding: 0.1em 0.55em;
   font-size: 0.85em;
-  color: var(--rw-muted);
+  color: var(--rw-text-muted);
+  background: var(--rw-surface-muted);
+}
+.rw-badge--accent { color: var(--rw-accent); border-color: var(--rw-accent); }
+.rw-badge--success { color: var(--rw-success); border-color: var(--rw-success); }
+.rw-badge--warning { color: var(--rw-warning); border-color: var(--rw-warning); }
+.rw-badge--danger { color: var(--rw-danger); border-color: var(--rw-danger); }
+.rw-stat {
+  display: flex;
+  min-height: 88px;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: var(--rw-space-2);
+  background: var(--rw-surface);
+  border: 1px solid var(--rw-border);
+  border-radius: var(--rw-radius-lg);
+  padding: var(--rw-space-4);
+}
+.rw-stat__label { color: var(--rw-text-muted); font-size: 0.85em; }
+.rw-stat__value { font-size: 1.5rem; font-weight: 650; line-height: 1.1; }
+.rw-callout {
+  border-left: 3px solid var(--rw-accent);
+  background: var(--rw-surface-muted);
+  border-radius: var(--rw-radius-md);
+  padding: var(--rw-space-3) var(--rw-space-4);
+}
+.rw-callout--success { border-left-color: var(--rw-success); }
+.rw-callout--warning { border-left-color: var(--rw-warning); }
+.rw-callout--danger { border-left-color: var(--rw-danger); }
+.rw-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+  border: 1px solid var(--rw-primary);
+  border-radius: var(--rw-radius-md);
+  padding: var(--rw-space-2) var(--rw-space-3);
+  color: var(--rw-primary-foreground);
+  background: var(--rw-primary);
+  font: 600 0.9rem/1 var(--rw-font-sans);
 }
 `.trim();
 
-export function buildShowWidgetSrcDoc(payload: ShowWidgetPayload): string {
-  const styles = [SHOW_WIDGET_DEFAULT_CSS, payload.css ?? '']
+function sanitizeCssValue(value: string): string {
+  return value.replace(/[<>{};]/g, '').trim();
+}
+
+function buildHostThemeCss(theme: ShowWidgetHostTheme): string {
+  const token = (value: string) => sanitizeCssValue(value);
+
+  return `:root {
+  color-scheme: ${theme.colorScheme};
+  --rw-background: ${token(theme.background)};
+  --rw-surface: ${token(theme.surface)};
+  --rw-surface-muted: ${token(theme.surfaceMuted)};
+  --rw-text: ${token(theme.text)};
+  --rw-text-muted: ${token(theme.textMuted)};
+  --rw-border: ${token(theme.border)};
+  --rw-primary: ${token(theme.primary)};
+  --rw-primary-foreground: ${token(theme.primaryForeground)};
+  --rw-accent: ${token(theme.accent)};
+  --rw-success: ${token(theme.success)};
+  --rw-warning: ${token(theme.warning)};
+  --rw-danger: ${token(theme.danger)};
+  --rw-code-background: ${token(theme.codeBackground)};
+  --rw-radius-sm: max(0px, calc(${token(theme.radius)} - 2px));
+  --rw-radius-md: ${token(theme.radius)};
+  --rw-radius-lg: calc(${token(theme.radius)} + 4px);
+  --rw-font-sans: ${token(theme.fontSans)};
+  --rw-font-mono: ${token(theme.fontMono)};
+}`;
+}
+
+export function buildShowWidgetSrcDoc(
+  payload: ShowWidgetPayload,
+  theme: ShowWidgetHostTheme = LIGHT_WIDGET_THEME,
+): string {
+  const styles = [
+    SHOW_WIDGET_DEFAULT_CSS,
+    buildHostThemeCss(theme),
+    payload.css ?? '',
+  ]
     .filter((part) => part.trim().length > 0)
     .map((part) => part.replace(/[<>]/g, ''))
     .join('\n\n');
@@ -293,7 +513,7 @@ export function buildShowWidgetSrcDoc(payload: ShowWidgetPayload): string {
 
   // Always wrap as a full document we fully control. Do not inject into
   // attacker-supplied <html>/<head> shells that could reintroduce remote loads.
-  return `<!DOCTYPE html><html><head><meta charset="utf-8">${headBits}</head><body>${payload.html}</body></html>`;
+  return `<!DOCTYPE html><html data-theme="${theme.colorScheme}"><head><meta charset="utf-8">${headBits}</head><body>${payload.html}</body></html>`;
 }
 
 function escapeHtmlText(value: string): string {

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/show-widget-tool-result.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/show-widget-tool-result.ts
@@ -1,4 +1,10 @@
 import type { AcpToolCallUiMessage, AcpToolResultUiMessage } from './types';
+import { SHOW_WIDGET_DEFAULT_CSS } from './show-widget-styles';
+import {
+  buildShowWidgetHostThemeCss,
+  DEFAULT_SHOW_WIDGET_HOST_THEME,
+  type ShowWidgetHostTheme,
+} from './show-widget-theme';
 
 export const SHOW_WIDGET_TOOL_NAME = 'show_widget';
 const ROOMOTE_MCP_SERVER_NAME = 'roomote';
@@ -14,119 +20,6 @@ export type ShowWidgetPayload = {
   height: number;
   textFallback: string | null;
 };
-
-export type ShowWidgetHostTheme = {
-  colorScheme: 'light' | 'dark';
-  background: string;
-  surface: string;
-  surfaceMuted: string;
-  text: string;
-  textMuted: string;
-  border: string;
-  primary: string;
-  primaryForeground: string;
-  accent: string;
-  success: string;
-  warning: string;
-  danger: string;
-  codeBackground: string;
-  radius: string;
-  fontSans: string;
-  fontMono: string;
-};
-
-const LIGHT_WIDGET_THEME: ShowWidgetHostTheme = {
-  colorScheme: 'light',
-  background: '#ffffff',
-  surface: '#fafaf9',
-  surfaceMuted: '#f5f5f4',
-  text: '#1c1917',
-  textMuted: '#57534e',
-  border: '#e7e5e4',
-  primary: '#1c1917',
-  primaryForeground: '#ffffff',
-  accent: '#0f766e',
-  success: '#0f766e',
-  warning: '#b45309',
-  danger: '#dc2626',
-  codeBackground: '#f5f5f4',
-  radius: '0.3rem',
-  fontSans:
-    'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
-  fontMono: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
-};
-
-const DARK_WIDGET_THEME: ShowWidgetHostTheme = {
-  colorScheme: 'dark',
-  background: '#1c1c1b',
-  surface: '#000000',
-  surfaceMuted: '#292929',
-  text: '#ffffff',
-  textMuted: '#a3a3a3',
-  border: '#737373',
-  primary: '#d8fb2b',
-  primaryForeground: '#000000',
-  accent: '#d8fb2b',
-  success: '#2bd1b6',
-  warning: '#ecb63a',
-  danger: '#de3d3d',
-  codeBackground: '#292929',
-  radius: '0.3rem',
-  fontSans: LIGHT_WIDGET_THEME.fontSans,
-  fontMono: LIGHT_WIDGET_THEME.fontMono,
-};
-
-function readHostValue(
-  styles: CSSStyleDeclaration,
-  property: string,
-  fallback: string,
-): string {
-  return styles.getPropertyValue(property).trim() || fallback;
-}
-
-/**
- * Resolve the widget theme from the element that hosts the iframe. CSS custom
- * properties do not cross iframe boundaries, so the resolved values are copied
- * into the generated document.
- */
-export function readShowWidgetHostTheme(element: Element): ShowWidgetHostTheme {
-  const styles = getComputedStyle(element);
-  const documentElement = element.ownerDocument.documentElement;
-  const body = element.ownerDocument.body;
-  const colorScheme =
-    styles.colorScheme === 'dark' ||
-    element.closest('.dark') !== null ||
-    documentElement.classList.contains('dark') ||
-    body?.classList.contains('dark')
-      ? 'dark'
-      : 'light';
-  const fallback =
-    colorScheme === 'dark' ? DARK_WIDGET_THEME : LIGHT_WIDGET_THEME;
-
-  return {
-    colorScheme,
-    background: readHostValue(styles, '--background', fallback.background),
-    surface: readHostValue(styles, '--card', fallback.surface),
-    surfaceMuted: readHostValue(styles, '--muted', fallback.surfaceMuted),
-    text: readHostValue(styles, '--foreground', fallback.text),
-    textMuted: readHostValue(styles, '--muted-foreground', fallback.textMuted),
-    border: readHostValue(styles, '--border', fallback.border),
-    primary: readHostValue(styles, '--primary', fallback.primary),
-    primaryForeground: readHostValue(
-      styles,
-      '--primary-foreground',
-      fallback.primaryForeground,
-    ),
-    accent: readHostValue(styles, '--accent-foreground', fallback.accent),
-    success: readHostValue(styles, '--chart-2', fallback.success),
-    warning: readHostValue(styles, '--warning', fallback.warning),
-    danger: readHostValue(styles, '--destructive', fallback.danger),
-    codeBackground: readHostValue(styles, '--muted', fallback.codeBackground),
-    radius: readHostValue(styles, '--radius', fallback.radius),
-    fontSans: readHostValue(styles, '--font-sans', fallback.fontSans),
-    fontMono: readHostValue(styles, '--font-mono', fallback.fontMono),
-  };
-}
 
 function asNonEmptyString(value: unknown): string | null {
   if (typeof value !== 'string') {
@@ -246,16 +139,11 @@ function isSettledToolResult(
 export function resolveShowWidgetForToolMessage(
   msg: AcpToolCallUiMessage | AcpToolResultUiMessage,
 ): ShowWidgetPayload | null {
-  if (msg.data.isMcp !== true) {
+  if (msg.data.isMcp !== true || !isRoomoteMcpServer(msg.data)) {
     return null;
   }
 
-  if (!isRoomoteMcpServer(msg.data)) {
-    return null;
-  }
-
-  const toolName = getMcpToolName(msg.data);
-  if (toolName !== SHOW_WIDGET_TOOL_NAME) {
+  if (getMcpToolName(msg.data) !== SHOW_WIDGET_TOOL_NAME) {
     return null;
   }
 
@@ -280,222 +168,13 @@ export function resolveShowWidgetForToolMessage(
   return null;
 }
 
-/**
- * Default stylesheet injected around model HTML so unstyled fragments still
- * look reasonable inside the dark/light task UI.
- */
-const SHOW_WIDGET_DEFAULT_CSS = `
-:root {
-  --rw-background: #ffffff;
-  --rw-surface: #fafaf9;
-  --rw-surface-muted: #f5f5f4;
-  --rw-text: #1c1917;
-  --rw-text-muted: #57534e;
-  --rw-border: #e7e5e4;
-  --rw-primary: #1c1917;
-  --rw-primary-foreground: #ffffff;
-  --rw-accent: #0f766e;
-  --rw-success: #0f766e;
-  --rw-warning: #b45309;
-  --rw-danger: #dc2626;
-  --rw-code-background: #f5f5f4;
-  --rw-radius-sm: 0.2rem;
-  --rw-radius-md: 0.3rem;
-  --rw-radius-lg: 0.55rem;
-  --rw-font-sans: ui-sans-serif, system-ui, sans-serif;
-  --rw-font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
-  --rw-space-1: 0.25rem;
-  --rw-space-2: 0.5rem;
-  --rw-space-3: 0.75rem;
-  --rw-space-4: 1rem;
-  --rw-space-6: 1.5rem;
-
-  /* Backward-compatible aliases for widgets created before the theme API. */
-  --rw-fg: var(--rw-text);
-  --rw-muted: var(--rw-text-muted);
-  --rw-bg: var(--rw-background);
-  --rw-card: var(--rw-surface);
-  --rw-code-bg: var(--rw-code-background);
-}
-*, *::before, *::after { box-sizing: border-box; }
-html, body {
-  margin: 0;
-  padding: 0;
-  background: transparent;
-  color: var(--rw-text);
-  font: 14px/1.5 var(--rw-font-sans);
-}
-body {
-  padding: var(--rw-space-4);
-  word-wrap: break-word;
-  overflow-wrap: anywhere;
-}
-h1, h2, h3, h4, h5, h6 {
-  margin: 0 0 0.6em;
-  line-height: 1.25;
-  font-weight: 600;
-}
-h1 { font-size: 1.35rem; }
-h2 { font-size: 1.2rem; }
-h3 { font-size: 1.05rem; }
-p, ul, ol, pre, table, blockquote {
-  margin: 0 0 0.75em;
-}
-ul, ol { padding-left: 1.25em; }
-a { color: var(--rw-accent); }
-hr { border: 0; border-top: 1px solid var(--rw-border); margin: var(--rw-space-4) 0; }
-code, kbd, samp {
-  font-family: var(--rw-font-mono);
-  font-size: 0.9em;
-  background: var(--rw-code-background);
-  border-radius: var(--rw-radius-sm);
-  padding: 0.1em 0.35em;
-}
-pre {
-  background: var(--rw-code-background);
-  border: 1px solid var(--rw-border);
-  border-radius: var(--rw-radius-lg);
-  padding: 10px 12px;
-  overflow: auto;
-}
-pre code {
-  background: transparent;
-  padding: 0;
-}
-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.95em;
-}
-th, td {
-  border-bottom: 1px solid var(--rw-border);
-  padding: var(--rw-space-2) var(--rw-space-3);
-  text-align: left;
-  vertical-align: top;
-}
-th { color: var(--rw-text-muted); font-size: 0.85em; font-weight: 600; }
-blockquote {
-  border-left: 3px solid var(--rw-border);
-  margin-left: 0;
-  padding: 0.2em 0 0.2em 0.9em;
-  color: var(--rw-muted);
-}
-img, svg, video {
-  max-width: 100%;
-  height: auto;
-}
-.rw-stack { display: flex; flex-direction: column; gap: var(--rw-space-3); }
-.rw-row, .row {
-  display: flex;
-  gap: var(--rw-space-2);
-  flex-wrap: wrap;
-  align-items: center;
-}
-.rw-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(180px, 100%), 1fr));
-  gap: var(--rw-space-3);
-}
-.rw-card, .card, .panel {
-  background: var(--rw-surface);
-  border: 1px solid var(--rw-border);
-  border-radius: var(--rw-radius-lg);
-  padding: var(--rw-space-4);
-}
-.rw-muted, .muted { color: var(--rw-text-muted); }
-.rw-kicker {
-  color: var(--rw-text-muted);
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-.rw-badge, .badge {
-  display: inline-block;
-  border: 1px solid var(--rw-border);
-  border-radius: 999px;
-  padding: 0.1em 0.55em;
-  font-size: 0.85em;
-  color: var(--rw-text-muted);
-  background: var(--rw-surface-muted);
-}
-.rw-badge--accent { color: var(--rw-accent); border-color: var(--rw-accent); }
-.rw-badge--success { color: var(--rw-success); border-color: var(--rw-success); }
-.rw-badge--warning { color: var(--rw-warning); border-color: var(--rw-warning); }
-.rw-badge--danger { color: var(--rw-danger); border-color: var(--rw-danger); }
-.rw-stat {
-  display: flex;
-  min-height: 88px;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: var(--rw-space-2);
-  background: var(--rw-surface);
-  border: 1px solid var(--rw-border);
-  border-radius: var(--rw-radius-lg);
-  padding: var(--rw-space-4);
-}
-.rw-stat__label { color: var(--rw-text-muted); font-size: 0.85em; }
-.rw-stat__value { font-size: 1.5rem; font-weight: 650; line-height: 1.1; }
-.rw-callout {
-  border-left: 3px solid var(--rw-accent);
-  background: var(--rw-surface-muted);
-  border-radius: var(--rw-radius-md);
-  padding: var(--rw-space-3) var(--rw-space-4);
-}
-.rw-callout--success { border-left-color: var(--rw-success); }
-.rw-callout--warning { border-left-color: var(--rw-warning); }
-.rw-callout--danger { border-left-color: var(--rw-danger); }
-.rw-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 2rem;
-  border: 1px solid var(--rw-primary);
-  border-radius: var(--rw-radius-md);
-  padding: var(--rw-space-2) var(--rw-space-3);
-  color: var(--rw-primary-foreground);
-  background: var(--rw-primary);
-  font: 600 0.9rem/1 var(--rw-font-sans);
-}
-`.trim();
-
-function sanitizeCssValue(value: string): string {
-  return value.replace(/[<>{};]/g, '').trim();
-}
-
-function buildHostThemeCss(theme: ShowWidgetHostTheme): string {
-  const token = (value: string) => sanitizeCssValue(value);
-
-  return `:root {
-  color-scheme: ${theme.colorScheme};
-  --rw-background: ${token(theme.background)};
-  --rw-surface: ${token(theme.surface)};
-  --rw-surface-muted: ${token(theme.surfaceMuted)};
-  --rw-text: ${token(theme.text)};
-  --rw-text-muted: ${token(theme.textMuted)};
-  --rw-border: ${token(theme.border)};
-  --rw-primary: ${token(theme.primary)};
-  --rw-primary-foreground: ${token(theme.primaryForeground)};
-  --rw-accent: ${token(theme.accent)};
-  --rw-success: ${token(theme.success)};
-  --rw-warning: ${token(theme.warning)};
-  --rw-danger: ${token(theme.danger)};
-  --rw-code-background: ${token(theme.codeBackground)};
-  --rw-radius-sm: max(0px, calc(${token(theme.radius)} - 2px));
-  --rw-radius-md: ${token(theme.radius)};
-  --rw-radius-lg: calc(${token(theme.radius)} + 4px);
-  --rw-font-sans: ${token(theme.fontSans)};
-  --rw-font-mono: ${token(theme.fontMono)};
-}`;
-}
-
 export function buildShowWidgetSrcDoc(
   payload: ShowWidgetPayload,
-  theme: ShowWidgetHostTheme = LIGHT_WIDGET_THEME,
+  theme: ShowWidgetHostTheme = DEFAULT_SHOW_WIDGET_HOST_THEME,
 ): string {
   const styles = [
     SHOW_WIDGET_DEFAULT_CSS,
-    buildHostThemeCss(theme),
+    buildShowWidgetHostThemeCss(theme),
     payload.css ?? '',
   ]
     .filter((part) => part.trim().length > 0)

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/use-show-widget-host-theme.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/use-show-widget-host-theme.ts
@@ -1,0 +1,54 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+
+import {
+  getShowWidgetHostThemeKey,
+  readShowWidgetHostTheme,
+  type ShowWidgetHostTheme,
+} from './show-widget-theme';
+
+/**
+ * Bridge the task view's selected theme into an isolated widget iframe.
+ * Watching only the host theme attributes keeps the bridge narrow and lets
+ * Storybook exercise the same behavior as the application.
+ */
+export function useShowWidgetHostTheme() {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const [hostTheme, setHostTheme] = useState<ShowWidgetHostTheme | null>(null);
+
+  useLayoutEffect(() => {
+    const host = hostRef.current;
+    if (!host) {
+      return;
+    }
+
+    const syncTheme = () => {
+      const nextTheme = readShowWidgetHostTheme(host);
+      setHostTheme((currentTheme) =>
+        currentTheme &&
+        getShowWidgetHostThemeKey(currentTheme) ===
+          getShowWidgetHostThemeKey(nextTheme)
+          ? currentTheme
+          : nextTheme,
+      );
+    };
+    const observer = new MutationObserver(syncTheme);
+
+    syncTheme();
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'style'],
+    });
+    observer.observe(document.body, {
+      attributes: true,
+      attributeFilter: ['class', 'style'],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return {
+    hostRef,
+    hostTheme,
+    hostThemeKey: hostTheme ? getShowWidgetHostThemeKey(hostTheme) : 'initial',
+  };
+}

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/tool-descriptions.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/tool-descriptions.test.ts
@@ -207,8 +207,9 @@ describe('roomote MCP tool descriptions', () => {
     const tool = getRegisteredTool(registeredTools, 'show_widget');
 
     expect(tool.config.description).toContain(
-      'Render a presentational HTML widget in the Roomote task transcript.',
+      'Render a presentational HTML widget in the current task transcript.',
     );
+    expect(tool.config.description).not.toContain('Roomote');
     expect(tool.config.description).toContain(
       'to demonstrate how something would look',
     );
@@ -234,6 +235,11 @@ describe('roomote MCP tool descriptions', () => {
     expect(getInputSchemaField(tool, 'textFallback').description).toContain(
       'originating chat surface',
     );
+    for (const field of ['html', 'title', 'css', 'height', 'textFallback']) {
+      expect(getInputSchemaField(tool, field).description).not.toContain(
+        'Roomote',
+      );
+    }
     expect(tool.config.annotations).toEqual({
       readOnlyHint: true,
       destructiveHint: false,

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/tool-descriptions.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/tool-descriptions.test.ts
@@ -217,10 +217,19 @@ describe('roomote MCP tool descriptions', () => {
     );
     expect(tool.config.description).toContain('rw-card');
     expect(tool.config.description).toContain('`--rw-*` theme variables');
+    expect(tool.config.description).toContain(
+      'Keep widgets compact enough to fit without scrolling',
+    );
     expect(tool.config.description).toContain('request_user_input');
     expect(getInputSchemaField(tool, 'html').description).toContain('HTML');
+    expect(getInputSchemaField(tool, 'html').description).toContain(
+      'Avoid long prose',
+    );
     expect(getInputSchemaField(tool, 'css').description).toContain(
       '--rw-surface',
+    );
+    expect(getInputSchemaField(tool, 'height').description).toContain(
+      'without a vertical scrollbar',
     );
     expect(getInputSchemaField(tool, 'textFallback').description).toContain(
       'originating chat surface',

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/tool-descriptions.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/tool-descriptions.test.ts
@@ -215,8 +215,13 @@ describe('roomote MCP tool descriptions', () => {
     expect(tool.config.description).toContain(
       'Do not use it for ordinary prose',
     );
+    expect(tool.config.description).toContain('rw-card');
+    expect(tool.config.description).toContain('`--rw-*` theme variables');
     expect(tool.config.description).toContain('request_user_input');
     expect(getInputSchemaField(tool, 'html').description).toContain('HTML');
+    expect(getInputSchemaField(tool, 'css').description).toContain(
+      '--rw-surface',
+    );
     expect(getInputSchemaField(tool, 'textFallback').description).toContain(
       'originating chat surface',
     );

--- a/apps/worker/src/mcp/roomote-mcp-server/index.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/index.ts
@@ -126,6 +126,7 @@ roomoteMcpServer.registerTool(
       'HTML is displayed in a sandboxed iframe with scripts disabled and network requests blocked. ' +
       'Prefer semantic HTML with Roomote theme classes (`rw-card`, `rw-stack`, `rw-row`, `rw-grid`, `rw-stat`, `rw-badge`, `rw-callout`, `rw-muted`) so the widget follows the task view theme. ' +
       'For custom CSS, use the `--rw-*` theme variables instead of hard-coded colors; omit css when the built-in styles are sufficient. ' +
+      'Keep widgets compact enough to fit without scrolling: use concise labels and a small number of cards, rows, or table entries, and choose a height that fully fits the expected content. Use ordinary prose or an artifact for long content. ' +
       'Do not use it for ordinary prose or collecting user input; use request_user_input when you need answers. ' +
       'Optional textFallback is delivered by Roomote to the originating chat surface (Slack/Teams/Telegram/Discord) when the task was started from chat.',
     inputSchema: {
@@ -133,7 +134,7 @@ roomoteMcpServer.registerTool(
         .string()
         .min(1)
         .describe(
-          'HTML fragment or full document to display. Scripts and nested browsing contexts are stripped. Roomote-themed classes include rw-card, rw-stack, rw-row, rw-grid, rw-stat, rw-badge, rw-callout, and rw-muted.',
+          'Compact HTML fragment or full document to display. Avoid long prose, large lists, and dense data likely to require scrolling. Scripts and nested browsing contexts are stripped. Roomote-themed classes include rw-card, rw-stack, rw-row, rw-grid, rw-stat, rw-badge, rw-callout, and rw-muted.',
         ),
       title: z
         .string()
@@ -149,7 +150,7 @@ roomoteMcpServer.registerTool(
         .number()
         .optional()
         .describe(
-          'Optional widget iframe height in pixels (clamped to a safe range; default 320)',
+          'Optional widget iframe height in pixels (clamped to 120-800; default 320). Choose the smallest height that fully fits the expected content without a vertical scrollbar.',
         ),
       textFallback: z
         .string()

--- a/apps/worker/src/mcp/roomote-mcp-server/index.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/index.ts
@@ -123,7 +123,9 @@ roomoteMcpServer.registerTool(
       'Render a presentational HTML widget in the Roomote task transcript. ' +
       'Use it when a structured or visual presentation is clearer than plain text, or to demonstrate how something would look. ' +
       'Examples include mock UI, status cards, tables, annotated plans, and other visual examples. ' +
-      'HTML is displayed in a sandboxed iframe with scripts disabled and network requests blocked; Roomote injects default styles when css is omitted. ' +
+      'HTML is displayed in a sandboxed iframe with scripts disabled and network requests blocked. ' +
+      'Prefer semantic HTML with Roomote theme classes (`rw-card`, `rw-stack`, `rw-row`, `rw-grid`, `rw-stat`, `rw-badge`, `rw-callout`, `rw-muted`) so the widget follows the task view theme. ' +
+      'For custom CSS, use the `--rw-*` theme variables instead of hard-coded colors; omit css when the built-in styles are sufficient. ' +
       'Do not use it for ordinary prose or collecting user input; use request_user_input when you need answers. ' +
       'Optional textFallback is delivered by Roomote to the originating chat surface (Slack/Teams/Telegram/Discord) when the task was started from chat.',
     inputSchema: {
@@ -131,7 +133,7 @@ roomoteMcpServer.registerTool(
         .string()
         .min(1)
         .describe(
-          'HTML fragment or full document to display. Scripts and nested browsing contexts are stripped.',
+          'HTML fragment or full document to display. Scripts and nested browsing contexts are stripped. Roomote-themed classes include rw-card, rw-stack, rw-row, rw-grid, rw-stat, rw-badge, rw-callout, and rw-muted.',
         ),
       title: z
         .string()
@@ -141,7 +143,7 @@ roomoteMcpServer.registerTool(
         .string()
         .optional()
         .describe(
-          'Optional extra CSS injected into the widget document after Roomote defaults',
+          'Optional extra CSS injected after Roomote defaults. Prefer --rw-background, --rw-surface, --rw-surface-muted, --rw-text, --rw-text-muted, --rw-border, --rw-primary, --rw-accent, --rw-success, --rw-warning, and --rw-danger instead of hard-coded colors.',
         ),
       height: z
         .number()

--- a/apps/worker/src/mcp/roomote-mcp-server/index.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/index.ts
@@ -120,21 +120,21 @@ roomoteMcpServer.registerTool(
   {
     title: 'Show Widget',
     description:
-      'Render a presentational HTML widget in the Roomote task transcript. ' +
+      'Render a presentational HTML widget in the current task transcript. ' +
       'Use it when a structured or visual presentation is clearer than plain text, or to demonstrate how something would look. ' +
       'Examples include mock UI, status cards, tables, annotated plans, and other visual examples. ' +
       'HTML is displayed in a sandboxed iframe with scripts disabled and network requests blocked. ' +
-      'Prefer semantic HTML with Roomote theme classes (`rw-card`, `rw-stack`, `rw-row`, `rw-grid`, `rw-stat`, `rw-badge`, `rw-callout`, `rw-muted`) so the widget follows the task view theme. ' +
-      'For custom CSS, use the `--rw-*` theme variables instead of hard-coded colors; omit css when the built-in styles are sufficient. ' +
+      'Prefer semantic HTML with the built-in widget classes (`rw-card`, `rw-stack`, `rw-row`, `rw-grid`, `rw-stat`, `rw-badge`, `rw-callout`, `rw-muted`) so the widget follows the host task theme. ' +
+      'For custom CSS, use the provided `--rw-*` theme variables instead of hard-coded colors; omit css when the built-in styles are sufficient. ' +
       'Keep widgets compact enough to fit without scrolling: use concise labels and a small number of cards, rows, or table entries, and choose a height that fully fits the expected content. Use ordinary prose or an artifact for long content. ' +
       'Do not use it for ordinary prose or collecting user input; use request_user_input when you need answers. ' +
-      'Optional textFallback is delivered by Roomote to the originating chat surface (Slack/Teams/Telegram/Discord) when the task was started from chat.',
+      'Optional textFallback is delivered to the originating chat surface (Slack/Teams/Telegram/Discord) when the task was started from chat.',
     inputSchema: {
       html: z
         .string()
         .min(1)
         .describe(
-          'Compact HTML fragment or full document to display. Avoid long prose, large lists, and dense data likely to require scrolling. Scripts and nested browsing contexts are stripped. Roomote-themed classes include rw-card, rw-stack, rw-row, rw-grid, rw-stat, rw-badge, rw-callout, and rw-muted.',
+          'Compact HTML fragment or full document to display. Avoid long prose, large lists, and dense data likely to require scrolling. Scripts and nested browsing contexts are stripped. Built-in widget classes include rw-card, rw-stack, rw-row, rw-grid, rw-stat, rw-badge, rw-callout, and rw-muted.',
         ),
       title: z
         .string()
@@ -144,7 +144,7 @@ roomoteMcpServer.registerTool(
         .string()
         .optional()
         .describe(
-          'Optional extra CSS injected after Roomote defaults. Prefer --rw-background, --rw-surface, --rw-surface-muted, --rw-text, --rw-text-muted, --rw-border, --rw-primary, --rw-accent, --rw-success, --rw-warning, and --rw-danger instead of hard-coded colors.',
+          'Optional extra CSS injected after the built-in widget defaults. Prefer --rw-background, --rw-surface, --rw-surface-muted, --rw-text, --rw-text-muted, --rw-border, --rw-primary, --rw-accent, --rw-success, --rw-warning, and --rw-danger instead of hard-coded colors.',
         ),
       height: z
         .number()


### PR DESCRIPTION
Summary
- Copy the resolved Roomote theme into sandboxed show_widget documents.
- Add namespaced rw-* layout primitives and theme variables while preserving legacy aliases.
- Guide agents toward native primitives and token-based custom CSS.
- Add permanent Storybook comparison stories, regression coverage, docs, and a changeset.

Validation
- pnpm lint
- web and worker TypeScript checks
- 32 focused web tests
- 23 worker MCP description tests
- local Storybook visual comparison in light and dark themes

Review note
- The iframe is remounted on theme changes to avoid stale or unpainted opaque sandbox documents.