### PR TITLE
Promote v0.21.1 to production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 This file tracks product releases for Roomote (single monorepo version). Automated release entries are prepended by `pnpm run version`.
 
+## 0.21.1 (2026-07-26)
+
+This release restores reliable structured routing while preserving tool restrictions for non-task agent sessions.
+
+### Highlights
+
+- Keep routing and other structured agent responses working without granting non-task sessions tool access.
+
+### Patch changes
+
+- Restore structured routing output while keeping non-task agent sessions unable to use tools.
+
 ## 0.21.0 (2026-07-26)
 
 This release expands self-hosted deployment options and inference-provider choice, while making agent activity and automation more reliable and secure.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roomote",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "license": "FCL-1.0-ALv2",
   "packageManager": "pnpm@10.29.3",
   "engines": {

--- a/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
@@ -347,7 +347,14 @@ describe('resolveOpenCodeSmallModel', () => {
       {
         directory: expect.stringContaining('roomote-non-task-'),
         title: `Roomote ${NON_TASK_INFERENCE_SURFACES.routerTaskRouting}`,
-        permission: [{ permission: '*', pattern: '*', action: 'deny' }],
+        // Enumerated denials, never a `*` wildcard: a wildcard also strips
+        // the internal structured-output mechanism `format: json_schema`
+        // relies on.
+        permission: expect.arrayContaining([
+          { permission: 'edit', pattern: '*', action: 'deny' },
+          { permission: 'bash', pattern: '*', action: 'deny' },
+          { permission: 'read', pattern: '*', action: 'deny' },
+        ]),
       },
       expect.objectContaining({
         signal: expect.any(AbortSignal),
@@ -356,6 +363,23 @@ describe('resolveOpenCodeSmallModel', () => {
     const sessionDirectory = sessionCreateMock.mock.calls[0]?.[0]
       ?.directory as string;
     expect(sessionDirectory).not.toBe(process.cwd());
+    const sessionPermissions = sessionCreateMock.mock.calls[0]?.[0]
+      ?.permission as Array<{ permission: string }>;
+    expect(sessionPermissions.every((rule) => rule.permission !== '*')).toBe(
+      true,
+    );
+    // The per-prompt tool filter is the fail-closed layer for tools the
+    // enumerated denials cannot name (MCP/plugin tools on external servers):
+    // everything off, with OpenCode's internal StructuredOutput tool as the
+    // only exception so `format: json_schema` keeps working.
+    const promptTools = sessionPromptMock.mock.calls[0]?.[0]?.tools as Record<
+      string,
+      boolean
+    >;
+    expect(promptTools).toEqual({ '*': false, StructuredOutput: true });
+    expect(
+      Object.entries(promptTools).filter(([, enabled]) => enabled),
+    ).toEqual([['StructuredOutput', true]]);
     expect(sessionPromptMock).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionID: 'session-1',

--- a/packages/cloud-agents/src/server/__tests__/opencode-runtime.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/opencode-runtime.test.ts
@@ -8,6 +8,7 @@ import {
   buildOpenCodeCliEnv,
   killOpenCodeSdkServerProcessesForShutdown,
   leaseOpenCodeSdkServer,
+  NON_TASK_TOOL_PERMISSION_DENIALS,
   readOpenCodeDebugConfig,
 } from '../opencode-runtime';
 
@@ -52,7 +53,7 @@ describe('buildOpenCodeCliEnv', () => {
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
       model: 'openrouter/openai/gpt-5.4',
       small_model: 'openrouter/openai/gpt-5.4',
-      permission: 'deny',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
     });
   });
 
@@ -67,7 +68,7 @@ describe('buildOpenCodeCliEnv', () => {
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
       model: 'openrouter/openai/gpt-5.4',
       small_model: 'openrouter/z-ai/glm-5.2',
-      permission: 'deny',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
       provider: {
         openrouter: {
           models: {
@@ -92,7 +93,7 @@ describe('buildOpenCodeCliEnv', () => {
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
       model: 'openrouter/z-ai/glm-5.2',
       small_model: 'openrouter/z-ai/glm-5.2',
-      permission: 'deny',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
       provider: {
         openrouter: {
           models: {
@@ -117,7 +118,7 @@ describe('buildOpenCodeCliEnv', () => {
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
       model: 'openrouter/z-ai/glm-5.2',
       small_model: 'openrouter/z-ai/glm-5.2',
-      permission: 'deny',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
       provider: {
         openrouter: {
           models: {
@@ -139,7 +140,7 @@ describe('buildOpenCodeCliEnv', () => {
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
       model: 'openrouter/openai/gpt-5.4',
       small_model: 'openrouter/openai/gpt-5.4',
-      permission: 'deny',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
       provider: {
         openrouter: {
           models: {
@@ -181,7 +182,7 @@ describe('buildOpenCodeCliEnv', () => {
     expect(env.MISTRAL_API_KEY).toBeUndefined();
     // No model-backed config remains, but the tool lockdown still applies.
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
-      permission: 'deny',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
     });
   });
 
@@ -189,15 +190,15 @@ describe('buildOpenCodeCliEnv', () => {
     const env = buildOpenCodeCliEnv();
 
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
-      permission: 'deny',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
     });
   });
 
-  it('merges the tool denial into operator-supplied config content', () => {
+  it('keeps model and provider config from operator-supplied content', () => {
     const env = buildOpenCodeCliEnv({
       OPENCODE_CONFIG_CONTENT: JSON.stringify({
         model: 'openrouter/openai/gpt-5.4',
-        theme: 'dark',
+        provider: { openrouter: { options: { baseURL: 'https://example' } } },
         // An operator-supplied allow must not survive: these servers only
         // serve non-task calls, which never run tools.
         permission: 'allow',
@@ -206,9 +207,45 @@ describe('buildOpenCodeCliEnv', () => {
 
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
       model: 'openrouter/openai/gpt-5.4',
-      theme: 'dark',
-      permission: 'deny',
+      provider: { openrouter: { options: { baseURL: 'https://example' } } },
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
     });
+  });
+
+  it('strips config keys that can introduce or re-enable tools', () => {
+    const env = buildOpenCodeCliEnv({
+      OPENCODE_CONFIG_CONTENT: JSON.stringify({
+        model: 'openrouter/openai/gpt-5.4',
+        // Each of these can add tools outside the enumerated denial list
+        // (or re-enable built-ins), so none may reach a helper server.
+        mcp: { docs: { type: 'remote', url: 'https://example/mcp' } },
+        plugin: ['some-plugin'],
+        agent: { build: { tools: { bash: true } } },
+        mode: { build: { tools: { edit: true } } },
+        tools: { bash: true },
+        default_agent: 'build',
+        // Operator permission entries never survive, including entries for
+        // tools we do not enumerate.
+        permission: { docs_search: 'allow', bash: 'allow' },
+      }),
+    });
+
+    expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
+      model: 'openrouter/openai/gpt-5.4',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
+    });
+  });
+
+  it('never uses a blanket permission denial', () => {
+    // Regression guard: OpenCode fulfils `format: json_schema` structured
+    // output through an internal mechanism that a blanket "deny" (or a
+    // wildcard rule) strips, silently breaking every structured routing
+    // call. The denial must stay in enumerated object form.
+    expect(typeof NON_TASK_TOOL_PERMISSION_DENIALS).toBe('object');
+    expect(Object.keys(NON_TASK_TOOL_PERMISSION_DENIALS)).not.toContain('*');
+    expect(Object.values(NON_TASK_TOOL_PERMISSION_DENIALS)).toEqual(
+      Object.keys(NON_TASK_TOOL_PERMISSION_DENIALS).map(() => 'deny'),
+    );
   });
 
   it('fails closed to a permission-only config on malformed content', () => {
@@ -218,7 +255,7 @@ describe('buildOpenCodeCliEnv', () => {
       });
 
       expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
-        permission: 'deny',
+        permission: NON_TASK_TOOL_PERMISSION_DENIALS,
       });
     }
   });

--- a/packages/cloud-agents/src/server/non-task-provider-usage.ts
+++ b/packages/cloud-agents/src/server/non-task-provider-usage.ts
@@ -13,6 +13,7 @@ import zodToJsonSchema from 'zod-to-json-schema';
 import {
   DEFAULT_OPENCODE_SDK_SERVER_START_TIMEOUT_MS,
   leaseOpenCodeSdkServer,
+  NON_TASK_TOOL_PERMISSION_DENIALS,
   readOpenCodeDebugConfig,
 } from './opencode-runtime';
 
@@ -24,10 +25,32 @@ const DEFAULT_OPENCODE_STRUCTURED_OUTPUT_RETRY_COUNT = 2;
  * (`withDeniedToolPermissions` in opencode-runtime), and this per-session
  * ruleset keeps a stale or externally configured server
  * (`OPENCODE_SDK_SERVER_URL`) equally locked down.
+ *
+ * Enumerated per tool rather than a `*` wildcard: a wildcard rule also
+ * strips the internal mechanism OpenCode uses for `format: json_schema`
+ * structured output, breaking every structured routing call.
  */
-const NON_TASK_SESSION_PERMISSIONS: PermissionRuleset = [
-  { permission: '*', pattern: '*', action: 'deny' },
-];
+const NON_TASK_SESSION_PERMISSIONS: PermissionRuleset = Object.keys(
+  NON_TASK_TOOL_PERMISSION_DENIALS,
+).map((permission) => ({ permission, pattern: '*', action: 'deny' }));
+
+/**
+ * Per-prompt tool filter: disable every registered tool — including MCP or
+ * plugin tools an externally configured server (`OPENCODE_SDK_SERVER_URL`)
+ * may define, which the enumerated permission denials cannot name — except
+ * OpenCode's internal `StructuredOutput` tool, which fulfils
+ * `format: json_schema`.
+ *
+ * The exact-name exception is deliberate: the `*` glob alone also removes
+ * `StructuredOutput` and breaks structured calls. If a future OpenCode
+ * release renames that internal tool, structured calls fail loudly ("Model
+ * did not produce structured output") rather than any tool becoming
+ * executable — this filter fails closed.
+ */
+const NON_TASK_SESSION_TOOL_DISABLES: Record<string, boolean> = {
+  '*': false,
+  StructuredOutput: true,
+};
 
 let nonTaskSessionDirectory: string | undefined;
 
@@ -325,6 +348,7 @@ async function runNonTaskSdkPrompt(
         sessionID: sessionResult.data.id,
         directory: sessionDirectory,
         model: splitOpenCodeModelId(model),
+        tools: NON_TASK_SESSION_TOOL_DISABLES,
         ...promptOptions,
       },
       { signal: abortController.signal },

--- a/packages/cloud-agents/src/server/opencode-runtime.ts
+++ b/packages/cloud-agents/src/server/opencode-runtime.ts
@@ -92,8 +92,53 @@ function buildModelBackedOpenCodeConfigContent(
 }
 
 /**
- * Force OpenCode's blanket tool-permission denial into a config content
- * string, preserving any other operator-supplied settings.
+ * Per-tool permission denials for the non-task helper servers, covering
+ * every tool OpenCode's permission config enumerates.
+ *
+ * Deliberately the enumerated object form, NOT the blanket `"deny"` string:
+ * OpenCode fulfils `format: json_schema` structured output through an
+ * internal mechanism that a blanket denial (or a wildcard session rule)
+ * strips along with the real tools, which silently breaks every structured
+ * routing call while plain-text calls keep working. The object form denies
+ * only the listed tools and leaves that mechanism available.
+ */
+export const NON_TASK_TOOL_PERMISSION_DENIALS = {
+  read: 'deny',
+  edit: 'deny',
+  glob: 'deny',
+  grep: 'deny',
+  list: 'deny',
+  bash: 'deny',
+  task: 'deny',
+  external_directory: 'deny',
+  todowrite: 'deny',
+  question: 'deny',
+  webfetch: 'deny',
+  websearch: 'deny',
+  lsp: 'deny',
+  skill: 'deny',
+} as const;
+
+/**
+ * Config keys forwarded to non-task helper servers. Everything else is
+ * dropped: OpenCode config can introduce or re-enable tools through several
+ * other keys (`mcp` servers, `plugin`, `agent`/`mode` overrides, global
+ * `tools` toggles), and any tool from those sources would fall outside
+ * {@link NON_TASK_TOOL_PERMISSION_DENIALS}. Allowlisting model/provider
+ * selection keeps the server's toolset exactly the built-in one, which the
+ * enumerated denials fully cover.
+ */
+const NON_TASK_CONFIG_ALLOWED_KEYS = [
+  'model',
+  'small_model',
+  'provider',
+  'disabled_providers',
+  'enabled_providers',
+] as const;
+
+/**
+ * Reduce a config content string to the model/provider allowlist plus the
+ * non-task tool denials.
  *
  * The servers this module spawns exist only for non-task inference — task
  * titles, routing, fast-agent answers — which is plain text or structured
@@ -102,13 +147,19 @@ function buildModelBackedOpenCodeConfigContent(
  * prompt (a task description saying "add some dinosaurs") can cause the
  * control plane to edit its own working directory.
  *
- * Malformed operator config fails closed to a permission-only config: every
- * non-task call passes its model explicitly, so dropping model-backed
- * defaults keeps text generation working while never booting a server with
- * tools enabled.
+ * Operator-supplied `permission` entries never survive, not even for tools
+ * outside the enumerated list: unknown entries imply tool sources the
+ * allowlist already strips, and allows for built-in tools must not win.
+ * Malformed config fails closed to a permission-only config: every non-task
+ * call passes its model explicitly, so dropping model-backed defaults keeps
+ * text generation working while never booting a server with tools enabled.
  */
-function withDeniedToolPermissions(configContent: string | undefined): string {
-  const permissionOnly = JSON.stringify({ permission: 'deny' });
+function toRestrictedNonTaskConfigContent(
+  configContent: string | undefined,
+): string {
+  const permissionOnly = JSON.stringify({
+    permission: NON_TASK_TOOL_PERMISSION_DENIALS,
+  });
 
   if (!configContent?.trim()) {
     return permissionOnly;
@@ -125,7 +176,18 @@ function withDeniedToolPermissions(configContent: string | undefined): string {
       return permissionOnly;
     }
 
-    return JSON.stringify({ ...parsed, permission: 'deny' });
+    const config = parsed as Record<string, unknown>;
+    const restricted: Record<string, unknown> = {};
+
+    for (const key of NON_TASK_CONFIG_ALLOWED_KEYS) {
+      if (config[key] !== undefined) {
+        restricted[key] = config[key];
+      }
+    }
+
+    restricted.permission = NON_TASK_TOOL_PERMISSION_DENIALS;
+
+    return JSON.stringify(restricted);
   } catch {
     return permissionOnly;
   }
@@ -157,8 +219,9 @@ export function buildOpenCodeCliEnv(
   }
 
   // Applied unconditionally, after any operator-supplied config content is
-  // selected, so custom OPENCODE_CONFIG_CONTENT cannot re-enable tools.
-  env.OPENCODE_CONFIG_CONTENT = withDeniedToolPermissions(
+  // selected, so custom OPENCODE_CONFIG_CONTENT cannot introduce tools
+  // (mcp/plugin/agent config) or re-enable built-in ones.
+  env.OPENCODE_CONFIG_CONTENT = toRestrictedNonTaskConfigContent(
     env.OPENCODE_CONFIG_CONTENT,
   );
 


### PR DESCRIPTION
## Promote v0.21.1

Frozen at `95e33be5a148b0fba321c3bc27f2dca360b8e970` — the commit where `0.21.1` was versioned. Commits merged to `develop` after that point ship in the next release.

- Merge this PR with a **merge commit** (do not squash or rebase).
- If multiple promote PRs are open, merge them in version order (oldest first).
- Merging publishes a GitHub Release for `v0.21.1` and triggers the existing GHCR `v*` image publish (`latest` channel).
- The `release/v0.21.1` branch can be deleted after this PR merges.

### Changelog

## 0.21.1 (2026-07-26)

This release restores reliable structured routing while preserving tool restrictions for non-task agent sessions.

### Highlights

- Keep routing and other structured agent responses working without granting non-task sessions tool access.

### Patch changes

- Restore structured routing output while keeping non-task agent sessions unable to use tools.
