### PR TITLE
[Fix] Setup sync repeats after source-control callback

### DIFF
--- a/apps/web/src/app/(onboarding)/setup/SetupPageClient.tsx
+++ b/apps/web/src/app/(onboarding)/setup/SetupPageClient.tsx
@@ -212,6 +212,11 @@ export default function SetupPageClient({
     },
     [commitSetupUrl, readSetupSearchParams],
   );
+  const removeSourceControlSyncMarker = useCallback(() => {
+    const params = readSetupSearchParams();
+    params.delete('sync');
+    commitSetupUrl(params);
+  }, [commitSetupUrl, readSetupSearchParams]);
   const saveSourceControlProviderChoice = useMutation(
     trpc.setupNew.saveSourceControlProviderChoice.mutationOptions({
       onSuccess: async (_data, variables) => {
@@ -749,6 +754,7 @@ export default function SetupPageClient({
             <StepSourceControlConnect
               sourceControlSetup={status.sourceControlSetup}
               onContinue={goToNextStep}
+              onRemoveSyncMarker={removeSourceControlSyncMarker}
               onBack={canGoBack ? goToPreviousStep : undefined}
             />
           )}

--- a/apps/web/src/app/(onboarding)/setup/SetupPageClient.tsx
+++ b/apps/web/src/app/(onboarding)/setup/SetupPageClient.tsx
@@ -53,7 +53,6 @@ import { getSetupStepPath } from './types';
 import { useSetSetupDocsContent } from './SetupDocsContext';
 import {
   getBootstrapAuthProvider,
-  getBootstrapStepPath,
   getBootstrapStepFromSetupStepParam,
   getBootstrapStepAfterWelcome,
   getNextBootstrapStep,
@@ -131,28 +130,6 @@ export default function SetupPageClient({
     useState<'forward' | 'backward'>('forward');
   const bootstrapStepRef = useRef(bootstrapStep);
   bootstrapStepRef.current = bootstrapStep;
-  const setBootstrapStepWithTransition = useCallback(
-    (nextStep: BootstrapStep) => {
-      const currentIndex = BOOTSTRAP_STEPS.indexOf(bootstrapStepRef.current);
-      const nextIndex = BOOTSTRAP_STEPS.indexOf(nextStep);
-
-      if (nextStep !== bootstrapStepRef.current) {
-        setBootstrapTransitionDirection(
-          nextIndex >= currentIndex ? 'forward' : 'backward',
-        );
-      }
-
-      bootstrapStepRef.current = nextStep;
-      setBootstrapStep(nextStep);
-      router.replace(
-        getBootstrapStepPath(
-          nextStep,
-          new URLSearchParams(window.location.search),
-        ),
-      );
-    },
-    [router],
-  );
   const [pendingAuthProvider, setPendingAuthProvider] =
     useState<CommunicationProviderChoice | null>(null);
   const pendingSetupAuthProvider =
@@ -206,6 +183,8 @@ export default function SetupPageClient({
     goToNextStep,
     canGoBack,
     goToNextPostOnboardingStep,
+    readSetupSearchParams,
+    commitSetupUrl,
     status,
     setupSession,
     isLoading,
@@ -214,6 +193,25 @@ export default function SetupPageClient({
     enabled: isSignedIn && isAdmin,
     pendingAuthProvider: pendingSetupAuthProvider,
   });
+  const setBootstrapStepWithTransition = useCallback(
+    (nextStep: BootstrapStep) => {
+      const currentIndex = BOOTSTRAP_STEPS.indexOf(bootstrapStepRef.current);
+      const nextIndex = BOOTSTRAP_STEPS.indexOf(nextStep);
+
+      if (nextStep !== bootstrapStepRef.current) {
+        setBootstrapTransitionDirection(
+          nextIndex >= currentIndex ? 'forward' : 'backward',
+        );
+      }
+
+      bootstrapStepRef.current = nextStep;
+      setBootstrapStep(nextStep);
+      const params = readSetupSearchParams();
+      params.set('step', nextStep);
+      commitSetupUrl(params);
+    },
+    [commitSetupUrl, readSetupSearchParams],
+  );
   const saveSourceControlProviderChoice = useMutation(
     trpc.setupNew.saveSourceControlProviderChoice.mutationOptions({
       onSuccess: async (_data, variables) => {
@@ -298,8 +296,12 @@ export default function SetupPageClient({
   const selectedModelProvider =
     pendingModelProvider ?? status?.setupNewState.modelProvider;
 
+  // The docs panel is server-rendered from these params, so keep them on the
+  // URL. Read and write through the setup flow's shared query view rather than
+  // `window.location`: a step navigation may not have reached the address bar
+  // yet, and writing a stale `step` back would leave the docs on the old step.
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
+    const params = readSetupSearchParams();
     const providerParams = {
       authProvider: selectedAuthProvider,
       computeProvider: selectedComputeProvider,
@@ -319,10 +321,11 @@ export default function SetupPageClient({
     }
 
     if (changed) {
-      router.replace(`${window.location.pathname}?${params}`);
+      commitSetupUrl(params);
     }
   }, [
-    router,
+    commitSetupUrl,
+    readSetupSearchParams,
     selectedAuthProvider,
     selectedComputeProvider,
     selectedModelProvider,

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConnect.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConnect.client.test.tsx
@@ -598,6 +598,7 @@ describe('StepSourceControlConnect', () => {
       value: { ...window.location, pathname: '/setup', search: '?sync=1' },
     });
     const onContinue = vi.fn();
+    const onRemoveSyncMarker = vi.fn();
 
     render(
       <StepSourceControlConnect
@@ -615,10 +616,12 @@ describe('StepSourceControlConnect', () => {
           ],
         })}
         onContinue={onContinue}
+        onRemoveSyncMarker={onRemoveSyncMarker}
       />,
     );
 
     expect(onContinue).toHaveBeenCalledOnce();
+    expect(onRemoveSyncMarker).toHaveBeenCalledOnce();
   });
 
   it('reports Gitea webhook setup failures as repositories', async () => {

--- a/apps/web/src/app/(onboarding)/setup/StepSourceControlConnect.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepSourceControlConnect.tsx
@@ -70,10 +70,12 @@ function getTokenBackedConnectCopy({
 export function StepSourceControlConnect({
   sourceControlSetup,
   onContinue,
+  onRemoveSyncMarker,
   onBack,
 }: {
   sourceControlSetup: SetupSourceControlStatus;
   onContinue: () => void;
+  onRemoveSyncMarker?: () => void;
   onBack?: () => void;
 }) {
   const trpc = useTRPC();
@@ -329,18 +331,14 @@ export function StepSourceControlConnect({
     void handleSyncRepositories();
 
     if (oauthAutoSyncMarkerPresent) {
-      const params = new URLSearchParams(window.location.search);
-      params.delete('sync');
-      const query = params.toString();
-      window.history.replaceState(
-        {},
-        '',
-        query
-          ? `${window.location.pathname}?${query}`
-          : window.location.pathname,
-      );
+      onRemoveSyncMarker?.();
     }
-  }, [handleSyncRepositories, oauthAutoSyncMarkerPresent, shouldAutoSync]);
+  }, [
+    handleSyncRepositories,
+    oauthAutoSyncMarkerPresent,
+    onRemoveSyncMarker,
+    shouldAutoSync,
+  ]);
 
   useEffect(() => {
     if (
@@ -351,20 +349,14 @@ export function StepSourceControlConnect({
       return;
     }
 
-    const params = new URLSearchParams(window.location.search);
-    params.delete('sync');
-    const query = params.toString();
-    window.history.replaceState(
-      {},
-      '',
-      query ? `${window.location.pathname}?${query}` : window.location.pathname,
-    );
+    onRemoveSyncMarker?.();
     onContinue();
   }, [
     alreadyConnected,
     needsAdoMicrosoftConnection,
     oauthAutoSyncMarkerPresent,
     onContinue,
+    onRemoveSyncMarker,
   ]);
 
   return (

--- a/apps/web/src/app/(onboarding)/setup/bootstrapFlow.client.test.ts
+++ b/apps/web/src/app/(onboarding)/setup/bootstrapFlow.client.test.ts
@@ -2,7 +2,6 @@ import type { SetupAuthProviderId, SetupAuthStatus } from '@roomote/types';
 
 import {
   getBootstrapAuthProvider,
-  getBootstrapStepPath,
   getBootstrapStepFromSetupStepParam,
   getBootstrapStepAfterWelcome,
   getNextBootstrapStep,
@@ -98,14 +97,5 @@ describe('bootstrapFlow', () => {
       getBootstrapStepFromSetupStepParam('source-control-config'),
     ).toBeNull();
     expect(getBootstrapStepFromSetupStepParam(null)).toBeNull();
-  });
-
-  it('preserves setup query parameters when a bootstrap step changes', () => {
-    expect(
-      getBootstrapStepPath(
-        'email-account',
-        new URLSearchParams('token=invite-token'),
-      ),
-    ).toBe('/setup?token=invite-token&step=email-account');
   });
 });

--- a/apps/web/src/app/(onboarding)/setup/bootstrapFlow.ts
+++ b/apps/web/src/app/(onboarding)/setup/bootstrapFlow.ts
@@ -30,15 +30,6 @@ export function getBootstrapStepFromSetupStepParam(
   return step === 'auth-provider' || step === 'auth-env-vars' ? step : null;
 }
 
-export function getBootstrapStepPath(
-  step: BootstrapStep,
-  currentParams: URLSearchParams,
-): string {
-  const params = new URLSearchParams(currentParams);
-  params.set('step', step);
-  return `/setup?${params.toString()}`;
-}
-
 export function getNextBootstrapStep(
   authSetup: SetupAuthStatus | null | undefined,
   pendingAuthProvider?: SetupAuthProviderId | null,

--- a/apps/web/src/app/(onboarding)/setup/hooks.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/hooks.client.test.tsx
@@ -1397,6 +1397,34 @@ describe('useSetupFlow', () => {
     expect(routerMock.push).toHaveBeenCalledWith('/setup?step=auth-provider');
   });
 
+  it('merges a later URL write into a step navigation the address bar has not committed yet', async () => {
+    mockStatus();
+    setLocationSearch('?step=welcome');
+
+    const { result } = renderHook(() => useSetupFlow());
+
+    await waitFor(() => {
+      expect(result.current.step).toBe('welcome');
+    });
+
+    act(() => {
+      result.current.goToStep('auth-env-vars');
+    });
+
+    // `router.push` commits asynchronously, so `window.location.search` still
+    // describes the previous step while the navigation is in flight.
+    const params = result.current.readSetupSearchParams();
+    params.set('authProvider', 'slack');
+
+    act(() => {
+      result.current.commitSetupUrl(params);
+    });
+
+    expect(routerMock.replace).toHaveBeenLastCalledWith(
+      '/setup?step=auth-env-vars&authProvider=slack',
+    );
+  });
+
   it('pushes a direct step URL when goToStep is called', async () => {
     mockStatus();
 

--- a/apps/web/src/app/(onboarding)/setup/hooks.ts
+++ b/apps/web/src/app/(onboarding)/setup/hooks.ts
@@ -12,7 +12,7 @@ import {
 import { useTRPC } from '@/trpc/client';
 import { useUser } from '@/hooks/useUser';
 
-import { SETUP_STEPS, getSetupStepPath, type SetupStep } from './types';
+import { SETUP_STEPS, getSetupPath, type SetupStep } from './types';
 import { useSetupAsyncSession } from './setup-session';
 import { hasSeenSetupWelcome } from './welcome-seen';
 
@@ -105,31 +105,24 @@ function readUrlStep(): SetupStep | null {
  */
 const TRANSIENT_ENTRY_PARAMS = ['slack', 'openrouter', 'reason'] as const;
 
-function stripTransientEntryParams() {
-  if (typeof window === 'undefined') {
-    return;
-  }
-
-  const params = new URLSearchParams(window.location.search);
+/**
+ * Returns the params without the transient entry params, or `null` when none
+ * were present.
+ */
+function stripTransientEntryParams(
+  params: URLSearchParams,
+): URLSearchParams | null {
+  const stripped = new URLSearchParams(params);
   let changed = false;
 
   for (const key of TRANSIENT_ENTRY_PARAMS) {
-    if (params.has(key)) {
-      params.delete(key);
+    if (stripped.has(key)) {
+      stripped.delete(key);
       changed = true;
     }
   }
 
-  if (!changed) {
-    return;
-  }
-
-  const query = params.toString();
-  window.history.replaceState(
-    {},
-    '',
-    query ? `${window.location.pathname}?${query}` : window.location.pathname,
-  );
+  return changed ? stripped : null;
 }
 
 function hasRealProgress(status: {
@@ -274,6 +267,15 @@ export function useSetupFlow(
   const lastUrlStepRef = useRef<SetupStep | null>(null);
   const syncedStepRef = useRef<SetupStep | null>(null);
   const ensuredTaskIdRef = useRef<string | null>(null);
+  // `router.push`/`router.replace` commit the address bar asynchronously, so
+  // `window.location.search` can still describe the previous URL while a
+  // navigation is in flight. Setup writes the URL from two places — step
+  // navigation here and the provider params in SetupPageClient — and both read
+  // and record through this ref so the later write merges into the pending
+  // query instead of reverting the other's change. Reading `window.location`
+  // directly let a provider sync restore a stale `step`, which stranded the
+  // server-rendered docs panel on the previous step's page.
+  const pendingSearchRef = useRef<string | null>(null);
   const setupSession = useSetupAsyncSession({
     currentTaskId: status?.setupNewState.onboardingTaskId ?? null,
   });
@@ -562,20 +564,53 @@ export function useSetupFlow(
     [shouldSkipPostOnboarding],
   );
 
-  const pushStepUrl = useCallback(
-    (nextStep: SetupStep) => {
-      lastUrlStepRef.current = nextStep;
-      router.push(getSetupStepPath(nextStep));
+  const readSetupSearchParams = useCallback(() => {
+    if (pendingSearchRef.current !== null) {
+      return new URLSearchParams(pendingSearchRef.current);
+    }
+
+    return new URLSearchParams(
+      typeof window === 'undefined' ? '' : window.location.search,
+    );
+  }, []);
+
+  const commitSetupUrl = useCallback(
+    (params: URLSearchParams, mode: 'push' | 'replace' = 'replace') => {
+      pendingSearchRef.current = params.toString();
+      const path = getSetupPath(params);
+
+      if (mode === 'push') {
+        router.push(path);
+        return;
+      }
+
+      router.replace(path);
     },
     [router],
   );
 
+  const writeStepUrl = useCallback(
+    (nextStep: SetupStep, mode: 'push' | 'replace') => {
+      lastUrlStepRef.current = nextStep;
+      const params = readSetupSearchParams();
+      params.set('step', nextStep);
+      commitSetupUrl(params, mode);
+    },
+    [commitSetupUrl, readSetupSearchParams],
+  );
+
+  const pushStepUrl = useCallback(
+    (nextStep: SetupStep) => {
+      writeStepUrl(nextStep, 'push');
+    },
+    [writeStepUrl],
+  );
+
   const replaceStepUrl = useCallback(
     (nextStep: SetupStep) => {
-      lastUrlStepRef.current = nextStep;
-      router.replace(getSetupStepPath(nextStep));
+      writeStepUrl(nextStep, 'replace');
     },
-    [router],
+    [writeStepUrl],
   );
 
   // Resolve a requested step (from a deep link or browser back/forward) into
@@ -636,7 +671,13 @@ export function useSetupFlow(
     if (resolvedStep === requestedStep) {
       // Valid deep link: keep the canonical `step` in the URL and only drop
       // the transient callback params so a refresh does not reprocess them.
-      stripTransientEntryParams();
+      const strippedParams = stripTransientEntryParams(readSetupSearchParams());
+
+      if (strippedParams && typeof window !== 'undefined') {
+        pendingSearchRef.current = strippedParams.toString();
+        window.history.replaceState({}, '', getSetupPath(strippedParams));
+      }
+
       lastUrlStepRef.current = resolvedStep;
     } else {
       // Missing, invalid, or gated step: correct the URL to the resolved step
@@ -645,6 +686,7 @@ export function useSetupFlow(
     }
   }, [
     entryContext.step,
+    readSetupSearchParams,
     replaceStepUrl,
     resolveDeepLinkStep,
     setStepWithTransition,
@@ -721,6 +763,9 @@ export function useSetupFlow(
         return;
       }
 
+      // The browser already committed the address bar, so it is authoritative
+      // again and any pending query we were tracking is obsolete.
+      pendingSearchRef.current = null;
       const requestedStep = readUrlStep();
       navigationHistoryRef.current = [];
       const resolvedStep = resolveDeepLinkStep(requestedStep);
@@ -857,6 +902,8 @@ export function useSetupFlow(
     goToNextStep,
     goToNextPostOnboardingStep,
     advancePostOnboardingStep,
+    readSetupSearchParams,
+    commitSetupUrl,
     status,
     isLoading: isLoading || !setupSession.hydrated,
     isError,

--- a/apps/web/src/app/(onboarding)/setup/types.ts
+++ b/apps/web/src/app/(onboarding)/setup/types.ts
@@ -83,3 +83,13 @@ export function getSetupStepDefinition(step: SetupStep) {
 export function getSetupStepPath(step: SetupStep): string {
   return `/setup?step=${step}`;
 }
+
+/**
+ * Canonical setup URL for a full query string. The setup URL carries both the
+ * active `step` and the provider params the docs panel renders from, so every
+ * writer builds the complete query and formats it here.
+ */
+export function getSetupPath(params: URLSearchParams): string {
+  const query = params.toString();
+  return query ? `/setup?${query}` : '/setup';
+}


### PR DESCRIPTION
## What changed

Setup URL updates now share one pending query state, so step navigation and provider metadata keep each other's query parameters. Source-control OAuth callbacks also remove their one-time `sync=1` marker through that same path before advancing the wizard.

## Why this change was made

The router applies URL changes asynchronously. A direct callback URL update could leave the shared pending query stale, allowing the next navigation to restore `sync=1` and trigger another repository sync.

## Impact

The setup wizard and its server-rendered documentation remain on the same step after source-control callbacks. Returning to the source-control connect step no longer reprocesses an already-consumed OAuth sync marker.