### PR TITLE
Notify production Cloud on main image builds

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -532,3 +532,37 @@ jobs:
             -f "client_payload[image_tag]=${IMAGE_TAG}" \
             -f "client_payload[sha]=${GITHUB_SHA}" \
             -f "client_payload[ref]=${GITHUB_REF}"
+
+  # Production Cloud rolls its tenant fleet from immutable main builds the
+  # same way staging follows develop builds. The Cloud-side workflow
+  # validates the tag against the commit before touching anything.
+  notify-production-cloud:
+    name: Notify production Cloud
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+      - publish
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.ROOMOTE_CLOUD_REPO != '' }}
+    permissions:
+      contents: read
+    steps:
+      - name: Send production repository dispatch
+        env:
+          GH_TOKEN: ${{ secrets.ROOMOTE_CLOUD_DISPATCH_TOKEN }}
+          CLOUD_REPO: ${{ vars.ROOMOTE_CLOUD_REPO }}
+          IMAGE_TAG: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          : "${GH_TOKEN:?ROOMOTE_CLOUD_DISPATCH_TOKEN is required}"
+          case "$CLOUD_REPO" in
+            RooCodeInc/Roomote-Cloud) ;;
+            *)
+              echo "Refusing unexpected ROOMOTE_CLOUD_REPO: $CLOUD_REPO" >&2
+              exit 1
+              ;;
+          esac
+          gh api "repos/${CLOUD_REPO}/dispatches" \
+            -f event_type=roomote-main-build \
+            -f "client_payload[image_tag]=${IMAGE_TAG}" \
+            -f "client_payload[sha]=${GITHUB_SHA}" \
+            -f "client_payload[ref]=${GITHUB_REF}"


### PR DESCRIPTION
Production counterpart to `notify-staging-cloud`: successful **main** image publishes now dispatch `roomote-main-build` to `RooCodeInc/Roomote-Cloud` with `client_payload` of the immutable `main-<sha8>` tag, the commit SHA, and the ref — the exact shape staging already receives for develop builds.

The Cloud side (companion PR in Roomote-Cloud) validates tag-against-SHA and ref before rolling: it updates the pinned image digests, redeploys production Cloud, and reconciles every ready tenant to the new pair. Nothing changes for the existing `notify-ops` / staging paths; reuses the existing `ROOMOTE_CLOUD_DISPATCH_TOKEN` secret and `ROOMOTE_CLOUD_REPO` var.

Note: takes effect once this reaches `main` (the workflow runs from the pushed ref).