### PR TITLE
[Fix] Show repository choices during environment setup

### DIFF
--- a/.changeset/show-environment-setup-repositories.md
+++ b/.changeset/show-environment-setup-repositories.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Show individual repository and branch choices when launching the environment setup skill from the task composer, while keeping them hidden for ordinary tasks.

--- a/apps/web/src/app/(authenticated)/home/Home.client.test.tsx
+++ b/apps/web/src/app/(authenticated)/home/Home.client.test.tsx
@@ -150,9 +150,11 @@ vi.mock('@/components/tasks', async () => {
     SelectWorkspace: ({
       allowAuto,
       allowBranchSelection,
+      showRepositories,
     }: {
       allowAuto?: boolean;
       allowBranchSelection?: boolean;
+      showRepositories?: boolean;
     }) => {
       const { watch, setValue } = useFormContext();
       const repository = watch('repository');
@@ -176,6 +178,9 @@ vi.mock('@/components/tasks', async () => {
           <span data-testid="allow-branch-selection">
             {String(Boolean(allowBranchSelection))}
           </span>
+          <span data-testid="show-repositories">
+            {String(Boolean(showRepositories))}
+          </span>
           <button
             type="button"
             onClick={() => {
@@ -195,6 +200,16 @@ vi.mock('@/components/tasks', async () => {
             }}
           >
             Use all repositories workspace
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setValue('repository', 'Roomote/example-app');
+              setValue('environmentId', undefined);
+              setValue('branch', 'develop');
+            }}
+          >
+            Use repository workspace
           </button>
           <button
             type="button"
@@ -778,6 +793,41 @@ describe('Home', () => {
     expect(screen.getByTestId('allow-branch-selection')).toHaveTextContent(
       'false',
     );
+  });
+
+  it('shows repository and branch choices only for environment setup commands', async () => {
+    const { unmount } = render(<Home initialPlaceholderIndex={0} />);
+
+    expect(screen.getByTestId('show-repositories')).toHaveTextContent('false');
+    expect(screen.getByTestId('allow-branch-selection')).toHaveTextContent(
+      'false',
+    );
+
+    unmount();
+    currentSearchParams = 'prompt=%24environment-setup';
+
+    render(<Home initialPlaceholderIndex={0} />);
+
+    expect(screen.getByTestId('show-repositories')).toHaveTextContent('true');
+    expect(screen.getByTestId('allow-branch-selection')).toHaveTextContent(
+      'true',
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Use repository workspace' }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Submit prompt' }));
+
+    await waitFor(() => {
+      expect(mockCreateStandardTaskRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            repo: 'Roomote/example-app',
+            branch: 'develop',
+          }),
+        }),
+      );
+    });
   });
 
   it('shows the compute provider selector outside cloud mode', () => {

--- a/apps/web/src/app/(authenticated)/home/Home.tsx
+++ b/apps/web/src/app/(authenticated)/home/Home.tsx
@@ -59,6 +59,7 @@ import {
 } from './promptPlaceholders';
 
 const FALLBACK_PROMPT_PLACEHOLDER = 'What do you want to do?';
+const ENVIRONMENT_SETUP_COMMAND_PATTERN = /^\s*[$/]environment-setup(?:\s|$)/i;
 
 type RoutingFlowState = 'idle' | 'routing_pending' | 'launching';
 
@@ -107,9 +108,6 @@ export function Home({
   const environments = useEnvironments();
   const { cloudEnabled } = useAuthorizedUser();
 
-  const { isDebugUIVisible } = useShowDebugUI();
-  const canSelectBranch = isDebugUIVisible;
-
   // Keep option order identical to the setup catalog so the first fallback
   // matches the first visible Sandbox provider row.
   const catalogComputeProviders = SETUP_COMPUTE_PROVIDER_CATALOG.map(
@@ -136,6 +134,9 @@ export function Home({
   const environmentIdParam = searchParams.get('environmentId')?.trim() ?? '';
 
   const [promptText, setPromptText] = useState(promptParam);
+  const isEnvironmentSetup = ENVIRONMENT_SETUP_COMMAND_PATTERN.test(promptText);
+  const { isDebugUIVisible } = useShowDebugUI();
+  const canSelectBranch = isDebugUIVisible || isEnvironmentSetup;
   const [isExiting, setIsExiting] = useState(false);
   const [routingState, setRoutingState] = useState<RoutingFlowState>('idle');
   const [selectedComputeProvider, setSelectedComputeProvider] =
@@ -626,6 +627,7 @@ export function Home({
               <div ref={workspaceRef}>
                 <SelectWorkspace
                   allowAuto
+                  showRepositories={isEnvironmentSetup}
                   allowBranchSelection={canSelectBranch}
                 />
               </div>

--- a/apps/web/src/components/tasks/SelectEnvironmentOrRepository.test.tsx
+++ b/apps/web/src/components/tasks/SelectEnvironmentOrRepository.test.tsx
@@ -1,6 +1,12 @@
 import { useEffect } from 'react';
 import { FormProvider, useForm, useFormContext } from 'react-hook-form';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 
 import type { CreateTaskFormValues } from '@/types';
 
@@ -57,11 +63,17 @@ vi.mock('@/components/system', async () => {
     DropdownMenuItem: ({
       children,
       className,
+      onSelect,
     }: {
       children: React.ReactNode;
       className?: string;
+      onSelect?: () => void;
     }) => (
-      <div data-slot="dropdown-menu-item" className={className}>
+      <div
+        data-slot="dropdown-menu-item"
+        className={className}
+        onClick={onSelect}
+      >
         {children}
       </div>
     ),
@@ -111,11 +123,13 @@ const WorkspaceValuesProbe = ({
 
 const SelectEnvironmentOrRepositoryHarness = ({
   allowAuto = false,
+  showRepositories = false,
   repositoryFilter,
   defaultValues,
   onValuesChange,
 }: {
   allowAuto?: boolean;
+  showRepositories?: boolean;
   /** Omit for no filter (homepage Auto). Pass a repo full name to filter. */
   repositoryFilter?: string;
   defaultValues: Partial<CreateTaskFormValues>;
@@ -134,6 +148,7 @@ const SelectEnvironmentOrRepositoryHarness = ({
       <SelectEnvironmentOrRepository
         repositoryFilter={repositoryFilter}
         allowAuto={allowAuto}
+        showRepositories={showRepositories}
         onCreate={vi.fn()}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
@@ -512,5 +527,47 @@ describe('SelectEnvironmentOrRepository', () => {
       '__separator__',
       'Auto',
     ]);
+  });
+
+  it('keeps individual repositories out of the ordinary workspace menu', () => {
+    render(
+      <SelectEnvironmentOrRepositoryHarness
+        allowAuto
+        defaultValues={{}}
+        onValuesChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText(REPOSITORY)).not.toBeInTheDocument();
+    expect(screen.queryByText('Repositories')).not.toBeInTheDocument();
+  });
+
+  it('lists and selects individual repositories during environment setup', async () => {
+    let latestValues: WorkspaceSelectionValues | undefined;
+
+    render(
+      <SelectEnvironmentOrRepositoryHarness
+        allowAuto
+        showRepositories
+        defaultValues={{ repository: AUTO_WORKSPACE_VALUE }}
+        onValuesChange={(values) => {
+          latestValues = values;
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Repositories')).toBeInTheDocument();
+    fireEvent.click(screen.getByText(REPOSITORY));
+
+    await waitFor(() => {
+      expect(latestValues).toMatchObject({
+        environmentId: undefined,
+        repository: REPOSITORY,
+      });
+    });
+
+    expect(setWorkspace).toHaveBeenCalledWith({
+      workspace: { type: 'repository', value: REPOSITORY },
+    });
   });
 });

--- a/apps/web/src/components/tasks/SelectEnvironmentOrRepository.tsx
+++ b/apps/web/src/components/tasks/SelectEnvironmentOrRepository.tsx
@@ -51,6 +51,7 @@ interface SelectEnvironmentOrRepositoryProps {
   repositoryFilter?: string;
   lockedBranch?: string;
   allowAuto?: boolean;
+  showRepositories?: boolean;
   onCreate: () => void;
   onEdit: (e: React.MouseEvent, envId: string) => void;
   onDelete: (e: React.MouseEvent, env: EnvironmentWithMeta) => void;
@@ -60,6 +61,7 @@ export const SelectEnvironmentOrRepository = ({
   repositoryFilter,
   lockedBranch,
   allowAuto = false,
+  showRepositories = false,
   onCreate,
   onEdit,
   onDelete,
@@ -459,6 +461,44 @@ export const SelectEnvironmentOrRepository = ({
             )}
 
             {sortedEnvironments.length > 0 && hasRepositoryWorkspaceOptions && (
+              <DropdownMenuSeparator />
+            )}
+
+            {showRepositories && allRepositories.length > 0 && (
+              <DropdownMenuGroup>
+                <DropdownMenuLabel>Repositories</DropdownMenuLabel>
+                {allRepositories.map((availableRepository) => (
+                  <DropdownMenuItem
+                    key={availableRepository.fullName}
+                    onSelect={() =>
+                      handleValueChange(
+                        `${REPO_PREFIX}${availableRepository.fullName}`,
+                      )
+                    }
+                  >
+                    <div className="flex min-w-0 items-center gap-2">
+                      {repository === availableRepository.fullName &&
+                      !environmentId ? (
+                        <Check
+                          className="size-3.5 shrink-0 text-accent-foreground"
+                          strokeWidth={1.5}
+                        />
+                      ) : (
+                        <BookMarked
+                          className="size-3.5 shrink-0 text-muted-foreground"
+                          strokeWidth={1.5}
+                        />
+                      )}
+                      <span className="truncate">
+                        {availableRepository.fullName}
+                      </span>
+                    </div>
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuGroup>
+            )}
+
+            {showRepositories && allRepositories.length > 0 && (
               <DropdownMenuSeparator />
             )}
 

--- a/apps/web/src/components/tasks/SelectWorkspace.test.tsx
+++ b/apps/web/src/components/tasks/SelectWorkspace.test.tsx
@@ -17,7 +17,18 @@ vi.mock('@/components/settings/environments', () => ({
 }));
 
 vi.mock('./SelectEnvironmentOrRepository', () => ({
-  SelectEnvironmentOrRepository: () => <div>Workspace picker</div>,
+  SelectEnvironmentOrRepository: ({
+    showRepositories,
+  }: {
+    showRepositories?: boolean;
+  }) => (
+    <div
+      data-testid="workspace-picker"
+      data-show-repositories={showRepositories}
+    >
+      Workspace picker
+    </div>
+  ),
 }));
 
 vi.mock('./SelectBranch', () => ({
@@ -48,11 +59,13 @@ const DEFAULT_VALUES: CreateTaskFormValues = {
 const SelectWorkspaceHarness = ({
   defaultValues,
   allowBranchSelection,
+  showRepositories,
   environmentBranchRepositoryFullName,
   environmentBranchDefault,
 }: {
   defaultValues: Partial<CreateTaskFormValues>;
   allowBranchSelection?: boolean;
+  showRepositories?: boolean;
   environmentBranchRepositoryFullName?: string;
   environmentBranchDefault?: string;
 }) => {
@@ -67,6 +80,7 @@ const SelectWorkspaceHarness = ({
     <FormProvider {...form}>
       <SelectWorkspace
         allowBranchSelection={allowBranchSelection}
+        showRepositories={showRepositories}
         environmentBranchRepositoryFullName={
           environmentBranchRepositoryFullName
         }
@@ -77,6 +91,20 @@ const SelectWorkspaceHarness = ({
 };
 
 describe('SelectWorkspace', () => {
+  it('only asks the workspace picker to show repositories when requested', () => {
+    render(
+      <SelectWorkspaceHarness
+        showRepositories
+        defaultValues={{ repository: AUTO_WORKSPACE_VALUE }}
+      />,
+    );
+
+    expect(screen.getByTestId('workspace-picker')).toHaveAttribute(
+      'data-show-repositories',
+      'true',
+    );
+  });
+
   it('shows a branch selector for a selected single-repo environment', () => {
     render(
       <SelectWorkspaceHarness

--- a/apps/web/src/components/tasks/SelectWorkspace.tsx
+++ b/apps/web/src/components/tasks/SelectWorkspace.tsx
@@ -21,6 +21,7 @@ export const SelectWorkspace = ({
   repositoryFilter,
   lockedBranch,
   allowAuto = false,
+  showRepositories = false,
   allowBranchSelection = true,
   environmentBranchRepositoryFullName,
   environmentBranchDefault,
@@ -28,6 +29,7 @@ export const SelectWorkspace = ({
   repositoryFilter?: string;
   lockedBranch?: string;
   allowAuto?: boolean;
+  showRepositories?: boolean;
   allowBranchSelection?: boolean;
   environmentBranchRepositoryFullName?: string;
   environmentBranchDefault?: string;
@@ -105,6 +107,7 @@ export const SelectWorkspace = ({
           repositoryFilter={repositoryFilter}
           lockedBranch={lockedBranch}
           allowAuto={allowAuto}
+          showRepositories={showRepositories}
           onCreate={handleCreateEnvironment}
           onEdit={handleUpdateEnvironment}
           onDelete={handleDeleteEnvironment}


### PR DESCRIPTION
## Related issue

Fixes #642

## Why this PR exists

- [ ] A maintainer explicitly invited this PR in the linked issue or discussion
- [x] I am a maintainer / this is internal Roomote work

## What changed

- Detect explicit `$environment-setup` and `/environment-setup` commands in the Home task composer.
- Show individual synced repositories and enable branch selection only while environment setup is active.
- Keep ordinary task workspace choices unchanged.
- Add a patch changeset for the user-visible fix.

## How it was tested

- `pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/web exec vitest run src/components/tasks/SelectEnvironmentOrRepository.test.tsx src/components/tasks/SelectWorkspace.test.tsx "src/app/(authenticated)/home/Home.client.test.tsx"`
- `pnpm lint`
- `pnpm check-types`
- Pre-push checks: oxlint, residual ESLint, fast typecheck, and knip

## Checklist

- [x] The PR title follows the repo convention: `[Fix]`, `[Feat]`, `[Improve]`, `[Refactor]`, `[Docs]`, or `[Chore]` followed by a user-facing description
- [x] This PR is small and scoped to one change
- [x] `pnpm lint` and `pnpm check-types` pass locally
- [x] I added tests or included a clear manual validation note above
- [x] I removed secrets, tokens, private keys, and customer data from code, logs, and screenshots
- [x] If this change should appear in the changelog, I ran `pnpm changeset`