### PR TITLE
fix: keep closeout reminders from interrupting in-flight agent work

### DIFF
--- a/apps/worker/src/run-task/__tests__/slack-stop-hook-script.test.ts
+++ b/apps/worker/src/run-task/__tests__/slack-stop-hook-script.test.ts
@@ -8,7 +8,7 @@ import { SLACK_STOP_HOOK_SCRIPT } from '../slack-stop-hook-script';
 describe('SLACK_STOP_HOOK_SCRIPT', () => {
   const tempDirs: string[] = [];
   const reminder =
-    'Before finalizing, post a terminal Slack-visible reply for the current turn: use send_chat_reply with purpose "closeout" for the answer, result, blocker, or handoff. Use request_user_input only when you genuinely require structured input from the user. Do not continue other work first.';
+    'Before finalizing, post a terminal Slack-visible reply for the current turn: use send_chat_reply with purpose "closeout" for the answer, result, blocker, or handoff. Use request_user_input only when you genuinely require structured input from the user. If the current turn was interrupted mid-action or its work is unfinished, finish that work first and then post the closeout. Do not start unrelated new work before the closeout.';
 
   function writeHook(): string {
     const tempDir = fs.mkdtempSync(

--- a/apps/worker/src/run-task/slack-stop-hook-script.ts
+++ b/apps/worker/src/run-task/slack-stop-hook-script.ts
@@ -6,7 +6,9 @@ const REMINDER = [
   'Before finalizing, post a terminal Slack-visible reply for the current turn:',
   'use send_chat_reply with purpose "closeout" for the answer, result, blocker, or handoff.',
   'Use request_user_input only when you genuinely require structured input from the user.',
-  'Do not continue other work first.',
+  'If the current turn was interrupted mid-action or its work is unfinished,',
+  'finish that work first and then post the closeout.',
+  'Do not start unrelated new work before the closeout.',
 ].join(' ');
 const AUTOMATION_CLOSEOUT_REMINDER = [
   'This automation-started task has not posted its Slack closeout yet.',

--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
@@ -1462,6 +1462,205 @@ describe('OpenCodeServerHarness', () => {
     }
   });
 
+  it('injects a single reminder when OpenCode pairs session.status(idle) with session.idle', async () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'roomote-opencode-stop-guard-paired-idle-'),
+    );
+    const stateFilePath = path.join(tempDir, 'slack-state.json');
+    const stopHookPath = path.join(tempDir, 'stop-hook.cjs');
+
+    fs.writeFileSync(
+      stateFilePath,
+      JSON.stringify({
+        currentTurnMessageTs: '111.222',
+        currentTurnStartedAtMs: Date.now() - 1_000,
+      }),
+      'utf8',
+    );
+    fs.writeFileSync(stopHookPath, SLACK_STOP_HOOK_SCRIPT, 'utf8');
+
+    const { client, harness } = createHarness(new FakeOpenCodeServerClient(), {
+      commandEnv: {
+        ROOMOTE_SLACK_REPLY_SATISFACTION_STATE_FILE: stateFilePath,
+        ROOMOTE_OPENCODE_SLACK_STOP_HOOK_SCRIPT: stopHookPath,
+      },
+    });
+
+    try {
+      await connectHarness(harness, client);
+
+      expect(
+        harness.sendCommand({
+          commandName: TaskCommandName.StartNewTask,
+          data: { text: 'Do work.', visibleInTranscript: true },
+        }),
+      ).toBe(true);
+
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(1);
+      });
+
+      client.message.mockResolvedValueOnce(createFinalAssistantMessage());
+      await client.emit({
+        type: 'message.updated',
+        properties: {
+          info: {
+            id: 'msg_1',
+            sessionID: 'ses_1',
+            role: 'assistant',
+            time: { completed: 1 },
+          },
+        },
+      });
+
+      await client.emit({
+        type: 'session.status',
+        properties: { sessionID: 'ses_1', status: { type: 'idle' } },
+      });
+
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(2);
+      });
+
+      // The paired session.idle for the same turn end must not inject a
+      // duplicate reminder into the fresh reminder turn.
+      await client.emit({
+        type: 'session.idle',
+        properties: { sessionID: 'ses_1' },
+      });
+      expect(client.promptAsync).toHaveBeenCalledTimes(2);
+
+      // Once the reminder turn actually starts (busy) and later ends without
+      // a closeout, enforcement still applies.
+      await client.emit({
+        type: 'session.status',
+        properties: { sessionID: 'ses_1', status: { type: 'busy' } },
+      });
+      await client.emit({
+        type: 'session.idle',
+        properties: { sessionID: 'ses_1' },
+      });
+
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(3);
+      });
+      expect(client.promptAsync.mock.calls[2]?.[0]).toMatchObject({
+        sessionId: 'ses_1',
+        request: {
+          parts: [
+            {
+              type: 'text',
+              text: expect.stringContaining(
+                'Before finalizing, post a terminal Slack-visible reply',
+              ),
+            },
+          ],
+        },
+      });
+    } finally {
+      harness.dispose();
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('defers the closeout reminder while the session still has unsettled tool work', async () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'roomote-opencode-stop-guard-unsettled-'),
+    );
+    const stateFilePath = path.join(tempDir, 'slack-state.json');
+    const stopHookPath = path.join(tempDir, 'stop-hook.cjs');
+
+    fs.writeFileSync(
+      stateFilePath,
+      JSON.stringify({
+        currentTurnMessageTs: '111.222',
+        currentTurnStartedAtMs: Date.now() - 1_000,
+      }),
+      'utf8',
+    );
+    fs.writeFileSync(stopHookPath, SLACK_STOP_HOOK_SCRIPT, 'utf8');
+
+    const { client, harness } = createHarness(new FakeOpenCodeServerClient(), {
+      commandEnv: {
+        ROOMOTE_SLACK_REPLY_SATISFACTION_STATE_FILE: stateFilePath,
+        ROOMOTE_OPENCODE_SLACK_STOP_HOOK_SCRIPT: stopHookPath,
+      },
+    });
+    const taskEvents: TaskEvent[] = [];
+
+    harness.subscribe((event) => taskEvents.push(event));
+
+    try {
+      await connectHarness(harness, client);
+
+      expect(
+        harness.sendCommand({
+          commandName: TaskCommandName.StartNewTask,
+          data: { text: 'Do work.', visibleInTranscript: true },
+        }),
+      ).toBe(true);
+
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(1);
+      });
+
+      // A completed assistant message that still carries a running tool part:
+      // the shape of a stale idle racing an in-flight tool call.
+      const message = createFinalAssistantMessage();
+      message.parts.push({
+        id: 'part_tool_1',
+        sessionID: 'ses_1',
+        messageID: 'msg_1',
+        type: 'tool',
+        tool: 'edit',
+        callID: 'call_1',
+        state: { status: 'running' },
+      });
+      client.messages.mockResolvedValue([message]);
+
+      await client.emit({
+        type: 'session.idle',
+        properties: { sessionID: 'ses_1' },
+      });
+
+      // No reminder was injected and the turn was not completed; enforcement
+      // waits for the next genuine idle.
+      expect(client.promptAsync).toHaveBeenCalledTimes(1);
+      expect(
+        taskEvents.some(
+          (event) => event.eventName === TaskEventName.TaskCompleted,
+        ),
+      ).toBe(false);
+
+      // Once the tool work settles, the next idle injects the reminder.
+      client.messages.mockResolvedValue([]);
+      await client.emit({
+        type: 'session.idle',
+        properties: { sessionID: 'ses_1' },
+      });
+
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(2);
+      });
+      expect(client.promptAsync.mock.calls[1]?.[0]).toMatchObject({
+        sessionId: 'ses_1',
+        request: {
+          parts: [
+            {
+              type: 'text',
+              text: expect.stringContaining(
+                'Before finalizing, post a terminal Slack-visible reply',
+              ),
+            },
+          ],
+        },
+      });
+    } finally {
+      harness.dispose();
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('drains an answered question replay before evaluating the stop guard', async () => {
     const tempDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'roomote-opencode-stop-guard-replay-'),

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
@@ -1609,6 +1609,13 @@ export class OpenCodeServerHarness
   private stopHookReminderCount = 0;
   private stopHookReminderStallTimer: ReturnType<typeof setTimeout> | null =
     null;
+  // OpenCode 1.17 emits session.status(idle) followed by session.idle for the
+  // same turn end. Submitting a closeout reminder on the status-sourced entry
+  // sets inFlight again, so the paired session.idle would re-enter
+  // finishCurrentTurn, see the still-unsatisfied closeout state, and inject a
+  // duplicate reminder into the fresh reminder turn. This guard swallows that
+  // exact follow-up idle; any busy/retry transition clears it first.
+  private ignoreNextStopHookSessionIdle = false;
   private readonly stallWatchdogs: OpenCodeStallWatchdogs;
   private resolveEventStreamReady: (() => void) | undefined;
   private rejectEventStreamReady: ((error: unknown) => void) | undefined;
@@ -2112,6 +2119,7 @@ export class OpenCodeServerHarness
     this.stopHookReminderCount = 0;
     this.queuedUserInputReplayPromptId = null;
     this.ignoreNextUserInputReplaySessionIdle = false;
+    this.ignoreNextStopHookSessionIdle = false;
     this.currentWorkflowPhase = command.data.workflowPhase ?? null;
     this.activeWorkflowSkill = null;
     this.cancelRequestedBeforeSession = false;
@@ -3732,6 +3740,7 @@ export class OpenCodeServerHarness
       // loop advanced. Keep the stall watchdog armed during transient backoff.
       this.ignoreNextProviderRecoverySessionIdle = false;
       this.ignoreNextUserInputReplaySessionIdle = false;
+      this.ignoreNextStopHookSessionIdle = false;
       this.inFlight = true;
       this.stallWatchdogs.noteActivity();
       this.stallWatchdogs.ensureTurnStallArmed();
@@ -3743,6 +3752,7 @@ export class OpenCodeServerHarness
       // guard consume the retry's eventual idle transition.
       this.ignoreNextProviderRecoverySessionIdle = false;
       this.ignoreNextUserInputReplaySessionIdle = false;
+      this.ignoreNextStopHookSessionIdle = false;
       this.inFlight = true;
       // Status transitions prove the session is alive (e.g. a provider retry
       // loop), but not that the turn's loop advanced — a steer awaiting
@@ -3827,6 +3837,11 @@ export class OpenCodeServerHarness
 
     if (this.ignoreNextUserInputReplaySessionIdle) {
       this.ignoreNextUserInputReplaySessionIdle = false;
+      return;
+    }
+
+    if (this.ignoreNextStopHookSessionIdle) {
+      this.ignoreNextStopHookSessionIdle = false;
       return;
     }
 
@@ -4602,12 +4617,32 @@ export class OpenCodeServerHarness
             `OpenCode Slack closeout hook still blocked after ${MAX_OPENCODE_STOP_HOOK_REMINDERS} reminders; completing the turn without a Slack closeout reason=${reason}`,
           );
         } else {
+          if (await this.hasUnsettledToolWork(sessionId)) {
+            // The idle that triggered enforcement was stale: the session
+            // still has a tool call pending/running or an assistant message
+            // streaming. A reminder submitted now lands mid-work and reads
+            // as an instruction to drop that work, so defer to the next
+            // genuine idle. Restore inFlight so that idle passes the entry
+            // guard, and arm the fail-safe in case it never arrives.
+            this.logger.info(
+              `OpenCode Slack closeout reminder deferred: the session still has unsettled tool work sessionId=${sessionId}`,
+            );
+            this.inFlight = true;
+            this.armStopHookReminderStall(sessionId);
+            return;
+          }
+
           this.stopHookReminderCount += 1;
           await this.submitPrompt({
             text: reason,
             visibleInTranscript: false,
             source: 'opencode-stop-hook',
           });
+          // The reminder submission re-arms inFlight, so the session.idle
+          // paired with the status-sourced idle that brought us here would
+          // re-enter this method against the unchanged closeout state and
+          // inject a duplicate reminder. Swallow that exact follow-up idle.
+          this.ignoreNextStopHookSessionIdle = source === 'session_status';
           // We now await a fresh turn to re-enter this method. Arm a fail-safe
           // so a session that never produces that turn (wedged after the
           // reminder) still reaches a terminal state instead of hanging.
@@ -4758,6 +4793,56 @@ export class OpenCodeServerHarness
     });
 
     return this.persistAssistantMessage(message);
+  }
+
+  /**
+   * Whether the session's recent messages show work still in progress: a tool
+   * part in pending/running state, or the newest assistant message not yet
+   * completed. Used to keep the closeout reminder from being injected into a
+   * session whose idle signal was stale, where the reminder would land
+   * mid-work and supersede the in-flight tool call. Verification failures return false
+   * (proceed with the reminder) so a transient fetch error cannot silently
+   * stall closeout enforcement.
+   */
+  private async hasUnsettledToolWork(sessionId: string): Promise<boolean> {
+    let messages: OpenCodeSessionMessage[];
+
+    try {
+      messages = await this.client.messages({
+        sessionId,
+        limit: 20,
+        signal: this.eventAbortController.signal,
+      });
+    } catch (error) {
+      this.logger.warn(
+        `OpenCode closeout quiescence check failed; proceeding with the reminder sessionId=${sessionId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return false;
+    }
+
+    const latestAssistantMessage = [...messages]
+      .reverse()
+      .find((message) => message.info.role === 'assistant');
+
+    if (
+      latestAssistantMessage &&
+      !latestAssistantMessage.info.time?.completed
+    ) {
+      return true;
+    }
+
+    return messages.some((message) =>
+      message.parts.some((part) => {
+        if (part.type !== 'tool') {
+          return false;
+        }
+
+        const status = (part as OpenCodeToolPart).state?.status;
+        return status === 'pending' || status === 'running';
+      }),
+    );
   }
 
   private async finalizeLatestAssistantMessage(): Promise<FinalizedAssistantTurn | null> {

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
@@ -4633,6 +4633,9 @@ export class OpenCodeServerHarness
           }
 
           this.stopHookReminderCount += 1;
+          this.logger.info(
+            `OpenCode Slack closeout reminder submitted count=${this.stopHookReminderCount} source=${source} sessionId=${sessionId}`,
+          );
           await this.submitPrompt({
             text: reason,
             visibleInTranscript: false,


### PR DESCRIPTION
## Problem

The OpenCode closeout stop-hook reminder could land as a mid-work interruption. Agents deep in multi-step work (PR creation, file edits) would receive a "post your closeout now, do not continue other work" message, abandon the in-flight action, and post a "work is paused" closeout instead of finishing. The reminder also sometimes appeared twice in a row.

## Cause

1. **Duplicate turn-end signal.** OpenCode announces one turn end with two events: `SessionStatus.set` publishes `session.status(idle)` and then `session.idle` from the same call (identical in 1.17.18 and 1.18.10). The reminder submitted on the first event re-armed `inFlight`, so the paired `session.idle` re-entered `finishCurrentTurn` against the unchanged closeout state and injected a duplicate reminder into the turn the model had just started. The harness already guards this pair in two other paths (provider recovery, question replays) but not in the reminder path. Reproduced: the new paired-idle test fails on the current develop harness with a doubled reminder.
2. **No quiescence check.** The reminder was injected purely on trust of the idle signal; a stale idle while a tool call was still pending or running meant the reminder superseded the in-flight call.
3. **Destructive wording.** The reminder commanded "Do not continue other work first", so when it landed adjacent to interrupted work the model abandoned that work rather than resuming it.

## Fix

- New `ignoreNextStopHookSessionIdle` guard swallows the paired idle after a reminder is submitted, mirroring the two existing guards; any busy/retry transition clears it so enforcement cannot wedge.
- New `hasUnsettledToolWork` check defers the reminder while recent messages show a pending/running tool part or an incomplete assistant message. The deferred path restores `inFlight` and is bounded by the existing 10-minute stall fail-safe; a failed check falls back to reminding so enforcement cannot silently stall.
- Reminder text now instructs finishing interrupted or unfinished work first, then posting the closeout, and only forbids starting unrelated new work.

## Testing

- New test: paired `session.status(idle)` + `session.idle` yields exactly one reminder, and enforcement still applies on the next real turn end (fails on develop without the fix).
- New test: unsettled tool work defers the reminder; the next quiet idle injects it.
- Updated the stop-hook script test for the reworded reminder.
- All 60 opencode-server harness tests and 21 stop-hook script tests pass; `pnpm lint` and `pnpm check-types` clean.