### PR TITLE
[Fix] Verify Microsoft Teams bot credentials before reporting them configured

### DIFF
--- a/.changeset/verify-teams-bot-credentials.md
+++ b/.changeset/verify-teams-bot-credentials.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Verify Microsoft Teams bot credentials with Microsoft before saving them, so a wrong app id, client secret, or tenant id fails the save with a message naming the field instead of reporting a configured bot that cannot authenticate. Teams settings now also reports when the saved credentials stop authenticating, and explains why the Teams app package cannot be pre-filled from a malformed App (Client) ID.

--- a/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
+++ b/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
@@ -56,6 +56,37 @@ const TELEGRAM_SETUP_HIDDEN_ENV_VAR_NAMES = new Set([
 export const MICROSOFT_APP_ID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+const MICROSOFT_APP_ID_FIELD_ENV_VAR_NAMES = new Set([
+  'R_MICROSOFT_CLIENT_ID',
+  'R_TEAMS_BOT_APP_ID',
+]);
+
+/**
+ * Inline warning shown directly under an app-id input whose value cannot be an
+ * Entra client id. The package-download note further down explains the same
+ * problem, but the feedback belongs at the field where the value was typed.
+ */
+export function getMicrosoftAppIdFormatWarning(
+  providerId: string,
+  envVarName: string,
+  value: string,
+): string | null {
+  if (
+    providerId !== 'microsoft' ||
+    !MICROSOFT_APP_ID_FIELD_ENV_VAR_NAMES.has(envVarName)
+  ) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+
+  if (!trimmed || MICROSOFT_APP_ID_PATTERN.test(trimmed)) {
+    return null;
+  }
+
+  return "This doesn't look like an Entra app ID — expected a GUID like 00000000-0000-0000-0000-000000000000.";
+}
+
 /**
  * The Teams app package embeds the bot app id, so a value that is not a GUID
  * cannot produce a usable package. Explain that instead of leaving the
@@ -243,6 +274,14 @@ function ProviderFields({
           explicitValue.length === 0 &&
           !clearedSavedValues[field.envVarName] &&
           !editingSavedValues[field.envVarName];
+        const formatWarning =
+          !isSecretField && !field.runtimeSatisfied
+            ? getMicrosoftAppIdFormatWarning(
+                provider.id,
+                field.envVarName,
+                value,
+              )
+            : null;
 
         return (
           <div
@@ -296,6 +335,9 @@ function ProviderFields({
                 />
                 {(field.runtimeSatisfied || field.savedSatisfied) && <Check />}
               </div>
+              {formatWarning ? (
+                <p className="mt-1 text-sm text-amber-600">{formatWarning}</p>
+              ) : null}
             </div>
           </div>
         );

--- a/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
+++ b/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
@@ -53,6 +53,26 @@ const TELEGRAM_SETUP_HIDDEN_ENV_VAR_NAMES = new Set([
   'R_TELEGRAM_WEBHOOK_SECRET',
 ]);
 
+export const MICROSOFT_APP_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * The Teams app package embeds the bot app id, so a value that is not a GUID
+ * cannot produce a usable package. Explain that instead of leaving the
+ * download button dead with no reason.
+ */
+export function getTeamsAppPackageUnavailableReason(
+  enteredAppId: string,
+): string | null {
+  const appId = enteredAppId.trim();
+
+  if (!appId || MICROSOFT_APP_ID_PATTERN.test(appId)) {
+    return null;
+  }
+
+  return 'That App (Client) ID is not a valid GUID, so Roomote cannot pre-fill the Teams app package. Copy the Application (client) ID from the Entra app registration overview — it looks like 00000000-0000-0000-0000-000000000000.';
+}
+
 export function getSetupVisibleFields(
   provider: ProviderStatus | null,
   options: { showMicrosoftAdvancedConfig?: boolean } = {},
@@ -292,6 +312,12 @@ type ProviderSetupExperienceProps = {
   editingSavedValues: Record<string, boolean>;
   clearedSavedValues: Record<string, boolean>;
   teamsAppPackageHref: string | null;
+  /**
+   * Why the pre-filled package cannot be built yet (e.g. the entered App
+   * (Client) ID is not a GUID). Without it the download button just goes dead
+   * with nothing to act on.
+   */
+  teamsAppPackageUnavailableReason?: string | null;
   createdSlackAppSettingsUrl?: string | null;
   createdSlackAppIconSet?: boolean | null;
   createSlackAppPending?: boolean;
@@ -687,11 +713,17 @@ function MicrosoftSetupExperience(props: ProviderSetupExperienceProps) {
               </Button>
             </div>
           ) : (
-            <div className="flex items-center gap-2">
-              <Button variant="outline" size="sm" disabled>
-                <Download />
-                Download Teams app package
-              </Button>
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <Button variant="outline" size="sm" disabled>
+                  <Download />
+                  Download Teams app package
+                </Button>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                {props.teamsAppPackageUnavailableReason ??
+                  'Enter the values above to build a pre-filled package.'}
+              </p>
             </div>
           )}
         </div>

--- a/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
+++ b/apps/web/src/app/(onboarding)/setup/ProviderSetupExperience.tsx
@@ -66,7 +66,7 @@ const MICROSOFT_APP_ID_FIELD_ENV_VAR_NAMES = new Set([
  * Entra client id. The package-download note further down explains the same
  * problem, but the feedback belongs at the field where the value was typed.
  */
-export function getMicrosoftAppIdFormatWarning(
+function getMicrosoftAppIdFormatWarning(
   providerId: string,
   envVarName: string,
   value: string,

--- a/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepAuthEnvVars.tsx
@@ -17,12 +17,11 @@ import {
   getSetupEffectiveFieldValue,
   getSetupSubmitValues,
   getSetupVisibleFields,
+  getTeamsAppPackageUnavailableReason,
+  MICROSOFT_APP_ID_PATTERN,
   ProviderSetupExperience,
 } from './ProviderSetupExperience';
 
-/** Microsoft app (client) IDs are GUIDs. */
-const MICROSOFT_APP_ID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const BOOTSTRAP_SIGN_IN_CALLBACK_PATH = '/setup';
 
 function getOAuth2ProviderId(
@@ -270,6 +269,9 @@ export function StepAuthEnvVars({
     : !bootstrapMode && teamsBotAppIdStored
       ? '/api/teams/app-package'
       : null;
+  const teamsAppPackageUnavailableReason = isMicrosoftProvider
+    ? getTeamsAppPackageUnavailableReason(enteredTeamsBotAppId)
+    : null;
   useEffect(() => {
     setCreatedSlackAppSettingsUrl(null);
     setCreatedSlackAppIconSet(null);
@@ -336,6 +338,7 @@ export function StepAuthEnvVars({
           editingSavedValues={editingSavedValues}
           clearedSavedValues={clearedSavedValues}
           teamsAppPackageHref={teamsAppPackageHref}
+          teamsAppPackageUnavailableReason={teamsAppPackageUnavailableReason}
           createdSlackAppSettingsUrl={createdSlackAppSettingsUrl}
           createdSlackAppIconSet={createdSlackAppIconSet}
           createSlackAppPending={

--- a/apps/web/src/components/settings/CommsProviderSection.test.tsx
+++ b/apps/web/src/components/settings/CommsProviderSection.test.tsx
@@ -47,6 +47,7 @@ const state = vi.hoisted(() => ({
   connectSlackUrl: 'https://slack.com/install' as string | null,
   teamsStatus: {
     botConfigured: false,
+    botCredentialCheck: { status: 'unchecked', message: null },
     botUsesTenantSpecificTokenFlow: false,
     microsoftAuthConfigured: false,
     webhookUrl: 'https://roomote.dev/api/webhooks/teams',
@@ -55,6 +56,10 @@ const state = vi.hoisted(() => ({
     primaryConversationType: null as string | null,
   } as null | {
     botConfigured: boolean;
+    botCredentialCheck: {
+      status: 'ok' | 'failed' | 'unchecked';
+      message: string | null;
+    };
     botUsesTenantSpecificTokenFlow: boolean;
     microsoftAuthConfigured: boolean;
     webhookUrl: string;
@@ -546,6 +551,7 @@ describe('CommsProviderSection', () => {
     state.connectSlackUrl = 'https://slack.com/install';
     state.teamsStatus = {
       botConfigured: false,
+      botCredentialCheck: { status: 'unchecked', message: null },
       botUsesTenantSpecificTokenFlow: false,
       microsoftAuthConfigured: false,
       webhookUrl: 'https://roomote.dev/api/webhooks/teams',
@@ -1103,6 +1109,7 @@ describe('CommsProviderSection', () => {
     it('renders bot status and Open in Teams link when configured', () => {
       state.teamsStatus = {
         botConfigured: true,
+        botCredentialCheck: { status: 'ok', message: null },
         botUsesTenantSpecificTokenFlow: true,
         microsoftAuthConfigured: true,
         webhookUrl: 'https://roomote.dev/api/webhooks/teams',
@@ -1156,6 +1163,7 @@ describe('CommsProviderSection', () => {
     it('shows bot status and app-package download when only R_TEAMS_BOT_* is configured (no Microsoft sign-in)', () => {
       state.teamsStatus = {
         botConfigured: true,
+        botCredentialCheck: { status: 'ok', message: null },
         botUsesTenantSpecificTokenFlow: true,
         microsoftAuthConfigured: false,
         webhookUrl: 'https://roomote.dev/api/webhooks/teams',
@@ -1192,6 +1200,7 @@ describe('CommsProviderSection', () => {
     it('nudges to send a first Teams message when the bot is configured but no conversation was captured', () => {
       state.teamsStatus = {
         botConfigured: true,
+        botCredentialCheck: { status: 'ok', message: null },
         botUsesTenantSpecificTokenFlow: true,
         microsoftAuthConfigured: true,
         webhookUrl: 'https://roomote.dev/api/webhooks/teams',
@@ -1224,6 +1233,7 @@ describe('CommsProviderSection', () => {
     it('hides the capture nudge once a primary Teams conversation exists', () => {
       state.teamsStatus = {
         botConfigured: true,
+        botCredentialCheck: { status: 'ok', message: null },
         botUsesTenantSpecificTokenFlow: true,
         microsoftAuthConfigured: true,
         webhookUrl: 'https://roomote.dev/api/webhooks/teams',
@@ -1247,6 +1257,64 @@ describe('CommsProviderSection', () => {
 
       expect(
         screen.queryByText(/has not captured a Teams conversation yet/),
+      ).not.toBeInTheDocument();
+    });
+
+    it('reports rejected credentials instead of claiming the bot is configured', () => {
+      state.teamsStatus = {
+        botConfigured: true,
+        botCredentialCheck: {
+          status: 'failed',
+          message:
+            'Microsoft rejected Client Secret Value (R_MICROSOFT_CLIENT_SECRET). AADSTS7000215: Invalid client secret provided.',
+        },
+        botUsesTenantSpecificTokenFlow: true,
+        microsoftAuthConfigured: true,
+        webhookUrl: 'https://roomote.dev/api/webhooks/teams',
+        openInTeamsUrl: 'https://teams.microsoft.com/l/chat/0/0?users=28%3Abot',
+        primaryConversationReady: false,
+        primaryConversationType: null,
+      };
+
+      render(
+        <CommsProviderSection
+          provider={buildMicrosoftProvider({
+            savedSatisfied: true,
+            setupSatisfied: true,
+          })}
+          onSave={vi.fn()}
+          onClear={vi.fn()}
+          savePending={false}
+          clearPending={false}
+        />,
+      );
+
+      expect(screen.getByText(/AADSTS7000215/)).toBeInTheDocument();
+      expect(screen.queryByText(/^Bot configured\./)).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/has not captured a Teams conversation yet/),
+      ).not.toBeInTheDocument();
+    });
+
+    it('explains why the Teams app package cannot be pre-filled from a malformed app id', () => {
+      render(
+        <CommsProviderSection
+          provider={buildMicrosoftProvider()}
+          onSave={vi.fn()}
+          onClear={vi.fn()}
+          savePending={false}
+          clearPending={false}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Set it up' }));
+      fireEvent.change(screen.getByPlaceholderText('Microsoft Client ID'), {
+        target: { value: 'not-a-guid' },
+      });
+
+      expect(screen.getByText(/not a valid GUID/)).toBeInTheDocument();
+      expect(
+        screen.queryByRole('link', { name: /Download Teams app package/ }),
       ).not.toBeInTheDocument();
     });
   });

--- a/apps/web/src/components/settings/CommsProviderSection.test.tsx
+++ b/apps/web/src/components/settings/CommsProviderSection.test.tsx
@@ -1312,9 +1312,35 @@ describe('CommsProviderSection', () => {
         target: { value: 'not-a-guid' },
       });
 
+      // Inline, next to the field where the value was typed…
+      expect(
+        screen.getByText(/doesn't look like an Entra app ID/),
+      ).toBeInTheDocument();
+      // …and again at the download button it disables further down.
       expect(screen.getByText(/not a valid GUID/)).toBeInTheDocument();
       expect(
         screen.queryByRole('link', { name: /Download Teams app package/ }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not warn about a well-formed App (Client) ID', () => {
+      render(
+        <CommsProviderSection
+          provider={buildMicrosoftProvider()}
+          onSave={vi.fn()}
+          onClear={vi.fn()}
+          savePending={false}
+          clearPending={false}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Set it up' }));
+      fireEvent.change(screen.getByPlaceholderText('Microsoft Client ID'), {
+        target: { value: '00000000-0000-0000-0000-000000000001' },
+      });
+
+      expect(
+        screen.queryByText(/doesn't look like an Entra app ID/),
       ).not.toBeInTheDocument();
     });
   });

--- a/apps/web/src/components/settings/CommsProviderSection.tsx
+++ b/apps/web/src/components/settings/CommsProviderSection.tsx
@@ -18,6 +18,8 @@ import {
   getSetupEffectiveFieldValue,
   getSetupSubmitValues,
   getSetupVisibleFields,
+  getTeamsAppPackageUnavailableReason,
+  MICROSOFT_APP_ID_PATTERN,
   ProviderSetupExperience,
 } from '@/app/(onboarding)/setup/ProviderSetupExperience';
 
@@ -84,9 +86,6 @@ import {
 import { Section } from './Section';
 import { TelegramLinkAccountStep } from './TelegramLinkAccountStep';
 import { DiscordSetupStatus } from './DiscordSetupStatus';
-
-const MICROSOFT_APP_ID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function getProviderIconId(providerId: CommsProviderId): string {
   return providerId === 'microsoft' ? 'teams' : providerId;
@@ -178,8 +177,13 @@ function TeamsBotStatus() {
   const teamsPrimaryConversationReady = Boolean(
     teamsStatus?.primaryConversationReady,
   );
+  const teamsCredentialCheck = teamsStatus?.botCredentialCheck ?? null;
+  const teamsCredentialsRejected = teamsCredentialCheck?.status === 'failed';
 
-  const statusCopy = teamsBotConfigured ? (
+  const statusCopy = teamsCredentialsRejected ? (
+    (teamsCredentialCheck?.message ??
+    'Microsoft rejected the saved Teams bot credentials.')
+  ) : teamsBotConfigured ? (
     teamsStatus?.microsoftAuthConfigured ? (
       <>
         Bot configured. Team members can link Microsoft Teams accounts from{' '}
@@ -208,14 +212,25 @@ function TeamsBotStatus() {
   return (
     <div className="space-y-2 mt-4">
       <div className="flex items-start gap-2">
-        {!teamsBotConfigured ? (
+        {!teamsBotConfigured || teamsCredentialsRejected ? (
           <TriangleAlert className="size-4 mt-0.5 shrink-0 text-amber-600" />
         ) : (
           <Info className="size-4 mt-0.5 shrink-0" />
         )}
         <p className="text-sm text-muted-foreground">{statusCopy}</p>
       </div>
-      {teamsBotConfigured && !teamsPrimaryConversationReady ? (
+      {teamsCredentialCheck?.status === 'unchecked' &&
+      teamsCredentialCheck.message ? (
+        <div className="flex items-start gap-2">
+          <Info className="size-4 mt-0.5 shrink-0" />
+          <p className="text-sm text-muted-foreground">
+            {teamsCredentialCheck.message}
+          </p>
+        </div>
+      ) : null}
+      {teamsBotConfigured &&
+      !teamsCredentialsRejected &&
+      !teamsPrimaryConversationReady ? (
         <div className="flex items-start gap-2">
           <TriangleAlert className="size-4 mt-0.5 shrink-0 text-amber-600" />
           <p className="text-sm text-muted-foreground">
@@ -497,6 +512,9 @@ export function CommsProviderSection({
     : teamsBotAppIdStored || teamsBotConfigured
       ? '/api/teams/app-package'
       : null;
+  const teamsAppPackageUnavailableReason = isMicrosoftProvider
+    ? getTeamsAppPackageUnavailableReason(enteredTeamsBotAppId)
+    : null;
 
   const handleSave = () => {
     onSave(provider.id, getSetupSubmitValues({ provider, values }));
@@ -544,6 +562,9 @@ export function CommsProviderSection({
               editingSavedValues={editingSavedValues}
               clearedSavedValues={clearedSavedValues}
               teamsAppPackageHref={teamsAppPackageHref}
+              teamsAppPackageUnavailableReason={
+                teamsAppPackageUnavailableReason
+              }
               createdSlackAppSettingsUrl={createdSlackAppSettingsUrl}
               createdSlackAppIconSet={createdSlackAppIconSet}
               createSlackAppPending={createSlackApp.isPending}

--- a/apps/web/src/trpc/commands/comms/index.test.ts
+++ b/apps/web/src/trpc/commands/comms/index.test.ts
@@ -17,6 +17,7 @@ const {
   mockTelegramRegisterWebhook,
   mockResolveDiscordRuntimeCredentials,
   mockValidateDiscordBotToken,
+  mockValidateTeamsBotCredentials,
   mockDiscordRegisterCommands,
   mockDiscordListGuilds,
   mockDiscordListGuildChannels,
@@ -55,6 +56,7 @@ const {
     identityErrorCode: null,
   })),
   mockValidateDiscordBotToken: vi.fn(),
+  mockValidateTeamsBotCredentials: vi.fn(async () => undefined),
   mockDiscordRegisterCommands: vi.fn(),
   mockDiscordListGuilds: vi.fn(
     async () =>
@@ -175,6 +177,21 @@ vi.mock('@roomote/communication/discord-provider', () => ({
     'Discord requires a tag for new posts in this forum, but no tag is available for Roomote to select.',
 }));
 
+vi.mock('@roomote/communication/teams-credential-validation', () => ({
+  validateTeamsBotCredentials: mockValidateTeamsBotCredentials,
+  TeamsBotCredentialValidationError: class TeamsBotCredentialValidationError extends Error {
+    constructor(
+      readonly code: string,
+      message: string,
+      readonly field: string | null = null,
+      readonly detail: string | null = null,
+    ) {
+      super(message);
+      this.name = 'TeamsBotCredentialValidationError';
+    }
+  },
+}));
+
 vi.mock('@/lib/server/env', () => ({
   Env: { R_APP_URL: 'https://app.example.com' },
 }));
@@ -192,6 +209,8 @@ vi.mock('../environment-variables', () => ({
   upsertDeploymentEnvironmentVariables:
     mockUpsertDeploymentEnvironmentVariables,
 }));
+
+import { TeamsBotCredentialValidationError } from '@roomote/communication/teams-credential-validation';
 
 import {
   classifyTelegramWebhookCheckError,
@@ -241,6 +260,7 @@ describe('comms commands', () => {
       botUsername: null,
     });
     mockTelegramGetWebhookInfo.mockReset();
+    mockValidateTeamsBotCredentials.mockResolvedValue(undefined);
     mockDiscordListGuilds.mockResolvedValue([]);
     mockDiscordListGuildChannels.mockResolvedValue([]);
     mockDiscordDiagnoseChannelPermissions.mockReset();
@@ -923,6 +943,119 @@ describe('comms commands', () => {
           'R_TEAMS_BOT_TENANT_ID',
         ]),
       );
+    });
+
+    it('verifies the Teams bot credentials a Microsoft save will produce', async () => {
+      mockDbTransaction.mockImplementation(async (callback) => {
+        return callback({} as never);
+      });
+
+      await saveCommsAuthConfigCommand(buildMockAuth(), {
+        provider: 'microsoft',
+        values: {
+          R_MICROSOFT_CLIENT_ID: 'ms-client-id',
+          R_MICROSOFT_CLIENT_SECRET: 'ms-client-secret',
+          R_MICROSOFT_TENANT_ID: 'ms-tenant-id',
+        },
+      });
+
+      expect(mockValidateTeamsBotCredentials).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appId: 'ms-client-id',
+          appPassword: 'ms-client-secret',
+          tenantId: 'ms-tenant-id',
+        }),
+      );
+    });
+
+    it('rejects a Microsoft save when Microsoft rejects the credentials', async () => {
+      mockDbTransaction.mockImplementation(async (callback) => {
+        return callback({} as never);
+      });
+      mockValidateTeamsBotCredentials.mockRejectedValue(
+        new TeamsBotCredentialValidationError(
+          'invalid_app_password',
+          'Microsoft rejected the client secret.',
+          'app_password',
+          'AADSTS7000215: Invalid client secret provided.',
+        ),
+      );
+
+      await expect(
+        saveCommsAuthConfigCommand(buildMockAuth(), {
+          provider: 'microsoft',
+          values: {
+            R_MICROSOFT_CLIENT_ID: '00000000-0000-0000-0000-000000000001',
+            R_MICROSOFT_CLIENT_SECRET: 'not-a-real-secret',
+            R_MICROSOFT_TENANT_ID: '00000000-0000-0000-0000-000000000002',
+          },
+        }),
+      ).rejects.toThrow(
+        /Client Secret Value \(R_MICROSOFT_CLIENT_SECRET\).*AADSTS7000215/su,
+      );
+
+      expect(mockUpsertDeploymentEnvironmentVariables).not.toHaveBeenCalled();
+    });
+
+    it('names the dedicated Teams bot field when that credential pair is in use', async () => {
+      mockDbTransaction.mockImplementation(async (callback) => {
+        return callback({} as never);
+      });
+      mockValidateTeamsBotCredentials.mockRejectedValue(
+        new TeamsBotCredentialValidationError(
+          'invalid_app_id',
+          'Microsoft rejected the app (client) id.',
+          'app_id',
+          "AADSTS700016: Application with identifier 'bot-app-id' was not found in the directory.",
+        ),
+      );
+
+      await expect(
+        saveCommsAuthConfigCommand(buildMockAuth(), {
+          provider: 'microsoft',
+          values: {
+            R_MICROSOFT_CLIENT_ID: 'ms-client-id',
+            R_MICROSOFT_CLIENT_SECRET: 'ms-client-secret',
+            R_MICROSOFT_TENANT_ID: 'ms-tenant-id',
+            R_TEAMS_BOT_APP_ID: 'bot-app-id',
+            R_TEAMS_BOT_APP_PASSWORD: 'bot-secret',
+          },
+        }),
+      ).rejects.toThrow(/Teams Bot App ID \(R_TEAMS_BOT_APP_ID\)/u);
+
+      expect(mockValidateTeamsBotCredentials).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appId: 'bot-app-id',
+          appPassword: 'bot-secret',
+        }),
+      );
+    });
+
+    it('keeps a Microsoft save blocked when Microsoft cannot be reached', async () => {
+      mockDbTransaction.mockImplementation(async (callback) => {
+        return callback({} as never);
+      });
+      mockValidateTeamsBotCredentials.mockRejectedValue(
+        new TeamsBotCredentialValidationError(
+          'unreachable',
+          'Could not reach Microsoft to verify the Teams bot credentials (timed out).',
+          null,
+          'The operation timed out.',
+        ),
+      );
+
+      await expect(
+        saveCommsAuthConfigCommand(buildMockAuth(), {
+          provider: 'microsoft',
+          values: {
+            R_MICROSOFT_CLIENT_ID: 'ms-client-id',
+            R_MICROSOFT_CLIENT_SECRET: 'ms-client-secret',
+            R_MICROSOFT_TENANT_ID: 'ms-tenant-id',
+          },
+        }),
+      ).rejects.toThrow(/login\.microsoftonline\.com/u);
+
+      expect(mockUpsertDeploymentEnvironmentVariables).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/src/trpc/commands/comms/index.ts
+++ b/apps/web/src/trpc/commands/comms/index.ts
@@ -59,6 +59,10 @@ import {
   getPersistedEnvironmentVariableValues,
   upsertDeploymentEnvironmentVariables,
 } from '../environment-variables';
+import {
+  assertTeamsBotCredentialsAuthenticate,
+  invalidateTeamsBotCredentialCheckCache,
+} from '../teams/bot-credential-check';
 
 type AdditionalCommsProviderId = 'telegram' | 'discord';
 type CommsProviderId = SetupAuthProviderId | AdditionalCommsProviderId;
@@ -930,6 +934,13 @@ export async function saveCommsAuthConfigCommand(
     }
   }
 
+  // Prove the Teams bot credentials authenticate before storing them; a wrong
+  // app id or secret otherwise only surfaces as unexplained 401s on the
+  // messaging endpoint, long after setup reported success.
+  if (input.provider === 'microsoft') {
+    await assertTeamsBotCredentialsAuthenticate(input.values);
+  }
+
   await db.transaction(async (tx) => {
     const persistedEnvVarNames = await getPersistedEnvironmentVariableNames(tx);
     const authSetup = buildSetupAuthStatus({
@@ -1101,6 +1112,7 @@ export async function saveCommsAuthConfigCommand(
 
   if (input.provider === 'microsoft') {
     invalidateTeamsBotRuntimeCredentialsCache();
+    invalidateTeamsBotCredentialCheckCache();
   }
 
   if (input.provider === 'discord') {
@@ -1159,6 +1171,7 @@ export async function clearCommsAuthConfigCommand(
 
   if (input.provider === 'microsoft') {
     invalidateTeamsBotRuntimeCredentialsCache();
+    invalidateTeamsBotCredentialCheckCache();
   }
 
   if (input.provider === 'discord') {

--- a/apps/web/src/trpc/commands/setup-new/index.test.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.test.ts
@@ -8,6 +8,7 @@ const {
   mockUpsertDeploymentEnvironmentVariables,
   mockGetPersistedEnvironmentVariableNames,
   mockGetPersistedEnvironmentVariableValues,
+  mockValidateTeamsBotCredentials,
   mockGetSetupBootstrapState,
   mockSetupTokenState,
   mockRunComputeProvisioning,
@@ -16,6 +17,7 @@ const {
   mockResolveGiteaBaseUrl,
   mockResolveDeploymentEnvVar,
 } = vi.hoisted(() => ({
+  mockValidateTeamsBotCredentials: vi.fn(async () => undefined),
   mockTxSelect: vi.fn(),
   mockDbTransaction: vi.fn(),
   mockUpsertDeploymentEnvironmentVariables: vi.fn(),
@@ -122,6 +124,7 @@ vi.mock('@roomote/db/server', () => ({
     identitySource: null,
     identityErrorCode: null,
   })),
+  invalidateTeamsBotRuntimeCredentialsCache: vi.fn(),
   slackInstallations: {},
   slackUserMappings: {},
   sql: vi.fn(),
@@ -185,6 +188,21 @@ vi.mock('../environment-variables', () => ({
     mockGetPersistedEnvironmentVariableValues,
 }));
 
+vi.mock('@roomote/communication/teams-credential-validation', () => ({
+  validateTeamsBotCredentials: mockValidateTeamsBotCredentials,
+  TeamsBotCredentialValidationError: class TeamsBotCredentialValidationError extends Error {
+    constructor(
+      readonly code: string,
+      message: string,
+      readonly field: string | null = null,
+      readonly detail: string | null = null,
+    ) {
+      super(message);
+      this.name = 'TeamsBotCredentialValidationError';
+    }
+  },
+}));
+
 vi.mock('../task-suggestions', () => ({
   triggerTaskSuggestionsCommand: vi.fn(),
 }));
@@ -220,9 +238,11 @@ import { enqueueTask } from '@roomote/cloud-agents/server';
 import { TelegramCommunicationProvider } from '@roomote/communication/telegram-provider';
 import { DiscordCommunicationProvider } from '@roomote/communication/discord-provider';
 import {
+  invalidateTeamsBotRuntimeCredentialsCache,
   resolveDiscordRuntimeCredentials,
   resolveTelegramRuntimeCredentials,
 } from '@roomote/db/server';
+import { TeamsBotCredentialValidationError } from '@roomote/communication/teams-credential-validation';
 import {
   createTeamsCommunicationProviderFromRuntimeCredentials,
   findTelegramPrimaryChatId,
@@ -286,6 +306,7 @@ describe('setup-new auth config commands', () => {
     vi.clearAllMocks();
     mockTxSelect.mockReset();
     mockGetPersistedEnvironmentVariableNames.mockResolvedValue([]);
+    mockValidateTeamsBotCredentials.mockResolvedValue(undefined);
     process.env.E2B_TEMPLATE_ID = '';
     process.env.DAYTONA_SNAPSHOT_NAME = '';
     process.env.BLAXEL_IMAGE = '';
@@ -333,6 +354,56 @@ describe('setup-new auth config commands', () => {
         ]),
       }),
     );
+  });
+
+  it('verifies Teams bot credentials and drops both caches after the commit', async () => {
+    mockGetSetupBootstrapState.mockResolvedValue({ setupOpen: false });
+
+    await saveSetupNewAuthConfigCommand(buildMockAuth(), {
+      provider: 'microsoft',
+      values: {
+        R_MICROSOFT_CLIENT_ID: 'ms-client-id',
+        R_MICROSOFT_CLIENT_SECRET: 'ms-client-secret',
+        R_MICROSOFT_TENANT_ID: 'ms-tenant-id',
+      },
+    });
+
+    expect(mockValidateTeamsBotCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId: 'ms-client-id',
+        appPassword: 'ms-client-secret',
+        tenantId: 'ms-tenant-id',
+      }),
+    );
+    // A stale 30s runtime cache would make the next status refresh report the
+    // credentials that were replaced, not the ones just verified.
+    expect(invalidateTeamsBotRuntimeCredentialsCache).toHaveBeenCalled();
+  });
+
+  it('does not save Teams credentials Microsoft rejects', async () => {
+    mockGetSetupBootstrapState.mockResolvedValue({ setupOpen: false });
+    mockValidateTeamsBotCredentials.mockRejectedValue(
+      new TeamsBotCredentialValidationError(
+        'invalid_app_password',
+        'Microsoft rejected the client secret.',
+        'app_password',
+        'AADSTS7000215: Invalid client secret provided.',
+      ),
+    );
+
+    await expect(
+      saveSetupNewAuthConfigCommand(buildMockAuth(), {
+        provider: 'microsoft',
+        values: {
+          R_MICROSOFT_CLIENT_ID: 'ms-client-id',
+          R_MICROSOFT_CLIENT_SECRET: 'wrong-secret',
+          R_MICROSOFT_TENANT_ID: 'ms-tenant-id',
+        },
+      }),
+    ).rejects.toThrow(/AADSTS7000215/u);
+
+    expect(mockUpsertDeploymentEnvironmentVariables).not.toHaveBeenCalled();
+    expect(invalidateTeamsBotRuntimeCredentialsCache).not.toHaveBeenCalled();
   });
 
   it('records bootstrap auth config without manufacturing a user', async () => {

--- a/apps/web/src/trpc/commands/setup-new/index.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.ts
@@ -35,6 +35,7 @@ import {
   purgeSavedDeploymentWorkerImage,
   resolveTelegramRuntimeCredentials,
   resolveDiscordRuntimeCredentials,
+  invalidateTeamsBotRuntimeCredentialsCache,
   isChatGptSubscriptionConnected,
   isGitHubCopilotSubscriptionConnected,
   isXaiSubscriptionConnected,
@@ -2094,10 +2095,9 @@ async function saveSetupAuthConfig(input: {
   // not report a configured Teams bot for credentials that never authenticated.
   if (input.provider === 'microsoft') {
     await assertTeamsBotCredentialsAuthenticate(input.values);
-    invalidateTeamsBotCredentialCheckCache();
   }
 
-  return db.transaction(async (tx) => {
+  const result = await db.transaction(async (tx) => {
     const [currentState, persistedEnvVarNames] = await Promise.all([
       getPersistedSetupNewState(tx),
       getPersistedEnvironmentVariableNames(tx),
@@ -2191,6 +2191,16 @@ async function saveSetupAuthConfig(input: {
       setupNewState,
     };
   });
+
+  // After the commit, or the 30s runtime credential cache keeps serving the
+  // pre-save tuple and the next status refresh reports the old credentials
+  // instead of the ones that were just verified and stored.
+  if (input.provider === 'microsoft') {
+    invalidateTeamsBotRuntimeCredentialsCache();
+    invalidateTeamsBotCredentialCheckCache();
+  }
+
+  return result;
 }
 
 export async function saveSetupNewSourceControlProviderChoiceCommand(

--- a/apps/web/src/trpc/commands/setup-new/index.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.ts
@@ -142,6 +142,10 @@ import {
   upsertDeploymentEnvironmentVariables,
 } from '../environment-variables';
 import {
+  assertTeamsBotCredentialsAuthenticate,
+  invalidateTeamsBotCredentialCheckCache,
+} from '../teams/bot-credential-check';
+import {
   getPersistedRuntimeComputeConfig,
   savePersistedRuntimeComputeConfig,
 } from '../compute';
@@ -2085,6 +2089,13 @@ async function saveSetupAuthConfig(input: {
     await assertSetupBootstrapOpen();
   }
   const provider = getSetupAuthProvider(input.provider);
+
+  // Runs before the transaction: it talks to Microsoft, and onboarding must
+  // not report a configured Teams bot for credentials that never authenticated.
+  if (input.provider === 'microsoft') {
+    await assertTeamsBotCredentialsAuthenticate(input.values);
+    invalidateTeamsBotCredentialCheckCache();
+  }
 
   return db.transaction(async (tx) => {
     const [currentState, persistedEnvVarNames] = await Promise.all([

--- a/apps/web/src/trpc/commands/teams/bot-credential-check.ts
+++ b/apps/web/src/trpc/commands/teams/bot-credential-check.ts
@@ -1,0 +1,253 @@
+import { createHash } from 'node:crypto';
+
+import {
+  TeamsBotCredentialValidationError,
+  validateTeamsBotCredentials,
+  type TeamsBotCredentialField,
+  type TeamsBotCredentialValidationCode,
+} from '@roomote/communication/teams-credential-validation';
+import {
+  getSetupAuthProvider,
+  resolveTeamsBotRuntimeCredentialsFromEnv,
+  TEAMS_BOT_CREDENTIAL_ENV_VAR_NAMES,
+  type TeamsBotCredentialSource,
+  type TeamsBotRuntimeCredentials,
+} from '@roomote/types';
+
+import { getPersistedEnvironmentVariableValues } from '../environment-variables';
+
+/**
+ * Saves block on this check, so keep it short enough that a wedged network
+ * does not look like a hung form.
+ */
+const SAVE_VALIDATION_TIMEOUT_MS = 8_000;
+const STATUS_VALIDATION_TIMEOUT_MS = 5_000;
+const STATUS_CHECK_CACHE_TTL_MS = 60_000;
+
+const FIELD_ENV_VAR_NAMES: Record<
+  TeamsBotCredentialField,
+  Record<Exclude<TeamsBotCredentialSource, null>, string>
+> = {
+  app_id: {
+    teams_bot: 'R_TEAMS_BOT_APP_ID',
+    microsoft_auth: 'R_MICROSOFT_CLIENT_ID',
+  },
+  app_password: {
+    teams_bot: 'R_TEAMS_BOT_APP_PASSWORD',
+    microsoft_auth: 'R_MICROSOFT_CLIENT_SECRET',
+  },
+  tenant_id: {
+    teams_bot: 'R_TEAMS_BOT_TENANT_ID',
+    microsoft_auth: 'R_MICROSOFT_TENANT_ID',
+  },
+};
+
+const FIELD_GUIDANCE: Partial<
+  Record<TeamsBotCredentialValidationCode, string>
+> = {
+  invalid_app_id:
+    'Copy the Application (client) ID from the Entra app registration overview.',
+  invalid_app_password:
+    'Use the client secret Value from Certificates & secrets, not the Secret ID.',
+  expired_app_password:
+    'Create a new client secret in Certificates & secrets and save its value here.',
+  invalid_tenant_id:
+    'Copy the Directory (tenant) ID from the Entra app registration overview.',
+};
+
+function getFieldDescription(
+  field: TeamsBotCredentialField,
+  source: TeamsBotCredentialSource,
+): string {
+  const envVarName = source ? FIELD_ENV_VAR_NAMES[field][source] : null;
+
+  if (!envVarName) {
+    return 'the Teams bot credentials';
+  }
+
+  const label = getSetupAuthProvider('microsoft').fields.find(
+    (candidate) => candidate.envVarName === envVarName,
+  )?.label;
+
+  return label ? `${label} (${envVarName})` : envVarName;
+}
+
+/**
+ * Turn a validation failure into copy an admin can act on: which value
+ * Microsoft rejected, what Microsoft said, and where to find the right value.
+ */
+function describeTeamsBotCredentialFailure(
+  error: TeamsBotCredentialValidationError,
+  source: TeamsBotCredentialSource,
+): string {
+  const detail = error.detail ? ` ${error.detail}` : '';
+
+  if (error.code === 'unreachable') {
+    return `${error.message}${detail} Check outbound access to login.microsoftonline.com and try again.`;
+  }
+
+  if (!error.field) {
+    return `${error.message}${detail}`;
+  }
+
+  const guidance = FIELD_GUIDANCE[error.code];
+
+  return `Microsoft rejected ${getFieldDescription(error.field, source)}.${detail}${
+    guidance ? ` ${guidance}` : ''
+  }`;
+}
+
+/**
+ * Resolve the Teams bot credentials a save is about to produce, the same way
+ * `resolveTeamsBotRuntimeCredentials` resolves them at runtime: real
+ * environment variables win, then the values being submitted, then what is
+ * already stored.
+ */
+async function resolvePendingTeamsBotCredentials(
+  values: Partial<Record<string, string>> | undefined,
+): Promise<TeamsBotRuntimeCredentials> {
+  const persisted = await getPersistedEnvironmentVariableValues([
+    ...TEAMS_BOT_CREDENTIAL_ENV_VAR_NAMES,
+  ]);
+  const merged: Partial<Record<string, string>> = {};
+
+  for (const name of TEAMS_BOT_CREDENTIAL_ENV_VAR_NAMES) {
+    merged[name] =
+      process.env[name]?.trim() || values?.[name]?.trim() || persisted[name];
+  }
+
+  return resolveTeamsBotRuntimeCredentialsFromEnv(merged);
+}
+
+/**
+ * Fail a Microsoft/Teams save when the credentials have never authenticated.
+ * Presence of non-empty values used to be enough to report "Bot configured",
+ * which left admins unable to tell a typo from a missing permission until the
+ * Azure Bot Service started getting 401s from the messaging endpoint.
+ */
+export async function assertTeamsBotCredentialsAuthenticate(
+  values: Partial<Record<string, string>> | undefined,
+): Promise<void> {
+  const credentials = await resolvePendingTeamsBotCredentials(values);
+
+  if (!credentials.botAppId || !credentials.botAppPassword) {
+    // The per-field required-value check reports missing values with copy that
+    // points at the specific empty field.
+    return;
+  }
+
+  try {
+    await validateTeamsBotCredentials({
+      appId: credentials.botAppId,
+      appPassword: credentials.botAppPassword,
+      tenantId: credentials.botTenantId,
+      tokenEndpoint: credentials.botTokenEndpoint,
+      oauthScope: credentials.botOauthScope,
+      timeoutMs: SAVE_VALIDATION_TIMEOUT_MS,
+    });
+  } catch (error) {
+    if (error instanceof TeamsBotCredentialValidationError) {
+      throw new Error(
+        describeTeamsBotCredentialFailure(error, credentials.source),
+      );
+    }
+
+    throw error;
+  }
+}
+
+export type TeamsBotCredentialCheck = {
+  /**
+   * `unchecked` means Roomote could not get an answer from Microsoft (no
+   * credentials configured, or the token endpoint was unreachable) — it is not
+   * a verdict on the credentials.
+   */
+  status: 'ok' | 'failed' | 'unchecked';
+  message: string | null;
+};
+
+let cachedStatusCheck: {
+  key: string;
+  value: TeamsBotCredentialCheck;
+  expiresAtMs: number;
+} | null = null;
+
+function getCredentialCacheKey(
+  credentials: TeamsBotRuntimeCredentials,
+): string {
+  return createHash('sha256')
+    .update(
+      JSON.stringify([
+        credentials.botAppId,
+        credentials.botAppPassword,
+        credentials.botTenantId,
+        credentials.botTokenEndpoint,
+        credentials.botOauthScope,
+      ]),
+    )
+    .digest('hex');
+}
+
+/**
+ * Report whether the currently resolved Teams bot credentials authenticate.
+ * Credentials supplied through real environment variables never pass through a
+ * save, and client secrets expire, so status cannot infer this from presence.
+ * Cached briefly because the settings page polls it.
+ */
+export async function checkTeamsBotCredentials(
+  credentials: TeamsBotRuntimeCredentials,
+): Promise<TeamsBotCredentialCheck> {
+  if (!credentials.botAppId || !credentials.botAppPassword) {
+    return { status: 'unchecked', message: null };
+  }
+
+  const key = getCredentialCacheKey(credentials);
+  const nowMs = Date.now();
+
+  if (cachedStatusCheck?.key === key && cachedStatusCheck.expiresAtMs > nowMs) {
+    return cachedStatusCheck.value;
+  }
+
+  let value: TeamsBotCredentialCheck;
+
+  try {
+    await validateTeamsBotCredentials({
+      appId: credentials.botAppId,
+      appPassword: credentials.botAppPassword,
+      tenantId: credentials.botTenantId,
+      tokenEndpoint: credentials.botTokenEndpoint,
+      oauthScope: credentials.botOauthScope,
+      timeoutMs: STATUS_VALIDATION_TIMEOUT_MS,
+    });
+    value = { status: 'ok', message: null };
+  } catch (error) {
+    if (error instanceof TeamsBotCredentialValidationError) {
+      const message = describeTeamsBotCredentialFailure(
+        error,
+        credentials.source,
+      );
+      value =
+        error.code === 'unreachable'
+          ? { status: 'unchecked', message }
+          : { status: 'failed', message };
+    } else {
+      value = {
+        status: 'unchecked',
+        message: 'Could not verify the Teams bot credentials with Microsoft.',
+      };
+    }
+  }
+
+  cachedStatusCheck = {
+    key,
+    value,
+    expiresAtMs: nowMs + STATUS_CHECK_CACHE_TTL_MS,
+  };
+
+  return value;
+}
+
+/** Drop the cached status verdict, e.g. right after credentials change. */
+export function invalidateTeamsBotCredentialCheckCache(): void {
+  cachedStatusCheck = null;
+}

--- a/apps/web/src/trpc/commands/teams/bot-credential-check.ts
+++ b/apps/web/src/trpc/commands/teams/bot-credential-check.ts
@@ -1,5 +1,3 @@
-import { createHash } from 'node:crypto';
-
 import {
   TeamsBotCredentialValidationError,
   validateTeamsBotCredentials,
@@ -166,26 +164,38 @@ export type TeamsBotCredentialCheck = {
   message: string | null;
 };
 
+type TeamsBotCredentialIdentity = Pick<
+  TeamsBotRuntimeCredentials,
+  | 'botAppId'
+  | 'botAppPassword'
+  | 'botTenantId'
+  | 'botTokenEndpoint'
+  | 'botOauthScope'
+>;
+
 let cachedStatusCheck: {
-  key: string;
+  credentials: TeamsBotCredentialIdentity;
   value: TeamsBotCredentialCheck;
   expiresAtMs: number;
 } | null = null;
 
-function getCredentialCacheKey(
-  credentials: TeamsBotRuntimeCredentials,
-): string {
-  return createHash('sha256')
-    .update(
-      JSON.stringify([
-        credentials.botAppId,
-        credentials.botAppPassword,
-        credentials.botTenantId,
-        credentials.botTokenEndpoint,
-        credentials.botOauthScope,
-      ]),
-    )
-    .digest('hex');
+/**
+ * Compare the resolved tuple directly instead of digesting it. A fast hash
+ * over a client secret is indistinguishable from insecure password hashing,
+ * and an exact comparison answers "are these the same credentials?" without
+ * the collision surface a digest would add.
+ */
+function isSameCredentialIdentity(
+  a: TeamsBotCredentialIdentity,
+  b: TeamsBotCredentialIdentity,
+): boolean {
+  return (
+    a.botAppId === b.botAppId &&
+    a.botAppPassword === b.botAppPassword &&
+    a.botTenantId === b.botTenantId &&
+    a.botTokenEndpoint === b.botTokenEndpoint &&
+    a.botOauthScope === b.botOauthScope
+  );
 }
 
 /**
@@ -201,10 +211,13 @@ export async function checkTeamsBotCredentials(
     return { status: 'unchecked', message: null };
   }
 
-  const key = getCredentialCacheKey(credentials);
   const nowMs = Date.now();
 
-  if (cachedStatusCheck?.key === key && cachedStatusCheck.expiresAtMs > nowMs) {
+  if (
+    cachedStatusCheck &&
+    cachedStatusCheck.expiresAtMs > nowMs &&
+    isSameCredentialIdentity(cachedStatusCheck.credentials, credentials)
+  ) {
     return cachedStatusCheck.value;
   }
 
@@ -239,7 +252,13 @@ export async function checkTeamsBotCredentials(
   }
 
   cachedStatusCheck = {
-    key,
+    credentials: {
+      botAppId: credentials.botAppId,
+      botAppPassword: credentials.botAppPassword,
+      botTenantId: credentials.botTenantId,
+      botTokenEndpoint: credentials.botTokenEndpoint,
+      botOauthScope: credentials.botOauthScope,
+    },
     value,
     expiresAtMs: nowMs + STATUS_CHECK_CACHE_TTL_MS,
   };

--- a/apps/web/src/trpc/commands/teams/index.test.ts
+++ b/apps/web/src/trpc/commands/teams/index.test.ts
@@ -1,4 +1,7 @@
+import { TeamsBotCredentialValidationError } from '@roomote/communication/teams-credential-validation';
+
 import { getTeamsIntegrationStatusCommand } from './index';
+import { invalidateTeamsBotCredentialCheckCache } from './bot-credential-check';
 
 import type { UserAuthSuccess } from '@/types';
 
@@ -6,10 +9,27 @@ const {
   mockResolveTeamsBotRuntimeCredentials,
   mockFindTeamsPrimaryConversation,
   mockResolveAuthProviderConfig,
+  mockValidateTeamsBotCredentials,
 } = vi.hoisted(() => ({
   mockResolveTeamsBotRuntimeCredentials: vi.fn(),
   mockFindTeamsPrimaryConversation: vi.fn(),
   mockResolveAuthProviderConfig: vi.fn(),
+  mockValidateTeamsBotCredentials: vi.fn(async () => undefined),
+}));
+
+vi.mock('@roomote/communication/teams-credential-validation', () => ({
+  validateTeamsBotCredentials: mockValidateTeamsBotCredentials,
+  TeamsBotCredentialValidationError: class TeamsBotCredentialValidationError extends Error {
+    constructor(
+      readonly code: string,
+      message: string,
+      readonly field: string | null = null,
+      readonly detail: string | null = null,
+    ) {
+      super(message);
+      this.name = 'TeamsBotCredentialValidationError';
+    }
+  },
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -56,6 +76,8 @@ function buildCredentials(
 describe('getTeamsIntegrationStatusCommand', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    invalidateTeamsBotCredentialCheckCache();
+    mockValidateTeamsBotCredentials.mockResolvedValue(undefined);
     mockResolveTeamsBotRuntimeCredentials.mockResolvedValue(buildCredentials());
     mockFindTeamsPrimaryConversation.mockResolvedValue(null);
     mockResolveAuthProviderConfig.mockResolvedValue({
@@ -69,6 +91,7 @@ describe('getTeamsIntegrationStatusCommand', () => {
     const status = await getTeamsIntegrationStatusCommand(mockAuth);
 
     expect(status.botConfigured).toBe(true);
+    expect(status.botCredentialCheck).toEqual({ status: 'ok', message: null });
     expect(status.microsoftAuthConfigured).toBe(true);
     expect(status.primaryConversationReady).toBe(false);
     expect(status.primaryConversationType).toBeNull();
@@ -106,8 +129,58 @@ describe('getTeamsIntegrationStatusCommand', () => {
     const status = await getTeamsIntegrationStatusCommand(mockAuth);
 
     expect(status.botConfigured).toBe(false);
+    expect(status.botCredentialCheck).toEqual({
+      status: 'unchecked',
+      message: null,
+    });
     expect(status.openInTeamsUrl).toBeNull();
     expect(status.primaryConversationReady).toBe(false);
     expect(status.primaryConversationType).toBeNull();
+    expect(mockValidateTeamsBotCredentials).not.toHaveBeenCalled();
+  });
+
+  it('reports credentials that never authenticated as failed, not configured', async () => {
+    mockValidateTeamsBotCredentials.mockRejectedValue(
+      new TeamsBotCredentialValidationError(
+        'invalid_app_id',
+        'Microsoft rejected the app (client) id.',
+        'app_id',
+        "AADSTS700016: Application with identifier 'bot-app-id' was not found in the directory.",
+      ),
+    );
+
+    const status = await getTeamsIntegrationStatusCommand(mockAuth);
+
+    expect(status.botConfigured).toBe(true);
+    expect(status.botCredentialCheck.status).toBe('failed');
+    expect(status.botCredentialCheck.message).toContain(
+      'Teams Bot App ID (R_TEAMS_BOT_APP_ID)',
+    );
+    expect(status.botCredentialCheck.message).toContain('AADSTS700016');
+  });
+
+  it('treats an unreachable Microsoft as unchecked, not as a credential failure', async () => {
+    mockValidateTeamsBotCredentials.mockRejectedValue(
+      new TeamsBotCredentialValidationError(
+        'unreachable',
+        'Could not reach Microsoft to verify the Teams bot credentials (timed out).',
+        null,
+        'The operation timed out.',
+      ),
+    );
+
+    const status = await getTeamsIntegrationStatusCommand(mockAuth);
+
+    expect(status.botCredentialCheck.status).toBe('unchecked');
+    expect(status.botCredentialCheck.message).toContain(
+      'login.microsoftonline.com',
+    );
+  });
+
+  it('caches the credential verdict so status polling does not hammer Microsoft', async () => {
+    await getTeamsIntegrationStatusCommand(mockAuth);
+    await getTeamsIntegrationStatusCommand(mockAuth);
+
+    expect(mockValidateTeamsBotCredentials).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/trpc/commands/teams/index.test.ts
+++ b/apps/web/src/trpc/commands/teams/index.test.ts
@@ -183,4 +183,15 @@ describe('getTeamsIntegrationStatusCommand', () => {
 
     expect(mockValidateTeamsBotCredentials).toHaveBeenCalledTimes(1);
   });
+
+  it('re-checks when only the client secret changed', async () => {
+    await getTeamsIntegrationStatusCommand(mockAuth);
+    mockResolveTeamsBotRuntimeCredentials.mockResolvedValue(
+      buildCredentials({ botAppPassword: 'rotated-app-password' }),
+    );
+
+    await getTeamsIntegrationStatusCommand(mockAuth);
+
+    expect(mockValidateTeamsBotCredentials).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/web/src/trpc/commands/teams/index.ts
+++ b/apps/web/src/trpc/commands/teams/index.ts
@@ -8,8 +8,19 @@ import type { UserAuthSuccess } from '@/types';
 import { Env } from '@/lib/server';
 import { resolveAuthProviderConfig } from '@/lib/server/auth-provider-config';
 
+import {
+  checkTeamsBotCredentials,
+  type TeamsBotCredentialCheck,
+} from './bot-credential-check';
+
 type TeamsIntegrationStatus = {
   botConfigured: boolean;
+  /**
+   * Whether the configured credentials actually authenticate with Microsoft.
+   * `botConfigured` only reports that values are present, which cannot
+   * distinguish a typo or an expired secret from a working bot.
+   */
+  botCredentialCheck: TeamsBotCredentialCheck;
   botUsesTenantSpecificTokenFlow: boolean;
   botUsesMicrosoftAuthFallback: boolean;
   microsoftAuthConfigured: boolean;
@@ -46,16 +57,18 @@ export async function getTeamsIntegrationStatusCommand(
 ): Promise<TeamsIntegrationStatus> {
   void auth;
 
-  const [credentials, authProviderConfig, primaryConversation, botName] =
+  const credentials = await resolveTeamsBotRuntimeCredentials();
+  const [authProviderConfig, primaryConversation, botName, botCredentialCheck] =
     await Promise.all([
-      resolveTeamsBotRuntimeCredentials(),
       resolveAuthProviderConfig(),
       findTeamsPrimaryConversation(),
       resolveTeamsInvocationBotName(),
+      checkTeamsBotCredentials(credentials),
     ]);
 
   return {
     botConfigured: Boolean(credentials.botAppId && credentials.botAppPassword),
+    botCredentialCheck,
     botUsesTenantSpecificTokenFlow: Boolean(credentials.botTenantId),
     botUsesMicrosoftAuthFallback: false,
     microsoftAuthConfigured: Boolean(

--- a/packages/communication/package.json
+++ b/packages/communication/package.json
@@ -17,6 +17,7 @@
     "./task-thread-title": "./src/task-thread-title.ts",
     "./teams-activity": "./src/teams-activity.ts",
     "./teams-bot-framework-client": "./src/teams-bot-framework-client.ts",
+    "./teams-credential-validation": "./src/teams-credential-validation.ts",
     "./teams-graph-client": "./src/teams-graph-client.ts",
     "./teams-provider": "./src/teams-provider.ts",
     "./telegram-provider": "./src/telegram-provider.ts",

--- a/packages/communication/src/__tests__/teams-credential-validation.test.ts
+++ b/packages/communication/src/__tests__/teams-credential-validation.test.ts
@@ -67,9 +67,9 @@ describe('validateTeamsBotCredentials', () => {
 
     expect(error.code).toBe('invalid_app_password');
     expect(error.field).toBe('app_password');
-    expect(error.detail).toBe(
-      'AADSTS7000215: Invalid client secret provided. Ensure the secret being sent in the request is the client secret value, not the client secret ID.',
-    );
+    // Entra's advice sentence is dropped; the field guidance layered on top by
+    // the web save path restates it.
+    expect(error.detail).toBe('AADSTS7000215: Invalid client secret provided.');
   });
 
   it('blames the app id for AADSTS700016', async () => {
@@ -90,6 +90,34 @@ describe('validateTeamsBotCredentials', () => {
 
     expect(error.code).toBe('invalid_app_id');
     expect(error.field).toBe('app_id');
+  });
+
+  it('strips inline trace ids from the detail (live AADSTS90002 shape)', async () => {
+    // Real Entra responses sometimes carry the diagnostics tail on the same
+    // line as the message instead of after \r\n.
+    const error = await expectValidationError(
+      validateTeamsBotCredentials({
+        appId: 'app-id',
+        appPassword: 'app-password',
+        tenantId: '00000000-0000-0000-0000-000000000002',
+        fetch: (async () =>
+          buildTokenErrorResponse(
+            {
+              error: 'invalid_request',
+              error_description:
+                "AADSTS90002: Tenant '00000000-0000-0000-0000-000000000002' not found. Check to make sure you have the correct tenant ID and are signing into the correct cloud. Check with your subscription administrator, this may happen if there are no active subscriptions for the tenant. Trace ID: bcea6d9d-1541-483f-a604-cc63ae9e6300 Correlation ID: 01af5574-834a-4b0d-8e1c-f7a3019567f1 Timestamp: 2026-07-29 16:22:35Z",
+              error_codes: [90002],
+            },
+            400,
+          )) as unknown as typeof fetch,
+      }),
+    );
+
+    expect(error.code).toBe('invalid_tenant_id');
+    expect(error.detail).toBe(
+      "AADSTS90002: Tenant '00000000-0000-0000-0000-000000000002' not found.",
+    );
+    expect(error.detail).not.toMatch(/Trace ID|Correlation ID|Timestamp/);
   });
 
   it('blames the tenant for AADSTS90002', async () => {

--- a/packages/communication/src/__tests__/teams-credential-validation.test.ts
+++ b/packages/communication/src/__tests__/teams-credential-validation.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  TeamsBotCredentialValidationError,
+  validateTeamsBotCredentials,
+} from '../teams-credential-validation';
+
+function buildTokenErrorResponse(body: unknown, status = 401) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+async function expectValidationError(
+  promise: Promise<void>,
+): Promise<TeamsBotCredentialValidationError> {
+  try {
+    await promise;
+  } catch (error) {
+    expect(error).toBeInstanceOf(TeamsBotCredentialValidationError);
+    return error as TeamsBotCredentialValidationError;
+  }
+
+  throw new Error('Expected validateTeamsBotCredentials to reject.');
+}
+
+describe('validateTeamsBotCredentials', () => {
+  it('resolves when Microsoft issues a token for the credentials', async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({ access_token: 'token', expires_in: 3600 }),
+    );
+
+    await expect(
+      validateTeamsBotCredentials({
+        appId: 'app-id',
+        appPassword: 'app-password',
+        tenantId: 'tenant-id',
+        fetch: fetchMock as unknown as typeof fetch,
+      }),
+    ).resolves.toBeUndefined();
+
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe(
+      'https://login.microsoftonline.com/tenant-id/oauth2/v2.0/token',
+    );
+    expect(String(init.body)).toContain('grant_type=client_credentials');
+  });
+
+  it('blames the client secret for AADSTS7000215', async () => {
+    const error = await expectValidationError(
+      validateTeamsBotCredentials({
+        appId: 'app-id',
+        appPassword: 'wrong-secret',
+        fetch: (async () =>
+          buildTokenErrorResponse({
+            error: 'invalid_client',
+            error_description:
+              'AADSTS7000215: Invalid client secret provided. Ensure the secret being sent in the request is the client secret value, not the client secret ID.\r\nTrace ID: abc\r\nCorrelation ID: def',
+            error_codes: [7000215],
+          })) as unknown as typeof fetch,
+      }),
+    );
+
+    expect(error.code).toBe('invalid_app_password');
+    expect(error.field).toBe('app_password');
+    expect(error.detail).toBe(
+      'AADSTS7000215: Invalid client secret provided. Ensure the secret being sent in the request is the client secret value, not the client secret ID.',
+    );
+  });
+
+  it('blames the app id for AADSTS700016', async () => {
+    const error = await expectValidationError(
+      validateTeamsBotCredentials({
+        appId: '00000000-0000-0000-0000-000000000001',
+        appPassword: 'app-password',
+        tenantId: '00000000-0000-0000-0000-000000000002',
+        fetch: (async () =>
+          buildTokenErrorResponse({
+            error: 'unauthorized_client',
+            error_description:
+              "AADSTS700016: Application with identifier '00000000-0000-0000-0000-000000000001' was not found in the directory 'contoso'.\r\nTrace ID: abc",
+            error_codes: [700016],
+          })) as unknown as typeof fetch,
+      }),
+    );
+
+    expect(error.code).toBe('invalid_app_id');
+    expect(error.field).toBe('app_id');
+  });
+
+  it('blames the tenant for AADSTS90002', async () => {
+    const error = await expectValidationError(
+      validateTeamsBotCredentials({
+        appId: 'app-id',
+        appPassword: 'app-password',
+        tenantId: 'not-a-tenant',
+        fetch: (async () =>
+          buildTokenErrorResponse(
+            {
+              error: 'invalid_request',
+              error_description:
+                "AADSTS90002: Tenant 'not-a-tenant' not found.",
+              error_codes: [90002],
+            },
+            400,
+          )) as unknown as typeof fetch,
+      }),
+    );
+
+    expect(error.code).toBe('invalid_tenant_id');
+    expect(error.field).toBe('tenant_id');
+  });
+
+  it('reads AADSTS codes out of the description when error_codes is absent', async () => {
+    const error = await expectValidationError(
+      validateTeamsBotCredentials({
+        appId: 'app-id',
+        appPassword: 'expired-secret',
+        fetch: (async () =>
+          buildTokenErrorResponse({
+            error: 'invalid_client',
+            error_description:
+              "AADSTS7000222: The provided client secret keys for app 'app-id' are expired.",
+          })) as unknown as typeof fetch,
+      }),
+    );
+
+    expect(error.code).toBe('expired_app_password');
+    expect(error.field).toBe('app_password');
+  });
+
+  it('reports an unnamed rejection for unrecognized failures', async () => {
+    const error = await expectValidationError(
+      validateTeamsBotCredentials({
+        appId: 'app-id',
+        appPassword: 'app-password',
+        fetch: (async () =>
+          new Response('<html>gateway error</html>', {
+            status: 502,
+          })) as unknown as typeof fetch,
+      }),
+    );
+
+    expect(error.code).toBe('rejected');
+    expect(error.field).toBeNull();
+    expect(error.message).toContain('HTTP 502');
+  });
+
+  it('separates an unreachable token endpoint from rejected credentials', async () => {
+    const error = await expectValidationError(
+      validateTeamsBotCredentials({
+        appId: 'app-id',
+        appPassword: 'app-password',
+        fetch: (async () => {
+          throw new TypeError('fetch failed');
+        }) as unknown as typeof fetch,
+      }),
+    );
+
+    expect(error.code).toBe('unreachable');
+    expect(error.field).toBeNull();
+  });
+
+  it('rejects empty credentials without calling Microsoft', async () => {
+    const fetchMock = vi.fn();
+
+    const error = await expectValidationError(
+      validateTeamsBotCredentials({
+        appId: '  ',
+        appPassword: 'app-password',
+        fetch: fetchMock as unknown as typeof fetch,
+      }),
+    );
+
+    expect(error.code).toBe('missing_credentials');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/communication/src/index.ts
+++ b/packages/communication/src/index.ts
@@ -8,6 +8,7 @@ export * from './request-user-input';
 export * from './task-thread-title';
 export * from './teams-activity';
 export * from './teams-bot-framework-client';
+export * from './teams-credential-validation';
 export * from './teams-graph-client';
 export * from './teams-provider';
 export * from './telegram-provider';

--- a/packages/communication/src/teams-bot-framework-client.ts
+++ b/packages/communication/src/teams-bot-framework-client.ts
@@ -151,6 +151,22 @@ async function readResponseText(response: Response): Promise<string> {
   }
 }
 
+/**
+ * Raised when the client-credentials token request itself fails. Carries the
+ * raw status and body so callers can turn Entra's `AADSTS…` codes into copy
+ * that names the field an operator got wrong.
+ */
+export class TeamsOAuthTokenError extends Error {
+  constructor(
+    message: string,
+    readonly status: number | null,
+    readonly responseBody: string | null,
+  ) {
+    super(message);
+    this.name = 'TeamsOAuthTokenError';
+  }
+}
+
 export class TeamsBotFrameworkClient {
   private readonly fetchImpl: FetchLike;
   private cachedToken: CachedToken | undefined;
@@ -394,6 +410,15 @@ export class TeamsBotFrameworkClient {
     };
   }
 
+  /**
+   * Runs the client-credentials token request and discards the token. Callers
+   * use it to prove the configured app id / secret / tenant actually
+   * authenticate instead of assuming that non-empty values are working ones.
+   */
+  async verifyCredentials(): Promise<void> {
+    await this.getAccessToken();
+  }
+
   private async getAccessToken(): Promise<string> {
     const now = Date.now();
 
@@ -420,23 +445,31 @@ export class TeamsBotFrameworkClient {
 
     if (!response.ok) {
       const responseBody = await readResponseText(response);
-      throw new Error(
+      throw new TeamsOAuthTokenError(
         `Teams OAuth token request failed with ${response.status}: ${responseBody}`,
+        response.status,
+        responseBody,
       );
     }
 
     const tokenResponse = (await response.json()) as unknown;
 
     if (!tokenResponse || typeof tokenResponse !== 'object') {
-      throw new Error('Teams OAuth token request returned a non-object body.');
+      throw new TeamsOAuthTokenError(
+        'Teams OAuth token request returned a non-object body.',
+        null,
+        null,
+      );
     }
 
     const tokenData = tokenResponse as Record<string, unknown>;
     const accessToken = readStringProperty(tokenData, 'access_token');
 
     if (!accessToken) {
-      throw new Error(
+      throw new TeamsOAuthTokenError(
         'Teams OAuth token response did not include access_token.',
+        null,
+        null,
       );
     }
 

--- a/packages/communication/src/teams-credential-validation.ts
+++ b/packages/communication/src/teams-credential-validation.ts
@@ -1,0 +1,224 @@
+import {
+  TeamsBotFrameworkClient,
+  TeamsOAuthTokenError,
+  type FetchLike,
+} from './teams-bot-framework-client';
+
+export type TeamsBotCredentialField = 'app_id' | 'app_password' | 'tenant_id';
+
+export type TeamsBotCredentialValidationCode =
+  | 'missing_credentials'
+  | 'invalid_app_id'
+  | 'invalid_app_password'
+  | 'expired_app_password'
+  | 'invalid_tenant_id'
+  | 'rejected'
+  | 'unreachable';
+
+export class TeamsBotCredentialValidationError extends Error {
+  constructor(
+    readonly code: TeamsBotCredentialValidationCode,
+    message: string,
+    /** Which configured value Microsoft blamed, when it is unambiguous. */
+    readonly field: TeamsBotCredentialField | null = null,
+    /** Microsoft's own explanation, trimmed to its first line. */
+    readonly detail: string | null = null,
+  ) {
+    super(message);
+    this.name = 'TeamsBotCredentialValidationError';
+  }
+}
+
+const DEFAULT_VALIDATION_TIMEOUT_MS = 8_000;
+
+/**
+ * Entra failures specific enough to name a field for. Anything else falls back
+ * to a generic rejection that still carries Microsoft's description.
+ */
+const AADSTS_FAILURES: Record<
+  number,
+  { code: TeamsBotCredentialValidationCode; field: TeamsBotCredentialField }
+> = {
+  // Application with identifier '<app id>' was not found in the directory.
+  700016: { code: 'invalid_app_id', field: 'app_id' },
+  // Invalid client secret provided (commonly the secret id, not its value).
+  7000215: { code: 'invalid_app_password', field: 'app_password' },
+  // The provided client secret keys for app '<app id>' are expired.
+  7000222: { code: 'expired_app_password', field: 'app_password' },
+  // Tenant '<tenant>' not found.
+  90002: { code: 'invalid_tenant_id', field: 'tenant_id' },
+  // Specified tenant identifier is neither a valid DNS name nor an external domain.
+  900023: { code: 'invalid_tenant_id', field: 'tenant_id' },
+};
+
+const FIELD_LABELS: Record<TeamsBotCredentialField, string> = {
+  app_id: 'app (client) id',
+  app_password: 'client secret',
+  tenant_id: 'directory (tenant) id',
+};
+
+function parseTokenErrorBody(responseBody: string | null): {
+  error: string | null;
+  description: string | null;
+  codes: number[];
+} {
+  let error: string | null = null;
+  let description: string | null = null;
+  const codes: number[] = [];
+
+  if (!responseBody) {
+    return { error, description, codes };
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(responseBody);
+
+    if (parsed && typeof parsed === 'object') {
+      const body = parsed as Record<string, unknown>;
+
+      if (typeof body.error === 'string') {
+        error = body.error;
+      }
+
+      if (typeof body.error_description === 'string') {
+        description = body.error_description;
+      }
+
+      if (Array.isArray(body.error_codes)) {
+        for (const code of body.error_codes) {
+          if (typeof code === 'number' && Number.isFinite(code)) {
+            codes.push(code);
+          }
+        }
+      }
+    }
+  } catch {
+    // Proxies and gateways can answer with HTML; the raw body still gets
+    // surfaced as the detail below.
+  }
+
+  for (const match of (description ?? responseBody).matchAll(/AADSTS(\d+)/gu)) {
+    const code = Number.parseInt(match[1] ?? '', 10);
+
+    if (Number.isFinite(code) && !codes.includes(code)) {
+      codes.push(code);
+    }
+  }
+
+  return { error, description, codes };
+}
+
+/** Entra descriptions append trace/correlation ids on later lines. */
+function firstLine(value: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+
+  return value.split(/\r?\n/u)[0]?.trim() || null;
+}
+
+function classifyTokenError(
+  error: TeamsOAuthTokenError,
+): TeamsBotCredentialValidationError {
+  const parsed = parseTokenErrorBody(error.responseBody);
+  const detail =
+    firstLine(parsed.description) ??
+    firstLine(error.responseBody) ??
+    firstLine(error.message);
+
+  for (const code of parsed.codes) {
+    const failure = AADSTS_FAILURES[code];
+
+    if (failure) {
+      return new TeamsBotCredentialValidationError(
+        failure.code,
+        `Microsoft rejected the ${FIELD_LABELS[failure.field]}.`,
+        failure.field,
+        detail,
+      );
+    }
+  }
+
+  if (parsed.error === 'invalid_client') {
+    return new TeamsBotCredentialValidationError(
+      'invalid_app_password',
+      `Microsoft rejected the ${FIELD_LABELS.app_password}.`,
+      'app_password',
+      detail,
+    );
+  }
+
+  return new TeamsBotCredentialValidationError(
+    'rejected',
+    error.status === null
+      ? 'Microsoft returned an unusable token response.'
+      : `Microsoft rejected the Teams bot credentials (HTTP ${error.status}).`,
+    null,
+    detail,
+  );
+}
+
+function isTimeout(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === 'TimeoutError' || error.name === 'AbortError')
+  );
+}
+
+/**
+ * Proves a Teams bot credential set authenticates by running the same
+ * client-credentials flow the bot uses at runtime. Throws a
+ * {@link TeamsBotCredentialValidationError} describing which value Microsoft
+ * rejected; resolves when the credentials are usable.
+ */
+export async function validateTeamsBotCredentials(input: {
+  appId: string | null | undefined;
+  appPassword: string | null | undefined;
+  tenantId?: string | null;
+  tokenEndpoint?: string | null;
+  oauthScope?: string | null;
+  fetch?: FetchLike;
+  timeoutMs?: number;
+}): Promise<void> {
+  const appId = input.appId?.trim();
+  const appPassword = input.appPassword?.trim();
+
+  if (!appId || !appPassword) {
+    throw new TeamsBotCredentialValidationError(
+      'missing_credentials',
+      'A Teams bot app id and client secret are required.',
+    );
+  }
+
+  const timeoutMs = input.timeoutMs ?? DEFAULT_VALIDATION_TIMEOUT_MS;
+  const fetchImpl = input.fetch ?? fetch;
+  const tenantId = input.tenantId?.trim();
+  const tokenEndpoint = input.tokenEndpoint?.trim();
+  const oauthScope = input.oauthScope?.trim();
+  const client = new TeamsBotFrameworkClient({
+    appId,
+    appPassword,
+    ...(tenantId ? { tenantId } : {}),
+    ...(tokenEndpoint ? { tokenEndpoint } : {}),
+    ...(oauthScope ? { oauthScope } : {}),
+    fetch: (url, init) =>
+      fetchImpl(url, { ...init, signal: AbortSignal.timeout(timeoutMs) }),
+  });
+
+  try {
+    await client.verifyCredentials();
+  } catch (error) {
+    if (error instanceof TeamsOAuthTokenError) {
+      throw classifyTokenError(error);
+    }
+
+    throw new TeamsBotCredentialValidationError(
+      'unreachable',
+      isTimeout(error)
+        ? 'Could not reach Microsoft to verify the Teams bot credentials (timed out).'
+        : 'Could not reach Microsoft to verify the Teams bot credentials.',
+      null,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}

--- a/packages/communication/src/teams-credential-validation.ts
+++ b/packages/communication/src/teams-credential-validation.ts
@@ -21,7 +21,10 @@ export class TeamsBotCredentialValidationError extends Error {
     message: string,
     /** Which configured value Microsoft blamed, when it is unambiguous. */
     readonly field: TeamsBotCredentialField | null = null,
-    /** Microsoft's own explanation, trimmed to its first line. */
+    /**
+     * Microsoft's own explanation, stripped of trace/correlation diagnostics
+     * and, when the field is identified, trimmed to its first sentence.
+     */
     readonly detail: string | null = null,
   ) {
     super(message);
@@ -108,13 +111,33 @@ function parseTokenErrorBody(responseBody: string | null): {
   return { error, description, codes };
 }
 
-/** Entra descriptions append trace/correlation ids on later lines. */
-function firstLine(value: string | null): string | null {
+/**
+ * Entra descriptions append trace/correlation ids and a timestamp — sometimes
+ * on later lines, sometimes inline on the same line. Keep the human-facing
+ * message and drop the diagnostics tail; server logs still carry the full
+ * response body when needed.
+ */
+function trimEntraDetail(value: string | null): string | null {
   if (!value) {
     return null;
   }
 
-  return value.split(/\r?\n/u)[0]?.trim() || null;
+  const line = value.split(/\r?\n/u)[0]?.trim() ?? '';
+
+  return (
+    line
+      .replace(/\s*\b(?:Trace ID|Correlation ID|Timestamp):.*$/isu, '')
+      .trim() || null
+  );
+}
+
+/**
+ * When the field is identified, our own guidance carries the fix, so keep only
+ * Entra's core fact ("AADSTSxxxxx: Tenant 'x' not found.") and drop its
+ * generic advice sentences.
+ */
+function firstSentence(value: string): string {
+  return value.match(/^.*?[.!?](?=\s|$)/su)?.[0] ?? value;
 }
 
 function classifyTokenError(
@@ -122,9 +145,10 @@ function classifyTokenError(
 ): TeamsBotCredentialValidationError {
   const parsed = parseTokenErrorBody(error.responseBody);
   const detail =
-    firstLine(parsed.description) ??
-    firstLine(error.responseBody) ??
-    firstLine(error.message);
+    trimEntraDetail(parsed.description) ??
+    trimEntraDetail(error.responseBody) ??
+    trimEntraDetail(error.message);
+  const fieldDetail = detail === null ? null : firstSentence(detail);
 
   for (const code of parsed.codes) {
     const failure = AADSTS_FAILURES[code];
@@ -134,7 +158,7 @@ function classifyTokenError(
         failure.code,
         `Microsoft rejected the ${FIELD_LABELS[failure.field]}.`,
         failure.field,
-        detail,
+        fieldDetail,
       );
     }
   }
@@ -144,7 +168,7 @@ function classifyTokenError(
       'invalid_app_password',
       `Microsoft rejected the ${FIELD_LABELS.app_password}.`,
       'app_password',
-      detail,
+      fieldDetail,
     );
   }
 


### PR DESCRIPTION
## Problem

Saving Microsoft Teams credentials only checked that fields were non-empty. A typo'd App ID, garbage secret, and nonexistent tenant saved fine, rendered "Bot configured" with a working Open-in-Teams link, and never contacted Microsoft. The mismatch surfaced later as bare 401s on the messaging endpoint, with the real cause only in server logs — an admin couldn't tell a wrong value from a missing permission. Discord and Telegram already validate at save time; `microsoft` did not.

## Change

- **Verify at save time** — run the same client-credentials token request the bot uses at runtime, and map Entra's `AADSTS` codes to the field that's wrong (`700016` → app id, `7000215`/`invalid_client` → secret, `7000222` → expired secret, `90002`/`900023` → tenant). The save resolves the credential tuple it's about to produce (env → submitted → stored, same precedence as runtime), so it names the right field for both dedicated `R_TEAMS_BOT_*` and Microsoft single-app setups. Both the settings and onboarding save paths block on this.
- **Status reports a live verdict** — `teams.integrationStatus` gains `botCredentialCheck` (`ok`/`failed`/`unchecked`, 60s cached), covering credentials injected as env vars and secrets that expire after setup. On `failed`, settings shows the error instead of "Bot configured". `unreachable` is reported as `unchecked`, never as a credential failure — a network blip shouldn't read as "your key is wrong". (Save is stricter and does fail when Microsoft is unreachable, matching the Discord precedent.)
- **App-package download explains itself** — a non-GUID App (Client) ID now shows why the pre-filled package is unavailable instead of silently removing the button.

## Screenshots

Saving the original repro's garbage credentials — rejected by a live Entra call, field named, nothing persisted:

<img width="1200" height="901" alt="image" src="https://github.com/user-attachments/assets/54b248c2-16f9-4fb3-8b17-03271f1ccb0a" />

Malformed App (Client) ID — download explains instead of disappearing:

<img width="1200" height="901" alt="image" src="https://github.com/user-attachments/assets/6e0dc020-0e3f-40a7-bab2-8ce78456c728" />

## Verification

- Live E2E on a local stack: the repro from the bug report now fails with `Microsoft rejected Directory (Tenant) ID (R_MICROSOFT_TENANT_ID). AADSTS90002: Tenant '…' not found…` from a real request to `login.microsoftonline.com`; `botConfigured` stays `false` and the page shows "Not configured" after reload.
- 24 tests added (error-code classification, save rejection per credential source, status check + caching, UI). `lint`, `check-types`, and the web/communication/types suites pass.
- Not exercised live: `AADSTS700016`/`7000215` (need a valid tenant to reach) — unit-tested against documented response shapes.
