### PR TITLE
feat: create a new repo (or fork) plus environment from within Roomote

### DIFF
--- a/apps/api/src/handlers/github/__tests__/handleInstallationRepositoriesChange.test.ts
+++ b/apps/api/src/handlers/github/__tests__/handleInstallationRepositoriesChange.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const { mockFindFirst, mockSyncGitHubInstallation } = vi.hoisted(() => ({
+  mockFindFirst: vi.fn(),
+  mockSyncGitHubInstallation: vi.fn(),
+}));
+
+vi.mock('@roomote/db/server', () => ({
+  db: {
+    query: {
+      githubInstallations: {
+        findFirst: mockFindFirst,
+      },
+    },
+  },
+  githubInstallations: {
+    installationId: 'installation_id',
+  },
+  eq: (column: unknown, value: unknown) => ({ eq: [column, value] }),
+}));
+
+vi.mock('@roomote/github', () => ({
+  syncGitHubInstallation: mockSyncGitHubInstallation,
+}));
+
+import { handleInstallationRepositoriesChange } from '../handleInstallationRepositoriesChange';
+
+describe('handleInstallationRepositoriesChange', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindFirst.mockResolvedValue({ installedByUserId: 'user-1' });
+    mockSyncGitHubInstallation.mockResolvedValue({
+      success: true,
+      githubInstallation: {},
+      repositories: [{ id: 'repo-1' }, { id: 'repo-2' }],
+    });
+  });
+
+  it('resyncs the installation attributed to the installing user', async () => {
+    const response = await handleInstallationRepositoriesChange({
+      installation: { id: 42 },
+    });
+
+    expect(mockSyncGitHubInstallation).toHaveBeenCalledWith({
+      userId: 'user-1',
+      installationId: 42,
+    });
+    expect(response.status).toBe('ok');
+    expect(response.metadata).toEqual({ repositoryCount: 2 });
+  });
+
+  it('short-circuits when the payload has no installation id', async () => {
+    const response = await handleInstallationRepositoriesChange({});
+
+    expect(response).toEqual({ status: 'ok', message: 'missing_installation' });
+    expect(mockFindFirst).not.toHaveBeenCalled();
+    expect(mockSyncGitHubInstallation).not.toHaveBeenCalled();
+  });
+
+  it('short-circuits for installations this deployment has not synced', async () => {
+    mockFindFirst.mockResolvedValue(undefined);
+
+    const response = await handleInstallationRepositoriesChange({
+      installation: { id: 42 },
+    });
+
+    expect(response).toEqual({ status: 'ok', message: 'unknown_installation' });
+    expect(mockSyncGitHubInstallation).not.toHaveBeenCalled();
+  });
+
+  it('reports an error when the resync fails', async () => {
+    mockSyncGitHubInstallation.mockResolvedValue({
+      success: false,
+      error: 'boom',
+    });
+
+    const response = await handleInstallationRepositoriesChange({
+      installation: { id: 42 },
+    });
+
+    expect(response.status).toBe('error');
+    expect(response.message).toContain('boom');
+  });
+});

--- a/apps/api/src/handlers/github/__tests__/isFromKnownInstallation.test.ts
+++ b/apps/api/src/handlers/github/__tests__/isFromKnownInstallation.test.ts
@@ -97,6 +97,34 @@ describe('isFromKnownInstallation', () => {
     ).resolves.toBe(false);
   });
 
+  it('allows installation_repositories events from a known installation', async () => {
+    mockFindFirst.mockResolvedValue({ id: 'installation-row' });
+
+    const payload = JSON.stringify({
+      action: 'added',
+      installation: { id: 456 },
+      repositories_added: [{ id: 1, full_name: 'acme/new-repo' }],
+    });
+
+    await expect(
+      isFromKnownInstallation('installation_repositories', payload),
+    ).resolves.toBe(true);
+  });
+
+  it('rejects repository.created events from an unknown installation', async () => {
+    mockFindFirst.mockResolvedValue(undefined);
+
+    const payload = JSON.stringify({
+      action: 'created',
+      installation: { id: 789 },
+      repository: { id: 1, full_name: 'acme/new-repo' },
+    });
+
+    await expect(isFromKnownInstallation('repository', payload)).resolves.toBe(
+      false,
+    );
+  });
+
   it('rejects non-created installation events from an unknown installation', async () => {
     mockFindFirst.mockResolvedValue(undefined);
 

--- a/apps/api/src/handlers/github/handleInstallationRepositoriesChange.ts
+++ b/apps/api/src/handlers/github/handleInstallationRepositoriesChange.ts
@@ -1,0 +1,53 @@
+import { db, eq, githubInstallations } from '@roomote/db/server';
+import * as GitHub from '@roomote/github';
+
+import type { WebhookResponse } from '../../types';
+
+interface InstallationRepositoriesChangePayload {
+  installation?: { id?: number } | null;
+}
+
+/**
+ * Resync an installation's repository list when its accessible repositories
+ * change on GitHub: `installation_repositories.added/removed` (selected-repos
+ * installs) and `repository.created/deleted/renamed` (all-repos installs emit
+ * these instead). A full resync is used rather than a narrow upsert because
+ * these payloads omit fields the `repositories` row needs (default branch,
+ * clone URL), and `syncRepositories` already handles upsert + deactivation.
+ */
+export async function handleInstallationRepositoriesChange(
+  payload: InstallationRepositoriesChangePayload,
+): Promise<WebhookResponse> {
+  const installationId = payload.installation?.id;
+
+  if (typeof installationId !== 'number') {
+    return { status: 'ok', message: 'missing_installation' };
+  }
+
+  const installation = await db.query.githubInstallations.findFirst({
+    where: eq(githubInstallations.installationId, installationId),
+    columns: { installedByUserId: true },
+  });
+
+  if (!installation) {
+    return { status: 'ok', message: 'unknown_installation' };
+  }
+
+  const result = await GitHub.syncGitHubInstallation({
+    userId: installation.installedByUserId,
+    installationId,
+  });
+
+  if (!result.success) {
+    return {
+      status: 'error',
+      message: `Failed to resync installation ${installationId}: ${result.error}`,
+    };
+  }
+
+  return {
+    status: 'ok',
+    message: `Resynced installation ${installationId}`,
+    metadata: { repositoryCount: result.repositories.length },
+  };
+}

--- a/apps/api/src/handlers/github/index.ts
+++ b/apps/api/src/handlers/github/index.ts
@@ -38,6 +38,7 @@ import { handleWorkflowRunCompleted } from './handleWorkflowRunCompleted';
 
 // Repository metadata sync:
 import { handleRepositoryEdited } from './handleRepositoryEdited';
+import { handleInstallationRepositoriesChange } from './handleInstallationRepositoriesChange';
 
 // Utilities:
 import { isFromKnownInstallation } from './isFromKnownInstallation';
@@ -460,6 +461,26 @@ github.post('/', async (c) => {
       recordWebhook(id, `${name}.${payload.action}`, payload, () =>
         handleRepositoryEdited(payload),
       ),
+    );
+
+    // Keep the stored repository list in sync as repos appear, disappear, or
+    // change access. Selected-repos installs emit `installation_repositories`;
+    // all-repos installs emit `repository.created/deleted` instead. Not gated
+    // on isRepoSkipped: the row must exist even for skipped repos.
+    webhooks.on(
+      ['installation_repositories.added', 'installation_repositories.removed'],
+      ({ id, name, payload }) =>
+        recordWebhook(id, `${name}.${payload.action}`, payload, () =>
+          handleInstallationRepositoriesChange(payload),
+        ),
+    );
+
+    webhooks.on(
+      ['repository.created', 'repository.deleted', 'repository.renamed'],
+      ({ id, name, payload }) =>
+        recordWebhook(id, `${name}.${payload.action}`, payload, () =>
+          handleInstallationRepositoriesChange(payload),
+        ),
     );
 
     webhooks.on('workflow_run.completed', ({ id, name, payload }) =>

--- a/apps/docs/environments.mdx
+++ b/apps/docs/environments.mdx
@@ -41,6 +41,21 @@ The setup task is meant to produce a working environment Roomote can reuse. If
 it cannot finish, adjust the input and try again from
 **Settings > Environments**.
 
+## Start from a brand-new repository
+
+You do not need an existing codebase to set up an environment. From
+**Settings > Environments > New** (or the onboarding repo-selection step),
+choose **Create a new repository** to open github.com with the right owner
+pre-filled — either a brand-new repository or a fork of an existing one by
+URL. Once you create it on GitHub, it appears in the repository list
+automatically; if the GitHub App only has access to selected repositories,
+grant it access to the new repository first.
+
+An empty repository is fine. When you start setup against a repository with
+no commits, Roomote pushes a minimal initial commit (a README and a
+.gitignore) to the default branch and creates a basic environment. Building
+the actual project is then just your first task in that environment.
+
 ## What to include
 
 Add enough context for Roomote to start productively:

--- a/apps/docs/providers/source-control/github.mdx
+++ b/apps/docs/providers/source-control/github.mdx
@@ -127,6 +127,12 @@ Subscribe to these events:
 GitHub Apps also receive `installation` and `installation_repositories`
 events automatically; you do not need to subscribe to them in the app form.
 
+Roomote uses the **Repository** and `installation_repositories` events to
+pick up newly created or newly granted repositories without a manual refresh.
+If your app was created before the **Repository** event was part of the
+manifest, confirm it is enabled under the app's **Permissions & events** page
+— GitHub has no API to update an app's event subscriptions.
+
 ## Save credentials
 
 Copy these values into the `/setup` manual form, deployment env vars, or your

--- a/apps/web/src/app/(onboarding)/setup/StepRepoSelection.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepRepoSelection.client.test.tsx
@@ -113,28 +113,31 @@ vi.mock('@/hooks/source-control', () => ({
 }));
 
 vi.mock('@/components/github/CreateGitHubRepoDialog', () => ({
-  CreateGitHubRepoButton: ({
+  CreateGitHubRepoDialog: ({
+    open,
     onRepositoryDetected,
   }: {
+    open: boolean;
     onRepositoryDetected?: (repository: {
       id: string;
       fullName: string;
       isEmpty?: boolean;
     }) => void;
-  }) => (
-    <button
-      type="button"
-      onClick={() =>
-        onRepositoryDetected?.({
-          id: 'repo-created',
-          fullName: 'acme/created',
-          isEmpty: true,
-        })
-      }
-    >
-      Create a new repository
-    </button>
-  ),
+  }) =>
+    open ? (
+      <button
+        type="button"
+        onClick={() =>
+          onRepositoryDetected?.({
+            id: 'repo-created',
+            fullName: 'acme/created',
+            isEmpty: true,
+          })
+        }
+      >
+        Detect created repository
+      </button>
+    ) : null,
 }));
 
 vi.mock('@/hooks/task-models/useLaunchTaskModels', () => ({
@@ -243,6 +246,7 @@ vi.mock('@/components/system', () => ({
   Input: (props: InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
   ArrowRight: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
   Loader2: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
+  Plus: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
   RefreshCcw: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
   RotateCw: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
   Search: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
@@ -740,8 +744,35 @@ describe('StepRepoSelection', () => {
     fireEvent.click(
       screen.getByRole('button', { name: 'Create a new repository' }),
     );
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Detect created repository' }),
+    );
 
     expect(screen.getByLabelText('acme/created')).toBeChecked();
+  });
+
+  it('keeps the create-repository item visible when the list is filtered to no matches', async () => {
+    mockRepositories.push(
+      ...Array.from({ length: 4 }, (_, index) => ({
+        id: `repo-extra-${index}`,
+        fullName: `acme/extra-${index}`,
+        private: true,
+        defaultBranch: 'main',
+      })),
+    );
+
+    await renderStepRepoSelection();
+
+    fireEvent.change(screen.getByLabelText('Filter repositories'), {
+      target: { value: 'does-not-exist' },
+    });
+
+    expect(
+      screen.getByRole('button', { name: 'Create a new repository' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('No repositories match that filter.'),
+    ).toBeInTheDocument();
   });
 
   it('renders the empty-repository warning below the repository list', async () => {

--- a/apps/web/src/app/(onboarding)/setup/StepRepoSelection.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepRepoSelection.client.test.tsx
@@ -112,6 +112,31 @@ vi.mock('@/hooks/source-control', () => ({
   useRepositories: mockUseRepositories,
 }));
 
+vi.mock('@/components/github/CreateGitHubRepoDialog', () => ({
+  CreateGitHubRepoButton: ({
+    onRepositoryDetected,
+  }: {
+    onRepositoryDetected?: (repository: {
+      id: string;
+      fullName: string;
+      isEmpty?: boolean;
+    }) => void;
+  }) => (
+    <button
+      type="button"
+      onClick={() =>
+        onRepositoryDetected?.({
+          id: 'repo-created',
+          fullName: 'acme/created',
+          isEmpty: true,
+        })
+      }
+    >
+      Create a new repository
+    </button>
+  ),
+}));
+
 vi.mock('@/hooks/task-models/useLaunchTaskModels', () => ({
   useLaunchTaskModels: () => ({
     data: {
@@ -633,7 +658,7 @@ describe('StepRepoSelection', () => {
     expect(onReviewComputeProvider).toHaveBeenCalled();
   });
 
-  it('shows a warning and disables Continue only when all selected repositories are empty', async () => {
+  it('explains the bootstrap and keeps Continue enabled when all selected repositories are empty', async () => {
     mockRepositories.splice(
       0,
       mockRepositories.length,
@@ -661,9 +686,11 @@ describe('StepRepoSelection', () => {
       screen.getByText(/all selected repositories have no commits yet/i),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/push an initial commit before continuing/i),
+      screen.getByText(
+        /will push an initial commit and set up a basic environment/i,
+      ),
     ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled();
   });
 
   it('keeps Continue enabled and hides the warning for mixed empty and non-empty selections', async () => {
@@ -692,9 +719,29 @@ describe('StepRepoSelection', () => {
     fireEvent.click(screen.getByLabelText(/acme\/empty/i));
 
     expect(
-      screen.queryByText(/push an initial commit before continuing/i),
+      screen.queryByText(
+        /will push an initial commit and set up a basic environment/i,
+      ),
     ).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled();
+  });
+
+  it('offers the create-repo affordance and selects the repository it detects', async () => {
+    mockRepositories.splice(0, mockRepositories.length, {
+      id: 'repo-created',
+      fullName: 'acme/created',
+      private: true,
+      defaultBranch: 'main',
+      isEmpty: true,
+    });
+
+    await renderStepRepoSelection();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Create a new repository' }),
+    );
+
+    expect(screen.getByLabelText('acme/created')).toBeChecked();
   });
 
   it('renders the empty-repository warning below the repository list', async () => {

--- a/apps/web/src/app/(onboarding)/setup/StepRepoSelection.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepRepoSelection.tsx
@@ -39,6 +39,10 @@ import {
   Info,
   X,
 } from '@/components/system';
+import {
+  CreateGitHubRepoButton,
+  type DetectedRepository,
+} from '@/components/github/CreateGitHubRepoDialog';
 import { EnvironmentRepositorySelector } from '@/components/settings/environments/EnvironmentRepositorySelector';
 import { ModelSelect } from '@/components/tasks';
 import { SetupFooter } from './SetupFooter';
@@ -205,6 +209,17 @@ export function StepRepoSelection({
     );
   }, []);
 
+  const selectDetectedRepository = useCallback(
+    (repository: DetectedRepository) => {
+      setSelectedRepositoryIds((currentSelection) =>
+        currentSelection.includes(repository.id)
+          ? currentSelection
+          : [...currentSelection, repository.id],
+      );
+    },
+    [],
+  );
+
   const handleManageGitHubAccess = useCallback(() => {
     connectGitHub.mutate(`${pathname}?step=repo-selection`);
   }, [connectGitHub, pathname]);
@@ -321,6 +336,11 @@ export function StepRepoSelection({
               )}
               Edit GitHub Access
             </Button>
+            <CreateGitHubRepoButton
+              size="default"
+              className="w-full md:w-auto"
+              onRepositoryDetected={selectDetectedRepository}
+            />
             <Button
               type="button"
               variant="outline"
@@ -465,12 +485,13 @@ export function StepRepoSelection({
             )}
           </div>
           {allSelectedRepositoriesAreEmpty ? (
-            <Alert variant="warning">
-              <AlertTriangle className="size-4" />
+            <Alert>
+              <Info className="size-4" />
               <AlertDescription className="flex-col items-start gap-1">
                 <p>
-                  {emptyRepositoryWarningCopy} Push an initial commit before
-                  continuing, or choose different repositories.
+                  {emptyRepositoryWarningCopy} {PRODUCT_NAME} will push an
+                  initial commit and set up a basic environment — then you can
+                  start building with your first task.
                 </p>
                 <p className="font-medium text-foreground">
                   {selectedEmptyRepositoryNames}
@@ -527,7 +548,7 @@ export function StepRepoSelection({
                   type="button"
                   size="sm"
                   onClick={() => void handleContinue()}
-                  disabled={isBusy || allSelectedRepositoriesAreEmpty}
+                  disabled={isBusy}
                 >
                   {isBusy && <Loader2 className="animate-spin" />}
                   Continue
@@ -580,6 +601,10 @@ export function StepRepoSelection({
             )}
             Edit GitHub Access
           </Button>
+          <CreateGitHubRepoButton
+            size="sm"
+            onRepositoryDetected={selectDetectedRepository}
+          />
           <Button type="button" variant="outline" size="sm" onClick={onSkip}>
             Skip
           </Button>

--- a/apps/web/src/app/(onboarding)/setup/StepRepoSelection.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepRepoSelection.tsx
@@ -40,7 +40,7 @@ import {
   X,
 } from '@/components/system';
 import {
-  CreateGitHubRepoButton,
+  CreateGitHubRepoDialog,
   type DetectedRepository,
 } from '@/components/github/CreateGitHubRepoDialog';
 import { EnvironmentRepositorySelector } from '@/components/settings/environments/EnvironmentRepositorySelector';
@@ -110,6 +110,7 @@ export function StepRepoSelection({
     initialSelectedModelId ?? undefined,
   );
   const [repositoryFilter, setRepositoryFilter] = useState('');
+  const [createRepoDialogOpen, setCreateRepoDialogOpen] = useState(false);
   const [setupGuidance, setSetupGuidance] = useState(initialSetupGuidance);
   const [isRefreshPending, setIsRefreshPending] = useState(false);
   const refreshPromiseRef = useRef<Promise<unknown> | null>(null);
@@ -297,62 +298,72 @@ export function StepRepoSelection({
 
   if (sortedRepositories.length === 0) {
     return (
-      <div className="relative w-full max-w-3xl space-y-6 py-2 md:py-4">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <StepTitle text={REPO_SELECTION_STEP.title} />
-        </div>
-        <div className="space-y-2">
-          <p className="font-semibold">No repositories available yet.</p>
-          <p>
-            {PRODUCT_NAME} is connected to GitHub, but this deployment does not
-            currently have any accessible repositories to use for setup.
-          </p>
-          <div className="flex flex-col md:flex-row gap-2 items-center mt-6">
-            <Button
-              type="button"
-              variant="default"
-              className="w-full md:w-auto"
-              onClick={() => void refreshRepositories()}
-              disabled={isRefreshingRepositories}
-            >
-              {isRefreshingRepositories ? (
-                <Loader2 className="animate-spin" />
-              ) : (
-                <RefreshCcw />
-              )}
-              Refresh
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              className="w-full md:w-auto"
-              onClick={handleManageGitHubAccess}
-              disabled={connectGitHub.isPending}
-            >
-              {connectGitHub.isPending ? (
-                <Loader2 className="animate-spin" />
-              ) : (
-                <Github />
-              )}
-              Edit GitHub Access
-            </Button>
-            <CreateGitHubRepoButton
-              size="default"
-              className="w-full md:w-auto"
-              onRepositoryDetected={selectDetectedRepository}
-            />
-            <Button
-              type="button"
-              variant="outline"
-              className="w-full md:w-auto"
-              onClick={onSkip}
-            >
-              Skip
-            </Button>
+      <>
+        <div className="relative w-full max-w-3xl space-y-6 py-2 md:py-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <StepTitle text={REPO_SELECTION_STEP.title} />
           </div>
-          <p className="text-sm text-muted-foreground">Not recommended</p>
+          <div className="space-y-2">
+            <p className="font-semibold">No repositories available yet.</p>
+            <p>
+              {PRODUCT_NAME} is connected to GitHub, but this deployment does
+              not currently have any accessible repositories to use for setup.
+            </p>
+            <EnvironmentRepositorySelector
+              repositories={[]}
+              selectedRepositoryIds={selectedRepositoryIds}
+              onToggleRepository={toggleRepository}
+              onCreateRepository={() => setCreateRepoDialogOpen(true)}
+              inputPrefix="setup-repository"
+              heightClassName="h-auto"
+            />
+            <div className="flex flex-col md:flex-row gap-2 items-center mt-6">
+              <Button
+                type="button"
+                variant="default"
+                className="w-full md:w-auto"
+                onClick={() => void refreshRepositories()}
+                disabled={isRefreshingRepositories}
+              >
+                {isRefreshingRepositories ? (
+                  <Loader2 className="animate-spin" />
+                ) : (
+                  <RefreshCcw />
+                )}
+                Refresh
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full md:w-auto"
+                onClick={handleManageGitHubAccess}
+                disabled={connectGitHub.isPending}
+              >
+                {connectGitHub.isPending ? (
+                  <Loader2 className="animate-spin" />
+                ) : (
+                  <Github />
+                )}
+                Edit GitHub Access
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full md:w-auto"
+                onClick={onSkip}
+              >
+                Skip
+              </Button>
+            </div>
+            <p className="text-sm text-muted-foreground">Not recommended</p>
+          </div>
         </div>
-      </div>
+        <CreateGitHubRepoDialog
+          open={createRepoDialogOpen}
+          onOpenChange={setCreateRepoDialogOpen}
+          onRepositoryDetected={selectDetectedRepository}
+        />
+      </>
     );
   }
 
@@ -369,250 +380,257 @@ export function StepRepoSelection({
     .join(', ');
 
   return (
-    <div className="relative w-full max-w-4xl space-y-6 py-2 md:py-4">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <StepTitle text={REPO_SELECTION_STEP.title} />
-      </div>
-      <div className="space-y-3 text-foreground">
-        {!showForm && (
-          <div className="space-y-2 flex gap-2 items-start">
-            <Info className="size-4 shrink-0 mt-1" />
-            <p>
-              <span className="font-semibold">
-                {PRODUCT_NAME} needs environments to verify its work.
-              </span>
-              <br />
-              That lets it run your app locally, click around, make API calls,
-              take screenshots.
-            </p>
-          </div>
-        )}
-        <p className={`text-foreground ${!showForm && 'ml-6'}`}>
-          Pick the repo(s) needed for the first env to set up.
-          <br />
-          Roomote will install dependencies and figure it all out on its own.
-        </p>
-      </div>
+    <>
+      <div className="relative w-full max-w-4xl space-y-6 py-2 md:py-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <StepTitle text={REPO_SELECTION_STEP.title} />
+        </div>
+        <div className="space-y-3 text-foreground">
+          {!showForm && (
+            <div className="space-y-2 flex gap-2 items-start">
+              <Info className="size-4 shrink-0 mt-1" />
+              <p>
+                <span className="font-semibold">
+                  {PRODUCT_NAME} needs environments to verify its work.
+                </span>
+                <br />
+                That lets it run your app locally, click around, make API calls,
+                take screenshots.
+              </p>
+            </div>
+          )}
+          <p className={`text-foreground ${!showForm && 'ml-6'}`}>
+            Pick the repo(s) needed for the first env to set up.
+            <br />
+            Roomote will install dependencies and figure it all out on its own.
+          </p>
+        </div>
 
-      {retryCopy ? (
-        <Alert variant="warning">
-          <AlertTriangle className="size-4" />
-          <AlertDescription>
-            {/* Single child: AlertDescription lays out its children with
+        {retryCopy ? (
+          <Alert variant="warning">
+            <AlertTriangle className="size-4" />
+            <AlertDescription>
+              {/* Single child: AlertDescription lays out its children with
                 flex, which would split loose text and the button apart. */}
-            <p>
-              {retryCopy}
-              {retryReason === 'task-failed' && onReviewComputeProvider ? (
-                <>
-                  {' '}
-                  If the run failed before doing any work, you can also{' '}
+              <p>
+                {retryCopy}
+                {retryReason === 'task-failed' && onReviewComputeProvider ? (
+                  <>
+                    {' '}
+                    If the run failed before doing any work, you can also{' '}
+                    <button
+                      type="button"
+                      className="underline underline-offset-4"
+                      onClick={onReviewComputeProvider}
+                    >
+                      review your sandbox provider
+                    </button>
+                    .
+                  </>
+                ) : null}
+              </p>
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        {computeProvisioningError ? (
+          <Alert variant="destructive">
+            <AlertTriangle className="size-4" />
+            <AlertDescription>
+              <p>
+                Sandbox provider provisioning failed: {computeProvisioningError}{' '}
+                {onRetryComputeProvisioning ? (
                   <button
                     type="button"
-                    className="underline underline-offset-4"
-                    onClick={onReviewComputeProvider}
+                    className="font-medium underline underline-offset-4"
+                    onClick={onRetryComputeProvisioning}
                   >
-                    review your sandbox provider
-                  </button>
-                  .
-                </>
-              ) : null}
-            </p>
-          </AlertDescription>
-        </Alert>
-      ) : null}
-
-      {computeProvisioningError ? (
-        <Alert variant="destructive">
-          <AlertTriangle className="size-4" />
-          <AlertDescription>
-            <p>
-              Sandbox provider provisioning failed: {computeProvisioningError}{' '}
-              {onRetryComputeProvisioning ? (
-                <button
-                  type="button"
-                  className="font-medium underline underline-offset-4"
-                  onClick={onRetryComputeProvisioning}
-                >
-                  Retry provisioning
-                </button>
-              ) : null}
-            </p>
-          </AlertDescription>
-        </Alert>
-      ) : null}
-
-      <Card className="p-3">
-        <CardContent>
-          <div className="space-y-3">
-            {showRepositoryFilter ? (
-              <div className="relative">
-                <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  type="text"
-                  value={repositoryFilter}
-                  onChange={(event) =>
-                    setRepositoryFilter(event.currentTarget.value)
-                  }
-                  placeholder="Filter repositories"
-                  aria-label="Filter repositories"
-                  className="pr-9 pl-9"
-                />
-                {repositoryFilter ? (
-                  <button
-                    type="button"
-                    onClick={() => setRepositoryFilter('')}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 cursor-pointer text-muted-foreground hover:text-foreground"
-                    aria-label="Clear repository filter"
-                  >
-                    <X className="size-4" />
+                    Retry provisioning
                   </button>
                 ) : null}
-              </div>
-            ) : null}
+              </p>
+            </AlertDescription>
+          </Alert>
+        ) : null}
 
-            {filteredRepositories.length > 0 ? (
+        <Card className="p-3">
+          <CardContent>
+            <div className="space-y-3">
+              {showRepositoryFilter ? (
+                <div className="relative">
+                  <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    type="text"
+                    value={repositoryFilter}
+                    onChange={(event) =>
+                      setRepositoryFilter(event.currentTarget.value)
+                    }
+                    placeholder="Filter repositories"
+                    aria-label="Filter repositories"
+                    className="pr-9 pl-9"
+                  />
+                  {repositoryFilter ? (
+                    <button
+                      type="button"
+                      onClick={() => setRepositoryFilter('')}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 cursor-pointer text-muted-foreground hover:text-foreground"
+                      aria-label="Clear repository filter"
+                    >
+                      <X className="size-4" />
+                    </button>
+                  ) : null}
+                </div>
+              ) : null}
+
               <EnvironmentRepositorySelector
                 repositories={filteredRepositories}
                 selectedRepositoryIds={selectedRepositoryIds}
                 onToggleRepository={toggleRepository}
+                onCreateRepository={() => setCreateRepoDialogOpen(true)}
                 inputPrefix="setup-repository"
                 heightClassName="max-h-[calc(var(--effective-viewport-height)-40rem)] md:h-[18.75rem]"
               />
-            ) : (
-              <div className="rounded-md border border-dashed px-4 py-6 text-sm text-muted-foreground">
-                No repositories match that filter.
-              </div>
-            )}
-          </div>
-          {allSelectedRepositoriesAreEmpty ? (
-            <Alert>
-              <Info className="size-4" />
-              <AlertDescription className="flex-col items-start gap-1">
-                <p>
-                  {emptyRepositoryWarningCopy} {PRODUCT_NAME} will push an
-                  initial commit and set up a basic environment — then you can
-                  start building with your first task.
-                </p>
-                <p className="font-medium text-foreground">
-                  {selectedEmptyRepositoryNames}
-                </p>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  onClick={() => void refreshRepositories()}
-                  disabled={connectGitHub.isPending || isRefreshingRepositories}
-                >
-                  {isRefreshingRepositories ? (
-                    <Loader2 className="animate-spin" />
-                  ) : (
-                    <RotateCw />
-                  )}
-                  Refresh list
-                </Button>
-              </AlertDescription>
-            </Alert>
-          ) : null}
-          {showForm ? (
-            <div className="space-y-2 flex flex-col items-start">
-              <Textarea
-                value={setupGuidance}
-                onChange={(event) => setSetupGuidance(event.target.value)}
-                placeholder={ENVIRONMENT_DEFINITION_SETUP_GUIDANCE_PLACEHOLDER}
-                maxLength={ENVIRONMENT_DEFINITION_SETUP_GUIDANCE_MAX_LENGTH}
-                disabled={isBusy}
-                className="h-20 min-h-20 resize-none"
-              />
-              <p
-                className={cn(
-                  'text-muted-foreground self-stretch text-right text-xs',
-                  setupGuidanceLength > SETUP_GUIDANCE_WARNING_THRESHOLD &&
-                    'text-warning-foreground',
-                )}
-              >
-                {setupGuidanceLength >
-                  ENVIRONMENT_DEFINITION_SETUP_GUIDANCE_MAX_LENGTH * 0.8 &&
-                  charCounter}
-              </p>
-              <SetupFooter
-                onBack={onBack}
-                backDisabled={isBusy}
-                className="w-full flex-wrap"
-              >
-                <ModelSelect
-                  value={effectiveSelectedModelId}
-                  onValueChange={setSelectedModelId}
-                  disabled={isBusy}
-                />
-                <Button
-                  type="button"
-                  size="sm"
-                  onClick={() => void handleContinue()}
-                  disabled={isBusy}
-                >
-                  {isBusy && <Loader2 className="animate-spin" />}
-                  Continue
-                  <ArrowRight />
-                </Button>
-                <p className="text-sm text-muted-foreground ml-auto">
-                  Or, if you must,
-                </p>
-                <Button
-                  type="button"
-                  variant="link"
-                  size="sm"
-                  className="p-0! -ml-1"
-                  onClick={onSkip}
-                >
-                  do this later
-                </Button>
-              </SetupFooter>
+              {filteredRepositories.length === 0 ? (
+                <div className="rounded-md border border-dashed px-4 py-6 text-sm text-muted-foreground">
+                  No repositories match that filter.
+                </div>
+              ) : null}
             </div>
-          ) : null}
-        </CardContent>
-      </Card>
-      {!showForm ? (
-        <SetupFooter onBack={onBack} className="flex-wrap">
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            onClick={() => void refreshRepositories()}
-            disabled={connectGitHub.isPending || isRefreshingRepositories}
-          >
-            {isRefreshingRepositories ? (
-              <Loader2 className="animate-spin" />
-            ) : (
-              <RotateCw />
-            )}
-            Refresh list
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={handleManageGitHubAccess}
-            disabled={connectGitHub.isPending}
-          >
-            {connectGitHub.isPending ? (
-              <Loader2 className="animate-spin" />
-            ) : (
-              <Github />
-            )}
-            Edit GitHub Access
-          </Button>
-          <CreateGitHubRepoButton
-            size="sm"
-            onRepositoryDetected={selectDetectedRepository}
-          />
-          <Button type="button" variant="outline" size="sm" onClick={onSkip}>
-            Skip
-          </Button>
-          <p className="self-center text-sm text-muted-foreground">
-            Not recommended
-          </p>
-        </SetupFooter>
-      ) : null}
-    </div>
+            {allSelectedRepositoriesAreEmpty ? (
+              <Alert>
+                <Info className="size-4" />
+                <AlertDescription className="flex-col items-start gap-1">
+                  <p>
+                    {emptyRepositoryWarningCopy} {PRODUCT_NAME} will push an
+                    initial commit and set up a basic environment — then you can
+                    start building with your first task.
+                  </p>
+                  <p className="font-medium text-foreground">
+                    {selectedEmptyRepositoryNames}
+                  </p>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => void refreshRepositories()}
+                    disabled={
+                      connectGitHub.isPending || isRefreshingRepositories
+                    }
+                  >
+                    {isRefreshingRepositories ? (
+                      <Loader2 className="animate-spin" />
+                    ) : (
+                      <RotateCw />
+                    )}
+                    Refresh list
+                  </Button>
+                </AlertDescription>
+              </Alert>
+            ) : null}
+            {showForm ? (
+              <div className="space-y-2 flex flex-col items-start">
+                <Textarea
+                  value={setupGuidance}
+                  onChange={(event) => setSetupGuidance(event.target.value)}
+                  placeholder={
+                    ENVIRONMENT_DEFINITION_SETUP_GUIDANCE_PLACEHOLDER
+                  }
+                  maxLength={ENVIRONMENT_DEFINITION_SETUP_GUIDANCE_MAX_LENGTH}
+                  disabled={isBusy}
+                  className="h-20 min-h-20 resize-none"
+                />
+                <p
+                  className={cn(
+                    'text-muted-foreground self-stretch text-right text-xs',
+                    setupGuidanceLength > SETUP_GUIDANCE_WARNING_THRESHOLD &&
+                      'text-warning-foreground',
+                  )}
+                >
+                  {setupGuidanceLength >
+                    ENVIRONMENT_DEFINITION_SETUP_GUIDANCE_MAX_LENGTH * 0.8 &&
+                    charCounter}
+                </p>
+                <SetupFooter
+                  onBack={onBack}
+                  backDisabled={isBusy}
+                  className="w-full flex-wrap"
+                >
+                  <ModelSelect
+                    value={effectiveSelectedModelId}
+                    onValueChange={setSelectedModelId}
+                    disabled={isBusy}
+                  />
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={() => void handleContinue()}
+                    disabled={isBusy}
+                  >
+                    {isBusy && <Loader2 className="animate-spin" />}
+                    Continue
+                    <ArrowRight />
+                  </Button>
+                  <p className="text-sm text-muted-foreground ml-auto">
+                    Or, if you must,
+                  </p>
+                  <Button
+                    type="button"
+                    variant="link"
+                    size="sm"
+                    className="p-0! -ml-1"
+                    onClick={onSkip}
+                  >
+                    do this later
+                  </Button>
+                </SetupFooter>
+              </div>
+            ) : null}
+          </CardContent>
+        </Card>
+        {!showForm ? (
+          <SetupFooter onBack={onBack} className="flex-wrap">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => void refreshRepositories()}
+              disabled={connectGitHub.isPending || isRefreshingRepositories}
+            >
+              {isRefreshingRepositories ? (
+                <Loader2 className="animate-spin" />
+              ) : (
+                <RotateCw />
+              )}
+              Refresh list
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleManageGitHubAccess}
+              disabled={connectGitHub.isPending}
+            >
+              {connectGitHub.isPending ? (
+                <Loader2 className="animate-spin" />
+              ) : (
+                <Github />
+              )}
+              Edit GitHub Access
+            </Button>
+            <Button type="button" variant="outline" size="sm" onClick={onSkip}>
+              Skip
+            </Button>
+            <p className="self-center text-sm text-muted-foreground">
+              Not recommended
+            </p>
+          </SetupFooter>
+        ) : null}
+      </div>
+      <CreateGitHubRepoDialog
+        open={createRepoDialogOpen}
+        onOpenChange={setCreateRepoDialogOpen}
+        onRepositoryDetected={selectDetectedRepository}
+      />
+    </>
   );
 }

--- a/apps/web/src/components/github/CreateGitHubRepoDialog.client.test.tsx
+++ b/apps/web/src/components/github/CreateGitHubRepoDialog.client.test.tsx
@@ -1,0 +1,297 @@
+import type {
+  ButtonHTMLAttributes,
+  InputHTMLAttributes,
+  ReactNode,
+  SVGProps,
+} from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+type RepositoryRow = {
+  id: string;
+  fullName: string;
+  sourceControlProvider: string;
+  isEmpty?: boolean;
+};
+
+const {
+  mockEnableGitHubApp,
+  mockSyncGitHubInstallations,
+  mockUserState,
+  mockInstallationsState,
+  mockRepositoriesState,
+  mockToast,
+} = vi.hoisted(() => ({
+  mockEnableGitHubApp: vi.fn(),
+  mockSyncGitHubInstallations: vi.fn(),
+  mockUserState: { isAdmin: true as boolean },
+  mockInstallationsState: {
+    data: [] as Array<{
+      id: string;
+      accountLogin: string;
+      accountType: string;
+      suspendedAt: string | null;
+    }>,
+  },
+  mockRepositoriesState: { data: [] as RepositoryRow[] },
+  mockToast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/settings/environments/new',
+  useSearchParams: () => new URLSearchParams(''),
+}));
+
+vi.mock('sonner', () => ({ toast: mockToast }));
+
+vi.mock('@/hooks/github', () => ({
+  useEnableGitHubApp: () => ({
+    mutate: mockEnableGitHubApp,
+    isPending: false,
+  }),
+  useGitHubInstallations: () => ({ data: mockInstallationsState.data }),
+  useSyncGitHubInstallations: () => ({
+    mutate: mockSyncGitHubInstallations,
+    isPending: false,
+  }),
+}));
+
+vi.mock('@/hooks/source-control', () => ({
+  useRepositories: () => ({ data: mockRepositoriesState.data }),
+}));
+
+vi.mock('@/hooks/useRealtimePolling', () => ({
+  useRealtimePolling: () => ({
+    refetchInterval: false,
+    refetchIntervalInBackground: false,
+    retry: 3,
+    isVisible: true,
+  }),
+}));
+
+vi.mock('@/hooks/useUser', () => ({
+  useAuthorizedUser: () => ({ isAdmin: mockUserState.isAdmin }),
+}));
+
+vi.mock('@/components/system', () => {
+  const passthrough = (Tag: 'div' | 'p' | 'span' = 'div') => {
+    const Passthrough = ({ children, ...props }: { children?: ReactNode }) => (
+      <Tag {...props}>{children}</Tag>
+    );
+    Passthrough.displayName = `Passthrough(${Tag})`;
+    return Passthrough;
+  };
+
+  return {
+    Alert: passthrough(),
+    AlertDescription: passthrough(),
+    AlertTitle: passthrough(),
+    Button: ({
+      children,
+      asChild: _asChild,
+      ...props
+    }: {
+      children: ReactNode;
+      asChild?: boolean;
+    } & ButtonHTMLAttributes<HTMLButtonElement>) =>
+      _asChild ? (
+        <>{children}</>
+      ) : (
+        <button type={props.type ?? 'button'} {...props}>
+          {children}
+        </button>
+      ),
+    CircleCheck: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
+    Dialog: ({ children, open }: { children: ReactNode; open: boolean }) =>
+      open ? <div>{children}</div> : null,
+    DialogContent: passthrough(),
+    DialogDescription: passthrough('p'),
+    DialogFooter: passthrough(),
+    DialogHeader: passthrough(),
+    DialogTitle: passthrough('p'),
+    ExternalLink: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
+    Input: (props: InputHTMLAttributes<HTMLInputElement>) => (
+      <input {...props} />
+    ),
+    Label: passthrough('span'),
+    Loader2: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
+    Pencil: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
+    Plus: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
+    Select: passthrough(),
+    SelectContent: passthrough(),
+    SelectItem: passthrough(),
+    SelectTrigger: passthrough(),
+    SelectValue: passthrough('span'),
+    Tabs: passthrough(),
+    TabsContent: passthrough(),
+    TabsList: passthrough(),
+    TabsTrigger: ({ children }: { children: ReactNode }) => (
+      <button type="button">{children}</button>
+    ),
+  };
+});
+
+import { CreateGitHubRepoDialog } from './CreateGitHubRepoDialog';
+
+function findLinkByText(text: RegExp): HTMLAnchorElement {
+  const link = screen
+    .getAllByRole('link')
+    .find((element) => text.test(element.textContent ?? ''));
+
+  if (!link) {
+    throw new Error(`No link matching ${text}`);
+  }
+
+  return link as HTMLAnchorElement;
+}
+
+describe('CreateGitHubRepoDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserState.isAdmin = true;
+    mockInstallationsState.data = [
+      {
+        id: 'install-1',
+        accountLogin: 'acme',
+        accountType: 'Organization',
+        suspendedAt: null,
+      },
+    ];
+    mockRepositoriesState.data = [
+      {
+        id: 'repo-1',
+        fullName: 'acme/existing',
+        sourceControlProvider: 'github',
+      },
+    ];
+  });
+
+  it('prefills the github.com/new link with the installation owner', () => {
+    render(
+      <CreateGitHubRepoDialog open={true} onOpenChange={() => undefined} />,
+    );
+
+    expect(findLinkByText(/Open GitHub$/).getAttribute('href')).toBe(
+      'https://github.com/new?owner=acme',
+    );
+  });
+
+  it('falls back to a bare github.com/new link without installations', () => {
+    mockInstallationsState.data = [];
+
+    render(
+      <CreateGitHubRepoDialog open={true} onOpenChange={() => undefined} />,
+    );
+
+    expect(findLinkByText(/Open GitHub$/).getAttribute('href')).toBe(
+      'https://github.com/new',
+    );
+  });
+
+  it('builds the fork link from a pasted repository URL', () => {
+    render(
+      <CreateGitHubRepoDialog open={true} onOpenChange={() => undefined} />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Repository to fork'), {
+      target: { value: 'https://github.com/RooCodeInc/Roomote' },
+    });
+
+    expect(findLinkByText(/Open GitHub fork page/).getAttribute('href')).toBe(
+      'https://github.com/RooCodeInc/Roomote/fork',
+    );
+  });
+
+  it('shows a validation hint for unparseable fork references', () => {
+    render(
+      <CreateGitHubRepoDialog open={true} onOpenChange={() => undefined} />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Repository to fork'), {
+      target: { value: 'https://gitlab.com/acme/repo' },
+    });
+
+    expect(
+      screen.getByText('Enter a GitHub repository URL or owner/repo.'),
+    ).toBeInTheDocument();
+  });
+
+  it('surfaces repositories that appear after the dialog opened', () => {
+    const onRepositoryDetected = vi.fn();
+    const { rerender } = render(
+      <CreateGitHubRepoDialog
+        open={true}
+        onOpenChange={() => undefined}
+        onRepositoryDetected={onRepositoryDetected}
+      />,
+    );
+
+    expect(screen.queryByText(/Found /)).not.toBeInTheDocument();
+
+    mockRepositoriesState.data = [
+      ...mockRepositoriesState.data,
+      {
+        id: 'repo-2',
+        fullName: 'acme/new-repo',
+        sourceControlProvider: 'github',
+        isEmpty: true,
+      },
+    ];
+
+    rerender(
+      <CreateGitHubRepoDialog
+        open={true}
+        onOpenChange={() => undefined}
+        onRepositoryDetected={onRepositoryDetected}
+      />,
+    );
+
+    expect(screen.getByText('Found acme/new-repo')).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Use this repository' }),
+    );
+
+    expect(onRepositoryDetected).toHaveBeenCalledWith({
+      id: 'repo-2',
+      fullName: 'acme/new-repo',
+      isEmpty: true,
+    });
+  });
+
+  it('triggers a manual GitHub sync from the refresh link', () => {
+    render(
+      <CreateGitHubRepoDialog open={true} onOpenChange={() => undefined} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh now' }));
+
+    expect(mockSyncGitHubInstallations).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers the Update GitHub action to admins only', () => {
+    const { unmount } = render(
+      <CreateGitHubRepoDialog open={true} onOpenChange={() => undefined} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Update GitHub/i }));
+    expect(mockEnableGitHubApp).toHaveBeenCalledWith(
+      {
+        redirect: '/settings/environments/new',
+        callbackBackground: 'background',
+      },
+      expect.any(Object),
+    );
+
+    unmount();
+    mockUserState.isAdmin = false;
+
+    render(
+      <CreateGitHubRepoDialog open={true} onOpenChange={() => undefined} />,
+    );
+
+    expect(screen.getByText(/Ask an admin/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Update GitHub/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/github/CreateGitHubRepoDialog.client.test.tsx
+++ b/apps/web/src/components/github/CreateGitHubRepoDialog.client.test.tsx
@@ -36,6 +36,10 @@ const {
   mockToast: { error: vi.fn(), success: vi.fn() },
 }));
 
+const mockRadioGroupState = vi.hoisted(() => ({
+  onValueChange: undefined as undefined | ((value: string) => void),
+}));
+
 vi.mock('next/navigation', () => ({
   usePathname: () => '/settings/environments/new',
   useSearchParams: () => new URLSearchParams(''),
@@ -128,20 +132,19 @@ vi.mock('@/components/system', () => {
     }: {
       children: ReactNode;
       onValueChange?: (value: string) => void;
-    }) => (
-      <fieldset
-        {...props}
-        onChange={(event) => {
-          if (event.target instanceof HTMLInputElement) {
-            onValueChange?.(event.target.value);
-          }
-        }}
-      >
-        {children}
-      </fieldset>
-    ),
+    }) => {
+      mockRadioGroupState.onValueChange = onValueChange;
+
+      return <fieldset {...props}>{children}</fieldset>;
+    },
     RadioGroupItem: (props: InputHTMLAttributes<HTMLInputElement>) => (
-      <input type="radio" {...props} />
+      <input
+        type="radio"
+        {...props}
+        onChange={(event) =>
+          mockRadioGroupState.onValueChange?.(event.currentTarget.value)
+        }
+      />
     ),
   };
 });
@@ -214,7 +217,7 @@ describe('CreateGitHubRepoDialog', () => {
       target: { value: 'https://github.com/RooCodeInc/Roomote' },
     });
 
-    expect(findLinkByText(/Open GitHub fork page/).getAttribute('href')).toBe(
+    expect(findLinkByText(/^Go$/).getAttribute('href')).toBe(
       'https://github.com/RooCodeInc/Roomote/fork',
     );
   });
@@ -265,11 +268,9 @@ describe('CreateGitHubRepoDialog', () => {
       />,
     );
 
-    expect(screen.getByText('Found acme/new-repo')).toBeInTheDocument();
+    expect(screen.getByText('acme/new-repo')).toBeInTheDocument();
 
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Use this repository' }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Use it' }));
 
     expect(onRepositoryDetected).toHaveBeenCalledWith({
       id: 'repo-2',

--- a/apps/web/src/components/github/CreateGitHubRepoDialog.client.test.tsx
+++ b/apps/web/src/components/github/CreateGitHubRepoDialog.client.test.tsx
@@ -73,7 +73,7 @@ vi.mock('@/hooks/useUser', () => ({
 }));
 
 vi.mock('@/components/system', () => {
-  const passthrough = (Tag: 'div' | 'p' | 'span' = 'div') => {
+  const passthrough = (Tag: 'div' | 'p' | 'span' | 'label' = 'div') => {
     const Passthrough = ({ children, ...props }: { children?: ReactNode }) => (
       <Tag {...props}>{children}</Tag>
     );
@@ -112,7 +112,7 @@ vi.mock('@/components/system', () => {
     Input: (props: InputHTMLAttributes<HTMLInputElement>) => (
       <input {...props} />
     ),
-    Label: passthrough('span'),
+    Label: passthrough('label'),
     Loader2: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
     Pencil: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
     Plus: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
@@ -121,11 +121,27 @@ vi.mock('@/components/system', () => {
     SelectItem: passthrough(),
     SelectTrigger: passthrough(),
     SelectValue: passthrough('span'),
-    Tabs: passthrough(),
-    TabsContent: passthrough(),
-    TabsList: passthrough(),
-    TabsTrigger: ({ children }: { children: ReactNode }) => (
-      <button type="button">{children}</button>
+    RadioGroup: ({
+      children,
+      onValueChange,
+      ...props
+    }: {
+      children: ReactNode;
+      onValueChange?: (value: string) => void;
+    }) => (
+      <fieldset
+        {...props}
+        onChange={(event) => {
+          if (event.target instanceof HTMLInputElement) {
+            onValueChange?.(event.target.value);
+          }
+        }}
+      >
+        {children}
+      </fieldset>
+    ),
+    RadioGroupItem: (props: InputHTMLAttributes<HTMLInputElement>) => (
+      <input type="radio" {...props} />
     ),
   };
 });
@@ -170,7 +186,7 @@ describe('CreateGitHubRepoDialog', () => {
       <CreateGitHubRepoDialog open={true} onOpenChange={() => undefined} />,
     );
 
-    expect(findLinkByText(/Open GitHub$/).getAttribute('href')).toBe(
+    expect(findLinkByText(/^Go$/).getAttribute('href')).toBe(
       'https://github.com/new?owner=acme',
     );
   });
@@ -182,7 +198,7 @@ describe('CreateGitHubRepoDialog', () => {
       <CreateGitHubRepoDialog open={true} onOpenChange={() => undefined} />,
     );
 
-    expect(findLinkByText(/Open GitHub$/).getAttribute('href')).toBe(
+    expect(findLinkByText(/^Go$/).getAttribute('href')).toBe(
       'https://github.com/new',
     );
   });
@@ -191,6 +207,8 @@ describe('CreateGitHubRepoDialog', () => {
     render(
       <CreateGitHubRepoDialog open={true} onOpenChange={() => undefined} />,
     );
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Fork existing' }));
 
     fireEvent.change(screen.getByLabelText('Repository to fork'), {
       target: { value: 'https://github.com/RooCodeInc/Roomote' },
@@ -205,6 +223,8 @@ describe('CreateGitHubRepoDialog', () => {
     render(
       <CreateGitHubRepoDialog open={true} onOpenChange={() => undefined} />,
     );
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Fork existing' }));
 
     fireEvent.change(screen.getByLabelText('Repository to fork'), {
       target: { value: 'https://gitlab.com/acme/repo' },

--- a/apps/web/src/components/github/CreateGitHubRepoDialog.tsx
+++ b/apps/web/src/components/github/CreateGitHubRepoDialog.tsx
@@ -1,0 +1,418 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { toast } from 'sonner';
+
+import {
+  useEnableGitHubApp,
+  useGitHubInstallations,
+  useSyncGitHubInstallations,
+} from '@/hooks/github';
+import { useRepositories } from '@/hooks/source-control';
+import { useRealtimePolling } from '@/hooks/useRealtimePolling';
+import { useAuthorizedUser } from '@/hooks/useUser';
+import { parseGitHubRepoReference } from '@/lib/github-urls';
+
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  Button,
+  CircleCheck,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  ExternalLink,
+  Input,
+  Label,
+  Loader2,
+  Pencil,
+  Plus,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/components/system';
+
+export type DetectedRepository = {
+  id: string;
+  fullName: string;
+  isEmpty?: boolean;
+};
+
+const REPOSITORY_POLL_INTERVAL_MS = 5000;
+
+export function CreateGitHubRepoDialog({
+  open,
+  onOpenChange,
+  onRepositoryDetected,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onRepositoryDetected?: (repository: DetectedRepository) => void;
+}) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { isAdmin } = useAuthorizedUser();
+
+  const [selectedOwner, setSelectedOwner] = useState<string | null>(null);
+  const [forkReference, setForkReference] = useState('');
+
+  const installations = useGitHubInstallations();
+  const enableGitHubApp = useEnableGitHubApp();
+  const syncGitHubInstallations = useSyncGitHubInstallations({
+    onError: () => toast.error('Failed to refresh GitHub. Please try again.'),
+  });
+
+  const polling = useRealtimePolling({
+    enabled: open,
+    interval: REPOSITORY_POLL_INTERVAL_MS,
+  });
+  const repositories = useRepositories(
+    { includeEmptyState: true },
+    {
+      refetchInterval: polling.refetchInterval,
+      refetchIntervalInBackground: polling.refetchIntervalInBackground,
+    },
+  );
+
+  const githubRepositories = useMemo<DetectedRepository[]>(
+    () =>
+      (repositories.data ?? [])
+        .filter((repository) => repository.sourceControlProvider === 'github')
+        .map((repository) => ({
+          id: repository.id,
+          fullName: repository.fullName,
+          // `isEmpty` is present because the query passes includeEmptyState,
+          // but the router output type does not narrow on that flag.
+          isEmpty: (repository as { isEmpty?: boolean }).isEmpty,
+        })),
+    [repositories.data],
+  );
+
+  // Snapshot the repos that existed when the dialog opened; anything beyond
+  // that baseline was just created (or just granted) and is offered back.
+  const baselineRepositoryIdsRef = useRef<Set<string> | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      baselineRepositoryIdsRef.current = null;
+      return;
+    }
+
+    if (
+      baselineRepositoryIdsRef.current === null &&
+      repositories.data !== undefined
+    ) {
+      baselineRepositoryIdsRef.current = new Set(
+        githubRepositories.map((repository) => repository.id),
+      );
+    }
+  }, [open, repositories.data, githubRepositories]);
+
+  const detectedRepositories = useMemo(() => {
+    const baseline = baselineRepositoryIdsRef.current;
+
+    if (!open || baseline === null) {
+      return [];
+    }
+
+    // The baseline ref is intentionally read during render: it only changes
+    // together with `githubRepositories`, which is a dependency.
+    return githubRepositories.filter(
+      (repository) => !baseline.has(repository.id),
+    );
+  }, [open, githubRepositories]);
+
+  // Returning from github.com is the most likely moment the new repo exists,
+  // so trigger one authoritative GitHub sync per return to the tab instead of
+  // waiting for a webhook or the next poll.
+  const visibilitySyncPendingRef = useRef(false);
+
+  useEffect(() => {
+    if (!open) {
+      visibilitySyncPendingRef.current = false;
+      return;
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        visibilitySyncPendingRef.current = true;
+        return;
+      }
+
+      if (
+        visibilitySyncPendingRef.current &&
+        !syncGitHubInstallations.isPending
+      ) {
+        visibilitySyncPendingRef.current = false;
+        syncGitHubInstallations.mutate();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [open, syncGitHubInstallations]);
+
+  const activeInstallations = useMemo(
+    () =>
+      (installations.data ?? []).filter(
+        (installation) => !installation.suspendedAt,
+      ),
+    [installations.data],
+  );
+
+  const defaultOwner =
+    activeInstallations.find(
+      (installation) => installation.accountType === 'Organization',
+    )?.accountLogin ??
+    activeInstallations[0]?.accountLogin ??
+    null;
+  const owner = selectedOwner ?? defaultOwner;
+
+  const newRepoUrl = owner
+    ? `https://github.com/new?owner=${encodeURIComponent(owner)}`
+    : 'https://github.com/new';
+
+  const forkTarget = parseGitHubRepoReference(forkReference);
+  const forkUrl = forkTarget
+    ? `https://github.com/${forkTarget.owner}/${forkTarget.repo}/fork`
+    : null;
+
+  const search = searchParams.toString();
+  const redirectTarget = search ? `${pathname}?${search}` : pathname;
+
+  const updateGitHubAccess = () => {
+    enableGitHubApp.mutate(
+      {
+        redirect: redirectTarget,
+        callbackBackground: 'background',
+      },
+      {
+        onSuccess: (result) => {
+          if (!result.success) {
+            toast.error(result.error);
+            return;
+          }
+
+          if (result.mode === 'redirect') {
+            window.location.href = result.url;
+            return;
+          }
+
+          toast.success('GitHub access updated.');
+        },
+        onError: () =>
+          toast.error('Failed to update GitHub. Please try again.'),
+      },
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>Add a GitHub repository</DialogTitle>
+          <DialogDescription>
+            Create the repository on GitHub — Roomote picks it up here
+            automatically.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Tabs defaultValue="new">
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="new">New repository</TabsTrigger>
+            <TabsTrigger value="fork">Fork existing</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="new" className="space-y-3 pt-2">
+            <p className="text-sm text-muted-foreground">
+              Create the repository on github.com. An empty repository is fine —
+              Roomote pushes the initial commit and sets up a basic environment
+              for it.
+            </p>
+            {activeInstallations.length > 1 ? (
+              <div className="space-y-1.5">
+                <Label htmlFor="create-repo-owner">Owner</Label>
+                <Select
+                  value={owner ?? undefined}
+                  onValueChange={setSelectedOwner}
+                >
+                  <SelectTrigger id="create-repo-owner">
+                    <SelectValue placeholder="Choose an owner" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {activeInstallations.map((installation) => (
+                      <SelectItem
+                        key={installation.id}
+                        value={installation.accountLogin}
+                      >
+                        {installation.accountLogin}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            ) : null}
+            <Button asChild className="w-full">
+              <a href={newRepoUrl} target="_blank" rel="noreferrer">
+                Open GitHub
+                <ExternalLink />
+              </a>
+            </Button>
+          </TabsContent>
+
+          <TabsContent value="fork" className="space-y-3 pt-2">
+            <p className="text-sm text-muted-foreground">
+              Paste the repository you want to fork — a GitHub URL or
+              owner/repo.
+            </p>
+            <Input
+              value={forkReference}
+              onChange={(event) => setForkReference(event.target.value)}
+              placeholder="https://github.com/owner/repo"
+              aria-label="Repository to fork"
+            />
+            {forkReference.trim() && !forkTarget ? (
+              <p className="text-xs text-destructive">
+                Enter a GitHub repository URL or owner/repo.
+              </p>
+            ) : null}
+            <Button asChild className="w-full" disabled={!forkUrl}>
+              <a
+                href={forkUrl ?? undefined}
+                target="_blank"
+                rel="noreferrer"
+                aria-disabled={!forkUrl}
+                onClick={(event) => {
+                  if (!forkUrl) event.preventDefault();
+                }}
+              >
+                Open GitHub fork page
+                <ExternalLink />
+              </a>
+            </Button>
+          </TabsContent>
+        </Tabs>
+
+        <div className="space-y-2 border-t pt-3">
+          <p className="text-xs text-muted-foreground">
+            If the GitHub App only has access to selected repositories, also
+            grant it access to the new one.
+          </p>
+          {isAdmin ? (
+            <Button
+              type="button"
+              size="xs"
+              variant="outline"
+              disabled={enableGitHubApp.isPending}
+              onClick={updateGitHubAccess}
+            >
+              <Pencil className="size-3" />
+              Update GitHub
+            </Button>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              Ask an admin to update the connected GitHub repositories.
+            </p>
+          )}
+        </div>
+
+        {detectedRepositories.length > 0 ? (
+          <div className="space-y-2">
+            {detectedRepositories.map((repository) => (
+              <Alert key={repository.id}>
+                <CircleCheck className="size-4" />
+                <AlertTitle>Found {repository.fullName}</AlertTitle>
+                <AlertDescription className="flex items-center justify-between gap-2">
+                  <span>
+                    {repository.isEmpty
+                      ? 'Brand new — Roomote will initialize it during setup.'
+                      : 'Ready to use.'}
+                  </span>
+                  <Button
+                    type="button"
+                    size="xs"
+                    onClick={() => onRepositoryDetected?.(repository)}
+                  >
+                    Use this repository
+                  </Button>
+                </AlertDescription>
+              </Alert>
+            ))}
+          </div>
+        ) : (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Loader2 className="size-3.5 animate-spin" />
+            <span>Watching for new repositories…</span>
+            <Button
+              type="button"
+              size="xs"
+              variant="link"
+              className="h-auto p-0"
+              disabled={syncGitHubInstallations.isPending}
+              onClick={() => syncGitHubInstallations.mutate()}
+            >
+              Refresh now
+            </Button>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function CreateGitHubRepoButton({
+  onRepositoryDetected,
+  size = 'sm',
+  variant = 'outline',
+  className,
+}: {
+  onRepositoryDetected?: (repository: DetectedRepository) => void;
+  size?: 'xs' | 'sm' | 'default';
+  variant?: 'outline' | 'ghost' | 'link' | 'default';
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        type="button"
+        size={size}
+        variant={variant}
+        className={className}
+        onClick={() => setOpen(true)}
+      >
+        <Plus />
+        Create a new repository
+      </Button>
+      <CreateGitHubRepoDialog
+        open={open}
+        onOpenChange={setOpen}
+        onRepositoryDetected={(repository) => {
+          setOpen(false);
+          onRepositoryDetected?.(repository);
+        }}
+      />
+    </>
+  );
+}

--- a/apps/web/src/components/github/CreateGitHubRepoDialog.tsx
+++ b/apps/web/src/components/github/CreateGitHubRepoDialog.tsx
@@ -181,6 +181,9 @@ export function CreateGitHubRepoDialog({
     activeInstallations[0]?.accountLogin ??
     null;
   const owner = selectedOwner ?? defaultOwner;
+  const newRepoUrl = owner
+    ? `https://github.com/new?owner=${encodeURIComponent(owner)}`
+    : 'https://github.com/new';
 
   const forkTarget = parseGitHubRepoReference(forkReference);
   const forkUrl = forkTarget
@@ -247,6 +250,12 @@ export function CreateGitHubRepoDialog({
                 <p className="text-sm text-muted-foreground grow">
                   Please create it now on Github and come back here when done.
                 </p>
+                <Button asChild size="sm">
+                  <a href={newRepoUrl} target="_blank" rel="noreferrer">
+                    Go
+                    <ExternalLink />
+                  </a>
+                </Button>
               </div>
               {activeInstallations.length > 1 ? (
                 <div className="space-y-1.5">
@@ -376,9 +385,9 @@ export function CreateGitHubRepoDialog({
                 Update GitHub
               </Button>
             ) : (
-              <p className="text-xs text-muted-foreground">
+              <span className="text-xs text-muted-foreground">
                 Ask an admin to update the connected GitHub repositories.
-              </p>
+              </span>
             )}
           </p>
         </div>

--- a/apps/web/src/components/github/CreateGitHubRepoDialog.tsx
+++ b/apps/web/src/components/github/CreateGitHubRepoDialog.tsx
@@ -19,7 +19,6 @@ import {
   AlertDescription,
   AlertTitle,
   Button,
-  CircleCheck,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -31,7 +30,6 @@ import {
   Label,
   Loader2,
   Pencil,
-  Plus,
   RadioGroup,
   RadioGroupItem,
   Select,
@@ -183,10 +181,6 @@ export function CreateGitHubRepoDialog({
     activeInstallations[0]?.accountLogin ??
     null;
   const owner = selectedOwner ?? defaultOwner;
-
-  const newRepoUrl = owner
-    ? `https://github.com/new?owner=${encodeURIComponent(owner)}`
-    : 'https://github.com/new';
 
   const forkTarget = parseGitHubRepoReference(forkReference);
   const forkUrl = forkTarget
@@ -366,9 +360,9 @@ export function CreateGitHubRepoDialog({
 
         <div className="space-y-2 mt-4">
           <p className="text-xs text-muted-foreground">
-            If the your GitHub integration doesn't have access to "all repos" by
-            default, make sure to grant it access to the new one, otherwise it
-            won't be detected.
+            If your GitHub integration does not have access to all repositories
+            by default, grant it access to the new one or it will not be
+            detected.
             {isAdmin ? (
               <Button
                 type="button"
@@ -396,42 +390,5 @@ export function CreateGitHubRepoDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
-  );
-}
-
-export function CreateGitHubRepoButton({
-  onRepositoryDetected,
-  size = 'sm',
-  variant = 'outline',
-  className,
-}: {
-  onRepositoryDetected?: (repository: DetectedRepository) => void;
-  size?: 'xs' | 'sm' | 'default';
-  variant?: 'outline' | 'ghost' | 'link' | 'default';
-  className?: string;
-}) {
-  const [open, setOpen] = useState(false);
-
-  return (
-    <>
-      <Button
-        type="button"
-        size={size}
-        variant={variant}
-        className={className}
-        onClick={() => setOpen(true)}
-      >
-        <Plus />
-        Create a new repository
-      </Button>
-      <CreateGitHubRepoDialog
-        open={open}
-        onOpenChange={setOpen}
-        onRepositoryDetected={(repository) => {
-          setOpen(false);
-          onRepositoryDetected?.(repository);
-        }}
-      />
-    </>
   );
 }

--- a/apps/web/src/components/github/CreateGitHubRepoDialog.tsx
+++ b/apps/web/src/components/github/CreateGitHubRepoDialog.tsx
@@ -32,16 +32,15 @@ import {
   Loader2,
   Pencil,
   Plus,
+  RadioGroup,
+  RadioGroupItem,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
 } from '@/components/system';
+import { ArrowRight, BookPlus, Check, GitFork } from 'lucide-react';
 
 export type DetectedRepository = {
   id: string;
@@ -65,6 +64,9 @@ export function CreateGitHubRepoDialog({
   const { isAdmin } = useAuthorizedUser();
 
   const [selectedOwner, setSelectedOwner] = useState<string | null>(null);
+  const [repositoryAction, setRepositoryAction] = useState<'new' | 'fork'>(
+    'new',
+  );
   const [forkReference, setForkReference] = useState('');
 
   const installations = useGitHubInstallations();
@@ -222,139 +224,131 @@ export function CreateGitHubRepoDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent size="md">
+      <DialogContent size="lg">
         <DialogHeader>
-          <DialogTitle>Add a GitHub repository</DialogTitle>
+          <DialogTitle>Create environment from new repo</DialogTitle>
           <DialogDescription>
-            Create the repository on GitHub — Roomote picks it up here
-            automatically.
+            Create the repo on Github first, and Roomote will pick it up here.
           </DialogDescription>
         </DialogHeader>
 
-        <Tabs defaultValue="new">
-          <TabsList className="grid w-full grid-cols-2">
-            <TabsTrigger value="new">New repository</TabsTrigger>
-            <TabsTrigger value="fork">Fork existing</TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="new" className="space-y-3 pt-2">
-            <p className="text-sm text-muted-foreground">
-              Create the repository on github.com. An empty repository is fine —
-              Roomote pushes the initial commit and sets up a basic environment
-              for it.
-            </p>
-            {activeInstallations.length > 1 ? (
-              <div className="space-y-1.5">
-                <Label htmlFor="create-repo-owner">Owner</Label>
-                <Select
-                  value={owner ?? undefined}
-                  onValueChange={setSelectedOwner}
-                >
-                  <SelectTrigger id="create-repo-owner">
-                    <SelectValue placeholder="Choose an owner" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {activeInstallations.map((installation) => (
-                      <SelectItem
-                        key={installation.id}
-                        value={installation.accountLogin}
-                      >
-                        {installation.accountLogin}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+        <RadioGroup
+          value={repositoryAction}
+          onValueChange={(value) =>
+            setRepositoryAction(value === 'fork' ? 'fork' : 'new')
+          }
+          className="space-y-0"
+          aria-label="Repository action"
+        >
+          <div className="flex items-center gap-2">
+            <RadioGroupItem value="new" id="create-repo-new" />
+            <Label htmlFor="create-repo-new" className="cursor-pointer">
+              <BookPlus className="size-4 text-muted-foreground" />
+              New repository
+            </Label>
+          </div>
+          {repositoryAction === 'new' && (
+            <div className="space-y-2 pl-6 mb-4">
+              <div className="flex gap-2 items-center">
+                <p className="text-sm text-muted-foreground grow">
+                  Please create it now on Github and come back here when done.
+                </p>
               </div>
-            ) : null}
-            <Button asChild className="w-full">
-              <a href={newRepoUrl} target="_blank" rel="noreferrer">
-                Open GitHub
-                <ExternalLink />
-              </a>
-            </Button>
-          </TabsContent>
-
-          <TabsContent value="fork" className="space-y-3 pt-2">
-            <p className="text-sm text-muted-foreground">
-              Paste the repository you want to fork — a GitHub URL or
-              owner/repo.
-            </p>
-            <Input
-              value={forkReference}
-              onChange={(event) => setForkReference(event.target.value)}
-              placeholder="https://github.com/owner/repo"
-              aria-label="Repository to fork"
-            />
-            {forkReference.trim() && !forkTarget ? (
-              <p className="text-xs text-destructive">
-                Enter a GitHub repository URL or owner/repo.
-              </p>
-            ) : null}
-            <Button asChild className="w-full" disabled={!forkUrl}>
-              <a
-                href={forkUrl ?? undefined}
-                target="_blank"
-                rel="noreferrer"
-                aria-disabled={!forkUrl}
-                onClick={(event) => {
-                  if (!forkUrl) event.preventDefault();
-                }}
-              >
-                Open GitHub fork page
-                <ExternalLink />
-              </a>
-            </Button>
-          </TabsContent>
-        </Tabs>
-
-        <div className="space-y-2 border-t pt-3">
-          <p className="text-xs text-muted-foreground">
-            If the GitHub App only has access to selected repositories, also
-            grant it access to the new one.
-          </p>
-          {isAdmin ? (
-            <Button
-              type="button"
-              size="xs"
-              variant="outline"
-              disabled={enableGitHubApp.isPending}
-              onClick={updateGitHubAccess}
-            >
-              <Pencil className="size-3" />
-              Update GitHub
-            </Button>
-          ) : (
-            <p className="text-xs text-muted-foreground">
-              Ask an admin to update the connected GitHub repositories.
-            </p>
+              {activeInstallations.length > 1 ? (
+                <div className="space-y-1.5">
+                  <Label htmlFor="create-repo-owner">Owner</Label>
+                  <Select
+                    value={owner ?? undefined}
+                    onValueChange={setSelectedOwner}
+                  >
+                    <SelectTrigger id="create-repo-owner">
+                      <SelectValue placeholder="Choose an owner" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {activeInstallations.map((installation) => (
+                        <SelectItem
+                          key={installation.id}
+                          value={installation.accountLogin}
+                        >
+                          {installation.accountLogin}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              ) : null}
+            </div>
           )}
-        </div>
+          <div className="flex items-center gap-2">
+            <RadioGroupItem value="fork" id="create-repo-fork" />
+            <Label htmlFor="create-repo-fork" className="cursor-pointer">
+              <GitFork className="size-4 text-muted-foreground" />
+              Fork existing
+            </Label>
+          </div>
+          {repositoryAction === 'fork' && (
+            <div className="space-y-2 pl-6 mb-4">
+              <p className="text-sm text-muted-foreground">
+                Enter the repo you want to fork, then fork it and come back here
+                when done.
+              </p>
+              <div className="flex gap-2 items-center">
+                <Input
+                  value={forkReference}
+                  onChange={(event) => setForkReference(event.target.value)}
+                  placeholder="https://github.com/owner/repo"
+                  aria-label="Repository to fork"
+                />
+                <Button asChild size="sm" disabled={!forkUrl}>
+                  <a
+                    href={forkUrl ?? undefined}
+                    target="_blank"
+                    rel="noreferrer"
+                    aria-disabled={!forkUrl}
+                    onClick={(event) => {
+                      if (!forkUrl) event.preventDefault();
+                    }}
+                  >
+                    Go
+                    <ExternalLink />
+                  </a>
+                </Button>
+              </div>
+              {forkReference.trim() && !forkTarget ? (
+                <p className="text-xs text-destructive">
+                  Enter a GitHub repository URL or owner/repo.
+                </p>
+              ) : null}
+            </div>
+          )}
+        </RadioGroup>
 
         {detectedRepositories.length > 0 ? (
           <div className="space-y-2">
             {detectedRepositories.map((repository) => (
-              <Alert key={repository.id}>
-                <CircleCheck className="size-4" />
-                <AlertTitle>Found {repository.fullName}</AlertTitle>
-                <AlertDescription className="flex items-center justify-between gap-2">
-                  <span>
-                    {repository.isEmpty
-                      ? 'Brand new — Roomote will initialize it during setup.'
-                      : 'Ready to use.'}
+              <Alert variant="notice" key={repository.id}>
+                <Check className="size-4" />
+                <AlertTitle>
+                  Found{' '}
+                  <span className="font-mono font-medium text-[0.9em]">
+                    {repository.fullName}
                   </span>
+                </AlertTitle>
+                <AlertDescription className="flex items-center justify-between gap-2">
                   <Button
                     type="button"
                     size="xs"
                     onClick={() => onRepositoryDetected?.(repository)}
                   >
-                    Use this repository
+                    Use it
+                    <ArrowRight />
                   </Button>
                 </AlertDescription>
               </Alert>
             ))}
           </div>
         ) : (
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <div className="flex items-center gap-2 text-sm text-foreground mt-4">
             <Loader2 className="size-3.5 animate-spin" />
             <span>Watching for new repositories…</span>
             <Button
@@ -369,6 +363,31 @@ export function CreateGitHubRepoDialog({
             </Button>
           </div>
         )}
+
+        <div className="space-y-2 mt-4">
+          <p className="text-xs text-muted-foreground">
+            If the your GitHub integration doesn't have access to "all repos" by
+            default, make sure to grant it access to the new one, otherwise it
+            won't be detected.
+            {isAdmin ? (
+              <Button
+                type="button"
+                size="xs"
+                variant="link"
+                className="relative top-0.5"
+                disabled={enableGitHubApp.isPending}
+                onClick={updateGitHubAccess}
+              >
+                <Pencil className="size-3" />
+                Update GitHub
+              </Button>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Ask an admin to update the connected GitHub repositories.
+              </p>
+            )}
+          </p>
+        </div>
 
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>

--- a/apps/web/src/components/settings/environments/CreateEnvironmentPage.client.test.tsx
+++ b/apps/web/src/components/settings/environments/CreateEnvironmentPage.client.test.tsx
@@ -48,11 +48,23 @@ const {
   };
 });
 
+const { mockNavigationState, mockRepositoriesState, mockCreateRepoDialog } =
+  vi.hoisted(() => ({
+    mockNavigationState: { search: '' as string },
+    mockRepositoriesState: {
+      data: [
+        { id: 'repo-1', fullName: 'acme/api' },
+        { id: 'repo-2', fullName: 'acme/web' },
+      ] as Array<{ id: string; fullName: string; isEmpty?: boolean }>,
+    },
+    mockCreateRepoDialog: vi.fn(),
+  }));
+
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
     push: mockRouterPush,
   }),
-  useSearchParams: () => new URLSearchParams(''),
+  useSearchParams: () => new URLSearchParams(mockNavigationState.search),
 }));
 
 vi.mock('sonner', () => ({
@@ -74,16 +86,7 @@ vi.mock('@/hooks/environments', () => ({
 
 vi.mock('@/hooks/source-control', () => ({
   useRepositories: () => ({
-    data: [
-      {
-        id: 'repo-1',
-        fullName: 'acme/api',
-      },
-      {
-        id: 'repo-2',
-        fullName: 'acme/web',
-      },
-    ],
+    data: mockRepositoriesState.data,
     isPending: false,
   }),
 }));
@@ -113,6 +116,21 @@ vi.mock('@/components/tasks', () => ({
       <option value="openrouter/z-ai/glm-5.2">GLM 5.2</option>
     </select>
   ),
+}));
+
+vi.mock('@/components/github/CreateGitHubRepoDialog', () => ({
+  CreateGitHubRepoDialog: (props: {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onRepositoryDetected?: (repository: {
+      id: string;
+      fullName: string;
+      isEmpty?: boolean;
+    }) => void;
+  }) => {
+    mockCreateRepoDialog(props);
+    return props.open ? <div data-testid="create-repo-dialog" /> : null;
+  },
 }));
 
 vi.mock('@/trpc/client', () => ({
@@ -170,8 +188,8 @@ vi.mock('@/components/system', () => ({
   AlertDescription: ({
     children,
     ...props
-  }: { children: ReactNode } & HTMLAttributes<HTMLParagraphElement>) => (
-    <p {...props}>{children}</p>
+  }: { children: ReactNode } & HTMLAttributes<HTMLDivElement>) => (
+    <div {...props}>{children}</div>
   ),
   ArrowLeft: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
   ArrowRight: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
@@ -244,7 +262,9 @@ vi.mock('@/components/system', () => ({
     <h2 {...props}>{children}</h2>
   ),
   HandMetal: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
+  Info: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
   Loader2: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
+  Plus: (props: SVGProps<SVGSVGElement>) => <svg {...props} />,
   ScrollArea: ({
     children,
     ...props
@@ -262,6 +282,78 @@ describe('CreateEnvironmentPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockYamlEditorState.reset();
+    mockNavigationState.search = '';
+    mockRepositoriesState.data = [
+      { id: 'repo-1', fullName: 'acme/api' },
+      { id: 'repo-2', fullName: 'acme/web' },
+    ];
+  });
+
+  it('renders the create-repo affordance and opens the dialog', () => {
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <CreateEnvironmentPage />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.queryByTestId('create-repo-dialog')).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /Create a new repository/i }),
+    );
+
+    expect(screen.getByTestId('create-repo-dialog')).toBeInTheDocument();
+  });
+
+  it('opens the create-repo dialog from the create-repo search param', () => {
+    mockNavigationState.search = 'create-repo=1';
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <CreateEnvironmentPage />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByTestId('create-repo-dialog')).toBeInTheDocument();
+  });
+
+  it('selects a detected repository and explains the empty-repo bootstrap', async () => {
+    mockRepositoriesState.data = [
+      { id: 'repo-1', fullName: 'acme/api' },
+      { id: 'repo-new', fullName: 'acme/new-repo', isEmpty: true },
+    ];
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <CreateEnvironmentPage />
+      </QueryClientProvider>,
+    );
+
+    const dialogProps = mockCreateRepoDialog.mock.calls.at(-1)?.[0] as {
+      onRepositoryDetected?: (repository: {
+        id: string;
+        fullName: string;
+        isEmpty?: boolean;
+      }) => void;
+    };
+
+    dialogProps.onRepositoryDetected?.({
+      id: 'repo-new',
+      fullName: 'acme/new-repo',
+      isEmpty: true,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/acme\/new-repo/i)).toBeChecked();
+    });
+    expect(
+      screen.getByText(/will push an initial commit and set up a basic/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Start Agent' })).toBeEnabled();
   });
 
   it('starts an environment definition task and opens it in the task view', async () => {
@@ -277,10 +369,6 @@ describe('CreateEnvironmentPage', () => {
     fireEvent.change(screen.getByPlaceholderText(/Optional agent guidance/i), {
       target: { value: 'Use the API service from the first repo set.' },
     });
-    fireEvent.change(
-      screen.getByRole('combobox', { name: /environment setup model/i }),
-      { target: { value: 'openrouter/z-ai/glm-5.2' } },
-    );
 
     fireEvent.click(screen.getByRole('button', { name: 'Start Agent' }));
 
@@ -290,7 +378,6 @@ describe('CreateEnvironmentPage', () => {
     expect(mockStartDefinitionTask.mock.calls[0]?.[0]).toEqual({
       repositoryIds: ['repo-1'],
       changeRequest: 'Use the API service from the first repo set.',
-      selectedModelId: 'openrouter/z-ai/glm-5.2',
     });
     expect(mockRouterPush).toHaveBeenCalledWith('/task/task-1');
   });

--- a/apps/web/src/components/settings/environments/CreateEnvironmentPage.client.test.tsx
+++ b/apps/web/src/components/settings/environments/CreateEnvironmentPage.client.test.tsx
@@ -378,6 +378,7 @@ describe('CreateEnvironmentPage', () => {
     expect(mockStartDefinitionTask.mock.calls[0]?.[0]).toEqual({
       repositoryIds: ['repo-1'],
       changeRequest: 'Use the API service from the first repo set.',
+      selectedModelId: 'openrouter/openai/gpt-5.4',
     });
     expect(mockRouterPush).toHaveBeenCalledWith('/task/task-1');
   });

--- a/apps/web/src/components/settings/environments/CreateEnvironmentPage.tsx
+++ b/apps/web/src/components/settings/environments/CreateEnvironmentPage.tsx
@@ -34,7 +34,6 @@ import {
   HandMetal,
   Info,
   Loader2,
-  Plus,
   Textarea,
 } from '@/components/system';
 
@@ -359,7 +358,7 @@ function AgentRepositorySelectionSubview({
   return (
     <>
       <p className="text-sm text-muted-foreground">
-        Pick the repos needed for the first environment you want to set up.
+        Pick the repo(s) needed for the environment you want to set up.
       </p>
 
       <Card>
@@ -377,15 +376,14 @@ function AgentRepositorySelectionSubview({
                 </AlertDescription>
               </Alert>
               <UpdateGitHubReposHint />
-              <Button
-                type="button"
-                size="xs"
-                variant="outline"
-                onClick={onOpenCreateRepo}
-              >
-                <Plus className="size-3" />
-                Create a new repository
-              </Button>
+              <EnvironmentRepositorySelector
+                repositories={repositories}
+                selectedRepositoryIds={selectedRepositoryIds}
+                onToggleRepository={onToggleRepository}
+                onCreateRepository={onOpenCreateRepo}
+                inputPrefix="create-environment-repository"
+                heightClassName="max-h-[calc(var(--effective-viewport-height)-17rem)] overflow-auto"
+              />
             </div>
           ) : (
             <div className="space-y-4">
@@ -393,21 +391,13 @@ function AgentRepositorySelectionSubview({
                 repositories={repositories}
                 selectedRepositoryIds={selectedRepositoryIds}
                 onToggleRepository={onToggleRepository}
+                onCreateRepository={onOpenCreateRepo}
                 inputPrefix="create-environment-repository"
                 heightClassName="max-h-[calc(var(--effective-viewport-height)-17rem)] overflow-auto"
               />
 
               <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                 <UpdateGitHubReposHint />
-                <Button
-                  type="button"
-                  size="xs"
-                  variant="outline"
-                  onClick={onOpenCreateRepo}
-                >
-                  <Plus className="size-3" />
-                  Create a new repository
-                </Button>
               </div>
 
               {allSelectedRepositoriesAreEmpty ? (

--- a/apps/web/src/components/settings/environments/CreateEnvironmentPage.tsx
+++ b/apps/web/src/components/settings/environments/CreateEnvironmentPage.tsx
@@ -16,6 +16,10 @@ import {
 } from '@/hooks/environments';
 import { useRepositories } from '@/hooks/source-control';
 import { useLaunchTaskModels } from '@/hooks/task-models/useLaunchTaskModels';
+import {
+  areAllRepositoriesEmpty,
+  getEmptyRepositories,
+} from '@/lib/repositories';
 import { useTRPC } from '@/trpc/client';
 import { ModelSelect } from '@/components/tasks';
 
@@ -28,10 +32,16 @@ import {
   Card,
   CardContent,
   HandMetal,
+  Info,
   Loader2,
+  Plus,
   Textarea,
 } from '@/components/system';
 
+import {
+  CreateGitHubRepoDialog,
+  type DetectedRepository,
+} from '@/components/github/CreateGitHubRepoDialog';
 import { EnvironmentRepositorySelector } from './EnvironmentRepositorySelector';
 import { UpdateGitHubReposHint } from './UpdateGitHubReposHint';
 import {
@@ -61,10 +71,13 @@ export function CreateEnvironmentPage({
   const trpc = useTRPC();
   const editorRef = useRef<YamlEnvironmentEditorHandle>(null);
 
-  const repositories = useRepositories();
+  const repositories = useRepositories({ includeEmptyState: true });
   const createEnvironment = useCreateEnvironment();
   const validateConfig = useValidateEnvironmentConfig();
   const launchTaskModels = useLaunchTaskModels();
+  const [createRepoDialogOpen, setCreateRepoDialogOpen] = useState(
+    searchParams.get('create-repo') === '1',
+  );
 
   const [activeView, setActiveView] = useState<MasterView>(
     suggestedMcpId ? 'yaml' : 'agent',
@@ -186,8 +199,15 @@ export function CreateEnvironmentPage({
             ) : null}
             {activeView === 'agent' ? (
               <AgentMasterView
-                repositories={repositories.data ?? []}
+                repositories={(repositories.data ?? []).map((repository) => ({
+                  id: repository.id,
+                  fullName: repository.fullName,
+                  // includeEmptyState is set on the query, but the router
+                  // output type does not narrow on that flag.
+                  isEmpty: (repository as { isEmpty?: boolean }).isEmpty,
+                }))}
                 repositoriesLoading={repositories.isPending}
+                onOpenCreateRepo={() => setCreateRepoDialogOpen(true)}
                 selectedRepositoryIds={selectedRepositoryIds}
                 onToggleRepository={(repositoryId) => {
                   setSelectedRepositoryIds((currentSelection) =>
@@ -224,9 +244,27 @@ export function CreateEnvironmentPage({
           </div>
         </div>
       </div>
+      <CreateGitHubRepoDialog
+        open={createRepoDialogOpen}
+        onOpenChange={setCreateRepoDialogOpen}
+        onRepositoryDetected={(repository: DetectedRepository) => {
+          setCreateRepoDialogOpen(false);
+          setSelectedRepositoryIds((currentSelection) =>
+            currentSelection.includes(repository.id)
+              ? currentSelection
+              : [...currentSelection, repository.id],
+          );
+        }}
+      />
     </>
   );
 }
+
+type AgentViewRepository = {
+  id: string;
+  fullName: string;
+  isEmpty?: boolean | null;
+};
 
 function AgentMasterView({
   repositories,
@@ -239,10 +277,11 @@ function AgentMasterView({
   selectedModelId,
   onSelectedModelIdChange,
   onSwitchToYaml,
+  onOpenCreateRepo,
   isStartAgentPending,
   isBusy,
 }: {
-  repositories: Array<{ id: string; fullName: string }>;
+  repositories: AgentViewRepository[];
   repositoriesLoading: boolean;
   selectedRepositoryIds: string[];
   onToggleRepository: (repositoryId: string) => void;
@@ -252,6 +291,7 @@ function AgentMasterView({
   selectedModelId?: string;
   onSelectedModelIdChange: (value: string) => void;
   onSwitchToYaml: () => void;
+  onOpenCreateRepo: () => void;
   isStartAgentPending: boolean;
   isBusy: boolean;
 }) {
@@ -267,6 +307,7 @@ function AgentMasterView({
       selectedModelId={selectedModelId}
       onSelectedModelIdChange={onSelectedModelIdChange}
       onSwitchToYaml={onSwitchToYaml}
+      onOpenCreateRepo={onOpenCreateRepo}
       isStartAgentPending={isStartAgentPending}
       isBusy={isBusy}
     />
@@ -284,10 +325,11 @@ function AgentRepositorySelectionSubview({
   selectedModelId,
   onSelectedModelIdChange,
   onSwitchToYaml,
+  onOpenCreateRepo,
   isStartAgentPending,
   isBusy,
 }: {
-  repositories: Array<{ id: string; fullName: string }>;
+  repositories: AgentViewRepository[];
   repositoriesLoading: boolean;
   selectedRepositoryIds: string[];
   onToggleRepository: (repositoryId: string) => void;
@@ -297,9 +339,23 @@ function AgentRepositorySelectionSubview({
   selectedModelId?: string;
   onSelectedModelIdChange: (value: string) => void;
   onSwitchToYaml: () => void;
+  onOpenCreateRepo: () => void;
   isStartAgentPending: boolean;
   isBusy: boolean;
 }) {
+  const selectedEmptyRepositories = getEmptyRepositories(
+    repositories.filter((repository) =>
+      selectedRepositoryIds.includes(repository.id),
+    ),
+  );
+  const allSelectedRepositoriesAreEmpty =
+    selectedRepositoryIds.length > 0 &&
+    areAllRepositoriesEmpty(
+      repositories.filter((repository) =>
+        selectedRepositoryIds.includes(repository.id),
+      ),
+    );
+
   return (
     <>
       <p className="text-sm text-muted-foreground">
@@ -321,6 +377,15 @@ function AgentRepositorySelectionSubview({
                 </AlertDescription>
               </Alert>
               <UpdateGitHubReposHint />
+              <Button
+                type="button"
+                size="xs"
+                variant="outline"
+                onClick={onOpenCreateRepo}
+              >
+                <Plus className="size-3" />
+                Create a new repository
+              </Button>
             </div>
           ) : (
             <div className="space-y-4">
@@ -332,7 +397,39 @@ function AgentRepositorySelectionSubview({
                 heightClassName="max-h-[calc(var(--effective-viewport-height)-17rem)] overflow-auto"
               />
 
-              <UpdateGitHubReposHint />
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                <UpdateGitHubReposHint />
+                <Button
+                  type="button"
+                  size="xs"
+                  variant="outline"
+                  onClick={onOpenCreateRepo}
+                >
+                  <Plus className="size-3" />
+                  Create a new repository
+                </Button>
+              </div>
+
+              {allSelectedRepositoriesAreEmpty ? (
+                <Alert>
+                  <Info className="size-4" />
+                  <AlertDescription className="flex-col items-start gap-1">
+                    <p>
+                      {selectedEmptyRepositories.length === 1
+                        ? 'The selected repository has no commits yet.'
+                        : 'All selected repositories have no commits yet.'}{' '}
+                      Roomote will push an initial commit and set up a basic
+                      environment — then you can start building with your first
+                      task.
+                    </p>
+                    <p className="font-medium text-foreground">
+                      {selectedEmptyRepositories
+                        .map((repository) => repository.fullName)
+                        .join(', ')}
+                    </p>
+                  </AlertDescription>
+                </Alert>
+              ) : null}
 
               <div>
                 <Textarea

--- a/apps/web/src/components/settings/environments/EnvironmentRepositorySelector.tsx
+++ b/apps/web/src/components/settings/environments/EnvironmentRepositorySelector.tsx
@@ -2,7 +2,8 @@
 
 import { useMemo } from 'react';
 
-import { Checkbox, ScrollArea } from '@/components/system';
+import { Button, Checkbox, Plus, ScrollArea } from '@/components/system';
+import { PackagePlus } from 'lucide-react';
 
 type RepositorySummary = {
   id: string;
@@ -13,12 +14,14 @@ export function EnvironmentRepositorySelector({
   repositories,
   selectedRepositoryIds,
   onToggleRepository,
+  onCreateRepository,
   inputPrefix = 'environment-repository',
   heightClassName = 'max-h-[11.5rem] md:h-[18.75rem]',
 }: {
   repositories: RepositorySummary[];
   selectedRepositoryIds: string[];
   onToggleRepository: (repositoryId: string) => void;
+  onCreateRepository?: () => void;
   inputPrefix?: string;
   heightClassName?: string;
 }) {
@@ -33,6 +36,17 @@ export function EnvironmentRepositorySelector({
   return (
     <ScrollArea className={`overflow-auto ${heightClassName}`}>
       <div className="space-y-1">
+        {onCreateRepository ? (
+          <p className="border-b border-dotted pb-1">
+            <span
+              className="w-full justify-start flex items-center gap-2 cursor-pointer hover:text-accent-foreground py-1"
+              onClick={onCreateRepository}
+            >
+              <PackagePlus className="size-4 mx-0.5" />
+              Create a new repository
+            </span>
+          </p>
+        ) : null}
         {sortedRepositories.map((repository) => (
           <label
             key={repository.id}

--- a/apps/web/src/components/settings/environments/EnvironmentRepositorySelector.tsx
+++ b/apps/web/src/components/settings/environments/EnvironmentRepositorySelector.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react';
 
-import { Button, Checkbox, Plus, ScrollArea } from '@/components/system';
+import { Checkbox, ScrollArea } from '@/components/system';
 import { PackagePlus } from 'lucide-react';
 
 type RepositorySummary = {

--- a/apps/web/src/components/settings/environments/EnvironmentRepositorySelector.tsx
+++ b/apps/web/src/components/settings/environments/EnvironmentRepositorySelector.tsx
@@ -38,13 +38,14 @@ export function EnvironmentRepositorySelector({
       <div className="space-y-1">
         {onCreateRepository ? (
           <p className="border-b border-dotted pb-1">
-            <span
-              className="w-full justify-start flex items-center gap-2 cursor-pointer hover:text-accent-foreground py-1"
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 py-1 text-left hover:text-accent-foreground"
               onClick={onCreateRepository}
             >
               <PackagePlus className="size-4 mx-0.5" />
               Create a new repository
-            </span>
+            </button>
           </p>
         ) : null}
         {sortedRepositories.map((repository) => (

--- a/apps/web/src/components/settings/environments/UpdateGitHubReposHint.tsx
+++ b/apps/web/src/components/settings/environments/UpdateGitHubReposHint.tsx
@@ -34,7 +34,7 @@ export function UpdateGitHubReposHint() {
       <Button
         type="button"
         size="xs"
-        variant="outline"
+        variant="link"
         disabled={enableGitHubApp.isPending}
         onClick={() => {
           enableGitHubApp.mutate(

--- a/apps/web/src/components/tasks/SelectEnvironmentOrRepository.test.tsx
+++ b/apps/web/src/components/tasks/SelectEnvironmentOrRepository.test.tsx
@@ -114,12 +114,14 @@ const SelectEnvironmentOrRepositoryHarness = ({
   repositoryFilter,
   defaultValues,
   onValuesChange,
+  onCreateRepository,
 }: {
   allowAuto?: boolean;
   /** Omit for no filter (homepage Auto). Pass a repo full name to filter. */
   repositoryFilter?: string;
   defaultValues: Partial<CreateTaskFormValues>;
   onValuesChange: (values: WorkspaceSelectionValues) => void;
+  onCreateRepository?: () => void;
 }) => {
   const form = useForm<CreateTaskFormValues>({
     defaultValues: {
@@ -135,6 +137,7 @@ const SelectEnvironmentOrRepositoryHarness = ({
         repositoryFilter={repositoryFilter}
         allowAuto={allowAuto}
         onCreate={vi.fn()}
+        onCreateRepository={onCreateRepository}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
       />
@@ -512,5 +515,54 @@ describe('SelectEnvironmentOrRepository', () => {
       '__separator__',
       'Auto',
     ]);
+  });
+
+  it('offers the New GitHub repository item to admins when wired up', async () => {
+    render(
+      <SelectEnvironmentOrRepositoryHarness
+        defaultValues={{}}
+        onValuesChange={vi.fn()}
+        onCreateRepository={vi.fn()}
+      />,
+    );
+
+    const menuItems = Array.from(
+      document.querySelectorAll('[data-slot="dropdown-menu-item"]'),
+    ).map((node) => node.textContent?.trim());
+
+    expect(menuItems).toContain('Create environment');
+    expect(menuItems).toContain('New GitHub repository');
+  });
+
+  it('hides the New GitHub repository item without a handler or admin rights', async () => {
+    const { unmount } = render(
+      <SelectEnvironmentOrRepositoryHarness
+        defaultValues={{}}
+        onValuesChange={vi.fn()}
+      />,
+    );
+
+    const menuItemsWithoutHandler = Array.from(
+      document.querySelectorAll('[data-slot="dropdown-menu-item"]'),
+    ).map((node) => node.textContent?.trim());
+    expect(menuItemsWithoutHandler).not.toContain('New GitHub repository');
+    unmount();
+
+    mockedUseAuthorizedUser.mockReturnValue({
+      isAdmin: false,
+    } as ReturnType<typeof useAuthorizedUser>);
+
+    render(
+      <SelectEnvironmentOrRepositoryHarness
+        defaultValues={{}}
+        onValuesChange={vi.fn()}
+        onCreateRepository={vi.fn()}
+      />,
+    );
+
+    const menuItemsAsMember = Array.from(
+      document.querySelectorAll('[data-slot="dropdown-menu-item"]'),
+    ).map((node) => node.textContent?.trim());
+    expect(menuItemsAsMember).not.toContain('New GitHub repository');
   });
 });

--- a/apps/web/src/components/tasks/SelectEnvironmentOrRepository.tsx
+++ b/apps/web/src/components/tasks/SelectEnvironmentOrRepository.tsx
@@ -52,6 +52,7 @@ interface SelectEnvironmentOrRepositoryProps {
   lockedBranch?: string;
   allowAuto?: boolean;
   onCreate: () => void;
+  onCreateRepository?: () => void;
   onEdit: (e: React.MouseEvent, envId: string) => void;
   onDelete: (e: React.MouseEvent, env: EnvironmentWithMeta) => void;
 }
@@ -61,6 +62,7 @@ export const SelectEnvironmentOrRepository = ({
   lockedBranch,
   allowAuto = false,
   onCreate,
+  onCreateRepository,
   onEdit,
   onDelete,
 }: SelectEnvironmentOrRepositoryProps) => {
@@ -455,6 +457,19 @@ export const SelectEnvironmentOrRepository = ({
                     Create environment
                   </span>
                 </DropdownMenuItem>
+                {onCreateRepository ? (
+                  <DropdownMenuItem
+                    onSelect={(event) => {
+                      event.preventDefault();
+                      onCreateRepository();
+                    }}
+                  >
+                    <span className="flex items-center gap-2">
+                      <Plus className="size-3.5" />
+                      New GitHub repository
+                    </span>
+                  </DropdownMenuItem>
+                ) : null}
               </>
             )}
 

--- a/apps/web/src/components/tasks/SelectWorkspace.tsx
+++ b/apps/web/src/components/tasks/SelectWorkspace.tsx
@@ -60,6 +60,10 @@ export const SelectWorkspace = ({
     router.push(SETTINGS_PATHS.newEnvironment);
   }, [router]);
 
+  const handleCreateRepository = useCallback(() => {
+    router.push(`${SETTINGS_PATHS.newEnvironment}?create-repo=1`);
+  }, [router]);
+
   const handleUpdateEnvironment = useCallback(
     (e: React.MouseEvent, envId: string) => {
       e.preventDefault();
@@ -106,6 +110,7 @@ export const SelectWorkspace = ({
           lockedBranch={lockedBranch}
           allowAuto={allowAuto}
           onCreate={handleCreateEnvironment}
+          onCreateRepository={handleCreateRepository}
           onEdit={handleUpdateEnvironment}
           onDelete={handleDeleteEnvironment}
         />

--- a/apps/web/src/hooks/source-control/useRepositories.ts
+++ b/apps/web/src/hooks/source-control/useRepositories.ts
@@ -8,8 +8,19 @@ type UseRepositoriesInput = {
   sourceControlProvider?: SourceControlProvider;
 };
 
-export const useRepositories = (input?: UseRepositoriesInput) => {
+type UseRepositoriesOptions = {
+  refetchInterval?: number | false;
+  refetchIntervalInBackground?: false;
+};
+
+export const useRepositories = (
+  input?: UseRepositoriesInput,
+  options?: UseRepositoriesOptions,
+) => {
   const trpc = useTRPC();
 
-  return useQuery(trpc.sourceControl.repositories.queryOptions(input));
+  return useQuery({
+    ...trpc.sourceControl.repositories.queryOptions(input),
+    ...options,
+  });
 };

--- a/apps/web/src/lib/environment-definition.test.ts
+++ b/apps/web/src/lib/environment-definition.test.ts
@@ -58,6 +58,36 @@ describe('environment definition helpers', () => {
     );
   });
 
+  it('flags empty repositories in the create prompt with bootstrap instructions', () => {
+    const prompt = buildCreateEnvironmentDefinitionPrompt(
+      ['acme/web', 'acme/new-repo'],
+      { emptyRepositoryFullNames: ['acme/new-repo'] },
+    );
+
+    expect(prompt).toContain(
+      'These repositories are brand new and have no commits yet:\n- acme/new-repo',
+    );
+    expect(prompt).toContain(
+      "follow the skill's empty-repository bootstrap: push exactly one initial commit containing only a README.md and a minimal .gitignore",
+    );
+    expect(prompt).toContain('Do not scaffold application code');
+  });
+
+  it('ignores empty-repository flags outside the selected repository set', () => {
+    const basePrompt = buildCreateEnvironmentDefinitionPrompt(['acme/web']);
+
+    expect(
+      buildCreateEnvironmentDefinitionPrompt(['acme/web'], {
+        emptyRepositoryFullNames: ['acme/other'],
+      }),
+    ).toBe(basePrompt);
+    expect(
+      buildCreateEnvironmentDefinitionPrompt(['acme/web'], {
+        emptyRepositoryFullNames: [],
+      }),
+    ).toBe(basePrompt);
+  });
+
   it('appends setup guidance only when the user provided it', () => {
     const basePrompt = buildCreateEnvironmentDefinitionPrompt(['acme/web']);
 

--- a/apps/web/src/lib/github-urls.test.ts
+++ b/apps/web/src/lib/github-urls.test.ts
@@ -1,0 +1,60 @@
+import { parseGitHubRepoReference } from './github-urls';
+
+describe('parseGitHubRepoReference', () => {
+  it('parses bare owner/repo shorthand', () => {
+    expect(parseGitHubRepoReference('RooCodeInc/Roomote')).toEqual({
+      owner: 'RooCodeInc',
+      repo: 'Roomote',
+    });
+  });
+
+  it('parses full GitHub URLs', () => {
+    expect(
+      parseGitHubRepoReference('https://github.com/RooCodeInc/Roomote'),
+    ).toEqual({ owner: 'RooCodeInc', repo: 'Roomote' });
+    expect(parseGitHubRepoReference('github.com/acme/repo')).toEqual({
+      owner: 'acme',
+      repo: 'repo',
+    });
+    expect(parseGitHubRepoReference('http://www.github.com/acme/repo')).toEqual(
+      { owner: 'acme', repo: 'repo' },
+    );
+  });
+
+  it('strips .git suffixes, extra path segments, queries, and fragments', () => {
+    expect(
+      parseGitHubRepoReference('https://github.com/acme/repo.git'),
+    ).toEqual({ owner: 'acme', repo: 'repo' });
+    expect(
+      parseGitHubRepoReference('https://github.com/acme/repo/tree/main/src'),
+    ).toEqual({ owner: 'acme', repo: 'repo' });
+    expect(
+      parseGitHubRepoReference('https://github.com/acme/repo?tab=readme'),
+    ).toEqual({ owner: 'acme', repo: 'repo' });
+    expect(
+      parseGitHubRepoReference('https://github.com/acme/repo#readme'),
+    ).toEqual({ owner: 'acme', repo: 'repo' });
+    expect(parseGitHubRepoReference('  acme/repo  ')).toEqual({
+      owner: 'acme',
+      repo: 'repo',
+    });
+  });
+
+  it('rejects values that do not identify a GitHub repository', () => {
+    expect(parseGitHubRepoReference('')).toBeNull();
+    expect(parseGitHubRepoReference('   ')).toBeNull();
+    expect(parseGitHubRepoReference('just-an-owner')).toBeNull();
+    expect(
+      parseGitHubRepoReference('https://github.com/only-owner'),
+    ).toBeNull();
+    expect(parseGitHubRepoReference('https://gitlab.com/acme/repo')).toBeNull();
+    expect(
+      parseGitHubRepoReference('https://example.com/acme/repo'),
+    ).toBeNull();
+    expect(parseGitHubRepoReference('acme//repo///')).toEqual({
+      owner: 'acme',
+      repo: 'repo',
+    });
+    expect(parseGitHubRepoReference('bad owner/repo')).toBeNull();
+  });
+});

--- a/apps/web/src/lib/github-urls.ts
+++ b/apps/web/src/lib/github-urls.ts
@@ -1,0 +1,53 @@
+type GitHubRepoReference = {
+  owner: string;
+  repo: string;
+};
+
+const OWNER_PATTERN = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,38})$/;
+const REPO_PATTERN = /^[a-zA-Z0-9._-]{1,100}$/;
+
+/**
+ * Parse a user-supplied reference to a GitHub repository. Accepts full URLs
+ * (`https://github.com/owner/repo`, with or without protocol, trailing
+ * `.git`, extra path segments, or a query string) and bare `owner/repo`
+ * shorthand. Returns null for anything that does not identify a repository.
+ */
+export function parseGitHubRepoReference(
+  value: string,
+): GitHubRepoReference | null {
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  let path = trimmed;
+
+  const urlMatch = trimmed.match(
+    /^(?:https?:\/\/)?(?:www\.)?github\.com\/(.+)$/i,
+  );
+
+  if (urlMatch?.[1]) {
+    path = urlMatch[1];
+  } else if (/^(?:https?:\/\/|www\.)/i.test(trimmed)) {
+    // A URL that is not github.com never identifies a GitHub repository.
+    return null;
+  }
+
+  const withoutFragment = path.split('#')[0] ?? '';
+  const withoutQuery = withoutFragment.split('?')[0] ?? '';
+  const segments = withoutQuery.split('/').filter(Boolean);
+
+  const owner = segments[0];
+  const repo = segments[1]?.replace(/\.git$/i, '');
+
+  if (!owner || !repo) {
+    return null;
+  }
+
+  if (!OWNER_PATTERN.test(owner) || !REPO_PATTERN.test(repo)) {
+    return null;
+  }
+
+  return { owner, repo };
+}

--- a/apps/web/src/trpc/commands/environments/index.test.ts
+++ b/apps/web/src/trpc/commands/environments/index.test.ts
@@ -3,6 +3,7 @@ const {
   mockDbSelect,
   mockEnqueueTask,
   mockGetBranches,
+  mockGetRepositoryEmptyStates,
   mockGetRepositories,
   mockBeginEnvironmentVerification,
   mockActiveVerificationRuns,
@@ -14,6 +15,7 @@ const {
     id: 'run-env-definition-1',
   }),
   mockGetBranches: vi.fn(),
+  mockGetRepositoryEmptyStates: vi.fn(async () => new Map<string, boolean>()),
   mockGetRepositories: vi.fn().mockResolvedValue([
     {
       id: 'repo-1',
@@ -38,6 +40,7 @@ vi.mock('@roomote/cloud-agents/server', () => ({
 
 vi.mock('@roomote/github', () => ({
   getBranches: mockGetBranches,
+  getRepositoryEmptyStates: mockGetRepositoryEmptyStates,
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -183,6 +186,45 @@ describe('startEnvironmentDefinitionTaskCommand', () => {
           }),
         }),
       }),
+    );
+  });
+
+  it('flags empty repositories in the kickoff prompt instead of blocking', async () => {
+    mockGetRepositoryEmptyStates.mockResolvedValueOnce(
+      new Map([
+        ['repo-1', true],
+        ['repo-2', false],
+      ]),
+    );
+
+    await startEnvironmentDefinitionTaskCommand(buildMockAuth(), {
+      repositoryIds: ['repo-2', 'repo-1'],
+    });
+
+    expect(mockGetRepositoryEmptyStates).toHaveBeenCalledWith({
+      repositoryIds: ['repo-1', 'repo-2'],
+    });
+
+    const enqueueInput = mockEnqueueTask.mock.calls[0]?.[0] as {
+      task: { payload: { description: string } };
+    };
+    // Only the empty repo appears in the bootstrap list; acme/web has
+    // commits, so the list ends right after acme/api.
+    expect(enqueueInput.task.payload.description).toContain(
+      'These repositories are brand new and have no commits yet:\n- acme/api\n\nFor each empty repository',
+    );
+  });
+
+  it('keeps the kickoff prompt unchanged when no selected repository is empty', async () => {
+    await startEnvironmentDefinitionTaskCommand(buildMockAuth(), {
+      repositoryIds: ['repo-1'],
+    });
+
+    const enqueueInput = mockEnqueueTask.mock.calls[0]?.[0] as {
+      task: { payload: { description: string } };
+    };
+    expect(enqueueInput.task.payload.description).not.toContain(
+      'brand new and have no commits',
     );
   });
 });

--- a/apps/web/src/trpc/commands/environments/index.ts
+++ b/apps/web/src/trpc/commands/environments/index.ts
@@ -828,11 +828,28 @@ export async function startEnvironmentDefinitionTaskCommand(
     throw new Error(modelSelection.error);
   }
 
-  let prompt = buildCreateEnvironmentDefinitionPrompt(
-    selectedRepositoryFullNames,
-  );
+  let prompt: string;
 
-  if (input.environmentId) {
+  if (!input.environmentId) {
+    // Brand-new repos with no commits are a supported setup target: the
+    // environment-setup skill bootstraps them with an initial commit, so the
+    // prompt flags which selected repositories are empty. Non-GitHub repos
+    // never appear in the empty-state map and are treated as non-empty.
+    const emptyStates = await GitHub.getRepositoryEmptyStates({
+      repositoryIds: selectedRepositories.map((repository) => repository.id),
+    });
+
+    const emptyRepositoryFullNames = selectedRepositories
+      .filter((repository) => emptyStates.get(repository.id) === true)
+      .map((repository) => repository.fullName);
+
+    prompt = buildCreateEnvironmentDefinitionPrompt(
+      selectedRepositoryFullNames,
+      emptyRepositoryFullNames.length > 0
+        ? { emptyRepositoryFullNames }
+        : undefined,
+    );
+  } else {
     const [environment] = await db
       .select({
         id: environments.id,

--- a/apps/web/src/trpc/commands/setup-new/index.test.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.test.ts
@@ -1131,6 +1131,36 @@ describe('setup-new onboarding task start command', () => {
     );
   });
 
+  it('launches with bootstrap instructions instead of blocking when every selected repo is empty', async () => {
+    const { getRepositoryEmptyStates } = await import('@roomote/github');
+    vi.mocked(getRepositoryEmptyStates).mockResolvedValue(
+      new Map([['repo-1', true]]),
+    );
+    mockOnboardingTransaction({ slackInstallation: null });
+
+    const result = await startSetupNewOnboardingTaskCommand(buildMockAuth());
+
+    expect(result.taskId).toBe('task-onboarding-1');
+    expect(buildSetupNewKickoffPrompt).toHaveBeenCalledWith(['acme/api'], {
+      emptyRepositoryFullNames: ['acme/api'],
+    });
+  });
+
+  it('omits the empty-repository flag when selected repos have commits', async () => {
+    const { getRepositoryEmptyStates } = await import('@roomote/github');
+    vi.mocked(getRepositoryEmptyStates).mockResolvedValue(
+      new Map([['repo-1', false]]),
+    );
+    mockOnboardingTransaction({ slackInstallation: null });
+
+    await startSetupNewOnboardingTaskCommand(buildMockAuth());
+
+    expect(buildSetupNewKickoffPrompt).toHaveBeenCalledWith(
+      ['acme/api'],
+      undefined,
+    );
+  });
+
   it('rejects a stale excluded compute provider before launch', async () => {
     vi.stubEnv('EXCLUDED_COMPUTE_PROVIDERS', 'docker');
     mockOnboardingTransaction({

--- a/apps/web/src/trpc/commands/setup-new/index.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.ts
@@ -117,7 +117,6 @@ import {
   isSetupTokenRequired,
   isSetupTokenValid,
 } from '@/lib/server';
-import { areAllRepositoriesEmpty } from '@/lib/repositories';
 import {
   appendEnvironmentDefinitionGuidance,
   buildSetupEnvironmentTaskTitle,
@@ -310,23 +309,17 @@ async function resolveSelectedRepositories(repositoryIds: string[]): Promise<{
   };
 }
 
-async function assertHasCommittedRepositorySelection(repositoryIds: string[]) {
-  const emptyStates = await GitHub.getRepositoryEmptyStates({
-    repositoryIds,
-  });
-
-  if (
-    emptyStates.size === repositoryIds.length &&
-    areAllRepositoriesEmpty(
-      [...emptyStates.values()].map((isEmpty) => ({ isEmpty })),
-    )
-  ) {
-    throw new Error(
-      emptyStates.size === 1
-        ? 'The selected repository has no commits yet. Push an initial commit first, or choose a different repository.'
-        : 'All selected repositories have no commits yet. Push an initial commit first, or choose different repositories.',
-    );
-  }
+/**
+ * Look up which selected repositories have no commits yet. Empty repos are a
+ * supported onboarding target (the environment-setup agent bootstraps them
+ * with an initial commit), so this only informs the kickoff prompt — it never
+ * blocks the selection. Non-GitHub repos are absent from the returned map and
+ * treated as non-empty.
+ */
+async function resolveRepositorySelectionEmptyStates(
+  repositoryIds: string[],
+): Promise<Map<string, boolean>> {
+  return GitHub.getRepositoryEmptyStates({ repositoryIds });
 }
 
 async function clearTaskSuggestions(
@@ -2382,7 +2375,6 @@ export async function saveSetupNewSelectionCommand(
   const { normalizedRepositoryIds } = await resolveSelectedRepositories(
     input.repositoryIds,
   );
-  await assertHasCommittedRepositorySelection(normalizedRepositoryIds);
   const nextSetupGuidance = input.setupGuidance?.trim() || null;
   const nextSelectedModelId = input.selectedModelId?.trim() || null;
 
@@ -2463,7 +2455,9 @@ export async function startSetupNewOnboardingTaskCommand(
 
     const { normalizedRepositoryIds, selectedRepositories } =
       await resolveSelectedRepositories(currentState.selectedRepositoryIds);
-    await assertHasCommittedRepositorySelection(normalizedRepositoryIds);
+    const repositoryEmptyStates = await resolveRepositorySelectionEmptyStates(
+      selectedRepositories.map((repository) => repository.id),
+    );
 
     if (selectedRepositories.length === 0) {
       throw new Error('Select at least one repository before starting setup.');
@@ -2485,8 +2479,16 @@ export async function startSetupNewOnboardingTaskCommand(
         (repository) => repository.sourceControlProvider,
       ),
     );
+    const emptyRepositoryFullNames = selectedRepositories
+      .filter((repository) => repositoryEmptyStates.get(repository.id) === true)
+      .map((repository) => repository.fullName);
     const prompt = appendEnvironmentDefinitionGuidance(
-      buildSetupNewKickoffPrompt(selectedRepositoryFullNames),
+      buildSetupNewKickoffPrompt(
+        selectedRepositoryFullNames,
+        emptyRepositoryFullNames.length > 0
+          ? { emptyRepositoryFullNames }
+          : undefined,
+      ),
       currentState.setupGuidance,
     );
     const modelSelection = resolveEvalHarnessSelection({

--- a/apps/worker/src/workspace/__tests__/workspace-manager-sync.test.ts
+++ b/apps/worker/src/workspace/__tests__/workspace-manager-sync.test.ts
@@ -47,6 +47,51 @@ const GIT_RESOLVE_REMOTE_HEAD_COMMAND = {
   continue_on_error: true,
 } as const;
 
+const GIT_CHECK_REMOTE_BRANCHES_COMMAND = {
+  name: 'Git check remote branches',
+  run: 'git ls-remote --heads origin',
+  timeout: 60,
+  retries: 1,
+  continue_on_error: true,
+} as const;
+
+const GIT_CHECK_LOCAL_COMMITS_COMMAND = {
+  name: 'Git check local commits',
+  run: 'git rev-parse --verify --quiet HEAD',
+  timeout: 60,
+  continue_on_error: true,
+} as const;
+
+function buildPointUnbornHeadCommand(branch: string) {
+  return {
+    name: 'Git point unborn HEAD at default branch',
+    run: `git symbolic-ref HEAD 'refs/heads/${branch}'`,
+    timeout: 60,
+    continue_on_error: false,
+  };
+}
+
+/**
+ * Mock sequence for an empty remote reached through the stored-default-branch
+ * path: fetch succeeds, every origin/HEAD resolution fails, the stored branch
+ * does not exist remotely, and the empty check confirms zero remote heads.
+ */
+function mockEmptyRemoteResolution(executeMock: ReturnType<typeof vi.fn>) {
+  executeMock
+    .mockResolvedValueOnce({ success: true, stdout: '', stderr: '' })
+    .mockResolvedValueOnce({ success: false, stdout: '', stderr: '' })
+    .mockResolvedValueOnce({ success: false, stdout: '', stderr: '' })
+    .mockResolvedValueOnce({ success: false, stdout: '', stderr: '' })
+    .mockResolvedValueOnce({ success: false, stdout: '', stderr: '' })
+    .mockResolvedValueOnce({
+      command: GIT_CHECK_REMOTE_BRANCHES_COMMAND,
+      success: true,
+      duration: 5,
+      stdout: '',
+      stderr: '',
+    });
+}
+
 function buildVerifyRemoteBranchCommand(branch: string) {
   return {
     name: 'Git verify remote branch',
@@ -543,7 +588,17 @@ describe('WorkspaceManager git synchronization', () => {
       .mockResolvedValueOnce({ success: false, stdout: '', stderr: '' })
       .mockResolvedValueOnce({ success: false, stdout: '', stderr: '' })
       .mockResolvedValueOnce({ success: false, stdout: '', stderr: '' })
-      .mockResolvedValueOnce({ success: false, stdout: '', stderr: '' });
+      .mockResolvedValueOnce({ success: false, stdout: '', stderr: '' })
+      // The remote has branches, so this is a real error and not an
+      // empty-repository bootstrap case.
+      .mockResolvedValueOnce({
+        command: GIT_CHECK_REMOTE_BRANCHES_COMMAND,
+        success: true,
+        duration: 5,
+        stdout:
+          '0123456789abcdef0123456789abcdef01234567\trefs/heads/develop\n',
+        stderr: '',
+      });
 
     await expect(
       syncRepositoryGitState({
@@ -556,6 +611,153 @@ describe('WorkspaceManager git synchronization', () => {
       }),
     ).rejects.toThrow(
       'Could not determine the default branch for acme/backend: origin/HEAD was unavailable and stored branch origin/main does not exist.',
+    );
+
+    expect(executor.executeAll).not.toHaveBeenCalled();
+  });
+
+  it('bootstraps an unborn branch instead of failing when the remote has no commits', async () => {
+    mockEmptyRemoteResolution(executor.execute);
+    executor.execute
+      // No local commits either: the workspace is a fresh clone.
+      .mockResolvedValueOnce({
+        command: GIT_CHECK_LOCAL_COMMITS_COMMAND,
+        success: false,
+        duration: 5,
+        stdout: '',
+        stderr: '',
+      })
+      .mockResolvedValueOnce({ success: true, stdout: '', stderr: '' });
+
+    await syncRepositoryGitState({
+      executor,
+      repoFullName: 'acme/new-repo',
+      targetBranch: 'main',
+      repositoryId: 'repo-1',
+      allowRemoteHeadFallback: true,
+      setDefaultRemote: false,
+    });
+
+    expect(executor.execute).toHaveBeenNthCalledWith(
+      6,
+      GIT_CHECK_REMOTE_BRANCHES_COMMAND,
+    );
+    expect(executor.execute).toHaveBeenNthCalledWith(
+      7,
+      GIT_CHECK_LOCAL_COMMITS_COMMAND,
+    );
+    expect(executor.execute).toHaveBeenNthCalledWith(
+      8,
+      buildPointUnbornHeadCommand('main'),
+    );
+    expect(executor.executeAll).not.toHaveBeenCalled();
+  });
+
+  it('still sets the default remote repo when bootstrapping an empty repository', async () => {
+    mockEmptyRemoteResolution(executor.execute);
+    executor.execute
+      .mockResolvedValueOnce({
+        command: GIT_CHECK_LOCAL_COMMITS_COMMAND,
+        success: false,
+        duration: 5,
+        stdout: '',
+        stderr: '',
+      })
+      .mockResolvedValueOnce({ success: true, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ success: true, stdout: '', stderr: '' });
+
+    await syncRepositoryGitState({
+      executor,
+      repoFullName: 'acme/new-repo',
+      targetBranch: 'main',
+      repositoryId: 'repo-1',
+      allowRemoteHeadFallback: true,
+      setDefaultRemote: true,
+    });
+
+    expect(executor.execute).toHaveBeenLastCalledWith({
+      name: 'Set default remote repo.',
+      run: "gh repo set-default 'acme/new-repo'",
+      timeout: 60,
+      continue_on_error: true,
+    });
+  });
+
+  it('preserves local commits when the remote is empty in a reused workspace', async () => {
+    mockEmptyRemoteResolution(executor.execute);
+    executor.execute
+      // Local commits exist: an earlier bootstrap attempt committed work
+      // that has not been pushed yet.
+      .mockResolvedValueOnce({
+        command: GIT_CHECK_LOCAL_COMMITS_COMMAND,
+        success: true,
+        duration: 5,
+        stdout: '0123456789abcdef0123456789abcdef01234567\n',
+        stderr: '',
+      });
+
+    await syncRepositoryGitState({
+      executor,
+      repoFullName: 'acme/new-repo',
+      targetBranch: 'main',
+      repositoryId: 'repo-1',
+      allowRemoteHeadFallback: true,
+      setDefaultRemote: false,
+    });
+
+    expect(executor.execute).toHaveBeenCalledTimes(7);
+    expect(executor.execute).not.toHaveBeenCalledWith(
+      buildPointUnbornHeadCommand('main'),
+    );
+    expect(executor.executeAll).not.toHaveBeenCalled();
+  });
+
+  it('rejects sha pins against an empty remote with a clear error', async () => {
+    mockEmptyRemoteResolution(executor.execute);
+
+    await expect(
+      syncRepositoryGitState({
+        executor,
+        repoFullName: 'acme/new-repo',
+        targetBranch: 'main',
+        sha: '0123456789abcdef0123456789abcdef01234567',
+        repositoryId: 'repo-1',
+        allowRemoteHeadFallback: true,
+        setDefaultRemote: false,
+      }),
+    ).rejects.toThrow(
+      'Cannot pin acme/new-repo to 0123456789abcdef0123456789abcdef01234567: the remote repository has no commits.',
+    );
+
+    expect(executor.executeAll).not.toHaveBeenCalled();
+  });
+
+  it('rethrows the branch resolution error when the empty-remote check itself fails', async () => {
+    executor.execute
+      .mockResolvedValueOnce({ success: true, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ success: false, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ success: false, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ success: false, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ success: false, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({
+        command: GIT_CHECK_REMOTE_BRANCHES_COMMAND,
+        success: false,
+        duration: 5,
+        stdout: '',
+        stderr: 'fatal: could not query remote',
+      });
+
+    await expect(
+      syncRepositoryGitState({
+        executor,
+        repoFullName: 'acme/backend',
+        targetBranch: 'main',
+        repositoryId: 'repo-1',
+        allowRemoteHeadFallback: true,
+        setDefaultRemote: false,
+      }),
+    ).rejects.toThrow(
+      'Could not determine the default branch for acme/backend',
     );
 
     expect(executor.executeAll).not.toHaveBeenCalled();

--- a/apps/worker/src/workspace/workspace-manager.ts
+++ b/apps/worker/src/workspace/workspace-manager.ts
@@ -862,12 +862,33 @@ export class WorkspaceManager {
       }),
     );
 
-    const checkoutBranch = await this.resolveCheckoutBranch({
-      executor,
-      repoFullName,
-      targetBranch,
-      allowRemoteHeadFallback,
-    });
+    let checkoutBranch: string;
+
+    try {
+      checkoutBranch = await this.resolveCheckoutBranch({
+        executor,
+        repoFullName,
+        targetBranch,
+        allowRemoteHeadFallback,
+      });
+    } catch (error) {
+      // A branch that cannot be resolved is usually a real error, but a
+      // brand-new repository legitimately has no branches yet (for example
+      // one just created through github.com/new without a README). Only that
+      // confirmed-empty case is handled specially; anything else rethrows.
+      if (await this.remoteHasNoBranches(executor)) {
+        await this.prepareEmptyRepositoryWorktree({
+          executor,
+          repoFullName,
+          targetBranch,
+          sha,
+          setDefaultRemote,
+        });
+        return;
+      }
+
+      throw error;
+    }
 
     if (
       allowRemoteHeadFallback &&
@@ -944,6 +965,85 @@ export class WorkspaceManager {
             ]
           : []),
       ]),
+    );
+  }
+
+  /**
+   * A brand-new repository can have no branches at all (for example one just
+   * created through github.com/new without a README). An errorless
+   * `git ls-remote --heads` with no output is the ground truth for that
+   * state; a failed lookup is treated as non-empty so real errors surface
+   * through the normal checkout path.
+   */
+  private async remoteHasNoBranches(
+    executor: CommandExecutor,
+  ): Promise<boolean> {
+    const result = await executor.execute({
+      name: 'Git check remote branches',
+      run: 'git ls-remote --heads origin',
+      timeout: 60,
+      retries: 1,
+      continue_on_error: true,
+    });
+
+    return result.success && (result.stdout ?? '').trim() === '';
+  }
+
+  /**
+   * Prepare a worktree for a repository whose remote has no commits. The
+   * checkout/reset command block requires `origin/<branch>` refs that do not
+   * exist yet, so it is skipped entirely; the unborn local branch is instead
+   * pointed at the stored default branch (GitHub reports `default_branch`
+   * even for empty repositories) so the first commit lands where the remote
+   * expects it. Local commits are preserved: a reused workspace mid-bootstrap
+   * may hold work that has not been pushed yet.
+   */
+  private async prepareEmptyRepositoryWorktree({
+    executor,
+    repoFullName,
+    targetBranch,
+    sha,
+    setDefaultRemote,
+  }: {
+    executor: CommandExecutor;
+    repoFullName: string;
+    targetBranch: string;
+    sha?: string;
+    setDefaultRemote: boolean;
+  }): Promise<void> {
+    if (sha) {
+      throw new Error(
+        `Cannot pin ${repoFullName} to ${sha}: the remote repository has no commits.`,
+      );
+    }
+
+    const localHead = await executor.execute({
+      name: 'Git check local commits',
+      run: 'git rev-parse --verify --quiet HEAD',
+      timeout: 60,
+      continue_on_error: true,
+    });
+
+    if (!localHead.success) {
+      await executor.execute({
+        name: 'Git point unborn HEAD at default branch',
+        run: `git symbolic-ref HEAD 'refs/heads/${shellEscape(targetBranch)}'`,
+        timeout: 60,
+        continue_on_error: false,
+      });
+    }
+
+    if (setDefaultRemote) {
+      await executor.execute({
+        name: 'Set default remote repo.',
+        run: `gh repo set-default '${shellEscape(repoFullName)}'`,
+        timeout: 60,
+        continue_on_error: true,
+      });
+    }
+
+    console.log(
+      `Remote for ${repoFullName} has no commits yet; prepared an empty-repository worktree on branch ${targetBranch}.`,
     );
   }
 

--- a/packages/cloud-agents/src/server/workflows/__tests__/environmentSetupSkill.test.ts
+++ b/packages/cloud-agents/src/server/workflows/__tests__/environmentSetupSkill.test.ts
@@ -34,6 +34,30 @@ describe('environment-setup guidance', () => {
     );
   });
 
+  it('bootstraps empty repositories with a minimal initial commit only', () => {
+    const skillContent = readSkillContent();
+
+    expect(skillContent).toContain(
+      'Bootstrap an empty repository before analysis',
+    );
+    expect(skillContent).toContain(
+      'create exactly one bootstrap commit containing only a `README.md`',
+    );
+    expect(skillContent).toContain(
+      'Do not scaffold application code, frameworks, package manifests, CI config, or anything beyond those two files',
+    );
+    expect(skillContent).toContain('Never force-push.');
+    expect(skillContent).toContain(
+      'If the repository has any commits, skip this step entirely and continue with normal analysis.',
+    );
+    expect(skillContent).toContain(
+      'Do not invent install, dev, or test commands for code that does not exist.',
+    );
+    expect(skillContent).toContain(
+      'it should confirm the workspace clones and environment setup completes cleanly, not expect a running service, test suite, or localhost surface',
+    );
+  });
+
   it('allows revising an existing environment instead of always creating a new one', () => {
     const skillContent = readSkillContent();
 

--- a/packages/cloud-agents/src/server/workflows/skills/standard/environment-setup/SKILL.md
+++ b/packages/cloud-agents/src/server/workflows/skills/standard/environment-setup/SKILL.md
@@ -31,6 +31,22 @@ You are an expert Roomote environment analyst. Analyze the already-checked-out r
         <validation>The repository target and branch baseline are explicit before config drafting starts.</validation>
       </step>
 
+      <step number="1a">
+        <title>Bootstrap an empty repository before analysis</title>
+        <description>A brand-new repository with no commits (for example one just created on github.com) cannot be analyzed or validated until it has an initial commit. Give it the smallest possible bootstrap, then continue normally.</description>
+        <actions>
+          <action>Detect emptiness from the checked-out workspace: `git log --oneline -1` failing (unborn HEAD) together with an effectively empty worktree means the repository has no commits yet. If the repository has any commits, skip this step entirely and continue with normal analysis.</action>
+          <action>When the repository is empty, create exactly one bootstrap commit containing only a `README.md` (the repository name as a title plus a line noting that Roomote initialized the repository) and a minimal general-purpose `.gitignore`. Do not scaffold application code, frameworks, package manifests, CI config, or anything beyond those two files; building the actual project is the user's next task, not part of environment setup.</action>
+          <action>Commit directly to the branch the workspace is already on (the unborn branch was already pointed at the repository's stored default branch) and push it with `git push -u origin <default-branch>`. Never force-push.</action>
+          <action>If the push is rejected because commits appeared on the remote in the meantime, discard the bootstrap commit, fetch, check out the remote default branch, and continue as a normal non-empty repository.</action>
+          <action>After the bootstrap push succeeds, continue the normal workflow against the now-initialized repository and expect the resulting environment definition to be minimal: typically the repository mapping alone with no commands, services, docker projects, or ports, because there is no application to install, test, or start yet. Do not invent install, dev, or test commands for code that does not exist.</action>
+          <action>When launching the follow-up verification task for such a minimal environment, adapt the verification prompt to what actually exists: it should confirm the workspace clones and environment setup completes cleanly, not expect a running service, test suite, or localhost surface.</action>
+          <action>In `agentInstructions`, note that the repository was newly initialized by Roomote and contains no application code yet.</action>
+          <action>In the final handoff, say that the repository was brand new, that Roomote pushed the initial commit, and that the user's next task can start building the actual project.</action>
+        </actions>
+        <validation>An empty repository receives exactly one README plus .gitignore bootstrap commit on its default branch; a repository with any existing commits is untouched by this step.</validation>
+      </step>
+
       <step number="2">
         <title>Inspect static repository evidence</title>
         <description>Collect only evidence that supports concrete environment fields.</description>
@@ -304,6 +320,8 @@ You are an expert Roomote environment analyst. Analyze the already-checked-out r
 <rule>Use `repositories[].commands` only for executing commands and setting configuration needed to validate the environment.</rule>
 <rule>If setup requires configuration or runtime file creation or modification, represent it with `repositories[].commands` entries instead of asking the user to edit files directly.</rule>
 <rule>Do not use `repositories[].commands` to write, generate, or patch application or source code; if source changes are required, report that as a blocker or separate follow-up work.</rule>
+<rule>When the target repository has no commits at all, bootstrap it with exactly one commit containing only `README.md` and `.gitignore` pushed to its default branch; never force-push, and never scaffold application code, frameworks, package manifests, or CI config during environment setup.</rule>
+<rule>For a just-bootstrapped repository, keep the environment definition minimal (typically the repository mapping with no commands, services, or ports) instead of inventing commands for application code that does not exist yet.</rule>
 <rule>Treat each `run` field as newline-split before execution. Do not rely on YAML multiline blocks to preserve shell control flow across lines.</rule>
 <rule>Do not emit YAML `run: |` blocks for `if ... fi`, `case`, loops, heredocs, or multiline shell functions unless the entire block is wrapped inside one explicit shell command such as `bash -lc '...'`.</rule>
 <rule>When setup logic needs conditional or multiline behavior, prefer multiple simple command entries or one explicit shell wrapper command over raw multiline shell fragments.</rule>

--- a/packages/types/src/environment-definition-tasks.ts
+++ b/packages/types/src/environment-definition-tasks.ts
@@ -50,6 +50,7 @@ export function normalizeRepositorySelection(
 
 export function buildCreateEnvironmentDefinitionPrompt(
   repositoryFullNames: string[],
+  options?: { emptyRepositoryFullNames?: string[] },
 ): string {
   const sortedRepositories = [...repositoryFullNames].sort((left, right) =>
     left.localeCompare(right),
@@ -59,10 +60,25 @@ export function buildCreateEnvironmentDefinitionPrompt(
     .map((repositoryFullName) => `- ${repositoryFullName}`)
     .join('\n');
 
+  const emptyRepositories = [...(options?.emptyRepositoryFullNames ?? [])]
+    .filter((fullName) => repositoryFullNames.includes(fullName))
+    .sort((left, right) => left.localeCompare(right));
+
+  // Restate the skill's empty-repository bootstrap rules inline so a worker
+  // whose packaged environment-setup skill predates the bootstrap section
+  // still degrades gracefully instead of failing on the empty checkout.
+  const emptyRepositorySection =
+    emptyRepositories.length > 0
+      ? `\n\nThese repositories are brand new and have no commits yet:
+${emptyRepositories.map((fullName) => `- ${fullName}`).join('\n')}
+
+For each empty repository, follow the skill's empty-repository bootstrap: push exactly one initial commit containing only a README.md and a minimal .gitignore to its default branch (never force-push), then define the smallest valid environment for it — typically the repository mapping alone, with no commands, services, or ports. Do not scaffold application code, frameworks, package manifests, or CI config; building the actual project is the user's next task.`
+      : '';
+
   return `$environment-setup
 
 Set up a ${PRODUCT_NAME} environment for this repository set:
-${repositoryLines}
+${repositoryLines}${emptyRepositorySection}
 
 Focus on the smallest correct environment that gets this setup target running locally.
 Use a plain, stable environment name based on the product or repository name. Do not append qualifiers like "Localhost", "Minimal", or similar unless the user explicitly asked for that distinction.


### PR DESCRIPTION
## What

Makes brand-new GitHub repositories a first-class setup target instead of a dead end. Users can now click "Create a new repository" in Roomote, create the repo (or fork one by URL) on github.com, and have Roomote pick it up automatically, bootstrap it if it's empty, and set up a basic environment — no repo-creation API permissions required.

## Why

Today repos only enter Roomote via GitHub App installation sync, and empty repos hit a hard wall: onboarding blocks with "Push an initial commit before continuing." Going from "I want a new project" to a working environment required manual round trips through GitHub and git. Creating repos via API would have required `administration:write` on the App manifest (with a manual permission-update step for every existing self-hosted App, and no coverage for personal accounts) — so instead the flow sends the user to `github.com/new` and automates everything after that click.

## How

**Backend**
- New `handleInstallationRepositoriesChange` webhook handler registered for `installation_repositories.added/removed` (selected-repos installs) and `repository.created/deleted/renamed` (all-repos installs), performing a full `syncGitHubInstallation` resync. No manifest change needed: `installation_repositories` is auto-delivered to GitHub Apps and `Repository` is already in `GITHUB_APP_DEFAULT_EVENTS`.
- Worker: `syncRepositoryGitState` now detects a branchless remote in the branch-resolution failure path, points the unborn HEAD at the stored default branch, and skips the remote-ref sync steps. SHA pins against empty remotes throw a clear error; local commits in a reused workspace are preserved.
- Environment-setup skill: new "Bootstrap an empty repository" step — push exactly one initial commit (README + .gitignore) to the default branch, never force-push, then define the smallest valid environment. Explicitly no app scaffolding; building the project is the user's first task.
- `buildCreateEnvironmentDefinitionPrompt` gains optional `emptyRepositoryFullNames` (byte-identical output when absent; the prompt restates bootstrap rules inline as an N-1 fallback for worker images whose packaged skill predates the section). The onboarding `assertHasCommittedRepositorySelection` throw is removed — empty selections proceed.

**Web UI**
- New `CreateGitHubRepoDialog`: "New repository" tab (opens `github.com/new?owner=<login>` with the installation owner prefilled) and "Fork existing" tab (paste a URL or `owner/repo` → GitHub's fork page). Polls the repository list while open, syncs on return to the tab, offers manual refresh and the inline Update GitHub flow, and surfaces newly appeared repos with a "Use this repository" action.
- Wired into onboarding repo selection (empty-repo wall becomes an informational note with Continue enabled), Settings > Environments > New (including a `?create-repo=1` deep link), and the workspace picker (admin-only "New GitHub repository" item).
- Docs: "Start from a brand-new repository" section in `environments.mdx`; webhook-event note in the GitHub provider guide (apps predating the `Repository` default event should confirm it's enabled — there's no API to update app event subscriptions).

Zero DB schema changes.

## Testing

- New/extended unit tests across `apps/api` (webhook handler, known-installation gating), `apps/worker` (empty-remote sync paths), `packages/cloud-agents` (skill guardrails), `packages/types`/`apps/web` (prompt builder variants, command plumbing, dialog, onboarding step, environments page, workspace picker).
- `pnpm lint`, `pnpm check-types`, and `pnpm knip` pass.
- Still owed before merge (needs a live deployment + GitHub App): confirm `installation_repositories.added` deliveries arrive for a manifest-created App, and one end-to-end run of create-empty-repo → auto-detect → bootstrap → verified environment.