### PR TITLE
Stop the dashboard blocking on dozens of live Slack calls

### DIFF
--- a/apps/web/src/app/(authenticated)/home/OnboardingCard.tsx
+++ b/apps/web/src/app/(authenticated)/home/OnboardingCard.tsx
@@ -6,7 +6,6 @@ import { useSearchParams, useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 import {
   getMcpIntegrationConnectionScope,
-  hasEnabledBackgroundAgents,
   isSelfServeMcpIntegration,
   isDeploymentScopedMcpIntegration,
   MCP_INTEGRATIONS,
@@ -111,11 +110,8 @@ export function OnboardingCard() {
   const userMcpConnections = useUserMcpConnections();
   const connectMcp = useConnectMcp();
   const mcpPending = enablements.isPending || userMcpConnections.isPending;
-  const { data: automationSettingsResult, isPending: automationsPending } =
-    useQuery(trpc.automations.getSettings.queryOptions());
-  const hasEnabledBackgroundAgentSettings = automationSettingsResult?.settings
-    ? hasEnabledBackgroundAgents(automationSettingsResult.settings)
-    : false;
+  const { data: automationOnboardingStatus, isPending: automationsPending } =
+    useQuery(trpc.automations.onboardingStatus.queryOptions());
 
   const promotedMcpIntegrations = mcpPending
     ? []
@@ -373,8 +369,8 @@ export function OnboardingCard() {
     },
     visible:
       !automationsPending &&
-      Boolean(automationSettingsResult?.settings) &&
-      !hasEnabledBackgroundAgentSettings,
+      Boolean(automationOnboardingStatus) &&
+      !automationOnboardingStatus?.hasEnabledAutomations,
   });
 
   const activeCard = cards.find((card) => card.visible && !dismissed[card.id]);

--- a/apps/web/src/trpc/client.tsx
+++ b/apps/web/src/trpc/client.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { type QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { createTRPCClient, httpBatchLink } from '@trpc/client';
+import { createTRPCClient, httpBatchStreamLink } from '@trpc/client';
 import { createTRPCContext } from '@trpc/tanstack-react-query';
 import superjson from 'superjson';
 
@@ -33,7 +33,11 @@ export function TRPCReactProvider({
 
   const [trpcClient] = useState(() =>
     createTRPCClient<AppRouter>({
-      links: [httpBatchLink({ url: '/api/trpc', transformer: superjson })],
+      // Streaming so one slow procedure in a batch cannot hold back the
+      // responses of the fast ones.
+      links: [
+        httpBatchStreamLink({ url: '/api/trpc', transformer: superjson }),
+      ],
     }),
   );
 

--- a/apps/web/src/trpc/commands/automations/__tests__/onboarding-status.test.ts
+++ b/apps/web/src/trpc/commands/automations/__tests__/onboarding-status.test.ts
@@ -1,0 +1,92 @@
+import {
+  automations,
+  db,
+  deploymentSettings,
+  slackInstallations,
+  upsertAutomation,
+} from '@roomote/db/server';
+import type { FeatureFlag } from '@roomote/feature-flags';
+
+import type { UserAuthSuccess } from '@/types';
+
+import { getAutomationOnboardingStatusCommand } from '../onboarding-status';
+
+const adminAuth: UserAuthSuccess = {
+  success: true,
+  userType: 'user',
+  userId: 'user-admin',
+  name: 'Admin',
+  primaryEmail: 'admin@example.com',
+  isAdmin: true,
+  featureFlags: {} as Record<FeatureFlag, boolean>,
+  anonymousAnalyticsEnabled: false,
+  cloudEnabled: false,
+  resource: {
+    username: null,
+    fullName: null,
+    firstName: null,
+    lastName: null,
+    primaryEmailAddress: null,
+    emailAddresses: [],
+    imageUrl: '',
+    createdAt: null,
+  },
+};
+
+describe('getAutomationOnboardingStatusCommand', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    await db.delete(automations);
+    await db.delete(deploymentSettings);
+    await db.delete(slackInstallations);
+
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('no network calls expected'));
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('reports no enabled automations on a fresh deployment without calling Slack', async () => {
+    await expect(
+      getAutomationOnboardingStatusCommand(adminAuth),
+    ).resolves.toEqual({ hasEnabledAutomations: false });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('reports enabled automations once one is scheduled', async () => {
+    await upsertAutomation(db, {
+      key: 'manager_stats',
+      enabled: true,
+      schedule: { mode: 'weekly' },
+    });
+
+    await expect(
+      getAutomationOnboardingStatusCommand(adminAuth),
+    ).resolves.toEqual({ hasEnabledAutomations: true });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('still reports nothing enabled when an automation exists but is off', async () => {
+    await upsertAutomation(db, {
+      key: 'manager_stats',
+      enabled: false,
+      schedule: { mode: 'weekly' },
+    });
+
+    await expect(
+      getAutomationOnboardingStatusCommand(adminAuth),
+    ).resolves.toEqual({ hasEnabledAutomations: false });
+  });
+
+  it('rejects non-admins', async () => {
+    await expect(
+      getAutomationOnboardingStatusCommand({ ...adminAuth, isAdmin: false }),
+    ).rejects.toThrow('Unauthorized');
+  });
+});

--- a/apps/web/src/trpc/commands/automations/__tests__/settings-read.test.ts
+++ b/apps/web/src/trpc/commands/automations/__tests__/settings-read.test.ts
@@ -1,0 +1,177 @@
+import {
+  automations,
+  db,
+  deploymentSettings,
+  slackInstallations,
+  upsertAutomation,
+  users,
+} from '@roomote/db/server';
+import type { FeatureFlag } from '@roomote/feature-flags';
+
+import type { UserAuthSuccess } from '@/types';
+
+import { getBackgroundAgentSettingsCommand } from '../settings-read';
+
+const SETTINGS_READ_USER_ID = 'user-settings-read-admin';
+const MANAGER_CHANNEL_ID = 'CMANAGER1';
+const STATS_CHANNEL_ID = 'CSTATS111';
+
+const adminAuth: UserAuthSuccess = {
+  success: true,
+  userType: 'user',
+  userId: SETTINGS_READ_USER_ID,
+  name: 'Admin',
+  primaryEmail: 'admin@example.com',
+  isAdmin: true,
+  featureFlags: {} as Record<FeatureFlag, boolean>,
+  anonymousAnalyticsEnabled: false,
+  cloudEnabled: false,
+  resource: {
+    username: null,
+    fullName: null,
+    firstName: null,
+    lastName: null,
+    primaryEmailAddress: null,
+    emailAddresses: [],
+    imageUrl: '',
+    createdAt: null,
+  },
+};
+
+/**
+ * Records how many Slack calls are in flight at once so the test can tell a
+ * serialized fan-out from a concurrent one.
+ */
+function createSlackFetchRecorder() {
+  const urls: string[] = [];
+  let inFlight = 0;
+  let peakInFlight = 0;
+
+  const impl = async (input: string | URL | Request) => {
+    const url = String(input);
+    urls.push(url);
+    inFlight += 1;
+    peakInFlight = Math.max(peakInFlight, inFlight);
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    inFlight -= 1;
+
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        ok: true,
+        channel: { name: 'reports', is_member: true, is_private: false },
+      }),
+    } as unknown as Response;
+  };
+
+  return {
+    impl,
+    urls,
+    get peakInFlight() {
+      return peakInFlight;
+    },
+    countFor: (channelId: string) =>
+      urls.filter(
+        (url) => url.includes('conversations.info') && url.includes(channelId),
+      ).length,
+  };
+}
+
+describe('getBackgroundAgentSettingsCommand Slack fan-out', () => {
+  let recorder: ReturnType<typeof createSlackFetchRecorder>;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    process.env.SLACK_API_BASE_URL = 'https://slack.com/api/';
+
+    await db.delete(automations);
+    await db.delete(deploymentSettings);
+    await db.delete(slackInstallations);
+
+    // Other suites share this database, so the fixture user is scoped to this
+    // file instead of clearing the whole users table.
+    await db
+      .insert(users)
+      .values({
+        id: SETTINGS_READ_USER_ID,
+        name: 'Admin',
+        email: 'settings-read-admin@example.com',
+        imageUrl: '',
+        entity: {},
+      })
+      .onConflictDoNothing({ target: users.id });
+
+    await db.insert(slackInstallations).values({
+      teamId: 'T123',
+      teamName: 'Acme',
+      appId: 'A123',
+      botUserId: 'B123',
+      botAccessToken: 'xoxb-test',
+      scopes: {
+        bot: ['channels:read', 'groups:read', 'reactions:read', 'team:read'],
+      },
+      installedByUserId: SETTINGS_READ_USER_ID,
+      isActive: true,
+    });
+
+    await db
+      .insert(deploymentSettings)
+      .values({ managerSlackChannelId: MANAGER_CHANNEL_ID });
+
+    // Only the manager-stats automation reports to its own channel; every
+    // other reporting automation falls back to the manager channel.
+    await upsertAutomation(db, {
+      key: 'manager_stats',
+      enabled: true,
+      schedule: { mode: 'weekly' },
+      targets: [
+        {
+          provider: 'slack',
+          targetKind: 'slack_channel',
+          externalRef: STATS_CHANNEL_ID,
+        },
+      ],
+    });
+
+    recorder = createSlackFetchRecorder();
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(recorder.impl as unknown as typeof fetch);
+  });
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+  });
+
+  it('runs the warning, display-name and destination rounds concurrently and resolves each channel once', async () => {
+    const result = await getBackgroundAgentSettingsCommand(adminAuth);
+
+    // The access-warning round only sees the stats channel and the
+    // display-name round only adds the manager channel, so two simultaneous
+    // conversations.info calls can only happen if the rounds overlap.
+    expect(recorder.peakInFlight).toBeGreaterThanOrEqual(2);
+
+    // The per-request memo collapses the repeated lookups of each channel.
+    expect(recorder.countFor(STATS_CHANNEL_ID)).toBe(1);
+    expect(recorder.countFor(MANAGER_CHANNEL_ID)).toBe(1);
+
+    expect(result.slackChannelDisplayNames.managerSlackChannel).toBe(
+      '#reports',
+    );
+    expect(result.slackChannelDisplayNames.managerStatsSlackChannel).toBe(
+      '#reports',
+    );
+    // The bot is a member of both channels, so nothing is flagged.
+    expect(
+      result.slackChannelAccessWarnings.managerStatsSlackChannel,
+    ).toBeNull();
+    expect(result.resolvedDestinations.manager_stats?.channelId).toBe(
+      STATS_CHANNEL_ID,
+    );
+    expect(result.capabilities.slackConnected).toBe(true);
+    expect(result.automationStatus.manager_stats?.enabled).toBe(true);
+  });
+});

--- a/apps/web/src/trpc/commands/automations/index.ts
+++ b/apps/web/src/trpc/commands/automations/index.ts
@@ -6,6 +6,8 @@ export type {
   ReviewerBackgroundAgentSettings,
   ReviewerRelayUser,
 } from './reviewer';
+export { getAutomationOnboardingStatusCommand } from './onboarding-status';
+export type { AutomationOnboardingStatus } from './onboarding-status';
 export { getBackgroundAgentSettingsCommand } from './settings-read';
 export { updateBackgroundAgentSettingsCommand } from './settings-update';
 export { listSlackChannelsCommand } from './slack-channels';

--- a/apps/web/src/trpc/commands/automations/onboarding-status.ts
+++ b/apps/web/src/trpc/commands/automations/onboarding-status.ts
@@ -1,0 +1,27 @@
+import { getBackgroundAgentSettingsForDeployment } from '@roomote/db/server';
+import { hasEnabledBackgroundAgents } from '@roomote/types';
+
+import type { UserAuthSuccess } from '@/types';
+
+import { assertAdmin } from './feature-gates';
+
+export type AutomationOnboardingStatus = {
+  hasEnabledAutomations: boolean;
+};
+
+/**
+ * Minimal projection for the home onboarding nudge: only whether any
+ * automation is enabled. Reads local rows and makes no Slack calls, so it can
+ * sit on the dashboard's critical path (unlike the full settings read).
+ */
+export async function getAutomationOnboardingStatusCommand(
+  auth: UserAuthSuccess,
+): Promise<AutomationOnboardingStatus> {
+  assertAdmin(auth);
+
+  const settings = await getBackgroundAgentSettingsForDeployment();
+
+  return {
+    hasEnabledAutomations: hasEnabledBackgroundAgents(settings),
+  };
+}

--- a/apps/web/src/trpc/commands/automations/settings-read.ts
+++ b/apps/web/src/trpc/commands/automations/settings-read.ts
@@ -10,12 +10,13 @@ import {
   desc,
   discordInstallations,
   eq,
-  getAutomationRuntime,
+  getAutomationRuntimes,
   getBackgroundAgentSettingsForDeployment,
+  getBackgroundAgentSettingsWithAutomationsForDeployment,
   inArray,
-  listAutomations,
   resolveTelegramRuntimeCredentials,
   tasks,
+  type Automation,
 } from '@roomote/db/server';
 import {
   findDiscordDestinationByChannelId,
@@ -25,7 +26,7 @@ import {
   type ResolvedAutomationDestination,
 } from '@roomote/sdk/server';
 import { resolveConfiguredGitHubAppSlug } from '@roomote/github';
-import { SlackNotifier } from '@roomote/slack';
+import { SlackChannelInfoCache, SlackNotifier } from '@roomote/slack';
 
 import type { UserAuthSuccess } from '@/types';
 
@@ -138,10 +139,9 @@ async function listRecentAutomationTasks(): Promise<
   return grouped;
 }
 
-async function buildAutomationStatus(): Promise<
-  Partial<Record<BackgroundAutomationKey, AutomationStatusSummary>>
-> {
-  const automationRows = await listAutomations();
+function buildAutomationStatus(
+  automationRows: Automation[],
+): Partial<Record<BackgroundAutomationKey, AutomationStatusSummary>> {
   const status: Partial<
     Record<BackgroundAutomationKey, AutomationStatusSummary>
   > = {};
@@ -211,9 +211,15 @@ async function resolveAutomationDestinations(params: {
   slackConnected: boolean;
   notifier: SlackNotifier | null;
 }): Promise<ResolvedAutomationDestinations> {
+  // One batched read for every reporting automation instead of a runtime
+  // lookup (plus its deployment_settings read) per key.
+  const runtimes = await getAutomationRuntimes(
+    MANAGER_REPORTING_AUTOMATION_KEYS,
+  );
+
   const entries = await Promise.all(
     MANAGER_REPORTING_AUTOMATION_KEYS.map(async (key) => {
-      const runtime = await getAutomationRuntime(key);
+      const runtime = runtimes[key];
       const destination = await resolveAutomationRuntimeDestination({
         runtime,
         slackConnected: params.slackConnected,
@@ -296,16 +302,15 @@ export async function getBackgroundAgentSettingsCommand(
   assertAdmin(auth);
 
   const [
-    settings,
+    { settings, automationRows },
     slackInstallation,
     discordInstallation,
     telegramCredentials,
     teamsPrimaryConversation,
     sentryConnected,
     recentRuns,
-    status,
   ] = await Promise.all([
-    getBackgroundAgentSettingsForDeployment(),
+    getBackgroundAgentSettingsWithAutomationsForDeployment(),
     findActiveSlackInstallationForOrg(),
     db.query.discordInstallations.findFirst({
       where: eq(discordInstallations.isActive, true),
@@ -315,12 +320,8 @@ export async function getBackgroundAgentSettingsCommand(
     findTeamsPrimaryConversation(),
     hasActiveSentryIntegration(),
     listRecentAutomationTasks(),
-    buildAutomationStatus(),
   ]);
-  const relayUsers = await listReviewerRelayUserRecords(
-    auth,
-    getRelayEligibleCreatorIds(settings.reviewCodeSettings),
-  );
+  const status = buildAutomationStatus(automationRows);
   const visibleSettings = maskSlackChannelAutoStartSettings(auth, settings);
 
   const botScopes = extractSlackBotScopes(slackInstallation?.scopes).map(
@@ -333,56 +334,71 @@ export async function getBackgroundAgentSettingsCommand(
         (scope) => !grantedScopes.has(scope),
       )
     : [];
+  // Request-scoped memo (backed by the shared Redis cache) so the warning and
+  // display-name passes resolve each channel through Slack at most once.
   const notifier = slackInstallation
-    ? new SlackNotifier(slackInstallation.botAccessToken)
+    ? new SlackNotifier(slackInstallation.botAccessToken, {
+        channelInfoCache: new SlackChannelInfoCache(slackInstallation.teamId),
+      })
     : null;
-  const slackChannelAccessWarnings = await getSlackChannelAccessWarnings({
-    notifier,
-    channelAutoStartSlackChannelIds:
-      visibleSettings.channelAutoStartSlackChannels.map(
-        ({ channelId }) => channelId,
-      ),
-    managerStatsSlackChannelId: visibleSettings.managerStatsSlackChannelId,
-    suggesterSlackChannelId: visibleSettings.suggesterSlackChannelId,
-    announcerSlackChannelId: visibleSettings.announcerSlackChannelId,
-    platformIssueSlackChannelId: visibleSettings.platformIssueSlackChannelId,
-    sentryTriageSlackChannelId: visibleSettings.sentryTriageSlackChannelId,
-    dependabotTriageSlackChannelId:
-      visibleSettings.dependabotTriageSlackChannelId,
-    codeqlTriageSlackChannelId: visibleSettings.codeqlTriageSlackChannelId,
-    securityAuditorSlackChannelId:
-      visibleSettings.securityAuditorSlackChannelId,
-    codeQualityAuditorSlackChannelId:
-      visibleSettings.codeQualityAuditorSlackChannelId,
-    ciFailureTriageSlackChannelId:
-      visibleSettings.ciFailureTriageSlackChannelId,
-  });
-  const slackChannelDisplayNames = await getSlackChannelDisplayNames({
-    notifier,
-    channelAutoStartSlackChannelIds:
-      visibleSettings.channelAutoStartSlackChannels.map(
-        ({ channelId }) => channelId,
-      ),
-    managerSlackChannelId: visibleSettings.managerSlackChannelId,
-    managerStatsSlackChannelId: visibleSettings.managerStatsSlackChannelId,
-    suggesterSlackChannelId: visibleSettings.suggesterSlackChannelId,
-    announcerSlackChannelId: visibleSettings.announcerSlackChannelId,
-    platformIssueSlackChannelId: visibleSettings.platformIssueSlackChannelId,
-    sentryTriageSlackChannelId: visibleSettings.sentryTriageSlackChannelId,
-    dependabotTriageSlackChannelId:
-      visibleSettings.dependabotTriageSlackChannelId,
-    codeqlTriageSlackChannelId: visibleSettings.codeqlTriageSlackChannelId,
-    securityAuditorSlackChannelId:
-      visibleSettings.securityAuditorSlackChannelId,
-    codeQualityAuditorSlackChannelId:
-      visibleSettings.codeQualityAuditorSlackChannelId,
-    ciFailureTriageSlackChannelId:
-      visibleSettings.ciFailureTriageSlackChannelId,
-  });
-  const resolvedDestinations = await resolveAutomationDestinations({
-    slackConnected: Boolean(slackInstallation?.isActive),
-    notifier,
-  });
+  const [
+    relayUsers,
+    slackChannelAccessWarnings,
+    slackChannelDisplayNames,
+    resolvedDestinations,
+  ] = await Promise.all([
+    listReviewerRelayUserRecords(
+      auth,
+      getRelayEligibleCreatorIds(settings.reviewCodeSettings),
+    ),
+    getSlackChannelAccessWarnings({
+      notifier,
+      channelAutoStartSlackChannelIds:
+        visibleSettings.channelAutoStartSlackChannels.map(
+          ({ channelId }) => channelId,
+        ),
+      managerStatsSlackChannelId: visibleSettings.managerStatsSlackChannelId,
+      suggesterSlackChannelId: visibleSettings.suggesterSlackChannelId,
+      announcerSlackChannelId: visibleSettings.announcerSlackChannelId,
+      platformIssueSlackChannelId: visibleSettings.platformIssueSlackChannelId,
+      sentryTriageSlackChannelId: visibleSettings.sentryTriageSlackChannelId,
+      dependabotTriageSlackChannelId:
+        visibleSettings.dependabotTriageSlackChannelId,
+      codeqlTriageSlackChannelId: visibleSettings.codeqlTriageSlackChannelId,
+      securityAuditorSlackChannelId:
+        visibleSettings.securityAuditorSlackChannelId,
+      codeQualityAuditorSlackChannelId:
+        visibleSettings.codeQualityAuditorSlackChannelId,
+      ciFailureTriageSlackChannelId:
+        visibleSettings.ciFailureTriageSlackChannelId,
+    }),
+    getSlackChannelDisplayNames({
+      notifier,
+      channelAutoStartSlackChannelIds:
+        visibleSettings.channelAutoStartSlackChannels.map(
+          ({ channelId }) => channelId,
+        ),
+      managerSlackChannelId: visibleSettings.managerSlackChannelId,
+      managerStatsSlackChannelId: visibleSettings.managerStatsSlackChannelId,
+      suggesterSlackChannelId: visibleSettings.suggesterSlackChannelId,
+      announcerSlackChannelId: visibleSettings.announcerSlackChannelId,
+      platformIssueSlackChannelId: visibleSettings.platformIssueSlackChannelId,
+      sentryTriageSlackChannelId: visibleSettings.sentryTriageSlackChannelId,
+      dependabotTriageSlackChannelId:
+        visibleSettings.dependabotTriageSlackChannelId,
+      codeqlTriageSlackChannelId: visibleSettings.codeqlTriageSlackChannelId,
+      securityAuditorSlackChannelId:
+        visibleSettings.securityAuditorSlackChannelId,
+      codeQualityAuditorSlackChannelId:
+        visibleSettings.codeQualityAuditorSlackChannelId,
+      ciFailureTriageSlackChannelId:
+        visibleSettings.ciFailureTriageSlackChannelId,
+    }),
+    resolveAutomationDestinations({
+      slackConnected: Boolean(slackInstallation?.isActive),
+      notifier,
+    }),
+  ]);
 
   // The reviewer mapping derives its managed-login list synchronously from
   // the cached configured app slug.

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -281,6 +281,7 @@ import {
 import {
   createCustomAutomationCommand,
   deleteCustomAutomationCommand,
+  getAutomationOnboardingStatusCommand,
   getBackgroundAgentSettingsCommand,
   listAutomationDiscordChannelsCommand,
   listCustomAutomationsCommand,
@@ -425,6 +426,11 @@ const conflictResolverMaxPrAgeDaysSchema = z.union([
 const automationsRouter = createRouter({
   getSettings: protectedProcedure.query(({ ctx: { auth } }) =>
     getBackgroundAgentSettingsCommand(auth),
+  ),
+
+  // Slack-free subset of getSettings for the dashboard onboarding nudge.
+  onboardingStatus: protectedProcedure.query(({ ctx: { auth } }) =>
+    getAutomationOnboardingStatusCommand(auth),
   ),
 
   listSlackChannels: protectedProcedure.query(({ ctx: { auth } }) =>

--- a/packages/db/src/lib/automations.ts
+++ b/packages/db/src/lib/automations.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from 'drizzle-orm';
+import { eq, inArray, sql } from 'drizzle-orm';
 
 import {
   type AnnouncerFrequency,
@@ -489,6 +489,16 @@ export function ensureAutomationRowsOnce(): Promise<void> {
 }
 
 export async function listAutomations(): Promise<Automation[]> {
+  const rows = await db.query.automations.findMany();
+
+  // Read paths must not write: only a deployment that is still missing seeded
+  // keys pays for the insert.
+  if (
+    BACKGROUND_AUTOMATION_KEYS.every((key) => rows.some((r) => r.key === key))
+  ) {
+    return rows;
+  }
+
   await ensureAutomationRows();
   return db.query.automations.findMany();
 }
@@ -743,19 +753,12 @@ export type AutomationRuntime = {
   destination: AutomationDestination | null;
 };
 
-export async function getAutomationRuntime(
-  key: BackgroundAutomationKey,
-): Promise<AutomationRuntime> {
-  await ensureAutomationRowsOnce();
-
-  const [automation, settingsRow] = await Promise.all([
-    db.query.automations.findFirst({ where: eq(automations.key, key) }),
-    db.query.deploymentSettings.findFirst({
-      columns: { managerSlackChannelId: true },
-    }),
-  ]);
-
-  const managerSlackChannelId = settingsRow?.managerSlackChannelId ?? null;
+function toAutomationRuntime(params: {
+  key: BackgroundAutomationKey;
+  automation: Automation | undefined;
+  managerSlackChannelId: string | null;
+}): AutomationRuntime {
+  const { key, automation, managerSlackChannelId } = params;
 
   return {
     key,
@@ -776,6 +779,61 @@ export async function getAutomationRuntime(
       managerSlackChannelId,
     ),
   };
+}
+
+export async function getAutomationRuntime(
+  key: BackgroundAutomationKey,
+): Promise<AutomationRuntime> {
+  await ensureAutomationRowsOnce();
+
+  const [automation, settingsRow] = await Promise.all([
+    db.query.automations.findFirst({ where: eq(automations.key, key) }),
+    db.query.deploymentSettings.findFirst({
+      columns: { managerSlackChannelId: true },
+    }),
+  ]);
+
+  return toAutomationRuntime({
+    key,
+    automation,
+    managerSlackChannelId: settingsRow?.managerSlackChannelId ?? null,
+  });
+}
+
+/**
+ * Batched `getAutomationRuntime` for callers that need several automations at
+ * once: the automations rows and the deployment settings row are each read a
+ * single time instead of once per key.
+ */
+export async function getAutomationRuntimes<
+  TKey extends BackgroundAutomationKey,
+>(keys: readonly TKey[]): Promise<Record<TKey, AutomationRuntime>> {
+  await ensureAutomationRowsOnce();
+
+  const [automationRows, settingsRow] = await Promise.all([
+    keys.length > 0
+      ? db.query.automations.findMany({
+          where: inArray(automations.key, [...keys]),
+        })
+      : Promise.resolve([]),
+    db.query.deploymentSettings.findFirst({
+      columns: { managerSlackChannelId: true },
+    }),
+  ]);
+
+  const automationMap = buildAutomationMap(automationRows);
+  const managerSlackChannelId = settingsRow?.managerSlackChannelId ?? null;
+
+  return Object.fromEntries(
+    keys.map((key) => [
+      key,
+      toAutomationRuntime({
+        key,
+        automation: automationMap.get(key),
+        managerSlackChannelId,
+      }),
+    ]),
+  ) as Record<TKey, AutomationRuntime>;
 }
 
 export async function ensureDeploymentSettingsRow(): Promise<void> {
@@ -996,9 +1054,41 @@ export async function getBackgroundAgentSettings(): Promise<BackgroundAgentSetti
   return normalizeBackgroundAgentSettings(row, automationRows);
 }
 
-export async function getBackgroundAgentSettingsForDeployment(): Promise<BackgroundAgentSettings> {
+/**
+ * Deployment settings plus the automations rows they were projected from, so
+ * callers that also need the raw rows do not re-read them.
+ */
+export async function getBackgroundAgentSettingsWithAutomationsForDeployment(): Promise<{
+  settings: BackgroundAgentSettings;
+  automationRows: Automation[];
+}> {
+  const [row, automationRows] = await Promise.all([
+    db.query.deploymentSettings.findFirst(),
+    listAutomations(),
+  ]);
+
+  if (row) {
+    return {
+      settings: normalizeBackgroundAgentSettings(row, automationRows),
+      automationRows,
+    };
+  }
+
+  // Fresh deployment: seed the singleton row, then project from it.
   await ensureDeploymentSettingsRow();
-  return getBackgroundAgentSettings();
+
+  return {
+    settings: normalizeBackgroundAgentSettings(
+      await db.query.deploymentSettings.findFirst(),
+      automationRows,
+    ),
+    automationRows,
+  };
+}
+
+export async function getBackgroundAgentSettingsForDeployment(): Promise<BackgroundAgentSettings> {
+  return (await getBackgroundAgentSettingsWithAutomationsForDeployment())
+    .settings;
 }
 
 /**

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -12,12 +12,22 @@ export const REDIS_KEYS = {
   CONTROLLER_HEARTBEAT: 'controller:heartbeat',
   /** Cached GitHub release notes payload keyed as `${prefix}:${version}`. */
   RELEASE_NOTES: 'release:notes',
+  /**
+   * Cached Slack `conversations.info` projection keyed as
+   * `${prefix}:${scope}:${channelId}`.
+   */
+  SLACK_CHANNEL_INFO: 'slack:channel_info',
 } as const;
 
 /** Positive-cache TTL for successfully fetched GitHub release notes. */
 export const RELEASE_NOTES_CACHE_TTL_SECONDS = 6 * 60 * 60;
 /** Negative-cache TTL when a release is missing or GitHub fetch fails. */
 export const RELEASE_NOTES_NEGATIVE_CACHE_TTL_SECONDS = 15 * 60;
+
+/** Positive-cache TTL for a resolved Slack channel name / membership. */
+export const SLACK_CHANNEL_INFO_CACHE_TTL_SECONDS = 600;
+/** Negative-cache TTL when Slack reports the channel as inaccessible. */
+export const SLACK_CHANNEL_INFO_NEGATIVE_CACHE_TTL_SECONDS = 60;
 
 export const AUTO_START_EMPTY_SENTINEL = '__roomote_empty__';
 export const AUTO_START_CHANNEL_CACHE_TTL_SECONDS = 60;

--- a/packages/slack/src/__tests__/slack-api-fetch.test.ts
+++ b/packages/slack/src/__tests__/slack-api-fetch.test.ts
@@ -1,0 +1,138 @@
+import {
+  fetchSlackGetJson,
+  slackFetch,
+  SLACK_REQUEST_TIMEOUT_MS,
+} from '../slack-api-fetch';
+
+describe('slackFetch', () => {
+  const originalBaseUrl = process.env.SLACK_API_BASE_URL;
+
+  beforeEach(() => {
+    process.env.SLACK_API_BASE_URL = 'https://slack.com/api/';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+
+    if (originalBaseUrl === undefined) {
+      delete process.env.SLACK_API_BASE_URL;
+      return;
+    }
+
+    process.env.SLACK_API_BASE_URL = originalBaseUrl;
+  });
+
+  it('applies the Slack request timeout to every call', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+
+    await slackFetch(
+      'https://slack.com/api/auth.test',
+      { method: 'POST' },
+      { fetchImpl: fetchMock as unknown as typeof fetch },
+    );
+
+    expect(timeoutSpy).toHaveBeenCalledWith(SLACK_REQUEST_TIMEOUT_MS);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.method).toBe('POST');
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('honours an explicit timeout override', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+
+    await slackFetch(
+      'https://files.slack.com/download',
+      {},
+      { fetchImpl: fetchMock as unknown as typeof fetch, timeoutMs: 30_000 },
+    );
+
+    expect(timeoutSpy).toHaveBeenCalledWith(30_000);
+  });
+
+  it('keeps a caller-provided signal', async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+
+    await slackFetch(
+      'https://slack.com/api/auth.test',
+      { signal: controller.signal },
+      { fetchImpl: fetchMock as unknown as typeof fetch },
+    );
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.signal).toBe(controller.signal);
+  });
+
+  it('propagates a timed-out request to the caller', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValue(
+        new DOMException('The operation was aborted.', 'TimeoutError'),
+      );
+
+    await expect(
+      slackFetch(
+        'https://slack.com/api/auth.test',
+        {},
+        { fetchImpl: fetchMock as unknown as typeof fetch },
+      ),
+    ).rejects.toThrow('The operation was aborted.');
+  });
+
+  describe('fetchSlackGetJson', () => {
+    it('sends the timeout signal with the Slack GET request', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true }),
+      });
+
+      await fetchSlackGetJson({
+        token: 'xoxb-test-token',
+        endpoint: 'conversations.list',
+        context: 'listPublicChannels',
+        fetchImpl: fetchMock as unknown as typeof fetch,
+      });
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it('caps each rate-limit wait at the configured ceiling', async () => {
+      const waits: number[] = [];
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          statusText: 'Too Many Requests',
+          headers: {
+            get: (name: string) => (name === 'Retry-After' ? '60' : null),
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({ ok: true }),
+        });
+
+      const result = await fetchSlackGetJson<{ ok: boolean }>({
+        token: 'xoxb-test-token',
+        endpoint: 'conversations.list',
+        context: 'resolveChannelId',
+        fetchImpl: fetchMock as unknown as typeof fetch,
+        maxRateLimitRetries: 2,
+        maxRateLimitWaitMs: 5_000,
+        sleepImpl: async (ms) => {
+          waits.push(ms);
+        },
+      });
+
+      expect(waits).toEqual([5_000]);
+      expect(result).toEqual({ ok: true });
+    });
+  });
+});

--- a/packages/slack/src/__tests__/slack-channel-discovery.test.ts
+++ b/packages/slack/src/__tests__/slack-channel-discovery.test.ts
@@ -155,13 +155,21 @@ describe('SlackChannelDiscovery', () => {
       );
     });
 
-    it('fails fast when conversations.list is rate limited', async () => {
+    it('gives up after the rate-limit retry budget is exhausted', async () => {
       const consoleErrorSpy = vi
         .spyOn(console, 'error')
         .mockImplementation(() => undefined);
+      const waits: number[] = [];
+      const retryingDiscovery = new SlackChannelDiscovery(
+        token,
+        fetchMock as unknown as typeof fetch,
+        async (ms) => {
+          waits.push(ms);
+        },
+      );
 
       try {
-        fetchMock.mockResolvedValueOnce({
+        fetchMock.mockResolvedValue({
           ok: false,
           status: 429,
           statusText: 'Too Many Requests',
@@ -170,10 +178,13 @@ describe('SlackChannelDiscovery', () => {
           },
         });
 
-        await expect(discovery.listAccessibleChannels()).resolves.toEqual([]);
-        expect(fetchMock).toHaveBeenCalledTimes(1);
+        await expect(
+          retryingDiscovery.listAccessibleChannels(),
+        ).resolves.toEqual([]);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+        expect(waits).toEqual([5_000, 5_000]);
         expect(consoleErrorSpy).toHaveBeenCalledWith(
-          '[listAccessibleChannels] Slack conversations.list exhausted 0 rate-limit retries',
+          '[listAccessibleChannels] Slack conversations.list exhausted 2 rate-limit retries',
         );
       } finally {
         consoleErrorSpy.mockRestore();
@@ -231,13 +242,57 @@ describe('SlackChannelDiscovery', () => {
       }
     });
 
-    it('fails fast when conversations.list is rate limited', async () => {
+    it('retries a rate-limited conversations.list with capped waits', async () => {
+      const waits: number[] = [];
+      const retryingDiscovery = new SlackChannelDiscovery(
+        token,
+        fetchMock as unknown as typeof fetch,
+        async (ms) => {
+          waits.push(ms);
+        },
+      );
+
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          statusText: 'Too Many Requests',
+          headers: {
+            get: (name: string) => (name === 'Retry-After' ? '60' : null),
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            ok: true,
+            channels: [{ id: 'C999', name: 'team-updates' }],
+            response_metadata: { next_cursor: '' },
+          }),
+        });
+
+      await expect(
+        retryingDiscovery.resolveChannelId('#team-updates'),
+      ).resolves.toBe('C999');
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      // Slack asked for 60s; the interactive cap keeps the save responsive.
+      expect(waits).toEqual([5_000]);
+    });
+
+    it('fails fast once the rate-limit retry budget is exhausted', async () => {
       const consoleErrorSpy = vi
         .spyOn(console, 'error')
         .mockImplementation(() => undefined);
+      const waits: number[] = [];
+      const retryingDiscovery = new SlackChannelDiscovery(
+        token,
+        fetchMock as unknown as typeof fetch,
+        async (ms) => {
+          waits.push(ms);
+        },
+      );
 
       try {
-        fetchMock.mockResolvedValueOnce({
+        fetchMock.mockResolvedValue({
           ok: false,
           status: 429,
           statusText: 'Too Many Requests',
@@ -247,11 +302,12 @@ describe('SlackChannelDiscovery', () => {
         });
 
         await expect(
-          discovery.resolveChannelId('#team-updates'),
+          retryingDiscovery.resolveChannelId('#team-updates'),
         ).resolves.toBeNull();
-        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+        expect(waits).toEqual([5_000, 5_000]);
         expect(consoleErrorSpy).toHaveBeenCalledWith(
-          '[resolveChannelId] Slack conversations.list exhausted 0 rate-limit retries',
+          '[resolveChannelId] Slack conversations.list exhausted 2 rate-limit retries',
         );
       } finally {
         consoleErrorSpy.mockRestore();

--- a/packages/slack/src/__tests__/slack-channel-info-cache.test.ts
+++ b/packages/slack/src/__tests__/slack-channel-info-cache.test.ts
@@ -1,0 +1,214 @@
+import { SlackChannelInfoCache } from '../slack-channel-info-cache';
+import { SlackNotifier } from '../slack-notifier';
+
+const { redisStore, getRedisMock } = vi.hoisted(() => {
+  const store = new Map<string, { value: string; ttlSeconds: number }>();
+
+  return {
+    redisStore: store,
+    getRedisMock: vi.fn(() => ({
+      get: vi.fn(async (key: string) => store.get(key)?.value ?? null),
+      set: vi.fn(
+        async (key: string, value: string, _mode: string, ttl: number) => {
+          store.set(key, { value, ttlSeconds: ttl });
+          return 'OK';
+        },
+      ),
+    })),
+  };
+});
+
+vi.mock('@roomote/redis', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@roomote/redis')>();
+
+  return { ...actual, getRedis: getRedisMock };
+});
+
+vi.mock('@slack/web-api', () => ({ WebClient: vi.fn() }));
+
+type GlobalWithFetchMock = { fetch: ReturnType<typeof vi.fn> };
+
+const getGlobalWithFetch = (): GlobalWithFetchMock =>
+  globalThis as unknown as GlobalWithFetchMock;
+
+function mockConversationsInfo(
+  channel: Record<string, unknown>,
+): ReturnType<typeof vi.fn> {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ ok: true, channel }),
+  });
+}
+
+describe('SlackChannelInfoCache', () => {
+  const token = 'xoxb-test-token';
+  const originalBaseUrl = process.env.SLACK_API_BASE_URL;
+
+  beforeEach(() => {
+    process.env.SLACK_API_BASE_URL = 'https://slack.com/api/';
+    redisStore.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (originalBaseUrl === undefined) {
+      delete process.env.SLACK_API_BASE_URL;
+      return;
+    }
+
+    process.env.SLACK_API_BASE_URL = originalBaseUrl;
+  });
+
+  it('resolves a channel once per request across every lookup', async () => {
+    getGlobalWithFetch().fetch = mockConversationsInfo({
+      name: 'roomote-managers',
+      is_member: true,
+      is_private: false,
+    });
+
+    const notifier = new SlackNotifier(token, {
+      channelInfoCache: new SlackChannelInfoCache('T123'),
+    });
+
+    const [name, isMember, isPublic] = await Promise.all([
+      notifier.getChannelName('C123'),
+      notifier.isAppInChannel('C123'),
+      notifier.isPublicChannel('C123'),
+    ]);
+
+    expect(name).toBe('roomote-managers');
+    expect(isMember).toBe(true);
+    expect(isPublic).toBe(true);
+    expect(getGlobalWithFetch().fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves a later request from the shared cache without calling Slack', async () => {
+    getGlobalWithFetch().fetch = mockConversationsInfo({
+      name: 'roomote-managers',
+      is_member: true,
+      is_private: false,
+    });
+
+    const first = new SlackNotifier(token, {
+      channelInfoCache: new SlackChannelInfoCache('T123'),
+    });
+    await first.getChannelName('C123');
+    expect(getGlobalWithFetch().fetch).toHaveBeenCalledTimes(1);
+
+    // A new cache instance stands in for the next request.
+    const second = new SlackNotifier(token, {
+      channelInfoCache: new SlackChannelInfoCache('T123'),
+    });
+
+    expect(await second.getChannelName('C123')).toBe('roomote-managers');
+    expect(await second.isAppInChannel('C123')).toBe(true);
+    expect(getGlobalWithFetch().fetch).toHaveBeenCalledTimes(1);
+    expect([...redisStore.values()][0]?.ttlSeconds).toBe(600);
+  });
+
+  it('keeps caches for different workspaces apart', async () => {
+    getGlobalWithFetch().fetch = mockConversationsInfo({
+      name: 'roomote-managers',
+      is_member: true,
+    });
+
+    await new SlackNotifier(token, {
+      channelInfoCache: new SlackChannelInfoCache('T123'),
+    }).getChannelName('C123');
+
+    await new SlackNotifier(token, {
+      channelInfoCache: new SlackChannelInfoCache('T999'),
+    }).getChannelName('C123');
+
+    expect(getGlobalWithFetch().fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches an inaccessible channel with the shorter negative TTL', async () => {
+    getGlobalWithFetch().fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: false, error: 'channel_not_found' }),
+    });
+
+    const notifier = new SlackNotifier(token, {
+      channelInfoCache: new SlackChannelInfoCache('T123'),
+    });
+
+    expect(await notifier.isAppInChannel('C404')).toBe(false);
+    expect(await notifier.getChannelName('C404')).toBeNull();
+    expect([...redisStore.values()][0]?.ttlSeconds).toBe(60);
+
+    const next = new SlackNotifier(token, {
+      channelInfoCache: new SlackChannelInfoCache('T123'),
+    });
+
+    expect(await next.isAppInChannel('C404')).toBe(false);
+    expect(getGlobalWithFetch().fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches a channel the bot has not joined with the shorter TTL', async () => {
+    // Inviting the bot must take effect in seconds: an operator fixing this
+    // should not wait out the full positive TTL to clear the warning.
+    getGlobalWithFetch().fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        channel: { id: 'C777', name: 'hospital-alerts', is_member: false },
+      }),
+    });
+
+    const notifier = new SlackNotifier(token, {
+      channelInfoCache: new SlackChannelInfoCache('T123'),
+    });
+
+    expect(await notifier.isAppInChannel('C777')).toBe(false);
+    expect([...redisStore.values()][0]?.ttlSeconds).toBe(60);
+  });
+
+  it('does not cache lookups Slack never resolved', async () => {
+    getGlobalWithFetch().fetch = vi
+      .fn()
+      .mockRejectedValue(new Error('network error'));
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    try {
+      expect(
+        await new SlackNotifier(token, {
+          channelInfoCache: new SlackChannelInfoCache('T123'),
+        }).isAppInChannel('C123'),
+      ).toBeNull();
+
+      expect(redisStore.size).toBe(0);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it('skips the shared cache when no workspace scope is given', async () => {
+    getGlobalWithFetch().fetch = mockConversationsInfo({ name: 'general' });
+
+    const notifier = new SlackNotifier(token, {
+      channelInfoCache: new SlackChannelInfoCache(null),
+    });
+
+    await notifier.getChannelName('C123');
+
+    expect(redisStore.size).toBe(0);
+    expect(getRedisMock).not.toHaveBeenCalled();
+  });
+
+  it('still calls Slack per lookup when no cache is supplied', async () => {
+    getGlobalWithFetch().fetch = mockConversationsInfo({
+      name: 'general',
+      is_member: true,
+    });
+
+    const notifier = new SlackNotifier(token);
+
+    await notifier.getChannelName('C123');
+    await notifier.isAppInChannel('C123');
+
+    expect(getGlobalWithFetch().fetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/slack/src/__tests__/slack-notifier.test.ts
+++ b/packages/slack/src/__tests__/slack-notifier.test.ts
@@ -537,6 +537,8 @@ describe('SlackNotifier', () => {
           headers: expect.objectContaining({
             Authorization: `Bearer ${token}`,
           }),
+          // Every Slack call is bounded by a timeout signal.
+          signal: expect.any(AbortSignal),
         }),
       );
       expect(result).toBe(true);

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -17,6 +17,8 @@ export * from './request-user-input-blocks';
 export * from './request-user-input';
 export * from './router-debug';
 export * from './slack-api-base-url';
+export * from './slack-api-fetch';
+export * from './slack-channel-info-cache';
 export * from './slack-messages';
 export * from './slack-notifier';
 export * from './slack-system-messages';

--- a/packages/slack/src/interactive-response.ts
+++ b/packages/slack/src/interactive-response.ts
@@ -1,8 +1,10 @@
+import { slackFetch } from './slack-api-fetch';
+
 export async function postSlackInteractiveResponse(
   responseUrl: string,
   body: Record<string, unknown>,
 ) {
-  await fetch(responseUrl, {
+  await slackFetch(responseUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),

--- a/packages/slack/src/slack-api-fetch.ts
+++ b/packages/slack/src/slack-api-fetch.ts
@@ -2,10 +2,41 @@ import { buildSlackApiUrl } from './slack-api-base-url';
 
 const DEFAULT_SLACK_RATE_LIMIT_RETRY_AFTER_MS = 1_000;
 
+/**
+ * Ceiling for every Slack Web API request. Slack calls sit on user-facing
+ * request paths, so a hung socket must fail fast instead of stalling the
+ * caller for the platform-default (unbounded) socket timeout.
+ */
+export const SLACK_REQUEST_TIMEOUT_MS = 5_000;
+
+/**
+ * File downloads stream real payloads, so they get a longer ceiling than the
+ * JSON API calls while still staying bounded.
+ */
+export const SLACK_DOWNLOAD_TIMEOUT_MS = 30_000;
+
 type SlackApiBaseResponse = {
   ok: boolean;
   error?: string;
 };
+
+/**
+ * Wraps `fetch` with a Slack-specific timeout. Callers already treat a thrown
+ * fetch as "unavailable", so an aborted request surfaces through their
+ * existing catch blocks unchanged.
+ */
+export function slackFetch(
+  url: string,
+  init: RequestInit = {},
+  options: { fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+): Promise<Response> {
+  const { fetchImpl = fetch, timeoutMs = SLACK_REQUEST_TIMEOUT_MS } = options;
+
+  return fetchImpl(url, {
+    ...init,
+    signal: init.signal ?? AbortSignal.timeout(timeoutMs),
+  });
+}
 
 export function getSlackRetryAfterMs(retryAfterHeader: string | null): number {
   const retryAfterSeconds = Number.parseFloat(retryAfterHeader ?? '');
@@ -20,6 +51,10 @@ export function getSlackRetryAfterMs(retryAfterHeader: string | null): number {
   );
 }
 
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export async function fetchSlackGetJson<
   TResponse extends SlackApiBaseResponse,
 >(params: {
@@ -29,6 +64,9 @@ export async function fetchSlackGetJson<
   query?: URLSearchParams;
   fetchImpl?: typeof fetch;
   maxRateLimitRetries?: number;
+  /** Caps each individual `Retry-After` wait so retries stay bounded. */
+  maxRateLimitWaitMs?: number;
+  sleepImpl?: (ms: number) => Promise<void>;
 }): Promise<TResponse | null> {
   const {
     token,
@@ -37,6 +75,8 @@ export async function fetchSlackGetJson<
     query,
     fetchImpl = fetch,
     maxRateLimitRetries = 0,
+    maxRateLimitWaitMs,
+    sleepImpl = defaultSleep,
   } = params;
 
   let retryCount = 0;
@@ -46,13 +86,17 @@ export async function fetchSlackGetJson<
       ? `${buildSlackApiUrl(endpoint)}?${query.toString()}`
       : buildSlackApiUrl(endpoint);
 
-    const response = await fetchImpl(url, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/x-www-form-urlencoded',
+    const response = await slackFetch(
+      url,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
       },
-    });
+      { fetchImpl },
+    );
 
     if (response.status === 429) {
       if (retryCount >= maxRateLimitRetries) {
@@ -63,11 +107,15 @@ export async function fetchSlackGetJson<
       }
 
       retryCount += 1;
-      await new Promise((resolve) =>
-        setTimeout(
-          resolve,
-          getSlackRetryAfterMs(response.headers.get('Retry-After')),
-        ),
+
+      const retryAfterMs = getSlackRetryAfterMs(
+        response.headers.get('Retry-After'),
+      );
+
+      await sleepImpl(
+        maxRateLimitWaitMs === undefined
+          ? retryAfterMs
+          : Math.min(retryAfterMs, maxRateLimitWaitMs),
       );
       continue;
     }

--- a/packages/slack/src/slack-channel-discovery.ts
+++ b/packages/slack/src/slack-channel-discovery.ts
@@ -2,6 +2,13 @@ import { fetchSlackGetJson } from './slack-api-fetch';
 
 const SLACK_CONVERSATIONS_LIST_LIMIT = 999;
 const MAX_SLACK_CONVERSATIONS_LIST_PUBLIC_CHANNEL_RATE_LIMIT_RETRIES = 3;
+const MAX_SLACK_CONVERSATIONS_LIST_INTERACTIVE_RATE_LIMIT_RETRIES = 2;
+
+/**
+ * Interactive flows retry rate limits, but each wait is capped so a
+ * user-facing save adds at most a couple of bounded pauses.
+ */
+const MAX_SLACK_CONVERSATIONS_LIST_INTERACTIVE_RATE_LIMIT_WAIT_MS = 5_000;
 
 type SlackConversationListChannel = {
   id?: string;
@@ -23,9 +30,21 @@ function getConversationsListRateLimitRetries(
       return MAX_SLACK_CONVERSATIONS_LIST_PUBLIC_CHANNEL_RATE_LIMIT_RETRIES;
     case 'listAccessibleChannels':
     case 'resolveChannelId':
-      // Interactive settings flows should fail fast when Slack rate-limits
-      // channel discovery instead of waiting through multi-minute retry windows.
-      return 0;
+      // Interactive settings flows retry a couple of times with capped waits
+      // instead of waiting through Slack's multi-minute retry windows.
+      return MAX_SLACK_CONVERSATIONS_LIST_INTERACTIVE_RATE_LIMIT_RETRIES;
+  }
+}
+
+function getConversationsListRateLimitWaitCapMs(
+  context: SlackConversationsListContext,
+): number | undefined {
+  switch (context) {
+    case 'listPublicChannels':
+      return undefined;
+    case 'listAccessibleChannels':
+    case 'resolveChannelId':
+      return MAX_SLACK_CONVERSATIONS_LIST_INTERACTIVE_RATE_LIMIT_WAIT_MS;
   }
 }
 
@@ -42,6 +61,7 @@ export class SlackChannelDiscovery {
   constructor(
     private readonly token: string,
     private readonly fetchImpl: typeof fetch = fetch,
+    private readonly sleepImpl?: (ms: number) => Promise<void>,
   ) {}
 
   private async fetchConversationsListPage(params: {
@@ -67,6 +87,8 @@ export class SlackChannelDiscovery {
       query,
       fetchImpl: this.fetchImpl,
       maxRateLimitRetries: getConversationsListRateLimitRetries(context),
+      maxRateLimitWaitMs: getConversationsListRateLimitWaitCapMs(context),
+      sleepImpl: this.sleepImpl,
     });
   }
 

--- a/packages/slack/src/slack-channel-info-cache.ts
+++ b/packages/slack/src/slack-channel-info-cache.ts
@@ -1,0 +1,132 @@
+import {
+  getRedis,
+  REDIS_KEYS,
+  SLACK_CHANNEL_INFO_CACHE_TTL_SECONDS,
+  SLACK_CHANNEL_INFO_NEGATIVE_CACHE_TTL_SECONDS,
+} from '@roomote/redis';
+
+/**
+ * Flattened `conversations.info` projection: everything the notifier's channel
+ * lookups need, so one Slack round trip answers name, membership and
+ * visibility questions for a channel.
+ */
+export type SlackChannelInfo = {
+  name: string | null;
+  isMember: boolean | null;
+  isPrivate: boolean | null;
+  /** Slack reported `channel_not_found` / `not_in_channel`. */
+  notFound: boolean;
+};
+
+function isSlackChannelInfo(value: unknown): value is SlackChannelInfo {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'notFound' in value &&
+    typeof (value as SlackChannelInfo).notFound === 'boolean'
+  );
+}
+
+/**
+ * Two-layer cache for `conversations.info`.
+ *
+ * The in-memory memo is scoped to one instance (created per request by the
+ * settings read path) so overlapping lookup rounds hit Slack once; the Redis
+ * layer keeps that answer warm across requests. Both layers are best effort -
+ * a Redis outage degrades to plain Slack calls.
+ */
+export class SlackChannelInfoCache {
+  private readonly memo = new Map<string, Promise<SlackChannelInfo | null>>();
+
+  /**
+   * @param scope Workspace identity (Slack team id or installation id) the
+   * cached entries belong to. Null disables the cross-request layer.
+   */
+  constructor(private readonly scope: string | null = null) {}
+
+  public resolve(
+    channelId: string,
+    load: () => Promise<SlackChannelInfo | null>,
+  ): Promise<SlackChannelInfo | null> {
+    const memoized = this.memo.get(channelId);
+
+    if (memoized) {
+      return memoized;
+    }
+
+    const pending = this.loadThroughSharedCache(channelId, load);
+    this.memo.set(channelId, pending);
+
+    return pending;
+  }
+
+  private async loadThroughSharedCache(
+    channelId: string,
+    load: () => Promise<SlackChannelInfo | null>,
+  ): Promise<SlackChannelInfo | null> {
+    const cached = await this.read(channelId);
+
+    if (cached) {
+      return cached;
+    }
+
+    const info = await load();
+
+    // Unresolved lookups (transport errors, unknown Slack errors) are not
+    // cached so the next request can retry them.
+    if (info) {
+      await this.write(channelId, info);
+    }
+
+    return info;
+  }
+
+  private key(channelId: string): string {
+    return `${REDIS_KEYS.SLACK_CHANNEL_INFO}:${this.scope}:${channelId}`;
+  }
+
+  private async read(channelId: string): Promise<SlackChannelInfo | null> {
+    if (!this.scope) {
+      return null;
+    }
+
+    try {
+      const raw = await getRedis().get(this.key(channelId));
+
+      if (!raw) {
+        return null;
+      }
+
+      const parsed: unknown = JSON.parse(raw);
+
+      return isSlackChannelInfo(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async write(
+    channelId: string,
+    info: SlackChannelInfo,
+  ): Promise<void> {
+    if (!this.scope) {
+      return;
+    }
+
+    try {
+      await getRedis().set(
+        this.key(channelId),
+        JSON.stringify(info),
+        'EX',
+        // A channel the bot cannot see or has not joined is a state the
+        // operator is usually in the middle of fixing: cache it briefly so
+        // inviting the bot is reflected in seconds, not minutes.
+        info.notFound || info.isMember === false
+          ? SLACK_CHANNEL_INFO_NEGATIVE_CACHE_TTL_SECONDS
+          : SLACK_CHANNEL_INFO_CACHE_TTL_SECONDS,
+      );
+    } catch {
+      // Best effort; the caller still uses the freshly fetched value.
+    }
+  }
+}

--- a/packages/slack/src/slack-notifier.ts
+++ b/packages/slack/src/slack-notifier.ts
@@ -16,7 +16,16 @@ import { convertSlackLinksToMarkdown } from './markdown-converter';
 import { logSlackError, slackDebug } from './logging';
 import { SlackChannelDiscovery } from './slack-channel-discovery';
 import { buildSlackApiUrl } from './slack-api-base-url';
-import { fetchSlackGetJson, getSlackRetryAfterMs } from './slack-api-fetch';
+import {
+  fetchSlackGetJson,
+  getSlackRetryAfterMs,
+  slackFetch,
+  SLACK_DOWNLOAD_TIMEOUT_MS,
+} from './slack-api-fetch';
+import type {
+  SlackChannelInfo,
+  SlackChannelInfoCache,
+} from './slack-channel-info-cache';
 import { isSlackImageFile } from './thread-image-utils';
 import { createSlackWebClient } from './web-client';
 import {
@@ -153,8 +162,15 @@ function normalizeOutboundMessage<T extends object & SlackMessage>(
   };
 }
 
+type SlackChannelInfoContext = {
+  /** Log prefix, kept per public method so log lines stay recognizable. */
+  name: string;
+  transportFailureLabel: string;
+};
+
 export class SlackNotifier {
   private readonly token: string;
+  private readonly channelInfoCache: SlackChannelInfoCache | null;
   private client?: WebClient;
   private channelDiscovery?: SlackChannelDiscovery;
   private ownBotIdentityPromise?: Promise<{
@@ -162,8 +178,12 @@ export class SlackNotifier {
     botId?: string;
   } | null>;
 
-  constructor(token: string) {
+  constructor(
+    token: string,
+    options: { channelInfoCache?: SlackChannelInfoCache } = {},
+  ) {
     this.token = token;
+    this.channelInfoCache = options.channelInfoCache ?? null;
   }
 
   private getClient(): WebClient {
@@ -189,7 +209,7 @@ export class SlackNotifier {
     if (!this.ownBotIdentityPromise) {
       this.ownBotIdentityPromise = (async () => {
         try {
-          const response = await fetch(buildSlackApiUrl('auth.test'), {
+          const response = await slackFetch(buildSlackApiUrl('auth.test'), {
             method: 'POST',
             headers: {
               Authorization: `Bearer ${this.token}`,
@@ -357,6 +377,94 @@ export class SlackNotifier {
   }
 
   /**
+   * Fetches the `conversations.info` projection for a channel once, going
+   * through the caller-supplied cache when there is one.
+   */
+  private async getChannelInfo(
+    channelId: string,
+    context: SlackChannelInfoContext,
+  ): Promise<SlackChannelInfo | null> {
+    const load = () => this.loadChannelInfo(channelId, context);
+
+    return this.channelInfoCache
+      ? this.channelInfoCache.resolve(channelId, load)
+      : load();
+  }
+
+  private async loadChannelInfo(
+    channelId: string,
+    context: SlackChannelInfoContext,
+  ): Promise<SlackChannelInfo | null> {
+    try {
+      const params = new URLSearchParams({ channel: channelId });
+      const response = await slackFetch(
+        `${buildSlackApiUrl('conversations.info')}?${params.toString()}`,
+        {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${this.token}`,
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+        },
+      );
+
+      if (!response.ok) {
+        console.error(
+          `[${context.name}] Slack conversations.info failed: ${response.status} ${response.statusText}`,
+        );
+        return null;
+      }
+
+      const result = (await response.json()) as {
+        ok: boolean;
+        error?: string;
+        channel?: {
+          name?: string | null;
+          is_member?: boolean;
+          is_private?: boolean;
+        };
+      };
+
+      if (!result.ok) {
+        if (
+          result.error === 'channel_not_found' ||
+          result.error === 'not_in_channel'
+        ) {
+          return {
+            name: null,
+            isMember: false,
+            isPrivate: null,
+            notFound: true,
+          };
+        }
+
+        console.error(
+          `[${context.name}] Slack conversations.info error: ${result.error ?? 'unknown_error'}`,
+        );
+        return null;
+      }
+
+      return {
+        name: result.channel?.name?.trim() || null,
+        isMember:
+          typeof result.channel?.is_member === 'boolean'
+            ? result.channel.is_member
+            : null,
+        isPrivate:
+          typeof result.channel?.is_private === 'boolean'
+            ? result.channel.is_private
+            : null,
+        notFound: false,
+      };
+    } catch (error) {
+      console.error(
+        `[${context.name}] ${context.transportFailureLabel}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return null;
+    }
+  }
+
+  /**
    * Returns whether the Slack app is a member of the given channel.
    *
    * - `true` when the app is already in the channel
@@ -370,57 +478,16 @@ export class SlackNotifier {
       return null;
     }
 
-    try {
-      const params = new URLSearchParams({ channel: trimmed });
-      const response = await fetch(
-        `${buildSlackApiUrl('conversations.info')}?${params.toString()}`,
-        {
-          method: 'GET',
-          headers: {
-            Authorization: `Bearer ${this.token}`,
-            'Content-Type': 'application/x-www-form-urlencoded',
-          },
-        },
-      );
+    const info = await this.getChannelInfo(trimmed, {
+      name: 'isAppInChannel',
+      transportFailureLabel: 'Failed to inspect channel membership',
+    });
 
-      if (!response.ok) {
-        console.error(
-          `[isAppInChannel] Slack conversations.info failed: ${response.status} ${response.statusText}`,
-        );
-        return null;
-      }
-
-      const result = (await response.json()) as {
-        ok: boolean;
-        error?: string;
-        channel?: { is_member?: boolean };
-      };
-
-      if (!result.ok) {
-        if (
-          result.error === 'channel_not_found' ||
-          result.error === 'not_in_channel'
-        ) {
-          return false;
-        }
-
-        console.error(
-          `[isAppInChannel] Slack conversations.info error: ${result.error ?? 'unknown_error'}`,
-        );
-        return null;
-      }
-
-      if (typeof result.channel?.is_member === 'boolean') {
-        return result.channel.is_member;
-      }
-
-      return null;
-    } catch (error) {
-      console.error(
-        `[isAppInChannel] Failed to inspect channel membership: ${error instanceof Error ? error.message : String(error)}`,
-      );
+    if (!info) {
       return null;
     }
+
+    return info.notFound ? false : info.isMember;
   }
 
   /**
@@ -437,50 +504,16 @@ export class SlackNotifier {
       return null;
     }
 
-    try {
-      const params = new URLSearchParams({ channel: trimmed });
-      const response = await fetch(
-        `${buildSlackApiUrl('conversations.info')}?${params.toString()}`,
-        {
-          method: 'GET',
-          headers: {
-            Authorization: `Bearer ${this.token}`,
-            'Content-Type': 'application/x-www-form-urlencoded',
-          },
-        },
-      );
+    const info = await this.getChannelInfo(trimmed, {
+      name: 'isPublicChannel',
+      transportFailureLabel: 'Failed to inspect channel visibility',
+    });
 
-      if (!response.ok) {
-        console.error(
-          `[isPublicChannel] Slack conversations.info failed: ${response.status} ${response.statusText}`,
-        );
-        return null;
-      }
-
-      const result = (await response.json()) as {
-        ok: boolean;
-        error?: string;
-        channel?: { is_private?: boolean };
-      };
-
-      if (!result.ok) {
-        console.error(
-          `[isPublicChannel] Slack conversations.info error: ${result.error ?? 'unknown_error'}`,
-        );
-        return null;
-      }
-
-      if (typeof result.channel?.is_private === 'boolean') {
-        return !result.channel.is_private;
-      }
-
-      return null;
-    } catch (error) {
-      console.error(
-        `[isPublicChannel] Failed to inspect channel visibility: ${error instanceof Error ? error.message : String(error)}`,
-      );
+    if (!info || info.isPrivate === null) {
       return null;
     }
+
+    return !info.isPrivate;
   }
 
   /**
@@ -493,46 +526,12 @@ export class SlackNotifier {
       return null;
     }
 
-    try {
-      const params = new URLSearchParams({ channel: trimmed });
-      const response = await fetch(
-        `${buildSlackApiUrl('conversations.info')}?${params.toString()}`,
-        {
-          method: 'GET',
-          headers: {
-            Authorization: `Bearer ${this.token}`,
-            'Content-Type': 'application/x-www-form-urlencoded',
-          },
-        },
-      );
+    const info = await this.getChannelInfo(trimmed, {
+      name: 'getChannelName',
+      transportFailureLabel: 'Failed to inspect channel name',
+    });
 
-      if (!response.ok) {
-        console.error(
-          `[getChannelName] Slack conversations.info failed: ${response.status} ${response.statusText}`,
-        );
-        return null;
-      }
-
-      const result = (await response.json()) as {
-        ok: boolean;
-        error?: string;
-        channel?: { name?: string | null };
-      };
-
-      if (!result.ok) {
-        console.error(
-          `[getChannelName] Slack conversations.info error: ${result.error ?? 'unknown_error'}`,
-        );
-        return null;
-      }
-
-      return result.channel?.name?.trim() || null;
-    } catch (error) {
-      console.error(
-        `[getChannelName] Failed to inspect channel name: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      return null;
-    }
+    return info?.name ?? null;
   }
 
   public async getMessagePermalink(params: {
@@ -551,7 +550,7 @@ export class SlackNotifier {
         channel,
         message_ts: messageTs,
       });
-      const response = await fetch(
+      const response = await slackFetch(
         `${buildSlackApiUrl('chat.getPermalink')}?${searchParams.toString()}`,
         {
           method: 'GET',
@@ -628,7 +627,7 @@ export class SlackNotifier {
           params.set('cursor', cursor);
         }
 
-        const response = await fetch(
+        const response = await slackFetch(
           `${buildSlackApiUrl('conversations.members')}?${params.toString()}`,
           {
             method: 'GET',
@@ -688,7 +687,7 @@ export class SlackNotifier {
    */
   public async getWorkspaceTimezone(): Promise<string | null> {
     try {
-      const response = await fetch(buildSlackApiUrl('team.info'), {
+      const response = await slackFetch(buildSlackApiUrl('team.info'), {
         method: 'GET',
         headers: {
           Authorization: `Bearer ${this.token}`,
@@ -778,14 +777,17 @@ export class SlackNotifier {
    */
   public async openConversation(userId: string): Promise<string | null> {
     try {
-      const response = await fetch(buildSlackApiUrl('conversations.open'), {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${this.token}`,
+      const response = await slackFetch(
+        buildSlackApiUrl('conversations.open'),
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${this.token}`,
+          },
+          body: JSON.stringify({ users: userId }),
         },
-        body: JSON.stringify({ users: userId }),
-      });
+      );
 
       if (!response.ok) {
         console.error(
@@ -824,7 +826,7 @@ export class SlackNotifier {
     const normalizedMessage = normalizeOutboundMessage(message);
 
     try {
-      const response = await fetch(buildSlackApiUrl(endpoint), {
+      const response = await slackFetch(buildSlackApiUrl(endpoint), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -906,7 +908,7 @@ export class SlackNotifier {
     try {
       const message = normalizeOutboundMessage({ channel, ts, ...rest });
 
-      const response = await fetch(buildSlackApiUrl('chat.update'), {
+      const response = await slackFetch(buildSlackApiUrl('chat.update'), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -968,7 +970,7 @@ export class SlackNotifier {
       };
 
       while (true) {
-        const response = await fetch(
+        const response = await slackFetch(
           `${buildSlackApiUrl('conversations.replies')}?${query.toString()}`,
           {
             method: 'GET',
@@ -1055,7 +1057,7 @@ export class SlackNotifier {
     threadTs: string;
   }): Promise<unknown[] | null> {
     try {
-      const response = await fetch(
+      const response = await slackFetch(
         `${buildSlackApiUrl('conversations.replies')}?channel=${encodeURIComponent(channel)}&ts=${encodeURIComponent(threadTs)}&oldest=${encodeURIComponent(messageTs)}&latest=${encodeURIComponent(messageTs)}&inclusive=true`,
         {
           method: 'GET',
@@ -1183,7 +1185,7 @@ export class SlackNotifier {
         };
       };
 
-      const historyResponse = await fetch(
+      const historyResponse = await slackFetch(
         `${buildSlackApiUrl('conversations.history')}?channel=${encodeURIComponent(channel)}&oldest=${encodeURIComponent(messageTs)}&latest=${encodeURIComponent(messageTs)}&inclusive=true&limit=1&include_all_metadata=true`,
         {
           method: 'GET',
@@ -1221,7 +1223,7 @@ export class SlackNotifier {
         return null;
       }
 
-      const repliesResponse = await fetch(
+      const repliesResponse = await slackFetch(
         `${buildSlackApiUrl('conversations.replies')}?channel=${encodeURIComponent(channel)}&ts=${encodeURIComponent(threadTs)}&oldest=${encodeURIComponent(messageTs)}&latest=${encodeURIComponent(messageTs)}&inclusive=true&include_all_metadata=true`,
         {
           method: 'GET',
@@ -1351,7 +1353,7 @@ export class SlackNotifier {
         return parseMessage(result.messages);
       };
 
-      const historyResponse = await fetch(
+      const historyResponse = await slackFetch(
         `${buildSlackApiUrl('conversations.history')}?channel=${encodeURIComponent(channel)}&oldest=${encodeURIComponent(messageTs)}&latest=${encodeURIComponent(messageTs)}&inclusive=true&limit=1`,
         {
           method: 'GET',
@@ -1396,7 +1398,7 @@ export class SlackNotifier {
         return messageFromHistory;
       }
 
-      const repliesResponse = await fetch(
+      const repliesResponse = await slackFetch(
         `${buildSlackApiUrl('conversations.replies')}?channel=${encodeURIComponent(channel)}&ts=${encodeURIComponent(messageTs)}&oldest=${encodeURIComponent(messageTs)}&latest=${encodeURIComponent(messageTs)}&inclusive=true`,
         {
           method: 'GET',
@@ -1517,7 +1519,7 @@ export class SlackNotifier {
 
   public async deleteMessage(payload: { channel: string; ts: string }) {
     try {
-      const response = await fetch(buildSlackApiUrl('chat.delete'), {
+      const response = await slackFetch(buildSlackApiUrl('chat.delete'), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1698,7 +1700,7 @@ export class SlackNotifier {
     name: string;
   }): Promise<boolean> {
     try {
-      const response = await fetch(buildSlackApiUrl('reactions.add'), {
+      const response = await slackFetch(buildSlackApiUrl('reactions.add'), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1757,7 +1759,7 @@ export class SlackNotifier {
     name: string;
   }): Promise<boolean> {
     try {
-      const response = await fetch(buildSlackApiUrl('reactions.remove'), {
+      const response = await slackFetch(buildSlackApiUrl('reactions.remove'), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1830,11 +1832,17 @@ export class SlackNotifier {
 
   public async downloadSlackFile(file: SlackFile): Promise<Buffer | null> {
     try {
-      const response = await fetch(file.url_private_download, {
-        headers: {
-          Authorization: `Bearer ${this.token}`,
+      const response = await slackFetch(
+        file.url_private_download,
+        {
+          headers: {
+            Authorization: `Bearer ${this.token}`,
+          },
         },
-      });
+        // File bodies stream, so they get the download ceiling rather than the
+        // short API-call ceiling.
+        { timeoutMs: SLACK_DOWNLOAD_TIMEOUT_MS },
+      );
 
       if (!response.ok) {
         console.error(
@@ -1872,7 +1880,7 @@ export class SlackNotifier {
     await Promise.all(
       uniqueUserIds.map(async (userId) => {
         try {
-          const response = await fetch(
+          const response = await slackFetch(
             `${buildSlackApiUrl('users.info')}?user=${encodeURIComponent(userId)}`,
             {
               method: 'GET',
@@ -1964,7 +1972,7 @@ export class SlackNotifier {
         params.set('inclusive', 'true');
       }
 
-      const response = await fetch(
+      const response = await slackFetch(
         `${buildSlackApiUrl('conversations.replies')}?${params.toString()}`,
         {
           method: 'GET',
@@ -2044,7 +2052,7 @@ export class SlackNotifier {
           params.set('cursor', cursor);
         }
 
-        const response = await fetch(
+        const response = await slackFetch(
           `${buildSlackApiUrl('conversations.history')}?${params.toString()}`,
           {
             method: 'GET',


### PR DESCRIPTION
A production instance takes **~7s** to render its dashboard. Profiling the batched tRPC request (13 procedures) found twelve trivial DB reads and one procedure doing real network work.

## What was happening

`automations.getSettings` makes **30–40 `conversations.info` calls to Slack per dashboard load**, in three *serialized* rounds that each re-resolve the same channel ids — no cache, no timeout, no retry — plus ~50–60 DB statements including `INSERT`s on a read path. `httpBatchLink` buffers the response until every procedure settles, so twelve fast queries waited on that one. It is called unconditionally from the home page's onboarding card, which only needed a single boolean from it.

This also explains a second report from the same instance — `Could not resolve Slack channel #…` when saving an automation. Each page load was spending dozens of calls against the workspace's Slack quota while `conversations.list` had a retry budget of **zero**.

## Changes

- **Timeouts**: every Slack request goes through one helper with a 5s timeout (30s for file downloads). A hung socket could previously hang a user-facing query forever.
- **Caching**: `conversations.info` is memoised per request and cached in Redis for 10 minutes — 60s when the bot is missing from the channel or cannot see it, because that is the state an operator is actively fixing (invite the bot, see it clear in seconds).
- **Off the critical path**: new `automations.onboardingStatus` returns just what the onboarding card consumes, from local rows, behind the same admin gate. `getSettings` is untouched for the settings page.
- **Inside the resolver**: the independent rounds now run concurrently, the 10× per-automation runtime reads are batched into two queries, a duplicate `listAutomations()` is gone, and read paths no longer INSERT.
- **`conversations.list`**: two retries honouring `Retry-After`, each wait capped at 5s so an interactive save stays bounded; the exhaustion message is unchanged.
- **Streaming**: `httpBatchStreamLink` lets the fast procedures render immediately instead of waiting for the slowest.

## Tests

Timeout application, cache hit/miss/dedupe and both TTL classes, retry-then-succeed and retry-exhausted, the new procedure's shape without Slack calls, and resolver concurrency. Full suites green for the touched packages — slack (323), db (405), web (2429), redis, sdk — plus repo-wide `check-types`, `lint`, and `knip`.

## Follow-ups not taken

`oauth.v2.access`/`openid.connect.*` and `create-app-from-manifest` still use un-timed bare fetches (off this path, same hang risk); `listAccessibleChannels` (`conversations.list`, up to 999/page) is uncached and paid on every channel-picker open; and several dashboard procedures independently re-read `deployment_settings`, which a request-scoped loader would collapse.