### PR TITLE
[Fix] ADO CI Failure Triage misses real builds due to legacy service hook payload shape

### DIFF
--- a/packages/ado/src/__tests__/api.test.ts
+++ b/packages/ado/src/__tests__/api.test.ts
@@ -993,6 +993,7 @@ describe('Azure DevOps API helpers', () => {
       eventType: string;
       publisherInputs: Record<string, string>;
       consumerInputs: Record<string, string>;
+      resourceVersion?: string;
     }>;
     expect(
       createBodies.some((body) =>
@@ -1037,7 +1038,10 @@ describe('Azure DevOps API helpers', () => {
         (body) =>
           body.eventType === 'build.complete' &&
           body.publisherInputs.projectId === 'project-1' &&
-          !body.publisherInputs.repository,
+          !body.publisherInputs.repository &&
+          // 1.0 sends the legacy XAML build shape without result/sourceBranch/
+          // repository; the handler needs the 2.0 Build resource.
+          body.resourceVersion === '2.0',
       ),
     ).toBe(true);
   });
@@ -1241,6 +1245,43 @@ describe('getLatestAdoBuild and getAdoBuildFailureEvidence', () => {
     expect(evidence).toContain('task="Build job"');
     expect(evidence).toContain('Job aborted');
     expect(evidence).not.toContain('Build stage');
+  });
+
+  it('tolerates null log and issues fields on real timeline records', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (url) => {
+      const href = String(url);
+      if (href.includes('/timeline')) {
+        return new Response(
+          JSON.stringify({
+            records: [
+              // Real ADO sends explicit nulls on wrapper/pending records.
+              { name: 'Stage', type: 'Stage', result: 'failed', log: null },
+              {
+                name: 'Test',
+                type: 'Task',
+                result: 'failed',
+                log: { id: 7 },
+                issues: null,
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      if (href.includes('/logs/7')) {
+        return new Response('AssertionError: boom\n', { status: 200 });
+      }
+      return new Response('{}', { status: 404 });
+    });
+
+    const evidence = await getAdoBuildFailureEvidence({
+      repositoryFullName: 'acme/Platform/backend',
+      buildId: 88,
+      fetchImpl: fetchMock,
+    });
+
+    expect(evidence).toContain('task="Test"');
+    expect(evidence).toContain('AssertionError: boom');
   });
 
   it('keeps a peer job-level failure alongside an unrelated task failure', async () => {

--- a/packages/ado/src/api.ts
+++ b/packages/ado/src/api.ts
@@ -59,10 +59,14 @@ const ADO_PULL_REQUEST_SERVICE_HOOK_EVENTS: readonly {
 const ADO_PROJECT_SERVICE_HOOK_EVENTS: readonly {
   eventType: string;
   publisherInputs?: Record<string, string>;
+  resourceVersion?: string;
 }[] = [
   { eventType: 'workitem.commented' },
   // CI Failure Triage: completed builds (result filtered in the handler).
-  { eventType: 'build.complete' },
+  // resourceVersion 1.0 sends the legacy XAML build shape with no `result`,
+  // `sourceBranch`, or `repository`; 2.0 sends the modern Build resource the
+  // build.complete handler parses.
+  { eventType: 'build.complete', resourceVersion: '2.0' },
 ] as const;
 
 const adoWorkItemCommentSchema = z
@@ -1032,6 +1036,7 @@ function buildAdoServiceHookSubscriptionBody({
   projectId,
   eventType,
   publisherInputs = {},
+  resourceVersion,
   webhookUrl,
   secretToken,
 }: {
@@ -1039,13 +1044,14 @@ function buildAdoServiceHookSubscriptionBody({
   projectId: string;
   eventType: string;
   publisherInputs?: Record<string, string>;
+  resourceVersion?: string;
   webhookUrl: string;
   secretToken: string;
 }) {
   return {
     publisherId: ADO_SERVICE_HOOK_PUBLISHER_ID,
     eventType,
-    resourceVersion: '1.0',
+    resourceVersion: resourceVersion ?? '1.0',
     consumerId: ADO_SERVICE_HOOK_CONSUMER_ID,
     consumerActionId: ADO_SERVICE_HOOK_CONSUMER_ACTION_ID,
     publisherInputs: {
@@ -1168,6 +1174,7 @@ async function upsertAdoServiceHookSubscription({
   projectId,
   eventType,
   publisherInputs,
+  resourceVersion,
   webhookUrl,
   secretToken,
   subscriptions,
@@ -1179,6 +1186,7 @@ async function upsertAdoServiceHookSubscription({
   projectId: string;
   eventType: string;
   publisherInputs?: Record<string, string>;
+  resourceVersion?: string;
   webhookUrl: string;
   secretToken: string;
   subscriptions: AdoServiceHookSubscription[];
@@ -1191,6 +1199,7 @@ async function upsertAdoServiceHookSubscription({
     projectId,
     eventType,
     publisherInputs,
+    resourceVersion,
     webhookUrl,
     secretToken,
   });
@@ -1303,6 +1312,7 @@ async function ensureAdoProjectServiceHooks({
         projectId,
         eventType: descriptor.eventType,
         publisherInputs: descriptor.publisherInputs,
+        resourceVersion: descriptor.resourceVersion,
         webhookUrl,
         secretToken,
         subscriptions,
@@ -1539,13 +1549,15 @@ const adoTimelineRecordSchema = z
     type: z.string().optional(),
     result: z.string().nullable().optional(),
     state: z.string().optional(),
+    // Real timelines send `"log": null` on records without logs; a plain
+    // .optional() rejects that and fails the whole timeline parse.
     log: z
       .object({
         id: z.number().optional(),
         url: z.string().optional(),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
     issues: z
       .array(
         z
@@ -1556,7 +1568,7 @@ const adoTimelineRecordSchema = z
           })
           .passthrough(),
       )
-      .optional(),
+      .nullish(),
   })
   .passthrough();
 


### PR DESCRIPTION
## Related issue

Live smoke-test follow-up to #667 (Azure DevOps CI Failure Triage).

## Why this PR exists

- [x] I am a maintainer / this is internal Roomote work

## What changed

Live validation of CI Failure Triage against a real Azure DevOps organization surfaced two payload-shape gaps the mock-based tests could not catch:

- **`build.complete` subscriptions now pin `resourceVersion: 2.0`.** The ensure path previously defaulted every hook to 1.0, which delivers the legacy XAML build shape — `status` only, with no `result`, `sourceBranch`, `sourceVersion`, `repository`, or `project` — so the webhook handler classified every real failed build as a non-failure and skipped it. Version 2.0 delivers the modern Build resource the handler parses. Existing 1.0 subscriptions self-heal on the next repository sync because ensure PUT-refreshes matching subscriptions.
- **Timeline schema accepts explicit nulls.** Real build timelines carry `"log": null` and `"issues": null` on wrapper and pending records; the Zod schema only allowed object-or-absent, so the whole evidence fetch failed with a ZodError and triage tasks launched without failure evidence.

## How it was tested

- Targeted Vitest for `@roomote/ado` (31) and the ADO API handlers (60), plus package typecheck
- Live against a real Azure DevOps org: a failing default-branch build at resourceVersion 1.0 was skipped as non-failure; after this fix, hook re-ensure upgraded the live subscription 1.0 → 2.0 (verified self-heal from a downgraded subscription), the next failed build delivered the modern payload, and the triage task launched with the failed task's timeline record, issue text, and log tail injected as failure evidence

## Checklist

- [x] The PR title follows the repo convention
- [x] This PR is small and scoped to one change
- [x] `pnpm lint` and `pnpm check-types` pass locally
- [x] I added tests or included a clear manual validation note above
- [x] I removed secrets, tokens, private keys, and customer data from code, logs, and screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)