### PR TITLE
fix: walk the resume chain for source-control stamps

### DIFF
--- a/packages/cloud-agents/src/server/__tests__/enqueue-task.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/enqueue-task.test.ts
@@ -772,6 +772,66 @@ describe('enqueueTask snapshot resume', () => {
     expect(resumePayload.sourceControlHost).toBe('dev.azure.com');
   });
 
+  it('walks the resume chain for stamps when the source run predates inheritance', async () => {
+    const userId = await createUser();
+
+    const freshRun = await launchFresh({
+      task: standardTaskInput({
+        payload: {
+          repo: 'roomote/Test ADO/Test ADO',
+          description: 'Do the thing',
+          sourceControlProvider: 'ado',
+          sourceControlHost: 'dev.azure.com',
+        },
+      }),
+      initiator: { kind: 'user', userId },
+      workflow: 'standard',
+      surface: 'slack',
+      trigger: 'message',
+    });
+
+    // Simulate a resume row created before stamps were inherited: it points
+    // at the stamped fresh run but its own rebuilt payload carries no stamps.
+    const [legacyResume] = await db
+      .insert(taskRuns)
+      .values({
+        taskId: freshRun.taskId,
+        kind: 'resume',
+        sourceRunId: freshRun.id,
+        payloadKind: TaskPayloadKind.SnapshotResume,
+        status: RunStatus.Completed,
+        sourceSnapshotId: 'snap-legacy-1',
+        payload: {
+          repo: 'roomote/Test ADO/Test ADO',
+          sourceSnapshotId: 'snap-legacy-1',
+          sourceRunId: freshRun.id,
+        },
+      })
+      .returning();
+
+    const resumeTask: SnapshotResumeTask = {
+      type: TaskPayloadKind.SnapshotResume,
+      payload: {
+        repo: 'roomote/Test ADO/Test ADO',
+        sourceSnapshotId: 'snap-legacy-1',
+        sourceRunId: legacyResume!.id,
+      },
+    } as SnapshotResumeTask;
+
+    const resumeRun = await enqueueTask(
+      { task: resumeTask, actingUserId: userId },
+      { enqueue: false },
+    );
+
+    const resumePayload = resumeRun.payload as {
+      sourceControlProvider?: string;
+      sourceControlHost?: string;
+    };
+
+    expect(resumePayload.sourceControlProvider).toBe('ado');
+    expect(resumePayload.sourceControlHost).toBe('dev.azure.com');
+  });
+
   it('keeps an explicit source-control provider on the resume payload', async () => {
     const userId = await createUser();
 

--- a/packages/cloud-agents/src/server/task-run-queue.ts
+++ b/packages/cloud-agents/src/server/task-run-queue.ts
@@ -2012,12 +2012,17 @@ async function enqueueSnapshotResume(
   ) {
     const parentRun = await db.query.taskRuns.findFirst({
       where: eq(taskRuns.id, parentRunId),
-      columns: { payloadKind: true, sourceRunId: true },
+      columns: { payloadKind: true, sourceRunId: true, payload: true },
     });
 
     if (!parentRun) {
       break;
     }
+
+    // Resume rows created before stamps were inherited may lack them even
+    // though an ancestor has them; pick up whatever is still missing while
+    // walking, nearest ancestor first.
+    inheritSnapshotResumeSourceControlStamps(task.payload, parentRun.payload);
 
     sourceTaskType = parentRun.payloadKind;
     parentRunId = parentRun.sourceRunId;


### PR DESCRIPTION
## What

Follow-up to #732. Snapshot-resume stamp inheritance only consulted the immediate source run. When that run is itself a resume created before inheritance existed, its rebuilt payload has no `sourceControlProvider`/`sourceControlHost` even though the original run does, so resuming such a legacy non-GitHub task a second time still fell back to the GitHub default and failed workspace preparation with `Repository not found`.

`enqueueSnapshotResume` already walks the `sourceRunId` chain to find the original run for model selection; this reuses that walk to inherit missing stamps from the nearest ancestor that has them. Nearest ancestor wins; explicit values on the resume payload are never overridden.

## Validation

- New regression test: a resume sourced from an unstamped legacy resume row inherits the stamps from the original run two hops up (real test database).
- `vitest run src/server/__tests__/enqueue-task.test.ts` (34/34)
- `pnpm --filter @roomote/cloud-agents check-types`, oxfmt/oxlint clean
- Verified live on the local docker provider: stripped the stamps from two intermediate resume runs of a slept Azure DevOps task, sent a thread follow-up, and the new resume walked the chain, inherited `sourceControlProvider: "ado"`, and completed workspace preparation and the reply normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)