### PR TITLE
Log per-request and slow-procedure timings

### DIFF
--- a/apps/web/src/app/api/trpc/[trpc]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/trpc/[trpc]/__tests__/route.test.ts
@@ -1,0 +1,137 @@
+import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
+
+import { logger } from '@/lib/server/logger';
+
+import { POST } from '../route';
+
+vi.mock('@/lib/server/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const { createContextMock } = vi.hoisted(() => ({
+  createContextMock: vi.fn(),
+}));
+
+vi.mock('@/trpc/init', () => ({
+  createContext: createContextMock,
+}));
+
+vi.mock('@/trpc/routers/_app', () => ({
+  appRouter: { _def: {} },
+}));
+
+vi.mock('@trpc/server/adapters/fetch', () => ({
+  fetchRequestHandler: vi.fn(),
+}));
+
+const infoMock = vi.mocked(logger.info);
+const fetchRequestHandlerMock = vi.mocked(fetchRequestHandler);
+
+describe('POST /api/trpc/[trpc]', () => {
+  let clock = 0;
+  let responseMetaResult: unknown;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clock = 0;
+    responseMetaResult = undefined;
+    vi.spyOn(performance, 'now').mockImplementation(() => clock);
+
+    createContextMock.mockImplementation(async () => {
+      // Time spent resolving the session, which runs even for requests that
+      // are rejected as unauthenticated.
+      clock += 30;
+      return { auth: { success: false } };
+    });
+
+    // Stand-in for tRPC: burn time before and after context creation, ask for
+    // response metadata the way the streaming adapter does, then answer.
+    fetchRequestHandlerMock.mockImplementation(async (opts) => {
+      clock += 5;
+      await (opts.createContext as (input: unknown) => Promise<unknown>)({});
+      clock += 15;
+      responseMetaResult = opts.responseMeta?.({
+        data: [],
+        ctx: undefined,
+        paths: ['tasks.get'],
+        info: undefined,
+        type: 'query',
+        errors: [],
+        eagerGeneration: true,
+      });
+
+      return new Response('{"result":{}}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const call = () =>
+    POST(
+      new Request('https://app.test/api/trpc/tasks.get,users.me?batch=1', {
+        method: 'POST',
+      }),
+    );
+
+  it('emits one request-timing line with the auth and handler durations', async () => {
+    const response = await call();
+
+    // The line is emitted once the response body has been flushed.
+    expect(infoMock).not.toHaveBeenCalled();
+
+    await expect(response.text()).resolves.toBe('{"result":{}}');
+
+    expect(infoMock).toHaveBeenCalledTimes(1);
+    expect(infoMock).toHaveBeenCalledWith(
+      '[request-timing] path=/api/trpc/tasks.get,users.me procedures=tasks.get,users.me auth=30 handler=50 status=200 batch=2 total=50',
+    );
+  });
+
+  it('exposes the known phases through Server-Timing', async () => {
+    const response = await call();
+
+    // Streaming responses ask for metadata before any procedure resolves, so
+    // only the auth phase is knowable there.
+    expect(responseMetaResult).toEqual({
+      headers: { 'server-timing': 'auth;dur=30' },
+    });
+    expect(response.headers.get('server-timing')).toBe('handler;dur=50');
+
+    await response.text();
+  });
+
+  it('still reports when context creation fails', async () => {
+    createContextMock.mockImplementation(async () => {
+      clock += 12;
+      throw new Error('session lookup failed');
+    });
+    fetchRequestHandlerMock.mockImplementation(async (opts) => {
+      clock += 5;
+
+      try {
+        await (opts.createContext as (input: unknown) => Promise<unknown>)({});
+      } catch {
+        // tRPC turns this into an error response rather than rejecting.
+      }
+
+      return new Response('{"error":{}}', { status: 500 });
+    });
+
+    const response = await call();
+    await response.text();
+
+    expect(infoMock).toHaveBeenCalledWith(
+      '[request-timing] path=/api/trpc/tasks.get,users.me procedures=tasks.get,users.me auth=12 handler=17 status=500 batch=2 total=17',
+    );
+  });
+});

--- a/apps/web/src/app/api/trpc/[trpc]/route.ts
+++ b/apps/web/src/app/api/trpc/[trpc]/route.ts
@@ -1,11 +1,71 @@
 import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
 
 import { createContext } from '@/trpc/init';
+import {
+  buildAuthServerTiming,
+  buildHandlerServerTiming,
+  describeRequestProcedures,
+  logRequestTiming,
+  withResponseCompletionTiming,
+} from '@/trpc/request-timing';
 import { appRouter as router } from '@/trpc/routers/_app';
 
 export const runtime = 'nodejs';
 
-const handler = (req: Request) =>
-  fetchRequestHandler({ endpoint: '/api/trpc', req, router, createContext });
+const handler = async (req: Request) => {
+  // Taken before anything else in the handler so the delta against the
+  // client-observed duration is attributable to us and not to our own setup.
+  const handlerStartedAt = performance.now();
+  let authMs: number | null = null;
+
+  const response = await fetchRequestHandler({
+    endpoint: '/api/trpc',
+    req,
+    router,
+    createContext: async () => {
+      const contextStartedAt = performance.now();
+
+      try {
+        return await createContext();
+      } finally {
+        authMs = performance.now() - contextStartedAt;
+      }
+    },
+    // Runs once the context exists but (with `httpBatchStreamLink`) before any
+    // procedure has resolved, so only the auth phase can be reported here.
+    responseMeta: () => {
+      const authTiming = buildAuthServerTiming(authMs);
+
+      return authTiming ? { headers: { 'server-timing': authTiming } } : {};
+    },
+  });
+
+  const handlerMs = performance.now() - handlerStartedAt;
+
+  try {
+    // Still ahead of the headers going out, so this reaches the client.
+    response.headers.append(
+      'server-timing',
+      buildHandlerServerTiming(handlerMs),
+    );
+  } catch {
+    // Immutable headers are not worth failing a request over.
+  }
+
+  const url = new URL(req.url);
+  const { procedures, batch } = describeRequestProcedures(url);
+
+  return withResponseCompletionTiming(response, () => {
+    logRequestTiming({
+      path: url.pathname,
+      procedures,
+      batch,
+      authMs,
+      handlerMs,
+      totalMs: performance.now() - handlerStartedAt,
+      status: response.status,
+    });
+  });
+};
 
 export { handler as GET, handler as POST };

--- a/apps/web/src/trpc/__tests__/procedure-timing-wiring.test.ts
+++ b/apps/web/src/trpc/__tests__/procedure-timing-wiring.test.ts
@@ -1,0 +1,98 @@
+import { callTRPCProcedure } from '@trpc/server';
+
+import { logger } from '@/lib/server/logger';
+
+import { createRouter, protectedProcedure, publicProcedure } from '../init';
+
+vi.mock('@/lib/server/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const { authorizeMock } = vi.hoisted(() => ({ authorizeMock: vi.fn() }));
+
+vi.mock('@/lib/server', () => ({
+  authorize: authorizeMock,
+}));
+
+vi.mock('@/trpc/error-logging', () => ({
+  shouldReportTrpcProcedureError: vi.fn(() => false),
+  enrichTrpcClientErrorDetails: vi.fn(),
+  reportTrpcProcedureError: vi.fn(),
+  getTrpcClientErrorDetails: vi.fn(() => null),
+}));
+
+const infoMock = vi.mocked(logger.info);
+
+const router = createRouter({
+  ping: publicProcedure.query(() => 'pong'),
+  boom: publicProcedure.query(() => {
+    throw new Error('kaboom');
+  }),
+  secret: protectedProcedure.query(() => 'classified'),
+});
+
+function call(path: string, auth: { success: boolean }) {
+  return callTRPCProcedure({
+    router,
+    path,
+    ctx: { auth },
+    type: 'query',
+    getRawInput: async () => undefined,
+    signal: undefined,
+    batchIndex: 0,
+  }) as Promise<unknown>;
+}
+
+describe('procedure timing wiring', () => {
+  const originalThreshold = process.env.R_SLOW_PROCEDURE_LOG_MS;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Log every procedure so the assertions do not depend on real durations.
+    process.env.R_SLOW_PROCEDURE_LOG_MS = '0';
+    vi.spyOn(performance, 'now').mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+
+    if (originalThreshold === undefined) {
+      delete process.env.R_SLOW_PROCEDURE_LOG_MS;
+    } else {
+      process.env.R_SLOW_PROCEDURE_LOG_MS = originalThreshold;
+    }
+  });
+
+  it('times public procedures without changing their result', async () => {
+    await expect(call('ping', { success: true })).resolves.toBe('pong');
+
+    expect(infoMock).toHaveBeenCalledWith(
+      '[procedure-timing] procedure=ping ms=0 ok=true',
+    );
+  });
+
+  it('times failing procedures without changing the error', async () => {
+    await expect(call('boom', { success: true })).rejects.toThrow('kaboom');
+
+    expect(infoMock).toHaveBeenCalledWith(
+      '[procedure-timing] procedure=boom ms=0 ok=false',
+    );
+  });
+
+  it('times protected procedures, including their auth rejection', async () => {
+    await expect(call('secret', { success: true })).resolves.toBe('classified');
+    await expect(call('secret', { success: false })).rejects.toThrow(
+      'UNAUTHORIZED',
+    );
+
+    expect(infoMock.mock.calls.map(([line]) => line)).toEqual([
+      '[procedure-timing] procedure=secret ms=0 ok=true',
+      '[procedure-timing] procedure=secret ms=0 ok=false',
+    ]);
+  });
+});

--- a/apps/web/src/trpc/__tests__/request-timing.test.ts
+++ b/apps/web/src/trpc/__tests__/request-timing.test.ts
@@ -1,0 +1,238 @@
+import { logger } from '@/lib/server/logger';
+
+import {
+  describeRequestProcedures,
+  getSlowProcedureLogThresholdMs,
+  withProcedureTiming,
+  withResponseCompletionTiming,
+} from '../request-timing';
+
+vi.mock('@/lib/server/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const infoMock = vi.mocked(logger.info);
+
+describe('procedure timing', () => {
+  const originalThreshold = process.env.R_SLOW_PROCEDURE_LOG_MS;
+  let clock = 0;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.R_SLOW_PROCEDURE_LOG_MS;
+    clock = 0;
+    vi.spyOn(performance, 'now').mockImplementation(() => clock);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+
+    if (originalThreshold === undefined) {
+      delete process.env.R_SLOW_PROCEDURE_LOG_MS;
+    } else {
+      process.env.R_SLOW_PROCEDURE_LOG_MS = originalThreshold;
+    }
+  });
+
+  const advance = (ms: number) => {
+    clock += ms;
+  };
+
+  it('returns the procedure result unchanged', async () => {
+    const result = { ok: true as const, data: { id: 'task-1' } };
+
+    await expect(
+      withProcedureTiming('tasks.get', async () => {
+        advance(10);
+        return result;
+      }),
+    ).resolves.toBe(result);
+  });
+
+  it('re-throws the original error untouched', async () => {
+    const error = new Error('boom');
+
+    await expect(
+      withProcedureTiming('tasks.get', async () => {
+        advance(10);
+        throw error;
+      }),
+    ).rejects.toBe(error);
+  });
+
+  it('stays silent below the default threshold', async () => {
+    await withProcedureTiming('tasks.get', async () => {
+      advance(249);
+      return { ok: true as const };
+    });
+
+    expect(infoMock).not.toHaveBeenCalled();
+  });
+
+  it('logs above the default threshold', async () => {
+    await withProcedureTiming('tasks.get', async () => {
+      advance(1500);
+      return { ok: true as const };
+    });
+
+    expect(infoMock).toHaveBeenCalledTimes(1);
+    expect(infoMock).toHaveBeenCalledWith(
+      '[procedure-timing] procedure=tasks.get ms=1500 ok=true',
+    );
+  });
+
+  it('reports ok=false for failed procedures', async () => {
+    await withProcedureTiming('tasks.get', async () => {
+      advance(400);
+      return { ok: false as const };
+    });
+
+    await expect(
+      withProcedureTiming('tasks.create', async () => {
+        advance(400);
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    expect(infoMock.mock.calls.map(([line]) => line)).toEqual([
+      '[procedure-timing] procedure=tasks.get ms=400 ok=false',
+      '[procedure-timing] procedure=tasks.create ms=400 ok=false',
+    ]);
+  });
+
+  it('honors R_SLOW_PROCEDURE_LOG_MS', async () => {
+    process.env.R_SLOW_PROCEDURE_LOG_MS = '1000';
+
+    await withProcedureTiming('tasks.get', async () => {
+      advance(500);
+      return { ok: true as const };
+    });
+
+    expect(infoMock).not.toHaveBeenCalled();
+
+    await withProcedureTiming('tasks.get', async () => {
+      advance(1000);
+      return { ok: true as const };
+    });
+
+    expect(infoMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs every procedure when the threshold is 0', async () => {
+    process.env.R_SLOW_PROCEDURE_LOG_MS = '0';
+
+    await withProcedureTiming('tasks.get', async () => {
+      return { ok: true as const };
+    });
+
+    expect(infoMock).toHaveBeenCalledWith(
+      '[procedure-timing] procedure=tasks.get ms=0 ok=true',
+    );
+  });
+
+  it('falls back to the default threshold for unparseable values', () => {
+    expect(getSlowProcedureLogThresholdMs({})).toBe(250);
+    expect(
+      getSlowProcedureLogThresholdMs({ R_SLOW_PROCEDURE_LOG_MS: '' }),
+    ).toBe(250);
+    expect(
+      getSlowProcedureLogThresholdMs({ R_SLOW_PROCEDURE_LOG_MS: 'nope' }),
+    ).toBe(250);
+    expect(
+      getSlowProcedureLogThresholdMs({ R_SLOW_PROCEDURE_LOG_MS: '-5' }),
+    ).toBe(250);
+    expect(
+      getSlowProcedureLogThresholdMs({ R_SLOW_PROCEDURE_LOG_MS: ' 40 ' }),
+    ).toBe(40);
+  });
+
+  it('strips characters that are not part of a tRPC path', async () => {
+    process.env.R_SLOW_PROCEDURE_LOG_MS = '0';
+
+    await withProcedureTiming('tasks.get\nfake=line', async () => ({
+      ok: true as const,
+    }));
+
+    expect(infoMock).toHaveBeenCalledWith(
+      '[procedure-timing] procedure=tasks.getfakeline ms=0 ok=true',
+    );
+  });
+});
+
+describe('describeRequestProcedures', () => {
+  it('lists the batched procedure names', () => {
+    expect(
+      describeRequestProcedures(
+        new URL('https://app.test/api/trpc/tasks.get,users.me?batch=1'),
+      ),
+    ).toEqual({ procedures: 'tasks.get,users.me', batch: 2 });
+  });
+
+  it('handles a single procedure', () => {
+    expect(
+      describeRequestProcedures(new URL('https://app.test/api/trpc/tasks.get')),
+    ).toEqual({ procedures: 'tasks.get', batch: 1 });
+  });
+
+  it('handles a request without a procedure segment', () => {
+    expect(
+      describeRequestProcedures(new URL('https://app.test/api/trpc')),
+    ).toEqual({ procedures: 'none', batch: 0 });
+  });
+
+  it('collapses very long batches to a count', () => {
+    const names = Array.from({ length: 40 }, (_, index) => `tasks.get${index}`);
+    const result = describeRequestProcedures(
+      new URL(`https://app.test/api/trpc/${names.join(',')}`),
+    );
+
+    expect(result).toEqual({ procedures: '40-procedures', batch: 40 });
+  });
+});
+
+describe('withResponseCompletionTiming', () => {
+  it('preserves the body, status and headers and reports once the body ends', async () => {
+    const onComplete = vi.fn();
+    const response = withResponseCompletionTiming(
+      new Response('chunk-one', {
+        status: 207,
+        headers: { 'content-type': 'application/json', 'x-test': 'kept' },
+      }),
+      onComplete,
+    );
+
+    expect(onComplete).not.toHaveBeenCalled();
+    expect(response.status).toBe(207);
+    expect(response.headers.get('x-test')).toBe('kept');
+    expect(response.headers.get('content-type')).toBe('application/json');
+
+    await expect(response.text()).resolves.toBe('chunk-one');
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports immediately when there is no body', () => {
+    const onComplete = vi.fn();
+    const original = new Response(null, { status: 204 });
+    const response = withResponseCompletionTiming(original, onComplete);
+
+    expect(response).toBe(original);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports once when the consumer cancels', async () => {
+    const onComplete = vi.fn();
+    const response = withResponseCompletionTiming(
+      new Response('chunk-one'),
+      onComplete,
+    );
+
+    await response.body?.cancel();
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/trpc/init.ts
+++ b/apps/web/src/trpc/init.ts
@@ -8,6 +8,7 @@ import {
   reportTrpcProcedureError,
   shouldReportTrpcProcedureError,
 } from './error-logging';
+import { withProcedureTiming } from './request-timing';
 
 // See:
 // - https://trpc.io/docs/server/context
@@ -60,7 +61,15 @@ const reportProcedureErrors = t.middleware(async (opts) => {
     throw error;
   }
 });
-const procedure = t.procedure.use(reportProcedureErrors);
+// Outermost middleware, so a procedure's reported duration covers everything
+// that runs on its behalf (input parsing, error reporting, the auth check on
+// protected procedures and the resolver itself). Both `publicProcedure` and
+// `protectedProcedure` are built from this, so every procedure is timed.
+const timeProcedures = t.middleware((opts) =>
+  withProcedureTiming(opts.path, () => opts.next()),
+);
+
+const procedure = t.procedure.use(timeProcedures).use(reportProcedureErrors);
 
 export const createRouter = t.router;
 export const publicProcedure = procedure;

--- a/apps/web/src/trpc/request-timing.ts
+++ b/apps/web/src/trpc/request-timing.ts
@@ -1,0 +1,268 @@
+import { logger } from '@/lib/server/logger';
+
+/**
+ * Server-side latency instrumentation for the tRPC HTTP route.
+ *
+ * The goal is to localize unexplained request latency: every HTTP request to
+ * `/api/trpc` emits exactly one `[request-timing]` line, and individually slow
+ * procedures emit a threshold-gated `[procedure-timing]` line. Comparing the
+ * handler duration against the client-observed duration tells us whether the
+ * time is spent inside our code or somewhere around it (Next.js routing,
+ * container CPU, proxy, TLS).
+ *
+ * Logging rules: procedure NAMES, durations, status codes and the request
+ * pathname only. Never inputs, user ids, headers or any other request payload.
+ */
+
+const DEFAULT_SLOW_PROCEDURE_LOG_MS = 250;
+const SLOW_PROCEDURE_LOG_MS_ENV_KEY = 'R_SLOW_PROCEDURE_LOG_MS';
+
+/**
+ * Procedure names come off the URL, so they are attacker-controlled. Strip
+ * anything outside the tRPC path alphabet and cap the joined list so a crafted
+ * URL cannot inject newlines into the log or blow up a line's size.
+ */
+const PROCEDURE_NAME_DISALLOWED = /[^A-Za-z0-9._-]/g;
+const MAX_PROCEDURE_LIST_CHARS = 200;
+
+function formatMs(value: number): string {
+  return String(Math.round(value * 10) / 10);
+}
+
+function sanitizeProcedureName(name: string): string {
+  return name.replace(PROCEDURE_NAME_DISALLOWED, '');
+}
+
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Reads the slow-procedure threshold from the environment on every call so the
+ * value can be flipped without a rebuild (and so tests can vary it).
+ *
+ * - unset / unparseable -> 250ms
+ * - `0` -> no threshold, every procedure is logged
+ */
+export function getSlowProcedureLogThresholdMs(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const raw = env[SLOW_PROCEDURE_LOG_MS_ENV_KEY]?.trim();
+
+  if (!raw || !/^\d+$/.test(raw)) {
+    return DEFAULT_SLOW_PROCEDURE_LOG_MS;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+
+  return Number.isFinite(parsed) ? parsed : DEFAULT_SLOW_PROCEDURE_LOG_MS;
+}
+
+function logProcedureTiming({
+  path,
+  durationMs,
+  ok,
+}: {
+  path: string;
+  durationMs: number;
+  ok: boolean;
+}): void {
+  if (durationMs < getSlowProcedureLogThresholdMs()) {
+    return;
+  }
+
+  logger.info(
+    `[procedure-timing] procedure=${sanitizeProcedureName(path)} ms=${formatMs(durationMs)} ok=${ok}`,
+  );
+}
+
+/**
+ * Times a single procedure call. Returns the middleware result untouched and
+ * re-throws whatever it caught, so it can never alter behavior.
+ *
+ * Note that tRPC's middleware chain converts downstream throws into
+ * `{ ok: false }` results rather than rejections, so both shapes are handled.
+ */
+export async function withProcedureTiming<TResult extends { ok: boolean }>(
+  path: string,
+  next: () => Promise<TResult>,
+): Promise<TResult> {
+  const startedAt = performance.now();
+
+  try {
+    const result = await next();
+
+    logProcedureTiming({
+      path,
+      durationMs: performance.now() - startedAt,
+      ok: result.ok,
+    });
+
+    return result;
+  } catch (error) {
+    logProcedureTiming({
+      path,
+      durationMs: performance.now() - startedAt,
+      ok: false,
+    });
+
+    throw error;
+  }
+}
+
+/**
+ * Derives the requested procedures from the tRPC URL
+ * (`/api/trpc/foo.bar,baz.qux`) without touching the request body.
+ */
+export function describeRequestProcedures(url: URL): {
+  procedures: string;
+  batch: number;
+} {
+  const trailing = url.pathname.split('/api/trpc/')[1] ?? '';
+  const names = trailing
+    .split(',')
+    .map((name) => sanitizeProcedureName(safeDecode(name)))
+    .filter((name) => name.length > 0);
+
+  if (names.length === 0) {
+    return { procedures: 'none', batch: 0 };
+  }
+
+  const joined = names.join(',');
+
+  return {
+    procedures:
+      joined.length > MAX_PROCEDURE_LIST_CHARS
+        ? `${names.length}-procedures`
+        : joined,
+    batch: names.length,
+  };
+}
+
+/**
+ * `Server-Timing` value emitted from `responseMeta`.
+ *
+ * The client uses `httpBatchStreamLink`, so tRPC generates response metadata
+ * eagerly — before any procedure has resolved. Only the context/auth phase is
+ * genuinely known at that point, and we must not block the stream to learn
+ * more, so this deliberately carries a single metric. The handler total is
+ * appended later (see `withResponseCompletionTiming`), which is still before
+ * the headers go out.
+ */
+export function buildAuthServerTiming(authMs: number | null): string | null {
+  return authMs === null ? null : `auth;dur=${formatMs(authMs)}`;
+}
+
+export function buildHandlerServerTiming(handlerMs: number): string {
+  return `handler;dur=${formatMs(handlerMs)}`;
+}
+
+/**
+ * Wraps the response body in a pass-through stream so we can observe when the
+ * response is fully flushed. The stream is pull-based, so backpressure and
+ * chunk boundaries are preserved and nothing is buffered or delayed; the only
+ * added work is one callback when the body ends, errors or is cancelled.
+ */
+export function withResponseCompletionTiming(
+  response: Response,
+  onComplete: () => void,
+): Response {
+  const body = response.body;
+
+  if (!body) {
+    onComplete();
+    return response;
+  }
+
+  let settled = false;
+
+  const finish = () => {
+    if (settled) {
+      return;
+    }
+
+    settled = true;
+
+    try {
+      onComplete();
+    } catch {
+      // Instrumentation must never break the response stream.
+    }
+  };
+
+  try {
+    const reader = body.getReader();
+
+    const measured = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        try {
+          const { done, value } = await reader.read();
+
+          if (done) {
+            controller.close();
+            finish();
+            return;
+          }
+
+          controller.enqueue(value);
+        } catch (error) {
+          finish();
+          controller.error(error);
+        }
+      },
+      cancel(reason) {
+        finish();
+        return reader.cancel(reason);
+      },
+    });
+
+    return new Response(measured, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  } catch {
+    // Never let instrumentation break a response.
+    finish();
+    return response;
+  }
+}
+
+/**
+ * The single per-request log line. One line per HTTP request, so volume is
+ * bounded by traffic.
+ *
+ * - `auth`    time spent in `createContext` (runs even for requests that are
+ *             rejected as unauthenticated)
+ * - `handler` time inside our exported route handler, entry to return
+ * - `total`   entry until the response body is fully flushed; for streamed
+ *             batches this is the number to compare against what the client
+ *             observes, since `handler` ends when the headers are ready
+ */
+export function logRequestTiming({
+  path,
+  procedures,
+  batch,
+  authMs,
+  handlerMs,
+  totalMs,
+  status,
+}: {
+  path: string;
+  procedures: string;
+  batch: number;
+  authMs: number | null;
+  handlerMs: number;
+  totalMs: number;
+  status: number;
+}): void {
+  logger.info(
+    `[request-timing] path=${path} procedures=${procedures} auth=${
+      authMs === null ? 'n/a' : formatMs(authMs)
+    } handler=${formatMs(handlerMs)} status=${status} batch=${batch} total=${formatMs(totalMs)}`,
+  );
+}


### PR DESCRIPTION
We could not attribute deployed-instance latency from outside the process. An **unauthenticated tRPC 401** — which rejects before any procedure runs — takes 0.4s on the lightest instance and 1.4–2.4s on heavier ones, while the database answers indexed queries in microseconds and TLS costs 50ms. Ruled out already: DB, internal networking, app sleep, per-request identity writes.

## What this adds

- **`[request-timing] path=… procedures=… auth=<ms> handler=<ms> status=… batch=<n> total=<ms>`** — one line per request. `auth` is time inside `createContext` (the phase that runs even for rejected requests); `total` measures until the body finishes flushing, which is the number comparable to what a browser sees, since `httpBatchStreamLink` returns headers long before the work completes.
- **`[procedure-timing] procedure=… ms=… ok=…`** — threshold-gated at 250ms, tunable with `R_SLOW_PROCEDURE_LOG_MS` (`0` logs everything), so normal traffic stays quiet.
- **`Server-Timing`** carries `auth` and `handler`; per-procedure values can't go in a header without blocking the stream, so they're log-only (documented inline).

No behavior change: values and errors pass through untouched, no inputs/ids/secrets are logged, and procedure names — which come from the URL — are sanitized and collapsed on large batches.

## Why it matters immediately

While building this we found a strong candidate for the fixed per-request cost: `getAuth()` calls `resolveAuthProviderConfig()` on **every** request; that resolves deployment env vars, decrypting each row, and each decrypt runs `scryptSync` — a deliberately slow KDF — **synchronously on the event loop**. Latency across four production instances tracks env-var count almost perfectly (10 vars → 0.44s, 15 → 0.49s, 30 → 1.40s, 49 → 1.44s). The new `auth=` field confirms or kills that in one deploy.

## Tests

Middleware passes values and errors through unchanged; threshold honored above/below and with `R_SLOW_PROCEDURE_LOG_MS=0`; route emits exactly one request line with both durations. Clock is stubbed — no test depends on real wall-clock time. `lint`, `check-types` (26 packages), `knip`, and the web suite (2474 tests) all pass.