### PR TITLE
[Fix] Show in-app release notices on deployments running channel builds

### DIFF
--- a/.changeset/release-notices-channel-builds.md
+++ b/.changeset/release-notices-channel-builds.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Show in-app release notices on deployments running channel builds by baking the product version into published images and reading it for the what's-new and update-available notices.

--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -84,8 +84,10 @@ COPY apps/worker ./apps/worker/
 
 ARG R_APP_ENV
 ARG RELEASE_VERSION
+ARG RELEASE_PRODUCT_VERSION
 ENV R_APP_ENV=${R_APP_ENV}
 ENV RELEASE_VERSION=${RELEASE_VERSION}
+ENV RELEASE_PRODUCT_VERSION=${RELEASE_PRODUCT_VERSION}
 
 # ---------------------------------------------------------------------------
 # web: Next.js standalone build. The placeholder env values only satisfy
@@ -271,8 +273,10 @@ RUN chmod +x /roomote/.docker/app/entrypoint.sh
 
 ARG R_APP_ENV
 ARG RELEASE_VERSION
+ARG RELEASE_PRODUCT_VERSION
 ENV R_APP_ENV=${R_APP_ENV}
 ENV RELEASE_VERSION=${RELEASE_VERSION}
+ENV RELEASE_PRODUCT_VERSION=${RELEASE_PRODUCT_VERSION}
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV HOME=/tmp

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -34,6 +34,7 @@ jobs:
       docs_only: ${{ steps.changed-paths.outputs.docs_only }}
       owner: ${{ steps.vars.outputs.owner }}
       version: ${{ steps.vars.outputs.version }}
+      product_version: ${{ steps.vars.outputs.product_version }}
       app_env: ${{ steps.vars.outputs.app_env }}
       extra_tag: ${{ steps.vars.outputs.extra_tag }}
     steps:

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -134,8 +134,20 @@ jobs:
               ;;
           esac
 
+          # The product (changelog) version is baked alongside the image tag
+          # so channel builds (develop-<sha>/main-<sha>) still know which
+          # product release they contain (used by the in-app release notices).
+          product_version="$(jq -r .version package.json)"
+          case "$product_version" in
+            ''|null)
+              echo "Failed to read product version from package.json" >&2
+              exit 1
+              ;;
+          esac
+
           echo "owner=$owner" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "product_version=$product_version" >> "$GITHUB_OUTPUT"
           echo "app_env=$app_env" >> "$GITHUB_OUTPUT"
           echo "extra_tag=$extra_tag" >> "$GITHUB_OUTPUT"
 
@@ -300,6 +312,7 @@ jobs:
           build-args: |
             R_APP_ENV=${{ needs.prepare.outputs.app_env }}
             RELEASE_VERSION=${{ needs.prepare.outputs.version }}
+            RELEASE_PRODUCT_VERSION=${{ needs.prepare.outputs.product_version }}
 
       - name: Export digest
         shell: bash

--- a/apps/docs/environment-variables.mdx
+++ b/apps/docs/environment-variables.mdx
@@ -360,6 +360,7 @@ apply semantics.
 | `API_SLOW_REQUEST_THRESHOLD_MS`          | Optional         | Threshold for slow API request logging. Defaults to 5 seconds.                        |
 | `API_SLOW_EXTERNAL_REQUEST_THRESHOLD_MS` | Optional         | Threshold for slow external request logging. Defaults to 2 seconds.                   |
 | `RELEASE_VERSION`                        | Release images   | Baked release version used for release tagging and worker image derivation.           |
+| `RELEASE_PRODUCT_VERSION`                | Release images   | Baked product (changelog) version shown by in-app release notices on channel builds.  |
 | `GITHUB_SHA`                             | Release metadata | Commit SHA fallback for monitoring release metadata.                                  |
 | `VERCEL_GIT_COMMIT_SHA`                  | Release metadata | Vercel commit SHA fallback for monitoring release metadata.                           |
 

--- a/apps/web/src/components/layout/release-notices/ReleaseNoticeSideNavItem.client.test.tsx
+++ b/apps/web/src/components/layout/release-notices/ReleaseNoticeSideNavItem.client.test.tsx
@@ -116,6 +116,22 @@ describe('ReleaseNoticeSideNavItem', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
+  it('discards an unorderable stored baseline and re-seeds silently', async () => {
+    mockReadWhatsNewSeenVersion.mockReturnValue('main-037146ca');
+    mockStatusData.mockReturnValue({
+      runningVersion: '0.16.0',
+      latestKnownVersion: null,
+      updateAvailable: false,
+    });
+
+    const { container } = render(<ReleaseNoticeSideNavItem />);
+
+    await waitFor(() => {
+      expect(mockWriteWhatsNewSeenVersion).toHaveBeenCalledWith('0.16.0');
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+
   it('shows whats-new before update-available', async () => {
     mockReadWhatsNewSeenVersion.mockReturnValue('0.14.0');
     mockStatusData.mockReturnValue({

--- a/apps/web/src/components/layout/release-notices/ReleaseNoticeSideNavItem.tsx
+++ b/apps/web/src/components/layout/release-notices/ReleaseNoticeSideNavItem.tsx
@@ -4,7 +4,11 @@ import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import { Astroid, Sparkles } from '@/components/system';
-import { isProductVersionNewer, toReleaseTag } from '@/lib/product-version';
+import {
+  isParsableProductVersion,
+  isProductVersionNewer,
+  toReleaseTag,
+} from '@/lib/product-version';
 import { useTRPC } from '@/trpc/client';
 
 import { SideNavItem } from '../side-nav/SideNavItem';
@@ -39,7 +43,11 @@ export function ReleaseNoticeSideNavItem({
   );
 
   useEffect(() => {
-    setSeenVersion(readWhatsNewSeenVersion());
+    // Browsers that stored an unorderable baseline (for example a channel
+    // build tag before the product version was baked into images) would
+    // otherwise never see a notice again; discard it so it gets re-seeded.
+    const stored = readWhatsNewSeenVersion();
+    setSeenVersion(stored && isParsableProductVersion(stored) ? stored : null);
     setHasHydratedStorage(true);
   }, []);
 

--- a/apps/web/src/lib/__tests__/product-version.test.ts
+++ b/apps/web/src/lib/__tests__/product-version.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   compareProductVersions,
+  isParsableProductVersion,
   isProductVersionNewer,
   normalizeProductVersion,
   toReleaseTag,
@@ -12,6 +13,17 @@ describe('product-version', () => {
     expect(normalizeProductVersion(' v0.14.1 ')).toBe('0.14.1');
     expect(normalizeProductVersion(null)).toBeNull();
     expect(normalizeProductVersion('')).toBeNull();
+  });
+
+  it('detects parsable product versions', () => {
+    expect(isParsableProductVersion('0.16.0')).toBe(true);
+    expect(isParsableProductVersion('v0.16.0')).toBe(true);
+    expect(isParsableProductVersion('0.16.0-rc.1')).toBe(true);
+    expect(isParsableProductVersion('main-037146ca')).toBe(false);
+    expect(isParsableProductVersion('develop-abc12345')).toBe(false);
+    expect(isParsableProductVersion('self-host-production')).toBe(false);
+    expect(isParsableProductVersion(null)).toBe(false);
+    expect(isParsableProductVersion('')).toBe(false);
   });
 
   it('compares numeric segments', () => {

--- a/apps/web/src/lib/product-version.ts
+++ b/apps/web/src/lib/product-version.ts
@@ -130,6 +130,21 @@ export function compareProductVersions(
   return comparePrereleaseSets(pa.prereleaseIds, pb.prereleaseIds);
 }
 
+/**
+ * Whether a value carries an orderable product version (numeric segments,
+ * optional prerelease suffix). Channel build tags like `main-<sha>` and
+ * placeholders like `self-host-production` are not parsable.
+ */
+export function isParsableProductVersion(
+  version: string | null | undefined,
+): boolean {
+  const normalized = normalizeProductVersion(version);
+  if (!normalized) {
+    return false;
+  }
+  return parseProductVersion(normalized).segments !== null;
+}
+
 export function isProductVersionNewer(
   candidate: string | null | undefined,
   baseline: string | null | undefined,

--- a/apps/web/src/trpc/commands/product-releases/index.test.ts
+++ b/apps/web/src/trpc/commands/product-releases/index.test.ts
@@ -42,7 +42,13 @@ vi.mock('@/lib/server/env', () => ({
 }));
 
 import type { UserAuthSuccess } from '@/types';
+import { Env } from '@/lib/server/env';
 import { getReleaseNotesCommand, getReleaseStatusCommand } from './index';
+
+const mockEnv = Env as {
+  RELEASE_VERSION?: string;
+  RELEASE_PRODUCT_VERSION?: string;
+};
 
 const adminAuth = {
   success: true,
@@ -75,6 +81,8 @@ const memberAuth = {
 describe('releases commands', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockEnv.RELEASE_VERSION = 'v0.14.0';
+    delete mockEnv.RELEASE_PRODUCT_VERSION;
     mockIsRoomoteCloudEnabled.mockReturnValue(false);
     mockFindFirst.mockResolvedValue({
       latestKnownVersion: '0.15.0',
@@ -103,6 +111,25 @@ describe('releases commands', () => {
     mockIsRoomoteCloudEnabled.mockReturnValue(true);
     await expect(getReleaseStatusCommand(adminAuth)).resolves.toMatchObject({
       latestKnownVersion: null,
+      updateAvailable: false,
+    });
+  });
+
+  it('prefers the baked product version over a channel build tag', async () => {
+    mockEnv.RELEASE_VERSION = 'main-037146ca';
+    mockEnv.RELEASE_PRODUCT_VERSION = '0.14.0';
+
+    await expect(getReleaseStatusCommand(adminAuth)).resolves.toMatchObject({
+      runningVersion: '0.14.0',
+      updateAvailable: true,
+    });
+  });
+
+  it('reports no update for channel build tags without a product version', async () => {
+    mockEnv.RELEASE_VERSION = 'main-037146ca';
+
+    await expect(getReleaseStatusCommand(adminAuth)).resolves.toMatchObject({
+      runningVersion: 'main-037146ca',
       updateAvailable: false,
     });
   });

--- a/apps/web/src/trpc/commands/product-releases/index.ts
+++ b/apps/web/src/trpc/commands/product-releases/index.ts
@@ -41,7 +41,13 @@ type ReleaseNotes = {
 };
 
 function getRunningVersion(): string | null {
-  return normalizeProductVersion(Env.RELEASE_VERSION);
+  // Channel builds bake RELEASE_VERSION as develop-<sha>/main-<sha>, which the
+  // product-version comparator cannot order. Prefer the product (changelog)
+  // version baked alongside it so release notices work on those deployments.
+  return (
+    normalizeProductVersion(Env.RELEASE_PRODUCT_VERSION) ??
+    normalizeProductVersion(Env.RELEASE_VERSION)
+  );
 }
 
 function canSeeUpdateStatus(auth: UserAuthSuccess): boolean {

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -89,6 +89,7 @@ x-roomote-production-env: &roomote-production-env
 x-roomote-production-build-args: &roomote-production-build-args
   R_APP_ENV: production
   RELEASE_VERSION: ${RELEASE_VERSION:-self-host-production}
+  RELEASE_PRODUCT_VERSION: ${RELEASE_PRODUCT_VERSION:-}
 
 services:
   postgres:

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -124,6 +124,10 @@ const serverSchema = {
   ROOMOTE_FORCE_TELEMETRY: z.string().optional(),
   // Release tag baked into published app images by the publish workflow.
   RELEASE_VERSION: z.string().min(1).optional(),
+  // Product (changelog) version baked into published app images alongside
+  // RELEASE_VERSION, so channel builds (develop-<sha>/main-<sha>) still know
+  // which product release they contain. Read by the in-app release notices.
+  RELEASE_PRODUCT_VERSION: z.string().min(1).optional(),
   TRPC_URL: z.string().min(1),
   R_MODEL: z.string().min(1).optional(),
   R_SMALL_MODEL: z.string().min(1).optional(),
@@ -400,6 +404,7 @@ const OPTIONAL_NON_EMPTY_KEYS = new Set([
   'WORKER_RELEASE_CHANNEL',
   'WORKER_RELEASE_VERSION',
   'RELEASE_VERSION',
+  'RELEASE_PRODUCT_VERSION',
   'R_PING_BASE_URL',
   'R_INSTANCE_ID',
   'R_INTERCOM_APP_ID',


### PR DESCRIPTION
## Related issue

None — internal Roomote work.

## Why this PR exists

- [ ] A maintainer explicitly invited this PR in the linked issue or discussion
- [x] I am a maintainer / this is internal Roomote work

## What changed

Channel builds (`develop-<sha>` / `main-<sha>`) bake an unorderable `RELEASE_VERSION`, so any deployment tracking a channel image never shows the in-app "What's new" or "Update available" notices — the product-version comparator cannot order those tags, so the notices silently never fire.

- The publish workflow now reads the product (changelog) version from the root `package.json` and bakes it into app images as a new optional `RELEASE_PRODUCT_VERSION` env var, alongside the untouched `RELEASE_VERSION` (which keeps feeding worker-image derivation, Sentry, and telemetry exactly as before).
- The release-status command prefers `RELEASE_PRODUCT_VERSION` when resolving the running version, falling back to `RELEASE_VERSION`, so `v*`-tagged images behave unchanged.
- Browsers that already stored an unorderable "seen" baseline (for example a channel build tag) discard it and silently re-seed, instead of staying stuck with no notices forever.
- New `isParsableProductVersion()` helper in `product-version.ts`; `RELEASE_PRODUCT_VERSION` passthrough in `docker-compose.production.yml` build args; docs row in `environment-variables.mdx`; patch changeset included.

Note for reviewers: on a channel deployment the "What's new" notice can appear slightly before the matching GitHub release is published; in that window the dialog shows the "notes unavailable" fallback with a link, and the short-lived negative cache self-heals once the release exists.

## How it was tested

- New unit tests: running-version preference for the baked product version over a channel tag, no-update reporting for unorderable channel tags, `isParsableProductVersion()` coverage, and the silent re-seed of an unorderable stored baseline in `ReleaseNoticeSideNavItem`.
- All touched web test files pass (21 tests), plus the full `@roomote/env` suite (70 tests).
- `tsc --noEmit` clean for `@roomote/env` and `@roomote/web`; `pnpm lint:fast` and `pnpm format` pass.

## Checklist

- [x] The PR title follows the repo convention: `[Fix]`, `[Feat]`, `[Improve]`, `[Refactor]`, `[Docs]`, or `[Chore]` followed by a user-facing description
- [x] This PR is small and scoped to one change
- [x] `pnpm lint` and `pnpm check-types` pass locally
- [x] I added tests or included a clear manual validation note above
- [x] I removed secrets, tokens, private keys, and customer data from code, logs, and screenshots
- [x] If this change should appear in the changelog, I ran `pnpm changeset`