### PR TITLE
feat: Z.AI usage bars in Models settings

### DIFF
--- a/.changeset/zai-usage-bars.md
+++ b/.changeset/zai-usage-bars.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': minor
+---
+
+Show Z.AI and Z.AI Coding Plan quota usage bars under connected provider rows in Models settings (5h and weekly windows from the monitor quota API).

--- a/apps/web/src/components/settings/InferenceProviderSection.test.tsx
+++ b/apps/web/src/components/settings/InferenceProviderSection.test.tsx
@@ -133,6 +133,7 @@ function buildProviderSetup(
     openaiSavedKey?: boolean;
     anthropicSavedKey?: boolean;
     chatgptConnected?: boolean;
+    zaiSavedKey?: boolean;
     includeMultiCredentialProviders?: boolean;
     bedrockSavedKey?: boolean;
     bedrockRegion?: string;
@@ -178,6 +179,17 @@ function buildProviderSetup(
           suggestedTaskModels: [],
           runtimeApiKeySatisfied: false,
           savedApiKeySatisfied: overrides.anthropicSavedKey ?? false,
+          additionalEnvValues: {} satisfies Record<string, string>,
+        },
+        {
+          id: 'zai' as SetupModelProviderId,
+          label: 'Z.AI',
+          envVarName: 'ZAI_API_KEY',
+          defaultRoomoteModel: 'zai/glm-5.2',
+          authKind: 'api-key' as const,
+          suggestedTaskModels: [],
+          runtimeApiKeySatisfied: false,
+          savedApiKeySatisfied: overrides.zaiSavedKey ?? false,
           additionalEnvValues: {} satisfies Record<string, string>,
         },
         ...(overrides.includeMultiCredentialProviders
@@ -400,6 +412,42 @@ describe('InferenceProviderSection', () => {
     expect(
       screen.getByRole('progressbar', { name: 'Credit balance' }),
     ).toBeInTheDocument();
+  });
+
+  it('shows a usage line under a connected Z.AI row', () => {
+    providerSetupData.current = buildProviderSetup({ zaiSavedKey: true });
+    subscriptionUsageData.current = [
+      {
+        providerId: 'zai',
+        planType: 'lite',
+        windows: [
+          {
+            label: '5h limit',
+            usedPercent: 16,
+            resetsAt: new Date(Date.now() + 2 * 3_600_000).toISOString(),
+          },
+          {
+            label: 'Weekly limit',
+            usedPercent: 4,
+          },
+        ],
+        fetchedAt: new Date().toISOString(),
+      },
+    ];
+
+    renderInferenceProviderSection();
+
+    expect(screen.getByText('Z.AI')).toBeInTheDocument();
+    expect(
+      screen.getByText('5h limit: 16% used (resets in 2h)'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Weekly limit: 4% used')).toBeInTheDocument();
+    expect(
+      screen.getByRole('progressbar', { name: '5h limit usage' }),
+    ).toHaveAttribute('aria-valuenow', '16');
+    expect(
+      screen.getByRole('progressbar', { name: 'Weekly limit usage' }),
+    ).toHaveAttribute('aria-valuenow', '4');
   });
 
   it('omits the usage line when no usage data is available or the row errored', () => {

--- a/apps/web/src/components/settings/InferenceProviderSection.tsx
+++ b/apps/web/src/components/settings/InferenceProviderSection.tsx
@@ -8,6 +8,7 @@ import {
   OPENAI_COMPATIBLE_PROVIDER_ID,
   getDefaultAdditionalEnvValues,
   getModelProviderLabel,
+  isApiKeySubscriptionUsageProviderId,
 } from '@roomote/types';
 import type {
   ProviderCreditBalance,
@@ -1164,9 +1165,7 @@ export function InferenceProviderSection({
                 key={provider.id}
                 provider={provider}
                 usage={
-                  provider.id === 'kimi-for-coding' ||
-                  provider.id === 'zai' ||
-                  provider.id === 'zai-coding-plan'
+                  isApiKeySubscriptionUsageProviderId(provider.id)
                     ? usageByProvider.get(provider.id)
                     : undefined
                 }

--- a/apps/web/src/components/settings/InferenceProviderSection.tsx
+++ b/apps/web/src/components/settings/InferenceProviderSection.tsx
@@ -1164,8 +1164,10 @@ export function InferenceProviderSection({
                 key={provider.id}
                 provider={provider}
                 usage={
-                  provider.id === 'kimi-for-coding'
-                    ? usageByProvider.get('kimi-for-coding')
+                  provider.id === 'kimi-for-coding' ||
+                  provider.id === 'zai' ||
+                  provider.id === 'zai-coding-plan'
+                    ? usageByProvider.get(provider.id)
                     : undefined
                 }
                 creditBalance={

--- a/apps/web/src/trpc/commands/subscription-usage/index.ts
+++ b/apps/web/src/trpc/commands/subscription-usage/index.ts
@@ -9,8 +9,9 @@ function assertAdmin(auth: UserAuthSuccess): void {
 
 /**
  * Usage/quota for connected subscription providers (ChatGPT, GitHub Copilot,
- * Kimi for Coding). Providers without a configured credential or whose usage
- * endpoint is unavailable are simply absent from the result.
+ * Kimi for Coding, Z.AI / Z.AI Coding Plan). Providers without a configured
+ * credential or whose usage endpoint is unavailable are simply absent from
+ * the result.
  */
 export async function getSubscriptionProviderUsageCommand(
   auth: UserAuthSuccess,

--- a/packages/db/src/lib/__tests__/subscription-provider-usage.test.ts
+++ b/packages/db/src/lib/__tests__/subscription-provider-usage.test.ts
@@ -540,6 +540,68 @@ describe('fetchZaiUsage', () => {
     expect(fetchImpl).toHaveBeenCalled();
   });
 
+  it('returns null on HTTP 200 business auth failures', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        code: 1000,
+        msg: 'Authentication Failed',
+        success: false,
+      }),
+    );
+
+    await expect(
+      fetchZaiUsage({ runtimeEnv: { ZAI_API_KEY: 'bad-key' }, fetchImpl }),
+    ).resolves.toBeNull();
+  });
+
+  it('parses live coding-plan TIME_LIMIT rows with currentValue/usage', () => {
+    const parsed = parseZaiQuotaUsage({
+      code: 200,
+      success: true,
+      data: {
+        level: 'max',
+        limits: [
+          { type: 'TOKENS_LIMIT', unit: 3, number: 5, percentage: 0 },
+          {
+            type: 'TOKENS_LIMIT',
+            unit: 6,
+            number: 1,
+            percentage: 30,
+            nextResetTime: 1_785_560_352_998,
+          },
+          {
+            type: 'TIME_LIMIT',
+            unit: 5,
+            number: 1,
+            usage: 4000,
+            currentValue: 24,
+            remaining: 3976,
+            percentage: 1,
+            nextResetTime: 1_785_819_552_997,
+          },
+        ],
+      },
+    });
+
+    expect(parsed.planType).toBe('max');
+    expect(parsed.windows).toEqual([
+      { label: '5h limit', usedPercent: 0 },
+      {
+        label: 'Weekly limit',
+        usedPercent: 30,
+        resetsAt: new Date(1_785_560_352_998).toISOString(),
+      },
+      {
+        label: 'Monthly tools',
+        usedPercent: 1,
+        used: 24,
+        remaining: 3976,
+        limit: 4000,
+        resetsAt: new Date(1_785_819_552_997).toISOString(),
+      },
+    ]);
+  });
+
   it('uses the China host when ZAI_REGION is china', async () => {
     const fetchImpl = vi.fn().mockResolvedValue(
       jsonResponse({

--- a/packages/db/src/lib/__tests__/subscription-provider-usage.test.ts
+++ b/packages/db/src/lib/__tests__/subscription-provider-usage.test.ts
@@ -444,7 +444,7 @@ describe('parseZaiQuotaUsage', () => {
     expect(parsed.planType).toBe('lite');
     expect(parsed.windows).toEqual([
       {
-        label: '5-hour limit',
+        label: '5h limit',
         usedPercent: 16,
         resetsAt: new Date(1_777_819_631_597).toISOString(),
       },
@@ -473,7 +473,7 @@ describe('parseZaiQuotaUsage', () => {
 
     expect(parsed.windows).toEqual([
       {
-        label: '5-hour limit',
+        label: '5h limit',
         usedPercent: 25,
         remaining: 75,
         limit: 100,
@@ -527,8 +527,17 @@ describe('fetchZaiUsage', () => {
     expect(usage).toMatchObject({
       providerId: 'zai',
       planType: 'pro',
-      windows: [{ label: '5-hour limit', usedPercent: 12 }],
+      windows: [{ label: '5h limit', usedPercent: 12 }],
     });
+  });
+
+  it('returns null on non-OK responses without throwing', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({}, 401));
+
+    await expect(
+      fetchZaiUsage({ runtimeEnv: { ZAI_API_KEY: 'zai-key' }, fetchImpl }),
+    ).resolves.toBeNull();
+    expect(fetchImpl).toHaveBeenCalled();
   });
 
   it('uses the China host when ZAI_REGION is china', async () => {

--- a/packages/db/src/lib/__tests__/subscription-provider-usage.test.ts
+++ b/packages/db/src/lib/__tests__/subscription-provider-usage.test.ts
@@ -9,7 +9,10 @@ import {
   fetchChatGptUsage,
   fetchGitHubCopilotUsage,
   fetchKimiForCodingUsage,
+  fetchZaiCodingPlanUsage,
+  fetchZaiUsage,
   getSubscriptionProviderUsage,
+  parseZaiQuotaUsage,
 } from '../subscription-provider-usage';
 
 /** Executor whose deployment-secret reads resolve the given rows per call. */
@@ -406,5 +409,192 @@ describe('getSubscriptionProviderUsage', () => {
 
     expect(usage).toHaveLength(1);
     expect(usage[0]).toMatchObject({ providerId: 'kimi-for-coding' });
+  });
+});
+
+describe('parseZaiQuotaUsage', () => {
+  it('normalizes live monitor quota windows and plan level', () => {
+    const parsed = parseZaiQuotaUsage({
+      code: 200,
+      data: {
+        level: 'lite',
+        limits: [
+          {
+            type: 'TOKENS_LIMIT',
+            unit: 3,
+            percentage: 16,
+            nextResetTime: 1_777_819_631_597,
+          },
+          {
+            type: 'TOKENS_LIMIT',
+            unit: 6,
+            percentage: 4,
+            nextResetTime: 1_778_262_784_969,
+          },
+          {
+            type: 'TIME_LIMIT',
+            unit: 5,
+            percentage: 0,
+            nextResetTime: 1_780_336_384_978,
+          },
+        ],
+      },
+    });
+
+    expect(parsed.planType).toBe('lite');
+    expect(parsed.windows).toEqual([
+      {
+        label: '5-hour limit',
+        usedPercent: 16,
+        resetsAt: new Date(1_777_819_631_597).toISOString(),
+      },
+      {
+        label: 'Weekly limit',
+        usedPercent: 4,
+        resetsAt: new Date(1_778_262_784_969).toISOString(),
+      },
+      {
+        label: 'Monthly tools',
+        usedPercent: 0,
+        resetsAt: new Date(1_780_336_384_978).toISOString(),
+      },
+    ]);
+  });
+
+  it('derives usedPercent from remaining/limit when percentage is absent', () => {
+    const parsed = parseZaiQuotaUsage([
+      {
+        type: 'TOKENS_LIMIT',
+        unit: 3,
+        remaining: 75,
+        limit: 100,
+      },
+    ]);
+
+    expect(parsed.windows).toEqual([
+      {
+        label: '5-hour limit',
+        usedPercent: 25,
+        remaining: 75,
+        limit: 100,
+      },
+    ]);
+  });
+
+  it('returns empty windows for unusable payloads', () => {
+    expect(parseZaiQuotaUsage(null)).toEqual({ windows: [] });
+    expect(parseZaiQuotaUsage({})).toEqual({ windows: [] });
+    expect(parseZaiQuotaUsage({ code: 200, data: { level: 'pro' } })).toEqual({
+      planType: 'pro',
+      windows: [],
+    });
+  });
+});
+
+describe('fetchZaiUsage', () => {
+  it('returns null when no API key is configured', async () => {
+    const fetchImpl = vi.fn();
+    await expect(
+      fetchZaiUsage({ runtimeEnv: {}, fetchImpl }),
+    ).resolves.toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('fetches the international quota endpoint by default', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        code: 200,
+        data: {
+          level: 'pro',
+          limits: [{ type: 'TOKENS_LIMIT', unit: 3, percentage: 12 }],
+        },
+      }),
+    );
+
+    const usage = await fetchZaiUsage({
+      runtimeEnv: { ZAI_API_KEY: 'zai-key' },
+      fetchImpl,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.z.ai/api/monitor/usage/quota/limit',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: 'Bearer zai-key',
+        }),
+      }),
+    );
+    expect(usage).toMatchObject({
+      providerId: 'zai',
+      planType: 'pro',
+      windows: [{ label: '5-hour limit', usedPercent: 12 }],
+    });
+  });
+
+  it('uses the China host when ZAI_REGION is china', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        code: 200,
+        data: {
+          limits: [{ type: 'TOKENS_LIMIT', unit: 6, percentage: 8 }],
+        },
+      }),
+    );
+
+    await fetchZaiUsage({
+      runtimeEnv: { ZAI_API_KEY: 'zai-key', ZAI_REGION: 'china' },
+      fetchImpl,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://open.bigmodel.cn/api/monitor/usage/quota/limit',
+      expect.anything(),
+    );
+  });
+
+  it('returns null when the payload has no displayable windows', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ code: 200, data: { level: 'lite' } }));
+
+    await expect(
+      fetchZaiUsage({ runtimeEnv: { ZAI_API_KEY: 'zai-key' }, fetchImpl }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe('fetchZaiCodingPlanUsage', () => {
+  it('fetches coding-plan keys against the same monitor path', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        code: 200,
+        data: {
+          level: 'max',
+          limits: [{ type: 'TOKENS_LIMIT', unit: 6, percentage: 33 }],
+        },
+      }),
+    );
+
+    const usage = await fetchZaiCodingPlanUsage({
+      runtimeEnv: {
+        ZAI_CODING_PLAN_API_KEY: 'coding-key',
+        ZAI_CODING_PLAN_REGION: 'global',
+      },
+      fetchImpl,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.z.ai/api/monitor/usage/quota/limit',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: 'Bearer coding-key',
+        }),
+      }),
+    );
+    expect(usage).toMatchObject({
+      providerId: 'zai-coding-plan',
+      planType: 'max',
+      windows: [{ label: 'Weekly limit', usedPercent: 33 }],
+    });
   });
 });

--- a/packages/db/src/lib/subscription-provider-usage.ts
+++ b/packages/db/src/lib/subscription-provider-usage.ts
@@ -3,7 +3,10 @@ import {
   CHATGPT_USAGE_ENDPOINT,
   GITHUB_COPILOT_USAGE_ENDPOINT,
   KIMI_FOR_CODING_USAGE_ENDPOINTS,
+  ZAI_USAGE_HOSTS,
+  ZAI_USAGE_QUOTA_PATH,
   type SubscriptionProviderUsage,
+  type SubscriptionUsageProviderId,
   type SubscriptionUsageWindow,
 } from '@roomote/types';
 
@@ -14,10 +17,10 @@ import { resolveModelProviderEnvValue } from './model-runtime-config';
 
 /**
  * Server-side usage/quota lookups for subscription-style inference providers,
- * using the same credentials the inference gateway already holds. All three
- * upstream endpoints are undocumented (each is what the provider's own CLI
- * polls), so every fetcher parses defensively and resolves to `null` on any
- * failure — the settings UI omits the usage line rather than erroring.
+ * using the same credentials the inference gateway already holds. Upstream
+ * endpoints are undocumented (each is what the provider's own CLI polls), so
+ * every fetcher parses defensively and resolves to `null` on any failure —
+ * the settings UI omits the usage line rather than erroring.
  */
 
 const USAGE_FETCH_TIMEOUT_MS = 10_000;
@@ -529,6 +532,204 @@ export async function fetchKimiForCodingUsage(
   return null;
 }
 
+// --- Z.AI / Z.AI Coding Plan ----------------------------------------------
+
+/**
+ * Unit values observed in the Z.AI monitor quota UI / Coding Plan tools:
+ * 3 = 5-hour token window, 6 = weekly token window, 5 = monthly tool quota.
+ */
+function zaiQuotaWindowLabel(
+  type: string | undefined,
+  unit: number | undefined,
+): string {
+  if (unit === 3) {
+    return '5-hour limit';
+  }
+  if (unit === 6) {
+    return 'Weekly limit';
+  }
+  if (unit === 5) {
+    return type === 'TIME_LIMIT' ? 'Monthly tools' : 'Monthly limit';
+  }
+  if (type === 'TOKENS_LIMIT') {
+    return 'Token limit';
+  }
+  if (type === 'TIME_LIMIT') {
+    return 'Time limit';
+  }
+  return 'Usage';
+}
+
+function parseZaiQuotaLimitEntry(
+  entry: Record<string, unknown> | undefined,
+): SubscriptionUsageWindow | undefined {
+  if (!entry) {
+    return undefined;
+  }
+
+  const type = firstString(entry, ['type']);
+  const unit = firstNumber(entry, ['unit']);
+  const usedPercent = firstNumber(entry, [
+    'percentage',
+    'percent',
+    'used_percent',
+    'usedPercent',
+  ]);
+  const remaining = firstNumber(entry, ['remaining', 'remain']);
+  const limit = firstNumber(entry, ['limit', 'total', 'quota']);
+  const used = firstNumber(entry, ['used', 'consumed']);
+  const resetsAt = toResetIso(
+    entry.nextResetTime ??
+      entry.next_reset_time ??
+      entry.resetTime ??
+      entry.resets_at,
+  );
+
+  if (
+    usedPercent === undefined &&
+    remaining === undefined &&
+    limit === undefined &&
+    used === undefined
+  ) {
+    return undefined;
+  }
+
+  const derivedPercent =
+    usedPercent ??
+    (limit !== undefined &&
+    limit > 0 &&
+    remaining !== undefined &&
+    Number.isFinite(remaining)
+      ? clampPercent(((limit - remaining) / limit) * 100)
+      : used !== undefined && limit !== undefined && limit > 0
+        ? clampPercent((used / limit) * 100)
+        : undefined);
+
+  return {
+    label: zaiQuotaWindowLabel(type, unit),
+    ...(derivedPercent !== undefined && {
+      usedPercent: clampPercent(derivedPercent),
+    }),
+    ...(used !== undefined && { used }),
+    ...(remaining !== undefined && { remaining }),
+    ...(limit !== undefined && { limit }),
+    ...(resetsAt && { resetsAt }),
+  };
+}
+
+/**
+ * Parse Z.AI monitor quota payloads. Live shape:
+ * `{ code: 200, data: { level, limits: [{ type, unit, percentage, nextResetTime }] } }`.
+ * Older tools also report a bare array of limit rows. Exported for tests.
+ */
+export function parseZaiQuotaUsage(payload: unknown): {
+  planType?: string;
+  windows: SubscriptionUsageWindow[];
+} {
+  const root = asRecord(payload);
+  const data = asRecord(root?.data) ?? root;
+
+  const planType = firstString(data, [
+    'level',
+    'plan',
+    'planType',
+    'plan_type',
+  ]);
+
+  const rawLimits =
+    (data && (data.limits ?? data.limit)) ??
+    (Array.isArray(payload) ? payload : undefined) ??
+    (Array.isArray(root?.limits) ? root.limits : undefined);
+
+  const windows: SubscriptionUsageWindow[] = [];
+  if (Array.isArray(rawLimits)) {
+    for (const raw of rawLimits) {
+      const window = parseZaiQuotaLimitEntry(asRecord(raw));
+      if (window) {
+        windows.push(window);
+      }
+    }
+  }
+
+  return {
+    ...(planType && { planType }),
+    windows,
+  };
+}
+
+function resolveZaiUsageHost(
+  region: string | null | undefined,
+): (typeof ZAI_USAGE_HOSTS)[keyof typeof ZAI_USAGE_HOSTS] {
+  return region === 'china' ? ZAI_USAGE_HOSTS.china : ZAI_USAGE_HOSTS.global;
+}
+
+async function fetchZaiFamilyUsage(
+  options: UsageFetchOptions,
+  config: {
+    providerId: Extract<SubscriptionUsageProviderId, 'zai' | 'zai-coding-plan'>;
+    apiKeyEnvNames: readonly string[];
+    regionEnvNames: readonly string[];
+  },
+): Promise<SubscriptionProviderUsage | null> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const apiKey = await resolveModelProviderEnvValue(config.apiKeyEnvNames, {
+    ...(options.runtimeEnv && { runtimeEnv: options.runtimeEnv }),
+    ...(options.executor && { executor: options.executor }),
+  });
+
+  if (!apiKey) {
+    return null;
+  }
+
+  const region = await resolveModelProviderEnvValue(config.regionEnvNames, {
+    ...(options.runtimeEnv && { runtimeEnv: options.runtimeEnv }),
+    ...(options.executor && { executor: options.executor }),
+  });
+
+  const endpoint = `${resolveZaiUsageHost(region)}${ZAI_USAGE_QUOTA_PATH}`;
+  const { status, payload } = await fetchJson(fetchImpl, endpoint, {
+    authorization: `Bearer ${apiKey}`,
+    accept: 'application/json',
+    'user-agent': 'roomote',
+  });
+
+  if (status !== 200) {
+    return null;
+  }
+
+  const parsed = parseZaiQuotaUsage(payload);
+  if (parsed.windows.length === 0) {
+    return null;
+  }
+
+  return {
+    providerId: config.providerId,
+    ...(parsed.planType && { planType: parsed.planType }),
+    windows: parsed.windows,
+    fetchedAt: new Date().toISOString(),
+  };
+}
+
+export async function fetchZaiUsage(
+  options: UsageFetchOptions = {},
+): Promise<SubscriptionProviderUsage | null> {
+  return fetchZaiFamilyUsage(options, {
+    providerId: 'zai',
+    apiKeyEnvNames: ['ZAI_API_KEY'],
+    regionEnvNames: ['ZAI_REGION'],
+  });
+}
+
+export async function fetchZaiCodingPlanUsage(
+  options: UsageFetchOptions = {},
+): Promise<SubscriptionProviderUsage | null> {
+  return fetchZaiFamilyUsage(options, {
+    providerId: 'zai-coding-plan',
+    apiKeyEnvNames: ['ZAI_CODING_PLAN_API_KEY'],
+    regionEnvNames: ['ZAI_CODING_PLAN_REGION'],
+  });
+}
+
 // --- Aggregate ------------------------------------------------------------
 
 /**
@@ -543,6 +744,8 @@ export async function getSubscriptionProviderUsage(
     fetchChatGptUsage(options),
     fetchGitHubCopilotUsage(options),
     fetchKimiForCodingUsage(options),
+    fetchZaiUsage(options),
+    fetchZaiCodingPlanUsage(options),
   ]);
 
   return results.flatMap((result) =>

--- a/packages/db/src/lib/subscription-provider-usage.ts
+++ b/packages/db/src/lib/subscription-provider-usage.ts
@@ -543,7 +543,8 @@ function zaiQuotaWindowLabel(
   unit: number | undefined,
 ): string {
   if (unit === 3) {
-    return '5-hour limit';
+    // Match ChatGPT's compact window label convention (`5h limit`).
+    return '5h limit';
   }
   if (unit === 6) {
     return 'Weekly limit';

--- a/packages/db/src/lib/subscription-provider-usage.ts
+++ b/packages/db/src/lib/subscription-provider-usage.ts
@@ -577,8 +577,14 @@ function parseZaiQuotaLimitEntry(
     'usedPercent',
   ]);
   const remaining = firstNumber(entry, ['remaining', 'remain']);
-  const limit = firstNumber(entry, ['limit', 'total', 'quota']);
-  const used = firstNumber(entry, ['used', 'consumed']);
+  // Live TIME_LIMIT rows use `usage` as the cap and `currentValue` as spent.
+  const limit = firstNumber(entry, ['limit', 'total', 'quota', 'usage']);
+  const used = firstNumber(entry, [
+    'used',
+    'consumed',
+    'currentValue',
+    'current_value',
+  ]);
   const resetsAt = toResetIso(
     entry.nextResetTime ??
       entry.next_reset_time ??
@@ -695,6 +701,17 @@ async function fetchZaiFamilyUsage(
   });
 
   if (status !== 200) {
+    return null;
+  }
+
+  // The monitor API often returns HTTP 200 with a business error envelope
+  // (`code: 1000`, `success: false`) for bad keys — treat as no usage.
+  const root = asRecord(payload);
+  const businessCode = firstNumber(root, ['code']);
+  if (
+    root?.success === false ||
+    (businessCode !== undefined && businessCode !== 200)
+  ) {
     return null;
   }
 

--- a/packages/types/src/subscription-provider-usage.ts
+++ b/packages/types/src/subscription-provider-usage.ts
@@ -19,6 +19,28 @@ export type SubscriptionUsageProviderId =
   | 'zai-coding-plan';
 
 /**
+ * Subscription-usage providers that share the generic API-key connected row
+ * (not dedicated OAuth rows like ChatGPT / Copilot). Keep the Settings
+ * allowlist in sync with this set.
+ */
+export const API_KEY_SUBSCRIPTION_USAGE_PROVIDER_IDS = [
+  'kimi-for-coding',
+  'zai',
+  'zai-coding-plan',
+] as const satisfies readonly SubscriptionUsageProviderId[];
+
+export type ApiKeySubscriptionUsageProviderId =
+  (typeof API_KEY_SUBSCRIPTION_USAGE_PROVIDER_IDS)[number];
+
+export function isApiKeySubscriptionUsageProviderId(
+  providerId: string,
+): providerId is ApiKeySubscriptionUsageProviderId {
+  return (
+    API_KEY_SUBSCRIPTION_USAGE_PROVIDER_IDS as readonly string[]
+  ).includes(providerId);
+}
+
+/**
  * One quota window, e.g. Copilot's monthly premium requests or the Codex
  * 5-hour/weekly rate-limit windows. Providers report different subsets of
  * these fields; the UI renders whatever is present.

--- a/packages/types/src/subscription-provider-usage.ts
+++ b/packages/types/src/subscription-provider-usage.ts
@@ -1,7 +1,7 @@
 /**
  * Normalized usage/quota data for subscription-style inference providers
- * (ChatGPT subscription, GitHub Copilot, Kimi for Coding), displayed in the
- * Models settings page.
+ * (ChatGPT subscription, GitHub Copilot, Kimi for Coding, Z.AI quotas),
+ * displayed in the Models settings page.
  *
  * None of the upstream usage endpoints below are officially documented; each
  * is the endpoint the provider's own CLI or editor plugin polls for its usage
@@ -14,7 +14,9 @@
 export type SubscriptionUsageProviderId =
   | 'chatgpt'
   | 'github-copilot'
-  | 'kimi-for-coding';
+  | 'kimi-for-coding'
+  | 'zai'
+  | 'zai-coding-plan';
 
 /**
  * One quota window, e.g. Copilot's monthly premium requests or the Codex
@@ -63,3 +65,14 @@ export const KIMI_FOR_CODING_USAGE_ENDPOINTS = [
   'https://api.kimi.com/coding/v1/usages',
   'https://api.kimi.com/coding/v1/usage',
 ] as const;
+
+/**
+ * Undocumented Z.AI / BigModel monitor quota endpoint polled by Coding Plan
+ * tools and community usage bars. Host is region-specific; path is shared.
+ * Global → api.z.ai; China → open.bigmodel.cn.
+ */
+export const ZAI_USAGE_QUOTA_PATH = '/api/monitor/usage/quota/limit' as const;
+export const ZAI_USAGE_HOSTS = {
+  global: 'https://api.z.ai',
+  china: 'https://open.bigmodel.cn',
+} as const;


### PR DESCRIPTION
## Summary

- Poll Z.AI's monitor quota endpoint (`/api/monitor/usage/quota/limit`) for connected **Z.AI** and **Z.AI Coding Plan** providers
- Render 5-hour / weekly (and monthly tools) usage bars under those rows on Models settings, same surface as Kimi / ChatGPT subscription usage
- Region-aware host selection: International → `api.z.ai`, China → `open.bigmodel.cn`

## Implementation

| Layer | Change |
|--------|--------|
| `packages/types` | `zai` / `zai-coding-plan` on `SubscriptionUsageProviderId`; host + path constants |
| `packages/db` | `parseZaiQuotaUsage`, `fetchZaiUsage`, `fetchZaiCodingPlanUsage`; included in `getSubscriptionProviderUsage` |
| `apps/web` | Pass usage into `ConnectedProviderRow` for both Z.AI providers |

Upstream payload (undocumented, same as Coding Plan tools / pi-glm-usage):

```json
{
  "code": 200,
  "data": {
    "level": "lite",
    "limits": [
      { "type": "TOKENS_LIMIT", "unit": 3, "percentage": 16, "nextResetTime": 1777819631597 },
      { "type": "TOKENS_LIMIT", "unit": 6, "percentage": 4, "nextResetTime": 1778262784969 }
    ]
  }
}
```

Missing credentials or unparseable responses still soft-fail (no bar), matching existing providers.


## Test plan

- [ ] Unit tests for `parseZaiQuotaUsage` and both fetchers (global + china hosts, coding-plan key)
- [ ] Connect Z.AI with an API key → Models settings shows usage bars when the monitor endpoint returns windows
- [ ] Connect Z.AI Coding Plan → same bars under that row
- [ ] China region uses `open.bigmodel.cn`
- [ ] No key / 401 / empty limits → row stays connected with no usage line (no error toast)