### PR TITLE
fix(worker): contain repository paths in workspace and materialize env GitHub token

### DIFF
--- a/apps/worker/src/lib/github-token.ts
+++ b/apps/worker/src/lib/github-token.ts
@@ -326,6 +326,16 @@ function writeGhToken(token: string): void {
   writeFileSync(GH_TOKEN_FILE_PATH, `${token}\n`, { mode: 0o600 });
 }
 
+/**
+ * Write an environment-provided GitHub token to the file-backed store. The
+ * git credential helper, gh wrapper, and token env scripts only read
+ * ~/.roomote/gh-token, so a token that exists solely as an env var would
+ * never reach git operations unless it is materialized here.
+ */
+export function writeGitHubTokenFile(token: string): void {
+  writeGhToken(token);
+}
+
 function clearGhToken(): void {
   rmSync(GH_TOKEN_FILE_PATH, { force: true });
 }

--- a/apps/worker/src/workspace/__tests__/workspace-manager-clone.test.ts
+++ b/apps/worker/src/workspace/__tests__/workspace-manager-clone.test.ts
@@ -36,6 +36,7 @@ vi.mock('../../command-executor', async (importOriginal) => {
 });
 
 const getGitHubTokenFileStatusMock = vi.fn();
+const writeGitHubTokenFileMock = vi.fn();
 
 vi.mock('../../lib/github-token', async (importOriginal) => {
   const actual =
@@ -45,6 +46,7 @@ vi.mock('../../lib/github-token', async (importOriginal) => {
     ...actual,
     ensureGitCredentialHelper: vi.fn(() => '/tmp/credential-helper.sh'),
     getGitHubTokenFileStatus: () => getGitHubTokenFileStatusMock(),
+    writeGitHubTokenFile: (token: string) => writeGitHubTokenFileMock(token),
   };
 });
 
@@ -148,14 +150,63 @@ describe('WorkspaceManager repository clone preparation', () => {
     );
   });
 
-  it('accepts a GH_TOKEN env var as a credential signal', async () => {
+  it('materializes an env GH_TOKEN into the token file before cloning', async () => {
     stubTokenFile({ nonEmpty: false });
     mockCloneCreatesRepo();
     const manager = createManager({ PATH: '/usr/bin', GH_TOKEN: 'env-token' });
 
     await manager.prepareRepository(REPO_FULL_NAME, 'main', undefined);
 
+    expect(writeGitHubTokenFileMock).toHaveBeenCalledWith('env-token');
     expect(getCloneCommand()).toBeDefined();
+  });
+
+  it('does not touch the token file when it already has a token', async () => {
+    stubTokenFile({ nonEmpty: true });
+    mockCloneCreatesRepo();
+    const manager = createManager({ PATH: '/usr/bin', GH_TOKEN: 'env-token' });
+
+    await manager.prepareRepository(REPO_FULL_NAME, 'main', undefined);
+
+    expect(writeGitHubTokenFileMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects repository names that resolve outside the workspace root', async () => {
+    stubTokenFile({ nonEmpty: true });
+    vi.mocked(sdk.repositories.findRepository).mockResolvedValue(undefined);
+    const manager = createManager();
+
+    await expect(
+      manager.prepareRepository(
+        '../../victim',
+        'main',
+        undefined,
+        false,
+        false,
+        {
+          sourceControlProvider: 'gitlab',
+        },
+      ),
+    ).rejects.toThrow(/resolves outside the workspace root/);
+
+    expect(getCloneCommand()).toBeUndefined();
+  });
+
+  it('rejects synced repository rows whose full name escapes the workspace', async () => {
+    stubTokenFile({ nonEmpty: true });
+    vi.mocked(sdk.repositories.findRepository).mockResolvedValue({
+      id: 'repo-1',
+      fullName: '../evil',
+      defaultBranch: 'main',
+      cloneUrl: 'https://github.com/acme/backend.git',
+    } as Awaited<ReturnType<typeof sdk.repositories.findRepository>>);
+    const manager = createManager();
+
+    await expect(
+      manager.prepareRepository(REPO_FULL_NAME, 'main', undefined),
+    ).rejects.toThrow(/resolves outside the workspace root/);
+
+    expect(getCloneCommand()).toBeUndefined();
   });
 
   it('removes an existing directory without .git and clones again', async () => {

--- a/apps/worker/src/workspace/workspace-manager.ts
+++ b/apps/worker/src/workspace/workspace-manager.ts
@@ -25,6 +25,7 @@ import {
   SOURCE_CONTROL_GIT_CONFIG_PATH,
   ensureGitCredentialHelper,
   getGitHubTokenFileStatus,
+  writeGitHubTokenFile,
 } from '../lib/github-token';
 
 interface PrepareRepositoryOptions {
@@ -512,6 +513,30 @@ export class WorkspaceManager {
   }
 
   /**
+   * Resolve a repository-relative path and reject any value that escapes
+   * the workspace root. Repository full names are provider-synced and reach
+   * both shell commands and recursive deletes, so traversal segments (`..`)
+   * from a hostile or misconfigured source-control origin must never
+   * resolve outside the workspace.
+   */
+  private resolveContainedWorkspacePath(relativePath: string): string {
+    const targetPath = join(this.workspaceRoot, relativePath);
+    const relativeToRoot = relative(this.workspaceRoot, targetPath);
+
+    if (
+      relativeToRoot === '' ||
+      relativeToRoot.startsWith('..') ||
+      isAbsolute(relativeToRoot)
+    ) {
+      throw new Error(
+        `Repository path '${relativePath}' resolves outside the workspace root and was rejected.`,
+      );
+    }
+
+    return targetPath;
+  }
+
+  /**
    * GitHub task runs always receive a GitHub App installation token at
    * dequeue, which the worker writes to the file-backed git credential
    * helper before repository setup. If no credential signal is present
@@ -519,17 +544,26 @@ export class WorkspaceManager {
    * checkout with a cryptic error — fail fast with an operator-actionable
    * message instead. Logs presence signals only, never token material.
    */
-  private assertGitHubCredentialsAvailable(repoFullName: string): void {
+  private ensureGitHubCredentialsAvailable(repoFullName: string): void {
     const tokenFile = getGitHubTokenFileStatus();
-    const envTokenPresent = Boolean(
-      this.env.GH_TOKEN?.trim() || this.env.GITHUB_TOKEN?.trim(),
-    );
+    const envToken = this.env.GH_TOKEN?.trim() || this.env.GITHUB_TOKEN?.trim();
 
     console.log(
-      `GitHub credential check for ${repoFullName}: tokenFilePresent=${tokenFile.present} tokenFileNonEmpty=${tokenFile.nonEmpty} envTokenPresent=${envTokenPresent}`,
+      `GitHub credential check for ${repoFullName}: tokenFilePresent=${tokenFile.present} tokenFileNonEmpty=${tokenFile.nonEmpty} envTokenPresent=${Boolean(envToken)}`,
     );
 
-    if (tokenFile.nonEmpty || envTokenPresent) {
+    if (tokenFile.nonEmpty) {
+      return;
+    }
+
+    if (envToken) {
+      // The git credential helper and gh wrapper only read the token file;
+      // a token that exists solely as an env var would never reach git and
+      // the clone would still run anonymously.
+      console.log(
+        'GitHub token file is empty; writing the GH_TOKEN/GITHUB_TOKEN env var to the token file for git authentication.',
+      );
+      writeGitHubTokenFile(envToken);
       return;
     }
 
@@ -586,9 +620,8 @@ export class WorkspaceManager {
 
     console.log(`Preparing ${fullName}#${targetBranch}`);
 
-    const repoPath = join(this.workspaceRoot, fullName);
-    const legacyRepoPath = join(
-      this.workspaceRoot,
+    const repoPath = this.resolveContainedWorkspacePath(fullName);
+    const legacyRepoPath = this.resolveContainedWorkspacePath(
       fullName.split('/').pop() ?? fullName,
     );
     let resolvedRepoPath =
@@ -620,7 +653,7 @@ export class WorkspaceManager {
       sourceControlProvider === 'github' &&
       (needsClone || !preserveGitState)
     ) {
-      this.assertGitHubCredentialsAvailable(fullName);
+      this.ensureGitHubCredentialsAvailable(fullName);
     }
 
     if (!needsClone) {


### PR DESCRIPTION
Follow-up to #703 addressing both outstanding review findings.

## Changes

- **Workspace path containment.** Repository full names are provider-synced and reached the clone command's `rm -rf` cleanup and the invalid-directory removal as unvalidated relative paths, so a value with traversal segments (e.g. `../../victim`) could resolve — and delete — outside the workspace root. `prepareRepository` now resolves the canonical and legacy repository paths through a containment check against `workspaceRoot` and rejects any value that escapes it, before any delete, mkdir, or clone.
- **Env token materialization.** The `GH_TOKEN`/`GITHUB_TOKEN` escape hatch in the credential fail-fast was ineffective: the git credential helper, gh wrapper, and token env scripts only read `~/.roomote/gh-token` (and the env script *unsets* `GH_TOKEN` when the file is missing), so an env-only token still produced the anonymous clone retries the check was meant to prevent. When the token file is missing or empty and an env token is present, the worker now writes it to the token file so git actually authenticates with it.

## Testing

- New tests: traversal rejection for both caller-supplied names and synced repository rows, env-token materialization into the token file, and no-op when the file already holds a token.
- `vitest run src/workspace/__tests__/`: 68/68 passing; `tsc --noEmit`, knip, oxlint, and oxfmt all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)