### PR TITLE
[Improve] Speed up authenticated navigation

### DIFF
--- a/.changeset/faster-authenticated-navigation.md
+++ b/.changeset/faster-authenticated-navigation.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Make authenticated navigation respond immediately and avoid redundant user profile writes during routine authorization checks.

--- a/apps/web/src/app/(authenticated)/loading.tsx
+++ b/apps/web/src/app/(authenticated)/loading.tsx
@@ -1,0 +1,25 @@
+import { Skeleton } from '@/components/system';
+
+export default function AuthenticatedRouteLoading() {
+  return (
+    <div
+      className="min-h-full w-full overflow-hidden bg-background p-8"
+      role="status"
+      aria-label="Loading page"
+    >
+      <div className="w-full max-w-6xl space-y-6">
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-56" />
+          <Skeleton className="h-4 w-full max-w-xl" />
+        </div>
+
+        <div className="space-y-4">
+          <Skeleton className="h-28 w-full rounded-xl" />
+          <Skeleton className="h-28 w-full rounded-xl" />
+          <Skeleton className="h-28 w-full rounded-xl" />
+        </div>
+      </div>
+      <span className="sr-only">Loading page</span>
+    </div>
+  );
+}

--- a/apps/web/src/lib/server/auth-context.test.ts
+++ b/apps/web/src/lib/server/auth-context.test.ts
@@ -153,9 +153,19 @@ describe('authorize', () => {
     });
     mockUsersFindFirst.mockResolvedValue({
       id: 'user-1',
+      name: 'Jane Admin',
+      email: 'jane@example.com',
+      entity: {
+        id: 'user-1',
+        name: 'Jane Admin',
+        email: 'jane@example.com',
+        imageUrl: 'https://example.com/avatar.png',
+      },
+      role: 'admin',
       createdAt: new Date('2025-01-01T00:00:00.000Z'),
       imageUrl: 'https://example.com/avatar.png',
       onboardingCompletedAt: new Date('2025-01-01T00:00:00.000Z'),
+      deletedAt: null,
     });
     mockUpdateWhere.mockResolvedValue([]);
   });
@@ -172,6 +182,66 @@ describe('authorize', () => {
     expect(mockUpdateSet).not.toHaveBeenCalledWith(
       expect.objectContaining({
         metadata: expect.anything(),
+      }),
+    );
+  });
+
+  it('does not write an unchanged existing user during authorization', async () => {
+    const result = await authorize();
+
+    expect(result.success).toBe(true);
+    expect(mockUpdateSet).not.toHaveBeenCalled();
+  });
+
+  it('keeps an unchanged member with incomplete onboarding read-only', async () => {
+    mockUsersFindFirst.mockResolvedValue({
+      id: 'user-1',
+      name: 'Jane Admin',
+      email: 'jane@example.com',
+      entity: {
+        id: 'user-1',
+        name: 'Jane Admin',
+        email: 'jane@example.com',
+        imageUrl: 'https://example.com/avatar.png',
+      },
+      role: 'member',
+      createdAt: new Date('2025-01-01T00:00:00.000Z'),
+      imageUrl: 'https://example.com/avatar.png',
+      onboardingCompletedAt: null,
+      deletedAt: null,
+    });
+
+    const result = await authorize();
+
+    expect(result.success).toBe(true);
+    expect(mockUpdateSet).not.toHaveBeenCalled();
+  });
+
+  it('syncs an existing user when their auth profile changes', async () => {
+    mockUsersFindFirst.mockResolvedValue({
+      id: 'user-1',
+      name: 'Old Name',
+      email: 'jane@example.com',
+      entity: {
+        id: 'user-1',
+        name: 'Old Name',
+        email: 'jane@example.com',
+        imageUrl: 'https://example.com/avatar.png',
+      },
+      role: 'admin',
+      createdAt: new Date('2025-01-01T00:00:00.000Z'),
+      imageUrl: 'https://example.com/avatar.png',
+      onboardingCompletedAt: new Date('2025-01-01T00:00:00.000Z'),
+      deletedAt: null,
+    });
+
+    const result = await authorize();
+
+    expect(result.success).toBe(true);
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Jane Admin',
+        entity: expect.objectContaining({ name: 'Jane Admin' }),
       }),
     );
   });

--- a/apps/web/src/lib/server/auth-context.ts
+++ b/apps/web/src/lib/server/auth-context.ts
@@ -42,6 +42,23 @@ type SignedInAuthContextOptions = {
   treatPendingAsSignedOut?: boolean;
 };
 
+async function loadDeploymentIdentityState(userId: string) {
+  const [existingDeploymentSettings, existingUser] = await Promise.all([
+    db.query.deploymentSettings.findFirst({
+      where: eq(deploymentSettings.id, DEFAULT_DEPLOYMENT_ID),
+    }),
+    db.query.users.findFirst({
+      where: eq(users.id, userId),
+    }),
+  ]);
+
+  return { existingDeploymentSettings, existingUser };
+}
+
+type DeploymentIdentityState = Awaited<
+  ReturnType<typeof loadDeploymentIdentityState>
+>;
+
 function createUserResource({
   userId,
   name,
@@ -82,6 +99,7 @@ async function ensureDeploymentIdentity({
   imageUrl,
   invitedByInviteId,
   admittedViaBootstrap,
+  identityState,
 }: {
   userId: string;
   name: string;
@@ -89,14 +107,11 @@ async function ensureDeploymentIdentity({
   imageUrl?: string | null;
   invitedByInviteId?: string | null;
   admittedViaBootstrap?: boolean;
+  identityState: DeploymentIdentityState;
 }) {
   const now = new Date();
   let deploymentMetadata: Record<string, unknown>;
-
-  const existingDeploymentSettings =
-    await db.query.deploymentSettings.findFirst({
-      where: eq(deploymentSettings.id, DEFAULT_DEPLOYMENT_ID),
-    });
+  const { existingDeploymentSettings, existingUser } = identityState;
 
   if (existingDeploymentSettings) {
     deploymentMetadata = normalizeMetadataRecord(
@@ -111,10 +126,6 @@ async function ensureDeploymentIdentity({
       setupCompletedAt: null,
     });
   }
-
-  const existingUser = await db.query.users.findFirst({
-    where: eq(users.id, userId),
-  });
 
   const userEntity = {
     id: userId,
@@ -208,10 +219,11 @@ async function ensureDeploymentIdentity({
         ? 'member'
         : existingUser.role;
 
+    const desiredImageUrl = imageUrl ?? existingUser.imageUrl;
     const profileUpdate = {
       name,
       email,
-      imageUrl: imageUrl ?? existingUser.imageUrl,
+      imageUrl: desiredImageUrl,
       entity: userEntity,
       // A null timestamp is intentional for an incomplete Member. Do not turn
       // later authentication checks into an implicit onboarding completion.
@@ -235,7 +247,13 @@ async function ensureDeploymentIdentity({
           .set({ ...profileUpdate, deletedAt: null, role })
           .where(eq(users.id, userId));
       });
-    } else {
+    } else if (
+      existingUser.name !== name ||
+      existingUser.email !== email ||
+      existingUser.imageUrl !== desiredImageUrl ||
+      (admittedViaBootstrap && existingUser.role !== 'admin') ||
+      !isMatchingUserEntity(existingUser.entity, userEntity)
+    ) {
       await db.update(users).set(profileUpdate).where(eq(users.id, userId));
     }
   }
@@ -251,6 +269,25 @@ async function ensureDeploymentIdentity({
       createdAt: existingUser?.createdAt ?? now,
     }),
   };
+}
+
+function isMatchingUserEntity(
+  value: unknown,
+  expected: { id: string; name: string; email: string; imageUrl: string },
+): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const entity = value as Record<string, unknown>;
+
+  return (
+    Object.keys(entity).length === 4 &&
+    entity.id === expected.id &&
+    entity.name === expected.name &&
+    entity.email === expected.email &&
+    entity.imageUrl === expected.imageUrl
+  );
 }
 
 async function getBetterAuthSession() {
@@ -278,10 +315,13 @@ export async function getSignedInAuthContext(
   const primaryEmail = sessionUser.email;
   const imageUrl = sessionUser.image ?? '';
 
-  const accessDecision = await evaluateSignInAccess({
-    userId,
-    email: primaryEmail,
-  });
+  const [accessDecision, identityState] = await Promise.all([
+    evaluateSignInAccess({
+      userId,
+      email: primaryEmail,
+    }),
+    loadDeploymentIdentityState(userId),
+  ]);
 
   if (!accessDecision.allowed) {
     return { success: false, error: 'Unauthorized: Not a member' };
@@ -300,6 +340,7 @@ export async function getSignedInAuthContext(
       imageUrl,
       invitedByInviteId,
       admittedViaBootstrap: accessDecision.via === 'bootstrap',
+      identityState,
     });
   } catch (error) {
     if (error instanceof InviteRedemptionFailedError) {


### PR DESCRIPTION
## Summary

- show an immediate loading skeleton during authenticated route transitions
- overlap independent authorization reads with access evaluation
- avoid rewriting unchanged user profiles during routine authorization checks
- preserve profile synchronization, member onboarding state, restoration, and bootstrap promotion behavior

## Validation

- pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/web exec vitest run src/lib/server/auth-context.test.ts
- pnpm --filter @roomote/web check-types
- targeted oxfmt, oxlint, and ESLint checks
- git diff --check

## Release note

Includes a patch changeset for the navigation and authorization performance improvement.