### PR TITLE
fix: name the task's chat surface in closeout and silence reminders

### DIFF
--- a/apps/worker/src/run-task/__tests__/opencode-slack-hooks-plugin-script.test.ts
+++ b/apps/worker/src/run-task/__tests__/opencode-slack-hooks-plugin-script.test.ts
@@ -38,6 +38,8 @@ describe('OPENCODE_SLACK_HOOKS_PLUGIN_SCRIPT', () => {
     tempDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'roomote-opencode-slack-hooks-plugin-'),
     );
+    delete process.env.ROOMOTE_COMMUNICATION_PROVIDER;
+    delete process.env.ROOMOTE_SLACK_CHANNEL;
   });
 
   afterEach(() => {
@@ -103,7 +105,7 @@ describe('OPENCODE_SLACK_HOOKS_PLUGIN_SCRIPT', () => {
     await hooks['tool.execute.after']({ ...input, args: {} }, output);
 
     expect(output.output.startsWith('tool output')).toBe(true);
-    expect(output.output).toContain('Slack-visible ack');
+    expect(output.output).toContain('chat-visible ack');
   });
 
   it('does not append a warning when the hook allows the tool call', async () => {
@@ -228,7 +230,7 @@ describe('OPENCODE_SLACK_HOOKS_PLUGIN_SCRIPT', () => {
     await expect(
       hooks['tool.execute.before'](input, { args: {} }),
     ).rejects.toThrow(
-      'Slack-posting tools are reserved for the parent agent session.',
+      'chat-posting tools are reserved for the parent agent session.',
     );
   });
 
@@ -312,6 +314,6 @@ describe('OPENCODE_SLACK_HOOKS_PLUGIN_SCRIPT', () => {
     ).resolves.toBeUndefined();
 
     expect(output.output.startsWith('tool output')).toBe(true);
-    expect(output.output).toContain('Slack-visible ack');
+    expect(output.output).toContain('chat-visible ack');
   });
 });

--- a/apps/worker/src/run-task/__tests__/slack-silence-hook-script.test.ts
+++ b/apps/worker/src/run-task/__tests__/slack-silence-hook-script.test.ts
@@ -8,11 +8,11 @@ import { SLACK_SILENCE_HOOK_SCRIPT } from '../slack-silence-hook-script';
 describe('SLACK_SILENCE_HOOK_SCRIPT', () => {
   const tempDirs: string[] = [];
   const reminder =
-    'Slack has not received a visible update for this turn. Your next action must be a Slack-visible update to the originating thread using send_chat_reply or use send_chat_reaction_emoji only when the latest user turn itself came from Slack and that message can receive a reaction. If a successful visual-proof capture returned screenshot artifact IDs that are not yet visible in the thread and the update mentions or relies on that proof, include those IDs in the same reply via imageArtifactIds. Use request_user_input only when you genuinely require structured input from the user. Normal assistant messages do not count. Do not run more tools first. The only exception is tool_search when the needed Slack reply/post tool is not visible. After sending the Slack update, continue the work you were doing.';
+    'The originating chat thread has not received a visible update for this turn. Your next action must be a chat-visible update to the originating thread using send_chat_reply or use send_chat_reaction_emoji only when the latest user turn itself came from chat and that message can receive a reaction. If a successful visual-proof capture returned screenshot artifact IDs that are not yet visible in the thread and the update mentions or relies on that proof, include those IDs in the same reply via imageArtifactIds. Use request_user_input only when you genuinely require structured input from the user. Normal assistant messages do not count. Do not run more tools first. The only exception is tool_search when the needed chat reply/post tool is not visible. After sending the chat update, continue the work you were doing.';
   const initialAckReminder =
-    'Before starting work that will not post to Slack on this turn, send a quick Slack-visible ack. When the latest user turn itself came from Slack, reactions are allowed on that message, and a lightweight acknowledgement is enough, start with send_chat_reaction_emoji. Otherwise use send_chat_reply. Do not use request_user_input as a generic opening acknowledgement; only use it when you genuinely require structured input from the user. If the needed Slack reply/post tool is not visible, use tool_search first. If context is still too thin to say anything concrete and the turn does not allow reactions, keep the text ack short and non-speculative. After that, continue the work you were doing.';
+    'Before starting work that will not post to chat on this turn, send a quick chat-visible ack. When the latest user turn itself came from chat, reactions are allowed on that message, and a lightweight acknowledgement is enough, start with send_chat_reaction_emoji. Otherwise use send_chat_reply. Do not use request_user_input as a generic opening acknowledgement; only use it when you genuinely require structured input from the user. If the needed chat reply/post tool is not visible, use tool_search first. If context is still too thin to say anything concrete and the turn does not allow reactions, keep the text ack short and non-speculative. After that, continue the work you were doing.';
   const subagentSlackPostDenial =
-    'Slack-posting tools are reserved for the parent agent session. This subagent session must not post to Slack directly. Return your findings in your final report to the parent agent instead; the parent agent will relay any Slack-visible update.';
+    'chat-posting tools are reserved for the parent agent session. This subagent session must not post to chat directly. Return your findings in your final report to the parent agent instead; the parent agent will relay any chat-visible update.';
 
   function writeHook(): string {
     const tempDir = fs.mkdtempSync(
@@ -35,6 +35,8 @@ describe('SLACK_SILENCE_HOOK_SCRIPT', () => {
         ...process.env,
         ROOMOTE_SLACK_HOOK_DEBUG: undefined,
         ROOMOTE_SLACK_REPLY_SATISFACTION_STATE_FILE: undefined,
+        ROOMOTE_COMMUNICATION_PROVIDER: undefined,
+        ROOMOTE_SLACK_CHANNEL: undefined,
         ...options.env,
       },
     });
@@ -481,6 +483,28 @@ describe('SLACK_SILENCE_HOOK_SCRIPT', () => {
     expect(result.stderr).toContain('trigger="PostToolUse"');
     expect(result.stderr).toContain('decision="block"');
     expect(result.stderr).toContain('reason="slack_update_overdue"');
+  });
+
+  it('names the communication surface in the silence reminder for non-Slack providers', () => {
+    const stateFilePath = writeState({
+      startedAtMs: Date.now() - 7 * 60_000 - 1_000,
+    });
+
+    const result = runHook({
+      input: { hook_event_name: 'PostToolUse', tool_name: 'shell' },
+      env: {
+        ROOMOTE_SLACK_REPLY_SATISFACTION_STATE_FILE: stateFilePath,
+        ROOMOTE_COMMUNICATION_PROVIDER: 'discord',
+      },
+    });
+
+    expect(result.status).toBe(0);
+    const decision = JSON.parse(result.stdout);
+    expect(decision.reason).toContain(
+      'The originating Discord thread has not received a visible update',
+    );
+    expect(decision.reason).toContain('Discord-visible update');
+    expect(decision.reason).not.toContain('Slack');
   });
 
   it('continues blocking stale non-Slack hook events until another successful Slack reply is recorded', () => {

--- a/apps/worker/src/run-task/__tests__/slack-stop-hook-script.test.ts
+++ b/apps/worker/src/run-task/__tests__/slack-stop-hook-script.test.ts
@@ -8,7 +8,7 @@ import { SLACK_STOP_HOOK_SCRIPT } from '../slack-stop-hook-script';
 describe('SLACK_STOP_HOOK_SCRIPT', () => {
   const tempDirs: string[] = [];
   const reminder =
-    'Before finalizing, post a terminal Slack-visible reply for the current turn: use send_chat_reply with purpose "closeout" for the answer, result, blocker, or handoff. Use request_user_input only when you genuinely require structured input from the user. If the current turn was interrupted mid-action or its work is unfinished, finish that work first and then post the closeout. Do not start unrelated new work before the closeout.';
+    'Before finalizing, post a terminal chat-visible reply for the current turn: use send_chat_reply with purpose "closeout" for the answer, result, blocker, or handoff. Use request_user_input only when you genuinely require structured input from the user. If the current turn was interrupted mid-action or its work is unfinished, finish that work first and then post the closeout. Do not start unrelated new work before the closeout.';
 
   function writeHook(): string {
     const tempDir = fs.mkdtempSync(
@@ -34,6 +34,8 @@ describe('SLACK_STOP_HOOK_SCRIPT', () => {
         ...process.env,
         ROOMOTE_SLACK_HOOK_DEBUG: undefined,
         ROOMOTE_SLACK_REPLY_SATISFACTION_STATE_FILE: undefined,
+        ROOMOTE_COMMUNICATION_PROVIDER: undefined,
+        ROOMOTE_SLACK_CHANNEL: undefined,
         ...options.env,
       },
     });
@@ -93,6 +95,39 @@ describe('SLACK_STOP_HOOK_SCRIPT', () => {
     expect(result.stdout).toBe('');
     expect(result.stderr).toContain('decision="allow"');
     expect(result.stderr).toContain('reason="non_parent_thread"');
+  });
+
+  it('names the communication surface in the reminder for non-Slack providers', () => {
+    const result = runHook({
+      env: {
+        ROOMOTE_SLACK_REPLY_SATISFACTION_STATE_FILE: '/tmp/roomote-state.json',
+        ROOMOTE_COMMUNICATION_PROVIDER: 'discord',
+      },
+    });
+
+    expect(result.status).toBe(0);
+    const decision = JSON.parse(result.stdout);
+    expect(decision.decision).toBe('block');
+    expect(decision.reason).toContain(
+      'post a terminal Discord-visible reply for the current turn',
+    );
+    expect(decision.reason).not.toContain('Slack');
+  });
+
+  it('names Slack in the reminder when a Slack channel is configured', () => {
+    const result = runHook({
+      env: {
+        ROOMOTE_SLACK_REPLY_SATISFACTION_STATE_FILE: '/tmp/roomote-state.json',
+        ROOMOTE_SLACK_CHANNEL: 'C123ABC456',
+      },
+    });
+
+    expect(result.status).toBe(0);
+    const decision = JSON.parse(result.stdout);
+    expect(decision.decision).toBe('block');
+    expect(decision.reason).toContain(
+      'post a terminal Slack-visible reply for the current turn',
+    );
   });
 
   it('blocks Stop when Slack reply satisfaction is configured and no successful reply has been recorded', () => {
@@ -166,7 +201,7 @@ describe('SLACK_STOP_HOOK_SCRIPT', () => {
     const decision = JSON.parse(result.stdout);
     expect(decision.decision).toBe('block');
     expect(decision.reason).toContain(
-      'This automation-started task has not posted its Slack closeout yet.',
+      'This automation-started task has not posted its chat closeout yet.',
     );
     expect(decision.reason).toContain('send_chat_reply purpose "closeout"');
     expect(decision.reason).toContain(

--- a/apps/worker/src/run-task/opencode-slack-hooks-plugin-script.ts
+++ b/apps/worker/src/run-task/opencode-slack-hooks-plugin-script.ts
@@ -51,7 +51,7 @@ function runHook(scriptPath, input) {
       payload?.reason ??
       payload?.stopReason ??
       payload?.hookSpecificOutput?.additionalContext ??
-      'Slack-visible update is required before continuing.',
+      'A user-visible chat update is required before continuing.',
   };
 }
 

--- a/apps/worker/src/run-task/slack-silence-hook-script.ts
+++ b/apps/worker/src/run-task/slack-silence-hook-script.ts
@@ -11,12 +11,33 @@ const SUBAGENT_RESTRICTED_SLACK_POSTING_TOOLS = ${JSON.stringify([
   ...SLACK_POSTING_TOOL_BASENAMES,
 ])};
 
+// Mirrors the Roomote MCP server's getChatReplySurfaceLabel so reminders name
+// the surface the task actually replies to instead of hardcoding Slack.
+function getChatSurfaceLabel() {
+  const provider = (process.env.ROOMOTE_COMMUNICATION_PROVIDER || '').trim();
+  if (provider === 'teams') {
+    return 'Teams';
+  }
+  if (provider === 'telegram') {
+    return 'Telegram';
+  }
+  if (provider === 'discord') {
+    return 'Discord';
+  }
+  return (process.env.ROOMOTE_SLACK_CHANNEL || '').trim() ? 'Slack' : 'chat';
+}
+
+const SURFACE_LABEL = getChatSurfaceLabel();
 const REMINDER = [
-  'Slack has not received a visible update for this turn. Your next action',
-  'must be a Slack-visible update to the originating thread using',
+  'The originating ' +
+    SURFACE_LABEL +
+    ' thread has not received a visible update for this turn. Your next action',
+  'must be a ' +
+    SURFACE_LABEL +
+    '-visible update to the originating thread using',
   'send_chat_reply',
   'or use send_chat_reaction_emoji only when the latest user turn itself came',
-  'from Slack and that message can receive a reaction.',
+  'from ' + SURFACE_LABEL + ' and that message can receive a reaction.',
   'If a successful visual-proof capture returned screenshot artifact IDs that',
   'are not yet visible in the thread and the update mentions or relies on that',
   'proof, include those IDs in the same reply via imageArtifactIds.',
@@ -24,29 +45,39 @@ const REMINDER = [
   'from the user.',
   'Normal assistant messages do not count.',
   'Do not run more tools first.',
-  'The only exception is tool_search when the needed Slack reply/post tool is',
+  'The only exception is tool_search when the needed ' +
+    SURFACE_LABEL +
+    ' reply/post tool is',
   'not visible.',
-  'After sending the Slack update, continue the work you were doing.',
+  'After sending the ' +
+    SURFACE_LABEL +
+    ' update, continue the work you were doing.',
 ].join(' ');
 const INITIAL_ACK_REMINDER = [
-  'Before starting work that will not post to Slack on this turn, send a',
-  'quick Slack-visible ack.',
-  'When the latest user turn itself came from Slack, reactions are allowed on',
+  'Before starting work that will not post to ' +
+    SURFACE_LABEL +
+    ' on this turn, send a',
+  'quick ' + SURFACE_LABEL + '-visible ack.',
+  'When the latest user turn itself came from ' +
+    SURFACE_LABEL +
+    ', reactions are allowed on',
   'that message, and a lightweight acknowledgement is enough, start with',
   'send_chat_reaction_emoji.',
   'Otherwise use send_chat_reply.',
   'Do not use request_user_input as a generic opening acknowledgement;',
   'only use it when you genuinely require structured input from the user.',
-  'If the needed Slack reply/post tool is not visible, use tool_search first.',
+  'If the needed ' +
+    SURFACE_LABEL +
+    ' reply/post tool is not visible, use tool_search first.',
   'If context is still too thin to say anything concrete and the turn does',
   'not allow reactions, keep the text ack short and non-speculative.',
   'After that, continue the work you were doing.',
 ].join(' ');
 const SUBAGENT_SLACK_POST_DENIAL = [
-  'Slack-posting tools are reserved for the parent agent session.',
-  'This subagent session must not post to Slack directly.',
+  SURFACE_LABEL + '-posting tools are reserved for the parent agent session.',
+  'This subagent session must not post to ' + SURFACE_LABEL + ' directly.',
   'Return your findings in your final report to the parent agent instead;',
-  'the parent agent will relay any Slack-visible update.',
+  'the parent agent will relay any ' + SURFACE_LABEL + '-visible update.',
 ].join(' ');
 const MAX_SILENCE_MS = 7 * 60 * 1000;
 const HOOK_NAME = 'slack-silence';

--- a/apps/worker/src/run-task/slack-stop-hook-script.ts
+++ b/apps/worker/src/run-task/slack-stop-hook-script.ts
@@ -2,8 +2,27 @@ export const SLACK_STOP_HOOK_SCRIPT = `#!/usr/bin/env node
 const fs = require('node:fs');
 const path = require('node:path');
 
+// Mirrors the Roomote MCP server's getChatReplySurfaceLabel so reminders name
+// the surface the task actually replies to instead of hardcoding Slack.
+function getChatSurfaceLabel() {
+  const provider = (process.env.ROOMOTE_COMMUNICATION_PROVIDER || '').trim();
+  if (provider === 'teams') {
+    return 'Teams';
+  }
+  if (provider === 'telegram') {
+    return 'Telegram';
+  }
+  if (provider === 'discord') {
+    return 'Discord';
+  }
+  return (process.env.ROOMOTE_SLACK_CHANNEL || '').trim() ? 'Slack' : 'chat';
+}
+
+const SURFACE_LABEL = getChatSurfaceLabel();
 const REMINDER = [
-  'Before finalizing, post a terminal Slack-visible reply for the current turn:',
+  'Before finalizing, post a terminal ' +
+    SURFACE_LABEL +
+    '-visible reply for the current turn:',
   'use send_chat_reply with purpose "closeout" for the answer, result, blocker, or handoff.',
   'Use request_user_input only when you genuinely require structured input from the user.',
   'If the current turn was interrupted mid-action or its work is unfinished,',
@@ -11,8 +30,12 @@ const REMINDER = [
   'Do not start unrelated new work before the closeout.',
 ].join(' ');
 const AUTOMATION_CLOSEOUT_REMINDER = [
-  'This automation-started task has not posted its Slack closeout yet.',
-  'Before finalizing, post one self-contained Slack message with send_chat_reply purpose "closeout" that explains',
+  'This automation-started task has not posted its ' +
+    SURFACE_LABEL +
+    ' closeout yet.',
+  'Before finalizing, post one self-contained ' +
+    SURFACE_LABEL +
+    ' message with send_chat_reply purpose "closeout" that explains',
   'what the automation asked you to investigate and the concrete outcome (PR link, no-op or deferred reason, or blocker).',
   'Do not start new work first.',
 ].join(' ');

--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
@@ -1445,7 +1445,7 @@ describe('OpenCodeServerHarness', () => {
             {
               type: 'text',
               text: expect.stringContaining(
-                'Before finalizing, post a terminal Slack-visible reply',
+                'Before finalizing, post a terminal chat-visible reply',
               ),
             },
           ],
@@ -1551,7 +1551,7 @@ describe('OpenCodeServerHarness', () => {
             {
               type: 'text',
               text: expect.stringContaining(
-                'Before finalizing, post a terminal Slack-visible reply',
+                'Before finalizing, post a terminal chat-visible reply',
               ),
             },
           ],
@@ -1649,7 +1649,7 @@ describe('OpenCodeServerHarness', () => {
             {
               type: 'text',
               text: expect.stringContaining(
-                'Before finalizing, post a terminal Slack-visible reply',
+                'Before finalizing, post a terminal chat-visible reply',
               ),
             },
           ],
@@ -1846,7 +1846,7 @@ describe('OpenCodeServerHarness', () => {
             {
               type: 'text',
               text: expect.stringContaining(
-                'Before finalizing, post a terminal Slack-visible reply',
+                'Before finalizing, post a terminal chat-visible reply',
               ),
             },
           ],
@@ -1975,7 +1975,7 @@ describe('OpenCodeServerHarness', () => {
             {
               type: 'text',
               text: expect.stringContaining(
-                'Before finalizing, post a terminal Slack-visible reply',
+                'Before finalizing, post a terminal chat-visible reply',
               ),
             },
           ],

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
@@ -300,7 +300,7 @@ const DEFAULT_SUBAGENT_SETTLEMENT_GRACE_MS = 10 * 60_000;
 const DEFAULT_QUEUED_PROMPT_RETRY_DELAY_MS = 1_000;
 const MAX_PROGRESS_COMMAND_CHARS = 240;
 const FALLBACK_OPENCODE_STOP_HOOK_REMINDER =
-  'Before finalizing, post a terminal Slack-visible reply for the current turn.';
+  'Before finalizing, post a terminal chat-visible reply for the current turn.';
 const ROOMOTE_OPENCODE_VISUAL_AGENT_NAME = 'visual';
 // OpenCode's built-in tool for loading skills into the session.
 const OPENCODE_SKILL_TOOL = 'skill';


### PR DESCRIPTION
Replaces #954, which was auto-closed when its stacked base branch (#953) merged and was deleted. Content is identical, rebased onto `develop`.

## Problem

The stop hook, silence hook, and OpenCode hooks plugin hardcode Slack in their model-facing reminder text, so Discord, Teams, and Telegram tasks are told to post a "Slack-visible" reply. In the incident that motivated #953 the agent had to note on Discord that "despite saying Slack-visible, this task's communication surface is Discord."

## Fix

The MCP tool descriptions already resolve the surface per provider via `getChatReplySurfaceLabel`. The three hook scripts now mirror that resolution (Teams/Telegram/Discord from `ROOMOTE_COMMUNICATION_PROVIDER`, Slack when a Slack channel is configured, `chat` otherwise) and build their reminder strings from the resolved label:

- `slack-stop-hook-script.ts`: closeout reminder and automation closeout reminder
- `slack-silence-hook-script.ts`: silence reminder, initial-ack reminder, and subagent posting denial
- `opencode-slack-hooks-plugin-script.ts`: provider-neutral fallback reason
- `harness.ts`: provider-neutral `FALLBACK_OPENCODE_STOP_HOOK_REMINDER`

The provider env vars flow into the hook scripts through the same env that already carries the satisfaction state file path, so no new plumbing is needed. Internal names (env vars, file names, log tags) are intentionally unchanged.

## Testing

- New stop-hook tests: Discord provider yields `Discord-visible` with no Slack mention; a configured Slack channel still yields `Slack-visible`.
- New silence-hook test: Discord provider names the Discord thread in the silence reminder.
- Existing expectations updated to the `chat` fallback; hook test helpers now pin the provider env vars so host machines cannot flake the label.
- All 133 tests across the four affected files pass; `pnpm lint` and `pnpm check-types` clean.