### PR TITLE
fix(snapshot): persist the snapshot id before tearing the sandbox down

### DIFF
--- a/apps/bullmq/src/jobs/snapshot-persistence.test.ts
+++ b/apps/bullmq/src/jobs/snapshot-persistence.test.ts
@@ -104,47 +104,69 @@ async function readRun(runId: number) {
   return row;
 }
 
+/**
+ * Reproduces the incident faithfully: the provider yields an id, and then the
+ * attempt never progresses again because its process stopped renewing the
+ * BullMQ lock. Nothing further in that attempt runs -- so this cannot be
+ * modelled with a thrown error, which would still run the catch block.
+ */
+function startStalledAttempt(runId: number, snapshotId: string) {
+  mockCreateSnapshot.mockImplementation(async ({ onSnapshotCreated }) => {
+    await onSnapshotCreated?.(snapshotId);
+    // Modal terminates the sandbox here. This attempt hangs instead.
+    return new Promise(() => {});
+  });
+
+  // Deliberately not awaited: the attempt is stalled, exactly as in the
+  // incident. Swallow any late rejection so it cannot fail an unrelated test.
+  void snapshotJob(buildJob(runId, 0)).catch(() => {});
+}
+
+async function waitForSnapshotId(runId: number, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const row = await readRun(runId);
+
+    if (row.snapshotId) {
+      return row;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+
+  throw new Error(`Snapshot id was never persisted for task run #${runId}`);
+}
+
 describe('snapshot id persistence (real database)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('keeps the snapshot id when the attempt dies after the provider produced it', async () => {
+  it('records the snapshot id while the attempt is still in flight', async () => {
     const run = await createIdleRunAwaitingSnapshot();
 
     mockGetInstanceStatus.mockResolvedValue({ status: 'running' });
-    mockCreateSnapshot.mockImplementation(async ({ onSnapshotCreated }) => {
-      await onSnapshotCreated?.('im-incident-replay');
-      // Modal terminates the sandbox here. This is the exact window where the
-      // original incident lost the id: the process stopped renewing its lock
-      // and the job was redelivered before it could record anything.
-      throw new Error('worker died during post-snapshot teardown');
-    });
+    startStalledAttempt(run.id, 'im-incident-replay');
 
-    await expect(snapshotJob(buildJob(run.id, 0))).rejects.toThrow();
+    // Nothing in attempt 1 will ever run again -- not its teardown, not its
+    // catch block, not its finalizing transaction. The id has to already be
+    // durable at this point or it is gone for good.
+    const inFlight = await waitForSnapshotId(run.id);
 
-    const afterCrash = await readRun(run.id);
-
-    // The snapshot survived the crash -- this is the entire fix.
-    expect(afterCrash.snapshotId).toBe('im-incident-replay');
-    expect(afterCrash.snapshotCreatedAt).toBeInstanceOf(Date);
-    expect(afterCrash.snapshotFailedAt).toBeNull();
-    // The failure path must not have cleared the id it found on the row.
-    expect(afterCrash.status).toBe(RunStatus.Idle);
+    expect(inFlight.snapshotId).toBe('im-incident-replay');
+    expect(inFlight.snapshotCreatedAt).toBeInstanceOf(Date);
+    expect(inFlight.snapshotFailedAt).toBeNull();
+    expect(inFlight.status).toBe(RunStatus.Idle);
   });
 
   it('finalizes a redelivered attempt from the persisted id instead of failing on the stopped sandbox', async () => {
     const run = await createIdleRunAwaitingSnapshot();
 
     mockGetInstanceStatus.mockResolvedValue({ status: 'running' });
-    mockCreateSnapshot.mockImplementation(async ({ onSnapshotCreated }) => {
-      await onSnapshotCreated?.('im-incident-replay');
-      throw new Error('worker died during post-snapshot teardown');
-    });
+    startStalledAttempt(run.id, 'im-incident-replay');
 
-    await expect(snapshotJob(buildJob(run.id, 0))).rejects.toThrow();
-
-    const persisted = await readRun(run.id);
+    const persisted = await waitForSnapshotId(run.id);
     const originalCreatedAt = persisted.snapshotCreatedAt;
 
     // BullMQ redelivers the stalled job. The sandbox is now stopped, because
@@ -179,16 +201,45 @@ describe('snapshot id persistence (real database)', () => {
     expect(decisions).toContain('reuse_persisted_snapshot');
   });
 
-  it('does not let a losing concurrent attempt overwrite the recorded snapshot', async () => {
+  it('finalizes in place when the attempt fails after the id was recorded', async () => {
     const run = await createIdleRunAwaitingSnapshot();
 
     mockGetInstanceStatus.mockResolvedValue({ status: 'running' });
     mockCreateSnapshot.mockImplementation(async ({ onSnapshotCreated }) => {
-      await onSnapshotCreated?.('im-first-writer');
-      throw new Error('worker died during post-snapshot teardown');
+      await onSnapshotCreated?.('im-teardown-failure');
+      throw new Error('teardown exploded');
     });
 
-    await expect(snapshotJob(buildJob(run.id, 0))).rejects.toThrow();
+    // Final attempt, so the job would raise UnrecoverableError and BullMQ
+    // would never redeliver it.
+    await snapshotJob(buildJob(run.id, 2));
+
+    const finalized = await readRun(run.id);
+
+    // Nothing else can rescue this run: sleep-check's candidate query skips
+    // rows that carry a snapshot id or a pending snapshot request, and there
+    // is no redelivery to short-circuit. Leaving it Idle would strand the
+    // task forever while holding a perfectly good snapshot.
+    expect(finalized.status).toBe(RunStatus.Completed);
+    expect(finalized.snapshotId).toBe('im-teardown-failure');
+    expect(finalized.snapshotFailedAt).toBeNull();
+
+    const events = await db.query.taskRunEvents.findMany({
+      where: eq(taskRunEvents.runId, run.id),
+    });
+
+    expect(events.map((event) => event.details?.decision)).toContain(
+      'recover_persisted_snapshot_after_failure',
+    );
+  });
+
+  it('does not let a losing concurrent attempt overwrite the recorded snapshot', async () => {
+    const run = await createIdleRunAwaitingSnapshot();
+
+    mockGetInstanceStatus.mockResolvedValue({ status: 'running' });
+    startStalledAttempt(run.id, 'im-first-writer');
+
+    await waitForSnapshotId(run.id);
 
     // A second attempt somehow produces a different image. The guarded update
     // must leave the already-recorded id alone rather than pointing the run at

--- a/apps/bullmq/src/jobs/snapshot-persistence.test.ts
+++ b/apps/bullmq/src/jobs/snapshot-persistence.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Regression coverage for the snapshot-loss incident, run against the real
+ * database rather than a mocked `db`.
+ *
+ * The unit tests in `snapshot.test.ts` mock every query, so they prove the
+ * job's control flow but not that the guarded `snapshot_id IS NULL` update
+ * actually behaves that way in Postgres -- which is the whole mechanism the
+ * fix depends on. These tests replay the incident end to end at the job
+ * level: attempt 1 hands over a snapshot id and then dies during teardown,
+ * and the redelivered attempt 2 finds the sandbox already stopped.
+ *
+ * Only the compute provider and the outbound integrations are stubbed. Every
+ * task_runs read and write here is real SQL.
+ */
+import {
+  db,
+  eq,
+  runFactory,
+  taskFactory,
+  taskRuns,
+  taskRunEvents,
+} from '@roomote/db/server';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
+
+const { mockGetInstanceStatus, mockCreateSnapshot } = vi.hoisted(() => ({
+  mockGetInstanceStatus: vi.fn(),
+  mockCreateSnapshot: vi.fn(),
+}));
+
+vi.mock('@roomote/compute-providers', () => ({
+  createComputeProviderClient: () => ({
+    vendor: 'modal',
+    getInstanceStatus: mockGetInstanceStatus,
+    createSnapshot: mockCreateSnapshot,
+    // Deliberately absent, matching Modal: there is no way to look a snapshot
+    // up by its source instance, so nothing can recover a lost id.
+    findSnapshotBySourceInstance: undefined,
+  }),
+}));
+
+vi.mock('@roomote/linear', () => ({
+  drainLinearMessagesToResumeRun: vi.fn().mockResolvedValue({ resumed: false }),
+}));
+
+vi.mock('@roomote/slack', () => ({
+  drainSlackMessagesToResumeRun: vi.fn().mockResolvedValue({ resumed: false }),
+}));
+
+vi.mock('@roomote/sdk/server', () => ({
+  withSandboxServerRpcClient: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../compute-provider-usage', () => ({
+  tryRecordComputeProviderUsage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../monitoring/sentry', () => ({
+  captureBullMqMessage: vi.fn(),
+}));
+
+import { snapshotJob } from './snapshot';
+
+const SANDBOX_ID = 'sb-persistence-regression';
+
+async function createIdleRunAwaitingSnapshot() {
+  const task = await taskFactory.create();
+
+  return runFactory.create({
+    taskId: task.id,
+    payloadKind: TaskPayloadKind.StandardTask,
+    payload: { repo: 'test/repo', description: 'snapshot persistence' },
+    status: RunStatus.Idle,
+    vendor: 'modal',
+    machineId: SANDBOX_ID,
+    // Stamped by sleep-check when it claims the snapshot handoff.
+    snapshotRequestedAt: new Date(),
+    sleepRequestedAt: new Date(),
+  });
+}
+
+function buildJob(runId: number, attemptsMade: number) {
+  return {
+    id: `due_sleep-${runId}`,
+    attemptsMade,
+    opts: { attempts: 3 },
+    data: {
+      runId,
+      sandboxId: SANDBOX_ID,
+      snapshotIntentId: `due_sleep-${runId}`,
+      triggerPath: 'due_sleep',
+    },
+  } as never;
+}
+
+async function readRun(runId: number) {
+  const row = await db.query.taskRuns.findFirst({
+    where: eq(taskRuns.id, runId),
+  });
+
+  if (!row) {
+    throw new Error(`Task run #${runId} disappeared`);
+  }
+
+  return row;
+}
+
+describe('snapshot id persistence (real database)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps the snapshot id when the attempt dies after the provider produced it', async () => {
+    const run = await createIdleRunAwaitingSnapshot();
+
+    mockGetInstanceStatus.mockResolvedValue({ status: 'running' });
+    mockCreateSnapshot.mockImplementation(async ({ onSnapshotCreated }) => {
+      await onSnapshotCreated?.('im-incident-replay');
+      // Modal terminates the sandbox here. This is the exact window where the
+      // original incident lost the id: the process stopped renewing its lock
+      // and the job was redelivered before it could record anything.
+      throw new Error('worker died during post-snapshot teardown');
+    });
+
+    await expect(snapshotJob(buildJob(run.id, 0))).rejects.toThrow();
+
+    const afterCrash = await readRun(run.id);
+
+    // The snapshot survived the crash -- this is the entire fix.
+    expect(afterCrash.snapshotId).toBe('im-incident-replay');
+    expect(afterCrash.snapshotCreatedAt).toBeInstanceOf(Date);
+    expect(afterCrash.snapshotFailedAt).toBeNull();
+    // The failure path must not have cleared the id it found on the row.
+    expect(afterCrash.status).toBe(RunStatus.Idle);
+  });
+
+  it('finalizes a redelivered attempt from the persisted id instead of failing on the stopped sandbox', async () => {
+    const run = await createIdleRunAwaitingSnapshot();
+
+    mockGetInstanceStatus.mockResolvedValue({ status: 'running' });
+    mockCreateSnapshot.mockImplementation(async ({ onSnapshotCreated }) => {
+      await onSnapshotCreated?.('im-incident-replay');
+      throw new Error('worker died during post-snapshot teardown');
+    });
+
+    await expect(snapshotJob(buildJob(run.id, 0))).rejects.toThrow();
+
+    const persisted = await readRun(run.id);
+    const originalCreatedAt = persisted.snapshotCreatedAt;
+
+    // BullMQ redelivers the stalled job. The sandbox is now stopped, because
+    // the first attempt snapshotted it successfully -- the precise condition
+    // that used to finalize the run without a snapshot and strand the task.
+    vi.clearAllMocks();
+    mockGetInstanceStatus.mockResolvedValue({ status: 'stopped' });
+
+    await snapshotJob(buildJob(run.id, 1));
+
+    const finalized = await readRun(run.id);
+
+    expect(finalized.status).toBe(RunStatus.Completed);
+    expect(finalized.snapshotId).toBe('im-incident-replay');
+    expect(finalized.snapshotFailedAt).toBeNull();
+    expect(finalized.sleepAt).toBeNull();
+    // Re-snapshotting is impossible once the sandbox is gone, so the job must
+    // not even try -- and must not consult the dead instance.
+    expect(mockCreateSnapshot).not.toHaveBeenCalled();
+    expect(mockGetInstanceStatus).not.toHaveBeenCalled();
+    // Expiry still runs from the real creation time, not the redelivery.
+    expect(finalized.snapshotCreatedAt?.toISOString()).toBe(
+      originalCreatedAt?.toISOString(),
+    );
+
+    const events = await db.query.taskRunEvents.findMany({
+      where: eq(taskRunEvents.runId, run.id),
+    });
+    const decisions = events.map((event) => event.details?.decision);
+
+    expect(decisions).toContain('persist_snapshot_id_before_teardown');
+    expect(decisions).toContain('reuse_persisted_snapshot');
+  });
+
+  it('does not let a losing concurrent attempt overwrite the recorded snapshot', async () => {
+    const run = await createIdleRunAwaitingSnapshot();
+
+    mockGetInstanceStatus.mockResolvedValue({ status: 'running' });
+    mockCreateSnapshot.mockImplementation(async ({ onSnapshotCreated }) => {
+      await onSnapshotCreated?.('im-first-writer');
+      throw new Error('worker died during post-snapshot teardown');
+    });
+
+    await expect(snapshotJob(buildJob(run.id, 0))).rejects.toThrow();
+
+    // A second attempt somehow produces a different image. The guarded update
+    // must leave the already-recorded id alone rather than pointing the run at
+    // a snapshot the first writer's consumers never saw.
+    vi.clearAllMocks();
+    mockGetInstanceStatus.mockResolvedValue({ status: 'running' });
+    mockCreateSnapshot.mockImplementation(async ({ onSnapshotCreated }) => {
+      await onSnapshotCreated?.('im-second-writer');
+      return { snapshotId: 'im-second-writer' };
+    });
+
+    await snapshotJob(buildJob(run.id, 1));
+
+    const finalized = await readRun(run.id);
+
+    expect(finalized.snapshotId).toBe('im-first-writer');
+    expect(mockCreateSnapshot).not.toHaveBeenCalled();
+  });
+});

--- a/apps/bullmq/src/jobs/snapshot-persistence.test.ts
+++ b/apps/bullmq/src/jobs/snapshot-persistence.test.ts
@@ -233,6 +233,72 @@ describe('snapshot id persistence (real database)', () => {
     );
   });
 
+  /**
+   * Both attempts overlap: the row is still empty when the attempt under test
+   * starts, so its short-circuit does not fire, and a competitor claims the
+   * row while it is mid-snapshot. The finalizing update is unconditional, so
+   * a loser that finalizes its own id would overwrite the recorded one and
+   * point the run at a snapshot no consumer ever saw.
+   */
+  function claimRowMidFlight(runId: number, winnerCreatedAt: Date) {
+    return async (
+      snapshotId: string,
+      onSnapshotCreated?: (id: string) => Promise<void>,
+    ) => {
+      await db
+        .update(taskRuns)
+        .set({ snapshotId: 'im-winner', snapshotCreatedAt: winnerCreatedAt })
+        .where(eq(taskRuns.id, runId));
+      await onSnapshotCreated?.(snapshotId);
+    };
+  }
+
+  it('finalizes the winning id when a concurrent attempt claims the row mid-flight', async () => {
+    const run = await createIdleRunAwaitingSnapshot();
+    const winnerCreatedAt = new Date('2026-04-24T06:29:00.000Z');
+    const claim = claimRowMidFlight(run.id, winnerCreatedAt);
+
+    mockGetInstanceStatus.mockResolvedValue({ status: 'running' });
+    mockCreateSnapshot.mockImplementation(async ({ onSnapshotCreated }) => {
+      await claim('im-loser', onSnapshotCreated);
+      return { snapshotId: 'im-loser' };
+    });
+
+    await snapshotJob(buildJob(run.id, 0));
+
+    const finalized = await readRun(run.id);
+
+    expect(finalized.snapshotId).toBe('im-winner');
+    expect(finalized.snapshotCreatedAt?.toISOString()).toBe(
+      winnerCreatedAt.toISOString(),
+    );
+    expect(finalized.status).toBe(RunStatus.Completed);
+  });
+
+  it('finalizes the winning id when a losing attempt then fails during teardown', async () => {
+    const run = await createIdleRunAwaitingSnapshot();
+    const winnerCreatedAt = new Date('2026-04-24T06:29:00.000Z');
+    const claim = claimRowMidFlight(run.id, winnerCreatedAt);
+
+    mockGetInstanceStatus.mockResolvedValue({ status: 'running' });
+    mockCreateSnapshot.mockImplementation(async ({ onSnapshotCreated }) => {
+      await claim('im-loser', onSnapshotCreated);
+      throw new Error('teardown exploded');
+    });
+
+    await snapshotJob(buildJob(run.id, 2));
+
+    const finalized = await readRun(run.id);
+
+    // The recovery path must recover the recorded snapshot, not this
+    // attempt's own.
+    expect(finalized.snapshotId).toBe('im-winner');
+    expect(finalized.snapshotCreatedAt?.toISOString()).toBe(
+      winnerCreatedAt.toISOString(),
+    );
+    expect(finalized.status).toBe(RunStatus.Completed);
+  });
+
   it('does not let a losing concurrent attempt overwrite the recorded snapshot', async () => {
     const run = await createIdleRunAwaitingSnapshot();
 

--- a/apps/bullmq/src/jobs/snapshot.test.ts
+++ b/apps/bullmq/src/jobs/snapshot.test.ts
@@ -183,7 +183,13 @@ describe('snapshotJob', () => {
     );
     updateFn.mockReturnValue({ set: setFn });
     setFn.mockReturnValue({ where: updateWhereFn });
-    updateWhereFn.mockResolvedValue([]);
+    // The early snapshot-id persist chains `.returning()` off `.where()`,
+    // while every other update awaits `.where()` directly. Support both.
+    updateWhereFn.mockImplementation(() =>
+      Object.assign(Promise.resolve([]), {
+        returning: () => Promise.resolve([{ id: baseTaskRun.id }]),
+      }),
+    );
     mockMarkTaskStartParallelCountEndedAt.mockResolvedValue(undefined);
     mockSyncTaskStateFromRuns.mockResolvedValue(undefined);
     mockUpdatePendingEnvironmentSnapshot.mockResolvedValue(true);
@@ -1366,5 +1372,134 @@ describe('snapshotJob', () => {
       }),
     );
     expect(mockCaptureBullMqMessage).not.toHaveBeenCalled();
+  });
+
+  it('persists the snapshot id before the adapter tears the sandbox down', async () => {
+    const persistOrder: string[] = [];
+
+    mockGetInstanceStatus.mockResolvedValue({ status: 'running' });
+    mockCreateSnapshot.mockImplementation(async ({ onSnapshotCreated }) => {
+      await onSnapshotCreated?.('snap_persisted_early');
+      // Stands in for the adapter's post-snapshot teardown, which is where the
+      // id used to be lost when the process died or the job was redelivered.
+      persistOrder.push('teardown');
+      return { snapshotId: 'snap_persisted_early' };
+    });
+
+    setFn.mockImplementation((values: Record<string, unknown>) => {
+      if (values.snapshotId === 'snap_persisted_early' && !values.status) {
+        persistOrder.push('persist');
+      }
+      return { where: updateWhereFn };
+    });
+
+    await snapshotJob({
+      data: { runId: 123, sandboxId: 'sb-early-persist' },
+    } as never);
+
+    expect(persistOrder).toEqual(['persist', 'teardown']);
+    expect(setFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshotId: 'snap_persisted_early',
+        snapshotCreatedAt: expect.any(Date),
+        snapshotFailedAt: null,
+      }),
+    );
+    expect(mockRecordTaskRunEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventType: 'decision',
+        details: expect.objectContaining({
+          decision: 'persist_snapshot_id_before_teardown',
+          snapshotId: 'snap_persisted_early',
+        }),
+      }),
+    );
+  });
+
+  it('finalizes from the persisted snapshot when a redelivery finds the sandbox stopped', async () => {
+    const snapshotCreatedAt = new Date('2026-04-24T06:30:00.000Z');
+    mockFindFirst.mockResolvedValue({
+      ...baseTaskRun,
+      snapshotId: 'snap_persisted_early',
+      snapshotCreatedAt,
+    });
+    // The sandbox is stopped precisely because the first attempt snapshotted
+    // it successfully. Re-snapshotting is impossible, so the job must not ask.
+    mockGetInstanceStatus.mockResolvedValue({ status: 'stopped' });
+
+    await snapshotJob({
+      data: { runId: 123, sandboxId: 'sb-redelivered' },
+    } as never);
+
+    expect(mockGetInstanceStatus).not.toHaveBeenCalled();
+    expect(mockCreateSnapshot).not.toHaveBeenCalled();
+    expect(mockCaptureBullMqMessage).not.toHaveBeenCalled();
+    expect(mockRecordTaskRunEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventType: 'decision',
+        details: expect.objectContaining({
+          decision: 'reuse_persisted_snapshot',
+          snapshotId: 'snap_persisted_early',
+        }),
+      }),
+    );
+    // Completed, resumable, and still carrying its original creation time so
+    // the resume window is not silently extended.
+    expect(setFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshotId: 'snap_persisted_early',
+        snapshotCreatedAt,
+        snapshotFailedAt: null,
+        status: RunStatus.Completed,
+      }),
+    );
+    expect(mockAttachEnvironmentSnapshot).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        snapshotId: 'snap_persisted_early',
+        snapshotCreatedAt,
+        snapshotStatus: 'ready',
+      }),
+    );
+  });
+
+  it('keeps an existing snapshot id when a losing attempt tries to persist', async () => {
+    const winnerCreatedAt = new Date('2026-04-24T06:31:00.000Z');
+    mockGetInstanceStatus.mockResolvedValue({ status: 'running' });
+    // No row returned: the guarded update matched nothing because another
+    // attempt already recorded a snapshot id.
+    updateWhereFn.mockImplementation(() =>
+      Object.assign(Promise.resolve([]), {
+        returning: () => Promise.resolve([]),
+      }),
+    );
+    mockFindFirst
+      .mockResolvedValueOnce(baseTaskRun)
+      .mockResolvedValueOnce({ snapshotCreatedAt: winnerCreatedAt });
+    mockCreateSnapshot.mockImplementation(async ({ onSnapshotCreated }) => {
+      await onSnapshotCreated?.('snap_loser');
+      return { snapshotId: 'snap_loser' };
+    });
+
+    await snapshotJob({
+      data: { runId: 123, sandboxId: 'sb-race' },
+    } as never);
+
+    expect(mockRecordTaskRunEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventType: 'decision',
+        details: expect.objectContaining({
+          decision: 'skip_persist_snapshot_id_claim_lost',
+        }),
+      }),
+    );
+    // The winner's creation time drives expiry, not this attempt's clock.
+    expect(mockAttachEnvironmentSnapshot).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ snapshotCreatedAt: winnerCreatedAt }),
+    );
   });
 });

--- a/apps/bullmq/src/jobs/snapshot.ts
+++ b/apps/bullmq/src/jobs/snapshot.ts
@@ -207,6 +207,10 @@ export const snapshotJob = async (job: SnapshotJob): Promise<void> => {
   // the snapshot was taken rather than from whenever this job finishes.
   let persistedSnapshotCreatedAt: Date | null =
     taskRun.snapshotCreatedAt ?? null;
+  // Set once `onSnapshotCreated` has recorded an id for this attempt. If the
+  // attempt then fails, the failure was in teardown rather than in the
+  // snapshot, and the recorded id must be finalized rather than abandoned.
+  let persistedSnapshotId: string | null = null;
   const snapshotAttemptStartedAt = new Date();
   let reconciledSnapshot: SourceInstanceSnapshot | null = null;
   const shouldCompleteTask = shouldCompleteTaskOnSnapshot(taskRun.payload);
@@ -392,6 +396,7 @@ export const snapshotJob = async (job: SnapshotJob): Promise<void> => {
             snapshotIntentId,
             triggerPath,
           });
+          persistedSnapshotId = createdSnapshotId;
         },
       });
 
@@ -453,21 +458,50 @@ export const snapshotJob = async (job: SnapshotJob): Promise<void> => {
         },
       });
 
-      reconciledSnapshot = await reconcileSnapshottingFailure({
-        taskRun,
-        client,
-        errorDetails,
-        instanceId,
-        postFailureInstanceStatus,
-        preSnapshotInstanceStatus: status,
-        queueAttempt,
-        queueJobId,
-        snapshotAttemptStartedAt,
-        snapshotIntentId,
-        triggerPath,
-      });
+      // The provider handed over an id before this attempt threw, so the
+      // snapshot itself succeeded and only the teardown that follows it
+      // failed. Finalize from the recorded id rather than abandoning it:
+      // sleep-check skips runs that already carry a snapshot id, and the
+      // abandon path ends in an UnrecoverableError that stops BullMQ from
+      // redelivering, so nothing downstream would ever finish this run.
+      if (persistedSnapshotId) {
+        await recordSnapshotQueueEvent(taskRun, {
+          eventType: 'decision',
+          message: `Recovered snapshot ${persistedSnapshotId} for sandbox ${instanceId} after the attempt failed during teardown.`,
+          details: {
+            queueJobId,
+            queueAttempt,
+            snapshotIntentId,
+            triggerPath,
+            decision: 'recover_persisted_snapshot_after_failure',
+            sandboxId: instanceId,
+            snapshotId: persistedSnapshotId,
+            error: errorMessage,
+            preSnapshotInstanceStatus: status,
+            postFailureInstanceStatus,
+          },
+        });
 
-      if (!reconciledSnapshot) {
+        snapshotResult = { snapshotId: persistedSnapshotId };
+      }
+
+      reconciledSnapshot = snapshotResult
+        ? null
+        : await reconcileSnapshottingFailure({
+            taskRun,
+            client,
+            errorDetails,
+            instanceId,
+            postFailureInstanceStatus,
+            preSnapshotInstanceStatus: status,
+            queueAttempt,
+            queueJobId,
+            snapshotAttemptStartedAt,
+            snapshotIntentId,
+            triggerPath,
+          });
+
+      if (!snapshotResult && !reconciledSnapshot) {
         if (
           !isFinalAttempt &&
           isRetryableSnapshotCreateFailure({
@@ -607,7 +641,9 @@ export const snapshotJob = async (job: SnapshotJob): Promise<void> => {
         throw new UnrecoverableError(errorMessage);
       }
 
-      snapshotResult = { snapshotId: reconciledSnapshot.snapshotId };
+      if (reconciledSnapshot) {
+        snapshotResult = { snapshotId: reconciledSnapshot.snapshotId };
+      }
     }
   }
 

--- a/apps/bullmq/src/jobs/snapshot.ts
+++ b/apps/bullmq/src/jobs/snapshot.ts
@@ -386,7 +386,7 @@ export const snapshotJob = async (job: SnapshotJob): Promise<void> => {
       snapshotResult = await client.createSnapshot({
         instanceId,
         onSnapshotCreated: async (createdSnapshotId) => {
-          persistedSnapshotCreatedAt = await persistCreatedSnapshotId({
+          const recorded = await persistCreatedSnapshotId({
             runId,
             taskRun,
             snapshotId: createdSnapshotId,
@@ -396,9 +396,41 @@ export const snapshotJob = async (job: SnapshotJob): Promise<void> => {
             snapshotIntentId,
             triggerPath,
           });
-          persistedSnapshotId = createdSnapshotId;
+          // Whatever is on the row wins, which is not necessarily the id this
+          // attempt just produced.
+          persistedSnapshotId = recorded.snapshotId;
+          persistedSnapshotCreatedAt = recorded.snapshotCreatedAt;
         },
       });
+
+      // A concurrent attempt may have claimed the row while this one was
+      // snapshotting. The finalizing update is unconditional, so finalizing
+      // our own id here would overwrite the recorded one and point the run at
+      // a snapshot no consumer ever saw. Ours becomes an orphaned image.
+      if (
+        persistedSnapshotId &&
+        persistedSnapshotId !== snapshotResult.snapshotId
+      ) {
+        await recordSnapshotQueueEvent(taskRun, {
+          eventType: 'decision',
+          message: `Deferring to snapshot ${persistedSnapshotId} recorded for sandbox ${instanceId} by a concurrent attempt.`,
+          details: {
+            queueJobId,
+            queueAttempt,
+            snapshotIntentId,
+            triggerPath,
+            decision: 'defer_to_recorded_snapshot',
+            sandboxId: instanceId,
+            recordedSnapshotId: persistedSnapshotId,
+            orphanedSnapshotId: snapshotResult.snapshotId,
+          },
+        });
+
+        snapshotResult = {
+          ...snapshotResult,
+          snapshotId: persistedSnapshotId,
+        };
+      }
 
       const { snapshotId } = snapshotResult;
 
@@ -999,8 +1031,10 @@ async function requestPostFailureCredentialRestore(input: {
  * task unresumable.
  *
  * Guarded on `snapshotId IS NULL` so a redelivered attempt never clobbers the
- * id a previous one already recorded. Returns the creation time now on the row
- * so the caller stamps expiry from when the snapshot really happened.
+ * id a previous one already recorded. Returns whichever snapshot is actually
+ * on the row, with its creation time: an attempt that loses the claim has to
+ * finalize the winner, because the finalizing update is unconditional and
+ * would otherwise point the run at its own orphaned image.
  */
 async function persistCreatedSnapshotId(input: {
   runId: number;
@@ -1011,7 +1045,7 @@ async function persistCreatedSnapshotId(input: {
   queueAttempt: number;
   snapshotIntentId: string;
   triggerPath: string | null;
-}): Promise<Date> {
+}): Promise<{ snapshotId: string; snapshotCreatedAt: Date }> {
   const snapshotCreatedAt = new Date();
 
   const [persisted] = await db
@@ -1034,20 +1068,28 @@ async function persistCreatedSnapshotId(input: {
   };
 
   if (!persisted) {
-    // Another attempt got there first. Keep its timestamp: ours would make an
+    // Another attempt got there first. Adopt its id and timestamp wholesale:
+    // ours names an image nothing references, and its clock would make an
     // already-aging snapshot look freshly created.
     const existing = await db.query.taskRuns.findFirst({
       where: eq(taskRuns.id, input.runId),
-      columns: { snapshotCreatedAt: true },
+      columns: { snapshotId: true, snapshotCreatedAt: true },
     });
 
     await recordSnapshotQueueEvent(input.taskRun, {
       eventType: 'decision',
       message: `Snapshot ${input.snapshotId} for sandbox ${input.instanceId} was already persisted by another attempt.`,
-      details: { ...details, decision: 'skip_persist_snapshot_id_claim_lost' },
+      details: {
+        ...details,
+        decision: 'skip_persist_snapshot_id_claim_lost',
+        winningSnapshotId: existing?.snapshotId ?? null,
+      },
     });
 
-    return existing?.snapshotCreatedAt ?? snapshotCreatedAt;
+    return {
+      snapshotId: existing?.snapshotId ?? input.snapshotId,
+      snapshotCreatedAt: existing?.snapshotCreatedAt ?? snapshotCreatedAt,
+    };
   }
 
   await recordSnapshotQueueEvent(input.taskRun, {
@@ -1060,7 +1102,7 @@ async function persistCreatedSnapshotId(input: {
     },
   });
 
-  return snapshotCreatedAt;
+  return { snapshotId: input.snapshotId, snapshotCreatedAt };
 }
 
 async function recordSnapshotQueueEvent(

--- a/apps/bullmq/src/jobs/snapshot.ts
+++ b/apps/bullmq/src/jobs/snapshot.ts
@@ -193,35 +193,73 @@ export const snapshotJob = async (job: SnapshotJob): Promise<void> => {
     },
     { logPrefix: 'snapshotJob', logger: console },
   );
-  const { status } = await client.getInstanceStatus({ instanceId });
+  // A stalled-job redelivery can land after `onSnapshotCreated` already
+  // persisted the id (see the createSnapshot call below). By then the adapter
+  // has terminated the sandbox, and no provider can look an image up by its
+  // source instance -- so re-snapshotting is impossible as well as pointless.
+  // Finalize from the persisted id instead of failing the run on an instance
+  // that is stopped precisely because the snapshot succeeded.
+  let snapshotResult: CreateSnapshotResult | null = taskRun.snapshotId
+    ? { snapshotId: taskRun.snapshotId }
+    : null;
+  // Real creation time of the snapshot, carried from the early persist (or
+  // from the row when this is a redelivery) so expiry is measured from when
+  // the snapshot was taken rather than from whenever this job finishes.
+  let persistedSnapshotCreatedAt: Date | null =
+    taskRun.snapshotCreatedAt ?? null;
   const snapshotAttemptStartedAt = new Date();
-  let snapshotResult: CreateSnapshotResult | null = null;
   let reconciledSnapshot: SourceInstanceSnapshot | null = null;
   const shouldCompleteTask = shouldCompleteTaskOnSnapshot(taskRun.payload);
   const clearedCompletionPayload = withoutCompleteTaskOnSnapshot(
     taskRun.payload,
   ) as TaskRun['payload'];
 
-  await recordSnapshotQueueEvent(taskRun, {
-    eventType: 'decision',
-    message: `Observed sandbox ${instanceId} in status ${status} before snapshot attempt.`,
-    details: {
-      queueJobId,
-      queueAttempt,
-      snapshotIntentId,
-      triggerPath,
-      decision: 'pre_snapshot_instance_status_observed',
-      sandboxId: instanceId,
-      instanceStatus: status,
-      taskRunStatus: taskRun.status,
-      taskPhase: taskRun.taskPhase ?? null,
-      sleepAt: taskRun.sleepAt?.toISOString() ?? null,
-      sleepRequestedAt: taskRun.sleepRequestedAt?.toISOString() ?? null,
-      snapshotRequestedAt: taskRun.snapshotRequestedAt?.toISOString() ?? null,
-    },
-  });
+  if (snapshotResult) {
+    await recordSnapshotQueueEvent(taskRun, {
+      eventType: 'decision',
+      message: `Reusing snapshot ${snapshotResult.snapshotId} already persisted for sandbox ${instanceId}.`,
+      details: {
+        queueJobId,
+        queueAttempt,
+        snapshotIntentId,
+        triggerPath,
+        decision: 'reuse_persisted_snapshot',
+        sandboxId: instanceId,
+        snapshotId: snapshotResult.snapshotId,
+        taskRunStatus: taskRun.status,
+        taskPhase: taskRun.taskPhase ?? null,
+      },
+    });
+  }
 
-  if (status !== 'running') {
+  // Skipped entirely when a persisted snapshot short-circuited the attempt:
+  // the sandbox is already gone and its status tells us nothing useful.
+  const status = snapshotResult
+    ? null
+    : (await client.getInstanceStatus({ instanceId })).status;
+
+  if (status !== null) {
+    await recordSnapshotQueueEvent(taskRun, {
+      eventType: 'decision',
+      message: `Observed sandbox ${instanceId} in status ${status} before snapshot attempt.`,
+      details: {
+        queueJobId,
+        queueAttempt,
+        snapshotIntentId,
+        triggerPath,
+        decision: 'pre_snapshot_instance_status_observed',
+        sandboxId: instanceId,
+        instanceStatus: status,
+        taskRunStatus: taskRun.status,
+        taskPhase: taskRun.taskPhase ?? null,
+        sleepAt: taskRun.sleepAt?.toISOString() ?? null,
+        sleepRequestedAt: taskRun.sleepRequestedAt?.toISOString() ?? null,
+        snapshotRequestedAt: taskRun.snapshotRequestedAt?.toISOString() ?? null,
+      },
+    });
+  }
+
+  if (status !== null && status !== 'running') {
     reconciledSnapshot = await reconcileSnapshotAfterRetryStatusChange({
       taskRun,
       client,
@@ -306,7 +344,10 @@ export const snapshotJob = async (job: SnapshotJob): Promise<void> => {
     }
   }
 
-  if (!snapshotResult) {
+  // `status` is non-null exactly when no snapshot was already persisted, so
+  // this is the same condition as `!snapshotResult` -- spelled out so the
+  // status stays narrowed for the reconcile helpers below.
+  if (!snapshotResult && status !== null) {
     await requestPreSnapshotScrub({
       taskRun,
       instanceId,
@@ -340,6 +381,18 @@ export const snapshotJob = async (job: SnapshotJob): Promise<void> => {
 
       snapshotResult = await client.createSnapshot({
         instanceId,
+        onSnapshotCreated: async (createdSnapshotId) => {
+          persistedSnapshotCreatedAt = await persistCreatedSnapshotId({
+            runId,
+            taskRun,
+            snapshotId: createdSnapshotId,
+            instanceId,
+            queueJobId,
+            queueAttempt,
+            snapshotIntentId,
+            triggerPath,
+          });
+        },
       });
 
       const { snapshotId } = snapshotResult;
@@ -565,8 +618,13 @@ export const snapshotJob = async (job: SnapshotJob): Promise<void> => {
   const { snapshotId, usageObservation } = snapshotResult;
   const now = new Date();
 
+  // Expiry runs from when the snapshot was actually taken. On a redelivery
+  // that can be minutes before `now`, and restamping it here would hand out a
+  // resume window the snapshot no longer has.
+  const snapshotCreatedAt = persistedSnapshotCreatedAt ?? now;
+
   const snapshotExpiresAt = new Date(
-    now.getTime() + SANDBOX_SNAPSHOT_EXPIRY_MS,
+    snapshotCreatedAt.getTime() + SANDBOX_SNAPSHOT_EXPIRY_MS,
   );
 
   await db.transaction(async (tx) => {
@@ -575,7 +633,7 @@ export const snapshotJob = async (job: SnapshotJob): Promise<void> => {
       .set({
         payload: clearedCompletionPayload,
         snapshotId,
-        snapshotCreatedAt: now,
+        snapshotCreatedAt,
         snapshotFailedAt: null,
         sleepAt: null,
         taskPhase: null,
@@ -622,7 +680,7 @@ export const snapshotJob = async (job: SnapshotJob): Promise<void> => {
       provider,
       snapshotId,
       snapshotStatus: 'ready',
-      snapshotCreatedAt: now,
+      snapshotCreatedAt,
       snapshotExpiresAt,
       attachmentSource,
       maxPendingUpdatedAt: attachmentSource ? null : taskRun.createdAt,
@@ -894,6 +952,79 @@ async function requestPostFailureCredentialRestore(input: {
       },
     });
   }
+}
+
+/**
+ * Write the snapshot id the instant the provider hands it over, before the
+ * adapter tears the sandbox down and long before this job reaches its
+ * finalizing transaction. Everything between those two points -- the teardown
+ * RPC, a stalled-job redelivery, a worker restart -- used to be a window where
+ * a perfectly good snapshot was lost with no way to find it again, leaving the
+ * task unresumable.
+ *
+ * Guarded on `snapshotId IS NULL` so a redelivered attempt never clobbers the
+ * id a previous one already recorded. Returns the creation time now on the row
+ * so the caller stamps expiry from when the snapshot really happened.
+ */
+async function persistCreatedSnapshotId(input: {
+  runId: number;
+  taskRun: TaskRun;
+  snapshotId: string;
+  instanceId: string;
+  queueJobId: string | null;
+  queueAttempt: number;
+  snapshotIntentId: string;
+  triggerPath: string | null;
+}): Promise<Date> {
+  const snapshotCreatedAt = new Date();
+
+  const [persisted] = await db
+    .update(taskRuns)
+    .set({
+      snapshotId: input.snapshotId,
+      snapshotCreatedAt,
+      snapshotFailedAt: null,
+    })
+    .where(and(eq(taskRuns.id, input.runId), isNull(taskRuns.snapshotId)))
+    .returning({ id: taskRuns.id });
+
+  const details = {
+    queueJobId: input.queueJobId,
+    queueAttempt: input.queueAttempt,
+    snapshotIntentId: input.snapshotIntentId,
+    triggerPath: input.triggerPath,
+    sandboxId: input.instanceId,
+    snapshotId: input.snapshotId,
+  };
+
+  if (!persisted) {
+    // Another attempt got there first. Keep its timestamp: ours would make an
+    // already-aging snapshot look freshly created.
+    const existing = await db.query.taskRuns.findFirst({
+      where: eq(taskRuns.id, input.runId),
+      columns: { snapshotCreatedAt: true },
+    });
+
+    await recordSnapshotQueueEvent(input.taskRun, {
+      eventType: 'decision',
+      message: `Snapshot ${input.snapshotId} for sandbox ${input.instanceId} was already persisted by another attempt.`,
+      details: { ...details, decision: 'skip_persist_snapshot_id_claim_lost' },
+    });
+
+    return existing?.snapshotCreatedAt ?? snapshotCreatedAt;
+  }
+
+  await recordSnapshotQueueEvent(input.taskRun, {
+    eventType: 'decision',
+    message: `Persisted snapshot ${input.snapshotId} for sandbox ${input.instanceId} before teardown.`,
+    details: {
+      ...details,
+      decision: 'persist_snapshot_id_before_teardown',
+      snapshotCreatedAt: snapshotCreatedAt.toISOString(),
+    },
+  });
+
+  return snapshotCreatedAt;
 }
 
 async function recordSnapshotQueueEvent(

--- a/packages/compute-providers/src/adapters/daytona.ts
+++ b/packages/compute-providers/src/adapters/daytona.ts
@@ -599,6 +599,7 @@ export class DaytonaClient implements ComputeProviderClient {
               { snapshotName },
             )}`,
           );
+          await input.onSnapshotCreated?.(snapshotName);
           await this.destroySandboxAfterSnapshot(input.instanceId);
         },
       });
@@ -621,6 +622,10 @@ export class DaytonaClient implements ComputeProviderClient {
     console.log(
       `[DaytonaClient] Snapshot created: ${snapshotName}; destroying sandbox ${input.instanceId}`,
     );
+
+    // Daytona's name is derived from the instance id, so this one is
+    // reconstructable -- persist here anyway to keep the contract uniform.
+    await input.onSnapshotCreated?.(snapshotName);
 
     await this.destroySandboxAfterSnapshot(input.instanceId);
 

--- a/packages/compute-providers/src/adapters/e2b.ts
+++ b/packages/compute-providers/src/adapters/e2b.ts
@@ -577,6 +577,7 @@ export class E2bClient implements ComputeProviderClient {
               { snapshotId: lateSnapshot.snapshotId },
             )}`,
           );
+          await input.onSnapshotCreated?.(lateSnapshot.snapshotId);
           await this.killSandboxAfterSnapshot(input.instanceId);
         },
       });
@@ -598,6 +599,10 @@ export class E2bClient implements ComputeProviderClient {
     console.log(
       `[E2bClient] Snapshot created: ${snapshot.snapshotId}; killing sandbox ${input.instanceId}`,
     );
+
+    // Persist before killing: the id is unrecoverable once the caller's write
+    // is skipped, and the sandbox is already gone by then.
+    await input.onSnapshotCreated?.(snapshot.snapshotId);
 
     await this.killSandboxAfterSnapshot(input.instanceId);
 

--- a/packages/compute-providers/src/adapters/modal.test.ts
+++ b/packages/compute-providers/src/adapters/modal.test.ts
@@ -536,6 +536,39 @@ describe('ModalClient', () => {
     expect(snapshotFilesystemMock).toHaveBeenCalledWith(20 * 60_000);
   });
 
+  it('reports the snapshot id before terminating the source sandbox', async () => {
+    const order: string[] = [];
+    const terminateMock = vi.fn(async () => {
+      order.push('terminate');
+    });
+
+    sandboxFromIdMock.mockResolvedValue({
+      sandboxId: 'modal-123',
+      snapshotFilesystem: vi.fn().mockResolvedValue({ imageId: 'im-abc123' }),
+      terminate: terminateMock,
+    });
+
+    const client = new ModalClient({
+      tokenId: 'token-id',
+      tokenSecret: 'token-secret',
+      baseImageRef: MODAL_IMAGE_REF,
+    });
+
+    const result = await client.createSnapshot({
+      instanceId: 'modal-123',
+      onSnapshotCreated: async (snapshotId) => {
+        order.push(`persist:${snapshotId}`);
+      },
+    });
+
+    // Modal images are addressable only by id, so a crash between the
+    // snapshot and the caller's write would strand a good snapshot forever.
+    // The persist hook has to land first.
+    expect(order).toEqual(['persist:im-abc123', 'terminate']);
+    expect(result).toEqual({ snapshotId: 'im-abc123' });
+    expect(terminateMock).toHaveBeenCalled();
+  });
+
   it('splits large file writes into multiple handle.write calls', async () => {
     const writeMock = vi.fn().mockResolvedValue(undefined);
     const closeMock = vi.fn().mockResolvedValue(undefined);

--- a/packages/compute-providers/src/adapters/modal.ts
+++ b/packages/compute-providers/src/adapters/modal.ts
@@ -927,6 +927,10 @@ export class ModalClient implements ComputeProviderClient {
               { imageId: lateImage.imageId },
             )}`,
           );
+          // The abort already rejected this call, so the id has no other way
+          // back to the caller. Persist before terminating so an aborted
+          // attempt still leaves a resumable snapshot behind.
+          await input.onSnapshotCreated?.(lateImage.imageId);
           await this.terminateSandboxAfterSnapshot(sandbox, input.instanceId);
         },
       });
@@ -941,6 +945,11 @@ export class ModalClient implements ComputeProviderClient {
     console.log(
       `[ModalClient] Snapshot created: ${image.imageId}; terminating sandbox ${input.instanceId}`,
     );
+
+    // Persist before terminating, not after returning. Modal images are
+    // addressable only by id, so an id lost between here and the caller's
+    // write is a snapshot nobody can ever resume.
+    await input.onSnapshotCreated?.(image.imageId);
 
     // Terminate the sandbox after snapshotting to free resources.
     await this.terminateSandboxAfterSnapshot(sandbox, input.instanceId);

--- a/packages/compute-providers/src/types.ts
+++ b/packages/compute-providers/src/types.ts
@@ -147,6 +147,20 @@ export interface WriteFileInput {
 export interface CreateSnapshotInput {
   instanceId: string;
   signal?: AbortSignal;
+  /**
+   * Durably record the snapshot id the moment the provider produces it, before
+   * the adapter tears the source instance down. Adapters snapshot and then
+   * destroy the sandbox, so the id only reaches the caller after that teardown
+   * returns; a crash or a stalled-job redelivery in between used to lose an
+   * otherwise-good snapshot for good. Providers expose no lookup by source
+   * instance (Modal images are addressable only by id), so the id cannot be
+   * recovered afterwards -- it has to be persisted the instant it exists.
+   *
+   * Called at most once per successful snapshot. Adapters must let a rejection
+   * propagate: failing to persist means the snapshot is unreachable, and the
+   * caller needs the failure rather than a sandbox destroyed for nothing.
+   */
+  onSnapshotCreated?: (snapshotId: string) => Promise<void>;
 }
 
 export interface CreateSnapshotResult {


### PR DESCRIPTION
## Problem

Snapshot adapters snapshot a sandbox and then destroy it, returning the snapshot id to the caller only after that teardown finishes. Everything in between — the teardown RPC, a stalled-job redelivery, a worker restart — was a window in which a **successful** snapshot could be lost with no way to find it again.

There is no recovery path. `ComputeProviderClient.findSnapshotBySourceInstance` is optional and implemented by no adapter, and it cannot be implemented for Modal: its SDK exposes only `fromId`, `fromRegistry`, `fromAwsEcr`, `fromGcpArtifactRegistry`, and `delete` — there is no list or search, so an image cannot be located from its source sandbox.

When the id is lost, the run is finalized without a snapshot, which makes the task **permanently unresumable**. Every resume path keys off `snapshot_id`, so follow-ups find nothing to resume.

Once the job is redelivered, each retry observes the sandbox as `stopped` — precisely **because** the earlier attempt's snapshot succeeded — and treats that as fatal.

## Fix

- Add `CreateSnapshotInput.onSnapshotCreated`, invoked the moment the provider yields an id and **before** any teardown. Wired through the Modal, E2B, and Daytona adapters, including their late-resolve paths, so an aborted attempt whose snapshot lands anyway still leaves a resumable snapshot instead of discarding the id.
- Persist the id from that hook, guarded on `snapshot_id IS NULL` so a racing attempt cannot clobber the winner.
- Short-circuit a redelivered job that finds an id already persisted: finalize from the stored id instead of consulting — and failing on — a sandbox that is stopped because the snapshot worked.
- Stamp expiry from the real creation time rather than job-finish time, so a redelivery cannot advertise a resume window the snapshot no longer has.
- Recover from the recorded id when an attempt fails *after* producing one. A failure at that point is a teardown failure, not a snapshot failure, so the run is finalized from the snapshot that already exists.

This is deliberately scoped to *not losing the id*. Retry and lock timing are left alone: with the id persisted before teardown, a redelivery is now harmless, so changing that timing would be untested config with no demonstrated effect.

## Testing

`snapshot-persistence.test.ts` replays the failure at the job level **against a real database** — only the compute provider and outbound integrations are stubbed, so every `task_runs` read and write is real SQL. Attempt 1 hands over an id then dies during teardown; the redelivered attempt 2 finds the sandbox stopped.

Verified against the pre-fix code, where it fails with:

```
AssertionError: expected null to be 'im-incident-replay'
```

That is the id loss this PR removes. The unit tests were also mutation-checked: reverting the fix fails exactly the new cases while all pre-existing ones still pass.

A second round of review caught a regression in an earlier revision of this PR, now fixed and covered: persisting the id early meant the abandon path could no longer clear `snapshot_requested_at` (that update is guarded on `snapshot_id IS NULL`), leaving the run `Idle` holding a good snapshot with nothing able to finish it — sleep-check skips rows carrying a snapshot id or a pending request, and the path ends in an `UnrecoverableError`, so BullMQ never redelivers. `Idle` counts as active for follow-up routing, so replies would have been dispatched at a dead sandbox. That was strictly worse than the original bug, which at least reached a terminal state.

The replay also models the stall faithfully now, by hanging the attempt rather than throwing — a thrown error still runs the catch block, which is precisely what a process that stopped renewing its lock never does.

- bullmq: 133 passing · compute-providers: 181 · types: 129
- `pnpm lint`, `pnpm check-types` clean; `knip` output byte-identical to the `develop` baseline

## Not covered by tests

- **The real Modal adapter path.** Tests stub `createSnapshot`, so the actual `snapshotFilesystem()` → persist → `terminate()` ordering rests on code reading. It cannot be exercised locally: local dev uses the Docker provider, whose `createSnapshot` is unsupported. Worth confirming on a deployed environment by checking that the `persist_snapshot_id_before_teardown` event precedes the `create_snapshot / completed` mutation event, then that a follow-up actually resumes.
- A **pre-existing** issue this does not address: if BullMQ loses a snapshot job outright rather than stalling, the run stays `Idle` forever — sleep-check excludes it via `snapshot_requested_at IS NULL`, and `Idle` counts as active for follow-up routing. This PR neither creates nor widens that window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
