### PR TITLE
Remove the retired Roomote-Ops fleet dispatch

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -456,31 +456,11 @@ jobs:
 
           echo "Announced GitHub Release $VERSION in Discord"
 
-  notify-ops:
-    name: Notify ops repository
-    runs-on: ubuntu-latest
-    needs: publish
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.ROOMOTE_OPS_REPO != '' }}
-    permissions:
-      contents: read
-    steps:
-      - name: Send repository dispatch
-        env:
-          GH_TOKEN: ${{ secrets.ROOMOTE_OPS_DISPATCH_TOKEN }}
-          OPS_REPO: ${{ vars.ROOMOTE_OPS_REPO }}
-        run: |
-          set -euo pipefail
-          : "${GH_TOKEN:?ROOMOTE_OPS_DISPATCH_TOKEN is required}"
-          event_type=roomote-main-build
-          image_tag="main-${GITHUB_SHA:0:8}"
-          gh api "repos/${OPS_REPO}/dispatches" \
-            -f "event_type=${event_type}" \
-            -f "client_payload[image_tag]=${image_tag}" \
-            -f "client_payload[sha]=${GITHUB_SHA}" \
-            -f "client_payload[ref]=${GITHUB_REF}"
-
-  # Keep staging Cloud delivery independent from the existing Roomote-Ops
-  # production path. This job only follows successful develop image publishes.
+  # This job only follows successful develop image publishes. (The old
+  # notify-ops job that dispatched hand-built fleet deploys to Roomote-Ops
+  # was removed 2026-08-01 with that repo's retirement: every tenant is
+  # Cloud-managed, and the dispatch had been redeploying quiesced legacy
+  # projects on every main build.)
   notify-staging-cloud:
     name: Notify staging Cloud
     runs-on: ubuntu-latest


### PR DESCRIPTION
Companion cleanup to archiving Roomote-Ops (2026-08-01).

Every production tenant is Cloud-managed as of the migrations completing, and this dispatch had a live failure mode: it deployed to the `railway-*` environments on every main build, **resurrecting the quiesced legacy projects' write paths** — stale twins of migrated tenants consuming Telegram polls and queued jobs against frozen databases. The kill switch (deleting the `ROOMOTE_OPS_REPO` variable) is already thrown and the seven deploy environments are deleted; this PR removes the dead `notify-ops` job and updates the neighbouring comment.

Cloud rollouts are untouched — staging/production image delivery goes through the Roomote-Cloud dispatches, which share the `roomote-main-build` event name but different repos/secrets.

Also done outside this PR: the orphaned `ROOMOTE_OPS_DISPATCH_TOKEN` repo secret is being removed; if the underlying PAT was single-purpose it can be revoked in GitHub settings.