### PR TITLE
[Fix] Invalid auth cookies no longer crash page rendering

### DIFF
--- a/.changeset/handle-invalid-auth-cookies.md
+++ b/.changeset/handle-invalid-auth-cookies.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Treat invalid or expired authentication cookies as signed-out sessions instead of failing the page render.

--- a/apps/web/src/lib/server/auth-context.test.ts
+++ b/apps/web/src/lib/server/auth-context.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FeatureFlag } from '@roomote/feature-flags';
+import { APIError } from 'better-auth/api';
 
 const {
   mockDeploymentFindFirst,
@@ -174,6 +175,28 @@ describe('authorize', () => {
         metadata: expect.anything(),
       }),
     );
+  });
+
+  it('treats invalid auth cookies as signed out instead of throwing', async () => {
+    mockGetSession.mockRejectedValue(
+      new APIError('UNAUTHORIZED', {
+        message: 'Invalid session',
+      }),
+    );
+
+    await expect(authorize()).resolves.toEqual({
+      success: false,
+      error: 'Unauthorized: User required',
+    });
+  });
+
+  it('does not hide auth service failures as signed-out sessions', async () => {
+    const error = new APIError('INTERNAL_SERVER_ERROR', {
+      message: 'Session store unavailable',
+    });
+    mockGetSession.mockRejectedValue(error);
+
+    await expect(authorize()).rejects.toBe(error);
   });
 
   it('admits a bootstrap sign-in as admin even when another user already exists', async () => {

--- a/apps/web/src/lib/server/auth-context.ts
+++ b/apps/web/src/lib/server/auth-context.ts
@@ -1,4 +1,5 @@
 import { headers } from 'next/headers';
+import { APIError } from 'better-auth/api';
 
 import { db, deploymentSettings, eq, invites, users } from '@roomote/db/server';
 import type { UserRole } from '@roomote/types';
@@ -256,9 +257,19 @@ async function ensureDeploymentIdentity({
 async function getBetterAuthSession() {
   const auth = await getAuth();
 
-  return auth.api.getSession({
-    headers: await headers(),
-  });
+  try {
+    return await auth.api.getSession({
+      headers: await headers(),
+    });
+  } catch (error) {
+    // Invalid or expired auth cookies should behave like a signed-out
+    // visitor on server renders instead of crashing the whole page.
+    if (error instanceof APIError && error.statusCode === 401) {
+      return null;
+    }
+
+    throw error;
+  }
 }
 
 export async function getSignedInAuthContext(


### PR DESCRIPTION
## Summary

- treat unauthorized session lookup failures as signed-out sessions during server rendering
- preserve 500-level Better Auth failures so infrastructure errors remain visible
- cover both behaviors with focused authorization tests

## Validation

- pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/web exec vitest run src/lib/server/auth-context.test.ts
- pnpm --filter @roomote/web check-types
- targeted oxfmt, oxlint, and ESLint checks
- git diff --check

## Release note

Includes a patch changeset for invalid and expired authentication cookie handling.