### PR TITLE
[Improve] Speed home and settings navigation

### DIFF
--- a/.changeset/faster-home-settings-navigation.md
+++ b/.changeset/faster-home-settings-navigation.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Make home and personal settings navigation render without waiting on unrelated provider, GitHub, or repeated authentication lookups.

--- a/apps/web/src/app/(authenticated)/home/Home.client.test.tsx
+++ b/apps/web/src/app/(authenticated)/home/Home.client.test.tsx
@@ -17,10 +17,6 @@ let currentFeatureFlags: Record<string, boolean> = {};
 let currentCloudEnabled = false;
 let currentShowDebugUI = false;
 let currentShowDebugUILoading = false;
-let currentGitHubInstallations = [{ id: 'installation-1' }];
-let currentGitHubInstallationsPending = false;
-let currentGitHubInstallationsFetching = false;
-let currentGitHubInstallationsSuccess = true;
 let currentEnvironments: Array<{ id: string; name: string }> | undefined = [
   { id: 'env-1', name: 'Primary Env' },
   { id: 'env-2', name: 'Secondary Env' },
@@ -81,15 +77,6 @@ vi.mock('@/hooks/useUser', () => ({
       imageUrl: '',
       createdAt: null,
     },
-  }),
-}));
-
-vi.mock('@/hooks/github', () => ({
-  useGitHubInstallations: () => ({
-    data: currentGitHubInstallations,
-    isPending: currentGitHubInstallationsPending,
-    isFetching: currentGitHubInstallationsFetching,
-    isSuccess: currentGitHubInstallationsSuccess,
   }),
 }));
 
@@ -339,10 +326,6 @@ describe('Home', () => {
     currentCloudEnabled = false;
     currentShowDebugUI = false;
     currentShowDebugUILoading = false;
-    currentGitHubInstallations = [{ id: 'installation-1' }];
-    currentGitHubInstallationsPending = false;
-    currentGitHubInstallationsFetching = false;
-    currentGitHubInstallationsSuccess = true;
     currentEnvironments = [
       { id: 'env-1', name: 'Primary Env' },
       { id: 'env-2', name: 'Secondary Env' },
@@ -461,17 +444,6 @@ describe('Home', () => {
     } finally {
       vi.useRealTimers();
     }
-  });
-
-  it('keeps the home page available when GitHub installations are empty', () => {
-    currentGitHubInstallations = [];
-
-    render(<Home initialPlaceholderIndex={0} />);
-
-    expect(
-      screen.getByRole('heading', { name: /let's get started/i }),
-    ).toBeInTheDocument();
-    expect(mockPush).not.toHaveBeenCalledWith('/tasks');
   });
 
   it('launches a standard task run without an agent identity for routed workspaces', async () => {

--- a/apps/web/src/app/(authenticated)/home/Home.tsx
+++ b/apps/web/src/app/(authenticated)/home/Home.tsx
@@ -23,7 +23,6 @@ import { preparePromptAttachments } from '@/lib/prompt-attachments';
 import { cn } from '@/lib/utils';
 
 import { useEnvironments } from '@/hooks/environments';
-import { useGitHubInstallations } from '@/hooks/github';
 import { useShowDebugUI } from '@/hooks/useShowDebugUI';
 import { useAuthorizedUser } from '@/hooks/useUser';
 import { useLaunchTaskModels } from '@/hooks/task-models/useLaunchTaskModels';
@@ -105,7 +104,6 @@ export function Home({
   availableComputeProviders,
 }: HomeProps) {
   const router = useRouter();
-  const githubInstallations = useGitHubInstallations();
   const environments = useEnvironments();
   const { cloudEnabled } = useAuthorizedUser();
 
@@ -596,10 +594,6 @@ export function Home({
       wiggleWorkspace,
     ],
   );
-
-  if (githubInstallations.isPending) {
-    return null;
-  }
 
   return (
     <FormProvider {...form}>

--- a/apps/web/src/app/(authenticated)/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/page.test.tsx
@@ -1,6 +1,17 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 
-const { mockHome } = vi.hoisted(() => ({
+const {
+  mockHome,
+  mockResolveComputeProviderSelection,
+  mockResolveDefaultComputeProvider,
+  runtimeState,
+} = vi.hoisted(() => ({
+  mockResolveComputeProviderSelection: vi.fn().mockResolvedValue({
+    defaultComputeProvider: 'modal',
+    availableComputeProviders: ['modal', 'docker'],
+  }),
+  mockResolveDefaultComputeProvider: vi.fn().mockResolvedValue('roomote'),
+  runtimeState: { cloudEnabled: false },
   mockHome: vi.fn(
     ({
       initialPlaceholderIndex,
@@ -25,10 +36,13 @@ vi.mock('./home/Home', () => ({
 }));
 
 vi.mock('@roomote/db/server', () => ({
-  resolveDefaultComputeProvider: vi.fn().mockResolvedValue('modal'),
-  listConfiguredComputeProviders: vi
-    .fn()
-    .mockResolvedValue(['modal', 'docker']),
+  resolveComputeProviderSelection: mockResolveComputeProviderSelection,
+  resolveDefaultComputeProvider: mockResolveDefaultComputeProvider,
+}));
+
+vi.mock('@/lib/server/env', () => ({
+  Env: { R_CLOUD_ENABLED: 'cloud-setting' },
+  isRoomoteCloudEnabled: () => runtimeState.cloudEnabled,
 }));
 
 vi.mock('@/lib/server/bootstrap-runtime-env', () => ({
@@ -43,7 +57,10 @@ import Page from './page';
 
 describe('Authenticated home page', () => {
   beforeEach(() => {
+    runtimeState.cloudEnabled = false;
     mockHome.mockClear();
+    mockResolveComputeProviderSelection.mockClear();
+    mockResolveDefaultComputeProvider.mockClear();
   });
 
   it('passes the server-selected placeholder index to Home', async () => {
@@ -60,5 +77,21 @@ describe('Authenticated home page', () => {
     expect(html).toContain('data-home-placeholder-index="4"');
     expect(html).toContain('data-home-compute-provider="modal"');
     expect(html).toContain('data-home-available-providers="modal,docker"');
+  });
+
+  it('does not scan picker options when cloud hides the provider picker', async () => {
+    runtimeState.cloudEnabled = true;
+
+    renderToStaticMarkup(await Page());
+
+    expect(mockResolveDefaultComputeProvider).toHaveBeenCalledOnce();
+    expect(mockResolveComputeProviderSelection).not.toHaveBeenCalled();
+    expect(mockHome).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultComputeProvider: 'roomote',
+        availableComputeProviders: ['roomote'],
+      }),
+      undefined,
+    );
   });
 });

--- a/apps/web/src/app/(authenticated)/page.tsx
+++ b/apps/web/src/app/(authenticated)/page.tsx
@@ -1,18 +1,23 @@
 import {
-  listConfiguredComputeProviders,
+  resolveComputeProviderSelection,
   resolveDefaultComputeProvider,
 } from '@roomote/db/server';
 
 import { bootstrapWebRuntimeEnv } from '@/lib/server/bootstrap-runtime-env';
+import { Env, isRoomoteCloudEnabled } from '@/lib/server/env';
 import { Home } from './home/Home';
 import { getRandomHomePromptPlaceholderIndex } from './home/promptPlaceholders';
 
 export default async function Page() {
   await bootstrapWebRuntimeEnv();
 
-  const [defaultComputeProvider, availableComputeProviders] = await Promise.all(
-    [resolveDefaultComputeProvider(), listConfiguredComputeProviders()],
-  );
+  const { defaultComputeProvider, availableComputeProviders } =
+    isRoomoteCloudEnabled(Env.R_CLOUD_ENABLED)
+      ? await resolveDefaultComputeProvider().then((provider) => ({
+          defaultComputeProvider: provider,
+          availableComputeProviders: [provider],
+        }))
+      : await resolveComputeProviderSelection();
 
   return (
     <Home

--- a/apps/web/src/app/(authenticated)/settings/page.client.test.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.client.test.tsx
@@ -4,21 +4,8 @@ vi.mock('@/components/settings/pages/EnvironmentsSettingsPage', () => ({
   EnvironmentsSettingsPage: () => <div>Environments Page</div>,
 }));
 
-vi.mock('@/components/settings/pages/PersonalSettingsPage', () => ({
-  PersonalSettingsPage: () => <div>Personal Settings Page</div>,
-}));
-
-vi.mock('@/lib/server/auth-context', () => ({
-  authorizeOrThrow: vi.fn(async () => ({
-    userId: 'user-1',
-    primaryEmail: 'test@example.com',
-    name: 'Test User',
-    resource: { imageUrl: null },
-  })),
-}));
-
-vi.mock('@/lib/server', () => ({
-  userHasCredentialAccount: vi.fn(async () => true),
+vi.mock('@/components/settings/pages/PersonalSettingsRoute', () => ({
+  PersonalSettingsRoute: () => <div>Personal Settings Page</div>,
 }));
 
 import Page from './page';

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -1,21 +1,5 @@
-import { PersonalSettingsPage } from '@/components/settings/pages/PersonalSettingsPage';
-import { authorizeOrThrow } from '@/lib/server/auth-context';
-import { userHasCredentialAccount } from '@/lib/server';
+import { PersonalSettingsRoute } from '@/components/settings/pages/PersonalSettingsRoute';
 
-export default async function Page() {
-  const authorizedUser = await authorizeOrThrow();
-  const canChangePassword = await userHasCredentialAccount(
-    authorizedUser.userId,
-  );
-
-  return (
-    <PersonalSettingsPage
-      canChangePassword={canChangePassword}
-      profile={{
-        email: authorizedUser.primaryEmail ?? '',
-        imageUrl: authorizedUser.resource.imageUrl,
-        name: authorizedUser.name ?? authorizedUser.primaryEmail ?? 'User',
-      }}
-    />
-  );
+export default function Page() {
+  return <PersonalSettingsRoute />;
 }

--- a/apps/web/src/app/(authenticated)/settings/personal/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/personal/page.tsx
@@ -1,21 +1,5 @@
-import { PersonalSettingsPage } from '@/components/settings/pages/PersonalSettingsPage';
-import { userHasCredentialAccount } from '@/lib/server';
-import { authorizeOrThrow } from '@/lib/server/auth-context';
+import { PersonalSettingsRoute } from '@/components/settings/pages/PersonalSettingsRoute';
 
-export default async function Page() {
-  const authorizedUser = await authorizeOrThrow();
-  const canChangePassword = await userHasCredentialAccount(
-    authorizedUser.userId,
-  );
-
-  return (
-    <PersonalSettingsPage
-      canChangePassword={canChangePassword}
-      profile={{
-        email: authorizedUser.primaryEmail ?? '',
-        imageUrl: authorizedUser.resource.imageUrl,
-        name: authorizedUser.name ?? authorizedUser.primaryEmail ?? 'User',
-      }}
-    />
-  );
+export default function Page() {
+  return <PersonalSettingsRoute />;
 }

--- a/apps/web/src/app/(authenticated)/settings/sandboxes/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/settings/sandboxes/page.test.tsx
@@ -1,0 +1,42 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+
+const { redirectMock, runtimeState } = vi.hoisted(() => ({
+  redirectMock: vi.fn(() => {
+    throw new Error('NEXT_REDIRECT');
+  }),
+  runtimeState: { cloudEnabled: false },
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+}));
+
+vi.mock('@/components/settings/pages/ComputeSettingsPage', () => ({
+  ComputeSettingsPage: () => <div>Compute settings</div>,
+}));
+
+vi.mock('@/lib/server/env', () => ({
+  Env: { R_CLOUD_ENABLED: 'cloud-setting' },
+  isRoomoteCloudEnabled: () => runtimeState.cloudEnabled,
+}));
+
+import Page from './page';
+
+describe('Sandbox settings page', () => {
+  beforeEach(() => {
+    runtimeState.cloudEnabled = false;
+    redirectMock.mockClear();
+  });
+
+  it('renders self-hosted sandbox settings without authorizing again', () => {
+    expect(renderToStaticMarkup(<Page />)).toContain('Compute settings');
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps cloud deployments redirected to personal settings', () => {
+    runtimeState.cloudEnabled = true;
+
+    expect(() => Page()).toThrow('NEXT_REDIRECT');
+    expect(redirectMock).toHaveBeenCalledWith('/settings/personal');
+  });
+});

--- a/apps/web/src/app/(authenticated)/settings/sandboxes/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/sandboxes/page.tsx
@@ -2,11 +2,10 @@ import { redirect } from 'next/navigation';
 
 import { ComputeSettingsPage } from '@/components/settings/pages/ComputeSettingsPage';
 import { SETTINGS_PATHS } from '@/lib/settings';
-import { authorizeOrThrow } from '@/lib/server/auth-context';
+import { Env, isRoomoteCloudEnabled } from '@/lib/server/env';
 
-export default async function Page() {
-  const user = await authorizeOrThrow();
-  if (user.cloudEnabled) {
+export default function Page() {
+  if (isRoomoteCloudEnabled(Env.R_CLOUD_ENABLED)) {
     redirect(SETTINGS_PATHS.personal);
   }
 

--- a/apps/web/src/components/settings/pages/PersonalSettingsRoute.test.tsx
+++ b/apps/web/src/components/settings/pages/PersonalSettingsRoute.test.tsx
@@ -1,0 +1,71 @@
+import { render } from '@testing-library/react';
+
+let accountCapabilities: { canChangePassword: boolean } | undefined = {
+  canChangePassword: true,
+};
+
+const { personalSettingsPageMock } = vi.hoisted(() => ({
+  personalSettingsPageMock: vi.fn(() => <div>Personal settings</div>),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({ data: accountCapabilities }),
+}));
+
+vi.mock('@/hooks/useUser', () => ({
+  useAuthorizedUser: () => ({
+    name: 'Ada Lovelace',
+    primaryEmail: 'ada@example.com',
+    resource: { imageUrl: 'https://example.com/ada.png' },
+  }),
+}));
+
+vi.mock('@/trpc/client', () => ({
+  useTRPC: () => ({
+    preferences: {
+      accountCapabilities: {
+        queryOptions: () => ({}),
+      },
+    },
+  }),
+}));
+
+vi.mock('./PersonalSettingsPage', () => ({
+  PersonalSettingsPage: personalSettingsPageMock,
+}));
+
+import { PersonalSettingsRoute } from './PersonalSettingsRoute';
+
+describe('PersonalSettingsRoute', () => {
+  beforeEach(() => {
+    accountCapabilities = { canChangePassword: true };
+    personalSettingsPageMock.mockClear();
+  });
+
+  it('renders the profile from the existing authorized-user context', () => {
+    render(<PersonalSettingsRoute />);
+
+    expect(personalSettingsPageMock).toHaveBeenCalledWith(
+      {
+        canChangePassword: true,
+        profile: {
+          email: 'ada@example.com',
+          imageUrl: 'https://example.com/ada.png',
+          name: 'Ada Lovelace',
+        },
+      },
+      undefined,
+    );
+  });
+
+  it('renders immediately while account capabilities load', () => {
+    accountCapabilities = undefined;
+
+    render(<PersonalSettingsRoute />);
+
+    expect(personalSettingsPageMock).toHaveBeenCalledWith(
+      expect.objectContaining({ canChangePassword: false }),
+      undefined,
+    );
+  });
+});

--- a/apps/web/src/components/settings/pages/PersonalSettingsRoute.tsx
+++ b/apps/web/src/components/settings/pages/PersonalSettingsRoute.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { useAuthorizedUser } from '@/hooks/useUser';
+import { useTRPC } from '@/trpc/client';
+
+import { PersonalSettingsPage } from './PersonalSettingsPage';
+
+export function PersonalSettingsRoute() {
+  const user = useAuthorizedUser();
+  const trpc = useTRPC();
+  const accountCapabilities = useQuery(
+    trpc.preferences.accountCapabilities.queryOptions(),
+  );
+
+  return (
+    <PersonalSettingsPage
+      canChangePassword={accountCapabilities.data?.canChangePassword ?? false}
+      profile={{
+        email: user.primaryEmail ?? '',
+        imageUrl: user.resource.imageUrl,
+        name: user.name ?? user.primaryEmail ?? 'User',
+      }}
+    />
+  );
+}

--- a/apps/web/src/trpc/commands/preferences/index.ts
+++ b/apps/web/src/trpc/commands/preferences/index.ts
@@ -2,6 +2,7 @@ import { db, eq, users } from '@roomote/db/server';
 import { FeatureFlag } from '@roomote/feature-flags';
 
 import type { UserAuthSuccess } from '@/types';
+import { userHasCredentialAccount } from '@/lib/server/user-management';
 import {
   DEFAULT_PERSONAL_PREFERENCES,
   isPersonalColorTheme,
@@ -58,6 +59,14 @@ export async function getPersonalPreferencesCommand(
     showDebugUISettingEnabled:
       auth.featureFlags[FeatureFlag.ShowDebugUISetting] === true,
   });
+}
+
+export async function getPersonalAccountCapabilitiesCommand(
+  auth: UserAuthSuccess,
+) {
+  return {
+    canChangePassword: await userHasCredentialAccount(auth.userId),
+  };
 }
 
 export async function updatePersonalPreferencesCommand(

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -134,6 +134,7 @@ import {
   getLinkedMicrosoftTeamsAccountCommand,
 } from '../commands/linked-accounts';
 import {
+  getPersonalAccountCapabilitiesCommand,
   getPersonalPreferencesCommand,
   updatePersonalPreferencesCommand,
 } from '../commands/preferences';
@@ -1109,6 +1110,9 @@ export const appRouter = createRouter({
   }),
 
   preferences: createRouter({
+    accountCapabilities: protectedProcedure.query(({ ctx: { auth } }) =>
+      getPersonalAccountCapabilitiesCommand(auth),
+    ),
     getPersonal: protectedProcedure.query(({ ctx: { auth } }) =>
       getPersonalPreferencesCommand(auth),
     ),

--- a/packages/db/src/lib/__tests__/compute-runtime-config.test.ts
+++ b/packages/db/src/lib/__tests__/compute-runtime-config.test.ts
@@ -9,6 +9,7 @@ vi.mock('../../encryption', () => ({
 import {
   listConfiguredComputeProviders,
   resolveComputeProviderEnvValues,
+  resolveComputeProviderSelection,
   resolveDefaultComputeProvider,
 } from '../compute-runtime-config';
 
@@ -372,5 +373,32 @@ describe('resolveDefaultComputeProvider', () => {
     });
 
     expect(provider).toBe('docker');
+  });
+});
+
+describe('resolveComputeProviderSelection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDecryptSecrets.mockImplementation(async (value) => value);
+  });
+
+  it('resolves the default and available providers from one deployment read', async () => {
+    const executor = makeExecutor([]);
+
+    const selection = await resolveComputeProviderSelection({
+      runtimeEnv: {
+        DEFAULT_COMPUTE_PROVIDER: 'docker',
+        MODAL_TOKEN_ID: 'id',
+        MODAL_TOKEN_SECRET: 'secret',
+        MODAL_BASE_IMAGE_REF: 'registry.example.com/image:tag',
+      },
+      executor,
+    });
+
+    expect(selection).toEqual({
+      defaultComputeProvider: 'modal',
+      availableComputeProviders: ['modal', 'docker'],
+    });
+    expect(executor.query.deploymentSettings.findFirst).toHaveBeenCalledOnce();
   });
 });

--- a/packages/db/src/lib/compute-runtime-config.ts
+++ b/packages/db/src/lib/compute-runtime-config.ts
@@ -71,6 +71,100 @@ async function isComputeProviderConfigured(
   );
 }
 
+type PersistedRuntimeComputeConfig = Awaited<
+  ReturnType<typeof loadPersistedRuntimeComputeConfig>
+>;
+
+function getExcludedComputeProviders(
+  runtimeEnv: Partial<Record<string, string | undefined>>,
+  persistedComputeConfig: PersistedRuntimeComputeConfig,
+) {
+  const excludedProviders = parseExcludedComputeProviders(
+    runtimeEnv.EXCLUDED_COMPUTE_PROVIDERS,
+  );
+
+  for (const provider of persistedComputeConfig.excludedProviders) {
+    excludedProviders.add(provider);
+  }
+
+  return excludedProviders;
+}
+
+async function listConfiguredComputeProvidersFromState({
+  runtimeEnv,
+  executor,
+  excludedProviders,
+}: {
+  runtimeEnv: Partial<Record<string, string | undefined>>;
+  executor: DatabaseOrTransaction;
+  excludedProviders: ReadonlySet<ComputeProvider>;
+}): Promise<ComputeProvider[]> {
+  const providerChecks = await Promise.all(
+    SETUP_COMPUTE_PROVIDER_CATALOG.map(async ({ provider }) => {
+      if (excludedProviders.has(provider)) {
+        return null;
+      }
+
+      return (await isComputeProviderConfigured(provider, {
+        runtimeEnv,
+        executor,
+      }))
+        ? provider
+        : null;
+    }),
+  );
+
+  return providerChecks.filter(
+    (provider): provider is ComputeProvider => provider !== null,
+  );
+}
+
+function pickDefaultComputeProvider({
+  runtimeEnv,
+  persistedComputeConfig,
+  excludedProviders,
+  configuredProviders,
+}: {
+  runtimeEnv: Partial<Record<string, string | undefined>>;
+  persistedComputeConfig: PersistedRuntimeComputeConfig;
+  excludedProviders: ReadonlySet<ComputeProvider>;
+  configuredProviders: readonly ComputeProvider[];
+}): ComputeProvider {
+  if (
+    persistedComputeConfig.defaultProvider &&
+    !excludedProviders.has(persistedComputeConfig.defaultProvider)
+  ) {
+    return persistedComputeConfig.defaultProvider;
+  }
+
+  const runtimeDefault = runtimeEnv.DEFAULT_COMPUTE_PROVIDER?.trim();
+  if (
+    runtimeDefault &&
+    isComputeProvider(runtimeDefault) &&
+    !excludedProviders.has(runtimeDefault) &&
+    runtimeDefault !== 'docker'
+  ) {
+    return runtimeDefault;
+  }
+
+  const preferredConfigured =
+    pickPreferredConfiguredComputeProvider(configuredProviders);
+
+  if (
+    runtimeDefault === 'docker' &&
+    isComputeProvider(runtimeDefault) &&
+    !excludedProviders.has(runtimeDefault)
+  ) {
+    return preferredConfigured && preferredConfigured !== 'docker'
+      ? preferredConfigured
+      : 'docker';
+  }
+
+  return (
+    preferredConfigured ?? getDefaultAvailableComputeProvider(excludedProviders)
+  );
+}
+
 /**
  * Lists sandbox providers that are both not excluded and fully configured for
  * task launch. Used by surfaces that let users pick a compute backend.
@@ -86,33 +180,57 @@ export async function listConfiguredComputeProviders(
   const persistedComputeConfig = executor.query?.deploymentSettings
     ? await loadPersistedRuntimeComputeConfig(executor)
     : { defaultProvider: null, excludedProviders: [] };
-  const excludedProviders = parseExcludedComputeProviders(
-    runtimeEnv.EXCLUDED_COMPUTE_PROVIDERS,
+  const excludedProviders = getExcludedComputeProviders(
+    runtimeEnv,
+    persistedComputeConfig,
   );
-  for (const provider of persistedComputeConfig.excludedProviders) {
-    excludedProviders.add(provider);
-  }
 
-  // Preserve setup-catalog display order so callers that fall back to the first
-  // entry match the home dropdown ordering (modal, e2b, daytona, docker).
-  const providers: ComputeProvider[] = [];
+  // Promise.all keeps independent provider checks to one latency window while
+  // map/filter preserve setup-catalog display order.
+  return listConfiguredComputeProvidersFromState({
+    runtimeEnv,
+    executor,
+    excludedProviders,
+  });
+}
 
-  for (const { provider } of SETUP_COMPUTE_PROVIDER_CATALOG) {
-    if (excludedProviders.has(provider)) {
-      continue;
-    }
+/**
+ * Resolves both values needed by provider pickers with one deployment-settings
+ * read and one parallel readiness scan.
+ */
+export async function resolveComputeProviderSelection(
+  options: {
+    runtimeEnv?: Partial<Record<string, string | undefined>>;
+    executor?: DatabaseOrTransaction;
+  } = {},
+): Promise<{
+  defaultComputeProvider: ComputeProvider;
+  availableComputeProviders: ComputeProvider[];
+}> {
+  const runtimeEnv = options.runtimeEnv ?? process.env;
+  const executor = options.executor ?? db;
+  const persistedComputeConfig =
+    await loadPersistedRuntimeComputeConfig(executor);
+  const excludedProviders = getExcludedComputeProviders(
+    runtimeEnv,
+    persistedComputeConfig,
+  );
+  const availableComputeProviders =
+    await listConfiguredComputeProvidersFromState({
+      runtimeEnv,
+      executor,
+      excludedProviders,
+    });
 
-    if (
-      await isComputeProviderConfigured(provider, {
-        runtimeEnv,
-        executor,
-      })
-    ) {
-      providers.push(provider);
-    }
-  }
-
-  return providers;
+  return {
+    defaultComputeProvider: pickDefaultComputeProvider({
+      runtimeEnv,
+      persistedComputeConfig,
+      excludedProviders,
+      configuredProviders: availableComputeProviders,
+    }),
+    availableComputeProviders,
+  };
 }
 
 /**
@@ -136,12 +254,10 @@ export async function resolveDefaultComputeProvider(
   const executor = options.executor ?? db;
   const persistedComputeConfig =
     await loadPersistedRuntimeComputeConfig(executor);
-  const excludedProviders = parseExcludedComputeProviders(
-    runtimeEnv.EXCLUDED_COMPUTE_PROVIDERS,
+  const excludedProviders = getExcludedComputeProviders(
+    runtimeEnv,
+    persistedComputeConfig,
   );
-  for (const provider of persistedComputeConfig.excludedProviders) {
-    excludedProviders.add(provider);
-  }
 
   if (
     persistedComputeConfig.defaultProvider &&
@@ -163,29 +279,18 @@ export async function resolveDefaultComputeProvider(
   }
 
   // Docker env default or unset: resolve cloud-vs-Local Docker from readiness.
-  const configuredProviders = await listConfiguredComputeProviders({
+  const configuredProviders = await listConfiguredComputeProvidersFromState({
     runtimeEnv,
     executor,
+    excludedProviders,
   });
-  const preferredConfigured =
-    pickPreferredConfiguredComputeProvider(configuredProviders);
 
-  if (
-    runtimeDefault === 'docker' &&
-    isComputeProvider(runtimeDefault) &&
-    !excludedProviders.has(runtimeDefault)
-  ) {
-    if (preferredConfigured && preferredConfigured !== 'docker') {
-      return preferredConfigured;
-    }
-    return 'docker';
-  }
-
-  if (preferredConfigured) {
-    return preferredConfigured;
-  }
-
-  return getDefaultAvailableComputeProvider(excludedProviders);
+  return pickDefaultComputeProvider({
+    runtimeEnv,
+    persistedComputeConfig,
+    excludedProviders,
+    configuredProviders,
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

- resolve homepage sandbox-provider options once and check independent providers concurrently
- skip provider-picker discovery when Roomote Cloud hides that picker
- render the homepage without waiting for GitHub installation data used only by onboarding
- render personal settings from the existing authorized-user context and load password capabilities in the background
- avoid full user authorization on the Sandboxes route when only the deployment cloud flag is needed

## Validation

- `pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/db exec vitest run src/lib/__tests__/compute-runtime-config.test.ts` (21 tests)
- focused `@roomote/web` Vitest run covering home and settings navigation (39 tests)
- `pnpm --filter @roomote/db check-types`
- `pnpm --filter @roomote/web check-types`
- `pnpm --filter @roomote/db lint`
- `pnpm --filter @roomote/web lint`
