### PR TITLE
[Revert] Router lookup gate and Gemini routing default (#716)

### DIFF
--- a/packages/cloud-agents/src/server/router/__tests__/router-service.test.ts
+++ b/packages/cloud-agents/src/server/router/__tests__/router-service.test.ts
@@ -80,7 +80,7 @@ describe('routeTask', () => {
     expect(mockGenerateTrackedNonTaskObject).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: undefined,
-        model: 'google/gemini-3.6-flash',
+        model: undefined,
         system: expect.stringContaining(
           'You are a workspace routing assistant',
         ),
@@ -106,30 +106,20 @@ describe('routeTask', () => {
     });
   });
 
-  it('fetches pasted GitHub issue context when the precheck asks for it', async () => {
+  it('uses pasted GitHub issue context when choosing a workspace', async () => {
     mockCallRouterMcpTool.mockResolvedValue({
       title: 'Fix the dashboard refresh failure',
       body: 'The dashboard API request belongs to the web application.',
     });
-    mockGenerateTrackedNonTaskObject
-      .mockResolvedValueOnce({
-        object: {
-          workspaceValue: 'Full Stack',
-          reasoning: 'The message alone does not identify the workspace.',
-          confidence: 0.4,
-          needsExternalLookup: true,
-          externalReference: 'acme/web#42',
-        },
-      })
-      .mockResolvedValueOnce({
-        object: {
-          workspaceValue: 'Full Stack',
-          reasoning: 'The linked issue describes the web application.',
-          confidence: 0.92,
-          needsExternalLookup: false,
-          externalReference: null,
-        },
-      });
+    mockGenerateTrackedNonTaskObject.mockResolvedValue({
+      object: {
+        workspaceValue: 'Full Stack',
+        reasoning: 'The linked issue describes the web application.',
+        confidence: 0.92,
+        needsExternalLookup: false,
+        externalReference: null,
+      },
+    });
 
     const result = await routeTask(
       createContext({
@@ -152,8 +142,7 @@ describe('routeTask', () => {
         issue_number: 42,
       },
     });
-    expect(mockGenerateTrackedNonTaskObject).toHaveBeenCalledTimes(2);
-    expect(mockGenerateTrackedNonTaskObject).toHaveBeenLastCalledWith(
+    expect(mockGenerateTrackedNonTaskObject).toHaveBeenCalledWith(
       expect.objectContaining({
         prompt: expect.stringContaining('Fix the dashboard refresh failure'),
       }),
@@ -164,71 +153,6 @@ describe('routeTask', () => {
         debug: {
           phase: 'mcp',
           toolsUsed: ['github.issue_read'],
-          needsExternalLookup: true,
-        },
-      },
-    });
-  });
-
-  it('skips the issue fetch when the precheck routes without external context', async () => {
-    mockGenerateTrackedNonTaskObject.mockResolvedValue({
-      object: {
-        workspaceValue: 'Full Stack',
-        reasoning: 'The message already identifies the dashboard work.',
-        confidence: 0.95,
-        needsExternalLookup: false,
-        externalReference: null,
-      },
-    });
-
-    const result = await routeTask(
-      createContext({
-        taskDescription:
-          'Fix the dashboard refresh bug, context: https://github.com/acme/web/issues/42',
-      }),
-    );
-
-    expect(mockCallRouterMcpTool).not.toHaveBeenCalled();
-    expect(mockGenerateTrackedNonTaskObject).toHaveBeenCalledTimes(1);
-    expect(result).toMatchObject({
-      status: 'routed',
-      result: {
-        debug: {
-          phase: 'direct',
-          toolsUsed: [],
-          needsExternalLookup: false,
-        },
-      },
-    });
-  });
-
-  it('keeps the precheck decision when the requested fetch returns nothing', async () => {
-    mockCallRouterMcpTool.mockRejectedValue(new Error('Not connected'));
-    mockGenerateTrackedNonTaskObject.mockResolvedValue({
-      object: {
-        workspaceValue: 'Full Stack',
-        reasoning: 'Best guess without the linked issue.',
-        confidence: 0.4,
-        needsExternalLookup: true,
-        externalReference: 'acme/web#42',
-      },
-    });
-
-    const result = await routeTask(
-      createContext({
-        taskDescription:
-          'Please investigate https://github.com/acme/web/issues/42',
-      }),
-    );
-
-    expect(mockGenerateTrackedNonTaskObject).toHaveBeenCalledTimes(1);
-    expect(result).toMatchObject({
-      status: 'routed',
-      result: {
-        debug: {
-          phase: 'direct',
-          toolsUsed: [],
-          needsExternalLookup: true,
         },
       },
     });

--- a/packages/cloud-agents/src/server/router/mcp-gather.ts
+++ b/packages/cloud-agents/src/server/router/mcp-gather.ts
@@ -66,48 +66,28 @@ export async function gatherContextFromConfiguredMcps<
     z.infer<TSubmitRoutingDecisionSchema> & LookupAwareRoutingResponse
   >
 > {
-  const generateRoutingDecision = async (messages: ModelMessage[]) => {
-    const { object } = await generateTrackedNonTaskObject({
-      userId: context.routingActor?.userId,
-      surface: NON_TASK_INFERENCE_SURFACES.routerTaskRouting,
-      model: routingModel,
-      schema: submitRoutingDecisionSchema,
-      system: routingPrompt,
-      prompt: serializeContextMessages(messages),
-    });
-
-    return object as z.infer<TSubmitRoutingDecisionSchema> &
-      LookupAwareRoutingResponse;
-  };
-
-  const response = await generateRoutingDecision(contextMessages);
-  const needsExternalLookup =
-    typeof response.needsExternalLookup === 'boolean'
-      ? response.needsExternalLookup
-      : null;
-
-  if (needsExternalLookup !== true) {
-    return { response, toolsUsed: [], phase: 'direct', needsExternalLookup };
-  }
-
-  // The precheck asked for the linked issue, so the fetch deadline is only
-  // paid when it can change the decision. Fail-open: with nothing fetched,
-  // the precheck decision stands.
   const externalIssueContext = await gatherExternalIssueContext(context);
-
-  if (externalIssueContext.contextMessages.length === 0) {
-    return { response, toolsUsed: [], phase: 'direct', needsExternalLookup };
-  }
-
-  const informedResponse = await generateRoutingDecision([
-    ...contextMessages,
-    ...externalIssueContext.contextMessages,
-  ]);
+  const { object } = await generateTrackedNonTaskObject({
+    userId: context.routingActor?.userId,
+    surface: NON_TASK_INFERENCE_SURFACES.routerTaskRouting,
+    model: routingModel,
+    schema: submitRoutingDecisionSchema,
+    system: routingPrompt,
+    prompt: serializeContextMessages([
+      ...contextMessages,
+      ...externalIssueContext.contextMessages,
+    ]),
+  });
+  const response = object as z.infer<TSubmitRoutingDecisionSchema> &
+    LookupAwareRoutingResponse;
 
   return {
-    response: informedResponse,
+    response,
     toolsUsed: externalIssueContext.toolsUsed,
-    phase: 'mcp',
-    needsExternalLookup: true,
+    phase: externalIssueContext.toolsUsed.length > 0 ? 'mcp' : 'direct',
+    needsExternalLookup:
+      typeof response.needsExternalLookup === 'boolean'
+        ? response.needsExternalLookup
+        : null,
   };
 }

--- a/packages/cloud-agents/src/server/router/router-service.ts
+++ b/packages/cloud-agents/src/server/router/router-service.ts
@@ -19,7 +19,7 @@ import type {
   RoutingTaskModelSelection,
   WorkspaceResponse,
 } from './types';
-import { resolveRoutingModel, PLATFORM_WORKSPACE_VALUE } from './types';
+import { R_SMALL_MODEL_LABEL, PLATFORM_WORKSPACE_VALUE } from './types';
 import { gatherContextFromConfiguredMcps } from './mcp-gather';
 import { callRouterMcpTool } from './mcp-tool-call';
 import { FOLLOWUP_PROMPT } from './prompts/followup-prompt';
@@ -331,7 +331,7 @@ async function runRoutingDecision(
     forceDisablePlatformWorkspace?: boolean;
   },
 ): Promise<InternalRoutingResult> {
-  const routingModel = resolveRoutingModel(context.routingModel);
+  const routingModel = context.routingModel?.trim() || R_SMALL_MODEL_LABEL;
 
   try {
     const promptContext = context;
@@ -345,7 +345,7 @@ async function runRoutingDecision(
 
     const responseResult = await gatherContextFromConfiguredMcps(
       promptContext,
-      routingModel,
+      context.routingModel?.trim(),
       routingPrompt,
       contextMessages,
       workspaceResponseSchema,
@@ -582,7 +582,7 @@ export async function routeTask(
 export async function routeGitHubTask(
   context: RoutingContext,
 ): Promise<GitHubRoutingDecision> {
-  const routingModel = resolveRoutingModel(context.routingModel);
+  const routingModel = context.routingModel?.trim() || R_SMALL_MODEL_LABEL;
 
   if (context.source.type !== 'github') {
     return {
@@ -600,7 +600,7 @@ export async function routeGitHubTask(
     const { object: response } = await generateTrackedNonTaskObject({
       userId: context.routingActor?.userId,
       surface: NON_TASK_INFERENCE_SURFACES.routerGitHubRouting,
-      model: routingModel,
+      model: context.routingModel?.trim(),
       schema: gitHubRoutingResponseSchema,
       system: buildGitHubRoutingPrompt(),
       prompt: JSON.stringify(buildContextMessages(context), null, 2),

--- a/packages/cloud-agents/src/server/router/types.ts
+++ b/packages/cloud-agents/src/server/router/types.ts
@@ -20,23 +20,6 @@ export const LINEAR_AUTO_CONFIRM_TIMEOUT_MS = 120_000;
 export const R_SMALL_MODEL_LABEL = 'roomote-small-model';
 
 /**
- * Default model for workspace-routing inference. Routing is a
- * latency-sensitive precheck that also gates the external issue fetch, so it
- * needs a model that asks for a lookup only when the message alone cannot
- * route. An explicit context.routingModel wins, then the R_ROUTER_MODEL
- * deployment override, then this default.
- */
-const DEFAULT_ROUTING_MODEL = 'google/gemini-3.6-flash';
-
-export function resolveRoutingModel(explicitModel?: string): string {
-  return (
-    explicitModel?.trim() ||
-    process.env.R_ROUTER_MODEL?.trim() ||
-    DEFAULT_ROUTING_MODEL
-  );
-}
-
-/**
  * Maximum length for task descriptions to prevent excessive token usage.
  */
 export const MAX_TASK_DESCRIPTION_LENGTH = 2000;


### PR DESCRIPTION
Reverts #716 (squash a3d79780) after routing degraded in production: a plain "Review the README in the Roomote repo" request fell through to the manual environment picker instead of routing confidently.

Restores the pre-#716 behavior: unconditional issue fetch from #693 and routing on the deployment small model (`R_SMALL_MODEL`). #718's registry refactor is untouched (no file overlap) and #722 stays unmerged.

Leading theory (debugging in parallel): the `google/gemini-3.6-flash` default doesn't resolve through the deployment's OpenCode provider config (`splitOpenCodeModelId` → provider `google`, which may not be registered — the eval validated the model via OpenRouter directly, not through the production provider path). If confirmed, the model call throws, `routeTask` catches, and every route degrades to `fallback` → manual picker, which matches the screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)