### PR TITLE
[Fix] Restrict non-task OpenCode sessions to text-only output

### DIFF
--- a/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
@@ -341,19 +341,25 @@ describe('resolveOpenCodeSmallModel', () => {
       baseUrl: 'http://127.0.0.1:4096',
       fetch: expect.any(Function),
     });
+    // Sessions are locked down: an empty scratch directory (never the
+    // service's own working directory) and a deny-all permission ruleset.
     expect(sessionCreateMock).toHaveBeenCalledWith(
       {
-        directory: process.cwd(),
+        directory: expect.stringContaining('roomote-non-task-'),
         title: `Roomote ${NON_TASK_INFERENCE_SURFACES.routerTaskRouting}`,
+        permission: [{ permission: '*', pattern: '*', action: 'deny' }],
       },
       expect.objectContaining({
         signal: expect.any(AbortSignal),
       }),
     );
+    const sessionDirectory = sessionCreateMock.mock.calls[0]?.[0]
+      ?.directory as string;
+    expect(sessionDirectory).not.toBe(process.cwd());
     expect(sessionPromptMock).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionID: 'session-1',
-        directory: process.cwd(),
+        directory: sessionDirectory,
         model: {
           providerID: 'openrouter',
           modelID: 'openai/gpt-5.4',
@@ -481,7 +487,7 @@ describe('resolveOpenCodeSmallModel', () => {
     expect(sessionPromptMock).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionID: 'session-1',
-        directory: process.cwd(),
+        directory: expect.stringContaining('roomote-non-task-'),
         model: {
           providerID: 'openrouter',
           modelID: 'openai/gpt-5.4',

--- a/packages/cloud-agents/src/server/__tests__/opencode-runtime.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/opencode-runtime.test.ts
@@ -52,6 +52,7 @@ describe('buildOpenCodeCliEnv', () => {
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
       model: 'openrouter/openai/gpt-5.4',
       small_model: 'openrouter/openai/gpt-5.4',
+      permission: 'deny',
     });
   });
 
@@ -66,6 +67,7 @@ describe('buildOpenCodeCliEnv', () => {
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
       model: 'openrouter/openai/gpt-5.4',
       small_model: 'openrouter/z-ai/glm-5.2',
+      permission: 'deny',
       provider: {
         openrouter: {
           models: {
@@ -90,6 +92,7 @@ describe('buildOpenCodeCliEnv', () => {
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
       model: 'openrouter/z-ai/glm-5.2',
       small_model: 'openrouter/z-ai/glm-5.2',
+      permission: 'deny',
       provider: {
         openrouter: {
           models: {
@@ -114,6 +117,7 @@ describe('buildOpenCodeCliEnv', () => {
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
       model: 'openrouter/z-ai/glm-5.2',
       small_model: 'openrouter/z-ai/glm-5.2',
+      permission: 'deny',
       provider: {
         openrouter: {
           models: {
@@ -135,6 +139,7 @@ describe('buildOpenCodeCliEnv', () => {
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
       model: 'openrouter/openai/gpt-5.4',
       small_model: 'openrouter/openai/gpt-5.4',
+      permission: 'deny',
       provider: {
         openrouter: {
           models: {
@@ -174,7 +179,48 @@ describe('buildOpenCodeCliEnv', () => {
     expect(env.R_SMALL_MODEL).toBeUndefined();
     expect(env.GOOGLE_APPLICATION_CREDENTIALS).toBeUndefined();
     expect(env.MISTRAL_API_KEY).toBeUndefined();
-    expect(env.OPENCODE_CONFIG_CONTENT).toBeUndefined();
+    // No model-backed config remains, but the tool lockdown still applies.
+    expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
+      permission: 'deny',
+    });
+  });
+
+  it('denies tools without any model config', () => {
+    const env = buildOpenCodeCliEnv();
+
+    expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
+      permission: 'deny',
+    });
+  });
+
+  it('merges the tool denial into operator-supplied config content', () => {
+    const env = buildOpenCodeCliEnv({
+      OPENCODE_CONFIG_CONTENT: JSON.stringify({
+        model: 'openrouter/openai/gpt-5.4',
+        theme: 'dark',
+        // An operator-supplied allow must not survive: these servers only
+        // serve non-task calls, which never run tools.
+        permission: 'allow',
+      }),
+    });
+
+    expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
+      model: 'openrouter/openai/gpt-5.4',
+      theme: 'dark',
+      permission: 'deny',
+    });
+  });
+
+  it('fails closed to a permission-only config on malformed content', () => {
+    for (const malformed of ['{not json', '"just a string"', '[1,2]']) {
+      const env = buildOpenCodeCliEnv({
+        OPENCODE_CONFIG_CONTENT: malformed,
+      });
+
+      expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
+        permission: 'deny',
+      });
+    }
   });
 
   it('prevents inherited BASH_ENV from restoring disabled credentials through a shell wrapper', () => {

--- a/packages/cloud-agents/src/server/non-task-provider-usage.ts
+++ b/packages/cloud-agents/src/server/non-task-provider-usage.ts
@@ -1,4 +1,11 @@
-import { createOpencodeClient } from '@opencode-ai/sdk/v2/client';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  createOpencodeClient,
+  type PermissionRuleset,
+} from '@opencode-ai/sdk/v2/client';
 import { resolveEffectiveModelRuntimeEnv } from '@roomote/db/server';
 import type { z } from 'zod';
 import zodToJsonSchema from 'zod-to-json-schema';
@@ -11,6 +18,30 @@ import {
 
 const DEFAULT_OPENCODE_STRUCTURED_OUTPUT_RETRY_COUNT = 2;
 
+/**
+ * Non-task sessions produce text or structured output only; no tool may ever
+ * run. The leased servers already deny tools via their config
+ * (`withDeniedToolPermissions` in opencode-runtime), and this per-session
+ * ruleset keeps a stale or externally configured server
+ * (`OPENCODE_SDK_SERVER_URL`) equally locked down.
+ */
+const NON_TASK_SESSION_PERMISSIONS: PermissionRuleset = [
+  { permission: '*', pattern: '*', action: 'deny' },
+];
+
+let nonTaskSessionDirectory: string | undefined;
+
+/**
+ * Sessions run in an empty scratch directory instead of the service's own
+ * working directory (the deployment's application code), so even a tool that
+ * slips past the permission layers has nothing to read or write, and OpenCode
+ * skips indexing the whole repository for a title-generation call.
+ */
+function resolveNonTaskSessionDirectory(): string {
+  nonTaskSessionDirectory ??= mkdtempSync(join(tmpdir(), 'roomote-non-task-'));
+  return nonTaskSessionDirectory;
+}
+
 export type NonTaskInferenceTrackingInput = {
   surface: string;
   userId?: string | null;
@@ -19,7 +50,6 @@ export type NonTaskInferenceTrackingInput = {
 };
 
 export const NON_TASK_INFERENCE_SURFACES = {
-  backgroundAnnouncer: 'background_announcer',
   fastAgentOnboardingSuggestions: 'fast_agent_onboarding_suggestions',
   fastAgentQuestionAnswering: 'fast_agent_question_answering',
   prReviewNotificationTriage: 'pr_review_notification_triage',
@@ -34,7 +64,6 @@ export const NON_TASK_INFERENCE_SURFACES = {
   suggestionRoutingValidation: 'suggestion_routing_validation',
   taskSummaryGeneration: 'task_summary_generation',
   taskTitleGeneration: 'task_title_generation',
-  videoDescription: 'video_description',
 } as const;
 
 export interface GenerateTrackedNonTaskTextParams extends NonTaskInferenceTrackingInput {
@@ -275,10 +304,12 @@ async function runNonTaskSdkPrompt(
       baseUrl: server.url,
       fetch: openCodeSdkFetch,
     });
+    const sessionDirectory = resolveNonTaskSessionDirectory();
     const sessionResult = await client.session.create(
       {
-        directory: process.cwd(),
+        directory: sessionDirectory,
         title: `Roomote ${params.surface}`,
+        permission: NON_TASK_SESSION_PERMISSIONS,
       },
       { signal: abortController.signal },
     );
@@ -292,7 +323,7 @@ async function runNonTaskSdkPrompt(
     const promptResult = await client.session.prompt(
       {
         sessionID: sessionResult.data.id,
-        directory: process.cwd(),
+        directory: sessionDirectory,
         model: splitOpenCodeModelId(model),
         ...promptOptions,
       },

--- a/packages/cloud-agents/src/server/opencode-runtime.ts
+++ b/packages/cloud-agents/src/server/opencode-runtime.ts
@@ -91,6 +91,46 @@ function buildModelBackedOpenCodeConfigContent(
   });
 }
 
+/**
+ * Force OpenCode's blanket tool-permission denial into a config content
+ * string, preserving any other operator-supplied settings.
+ *
+ * The servers this module spawns exist only for non-task inference — task
+ * titles, routing, fast-agent answers — which is plain text or structured
+ * output and must never run tools. Without this, OpenCode's default `build`
+ * agent auto-approves edit/bash in server mode, and an instruction-shaped
+ * prompt (a task description saying "add some dinosaurs") can cause the
+ * control plane to edit its own working directory.
+ *
+ * Malformed operator config fails closed to a permission-only config: every
+ * non-task call passes its model explicitly, so dropping model-backed
+ * defaults keeps text generation working while never booting a server with
+ * tools enabled.
+ */
+function withDeniedToolPermissions(configContent: string | undefined): string {
+  const permissionOnly = JSON.stringify({ permission: 'deny' });
+
+  if (!configContent?.trim()) {
+    return permissionOnly;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(configContent);
+
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      return permissionOnly;
+    }
+
+    return JSON.stringify({ ...parsed, permission: 'deny' });
+  } catch {
+    return permissionOnly;
+  }
+}
+
 export function buildOpenCodeCliEnv(
   extraEnv?: Partial<Record<string, string>>,
 ): NodeJS.ProcessEnv {
@@ -115,6 +155,12 @@ export function buildOpenCodeCliEnv(
       env.OPENCODE_CONFIG_CONTENT = modelBackedConfigContent;
     }
   }
+
+  // Applied unconditionally, after any operator-supplied config content is
+  // selected, so custom OPENCODE_CONFIG_CONTENT cannot re-enable tools.
+  env.OPENCODE_CONFIG_CONTENT = withDeniedToolPermissions(
+    env.OPENCODE_CONFIG_CONTENT,
+  );
 
   // Do not inherit or accept disabled-provider credentials in helper model
   // processes, including callers that bypass the task dequeue path.

--- a/packages/sdk/src/server/automations/__tests__/announcer.test.ts
+++ b/packages/sdk/src/server/automations/__tests__/announcer.test.ts
@@ -12,7 +12,6 @@ const {
   mockGetCommunicationProviderAdapter,
   mockLoadAutomationThreadFeedbackContext,
   mockEnqueueTask,
-  mockGenerateTrackedNonTaskText,
   mockSlackNotifier,
   mockAdapterPostMessage,
 } = vi.hoisted(() => ({
@@ -41,7 +40,6 @@ const {
   mockGetCommunicationProviderAdapter: vi.fn(),
   mockLoadAutomationThreadFeedbackContext: vi.fn(),
   mockEnqueueTask: vi.fn(),
-  mockGenerateTrackedNonTaskText: vi.fn(),
   mockSlackNotifier: vi.fn(),
   mockAdapterPostMessage: vi.fn(),
 }));
@@ -82,11 +80,6 @@ vi.mock('@roomote/db/server', () => ({
 vi.mock('@roomote/cloud-agents/server', () => ({
   buildManagerAutomationRootSummaryPromptContract: vi.fn(() => 'contract'),
   enqueueTask: mockEnqueueTask,
-}));
-
-vi.mock('@roomote/cloud-agents/server/non-task-provider-usage', () => ({
-  generateTrackedNonTaskText: mockGenerateTrackedNonTaskText,
-  NON_TASK_INFERENCE_SURFACES: { backgroundAnnouncer: 'background_announcer' },
 }));
 
 vi.mock('@roomote/slack', () => ({


### PR DESCRIPTION
## Summary
- Non-task inference (task titles, routing, fast-agent answers, summaries) only needs plain text or structured output, but the locally managed OpenCode SDK servers ran the default `build` agent, which can act on instruction-like prompt content with its standard tools. Since these prompts include externally supplied text such as task descriptions, restrict the sessions to output-only.
- Merge a blanket tool-permission denial into `OPENCODE_CONFIG_CONTENT` for every helper server spawn, preserving operator-supplied settings and failing closed to a permission-only config when the content is malformed (calls pass their model explicitly, so text generation keeps working).
- Pass a deny-all permission ruleset on each session so externally configured servers (`OPENCODE_SDK_SERVER_URL`) get the same restriction, and run sessions in an empty scratch directory instead of the service's working directory (which also skips repository indexing these calls never needed).
- Router and fast-agent MCP lookups are unaffected: they call MCP servers directly from application code, outside the OpenCode session.
- Remove two `NON_TASK_INFERENCE_SURFACES` entries with no remaining callers (`background_announcer`, `video_description`) and the stale announcer test mock referencing one of them.

Deployments pick this up on restart; a long-lived previously spawned helper server keeps its old config until it exits, so restarting the services (or killing stray `opencode serve` processes in dev) completes the rollout.

## Test plan
- [x] `buildOpenCodeCliEnv` tests: denial merged with model-backed config, with operator-supplied content (including overriding an operator `allow`), with no config at all, and fail-closed on malformed content
- [x] `runNonTaskSdkPrompt` tests: session create/prompt carry the deny-all ruleset and a scratch directory, never the service cwd
- [x] Full `@roomote/cloud-agents` suite (575 tests) and the announcer automation tests
- [x] `pnpm lint`, `pnpm check-types`, `pnpm knip`