### PR TITLE
[Feat] Show subscription provider usage on Models settings

### DIFF
--- a/apps/docs/models.mdx
+++ b/apps/docs/models.mdx
@@ -137,6 +137,13 @@ list.
 - **Models** controls the provider/model pairs that are available, the default
   model, and specialized model roles.
 
+For subscription-based providers (ChatGPT, GitHub Copilot, and Kimi for
+Coding), the provider row also shows current plan usage when the provider
+reports it, such as remaining Copilot premium requests or the percent used of
+the ChatGPT 5-hour and weekly limits. These numbers come from unofficial
+provider endpoints, so the usage line is hidden whenever the provider does not
+return usable data.
+
 Admins can enable or disable models from the task model list. The default model
 must stay enabled, because Roomote uses it when a task does not request a
 specific model.

--- a/apps/web/src/components/settings/ChatGptConnectDialog.tsx
+++ b/apps/web/src/components/settings/ChatGptConnectDialog.tsx
@@ -87,6 +87,9 @@ export function ChatGptConnectDialog({
           await queryClient.invalidateQueries({
             queryKey: trpc.chatgptSubscription.status.queryKey(),
           });
+          await queryClient.invalidateQueries({
+            queryKey: trpc.subscriptionUsage.list.queryKey(),
+          });
           await onConnected?.();
           handleOpenChange(false);
         } else if (result.status === 'failed') {

--- a/apps/web/src/components/settings/GitHubCopilotConnectDialog.tsx
+++ b/apps/web/src/components/settings/GitHubCopilotConnectDialog.tsx
@@ -94,6 +94,9 @@ export function GitHubCopilotConnectDialog({
             queryClient.invalidateQueries({
               queryKey: trpc.githubCopilotSubscription.status.queryKey(),
             }),
+            queryClient.invalidateQueries({
+              queryKey: trpc.subscriptionUsage.list.queryKey(),
+            }),
           ]);
           await onConnected?.();
           close(false);

--- a/apps/web/src/components/settings/InferenceProviderSection.test.tsx
+++ b/apps/web/src/components/settings/InferenceProviderSection.test.tsx
@@ -14,14 +14,19 @@ const chatgptStatusData = vi.hoisted(() => ({
 const githubCopilotStatusData = vi.hoisted(() => ({
   current: null as Record<string, unknown> | null,
 }));
+const subscriptionUsageData = vi.hoisted(() => ({
+  current: null as Array<Record<string, unknown>> | null,
+}));
 const mutateAsyncMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@tanstack/react-query', () => ({
   useMutation: () => ({ mutateAsync: mutateAsyncMock }),
   useQuery: (options: { queryKey?: string[] }) => ({
-    data: options.queryKey?.[0]?.includes('githubCopilot')
-      ? githubCopilotStatusData.current
-      : chatgptStatusData.current,
+    data: options.queryKey?.[0]?.includes('subscriptionUsage')
+      ? subscriptionUsageData.current
+      : options.queryKey?.[0]?.includes('githubCopilot')
+        ? githubCopilotStatusData.current
+        : chatgptStatusData.current,
   }),
   useQueryClient: () => ({ invalidateQueries: vi.fn() }),
 }));
@@ -77,6 +82,12 @@ vi.mock('@/trpc/client', () => ({
       },
       disconnect: {
         mutationOptions: () => ({ mutationKey: ['disconnectCopilot'] }),
+      },
+    },
+    subscriptionUsage: {
+      list: {
+        queryOptions: () => ({ queryKey: ['subscriptionUsage', 'list'] }),
+        queryKey: () => ['subscriptionUsage', 'list'],
       },
     },
   }),
@@ -219,6 +230,8 @@ describe('InferenceProviderSection', () => {
     window.HTMLElement.prototype.scrollIntoView = vi.fn();
     providerSetupData.current = null;
     chatgptStatusData.current = null;
+    githubCopilotStatusData.current = null;
+    subscriptionUsageData.current = null;
   });
 
   const renderInferenceProviderSection = () => {
@@ -307,6 +320,68 @@ describe('InferenceProviderSection', () => {
     expect(
       screen.queryByRole('button', { name: /Connect ChatGPT/ }),
     ).not.toBeInTheDocument();
+  });
+
+  it('shows a usage line under a connected subscription row', () => {
+    providerSetupData.current = buildProviderSetup({ chatgptConnected: true });
+    chatgptStatusData.current = {
+      connected: true,
+      status: 'connected',
+      email: 'user@example.com',
+    };
+    githubCopilotStatusData.current = { connected: true, status: 'connected' };
+    subscriptionUsageData.current = [
+      {
+        providerId: 'chatgpt',
+        planType: 'pro',
+        windows: [
+          {
+            label: 'Weekly limit',
+            usedPercent: 8,
+            resetsAt: new Date(Date.now() + 5 * 3_600_000).toISOString(),
+          },
+        ],
+        fetchedAt: new Date().toISOString(),
+      },
+      {
+        providerId: 'github-copilot',
+        windows: [{ label: 'Premium requests', remaining: 211, limit: 300 }],
+        fetchedAt: new Date().toISOString(),
+      },
+    ];
+
+    renderInferenceProviderSection();
+
+    expect(
+      screen.getByText('Weekly limit: 8% used (resets in 5h)'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Premium requests: 211 of 300 left'),
+    ).toBeInTheDocument();
+  });
+
+  it('omits the usage line when no usage data is available or the row errored', () => {
+    providerSetupData.current = buildProviderSetup({ chatgptConnected: true });
+    chatgptStatusData.current = {
+      connected: false,
+      status: 'error',
+      error: 'ChatGPT token refresh failed: 401',
+    };
+    githubCopilotStatusData.current = { connected: true, status: 'connected' };
+    subscriptionUsageData.current = [
+      {
+        providerId: 'chatgpt',
+        windows: [{ label: 'Weekly limit', usedPercent: 8 }],
+        fetchedAt: new Date().toISOString(),
+      },
+    ];
+
+    renderInferenceProviderSection();
+
+    // The errored ChatGPT row hides its stale usage; the Copilot row has no
+    // usage entry at all, so neither renders a usage line.
+    expect(screen.queryByText(/Weekly limit/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Premium requests/)).not.toBeInTheDocument();
   });
 
   it('renders Reconnect and Disconnect for an errored ChatGPT subscription', () => {

--- a/apps/web/src/components/settings/InferenceProviderSection.tsx
+++ b/apps/web/src/components/settings/InferenceProviderSection.tsx
@@ -851,6 +851,9 @@ export function InferenceProviderSection({
           queryClient.invalidateQueries({
             queryKey: trpc.taskModels.providerSetup.queryKey(),
           }),
+          queryClient.invalidateQueries({
+            queryKey: trpc.subscriptionUsage.list.queryKey(),
+          }),
           ...(addedModelCount > 0 || addedDiscoveredModelCount > 0
             ? [
                 queryClient.invalidateQueries({
@@ -890,6 +893,9 @@ export function InferenceProviderSection({
           queryClient.invalidateQueries({
             queryKey: trpc.chatgptSubscription.status.queryKey(),
           }),
+          queryClient.invalidateQueries({
+            queryKey: trpc.subscriptionUsage.list.queryKey(),
+          }),
         ]);
       },
       onError: (error) => {
@@ -910,6 +916,9 @@ export function InferenceProviderSection({
           }),
           queryClient.invalidateQueries({
             queryKey: trpc.githubCopilotSubscription.status.queryKey(),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: trpc.subscriptionUsage.list.queryKey(),
           }),
         ]);
       },
@@ -933,6 +942,9 @@ export function InferenceProviderSection({
           }),
           queryClient.invalidateQueries({
             queryKey: trpc.taskModels.launchOptions.queryKey(),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: trpc.subscriptionUsage.list.queryKey(),
           }),
         ]);
       },

--- a/apps/web/src/components/settings/InferenceProviderSection.tsx
+++ b/apps/web/src/components/settings/InferenceProviderSection.tsx
@@ -12,6 +12,9 @@ import type {
   SetupModelProviderId,
   SetupModelProviderStatus,
   SetupModelStatus,
+  SubscriptionProviderUsage,
+  SubscriptionUsageProviderId,
+  SubscriptionUsageWindow,
 } from '@roomote/types';
 
 import { useTRPC } from '@/trpc/client';
@@ -113,14 +116,86 @@ function getSubmitAdditionalEnvValues(
   );
 }
 
+function formatUsageReset(resetsAt: string): string | null {
+  const reset = new Date(resetsAt).getTime();
+
+  if (Number.isNaN(reset)) {
+    return null;
+  }
+
+  const deltaMinutes = Math.round((reset - Date.now()) / 60_000);
+
+  if (deltaMinutes <= 0) {
+    return null;
+  }
+  if (deltaMinutes < 60) {
+    return `resets in ${deltaMinutes}m`;
+  }
+  if (deltaMinutes < 48 * 60) {
+    return `resets in ${Math.round(deltaMinutes / 60)}h`;
+  }
+
+  return `resets ${new Date(reset).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  })}`;
+}
+
+function formatUsageWindow(window: SubscriptionUsageWindow): string | null {
+  let value: string;
+
+  if (window.unlimited) {
+    value = 'unlimited';
+  } else if (window.remaining !== undefined && window.limit !== undefined) {
+    value = `${window.remaining.toLocaleString()} of ${window.limit.toLocaleString()} left`;
+  } else if (window.usedPercent !== undefined) {
+    value = `${Math.round(window.usedPercent)}% used`;
+  } else {
+    return null;
+  }
+
+  const reset =
+    !window.unlimited && window.resetsAt
+      ? formatUsageReset(window.resetsAt)
+      : null;
+
+  return `${window.label}: ${value}${reset ? ` (${reset})` : ''}`;
+}
+
+function SubscriptionUsageLine({
+  usage,
+  className,
+}: {
+  usage: SubscriptionProviderUsage | undefined;
+  className?: string;
+}) {
+  const parts = (usage?.windows ?? [])
+    .map(formatUsageWindow)
+    .filter((part): part is string => part !== null);
+
+  if (parts.length === 0) {
+    return null;
+  }
+
+  return (
+    <p
+      className={`min-w-0 truncate text-xs text-muted-foreground ${className ?? ''}`}
+    >
+      {parts.join(' · ')}
+    </p>
+  );
+}
+
 function ConnectedProviderRow({
   provider,
+  usage,
   isSaving,
   canDelete,
   onEdit,
   onDelete,
 }: {
   provider: SetupModelProviderStatus;
+  usage?: SubscriptionProviderUsage;
   isSaving: boolean;
   canDelete: boolean;
   onEdit: () => void;
@@ -158,6 +233,7 @@ function ConnectedProviderRow({
             aria-label={`${primaryCredentialLabel} for ${provider.label}`}
             data-1p-ignore
           />
+          <SubscriptionUsageLine usage={usage} className="mt-1" />
         </div>
 
         {hasRuntimeKey ? (
@@ -549,6 +625,7 @@ function ChatGptSubscriptionRow({
   errored,
   accountEmail,
   errorMessage,
+  usage,
   onReconnect,
   onDisconnect,
   isDisconnecting,
@@ -556,6 +633,7 @@ function ChatGptSubscriptionRow({
   errored: boolean;
   accountEmail?: string;
   errorMessage?: string;
+  usage?: SubscriptionProviderUsage;
   onReconnect: () => void;
   onDisconnect: () => Promise<void>;
   isDisconnecting: boolean;
@@ -569,17 +647,20 @@ function ChatGptSubscriptionRow({
       </div>
 
       <div className="flex min-w-0 items-center gap-2">
-        {errored ? (
-          <p className="min-w-0 flex-1 truncate text-sm text-destructive">
-            {errorMessage ?? 'ChatGPT subscription needs to be reconnected.'}
-          </p>
-        ) : (
-          <p className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
-            {accountEmail
-              ? `Connected as ${accountEmail}`
-              : 'Connected to a ChatGPT account.'}
-          </p>
-        )}
+        <div className="min-w-0 flex-1">
+          {errored ? (
+            <p className="min-w-0 truncate text-sm text-destructive">
+              {errorMessage ?? 'ChatGPT subscription needs to be reconnected.'}
+            </p>
+          ) : (
+            <p className="min-w-0 truncate text-sm text-muted-foreground">
+              {accountEmail
+                ? `Connected as ${accountEmail}`
+                : 'Connected to a ChatGPT account.'}
+            </p>
+          )}
+          {!errored ? <SubscriptionUsageLine usage={usage} /> : null}
+        </div>
 
         {errored ? (
           <Button
@@ -608,12 +689,14 @@ function ChatGptSubscriptionRow({
 function GitHubCopilotSubscriptionRow({
   errored,
   errorMessage,
+  usage,
   onReconnect,
   onDisconnect,
   isDisconnecting,
 }: {
   errored: boolean;
   errorMessage?: string;
+  usage?: SubscriptionProviderUsage;
   onReconnect: () => void;
   onDisconnect: () => Promise<void>;
   isDisconnecting: boolean;
@@ -624,13 +707,16 @@ function GitHubCopilotSubscriptionRow({
         {getModelProviderLabel('github-copilot')}
       </span>
       <div className="flex min-w-0 items-center gap-2">
-        <p
-          className={`min-w-0 flex-1 truncate text-sm ${errored ? 'text-destructive' : 'text-muted-foreground'}`}
-        >
-          {errored
-            ? (errorMessage ?? 'GitHub Copilot needs to be reconnected.')
-            : 'Connected to a GitHub Copilot account.'}
-        </p>
+        <div className="min-w-0 flex-1">
+          <p
+            className={`min-w-0 truncate text-sm ${errored ? 'text-destructive' : 'text-muted-foreground'}`}
+          >
+            {errored
+              ? (errorMessage ?? 'GitHub Copilot needs to be reconnected.')
+              : 'Connected to a GitHub Copilot account.'}
+          </p>
+          {!errored ? <SubscriptionUsageLine usage={usage} /> : null}
+        </div>
         {errored ? (
           <Button size="sm" variant="outline" onClick={onReconnect}>
             Reconnect
@@ -724,6 +810,24 @@ export function InferenceProviderSection({
     trpc.githubCopilotSubscription.status.queryOptions(),
   );
   const githubCopilotStatus = githubCopilotStatusQuery.data ?? null;
+
+  // Usage endpoints are unofficial upstream surfaces; a provider missing from
+  // the result just means no usage line is rendered for it.
+  const subscriptionUsageQuery = useQuery(
+    trpc.subscriptionUsage.list.queryOptions(undefined, {
+      staleTime: 60_000,
+    }),
+  );
+  const usageByProvider = useMemo(
+    () =>
+      new Map<SubscriptionUsageProviderId, SubscriptionProviderUsage>(
+        (subscriptionUsageQuery.data ?? []).map((usage) => [
+          usage.providerId,
+          usage,
+        ]),
+      ),
+    [subscriptionUsageQuery.data],
+  );
 
   const saveProvider = useMutation(
     trpc.taskModels.saveProvider.mutationOptions({
@@ -1057,6 +1161,7 @@ export function InferenceProviderSection({
                 errored={chatgptErrored}
                 accountEmail={chatgptStatus?.email}
                 errorMessage={chatgptStatus?.error}
+                usage={usageByProvider.get(CHATGPT_SUBSCRIPTION_PROVIDER_ID)}
                 onReconnect={() => setIsChatGptDialogOpen(true)}
                 onDisconnect={handleDisconnectChatGpt}
                 isDisconnecting={disconnectChatGpt.isPending}
@@ -1066,6 +1171,7 @@ export function InferenceProviderSection({
               <GitHubCopilotSubscriptionRow
                 errored={githubCopilotErrored}
                 errorMessage={githubCopilotStatus?.error}
+                usage={usageByProvider.get('github-copilot')}
                 onReconnect={() => setIsGitHubCopilotDialogOpen(true)}
                 onDisconnect={handleDisconnectGitHubCopilot}
                 isDisconnecting={disconnectGitHubCopilot.isPending}
@@ -1075,6 +1181,11 @@ export function InferenceProviderSection({
               <ConnectedProviderRow
                 key={provider.id}
                 provider={provider}
+                usage={
+                  provider.id === 'kimi-for-coding'
+                    ? usageByProvider.get('kimi-for-coding')
+                    : undefined
+                }
                 isSaving={savingProviderId === provider.id}
                 canDelete={connectedProviderCount > 1}
                 onEdit={() =>

--- a/apps/web/src/trpc/commands/subscription-usage/index.ts
+++ b/apps/web/src/trpc/commands/subscription-usage/index.ts
@@ -1,0 +1,20 @@
+import { getSubscriptionProviderUsage } from '@roomote/db/server';
+import type { SubscriptionProviderUsage } from '@roomote/types';
+
+import type { UserAuthSuccess } from '@/types';
+
+function assertAdmin(auth: UserAuthSuccess): void {
+  if (!auth.isAdmin) throw new Error('Unauthorized');
+}
+
+/**
+ * Usage/quota for connected subscription providers (ChatGPT, GitHub Copilot,
+ * Kimi for Coding). Providers without a configured credential or whose usage
+ * endpoint is unavailable are simply absent from the result.
+ */
+export async function getSubscriptionProviderUsageCommand(
+  auth: UserAuthSuccess,
+): Promise<SubscriptionProviderUsage[]> {
+  assertAdmin(auth);
+  return getSubscriptionProviderUsage();
+}

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -323,6 +323,7 @@ import {
   pollGitHubCopilotDeviceAuthCommand,
   startGitHubCopilotDeviceAuthCommand,
 } from '../commands/github-copilot-subscription';
+import { getSubscriptionProviderUsageCommand } from '../commands/subscription-usage';
 import {
   getRouterDebugSettingsCommand,
   updateRouterDebugSettingsCommand,
@@ -1891,6 +1892,12 @@ export const appRouter = createRouter({
       ),
     disconnect: protectedProcedure.mutation(({ ctx: { auth } }) =>
       disconnectGitHubCopilotSubscriptionCommand(auth),
+    ),
+  }),
+
+  subscriptionUsage: createRouter({
+    list: protectedProcedure.query(({ ctx: { auth } }) =>
+      getSubscriptionProviderUsageCommand(auth),
     ),
   }),
 

--- a/packages/db/src/lib/__tests__/subscription-provider-usage.test.ts
+++ b/packages/db/src/lib/__tests__/subscription-provider-usage.test.ts
@@ -390,7 +390,7 @@ describe('getSubscriptionProviderUsage', () => {
     } as never;
 
     const fetchImpl = vi.fn(async (url: string | URL | Request) => {
-      if (String(url).includes('api.kimi.com')) {
+      if (new URL(String(url)).hostname === 'api.kimi.com') {
         return jsonResponse({
           data: [{ model_name: 'all', limit: 100, used: 10 }],
         });

--- a/packages/db/src/lib/__tests__/subscription-provider-usage.test.ts
+++ b/packages/db/src/lib/__tests__/subscription-provider-usage.test.ts
@@ -1,0 +1,410 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../encryption', () => ({
+  encryptJSON: (value: unknown) => JSON.stringify(value),
+  decryptSecrets: async (value: string) => JSON.parse(value) as unknown,
+}));
+
+import {
+  fetchChatGptUsage,
+  fetchGitHubCopilotUsage,
+  fetchKimiForCodingUsage,
+  getSubscriptionProviderUsage,
+} from '../subscription-provider-usage';
+
+/** Executor whose deployment-secret reads resolve the given rows per call. */
+function makeSecretExecutor(
+  rowsPerCall: Array<Record<string, unknown> | null>,
+) {
+  const limit = vi.fn();
+  for (const row of rowsPerCall) {
+    limit.mockResolvedValueOnce(row ? [{ value: JSON.stringify(row) }] : []);
+  }
+  const where = vi.fn().mockReturnValue({ limit });
+  const from = vi.fn().mockReturnValue({ where });
+  const select = vi.fn().mockReturnValue({ from });
+  return { executor: { select } as never, select };
+}
+
+function jsonResponse(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), { status });
+}
+
+const COPILOT_RECORD = {
+  access: 'gho-token',
+  status: 'connected',
+  connectedAt: '2026-07-01T00:00:00.000Z',
+  updatedAt: '2026-07-01T00:00:00.000Z',
+};
+
+function chatGptRecord() {
+  return {
+    refresh: 'refresh-token',
+    access: 'chatgpt-access',
+    expires: Date.now() + 60 * 60 * 1000,
+    accountId: 'acct-1',
+    status: 'connected',
+    connectedAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+  };
+}
+
+describe('fetchGitHubCopilotUsage', () => {
+  it('normalizes the premium-request quota snapshot', async () => {
+    const { executor } = makeSecretExecutor([COPILOT_RECORD]);
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        quota_snapshots: {
+          premium_interactions: {
+            entitlement: 300,
+            remaining: 211,
+            percent_remaining: 70.33,
+            unlimited: false,
+            overage_count: 0,
+          },
+          chat: { unlimited: true },
+        },
+        quota_reset_date: '2026-08-01',
+      }),
+    );
+
+    const usage = await fetchGitHubCopilotUsage({ executor, fetchImpl });
+
+    expect(usage).toMatchObject({
+      providerId: 'github-copilot',
+      windows: [
+        {
+          label: 'Premium requests',
+          used: 89,
+          remaining: 211,
+          limit: 300,
+        },
+      ],
+    });
+    expect(usage?.windows[0]?.usedPercent).toBeCloseTo(29.67, 2);
+    expect(usage?.windows[0]?.resetsAt).toBe(
+      new Date('2026-08-01').toISOString(),
+    );
+
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.github.com/copilot_internal/user');
+    expect(init.headers).toMatchObject({
+      authorization: 'Bearer gho-token',
+      'editor-version': 'vscode/1.99.3',
+    });
+  });
+
+  it('resolves null without fetching when no subscription is connected', async () => {
+    const { executor } = makeSecretExecutor([null]);
+    const fetchImpl = vi.fn();
+
+    await expect(
+      fetchGitHubCopilotUsage({ executor, fetchImpl }),
+    ).resolves.toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('resolves null on an upstream error or unrecognized payload', async () => {
+    const { executor } = makeSecretExecutor([COPILOT_RECORD, COPILOT_RECORD]);
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({}, 403))
+      .mockResolvedValueOnce(jsonResponse({ unexpected: true }));
+
+    await expect(
+      fetchGitHubCopilotUsage({ executor, fetchImpl }),
+    ).resolves.toBeNull();
+    await expect(
+      fetchGitHubCopilotUsage({ executor, fetchImpl }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe('fetchChatGptUsage', () => {
+  it('normalizes primary/secondary rate-limit windows', async () => {
+    const { executor } = makeSecretExecutor([chatGptRecord()]);
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        plan_type: 'pro',
+        rate_limits: {
+          primary: {
+            used_percent: 12.5,
+            window_minutes: 300,
+            resets_in_seconds: 3600,
+          },
+          secondary: { used_percent: 40, window_minutes: 10080 },
+        },
+      }),
+    );
+
+    const usage = await fetchChatGptUsage({ executor, fetchImpl });
+
+    expect(usage).toMatchObject({
+      providerId: 'chatgpt',
+      planType: 'pro',
+      windows: [
+        { label: '5h limit', usedPercent: 12.5 },
+        { label: 'Weekly limit', usedPercent: 40 },
+      ],
+    });
+    expect(usage?.windows[0]?.resetsAt).toBeDefined();
+
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://chatgpt.com/backend-api/wham/usage');
+    expect(init.headers).toMatchObject({
+      authorization: 'Bearer chatgpt-access',
+      'ChatGPT-Account-Id': 'acct-1',
+    });
+  });
+
+  it('accepts the aliased array payload shape', async () => {
+    const { executor } = makeSecretExecutor([chatGptRecord()]);
+    const resetEpochSeconds = Math.floor(Date.now() / 1000) + 7200;
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        planType: 'plus',
+        rate_limits: [
+          {
+            limit_id: 'codex',
+            primary_window: { usedPercent: 5, limit_window_seconds: 18_000 },
+            secondary_window: { percent_left: 80, reset_at: resetEpochSeconds },
+          },
+        ],
+      }),
+    );
+
+    const usage = await fetchChatGptUsage({ executor, fetchImpl });
+
+    expect(usage).toMatchObject({
+      providerId: 'chatgpt',
+      planType: 'plus',
+      windows: [
+        { label: '5h limit', usedPercent: 5 },
+        { label: 'Weekly limit', usedPercent: 20 },
+      ],
+    });
+    expect(usage?.windows[1]?.resetsAt).toBe(
+      new Date(resetEpochSeconds * 1000).toISOString(),
+    );
+  });
+
+  it('parses the live singular rate_limit payload shape', async () => {
+    // Shape observed from the real endpoint on a Pro plan: a singular
+    // `rate_limit` object with `primary_window` (weekly) and a null
+    // `secondary_window`.
+    const { executor } = makeSecretExecutor([chatGptRecord()]);
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        user_id: 'user-1',
+        plan_type: 'pro',
+        rate_limit: {
+          allowed: true,
+          limit_reached: false,
+          primary_window: {
+            used_percent: 8,
+            limit_window_seconds: 604_800,
+            reset_after_seconds: 481_997,
+            reset_at: 1_784_949_989,
+          },
+          secondary_window: null,
+        },
+        credits: { has_credits: false, unlimited: false, balance: '0' },
+      }),
+    );
+
+    const usage = await fetchChatGptUsage({ executor, fetchImpl });
+
+    expect(usage).toMatchObject({
+      providerId: 'chatgpt',
+      planType: 'pro',
+      windows: [{ label: 'Weekly limit', usedPercent: 8 }],
+    });
+    expect(usage?.windows[0]?.resetsAt).toBe(
+      new Date(1_784_949_989 * 1000).toISOString(),
+    );
+  });
+
+  it('resolves null when no subscription is connected', async () => {
+    const { executor } = makeSecretExecutor([null]);
+    const fetchImpl = vi.fn();
+
+    await expect(
+      fetchChatGptUsage({ executor, fetchImpl }),
+    ).resolves.toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe('fetchKimiForCodingUsage', () => {
+  it('parses the flat data-array payload using the plan-wide summary row', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: [
+          {
+            model_name: 'all',
+            title: 'Weekly',
+            limit: 2048,
+            used: 120,
+            remaining: 1928,
+            reset_time: '2026-07-20T00:00:00Z',
+          },
+          { model_name: 'k3', limit: 1024, used: 60 },
+        ],
+      }),
+    );
+
+    const usage = await fetchKimiForCodingUsage({
+      runtimeEnv: { KIMI_API_KEY: 'sk-kimi-test' },
+      fetchImpl,
+    });
+
+    expect(usage).toMatchObject({
+      providerId: 'kimi-for-coding',
+      windows: [
+        {
+          label: 'Weekly',
+          used: 120,
+          remaining: 1928,
+          limit: 2048,
+          resetsAt: '2026-07-20T00:00:00.000Z',
+        },
+      ],
+    });
+    expect(usage?.windows[0]?.usedPercent).toBeCloseTo(5.86, 1);
+
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.kimi.com/coding/v1/usages');
+    expect(init.headers).toMatchObject({
+      authorization: 'Bearer sk-kimi-test',
+      'x-api-key': 'sk-kimi-test',
+    });
+  });
+
+  it('parses the live windowed payload with string numbers and proto enums', async () => {
+    // Shape observed from the real endpoint: numeric fields are strings,
+    // timeUnit is a proto-style enum, and top-level `usage` is the weekly
+    // plan quota alongside the short-window `limits` entries.
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        user: { userId: 'u-1', membership: { level: 'LEVEL_BASIC' } },
+        usage: {
+          limit: '100',
+          used: '27',
+          remaining: '73',
+          resetTime: '2026-07-25T02:26:20.963457Z',
+        },
+        limits: [
+          {
+            window: { duration: 300, timeUnit: 'TIME_UNIT_MINUTE' },
+            detail: {
+              limit: '100',
+              used: '34',
+              remaining: '66',
+              resetTime: '2026-07-19T13:26:20.963457Z',
+            },
+          },
+        ],
+      }),
+    );
+
+    const usage = await fetchKimiForCodingUsage({
+      runtimeEnv: { KIMI_API_KEY: 'sk-kimi-test' },
+      fetchImpl,
+    });
+
+    expect(usage).toMatchObject({
+      providerId: 'kimi-for-coding',
+      windows: [
+        {
+          label: '5h limit',
+          usedPercent: 34,
+          used: 34,
+          remaining: 66,
+          limit: 100,
+          resetsAt: '2026-07-19T13:26:20.963Z',
+        },
+        {
+          label: 'Weekly limit',
+          usedPercent: 27,
+          used: 27,
+          remaining: 73,
+          limit: 100,
+          resetsAt: '2026-07-25T02:26:20.963Z',
+        },
+      ],
+    });
+  });
+
+  it('falls back to /v1/usage on 404', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('', { status: 404 }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          usage: { limit: 100, used: 30 },
+        }),
+      );
+
+    const usage = await fetchKimiForCodingUsage({
+      runtimeEnv: { KIMI_API_KEY: 'sk-kimi-test' },
+      fetchImpl,
+    });
+
+    expect(fetchImpl.mock.calls.map(([url]) => url)).toEqual([
+      'https://api.kimi.com/coding/v1/usages',
+      'https://api.kimi.com/coding/v1/usage',
+    ]);
+    expect(usage).toMatchObject({
+      providerId: 'kimi-for-coding',
+      windows: [{ label: 'Usage', used: 30, remaining: 70, limit: 100 }],
+    });
+  });
+
+  it('resolves null without fetching when no Kimi key is configured', async () => {
+    const executor = {
+      query: {
+        environmentVariables: { findMany: vi.fn().mockResolvedValue([]) },
+      },
+    } as never;
+    const fetchImpl = vi.fn();
+
+    await expect(
+      fetchKimiForCodingUsage({ executor, fetchImpl, runtimeEnv: {} }),
+    ).resolves.toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe('getSubscriptionProviderUsage', () => {
+  it('keeps working providers when another provider fails', async () => {
+    // The ChatGPT fetcher reads its secret first, then Copilot reads its own.
+    const { executor: secretExecutor } = makeSecretExecutor([
+      null,
+      COPILOT_RECORD,
+    ]);
+    const executor = {
+      ...(secretExecutor as object),
+      query: {
+        environmentVariables: { findMany: vi.fn().mockResolvedValue([]) },
+      },
+    } as never;
+
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      if (String(url).includes('api.kimi.com')) {
+        return jsonResponse({
+          data: [{ model_name: 'all', limit: 100, used: 10 }],
+        });
+      }
+      throw new Error('upstream unavailable');
+    }) as unknown as typeof fetch;
+
+    const usage = await getSubscriptionProviderUsage({
+      executor,
+      fetchImpl,
+      runtimeEnv: { KIMI_API_KEY: 'sk-kimi-test' },
+    });
+
+    expect(usage).toHaveLength(1);
+    expect(usage[0]).toMatchObject({ providerId: 'kimi-for-coding' });
+  });
+});

--- a/packages/db/src/lib/subscription-provider-usage.ts
+++ b/packages/db/src/lib/subscription-provider-usage.ts
@@ -1,0 +1,553 @@
+import {
+  CHATGPT_ACCOUNT_ID_HEADER,
+  CHATGPT_USAGE_ENDPOINT,
+  GITHUB_COPILOT_USAGE_ENDPOINT,
+  KIMI_FOR_CODING_USAGE_ENDPOINTS,
+  type SubscriptionProviderUsage,
+  type SubscriptionUsageWindow,
+} from '@roomote/types';
+
+import { type DatabaseOrTransaction } from '../db';
+import { getFreshChatGptAccessToken } from './chatgpt-subscription';
+import { getGitHubCopilotAccessToken } from './github-copilot-subscription';
+import { resolveModelProviderEnvValue } from './model-runtime-config';
+
+/**
+ * Server-side usage/quota lookups for subscription-style inference providers,
+ * using the same credentials the inference gateway already holds. All three
+ * upstream endpoints are undocumented (each is what the provider's own CLI
+ * polls), so every fetcher parses defensively and resolves to `null` on any
+ * failure — the settings UI omits the usage line rather than erroring.
+ */
+
+const USAGE_FETCH_TIMEOUT_MS = 10_000;
+
+type UsageFetchOptions = {
+  executor?: DatabaseOrTransaction;
+  fetchImpl?: typeof fetch;
+  runtimeEnv?: Partial<Record<string, string | undefined>>;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+/** Kimi's usage payload serializes numbers as strings, so coerce both. */
+function firstNumber(
+  source: Record<string, unknown> | undefined,
+  keys: readonly string[],
+): number | undefined {
+  for (const key of keys) {
+    const value = source?.[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === 'string' && value.trim().length > 0) {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+  return undefined;
+}
+
+function firstString(
+  source: Record<string, unknown> | undefined,
+  keys: readonly string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = source?.[key];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function clampPercent(value: number): number {
+  return Math.min(100, Math.max(0, value));
+}
+
+/** Epoch reset values appear as seconds or milliseconds; ISO strings too. */
+function toResetIso(value: unknown): string | undefined {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    const ms = value > 1e12 ? value : value * 1000;
+    return new Date(ms).toISOString();
+  }
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+  }
+  return undefined;
+}
+
+function resetFromRelativeSeconds(seconds: number | undefined, now: number) {
+  return seconds !== undefined && seconds >= 0
+    ? new Date(now + seconds * 1000).toISOString()
+    : undefined;
+}
+
+async function fetchJson(
+  fetchImpl: typeof fetch,
+  url: string,
+  headers: Record<string, string>,
+): Promise<{ status: number; payload: unknown }> {
+  const response = await fetchImpl(url, {
+    headers,
+    signal: AbortSignal.timeout(USAGE_FETCH_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    return { status: response.status, payload: undefined };
+  }
+
+  try {
+    return { status: response.status, payload: await response.json() };
+  } catch {
+    return { status: response.status, payload: undefined };
+  }
+}
+
+// --- GitHub Copilot -------------------------------------------------------
+
+function parseGitHubCopilotUsage(payload: unknown): SubscriptionUsageWindow[] {
+  const root = asRecord(payload);
+  const premium = asRecord(
+    asRecord(root?.quota_snapshots)?.premium_interactions,
+  );
+
+  if (!premium) {
+    return [];
+  }
+
+  const entitlement = firstNumber(premium, ['entitlement']);
+  const remaining = firstNumber(premium, ['remaining', 'quota_remaining']);
+  const percentRemaining = firstNumber(premium, ['percent_remaining']);
+  const unlimited = premium.unlimited === true;
+  const resetsAt = toResetIso(firstString(root, ['quota_reset_date']));
+
+  const usedPercent =
+    percentRemaining !== undefined
+      ? clampPercent(100 - percentRemaining)
+      : entitlement && remaining !== undefined
+        ? clampPercent(((entitlement - remaining) / entitlement) * 100)
+        : undefined;
+
+  if (!unlimited && usedPercent === undefined && remaining === undefined) {
+    return [];
+  }
+
+  return [
+    {
+      label: 'Premium requests',
+      ...(usedPercent !== undefined && { usedPercent }),
+      ...(entitlement !== undefined &&
+        remaining !== undefined && {
+          used: Math.max(0, Math.round(entitlement - remaining)),
+        }),
+      ...(remaining !== undefined && { remaining: Math.round(remaining) }),
+      ...(entitlement !== undefined && { limit: entitlement }),
+      ...(unlimited && { unlimited }),
+      ...(resetsAt && { resetsAt }),
+    },
+  ];
+}
+
+export async function fetchGitHubCopilotUsage(
+  options: UsageFetchOptions = {},
+): Promise<SubscriptionProviderUsage | null> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const token = await getGitHubCopilotAccessToken(options.executor);
+
+  if (!token) {
+    return null;
+  }
+
+  // Editor headers mirror the OpenCode Copilot plugin whose client id minted
+  // this token; copilot_internal rejects requests it cannot attribute to an
+  // editor integration.
+  const { payload } = await fetchJson(
+    fetchImpl,
+    GITHUB_COPILOT_USAGE_ENDPOINT,
+    {
+      authorization: `Bearer ${token}`,
+      accept: 'application/json',
+      'user-agent': 'GitHubCopilotChat/0.26.7',
+      'editor-version': 'vscode/1.99.3',
+      'editor-plugin-version': 'copilot-chat/0.26.7',
+    },
+  );
+
+  const windows = parseGitHubCopilotUsage(payload);
+
+  if (windows.length === 0) {
+    return null;
+  }
+
+  return {
+    providerId: 'github-copilot',
+    windows,
+    fetchedAt: new Date().toISOString(),
+  };
+}
+
+// --- ChatGPT subscription -------------------------------------------------
+
+function formatWindowLabel(minutes: number | undefined): string | undefined {
+  if (minutes === undefined || minutes <= 0) {
+    return undefined;
+  }
+  if (minutes % 1440 === 0) {
+    const days = minutes / 1440;
+    return days === 7 ? 'Weekly limit' : `${days}d limit`;
+  }
+  if (minutes % 60 === 0) {
+    return `${minutes / 60}h limit`;
+  }
+  return `${minutes}m limit`;
+}
+
+function parseChatGptWindow(
+  window: Record<string, unknown> | undefined,
+  fallbackLabel: string,
+  now: number,
+): SubscriptionUsageWindow | undefined {
+  if (!window) {
+    return undefined;
+  }
+
+  let usedPercent = firstNumber(window, ['used_percent', 'usedPercent']);
+  if (usedPercent === undefined) {
+    const percentLeft = firstNumber(window, [
+      'percent_left',
+      'remaining_percent',
+    ]);
+    if (percentLeft !== undefined) {
+      usedPercent = 100 - percentLeft;
+    }
+  }
+
+  if (usedPercent === undefined) {
+    return undefined;
+  }
+
+  const windowSeconds = firstNumber(window, [
+    'limit_window_seconds',
+    'window_seconds',
+  ]);
+  const windowMinutes =
+    firstNumber(window, [
+      'window_minutes',
+      'window_duration_mins',
+      'windowDurationMins',
+    ]) ?? (windowSeconds !== undefined ? windowSeconds / 60 : undefined);
+
+  const resetsAt =
+    toResetIso(window['resets_at'] ?? window['reset_at']) ??
+    resetFromRelativeSeconds(
+      firstNumber(window, ['resets_in_seconds', 'reset_after_seconds']),
+      now,
+    );
+
+  return {
+    label: formatWindowLabel(windowMinutes) ?? fallbackLabel,
+    usedPercent: clampPercent(usedPercent),
+    ...(resetsAt && { resetsAt }),
+  };
+}
+
+function parseChatGptUsage(
+  payload: unknown,
+  now: number,
+): { planType?: string; windows: SubscriptionUsageWindow[] } {
+  const root = asRecord(payload);
+
+  if (!root) {
+    return { windows: [] };
+  }
+
+  const planType = firstString(root, ['plan_type', 'planType']);
+  // The live endpoint nests windows under singular `rate_limit`; older
+  // payloads used `rate_limits` (object or array of limit entries).
+  const rawRateLimits = root.rate_limits ?? root.rateLimits ?? root.rate_limit;
+  const rateLimits = Array.isArray(rawRateLimits)
+    ? asRecord(
+        rawRateLimits.find((entry) => asRecord(entry)?.limit_id === 'codex') ??
+          rawRateLimits[0],
+      )
+    : asRecord(rawRateLimits);
+
+  const primary = parseChatGptWindow(
+    asRecord(
+      rateLimits?.primary ??
+        rateLimits?.primary_window ??
+        rateLimits?.five_hour,
+    ),
+    '5h limit',
+    now,
+  );
+  const secondary = parseChatGptWindow(
+    asRecord(
+      rateLimits?.secondary ??
+        rateLimits?.secondary_window ??
+        rateLimits?.weekly,
+    ),
+    'Weekly limit',
+    now,
+  );
+
+  return {
+    ...(planType && { planType }),
+    windows: [primary, secondary].filter(
+      (window): window is SubscriptionUsageWindow => window !== undefined,
+    ),
+  };
+}
+
+export async function fetchChatGptUsage(
+  options: UsageFetchOptions = {},
+): Promise<SubscriptionProviderUsage | null> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const fresh = await getFreshChatGptAccessToken({
+    ...(options.executor && { executor: options.executor }),
+    fetchImpl,
+  });
+
+  if (!fresh) {
+    return null;
+  }
+
+  const { payload } = await fetchJson(fetchImpl, CHATGPT_USAGE_ENDPOINT, {
+    authorization: `Bearer ${fresh.access}`,
+    accept: 'application/json',
+    'user-agent': 'roomote',
+    origin: 'https://chatgpt.com',
+    ...(fresh.accountId && { [CHATGPT_ACCOUNT_ID_HEADER]: fresh.accountId }),
+  });
+
+  const { planType, windows } = parseChatGptUsage(payload, Date.now());
+
+  if (windows.length === 0) {
+    return null;
+  }
+
+  return {
+    providerId: 'chatgpt',
+    ...(planType && { planType }),
+    windows,
+    fetchedAt: new Date().toISOString(),
+  };
+}
+
+// --- Kimi for Coding ------------------------------------------------------
+
+const KIMI_LIMIT_KEYS = ['limit', 'limit_amount', 'total'] as const;
+const KIMI_USED_KEYS = ['used', 'used_amount'] as const;
+const KIMI_REMAINING_KEYS = ['remaining', 'remaining_amount'] as const;
+
+function parseKimiEntry(
+  entry: Record<string, unknown> | undefined,
+  label: string,
+  now: number,
+): SubscriptionUsageWindow | undefined {
+  if (!entry) {
+    return undefined;
+  }
+
+  const limit = firstNumber(entry, KIMI_LIMIT_KEYS);
+  let used = firstNumber(entry, KIMI_USED_KEYS);
+  let remaining = firstNumber(entry, KIMI_REMAINING_KEYS);
+
+  if (remaining === undefined && limit !== undefined && used !== undefined) {
+    remaining = limit - used;
+  }
+  if (used === undefined && limit !== undefined && remaining !== undefined) {
+    used = limit - remaining;
+  }
+
+  if (limit === undefined && used === undefined && remaining === undefined) {
+    return undefined;
+  }
+
+  const resetsAt =
+    toResetIso(
+      entry['resetTime'] ?? entry['reset_time'] ?? entry['reset_at'],
+    ) ??
+    resetFromRelativeSeconds(
+      firstNumber(entry, ['reset_in', 'resets_in_seconds']),
+      now,
+    );
+
+  return {
+    label,
+    ...(limit !== undefined &&
+      limit > 0 &&
+      used !== undefined && {
+        usedPercent: clampPercent((used / limit) * 100),
+      }),
+    ...(used !== undefined && { used }),
+    ...(remaining !== undefined && { remaining }),
+    ...(limit !== undefined && { limit }),
+    ...(resetsAt && { resetsAt }),
+  };
+}
+
+function kimiWindowLabel(window: Record<string, unknown> | undefined): string {
+  const duration = firstNumber(window, ['duration']);
+  const timeUnit = firstString(window, ['timeUnit', 'time_unit']);
+
+  if (duration === undefined || !timeUnit) {
+    return 'Usage';
+  }
+
+  const minutesPerUnit: Record<string, number> = {
+    MINUTE: 1,
+    HOUR: 60,
+    DAY: 1440,
+    WEEK: 10080,
+    MONTH: 43200,
+  };
+  // The live API reports proto-style enum values like 'TIME_UNIT_MINUTE'.
+  const normalizedUnit = timeUnit.toUpperCase().replace(/^TIME_UNIT_/, '');
+  const minutes = minutesPerUnit[normalizedUnit];
+
+  return (
+    (minutes !== undefined
+      ? formatWindowLabel(duration * minutes)
+      : undefined) ?? 'Usage'
+  );
+}
+
+function parseKimiForCodingUsage(
+  payload: unknown,
+  now: number,
+): SubscriptionUsageWindow[] {
+  const root = asRecord(payload);
+
+  if (!root) {
+    return [];
+  }
+
+  // Variant A: { data: [{ model_name, limit, used, remaining, ... }] } where
+  // model_name 'all' is the plan-wide summary row.
+  if (Array.isArray(root.data)) {
+    const rows = root.data
+      .map(asRecord)
+      .filter((row): row is Record<string, unknown> => row !== undefined);
+    const summary =
+      rows.find((row) => row.model_name === 'all') ??
+      (rows.length === 1 ? rows[0] : undefined);
+
+    if (summary) {
+      const window = parseKimiEntry(
+        summary,
+        firstString(summary, ['name', 'title']) ?? 'Weekly limit',
+        now,
+      );
+      return window ? [window] : [];
+    }
+
+    return [];
+  }
+
+  // Variant B (the live shape): { usage: {...}, limits: [{ detail, window:
+  // { duration, timeUnit } }] }. `limits` carries the short rate-limit
+  // windows (e.g. 300 minutes); top-level `usage` is the plan quota, which
+  // resets weekly on Kimi for Coding plans.
+  const windows: SubscriptionUsageWindow[] = [];
+
+  if (Array.isArray(root.limits)) {
+    for (const rawLimit of root.limits) {
+      const limitRecord = asRecord(rawLimit);
+      const window = parseKimiEntry(
+        asRecord(limitRecord?.detail) ?? limitRecord,
+        kimiWindowLabel(asRecord(limitRecord?.window)),
+        now,
+      );
+      if (window) {
+        windows.push(window);
+      }
+    }
+  }
+
+  const planUsage = parseKimiEntry(
+    asRecord(root.usage),
+    windows.length > 0 ? 'Weekly limit' : 'Usage',
+    now,
+  );
+  if (planUsage) {
+    windows.push(planUsage);
+  }
+
+  return windows;
+}
+
+export async function fetchKimiForCodingUsage(
+  options: UsageFetchOptions = {},
+): Promise<SubscriptionProviderUsage | null> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const apiKey = await resolveModelProviderEnvValue(['KIMI_API_KEY'], {
+    ...(options.runtimeEnv && { runtimeEnv: options.runtimeEnv }),
+    ...(options.executor && { executor: options.executor }),
+  });
+
+  if (!apiKey) {
+    return null;
+  }
+
+  for (const endpoint of KIMI_FOR_CODING_USAGE_ENDPOINTS) {
+    // Both auth header styles are sent: inference uses x-api-key while the
+    // usage endpoint is known to accept bearer auth. The Kimi CLI user-agent
+    // matches the client this endpoint is built for.
+    const { status, payload } = await fetchJson(fetchImpl, endpoint, {
+      authorization: `Bearer ${apiKey}`,
+      'x-api-key': apiKey,
+      accept: 'application/json',
+      'user-agent': 'KimiCLI/1.6',
+    });
+
+    if (status === 404) {
+      continue;
+    }
+
+    const windows = parseKimiForCodingUsage(payload, Date.now());
+
+    if (windows.length === 0) {
+      return null;
+    }
+
+    return {
+      providerId: 'kimi-for-coding',
+      windows,
+      fetchedAt: new Date().toISOString(),
+    };
+  }
+
+  return null;
+}
+
+// --- Aggregate ------------------------------------------------------------
+
+/**
+ * Fetch usage for every configured subscription provider. Providers that are
+ * not connected, fail to respond, or return an unrecognized payload are
+ * omitted rather than surfaced as errors.
+ */
+export async function getSubscriptionProviderUsage(
+  options: UsageFetchOptions = {},
+): Promise<SubscriptionProviderUsage[]> {
+  const results = await Promise.allSettled([
+    fetchChatGptUsage(options),
+    fetchGitHubCopilotUsage(options),
+    fetchKimiForCodingUsage(options),
+  ]);
+
+  return results.flatMap((result) =>
+    result.status === 'fulfilled' && result.value !== null
+      ? [result.value]
+      : [],
+  );
+}

--- a/packages/db/src/server.ts
+++ b/packages/db/src/server.ts
@@ -62,6 +62,7 @@ export * from './lib/compute-runtime-config';
 export * from './lib/model-runtime-config';
 export * from './lib/chatgpt-subscription';
 export * from './lib/github-copilot-subscription';
+export * from './lib/subscription-provider-usage';
 export * from './lib/preview-runtime-config';
 export * from './lib/out-of-band-task-messages';
 export * from './lib/record-task-kickoff-message';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -48,6 +48,7 @@ export * from './preview-proxy';
 export * from './primitives';
 export * from './provider-retry-notice';
 export * from './provider-usage-workflow-phase';
+export * from './subscription-provider-usage';
 export * from './request-observability';
 export * from './sandbox-server';
 export * from './sandbox-spawn';

--- a/packages/types/src/subscription-provider-usage.ts
+++ b/packages/types/src/subscription-provider-usage.ts
@@ -1,0 +1,65 @@
+/**
+ * Normalized usage/quota data for subscription-style inference providers
+ * (ChatGPT subscription, GitHub Copilot, Kimi for Coding), displayed in the
+ * Models settings page.
+ *
+ * None of the upstream usage endpoints below are officially documented; each
+ * is the endpoint the provider's own CLI or editor plugin polls for its usage
+ * display. Their payload shapes have shifted before, so parsers must stay
+ * tolerant and callers must treat missing usage as a non-error (the UI simply
+ * omits the usage line).
+ */
+
+/** Setup-catalog provider ids that report subscription usage. */
+export type SubscriptionUsageProviderId =
+  | 'chatgpt'
+  | 'github-copilot'
+  | 'kimi-for-coding';
+
+/**
+ * One quota window, e.g. Copilot's monthly premium requests or the Codex
+ * 5-hour/weekly rate-limit windows. Providers report different subsets of
+ * these fields; the UI renders whatever is present.
+ */
+export interface SubscriptionUsageWindow {
+  /** Short display label, e.g. '5h limit', 'Weekly limit', 'Premium requests'. */
+  label: string;
+  /** Percent of the window consumed, 0-100. */
+  usedPercent?: number;
+  used?: number;
+  remaining?: number;
+  limit?: number;
+  unlimited?: boolean;
+  /** ISO timestamp when the window resets. */
+  resetsAt?: string;
+}
+
+export interface SubscriptionProviderUsage {
+  providerId: SubscriptionUsageProviderId;
+  /** Provider-reported plan name (e.g. ChatGPT 'plus'/'pro'), when available. */
+  planType?: string;
+  windows: SubscriptionUsageWindow[];
+  fetchedAt: string;
+}
+
+/**
+ * Internal GitHub endpoint whose `quota_snapshots` field carries the live
+ * premium-request quota; the official billing API only reports lagging
+ * consumption. Same endpoint Copilot editor integrations poll.
+ */
+export const GITHUB_COPILOT_USAGE_ENDPOINT =
+  'https://api.github.com/copilot_internal/user';
+
+/** ChatGPT backend endpoint Codex CLI polls for its /status rate-limit view. */
+export const CHATGPT_USAGE_ENDPOINT =
+  'https://chatgpt.com/backend-api/wham/usage';
+
+/**
+ * Kimi Code (Coding Plan) usage endpoints, as polled by Kimi CLI's /usage
+ * command. Newer deployments serve /v1/usages; older ones only /v1/usage, so
+ * callers try each in order and fall through on 404.
+ */
+export const KIMI_FOR_CODING_USAGE_ENDPOINTS = [
+  'https://api.kimi.com/coding/v1/usages',
+  'https://api.kimi.com/coding/v1/usage',
+] as const;


### PR DESCRIPTION
## What

Adds a usage line under the ChatGPT, GitHub Copilot, and Kimi for Coding provider rows in **Settings > Models**, showing current plan usage such as remaining Copilot premium requests or percent used of the 5-hour and weekly rate-limit windows, with reset times.

## How

- **`packages/types`**: new normalized `SubscriptionProviderUsage` / `SubscriptionUsageWindow` types plus the provider usage endpoint constants.
- **`packages/db`**: `getSubscriptionProviderUsage()` with one fetcher per provider, reusing credentials the deployment already holds:
  - Copilot: `copilot_internal/user` with the stored OAuth token, reading the `premium_interactions` quota snapshot.
  - ChatGPT: `backend-api/wham/usage` via `getFreshChatGptAccessToken()`, so it rides the existing advisory-locked refresh.
  - Kimi for Coding: the Kimi Code usage endpoint with the configured `KIMI_API_KEY`, with a `/v1/usage` fallback on 404.
- **`apps/web`**: admin-gated `subscriptionUsage.list` tRPC query and the usage line rendering in `InferenceProviderSection` (1 minute stale time). Only normalized numbers reach the client, never tokens.
- **`apps/docs`**: short note on the new usage display in `models.mdx`.

## Notes on the upstream endpoints

None of these usage endpoints are officially documented; each is the endpoint the provider's own CLI polls for its usage display. Live payloads were verified against all three providers and differ in places from what third-party tooling documents (ChatGPT now nests windows under a singular `rate_limit` key; Kimi serializes numbers as strings and uses proto-style enum values). Parsers accept the known field aliases, the live shapes are pinned in tests, and any fetch/parse failure resolves to null so the UI omits the usage line rather than erroring. Window labels are derived from the reported window durations rather than hardcoded, so label text survives upstream window changes.

## Testing

- 12 unit tests covering the parsers (documented and live payload shapes), 404 fallback, not-connected short-circuits, and aggregator failure isolation.
- Verified end-to-end against all three live provider APIs on a connected deployment.
- `pnpm lint`, `pnpm check-types`, `pnpm knip`, and the full `packages/db` lib suite pass.