### PR TITLE
Send an instance report on setup completion and membership changes

### DIFF
--- a/apps/web/src/lib/server/__tests__/user-management.test.ts
+++ b/apps/web/src/lib/server/__tests__/user-management.test.ts
@@ -22,6 +22,10 @@ const { state } = vi.hoisted(() => ({
   },
 }));
 
+vi.mock('@roomote/sdk/server/request-instance-ping', () => ({
+  requestInstancePing: vi.fn(async () => undefined),
+}));
+
 vi.mock('../auth', () => ({
   PASSWORD_RESET_TOKEN_EXPIRES_IN_SECONDS: 3600,
   capturePasswordResetLink: async (callback: () => Promise<void>) => {

--- a/apps/web/src/lib/server/auth-context.test.ts
+++ b/apps/web/src/lib/server/auth-context.test.ts
@@ -31,6 +31,10 @@ const {
   },
 }));
 
+vi.mock('@roomote/sdk/server/request-instance-ping', () => ({
+  requestInstancePing: vi.fn(async () => undefined),
+}));
+
 vi.mock('next/headers', () => ({
   headers: vi.fn(async () => new Headers()),
 }));

--- a/apps/web/src/lib/server/auth-context.ts
+++ b/apps/web/src/lib/server/auth-context.ts
@@ -9,6 +9,7 @@ import {
   normalizeMetadataRecord,
 } from '@roomote/feature-flags';
 import { getManagedDeploymentAccessFromMetadata } from '@roomote/types';
+import { requestInstancePing } from '@roomote/sdk/server/request-instance-ping';
 import { isTelemetryEnvAllowed } from '@roomote/telemetry/server';
 
 import {
@@ -209,6 +210,10 @@ async function ensureDeploymentIdentity({
     });
 
     await seedDeploymentAccessPolicyIfNeeded({ userId });
+
+    // A new admission changes the instance's user counts; refresh the
+    // anonymous report instead of waiting for the daily tick.
+    void requestInstancePing('user-admitted');
   } else {
     // Removal deletes the Better Auth user, so a removed user normally can
     // never reach this branch again. If a soft-deleted row's auth user still

--- a/apps/web/src/lib/server/user-management.ts
+++ b/apps/web/src/lib/server/user-management.ts
@@ -11,6 +11,7 @@ import {
   telegramUserMappings,
   users,
 } from '@roomote/db/server';
+import { requestInstancePing } from '@roomote/sdk/server/request-instance-ping';
 import type { UserRole } from '@roomote/types';
 
 import {
@@ -149,7 +150,7 @@ export async function removeUser({
     return { removed: false, reason: 'own_account' };
   }
 
-  return db.transaction(async (tx) => {
+  const result = await db.transaction(async (tx) => {
     await lockDeploymentMembership(tx);
 
     const target = await tx.query.users.findFirst({
@@ -186,6 +187,14 @@ export async function removeUser({
 
     return { removed: true } as const;
   });
+
+  if (result.removed) {
+    // A removal changes the instance's user counts; refresh the anonymous
+    // report instead of waiting for the daily tick.
+    void requestInstancePing('user-removed');
+  }
+
+  return result;
 }
 
 function getPasswordResetRedirectUrl(): string {

--- a/apps/web/src/trpc/commands/setup/index.ts
+++ b/apps/web/src/trpc/commands/setup/index.ts
@@ -17,6 +17,7 @@ import {
   normalizeSetupNewState,
 } from '@roomote/types';
 import { ANONYMOUS_ANALYTICS_METADATA_KEY } from '@roomote/feature-flags';
+import { requestInstancePing } from '@roomote/sdk/server/request-instance-ping';
 import { captureEvent } from '@roomote/telemetry/server';
 import {
   AVAILABLE_SETUP_MCP_INTEGRATIONS,
@@ -460,6 +461,11 @@ export async function completeSetupCommand(
   });
 
   void captureEvent('setup_completed', { userId });
+
+  // Refresh the anonymous instance report now that setup is complete, so the
+  // Ping service sees the founding admin within minutes instead of at the
+  // next daily tick.
+  void requestInstancePing('setup-completed');
 
   return { success: true as const };
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -24,6 +24,10 @@
       "import": "./src/server/lib/slack-conversation-log.ts",
       "require": "./src/server/lib/slack-conversation-log.ts"
     },
+    "./server/request-instance-ping": {
+      "import": "./src/server/lib/request-instance-ping.ts",
+      "require": "./src/server/lib/request-instance-ping.ts"
+    },
     "./server/docker-environment-validation": {
       "import": "./src/server/lib/docker-environment-validation.ts",
       "require": "./src/server/lib/docker-environment-validation.ts"

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -304,3 +304,8 @@ export {
   getLinearDeploymentMetadata,
   getLinearUserMetadata,
 } from './lib/mcp/linear-connections';
+
+export {
+  requestInstancePing,
+  resetInstancePingQueueForTests,
+} from './lib/request-instance-ping';

--- a/packages/sdk/src/server/lib/__tests__/request-instance-ping.test.ts
+++ b/packages/sdk/src/server/lib/__tests__/request-instance-ping.test.ts
@@ -1,0 +1,59 @@
+const mockQueueAdd = vi.fn();
+
+vi.mock('@roomote/redis', () => ({
+  getRedis: () => ({}),
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class MockQueue {
+    add = (...args: unknown[]) => mockQueueAdd(...args);
+  },
+}));
+
+import {
+  requestInstancePing,
+  resetInstancePingQueueForTests,
+} from '../request-instance-ping';
+
+describe('requestInstancePing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-22T21:30:30.000Z'));
+    resetInstancePingQueueForTests();
+    mockQueueAdd.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('enqueues an InstancePing job with a per-minute debounce id', async () => {
+    await requestInstancePing('setup-completed');
+
+    expect(mockQueueAdd).toHaveBeenCalledWith(
+      'InstancePing',
+      { reason: 'setup-completed' },
+      { jobId: `instance-ping-request-${Math.floor(Date.now() / 60_000)}` },
+    );
+  });
+
+  it('collapses bursts within the same minute onto one job id', async () => {
+    await requestInstancePing('user-admitted');
+    vi.advanceTimersByTime(10_000);
+    await requestInstancePing('user-removed');
+
+    const [first, second] = mockQueueAdd.mock.calls;
+    expect(first?.[2]).toEqual(second?.[2]);
+
+    vi.advanceTimersByTime(60_000);
+    await requestInstancePing('user-admitted');
+    expect(mockQueueAdd.mock.calls[2]?.[2]).not.toEqual(first?.[2]);
+  });
+
+  it('swallows enqueue failures so telemetry never breaks the caller', async () => {
+    mockQueueAdd.mockRejectedValueOnce(new Error('redis down'));
+
+    await expect(requestInstancePing('user-admitted')).resolves.toBeUndefined();
+  });
+});

--- a/packages/sdk/src/server/lib/request-instance-ping.ts
+++ b/packages/sdk/src/server/lib/request-instance-ping.ts
@@ -1,0 +1,60 @@
+import { Queue } from 'bullmq';
+
+import { getRedis } from '@roomote/redis';
+
+/**
+ * The bullmq scheduled-jobs queue and the InstancePing job name it
+ * dispatches on (apps/bullmq ScheduledJobName.InstancePing). Duplicated as
+ * literals because the enum lives in the bullmq app, which the SDK cannot
+ * depend on.
+ */
+const SCHEDULED_JOBS_QUEUE = 'scheduled-jobs';
+const INSTANCE_PING_JOB = 'InstancePing';
+
+let queue: Queue | null = null;
+
+function getQueue(): Queue {
+  if (!queue) {
+    queue = new Queue(SCHEDULED_JOBS_QUEUE, {
+      connection: getRedis(),
+      defaultJobOptions: {
+        attempts: 1,
+        removeOnComplete: { age: 3600, count: 10 },
+        removeOnFail: { age: 3600 },
+      },
+    });
+  }
+
+  return queue;
+}
+
+/** Test seam: drop the memoized queue so a fresh connection is created. */
+export function resetInstancePingQueueForTests(): void {
+  queue = null;
+}
+
+/**
+ * Requests an immediate anonymous instance report instead of waiting for the
+ * daily InstancePing tick. Used after moments that change what the report
+ * says — setup completion and user admission — so a fresh deployment's user
+ * count reaches the Ping service within minutes rather than a day.
+ *
+ * Fire-and-forget: bursts collapse onto a per-minute job id, a single
+ * attempt is enough (the daily schedule is the safety net), and failures are
+ * swallowed because telemetry must never break signup or setup.
+ */
+export async function requestInstancePing(reason: string): Promise<void> {
+  try {
+    const minuteBucket = Math.floor(Date.now() / 60_000);
+    await getQueue().add(
+      INSTANCE_PING_JOB,
+      { reason },
+      { jobId: `instance-ping-request-${minuteBucket}` },
+    );
+  } catch (error) {
+    console.warn(
+      `[requestInstancePing] failed to enqueue (reason=${reason}):`,
+      error instanceof Error ? error.message : error,
+    );
+  }
+}


### PR DESCRIPTION
## Why

The anonymous instance report (which carries user counts to the Ping service) only runs on the daily `InstancePing` tick. A fresh deployment therefore reports **0 users** from its provisioning-moment snapshot — before anyone completes setup — and stays stale for up to a day after the founding admin signs in. (Observed on the Roomote Cloud staging fleet: every tenant reported `users.total: 0` even with an admin account present, because each report predated the account.)

## Change

New SDK helper `requestInstancePing(reason)` enqueues a one-off `InstancePing` job on the existing `scheduled-jobs` queue (same dispatch path as the daily tick), called from:

- **Setup completion** (`completeSetupCommand`)
- **New user admission** (`provisionUser`'s new-user branch in auth-context)
- **User removal** (`removeUser`, only when a row was actually removed)

Properties:
- **Debounced** — bursts collapse onto a per-minute `jobId`
- **Single attempt** — the daily schedule remains the safety net
- **Fire-and-forget** — enqueue failures are swallowed; telemetry can never break signup, setup, or removal
- All existing gates still apply (the job itself checks `isTelemetryEnvAllowed` + the admin analytics opt-out)

## Tests

Unit tests for the helper: job name/payload/debounce id, same-minute collapse vs next-minute new id, and error swallowing. Typecheck clean for sdk + web. (The two `--max-warnings=0` lint warnings in sdk are pre-existing in untouched files.)