### PR TITLE
[Fix] Tasks stay active after workers die during preparation

### DIFF
--- a/.changeset/recover-stale-preparing-runs.md
+++ b/.changeset/recover-stale-preparing-runs.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Recover task runs whose workers stop responding during preparation so tasks no longer remain stuck indefinitely.

--- a/apps/bullmq/src/scheduled-jobs/__tests__/sleep-check.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/sleep-check.test.ts
@@ -402,21 +402,27 @@ describe('sleepCheckJob', () => {
     });
   });
 
-  it('uses inArray for stale-worker query so idle jobs are recovered too', async () => {
+  it('includes active and booting statuses in stale-worker recovery', async () => {
     mockJobQueries({});
 
     await sleepCheckJob();
 
-    // dueJobs query uses inArray with two statuses
+    // Due and hard-limit queries only consider active sessions.
     expect(inArrayFn).toHaveBeenCalledWith('status', [
       RunStatus.Running,
       RunStatus.Idle,
     ]);
-    // staleWorkerJobs query also uses inArray so idle jobs are recovered.
+    // Once any heartbeat has gone stale, booting runs need the same recovery
+    // as running and idle sessions.
     expect(inArrayFn).toHaveBeenCalledWith('status', [
       RunStatus.Running,
       RunStatus.Idle,
+      RunStatus.Processing,
+      RunStatus.Preparing,
+      RunStatus.Spawning,
+      RunStatus.Connecting,
     ]);
+    // The no-heartbeat query remains limited to runs that never heartbeated.
     expect(inArrayFn).toHaveBeenCalledWith('status', [
       RunStatus.Processing,
       RunStatus.Preparing,
@@ -1289,13 +1295,13 @@ describe('sleepCheckJob', () => {
     expect(recordedPaths).not.toContain('hard_limit');
   });
 
-  it('fails stale-worker jobs when the sandbox is already gone', async () => {
+  it('fails preparing jobs with a stale heartbeat when the sandbox is already gone', async () => {
     const mockJob = {
       id: 91,
       machineId: 'sb-gone',
       payloadKind: TaskPayloadKind.StandardTask,
-      status: RunStatus.Running,
-      taskPhase: 'stopped',
+      status: RunStatus.Preparing,
+      taskPhase: null,
       vendor: 'modal',
       workerHeartbeatAt: new Date(Date.now() - 5 * 60 * 1_000),
       snapshotId: null,
@@ -1342,13 +1348,13 @@ describe('sleepCheckJob', () => {
     );
   });
 
-  it('finalizes stale-worker jobs as canceled when a stop was requested and the sandbox is already gone', async () => {
+  it('cancels preparing jobs with a stale heartbeat and stop request when the sandbox is gone', async () => {
     const mockJob = {
       id: 101,
       machineId: 'sb-gone-after-stop',
       payloadKind: TaskPayloadKind.StandardTask,
-      status: RunStatus.Running,
-      taskPhase: 'stopped',
+      status: RunStatus.Preparing,
+      taskPhase: null,
       vendor: 'modal',
       workerHeartbeatAt: new Date(Date.now() - 5 * 60 * 1_000),
       snapshotId: null,

--- a/apps/bullmq/src/scheduled-jobs/__tests__/sleep-check.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/sleep-check.test.ts
@@ -408,13 +408,13 @@ describe('sleepCheckJob', () => {
     await sleepCheckJob();
 
     // Due and hard-limit queries only consider active sessions.
-    expect(inArrayFn).toHaveBeenCalledWith('status', [
+    expect(inArrayFn).toHaveBeenNthCalledWith(1, 'status', [
       RunStatus.Running,
       RunStatus.Idle,
     ]);
     // Once any heartbeat has gone stale, booting runs need the same recovery
     // as running and idle sessions.
-    expect(inArrayFn).toHaveBeenCalledWith('status', [
+    expect(inArrayFn).toHaveBeenNthCalledWith(3, 'status', [
       RunStatus.Running,
       RunStatus.Idle,
       RunStatus.Processing,
@@ -423,11 +423,15 @@ describe('sleepCheckJob', () => {
       RunStatus.Connecting,
     ]);
     // The no-heartbeat query remains limited to runs that never heartbeated.
-    expect(inArrayFn).toHaveBeenCalledWith('status', [
+    expect(inArrayFn).toHaveBeenNthCalledWith(5, 'status', [
       RunStatus.Processing,
       RunStatus.Preparing,
       RunStatus.Spawning,
       RunStatus.Connecting,
+    ]);
+    expect(inArrayFn).toHaveBeenNthCalledWith(7, 'status', [
+      RunStatus.Running,
+      RunStatus.Idle,
     ]);
   });
 

--- a/apps/bullmq/src/scheduled-jobs/sleep-check.ts
+++ b/apps/bullmq/src/scheduled-jobs/sleep-check.ts
@@ -52,6 +52,10 @@ const BOOTING_NO_HEARTBEAT_STATUSES = [
   RunStatus.Spawning,
   RunStatus.Connecting,
 ];
+const STALE_WORKER_STATUSES = [
+  ...ACTIVE_SLEEP_CHECK_STATUSES,
+  ...BOOTING_NO_HEARTBEAT_STATUSES,
+];
 
 const SLEEP_CHECK_PROVIDERS = sleepCheckManagedComputeProviders;
 
@@ -214,7 +218,7 @@ export const sleepCheckJob = async () => {
     .from(taskRuns)
     .where(
       and(
-        ...getBaseSleepCheckCandidateConditions(),
+        ...getBaseSleepCheckCandidateConditions(STALE_WORKER_STATUSES),
         isNotNull(taskRuns.workerHeartbeatAt),
         lte(
           taskRuns.workerHeartbeatAt,


### PR DESCRIPTION
## Related issue

Fixes #659

## Why this PR exists

- [ ] A maintainer explicitly invited this PR in the linked issue or discussion
- [x] I am a maintainer / this is internal Roomote work

## What changed

- Include booting run statuses in stale-worker heartbeat recovery after a worker has emitted at least one heartbeat.
- Keep never-heartbeated boot failures on the existing dedicated recovery path.
- Cover both failed and user-canceled `preparing` runs whose sandbox is already gone.
- Add a patch changeset for the operator-visible fix.

## How it was tested

- `pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/bullmq exec vitest run src/scheduled-jobs/__tests__/sleep-check.test.ts` (35 tests)
- Local integration probe against the real test Postgres database and Docker adapter: inserted stale `preparing` runs backed by missing Docker instances, invoked the real sleep-check job, and verified persisted run/task outcomes of `failed`/`failed` and `canceled`/`canceled`.
- Mutation check: removing only the stale-worker status expansion makes the focused suite fail; restoring it passes all 35 tests.
- `pnpm lint`
- `pnpm check-types`
- Pre-push checks: oxlint, residual lint, fast typecheck, and knip

## Checklist

- [x] The PR title follows the repo convention: `[Fix]`, `[Feat]`, `[Improve]`, `[Refactor]`, `[Docs]`, or `[Chore]` followed by a user-facing description
- [x] This PR is small and scoped to one change
- [x] `pnpm lint` and `pnpm check-types` pass locally
- [x] I added tests or included a clear manual validation note above
- [x] I removed secrets, tokens, private keys, and customer data from code, logs, and screenshots
- [x] If this change should appear in the changelog, I ran `pnpm changeset`
