### PR TITLE
fix(worker): fail fast on missing GitHub credentials and harden clone cleanup

### DIFF
--- a/apps/docs/self-hosting.mdx
+++ b/apps/docs/self-hosting.mdx
@@ -157,8 +157,13 @@ deployment should let you:
 - **Callbacks fail.** For providers that use callbacks or webhooks, confirm the
   deployment has a public HTTPS URL and that the provider is using that exact
   URL. Discord uses its Gateway service instead of a public callback.
-- **The first task cannot clone a repository.** Check source-control
-  installation scope and repository permissions.
+- **The first task cannot clone a repository.** Workers authenticate git with a
+  short-lived GitHub App installation token created when the run starts — they
+  do not read a `GH_TOKEN`/`GITHUB_TOKEN` from the container environment. If a
+  task fails with "No GitHub credentials are available", verify the GitHub App
+  is installed for the repository owner, the installation covers the
+  repository, and the repository appears in the source-control settings after a
+  sync.
 - **The agent cannot run useful commands.** Add missing services, environment
   variables, setup commands, or tool versions to the environment.
 - **Chat messages do not reach Roomote.** Confirm the app is installed, invited

--- a/apps/worker/src/lib/github-token.ts
+++ b/apps/worker/src/lib/github-token.ts
@@ -302,7 +302,7 @@ export function ensureGhCliWrapper(): string {
   return GH_CLI_WRAPPER_PATH;
 }
 
-export type GitHubTokenFileStatus = {
+type GitHubTokenFileStatus = {
   present: boolean;
   nonEmpty: boolean;
 };

--- a/apps/worker/src/lib/github-token.ts
+++ b/apps/worker/src/lib/github-token.ts
@@ -1,4 +1,11 @@
-import { chmodSync, existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
 import { createServer } from 'http';
 import { homedir } from 'os';
 import { join } from 'path';
@@ -293,6 +300,25 @@ export function ensureGhCliWrapper(): string {
   });
 
   return GH_CLI_WRAPPER_PATH;
+}
+
+export type GitHubTokenFileStatus = {
+  present: boolean;
+  nonEmpty: boolean;
+};
+
+/**
+ * Redacted status of the file-backed GitHub token the git credential helper
+ * reads. Exposes only presence signals, never token material, so callers can
+ * log it and fail fast before attempting anonymous git operations.
+ */
+export function getGitHubTokenFileStatus(): GitHubTokenFileStatus {
+  try {
+    const content = readFileSync(GH_TOKEN_FILE_PATH, 'utf-8');
+    return { present: true, nonEmpty: content.trim().length > 0 };
+  } catch {
+    return { present: false, nonEmpty: false };
+  }
 }
 
 function writeGhToken(token: string): void {

--- a/apps/worker/src/workspace/__tests__/tool-versions.test.ts
+++ b/apps/worker/src/workspace/__tests__/tool-versions.test.ts
@@ -45,6 +45,9 @@ vi.mock('../../lib/github-token', () => ({
   ensureGitCredentialHelper: vi
     .fn()
     .mockReturnValue('/tmp/git-credential-roomote.sh'),
+  getGitHubTokenFileStatus: vi
+    .fn()
+    .mockReturnValue({ present: true, nonEmpty: true }),
   SOURCE_CONTROL_GIT_CONFIG_PATH: '/tmp/source-control-gitconfig',
 }));
 
@@ -293,7 +296,7 @@ describe('WorkspaceManager tool versions', () => {
       });
       expect(mockExecute).toHaveBeenCalledWith({
         name: 'Git clone',
-        run: "git clone 'https://github.com/acme/backend.git' 'acme/backend'",
+        run: "rm -rf -- 'acme/backend' && git clone 'https://github.com/acme/backend.git' 'acme/backend'",
         retries: 4,
         timeout: 300,
         continue_on_error: false,
@@ -317,7 +320,7 @@ describe('WorkspaceManager tool versions', () => {
 
       expect(mockExecute).toHaveBeenCalledWith({
         name: 'Git clone',
-        run: "git clone 'https://gitlab.com/acme/backend.git' 'acme/backend'",
+        run: "rm -rf -- 'acme/backend' && git clone 'https://gitlab.com/acme/backend.git' 'acme/backend'",
         retries: 4,
         timeout: 300,
         continue_on_error: false,
@@ -366,7 +369,7 @@ describe('WorkspaceManager tool versions', () => {
 
       expect(mockExecute).toHaveBeenCalledWith({
         name: 'Git clone',
-        run: "git clone 'https://git.example.com/acme/backend.git' 'acme/backend'",
+        run: "rm -rf -- 'acme/backend' && git clone 'https://git.example.com/acme/backend.git' 'acme/backend'",
         retries: 4,
         timeout: 300,
         continue_on_error: false,
@@ -413,7 +416,7 @@ describe('WorkspaceManager tool versions', () => {
 
       expect(mockExecute).toHaveBeenCalledWith({
         name: 'Git clone',
-        run: "git clone 'https://dev.azure.com/acme/Platform/_git/backend' 'acme/Platform/backend'",
+        run: "rm -rf -- 'acme/Platform/backend' && git clone 'https://dev.azure.com/acme/Platform/_git/backend' 'acme/Platform/backend'",
         retries: 4,
         timeout: 300,
         continue_on_error: false,
@@ -548,7 +551,9 @@ describe('WorkspaceManager tool versions', () => {
 
     it('reuses legacy snapshot clone paths during preserveGitState resumes', async () => {
       vi.mocked(existsSync).mockImplementation(
-        (targetPath) => targetPath === '/workspace/backend',
+        (targetPath) =>
+          targetPath === '/workspace/backend' ||
+          targetPath === join('/workspace/backend', '.git'),
       );
 
       vi.mocked(sdk.repositories.findRepository).mockResolvedValue({

--- a/apps/worker/src/workspace/__tests__/workspace-manager-clone.test.ts
+++ b/apps/worker/src/workspace/__tests__/workspace-manager-clone.test.ts
@@ -1,0 +1,214 @@
+// pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/worker exec vitest run src/workspace/__tests__/workspace-manager-clone.test.ts
+
+import { existsSync } from 'fs';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { WorkspaceManager } from '../workspace-manager';
+
+vi.mock('@roomote/sdk/client', () => ({
+  sdk: {
+    repositories: {
+      findRepository: vi.fn(),
+      reportDefaultBranch: vi.fn(),
+    },
+  },
+}));
+
+const executeMock = vi.fn();
+const executeAllMock = vi.fn();
+
+vi.mock('../../command-executor', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../command-executor')>();
+
+  return {
+    ...actual,
+    CommandExecutor: vi.fn().mockImplementation(function (cwd: string) {
+      return {
+        cwd,
+        execute: executeMock,
+        executeAll: executeAllMock,
+      };
+    }),
+  };
+});
+
+const getGitHubTokenFileStatusMock = vi.fn();
+
+vi.mock('../../lib/github-token', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../lib/github-token')>();
+
+  return {
+    ...actual,
+    ensureGitCredentialHelper: vi.fn(() => '/tmp/credential-helper.sh'),
+    getGitHubTokenFileStatus: () => getGitHubTokenFileStatusMock(),
+  };
+});
+
+import { sdk } from '@roomote/sdk/client';
+
+const REPO_FULL_NAME = 'acme/backend';
+
+function stubTokenFile({ nonEmpty }: { nonEmpty: boolean }) {
+  getGitHubTokenFileStatusMock.mockReturnValue({
+    present: nonEmpty,
+    nonEmpty,
+  });
+}
+
+describe('WorkspaceManager repository clone preparation', () => {
+  let workspaceRoot: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    workspaceRoot = await mkdtemp(join(tmpdir(), 'workspace-clone-test-'));
+
+    vi.mocked(sdk.repositories.findRepository).mockResolvedValue({
+      id: 'repo-1',
+      fullName: REPO_FULL_NAME,
+      defaultBranch: 'main',
+      cloneUrl: `https://github.com/${REPO_FULL_NAME}.git`,
+    } as Awaited<ReturnType<typeof sdk.repositories.findRepository>>);
+  });
+
+  afterEach(async () => {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  function createManager(env: NodeJS.ProcessEnv = { PATH: '/usr/bin' }) {
+    const manager = new WorkspaceManager(workspaceRoot, env);
+
+    // Stub the post-clone steps that shell out or hit the network; these
+    // tests only cover the credential fail-fast and clone/cleanup behavior.
+    const internals = manager as unknown as {
+      markGitSafeDirectory: () => Promise<void>;
+      syncRepositoryGitState: () => Promise<void>;
+      installToolVersions: () => Promise<void>;
+    };
+    internals.markGitSafeDirectory = vi.fn().mockResolvedValue(undefined);
+    internals.syncRepositoryGitState = vi.fn().mockResolvedValue(undefined);
+    internals.installToolVersions = vi.fn().mockResolvedValue(undefined);
+
+    return manager;
+  }
+
+  async function createRepoDir({ withGitDir }: { withGitDir: boolean }) {
+    const repoPath = join(workspaceRoot, REPO_FULL_NAME);
+    await mkdir(withGitDir ? join(repoPath, '.git') : repoPath, {
+      recursive: true,
+    });
+    await writeFile(join(repoPath, 'leftover.txt'), 'partial');
+    return repoPath;
+  }
+
+  function mockCloneCreatesRepo() {
+    executeMock.mockImplementation(async (command: { name: string }) => {
+      if (command.name === 'Git clone') {
+        await mkdir(join(workspaceRoot, REPO_FULL_NAME, '.git'), {
+          recursive: true,
+        });
+      }
+      return { success: true, stdout: '', stderr: '' };
+    });
+  }
+
+  function getCloneCommand() {
+    return executeMock.mock.calls
+      .map(([command]) => command as { name: string; run: string })
+      .find((command) => command.name === 'Git clone');
+  }
+
+  it('fails fast with an actionable error when a GitHub run has no credentials', async () => {
+    stubTokenFile({ nonEmpty: false });
+    const manager = createManager();
+
+    await expect(
+      manager.prepareRepository(REPO_FULL_NAME, 'main', undefined),
+    ).rejects.toThrow(
+      /No GitHub credentials are available for acme\/backend.*GitHub App/s,
+    );
+
+    expect(getCloneCommand()).toBeUndefined();
+  });
+
+  it('proceeds when the file-backed GitHub token is present', async () => {
+    stubTokenFile({ nonEmpty: true });
+    mockCloneCreatesRepo();
+    const manager = createManager();
+
+    await manager.prepareRepository(REPO_FULL_NAME, 'main', undefined);
+
+    const clone = getCloneCommand();
+    expect(clone).toBeDefined();
+    expect(clone!.run).toBe(
+      `rm -rf -- 'acme/backend' && git clone 'https://github.com/acme/backend.git' 'acme/backend'`,
+    );
+  });
+
+  it('accepts a GH_TOKEN env var as a credential signal', async () => {
+    stubTokenFile({ nonEmpty: false });
+    mockCloneCreatesRepo();
+    const manager = createManager({ PATH: '/usr/bin', GH_TOKEN: 'env-token' });
+
+    await manager.prepareRepository(REPO_FULL_NAME, 'main', undefined);
+
+    expect(getCloneCommand()).toBeDefined();
+  });
+
+  it('removes an existing directory without .git and clones again', async () => {
+    stubTokenFile({ nonEmpty: true });
+    mockCloneCreatesRepo();
+    const repoPath = await createRepoDir({ withGitDir: false });
+    const manager = createManager();
+
+    await manager.prepareRepository(REPO_FULL_NAME, 'main', undefined);
+
+    expect(getCloneCommand()).toBeDefined();
+    expect(existsSync(join(repoPath, 'leftover.txt'))).toBe(false);
+    expect(existsSync(join(repoPath, '.git'))).toBe(true);
+  });
+
+  it('keeps an existing valid clone and skips cloning', async () => {
+    stubTokenFile({ nonEmpty: true });
+    executeMock.mockResolvedValue({ success: true, stdout: '', stderr: '' });
+    const repoPath = await createRepoDir({ withGitDir: true });
+    const manager = createManager();
+
+    await manager.prepareRepository(REPO_FULL_NAME, 'main', undefined);
+
+    expect(getCloneCommand()).toBeUndefined();
+    expect(existsSync(join(repoPath, 'leftover.txt'))).toBe(true);
+  });
+
+  it('skips the credential check when preserving git state of an existing clone', async () => {
+    stubTokenFile({ nonEmpty: false });
+    executeMock.mockResolvedValue({ success: true, stdout: '', stderr: '' });
+    await createRepoDir({ withGitDir: true });
+    const manager = createManager();
+
+    await expect(
+      manager.prepareRepository(REPO_FULL_NAME, 'main', undefined, true),
+    ).resolves.toBeDefined();
+  });
+
+  it('does not run the GitHub credential check for other providers', async () => {
+    stubTokenFile({ nonEmpty: false });
+    mockCloneCreatesRepo();
+    const manager = createManager();
+
+    await manager.prepareRepository(
+      REPO_FULL_NAME,
+      'main',
+      undefined,
+      false,
+      false,
+      { sourceControlProvider: 'gitlab' },
+    );
+
+    expect(getGitHubTokenFileStatusMock).not.toHaveBeenCalled();
+    expect(getCloneCommand()).toBeDefined();
+  });
+});

--- a/apps/worker/src/workspace/workspace-manager.ts
+++ b/apps/worker/src/workspace/workspace-manager.ts
@@ -24,6 +24,7 @@ import { createWorkspaceRepositoryPreparationError } from '../commands/setup/wor
 import {
   SOURCE_CONTROL_GIT_CONFIG_PATH,
   ensureGitCredentialHelper,
+  getGitHubTokenFileStatus,
 } from '../lib/github-token';
 
 interface PrepareRepositoryOptions {
@@ -510,6 +511,35 @@ export class WorkspaceManager {
     });
   }
 
+  /**
+   * GitHub task runs always receive a GitHub App installation token at
+   * dequeue, which the worker writes to the file-backed git credential
+   * helper before repository setup. If no credential signal is present
+   * here, git would fall back to slow anonymous clone retries and fail
+   * checkout with a cryptic error — fail fast with an operator-actionable
+   * message instead. Logs presence signals only, never token material.
+   */
+  private assertGitHubCredentialsAvailable(repoFullName: string): void {
+    const tokenFile = getGitHubTokenFileStatus();
+    const envTokenPresent = Boolean(
+      this.env.GH_TOKEN?.trim() || this.env.GITHUB_TOKEN?.trim(),
+    );
+
+    console.log(
+      `GitHub credential check for ${repoFullName}: tokenFilePresent=${tokenFile.present} tokenFileNonEmpty=${tokenFile.nonEmpty} envTokenPresent=${envTokenPresent}`,
+    );
+
+    if (tokenFile.nonEmpty || envTokenPresent) {
+      return;
+    }
+
+    throw new Error(
+      `No GitHub credentials are available for ${repoFullName}: the worker's token file (~/.roomote/gh-token) is missing or empty and no GH_TOKEN/GITHUB_TOKEN env var is set. ` +
+        'The control plane creates a GitHub App installation token when the run is dequeued; verify the GitHub App is installed for the repository owner, the installation covers this repository, and repositories are synced. ' +
+        'Anonymous git access is rate limited and fails for private repositories, so repository setup was stopped before cloning.',
+    );
+  }
+
   public async prepareRepository(
     repoFullName: string,
     branch: string | undefined,
@@ -561,14 +591,37 @@ export class WorkspaceManager {
       this.workspaceRoot,
       fullName.split('/').pop() ?? fullName,
     );
-    const resolvedRepoPath =
+    let resolvedRepoPath =
       preserveGitState &&
       repoPath !== legacyRepoPath &&
       !existsSync(repoPath) &&
       existsSync(legacyRepoPath)
         ? legacyRepoPath
         : repoPath;
+
+    // An interrupted earlier run can leave a directory behind that is not a
+    // git repository (e.g. a clone killed before .git was written). Treating
+    // it as an existing clone would skip cloning here and fail much later at
+    // checkout with a cryptic "'origin/<branch>' is not a commit" error.
+    if (
+      existsSync(resolvedRepoPath) &&
+      !existsSync(join(resolvedRepoPath, '.git'))
+    ) {
+      console.warn(
+        `Repository path ${resolvedRepoPath} exists but is not a git repository; removing it and cloning again.`,
+      );
+      await rm(resolvedRepoPath, { recursive: true, force: true });
+      resolvedRepoPath = repoPath;
+    }
+
     const needsClone = !existsSync(resolvedRepoPath);
+
+    if (
+      sourceControlProvider === 'github' &&
+      (needsClone || !preserveGitState)
+    ) {
+      this.assertGitHubCredentialsAvailable(fullName);
+    }
 
     if (!needsClone) {
       console.log(`Repository ${fullName} already exists, skipping clone`);
@@ -589,7 +642,12 @@ export class WorkspaceManager {
           // file-backed credential helper and avoids gh's extra API lookup.
           // Escape both args: cloneUrl is provider-synced and may include
           // shell metacharacters from a hostile self-hosted origin.
-          run: `git clone '${shellEscape(cloneUrl)}' '${shellEscape(fullName)}'`,
+          // Retries re-run this same line, and a clone killed mid-transfer
+          // (e.g. by the timeout) leaves a partial target directory that
+          // would make every retry fail with "destination path already
+          // exists" — remove it first. Safe: needsClone guarantees the path
+          // did not exist before the first attempt.
+          run: `rm -rf -- '${shellEscape(fullName)}' && git clone '${shellEscape(cloneUrl)}' '${shellEscape(fullName)}'`,
           // Allow brief auth and repository visibility propagation delays.
           retries: 4,
           timeout: 300,


### PR DESCRIPTION
## Problem

Reported in #630: on a self-hosted deployment, tasks spent ~4 minutes in anonymous `git clone` retries and then failed checkout with a cryptic `'origin/main' is not a commit` error.

The issue's suggested fix (adding `GH_TOKEN` to the Docker spawn env) targets the wrong boundary: workers intentionally receive a short-lived GitHub App installation token in the dequeue payload, written to `~/.roomote/gh-token` and read by a file-backed git credential helper — never a long-lived container env var. The real gaps were that a token missing *at git time* failed slowly and cryptically, and that partial clone state could poison subsequent attempts.

## Changes

- **Fail fast with an actionable error.** Before cloning or fetching a GitHub repository, `WorkspaceManager` logs redacted credential presence signals (`tokenFilePresent`/`tokenFileNonEmpty`/`envTokenPresent` — never token material) and throws an operator-actionable error when no token file or `GH_TOKEN`/`GITHUB_TOKEN` env var is available, pointing at GitHub App installation coverage and repository sync. Skipped for non-GitHub providers (they authenticate through proxy credentials) and for preserve-git-state resumes of existing clones. Both `setup()` entry points inject the dequeue token before this check runs.
- **Re-clone over invalid leftovers.** An existing repository directory with no `.git` entry (e.g. from an interrupted earlier run) is now removed and re-cloned instead of being treated as a valid clone and failing much later at checkout.
- **Retry-safe clone.** The clone command clears its target before each attempt, so a clone killed mid-transfer (e.g. by the 300s timeout) no longer makes every retry fail with `destination path already exists`. Safe because the clone branch is only reached when the target did not exist.
- **Docs.** Expanded the self-hosting troubleshooting entry to explain the token handoff and what to verify when the new error appears.

## Testing

- New `workspace-manager-clone.test.ts` covering the fail-fast error, env-token escape hatch, invalid-directory re-clone, valid-clone reuse, preserve-git-state skip, and provider scoping.
- Updated `tool-versions.test.ts` clone-command expectations.
- `vitest run src/workspace/__tests__/ src/commands/setup/__tests__/workspace.test.ts`: 79/79 passing; worker `tsc --noEmit`, oxlint, and oxfmt clean.

Related to #630

🤖 Generated with [Claude Code](https://claude.com/claude-code)