### PR TITLE
[Feat] Add the broker backend so managed deployments hold no Modal credentials

### DIFF
--- a/apps/controller/src/RoomoteController.ts
+++ b/apps/controller/src/RoomoteController.ts
@@ -90,10 +90,19 @@ export class RoomoteController extends BaseController {
       // own spawn function here after the backend resolution.
       case 'modal':
       case 'roomote': {
-        if (provider === 'roomote') {
-          // Throws on an unsupported backend; the resolved value is 'modal'
-          // until more ROOMOTE_CLOUD_BACKENDS exist.
-          resolveRoomoteCloudBackend(resolvedEnv);
+        // Throws on an unsupported backend. `broker` routes all sandbox
+        // operations through the hosting operator's compute broker; the
+        // token pair then carries the tenant id + derived broker credential.
+        const backend =
+          provider === 'roomote'
+            ? resolveRoomoteCloudBackend(resolvedEnv)
+            : ('modal' as const);
+        const brokerUrl = resolvedEnv.ROOMOTE_CLOUD_BROKER_URL;
+
+        if (backend === 'broker' && !brokerUrl) {
+          throw new Error(
+            'ROOMOTE_CLOUD_BROKER_URL is required to spawn broker-backed Roomote Cloud workers',
+          );
         }
 
         const modalTokenId =
@@ -122,6 +131,8 @@ export class RoomoteController extends BaseController {
 
         await spawnModalWorker(taskRun, authToken, {
           vendor: provider,
+          backend,
+          ...(brokerUrl ? { brokerUrl } : {}),
           deploymentSlug: deploymentSlug,
           modalTags: this.buildSandboxTags(),
           modalTokenId,

--- a/apps/controller/src/compute-providers/spawn-modal-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-modal-worker.ts
@@ -19,6 +19,7 @@ import {
   createComputeProviderClient,
   createModalMachine,
   parseModalRegions,
+  RoomoteBrokerClient,
   resolveAuthBypassHeaderName,
   resolveAuthBypassValue,
 } from '@roomote/compute-providers';
@@ -123,6 +124,14 @@ export async function spawnModalWorker(
      * spawn path with deployment-managed credentials. Defaults to `modal`.
      */
     vendor?: 'modal' | 'roomote';
+    /**
+     * Engine backing a `roomote` spawn. With `broker`, modalTokenId /
+     * modalTokenSecret carry the tenant id + derived broker credential and
+     * all Modal operations go through the compute broker at `brokerUrl`;
+     * no Modal workspace credentials exist in this deployment.
+     */
+    backend?: 'modal' | 'broker';
+    brokerUrl?: string;
     modalTokenId: string;
     modalTokenSecret: string;
     modalEndpoint?: string;
@@ -156,6 +165,8 @@ export async function spawnModalWorker(
 }> {
   const {
     vendor = 'modal',
+    backend = 'modal',
+    brokerUrl,
     modalTokenId,
     modalTokenSecret,
     modalEndpoint,
@@ -307,10 +318,27 @@ export async function spawnModalWorker(
     timeoutMs: modalTimeoutMs,
   };
 
-  const computeClient = createComputeProviderClient({
-    provider: 'modal',
-    config: modalConfig,
-  });
+  const computeClient =
+    backend === 'broker'
+      ? new RoomoteBrokerClient({
+          brokerUrl: brokerUrl ?? '',
+          tenantId: modalTokenId,
+          brokerKey: modalTokenSecret,
+          baseImageRef: modalBaseImageRef,
+          ...(parsedModalRegions ? { regions: parsedModalRegions } : {}),
+          ...(useVmRuntime ? { vmRuntime: true } : {}),
+          ...(configuredResources.configuredCpuCores !== null
+            ? { cpu: configuredResources.configuredCpuCores }
+            : {}),
+          ...(configuredResources.configuredMemoryMiB !== null
+            ? { memoryMiB: configuredResources.configuredMemoryMiB }
+            : {}),
+          timeoutMs: modalTimeoutMs,
+        })
+      : createComputeProviderClient({
+          provider: 'modal',
+          config: modalConfig,
+        });
 
   // Stamp provisionStartedAt + launchMode before the Modal API call. Only-if-
   // null semantics preserve the earliest provision timestamp.

--- a/packages/compute-providers/src/__tests__/factory.test.ts
+++ b/packages/compute-providers/src/__tests__/factory.test.ts
@@ -3,6 +3,7 @@ import type { DaytonaConfig, E2bConfig, ModalConfig } from '../types';
 
 const {
   modalClientMock,
+  roomoteBrokerClientMock,
   dockerClientMock,
   daytonaClientMock,
   e2bClientMock,
@@ -13,6 +14,7 @@ const {
   modalCapabilities,
 } = vi.hoisted(() => ({
   modalClientMock: vi.fn(),
+  roomoteBrokerClientMock: vi.fn(),
   dockerClientMock: vi.fn(),
   daytonaClientMock: vi.fn(),
   e2bClientMock: vi.fn(),
@@ -42,6 +44,7 @@ const {
 vi.mock('../adapters', () => ({
   DockerClient: dockerClientMock,
   ModalClient: modalClientMock,
+  RoomoteBrokerClient: roomoteBrokerClientMock,
   DaytonaClient: daytonaClientMock,
   E2bClient: e2bClientMock,
   BlaxelClient: blaxelClientMock,
@@ -188,6 +191,57 @@ describe('createComputeProviderClient', () => {
         },
       }),
     ).toThrow('Unsupported ROOMOTE_CLOUD_BACKEND "e2b"');
+  });
+
+  it('builds the broker client for the broker backend without Modal credentials', () => {
+    process.env.MODAL_REGISTRY_USERNAME = 'ghcr-user';
+    process.env.MODAL_REGISTRY_PASSWORD = 'ghcr-token';
+
+    createComputeProviderClient({
+      provider: 'roomote',
+      envFallback: {
+        ROOMOTE_CLOUD_BACKEND: 'broker',
+        ROOMOTE_CLOUD_BROKER_URL: 'https://broker.roomote.dev',
+        ROOMOTE_CLOUD_TOKEN_ID: 'deployment-id',
+        ROOMOTE_CLOUD_TOKEN_SECRET: 'rbk_derived-credential',
+        MODAL_BASE_IMAGE_REF: 'ghcr.io/roomote/modal-worker:test',
+      },
+    });
+
+    expect(modalClientMock).not.toHaveBeenCalled();
+    expect(roomoteBrokerClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        brokerUrl: 'https://broker.roomote.dev',
+        tenantId: 'deployment-id',
+        brokerKey: 'rbk_derived-credential',
+        baseImageRef: 'ghcr.io/roomote/modal-worker:test',
+        cpuLimit: 8,
+        memoryLimitMiB: 32_768,
+      }),
+    );
+
+    // Registry pull credentials are broker-side by design; the tenant
+    // client must never receive them.
+    const config = roomoteBrokerClientMock.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(JSON.stringify(config)).not.toContain('ghcr-user');
+    expect(JSON.stringify(config)).not.toContain('ghcr-token');
+  });
+
+  it('requires the broker URL for the broker backend', () => {
+    expect(() =>
+      createComputeProviderClient({
+        provider: 'roomote',
+        envFallback: {
+          ROOMOTE_CLOUD_BACKEND: 'broker',
+          ROOMOTE_CLOUD_TOKEN_ID: 'deployment-id',
+          ROOMOTE_CLOUD_TOKEN_SECRET: 'rbk_derived-credential',
+          MODAL_BASE_IMAGE_REF: 'ghcr.io/roomote/modal-worker:test',
+        },
+      }),
+    ).toThrow('Missing ROOMOTE_CLOUD_BROKER_URL');
   });
 
   it('resolves Modal private registry credentials from env', () => {

--- a/packages/compute-providers/src/adapters/index.ts
+++ b/packages/compute-providers/src/adapters/index.ts
@@ -1,4 +1,5 @@
 export { ModalClient } from './modal';
+export { RoomoteBrokerClient } from './roomote-broker';
 export { DockerClient } from './docker';
 export { DaytonaClient } from './daytona';
 export { E2bClient } from './e2b';

--- a/packages/compute-providers/src/adapters/roomote-broker.test.ts
+++ b/packages/compute-providers/src/adapters/roomote-broker.test.ts
@@ -1,0 +1,405 @@
+import { createHash, createHmac } from 'node:crypto';
+
+import { BrokerRequestError, RoomoteBrokerClient } from './roomote-broker';
+
+const brokerUrl = 'https://broker.roomote.dev';
+const tenantId = '9d137fea-a018-4432-af24-83ce802b4ed2';
+const brokerKey = 'rbk_derived-tenant-credential';
+const baseImageRef = `ghcr.io/roocodeinc/roomote-worker@sha256:${'a'.repeat(64)}`;
+
+type RecordedRequest = {
+  method: string;
+  path: string;
+  body: unknown;
+  headers: Record<string, string>;
+  rawBody: string;
+};
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function ndjsonResponse(events: unknown[]): Response {
+  return new Response(events.map((e) => `${JSON.stringify(e)}\n`).join(''), {
+    status: 200,
+    headers: { 'content-type': 'application/x-ndjson' },
+  });
+}
+
+function harness(
+  handler: (request: RecordedRequest) => Response | Promise<Response>,
+) {
+  const requests: RecordedRequest[] = [];
+  const fetchImpl = vi.fn(
+    async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      const request: RecordedRequest = {
+        method: init?.method ?? 'GET',
+        path: url.pathname + url.search,
+        rawBody: typeof init?.body === 'string' ? init.body : '',
+        body:
+          typeof init?.body === 'string' && init.body
+            ? JSON.parse(init.body)
+            : undefined,
+        headers: Object.fromEntries(
+          Object.entries((init?.headers ?? {}) as Record<string, string>).map(
+            ([key, value]) => [key.toLowerCase(), value],
+          ),
+        ),
+      };
+      requests.push(request);
+      return handler(request);
+    },
+  );
+
+  const client = new RoomoteBrokerClient({
+    brokerUrl,
+    tenantId,
+    brokerKey,
+    baseImageRef,
+    timeoutMs: 60_000,
+    cpu: 2,
+    memoryMiB: 8_192,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+
+  return { client, requests, fetchImpl };
+}
+
+describe('RoomoteBrokerClient', () => {
+  it('signs every request with the tenant HMAC scheme', async () => {
+    const { client, requests } = harness(() => jsonResponse({ instances: [] }));
+
+    await client.listInstances({});
+
+    const request = requests[0]!;
+    expect(request.headers['x-roomote-tenant']).toBe(tenantId);
+    expect(request.headers['x-roomote-nonce']).toBeTruthy();
+
+    const expected = createHmac('sha256', brokerKey)
+      .update(
+        [
+          request.headers['x-roomote-timestamp'],
+          request.headers['x-roomote-nonce'],
+          'GET',
+          '/v1/sandboxes',
+          createHash('sha256').update('').digest('hex'),
+        ].join('\n'),
+      )
+      .digest('hex');
+    expect(request.headers['x-roomote-signature']).toBe(expected);
+  });
+
+  it('includes a broker URL path prefix in the signed path', async () => {
+    const requests: RecordedRequest[] = [];
+    const fetchImpl = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = new URL(String(input));
+      requests.push({
+        method: init?.method ?? 'GET',
+        path: url.pathname,
+        rawBody: '',
+        body: undefined,
+        headers: Object.fromEntries(
+          Object.entries((init?.headers ?? {}) as Record<string, string>).map(
+            ([key, value]) => [key.toLowerCase(), value],
+          ),
+        ),
+      });
+      return jsonResponse({ instances: [] });
+    });
+
+    const client = new RoomoteBrokerClient({
+      brokerUrl: 'http://localhost:4100/compute-broker',
+      tenantId,
+      brokerKey,
+      baseImageRef,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    await client.listInstances({});
+
+    const request = requests[0]!;
+    expect(request.path).toBe('/compute-broker/v1/sandboxes');
+
+    const expected = createHmac('sha256', brokerKey)
+      .update(
+        [
+          request.headers['x-roomote-timestamp'],
+          request.headers['x-roomote-nonce'],
+          'GET',
+          '/compute-broker/v1/sandboxes',
+          createHash('sha256').update('').digest('hex'),
+        ].join('\n'),
+      )
+      .digest('hex');
+    expect(request.headers['x-roomote-signature']).toBe(expected);
+  });
+
+  it('creates instances with configured resources and an idempotency key', async () => {
+    const { client, requests } = harness(() =>
+      jsonResponse({
+        instanceId: 'sb-1',
+        domains: { '3000': 'https://sb-1-3000.modal.host' },
+      }),
+    );
+
+    const created = await client.createInstance({
+      ports: [3000],
+      tags: { roomote_task_run: '42' },
+    });
+
+    expect(created).toEqual({
+      instanceId: 'sb-1',
+      status: 'running',
+      domains: { '3000': 'https://sb-1-3000.modal.host' },
+    });
+    const request = requests[0]!;
+    expect(request.headers['idempotency-key']).toBeTruthy();
+    expect(request.body).toEqual({
+      imageRef: baseImageRef,
+      ports: [3000],
+      tags: { roomote_task_run: '42' },
+      timeoutMs: 60_000,
+      cpu: 2,
+      memoryMiB: 8_192,
+    });
+  });
+
+  it('resumes from a snapshot without sending an image ref', async () => {
+    const { client, requests } = harness(() =>
+      jsonResponse({ instanceId: 'sb-2' }),
+    );
+
+    const resumed = await client.resumeFromSnapshot({
+      sourceSnapshotId: 'im-9',
+    });
+
+    expect(resumed).toMatchObject({
+      instanceId: 'sb-2',
+      sourceSnapshotId: 'im-9',
+    });
+    expect(requests[0]!.body).toMatchObject({ snapshotId: 'im-9' });
+    expect(requests[0]!.body).not.toHaveProperty('imageRef');
+  });
+
+  it('maps a 404 status lookup to stopped', async () => {
+    const { client } = harness(() =>
+      jsonResponse(
+        { error: 'Sandbox not found.', code: 'sandbox_not_found' },
+        404,
+      ),
+    );
+
+    await expect(
+      client.getInstanceStatus({ instanceId: 'sb-gone' }),
+    ).resolves.toEqual({ status: 'stopped' });
+  });
+
+  it('throws a typed error carrying the broker error code', async () => {
+    const { client } = harness(() =>
+      jsonResponse(
+        {
+          error: 'The requested image is not allowed.',
+          code: 'image_not_allowed',
+        },
+        400,
+      ),
+    );
+
+    await expect(client.createInstance({})).rejects.toMatchObject({
+      name: 'BrokerRequestError',
+      status: 400,
+      code: 'image_not_allowed',
+    });
+  });
+
+  it('aggregates streamed exec output and reports the exit code', async () => {
+    const { client } = harness(() =>
+      ndjsonResponse([
+        { type: 'started', execId: 'exec-1' },
+        { type: 'stdout', data: 'hello ' },
+        { type: 'heartbeat' },
+        { type: 'stdout', data: 'world' },
+        { type: 'stderr', data: 'warn' },
+        { type: 'exit', exitCode: 3 },
+      ]),
+    );
+
+    const outputs: { stream: string; data: string }[] = [];
+    const result = await client.runCommand({
+      instanceId: 'sb-1',
+      cmd: 'echo',
+      args: ['hello world'],
+      onOutput: (event) => outputs.push(event),
+    });
+
+    expect(result).toEqual({
+      commandId: undefined,
+      exitCode: 3,
+      stdout: 'hello world',
+      stderr: 'warn',
+    });
+    // Aggregated delivery, one call per non-empty stream (Modal parity).
+    expect(outputs).toEqual([
+      { stream: 'stdout', data: 'hello world' },
+      { stream: 'stderr', data: 'warn' },
+    ]);
+  });
+
+  it('reports a grace-period exit for detached commands', async () => {
+    const { client } = harness(() =>
+      ndjsonResponse([
+        { type: 'started', execId: 'exec-1' },
+        { type: 'stderr', data: 'boom' },
+        { type: 'exit', exitCode: 1 },
+      ]),
+    );
+
+    const result = await client.runCommand({
+      instanceId: 'sb-1',
+      cmd: 'worker',
+      detached: true,
+    });
+
+    expect(result).toEqual({
+      commandId: undefined,
+      exitCode: 1,
+      stdout: undefined,
+      stderr: 'boom',
+    });
+  });
+
+  it('returns a running detached command and delivers onExit from the stream', async () => {
+    let releaseTail!: () => void;
+    const tail = new Promise<void>((resolve) => {
+      releaseTail = resolve;
+    });
+
+    const { client } = harness(() => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream<Uint8Array>({
+        async start(controller) {
+          controller.enqueue(
+            encoder.encode(
+              `${JSON.stringify({ type: 'started', execId: 'exec-1' })}\n`,
+            ),
+          );
+          await tail;
+          controller.enqueue(
+            encoder.encode(
+              `${JSON.stringify({ type: 'exit', exitCode: 7 })}\n`,
+            ),
+          );
+          controller.close();
+        },
+      });
+      return new Response(stream, { status: 200 });
+    });
+
+    const exitCodes: number[] = [];
+    let resolveExit!: () => void;
+    const exitSeen = new Promise<void>((resolve) => {
+      resolveExit = resolve;
+    });
+
+    const result = await client.runCommand({
+      instanceId: 'sb-1',
+      cmd: 'worker',
+      detached: true,
+      onExit: ({ exitCode }) => {
+        exitCodes.push(exitCode);
+        resolveExit();
+      },
+    });
+
+    expect(result).toEqual({ commandId: undefined, exitCode: null });
+    releaseTail();
+    await exitSeen;
+    expect(exitCodes).toEqual([7]);
+  });
+
+  it('writes files as base64 payloads', async () => {
+    const { client, requests } = harness(() => jsonResponse({}));
+
+    await client.writeFiles({
+      instanceId: 'sb-1',
+      files: [{ path: '/sandbox/install.sh', content: Buffer.from('echo hi') }],
+    });
+
+    expect(requests[0]!.method).toBe('PUT');
+    expect(requests[0]!.body).toEqual({
+      files: [
+        {
+          path: '/sandbox/install.sh',
+          contentBase64: Buffer.from('echo hi').toString('base64'),
+        },
+      ],
+    });
+  });
+
+  it('polls snapshot operations to completion', async () => {
+    let polls = 0;
+    const { client } = harness((request) => {
+      if (request.path.endsWith('/snapshot')) {
+        return jsonResponse({ operationId: 'op-1' }, 202);
+      }
+
+      polls += 1;
+      return jsonResponse(
+        polls < 2
+          ? { status: 'running' }
+          : { status: 'succeeded', snapshotId: 'im-1' },
+      );
+    });
+
+    vi.useFakeTimers();
+    try {
+      const pending = client.createSnapshot({ instanceId: 'sb-1' });
+      await vi.advanceTimersByTimeAsync(11_000);
+      await expect(pending).resolves.toEqual({ snapshotId: 'im-1' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('surfaces snapshot failures with the broker error', async () => {
+    const { client } = harness((request) =>
+      request.path.endsWith('/snapshot')
+        ? jsonResponse({ operationId: 'op-1' }, 202)
+        : jsonResponse({ status: 'failed', error: 'snapshot blew up' }),
+    );
+
+    vi.useFakeTimers();
+    try {
+      const pending = client.createSnapshot({ instanceId: 'sb-1' });
+      const assertion = expect(pending).rejects.toThrow('snapshot blew up');
+      await vi.advanceTimersByTimeAsync(6_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('throws an AbortError when the signal aborts a request', async () => {
+    const { client } = harness(() => {
+      const error = new Error('aborted');
+      error.name = 'AbortError';
+      throw error;
+    });
+
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      client.listInstances({ signal: controller.signal }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('exposes BrokerRequestError for callers that map status codes', () => {
+    const error = new BrokerRequestError('nope', 404, 'sandbox_not_found');
+    expect(error.status).toBe(404);
+    expect(error.code).toBe('sandbox_not_found');
+  });
+});

--- a/packages/compute-providers/src/adapters/roomote-broker.test.ts
+++ b/packages/compute-providers/src/adapters/roomote-broker.test.ts
@@ -320,6 +320,62 @@ describe('RoomoteBrokerClient', () => {
     expect(exitCodes).toEqual([7]);
   });
 
+  it('recovers onExit via polling when started arrives late and the stream drops', async () => {
+    vi.useFakeTimers();
+    try {
+      const encoder = new TextEncoder();
+      let controller!: ReadableStreamDefaultController<Uint8Array>;
+      const { client } = harness((request) => {
+        if (request.path.endsWith('/exec')) {
+          const stream = new ReadableStream<Uint8Array>({
+            start(streamController) {
+              controller = streamController;
+            },
+          });
+          return new Response(stream, { status: 200 });
+        }
+
+        // Exec-status poll must use the late-arriving exec id.
+        if (request.path.endsWith('/exec/exec-late')) {
+          return jsonResponse({ status: 'exited', exitCode: 5 });
+        }
+
+        return jsonResponse({ error: 'unexpected path' }, 500);
+      });
+
+      const exitCodes: number[] = [];
+      const resultPromise = client.runCommand({
+        instanceId: 'sb-1',
+        cmd: 'worker',
+        detached: true,
+        onExit: ({ exitCode }) => {
+          exitCodes.push(exitCode);
+        },
+      });
+
+      // No events inside the grace period: the command reports as running.
+      await vi.advanceTimersByTimeAsync(1_100);
+      await expect(resultPromise).resolves.toEqual({
+        commandId: undefined,
+        exitCode: null,
+      });
+
+      // started lands only now, then the stream drops before exit.
+      controller.enqueue(
+        encoder.encode(
+          `${JSON.stringify({ type: 'started', execId: 'exec-late' })}\n`,
+        ),
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      controller.error(new Error('connection reset'));
+      await vi.advanceTimersByTimeAsync(31_000);
+
+      expect(exitCodes).toEqual([5]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('writes files as base64 payloads', async () => {
     const { client, requests } = harness(() => jsonResponse({}));
 

--- a/packages/compute-providers/src/adapters/roomote-broker.ts
+++ b/packages/compute-providers/src/adapters/roomote-broker.ts
@@ -1,0 +1,772 @@
+import { createHash, createHmac, randomUUID } from 'node:crypto';
+
+import { MODAL_CAPABILITIES as MODAL_CAPABILITIES_VALUE } from '@roomote/types';
+
+import type { ComputeProvider } from '@roomote/types';
+
+import type {
+  CommandOutputEvent,
+  ComputeProviderCapabilities,
+  ComputeProviderClient,
+  CreateInstanceInput,
+  CreateSnapshotInput,
+  CreateSnapshotResult,
+  CreatedInstance,
+  DestroyInstanceInput,
+  DestroyInstanceResult,
+  GetCommandOutputInput,
+  GetInstanceStatusInput,
+  GetInstanceStatusResult,
+  InstanceSummary,
+  ListInstancesInput,
+  ResumeInstanceInput,
+  RoomoteBrokerConfig,
+  RunCommandInput,
+  RunCommandResult,
+  StreamCommandOutputInput,
+  WriteFileInput,
+} from '../types';
+import { unsupported } from '../errors';
+import { throwIfAborted, toAbortError } from '../modal/abort';
+
+const DETACHED_EXIT_GRACE_PERIOD_MS = 1_000;
+const SNAPSHOT_POLL_INTERVAL_MS = 5_000;
+const SNAPSHOT_POLL_TIMEOUT_MS = 25 * 60_000;
+const EXIT_POLL_INTERVAL_MS = 30_000;
+const EXIT_POLL_MAX_MS = 6 * 60 * 60_000;
+// Keep each request's decoded file payload under the broker's 24 MiB cap.
+const FILE_BATCH_MAX_BYTES = 16 * 1024 * 1024;
+
+export class BrokerRequestError extends Error {
+  public constructor(
+    message: string,
+    public readonly status: number,
+    public readonly code: string,
+  ) {
+    super(message);
+    this.name = 'BrokerRequestError';
+  }
+}
+
+type BrokerExecEvent =
+  | { type: 'started'; execId: string }
+  | { type: 'stdout' | 'stderr'; data: string }
+  | { type: 'exit'; exitCode: number }
+  | { type: 'error'; message: string }
+  | { type: 'heartbeat' };
+
+/**
+ * Broker-backed engine for the deployment-managed `roomote` provider. The
+ * deployment holds no Modal credentials; every sandbox operation is an
+ * HMAC-signed HTTP request to the hosting operator's compute broker, which
+ * owns the sole Modal token and enforces per-tenant scoping server-side.
+ *
+ * Behavioral reference: the direct Modal adapter (`./modal.ts`) — command,
+ * detached-exit, and snapshot semantics must match it so the modal→broker
+ * flip is invisible to the controller.
+ */
+export class RoomoteBrokerClient implements ComputeProviderClient {
+  public readonly vendor: ComputeProvider = 'roomote';
+
+  public readonly capabilities: ComputeProviderCapabilities =
+    MODAL_CAPABILITIES_VALUE;
+
+  private readonly fetchImpl: typeof fetch;
+
+  public constructor(private readonly config: RoomoteBrokerConfig) {
+    if (!config.brokerUrl || !config.tenantId || !config.brokerKey) {
+      throw new Error(
+        'The broker backend requires brokerUrl, tenantId, and brokerKey',
+      );
+    }
+
+    if (!config.baseImageRef) {
+      throw new Error(
+        'The broker backend requires an explicit baseImageRef for fresh sandboxes',
+      );
+    }
+
+    this.fetchImpl = config.fetchImpl ?? fetch;
+
+    console.log(
+      `[RoomoteBrokerClient] Initialized ${JSON.stringify({
+        brokerUrl: config.brokerUrl,
+        tenantId: config.tenantId,
+        baseImageRef: config.baseImageRef,
+        regions: config.regions ?? '(default)',
+        timeoutMs: config.timeoutMs ?? '(default)',
+      })}`,
+    );
+  }
+
+  public async listInstances(
+    input: ListInstancesInput,
+  ): Promise<InstanceSummary[]> {
+    const payload = (await this.requestJson({
+      method: 'GET',
+      path: '/v1/sandboxes',
+      signal: input.signal,
+    })) as { instances: { instanceId: string; status: string }[] };
+
+    return payload.instances.map((instance) => ({
+      instanceId: instance.instanceId,
+      status: instance.status === 'running' ? 'running' : 'stopped',
+      timeoutRemainingMs: 0,
+    }));
+  }
+
+  public async getInstanceStatus(
+    input: GetInstanceStatusInput,
+  ): Promise<GetInstanceStatusResult> {
+    try {
+      const payload = (await this.requestJson({
+        method: 'GET',
+        path: `/v1/sandboxes/${encodeURIComponent(input.instanceId)}`,
+        signal: input.signal,
+      })) as { status: string };
+
+      return { status: payload.status === 'running' ? 'running' : 'stopped' };
+    } catch (error) {
+      if (error instanceof BrokerRequestError && error.status === 404) {
+        return { status: 'stopped' };
+      }
+
+      throw error;
+    }
+  }
+
+  public async createInstance(
+    input: CreateInstanceInput,
+  ): Promise<CreatedInstance> {
+    return this.launchInstance(input, undefined);
+  }
+
+  public async resumeFromSnapshot(
+    input: ResumeInstanceInput,
+  ): Promise<CreatedInstance> {
+    return this.launchInstance(input, input.sourceSnapshotId);
+  }
+
+  public async destroyInstance(
+    input: DestroyInstanceInput,
+  ): Promise<DestroyInstanceResult> {
+    await this.requestJson({
+      method: 'DELETE',
+      path: `/v1/sandboxes/${encodeURIComponent(input.instanceId)}`,
+      signal: input.signal,
+    });
+
+    return {};
+  }
+
+  public async runCommand(input: RunCommandInput): Promise<RunCommandResult> {
+    throwIfAborted(input.signal);
+
+    const response = await this.request({
+      method: 'POST',
+      path: `/v1/sandboxes/${encodeURIComponent(input.instanceId)}/exec`,
+      body: JSON.stringify({
+        cmd: input.cmd,
+        ...(input.args?.length ? { args: input.args } : {}),
+        ...(input.cwd ? { cwd: input.cwd } : {}),
+        ...(input.env ? { env: input.env } : {}),
+      }),
+      signal: input.signal,
+    });
+
+    const events = new ExecEventPump(iterateNdjson<BrokerExecEvent>(response));
+
+    if (!input.detached) {
+      const outcome = await consumeExecEvents(events);
+
+      if (outcome.error !== undefined) {
+        throw new Error(outcome.error);
+      }
+
+      return finishCommandResult(outcome, input);
+    }
+
+    // Detached: report a grace-period exit synchronously (bootstrap failures
+    // surface immediately); otherwise keep consuming in the background and
+    // deliver onExit — falling back to status polling if the stream drops.
+    const graceOutcome = await consumeExecEvents(
+      events,
+      DETACHED_EXIT_GRACE_PERIOD_MS,
+    );
+
+    if (graceOutcome.error !== undefined) {
+      throw new Error(graceOutcome.error);
+    }
+
+    if (graceOutcome.exitCode !== null) {
+      console.warn(
+        `[RoomoteBrokerClient] Detached command exited during grace period ${JSON.stringify(
+          {
+            instanceId: input.instanceId,
+            cmd: input.cmd,
+            exitCode: graceOutcome.exitCode,
+          },
+        )}`,
+      );
+
+      return finishCommandResult(graceOutcome, input);
+    }
+
+    this.watchDetachedCommand(input, graceOutcome);
+
+    return { commandId: undefined, exitCode: null };
+  }
+
+  public streamCommandOutput(
+    _input: StreamCommandOutputInput,
+  ): AsyncIterable<CommandOutputEvent> {
+    unsupported(this.vendor, 'streamCommandOutput');
+  }
+
+  public getCommandOutput(_input: GetCommandOutputInput): Promise<string> {
+    unsupported(this.vendor, 'getCommandOutput');
+  }
+
+  public async writeFiles(input: WriteFileInput): Promise<void> {
+    throwIfAborted(input.signal);
+
+    const batches: { path: string; contentBase64: string }[][] = [];
+    let batch: { path: string; contentBase64: string }[] = [];
+    let batchBytes = 0;
+
+    for (const file of input.files) {
+      if (
+        batch.length > 0 &&
+        batchBytes + file.content.byteLength > FILE_BATCH_MAX_BYTES
+      ) {
+        batches.push(batch);
+        batch = [];
+        batchBytes = 0;
+      }
+
+      batch.push({
+        path: file.path,
+        contentBase64: file.content.toString('base64'),
+      });
+      batchBytes += file.content.byteLength;
+    }
+
+    if (batch.length > 0) {
+      batches.push(batch);
+    }
+
+    for (const files of batches) {
+      await this.requestJson({
+        method: 'PUT',
+        path: `/v1/sandboxes/${encodeURIComponent(input.instanceId)}/files`,
+        body: JSON.stringify({ files }),
+        signal: input.signal,
+      });
+    }
+  }
+
+  public async createSnapshot(
+    input: CreateSnapshotInput,
+  ): Promise<CreateSnapshotResult> {
+    throwIfAborted(input.signal);
+
+    const accepted = (await this.requestJson({
+      method: 'POST',
+      path: `/v1/sandboxes/${encodeURIComponent(input.instanceId)}/snapshot`,
+      signal: input.signal,
+    })) as { operationId: string };
+
+    const deadline = Date.now() + SNAPSHOT_POLL_TIMEOUT_MS;
+
+    while (true) {
+      throwIfAborted(input.signal);
+
+      if (Date.now() > deadline) {
+        throw new Error(
+          `Snapshot operation ${accepted.operationId} for ${input.instanceId} timed out`,
+        );
+      }
+
+      const operation = (await this.requestJson({
+        method: 'GET',
+        path: `/v1/operations/${encodeURIComponent(accepted.operationId)}`,
+        signal: input.signal,
+      })) as { status: string; snapshotId?: string; error?: string };
+
+      if (operation.status === 'succeeded' && operation.snapshotId) {
+        return { snapshotId: operation.snapshotId };
+      }
+
+      if (operation.status === 'failed') {
+        throw new Error(
+          `Snapshot of ${input.instanceId} failed: ${operation.error ?? 'unknown error'}`,
+        );
+      }
+
+      await sleep(SNAPSHOT_POLL_INTERVAL_MS, input.signal);
+    }
+  }
+
+  private async launchInstance(
+    input: CreateInstanceInput,
+    sourceSnapshotId: string | undefined,
+  ): Promise<CreatedInstance> {
+    throwIfAborted(input.signal);
+
+    const idempotencyKey = input.idempotencyKey ?? randomUUID();
+    const body = JSON.stringify({
+      ...(sourceSnapshotId
+        ? { snapshotId: sourceSnapshotId }
+        : { imageRef: this.config.baseImageRef }),
+      ...(input.ports?.length ? { ports: input.ports } : {}),
+      ...(input.tags && Object.keys(input.tags).length > 0
+        ? { tags: input.tags }
+        : {}),
+      ...(this.config.timeoutMs ? { timeoutMs: this.config.timeoutMs } : {}),
+      ...(this.config.cpu ? { cpu: this.config.cpu } : {}),
+      ...(this.config.cpuLimit ? { cpuLimit: this.config.cpuLimit } : {}),
+      ...(this.config.memoryMiB ? { memoryMiB: this.config.memoryMiB } : {}),
+      ...(this.config.memoryLimitMiB
+        ? { memoryLimitMiB: this.config.memoryLimitMiB }
+        : {}),
+      ...(this.config.regions?.length ? { regions: this.config.regions } : {}),
+      ...(this.config.vmRuntime ? { vmRuntime: true } : {}),
+    });
+
+    try {
+      const created = (await this.requestJson({
+        method: 'POST',
+        path: '/v1/sandboxes',
+        body,
+        signal: input.signal,
+        headers: { 'idempotency-key': idempotencyKey },
+      })) as {
+        instanceId: string;
+        domains?: Record<string, string>;
+      };
+
+      return {
+        instanceId: created.instanceId,
+        status: 'running',
+        ...(sourceSnapshotId ? { sourceSnapshotId } : {}),
+        ...(created.domains ? { domains: created.domains } : {}),
+      };
+    } catch (error) {
+      // The broker may have completed the create after a local abort. Replay
+      // the idempotent request without a signal and terminate the orphan.
+      if (isAbortLike(error)) {
+        this.reconcileAbortedCreate(idempotencyKey, body);
+        throw toAbortError(
+          input.signal,
+          'Creating a broker sandbox was aborted',
+        );
+      }
+
+      throw error;
+    }
+  }
+
+  private reconcileAbortedCreate(idempotencyKey: string, body: string): void {
+    void (async () => {
+      const created = (await this.requestJson({
+        method: 'POST',
+        path: '/v1/sandboxes',
+        body,
+        headers: { 'idempotency-key': idempotencyKey },
+      })) as { instanceId: string };
+
+      console.warn(
+        `[RoomoteBrokerClient] Terminating sandbox created after abort ${JSON.stringify(
+          { instanceId: created.instanceId },
+        )}`,
+      );
+
+      await this.requestJson({
+        method: 'DELETE',
+        path: `/v1/sandboxes/${encodeURIComponent(created.instanceId)}`,
+      });
+    })().catch((error: unknown) => {
+      console.warn(
+        `[RoomoteBrokerClient] Aborted-create reconciliation failed (orphan recovery will cover it): ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    });
+  }
+
+  /**
+   * Background consumption of a detached command: pipe output to logs and
+   * fire onExit when the process ends. If the stream drops before the exit
+   * event, recover the exit code by polling the broker's exec-session
+   * status — the controller's bootstrap-restart classification depends on
+   * that callback arriving.
+   */
+  private watchDetachedCommand(
+    input: RunCommandInput,
+    grace: ExecOutcome,
+  ): void {
+    const label = `broker:${input.instanceId}`;
+
+    void (async () => {
+      const streamed = await consumeExecEvents(grace.remaining, undefined, {
+        onOutput: (event) => {
+          for (const line of event.data.trimEnd().split('\n')) {
+            console.log(`[${label}:${event.stream}] ${line}`);
+          }
+        },
+      }).catch(() => undefined);
+
+      let exitCode = streamed?.exitCode ?? null;
+
+      if (exitCode === null && grace.execId) {
+        exitCode = await this.pollForExit(input.instanceId, grace.execId);
+      }
+
+      if (exitCode === null) {
+        console.warn(
+          `[${label}] Lost track of detached command ${grace.execId ?? '(unknown)'}; onExit will not fire`,
+        );
+        return;
+      }
+
+      console.log(`[${label}] Detached process exited with code ${exitCode}`);
+      await input.onExit?.({ exitCode });
+    })().catch((error: unknown) => {
+      console.warn(
+        `[${label}] Detached exit handler error: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    });
+  }
+
+  private async pollForExit(
+    instanceId: string,
+    execId: string,
+  ): Promise<number | null> {
+    const deadline =
+      Date.now() +
+      Math.min(this.config.timeoutMs ?? EXIT_POLL_MAX_MS, EXIT_POLL_MAX_MS);
+
+    while (Date.now() < deadline) {
+      await sleep(EXIT_POLL_INTERVAL_MS);
+
+      try {
+        const status = (await this.requestJson({
+          method: 'GET',
+          path: `/v1/sandboxes/${encodeURIComponent(instanceId)}/exec/${encodeURIComponent(execId)}`,
+        })) as { status: string; exitCode: number | null };
+
+        if (status.status === 'exited' && status.exitCode !== null) {
+          return status.exitCode;
+        }
+
+        if (status.status === 'failed') {
+          return null;
+        }
+      } catch (error) {
+        if (error instanceof BrokerRequestError && error.status === 404) {
+          return null;
+        }
+
+        // Transient broker/network errors: keep polling until the deadline.
+      }
+    }
+
+    return null;
+  }
+
+  private async requestJson(input: {
+    method: string;
+    path: string;
+    body?: string;
+    signal?: AbortSignal;
+    headers?: Record<string, string>;
+  }): Promise<unknown> {
+    const response = await this.request(input);
+    return response.json() as Promise<unknown>;
+  }
+
+  private async request(input: {
+    method: string;
+    path: string;
+    body?: string;
+    signal?: AbortSignal;
+    headers?: Record<string, string>;
+  }): Promise<Response> {
+    throwIfAborted(input.signal);
+
+    const url = new URL(this.config.brokerUrl);
+    url.pathname = `${url.pathname.replace(/\/$/, '')}${input.path}`;
+
+    const timestamp = Date.now().toString();
+    const nonce = randomUUID();
+    const body = input.body ?? '';
+    const bodyHash = createHash('sha256').update(body).digest('hex');
+    const signature = createHmac('sha256', this.config.brokerKey)
+      .update(
+        [
+          timestamp,
+          nonce,
+          input.method.toUpperCase(),
+          url.pathname + url.search,
+          bodyHash,
+        ].join('\n'),
+      )
+      .digest('hex');
+
+    let response: Response;
+
+    try {
+      response = await this.fetchImpl(url, {
+        method: input.method,
+        headers: {
+          'content-type': 'application/json',
+          'x-roomote-tenant': this.config.tenantId,
+          'x-roomote-timestamp': timestamp,
+          'x-roomote-nonce': nonce,
+          'x-roomote-signature': signature,
+          ...(input.headers ?? {}),
+        },
+        ...(input.body !== undefined ? { body: input.body } : {}),
+        ...(input.signal ? { signal: input.signal } : {}),
+      });
+    } catch (error) {
+      if (isAbortLike(error)) {
+        throw toAbortError(
+          input.signal,
+          `Broker request ${input.method} ${input.path} was aborted`,
+        );
+      }
+
+      throw error;
+    }
+
+    if (!response.ok) {
+      const payload = (await response.json().catch(() => undefined)) as
+        | { error?: string; code?: string }
+        | undefined;
+
+      throw new BrokerRequestError(
+        payload?.error ??
+          `Broker request ${input.method} ${input.path} failed with HTTP ${response.status}`,
+        response.status,
+        payload?.code ?? 'unknown_error',
+      );
+    }
+
+    return response;
+  }
+}
+
+/**
+ * Single-consumer wrapper around the exec event stream. Racing a raw
+ * generator's next() against a timer would drop the in-flight event when the
+ * timer wins; the pump keeps that pending read and hands it to the next
+ * consumer instead.
+ */
+class ExecEventPump {
+  private pending: Promise<IteratorResult<BrokerExecEvent>> | undefined;
+
+  public constructor(
+    private readonly events: AsyncGenerator<BrokerExecEvent>,
+  ) {}
+
+  public next(): Promise<IteratorResult<BrokerExecEvent>> {
+    const result = this.pending ?? this.events.next();
+    this.pending = undefined;
+    return result;
+  }
+
+  /** Resolves 'timeout' without consuming the in-flight event. */
+  public async nextWithTimeout(
+    timeoutMs: number,
+  ): Promise<IteratorResult<BrokerExecEvent> | 'timeout'> {
+    this.pending ??= this.events.next();
+    const pending = this.pending;
+    const winner = await Promise.race([
+      pending.then((result) => ({ kind: 'result' as const, result })),
+      sleep(timeoutMs).then(() => ({ kind: 'timeout' as const })),
+    ]);
+
+    if (winner.kind === 'timeout') {
+      return 'timeout';
+    }
+
+    this.pending = undefined;
+    return winner.result;
+  }
+}
+
+type ExecOutcome = {
+  execId: string | undefined;
+  exitCode: number | null;
+  error: string | undefined;
+  stdout: string;
+  stderr: string;
+  /** Continues where consumption stopped (grace-period handoff). */
+  remaining: ExecEventPump;
+};
+
+async function consumeExecEvents(
+  events: ExecEventPump,
+  graceMs?: number,
+  hooks?: { onOutput?: (event: CommandOutputEvent) => void },
+): Promise<ExecOutcome> {
+  const outcome: ExecOutcome = {
+    execId: undefined,
+    exitCode: null,
+    error: undefined,
+    stdout: '',
+    stderr: '',
+    remaining: events,
+  };
+  const deadline = graceMs !== undefined ? Date.now() + graceMs : undefined;
+
+  while (true) {
+    let result: IteratorResult<BrokerExecEvent>;
+
+    if (deadline !== undefined) {
+      const timeLeft = deadline - Date.now();
+
+      if (timeLeft <= 0) {
+        return outcome;
+      }
+
+      const raced = await events.nextWithTimeout(timeLeft);
+
+      if (raced === 'timeout') {
+        return outcome;
+      }
+
+      result = raced;
+    } else {
+      result = await events.next();
+    }
+
+    if (result.done) {
+      return outcome;
+    }
+
+    const event = result.value;
+
+    switch (event.type) {
+      case 'started':
+        outcome.execId = event.execId;
+        break;
+      case 'stdout':
+        outcome.stdout += event.data;
+        hooks?.onOutput?.({ stream: 'stdout', data: event.data });
+        break;
+      case 'stderr':
+        outcome.stderr += event.data;
+        hooks?.onOutput?.({ stream: 'stderr', data: event.data });
+        break;
+      case 'exit':
+        outcome.exitCode = event.exitCode;
+        return outcome;
+      case 'error':
+        outcome.error = event.message;
+        return outcome;
+      case 'heartbeat':
+        break;
+    }
+  }
+}
+
+/**
+ * Matches the direct Modal adapter's contract: output is delivered to
+ * onOutput as one aggregated call per non-empty stream, after exit.
+ */
+function finishCommandResult(
+  outcome: ExecOutcome,
+  input: RunCommandInput,
+): RunCommandResult {
+  const stdout = outcome.stdout || undefined;
+  const stderr = outcome.stderr || undefined;
+
+  if (input.onOutput) {
+    if (stdout) {
+      input.onOutput({ stream: 'stdout', data: stdout });
+    }
+
+    if (stderr) {
+      input.onOutput({ stream: 'stderr', data: stderr });
+    }
+  }
+
+  return {
+    commandId: undefined,
+    exitCode: outcome.exitCode,
+    stdout,
+    stderr,
+  };
+}
+
+async function* iterateNdjson<T>(response: Response): AsyncGenerator<T> {
+  if (!response.body) {
+    return;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffered = '';
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+
+      if (value) {
+        buffered += decoder.decode(value, { stream: true });
+
+        let newlineIndex: number;
+
+        while ((newlineIndex = buffered.indexOf('\n')) >= 0) {
+          const line = buffered.slice(0, newlineIndex).trim();
+          buffered = buffered.slice(newlineIndex + 1);
+
+          if (line) {
+            yield JSON.parse(line) as T;
+          }
+        }
+      }
+
+      if (done) {
+        break;
+      }
+    }
+
+    const tail = buffered.trim();
+
+    if (tail) {
+      yield JSON.parse(tail) as T;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function isAbortLike(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === 'AbortError' || error.name === 'TimeoutError')
+  );
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  throwIfAborted(signal);
+
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+
+    const onAbort = () => {
+      clearTimeout(timeoutId);
+      reject(toAbortError(signal));
+    };
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}

--- a/packages/compute-providers/src/adapters/roomote-broker.ts
+++ b/packages/compute-providers/src/adapters/roomote-broker.ts
@@ -409,22 +409,26 @@ export class RoomoteBrokerClient implements ComputeProviderClient {
 
     void (async () => {
       const streamed = await consumeExecEvents(grace.remaining, undefined, {
+        tolerateStreamErrors: true,
         onOutput: (event) => {
           for (const line of event.data.trimEnd().split('\n')) {
             console.log(`[${label}:${event.stream}] ${line}`);
           }
         },
-      }).catch(() => undefined);
+      });
 
-      let exitCode = streamed?.exitCode ?? null;
+      // The started event may arrive only after the grace period, so the
+      // background outcome is the more complete source of the exec id.
+      const execId = streamed.execId ?? grace.execId;
+      let exitCode = streamed.exitCode;
 
-      if (exitCode === null && grace.execId) {
-        exitCode = await this.pollForExit(input.instanceId, grace.execId);
+      if (exitCode === null && execId) {
+        exitCode = await this.pollForExit(input.instanceId, execId);
       }
 
       if (exitCode === null) {
         console.warn(
-          `[${label}] Lost track of detached command ${grace.execId ?? '(unknown)'}; onExit will not fire`,
+          `[${label}] Lost track of detached command ${execId ?? '(unknown)'}; onExit will not fire`,
         );
         return;
       }
@@ -611,7 +615,16 @@ type ExecOutcome = {
 async function consumeExecEvents(
   events: ExecEventPump,
   graceMs?: number,
-  hooks?: { onOutput?: (event: CommandOutputEvent) => void },
+  hooks?: {
+    onOutput?: (event: CommandOutputEvent) => void;
+    /**
+     * Return the partial outcome instead of throwing when the stream drops.
+     * The detached watcher needs everything observed so far — in particular
+     * a `started` event that arrived after the grace period — so it can
+     * fall back to exec-status polling with the right id.
+     */
+    tolerateStreamErrors?: boolean;
+  },
 ): Promise<ExecOutcome> {
   const outcome: ExecOutcome = {
     execId: undefined,
@@ -626,22 +639,30 @@ async function consumeExecEvents(
   while (true) {
     let result: IteratorResult<BrokerExecEvent>;
 
-    if (deadline !== undefined) {
-      const timeLeft = deadline - Date.now();
+    try {
+      if (deadline !== undefined) {
+        const timeLeft = deadline - Date.now();
 
-      if (timeLeft <= 0) {
+        if (timeLeft <= 0) {
+          return outcome;
+        }
+
+        const raced = await events.nextWithTimeout(timeLeft);
+
+        if (raced === 'timeout') {
+          return outcome;
+        }
+
+        result = raced;
+      } else {
+        result = await events.next();
+      }
+    } catch (error) {
+      if (hooks?.tolerateStreamErrors) {
         return outcome;
       }
 
-      const raced = await events.nextWithTimeout(timeLeft);
-
-      if (raced === 'timeout') {
-        return outcome;
-      }
-
-      result = raced;
-    } else {
-      result = await events.next();
+      throw error;
     }
 
     if (result.done) {

--- a/packages/compute-providers/src/factory.ts
+++ b/packages/compute-providers/src/factory.ts
@@ -18,6 +18,7 @@ import type {
 import { assertDefined } from './errors';
 import {
   ModalClient,
+  RoomoteBrokerClient,
   DockerClient,
   DaytonaClient,
   E2bClient,
@@ -61,11 +62,66 @@ export function createComputeProviderClient(
     case 'modal':
     case 'roomote': {
       if (options.provider === 'roomote') {
-        // Throws on an unsupported backend; the resolved value is 'modal'
-        // until more ROOMOTE_CLOUD_BACKENDS exist.
-        resolveRoomoteCloudBackend({
+        // Throws on an unsupported backend.
+        const backend = resolveRoomoteCloudBackend({
           ROOMOTE_CLOUD_BACKEND: envValue('ROOMOTE_CLOUD_BACKEND'),
         });
+
+        // Broker backend: the deployment holds no Modal credentials. The
+        // token env vars carry the tenant id + derived broker credential,
+        // and registry/ECR pull secrets are broker-side by design — never
+        // read them here.
+        if (backend === 'broker') {
+          const brokerUrl = envValue('ROOMOTE_CLOUD_BROKER_URL');
+          const tenantId = envValue('ROOMOTE_CLOUD_TOKEN_ID');
+          const brokerKey = envValue('ROOMOTE_CLOUD_TOKEN_SECRET');
+          const brokerBaseImageRef =
+            options.config?.baseImageRef ??
+            resolveEffectiveModalBaseImageRef({
+              MODAL_BASE_IMAGE_REF: envValue('MODAL_BASE_IMAGE_REF'),
+              DOCKER_WORKER_IMAGE: envValue('DOCKER_WORKER_IMAGE'),
+              RELEASE_VERSION: envValue('RELEASE_VERSION'),
+              ROOMOTE_WORKER_IMAGE_REPO: envValue('ROOMOTE_WORKER_IMAGE_REPO'),
+              APP_ENV: envValue('APP_ENV'),
+              NODE_ENV: envValue('NODE_ENV'),
+            }) ??
+            undefined;
+
+          assertDefined(brokerUrl, 'Missing ROOMOTE_CLOUD_BROKER_URL');
+          assertDefined(tenantId, 'Missing ROOMOTE_CLOUD_TOKEN_ID');
+          assertDefined(brokerKey, 'Missing ROOMOTE_CLOUD_TOKEN_SECRET');
+          assertDefined(brokerBaseImageRef, 'Missing MODAL_BASE_IMAGE_REF');
+
+          const brokerResources = resolveConfiguredComputeProviderResources({
+            provider: options.provider,
+            configuredCpuCores: options.config?.cpu,
+            configuredMemoryMiB: options.config?.memoryMiB,
+          });
+          const brokerRegions =
+            parseModalRegions(options.config?.regions) ??
+            parseModalRegions(envValue('MODAL_REGIONS'));
+
+          return new RoomoteBrokerClient({
+            brokerUrl,
+            tenantId,
+            brokerKey,
+            baseImageRef: brokerBaseImageRef,
+            ...(brokerRegions ? { regions: brokerRegions } : {}),
+            ...(options.config?.timeoutMs
+              ? { timeoutMs: options.config.timeoutMs }
+              : {}),
+            ...(brokerResources.configuredCpuCores !== null
+              ? { cpu: brokerResources.configuredCpuCores }
+              : {}),
+            cpuLimit: options.config?.cpuLimit ?? SANDBOX_DEFAULT_VCPUS,
+            ...(brokerResources.configuredMemoryMiB !== null
+              ? { memoryMiB: brokerResources.configuredMemoryMiB }
+              : {}),
+            memoryLimitMiB:
+              options.config?.memoryLimitMiB ?? MODAL_DEFAULT_MEMORY_LIMIT_MIB,
+            ...(options.config?.vmRuntime ? { vmRuntime: true } : {}),
+          });
+        }
       }
 
       const tokenIdEnvVar =

--- a/packages/compute-providers/src/index.ts
+++ b/packages/compute-providers/src/index.ts
@@ -9,6 +9,7 @@ export * from './worker-env';
 export * from './modal';
 
 export * from './adapters/modal';
+export * from './adapters/roomote-broker';
 export * from './adapters/docker';
 export * from './adapters/daytona';
 export * from './daytona';

--- a/packages/compute-providers/src/types.ts
+++ b/packages/compute-providers/src/types.ts
@@ -260,6 +260,33 @@ export interface ModalConfig {
   vmRuntime?: boolean;
 }
 
+export interface RoomoteBrokerConfig {
+  /** Base URL of the hosting operator's compute broker. */
+  brokerUrl: string;
+  /** Deployment id; the broker's tenant identity (`ROOMOTE_CLOUD_TOKEN_ID`). */
+  tenantId: string;
+  /** Derived per-tenant broker credential (`ROOMOTE_CLOUD_TOKEN_SECRET`). */
+  brokerKey: string;
+  /** Baked worker image reference for fresh sandboxes. */
+  baseImageRef: string;
+  /** Optional Modal placement region(s), enforced server-side. */
+  regions?: string[];
+  /** Maximum sandbox lifetime in milliseconds, clamped server-side. */
+  timeoutMs?: number;
+  /** CPU core reservation (can be fractional). */
+  cpu?: number;
+  /** Hard CPU cap in physical cores. */
+  cpuLimit?: number;
+  /** Memory reservation in MiB. */
+  memoryMiB?: number;
+  /** Hard memory cap in MiB. */
+  memoryLimitMiB?: number;
+  /** Use the VM sandbox runtime for nested Docker workloads. */
+  vmRuntime?: boolean;
+  /** Test seam; defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
 export interface DockerConfig {
   /** Local Docker image used for worker containers. */
   image?: string;

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -226,6 +226,10 @@ const serverSchema = {
   ROOMOTE_CLOUD_BACKEND: z.enum(ROOMOTE_CLOUD_BACKENDS).optional(),
   ROOMOTE_CLOUD_SLUG: z.string().optional(),
   ROOMOTE_CLOUD_APP_NAME: z.string().optional(),
+  // Compute broker base URL for the `broker` backend; with it, the token
+  // pair above carries a derived per-tenant broker credential instead of
+  // Modal workspace tokens.
+  ROOMOTE_CLOUD_BROKER_URL: z.string().url().optional(),
   MODAL_ENDPOINT: z.string().optional(),
   MODAL_ENVIRONMENT: z.string().optional(),
   MODAL_APP_NAME: z.string().optional(),

--- a/packages/types/src/compute-providers/roomote-cloud.ts
+++ b/packages/types/src/compute-providers/roomote-cloud.ts
@@ -5,24 +5,37 @@
  * persisted vendor `roomote` — while `ROOMOTE_CLOUD_BACKEND` selects which
  * engine actually runs the sandboxes.
  *
- * Only the Modal backend exists today. Adding an engine means extending this
- * list and the two dispatch sites that branch on the resolved backend: the
+ * Two backends exist today: `modal` (direct Modal SDK access with a Modal
+ * token pair in the deployment env) and `broker` (the hosting operator's
+ * compute broker performs the Modal operations; the deployment holds only a
+ * derived per-tenant broker credential in the same token env vars, plus
+ * `ROOMOTE_CLOUD_BROKER_URL`). Adding an engine means extending this list
+ * and the two dispatch sites that branch on the resolved backend: the
  * compute-provider factory (client construction) and the controller's spawn
  * switch — plus making the static per-provider metadata (capabilities,
  * worker label, resource model, usage policy) backend-aware.
  *
- * Note: the backend is a per-deployment choice. Switching it on a live
- * deployment requires draining `roomote`-vendor task runs and dropping
- * environment snapshots first — machine ids and snapshots are
- * engine-specific.
+ * Note: the backend is a per-deployment choice. Switching between distinct
+ * engines on a live deployment requires draining `roomote`-vendor task runs
+ * and dropping environment snapshots first — machine ids and snapshots are
+ * engine-specific. `modal` ↔ `broker` is the exception: the broker fronts
+ * the same Modal workspace with the same `roomote-<slug>` app naming, so
+ * machine ids and snapshots remain valid across that flip.
  */
-export const ROOMOTE_CLOUD_BACKENDS = ['modal'] as const;
+export const ROOMOTE_CLOUD_BACKENDS = ['modal', 'broker'] as const;
 
 export type RoomoteCloudBackend = (typeof ROOMOTE_CLOUD_BACKENDS)[number];
 
 export const DEFAULT_ROOMOTE_CLOUD_BACKEND: RoomoteCloudBackend = 'modal';
 
 export const ROOMOTE_CLOUD_BACKEND_ENV_VAR = 'ROOMOTE_CLOUD_BACKEND';
+
+/**
+ * Base URL of the hosting operator's compute broker, required by the
+ * `broker` backend. With this backend the deployment's token env vars carry
+ * a derived per-tenant broker credential instead of Modal workspace tokens.
+ */
+export const ROOMOTE_CLOUD_BROKER_URL_ENV_VAR = 'ROOMOTE_CLOUD_BROKER_URL';
 
 /**
  * Engine-neutral deployment identity for the managed provider. Backends map

--- a/packages/types/src/setup-compute-config.ts
+++ b/packages/types/src/setup-compute-config.ts
@@ -331,6 +331,14 @@ export const SETUP_COMPUTE_PROVIDER_CATALOG = [
         category: 'infrastructure',
       },
       {
+        // Compute broker base URL for the `broker` backend. Seeded by the
+        // hosting operator's provisioning alongside the token pair.
+        envVarName: 'ROOMOTE_CLOUD_BROKER_URL',
+        label: 'Roomote Cloud Broker URL',
+        required: false,
+        category: 'infrastructure',
+      },
+      {
         // Shared with the Modal provider: the default backend runs on Modal,
         // and the base image derives from the deployment's worker image.
         envVarName: 'MODAL_BASE_IMAGE_REF',
@@ -593,6 +601,7 @@ const DEPLOYMENT_MANAGED_COMPUTE_ENV_VARS: ReadonlySet<string> = new Set([
   'ROOMOTE_CLOUD_BACKEND',
   'ROOMOTE_CLOUD_SLUG',
   'ROOMOTE_CLOUD_APP_NAME',
+  'ROOMOTE_CLOUD_BROKER_URL',
 ]);
 
 /**


### PR DESCRIPTION
## Problem

The managed `roomote` provider authenticates to Modal with a shared workspace token pair injected by Roomote Cloud into every tenant deployment. One compromised deployment exposes the entire Modal workspace.

## What this adds

A new `broker` value for `ROOMOTE_CLOUD_BACKENDS`: sandbox operations route through the hosting operator's compute broker over HMAC-signed HTTP (timestamp + nonce + method + path + body-hash, per request). In broker mode:

- `ROOMOTE_CLOUD_TOKEN_ID/SECRET` carry the deployment id + a derived per-tenant broker credential — **no Modal workspace credentials exist in the deployment**.
- Registry/ECR pull secrets move entirely broker-side; the factory's broker branch never reads them.
- `ROOMOTE_CLOUD_BROKER_URL` (new env var, deployment-managed and reserved like the rest of the `ROOMOTE_CLOUD_*` set) selects the backend alongside `ROOMOTE_CLOUD_BACKEND=broker`.

`RoomoteBrokerClient` (`packages/compute-providers/src/adapters/roomote-broker.ts`) implements the existing `ComputeProviderClient` interface with Modal-parity semantics: aggregated exec output delivery, the 1s detached-exit grace period, background `onExit` delivery with exec-status polling recovery if the stream drops, snapshot via 202+poll (snapshot still terminates the source sandbox), abort → `AbortError`, and `commandId: undefined`. Non-spawn consumers (bullmq snapshot/sleep-check, sandbox OIDC priming, cleanup) get the broker client for free through the factory.

**Backward compatibility**: the default backend stays `modal`; existing deployments are untouched until Cloud flips their env. `modal` ↔ `broker` is id-compatible — the broker fronts the same Modal workspace with the same `roomote-<slug>` app naming, so machine ids and snapshots stay valid across the flip (doc note added in `roomote-cloud.ts`).

Companion control-plane PR (broker service + provisioning contract): RooCodeInc/Roomote-Cloud#32. This PR must be in the pinned app image before any tenant is flipped to broker mode.

## Verification

- 15 new adapter unit tests (signing incl. base-path prefixes, streaming aggregation, detached grace/onExit, snapshot polling, error mapping, abort) + broker factory tests; full compute-providers (179), types (643), and controller (151) suites pass.
- Cross-repo e2e over real HTTP against the real broker app: 31/31 checks (tenant isolation, revocation, forged credentials, image allowlist).
- Live-Modal e2e with the real workspace token through the broker: create/exec/writeFiles/snapshot→resume/destroy on real sandboxes, including filesystem persistence across snapshot-resume and cross-tenant isolation.