### PR TITLE
[Fix] Route thread replies and add the automation footer for custom automation report threads

### DIFF
--- a/apps/api/src/handlers/mcp/slack.ts
+++ b/apps/api/src/handlers/mcp/slack.ts
@@ -7,6 +7,7 @@ import {
   db,
   eq,
   findBackgroundAutomationSlackThread,
+  getCustomAutomationById,
   slackInstallations,
   taskRuns,
   tasks,
@@ -214,6 +215,29 @@ async function buildLateBoundAutomationRootFooterBlocks(params: {
   });
   return buildAutomationRootFooterBlocks({
     automationLabel,
+    taskUrl: params.taskUrl,
+    linkedPrUrl: linkedPr?.prUrl ?? null,
+  });
+}
+
+async function buildLateBoundCustomAutomationRootFooterBlocks(params: {
+  customAutomationId: string;
+  taskUrl: string;
+  taskId: string;
+}): Promise<SlackBlock[] | null> {
+  const automation = await getCustomAutomationById(params.customAutomationId);
+
+  if (!automation) {
+    return null;
+  }
+
+  const linkedPr = await resolveSlackThreadLinkedPr({
+    taskId: params.taskId,
+    prRepo: null,
+    prNumber: null,
+  });
+  return buildAutomationRootFooterBlocks({
+    automationLabel: automation.name,
     taskUrl: params.taskUrl,
     linkedPrUrl: linkedPr?.prUrl ?? null,
   });
@@ -872,6 +896,9 @@ slackMcp.post('/thread_reply', async (c) => {
   const automationWorkItemId = getAutomationWorkItemIdFromTaskPayload(
     taskRun.payload,
   );
+  const customAutomationId = getCustomAutomationIdFromTaskPayload(
+    taskRun.payload,
+  );
   const existingThreadTs = slackReplyTarget.threadTs;
   let messageTs: string;
   let outboundThreadTs = existingThreadTs ?? '';
@@ -884,7 +911,13 @@ slackMcp.post('/thread_reply', async (c) => {
             taskUrl,
             taskId: taskRun.taskId,
           })
-        : null;
+        : includeFooter && customAutomationId
+          ? await buildLateBoundCustomAutomationRootFooterBlocks({
+              customAutomationId,
+              taskUrl,
+              taskId: taskRun.taskId,
+            })
+          : null;
     const rootFooterBlocks =
       lateBoundAutomationFooterBlocks ??
       (includeFooter

--- a/apps/api/src/handlers/shared/unmentioned-thread-reply.test.ts
+++ b/apps/api/src/handlers/shared/unmentioned-thread-reply.test.ts
@@ -36,6 +36,7 @@ function decide(input: {
   senderUserId?: string;
   isThreadTaskOwner?: boolean;
   isThreadRootAuthor?: boolean;
+  isAutomationReportThread?: boolean;
   threadMessages: UnmentionedThreadHistoryMessage[];
 }) {
   return evaluateUnmentionedThreadReplyRouting({
@@ -43,6 +44,7 @@ function decide(input: {
     senderUserId: input.senderUserId ?? 'U1',
     isThreadTaskOwner: input.isThreadTaskOwner ?? true,
     isThreadRootAuthor: input.isThreadRootAuthor ?? false,
+    isAutomationReportThread: input.isAutomationReportThread ?? false,
     threadMessages: input.threadMessages,
     compareMessageIds: compareNumericMessageIds,
   });
@@ -105,6 +107,28 @@ describe('evaluateUnmentionedThreadReplyRouting', () => {
         ],
       }),
     ).toEqual({ shouldRoute: true, interjectionDetected: false });
+  });
+
+  it('routes a first-time sender in an automation report thread', () => {
+    expect(
+      decide({
+        isThreadTaskOwner: false,
+        isThreadRootAuthor: false,
+        isAutomationReportThread: true,
+        threadMessages: [bot('100'), bot('200')],
+      }),
+    ).toEqual({ shouldRoute: true, interjectionDetected: false });
+  });
+
+  it('still requires a mention after an interjection in an automation report thread', () => {
+    expect(
+      decide({
+        isThreadTaskOwner: false,
+        isThreadRootAuthor: false,
+        isAutomationReportThread: true,
+        threadMessages: [bot('100'), human('200', 'U2')],
+      }),
+    ).toEqual({ shouldRoute: false, interjectionDetected: true });
   });
 
   it('rejects a first-time sender who never owned/rooted/mentioned', () => {

--- a/apps/api/src/handlers/shared/unmentioned-thread-reply.ts
+++ b/apps/api/src/handlers/shared/unmentioned-thread-reply.ts
@@ -63,15 +63,18 @@ export function compareBigIntMessageIds(left: string, right: string): number {
  * skip, ownership lookup, history fetch) have already passed.
  *
  * Eligibility is limited to senders already in the conversation: task owner,
- * thread starter, or someone who mentioned the bot earlier. Routing still
- * fails when somebody else posted or was mentioned after the bot's last
- * message; a later bot reply reopens that window.
+ * thread starter, or someone who mentioned the bot earlier. Automation report
+ * threads (`isAutomationReportThread`) have a bot-authored root and no owning
+ * user, so any human reply there is eligible. Routing still fails when
+ * somebody else posted or was mentioned after the bot's last message; a later
+ * bot reply reopens that window.
  */
 export function evaluateUnmentionedThreadReplyRouting(input: {
   eventMessageId: string;
   senderUserId: string;
   isThreadTaskOwner: boolean;
   isThreadRootAuthor: boolean;
+  isAutomationReportThread?: boolean;
   threadMessages: UnmentionedThreadHistoryMessage[];
   compareMessageIds: CompareMessageIds;
 }): UnmentionedThreadReplyEvaluation {
@@ -80,6 +83,7 @@ export function evaluateUnmentionedThreadReplyRouting(input: {
     senderUserId,
     isThreadTaskOwner,
     isThreadRootAuthor,
+    isAutomationReportThread = false,
     threadMessages,
     compareMessageIds,
   } = input;
@@ -100,7 +104,8 @@ export function evaluateUnmentionedThreadReplyRouting(input: {
   if (
     !isThreadTaskOwner &&
     !isThreadRootAuthor &&
-    !hasMentionedBotEarlierInThread
+    !hasMentionedBotEarlierInThread &&
+    !isAutomationReportThread
   ) {
     return { shouldRoute: false, interjectionDetected: false };
   }

--- a/apps/api/src/handlers/slack/events/message-entry-unmentioned-routing.test.ts
+++ b/apps/api/src/handlers/slack/events/message-entry-unmentioned-routing.test.ts
@@ -302,6 +302,24 @@ describe('shouldRouteUnmentionedSlackThreadReplyToAgent', () => {
     ).resolves.toEqual({ shouldRoute: false });
   });
 
+  it('routes a first-time sender replying in a custom automation report thread', async () => {
+    findRoomoteOwnedSlackThreadMock.mockResolvedValue({
+      userId: null,
+      slackUserId: null,
+      isCustomAutomationThread: true,
+    });
+    fetchThreadMessagesMock.mockResolvedValue([
+      botMessage(THREAD_TS, 'Automation report root'),
+      botMessage('101.000'),
+    ]);
+
+    const decision = await routeDecision(
+      threadReplyEvent({ user: 'U222', ts: '102.000' }),
+    );
+
+    expect(decision.shouldRoute).toBe(true);
+  });
+
   it('ignores replies in threads Roomote does not own', async () => {
     findRoomoteOwnedSlackThreadMock.mockResolvedValue(null);
 

--- a/apps/api/src/handlers/slack/events/message-entry.ts
+++ b/apps/api/src/handlers/slack/events/message-entry.ts
@@ -533,6 +533,9 @@ export async function shouldRouteUnmentionedSlackThreadReplyToAgent(params: {
     senderUserId: event.user,
     isThreadTaskOwner,
     isThreadRootAuthor,
+    isAutomationReportThread: Boolean(
+      roomoteThreadMatch?.isCustomAutomationThread,
+    ),
     threadMessages: sharedHistory,
     compareMessageIds: compareNumericMessageIds,
   });

--- a/apps/api/src/handlers/slack/helpers/conversation-log.ts
+++ b/apps/api/src/handlers/slack/helpers/conversation-log.ts
@@ -57,6 +57,12 @@ export function getInboundSlackConversationSource(
 type RoomoteOwnedSlackThreadMatch = {
   userId: string | null;
   slackUserId: string | null;
+  /**
+   * True when the thread-bound task was launched by a custom automation.
+   * These report threads have a bot-authored root and no owning Slack user,
+   * so unmentioned-reply routing treats any human reply as eligible.
+   */
+  isCustomAutomationThread: boolean;
 };
 
 export async function findRoomoteOwnedSlackThread(params: {
@@ -84,6 +90,18 @@ export async function findRoomoteOwnedSlackThread(params: {
     userId: row.initiatorUserId ?? row.actingUserId,
   }));
 
+  const isCustomAutomationThread = existingSlackTaskRuns.some((job) => {
+    const payload = job.payload as
+      | { channel?: unknown; customAutomationId?: unknown }
+      | undefined;
+
+    return (
+      payload?.channel === params.channelId &&
+      typeof payload.customAutomationId === 'string' &&
+      payload.customAutomationId.trim().length > 0
+    );
+  });
+
   let fallbackMatch: RoomoteOwnedSlackThreadMatch | null = null;
 
   for (const job of existingSlackTaskRuns) {
@@ -99,6 +117,7 @@ export async function findRoomoteOwnedSlackThread(params: {
       const match = {
         userId: job.userId,
         slackUserId: typeof payload.user === 'string' ? payload.user : null,
+        isCustomAutomationThread,
       } satisfies RoomoteOwnedSlackThreadMatch;
 
       if (match.slackUserId) {
@@ -134,6 +153,7 @@ export async function findRoomoteOwnedSlackThread(params: {
       return {
         userId: sourceTaskRun.userId,
         slackUserId: null,
+        isCustomAutomationThread,
       };
     }
 
@@ -158,6 +178,7 @@ export async function findRoomoteOwnedSlackThread(params: {
         userId:
           sourceTaskRunById.initiatorUserId ?? sourceTaskRunById.actingUserId,
         slackUserId: null,
+        isCustomAutomationThread,
       };
     }
   }
@@ -172,6 +193,7 @@ export async function findRoomoteOwnedSlackThread(params: {
       fallbackMatch ?? {
         userId: null,
         slackUserId: null,
+        isCustomAutomationThread,
       }
     );
   }


### PR DESCRIPTION
## Summary

Two follow-ups to the custom-automation report threads introduced in #679, both found by testing against a real Slack workspace:

**1. Plain replies in a report thread now route to the task.** Custom automation report threads have a bot-authored root (the late-bound report message) and no owning Slack user, so a plain (non-mention) reply failed every eligibility condition in the unmentioned-thread-reply gate — `isThreadTaskOwner`, `isThreadRootAuthor`, and prior-bot-mention were all false — and was silently dropped in `handleMessageOrAppMentionEvent` before any task routing ran. Only an explicit @mention reached the task.

Fix: `findRoomoteOwnedSlackThread` now reports an `isCustomAutomationThread` flag (derived from the thread-bound task's run payloads carrying `customAutomationId`), and the shared `evaluateUnmentionedThreadReplyRouting` accepts an `isAutomationReportThread` eligibility basis so any human reply in such a thread routes. The interjection window is unchanged: once somebody else posts or is mentioned after the bot's last message, an explicit mention is still required. This grants no new authority — any channel member could already steer these tasks by @mentioning the bot in the thread.

Routing behavior after the gate is inherited: an active/idle run gets the reply as a follow-up (the blocker/question case), a completed run with a snapshot resumes, and a completed run without a snapshot falls back to fresh-task configuration in the thread (same as replying to a thread whose snapshot expired).

**2. Report roots now carry the automation footer.** The late-bound root for a custom automation used the generic task-link footer instead of the automation context footer. It now gets the same "Created via the … automation" context block with See PR / Go to task buttons that work-item execution threads get, labeled with the custom automation's name.

## Testing

- Shared-eligibility tests: an automation report thread routes a first-time sender; an interjection still requires a mention.
- Slack gate test: a first-time sender's plain reply in a custom-automation thread routes.
- `pnpm check-types`, `pnpm lint`, `pnpm knip` pass; conversation-log tests pass.