### PR TITLE
[Fix] Resume MCP OAuth connections after sign-in

### DIFF
--- a/apps/web/src/app/(authenticated)/AuthenticatedLayoutClient.client.test.tsx
+++ b/apps/web/src/app/(authenticated)/AuthenticatedLayoutClient.client.test.tsx
@@ -61,6 +61,10 @@ vi.mock('@/components/layout/CommandPalette', () => ({
   CommandPalette: () => <div>Command palette</div>,
 }));
 
+vi.mock('@/components/layout/McpOAuthResultFeedback', () => ({
+  McpOAuthResultFeedback: () => null,
+}));
+
 import AuthenticatedLayoutClient from './AuthenticatedLayoutClient';
 
 describe('AuthenticatedLayoutClient', () => {

--- a/apps/web/src/app/(authenticated)/AuthenticatedLayoutClient.tsx
+++ b/apps/web/src/app/(authenticated)/AuthenticatedLayoutClient.tsx
@@ -13,6 +13,7 @@ import { useTRPC } from '@/trpc/client';
 import { NavbarHeader, SideNav, FramedSurface } from '@/components/layout';
 import { CommandPaletteProvider } from '@/components/layout/CommandPaletteContext';
 import { CommandPalette } from '@/components/layout/CommandPalette';
+import { McpOAuthResultFeedback } from '@/components/layout/McpOAuthResultFeedback';
 import { ManagedAccessBanner } from './ManagedAccessBanner';
 
 export default function AuthenticatedLayoutClient({
@@ -92,6 +93,7 @@ function AuthenticatedLayoutShell({ children }: { children: React.ReactNode }) {
 
   return (
     <CommandPaletteProvider>
+      <McpOAuthResultFeedback />
       <div className="flex h-effective-viewport min-h-0 flex-col bg-card">
         <div className="mx-2 rounded-b-2xl overflow-clip">
           <ManagedAccessBanner />

--- a/apps/web/src/app/api/mcp-oauth/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/mcp-oauth/callback/__tests__/route.test.ts
@@ -11,6 +11,8 @@ const {
   hydrateLinearMcpConnectionAfterOauthMock,
   isDeploymentScopedMcpIntegrationMock,
   isSelfServeMcpIntegrationMock,
+  loggerErrorMock,
+  loggerWarnMock,
   mcpConnectionsFindFirstMock,
   storeTokensMock,
   updateAuthStatusMock,
@@ -25,6 +27,8 @@ const {
   hydrateLinearMcpConnectionAfterOauthMock: vi.fn(),
   isDeploymentScopedMcpIntegrationMock: vi.fn(),
   isSelfServeMcpIntegrationMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
+  loggerWarnMock: vi.fn(),
   mcpConnectionsFindFirstMock: vi.fn(),
   storeTokensMock: vi.fn(),
   updateAuthStatusMock: vi.fn(),
@@ -41,6 +45,13 @@ vi.mock('@/lib/server/bootstrap-runtime-env', () => ({
 vi.mock('@/lib/server/mcp-linear', () => ({
   hydrateLinearMcpConnectionAfterOauth:
     hydrateLinearMcpConnectionAfterOauthMock,
+}));
+
+vi.mock('@/lib/server/logger', () => ({
+  logger: {
+    error: loggerErrorMock,
+    warn: loggerWarnMock,
+  },
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -169,6 +180,30 @@ describe('GET /api/mcp-oauth/callback', () => {
     );
   });
 
+  it('records callback host context when the Roomote session is unavailable', async () => {
+    authorizeMock.mockResolvedValueOnce({ success: false });
+    const request = new NextRequest(
+      'https://legacy.example/api/mcp-oauth/callback?code=auth-code&state=state-1',
+    );
+
+    const response = await GET(request);
+
+    expect(response.headers.get('location')).toBe(
+      'https://customer.example/settings?mcp=error&reason=unauthorized',
+    );
+    expect(consumeOAuthStateMock).not.toHaveBeenCalled();
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      {
+        event: 'mcp_oauth_callback_rejected',
+        reason: 'unauthorized',
+        requestHost: 'legacy.example',
+        configuredCallbackHost: 'customer.example',
+        callbackHostMatchesRequest: false,
+      },
+      'MCP OAuth callback was rejected',
+    );
+  });
+
   it('redirects oauth errors to the public settings host', async () => {
     const response = await GET(
       buildRequest(
@@ -178,9 +213,70 @@ describe('GET /api/mcp-oauth/callback', () => {
 
     expect(response.status).toBe(307);
     expect(response.headers.get('location')).toBe(
-      'https://customer.example/settings?mcp=error',
+      'https://customer.example/settings?mcp=error&reason=access_denied',
     );
     expect(updateAuthStatusMock).toHaveBeenCalledWith(CONNECTION_ID, 'error');
     expect(exchangeCodeForTokensMock).not.toHaveBeenCalled();
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'mcp_oauth_provider_error',
+        providerError: 'access_denied',
+        hasErrorDescription: true,
+      }),
+      'MCP OAuth provider returned an error',
+    );
+  });
+
+  it('surfaces token exchange failures with a safe reason and stage', async () => {
+    exchangeCodeForTokensMock.mockRejectedValueOnce(
+      new Error('provider response omitted'),
+    );
+
+    const response = await GET(buildRequest('?code=auth-code&state=state-1'));
+
+    expect(response.headers.get('location')).toBe(
+      'https://customer.example/settings?mcp=error&reason=token_exchange_failed',
+    );
+    expect(updateAuthStatusMock).toHaveBeenCalledWith(CONNECTION_ID, 'error');
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'mcp_oauth_callback_failed',
+        failureStage: 'token_exchange',
+        reason: 'token_exchange_failed',
+        integrationId: 'linear',
+        connectionId: CONNECTION_ID,
+        errorName: 'Error',
+      }),
+      'MCP OAuth callback failed',
+    );
+    expect(JSON.stringify(loggerErrorMock.mock.calls)).not.toContain(
+      'provider response omitted',
+    );
+  });
+
+  it('distinguishes Linear workspace metadata failures after token storage', async () => {
+    hydrateLinearMcpConnectionAfterOauthMock.mockRejectedValueOnce(
+      new Error('viewer lookup failed'),
+    );
+
+    const response = await GET(buildRequest('?code=auth-code&state=state-1'));
+
+    expect(storeTokensMock).toHaveBeenCalledWith(CONNECTION_ID, {
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+    });
+    expect(response.headers.get('location')).toBe(
+      'https://customer.example/settings?mcp=error&reason=linear_metadata_failed',
+    );
+    expect(updateAuthStatusMock).toHaveBeenCalledWith(CONNECTION_ID, 'error');
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'mcp_oauth_callback_failed',
+        failureStage: 'linear_metadata',
+        reason: 'linear_metadata_failed',
+        integrationId: 'linear',
+      }),
+      'MCP OAuth callback failed',
+    );
   });
 });

--- a/apps/web/src/app/api/mcp-oauth/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/mcp-oauth/callback/__tests__/route.test.ts
@@ -180,7 +180,7 @@ describe('GET /api/mcp-oauth/callback', () => {
     );
   });
 
-  it('records callback host context when the Roomote session is unavailable', async () => {
+  it('signs in on the configured host and resumes the unconsumed callback', async () => {
     authorizeMock.mockResolvedValueOnce({ success: false });
     const request = new NextRequest(
       'https://legacy.example/api/mcp-oauth/callback?code=auth-code&state=state-1',
@@ -189,19 +189,30 @@ describe('GET /api/mcp-oauth/callback', () => {
     const response = await GET(request);
 
     expect(response.headers.get('location')).toBe(
-      'https://customer.example/settings?mcp=error&reason=unauthorized',
+      'https://customer.example/sign-in?redirect_url=%2Fapi%2Fmcp-oauth%2Fcallback%3Fcode%3Dauth-code%26state%3Dstate-1',
     );
     expect(consumeOAuthStateMock).not.toHaveBeenCalled();
     expect(loggerWarnMock).toHaveBeenCalledWith(
       {
-        event: 'mcp_oauth_callback_rejected',
-        reason: 'unauthorized',
+        event: 'mcp_oauth_callback_auth_required',
         requestHost: 'legacy.example',
         configuredCallbackHost: 'customer.example',
         callbackHostMatchesRequest: false,
       },
-      'MCP OAuth callback was rejected',
+      'MCP OAuth callback requires sign-in before it can continue',
     );
+
+    const resumedResponse = await GET(
+      buildRequest('?code=auth-code&state=state-1'),
+    );
+    expect(resumedResponse.headers.get('location')).toBe(
+      'https://customer.example/settings?mcp=connected',
+    );
+    expect(consumeOAuthStateMock).toHaveBeenCalledTimes(1);
+    expect(storeTokensMock).toHaveBeenCalledWith(CONNECTION_ID, {
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+    });
   });
 
   it('redirects oauth errors to the public settings host', async () => {

--- a/apps/web/src/app/api/mcp-oauth/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/mcp-oauth/callback/__tests__/route.test.ts
@@ -180,35 +180,55 @@ describe('GET /api/mcp-oauth/callback', () => {
     );
   });
 
-  it('signs in on the configured host and resumes the unconsumed callback', async () => {
+  it('resumes after sign-in without putting the authorization code in the URL', async () => {
     authorizeMock.mockResolvedValueOnce({ success: false });
-    const request = new NextRequest(
-      'https://legacy.example/api/mcp-oauth/callback?code=auth-code&state=state-1',
-    );
+    const request = buildRequest('?code=auth-code&state=state-1');
 
     const response = await GET(request);
 
     expect(response.headers.get('location')).toBe(
-      'https://customer.example/sign-in?redirect_url=%2Fapi%2Fmcp-oauth%2Fcallback%3Fcode%3Dauth-code%26state%3Dstate-1',
+      'https://customer.example/sign-in?redirect_url=%2Fapi%2Fmcp-oauth%2Fcallback%3Fstate%3Dstate-1%26resume%3D1',
     );
+    expect(response.headers.get('location')).not.toContain('auth-code');
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    const setCookie = response.headers.get('set-cookie');
+    expect(setCookie).toContain('roomote-mcp-oauth-continuation-');
+    expect(setCookie).toContain('auth-code');
+    expect(setCookie).toContain('Path=/api/mcp-oauth/callback');
+    expect(setCookie).toContain('Max-Age=600');
+    expect(setCookie).toContain('HttpOnly');
+    expect(setCookie).toContain('Secure');
+    expect(setCookie).toContain('SameSite=lax');
     expect(consumeOAuthStateMock).not.toHaveBeenCalled();
     expect(loggerWarnMock).toHaveBeenCalledWith(
       {
         event: 'mcp_oauth_callback_auth_required',
-        requestHost: 'legacy.example',
+        requestHost: 'customer.example',
         configuredCallbackHost: 'customer.example',
-        callbackHostMatchesRequest: false,
+        callbackHostMatchesRequest: true,
       },
       'MCP OAuth callback requires sign-in before it can continue',
     );
 
+    const continuationCookie = setCookie?.split(';', 1)[0];
     const resumedResponse = await GET(
-      buildRequest('?code=auth-code&state=state-1'),
+      new NextRequest(
+        'https://customer.example/api/mcp-oauth/callback?state=state-1&resume=1',
+        { headers: { cookie: continuationCookie ?? '' } },
+      ),
     );
     expect(resumedResponse.headers.get('location')).toBe(
       'https://customer.example/settings?mcp=connected',
     );
+    expect(resumedResponse.headers.get('set-cookie')).toContain('Max-Age=0');
     expect(consumeOAuthStateMock).toHaveBeenCalledTimes(1);
+    expect(exchangeCodeForTokensMock).toHaveBeenCalledWith(
+      'https://mcp.linear.app/token',
+      'auth-code',
+      'verifier-1',
+      { client_id: 'client-1' },
+      PUBLIC_CALLBACK,
+    );
     expect(storeTokensMock).toHaveBeenCalledWith(CONNECTION_ID, {
       access_token: 'access-token',
       refresh_token: 'refresh-token',

--- a/apps/web/src/app/api/mcp-oauth/callback/route.ts
+++ b/apps/web/src/app/api/mcp-oauth/callback/route.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { type NextRequest, NextResponse } from 'next/server';
 
 import {
@@ -24,6 +25,10 @@ import { bootstrapWebRuntimeEnv } from '@/lib/server/bootstrap-runtime-env';
 import { getPublicAppUrl } from '@/lib/server/get-public-app-url';
 import { logger } from '@/lib/server/logger';
 import { hydrateLinearMcpConnectionAfterOauth } from '@/lib/server/mcp-linear';
+import type {
+  McpOAuthErrorReason,
+  McpOAuthResult,
+} from '@/lib/mcp-oauth-result';
 
 export const runtime = 'nodejs';
 
@@ -31,6 +36,9 @@ export const dynamic = 'force-dynamic';
 
 const DEFAULT_REDIRECT_PATH = '/settings';
 const REDIRECT_STATE_DELIMITER = '~';
+const CALLBACK_PATH = '/api/mcp-oauth/callback';
+const CONTINUATION_COOKIE_PREFIX = 'roomote-mcp-oauth-continuation-';
+const CONTINUATION_MAX_AGE_SECONDS = 10 * 60;
 
 type McpOAuthCallbackStage =
   | 'state_validation'
@@ -42,7 +50,9 @@ type McpOAuthCallbackStage =
   | 'linear_metadata'
   | 'deployment_enablement';
 
-function getCallbackFailureReason(stage: McpOAuthCallbackStage): string {
+function getCallbackFailureReason(
+  stage: McpOAuthCallbackStage,
+): McpOAuthErrorReason {
   switch (stage) {
     case 'provider_discovery':
       return 'provider_metadata_failed';
@@ -94,34 +104,67 @@ function readRedirectPathFromState(state: string | null): string {
   }
 }
 
-function withMcpQuery(
+function getContinuationCookieName(state: string): string {
+  const stateHash = createHash('sha256')
+    .update(state)
+    .digest('hex')
+    .slice(0, 16);
+  return `${CONTINUATION_COOKIE_PREFIX}${stateHash}`;
+}
+
+function getContinuationCookieOptions(webUrl: string) {
+  return {
+    httpOnly: true,
+    sameSite: 'lax' as const,
+    secure: new URL(webUrl).protocol === 'https:',
+    path: CALLBACK_PATH,
+  };
+}
+
+function redirectWithMcpResult(
   webUrl: string,
   redirectPath: string,
-  mcpStatus: 'error' | 'connected',
-  reason?: string,
-) {
+  result: McpOAuthResult,
+  state: string | null,
+): NextResponse {
   const url = new URL(redirectPath, webUrl);
-  url.searchParams.set('mcp', mcpStatus);
-  if (reason) {
-    url.searchParams.set('reason', reason);
+  url.searchParams.set('mcp', result.status);
+  if (result.status === 'error' && result.reason) {
+    url.searchParams.set('reason', result.reason);
   }
-  return url;
+
+  const response = NextResponse.redirect(url);
+  if (state) {
+    response.cookies.set(getContinuationCookieName(state), '', {
+      ...getContinuationCookieOptions(webUrl),
+      maxAge: 0,
+    });
+  }
+  return response;
 }
 
 export async function GET(request: NextRequest) {
   const webEnv = await bootstrapWebRuntimeEnv();
-  const code = request.nextUrl.searchParams.get('code');
   const state = request.nextUrl.searchParams.get('state');
+  const queryCode = request.nextUrl.searchParams.get('code');
+  const isResume = request.nextUrl.searchParams.get('resume') === '1';
+  const code =
+    queryCode ??
+    (state && isResume
+      ? (request.cookies.get(getContinuationCookieName(state))?.value ?? null)
+      : null);
   const error = request.nextUrl.searchParams.get('error');
   const errorDescription =
     request.nextUrl.searchParams.get('error_description');
 
   const webUrl = getPublicAppUrl(webEnv);
   const redirectPath = readRedirectPathFromState(state);
+  const redirectToResult = (result: McpOAuthResult) =>
+    redirectWithMcpResult(webUrl, redirectPath, result, state);
 
   // Handle OAuth errors
   if (error) {
-    const reason =
+    const reason: McpOAuthErrorReason =
       error === 'access_denied' ? 'access_denied' : 'provider_error';
     logger.warn(
       {
@@ -137,9 +180,7 @@ export async function GET(request: NextRequest) {
         const oauthState = await consumeOAuthState(state);
         if (oauthState) {
           await updateAuthStatus(oauthState.connectionId, 'error');
-          return NextResponse.redirect(
-            withMcpQuery(webUrl, redirectPath, 'error', reason),
-          );
+          return redirectToResult({ status: 'error', reason });
         }
       } catch (e) {
         logger.error(
@@ -152,9 +193,7 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    return NextResponse.redirect(
-      withMcpQuery(webUrl, redirectPath, 'error', reason),
-    );
+    return redirectToResult({ status: 'error', reason });
   }
 
   // Validate required parameters
@@ -168,9 +207,7 @@ export async function GET(request: NextRequest) {
       },
       'MCP OAuth callback was rejected',
     );
-    return NextResponse.redirect(
-      withMcpQuery(webUrl, redirectPath, 'error', 'missing_params'),
-    );
+    return redirectToResult({ status: 'error', reason: 'missing_params' });
   }
 
   const authResult = await authorize();
@@ -187,10 +224,21 @@ export async function GET(request: NextRequest) {
       'MCP OAuth callback requires sign-in before it can continue',
     );
 
-    const callbackReturnPath = `${request.nextUrl.pathname}${request.nextUrl.search}`;
+    const callbackReturnUrl = new URL(CALLBACK_PATH, webUrl);
+    callbackReturnUrl.searchParams.set('state', state);
+    callbackReturnUrl.searchParams.set('resume', '1');
     const signInUrl = new URL('/sign-in', webUrl);
-    signInUrl.searchParams.set('redirect_url', callbackReturnPath);
-    return NextResponse.redirect(signInUrl);
+    signInUrl.searchParams.set(
+      'redirect_url',
+      `${callbackReturnUrl.pathname}${callbackReturnUrl.search}`,
+    );
+    const response = NextResponse.redirect(signInUrl);
+    response.headers.set('Cache-Control', 'no-store');
+    response.cookies.set(getContinuationCookieName(state), code, {
+      ...getContinuationCookieOptions(webUrl),
+      maxAge: CONTINUATION_MAX_AGE_SECONDS,
+    });
+    return response;
   }
   const { userId } = authResult;
 
@@ -209,9 +257,7 @@ export async function GET(request: NextRequest) {
         },
         'MCP OAuth callback was rejected',
       );
-      return NextResponse.redirect(
-        withMcpQuery(webUrl, redirectPath, 'error', 'invalid_state'),
-      );
+      return redirectToResult({ status: 'error', reason: 'invalid_state' });
     }
 
     const resolvedConnectionId = oauthState.connectionId;
@@ -222,24 +268,18 @@ export async function GET(request: NextRequest) {
       where: eq(mcpConnections.id, resolvedConnectionId),
     });
     if (!connection) {
-      return NextResponse.redirect(
-        withMcpQuery(webUrl, redirectPath, 'error', 'not_found'),
-      );
+      return redirectToResult({ status: 'error', reason: 'not_found' });
     }
     integrationId = connection.mcpId;
     connectionRole = connection.connectionRole;
 
     const integration = getMcpIntegration(connection.mcpId);
     if (!integration) {
-      return NextResponse.redirect(
-        withMcpQuery(webUrl, redirectPath, 'error', 'not_found'),
-      );
+      return redirectToResult({ status: 'error', reason: 'not_found' });
     }
 
     if (!isSelfServeMcpIntegration(integration) || !integration.url) {
-      return NextResponse.redirect(
-        withMcpQuery(webUrl, redirectPath, 'error', 'not_found'),
-      );
+      return redirectToResult({ status: 'error', reason: 'not_found' });
     }
 
     const requiresOrgAdmin = isDeploymentScopedMcpIntegration(
@@ -252,22 +292,18 @@ export async function GET(request: NextRequest) {
       (requiresOrgAdmin && !isAdmin) ||
       (!requiresOrgAdmin && connection.userId !== userId)
     ) {
-      return NextResponse.redirect(
-        withMcpQuery(webUrl, redirectPath, 'error', 'not_found'),
-      );
+      return redirectToResult({ status: 'error', reason: 'not_found' });
     }
 
     failureStage = 'client_lookup';
     const clientInfo = await getClientInformation(resolvedConnectionId);
     if (!clientInfo) {
-      return NextResponse.redirect(
-        withMcpQuery(webUrl, redirectPath, 'error', 'not_registered'),
-      );
+      return redirectToResult({ status: 'error', reason: 'not_registered' });
     }
 
     failureStage = 'provider_discovery';
     const serverMetadata = await discoverOAuthEndpoints(integration.url);
-    const redirectUri = new URL('/api/mcp-oauth/callback', webUrl).toString();
+    const redirectUri = new URL(CALLBACK_PATH, webUrl).toString();
 
     failureStage = 'token_exchange';
     const tokens = await exchangeCodeForTokens(
@@ -310,9 +346,7 @@ export async function GET(request: NextRequest) {
         });
     }
 
-    return NextResponse.redirect(
-      withMcpQuery(webUrl, redirectPath, 'connected'),
-    );
+    return redirectToResult({ status: 'connected' });
   } catch (error) {
     const reason = getCallbackFailureReason(failureStage);
     logger.error(
@@ -344,8 +378,6 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    return NextResponse.redirect(
-      withMcpQuery(webUrl, redirectPath, 'error', reason),
-    );
+    return redirectToResult({ status: 'error', reason });
   }
 }

--- a/apps/web/src/app/api/mcp-oauth/callback/route.ts
+++ b/apps/web/src/app/api/mcp-oauth/callback/route.ts
@@ -22,6 +22,7 @@ import {
 import { authorize } from '@/lib/server';
 import { bootstrapWebRuntimeEnv } from '@/lib/server/bootstrap-runtime-env';
 import { getPublicAppUrl } from '@/lib/server/get-public-app-url';
+import { logger } from '@/lib/server/logger';
 import { hydrateLinearMcpConnectionAfterOauth } from '@/lib/server/mcp-linear';
 
 export const runtime = 'nodejs';
@@ -30,6 +31,37 @@ export const dynamic = 'force-dynamic';
 
 const DEFAULT_REDIRECT_PATH = '/settings';
 const REDIRECT_STATE_DELIMITER = '~';
+
+type McpOAuthCallbackStage =
+  | 'state_validation'
+  | 'connection_lookup'
+  | 'client_lookup'
+  | 'provider_discovery'
+  | 'token_exchange'
+  | 'token_storage'
+  | 'linear_metadata'
+  | 'deployment_enablement';
+
+function getCallbackFailureReason(stage: McpOAuthCallbackStage): string {
+  switch (stage) {
+    case 'provider_discovery':
+      return 'provider_metadata_failed';
+    case 'token_exchange':
+      return 'token_exchange_failed';
+    case 'token_storage':
+      return 'token_storage_failed';
+    case 'linear_metadata':
+      return 'linear_metadata_failed';
+    case 'deployment_enablement':
+      return 'deployment_enablement_failed';
+    default:
+      return 'callback_failed';
+  }
+}
+
+function getErrorName(error: unknown): string {
+  return error instanceof Error ? error.name : typeof error;
+}
 
 function sanitizeRedirectPath(redirectTo: string | null): string | null {
   if (!redirectTo) {
@@ -89,7 +121,16 @@ export async function GET(request: NextRequest) {
 
   // Handle OAuth errors
   if (error) {
-    console.error('[MCP OAuth] OAuth error:', error, errorDescription);
+    const reason =
+      error === 'access_denied' ? 'access_denied' : 'provider_error';
+    logger.warn(
+      {
+        event: 'mcp_oauth_provider_error',
+        providerError: reason,
+        hasErrorDescription: Boolean(errorDescription),
+      },
+      'MCP OAuth provider returned an error',
+    );
 
     if (state) {
       try {
@@ -97,22 +138,36 @@ export async function GET(request: NextRequest) {
         if (oauthState) {
           await updateAuthStatus(oauthState.connectionId, 'error');
           return NextResponse.redirect(
-            withMcpQuery(webUrl, redirectPath, 'error'),
+            withMcpQuery(webUrl, redirectPath, 'error', reason),
           );
         }
       } catch (e) {
-        console.error(
-          '[MCP OAuth] Error consuming state during error handling:',
-          e,
+        logger.error(
+          {
+            event: 'mcp_oauth_provider_error_state_update_failed',
+            errorName: getErrorName(e),
+          },
+          'Failed to mark an MCP OAuth provider error',
         );
       }
     }
 
-    return NextResponse.redirect(withMcpQuery(webUrl, redirectPath, 'error'));
+    return NextResponse.redirect(
+      withMcpQuery(webUrl, redirectPath, 'error', reason),
+    );
   }
 
   // Validate required parameters
   if (!code || !state) {
+    logger.warn(
+      {
+        event: 'mcp_oauth_callback_rejected',
+        reason: 'missing_params',
+        hasCode: Boolean(code),
+        hasState: Boolean(state),
+      },
+      'MCP OAuth callback was rejected',
+    );
     return NextResponse.redirect(
       withMcpQuery(webUrl, redirectPath, 'error', 'missing_params'),
     );
@@ -120,6 +175,18 @@ export async function GET(request: NextRequest) {
 
   const authResult = await authorize();
   if (!authResult.success) {
+    const configuredCallbackHost = new URL(webUrl).host;
+    logger.warn(
+      {
+        event: 'mcp_oauth_callback_rejected',
+        reason: 'unauthorized',
+        requestHost: request.nextUrl.host,
+        configuredCallbackHost,
+        callbackHostMatchesRequest:
+          request.nextUrl.host === configuredCallbackHost,
+      },
+      'MCP OAuth callback was rejected',
+    );
     return NextResponse.redirect(
       withMcpQuery(webUrl, redirectPath, 'error', 'unauthorized'),
     );
@@ -127,10 +194,20 @@ export async function GET(request: NextRequest) {
   const { userId } = authResult;
 
   let connectionId: string | undefined;
+  let integrationId: string | undefined;
+  let connectionRole: string | undefined;
+  let failureStage: McpOAuthCallbackStage = 'state_validation';
 
   try {
     const oauthState = await consumeOAuthState(state);
     if (!oauthState) {
+      logger.warn(
+        {
+          event: 'mcp_oauth_callback_rejected',
+          reason: 'invalid_state',
+        },
+        'MCP OAuth callback was rejected',
+      );
       return NextResponse.redirect(
         withMcpQuery(webUrl, redirectPath, 'error', 'invalid_state'),
       );
@@ -139,6 +216,7 @@ export async function GET(request: NextRequest) {
     const resolvedConnectionId = oauthState.connectionId;
     connectionId = resolvedConnectionId;
 
+    failureStage = 'connection_lookup';
     const connection = await db.query.mcpConnections.findFirst({
       where: eq(mcpConnections.id, resolvedConnectionId),
     });
@@ -147,6 +225,8 @@ export async function GET(request: NextRequest) {
         withMcpQuery(webUrl, redirectPath, 'error', 'not_found'),
       );
     }
+    integrationId = connection.mcpId;
+    connectionRole = connection.connectionRole;
 
     const integration = getMcpIntegration(connection.mcpId);
     if (!integration) {
@@ -176,6 +256,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    failureStage = 'client_lookup';
     const clientInfo = await getClientInformation(resolvedConnectionId);
     if (!clientInfo) {
       return NextResponse.redirect(
@@ -183,9 +264,11 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    failureStage = 'provider_discovery';
     const serverMetadata = await discoverOAuthEndpoints(integration.url);
     const redirectUri = new URL('/api/mcp-oauth/callback', webUrl).toString();
 
+    failureStage = 'token_exchange';
     const tokens = await exchangeCodeForTokens(
       serverMetadata.token_endpoint,
       code,
@@ -194,9 +277,11 @@ export async function GET(request: NextRequest) {
       redirectUri,
     );
 
+    failureStage = 'token_storage';
     await storeTokens(resolvedConnectionId, tokens);
 
     if (integration.id === 'linear') {
+      failureStage = 'linear_metadata';
       await hydrateLinearMcpConnectionAfterOauth({
         connection,
         accessToken: tokens.access_token,
@@ -206,6 +291,7 @@ export async function GET(request: NextRequest) {
     }
 
     if (requiresOrgAdmin) {
+      failureStage = 'deployment_enablement';
       await db
         .insert(deploymentMcpEnablements)
         .values({
@@ -227,19 +313,38 @@ export async function GET(request: NextRequest) {
       withMcpQuery(webUrl, redirectPath, 'connected'),
     );
   } catch (error) {
-    console.error('[MCP OAuth] Error in callback:', error);
+    const reason = getCallbackFailureReason(failureStage);
+    logger.error(
+      {
+        event: 'mcp_oauth_callback_failed',
+        failureStage,
+        reason,
+        integrationId,
+        connectionRole,
+        connectionId,
+        errorName: getErrorName(error),
+      },
+      'MCP OAuth callback failed',
+    );
 
     if (connectionId) {
       try {
         await updateAuthStatus(connectionId, 'error');
-        return NextResponse.redirect(
-          withMcpQuery(webUrl, redirectPath, 'error'),
+      } catch (statusError) {
+        logger.error(
+          {
+            event: 'mcp_oauth_error_status_update_failed',
+            connectionId,
+            integrationId,
+            errorName: getErrorName(statusError),
+          },
+          'Failed to mark an MCP OAuth connection as errored',
         );
-      } catch {
-        // Ignore errors during error handling
       }
     }
 
-    return NextResponse.redirect(withMcpQuery(webUrl, redirectPath, 'error'));
+    return NextResponse.redirect(
+      withMcpQuery(webUrl, redirectPath, 'error', reason),
+    );
   }
 }

--- a/apps/web/src/app/api/mcp-oauth/callback/route.ts
+++ b/apps/web/src/app/api/mcp-oauth/callback/route.ts
@@ -178,18 +178,19 @@ export async function GET(request: NextRequest) {
     const configuredCallbackHost = new URL(webUrl).host;
     logger.warn(
       {
-        event: 'mcp_oauth_callback_rejected',
-        reason: 'unauthorized',
+        event: 'mcp_oauth_callback_auth_required',
         requestHost: request.nextUrl.host,
         configuredCallbackHost,
         callbackHostMatchesRequest:
           request.nextUrl.host === configuredCallbackHost,
       },
-      'MCP OAuth callback was rejected',
+      'MCP OAuth callback requires sign-in before it can continue',
     );
-    return NextResponse.redirect(
-      withMcpQuery(webUrl, redirectPath, 'error', 'unauthorized'),
-    );
+
+    const callbackReturnPath = `${request.nextUrl.pathname}${request.nextUrl.search}`;
+    const signInUrl = new URL('/sign-in', webUrl);
+    signInUrl.searchParams.set('redirect_url', callbackReturnPath);
+    return NextResponse.redirect(signInUrl);
   }
   const { userId } = authResult;
 

--- a/apps/web/src/components/layout/McpOAuthResultFeedback.test.tsx
+++ b/apps/web/src/components/layout/McpOAuthResultFeedback.test.tsx
@@ -1,0 +1,79 @@
+import { render } from '@testing-library/react';
+
+const { navigationState, toastErrorMock, toastSuccessMock } = vi.hoisted(
+  () => ({
+    navigationState: {
+      pathname: '/settings/integrations',
+      searchParams: '',
+    },
+    toastErrorMock: vi.fn(),
+    toastSuccessMock: vi.fn(),
+  }),
+);
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => navigationState.pathname,
+  useSearchParams: () => new URLSearchParams(navigationState.searchParams),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: toastErrorMock,
+    success: toastSuccessMock,
+  },
+}));
+
+vi.mock('@roomote/types', () => ({
+  MCP_INTEGRATIONS: [{ id: 'linear', name: 'Linear' }],
+}));
+
+import { McpOAuthResultFeedback } from './McpOAuthResultFeedback';
+
+describe('McpOAuthResultFeedback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    navigationState.pathname = '/settings/integrations';
+    navigationState.searchParams = '';
+    window.history.replaceState(null, '', navigationState.pathname);
+  });
+
+  it('explains failures and removes only the transient OAuth parameters', () => {
+    const replaceState = vi.spyOn(window.history, 'replaceState');
+    navigationState.searchParams =
+      'service=linear&mcp=error&reason=linear_metadata_failed&tab=accounts';
+    window.history.replaceState(
+      null,
+      '',
+      `${navigationState.pathname}?${navigationState.searchParams}`,
+    );
+
+    render(<McpOAuthResultFeedback />);
+
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      'Roomote connected to Linear but could not verify the workspace. Try again.',
+    );
+    expect(replaceState).toHaveBeenLastCalledWith(
+      null,
+      '',
+      '/settings/integrations?service=linear&tab=accounts',
+    );
+  });
+
+  it('confirms success on any authenticated return page', () => {
+    const replaceState = vi.spyOn(window.history, 'replaceState');
+    navigationState.pathname = '/';
+    navigationState.searchParams = 'service=linear&mcp=connected';
+    window.history.replaceState(
+      null,
+      '',
+      `${navigationState.pathname}?${navigationState.searchParams}`,
+    );
+
+    render(<McpOAuthResultFeedback />);
+
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      'Linear connected successfully.',
+    );
+    expect(replaceState).toHaveBeenLastCalledWith(null, '', '/?service=linear');
+  });
+});

--- a/apps/web/src/components/layout/McpOAuthResultFeedback.tsx
+++ b/apps/web/src/components/layout/McpOAuthResultFeedback.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { toast } from 'sonner';
+
+import { MCP_INTEGRATIONS } from '@roomote/types';
+
+import {
+  getMcpOAuthResultMessage,
+  parseMcpOAuthResult,
+} from '@/lib/mcp-oauth-result';
+
+const MCP_INTEGRATION_NAME_BY_ID = new Map(
+  MCP_INTEGRATIONS.map((integration) => [integration.id, integration.name]),
+);
+
+export function McpOAuthResultFeedback() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const searchParamsString = searchParams.toString();
+  const handledResultRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const currentSearchParams = new URLSearchParams(searchParamsString);
+    const result = parseMcpOAuthResult(
+      currentSearchParams.get('mcp'),
+      currentSearchParams.get('reason'),
+    );
+    if (!result || handledResultRef.current === searchParamsString) {
+      return;
+    }
+    handledResultRef.current = searchParamsString;
+
+    const serviceId = currentSearchParams.get('service')?.trim() ?? '';
+    const serviceName = MCP_INTEGRATION_NAME_BY_ID.get(serviceId) ?? null;
+    const message = getMcpOAuthResultMessage(result, serviceName);
+    if (result.status === 'connected') {
+      toast.success(message);
+    } else {
+      toast.error(message);
+    }
+
+    currentSearchParams.delete('mcp');
+    currentSearchParams.delete('reason');
+    const nextSearch = currentSearchParams.toString();
+    window.history.replaceState(
+      null,
+      '',
+      nextSearch ? `${pathname}?${nextSearch}` : pathname,
+    );
+  }, [pathname, searchParamsString]);
+
+  return null;
+}

--- a/apps/web/src/components/settings/Integrations.test.tsx
+++ b/apps/web/src/components/settings/Integrations.test.tsx
@@ -399,49 +399,6 @@ describe('Integrations settings', () => {
     );
   });
 
-  it('explains a Linear callback failure and clears transient OAuth params', () => {
-    state.searchParams =
-      'service=linear&mcp=error&reason=linear_metadata_failed';
-    const replaceState = vi.spyOn(window.history, 'replaceState');
-    window.history.replaceState(
-      null,
-      '',
-      '/settings/integrations?service=linear&mcp=error&reason=linear_metadata_failed',
-    );
-
-    render(<Integrations />);
-
-    expect(toast.error).toHaveBeenCalledWith(
-      'Roomote connected to Linear but could not verify the workspace. Try again.',
-    );
-    expect(replaceState).toHaveBeenLastCalledWith(
-      null,
-      '',
-      '/settings/integrations?service=linear',
-    );
-  });
-
-  it('confirms a successful Linear callback and clears transient OAuth params', () => {
-    state.searchParams = 'service=linear&mcp=connected';
-    const replaceState = vi.spyOn(window.history, 'replaceState');
-    window.history.replaceState(
-      null,
-      '',
-      '/settings/integrations?service=linear&mcp=connected',
-    );
-
-    render(<Integrations />);
-
-    expect(toast.success).toHaveBeenCalledWith(
-      'Linear connected successfully.',
-    );
-    expect(replaceState).toHaveBeenLastCalledWith(
-      null,
-      '',
-      '/settings/integrations?service=linear',
-    );
-  });
-
   it('sorts integrations alphabetically and splits installed vs available', () => {
     const sorted = sortIntegrationItems([
       { id: 'sentry', name: 'Sentry', enabled: false },

--- a/apps/web/src/components/settings/Integrations.test.tsx
+++ b/apps/web/src/components/settings/Integrations.test.tsx
@@ -785,6 +785,22 @@ describe('Integrations settings', () => {
     );
   });
 
+  it('does not restore cleared OAuth result parameters when dismissing Linear', () => {
+    state.searchParams = 'service=linear&mcp=error&reason=access_denied';
+    const replaceState = vi.spyOn(window.history, 'replaceState');
+    state.linearInstallation = null;
+
+    render(<Integrations />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Not now' }));
+
+    expect(replaceState).toHaveBeenLastCalledWith(
+      null,
+      '',
+      '/settings/integrations',
+    );
+  });
+
   it('shows workspace connection status for an enabled org-scoped MCP', () => {
     state.deploymentEnablements = [{ mcpId: 'pylon', enabled: true }];
     state.userConnections = [{ mcpId: 'pylon', authStatus: 'authenticated' }];

--- a/apps/web/src/components/settings/Integrations.test.tsx
+++ b/apps/web/src/components/settings/Integrations.test.tsx
@@ -53,6 +53,7 @@ const state = vi.hoisted(() => ({
   linearInstallation: {
     linearOrganizationName: 'Roomote',
   } as null | { linearOrganizationName?: string },
+  linearRedirectPath: '',
   searchParams: '',
 }));
 
@@ -140,10 +141,13 @@ vi.mock('@/hooks/linear', () => ({
     data: state.linearInstallation,
     isPending: false,
   }),
-  useConnectLinear: () => ({
-    isPending: false,
-    mutate: mutations.connectLinear,
-  }),
+  useConnectLinear: (redirectPath: string) => {
+    state.linearRedirectPath = redirectPath;
+    return {
+      isPending: false,
+      mutate: mutations.connectLinear,
+    };
+  },
   useDisconnectLinear: () => ({
     isPending: false,
     mutate: mutations.disconnectLinear,
@@ -377,6 +381,7 @@ describe('Integrations settings', () => {
     state.linearInstallation = {
       linearOrganizationName: 'Roomote',
     };
+    state.linearRedirectPath = '';
     state.asanaConnection = null;
     state.grafanaConnection = null;
     state.vercelConnection = null;
@@ -384,6 +389,57 @@ describe('Integrations settings', () => {
     state.featureFlags = {};
     state.snowflakeConnection = null;
     state.searchParams = '';
+  });
+
+  it('returns Linear OAuth to a service-specific integrations URL', () => {
+    render(<Integrations />);
+
+    expect(state.linearRedirectPath).toBe(
+      '/settings/integrations?service=linear',
+    );
+  });
+
+  it('explains a Linear callback failure and clears transient OAuth params', () => {
+    state.searchParams =
+      'service=linear&mcp=error&reason=linear_metadata_failed';
+    const replaceState = vi.spyOn(window.history, 'replaceState');
+    window.history.replaceState(
+      null,
+      '',
+      '/settings/integrations?service=linear&mcp=error&reason=linear_metadata_failed',
+    );
+
+    render(<Integrations />);
+
+    expect(toast.error).toHaveBeenCalledWith(
+      'Roomote connected to Linear but could not verify the workspace. Try again.',
+    );
+    expect(replaceState).toHaveBeenLastCalledWith(
+      null,
+      '',
+      '/settings/integrations?service=linear',
+    );
+  });
+
+  it('confirms a successful Linear callback and clears transient OAuth params', () => {
+    state.searchParams = 'service=linear&mcp=connected';
+    const replaceState = vi.spyOn(window.history, 'replaceState');
+    window.history.replaceState(
+      null,
+      '',
+      '/settings/integrations?service=linear&mcp=connected',
+    );
+
+    render(<Integrations />);
+
+    expect(toast.success).toHaveBeenCalledWith(
+      'Linear connected successfully.',
+    );
+    expect(replaceState).toHaveBeenLastCalledWith(
+      null,
+      '',
+      '/settings/integrations?service=linear',
+    );
   });
 
   it('sorts integrations alphabetically and splits installed vs available', () => {

--- a/apps/web/src/components/settings/Integrations.tsx
+++ b/apps/web/src/components/settings/Integrations.tsx
@@ -1064,7 +1064,6 @@ function VercelConnectionFields({
 export function Integrations() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const searchParamsString = searchParams.toString();
   const { isAdmin } = useAuthorizedUser();
   const deepLinkedIntegrationId = (
     searchParams.get('service') ??
@@ -1616,9 +1615,11 @@ export function Integrations() {
     setDismissedDeepLinkIntegrationId(deepLinkedIntegrationId);
     setClearedDeepLinkIntegrationId(deepLinkedIntegrationId);
 
-    const nextSearchParams = new URLSearchParams(searchParamsString);
+    const nextSearchParams = new URLSearchParams(searchParams.toString());
     nextSearchParams.delete('service');
     nextSearchParams.delete('highlight');
+    nextSearchParams.delete('mcp');
+    nextSearchParams.delete('reason');
 
     const nextSearch = nextSearchParams.toString();
     window.history.replaceState(

--- a/apps/web/src/components/settings/Integrations.tsx
+++ b/apps/web/src/components/settings/Integrations.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { FormEvent, ReactNode } from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
@@ -108,6 +108,55 @@ const DEEP_LINK_ENABLE_DESCRIPTIONS: Record<string, string> = {
     'Roomote will be able to inspect Vercel teams, projects, deployments, logs, and domain availability.',
   zero: 'Roomote will be able to authenticate the workspace Zero connection so agents can discover and pay for external capabilities.',
 };
+const MCP_INTEGRATION_NAME_BY_ID = new Map(
+  MCP_INTEGRATIONS.map((integration) => [integration.id, integration.name]),
+);
+
+function getMcpOAuthServiceName(serviceId: string): string | null {
+  return MCP_INTEGRATION_NAME_BY_ID.get(serviceId) ?? null;
+}
+
+function getMcpOAuthErrorMessage(
+  reason: string | null,
+  serviceId: string,
+): string {
+  const serviceName = getMcpOAuthServiceName(serviceId);
+  const subject = serviceName ?? 'The integration';
+  const object = serviceName ?? 'the integration';
+  const label = serviceName ?? 'integration';
+  const authorization = serviceName
+    ? `${serviceName} authorization`
+    : 'the integration authorization';
+  const provider = serviceName ? `${serviceName}'s` : "the integration's";
+
+  switch (reason) {
+    case 'access_denied':
+      return `${subject} authorization was canceled. No changes were saved.`;
+    case 'unauthorized':
+      return `Your Roomote session expired while connecting ${object}. Sign in and try again.`;
+    case 'invalid_state':
+      return `This ${label} authorization attempt expired or was already used. Start the connection again.`;
+    case 'missing_params':
+      return `${subject} did not return the information Roomote needed. Try connecting again.`;
+    case 'not_found':
+      return `Roomote could not find this ${label} connection. Start the connection again.`;
+    case 'not_registered':
+      return `Roomote could not resume ${authorization}. Try connecting again.`;
+    case 'provider_metadata_failed':
+      return `Roomote could not reach ${provider} authorization service. Try again.`;
+    case 'token_exchange_failed':
+    case 'token_storage_failed':
+      return `${subject} approved access, but Roomote could not complete the connection. Try again.`;
+    case 'linear_metadata_failed':
+      return 'Roomote connected to Linear but could not verify the workspace. Try again.';
+    case 'deployment_enablement_failed':
+      return `${subject} connected, but Roomote could not enable it for this workspace. Try again.`;
+    case 'provider_error':
+      return `${subject} could not authorize Roomote. Try connecting again.`;
+    default:
+      return `Roomote could not complete the ${object} connection. Try again.`;
+  }
+}
 
 type IntegrationItem = {
   id: string;
@@ -1065,7 +1114,12 @@ function VercelConnectionFields({
 export function Integrations() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const searchParamsString = searchParams.toString();
   const { isAdmin } = useAuthorizedUser();
+  const mcpOAuthStatus = searchParams.get('mcp');
+  const mcpOAuthReason = searchParams.get('reason');
+  const mcpOAuthServiceId = (searchParams.get('service') ?? '').trim();
+  const handledMcpOAuthResultRef = useRef<string | null>(null);
   const deepLinkedIntegrationId = (
     searchParams.get('service') ??
     searchParams.get('highlight') ??
@@ -1119,7 +1173,7 @@ export function Integrations() {
   } | null>(null);
 
   const linearInstallation = useLinearInstallation();
-  const connectLinear = useConnectLinear(pathname);
+  const connectLinear = useConnectLinear(`${pathname}?service=linear`);
   const disconnectLinear = useDisconnectLinear();
 
   const deploymentEnablements = useDeploymentMcpEnablements();
@@ -1596,6 +1650,50 @@ export function Integrations() {
       : null;
 
   useEffect(() => {
+    if (mcpOAuthStatus !== 'connected' && mcpOAuthStatus !== 'error') {
+      return;
+    }
+
+    const resultKey = [
+      mcpOAuthStatus,
+      mcpOAuthReason ?? '',
+      mcpOAuthServiceId,
+    ].join(':');
+    if (handledMcpOAuthResultRef.current === resultKey) {
+      return;
+    }
+    handledMcpOAuthResultRef.current = resultKey;
+
+    const serviceName = getMcpOAuthServiceName(mcpOAuthServiceId);
+    if (mcpOAuthStatus === 'connected') {
+      toast.success(
+        serviceName
+          ? `${serviceName} connected successfully.`
+          : 'Integration connected successfully.',
+      );
+    } else {
+      toast.error(getMcpOAuthErrorMessage(mcpOAuthReason, mcpOAuthServiceId));
+    }
+
+    const nextSearchParams = new URLSearchParams(searchParamsString);
+    nextSearchParams.delete('mcp');
+    nextSearchParams.delete('reason');
+
+    const nextSearch = nextSearchParams.toString();
+    window.history.replaceState(
+      null,
+      '',
+      nextSearch.length > 0 ? `${pathname}?${nextSearch}` : pathname,
+    );
+  }, [
+    mcpOAuthReason,
+    mcpOAuthServiceId,
+    mcpOAuthStatus,
+    pathname,
+    searchParamsString,
+  ]);
+
+  useEffect(() => {
     setDismissedDeepLinkIntegrationId(null);
     setClearedDeepLinkIntegrationId(null);
   }, [deepLinkedIntegrationId]);
@@ -1616,7 +1714,7 @@ export function Integrations() {
     setDismissedDeepLinkIntegrationId(deepLinkedIntegrationId);
     setClearedDeepLinkIntegrationId(deepLinkedIntegrationId);
 
-    const nextSearchParams = new URLSearchParams(searchParams.toString());
+    const nextSearchParams = new URLSearchParams(searchParamsString);
     nextSearchParams.delete('service');
     nextSearchParams.delete('highlight');
 

--- a/apps/web/src/components/settings/Integrations.tsx
+++ b/apps/web/src/components/settings/Integrations.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { FormEvent, ReactNode } from 'react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
@@ -108,56 +108,6 @@ const DEEP_LINK_ENABLE_DESCRIPTIONS: Record<string, string> = {
     'Roomote will be able to inspect Vercel teams, projects, deployments, logs, and domain availability.',
   zero: 'Roomote will be able to authenticate the workspace Zero connection so agents can discover and pay for external capabilities.',
 };
-const MCP_INTEGRATION_NAME_BY_ID = new Map(
-  MCP_INTEGRATIONS.map((integration) => [integration.id, integration.name]),
-);
-
-function getMcpOAuthServiceName(serviceId: string): string | null {
-  return MCP_INTEGRATION_NAME_BY_ID.get(serviceId) ?? null;
-}
-
-function getMcpOAuthErrorMessage(
-  reason: string | null,
-  serviceId: string,
-): string {
-  const serviceName = getMcpOAuthServiceName(serviceId);
-  const subject = serviceName ?? 'The integration';
-  const object = serviceName ?? 'the integration';
-  const label = serviceName ?? 'integration';
-  const authorization = serviceName
-    ? `${serviceName} authorization`
-    : 'the integration authorization';
-  const provider = serviceName ? `${serviceName}'s` : "the integration's";
-
-  switch (reason) {
-    case 'access_denied':
-      return `${subject} authorization was canceled. No changes were saved.`;
-    case 'unauthorized':
-      return `Your Roomote session expired while connecting ${object}. Sign in and try again.`;
-    case 'invalid_state':
-      return `This ${label} authorization attempt expired or was already used. Start the connection again.`;
-    case 'missing_params':
-      return `${subject} did not return the information Roomote needed. Try connecting again.`;
-    case 'not_found':
-      return `Roomote could not find this ${label} connection. Start the connection again.`;
-    case 'not_registered':
-      return `Roomote could not resume ${authorization}. Try connecting again.`;
-    case 'provider_metadata_failed':
-      return `Roomote could not reach ${provider} authorization service. Try again.`;
-    case 'token_exchange_failed':
-    case 'token_storage_failed':
-      return `${subject} approved access, but Roomote could not complete the connection. Try again.`;
-    case 'linear_metadata_failed':
-      return 'Roomote connected to Linear but could not verify the workspace. Try again.';
-    case 'deployment_enablement_failed':
-      return `${subject} connected, but Roomote could not enable it for this workspace. Try again.`;
-    case 'provider_error':
-      return `${subject} could not authorize Roomote. Try connecting again.`;
-    default:
-      return `Roomote could not complete the ${object} connection. Try again.`;
-  }
-}
-
 type IntegrationItem = {
   id: string;
   name: string;
@@ -1116,10 +1066,6 @@ export function Integrations() {
   const searchParams = useSearchParams();
   const searchParamsString = searchParams.toString();
   const { isAdmin } = useAuthorizedUser();
-  const mcpOAuthStatus = searchParams.get('mcp');
-  const mcpOAuthReason = searchParams.get('reason');
-  const mcpOAuthServiceId = (searchParams.get('service') ?? '').trim();
-  const handledMcpOAuthResultRef = useRef<string | null>(null);
   const deepLinkedIntegrationId = (
     searchParams.get('service') ??
     searchParams.get('highlight') ??
@@ -1648,50 +1594,6 @@ export function Integrations() {
     DEEP_LINK_ENABLE_DESCRIPTIONS[highlightedItem.id] != null
       ? highlightedItem
       : null;
-
-  useEffect(() => {
-    if (mcpOAuthStatus !== 'connected' && mcpOAuthStatus !== 'error') {
-      return;
-    }
-
-    const resultKey = [
-      mcpOAuthStatus,
-      mcpOAuthReason ?? '',
-      mcpOAuthServiceId,
-    ].join(':');
-    if (handledMcpOAuthResultRef.current === resultKey) {
-      return;
-    }
-    handledMcpOAuthResultRef.current = resultKey;
-
-    const serviceName = getMcpOAuthServiceName(mcpOAuthServiceId);
-    if (mcpOAuthStatus === 'connected') {
-      toast.success(
-        serviceName
-          ? `${serviceName} connected successfully.`
-          : 'Integration connected successfully.',
-      );
-    } else {
-      toast.error(getMcpOAuthErrorMessage(mcpOAuthReason, mcpOAuthServiceId));
-    }
-
-    const nextSearchParams = new URLSearchParams(searchParamsString);
-    nextSearchParams.delete('mcp');
-    nextSearchParams.delete('reason');
-
-    const nextSearch = nextSearchParams.toString();
-    window.history.replaceState(
-      null,
-      '',
-      nextSearch.length > 0 ? `${pathname}?${nextSearch}` : pathname,
-    );
-  }, [
-    mcpOAuthReason,
-    mcpOAuthServiceId,
-    mcpOAuthStatus,
-    pathname,
-    searchParamsString,
-  ]);
 
   useEffect(() => {
     setDismissedDeepLinkIntegrationId(null);

--- a/apps/web/src/lib/mcp-oauth-result.ts
+++ b/apps/web/src/lib/mcp-oauth-result.ts
@@ -1,0 +1,83 @@
+export const MCP_OAUTH_ERROR_REASONS = [
+  'access_denied',
+  'provider_error',
+  'missing_params',
+  'invalid_state',
+  'not_found',
+  'not_registered',
+  'provider_metadata_failed',
+  'token_exchange_failed',
+  'token_storage_failed',
+  'linear_metadata_failed',
+  'deployment_enablement_failed',
+  'callback_failed',
+] as const;
+
+export type McpOAuthErrorReason = (typeof MCP_OAUTH_ERROR_REASONS)[number];
+
+export type McpOAuthResult =
+  | { status: 'connected' }
+  | { status: 'error'; reason: McpOAuthErrorReason | null };
+
+export function parseMcpOAuthResult(
+  status: string | null,
+  reason: string | null,
+): McpOAuthResult | null {
+  if (status === 'connected') {
+    return { status };
+  }
+
+  if (status !== 'error') {
+    return null;
+  }
+
+  return {
+    status,
+    reason: MCP_OAUTH_ERROR_REASONS.includes(reason as McpOAuthErrorReason)
+      ? (reason as McpOAuthErrorReason)
+      : null,
+  };
+}
+
+export function getMcpOAuthResultMessage(
+  result: McpOAuthResult,
+  serviceName: string | null,
+): string {
+  const subject = serviceName ?? 'The integration';
+  if (result.status === 'connected') {
+    return `${subject} connected successfully.`;
+  }
+
+  const object = serviceName ?? 'the integration';
+  const label = serviceName ?? 'integration';
+  const authorization = serviceName
+    ? `${serviceName} authorization`
+    : 'the integration authorization';
+  const provider = serviceName ? `${serviceName}'s` : "the integration's";
+
+  switch (result.reason) {
+    case 'access_denied':
+      return `${subject} authorization was canceled. No changes were saved.`;
+    case 'invalid_state':
+      return `This ${label} authorization attempt expired or was already used. Start the connection again.`;
+    case 'missing_params':
+      return `${subject} did not return the information Roomote needed. Try connecting again.`;
+    case 'not_found':
+      return `Roomote could not find this ${label} connection. Start the connection again.`;
+    case 'not_registered':
+      return `Roomote could not resume ${authorization}. Try connecting again.`;
+    case 'provider_metadata_failed':
+      return `Roomote could not reach ${provider} authorization service. Try again.`;
+    case 'token_exchange_failed':
+    case 'token_storage_failed':
+      return `${subject} approved access, but Roomote could not complete the connection. Try again.`;
+    case 'linear_metadata_failed':
+      return 'Roomote connected to Linear but could not verify the workspace. Try again.';
+    case 'deployment_enablement_failed':
+      return `${subject} connected, but Roomote could not enable it for this workspace. Try again.`;
+    case 'provider_error':
+      return `${subject} could not authorize Roomote. Try connecting again.`;
+    default:
+      return `Roomote could not complete the ${object} connection. Try again.`;
+  }
+}


### PR DESCRIPTION
## What changed

- MCP OAuth callbacks can resume the same connection after the user signs in, without exposing authorization codes in the sign-in URL.
- OAuth results now show a clear success or safe failure message on authenticated return pages.
- Linear OAuth returns to its integration deep link, and dismissing that prompt removes the deep-link and transient OAuth-result query parameters.

## Why this change was made

OAuth authorization could previously stop when the Roomote session had expired. A failed Linear authorization could also resurface its error message after the user dismissed the follow-up prompt.

## Impact

Users can sign in and complete an interrupted MCP OAuth connection safely. Dismissing the Linear prompt leaves the integrations URL clean, preventing stale failure feedback from appearing again on reload.

## Screenshots

![Dismissing the failed Linear OAuth prompt leaves the integrations route clean](https://roomote.roomote.ai/api/artifacts/01ae654e-bbd1-4d16-bae9-5f93028a9f5c/raw?sig=fda52829550c42e3fe7a61ba3acc10825314348f290c6fb39dc2639d31b12bb6&ts=1785176094)