### PR TITLE
[Fix] Drop emoji from PR review action copy

### DIFF
--- a/apps/api/src/handlers/discord/pr-review-action.ts
+++ b/apps/api/src/handlers/discord/pr-review-action.ts
@@ -91,8 +91,8 @@ export async function handleDiscordPrReviewActionCallback(input: {
 
     await reply(
       input.choice === 'auto'
-        ? '⚡ Auto-handling enabled — future review feedback on this PR lands in this task automatically. Taking a look at the current feedback now.'
-        : '✅ On it — taking a look at the review feedback.',
+        ? 'Auto-handling enabled — future review feedback on this PR lands in this task automatically. Taking a look at the current feedback now.'
+        : 'On it — taking a look at the review feedback.',
     );
   } catch (error) {
     apiLogger.error(

--- a/apps/api/src/handlers/slack/dispatch/pr-review-action.ts
+++ b/apps/api/src/handlers/slack/dispatch/pr-review-action.ts
@@ -234,8 +234,8 @@ async function dispatchAcceptedPrReviewAction({
   }
 
   const resolution = enableAutoHandle
-    ? `:zap: Auto-handling enabled by <@${payload.user.id}> — future review feedback on this PR lands in this task automatically.`
-    : `:white_check_mark: On it — requested by <@${payload.user.id}>.`;
+    ? `Auto-handling enabled by <@${payload.user.id}> — future review feedback on this PR lands in this task automatically.`
+    : `On it — requested by <@${payload.user.id}>.`;
 
   await updateNotificationMessage({ payload, resolution });
 }

--- a/apps/api/src/handlers/telegram/pr-review-action.ts
+++ b/apps/api/src/handlers/telegram/pr-review-action.ts
@@ -130,8 +130,8 @@ export async function handleTelegramPrReviewActionCallback(params: {
           replyToMessageId: messageId,
           text:
             choice === 'auto'
-              ? '⚡ Auto-handling enabled — future review feedback on this PR lands in this task automatically. Taking a look at the current feedback now.'
-              : '✅ On it — taking a look at the review feedback.',
+              ? 'Auto-handling enabled — future review feedback on this PR lands in this task automatically. Taking a look at the current feedback now.'
+              : 'On it — taking a look at the review feedback.',
         });
       }
     }

--- a/apps/bullmq/src/jobs/pr-review-notification.ts
+++ b/apps/bullmq/src/jobs/pr-review-notification.ts
@@ -329,7 +329,7 @@ export const prReviewNotificationJob = async (
       });
 
       if (dispatched.outcome !== 'unavailable') {
-        const autoText = `⚡ Auto-handling new review feedback:
+        const autoText = `Auto-handling new review feedback:
 ${delivery.text}`;
         const messageTs = await postPrReviewNotification({
           taskId: data.taskId,


### PR DESCRIPTION
Removes the ⚡/✅ decorations from the auto-handle and acceptance messages across Slack, Discord, and Telegram so the notifications read more like a teammate and less like a bot. Copy only; both affected test files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)