### PR TITLE
[Fix] Use priority tier for ChatGPT fast mode

### DIFF
--- a/apps/worker/src/run-task/agent-home.test.ts
+++ b/apps/worker/src/run-task/agent-home.test.ts
@@ -413,10 +413,10 @@ describe('generateOpenCodeConfig provider support', () => {
 
     expect(config.provider.openai?.models?.['gpt-5.6-terra']?.options).toEqual({
       reasoningEffort: 'high',
-      serviceTier: 'fast',
+      serviceTier: 'priority',
     });
     expect(config.provider.openai?.models?.['gpt-5.6-luna']?.options).toEqual({
-      serviceTier: 'fast',
+      serviceTier: 'priority',
     });
     expect(runtimeEnv).not.toHaveProperty('R_CHATGPT_FAST_MODE');
   });

--- a/packages/cloud-agents/src/server/__tests__/opencode-runtime.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/opencode-runtime.test.ts
@@ -103,11 +103,11 @@ describe('buildOpenCodeCliEnv', () => {
             'gpt-5.6-terra': {
               options: {
                 reasoningEffort: 'high',
-                serviceTier: 'fast',
+                serviceTier: 'priority',
               },
             },
             'gpt-5.6-luna': {
-              options: { serviceTier: 'fast' },
+              options: { serviceTier: 'priority' },
             },
           },
         },

--- a/packages/types/src/chatgpt-subscription.test.ts
+++ b/packages/types/src/chatgpt-subscription.test.ts
@@ -19,10 +19,10 @@ describe('mergeOpenCodeChatGptFastModeOptions', () => {
       openai: {
         models: {
           'gpt-5.6-terra': {
-            options: { reasoningEffort: 'high', serviceTier: 'fast' },
+            options: { reasoningEffort: 'high', serviceTier: 'priority' },
           },
-          'gpt-5.6-sol': { options: { serviceTier: 'fast' } },
-          'gpt-5.6-luna': { options: { serviceTier: 'fast' } },
+          'gpt-5.6-sol': { options: { serviceTier: 'priority' } },
+          'gpt-5.6-luna': { options: { serviceTier: 'priority' } },
         },
       },
     });

--- a/packages/types/src/chatgpt-subscription.ts
+++ b/packages/types/src/chatgpt-subscription.ts
@@ -44,6 +44,11 @@ const CHATGPT_FAST_MODE_MODEL_IDS = new Set([
   'gpt-5.6-luna',
 ]);
 
+// Codex calls this user-facing mode "fast", but its canonical Responses API
+// service tier is `priority`. OpenCode validates model provider options before
+// sending the request and rejects the legacy `fast` alias.
+const CHATGPT_FAST_MODE_SERVICE_TIER = 'priority';
+
 /**
  * Adds ChatGPT fast mode to supported OpenAI models while preserving any
  * existing per-model options such as reasoning effort.
@@ -79,7 +84,10 @@ export function mergeOpenCodeChatGptFastModeOptions(
           ...models,
           [openCodeModelId]: {
             ...model,
-            options: { ...options, serviceTier: 'fast' },
+            options: {
+              ...options,
+              serviceTier: CHATGPT_FAST_MODE_SERVICE_TIER,
+            },
           },
         },
       },


### PR DESCRIPTION
## Summary

- emit OpenAI’s canonical `priority` service tier for ChatGPT Fast mode
- preserve existing per-model reasoning options
- update worker and control-plane config regression coverage

## Root cause

Roomote configured OpenCode with `serviceTier: "fast"`. OpenCode validates this option before sending a request and only accepts its canonical service-tier values, so ChatGPT subscription runs failed with an invalid provider-options error. Codex maps the user-facing Fast mode to the `priority` request tier.

## Impact

ChatGPT subscription users can enable Fast mode without preventing OpenCode tasks from starting.

## Validation

- `@roomote/types`: 2 focused tests passed
- `@roomote/worker`: 41 focused tests passed
- `@roomote/cloud-agents`: 16 focused tests passed
- package typechecks passed for types, worker, and cloud-agents
- oxlint, residual lint, and the full fast typecheck passed