### PR TITLE
[Fix] Azure DevOps connectionData requests always fail with a 400

### DIFF
--- a/.changeset/ado-connection-data-preview.md
+++ b/.changeset/ado-connection-data-preview.md
@@ -1,0 +1,6 @@
+---
+'@roomote/ado': patch
+'@roomote/sdk': patch
+---
+
+Request Azure DevOps `/_apis/connectionData` with api-version `7.1-preview`. The resource is preview-only, so the plain `7.1` version always failed with a 400, which silently disabled Roomote's own-comment detection on Azure DevOps pull request and work item comments and broke approve/request-changes reviewer votes on pull requests.

--- a/packages/ado/src/__tests__/api.test.ts
+++ b/packages/ado/src/__tests__/api.test.ts
@@ -771,8 +771,10 @@ describe('Azure DevOps API helpers', () => {
     });
     expect(second).toEqual(first);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    // connectionData is preview-only: Azure DevOps 400s on api-version=7.1
+    // unless the -preview suffix is present.
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://dev.azure.com/acme/_apis/connectionData?api-version=7.1',
+      'https://dev.azure.com/acme/_apis/connectionData?api-version=7.1-preview',
       expect.objectContaining({
         method: 'GET',
         headers: expect.objectContaining({

--- a/packages/ado/src/api.ts
+++ b/packages/ado/src/api.ts
@@ -23,6 +23,9 @@ export * from './ci';
 const ADO_PROVIDER = 'ado' satisfies SourceControlProvider;
 const DEFAULT_ADO_BASE_URL = 'https://dev.azure.com';
 export const ADO_API_VERSION = '7.1';
+// `/_apis/connectionData` is a preview-only resource: Azure DevOps answers
+// plain `7.1` (and `7.0`) with a 400 demanding the `-preview` suffix.
+const ADO_CONNECTION_DATA_API_VERSION = '7.1-preview';
 const ADO_TOKEN_VALIDATION_TIMEOUT_MS = 10_000;
 // Fits the whole TF401444 sentence (~204 chars with its three GUIDs) while
 // still keeping pathological provider messages toast-sized.
@@ -807,7 +810,7 @@ export async function getAdoDeploymentUser(options?: {
     organizationApiBaseUrl,
     fetchImpl: options?.fetchImpl,
     path: '/_apis/connectionData',
-    params: { 'api-version': ADO_API_VERSION },
+    params: { 'api-version': ADO_CONNECTION_DATA_API_VERSION },
     token: adoToken,
     schema: adoConnectionDataSchema,
   });

--- a/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-writes.test.ts
+++ b/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-writes.test.ts
@@ -300,7 +300,7 @@ describe('writeSourceControlPullRequestForTaskRun', () => {
 
     expect(fetchImpl).toHaveBeenNthCalledWith(
       1,
-      'https://dev.azure.com/acme/_apis/connectionData?api-version=7.1',
+      'https://dev.azure.com/acme/_apis/connectionData?api-version=7.1-preview',
       expect.objectContaining({
         method: 'GET',
         headers: expect.objectContaining({

--- a/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-writes.ts
+++ b/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-writes.ts
@@ -34,6 +34,9 @@ import {
 } from './source-control-pull-request-shared';
 
 const ADO_API_VERSION = '7.1';
+// `/_apis/connectionData` is a preview-only resource: Azure DevOps answers
+// plain `7.1` (and `7.0`) with a 400 demanding the `-preview` suffix.
+const ADO_CONNECTION_DATA_API_VERSION = '7.1-preview';
 
 /**
  * Optional id fields from LLM/tool clients often arrive as `""` or whitespace
@@ -1351,7 +1354,7 @@ async function writeAdoPullRequest({
       const connectionData = await requestJson({
         fetchImpl,
         url: buildApiUrl(organizationApiBaseUrl, '/_apis/connectionData', {
-          'api-version': ADO_API_VERSION,
+          'api-version': ADO_CONNECTION_DATA_API_VERSION,
         }),
         tokenHeader,
         schema: adoConnectionDataSchema,


### PR DESCRIPTION
## Problem

Azure DevOps only serves `/_apis/connectionData` at preview api-versions. Requesting it with the shared GA version fails on every call:

```
connectionData api-version=7.1          -> 400 "The -preview flag must be supplied..."
connectionData api-version=7.0          -> 400 (same message)
connectionData api-version=7.1-preview  -> 200 (returns authenticatedUser)
```

Two features depended on that call and were silently broken:

- **Own-comment detection** on ADO PR and work item comments: `getAdoDeploymentUser` threw on every call, so `isDeploymentTokenAuthor` failed open (a `console.warn` and `false`), leaving only the name-prefix check to keep Roomote from reacting to comments it posted itself.
- **Reviewer votes**: `submit_pull_request_review` with approve/request_changes resolves the voting identity through the same resource before casting the vote, so ADO reviewer votes always failed.

## Fix

A dedicated `ADO_CONNECTION_DATA_API_VERSION = '7.1-preview'` constant for the two connectionData call sites (`packages/ado` and `packages/sdk`), matching the constant `apps/web/src/lib/server/auth.ts` already uses for its vssps connectionData probe. The shared `ADO_API_VERSION` stays `7.1` for the GA resources. Test URL assertions now pin the `-preview` suffix so this cannot regress silently.

## Verification

- Reproduced the 400/400/200 matrix above against a real dev.azure.com organization, and ran the fixed `getAdoDeploymentUser` live: it resolves the deployment identity where it previously threw.
- Confirmed live that the id connectionData returns for a PAT matches the id on the same user's PR-surface activity, so the id branch of `isDeploymentTokenAuthor` detects Roomote's own comments. (The existing `normalizeAdoLinkedAccountKey` docblock caveat about vssps vs org identity ids applies to Entra OAuth, not PAT.)
- `@roomote/ado` suite (41), sdk pull-request-writes tests (13), and all ADO handler tests in `apps/api` (60) pass; `tsc --noEmit` clean on both packages.

Context: found as a follow-up to #888, whose credential probe hit the same 400 and deliberately switched to `/_apis/git/repositories` instead of touching `getAdoDeploymentUser`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)