### PR TITLE
[Fix] Attach Coolify trusted services to the worker discovery network

### DIFF
--- a/deploy/coolify/docker-compose.yaml
+++ b/deploy/coolify/docker-compose.yaml
@@ -160,6 +160,7 @@ services:
     image: *roomote-app-image
     restart: unless-stopped
     command: api
+    networks: [default]
     depends_on:
       redis:
         condition: service_started
@@ -226,7 +227,7 @@ services:
       <<: *roomote-shared-env
       DOCKER_HOST: tcp://docker-proxy:2375
       # The worker release archive is baked into the app image; the
-      # controller reads the release version from the VERSION file inside
+      # controller reads the worker release version from the VERSION file inside
       # the archive. Do not unset: the fallback is GitHub worker releases,
       # which do not exist for develop builds.
       DOCKER_WORKER_RELEASE_PATH: /roomote/releases/worker-current.tar.gz
@@ -290,6 +291,7 @@ services:
   #   image: *roomote-app-image
   #   restart: unless-stopped
   #   command: preview-proxy
+  #   networks: [default]
   #   depends_on:
   #     db-migrate:
   #       condition: service_completed_successfully


### PR DESCRIPTION
## Why this PR exists

The Coolify template names its worker discovery network `roomote_default`
and configures the controller to discover the trusted `api` and optional
`preview-proxy` services on that network.

Coolify may attach services with public domains only to its generated proxy
network unless their Compose network membership is explicit. In that case:

- the controller cannot reliably discover `api` on `roomote_default`
- environment creation fails with the following error message:
```
Docker worker control network roomote_default is missing trusted service(s): api. Compose services must use the standard service labels, or set dev.roomote.docker-worker.trusted-service.
```
- when live previews are enabled, `preview-proxy` is not attached to per-task
  networks, causing requests to fail with
  `getaddrinfo ENOTFOUND roomote-worker-<run-id>`

## What changed

- Explicitly attached `api` to the Compose `default` network
  (`roomote_default`).
- Explicitly attached the optional `preview-proxy` service to the same network
  when enabled.

This preserves Coolify's generated proxy network while ensuring the controller
can discover the trusted services and attach them to isolated task networks.

## How it was tested

- Redeployed the Coolify Compose stack with live previews enabled.
- Confirmed `api`, `controller`, and `preview-proxy` joined `roomote_default`.
- Confirmed workers remained isolated on `roomote-task-<run-id>`.
- Confirmed the controller attached `preview-proxy` to the task network.
- Confirmed `preview-proxy` could resolve and reach
  `roomote-worker-<run-id>:4200`.
- Confirmed browser tRPC and WebSocket connections worked through the wildcard
  preview hostname.

## Checklist

- [x] The PR title follows the repository convention.
- [x] The PR is small and scoped to one deployment fix.
- [x] Manual deployment validation is documented above.
- [x] No secrets, tokens, private keys, or customer data are included.