### PR TITLE
[Improve] Use blobless partial clones for repository setup

### DIFF
--- a/apps/worker/src/workspace/__tests__/tool-versions.test.ts
+++ b/apps/worker/src/workspace/__tests__/tool-versions.test.ts
@@ -296,7 +296,7 @@ describe('WorkspaceManager tool versions', () => {
       });
       expect(mockExecute).toHaveBeenCalledWith({
         name: 'Git clone',
-        run: "rm -rf -- 'acme/backend' && git clone 'https://github.com/acme/backend.git' 'acme/backend'",
+        run: "rm -rf -- 'acme/backend' && git clone --filter=blob:none 'https://github.com/acme/backend.git' 'acme/backend'",
         retries: 4,
         timeout: 300,
         continue_on_error: false,
@@ -320,7 +320,7 @@ describe('WorkspaceManager tool versions', () => {
 
       expect(mockExecute).toHaveBeenCalledWith({
         name: 'Git clone',
-        run: "rm -rf -- 'acme/backend' && git clone 'https://gitlab.com/acme/backend.git' 'acme/backend'",
+        run: "rm -rf -- 'acme/backend' && git clone --filter=blob:none 'https://gitlab.com/acme/backend.git' 'acme/backend'",
         retries: 4,
         timeout: 300,
         continue_on_error: false,
@@ -369,7 +369,7 @@ describe('WorkspaceManager tool versions', () => {
 
       expect(mockExecute).toHaveBeenCalledWith({
         name: 'Git clone',
-        run: "rm -rf -- 'acme/backend' && git clone 'https://git.example.com/acme/backend.git' 'acme/backend'",
+        run: "rm -rf -- 'acme/backend' && git clone --filter=blob:none 'https://git.example.com/acme/backend.git' 'acme/backend'",
         retries: 4,
         timeout: 300,
         continue_on_error: false,
@@ -416,7 +416,7 @@ describe('WorkspaceManager tool versions', () => {
 
       expect(mockExecute).toHaveBeenCalledWith({
         name: 'Git clone',
-        run: "rm -rf -- 'acme/Platform/backend' && git clone 'https://dev.azure.com/acme/Platform/_git/backend' 'acme/Platform/backend'",
+        run: "rm -rf -- 'acme/Platform/backend' && git clone --filter=blob:none 'https://dev.azure.com/acme/Platform/_git/backend' 'acme/Platform/backend'",
         retries: 4,
         timeout: 300,
         continue_on_error: false,

--- a/apps/worker/src/workspace/__tests__/workspace-manager-clone.test.ts
+++ b/apps/worker/src/workspace/__tests__/workspace-manager-clone.test.ts
@@ -146,7 +146,7 @@ describe('WorkspaceManager repository clone preparation', () => {
     const clone = getCloneCommand();
     expect(clone).toBeDefined();
     expect(clone!.run).toBe(
-      `rm -rf -- 'acme/backend' && git clone 'https://github.com/acme/backend.git' 'acme/backend'`,
+      `rm -rf -- 'acme/backend' && git clone --filter=blob:none 'https://github.com/acme/backend.git' 'acme/backend'`,
     );
   });
 

--- a/apps/worker/src/workspace/workspace-manager.ts
+++ b/apps/worker/src/workspace/workspace-manager.ts
@@ -680,7 +680,12 @@ export class WorkspaceManager {
           // would make every retry fail with "destination path already
           // exists" — remove it first. Safe: needsClone guarantees the path
           // did not exist before the first attempt.
-          run: `rm -rf -- '${shellEscape(fullName)}' && git clone '${shellEscape(cloneUrl)}' '${shellEscape(fullName)}'`,
+          // Blobless partial clone: full commit/tree history (so log,
+          // merge-base, and PR base computations work), but historical
+          // blobs are fetched lazily instead of up front — large repos
+          // clone in a fraction of the time. Lazy fetches go through the
+          // same credential proxy that is alive for the whole run.
+          run: `rm -rf -- '${shellEscape(fullName)}' && git clone --filter=blob:none '${shellEscape(cloneUrl)}' '${shellEscape(fullName)}'`,
           // Allow brief auth and repository visibility propagation delays.
           retries: 4,
           timeout: 300,


### PR DESCRIPTION
## Summary

Fresh repository setup ran a plain `git clone`, downloading the full history and every blob up front. For large repositories this dominates environment setup time: in a recent setup run, a 2.3 GB repository took ~105s to clone (the `initializeRepositories` phase), while every other setup phase finished in a second or two. A blobless clone of the same repository transfers ~700 MB and finished in under 30s in a local comparison.

This adds `--filter=blob:none` to the worker's clone command.

## Why blobless instead of shallow

- Full commit and tree history is still fetched, so `git log`, `git merge-base`, branch diffs, and PR base computations all behave normally. `--depth=1` would break exactly the git operations agents rely on when preparing PRs.
- Blobs are fetched lazily; checkout of the target branch pulls only that branch's file contents.
- Commands that touch historical blobs (`git log -p`, `git blame` on old files) trigger on-demand fetches through the run's file-backed credential helper, which is alive for the whole run. Occasional lazy-fetch latency on deep history digs is the tradeoff for not paying the full pack download on every fresh setup.

## Notes

- Applies to all providers (GitHub, GitLab, Gitea, Azure DevOps) since they share the same clone path.
- The snapshot-resume path is unchanged: `git fetch --all --tags --prune --force` respects the clone-time filter, and the promisor-remote config survives snapshots.
- Existing clones are unaffected (the "already exists, skipping clone" path).

## Testing

- Updated the clone-command assertions in `workspace-manager-clone.test.ts` and `tool-versions.test.ts`; both files pass (48 tests).
- Local timing comparison on a 2.3 GB repository: full clone ~105s in a sandbox setup run vs ~30s / 700 MB blobless.