### PR TITLE
[Fix] Active PR reviews include newly pushed commits

### DIFF
--- a/apps/api/src/handlers/github/__tests__/handlePrSynchronize.test.ts
+++ b/apps/api/src/handlers/github/__tests__/handlePrSynchronize.test.ts
@@ -2,28 +2,24 @@ import type { WebhookPullRequestSynchronize } from '../types';
 
 const {
   mockAcquireRedisLock,
-  mockBuildGitHubPrSynchronizeFollowUpMessage,
+  mockEnqueueActivePrReviewFollowUp,
   mockEnqueueTask,
   mockGetGitHubAutomationTargets,
   mockReleaseLock,
-  mockSendPrompt,
   mockSelect,
   mockUpdate,
   mockUpdateSet,
   mockUpdateWhere,
-  mockWithSandboxServerRpcClient,
 } = vi.hoisted(() => ({
   mockAcquireRedisLock: vi.fn(),
-  mockBuildGitHubPrSynchronizeFollowUpMessage: vi.fn(),
+  mockEnqueueActivePrReviewFollowUp: vi.fn(),
   mockEnqueueTask: vi.fn(),
   mockGetGitHubAutomationTargets: vi.fn(),
   mockReleaseLock: vi.fn().mockResolvedValue(undefined),
-  mockSendPrompt: vi.fn(),
   mockSelect: vi.fn(),
   mockUpdate: vi.fn(),
   mockUpdateSet: vi.fn(),
   mockUpdateWhere: vi.fn(),
-  mockWithSandboxServerRpcClient: vi.fn(),
 }));
 
 vi.mock('@roomote/redis', () => ({
@@ -31,14 +27,12 @@ vi.mock('@roomote/redis', () => ({
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
-  buildGitHubPrSynchronizeFollowUpMessage: (...args: unknown[]) =>
-    mockBuildGitHubPrSynchronizeFollowUpMessage(...args),
   enqueueTask: (...args: unknown[]) => mockEnqueueTask(...args),
 }));
 
 vi.mock('@roomote/sdk/server', () => ({
-  withSandboxServerRpcClient: (...args: unknown[]) =>
-    mockWithSandboxServerRpcClient(...args),
+  enqueueActivePrReviewFollowUp: (...args: unknown[]) =>
+    mockEnqueueActivePrReviewFollowUp(...args),
 }));
 
 vi.mock('@roomote/db/server', async () => {
@@ -103,16 +97,7 @@ describe('handlePrSynchronize', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockAcquireRedisLock.mockResolvedValue(mockReleaseLock);
-    mockBuildGitHubPrSynchronizeFollowUpMessage.mockReturnValue(
-      'Review the latest live PR head.',
-    );
-    mockSendPrompt.mockResolvedValue({ success: true });
-    mockWithSandboxServerRpcClient.mockImplementation(
-      ({ call }: { call: (client: unknown) => Promise<unknown> }) =>
-        call({
-          commands: { sendPrompt: { mutate: mockSendPrompt } },
-        }),
-    );
+    mockEnqueueActivePrReviewFollowUp.mockResolvedValue(undefined);
     mockUpdate.mockReturnValue({ set: mockUpdateSet });
     mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
     mockUpdateWhere.mockResolvedValue(undefined);
@@ -149,7 +134,7 @@ describe('handlePrSynchronize', () => {
     });
 
     expect(mockEnqueueTask).not.toHaveBeenCalled();
-    expect(mockWithSandboxServerRpcClient).not.toHaveBeenCalled();
+    expect(mockEnqueueActivePrReviewFollowUp).not.toHaveBeenCalled();
     expect(mockUpdate).not.toHaveBeenCalled();
     expect(mockReleaseLock).toHaveBeenCalledOnce();
   });
@@ -175,11 +160,11 @@ describe('handlePrSynchronize', () => {
 
     expect(mockUpdateSet).toHaveBeenCalledWith({ prSha: 'new-head' });
     expect(mockEnqueueTask).not.toHaveBeenCalled();
-    expect(mockWithSandboxServerRpcClient).not.toHaveBeenCalled();
+    expect(mockEnqueueActivePrReviewFollowUp).not.toHaveBeenCalled();
     expect(mockReleaseLock).toHaveBeenCalledOnce();
   });
 
-  it('natively steers new commits into an active OpenCode review', async () => {
+  it('debounces new commits onto the active OpenCode review', async () => {
     mockSelect.mockReturnValueOnce(
       selectResult([
         {
@@ -198,32 +183,29 @@ describe('handlePrSynchronize', () => {
       message: 'Queued new PR changes on the active review.',
     });
 
-    expect(mockBuildGitHubPrSynchronizeFollowUpMessage).toHaveBeenCalledWith({
-      repository: 'owner/repo',
-      prNumber: 42,
-      previousHeadSha: 'old-head',
-      eventHeadSha: 'new-head',
-    });
-    expect(mockWithSandboxServerRpcClient).toHaveBeenCalledWith(
+    expect(mockEnqueueActivePrReviewFollowUp).toHaveBeenCalledWith(
       expect.objectContaining({
         runId: 100,
-        userId: null,
+        taskId: 'task-100',
         sandboxServerUrl: 'http://sandbox.test',
+        repository: 'owner/repo',
+        prNumber: 42,
+        previousHeadSha: 'old-head',
+        eventHeadSha: 'new-head',
+        fallback: expect.objectContaining({
+          task: expect.objectContaining({
+            type: 'github_pr_review_sync',
+            payload: expect.objectContaining({ headSha: 'new-head' }),
+          }),
+        }),
       }),
     );
-    expect(mockSendPrompt).toHaveBeenCalledWith({
-      prompt: 'Review the latest live PR head.',
-      source: 'github-pr-synchronize',
-      clientMessageId: 'github-pr-synchronize:owner/repo:42:new-head',
-      autoSteerWhenQueued: true,
-      visibleInTranscript: false,
-    });
-    expect(mockUpdateSet).toHaveBeenCalledWith({ prSha: 'new-head' });
+    expect(mockUpdate).not.toHaveBeenCalled();
     expect(mockEnqueueTask).not.toHaveBeenCalled();
     expect(mockReleaseLock).toHaveBeenCalledOnce();
   });
 
-  it('leaves the stored head unchanged when active-review steering fails', async () => {
+  it('leaves the stored head unchanged when debounce scheduling fails', async () => {
     mockSelect.mockReturnValueOnce(
       selectResult([
         {
@@ -236,10 +218,12 @@ describe('handlePrSynchronize', () => {
         },
       ]),
     );
-    mockSendPrompt.mockRejectedValueOnce(new Error('sandbox unavailable'));
+    mockEnqueueActivePrReviewFollowUp.mockRejectedValueOnce(
+      new Error('queue unavailable'),
+    );
 
     await expect(handlePrSynchronize(payload)).rejects.toThrow(
-      'sandbox unavailable',
+      'queue unavailable',
     );
 
     expect(mockUpdate).not.toHaveBeenCalled();

--- a/apps/api/src/handlers/github/__tests__/handlePrSynchronize.test.ts
+++ b/apps/api/src/handlers/github/__tests__/handlePrSynchronize.test.ts
@@ -2,22 +2,28 @@ import type { WebhookPullRequestSynchronize } from '../types';
 
 const {
   mockAcquireRedisLock,
+  mockBuildGitHubPrSynchronizeFollowUpMessage,
   mockEnqueueTask,
   mockGetGitHubAutomationTargets,
   mockReleaseLock,
+  mockSendPrompt,
   mockSelect,
   mockUpdate,
   mockUpdateSet,
   mockUpdateWhere,
+  mockWithSandboxServerRpcClient,
 } = vi.hoisted(() => ({
   mockAcquireRedisLock: vi.fn(),
+  mockBuildGitHubPrSynchronizeFollowUpMessage: vi.fn(),
   mockEnqueueTask: vi.fn(),
   mockGetGitHubAutomationTargets: vi.fn(),
   mockReleaseLock: vi.fn().mockResolvedValue(undefined),
+  mockSendPrompt: vi.fn(),
   mockSelect: vi.fn(),
   mockUpdate: vi.fn(),
   mockUpdateSet: vi.fn(),
   mockUpdateWhere: vi.fn(),
+  mockWithSandboxServerRpcClient: vi.fn(),
 }));
 
 vi.mock('@roomote/redis', () => ({
@@ -25,7 +31,14 @@ vi.mock('@roomote/redis', () => ({
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
+  buildGitHubPrSynchronizeFollowUpMessage: (...args: unknown[]) =>
+    mockBuildGitHubPrSynchronizeFollowUpMessage(...args),
   enqueueTask: (...args: unknown[]) => mockEnqueueTask(...args),
+}));
+
+vi.mock('@roomote/sdk/server', () => ({
+  withSandboxServerRpcClient: (...args: unknown[]) =>
+    mockWithSandboxServerRpcClient(...args),
 }));
 
 vi.mock('@roomote/db/server', async () => {
@@ -90,6 +103,16 @@ describe('handlePrSynchronize', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockAcquireRedisLock.mockResolvedValue(mockReleaseLock);
+    mockBuildGitHubPrSynchronizeFollowUpMessage.mockReturnValue(
+      'Review the latest live PR head.',
+    );
+    mockSendPrompt.mockResolvedValue({ success: true });
+    mockWithSandboxServerRpcClient.mockImplementation(
+      ({ call }: { call: (client: unknown) => Promise<unknown> }) =>
+        call({
+          commands: { sendPrompt: { mutate: mockSendPrompt } },
+        }),
+    );
     mockUpdate.mockReturnValue({ set: mockUpdateSet });
     mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
     mockUpdateWhere.mockResolvedValue(undefined);
@@ -107,7 +130,18 @@ describe('handlePrSynchronize', () => {
   });
 
   it('keeps the existing non-terminal review and prevents a new run', async () => {
-    mockSelect.mockReturnValueOnce(selectResult([{ id: 100 }]));
+    mockSelect.mockReturnValueOnce(
+      selectResult([
+        {
+          id: 100,
+          taskId: 'task-100',
+          status: 'running',
+          startedAt: new Date(),
+          sandboxServerUrl: 'http://sandbox.test',
+          prSha: 'new-head',
+        },
+      ]),
+    );
 
     await expect(handlePrSynchronize(payload)).resolves.toEqual({
       status: 'ok',
@@ -115,6 +149,8 @@ describe('handlePrSynchronize', () => {
     });
 
     expect(mockEnqueueTask).not.toHaveBeenCalled();
+    expect(mockWithSandboxServerRpcClient).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
     expect(mockReleaseLock).toHaveBeenCalledOnce();
   });
 
@@ -125,6 +161,8 @@ describe('handlePrSynchronize', () => {
           id: 100,
           taskId: 'task-100',
           status: 'pending',
+          startedAt: null,
+          sandboxServerUrl: null,
           prSha: 'old-head',
         },
       ]),
@@ -136,6 +174,75 @@ describe('handlePrSynchronize', () => {
     });
 
     expect(mockUpdateSet).toHaveBeenCalledWith({ prSha: 'new-head' });
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
+    expect(mockWithSandboxServerRpcClient).not.toHaveBeenCalled();
+    expect(mockReleaseLock).toHaveBeenCalledOnce();
+  });
+
+  it('natively steers new commits into an active OpenCode review', async () => {
+    mockSelect.mockReturnValueOnce(
+      selectResult([
+        {
+          id: 100,
+          taskId: 'task-100',
+          status: 'running',
+          startedAt: new Date(),
+          sandboxServerUrl: 'http://sandbox.test',
+          prSha: 'old-head',
+        },
+      ]),
+    );
+
+    await expect(handlePrSynchronize(payload)).resolves.toEqual({
+      status: 'ok',
+      message: 'Queued new PR changes on the active review.',
+    });
+
+    expect(mockBuildGitHubPrSynchronizeFollowUpMessage).toHaveBeenCalledWith({
+      repository: 'owner/repo',
+      prNumber: 42,
+      previousHeadSha: 'old-head',
+      eventHeadSha: 'new-head',
+    });
+    expect(mockWithSandboxServerRpcClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 100,
+        userId: null,
+        sandboxServerUrl: 'http://sandbox.test',
+      }),
+    );
+    expect(mockSendPrompt).toHaveBeenCalledWith({
+      prompt: 'Review the latest live PR head.',
+      source: 'github-pr-synchronize',
+      clientMessageId: 'github-pr-synchronize:owner/repo:42:new-head',
+      autoSteerWhenQueued: true,
+      visibleInTranscript: false,
+    });
+    expect(mockUpdateSet).toHaveBeenCalledWith({ prSha: 'new-head' });
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
+    expect(mockReleaseLock).toHaveBeenCalledOnce();
+  });
+
+  it('leaves the stored head unchanged when active-review steering fails', async () => {
+    mockSelect.mockReturnValueOnce(
+      selectResult([
+        {
+          id: 100,
+          taskId: 'task-100',
+          status: 'running',
+          startedAt: new Date(),
+          sandboxServerUrl: 'http://sandbox.test',
+          prSha: 'old-head',
+        },
+      ]),
+    );
+    mockSendPrompt.mockRejectedValueOnce(new Error('sandbox unavailable'));
+
+    await expect(handlePrSynchronize(payload)).rejects.toThrow(
+      'sandbox unavailable',
+    );
+
+    expect(mockUpdate).not.toHaveBeenCalled();
     expect(mockEnqueueTask).not.toHaveBeenCalled();
     expect(mockReleaseLock).toHaveBeenCalledOnce();
   });

--- a/apps/api/src/handlers/github/handlePrSynchronize.ts
+++ b/apps/api/src/handlers/github/handlePrSynchronize.ts
@@ -21,8 +21,12 @@ import {
   not,
   sql,
 } from '@roomote/db/server';
-import { enqueueTask } from '@roomote/cloud-agents/server';
+import {
+  buildGitHubPrSynchronizeFollowUpMessage,
+  enqueueTask,
+} from '@roomote/cloud-agents/server';
 import { acquireRedisLock } from '@roomote/redis';
+import { withSandboxServerRpcClient } from '@roomote/sdk/server';
 
 import type { WebhookResponse } from '../../types';
 import { toHostFromUrl } from '../utils';
@@ -38,6 +42,8 @@ async function findActiveReviewRun(repository: string, prNumber: number) {
       id: taskRuns.id,
       taskId: taskRuns.taskId,
       status: taskRuns.status,
+      startedAt: taskRuns.startedAt,
+      sandboxServerUrl: taskRuns.sandboxServerUrl,
       prSha: taskPullRequests.prSha,
     })
     .from(tasks)
@@ -103,6 +109,45 @@ async function acquirePrReviewLaunchLock(repository: string, prNumber: number) {
   return null;
 }
 
+async function queueActiveReviewFollowUp({
+  runId,
+  sandboxServerUrl,
+  repository,
+  prNumber,
+  previousHeadSha,
+  eventHeadSha,
+}: {
+  runId: number;
+  sandboxServerUrl: string;
+  repository: string;
+  prNumber: number;
+  previousHeadSha: string | null;
+  eventHeadSha: string;
+}) {
+  const prompt = buildGitHubPrSynchronizeFollowUpMessage({
+    repository,
+    prNumber,
+    previousHeadSha,
+    eventHeadSha,
+  });
+
+  await withSandboxServerRpcClient({
+    runId,
+    // This is a platform event, not a human handoff. A deployment-principal
+    // token preserves the review's current acting user and credentials.
+    userId: null,
+    sandboxServerUrl,
+    call: (client) =>
+      client.commands.sendPrompt.mutate({
+        prompt,
+        source: 'github-pr-synchronize',
+        clientMessageId: `github-pr-synchronize:${repository}:${prNumber}:${eventHeadSha}`,
+        autoSteerWhenQueued: true,
+        visibleInTranscript: false,
+      }),
+  });
+}
+
 export async function handlePrSynchronize({
   installation,
   repository,
@@ -143,6 +188,7 @@ export async function handlePrSynchronize({
 
   const target = targets[0];
   let skippedCompletedHead = false;
+  let queuedActiveReviewFollowUp = false;
 
   if (!target) {
     return { status: 'ok', message: 'No PR reviewer targets found.' };
@@ -167,18 +213,37 @@ export async function handlePrSynchronize({
       );
 
       if (activeReviewRun) {
-        if (
-          activeReviewRun.status === RunStatus.Pending &&
-          activeReviewRun.prSha !== pr.head.sha
-        ) {
-          await db
-            .update(taskPullRequests)
-            .set({ prSha: pr.head.sha })
-            .where(eq(taskPullRequests.taskId, activeReviewRun.taskId));
+        if (activeReviewRun.prSha === pr.head.sha) {
+          console.log(
+            `[handlePrSynchronize] ${repository.full_name}#${pr.number} -> skip_active_review_same_head (target: ${currentTarget.id})`,
+          );
+
+          return null;
         }
 
+        if (activeReviewRun.startedAt && activeReviewRun.sandboxServerUrl) {
+          await queueActiveReviewFollowUp({
+            runId: activeReviewRun.id,
+            sandboxServerUrl: activeReviewRun.sandboxServerUrl,
+            repository: repository.full_name,
+            prNumber: pr.number,
+            previousHeadSha: activeReviewRun.prSha,
+            eventHeadSha: pr.head.sha,
+          });
+          queuedActiveReviewFollowUp = true;
+        }
+
+        await db
+          .update(taskPullRequests)
+          .set({ prSha: pr.head.sha })
+          .where(eq(taskPullRequests.taskId, activeReviewRun.taskId));
+
         console.log(
-          `[handlePrSynchronize] ${repository.full_name}#${pr.number} -> skip_active_review (target: ${currentTarget.id})`,
+          `[handlePrSynchronize] ${repository.full_name}#${pr.number} -> ${
+            activeReviewRun.startedAt && activeReviewRun.sandboxServerUrl
+              ? 'queue_active_review_follow_up'
+              : 'update_pending_review_head'
+          } (target: ${currentTarget.id})`,
         );
 
         return null;
@@ -288,9 +353,11 @@ export async function handlePrSynchronize({
   if (ids.length === 0) {
     return {
       status: 'ok',
-      message: skippedCompletedHead
-        ? 'PR head SHA already matches the latest reviewed SHA.'
-        : 'A PR review is already active.',
+      message: queuedActiveReviewFollowUp
+        ? 'Queued new PR changes on the active review.'
+        : skippedCompletedHead
+          ? 'PR head SHA already matches the latest reviewed SHA.'
+          : 'A PR review is already active.',
     };
   }
 

--- a/apps/api/src/handlers/github/handlePrSynchronize.ts
+++ b/apps/api/src/handlers/github/handlePrSynchronize.ts
@@ -21,12 +21,9 @@ import {
   not,
   sql,
 } from '@roomote/db/server';
-import {
-  buildGitHubPrSynchronizeFollowUpMessage,
-  enqueueTask,
-} from '@roomote/cloud-agents/server';
+import { enqueueTask } from '@roomote/cloud-agents/server';
 import { acquireRedisLock } from '@roomote/redis';
-import { withSandboxServerRpcClient } from '@roomote/sdk/server';
+import { enqueueActivePrReviewFollowUp } from '@roomote/sdk/server';
 
 import type { WebhookResponse } from '../../types';
 import { toHostFromUrl } from '../utils';
@@ -109,45 +106,6 @@ async function acquirePrReviewLaunchLock(repository: string, prNumber: number) {
   return null;
 }
 
-async function queueActiveReviewFollowUp({
-  runId,
-  sandboxServerUrl,
-  repository,
-  prNumber,
-  previousHeadSha,
-  eventHeadSha,
-}: {
-  runId: number;
-  sandboxServerUrl: string;
-  repository: string;
-  prNumber: number;
-  previousHeadSha: string | null;
-  eventHeadSha: string;
-}) {
-  const prompt = buildGitHubPrSynchronizeFollowUpMessage({
-    repository,
-    prNumber,
-    previousHeadSha,
-    eventHeadSha,
-  });
-
-  await withSandboxServerRpcClient({
-    runId,
-    // This is a platform event, not a human handoff. A deployment-principal
-    // token preserves the review's current acting user and credentials.
-    userId: null,
-    sandboxServerUrl,
-    call: (client) =>
-      client.commands.sendPrompt.mutate({
-        prompt,
-        source: 'github-pr-synchronize',
-        clientMessageId: `github-pr-synchronize:${repository}:${prNumber}:${eventHeadSha}`,
-        autoSteerWhenQueued: true,
-        visibleInTranscript: false,
-      }),
-  });
-}
-
 export async function handlePrSynchronize({
   installation,
   repository,
@@ -222,21 +180,64 @@ export async function handlePrSynchronize({
         }
 
         if (activeReviewRun.startedAt && activeReviewRun.sandboxServerUrl) {
-          await queueActiveReviewFollowUp({
+          const relayPayload = await getReviewTaskRelayPayload({
+            repository: repository.full_name,
+            prNumber: pr.number,
+            branchName: pr.head.ref,
+            prBody: pr.body ?? null,
+            reviewerSettings: currentTarget.settings,
+          });
+
+          await enqueueActivePrReviewFollowUp({
             runId: activeReviewRun.id,
+            taskId: activeReviewRun.taskId,
             sandboxServerUrl: activeReviewRun.sandboxServerUrl,
             repository: repository.full_name,
             prNumber: pr.number,
             previousHeadSha: activeReviewRun.prSha,
             eventHeadSha: pr.head.sha,
+            fallback: {
+              task: {
+                type: TaskPayloadKind.GithubPrReviewSync,
+                ...getBackgroundGithubTaskProperties(currentTarget.properties),
+                payload: {
+                  repo: repository.full_name,
+                  prNumber: pr.number,
+                  prTitle: pr.title,
+                  prUrl: pr.html_url,
+                  headSha: pr.head.sha,
+                  branchName: pr.head.ref,
+                  ...relayPayload,
+                },
+              },
+              initiatorActor: {
+                externalId: String(sender.id),
+                displayName: sender.login,
+              },
+              prLinkage: {
+                provider: 'github',
+                host:
+                  currentTarget.repo.host ??
+                  toHostFromUrl(pr.html_url) ??
+                  'github.com',
+                repositoryId: currentTarget.repo.id,
+                repository: repository.full_name,
+                prNumber: pr.number,
+                prUrl: pr.html_url,
+                prTitle: pr.title,
+                prSha: pr.head.sha,
+                prBaseRef: pr.base?.ref ?? null,
+                prBaseSha: pr.base?.sha ?? null,
+              },
+            },
           });
           queuedActiveReviewFollowUp = true;
+        } else {
+          await db
+            .update(taskPullRequests)
+            .set({ prSha: pr.head.sha })
+            .where(eq(taskPullRequests.taskId, activeReviewRun.taskId));
         }
-
-        await db
-          .update(taskPullRequests)
-          .set({ prSha: pr.head.sha })
-          .where(eq(taskPullRequests.taskId, activeReviewRun.taskId));
 
         console.log(
           `[handlePrSynchronize] ${repository.full_name}#${pr.number} -> ${

--- a/apps/bullmq/src/active-pr-review-follow-up-producer.test.ts
+++ b/apps/bullmq/src/active-pr-review-follow-up-producer.test.ts
@@ -1,0 +1,71 @@
+const mockQueueAdd = vi.fn();
+
+vi.mock('@roomote/redis', () => ({
+  getRedis: vi.fn(() => ({})),
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class MockQueue {
+    add = (...args: unknown[]) => mockQueueAdd(...args);
+  },
+}));
+
+import {
+  ACTIVE_PR_REVIEW_FOLLOW_UP_DEBOUNCE_MS,
+  enqueueActivePrReviewFollowUp,
+} from '@roomote/sdk/server';
+
+const request = {
+  runId: 100,
+  taskId: 'task-100',
+  sandboxServerUrl: 'https://sandbox.example.test',
+  repository: 'owner/repo',
+  prNumber: 42,
+  previousHeadSha: 'old-head',
+  eventHeadSha: 'new-head',
+  fallback: {
+    task: {
+      type: 'github_pr_review_sync' as const,
+      payload: {
+        repo: 'owner/repo',
+        prNumber: 42,
+        prTitle: 'Update feature',
+        prUrl: 'https://github.com/owner/repo/pull/42',
+        headSha: 'new-head',
+      },
+    },
+    initiatorActor: { externalId: '3', displayName: 'roomote-user' },
+    prLinkage: {
+      provider: 'github' as const,
+      host: 'github.com',
+      repositoryId: 'repo-id',
+      repository: 'owner/repo',
+      prNumber: 42,
+      prUrl: 'https://github.com/owner/repo/pull/42',
+      prTitle: 'Update feature',
+      prSha: 'new-head',
+      prBaseRef: 'main',
+      prBaseSha: 'base-head',
+    },
+  },
+};
+
+describe('enqueueActivePrReviewFollowUp', () => {
+  it('uses trailing-edge replacement for one active review run', async () => {
+    await enqueueActivePrReviewFollowUp(request);
+
+    expect(mockQueueAdd).toHaveBeenCalledWith(
+      'queue-active-pr-review-follow-up',
+      request,
+      {
+        delay: ACTIVE_PR_REVIEW_FOLLOW_UP_DEBOUNCE_MS,
+        deduplication: {
+          id: 'active-pr-review-follow-up:100',
+          ttl: ACTIVE_PR_REVIEW_FOLLOW_UP_DEBOUNCE_MS,
+          extend: true,
+          replace: true,
+        },
+      },
+    );
+  });
+});

--- a/apps/bullmq/src/active-pr-review-follow-up-queue.ts
+++ b/apps/bullmq/src/active-pr-review-follow-up-queue.ts
@@ -1,0 +1,49 @@
+import { Queue, QueueEvents, Worker } from 'bullmq';
+
+import {
+  ACTIVE_PR_REVIEW_FOLLOW_UP_QUEUE_NAME,
+  type ActivePrReviewFollowUpRequest,
+} from '@roomote/sdk/server';
+
+import { activePrReviewFollowUpJob } from './jobs/active-pr-review-follow-up';
+import { getRedis } from './redis';
+
+export function startActivePrReviewFollowUpQueue() {
+  const connection = getRedis();
+  const queue = new Queue<ActivePrReviewFollowUpRequest, void, string>(
+    ACTIVE_PR_REVIEW_FOLLOW_UP_QUEUE_NAME,
+    {
+      connection,
+      defaultJobOptions: {
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 2000 },
+        removeOnComplete: { age: 3600, count: 100 },
+        removeOnFail: { age: 24 * 3600 },
+      },
+    },
+  );
+  const worker = new Worker<ActivePrReviewFollowUpRequest, void, string>(
+    ACTIVE_PR_REVIEW_FOLLOW_UP_QUEUE_NAME,
+    activePrReviewFollowUpJob,
+    { connection, concurrency: 5, autorun: true },
+  );
+  const queueEvents = new QueueEvents(ACTIVE_PR_REVIEW_FOLLOW_UP_QUEUE_NAME, {
+    connection,
+  });
+
+  worker.on('failed', (job, error) =>
+    console.error(
+      `[ActivePrReviewFollowUpQueue] job ${job?.id} failed:`,
+      error.message,
+    ),
+  );
+  worker.on('error', (error) =>
+    console.error('[ActivePrReviewFollowUpQueue] worker error:', error),
+  );
+
+  console.log(
+    '[ActivePrReviewFollowUpQueue] Started active PR review follow-up worker',
+  );
+
+  return { queue, worker, queueEvents };
+}

--- a/apps/bullmq/src/index.ts
+++ b/apps/bullmq/src/index.ts
@@ -46,6 +46,7 @@ import { startSnapshotQueue } from './snapshot-queue';
 import { startDockerValidationQueue } from './docker-validation-queue';
 import { startSlackPrInactivityQueue } from './slack-pr-inactivity-queue';
 import { startPrReviewNotificationQueue } from './pr-review-notification-queue';
+import { startActivePrReviewFollowUpQueue } from './active-pr-review-follow-up-queue';
 import { startTaskSleepQueue } from './task-sleep-queue';
 
 // Resolve auto-generated auth keypairs before any queue worker starts so
@@ -162,6 +163,11 @@ const {
   prReviewNotificationWorker,
   prReviewNotificationQueueEvents,
 } = startPrReviewNotificationQueue();
+const {
+  queue: activePrReviewFollowUpQueue,
+  worker: activePrReviewFollowUpWorker,
+  queueEvents: activePrReviewFollowUpQueueEvents,
+} = startActivePrReviewFollowUpQueue();
 
 const serverAdapter = new HonoAdapter(serveStatic);
 
@@ -188,6 +194,7 @@ createBullBoard({
     }),
     new BullMQAdapter(slackPrInactivityQueue, { readOnlyMode: false }),
     new BullMQAdapter(prReviewNotificationQueue, { readOnlyMode: false }),
+    new BullMQAdapter(activePrReviewFollowUpQueue, { readOnlyMode: false }),
   ],
   serverAdapter,
 });
@@ -346,6 +353,9 @@ async function gracefulShutdown() {
     await prReviewNotificationWorker.close();
     await prReviewNotificationQueueEvents.close();
     await prReviewNotificationQueue.close();
+    await activePrReviewFollowUpWorker.close();
+    await activePrReviewFollowUpQueueEvents.close();
+    await activePrReviewFollowUpQueue.close();
     await discordGatewaySupervisor.stop();
     await closeRedis();
   } catch (error) {

--- a/apps/bullmq/src/jobs/active-pr-review-follow-up.test.ts
+++ b/apps/bullmq/src/jobs/active-pr-review-follow-up.test.ts
@@ -1,0 +1,199 @@
+import { z } from 'zod';
+
+const {
+  mockBuildPrompt,
+  mockEnqueueTask,
+  mockFindFirstRun,
+  mockSendPrompt,
+  mockUpdateWhere,
+  mockWithSandboxServerRpcClient,
+} = vi.hoisted(() => ({
+  mockBuildPrompt: vi.fn(),
+  mockEnqueueTask: vi.fn(),
+  mockFindFirstRun: vi.fn(),
+  mockSendPrompt: vi.fn(),
+  mockUpdateWhere: vi.fn(),
+  mockWithSandboxServerRpcClient: vi.fn(),
+}));
+
+vi.mock('@roomote/cloud-agents/server', () => ({
+  buildGitHubPrSynchronizeFollowUpMessage: (...args: unknown[]) =>
+    mockBuildPrompt(...args),
+  enqueueTask: (...args: unknown[]) => mockEnqueueTask(...args),
+}));
+
+vi.mock('@roomote/db/server', () => ({
+  db: {
+    query: {
+      taskRuns: {
+        findFirst: (...args: unknown[]) => mockFindFirstRun(...args),
+      },
+    },
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: (...args: unknown[]) => mockUpdateWhere(...args),
+      })),
+    })),
+  },
+  eq: vi.fn((...args: unknown[]) => args),
+  taskPullRequests: { taskId: 'taskPullRequests.taskId' },
+  taskRuns: { id: 'taskRuns.id' },
+}));
+
+vi.mock('@roomote/sdk/server', () => ({
+  activePrReviewFollowUpRequestSchema: z.object({
+    runId: z.number(),
+    taskId: z.string(),
+    sandboxServerUrl: z.string(),
+    repository: z.string(),
+    prNumber: z.number(),
+    previousHeadSha: z.string().nullable(),
+    eventHeadSha: z.string(),
+    fallback: z.any(),
+  }),
+  withSandboxServerRpcClient: (...args: unknown[]) =>
+    mockWithSandboxServerRpcClient(...args),
+}));
+
+import type { Job } from 'bullmq';
+
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
+
+import { activePrReviewFollowUpJob } from './active-pr-review-follow-up';
+
+const data = {
+  runId: 100,
+  taskId: 'task-100',
+  sandboxServerUrl: 'https://sandbox.example.test',
+  repository: 'owner/repo',
+  prNumber: 42,
+  previousHeadSha: 'old-head',
+  eventHeadSha: 'new-head',
+  fallback: {
+    task: {
+      type: TaskPayloadKind.GithubPrReviewSync,
+      payload: {
+        repo: 'owner/repo',
+        prNumber: 42,
+        prTitle: 'Update feature',
+        prUrl: 'https://github.com/owner/repo/pull/42',
+        headSha: 'new-head',
+      },
+    },
+    initiatorActor: { externalId: '3', displayName: 'roomote-user' },
+    prLinkage: {
+      provider: 'github' as const,
+      host: 'github.com',
+      repository: 'owner/repo',
+      prNumber: 42,
+      prUrl: 'https://github.com/owner/repo/pull/42',
+      prSha: 'new-head',
+    },
+  },
+};
+
+function makeJob() {
+  return { data } as unknown as Job<typeof data, void, string>;
+}
+
+describe('activePrReviewFollowUpJob', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBuildPrompt.mockReturnValue('Review the latest live PR head.');
+    mockEnqueueTask.mockResolvedValue({ id: 200 });
+    mockSendPrompt.mockResolvedValue({ success: true });
+    mockUpdateWhere.mockResolvedValue(undefined);
+    mockWithSandboxServerRpcClient.mockImplementation(
+      ({ call }: { call: (client: unknown) => Promise<unknown> }) =>
+        call({ commands: { sendPrompt: { mutate: mockSendPrompt } } }),
+    );
+  });
+
+  it('queues one hidden OpenCode follow-up behind the active turn', async () => {
+    mockFindFirstRun.mockResolvedValue({
+      id: 100,
+      taskId: 'task-100',
+      status: RunStatus.Running,
+      sandboxServerUrl: 'https://sandbox.example.test',
+      snapshotId: null,
+      snapshotCreatedAt: null,
+      port: null,
+      payload: { repo: 'owner/repo' },
+      actingUserId: null,
+    });
+
+    await activePrReviewFollowUpJob(makeJob());
+
+    expect(mockSendPrompt).toHaveBeenCalledWith({
+      prompt: 'Review the latest live PR head.',
+      source: 'github-pr-synchronize',
+      clientMessageId: 'github-pr-synchronize:100:owner/repo:42',
+      queueOnly: true,
+      visibleInTranscript: false,
+    });
+    expect(mockUpdateWhere).toHaveBeenCalledOnce();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
+  });
+
+  it('resumes the same task when the active review finishes during debounce', async () => {
+    mockFindFirstRun.mockResolvedValue({
+      id: 100,
+      taskId: 'task-100',
+      status: RunStatus.Completed,
+      sandboxServerUrl: null,
+      snapshotId: 'snapshot-100',
+      snapshotCreatedAt: new Date(),
+      port: 3000,
+      payload: { repo: 'owner/repo', environmentId: undefined },
+      actingUserId: 'user-1',
+    });
+
+    await activePrReviewFollowUpJob(makeJob());
+
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          type: TaskPayloadKind.SnapshotResume,
+          sourceRunId: 100,
+          payload: expect.objectContaining({
+            sourceSnapshotId: 'snapshot-100',
+            resumePrompt: 'Review the latest live PR head.',
+          }),
+        }),
+        actingUserId: 'user-1',
+      }),
+    );
+    expect(mockUpdateWhere).toHaveBeenCalledOnce();
+    expect(mockSendPrompt).not.toHaveBeenCalled();
+  });
+
+  it('starts a sync review when the completed run has no resumable snapshot', async () => {
+    mockFindFirstRun.mockResolvedValue({
+      id: 100,
+      taskId: 'task-100',
+      status: RunStatus.Completed,
+      sandboxServerUrl: null,
+      snapshotId: null,
+      snapshotCreatedAt: null,
+      port: null,
+      payload: { repo: 'owner/repo' },
+      actingUserId: null,
+    });
+
+    await activePrReviewFollowUpJob(makeJob());
+
+    expect(mockEnqueueTask).toHaveBeenCalledWith({
+      task: data.fallback.task,
+      initiator: {
+        kind: 'automation',
+        key: 'review_code',
+        actor: data.fallback.initiatorActor,
+      },
+      workflow: 'pr_review',
+      surface: 'github',
+      trigger: 'webhook',
+      prLinkage: data.fallback.prLinkage,
+    });
+    expect(mockUpdateWhere).not.toHaveBeenCalled();
+  });
+});

--- a/apps/bullmq/src/jobs/active-pr-review-follow-up.ts
+++ b/apps/bullmq/src/jobs/active-pr-review-follow-up.ts
@@ -1,0 +1,141 @@
+import { Job } from 'bullmq';
+
+import {
+  buildGitHubPrSynchronizeFollowUpMessage,
+  enqueueTask,
+} from '@roomote/cloud-agents/server';
+import { db, eq, taskPullRequests, taskRuns } from '@roomote/db/server';
+import {
+  activePrReviewFollowUpRequestSchema,
+  type ActivePrReviewFollowUpRequest,
+  withSandboxServerRpcClient,
+} from '@roomote/sdk/server';
+import {
+  isExitedRunStatus,
+  isSnapshotResumable,
+  type TaskPayload,
+  TaskPayloadKind,
+} from '@roomote/types';
+
+type ActivePrReviewFollowUpJob = Job<
+  ActivePrReviewFollowUpRequest,
+  void,
+  string
+>;
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function buildClientMessageId(data: ActivePrReviewFollowUpRequest): string {
+  return `github-pr-synchronize:${data.runId}:${data.repository}:${data.prNumber}`;
+}
+
+async function updateLinkedHead(
+  taskId: string,
+  headSha: string,
+): Promise<void> {
+  await db
+    .update(taskPullRequests)
+    .set({ prSha: headSha })
+    .where(eq(taskPullRequests.taskId, taskId));
+}
+
+export const activePrReviewFollowUpJob = async (
+  job: ActivePrReviewFollowUpJob,
+): Promise<void> => {
+  const data = activePrReviewFollowUpRequestSchema.parse(job.data);
+  const run = await db.query.taskRuns.findFirst({
+    where: eq(taskRuns.id, data.runId),
+    columns: {
+      id: true,
+      taskId: true,
+      status: true,
+      sandboxServerUrl: true,
+      snapshotId: true,
+      snapshotCreatedAt: true,
+      port: true,
+      payload: true,
+      actingUserId: true,
+    },
+  });
+
+  if (!run || run.taskId !== data.taskId) {
+    console.warn(
+      `[ActivePrReviewFollowUp] Review run ${data.runId} was not found, skipping`,
+    );
+    return;
+  }
+
+  const prompt = buildGitHubPrSynchronizeFollowUpMessage({
+    repository: data.repository,
+    prNumber: data.prNumber,
+    previousHeadSha: data.previousHeadSha,
+    eventHeadSha: data.eventHeadSha,
+  });
+
+  if (!isExitedRunStatus(run.status)) {
+    await withSandboxServerRpcClient({
+      runId: run.id,
+      userId: null,
+      sandboxServerUrl: run.sandboxServerUrl ?? data.sandboxServerUrl,
+      call: (client) =>
+        client.commands.sendPrompt.mutate({
+          prompt,
+          source: 'github-pr-synchronize',
+          clientMessageId: buildClientMessageId(data),
+          queueOnly: true,
+          visibleInTranscript: false,
+        }),
+    });
+    await updateLinkedHead(run.taskId, data.eventHeadSha);
+    return;
+  }
+
+  if (run.snapshotId && isSnapshotResumable(run.snapshotCreatedAt)) {
+    const sourcePayload = (run.payload ?? {}) as Record<string, unknown>;
+    const selectedRepositories = Array.isArray(
+      sourcePayload.selectedRepositories,
+    )
+      ? sourcePayload.selectedRepositories.filter(
+          (value): value is string => typeof value === 'string',
+        )
+      : undefined;
+    const resumePayload = {
+      repo: optionalString(sourcePayload.repo) ?? data.repository,
+      environmentId: optionalString(sourcePayload.environmentId),
+      port: run.port ?? undefined,
+      sourceSnapshotId: run.snapshotId,
+      sourceRunId: run.id,
+      ...(selectedRepositories ? { selectedRepositories } : {}),
+      resumePrompt: prompt,
+      resumePromptSource: 'github-pr-synchronize',
+      resumePromptClientMessageId: buildClientMessageId(data),
+    } satisfies TaskPayload<typeof TaskPayloadKind.SnapshotResume>;
+
+    await enqueueTask({
+      task: {
+        type: TaskPayloadKind.SnapshotResume,
+        sourceSnapshotId: run.snapshotId,
+        sourceRunId: run.id,
+        payload: resumePayload,
+      },
+      actingUserId: run.actingUserId,
+    });
+    await updateLinkedHead(run.taskId, data.eventHeadSha);
+    return;
+  }
+
+  await enqueueTask({
+    task: data.fallback.task,
+    initiator: {
+      kind: 'automation',
+      key: 'review_code',
+      actor: data.fallback.initiatorActor,
+    },
+    workflow: 'pr_review',
+    surface: 'github',
+    trigger: 'webhook',
+    prLinkage: data.fallback.prLinkage,
+  });
+};

--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/runtime-prompt-queue.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/runtime-prompt-queue.test.ts
@@ -345,6 +345,35 @@ describe('RuntimePromptQueue', () => {
       });
     });
 
+    it('replaces a queue-only prompt with the same client message id', () => {
+      const { queue, emittedEvents } = createQueue();
+
+      const firstId = queue.enqueue({
+        text: 'review head a',
+        queueOnly: true,
+        clientMessageId: 'github-pr-synchronize:100:owner/repo:42',
+      });
+      const replacementId = queue.enqueue({
+        text: 'review head b',
+        queueOnly: true,
+        clientMessageId: 'github-pr-synchronize:100:owner/repo:42',
+      });
+
+      expect(replacementId).toBe(firstId);
+      expect(queue.snapshot()).toEqual([
+        expect.objectContaining({
+          id: firstId,
+          text: 'review head b',
+          queueOnly: true,
+        }),
+      ]);
+      expect(emittedEvents.at(-1)?.payload).toMatchObject({
+        cause: 'replace',
+        queuedMessages: [],
+        deliverableCount: 0,
+      });
+    });
+
     it('hides internal continuations from the visible payload but counts them as deliverable', () => {
       const { queue, emittedEvents } = createQueue();
 

--- a/apps/worker/src/sandbox-server/lib/harnesses/runtime-prompt-queue.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/runtime-prompt-queue.ts
@@ -14,6 +14,7 @@ type RuntimePromptQueueUpdateCause =
   | 'delete'
   | 'prioritize'
   | 'move'
+  | 'replace'
   | 'clear'
   | 'restore';
 
@@ -42,8 +43,18 @@ export class RuntimePromptQueue {
     userImageUrl?: string;
     clientMessageId?: string;
   }): string {
+    const replaceIndex =
+      prompt.queueOnly && prompt.clientMessageId
+        ? this.queuedMessages.findIndex(
+            (message) =>
+              message.queueOnly &&
+              message.clientMessageId === prompt.clientMessageId,
+          )
+        : -1;
+    const existing =
+      replaceIndex >= 0 ? this.queuedMessages[replaceIndex] : undefined;
     const queuedMessage = {
-      id: `runtime-queued-${++this.queuedMessageIdCounter}`,
+      id: existing?.id ?? `runtime-queued-${++this.queuedMessageIdCounter}`,
       text: prompt.text,
       images: prompt.images ? [...prompt.images] : undefined,
       queueOnly: prompt.queueOnly,
@@ -55,8 +66,13 @@ export class RuntimePromptQueue {
       timestamp: Date.now(),
     };
 
-    this.queuedMessages.push(queuedMessage);
+    if (replaceIndex >= 0) {
+      this.queuedMessages[replaceIndex] = queuedMessage;
+      this.emitUpdate('replace');
+      return queuedMessage.id;
+    }
 
+    this.queuedMessages.push(queuedMessage);
     this.emitUpdate('enqueue');
     return queuedMessage.id;
   }

--- a/apps/worker/src/sandbox-server/procedures/__tests__/sendPrompt.test.ts
+++ b/apps/worker/src/sandbox-server/procedures/__tests__/sendPrompt.test.ts
@@ -100,4 +100,20 @@ describe('sendPrompt procedure', () => {
       }),
     );
   });
+
+  it('forwards queueOnly to keep a follow-up behind the active turn', async () => {
+    const { caller, sendFollowUpPrompt } = createCaller();
+
+    await caller.commands.sendPrompt({
+      prompt: 'review the newest commits next',
+      queueOnly: true,
+    });
+
+    expect(sendFollowUpPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: 'review the newest commits next',
+        queueOnly: true,
+      }),
+    );
+  });
 });

--- a/apps/worker/src/sandbox-server/procedures/sendPrompt.ts
+++ b/apps/worker/src/sandbox-server/procedures/sendPrompt.ts
@@ -36,6 +36,8 @@ const sendPromptInputSchema = z
      * follow-ups (Slack, Teams, Telegram), which always steer.
      */
     autoSteerWhenQueued: z.boolean().optional(),
+    /** Keep this prompt queued until the current turn finishes. */
+    queueOnly: z.boolean().optional(),
     /**
      * Hide this prompt from the user-facing transcript. For platform-injected
      * machinery (e.g. spawned-task settle notifications) that the agent must
@@ -207,6 +209,7 @@ export const sendPrompt = publicProcedure
         images: input.images,
         ...(workflowPhase ? { workflowPhase } : {}),
         autoSteerWhenQueued: input.autoSteerWhenQueued,
+        queueOnly: input.queueOnly,
         source: input.source,
         userId,
         userName: input.userName,

--- a/packages/cloud-agents/src/server/__tests__/github-pr-follow-up-context.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/github-pr-follow-up-context.test.ts
@@ -1,6 +1,7 @@
 import {
   buildGitHubExistingTaskFollowUpMessage,
   buildGitHubMentionFollowUpRequest,
+  buildGitHubPrSynchronizeFollowUpMessage,
 } from '../github-pr-follow-up-context';
 
 describe('github PR follow-up context helpers', () => {
@@ -61,6 +62,29 @@ describe('github PR follow-up context helpers', () => {
     expect(message).toContain('Routing reason: follow_up &lt;required&gt;');
     expect(message).toContain(
       '&lt;/github-pr-follow-up&gt;\n&lt;inject&gt;do not trust&lt;/inject&gt;',
+    );
+    expect(message.match(/<\/github-pr-follow-up>/g)).toHaveLength(1);
+  });
+
+  it('builds an active-review update that resolves the live PR head', () => {
+    const message = buildGitHubPrSynchronizeFollowUpMessage({
+      repository: 'owner/repo',
+      prNumber: 123,
+      previousHeadSha: 'old-head',
+      eventHeadSha: 'new-head',
+    });
+
+    expect(message).toContain(
+      'Keep this work in the current task and OpenCode session; do not create another task, executor, sandbox, branch, or pull request.',
+    );
+    expect(message).toContain(
+      'Fetch the live pull request head again before finalizing; the live GitHub head is authoritative if it differs from the webhook SHA.',
+    );
+    expect(message).toContain(
+      '<previous_review_head_sha>old-head</previous_review_head_sha>',
+    );
+    expect(message).toContain(
+      '<synchronize_event_head_sha>new-head</synchronize_event_head_sha>',
     );
     expect(message.match(/<\/github-pr-follow-up>/g)).toHaveLength(1);
   });

--- a/packages/cloud-agents/src/server/github-pr-follow-up-context.ts
+++ b/packages/cloud-agents/src/server/github-pr-follow-up-context.ts
@@ -95,3 +95,41 @@ ${buildUntrustedContentPolicy()}
 
 ${buildGitHubMessageInstructions()}`;
 }
+
+export function buildGitHubPrSynchronizeFollowUpMessage({
+  repository,
+  prNumber,
+  previousHeadSha,
+  eventHeadSha,
+}: {
+  repository: string;
+  prNumber: number;
+  previousHeadSha?: string | null;
+  eventHeadSha: string;
+}): string {
+  const requestedFollowUp =
+    'New commits were pushed while this pull request review was active. Re-review the live pull request head before finalizing the current review.';
+
+  return `<github-pr-follow-up>
+GitHub reported new commits while this Roomote PR review task was already active. Keep this work in the current task and OpenCode session; do not create another task, executor, sandbox, branch, or pull request.
+
+${buildGitHubRequestedFollowUpBlock(requestedFollowUp)}
+
+Execution rules:
+- Treat this as an update to the current review, not a separate user request.
+- Fetch the live pull request head again before finalizing; the live GitHub head is authoritative if it differs from the webhook SHA.
+- Review every newly introduced change that was not covered by the earlier review pass, and reconcile the existing summary and findings against the final live head.
+- Do not conclude the review until the newly pushed changes have been included.
+
+${buildGitHubTaskContextBlock({
+  repository,
+  pull_request_number: prNumber,
+  previous_review_head_sha: previousHeadSha,
+  synchronize_event_head_sha: eventHeadSha,
+})}
+</github-pr-follow-up>
+
+${buildUntrustedContentPolicy()}
+
+${buildGitHubMessageInstructions()}`;
+}

--- a/packages/sdk/src/sandbox-router.ts
+++ b/packages/sdk/src/sandbox-router.ts
@@ -128,6 +128,8 @@ export interface SandboxSendPromptInput {
   userName?: string;
   userImageUrl?: string;
   autoSteerWhenQueued?: boolean;
+  /** Keep the prompt queued until the current turn finishes. */
+  queueOnly?: boolean;
   /** Hide the prompt from the user-facing transcript (platform machinery). */
   visibleInTranscript?: boolean;
 }

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -31,6 +31,13 @@ export {
   refreshTaskTitleOnCompletion,
 } from './lib/task-runs/record-task-message-envelope';
 export { ensureSnapshotResumeGitHubFollowUpFallback } from './lib/task-runs/ensure-snapshot-resume-github-follow-up-fallback';
+export {
+  ACTIVE_PR_REVIEW_FOLLOW_UP_DEBOUNCE_MS,
+  ACTIVE_PR_REVIEW_FOLLOW_UP_QUEUE_NAME,
+  activePrReviewFollowUpRequestSchema,
+  enqueueActivePrReviewFollowUp,
+  type ActivePrReviewFollowUpRequest,
+} from './lib/task-runs/active-pr-review-follow-up';
 export * from './lib/manager-slack';
 export * from './automations';
 export * from './lib/manager-stats';

--- a/packages/sdk/src/server/lib/task-runs/active-pr-review-follow-up.ts
+++ b/packages/sdk/src/server/lib/task-runs/active-pr-review-follow-up.ts
@@ -1,0 +1,95 @@
+import { Queue } from 'bullmq';
+import { z } from 'zod';
+
+import { getRedis } from '@roomote/redis';
+import {
+  githubPullRequestReviewSyncSchema,
+  sourceControlProviderSchema,
+} from '@roomote/types';
+
+export const ACTIVE_PR_REVIEW_FOLLOW_UP_QUEUE_NAME =
+  'active-pr-review-follow-up-jobs';
+export const ACTIVE_PR_REVIEW_FOLLOW_UP_DEBOUNCE_MS = 15_000;
+
+const taskPrLinkageSchema = z.object({
+  provider: sourceControlProviderSchema,
+  host: z.string().nullish(),
+  repositoryId: z.string().nullish(),
+  repository: z.string(),
+  prNumber: z.number().int().positive(),
+  prUrl: z.string(),
+  prTitle: z.string().nullish(),
+  prSha: z.string().nullish(),
+  prBaseRef: z.string().nullish(),
+  prBaseSha: z.string().nullish(),
+});
+
+export const activePrReviewFollowUpRequestSchema = z.object({
+  runId: z.number().int().positive(),
+  taskId: z.string(),
+  sandboxServerUrl: z.string(),
+  repository: z.string(),
+  prNumber: z.number().int().positive(),
+  previousHeadSha: z.string().nullable(),
+  eventHeadSha: z.string(),
+  fallback: z.object({
+    task: githubPullRequestReviewSyncSchema,
+    initiatorActor: z.object({
+      externalId: z.string(),
+      displayName: z.string(),
+    }),
+    prLinkage: taskPrLinkageSchema,
+  }),
+});
+
+export type ActivePrReviewFollowUpRequest = z.infer<
+  typeof activePrReviewFollowUpRequestSchema
+>;
+
+let activePrReviewFollowUpQueue: Queue<ActivePrReviewFollowUpRequest> | null =
+  null;
+
+function getActivePrReviewFollowUpQueue(): Queue<ActivePrReviewFollowUpRequest> {
+  if (!activePrReviewFollowUpQueue) {
+    activePrReviewFollowUpQueue = new Queue<ActivePrReviewFollowUpRequest>(
+      ACTIVE_PR_REVIEW_FOLLOW_UP_QUEUE_NAME,
+      {
+        connection: getRedis(),
+        defaultJobOptions: {
+          attempts: 3,
+          backoff: { type: 'exponential', delay: 2000 },
+          removeOnComplete: { age: 3600, count: 100 },
+          removeOnFail: { age: 24 * 3600 },
+        },
+      },
+    );
+  }
+
+  return activePrReviewFollowUpQueue;
+}
+
+/**
+ * Debounces synchronize events for one active review run. BullMQ replaces the
+ * delayed job and extends its delay, so a burst of commits becomes one
+ * follow-up containing the newest observed head.
+ */
+export async function enqueueActivePrReviewFollowUp(
+  input: ActivePrReviewFollowUpRequest,
+): Promise<void> {
+  const data = activePrReviewFollowUpRequestSchema.parse(input);
+  const deduplicationId = `active-pr-review-follow-up:${data.runId}`;
+
+  await getActivePrReviewFollowUpQueue().add(
+    'queue-active-pr-review-follow-up',
+    data,
+    {
+      delay: ACTIVE_PR_REVIEW_FOLLOW_UP_DEBOUNCE_MS,
+      deduplication: {
+        id: deduplicationId,
+        ttl: ACTIVE_PR_REVIEW_FOLLOW_UP_DEBOUNCE_MS,
+        extend: true,
+        replace: true,
+      },
+    },
+  );
+}


### PR DESCRIPTION
## What changed

- Keep pending PR reviews on the latest linked head before sandbox startup.
- Debounce synchronize events for an active review with a 15-second trailing window, replacing the delayed BullMQ job with the newest head.
- Queue one hidden OpenCode follow-up for the next turn with `queueOnly`, rather than interrupting the current turn.
- Replace an already-buffered PR-sync follow-up by stable client message ID, so later commits do not spam the task while the current turn is still running.
- Re-fetch the live PR head in the follow-up and review all changes that arrived during the active review.
- Resume the same task from its snapshot if the review finishes during the debounce window; fall back to a normal sync review only when no resumable snapshot exists.

## Why

The existing launch debounce prevents duplicate sandbox provisioning, but a commit pushed after review execution begins could otherwise be skipped. This keeps the review current while coalescing bursts and preserving turn boundaries.

## Validation

- Focused GitHub synchronize handler tests
- Focused active-review BullMQ producer and worker tests
- Focused OpenCode runtime prompt queue and send-prompt tests
- API, SDK, BullMQ, and worker package typechecks
- Changed-file ESLint and formatting checks
- `pnpm lint:fast`
- `pnpm check-types:fast`
- `pnpm knip`
