### PR TITLE
[Fix] Provider error classification depends on message wording

### DIFF
--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
@@ -2245,7 +2245,7 @@ describe('OpenCodeServerHarness', () => {
     }
   });
 
-  it('terminates an OpenCode retry loop from a structured billing code without a message', async () => {
+  it('terminates an OpenCode retry loop from a structured 4xx status without a message', async () => {
     const { client, harness } = createHarness();
     const taskEvents: TaskEvent[] = [];
     const persistedEnvelopes: AcpPersistedEnvelope[] = [];
@@ -2289,7 +2289,7 @@ describe('OpenCodeServerHarness', () => {
           status: {
             type: 'retry',
             attempt: 1,
-            code: 'insufficient_balance',
+            statusCode: 402,
             next: Date.now() + 2_000,
           },
         },
@@ -2395,7 +2395,7 @@ describe('OpenCodeServerHarness', () => {
     }
   });
 
-  it('retries a cyber policy refusal with safer framing without aborting the task', async () => {
+  it('retries a ContentFilterError refusal with safer framing without aborting the task', async () => {
     vi.useFakeTimers();
     const { client, harness } = createHarness();
     const taskEvents: TaskEvent[] = [];
@@ -2438,17 +2438,10 @@ describe('OpenCodeServerHarness', () => {
         properties: {
           sessionID: 'ses_1',
           error: {
-            name: 'UnknownError',
+            name: 'ContentFilterError',
             data: {
-              message: JSON.stringify({
-                type: 'error',
-                error: {
-                  type: 'invalid_request',
-                  code: 'cyber_policy',
-                  message:
-                    'This content was flagged for possible cybersecurity risk.',
-                },
-              }),
+              message:
+                "The response was blocked by the provider's content filter",
             },
           },
         },

--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
@@ -2245,7 +2245,7 @@ describe('OpenCodeServerHarness', () => {
     }
   });
 
-  it('terminates an OpenCode retry loop for provider billing suspension', async () => {
+  it('terminates an OpenCode retry loop from a structured billing code without a message', async () => {
     const { client, harness } = createHarness();
     const taskEvents: TaskEvent[] = [];
     const persistedEnvelopes: AcpPersistedEnvelope[] = [];
@@ -2289,8 +2289,7 @@ describe('OpenCodeServerHarness', () => {
           status: {
             type: 'retry',
             attempt: 1,
-            message:
-              'Your account org-redacted is suspended due to insufficient balance, please recharge your account.',
+            code: 'insufficient_balance',
             next: Date.now() + 2_000,
           },
         },
@@ -2312,7 +2311,7 @@ describe('OpenCodeServerHarness', () => {
           (envelope) =>
             envelope.eventType === ACP_ENVELOPE_EVENT_TYPES.AssistantMessage &&
             String(envelope.payload.text ?? '').includes(
-              'suspended due to insufficient balance',
+              'Provider request failed with a non-retryable error.',
             ),
         ),
       ).toBe(true);
@@ -2321,7 +2320,7 @@ describe('OpenCodeServerHarness', () => {
     }
   });
 
-  it('terminates an OpenCode retry loop for message-only payment required status', async () => {
+  it('terminates an OpenCode retry loop after its structured attempt budget without a message', async () => {
     const { client, harness } = createHarness();
     const taskEvents: TaskEvent[] = [];
     const persistedEnvelopes: AcpPersistedEnvelope[] = [];
@@ -2358,15 +2357,14 @@ describe('OpenCodeServerHarness', () => {
         }),
       ).toBe(true);
 
-      // Retry status only carries message; no statusCode/code fields.
+      // The decision uses the structured attempt count, not the provider prose.
       await client.emit({
         type: 'session.status',
         properties: {
           sessionID: 'ses_1',
           status: {
             type: 'retry',
-            attempt: 1,
-            message: 'Payment required',
+            attempt: 3,
             next: Date.now() + 2_000,
           },
         },
@@ -2387,7 +2385,9 @@ describe('OpenCodeServerHarness', () => {
         persistedEnvelopes.some(
           (envelope) =>
             envelope.eventType === ACP_ENVELOPE_EVENT_TYPES.AssistantMessage &&
-            String(envelope.payload.text ?? '').includes('Payment required'),
+            String(envelope.payload.text ?? '').includes(
+              'Provider retry limit exceeded.',
+            ),
         ),
       ).toBe(true);
     } finally {

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
@@ -275,6 +275,7 @@ const OPEN_CODE_EXECUTE_TOOLS = new Set(['bash', 'shell']);
 const OPEN_CODE_READ_TOOLS = new Set(['read']);
 const OPEN_CODE_SEARCH_TOOLS = new Set(['grep', 'glob', 'find', 'list', 'ls']);
 const MAX_OPENCODE_STOP_HOOK_REMINDERS = 3;
+const MAX_OPENCODE_INTERNAL_RETRY_ATTEMPTS = 3;
 // Fail-safe for a wedged stop-hook reminder cycle. After a turn finishes
 // without the required Slack closeout, we resubmit a reminder prompt and then
 // wait for a fresh turn (a future session.idle re-enters finishCurrentTurn).
@@ -3686,13 +3687,20 @@ export class OpenCodeServerHarness
         asString(properties?.sessionId) ??
         this.sessionId;
       const message = asString(status?.message);
+      const retryAttempt = asFiniteNumber(status?.attempt);
+      const isTerminalProviderError = isOpenCodeTerminalProviderError(status);
+      const exhaustedRetryBudget =
+        retryAttempt !== undefined &&
+        retryAttempt >= MAX_OPENCODE_INTERNAL_RETRY_ATTEMPTS;
 
-      if (
-        sessionId &&
-        message &&
-        isOpenCodeTerminalProviderError({ message })
-      ) {
-        await this.terminateOpenCodeProviderRetry(sessionId, message);
+      if (sessionId && (isTerminalProviderError || exhaustedRetryBudget)) {
+        await this.terminateOpenCodeProviderRetry(
+          sessionId,
+          message ??
+            (isTerminalProviderError
+              ? 'Provider request failed with a non-retryable error.'
+              : 'Provider retry limit exceeded.'),
+        );
         return;
       }
 

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-error-recovery.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-error-recovery.test.ts
@@ -32,7 +32,7 @@ describe('getOpenCodeProviderErrorRecovery', () => {
     );
   });
 
-  it('treats unknown provider errors as recoverable once', () => {
+  it('gives unknown provider errors a bounded retry budget', () => {
     expect(
       getOpenCodeProviderErrorRecovery({
         name: 'UnknownError',
@@ -66,34 +66,52 @@ describe('getOpenCodeProviderErrorRecovery', () => {
     ).toBeNull();
   });
 
-  it('classifies API key is invalid wording as terminal without metadata', () => {
+  it('does not classify message wording as terminal without metadata', () => {
     expect(
       isOpenCodeTerminalProviderError({
         message: 'The provider returned an error: API key is invalid.',
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       getOpenCodeProviderErrorRecovery({
         message: 'The provider returned an error: API key is invalid.',
       }),
-    ).toBeNull();
+    ).toMatchObject({ kind: 'provider_error', maxRetries: 3 });
   });
 
-  it.each([
-    'Your account org-redacted is suspended due to insufficient balance, please recharge your account or check your plan and billing details',
-    JSON.stringify({
+  it('classifies structured billing codes inside JSON strings as terminal', () => {
+    const error = JSON.stringify({
       error: {
         code: 'insufficient_balance',
         message: 'There is not enough credit to run this request.',
       },
-    }),
-  ])(
-    'classifies provider billing and suspension errors as terminal',
-    (error) => {
-      expect(isOpenCodeTerminalProviderError(error)).toBe(true);
-      expect(getOpenCodeProviderErrorRecovery(error)).toBeNull();
+    });
+
+    expect(isOpenCodeTerminalProviderError(error)).toBe(true);
+    expect(getOpenCodeProviderErrorRecovery(error)).toBeNull();
+  });
+
+  it.each([
+    {
+      name: 'ContextOverflowError',
+      data: { message: 'Input exceeds context window of this model' },
     },
-  );
+    {
+      cause: {
+        name: 'ContextOverflowError',
+        message: 'Input exceeds context window of this model',
+      },
+    },
+    JSON.stringify({
+      error: {
+        name: 'ContextOverflowError',
+        message: 'Input exceeds context window of this model',
+      },
+    }),
+  ])('classifies structured context overflow names as terminal', (error) => {
+    expect(isOpenCodeTerminalProviderError(error)).toBe(true);
+    expect(getOpenCodeProviderErrorRecovery(error)).toBeNull();
+  });
 
   it('classifies payment-required responses as terminal', () => {
     expect(
@@ -108,14 +126,21 @@ describe('getOpenCodeProviderErrorRecovery', () => {
     ).toBe(true);
   });
 
-  it('classifies message-only payment-required retry status as terminal', () => {
-    // handleSessionStatus only has the retry status message, not statusCode/code.
+  it('retries message-only payment errors without structured metadata', () => {
     expect(
       isOpenCodeTerminalProviderError({ message: 'Payment required' }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       getOpenCodeProviderErrorRecovery({ message: 'Payment required' }),
-    ).toBeNull();
+    ).toMatchObject({ kind: 'provider_error', maxRetries: 3 });
+  });
+
+  it('does not classify policy-refusal prose without structured metadata', () => {
+    expect(
+      getOpenCodeProviderErrorRecovery({
+        message: 'This content was flagged for possible cybersecurity risk.',
+      }),
+    ).toMatchObject({ kind: 'provider_error', maxRetries: 3 });
   });
 });
 

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-error-recovery.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-error-recovery.test.ts
@@ -9,27 +9,25 @@ import {
 } from './provider-error-recovery';
 
 describe('getOpenCodeProviderErrorRecovery', () => {
-  it('detects an UnknownError-wrapped cyber policy refusal', () => {
-    const recovery = getOpenCodeProviderErrorRecovery({
-      name: 'UnknownError',
-      data: {
-        message: JSON.stringify({
-          type: 'error',
-          error: {
-            type: 'invalid_request',
-            code: 'cyber_policy',
-            message:
-              'This content was flagged for possible cybersecurity risk.',
-          },
-        }),
-      },
-    });
-
-    expect(recovery).toMatchObject({ kind: 'policy_refusal', maxRetries: 2 });
-    expect(recovery?.promptText).toContain('Continue the legitimate task');
-    expect(recovery?.promptText).toContain(
-      'Do not attempt to bypass the policy',
-    );
+  it('gives status-less policy codes the generic bounded retry budget', () => {
+    // Only OpenCode's typed ContentFilterError selects the policy prompt;
+    // provider policy code vocabulary is not classified.
+    expect(
+      getOpenCodeProviderErrorRecovery({
+        name: 'UnknownError',
+        data: {
+          message: JSON.stringify({
+            type: 'error',
+            error: {
+              type: 'invalid_request',
+              code: 'cyber_policy',
+              message:
+                'This content was flagged for possible cybersecurity risk.',
+            },
+          }),
+        },
+      }),
+    ).toMatchObject({ kind: 'provider_error', maxRetries: 3 });
   });
 
   it('gives unknown provider errors a bounded retry budget', () => {
@@ -79,7 +77,7 @@ describe('getOpenCodeProviderErrorRecovery', () => {
     ).toMatchObject({ kind: 'provider_error', maxRetries: 3 });
   });
 
-  it('classifies structured billing codes inside JSON strings as terminal', () => {
+  it('gives status-less billing codes the bounded retry budget', () => {
     const error = JSON.stringify({
       error: {
         code: 'insufficient_balance',
@@ -87,9 +85,35 @@ describe('getOpenCodeProviderErrorRecovery', () => {
       },
     });
 
+    expect(isOpenCodeTerminalProviderError(error)).toBe(false);
+    expect(getOpenCodeProviderErrorRecovery(error)).toMatchObject({
+      kind: 'provider_error',
+      maxRetries: 3,
+    });
+  });
+
+  it('classifies HTTP client-error statuses inside JSON strings as terminal', () => {
+    const error = JSON.stringify({
+      error: {
+        code: 402,
+        message: 'There is not enough credit to run this request.',
+      },
+    });
+
     expect(isOpenCodeTerminalProviderError(error)).toBe(true);
     expect(getOpenCodeProviderErrorRecovery(error)).toBeNull();
   });
+
+  it.each([408, 429, 500, 503])(
+    'keeps retryable status %d out of the terminal set',
+    (statusCode) => {
+      expect(isOpenCodeTerminalProviderError({ statusCode })).toBe(false);
+      expect(getOpenCodeProviderErrorRecovery({ statusCode })).toMatchObject({
+        kind: 'provider_error',
+        maxRetries: 3,
+      });
+    },
+  );
 
   it.each([
     {

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-error-recovery.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-error-recovery.ts
@@ -22,35 +22,17 @@ export type OpenCodeProviderErrorRecovery = {
   promptText: string;
 };
 
-const POLICY_CODES = new Set([
-  'cyber_policy',
-  'content_policy',
-  'content_policy_violation',
-  'safety_policy',
-]);
+// OpenCode's own typed error names, not provider vocabulary. These are the
+// only non-HTTP signals: they never carry a status because they are raised
+// client-side before or instead of an HTTP response.
+const TERMINAL_ERROR_NAMES = new Set(['contextoverflowerror']);
+const POLICY_ERROR_NAMES = new Set(['contentfiltererror']);
 
-const TERMINAL_CODES = new Set([
-  'account_suspended',
-  'authentication_error',
-  'billing_error',
-  'context_length_exceeded',
-  'credit_balance_too_low',
-  'forbidden',
-  'insufficient_balance',
-  'insufficient_quota',
-  'invalid_api_key',
-  'invalid_model',
-  'model_not_found',
-  'payment_required',
-  'permission_denied',
-  'unauthorized',
-]);
+// Client errors are terminal because replaying the same request cannot
+// succeed, except timeouts (408) and rate limits (429) which are transient.
+const RETRYABLE_CLIENT_STATUS_CODES = new Set([408, 429]);
 
-const TERMINAL_NAMES = new Set(['contextoverflowerror']);
-
-const TERMINAL_STATUS_CODES = new Set([400, 401, 402, 403, 404, 422]);
-
-function collectProviderErrorValues(error: unknown): unknown[] {
+export function collectProviderErrorValues(error: unknown): unknown[] {
   const pending: Array<{ value: unknown; depth: number }> = [
     { value: error, depth: 0 },
   ];
@@ -95,47 +77,71 @@ function normalizeIdentifier(value: unknown): string | undefined {
   return identifier || undefined;
 }
 
-function isPolicyRefusal(values: unknown[]): boolean {
+function asHttpErrorStatus(value: unknown): number | undefined {
+  const numeric =
+    asFiniteNumber(value) ??
+    (typeof value === 'string' && /^\d{3}$/u.test(value.trim())
+      ? Number(value.trim())
+      : undefined);
+
+  return numeric !== undefined &&
+    Number.isInteger(numeric) &&
+    numeric >= 400 &&
+    numeric <= 599
+    ? numeric
+    : undefined;
+}
+
+/**
+ * First HTTP error status found anywhere in the error, outermost value first.
+ * Providers surface it under `statusCode`, `status`, or (OpenRouter) `code`.
+ */
+export function extractProviderErrorHttpStatus(
+  values: unknown[],
+): number | undefined {
   for (const value of values) {
     const record = asRecord(value);
-    const code = normalizeIdentifier(record?.code);
-    const name = normalizeIdentifier(record?.name);
 
-    if ((code && POLICY_CODES.has(code)) || name === 'contentfiltererror') {
-      return true;
+    if (!record) {
+      continue;
+    }
+
+    const status =
+      asHttpErrorStatus(record.statusCode) ??
+      asHttpErrorStatus(record.status) ??
+      asHttpErrorStatus(record.code);
+
+    if (status !== undefined) {
+      return status;
     }
   }
 
-  return false;
+  return undefined;
+}
+
+function hasErrorName(values: unknown[], names: Set<string>): boolean {
+  return values.some((value) => {
+    const name = normalizeIdentifier(asRecord(value)?.name);
+    return name !== undefined && names.has(name);
+  });
 }
 
 function isExplicitlyTerminal(values: unknown[]): boolean {
-  for (const value of values) {
-    const record = asRecord(value);
-
-    if (record?.isRetryable === false) {
-      return true;
-    }
-
-    const statusCode =
-      asFiniteNumber(record?.statusCode) ?? asFiniteNumber(record?.status);
-
-    if (statusCode !== undefined && TERMINAL_STATUS_CODES.has(statusCode)) {
-      return true;
-    }
-
-    const code = normalizeIdentifier(record?.code);
-    const name = normalizeIdentifier(record?.name);
-
-    if (
-      (code && TERMINAL_CODES.has(code)) ||
-      (name && TERMINAL_NAMES.has(name))
-    ) {
-      return true;
-    }
+  if (values.some((value) => asRecord(value)?.isRetryable === false)) {
+    return true;
   }
 
-  return false;
+  if (hasErrorName(values, TERMINAL_ERROR_NAMES)) {
+    return true;
+  }
+
+  const status = extractProviderErrorHttpStatus(values);
+
+  return (
+    status !== undefined &&
+    status < 500 &&
+    !RETRYABLE_CLIENT_STATUS_CODES.has(status)
+  );
 }
 
 /**
@@ -159,7 +165,7 @@ export function getOpenCodeProviderErrorRecovery(
 ): OpenCodeProviderErrorRecovery | null {
   const values = collectProviderErrorValues(error);
 
-  if (isPolicyRefusal(values)) {
+  if (hasErrorName(values, POLICY_ERROR_NAMES)) {
     return {
       kind: 'policy_refusal',
       maxRetries: DEFAULT_OPENCODE_POLICY_REFUSAL_MAX_RETRIES,

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-error-recovery.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-error-recovery.ts
@@ -46,6 +46,8 @@ const TERMINAL_CODES = new Set([
   'unauthorized',
 ]);
 
+const TERMINAL_NAMES = new Set(['contextoverflowerror']);
+
 const TERMINAL_STATUS_CODES = new Set([400, 401, 402, 403, 404, 422]);
 
 function collectProviderErrorValues(error: unknown): unknown[] {
@@ -69,7 +71,7 @@ function collectProviderErrorValues(error: unknown): unknown[] {
       try {
         pending.push({ value: JSON.parse(value) as unknown, depth: depth + 1 });
       } catch {
-        // Not JSON; the raw text is still useful for marker detection below.
+        // Classification never depends on unstructured provider prose.
       }
       continue;
     }
@@ -88,33 +90,19 @@ function collectProviderErrorValues(error: unknown): unknown[] {
   return collected;
 }
 
-function normalizeCode(value: unknown): string | undefined {
-  const code = asString(value)?.trim().toLowerCase();
-  return code || undefined;
+function normalizeIdentifier(value: unknown): string | undefined {
+  const identifier = asString(value)?.trim().toLowerCase();
+  return identifier || undefined;
 }
 
 function isPolicyRefusal(values: unknown[]): boolean {
   for (const value of values) {
     const record = asRecord(value);
-    const code = normalizeCode(record?.code);
-    const name = normalizeCode(record?.name);
+    const code = normalizeIdentifier(record?.code);
+    const name = normalizeIdentifier(record?.name);
 
     if ((code && POLICY_CODES.has(code)) || name === 'contentfiltererror') {
       return true;
-    }
-
-    if (typeof value === 'string') {
-      const lower = value.toLowerCase();
-
-      if (
-        lower.includes('cyber_policy') ||
-        lower.includes('content_policy_violation') ||
-        lower.includes('flagged for possible cybersecurity risk') ||
-        lower.includes("blocked by the provider's content filter") ||
-        lower.includes('declined by the provider safety policy')
-      ) {
-        return true;
-      }
     }
   }
 
@@ -136,31 +124,14 @@ function isExplicitlyTerminal(values: unknown[]): boolean {
       return true;
     }
 
-    const code = normalizeCode(record?.code);
+    const code = normalizeIdentifier(record?.code);
+    const name = normalizeIdentifier(record?.name);
 
-    if (code && TERMINAL_CODES.has(code)) {
+    if (
+      (code && TERMINAL_CODES.has(code)) ||
+      (name && TERMINAL_NAMES.has(name))
+    ) {
       return true;
-    }
-
-    if (typeof value === 'string') {
-      const lower = value.toLowerCase();
-
-      if (
-        lower.includes('api key is missing') ||
-        lower.includes('invalid api key') ||
-        lower.includes('api key is invalid') ||
-        lower.includes('authentication failed') ||
-        lower.includes('model is not available') ||
-        lower.includes('model not found') ||
-        lower.includes('maximum context length') ||
-        lower.includes('insufficient balance') ||
-        lower.includes('please recharge') ||
-        (lower.includes('account') && lower.includes('is suspended')) ||
-        lower.includes('payment required') ||
-        lower.includes('insufficient quota')
-      ) {
-        return true;
-      }
     }
   }
 

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-rate-limit.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-rate-limit.test.ts
@@ -36,6 +36,32 @@ describe('isOpenCodeProviderRateLimitError', () => {
     ).toBe(true);
   });
 
+  it('detects exact structured rate-limit identifiers', () => {
+    expect(
+      isOpenCodeProviderRateLimitError({ code: 'rate_limit_exceeded' }),
+    ).toBe(true);
+    expect(
+      isOpenCodeProviderRateLimitError({
+        metadata: { error_type: 'too_many_requests' },
+      }),
+    ).toBe(true);
+  });
+
+  it('does not classify message wording as a rate limit', () => {
+    expect(
+      isOpenCodeProviderRateLimitError({ message: 'Too many requests' }),
+    ).toBe(false);
+  });
+
+  it('does not retry an explicitly non-retryable 429', () => {
+    expect(
+      isOpenCodeProviderRateLimitError({
+        statusCode: 429,
+        isRetryable: false,
+      }),
+    ).toBe(false);
+  });
+
   it('rejects non-rate-limit provider errors', () => {
     expect(
       isOpenCodeProviderRateLimitError({

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-rate-limit.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-rate-limit.test.ts
@@ -36,18 +36,15 @@ describe('isOpenCodeProviderRateLimitError', () => {
     ).toBe(true);
   });
 
-  it('detects exact structured rate-limit identifiers', () => {
+  it('requires an HTTP 429; identifier strings and wording do not count', () => {
     expect(
       isOpenCodeProviderRateLimitError({ code: 'rate_limit_exceeded' }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       isOpenCodeProviderRateLimitError({
         metadata: { error_type: 'too_many_requests' },
       }),
-    ).toBe(true);
-  });
-
-  it('does not classify message wording as a rate limit', () => {
+    ).toBe(false);
     expect(
       isOpenCodeProviderRateLimitError({ message: 'Too many requests' }),
     ).toBe(false);

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-rate-limit.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-rate-limit.ts
@@ -14,74 +14,61 @@ export const OPENCODE_RATE_LIMIT_RETRY_PROMPT_TEXT = [
   'Resume from where you left off without restating the rate-limit error.',
 ].join(' ');
 
-function collectRateLimitCandidateStrings(error: unknown): string[] {
-  const record = asRecord(error);
-  const data = asRecord(record?.data);
-  const values: unknown[] = [
-    record?.message,
-    data?.message,
-    data?.responseBody,
-    data?.body,
-    // When OpenCode surfaces UnknownError, the message may already be a JSON
-    // string of the provider payload; also keep the whole error serialized
-    // as a final fallback for nested markers.
-    typeof error === 'string' ? error : undefined,
+const RATE_LIMIT_IDENTIFIERS = new Set([
+  '429',
+  'rate_limit',
+  'rate_limit_error',
+  'rate_limit_exceeded',
+  'too_many_requests',
+]);
+
+function normalizeIdentifier(value: unknown): string | undefined {
+  const identifier = asString(value)?.trim().toLowerCase();
+  return identifier || undefined;
+}
+
+function collectRateLimitValues(error: unknown): unknown[] {
+  const pending: Array<{ value: unknown; depth: number }> = [
+    { value: error, depth: 0 },
   ];
+  const collected: unknown[] = [];
+  const seen = new Set<object>();
 
-  const strings: string[] = [];
+  while (pending.length > 0) {
+    const current = pending.shift();
 
-  for (const value of values) {
-    if (typeof value === 'string' && value.trim().length > 0) {
-      strings.push(value);
+    if (!current || current.depth > 4) {
+      continue;
+    }
+
+    const { value, depth } = current;
+    collected.push(value);
+
+    if (typeof value === 'string') {
+      try {
+        pending.push({ value: JSON.parse(value) as unknown, depth: depth + 1 });
+      } catch {
+        // Classification never depends on unstructured provider prose.
+      }
+      continue;
+    }
+
+    if (!value || typeof value !== 'object' || seen.has(value)) {
+      continue;
+    }
+
+    seen.add(value);
+    for (const nested of Object.values(value)) {
+      pending.push({ value: nested, depth: depth + 1 });
     }
   }
 
-  return strings;
-}
-
-function objectIndicatesRateLimit(value: unknown): boolean {
-  const record = asRecord(value);
-
-  if (!record) {
-    return false;
-  }
-
-  const code = record.code;
-  if (code === 429 || code === '429') {
-    return true;
-  }
-
-  if (typeof code === 'string' && code.toLowerCase().includes('rate_limit')) {
-    return true;
-  }
-
-  const statusCode = asFiniteNumber(record.statusCode);
-  if (statusCode === 429) {
-    return true;
-  }
-
-  const metadata = asRecord(record.metadata);
-  const errorType =
-    asString(metadata?.error_type) ?? asString(record.error_type);
-  if (
-    errorType &&
-    (errorType.toLowerCase().includes('rate_limit') ||
-      errorType.toLowerCase() === 'too_many_requests')
-  ) {
-    return true;
-  }
-
-  const nestedError = asRecord(record.error);
-  if (nestedError && objectIndicatesRateLimit(nestedError)) {
-    return true;
-  }
-
-  return false;
+  return collected;
 }
 
 /**
  * True when an OpenCode session.error payload is a provider rate limit
- * (HTTP 429 / rate_limit_exceeded / "too many requests"), including the
+ * (HTTP 429 / rate_limit_exceeded), including the
  * UnknownError-wrapped OpenRouter shape:
  * `{"code":429,"message":"Provider returned error","metadata":{"error_type":"rate_limit_exceeded"}}`
  *
@@ -89,33 +76,29 @@ function objectIndicatesRateLimit(value: unknown): boolean {
  * that UnknownError payload falls through as a terminal session.error.
  */
 export function isOpenCodeProviderRateLimitError(error: unknown): boolean {
-  const record = asRecord(error);
-  const data = asRecord(record?.data) ?? record;
+  const values = collectRateLimitValues(error);
 
-  if (objectIndicatesRateLimit(data) || objectIndicatesRateLimit(record)) {
-    return true;
+  if (values.some((value) => asRecord(value)?.isRetryable === false)) {
+    return false;
   }
 
-  for (const text of collectRateLimitCandidateStrings(error)) {
-    const lower = text.toLowerCase();
-
-    if (
-      lower.includes('rate_limit') ||
-      lower.includes('rate limit') ||
-      lower.includes('too many requests') ||
-      lower.includes('"error_type":"rate_limit_exceeded"') ||
-      lower.includes('"code":429')
-    ) {
-      return true;
+  for (const value of values) {
+    const record = asRecord(value);
+    if (!record) {
+      continue;
     }
 
-    try {
-      const parsed: unknown = JSON.parse(text);
-      if (objectIndicatesRateLimit(parsed)) {
-        return true;
-      }
-    } catch {
-      // not JSON
+    const statusCode =
+      asFiniteNumber(record.statusCode) ?? asFiniteNumber(record.status);
+    const code = normalizeIdentifier(record.code);
+    const errorType = normalizeIdentifier(record.error_type);
+
+    if (
+      statusCode === 429 ||
+      (code && RATE_LIMIT_IDENTIFIERS.has(code)) ||
+      (errorType && RATE_LIMIT_IDENTIFIERS.has(errorType))
+    ) {
+      return true;
     }
   }
 

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-rate-limit.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/provider-rate-limit.ts
@@ -1,5 +1,10 @@
 import { asFiniteNumber, asRecord, asString } from '@roomote/types';
 
+import {
+  collectProviderErrorValues,
+  extractProviderErrorHttpStatus,
+} from './provider-error-recovery';
+
 /** How many automatic continue attempts after a provider rate limit. */
 export const DEFAULT_OPENCODE_RATE_LIMIT_MAX_RETRIES = 3;
 
@@ -14,61 +19,8 @@ export const OPENCODE_RATE_LIMIT_RETRY_PROMPT_TEXT = [
   'Resume from where you left off without restating the rate-limit error.',
 ].join(' ');
 
-const RATE_LIMIT_IDENTIFIERS = new Set([
-  '429',
-  'rate_limit',
-  'rate_limit_error',
-  'rate_limit_exceeded',
-  'too_many_requests',
-]);
-
-function normalizeIdentifier(value: unknown): string | undefined {
-  const identifier = asString(value)?.trim().toLowerCase();
-  return identifier || undefined;
-}
-
-function collectRateLimitValues(error: unknown): unknown[] {
-  const pending: Array<{ value: unknown; depth: number }> = [
-    { value: error, depth: 0 },
-  ];
-  const collected: unknown[] = [];
-  const seen = new Set<object>();
-
-  while (pending.length > 0) {
-    const current = pending.shift();
-
-    if (!current || current.depth > 4) {
-      continue;
-    }
-
-    const { value, depth } = current;
-    collected.push(value);
-
-    if (typeof value === 'string') {
-      try {
-        pending.push({ value: JSON.parse(value) as unknown, depth: depth + 1 });
-      } catch {
-        // Classification never depends on unstructured provider prose.
-      }
-      continue;
-    }
-
-    if (!value || typeof value !== 'object' || seen.has(value)) {
-      continue;
-    }
-
-    seen.add(value);
-    for (const nested of Object.values(value)) {
-      pending.push({ value: nested, depth: depth + 1 });
-    }
-  }
-
-  return collected;
-}
-
 /**
- * True when an OpenCode session.error payload is a provider rate limit
- * (HTTP 429 / rate_limit_exceeded), including the
+ * True when an OpenCode session.error payload is an HTTP 429, including the
  * UnknownError-wrapped OpenRouter shape:
  * `{"code":429,"message":"Provider returned error","metadata":{"error_type":"rate_limit_exceeded"}}`
  *
@@ -76,33 +28,13 @@ function collectRateLimitValues(error: unknown): unknown[] {
  * that UnknownError payload falls through as a terminal session.error.
  */
 export function isOpenCodeProviderRateLimitError(error: unknown): boolean {
-  const values = collectRateLimitValues(error);
+  const values = collectProviderErrorValues(error);
 
   if (values.some((value) => asRecord(value)?.isRetryable === false)) {
     return false;
   }
 
-  for (const value of values) {
-    const record = asRecord(value);
-    if (!record) {
-      continue;
-    }
-
-    const statusCode =
-      asFiniteNumber(record.statusCode) ?? asFiniteNumber(record.status);
-    const code = normalizeIdentifier(record.code);
-    const errorType = normalizeIdentifier(record.error_type);
-
-    if (
-      statusCode === 429 ||
-      (code && RATE_LIMIT_IDENTIFIERS.has(code)) ||
-      (errorType && RATE_LIMIT_IDENTIFIERS.has(errorType))
-    ) {
-      return true;
-    }
-  }
-
-  return false;
+  return extractProviderErrorHttpStatus(values) === 429;
 }
 
 /**


### PR DESCRIPTION
Split out of #911 so the classification policy change gets its own review, separate from the failed-run notification mechanism.

## What changed

- Classify provider errors by HTTP status only: 4xx is terminal (replaying the request cannot succeed), except 408 and 429 which are transient; 429 is the rate-limit path; 5xx and status-less errors get a bounded generic retry budget (3 attempts) and then fail cleanly.
- Delete every provider vocabulary table: the terminal code set, the policy code set, the rate-limit identifier set, and all substring matching on provider prose.
- Keep exactly two non-HTTP signals, both structured and none of them provider vocabulary: an explicit `isRetryable: false` flag, and OpenCode's own typed error names (`ContextOverflowError` is terminal, `ContentFilterError` selects the safety-refusal retry prompt). These never carry an HTTP status because they are raised client-side.
- Share one error walker between the recovery and rate-limit modules instead of duplicating it.
- Terminate the OpenCode internal retry loop from either a structured 4xx status or the structured attempt count, with generic fallback messages when the provider supplies none.

## Why this change was made

Provider error vocabularies are unbounded: every provider words and codes its failures differently, the tables grow forever, and they are never complete. HTTP status classes are the one signal providers agree on. With #911 guaranteeing that failures reach the originating communication channel, misclassification is cheap: an unrecognized terminal error burns the 3-attempt retry budget (a few seconds of backoff) and then fails loudly, instead of needing a new dictionary entry.

## Impact

Errors carrying an HTTP status behave as before or better. Status-less errors that previously matched a code table (for example a bare `insufficient_balance` code) now consume the bounded retry budget before failing instead of failing instantly. Provider policy-refusal codes without OpenCode's typed `ContentFilterError` name use the generic retry prompt rather than the safety-refusal prompt. No classification path reads provider message wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
