### PR TITLE
Cache derived encryption keys instead of re-running scrypt per read

### DIFF
--- a/packages/db/src/lib/__tests__/encryption.test.ts
+++ b/packages/db/src/lib/__tests__/encryption.test.ts
@@ -7,6 +7,36 @@ import {
 } from '../encryption';
 
 describe('Encryption utilities', () => {
+  describe('derived key caching', () => {
+    it('reuses the derived key when decrypting the same ciphertext', () => {
+      // Every request re-reads the same stored rows; without caching each
+      // read pays a fresh scrypt derivation, synchronously.
+      const encrypted = encrypt('cached-secret');
+
+      expect(decrypt(encrypted)).toBe('cached-secret');
+
+      const started = performance.now();
+
+      for (let index = 0; index < 20; index += 1) {
+        expect(decrypt(encrypted)).toBe('cached-secret');
+      }
+
+      // 20 uncached scrypt derivations take hundreds of milliseconds; cached
+      // reads are microseconds. The bound is loose so the assertion is about
+      // the cache existing, not about machine speed.
+      expect(performance.now() - started).toBeLessThan(150);
+    });
+
+    it('keeps distinct ciphertexts independent', () => {
+      const first = encrypt('first-secret');
+      const second = encrypt('second-secret');
+
+      expect(decrypt(first)).toBe('first-secret');
+      expect(decrypt(second)).toBe('second-secret');
+      expect(decrypt(first)).toBe('first-secret');
+    });
+  });
+
   describe('encrypt/decrypt', () => {
     it('should encrypt and decrypt a string correctly', () => {
       const originalText = 'This is a secret message';

--- a/packages/db/src/lib/encryption.ts
+++ b/packages/db/src/lib/encryption.ts
@@ -28,11 +28,47 @@ function describeEncryptionKey(): string {
   return `ENCRYPTION_KEY(length=${key.length}, fingerprint=${fingerprint})`;
 }
 
+// scrypt is deliberately expensive and scryptSync blocks the event loop.
+// Stored ciphertexts keep a fixed per-row salt, so re-reading the same rows
+// re-derives the same keys: without this cache, every request that decrypts
+// N rows pays N derivations, serially, ahead of any real work. Keyed by
+// encryption key fingerprint as well as salt so a key rotation cannot serve
+// a stale derivation.
+const derivedKeyCache = new Map<string, Buffer>();
+const DERIVED_KEY_CACHE_MAX_ENTRIES = 500;
+
 /**
  * Derives a key from the encryption key using scrypt.
  */
 function deriveKey(salt: Buffer): Buffer {
-  return scryptSync(getEncryptionKey(), salt, KEY_LENGTH);
+  const encryptionKey = getEncryptionKey();
+  const cacheKey = `${createHash('sha256')
+    .update(encryptionKey)
+    .digest('hex')
+    .slice(0, 16)}:${salt.toString('base64')}`;
+
+  const cached = derivedKeyCache.get(cacheKey);
+
+  if (cached) {
+    return cached;
+  }
+
+  const derived = scryptSync(encryptionKey, salt, KEY_LENGTH);
+
+  // Bounded so a process that decrypts unboundedly many distinct rows keeps
+  // the working set rather than growing forever; insertion order makes the
+  // oldest entry the eviction candidate.
+  if (derivedKeyCache.size >= DERIVED_KEY_CACHE_MAX_ENTRIES) {
+    const oldest = derivedKeyCache.keys().next().value;
+
+    if (oldest !== undefined) {
+      derivedKeyCache.delete(oldest);
+    }
+  }
+
+  derivedKeyCache.set(cacheKey, derived);
+
+  return derived;
 }
 
 export function encrypt(text: string): string {


### PR DESCRIPTION
Root cause of the fixed per-request latency we have been chasing on deployed instances.

## What happens today

Every tRPC request — including ones rejected as unauthenticated — calls `getAuth()` → `resolveAuthProviderConfig()`, which reads **all** deployment environment variables and decrypts each one. Each decrypt calls `scryptSync`, a deliberately slow KDF, **synchronously on the event loop**. Stored ciphertexts carry a fixed per-row salt, so every request re-derives the identical keys.

The cost is linear in how much a deployment has configured, and because it blocks, it serializes concurrent requests.

## Evidence

Latency of a request that runs **no procedures** (a 401), measured across four production instances, tracks env-var count almost perfectly:

| instance | env vars | 401 latency |
|---|---|---|
| bitwerx | 10 | 0.44s |
| zoocode | 15 | 0.49s |
| nightly | 30 | 1.40s |
| roo | 49 | 1.44s |

Locally, 49 scrypt derivations take **1014ms**; the same 49 served from a cache take **0.05ms**. Earlier suspects were eliminated first: indexed queries return in microseconds, tenants use internal DB networking, app sleep is off, TLS is 50ms, and identity writes are per-session not per-request.

## The fix

Memoize derivations keyed by salt **and** a fingerprint of the encryption key, so a key rotation cannot serve a stale derivation. The cache is bounded at 500 entries with oldest-first eviction, so a process decrypting unboundedly many distinct rows keeps its working set rather than growing forever.

No change to the ciphertext format, the algorithm, or any stored data — the same key is computed, just not repeatedly. Cached key material is no more exposed than the encryption key already in process memory.

## Tests

Repeated decrypts of one ciphertext stay well under the time a single uncached derivation would take, distinct ciphertexts stay independent, and the existing encrypt/decrypt, JSON, and secrets suites pass unchanged (407 tests in `@roomote/db`). `lint` and `check-types` green.

Pairs with #831 (request timing), whose `auth=` field will show this drop directly in production logs.