### PR TITLE
[Improve] Make custom automation report channels optional and thread-anchored

### DIFF
--- a/apps/api/src/handlers/mcp/slack.ts
+++ b/apps/api/src/handlers/mcp/slack.ts
@@ -230,6 +230,15 @@ function getAutomationWorkItemIdFromTaskPayload(
   return typeof value === 'string' && value.trim().length > 0 ? value : null;
 }
 
+function getCustomAutomationIdFromTaskPayload(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return null;
+  }
+
+  const value = (payload as Record<string, unknown>).customAutomationId;
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
 function normalizeSlackQuoteText(text: string): string {
   return text.replace(/\s+/g, ' ').trim();
 }
@@ -799,10 +808,12 @@ slackMcp.post('/thread_reply', async (c) => {
   }
 
   // Creating a brand-new top-level channel message is reserved for late-bound
-  // automation execution tasks, marked by automationWorkItemId in the payload.
+  // automation tasks: execution tasks marked by automationWorkItemId and
+  // custom automation runs marked by customAutomationId in the payload.
   if (
     !slackReplyTarget.threadTs &&
-    !getAutomationWorkItemIdFromTaskPayload(taskRun.payload)
+    !getAutomationWorkItemIdFromTaskPayload(taskRun.payload) &&
+    !getCustomAutomationIdFromTaskPayload(taskRun.payload)
   ) {
     return c.json(
       {

--- a/apps/docs/automations.mdx
+++ b/apps/docs/automations.mdx
@@ -65,11 +65,17 @@ Create arbitrary scheduled agent runs with:
 - the **prompt** Roomote should run
 - a **cadence** (`every hour`, `every 6 hours`, `daily`, or `weekly`)
 - one required **environment**
-- one **report destination** channel (Slack, Discord, Teams, or Telegram)
+- an optional **report destination** channel (Slack, Discord, Teams, or
+  Telegram)
 
 On each due tick, Roomote launches a normal task with that prompt in that
-environment and reports progress and the final result to the destination
-channel. Use **Run now** on an enabled automation to test it immediately.
+environment. When a report destination is set, the run is anchored to that
+channel: Roomote's first message (the final result, or a blocker or question
+that needs input) starts a thread, later updates continue that same thread,
+and you can reply in the thread to talk to the task. There is no progress
+chatter in between. Without a destination, the run happens silently and its
+results appear only in the task view. Use **Run now** on an enabled
+automation to test it immediately.
 
 Daily and weekly custom automations use the same local-hour window as the
 other scheduled automations (around 3am in the workspace timezone). Cap is

--- a/apps/web/src/components/settings/automations/CustomAutomationsSection.tsx
+++ b/apps/web/src/components/settings/automations/CustomAutomationsSection.tsx
@@ -40,7 +40,7 @@ type CustomAutomationFormState = {
   enabled: boolean;
   scheduleMode: CustomAutomationScheduleMode;
   environmentId: string;
-  targetProvider: 'slack' | 'discord' | 'teams' | 'telegram';
+  targetProvider: 'none' | 'slack' | 'discord' | 'teams' | 'telegram';
   targetChannelId: string;
   targetServiceUrl: string;
 };
@@ -78,6 +78,10 @@ function targetFromRow(row: CustomAutomationListItem): {
   channelId: string;
   serviceUrl: string;
 } {
+  if (!row.target.provider || !row.target.externalRef) {
+    return { provider: 'none', channelId: '', serviceUrl: '' };
+  }
+
   const provider =
     row.target.provider === 'discord' ||
     row.target.provider === 'teams' ||
@@ -251,8 +255,10 @@ export function CustomAutomationsSection() {
       toast.error('Choose an environment.');
       return;
     }
-    if (!form.targetChannelId.trim()) {
-      toast.error('Choose a destination channel.');
+    if (form.targetProvider !== 'none' && !form.targetChannelId.trim()) {
+      toast.error(
+        'Choose a destination channel, or set the destination to None.',
+      );
       return;
     }
 
@@ -262,8 +268,12 @@ export function CustomAutomationsSection() {
       enabled: form.enabled,
       scheduleMode: form.scheduleMode,
       environmentId: form.environmentId,
-      targetProvider: form.targetProvider,
-      targetChannelId: form.targetChannelId,
+      ...(form.targetProvider !== 'none'
+        ? {
+            targetProvider: form.targetProvider,
+            targetChannelId: form.targetChannelId,
+          }
+        : {}),
       ...(form.targetProvider === 'teams' && form.targetServiceUrl.trim()
         ? { targetServiceUrl: form.targetServiceUrl.trim() }
         : {}),
@@ -389,6 +399,7 @@ export function CustomAutomationsSection() {
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
+                <SelectItem value="none">None</SelectItem>
                 <SelectItem value="slack">Slack</SelectItem>
                 <SelectItem value="discord">Discord</SelectItem>
                 <SelectItem value="teams">Teams</SelectItem>
@@ -397,60 +408,69 @@ export function CustomAutomationsSection() {
             </Select>
           </div>
 
-          <div className="space-y-2">
-            <Label>Destination channel</Label>
-            {form.targetProvider === 'slack' ? (
-              <SlackChannelSelect
-                value={form.targetChannelId || null}
-                options={slackOptions}
-                disabled={busy}
-                onChange={(value) =>
-                  setForm((current) => ({
-                    ...current,
-                    targetChannelId: value ?? '',
-                  }))
-                }
-              />
-            ) : form.targetProvider === 'discord' ? (
-              <Select
-                value={form.targetChannelId || undefined}
-                disabled={busy}
-                onValueChange={(value) =>
-                  setForm((current) => ({
-                    ...current,
-                    targetChannelId: value,
-                  }))
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="Select Discord channel" />
-                </SelectTrigger>
-                <SelectContent>
-                  {discordOptions.map((channel) => (
-                    <SelectItem key={channel.id} value={channel.id}>
-                      {channel.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            ) : (
-              <Input
-                value={form.targetChannelId}
-                disabled={busy}
-                onChange={(event) =>
-                  setForm((current) => ({
-                    ...current,
-                    targetChannelId: event.target.value,
-                  }))
-                }
-                placeholder={
-                  form.targetProvider === 'teams'
-                    ? 'Teams conversation ID'
-                    : 'Telegram chat ID'
-                }
-              />
-            )}
-          </div>
+          {form.targetProvider === 'none' ? (
+            <div className="space-y-2">
+              <Label>Destination channel</Label>
+              <p className="pt-2 text-sm text-muted-foreground">
+                Results appear only in the task view.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              <Label>Destination channel</Label>
+              {form.targetProvider === 'slack' ? (
+                <SlackChannelSelect
+                  value={form.targetChannelId || null}
+                  options={slackOptions}
+                  disabled={busy}
+                  onChange={(value) =>
+                    setForm((current) => ({
+                      ...current,
+                      targetChannelId: value ?? '',
+                    }))
+                  }
+                />
+              ) : form.targetProvider === 'discord' ? (
+                <Select
+                  value={form.targetChannelId || undefined}
+                  disabled={busy}
+                  onValueChange={(value) =>
+                    setForm((current) => ({
+                      ...current,
+                      targetChannelId: value,
+                    }))
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select Discord channel" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {discordOptions.map((channel) => (
+                      <SelectItem key={channel.id} value={channel.id}>
+                        {channel.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <Input
+                  value={form.targetChannelId}
+                  disabled={busy}
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      targetChannelId: event.target.value,
+                    }))
+                  }
+                  placeholder={
+                    form.targetProvider === 'teams'
+                      ? 'Teams conversation ID'
+                      : 'Telegram chat ID'
+                  }
+                />
+              )}
+            </div>
+          )}
         </div>
 
         {form.targetProvider === 'teams' ? (
@@ -515,8 +535,8 @@ export function CustomAutomationsSection() {
           </h2>
           <p className="text-sm text-muted-foreground">
             Create your own scheduled agent runs with a prompt, cadence,
-            environment, and report channel. Daily and weekly runs fire around
-            local 3am, matching the other automations.
+            environment, and optional report channel. Daily and weekly runs fire
+            around local 3am, matching the other automations.
           </p>
         </div>
         {!isCreating && !editingId ? (
@@ -558,17 +578,19 @@ export function CustomAutomationsSection() {
               )?.name ?? 'Environment missing';
             const target = targetFromRow(row);
             const destinationLabel =
-              target.provider === 'slack'
-                ? (slackOptions.find(
-                    (option) =>
-                      option.id === target.channelId ||
-                      option.name === target.channelId,
-                  )?.label ?? target.channelId)
-                : target.provider === 'discord'
-                  ? (discordOptions.find(
-                      (option) => option.id === target.channelId,
+              target.provider === 'none'
+                ? 'no report channel'
+                : target.provider === 'slack'
+                  ? (slackOptions.find(
+                      (option) =>
+                        option.id === target.channelId ||
+                        option.name === target.channelId,
                     )?.label ?? target.channelId)
-                  : target.channelId;
+                  : target.provider === 'discord'
+                    ? (discordOptions.find(
+                        (option) => option.id === target.channelId,
+                      )?.label ?? target.channelId)
+                    : target.channelId;
 
             return (
               <Card key={row.id}>
@@ -579,7 +601,10 @@ export function CustomAutomationsSection() {
                     </CardTitle>
                     <p className="text-xs text-muted-foreground">
                       {scheduleLabel(row.scheduleMode)} · {environmentName} ·{' '}
-                      {target.provider}:{destinationLabel} · {statusLine(row)}
+                      {target.provider === 'none'
+                        ? destinationLabel
+                        : `${target.provider}:${destinationLabel}`}{' '}
+                      · {statusLine(row)}
                     </p>
                   </div>
                   <div className="flex items-center gap-1">

--- a/apps/web/src/components/settings/automations/CustomAutomationsSection.tsx
+++ b/apps/web/src/components/settings/automations/CustomAutomationsSection.tsx
@@ -142,10 +142,16 @@ export function CustomAutomationsSection() {
   const discordChannelsQuery = useQuery(
     trpc.automations.listDiscordChannels.queryOptions(),
   );
+  const settingsQuery = useQuery(trpc.automations.getSettings.queryOptions());
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
   const [form, setForm] = useState<CustomAutomationFormState>(EMPTY_FORM);
+
+  // New Slack destinations default to the shared manager channel, matching
+  // where the other automations report by default.
+  const managerSlackChannelId =
+    settingsQuery.data?.settings.managerSlackChannelId ?? '';
 
   const environmentOptions = useMemo(
     () =>
@@ -288,8 +294,8 @@ export function CustomAutomationsSection() {
   };
 
   const renderEditor = () => (
-    <Card className="border-dashed">
-      <CardHeader className="pb-3">
+    <Card variant="snug" className="border-dashed">
+      <CardHeader>
         <CardTitle className="text-sm font-medium">
           {editingId ? 'Edit custom automation' : 'New custom automation'}
         </CardTitle>
@@ -390,7 +396,8 @@ export function CustomAutomationsSection() {
                   ...current,
                   targetProvider:
                     value as CustomAutomationFormState['targetProvider'],
-                  targetChannelId: '',
+                  targetChannelId:
+                    value === 'slack' ? managerSlackChannelId : '',
                   targetServiceUrl: '',
                 }))
               }
@@ -547,7 +554,10 @@ export function CustomAutomationsSection() {
             onClick={() => {
               setIsCreating(true);
               setEditingId(null);
-              setForm(EMPTY_FORM);
+              setForm({
+                ...EMPTY_FORM,
+                targetChannelId: managerSlackChannelId,
+              });
             }}
           >
             <Plus className="size-4" />
@@ -563,8 +573,8 @@ export function CustomAutomationsSection() {
           Loading custom automations…
         </p>
       ) : rows.length === 0 && !isCreating ? (
-        <Card>
-          <CardContent className="py-6 text-sm text-muted-foreground">
+        <Card variant="snug">
+          <CardContent className="text-muted-foreground">
             No custom automations yet. Example: every Monday, summarize flaky
             tests and post to #eng-quality.
           </CardContent>
@@ -593,7 +603,7 @@ export function CustomAutomationsSection() {
                     : target.channelId;
 
             return (
-              <Card key={row.id}>
+              <Card key={row.id} variant="snug">
                 <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0 pb-2">
                   <div className="space-y-1">
                     <CardTitle className="text-sm font-medium">

--- a/apps/web/src/trpc/commands/automations/custom-automations.ts
+++ b/apps/web/src/trpc/commands/automations/custom-automations.ts
@@ -17,6 +17,7 @@ import {
   type BackgroundAutomationProvider,
   type BackgroundAutomationTargetKind,
   type CustomAutomationScheduleMode,
+  type OptionalAutomationTarget,
 } from '@roomote/types';
 
 import type { UserAuthSuccess } from '@/types';
@@ -30,7 +31,7 @@ export type CustomAutomationListItem = {
   enabled: boolean;
   scheduleMode: CustomAutomationScheduleMode;
   environmentId: string | null;
-  target: AutomationTarget;
+  target: OptionalAutomationTarget;
   lastRunAt: Date | null;
   lastSucceededAt: Date | null;
   lastFailedAt: Date | null;
@@ -46,8 +47,9 @@ export type CustomAutomationWriteInput = {
   enabled: boolean;
   scheduleMode: string;
   environmentId: string;
-  targetProvider: 'slack' | 'discord' | 'teams' | 'telegram';
-  targetChannelId: string;
+  /** Omitted when the automation has no report destination channel. */
+  targetProvider?: 'slack' | 'discord' | 'teams' | 'telegram';
+  targetChannelId?: string;
   targetServiceUrl?: string | null;
 };
 
@@ -76,14 +78,22 @@ function toListItem(row: CustomAutomation): CustomAutomationListItem {
   };
 }
 
-function buildTarget(input: CustomAutomationWriteInput): AutomationTarget {
-  const externalRef = input.targetChannelId.trim();
+function buildTarget(
+  input: CustomAutomationWriteInput,
+): OptionalAutomationTarget {
+  if (!input.targetProvider) {
+    return {};
+  }
+
+  const externalRef = input.targetChannelId?.trim() ?? '';
   if (!externalRef) {
-    throw new Error('A report destination channel is required.');
+    throw new Error(
+      'Choose a destination channel for the selected provider, or set the destination to None.',
+    );
   }
 
   const targetKindByProvider: Record<
-    CustomAutomationWriteInput['targetProvider'],
+    NonNullable<CustomAutomationWriteInput['targetProvider']>,
     BackgroundAutomationTargetKind
   > = {
     slack: 'slack_channel',
@@ -116,7 +126,7 @@ function assertScheduleMode(
 }
 
 async function assertDestinationConnected(
-  provider: CustomAutomationWriteInput['targetProvider'],
+  provider: NonNullable<CustomAutomationWriteInput['targetProvider']>,
 ): Promise<void> {
   const connected = await listConnectedCommunicationProviders();
   if (!connected.includes(provider)) {
@@ -140,7 +150,9 @@ export async function createCustomAutomationCommand(
 ): Promise<CustomAutomationListItem> {
   assertAdmin(auth);
   assertScheduleMode(input.scheduleMode);
-  await assertDestinationConnected(input.targetProvider);
+  if (input.targetProvider) {
+    await assertDestinationConnected(input.targetProvider);
+  }
 
   const created = await createCustomAutomation({
     name: input.name,
@@ -161,7 +173,9 @@ export async function updateCustomAutomationCommand(
 ): Promise<CustomAutomationListItem> {
   assertAdmin(auth);
   assertScheduleMode(input.scheduleMode);
-  await assertDestinationConnected(input.targetProvider);
+  if (input.targetProvider) {
+    await assertDestinationConnected(input.targetProvider);
+  }
 
   const updated = await updateCustomAutomation(input.id, {
     name: input.name,

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -638,8 +638,10 @@ const automationsRouter = createRouter({
           'weekly',
         ]),
         environmentId: z.string().uuid(),
-        targetProvider: z.enum(['slack', 'discord', 'teams', 'telegram']),
-        targetChannelId: z.string().trim().min(1).max(160),
+        targetProvider: z
+          .enum(['slack', 'discord', 'teams', 'telegram'])
+          .optional(),
+        targetChannelId: z.string().trim().min(1).max(160).optional(),
         targetServiceUrl: z
           .string()
           .trim()
@@ -668,8 +670,10 @@ const automationsRouter = createRouter({
           'weekly',
         ]),
         environmentId: z.string().uuid(),
-        targetProvider: z.enum(['slack', 'discord', 'teams', 'telegram']),
-        targetChannelId: z.string().trim().min(1).max(160),
+        targetProvider: z
+          .enum(['slack', 'discord', 'teams', 'telegram'])
+          .optional(),
+        targetChannelId: z.string().trim().min(1).max(160).optional(),
         targetServiceUrl: z
           .string()
           .trim()

--- a/apps/worker/src/run-task/__tests__/run-task.test.ts
+++ b/apps/worker/src/run-task/__tests__/run-task.test.ts
@@ -1383,6 +1383,124 @@ describe('runTask', () => {
     );
   });
 
+  it('marks Slack custom automation runs as silent with a required terminal closeout', async () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(456_789);
+
+    try {
+      await runTask({
+        taskRun: {
+          id: 110,
+          taskId: 'task-110',
+          payloadKind: TaskPayloadKind.StandardTask,
+          harness: 'opencode-server',
+          payload: {
+            repo: '',
+            description: 'scan for flaky tests',
+            slackChannel: 'C123',
+            channel: 'C123',
+            customAutomationId: 'custom-automation-1',
+          },
+          result: null,
+        } as never,
+        envVars: {},
+        workspacePath: '/tmp/workspace',
+        prompt: '',
+        harnessInstructions: undefined,
+        agentInstructions: undefined,
+        environmentConfig: undefined,
+        callbacks: {},
+        context: {},
+        logger: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          log: vi.fn(),
+        } as never,
+        harnessSessionId: 'session-110',
+        workerEnv: {
+          authToken: 'cloud-token',
+          roomoteAppUrl: 'https://api.example.test',
+          trpcUrl: 'https://web.example.test',
+          buildUserFacingEnv: vi.fn(() => ({
+            HOME: '/tmp/home',
+            PATH: '/usr/bin',
+          })),
+        } as never,
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
+
+    expect(writeFileSyncMock).toHaveBeenCalledWith(
+      '/tmp/workspace/.roomote-runtime-home/.config/opencode/roomote-slack-reply-satisfaction.json',
+      JSON.stringify({
+        startedAtMs: 456_789,
+        currentTurnRequiresInitialAck: false,
+        requiresTerminalCloseoutWithoutTurn: true,
+      }),
+      'utf8',
+    );
+  });
+
+  it('marks non-Slack custom automation runs as silent with a required terminal closeout', async () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(567_891);
+
+    try {
+      await runTask({
+        taskRun: {
+          id: 111,
+          taskId: 'task-111',
+          payloadKind: TaskPayloadKind.StandardTask,
+          harness: 'opencode-server',
+          payload: {
+            repo: '',
+            description: 'scan for flaky tests',
+            communicationProvider: 'telegram',
+            communicationChannelId: 'chat-1',
+            customAutomationId: 'custom-automation-1',
+          },
+          result: null,
+        } as never,
+        envVars: {},
+        workspacePath: '/tmp/workspace',
+        prompt: '',
+        harnessInstructions: undefined,
+        agentInstructions: undefined,
+        environmentConfig: undefined,
+        callbacks: {},
+        context: {},
+        logger: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          log: vi.fn(),
+        } as never,
+        harnessSessionId: 'session-111',
+        workerEnv: {
+          authToken: 'cloud-token',
+          roomoteAppUrl: 'https://api.example.test',
+          trpcUrl: 'https://web.example.test',
+          buildUserFacingEnv: vi.fn(() => ({
+            HOME: '/tmp/home',
+            PATH: '/usr/bin',
+          })),
+        } as never,
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
+
+    expect(writeFileSyncMock).toHaveBeenCalledWith(
+      '/tmp/workspace/.roomote-runtime-home/.config/opencode/roomote-slack-reply-satisfaction.json',
+      JSON.stringify({
+        startedAtMs: 567_891,
+        currentTurnRequiresInitialAck: false,
+        requiresTerminalCloseoutWithoutTurn: true,
+      }),
+      'utf8',
+    );
+  });
+
   it('checks Slack drain during sleep fallback when the worker started before thread ts was persisted', async () => {
     waitForExternalSleepActionMock.mockResolvedValueOnce({
       claimed: true,

--- a/apps/worker/src/run-task/run-task.ts
+++ b/apps/worker/src/run-task/run-task.ts
@@ -224,12 +224,40 @@ function hasAutomationWorkItemId(taskRun: { payload: unknown }): boolean {
   );
 }
 
+function hasCustomAutomationId(taskRun: { payload: unknown }): boolean {
+  if (!taskRun.payload || typeof taskRun.payload !== 'object') {
+    return false;
+  }
+
+  const payload = taskRun.payload as {
+    customAutomationId?: unknown;
+  };
+
+  return (
+    typeof payload.customAutomationId === 'string' &&
+    payload.customAutomationId.trim().length > 0
+  );
+}
+
+/**
+ * Channel-only automation launches (work-item execution tasks and custom
+ * automation runs) stay silent until they have a final result or blocker;
+ * their first chat message late-binds the report thread, so an opening ack
+ * would hijack the thread root.
+ */
+function isSilentChannelAutomationLaunch(taskRun: {
+  payload: unknown;
+}): boolean {
+  return hasAutomationWorkItemId(taskRun) || hasCustomAutomationId(taskRun);
+}
+
 function shouldRequireInitialAckOnInitialTurn(taskRun: {
   payloadKind: string;
   payload: unknown;
 }): boolean {
-  // Automation work items deliberately skip opening acknowledgements.
-  if (hasAutomationWorkItemId(taskRun)) {
+  // Channel-only automation launches deliberately skip opening
+  // acknowledgements.
+  if (isSilentChannelAutomationLaunch(taskRun)) {
     return false;
   }
 
@@ -865,10 +893,11 @@ export const runTask = async ({
                   shouldAllowEmojiReactionOnInitialTurn(taskRun),
               }
             : {}),
-          // Late-bound automation execution tasks have no inbound Slack turn,
-          // but must still end with one agent-written closeout; the Stop hook
-          // blocks silent completion when this flag is set.
-          ...(!initialTurnMessageTs && hasAutomationWorkItemId(taskRun)
+          // Late-bound automation tasks (work-item execution tasks and
+          // custom automation runs) have no inbound Slack turn, but must
+          // still end with one agent-written closeout; the Stop hook blocks
+          // silent completion when this flag is set.
+          ...(!initialTurnMessageTs && isSilentChannelAutomationLaunch(taskRun)
             ? { requiresTerminalCloseoutWithoutTurn: true }
             : {}),
         }),

--- a/packages/db/src/lib/__tests__/custom-automations.test.ts
+++ b/packages/db/src/lib/__tests__/custom-automations.test.ts
@@ -63,4 +63,43 @@ describe('custom automations helpers', () => {
     await deleteCustomAutomation(created.id);
     expect(await getCustomAutomationById(created.id)).toBeNull();
   });
+
+  it('creates a custom automation without a report destination', async () => {
+    const [environment] = await db
+      .insert(environments)
+      .values({
+        name: `custom-auto-env-nodest-${Date.now()}`,
+        config: {
+          name: 'test',
+          repositories: [],
+        },
+      })
+      .returning();
+
+    const created = await createCustomAutomation({
+      name: `Silent scan ${Date.now()}`,
+      prompt: 'Scan for flaky tests without reporting to a channel.',
+      enabled: true,
+      scheduleMode: 'daily',
+      environmentId: environment!.id,
+      target: {},
+    });
+
+    expect(created.target).toEqual({});
+
+    await deleteCustomAutomation(created.id);
+  });
+
+  it('rejects a partially specified report destination', async () => {
+    await expect(
+      createCustomAutomation({
+        name: `Partial target ${Date.now()}`,
+        prompt: 'Scan for flaky tests.',
+        enabled: true,
+        scheduleMode: 'daily',
+        environmentId: 'ignored-by-early-validation',
+        target: { provider: 'slack' } as never,
+      }),
+    ).rejects.toThrow('Report destination');
+  });
 });

--- a/packages/db/src/lib/custom-automations.ts
+++ b/packages/db/src/lib/custom-automations.ts
@@ -1,9 +1,10 @@
 import { and, asc, count, eq, isNull, lt, or, sql } from 'drizzle-orm';
 
 import {
+  isConfiguredAutomationTarget,
   isScheduleOnlyBackgroundAutomationFrequency,
-  type AutomationTarget,
   type CustomAutomationScheduleMode,
+  type OptionalAutomationTarget,
   type ScheduleOnlyBackgroundAutomationFrequency,
   CUSTOM_AUTOMATION_NAME_MAX_LENGTH,
   CUSTOM_AUTOMATION_PROMPT_MAX_LENGTH,
@@ -30,7 +31,8 @@ export type CustomAutomationWriteInput = {
   enabled: boolean;
   scheduleMode: CustomAutomationScheduleMode;
   environmentId: string;
-  target: AutomationTarget;
+  /** Full destination target, or {} when the automation has no report channel. */
+  target: OptionalAutomationTarget;
   createdByUserId?: string | null;
 };
 
@@ -73,12 +75,15 @@ function assertValidWriteInput(input: CustomAutomationWriteInput): {
     throw new Error('Environment is required.');
   }
 
-  if (
-    !input.target?.provider ||
-    !input.target?.targetKind ||
-    !input.target?.externalRef
-  ) {
-    throw new Error('A report destination channel is required.');
+  const hasAnyTargetField = Boolean(
+    input.target?.provider ||
+    input.target?.targetKind ||
+    input.target?.externalRef,
+  );
+  if (hasAnyTargetField && !isConfiguredAutomationTarget(input.target)) {
+    throw new Error(
+      'Report destination must include a provider, target kind, and channel.',
+    );
   }
 
   return { name, prompt };

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -52,6 +52,7 @@ import type {
   LinearPendingSelectionStep,
   AutomationScanCursor,
   AutomationTarget,
+  OptionalAutomationTarget,
   BackgroundAutomationKey,
   PlatformIssueReport,
   WorkspaceReadiness,
@@ -2653,7 +2654,7 @@ export const customAutomations = pgTable(
     target: jsonb('target')
       .notNull()
       .default(sql`'{}'::jsonb`)
-      .$type<AutomationTarget>(),
+      .$type<OptionalAutomationTarget>(),
     createdByUserId: text('created_by_user_id').references(() => users.id, {
       onDelete: 'set null',
     }),

--- a/packages/sdk/src/server/automations/__tests__/custom-automations.test.ts
+++ b/packages/sdk/src/server/automations/__tests__/custom-automations.test.ts
@@ -23,6 +23,11 @@ vi.mock('@roomote/db/server', () => ({
 }));
 
 vi.mock('../destination', () => ({
+  buildDestinationPromptContext: vi.fn(() => ({
+    channelTag: 'slack_channel_id',
+    postToolName: 'post_to_slack_channel',
+    surfaceLabel: 'Slack',
+  })),
   buildDestinationTaskPayloadFields: vi.fn(() => ({})),
   findTeamsConversationServiceUrl: vi.fn(),
   listConnectedCommunicationProviders: vi.fn(async () => ['slack', 'teams']),
@@ -115,8 +120,11 @@ describe('customAutomationsJob', () => {
           type: TaskPayloadKind.StandardTask,
           payload: expect.objectContaining({
             environmentId: automation.environmentId,
-            description: automation.prompt,
+            description: expect.stringContaining(automation.prompt),
             repo: '',
+            customAutomationId: automation.id,
+            channel: 'C123',
+            slackChannel: 'C123',
           }),
         }),
         initiator: {
@@ -143,6 +151,40 @@ describe('customAutomationsJob', () => {
         launchClaimedAt: expect.any(Date),
       }),
     );
+  });
+
+  it('anchors the prompt to the configured report channel', async () => {
+    await customAutomationsJob();
+
+    const enqueued = vi.mocked(enqueueTask).mock.calls[0]?.[0] as {
+      task: { payload: { description: string } };
+    };
+    expect(enqueued.task.payload.description).toContain(
+      '<slack_channel_id>C123</slack_channel_id>',
+    );
+    expect(enqueued.task.payload.description).toContain('send_chat_reply');
+    expect(enqueued.task.payload.description).toContain(
+      'do not post progress updates',
+    );
+  });
+
+  it('launches without channel anchoring when no report channel is configured', async () => {
+    vi.mocked(listEnabledCustomAutomations).mockResolvedValue([
+      { ...automation, target: {} } as never,
+    ]);
+
+    const result = await customAutomationsJob();
+
+    expect(result.launchedTaskId).toBe('task_abc');
+    const enqueued = vi.mocked(enqueueTask).mock.calls[0]?.[0] as {
+      task: { payload: Record<string, unknown> };
+      channels?: unknown;
+    };
+    expect(enqueued.task.payload.description).toBe(automation.prompt);
+    expect(enqueued.task.payload.customAutomationId).toBeUndefined();
+    expect(enqueued.task.payload.channel).toBeUndefined();
+    expect(enqueued.channels).toBeUndefined();
+    expect(buildDestinationTaskPayloadFields).not.toHaveBeenCalled();
   });
 
   it('uses hour-0 boundary for hourly schedules', async () => {

--- a/packages/sdk/src/server/automations/custom-automations.ts
+++ b/packages/sdk/src/server/automations/custom-automations.ts
@@ -13,12 +13,14 @@ import {
   type CustomAutomation,
 } from '@roomote/db/server';
 import {
+  isConfiguredAutomationTarget,
   TaskPayloadKind,
   type AutomationTarget,
   type CommunicationProvider,
 } from '@roomote/types';
 
 import {
+  buildDestinationPromptContext,
   buildDestinationTaskPayloadFields,
   findTeamsConversationServiceUrl,
   listConnectedCommunicationProviders,
@@ -101,6 +103,27 @@ async function resolveDestination(
   };
 }
 
+/**
+ * Anchors a custom automation's prompt to its configured report channel,
+ * mirroring how the built-in channel automations tell the agent which surface
+ * and posting tool to report through.
+ */
+function buildChannelAnchoredDescription(
+  prompt: string,
+  destination: ResolvedAutomationDestination,
+): string {
+  const promptContext = buildDestinationPromptContext(destination);
+
+  return `${prompt}
+
+<task_context>
+  <source>background-automation</source>
+  <${promptContext.channelTag}>${destination.channelId}</${promptContext.channelTag}>
+</task_context>
+
+This run is anchored to the ${promptContext.surfaceLabel} channel above and reports through \`send_chat_reply\`; do not use \`${promptContext.postToolName}\` and do not post to any other channel. Stay silent while work is in flight: send no opening acknowledgement and do not post progress updates. Send a ${promptContext.surfaceLabel} message only for your final result, a durable blocker, or a required user input. Your first message creates this run's thread in that channel, so make it one self-contained message that stands alone for readers who have not seen this task; later messages and user replies continue that same thread.`;
+}
+
 async function resolveTimezone(): Promise<string> {
   const installation = await db.query.slackInstallations.findFirst({
     columns: { botAccessToken: true, teamId: true },
@@ -178,33 +201,38 @@ async function launchCustomAutomationRow(
     return result;
   }
 
-  const destination = await resolveDestination(automation.target);
-  if (!destination) {
-    const message =
-      automation.target.provider === 'teams'
-        ? 'Teams report destination is missing a resolvable service URL.'
-        : 'Report destination is not configured.';
-    result.skippedReason = message;
-    result.errors.push(message);
-    await recordCustomAutomationRunOutcome(db, {
-      id: automation.id,
-      status: 'failed',
-      error: message,
-    });
-    return result;
-  }
+  // A report destination is optional: automations without one run silently
+  // and surface results only in the task UI.
+  let destination: ResolvedAutomationDestination | null = null;
+  if (isConfiguredAutomationTarget(automation.target)) {
+    destination = await resolveDestination(automation.target);
+    if (!destination) {
+      const message =
+        automation.target.provider === 'teams'
+          ? 'Teams report destination is missing a resolvable service URL.'
+          : 'Report destination could not be resolved.';
+      result.skippedReason = message;
+      result.errors.push(message);
+      await recordCustomAutomationRunOutcome(db, {
+        id: automation.id,
+        status: 'failed',
+        error: message,
+      });
+      return result;
+    }
 
-  const connected = await listConnectedCommunicationProviders();
-  if (!connected.includes(destination.provider)) {
-    const message = `${destination.provider} is not connected.`;
-    result.skippedReason = message;
-    result.errors.push(message);
-    await recordCustomAutomationRunOutcome(db, {
-      id: automation.id,
-      status: 'failed',
-      error: message,
-    });
-    return result;
+    const connected = await listConnectedCommunicationProviders();
+    if (!connected.includes(destination.provider)) {
+      const message = `${destination.provider} is not connected.`;
+      result.skippedReason = message;
+      result.errors.push(message);
+      await recordCustomAutomationRunOutcome(db, {
+        id: automation.id,
+        status: 'failed',
+        error: message,
+      });
+      return result;
+    }
   }
 
   const launchClaimedAt = await tryClaimCustomAutomationLaunch(automation.id);
@@ -220,8 +248,25 @@ async function launchCustomAutomationRow(
         payload: {
           repo: '',
           environmentId: automation.environmentId,
-          description: automation.prompt,
-          ...buildDestinationTaskPayloadFields(destination),
+          description: destination
+            ? buildChannelAnchoredDescription(automation.prompt, destination)
+            : automation.prompt,
+          ...(destination
+            ? buildDestinationTaskPayloadFields(destination)
+            : {}),
+          // customAutomationId authorizes the Slack late-bound thread flow:
+          // the run's first send_chat_reply posts a root message in the
+          // destination channel and binds it as the task thread, so later
+          // updates continue the thread and user replies route back into the
+          // task. The channel/slackChannel payload fields give the sandbox
+          // its Slack reply context (ROOMOTE_SLACK_CHANNEL).
+          ...(destination ? { customAutomationId: automation.id } : {}),
+          ...(destination?.provider === 'slack'
+            ? {
+                channel: destination.channelId,
+                slackChannel: destination.channelId,
+              }
+            : {}),
         },
       },
       title: automation.name,
@@ -236,7 +281,7 @@ async function launchCustomAutomationRow(
       workflow: 'standard',
       surface: 'system',
       trigger: opts.manualTrigger ? 'manual' : 'schedule',
-      ...(destination.provider === 'slack'
+      ...(destination?.provider === 'slack'
         ? { channels: { slackChannelId: destination.channelId } }
         : {}),
     });

--- a/packages/types/src/__tests__/task-runs.test.ts
+++ b/packages/types/src/__tests__/task-runs.test.ts
@@ -269,6 +269,30 @@ describe('taskSpecSchema', () => {
     expect(parsed.payload.sourceControlProvider).toBe('gitlab');
   });
 
+  it('preserves customAutomationId and Slack channel context on StandardTask payloads', () => {
+    const parsed = taskSpecSchema.parse({
+      userId: 'user-1',
+      type: TaskPayloadKind.StandardTask,
+      payload: {
+        repo: '',
+        description: 'Scan for flaky tests.',
+        customAutomationId: 'custom-automation-1',
+        channel: 'C123',
+        slackChannel: 'C123',
+      },
+    });
+
+    expect(parsed.type).toBe(TaskPayloadKind.StandardTask);
+
+    if (parsed.type !== TaskPayloadKind.StandardTask) {
+      throw new Error('Expected StandardTask payload');
+    }
+
+    expect(parsed.payload.customAutomationId).toBe('custom-automation-1');
+    expect(parsed.payload.channel).toBe('C123');
+    expect(parsed.payload.slackChannel).toBe('C123');
+  });
+
   it('allows GitLab target branch metadata on PR review payloads', () => {
     const parsed = taskSpecSchema.parse({
       type: TaskPayloadKind.GithubPrReview,

--- a/packages/types/src/background-agents.ts
+++ b/packages/types/src/background-agents.ts
@@ -172,6 +172,19 @@ export type AutomationTarget = {
 };
 
 /**
+ * A custom automation's stored report destination: a full AutomationTarget,
+ * or the empty object (the column default) when no report channel is
+ * configured.
+ */
+export type OptionalAutomationTarget = AutomationTarget | Record<string, never>;
+
+export function isConfiguredAutomationTarget(
+  target: OptionalAutomationTarget | null | undefined,
+): target is AutomationTarget {
+  return Boolean(target?.provider && target?.targetKind && target?.externalRef);
+}
+
+/**
  * Merged-PR scan resume cursor stored in automations.scan_cursor
  * (security_auditor / code_quality_auditor).
  */

--- a/packages/types/src/task-runs.ts
+++ b/packages/types/src/task-runs.ts
@@ -983,6 +983,14 @@ const sharedTaskPayloadSchema = z.object({
    * survive schema parsing rather than being stripped as an unknown key.
    */
   automationWorkItemId: z.string().optional(),
+
+  /**
+   * Optional custom automation marker for channel-anchored custom automation
+   * runs. Like automationWorkItemId, its presence authorizes the Slack
+   * thread-reply late-bind flow and marks the run as a silent channel
+   * automation launch in the worker, so it must survive schema parsing.
+   */
+  customAutomationId: z.string().optional(),
 });
 
 const queuedSnapshotResumeSlackMessageSchema = z.object({


### PR DESCRIPTION
## Summary

Two changes to custom automations, following up on how the built-in channel automations behave:

**1. The report destination channel is now optional.** Previously a channel was required at three layers (UI form, tRPC command, db validation). Now the destination provider select includes a **None** option; without a destination the run happens silently and its results appear only in the task view. The stored `target` uses the existing `{}` column default, typed via a new `OptionalAutomationTarget` + `isConfiguredAutomationTarget` guard. Partially specified targets are still rejected.

**2. When a destination is set, the run is anchored to that channel with real thread semantics.** Custom automation tasks previously launched with only `channels: { slackChannelId }` and a raw user prompt: the agent's `post_to_slack_channel` report was a fire-and-forget top-level message that nothing threaded under, and user replies never routed back to the task. Now the launch mirrors the automation work-item execution-task pattern:

- The payload carries a `customAutomationId` marker plus the Slack `channel`/`slackChannel` fields, so the sandbox gets Slack reply context and registers `send_chat_reply`.
- The Slack `thread_reply` late-bind gate accepts `customAutomationId` alongside `automationWorkItemId`, so the run's first `send_chat_reply` posts a root message in the destination channel and binds it as the task thread via `bindLateSlackThreadToTask`.
- From then on, later task messages continue the thread and user replies in the thread route back into the task (including snapshot resume after completion).
- The prompt appended to the user's automation prompt instructs reporting through `send_chat_reply` with final results, durable blockers, or required input only: no opening acks and no progress updates, matching the execution-task instruction set.

Non-Slack destinations (Teams/Telegram/Discord) already route replies via the `communication*` payload fields, and their reply path degrades to a clean channel post when there is no inbound message to anchor to.

Also updates the failure message for a configured-but-unresolvable destination from "Report destination is not configured." to "Report destination could not be resolved.", and updates the docs page for the optional destination and thread behavior.

## Testing

- `pnpm check-types`, `pnpm lint`, `pnpm knip` all pass
- SDK unit tests cover the anchored prompt (channel tag, `send_chat_reply` instruction, no-progress instruction, payload stamping) and the no-destination launch (raw prompt, no channel bindings, no connectivity check)
- db tests cover creating without a destination and rejecting a partial destination
- Not yet smoke-tested against a live Slack workspace; the Slack late-bind path is verified by code trace against the execution-task flow it reuses