### PR TITLE
Fix persisted worker bootstrap recovery query

### DIFF
--- a/apps/controller/src/BaseController.ts
+++ b/apps/controller/src/BaseController.ts
@@ -18,7 +18,6 @@ import {
   type TaskRun,
   db,
   taskRuns,
-  taskRunEvents,
   buildPendingEnvironmentSnapshotMatchForTaskRun,
   recordTaskRunLifecycleEvent,
   resolveDefaultComputeProvider,
@@ -41,6 +40,7 @@ import {
   captureControllerMessage,
 } from './monitoring/sentry';
 import { resolveFromWorkspaceRoot } from './repo-paths';
+import { findPersistedWorkerBootstrapRestarts } from './worker-bootstrap-restarts';
 
 type WorkerBootstrapExitDisposition = 'ignore' | 'restart' | 'failed';
 
@@ -677,21 +677,7 @@ export abstract class BaseController {
   }
 
   protected async recoverPersistedWorkerBootstrapRestarts(): Promise<number> {
-    const scheduledRuns = await db.query.taskRuns.findMany({
-      where: and(
-        eq(taskRuns.status, RunStatus.Pending),
-        isNull(taskRuns.startedAt),
-        isNull(taskRuns.canceledAt),
-        sql`EXISTS (
-          SELECT 1
-          FROM ${taskRunEvents}
-          WHERE ${taskRunEvents.runId} = ${taskRuns.id}
-            AND ${taskRunEvents.source} = 'run_lifecycle'
-            AND ${taskRunEvents.details} ->> 'stage' = 'worker_bootstrap_restart'
-        )`,
-      ),
-      orderBy: [asc(taskRuns.createdAt)],
-    });
+    const scheduledRuns = await findPersistedWorkerBootstrapRestarts();
 
     let recoveredCount = 0;
 

--- a/apps/controller/src/__tests__/BaseController.test.ts
+++ b/apps/controller/src/__tests__/BaseController.test.ts
@@ -14,6 +14,7 @@ const {
   mockTaskRunsFindMany,
   mockOrgsFindFirst,
   mockDequeueTaskRun,
+  mockFindPersistedWorkerBootstrapRestarts,
   mockGetOrphanedTaskRun,
   mockRecordTaskRunLifecycleEvent,
   mockRedisSet,
@@ -27,6 +28,7 @@ const {
   mockTaskRunsFindMany: vi.fn(),
   mockOrgsFindFirst: vi.fn(),
   mockDequeueTaskRun: vi.fn().mockResolvedValue(null),
+  mockFindPersistedWorkerBootstrapRestarts: vi.fn().mockResolvedValue([]),
   mockGetOrphanedTaskRun: vi.fn().mockResolvedValue(null),
   mockRecordTaskRunLifecycleEvent: vi.fn().mockResolvedValue(undefined),
   mockRedisSet: vi.fn().mockResolvedValue('OK'),
@@ -99,6 +101,11 @@ vi.mock('@roomote/cloud-agents/server', () => ({
 
 vi.mock('../orphaned-task-runs', () => ({
   getOrphanedTaskRun: (...args: unknown[]) => mockGetOrphanedTaskRun(...args),
+}));
+
+vi.mock('../worker-bootstrap-restarts', () => ({
+  findPersistedWorkerBootstrapRestarts: (...args: unknown[]) =>
+    mockFindPersistedWorkerBootstrapRestarts(...args),
 }));
 
 vi.mock('../monitoring/sentry', () => ({
@@ -196,6 +203,7 @@ function resetControllerMocks() {
   mockTaskRunsFindFirst.mockResolvedValue(null);
   mockTaskRunsFindMany.mockResolvedValue([]);
   mockDequeueTaskRun.mockResolvedValue(null);
+  mockFindPersistedWorkerBootstrapRestarts.mockResolvedValue([]);
   mockGetOrphanedTaskRun.mockResolvedValue(null);
   mockRecordTaskRunLifecycleEvent.mockResolvedValue(undefined);
   mockRedisSet.mockResolvedValue('OK');
@@ -642,7 +650,7 @@ describe('BaseController.handleWorkerExitBeforeStart', () => {
   });
 
   it('recovers every persisted bootstrap restart after controller state is lost', async () => {
-    mockTaskRunsFindMany.mockResolvedValueOnce([
+    mockFindPersistedWorkerBootstrapRestarts.mockResolvedValueOnce([
       makeTaskRun({ id: 46, status: RunStatus.Pending }),
       makeTaskRun({ id: 47, status: RunStatus.Pending }),
     ]);

--- a/apps/controller/src/__tests__/worker-bootstrap-restarts.test.ts
+++ b/apps/controller/src/__tests__/worker-bootstrap-restarts.test.ts
@@ -1,0 +1,21 @@
+import { drizzle } from '@roomote/db/server';
+
+import { buildPersistedWorkerBootstrapRestartsQuery } from '../worker-bootstrap-restarts';
+
+describe('buildPersistedWorkerBootstrapRestartsQuery', () => {
+  it('preserves the inner event table and outer run table in correlated SQL', () => {
+    const database = drizzle.mock();
+    const query = buildPersistedWorkerBootstrapRestartsQuery(database);
+    const generated = query.toSQL();
+
+    expect(generated.sql).toContain(
+      '"task_run_events"."run_id" = "task_runs"."id"',
+    );
+    expect(generated.sql).toContain('"task_run_events"."source" = $2');
+    expect(generated.sql).toContain(
+      '"task_run_events"."details" ->> \'stage\' = \'worker_bootstrap_restart\'',
+    );
+    expect(generated.sql).not.toContain('"taskRuns"."run_id"');
+    expect(generated.params).toEqual(['pending', 'run_lifecycle']);
+  });
+});

--- a/apps/controller/src/worker-bootstrap-restarts.ts
+++ b/apps/controller/src/worker-bootstrap-restarts.ts
@@ -1,0 +1,49 @@
+import { RunStatus } from '@roomote/types';
+import {
+  and,
+  asc,
+  db,
+  eq,
+  exists,
+  isNull,
+  sql,
+  taskRunEvents,
+  taskRuns,
+} from '@roomote/db/server';
+
+type SelectDatabase = Pick<typeof db, 'select'>;
+
+export function buildPersistedWorkerBootstrapRestartsQuery(
+  database: SelectDatabase = db,
+) {
+  const matchingRestartEvent = database
+    .select({ id: taskRunEvents.id })
+    .from(taskRunEvents)
+    .where(
+      and(
+        eq(taskRunEvents.runId, taskRuns.id),
+        eq(taskRunEvents.source, 'run_lifecycle'),
+        sql`${taskRunEvents.details} ->> 'stage' = 'worker_bootstrap_restart'`,
+      ),
+    );
+
+  // Use the core query builder here. The relational query builder aliases the
+  // outer task_runs table and remaps columns inside correlated raw SQL, which
+  // can incorrectly turn task_run_events.run_id into taskRuns.run_id.
+  return database
+    .select()
+    .from(taskRuns)
+    .where(
+      and(
+        eq(taskRuns.status, RunStatus.Pending),
+        isNull(taskRuns.startedAt),
+        isNull(taskRuns.canceledAt),
+        exists(matchingRestartEvent),
+      ),
+    )
+    .orderBy(asc(taskRuns.createdAt));
+}
+
+export async function findPersistedWorkerBootstrapRestarts() {
+  return buildPersistedWorkerBootstrapRestartsQuery();
+}

--- a/packages/db/src/server.ts
+++ b/packages/db/src/server.ts
@@ -24,6 +24,7 @@ export {
   lt,
   lte,
   count,
+  exists,
   max,
   isNotNull,
   isNull,


### PR DESCRIPTION
## What changed

- move the persisted worker-bootstrap restart lookup to a dedicated core Drizzle query
- preserve the correlated `task_run_events.run_id = task_runs.id` reference
- add regression coverage that inspects the generated SQL and rejects the invalid relational alias

## Why

The relational query builder aliased the outer `task_runs` table and remapped columns inside the correlated raw SQL fragment. That produced references such as `taskRuns.run_id`, `taskRuns.source`, and `taskRuns.details`, even though those columns belong to `task_run_events`. PostgreSQL rejected the recovery scan and interrupted controller iterations.

## Impact

Controllers can scan for persisted bootstrap restarts without query failures, allowing queued work and bootstrap recovery to continue normally.

## Validation

- full controller Vitest suite: 117 passed, 2 skipped
- controller and database TypeScript checks
- controller and database ESLint checks
- repository formatting check
- generated-SQL regression test
- corrected read-only correlation accepted by PostgreSQL
