### PR TITLE
Promote v0.20.1 to production

### DIFF
--- a/.changeset/replyable-automation-threads.md
+++ b/.changeset/replyable-automation-threads.md
@@ -1,0 +1,5 @@
+---
+'@roomote/api': patch
+---
+
+Replies now reach the task behind every automation report thread, not just merged-PR digests.

--- a/.changeset/replyable-automation-threads.md
+++ b/.changeset/replyable-automation-threads.md
@@ -1,5 +1,0 @@
----
-'@roomote/api': patch
----
-
-Replies now reach the task behind every automation report thread, not just merged-PR digests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 This file tracks product releases for Roomote (single monorepo version). Automated release entries are prepended by `pnpm run version`.
 
+## 0.20.1 (2026-07-25)
+
+This release makes chat-driven automation more reliable, keeping Discord tasks moving and report-thread replies connected to their work.
+
+### Highlights
+
+- Keep Discord tasks responsive and recover safely from slow API processing or retries.
+- Reply to any automation report thread to continue the task behind it, not only merged pull-request reports.
+
+### Patch changes
+
+- Discord tasks keep processing reliably when API work is slow or a delivery needs to retry.
+- Replies now reach the task behind every automation report thread, not just merged-PR digests.
+
 ## 0.20.0 (2026-07-24)
 
 This release makes it easier to give Roomote context, follow work across chat, and complete setup with guidance that matches the task at hand.

--- a/apps/api/src/__tests__/route-policy-enforcement.test.ts
+++ b/apps/api/src/__tests__/route-policy-enforcement.test.ts
@@ -82,6 +82,7 @@ vi.mock('../middleware', async (importOriginal) => {
 
 import { createApiApp } from '../server';
 import { evaluateRoutePolicy } from '../middleware/routePolicyMiddleware';
+import { findRoutePolicyRule } from '../route-policies';
 
 describe('route policy enforcement', () => {
   beforeEach(() => {
@@ -238,6 +239,18 @@ describe('route policy enforcement', () => {
   });
 
   describe('webhook routes', () => {
+    it('exempts the secret-authenticated Discord worker route from shared IP limits', () => {
+      expect(
+        findRoutePolicyRule('/api/internal/discord/events/process'),
+      ).toMatchObject({
+        name: 'internal-discord-event-processing',
+        policy: 'webhook',
+      });
+      expect(
+        findRoutePolicyRule('/api/internal/discord/events/process')?.rateLimits,
+      ).toBeUndefined();
+    });
+
     it('lets webhook deliveries through to handler-level verification', async () => {
       const response = await createApiApp().request(
         'http://localhost/api/webhooks/linear',

--- a/apps/api/src/handlers/discord/__tests__/index.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/index.test.ts
@@ -49,6 +49,7 @@ const mocks = vi.hoisted(() => ({
   markThreadHistoryDelivered: vi.fn(),
   fetchThreadHistory: vi.fn(),
   shouldRouteUnmentioned: vi.fn(),
+  enqueueGatewayEvent: vi.fn(),
 }));
 
 vi.mock('@roomote/redis', async (importOriginal) => {
@@ -84,6 +85,7 @@ vi.mock('@roomote/sdk/server', () => ({
   restoreDiscordLinkCode: mocks.restoreLinkCode,
   upsertDiscordUserMapping: mocks.upsertUserMapping,
   upsertDiscordInstallation: mocks.upsertInstallation,
+  enqueueDiscordGatewayEvent: mocks.enqueueGatewayEvent,
   claimPendingPrReviewActionsForThread: vi.fn(async () => []),
 }));
 
@@ -145,7 +147,7 @@ vi.mock('@roomote/cloud-agents/server', () => ({
   getTaskUrl: mocks.getTaskUrl,
 }));
 
-import { discord } from '../index.js';
+import { discord, discordGatewayEventProcessingTimeout } from '../index.js';
 
 const app = new Hono();
 app.route('/api/internal/discord', discord);
@@ -186,6 +188,17 @@ function message(overrides: Record<string, unknown> = {}) {
 }
 
 async function postEvent(body: unknown, secret = 'gateway-secret') {
+  return app.request('http://localhost/api/internal/discord/events/process', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-roomote-discord-gateway-secret': secret,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+async function postIngressEvent(body: unknown, secret = 'gateway-secret') {
   return app.request('http://localhost/api/internal/discord/events', {
     method: 'POST',
     headers: {
@@ -273,6 +286,7 @@ describe('Discord Gateway event handler', () => {
     mocks.fetchThreadHistory.mockResolvedValue([]);
     mocks.shouldRouteUnmentioned.mockResolvedValue(true);
     mocks.queueMessage.mockResolvedValue(true);
+    mocks.enqueueGatewayEvent.mockResolvedValue({ jobId: 'event-message-1' });
   });
 
   afterEach(() => {
@@ -339,6 +353,52 @@ describe('Discord Gateway event handler', () => {
     await expect(response.json()).resolves.toEqual({
       ok: false,
       error: 'discord_gateway_unauthorized',
+    });
+    expect(mocks.claimEvent).not.toHaveBeenCalled();
+  });
+
+  it('durably queues a valid event without invoking its processing pipeline', async () => {
+    const body = envelope(message());
+
+    const response = await postIngressEvent(body);
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({ ok: true, queued: true });
+    expect(mocks.enqueueGatewayEvent).toHaveBeenCalledWith(body);
+    expect(mocks.claimEvent).not.toHaveBeenCalled();
+    expect(mocks.resolveProvider).not.toHaveBeenCalled();
+  });
+
+  it('rejects unauthorized ingress before enqueueing', async () => {
+    const response = await postIngressEvent(
+      envelope(message()),
+      'wrong-secret',
+    );
+
+    expect(response.status).toBe(401);
+    expect(mocks.enqueueGatewayEvent).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid ingress payloads before enqueueing', async () => {
+    const response = await postIngressEvent({ eventType: 'MESSAGE_CREATE' });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: 'invalid_discord_event',
+    });
+    expect(mocks.enqueueGatewayEvent).not.toHaveBeenCalled();
+  });
+
+  it('returns 503 when durable event enqueueing fails', async () => {
+    mocks.enqueueGatewayEvent.mockRejectedValue(new Error('Redis unavailable'));
+
+    const response = await postIngressEvent(envelope(message()));
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: 'discord_event_enqueue_failed',
     });
     expect(mocks.claimEvent).not.toHaveBeenCalled();
   });
@@ -416,6 +476,33 @@ describe('Discord Gateway event handler', () => {
       expect(mocks.completeEvent).not.toHaveBeenCalled();
     },
   );
+
+  it('times out slow processing and releases the event lease for a retry', async () => {
+    const originalTimeout = discordGatewayEventProcessingTimeout.timeoutMs;
+    vi.useFakeTimers();
+    discordGatewayEventProcessingTimeout.timeoutMs = 10;
+    mocks.getChannel.mockImplementation(() => new Promise(() => undefined));
+
+    try {
+      const responsePromise = postEvent(envelope(message()));
+      await vi.advanceTimersByTimeAsync(10);
+      const response = await responsePromise;
+
+      expect(response.status).toBe(503);
+      await expect(response.json()).resolves.toEqual({
+        ok: false,
+        error: 'discord_api_unavailable',
+      });
+      expect(mocks.releaseEvent).toHaveBeenCalledWith({
+        eventType: 'MESSAGE_CREATE',
+        eventId: 'message-1',
+        token: 'claim-token',
+      });
+    } finally {
+      discordGatewayEventProcessingTimeout.timeoutMs = originalTimeout;
+      vi.useRealTimers();
+    }
+  });
 
   it.each([403, 404])(
     'acknowledges an event whose Discord resource returns %s',

--- a/apps/api/src/handlers/discord/__tests__/task-orchestration.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/task-orchestration.test.ts
@@ -133,6 +133,54 @@ describe('startNewDiscordTask', () => {
     );
   });
 
+  it('clears intake eyes when a retried source event already started a task', async () => {
+    mocks.findSourceRun.mockResolvedValue({
+      id: 41,
+      taskId: 'task-1',
+      status: 'running',
+      payload: {
+        communicationProvider: 'discord',
+        communicationSourceEventId: 'message-1',
+      },
+    });
+    const removeReaction = vi.fn().mockResolvedValue(undefined);
+
+    await startNewDiscordTask({
+      provider: { removeReaction } as never,
+      applicationId: 'application-1',
+      requesterDiscordUserId: 'discord-user-1',
+      launchOwnerUserId: 'user-1',
+      intakeAckPinned: true,
+      queuedMessage: {
+        provider: 'discord',
+        text: 'Fix the flaky test',
+        user: 'Matt',
+        userId: 'user-1',
+        ts: 'message-1',
+      },
+      metadata: {
+        communicationProvider: 'discord',
+        communicationChannelId: 'channel-1',
+        communicationMessageId: 'message-1',
+        communicationAnchorMessageId: 'message-1',
+      },
+      channel: {
+        channelId: 'channel-1',
+        channelName: 'general',
+        channelType: 0,
+        guildId: 'guild-1',
+        isDirectMessage: false,
+        isThread: false,
+      },
+    });
+
+    expect(removeReaction).toHaveBeenCalledWith({
+      channelId: 'channel-1',
+      messageId: 'message-1',
+      name: 'eyes',
+    });
+  });
+
   it('launches in-thread with full history and attachment context (Slack parity)', async () => {
     const provider = {
       fetchChannelMessages: vi.fn().mockResolvedValue({
@@ -611,5 +659,71 @@ describe('startNewDiscordTask', () => {
 
     expect(result.status).toBe('replied_inline');
     expect(removeReaction).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: 'the source event lookup fails',
+      setup: () =>
+        mocks.findSourceRun.mockRejectedValue(new Error('lookup failed')),
+    },
+    {
+      name: 'routing fails',
+      setup: () =>
+        mocks.routeTask.mockRejectedValue(new Error('routing failed')),
+    },
+    {
+      name: 'routing confirmation fails',
+      setup: () => {
+        mocks.shouldAutoConfirm.mockReturnValue(false);
+        mocks.requestConfirmation.mockRejectedValue(
+          new Error('confirmation failed'),
+        );
+      },
+    },
+    {
+      name: 'the routed workspace is unavailable',
+      setup: () => mocks.resolveWorkspace.mockResolvedValue(null),
+    },
+  ])('clears intake eyes when $name', async ({ setup }) => {
+    setup();
+    const removeReaction = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      startNewDiscordTask({
+        provider: { removeReaction } as never,
+        applicationId: 'application-1',
+        requesterDiscordUserId: 'discord-user-1',
+        launchOwnerUserId: 'user-1',
+        intakeAckPinned: true,
+        queuedMessage: {
+          provider: 'discord',
+          text: 'Fix the flaky test',
+          user: 'Matt',
+          userId: 'user-1',
+          ts: 'message-1',
+        },
+        metadata: {
+          communicationProvider: 'discord',
+          communicationChannelId: 'channel-1',
+          communicationMessageId: 'message-1',
+          communicationAnchorMessageId: 'message-1',
+        },
+        channel: {
+          channelId: 'channel-1',
+          channelName: 'general',
+          channelType: 0,
+          guildId: 'guild-1',
+          isDirectMessage: false,
+          isThread: false,
+        },
+      }),
+    ).rejects.toThrow();
+
+    expect(removeReaction).toHaveBeenCalledWith({
+      channelId: 'channel-1',
+      messageId: 'message-1',
+      name: 'eyes',
+    });
   });
 });

--- a/apps/api/src/handlers/discord/index.ts
+++ b/apps/api/src/handlers/discord/index.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 
 import {
   discordEventToQueuedCommunicationMessage,
@@ -34,6 +34,7 @@ import {
   restoreDiscordLinkCode,
   upsertDiscordInstallation,
   upsertDiscordUserMapping,
+  enqueueDiscordGatewayEvent,
 } from '@roomote/sdk/server';
 
 import { apiLogger } from '../../logging.js';
@@ -84,6 +85,38 @@ import {
   markDiscordThreadHistoryDelivered,
 } from './thread-context.js';
 import { shouldRouteUnmentionedDiscordThreadReplyToAgent } from './unmentioned-thread-reply.js';
+
+export const discordGatewayEventProcessingTimeout = {
+  timeoutMs: 4 * 60 * 1000,
+};
+
+class DiscordGatewayEventProcessingTimeoutError extends Error {
+  constructor() {
+    super('Discord Gateway event processing timed out');
+  }
+}
+
+function withDiscordGatewayEventProcessingTimeout<T>(
+  promise: Promise<T>,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new DiscordGatewayEventProcessingTimeoutError()),
+      discordGatewayEventProcessingTimeout.timeoutMs,
+    );
+
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
 
 const DISCORD_HELP_MESSAGE = [
   "👋 I'm Roomote. Mention me in a server channel or message me directly to start a task.",
@@ -850,26 +883,52 @@ async function processDiscordGatewayEvent(event: DiscordGatewayEvent) {
 
 export const discord = new Hono();
 
-discord.post('/events', async (c) => {
+async function parseAuthorizedDiscordGatewayEvent(c: Context) {
   const authError = await verifyDiscordGatewaySecret(
     c.req.header(DISCORD_GATEWAY_SECRET_HEADER),
   );
   if (authError) {
-    return c.json({ ok: false, error: authError.error }, authError.status);
+    return {
+      response: c.json({ ok: false, error: authError.error }, authError.status),
+    };
   }
   let rawBody: unknown;
   try {
     rawBody = await c.req.json();
   } catch {
-    return c.json({ ok: false, error: 'invalid_json' }, 400);
+    return { response: c.json({ ok: false, error: 'invalid_json' }, 400) };
   }
   const parsed = parseDiscordGatewayEvent(rawBody);
   if (!parsed.success) {
-    return c.json({ ok: false, error: 'invalid_discord_event' }, 400);
+    return {
+      response: c.json({ ok: false, error: 'invalid_discord_event' }, 400),
+    };
   }
+  return { event: parsed.data };
+}
+
+discord.post('/events', async (c) => {
+  const parsed = await parseAuthorizedDiscordGatewayEvent(c);
+  if ('response' in parsed) return parsed.response;
+
+  try {
+    await enqueueDiscordGatewayEvent(parsed.event);
+    return c.json({ ok: true, queued: true }, 202);
+  } catch (error) {
+    apiLogger.error(
+      `[discord] Failed to enqueue event ${parsed.event.eventId}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return c.json({ ok: false, error: 'discord_event_enqueue_failed' }, 503);
+  }
+});
+
+discord.post('/events/process', async (c) => {
+  const parsed = await parseAuthorizedDiscordGatewayEvent(c);
+  if ('response' in parsed) return parsed.response;
+
   const eventRef = {
-    eventType: parsed.data.eventType,
-    eventId: parsed.data.eventId,
+    eventType: parsed.event.eventType,
+    eventId: parsed.event.eventId,
   };
   const claim = await claimDiscordApiEvent(eventRef);
   if (claim.status === 'completed') {
@@ -879,10 +938,11 @@ discord.post('/events', async (c) => {
     return c.json({ ok: false, error: 'discord_event_in_progress' }, 425);
   }
   try {
-    const result = await processDiscordGatewayEvent(parsed.data);
-    // The 2xx response is sufficient for the durable Gateway to acknowledge
-    // this entry. If Redis is unavailable for this final bookkeeping write,
-    // the short processing lease expires instead of failing completed work.
+    const result = await withDiscordGatewayEventProcessingTimeout(
+      processDiscordGatewayEvent(parsed.event),
+    );
+    // The queue retries processing failures. If this bookkeeping write is
+    // unavailable, the short lease expires and a later job attempt can claim it.
     await completeDiscordApiEvent({ ...eventRef, token: claim.token }).catch(
       (error) => {
         apiLogger.warn(
@@ -893,9 +953,6 @@ discord.post('/events', async (c) => {
     return c.json(result);
   } catch (error) {
     if (isPermanentDiscordEventError(error)) {
-      // The channel/message no longer exists or the bot cannot access it.
-      // Retrying this specific event cannot make progress, so complete it
-      // instead of eventually poisoning the Gateway's durable delivery queue.
       await completeDiscordApiEvent({
         ...eventRef,
         token: claim.token,
@@ -919,12 +976,13 @@ discord.post('/events', async (c) => {
         503,
       );
     }
-    if (isRetryableDiscordProviderError(error)) {
+    if (
+      error instanceof DiscordGatewayEventProcessingTimeoutError ||
+      isRetryableDiscordProviderError(error)
+    ) {
       apiLogger.warn(
         `[discord] Discord API unavailable while processing event ${eventRef.eventId}: ${error.message}`,
       );
-      // The Gateway treats 503 as delivery infrastructure and retains the
-      // stream entry without applying its poison-event attempt cap.
       return c.json({ ok: false, error: 'discord_api_unavailable' }, 503);
     }
     apiLogger.error(

--- a/apps/api/src/handlers/discord/task-orchestration.ts
+++ b/apps/api/src/handlers/discord/task-orchestration.ts
@@ -103,6 +103,9 @@ export async function startNewDiscordTask(input: {
   const existingRun = await findCommunicationTaskRunBySourceEvent({
     provider: 'discord',
     sourceEventId: input.queuedMessage.ts,
+  }).catch(async (error) => {
+    await clearDiscordIntakeAckBestEffort(input);
+    throw error;
   });
   if (existingRun) {
     const taskUrl = getTaskUrl({
@@ -120,6 +123,7 @@ export async function startNewDiscordTask(input: {
           : 'This request already started a task.',
       }).catch(() => undefined);
     }
+    await clearDiscordIntakeAckBestEffort(input);
     return {
       status: 'already_started' as const,
       existingRun,
@@ -127,159 +131,207 @@ export async function startNewDiscordTask(input: {
     };
   }
 
-  // Full transcript + prior attachments belong on task start only when the
-  // launch already lives inside a Discord thread and is not /new (or another
-  // forced sibling). Matching Slack: continue-in-thread gets history; a fresh
-  // task must start clean. Top-level channel launches never dump unrelated
-  // channel history into the agent prompt — except the single message the user
-  // explicitly replied to via Discord's reply UI.
-  const includeFullThreadContext =
-    input.channel.isThread && !input.forceNewThread;
-  const shouldFetchRepliedTo =
-    Boolean(input.replyToMessageId) && !input.forceNewThread;
-  const [historyBase, repliedToMessage, installation] = await Promise.all([
-    includeFullThreadContext
-      ? fetchDiscordThreadHistoryBestEffort({
-          provider: input.provider,
-          channelId: input.channel.channelId,
-          ...(input.channel.parentChannelId
-            ? { parentChannelId: input.channel.parentChannelId }
-            : {}),
-        })
-      : Promise.resolve([] as DiscordThreadHistoryMessage[]),
-    shouldFetchRepliedTo && input.replyToMessageId
-      ? fetchDiscordRepliedToMessageBestEffort({
-          provider: input.provider,
-          channelId:
-            input.replyToChannelId ??
-            input.channel.parentChannelId ??
-            input.channel.channelId,
-          messageId: input.replyToMessageId,
-        })
-      : Promise.resolve(null),
-    input.channel.guildId
-      ? findDiscordInstallationByGuildId(input.channel.guildId)
-      : Promise.resolve(null),
-  ]);
-  const history = mergeDiscordRepliedToMessage({
-    messages: historyBase,
-    repliedTo: repliedToMessage,
-  });
-  const triggeringMessage: DiscordThreadHistoryMessage = {
-    id: input.queuedMessage.ts,
-    user: input.queuedMessage.user,
-    text: input.queuedMessage.text,
-    attachments: [],
-  };
-  const historyWithTrigger = history.some(
-    (message) => message.id === triggeringMessage.id,
-  )
-    ? history
-    : [...history, triggeringMessage];
-  // Full thread launches get the reconstructed transcript; top-level channel
-  // reply launches only pass the explicit reply target + current turn.
-  const includeReplyContext =
-    includeFullThreadContext ||
-    (Boolean(repliedToMessage) && !input.forceNewThread);
-  const routingThreadMessages = includeReplyContext
-    ? historyWithTrigger.map((message) => ({
-        user: message.username ?? message.user,
-        text: message.text,
-      }))
-    : [
-        {
-          user: triggeringMessage.user,
-          text: triggeringMessage.text,
-        },
-      ];
-  const historyAttachments = includeReplyContext
-    ? toDiscordAttachmentsFromHistory(history, {
-        excludeMessageId: input.queuedMessage.ts,
-      })
-    : [];
-  const threadAttachments = historyAttachments.length
-    ? await processDiscordAttachments(historyAttachments)
-    : { images: [], attachmentTexts: [], warnings: [] };
-  for (const warning of threadAttachments.warnings) {
-    console.warn(`[discord] Thread attachment warning: ${warning}`);
-  }
-
-  const taskDescriptionWithAttachments = appendAttachmentTextsToPromptText({
-    text: input.queuedMessage.text,
-    attachmentTexts: threadAttachments.attachmentTexts,
-  });
-  const allImages = [
-    ...(input.queuedMessage.images ?? []),
-    ...threadAttachments.images,
-  ];
-  const threadContext = includeReplyContext
-    ? formatDiscordThreadContext({
-        messages: historyWithTrigger,
-        currentMessageId: input.queuedMessage.ts,
-      })
-    : undefined;
-  const agentPromptPrefix = input.channelAutoStart?.agentPromptPrefix?.trim();
-  const agentPromptBody = [threadContext, taskDescriptionWithAttachments]
-    .filter((part): part is string => Boolean(part?.trim()))
-    .join('\n\n');
-  const agentPromptText = agentPromptPrefix
-    ? `${agentPromptPrefix}\n\n${agentPromptBody}`
-    : agentPromptBody !== input.queuedMessage.text
-      ? agentPromptBody
-      : undefined;
-  const routingContext = await buildDiscordRoutingContext({
-    userId: input.launchOwnerUserId,
-    taskDescription: taskDescriptionWithAttachments,
-    guildName: installation?.guildName ?? undefined,
-    channelName: input.channel.channelName,
-    threadMessages: routingThreadMessages,
-    ...(allImages.length ? { images: allImages } : {}),
-    apiBaseUrl: Env.TRPC_URL ?? Env.R_APP_URL,
-  });
-  const routingDecision = await routeTask(routingContext);
-  if (routingDecision.status === 'platform_answer') {
-    // Auto-respond channels must not turn Roomote into a channel chatbot:
-    // a question-shaped message that routes to a platform answer is skipped
-    // silently (mirrors Slack's auto-routed path, which never posts answers).
-    if (input.channelAutoStart) {
-      await clearDiscordIntakeAckBestEffort(input);
-      return { status: 'skipped_platform_answer' as const, routingDecision };
-    }
-    await replyToDiscordEvent({
-      provider: input.provider,
-      applicationId: input.applicationId,
-      channel: input.channel,
-      ...(input.interaction ? { interaction: input.interaction } : {}),
-      text: routingDecision.result.answer,
+  try {
+    // Full transcript + prior attachments belong on task start only when the
+    // launch already lives inside a Discord thread and is not /new (or another
+    // forced sibling). Matching Slack: continue-in-thread gets history; a fresh
+    // task must start clean. Top-level channel launches never dump unrelated
+    // channel history into the agent prompt — except the single message the user
+    // explicitly replied to via Discord's reply UI.
+    const includeFullThreadContext =
+      input.channel.isThread && !input.forceNewThread;
+    const shouldFetchRepliedTo =
+      Boolean(input.replyToMessageId) && !input.forceNewThread;
+    const [historyBase, repliedToMessage, installation] = await Promise.all([
+      includeFullThreadContext
+        ? fetchDiscordThreadHistoryBestEffort({
+            provider: input.provider,
+            channelId: input.channel.channelId,
+            ...(input.channel.parentChannelId
+              ? { parentChannelId: input.channel.parentChannelId }
+              : {}),
+          })
+        : Promise.resolve([] as DiscordThreadHistoryMessage[]),
+      shouldFetchRepliedTo && input.replyToMessageId
+        ? fetchDiscordRepliedToMessageBestEffort({
+            provider: input.provider,
+            channelId:
+              input.replyToChannelId ??
+              input.channel.parentChannelId ??
+              input.channel.channelId,
+            messageId: input.replyToMessageId,
+          })
+        : Promise.resolve(null),
+      input.channel.guildId
+        ? findDiscordInstallationByGuildId(input.channel.guildId)
+        : Promise.resolve(null),
+    ]);
+    const history = mergeDiscordRepliedToMessage({
+      messages: historyBase,
+      repliedTo: repliedToMessage,
     });
-    // No worker onStart fires for inline answers; clear intake 👀 here.
-    await clearDiscordIntakeAckBestEffort(input);
-    return { status: 'replied_inline' as const, routingDecision };
-  }
+    const triggeringMessage: DiscordThreadHistoryMessage = {
+      id: input.queuedMessage.ts,
+      user: input.queuedMessage.user,
+      text: input.queuedMessage.text,
+      attachments: [],
+    };
+    const historyWithTrigger = history.some(
+      (message) => message.id === triggeringMessage.id,
+    )
+      ? history
+      : [...history, triggeringMessage];
+    // Full thread launches get the reconstructed transcript; top-level channel
+    // reply launches only pass the explicit reply target + current turn.
+    const includeReplyContext =
+      includeFullThreadContext ||
+      (Boolean(repliedToMessage) && !input.forceNewThread);
+    const routingThreadMessages = includeReplyContext
+      ? historyWithTrigger.map((message) => ({
+          user: message.username ?? message.user,
+          text: message.text,
+        }))
+      : [
+          {
+            user: triggeringMessage.user,
+            text: triggeringMessage.text,
+          },
+        ];
+    const historyAttachments = includeReplyContext
+      ? toDiscordAttachmentsFromHistory(history, {
+          excludeMessageId: input.queuedMessage.ts,
+        })
+      : [];
+    const threadAttachments = historyAttachments.length
+      ? await processDiscordAttachments(historyAttachments)
+      : { images: [], attachmentTexts: [], warnings: [] };
+    for (const warning of threadAttachments.warnings) {
+      console.warn(`[discord] Thread attachment warning: ${warning}`);
+    }
 
-  if (
-    !input.skipRoutingConfirmation &&
-    // Confirmation cards need a launch owner to accept on behalf of; the
-    // ownerless case only arises on auto-start paths, which skip them anyway.
-    input.launchOwnerUserId &&
-    !shouldAutoConfirmDiscordRoute(routingDecision)
-  ) {
-    const confirmation = await requestDiscordRoutingConfirmation({
+    const taskDescriptionWithAttachments = appendAttachmentTextsToPromptText({
+      text: input.queuedMessage.text,
+      attachmentTexts: threadAttachments.attachmentTexts,
+    });
+    const allImages = [
+      ...(input.queuedMessage.images ?? []),
+      ...threadAttachments.images,
+    ];
+    const threadContext = includeReplyContext
+      ? formatDiscordThreadContext({
+          messages: historyWithTrigger,
+          currentMessageId: input.queuedMessage.ts,
+        })
+      : undefined;
+    const agentPromptPrefix = input.channelAutoStart?.agentPromptPrefix?.trim();
+    const agentPromptBody = [threadContext, taskDescriptionWithAttachments]
+      .filter((part): part is string => Boolean(part?.trim()))
+      .join('\n\n');
+    const agentPromptText = agentPromptPrefix
+      ? `${agentPromptPrefix}\n\n${agentPromptBody}`
+      : agentPromptBody !== input.queuedMessage.text
+        ? agentPromptBody
+        : undefined;
+    const routingContext = await buildDiscordRoutingContext({
+      userId: input.launchOwnerUserId,
+      taskDescription: taskDescriptionWithAttachments,
+      guildName: installation?.guildName ?? undefined,
+      channelName: input.channel.channelName,
+      threadMessages: routingThreadMessages,
+      ...(allImages.length ? { images: allImages } : {}),
+      apiBaseUrl: Env.TRPC_URL ?? Env.R_APP_URL,
+    });
+    const routingDecision = await routeTask(routingContext);
+    if (routingDecision.status === 'platform_answer') {
+      // Auto-respond channels must not turn Roomote into a channel chatbot:
+      // a question-shaped message that routes to a platform answer is skipped
+      // silently (mirrors Slack's auto-routed path, which never posts answers).
+      if (input.channelAutoStart) {
+        await clearDiscordIntakeAckBestEffort(input);
+        return { status: 'skipped_platform_answer' as const, routingDecision };
+      }
+      await replyToDiscordEvent({
+        provider: input.provider,
+        applicationId: input.applicationId,
+        channel: input.channel,
+        ...(input.interaction ? { interaction: input.interaction } : {}),
+        text: routingDecision.result.answer,
+      });
+      // No worker onStart fires for inline answers; clear intake 👀 here.
+      await clearDiscordIntakeAckBestEffort(input);
+      return { status: 'replied_inline' as const, routingDecision };
+    }
+
+    if (
+      !input.skipRoutingConfirmation &&
+      // Confirmation cards need a launch owner to accept on behalf of; the
+      // ownerless case only arises on auto-start paths, which skip them anyway.
+      input.launchOwnerUserId &&
+      !shouldAutoConfirmDiscordRoute(routingDecision)
+    ) {
+      const confirmation = await requestDiscordRoutingConfirmation({
+        provider: input.provider,
+        applicationId: input.applicationId,
+        ...(input.interaction ? { interaction: input.interaction } : {}),
+        requesterDiscordUserId: input.requesterDiscordUserId,
+        launchOwnerUserId: input.launchOwnerUserId,
+        queuedMessage: {
+          ...input.queuedMessage,
+          ...(allImages.length ? { images: allImages } : {}),
+        },
+        metadata: input.metadata,
+        routingContext,
+        channel: input.channel,
+        routingDecision,
+        forceNewThread: input.forceNewThread,
+        ...(agentPromptText ? { agentPromptText } : {}),
+        ...(input.intakeAckPinned ? { intakeAckPinned: true } : {}),
+      });
+      if (includeReplyContext) {
+        await markDiscordThreadHistoryDelivered({
+          channelId: input.channel.channelId,
+          messageIds: historyWithTrigger.map((message) => message.id),
+        });
+      }
+      return {
+        status: 'confirmation_pending' as const,
+        routingDecision,
+        pendingRouteId: confirmation.pendingRouteId,
+      };
+    }
+
+    const workspace =
+      routingDecision.status === 'routed'
+        ? await resolveDiscordWorkspace(routingDecision.result.workspace)
+        : {
+            repoForPayload: ALL_REPOSITORIES,
+            workspaceDisplayName: 'all repos',
+          };
+    if (!workspace) {
+      throw new Error(
+        'Discord task routing selected an unavailable workspace.',
+      );
+    }
+    const kickoffMessage =
+      routingDecision.status === 'routed'
+        ? routingDecision.result.kickoffMessage
+        : undefined;
+    const launched = await launchDiscordTask({
       provider: input.provider,
-      applicationId: input.applicationId,
-      ...(input.interaction ? { interaction: input.interaction } : {}),
-      requesterDiscordUserId: input.requesterDiscordUserId,
       launchOwnerUserId: input.launchOwnerUserId,
+      ...(input.channelAutoStart
+        ? { initiator: input.channelAutoStart.initiator }
+        : {}),
+      ...(agentPromptText ? { agentPromptText } : {}),
       queuedMessage: {
         ...input.queuedMessage,
         ...(allImages.length ? { images: allImages } : {}),
       },
       metadata: input.metadata,
-      routingContext,
       channel: input.channel,
-      routingDecision,
+      workspace,
       forceNewThread: input.forceNewThread,
-      ...(agentPromptText ? { agentPromptText } : {}),
+      ...(kickoffMessage ? { kickoffMessage } : {}),
       ...(input.intakeAckPinned ? { intakeAckPinned: true } : {}),
     });
     if (includeReplyContext) {
@@ -288,69 +340,28 @@ export async function startNewDiscordTask(input: {
         messageIds: historyWithTrigger.map((message) => message.id),
       });
     }
+    if (input.interaction) {
+      await replyToDiscordEvent({
+        provider: input.provider,
+        applicationId: input.applicationId,
+        channel: input.channel,
+        interaction: input.interaction,
+        text: launched.createdThread
+          ? `Started in **${workspace.workspaceDisplayName}**. Continue in the new task thread.`
+          : `Started in **${workspace.workspaceDisplayName}**.`,
+        ...(launched.taskUrl
+          ? { buttons: [[{ text: 'Follow', url: launched.taskUrl }]] }
+          : {}),
+      });
+    }
     return {
-      status: 'confirmation_pending' as const,
+      status: 'started' as const,
       routingDecision,
-      pendingRouteId: confirmation.pendingRouteId,
+      workspace,
+      ...launched,
     };
+  } catch (error) {
+    await clearDiscordIntakeAckBestEffort(input);
+    throw error;
   }
-
-  const workspace =
-    routingDecision.status === 'routed'
-      ? await resolveDiscordWorkspace(routingDecision.result.workspace)
-      : {
-          repoForPayload: ALL_REPOSITORIES,
-          workspaceDisplayName: 'all repos',
-        };
-  if (!workspace) {
-    throw new Error('Discord task routing selected an unavailable workspace.');
-  }
-  const kickoffMessage =
-    routingDecision.status === 'routed'
-      ? routingDecision.result.kickoffMessage
-      : undefined;
-  const launched = await launchDiscordTask({
-    provider: input.provider,
-    launchOwnerUserId: input.launchOwnerUserId,
-    ...(input.channelAutoStart
-      ? { initiator: input.channelAutoStart.initiator }
-      : {}),
-    ...(agentPromptText ? { agentPromptText } : {}),
-    queuedMessage: {
-      ...input.queuedMessage,
-      ...(allImages.length ? { images: allImages } : {}),
-    },
-    metadata: input.metadata,
-    channel: input.channel,
-    workspace,
-    forceNewThread: input.forceNewThread,
-    ...(kickoffMessage ? { kickoffMessage } : {}),
-    ...(input.intakeAckPinned ? { intakeAckPinned: true } : {}),
-  });
-  if (includeReplyContext) {
-    await markDiscordThreadHistoryDelivered({
-      channelId: input.channel.channelId,
-      messageIds: historyWithTrigger.map((message) => message.id),
-    });
-  }
-  if (input.interaction) {
-    await replyToDiscordEvent({
-      provider: input.provider,
-      applicationId: input.applicationId,
-      channel: input.channel,
-      interaction: input.interaction,
-      text: launched.createdThread
-        ? `Started in **${workspace.workspaceDisplayName}**. Continue in the new task thread.`
-        : `Started in **${workspace.workspaceDisplayName}**.`,
-      ...(launched.taskUrl
-        ? { buttons: [[{ text: 'Follow', url: launched.taskUrl }]] }
-        : {}),
-    });
-  }
-  return {
-    status: 'started' as const,
-    routingDecision,
-    workspace,
-    ...launched,
-  };
 }

--- a/apps/api/src/handlers/discord/unmentioned-thread-reply.ts
+++ b/apps/api/src/handlers/discord/unmentioned-thread-reply.ts
@@ -96,7 +96,7 @@ export async function shouldRouteUnmentionedDiscordThreadReplyToAgent(params: {
   isRoomoteThread: boolean;
   /** Roomote user id of the thread task owner when known. */
   ownedThreadUserId: string | null | undefined;
-  /** True when the reply targets an announcer report root. */
+  /** True when the reply targets an automation report root. */
   isAutomationReportThread?: boolean;
   fetchThreadMessages: () => Promise<DiscordThreadHistoryMessage[] | null>;
 }): Promise<boolean> {

--- a/apps/api/src/handlers/mcp/communication-thread-replies.ts
+++ b/apps/api/src/handlers/mcp/communication-thread-replies.ts
@@ -11,6 +11,7 @@ import {
   db,
   and,
   eq,
+  getTaskAutomationInitiatorKey,
   sql,
   taskRuns,
   upsertBackgroundAutomationSlackThread,
@@ -185,15 +186,21 @@ async function bindLateCommunicationReportThread(params: {
   provider: 'teams' | 'telegram' | 'discord';
   messageId: string;
 }): Promise<void> {
-  const payload = params.taskRun.payload as
-    | { backgroundAutomationKey?: unknown }
-    | undefined;
-  const automationKey = payload?.backgroundAutomationKey;
   const channelId = getCommunicationChannelFromTaskPayload(
     params.taskRun.payload,
   );
 
-  if (automationKey !== 'announcer' || !channelId) {
+  if (!channelId) {
+    return;
+  }
+
+  // Every automation-launched report root gets bound, so replies to it route
+  // back to the task on any provider.
+  const automationKey = await getTaskAutomationInitiatorKey(
+    params.taskRun.taskId,
+  );
+
+  if (!automationKey) {
     return;
   }
 
@@ -222,7 +229,7 @@ async function bindLateCommunicationReportThread(params: {
     }
     await upsertBackgroundAutomationSlackThread(tx, {
       surface: params.provider,
-      automationKey: 'announcer',
+      automationKey,
       slackChannelId: channelId,
       threadTs: params.messageId,
       summaryText: '',

--- a/apps/api/src/handlers/mcp/slack.ts
+++ b/apps/api/src/handlers/mcp/slack.ts
@@ -9,6 +9,7 @@ import {
   eq,
   findBackgroundAutomationSlackThread,
   getCustomAutomationById,
+  getTaskAutomationInitiatorKey,
   slackInstallations,
   taskRuns,
   tasks,
@@ -16,7 +17,6 @@ import {
 } from '@roomote/db/server';
 import {
   getTriggerableBackgroundAutomationDescriptorByKey,
-  type BackgroundAutomationKey,
   type SlackBlock,
 } from '@roomote/types';
 import {
@@ -263,19 +263,6 @@ function getCustomAutomationIdFromTaskPayload(payload: unknown): string | null {
 
   const value = (payload as Record<string, unknown>).customAutomationId;
   return typeof value === 'string' && value.trim().length > 0 ? value : null;
-}
-
-function getBackgroundAutomationKeyFromTaskPayload(
-  payload: unknown,
-): BackgroundAutomationKey | null {
-  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
-    return null;
-  }
-
-  const value = (payload as Record<string, unknown>).backgroundAutomationKey;
-  return typeof value === 'string' && value.trim().length > 0
-    ? (value as BackgroundAutomationKey)
-    : null;
 }
 
 function normalizeSlackQuoteText(text: string): string {
@@ -872,13 +859,18 @@ slackMcp.post('/thread_reply', async (c) => {
   }
 
   // Creating a brand-new top-level channel message is reserved for late-bound
-  // automation tasks: execution tasks marked by automationWorkItemId and
-  // custom automation runs marked by customAutomationId in the payload.
+  // automation tasks: execution tasks marked by automationWorkItemId, custom
+  // automation runs marked by customAutomationId in the payload, and any task
+  // an automation launched.
+  const backgroundAutomationKey = await getTaskAutomationInitiatorKey(
+    taskRun.taskId,
+  );
+
   if (
     !slackReplyTarget.threadTs &&
     !getAutomationWorkItemIdFromTaskPayload(taskRun.payload) &&
     !getCustomAutomationIdFromTaskPayload(taskRun.payload) &&
-    !getBackgroundAutomationKeyFromTaskPayload(taskRun.payload)
+    !backgroundAutomationKey
   ) {
     return c.json(
       {
@@ -938,9 +930,6 @@ slackMcp.post('/thread_reply', async (c) => {
     taskRun.payload,
   );
   const customAutomationId = getCustomAutomationIdFromTaskPayload(
-    taskRun.payload,
-  );
-  const backgroundAutomationKey = getBackgroundAutomationKeyFromTaskPayload(
     taskRun.payload,
   );
   const existingThreadTs = slackReplyTarget.threadTs;

--- a/apps/api/src/handlers/slack/helpers/__tests__/conversation-log.test.ts
+++ b/apps/api/src/handlers/slack/helpers/__tests__/conversation-log.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  taskRunRowsMock,
+  findBackgroundAutomationSlackThreadMock,
+  getLatestSlackBotReplyMock,
+} = vi.hoisted(() => ({
+  taskRunRowsMock: vi.fn(),
+  findBackgroundAutomationSlackThreadMock: vi.fn(),
+  getLatestSlackBotReplyMock: vi.fn(),
+}));
+
+vi.mock('@roomote/cloud-agents', () => ({
+  stripLeadingRawSlackMention: vi.fn((text: string) => text),
+  stripLeadingSlackProductMention: vi.fn((text: string) => text),
+}));
+
+vi.mock('@roomote/sdk/server', () => ({
+  recordSlackConversationMessageBestEffort: vi.fn(),
+}));
+
+vi.mock('@roomote/slack', () => ({
+  getLatestSlackBotReply: getLatestSlackBotReplyMock,
+}));
+
+vi.mock('@roomote/db/server', () => {
+  const chain = {
+    from: vi.fn(),
+    innerJoin: vi.fn(),
+    where: vi.fn(),
+    orderBy: vi.fn(),
+    limit: vi.fn(async () => taskRunRowsMock()),
+  };
+  chain.from.mockReturnValue(chain);
+  chain.innerJoin.mockReturnValue(chain);
+  chain.where.mockReturnValue(chain);
+  chain.orderBy.mockReturnValue(chain);
+
+  return {
+    and: vi.fn((...conditions: unknown[]) => ({ conditions })),
+    db: { select: vi.fn(() => chain) },
+    desc: vi.fn((value: unknown) => value),
+    eq: vi.fn((left: unknown, right: unknown) => ({ left, right })),
+    findBackgroundAutomationSlackThread:
+      findBackgroundAutomationSlackThreadMock,
+    taskRuns: {
+      actingUserId: 'taskRuns.actingUserId',
+      createdAt: 'taskRuns.createdAt',
+      id: 'taskRuns.id',
+      payload: 'taskRuns.payload',
+      taskId: 'taskRuns.taskId',
+    },
+    tasks: {
+      id: 'tasks.id',
+      initiatorUserId: 'tasks.initiatorUserId',
+      slackThreadTs: 'tasks.slackThreadTs',
+    },
+  };
+});
+
+import { findRoomoteOwnedSlackThread } from '../conversation-log';
+
+const THREAD = { teamId: 'T1', channelId: 'C1', threadTs: '100.000' };
+
+describe('findRoomoteOwnedSlackThread', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    taskRunRowsMock.mockResolvedValue([]);
+    findBackgroundAutomationSlackThreadMock.mockResolvedValue(null);
+    getLatestSlackBotReplyMock.mockResolvedValue(null);
+  });
+
+  it.each([['ci_failure_triage'], ['sentry_triage'], ['announcer']])(
+    'treats a task-bound %s report thread as an automation report thread',
+    async (automationKey) => {
+      taskRunRowsMock.mockResolvedValue([
+        {
+          id: 7,
+          taskId: 'task-1',
+          payload: { channel: 'C1' },
+          initiatorUserId: null,
+          actingUserId: null,
+        },
+      ]);
+      findBackgroundAutomationSlackThreadMock.mockResolvedValue({
+        automationKey,
+        metadata: { sourceTaskId: 'task-1' },
+      });
+
+      await expect(findRoomoteOwnedSlackThread(THREAD)).resolves.toMatchObject({
+        isAutomationReportThread: true,
+      });
+    },
+  );
+
+  it('ignores a tracked automation thread with no bound task', async () => {
+    findBackgroundAutomationSlackThreadMock.mockResolvedValue({
+      automationKey: 'ci_failure_triage',
+      metadata: {},
+    });
+
+    await expect(findRoomoteOwnedSlackThread(THREAD)).resolves.toBeNull();
+  });
+});

--- a/apps/api/src/handlers/slack/helpers/conversation-log.ts
+++ b/apps/api/src/handlers/slack/helpers/conversation-log.ts
@@ -2,7 +2,6 @@ import {
   stripLeadingRawSlackMention,
   stripLeadingSlackProductMention,
 } from '@roomote/cloud-agents';
-import { isTaskBackedReportAutomationKey } from '@roomote/types';
 import { recordSlackConversationMessageBestEffort } from '@roomote/sdk/server';
 import {
   getLatestSlackBotReply,
@@ -135,11 +134,12 @@ export async function findRoomoteOwnedSlackThread(params: {
     threadTs: params.threadTs,
   });
 
+  // Any automation thread carrying a sourceTaskId is task-backed by
+  // construction: the binding is written only when a task owns the root. The
+  // automation key itself is irrelevant, so every automation's report thread
+  // accepts unmentioned replies, not just the ones that predate this.
   const sourceTaskId =
-    trackedAutomationThread &&
-    trackedAutomationThread.automationKey != null &&
-    isTaskBackedReportAutomationKey(trackedAutomationThread.automationKey) &&
-    typeof trackedAutomationThread.metadata?.sourceTaskId === 'string' &&
+    typeof trackedAutomationThread?.metadata?.sourceTaskId === 'string' &&
     trackedAutomationThread.metadata.sourceTaskId.trim().length > 0
       ? trackedAutomationThread.metadata.sourceTaskId
       : null;

--- a/apps/api/src/handlers/tasks/automation-work-items/slack.ts
+++ b/apps/api/src/handlers/tasks/automation-work-items/slack.ts
@@ -4,6 +4,7 @@ import {
   and,
   asc,
   db,
+  type DatabaseOrTransaction,
   eq,
   getAutomationRuntime,
   isNull,
@@ -68,6 +69,29 @@ export async function resolveAutomationSlackTarget(params: {
   };
 }
 
+async function resolveWorkItemAutomationKey(
+  tx: DatabaseOrTransaction,
+  automationWorkItemId: string,
+): Promise<BackgroundAutomationKey | null> {
+  const [automationWorkItem] = await tx
+    .select({
+      automationKey: workItems.automationKey,
+      sourceTaskId: workItems.sourceTaskId,
+    })
+    .from(workItems)
+    .where(
+      and(
+        eq(workItems.kind, 'auto_fix'),
+        eq(workItems.id, automationWorkItemId),
+      ),
+    )
+    .limit(1);
+
+  return automationWorkItem?.sourceTaskId
+    ? (automationWorkItem.automationKey ?? null)
+    : null;
+}
+
 export async function bindLateSlackThreadToTask(params: {
   taskId: string;
   channelId: string;
@@ -109,47 +133,21 @@ export async function bindLateSlackThreadToTask(params: {
       })
       .where(eq(taskRuns.taskId, params.taskId));
 
-    if (params.backgroundAutomationKey) {
-      await upsertBackgroundAutomationSlackThread(tx, {
-        surface: 'slack',
-        automationKey: params.backgroundAutomationKey,
-        slackChannelId: params.channelId,
-        threadTs: params.threadTs,
-        summaryText: params.summaryText,
-        postedAt: new Date(),
-        metadata: { sourceTaskId: params.taskId },
-      });
-      return;
-    }
+    // A work item names the automation that queued it, which is more specific
+    // than the launching automation, so it wins when both are available.
+    const workItemAutomationKey = params.automationWorkItemId
+      ? await resolveWorkItemAutomationKey(tx, params.automationWorkItemId)
+      : null;
+    const automationKey =
+      workItemAutomationKey ?? params.backgroundAutomationKey;
 
-    if (!params.automationWorkItemId) {
-      return;
-    }
-
-    const [automationWorkItem] = await tx
-      .select({
-        automationKey: workItems.automationKey,
-        sourceTaskId: workItems.sourceTaskId,
-      })
-      .from(workItems)
-      .where(
-        and(
-          eq(workItems.kind, 'auto_fix'),
-          eq(workItems.id, params.automationWorkItemId),
-        ),
-      )
-      .limit(1);
-
-    if (
-      !automationWorkItem?.sourceTaskId ||
-      !automationWorkItem.automationKey
-    ) {
+    if (!automationKey) {
       return;
     }
 
     await upsertBackgroundAutomationSlackThread(tx, {
       surface: 'slack',
-      automationKey: automationWorkItem.automationKey,
+      automationKey,
       slackChannelId: params.channelId,
       threadTs: params.threadTs,
       summaryText: params.summaryText,

--- a/apps/api/src/handlers/teams/find-active-teams-run.ts
+++ b/apps/api/src/handlers/teams/find-active-teams-run.ts
@@ -200,7 +200,7 @@ export async function findLatestTeamsThreadTaskRun(input: {
   return row ? withResolvedUserId(row) : undefined;
 }
 
-/** Finds an announcer report by its immutable Teams thread root. */
+/** Finds an automation report by its immutable Teams thread root. */
 export async function findTaskBackedTeamsAutomationReportRun(input: {
   conversationId: string;
   threadId: string;
@@ -220,7 +220,7 @@ export async function findTaskBackedTeamsAutomationReportRun(input: {
         teamsProviderMatch,
         conversationMatch,
         threadMatch,
-        sql`${taskRuns.payload}->>'backgroundAutomationKey' = 'announcer'`,
+        eq(tasks.initiatorKind, 'automation'),
         isNull(taskRuns.canceledAt),
       ),
     )

--- a/apps/api/src/route-policies.ts
+++ b/apps/api/src/route-policies.ts
@@ -208,8 +208,16 @@ export const ROUTE_POLICY_RULES: readonly RoutePolicyRule[] = [
     rateLimits: WEBHOOK_RATE_LIMITS,
   },
   {
+    // The BullMQ worker authenticates this route with the Discord gateway
+    // secret. It has no client IP, so applying webhook limits would make every
+    // worker request share one bucket during an outage retry storm.
+    name: 'internal-discord-event-processing',
+    match: { type: 'exact', path: '/api/internal/discord/events/process' },
+    policy: 'webhook',
+  },
+  {
     name: 'internal-discord-events',
-    match: { type: 'exact', path: '/api/internal/discord/events' },
+    match: { type: 'prefix', path: '/api/internal/discord/events' },
     policy: 'webhook',
     rateLimits: WEBHOOK_RATE_LIMITS,
   },

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -73,6 +73,7 @@ const SELF_AUTHENTICATING_WEBHOOK_PATHS = new Set([
   '/api/webhooks/teams',
   '/api/webhooks/telegram',
   '/api/internal/discord/events',
+  '/api/internal/discord/events/process',
   '/api/internal/cloud/deployment-access',
 ]);
 

--- a/apps/bullmq/src/discord-gateway-events-queue.test.ts
+++ b/apps/bullmq/src/discord-gateway-events-queue.test.ts
@@ -1,0 +1,98 @@
+import type { Job } from 'bullmq';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { envMock, fetchMock, resolveSecretMock } = vi.hoisted(() => ({
+  envMock: { TRPC_URL: 'http://api:13001' as string | undefined },
+  fetchMock: vi.fn(),
+  resolveSecretMock: vi.fn(),
+}));
+
+vi.mock('@roomote/env', () => ({
+  Env: envMock,
+}));
+
+vi.mock('@roomote/db/server', () => ({
+  resolveDiscordGatewaySecret: resolveSecretMock,
+}));
+
+vi.mock('@roomote/sdk/server', () => ({
+  DISCORD_GATEWAY_EVENTS_QUEUE_NAME: 'discord-gateway-events',
+}));
+
+import { processDiscordGatewayEventJob } from './discord-gateway-events-queue';
+
+const event = {
+  eventId: 'message-1',
+  eventType: 'MESSAGE_CREATE' as const,
+  payload: {
+    id: 'message-1',
+    channel_id: 'channel-1',
+    content: 'hello',
+    author: { id: 'user-1', username: 'user' },
+    mentions: [],
+    attachments: [],
+  },
+  receivedAt: '2026-07-24T00:00:00.000Z',
+};
+
+describe('processDiscordGatewayEventJob', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    envMock.TRPC_URL = 'http://api:13001';
+    vi.stubGlobal('fetch', fetchMock);
+    resolveSecretMock.mockResolvedValue('gateway-secret');
+  });
+
+  it('posts the event to the internal processing endpoint with gateway auth', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+
+    await processDiscordGatewayEventJob({ data: event } as Job<typeof event>);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://api:13001/api/internal/discord/events/process',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-roomote-discord-gateway-secret': 'gateway-secret',
+        },
+        body: JSON.stringify(event),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it('treats an already completed event as successful', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 409 }));
+
+    await expect(
+      processDiscordGatewayEventJob({ data: event } as Job<typeof event>),
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws retryable processing failures for BullMQ', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 503 }));
+
+    await expect(
+      processDiscordGatewayEventJob({ data: event } as Job<typeof event>),
+    ).rejects.toThrow('HTTP 503');
+  });
+
+  it('throws 425 processing responses so BullMQ retries the event', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 425 }));
+
+    await expect(
+      processDiscordGatewayEventJob({ data: event } as Job<typeof event>),
+    ).rejects.toThrow('HTTP 425');
+  });
+
+  it('fails fast when the worker API URL is missing', async () => {
+    envMock.TRPC_URL = undefined;
+
+    await expect(
+      processDiscordGatewayEventJob({ data: event } as Job<typeof event>),
+    ).rejects.toThrow('TRPC_URL is required to process Discord gateway events');
+    expect(resolveSecretMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/bullmq/src/discord-gateway-events-queue.ts
+++ b/apps/bullmq/src/discord-gateway-events-queue.ts
@@ -1,0 +1,77 @@
+import { Queue, Worker, type Job } from 'bullmq';
+
+import { resolveDiscordGatewaySecret } from '@roomote/db/server';
+import { Env } from '@roomote/env';
+import type { DiscordGatewayEvent } from '@roomote/communication/discord-event';
+import { DISCORD_GATEWAY_EVENTS_QUEUE_NAME } from '@roomote/sdk/server';
+
+import { getRedis } from './redis';
+
+const DISCORD_GATEWAY_SECRET_HEADER = 'x-roomote-discord-gateway-secret';
+const DISCORD_GATEWAY_EVENT_WORKER_TIMEOUT_MS = 4 * 60 * 1000 + 15_000;
+
+function processUrl(): string {
+  if (!Env.TRPC_URL) {
+    throw new Error('TRPC_URL is required to process Discord gateway events');
+  }
+
+  return new URL(
+    '/api/internal/discord/events/process',
+    Env.TRPC_URL,
+  ).toString();
+}
+
+export async function processDiscordGatewayEventJob(
+  job: Job<DiscordGatewayEvent>,
+): Promise<void> {
+  const url = processUrl();
+  const secret = await resolveDiscordGatewaySecret();
+  if (!secret) {
+    throw new Error('Discord Gateway secret is not configured');
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      [DISCORD_GATEWAY_SECRET_HEADER]: secret,
+    },
+    body: JSON.stringify(job.data),
+    // Let the API release its lease and return its retryable timeout first.
+    signal: AbortSignal.timeout(DISCORD_GATEWAY_EVENT_WORKER_TIMEOUT_MS),
+  });
+
+  // A completed event can outlive its retained BullMQ job. The API's durable
+  // idempotency gate reports that state as a conflict, which is successful work.
+  if (response.ok || response.status === 409) return;
+
+  throw new Error(
+    `Discord event processing failed with HTTP ${response.status}`,
+  );
+}
+
+export function startDiscordGatewayEventsQueue() {
+  const connection = getRedis();
+  const queue = new Queue<DiscordGatewayEvent>(
+    DISCORD_GATEWAY_EVENTS_QUEUE_NAME,
+    {
+      connection,
+    },
+  );
+  const worker = new Worker<DiscordGatewayEvent>(
+    DISCORD_GATEWAY_EVENTS_QUEUE_NAME,
+    processDiscordGatewayEventJob,
+    { connection, concurrency: 5, autorun: true },
+  );
+
+  worker.on('failed', (job, error) =>
+    console.error(
+      `[DiscordGatewayEventsQueue] job ${job?.id} failed for ${job?.data.eventId}: ${error.message}`,
+    ),
+  );
+  worker.on('error', (error) =>
+    console.error('[DiscordGatewayEventsQueue] worker error:', error),
+  );
+
+  return { queue, worker };
+}

--- a/apps/bullmq/src/index.ts
+++ b/apps/bullmq/src/index.ts
@@ -37,6 +37,7 @@ import { startScheduler } from './scheduler';
 import { startSandboxOidcRefreshQueue } from './sandbox-oidc-refresh-queue';
 import { startSlackAccountLinkEducationQueue } from './slack-account-link-education-queue';
 import { startSuggestedTasksOnboardingFollowupQueue } from './suggested-tasks-onboarding-followup-queue';
+import { startDiscordGatewayEventsQueue } from './discord-gateway-events-queue';
 import { discordSuggestedTasksOnboardingFollowupJob } from './jobs/discord-suggested-tasks-onboarding-followup';
 import { slackSuggestedTasksOnboardingFollowupJob } from './jobs/slack-suggested-tasks-onboarding-followup';
 import { telegramSuggestedTasksOnboardingFollowupJob } from './jobs/telegram-suggested-tasks-onboarding-followup';
@@ -89,6 +90,8 @@ const discordGatewaySupervisor = startDiscordGatewaySupervisor(
       ),
   },
 );
+const { queue: discordGatewayEventsQueue, worker: discordGatewayEventsWorker } =
+  startDiscordGatewayEventsQueue();
 
 const { schedulerQueue, schedulerWorker, schedulerQueueEvents } =
   startScheduler();
@@ -170,6 +173,7 @@ createBullBoard({
     new BullMQAdapter(dockerValidationQueue, { readOnlyMode: false }),
     new BullMQAdapter(taskSleepQueue, { readOnlyMode: false }),
     new BullMQAdapter(slackAccountLinkEducationQueue, { readOnlyMode: false }),
+    new BullMQAdapter(discordGatewayEventsQueue, { readOnlyMode: false }),
     new BullMQAdapter(discordSuggestedTasksOnboardingFollowupQueue, {
       readOnlyMode: false,
     }),
@@ -325,6 +329,8 @@ async function gracefulShutdown() {
     await slackAccountLinkEducationWorker.close();
     await slackAccountLinkEducationQueueEvents.close();
     await slackAccountLinkEducationQueue.close();
+    await discordGatewayEventsWorker.close();
+    await discordGatewayEventsQueue.close();
     await discordSuggestedTasksOnboardingFollowupWorker.close();
     await discordSuggestedTasksOnboardingFollowupQueue.close();
     await slackSuggestedTasksOnboardingFollowupWorker.close();

--- a/apps/docs/automations.mdx
+++ b/apps/docs/automations.mdx
@@ -26,6 +26,11 @@ Automations can create useful work quickly. Start with one or two that map to
 a real team habit, tell the team where output will appear, then expand once
 the signal is good.
 
+Every automation that posts to a chat channel is replyable. Reply in the
+thread Roomote started and you are talking to the task behind that report,
+without needing to mention Roomote. That works on Slack, Discord, Teams, and
+Telegram, and it works after the run has finished.
+
 ## Pull request automations
 
 These automations react to pull requests, issues, and repository state.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roomote",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "license": "FCL-1.0-ALv2",
   "packageManager": "pnpm@10.29.3",
   "engines": {

--- a/packages/db/src/lib/tasks.ts
+++ b/packages/db/src/lib/tasks.ts
@@ -1,5 +1,7 @@
 import { and, eq, isNull, type SQL } from 'drizzle-orm';
 
+import type { BackgroundAutomationKey } from '@roomote/types';
+
 import { type DatabaseOrTransaction, db } from '../db';
 import { tasks } from '../schema';
 import type { CreateTask, Task } from '../types';
@@ -116,4 +118,28 @@ function isTaskIdCollisionError(error: unknown): boolean {
     typeof e.message === 'string' &&
     e.message.includes(TASK_PRIMARY_KEY_CONSTRAINT)
   );
+}
+
+/**
+ * Resolves the automation that launched a task, or null for user-initiated
+ * tasks. The initiator columns are the single source of truth here: only some
+ * automations stamp an automation key into the run payload, so payload reads
+ * silently miss most automation launches.
+ */
+export async function getTaskAutomationInitiatorKey(
+  taskId: string,
+  database: DatabaseOrTransaction = db,
+): Promise<BackgroundAutomationKey | null> {
+  const [task] = await database
+    .select({
+      initiatorKind: tasks.initiatorKind,
+      initiatorAutomation: tasks.initiatorAutomation,
+    })
+    .from(tasks)
+    .where(eq(tasks.id, taskId))
+    .limit(1);
+
+  return task?.initiatorKind === 'automation'
+    ? (task.initiatorAutomation ?? null)
+    : null;
 }

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -89,6 +89,11 @@ export {
 } from './lib/suggested-tasks-onboarding-followup';
 
 export {
+  DISCORD_GATEWAY_EVENTS_QUEUE_NAME,
+  enqueueDiscordGatewayEvent,
+} from './lib/discord-gateway-events';
+
+export {
   TELEGRAM_LINK_CODE_TTL_SECONDS,
   consumeTelegramLinkCode,
   createTelegramLinkCode,

--- a/packages/sdk/src/server/lib/communication/__tests__/communication-task-run-lookup.test.ts
+++ b/packages/sdk/src/server/lib/communication/__tests__/communication-task-run-lookup.test.ts
@@ -46,6 +46,7 @@ vi.mock('@roomote/db/server', () => {
     },
     tasks: {
       id: 'tasks.id',
+      initiatorKind: 'tasks.initiatorKind',
       initiatorUserId: 'tasks.initiatorUserId',
     },
     trackedMessages: {
@@ -67,8 +68,14 @@ function automationRun(id: number, taskId: string) {
     taskId,
     initiatorUserId: null,
     actingUserId: null,
-    payload: { backgroundAutomationKey: 'announcer' },
+    payload: {},
   };
+}
+
+function whereConditions() {
+  return whereMock.mock.calls.flatMap(
+    ([condition]) => condition.conditions ?? [],
+  );
 }
 
 describe('findTaskBackedAutomationReportRun', () => {
@@ -77,49 +84,78 @@ describe('findTaskBackedAutomationReportRun', () => {
     queryResults.length = 0;
   });
 
-  it('keeps two announcer roots in the same channel bound to their own runs', async () => {
+  it('keeps two report roots in the same channel bound to their own runs', async () => {
     queryResults.push(
-      [automationRun(11, 'announcer-task-one')],
-      [automationRun(22, 'announcer-task-two')],
+      [automationRun(11, 'report-task-one')],
+      [automationRun(22, 'report-task-two')],
     );
 
     await expect(
       findTaskBackedAutomationReportRun({
         provider: 'discord',
         channelId: 'channel-1',
-        messageId: 'announcer-root-one',
+        messageId: 'report-root-one',
       }),
-    ).resolves.toMatchObject({ id: 11, taskId: 'announcer-task-one' });
+    ).resolves.toMatchObject({ id: 11, taskId: 'report-task-one' });
     await expect(
       findTaskBackedAutomationReportRun({
         provider: 'discord',
         channelId: 'channel-1',
-        messageId: 'announcer-root-two',
+        messageId: 'report-root-two',
       }),
-    ).resolves.toMatchObject({ id: 22, taskId: 'announcer-task-two' });
+    ).resolves.toMatchObject({ id: 22, taskId: 'report-task-two' });
 
-    const messageIds = whereMock.mock.calls
-      .flatMap(([condition]) => condition.conditions ?? [])
+    const messageIds = whereConditions()
       .flatMap((condition: { values?: unknown[] }) => condition.values ?? [])
       .filter((value) => typeof value === 'string');
     expect(messageIds).toEqual(
-      expect.arrayContaining(['announcer-root-one', 'announcer-root-two']),
+      expect.arrayContaining(['report-root-one', 'report-root-two']),
     );
+  });
+
+  it('matches any automation-initiated task, not one hardcoded automation key', async () => {
+    queryResults.push([automationRun(11, 'ci-triage-task')]);
+
+    await expect(
+      findTaskBackedAutomationReportRun({
+        provider: 'discord',
+        channelId: 'channel-1',
+        messageId: 'ci-triage-root',
+      }),
+    ).resolves.toMatchObject({ id: 11, taskId: 'ci-triage-task' });
+
+    const conditions = whereConditions();
+    expect(conditions).toContainEqual({
+      left: 'tasks.initiatorKind',
+      right: 'automation',
+    });
+    expect(
+      conditions.some((condition: { strings?: string[] }) =>
+        condition.strings?.some((fragment) => fragment.includes('announcer')),
+      ),
+    ).toBe(false);
   });
 
   it('falls back from a missing payload binding to the tracked automation thread source task', async () => {
     queryResults.push(
       [],
-      [{ sourceTaskId: 'announcer-task-one' }],
-      [automationRun(11, 'announcer-task-one')],
+      [{ sourceTaskId: 'report-task-one' }],
+      [automationRun(11, 'report-task-one')],
     );
 
     await expect(
       findTaskBackedAutomationReportRun({
         provider: 'telegram',
         channelId: 'chat-1',
-        messageId: 'announcer-root-one',
+        messageId: 'report-root-one',
       }),
-    ).resolves.toMatchObject({ id: 11, taskId: 'announcer-task-one' });
+    ).resolves.toMatchObject({ id: 11, taskId: 'report-task-one' });
+
+    // The tracked-thread fallback must not filter on a specific automation
+    // key either, or non-announcer reports lose their late-bound roots.
+    expect(whereConditions()).not.toContainEqual({
+      left: 'trackedMessages.automationKey',
+      right: 'announcer',
+    });
   });
 });

--- a/packages/sdk/src/server/lib/communication/communication-task-run-lookup.ts
+++ b/packages/sdk/src/server/lib/communication/communication-task-run-lookup.ts
@@ -123,6 +123,10 @@ export async function findCompletedCommunicationTaskRunWithSnapshot(
  * Finds the task that produced an automation report root. Inbound replies use
  * the provider's reply target, not the newest task in the channel, so reports
  * remain routable after later tasks have run in the same conversation.
+ *
+ * Every automation-initiated task qualifies. The initiator columns carry that
+ * signal for all of them, unlike the run payload, which only some automations
+ * stamp with an automation key.
  */
 export async function findTaskBackedAutomationReportRun(input: {
   provider: CommunicationProvider;
@@ -138,7 +142,7 @@ export async function findTaskBackedAutomationReportRun(input: {
         sql`${taskRuns.payload}->>'communicationProvider' = ${input.provider}`,
         sql`${taskRuns.payload}->>'communicationChannelId' = ${input.channelId}`,
         sql`${taskRuns.payload}->>'communicationMessageId' = ${input.messageId}`,
-        sql`${taskRuns.payload}->>'backgroundAutomationKey' = 'announcer'`,
+        eq(tasks.initiatorKind, 'automation'),
         isNull(taskRuns.canceledAt),
       ),
     )
@@ -160,7 +164,6 @@ export async function findTaskBackedAutomationReportRun(input: {
       and(
         eq(trackedMessages.surface, input.provider),
         eq(trackedMessages.kind, 'automation_thread'),
-        eq(trackedMessages.automationKey, 'announcer'),
         eq(trackedMessages.channelId, input.channelId),
         eq(trackedMessages.threadTs, input.messageId),
       ),

--- a/packages/sdk/src/server/lib/discord-gateway-events.test.ts
+++ b/packages/sdk/src/server/lib/discord-gateway-events.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { addMock, getJobMock, queueMock } = vi.hoisted(() => ({
+  addMock: vi.fn(),
+  getJobMock: vi.fn(),
+  queueMock: vi.fn().mockImplementation(function () {
+    return { add: addMock, getJob: getJobMock };
+  }),
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: queueMock,
+}));
+
+vi.mock('@roomote/redis', () => ({ getRedis: vi.fn(() => ({})) }));
+
+import {
+  DISCORD_GATEWAY_EVENTS_QUEUE_NAME,
+  enqueueDiscordGatewayEvent,
+} from './discord-gateway-events';
+
+describe('enqueueDiscordGatewayEvent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    addMock.mockResolvedValue({ id: 'event-message-1' });
+    getJobMock.mockResolvedValue(undefined);
+  });
+
+  it('persists a validated event with a deterministic id and retry policy', async () => {
+    const event = {
+      eventId: 'message-1',
+      eventType: 'MESSAGE_CREATE' as const,
+      payload: {
+        id: 'message-1',
+        channel_id: 'channel-1',
+        content: 'hello',
+        author: { id: 'user-1', username: 'user' },
+        mentions: [],
+        attachments: [],
+      },
+      receivedAt: '2026-07-24T00:00:00.000Z',
+    };
+
+    await expect(enqueueDiscordGatewayEvent(event)).resolves.toEqual({
+      jobId: 'discord-gateway-event-MESSAGE_CREATE-message-1',
+    });
+    expect(DISCORD_GATEWAY_EVENTS_QUEUE_NAME).toBe('discord-gateway-events');
+    expect(queueMock).toHaveBeenCalledWith(
+      DISCORD_GATEWAY_EVENTS_QUEUE_NAME,
+      expect.objectContaining({
+        defaultJobOptions: expect.objectContaining({
+          attempts: 9,
+          backoff: { type: 'exponential', delay: 2_000 },
+          removeOnFail: { age: 7 * 24 * 3600, count: 1_000 },
+        }),
+      }),
+    );
+    expect(addMock).toHaveBeenCalledWith(
+      'process-discord-gateway-event',
+      event,
+      {
+        jobId: 'discord-gateway-event-MESSAGE_CREATE-message-1',
+      },
+    );
+  });
+
+  it('retains exhausted failed jobs for dead-letter inspection', async () => {
+    vi.resetModules();
+    const { enqueueDiscordGatewayEvent: enqueueEvent } =
+      await import('./discord-gateway-events');
+
+    await enqueueEvent({
+      eventId: 'message-2',
+      eventType: 'MESSAGE_CREATE',
+      payload: {
+        id: 'message-2',
+        channel_id: 'channel-1',
+        content: 'hello',
+        author: { id: 'user-1', username: 'user' },
+        mentions: [],
+        attachments: [],
+      },
+      receivedAt: '2026-07-24T00:00:00.000Z',
+    });
+
+    expect(queueMock).toHaveBeenCalledWith(
+      'discord-gateway-events',
+      expect.objectContaining({
+        defaultJobOptions: expect.objectContaining({
+          removeOnFail: { age: 7 * 24 * 3600, count: 1_000 },
+        }),
+      }),
+    );
+  });
+
+  it('creates a new generation when the deterministic job is retained as failed', async () => {
+    getJobMock
+      .mockResolvedValueOnce({ getState: vi.fn().mockResolvedValue('failed') })
+      .mockResolvedValueOnce(undefined);
+    const event = {
+      eventId: 'message-3',
+      eventType: 'MESSAGE_CREATE' as const,
+      payload: {
+        id: 'message-3',
+        channel_id: 'channel-1',
+        content: 'hello',
+        author: { id: 'user-1', username: 'user' },
+        mentions: [],
+        attachments: [],
+      },
+      receivedAt: '2026-07-24T00:00:00.000Z',
+    };
+
+    await expect(enqueueDiscordGatewayEvent(event)).resolves.toEqual({
+      jobId: 'discord-gateway-event-MESSAGE_CREATE-message-3-redelivery-1',
+    });
+    expect(addMock).toHaveBeenCalledWith(
+      'process-discord-gateway-event',
+      event,
+      {
+        jobId: 'discord-gateway-event-MESSAGE_CREATE-message-3-redelivery-1',
+      },
+    );
+  });
+
+  it('fails with a diagnostic when every retained redelivery generation is exhausted', async () => {
+    getJobMock.mockImplementation(async () => ({
+      getState: async () => 'failed',
+    }));
+    const event = {
+      eventId: 'message-4',
+      eventType: 'MESSAGE_CREATE' as const,
+      payload: {
+        id: 'message-4',
+        channel_id: 'channel-1',
+        content: 'hello',
+        author: { id: 'user-1', username: 'user' },
+        mentions: [],
+        attachments: [],
+      },
+      receivedAt: '2026-07-24T00:00:00.000Z',
+    };
+
+    await expect(enqueueDiscordGatewayEvent(event)).rejects.toThrow(
+      'Discord gateway event discord-gateway-event-MESSAGE_CREATE-message-4 exceeded 100 retained redelivery generations',
+    );
+    expect(addMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sdk/src/server/lib/discord-gateway-events.ts
+++ b/packages/sdk/src/server/lib/discord-gateway-events.ts
@@ -1,0 +1,83 @@
+import { Queue } from 'bullmq';
+
+import type { DiscordGatewayEvent } from '@roomote/communication/discord-event';
+import { getRedis } from '@roomote/redis';
+
+export const DISCORD_GATEWAY_EVENTS_QUEUE_NAME = 'discord-gateway-events';
+const MAX_DISCORD_GATEWAY_EVENT_REDELIVERY_GENERATIONS = 100;
+
+let discordGatewayEventsQueue: Queue<DiscordGatewayEvent> | null = null;
+
+function getDiscordGatewayEventsQueue(): Queue<DiscordGatewayEvent> {
+  if (!discordGatewayEventsQueue) {
+    discordGatewayEventsQueue = new Queue<DiscordGatewayEvent>(
+      DISCORD_GATEWAY_EVENTS_QUEUE_NAME,
+      {
+        connection: getRedis(),
+        defaultJobOptions: {
+          // Eight exponential backoffs total 510 seconds, exceeding the API's
+          // five-minute processing lease before this job is dead-lettered.
+          attempts: 9,
+          backoff: { type: 'exponential', delay: 2_000 },
+          removeOnComplete: { age: 3600, count: 1_000 },
+          // Keep exhausted jobs for inspection rather than silently dropping
+          // them and allowing a redelivery to hide the original failure.
+          removeOnFail: { age: 7 * 24 * 3600, count: 1_000 },
+        },
+      },
+    );
+  }
+
+  return discordGatewayEventsQueue;
+}
+
+function discordGatewayEventJobId(event: DiscordGatewayEvent): string {
+  return [
+    'discord-gateway-event',
+    encodeURIComponent(event.eventType),
+    encodeURIComponent(event.eventId),
+  ].join('-');
+}
+
+async function discordGatewayEventRedeliveryJobId(
+  queue: Queue<DiscordGatewayEvent>,
+  jobId: string,
+): Promise<string> {
+  const originalJob = await queue.getJob(jobId);
+  if (!originalJob || (await originalJob.getState()) !== 'failed') {
+    return jobId;
+  }
+
+  // Keep each exhausted generation for diagnosis, but do not let it prevent a
+  // later gateway delivery from being queued.
+  for (
+    let generation = 1;
+    generation <= MAX_DISCORD_GATEWAY_EVENT_REDELIVERY_GENERATIONS;
+    generation += 1
+  ) {
+    const redeliveryJobId = `${jobId}-redelivery-${generation}`;
+    const redeliveryJob = await queue.getJob(redeliveryJobId);
+    if (!redeliveryJob || (await redeliveryJob.getState()) !== 'failed') {
+      return redeliveryJobId;
+    }
+  }
+
+  throw new Error(
+    `Discord gateway event ${jobId} exceeded ${MAX_DISCORD_GATEWAY_EVENT_REDELIVERY_GENERATIONS} retained redelivery generations`,
+  );
+}
+
+/** Persist a validated Gateway event before acknowledging the Gateway. */
+export async function enqueueDiscordGatewayEvent(
+  event: DiscordGatewayEvent,
+): Promise<{ jobId: string }> {
+  const queue = getDiscordGatewayEventsQueue();
+  const jobId = await discordGatewayEventRedeliveryJobId(
+    queue,
+    discordGatewayEventJobId(event),
+  );
+  await queue.add('process-discord-gateway-event', event, {
+    jobId,
+  });
+  return { jobId };
+}

--- a/packages/types/src/background-agents.ts
+++ b/packages/types/src/background-agents.ts
@@ -320,21 +320,6 @@ export function supportsHistoricalThreadFeedback(
   return AUTOMATION_KEYS_WITH_HISTORICAL_THREAD_FEEDBACK_SET.has(automationKey);
 }
 
-const TASK_BACKED_REPORT_AUTOMATION_KEYS = [
-  'announcer',
-] as const satisfies readonly BackgroundAutomationKey[];
-
-export type TaskBackedReportAutomationKey =
-  (typeof TASK_BACKED_REPORT_AUTOMATION_KEYS)[number];
-
-export function isTaskBackedReportAutomationKey(
-  automationKey: BackgroundAutomationKey,
-): automationKey is TaskBackedReportAutomationKey {
-  return (TASK_BACKED_REPORT_AUTOMATION_KEYS as readonly string[]).includes(
-    automationKey,
-  );
-}
-
 export type BackgroundAgentSettingsLike = Record<string, unknown>;
 
 export function getBackgroundAgentFrequencyValues(


### PR DESCRIPTION
## Promote v0.20.1

Frozen at `8668dc2886c5f95548b1e420dd1c5345aa2cf56d` — the commit where `0.20.1` was versioned. Commits merged to `develop` after that point ship in the next release.

- Merge this PR with a **merge commit** (do not squash or rebase).
- If multiple promote PRs are open, merge them in version order (oldest first).
- Merging publishes a GitHub Release for `v0.20.1` and triggers the existing GHCR `v*` image publish (`latest` channel).
- The `release/v0.20.1` branch can be deleted after this PR merges.

### Changelog

## 0.20.1 (2026-07-25)

This release makes chat-driven automation more reliable, keeping Discord tasks moving and report-thread replies connected to their work.

### Highlights

- Keep Discord tasks responsive and recover safely from slow API processing or retries.
- Reply to any automation report thread to continue the task behind it, not only merged pull-request reports.

### Patch changes

- Discord tasks keep processing reliably when API work is slow or a delivery needs to retry.
- Replies now reach the task behind every automation report thread, not just merged-PR digests.
