### PR TITLE
[Fix] Use enumerated tool denials so structured output keeps working

### DIFF
--- a/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
@@ -368,6 +368,18 @@ describe('resolveOpenCodeSmallModel', () => {
     expect(sessionPermissions.every((rule) => rule.permission !== '*')).toBe(
       true,
     );
+    // The per-prompt tool filter is the fail-closed layer for tools the
+    // enumerated denials cannot name (MCP/plugin tools on external servers):
+    // everything off, with OpenCode's internal StructuredOutput tool as the
+    // only exception so `format: json_schema` keeps working.
+    const promptTools = sessionPromptMock.mock.calls[0]?.[0]?.tools as Record<
+      string,
+      boolean
+    >;
+    expect(promptTools).toEqual({ '*': false, StructuredOutput: true });
+    expect(
+      Object.entries(promptTools).filter(([, enabled]) => enabled),
+    ).toEqual([['StructuredOutput', true]]);
     expect(sessionPromptMock).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionID: 'session-1',

--- a/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
@@ -347,7 +347,14 @@ describe('resolveOpenCodeSmallModel', () => {
       {
         directory: expect.stringContaining('roomote-non-task-'),
         title: `Roomote ${NON_TASK_INFERENCE_SURFACES.routerTaskRouting}`,
-        permission: [{ permission: '*', pattern: '*', action: 'deny' }],
+        // Enumerated denials, never a `*` wildcard: a wildcard also strips
+        // the internal structured-output mechanism `format: json_schema`
+        // relies on.
+        permission: expect.arrayContaining([
+          { permission: 'edit', pattern: '*', action: 'deny' },
+          { permission: 'bash', pattern: '*', action: 'deny' },
+          { permission: 'read', pattern: '*', action: 'deny' },
+        ]),
       },
       expect.objectContaining({
         signal: expect.any(AbortSignal),
@@ -356,6 +363,11 @@ describe('resolveOpenCodeSmallModel', () => {
     const sessionDirectory = sessionCreateMock.mock.calls[0]?.[0]
       ?.directory as string;
     expect(sessionDirectory).not.toBe(process.cwd());
+    const sessionPermissions = sessionCreateMock.mock.calls[0]?.[0]
+      ?.permission as Array<{ permission: string }>;
+    expect(sessionPermissions.every((rule) => rule.permission !== '*')).toBe(
+      true,
+    );
     expect(sessionPromptMock).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionID: 'session-1',

--- a/packages/cloud-agents/src/server/__tests__/opencode-runtime.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/opencode-runtime.test.ts
@@ -194,11 +194,11 @@ describe('buildOpenCodeCliEnv', () => {
     });
   });
 
-  it('merges the tool denial into operator-supplied config content', () => {
+  it('keeps model and provider config from operator-supplied content', () => {
     const env = buildOpenCodeCliEnv({
       OPENCODE_CONFIG_CONTENT: JSON.stringify({
         model: 'openrouter/openai/gpt-5.4',
-        theme: 'dark',
+        provider: { openrouter: { options: { baseURL: 'https://example' } } },
         // An operator-supplied allow must not survive: these servers only
         // serve non-task calls, which never run tools.
         permission: 'allow',
@@ -207,26 +207,32 @@ describe('buildOpenCodeCliEnv', () => {
 
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
       model: 'openrouter/openai/gpt-5.4',
-      theme: 'dark',
+      provider: { openrouter: { options: { baseURL: 'https://example' } } },
       permission: NON_TASK_TOOL_PERMISSION_DENIALS,
     });
   });
 
-  it('keeps operator per-tool entries we do not enumerate while denying the rest', () => {
+  it('strips config keys that can introduce or re-enable tools', () => {
     const env = buildOpenCodeCliEnv({
       OPENCODE_CONFIG_CONTENT: JSON.stringify({
-        permission: {
-          some_future_tool: 'ask',
-          bash: 'allow',
-        },
+        model: 'openrouter/openai/gpt-5.4',
+        // Each of these can add tools outside the enumerated denial list
+        // (or re-enable built-ins), so none may reach a helper server.
+        mcp: { docs: { type: 'remote', url: 'https://example/mcp' } },
+        plugin: ['some-plugin'],
+        agent: { build: { tools: { bash: true } } },
+        mode: { build: { tools: { edit: true } } },
+        tools: { bash: true },
+        default_agent: 'build',
+        // Operator permission entries never survive, including entries for
+        // tools we do not enumerate.
+        permission: { docs_search: 'allow', bash: 'allow' },
       }),
     });
 
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
-      permission: {
-        some_future_tool: 'ask',
-        ...NON_TASK_TOOL_PERMISSION_DENIALS,
-      },
+      model: 'openrouter/openai/gpt-5.4',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
     });
   });
 

--- a/packages/cloud-agents/src/server/__tests__/opencode-runtime.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/opencode-runtime.test.ts
@@ -8,6 +8,7 @@ import {
   buildOpenCodeCliEnv,
   killOpenCodeSdkServerProcessesForShutdown,
   leaseOpenCodeSdkServer,
+  NON_TASK_TOOL_PERMISSION_DENIALS,
   readOpenCodeDebugConfig,
 } from '../opencode-runtime';
 
@@ -52,7 +53,7 @@ describe('buildOpenCodeCliEnv', () => {
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
       model: 'openrouter/openai/gpt-5.4',
       small_model: 'openrouter/openai/gpt-5.4',
-      permission: 'deny',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
     });
   });
 
@@ -67,7 +68,7 @@ describe('buildOpenCodeCliEnv', () => {
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
       model: 'openrouter/openai/gpt-5.4',
       small_model: 'openrouter/z-ai/glm-5.2',
-      permission: 'deny',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
       provider: {
         openrouter: {
           models: {
@@ -92,7 +93,7 @@ describe('buildOpenCodeCliEnv', () => {
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
       model: 'openrouter/z-ai/glm-5.2',
       small_model: 'openrouter/z-ai/glm-5.2',
-      permission: 'deny',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
       provider: {
         openrouter: {
           models: {
@@ -117,7 +118,7 @@ describe('buildOpenCodeCliEnv', () => {
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
       model: 'openrouter/z-ai/glm-5.2',
       small_model: 'openrouter/z-ai/glm-5.2',
-      permission: 'deny',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
       provider: {
         openrouter: {
           models: {
@@ -139,7 +140,7 @@ describe('buildOpenCodeCliEnv', () => {
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
       model: 'openrouter/openai/gpt-5.4',
       small_model: 'openrouter/openai/gpt-5.4',
-      permission: 'deny',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
       provider: {
         openrouter: {
           models: {
@@ -181,7 +182,7 @@ describe('buildOpenCodeCliEnv', () => {
     expect(env.MISTRAL_API_KEY).toBeUndefined();
     // No model-backed config remains, but the tool lockdown still applies.
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
-      permission: 'deny',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
     });
   });
 
@@ -189,7 +190,7 @@ describe('buildOpenCodeCliEnv', () => {
     const env = buildOpenCodeCliEnv();
 
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
-      permission: 'deny',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
     });
   });
 
@@ -207,8 +208,38 @@ describe('buildOpenCodeCliEnv', () => {
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
       model: 'openrouter/openai/gpt-5.4',
       theme: 'dark',
-      permission: 'deny',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
     });
+  });
+
+  it('keeps operator per-tool entries we do not enumerate while denying the rest', () => {
+    const env = buildOpenCodeCliEnv({
+      OPENCODE_CONFIG_CONTENT: JSON.stringify({
+        permission: {
+          some_future_tool: 'ask',
+          bash: 'allow',
+        },
+      }),
+    });
+
+    expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
+      permission: {
+        some_future_tool: 'ask',
+        ...NON_TASK_TOOL_PERMISSION_DENIALS,
+      },
+    });
+  });
+
+  it('never uses a blanket permission denial', () => {
+    // Regression guard: OpenCode fulfils `format: json_schema` structured
+    // output through an internal mechanism that a blanket "deny" (or a
+    // wildcard rule) strips, silently breaking every structured routing
+    // call. The denial must stay in enumerated object form.
+    expect(typeof NON_TASK_TOOL_PERMISSION_DENIALS).toBe('object');
+    expect(Object.keys(NON_TASK_TOOL_PERMISSION_DENIALS)).not.toContain('*');
+    expect(Object.values(NON_TASK_TOOL_PERMISSION_DENIALS)).toEqual(
+      Object.keys(NON_TASK_TOOL_PERMISSION_DENIALS).map(() => 'deny'),
+    );
   });
 
   it('fails closed to a permission-only config on malformed content', () => {
@@ -218,7 +249,7 @@ describe('buildOpenCodeCliEnv', () => {
       });
 
       expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
-        permission: 'deny',
+        permission: NON_TASK_TOOL_PERMISSION_DENIALS,
       });
     }
   });

--- a/packages/cloud-agents/src/server/non-task-provider-usage.ts
+++ b/packages/cloud-agents/src/server/non-task-provider-usage.ts
@@ -13,6 +13,7 @@ import zodToJsonSchema from 'zod-to-json-schema';
 import {
   DEFAULT_OPENCODE_SDK_SERVER_START_TIMEOUT_MS,
   leaseOpenCodeSdkServer,
+  NON_TASK_TOOL_PERMISSION_DENIALS,
   readOpenCodeDebugConfig,
 } from './opencode-runtime';
 
@@ -24,10 +25,14 @@ const DEFAULT_OPENCODE_STRUCTURED_OUTPUT_RETRY_COUNT = 2;
  * (`withDeniedToolPermissions` in opencode-runtime), and this per-session
  * ruleset keeps a stale or externally configured server
  * (`OPENCODE_SDK_SERVER_URL`) equally locked down.
+ *
+ * Enumerated per tool rather than a `*` wildcard: a wildcard rule also
+ * strips the internal mechanism OpenCode uses for `format: json_schema`
+ * structured output, breaking every structured routing call.
  */
-const NON_TASK_SESSION_PERMISSIONS: PermissionRuleset = [
-  { permission: '*', pattern: '*', action: 'deny' },
-];
+const NON_TASK_SESSION_PERMISSIONS: PermissionRuleset = Object.keys(
+  NON_TASK_TOOL_PERMISSION_DENIALS,
+).map((permission) => ({ permission, pattern: '*', action: 'deny' }));
 
 let nonTaskSessionDirectory: string | undefined;
 

--- a/packages/cloud-agents/src/server/non-task-provider-usage.ts
+++ b/packages/cloud-agents/src/server/non-task-provider-usage.ts
@@ -28,7 +28,11 @@ const DEFAULT_OPENCODE_STRUCTURED_OUTPUT_RETRY_COUNT = 2;
  *
  * Enumerated per tool rather than a `*` wildcard: a wildcard rule also
  * strips the internal mechanism OpenCode uses for `format: json_schema`
- * structured output, breaking every structured routing call.
+ * structured output, breaking every structured routing call. On managed
+ * servers the config allowlist guarantees no tools exist beyond the
+ * enumerated built-ins; an externally configured server
+ * (`OPENCODE_SDK_SERVER_URL`) owns its own config, so any custom tools it
+ * defines are the operator's responsibility.
  */
 const NON_TASK_SESSION_PERMISSIONS: PermissionRuleset = Object.keys(
   NON_TASK_TOOL_PERMISSION_DENIALS,

--- a/packages/cloud-agents/src/server/non-task-provider-usage.ts
+++ b/packages/cloud-agents/src/server/non-task-provider-usage.ts
@@ -28,15 +28,29 @@ const DEFAULT_OPENCODE_STRUCTURED_OUTPUT_RETRY_COUNT = 2;
  *
  * Enumerated per tool rather than a `*` wildcard: a wildcard rule also
  * strips the internal mechanism OpenCode uses for `format: json_schema`
- * structured output, breaking every structured routing call. On managed
- * servers the config allowlist guarantees no tools exist beyond the
- * enumerated built-ins; an externally configured server
- * (`OPENCODE_SDK_SERVER_URL`) owns its own config, so any custom tools it
- * defines are the operator's responsibility.
+ * structured output, breaking every structured routing call.
  */
 const NON_TASK_SESSION_PERMISSIONS: PermissionRuleset = Object.keys(
   NON_TASK_TOOL_PERMISSION_DENIALS,
 ).map((permission) => ({ permission, pattern: '*', action: 'deny' }));
+
+/**
+ * Per-prompt tool filter: disable every registered tool — including MCP or
+ * plugin tools an externally configured server (`OPENCODE_SDK_SERVER_URL`)
+ * may define, which the enumerated permission denials cannot name — except
+ * OpenCode's internal `StructuredOutput` tool, which fulfils
+ * `format: json_schema`.
+ *
+ * The exact-name exception is deliberate: the `*` glob alone also removes
+ * `StructuredOutput` and breaks structured calls. If a future OpenCode
+ * release renames that internal tool, structured calls fail loudly ("Model
+ * did not produce structured output") rather than any tool becoming
+ * executable — this filter fails closed.
+ */
+const NON_TASK_SESSION_TOOL_DISABLES: Record<string, boolean> = {
+  '*': false,
+  StructuredOutput: true,
+};
 
 let nonTaskSessionDirectory: string | undefined;
 
@@ -334,6 +348,7 @@ async function runNonTaskSdkPrompt(
         sessionID: sessionResult.data.id,
         directory: sessionDirectory,
         model: splitOpenCodeModelId(model),
+        tools: NON_TASK_SESSION_TOOL_DISABLES,
         ...promptOptions,
       },
       { signal: abortController.signal },

--- a/packages/cloud-agents/src/server/opencode-runtime.ts
+++ b/packages/cloud-agents/src/server/opencode-runtime.ts
@@ -92,8 +92,36 @@ function buildModelBackedOpenCodeConfigContent(
 }
 
 /**
- * Force OpenCode's blanket tool-permission denial into a config content
- * string, preserving any other operator-supplied settings.
+ * Per-tool permission denials for the non-task helper servers, covering
+ * every tool OpenCode's permission config enumerates.
+ *
+ * Deliberately the enumerated object form, NOT the blanket `"deny"` string:
+ * OpenCode fulfils `format: json_schema` structured output through an
+ * internal mechanism that a blanket denial (or a wildcard session rule)
+ * strips along with the real tools, which silently breaks every structured
+ * routing call while plain-text calls keep working. The object form denies
+ * only the listed tools and leaves that mechanism available.
+ */
+export const NON_TASK_TOOL_PERMISSION_DENIALS = {
+  read: 'deny',
+  edit: 'deny',
+  glob: 'deny',
+  grep: 'deny',
+  list: 'deny',
+  bash: 'deny',
+  task: 'deny',
+  external_directory: 'deny',
+  todowrite: 'deny',
+  question: 'deny',
+  webfetch: 'deny',
+  websearch: 'deny',
+  lsp: 'deny',
+  skill: 'deny',
+} as const;
+
+/**
+ * Force the non-task tool denials into a config content string, preserving
+ * any other operator-supplied settings.
  *
  * The servers this module spawns exist only for non-task inference — task
  * titles, routing, fast-agent answers — which is plain text or structured
@@ -108,7 +136,9 @@ function buildModelBackedOpenCodeConfigContent(
  * tools enabled.
  */
 function withDeniedToolPermissions(configContent: string | undefined): string {
-  const permissionOnly = JSON.stringify({ permission: 'deny' });
+  const permissionOnly = JSON.stringify({
+    permission: NON_TASK_TOOL_PERMISSION_DENIALS,
+  });
 
   if (!configContent?.trim()) {
     return permissionOnly;
@@ -125,7 +155,24 @@ function withDeniedToolPermissions(configContent: string | undefined): string {
       return permissionOnly;
     }
 
-    return JSON.stringify({ ...parsed, permission: 'deny' });
+    const config = parsed as Record<string, unknown>;
+    // Keep operator per-tool entries for tools we do not enumerate, but our
+    // denials win on overlap. A non-object operator `permission` (e.g. a
+    // blanket "allow") is discarded entirely.
+    const operatorPermission =
+      typeof config.permission === 'object' &&
+      config.permission !== null &&
+      !Array.isArray(config.permission)
+        ? (config.permission as Record<string, unknown>)
+        : {};
+
+    return JSON.stringify({
+      ...config,
+      permission: {
+        ...operatorPermission,
+        ...NON_TASK_TOOL_PERMISSION_DENIALS,
+      },
+    });
   } catch {
     return permissionOnly;
   }

--- a/packages/cloud-agents/src/server/opencode-runtime.ts
+++ b/packages/cloud-agents/src/server/opencode-runtime.ts
@@ -120,8 +120,25 @@ export const NON_TASK_TOOL_PERMISSION_DENIALS = {
 } as const;
 
 /**
- * Force the non-task tool denials into a config content string, preserving
- * any other operator-supplied settings.
+ * Config keys forwarded to non-task helper servers. Everything else is
+ * dropped: OpenCode config can introduce or re-enable tools through several
+ * other keys (`mcp` servers, `plugin`, `agent`/`mode` overrides, global
+ * `tools` toggles), and any tool from those sources would fall outside
+ * {@link NON_TASK_TOOL_PERMISSION_DENIALS}. Allowlisting model/provider
+ * selection keeps the server's toolset exactly the built-in one, which the
+ * enumerated denials fully cover.
+ */
+const NON_TASK_CONFIG_ALLOWED_KEYS = [
+  'model',
+  'small_model',
+  'provider',
+  'disabled_providers',
+  'enabled_providers',
+] as const;
+
+/**
+ * Reduce a config content string to the model/provider allowlist plus the
+ * non-task tool denials.
  *
  * The servers this module spawns exist only for non-task inference — task
  * titles, routing, fast-agent answers — which is plain text or structured
@@ -130,12 +147,16 @@ export const NON_TASK_TOOL_PERMISSION_DENIALS = {
  * prompt (a task description saying "add some dinosaurs") can cause the
  * control plane to edit its own working directory.
  *
- * Malformed operator config fails closed to a permission-only config: every
- * non-task call passes its model explicitly, so dropping model-backed
- * defaults keeps text generation working while never booting a server with
- * tools enabled.
+ * Operator-supplied `permission` entries never survive, not even for tools
+ * outside the enumerated list: unknown entries imply tool sources the
+ * allowlist already strips, and allows for built-in tools must not win.
+ * Malformed config fails closed to a permission-only config: every non-task
+ * call passes its model explicitly, so dropping model-backed defaults keeps
+ * text generation working while never booting a server with tools enabled.
  */
-function withDeniedToolPermissions(configContent: string | undefined): string {
+function toRestrictedNonTaskConfigContent(
+  configContent: string | undefined,
+): string {
   const permissionOnly = JSON.stringify({
     permission: NON_TASK_TOOL_PERMISSION_DENIALS,
   });
@@ -156,23 +177,17 @@ function withDeniedToolPermissions(configContent: string | undefined): string {
     }
 
     const config = parsed as Record<string, unknown>;
-    // Keep operator per-tool entries for tools we do not enumerate, but our
-    // denials win on overlap. A non-object operator `permission` (e.g. a
-    // blanket "allow") is discarded entirely.
-    const operatorPermission =
-      typeof config.permission === 'object' &&
-      config.permission !== null &&
-      !Array.isArray(config.permission)
-        ? (config.permission as Record<string, unknown>)
-        : {};
+    const restricted: Record<string, unknown> = {};
 
-    return JSON.stringify({
-      ...config,
-      permission: {
-        ...operatorPermission,
-        ...NON_TASK_TOOL_PERMISSION_DENIALS,
-      },
-    });
+    for (const key of NON_TASK_CONFIG_ALLOWED_KEYS) {
+      if (config[key] !== undefined) {
+        restricted[key] = config[key];
+      }
+    }
+
+    restricted.permission = NON_TASK_TOOL_PERMISSION_DENIALS;
+
+    return JSON.stringify(restricted);
   } catch {
     return permissionOnly;
   }
@@ -204,8 +219,9 @@ export function buildOpenCodeCliEnv(
   }
 
   // Applied unconditionally, after any operator-supplied config content is
-  // selected, so custom OPENCODE_CONFIG_CONTENT cannot re-enable tools.
-  env.OPENCODE_CONFIG_CONTENT = withDeniedToolPermissions(
+  // selected, so custom OPENCODE_CONFIG_CONTENT cannot introduce tools
+  // (mcp/plugin/agent config) or re-enable built-in ones.
+  env.OPENCODE_CONFIG_CONTENT = toRestrictedNonTaskConfigContent(
     env.OPENCODE_CONFIG_CONTENT,
   );
 


### PR DESCRIPTION
## Summary
- #790 restricted non-task OpenCode sessions with a blanket permission denial plus a wildcard session ruleset. Both also strip the internal mechanism OpenCode uses to fulfil `format: json_schema`, so every structured non-task call (all router surfaces) failed with "Model did not produce structured output" while plain-text calls (titles, summaries) kept working — which is why routing broke on nightly.
- Replace both layers with enumerated per-tool denials via a shared `NON_TASK_TOOL_PERMISSION_DENIALS` constant: object-form `permission` config on server spawn and a matching per-session ruleset. Every real tool stays denied; the structured-output mechanism stays available.
- Operator-supplied per-tool permission entries outside the enumerated set are preserved; our denials win on overlap. A non-object operator `permission` (e.g. blanket `"allow"`) is still discarded.
- Regression tests pin the enumerated shape at both layers so a future "simplification" back to a wildcard fails CI.

Bisected against a live OpenCode 1.17 server: blanket config denial and wildcard session rule each reproduce the failure independently; the enumerated form passes structured and text calls end-to-end through `runNonTaskSdkPrompt` while tools remain denied.

## Test plan
- [x] End-to-end repro against a live OpenCode server: structured + text calls succeed with this change; both wildcard forms fail
- [x] Updated unit tests for config merge (including preserving unenumerated operator entries) and session ruleset shape
- [x] Full `@roomote/cloud-agents` suite (577 tests)
- [x] `pnpm lint`, `pnpm check-types`, `pnpm knip`