### PR TITLE
Allow administrators to reconfigure Linear OAuth

### DIFF
--- a/apps/docs/integrations/linear.mdx
+++ b/apps/docs/integrations/linear.mdx
@@ -29,6 +29,13 @@ priority, or discussion.
     `R_LINEAR_CLIENT_SECRET`, and `R_LINEAR_WEBHOOK_SECRET` in the runtime
     environment continue to use those values and skip the in-app setup.
   </Step>
+  <Step title="Update or remove saved credentials">
+    A deployment administrator can return to **Settings > Integrations** and
+    select **Configure** on Linear. Saving a new client ID or client secret
+    disconnects the current workspace so it can be authorized again. Removing
+    saved credentials disables Linear but does not delete the app in Linear.
+    Credentials managed by the deployment environment must be changed there.
+  </Step>
   <Step title="Link your user account">
     Link your Linear identity when prompted so Roomote can associate issue
     activity with your Roomote user.

--- a/apps/web/src/components/settings/Integrations.test.tsx
+++ b/apps/web/src/components/settings/Integrations.test.tsx
@@ -62,9 +62,21 @@ const state = vi.hoisted(() => ({
     webhookUrl: 'https://roomote.example/api/webhooks/linear',
     manifestUrl: 'https://linear.app/settings/api/applications/new?manifest=x',
     fields: {
-      clientId: { configured: false, managedByEnvironment: false },
-      clientSecret: { configured: false, managedByEnvironment: false },
-      webhookSecret: { configured: false, managedByEnvironment: false },
+      clientId: {
+        configured: false,
+        managedByEnvironment: false,
+        savedInRoomote: false,
+      },
+      clientSecret: {
+        configured: false,
+        managedByEnvironment: false,
+        savedInRoomote: false,
+      },
+      webhookSecret: {
+        configured: false,
+        managedByEnvironment: false,
+        savedInRoomote: false,
+      },
     },
   },
   linearRedirectPath: '',
@@ -84,6 +96,7 @@ const { mutations, selectMock } = vi.hoisted(() => ({
     saveSnowflakeConnection: vi.fn(),
     saveVercelConnection: vi.fn(),
     saveLinearOauthSetup: vi.fn(),
+    removeLinearOauthSetup: vi.fn(),
   },
   selectMock: {
     latestOnValueChange: null as null | ((value: string) => void),
@@ -174,6 +187,10 @@ vi.mock('@/hooks/linear', () => ({
   useSaveLinearOauthSetup: () => ({
     isPending: false,
     mutate: mutations.saveLinearOauthSetup,
+  }),
+  useRemoveLinearOauthSetup: () => ({
+    isPending: false,
+    mutate: mutations.removeLinearOauthSetup,
   }),
 }));
 
@@ -426,6 +443,23 @@ describe('Integrations settings', () => {
     state.featureFlags = {};
     state.snowflakeConnection = null;
     state.searchParams = '';
+    state.linearOauthSetup.fields = {
+      clientId: {
+        configured: false,
+        managedByEnvironment: false,
+        savedInRoomote: false,
+      },
+      clientSecret: {
+        configured: false,
+        managedByEnvironment: false,
+        savedInRoomote: false,
+      },
+      webhookSecret: {
+        configured: false,
+        managedByEnvironment: false,
+        savedInRoomote: false,
+      },
+    };
   });
 
   it('returns Linear OAuth to a service-specific integrations URL', () => {
@@ -501,7 +535,7 @@ describe('Integrations settings', () => {
     expect(screen.getByLabelText('Webhook secret')).toBeInTheDocument();
   });
 
-  it('only offers app creation while Linear is unconfigured', () => {
+  it('offers administrators configuration access after Linear is configured', () => {
     state.linearInstallation = null;
     state.oauthReadiness = [{ mcpId: 'linear', status: 'ready' }];
 
@@ -510,9 +544,101 @@ describe('Integrations settings', () => {
     expect(
       screen.queryByRole('button', { name: 'Set up Linear' }),
     ).not.toBeInTheDocument();
+    const configureButton = screen.getByRole('button', {
+      name: 'Configure Linear',
+    });
+    expect(configureButton).toBeInTheDocument();
+    expect(configureButton).not.toHaveTextContent('Configure');
     expect(
       screen.getByRole('button', { name: 'Enable Linear' }),
     ).toBeInTheDocument();
+  });
+
+  it('does not offer Linear credential configuration to non-admins', () => {
+    state.isAdmin = false;
+
+    render(<Integrations />);
+
+    expect(
+      screen.queryByRole('button', { name: 'Configure Linear' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('removes saved Linear credentials after confirmation', () => {
+    state.linearInstallation = null;
+    state.linearOauthSetup.fields = {
+      clientId: {
+        configured: true,
+        managedByEnvironment: false,
+        savedInRoomote: true,
+      },
+      clientSecret: {
+        configured: true,
+        managedByEnvironment: false,
+        savedInRoomote: true,
+      },
+      webhookSecret: {
+        configured: true,
+        managedByEnvironment: false,
+        savedInRoomote: true,
+      },
+    };
+    mutations.removeLinearOauthSetup.mockImplementation((_variables, options) =>
+      options?.onSuccess?.({ success: true }),
+    );
+
+    render(<Integrations />);
+    fireEvent.click(screen.getByRole('button', { name: 'Configure Linear' }));
+
+    expect(
+      screen.getByRole('heading', { name: 'Configure Linear' }),
+    ).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Remove saved credentials' }),
+    );
+    expect(
+      screen.getByRole('heading', {
+        name: 'Remove saved Linear credentials?',
+      }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove credentials' }));
+
+    expect(mutations.removeLinearOauthSetup).toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalledWith(
+      'Saved Linear OAuth credentials removed.',
+    );
+  });
+
+  it('does not offer to remove environment-managed Linear credentials', () => {
+    state.linearInstallation = null;
+    state.linearOauthSetup.fields = {
+      clientId: {
+        configured: true,
+        managedByEnvironment: true,
+        savedInRoomote: false,
+      },
+      clientSecret: {
+        configured: true,
+        managedByEnvironment: true,
+        savedInRoomote: false,
+      },
+      webhookSecret: {
+        configured: true,
+        managedByEnvironment: true,
+        savedInRoomote: false,
+      },
+    };
+
+    render(<Integrations />);
+    fireEvent.click(screen.getByRole('button', { name: 'Configure Linear' }));
+
+    expect(
+      screen.queryByRole('button', { name: 'Remove saved credentials' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getAllByText('Managed by the deployment environment.'),
+    ).toHaveLength(3);
   });
 
   it('offers setup for a legacy workspace when deployment credentials are missing', () => {

--- a/apps/web/src/components/settings/Integrations.tsx
+++ b/apps/web/src/components/settings/Integrations.tsx
@@ -538,7 +538,7 @@ function IntegrationCard({ item }: { item: IntegrationItem }) {
       </CardHeader>
 
       {item.status || footerActions.length > 0 ? (
-        <CardContent className="p-">
+        <CardContent>
           <div className="flex gap-3 p-0">
             <div
               className={`mt-0.5 ${iconColumnWidthClass} shrink-0`}
@@ -556,7 +556,7 @@ function IntegrationCard({ item }: { item: IntegrationItem }) {
                 </div>
               )}
               {footerActions.length > 0 ? (
-                <div className="flex gap-2">
+                <div className="-ml-4 flex gap-2">
                   {footerActions.map((action) => (
                     <Button
                       key={action.ariaLabel}

--- a/apps/web/src/components/settings/Integrations.tsx
+++ b/apps/web/src/components/settings/Integrations.tsx
@@ -1146,7 +1146,7 @@ export function Integrations() {
   const linearOauthUnavailable =
     linearOauthStatus === 'missing' || linearOauthStatus === 'partial';
   const linearOauthSetup = useLinearOauthSetup(
-    isAdmin && linearOauthUnavailable,
+    isAdmin && (linearOauthUnavailable || isLinearOauthSetupOpen),
   );
   const setDeploymentEnabled = useSetDeploymentMcpEnabled();
   const userMcpConnections = useUserMcpConnections();
@@ -1290,6 +1290,7 @@ export function Integrations() {
       (userMcpConnections.data ?? []).map((entry) => [entry.mcpId, entry]),
     );
     const canSetUpLinearOauth = isAdmin && linearOauthUnavailable;
+    const canConfigureLinearOauth = isAdmin && !linearOauthUnavailable;
     const canReconnectLinear =
       isAdmin && Boolean(linearInstallation.data) && !linearOauthUnavailable;
     const startLinearConnection = () => {
@@ -1370,6 +1371,15 @@ export function Integrations() {
                 icon: <RefreshCw />,
               }
             : undefined,
+        utilityAction: canConfigureLinearOauth
+          ? {
+              label: 'Configure credentials',
+              ariaLabel: 'Configure Linear',
+              onAction: () => setIsLinearOauthSetupOpen(true),
+              isPending: isLinearOauthSetupOpen && linearOauthSetup.isPending,
+              icon: <Settings2 />,
+            }
+          : undefined,
         onAction: linearOauthUnavailable
           ? undefined
           : () => {
@@ -1632,6 +1642,7 @@ export function Integrations() {
     oauthReadiness.isPending,
     isAdmin,
     isGrafanaDialogOpen,
+    isLinearOauthSetupOpen,
     saveAsanaConnection.isPending,
     saveGrafanaConnection.isPending,
     saveVercelConnection.isPending,

--- a/apps/web/src/components/settings/LinearOauthSetupDialog.tsx
+++ b/apps/web/src/components/settings/LinearOauthSetupDialog.tsx
@@ -5,7 +5,10 @@ import Link from 'next/link';
 import { toast } from 'sonner';
 
 import { DOCS_LINEAR_INTEGRATION_URL } from '@/lib/docs';
-import { useSaveLinearOauthSetup } from '@/hooks/linear';
+import {
+  useRemoveLinearOauthSetup,
+  useSaveLinearOauthSetup,
+} from '@/hooks/linear';
 import {
   Alert,
   AlertDescription,
@@ -28,6 +31,7 @@ import {
 type SetupFieldStatus = {
   configured: boolean;
   managedByEnvironment: boolean;
+  savedInRoomote: boolean;
 };
 
 type LinearOauthSetupDetails = {
@@ -94,7 +98,9 @@ function CredentialField({
   onChange: (value: string) => void;
 }) {
   const helperText = status.managedByEnvironment
-    ? 'Managed by the deployment environment.'
+    ? status.savedInRoomote
+      ? 'Managed by the deployment environment. A saved fallback is also stored in Roomote.'
+      : 'Managed by the deployment environment.'
     : status.configured
       ? 'Already saved. Leave blank to keep the current value.'
       : 'Required.';
@@ -136,12 +142,15 @@ export function LinearOauthSetupDialog({
 }) {
   const [form, setForm] = useState<LinearOauthForm>(EMPTY_FORM);
   const [formError, setFormError] = useState<string | null>(null);
+  const [removeConfirmationOpen, setRemoveConfirmationOpen] = useState(false);
   const saveSetup = useSaveLinearOauthSetup();
+  const removeSetup = useRemoveLinearOauthSetup();
 
   useEffect(() => {
     if (open) {
       setForm(EMPTY_FORM);
       setFormError(null);
+      setRemoveConfirmationOpen(false);
     }
   }, [open]);
 
@@ -171,138 +180,217 @@ export function LinearOauthSetupDialog({
   };
 
   const publicUrlUsesHttps = setup?.webhookUrl.startsWith('https://') ?? true;
+  const fieldStatuses = setup ? Object.values(setup.fields) : [];
+  const hasConfiguredCredentials = fieldStatuses.some(
+    (field) => field.configured,
+  );
+  const hasSavedCredentials = fieldStatuses.some(
+    (field) => field.savedInRoomote,
+  );
+
+  const remove = () => {
+    removeSetup.mutate(undefined, {
+      onSuccess: () => {
+        toast.success('Saved Linear OAuth credentials removed.');
+        setRemoveConfirmationOpen(false);
+        onOpenChange(false);
+      },
+      onError: (error) => {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : 'Failed to remove saved Linear OAuth credentials.',
+        );
+      },
+    });
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent size="lg">
-        <DialogHeader>
-          <DialogTitle>Set up Linear</DialogTitle>
-          <DialogDescription>
-            Create a Linear app for this deployment, then connect it to your
-            workspace.
-          </DialogDescription>
-        </DialogHeader>
-
-        {!setup ? (
-          <div className="space-y-4 py-2">
-            <Skeleton className="h-20 w-full" />
-            <Skeleton className="h-32 w-full" />
-          </div>
-        ) : (
-          <div className="space-y-6 py-2">
-            {!publicUrlUsesHttps ? (
-              <Alert variant="destructive">
-                <TriangleAlert className="size-4" />
-                <AlertDescription>
-                  Linear requires a public HTTPS webhook URL. Configure
-                  R_PUBLIC_URL with your deployment&apos;s HTTPS address before
-                  creating the app.
-                </AlertDescription>
-              </Alert>
-            ) : null}
-
-            <section className="space-y-3">
-              <div>
-                <h3 className="font-medium">
-                  Create a Linear app for this deployment.
-                </h3>
-                <p className="text-sm text-muted-foreground">
-                  Self-hosted Roomote needs its own Linear app. The manifest
-                  pre-fills the callback, webhook, and agent event settings.
-                  Review it in Linear, then create the app.
-                </p>
-              </div>
+      <DialogContent size={removeConfirmationOpen ? 'sm' : 'lg'}>
+        {removeConfirmationOpen ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Remove saved Linear credentials?</DialogTitle>
+              <DialogDescription>
+                This disables Linear and removes credentials stored by Roomote.
+                It does not delete the app in Linear or change credentials
+                managed by the deployment environment.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
               <Button
                 type="button"
                 variant="outline"
-                disabled={!publicUrlUsesHttps}
-                onClick={() =>
-                  window.open(
-                    setup.manifestUrl,
-                    '_blank',
-                    'noopener,noreferrer',
-                  )
-                }
+                onClick={() => setRemoveConfirmationOpen(false)}
               >
-                Create Linear app
-                <ExternalLink />
+                Cancel
               </Button>
-              <div className="grid gap-3">
-                <EndpointField label="Callback URL" value={setup.callbackUrl} />
-                <EndpointField label="Webhook URL" value={setup.webhookUrl} />
-              </div>
-            </section>
+              <Button
+                type="button"
+                variant="destructive"
+                disabled={removeSetup.isPending}
+                onClick={remove}
+              >
+                {removeSetup.isPending ? <Spinner size="sm" /> : null}
+                Remove credentials
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>
+                {hasConfiguredCredentials
+                  ? 'Configure Linear'
+                  : 'Set up Linear'}
+              </DialogTitle>
+              <DialogDescription>
+                {hasConfiguredCredentials
+                  ? 'Update or remove the Linear app credentials saved for this deployment.'
+                  : 'Create a Linear app for this deployment, then connect it to your workspace.'}
+              </DialogDescription>
+            </DialogHeader>
 
-            <section className="space-y-3">
-              <div>
-                <h3 className="font-medium">Then save the credentials.</h3>
-                <p className="text-sm text-muted-foreground">
-                  Copy these values from the new app&apos;s settings. Roomote
-                  encrypts values saved here. After they are saved, Enable
-                  Linear connects the app to your workspace.
-                </p>
+            {!setup ? (
+              <div className="space-y-4 py-2">
+                <Skeleton className="h-20 w-full" />
+                <Skeleton className="h-32 w-full" />
               </div>
-              <div className="grid gap-4 sm:grid-cols-2">
-                <CredentialField
-                  id="linear-client-id"
-                  label="Client ID"
-                  value={form.clientId}
-                  status={setup.fields.clientId}
-                  onChange={(value) => updateField('clientId', value)}
-                />
-                <CredentialField
-                  id="linear-client-secret"
-                  label="Client secret"
-                  value={form.clientSecret}
-                  status={setup.fields.clientSecret}
-                  secret
-                  onChange={(value) => updateField('clientSecret', value)}
-                />
-                <CredentialField
-                  id="linear-webhook-secret"
-                  label="Webhook secret"
-                  value={form.webhookSecret}
-                  status={setup.fields.webhookSecret}
-                  secret
-                  onChange={(value) => updateField('webhookSecret', value)}
-                />
+            ) : (
+              <div className="space-y-6 py-2">
+                {!publicUrlUsesHttps ? (
+                  <Alert variant="destructive">
+                    <TriangleAlert className="size-4" />
+                    <AlertDescription>
+                      Linear requires a public HTTPS webhook URL. Configure
+                      R_PUBLIC_URL with your deployment&apos;s HTTPS address
+                      before creating the app.
+                    </AlertDescription>
+                  </Alert>
+                ) : null}
+
+                <section className="space-y-3">
+                  <div>
+                    <h3 className="font-medium">
+                      Create a Linear app for this deployment.
+                    </h3>
+                    <p className="text-sm text-muted-foreground">
+                      Self-hosted Roomote needs its own Linear app. The manifest
+                      pre-fills the callback, webhook, and agent event settings.
+                      Review it in Linear, then create the app.
+                    </p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={!publicUrlUsesHttps}
+                    onClick={() =>
+                      window.open(
+                        setup.manifestUrl,
+                        '_blank',
+                        'noopener,noreferrer',
+                      )
+                    }
+                  >
+                    Create Linear app
+                    <ExternalLink />
+                  </Button>
+                  <div className="grid gap-3">
+                    <EndpointField
+                      label="Callback URL"
+                      value={setup.callbackUrl}
+                    />
+                    <EndpointField
+                      label="Webhook URL"
+                      value={setup.webhookUrl}
+                    />
+                  </div>
+                </section>
+
+                <section className="space-y-3">
+                  <div>
+                    <h3 className="font-medium">Then save the credentials.</h3>
+                    <p className="text-sm text-muted-foreground">
+                      Copy these values from the new app&apos;s settings.
+                      Roomote encrypts values saved here. After they are saved,
+                      Enable Linear connects the app to your workspace.
+                    </p>
+                  </div>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <CredentialField
+                      id="linear-client-id"
+                      label="Client ID"
+                      value={form.clientId}
+                      status={setup.fields.clientId}
+                      onChange={(value) => updateField('clientId', value)}
+                    />
+                    <CredentialField
+                      id="linear-client-secret"
+                      label="Client secret"
+                      value={form.clientSecret}
+                      status={setup.fields.clientSecret}
+                      secret
+                      onChange={(value) => updateField('clientSecret', value)}
+                    />
+                    <CredentialField
+                      id="linear-webhook-secret"
+                      label="Webhook secret"
+                      value={form.webhookSecret}
+                      status={setup.fields.webhookSecret}
+                      secret
+                      onChange={(value) => updateField('webhookSecret', value)}
+                    />
+                  </div>
+                  {formError ? (
+                    <p className="text-sm text-destructive">{formError}</p>
+                  ) : null}
+                </section>
               </div>
-              {formError ? (
-                <p className="text-sm text-destructive">{formError}</p>
-              ) : null}
-            </section>
-          </div>
+            )}
+
+            <DialogFooter className="gap-2 sm:justify-between">
+              <div className="flex flex-wrap gap-2">
+                <Button variant="ghost" asChild>
+                  <Link
+                    href={DOCS_LINEAR_INTEGRATION_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Setup guide
+                    <ExternalLink />
+                  </Link>
+                </Button>
+                {hasSavedCredentials ? (
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    onClick={() => setRemoveConfirmationOpen(true)}
+                  >
+                    Remove saved credentials
+                  </Button>
+                ) : null}
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => onOpenChange(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  disabled={!setup || saveSetup.isPending}
+                  onClick={save}
+                >
+                  {saveSetup.isPending ? <Spinner size="sm" /> : null}
+                  Save credentials
+                </Button>
+              </div>
+            </DialogFooter>
+          </>
         )}
-
-        <DialogFooter className="gap-2 sm:justify-between">
-          <Button variant="ghost" asChild>
-            <Link
-              href={DOCS_LINEAR_INTEGRATION_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Setup guide
-              <ExternalLink />
-            </Link>
-          </Button>
-          <div className="flex justify-end gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              disabled={!setup || saveSetup.isPending}
-              onClick={save}
-            >
-              {saveSetup.isPending ? <Spinner size="sm" /> : null}
-              Save credentials
-            </Button>
-          </div>
-        </DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/src/components/settings/LinearOauthSetupDialog.tsx
+++ b/apps/web/src/components/settings/LinearOauthSetupDialog.tsx
@@ -276,9 +276,9 @@ export function LinearOauthSetupDialog({
                       Create a Linear app for this deployment.
                     </h3>
                     <p className="text-sm text-muted-foreground">
-                      Self-hosted Roomote needs its own Linear app. The manifest
-                      pre-fills the callback, webhook, and agent event settings.
-                      Review it in Linear, then create the app.
+                      Roomote needs its own Linear app. The manifest pre-fills
+                      the callback, webhook, and agent event settings. Review it
+                      in Linear, then create the app.
                     </p>
                   </div>
                   <Button

--- a/apps/web/src/hooks/linear/index.ts
+++ b/apps/web/src/hooks/linear/index.ts
@@ -3,4 +3,5 @@ export { useConnectLinear } from './useConnectLinear';
 export { useDisconnectLinear } from './useDisconnectLinear';
 export { useLinearOauthSetup } from './useLinearOauthSetup';
 export { useSaveLinearOauthSetup } from './useSaveLinearOauthSetup';
+export { useRemoveLinearOauthSetup } from './useRemoveLinearOauthSetup';
 export { useAuthenticateLinearAccount } from './useAuthenticateLinearAccount';

--- a/apps/web/src/hooks/linear/useInvalidateLinearOauthSetup.ts
+++ b/apps/web/src/hooks/linear/useInvalidateLinearOauthSetup.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+
+import { useTRPC } from '@/trpc/client';
+
+export function useInvalidateLinearOauthSetup() {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  return async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: trpc.linear.oauthSetup.queryKey(),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.mcpConnections.oauthReadiness.queryKey(),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.linear.installation.queryKey(),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.mcpConnections.deploymentEnablements.queryKey(),
+      }),
+    ]);
+  };
+}

--- a/apps/web/src/hooks/linear/useRemoveLinearOauthSetup.ts
+++ b/apps/web/src/hooks/linear/useRemoveLinearOauthSetup.ts
@@ -6,12 +6,12 @@ import { useTRPC } from '@/trpc/client';
 
 import { useInvalidateLinearOauthSetup } from './useInvalidateLinearOauthSetup';
 
-export function useSaveLinearOauthSetup() {
+export function useRemoveLinearOauthSetup() {
   const trpc = useTRPC();
   const invalidateLinearOauthSetup = useInvalidateLinearOauthSetup();
 
   return useMutation(
-    trpc.linear.saveOauthSetup.mutationOptions({
+    trpc.linear.removeOauthSetup.mutationOptions({
       onSuccess: invalidateLinearOauthSetup,
     }),
   );

--- a/apps/web/src/trpc/commands/linear/index.test.ts
+++ b/apps/web/src/trpc/commands/linear/index.test.ts
@@ -1,11 +1,17 @@
 const {
   envState,
   deletedConnectionsState,
+  persistedEnvVarNamesState,
+  deleteDeploymentEnvironmentVariablesMock,
+  getPersistedEnvironmentVariableNamesMock,
   resolveDeploymentEnvVarMock,
   upsertDeploymentEnvironmentVariablesMock,
 } = vi.hoisted(() => ({
   envState: {} as Record<string, string | undefined>,
   deletedConnectionsState: [] as Array<{ id: string }>,
+  persistedEnvVarNamesState: [] as string[],
+  deleteDeploymentEnvironmentVariablesMock: vi.fn(),
+  getPersistedEnvironmentVariableNamesMock: vi.fn(),
   resolveDeploymentEnvVarMock: vi.fn(),
   upsertDeploymentEnvironmentVariablesMock: vi.fn(),
 }));
@@ -15,6 +21,10 @@ vi.mock('@/lib/server/get-public-app-url', () => ({
   getPublicAppUrl: () => 'https://roomote.example',
 }));
 vi.mock('../environment-variables', () => ({
+  deleteDeploymentEnvironmentVariables:
+    deleteDeploymentEnvironmentVariablesMock,
+  getPersistedEnvironmentVariableNames:
+    getPersistedEnvironmentVariableNamesMock,
   upsertDeploymentEnvironmentVariables:
     upsertDeploymentEnvironmentVariablesMock,
 }));
@@ -54,6 +64,7 @@ vi.mock('@roomote/sdk/server', () => ({
 
 import {
   getLinearOauthSetupCommand,
+  removeLinearOauthSetupCommand,
   saveLinearOauthSetupCommand,
 } from './index';
 
@@ -69,6 +80,10 @@ describe('Linear OAuth setup', () => {
       delete envState[key];
     }
     deletedConnectionsState.splice(0);
+    persistedEnvVarNamesState.splice(0);
+    getPersistedEnvironmentVariableNamesMock.mockImplementation(
+      async () => persistedEnvVarNamesState,
+    );
     resolveDeploymentEnvVarMock.mockResolvedValue(null);
   });
 
@@ -99,7 +114,36 @@ describe('Linear OAuth setup', () => {
     });
   });
 
-  it('requires an administrator to view or save app setup', async () => {
+  it('identifies credentials saved in Roomote separately from runtime values', async () => {
+    persistedEnvVarNamesState.push(
+      'R_LINEAR_CLIENT_ID',
+      'R_LINEAR_CLIENT_SECRET',
+    );
+    envState.R_LINEAR_CLIENT_ID = 'runtime-client';
+    resolveDeploymentEnvVarMock.mockResolvedValue('configured');
+
+    const setup = await getLinearOauthSetupCommand(ADMIN);
+
+    expect(setup.fields).toEqual({
+      clientId: {
+        configured: true,
+        managedByEnvironment: true,
+        savedInRoomote: true,
+      },
+      clientSecret: {
+        configured: true,
+        managedByEnvironment: false,
+        savedInRoomote: true,
+      },
+      webhookSecret: {
+        configured: true,
+        managedByEnvironment: false,
+        savedInRoomote: false,
+      },
+    });
+  });
+
+  it('requires an administrator to view, save, or remove app setup', async () => {
     const nonAdmin = { ...ADMIN, isAdmin: false };
 
     await expect(getLinearOauthSetupCommand(nonAdmin)).rejects.toThrow(
@@ -112,6 +156,25 @@ describe('Linear OAuth setup', () => {
         webhookSecret: 'webhook-secret',
       }),
     ).rejects.toThrow('Unauthorized');
+    await expect(removeLinearOauthSetupCommand(nonAdmin)).rejects.toThrow(
+      'Unauthorized',
+    );
+  });
+
+  it('removes saved credentials and disconnects the current workspace', async () => {
+    deletedConnectionsState.push({ id: 'linear-connection' });
+
+    const result = await removeLinearOauthSetupCommand(ADMIN);
+
+    expect(deleteDeploymentEnvironmentVariablesMock).toHaveBeenCalledWith(
+      expect.anything(),
+      [
+        'R_LINEAR_CLIENT_ID',
+        'R_LINEAR_CLIENT_SECRET',
+        'R_LINEAR_WEBHOOK_SECRET',
+      ],
+    );
+    expect(result).toEqual({ success: true });
   });
 
   it('saves all three credentials in the encrypted deployment store', async () => {

--- a/apps/web/src/trpc/commands/linear/index.ts
+++ b/apps/web/src/trpc/commands/linear/index.ts
@@ -10,6 +10,7 @@ import { clearLinearDeploymentConnection } from './oauth-setup';
 
 export {
   getLinearOauthSetupCommand,
+  removeLinearOauthSetupCommand,
   saveLinearOauthSetupCommand,
 } from './oauth-setup';
 

--- a/apps/web/src/trpc/commands/linear/oauth-setup.ts
+++ b/apps/web/src/trpc/commands/linear/oauth-setup.ts
@@ -18,7 +18,11 @@ import {
 import { getPublicAppUrl } from '@/lib/server/get-public-app-url';
 import type { UserAuthSuccess } from '@/types';
 
-import { upsertDeploymentEnvironmentVariables } from '../environment-variables';
+import {
+  deleteDeploymentEnvironmentVariables,
+  getPersistedEnvironmentVariableNames,
+  upsertDeploymentEnvironmentVariables,
+} from '../environment-variables';
 
 const LINEAR_OAUTH_ENV_FIELDS = {
   clientId: 'R_LINEAR_CLIENT_ID',
@@ -130,6 +134,9 @@ export async function getLinearOauthSetupCommand(auth: UserAuthSuccess) {
   const publicOrigin = getPublicAppUrl(Env);
   const runtimeEnv = getLinearRuntimeEnv();
   const urls = buildLinearOauthSetup(publicOrigin);
+  const persistedEnvVarNames = new Set(
+    await getPersistedEnvironmentVariableNames(),
+  );
   const fieldEntries = await Promise.all(
     Object.entries(LINEAR_OAUTH_ENV_FIELDS).map(async ([field, envName]) => {
       const runtimeValue = getRuntimeEnvValue(envName);
@@ -144,6 +151,7 @@ export async function getLinearOauthSetupCommand(auth: UserAuthSuccess) {
         {
           configured: Boolean(effectiveValue),
           managedByEnvironment: Boolean(runtimeValue),
+          savedInRoomote: persistedEnvVarNames.has(envName),
         },
       ] as const;
     }),
@@ -153,9 +161,27 @@ export async function getLinearOauthSetupCommand(auth: UserAuthSuccess) {
     ...urls,
     fields: Object.fromEntries(fieldEntries) as Record<
       LinearOauthSetupField,
-      { configured: boolean; managedByEnvironment: boolean }
+      {
+        configured: boolean;
+        managedByEnvironment: boolean;
+        savedInRoomote: boolean;
+      }
     >,
   };
+}
+
+export async function removeLinearOauthSetupCommand(auth: UserAuthSuccess) {
+  assertAdmin(auth);
+
+  await db.transaction(async (tx) => {
+    await deleteDeploymentEnvironmentVariables(
+      tx,
+      Object.values(LINEAR_OAUTH_ENV_FIELDS),
+    );
+    await clearLinearDeploymentConnection(tx, auth.userId);
+  });
+
+  return { success: true as const };
 }
 
 export async function saveLinearOauthSetupCommand(

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -113,6 +113,7 @@ import {
   getLinearInstallationCommand,
   disconnectLinearAppCommand,
   getLinearOauthSetupCommand,
+  removeLinearOauthSetupCommand,
   saveLinearOauthSetupCommand,
 } from '../commands/linear';
 import { getTeamsIntegrationStatusCommand } from '../commands/teams';
@@ -1151,6 +1152,10 @@ export const appRouter = createRouter({
 
     oauthSetup: protectedProcedure.query(({ ctx: { auth } }) =>
       getLinearOauthSetupCommand(auth),
+    ),
+
+    removeOauthSetup: protectedProcedure.mutation(({ ctx: { auth } }) =>
+      removeLinearOauthSetupCommand(auth),
     ),
 
     saveOauthSetup: protectedProcedure


### PR DESCRIPTION
## Summary

- keep Linear OAuth credential management available to deployment administrators after initial configuration
- use a compact settings action so the Linear card retains the shared integration-card layout
- preserve the generic Reconnect action for connected Linear workspaces
- allow stored credentials to be replaced without exposing their current values
- add a confirmed removal flow that disables Linear and clears only credentials stored by Roomote
- keep runtime environment credentials read-only and clearly identify their source
- document the reconfiguration behavior

## Validation

- focused Linear command and integrations UI tests (65 tests)
- @roomote/web typecheck
- ESLint on changed web files
- formatting and diff checks