### PR TITLE
[Fix] Hide admin-only Slack/Linear connect cards from members

### DIFF
--- a/apps/web/src/app/(authenticated)/home/OnboardingCard.tsx
+++ b/apps/web/src/app/(authenticated)/home/OnboardingCard.tsx
@@ -264,7 +264,8 @@ export function OnboardingCard() {
         })();
       },
       disabled: connectSlack.isPending,
-      visible: !slackPending && !slackInstallation,
+      // slack.connectApp is admin-gated server-side.
+      visible: isAdmin && !slackPending && !slackInstallation,
     },
     {
       id: 'linear',
@@ -290,7 +291,8 @@ export function OnboardingCard() {
         })();
       },
       disabled: connectLinear.isPending,
-      visible: !linearPending && !linearInstallation,
+      // linear.connectApp is admin-gated server-side.
+      visible: isAdmin && !linearPending && !linearInstallation,
     },
     {
       id: 'github-account',


### PR DESCRIPTION
## Problem

The home page onboarding cards **"Chat with Roomote on Slack"** and **"Assign tasks to agents from Linear"** in `OnboardingCard.tsx` are shown to every signed-in user, but their "Do it" actions call `slack.connectApp` / `linear.connectApp`, which are admin-gated server-side (`assertAdminResult`) and return `{ success: false, error: 'Unauthorized' }` for members. A member clicking "Do it" hits a dead end with no path forward.

Repro: with a `role='member'` user and no active Slack installation, load `/` — the Slack card shows, and clicking "Do it" POSTs `slack.connectApp`, which returns `Unauthorized`.

## Fix

Gate both cards on `isAdmin` (already available in the component), consistent with how the deployment-scoped MCP cards in the same file are gated. Members instead see the next applicable card (e.g. the member-appropriate "Link your GitHub so Roomote acts as you").

Other cards in the file were checked for the same pattern: the GitHub link card uses the non-admin-gated personal linking mutation, the promoted MCP cards already filter deployment-scoped integrations on `isAdmin`, and the automations card is already effectively hidden for members because `automations.onboardingStatus` throws for non-admins.

## Verification

Verified locally against a running instance with the Slack installation deactivated:
- **Admin:** the Slack card still appears (no regression).
- **Member:** the Slack and Linear cards no longer appear; the GitHub link card correctly takes their place.
- `check-types:fast`, oxlint, and oxfmt pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)