### PR TITLE
Ship apps/docs in the app image so setup docs render

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -81,6 +81,9 @@ COPY apps/bullmq ./apps/bullmq/
 COPY apps/discord-gateway ./apps/discord-gateway/
 COPY apps/preview-proxy ./apps/preview-proxy/
 COPY apps/worker ./apps/worker/
+# The web app reads setup-flow documentation from apps/docs at runtime and
+# copies its logo assets into public/ during `pnpm docs:assets`.
+COPY apps/docs ./apps/docs/
 
 ARG R_APP_ENV
 ARG RELEASE_VERSION
@@ -349,6 +352,9 @@ RUN chmod +x /entrypoint.sh
 COPY --chown=roomote-app:roomote-app --from=build-web /roomote/apps/web/.next/standalone ./
 COPY --chown=roomote-app:roomote-app --from=build-web /roomote/apps/web/.next/static ./apps/web/.next/static/
 COPY --chown=roomote-app:roomote-app --from=build-web /roomote/apps/web/public ./apps/web/public/
+# The web server (cwd /roomote/apps/web) reads setup-flow docs from
+# ../docs at request time, so the MDX sources must ship in the image.
+COPY --chown=roomote-app:roomote-app --from=build-web /roomote/apps/docs ./apps/docs/
 COPY --from=build-api /roomote/apps/api/package.json ./apps/api/
 COPY --from=build-api /roomote/apps/api/dist ./apps/api/dist/
 COPY --from=build-api /runtime-deps/node_modules ./apps/api/node_modules/

--- a/.dockerignore
+++ b/.dockerignore
@@ -24,7 +24,6 @@ knip.json
 # monorepo
 .turbo/
 **/.turbo/
-apps/docs/
 
 # next.js
 **/.next/


### PR DESCRIPTION
The contextual setup documentation from #724 doesn't render in any deployed environment: .dockerignore excludes apps/docs from the Docker build context and the app Dockerfile never copies it, while apps/web/src/lib/docs-content.ts reads the MDX at request time from ../docs and silently returns null on failure — so the panel just disappears. Works in local dev because the repo checkout has apps/docs.

Fix: include apps/docs in the build context, copy it into the build stage (also un-breaks the silent pnpm docs:assets logo sync) and into the runtime image next to apps/web where the server (cwd /roomote/apps/web) resolves ../docs.

Verified locally: built the base stage with the new context and confirmed /roomote/apps/docs is present. pnpm install is unaffected (docs land after install). apps/docs is 79 small MDX/config files, so image-size impact is negligible.

After merge, the develop build auto-rolls to the preview fleet — verify by opening a setup step on a preview tenant.