### PR TITLE
[Fix] Isolate app-URL env vars in Slack install-after-auth route tests

### DIFF
--- a/apps/web/src/app/api/slack/install-after-auth/__tests__/route.test.ts
+++ b/apps/web/src/app/api/slack/install-after-auth/__tests__/route.test.ts
@@ -13,14 +13,36 @@ const mockInstallation = vi.fn();
 const mockConnectApp = vi.fn();
 
 describe('GET /api/slack/install-after-auth', () => {
+  // getCallbackHost rewrites internal request origins (localhost) to the
+  // configured public app URL, so machine-level R_APP_URL/R_PUBLIC_URL (e.g. an
+  // ngrok host in the shell) leak into redirect assertions. Pin them per test.
+  const originalAppUrl = process.env.R_APP_URL;
+  const originalPublicUrl = process.env.R_PUBLIC_URL;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    process.env.R_APP_URL = 'http://localhost:13000';
+    delete process.env.R_PUBLIC_URL;
     mockCreateServerCaller.mockResolvedValue({
       slack: {
         installation: mockInstallation,
         connectApp: mockConnectApp,
       },
     } as never);
+  });
+
+  afterEach(() => {
+    if (originalAppUrl === undefined) {
+      delete process.env.R_APP_URL;
+    } else {
+      process.env.R_APP_URL = originalAppUrl;
+    }
+
+    if (originalPublicUrl === undefined) {
+      delete process.env.R_PUBLIC_URL;
+    } else {
+      process.env.R_PUBLIC_URL = originalPublicUrl;
+    }
   });
 
   it('redirects to the requested path when Slack is already installed', async () => {


### PR DESCRIPTION
## Description

Two tests in `apps/web/src/app/api/slack/install-after-auth/__tests__/route.test.ts` ("redirects to the requested path when Slack is already installed" and "falls back to the app root for unsafe redirect paths") fail on machines where the deployment app URL is set in the shell (e.g. `R_APP_URL=https://<public-host>`).

The route builds redirect locations through `getCallbackHost`, which rewrites internal request origins (`localhost`) to the configured public app URL (`R_PUBLIC_URL ?? R_APP_URL`). Under dotenvx, shell values take precedence over `.env.test`, so a machine-level app URL leaked into the `http://localhost:13000/...` redirect assertions.

## Changes

- Pin `process.env.R_APP_URL` to `http://localhost:13000` and clear `R_PUBLIC_URL` in `beforeEach`
- Restore both originals in `afterEach` (vitest worker threads share `process.env` across test files)

This works because the web `Env` proxy initializes lazily on first access (inside the first `GET` call, after `beforeEach`), and dotenvx resolves with `process.env` precedence at read time. Mirrors the save/restore pattern used in `apps/web/src/trpc/commands/task-models/index.test.ts`.

## Verification

Ran `pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/web exec vitest run "src/app/api/slack/install-after-auth/__tests__/route.test.ts"` under three shell configurations: clean env, `R_APP_URL` set to a public host, and both `R_APP_URL` and `R_PUBLIC_URL` set. All 3 tests pass in each case.