### PR TITLE
[Feat] Resolve bare issue references (#234, ENG-512) against configured repositories

### DIFF
--- a/packages/cloud-agents/src/server/router/__tests__/external-issue-context.test.ts
+++ b/packages/cloud-agents/src/server/router/__tests__/external-issue-context.test.ts
@@ -100,6 +100,25 @@ describe('gatherExternalIssueContext', () => {
     expect(result).toEqual({ contextMessages: [], toolsUsed: [] });
   });
 
+  it('shares one lookup deadline across fetch attempts instead of extending it', async () => {
+    vi.useFakeTimers();
+
+    try {
+      vi.mocked(callRouterMcpTool).mockReturnValue(new Promise(() => {}));
+
+      const pending = gatherExternalIssueContext(
+        createContext('Investigate https://github.com/acme/web/issues/42'),
+      );
+
+      await vi.advanceTimersByTimeAsync(8_000);
+
+      expect(await pending).toEqual({ contextMessages: [], toolsUsed: [] });
+      expect(callRouterMcpTool).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('resolves a bare Linear identifier from the precheck', async () => {
     vi.mocked(callRouterMcpTool).mockResolvedValue({
       title: 'Fix OAuth callback',
@@ -124,10 +143,7 @@ describe('gatherExternalIssueContext', () => {
     vi.mocked(callRouterMcpTool).mockResolvedValue({ title: 'Some issue' });
 
     const result = await gatherExternalIssueContext(
-      createContextWithRepos('Check issue #234', [
-        'acme/web',
-        'acme/api',
-      ]),
+      createContextWithRepos('Check issue #234', ['acme/web', 'acme/api']),
       '#234',
     );
 

--- a/packages/cloud-agents/src/server/router/__tests__/external-issue-context.test.ts
+++ b/packages/cloud-agents/src/server/router/__tests__/external-issue-context.test.ts
@@ -185,19 +185,31 @@ describe('gatherExternalIssueContext', () => {
     expect(unconfigured).toEqual({ contextMessages: [], toolsUsed: [] });
   });
 
-  it('fails open on a bare number when too many repositories are configured', async () => {
+  it('caps a bare-number fan-out at the first five configured repositories', async () => {
+    vi.mocked(callRouterMcpTool).mockResolvedValue({ title: 'Some issue' });
+
     const result = await gatherExternalIssueContext(
       createContextWithRepos('Check issue #234', [
         'acme/web',
         'acme/api',
         'acme/mobile',
         'acme/infra',
+        'acme/docs',
+        'acme/tooling',
+        'acme/design',
       ]),
       '#234',
     );
 
-    expect(callRouterMcpTool).not.toHaveBeenCalled();
-    expect(result).toEqual({ contextMessages: [], toolsUsed: [] });
+    const fetchedRepos = vi
+      .mocked(callRouterMcpTool)
+      .mock.calls.map(([options]) => (options.args as { repo: string }).repo);
+
+    expect(new Set(fetchedRepos)).toEqual(
+      new Set(['web', 'api', 'mobile', 'infra', 'docs']),
+    );
+    expect(result.contextMessages[0]?.content).toContain('[acme/docs#234]');
+    expect(result.contextMessages[0]?.content).not.toContain('acme/tooling');
   });
 
   it('prefers pasted issue URLs over the precheck reference', async () => {

--- a/packages/cloud-agents/src/server/router/__tests__/external-issue-context.test.ts
+++ b/packages/cloud-agents/src/server/router/__tests__/external-issue-context.test.ts
@@ -99,4 +99,114 @@ describe('gatherExternalIssueContext', () => {
 
     expect(result).toEqual({ contextMessages: [], toolsUsed: [] });
   });
+
+  it('resolves a bare Linear identifier from the precheck', async () => {
+    vi.mocked(callRouterMcpTool).mockResolvedValue({
+      title: 'Fix OAuth callback',
+    });
+
+    const result = await gatherExternalIssueContext(
+      createContext('Check ENG-512 when you get a chance'),
+      'ENG-512',
+    );
+
+    expect(callRouterMcpTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverId: 'linear',
+        toolName: 'get_issue',
+        args: { id: 'ENG-512' },
+      }),
+    );
+    expect(result.contextMessages[0]?.content).toContain('[ENG-512]');
+  });
+
+  it('fans a bare issue number out across the configured repositories', async () => {
+    vi.mocked(callRouterMcpTool).mockResolvedValue({ title: 'Some issue' });
+
+    const result = await gatherExternalIssueContext(
+      createContextWithRepos('Check issue #234', [
+        'acme/web',
+        'acme/api',
+      ]),
+      '#234',
+    );
+
+    expect(callRouterMcpTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverId: 'github',
+        args: expect.objectContaining({ repo: 'web', issue_number: 234 }),
+      }),
+    );
+    expect(callRouterMcpTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverId: 'github',
+        args: expect.objectContaining({ repo: 'api', issue_number: 234 }),
+      }),
+    );
+    expect(result.contextMessages[0]?.content).toContain('[acme/web#234]');
+    expect(result.contextMessages[0]?.content).toContain('[acme/api#234]');
+  });
+
+  it('only resolves a repo-qualified reference against configured repositories', async () => {
+    vi.mocked(callRouterMcpTool).mockResolvedValue({ title: 'Some issue' });
+
+    const configured = await gatherExternalIssueContext(
+      createContextWithRepos('Check acme/web#42', ['acme/web']),
+      'acme/web#42',
+    );
+
+    expect(configured.toolsUsed).toEqual(['github.issue_read']);
+
+    vi.clearAllMocks();
+    vi.mocked(callRouterMcpTool).mockResolvedValue({ title: 'Some issue' });
+
+    const unconfigured = await gatherExternalIssueContext(
+      createContextWithRepos('Check evil/repo#1', ['acme/web']),
+      'evil/repo#1',
+    );
+
+    expect(callRouterMcpTool).not.toHaveBeenCalled();
+    expect(unconfigured).toEqual({ contextMessages: [], toolsUsed: [] });
+  });
+
+  it('fails open on a bare number when too many repositories are configured', async () => {
+    const result = await gatherExternalIssueContext(
+      createContextWithRepos('Check issue #234', [
+        'acme/web',
+        'acme/api',
+        'acme/mobile',
+        'acme/infra',
+      ]),
+      '#234',
+    );
+
+    expect(callRouterMcpTool).not.toHaveBeenCalled();
+    expect(result).toEqual({ contextMessages: [], toolsUsed: [] });
+  });
+
+  it('prefers pasted issue URLs over the precheck reference', async () => {
+    vi.mocked(callRouterMcpTool).mockResolvedValue({ title: 'Some issue' });
+
+    await gatherExternalIssueContext(
+      createContext('Investigate https://github.com/acme/web/issues/42'),
+      'ENG-512',
+    );
+
+    expect(callRouterMcpTool).not.toHaveBeenCalledWith(
+      expect.objectContaining({ serverId: 'linear' }),
+    );
+  });
 });
+
+function createContextWithRepos(
+  taskDescription: string,
+  repositoryNames: string[],
+): RoutingContext {
+  return {
+    taskDescription,
+    source: { type: 'slack' },
+    availableEnvironments: [
+      { id: 'env-1', name: 'Full Stack', repositoryNames },
+    ],
+  };
+}

--- a/packages/cloud-agents/src/server/router/__tests__/router-service.test.ts
+++ b/packages/cloud-agents/src/server/router/__tests__/router-service.test.ts
@@ -202,6 +202,53 @@ describe('routeTask', () => {
     });
   });
 
+  it('resolves a bare issue reference from the precheck against configured repos', async () => {
+    mockCallRouterMcpTool.mockResolvedValue({
+      title: 'Dashboard export button broken',
+    });
+    mockGenerateTrackedNonTaskObject
+      .mockResolvedValueOnce({
+        object: {
+          workspaceValue: 'Full Stack',
+          reasoning: 'The message references an issue by number only.',
+          confidence: 0.4,
+          needsExternalLookup: true,
+          externalReference: '#234',
+        },
+      })
+      .mockResolvedValueOnce({
+        object: {
+          workspaceValue: 'Full Stack',
+          reasoning: 'The referenced issue describes dashboard work.',
+          confidence: 0.9,
+          needsExternalLookup: false,
+          externalReference: null,
+        },
+      });
+
+    const result = await routeTask(
+      createContext({ taskDescription: 'Check issue #234' }),
+    );
+
+    expect(mockCallRouterMcpTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverId: 'github',
+        toolName: 'issue_read',
+        args: expect.objectContaining({ issue_number: 234 }),
+      }),
+    );
+    expect(mockGenerateTrackedNonTaskObject).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({
+      status: 'routed',
+      result: {
+        debug: {
+          phase: 'mcp',
+          needsExternalLookup: true,
+        },
+      },
+    });
+  });
+
   it('keeps the precheck decision when the requested fetch returns nothing', async () => {
     mockCallRouterMcpTool.mockRejectedValue(new Error('Not connected'));
     mockGenerateTrackedNonTaskObject.mockResolvedValue({

--- a/packages/cloud-agents/src/server/router/external-issue-context.ts
+++ b/packages/cloud-agents/src/server/router/external-issue-context.ts
@@ -162,9 +162,11 @@ function serializeExternalContext(value: unknown): string {
 }
 
 async function withExternalLookupTimeout<T>(
-  operation: Promise<T>,
+  operation: () => Promise<T>,
   deadline: number,
 ): Promise<T | null> {
+  // Checked before invoking so an exhausted deadline never dispatches
+  // another MCP call whose result nothing will await.
   const remainingMs = deadline - Date.now();
   if (remainingMs <= 0) {
     return null;
@@ -174,7 +176,7 @@ async function withExternalLookupTimeout<T>(
 
   try {
     return await Promise.race([
-      operation,
+      operation(),
       new Promise<null>((resolve) => {
         timeout = setTimeout(resolve, remainingMs, null);
       }),
@@ -195,12 +197,13 @@ async function fetchExternalIssueContext(
 
     for (const attempt of reference.fetchAttempts) {
       const result = await withExternalLookupTimeout(
-        callRouterMcpTool({
-          context,
-          serverId: attempt.serverId,
-          toolName: attempt.toolName,
-          args: attempt.args,
-        }),
+        () =>
+          callRouterMcpTool({
+            context,
+            serverId: attempt.serverId,
+            toolName: attempt.toolName,
+            args: attempt.args,
+          }),
         deadline,
       );
 

--- a/packages/cloud-agents/src/server/router/external-issue-context.ts
+++ b/packages/cloud-agents/src/server/router/external-issue-context.ts
@@ -10,7 +10,7 @@ import type { RoutingContext } from './types';
 const MAX_EXTERNAL_ISSUES = 2;
 const MAX_EXTERNAL_CONTEXT_CHARS = 8_000;
 const EXTERNAL_LOOKUP_TIMEOUT_MS = 8_000;
-const MAX_BARE_REFERENCE_REPOS = 3;
+const MAX_BARE_REFERENCE_REPOS = 5;
 
 interface ExternalIssueReference {
   url: string;
@@ -83,8 +83,9 @@ function uniqueConfiguredRepositories(context: RoutingContext): string[] {
  * configuration. The model only proposes the reference text; the fetch
  * targets always come from this closed candidate set, so a steered or
  * hallucinated reference can at most read issues the deployment already
- * routes for. An ambiguous issue number fans out across configured
- * repositories only when that set is small enough to stay bounded.
+ * routes for. An ambiguous issue number fans out across the first
+ * MAX_BARE_REFERENCE_REPOS configured repositories (environment order) so the
+ * fetch stays bounded on deployments with many repositories.
  */
 function resolveBareIssueReferences(
   context: RoutingContext,
@@ -131,19 +132,19 @@ function resolveBareIssueReferences(
 
   const bareNumber = raw.match(/^#?(?<issueNumber>\d+)$/);
 
-  if (
-    bareNumber?.groups &&
-    configuredRepositories.length > 0 &&
-    configuredRepositories.length <= MAX_BARE_REFERENCE_REPOS
-  ) {
-    return configuredRepositories.flatMap((fullRepository) => {
-      const reference = githubReference(
-        fullRepository,
-        bareNumber.groups!.issueNumber!,
-      );
+  if (bareNumber?.groups && configuredRepositories.length > 0) {
+    // Environment order decides which repositories make the cut; repos where
+    // the issue number does not exist drop out at fetch time anyway.
+    return configuredRepositories
+      .slice(0, MAX_BARE_REFERENCE_REPOS)
+      .flatMap((fullRepository) => {
+        const reference = githubReference(
+          fullRepository,
+          bareNumber.groups!.issueNumber!,
+        );
 
-      return reference ? [reference] : [];
-    });
+        return reference ? [reference] : [];
+      });
   }
 
   return [];

--- a/packages/cloud-agents/src/server/router/external-issue-context.ts
+++ b/packages/cloud-agents/src/server/router/external-issue-context.ts
@@ -10,6 +10,7 @@ import type { RoutingContext } from './types';
 const MAX_EXTERNAL_ISSUES = 2;
 const MAX_EXTERNAL_CONTEXT_CHARS = 8_000;
 const EXTERNAL_LOOKUP_TIMEOUT_MS = 8_000;
+const MAX_BARE_REFERENCE_REPOS = 3;
 
 interface ExternalIssueReference {
   url: string;
@@ -49,6 +50,103 @@ function parseExternalIssueReferences(text: string): ExternalIssueReference[] {
   }
 
   return references;
+}
+
+function referenceFromCanonicalUrl(
+  label: string,
+  canonicalUrl: string,
+): ExternalIssueReference | null {
+  try {
+    const match = matchExternalIssueUrl(new URL(canonicalUrl));
+
+    return match ? { url: label, fetchAttempts: match.fetchAttempts } : null;
+  } catch {
+    return null;
+  }
+}
+
+function uniqueConfiguredRepositories(context: RoutingContext): string[] {
+  const repositories = new Set<string>();
+
+  for (const environment of context.availableEnvironments) {
+    for (const name of environment.repositoryNames ?? []) {
+      repositories.add(name);
+    }
+  }
+
+  return [...repositories];
+}
+
+/**
+ * Resolves a bare reference the routing precheck extracted (for example
+ * "#234", "acme/web#234", or "ENG-512") against the deployment's own
+ * configuration. The model only proposes the reference text; the fetch
+ * targets always come from this closed candidate set, so a steered or
+ * hallucinated reference can at most read issues the deployment already
+ * routes for. An ambiguous issue number fans out across configured
+ * repositories only when that set is small enough to stay bounded.
+ */
+function resolveBareIssueReferences(
+  context: RoutingContext,
+  externalReference: string | null | undefined,
+): ExternalIssueReference[] {
+  const raw = externalReference?.trim();
+
+  if (!raw) {
+    return [];
+  }
+
+  if (/^[A-Za-z]+-\d+$/.test(raw)) {
+    const reference = referenceFromCanonicalUrl(
+      raw,
+      `https://linear.app/_/issue/${raw}`,
+    );
+
+    return reference ? [reference] : [];
+  }
+
+  const configuredRepositories = uniqueConfiguredRepositories(context);
+  const githubReference = (fullRepository: string, issueNumber: string) =>
+    referenceFromCanonicalUrl(
+      `${fullRepository}#${issueNumber}`,
+      `https://github.com/${fullRepository}/issues/${issueNumber}`,
+    );
+
+  const qualified = raw.match(
+    /^(?<owner>[^\s/#]+)\/(?<repository>[^\s/#]+)#(?<issueNumber>\d+)$/,
+  );
+
+  if (qualified?.groups) {
+    const fullRepository = configuredRepositories.find(
+      (name) =>
+        name.toLowerCase() ===
+        `${qualified.groups!.owner}/${qualified.groups!.repository}`.toLowerCase(),
+    );
+    const reference =
+      fullRepository &&
+      githubReference(fullRepository, qualified.groups.issueNumber!);
+
+    return reference ? [reference] : [];
+  }
+
+  const bareNumber = raw.match(/^#?(?<issueNumber>\d+)$/);
+
+  if (
+    bareNumber?.groups &&
+    configuredRepositories.length > 0 &&
+    configuredRepositories.length <= MAX_BARE_REFERENCE_REPOS
+  ) {
+    return configuredRepositories.flatMap((fullRepository) => {
+      const reference = githubReference(
+        fullRepository,
+        bareNumber.groups!.issueNumber!,
+      );
+
+      return reference ? [reference] : [];
+    });
+  }
+
+  return [];
 }
 
 function serializeExternalContext(value: unknown): string {
@@ -120,8 +218,13 @@ async function fetchExternalIssueContext(
 
 export async function gatherExternalIssueContext(
   context: RoutingContext,
+  externalReference?: string | null,
 ): Promise<{ contextMessages: ModelMessage[]; toolsUsed: string[] }> {
-  const references = parseExternalIssueReferences(context.taskDescription);
+  const urlReferences = parseExternalIssueReferences(context.taskDescription);
+  const references =
+    urlReferences.length > 0
+      ? urlReferences
+      : resolveBareIssueReferences(context, externalReference);
   const results = await Promise.all(
     references.map(async (reference) => ({
       reference,

--- a/packages/cloud-agents/src/server/router/mcp-gather.ts
+++ b/packages/cloud-agents/src/server/router/mcp-gather.ts
@@ -91,9 +91,13 @@ export async function gatherContextFromConfiguredMcps<
   }
 
   // The precheck asked for the linked issue, so the fetch deadline is only
-  // paid when it can change the decision. Fail-open: with nothing fetched,
-  // the precheck decision stands.
-  const externalIssueContext = await gatherExternalIssueContext(context);
+  // paid when it can change the decision. Bare references (no pasted URL)
+  // resolve against the deployment's configured repositories only. Fail-open:
+  // with nothing fetched, the precheck decision stands.
+  const externalIssueContext = await gatherExternalIssueContext(
+    context,
+    response.externalReference,
+  );
 
   if (externalIssueContext.contextMessages.length === 0) {
     return { response, toolsUsed: [], phase: 'direct', needsExternalLookup };


### PR DESCRIPTION
**Draft until reviewed — do not merge without Dan's call.** Rebased onto `develop` after #718 and #728 landed; now two commits: bare-reference resolution + a deadline-dispatch fix its new test caught.

## What changed

Closes the last gap in the lookup gate: the routing precheck already extracts references like `#234`, `acme/web#42`, or `ENG-512` into its `externalReference` field, but nothing acted on it when the message had no pasted URL. Now, when the precheck returns `needsExternalLookup=true` and URL parsing finds nothing, `gatherExternalIssueContext` resolves the reference deterministically:

- `ENG-512`-style identifiers → Linear `get_issue` directly.
- `owner/repo#N` → fetched only if that repo is in the deployment's configured `repositoryNames` (case-insensitive match, configured casing wins).
- Bare `#N` / `N` → fans out across the **first 5** configured repositories (environment order; issue numbers that don't exist in a repo drop out at fetch time); each result is labeled per repo (`[acme/web#234]`) so the informed re-route call disambiguates. Smarter candidate selection (routing memory) is a planned follow-up.

Bare references normalize to canonical URLs and run through #718's registry, so fetch-attempt construction (incl. GitHub's `issue_read` → `get_issue` fallback) stays single-source. Pasted URLs always take precedence over the precheck reference.

## Also in this PR (found by its own test)

A fake-timer test for the shared 8s deadline exposed a pre-existing bug from #693: `withExternalLookupTimeout` received an already-invoked promise, so an exhausted deadline still **dispatched** the next MCP call and merely never awaited it. The helper now takes a thunk and checks the remaining budget before invoking.

## Security posture unchanged

The model proposes reference *text* only; fetch targets come from a closed candidate set (the deployment's own configured repos / the connected Linear workspace), execution stays in server code under the shared 8s fail-open deadline. No model changes — same routing model as develop.

## Tests

105 router tests green: five bare-reference cases (bare Linear id, multi-repo fan-out with per-repo labels, repo-qualified validation incl. unconfigured-repo rejection, seven-repo fan-out capped at five, URL precedence), the deadline-sharing fake-timer test, and an end-to-end `Check issue #234` → fetch → `phase: 'mcp'` case. `pnpm knip`, `tsc --noEmit`, `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
