### PR TITLE
[Feat] Guide self-hosted Linear OAuth setup

### DIFF
--- a/apps/api/src/handlers/linear/__tests__/linear-routing-confirmation.test.ts
+++ b/apps/api/src/handlers/linear/__tests__/linear-routing-confirmation.test.ts
@@ -13,6 +13,7 @@ const {
   findLinearUserMcpConnectionByIdentityMock,
   getValidAccessTokenMock,
   createMcpOauthReplayMock,
+  resolveDeploymentEnvVarMock,
 } = vi.hoisted(() => ({
   redisMock: {
     eval: vi.fn().mockResolvedValue(null),
@@ -31,6 +32,7 @@ const {
   findLinearUserMcpConnectionByIdentityMock: vi.fn(),
   getValidAccessTokenMock: vi.fn(),
   createMcpOauthReplayMock: vi.fn(),
+  resolveDeploymentEnvVarMock: vi.fn().mockResolvedValue('test-linear-secret'),
 }));
 
 vi.mock('@roomote/env', async (importOriginal) => {
@@ -154,6 +156,7 @@ vi.mock('@roomote/db/server', async (importOriginal) => {
     },
     linearAuthTokens: {},
     webhooks: { id: 'id', deliveryId: 'deliveryId' },
+    resolveDeploymentEnvVar: resolveDeploymentEnvVarMock,
     eq: vi.fn(),
     and: vi.fn(),
   };
@@ -293,6 +296,11 @@ describe('linear routed task startup', () => {
     );
 
     expect(response.status).toBe(200);
+    expect(resolveDeploymentEnvVarMock).toHaveBeenCalledWith(
+      'R_LINEAR_WEBHOOK_SECRET',
+      db,
+      { R_LINEAR_WEBHOOK_SECRET: 'test-linear-secret' },
+    );
     expect(emitThought).toHaveBeenCalledWith(
       'session-1',
       'Getting started...',

--- a/apps/api/src/handlers/linear/index.ts
+++ b/apps/api/src/handlers/linear/index.ts
@@ -23,7 +23,11 @@ import {
 import { buildTaskStartingText } from '@roomote/communication/chat-messages';
 import { getRedis } from '@roomote/redis';
 import { postRouterDebugMessage } from '@roomote/slack';
-import { setTrustedRunActingUserOnSuccess } from '@roomote/db/server';
+import {
+  db,
+  resolveDeploymentEnvVar,
+  setTrustedRunActingUserOnSuccess,
+} from '@roomote/db/server';
 import {
   createMcpOauthReplay,
   findLinearDeploymentMcpConnectionByIdentity,
@@ -302,7 +306,11 @@ linear.post('/', async (c) => {
 
   // Verify webhook signature
   const signature = headers['linear-signature'] ?? '';
-  const webhookSecret = Env.R_LINEAR_WEBHOOK_SECRET;
+  const webhookSecret = await resolveDeploymentEnvVar(
+    'R_LINEAR_WEBHOOK_SECRET',
+    db,
+    { R_LINEAR_WEBHOOK_SECRET: Env.R_LINEAR_WEBHOOK_SECRET },
+  );
 
   if (!webhookSecret) {
     console.error('[LinearWebhook] R_LINEAR_WEBHOOK_SECRET not configured');

--- a/apps/docs/integrations/linear.mdx
+++ b/apps/docs/integrations/linear.mdx
@@ -14,16 +14,19 @@ priority, or discussion.
 
 ## Setup
 
-For self-hosted deployments, create a Linear OAuth application before
-connecting the workspace. Configure its callback as
-`<R_PUBLIC_URL>/api/mcp-oauth/callback`, then set
-`R_LINEAR_CLIENT_ID`, `R_LINEAR_CLIENT_SECRET`, and
-`R_LINEAR_WEBHOOK_SECRET` on the Roomote deployment.
-
 <Steps>
-  <Step title="Connect Linear">
-    In Roomote, go to **Settings > Integrations** and connect your Linear
-    workspace.
+  <Step title="Set up the OAuth app">
+    On a self-hosted deployment, an administrator goes to **Settings >
+    Integrations**, selects **Set up Linear**, and opens the pre-filled Linear
+    app manifest. After creating the private app, copy its client ID, client
+    secret, and webhook secret back into Roomote. Roomote encrypts the saved
+    credentials.
+  </Step>
+  <Step title="Connect the workspace">
+    Select **Enable Linear**, approve the app in Linear, and return to Roomote.
+    Deployments that provide `R_LINEAR_CLIENT_ID`,
+    `R_LINEAR_CLIENT_SECRET`, and `R_LINEAR_WEBHOOK_SECRET` in the runtime
+    environment continue to use those values and skip the in-app setup.
   </Step>
   <Step title="Link your user account">
     Link your Linear identity when prompted so Roomote can associate issue

--- a/apps/docs/integrations/linear.mdx
+++ b/apps/docs/integrations/linear.mdx
@@ -17,10 +17,11 @@ priority, or discussion.
 <Steps>
   <Step title="Set up the OAuth app">
     On a self-hosted deployment, an administrator goes to **Settings >
-    Integrations**, selects **Set up Linear**, and opens the pre-filled Linear
-    app manifest. After creating the private app, copy its client ID, client
-    secret, and webhook secret back into Roomote. Roomote encrypts the saved
-    credentials.
+    Integrations**, selects **Set it up**, and then selects **Create Linear
+    app** to open the pre-filled manifest. The app name defaults to the same
+    `roomote-<deployment-hostname>` convention used by the GitHub setup. After
+    creating the private app, copy its client ID, client secret, and webhook
+    secret back into Roomote. Roomote encrypts the saved credentials.
   </Step>
   <Step title="Connect the workspace">
     Select **Enable Linear**, approve the app in Linear, and return to Roomote.

--- a/apps/web/src/app/api/mcp-oauth/initiate/[connectionId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/mcp-oauth/initiate/[connectionId]/__tests__/route.test.ts
@@ -18,7 +18,7 @@ const {
   isSelfServeMcpIntegrationMock,
   mcpConnectionsFindFirstMock,
   registerOAuthClientMock,
-  resolveStaticOauthClientInformationMock,
+  resolveDeploymentStaticOauthClientInformationMock,
   storeClientInformationMock,
   storeOAuthStateWithIdMock,
 } = vi.hoisted(() => ({
@@ -41,7 +41,7 @@ const {
   isSelfServeMcpIntegrationMock: vi.fn(),
   mcpConnectionsFindFirstMock: vi.fn(),
   registerOAuthClientMock: vi.fn(),
-  resolveStaticOauthClientInformationMock: vi.fn(),
+  resolveDeploymentStaticOauthClientInformationMock: vi.fn(),
   storeClientInformationMock: vi.fn(),
   storeOAuthStateWithIdMock: vi.fn(),
 }));
@@ -54,8 +54,9 @@ vi.mock('@/lib/server/bootstrap-runtime-env', () => ({
   bootstrapWebRuntimeEnv: bootstrapWebRuntimeEnvMock,
 }));
 
-vi.mock('@/lib/server/mcp-static-oauth', () => ({
-  resolveStaticOauthClientInformation: resolveStaticOauthClientInformationMock,
+vi.mock('@/lib/server/deployment-static-oauth', () => ({
+  resolveDeploymentStaticOauthClientInformation:
+    resolveDeploymentStaticOauthClientInformationMock,
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -153,7 +154,9 @@ describe('GET /api/mcp-oauth/initiate/[connectionId]', () => {
     generateCodeChallengeMock.mockResolvedValue('challenge-value');
     generateStateMock.mockReturnValue('state-value');
     storeOAuthStateWithIdMock.mockResolvedValue(undefined);
-    resolveStaticOauthClientInformationMock.mockReturnValue(undefined);
+    resolveDeploymentStaticOauthClientInformationMock.mockResolvedValue(
+      undefined,
+    );
     registerOAuthClientMock.mockResolvedValue({
       client_id: 'fresh-client',
     });
@@ -217,7 +220,7 @@ describe('GET /api/mcp-oauth/initiate/[connectionId]', () => {
     getMcpIntegrationOauthScopesMock.mockReturnValue(['read', 'write']);
     getMcpIntegrationOauthScopeSeparatorMock.mockReturnValue(',');
     getClientInformationMock.mockResolvedValue(undefined);
-    resolveStaticOauthClientInformationMock.mockReturnValue({
+    resolveDeploymentStaticOauthClientInformationMock.mockResolvedValue({
       client_id: 'linear-client',
       client_secret: 'linear-secret',
       token_endpoint_auth_method: 'client_secret_post',
@@ -238,6 +241,35 @@ describe('GET /api/mcp-oauth/initiate/[connectionId]', () => {
       PUBLIC_CALLBACK,
     );
     expect(registerOAuthClientMock).not.toHaveBeenCalled();
+  });
+
+  it('replaces a legacy registered client with configured deployment credentials', async () => {
+    getMcpIntegrationOauthEndpointsMock.mockReturnValue({
+      authorizationEndpoint: 'https://linear.app/oauth/authorize',
+      tokenEndpoint: 'https://api.linear.app/oauth/token',
+    });
+    getClientInformationMock.mockResolvedValue({
+      client_id: 'legacy-dynamic-client',
+      client_secret: 'legacy-secret',
+    });
+    resolveDeploymentStaticOauthClientInformationMock.mockResolvedValue({
+      client_id: 'configured-client',
+      client_secret: 'configured-secret',
+      token_endpoint_auth_method: 'client_secret_post',
+    });
+
+    const response = await GET(buildRequest(), {
+      params: Promise.resolve({ connectionId: CONNECTION_ID }),
+    });
+
+    expect(getClientInformationMock).not.toHaveBeenCalled();
+    expect(storeClientInformationMock).toHaveBeenCalledWith(
+      CONNECTION_ID,
+      expect.objectContaining({ client_id: 'configured-client' }),
+      PUBLIC_CALLBACK,
+    );
+    const authUrl = new URL(response.headers.get('location')!);
+    expect(authUrl.searchParams.get('client_id')).toBe('configured-client');
   });
 
   it('re-registers when stored client was registered against a different callback', async () => {

--- a/apps/web/src/app/api/mcp-oauth/initiate/[connectionId]/route.ts
+++ b/apps/web/src/app/api/mcp-oauth/initiate/[connectionId]/route.ts
@@ -34,7 +34,7 @@ import {
 import { authorize } from '@/lib/server';
 import { bootstrapWebRuntimeEnv } from '@/lib/server/bootstrap-runtime-env';
 import { getPublicAppUrl } from '@/lib/server/get-public-app-url';
-import { resolveStaticOauthClientInformation } from '@/lib/server/mcp-static-oauth';
+import { resolveDeploymentStaticOauthClientInformation } from '@/lib/server/deployment-static-oauth';
 
 export const runtime = 'nodejs';
 
@@ -147,13 +147,6 @@ function getOAuthServerMetadataOverride(
   };
 }
 
-function getStaticClientInformation(
-  env: unknown,
-  integration: McpIntegration,
-): OAuthClientInformation | undefined {
-  return resolveStaticOauthClientInformation(env, integration);
-}
-
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ connectionId: string }> },
@@ -229,22 +222,20 @@ export async function GET(
       connection.connectionRole,
     );
 
-    let clientInfo: OAuthClientInformation | undefined =
-      await getClientInformation(connectionId, {
+    const staticClientInfo =
+      await resolveDeploymentStaticOauthClientInformation(webEnv, integration);
+    let clientInfo: OAuthClientInformation | undefined;
+
+    if (staticClientInfo) {
+      // Configured deployment credentials are authoritative. Replacing the
+      // stored client also migrates connections created by the old dynamic
+      // registration flow before their next authorization or token refresh.
+      await storeClientInformation(connectionId, staticClientInfo, redirectUri);
+      clientInfo = staticClientInfo;
+    } else {
+      clientInfo = await getClientInformation(connectionId, {
         expectedRedirectUri: redirectUri,
       });
-
-    if (!clientInfo) {
-      const staticClientInfo = getStaticClientInformation(webEnv, integration);
-
-      if (staticClientInfo) {
-        await storeClientInformation(
-          connectionId,
-          staticClientInfo,
-          redirectUri,
-        );
-        clientInfo = staticClientInfo;
-      }
     }
 
     if (!clientInfo && serverMetadata.registration_endpoint) {

--- a/apps/web/src/components/settings/Integrations.test.tsx
+++ b/apps/web/src/components/settings/Integrations.test.tsx
@@ -446,14 +446,12 @@ describe('Integrations settings', () => {
       .getByRole('heading', { name: 'Linear' })
       .closest('[id="integration-linear"]');
 
-    expect(linearCard).toHaveTextContent(
-      'Linear OAuth is not configured for this deployment.',
-    );
+    expect(linearCard).toHaveTextContent('Not configured.');
     expect(
       screen.queryByRole('button', { name: 'Enable Linear' }),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'Set up Linear OAuth' }),
+      screen.getByRole('button', { name: 'Set up Linear' }),
     ).toBeInTheDocument();
   });
 
@@ -467,9 +465,7 @@ describe('Integrations settings', () => {
       .getByRole('heading', { name: 'Linear' })
       .closest('[id="integration-linear"]');
 
-    expect(linearCard).toHaveTextContent(
-      'Linear OAuth setup is incomplete. Finish configuring both client credentials before connecting.',
-    );
+    expect(linearCard).toHaveTextContent('Configuration incomplete.');
   });
 
   it('asks non-admins to contact an administrator when OAuth is unavailable', () => {
@@ -480,12 +476,10 @@ describe('Integrations settings', () => {
     render(<Integrations />);
 
     expect(
-      screen.getByText(
-        'Linear is not configured for this deployment. Ask an administrator to finish its OAuth setup.',
-      ),
+      screen.getByText('Not configured. Ask an administrator to set it up.'),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('button', { name: 'Set up Linear OAuth' }),
+      screen.queryByRole('button', { name: 'Set up Linear' }),
     ).not.toBeInTheDocument();
   });
 
@@ -494,19 +488,45 @@ describe('Integrations settings', () => {
     state.oauthReadiness = [{ mcpId: 'linear', status: 'missing' }];
 
     render(<Integrations />);
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Set up Linear OAuth' }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Set up Linear' }));
 
     expect(
       screen.getByRole('heading', { name: 'Set up Linear' }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'Open Linear app setup' }),
+      screen.getByRole('button', { name: 'Create Linear app' }),
     ).toBeInTheDocument();
     expect(screen.getByLabelText('Client ID')).toBeInTheDocument();
     expect(screen.getByLabelText('Client secret')).toBeInTheDocument();
     expect(screen.getByLabelText('Webhook secret')).toBeInTheDocument();
+  });
+
+  it('only offers app creation while Linear is unconfigured', () => {
+    state.linearInstallation = null;
+    state.oauthReadiness = [{ mcpId: 'linear', status: 'ready' }];
+
+    render(<Integrations />);
+
+    expect(
+      screen.queryByRole('button', { name: 'Set up Linear' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Enable Linear' }),
+    ).toBeInTheDocument();
+  });
+
+  it('offers setup for a legacy workspace when deployment credentials are missing', () => {
+    state.linearInstallation = { linearOrganizationName: 'Legacy workspace' };
+    state.oauthReadiness = [{ mcpId: 'linear', status: 'missing' }];
+
+    render(<Integrations />);
+
+    expect(
+      screen.getByRole('button', { name: 'Set up Linear' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Disable Linear' }),
+    ).not.toBeInTheDocument();
   });
 
   it('surfaces the server error when starting Linear fails', () => {

--- a/apps/web/src/components/settings/Integrations.test.tsx
+++ b/apps/web/src/components/settings/Integrations.test.tsx
@@ -57,6 +57,16 @@ const state = vi.hoisted(() => ({
   linearInstallation: {
     linearOrganizationName: 'Roomote',
   } as null | { linearOrganizationName?: string },
+  linearOauthSetup: {
+    callbackUrl: 'https://roomote.example/api/mcp-oauth/callback',
+    webhookUrl: 'https://roomote.example/api/webhooks/linear',
+    manifestUrl: 'https://linear.app/settings/api/applications/new?manifest=x',
+    fields: {
+      clientId: { configured: false, managedByEnvironment: false },
+      clientSecret: { configured: false, managedByEnvironment: false },
+      webhookSecret: { configured: false, managedByEnvironment: false },
+    },
+  },
   linearRedirectPath: '',
   searchParams: '',
 }));
@@ -73,6 +83,7 @@ const { mutations, selectMock } = vi.hoisted(() => ({
     saveGrafanaConnection: vi.fn(),
     saveSnowflakeConnection: vi.fn(),
     saveVercelConnection: vi.fn(),
+    saveLinearOauthSetup: vi.fn(),
   },
   selectMock: {
     latestOnValueChange: null as null | ((value: string) => void),
@@ -155,6 +166,14 @@ vi.mock('@/hooks/linear', () => ({
   useDisconnectLinear: () => ({
     isPending: false,
     mutate: mutations.disconnectLinear,
+  }),
+  useLinearOauthSetup: () => ({
+    data: state.linearOauthSetup,
+    isPending: false,
+  }),
+  useSaveLinearOauthSetup: () => ({
+    isPending: false,
+    mutate: mutations.saveLinearOauthSetup,
   }),
 }));
 
@@ -254,11 +273,18 @@ vi.mock('@/components/system', () => ({
   BrandIcon: ({ name }: { name: string }) => (
     <svg aria-label={name} role="img" />
   ),
-  Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
-    <button type="button" {...props}>
-      {children}
-    </button>
-  ),
+  Button: ({
+    children,
+    asChild,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean }) =>
+    asChild ? (
+      children
+    ) : (
+      <button type="button" {...props}>
+        {children}
+      </button>
+    ),
   Card: ({
     children,
     ...props
@@ -270,6 +296,7 @@ vi.mock('@/components/system', () => ({
   CardHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   CardTitle: ({ children }: { children: ReactNode }) => <h3>{children}</h3>,
   Check: () => <svg aria-hidden="true" />,
+  Copy: () => <svg aria-hidden="true" />,
   Dialog: ({ open, children }: { open: boolean; children: ReactNode }) =>
     open ? <div>{children}</div> : null,
   DialogContent: ({ children }: { children: ReactNode }) => (
@@ -288,6 +315,7 @@ vi.mock('@/components/system', () => ({
   Eye: () => <svg aria-hidden="true" />,
   EyeOff: () => <svg aria-hidden="true" />,
   EthernetPort: () => <svg aria-hidden="true" />,
+  ExternalLink: () => <svg aria-hidden="true" />,
   Info: () => <svg aria-hidden="true" />,
   InfoTooltip: ({ content }: { content: string }) => <span>{content}</span>,
   Input: ({ ...props }: InputHTMLAttributes<HTMLInputElement>) => (
@@ -419,14 +447,14 @@ describe('Integrations settings', () => {
       .closest('[id="integration-linear"]');
 
     expect(linearCard).toHaveTextContent(
-      'Linear OAuth is not configured for this deployment. View setup guide.',
+      'Linear OAuth is not configured for this deployment.',
     );
     expect(
       screen.queryByRole('button', { name: 'Enable Linear' }),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByRole('link', { name: 'View setup guide' }),
-    ).toHaveAttribute('href', 'https://docs.roomote.dev/integrations/linear');
+      screen.getByRole('button', { name: 'Set up Linear OAuth' }),
+    ).toBeInTheDocument();
   });
 
   it('distinguishes incomplete Linear OAuth setup for admins', () => {
@@ -440,7 +468,7 @@ describe('Integrations settings', () => {
       .closest('[id="integration-linear"]');
 
     expect(linearCard).toHaveTextContent(
-      'Linear OAuth setup is incomplete. Finish configuring both client credentials before connecting. View setup guide.',
+      'Linear OAuth setup is incomplete. Finish configuring both client credentials before connecting.',
     );
   });
 
@@ -457,8 +485,28 @@ describe('Integrations settings', () => {
       ),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('link', { name: 'View setup guide' }),
+      screen.queryByRole('button', { name: 'Set up Linear OAuth' }),
     ).not.toBeInTheDocument();
+  });
+
+  it('opens the guided Linear OAuth setup for admins', () => {
+    state.linearInstallation = null;
+    state.oauthReadiness = [{ mcpId: 'linear', status: 'missing' }];
+
+    render(<Integrations />);
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Set up Linear OAuth' }),
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Set up Linear' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Open Linear app setup' }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Client ID')).toBeInTheDocument();
+    expect(screen.getByLabelText('Client secret')).toBeInTheDocument();
+    expect(screen.getByLabelText('Webhook secret')).toBeInTheDocument();
   });
 
   it('surfaces the server error when starting Linear fails', () => {

--- a/apps/web/src/components/settings/Integrations.tsx
+++ b/apps/web/src/components/settings/Integrations.tsx
@@ -156,15 +156,10 @@ function getLinearOauthSetupStatus(
   isAdmin: boolean,
 ): ReactNode {
   if (!isAdmin) {
-    return 'Linear is not configured for this deployment. Ask an administrator to finish its OAuth setup.';
+    return 'Not configured. Ask an administrator to set it up.';
   }
 
-  const message =
-    status === 'partial'
-      ? 'Linear OAuth setup is incomplete. Finish configuring both client credentials before connecting.'
-      : 'Linear OAuth is not configured for this deployment.';
-
-  return message;
+  return status === 'partial' ? 'Configuration incomplete.' : 'Not configured.';
 }
 
 type AdminConfiguredIntegrationItemOptions = {
@@ -1142,10 +1137,17 @@ export function Integrations() {
   const linearInstallation = useLinearInstallation();
   const connectLinear = useConnectLinear(`${pathname}?service=linear`);
   const disconnectLinear = useDisconnectLinear();
-  const linearOauthSetup = useLinearOauthSetup(isAdmin);
 
   const deploymentEnablements = useDeploymentMcpEnablements();
   const oauthReadiness = useMcpOauthReadiness();
+  const linearOauthStatus = oauthReadiness.data?.find(
+    (entry) => entry.mcpId === 'linear',
+  )?.status;
+  const linearOauthUnavailable =
+    linearOauthStatus === 'missing' || linearOauthStatus === 'partial';
+  const linearOauthSetup = useLinearOauthSetup(
+    isAdmin && linearOauthUnavailable,
+  );
   const setDeploymentEnabled = useSetDeploymentMcpEnabled();
   const userMcpConnections = useUserMcpConnections();
   const connectMcp = useConnectMcp();
@@ -1287,21 +1289,7 @@ export function Integrations() {
     const userConnectionMap = new Map(
       (userMcpConnections.data ?? []).map((entry) => [entry.mcpId, entry]),
     );
-    const oauthReadinessMap = new Map<string, OauthReadinessStatus>(
-      (oauthReadiness.data ?? []).map((entry) => [entry.mcpId, entry.status]),
-    );
-    const linearOauthStatus = oauthReadinessMap.get('linear');
-    const linearOauthUnavailable =
-      !linearInstallation.data &&
-      (linearOauthStatus === 'missing' || linearOauthStatus === 'partial');
-    const canManageLinearOauth =
-      isAdmin &&
-      Boolean(
-        linearOauthSetup.data &&
-        Object.values(linearOauthSetup.data.fields).some(
-          (field) => !field.managedByEnvironment,
-        ),
-      );
+    const canSetUpLinearOauth = isAdmin && linearOauthUnavailable;
     const openMcpToolDialog = (integration: McpIntegrationDefinition) =>
       setToolDialogState({
         mcpId: integration.id,
@@ -1349,21 +1337,14 @@ export function Integrations() {
         statusIcon: linearOauthUnavailable ? (
           <TriangleAlert className="size-4" />
         ) : undefined,
-        headerAction: canManageLinearOauth
+        headerAction: canSetUpLinearOauth
           ? {
-              label: linearOauthUnavailable
-                ? 'Set up Linear'
-                : 'Edit OAuth setup',
-              ariaLabel: linearOauthUnavailable
-                ? 'Set up Linear OAuth'
-                : 'Edit Linear OAuth setup',
+              label: 'Set it up',
+              ariaLabel: 'Set up Linear',
               onAction: () => setIsLinearOauthSetupOpen(true),
-              isPending: linearOauthSetup.isPending,
-              icon: linearOauthUnavailable ? (
-                <Settings2 className="size-4" />
-              ) : (
-                <Pencil className="size-4" />
-              ),
+              isPending:
+                linearOauthSetup.isPending || linearOauthSetup.data == null,
+              icon: <Settings2 />,
             }
           : undefined,
         onAction: linearOauthUnavailable
@@ -1633,7 +1614,8 @@ export function Integrations() {
     linearInstallation.isPending,
     linearOauthSetup.data,
     linearOauthSetup.isPending,
-    oauthReadiness.data,
+    linearOauthStatus,
+    linearOauthUnavailable,
     oauthReadiness.isPending,
     isAdmin,
     isGrafanaDialogOpen,

--- a/apps/web/src/components/settings/Integrations.tsx
+++ b/apps/web/src/components/settings/Integrations.tsx
@@ -17,6 +17,7 @@ import {
   useConnectLinear,
   useDisconnectLinear,
   useLinearInstallation,
+  useLinearOauthSetup,
 } from '@/hooks/linear';
 import {
   useAsanaConnection,
@@ -35,7 +36,6 @@ import {
   useVercelConnection,
 } from '@/hooks/mcp-connections';
 import { useAuthorizedUser } from '@/hooks/useUser';
-import { DOCS_LINEAR_INTEGRATION_URL } from '@/lib/docs';
 import { SETTINGS_PATHS } from '@/lib/settings';
 import {
   saveAsanaConnectionSchema,
@@ -77,6 +77,7 @@ import {
 } from '@/components/system';
 import { McpToolManagementDialog } from './McpToolManagementDialog';
 import { McpIcon } from './McpIcon';
+import { LinearOauthSetupDialog } from './LinearOauthSetupDialog';
 
 const DEEP_LINK_ENABLE_DESCRIPTIONS: Record<string, string> = {
   asana:
@@ -163,20 +164,7 @@ function getLinearOauthSetupStatus(
       ? 'Linear OAuth setup is incomplete. Finish configuring both client credentials before connecting.'
       : 'Linear OAuth is not configured for this deployment.';
 
-  return (
-    <>
-      {message}{' '}
-      <Link
-        href={DOCS_LINEAR_INTEGRATION_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="underline underline-offset-2"
-      >
-        View setup guide
-      </Link>
-      .
-    </>
-  );
+  return message;
 }
 
 type AdminConfiguredIntegrationItemOptions = {
@@ -1149,10 +1137,12 @@ export function Integrations() {
     mcpId: string;
     integrationName: string;
   } | null>(null);
+  const [isLinearOauthSetupOpen, setIsLinearOauthSetupOpen] = useState(false);
 
   const linearInstallation = useLinearInstallation();
   const connectLinear = useConnectLinear(`${pathname}?service=linear`);
   const disconnectLinear = useDisconnectLinear();
+  const linearOauthSetup = useLinearOauthSetup(isAdmin);
 
   const deploymentEnablements = useDeploymentMcpEnablements();
   const oauthReadiness = useMcpOauthReadiness();
@@ -1304,6 +1294,14 @@ export function Integrations() {
     const linearOauthUnavailable =
       !linearInstallation.data &&
       (linearOauthStatus === 'missing' || linearOauthStatus === 'partial');
+    const canManageLinearOauth =
+      isAdmin &&
+      Boolean(
+        linearOauthSetup.data &&
+        Object.values(linearOauthSetup.data.fields).some(
+          (field) => !field.managedByEnvironment,
+        ),
+      );
     const openMcpToolDialog = (integration: McpIntegrationDefinition) =>
       setToolDialogState({
         mcpId: integration.id,
@@ -1351,6 +1349,23 @@ export function Integrations() {
         statusIcon: linearOauthUnavailable ? (
           <TriangleAlert className="size-4" />
         ) : undefined,
+        headerAction: canManageLinearOauth
+          ? {
+              label: linearOauthUnavailable
+                ? 'Set up Linear'
+                : 'Edit OAuth setup',
+              ariaLabel: linearOauthUnavailable
+                ? 'Set up Linear OAuth'
+                : 'Edit Linear OAuth setup',
+              onAction: () => setIsLinearOauthSetupOpen(true),
+              isPending: linearOauthSetup.isPending,
+              icon: linearOauthUnavailable ? (
+                <Settings2 className="size-4" />
+              ) : (
+                <Pencil className="size-4" />
+              ),
+            }
+          : undefined,
         onAction: linearOauthUnavailable
           ? undefined
           : () => {
@@ -1616,6 +1631,8 @@ export function Integrations() {
     grafanaConnection.isPending,
     linearInstallation.data,
     linearInstallation.isPending,
+    linearOauthSetup.data,
+    linearOauthSetup.isPending,
     oauthReadiness.data,
     oauthReadiness.isPending,
     isAdmin,
@@ -1973,6 +1990,11 @@ export function Integrations() {
             setToolDialogState(null);
           }
         }}
+      />
+      <LinearOauthSetupDialog
+        open={isLinearOauthSetupOpen}
+        onOpenChange={setIsLinearOauthSetupOpen}
+        setup={linearOauthSetup.data}
       />
       <AdminConfiguredIntegrationDialog
         integrationName="Asana"

--- a/apps/web/src/components/settings/LinearOauthSetupDialog.tsx
+++ b/apps/web/src/components/settings/LinearOauthSetupDialog.tsx
@@ -20,6 +20,7 @@ import {
   ExternalLink,
   Input,
   Label,
+  Skeleton,
   Spinner,
   TriangleAlert,
 } from '@/components/system';
@@ -70,7 +71,7 @@ function EndpointField({ label, value }: { label: string; value: string }) {
           aria-label={`Copy ${label.toLowerCase()}`}
           onClick={copyValue}
         >
-          <Copy className="size-4" />
+          <Copy />
         </Button>
       </div>
     </div>
@@ -173,18 +174,19 @@ export function LinearOauthSetupDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+      <DialogContent size="lg">
         <DialogHeader>
           <DialogTitle>Set up Linear</DialogTitle>
           <DialogDescription>
-            Create a private OAuth app for this Roomote deployment, then save
-            the credentials it gives you.
+            Create a Linear app for this deployment, then connect it to your
+            workspace.
           </DialogDescription>
         </DialogHeader>
 
         {!setup ? (
-          <div className="flex min-h-40 items-center justify-center">
-            <Spinner />
+          <div className="space-y-4 py-2">
+            <Skeleton className="h-20 w-full" />
+            <Skeleton className="h-32 w-full" />
           </div>
         ) : (
           <div className="space-y-6 py-2">
@@ -201,11 +203,13 @@ export function LinearOauthSetupDialog({
 
             <section className="space-y-3">
               <div>
-                <h3 className="font-medium">1. Create the app in Linear</h3>
+                <h3 className="font-medium">
+                  Create a Linear app for this deployment.
+                </h3>
                 <p className="text-sm text-muted-foreground">
-                  The manifest pre-fills the callback, webhook, and agent event
-                  settings for this deployment. Review it in Linear, then create
-                  the app.
+                  Self-hosted Roomote needs its own Linear app. The manifest
+                  pre-fills the callback, webhook, and agent event settings.
+                  Review it in Linear, then create the app.
                 </p>
               </div>
               <Button
@@ -220,8 +224,8 @@ export function LinearOauthSetupDialog({
                   )
                 }
               >
-                Open Linear app setup
-                <ExternalLink className="size-4" />
+                Create Linear app
+                <ExternalLink />
               </Button>
               <div className="grid gap-3">
                 <EndpointField label="Callback URL" value={setup.callbackUrl} />
@@ -231,10 +235,11 @@ export function LinearOauthSetupDialog({
 
             <section className="space-y-3">
               <div>
-                <h3 className="font-medium">2. Save the credentials</h3>
+                <h3 className="font-medium">Then save the credentials.</h3>
                 <p className="text-sm text-muted-foreground">
                   Copy these values from the new app&apos;s settings. Roomote
-                  encrypts values saved here.
+                  encrypts values saved here. After they are saved, Enable
+                  Linear connects the app to your workspace.
                 </p>
               </div>
               <div className="grid gap-4 sm:grid-cols-2">
@@ -277,7 +282,7 @@ export function LinearOauthSetupDialog({
               rel="noopener noreferrer"
             >
               Setup guide
-              <ExternalLink className="size-4" />
+              <ExternalLink />
             </Link>
           </Button>
           <div className="flex justify-end gap-2">

--- a/apps/web/src/components/settings/LinearOauthSetupDialog.tsx
+++ b/apps/web/src/components/settings/LinearOauthSetupDialog.tsx
@@ -1,0 +1,304 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { toast } from 'sonner';
+
+import { DOCS_LINEAR_INTEGRATION_URL } from '@/lib/docs';
+import { useSaveLinearOauthSetup } from '@/hooks/linear';
+import {
+  Alert,
+  AlertDescription,
+  Button,
+  Copy,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  ExternalLink,
+  Input,
+  Label,
+  Spinner,
+  TriangleAlert,
+} from '@/components/system';
+
+type SetupFieldStatus = {
+  configured: boolean;
+  managedByEnvironment: boolean;
+};
+
+type LinearOauthSetupDetails = {
+  callbackUrl: string;
+  webhookUrl: string;
+  manifestUrl: string;
+  fields: {
+    clientId: SetupFieldStatus;
+    clientSecret: SetupFieldStatus;
+    webhookSecret: SetupFieldStatus;
+  };
+};
+
+type LinearOauthForm = {
+  clientId: string;
+  clientSecret: string;
+  webhookSecret: string;
+};
+
+const EMPTY_FORM: LinearOauthForm = {
+  clientId: '',
+  clientSecret: '',
+  webhookSecret: '',
+};
+
+function EndpointField({ label, value }: { label: string; value: string }) {
+  const copyValue = async () => {
+    await navigator.clipboard.writeText(value);
+    toast.success(`${label} copied.`);
+  };
+
+  return (
+    <div className="space-y-1.5">
+      <Label>{label}</Label>
+      <div className="flex gap-2">
+        <Input value={value} readOnly className="font-mono text-xs" />
+        <Button
+          type="button"
+          size="icon"
+          variant="outline"
+          aria-label={`Copy ${label.toLowerCase()}`}
+          onClick={copyValue}
+        >
+          <Copy className="size-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function CredentialField({
+  id,
+  label,
+  value,
+  status,
+  secret = false,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  status: SetupFieldStatus;
+  secret?: boolean;
+  onChange: (value: string) => void;
+}) {
+  const helperText = status.managedByEnvironment
+    ? 'Managed by the deployment environment.'
+    : status.configured
+      ? 'Already saved. Leave blank to keep the current value.'
+      : 'Required.';
+
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      <Input
+        id={id}
+        type={secret ? 'password' : 'text'}
+        value={status.managedByEnvironment ? '' : value}
+        placeholder={
+          status.managedByEnvironment
+            ? 'Managed by environment'
+            : status.configured
+              ? 'Saved'
+              : undefined
+        }
+        disabled={status.managedByEnvironment}
+        onChange={(event) => onChange(event.target.value)}
+        autoCapitalize="off"
+        autoCorrect="off"
+        spellCheck={false}
+        data-1p-ignore
+      />
+      <p className="text-xs text-muted-foreground">{helperText}</p>
+    </div>
+  );
+}
+
+export function LinearOauthSetupDialog({
+  open,
+  onOpenChange,
+  setup,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  setup: LinearOauthSetupDetails | undefined;
+}) {
+  const [form, setForm] = useState<LinearOauthForm>(EMPTY_FORM);
+  const [formError, setFormError] = useState<string | null>(null);
+  const saveSetup = useSaveLinearOauthSetup();
+
+  useEffect(() => {
+    if (open) {
+      setForm(EMPTY_FORM);
+      setFormError(null);
+    }
+  }, [open]);
+
+  const updateField = (field: keyof LinearOauthForm, value: string) => {
+    setForm((current) => ({ ...current, [field]: value }));
+    setFormError(null);
+  };
+
+  const save = () => {
+    saveSetup.mutate(form, {
+      onSuccess: (result) => {
+        toast.success(
+          result.requiresReconnect
+            ? 'Linear OAuth credentials saved. Enable Linear to reconnect the workspace.'
+            : 'Linear OAuth credentials saved.',
+        );
+        onOpenChange(false);
+      },
+      onError: (error) => {
+        setFormError(
+          error instanceof Error
+            ? error.message
+            : 'Failed to save Linear OAuth credentials.',
+        );
+      },
+    });
+  };
+
+  const publicUrlUsesHttps = setup?.webhookUrl.startsWith('https://') ?? true;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Set up Linear</DialogTitle>
+          <DialogDescription>
+            Create a private OAuth app for this Roomote deployment, then save
+            the credentials it gives you.
+          </DialogDescription>
+        </DialogHeader>
+
+        {!setup ? (
+          <div className="flex min-h-40 items-center justify-center">
+            <Spinner />
+          </div>
+        ) : (
+          <div className="space-y-6 py-2">
+            {!publicUrlUsesHttps ? (
+              <Alert variant="destructive">
+                <TriangleAlert className="size-4" />
+                <AlertDescription>
+                  Linear requires a public HTTPS webhook URL. Configure
+                  R_PUBLIC_URL with your deployment&apos;s HTTPS address before
+                  creating the app.
+                </AlertDescription>
+              </Alert>
+            ) : null}
+
+            <section className="space-y-3">
+              <div>
+                <h3 className="font-medium">1. Create the app in Linear</h3>
+                <p className="text-sm text-muted-foreground">
+                  The manifest pre-fills the callback, webhook, and agent event
+                  settings for this deployment. Review it in Linear, then create
+                  the app.
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={!publicUrlUsesHttps}
+                onClick={() =>
+                  window.open(
+                    setup.manifestUrl,
+                    '_blank',
+                    'noopener,noreferrer',
+                  )
+                }
+              >
+                Open Linear app setup
+                <ExternalLink className="size-4" />
+              </Button>
+              <div className="grid gap-3">
+                <EndpointField label="Callback URL" value={setup.callbackUrl} />
+                <EndpointField label="Webhook URL" value={setup.webhookUrl} />
+              </div>
+            </section>
+
+            <section className="space-y-3">
+              <div>
+                <h3 className="font-medium">2. Save the credentials</h3>
+                <p className="text-sm text-muted-foreground">
+                  Copy these values from the new app&apos;s settings. Roomote
+                  encrypts values saved here.
+                </p>
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <CredentialField
+                  id="linear-client-id"
+                  label="Client ID"
+                  value={form.clientId}
+                  status={setup.fields.clientId}
+                  onChange={(value) => updateField('clientId', value)}
+                />
+                <CredentialField
+                  id="linear-client-secret"
+                  label="Client secret"
+                  value={form.clientSecret}
+                  status={setup.fields.clientSecret}
+                  secret
+                  onChange={(value) => updateField('clientSecret', value)}
+                />
+                <CredentialField
+                  id="linear-webhook-secret"
+                  label="Webhook secret"
+                  value={form.webhookSecret}
+                  status={setup.fields.webhookSecret}
+                  secret
+                  onChange={(value) => updateField('webhookSecret', value)}
+                />
+              </div>
+              {formError ? (
+                <p className="text-sm text-destructive">{formError}</p>
+              ) : null}
+            </section>
+          </div>
+        )}
+
+        <DialogFooter className="gap-2 sm:justify-between">
+          <Button variant="ghost" asChild>
+            <Link
+              href={DOCS_LINEAR_INTEGRATION_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Setup guide
+              <ExternalLink className="size-4" />
+            </Link>
+          </Button>
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              disabled={!setup || saveSetup.isPending}
+              onClick={save}
+            >
+              {saveSetup.isPending ? <Spinner size="sm" /> : null}
+              Save credentials
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/hooks/linear/index.ts
+++ b/apps/web/src/hooks/linear/index.ts
@@ -1,4 +1,6 @@
 export { useLinearInstallation } from './useLinearInstallation';
 export { useConnectLinear } from './useConnectLinear';
 export { useDisconnectLinear } from './useDisconnectLinear';
+export { useLinearOauthSetup } from './useLinearOauthSetup';
+export { useSaveLinearOauthSetup } from './useSaveLinearOauthSetup';
 export { useAuthenticateLinearAccount } from './useAuthenticateLinearAccount';

--- a/apps/web/src/hooks/linear/useLinearOauthSetup.ts
+++ b/apps/web/src/hooks/linear/useLinearOauthSetup.ts
@@ -1,0 +1,14 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { useTRPC } from '@/trpc/client';
+
+export function useLinearOauthSetup(enabled = true) {
+  const trpc = useTRPC();
+
+  return useQuery({
+    ...trpc.linear.oauthSetup.queryOptions(),
+    enabled,
+  });
+}

--- a/apps/web/src/hooks/linear/useSaveLinearOauthSetup.ts
+++ b/apps/web/src/hooks/linear/useSaveLinearOauthSetup.ts
@@ -1,0 +1,31 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { useTRPC } from '@/trpc/client';
+
+export function useSaveLinearOauthSetup() {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    trpc.linear.saveOauthSetup.mutationOptions({
+      onSuccess: async () => {
+        await Promise.all([
+          queryClient.invalidateQueries({
+            queryKey: trpc.linear.oauthSetup.queryKey(),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: trpc.mcpConnections.oauthReadiness.queryKey(),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: trpc.linear.installation.queryKey(),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: trpc.mcpConnections.deploymentEnablements.queryKey(),
+          }),
+        ]);
+      },
+    }),
+  );
+}

--- a/apps/web/src/lib/server/deployment-app-name.test.ts
+++ b/apps/web/src/lib/server/deployment-app-name.test.ts
@@ -1,0 +1,21 @@
+import { buildDeploymentAppName } from './deployment-app-name';
+
+describe('buildDeploymentAppName', () => {
+  it('uses the same hostname-derived default across provider manifests', () => {
+    expect(buildDeploymentAppName('https://customer.example.com')).toBe(
+      'roomote-customer-example-com',
+    );
+    expect(buildDeploymentAppName('https://roomote.example.com')).toBe(
+      'roomote-example-com',
+    );
+  });
+
+  it('keeps the shared name within GitHub app naming limits', () => {
+    const name = buildDeploymentAppName(
+      'https://a-very-long-customer-deployment-name.example.com',
+    );
+
+    expect(name.length).toBeLessThanOrEqual(34);
+    expect(name.endsWith('-')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/server/deployment-app-name.ts
+++ b/apps/web/src/lib/server/deployment-app-name.ts
@@ -1,0 +1,25 @@
+const DEPLOYMENT_APP_NAME_MAX_LENGTH = 34;
+const DEPLOYMENT_APP_NAME_PREFIX = 'roomote-';
+
+export const DEPLOYMENT_APP_DESCRIPTION = 'Cloud coding agents for all';
+
+/**
+ * Build the shared default name used for deployment-owned provider apps.
+ * GitHub's 34-character limit is the strictest supported limit, so keeping
+ * the shared name within it produces the same name across providers.
+ */
+export function buildDeploymentAppName(publicOrigin: string): string {
+  const host = new URL(publicOrigin).hostname
+    .replace(/[^a-zA-Z0-9-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  if (!host) {
+    return 'roomote';
+  }
+
+  const candidate = host.startsWith('roomote')
+    ? host
+    : `${DEPLOYMENT_APP_NAME_PREFIX}${host}`;
+
+  return candidate.slice(0, DEPLOYMENT_APP_NAME_MAX_LENGTH).replace(/-+$/g, '');
+}

--- a/apps/web/src/lib/server/deployment-static-oauth.test.ts
+++ b/apps/web/src/lib/server/deployment-static-oauth.test.ts
@@ -1,0 +1,52 @@
+const { resolveDeploymentEnvVarMock } = vi.hoisted(() => ({
+  resolveDeploymentEnvVarMock: vi.fn(),
+}));
+
+vi.mock('@roomote/db/server', () => ({
+  db: { query: { environmentVariables: { findMany: vi.fn() } } },
+  resolveDeploymentEnvVar: resolveDeploymentEnvVarMock,
+}));
+
+import {
+  getDeploymentStaticOauthReadiness,
+  resolveDeploymentStaticOauthClientInformation,
+} from './deployment-static-oauth';
+
+const LINEAR_INTEGRATION = {
+  id: 'linear',
+  oauthClientEnv: {
+    clientIdEnv: 'R_LINEAR_CLIENT_ID',
+    clientSecretEnv: 'R_LINEAR_CLIENT_SECRET',
+    tokenEndpointAuthMethod: 'client_secret_post' as const,
+  },
+};
+
+describe('deployment static OAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves a client stored in the encrypted deployment environment', async () => {
+    resolveDeploymentEnvVarMock.mockImplementation(async (name: string) =>
+      name === 'R_LINEAR_CLIENT_ID' ? 'saved-client' : 'saved-secret',
+    );
+
+    await expect(
+      resolveDeploymentStaticOauthClientInformation({}, LINEAR_INTEGRATION),
+    ).resolves.toEqual({
+      client_id: 'saved-client',
+      client_secret: 'saved-secret',
+      token_endpoint_auth_method: 'client_secret_post',
+    });
+  });
+
+  it('reports a partially configured deployment', async () => {
+    resolveDeploymentEnvVarMock.mockImplementation(async (name: string) =>
+      name === 'R_LINEAR_CLIENT_ID' ? 'saved-client' : null,
+    );
+
+    await expect(
+      getDeploymentStaticOauthReadiness({}, LINEAR_INTEGRATION),
+    ).resolves.toBe('partial');
+  });
+});

--- a/apps/web/src/lib/server/deployment-static-oauth.ts
+++ b/apps/web/src/lib/server/deployment-static-oauth.ts
@@ -1,0 +1,60 @@
+import {
+  db,
+  resolveDeploymentEnvVar,
+  type DatabaseOrTransaction,
+} from '@roomote/db/server';
+import type { McpIntegration } from '@roomote/types';
+
+import {
+  getStaticOauthEnvKeys,
+  getStaticOauthReadiness,
+  resolveStaticOauthClientInformation,
+} from './mcp-static-oauth';
+
+async function resolveDeploymentStaticOauthEnv(
+  runtimeEnv: unknown,
+  integration: Pick<McpIntegration, 'id' | 'oauthClientEnv'>,
+  executor: DatabaseOrTransaction = db,
+): Promise<Record<string, string>> {
+  const keys = getStaticOauthEnvKeys(integration);
+  const runtimeRecord =
+    typeof runtimeEnv === 'object' && runtimeEnv !== null
+      ? (runtimeEnv as Partial<Record<string, string | undefined>>)
+      : {};
+  const entries = await Promise.all(
+    keys.map(async (key) => {
+      const value = await resolveDeploymentEnvVar(key, executor, runtimeRecord);
+      return value ? ([key, value] as const) : null;
+    }),
+  );
+
+  return Object.fromEntries(entries.filter((entry) => entry !== null));
+}
+
+export async function getDeploymentStaticOauthReadiness(
+  runtimeEnv: unknown,
+  integration: Pick<McpIntegration, 'id' | 'oauthClientEnv'>,
+  executor: DatabaseOrTransaction = db,
+) {
+  const resolvedEnv = await resolveDeploymentStaticOauthEnv(
+    runtimeEnv,
+    integration,
+    executor,
+  );
+
+  return getStaticOauthReadiness(resolvedEnv, integration);
+}
+
+export async function resolveDeploymentStaticOauthClientInformation(
+  runtimeEnv: unknown,
+  integration: Pick<McpIntegration, 'id' | 'oauthClientEnv'>,
+  executor: DatabaseOrTransaction = db,
+) {
+  const resolvedEnv = await resolveDeploymentStaticOauthEnv(
+    runtimeEnv,
+    integration,
+    executor,
+  );
+
+  return resolveStaticOauthClientInformation(resolvedEnv, integration);
+}

--- a/apps/web/src/lib/server/mcp-static-oauth.ts
+++ b/apps/web/src/lib/server/mcp-static-oauth.ts
@@ -155,6 +155,19 @@ function getStaticOauthEnvCandidates(
   ];
 }
 
+export function getStaticOauthEnvKeys(
+  integration: Pick<McpIntegration, 'id' | 'oauthClientEnv'>,
+): string[] {
+  return Array.from(
+    new Set(
+      getStaticOauthEnvCandidates(integration).flatMap((candidate) => [
+        candidate.clientIdEnv,
+        ...(candidate.clientSecretEnv ? [candidate.clientSecretEnv] : []),
+      ]),
+    ),
+  );
+}
+
 function resolveStaticOauthIntegration(
   env: unknown,
   integration: Pick<McpIntegration, 'id' | 'oauthClientEnv'>,

--- a/apps/web/src/trpc/commands/github/mutations.ts
+++ b/apps/web/src/trpc/commands/github/mutations.ts
@@ -23,6 +23,10 @@ import { Env } from '@/lib/server';
 import { encodeRecord } from '@/lib';
 import { getPublicAppUrl } from '@/lib/server/get-public-app-url';
 import {
+  buildDeploymentAppName,
+  DEPLOYMENT_APP_DESCRIPTION,
+} from '@/lib/server/deployment-app-name';
+import {
   createSignedGitHubAuthState,
   decodeSignedGitHubAuthState,
 } from '@/lib/server/github-oauth-state';
@@ -80,8 +84,6 @@ const GITHUB_APP_DEFAULT_EVENTS = [
   'workflow_job',
   'workflow_run',
 ] as const;
-
-const GITHUB_APP_MANIFEST_DESCRIPTION = 'Cloud coding agents for all';
 
 type GitHubAppManifest = {
   name: string;
@@ -207,32 +209,12 @@ function getGitHubWebhookUrl() {
   return new URL('/api/webhooks/github', webhookBaseUrl).toString();
 }
 
-function buildGitHubManifestName() {
-  // GitHub enforces a 34-character maximum on GitHub App names.
-  const GITHUB_APP_NAME_MAX_LENGTH = 34;
-  const prefix = 'roomote-';
-
-  const host = new URL(getPublicAppUrl(Env)).hostname
-    .replace(/[^a-zA-Z0-9-]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-
-  if (!host) {
-    return 'roomote';
-  }
-
-  // Optionally prefix with `roomote-` when the deployment hostname does not
-  // already start with `roomote`, then trim the final name to GitHub's limit.
-  const candidate = host.startsWith('roomote') ? host : `${prefix}${host}`;
-
-  return candidate.slice(0, GITHUB_APP_NAME_MAX_LENGTH).replace(/-+$/g, '');
-}
-
 function buildGitHubAppManifest(): GitHubAppManifest {
   const callbackUrl = getGitHubCallbackUrl();
 
   return {
-    name: buildGitHubManifestName(),
-    description: GITHUB_APP_MANIFEST_DESCRIPTION,
+    name: buildDeploymentAppName(getPublicAppUrl(Env)),
+    description: DEPLOYMENT_APP_DESCRIPTION,
     url: callbackUrl,
     redirect_url: callbackUrl,
     setup_url: callbackUrl,

--- a/apps/web/src/trpc/commands/linear/index.test.ts
+++ b/apps/web/src/trpc/commands/linear/index.test.ts
@@ -86,8 +86,9 @@ describe('Linear OAuth setup', () => {
     expect(manifest).toMatchObject({
       schemaVersion: '1.0.0',
       distribution: 'private',
+      display: { description: 'Cloud coding agents for all' },
       oauth: {
-        client_name: 'Roomote',
+        client_name: 'roomote-example',
         redirect_uris: [setup.callbackUrl],
       },
       webhook: {
@@ -96,6 +97,21 @@ describe('Linear OAuth setup', () => {
         resourceTypes: ['AgentSessionEvent'],
       },
     });
+  });
+
+  it('requires an administrator to view or save app setup', async () => {
+    const nonAdmin = { ...ADMIN, isAdmin: false };
+
+    await expect(getLinearOauthSetupCommand(nonAdmin)).rejects.toThrow(
+      'Unauthorized',
+    );
+    await expect(
+      saveLinearOauthSetupCommand(nonAdmin, {
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+        webhookSecret: 'webhook-secret',
+      }),
+    ).rejects.toThrow('Unauthorized');
   });
 
   it('saves all three credentials in the encrypted deployment store', async () => {

--- a/apps/web/src/trpc/commands/linear/index.test.ts
+++ b/apps/web/src/trpc/commands/linear/index.test.ts
@@ -1,0 +1,193 @@
+const {
+  envState,
+  deletedConnectionsState,
+  resolveDeploymentEnvVarMock,
+  upsertDeploymentEnvironmentVariablesMock,
+} = vi.hoisted(() => ({
+  envState: {} as Record<string, string | undefined>,
+  deletedConnectionsState: [] as Array<{ id: string }>,
+  resolveDeploymentEnvVarMock: vi.fn(),
+  upsertDeploymentEnvironmentVariablesMock: vi.fn(),
+}));
+
+vi.mock('@/lib/server/env', () => ({ Env: envState }));
+vi.mock('@/lib/server/get-public-app-url', () => ({
+  getPublicAppUrl: () => 'https://roomote.example',
+}));
+vi.mock('../environment-variables', () => ({
+  upsertDeploymentEnvironmentVariables:
+    upsertDeploymentEnvironmentVariablesMock,
+}));
+vi.mock('@roomote/db/server', () => ({
+  db: {
+    transaction: async (operation: (tx: unknown) => Promise<unknown>) =>
+      operation({
+        delete: () => ({
+          where: () => ({
+            returning: async () => deletedConnectionsState,
+          }),
+        }),
+        insert: () => ({
+          values: () => ({
+            onConflictDoUpdate: async () => undefined,
+          }),
+        }),
+      }),
+  },
+  resolveDeploymentEnvVar: resolveDeploymentEnvVarMock,
+  and: vi.fn(),
+  eq: vi.fn(),
+  isNull: vi.fn(),
+  mcpConnections: {
+    id: 'id',
+    mcpId: 'mcpId',
+    connectionRole: 'connectionRole',
+    userId: 'userId',
+  },
+  deploymentMcpEnablements: { mcpId: 'mcpId' },
+}));
+vi.mock('@roomote/sdk/server', () => ({
+  findLinearDeploymentMcpConnection: vi.fn(),
+  getLinearDeploymentMetadata: vi.fn(),
+  LINEAR_ORG_CONNECTION_ROLE: 'linear_org_install',
+}));
+
+import {
+  getLinearOauthSetupCommand,
+  saveLinearOauthSetupCommand,
+} from './index';
+
+const ADMIN = {
+  userId: 'admin-1',
+  isAdmin: true,
+} as Parameters<typeof getLinearOauthSetupCommand>[0];
+
+describe('Linear OAuth setup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const key of Object.keys(envState)) {
+      delete envState[key];
+    }
+    deletedConnectionsState.splice(0);
+    resolveDeploymentEnvVarMock.mockResolvedValue(null);
+  });
+
+  it('builds a private Linear app manifest for this deployment', async () => {
+    const setup = await getLinearOauthSetupCommand(ADMIN);
+    const setupUrl = new URL(setup.manifestUrl);
+    const manifest = JSON.parse(setupUrl.searchParams.get('manifest')!);
+
+    expect(setup.callbackUrl).toBe(
+      'https://roomote.example/api/mcp-oauth/callback',
+    );
+    expect(setup.webhookUrl).toBe(
+      'https://roomote.example/api/webhooks/linear',
+    );
+    expect(manifest).toMatchObject({
+      schemaVersion: '1.0.0',
+      distribution: 'private',
+      oauth: {
+        client_name: 'Roomote',
+        redirect_uris: [setup.callbackUrl],
+      },
+      webhook: {
+        enabled: true,
+        url: setup.webhookUrl,
+        resourceTypes: ['AgentSessionEvent'],
+      },
+    });
+  });
+
+  it('saves all three credentials in the encrypted deployment store', async () => {
+    await saveLinearOauthSetupCommand(ADMIN, {
+      clientId: ' client-id ',
+      clientSecret: ' client-secret ',
+      webhookSecret: ' webhook-secret ',
+    });
+
+    expect(upsertDeploymentEnvironmentVariablesMock).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        userId: 'admin-1',
+        values: [
+          { name: 'R_LINEAR_CLIENT_ID', value: 'client-id' },
+          { name: 'R_LINEAR_CLIENT_SECRET', value: 'client-secret' },
+          { name: 'R_LINEAR_WEBHOOK_SECRET', value: 'webhook-secret' },
+        ],
+      },
+    );
+  });
+
+  it('requires an existing workspace to reconnect when its OAuth client changes', async () => {
+    deletedConnectionsState.push({ id: 'legacy-linear-connection' });
+
+    const result = await saveLinearOauthSetupCommand(ADMIN, {
+      clientId: 'new-client-id',
+      clientSecret: 'new-client-secret',
+      webhookSecret: 'new-webhook-secret',
+    });
+
+    expect(result.requiresReconnect).toBe(true);
+  });
+
+  it('keeps the workspace connected when only the webhook secret changes', async () => {
+    deletedConnectionsState.push({ id: 'current-linear-connection' });
+    resolveDeploymentEnvVarMock.mockResolvedValue('already-configured');
+
+    const result = await saveLinearOauthSetupCommand(ADMIN, {
+      clientId: '',
+      clientSecret: '',
+      webhookSecret: 'rotated-webhook-secret',
+    });
+
+    expect(result.requiresReconnect).toBe(false);
+  });
+
+  it('keeps saved values when an administrator leaves their fields blank', async () => {
+    resolveDeploymentEnvVarMock.mockResolvedValue('already-configured');
+
+    await saveLinearOauthSetupCommand(ADMIN, {
+      clientId: '',
+      clientSecret: '',
+      webhookSecret: '',
+    });
+
+    expect(upsertDeploymentEnvironmentVariablesMock).toHaveBeenCalledWith(
+      expect.anything(),
+      { userId: 'admin-1', values: [] },
+    );
+  });
+
+  it('does not copy runtime-managed credentials into the database', async () => {
+    envState.R_LINEAR_CLIENT_ID = 'runtime-client';
+    envState.R_LINEAR_CLIENT_SECRET = 'runtime-secret';
+    envState.R_LINEAR_WEBHOOK_SECRET = 'runtime-webhook-secret';
+    resolveDeploymentEnvVarMock.mockImplementation(
+      async (name: string, _db: unknown, runtimeEnv: Record<string, string>) =>
+        runtimeEnv[name] ?? null,
+    );
+
+    await saveLinearOauthSetupCommand(ADMIN, {
+      clientId: 'ignored-client',
+      clientSecret: 'ignored-secret',
+      webhookSecret: 'ignored-webhook-secret',
+    });
+
+    expect(upsertDeploymentEnvironmentVariablesMock).toHaveBeenCalledWith(
+      expect.anything(),
+      { userId: 'admin-1', values: [] },
+    );
+  });
+
+  it('requires every value that is not already configured', async () => {
+    await expect(
+      saveLinearOauthSetupCommand(ADMIN, {
+        clientId: 'client-id',
+        clientSecret: '',
+        webhookSecret: '',
+      }),
+    ).rejects.toThrow('client secret, webhook secret');
+
+    expect(upsertDeploymentEnvironmentVariablesMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/trpc/commands/linear/index.ts
+++ b/apps/web/src/trpc/commands/linear/index.ts
@@ -1,18 +1,17 @@
-import {
-  and,
-  db,
-  eq,
-  isNull,
-  mcpConnections,
-  deploymentMcpEnablements,
-} from '@roomote/db/server';
+import { db } from '@roomote/db/server';
 import {
   findLinearDeploymentMcpConnection,
   getLinearDeploymentMetadata,
-  LINEAR_ORG_CONNECTION_ROLE,
 } from '@roomote/sdk/server';
 
 import type { UserAuthSuccess } from '@/types';
+
+import { clearLinearDeploymentConnection } from './oauth-setup';
+
+export {
+  getLinearOauthSetupCommand,
+  saveLinearOauthSetupCommand,
+} from './oauth-setup';
 
 type LinearInstallationSummary = {
   id: string;
@@ -55,31 +54,7 @@ export async function disconnectLinearAppCommand(
       };
     }
 
-    await db
-      .delete(mcpConnections)
-      .where(
-        and(
-          eq(mcpConnections.mcpId, 'linear'),
-          eq(mcpConnections.connectionRole, LINEAR_ORG_CONNECTION_ROLE),
-          isNull(mcpConnections.userId),
-        ),
-      );
-
-    await db
-      .insert(deploymentMcpEnablements)
-      .values({
-        mcpId: 'linear',
-        enabled: false,
-        enabledByUserId: auth.userId,
-      })
-      .onConflictDoUpdate({
-        target: deploymentMcpEnablements.mcpId,
-        set: {
-          enabled: false,
-          enabledByUserId: auth.userId,
-          updatedAt: new Date(),
-        },
-      });
+    await clearLinearDeploymentConnection(db, auth.userId);
 
     return { success: true };
   } catch (error) {

--- a/apps/web/src/trpc/commands/linear/oauth-setup.ts
+++ b/apps/web/src/trpc/commands/linear/oauth-setup.ts
@@ -1,0 +1,228 @@
+import {
+  and,
+  db,
+  deploymentMcpEnablements,
+  eq,
+  isNull,
+  mcpConnections,
+  resolveDeploymentEnvVar,
+  type DatabaseOrTransaction,
+} from '@roomote/db/server';
+import { LINEAR_ORG_CONNECTION_ROLE } from '@roomote/sdk/server';
+
+import { Env } from '@/lib/server/env';
+import { getPublicAppUrl } from '@/lib/server/get-public-app-url';
+import type { UserAuthSuccess } from '@/types';
+
+import { upsertDeploymentEnvironmentVariables } from '../environment-variables';
+
+const LINEAR_OAUTH_ENV_FIELDS = {
+  clientId: 'R_LINEAR_CLIENT_ID',
+  clientSecret: 'R_LINEAR_CLIENT_SECRET',
+  webhookSecret: 'R_LINEAR_WEBHOOK_SECRET',
+} as const;
+
+type LinearOauthSetupField = keyof typeof LINEAR_OAUTH_ENV_FIELDS;
+
+type SaveLinearOauthSetupInput = Record<LinearOauthSetupField, string>;
+
+function assertAdmin(auth: Pick<UserAuthSuccess, 'isAdmin'>) {
+  if (!auth.isAdmin) {
+    throw new Error('Unauthorized');
+  }
+}
+
+function getRuntimeEnvValue(name: string): string | null {
+  const value = (Env as unknown as Record<string, unknown>)[name];
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalizedValue = value.trim();
+  return normalizedValue || null;
+}
+
+function getLinearRuntimeEnv(): Partial<Record<string, string | undefined>> {
+  return Object.fromEntries(
+    Object.values(LINEAR_OAUTH_ENV_FIELDS).flatMap((envName) => {
+      const value = getRuntimeEnvValue(envName);
+      return value ? [[envName, value]] : [];
+    }),
+  );
+}
+
+function buildLinearOauthSetup(publicOrigin: string) {
+  const callbackUrl = new URL(
+    '/api/mcp-oauth/callback',
+    publicOrigin,
+  ).toString();
+  const webhookUrl = new URL('/api/webhooks/linear', publicOrigin).toString();
+  const manifest = {
+    $schema: 'https://linear.app/.well-known/oauth-app-manifest.schema.json',
+    schemaVersion: '1.0.0',
+    distribution: 'private',
+    display: {
+      description:
+        'Run Roomote agents from Linear issues and keep progress in sync.',
+    },
+    developer: { name: 'Roomote' },
+    oauth: {
+      client_name: 'Roomote',
+      client_uri: publicOrigin,
+      redirect_uris: [callbackUrl],
+      grant_types: ['authorization_code'],
+    },
+    webhook: {
+      enabled: true,
+      url: webhookUrl,
+      resourceTypes: ['AgentSessionEvent'],
+    },
+  };
+  const url = new URL('https://linear.app/settings/api/applications/new');
+  url.searchParams.set('manifest', JSON.stringify(manifest));
+  return {
+    callbackUrl,
+    webhookUrl,
+    manifestUrl: url.toString(),
+  };
+}
+
+export async function clearLinearDeploymentConnection(
+  executor: DatabaseOrTransaction,
+  userId: string,
+): Promise<boolean> {
+  const deletedConnections = await executor
+    .delete(mcpConnections)
+    .where(
+      and(
+        eq(mcpConnections.mcpId, 'linear'),
+        eq(mcpConnections.connectionRole, LINEAR_ORG_CONNECTION_ROLE),
+        isNull(mcpConnections.userId),
+      ),
+    )
+    .returning({ id: mcpConnections.id });
+
+  await executor
+    .insert(deploymentMcpEnablements)
+    .values({
+      mcpId: 'linear',
+      enabled: false,
+      enabledByUserId: userId,
+    })
+    .onConflictDoUpdate({
+      target: deploymentMcpEnablements.mcpId,
+      set: {
+        enabled: false,
+        enabledByUserId: userId,
+        updatedAt: new Date(),
+      },
+    });
+
+  return deletedConnections.length > 0;
+}
+
+export async function getLinearOauthSetupCommand(auth: UserAuthSuccess) {
+  assertAdmin(auth);
+
+  const publicOrigin = getPublicAppUrl(Env);
+  const runtimeEnv = getLinearRuntimeEnv();
+  const urls = buildLinearOauthSetup(publicOrigin);
+  const fieldEntries = await Promise.all(
+    Object.entries(LINEAR_OAUTH_ENV_FIELDS).map(async ([field, envName]) => {
+      const runtimeValue = getRuntimeEnvValue(envName);
+      const effectiveValue = await resolveDeploymentEnvVar(
+        envName,
+        db,
+        runtimeEnv,
+      );
+
+      return [
+        field,
+        {
+          configured: Boolean(effectiveValue),
+          managedByEnvironment: Boolean(runtimeValue),
+        },
+      ] as const;
+    }),
+  );
+
+  return {
+    ...urls,
+    fields: Object.fromEntries(fieldEntries) as Record<
+      LinearOauthSetupField,
+      { configured: boolean; managedByEnvironment: boolean }
+    >,
+  };
+}
+
+export async function saveLinearOauthSetupCommand(
+  auth: UserAuthSuccess,
+  input: SaveLinearOauthSetupInput,
+) {
+  assertAdmin(auth);
+  const runtimeEnv = getLinearRuntimeEnv();
+
+  const currentValues = await Promise.all(
+    Object.entries(LINEAR_OAUTH_ENV_FIELDS).map(async ([field, envName]) => [
+      field,
+      await resolveDeploymentEnvVar(envName, db, runtimeEnv),
+    ]),
+  );
+  const currentByField = Object.fromEntries(currentValues) as Record<
+    LinearOauthSetupField,
+    string | null
+  >;
+  const labels: Record<LinearOauthSetupField, string> = {
+    clientId: 'client ID',
+    clientSecret: 'client secret',
+    webhookSecret: 'webhook secret',
+  };
+  const missingFields = (
+    Object.keys(LINEAR_OAUTH_ENV_FIELDS) as LinearOauthSetupField[]
+  ).filter((field) => !input[field].trim() && !currentByField[field]);
+
+  if (missingFields.length > 0) {
+    throw new Error(
+      `Enter the Linear ${missingFields.map((field) => labels[field]).join(', ')}.`,
+    );
+  }
+
+  const values = (
+    Object.entries(LINEAR_OAUTH_ENV_FIELDS) as Array<
+      [LinearOauthSetupField, string]
+    >
+  ).flatMap(([field, envName]) => {
+    const value = input[field].trim();
+    return value && !getRuntimeEnvValue(envName)
+      ? [{ name: envName, value }]
+      : [];
+  });
+  const clientCredentialsChanged = (['clientId', 'clientSecret'] as const).some(
+    (field) => {
+      const value = input[field].trim();
+      const envName = LINEAR_OAUTH_ENV_FIELDS[field];
+      return (
+        Boolean(value) &&
+        !getRuntimeEnvValue(envName) &&
+        value !== currentByField[field]
+      );
+    },
+  );
+  let requiresReconnect = false;
+
+  await db.transaction(async (tx) => {
+    await upsertDeploymentEnvironmentVariables(tx, {
+      userId: auth.userId,
+      values,
+    });
+
+    if (clientCredentialsChanged) {
+      requiresReconnect = await clearLinearDeploymentConnection(
+        tx,
+        auth.userId,
+      );
+    }
+  });
+
+  return { success: true as const, requiresReconnect };
+}

--- a/apps/web/src/trpc/commands/linear/oauth-setup.ts
+++ b/apps/web/src/trpc/commands/linear/oauth-setup.ts
@@ -11,6 +11,10 @@ import {
 import { LINEAR_ORG_CONNECTION_ROLE } from '@roomote/sdk/server';
 
 import { Env } from '@/lib/server/env';
+import {
+  buildDeploymentAppName,
+  DEPLOYMENT_APP_DESCRIPTION,
+} from '@/lib/server/deployment-app-name';
 import { getPublicAppUrl } from '@/lib/server/get-public-app-url';
 import type { UserAuthSuccess } from '@/types';
 
@@ -62,12 +66,11 @@ function buildLinearOauthSetup(publicOrigin: string) {
     schemaVersion: '1.0.0',
     distribution: 'private',
     display: {
-      description:
-        'Run Roomote agents from Linear issues and keep progress in sync.',
+      description: DEPLOYMENT_APP_DESCRIPTION,
     },
     developer: { name: 'Roomote' },
     oauth: {
-      client_name: 'Roomote',
+      client_name: buildDeploymentAppName(publicOrigin),
       client_uri: publicOrigin,
       redirect_uris: [callbackUrl],
       grant_types: ['authorization_code'],

--- a/apps/web/src/trpc/commands/mcp-connections/index.ts
+++ b/apps/web/src/trpc/commands/mcp-connections/index.ts
@@ -32,10 +32,8 @@ import { encrypt } from '@roomote/db/encryption';
 import { getValidAccessToken } from '@roomote/sdk/server';
 
 import type { UserAuthSuccess } from '@/types';
-import {
-  getStaticOauthReadiness,
-  type StaticOauthReadiness,
-} from '@/lib/server/mcp-static-oauth';
+import type { StaticOauthReadiness } from '@/lib/server/mcp-static-oauth';
+import { getDeploymentStaticOauthReadiness } from '@/lib/server/deployment-static-oauth';
 import { Env } from '@/lib/server/env';
 import { MCP_TOOL_CATALOG_REQUIRES_PERSONAL_CONNECTION } from '@/lib/mcp-tool-errors';
 import type {
@@ -87,8 +85,10 @@ function getStaticOauthSetupError(
   return `${integration.name} isn't available on this Roomote deployment yet. Ask the team managing this deployment to configure OAuth before connecting.`;
 }
 
-function assertStaticOauthReady(integration: McpIntegration): void {
-  const readiness = getStaticOauthReadiness(Env, integration);
+async function assertStaticOauthReady(
+  integration: McpIntegration,
+): Promise<void> {
+  const readiness = await getDeploymentStaticOauthReadiness(Env, integration);
   const error = getStaticOauthSetupError(integration, readiness);
 
   if (error) {
@@ -527,11 +527,21 @@ export async function getDeploymentMcpEnablementsCommand(
  * server.
  */
 export async function getMcpOauthReadinessCommand(_auth: UserAuthSuccess) {
-  return MCP_INTEGRATIONS.flatMap((integration) => {
-    const status = getStaticOauthReadiness(Env, integration);
+  const readiness = await Promise.all(
+    MCP_INTEGRATIONS.map(async (integration) => ({
+      mcpId: integration.id,
+      status: await getDeploymentStaticOauthReadiness(Env, integration),
+    })),
+  );
 
-    return status === 'not_required' ? [] : [{ mcpId: integration.id, status }];
-  });
+  return readiness.filter(
+    (
+      entry,
+    ): entry is {
+      mcpId: string;
+      status: Exclude<StaticOauthReadiness, 'not_required'>;
+    } => entry.status !== 'not_required',
+  );
 }
 
 /**
@@ -579,7 +589,7 @@ export async function setDeploymentMcpEnabledCommand(
     integration?.oauthClientEnv &&
     !isDeploymentScopedMcpIntegration(input.mcpId)
   ) {
-    assertStaticOauthReady(integration);
+    await assertStaticOauthReady(integration);
   }
 
   const [result] = await db
@@ -1262,7 +1272,7 @@ export async function connectMcpCommand(
     );
   }
 
-  assertStaticOauthReady(integration);
+  await assertStaticOauthReady(integration);
 
   if (
     input.redirectTo &&

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -112,6 +112,8 @@ import {
 import {
   getLinearInstallationCommand,
   disconnectLinearAppCommand,
+  getLinearOauthSetupCommand,
+  saveLinearOauthSetupCommand,
 } from '../commands/linear';
 import { getTeamsIntegrationStatusCommand } from '../commands/teams';
 import {
@@ -1146,6 +1148,22 @@ export const appRouter = createRouter({
     disconnectApp: protectedProcedure.mutation(({ ctx: { auth } }) =>
       disconnectLinearAppCommand(auth),
     ),
+
+    oauthSetup: protectedProcedure.query(({ ctx: { auth } }) =>
+      getLinearOauthSetupCommand(auth),
+    ),
+
+    saveOauthSetup: protectedProcedure
+      .input(
+        z.object({
+          clientId: z.string().max(1_000),
+          clientSecret: z.string().max(10_000),
+          webhookSecret: z.string().max(10_000),
+        }),
+      )
+      .mutation(({ ctx: { auth }, input }) =>
+        saveLinearOauthSetupCommand(auth, input),
+      ),
   }),
 
   teams: createRouter({


### PR DESCRIPTION
## Summary

- add an admin-guided Linear OAuth setup dialog backed by Linear’s pre-filled app manifest
- use the same hostname-derived app name and default description as the GitHub setup
- show setup only while Linear OAuth is missing or incomplete, with the same administrator requirements and status language as GitHub
- store self-hosted client and webhook credentials in the encrypted deployment environment while keeping runtime environment variables authoritative
- resolve saved credentials in the OAuth and webhook paths, and replace legacy dynamically registered clients during reconnect
- require an existing workspace to reconnect when its OAuth client changes so old refresh tokens are not reused
- document the new self-hosted flow

## User flow

1. An administrator selects **Set it up** when Linear OAuth is missing or incomplete.
2. Roomote opens Linear’s private app form with the shared **roomote-<deployment-hostname>** name plus the callback URL, webhook URL, and AgentSessionEvent subscription pre-filled.
3. The administrator copies the client ID, client secret, and webhook secret back into Roomote.
4. Roomote encrypts the values and exposes **Enable Linear**. If client credentials replaced an existing app, the old workspace connection is cleared and must be approved again.

Non-admins see the same contact-an-administrator guidance used by GitHub. Deployments configured through runtime environment variables keep using those values and do not expose a setup action.

Linear still differs where its platform requires it: its manifest creates a private app and Linear requires the generated credentials to be copied back manually.

## Screenshots

**Missing Linear credentials**

<img width="410" height="175" alt="Linear integration showing the Set it up action" src="https://github.com/user-attachments/assets/6e98f3d9-cbed-4858-a168-bb8e610a0849" />

**Guided setup**

<img width="390" height="560" alt="Linear OAuth setup dialog" src="https://github.com/user-attachments/assets/da1db150-ff9e-4ac1-ba2b-b0d02a3bbeac" />

## Validation

- pnpm lint
- pnpm check-types:fast
- pnpm knip
- 79 focused web tests covering shared app naming, setup UX, manifest generation, encrypted credential resolution, and legacy OAuth client replacement
- 11 focused Linear API tests covering webhook secret resolution and routing behavior
- clean-restarted the web service and verified both local and public integration pages return 200
