### PR TITLE
[Fix] Restore BullMQ Docker access in Coolify

### DIFF
--- a/deploy/coolify/docker-compose.yaml
+++ b/deploy/coolify/docker-compose.yaml
@@ -256,14 +256,22 @@ services:
     image: *roomote-app-image
     restart: unless-stopped
     command: bullmq
+    # Docker standby retention and the settings "Validate environment" checks
+    # run here; both reach Docker through the restricted socket proxy, never
+    # the raw socket.
+    networks: [default, docker-api]
     depends_on:
       redis:
         condition: service_started
       db-migrate:
         condition: service_completed_successfully
+      docker-proxy:
+        condition: service_started
     environment:
       <<: *roomote-shared-env
       PORT: 3002
+      DOCKER_HOST: tcp://docker-proxy:2375
+      DOCKER_WORKER_RELEASE_PATH: /roomote/releases/worker-current.tar.gz
     healthcheck:
       test:
         [


### PR DESCRIPTION
## Related issue

Fixes #929

## Why this PR exists

- [x] A maintainer explicitly invited this PR in the linked issue or discussion
- [ ] I am a maintainer / this is internal Roomote work

The maintained Coolify Compose template gives the controller access to the
restricted Docker socket proxy, but the BullMQ service does not receive the
same access.

Docker environment validation executes as a BullMQ job. BullMQ also performs
Docker lifecycle work such as standby retention. Without access to the socket
proxy, Docker validation reports that the daemon is unreachable even when
controller-backed task spawning works.

## What changed

- Connected the Coolify `bullmq` service to the internal `docker-api` network.
- Configured BullMQ to use `tcp://docker-proxy:2375`.
- Added `docker-proxy` as a BullMQ startup dependency.
- Passed `DOCKER_WORKER_RELEASE_PATH` to BullMQ so validation checks the same
  baked worker archive used by the controller.
- Documented why BullMQ requires restricted Docker access.
- Added deployment validation assertions covering BullMQ's:
  - `docker-api` network membership
  - `docker-proxy` startup dependency
  - `DOCKER_HOST`
  - worker release archive path

BullMQ still does not mount `/var/run/docker.sock`. Docker access continues
to go through the existing restricted socket proxy.

## How it was tested

- [ ] `pnpm deployment:validate`
- [ ] `pnpm lint`
- [ ] `pnpm check-types`
- [x] Redeployed the updated Compose configuration on Coolify.
- [x] Confirmed BullMQ joined `roomote_default` and `roomote_docker_api`.
- [x] Confirmed BullMQ could reach Docker through
  `tcp://docker-proxy:2375`.
- [x] Confirmed the worker release archive was detected.
- [x] Confirmed Local Docker **Validate environment** passed:
  - Docker daemon
  - worker image
  - worker release archive
- [x] Confirmed Docker-backed tasks continued to start successfully.

## Checklist

- [x] The PR title follows the repo convention: `[Fix]`, `[Feat]`,
  `[Improve]`, `[Refactor]`, `[Docs]`, or `[Chore]` followed by a
  user-facing description
- [x] This PR is small and scoped to one change
- [ ] `pnpm lint` and `pnpm check-types` pass locally
- [x] I added tests or included a clear manual validation note above
- [x] I removed secrets, tokens, private keys, and customer data from code,
  logs, and screenshots
- [ ] If this change should appear in the changelog, I ran `pnpm changeset`