### PR TITLE
[Fix] Wake idle tasks when background environment setup finishes

### DIFF
--- a/apps/worker/src/run-task/__tests__/run-task.test.ts
+++ b/apps/worker/src/run-task/__tests__/run-task.test.ts
@@ -2741,13 +2741,13 @@ describe('runTask', () => {
       expect(environmentSetupNoticeCalls(manager)).toHaveLength(1);
     });
 
-    it('drops the settled notice when the task is no longer running', async () => {
+    it('drops the settled notice when the task is stopped', async () => {
       const { manager, settledListener } = await runTaskWithBackgroundSetup();
 
       manager.emit('taskStateEvent', 'taskStarted');
       manager.getStatus.mockReturnValue({
         isConnected: true,
-        phase: 'waiting_for_prompt',
+        phase: 'stopped',
         sessionId: undefined,
       });
       settledListener!({ status: 'fulfilled', warningMessages: [] });
@@ -2762,6 +2762,64 @@ describe('runTask', () => {
       });
       manager.emit('stateChange', 'running', {});
       expect(environmentSetupNoticeCalls(manager)).toHaveLength(0);
+    });
+
+    it('wakes a task that went idle while setup was still running with an idle-aware notice', async () => {
+      const { manager, settledListener } = await runTaskWithBackgroundSetup();
+
+      manager.emit('taskStateEvent', 'taskStarted');
+      manager.getStatus.mockReturnValue({
+        isConnected: true,
+        phase: 'waiting_for_prompt',
+        sessionId: undefined,
+      });
+      settledListener!({
+        status: 'fulfilled',
+        warningMessages: ['Dev server never became ready'],
+      });
+
+      const noticeCalls = environmentSetupNoticeCalls(manager);
+
+      expect(noticeCalls).toHaveLength(1);
+      expect(noticeCalls[0]![0]).toMatchObject({
+        visibleInTranscript: false,
+        source: 'environment-setup',
+      });
+      expect(noticeCalls[0]![0].prompt).toContain(
+        'Dev server never became ready',
+      );
+      expect(noticeCalls[0]![0].prompt).toContain(
+        'Your previous turn ended while this environment setup was still running.',
+      );
+      expect(noticeCalls[0]![0].prompt).toContain(
+        'end this turn immediately without calling any tools',
+      );
+
+      // The wake consumes the outcome; later phase changes must not re-send.
+      manager.getStatus.mockReturnValue({
+        isConnected: true,
+        phase: 'running',
+        sessionId: undefined,
+      });
+      manager.emit('stateChange', 'running', {});
+      expect(environmentSetupNoticeCalls(manager)).toHaveLength(1);
+    });
+
+    it('does not use the idle wake wording for a task that is actively running', async () => {
+      const { manager, settledListener } = await runTaskWithBackgroundSetup();
+
+      manager.emit('taskStateEvent', 'taskStarted');
+      settledListener!({ status: 'fulfilled', warningMessages: [] });
+
+      const noticeCalls = environmentSetupNoticeCalls(manager);
+
+      expect(noticeCalls).toHaveLength(1);
+      expect(noticeCalls[0]![0].prompt).not.toContain(
+        'Your previous turn ended',
+      );
+      expect(noticeCalls[0]![0].prompt).toContain(
+        'Continue with the user request',
+      );
     });
 
     it('reports a rejected background setup with the error message', async () => {

--- a/apps/worker/src/run-task/run-task.ts
+++ b/apps/worker/src/run-task/run-task.ts
@@ -156,8 +156,7 @@ function buildEnvironmentSetupSettledPrompt(
 
   if (outcome.status === 'rejected') {
     return [
-      'Environment setup update: background environment setup failed unexpectedly.',
-      `Error: ${outcome.errorMessage}`,
+      ...buildEnvironmentSetupSettledOutcomeSummary(outcome),
       'Check `.roomote/setup-status.json` and `.roomote/setup-logs/` in the workspace root before relying on installed dependencies or running services. Continue with the user request and mention the failure if it affects your work.',
       doNotRepeatQuestions,
     ].join('\n');
@@ -165,16 +164,60 @@ function buildEnvironmentSetupSettledPrompt(
 
   if (outcome.warningMessages.length > 0) {
     return [
-      'Environment setup update: background environment setup (repository setup commands and Docker projects) finished with warnings:',
-      ...outcome.warningMessages.map((warning) => `- ${warning}`),
+      ...buildEnvironmentSetupSettledOutcomeSummary(outcome),
       'Details are in `.roomote/setup-status.json` and `.roomote/setup-logs/` in the workspace root. Verify anything you depend on is actually available. Continue with the user request; only mention this if it affects your work.',
       doNotRepeatQuestions,
     ].join('\n');
   }
 
   return [
-    'Environment setup update: background environment setup (repository setup commands and Docker projects) finished successfully. The environment is now fully configured; `.roomote/setup-status.json` has per-command results. Continue with the user request — no action or acknowledgement is needed.',
+    ...buildEnvironmentSetupSettledOutcomeSummary(outcome),
+    'The environment is now fully configured; `.roomote/setup-status.json` has per-command results. Continue with the user request — no action or acknowledgement is needed.',
     doNotRepeatQuestions,
+  ].join('\n');
+}
+
+function buildEnvironmentSetupSettledOutcomeSummary(
+  outcome: EnvironmentSetupSettledOutcome,
+): string[] {
+  if (outcome.status === 'rejected') {
+    return [
+      'Environment setup update: background environment setup failed unexpectedly.',
+      `Error: ${outcome.errorMessage}`,
+    ];
+  }
+
+  if (outcome.warningMessages.length > 0) {
+    return [
+      'Environment setup update: background environment setup (repository setup commands and Docker projects) finished with warnings:',
+      ...outcome.warningMessages.map((warning) => `- ${warning}`),
+    ];
+  }
+
+  return [
+    'Environment setup update: background environment setup (repository setup commands and Docker projects) finished successfully.',
+  ];
+}
+
+/**
+ * Variant of the settled notice used to wake a task that went idle while
+ * background setup was still running, so a task that reported itself blocked
+ * on setup can resume without a manual user nudge. The zero-tool-call escape
+ * hatch is load-bearing: after a terminal closeout, any non-Slack tool call
+ * re-arms the Slack stop hook's closeout requirement
+ * (current_turn_terminal_reply_stale), so an agent that "just checks"
+ * something before ending an already-completed task would be forced to post
+ * a redundant message.
+ */
+function buildEnvironmentSetupSettledWakePrompt(
+  outcome: EnvironmentSetupSettledOutcome,
+): string {
+  return [
+    ...buildEnvironmentSetupSettledOutcomeSummary(outcome),
+    'Per-command results are in `.roomote/setup-status.json` in the workspace root, with output logs under `.roomote/setup-logs/`.',
+    'Your previous turn ended while this environment setup was still running.',
+    "If any part of the user's request was deferred or reported as blocked because setup had not finished, continue that work now and report the outcome as you normally would.",
+    'If the request was already fully handled, end this turn immediately without calling any tools and without posting any message — this update needs no acknowledgement.',
   ].join('\n');
 }
 
@@ -1336,9 +1379,11 @@ export const runTask = async ({
     // notice instead of injecting: an unsolicited system turn at that point
     // made agents re-issue the pending request_user_input, which Slack
     // rendered as duplicate questions (#661). A held notice is retried on the
-    // next phase change once the answer arrives. If the task has settled to
-    // idle, drop the notice — waking an idle task would burn a turn for
-    // nothing, and .roomote/setup-status.json already has the ground truth.
+    // next phase change once the answer arrives. A task that settled to
+    // waiting_for_prompt is woken with an idle-aware variant — it may have
+    // ended its turn reporting itself blocked on setup — while stopped or
+    // shutting-down tasks drop the notice; .roomote/setup-status.json keeps
+    // the ground truth either way.
     let pendingEnvironmentSetupOutcome:
       | EnvironmentSetupSettledOutcome
       | undefined;
@@ -1362,23 +1407,32 @@ export const runTask = async ({
 
       pendingEnvironmentSetupOutcome = undefined;
 
-      if (phase !== 'running') {
+      // A task that settled to waiting_for_prompt while setup was still
+      // running may have ended its turn reporting itself blocked on setup, so
+      // wake it with an idle-aware notice instead of dropping the outcome.
+      // Any other non-running phase (stopped, shutting down) stays dropped.
+      const wakeFromIdle = phase === 'waiting_for_prompt';
+
+      if (phase !== 'running' && !wakeFromIdle) {
         return;
       }
 
       const sent = currentManager.sendFollowUpPrompt({
-        prompt: buildEnvironmentSetupSettledPrompt(outcome),
+        prompt: wakeFromIdle
+          ? buildEnvironmentSetupSettledWakePrompt(outcome)
+          : buildEnvironmentSetupSettledPrompt(outcome),
         visibleInTranscript: false,
         source: 'environment-setup',
       });
 
       void recordWorkerRuntimeEvent({
         eventType: 'decision',
-        message: `Background environment setup settled (${outcome.status}) while task run #${taskRun.id} was running; in-session notification ${sent ? 'delivered' : 'was not accepted by the harness'}.`,
+        message: `Background environment setup settled (${outcome.status}) while task run #${taskRun.id} was ${wakeFromIdle ? 'idle' : 'running'}; in-session ${wakeFromIdle ? 'wake-up' : 'notification'} ${sent ? 'delivered' : 'was not accepted by the harness'}.`,
         details: {
           reason: 'background_environment_setup_notification',
           outcome: outcome.status,
           delivered: sent,
+          wakeFromIdle,
         },
       });
     };

--- a/apps/worker/src/run-task/types.ts
+++ b/apps/worker/src/run-task/types.ts
@@ -38,9 +38,11 @@ export type EnvironmentSetupSettledOutcome =
  * runTask to (a) tell the agent whether setup is still running and (b) push a
  * notification into the harness session when it settles mid-task. Delivery is
  * withheld while a request_user_input is outstanding so the notice cannot
- * make the agent re-issue a pending question (#661), and skipped entirely for
- * settled/idle tasks — `.roomote/setup-status.json` stays the on-disk ground
- * truth either way.
+ * make the agent re-issue a pending question (#661). A task that went idle
+ * while setup was still running is woken with an idle-aware variant so it can
+ * resume work it reported as blocked; stopped or shutting-down tasks drop the
+ * notice. `.roomote/setup-status.json` stays the on-disk ground truth either
+ * way.
  */
 export interface BackgroundEnvironmentSetupNotifier {
   /** True while environment setup is still running in the background. */
@@ -168,8 +170,9 @@ export type RunTaskOptions = {
   /**
    * Observer for environment setup still finishing in the background. Used to
    * pick accurate readiness wording for the agent and to notify it in-session
-   * when setup settles (withheld while a question is pending, dropped once
-   * the task is idle).
+   * when setup settles (withheld while a question is pending, delivered as an
+   * idle wake-up when the task settled mid-setup, dropped once the task is
+   * stopped or shutting down).
    */
   backgroundEnvironmentSetup?: BackgroundEnvironmentSetupNotifier;
   /**


### PR DESCRIPTION
## What changed

Follow-up to #909. When background environment setup settles and the task has already gone idle (`waiting_for_prompt`), the runtime now wakes it with an idle-aware variant of the settle notice instead of dropping the notice. Stopped and shutting-down tasks still drop it, and the #909 behaviors (mid-turn delivery, hold while a question is pending) are unchanged.

The idle wake prompt tells the agent:

- setup finished (with the same success/warnings/failure summary as the mid-turn notice, plus the `.roomote/setup-status.json` / `.roomote/setup-logs/` pointers),
- if any part of the user's request was deferred or reported as blocked on setup, continue that work now and report the outcome as usual,
- if the request was already fully handled, end the turn immediately **without calling any tools** and without posting anything.

The zero-tool-call instruction is load-bearing: after a terminal closeout, any non-Slack tool call re-arms the Slack stop hook's closeout requirement (`current_turn_terminal_reply_stale`), so an agent that "just checks" something before ending an already-completed task would be forced to post a redundant "nothing to do" message. Conversely, an agent that resumes real deferred work will do tool calls, and the same hook then correctly requires a fresh closeout reporting the outcome — the existing machinery enforces exactly the right behavior on both paths.

## Why this change was made

#909 closed the main gap with two layers: agents are instructed to keep polling `setup-status.json` instead of idling while blocked, and running sessions get a settle notice. But the notice was still dropped for idle tasks, so a single prompt-miss — an agent that ends its turn as "blocked on setup" anyway — recreated the original stall where the user had to manually nudge the task. This adds the safety net for that cohort. The gate is narrow: only tasks that went idle *while setup was still running* are woken; tasks that idled after setup completed never see it.

## Impact

- A task that reported itself blocked on setup and went idle now resumes and finishes on its own once setup settles.
- Tasks that were already done get one cheap wake turn that ends silently; no user-visible messages are added.
- No change for running tasks, question-blocked tasks, or stopped/shutting-down tasks.

## Testing

- New unit tests: idle wake delivers the idle-aware wording (and consumes the outcome — no re-delivery on later phase changes), running tasks keep the mid-turn wording, stopped tasks still drop the notice.
- `pnpm --filter worker exec vitest run src/run-task/__tests__/run-task.test.ts src/run-task/__tests__/sandbox-instruction.test.ts` — 80 passed.
- `tsc --noEmit`, `oxlint`, `oxfmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)