### PR TITLE
[Fix] Replies to automation report threads only worked for merged-PR digests

### DIFF
--- a/.changeset/replyable-automation-threads.md
+++ b/.changeset/replyable-automation-threads.md
@@ -1,0 +1,5 @@
+---
+'@roomote/api': patch
+---
+
+Replies now reach the task behind every automation report thread, not just merged-PR digests.

--- a/apps/api/src/handlers/discord/unmentioned-thread-reply.ts
+++ b/apps/api/src/handlers/discord/unmentioned-thread-reply.ts
@@ -96,7 +96,7 @@ export async function shouldRouteUnmentionedDiscordThreadReplyToAgent(params: {
   isRoomoteThread: boolean;
   /** Roomote user id of the thread task owner when known. */
   ownedThreadUserId: string | null | undefined;
-  /** True when the reply targets an announcer report root. */
+  /** True when the reply targets an automation report root. */
   isAutomationReportThread?: boolean;
   fetchThreadMessages: () => Promise<DiscordThreadHistoryMessage[] | null>;
 }): Promise<boolean> {

--- a/apps/api/src/handlers/mcp/communication-thread-replies.ts
+++ b/apps/api/src/handlers/mcp/communication-thread-replies.ts
@@ -11,6 +11,7 @@ import {
   db,
   and,
   eq,
+  getTaskAutomationInitiatorKey,
   sql,
   taskRuns,
   upsertBackgroundAutomationSlackThread,
@@ -185,15 +186,21 @@ async function bindLateCommunicationReportThread(params: {
   provider: 'teams' | 'telegram' | 'discord';
   messageId: string;
 }): Promise<void> {
-  const payload = params.taskRun.payload as
-    | { backgroundAutomationKey?: unknown }
-    | undefined;
-  const automationKey = payload?.backgroundAutomationKey;
   const channelId = getCommunicationChannelFromTaskPayload(
     params.taskRun.payload,
   );
 
-  if (automationKey !== 'announcer' || !channelId) {
+  if (!channelId) {
+    return;
+  }
+
+  // Every automation-launched report root gets bound, so replies to it route
+  // back to the task on any provider.
+  const automationKey = await getTaskAutomationInitiatorKey(
+    params.taskRun.taskId,
+  );
+
+  if (!automationKey) {
     return;
   }
 
@@ -222,7 +229,7 @@ async function bindLateCommunicationReportThread(params: {
     }
     await upsertBackgroundAutomationSlackThread(tx, {
       surface: params.provider,
-      automationKey: 'announcer',
+      automationKey,
       slackChannelId: channelId,
       threadTs: params.messageId,
       summaryText: '',

--- a/apps/api/src/handlers/mcp/slack.ts
+++ b/apps/api/src/handlers/mcp/slack.ts
@@ -9,6 +9,7 @@ import {
   eq,
   findBackgroundAutomationSlackThread,
   getCustomAutomationById,
+  getTaskAutomationInitiatorKey,
   slackInstallations,
   taskRuns,
   tasks,
@@ -16,7 +17,6 @@ import {
 } from '@roomote/db/server';
 import {
   getTriggerableBackgroundAutomationDescriptorByKey,
-  type BackgroundAutomationKey,
   type SlackBlock,
 } from '@roomote/types';
 import {
@@ -263,19 +263,6 @@ function getCustomAutomationIdFromTaskPayload(payload: unknown): string | null {
 
   const value = (payload as Record<string, unknown>).customAutomationId;
   return typeof value === 'string' && value.trim().length > 0 ? value : null;
-}
-
-function getBackgroundAutomationKeyFromTaskPayload(
-  payload: unknown,
-): BackgroundAutomationKey | null {
-  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
-    return null;
-  }
-
-  const value = (payload as Record<string, unknown>).backgroundAutomationKey;
-  return typeof value === 'string' && value.trim().length > 0
-    ? (value as BackgroundAutomationKey)
-    : null;
 }
 
 function normalizeSlackQuoteText(text: string): string {
@@ -872,13 +859,18 @@ slackMcp.post('/thread_reply', async (c) => {
   }
 
   // Creating a brand-new top-level channel message is reserved for late-bound
-  // automation tasks: execution tasks marked by automationWorkItemId and
-  // custom automation runs marked by customAutomationId in the payload.
+  // automation tasks: execution tasks marked by automationWorkItemId, custom
+  // automation runs marked by customAutomationId in the payload, and any task
+  // an automation launched.
+  const backgroundAutomationKey = await getTaskAutomationInitiatorKey(
+    taskRun.taskId,
+  );
+
   if (
     !slackReplyTarget.threadTs &&
     !getAutomationWorkItemIdFromTaskPayload(taskRun.payload) &&
     !getCustomAutomationIdFromTaskPayload(taskRun.payload) &&
-    !getBackgroundAutomationKeyFromTaskPayload(taskRun.payload)
+    !backgroundAutomationKey
   ) {
     return c.json(
       {
@@ -938,9 +930,6 @@ slackMcp.post('/thread_reply', async (c) => {
     taskRun.payload,
   );
   const customAutomationId = getCustomAutomationIdFromTaskPayload(
-    taskRun.payload,
-  );
-  const backgroundAutomationKey = getBackgroundAutomationKeyFromTaskPayload(
     taskRun.payload,
   );
   const existingThreadTs = slackReplyTarget.threadTs;

--- a/apps/api/src/handlers/slack/helpers/__tests__/conversation-log.test.ts
+++ b/apps/api/src/handlers/slack/helpers/__tests__/conversation-log.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  taskRunRowsMock,
+  findBackgroundAutomationSlackThreadMock,
+  getLatestSlackBotReplyMock,
+} = vi.hoisted(() => ({
+  taskRunRowsMock: vi.fn(),
+  findBackgroundAutomationSlackThreadMock: vi.fn(),
+  getLatestSlackBotReplyMock: vi.fn(),
+}));
+
+vi.mock('@roomote/cloud-agents', () => ({
+  stripLeadingRawSlackMention: vi.fn((text: string) => text),
+  stripLeadingSlackProductMention: vi.fn((text: string) => text),
+}));
+
+vi.mock('@roomote/sdk/server', () => ({
+  recordSlackConversationMessageBestEffort: vi.fn(),
+}));
+
+vi.mock('@roomote/slack', () => ({
+  getLatestSlackBotReply: getLatestSlackBotReplyMock,
+}));
+
+vi.mock('@roomote/db/server', () => {
+  const chain = {
+    from: vi.fn(),
+    innerJoin: vi.fn(),
+    where: vi.fn(),
+    orderBy: vi.fn(),
+    limit: vi.fn(async () => taskRunRowsMock()),
+  };
+  chain.from.mockReturnValue(chain);
+  chain.innerJoin.mockReturnValue(chain);
+  chain.where.mockReturnValue(chain);
+  chain.orderBy.mockReturnValue(chain);
+
+  return {
+    and: vi.fn((...conditions: unknown[]) => ({ conditions })),
+    db: { select: vi.fn(() => chain) },
+    desc: vi.fn((value: unknown) => value),
+    eq: vi.fn((left: unknown, right: unknown) => ({ left, right })),
+    findBackgroundAutomationSlackThread:
+      findBackgroundAutomationSlackThreadMock,
+    taskRuns: {
+      actingUserId: 'taskRuns.actingUserId',
+      createdAt: 'taskRuns.createdAt',
+      id: 'taskRuns.id',
+      payload: 'taskRuns.payload',
+      taskId: 'taskRuns.taskId',
+    },
+    tasks: {
+      id: 'tasks.id',
+      initiatorUserId: 'tasks.initiatorUserId',
+      slackThreadTs: 'tasks.slackThreadTs',
+    },
+  };
+});
+
+import { findRoomoteOwnedSlackThread } from '../conversation-log';
+
+const THREAD = { teamId: 'T1', channelId: 'C1', threadTs: '100.000' };
+
+describe('findRoomoteOwnedSlackThread', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    taskRunRowsMock.mockResolvedValue([]);
+    findBackgroundAutomationSlackThreadMock.mockResolvedValue(null);
+    getLatestSlackBotReplyMock.mockResolvedValue(null);
+  });
+
+  it.each([['ci_failure_triage'], ['sentry_triage'], ['announcer']])(
+    'treats a task-bound %s report thread as an automation report thread',
+    async (automationKey) => {
+      taskRunRowsMock.mockResolvedValue([
+        {
+          id: 7,
+          taskId: 'task-1',
+          payload: { channel: 'C1' },
+          initiatorUserId: null,
+          actingUserId: null,
+        },
+      ]);
+      findBackgroundAutomationSlackThreadMock.mockResolvedValue({
+        automationKey,
+        metadata: { sourceTaskId: 'task-1' },
+      });
+
+      await expect(findRoomoteOwnedSlackThread(THREAD)).resolves.toMatchObject({
+        isAutomationReportThread: true,
+      });
+    },
+  );
+
+  it('ignores a tracked automation thread with no bound task', async () => {
+    findBackgroundAutomationSlackThreadMock.mockResolvedValue({
+      automationKey: 'ci_failure_triage',
+      metadata: {},
+    });
+
+    await expect(findRoomoteOwnedSlackThread(THREAD)).resolves.toBeNull();
+  });
+});

--- a/apps/api/src/handlers/slack/helpers/conversation-log.ts
+++ b/apps/api/src/handlers/slack/helpers/conversation-log.ts
@@ -2,7 +2,6 @@ import {
   stripLeadingRawSlackMention,
   stripLeadingSlackProductMention,
 } from '@roomote/cloud-agents';
-import { isTaskBackedReportAutomationKey } from '@roomote/types';
 import { recordSlackConversationMessageBestEffort } from '@roomote/sdk/server';
 import {
   getLatestSlackBotReply,
@@ -135,11 +134,12 @@ export async function findRoomoteOwnedSlackThread(params: {
     threadTs: params.threadTs,
   });
 
+  // Any automation thread carrying a sourceTaskId is task-backed by
+  // construction: the binding is written only when a task owns the root. The
+  // automation key itself is irrelevant, so every automation's report thread
+  // accepts unmentioned replies, not just the ones that predate this.
   const sourceTaskId =
-    trackedAutomationThread &&
-    trackedAutomationThread.automationKey != null &&
-    isTaskBackedReportAutomationKey(trackedAutomationThread.automationKey) &&
-    typeof trackedAutomationThread.metadata?.sourceTaskId === 'string' &&
+    typeof trackedAutomationThread?.metadata?.sourceTaskId === 'string' &&
     trackedAutomationThread.metadata.sourceTaskId.trim().length > 0
       ? trackedAutomationThread.metadata.sourceTaskId
       : null;

--- a/apps/api/src/handlers/tasks/automation-work-items/slack.ts
+++ b/apps/api/src/handlers/tasks/automation-work-items/slack.ts
@@ -4,6 +4,7 @@ import {
   and,
   asc,
   db,
+  type DatabaseOrTransaction,
   eq,
   getAutomationRuntime,
   isNull,
@@ -68,6 +69,29 @@ export async function resolveAutomationSlackTarget(params: {
   };
 }
 
+async function resolveWorkItemAutomationKey(
+  tx: DatabaseOrTransaction,
+  automationWorkItemId: string,
+): Promise<BackgroundAutomationKey | null> {
+  const [automationWorkItem] = await tx
+    .select({
+      automationKey: workItems.automationKey,
+      sourceTaskId: workItems.sourceTaskId,
+    })
+    .from(workItems)
+    .where(
+      and(
+        eq(workItems.kind, 'auto_fix'),
+        eq(workItems.id, automationWorkItemId),
+      ),
+    )
+    .limit(1);
+
+  return automationWorkItem?.sourceTaskId
+    ? (automationWorkItem.automationKey ?? null)
+    : null;
+}
+
 export async function bindLateSlackThreadToTask(params: {
   taskId: string;
   channelId: string;
@@ -109,47 +133,21 @@ export async function bindLateSlackThreadToTask(params: {
       })
       .where(eq(taskRuns.taskId, params.taskId));
 
-    if (params.backgroundAutomationKey) {
-      await upsertBackgroundAutomationSlackThread(tx, {
-        surface: 'slack',
-        automationKey: params.backgroundAutomationKey,
-        slackChannelId: params.channelId,
-        threadTs: params.threadTs,
-        summaryText: params.summaryText,
-        postedAt: new Date(),
-        metadata: { sourceTaskId: params.taskId },
-      });
-      return;
-    }
+    // A work item names the automation that queued it, which is more specific
+    // than the launching automation, so it wins when both are available.
+    const workItemAutomationKey = params.automationWorkItemId
+      ? await resolveWorkItemAutomationKey(tx, params.automationWorkItemId)
+      : null;
+    const automationKey =
+      workItemAutomationKey ?? params.backgroundAutomationKey;
 
-    if (!params.automationWorkItemId) {
-      return;
-    }
-
-    const [automationWorkItem] = await tx
-      .select({
-        automationKey: workItems.automationKey,
-        sourceTaskId: workItems.sourceTaskId,
-      })
-      .from(workItems)
-      .where(
-        and(
-          eq(workItems.kind, 'auto_fix'),
-          eq(workItems.id, params.automationWorkItemId),
-        ),
-      )
-      .limit(1);
-
-    if (
-      !automationWorkItem?.sourceTaskId ||
-      !automationWorkItem.automationKey
-    ) {
+    if (!automationKey) {
       return;
     }
 
     await upsertBackgroundAutomationSlackThread(tx, {
       surface: 'slack',
-      automationKey: automationWorkItem.automationKey,
+      automationKey,
       slackChannelId: params.channelId,
       threadTs: params.threadTs,
       summaryText: params.summaryText,

--- a/apps/api/src/handlers/teams/find-active-teams-run.ts
+++ b/apps/api/src/handlers/teams/find-active-teams-run.ts
@@ -200,7 +200,7 @@ export async function findLatestTeamsThreadTaskRun(input: {
   return row ? withResolvedUserId(row) : undefined;
 }
 
-/** Finds an announcer report by its immutable Teams thread root. */
+/** Finds an automation report by its immutable Teams thread root. */
 export async function findTaskBackedTeamsAutomationReportRun(input: {
   conversationId: string;
   threadId: string;
@@ -220,7 +220,7 @@ export async function findTaskBackedTeamsAutomationReportRun(input: {
         teamsProviderMatch,
         conversationMatch,
         threadMatch,
-        sql`${taskRuns.payload}->>'backgroundAutomationKey' = 'announcer'`,
+        eq(tasks.initiatorKind, 'automation'),
         isNull(taskRuns.canceledAt),
       ),
     )

--- a/apps/docs/automations.mdx
+++ b/apps/docs/automations.mdx
@@ -26,6 +26,11 @@ Automations can create useful work quickly. Start with one or two that map to
 a real team habit, tell the team where output will appear, then expand once
 the signal is good.
 
+Every automation that posts to a chat channel is replyable. Reply in the
+thread Roomote started and you are talking to the task behind that report,
+without needing to mention Roomote. That works on Slack, Discord, Teams, and
+Telegram, and it works after the run has finished.
+
 ## Pull request automations
 
 These automations react to pull requests, issues, and repository state.

--- a/packages/db/src/lib/tasks.ts
+++ b/packages/db/src/lib/tasks.ts
@@ -1,5 +1,7 @@
 import { and, eq, isNull, type SQL } from 'drizzle-orm';
 
+import type { BackgroundAutomationKey } from '@roomote/types';
+
 import { type DatabaseOrTransaction, db } from '../db';
 import { tasks } from '../schema';
 import type { CreateTask, Task } from '../types';
@@ -116,4 +118,28 @@ function isTaskIdCollisionError(error: unknown): boolean {
     typeof e.message === 'string' &&
     e.message.includes(TASK_PRIMARY_KEY_CONSTRAINT)
   );
+}
+
+/**
+ * Resolves the automation that launched a task, or null for user-initiated
+ * tasks. The initiator columns are the single source of truth here: only some
+ * automations stamp an automation key into the run payload, so payload reads
+ * silently miss most automation launches.
+ */
+export async function getTaskAutomationInitiatorKey(
+  taskId: string,
+  database: DatabaseOrTransaction = db,
+): Promise<BackgroundAutomationKey | null> {
+  const [task] = await database
+    .select({
+      initiatorKind: tasks.initiatorKind,
+      initiatorAutomation: tasks.initiatorAutomation,
+    })
+    .from(tasks)
+    .where(eq(tasks.id, taskId))
+    .limit(1);
+
+  return task?.initiatorKind === 'automation'
+    ? (task.initiatorAutomation ?? null)
+    : null;
 }

--- a/packages/sdk/src/server/lib/communication/__tests__/communication-task-run-lookup.test.ts
+++ b/packages/sdk/src/server/lib/communication/__tests__/communication-task-run-lookup.test.ts
@@ -46,6 +46,7 @@ vi.mock('@roomote/db/server', () => {
     },
     tasks: {
       id: 'tasks.id',
+      initiatorKind: 'tasks.initiatorKind',
       initiatorUserId: 'tasks.initiatorUserId',
     },
     trackedMessages: {
@@ -67,8 +68,14 @@ function automationRun(id: number, taskId: string) {
     taskId,
     initiatorUserId: null,
     actingUserId: null,
-    payload: { backgroundAutomationKey: 'announcer' },
+    payload: {},
   };
+}
+
+function whereConditions() {
+  return whereMock.mock.calls.flatMap(
+    ([condition]) => condition.conditions ?? [],
+  );
 }
 
 describe('findTaskBackedAutomationReportRun', () => {
@@ -77,49 +84,78 @@ describe('findTaskBackedAutomationReportRun', () => {
     queryResults.length = 0;
   });
 
-  it('keeps two announcer roots in the same channel bound to their own runs', async () => {
+  it('keeps two report roots in the same channel bound to their own runs', async () => {
     queryResults.push(
-      [automationRun(11, 'announcer-task-one')],
-      [automationRun(22, 'announcer-task-two')],
+      [automationRun(11, 'report-task-one')],
+      [automationRun(22, 'report-task-two')],
     );
 
     await expect(
       findTaskBackedAutomationReportRun({
         provider: 'discord',
         channelId: 'channel-1',
-        messageId: 'announcer-root-one',
+        messageId: 'report-root-one',
       }),
-    ).resolves.toMatchObject({ id: 11, taskId: 'announcer-task-one' });
+    ).resolves.toMatchObject({ id: 11, taskId: 'report-task-one' });
     await expect(
       findTaskBackedAutomationReportRun({
         provider: 'discord',
         channelId: 'channel-1',
-        messageId: 'announcer-root-two',
+        messageId: 'report-root-two',
       }),
-    ).resolves.toMatchObject({ id: 22, taskId: 'announcer-task-two' });
+    ).resolves.toMatchObject({ id: 22, taskId: 'report-task-two' });
 
-    const messageIds = whereMock.mock.calls
-      .flatMap(([condition]) => condition.conditions ?? [])
+    const messageIds = whereConditions()
       .flatMap((condition: { values?: unknown[] }) => condition.values ?? [])
       .filter((value) => typeof value === 'string');
     expect(messageIds).toEqual(
-      expect.arrayContaining(['announcer-root-one', 'announcer-root-two']),
+      expect.arrayContaining(['report-root-one', 'report-root-two']),
     );
+  });
+
+  it('matches any automation-initiated task, not one hardcoded automation key', async () => {
+    queryResults.push([automationRun(11, 'ci-triage-task')]);
+
+    await expect(
+      findTaskBackedAutomationReportRun({
+        provider: 'discord',
+        channelId: 'channel-1',
+        messageId: 'ci-triage-root',
+      }),
+    ).resolves.toMatchObject({ id: 11, taskId: 'ci-triage-task' });
+
+    const conditions = whereConditions();
+    expect(conditions).toContainEqual({
+      left: 'tasks.initiatorKind',
+      right: 'automation',
+    });
+    expect(
+      conditions.some((condition: { strings?: string[] }) =>
+        condition.strings?.some((fragment) => fragment.includes('announcer')),
+      ),
+    ).toBe(false);
   });
 
   it('falls back from a missing payload binding to the tracked automation thread source task', async () => {
     queryResults.push(
       [],
-      [{ sourceTaskId: 'announcer-task-one' }],
-      [automationRun(11, 'announcer-task-one')],
+      [{ sourceTaskId: 'report-task-one' }],
+      [automationRun(11, 'report-task-one')],
     );
 
     await expect(
       findTaskBackedAutomationReportRun({
         provider: 'telegram',
         channelId: 'chat-1',
-        messageId: 'announcer-root-one',
+        messageId: 'report-root-one',
       }),
-    ).resolves.toMatchObject({ id: 11, taskId: 'announcer-task-one' });
+    ).resolves.toMatchObject({ id: 11, taskId: 'report-task-one' });
+
+    // The tracked-thread fallback must not filter on a specific automation
+    // key either, or non-announcer reports lose their late-bound roots.
+    expect(whereConditions()).not.toContainEqual({
+      left: 'trackedMessages.automationKey',
+      right: 'announcer',
+    });
   });
 });

--- a/packages/sdk/src/server/lib/communication/communication-task-run-lookup.ts
+++ b/packages/sdk/src/server/lib/communication/communication-task-run-lookup.ts
@@ -123,6 +123,10 @@ export async function findCompletedCommunicationTaskRunWithSnapshot(
  * Finds the task that produced an automation report root. Inbound replies use
  * the provider's reply target, not the newest task in the channel, so reports
  * remain routable after later tasks have run in the same conversation.
+ *
+ * Every automation-initiated task qualifies. The initiator columns carry that
+ * signal for all of them, unlike the run payload, which only some automations
+ * stamp with an automation key.
  */
 export async function findTaskBackedAutomationReportRun(input: {
   provider: CommunicationProvider;
@@ -138,7 +142,7 @@ export async function findTaskBackedAutomationReportRun(input: {
         sql`${taskRuns.payload}->>'communicationProvider' = ${input.provider}`,
         sql`${taskRuns.payload}->>'communicationChannelId' = ${input.channelId}`,
         sql`${taskRuns.payload}->>'communicationMessageId' = ${input.messageId}`,
-        sql`${taskRuns.payload}->>'backgroundAutomationKey' = 'announcer'`,
+        eq(tasks.initiatorKind, 'automation'),
         isNull(taskRuns.canceledAt),
       ),
     )
@@ -160,7 +164,6 @@ export async function findTaskBackedAutomationReportRun(input: {
       and(
         eq(trackedMessages.surface, input.provider),
         eq(trackedMessages.kind, 'automation_thread'),
-        eq(trackedMessages.automationKey, 'announcer'),
         eq(trackedMessages.channelId, input.channelId),
         eq(trackedMessages.threadTs, input.messageId),
       ),

--- a/packages/types/src/background-agents.ts
+++ b/packages/types/src/background-agents.ts
@@ -320,21 +320,6 @@ export function supportsHistoricalThreadFeedback(
   return AUTOMATION_KEYS_WITH_HISTORICAL_THREAD_FEEDBACK_SET.has(automationKey);
 }
 
-const TASK_BACKED_REPORT_AUTOMATION_KEYS = [
-  'announcer',
-] as const satisfies readonly BackgroundAutomationKey[];
-
-export type TaskBackedReportAutomationKey =
-  (typeof TASK_BACKED_REPORT_AUTOMATION_KEYS)[number];
-
-export function isTaskBackedReportAutomationKey(
-  automationKey: BackgroundAutomationKey,
-): automationKey is TaskBackedReportAutomationKey {
-  return (TASK_BACKED_REPORT_AUTOMATION_KEYS as readonly string[]).includes(
-    automationKey,
-  );
-}
-
 export type BackgroundAgentSettingsLike = Record<string, unknown>;
 
 export function getBackgroundAgentFrequencyValues(


### PR DESCRIPTION
## Problem

Replying in an automation's chat thread only reached the task behind merged-PR digests. Replies in every other automation's report thread were dropped silently — no error, no acknowledgement.

Two gates caused it:

1. **A single-key allowlist.** `TASK_BACKED_REPORT_AUTOMATION_KEYS` held only `announcer`, and three further call sites hardcoded that string in SQL. An automation report root is bot-authored and has no owning user, so `isAutomationReportThread` is the only path through `evaluateUnmentionedThreadReplyRouting` — and it came back `false` for everything else.

2. **A payload field almost nothing set.** Only the announcer stamped `backgroundAutomationKey` into its run payload. Widening the allowlist alone would not have reached the other automations, because there was nothing for those lookups to match on.

## Fix

Key off `tasks.initiatorKind = 'automation'` instead of the payload field. Every automation-launched task already carries that stamp, so this covers all of them and works on threads created before this change.

- `packages/types/src/background-agents.ts` — remove the allowlist and its type guard
- `apps/api/src/handlers/slack/helpers/conversation-log.ts` — a tracked automation thread carrying a `sourceTaskId` is task-backed by construction; the automation key is irrelevant
- `packages/sdk/src/server/lib/communication/communication-task-run-lookup.ts` — initiator-based match, and the tracked-thread fallback no longer filters by key
- `apps/api/src/handlers/teams/find-active-teams-run.ts` — same swap for Teams
- `apps/api/src/handlers/mcp/communication-thread-replies.ts` and `apps/api/src/handlers/mcp/slack.ts` — late-bound report roots resolve their automation from the task initiator, so Slack, Discord, Teams, and Telegram all bind
- `packages/db/src/lib/tasks.ts` — new `getTaskAutomationInitiatorKey` helper
- `apps/api/src/handlers/tasks/automation-work-items/slack.ts` — restructured so a work item's own key still wins over the launching automation's key; the new branch would otherwise have shadowed it

## Testing

New `conversation-log.test.ts` covers `ci_failure_triage`, `sentry_triage`, and `announcer` report threads; the first two fail against the previous code. The lookup test additionally asserts no hardcoded automation key survives in either query.

`pnpm lint`, `pnpm check-types`, `pnpm knip`, and the api (1382), sdk (728), types (647), and db (356) suites all pass.