### PR TITLE
[Improve] Frame provider comment follow-ups as untrusted content

### DIFF
--- a/.changeset/provider-comment-untrusted-framing.md
+++ b/.changeset/provider-comment-untrusted-framing.md
@@ -1,0 +1,5 @@
+---
+"@roomote/web": patch
+---
+
+Apply the untrusted-content prompt framing to GitLab, Bitbucket, Azure DevOps, and Gitea comment follow-up messages, wrapping the triggering comment in a mention-request block and appending the shared injection-resistance policy

--- a/apps/api/src/handlers/ado/__tests__/handleComment.test.ts
+++ b/apps/api/src/handlers/ado/__tests__/handleComment.test.ts
@@ -20,9 +20,16 @@ const {
   mockSteerMessageToTask: vi.fn(),
 }));
 
+// Prompt-framing fakes use distinctive markers so tests can assert the
+// handler routes each piece of text through the right builder; the real
+// escaping/wrapping behavior is unit-tested in @roomote/cloud-agents.
 vi.mock('@roomote/cloud-agents/server', () => ({
   enqueueTask: mockEnqueueTask,
   getTaskUrl: mockGetTaskUrl,
+  buildMentionRequestBlock: (text: string) =>
+    `<mention_request>${text}</mention_request>`,
+  buildUntrustedContentPolicy: () => '<untrusted_content_policy/>',
+  escapeTaskContextText: (value: string) => value,
 }));
 
 vi.mock('@roomote/ado', () => ({
@@ -354,8 +361,15 @@ describe('handleAdoComment', () => {
       expect.objectContaining({
         taskId: 'task-existing',
         userId: 'user-1',
-        message: expect.stringContaining('mentioned Roomote in a comment'),
+        message: expect.stringContaining(
+          '<mention_request>@roomote please review this</mention_request>',
+        ),
         senderMode: 'github_pr_follow_up',
+      }),
+    );
+    expect(mockSteerMessageToTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('<untrusted_content_policy/>'),
       }),
     );
     expect(mockEnqueueTask).not.toHaveBeenCalled();

--- a/apps/api/src/handlers/ado/handleComment.ts
+++ b/apps/api/src/handlers/ado/handleComment.ts
@@ -1,4 +1,10 @@
-import { enqueueTask, getTaskUrl } from '@roomote/cloud-agents/server';
+import {
+  buildMentionRequestBlock,
+  buildUntrustedContentPolicy,
+  enqueueTask,
+  escapeTaskContextText,
+  getTaskUrl,
+} from '@roomote/cloud-agents/server';
 import {
   findActiveGitHubPrReviewTask,
   findReusableGitHubPrFollowUpOwner,
@@ -207,14 +213,6 @@ function buildTaskStartFailedComment(): string {
   return 'I saw the mention, but I could not start a task for this pull request right now. Please try again in a moment.';
 }
 
-function formatQuotedText(text: string): string {
-  return text
-    .trim()
-    .split('\n')
-    .map((line) => `> ${line}`)
-    .join('\n');
-}
-
 function buildExistingTaskFollowUpMessage({
   repoFullName,
   pullRequest,
@@ -227,8 +225,7 @@ function buildExistingTaskFollowUpMessage({
   commentBody: string;
 }): string {
   const lines = [
-    `${commenter} mentioned Roomote in a comment on Azure DevOps pull request #${pullRequest.pullRequestId} (${pullRequest.title}) in ${repoFullName}:`,
-    formatQuotedText(commentBody),
+    `${commenter} mentioned Roomote in a comment on Azure DevOps pull request #${pullRequest.pullRequestId} (${escapeTaskContextText(pullRequest.title)}) in ${repoFullName}.`,
     '',
     'Please act on this comment as a follow-up to your existing work on this pull request.',
   ];
@@ -237,6 +234,14 @@ function buildExistingTaskFollowUpMessage({
   if (branchName) {
     lines.push(`The pull request source branch is \`${branchName}\`.`);
   }
+
+  lines.push(
+    '',
+    'Mention comment (the request to act on):',
+    buildMentionRequestBlock(commentBody),
+    '',
+    buildUntrustedContentPolicy(),
+  );
 
   return lines.join('\n');
 }

--- a/apps/api/src/handlers/bitbucket/__tests__/handleComment.test.ts
+++ b/apps/api/src/handlers/bitbucket/__tests__/handleComment.test.ts
@@ -4,15 +4,30 @@ const {
   mockCreateBitbucketPullRequestComment,
   mockGetBitbucketAutomationTargets,
   mockEnqueueTask,
+  mockFindActiveGitHubPrReviewTask,
+  mockFindReusableGitHubPrFollowUpOwner,
+  mockSendMessageToTask,
+  mockSteerMessageToTask,
 } = vi.hoisted(() => ({
   mockCreateBitbucketPullRequestComment: vi.fn(),
   mockGetBitbucketAutomationTargets: vi.fn(),
   mockEnqueueTask: vi.fn(),
+  mockFindActiveGitHubPrReviewTask: vi.fn(),
+  mockFindReusableGitHubPrFollowUpOwner: vi.fn(),
+  mockSendMessageToTask: vi.fn(),
+  mockSteerMessageToTask: vi.fn(),
 }));
 
+// Prompt-framing fakes use distinctive markers so tests can assert the
+// handler routes each piece of text through the right builder; the real
+// escaping/wrapping behavior is unit-tested in @roomote/cloud-agents.
 vi.mock('@roomote/cloud-agents/server', () => ({
   enqueueTask: mockEnqueueTask,
   getTaskUrl: vi.fn(),
+  buildMentionRequestBlock: (text: string) =>
+    `<mention_request>${text}</mention_request>`,
+  buildUntrustedContentPolicy: () => '<untrusted_content_policy/>',
+  escapeTaskContextText: (value: string) => value,
 }));
 
 vi.mock('@roomote/bitbucket', () => ({
@@ -24,10 +39,15 @@ vi.mock('@roomote/db/server', async (importOriginal) => {
 
   return {
     ...actual,
-    findActiveGitHubPrReviewTask: vi.fn(),
-    findReusableGitHubPrFollowUpOwner: vi.fn(),
+    findActiveGitHubPrReviewTask: mockFindActiveGitHubPrReviewTask,
+    findReusableGitHubPrFollowUpOwner: mockFindReusableGitHubPrFollowUpOwner,
   };
 });
+
+vi.mock('../../tasks/sendMessageToTask', () => ({
+  sendMessageToTask: mockSendMessageToTask,
+  steerMessageToTask: mockSteerMessageToTask,
+}));
 
 vi.mock('../getBitbucketAutomationTargets', async () => {
   const actual = await vi.importActual<
@@ -39,6 +59,8 @@ vi.mock('../getBitbucketAutomationTargets', async () => {
     getBitbucketAutomationTargets: mockGetBitbucketAutomationTargets,
   };
 });
+
+import { RunStatus } from '@roomote/types';
 
 import { handleBitbucketComment } from '../handleComment';
 import type { BitbucketPullRequestCommentWebhook } from '../types';
@@ -74,12 +96,18 @@ describe('handleBitbucketComment', () => {
     mockCreateBitbucketPullRequestComment.mockReset();
     mockGetBitbucketAutomationTargets.mockReset();
     mockEnqueueTask.mockReset();
+    mockFindActiveGitHubPrReviewTask.mockReset();
+    mockFindReusableGitHubPrFollowUpOwner.mockReset();
+    mockSendMessageToTask.mockReset();
+    mockSteerMessageToTask.mockReset();
 
     mockGetBitbucketAutomationTargets.mockResolvedValue({
       status: 'error',
       code: 'account_link_required',
       message: 'Bitbucket user alice is not linked',
     });
+    mockFindActiveGitHubPrReviewTask.mockResolvedValue(null);
+    mockFindReusableGitHubPrFollowUpOwner.mockResolvedValue(null);
   });
 
   it('propagates a failed account-link response so the webhook is recorded as failed', async () => {
@@ -157,6 +185,55 @@ describe('handleBitbucketComment', () => {
     ).resolves.toEqual({ status: 'ok', message: 'account_link_required' });
 
     expect(mockCreateBitbucketPullRequestComment).toHaveBeenCalledOnce();
+  });
+
+  it('routes mentions into a reusable active task with untrusted-content framing', async () => {
+    mockGetBitbucketAutomationTargets.mockResolvedValue({
+      status: 'ok',
+      targets: [
+        {
+          id: 'bitbucket:pr_review:repo-1',
+          workflow: 'pr_review',
+          settings: null,
+          repo: {
+            id: 'repo-1',
+            host: 'bitbucket.org',
+          },
+          repositoryIds: ['repo-1'],
+          userId: 'user-1',
+        },
+      ],
+    });
+    mockFindReusableGitHubPrFollowUpOwner.mockResolvedValue({
+      taskId: 'task-existing',
+      status: RunStatus.Running,
+      taskPhase: 'running',
+    });
+    mockSteerMessageToTask.mockResolvedValue({ success: true, result: {} });
+    mockCreateBitbucketPullRequestComment.mockResolvedValue({ id: 7 });
+
+    const result = await handleBitbucketComment(
+      makeCommentPayload(),
+      'pullrequest:comment_created',
+    );
+
+    expect(result).toEqual({ status: 'ok', message: 'active_pr_owner_routed' });
+    expect(mockSteerMessageToTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: 'task-existing',
+        userId: 'user-1',
+        message: expect.stringContaining(
+          '<mention_request>@roomote review this please</mention_request>',
+        ),
+        senderMode: 'github_pr_follow_up',
+      }),
+    );
+    expect(mockSteerMessageToTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('<untrusted_content_policy/>'),
+      }),
+    );
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('logs enqueue failures and posts a queue-specific response', async () => {

--- a/apps/api/src/handlers/bitbucket/handleComment.ts
+++ b/apps/api/src/handlers/bitbucket/handleComment.ts
@@ -1,4 +1,10 @@
-import { enqueueTask, getTaskUrl } from '@roomote/cloud-agents/server';
+import {
+  buildMentionRequestBlock,
+  buildUntrustedContentPolicy,
+  enqueueTask,
+  escapeTaskContextText,
+  getTaskUrl,
+} from '@roomote/cloud-agents/server';
 import {
   findActiveGitHubPrReviewTask,
   findReusableGitHubPrFollowUpOwner,
@@ -141,14 +147,6 @@ function buildTaskStartFailedComment(): string {
   return 'I saw the mention, but Roomote could not queue a review task for this pull request. Please try again in a moment. If it keeps failing, an administrator should check the deployment logs.';
 }
 
-function formatQuotedText(text: string): string {
-  return text
-    .trim()
-    .split('\n')
-    .map((line) => `> ${line}`)
-    .join('\n');
-}
-
 function buildExistingTaskFollowUpMessage({
   repoFullName,
   pullRequestNumber,
@@ -165,8 +163,7 @@ function buildExistingTaskFollowUpMessage({
   commentBody: string;
 }): string {
   const lines = [
-    `${commenter} mentioned Roomote in a comment on Bitbucket pull request #${pullRequestNumber} (${pullRequestTitle}) in ${repoFullName}:`,
-    formatQuotedText(commentBody),
+    `${commenter} mentioned Roomote in a comment on Bitbucket pull request #${pullRequestNumber} (${escapeTaskContextText(pullRequestTitle)}) in ${repoFullName}.`,
     '',
     'Please act on this comment as a follow-up to your existing work on this pull request.',
   ];
@@ -174,6 +171,14 @@ function buildExistingTaskFollowUpMessage({
   if (headRef) {
     lines.push(`The pull request source branch is \`${headRef}\`.`);
   }
+
+  lines.push(
+    '',
+    'Mention comment (the request to act on):',
+    buildMentionRequestBlock(commentBody),
+    '',
+    buildUntrustedContentPolicy(),
+  );
 
   return lines.join('\n');
 }

--- a/apps/api/src/handlers/gitea/__tests__/handleComment.test.ts
+++ b/apps/api/src/handlers/gitea/__tests__/handleComment.test.ts
@@ -20,9 +20,16 @@ const {
   mockSteerMessageToTask: vi.fn(),
 }));
 
+// Prompt-framing fakes use distinctive markers so tests can assert the
+// handler routes each piece of text through the right builder; the real
+// escaping/wrapping behavior is unit-tested in @roomote/cloud-agents.
 vi.mock('@roomote/cloud-agents/server', () => ({
   enqueueTask: mockEnqueueTask,
   getTaskUrl: mockGetTaskUrl,
+  buildMentionRequestBlock: (text: string) =>
+    `<mention_request>${text}</mention_request>`,
+  buildUntrustedContentPolicy: () => '<untrusted_content_policy/>',
+  escapeTaskContextText: (value: string) => value,
 }));
 
 vi.mock('@roomote/gitea', () => ({
@@ -279,7 +286,14 @@ describe('handleGiteaComment', () => {
       expect.objectContaining({
         taskId: 'task-existing',
         userId: 'user-1',
-        message: expect.stringContaining('mentioned Roomote in a comment'),
+        message: expect.stringContaining(
+          '<mention_request>@roomote please review this</mention_request>',
+        ),
+      }),
+    );
+    expect(mockSteerMessageToTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('<untrusted_content_policy/>'),
       }),
     );
     expect(mockEnqueueTask).not.toHaveBeenCalled();

--- a/apps/api/src/handlers/gitea/handleComment.ts
+++ b/apps/api/src/handlers/gitea/handleComment.ts
@@ -1,4 +1,10 @@
-import { enqueueTask, getTaskUrl } from '@roomote/cloud-agents/server';
+import {
+  buildMentionRequestBlock,
+  buildUntrustedContentPolicy,
+  enqueueTask,
+  escapeTaskContextText,
+  getTaskUrl,
+} from '@roomote/cloud-agents/server';
 import {
   findActiveGitHubPrReviewTask,
   findReusableGitHubPrFollowUpOwner,
@@ -184,14 +190,6 @@ function buildTaskStartFailedComment(): string {
   return 'I saw the mention, but I could not start a task for this pull request right now. Please try again in a moment.';
 }
 
-function formatQuotedText(text: string): string {
-  return text
-    .trim()
-    .split('\n')
-    .map((line) => `> ${line}`)
-    .join('\n');
-}
-
 function buildExistingTaskFollowUpMessage({
   repoFullName,
   pullRequest,
@@ -204,8 +202,7 @@ function buildExistingTaskFollowUpMessage({
   commentBody: string;
 }): string {
   const lines = [
-    `${commenter} mentioned Roomote in a comment on Gitea pull request #${pullRequest.number} (${pullRequest.title}) in ${repoFullName}:`,
-    formatQuotedText(commentBody),
+    `${commenter} mentioned Roomote in a comment on Gitea pull request #${pullRequest.number} (${escapeTaskContextText(pullRequest.title)}) in ${repoFullName}.`,
     '',
     'Please act on this comment as a follow-up to your existing work on this pull request.',
   ];
@@ -215,6 +212,14 @@ function buildExistingTaskFollowUpMessage({
       `The pull request source branch is \`${pullRequest.head.ref}\`.`,
     );
   }
+
+  lines.push(
+    '',
+    'Mention comment (the request to act on):',
+    buildMentionRequestBlock(commentBody),
+    '',
+    buildUntrustedContentPolicy(),
+  );
 
   return lines.join('\n');
 }

--- a/apps/api/src/handlers/gitlab/__tests__/handleNote.test.ts
+++ b/apps/api/src/handlers/gitlab/__tests__/handleNote.test.ts
@@ -20,9 +20,16 @@ const {
   mockSteerMessageToTask: vi.fn(),
 }));
 
+// Prompt-framing fakes use distinctive markers so tests can assert the
+// handler routes each piece of text through the right builder; the real
+// escaping/wrapping behavior is unit-tested in @roomote/cloud-agents.
 vi.mock('@roomote/cloud-agents/server', () => ({
   enqueueTask: mockEnqueueTask,
   getTaskUrl: mockGetTaskUrl,
+  buildMentionRequestBlock: (text: string) =>
+    `<mention_request>${text}</mention_request>`,
+  buildUntrustedContentPolicy: () => '<untrusted_content_policy/>',
+  escapeTaskContextText: (value: string) => value,
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -315,7 +322,15 @@ describe('handleGitLabNote', () => {
       expect.objectContaining({
         taskId: 'owner-task',
         userId: 'user-1',
+        message: expect.stringContaining(
+          '<mention_request>Hey @roomote please take a look</mention_request>',
+        ),
         senderMode: 'github_pr_follow_up',
+      }),
+    );
+    expect(mockSteerMessageToTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('<untrusted_content_policy/>'),
       }),
     );
     expect(mockEnqueueTask).not.toHaveBeenCalled();

--- a/apps/api/src/handlers/gitlab/handleNote.ts
+++ b/apps/api/src/handlers/gitlab/handleNote.ts
@@ -1,4 +1,10 @@
-import { enqueueTask, getTaskUrl } from '@roomote/cloud-agents/server';
+import {
+  buildMentionRequestBlock,
+  buildUntrustedContentPolicy,
+  enqueueTask,
+  escapeTaskContextText,
+  getTaskUrl,
+} from '@roomote/cloud-agents/server';
 import {
   findActiveGitHubPrReviewTask,
   findReusableGitHubPrFollowUpOwner,
@@ -155,14 +161,6 @@ function buildTaskStartFailedNote(): string {
   return 'I saw the mention, but I could not start a task for this merge request right now. Please try again in a moment.';
 }
 
-function formatQuotedText(text: string): string {
-  return text
-    .trim()
-    .split('\n')
-    .map((line) => `> ${line}`)
-    .join('\n');
-}
-
 function buildExistingTaskFollowUpMessage({
   repoFullName,
   mergeRequest,
@@ -175,8 +173,7 @@ function buildExistingTaskFollowUpMessage({
   noteBody: string;
 }): string {
   const lines = [
-    `${commenter} mentioned Roomote in a comment on GitLab merge request !${mergeRequest.iid} (${mergeRequest.title}) in ${repoFullName}:`,
-    formatQuotedText(noteBody),
+    `${commenter} mentioned Roomote in a comment on GitLab merge request !${mergeRequest.iid} (${escapeTaskContextText(mergeRequest.title)}) in ${repoFullName}.`,
     '',
     'Please act on this comment as a follow-up to your existing work on this merge request.',
   ];
@@ -186,6 +183,14 @@ function buildExistingTaskFollowUpMessage({
       `The merge request source branch is \`${mergeRequest.source_branch}\`.`,
     );
   }
+
+  lines.push(
+    '',
+    'Mention comment (the request to act on):',
+    buildMentionRequestBlock(noteBody),
+    '',
+    buildUntrustedContentPolicy(),
+  );
 
   return lines.join('\n');
 }


### PR DESCRIPTION
## Description

Follow-up to #570, which added shared prompt-hardening helpers (`buildMentionRequestBlock`, `buildUntrustedContentPolicy`) and applied them to the GitHub-facing prompts. The non-GitHub provider comment handlers still interpolated the triggering comment into follow-up task messages with plain `> ` quoting and no untrusted-content policy.

The GitLab, Bitbucket, Azure DevOps, and Gitea comment handlers now compose their existing-task follow-up messages the same way as the GitHub issue-mention handler:

- The triggering comment (authored by a commenter who passed the linked-account gate, so it is the request to act on) lands in an escaped `<mention_request>` block instead of `> ` quoting.
- The PR/MR title is escaped with `escapeTaskContextText`, matching the GitHub composition.
- The shared untrusted-content policy is appended to each built follow-up message.
- The now-unused local `formatQuotedText` helpers are removed.

## Test plan

- Handler tests now mock the `@roomote/cloud-agents/server` barrel with distinctive marker fakes and assert the follow-up message routes text through the right builders, mirroring the GitHub handler test update in #570.
- The Bitbucket suite gains its first coverage of the reusable-task follow-up path (steer into an active owner task).
- Ran the four affected `apps/api` handler test directories (21 files, 146 tests), `pnpm lint`, `pnpm check-types`, and `pnpm knip`.