### PR TITLE
fix: stop skipping GHCR publishes for docs-only pushes

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -31,7 +31,6 @@ jobs:
     permissions:
       contents: read
     outputs:
-      docs_only: ${{ steps.changed-paths.outputs.docs_only }}
       owner: ${{ steps.vars.outputs.owner }}
       version: ${{ steps.vars.outputs.version }}
       product_version: ${{ steps.vars.outputs.product_version }}
@@ -40,56 +39,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          fetch-depth: 0
-      - name: Classify changed paths
-        id: changed-paths
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [ "$GITHUB_EVENT_NAME" != "push" ]; then
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          case "$GITHUB_REF" in
-            refs/heads/develop|refs/heads/main) ;;
-            *)
-              echo "docs_only=false" >> "$GITHUB_OUTPUT"
-              exit 0
-              ;;
-          esac
-
-          before="${{ github.event.before }}"
-          if [ "$before" = "0000000000000000000000000000000000000000" ]; then
-            changed_files="$(git diff-tree --no-commit-id --name-only -r "$GITHUB_SHA")"
-          elif git cat-file -e "$before" 2>/dev/null; then
-            changed_files="$(git diff --name-only "$before" "$GITHUB_SHA")"
-          else
-            # Force-pushed over the previous tip; the base is gone, so build everything.
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [ -z "$changed_files" ]; then
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          docs_only=true
-          while IFS= read -r path; do
-            case "$path" in
-              apps/docs/*|*.md|*.mdx)
-                ;;
-              *)
-                docs_only=false
-                break
-                ;;
-            esac
-          done <<< "$changed_files"
-
-          echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
-
       - name: Resolve image metadata
         id: vars
         shell: bash
@@ -155,7 +104,6 @@ jobs:
   deployment-acceptance:
     name: Deployment acceptance (amd64)
     needs: prepare
-    if: ${{ needs.prepare.outputs.docs_only != 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
@@ -247,7 +195,6 @@ jobs:
   build:
     name: Build ${{ matrix.app }} (${{ matrix.arch }})
     needs: prepare
-    if: ${{ needs.prepare.outputs.docs_only != 'true' }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -398,7 +345,7 @@ jobs:
     name: Create GitHub Release
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [prepare, publish]
-    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && needs.prepare.outputs.docs_only != 'true' }}
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
     permissions:
       contents: write
       packages: read


### PR DESCRIPTION
## Problem

The Publish GHCR Images workflow skipped all build jobs for docs-only develop/main pushes. That skip is wrong in two ways:

1. **It ships stale content.** Since #754 the app image copies `apps/docs` into the image — the web server reads setup-flow docs from `../docs` at request time — so a "docs-only" change produces a genuinely different app image. The skip predates that change. The classifier also treated every `*.md`/`*.mdx` in the repo as docs, even though some markdown (for example workflow `SKILL.md` sources) is runtime content.

2. **It breaks immutable-tag consumers.** A skipped push leaves the commit with no `<channel>-<sha8>` image tag. `pnpm dev` derives `ghcr.io/roocodeinc/roomote-worker:develop-<first 8 chars of origin/develop>` for hosted compute, so after a changelog-only push lands on develop (for example `acab6738`, where every build/publish job was skipped), Modal sandbox creation fails with an empty "Image build for im-... failed" error and every local task run fails to spawn until the next code push. Verified against the registry: `develop-acab6738` returns 404 while `develop-4a08f555` and the `develop` alias return 200.

## Fix

Remove the docs-only skip entirely: delete the `Classify changed paths` step and the `docs_only` gates on `deployment-acceptance`, `build`, and `create-github-release`. Every develop/main push now builds and publishes, restoring the invariant that every branch commit has a published immutable tag and keeping shipped docs current.

Alternatives considered and dropped:

- **Client-side registry check in `pnpm dev`** (probe GHCR, walk back to the newest published tag): works, but adds machinery to every consumer and leaves the tag gap in place.
- **Retagging the previous image under the new sha for docs-only pushes**: fixes the tag gap cheaply, but publishes a stale app image under the new commit's tag, since docs-only changes do affect the app image (caught by review on an earlier revision of this PR).

Tradeoff: changelog-only and docs-only pushes now pay for a full image build. Those pushes are infrequent, and the previous behavior was silently shipping stale docs, so the skip was not a safe optimization to keep.

## Validation

- Workflow YAML parses cleanly; the diff is a pure removal (1 insertion, 54 deletions).
- No `docs_only` references remain in the workflow.
