### PR TITLE
[Fix] Knip floods phantom unused findings when run from a nested agent worktree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,8 +69,14 @@ AGENTS.local.md
 # claude skills (tracked via .agents/, not through .claude symlink)
 .claude/skills/
 
-# temporary agent worktree checkouts (.agents/skills stays tracked)
-.agents/worktrees/
+# temporary agent worktree checkouts (.agents/skills stays tracked). Anchored
+# because knip prefixes unanchored patterns with **/ and applies them to
+# absolute paths in some globs, which made every file inside a worktree nested
+# under .agents/worktrees/ match and flooded knip with phantom unused findings.
+# The .claude line covers the same worktrees reached through the tracked
+# .claude -> .agents symlink, which filesystem walkers follow but git does not.
+/.agents/worktrees/
+/.claude/worktrees/
 
 # e2e
 artifacts/ci-e2e/


### PR DESCRIPTION
## Problem

Running `pnpm knip` from a git worktree checked out under `<repo>/.agents/worktrees/` (where the agent harness puts them) reports ~380 phantom findings (unused files, exports, types, dependencies) and fails the pre-push hook, while the same commit passes knip on CI and on a normal checkout.

## Root cause

knip converts unanchored gitignore patterns by prefixing `**/` (`.agents/worktrees/` becomes `**/.agents/worktrees/**`) and applies the converted patterns to **absolute** paths in its plugin-entry and package.json source-mapping globs. From a worktree nested under `.agents/worktrees/`, every file's absolute path matches, so knip silently drops root script entries (`.husky` hooks, GitHub workflow scripts, seed/migration scripts) and dist-to-src source mappings. Everything only those entries reference then surfaces as unused. CI never sees this because CI checkouts are never nested inside another checkout.

A second alias of the same problem: `.claude` is a tracked symlink to `.agents`, which git never traverses but filesystem walkers follow. A checkout that *contains* worktrees floods knip with unlisted-dependency findings through `.claude/worktrees/...` paths unless a machine-local `.git/info/exclude` happens to cover them (fresh clones have none).

## Fix

Two lines in `.gitignore`, no tooling or config changes:

- Anchor the pattern to `/.agents/worktrees/` — the directory only ever exists at the repo root, so git semantics are unchanged, and the converted pattern can no longer match absolute path prefixes.
- Add `/.claude/worktrees/` to cover the symlink alias, following the precedent of the existing `.claude/skills/` entry.

## Verification

All on the same commit content, exit codes from `pnpm knip`:

| Scenario | before | after |
| --- | --- | --- |
| pristine clone | pass | pass |
| sibling worktree | pass | pass |
| worktree nested at `.agents/worktrees/` | fail (385 findings) | pass |
| clone containing a nested worktree | fail (750 unlisted deps via `.claude` alias) | pass |
| real agent worktree that hit the original failure | fail | pass |

Git semantics verified unchanged: `git check-ignore` still ignores files under `.agents/worktrees/`, `.agents/skills` stays tracked, `git status` clean. The push of this branch ran the full pre-push hook (oxlint, residual ESLint, check-types, knip) without bypass.

Upstream note: matching `**/`-prefixed gitignore-derived patterns against absolute paths is arguably a knip bug worth reporting, but the anchored pattern is the more precise expression of intent regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)