### PR TITLE
Fix first-session Linear routing after OAuth

### DIFF
--- a/apps/api/src/handlers/linear/index.ts
+++ b/apps/api/src/handlers/linear/index.ts
@@ -15,10 +15,7 @@ import {
 import { Env } from '@roomote/env';
 import {
   type RoutingDebugInfo,
-  type RoutingWorkspace,
   enqueueTask,
-  routeTask,
-  buildLinearRoutingContext,
 } from '@roomote/cloud-agents/server';
 import { buildTaskStartingText } from '@roomote/communication/chat-messages';
 import { getRedis } from '@roomote/redis';
@@ -52,12 +49,14 @@ import {
   cancelLinearTaskRun,
   parseAgentSessionEventPayload,
   createLinearAgentRun,
-  startElicitationFallback,
   findPendingSelection,
   handleElicitationResponse,
   deletePendingSelection,
   enrichSessionComments,
+  resolveLinearTaskDestination,
   type CreateLinearAgentRunResult,
+  type LinearWorkspaceSelection,
+  type ResolvedLinearTaskDestination,
 } from '@roomote/linear';
 
 import type { WebhookResponse } from '../../types';
@@ -118,37 +117,7 @@ const AUTH_TOKEN_EXPIRY_MS = 15 * 60 * 1000;
  * Result of workspace mapping that properly distinguishes between
  * repository names and environment IDs.
  */
-interface WorkspaceSelection {
-  repo?: string;
-  environmentId?: string;
-}
-
-/**
- * Maps a routing workspace to the appropriate repo/environmentId fields.
- *
- * @param workspace - The workspace selection from the LLM router
- * @returns Object with either repo or environmentId populated
- */
-function mapWorkspaceToSelection(
-  workspace: RoutingWorkspace,
-): WorkspaceSelection {
-  switch (workspace.type) {
-    case 'environment':
-      return { environmentId: workspace.id };
-    case 'all_repositories':
-      return { repo: ALL_REPOSITORIES };
-  }
-}
-
-/**
- * Derives the workspace type from a WorkspaceSelection.
- */
-function deriveWorkspaceType(
-  ws: WorkspaceSelection,
-): 'environment' | 'all_repositories' {
-  if (ws.environmentId) return 'environment';
-  return 'all_repositories';
-}
+type WorkspaceSelection = LinearWorkspaceSelection;
 
 /**
  * Maps an elicitation workspace type + value to the appropriate WorkspaceSelection.
@@ -201,16 +170,7 @@ function postLinearFinalRouterDebug({
   });
 }
 
-interface RoutedLinearTask {
-  workspaceSelection: WorkspaceSelection;
-  workspaceDisplayName: string;
-  workspaceType: 'environment' | 'all_repositories';
-  kickoffMessage?: string;
-  reasoning?: string;
-  routingDebug?: RoutingDebugInfo;
-  routingDurationMs?: number;
-  userRoute?: string;
-}
+type RoutedLinearTask = ResolvedLinearTaskDestination;
 
 async function startLinearTask({
   linearClient,
@@ -929,203 +889,41 @@ async function handleAgentSessionEvent(
     agentSession,
   );
 
-  let workspaceSelection: WorkspaceSelection = { repo: ALL_REPOSITORIES };
-
   console.log(`[LinearWebhook] Attempting to route Linear task`);
-
-  try {
-    // Production routing already resolves the correct workspace, so keep the
-    // existing Linear task description input and only change the kickoff flow.
-    const taskDescription =
-      agentSession.comment?.body ||
-      agentSession.issue.description ||
-      agentSession.issue.title;
-
-    // Build routing context with all relevant Linear data
-    const routingContext = await buildLinearRoutingContext({
-      userId,
-      taskDescription,
-      issueIdentifier: agentSession.issue.identifier,
-      issueTitle: agentSession.issue.title,
-      issueDescription: agentSession.issue.description,
-      projectName: agentSession.issue.project?.name,
-      teamName: agentSession.issue.team?.name,
-      guidance: agentSession.guidance,
-      previousComments: enrichedSession.previousComments?.map((c) => ({
-        body: c.body,
-        username: c.user?.name,
-      })),
-      apiBaseUrl: Env.TRPC_URL ?? Env.R_APP_URL,
-    });
-
-    // Attempt LLM routing
-    const routingStart = Date.now();
-    const routingDecision = await routeTask(routingContext);
-    const routingDurationMs = Date.now() - routingStart;
-
-    if (routingDecision.status === 'platform_answer') {
-      const responseResult = await linearClient.emitResponse(
-        sessionId,
-        routingDecision.result.answer,
-      );
-
-      if (!responseResult.success) {
-        console.error(
-          `[LinearWebhook] Failed to emit platform answer to Linear: ${responseResult.error}`,
-        );
-      }
-
-      return { status: 'ok' };
-    }
-
-    if (routingDecision.status === 'routed') {
-      const { result } = routingDecision;
-
-      console.log(
-        `[LinearWebhook] LLM routing decision: ` +
-          `workspace=${result.workspace.type}${result.workspace.type === 'environment' ? `(${result.workspace.name})` : ''}, ` +
-          `reasoning="${result.reasoning}"`,
-      );
-
-      const ws = mapWorkspaceToSelection(result.workspace);
-
-      const wsDesc =
-        ws.repo === ALL_REPOSITORIES
-          ? 'all repos'
-          : ws.repo ||
-            (result.workspace.type === 'environment'
-              ? result.workspace.name
-              : `environment(${ws.environmentId})`);
-
-      return startLinearTask({
-        linearClient,
-        payload,
-        userId,
-        routedTask: {
-          workspaceSelection: ws,
-          workspaceDisplayName: wsDesc,
-          workspaceType: deriveWorkspaceType(ws),
-          ...(result.kickoffMessage
-            ? { kickoffMessage: result.kickoffMessage }
-            : {}),
-          reasoning: result.reasoning,
-          routingDebug: result.debug,
-          routingDurationMs,
-        },
-        agentSession: enrichedSession,
-      });
-    } else {
-      console.log(
-        `[LinearWebhook] LLM routing fell back: ${routingDecision.reason}`,
-      );
-    }
-  } catch (routingError) {
-    console.error(
-      `[LinearWebhook] LLM routing error, falling back to default:`,
-      routingError instanceof Error
-        ? routingError.message
-        : String(routingError),
-    );
-  }
-
-  // If routing was not used or failed, use the elicitation fallback flow
-  if (!userId) {
-    return startLinearTask({
-      linearClient,
-      payload,
-      userId,
-      routedTask: {
-        workspaceSelection: { repo: ALL_REPOSITORIES },
-        workspaceDisplayName: 'all repos',
-        workspaceType: 'all_repositories',
-      },
-      agentSession: enrichedSession,
-    });
-  }
-
-  console.log(
-    `[LinearWebhook] LLM routing not available or failed, starting elicitation fallback for session ${sessionId}`,
-  );
-
-  const fallbackResult = await startElicitationFallback({
-    sessionId,
-    linearOrganizationId: organizationId,
-    userId,
+  const destinationResult = await resolveLinearTaskDestination({
     payload,
+    agentSession: enrichedSession,
+    userId,
     linearClient,
+    apiBaseUrl: Env.TRPC_URL ?? Env.R_APP_URL,
   });
 
-  if (fallbackResult.status === 'error') {
-    console.error(
-      `[LinearWebhook] Elicitation fallback error: ${fallbackResult.message}`,
-    );
-
-    const errorResult = await linearClient.emitError(
+  if (destinationResult.status === 'platform_answer') {
+    const responseResult = await linearClient.emitResponse(
       sessionId,
-      `Failed to start workspace selection: ${fallbackResult.message}`,
+      destinationResult.answer,
     );
 
-    if (!errorResult.success) {
+    if (!responseResult.success) {
       console.error(
-        `[LinearWebhook] Failed to emit error to Linear: ${errorResult.error}`,
+        `[LinearWebhook] Failed to emit platform answer to Linear: ${responseResult.error}`,
       );
     }
-
-    return { status: 'error', message: fallbackResult.message };
-  }
-
-  // Check if the elicitation completed immediately (e.g., only one workspace)
-  if (fallbackResult.pendingSelection.step === 'completed') {
-    const selectedRepo =
-      fallbackResult.pendingSelection.selectedRepo ?? ALL_REPOSITORIES;
-
-    const wsOptions = fallbackResult.pendingSelection
-      .workspaceOptions as Array<{
-      type: 'all' | 'environment';
-      id: string;
-      name: string;
-    }> | null;
-
-    const matchedWs = wsOptions?.find((ws) => ws.id === selectedRepo);
-
-    if (matchedWs?.type === 'environment') {
-      workspaceSelection = { environmentId: matchedWs.id };
-    } else if (selectedRepo === ALL_REPOSITORIES) {
-      workspaceSelection = { repo: ALL_REPOSITORIES };
-    } else {
-      workspaceSelection = { repo: selectedRepo };
-    }
-
-    console.log(
-      `[LinearWebhook] Elicitation auto-completed with workspace=${JSON.stringify(workspaceSelection)}`,
-    );
-
-    await deletePendingSelection(sessionId);
-  } else {
-    console.log(
-      `[LinearWebhook] Elicitation started, awaiting workspace selection for session ${sessionId}`,
-    );
 
     return { status: 'ok' };
   }
 
-  // Create the task run
-  const runResult = await createLinearAgentRun({
-    agentSession: enrichedSession,
-    payload,
-    userId,
-    repo: workspaceSelection.repo,
-    environmentId: workspaceSelection.environmentId,
-  });
-
-  if (runResult.status === 'error') {
-    console.error(
-      `[LinearWebhook] Failed to create task run: ${runResult.message}`,
+  if (destinationResult.status === 'awaiting_selection') {
+    console.log(
+      `[LinearWebhook] Elicitation started, awaiting workspace selection for session ${sessionId}`,
     );
+    return { status: 'ok' };
+  }
 
+  if (destinationResult.status === 'error') {
     const errorResult = await linearClient.emitError(
       sessionId,
-      `Failed to start agent: ${runResult.message}`,
+      `Failed to start workspace selection: ${destinationResult.message}`,
     );
 
     if (!errorResult.success) {
@@ -1134,20 +932,16 @@ async function handleAgentSessionEvent(
       );
     }
 
-    return { status: 'error', message: runResult.message };
+    return { status: 'error', message: destinationResult.message };
   }
 
-  console.log(
-    `[LinearWebhook] Created ${describeLinearRunResult(runResult)} for session ${sessionId}`,
-  );
-
-  await updateLinearSessionTaskUrlForDirectLaunch({
+  return startLinearTask({
     linearClient,
-    sessionId,
-    runResult,
+    payload,
+    userId,
+    routedTask: destinationResult.destination,
+    agentSession: enrichedSession,
   });
-
-  return { status: 'ok' };
 }
 
 /**

--- a/apps/web/src/lib/server/mcp-linear.test.ts
+++ b/apps/web/src/lib/server/mcp-linear.test.ts
@@ -1,0 +1,188 @@
+const {
+  dbUpdateMock,
+  consumeMcpOauthReplayMock,
+  createLinearAgentRunMock,
+  emitThoughtMock,
+  payload,
+  resolveLinearTaskDestinationMock,
+  updateSessionExternalUrlsMock,
+} = vi.hoisted(() => ({
+  dbUpdateMock: vi.fn(),
+  consumeMcpOauthReplayMock: vi.fn(),
+  createLinearAgentRunMock: vi.fn(),
+  emitThoughtMock: vi.fn(),
+  payload: {
+    type: 'AgentSessionEvent',
+    action: 'created',
+    organizationId: 'linear-org-1',
+    appUserId: 'linear-app-user-1',
+    webhookTimestamp: Date.now(),
+    webhookId: 'webhook-1',
+    agentSession: {
+      id: 'session-1',
+      issue: {
+        id: 'issue-1',
+        identifier: 'ENG-123',
+        title: 'Fix API retries',
+        description: 'Retry failed API requests',
+        url: 'https://linear.example/ENG-123',
+      },
+      createdAt: '2026-07-29T00:00:00.000Z',
+      updatedAt: '2026-07-29T00:00:00.000Z',
+    },
+  },
+  resolveLinearTaskDestinationMock: vi.fn(),
+  updateSessionExternalUrlsMock: vi.fn(),
+}));
+
+vi.mock('@linear/sdk', () => ({
+  LinearClient: class {
+    viewer = Promise.resolve({
+      id: 'linear-user-1',
+      organization: Promise.resolve({
+        id: 'linear-org-1',
+        name: 'Linear Test',
+        urlKey: 'linear-test',
+      }),
+    });
+  },
+}));
+
+vi.mock('@roomote/communication/chat-messages', () => ({
+  buildTaskStartingText: vi.fn(
+    ({ workspaceDisplayName }: { workspaceDisplayName: string }) =>
+      `Getting started on your task in ${workspaceDisplayName}`,
+  ),
+}));
+
+vi.mock('@roomote/db/server', () => ({
+  db: {
+    update: dbUpdateMock,
+    query: { mcpConnections: { findFirst: vi.fn() } },
+  },
+  mcpConnections: { id: 'id' },
+  deploymentMcpEnablements: { mcpId: 'mcpId' },
+  eq: vi.fn(),
+}));
+
+vi.mock('@roomote/sdk/server', () => ({
+  consumeMcpOauthReplay: consumeMcpOauthReplayMock,
+  findLinearDeploymentMcpConnection: vi.fn().mockResolvedValue({
+    id: 'deployment-connection-1',
+    authConfig: { linearOrganizationId: 'linear-org-1' },
+  }),
+  getLinearDeploymentMetadata: vi.fn().mockReturnValue({
+    linearOrganizationId: 'linear-org-1',
+  }),
+  getValidAccessToken: vi.fn().mockResolvedValue('deployment-token'),
+  LINEAR_ORG_CONNECTION_ROLE: 'linear_org',
+  LINEAR_USER_CONNECTION_ROLE: 'linear_user',
+}));
+
+vi.mock('@roomote/linear', () => ({
+  createLinearAgentRun: createLinearAgentRunMock,
+  createLinearClient: vi.fn().mockReturnValue({
+    emitThought: emitThoughtMock,
+    emitResponse: vi.fn(),
+    emitError: vi.fn(),
+    updateSessionExternalUrls: updateSessionExternalUrlsMock,
+  }),
+  enrichSessionComments: vi.fn(
+    (_client: unknown, agentSession: unknown) => agentSession,
+  ),
+  parseAgentSessionEventPayload: vi.fn().mockReturnValue({
+    success: true,
+    data: payload,
+  }),
+  resolveLinearTaskDestination: resolveLinearTaskDestinationMock,
+}));
+
+vi.mock('@/lib/server/env', () => ({
+  Env: {
+    TRPC_URL: 'https://api.roomote.example',
+    R_APP_URL: 'https://app.roomote.example',
+    R_PUBLIC_URL: 'https://public.roomote.example',
+  },
+}));
+
+vi.mock('@/lib/server/get-public-app-url', () => ({
+  getPublicAppUrl: vi.fn().mockReturnValue('https://public.roomote.example'),
+}));
+
+import { hydrateLinearMcpConnectionAfterOauth } from './mcp-linear';
+
+describe('hydrateLinearMcpConnectionAfterOauth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbUpdateMock.mockReturnValue({
+      set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }),
+    });
+    consumeMcpOauthReplayMock.mockResolvedValue({
+      mcpId: 'linear',
+      sessionId: 'session-1',
+      payload,
+    });
+    resolveLinearTaskDestinationMock.mockResolvedValue({
+      status: 'routed',
+      destination: {
+        workspaceSelection: { environmentId: 'env-api' },
+        workspaceDisplayName: 'API',
+        workspaceType: 'environment',
+        kickoffMessage: 'I will inspect the retry path.',
+      },
+    });
+    createLinearAgentRunMock.mockResolvedValue({
+      status: 'ok',
+      runId: 42,
+      taskId: 'task-42',
+    });
+    emitThoughtMock.mockResolvedValue({ success: true });
+    updateSessionExternalUrlsMock.mockResolvedValue({ success: true });
+  });
+
+  it('routes the first replayed session before starting its task', async () => {
+    await hydrateLinearMcpConnectionAfterOauth({
+      connection: {
+        id: 'user-connection-1',
+        connectionRole: 'linear_user',
+        userId: 'roomote-user-1',
+        authConfig: null,
+      } as never,
+      accessToken: 'user-token',
+      replayToken: 'replay-token',
+    });
+
+    expect(resolveLinearTaskDestinationMock).toHaveBeenCalledWith({
+      payload,
+      agentSession: payload.agentSession,
+      userId: 'roomote-user-1',
+      linearClient: expect.any(Object),
+      apiBaseUrl: 'https://api.roomote.example',
+    });
+    expect(createLinearAgentRunMock).toHaveBeenCalledWith({
+      agentSession: payload.agentSession,
+      payload,
+      userId: 'roomote-user-1',
+      repo: undefined,
+      environmentId: 'env-api',
+    });
+    expect(emitThoughtMock).toHaveBeenNthCalledWith(
+      1,
+      'session-1',
+      'Getting started...',
+      true,
+    );
+    expect(emitThoughtMock).toHaveBeenNthCalledWith(
+      2,
+      'session-1',
+      'Getting started on your task in API',
+      true,
+    );
+    expect(updateSessionExternalUrlsMock).toHaveBeenCalledWith('session-1', [
+      {
+        label: 'Open task',
+        url: 'https://public.roomote.example/task/task-42',
+      },
+    ]);
+  });
+});

--- a/apps/web/src/lib/server/mcp-linear.ts
+++ b/apps/web/src/lib/server/mcp-linear.ts
@@ -1,5 +1,6 @@
 import { LinearClient } from '@linear/sdk';
 
+import { buildTaskStartingText } from '@roomote/communication/chat-messages';
 import {
   db,
   mcpConnections,
@@ -19,7 +20,11 @@ import {
   createLinearClient,
   enrichSessionComments,
   parseAgentSessionEventPayload,
+  resolveLinearTaskDestination,
 } from '@roomote/linear';
+
+import { Env } from '@/lib/server/env';
+import { getPublicAppUrl } from '@/lib/server/get-public-app-url';
 
 type McpConnectionRecord = Awaited<
   ReturnType<typeof db.query.mcpConnections.findFirst>
@@ -103,11 +108,48 @@ async function resumeLinearReplay(input: {
     linearClient,
     payload.agentSession,
   );
+  const destinationResult = await resolveLinearTaskDestination({
+    payload,
+    agentSession: enrichedSession,
+    userId: input.userId,
+    linearClient,
+    apiBaseUrl: Env.TRPC_URL ?? Env.R_APP_URL,
+  });
+
+  if (destinationResult.status === 'platform_answer') {
+    await linearClient.emitResponse(sessionId, destinationResult.answer);
+    return;
+  }
+
+  if (destinationResult.status === 'awaiting_selection') {
+    return;
+  }
+
+  if (destinationResult.status === 'error') {
+    await linearClient.emitError(
+      sessionId,
+      `Failed to start workspace selection: ${destinationResult.message}`,
+    );
+    return;
+  }
+
+  const { destination } = destinationResult;
+
+  await linearClient.emitThought(
+    sessionId,
+    buildTaskStartingText({
+      workspaceDisplayName: destination.workspaceDisplayName,
+      kickoffMessage: destination.kickoffMessage,
+    }),
+    true,
+  );
 
   const runResult = await createLinearAgentRun({
     agentSession: enrichedSession,
     payload,
     userId: input.userId,
+    repo: destination.workspaceSelection.repo,
+    environmentId: destination.workspaceSelection.environmentId,
   });
 
   if (runResult.status === 'error') {
@@ -119,12 +161,10 @@ async function resumeLinearReplay(input: {
   }
 
   if ('taskId' in runResult) {
-    const baseUrl = process.env.R_APP_URL;
-    if (baseUrl) {
-      await linearClient.updateSessionExternalUrls(sessionId, [
-        { label: 'Open task', url: `${baseUrl}/task/${runResult.taskId}` },
-      ]);
-    }
+    const baseUrl = getPublicAppUrl(Env);
+    await linearClient.updateSessionExternalUrls(sessionId, [
+      { label: 'Open task', url: `${baseUrl}/task/${runResult.taskId}` },
+    ]);
   }
 }
 

--- a/packages/linear/src/index.ts
+++ b/packages/linear/src/index.ts
@@ -117,3 +117,11 @@ export {
 
 // Session comment enrichment (fetches all comments including external ones)
 export { enrichSessionComments } from './enrich-session-comments';
+
+// Shared routing for both webhook intake and post-OAuth replay.
+export type {
+  LinearWorkspaceSelection,
+  ResolvedLinearTaskDestination,
+  ResolveLinearTaskDestinationResult,
+} from './resolve-task-destination';
+export { resolveLinearTaskDestination } from './resolve-task-destination';

--- a/packages/linear/src/resolve-task-destination.test.ts
+++ b/packages/linear/src/resolve-task-destination.test.ts
@@ -1,0 +1,173 @@
+import { ALL_REPOSITORIES } from '@roomote/types';
+
+const {
+  buildLinearRoutingContextMock,
+  routeTaskMock,
+  deletePendingSelectionMock,
+  startElicitationFallbackMock,
+} = vi.hoisted(() => ({
+  buildLinearRoutingContextMock: vi.fn(),
+  routeTaskMock: vi.fn(),
+  deletePendingSelectionMock: vi.fn(),
+  startElicitationFallbackMock: vi.fn(),
+}));
+
+vi.mock('@roomote/cloud-agents/server', () => ({
+  buildLinearRoutingContext: buildLinearRoutingContextMock,
+  routeTask: routeTaskMock,
+}));
+
+vi.mock('./elicitation-fallback', () => ({
+  deletePendingSelection: deletePendingSelectionMock,
+  startElicitationFallback: startElicitationFallbackMock,
+  stripEmojiPrefix: (value: string) => value.replace(/^\p{Emoji}\s*/u, ''),
+}));
+
+import type { LinearClient } from './linear-client';
+import { resolveLinearTaskDestination } from './resolve-task-destination';
+import type { AgentSessionEventPayload } from './types';
+
+function makePayload(): AgentSessionEventPayload {
+  return {
+    type: 'AgentSessionEvent',
+    action: 'created',
+    organizationId: 'linear-org-1',
+    appUserId: 'linear-app-user-1',
+    webhookTimestamp: Date.now(),
+    webhookId: 'webhook-1',
+    agentSession: {
+      id: 'session-1',
+      issue: {
+        id: 'issue-1',
+        identifier: 'ENG-123',
+        title: 'Fix API retries',
+        description: 'Retry failed requests from the API',
+        url: 'https://linear.example/ENG-123',
+        project: { id: 'project-1', name: 'Reliability' },
+        team: { id: 'team-1', key: 'ENG', name: 'Engineering' },
+      },
+      comment: {
+        id: 'comment-2',
+        body: 'Please fix the retry behavior',
+        user: { id: 'linear-user-1', name: 'Daniel' },
+      },
+      previousComments: [
+        {
+          id: 'comment-1',
+          body: 'This belongs in the API service',
+          user: { id: 'linear-user-2', name: 'Matt' },
+        },
+      ],
+      createdAt: '2026-07-29T00:00:00.000Z',
+      updatedAt: '2026-07-29T00:00:00.000Z',
+    },
+  };
+}
+
+describe('resolveLinearTaskDestination', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    buildLinearRoutingContextMock.mockResolvedValue({ source: 'linear' });
+  });
+
+  it('returns the environment selected by the router', async () => {
+    routeTaskMock.mockResolvedValue({
+      status: 'routed',
+      result: {
+        workspace: { type: 'environment', id: 'env-api', name: 'API' },
+        kickoffMessage: 'I will inspect the retry path.',
+        reasoning: 'The issue explicitly refers to the API service.',
+        debug: { stages: [] },
+      },
+    });
+    const payload = makePayload();
+
+    const result = await resolveLinearTaskDestination({
+      payload,
+      agentSession: payload.agentSession,
+      userId: 'roomote-user-1',
+      linearClient: {} as LinearClient,
+      apiBaseUrl: 'https://api.roomote.example',
+    });
+
+    expect(buildLinearRoutingContextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'roomote-user-1',
+        taskDescription: 'Please fix the retry behavior',
+        issueIdentifier: 'ENG-123',
+        projectName: 'Reliability',
+        teamName: 'Engineering',
+        previousComments: [
+          {
+            body: 'This belongs in the API service',
+            username: 'Matt',
+          },
+        ],
+        apiBaseUrl: 'https://api.roomote.example',
+      }),
+    );
+    expect(result).toMatchObject({
+      status: 'routed',
+      destination: {
+        workspaceSelection: { environmentId: 'env-api' },
+        workspaceDisplayName: 'API',
+        workspaceType: 'environment',
+        kickoffMessage: 'I will inspect the retry path.',
+        reasoning: 'The issue explicitly refers to the API service.',
+      },
+    });
+    expect(startElicitationFallbackMock).not.toHaveBeenCalled();
+  });
+
+  it('waits for a workspace choice when routing cannot decide', async () => {
+    routeTaskMock.mockResolvedValue({
+      status: 'fallback',
+      reason: 'No confident workspace match',
+    });
+    startElicitationFallbackMock.mockResolvedValue({
+      status: 'ok',
+      pendingSelection: { step: 'awaiting_workspace' },
+    });
+    const payload = makePayload();
+    const linearClient = {} as LinearClient;
+
+    const result = await resolveLinearTaskDestination({
+      payload,
+      agentSession: payload.agentSession,
+      userId: 'roomote-user-1',
+      linearClient,
+      apiBaseUrl: 'https://api.roomote.example',
+    });
+
+    expect(result).toEqual({ status: 'awaiting_selection' });
+    expect(startElicitationFallbackMock).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      linearOrganizationId: 'linear-org-1',
+      userId: 'roomote-user-1',
+      payload,
+      linearClient,
+    });
+  });
+
+  it('uses all repositories for an automation when routing is unavailable', async () => {
+    routeTaskMock.mockRejectedValue(new Error('router unavailable'));
+    const payload = makePayload();
+
+    const result = await resolveLinearTaskDestination({
+      payload,
+      agentSession: payload.agentSession,
+      linearClient: {} as LinearClient,
+      apiBaseUrl: 'https://api.roomote.example',
+    });
+
+    expect(result).toEqual({
+      status: 'routed',
+      destination: {
+        workspaceSelection: { repo: ALL_REPOSITORIES },
+        workspaceDisplayName: 'all repos',
+        workspaceType: 'all_repositories',
+      },
+    });
+    expect(startElicitationFallbackMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/linear/src/resolve-task-destination.ts
+++ b/packages/linear/src/resolve-task-destination.ts
@@ -1,0 +1,191 @@
+import {
+  buildLinearRoutingContext,
+  routeTask,
+  type RoutingDebugInfo,
+} from '@roomote/cloud-agents/server';
+import { ALL_REPOSITORIES } from '@roomote/types';
+
+import {
+  deletePendingSelection,
+  startElicitationFallback,
+  stripEmojiPrefix,
+} from './elicitation-fallback';
+import type { LinearClient } from './linear-client';
+import type { AgentSessionEventPayload } from './types';
+
+export type LinearWorkspaceSelection = {
+  repo?: string;
+  environmentId?: string;
+};
+
+export type ResolvedLinearTaskDestination = {
+  workspaceSelection: LinearWorkspaceSelection;
+  workspaceDisplayName: string;
+  workspaceType: 'environment' | 'all_repositories';
+  kickoffMessage?: string;
+  reasoning?: string;
+  routingDebug?: RoutingDebugInfo;
+  routingDurationMs?: number;
+  userRoute?: string;
+};
+
+export type ResolveLinearTaskDestinationResult =
+  | { status: 'routed'; destination: ResolvedLinearTaskDestination }
+  | { status: 'platform_answer'; answer: string }
+  | { status: 'awaiting_selection' }
+  | { status: 'error'; message: string };
+
+export async function resolveLinearTaskDestination({
+  payload,
+  agentSession,
+  userId,
+  linearClient,
+  apiBaseUrl,
+}: {
+  payload: AgentSessionEventPayload;
+  agentSession: AgentSessionEventPayload['agentSession'];
+  userId?: string;
+  linearClient: LinearClient;
+  apiBaseUrl: string;
+}): Promise<ResolveLinearTaskDestinationResult> {
+  try {
+    const taskDescription =
+      agentSession.comment?.body ||
+      agentSession.issue.description ||
+      agentSession.issue.title;
+    const routingContext = await buildLinearRoutingContext({
+      userId,
+      taskDescription,
+      issueIdentifier: agentSession.issue.identifier,
+      issueTitle: agentSession.issue.title,
+      issueDescription: agentSession.issue.description,
+      projectName: agentSession.issue.project?.name,
+      teamName: agentSession.issue.team?.name,
+      guidance: agentSession.guidance,
+      previousComments: agentSession.previousComments?.map((comment) => ({
+        body: comment.body,
+        username: comment.user?.name,
+      })),
+      apiBaseUrl,
+    });
+    const routingStart = Date.now();
+    const routingDecision = await routeTask(routingContext);
+    const routingDurationMs = Date.now() - routingStart;
+
+    if (routingDecision.status === 'platform_answer') {
+      return {
+        status: 'platform_answer',
+        answer: routingDecision.result.answer,
+      };
+    }
+
+    if (routingDecision.status === 'routed') {
+      const { result } = routingDecision;
+
+      if (result.workspace.type === 'environment') {
+        return {
+          status: 'routed',
+          destination: {
+            workspaceSelection: { environmentId: result.workspace.id },
+            workspaceDisplayName: result.workspace.name,
+            workspaceType: 'environment',
+            ...(result.kickoffMessage
+              ? { kickoffMessage: result.kickoffMessage }
+              : {}),
+            reasoning: result.reasoning,
+            routingDebug: result.debug,
+            routingDurationMs,
+          },
+        };
+      }
+
+      return {
+        status: 'routed',
+        destination: {
+          workspaceSelection: { repo: ALL_REPOSITORIES },
+          workspaceDisplayName: 'all repos',
+          workspaceType: 'all_repositories',
+          ...(result.kickoffMessage
+            ? { kickoffMessage: result.kickoffMessage }
+            : {}),
+          reasoning: result.reasoning,
+          routingDebug: result.debug,
+          routingDurationMs,
+        },
+      };
+    }
+
+    console.log(
+      `[LinearRouting] LLM routing fell back: ${routingDecision.reason}`,
+    );
+  } catch (error) {
+    console.error(
+      '[LinearRouting] LLM routing error, falling back to workspace selection:',
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+
+  if (!userId) {
+    return {
+      status: 'routed',
+      destination: {
+        workspaceSelection: { repo: ALL_REPOSITORIES },
+        workspaceDisplayName: 'all repos',
+        workspaceType: 'all_repositories',
+      },
+    };
+  }
+
+  const sessionId = payload.agentSession.id;
+  const fallbackResult = await startElicitationFallback({
+    sessionId,
+    linearOrganizationId: payload.organizationId,
+    userId,
+    payload,
+    linearClient,
+  });
+
+  if (fallbackResult.status === 'error') {
+    return fallbackResult;
+  }
+
+  if (fallbackResult.pendingSelection.step !== 'completed') {
+    return { status: 'awaiting_selection' };
+  }
+
+  const selectedWorkspaceId =
+    fallbackResult.pendingSelection.selectedRepo ?? ALL_REPOSITORIES;
+  const workspaceOptions = fallbackResult.pendingSelection
+    .workspaceOptions as Array<{
+    type: 'all' | 'environment';
+    id: string;
+    name: string;
+  }> | null;
+  const selectedWorkspace = workspaceOptions?.find(
+    (workspace) => workspace.id === selectedWorkspaceId,
+  );
+
+  await deletePendingSelection(sessionId);
+
+  if (selectedWorkspace?.type === 'environment') {
+    return {
+      status: 'routed',
+      destination: {
+        workspaceSelection: { environmentId: selectedWorkspace.id },
+        workspaceDisplayName: stripEmojiPrefix(selectedWorkspace.name),
+        workspaceType: 'environment',
+        userRoute: selectedWorkspace.name,
+      },
+    };
+  }
+
+  return {
+    status: 'routed',
+    destination: {
+      workspaceSelection: { repo: ALL_REPOSITORIES },
+      workspaceDisplayName: 'all repos',
+      workspaceType: 'all_repositories',
+      userRoute: selectedWorkspace?.name,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- route replayed Linear sessions before creating their task
- share one Linear destination resolver between normal webhooks and post-OAuth replay
- preserve platform answers and workspace-selection fallback in both entry paths
- add regression coverage proving the first replayed session receives its routed environment

## Why

A user's first Linear request can pause while they link their account. After OAuth, the saved request was replayed through a separate path that created the task without running the router, so it defaulted to all repositories. Later requests used the normal webhook path and routed correctly.

Both paths now resolve the destination through the same helper before starting a task.

## Validation

- `@roomote/linear`: resolver tests (3 passed)
- `@roomote/web`: OAuth replay regression test (1 passed)
- `@roomote/api`: Linear routing and active-run tests (11 passed)
- type checking passed for `@roomote/linear`, `@roomote/web`, and `@roomote/api`
- changed files pass formatting and lint
