### PR TITLE
Promote v0.14.0 to production

### DIFF
--- a/.changeset/provider-comment-untrusted-framing.md
+++ b/.changeset/provider-comment-untrusted-framing.md
@@ -1,5 +1,0 @@
----
-"@roomote/web": patch
----
-
-Apply the untrusted-content prompt framing to GitLab, Bitbucket, Azure DevOps, and Gitea comment follow-up messages, wrapping the triggering comment in a mention-request block and appending the shared injection-resistance policy

--- a/.changeset/provider-comment-untrusted-framing.md
+++ b/.changeset/provider-comment-untrusted-framing.md
@@ -1,0 +1,5 @@
+---
+"@roomote/web": patch
+---
+
+Apply the untrusted-content prompt framing to GitLab, Bitbucket, Azure DevOps, and Gitea comment follow-up messages, wrapping the triggering comment in a mention-request block and appending the shared injection-resistance policy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This file tracks product releases for Roomote (single monorepo version). Automated release entries are prepended by `pnpm run version`.
 
+## 0.14.0 (2026-07-19)
+
+### Minor changes
+
+- Handle @roomote mentions on GitLab issues (not only merge requests): the first mention starts a linked task and later mentions on the same issue resume that task.
+- Show ChatGPT, GitHub Copilot, and Kimi for Coding plan usage on Settings > Models, including remaining premium requests or rate-limit window percent used and reset times.
+
+### Patch changes
+
+- Apply the untrusted-content prompt framing to GitLab, Bitbucket, Azure DevOps, and Gitea comment follow-up messages, wrapping the triggering comment in a mention-request block and appending the shared injection-resistance policy
+
 ## 0.13.0 (2026-07-19)
 
 ### Minor changes

--- a/apps/api/src/handlers/ado/__tests__/handleComment.test.ts
+++ b/apps/api/src/handlers/ado/__tests__/handleComment.test.ts
@@ -20,9 +20,16 @@ const {
   mockSteerMessageToTask: vi.fn(),
 }));
 
+// Prompt-framing fakes use distinctive markers so tests can assert the
+// handler routes each piece of text through the right builder; the real
+// escaping/wrapping behavior is unit-tested in @roomote/cloud-agents.
 vi.mock('@roomote/cloud-agents/server', () => ({
   enqueueTask: mockEnqueueTask,
   getTaskUrl: mockGetTaskUrl,
+  buildMentionRequestBlock: (text: string) =>
+    `<mention_request>${text}</mention_request>`,
+  buildUntrustedContentPolicy: () => '<untrusted_content_policy/>',
+  escapeTaskContextText: (value: string) => value,
 }));
 
 vi.mock('@roomote/ado', () => ({
@@ -354,8 +361,15 @@ describe('handleAdoComment', () => {
       expect.objectContaining({
         taskId: 'task-existing',
         userId: 'user-1',
-        message: expect.stringContaining('mentioned Roomote in a comment'),
+        message: expect.stringContaining(
+          '<mention_request>@roomote please review this</mention_request>',
+        ),
         senderMode: 'github_pr_follow_up',
+      }),
+    );
+    expect(mockSteerMessageToTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('<untrusted_content_policy/>'),
       }),
     );
     expect(mockEnqueueTask).not.toHaveBeenCalled();

--- a/apps/api/src/handlers/ado/handleComment.ts
+++ b/apps/api/src/handlers/ado/handleComment.ts
@@ -1,4 +1,10 @@
-import { enqueueTask, getTaskUrl } from '@roomote/cloud-agents/server';
+import {
+  buildMentionRequestBlock,
+  buildUntrustedContentPolicy,
+  enqueueTask,
+  escapeTaskContextText,
+  getTaskUrl,
+} from '@roomote/cloud-agents/server';
 import {
   findActiveGitHubPrReviewTask,
   findReusableGitHubPrFollowUpOwner,
@@ -207,14 +213,6 @@ function buildTaskStartFailedComment(): string {
   return 'I saw the mention, but I could not start a task for this pull request right now. Please try again in a moment.';
 }
 
-function formatQuotedText(text: string): string {
-  return text
-    .trim()
-    .split('\n')
-    .map((line) => `> ${line}`)
-    .join('\n');
-}
-
 function buildExistingTaskFollowUpMessage({
   repoFullName,
   pullRequest,
@@ -227,8 +225,7 @@ function buildExistingTaskFollowUpMessage({
   commentBody: string;
 }): string {
   const lines = [
-    `${commenter} mentioned Roomote in a comment on Azure DevOps pull request #${pullRequest.pullRequestId} (${pullRequest.title}) in ${repoFullName}:`,
-    formatQuotedText(commentBody),
+    `${commenter} mentioned Roomote in a comment on Azure DevOps pull request #${pullRequest.pullRequestId} (${escapeTaskContextText(pullRequest.title)}) in ${repoFullName}.`,
     '',
     'Please act on this comment as a follow-up to your existing work on this pull request.',
   ];
@@ -237,6 +234,14 @@ function buildExistingTaskFollowUpMessage({
   if (branchName) {
     lines.push(`The pull request source branch is \`${branchName}\`.`);
   }
+
+  lines.push(
+    '',
+    'Mention comment (the request to act on):',
+    buildMentionRequestBlock(commentBody),
+    '',
+    buildUntrustedContentPolicy(),
+  );
 
   return lines.join('\n');
 }

--- a/apps/api/src/handlers/bitbucket/__tests__/handleComment.test.ts
+++ b/apps/api/src/handlers/bitbucket/__tests__/handleComment.test.ts
@@ -4,15 +4,30 @@ const {
   mockCreateBitbucketPullRequestComment,
   mockGetBitbucketAutomationTargets,
   mockEnqueueTask,
+  mockFindActiveGitHubPrReviewTask,
+  mockFindReusableGitHubPrFollowUpOwner,
+  mockSendMessageToTask,
+  mockSteerMessageToTask,
 } = vi.hoisted(() => ({
   mockCreateBitbucketPullRequestComment: vi.fn(),
   mockGetBitbucketAutomationTargets: vi.fn(),
   mockEnqueueTask: vi.fn(),
+  mockFindActiveGitHubPrReviewTask: vi.fn(),
+  mockFindReusableGitHubPrFollowUpOwner: vi.fn(),
+  mockSendMessageToTask: vi.fn(),
+  mockSteerMessageToTask: vi.fn(),
 }));
 
+// Prompt-framing fakes use distinctive markers so tests can assert the
+// handler routes each piece of text through the right builder; the real
+// escaping/wrapping behavior is unit-tested in @roomote/cloud-agents.
 vi.mock('@roomote/cloud-agents/server', () => ({
   enqueueTask: mockEnqueueTask,
   getTaskUrl: vi.fn(),
+  buildMentionRequestBlock: (text: string) =>
+    `<mention_request>${text}</mention_request>`,
+  buildUntrustedContentPolicy: () => '<untrusted_content_policy/>',
+  escapeTaskContextText: (value: string) => value,
 }));
 
 vi.mock('@roomote/bitbucket', () => ({
@@ -24,10 +39,15 @@ vi.mock('@roomote/db/server', async (importOriginal) => {
 
   return {
     ...actual,
-    findActiveGitHubPrReviewTask: vi.fn(),
-    findReusableGitHubPrFollowUpOwner: vi.fn(),
+    findActiveGitHubPrReviewTask: mockFindActiveGitHubPrReviewTask,
+    findReusableGitHubPrFollowUpOwner: mockFindReusableGitHubPrFollowUpOwner,
   };
 });
+
+vi.mock('../../tasks/sendMessageToTask', () => ({
+  sendMessageToTask: mockSendMessageToTask,
+  steerMessageToTask: mockSteerMessageToTask,
+}));
 
 vi.mock('../getBitbucketAutomationTargets', async () => {
   const actual = await vi.importActual<
@@ -39,6 +59,8 @@ vi.mock('../getBitbucketAutomationTargets', async () => {
     getBitbucketAutomationTargets: mockGetBitbucketAutomationTargets,
   };
 });
+
+import { RunStatus } from '@roomote/types';
 
 import { handleBitbucketComment } from '../handleComment';
 import type { BitbucketPullRequestCommentWebhook } from '../types';
@@ -74,12 +96,18 @@ describe('handleBitbucketComment', () => {
     mockCreateBitbucketPullRequestComment.mockReset();
     mockGetBitbucketAutomationTargets.mockReset();
     mockEnqueueTask.mockReset();
+    mockFindActiveGitHubPrReviewTask.mockReset();
+    mockFindReusableGitHubPrFollowUpOwner.mockReset();
+    mockSendMessageToTask.mockReset();
+    mockSteerMessageToTask.mockReset();
 
     mockGetBitbucketAutomationTargets.mockResolvedValue({
       status: 'error',
       code: 'account_link_required',
       message: 'Bitbucket user alice is not linked',
     });
+    mockFindActiveGitHubPrReviewTask.mockResolvedValue(null);
+    mockFindReusableGitHubPrFollowUpOwner.mockResolvedValue(null);
   });
 
   it('propagates a failed account-link response so the webhook is recorded as failed', async () => {
@@ -157,6 +185,55 @@ describe('handleBitbucketComment', () => {
     ).resolves.toEqual({ status: 'ok', message: 'account_link_required' });
 
     expect(mockCreateBitbucketPullRequestComment).toHaveBeenCalledOnce();
+  });
+
+  it('routes mentions into a reusable active task with untrusted-content framing', async () => {
+    mockGetBitbucketAutomationTargets.mockResolvedValue({
+      status: 'ok',
+      targets: [
+        {
+          id: 'bitbucket:pr_review:repo-1',
+          workflow: 'pr_review',
+          settings: null,
+          repo: {
+            id: 'repo-1',
+            host: 'bitbucket.org',
+          },
+          repositoryIds: ['repo-1'],
+          userId: 'user-1',
+        },
+      ],
+    });
+    mockFindReusableGitHubPrFollowUpOwner.mockResolvedValue({
+      taskId: 'task-existing',
+      status: RunStatus.Running,
+      taskPhase: 'running',
+    });
+    mockSteerMessageToTask.mockResolvedValue({ success: true, result: {} });
+    mockCreateBitbucketPullRequestComment.mockResolvedValue({ id: 7 });
+
+    const result = await handleBitbucketComment(
+      makeCommentPayload(),
+      'pullrequest:comment_created',
+    );
+
+    expect(result).toEqual({ status: 'ok', message: 'active_pr_owner_routed' });
+    expect(mockSteerMessageToTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: 'task-existing',
+        userId: 'user-1',
+        message: expect.stringContaining(
+          '<mention_request>@roomote review this please</mention_request>',
+        ),
+        senderMode: 'github_pr_follow_up',
+      }),
+    );
+    expect(mockSteerMessageToTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('<untrusted_content_policy/>'),
+      }),
+    );
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
   it('logs enqueue failures and posts a queue-specific response', async () => {

--- a/apps/api/src/handlers/bitbucket/handleComment.ts
+++ b/apps/api/src/handlers/bitbucket/handleComment.ts
@@ -1,4 +1,10 @@
-import { enqueueTask, getTaskUrl } from '@roomote/cloud-agents/server';
+import {
+  buildMentionRequestBlock,
+  buildUntrustedContentPolicy,
+  enqueueTask,
+  escapeTaskContextText,
+  getTaskUrl,
+} from '@roomote/cloud-agents/server';
 import {
   findActiveGitHubPrReviewTask,
   findReusableGitHubPrFollowUpOwner,
@@ -141,14 +147,6 @@ function buildTaskStartFailedComment(): string {
   return 'I saw the mention, but Roomote could not queue a review task for this pull request. Please try again in a moment. If it keeps failing, an administrator should check the deployment logs.';
 }
 
-function formatQuotedText(text: string): string {
-  return text
-    .trim()
-    .split('\n')
-    .map((line) => `> ${line}`)
-    .join('\n');
-}
-
 function buildExistingTaskFollowUpMessage({
   repoFullName,
   pullRequestNumber,
@@ -165,8 +163,7 @@ function buildExistingTaskFollowUpMessage({
   commentBody: string;
 }): string {
   const lines = [
-    `${commenter} mentioned Roomote in a comment on Bitbucket pull request #${pullRequestNumber} (${pullRequestTitle}) in ${repoFullName}:`,
-    formatQuotedText(commentBody),
+    `${commenter} mentioned Roomote in a comment on Bitbucket pull request #${pullRequestNumber} (${escapeTaskContextText(pullRequestTitle)}) in ${repoFullName}.`,
     '',
     'Please act on this comment as a follow-up to your existing work on this pull request.',
   ];
@@ -174,6 +171,14 @@ function buildExistingTaskFollowUpMessage({
   if (headRef) {
     lines.push(`The pull request source branch is \`${headRef}\`.`);
   }
+
+  lines.push(
+    '',
+    'Mention comment (the request to act on):',
+    buildMentionRequestBlock(commentBody),
+    '',
+    buildUntrustedContentPolicy(),
+  );
 
   return lines.join('\n');
 }

--- a/apps/api/src/handlers/gitea/__tests__/handleComment.test.ts
+++ b/apps/api/src/handlers/gitea/__tests__/handleComment.test.ts
@@ -20,9 +20,16 @@ const {
   mockSteerMessageToTask: vi.fn(),
 }));
 
+// Prompt-framing fakes use distinctive markers so tests can assert the
+// handler routes each piece of text through the right builder; the real
+// escaping/wrapping behavior is unit-tested in @roomote/cloud-agents.
 vi.mock('@roomote/cloud-agents/server', () => ({
   enqueueTask: mockEnqueueTask,
   getTaskUrl: mockGetTaskUrl,
+  buildMentionRequestBlock: (text: string) =>
+    `<mention_request>${text}</mention_request>`,
+  buildUntrustedContentPolicy: () => '<untrusted_content_policy/>',
+  escapeTaskContextText: (value: string) => value,
 }));
 
 vi.mock('@roomote/gitea', () => ({
@@ -279,7 +286,14 @@ describe('handleGiteaComment', () => {
       expect.objectContaining({
         taskId: 'task-existing',
         userId: 'user-1',
-        message: expect.stringContaining('mentioned Roomote in a comment'),
+        message: expect.stringContaining(
+          '<mention_request>@roomote please review this</mention_request>',
+        ),
+      }),
+    );
+    expect(mockSteerMessageToTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('<untrusted_content_policy/>'),
       }),
     );
     expect(mockEnqueueTask).not.toHaveBeenCalled();

--- a/apps/api/src/handlers/gitea/handleComment.ts
+++ b/apps/api/src/handlers/gitea/handleComment.ts
@@ -1,4 +1,10 @@
-import { enqueueTask, getTaskUrl } from '@roomote/cloud-agents/server';
+import {
+  buildMentionRequestBlock,
+  buildUntrustedContentPolicy,
+  enqueueTask,
+  escapeTaskContextText,
+  getTaskUrl,
+} from '@roomote/cloud-agents/server';
 import {
   findActiveGitHubPrReviewTask,
   findReusableGitHubPrFollowUpOwner,
@@ -184,14 +190,6 @@ function buildTaskStartFailedComment(): string {
   return 'I saw the mention, but I could not start a task for this pull request right now. Please try again in a moment.';
 }
 
-function formatQuotedText(text: string): string {
-  return text
-    .trim()
-    .split('\n')
-    .map((line) => `> ${line}`)
-    .join('\n');
-}
-
 function buildExistingTaskFollowUpMessage({
   repoFullName,
   pullRequest,
@@ -204,8 +202,7 @@ function buildExistingTaskFollowUpMessage({
   commentBody: string;
 }): string {
   const lines = [
-    `${commenter} mentioned Roomote in a comment on Gitea pull request #${pullRequest.number} (${pullRequest.title}) in ${repoFullName}:`,
-    formatQuotedText(commentBody),
+    `${commenter} mentioned Roomote in a comment on Gitea pull request #${pullRequest.number} (${escapeTaskContextText(pullRequest.title)}) in ${repoFullName}.`,
     '',
     'Please act on this comment as a follow-up to your existing work on this pull request.',
   ];
@@ -215,6 +212,14 @@ function buildExistingTaskFollowUpMessage({
       `The pull request source branch is \`${pullRequest.head.ref}\`.`,
     );
   }
+
+  lines.push(
+    '',
+    'Mention comment (the request to act on):',
+    buildMentionRequestBlock(commentBody),
+    '',
+    buildUntrustedContentPolicy(),
+  );
 
   return lines.join('\n');
 }

--- a/apps/api/src/handlers/gitlab/__tests__/handleNote.test.ts
+++ b/apps/api/src/handlers/gitlab/__tests__/handleNote.test.ts
@@ -26,6 +26,9 @@ const {
   mockDbSelect: vi.fn(),
 }));
 
+// Prompt-framing fakes use distinctive markers so tests can assert the
+// handler routes each piece of text through the right builder; the real
+// escaping/wrapping behavior is unit-tested in @roomote/cloud-agents.
 vi.mock('@roomote/cloud-agents/server', () => ({
   enqueueTask: mockEnqueueTask,
   getTaskUrl: mockGetTaskUrl,
@@ -372,7 +375,15 @@ describe('handleGitLabNote', () => {
       expect.objectContaining({
         taskId: 'owner-task',
         userId: 'user-1',
+        message: expect.stringContaining(
+          '<mention_request>Hey @roomote please take a look</mention_request>',
+        ),
         senderMode: 'github_pr_follow_up',
+      }),
+    );
+    expect(mockSteerMessageToTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('<untrusted_content_policy/>'),
       }),
     );
     expect(mockEnqueueTask).not.toHaveBeenCalled();

--- a/apps/api/src/handlers/gitlab/__tests__/handleNote.test.ts
+++ b/apps/api/src/handlers/gitlab/__tests__/handleNote.test.ts
@@ -3,36 +3,65 @@ const {
   mockGetTaskUrl,
   mockGetGitLabAutomationTargets,
   mockFindReusableGitHubPrFollowUpOwner,
+  mockFindReusableGitHubIssueTaskOwner,
   mockFindActiveGitHubPrReviewTask,
   mockGetGitLabDeploymentUser,
   mockCreateGitLabMergeRequestNote,
+  mockCreateGitLabIssueNote,
   mockSendMessageToTask,
   mockSteerMessageToTask,
+  mockDbSelect,
 } = vi.hoisted(() => ({
   mockEnqueueTask: vi.fn(),
   mockGetTaskUrl: vi.fn(),
   mockGetGitLabAutomationTargets: vi.fn(),
   mockFindReusableGitHubPrFollowUpOwner: vi.fn(),
+  mockFindReusableGitHubIssueTaskOwner: vi.fn(),
   mockFindActiveGitHubPrReviewTask: vi.fn(),
   mockGetGitLabDeploymentUser: vi.fn(),
   mockCreateGitLabMergeRequestNote: vi.fn(),
+  mockCreateGitLabIssueNote: vi.fn(),
   mockSendMessageToTask: vi.fn(),
   mockSteerMessageToTask: vi.fn(),
+  mockDbSelect: vi.fn(),
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
   enqueueTask: mockEnqueueTask,
   getTaskUrl: mockGetTaskUrl,
+  buildMentionRequestBlock: (text: string) =>
+    `<mention_request>${text}</mention_request>`,
+  buildUntrustedExternalContentBlock: ({
+    source,
+    text,
+  }: {
+    source: string;
+    text: string;
+  }) =>
+    `<untrusted_external_content source="${source}">${text}</untrusted_external_content>`,
+  buildUntrustedContentPolicy: () => '<untrusted_content_policy/>',
+  escapeTaskContextText: (value: string) => value,
 }));
 
 vi.mock('@roomote/db/server', () => ({
+  db: {
+    select: mockDbSelect,
+  },
+  environmentRepositoryMappings: {
+    environmentId: 'environmentId',
+    repositoryId: 'repositoryId',
+  },
+  eq: vi.fn((...args: unknown[]) => args),
+  asc: vi.fn((value: unknown) => value),
   findReusableGitHubPrFollowUpOwner: mockFindReusableGitHubPrFollowUpOwner,
+  findReusableGitHubIssueTaskOwner: mockFindReusableGitHubIssueTaskOwner,
   findActiveGitHubPrReviewTask: mockFindActiveGitHubPrReviewTask,
 }));
 
 vi.mock('@roomote/gitlab', () => ({
   getGitLabDeploymentUser: mockGetGitLabDeploymentUser,
   createGitLabMergeRequestNote: mockCreateGitLabMergeRequestNote,
+  createGitLabIssueNote: mockCreateGitLabIssueNote,
 }));
 
 vi.mock('../getGitLabAutomationTargets', async () => {
@@ -59,11 +88,14 @@ function makeNotePayload(
   overrides: {
     note?: Partial<GitLabNoteWebhook['object_attributes']>;
     mergeRequest?: Partial<NonNullable<GitLabNoteWebhook['merge_request']>>;
+    issue?: Partial<NonNullable<GitLabNoteWebhook['issue']>>;
     user?: GitLabNoteWebhook['user'];
     includeMergeRequest?: boolean;
+    includeIssue?: boolean;
   } = {},
 ): GitLabNoteWebhook {
   const includeMergeRequest = overrides.includeMergeRequest ?? true;
+  const includeIssue = overrides.includeIssue ?? false;
 
   return {
     object_kind: 'note',
@@ -77,7 +109,7 @@ function makeNotePayload(
     object_attributes: {
       id: 555,
       note: 'Hey @roomote please take a look',
-      noteable_type: 'MergeRequest',
+      noteable_type: includeIssue ? 'Issue' : 'MergeRequest',
       action: 'create',
       ...overrides.note,
     },
@@ -94,6 +126,17 @@ function makeNotePayload(
           },
         }
       : {}),
+    ...(includeIssue
+      ? {
+          issue: {
+            iid: 17,
+            title: 'Broken login',
+            description: 'Repro steps for the crash',
+            url: 'https://gitlab.com/acme/backend/-/issues/17',
+            ...overrides.issue,
+          },
+        }
+      : {}),
   };
 }
 
@@ -103,11 +146,14 @@ describe('handleGitLabNote', () => {
     mockGetTaskUrl.mockReset();
     mockGetGitLabAutomationTargets.mockReset();
     mockFindReusableGitHubPrFollowUpOwner.mockReset();
+    mockFindReusableGitHubIssueTaskOwner.mockReset();
     mockFindActiveGitHubPrReviewTask.mockReset();
     mockGetGitLabDeploymentUser.mockReset();
     mockCreateGitLabMergeRequestNote.mockReset();
+    mockCreateGitLabIssueNote.mockReset();
     mockSendMessageToTask.mockReset();
     mockSteerMessageToTask.mockReset();
+    mockDbSelect.mockReset();
 
     mockGetGitLabAutomationTargets.mockResolvedValue({
       status: 'ok',
@@ -122,14 +168,25 @@ describe('handleGitLabNote', () => {
       ],
     });
     mockFindReusableGitHubPrFollowUpOwner.mockResolvedValue(null);
+    mockFindReusableGitHubIssueTaskOwner.mockResolvedValue(null);
     mockFindActiveGitHubPrReviewTask.mockResolvedValue(null);
     mockGetGitLabDeploymentUser.mockResolvedValue({
       id: 99,
       username: 'roomote-bot',
     });
     mockCreateGitLabMergeRequestNote.mockResolvedValue({ id: 1 });
+    mockCreateGitLabIssueNote.mockResolvedValue({ id: 2 });
     mockEnqueueTask.mockResolvedValue({ id: 1234, taskId: 'task-1' });
     mockGetTaskUrl.mockReturnValue('https://app.roomote.dev/task/task-1');
+    mockSendMessageToTask.mockResolvedValue({ success: true, result: {} });
+    mockSteerMessageToTask.mockResolvedValue({ success: true, result: {} });
+    mockDbSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockResolvedValue([{ environmentId: 'env-1' }]),
+        }),
+      }),
+    });
   });
 
   it('enqueues a GitLab MR review task when a mention has no reusable owner', async () => {
@@ -432,17 +489,18 @@ describe('handleGitLabNote', () => {
     expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 
-  it('ignores notes on non-merge-request targets', async () => {
+  it('ignores notes on unsupported targets', async () => {
     const result = await handleGitLabNote(
       makeNotePayload({
-        note: { noteable_type: 'Issue' },
+        note: { noteable_type: 'Commit' },
         includeMergeRequest: false,
+        includeIssue: false,
       }),
     );
 
     expect(result).toEqual({
       status: 'ok',
-      message: 'unsupported_noteable_type:Issue',
+      message: 'unsupported_noteable_type:Commit',
     });
     expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
@@ -489,5 +547,230 @@ describe('handleGitLabNote', () => {
     expect(mockGetGitLabAutomationTargets).toHaveBeenCalledWith(
       expect.objectContaining({ ignoreAuthorPolicy: true }),
     );
+  });
+
+  it('starts a standard task for a first @roomote mention on an issue', async () => {
+    const result = await handleGitLabNote(
+      makeNotePayload({
+        includeMergeRequest: false,
+        includeIssue: true,
+      }),
+    );
+
+    expect(result).toEqual({ status: 'ok', metadata: { ids: [1234] } });
+    expect(mockGetGitLabAutomationTargets).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflow: 'pr_conflict_resolve',
+        requireLinkedSenderAccount: true,
+        ignoreAuthorPolicy: true,
+      }),
+    );
+    expect(mockFindReusableGitHubIssueTaskOwner).toHaveBeenCalledWith({
+      repoFullName: 'acme/backend',
+      issueNumber: 17,
+      sourceControlProvider: 'gitlab',
+      host: null,
+    });
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          type: TaskPayloadKind.StandardTask,
+          payload: expect.objectContaining({
+            repo: 'acme/backend',
+            sourceControlProvider: 'gitlab',
+            environmentId: 'env-1',
+            selectedRepositories: ['acme/backend'],
+            linkedWorkItems: [
+              expect.objectContaining({
+                provider: 'gitlab',
+                identifier: '17',
+                repository: 'acme/backend',
+                url: 'https://gitlab.com/acme/backend/-/issues/17',
+                title: 'Broken login',
+              }),
+            ],
+          }),
+        }),
+        initiator: { kind: 'user', userId: 'user-1' },
+        workflow: 'standard',
+        surface: 'gitlab',
+        trigger: 'message',
+      }),
+    );
+    const description = mockEnqueueTask.mock.calls[0]?.[0].task.payload
+      .description as string;
+    expect(description).toContain(
+      '<mention_request>Hey @roomote please take a look</mention_request>',
+    );
+    expect(description).toContain(
+      '<untrusted_external_content source="gitlab_issue_description">Repro steps for the crash</untrusted_external_content>',
+    );
+    expect(description).toContain('<untrusted_content_policy/>');
+    expect(mockCreateGitLabIssueNote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 123,
+        issueIid: 17,
+        body: expect.stringContaining('started a task for this issue'),
+      }),
+    );
+    expect(mockCreateGitLabMergeRequestNote).not.toHaveBeenCalled();
+  });
+
+  it('threads the repository host into issue reuse lookup and launch payloads', async () => {
+    mockGetGitLabAutomationTargets.mockResolvedValue({
+      status: 'ok',
+      targets: [
+        {
+          id: 'gitlab:pr_conflict_resolve:repo-1',
+          settings: null,
+          repo: { id: 'repo-1', host: 'gitlab.example.com' },
+          repositoryIds: ['repo-1'],
+          userId: 'user-1',
+        },
+      ],
+    });
+
+    await handleGitLabNote(
+      makeNotePayload({
+        includeMergeRequest: false,
+        includeIssue: true,
+      }),
+    );
+
+    expect(mockFindReusableGitHubIssueTaskOwner).toHaveBeenCalledWith({
+      repoFullName: 'acme/backend',
+      issueNumber: 17,
+      sourceControlProvider: 'gitlab',
+      host: 'gitlab.example.com',
+    });
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            sourceControlHost: 'gitlab.example.com',
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('routes a second issue @mention into the existing issue task', async () => {
+    mockFindReusableGitHubIssueTaskOwner.mockResolvedValue({
+      taskId: 'issue-task',
+      runId: 8,
+      type: TaskPayloadKind.StandardTask,
+      status: RunStatus.Running,
+      taskPhase: 'running',
+      delivery: 'attach',
+    });
+    mockGetTaskUrl.mockReturnValue('https://app.roomote.dev/task/issue-task');
+
+    const result = await handleGitLabNote(
+      makeNotePayload({
+        includeMergeRequest: false,
+        includeIssue: true,
+        note: { note: '@roomote also fix the tests' },
+      }),
+    );
+
+    expect(result).toEqual({
+      status: 'ok',
+      message: 'active_issue_owner_routed',
+    });
+    expect(mockSteerMessageToTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: 'issue-task',
+        userId: 'user-1',
+        message: expect.stringContaining(
+          '<mention_request>@roomote also fix the tests</mention_request>',
+        ),
+        senderMode: 'github_pr_follow_up',
+      }),
+    );
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
+    expect(mockCreateGitLabIssueNote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('existing task for this issue'),
+      }),
+    );
+  });
+
+  it('resumes an idle issue owner on a second mention', async () => {
+    mockFindReusableGitHubIssueTaskOwner.mockResolvedValue({
+      taskId: 'issue-task',
+      runId: 8,
+      type: TaskPayloadKind.StandardTask,
+      status: RunStatus.Idle,
+      taskPhase: 'waiting_for_prompt',
+      delivery: 'attach',
+    });
+
+    const result = await handleGitLabNote(
+      makeNotePayload({
+        includeMergeRequest: false,
+        includeIssue: true,
+      }),
+    );
+
+    expect(result).toEqual({
+      status: 'ok',
+      message: 'active_issue_owner_routed',
+    });
+    expect(mockSendMessageToTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: 'issue-task',
+        userId: 'user-1',
+      }),
+    );
+    expect(mockSteerMessageToTask).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
+  });
+
+  it('requires a mapped environment before starting an issue task', async () => {
+    mockDbSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    });
+
+    const result = await handleGitLabNote(
+      makeNotePayload({
+        includeMergeRequest: false,
+        includeIssue: true,
+      }),
+    );
+
+    expect(result).toEqual({ status: 'ok', message: 'environment_required' });
+    expect(mockCreateGitLabIssueNote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('environment is mapped'),
+      }),
+    );
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
+  });
+
+  it('prompts account linking on issue mentions when the sender is unlinked', async () => {
+    mockGetGitLabAutomationTargets.mockResolvedValue({
+      status: 'error',
+      code: 'account_link_required',
+      message: 'GitLab user alice is not linked',
+    });
+
+    const result = await handleGitLabNote(
+      makeNotePayload({
+        includeMergeRequest: false,
+        includeIssue: true,
+      }),
+    );
+
+    expect(result).toEqual({ status: 'ok', message: 'account_link_required' });
+    expect(mockCreateGitLabIssueNote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('GitLab account linked'),
+      }),
+    );
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/handlers/gitlab/handleNote.ts
+++ b/apps/api/src/handlers/gitlab/handleNote.ts
@@ -229,14 +229,6 @@ function buildTaskStartFailedNote(surface: 'merge request' | 'issue'): string {
   return `I saw the mention, but I could not start a task for this ${surface} right now. Please try again in a moment.`;
 }
 
-function formatQuotedText(text: string): string {
-  return text
-    .trim()
-    .split('\n')
-    .map((line) => `> ${line}`)
-    .join('\n');
-}
-
 function buildExistingMrTaskFollowUpMessage({
   repoFullName,
   mergeRequest,
@@ -249,8 +241,7 @@ function buildExistingMrTaskFollowUpMessage({
   noteBody: string;
 }): string {
   const lines = [
-    `${commenter} mentioned Roomote in a comment on GitLab merge request !${mergeRequest.iid} (${mergeRequest.title}) in ${repoFullName}:`,
-    formatQuotedText(noteBody),
+    `${commenter} mentioned Roomote in a comment on GitLab merge request !${mergeRequest.iid} (${escapeTaskContextText(mergeRequest.title)}) in ${repoFullName}.`,
     '',
     'Please act on this comment as a follow-up to your existing work on this merge request.',
   ];
@@ -260,6 +251,14 @@ function buildExistingMrTaskFollowUpMessage({
       `The merge request source branch is \`${mergeRequest.source_branch}\`.`,
     );
   }
+
+  lines.push(
+    '',
+    'Mention comment (the request to act on):',
+    buildMentionRequestBlock(noteBody),
+    '',
+    buildUntrustedContentPolicy(),
+  );
 
   return lines.join('\n');
 }

--- a/apps/api/src/handlers/gitlab/handleNote.ts
+++ b/apps/api/src/handlers/gitlab/handleNote.ts
@@ -1,9 +1,22 @@
-import { enqueueTask, getTaskUrl } from '@roomote/cloud-agents/server';
 import {
+  buildMentionRequestBlock,
+  buildUntrustedContentPolicy,
+  buildUntrustedExternalContentBlock,
+  enqueueTask,
+  escapeTaskContextText,
+  getTaskUrl,
+} from '@roomote/cloud-agents/server';
+import {
+  db,
+  environmentRepositoryMappings,
+  eq,
+  asc,
   findActiveGitHubPrReviewTask,
+  findReusableGitHubIssueTaskOwner,
   findReusableGitHubPrFollowUpOwner,
 } from '@roomote/db/server';
 import {
+  createGitLabIssueNote,
   createGitLabMergeRequestNote,
   getGitLabDeploymentUser,
 } from '@roomote/gitlab';
@@ -23,7 +36,10 @@ import {
   getGitLabAutomationTargets,
   isRoomoteGitLabUsername,
 } from './getGitLabAutomationTargets';
-import { buildSourceControlAccountLinkRequiredMessage } from '../source-control-account-linking';
+import {
+  buildSourceControlAccountLinkRequiredMessage,
+  buildSourceControlEnvironmentRequiredMessage,
+} from '../source-control-account-linking';
 import { toHostFromUrl } from '../utils';
 import type { GitLabNoteWebhook } from './types';
 
@@ -38,6 +54,8 @@ type GitLabMrMentionReplyKind =
   | 'active_follow_up'
   | 'active_review'
   | 'review_started';
+
+type GitLabIssueMentionReplyKind = 'active_follow_up' | 'task_started';
 
 function isGitLabMention(noteBody: string): boolean {
   return noteBody.toLowerCase().includes(GITLAB_MENTION_HANDLE);
@@ -67,7 +85,7 @@ async function isDeploymentTokenAuthor(username: string): Promise<boolean> {
   }
 }
 
-async function postMentionResponseNote({
+async function postMergeRequestMentionResponseNote({
   projectId,
   mergeRequestIid,
   body,
@@ -85,6 +103,28 @@ async function postMentionResponseNote({
   } catch (error) {
     console.warn(
       `[handleGitLabNote] failed to post mention response note on project ${projectId} MR !${mergeRequestIid}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+async function postIssueMentionResponseNote({
+  projectId,
+  issueIid,
+  body,
+}: {
+  projectId: number;
+  issueIid: number;
+  body: string;
+}): Promise<void> {
+  try {
+    await createGitLabIssueNote({
+      projectId,
+      issueIid,
+      body,
+    });
+  } catch (error) {
+    console.warn(
+      `[handleGitLabNote] failed to post mention response note on project ${projectId} issue #${issueIid}: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
 }
@@ -147,12 +187,46 @@ function formatGitLabMrMentionReply(
   return `${replyCopy.intro} [See task](${link})`;
 }
 
+function formatGitLabIssueMentionReply(
+  kind: GitLabIssueMentionReplyKind,
+  link: string | null,
+): string {
+  const replyCopy = (() => {
+    switch (kind) {
+      case 'active_follow_up':
+        return {
+          intro:
+            "I'm on it. I routed this request into the existing task for this issue so follow-up work stays on one Roomote thread, and I'll keep updates here.",
+          fallback:
+            'I could not generate the task link for this note, but the follow-up was delivered.',
+        };
+      case 'task_started':
+        return {
+          intro:
+            "I'm on it. I started a task for this issue, and I'll keep updates here.",
+          fallback:
+            'I could not generate the task link for this note, but the task is already running.',
+        };
+    }
+  })();
+
+  if (!link) {
+    return `${replyCopy.intro} ${replyCopy.fallback}`;
+  }
+
+  return `${replyCopy.intro} [See task](${link})`;
+}
+
 function buildReviewerGateMissNote(): string {
   return `I saw the mention, but I could not start work on this merge request with the current ${PRODUCT_NAME} GitLab setup.`;
 }
 
-function buildTaskStartFailedNote(): string {
-  return 'I saw the mention, but I could not start a task for this merge request right now. Please try again in a moment.';
+function buildIssueGateMissNote(): string {
+  return `I saw the mention, but I could not start work on this issue with the current ${PRODUCT_NAME} GitLab setup.`;
+}
+
+function buildTaskStartFailedNote(surface: 'merge request' | 'issue'): string {
+  return `I saw the mention, but I could not start a task for this ${surface} right now. Please try again in a moment.`;
 }
 
 function formatQuotedText(text: string): string {
@@ -163,7 +237,7 @@ function formatQuotedText(text: string): string {
     .join('\n');
 }
 
-function buildExistingTaskFollowUpMessage({
+function buildExistingMrTaskFollowUpMessage({
   repoFullName,
   mergeRequest,
   commenter,
@@ -190,53 +264,305 @@ function buildExistingTaskFollowUpMessage({
   return lines.join('\n');
 }
 
-export async function handleGitLabNote(
-  payload: GitLabNoteWebhook,
-): Promise<WebhookResponse> {
-  const note = payload.object_attributes;
-  const mergeRequest = payload.merge_request;
+function buildIssueMentionPrompt({
+  repositoryFullName,
+  issueIid,
+  issueTitle,
+  issueBody,
+  issueUrl,
+  commentBody,
+  commenterLogin,
+}: {
+  repositoryFullName: string;
+  issueIid: number;
+  issueTitle: string;
+  issueBody?: string | null;
+  issueUrl: string;
+  commentBody: string;
+  commenterLogin: string;
+}): string {
+  const trimmedIssueBody = issueBody?.trim() ?? '';
+  const trimmedCommentBody = commentBody.trim();
+  const issueBodySection =
+    trimmedIssueBody && trimmedIssueBody !== trimmedCommentBody
+      ? [
+          '',
+          'Issue description (context only):',
+          buildUntrustedExternalContentBlock({
+            source: 'gitlab_issue_description',
+            text: trimmedIssueBody,
+          }),
+        ]
+      : [];
 
-  if (note.action && note.action !== 'create') {
-    return { status: 'ok', message: `unsupported_note_action:${note.action}` };
+  return [
+    `${commenterLogin} mentioned Roomote on GitLab issue #${issueIid} (${escapeTaskContextText(issueTitle)}) in ${repositoryFullName}.`,
+    `Issue URL: ${issueUrl}`,
+    '',
+    'Mention comment (the request to act on):',
+    buildMentionRequestBlock(trimmedCommentBody),
+    ...issueBodySection,
+    '',
+    buildUntrustedContentPolicy(),
+  ].join('\n');
+}
+
+function buildIssueFollowUpMessage({
+  repositoryFullName,
+  issueIid,
+  issueTitle,
+  issueUrl,
+  commentBody,
+  commenterLogin,
+}: {
+  repositoryFullName: string;
+  issueIid: number;
+  issueTitle: string;
+  issueUrl: string;
+  commentBody: string;
+  commenterLogin: string;
+}): string {
+  return [
+    `${commenterLogin} mentioned Roomote again on GitLab issue #${issueIid} (${escapeTaskContextText(issueTitle)}) in ${repositoryFullName}.`,
+    `Issue URL: ${issueUrl}`,
+    '',
+    'This is a follow-up on the existing Roomote task for this issue. Continue that work instead of starting a separate task.',
+    '',
+    'Mention comment (the request to act on):',
+    buildMentionRequestBlock(commentBody),
+    '',
+    buildUntrustedContentPolicy(),
+  ].join('\n');
+}
+
+async function resolveMappedEnvironmentId(
+  repositoryId: string,
+): Promise<string | null> {
+  const mappings = await db
+    .select({
+      environmentId: environmentRepositoryMappings.environmentId,
+    })
+    .from(environmentRepositoryMappings)
+    .where(eq(environmentRepositoryMappings.repositoryId, repositoryId))
+    .orderBy(asc(environmentRepositoryMappings.environmentId));
+
+  if (mappings.length === 0) {
+    return null;
   }
 
-  // System notes are GitLab-generated activity (label changes, cross-references,
-  // "mentioned in ..." echoes). They can restate a user's @roomote text without
-  // being a real request, so never treat them as mentions.
-  if (note.system) {
-    return { status: 'ok', message: 'system_note' };
-  }
+  return mappings[0]?.environmentId ?? null;
+}
 
-  if (note.noteable_type !== 'MergeRequest' || !mergeRequest) {
+async function handleGitLabIssueNote({
+  payload,
+  note,
+  issue,
+  commenter,
+  repoFullName,
+}: {
+  payload: GitLabNoteWebhook;
+  note: GitLabNoteWebhook['object_attributes'];
+  issue: NonNullable<GitLabNoteWebhook['issue']>;
+  commenter: string;
+  repoFullName: string;
+}): Promise<WebhookResponse> {
+  const mentionResponseTarget = {
+    projectId: payload.project.id,
+    issueIid: issue.iid,
+  };
+
+  // Skip pr_review automation gates (review enabled / author policy). Issue
+  // mentions should only need a linked sender and a mapped environment, matching
+  // GitHub issue comment handling.
+  const targetsResult = await getGitLabAutomationTargets({
+    workflow: 'pr_conflict_resolve',
+    payload,
+    webhookHost: toHostFromUrl(issue.url ?? payload.project.web_url ?? ''),
+    ignoreAuthorPolicy: true,
+    requireLinkedSenderAccount: true,
+  });
+
+  const target =
+    targetsResult.status === 'ok' ? targetsResult.targets[0] : undefined;
+
+  if (!target || !target.userId) {
+    await postIssueMentionResponseNote({
+      ...mentionResponseTarget,
+      body:
+        targetsResult.status === 'error' &&
+        targetsResult.code === 'account_link_required'
+          ? buildSourceControlAccountLinkRequiredMessage('gitlab')
+          : buildIssueGateMissNote(),
+    });
+
     return {
       status: 'ok',
-      message: `unsupported_noteable_type:${note.noteable_type}`,
+      message:
+        targetsResult.status === 'error' &&
+        targetsResult.code === 'account_link_required'
+          ? 'account_link_required'
+          : 'issue_gate_miss',
     };
   }
 
-  if (!isGitLabMention(note.note)) {
-    return { status: 'ok', message: 'no_mention' };
+  const environmentId = await resolveMappedEnvironmentId(target.repo.id);
+
+  if (!environmentId) {
+    await postIssueMentionResponseNote({
+      ...mentionResponseTarget,
+      body: buildSourceControlEnvironmentRequiredMessage('gitlab'),
+    });
+
+    return { status: 'ok', message: 'environment_required' };
   }
 
-  const commenter = payload.user?.username;
+  const issueUrl =
+    issue.url ??
+    (payload.project.web_url
+      ? `${payload.project.web_url}/-/issues/${issue.iid}`
+      : '');
+  const issueTitle = issue.title ?? `Issue #${issue.iid}`;
+  const issueBody = issue.description ?? null;
 
-  if (!commenter) {
-    return { status: 'ok', message: 'no_note_author' };
+  const existingIssueOwner = await findReusableGitHubIssueTaskOwner({
+    repoFullName,
+    issueNumber: issue.iid,
+    sourceControlProvider: 'gitlab',
+    host: target.repo.host ?? null,
+  });
+
+  if (existingIssueOwner?.taskId) {
+    const followUpMessage = buildIssueFollowUpMessage({
+      repositoryFullName: repoFullName,
+      issueIid: issue.iid,
+      issueTitle,
+      issueUrl,
+      commentBody: note.note,
+      commenterLogin: commenter,
+    });
+
+    const delivery = isActivelyRunningTask(
+      existingIssueOwner.status,
+      existingIssueOwner.taskPhase,
+    )
+      ? await steerMessageToTask({
+          taskId: existingIssueOwner.taskId,
+          userId: target.userId,
+          message: followUpMessage,
+          senderMode: 'github_pr_follow_up',
+        })
+      : await sendMessageToTask({
+          taskId: existingIssueOwner.taskId,
+          userId: target.userId,
+          message: followUpMessage,
+          senderMode: 'github_pr_follow_up',
+        });
+
+    if (delivery.success) {
+      await postIssueMentionResponseNote({
+        ...mentionResponseTarget,
+        body: formatGitLabIssueMentionReply(
+          'active_follow_up',
+          tryBuildTaskLink({
+            taskId: existingIssueOwner.taskId,
+            campaign: 'gitlab.issue.mention.active-owner',
+          }),
+        ),
+      });
+
+      return { status: 'ok', message: 'active_issue_owner_routed' };
+    }
+
+    console.warn(
+      `[handleGitLabNote] failed to deliver issue mention to reusable task ${existingIssueOwner.taskId}: ${delivery.error}`,
+    );
   }
 
-  if (
-    isGitLabRoomoteAuthoredNote(commenter) ||
-    (await isDeploymentTokenAuthor(commenter))
-  ) {
-    return { status: 'ok', message: 'roomote_authored_note' };
+  const prompt = buildIssueMentionPrompt({
+    repositoryFullName: repoFullName,
+    issueIid: issue.iid,
+    issueTitle,
+    issueBody,
+    issueUrl,
+    commentBody: note.note,
+    commenterLogin: commenter,
+  });
+
+  const taskPayload = {
+    repo: repoFullName,
+    sourceControlProvider: 'gitlab',
+    ...(target.repo.host ? { sourceControlHost: target.repo.host } : {}),
+    environmentId,
+    selectedRepositories: [repoFullName],
+    description: prompt,
+    linkedWorkItems: [
+      {
+        provider: 'gitlab',
+        identifier: String(issue.iid),
+        url: issueUrl,
+        title: issueTitle,
+        repository: repoFullName,
+      },
+    ],
+  } satisfies TaskPayload<typeof TaskPayloadKind.StandardTask>;
+
+  try {
+    const launch = await enqueueTask({
+      task: {
+        type: TaskPayloadKind.StandardTask,
+        payload: taskPayload,
+      },
+      initiator: { kind: 'user', userId: target.userId },
+      workflow: 'standard',
+      surface: 'gitlab',
+      trigger: 'message',
+    });
+
+    await postIssueMentionResponseNote({
+      ...mentionResponseTarget,
+      body: formatGitLabIssueMentionReply(
+        'task_started',
+        tryBuildTaskLink({
+          taskId: launch.taskId,
+          campaign: 'gitlab.issue.mention',
+        }),
+      ),
+    });
+
+    return {
+      status: 'ok',
+      metadata: { ids: [launch.id] },
+    };
+  } catch (error) {
+    console.warn(
+      `[handleGitLabNote] failed to start issue task for ${repoFullName}#${issue.iid}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+
+    await postIssueMentionResponseNote({
+      ...mentionResponseTarget,
+      body: buildTaskStartFailedNote('issue'),
+    });
+
+    return {
+      status: 'error',
+      message: `issue_task_start_failed:${error instanceof Error ? error.message : String(error)}`,
+    };
   }
+}
 
-  const repoFullName = payload.project.path_with_namespace;
-
-  if (!repoFullName) {
-    return { status: 'error', message: 'missing_project_path_with_namespace' };
-  }
-
+async function handleGitLabMergeRequestNote({
+  payload,
+  note,
+  mergeRequest,
+  commenter,
+  repoFullName,
+}: {
+  payload: GitLabNoteWebhook;
+  note: GitLabNoteWebhook['object_attributes'];
+  mergeRequest: NonNullable<GitLabNoteWebhook['merge_request']>;
+  commenter: string;
+  repoFullName: string;
+}): Promise<WebhookResponse> {
   const mentionResponseTarget = {
     projectId: payload.project.id,
     mergeRequestIid: mergeRequest.iid,
@@ -259,7 +585,7 @@ export async function handleGitLabNote(
 
   // requireLinkedSenderAccount guarantees a linked commenter here.
   if (!target || !target.userId) {
-    await postMentionResponseNote({
+    await postMergeRequestMentionResponseNote({
       ...mentionResponseTarget,
       body:
         targetsResult.status === 'error' &&
@@ -288,7 +614,7 @@ export async function handleGitLabNote(
   });
 
   if (activeOwner?.taskId) {
-    const followUpMessage = buildExistingTaskFollowUpMessage({
+    const followUpMessage = buildExistingMrTaskFollowUpMessage({
       repoFullName,
       mergeRequest,
       commenter,
@@ -312,7 +638,7 @@ export async function handleGitLabNote(
         });
 
     if (delivery.success) {
-      await postMentionResponseNote({
+      await postMergeRequestMentionResponseNote({
         ...mentionResponseTarget,
         body: formatGitLabMrMentionReply(
           'active_follow_up',
@@ -345,7 +671,7 @@ export async function handleGitLabNote(
     });
 
     if (activeReview?.taskId) {
-      await postMentionResponseNote({
+      await postMergeRequestMentionResponseNote({
         ...mentionResponseTarget,
         body: formatGitLabMrMentionReply(
           'active_review',
@@ -410,7 +736,7 @@ export async function handleGitLabNote(
       },
     });
 
-    await postMentionResponseNote({
+    await postMergeRequestMentionResponseNote({
       ...mentionResponseTarget,
       body: formatGitLabMrMentionReply(
         'review_started',
@@ -427,9 +753,9 @@ export async function handleGitLabNote(
       `[handleGitLabNote] failed to start MR review task for ${repoFullName}!${mergeRequest.iid}: ${error instanceof Error ? error.message : String(error)}`,
     );
 
-    await postMentionResponseNote({
+    await postMergeRequestMentionResponseNote({
       ...mentionResponseTarget,
-      body: buildTaskStartFailedNote(),
+      body: buildTaskStartFailedNote('merge request'),
     });
 
     return {
@@ -437,4 +763,71 @@ export async function handleGitLabNote(
       message: `review_start_failed:${error instanceof Error ? error.message : String(error)}`,
     };
   }
+}
+
+export async function handleGitLabNote(
+  payload: GitLabNoteWebhook,
+): Promise<WebhookResponse> {
+  const note = payload.object_attributes;
+  const mergeRequest = payload.merge_request;
+  const issue = payload.issue;
+
+  if (note.action && note.action !== 'create') {
+    return { status: 'ok', message: `unsupported_note_action:${note.action}` };
+  }
+
+  // System notes are GitLab-generated activity (label changes, cross-references,
+  // "mentioned in ..." echoes). They can restate a user's @roomote text without
+  // being a real request, so never treat them as mentions.
+  if (note.system) {
+    return { status: 'ok', message: 'system_note' };
+  }
+
+  if (!isGitLabMention(note.note)) {
+    return { status: 'ok', message: 'no_mention' };
+  }
+
+  const commenter = payload.user?.username;
+
+  if (!commenter) {
+    return { status: 'ok', message: 'no_note_author' };
+  }
+
+  if (
+    isGitLabRoomoteAuthoredNote(commenter) ||
+    (await isDeploymentTokenAuthor(commenter))
+  ) {
+    return { status: 'ok', message: 'roomote_authored_note' };
+  }
+
+  const repoFullName = payload.project.path_with_namespace;
+
+  if (!repoFullName) {
+    return { status: 'error', message: 'missing_project_path_with_namespace' };
+  }
+
+  if (note.noteable_type === 'Issue' && issue) {
+    return handleGitLabIssueNote({
+      payload,
+      note,
+      issue,
+      commenter,
+      repoFullName,
+    });
+  }
+
+  if (note.noteable_type === 'MergeRequest' && mergeRequest) {
+    return handleGitLabMergeRequestNote({
+      payload,
+      note,
+      mergeRequest,
+      commenter,
+      repoFullName,
+    });
+  }
+
+  return {
+    status: 'ok',
+    message: `unsupported_noteable_type:${note.noteable_type}`,
+  };
 }

--- a/apps/api/src/handlers/gitlab/types.ts
+++ b/apps/api/src/handlers/gitlab/types.ts
@@ -86,6 +86,16 @@ const gitLabNoteMergeRequestSchema = z
   })
   .passthrough();
 
+const gitLabNoteIssueSchema = z
+  .object({
+    iid: z.number(),
+    title: z.string(),
+    description: z.string().nullable().optional(),
+    state: z.string().optional(),
+    url: z.string().optional(),
+  })
+  .passthrough();
+
 export const gitLabNoteWebhookSchema = z
   .object({
     object_kind: z.literal('note'),
@@ -94,6 +104,7 @@ export const gitLabNoteWebhookSchema = z
     project: gitLabProjectSchema,
     object_attributes: gitLabNoteAttributesSchema,
     merge_request: gitLabNoteMergeRequestSchema.optional(),
+    issue: gitLabNoteIssueSchema.optional(),
   })
   .passthrough();
 

--- a/apps/api/src/handlers/source-control-account-linking.ts
+++ b/apps/api/src/handlers/source-control-account-linking.ts
@@ -16,7 +16,7 @@ const sourceControlCommentProviderCopy = {
   },
   gitlab: {
     accountLabel: 'GitLab',
-    commentSurface: 'merge request comments',
+    commentSurface: 'issue and merge request comments',
     settingsQuery: 'gitlab',
   },
   gitea: {

--- a/apps/docs/models.mdx
+++ b/apps/docs/models.mdx
@@ -137,6 +137,13 @@ list.
 - **Models** controls the provider/model pairs that are available, the default
   model, and specialized model roles.
 
+For subscription-based providers (ChatGPT, GitHub Copilot, and Kimi for
+Coding), the provider row also shows current plan usage when the provider
+reports it, such as remaining Copilot premium requests or the percent used of
+the ChatGPT 5-hour and weekly limits. These numbers come from unofficial
+provider endpoints, so the usage line is hidden whenever the provider does not
+return usable data.
+
 Admins can enable or disable models from the task model list. The default model
 must stay enabled, because Roomote uses it when a task does not request a
 specific model.

--- a/apps/web/src/components/settings/ChatGptConnectDialog.tsx
+++ b/apps/web/src/components/settings/ChatGptConnectDialog.tsx
@@ -87,6 +87,9 @@ export function ChatGptConnectDialog({
           await queryClient.invalidateQueries({
             queryKey: trpc.chatgptSubscription.status.queryKey(),
           });
+          await queryClient.invalidateQueries({
+            queryKey: trpc.subscriptionUsage.list.queryKey(),
+          });
           await onConnected?.();
           handleOpenChange(false);
         } else if (result.status === 'failed') {

--- a/apps/web/src/components/settings/GitHubCopilotConnectDialog.tsx
+++ b/apps/web/src/components/settings/GitHubCopilotConnectDialog.tsx
@@ -94,6 +94,9 @@ export function GitHubCopilotConnectDialog({
             queryClient.invalidateQueries({
               queryKey: trpc.githubCopilotSubscription.status.queryKey(),
             }),
+            queryClient.invalidateQueries({
+              queryKey: trpc.subscriptionUsage.list.queryKey(),
+            }),
           ]);
           await onConnected?.();
           close(false);

--- a/apps/web/src/components/settings/InferenceProviderSection.test.tsx
+++ b/apps/web/src/components/settings/InferenceProviderSection.test.tsx
@@ -14,14 +14,19 @@ const chatgptStatusData = vi.hoisted(() => ({
 const githubCopilotStatusData = vi.hoisted(() => ({
   current: null as Record<string, unknown> | null,
 }));
+const subscriptionUsageData = vi.hoisted(() => ({
+  current: null as Array<Record<string, unknown>> | null,
+}));
 const mutateAsyncMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@tanstack/react-query', () => ({
   useMutation: () => ({ mutateAsync: mutateAsyncMock }),
   useQuery: (options: { queryKey?: string[] }) => ({
-    data: options.queryKey?.[0]?.includes('githubCopilot')
-      ? githubCopilotStatusData.current
-      : chatgptStatusData.current,
+    data: options.queryKey?.[0]?.includes('subscriptionUsage')
+      ? subscriptionUsageData.current
+      : options.queryKey?.[0]?.includes('githubCopilot')
+        ? githubCopilotStatusData.current
+        : chatgptStatusData.current,
   }),
   useQueryClient: () => ({ invalidateQueries: vi.fn() }),
 }));
@@ -77,6 +82,12 @@ vi.mock('@/trpc/client', () => ({
       },
       disconnect: {
         mutationOptions: () => ({ mutationKey: ['disconnectCopilot'] }),
+      },
+    },
+    subscriptionUsage: {
+      list: {
+        queryOptions: () => ({ queryKey: ['subscriptionUsage', 'list'] }),
+        queryKey: () => ['subscriptionUsage', 'list'],
       },
     },
   }),
@@ -219,6 +230,8 @@ describe('InferenceProviderSection', () => {
     window.HTMLElement.prototype.scrollIntoView = vi.fn();
     providerSetupData.current = null;
     chatgptStatusData.current = null;
+    githubCopilotStatusData.current = null;
+    subscriptionUsageData.current = null;
   });
 
   const renderInferenceProviderSection = () => {
@@ -307,6 +320,68 @@ describe('InferenceProviderSection', () => {
     expect(
       screen.queryByRole('button', { name: /Connect ChatGPT/ }),
     ).not.toBeInTheDocument();
+  });
+
+  it('shows a usage line under a connected subscription row', () => {
+    providerSetupData.current = buildProviderSetup({ chatgptConnected: true });
+    chatgptStatusData.current = {
+      connected: true,
+      status: 'connected',
+      email: 'user@example.com',
+    };
+    githubCopilotStatusData.current = { connected: true, status: 'connected' };
+    subscriptionUsageData.current = [
+      {
+        providerId: 'chatgpt',
+        planType: 'pro',
+        windows: [
+          {
+            label: 'Weekly limit',
+            usedPercent: 8,
+            resetsAt: new Date(Date.now() + 5 * 3_600_000).toISOString(),
+          },
+        ],
+        fetchedAt: new Date().toISOString(),
+      },
+      {
+        providerId: 'github-copilot',
+        windows: [{ label: 'Premium requests', remaining: 211, limit: 300 }],
+        fetchedAt: new Date().toISOString(),
+      },
+    ];
+
+    renderInferenceProviderSection();
+
+    expect(
+      screen.getByText('Weekly limit: 8% used (resets in 5h)'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Premium requests: 211 of 300 left'),
+    ).toBeInTheDocument();
+  });
+
+  it('omits the usage line when no usage data is available or the row errored', () => {
+    providerSetupData.current = buildProviderSetup({ chatgptConnected: true });
+    chatgptStatusData.current = {
+      connected: false,
+      status: 'error',
+      error: 'ChatGPT token refresh failed: 401',
+    };
+    githubCopilotStatusData.current = { connected: true, status: 'connected' };
+    subscriptionUsageData.current = [
+      {
+        providerId: 'chatgpt',
+        windows: [{ label: 'Weekly limit', usedPercent: 8 }],
+        fetchedAt: new Date().toISOString(),
+      },
+    ];
+
+    renderInferenceProviderSection();
+
+    // The errored ChatGPT row hides its stale usage; the Copilot row has no
+    // usage entry at all, so neither renders a usage line.
+    expect(screen.queryByText(/Weekly limit/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Premium requests/)).not.toBeInTheDocument();
   });
 
   it('renders Reconnect and Disconnect for an errored ChatGPT subscription', () => {

--- a/apps/web/src/components/settings/InferenceProviderSection.tsx
+++ b/apps/web/src/components/settings/InferenceProviderSection.tsx
@@ -12,6 +12,9 @@ import type {
   SetupModelProviderId,
   SetupModelProviderStatus,
   SetupModelStatus,
+  SubscriptionProviderUsage,
+  SubscriptionUsageProviderId,
+  SubscriptionUsageWindow,
 } from '@roomote/types';
 
 import { useTRPC } from '@/trpc/client';
@@ -113,14 +116,86 @@ function getSubmitAdditionalEnvValues(
   );
 }
 
+function formatUsageReset(resetsAt: string): string | null {
+  const reset = new Date(resetsAt).getTime();
+
+  if (Number.isNaN(reset)) {
+    return null;
+  }
+
+  const deltaMinutes = Math.round((reset - Date.now()) / 60_000);
+
+  if (deltaMinutes <= 0) {
+    return null;
+  }
+  if (deltaMinutes < 60) {
+    return `resets in ${deltaMinutes}m`;
+  }
+  if (deltaMinutes < 48 * 60) {
+    return `resets in ${Math.round(deltaMinutes / 60)}h`;
+  }
+
+  return `resets ${new Date(reset).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  })}`;
+}
+
+function formatUsageWindow(window: SubscriptionUsageWindow): string | null {
+  let value: string;
+
+  if (window.unlimited) {
+    value = 'unlimited';
+  } else if (window.remaining !== undefined && window.limit !== undefined) {
+    value = `${window.remaining.toLocaleString()} of ${window.limit.toLocaleString()} left`;
+  } else if (window.usedPercent !== undefined) {
+    value = `${Math.round(window.usedPercent)}% used`;
+  } else {
+    return null;
+  }
+
+  const reset =
+    !window.unlimited && window.resetsAt
+      ? formatUsageReset(window.resetsAt)
+      : null;
+
+  return `${window.label}: ${value}${reset ? ` (${reset})` : ''}`;
+}
+
+function SubscriptionUsageLine({
+  usage,
+  className,
+}: {
+  usage: SubscriptionProviderUsage | undefined;
+  className?: string;
+}) {
+  const parts = (usage?.windows ?? [])
+    .map(formatUsageWindow)
+    .filter((part): part is string => part !== null);
+
+  if (parts.length === 0) {
+    return null;
+  }
+
+  return (
+    <p
+      className={`min-w-0 truncate text-xs text-muted-foreground ${className ?? ''}`}
+    >
+      {parts.join(' · ')}
+    </p>
+  );
+}
+
 function ConnectedProviderRow({
   provider,
+  usage,
   isSaving,
   canDelete,
   onEdit,
   onDelete,
 }: {
   provider: SetupModelProviderStatus;
+  usage?: SubscriptionProviderUsage;
   isSaving: boolean;
   canDelete: boolean;
   onEdit: () => void;
@@ -158,6 +233,7 @@ function ConnectedProviderRow({
             aria-label={`${primaryCredentialLabel} for ${provider.label}`}
             data-1p-ignore
           />
+          <SubscriptionUsageLine usage={usage} className="mt-1" />
         </div>
 
         {hasRuntimeKey ? (
@@ -549,6 +625,7 @@ function ChatGptSubscriptionRow({
   errored,
   accountEmail,
   errorMessage,
+  usage,
   onReconnect,
   onDisconnect,
   isDisconnecting,
@@ -556,6 +633,7 @@ function ChatGptSubscriptionRow({
   errored: boolean;
   accountEmail?: string;
   errorMessage?: string;
+  usage?: SubscriptionProviderUsage;
   onReconnect: () => void;
   onDisconnect: () => Promise<void>;
   isDisconnecting: boolean;
@@ -569,17 +647,20 @@ function ChatGptSubscriptionRow({
       </div>
 
       <div className="flex min-w-0 items-center gap-2">
-        {errored ? (
-          <p className="min-w-0 flex-1 truncate text-sm text-destructive">
-            {errorMessage ?? 'ChatGPT subscription needs to be reconnected.'}
-          </p>
-        ) : (
-          <p className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
-            {accountEmail
-              ? `Connected as ${accountEmail}`
-              : 'Connected to a ChatGPT account.'}
-          </p>
-        )}
+        <div className="min-w-0 flex-1">
+          {errored ? (
+            <p className="min-w-0 truncate text-sm text-destructive">
+              {errorMessage ?? 'ChatGPT subscription needs to be reconnected.'}
+            </p>
+          ) : (
+            <p className="min-w-0 truncate text-sm text-muted-foreground">
+              {accountEmail
+                ? `Connected as ${accountEmail}`
+                : 'Connected to a ChatGPT account.'}
+            </p>
+          )}
+          {!errored ? <SubscriptionUsageLine usage={usage} /> : null}
+        </div>
 
         {errored ? (
           <Button
@@ -608,12 +689,14 @@ function ChatGptSubscriptionRow({
 function GitHubCopilotSubscriptionRow({
   errored,
   errorMessage,
+  usage,
   onReconnect,
   onDisconnect,
   isDisconnecting,
 }: {
   errored: boolean;
   errorMessage?: string;
+  usage?: SubscriptionProviderUsage;
   onReconnect: () => void;
   onDisconnect: () => Promise<void>;
   isDisconnecting: boolean;
@@ -624,13 +707,16 @@ function GitHubCopilotSubscriptionRow({
         {getModelProviderLabel('github-copilot')}
       </span>
       <div className="flex min-w-0 items-center gap-2">
-        <p
-          className={`min-w-0 flex-1 truncate text-sm ${errored ? 'text-destructive' : 'text-muted-foreground'}`}
-        >
-          {errored
-            ? (errorMessage ?? 'GitHub Copilot needs to be reconnected.')
-            : 'Connected to a GitHub Copilot account.'}
-        </p>
+        <div className="min-w-0 flex-1">
+          <p
+            className={`min-w-0 truncate text-sm ${errored ? 'text-destructive' : 'text-muted-foreground'}`}
+          >
+            {errored
+              ? (errorMessage ?? 'GitHub Copilot needs to be reconnected.')
+              : 'Connected to a GitHub Copilot account.'}
+          </p>
+          {!errored ? <SubscriptionUsageLine usage={usage} /> : null}
+        </div>
         {errored ? (
           <Button size="sm" variant="outline" onClick={onReconnect}>
             Reconnect
@@ -725,6 +811,24 @@ export function InferenceProviderSection({
   );
   const githubCopilotStatus = githubCopilotStatusQuery.data ?? null;
 
+  // Usage endpoints are unofficial upstream surfaces; a provider missing from
+  // the result just means no usage line is rendered for it.
+  const subscriptionUsageQuery = useQuery(
+    trpc.subscriptionUsage.list.queryOptions(undefined, {
+      staleTime: 60_000,
+    }),
+  );
+  const usageByProvider = useMemo(
+    () =>
+      new Map<SubscriptionUsageProviderId, SubscriptionProviderUsage>(
+        (subscriptionUsageQuery.data ?? []).map((usage) => [
+          usage.providerId,
+          usage,
+        ]),
+      ),
+    [subscriptionUsageQuery.data],
+  );
+
   const saveProvider = useMutation(
     trpc.taskModels.saveProvider.mutationOptions({
       onSuccess: async (result, variables) => {
@@ -746,6 +850,9 @@ export function InferenceProviderSection({
         await Promise.all([
           queryClient.invalidateQueries({
             queryKey: trpc.taskModels.providerSetup.queryKey(),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: trpc.subscriptionUsage.list.queryKey(),
           }),
           ...(addedModelCount > 0 || addedDiscoveredModelCount > 0
             ? [
@@ -786,6 +893,9 @@ export function InferenceProviderSection({
           queryClient.invalidateQueries({
             queryKey: trpc.chatgptSubscription.status.queryKey(),
           }),
+          queryClient.invalidateQueries({
+            queryKey: trpc.subscriptionUsage.list.queryKey(),
+          }),
         ]);
       },
       onError: (error) => {
@@ -806,6 +916,9 @@ export function InferenceProviderSection({
           }),
           queryClient.invalidateQueries({
             queryKey: trpc.githubCopilotSubscription.status.queryKey(),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: trpc.subscriptionUsage.list.queryKey(),
           }),
         ]);
       },
@@ -829,6 +942,9 @@ export function InferenceProviderSection({
           }),
           queryClient.invalidateQueries({
             queryKey: trpc.taskModels.launchOptions.queryKey(),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: trpc.subscriptionUsage.list.queryKey(),
           }),
         ]);
       },
@@ -1057,6 +1173,7 @@ export function InferenceProviderSection({
                 errored={chatgptErrored}
                 accountEmail={chatgptStatus?.email}
                 errorMessage={chatgptStatus?.error}
+                usage={usageByProvider.get(CHATGPT_SUBSCRIPTION_PROVIDER_ID)}
                 onReconnect={() => setIsChatGptDialogOpen(true)}
                 onDisconnect={handleDisconnectChatGpt}
                 isDisconnecting={disconnectChatGpt.isPending}
@@ -1066,6 +1183,7 @@ export function InferenceProviderSection({
               <GitHubCopilotSubscriptionRow
                 errored={githubCopilotErrored}
                 errorMessage={githubCopilotStatus?.error}
+                usage={usageByProvider.get('github-copilot')}
                 onReconnect={() => setIsGitHubCopilotDialogOpen(true)}
                 onDisconnect={handleDisconnectGitHubCopilot}
                 isDisconnecting={disconnectGitHubCopilot.isPending}
@@ -1075,6 +1193,11 @@ export function InferenceProviderSection({
               <ConnectedProviderRow
                 key={provider.id}
                 provider={provider}
+                usage={
+                  provider.id === 'kimi-for-coding'
+                    ? usageByProvider.get('kimi-for-coding')
+                    : undefined
+                }
                 isSaving={savingProviderId === provider.id}
                 canDelete={connectedProviderCount > 1}
                 onEdit={() =>

--- a/apps/web/src/trpc/commands/subscription-usage/index.ts
+++ b/apps/web/src/trpc/commands/subscription-usage/index.ts
@@ -1,0 +1,20 @@
+import { getSubscriptionProviderUsage } from '@roomote/db/server';
+import type { SubscriptionProviderUsage } from '@roomote/types';
+
+import type { UserAuthSuccess } from '@/types';
+
+function assertAdmin(auth: UserAuthSuccess): void {
+  if (!auth.isAdmin) throw new Error('Unauthorized');
+}
+
+/**
+ * Usage/quota for connected subscription providers (ChatGPT, GitHub Copilot,
+ * Kimi for Coding). Providers without a configured credential or whose usage
+ * endpoint is unavailable are simply absent from the result.
+ */
+export async function getSubscriptionProviderUsageCommand(
+  auth: UserAuthSuccess,
+): Promise<SubscriptionProviderUsage[]> {
+  assertAdmin(auth);
+  return getSubscriptionProviderUsage();
+}

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -323,6 +323,7 @@ import {
   pollGitHubCopilotDeviceAuthCommand,
   startGitHubCopilotDeviceAuthCommand,
 } from '../commands/github-copilot-subscription';
+import { getSubscriptionProviderUsageCommand } from '../commands/subscription-usage';
 import {
   getRouterDebugSettingsCommand,
   updateRouterDebugSettingsCommand,
@@ -1891,6 +1892,12 @@ export const appRouter = createRouter({
       ),
     disconnect: protectedProcedure.mutation(({ ctx: { auth } }) =>
       disconnectGitHubCopilotSubscriptionCommand(auth),
+    ),
+  }),
+
+  subscriptionUsage: createRouter({
+    list: protectedProcedure.query(({ ctx: { auth } }) =>
+      getSubscriptionProviderUsageCommand(auth),
     ),
   }),
 

--- a/apps/worker/src/run-task/agent-home.test.ts
+++ b/apps/worker/src/run-task/agent-home.test.ts
@@ -369,15 +369,20 @@ describe('generateOpenCodeConfig provider support', () => {
         OPENAI_COMPATIBLE_COMPANY_PROXY_BASE_URL:
           'https://proxy.example.com/v1',
         OPENAI_COMPATIBLE_COMPANY_PROXY_API_KEY: 'proxy-key',
+        OPENAI_COMPATIBLE_COMPANY_PROXY_LABEL: 'Corp Proxy',
         OPENAI_COMPATIBLE_LOCAL_BASE_URL: 'http://127.0.0.1:8080/v1',
       },
     });
     const config = JSON.parse(result.configContent) as {
-      provider: Record<string, { options: Record<string, unknown> }>;
+      provider: Record<
+        string,
+        { name?: string; options: Record<string, unknown> }
+      >;
     };
 
     expect(config.provider['openai-compatible-company-proxy']).toMatchObject({
       npm: '@ai-sdk/openai-compatible',
+      name: 'OpenAI-compatible (Corp Proxy)',
       options: {
         baseURL: 'https://proxy.example.com/v1',
         apiKey: '{env:OPENAI_COMPATIBLE_COMPANY_PROXY_API_KEY}',
@@ -386,6 +391,7 @@ describe('generateOpenCodeConfig provider support', () => {
     });
     expect(config.provider['openai-compatible-local']).toMatchObject({
       npm: '@ai-sdk/openai-compatible',
+      name: 'OpenAI-compatible (Local)',
       options: {
         baseURL: 'http://127.0.0.1:8080/v1',
       },
@@ -393,6 +399,52 @@ describe('generateOpenCodeConfig provider support', () => {
     });
     expect(
       config.provider['openai-compatible-local']?.options.apiKey,
+    ).toBeUndefined();
+  });
+
+  it('ignores invalid openai-compatible env segments from shared parsing', () => {
+    const result = generateOpenCodeConfig({
+      homeDir: createHomeDir(),
+      runtimeEnv: {
+        R_MODEL: 'openai-compatible/gpt-4o',
+        OPENAI_COMPATIBLE_BASE_URL: 'https://proxy.example.com/v1',
+        // Double underscore is rejected by shared named-env validation
+        OPENAI_COMPATIBLE_BAD__SLUG_BASE_URL: 'https://bad.example.com/v1',
+        // Leading digit env segment is invalid
+        OPENAI_COMPATIBLE_9PROXY_BASE_URL: 'https://nine.example.com/v1',
+      },
+    });
+    const config = JSON.parse(result.configContent) as {
+      provider: Record<string, unknown>;
+    };
+
+    expect(config.provider['openai-compatible']).toBeDefined();
+    expect(config.provider['openai-compatible-bad--slug']).toBeUndefined();
+    expect(config.provider['openai-compatible-9proxy']).toBeUndefined();
+  });
+
+  it('does not fall back named openai-compatible connections to OPENAI_* credentials', () => {
+    const result = generateOpenCodeConfig({
+      homeDir: createHomeDir(),
+      runtimeEnv: {
+        R_MODEL: 'openai-compatible-company-proxy/gpt-4o',
+        OPENAI_COMPATIBLE_COMPANY_PROXY_BASE_URL:
+          'https://proxy.example.com/v1',
+        OPENAI_API_KEY: 'sk-openai-should-not-leak',
+        OPENAI_BASE_URL: 'https://api.openai.com/v1',
+      },
+    });
+    const config = JSON.parse(result.configContent) as {
+      provider: Record<string, { options: Record<string, unknown> }>;
+    };
+
+    expect(config.provider['openai-compatible-company-proxy']).toMatchObject({
+      options: {
+        baseURL: 'https://proxy.example.com/v1',
+      },
+    });
+    expect(
+      config.provider['openai-compatible-company-proxy']?.options.apiKey,
     ).toBeUndefined();
   });
 

--- a/apps/worker/src/run-task/agent-home.ts
+++ b/apps/worker/src/run-task/agent-home.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import {
   BEDROCK_MANTLE_OPENCODE_PROVIDER_ID,
   buildInferenceGatewayOpenCodeBaseUrl,
+  buildOpenAiCompatibleProviderInstance,
   buildOpenCodeModelReasoningOptions,
   CHATGPT_GATEWAY_PROVIDER_ID,
   CHATGPT_OPENCODE_PROVIDER_ID,
@@ -13,16 +14,21 @@ import {
   getInferenceGatewayProvider,
   getInferenceGatewayProviderByEnvVarName,
   getMcpIntegration,
+  getOpenAiCompatibleProviderInstance,
   INFERENCE_GATEWAY_CHATGPT_ENV_VAR_NAME,
   INFERENCE_GATEWAY_GITHUB_COPILOT_ENV_VAR_NAME,
   INFERENCE_GATEWAY_KEYS_ENV_VAR_NAME,
   INFERENCE_GATEWAY_REGION_PATTERN,
   INFERENCE_GATEWAY_URL_ENV_VAR_NAME,
   type InferenceGatewayProvider,
+  isOpenAiCompatibleProviderId,
   isTaskModelIdDisabled,
+  listOpenAiCompatibleProviderInstancesFromEnvNames,
   mergeOpenCodeModelReasoningOptions,
   mergeOpenRouterVariantAliasModels,
   normalizeOptionalReasoningEffort,
+  OPENAI_COMPATIBLE_PROVIDER_ID,
+  type OpenAiCompatibleProviderInstance,
   parseInferenceGatewayKeys,
   renderManualSkillMarkdown,
   resolveOpenRouterVariantModelAlias,
@@ -69,12 +75,26 @@ export const OPENCODE_AUTH_FILE_NAME = 'auth.json';
 
 const OPENROUTER_PROVIDER_ID = 'openrouter';
 
-const OPENAI_COMPATIBLE_PROVIDER_CONFIGS = {
-  'openai-compatible': {
-    name: 'OpenAI-compatible',
-    baseUrlEnvVarName: 'OPENAI_COMPATIBLE_BASE_URL',
-    fallbackBaseUrl: 'http://127.0.0.1:4000/v1',
-    apiKeyEnvVarName: 'OPENAI_COMPATIBLE_API_KEY' as string | undefined,
+/** Fallback direct-mode base URL for default and named OpenAI-compatible ids. */
+const OPENAI_COMPATIBLE_DEFAULT_FALLBACK_BASE_URL = 'http://127.0.0.1:4000/v1';
+
+const DEFAULT_OPENAI_COMPATIBLE_INSTANCE =
+  buildOpenAiCompatibleProviderInstance(null);
+
+/**
+ * Static OpenAI-compatible-style endpoint providers. Catalog entry names and
+ * env vars for the built-in `openai-compatible` id come from `@roomote/types`;
+ * ollama/vllm/litellm stay local here. Named `openai-compatible-<slug>`
+ * connections are discovered dynamically via the shared helpers.
+ */
+const STATIC_OPENAI_COMPATIBLE_PROVIDER_CONFIGS = {
+  [OPENAI_COMPATIBLE_PROVIDER_ID]: {
+    name: DEFAULT_OPENAI_COMPATIBLE_INSTANCE.label,
+    baseUrlEnvVarName: DEFAULT_OPENAI_COMPATIBLE_INSTANCE.baseUrlEnvVarName,
+    fallbackBaseUrl: OPENAI_COMPATIBLE_DEFAULT_FALLBACK_BASE_URL,
+    apiKeyEnvVarName: DEFAULT_OPENAI_COMPATIBLE_INSTANCE.apiKeyEnvVarName as
+      | string
+      | undefined,
     keyless: false,
     // Arbitrary endpoints must not inherit OPENAI_* credentials. When the
     // optional dedicated key is blank, omit the API key entirely so keyless
@@ -108,7 +128,7 @@ const OPENAI_COMPATIBLE_PROVIDER_CONFIGS = {
 } as const;
 
 type StaticOpenAiCompatibleProviderId =
-  keyof typeof OPENAI_COMPATIBLE_PROVIDER_CONFIGS;
+  keyof typeof STATIC_OPENAI_COMPATIBLE_PROVIDER_CONFIGS;
 
 type OpenAiCompatibleProviderRuntimeConfig = {
   name: string;
@@ -119,6 +139,40 @@ type OpenAiCompatibleProviderRuntimeConfig = {
   allowOpenAiEnvFallback: boolean;
 };
 
+function toNamedOpenAiCompatibleRuntimeConfig(
+  instance: OpenAiCompatibleProviderInstance,
+): OpenAiCompatibleProviderRuntimeConfig {
+  return {
+    name: instance.label,
+    baseUrlEnvVarName: instance.baseUrlEnvVarName,
+    fallbackBaseUrl: OPENAI_COMPATIBLE_DEFAULT_FALLBACK_BASE_URL,
+    apiKeyEnvVarName: instance.apiKeyEnvVarName,
+    keyless: false,
+    allowOpenAiEnvFallback: false,
+  };
+}
+
+function resolveNamedOpenAiCompatibleInstance(
+  providerId: string,
+  runtimeEnv: Record<string, string>,
+): OpenAiCompatibleProviderInstance | null {
+  const instance = getOpenAiCompatibleProviderInstance(providerId);
+  if (!instance?.slug) {
+    return null;
+  }
+
+  if (!instance.labelEnvVarName) {
+    return instance;
+  }
+
+  const label = runtimeEnv[instance.labelEnvVarName]?.trim();
+  if (!label) {
+    return instance;
+  }
+
+  return getOpenAiCompatibleProviderInstance(providerId, { label }) ?? instance;
+}
+
 function getOpenAiCompatibleRuntimeConfigs(
   modelIds: Array<string | undefined>,
   runtimeEnv: Record<string, string>,
@@ -126,7 +180,7 @@ function getOpenAiCompatibleRuntimeConfigs(
   const configs = new Map<string, OpenAiCompatibleProviderRuntimeConfig>();
 
   for (const [providerId, provider] of Object.entries(
-    OPENAI_COMPATIBLE_PROVIDER_CONFIGS,
+    STATIC_OPENAI_COMPATIBLE_PROVIDER_CONFIGS,
   ) as Array<
     [StaticOpenAiCompatibleProviderId, OpenAiCompatibleProviderRuntimeConfig]
   >) {
@@ -134,56 +188,34 @@ function getOpenAiCompatibleRuntimeConfigs(
   }
 
   const candidateProviderIds = new Set<string>();
+
   for (const modelId of modelIds) {
     const providerId = modelId?.trim().split('/')[0];
-    if (providerId?.startsWith('openai-compatible')) {
+    if (providerId && isOpenAiCompatibleProviderId(providerId)) {
       candidateProviderIds.add(providerId);
     }
   }
 
-  for (const envName of Object.keys(runtimeEnv)) {
-    if (
-      envName.startsWith('OPENAI_COMPATIBLE_') &&
-      envName.endsWith('_BASE_URL')
-    ) {
-      // OPENAI_COMPATIBLE_BASE_URL → openai-compatible
-      // OPENAI_COMPATIBLE_FOO_BAR_BASE_URL → openai-compatible-foo-bar
-      if (envName === 'OPENAI_COMPATIBLE_BASE_URL') {
-        candidateProviderIds.add('openai-compatible');
-        continue;
-      }
-      const middle = envName.slice(
-        'OPENAI_COMPATIBLE_'.length,
-        envName.length - '_BASE_URL'.length,
-      );
-      if (middle) {
-        candidateProviderIds.add(
-          `openai-compatible-${middle.toLowerCase().replaceAll('_', '-')}`,
-        );
-      }
-    }
+  for (const instance of listOpenAiCompatibleProviderInstancesFromEnvNames(
+    Object.keys(runtimeEnv),
+  )) {
+    candidateProviderIds.add(instance.id);
   }
 
   for (const providerId of candidateProviderIds) {
     if (configs.has(providerId)) {
       continue;
     }
-    if (providerId === 'openai-compatible') {
+
+    const instance = resolveNamedOpenAiCompatibleInstance(
+      providerId,
+      runtimeEnv,
+    );
+    if (!instance) {
       continue;
     }
-    if (!providerId.startsWith('openai-compatible-')) {
-      continue;
-    }
-    const slug = providerId.slice('openai-compatible-'.length);
-    const envSegment = slug.replaceAll('-', '_').toUpperCase();
-    configs.set(providerId, {
-      name: `OpenAI-compatible (${slug})`,
-      baseUrlEnvVarName: `OPENAI_COMPATIBLE_${envSegment}_BASE_URL`,
-      fallbackBaseUrl: 'http://127.0.0.1:4000/v1',
-      apiKeyEnvVarName: `OPENAI_COMPATIBLE_${envSegment}_API_KEY`,
-      keyless: false,
-      allowOpenAiEnvFallback: false,
-    });
+
+    configs.set(providerId, toNamedOpenAiCompatibleRuntimeConfig(instance));
   }
 
   return configs;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roomote",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "license": "FCL-1.0-ALv2",
   "packageManager": "pnpm@10.29.3",
   "engines": {

--- a/packages/db/src/lib/__tests__/github-branch-activity.test.ts
+++ b/packages/db/src/lib/__tests__/github-branch-activity.test.ts
@@ -1363,6 +1363,156 @@ describe('findReusableGitHubIssueTaskOwner', () => {
       delivery: 'resume',
     });
   });
+
+  it('reuses a standard task linked to the same GitLab issue', async () => {
+    const { user } = await createActor();
+    const repoFullName = 'acme/backend-issue-gitlab';
+    const issueNumber = 91;
+
+    const task = await taskFactory.create({
+      initiatorUserId: user.id,
+    });
+    const run = await runFactory.create({
+      actingUserId: user.id,
+      taskId: task.id,
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Running,
+      taskPhase: 'running',
+      payload: {
+        repo: repoFullName,
+        sourceControlProvider: 'gitlab',
+        description: `work on gitlab #${issueNumber}`,
+        linkedWorkItems: [
+          {
+            provider: 'gitlab',
+            identifier: String(issueNumber),
+            repository: repoFullName,
+            url: `https://gitlab.com/${repoFullName}/-/issues/${issueNumber}`,
+            title: `Issue #${issueNumber}`,
+          },
+        ],
+      },
+    });
+
+    // Same number/repo with the default GitHub provider must not match.
+    await createIssueLinkedStandardTaskRun({
+      repoFullName,
+      issueNumber,
+      userId: user.id,
+      status: RunStatus.Running,
+      taskPhase: 'running',
+    });
+
+    const result = await findReusableGitHubIssueTaskOwner({
+      repoFullName,
+      issueNumber,
+      sourceControlProvider: 'gitlab',
+    });
+
+    expect(result).toEqual({
+      runId: run.id,
+      taskId: run.taskId,
+      type: TaskPayloadKind.StandardTask,
+      status: RunStatus.Running,
+      taskPhase: 'running',
+      delivery: 'attach',
+    });
+  });
+
+  it('host-scopes GitLab issue reuse and tolerates unstamped legacy payloads', async () => {
+    const { user } = await createActor();
+    const repoFullName = 'acme/backend-issue-host';
+    const issueNumber = 92;
+
+    async function createGitLabIssueRun({
+      sourceControlHost,
+    }: {
+      sourceControlHost?: string;
+    }) {
+      const task = await taskFactory.create({
+        initiatorUserId: user.id,
+      });
+
+      return runFactory.create({
+        actingUserId: user.id,
+        taskId: task.id,
+        payloadKind: TaskPayloadKind.StandardTask,
+        status: RunStatus.Running,
+        taskPhase: 'running',
+        payload: {
+          repo: repoFullName,
+          sourceControlProvider: 'gitlab',
+          ...(sourceControlHost ? { sourceControlHost } : {}),
+          description: `work on gitlab #${issueNumber}`,
+          linkedWorkItems: [
+            {
+              provider: 'gitlab',
+              identifier: String(issueNumber),
+              repository: repoFullName,
+            },
+          ],
+        },
+      });
+    }
+
+    const hostARun = await createGitLabIssueRun({
+      sourceControlHost: 'gitlab.host-a.example',
+    });
+    const hostBRun = await createGitLabIssueRun({
+      sourceControlHost: 'gitlab.host-b.example',
+    });
+
+    const hostBResult = await findReusableGitHubIssueTaskOwner({
+      repoFullName,
+      issueNumber,
+      sourceControlProvider: 'gitlab',
+      host: 'gitlab.host-b.example',
+    });
+
+    expect(hostBResult).toEqual({
+      runId: hostBRun.id,
+      taskId: hostBRun.taskId,
+      type: TaskPayloadKind.StandardTask,
+      status: RunStatus.Running,
+      taskPhase: 'running',
+      delivery: 'attach',
+    });
+
+    const hostAResult = await findReusableGitHubIssueTaskOwner({
+      repoFullName,
+      issueNumber,
+      sourceControlProvider: 'gitlab',
+      host: 'gitlab.host-a.example',
+    });
+
+    expect(hostAResult).toEqual({
+      runId: hostARun.id,
+      taskId: hostARun.taskId,
+      type: TaskPayloadKind.StandardTask,
+      status: RunStatus.Running,
+      taskPhase: 'running',
+      delivery: 'attach',
+    });
+
+    const legacyUnstamped = await createGitLabIssueRun({});
+    const hostScopedWithLegacy = await findReusableGitHubIssueTaskOwner({
+      repoFullName,
+      issueNumber,
+      sourceControlProvider: 'gitlab',
+      host: 'gitlab.host-a.example',
+    });
+
+    // Newest matching row is the unstamped legacy task; stamped host-B must
+    // not win a host-A lookup.
+    expect(hostScopedWithLegacy).toEqual({
+      runId: legacyUnstamped.id,
+      taskId: legacyUnstamped.taskId,
+      type: TaskPayloadKind.StandardTask,
+      status: RunStatus.Running,
+      taskPhase: 'running',
+      delivery: 'attach',
+    });
+  });
 });
 
 describe('findActiveGitHubPrReviewTask', () => {

--- a/packages/db/src/lib/__tests__/subscription-provider-usage.test.ts
+++ b/packages/db/src/lib/__tests__/subscription-provider-usage.test.ts
@@ -1,0 +1,410 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../encryption', () => ({
+  encryptJSON: (value: unknown) => JSON.stringify(value),
+  decryptSecrets: async (value: string) => JSON.parse(value) as unknown,
+}));
+
+import {
+  fetchChatGptUsage,
+  fetchGitHubCopilotUsage,
+  fetchKimiForCodingUsage,
+  getSubscriptionProviderUsage,
+} from '../subscription-provider-usage';
+
+/** Executor whose deployment-secret reads resolve the given rows per call. */
+function makeSecretExecutor(
+  rowsPerCall: Array<Record<string, unknown> | null>,
+) {
+  const limit = vi.fn();
+  for (const row of rowsPerCall) {
+    limit.mockResolvedValueOnce(row ? [{ value: JSON.stringify(row) }] : []);
+  }
+  const where = vi.fn().mockReturnValue({ limit });
+  const from = vi.fn().mockReturnValue({ where });
+  const select = vi.fn().mockReturnValue({ from });
+  return { executor: { select } as never, select };
+}
+
+function jsonResponse(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), { status });
+}
+
+const COPILOT_RECORD = {
+  access: 'gho-token',
+  status: 'connected',
+  connectedAt: '2026-07-01T00:00:00.000Z',
+  updatedAt: '2026-07-01T00:00:00.000Z',
+};
+
+function chatGptRecord() {
+  return {
+    refresh: 'refresh-token',
+    access: 'chatgpt-access',
+    expires: Date.now() + 60 * 60 * 1000,
+    accountId: 'acct-1',
+    status: 'connected',
+    connectedAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+  };
+}
+
+describe('fetchGitHubCopilotUsage', () => {
+  it('normalizes the premium-request quota snapshot', async () => {
+    const { executor } = makeSecretExecutor([COPILOT_RECORD]);
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        quota_snapshots: {
+          premium_interactions: {
+            entitlement: 300,
+            remaining: 211,
+            percent_remaining: 70.33,
+            unlimited: false,
+            overage_count: 0,
+          },
+          chat: { unlimited: true },
+        },
+        quota_reset_date: '2026-08-01',
+      }),
+    );
+
+    const usage = await fetchGitHubCopilotUsage({ executor, fetchImpl });
+
+    expect(usage).toMatchObject({
+      providerId: 'github-copilot',
+      windows: [
+        {
+          label: 'Premium requests',
+          used: 89,
+          remaining: 211,
+          limit: 300,
+        },
+      ],
+    });
+    expect(usage?.windows[0]?.usedPercent).toBeCloseTo(29.67, 2);
+    expect(usage?.windows[0]?.resetsAt).toBe(
+      new Date('2026-08-01').toISOString(),
+    );
+
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.github.com/copilot_internal/user');
+    expect(init.headers).toMatchObject({
+      authorization: 'Bearer gho-token',
+      'editor-version': 'vscode/1.99.3',
+    });
+  });
+
+  it('resolves null without fetching when no subscription is connected', async () => {
+    const { executor } = makeSecretExecutor([null]);
+    const fetchImpl = vi.fn();
+
+    await expect(
+      fetchGitHubCopilotUsage({ executor, fetchImpl }),
+    ).resolves.toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('resolves null on an upstream error or unrecognized payload', async () => {
+    const { executor } = makeSecretExecutor([COPILOT_RECORD, COPILOT_RECORD]);
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({}, 403))
+      .mockResolvedValueOnce(jsonResponse({ unexpected: true }));
+
+    await expect(
+      fetchGitHubCopilotUsage({ executor, fetchImpl }),
+    ).resolves.toBeNull();
+    await expect(
+      fetchGitHubCopilotUsage({ executor, fetchImpl }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe('fetchChatGptUsage', () => {
+  it('normalizes primary/secondary rate-limit windows', async () => {
+    const { executor } = makeSecretExecutor([chatGptRecord()]);
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        plan_type: 'pro',
+        rate_limits: {
+          primary: {
+            used_percent: 12.5,
+            window_minutes: 300,
+            resets_in_seconds: 3600,
+          },
+          secondary: { used_percent: 40, window_minutes: 10080 },
+        },
+      }),
+    );
+
+    const usage = await fetchChatGptUsage({ executor, fetchImpl });
+
+    expect(usage).toMatchObject({
+      providerId: 'chatgpt',
+      planType: 'pro',
+      windows: [
+        { label: '5h limit', usedPercent: 12.5 },
+        { label: 'Weekly limit', usedPercent: 40 },
+      ],
+    });
+    expect(usage?.windows[0]?.resetsAt).toBeDefined();
+
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://chatgpt.com/backend-api/wham/usage');
+    expect(init.headers).toMatchObject({
+      authorization: 'Bearer chatgpt-access',
+      'ChatGPT-Account-Id': 'acct-1',
+    });
+  });
+
+  it('accepts the aliased array payload shape', async () => {
+    const { executor } = makeSecretExecutor([chatGptRecord()]);
+    const resetEpochSeconds = Math.floor(Date.now() / 1000) + 7200;
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        planType: 'plus',
+        rate_limits: [
+          {
+            limit_id: 'codex',
+            primary_window: { usedPercent: 5, limit_window_seconds: 18_000 },
+            secondary_window: { percent_left: 80, reset_at: resetEpochSeconds },
+          },
+        ],
+      }),
+    );
+
+    const usage = await fetchChatGptUsage({ executor, fetchImpl });
+
+    expect(usage).toMatchObject({
+      providerId: 'chatgpt',
+      planType: 'plus',
+      windows: [
+        { label: '5h limit', usedPercent: 5 },
+        { label: 'Weekly limit', usedPercent: 20 },
+      ],
+    });
+    expect(usage?.windows[1]?.resetsAt).toBe(
+      new Date(resetEpochSeconds * 1000).toISOString(),
+    );
+  });
+
+  it('parses the live singular rate_limit payload shape', async () => {
+    // Shape observed from the real endpoint on a Pro plan: a singular
+    // `rate_limit` object with `primary_window` (weekly) and a null
+    // `secondary_window`.
+    const { executor } = makeSecretExecutor([chatGptRecord()]);
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        user_id: 'user-1',
+        plan_type: 'pro',
+        rate_limit: {
+          allowed: true,
+          limit_reached: false,
+          primary_window: {
+            used_percent: 8,
+            limit_window_seconds: 604_800,
+            reset_after_seconds: 481_997,
+            reset_at: 1_784_949_989,
+          },
+          secondary_window: null,
+        },
+        credits: { has_credits: false, unlimited: false, balance: '0' },
+      }),
+    );
+
+    const usage = await fetchChatGptUsage({ executor, fetchImpl });
+
+    expect(usage).toMatchObject({
+      providerId: 'chatgpt',
+      planType: 'pro',
+      windows: [{ label: 'Weekly limit', usedPercent: 8 }],
+    });
+    expect(usage?.windows[0]?.resetsAt).toBe(
+      new Date(1_784_949_989 * 1000).toISOString(),
+    );
+  });
+
+  it('resolves null when no subscription is connected', async () => {
+    const { executor } = makeSecretExecutor([null]);
+    const fetchImpl = vi.fn();
+
+    await expect(
+      fetchChatGptUsage({ executor, fetchImpl }),
+    ).resolves.toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe('fetchKimiForCodingUsage', () => {
+  it('parses the flat data-array payload using the plan-wide summary row', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: [
+          {
+            model_name: 'all',
+            title: 'Weekly',
+            limit: 2048,
+            used: 120,
+            remaining: 1928,
+            reset_time: '2026-07-20T00:00:00Z',
+          },
+          { model_name: 'k3', limit: 1024, used: 60 },
+        ],
+      }),
+    );
+
+    const usage = await fetchKimiForCodingUsage({
+      runtimeEnv: { KIMI_API_KEY: 'sk-kimi-test' },
+      fetchImpl,
+    });
+
+    expect(usage).toMatchObject({
+      providerId: 'kimi-for-coding',
+      windows: [
+        {
+          label: 'Weekly',
+          used: 120,
+          remaining: 1928,
+          limit: 2048,
+          resetsAt: '2026-07-20T00:00:00.000Z',
+        },
+      ],
+    });
+    expect(usage?.windows[0]?.usedPercent).toBeCloseTo(5.86, 1);
+
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.kimi.com/coding/v1/usages');
+    expect(init.headers).toMatchObject({
+      authorization: 'Bearer sk-kimi-test',
+      'x-api-key': 'sk-kimi-test',
+    });
+  });
+
+  it('parses the live windowed payload with string numbers and proto enums', async () => {
+    // Shape observed from the real endpoint: numeric fields are strings,
+    // timeUnit is a proto-style enum, and top-level `usage` is the weekly
+    // plan quota alongside the short-window `limits` entries.
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        user: { userId: 'u-1', membership: { level: 'LEVEL_BASIC' } },
+        usage: {
+          limit: '100',
+          used: '27',
+          remaining: '73',
+          resetTime: '2026-07-25T02:26:20.963457Z',
+        },
+        limits: [
+          {
+            window: { duration: 300, timeUnit: 'TIME_UNIT_MINUTE' },
+            detail: {
+              limit: '100',
+              used: '34',
+              remaining: '66',
+              resetTime: '2026-07-19T13:26:20.963457Z',
+            },
+          },
+        ],
+      }),
+    );
+
+    const usage = await fetchKimiForCodingUsage({
+      runtimeEnv: { KIMI_API_KEY: 'sk-kimi-test' },
+      fetchImpl,
+    });
+
+    expect(usage).toMatchObject({
+      providerId: 'kimi-for-coding',
+      windows: [
+        {
+          label: '5h limit',
+          usedPercent: 34,
+          used: 34,
+          remaining: 66,
+          limit: 100,
+          resetsAt: '2026-07-19T13:26:20.963Z',
+        },
+        {
+          label: 'Weekly limit',
+          usedPercent: 27,
+          used: 27,
+          remaining: 73,
+          limit: 100,
+          resetsAt: '2026-07-25T02:26:20.963Z',
+        },
+      ],
+    });
+  });
+
+  it('falls back to /v1/usage on 404', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('', { status: 404 }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          usage: { limit: 100, used: 30 },
+        }),
+      );
+
+    const usage = await fetchKimiForCodingUsage({
+      runtimeEnv: { KIMI_API_KEY: 'sk-kimi-test' },
+      fetchImpl,
+    });
+
+    expect(fetchImpl.mock.calls.map(([url]) => url)).toEqual([
+      'https://api.kimi.com/coding/v1/usages',
+      'https://api.kimi.com/coding/v1/usage',
+    ]);
+    expect(usage).toMatchObject({
+      providerId: 'kimi-for-coding',
+      windows: [{ label: 'Usage', used: 30, remaining: 70, limit: 100 }],
+    });
+  });
+
+  it('resolves null without fetching when no Kimi key is configured', async () => {
+    const executor = {
+      query: {
+        environmentVariables: { findMany: vi.fn().mockResolvedValue([]) },
+      },
+    } as never;
+    const fetchImpl = vi.fn();
+
+    await expect(
+      fetchKimiForCodingUsage({ executor, fetchImpl, runtimeEnv: {} }),
+    ).resolves.toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe('getSubscriptionProviderUsage', () => {
+  it('keeps working providers when another provider fails', async () => {
+    // The ChatGPT fetcher reads its secret first, then Copilot reads its own.
+    const { executor: secretExecutor } = makeSecretExecutor([
+      null,
+      COPILOT_RECORD,
+    ]);
+    const executor = {
+      ...(secretExecutor as object),
+      query: {
+        environmentVariables: { findMany: vi.fn().mockResolvedValue([]) },
+      },
+    } as never;
+
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      if (new URL(String(url)).hostname === 'api.kimi.com') {
+        return jsonResponse({
+          data: [{ model_name: 'all', limit: 100, used: 10 }],
+        });
+      }
+      throw new Error('upstream unavailable');
+    }) as unknown as typeof fetch;
+
+    const usage = await getSubscriptionProviderUsage({
+      executor,
+      fetchImpl,
+      runtimeEnv: { KIMI_API_KEY: 'sk-kimi-test' },
+    });
+
+    expect(usage).toHaveLength(1);
+    expect(usage[0]).toMatchObject({ providerId: 'kimi-for-coding' });
+  });
+});

--- a/packages/db/src/lib/github-branch-activity.ts
+++ b/packages/db/src/lib/github-branch-activity.ts
@@ -299,21 +299,36 @@ export async function findReusableGitHubPrFollowUpOwner({
 }
 
 /**
- * Returns the newest reusable Roomote task started from a GitHub issue
- * @mention (payload `linkedWorkItems` entry) so a second issue comment can
- * continue the original task instead of launching a sibling.
+ * Returns the newest reusable Roomote task started from an issue @mention
+ * (payload `linkedWorkItems` entry) so a second issue comment can continue the
+ * original task instead of launching a sibling.
+ *
+ * `sourceControlProvider` scopes both the task payload and the linked work
+ * item provider (defaults to GitHub, matching historical issue-mention rows).
+ *
+ * When a non-null `host` is given, payload `sourceControlHost` must match that
+ * host. Rows without a stamped host still match (legacy null fallback) so
+ * pre-host-stamping issue tasks remain reusable, while a payload stamped for a
+ * different self-managed instance never cross-matches.
  */
 export async function findReusableGitHubIssueTaskOwner({
   repoFullName,
   issueNumber,
+  sourceControlProvider = 'github',
+  host,
 }: {
   repoFullName: string;
   issueNumber: number;
+  sourceControlProvider?: SourceControlProvider;
+  host?: string | null;
 }): Promise<ReusableGitHubIssueTaskOwner | null> {
   const issueIdentifier = String(issueNumber);
+  // Linked work items use the same provider enum for GitHub/GitLab issues.
+  const linkedWorkItemProvider =
+    sourceControlProvider === 'gitlab' ? 'gitlab' : 'github';
   const linkedWorkItemMatch = JSON.stringify([
     {
-      provider: 'github',
+      provider: linkedWorkItemProvider,
       identifier: issueIdentifier,
       repository: repoFullName,
     },
@@ -326,9 +341,17 @@ export async function findReusableGitHubIssueTaskOwner({
       and(
         isNull(taskRuns.canceledAt),
         inArray(taskRuns.payloadKind, [...REUSABLE_FOLLOW_UP_OWNER_TYPES]),
-        payloadProviderCondition('github'),
+        payloadProviderCondition(sourceControlProvider),
         sql`${taskRuns.payload}->>'repo' = ${repoFullName}`,
         sql`${taskRuns.payload}->'linkedWorkItems' @> ${linkedWorkItemMatch}::jsonb`,
+        ...(host
+          ? [
+              sql`(
+                ${taskRuns.payload}->>'sourceControlHost' = ${host}
+                OR ${taskRuns.payload}->>'sourceControlHost' IS NULL
+              )`,
+            ]
+          : []),
       ),
     )
     .orderBy(desc(taskRuns.createdAt));

--- a/packages/db/src/lib/subscription-provider-usage.ts
+++ b/packages/db/src/lib/subscription-provider-usage.ts
@@ -1,0 +1,553 @@
+import {
+  CHATGPT_ACCOUNT_ID_HEADER,
+  CHATGPT_USAGE_ENDPOINT,
+  GITHUB_COPILOT_USAGE_ENDPOINT,
+  KIMI_FOR_CODING_USAGE_ENDPOINTS,
+  type SubscriptionProviderUsage,
+  type SubscriptionUsageWindow,
+} from '@roomote/types';
+
+import { type DatabaseOrTransaction } from '../db';
+import { getFreshChatGptAccessToken } from './chatgpt-subscription';
+import { getGitHubCopilotAccessToken } from './github-copilot-subscription';
+import { resolveModelProviderEnvValue } from './model-runtime-config';
+
+/**
+ * Server-side usage/quota lookups for subscription-style inference providers,
+ * using the same credentials the inference gateway already holds. All three
+ * upstream endpoints are undocumented (each is what the provider's own CLI
+ * polls), so every fetcher parses defensively and resolves to `null` on any
+ * failure — the settings UI omits the usage line rather than erroring.
+ */
+
+const USAGE_FETCH_TIMEOUT_MS = 10_000;
+
+type UsageFetchOptions = {
+  executor?: DatabaseOrTransaction;
+  fetchImpl?: typeof fetch;
+  runtimeEnv?: Partial<Record<string, string | undefined>>;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+/** Kimi's usage payload serializes numbers as strings, so coerce both. */
+function firstNumber(
+  source: Record<string, unknown> | undefined,
+  keys: readonly string[],
+): number | undefined {
+  for (const key of keys) {
+    const value = source?.[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === 'string' && value.trim().length > 0) {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+  return undefined;
+}
+
+function firstString(
+  source: Record<string, unknown> | undefined,
+  keys: readonly string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = source?.[key];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function clampPercent(value: number): number {
+  return Math.min(100, Math.max(0, value));
+}
+
+/** Epoch reset values appear as seconds or milliseconds; ISO strings too. */
+function toResetIso(value: unknown): string | undefined {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    const ms = value > 1e12 ? value : value * 1000;
+    return new Date(ms).toISOString();
+  }
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+  }
+  return undefined;
+}
+
+function resetFromRelativeSeconds(seconds: number | undefined, now: number) {
+  return seconds !== undefined && seconds >= 0
+    ? new Date(now + seconds * 1000).toISOString()
+    : undefined;
+}
+
+async function fetchJson(
+  fetchImpl: typeof fetch,
+  url: string,
+  headers: Record<string, string>,
+): Promise<{ status: number; payload: unknown }> {
+  const response = await fetchImpl(url, {
+    headers,
+    signal: AbortSignal.timeout(USAGE_FETCH_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    return { status: response.status, payload: undefined };
+  }
+
+  try {
+    return { status: response.status, payload: await response.json() };
+  } catch {
+    return { status: response.status, payload: undefined };
+  }
+}
+
+// --- GitHub Copilot -------------------------------------------------------
+
+function parseGitHubCopilotUsage(payload: unknown): SubscriptionUsageWindow[] {
+  const root = asRecord(payload);
+  const premium = asRecord(
+    asRecord(root?.quota_snapshots)?.premium_interactions,
+  );
+
+  if (!premium) {
+    return [];
+  }
+
+  const entitlement = firstNumber(premium, ['entitlement']);
+  const remaining = firstNumber(premium, ['remaining', 'quota_remaining']);
+  const percentRemaining = firstNumber(premium, ['percent_remaining']);
+  const unlimited = premium.unlimited === true;
+  const resetsAt = toResetIso(firstString(root, ['quota_reset_date']));
+
+  const usedPercent =
+    percentRemaining !== undefined
+      ? clampPercent(100 - percentRemaining)
+      : entitlement && remaining !== undefined
+        ? clampPercent(((entitlement - remaining) / entitlement) * 100)
+        : undefined;
+
+  if (!unlimited && usedPercent === undefined && remaining === undefined) {
+    return [];
+  }
+
+  return [
+    {
+      label: 'Premium requests',
+      ...(usedPercent !== undefined && { usedPercent }),
+      ...(entitlement !== undefined &&
+        remaining !== undefined && {
+          used: Math.max(0, Math.round(entitlement - remaining)),
+        }),
+      ...(remaining !== undefined && { remaining: Math.round(remaining) }),
+      ...(entitlement !== undefined && { limit: entitlement }),
+      ...(unlimited && { unlimited }),
+      ...(resetsAt && { resetsAt }),
+    },
+  ];
+}
+
+export async function fetchGitHubCopilotUsage(
+  options: UsageFetchOptions = {},
+): Promise<SubscriptionProviderUsage | null> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const token = await getGitHubCopilotAccessToken(options.executor);
+
+  if (!token) {
+    return null;
+  }
+
+  // Editor headers mirror the OpenCode Copilot plugin whose client id minted
+  // this token; copilot_internal rejects requests it cannot attribute to an
+  // editor integration.
+  const { payload } = await fetchJson(
+    fetchImpl,
+    GITHUB_COPILOT_USAGE_ENDPOINT,
+    {
+      authorization: `Bearer ${token}`,
+      accept: 'application/json',
+      'user-agent': 'GitHubCopilotChat/0.26.7',
+      'editor-version': 'vscode/1.99.3',
+      'editor-plugin-version': 'copilot-chat/0.26.7',
+    },
+  );
+
+  const windows = parseGitHubCopilotUsage(payload);
+
+  if (windows.length === 0) {
+    return null;
+  }
+
+  return {
+    providerId: 'github-copilot',
+    windows,
+    fetchedAt: new Date().toISOString(),
+  };
+}
+
+// --- ChatGPT subscription -------------------------------------------------
+
+function formatWindowLabel(minutes: number | undefined): string | undefined {
+  if (minutes === undefined || minutes <= 0) {
+    return undefined;
+  }
+  if (minutes % 1440 === 0) {
+    const days = minutes / 1440;
+    return days === 7 ? 'Weekly limit' : `${days}d limit`;
+  }
+  if (minutes % 60 === 0) {
+    return `${minutes / 60}h limit`;
+  }
+  return `${minutes}m limit`;
+}
+
+function parseChatGptWindow(
+  window: Record<string, unknown> | undefined,
+  fallbackLabel: string,
+  now: number,
+): SubscriptionUsageWindow | undefined {
+  if (!window) {
+    return undefined;
+  }
+
+  let usedPercent = firstNumber(window, ['used_percent', 'usedPercent']);
+  if (usedPercent === undefined) {
+    const percentLeft = firstNumber(window, [
+      'percent_left',
+      'remaining_percent',
+    ]);
+    if (percentLeft !== undefined) {
+      usedPercent = 100 - percentLeft;
+    }
+  }
+
+  if (usedPercent === undefined) {
+    return undefined;
+  }
+
+  const windowSeconds = firstNumber(window, [
+    'limit_window_seconds',
+    'window_seconds',
+  ]);
+  const windowMinutes =
+    firstNumber(window, [
+      'window_minutes',
+      'window_duration_mins',
+      'windowDurationMins',
+    ]) ?? (windowSeconds !== undefined ? windowSeconds / 60 : undefined);
+
+  const resetsAt =
+    toResetIso(window['resets_at'] ?? window['reset_at']) ??
+    resetFromRelativeSeconds(
+      firstNumber(window, ['resets_in_seconds', 'reset_after_seconds']),
+      now,
+    );
+
+  return {
+    label: formatWindowLabel(windowMinutes) ?? fallbackLabel,
+    usedPercent: clampPercent(usedPercent),
+    ...(resetsAt && { resetsAt }),
+  };
+}
+
+function parseChatGptUsage(
+  payload: unknown,
+  now: number,
+): { planType?: string; windows: SubscriptionUsageWindow[] } {
+  const root = asRecord(payload);
+
+  if (!root) {
+    return { windows: [] };
+  }
+
+  const planType = firstString(root, ['plan_type', 'planType']);
+  // The live endpoint nests windows under singular `rate_limit`; older
+  // payloads used `rate_limits` (object or array of limit entries).
+  const rawRateLimits = root.rate_limits ?? root.rateLimits ?? root.rate_limit;
+  const rateLimits = Array.isArray(rawRateLimits)
+    ? asRecord(
+        rawRateLimits.find((entry) => asRecord(entry)?.limit_id === 'codex') ??
+          rawRateLimits[0],
+      )
+    : asRecord(rawRateLimits);
+
+  const primary = parseChatGptWindow(
+    asRecord(
+      rateLimits?.primary ??
+        rateLimits?.primary_window ??
+        rateLimits?.five_hour,
+    ),
+    '5h limit',
+    now,
+  );
+  const secondary = parseChatGptWindow(
+    asRecord(
+      rateLimits?.secondary ??
+        rateLimits?.secondary_window ??
+        rateLimits?.weekly,
+    ),
+    'Weekly limit',
+    now,
+  );
+
+  return {
+    ...(planType && { planType }),
+    windows: [primary, secondary].filter(
+      (window): window is SubscriptionUsageWindow => window !== undefined,
+    ),
+  };
+}
+
+export async function fetchChatGptUsage(
+  options: UsageFetchOptions = {},
+): Promise<SubscriptionProviderUsage | null> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const fresh = await getFreshChatGptAccessToken({
+    ...(options.executor && { executor: options.executor }),
+    fetchImpl,
+  });
+
+  if (!fresh) {
+    return null;
+  }
+
+  const { payload } = await fetchJson(fetchImpl, CHATGPT_USAGE_ENDPOINT, {
+    authorization: `Bearer ${fresh.access}`,
+    accept: 'application/json',
+    'user-agent': 'roomote',
+    origin: 'https://chatgpt.com',
+    ...(fresh.accountId && { [CHATGPT_ACCOUNT_ID_HEADER]: fresh.accountId }),
+  });
+
+  const { planType, windows } = parseChatGptUsage(payload, Date.now());
+
+  if (windows.length === 0) {
+    return null;
+  }
+
+  return {
+    providerId: 'chatgpt',
+    ...(planType && { planType }),
+    windows,
+    fetchedAt: new Date().toISOString(),
+  };
+}
+
+// --- Kimi for Coding ------------------------------------------------------
+
+const KIMI_LIMIT_KEYS = ['limit', 'limit_amount', 'total'] as const;
+const KIMI_USED_KEYS = ['used', 'used_amount'] as const;
+const KIMI_REMAINING_KEYS = ['remaining', 'remaining_amount'] as const;
+
+function parseKimiEntry(
+  entry: Record<string, unknown> | undefined,
+  label: string,
+  now: number,
+): SubscriptionUsageWindow | undefined {
+  if (!entry) {
+    return undefined;
+  }
+
+  const limit = firstNumber(entry, KIMI_LIMIT_KEYS);
+  let used = firstNumber(entry, KIMI_USED_KEYS);
+  let remaining = firstNumber(entry, KIMI_REMAINING_KEYS);
+
+  if (remaining === undefined && limit !== undefined && used !== undefined) {
+    remaining = limit - used;
+  }
+  if (used === undefined && limit !== undefined && remaining !== undefined) {
+    used = limit - remaining;
+  }
+
+  if (limit === undefined && used === undefined && remaining === undefined) {
+    return undefined;
+  }
+
+  const resetsAt =
+    toResetIso(
+      entry['resetTime'] ?? entry['reset_time'] ?? entry['reset_at'],
+    ) ??
+    resetFromRelativeSeconds(
+      firstNumber(entry, ['reset_in', 'resets_in_seconds']),
+      now,
+    );
+
+  return {
+    label,
+    ...(limit !== undefined &&
+      limit > 0 &&
+      used !== undefined && {
+        usedPercent: clampPercent((used / limit) * 100),
+      }),
+    ...(used !== undefined && { used }),
+    ...(remaining !== undefined && { remaining }),
+    ...(limit !== undefined && { limit }),
+    ...(resetsAt && { resetsAt }),
+  };
+}
+
+function kimiWindowLabel(window: Record<string, unknown> | undefined): string {
+  const duration = firstNumber(window, ['duration']);
+  const timeUnit = firstString(window, ['timeUnit', 'time_unit']);
+
+  if (duration === undefined || !timeUnit) {
+    return 'Usage';
+  }
+
+  const minutesPerUnit: Record<string, number> = {
+    MINUTE: 1,
+    HOUR: 60,
+    DAY: 1440,
+    WEEK: 10080,
+    MONTH: 43200,
+  };
+  // The live API reports proto-style enum values like 'TIME_UNIT_MINUTE'.
+  const normalizedUnit = timeUnit.toUpperCase().replace(/^TIME_UNIT_/, '');
+  const minutes = minutesPerUnit[normalizedUnit];
+
+  return (
+    (minutes !== undefined
+      ? formatWindowLabel(duration * minutes)
+      : undefined) ?? 'Usage'
+  );
+}
+
+function parseKimiForCodingUsage(
+  payload: unknown,
+  now: number,
+): SubscriptionUsageWindow[] {
+  const root = asRecord(payload);
+
+  if (!root) {
+    return [];
+  }
+
+  // Variant A: { data: [{ model_name, limit, used, remaining, ... }] } where
+  // model_name 'all' is the plan-wide summary row.
+  if (Array.isArray(root.data)) {
+    const rows = root.data
+      .map(asRecord)
+      .filter((row): row is Record<string, unknown> => row !== undefined);
+    const summary =
+      rows.find((row) => row.model_name === 'all') ??
+      (rows.length === 1 ? rows[0] : undefined);
+
+    if (summary) {
+      const window = parseKimiEntry(
+        summary,
+        firstString(summary, ['name', 'title']) ?? 'Weekly limit',
+        now,
+      );
+      return window ? [window] : [];
+    }
+
+    return [];
+  }
+
+  // Variant B (the live shape): { usage: {...}, limits: [{ detail, window:
+  // { duration, timeUnit } }] }. `limits` carries the short rate-limit
+  // windows (e.g. 300 minutes); top-level `usage` is the plan quota, which
+  // resets weekly on Kimi for Coding plans.
+  const windows: SubscriptionUsageWindow[] = [];
+
+  if (Array.isArray(root.limits)) {
+    for (const rawLimit of root.limits) {
+      const limitRecord = asRecord(rawLimit);
+      const window = parseKimiEntry(
+        asRecord(limitRecord?.detail) ?? limitRecord,
+        kimiWindowLabel(asRecord(limitRecord?.window)),
+        now,
+      );
+      if (window) {
+        windows.push(window);
+      }
+    }
+  }
+
+  const planUsage = parseKimiEntry(
+    asRecord(root.usage),
+    windows.length > 0 ? 'Weekly limit' : 'Usage',
+    now,
+  );
+  if (planUsage) {
+    windows.push(planUsage);
+  }
+
+  return windows;
+}
+
+export async function fetchKimiForCodingUsage(
+  options: UsageFetchOptions = {},
+): Promise<SubscriptionProviderUsage | null> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const apiKey = await resolveModelProviderEnvValue(['KIMI_API_KEY'], {
+    ...(options.runtimeEnv && { runtimeEnv: options.runtimeEnv }),
+    ...(options.executor && { executor: options.executor }),
+  });
+
+  if (!apiKey) {
+    return null;
+  }
+
+  for (const endpoint of KIMI_FOR_CODING_USAGE_ENDPOINTS) {
+    // Both auth header styles are sent: inference uses x-api-key while the
+    // usage endpoint is known to accept bearer auth. The Kimi CLI user-agent
+    // matches the client this endpoint is built for.
+    const { status, payload } = await fetchJson(fetchImpl, endpoint, {
+      authorization: `Bearer ${apiKey}`,
+      'x-api-key': apiKey,
+      accept: 'application/json',
+      'user-agent': 'KimiCLI/1.6',
+    });
+
+    if (status === 404) {
+      continue;
+    }
+
+    const windows = parseKimiForCodingUsage(payload, Date.now());
+
+    if (windows.length === 0) {
+      return null;
+    }
+
+    return {
+      providerId: 'kimi-for-coding',
+      windows,
+      fetchedAt: new Date().toISOString(),
+    };
+  }
+
+  return null;
+}
+
+// --- Aggregate ------------------------------------------------------------
+
+/**
+ * Fetch usage for every configured subscription provider. Providers that are
+ * not connected, fail to respond, or return an unrecognized payload are
+ * omitted rather than surfaced as errors.
+ */
+export async function getSubscriptionProviderUsage(
+  options: UsageFetchOptions = {},
+): Promise<SubscriptionProviderUsage[]> {
+  const results = await Promise.allSettled([
+    fetchChatGptUsage(options),
+    fetchGitHubCopilotUsage(options),
+    fetchKimiForCodingUsage(options),
+  ]);
+
+  return results.flatMap((result) =>
+    result.status === 'fulfilled' && result.value !== null
+      ? [result.value]
+      : [],
+  );
+}

--- a/packages/db/src/server.ts
+++ b/packages/db/src/server.ts
@@ -62,6 +62,7 @@ export * from './lib/compute-runtime-config';
 export * from './lib/model-runtime-config';
 export * from './lib/chatgpt-subscription';
 export * from './lib/github-copilot-subscription';
+export * from './lib/subscription-provider-usage';
 export * from './lib/preview-runtime-config';
 export * from './lib/out-of-band-task-messages';
 export * from './lib/record-task-kickoff-message';

--- a/packages/gitlab/src/__tests__/api.test.ts
+++ b/packages/gitlab/src/__tests__/api.test.ts
@@ -73,6 +73,7 @@ import {
   clearGitLabDeploymentUserCache,
   createTaskRunScopedGitLabTokens,
   createGitLabMergeRequestNote,
+  createGitLabIssueNote,
   ensureGitLabWebhooksForProjects,
   removeGitLabWebhooksForProjects,
   getGitLabDeploymentUser,
@@ -840,6 +841,51 @@ describe('createGitLabMergeRequestNote', () => {
       }),
     ).rejects.toThrow(
       'GitLab OAuth authorization is required to create merge request notes.',
+    );
+  });
+});
+
+describe('createGitLabIssueNote', () => {
+  it('posts a note to the issue notes endpoint', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ id: 8765 }), { status: 201 }),
+      );
+
+    const result = await createGitLabIssueNote({
+      projectId: '42',
+      issueIid: 9,
+      body: 'Looking into it!',
+      token: 'glpat_deployment_token',
+      fetchImpl: fetchMock,
+    });
+
+    expect(result).toEqual({ id: 8765 });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://gitlab.com/api/v4/projects/42/issues/9/notes',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'PRIVATE-TOKEN': 'glpat_deployment_token',
+          'Content-Type': 'application/json',
+        }),
+        body: JSON.stringify({ body: 'Looking into it!' }),
+      }),
+    );
+  });
+
+  it('requires a token', async () => {
+    await expect(
+      createGitLabIssueNote({
+        projectId: '42',
+        issueIid: 9,
+        body: 'hi',
+        token: '',
+        fetchImpl: vi.fn<typeof fetch>(),
+      }),
+    ).rejects.toThrow(
+      'GitLab OAuth authorization is required to create issue notes.',
     );
   });
 });

--- a/packages/gitlab/src/api.ts
+++ b/packages/gitlab/src/api.ts
@@ -50,7 +50,7 @@ const gitLabUserSchema = z.object({
   id: z.number(),
   username: z.string(),
 });
-const gitLabMergeRequestNoteSchema = z.object({
+const gitLabNoteSchema = z.object({
   id: z.number(),
 });
 const gitLabProjectHookSchema = z.object({
@@ -222,7 +222,44 @@ export async function createGitLabMergeRequestNote({
     params: {},
     token: gitLabToken,
     body: { body },
-    schema: gitLabMergeRequestNoteSchema,
+    schema: gitLabNoteSchema,
+  });
+
+  return data;
+}
+
+export async function createGitLabIssueNote({
+  projectId,
+  issueIid,
+  body,
+  token,
+  apiBaseUrl,
+  fetchImpl,
+}: {
+  projectId: string | number;
+  issueIid: number;
+  body: string;
+  token?: string;
+  apiBaseUrl?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<{ id: number }> {
+  const gitLabToken = token ?? (await resolveGitLabToken());
+
+  if (!gitLabToken?.trim()) {
+    throw new Error(
+      'GitLab OAuth authorization is required to create issue notes.',
+    );
+  }
+
+  const { data } = await requestGitLabJson({
+    apiBaseUrl,
+    fetchImpl,
+    method: 'POST',
+    path: `/projects/${encodeURIComponent(String(projectId))}/issues/${issueIid}/notes`,
+    params: {},
+    token: gitLabToken,
+    body: { body },
+    schema: gitLabNoteSchema,
   });
 
   return data;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -48,6 +48,7 @@ export * from './preview-proxy';
 export * from './primitives';
 export * from './provider-retry-notice';
 export * from './provider-usage-workflow-phase';
+export * from './subscription-provider-usage';
 export * from './request-observability';
 export * from './sandbox-server';
 export * from './sandbox-spawn';

--- a/packages/types/src/subscription-provider-usage.ts
+++ b/packages/types/src/subscription-provider-usage.ts
@@ -1,0 +1,65 @@
+/**
+ * Normalized usage/quota data for subscription-style inference providers
+ * (ChatGPT subscription, GitHub Copilot, Kimi for Coding), displayed in the
+ * Models settings page.
+ *
+ * None of the upstream usage endpoints below are officially documented; each
+ * is the endpoint the provider's own CLI or editor plugin polls for its usage
+ * display. Their payload shapes have shifted before, so parsers must stay
+ * tolerant and callers must treat missing usage as a non-error (the UI simply
+ * omits the usage line).
+ */
+
+/** Setup-catalog provider ids that report subscription usage. */
+export type SubscriptionUsageProviderId =
+  | 'chatgpt'
+  | 'github-copilot'
+  | 'kimi-for-coding';
+
+/**
+ * One quota window, e.g. Copilot's monthly premium requests or the Codex
+ * 5-hour/weekly rate-limit windows. Providers report different subsets of
+ * these fields; the UI renders whatever is present.
+ */
+export interface SubscriptionUsageWindow {
+  /** Short display label, e.g. '5h limit', 'Weekly limit', 'Premium requests'. */
+  label: string;
+  /** Percent of the window consumed, 0-100. */
+  usedPercent?: number;
+  used?: number;
+  remaining?: number;
+  limit?: number;
+  unlimited?: boolean;
+  /** ISO timestamp when the window resets. */
+  resetsAt?: string;
+}
+
+export interface SubscriptionProviderUsage {
+  providerId: SubscriptionUsageProviderId;
+  /** Provider-reported plan name (e.g. ChatGPT 'plus'/'pro'), when available. */
+  planType?: string;
+  windows: SubscriptionUsageWindow[];
+  fetchedAt: string;
+}
+
+/**
+ * Internal GitHub endpoint whose `quota_snapshots` field carries the live
+ * premium-request quota; the official billing API only reports lagging
+ * consumption. Same endpoint Copilot editor integrations poll.
+ */
+export const GITHUB_COPILOT_USAGE_ENDPOINT =
+  'https://api.github.com/copilot_internal/user';
+
+/** ChatGPT backend endpoint Codex CLI polls for its /status rate-limit view. */
+export const CHATGPT_USAGE_ENDPOINT =
+  'https://chatgpt.com/backend-api/wham/usage';
+
+/**
+ * Kimi Code (Coding Plan) usage endpoints, as polled by Kimi CLI's /usage
+ * command. Newer deployments serve /v1/usages; older ones only /v1/usage, so
+ * callers try each in order and fall through on 404.
+ */
+export const KIMI_FOR_CODING_USAGE_ENDPOINTS = [
+  'https://api.kimi.com/coding/v1/usages',
+  'https://api.kimi.com/coding/v1/usage',
+] as const;


### PR DESCRIPTION
## Promote v0.14.0

Frozen at `357c191b935a1fa8ec970e4a4aeee8bc456ecc3f` — the commit where `0.14.0` was versioned. Commits merged to `develop` after that point ship in the next release.

- Merge this PR with a **merge commit** (do not squash or rebase).
- If multiple promote PRs are open, merge them in version order (oldest first).
- Merging publishes a GitHub Release for `v0.14.0` and triggers the existing GHCR `v*` image publish (`latest` channel).
- The `release/v0.14.0` branch can be deleted after this PR merges.

### Changelog

## 0.14.0 (2026-07-19)

### Minor changes

- Handle @roomote mentions on GitLab issues (not only merge requests): the first mention starts a linked task and later mentions on the same issue resume that task.
- Show ChatGPT, GitHub Copilot, and Kimi for Coding plan usage on Settings > Models, including remaining premium requests or rate-limit window percent used and reset times.

### Patch changes

- Apply the untrusted-content prompt framing to GitLab, Bitbucket, Azure DevOps, and Gitea comment follow-up messages, wrapping the triggering comment in a mention-request block and appending the shared injection-resistance policy
