### PR TITLE
Promote v0.30.1 to production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 This file tracks product releases for Roomote (single monorepo version). Automated release entries are prepended by `pnpm run version`.
 
+## 0.30.1 (2026-08-02)
+
+This patch improves custom automation scheduling and keeps Docker sandbox cleanup reliable in restricted deployments.
+
+### Highlights
+
+- Keep Docker sandbox cleanup working through restricted socket proxies so expired orphan task networks are removed without broadening proxy permissions.
+- Schedule custom automations reliably with discoverable built-in hourly, daily, and weekly presets.
+
+### Patch changes
+
+- Keep Docker sandbox cleanup working through restricted socket proxies so expired orphan task networks are removed without broadening proxy permissions.
+- Help agents schedule custom automations reliably by exposing every built-in hourly, daily, and weekly schedule preset through Roomote's management tools.
+
 ## 0.30.0 (2026-08-02)
 
 This release makes custom automations more flexible and reliable while improving task recovery and cross-channel follow-ups.

--- a/apps/controller/src/compute-providers/__tests__/docker-sandbox-security.test.ts
+++ b/apps/controller/src/compute-providers/__tests__/docker-sandbox-security.test.ts
@@ -196,7 +196,11 @@ describe('prepareDockerTaskNetwork', () => {
           },
         ]);
       }
-      if (args[0] === 'inspect' && args[1] === 'apiContainerId') {
+      if (
+        args[0] === 'container' &&
+        args[1] === 'inspect' &&
+        args[2] === 'apiContainerId'
+      ) {
         return JSON.stringify([
           {
             Config: {
@@ -375,7 +379,11 @@ describe('restoreDockerStandbyNetworking', () => {
           },
         ]);
       }
-      if (args[0] === 'inspect' && args[1] === 'apiContainerId') {
+      if (
+        args[0] === 'container' &&
+        args[1] === 'inspect' &&
+        args[2] === 'apiContainerId'
+      ) {
         return JSON.stringify([
           {
             Config: { Labels: { 'com.docker.compose.service': 'api' } },
@@ -390,7 +398,11 @@ describe('restoreDockerStandbyNetworking', () => {
           },
         ]);
       }
-      if (args[0] === 'inspect' && args[1] === 'previewContainerId') {
+      if (
+        args[0] === 'container' &&
+        args[1] === 'inspect' &&
+        args[2] === 'previewContainerId'
+      ) {
         return JSON.stringify([
           {
             Config: {
@@ -450,6 +462,54 @@ describe('restoreDockerStandbyNetworking', () => {
 });
 
 describe('cleanupStaleDockerSandboxes', () => {
+  it('uses container-specific inspection when a stale worker no longer exists', async () => {
+    const taskNetwork = getDockerTaskNetworkName(27);
+    const containerName = 'roomote-worker-27';
+    const nowMs = 20 * 60 * 1_000;
+    const createdAtMs = 1_000;
+    const runDocker = vi.fn<DockerCommand>(async (args) => {
+      if (args[0] === 'network' && args[1] === 'ls') {
+        return `${taskNetwork}\n`;
+      }
+      if (
+        args[0] === 'network' &&
+        args[1] === 'inspect' &&
+        args[2] === taskNetwork
+      ) {
+        return JSON.stringify([
+          {
+            Labels: {
+              'dev.roomote.sandbox.container': containerName,
+              'dev.roomote.sandbox.managed': 'true',
+              'dev.roomote.sandbox.auto-remove': 'true',
+              'dev.roomote.sandbox.created-at-ms': String(createdAtMs),
+            },
+          },
+        ]);
+      }
+      if (
+        args[0] === 'container' &&
+        args[1] === 'inspect' &&
+        args[2] === containerName
+      ) {
+        throw new Error(`No such container: ${containerName}`);
+      }
+      return '';
+    });
+
+    await cleanupStaleDockerSandboxes({ nowMs }, runDocker);
+
+    expect(runDocker).toHaveBeenCalledWith([
+      'container',
+      'inspect',
+      containerName,
+    ]);
+    expect(runDocker).not.toHaveBeenCalledWith(['inspect', containerName]);
+    expect(runDocker).toHaveBeenCalledWith(['network', 'rm', taskNetwork], {
+      allowFailure: true,
+    });
+  });
+
   it('removes an old orphan network after disconnecting trusted peers', async () => {
     const taskNetwork = getDockerTaskNetworkName(92);
     const runDocker = vi.fn<DockerCommand>(async (args) => {
@@ -506,7 +566,11 @@ describe('cleanupStaleDockerSandboxes', () => {
       if (args[0] === 'network' && args[1] === 'inspect') {
         return networkInspect;
       }
-      if (args[0] === 'inspect' && args[1] === 'roomote-worker-93') {
+      if (
+        args[0] === 'container' &&
+        args[1] === 'inspect' &&
+        args[2] === 'roomote-worker-93'
+      ) {
         return JSON.stringify([{ State: { Running: false } }]);
       }
       return '';
@@ -514,6 +578,11 @@ describe('cleanupStaleDockerSandboxes', () => {
 
     await cleanupStaleDockerSandboxes({ nowMs: 20_000 }, runDocker);
 
+    expect(runDocker).toHaveBeenCalledWith([
+      'container',
+      'inspect',
+      'roomote-worker-93',
+    ]);
     expect(runDocker).toHaveBeenCalledWith(['rm', '-f', 'roomote-worker-93'], {
       allowFailure: true,
     });
@@ -562,10 +631,18 @@ describe('cleanupStaleDockerSandboxes', () => {
           },
         ]);
       }
-      if (args[0] === 'inspect' && args[1] === 'roomote-worker-96') {
+      if (
+        args[0] === 'container' &&
+        args[1] === 'inspect' &&
+        args[2] === 'roomote-worker-96'
+      ) {
         return JSON.stringify([{ State: { Running: true } }]);
       }
-      if (args[0] === 'inspect' && args[1] === 'replacementApi') {
+      if (
+        args[0] === 'container' &&
+        args[1] === 'inspect' &&
+        args[2] === 'replacementApi'
+      ) {
         return JSON.stringify([
           {
             Config: { Labels: { 'com.docker.compose.service': 'api' } },
@@ -665,7 +742,11 @@ describe('cleanupStaleDockerSandboxes', () => {
             },
           ]);
         }
-        if (args[0] === 'inspect' && args[1] === containerName) {
+        if (
+          args[0] === 'container' &&
+          args[1] === 'inspect' &&
+          args[2] === containerName
+        ) {
           return JSON.stringify([{ State: { Running: true } }]);
         }
         if (args[0] === 'exec') {
@@ -702,7 +783,11 @@ describe('cleanupStaleDockerSandboxes', () => {
           },
         ]);
       }
-      if (args[0] === 'inspect' && args[1] === 'apiContainerId') {
+      if (
+        args[0] === 'container' &&
+        args[1] === 'inspect' &&
+        args[2] === 'apiContainerId'
+      ) {
         return JSON.stringify([
           {
             Config: { Labels: { 'com.docker.compose.service': 'api' } },

--- a/apps/controller/src/compute-providers/docker-sandbox-security.ts
+++ b/apps/controller/src/compute-providers/docker-sandbox-security.ts
@@ -901,7 +901,7 @@ async function inspectContainer(
   let output: string;
 
   try {
-    output = await runDocker(['inspect', containerIdOrName]);
+    output = await runDocker(['container', 'inspect', containerIdOrName]);
   } catch (error) {
     if (isDockerObjectNotFoundError(error)) {
       return undefined;

--- a/apps/docs/automations.mdx
+++ b/apps/docs/automations.mdx
@@ -158,16 +158,17 @@ manager-facing updates and suggestions.
 | **CI Failure Triage**        | Automatic repro-and-fix tasks for failing default-branch CI runs | Immediate via webhook                       |
 | **Summarize Merged PRs**     | A digest of recently merged pull requests                        | Daily or weekly                             |
 
-Set **Automation output** first. This is the shared Slack channel for
-manager-facing posts, suggestions, summaries, and setup alerts. Invite Roomote
-to that channel before you save it.
+Set **Automation output** first. This is the shared Slack or Discord Manager
+Channel for manager-facing posts, suggestions, summaries, and setup alerts.
+Make sure the Roomote app can access the channel before you save it.
 
 Each automation card shows a **Reports to** line with the destination the next
 run will use and which setting produced it. Reports go to the automation's own
-channel when one is set, otherwise to the shared Manager Channel. When Slack
-is not connected at all, reports fall back automatically to your primary
-Microsoft Teams conversation, the configured Telegram chat, or the configured
-Discord channel (see
+channel when one is set, otherwise to the shared Manager Channel. If Slack is
+not connected, fallback selection runs only when no destination is saved or the
+saved destination is a Slack channel. Roomote then checks your primary Microsoft
+Teams conversation, the configured Telegram chat, and the default Discord
+channel in that order (see
 [Communications](/communications#supported-providers) for connecting those
 surfaces).
 

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/tool-descriptions.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/tool-descriptions.test.ts
@@ -119,6 +119,25 @@ describe('roomote MCP tool descriptions', () => {
     vi.unstubAllGlobals();
   });
 
+  it('documents every built-in custom automation schedule preset', async () => {
+    const { registeredTools } = await importRoomoteMcpServer();
+    const automationsTool = getRegisteredTool(
+      registeredTools,
+      'manage_custom_automations',
+    );
+    const scheduleDescription = getInputSchemaField(
+      automationsTool,
+      'schedule',
+    ).description;
+
+    expect(scheduleDescription).toContain(
+      'built-in presets: off, every_hour, every_6_hours, daily, weekly',
+    );
+    expect(scheduleDescription).toContain(
+      'Prefer a built-in preset when it matches the requested cadence.',
+    );
+  });
+
   it('guides existing product task URLs toward task inspection actions', async () => {
     const { registeredTools } = await importRoomoteMcpServer();
     const manageTasksTool = getRegisteredTool(registeredTools, 'manage_tasks');

--- a/apps/worker/src/mcp/roomote-mcp-server/index.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/index.ts
@@ -9,6 +9,7 @@ import {
   ALL_REPOSITORIES,
   CHAT_CHANNEL_MESSAGES_TOOL,
   CHAT_MESSAGE_CONTEXT_TOOL,
+  SCHEDULE_ONLY_BACKGROUND_AUTOMATION_FREQUENCIES,
   TaskPayloadKind,
   createTaskEnvVarRequestBaseSchema,
   PRODUCT_NAME,
@@ -104,7 +105,7 @@ roomoteMcpServer.registerTool(
         .string()
         .optional()
         .describe(
-          'A five-field cron expression, preset, or natural-language recurring schedule.',
+          `A five-field cron expression, natural-language recurring schedule, or one of these built-in presets: ${SCHEDULE_ONLY_BACKGROUND_AUTOMATION_FREQUENCIES.join(', ')}. Prefer a built-in preset when it matches the requested cadence.`,
         ),
       model: z
         .string()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roomote",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "license": "FCL-1.0-ALv2",
   "packageManager": "pnpm@10.29.3",
   "engines": {


### PR DESCRIPTION
## Promote v0.30.1

Frozen at `9de08574a9d7e9db0497e34ba13ae5f4af612b01` — the commit where `0.30.1` was versioned. Commits merged to `develop` afterward require an explicit candidate refresh or ship in the next release.

- Merge this PR with a **merge commit** (do not squash or rebase).
- If multiple promote PRs are open, merge them in version order (oldest first).
- Merging publishes a GitHub Release for `v0.30.1` and triggers the existing GHCR `v*` image publish (`latest` channel).
- The `release/v0.30.1` branch can be deleted after this PR merges.

### Changelog

## 0.30.1 (2026-08-02)

This patch improves custom automation scheduling and keeps Docker sandbox cleanup reliable in restricted deployments.

### Highlights

- Keep Docker sandbox cleanup working through restricted socket proxies so expired orphan task networks are removed without broadening proxy permissions.
- Schedule custom automations reliably with discoverable built-in hourly, daily, and weekly presets.

### Patch changes

- Keep Docker sandbox cleanup working through restricted socket proxies so expired orphan task networks are removed without broadening proxy permissions.
- Help agents schedule custom automations reliably by exposing every built-in hourly, daily, and weekly schedule preset through Roomote's management tools.
