### PR TITLE
[Feat] Sync stored default branches from GitHub repository.edited webhooks

### DIFF
--- a/.changeset/repository-edited-webhook.md
+++ b/.changeset/repository-edited-webhook.md
@@ -1,0 +1,5 @@
+---
+'@roomote/api': patch
+---
+
+Handle the GitHub `repository.edited` webhook so stored repository metadata follows default-branch changes instead of going stale until a manual installation resync.

--- a/apps/api/src/handlers/github/__tests__/handleRepositoryEdited.test.ts
+++ b/apps/api/src/handlers/github/__tests__/handleRepositoryEdited.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const { mockSet, mockWhere, mockReturning } = vi.hoisted(() => ({
+  mockSet: vi.fn(),
+  mockWhere: vi.fn(),
+  mockReturning: vi.fn(),
+}));
+
+vi.mock('@roomote/db/server', () => ({
+  db: {
+    update: () => ({
+      set: (values: unknown) => {
+        mockSet(values);
+        return {
+          where: (condition: unknown) => {
+            mockWhere(condition);
+            return { returning: () => mockReturning() };
+          },
+        };
+      },
+    }),
+  },
+  repositories: {
+    sourceControlProvider: 'source_control_provider',
+    githubRepoId: 'github_repo_id',
+    defaultBranch: 'default_branch',
+  },
+  and: (...conditions: unknown[]) => ({ and: conditions }),
+  eq: (column: unknown, value: unknown) => ({ eq: [column, value] }),
+  ne: (column: unknown, value: unknown) => ({ ne: [column, value] }),
+}));
+
+import { handleRepositoryEdited } from '../handleRepositoryEdited';
+
+function makePayload(
+  overrides: Partial<{
+    changes: { default_branch?: { from?: string | null } | null } | null;
+  }> = {},
+) {
+  return {
+    action: 'edited',
+    changes: { default_branch: { from: 'main' } },
+    repository: {
+      id: 1234,
+      full_name: 'acme/backend',
+      default_branch: 'develop',
+    },
+    installation: { id: 42 },
+    ...overrides,
+  };
+}
+
+describe('handleRepositoryEdited', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReturning.mockResolvedValue([{ id: 'repo-1' }]);
+  });
+
+  it('updates stored default branches when the default branch changed', async () => {
+    const response = await handleRepositoryEdited(makePayload());
+
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultBranch: 'develop' }),
+    );
+    expect(mockWhere).toHaveBeenCalledWith({
+      and: [
+        { eq: ['source_control_provider', 'github'] },
+        { eq: ['github_repo_id', 1234] },
+        { ne: ['default_branch', 'develop'] },
+      ],
+    });
+    expect(response).toEqual({
+      status: 'ok',
+      message: 'Updated default branch for acme/backend to develop',
+      metadata: { updatedRepositoryCount: 1 },
+    });
+  });
+
+  it('ignores edits that do not change the default branch', async () => {
+    const response = await handleRepositoryEdited(
+      makePayload({ changes: { default_branch: null } }),
+    );
+
+    expect(mockSet).not.toHaveBeenCalled();
+    expect(response).toEqual({
+      status: 'ok',
+      message: 'Ignoring non-default-branch edit',
+    });
+  });
+
+  it('ignores edits with no changes payload', async () => {
+    const response = await handleRepositoryEdited(
+      makePayload({ changes: null }),
+    );
+
+    expect(mockSet).not.toHaveBeenCalled();
+    expect(response).toEqual({
+      status: 'ok',
+      message: 'Ignoring non-default-branch edit',
+    });
+  });
+
+  it('reports zero updated rows when no stored repository matched', async () => {
+    mockReturning.mockResolvedValue([]);
+
+    const response = await handleRepositoryEdited(makePayload());
+
+    expect(response.metadata).toEqual({ updatedRepositoryCount: 0 });
+  });
+});

--- a/apps/api/src/handlers/github/handleRepositoryEdited.ts
+++ b/apps/api/src/handlers/github/handleRepositoryEdited.ts
@@ -1,0 +1,49 @@
+import { and, db, eq, ne, repositories } from '@roomote/db/server';
+
+import type { WebhookResponse } from '../../types';
+
+interface RepositoryEditedPayload {
+  action: string;
+  changes?: {
+    default_branch?: { from?: string | null } | null;
+  } | null;
+  repository: {
+    id: number;
+    full_name: string;
+    default_branch: string;
+  };
+  installation?: { id: number } | null;
+}
+
+/**
+ * Keep stored repository metadata in sync when the default branch changes
+ * on GitHub. Stale `default_branch` rows otherwise persist until a manual
+ * installation resync and break implicit-branch checkouts downstream.
+ */
+export async function handleRepositoryEdited(
+  payload: RepositoryEditedPayload,
+): Promise<WebhookResponse> {
+  if (!payload.changes?.default_branch) {
+    return { status: 'ok', message: 'Ignoring non-default-branch edit' };
+  }
+
+  const defaultBranch = payload.repository.default_branch;
+
+  const updated = await db
+    .update(repositories)
+    .set({ defaultBranch, updatedAt: new Date() })
+    .where(
+      and(
+        eq(repositories.sourceControlProvider, 'github'),
+        eq(repositories.githubRepoId, payload.repository.id),
+        ne(repositories.defaultBranch, defaultBranch),
+      ),
+    )
+    .returning({ id: repositories.id });
+
+  return {
+    status: 'ok',
+    message: `Updated default branch for ${payload.repository.full_name} to ${defaultBranch}`,
+    metadata: { updatedRepositoryCount: updated.length },
+  };
+}

--- a/apps/api/src/handlers/github/index.ts
+++ b/apps/api/src/handlers/github/index.ts
@@ -36,6 +36,9 @@ import {
 import { handlePushConflictCheck } from './handlePushConflictCheck';
 import { handleWorkflowRunCompleted } from './handleWorkflowRunCompleted';
 
+// Repository metadata sync:
+import { handleRepositoryEdited } from './handleRepositoryEdited';
+
 // Utilities:
 import { isFromKnownInstallation } from './isFromKnownInstallation';
 import { recordWebhook } from './recordWebhook';
@@ -451,6 +454,12 @@ github.post('/', async (c) => {
 
     webhooks.on('push', ({ id, name, payload }) =>
       recordWebhook(id, name, payload, () => handlePushConflictCheck(payload)),
+    );
+
+    webhooks.on('repository.edited', ({ id, name, payload }) =>
+      recordWebhook(id, `${name}.${payload.action}`, payload, () =>
+        handleRepositoryEdited(payload),
+      ),
     );
 
     webhooks.on('workflow_run.completed', ({ id, name, payload }) =>


### PR DESCRIPTION
## What changed

- Handle the `repository.edited` GitHub webhook: when the delivery carries a `changes.default_branch` entry, update matching stored repository rows (`sourceControlProvider = github`, matched by `githubRepoId`) to the new default branch. Edits that do not touch the default branch are acknowledged and ignored.
- The App manifest already subscribes to the `repository` event, so existing installations receive these deliveries without any re-configuration.

## Why

Nothing currently refreshes `repositories.default_branch` after the initial installation sync, so a default-branch change on GitHub leaves the row stale until someone manually resyncs the installation. Stale defaults then feed implicit-branch checkouts and branch pickers. Complements #635 (worker-side resilience) and #636 (worker-side self-heal) by fixing the row at the source when webhook delivery is available.

## Validation

- `pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/api exec vitest run src/handlers/github/__tests__/handleRepositoryEdited.test.ts` (4 tests: update, non-default-branch edit, missing changes payload, zero-match reporting)
- `pnpm --filter @roomote/api check-types`
- `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)