### PR TITLE
[Fix] Isolate Slack install-after-auth route tests from developer .env.local

### DIFF
--- a/apps/web/src/app/api/slack/install-after-auth/__tests__/route.test.ts
+++ b/apps/web/src/app/api/slack/install-after-auth/__tests__/route.test.ts
@@ -4,6 +4,21 @@ import { createServerCaller } from '@/trpc/server';
 
 import { GET } from '../route';
 
+// getCallbackHost rewrites internal request origins (localhost) to the
+// configured public app URL, which it reads through the dotenvx-backed Env
+// proxy. The proxy resolves values from the repo-root .env.local file, so a
+// developer-local R_APP_URL/R_PUBLIC_URL (e.g. an ngrok host) would leak into
+// redirect assertions even with process.env stubbed. Replace Env with a
+// test-owned object so redirects always resolve against localhost.
+const { envState } = vi.hoisted(() => ({
+  envState: {} as { R_APP_URL: string; R_PUBLIC_URL?: string },
+}));
+
+vi.mock('@/lib/server/env', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/server/env')>()),
+  Env: envState,
+}));
+
 vi.mock('@/trpc/server', () => ({
   createServerCaller: vi.fn(),
 }));
@@ -13,36 +28,16 @@ const mockInstallation = vi.fn();
 const mockConnectApp = vi.fn();
 
 describe('GET /api/slack/install-after-auth', () => {
-  // getCallbackHost rewrites internal request origins (localhost) to the
-  // configured public app URL, so machine-level R_APP_URL/R_PUBLIC_URL (e.g. an
-  // ngrok host in the shell) leak into redirect assertions. Pin them per test.
-  const originalAppUrl = process.env.R_APP_URL;
-  const originalPublicUrl = process.env.R_PUBLIC_URL;
-
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.R_APP_URL = 'http://localhost:13000';
-    delete process.env.R_PUBLIC_URL;
+    envState.R_APP_URL = 'http://localhost:13000';
+    delete envState.R_PUBLIC_URL;
     mockCreateServerCaller.mockResolvedValue({
       slack: {
         installation: mockInstallation,
         connectApp: mockConnectApp,
       },
     } as never);
-  });
-
-  afterEach(() => {
-    if (originalAppUrl === undefined) {
-      delete process.env.R_APP_URL;
-    } else {
-      process.env.R_APP_URL = originalAppUrl;
-    }
-
-    if (originalPublicUrl === undefined) {
-      delete process.env.R_PUBLIC_URL;
-    } else {
-      process.env.R_PUBLIC_URL = originalPublicUrl;
-    }
   });
 
   it('redirects to the requested path when Slack is already installed', async () => {


### PR DESCRIPTION
## Problem

`apps/web/src/app/api/slack/install-after-auth/__tests__/route.test.ts` fails locally for any developer whose repo-root `.env.local` sets `R_PUBLIC_URL` (e.g. an ngrok URL). The test stubbed `process.env.R_APP_URL`/`R_PUBLIC_URL` (isolation added in #758), but the route resolves the public URL via `getCallbackHost` → the dotenvx-backed web `Env` proxy, which reads the repo-root `.env.local` file directly — so the file value bypasses the `process.env` stubs. Symptom: `expected http://localhost:13000/... but received https://<ngrok-domain>/...` in the two redirect tests.

## Fix

Replace the `process.env` stub/restore dance with the existing repo pattern (`vi.hoisted` env state + `vi.mock('@/lib/server/env')`, as in `trpc/commands/linear/index.test.ts`): spread the real module and override `Env` with a test-owned object, so dotenvx file resolution is never consulted. `getPublicAppUrl` stays unmocked so the real `R_PUBLIC_URL ?? R_APP_URL` preference logic remains under test.

## Verification

`pnpm exec dotenvx run -f .env.test -- pnpm --filter web exec vitest run src/app/api/slack/install-after-auth/__tests__/route.test.ts`

- Reproduced the failure first with a repo-root `.env.local` setting `R_PUBLIC_URL=https://example-dev.ngrok.app` (2/3 failed)
- After the fix: 3/3 pass both with and without that `.env.local` present
- `pnpm lint` and `pnpm --filter web check-types` clean