### PR TITLE
[Fix] Resolve implicit repository branches from origin HEAD

### DIFF
--- a/.changeset/resolve-default-repository-branches.md
+++ b/.changeset/resolve-default-repository-branches.md
@@ -1,0 +1,5 @@
+---
+'@roomote/worker': patch
+---
+
+Resolve implicit repository branches from the fetched `origin/HEAD` before using stored metadata, and fail clearly when no valid default branch exists.

--- a/apps/worker/src/workspace/__tests__/workspace-manager-sync.test.ts
+++ b/apps/worker/src/workspace/__tests__/workspace-manager-sync.test.ts
@@ -22,6 +22,30 @@ const GIT_FETCH_COMMAND = {
   continue_on_error: false,
 } as const;
 
+const GIT_RESOLVE_LOCAL_ORIGIN_HEAD_COMMAND = {
+  name: 'Git resolve local origin/HEAD',
+  run: 'git symbolic-ref --quiet --short refs/remotes/origin/HEAD',
+  timeout: 60,
+  continue_on_error: true,
+} as const;
+
+const GIT_RESOLVE_REMOTE_HEAD_COMMAND = {
+  name: 'Git resolve remote HEAD',
+  run: 'git ls-remote --symref origin HEAD',
+  timeout: 60,
+  retries: 1,
+  continue_on_error: true,
+} as const;
+
+function buildVerifyRemoteBranchCommand(branch: string) {
+  return {
+    name: 'Git verify remote branch',
+    run: `git show-ref --verify --quiet 'refs/remotes/origin/${branch}'`,
+    timeout: 60,
+    continue_on_error: true,
+  };
+}
+
 function buildCheckoutCommands(branch: string) {
   return [
     {
@@ -88,7 +112,7 @@ type PrivateWorkspaceManagerMethods = {
   }) => Promise<void>;
 };
 
-describe('WorkspaceManager git fetch retry', () => {
+describe('WorkspaceManager git synchronization', () => {
   let manager: WorkspaceManager;
   let privateManager: PrivateWorkspaceManagerMethods;
   let syncRepositoryGitState: PrivateWorkspaceManagerMethods['syncRepositoryGitState'];
@@ -219,7 +243,7 @@ describe('WorkspaceManager git fetch retry', () => {
     expect(console.warn).toHaveBeenCalledTimes(4);
   });
 
-  it('uses the remote HEAD when syncing an implicit default branch', async () => {
+  it('uses local origin/HEAD before a network lookup when stored default metadata is stale', async () => {
     executor.execute
       .mockResolvedValueOnce({
         command: GIT_FETCH_COMMAND,
@@ -229,16 +253,17 @@ describe('WorkspaceManager git fetch retry', () => {
         stderr: '',
       })
       .mockResolvedValueOnce({
-        command: {
-          name: 'Git resolve remote HEAD',
-          run: 'git ls-remote --symref origin HEAD',
-          timeout: 60,
-          continue_on_error: true,
-        },
+        command: GIT_RESOLVE_LOCAL_ORIGIN_HEAD_COMMAND,
         success: true,
         duration: 5,
-        stdout:
-          'ref: refs/heads/master\tHEAD\n0123456789abcdef0123456789abcdef01234567\tHEAD\n',
+        stdout: 'origin/develop\n',
+        stderr: '',
+      })
+      .mockResolvedValueOnce({
+        command: buildVerifyRemoteBranchCommand('develop'),
+        success: true,
+        duration: 5,
+        stdout: '',
         stderr: '',
       });
 
@@ -250,18 +275,106 @@ describe('WorkspaceManager git fetch retry', () => {
       setDefaultRemote: false,
     });
 
-    expect(executor.execute).toHaveBeenCalledTimes(2);
+    expect(executor.execute).toHaveBeenCalledTimes(3);
     expect(executor.execute).not.toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'Git resolve origin/HEAD',
-      }),
+      GIT_RESOLVE_REMOTE_HEAD_COMMAND,
     );
+    expect(executor.executeAll).toHaveBeenCalledWith(
+      buildCheckoutCommands('develop'),
+    );
+    expect(console.warn).toHaveBeenCalledWith(
+      'Resolved origin/HEAD for acme/backend to develop; ignoring stale default branch main.',
+    );
+  });
+
+  it('uses the remote HEAD when the local origin/HEAD ref is unavailable', async () => {
+    executor.execute
+      .mockResolvedValueOnce({
+        command: GIT_FETCH_COMMAND,
+        success: true,
+        duration: 5,
+        stdout: '',
+        stderr: '',
+      })
+      .mockResolvedValueOnce({
+        command: GIT_RESOLVE_LOCAL_ORIGIN_HEAD_COMMAND,
+        success: false,
+        duration: 5,
+        stdout: '',
+        stderr: 'fatal: ref refs/remotes/origin/HEAD is not a symbolic ref',
+      })
+      .mockResolvedValueOnce({
+        command: GIT_RESOLVE_REMOTE_HEAD_COMMAND,
+        success: true,
+        duration: 5,
+        stdout:
+          'ref: refs/heads/master\tHEAD\n0123456789abcdef0123456789abcdef01234567\tHEAD\n',
+        stderr: '',
+      })
+      .mockResolvedValueOnce({
+        command: buildVerifyRemoteBranchCommand('master'),
+        success: true,
+        duration: 5,
+        stdout: '',
+        stderr: '',
+      });
+
+    await syncRepositoryGitState({
+      executor,
+      repoFullName: 'acme/backend',
+      targetBranch: 'main',
+      allowRemoteHeadFallback: true,
+      setDefaultRemote: false,
+    });
+
     expect(executor.executeAll).toHaveBeenCalledWith(
       buildCheckoutCommands('master'),
     );
-    expect(console.warn).toHaveBeenCalledWith(
-      'Resolved remote HEAD for acme/backend to master; ignoring stale default branch main.',
+  });
+
+  it('uses a verified stored default when both origin/HEAD lookups are unavailable', async () => {
+    executor.execute
+      .mockResolvedValueOnce({ success: true, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ success: false, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ success: false, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ success: true, stdout: '', stderr: '' });
+
+    await syncRepositoryGitState({
+      executor,
+      repoFullName: 'acme/backend',
+      targetBranch: 'main',
+      allowRemoteHeadFallback: true,
+      setDefaultRemote: false,
+    });
+
+    expect(executor.execute).toHaveBeenLastCalledWith(
+      buildVerifyRemoteBranchCommand('main'),
     );
+    expect(executor.executeAll).toHaveBeenCalledWith(
+      buildCheckoutCommands('main'),
+    );
+  });
+
+  it('fails before checkout when origin/HEAD is unavailable and the stored default does not exist', async () => {
+    executor.execute
+      .mockResolvedValueOnce({ success: true, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ success: false, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ success: false, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ success: false, stdout: '', stderr: '' });
+
+    await expect(
+      syncRepositoryGitState({
+        executor,
+        repoFullName: 'acme/backend',
+        targetBranch: 'main',
+        allowRemoteHeadFallback: true,
+        setDefaultRemote: false,
+      }),
+    ).rejects.toThrow(
+      'Could not determine the default branch for acme/backend: origin/HEAD was unavailable and stored branch origin/main does not exist.',
+    );
+
+    expect(executor.executeAll).not.toHaveBeenCalled();
   });
 
   it('keeps the longer sync timeout while still pinning repositories to an exact sha', async () => {

--- a/apps/worker/src/workspace/workspace-manager.ts
+++ b/apps/worker/src/workspace/workspace-manager.ts
@@ -90,6 +90,16 @@ function parseOriginHeadLsRemote(stdout?: string): string | null {
   return null;
 }
 
+function parseLocalOriginHead(stdout?: string): string | null {
+  const ref = stdout?.trim();
+
+  if (!ref?.startsWith('origin/')) {
+    return null;
+  }
+
+  return ref.slice('origin/'.length) || null;
+}
+
 function renderToolVersionsFile(
   toolVersionsConfig: Record<string, string>,
 ): string {
@@ -837,31 +847,87 @@ export class WorkspaceManager {
     targetBranch: string;
     allowRemoteHeadFallback: boolean;
   }): Promise<string> {
-    const originHeadBranch = allowRemoteHeadFallback
-      ? await this.resolveOriginHeadBranch(executor)
-      : null;
+    if (!allowRemoteHeadFallback) {
+      return targetBranch;
+    }
+
+    const originHeadBranch =
+      (await this.resolveLocalOriginHeadBranch(executor)) ??
+      (await this.resolveRemoteOriginHeadBranch(executor));
 
     if (originHeadBranch && originHeadBranch !== targetBranch) {
       console.warn(
-        `Resolved remote HEAD for ${repoFullName} to ${originHeadBranch}; ignoring stale default branch ${targetBranch}.`,
+        `Resolved origin/HEAD for ${repoFullName} to ${originHeadBranch}; ignoring stale default branch ${targetBranch}.`,
       );
       return originHeadBranch;
     }
 
-    return originHeadBranch ?? targetBranch;
+    if (
+      originHeadBranch ||
+      (await this.remoteTrackingBranchExists(executor, targetBranch))
+    ) {
+      return originHeadBranch ?? targetBranch;
+    }
+
+    throw new Error(
+      `Could not determine the default branch for ${repoFullName}: origin/HEAD was unavailable and stored branch origin/${targetBranch} does not exist.`,
+    );
   }
 
-  private async resolveOriginHeadBranch(
+  private async resolveLocalOriginHeadBranch(
+    executor: CommandExecutor,
+  ): Promise<string | null> {
+    const symbolicRefResult = await executor.execute({
+      name: 'Git resolve local origin/HEAD',
+      run: 'git symbolic-ref --quiet --short refs/remotes/origin/HEAD',
+      timeout: 60,
+      continue_on_error: true,
+    });
+    const branch = parseLocalOriginHead(symbolicRefResult.stdout);
+
+    if (!branch) {
+      return null;
+    }
+
+    return (await this.remoteTrackingBranchExists(executor, branch))
+      ? branch
+      : null;
+  }
+
+  private async resolveRemoteOriginHeadBranch(
     executor: CommandExecutor,
   ): Promise<string | null> {
     const lsRemoteResult = await executor.execute({
       name: 'Git resolve remote HEAD',
       run: 'git ls-remote --symref origin HEAD',
       timeout: 60,
+      retries: 1,
       continue_on_error: true,
     });
 
-    return parseOriginHeadLsRemote(lsRemoteResult.stdout);
+    const branch = parseOriginHeadLsRemote(lsRemoteResult.stdout);
+
+    if (!branch) {
+      return null;
+    }
+
+    return (await this.remoteTrackingBranchExists(executor, branch))
+      ? branch
+      : null;
+  }
+
+  private async remoteTrackingBranchExists(
+    executor: CommandExecutor,
+    branch: string,
+  ): Promise<boolean> {
+    const result = await executor.execute({
+      name: 'Git verify remote branch',
+      run: `git show-ref --verify --quiet 'refs/remotes/origin/${shellEscape(branch)}'`,
+      timeout: 60,
+      continue_on_error: true,
+    });
+
+    return result.success;
   }
 
   private async fetchRepositoryWithRetry({


### PR DESCRIPTION
## What changed

- Prefer the fetched local `origin/HEAD` when a task does not explicitly select a branch.
- Fall back to the remote HEAD lookup with a bounded retry.
- Verify remote-tracking refs before checkout and fail with a clear diagnostic when neither HEAD nor stored metadata points to an existing branch.
- Add regression coverage for stale metadata, missing local HEAD, verified stored defaults, and unresolved defaults.

## Why

All-repositories tasks intentionally omit a branch. If stored repository metadata was stale and the remote HEAD lookup returned no result, the worker previously fell through to that stale value and attempted a checkout such as `origin/main` even when the repository default was `develop`.

This keeps explicit branch selections unchanged while making implicit default-branch resolution resilient to stale metadata and transient provider lookups.

Addresses the branch-checkout failure reported in #630.

## Validation

- `pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/worker exec vitest run src/workspace/__tests__ src/commands/setup/__tests__/workspace.test.ts` (69 tests)
- `pnpm --filter @roomote/worker check-types`
- `pnpm --filter @roomote/worker lint`
- Full pre-push suite: oxlint, residual lint, fast typecheck, and knip
- Real clone of `easonLiangWorldedtech/Roomote` with deliberately stale `main` metadata checked out `develop`
- Rebuilt local worker release archive and confirmed the packaged worker contains the new resolver
