### PR TITLE
[Improve] Validate environment button for Local Docker settings

### DIFF
--- a/apps/bullmq/src/docker-validation-queue.ts
+++ b/apps/bullmq/src/docker-validation-queue.ts
@@ -1,0 +1,64 @@
+import { Queue, QueueEvents, Worker } from 'bullmq';
+
+import { DOCKER_VALIDATION_QUEUE_NAME } from '@roomote/types';
+import type { DockerEnvironmentValidationResult } from '@roomote/compute-providers';
+
+import { getRedis } from './redis';
+import {
+  type DockerValidationJobData,
+  dockerValidationJob,
+} from './jobs/docker-validation';
+
+export function startDockerValidationQueue() {
+  const connection = getRedis();
+
+  const queue = new Queue<
+    DockerValidationJobData,
+    DockerEnvironmentValidationResult,
+    string
+  >(DOCKER_VALIDATION_QUEUE_NAME, {
+    connection,
+    defaultJobOptions: {
+      // Validation is interactive and single-shot: the settings UI waits on
+      // the result, so a retry would only delay an accurate failure report.
+      attempts: 1,
+      removeOnComplete: { age: 600, count: 50 },
+      removeOnFail: { age: 3600 },
+    },
+  });
+
+  const worker = new Worker<
+    DockerValidationJobData,
+    DockerEnvironmentValidationResult,
+    string
+  >(DOCKER_VALIDATION_QUEUE_NAME, dockerValidationJob, {
+    connection,
+    concurrency: 1,
+    autorun: true,
+    // Image pulls can be slow on first validation.
+    lockDuration: 180_000,
+  });
+
+  worker.on('failed', (job, err) =>
+    console.error(
+      `[DockerValidationQueue] job ${job?.id} failed:`,
+      err.message,
+    ),
+  );
+
+  worker.on('error', (err) =>
+    console.error('[DockerValidationQueue] worker error:', err),
+  );
+
+  const queueEvents = new QueueEvents(DOCKER_VALIDATION_QUEUE_NAME, {
+    connection,
+  });
+
+  console.log('[DockerValidationQueue] Started docker validation worker');
+
+  return {
+    dockerValidationQueue: queue,
+    dockerValidationWorker: worker,
+    dockerValidationQueueEvents: queueEvents,
+  };
+}

--- a/apps/bullmq/src/index.ts
+++ b/apps/bullmq/src/index.ts
@@ -42,6 +42,7 @@ import { slackSuggestedTasksOnboardingFollowupJob } from './jobs/slack-suggested
 import { telegramSuggestedTasksOnboardingFollowupJob } from './jobs/telegram-suggested-tasks-onboarding-followup';
 import { teamsSuggestedTasksOnboardingFollowupJob } from './jobs/teams-suggested-tasks-onboarding-followup';
 import { startSnapshotQueue } from './snapshot-queue';
+import { startDockerValidationQueue } from './docker-validation-queue';
 import { startSlackPrInactivityQueue } from './slack-pr-inactivity-queue';
 import { startPrReviewNotificationQueue } from './pr-review-notification-queue';
 import { startTaskSleepQueue } from './task-sleep-queue';
@@ -99,6 +100,11 @@ const {
 
 const { snapshotQueue, snapshotWorker, snapshotQueueEvents } =
   startSnapshotQueue();
+const {
+  dockerValidationQueue,
+  dockerValidationWorker,
+  dockerValidationQueueEvents,
+} = startDockerValidationQueue();
 const {
   queue: taskSleepQueue,
   worker: taskSleepWorker,
@@ -161,6 +167,7 @@ createBullBoard({
     new BullMQAdapter(schedulerQueue, { readOnlyMode: false }),
     new BullMQAdapter(sandboxOidcRefreshQueue, { readOnlyMode: false }),
     new BullMQAdapter(snapshotQueue, { readOnlyMode: false }),
+    new BullMQAdapter(dockerValidationQueue, { readOnlyMode: false }),
     new BullMQAdapter(taskSleepQueue, { readOnlyMode: false }),
     new BullMQAdapter(slackAccountLinkEducationQueue, { readOnlyMode: false }),
     new BullMQAdapter(discordSuggestedTasksOnboardingFollowupQueue, {
@@ -309,6 +316,9 @@ async function gracefulShutdown() {
     await snapshotWorker.close();
     await snapshotQueueEvents.close();
     await snapshotQueue.close();
+    await dockerValidationWorker.close();
+    await dockerValidationQueueEvents.close();
+    await dockerValidationQueue.close();
     await taskSleepWorker.close();
     await taskSleepQueueEvents.close();
     await taskSleepQueue.close();

--- a/apps/bullmq/src/jobs/docker-validation.ts
+++ b/apps/bullmq/src/jobs/docker-validation.ts
@@ -1,0 +1,38 @@
+import type { Job } from 'bullmq';
+
+import { Env } from '@roomote/env';
+import {
+  validateDockerEnvironment,
+  type DockerEnvironmentValidationResult,
+} from '@roomote/compute-providers';
+
+export interface DockerValidationJobData {
+  /** Image resolved by the requesting web process; falls back to this process's env. */
+  image?: string;
+}
+
+/**
+ * Runs the Docker environment checks on behalf of the settings UI. This
+ * process holds the Docker socket in self-host Docker deployments; the web
+ * app does not, so it requests validation through this queue.
+ */
+export async function dockerValidationJob(
+  job: Job<DockerValidationJobData, DockerEnvironmentValidationResult, string>,
+): Promise<DockerEnvironmentValidationResult> {
+  const image = job.data.image?.trim() || Env.DOCKER_WORKER_IMAGE;
+
+  const result = await validateDockerEnvironment({
+    image,
+    ...(Env.DOCKER_WORKER_RELEASE_PATH
+      ? { releaseArchivePath: Env.DOCKER_WORKER_RELEASE_PATH }
+      : {}),
+  });
+
+  console.log(
+    `[DockerValidationQueue] validated image=${image} ok=${result.ok} ${JSON.stringify(
+      result.checks.map((check) => `${check.id}:${check.status}`),
+    )}`,
+  );
+
+  return result;
+}

--- a/apps/docs/providers/compute/docker.mdx
+++ b/apps/docs/providers/compute/docker.mdx
@@ -125,10 +125,16 @@ repositories.
 ## Verify setup
 
 1. select Docker as the sandbox provider
-2. start a small task from an environment
-3. confirm the task can clone the repository and run a simple command
-4. open task logs and verify output streams back to Roomote
-5. check that the worker container stops after the task completes
+2. use **Validate environment** in Settings → Sandboxes (Local Docker
+   section) to check the Docker daemon, worker image, and worker release
+   archive before starting anything
+3. start a small task from an environment
+4. confirm the task can clone the repository and run a simple command
+5. open task logs and verify output streams back to Roomote
+6. check that the worker container stops after the task completes
+
+The validation runs in the background worker service (the process with Docker
+socket access), so it reflects exactly what task boots will see.
 
 ## Common issues
 

--- a/apps/web/src/components/settings/ComputeProviderSection.client.test.tsx
+++ b/apps/web/src/components/settings/ComputeProviderSection.client.test.tsx
@@ -6,6 +6,11 @@ import type {
 
 import { ComputeProviderSection } from './ComputeProviderSection';
 
+// Requires a TRPCProvider; its behavior is not under test here.
+vi.mock('./DockerEnvironmentValidation', () => ({
+  DockerEnvironmentValidation: () => null,
+}));
+
 type ComputeProviderStatus = SetupComputeStatus['providers'][number];
 
 const apiKeyField: ComputeProviderStatus['fields'][number] = {

--- a/apps/web/src/components/settings/ComputeProviderSection.tsx
+++ b/apps/web/src/components/settings/ComputeProviderSection.tsx
@@ -37,6 +37,7 @@ import {
   Trash2,
 } from '@/components/system';
 import { Section } from './Section';
+import { DockerEnvironmentValidation } from './DockerEnvironmentValidation';
 
 const MASKED_VALUE = '••••••••••••••••••••••••••••';
 
@@ -404,6 +405,10 @@ export function ComputeProviderSection({
               </p>
             </div>
           </div>
+        ) : null}
+
+        {isLocalDocker && (localDockerEnabled ?? true) ? (
+          <DockerEnvironmentValidation />
         ) : null}
 
         {(!isLocalDocker || (localDockerEnabled ?? true)) &&

--- a/apps/web/src/components/settings/DockerEnvironmentValidation.tsx
+++ b/apps/web/src/components/settings/DockerEnvironmentValidation.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+
+import { useTRPC } from '@/trpc/client';
+import {
+  Alert,
+  AlertCircle,
+  AlertDescription,
+  Button,
+  Check,
+  Minus,
+  Spinner,
+} from '@/components/system';
+
+type ValidationOutput = {
+  status: 'completed' | 'unavailable';
+  message?: string;
+  result?: {
+    ok: boolean;
+    checks: Array<{
+      id: string;
+      status: 'pass' | 'fail' | 'skipped';
+      message: string;
+    }>;
+  };
+};
+
+const CHECK_LABELS: Record<string, string> = {
+  daemon: 'Docker daemon',
+  worker_image: 'Worker image',
+  release_archive: 'Worker release archive',
+};
+
+/**
+ * On-demand Docker environment validation for self-host settings. Runs the
+ * same checks the controller preflights before a spawn, so operators can find
+ * boot blockers before their first task.
+ */
+export function DockerEnvironmentValidation() {
+  const trpc = useTRPC();
+  const [output, setOutput] = useState<ValidationOutput | null>(null);
+
+  const validate = useMutation(
+    trpc.compute.validateDockerEnvironment.mutationOptions({
+      onSuccess: (data) => setOutput(data),
+      onError: (error) =>
+        setOutput({
+          status: 'unavailable',
+          message: error.message || 'Validation failed unexpectedly.',
+        }),
+    }),
+  );
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-3">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={validate.isPending}
+          onClick={() => validate.mutate()}
+        >
+          {validate.isPending ? (
+            <>
+              <Spinner className="size-4" />
+              Validating…
+            </>
+          ) : (
+            'Validate environment'
+          )}
+        </Button>
+        {validate.isPending && (
+          <span className="text-sm text-muted-foreground">
+            Checking the Docker daemon, worker image, and release archive. A
+            first-time image pull can take a minute.
+          </span>
+        )}
+      </div>
+
+      {output?.status === 'unavailable' && (
+        <Alert variant="destructive">
+          <AlertCircle className="size-4" />
+          <AlertDescription>{output.message}</AlertDescription>
+        </Alert>
+      )}
+
+      {output?.status === 'completed' && output.result && (
+        <ul className="space-y-1.5 text-sm">
+          {output.result.checks.map((check) => (
+            <li key={check.id} className="flex items-start gap-2">
+              {check.status === 'pass' ? (
+                <Check className="mt-0.5 size-4 shrink-0 text-green-600 dark:text-green-500" />
+              ) : check.status === 'fail' ? (
+                <AlertCircle className="mt-0.5 size-4 shrink-0 text-destructive" />
+              ) : (
+                <Minus className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+              )}
+              <span className="min-w-0">
+                <span className="font-medium">
+                  {CHECK_LABELS[check.id] ?? check.id}:
+                </span>{' '}
+                <span
+                  className={
+                    check.status === 'fail'
+                      ? 'text-destructive wrap-break-word'
+                      : 'text-muted-foreground wrap-break-word'
+                  }
+                >
+                  {check.message}
+                </span>
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/system/primitives/icons.ts
+++ b/apps/web/src/components/system/primitives/icons.ts
@@ -126,6 +126,7 @@ export {
   MessagesSquare,
   Mic,
   MicOff,
+  Minus,
   MoreHorizontal,
   MoreVertical,
   Moon,

--- a/apps/web/src/trpc/commands/compute/index.ts
+++ b/apps/web/src/trpc/commands/compute/index.ts
@@ -31,7 +31,9 @@ import {
   type SetupProvisionableComputeProvider,
 } from '@roomote/types';
 
-import { requestDockerEnvironmentValidation } from '@roomote/sdk/server';
+// Deep import: the server barrel drags the full sdk surface (db queries,
+// Linear, Slack) into every consumer, which breaks narrowly-mocked tests.
+import { requestDockerEnvironmentValidation } from '@roomote/sdk/server/docker-environment-validation';
 import type { DockerEnvironmentValidationResult } from '@roomote/compute-providers';
 
 import type { UserAuthSuccess } from '@/types';

--- a/apps/web/src/trpc/commands/compute/index.ts
+++ b/apps/web/src/trpc/commands/compute/index.ts
@@ -31,6 +31,9 @@ import {
   type SetupProvisionableComputeProvider,
 } from '@roomote/types';
 
+import { requestDockerEnvironmentValidation } from '@roomote/sdk/server';
+import type { DockerEnvironmentValidationResult } from '@roomote/compute-providers';
+
 import type { UserAuthSuccess } from '@/types';
 
 import {
@@ -433,6 +436,39 @@ export async function setDefaultComputeProviderCommand(
 
     return { runtimeComputeConfig };
   });
+}
+
+export async function validateDockerEnvironmentCommand(
+  auth: UserAuthSuccess,
+): Promise<
+  | { status: 'completed'; result: DockerEnvironmentValidationResult }
+  | { status: 'unavailable'; message: string }
+> {
+  assertAdmin(auth);
+
+  try {
+    const result = await requestDockerEnvironmentValidation({
+      // The web process may know the configured image; the bullmq worker
+      // falls back to its own DOCKER_WORKER_IMAGE when this is unset.
+      ...(process.env.DOCKER_WORKER_IMAGE
+        ? { image: process.env.DOCKER_WORKER_IMAGE }
+        : {}),
+    });
+
+    return { status: 'completed', result };
+  } catch (error) {
+    console.warn(
+      `[validateDockerEnvironment] validation request failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+
+    return {
+      status: 'unavailable',
+      message:
+        'The validation service did not respond. Make sure the background worker (bullmq) service is running, then try again.',
+    };
+  }
 }
 
 export async function setLocalDockerEnabledCommand(

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -268,6 +268,7 @@ import {
   clearComputeConfigCommand,
   setDefaultComputeProviderCommand,
   setLocalDockerEnabledCommand,
+  validateDockerEnvironmentCommand,
 } from '../commands/compute';
 import {
   getTaskSuggestionFilterOptionsCommand,
@@ -1586,6 +1587,10 @@ export const appRouter = createRouter({
       .mutation(({ ctx: { auth }, input }) =>
         setLocalDockerEnabledCommand(auth, input),
       ),
+
+    validateDockerEnvironment: protectedProcedure.mutation(
+      ({ ctx: { auth } }) => validateDockerEnvironmentCommand(auth),
+    ),
   }),
 
   taskEnvVarRequests: createRouter({

--- a/deploy/compose/docker-compose.prod.yml
+++ b/deploy/compose/docker-compose.prod.yml
@@ -206,6 +206,11 @@ x-roomote-bullmq-env: &roomote-bullmq-env
   DASHBOARD_PASSWORD: ${DASHBOARD_PASSWORD:?DASHBOARD_PASSWORD is required}
   ENCRYPTION_KEY: ${ENCRYPTION_KEY:?ENCRYPTION_KEY is required}
   DEFAULT_COMPUTE_PROVIDER: ${DEFAULT_COMPUTE_PROVIDER:-docker}
+  # Mirrors the controller's worker image/release resolution so the
+  # "Validate environment" checks report what task boots will actually use.
+  DOCKER_WORKER_IMAGE: ${DOCKER_WORKER_IMAGE:-}
+  ROOMOTE_WORKER_IMAGE_REPO: ${ROOMOTE_WORKER_IMAGE_REPO:-${IMAGE_REGISTRY:-ghcr.io}/${IMAGE_NAMESPACE:-roocodeinc}/roomote-worker}
+  DOCKER_WORKER_RELEASE_PATH: ${DOCKER_WORKER_RELEASE_PATH:-/roomote/releases/worker-current.tar.gz}
   R_TELEGRAM_BOT_TOKEN: ${R_TELEGRAM_BOT_TOKEN:-}
   R_DISCORD_BOT_TOKEN: ${R_DISCORD_BOT_TOKEN:-}
   R_DISCORD_GATEWAY_SECRET: ${R_DISCORD_GATEWAY_SECRET:-}
@@ -295,8 +300,8 @@ services:
         mc mb --ignore-existing "roomote/$$S3_BUCKET_ARTIFACTS"
 
   # The only service with the host Docker socket. Its API is reachable solely
-  # from the controller over an internal network, and all unrelated Docker API
-  # sections remain denied by the proxy defaults.
+  # from the controller and bullmq over an internal network, and all unrelated
+  # Docker API sections remain denied by the proxy defaults.
   docker-proxy:
     image: ghcr.io/tecnativa/docker-socket-proxy:v0.4.2@sha256:1f3a6f303320723d199d2316a3e82b2e2685d86c275d5e3deeaf182573b47476
     restart: unless-stopped
@@ -427,15 +432,22 @@ services:
     <<: *roomote-service
     image: *roomote-app-image
     command: ['bullmq']
+    # Docker standby retention and the settings "Validate environment" checks
+    # run here; both reach Docker through the restricted socket proxy, never
+    # the raw socket.
+    networks: [default, docker-api]
     depends_on:
       redis:
         condition: service_started
       db-migrate:
         condition: service_completed_successfully
+      docker-proxy:
+        condition: service_started
     environment:
       <<: *roomote-bullmq-env
       ROOMOTE_SERVICE: bullmq
       PORT: 3002
+      DOCKER_HOST: tcp://docker-proxy:2375
     healthcheck:
       test:
         [

--- a/docker-compose.compute-docker.yml
+++ b/docker-compose.compute-docker.yml
@@ -38,5 +38,10 @@ services:
     environment:
       DOCKER_STANDBY_MAX_COUNT: ${DOCKER_STANDBY_MAX_COUNT:-10}
       DOCKER_STANDBY_MAX_AGE_HOURS: ${DOCKER_STANDBY_MAX_AGE_HOURS:-24}
+      # The settings "Validate environment" checks run in this service (it
+      # holds the Docker socket), so it needs the same image/release config
+      # as the controller.
+      DOCKER_WORKER_IMAGE: ${DOCKER_WORKER_IMAGE:-roomote-worker:local}
+      DOCKER_WORKER_RELEASE_PATH: ${DOCKER_WORKER_RELEASE_PATH:-/roomote/releases/worker-current.tar.gz}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/packages/compute-providers/src/__tests__/docker-environment-validation.test.ts
+++ b/packages/compute-providers/src/__tests__/docker-environment-validation.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateDockerEnvironment } from '../docker-environment-validation';
+
+const IMAGE = 'roomote-worker:local';
+
+describe('validateDockerEnvironment', () => {
+  it('passes all checks in a healthy environment', async () => {
+    const result = await validateDockerEnvironment({
+      image: IMAGE,
+      releaseArchivePath: '/releases/worker-current.tar.gz',
+      runDocker: async (args) => {
+        if (args[0] === 'version') return '28.0.1';
+        if (args[0] === 'image') return 'sha256:abc';
+        throw new Error(`unexpected docker ${args[0]}`);
+      },
+      fileExists: () => true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.checks.map((check) => check.status)).toEqual([
+      'pass',
+      'pass',
+      'pass',
+    ]);
+  });
+
+  it('fails the daemon check and skips the image check when the daemon is down', async () => {
+    const result = await validateDockerEnvironment({
+      image: IMAGE,
+      releaseArchivePath: '/releases/worker-current.tar.gz',
+      runDocker: async () => {
+        throw new Error(
+          'Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?',
+        );
+      },
+      fileExists: () => true,
+    });
+
+    expect(result.ok).toBe(false);
+    const [daemon, image] = result.checks;
+    expect(daemon?.status).toBe('fail');
+    expect(daemon?.message).toContain('Cannot connect to the Docker daemon');
+    expect(image?.status).toBe('skipped');
+  });
+
+  it('pulls a missing image and reports the pull as a pass', async () => {
+    const calls: string[] = [];
+    const result = await validateDockerEnvironment({
+      image: IMAGE,
+      releaseArchivePath: '/releases/worker-current.tar.gz',
+      runDocker: async (args) => {
+        calls.push(args[0] ?? '');
+        if (args[0] === 'version') return '28.0.1';
+        if (args[0] === 'image') throw new Error('No such image');
+        if (args[0] === 'pull') return 'Downloaded';
+        throw new Error(`unexpected docker ${args[0]}`);
+      },
+      fileExists: () => true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(calls).toContain('pull');
+    expect(result.checks[1]?.message).toContain('pulled successfully');
+  });
+
+  it('fails the image check with stderr detail when the pull fails', async () => {
+    const pullError = Object.assign(new Error('Command failed'), {
+      stderr:
+        'pull access denied for roomote-worker, repository does not exist',
+    });
+    const result = await validateDockerEnvironment({
+      image: IMAGE,
+      releaseArchivePath: '/releases/worker-current.tar.gz',
+      runDocker: async (args) => {
+        if (args[0] === 'version') return '28.0.1';
+        throw args[0] === 'pull' ? pullError : new Error('No such image');
+      },
+      fileExists: () => true,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.checks[1]?.status).toBe('fail');
+    expect(result.checks[1]?.message).toContain('pull access denied');
+  });
+
+  it('marks the archive check skipped when no path is configured and failed when missing', async () => {
+    const healthyDocker = async (args: string[]) =>
+      args[0] === 'version' ? '28.0.1' : 'sha256:abc';
+
+    const skipped = await validateDockerEnvironment({
+      image: IMAGE,
+      runDocker: healthyDocker,
+      fileExists: () => true,
+    });
+    expect(skipped.ok).toBe(true);
+    expect(skipped.checks[2]?.status).toBe('skipped');
+
+    const missing = await validateDockerEnvironment({
+      image: IMAGE,
+      releaseArchivePath: '/releases/worker-current.tar.gz',
+      runDocker: healthyDocker,
+      fileExists: () => false,
+    });
+    expect(missing.ok).toBe(false);
+    expect(missing.checks[2]?.status).toBe('fail');
+  });
+});

--- a/packages/compute-providers/src/docker-environment-validation.ts
+++ b/packages/compute-providers/src/docker-environment-validation.ts
@@ -1,0 +1,157 @@
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export type DockerEnvironmentCheckId =
+  | 'daemon'
+  | 'worker_image'
+  | 'release_archive';
+
+export type DockerEnvironmentCheckStatus = 'pass' | 'fail' | 'skipped';
+
+export interface DockerEnvironmentCheck {
+  id: DockerEnvironmentCheckId;
+  status: DockerEnvironmentCheckStatus;
+  /** Human-readable outcome shown in the settings UI. */
+  message: string;
+}
+
+export interface DockerEnvironmentValidationResult {
+  ok: boolean;
+  checks: DockerEnvironmentCheck[];
+}
+
+type DockerRunner = (args: string[]) => Promise<string>;
+
+async function runDockerCli(args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('docker', args, {
+    maxBuffer: 10 * 1024 * 1024,
+  });
+
+  return stdout.trim();
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    const failure = error as Error & { stderr?: string | Buffer };
+    const stderr =
+      typeof failure.stderr === 'string'
+        ? failure.stderr.trim()
+        : Buffer.isBuffer(failure.stderr)
+          ? failure.stderr.toString('utf8').trim()
+          : '';
+
+    return stderr || error.message;
+  }
+
+  return String(error);
+}
+
+/**
+ * Run the same environment checks the controller preflights before a Docker
+ * spawn — daemon reachable, worker image present (or pullable), release
+ * archive on disk — but report per-check results instead of failing fast, so
+ * the settings UI can show operators everything that needs fixing at once.
+ *
+ * Must run in a process with Docker socket access (bullmq/controller); the
+ * web app does not have the socket in production Compose.
+ */
+export async function validateDockerEnvironment(params: {
+  image: string;
+  /** Absent when the running process has no release path configured. */
+  releaseArchivePath?: string;
+  runDocker?: DockerRunner;
+  fileExists?: (path: string) => boolean;
+}): Promise<DockerEnvironmentValidationResult> {
+  const runDocker = params.runDocker ?? runDockerCli;
+  const fileExists = params.fileExists ?? existsSync;
+  const checks: DockerEnvironmentCheck[] = [];
+
+  let daemonReachable = false;
+
+  try {
+    const version = await runDocker([
+      'version',
+      '--format',
+      '{{.Server.Version}}',
+    ]);
+    daemonReachable = true;
+    checks.push({
+      id: 'daemon',
+      status: 'pass',
+      message: `Docker daemon is reachable (server ${version.trim() || 'unknown'}).`,
+    });
+  } catch (error) {
+    checks.push({
+      id: 'daemon',
+      status: 'fail',
+      message: `Cannot reach the Docker daemon: ${errorMessage(error)}`,
+    });
+  }
+
+  if (!daemonReachable) {
+    checks.push({
+      id: 'worker_image',
+      status: 'skipped',
+      message: 'Skipped because the Docker daemon is unreachable.',
+    });
+  } else {
+    try {
+      await runDocker([
+        'image',
+        'inspect',
+        '--format',
+        '{{.Id}}',
+        params.image,
+      ]);
+      checks.push({
+        id: 'worker_image',
+        status: 'pass',
+        message: `Worker image ${params.image} is available locally.`,
+      });
+    } catch {
+      try {
+        await runDocker(['pull', params.image]);
+        checks.push({
+          id: 'worker_image',
+          status: 'pass',
+          message: `Worker image ${params.image} was pulled successfully.`,
+        });
+      } catch (error) {
+        checks.push({
+          id: 'worker_image',
+          status: 'fail',
+          message: `Worker image ${params.image} is not available locally and could not be pulled: ${errorMessage(error)}`,
+        });
+      }
+    }
+  }
+
+  if (!params.releaseArchivePath) {
+    checks.push({
+      id: 'release_archive',
+      status: 'skipped',
+      message:
+        'No worker release archive path is configured for this process (DOCKER_WORKER_RELEASE_PATH).',
+    });
+  } else if (fileExists(params.releaseArchivePath)) {
+    checks.push({
+      id: 'release_archive',
+      status: 'pass',
+      message: `Worker release archive exists at ${params.releaseArchivePath}.`,
+    });
+  } else {
+    checks.push({
+      id: 'release_archive',
+      status: 'fail',
+      message: `Worker release archive does not exist: ${params.releaseArchivePath}`,
+    });
+  }
+
+  return {
+    ok: checks.every((check) => check.status !== 'fail'),
+    checks,
+  };
+}

--- a/packages/compute-providers/src/index.ts
+++ b/packages/compute-providers/src/index.ts
@@ -1,4 +1,5 @@
 export * from './types';
+export * from './docker-environment-validation';
 export * from './mutation-events';
 export * from './errors';
 export * from './environment-machine';

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -24,6 +24,10 @@
       "import": "./src/server/lib/slack-conversation-log.ts",
       "require": "./src/server/lib/slack-conversation-log.ts"
     },
+    "./server/docker-environment-validation": {
+      "import": "./src/server/lib/docker-environment-validation.ts",
+      "require": "./src/server/lib/docker-environment-validation.ts"
+    },
     "./server/telegram-primary-chat": {
       "import": "./src/server/lib/telegram-primary-chat.ts",
       "require": "./src/server/lib/telegram-primary-chat.ts"

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -19,6 +19,7 @@ export {
 } from './lib/task-runs/record-task-inference-usage';
 export { findTaskRunByRunTokenClaims } from './lib/task-runs/find-task-run';
 export { createSnapshot } from './lib/task-runs/enqueue-snapshot';
+export { requestDockerEnvironmentValidation } from './lib/docker-environment-validation';
 export {
   enqueueTaskSleep,
   TASK_SLEEP_QUEUE_NAME,

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -19,7 +19,6 @@ export {
 } from './lib/task-runs/record-task-inference-usage';
 export { findTaskRunByRunTokenClaims } from './lib/task-runs/find-task-run';
 export { createSnapshot } from './lib/task-runs/enqueue-snapshot';
-export { requestDockerEnvironmentValidation } from './lib/docker-environment-validation';
 export {
   enqueueTaskSleep,
   TASK_SLEEP_QUEUE_NAME,

--- a/packages/sdk/src/server/lib/docker-environment-validation.ts
+++ b/packages/sdk/src/server/lib/docker-environment-validation.ts
@@ -1,0 +1,70 @@
+import { Queue, QueueEvents } from 'bullmq';
+
+import { getRedis } from '@roomote/redis';
+import { DOCKER_VALIDATION_QUEUE_NAME } from '@roomote/types';
+import type { DockerEnvironmentValidationResult } from '@roomote/compute-providers';
+
+/**
+ * First-run pulls of the worker image can take a while; anything past this is
+ * reported as a timeout rather than leaving the settings UI hanging.
+ */
+const VALIDATION_TIMEOUT_MS = 120_000;
+
+interface DockerValidationRequest {
+  image?: string;
+}
+
+let validationQueue: Queue<
+  DockerValidationRequest,
+  DockerEnvironmentValidationResult,
+  string
+> | null = null;
+let validationQueueEvents: QueueEvents | null = null;
+
+function getValidationQueue() {
+  if (!validationQueue) {
+    validationQueue = new Queue(DOCKER_VALIDATION_QUEUE_NAME, {
+      connection: getRedis(),
+      defaultJobOptions: {
+        attempts: 1,
+        removeOnComplete: { age: 600, count: 50 },
+        removeOnFail: { age: 3600 },
+      },
+    });
+  }
+
+  return validationQueue;
+}
+
+function getValidationQueueEvents(): QueueEvents {
+  if (!validationQueueEvents) {
+    validationQueueEvents = new QueueEvents(DOCKER_VALIDATION_QUEUE_NAME, {
+      connection: getRedis(),
+    });
+  }
+
+  return validationQueueEvents;
+}
+
+/**
+ * Request a Docker environment validation from the bullmq worker (the process
+ * holding the Docker socket) and wait for its result. Throws on timeout or if
+ * no worker consumes the queue — callers should surface that as "validation
+ * service unavailable" rather than a failed environment.
+ */
+export async function requestDockerEnvironmentValidation(params: {
+  image?: string;
+}): Promise<DockerEnvironmentValidationResult> {
+  const queue = getValidationQueue();
+  const queueEvents = getValidationQueueEvents();
+  await queueEvents.waitUntilReady();
+
+  const job = await queue.add('validate-docker-environment', {
+    ...(params.image ? { image: params.image } : {}),
+  });
+
+  return (await job.waitUntilFinished(
+    queueEvents,
+    VALIDATION_TIMEOUT_MS,
+  )) as DockerEnvironmentValidationResult;
+}

--- a/packages/types/src/compute-providers/worker-runtime.ts
+++ b/packages/types/src/compute-providers/worker-runtime.ts
@@ -28,3 +28,9 @@ export const SNAPSHOT_JOB_RETRY_OPTIONS = {
   attempts: 3,
   backoff: { type: 'exponential' as const, delay: 5_000 },
 } as const;
+
+/**
+ * BullMQ queue for on-demand Docker environment validation requested from the
+ * settings UI. Shared between the web producer and the bullmq consumer.
+ */
+export const DOCKER_VALIDATION_QUEUE_NAME = 'docker-validation-jobs';


### PR DESCRIPTION
## What changed

Settings → Sandboxes → Local Docker gains a **Validate environment** button that runs the same checks the controller preflights before a Docker spawn (added in #622):

- Docker daemon reachable
- worker image available locally (with an explicit pull attempt)
- worker release archive present on disk

Results render as a per-check list (pass / fail / skipped with reasons), so operators see everything that needs fixing at once instead of failing fast.

## How it works

The web app has no Docker socket in production Compose, so validation runs as a **BullMQ request/reply job** consumed by the bullmq service (which holds the socket in the `docker-compose.compute-docker.yml` overlay). The tRPC mutation (`compute.validateDockerEnvironment`, admin-gated) enqueues the request and waits on the job result with a 120s bound; if no worker consumes the queue, the UI reports the validation service as unavailable rather than a failed environment.

The check logic lives in `packages/compute-providers` with injectable docker/fs runners. The compose overlay now passes `DOCKER_WORKER_IMAGE` / `DOCKER_WORKER_RELEASE_PATH` to the bullmq service so its checks match what the controller will actually use.

## Why this change was made

#622 made boot failures precise after the fact; this closes the loop by letting self-hosters find the same problems **before** their first task — the moment where opaque failures previously caused churn.

## Validation

- 5 new unit tests for the check logic (163 total in compute-providers pass)
- Live smoke test of the full producer → Redis → worker → Docker round trip against a real daemon: healthy path, unreachable daemon, and unpullable image all classified correctly
- `pnpm lint:fast`, `pnpm check-types:fast`, `pnpm knip` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)