### PR TITLE
Promote v0.29.0 to production

### DIFF
--- a/.agents/skills/changeset-release-pr/SKILL.md
+++ b/.agents/skills/changeset-release-pr/SKILL.md
@@ -66,15 +66,20 @@ git log v<last>..origin/develop --oneline --first-parent
 For anything ambiguous, read the PR body with `gh pr view <number>` to identify
 the user-facing or operator-facing impact.
 
-### 3. Identify external contributors
+### 3. Identify external contributors and issue reporters
 
 For every merged PR that will have a changelog bullet, inspect its author with
-`gh pr view <number> --json author`. Thank contributors only when the author is
-not a bot and is not a code owner. Read the applicable `CODEOWNERS` file and
+`gh pr view <number> --json author,closingIssuesReferences`. Inspect the author
+of every returned issue with
+`gh issue view <issue-url> --json author,authorAssociation,url`. Classify PR
+authors and issue reporters as external only when they are not bots and are not
+code owners. Also require an issue reporter's `authorAssociation` to be outside
+`OWNER`, `MEMBER`, and `COLLABORATOR`. Read the applicable `CODEOWNERS` file and
 resolve its individual GitHub-owner entries and organization-team entries before
-classifying the author; if this repository has no `CODEOWNERS` file, no author
-is excluded on that basis. Do not treat an author as external merely because
-their PR was merged by someone else.
+classifying them; if this repository has no `CODEOWNERS` file, no author or
+reporter is excluded on that basis, but the issue-author association check still
+applies. Do not treat someone as external merely because another person merged
+the PR or implemented the fix.
 
 - Treat GitHub App and bot accounts as bots; never add contributor thanks for
   them.
@@ -82,6 +87,11 @@ their PR was merged by someone else.
 - Keep a mapping from each eligible external contributor to the release note
   that covers their PR. If multiple eligible contributors are covered by one
   note, thank each of them in that note.
+- Keep a mapping from each eligible external issue reporter and linked issue URL
+  to the release note that covers the associated PR. Link each issue and thank
+  its reporter in that note.
+- When the same person is both the contributor and issue reporter for one note,
+  combine the acknowledgement instead of thanking them twice.
 - Do not add a thank-you to a skipped internal, docs-only, CI, or dependency
   change that does not receive a changelog bullet.
 
@@ -140,6 +150,11 @@ One concise, user-facing summary of the change.
   sentence such as `Thanks to @octocat for contributing this improvement.` Keep
   the thanks in the same paragraph as the release-note summary. Update an
   existing pending changeset when it is the note that covers the contribution.
+- For a note associated with an issue from an eligible external reporter, link
+  the issue and thank them with a concise sentence such as
+  `Thanks to @octocat for reporting [#123](https://github.com/owner/repo/issues/123).`
+  Use the issue's canonical URL, keep the thanks in the same paragraph, and
+  update an existing pending changeset when it covers the reported change.
 - These newly authored files are temporary release inputs. `pnpm run version`
   consumes them before the release branch is committed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 This file tracks product releases for Roomote (single monorepo version). Automated release entries are prepended by `pnpm run version`.
 
+## 0.29.0 (2026-08-01)
+
+This release expands model reasoning and preset options while improving LiteLLM routing, invite previews, and environment guidance.
+
+### Highlights
+
+- Choose Max reasoning for supported OpenAI and Anthropic models, and use refreshed OpenAI and ChatGPT presets with specialized defaults and a Luna Max option.
+- Route GitHub mentions and other helper calls reliably through configured LiteLLM providers.
+- Share invite links with clear, privacy-safe previews and keep admin-only environment guidance hidden from members.
+
+### Minor changes
+
+- Refresh the recommended OpenAI and ChatGPT subscription model presets with Sol defaults for coding and vision, specialized supporting models, and a Luna Max option for higher-effort coding.
+- Let administrators select and persist Max reasoning for supported OpenAI and Anthropic models while preserving compatibility with existing reasoning levels.
+
+### Patch changes
+
+- Give shared invite links a clear Roomote Invitation preview without exposing invite tokens, roles, or deployment details.
+- Keep GitHub mention routing and other non-task helper calls working with LiteLLM-backed models by registering their configured endpoint, adapter, credentials, and model catalog. Thanks to @tomny-dev for reporting [#963](https://github.com/RooCodeInc/Roomote/issues/963).
+- Hide the homepage environment-creation warning and admin-only action from members who cannot manage environments.
+
 ## 0.28.0 (2026-08-01)
 
 This release speeds up setup and pull request reviews while improving chat task continuity, task attribution, model recommendations, and deployment reliability.

--- a/apps/web/src/app/(authenticated)/home/Home.client.test.tsx
+++ b/apps/web/src/app/(authenticated)/home/Home.client.test.tsx
@@ -15,6 +15,7 @@ import { AUTO_WORKSPACE_VALUE } from '@/components/tasks/constants';
 let currentSearchParams = '';
 let currentFeatureFlags: Record<string, boolean> = {};
 let currentCloudEnabled = false;
+let currentIsAdmin = true;
 let currentShowDebugUI = false;
 let currentShowDebugUILoading = false;
 let currentEnvironments: Array<{ id: string; name: string }> | undefined = [
@@ -62,7 +63,7 @@ vi.mock('sonner', () => ({
 vi.mock('@/hooks/useUser', () => ({
   useAuthorizedUser: () => ({
     userId: 'user-1',
-    isAdmin: true,
+    isAdmin: currentIsAdmin,
     name: 'Test User',
     primaryEmail: 'test@example.com',
     cloudEnabled: currentCloudEnabled,
@@ -324,6 +325,7 @@ describe('Home', () => {
     currentSearchParams = '';
     currentFeatureFlags = {};
     currentCloudEnabled = false;
+    currentIsAdmin = true;
     currentShowDebugUI = false;
     currentShowDebugUILoading = false;
     currentEnvironments = [
@@ -939,6 +941,17 @@ describe('Home', () => {
     expect(
       screen.getByText(/You haven't created any environments yet/i),
     ).toBeInTheDocument();
+  });
+
+  it('does not show the empty-environments warning to members', () => {
+    currentIsAdmin = false;
+    currentEnvironments = [];
+
+    render(<Home initialPlaceholderIndex={0} />);
+
+    expect(
+      screen.queryByText(/You haven't created any environments yet/i),
+    ).not.toBeInTheDocument();
   });
 
   it('allows all-repositories launches when no environments exist', async () => {

--- a/apps/web/src/app/(authenticated)/home/Home.tsx
+++ b/apps/web/src/app/(authenticated)/home/Home.tsx
@@ -107,8 +107,11 @@ export function Home({
 }: HomeProps) {
   const router = useRouter();
   const environments = useEnvironments();
-  const { cloudEnabled, managedAccess = DEFAULT_MANAGED_DEPLOYMENT_ACCESS } =
-    useAuthorizedUser();
+  const {
+    cloudEnabled,
+    isAdmin,
+    managedAccess = DEFAULT_MANAGED_DEPLOYMENT_ACCESS,
+  } = useAuthorizedUser();
 
   const { isDebugUIVisible } = useShowDebugUI();
   const canSelectBranch = isDebugUIVisible;
@@ -447,7 +450,7 @@ export function Home({
   const shouldDimMainForm = isBottomSheetExpanded && isShortViewport;
   const hasAnyEnvironments = (environments.data?.length ?? 0) > 0;
   const showNoEnvironmentsWarning =
-    !environments.isPending && !hasAnyEnvironments;
+    isAdmin && !environments.isPending && !hasAnyEnvironments;
   const submitDisabledReason =
     getTaskLaunchDisabledReason(managedAccess) ??
     (!hasAnyEnvironments && watchedRepository === AUTO_WORKSPACE_VALUE

--- a/apps/web/src/app/(unauthenticated)/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/web/src/app/(unauthenticated)/sign-in/[[...sign-in]]/page.tsx
@@ -27,14 +27,8 @@ export async function generateMetadata(props: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }): Promise<Metadata> {
   const searchParams = await props.searchParams;
-  // Bootstrap web runtime env the same way the page does before asking
-  // whether this visitor is allowed to create an account.
-  await getConfiguredAuthProviders();
-  const canSignUp = await canVisitorSignUp();
-  // Match auth-form defaultMode: sign-up only when the form can show it
-  // and the visitor arrived with a non-empty `invited` query.
-  return canSignUp && hasInvitedParam(searchParams.invited)
-    ? PAGE_METADATA.signUp
+  return hasInvitedParam(searchParams.invited)
+    ? PAGE_METADATA.invite
     : PAGE_METADATA.logIn;
 }
 

--- a/apps/web/src/components/settings/ModelSettingsSection.test.tsx
+++ b/apps/web/src/components/settings/ModelSettingsSection.test.tsx
@@ -1282,7 +1282,7 @@ describe('ModelSettingsSection', () => {
       // subscription models keep the openai/ model-id prefix.
       expect(screen.getByLabelText('New model slug')).toHaveAttribute(
         'placeholder',
-        'Eg: gpt-5.6-terra',
+        'Eg: gpt-5.6-sol',
       );
 
       fireEvent.change(screen.getByLabelText('New model slug'), {

--- a/apps/web/src/lib/metadata.test.ts
+++ b/apps/web/src/lib/metadata.test.ts
@@ -30,7 +30,7 @@ describe('PAGE_METADATA', () => {
     expect(PAGE_METADATA.settings.title).toBe('Roomote Settings');
     expect(PAGE_METADATA.taskHistory.title).toBe('Roomote Task History');
     expect(PAGE_METADATA.logIn.title).toBe('Roomote Log In');
-    expect(PAGE_METADATA.signUp.title).toBe('Roomote Sign up');
+    expect(PAGE_METADATA.invite.title).toBe('Roomote Invitation');
     expect(PAGE_METADATA.setup.title).toBe('Roomote Setup');
     expect(PAGE_METADATA.onboarding.title).toBe('Roomote Onboarding');
 
@@ -41,19 +41,23 @@ describe('PAGE_METADATA', () => {
     }
   });
 
-  it('keeps login and signup titles distinct and static', () => {
-    expect(PAGE_METADATA.logIn.title).not.toEqual(PAGE_METADATA.signUp.title);
+  it('keeps login and invite titles distinct and static', () => {
+    expect(PAGE_METADATA.logIn.title).not.toEqual(PAGE_METADATA.invite.title);
     expect(PAGE_METADATA.logIn.description).not.toContain('task');
-    expect(PAGE_METADATA.signUp.description).not.toContain('task');
+    expect(PAGE_METADATA.invite.description).not.toContain('task');
   });
 });
 
-describe('sign-in metadata eligibility', () => {
-  it('documents that sign-up titles require form eligibility plus invite', () => {
-    // Contract reminder for page generateMetadata: invited alone is not enough.
-    // Keep the static strings available; route wiring gates them with
-    // canVisitorSignUp() && invited.
-    expect(PAGE_METADATA.signUp.title).toBe('Roomote Sign up');
+describe('invite metadata', () => {
+  it('clearly identifies invite links without exposing invite details', () => {
+    expect(PAGE_METADATA.invite.title).toBe('Roomote Invitation');
+    expect(PAGE_METADATA.invite.description).toBe(
+      "You've been invited to join this Roomote deployment.",
+    );
+    expect(PAGE_METADATA.invite.openGraph).toEqual({
+      title: 'Roomote Invitation',
+      description: "You've been invited to join this Roomote deployment.",
+    });
     expect(PAGE_METADATA.logIn.title).toBe('Roomote Log In');
   });
 });

--- a/apps/web/src/lib/metadata.ts
+++ b/apps/web/src/lib/metadata.ts
@@ -50,9 +50,9 @@ export const PAGE_METADATA = {
     title: 'Roomote Log In',
     description: 'Sign in to your Roomote account.',
   }),
-  signUp: createPageMetadata({
-    title: 'Roomote Sign up',
-    description: 'Create a Roomote account.',
+  invite: createPageMetadata({
+    title: 'Roomote Invitation',
+    description: "You've been invited to join this Roomote deployment.",
   }),
   setup: createPageMetadata({
     title: 'Roomote Setup',

--- a/apps/worker/src/run-task/agent-home.ts
+++ b/apps/worker/src/run-task/agent-home.ts
@@ -6,7 +6,6 @@ import {
   BEDROCK_MANTLE_OPENAI_OPENCODE_PROVIDER_ID,
   BEDROCK_MANTLE_OPENCODE_PROVIDER_ID,
   buildInferenceGatewayOpenCodeBaseUrl,
-  buildOpenAiCompatibleProviderInstance,
   buildOpenCodeModelReasoningOptions,
   CHATGPT_FAST_MODE_ENV_VAR_NAME,
   CHATGPT_GATEWAY_PROVIDER_ID,
@@ -17,7 +16,7 @@ import {
   getInferenceGatewayProvider,
   getInferenceGatewayProviderByEnvVarName,
   getMcpIntegration,
-  getOpenAiCompatibleProviderInstance,
+  getOpenAiCompatibleRuntimeConfigs,
   INFERENCE_GATEWAY_CHATGPT_ENV_VAR_NAME,
   INFERENCE_GATEWAY_GITHUB_COPILOT_ENV_VAR_NAME,
   INFERENCE_GATEWAY_KEYS_ENV_VAR_NAME,
@@ -27,15 +26,12 @@ import {
   XAI_OPENCODE_PROVIDER_ID,
   type InferenceGatewayProvider,
   isConfiguredEnvValue,
-  isOpenAiCompatibleProviderId,
   isTaskModelIdDisabled,
-  listOpenAiCompatibleProviderInstancesFromEnvNames,
+  mergeOpenAiCompatibleProviderConfig,
   mergeOpenCodeModelReasoningOptions,
   mergeOpenCodeChatGptFastModeOptions,
   mergeOpenRouterVariantAliasModels,
   normalizeOptionalReasoningEffort,
-  OPENAI_COMPATIBLE_PROVIDER_ID,
-  type OpenAiCompatibleProviderInstance,
   parseInferenceGatewayKeys,
   renderManualSkillMarkdown,
   resolveOpenRouterVariantModelAlias,
@@ -86,152 +82,6 @@ const AZURE_COGNITIVE_SERVICES_PROVIDER_ID = 'azure-cognitive-services';
 
 const AZURE_COGNITIVE_SERVICES_API_KEY_ENV_VAR_NAME =
   'AZURE_COGNITIVE_SERVICES_API_KEY';
-
-/** Fallback direct-mode base URL for default and named OpenAI-compatible ids. */
-const OPENAI_COMPATIBLE_DEFAULT_FALLBACK_BASE_URL = 'http://127.0.0.1:4000/v1';
-
-const DEFAULT_OPENAI_COMPATIBLE_INSTANCE =
-  buildOpenAiCompatibleProviderInstance(null);
-
-/**
- * Static OpenAI-compatible-style endpoint providers. Catalog entry names and
- * env vars for the built-in `openai-compatible` id come from `@roomote/types`;
- * ollama/vllm/litellm stay local here. Named `openai-compatible-<slug>`
- * connections are discovered dynamically via the shared helpers.
- */
-const STATIC_OPENAI_COMPATIBLE_PROVIDER_CONFIGS = {
-  [OPENAI_COMPATIBLE_PROVIDER_ID]: {
-    name: DEFAULT_OPENAI_COMPATIBLE_INSTANCE.label,
-    baseUrlEnvVarName: DEFAULT_OPENAI_COMPATIBLE_INSTANCE.baseUrlEnvVarName,
-    fallbackBaseUrl: OPENAI_COMPATIBLE_DEFAULT_FALLBACK_BASE_URL,
-    apiKeyEnvVarName: DEFAULT_OPENAI_COMPATIBLE_INSTANCE.apiKeyEnvVarName as
-      | string
-      | undefined,
-    keyless: false,
-    // Arbitrary endpoints must not inherit OPENAI_* credentials. When the
-    // optional dedicated key is blank, omit the API key entirely so keyless
-    // servers that reject bearer auth match setup qualification behavior.
-    allowOpenAiEnvFallback: false,
-  },
-  ollama: {
-    name: 'Ollama',
-    baseUrlEnvVarName: 'OLLAMA_BASE_URL',
-    fallbackBaseUrl: 'http://127.0.0.1:11434/v1',
-    apiKeyEnvVarName: undefined as string | undefined,
-    keyless: true,
-    allowOpenAiEnvFallback: false,
-  },
-  vllm: {
-    name: 'vLLM',
-    baseUrlEnvVarName: 'VLLM_BASE_URL',
-    fallbackBaseUrl: 'http://127.0.0.1:8000/v1',
-    apiKeyEnvVarName: 'VLLM_API_KEY' as string | undefined,
-    keyless: false,
-    allowOpenAiEnvFallback: true,
-  },
-  litellm: {
-    name: 'LiteLLM',
-    baseUrlEnvVarName: 'LITELLM_BASE_URL',
-    fallbackBaseUrl: 'http://127.0.0.1:4000/v1',
-    apiKeyEnvVarName: 'LITELLM_API_KEY' as string | undefined,
-    keyless: false,
-    allowOpenAiEnvFallback: true,
-  },
-} as const;
-
-type StaticOpenAiCompatibleProviderId =
-  keyof typeof STATIC_OPENAI_COMPATIBLE_PROVIDER_CONFIGS;
-
-type OpenAiCompatibleProviderRuntimeConfig = {
-  name: string;
-  baseUrlEnvVarName: string;
-  fallbackBaseUrl: string;
-  apiKeyEnvVarName: string | undefined;
-  keyless: boolean;
-  allowOpenAiEnvFallback: boolean;
-};
-
-function toNamedOpenAiCompatibleRuntimeConfig(
-  instance: OpenAiCompatibleProviderInstance,
-): OpenAiCompatibleProviderRuntimeConfig {
-  return {
-    name: instance.label,
-    baseUrlEnvVarName: instance.baseUrlEnvVarName,
-    fallbackBaseUrl: OPENAI_COMPATIBLE_DEFAULT_FALLBACK_BASE_URL,
-    apiKeyEnvVarName: instance.apiKeyEnvVarName,
-    keyless: false,
-    allowOpenAiEnvFallback: false,
-  };
-}
-
-function resolveNamedOpenAiCompatibleInstance(
-  providerId: string,
-  runtimeEnv: Record<string, string>,
-): OpenAiCompatibleProviderInstance | null {
-  const instance = getOpenAiCompatibleProviderInstance(providerId);
-  if (!instance?.slug) {
-    return null;
-  }
-
-  if (!instance.labelEnvVarName) {
-    return instance;
-  }
-
-  const label = runtimeEnv[instance.labelEnvVarName]?.trim();
-  if (!label) {
-    return instance;
-  }
-
-  return getOpenAiCompatibleProviderInstance(providerId, { label }) ?? instance;
-}
-
-function getOpenAiCompatibleRuntimeConfigs(
-  modelIds: Array<string | undefined>,
-  runtimeEnv: Record<string, string>,
-): Map<string, OpenAiCompatibleProviderRuntimeConfig> {
-  const configs = new Map<string, OpenAiCompatibleProviderRuntimeConfig>();
-
-  for (const [providerId, provider] of Object.entries(
-    STATIC_OPENAI_COMPATIBLE_PROVIDER_CONFIGS,
-  ) as Array<
-    [StaticOpenAiCompatibleProviderId, OpenAiCompatibleProviderRuntimeConfig]
-  >) {
-    configs.set(providerId, provider);
-  }
-
-  const candidateProviderIds = new Set<string>();
-
-  for (const modelId of modelIds) {
-    const providerId = modelId?.trim().split('/')[0];
-    if (providerId && isOpenAiCompatibleProviderId(providerId)) {
-      candidateProviderIds.add(providerId);
-    }
-  }
-
-  for (const instance of listOpenAiCompatibleProviderInstancesFromEnvNames(
-    Object.keys(runtimeEnv),
-  )) {
-    candidateProviderIds.add(instance.id);
-  }
-
-  for (const providerId of candidateProviderIds) {
-    if (configs.has(providerId)) {
-      continue;
-    }
-
-    const instance = resolveNamedOpenAiCompatibleInstance(
-      providerId,
-      runtimeEnv,
-    );
-    if (!instance) {
-      continue;
-    }
-
-    configs.set(providerId, toNamedOpenAiCompatibleRuntimeConfig(instance));
-  }
-
-  return configs;
-}
 
 /**
  * OpenRouter identifies the calling application through the `HTTP-Referer`
@@ -933,97 +783,6 @@ function toBedrockMantleRuntimeModelId(modelId: string): string {
         BEDROCK_MANTLE_OPENCODE_PROVIDER_ID.length + 1,
       )}`
     : modelId;
-}
-
-function mergeOpenAiCompatibleProviderConfig(
-  providerConfig: Record<string, unknown>,
-  runtimeEnv: Record<string, string>,
-  modelIds: Array<string | undefined>,
-  visionModel?: string,
-): Record<string, unknown> {
-  let merged = providerConfig;
-  const runtimeConfigs = getOpenAiCompatibleRuntimeConfigs(
-    modelIds,
-    runtimeEnv,
-  );
-
-  for (const [providerId, provider] of runtimeConfigs) {
-    const prefix = `${providerId}/`;
-    const modelIdsForProvider = [
-      ...new Set(
-        modelIds.flatMap((modelId) => {
-          const normalized = modelId?.trim();
-
-          return normalized?.startsWith(prefix)
-            ? [normalized.slice(prefix.length)]
-            : [];
-        }),
-      ),
-    ];
-
-    if (modelIdsForProvider.length === 0) {
-      continue;
-    }
-
-    const existingProvider = asRecord(merged[providerId]);
-    const existingOptions = asRecord(existingProvider.options);
-    const existingModels = asRecord(existingProvider.models);
-    const directApiKey = provider.apiKeyEnvVarName
-      ? runtimeEnv[provider.apiKeyEnvVarName]?.trim()
-      : undefined;
-    const baseURL =
-      runtimeEnv[provider.baseUrlEnvVarName]?.trim() ||
-      (provider.allowOpenAiEnvFallback
-        ? runtimeEnv.OPENAI_BASE_URL?.trim()
-        : '') ||
-      provider.fallbackBaseUrl;
-    const apiKeyOptions = directApiKey
-      ? { apiKey: `{env:${provider.apiKeyEnvVarName}}` }
-      : provider.keyless
-        ? { apiKey: 'ollama' }
-        : provider.allowOpenAiEnvFallback && runtimeEnv.OPENAI_API_KEY?.trim()
-          ? { apiKey: '{env:OPENAI_API_KEY}' }
-          : {};
-
-    merged = {
-      ...merged,
-      [providerId]: {
-        ...existingProvider,
-        npm: '@ai-sdk/openai-compatible',
-        name: provider.name,
-        options: {
-          ...existingOptions,
-          baseURL,
-          // OpenAI-compatible clients require an API key even though Ollama
-          // itself accepts unauthenticated requests.
-          ...apiKeyOptions,
-        },
-        models: {
-          ...existingModels,
-          ...Object.fromEntries(
-            modelIdsForProvider.map((modelId) => [
-              modelId,
-              {
-                name: modelId,
-                ...(visionModel === `${providerId}/${modelId}`
-                  ? {
-                      attachment: true,
-                      modalities: {
-                        input: ['text', 'image'],
-                        output: ['text'],
-                      },
-                    }
-                  : {}),
-                ...asRecord(existingModels[modelId]),
-              },
-            ]),
-          ),
-        },
-      },
-    };
-  }
-
-  return merged;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roomote",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "license": "FCL-1.0-ALv2",
   "packageManager": "pnpm@10.29.3",
   "engines": {

--- a/packages/cloud-agents/src/server/__tests__/opencode-runtime.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/opencode-runtime.test.ts
@@ -20,6 +20,8 @@ describe('buildOpenCodeCliEnv', () => {
     'R_MODEL_REASONING_EFFORT',
     'R_SMALL_MODEL_REASONING_EFFORT',
     'R_CHATGPT_FAST_MODE',
+    'LITELLM_BASE_URL',
+    'LITELLM_API_KEY',
     'GOOGLE_APPLICATION_CREDENTIALS',
     'MISTRAL_API_KEY',
     'BASH_ENV',
@@ -54,6 +56,49 @@ describe('buildOpenCodeCliEnv', () => {
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
       model: 'openrouter/openai/gpt-5.4',
       small_model: 'openrouter/openai/gpt-5.4',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
+    });
+  });
+
+  it('materializes LiteLLM provider config for restricted helper inference', () => {
+    const env = buildOpenCodeCliEnv({
+      R_MODEL: 'litellm/qwen3.6:35b-unsloth',
+      R_SMALL_MODEL: 'litellm/coding',
+      LITELLM_BASE_URL: 'https://litellm.example.com/v1',
+      LITELLM_API_KEY: 'secret',
+    });
+
+    expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
+      model: 'litellm/qwen3.6:35b-unsloth',
+      small_model: 'litellm/coding',
+      provider: {
+        litellm: {
+          npm: '@ai-sdk/openai-compatible',
+          name: 'LiteLLM',
+          options: {
+            baseURL: 'https://litellm.example.com/v1',
+            apiKey: '{env:LITELLM_API_KEY}',
+          },
+          models: {
+            'qwen3.6:35b-unsloth': { name: 'qwen3.6:35b-unsloth' },
+            coding: { name: 'coding' },
+          },
+        },
+      },
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
+    });
+  });
+
+  it('does not infer model ownership from LiteLLM endpoint availability', () => {
+    const env = buildOpenCodeCliEnv({
+      R_MODEL: 'qwen3.6:35b-unsloth',
+      LITELLM_BASE_URL: 'https://litellm.example.com/v1',
+      LITELLM_API_KEY: 'secret',
+    });
+
+    expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
+      model: 'qwen3.6:35b-unsloth',
+      small_model: 'qwen3.6:35b-unsloth',
       permission: NON_TASK_TOOL_PERMISSION_DENIALS,
     });
   });

--- a/packages/cloud-agents/src/server/opencode-runtime.ts
+++ b/packages/cloud-agents/src/server/opencode-runtime.ts
@@ -7,6 +7,7 @@ import {
   CHATGPT_FAST_MODE_ENV_VAR_NAME,
   DISABLED_MODEL_PROVIDER_ENV_VAR_NAMES,
   isTaskModelIdDisabled,
+  mergeOpenAiCompatibleProviderConfig,
   mergeOpenCodeModelReasoningOptions,
   mergeOpenCodeChatGptFastModeOptions,
   mergeOpenRouterVariantAliasModels,
@@ -86,9 +87,10 @@ function buildModelBackedOpenCodeConfigContent(
           smallModel,
         ])
       : providerReasoningConfig;
-  const providerConfig = mergeOpenRouterVariantAliasModels(
-    providerModelConfig,
-    variantAliases,
+  const providerConfig = mergeOpenAiCompatibleProviderConfig(
+    mergeOpenRouterVariantAliasModels(providerModelConfig, variantAliases),
+    env,
+    [model, smallModel],
   );
 
   return JSON.stringify({

--- a/packages/types/src/__tests__/opencode-provider-config.test.ts
+++ b/packages/types/src/__tests__/opencode-provider-config.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { mergeOpenAiCompatibleProviderConfig } from '../opencode-provider-config';
+
+describe('mergeOpenAiCompatibleProviderConfig', () => {
+  it('materializes LiteLLM provider metadata for selected models', () => {
+    expect(
+      mergeOpenAiCompatibleProviderConfig(
+        {},
+        {
+          LITELLM_BASE_URL: 'https://litellm.example.com/v1',
+          LITELLM_API_KEY: 'secret',
+        },
+        ['litellm/qwen3.6:35b-unsloth', 'litellm/coding'],
+      ),
+    ).toEqual({
+      litellm: {
+        npm: '@ai-sdk/openai-compatible',
+        name: 'LiteLLM',
+        options: {
+          baseURL: 'https://litellm.example.com/v1',
+          apiKey: '{env:LITELLM_API_KEY}',
+        },
+        models: {
+          'qwen3.6:35b-unsloth': { name: 'qwen3.6:35b-unsloth' },
+          coding: { name: 'coding' },
+        },
+      },
+    });
+  });
+
+  it('preserves existing model options for named OpenAI-compatible providers', () => {
+    expect(
+      mergeOpenAiCompatibleProviderConfig(
+        {
+          'openai-compatible-company-proxy': {
+            models: { 'gpt-4o': { options: { temperature: 0 } } },
+          },
+        },
+        {
+          OPENAI_COMPATIBLE_COMPANY_PROXY_BASE_URL:
+            'https://proxy.example.com/v1',
+          OPENAI_COMPATIBLE_COMPANY_PROXY_API_KEY: 'secret',
+          OPENAI_COMPATIBLE_COMPANY_PROXY_LABEL: 'Corp Proxy',
+        },
+        ['openai-compatible-company-proxy/gpt-4o'],
+      ),
+    ).toMatchObject({
+      'openai-compatible-company-proxy': {
+        npm: '@ai-sdk/openai-compatible',
+        name: 'OpenAI-compatible (Corp Proxy)',
+        options: {
+          baseURL: 'https://proxy.example.com/v1',
+          apiKey: '{env:OPENAI_COMPATIBLE_COMPANY_PROXY_API_KEY}',
+        },
+        models: {
+          'gpt-4o': { name: 'gpt-4o', options: { temperature: 0 } },
+        },
+      },
+    });
+  });
+});

--- a/packages/types/src/__tests__/opencode-reasoning.test.ts
+++ b/packages/types/src/__tests__/opencode-reasoning.test.ts
@@ -19,6 +19,12 @@ describe('buildOpenCodeModelReasoningOptions', () => {
     ).toEqual({ reasoning: { effort: 'xhigh' } });
   });
 
+  it('passes max through for OpenAI-style OpenRouter models', () => {
+    expect(
+      buildOpenCodeModelReasoningOptions('openrouter/openai/gpt-5.4', 'max'),
+    ).toEqual({ reasoning: { effort: 'max' } });
+  });
+
   it('clamps xhigh to high for non-OpenAI OpenRouter models', () => {
     expect(
       buildOpenCodeModelReasoningOptions(
@@ -73,6 +79,12 @@ describe('buildOpenCodeModelReasoningOptions', () => {
       thinking: { type: 'adaptive', display: 'summarized' },
       effort: 'medium',
     });
+    expect(
+      buildOpenCodeModelReasoningOptions('anthropic/claude-opus-4-7', 'max'),
+    ).toEqual({
+      thinking: { type: 'adaptive', display: 'summarized' },
+      effort: 'max',
+    });
   });
 
   it('clamps xhigh to high for the Anthropic 4.6 family', () => {
@@ -87,6 +99,12 @@ describe('buildOpenCodeModelReasoningOptions', () => {
     ).toEqual({
       thinking: { type: 'adaptive' },
       effort: 'high',
+    });
+    expect(
+      buildOpenCodeModelReasoningOptions('anthropic/claude-sonnet-4-6', 'max'),
+    ).toEqual({
+      thinking: { type: 'adaptive' },
+      effort: 'max',
     });
   });
 
@@ -141,6 +159,9 @@ describe('buildOpenCodeModelReasoningOptions', () => {
     expect(
       buildOpenCodeModelReasoningOptions('vercel/openai/gpt-5.4', 'medium'),
     ).toEqual({ reasoningEffort: 'medium' });
+    expect(buildOpenCodeModelReasoningOptions('openai/gpt-5.4', 'max')).toEqual(
+      { reasoningEffort: 'max' },
+    );
   });
 
   it('clamps LiteLLM xhigh reasoning to high', () => {

--- a/packages/types/src/__tests__/task-runs.test.ts
+++ b/packages/types/src/__tests__/task-runs.test.ts
@@ -614,6 +614,24 @@ describe('taskSpecSchema', () => {
     expect(parsed.payload.reasoningEffort).toBe('xhigh');
   });
 
+  it('parses max reasoningEffort overrides on task payloads', () => {
+    const parsed = taskSpecSchema.parse({
+      userId: 'user-1',
+      type: TaskPayloadKind.StandardTask,
+      payload: {
+        repo: 'owner/repo',
+        description: 'Investigate this flow',
+        reasoningEffort: 'max',
+      },
+    });
+
+    if (parsed.type !== TaskPayloadKind.StandardTask) {
+      throw new Error('Expected StandardTask payload');
+    }
+
+    expect(parsed.payload.reasoningEffort).toBe('max');
+  });
+
   it('parses OpenCode harness model overrides on task payloads', () => {
     const parsed = taskSpecSchema.parse({
       userId: 'user-1',
@@ -1088,7 +1106,7 @@ describe('taskSpecSchema', () => {
       payload: {
         repo: 'owner/repo',
         description: 'Fix this',
-        reasoningEffort: 'max',
+        reasoningEffort: 'turbo',
       },
     });
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -42,6 +42,7 @@ export * from './model-provider-config';
 export * from './openai-compatible-providers';
 export * from './recommended-task-models';
 export * from './opencode-openrouter-variants';
+export * from './opencode-provider-config';
 export * from './opencode-reasoning';
 export * from './mcp-oauth';
 export * from './mcp-response-parsing';

--- a/packages/types/src/model-provider-config.test.ts
+++ b/packages/types/src/model-provider-config.test.ts
@@ -556,7 +556,7 @@ describe('SETUP_MODEL_PROVIDER_CATALOG', () => {
       id: 'chatgpt',
       label: 'ChatGPT (subscription)',
       authKind: 'oauth',
-      defaultRoomoteModel: 'openai/gpt-5.6-terra',
+      defaultRoomoteModel: 'openai/gpt-5.6-sol',
     });
     expect(chatgptProvider?.envVarName).toBeUndefined();
   });
@@ -761,6 +761,44 @@ describe('SETUP_MODEL_PROVIDER_CATALOG', () => {
 });
 
 describe('buildRecommendedDeploymentModelConfig', () => {
+  it.each(['openai', 'chatgpt'] as const)(
+    'builds the %s presets with role-specific reasoning',
+    (providerId) => {
+      const provider = getSetupModelProvider(providerId);
+
+      expect(buildRecommendedDeploymentModelConfig(provider)).toEqual({
+        roomoteModel: 'openai/gpt-5.6-sol',
+        roomoteSmallModel: 'openai/gpt-5.6-luna',
+        roomoteVisionModel: 'openai/gpt-5.6-sol',
+        roomoteCodeReviewModel: 'openai/gpt-5.6-terra',
+        roomoteExploreModel: 'openai/gpt-5.6-luna',
+        roomotePlanningModel: 'openai/gpt-5.6-sol',
+        roomoteModelReasoningEffort: 'medium',
+        roomoteSmallModelReasoningEffort: 'low',
+        roomoteVisionModelReasoningEffort: 'low',
+        roomoteCodeReviewModelReasoningEffort: 'high',
+        roomoteExploreModelReasoningEffort: 'low',
+        roomotePlanningModelReasoningEffort: 'xhigh',
+      });
+      expect(
+        buildRecommendedDeploymentModelConfig(provider, 'luna-max'),
+      ).toEqual({
+        roomoteModel: 'openai/gpt-5.6-luna',
+        roomoteSmallModel: 'openai/gpt-5.6-luna',
+        roomoteVisionModel: 'openai/gpt-5.6-sol',
+        roomoteCodeReviewModel: 'openai/gpt-5.6-terra',
+        roomoteExploreModel: 'openai/gpt-5.6-luna',
+        roomotePlanningModel: 'openai/gpt-5.6-sol',
+        roomoteModelReasoningEffort: 'max',
+        roomoteSmallModelReasoningEffort: 'low',
+        roomoteVisionModelReasoningEffort: 'low',
+        roomoteCodeReviewModelReasoningEffort: 'high',
+        roomoteExploreModelReasoningEffort: 'low',
+        roomotePlanningModelReasoningEffort: 'xhigh',
+      });
+    },
+  );
+
   it('maps the provider default to coding and recommended models to their roles', () => {
     expect(
       buildRecommendedDeploymentModelConfig(getSetupModelProvider('anthropic')),

--- a/packages/types/src/model-provider-config.test.ts
+++ b/packages/types/src/model-provider-config.test.ts
@@ -1055,11 +1055,13 @@ describe('reasoning effort labels', () => {
       { value: 'medium', label: 'Medium' },
       { value: 'high', label: 'High' },
       { value: 'xhigh', label: 'Extra high' },
+      { value: 'max', label: 'Max' },
     ]);
   });
 
   it('returns the shared label for a reasoning effort', () => {
     expect(getReasoningEffortLabel('high')).toBe('High');
+    expect(getReasoningEffortLabel('max')).toBe('Max');
   });
 });
 

--- a/packages/types/src/model-provider-config.ts
+++ b/packages/types/src/model-provider-config.ts
@@ -189,6 +189,70 @@ export type SetupModelProviderDescriptor = {
 export const DEFAULT_SETUP_MODEL_PROVIDER_ID: SetupModelProviderId =
   'openrouter';
 
+const OPENAI_RECOMMENDED_MODEL_PRESETS = [
+  {
+    id: 'default',
+    label: 'Recommended',
+    default: true,
+    roles: {
+      coding: {
+        modelId: 'openai/gpt-5.6-sol',
+        reasoningEffort: 'medium',
+      },
+      helper: {
+        modelId: 'openai/gpt-5.6-luna',
+        reasoningEffort: 'low',
+      },
+      vision: {
+        modelId: 'openai/gpt-5.6-sol',
+        reasoningEffort: 'low',
+      },
+      codeReview: {
+        modelId: 'openai/gpt-5.6-terra',
+        reasoningEffort: 'high',
+      },
+      explore: {
+        modelId: 'openai/gpt-5.6-luna',
+        reasoningEffort: 'low',
+      },
+      planning: {
+        modelId: 'openai/gpt-5.6-sol',
+        reasoningEffort: 'xhigh',
+      },
+    },
+  },
+  {
+    id: 'luna-max',
+    label: 'Luna Max',
+    roles: {
+      coding: {
+        modelId: 'openai/gpt-5.6-luna',
+        reasoningEffort: 'max',
+      },
+      helper: {
+        modelId: 'openai/gpt-5.6-luna',
+        reasoningEffort: 'low',
+      },
+      vision: {
+        modelId: 'openai/gpt-5.6-sol',
+        reasoningEffort: 'low',
+      },
+      codeReview: {
+        modelId: 'openai/gpt-5.6-terra',
+        reasoningEffort: 'high',
+      },
+      explore: {
+        modelId: 'openai/gpt-5.6-luna',
+        reasoningEffort: 'low',
+      },
+      planning: {
+        modelId: 'openai/gpt-5.6-sol',
+        reasoningEffort: 'xhigh',
+      },
+    },
+  },
+] as const satisfies readonly RecommendedModelPreset[];
+
 export const SETUP_MODEL_PROVIDER_CATALOG = [
   {
     id: 'openrouter',
@@ -341,19 +405,14 @@ export const SETUP_MODEL_PROVIDER_CATALOG = [
     id: 'openai',
     label: 'OpenAI',
     envVarName: 'OPENAI_API_KEY',
-    defaultRoomoteModel: 'openai/gpt-5.6-terra',
+    defaultRoomoteModel: 'openai/gpt-5.6-sol',
     authKind: 'api-key',
     suggestedTaskModels: mapRecommendedTaskModels({
       'gpt-5-6-sol': 'openai/gpt-5.6-sol',
       'gpt-5-6-terra': 'openai/gpt-5.6-terra',
       'gpt-5-6-luna': 'openai/gpt-5.6-luna',
     }),
-    recommendedRoleModels: {
-      helper: 'openai/gpt-5.6-luna',
-      codeReview: 'openai/gpt-5.6-sol',
-      explore: 'openai/gpt-5.6-luna',
-      planning: 'openai/gpt-5.6-sol',
-    },
+    recommendedPresets: OPENAI_RECOMMENDED_MODEL_PRESETS,
   },
   {
     id: 'azure',
@@ -762,19 +821,14 @@ export const SETUP_MODEL_PROVIDER_CATALOG = [
     id: CHATGPT_SUBSCRIPTION_PROVIDER_ID,
     label: 'ChatGPT (subscription)',
     envVarName: undefined,
-    defaultRoomoteModel: 'openai/gpt-5.6-terra',
+    defaultRoomoteModel: 'openai/gpt-5.6-sol',
     authKind: 'oauth',
     suggestedTaskModels: mapRecommendedTaskModels({
       'gpt-5-6-sol': 'openai/gpt-5.6-sol',
       'gpt-5-6-terra': 'openai/gpt-5.6-terra',
       'gpt-5-6-luna': 'openai/gpt-5.6-luna',
     }),
-    recommendedRoleModels: {
-      helper: 'openai/gpt-5.6-luna',
-      codeReview: 'openai/gpt-5.6-sol',
-      explore: 'openai/gpt-5.6-luna',
-      planning: 'openai/gpt-5.6-sol',
-    },
+    recommendedPresets: OPENAI_RECOMMENDED_MODEL_PRESETS,
   },
   {
     id: XAI_SUBSCRIPTION_PROVIDER_ID,

--- a/packages/types/src/model-provider-config.ts
+++ b/packages/types/src/model-provider-config.ts
@@ -903,6 +903,7 @@ export const REASONING_EFFORT_LABELS = {
   medium: 'Medium',
   high: 'High',
   xhigh: 'Extra high',
+  max: 'Max',
 } satisfies Record<ReasoningEffort, string>;
 
 export const REASONING_EFFORT_OPTIONS = REASONING_EFFORT_VALUES.map(

--- a/packages/types/src/opencode-provider-config.ts
+++ b/packages/types/src/opencode-provider-config.ts
@@ -1,0 +1,240 @@
+import {
+  buildOpenAiCompatibleProviderInstance,
+  getOpenAiCompatibleProviderInstance,
+  isOpenAiCompatibleProviderId,
+  listOpenAiCompatibleProviderInstancesFromEnvNames,
+  OPENAI_COMPATIBLE_PROVIDER_ID,
+  type OpenAiCompatibleProviderInstance,
+} from './openai-compatible-providers';
+
+/** Fallback direct-mode base URL for default and named OpenAI-compatible ids. */
+const OPENAI_COMPATIBLE_DEFAULT_FALLBACK_BASE_URL = 'http://127.0.0.1:4000/v1';
+
+const DEFAULT_OPENAI_COMPATIBLE_INSTANCE =
+  buildOpenAiCompatibleProviderInstance(null);
+
+const STATIC_OPENAI_COMPATIBLE_PROVIDER_CONFIGS = {
+  [OPENAI_COMPATIBLE_PROVIDER_ID]: {
+    name: DEFAULT_OPENAI_COMPATIBLE_INSTANCE.label,
+    baseUrlEnvVarName: DEFAULT_OPENAI_COMPATIBLE_INSTANCE.baseUrlEnvVarName,
+    fallbackBaseUrl: OPENAI_COMPATIBLE_DEFAULT_FALLBACK_BASE_URL,
+    apiKeyEnvVarName: DEFAULT_OPENAI_COMPATIBLE_INSTANCE.apiKeyEnvVarName as
+      | string
+      | undefined,
+    keyless: false,
+    // Arbitrary endpoints must not inherit OPENAI_* credentials.
+    allowOpenAiEnvFallback: false,
+  },
+  ollama: {
+    name: 'Ollama',
+    baseUrlEnvVarName: 'OLLAMA_BASE_URL',
+    fallbackBaseUrl: 'http://127.0.0.1:11434/v1',
+    apiKeyEnvVarName: undefined as string | undefined,
+    keyless: true,
+    allowOpenAiEnvFallback: false,
+  },
+  vllm: {
+    name: 'vLLM',
+    baseUrlEnvVarName: 'VLLM_BASE_URL',
+    fallbackBaseUrl: 'http://127.0.0.1:8000/v1',
+    apiKeyEnvVarName: 'VLLM_API_KEY' as string | undefined,
+    keyless: false,
+    allowOpenAiEnvFallback: true,
+  },
+  litellm: {
+    name: 'LiteLLM',
+    baseUrlEnvVarName: 'LITELLM_BASE_URL',
+    fallbackBaseUrl: 'http://127.0.0.1:4000/v1',
+    apiKeyEnvVarName: 'LITELLM_API_KEY' as string | undefined,
+    keyless: false,
+    allowOpenAiEnvFallback: true,
+  },
+} as const;
+
+type StaticOpenAiCompatibleProviderId =
+  keyof typeof STATIC_OPENAI_COMPATIBLE_PROVIDER_CONFIGS;
+
+type OpenAiCompatibleProviderRuntimeConfig = {
+  name: string;
+  baseUrlEnvVarName: string;
+  fallbackBaseUrl: string;
+  apiKeyEnvVarName: string | undefined;
+  keyless: boolean;
+  allowOpenAiEnvFallback: boolean;
+};
+
+type RuntimeEnv = Readonly<Record<string, string | undefined>>;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? { ...(value as Record<string, unknown>) }
+    : {};
+}
+
+function toNamedOpenAiCompatibleRuntimeConfig(
+  instance: OpenAiCompatibleProviderInstance,
+): OpenAiCompatibleProviderRuntimeConfig {
+  return {
+    name: instance.label,
+    baseUrlEnvVarName: instance.baseUrlEnvVarName,
+    fallbackBaseUrl: OPENAI_COMPATIBLE_DEFAULT_FALLBACK_BASE_URL,
+    apiKeyEnvVarName: instance.apiKeyEnvVarName,
+    keyless: false,
+    allowOpenAiEnvFallback: false,
+  };
+}
+
+function resolveNamedOpenAiCompatibleInstance(
+  providerId: string,
+  runtimeEnv: RuntimeEnv,
+): OpenAiCompatibleProviderInstance | null {
+  const instance = getOpenAiCompatibleProviderInstance(providerId);
+  if (!instance?.slug) {
+    return null;
+  }
+
+  if (!instance.labelEnvVarName) {
+    return instance;
+  }
+
+  const label = runtimeEnv[instance.labelEnvVarName]?.trim();
+  if (!label) {
+    return instance;
+  }
+
+  return getOpenAiCompatibleProviderInstance(providerId, { label }) ?? instance;
+}
+
+export function getOpenAiCompatibleRuntimeConfigs(
+  modelIds: Array<string | undefined>,
+  runtimeEnv: RuntimeEnv,
+): Map<string, OpenAiCompatibleProviderRuntimeConfig> {
+  const configs = new Map<string, OpenAiCompatibleProviderRuntimeConfig>();
+
+  for (const [providerId, provider] of Object.entries(
+    STATIC_OPENAI_COMPATIBLE_PROVIDER_CONFIGS,
+  ) as Array<
+    [StaticOpenAiCompatibleProviderId, OpenAiCompatibleProviderRuntimeConfig]
+  >) {
+    configs.set(providerId, provider);
+  }
+
+  const candidateProviderIds = new Set<string>();
+
+  for (const modelId of modelIds) {
+    const providerId = modelId?.trim().split('/')[0];
+    if (providerId && isOpenAiCompatibleProviderId(providerId)) {
+      candidateProviderIds.add(providerId);
+    }
+  }
+
+  for (const instance of listOpenAiCompatibleProviderInstancesFromEnvNames(
+    Object.keys(runtimeEnv),
+  )) {
+    candidateProviderIds.add(instance.id);
+  }
+
+  for (const providerId of candidateProviderIds) {
+    if (configs.has(providerId)) {
+      continue;
+    }
+
+    const instance = resolveNamedOpenAiCompatibleInstance(
+      providerId,
+      runtimeEnv,
+    );
+    if (instance) {
+      configs.set(providerId, toNamedOpenAiCompatibleRuntimeConfig(instance));
+    }
+  }
+
+  return configs;
+}
+
+export function mergeOpenAiCompatibleProviderConfig(
+  providerConfig: Record<string, unknown>,
+  runtimeEnv: RuntimeEnv,
+  modelIds: Array<string | undefined>,
+  visionModel?: string,
+): Record<string, unknown> {
+  let merged = providerConfig;
+  const runtimeConfigs = getOpenAiCompatibleRuntimeConfigs(
+    modelIds,
+    runtimeEnv,
+  );
+
+  for (const [providerId, provider] of runtimeConfigs) {
+    const prefix = `${providerId}/`;
+    const modelIdsForProvider = [
+      ...new Set(
+        modelIds.flatMap((modelId) => {
+          const normalized = modelId?.trim();
+          return normalized?.startsWith(prefix)
+            ? [normalized.slice(prefix.length)]
+            : [];
+        }),
+      ),
+    ];
+
+    if (modelIdsForProvider.length === 0) {
+      continue;
+    }
+
+    const existingProvider = asRecord(merged[providerId]);
+    const existingOptions = asRecord(existingProvider.options);
+    const existingModels = asRecord(existingProvider.models);
+    const directApiKey = provider.apiKeyEnvVarName
+      ? runtimeEnv[provider.apiKeyEnvVarName]?.trim()
+      : undefined;
+    const baseURL =
+      runtimeEnv[provider.baseUrlEnvVarName]?.trim() ||
+      (provider.allowOpenAiEnvFallback
+        ? runtimeEnv.OPENAI_BASE_URL?.trim()
+        : '') ||
+      provider.fallbackBaseUrl;
+    const apiKeyOptions = directApiKey
+      ? { apiKey: `{env:${provider.apiKeyEnvVarName}}` }
+      : provider.keyless
+        ? { apiKey: 'ollama' }
+        : provider.allowOpenAiEnvFallback && runtimeEnv.OPENAI_API_KEY?.trim()
+          ? { apiKey: '{env:OPENAI_API_KEY}' }
+          : {};
+
+    merged = {
+      ...merged,
+      [providerId]: {
+        ...existingProvider,
+        npm: '@ai-sdk/openai-compatible',
+        name: provider.name,
+        options: {
+          ...existingOptions,
+          baseURL,
+          ...apiKeyOptions,
+        },
+        models: {
+          ...existingModels,
+          ...Object.fromEntries(
+            modelIdsForProvider.map((modelId) => [
+              modelId,
+              {
+                name: modelId,
+                ...(visionModel === `${providerId}/${modelId}`
+                  ? {
+                      attachment: true,
+                      modalities: {
+                        input: ['text', 'image'],
+                        output: ['text'],
+                      },
+                    }
+                  : {}),
+                ...asRecord(existingModels[modelId]),
+              },
+            ]),
+          ),
+        },
+      },
+    };
+  }
+
+  return merged;
+}

--- a/packages/types/src/opencode-reasoning.ts
+++ b/packages/types/src/opencode-reasoning.ts
@@ -11,6 +11,7 @@ const ANTHROPIC_THINKING_BUDGET_TOKENS: Record<ReasoningEffort, number> = {
   medium: 8_000,
   high: 16_000,
   xhigh: 31_999,
+  max: 31_999,
 };
 
 /**

--- a/packages/types/src/task-runs.ts
+++ b/packages/types/src/task-runs.ts
@@ -285,6 +285,7 @@ export const REASONING_EFFORT_VALUES = [
   'medium',
   'high',
   'xhigh',
+  'max',
 ] as const;
 
 export type ReasoningEffort = (typeof REASONING_EFFORT_VALUES)[number];


### PR DESCRIPTION
## Promote v0.29.0

Candidate refreshed to `d40fff12680b18bdf54919597e2416c57c2a8f5b` from `develop`.

- Merge this PR with a **merge commit** (do not squash or rebase).
- If multiple promote PRs are open, merge them in version order (oldest first).
- Merging publishes a GitHub Release for `v0.29.0` and triggers the existing GHCR `v*` image publish (`latest` channel).
- The `release/v0.29.0` branch can be deleted after this PR merges.

### Changelog

## 0.29.0 (2026-08-01)

This release expands model reasoning and preset options while improving LiteLLM routing, invite previews, and environment guidance.

### Highlights

- Choose Max reasoning for supported OpenAI and Anthropic models, and use refreshed OpenAI and ChatGPT presets with specialized defaults and a Luna Max option.
- Route GitHub mentions and other helper calls reliably through configured LiteLLM providers.
- Share invite links with clear, privacy-safe previews and keep admin-only environment guidance hidden from members.

### Minor changes

- Refresh the recommended OpenAI and ChatGPT subscription model presets with Sol defaults for coding and vision, specialized supporting models, and a Luna Max option for higher-effort coding.
- Let administrators select and persist Max reasoning for supported OpenAI and Anthropic models while preserving compatibility with existing reasoning levels.

### Patch changes

- Give shared invite links a clear Roomote Invitation preview without exposing invite tokens, roles, or deployment details.
- Keep GitHub mention routing and other non-task helper calls working with LiteLLM-backed models by registering their configured endpoint, adapter, credentials, and model catalog. Thanks to @tomny-dev for reporting [#963](https://github.com/RooCodeInc/Roomote/issues/963).
- Hide the homepage environment-creation warning and admin-only action from members who cannot manage environments.
