### PR TITLE
[Feature] Explicit resolve buttons for PR review offers

### DIFF
--- a/apps/api/src/handlers/discord/pr-review-action.ts
+++ b/apps/api/src/handlers/discord/pr-review-action.ts
@@ -84,7 +84,7 @@ export async function handleDiscordPrReviewActionCallback(input: {
     if (dispatched.outcome === 'unavailable') {
       await reply(
         input.choice === 'auto'
-          ? "I'll take future feedback from here, but this task can no longer be resumed for the current one. Reply here to start fresh."
+          ? "I'll resolve future feedback on this PR, but this task can no longer be resumed for the current feedback. Reply here to start fresh."
           : 'This task can no longer be resumed. Reply here to start fresh.',
       );
       return;
@@ -92,8 +92,8 @@ export async function handleDiscordPrReviewActionCallback(input: {
 
     await reply(
       input.choice === 'auto'
-        ? "I'll take it from here — future review feedback on this PR gets handled in this task. Looking at the current feedback now."
-        : 'On it — taking a look at the review feedback.',
+        ? "I'll resolve these and any future feedback on this PR automatically. Starting on the current feedback now."
+        : 'On it — resolving the review feedback.',
     );
   } catch (error) {
     apiLogger.error(

--- a/apps/api/src/handlers/slack/dispatch/__tests__/pr-review-action.test.ts
+++ b/apps/api/src/handlers/slack/dispatch/__tests__/pr-review-action.test.ts
@@ -218,7 +218,7 @@ describe('handleSlackPrReviewActionAuto', () => {
             expect.objectContaining({
               elements: [
                 expect.objectContaining({
-                  text: expect.stringContaining('Taking it from here'),
+                  text: expect.stringContaining('Resolving all issues'),
                 }),
               ],
             }),
@@ -237,7 +237,7 @@ describe('handleSlackPrReviewActionAuto', () => {
     expect(postSlackInteractiveResponseMock).toHaveBeenCalledWith(
       'https://hooks.slack.test/response',
       expect.objectContaining({
-        text: expect.stringContaining('take future feedback from here'),
+        text: expect.stringContaining('resolve future feedback'),
       }),
     );
     // The message still resolves to the auto-handling note.

--- a/apps/api/src/handlers/slack/dispatch/pr-review-action.ts
+++ b/apps/api/src/handlers/slack/dispatch/pr-review-action.ts
@@ -186,7 +186,7 @@ async function dispatchAcceptedPrReviewAction({
     await respondEphemeral(
       payload,
       enableAutoHandle
-        ? "I'll take future feedback from here, but this task can no longer be resumed for the current one. Reply in the thread to start fresh."
+        ? "I'll resolve future feedback on this PR, but this task can no longer be resumed for the current feedback. Reply in the thread to start fresh."
         : 'This task can no longer be resumed. Reply in the thread to start fresh.',
     );
 
@@ -196,7 +196,7 @@ async function dispatchAcceptedPrReviewAction({
   }
 
   const resolution = enableAutoHandle
-    ? `Taking it from here — requested by <@${payload.user.id}>. Future review feedback on this PR gets handled in this task.`
+    ? `Resolving all issues — requested by <@${payload.user.id}>. Future review feedback on this PR gets resolved in this task automatically.`
     : `On it — requested by <@${payload.user.id}>.`;
 
   await updateNotificationMessage({ payload, resolution });

--- a/apps/api/src/handlers/telegram/pr-review-action.ts
+++ b/apps/api/src/handlers/telegram/pr-review-action.ts
@@ -106,7 +106,7 @@ export async function handleTelegramPrReviewActionCallback(params: {
           ...(messageId ? { replyToMessageId: messageId } : {}),
           text:
             choice === 'auto'
-              ? "I'll take future feedback from here, but this task can no longer be resumed for the current one. Reply here to start fresh."
+              ? "I'll resolve future feedback on this PR, but this task can no longer be resumed for the current feedback. Reply here to start fresh."
               : 'This task can no longer be resumed. Reply here to start fresh.',
         });
       }
@@ -118,7 +118,7 @@ export async function handleTelegramPrReviewActionCallback(params: {
 
     await answerTelegramCallbackQueryBestEffort({
       callbackQueryId: query.id,
-      text: choice === 'auto' ? 'Taking it from here.' : 'On it.',
+      text: choice === 'auto' ? 'Resolving all issues.' : 'On it.',
     });
 
     if (chatId && messageId) {
@@ -131,8 +131,8 @@ export async function handleTelegramPrReviewActionCallback(params: {
           replyToMessageId: messageId,
           text:
             choice === 'auto'
-              ? "I'll take it from here — future review feedback on this PR gets handled in this task. Looking at the current feedback now."
-              : 'On it — taking a look at the review feedback.',
+              ? "I'll resolve these and any future feedback on this PR automatically. Starting on the current feedback now."
+              : 'On it — resolving the review feedback.',
         });
       }
     }

--- a/apps/bullmq/src/jobs/pr-review-notification.test.ts
+++ b/apps/bullmq/src/jobs/pr-review-notification.test.ts
@@ -311,11 +311,11 @@ describe('prReviewNotificationJob', () => {
         buttons: [
           [
             expect.objectContaining({
-              text: 'Yes, take a look',
+              text: 'Resolve these issues',
               callbackData: `prr:y:${storedNonce}`,
             }),
             expect.objectContaining({
-              text: 'Take it from here',
+              text: 'Resolve all issues',
               callbackData: `prr:a:${storedNonce}`,
             }),
             expect.objectContaining({

--- a/apps/bullmq/src/jobs/pr-review-notification.ts
+++ b/apps/bullmq/src/jobs/pr-review-notification.ts
@@ -179,11 +179,11 @@ async function postPrReviewNotification({
     postInput.buttons = [
       [
         {
-          text: 'Yes, take a look',
+          text: 'Resolve these issues',
           callbackData: buildPrReviewActionCallbackData('yes', nonce),
         },
         {
-          text: 'Take it from here',
+          text: 'Resolve all issues',
           callbackData: buildPrReviewActionCallbackData('auto', nonce),
         },
         {

--- a/packages/sdk/src/server/lib/task-runs/__tests__/pr-review-notification-delivery.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/pr-review-notification-delivery.test.ts
@@ -433,7 +433,7 @@ describe('triagePrReviewActivity', () => {
     expect(system).toContain(
       'current pull request state includes "- Merge conflicts: yes"',
     );
-    expect(system).toContain('Do you want me to fix it?');
+    expect(system).toContain('Would you like me to resolve this?');
   });
 
   it('includes the latest Roomote review summary comment verbatim for self-review results', async () => {

--- a/packages/sdk/src/server/lib/task-runs/pr-review-notification-delivery.ts
+++ b/packages/sdk/src/server/lib/task-runs/pr-review-notification-delivery.ts
@@ -438,8 +438,11 @@ offers to act go in "followUpQuestion" and "followUpPrompt" instead. Rules:
   headers
 - when the feedback contains findings, requested changes, failed CI, or
   merge conflicts that are not already handled, write "followUpQuestion" as
-  one short question asking whether the user wants the agent to work on them
-  (for example: Want me to take a look?), and write "followUpPrompt" as a
+  one short question asking whether the user wants the agent to resolve
+  them, phrased with the verb "resolve" so it matches the reply buttons
+  labeled "Resolve these issues" and "Resolve all issues" (for example:
+  Would you like me to resolve these issues? or, for a single finding,
+  Would you like me to resolve this issue?), and write "followUpPrompt" as a
   self-contained imperative instruction to the coding agent describing
   exactly what to investigate and address - name the feedback source, the
   affected pull request, any failed check, and include the relevant links
@@ -463,7 +466,7 @@ offers to act go in "followUpQuestion" and "followUpPrompt" instead. Rules:
   "looked good" review wrap-up. Prefer a summary shape like "I reviewed
   [owner/repo#42](pull request URL) on GitHub and the code looked good
   overall, but a test is failing in CI." with the offer to fix it carried by
-  "followUpQuestion" (for example: Do you want me to fix it?). Name the
+  "followUpQuestion" (for example: Would you like me to resolve this?). Name the
   failed check when one is listed. Pending checks may get a brief mention but
   must not overshadow a hard failure
 - when open feedback is already actionable (findings, requested changes, or

--- a/packages/sdk/trigger-automation-now.ts
+++ b/packages/sdk/trigger-automation-now.ts
@@ -1,0 +1,25 @@
+/**
+ * Local repro trigger: runs a background automation exactly like the web
+ * "Run now" button (manualTrigger: true). Untracked; delete after the repro.
+ *
+ * Usage:
+ *   pnpm exec dotenvx run -f ../../.env.local -- pnpm exec tsx trigger-automation-now.ts <automationKey>
+ */
+import { runAutomationNow } from './src/server/automations';
+
+const key = process.argv[2];
+
+if (!key) {
+  console.error('Usage: tsx trigger-automation-now.ts <automationKey>');
+  process.exit(1);
+}
+
+runAutomationNow(key as never)
+  .then((result) => {
+    console.log('run-now result:', JSON.stringify(result, null, 2));
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/packages/slack/src/pr-review-action.ts
+++ b/packages/slack/src/pr-review-action.ts
@@ -60,7 +60,11 @@ export function buildSlackPrReviewActionBlocks(params: {
         {
           type: 'button',
           action_id: PR_REVIEW_ACTION_YES_ACTION_ID,
-          text: { type: 'plain_text', text: 'Yes, take a look', emoji: true },
+          text: {
+            type: 'plain_text',
+            text: 'Resolve these issues',
+            emoji: true,
+          },
           style: 'primary',
           value,
         },
@@ -69,7 +73,7 @@ export function buildSlackPrReviewActionBlocks(params: {
           action_id: PR_REVIEW_ACTION_AUTO_ACTION_ID,
           text: {
             type: 'plain_text',
-            text: 'Take it from here',
+            text: 'Resolve all issues',
             emoji: true,
           },
           value,


### PR DESCRIPTION
Team feedback: the difference between "Yes, take a look" and "Take it from here" wasn't obvious, and an explainer paragraph looked too loaded. The buttons now answer the question directly — **Resolve these issues** (the feedback in this notification), **Resolve all issues** (these and every future one on this PR), **Dismiss** — and the triage prompt phrases its question with the same resolve verb ("Would you like me to resolve these issues?") so message and buttons stay congruent. Click confirmations follow the same voice. No explainer text added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)