### PR TITLE
fix(snapshot): report the snapshot id from the broker backend too

### DIFF
--- a/packages/compute-providers/src/adapters/roomote-broker.test.ts
+++ b/packages/compute-providers/src/adapters/roomote-broker.test.ts
@@ -420,6 +420,43 @@ describe('RoomoteBrokerClient', () => {
     }
   });
 
+  it('reports the snapshot id before returning it', async () => {
+    let polls = 0;
+    const { client } = harness((request) => {
+      if (request.path.endsWith('/snapshot')) {
+        return jsonResponse({ operationId: 'op-1' }, 202);
+      }
+
+      polls += 1;
+      return jsonResponse(
+        polls < 2
+          ? { status: 'running' }
+          : { status: 'succeeded', snapshotId: 'im-1' },
+      );
+    });
+
+    const reported: string[] = [];
+
+    vi.useFakeTimers();
+    try {
+      const pending = client.createSnapshot({
+        instanceId: 'sb-1',
+        onSnapshotCreated: async (snapshotId) => {
+          reported.push(snapshotId);
+        },
+      });
+      await vi.advanceTimersByTimeAsync(11_000);
+      await pending;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    // The broker has already torn the sandbox down by the time it reports
+    // success, so a stall before the caller records the id would strand the
+    // snapshot with no way to look it up again.
+    expect(reported).toEqual(['im-1']);
+  });
+
   it('surfaces snapshot failures with the broker error', async () => {
     const { client } = harness((request) =>
       request.path.endsWith('/snapshot')

--- a/packages/compute-providers/src/adapters/roomote-broker.ts
+++ b/packages/compute-providers/src/adapters/roomote-broker.ts
@@ -234,6 +234,11 @@ export class RoomoteBrokerClient implements ComputeProviderClient {
       })) as { status: string; snapshotId?: string; error?: string };
 
       if (operation.status === 'succeeded' && operation.snapshotId) {
+        // Record the id before returning. The broker has already snapshotted
+        // and torn down the sandbox by this point, so a stall between here
+        // and the caller's write loses the only handle to that snapshot.
+        await input.onSnapshotCreated?.(operation.snapshotId);
+
         return { snapshotId: operation.snapshotId };
       }
 


### PR DESCRIPTION
Stacked on #839 — **base that PR, not `develop`**. The `onSnapshotCreated` hook this uses is introduced there, so this cannot build on `develop` alone.

## Problem

`RoomoteBrokerClient.createSnapshot` returns the polled operation's `snapshotId` without reporting it, so the deployment-managed `roomote` provider running on `ROOMOTE_CLOUD_BACKEND=broker` keeps the snapshot-loss window that #839 closes for every other backend.

The broker has already snapshotted and torn the sandbox down by the time it reports success, so there is nothing left to re-snapshot: a stall or worker restart between that response and the caller's write loses the only handle to a snapshot that exists, leaving the task unresumable.

## Fix

Report the id before returning the successful result, matching the other adapters.

Full audit of the adapters that implement `createSnapshot`:

| adapter | reports id |
|---|---|
| modal | yes, incl. late-resolve (#839) |
| e2b | yes, incl. late-resolve (#839) |
| daytona | yes, incl. late-resolve (#839) |
| **roomote-broker** | **yes — this PR** |
| blaxel | n/a — throws unsupported |
| docker | n/a — throws unsupported |

## Testing

Adapter coverage added alongside the existing broker snapshot tests, asserting the id is reported for a successful operation. It fails without the hook with `expected [] to deeply equal [ 'im-1' ]`.

compute-providers: 182 passing; typecheck clean.

Not covered: the real broker service, same as the real Modal path in #839.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
