### PR TITLE
[Fix] Tasks blocked on background environment setup stall until manually nudged

### DIFF
--- a/apps/worker/src/run-task/__tests__/run-task.test.ts
+++ b/apps/worker/src/run-task/__tests__/run-task.test.ts
@@ -266,6 +266,7 @@ import { RunStatus, TaskPayloadKind } from '@roomote/types';
 
 import { getDefaultKeepaliveMs } from '../completion';
 import { runTask } from '../run-task';
+import type { EnvironmentSetupSettledOutcome } from '../types';
 
 describe('runTask', () => {
   beforeEach(() => {
@@ -2628,62 +2629,158 @@ describe('runTask', () => {
     );
   });
 
-  it('does not inject mid-task notices when background environment setup settles', async () => {
-    const onSettled = vi.fn();
+  describe('background environment setup settled notices', () => {
+    type SettledListener = (outcome: EnvironmentSetupSettledOutcome) => void;
 
-    await runTask({
-      taskRun: {
-        id: 205,
-        taskId: 'task-205',
-        payloadKind: TaskPayloadKind.StandardTask,
-        harness: 'opencode-server',
-        payload: {},
-        result: null,
-      } as never,
-      envVars: {},
-      workspacePath: '/tmp/workspace',
-      prompt: 'do work',
-      harnessInstructions: undefined,
-      agentInstructions: undefined,
-      environmentConfig: undefined,
-      backgroundEnvironmentSetup: {
-        hasPendingBackgroundSetup: true,
-        onSettled,
-      },
-      callbacks: {},
-      context: {},
-      logger: {
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-        log: vi.fn(),
-      } as never,
-      workerEnv: {
-        buildUserFacingEnv: vi.fn(() => ({})),
-        roomoteAppUrl: 'http://localhost:3000',
-        trpcUrl: 'http://localhost:3001',
-        authToken: 'auth-token',
-        appEnv: 'test',
-        setRuntimeEnv: vi.fn(),
-      } as never,
+    const runTaskWithBackgroundSetup = async () => {
+      const onSettled = vi.fn<(listener: SettledListener) => void>();
+
+      await runTask({
+        taskRun: {
+          id: 205,
+          taskId: 'task-205',
+          payloadKind: TaskPayloadKind.StandardTask,
+          harness: 'opencode-server',
+          payload: {},
+          result: null,
+        } as never,
+        envVars: {},
+        workspacePath: '/tmp/workspace',
+        prompt: 'do work',
+        harnessInstructions: undefined,
+        agentInstructions: undefined,
+        environmentConfig: undefined,
+        backgroundEnvironmentSetup: {
+          hasPendingBackgroundSetup: true,
+          onSettled,
+        },
+        callbacks: {},
+        context: {},
+        logger: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          log: vi.fn(),
+        } as never,
+        workerEnv: {
+          buildUserFacingEnv: vi.fn(() => ({})),
+          roomoteAppUrl: 'http://localhost:3000',
+          trpcUrl: 'http://localhost:3001',
+          authToken: 'auth-token',
+          appEnv: 'test',
+          setRuntimeEnv: vi.fn(),
+        } as never,
+      });
+
+      const manager = harnessManagerInstances[0]!;
+      const settledListener = onSettled.mock.calls[0]?.[0];
+
+      return { manager, settledListener };
+    };
+
+    const environmentSetupNoticeCalls = (manager: FakeHarnessManager) =>
+      manager.sendFollowUpPrompt.mock.calls.filter(
+        (call) => call[0]?.source === 'environment-setup',
+      );
+
+    it('injects a settled notice once the runtime task has started', async () => {
+      const { manager, settledListener } = await runTaskWithBackgroundSetup();
+
+      expect(settledListener).toBeDefined();
+
+      // Settling before taskStarted must not race the initial prompt.
+      settledListener!({ status: 'fulfilled', warningMessages: [] });
+      expect(environmentSetupNoticeCalls(manager)).toHaveLength(0);
+
+      manager.emit('taskStateEvent', 'taskStarted');
+
+      const noticeCalls = environmentSetupNoticeCalls(manager);
+
+      expect(noticeCalls).toHaveLength(1);
+      expect(noticeCalls[0]![0]).toMatchObject({
+        visibleInTranscript: false,
+        source: 'environment-setup',
+      });
+      expect(noticeCalls[0]![0].prompt).toContain(
+        'Environment setup update: background environment setup (repository setup commands and Docker projects) finished successfully.',
+      );
     });
 
-    const manager = harnessManagerInstances[0]!;
+    it('holds the settled notice while a question is pending and delivers it when the phase returns to running', async () => {
+      const { manager, settledListener } = await runTaskWithBackgroundSetup();
 
-    expect(onSettled).not.toHaveBeenCalled();
-    expect(manager.sendFollowUpPrompt).not.toHaveBeenCalledWith(
-      expect.objectContaining({ source: 'environment-setup' }),
-    );
-    expect(
-      manager.sendFollowUpPrompt.mock.calls.some((call) => {
-        const prompt = call[0]?.prompt;
+      manager.emit('taskStateEvent', 'taskStarted');
+      manager.getStatus.mockReturnValue({
+        isConnected: true,
+        phase: 'waiting_for_user_input',
+        sessionId: undefined,
+      });
+      settledListener!({
+        status: 'fulfilled',
+        warningMessages: ['Dev server never became ready'],
+      });
 
-        return (
-          typeof prompt === 'string' &&
-          prompt.includes('Environment setup update:')
-        );
-      }),
-    ).toBe(false);
+      expect(environmentSetupNoticeCalls(manager)).toHaveLength(0);
+
+      manager.getStatus.mockReturnValue({
+        isConnected: true,
+        phase: 'running',
+        sessionId: undefined,
+      });
+      manager.emit('stateChange', 'running', {});
+
+      const noticeCalls = environmentSetupNoticeCalls(manager);
+
+      expect(noticeCalls).toHaveLength(1);
+      expect(noticeCalls[0]![0].prompt).toContain(
+        'Dev server never became ready',
+      );
+
+      // Later phase changes must not re-deliver the consumed notice.
+      manager.emit('stateChange', 'running', {});
+      expect(environmentSetupNoticeCalls(manager)).toHaveLength(1);
+    });
+
+    it('drops the settled notice when the task is no longer running', async () => {
+      const { manager, settledListener } = await runTaskWithBackgroundSetup();
+
+      manager.emit('taskStateEvent', 'taskStarted');
+      manager.getStatus.mockReturnValue({
+        isConnected: true,
+        phase: 'waiting_for_prompt',
+        sessionId: undefined,
+      });
+      settledListener!({ status: 'fulfilled', warningMessages: [] });
+
+      expect(environmentSetupNoticeCalls(manager)).toHaveLength(0);
+
+      // Even if the task later runs again, the stale notice stays dropped.
+      manager.getStatus.mockReturnValue({
+        isConnected: true,
+        phase: 'running',
+        sessionId: undefined,
+      });
+      manager.emit('stateChange', 'running', {});
+      expect(environmentSetupNoticeCalls(manager)).toHaveLength(0);
+    });
+
+    it('reports a rejected background setup with the error message', async () => {
+      const { manager, settledListener } = await runTaskWithBackgroundSetup();
+
+      manager.emit('taskStateEvent', 'taskStarted');
+      settledListener!({
+        status: 'rejected',
+        errorMessage: 'setup exploded',
+      });
+
+      const noticeCalls = environmentSetupNoticeCalls(manager);
+
+      expect(noticeCalls).toHaveLength(1);
+      expect(noticeCalls[0]![0].prompt).toContain(
+        'background environment setup failed unexpectedly',
+      );
+      expect(noticeCalls[0]![0].prompt).toContain('setup exploded');
+    });
   });
 
   it('coerces an explicit legacy direct harness into the sandbox server', async () => {

--- a/apps/worker/src/run-task/__tests__/sandbox-instruction.test.ts
+++ b/apps/worker/src/run-task/__tests__/sandbox-instruction.test.ts
@@ -337,8 +337,14 @@ describe('buildSandboxInstruction', () => {
     );
     expect(pendingInstruction).toContain('.roomote/setup-status.json');
     expect(pendingInstruction).toContain('.roomote/setup-logs/');
-    expect(pendingInstruction).not.toContain(
-      'You will receive a message when background environment setup finishes',
+    expect(pendingInstruction).toContain(
+      'wait for it instead of reporting that you are blocked and ending your turn',
+    );
+    expect(pendingInstruction).toContain(
+      're-read `.roomote/setup-status.json` every 10-15 seconds',
+    );
+    expect(pendingInstruction).toContain(
+      'You will also receive an in-session `Environment setup update:` message when background setup finishes',
     );
     expect(pendingInstruction).not.toContain(
       'were already executed before your task started',
@@ -353,6 +359,7 @@ describe('buildSandboxInstruction', () => {
       'were already executed before your task started',
     );
     expect(settledInstruction).toContain('.roomote/setup-status.json');
+    expect(settledInstruction).not.toContain('Environment setup update:');
   });
 
   it('omits external preview URLs when configured hosts are unavailable', () => {

--- a/apps/worker/src/run-task/run-task.ts
+++ b/apps/worker/src/run-task/run-task.ts
@@ -46,7 +46,11 @@ import { recordChatTurnStart } from '../mcp/roomote-mcp-server/chat-reply-satisf
 import { recordSandboxPromptSlackTurnStart } from '../sandbox-server/procedures/slackReplyTurnTracking';
 import { type IntegrationMcpOptions } from '../commands/setup/setup-mcps';
 
-import type { RunTaskOptions, RunTaskState } from './types';
+import type {
+  EnvironmentSetupSettledOutcome,
+  RunTaskOptions,
+  RunTaskState,
+} from './types';
 import {
   DEFAULT_DELEGATED_KEEPALIVE_MS,
   DEFAULT_KEEPALIVE_DEV_MS,
@@ -134,6 +138,43 @@ function formatWorkspaceReadinessWarnings(
     'This task is starting before workspace readiness is fully settled. Some environment setup steps may still be running or may have reported warnings.',
     'Acknowledge this politely if it affects the user request, and do not assume the environment is fully configured.',
     ...normalizedWarnings.map((warning) => `- ${warning}`),
+  ].join('\n');
+}
+
+/**
+ * In-session notification delivered when background environment setup
+ * settles while the agent is already working. The trailing guard sentence is
+ * insurance against the #661 duplicate-question bug for the narrow race where
+ * a request_user_input is issued between the delivery-time phase check and
+ * the prompt landing in the session.
+ */
+function buildEnvironmentSetupSettledPrompt(
+  outcome: EnvironmentSetupSettledOutcome,
+): string {
+  const doNotRepeatQuestions =
+    'If you have already asked the user a question that is still unanswered, do not repeat or re-issue it — keep waiting for their reply.';
+
+  if (outcome.status === 'rejected') {
+    return [
+      'Environment setup update: background environment setup failed unexpectedly.',
+      `Error: ${outcome.errorMessage}`,
+      'Check `.roomote/setup-status.json` and `.roomote/setup-logs/` in the workspace root before relying on installed dependencies or running services. Continue with the user request and mention the failure if it affects your work.',
+      doNotRepeatQuestions,
+    ].join('\n');
+  }
+
+  if (outcome.warningMessages.length > 0) {
+    return [
+      'Environment setup update: background environment setup (repository setup commands and Docker projects) finished with warnings:',
+      ...outcome.warningMessages.map((warning) => `- ${warning}`),
+      'Details are in `.roomote/setup-status.json` and `.roomote/setup-logs/` in the workspace root. Verify anything you depend on is actually available. Continue with the user request; only mention this if it affects your work.',
+      doNotRepeatQuestions,
+    ].join('\n');
+  }
+
+  return [
+    'Environment setup update: background environment setup (repository setup commands and Docker projects) finished successfully. The environment is now fully configured; `.roomote/setup-status.json` has per-command results. Continue with the user request — no action or acknowledgement is needed.',
+    doNotRepeatQuestions,
   ].join('\n');
 }
 
@@ -1283,6 +1324,77 @@ export const runTask = async ({
       // terminal intent, so shut the sandbox down instead of leaving a soft
       // resume hold that outlives the canceled task.
       harnessManager?.cancelTask({ terminate: true });
+    });
+    // Close the loop on background environment setup: when it settles while
+    // the agent is actively working, push a notification into the session so
+    // the agent can stop polling `.roomote/setup-status.json` and continue.
+    // Delivery is deferred until the runtime signals taskStarted — the phase
+    // flips to running before the StartNewTask command carrying the initial
+    // prompt is delivered, so injecting earlier can race the initial user
+    // prompt and replace it as the session's first message. While a
+    // structured question is outstanding (waiting_for_user_input), hold the
+    // notice instead of injecting: an unsolicited system turn at that point
+    // made agents re-issue the pending request_user_input, which Slack
+    // rendered as duplicate questions (#661). A held notice is retried on the
+    // next phase change once the answer arrives. If the task has settled to
+    // idle, drop the notice — waking an idle task would burn a turn for
+    // nothing, and .roomote/setup-status.json already has the ground truth.
+    let pendingEnvironmentSetupOutcome:
+      | EnvironmentSetupSettledOutcome
+      | undefined;
+    let runtimeTaskStartedForSetupNotice = false;
+
+    const deliverEnvironmentSetupNotice = () => {
+      const currentManager = harnessManager;
+      const outcome = pendingEnvironmentSetupOutcome;
+
+      if (!currentManager || !outcome || !runtimeTaskStartedForSetupNotice) {
+        return;
+      }
+
+      const phase = currentManager.getStatus().phase;
+
+      if (phase === 'waiting_for_user_input') {
+        // Keep the outcome pending; answering the question flips the phase
+        // back to running, and that stateChange retries delivery.
+        return;
+      }
+
+      pendingEnvironmentSetupOutcome = undefined;
+
+      if (phase !== 'running') {
+        return;
+      }
+
+      const sent = currentManager.sendFollowUpPrompt({
+        prompt: buildEnvironmentSetupSettledPrompt(outcome),
+        visibleInTranscript: false,
+        source: 'environment-setup',
+      });
+
+      void recordWorkerRuntimeEvent({
+        eventType: 'decision',
+        message: `Background environment setup settled (${outcome.status}) while task run #${taskRun.id} was running; in-session notification ${sent ? 'delivered' : 'was not accepted by the harness'}.`,
+        details: {
+          reason: 'background_environment_setup_notification',
+          outcome: outcome.status,
+          delivered: sent,
+        },
+      });
+    };
+
+    backgroundEnvironmentSetup?.onSettled((outcome) => {
+      pendingEnvironmentSetupOutcome = outcome;
+      deliverEnvironmentSetupNotice();
+    });
+    harnessManager.on('taskStateEvent', (eventName) => {
+      if (eventName === 'taskStarted') {
+        runtimeTaskStartedForSetupNotice = true;
+        deliverEnvironmentSetupNotice();
+      }
+    });
+    harnessManager.on('stateChange', () => {
+      deliverEnvironmentSetupNotice();
     });
     harnessManager.on('taskStateEvent', (eventName) => {
       void recordWorkerRuntimeEvent({

--- a/apps/worker/src/run-task/sandbox-instruction.ts
+++ b/apps/worker/src/run-task/sandbox-instruction.ts
@@ -196,6 +196,7 @@ export function buildSandboxInstruction(
         lines.push(
           '',
           'Repository setup commands from this environment configuration run in the background and may still be executing while you work. Do not assume dependencies are installed or services are ready: check `.roomote/setup-status.json` in the workspace root for live per-command status, and read the logs under `.roomote/setup-logs/` if something you need appears to be missing. Never re-run a setup command that is still marked as running.',
+          'If the requested work depends on setup that is still running (dependency installs, service startup, secret retrieval), wait for it instead of reporting that you are blocked and ending your turn: re-read `.roomote/setup-status.json` every 10-15 seconds until its top-level `state` reaches a terminal value (`completed`, `completed_with_warnings`, or `failed`), then continue the task from there. You will also receive an in-session `Environment setup update:` message when background setup finishes, so treat a still-running setup as normal startup, not a blocker to hand back to the user.',
         );
       } else {
         lines.push(

--- a/apps/worker/src/run-task/types.ts
+++ b/apps/worker/src/run-task/types.ts
@@ -35,9 +35,12 @@ export type EnvironmentSetupSettledOutcome =
 /**
  * Lets the task runtime observe background environment setup without owning
  * it. Implemented by BackgroundEnvironmentSetupController; consumed by
- * runTask so sandbox instructions can tell the agent whether setup is still
- * running. Agents should poll `.roomote/setup-status.json` — the runtime does
- * not inject mid-task settled notices into the harness session.
+ * runTask to (a) tell the agent whether setup is still running and (b) push a
+ * notification into the harness session when it settles mid-task. Delivery is
+ * withheld while a request_user_input is outstanding so the notice cannot
+ * make the agent re-issue a pending question (#661), and skipped entirely for
+ * settled/idle tasks — `.roomote/setup-status.json` stays the on-disk ground
+ * truth either way.
  */
 export interface BackgroundEnvironmentSetupNotifier {
   /** True while environment setup is still running in the background. */
@@ -45,8 +48,7 @@ export interface BackgroundEnvironmentSetupNotifier {
   /**
    * Register a listener invoked once background setup settles. Fires
    * immediately (synchronously) if setup already settled; never fires when
-   * there is no background setup. Kept for controller/wiring callers; runTask
-   * no longer uses this to wake the agent session.
+   * there is no background setup.
    */
   onSettled(listener: (outcome: EnvironmentSetupSettledOutcome) => void): void;
 }
@@ -164,9 +166,10 @@ export type RunTaskOptions = {
   repoLocalSkills?: RepoLocalSkill[];
   workspaceReadinessWarnings?: string[];
   /**
-   * Observer for environment setup still finishing in the background. Used only
-   * to pick accurate initial readiness wording for sandbox instructions
-   * (`.roomote/setup-status.json`); does not inject mid-task settled notices.
+   * Observer for environment setup still finishing in the background. Used to
+   * pick accurate readiness wording for the agent and to notify it in-session
+   * when setup settles (withheld while a question is pending, dropped once
+   * the task is idle).
    */
   backgroundEnvironmentSetup?: BackgroundEnvironmentSetupNotifier;
   /**


### PR DESCRIPTION
## What changed

Tasks that start while environment setup commands are still running in the background can now continue on their own when setup finishes, instead of reporting themselves blocked and idling until the user sends another message.

Two complementary changes:

1. **Reinstate the in-session settled notice, with a targeted guard.** #661 removed the "Environment setup update…" notice entirely because an unsolicited system turn while an agent was parked on `request_user_input` made it re-issue the question, which Slack rendered as duplicate prompts. This brings the notice back but withholds delivery while the harness phase is `waiting_for_user_input`, retrying on the next phase change once the question is answered. Notices for tasks that have already settled to idle are still dropped (waking an idle task would burn a turn for nothing), and `.roomote/setup-status.json` remains the on-disk ground truth. The notice text also tells the agent not to repeat any still-unanswered question, as insurance for the narrow race between the phase check and the prompt landing.

2. **Tell agents to wait, not bail.** The pending-setup sandbox instruction now says: if the requested work depends on setup that is still running, re-read `.roomote/setup-status.json` every 10-15 seconds until it reaches a terminal state and then continue — do not end the turn as blocked. This borrows the wording the environment-setup skill's verification prompt already uses successfully, and it covers the window before any notice can be delivered.

## Why this change was made

A task that needs the environment (dependency installs, browser installs, secret retrieval) but starts before background setup finishes would check `setup-status.json`, correctly report that setup was pending, and end its turn. Nothing ever woke it, so a request that used to complete in a single message needed several manual follow-ups ("has setup completed?", "ok, now do the thing"). This regressed with #661 (Jul 21), which removed the wakeup added in #333 without a replacement signal.

## Impact

- Agents blocked on background setup now keep polling in-turn and get an in-session notice when setup settles, so single-request flows complete without manual nudges.
- The #661 duplicate-question bug stays fixed: the notice is never injected while a structured question is outstanding.
- No behavior change for tasks whose setup finished before start, or for idle tasks.

## Testing

- New unit tests cover: delivery deferred until `taskStarted`, delivery held during `waiting_for_user_input` and retried after the phase returns to running, stale notices dropped for settled tasks, and the rejected-setup error message.
- `pnpm --filter worker exec vitest run src/run-task/__tests__/run-task.test.ts src/run-task/__tests__/sandbox-instruction.test.ts` — 78 passed.
- `tsc --noEmit`, `oxlint`, `oxfmt --check` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)