### PR TITLE
Notify staging Cloud after develop images

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -485,3 +485,36 @@ jobs:
             -f "client_payload[image_tag]=${image_tag}" \
             -f "client_payload[sha]=${GITHUB_SHA}" \
             -f "client_payload[ref]=${GITHUB_REF}"
+
+  # Keep staging Cloud delivery independent from the existing Roomote-Ops
+  # production path. This job only follows successful develop image publishes.
+  notify-staging-cloud:
+    name: Notify staging Cloud
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+      - publish
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' && vars.ROOMOTE_CLOUD_REPO != '' }}
+    permissions:
+      contents: read
+    steps:
+      - name: Send staging repository dispatch
+        env:
+          GH_TOKEN: ${{ secrets.ROOMOTE_CLOUD_DISPATCH_TOKEN }}
+          CLOUD_REPO: ${{ vars.ROOMOTE_CLOUD_REPO }}
+          IMAGE_TAG: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          : "${GH_TOKEN:?ROOMOTE_CLOUD_DISPATCH_TOKEN is required}"
+          case "$CLOUD_REPO" in
+            RooCodeInc/Roomote-Cloud) ;;
+            *)
+              echo "Refusing unexpected ROOMOTE_CLOUD_REPO: $CLOUD_REPO" >&2
+              exit 1
+              ;;
+          esac
+          gh api "repos/${CLOUD_REPO}/dispatches" \
+            -f event_type=roomote-develop-build \
+            -f "client_payload[image_tag]=${IMAGE_TAG}" \
+            -f "client_payload[sha]=${GITHUB_SHA}" \
+            -f "client_payload[ref]=${GITHUB_REF}"


### PR DESCRIPTION
## What changed

- add an independent `notify-staging-cloud` job after successful GHCR publication
- dispatch `roomote-develop-build` to Roomote-Cloud with the exact immutable tag produced by the build
- fail closed unless `ROOMOTE_CLOUD_REPO` is exactly `RooCodeInc/Roomote-Cloud`

## Why

Roomote-Cloud now has a tested staging rollout receiver. This connects successful Roomote `develop` image builds to that receiver while keeping the existing Roomote-Ops notification path unchanged.

## Activation

Before setting `ROOMOTE_CLOUD_REPO`, add a `ROOMOTE_CLOUD_DISPATCH_TOKEN` Actions secret. It should be scoped only to `RooCodeInc/Roomote-Cloud` with repository Contents write permission. Set the repo variable last to activate the job.

## Validation

- YAML parsed successfully
- embedded shell passed `bash -n`
- pre-push oxlint, package lint, fast type checks, and knip passed
