### PR TITLE
[Fix] Use the built-in BuildKit frontend for the app image

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -1,4 +1,8 @@
-# syntax=docker/dockerfile:1.7
+# No `# syntax=` directive on purpose: this Dockerfile only needs features the
+# BuildKit built-in frontend already provides (secret mounts, multi-stage
+# targets), and resolving an external docker/dockerfile frontend image has
+# crashed CI builders ("frontend grpc server closed unexpectedly") when the
+# cached frontend image goes bad.
 #
 # Shared application image for the Roomote control plane.
 #


### PR DESCRIPTION
## What changed

Removed the `# syntax=docker/dockerfile:1.7` directive from the app Dockerfile, with a comment explaining why it stays off.

## Why this change was made

The amd64 app image builds started failing repo-wide with `ERROR: failed to solve: frontend grpc server closed unexpectedly` — the crash happens while BuildKit launches the external `docker/dockerfile:1.7` frontend image, before any instruction in the Dockerfile is read. arm64 builds of the same commits pass, pointing at a bad cached frontend image on the persistent amd64 builder rather than anything in the repo.

The Dockerfile does not need the external frontend: its only non-basic feature is `--mount=type=secret`, which the BuildKit built-in frontend has supported for years. Dropping the directive removes the crashing component entirely instead of depending on builder cache health.

## Impact

amd64 and arm64 app image builds parse with the built-in frontend and no longer pull or launch an external frontend image, removing this failure mode from CI and making builds slightly faster to start. No Dockerfile instructions changed, so the produced image is identical.