### PR TITLE
[Fix] Harden queued communication-message delivery for idle task runs

### DIFF
--- a/apps/bullmq/src/jobs/snapshot.ts
+++ b/apps/bullmq/src/jobs/snapshot.ts
@@ -36,6 +36,7 @@ import {
 } from '@roomote/compute-providers';
 import { drainLinearMessagesToResumeRun } from '@roomote/linear';
 import { withSandboxServerRpcClient } from '@roomote/sdk/server';
+import { drainCommunicationMessagesToResumeRun } from '@roomote/sdk/server/communication';
 import { drainSlackMessagesToResumeRun } from '@roomote/slack';
 import { z } from 'zod';
 
@@ -753,6 +754,34 @@ export const snapshotJob = async (job: SnapshotJob): Promise<void> => {
         `[SnapshotQueue] Failed to drain Slack messages for run #${runId}: ${drainError instanceof Error ? drainError.message : String(drainError)}`,
       );
     }
+  }
+
+  // Drain pending Discord/Telegram/Teams messages using the same pattern.
+  // Without this, a follow-up queued into a run whose poller died before the
+  // snapshot stays orphaned in Redis: the run sleeps, nothing wakes it, and
+  // the sender's prompt silently expires.
+  try {
+    const drainResult = await drainCommunicationMessagesToResumeRun(
+      {
+        id: taskRun.id,
+        taskId: taskRun.taskId,
+        snapshotId,
+        payload: taskRun.payload as Record<string, unknown>,
+        port: taskRun.port,
+      },
+      snapshotId,
+    );
+
+    if (drainResult.resumed) {
+      console.log(
+        `[SnapshotQueue] Routed ${drainResult.messageCount} ${drainResult.provider} message(s) to SnapshotResume run ${drainResult.runId}`,
+      );
+    }
+  } catch (drainError) {
+    // Log but don't fail the snapshot -- the snapshot itself succeeded.
+    console.error(
+      `[SnapshotQueue] Failed to drain communication messages for run #${runId}: ${drainError instanceof Error ? drainError.message : String(drainError)}`,
+    );
   }
 };
 

--- a/apps/worker/src/run-task/polling.ts
+++ b/apps/worker/src/run-task/polling.ts
@@ -96,6 +96,11 @@ export const stopPolling = async (state: RunTaskState) => {
     state.linearMessageInterval = undefined;
   }
 
+  if (state.linearMessageCleanup) {
+    await state.linearMessageCleanup();
+    state.linearMessageCleanup = undefined;
+  }
+
   if (state.githubTokenRefreshInterval) {
     clearInterval(state.githubTokenRefreshInterval);
     state.githubTokenRefreshInterval = undefined;

--- a/apps/worker/src/run-task/polling/communication.ts
+++ b/apps/worker/src/run-task/polling/communication.ts
@@ -8,11 +8,13 @@ import { sdk } from '@roomote/sdk/client';
 
 import { isActiveTaskPhase } from '../../sandbox-server/lib/harness-manager';
 import { recordChatTurnStart } from '../../mcp/roomote-mcp-server/chat-reply-satisfaction';
+import { createDiagnosticEventRecorder } from '../diagnostic-events';
 import type { ListenerOptions } from '../types';
 import {
   logPollingTransportError,
   runPollingSdkCall,
 } from './poll-error-context';
+import { createSerializedPollLoop } from './serialized-poll-loop';
 import { wrapCommunicationMessage } from '../communication-message-prompt';
 
 const COMMUNICATION_MESSAGE_CHECK_INTERVAL_MS = 5_000;
@@ -64,17 +66,13 @@ export function createCommunicationMessageInterval({
     prepareActorScopedTurn,
     answerUserInputRequest,
   } = options;
-  let stopping = false;
-  let activePoll = Promise.resolve();
-
-  state.communicationMessageCleanups ??= {};
-  state.communicationMessageCleanups[provider] = async () => {
-    stopping = true;
-    await activePoll;
-  };
+  const diagnostics = createDiagnosticEventRecorder({
+    runId: taskRun.id,
+    logger,
+  });
 
   const pollOnce = async () => {
-    if (stopping || !state.sessionId) {
+    if (!state.sessionId) {
       return;
     }
 
@@ -216,6 +214,16 @@ export function createCommunicationMessageInterval({
           logger.warn(
             `[listenFor${provider}Events] Delaying ${provider} follow-up for task ${state.sessionId} until actor-scoped turn preparation succeeds`,
           );
+          diagnostics.record({
+            kind: 'queued_message_requeued',
+            message: `Requeued ${deliveryOrder.length - index} queued ${provider} message(s) because actor-scoped turn preparation did not succeed.`,
+            details: {
+              provider,
+              reason: 'actor_prep_failed',
+              count: deliveryOrder.length - index,
+              ts: message.ts,
+            },
+          });
 
           try {
             await requeueCommunicationMessages(
@@ -239,6 +247,11 @@ export function createCommunicationMessageInterval({
           logger.warn(
             `[listenFor${provider}Events] Skipped ${provider} follow-up for task ${state.sessionId}: sender is not the server-side acting user (ts=${message.ts})`,
           );
+          diagnostics.record({
+            kind: 'queued_message_skipped',
+            message: `Skipped queued ${provider} message ts=${message.ts}: sender is not the server-side acting user.`,
+            details: { provider, reason: 'actor_mismatch', ts: message.ts },
+          });
           index += 1;
           continue;
         }
@@ -260,6 +273,16 @@ export function createCommunicationMessageInterval({
           logger.warn(
             `[listenFor${provider}Events] Failed to send follow-up prompt for task ${state.sessionId}`,
           );
+          diagnostics.record({
+            kind: 'queued_message_requeued',
+            message: `Requeued ${deliveryOrder.length - index} queued ${provider} message(s) because the harness rejected the prompt.`,
+            details: {
+              provider,
+              reason: 'send_failed',
+              count: deliveryOrder.length - index,
+              ts: message.ts,
+            },
+          });
 
           try {
             await requeueCommunicationMessages(
@@ -278,6 +301,17 @@ export function createCommunicationMessageInterval({
 
           return;
         }
+
+        diagnostics.record({
+          kind: 'queued_message_delivered',
+          message: `Delivered queued ${provider} message ts=${message.ts} to the harness.`,
+          details: {
+            provider,
+            ts: message.ts,
+            clientMessageId: getCommunicationClientMessageId(provider, message),
+            promptLength: prompt.length,
+          },
+        });
 
         if (
           provider === 'telegram' ||
@@ -311,11 +345,42 @@ export function createCommunicationMessageInterval({
     }
   };
 
-  const interval = setInterval(() => {
-    activePoll = activePoll.then(async () => {
-      await pollOnce();
-    });
-  }, COMMUNICATION_MESSAGE_CHECK_INTERVAL_MS);
+  const { interval, cleanup } = createSerializedPollLoop({
+    pollOnce,
+    intervalMs: COMMUNICATION_MESSAGE_CHECK_INTERVAL_MS,
+    onStall: ({ stalledForMs }) => {
+      logPollingTransportError({
+        stage: `listenFor${provider}Events`,
+        runId: taskRun.id,
+        sessionId: state.sessionId ?? '',
+        sdkMethod: 'listenForCommunicationEvents.pollOnce',
+        failurePoint: 'queuedCommunicationPollStalled',
+        logger,
+        error: new Error(
+          `${provider} queued-message poll stalled for ${stalledForMs}ms`,
+        ),
+        message: `[listenFor${provider}Events] Queued ${provider} message poll for job ${taskRun.id} stalled for ${stalledForMs}ms; abandoning it and starting a fresh poll`,
+      });
+      diagnostics.record({
+        kind: 'message_poller_stalled',
+        message: `Queued ${provider} message poll stalled for ${stalledForMs}ms and was abandoned; a fresh poll took over.`,
+        details: { provider, stalledForMs },
+      });
+    },
+    onStallRecovered: ({ ranForMs }) => {
+      logger.warn(
+        `[listenFor${provider}Events] A previously stalled ${provider} poll for job ${taskRun.id} settled after ${ranForMs}ms`,
+      );
+      diagnostics.record({
+        kind: 'message_poller_stall_recovered',
+        message: `A previously stalled ${provider} poll settled after ${ranForMs}ms.`,
+        details: { provider, ranForMs },
+      });
+    },
+  });
+
+  state.communicationMessageCleanups ??= {};
+  state.communicationMessageCleanups[provider] = cleanup;
 
   return interval;
 }

--- a/apps/worker/src/run-task/polling/linear.ts
+++ b/apps/worker/src/run-task/polling/linear.ts
@@ -5,11 +5,13 @@ import {
 } from '@roomote/linear/client';
 
 import { isActiveTaskPhase } from '../../sandbox-server/lib/harness-manager';
+import { createDiagnosticEventRecorder } from '../diagnostic-events';
 import type { ListenerOptions } from '../types';
 import {
   logPollingTransportError,
   runPollingSdkCall,
 } from './poll-error-context';
+import { createSerializedPollLoop } from './serialized-poll-loop';
 
 const LINEAR_MESSAGE_CHECK_INTERVAL_MS = 5_000;
 
@@ -42,7 +44,12 @@ export function createLinearMessageInterval({
   logger,
   prepareActorScopedTurn,
 }: ListenerOptions): NodeJS.Timeout {
-  return setInterval(async () => {
+  const diagnostics = createDiagnosticEventRecorder({
+    runId: taskRun.id,
+    logger,
+  });
+
+  const pollOnce = async () => {
     if (!state.sessionId) {
       return;
     }
@@ -223,6 +230,12 @@ export function createLinearMessageInterval({
             logger.warn(
               `[listenForLinearEvents] Failed to send follow-up prompt for task ${state.sessionId}`,
             );
+          } else {
+            diagnostics.record({
+              kind: 'queued_message_delivered',
+              message: `Delivered queued Linear message to the harness.`,
+              details: { provider: 'linear', promptLength: text.length },
+            });
           }
 
           logger.log(
@@ -242,5 +255,43 @@ export function createLinearMessageInterval({
         message: `[listenForLinearEvents] Unexpected error while delivering queued Linear events for job ${taskRun.id}`,
       });
     }
-  }, LINEAR_MESSAGE_CHECK_INTERVAL_MS);
+  };
+
+  const { interval, cleanup } = createSerializedPollLoop({
+    pollOnce,
+    intervalMs: LINEAR_MESSAGE_CHECK_INTERVAL_MS,
+    onStall: ({ stalledForMs }) => {
+      logPollingTransportError({
+        stage: 'listenForLinearEvents',
+        runId: taskRun.id,
+        sessionId: state.sessionId ?? '',
+        sdkMethod: 'listenForLinearEvents.pollOnce',
+        failurePoint: 'queuedLinearPollStalled',
+        logger,
+        error: new Error(
+          `Linear queued-message poll stalled for ${stalledForMs}ms`,
+        ),
+        message: `[listenForLinearEvents] Queued Linear message poll for job ${taskRun.id} stalled for ${stalledForMs}ms; abandoning it and starting a fresh poll`,
+      });
+      diagnostics.record({
+        kind: 'message_poller_stalled',
+        message: `Queued Linear message poll stalled for ${stalledForMs}ms and was abandoned; a fresh poll took over.`,
+        details: { provider: 'linear', stalledForMs },
+      });
+    },
+    onStallRecovered: ({ ranForMs }) => {
+      logger.warn(
+        `[listenForLinearEvents] A previously stalled Linear poll for job ${taskRun.id} settled after ${ranForMs}ms`,
+      );
+      diagnostics.record({
+        kind: 'message_poller_stall_recovered',
+        message: `A previously stalled Linear poll settled after ${ranForMs}ms.`,
+        details: { provider: 'linear', ranForMs },
+      });
+    },
+  });
+
+  state.linearMessageCleanup = cleanup;
+
+  return interval;
 }

--- a/apps/worker/src/run-task/polling/serialized-poll-loop.test.ts
+++ b/apps/worker/src/run-task/polling/serialized-poll-loop.test.ts
@@ -1,0 +1,187 @@
+import { createSerializedPollLoop } from './serialized-poll-loop';
+
+const INTERVAL_MS = 5_000;
+const STALL_TIMEOUT_MS = 60_000;
+
+describe('createSerializedPollLoop', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setInterval', 'setTimeout', 'Date'] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not overlap polls while the previous poll is still running', async () => {
+    let resolveActive: (() => void) | undefined;
+    const pollOnce = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveActive = resolve;
+        }),
+    );
+
+    const { interval, cleanup } = createSerializedPollLoop({
+      pollOnce,
+      intervalMs: INTERVAL_MS,
+      stallTimeoutMs: STALL_TIMEOUT_MS,
+    });
+
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS * 3);
+    expect(pollOnce).toHaveBeenCalledTimes(1);
+
+    resolveActive?.();
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS);
+    expect(pollOnce).toHaveBeenCalledTimes(2);
+
+    clearInterval(interval);
+    resolveActive?.();
+    await cleanup();
+  });
+
+  it('abandons a hung poll after the stall deadline and keeps polling', async () => {
+    let hangs = 0;
+    const pollOnce = vi.fn(() => {
+      hangs += 1;
+
+      if (hangs === 1) {
+        return new Promise<void>(() => {});
+      }
+
+      return Promise.resolve();
+    });
+    const onStall = vi.fn();
+
+    const { interval, cleanup } = createSerializedPollLoop({
+      pollOnce,
+      intervalMs: INTERVAL_MS,
+      stallTimeoutMs: STALL_TIMEOUT_MS,
+      onStall,
+    });
+
+    // First tick starts the hung poll; nothing else runs until the deadline.
+    await vi.advanceTimersByTimeAsync(STALL_TIMEOUT_MS);
+    expect(pollOnce).toHaveBeenCalledTimes(1);
+    expect(onStall).not.toHaveBeenCalled();
+
+    // The first tick past the deadline reports the stall and starts fresh.
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS);
+    expect(onStall).toHaveBeenCalledTimes(1);
+    expect(onStall).toHaveBeenCalledWith({
+      stalledForMs: expect.any(Number),
+    });
+    expect(pollOnce).toHaveBeenCalledTimes(2);
+
+    // Polling continues normally afterwards.
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS * 2);
+    expect(pollOnce).toHaveBeenCalledTimes(4);
+    expect(onStall).toHaveBeenCalledTimes(1);
+
+    clearInterval(interval);
+    await cleanup();
+  });
+
+  it('reports when an abandoned poll eventually settles', async () => {
+    let resolveHung: (() => void) | undefined;
+    let calls = 0;
+    const pollOnce = vi.fn(() => {
+      calls += 1;
+
+      if (calls === 1) {
+        return new Promise<void>((resolve) => {
+          resolveHung = resolve;
+        });
+      }
+
+      return Promise.resolve();
+    });
+    const onStall = vi.fn();
+    const onStallRecovered = vi.fn();
+
+    const { interval, cleanup } = createSerializedPollLoop({
+      pollOnce,
+      intervalMs: INTERVAL_MS,
+      stallTimeoutMs: STALL_TIMEOUT_MS,
+      onStall,
+      onStallRecovered,
+    });
+
+    await vi.advanceTimersByTimeAsync(STALL_TIMEOUT_MS + INTERVAL_MS);
+    expect(onStall).toHaveBeenCalledTimes(1);
+
+    resolveHung?.();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onStallRecovered).toHaveBeenCalledTimes(1);
+    expect(onStallRecovered).toHaveBeenCalledWith({
+      ranForMs: expect.any(Number),
+    });
+
+    clearInterval(interval);
+    await cleanup();
+  });
+
+  it('swallows poll rejections without stopping the loop', async () => {
+    const pollOnce = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValue(undefined);
+
+    const { interval, cleanup } = createSerializedPollLoop({
+      pollOnce,
+      intervalMs: INTERVAL_MS,
+      stallTimeoutMs: STALL_TIMEOUT_MS,
+    });
+
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS * 3);
+    expect(pollOnce).toHaveBeenCalledTimes(3);
+
+    clearInterval(interval);
+    await cleanup();
+  });
+
+  it('bounds cleanup when the in-flight poll is wedged', async () => {
+    const pollOnce = vi.fn(() => new Promise<void>(() => {}));
+
+    const { interval, cleanup } = createSerializedPollLoop({
+      pollOnce,
+      intervalMs: INTERVAL_MS,
+      stallTimeoutMs: STALL_TIMEOUT_MS,
+    });
+
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS);
+    expect(pollOnce).toHaveBeenCalledTimes(1);
+
+    clearInterval(interval);
+
+    let cleanupDone = false;
+    const pending = cleanup().then(() => {
+      cleanupDone = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(STALL_TIMEOUT_MS - 1);
+    expect(cleanupDone).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS);
+    await pending;
+    expect(cleanupDone).toBe(true);
+  });
+
+  it('stops starting polls after cleanup', async () => {
+    const pollOnce = vi.fn(() => Promise.resolve());
+
+    const { interval, cleanup } = createSerializedPollLoop({
+      pollOnce,
+      intervalMs: INTERVAL_MS,
+      stallTimeoutMs: STALL_TIMEOUT_MS,
+    });
+
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS);
+    expect(pollOnce).toHaveBeenCalledTimes(1);
+
+    await cleanup();
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS * 3);
+    expect(pollOnce).toHaveBeenCalledTimes(1);
+
+    clearInterval(interval);
+  });
+});

--- a/apps/worker/src/run-task/polling/serialized-poll-loop.ts
+++ b/apps/worker/src/run-task/polling/serialized-poll-loop.ts
@@ -1,0 +1,128 @@
+/**
+ * Serialized polling with a stall watchdog.
+ *
+ * The message pollers must not overlap (delivery order and requeue bookkeeping
+ * assume one poll at a time), but the previous implementation chained every
+ * tick onto the last poll's promise — a single poll that never settled
+ * silently stopped all future polls for the rest of the run. This loop keeps
+ * the serialization while bounding each poll: an in-flight poll that exceeds
+ * the stall deadline is reported and abandoned so the next tick starts fresh.
+ */
+
+/**
+ * Comfortably above the worst-case legitimate poll (SDK fetches are bounded
+ * per attempt and retried a few times, plus actor-scoped turn preparation), so
+ * a stall report means the poll is genuinely wedged, not slow.
+ */
+const DEFAULT_POLL_STALL_TIMEOUT_MS = 5 * 60_000;
+
+interface SerializedPollLoopOptions {
+  pollOnce: () => Promise<void>;
+  intervalMs: number;
+  stallTimeoutMs?: number;
+  /** Invoked once per stalled poll, right before the poll is abandoned. */
+  onStall?: (info: { stalledForMs: number }) => void;
+  /** Invoked if an abandoned poll eventually settles after all. */
+  onStallRecovered?: (info: { ranForMs: number }) => void;
+}
+
+interface SerializedPollLoop {
+  interval: NodeJS.Timeout;
+  /**
+   * Stop scheduling and wait for the in-flight poll to settle, bounded by the
+   * stall deadline so a wedged poll cannot hang shutdown.
+   */
+  cleanup: () => Promise<void>;
+}
+
+interface InFlightPoll {
+  promise: Promise<void>;
+  startedAt: number;
+  abandoned: boolean;
+}
+
+export function createSerializedPollLoop({
+  pollOnce,
+  intervalMs,
+  stallTimeoutMs = DEFAULT_POLL_STALL_TIMEOUT_MS,
+  onStall,
+  onStallRecovered,
+}: SerializedPollLoopOptions): SerializedPollLoop {
+  let stopping = false;
+  let inFlight: InFlightPoll | null = null;
+
+  const startPoll = () => {
+    const poll: InFlightPoll = {
+      promise: Promise.resolve(),
+      startedAt: Date.now(),
+      abandoned: false,
+    };
+
+    poll.promise = (async () => {
+      try {
+        await pollOnce();
+      } finally {
+        if (inFlight === poll) {
+          inFlight = null;
+        } else if (poll.abandoned) {
+          onStallRecovered?.({ ranForMs: Date.now() - poll.startedAt });
+        }
+      }
+    })().catch(() => {
+      // pollOnce handles its own errors; this guard only prevents an
+      // unhandled rejection from an abandoned poll.
+    });
+
+    inFlight = poll;
+  };
+
+  const interval = setInterval(() => {
+    if (stopping) {
+      return;
+    }
+
+    if (!inFlight) {
+      startPoll();
+      return;
+    }
+
+    const stalledForMs = Date.now() - inFlight.startedAt;
+
+    if (stalledForMs < stallTimeoutMs) {
+      // Previous poll is still running; skip this tick instead of queueing
+      // behind it.
+      return;
+    }
+
+    inFlight.abandoned = true;
+    inFlight = null;
+    onStall?.({ stalledForMs });
+    startPoll();
+  }, intervalMs);
+
+  const cleanup = async () => {
+    stopping = true;
+
+    const pending = inFlight;
+
+    if (!pending) {
+      return;
+    }
+
+    const remainingMs = Math.max(
+      0,
+      stallTimeoutMs - (Date.now() - pending.startedAt),
+    );
+
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(resolve, remainingMs);
+
+      void pending.promise.finally(() => {
+        clearTimeout(timeout);
+        resolve();
+      });
+    });
+  };
+
+  return { interval, cleanup };
+}

--- a/apps/worker/src/run-task/polling/slack.ts
+++ b/apps/worker/src/run-task/polling/slack.ts
@@ -10,11 +10,13 @@ import {
 
 import { recordChatTurnStart } from '../../mcp/roomote-mcp-server/chat-reply-satisfaction';
 import { isActiveTaskPhase } from '../../sandbox-server/lib/harness-manager';
+import { createDiagnosticEventRecorder } from '../diagnostic-events';
 import type { ListenerOptions } from '../types';
 import {
   logPollingTransportError,
   runPollingSdkCall,
 } from './poll-error-context';
+import { createSerializedPollLoop } from './serialized-poll-loop';
 
 /** Interval (ms) between polling for new Slack messages during SlackAppMention tasks. */
 const SLACK_MESSAGE_CHECK_INTERVAL_MS = 5_000;
@@ -64,16 +66,13 @@ export function createSlackMessageInterval({
   logger,
   prepareActorScopedTurn,
 }: ListenerOptions): NodeJS.Timeout {
-  let stopping = false;
-  let activePoll = Promise.resolve();
-
-  state.slackMessageCleanup = async () => {
-    stopping = true;
-    await activePoll;
-  };
+  const diagnostics = createDiagnosticEventRecorder({
+    runId: taskRun.id,
+    logger,
+  });
 
   const pollOnce = async () => {
-    if (stopping || !state.sessionId) {
+    if (!state.sessionId) {
       return;
     }
 
@@ -216,6 +215,16 @@ export function createSlackMessageInterval({
             logger.warn(
               `[listenForSlackEvents] Delaying Slack follow-up for task ${state.sessionId} until actor-scoped turn preparation succeeds`,
             );
+            diagnostics.record({
+              kind: 'queued_message_requeued',
+              message: `Requeued ${deliveryOrder.length - index} queued Slack message(s) because actor-scoped turn preparation did not succeed.`,
+              details: {
+                provider: 'slack',
+                reason: 'actor_prep_failed',
+                count: deliveryOrder.length - index,
+                ts: msg.ts,
+              },
+            });
 
             try {
               await requeueSlackMessages(taskRun.id, deliveryOrder, index);
@@ -234,6 +243,15 @@ export function createSlackMessageInterval({
             logger.warn(
               `[listenForSlackEvents] Skipped Slack follow-up for task ${state.sessionId}: sender is not the server-side acting user (ts=${msg.ts})`,
             );
+            diagnostics.record({
+              kind: 'queued_message_skipped',
+              message: `Skipped queued Slack message ts=${msg.ts}: sender is not the server-side acting user.`,
+              details: {
+                provider: 'slack',
+                reason: 'actor_mismatch',
+                ts: msg.ts,
+              },
+            });
             index += 1;
             continue;
           }
@@ -261,6 +279,16 @@ export function createSlackMessageInterval({
             logger.warn(
               `[listenForSlackEvents] Failed to send follow-up prompt for task ${state.sessionId}`,
             );
+            diagnostics.record({
+              kind: 'queued_message_requeued',
+              message: `Requeued ${deliveryOrder.length - index} queued Slack message(s) because the harness rejected the prompt.`,
+              details: {
+                provider: 'slack',
+                reason: 'send_failed',
+                count: deliveryOrder.length - index,
+                ts: msg.ts,
+              },
+            });
 
             try {
               await requeueSlackMessages(taskRun.id, deliveryOrder, index);
@@ -274,6 +302,17 @@ export function createSlackMessageInterval({
 
             return;
           }
+
+          diagnostics.record({
+            kind: 'queued_message_delivered',
+            message: `Delivered queued Slack message ts=${msg.ts} to the harness.`,
+            details: {
+              provider: 'slack',
+              ts: msg.ts,
+              clientMessageId: getSlackClientMessageId(msg),
+              promptLength: prompt.length,
+            },
+          });
 
           recordChatTurnStart({
             turnMessageTs: msg.ts,
@@ -299,11 +338,41 @@ export function createSlackMessageInterval({
     }
   };
 
-  const interval = setInterval(() => {
-    activePoll = activePoll.then(async () => {
-      await pollOnce();
-    });
-  }, SLACK_MESSAGE_CHECK_INTERVAL_MS);
+  const { interval, cleanup } = createSerializedPollLoop({
+    pollOnce,
+    intervalMs: SLACK_MESSAGE_CHECK_INTERVAL_MS,
+    onStall: ({ stalledForMs }) => {
+      logPollingTransportError({
+        stage: 'listenForSlackEvents',
+        runId: taskRun.id,
+        sessionId: state.sessionId ?? '',
+        sdkMethod: 'listenForSlackEvents.pollOnce',
+        failurePoint: 'queuedSlackPollStalled',
+        logger,
+        error: new Error(
+          `Slack queued-message poll stalled for ${stalledForMs}ms`,
+        ),
+        message: `[listenForSlackEvents] Queued Slack message poll for job ${taskRun.id} stalled for ${stalledForMs}ms; abandoning it and starting a fresh poll`,
+      });
+      diagnostics.record({
+        kind: 'message_poller_stalled',
+        message: `Queued Slack message poll stalled for ${stalledForMs}ms and was abandoned; a fresh poll took over.`,
+        details: { provider: 'slack', stalledForMs },
+      });
+    },
+    onStallRecovered: ({ ranForMs }) => {
+      logger.warn(
+        `[listenForSlackEvents] A previously stalled Slack poll for job ${taskRun.id} settled after ${ranForMs}ms`,
+      );
+      diagnostics.record({
+        kind: 'message_poller_stall_recovered',
+        message: `A previously stalled Slack poll settled after ${ranForMs}ms.`,
+        details: { provider: 'slack', ranForMs },
+      });
+    },
+  });
+
+  state.slackMessageCleanup = cleanup;
 
   return interval;
 }

--- a/apps/worker/src/run-task/types.ts
+++ b/apps/worker/src/run-task/types.ts
@@ -244,6 +244,7 @@ export type PollingIntervals = {
     Record<CommunicationProvider, () => Promise<void>>
   >;
   linearMessageInterval: NodeJS.Timeout | undefined;
+  linearMessageCleanup?: () => Promise<void>;
   githubTokenRefreshInterval: NodeJS.Timeout | undefined;
 };
 

--- a/packages/sdk/src/client/index.test.ts
+++ b/packages/sdk/src/client/index.test.ts
@@ -476,6 +476,76 @@ describe('createWorkerFetchWithRetry', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('bounds a hung fetch attempt with the per-attempt deadline', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockImplementation(() => new Promise<Response>(() => {}));
+
+    const workerFetch = createWorkerFetchWithRetry(fetchMock, {
+      maxAttempts: 1,
+      baseDelayMs: 0,
+      attemptTimeoutMs: 20,
+    });
+
+    await expect(
+      workerFetch('https://api.roomote.dev/trpc', { method: 'GET' }),
+    ).rejects.toThrow(/timed out after 20ms/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a timed-out attempt and returns the later success', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockImplementationOnce(() => new Promise<Response>(() => {}))
+      .mockResolvedValueOnce(
+        new Response('[]', {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+
+    const workerFetch = createWorkerFetchWithRetry(fetchMock, {
+      maxAttempts: 2,
+      baseDelayMs: 0,
+      attemptTimeoutMs: 20,
+    });
+
+    const response = await workerFetch('https://api.roomote.dev/trpc', {
+      method: 'GET',
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces caller aborts without rewriting them into attempt timeouts', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(
+      (_input, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () =>
+            reject(new DOMException('The operation was aborted', 'AbortError')),
+          );
+        }),
+    );
+    const controller = new AbortController();
+
+    const workerFetch = createWorkerFetchWithRetry(fetchMock, {
+      maxAttempts: 3,
+      baseDelayMs: 0,
+      attemptTimeoutMs: 5_000,
+    });
+
+    const pending = workerFetch('https://api.roomote.dev/trpc', {
+      method: 'GET',
+      signal: controller.signal,
+    });
+
+    controller.abort();
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('fails fast with a callback diagnostic when TRPC returns HTML', async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response('<!DOCTYPE html><html><body>Wrong host</body></html>', {

--- a/packages/sdk/src/client/index.ts
+++ b/packages/sdk/src/client/index.ts
@@ -73,11 +73,21 @@ const WORKER_QUERY_RETRYABLE_STATUS_CODES = new Set([408, 429, 502, 503, 504]);
 const WORKER_QUERY_RETRY_MAX_ATTEMPTS = 4;
 const WORKER_QUERY_RETRY_BASE_DELAY_MS = 250;
 
+// Every worker callback RPC must resolve or fail within a bounded window. A
+// fetch with no deadline can hang forever on a half-dead connection, which
+// silently freezes any worker loop that awaits it (the queued-message pollers
+// serialize on the previous poll, so one hung RPC used to stop delivery for
+// the rest of the run's life). Generous enough for slow endpoints such as
+// large message-envelope uploads.
+const WORKER_FETCH_ATTEMPT_TIMEOUT_MS = 60_000;
+
 type FetchLike = typeof fetch;
 
 export interface WorkerQueryRetryOptions {
   maxAttempts?: number;
   baseDelayMs?: number;
+  /** Per-attempt deadline; a timed-out attempt is retried like a transport error. */
+  attemptTimeoutMs?: number;
 }
 
 // The worker's first callbacks claim its job through the public edge, and a
@@ -259,6 +269,59 @@ function getWorkerQueryRetryDelayMs(
   return baseDelayMs * 2 ** (attemptNumber - 1);
 }
 
+/**
+ * Deliberately not named `AbortError`/`TimeoutError`: the retry layer treats
+ * those as caller-initiated aborts and rethrows immediately, while an attempt
+ * that hit its own deadline should be retried like any transport failure.
+ */
+export class WorkerFetchAttemptTimeoutError extends Error {
+  constructor(requestUrl: string, timeoutMs: number) {
+    super(
+      `Worker callback fetch to ${requestUrl} timed out after ${timeoutMs}ms`,
+    );
+    this.name = 'WorkerFetchAttemptTimeoutError';
+  }
+}
+
+async function fetchWithAttemptTimeout(
+  baseFetch: FetchLike,
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  timeoutMs: number,
+  requestUrl: string,
+): Promise<Response> {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const signal = init?.signal
+    ? AbortSignal.any([init.signal, timeoutSignal])
+    : timeoutSignal;
+
+  // The deadline is enforced by an explicit race, not just the abort signal:
+  // the whole point is to unblock callers even when the underlying transport
+  // never observes the abort. The signal is still passed so a well-behaved
+  // fetch tears down its socket.
+  return new Promise<Response>((resolve, reject) => {
+    const onTimeout = () =>
+      reject(new WorkerFetchAttemptTimeoutError(requestUrl, timeoutMs));
+
+    timeoutSignal.addEventListener('abort', onTimeout, { once: true });
+    baseFetch(input, { ...init, signal }).then(
+      (response) => {
+        timeoutSignal.removeEventListener('abort', onTimeout);
+        resolve(response);
+      },
+      (error: unknown) => {
+        timeoutSignal.removeEventListener('abort', onTimeout);
+
+        if (timeoutSignal.aborted && !init?.signal?.aborted) {
+          reject(new WorkerFetchAttemptTimeoutError(requestUrl, timeoutMs));
+        } else {
+          reject(error);
+        }
+      },
+    );
+  });
+}
+
 export function createWorkerFetchWithRetry(
   baseFetch: FetchLike = globalThis.fetch.bind(globalThis),
   options: WorkerQueryRetryOptions = {},
@@ -280,15 +343,25 @@ export function createWorkerFetchWithRetry(
       (retryPlan.retryable
         ? retryPlan.baseDelayMs
         : WORKER_QUERY_RETRY_BASE_DELAY_MS);
+    const attemptTimeoutMs =
+      options.attemptTimeoutMs ?? WORKER_FETCH_ATTEMPT_TIMEOUT_MS;
+    const fetchOnce = () =>
+      fetchWithAttemptTimeout(
+        baseFetch,
+        input,
+        init,
+        attemptTimeoutMs,
+        requestUrl,
+      );
 
     if (!retryPlan.retryable || maxAttempts <= 1) {
-      const response = await baseFetch(input, init);
+      const response = await fetchOnce();
 
       await assertValidWorkerTrpcResponse(response, requestUrl);
       return response;
     }
 
-    const response = await retryAsync(() => baseFetch(input, init), {
+    const response = await retryAsync(fetchOnce, {
       maxAttempts,
       signal: init?.signal,
       getDelayMs: (attemptNumber) =>

--- a/packages/sdk/src/server/lib/communication/__tests__/communication-snapshot-resume.test.ts
+++ b/packages/sdk/src/server/lib/communication/__tests__/communication-snapshot-resume.test.ts
@@ -2,10 +2,23 @@ const mocks = vi.hoisted(() => ({
   enqueueTask: vi.fn(),
   attachOutOfBand: vi.fn(),
   releaseOutOfBand: vi.fn(),
+  getCommunicationMessages: vi.fn(),
+  prependCommunicationMessages: vi.fn(),
+  recordTaskRunEvent: vi.fn(),
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
   enqueueTask: mocks.enqueueTask,
+}));
+
+vi.mock('@roomote/communication', () => ({
+  getCommunicationMessages: mocks.getCommunicationMessages,
+  prependCommunicationMessages: mocks.prependCommunicationMessages,
+}));
+
+vi.mock('@roomote/db/server', () => ({
+  db: {},
+  recordTaskRunEvent: mocks.recordTaskRunEvent,
 }));
 
 vi.mock('../communication-out-of-band-context', () => ({
@@ -19,6 +32,8 @@ describe('resumeCommunicationTaskFromSnapshot', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.enqueueTask.mockResolvedValue({ id: 42, taskId: 'task-1' });
+    mocks.getCommunicationMessages.mockResolvedValue([]);
+    mocks.recordTaskRunEvent.mockResolvedValue(undefined);
     mocks.attachOutOfBand.mockImplementation(
       async ({ message }: { message: Record<string, unknown> }) => ({
         message,
@@ -220,6 +235,142 @@ describe('resumeCommunicationTaskFromSnapshot', () => {
         }),
       }),
       { launchClass: 'human' },
+    );
+  });
+
+  it('carries undelivered source-run queue messages ahead of the new message', async () => {
+    const orphanedMessage = {
+      provider: 'discord',
+      text: 'address the review feedback',
+      user: 'roomote',
+      userId: 'user-1',
+      ts: 'orphaned-ts',
+    };
+    mocks.getCommunicationMessages.mockResolvedValue([orphanedMessage]);
+
+    await resumeCommunicationTaskFromSnapshot({
+      provider: 'discord',
+      completedRun: {
+        id: 41,
+        taskId: 'task-1',
+        payload: {
+          repo: 'acme/repo',
+          communicationProvider: 'discord',
+          communicationChannelId: 'channel-1',
+        },
+        port: null,
+        snapshotId: 'snapshot-1',
+      },
+      queuedMessage: {
+        provider: 'discord',
+        text: 'new follow-up',
+        user: 'Matt',
+        userId: 'user-1',
+        ts: 'message-resume',
+      },
+      channelId: 'channel-1',
+    });
+
+    expect(mocks.getCommunicationMessages).toHaveBeenCalledWith('discord', 41);
+    expect(mocks.enqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            queuedCommunicationMessages: [
+              expect.objectContaining({ ts: 'orphaned-ts' }),
+              expect.objectContaining({ ts: 'message-resume' }),
+            ],
+          }),
+        }),
+      }),
+      { launchClass: 'human' },
+    );
+    expect(mocks.recordTaskRunEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        runId: 41,
+        source: 'snapshot_resume',
+        details: expect.objectContaining({
+          carriedCount: 1,
+          carriedTs: ['orphaned-ts'],
+        }),
+      }),
+    );
+  });
+
+  it('does not duplicate the new message when it is still in the source queue', async () => {
+    mocks.getCommunicationMessages.mockResolvedValue([
+      {
+        provider: 'discord',
+        text: 'new follow-up',
+        user: 'Matt',
+        userId: 'user-1',
+        ts: 'message-resume',
+      },
+    ]);
+
+    await resumeCommunicationTaskFromSnapshot({
+      provider: 'discord',
+      completedRun: {
+        id: 41,
+        taskId: 'task-1',
+        payload: { repo: 'acme/repo' },
+        port: null,
+        snapshotId: 'snapshot-1',
+      },
+      queuedMessage: {
+        provider: 'discord',
+        text: 'new follow-up',
+        user: 'Matt',
+        userId: 'user-1',
+        ts: 'message-resume',
+      },
+      channelId: 'channel-1',
+    });
+
+    const payload = mocks.enqueueTask.mock.calls[0]?.[0]?.task?.payload as {
+      queuedCommunicationMessages: Array<{ ts: string }>;
+    };
+    expect(payload.queuedCommunicationMessages).toHaveLength(1);
+    expect(mocks.recordTaskRunEvent).not.toHaveBeenCalled();
+  });
+
+  it('requeues drained messages when the resume enqueue fails', async () => {
+    const orphanedMessage = {
+      provider: 'discord',
+      text: 'address the review feedback',
+      user: 'roomote',
+      userId: 'user-1',
+      ts: 'orphaned-ts',
+    };
+    mocks.getCommunicationMessages.mockResolvedValue([orphanedMessage]);
+    mocks.enqueueTask.mockRejectedValue(new Error('enqueue failed'));
+
+    await expect(
+      resumeCommunicationTaskFromSnapshot({
+        provider: 'discord',
+        completedRun: {
+          id: 41,
+          taskId: 'task-1',
+          payload: { repo: 'acme/repo' },
+          port: null,
+          snapshotId: 'snapshot-1',
+        },
+        queuedMessage: {
+          provider: 'discord',
+          text: 'new follow-up',
+          user: 'Matt',
+          userId: 'user-1',
+          ts: 'message-resume',
+        },
+        channelId: 'channel-1',
+      }),
+    ).rejects.toThrow('enqueue failed');
+
+    expect(mocks.prependCommunicationMessages).toHaveBeenCalledWith(
+      'discord',
+      41,
+      [orphanedMessage],
     );
   });
 

--- a/packages/sdk/src/server/lib/communication/__tests__/drain-communication-messages.test.ts
+++ b/packages/sdk/src/server/lib/communication/__tests__/drain-communication-messages.test.ts
@@ -1,0 +1,169 @@
+const mocks = vi.hoisted(() => ({
+  enqueueTask: vi.fn(),
+  getCommunicationMessages: vi.fn(),
+  peekCommunicationMessageCount: vi.fn(),
+  prependCommunicationMessages: vi.fn(),
+  recordTaskRunEvent: vi.fn(),
+  redisSet: vi.fn(),
+  redisDel: vi.fn(),
+}));
+
+vi.mock('@roomote/cloud-agents/server', () => ({
+  enqueueTask: mocks.enqueueTask,
+}));
+
+vi.mock('@roomote/communication', () => ({
+  getCommunicationMessages: mocks.getCommunicationMessages,
+  peekCommunicationMessageCount: mocks.peekCommunicationMessageCount,
+  prependCommunicationMessages: mocks.prependCommunicationMessages,
+}));
+
+vi.mock('@roomote/db/server', () => ({
+  db: {},
+  recordTaskRunEvent: mocks.recordTaskRunEvent,
+}));
+
+vi.mock('@roomote/redis', () => ({
+  getRedis: () => ({ set: mocks.redisSet, del: mocks.redisDel }),
+}));
+
+import { drainCommunicationMessagesToResumeRun } from '../drain-communication-messages';
+
+const orphanedMessage = {
+  text: 'address the review feedback',
+  user: 'roomote',
+  userId: 'user-1',
+  ts: 'orphaned-ts',
+};
+
+const sourceRun = {
+  id: 41,
+  taskId: 'task-1',
+  snapshotId: 'snapshot-1',
+  payload: {
+    repo: 'acme/repo',
+    communicationProvider: 'discord',
+    communicationChannelId: 'channel-1',
+    communicationThreadId: 'thread-1',
+    discordTaskThread: true,
+  },
+  port: null,
+};
+
+describe('drainCommunicationMessagesToResumeRun', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.enqueueTask.mockResolvedValue({ id: 42, taskId: 'task-1' });
+    mocks.peekCommunicationMessageCount.mockResolvedValue(1);
+    mocks.getCommunicationMessages.mockResolvedValue([orphanedMessage]);
+    mocks.recordTaskRunEvent.mockResolvedValue(undefined);
+    mocks.redisSet.mockResolvedValue('OK');
+  });
+
+  it('creates a resume run embedding the drained messages', async () => {
+    const result = await drainCommunicationMessagesToResumeRun(sourceRun);
+
+    expect(result).toEqual({
+      resumed: true,
+      runId: 42,
+      taskId: 'task-1',
+      provider: 'discord',
+      messageCount: 1,
+    });
+    expect(mocks.enqueueTask).toHaveBeenCalledWith({
+      task: expect.objectContaining({
+        sourceSnapshotId: 'snapshot-1',
+        sourceRunId: 41,
+        payload: expect.objectContaining({
+          communicationProvider: 'discord',
+          communicationChannelId: 'channel-1',
+          discordTaskThread: true,
+          queuedCommunicationMessages: [
+            expect.objectContaining({ ts: 'orphaned-ts', provider: 'discord' }),
+          ],
+        }),
+      }),
+      actingUserId: 'user-1',
+    });
+    expect(mocks.recordTaskRunEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        runId: 41,
+        source: 'snapshot_resume',
+        details: expect.objectContaining({
+          drainedCount: 1,
+          resumeRunId: 42,
+        }),
+      }),
+    );
+  });
+
+  it('does nothing when the run has no communication provider', async () => {
+    const result = await drainCommunicationMessagesToResumeRun({
+      ...sourceRun,
+      payload: { repo: 'acme/repo' },
+    });
+
+    expect(result).toEqual({
+      resumed: false,
+      reason: 'no_communication_provider',
+    });
+    expect(mocks.peekCommunicationMessageCount).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the queue is empty', async () => {
+    mocks.peekCommunicationMessageCount.mockResolvedValue(0);
+
+    const result = await drainCommunicationMessagesToResumeRun(sourceRun);
+
+    expect(result).toEqual({
+      resumed: false,
+      reason: 'no_pending_messages',
+      provider: 'discord',
+    });
+    expect(mocks.enqueueTask).not.toHaveBeenCalled();
+  });
+
+  it('skips when another drain holds the lock', async () => {
+    mocks.redisSet.mockResolvedValue(null);
+
+    const result = await drainCommunicationMessagesToResumeRun(sourceRun);
+
+    expect(result).toEqual({
+      resumed: false,
+      reason: 'resume_lock_held',
+      provider: 'discord',
+    });
+    expect(mocks.getCommunicationMessages).not.toHaveBeenCalled();
+  });
+
+  it('restores drained messages and releases the lock when enqueue fails', async () => {
+    mocks.enqueueTask.mockRejectedValue(new Error('enqueue failed'));
+
+    await expect(
+      drainCommunicationMessagesToResumeRun(sourceRun),
+    ).rejects.toThrow('enqueue failed');
+
+    expect(mocks.prependCommunicationMessages).toHaveBeenCalledWith(
+      'discord',
+      41,
+      [orphanedMessage],
+    );
+    expect(mocks.redisDel).toHaveBeenCalledWith('discord:drain-resume-lock:41');
+  });
+
+  it('prefers the snapshot id override', async () => {
+    await drainCommunicationMessagesToResumeRun(
+      { ...sourceRun, snapshotId: null },
+      'fresh-snapshot',
+    );
+
+    expect(mocks.enqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          sourceSnapshotId: 'fresh-snapshot',
+        }),
+      }),
+    );
+  });
+});

--- a/packages/sdk/src/server/lib/communication/communication-snapshot-resume.ts
+++ b/packages/sdk/src/server/lib/communication/communication-snapshot-resume.ts
@@ -1,5 +1,10 @@
 import { enqueueTask } from '@roomote/cloud-agents/server';
 import {
+  getCommunicationMessages,
+  prependCommunicationMessages,
+} from '@roomote/communication';
+import { db, recordTaskRunEvent } from '@roomote/db/server';
+import {
   ALL_REPOSITORIES,
   TaskPayloadKind,
   populateSnapshotResumeCommunicationMetadata,
@@ -13,6 +18,58 @@ import {
   attachOutOfBandContextToCommunicationMessage,
   releaseCommunicationOutOfBandClaim,
 } from './communication-out-of-band-context';
+
+/**
+ * Drain any messages still sitting in the source run's per-run Redis queue.
+ * They were queued while that run was alive but never delivered (for example
+ * when its poller wedged before the due-sleep snapshot), so a resume that
+ * ignored them would orphan those prompts permanently. Callers must either
+ * hand the drained messages to the resume run or put them back.
+ */
+async function drainUndeliveredCommunicationMessages(
+  provider: CommunicationProvider,
+  sourceRunId: number,
+): Promise<QueuedCommunicationMessage[]> {
+  try {
+    return await getCommunicationMessages(provider, sourceRunId);
+  } catch (error) {
+    console.error(
+      `[resumeCommunicationTaskFromSnapshot] Failed to drain undelivered ${provider} messages for source run ${sourceRunId}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+
+    return [];
+  }
+}
+
+async function recordCarriedMessagesEvent(input: {
+  provider: CommunicationProvider;
+  sourceRunId: number;
+  taskId?: string;
+  carried: QueuedCommunicationMessage[];
+}): Promise<void> {
+  try {
+    await recordTaskRunEvent(db, {
+      runId: input.sourceRunId,
+      taskId: input.taskId,
+      source: 'snapshot_resume',
+      eventType: 'decision',
+      message: `Carried ${input.carried.length} undelivered queued ${input.provider} message(s) from run #${input.sourceRunId} into the snapshot resume payload.`,
+      details: {
+        provider: input.provider,
+        carriedCount: input.carried.length,
+        carriedTs: input.carried.map((message) => message.ts),
+      },
+    });
+  } catch (error) {
+    console.warn(
+      `[resumeCommunicationTaskFromSnapshot] Failed to record carried-messages event for source run ${input.sourceRunId}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
 
 type CompletedCommunicationTaskRun = {
   id: number;
@@ -78,6 +135,24 @@ export async function resumeCommunicationTaskFromSnapshot(input: {
     outOfBandClaim = attached.claim;
   }
 
+  // Undelivered leftovers ride ahead of the new message so the resume run
+  // replays the conversation in its original order.
+  const undeliveredMessages = (
+    await drainUndeliveredCommunicationMessages(
+      input.provider,
+      input.completedRun.id,
+    )
+  ).filter((message) => message.ts !== queuedMessage.ts);
+
+  if (undeliveredMessages.length > 0) {
+    await recordCarriedMessagesEvent({
+      provider: input.provider,
+      sourceRunId: input.completedRun.id,
+      taskId: input.completedRun.taskId,
+      carried: undeliveredMessages,
+    });
+  }
+
   const resumePayload: TaskPayload<typeof TaskPayloadKind.SnapshotResume> = {
     repo,
     ...(environmentId ? { environmentId } : {}),
@@ -85,6 +160,10 @@ export async function resumeCommunicationTaskFromSnapshot(input: {
     sourceSnapshotId: input.completedRun.snapshotId,
     sourceRunId: input.completedRun.id,
     queuedCommunicationMessages: [
+      ...undeliveredMessages.map((message) => ({
+        ...message,
+        provider: input.provider,
+      })),
       {
         ...queuedMessage,
         provider: input.provider,
@@ -134,6 +213,27 @@ export async function resumeCommunicationTaskFromSnapshot(input: {
     );
   } catch (error) {
     await releaseCommunicationOutOfBandClaim(outOfBandClaim);
+
+    if (undeliveredMessages.length > 0) {
+      // The resume never launched; put the drained leftovers back so the next
+      // resume attempt can carry them again.
+      try {
+        await prependCommunicationMessages(
+          input.provider,
+          input.completedRun.id,
+          undeliveredMessages,
+        );
+      } catch (requeueError) {
+        console.error(
+          `[resumeCommunicationTaskFromSnapshot] Failed to requeue ${undeliveredMessages.length} drained ${input.provider} message(s) for source run ${input.completedRun.id}: ${
+            requeueError instanceof Error
+              ? requeueError.message
+              : String(requeueError)
+          }`,
+        );
+      }
+    }
+
     throw error;
   }
 }

--- a/packages/sdk/src/server/lib/communication/drain-communication-messages.ts
+++ b/packages/sdk/src/server/lib/communication/drain-communication-messages.ts
@@ -1,0 +1,205 @@
+import { enqueueTask } from '@roomote/cloud-agents/server';
+import {
+  getCommunicationMessages,
+  peekCommunicationMessageCount,
+  prependCommunicationMessages,
+} from '@roomote/communication';
+import { db, recordTaskRunEvent } from '@roomote/db/server';
+import { getRedis } from '@roomote/redis';
+import {
+  ALL_REPOSITORIES,
+  TaskPayloadKind,
+  getCommunicationProviderFromTaskPayload,
+  populateSnapshotResumeCommunicationMetadata,
+  restoreSnapshotResumeVisiblePromptFields,
+  type CommunicationProvider,
+  type QueuedCommunicationMessage,
+  type TaskPayload,
+} from '@roomote/types';
+
+const RESUME_LOCK_TTL_SECONDS = 30;
+
+/**
+ * Payload flags that must survive into a resume run so its outbound messages
+ * keep landing in the right provider surface (dedicated thread/topic).
+ */
+const PRESERVED_PAYLOAD_FLAGS = ['discordTaskThread', 'telegramTaskTopic'];
+
+/**
+ * Minimum shape of the source task run required by the drain helper, kept
+ * narrow so both SDK routers (full DB rows) and the BullMQ snapshot handler
+ * (partial query results) can call it.
+ */
+interface CommunicationDrainSourceRun {
+  id: number;
+  taskId?: string;
+  snapshotId: string | null;
+  payload: Record<string, unknown>;
+  port: number | null;
+}
+
+type CommunicationDrainResult =
+  | {
+      resumed: true;
+      runId: number;
+      taskId: string;
+      provider: CommunicationProvider;
+      messageCount: number;
+    }
+  | { resumed: false; reason: string; provider?: CommunicationProvider };
+
+/**
+ * Peek for pending Discord/Telegram/Teams messages on a snapshotted task run
+ * and, if any exist, create a SnapshotResume run that embeds them for worker
+ * replay. The non-Slack counterpart of `drainSlackMessagesToResumeRun`:
+ * without it, a message queued into a run whose poller died before the
+ * due-sleep snapshot is orphaned in Redis until its TTL expires — the run
+ * sleeps, nothing ever wakes it, and the sender's prompt silently vanishes.
+ *
+ * If resume creation fails, the drained messages are restored to the source
+ * run's queue.
+ */
+export async function drainCommunicationMessagesToResumeRun(
+  sourceRun: CommunicationDrainSourceRun,
+  snapshotIdOverride?: string,
+): Promise<CommunicationDrainResult> {
+  const provider = getCommunicationProviderFromTaskPayload(sourceRun.payload);
+
+  if (!provider || provider === 'slack') {
+    return { resumed: false, reason: 'no_communication_provider' };
+  }
+
+  const snapshotId = snapshotIdOverride ?? sourceRun.snapshotId;
+
+  if (!snapshotId) {
+    return { resumed: false, reason: 'no_snapshot', provider };
+  }
+
+  const messageCount = await peekCommunicationMessageCount(
+    provider,
+    sourceRun.id,
+  );
+
+  if (messageCount === 0) {
+    return { resumed: false, reason: 'no_pending_messages', provider };
+  }
+
+  // One drain per source run at a time; the atomic queue pop keeps a race
+  // with a concurrent inbound-message resume from duplicating messages.
+  const redis = getRedis();
+  const lockKey = `${provider}:drain-resume-lock:${sourceRun.id}`;
+  const acquired = await redis.set(
+    lockKey,
+    '1',
+    'EX',
+    RESUME_LOCK_TTL_SECONDS,
+    'NX',
+  );
+
+  if (!acquired) {
+    return { resumed: false, reason: 'resume_lock_held', provider };
+  }
+
+  const sourcePayload = sourceRun.payload;
+  const repo =
+    typeof sourcePayload?.repo === 'string'
+      ? sourcePayload.repo
+      : ALL_REPOSITORIES;
+  const environmentId =
+    typeof sourcePayload?.environmentId === 'string'
+      ? sourcePayload.environmentId
+      : undefined;
+
+  let messages: QueuedCommunicationMessage[] = [];
+
+  try {
+    messages = await getCommunicationMessages(provider, sourceRun.id);
+
+    if (messages.length === 0) {
+      await redis.del(lockKey);
+      return { resumed: false, reason: 'no_pending_messages', provider };
+    }
+
+    const resumePayload: TaskPayload<typeof TaskPayloadKind.SnapshotResume> = {
+      repo,
+      ...(environmentId ? { environmentId } : {}),
+      ...(sourceRun.port ? { port: sourceRun.port } : {}),
+      sourceSnapshotId: snapshotId,
+      sourceRunId: sourceRun.id,
+      queuedCommunicationMessages: messages.map((message) => ({
+        ...message,
+        provider,
+      })),
+    };
+    populateSnapshotResumeCommunicationMetadata(resumePayload, {
+      provider,
+      sourcePayload,
+    });
+    for (const key of PRESERVED_PAYLOAD_FLAGS) {
+      if (sourcePayload[key] === true) {
+        (resumePayload as Record<string, unknown>)[key] = true;
+      }
+    }
+    restoreSnapshotResumeVisiblePromptFields(resumePayload, sourcePayload);
+
+    // The resumer becomes the new run's acting user: the most recent drained
+    // follow-up sender we could resolve to a Roomote user.
+    const resumeActingUserId =
+      [...messages].reverse().find((message) => message.userId)?.userId ?? null;
+
+    const resumeLaunch = await enqueueTask({
+      task: {
+        type: TaskPayloadKind.SnapshotResume,
+        sourceSnapshotId: snapshotId,
+        sourceRunId: sourceRun.id,
+        payload: resumePayload,
+      },
+      actingUserId: resumeActingUserId,
+    });
+
+    try {
+      await recordTaskRunEvent(db, {
+        runId: sourceRun.id,
+        taskId: sourceRun.taskId,
+        source: 'snapshot_resume',
+        eventType: 'decision',
+        message: `Drained ${messages.length} undelivered queued ${provider} message(s) into snapshot resume run #${resumeLaunch.id}.`,
+        details: {
+          provider,
+          drainedCount: messages.length,
+          drainedTs: messages.map((message) => message.ts),
+          resumeRunId: resumeLaunch.id,
+        },
+      });
+    } catch (eventError) {
+      console.warn(
+        `[drainCommunicationMessagesToResumeRun] Failed to record drain event for run ${sourceRun.id}: ${
+          eventError instanceof Error ? eventError.message : String(eventError)
+        }`,
+      );
+    }
+
+    console.log(
+      `[drainCommunicationMessagesToResumeRun] Created resume task run ${resumeLaunch.id} with ${messages.length} ${provider} message(s)`,
+    );
+
+    return {
+      resumed: true,
+      runId: resumeLaunch.id,
+      taskId: resumeLaunch.taskId,
+      provider,
+      messageCount: messages.length,
+    };
+  } catch (error) {
+    // Restore drained messages and release the lock so a retry can proceed.
+    try {
+      if (messages.length > 0) {
+        await prependCommunicationMessages(provider, sourceRun.id, messages);
+      }
+      await redis.del(lockKey);
+    } catch {
+      // no-op
+    }
+    throw error;
+  }
+}

--- a/packages/sdk/src/server/lib/communication/index.ts
+++ b/packages/sdk/src/server/lib/communication/index.ts
@@ -1,3 +1,4 @@
 export * from './communication-snapshot-resume';
+export * from './drain-communication-messages';
 export * from './communication-task-run-lookup';
 export * from './communication-out-of-band-context';

--- a/packages/sdk/src/server/lib/task-runs/pr-review-follow-up-dispatch.ts
+++ b/packages/sdk/src/server/lib/task-runs/pr-review-follow-up-dispatch.ts
@@ -31,7 +31,40 @@ import {
   findActiveCommunicationTaskRun,
   findCompletedCommunicationTaskRunWithSnapshot,
 } from '../communication/communication-task-run-lookup';
+import { recordTaskRunEvent } from './record-task-run-event';
 import type { PrReviewActionProvider } from './pr-review-action';
+
+/**
+ * Durable record that a PR review follow-up was queued into an active run's
+ * Redis queue. The queue itself is invisible after the sandbox dies, so this
+ * event is what lets an operator pair "queued" with the worker's popped/
+ * delivered events when a follow-up goes missing. Fire-and-forget.
+ */
+function recordFollowUpQueuedEvent(input: {
+  runId: number;
+  provider: PrReviewActionProvider;
+  ts: string;
+  runStatus?: string;
+}): void {
+  void recordTaskRunEvent({
+    runId: input.runId,
+    source: 'communication_queue',
+    eventType: 'decision',
+    message: `Queued a PR review follow-up (${input.provider} ts=${input.ts}) into the run's message queue.`,
+    details: {
+      provider: input.provider,
+      ts: input.ts,
+      kind: 'pr_review_follow_up',
+      ...(input.runStatus ? { runStatus: input.runStatus } : {}),
+    },
+  }).catch((error: unknown) => {
+    console.warn(
+      `[dispatchPrReviewFollowUp] Failed to record queued event for run ${input.runId}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  });
+}
 
 export type PrReviewFollowUpDispatchResult =
   | { outcome: 'queued'; runId: number }
@@ -89,6 +122,12 @@ async function dispatchSlackFollowUp(input: {
       userId: input.actingUserId,
     });
     await queueSlackMessage(activeRun.id, queuedMessage);
+    recordFollowUpQueuedEvent({
+      runId: activeRun.id,
+      provider: 'slack',
+      ts: queuedMessage.ts,
+      runStatus: activeRun.status,
+    });
 
     return { outcome: 'queued', runId: activeRun.id };
   }
@@ -211,6 +250,12 @@ async function dispatchCommunicationFollowUp(input: {
       userId: input.actingUserId,
     });
     await queueCommunicationMessage(provider, activeRun.id, queuedMessage);
+    recordFollowUpQueuedEvent({
+      runId: activeRun.id,
+      provider,
+      ts: queuedMessage.ts,
+      runStatus: activeRun.status,
+    });
 
     return { outcome: 'queued', runId: activeRun.id };
   }

--- a/packages/sdk/src/server/lib/task-runs/record-task-run-event.ts
+++ b/packages/sdk/src/server/lib/task-runs/record-task-run-event.ts
@@ -18,3 +18,38 @@ export async function recordTaskRunEvent(input: {
   const { runId, ...rest } = input;
   await persistTaskRunEvent(db, { runId: runId, ...rest });
 }
+
+/**
+ * Durable proof that the worker's poller fetched (and thereby atomically
+ * removed) queued messages from the per-run Redis queue. Without this record
+ * there is no way to tell, after the sandbox is gone, whether an undelivered
+ * message was never popped (poller dead) or popped and then lost. Recorded
+ * fire-and-forget: delivery must never fail because the audit write did.
+ */
+export function recordQueuedMessagesPoppedEvent(input: {
+  runId: number;
+  provider: string;
+  poppedTs: string[];
+}): void {
+  if (input.poppedTs.length === 0) {
+    return;
+  }
+
+  void recordTaskRunEvent({
+    runId: input.runId,
+    source: 'communication_queue',
+    eventType: 'decision',
+    message: `Worker popped ${input.poppedTs.length} queued ${input.provider} message(s) for delivery.`,
+    details: {
+      provider: input.provider,
+      poppedCount: input.poppedTs.length,
+      poppedTs: input.poppedTs,
+    },
+  }).catch((error: unknown) => {
+    console.warn(
+      `[recordQueuedMessagesPoppedEvent] Failed to persist popped event for run ${input.runId}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  });
+}

--- a/packages/sdk/src/server/routers/task-runs.ts
+++ b/packages/sdk/src/server/routers/task-runs.ts
@@ -93,6 +93,7 @@ import {
   refreshGitHubTokenWithMetadata,
   fetchSnapshotEnv,
   recordTaskRunEvent,
+  recordQueuedMessagesPoppedEvent,
   stampTaskRunMilestone,
   taskRunMilestoneFields,
   updateTaskRunEnvironmentSetup,
@@ -552,7 +553,17 @@ export const taskRunsRouter = router({
     )
     .mutation(async ({ ctx, input }) => revertPrCommit(ctx.auth, input)),
   getSlackMessages: runScoped(z.object({ runId: z.number() }), 'runId').query(
-    async ({ input }) => getSlackMessages(input.runId),
+    async ({ input }) => {
+      const messages = await getSlackMessages(input.runId);
+
+      recordQueuedMessagesPoppedEvent({
+        runId: input.runId,
+        provider: 'slack',
+        poppedTs: messages.map((message) => message.ts),
+      });
+
+      return messages;
+    },
   ),
   getCommunicationMessages: runScoped(
     z.object({
@@ -560,9 +571,20 @@ export const taskRunsRouter = router({
       provider: communicationProviderSchema,
     }),
     'runId',
-  ).query(async ({ input }) =>
-    getCommunicationMessages(input.provider, input.runId),
-  ),
+  ).query(async ({ input }) => {
+    const messages = await getCommunicationMessages(
+      input.provider,
+      input.runId,
+    );
+
+    recordQueuedMessagesPoppedEvent({
+      runId: input.runId,
+      provider: input.provider,
+      poppedTs: messages.map((message) => message.ts),
+    });
+
+    return messages;
+  }),
   queueSlackMessage: runTokenOnlyScoped(
     z.object({
       runId: z.number(),

--- a/packages/types/src/task-runs.ts
+++ b/packages/types/src/task-runs.ts
@@ -662,6 +662,7 @@ export const runEventSources = [
   'sleep_check',
   'compute_provider',
   'machine_oidc',
+  'communication_queue',
   'snapshot_request',
   'snapshot_queue',
   'snapshot_resume',


### PR DESCRIPTION
## Problem

A Discord PR-review button follow-up on a staging idle run was acked as started but never delivered. The chain: the follow-up was queued into the run's per-run Redis queue, the worker's queued-message poller had silently stopped (a single hung poll permanently blocked all future polls, with no timeout on the underlying tRPC fetches), and when the run hit its due-sleep snapshot nothing migrated the leftover queue — the prompt was orphaned until its TTL expired.

## Fixes

**Worker poller stall watchdog** (`apps/worker/src/run-task/polling/`)
- New `createSerializedPollLoop` keeps polls non-overlapping (the old chained-promise behavior) but bounds each poll with a 5-minute stall deadline. A stalled poll is logged, captured to Sentry, recorded as a durable diagnostic event, and abandoned so the next tick starts a fresh poll. Applied to the communication (Discord/Telegram/Teams), Slack, and Linear pollers; Linear previously allowed overlapping polls and now also gets a bounded cleanup on stop.
- Delivery outcomes (delivered / skipped / requeued) are recorded as durable diagnostic events.

**Worker SDK fetch deadline** (`packages/sdk/src/client/index.ts`)
- Every worker callback fetch attempt now races a 60s deadline (enforced even if the transport never observes the abort signal). Timed-out attempts retry like transport errors; caller-initiated aborts surface unchanged.

**No more orphaned queues at sleep handoff** (`packages/sdk/src/server/lib/communication/`, `apps/bullmq/src/jobs/snapshot.ts`)
- The snapshot-completion job now drains pending Discord/Telegram/Teams messages into a fresh `SnapshotResume` run — the exact counterpart of the existing Slack/Linear drains, which these providers were missing. On enqueue failure the messages are restored and the drain lock released.
- `resumeCommunicationTaskFromSnapshot` additionally carries any leftover source-run queue messages into the resume payload ahead of the new message, so later conversation resumes also recover strays.

**Durable queue lifecycle audit** (`communication_queue` event source)
- Queued: PR-review follow-ups dispatched into an active run record a durable event with the run status at queue time.
- Popped: the `getSlackMessages` / `getCommunicationMessages` tRPC procedures record when the worker pops queued messages.
- Together with the worker-side delivered/skipped/requeued/stalled events, a lost message's last known stage is now visible after the sandbox is gone.

## Tests

- `serialized-poll-loop.test.ts`: hanging-poll watchdog, no-overlap, stall recovery, bounded cleanup, post-cleanup stop (6 tests).
- SDK client: hung-fetch deadline, timeout-then-retry-success, caller aborts not rewritten (3 new tests; 24 total pass).
- `drain-communication-messages.test.ts`: drain-to-resume, empty queue, lock contention, restore-on-failure, snapshot-id override (6 tests).
- Snapshot-resume carry: leftovers ride ahead of the new message, no duplication, requeue on enqueue failure (3 new tests).
- Full suites pass: sdk 737, api 1370, bullmq 120, types 647, worker 1532 (the 4 worker failures are pre-existing macOS `/tmp` symlink quirks, reproduced on a clean checkout).

## Notes

- Standby-capable providers (`enterStandby` path) skip the snapshot job, so they don't get the immediate drain — same pre-existing gap as Slack/Linear; the resume-time carry covers recovery there.
- Delivery-verified dispatch acks (confirming a turn actually starts before posting "Starting on the current feedback now.") are deliberately left for a follow-up PR since they change user-visible ack semantics on three surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
