### PR TITLE
[Improve] Show linked work in Task Info

### DIFF
--- a/.changeset/show-linked-work-in-task-info.md
+++ b/.changeset/show-linked-work-in-task-info.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Show linked issues and work items in the Task Info panel.

--- a/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-panels/TaskInfoPanel.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-panels/TaskInfoPanel.client.test.tsx
@@ -395,6 +395,99 @@ describe('TaskInfoPanel', () => {
     expect(screen.getByText('Last Error')).toBeInTheDocument();
   });
 
+  it('links titled work items from the task payload', () => {
+    render(
+      <TaskInfoPanel
+        active={true}
+        task={baseTask as never}
+        taskRun={
+          {
+            ...baseTaskRun,
+            payload: {
+              ...baseTaskRun.payload,
+              linkedWorkItems: [
+                {
+                  provider: 'github',
+                  identifier: '42',
+                  repository: 'RooCodeInc/Roomote',
+                  title: 'Keep GitHub issue follow-ups on one task',
+                  url: 'https://github.com/RooCodeInc/Roomote/issues/42',
+                },
+                {
+                  provider: 'linear',
+                  identifier: 'ENG-123',
+                  title: 'Show linked work in Task Info',
+                  url: 'https://linear.app/roomote/issue/ENG-123',
+                },
+              ],
+            },
+          } as never
+        }
+        harness="opencode-server"
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Linked Work')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {
+        name: 'Keep GitHub issue follow-ups on one task RooCodeInc/Roomote#42',
+      }),
+    ).toHaveAttribute(
+      'href',
+      'https://github.com/RooCodeInc/Roomote/issues/42',
+    );
+    expect(
+      screen.getByRole('link', {
+        name: 'Show linked work in Task Info ENG-123',
+      }),
+    ).toHaveAttribute('href', 'https://linear.app/roomote/issue/ENG-123');
+  });
+
+  it('shows an identifier when linked work has no title or URL', () => {
+    render(
+      <TaskInfoPanel
+        active={true}
+        task={baseTask as never}
+        taskRun={
+          {
+            ...baseTaskRun,
+            payload: {
+              ...baseTaskRun.payload,
+              linkedWorkItems: [
+                {
+                  provider: 'github',
+                  identifier: '42',
+                  repository: 'RooCodeInc/Roomote',
+                  url: '   ',
+                },
+              ],
+            },
+          } as never
+        }
+        harness="opencode-server"
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('RooCodeInc/Roomote#42')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('hides linked work when the task has no linked items', () => {
+    render(
+      <TaskInfoPanel
+        active={true}
+        task={baseTask as never}
+        taskRun={baseTaskRun as never}
+        harness="opencode-server"
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText('Linked Work')).not.toBeInTheDocument();
+  });
+
   it('shows the runtime row when debug UI is enabled', () => {
     showDebugUiState.isDebugUIVisible = true;
 

--- a/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-panels/TaskInfoPanel.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-panels/TaskInfoPanel.tsx
@@ -7,6 +7,7 @@ import { Streamdown } from 'streamdown';
 import {
   type ComputeProvider,
   type CodingHarness,
+  type LinkedWorkItem,
   type SourceControlProvider,
   HARNESS_LABELS,
   PRODUCT_NAME,
@@ -125,6 +126,52 @@ const SOURCE_CONTROL_SURFACES: ReadonlySet<string> = new Set([
   'ado',
 ]);
 
+function getLinkedWorkItemReference(item: LinkedWorkItem): string {
+  if (item.provider === 'github' && item.repository) {
+    return `${item.repository}#${item.identifier}`;
+  }
+
+  return item.identifier;
+}
+
+function LinkedWorkItemDisplay({ item }: { item: LinkedWorkItem }) {
+  const title = item.title?.trim();
+  const url = item.url?.trim();
+  const reference = getLinkedWorkItemReference(item);
+  const content = (
+    <>
+      <BrandIcon
+        icon={item.provider}
+        name=""
+        className="mt-0.5 size-3.5 shrink-0 text-muted-foreground"
+      />
+      <span className="min-w-0">
+        <span className="block truncate">{title || reference}</span>
+        {title ? (
+          <span className="block truncate text-xs text-muted-foreground">
+            {reference}
+          </span>
+        ) : null}
+      </span>
+    </>
+  );
+
+  if (!url) {
+    return <span className="flex min-w-0 items-start gap-1.5">{content}</span>;
+  }
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex min-w-0 items-start gap-1.5 hover:underline"
+    >
+      {content}
+    </a>
+  );
+}
+
 function getStartedFrom(
   task: SessionTask,
   taskRun: SessionTaskRun,
@@ -191,6 +238,7 @@ export function TaskInfoPanel({
 
   const taskRunError = getTaskRunDisplayError(taskRun);
   const startedFrom = getStartedFrom(task, taskRun);
+  const linkedWorkItems = taskRun.payload?.linkedWorkItems ?? [];
   const effectiveHarness = taskRun.harness ?? harness;
   const HarnessIcon = HARNESS_ICONS[effectiveHarness];
   const SandboxProviderIcon = taskRun.vendor
@@ -387,6 +435,24 @@ export function TaskInfoPanel({
                   </td>
                 </tr>
               )}
+
+              {linkedWorkItems.length > 0 ? (
+                <tr>
+                  <td className="pr-4 py-1 align-top whitespace-nowrap">
+                    Linked Work
+                  </td>
+                  <td className="py-1">
+                    <div className="flex max-w-72 flex-col gap-2">
+                      {linkedWorkItems.map((item, index) => (
+                        <LinkedWorkItemDisplay
+                          key={`${item.provider}:${item.repository ?? ''}:${item.identifier}:${item.url ?? ''}:${index}`}
+                          item={item}
+                        />
+                      ))}
+                    </div>
+                  </td>
+                </tr>
+              ) : null}
 
               <tr>
                 <td className="pr-4 py-1 align-top whitespace-nowrap">


### PR DESCRIPTION
## Summary
- show existing linked work-item metadata in the Task Info panel
- link titled GitHub, Gitea, Linear, Jira, Asana, and GitLab work items when URLs are available
- keep the row hidden for tasks without linked work

## Testing
- `pnpm exec dotenvx run -- pnpm --filter @roomote/web exec vitest run 'src/app/(sandbox)/task/[taskId]/sidebar-panels/TaskInfoPanel.client.test.tsx'`
- `pnpm --filter @roomote/web check-types`
- targeted oxfmt, oxlint, and ESLint checks
