### PR TITLE
[Fix] Restore dev Caddy upstream ports to 13000/13001

### DIFF
--- a/.docker/caddy/Caddyfile
+++ b/.docker/caddy/Caddyfile
@@ -35,7 +35,7 @@
 
 	handle @api {
 		uri strip_prefix /_roomote-api
-		reverse_proxy host.docker.internal:13101 {
+		reverse_proxy host.docker.internal:13001 {
 			lb_try_duration 10s
 			lb_try_interval 250ms
 		}
@@ -58,7 +58,7 @@
 	}
 
 	handle {
-		reverse_proxy host.docker.internal:13100 {
+		reverse_proxy host.docker.internal:13000 {
 			lb_try_duration 10s
 			lb_try_interval 250ms
 		}


### PR DESCRIPTION
## Problem

Since #719, the local dev edge (`.docker/caddy/Caddyfile`) proxies web traffic to `host.docker.internal:13100` and `/_roomote-api/*` to `:13101`. Nothing in the dev stack listens there — `pnpm dev` starts web on 13000 and the API on 13001 (see `apps/dev/src/services/port.ts` and `doctor.ts`). Every request through the dev Caddy listener on 18080, including any ngrok tunnel pointed at it, fails with a 502:

```
dial tcp 192.168.65.254:13100: connect: connection refused
```

The 131xx values match the +100 port offset used by agent worktrees, so this looks like a worktree-local edit that slipped into #719, which otherwise didn't touch ports.

## Fix

Revert the two `reverse_proxy` targets to 13000 (web) and 13001 (API).

## Verification

With the dev stack running: restarted `roomote-caddy-dev` with this config and confirmed `GET /` through port 18080 (and through an ngrok tunnel in front of it) returns 200 instead of 502.