### PR TITLE
[Fix] Discord thread context misses the thread-starter message

### DIFF
--- a/apps/api/src/handlers/discord/__tests__/task-orchestration.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/task-orchestration.test.ts
@@ -160,6 +160,17 @@ describe('startNewDiscordTask', () => {
           },
         ],
       }),
+      // The message this thread was started from lives in the parent channel
+      // (its id equals the thread id) and is absent from the thread listing.
+      fetchMessage: vi.fn().mockResolvedValue({
+        provider: 'discord',
+        id: '50',
+        user: 'u-sky',
+        username: 'Sky',
+        text: 'Tested the PR and the task failed while preparing the workspace.',
+        channelId: 'channel-1',
+        fileCount: 0,
+      }),
     };
     mocks.processAttachments.mockResolvedValue({
       images: ['data:image/png;base64,thread'],
@@ -183,11 +194,11 @@ describe('startNewDiscordTask', () => {
       metadata: {
         communicationProvider: 'discord',
         communicationChannelId: 'channel-1',
-        communicationThreadId: 'discussion-thread',
+        communicationThreadId: '50',
         communicationMessageId: '200',
       },
       channel: {
-        channelId: 'discussion-thread',
+        channelId: '50',
         channelName: 'General discussion',
         channelType: 11,
         guildId: 'guild-1',
@@ -200,7 +211,11 @@ describe('startNewDiscordTask', () => {
 
     expect(result.status).toBe('started');
     expect(provider.fetchChannelMessages).toHaveBeenCalledWith({
-      channelId: 'discussion-thread',
+      channelId: '50',
+    });
+    expect(provider.fetchMessage).toHaveBeenCalledWith({
+      channelId: 'channel-1',
+      messageId: '50',
     });
     expect(mocks.processAttachments).toHaveBeenCalledWith([
       expect.objectContaining({
@@ -213,6 +228,10 @@ describe('startNewDiscordTask', () => {
       expect.objectContaining({
         taskDescription: expect.stringContaining('log.txt contents'),
         threadMessages: [
+          {
+            user: 'Sky',
+            text: 'Tested the PR and the task failed while preparing the workspace.',
+          },
           { user: 'Alice', text: 'Deploy failed on main' },
           { user: 'Matt', text: '@Roomote investigate the flaky build' },
         ],
@@ -236,6 +255,9 @@ describe('startNewDiscordTask', () => {
     );
     const agentPrompt = mocks.launchTask.mock.calls[0]?.[0]
       .agentPromptText as string;
+    expect(agentPrompt).toContain(
+      'Sky: Tested the PR and the task failed while preparing the workspace.',
+    );
     expect(agentPrompt).toContain('Alice: Deploy failed on main');
     expect(agentPrompt).toContain('investigate the flaky build');
     expect(agentPrompt).toContain('log.txt contents');

--- a/apps/api/src/handlers/discord/__tests__/thread-context.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/thread-context.test.ts
@@ -17,8 +17,105 @@ vi.mock('../attachments.js', () => ({
 
 import {
   buildDiscordContinuationPrompt,
+  fetchDiscordThreadHistoryBestEffort,
   formatDiscordThreadContext,
 } from '../thread-context.js';
+
+describe('fetchDiscordThreadHistoryBestEffort', () => {
+  it('recovers the thread-starter message from the parent channel', async () => {
+    const provider = {
+      fetchChannelMessages: vi.fn().mockResolvedValue({
+        messages: [
+          { id: '200', user: 'u-matt', username: 'Matt', text: 'take a look' },
+        ],
+      }),
+      fetchMessage: vi.fn().mockResolvedValue({
+        provider: 'discord',
+        id: '50',
+        user: 'u-sky',
+        username: 'Sky',
+        text: 'Tested the PR and it failed.',
+        channelId: 'channel-1',
+        fileCount: 0,
+      }),
+    };
+
+    const history = await fetchDiscordThreadHistoryBestEffort({
+      provider: provider as never,
+      channelId: '50',
+      parentChannelId: 'channel-1',
+    });
+
+    expect(provider.fetchMessage).toHaveBeenCalledWith({
+      channelId: 'channel-1',
+      messageId: '50',
+    });
+    expect(history.map((message) => message.id)).toEqual(['50', '200']);
+    expect(history[0]).toMatchObject({
+      username: 'Sky',
+      text: 'Tested the PR and it failed.',
+    });
+  });
+
+  it('does not refetch a starter already present in the thread listing (forum posts)', async () => {
+    const provider = {
+      fetchChannelMessages: vi.fn().mockResolvedValue({
+        messages: [
+          { id: '50', user: 'u-sky', username: 'Sky', text: 'Forum post body' },
+          { id: '200', user: 'u-matt', username: 'Matt', text: 'reply' },
+        ],
+      }),
+      fetchMessage: vi.fn(),
+    };
+
+    const history = await fetchDiscordThreadHistoryBestEffort({
+      provider: provider as never,
+      channelId: '50',
+      parentChannelId: 'forum-1',
+    });
+
+    expect(provider.fetchMessage).not.toHaveBeenCalled();
+    expect(history.map((message) => message.id)).toEqual(['50', '200']);
+  });
+
+  it('skips the starter lookup without a parent channel', async () => {
+    const provider = {
+      fetchChannelMessages: vi.fn().mockResolvedValue({
+        messages: [
+          { id: '200', user: 'u-matt', username: 'Matt', text: 'hello' },
+        ],
+      }),
+      fetchMessage: vi.fn(),
+    };
+
+    const history = await fetchDiscordThreadHistoryBestEffort({
+      provider: provider as never,
+      channelId: '50',
+    });
+
+    expect(provider.fetchMessage).not.toHaveBeenCalled();
+    expect(history.map((message) => message.id)).toEqual(['200']);
+  });
+
+  it('keeps collected thread history when the starter lookup fails', async () => {
+    const provider = {
+      fetchChannelMessages: vi.fn().mockResolvedValue({
+        messages: [
+          { id: '200', user: 'u-matt', username: 'Matt', text: 'still here' },
+        ],
+      }),
+      fetchMessage: vi.fn().mockRejectedValue(new Error('Unknown Message')),
+    };
+
+    const history = await fetchDiscordThreadHistoryBestEffort({
+      provider: provider as never,
+      channelId: '50',
+      parentChannelId: 'channel-1',
+    });
+
+    expect(history.map((message) => message.id)).toEqual(['200']);
+  });
+});
 
 describe('formatDiscordThreadContext', () => {
   it('formats earlier messages and omits the current one', () => {

--- a/apps/api/src/handlers/discord/index.ts
+++ b/apps/api/src/handlers/discord/index.ts
@@ -411,6 +411,9 @@ async function processDiscordGatewayEvent(event: DiscordGatewayEvent) {
           const history = await fetchDiscordThreadHistoryBestEffort({
             provider: resolved.provider,
             channelId: channel.channelId,
+            ...(channel.parentChannelId
+              ? { parentChannelId: channel.parentChannelId }
+              : {}),
           });
           return history.length > 0 ? history : null;
         },
@@ -571,6 +574,9 @@ async function processDiscordGatewayEvent(event: DiscordGatewayEvent) {
       const continuation = await buildDiscordContinuationPrompt({
         provider: resolved.provider,
         channelId: channel.channelId,
+        ...(channel.parentChannelId
+          ? { parentChannelId: channel.parentChannelId }
+          : {}),
         botUserId: resolved.botUserId,
         queuedMessage,
       });
@@ -637,6 +643,9 @@ async function processDiscordGatewayEvent(event: DiscordGatewayEvent) {
       const continuation = await buildDiscordContinuationPrompt({
         provider: resolved.provider,
         channelId: channel.channelId,
+        ...(channel.parentChannelId
+          ? { parentChannelId: channel.parentChannelId }
+          : {}),
         botUserId: resolved.botUserId,
         queuedMessage,
       });

--- a/apps/api/src/handlers/discord/task-orchestration.ts
+++ b/apps/api/src/handlers/discord/task-orchestration.ts
@@ -129,6 +129,9 @@ export async function startNewDiscordTask(input: {
       ? fetchDiscordThreadHistoryBestEffort({
           provider: input.provider,
           channelId: input.channel.channelId,
+          ...(input.channel.parentChannelId
+            ? { parentChannelId: input.channel.parentChannelId }
+            : {}),
         })
       : Promise.resolve([] as DiscordThreadHistoryMessage[]),
     input.channel.guildId

--- a/apps/api/src/handlers/discord/thread-context.ts
+++ b/apps/api/src/handlers/discord/thread-context.ts
@@ -116,9 +116,50 @@ export function toDiscordAttachmentsFromHistory(
   return attachments;
 }
 
+function toDiscordThreadHistoryMessage(message: {
+  id: string;
+  user: string;
+  username?: string;
+  text: string;
+  botId?: string;
+  files?: Array<{
+    id: string;
+    name: string;
+    mimeType: string;
+    size: number;
+    url?: string;
+  }>;
+}): DiscordThreadHistoryMessage {
+  return {
+    id: message.id,
+    user: message.user,
+    ...(message.username ? { username: message.username } : {}),
+    text: message.text,
+    ...(message.botId ? { botId: message.botId } : {}),
+    attachments: (message.files ?? [])
+      .filter((file) => Boolean(file.url?.trim()))
+      .map((file) => ({
+        id: file.id,
+        filename: file.name,
+        size: file.size,
+        url: file.url!,
+        ...(file.mimeType && file.mimeType !== 'application/octet-stream'
+          ? { content_type: file.mimeType }
+          : {}),
+      })),
+  };
+}
+
 export async function fetchDiscordThreadHistoryBestEffort(input: {
   provider: DiscordCommunicationProvider;
   channelId: string;
+  /**
+   * Parent channel of a thread. Threads anchored to a channel message share
+   * their id with the starter message, which lives in the parent channel and
+   * never appears in the thread's own listing; pass the parent so the starter
+   * can be recovered from there.
+   */
+  parentChannelId?: string;
 }): Promise<DiscordThreadHistoryMessage[]> {
   // Discord returns newest-first pages of up to 100. Walk backward with `before`
   // so a long thread still becomes agent context (Slack fetches full reply chains).
@@ -134,24 +175,7 @@ export async function fetchDiscordThreadHistoryBestEffort(input: {
       });
       if (result.messages.length === 0) break;
 
-      const page = result.messages.map((message) => ({
-        id: message.id,
-        user: message.user,
-        ...(message.username ? { username: message.username } : {}),
-        text: message.text,
-        ...(message.botId ? { botId: message.botId } : {}),
-        attachments: (message.files ?? [])
-          .filter((file) => Boolean(file.url?.trim()))
-          .map((file) => ({
-            id: file.id,
-            filename: file.name,
-            size: file.size,
-            url: file.url!,
-            ...(file.mimeType && file.mimeType !== 'application/octet-stream'
-              ? { content_type: file.mimeType }
-              : {}),
-          })),
-      }));
+      const page = result.messages.map(toDiscordThreadHistoryMessage);
 
       // Pages arrive newest-last after provider reverse; prepend so overall
       // order stays oldest -> newest while we walk earlier pages.
@@ -161,10 +185,33 @@ export async function fetchDiscordThreadHistoryBestEffort(input: {
       if (!before) break;
     }
 
-    if (collected.length > MAX_THREAD_HISTORY_MESSAGES) {
-      return collected.slice(-MAX_THREAD_HISTORY_MESSAGES);
+    const capped =
+      collected.length > MAX_THREAD_HISTORY_MESSAGES
+        ? collected.slice(-MAX_THREAD_HISTORY_MESSAGES)
+        : collected;
+
+    // Forum posts carry their starter inside the thread listing; message-
+    // anchored threads never do, so recover it from the parent channel.
+    if (
+      input.parentChannelId &&
+      !collected.some((message) => message.id === input.channelId)
+    ) {
+      // Independently best-effort: a missing or unreadable starter must not
+      // discard the thread history that was already collected.
+      const starter = await Promise.resolve()
+        .then(() =>
+          input.provider.fetchMessage({
+            channelId: input.parentChannelId!,
+            messageId: input.channelId,
+          }),
+        )
+        .catch(() => null);
+      if (starter) {
+        capped.unshift(toDiscordThreadHistoryMessage(starter));
+      }
     }
-    return collected;
+
+    return capped;
   } catch (error) {
     console.warn(
       `[discord] Failed to fetch thread history for channel ${input.channelId}: ${
@@ -205,6 +252,8 @@ type DiscordContinuationPromptResult = {
 export async function buildDiscordContinuationPrompt(input: {
   provider: DiscordCommunicationProvider;
   channelId: string;
+  /** Parent channel of a thread; lets history recover the starter message. */
+  parentChannelId?: string;
   botUserId?: string;
   queuedMessage: QueuedCommunicationMessage;
   /**
@@ -218,6 +267,9 @@ export async function buildDiscordContinuationPrompt(input: {
   const history = await fetchDiscordThreadHistoryBestEffort({
     provider: input.provider,
     channelId: input.channelId,
+    ...(input.parentChannelId
+      ? { parentChannelId: input.parentChannelId }
+      : {}),
   });
 
   const earlier = history.filter(

--- a/apps/api/src/handlers/discord/thread-context.ts
+++ b/apps/api/src/handlers/discord/thread-context.ts
@@ -185,7 +185,7 @@ export async function fetchDiscordThreadHistoryBestEffort(input: {
       if (!before) break;
     }
 
-    const capped =
+    let capped =
       collected.length > MAX_THREAD_HISTORY_MESSAGES
         ? collected.slice(-MAX_THREAD_HISTORY_MESSAGES)
         : collected;
@@ -207,7 +207,13 @@ export async function fetchDiscordThreadHistoryBestEffort(input: {
         )
         .catch(() => null);
       if (starter) {
-        capped.unshift(toDiscordThreadHistoryMessage(starter));
+        // The starter takes a slot inside the cap rather than on top of it.
+        capped = [
+          toDiscordThreadHistoryMessage(starter),
+          ...capped.slice(
+            Math.max(0, capped.length - (MAX_THREAD_HISTORY_MESSAGES - 1)),
+          ),
+        ];
       }
     }
 

--- a/packages/communication/src/__tests__/discord-provider.test.ts
+++ b/packages/communication/src/__tests__/discord-provider.test.ts
@@ -527,6 +527,23 @@ describe('DiscordCommunicationProvider', () => {
     expect(server.state.messages[channelId]).toHaveLength(0);
   });
 
+  it('fetches a single message by id and rejects for unknown messages', async () => {
+    const { provider } = createHarness();
+    const channelId = '400000000000000003';
+    const sent = await provider.postMessage({ channelId, text: 'starter body' });
+
+    await expect(
+      provider.fetchMessage({ channelId, messageId: sent.messageId }),
+    ).resolves.toMatchObject({
+      provider: 'discord',
+      id: sent.messageId,
+      text: 'starter body',
+    });
+    await expect(
+      provider.fetchMessage({ channelId, messageId: '999999999999999999' }),
+    ).rejects.toThrow();
+  });
+
   it('maps Slack-style reaction names onto Discord unicode emoji', async () => {
     const { server, provider } = createHarness();
     const channelId = '400000000000000002';

--- a/packages/communication/src/__tests__/discord-provider.test.ts
+++ b/packages/communication/src/__tests__/discord-provider.test.ts
@@ -530,7 +530,10 @@ describe('DiscordCommunicationProvider', () => {
   it('fetches a single message by id and rejects for unknown messages', async () => {
     const { provider } = createHarness();
     const channelId = '400000000000000003';
-    const sent = await provider.postMessage({ channelId, text: 'starter body' });
+    const sent = await provider.postMessage({
+      channelId,
+      text: 'starter body',
+    });
 
     await expect(
       provider.fetchMessage({ channelId, messageId: sent.messageId }),

--- a/packages/communication/src/discord-provider.ts
+++ b/packages/communication/src/discord-provider.ts
@@ -829,6 +829,24 @@ export class DiscordCommunicationProvider implements CommunicationProviderAdapte
     };
   }
 
+  /**
+   * Fetches one message by id. A message-anchored thread's starter message
+   * shares the thread's id but lives in the parent channel, so it never
+   * appears in the thread's own message listing and must be read here.
+   */
+  async fetchMessage(input: {
+    channelId: string;
+    messageId: string;
+  }): Promise<CommunicationMessage> {
+    const raw = await this.request<DiscordApiMessage>(
+      'GET',
+      `/channels/${input.channelId}/messages/${input.messageId}`,
+      undefined,
+      { retryNetworkErrors: true, retryServerErrors: true },
+    );
+    return toCommunicationMessage(raw);
+  }
+
   async fetchChannelMessages(input: {
     channelId: string;
     oldest?: string;

--- a/packages/communication/src/mock-discord-server.ts
+++ b/packages/communication/src/mock-discord-server.ts
@@ -535,6 +535,11 @@ export class MockDiscordServer {
     }
 
     const message = /^\/channels\/([^/]+)\/messages\/([^/]+)$/u.exec(path);
+    if (message && method === 'GET') {
+      const existing = this.findMessage(message[1] ?? '', message[2] ?? '');
+      if (!existing) return jsonResponse({ message: 'Unknown Message' }, 404);
+      return jsonResponse(existing);
+    }
     if (message && method === 'PATCH') {
       const existing = this.findMessage(message[1] ?? '', message[2] ?? '');
       if (!existing) return jsonResponse({ message: 'Unknown Message' }, 404);


### PR DESCRIPTION
## Problem

When a task is started from inside a Discord thread that was created from a channel message, the agent (and the router) never see the message the thread was started from — frequently the actual problem statement the requester is pointing at. With only a mention like "take a look" in the thread, the task launches with essentially no context and answers the wrong question.

Root cause: a message-anchored thread shares its id with its starter message, but that message lives in the **parent channel**. `GET /channels/{thread_id}/messages` never returns it, so `fetchDiscordThreadHistoryBestEffort` silently dropped it from every consumer: task-launch `<thread_context>`, routing context, follow-up continuation prompts, and the unmentioned-thread-reply check.

## Fix

- `DiscordCommunicationProvider.fetchMessage`: fetch a single message by id (`GET /channels/{id}/messages/{id}`).
- `fetchDiscordThreadHistoryBestEffort` accepts the thread's `parentChannelId` and, when the listing doesn't already contain a message with the thread's id, recovers the starter from the parent channel and prepends it (oldest-first order preserved).
  - Forum posts keep their starter inside the thread listing, so the extra lookup is skipped there.
  - The lookup is independently best-effort: a deleted/unreadable starter never discards the history that was already collected.
- Plumbed `parentChannelId` through all call sites: task orchestration, both continuation-prompt builds (active-run follow-up and snapshot resume), and the unmentioned-reply gate.
- Mock Discord server: added the `GET /channels/:channelId/messages/:messageId` route.

Because launch now marks the starter's id delivered, follow-ups won't re-inject it; tasks launched before this fix pick the starter up as undelivered context on their next follow-up.

## Tests

- `fetchDiscordThreadHistoryBestEffort`: starter recovered from parent channel; forum starter not refetched; no lookup without a parent; history kept when the lookup fails.
- Slack-parity launch test now models the incident shape: starter + replies, asserting the starter reaches both routing `threadMessages` and the agent's `<thread_context>`.
- Provider: `fetchMessage` happy path + unknown-message rejection against the mock server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)