### PR TITLE
Dispatch notify-ops on main builds only

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -469,8 +469,6 @@ jobs:
     name: Notify ops repository
     runs-on: ubuntu-latest
     needs: publish
-    # Main builds only: the ops repo's develop consumer (the retired nightly
-    # instance) is gone, so a develop dispatch would land on no listener.
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.ROOMOTE_OPS_REPO != '' }}
     permissions:
       contents: read

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -469,7 +469,9 @@ jobs:
     name: Notify ops repository
     runs-on: ubuntu-latest
     needs: publish
-    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') && vars.ROOMOTE_OPS_REPO != '' }}
+    # Main builds only: the ops repo's develop consumer (the retired nightly
+    # instance) is gone, so a develop dispatch would land on no listener.
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.ROOMOTE_OPS_REPO != '' }}
     permissions:
       contents: read
     steps:
@@ -480,20 +482,8 @@ jobs:
         run: |
           set -euo pipefail
           : "${GH_TOKEN:?ROOMOTE_OPS_DISPATCH_TOKEN is required}"
-          case "$GITHUB_REF" in
-            refs/heads/develop)
-              event_type=roomote-develop-build
-              image_tag="develop-${GITHUB_SHA:0:8}"
-              ;;
-            refs/heads/main)
-              event_type=roomote-main-build
-              image_tag="main-${GITHUB_SHA:0:8}"
-              ;;
-            *)
-              echo "Unexpected ref for notify-ops: $GITHUB_REF" >&2
-              exit 1
-              ;;
-          esac
+          event_type=roomote-main-build
+          image_tag="main-${GITHUB_SHA:0:8}"
           gh api "repos/${OPS_REPO}/dispatches" \
             -f "event_type=${event_type}" \
             -f "client_payload[image_tag]=${image_tag}" \


### PR DESCRIPTION
Companion to RooCodeInc/Roomote-Ops#14: with the retired nightly instance's `nightly.yml` removed, the ops repo has no `roomote-develop-build` listener — every develop push has been firing a dispatch that lands on nothing. Restrict `notify-ops` to main pushes and drop the now-single-armed ref switch.

The `notify-staging-cloud` / `notify-production-cloud` jobs (Roomote-Cloud fleet rollouts) are a separate system and are untouched — staging still follows develop builds through them.