### PR TITLE
feat: support safe inline SVG widgets

### DIFF
--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/show-widget.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/show-widget.test.ts
@@ -97,6 +97,56 @@ describe('handleShowWidget', () => {
 });
 
 describe('show-widget helpers', () => {
+  it('keeps static inline SVG chart primitives', async () => {
+    const html = await sanitizeWidgetHtml(`
+      <svg viewBox="0 0 200 100" role="img" aria-label="Bar chart">
+        <defs>
+          <linearGradient id="bar-gradient"><stop offset="0" stop-color="#38bdf8" /></linearGradient>
+          <clipPath id="plot"><rect width="200" height="100" /></clipPath>
+        </defs>
+        <g clip-path="url(#plot)">
+          <rect x="10" y="20" width="30" height="70" fill="url(#bar-gradient)" />
+          <circle cx="80" cy="50" r="12" />
+          <path d="M110 80 L140 30 L170 60" />
+          <text x="10" y="15">Static chart</text>
+        </g>
+      </svg>
+    `);
+
+    expect(html).toContain('<svg');
+    expect(html).toContain('<linearGradient');
+    expect(html).toContain('<clipPath');
+    expect(html).toContain('<rect');
+    expect(html).toContain('<circle');
+    expect(html).toContain('<path');
+    expect(html).toContain('<text');
+    expect(html).toContain('url(#bar-gradient)');
+  });
+
+  it('strips active SVG content and external references', async () => {
+    const html = await sanitizeWidgetHtml(`
+      <svg viewBox="0 0 100 100">
+        <foreignObject><div>embedded HTML</div></foreignObject>
+        <image href="https://evil.example/chart.svg" />
+        <use href="https://evil.example/icons.svg#chart" />
+        <animateTransform attributeName="transform" />
+        <rect onclick="alert(1)" fill="url(https://evil.example/paint.svg#gradient)" />
+        <a xlink:href="javascript:alert(1)"><text>bad link</text></a>
+      </svg>
+    `);
+
+    expect(html).toContain('<svg');
+    expect(html.toLowerCase()).not.toContain('foreignobject');
+    expect(html).not.toContain('embedded HTML');
+    expect(html.toLowerCase()).not.toContain('<image');
+    expect(html.toLowerCase()).not.toContain('<use');
+    expect(html.toLowerCase()).not.toContain('animatetransform');
+    expect(html.toLowerCase()).not.toContain('onclick');
+    expect(html.toLowerCase()).not.toContain('xlink:href');
+    expect(html.toLowerCase()).not.toContain('https://evil.example');
+    expect(html.toLowerCase()).not.toContain('javascript:');
+  });
+
   it('strips javascript urls and nested frames', async () => {
     const html = await sanitizeWidgetHtml(
       '<a href="javascript:alert(1)">x</a><iframe src="https://evil"></iframe><img src="https://evil/x.png">',

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/tool-descriptions.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/tool-descriptions.test.ts
@@ -221,10 +221,16 @@ describe('roomote MCP tool descriptions', () => {
     expect(tool.config.description).toContain(
       'Keep widgets compact enough to fit without scrolling',
     );
+    expect(tool.config.description).toContain(
+      'HTML, CSS, and inline SVG are displayed in a sandboxed iframe',
+    );
     expect(tool.config.description).toContain('request_user_input');
     expect(getInputSchemaField(tool, 'html').description).toContain('HTML');
     expect(getInputSchemaField(tool, 'html').description).toContain(
       'Avoid long prose',
+    );
+    expect(getInputSchemaField(tool, 'html').description).toContain(
+      'including inline SVG',
     );
     expect(getInputSchemaField(tool, 'css').description).toContain(
       '--rw-surface',

--- a/apps/worker/src/mcp/roomote-mcp-server/index.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/index.ts
@@ -123,7 +123,7 @@ roomoteMcpServer.registerTool(
       'Render a presentational HTML widget in the current task transcript. ' +
       'Use it when a structured or visual presentation is clearer than plain text, or to demonstrate how something would look. ' +
       'Examples include mock UI, status cards, tables, annotated plans, and other visual examples. ' +
-      'HTML is displayed in a sandboxed iframe with scripts disabled and network requests blocked. ' +
+      'HTML, CSS, and inline SVG are displayed in a sandboxed iframe with scripts disabled and network requests blocked. ' +
       'Prefer semantic HTML with the built-in widget classes (`rw-card`, `rw-stack`, `rw-row`, `rw-grid`, `rw-stat`, `rw-badge`, `rw-callout`, `rw-muted`) so the widget follows the host task theme. ' +
       'For custom CSS, use the provided `--rw-*` theme variables instead of hard-coded colors; omit css when the built-in styles are sufficient. ' +
       'Keep widgets compact enough to fit without scrolling: use concise labels and a small number of cards, rows, or table entries, and choose a height that fully fits the expected content. Use ordinary prose or an artifact for long content. ' +
@@ -134,7 +134,7 @@ roomoteMcpServer.registerTool(
         .string()
         .min(1)
         .describe(
-          'Compact HTML fragment or full document to display. Avoid long prose, large lists, and dense data likely to require scrolling. Scripts and nested browsing contexts are stripped. Built-in widget classes include rw-card, rw-stack, rw-row, rw-grid, rw-stat, rw-badge, rw-callout, and rw-muted.',
+          'Compact HTML fragment or full document to display, including inline SVG. Avoid long prose, large lists, and dense data likely to require scrolling. Scripts and nested browsing contexts are stripped. Built-in widget classes include rw-card, rw-stack, rw-row, rw-grid, rw-stat, rw-badge, rw-callout, and rw-muted.',
         ),
       title: z
         .string()

--- a/apps/worker/src/mcp/roomote-mcp-server/show-widget.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/show-widget.ts
@@ -7,6 +7,7 @@ const SHOW_WIDGET_MAX_HTML_CHARS = 100_000;
 const SHOW_WIDGET_MAX_CSS_CHARS = 50_000;
 const SHOW_WIDGET_MAX_TITLE_CHARS = 200;
 const SHOW_WIDGET_MAX_TEXT_FALLBACK_CHARS = 4_000;
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
 export const SHOW_WIDGET_DEFAULT_HEIGHT = 320;
 export const SHOW_WIDGET_MIN_HEIGHT = 120;
 export const SHOW_WIDGET_MAX_HEIGHT = 800;
@@ -49,8 +50,11 @@ async function getPurifier(): Promise<DOMPurify> {
     ([{ default: createDOMPurify }, { JSDOM }]) => {
       const purifier = createDOMPurify(new JSDOM('').window);
 
-      purifier.addHook('uponSanitizeAttribute', (_node, data) => {
+      purifier.addHook('uponSanitizeAttribute', (node, data) => {
         const name = data.attrName.toLowerCase();
+        const value = String(data.attrValue ?? '')
+          .trim()
+          .toLowerCase();
 
         if (
           name.startsWith('on') ||
@@ -62,6 +66,22 @@ async function getPurifier(): Promise<DOMPurify> {
           return;
         }
 
+        if (node.namespaceURI === SVG_NAMESPACE) {
+          if (name === 'href' && !value.startsWith('#')) {
+            data.keepAttr = false;
+            return;
+          }
+
+          const withoutLocalReferences = value.replace(
+            /url\(\s*(['"]?)#[^'"()\s]+\1\s*\)/gi,
+            '',
+          );
+          if (/url\s*\(/i.test(withoutLocalReferences)) {
+            data.keepAttr = false;
+            return;
+          }
+        }
+
         if (
           name === 'href' ||
           name === 'src' ||
@@ -69,10 +89,6 @@ async function getPurifier(): Promise<DOMPurify> {
           name === 'action' ||
           name === 'srcset'
         ) {
-          const value = String(data.attrValue ?? '')
-            .trim()
-            .toLowerCase();
-
           if (
             value.startsWith('http:') ||
             value.startsWith('https:') ||
@@ -103,7 +119,7 @@ export async function sanitizeWidgetHtml(html: string): Promise<string> {
   const purifier = await getPurifier();
 
   return purifier.sanitize(html, {
-    USE_PROFILES: { html: true },
+    USE_PROFILES: { html: true, svg: true },
     FORBID_TAGS: [
       'script',
       'iframe',
@@ -114,8 +130,17 @@ export async function sanitizeWidgetHtml(html: string): Promise<string> {
       'meta',
       'link',
       'style',
-      'svg',
       'math',
+      'foreignobject',
+      'image',
+      'use',
+      'animate',
+      'animatecolor',
+      'animatemotion',
+      'animatetransform',
+      'filter',
+      'set',
+      'mpath',
       'noscript',
       'template',
       'video',
@@ -128,7 +153,7 @@ export async function sanitizeWidgetHtml(html: string): Promise<string> {
       'applet',
     ],
     ALLOW_DATA_ATTR: false,
-    FORBID_CONTENTS: ['script', 'style'],
+    ADD_FORBID_CONTENTS: ['script', 'style'],
   });
 }
 


### PR DESCRIPTION
## Summary
- allow inline SVG through the widget sanitizer using DOMPurify's SVG profile
- preserve chart primitives such as shapes, paths, text, gradients, and clipping
- strip active or externally loaded SVG markup, including SVG animation elements, filters, embedded HTML, images, and external references
- tell agents that inline SVG is supported while keeping the prompt focused on the sandbox boundary
- cover safe chart markup and malicious SVG payloads with focused tests

## Security boundary
Widgets remain scriptless and network-isolated. The iframe CSP continues to use `default-src 'none'`, while the worker sanitizer removes executable attributes and unsafe SVG elements or references before persistence. Custom CSS behavior is unchanged.

## Validation
- `mise exec -- pnpm --filter @roomote/worker exec vitest run src/mcp/roomote-mcp-server/__tests__/show-widget.test.ts src/mcp/roomote-mcp-server/__tests__/tool-descriptions.test.ts`
- `mise exec -- pnpm --filter @roomote/worker check-types`
- `mise exec -- pnpm --filter @roomote/worker lint`