### PR TITLE
[Fix] ACA Sandboxes wake-loop fix and improved suspend state management

### DIFF
--- a/.changeset/aca-sandboxes-sleep-wake-remediation.md
+++ b/.changeset/aca-sandboxes-sleep-wake-remediation.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Fix an Azure Container Apps Sandboxes sleep/wake loop where waking a suspended task repeatedly died on "waking up" and sandboxes never stayed suspended. Workers revived from a suspended sandbox now terminate themselves once the server reports their run as finalized (instead of idling as zombies holding the sandbox-server port), resume launches reap leftover workers before booting the new one, retained standby sandboxes found Running are re-suspended automatically, runs whose sandboxes were deleted are finalized instead of retried forever, and sandbox ports use Manual activation so inbound traffic no longer wakes sandboxes out-of-band.

--- a/apps/bullmq/src/jobs/snapshot.test.ts
+++ b/apps/bullmq/src/jobs/snapshot.test.ts
@@ -33,6 +33,7 @@ const {
   setFn,
   updateFn,
 } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- suppressed for oxlint; ESLint's own rule is offloaded and reports this directive as unused, which is a false positive
   type AnyMock = Mock<(...args: any[]) => any>;
 
   const andFn: AnyMock = vi.fn(() => 'and-condition');

--- a/apps/bullmq/src/jobs/snapshot.test.ts
+++ b/apps/bullmq/src/jobs/snapshot.test.ts
@@ -33,7 +33,6 @@ const {
   setFn,
   updateFn,
 } = vi.hoisted(() => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   type AnyMock = Mock<(...args: any[]) => any>;
 
   const andFn: AnyMock = vi.fn(() => 'and-condition');

--- a/apps/bullmq/src/scheduled-jobs/__tests__/sleep-check.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/sleep-check.test.ts
@@ -35,14 +35,13 @@ const {
   selectFn,
   inArrayFn,
 } = vi.hoisted(() => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   type AnyMock = Mock<(...args: any[]) => any>;
 
   const returningFn: AnyMock = vi.fn(() => Promise.resolve([]));
   const updateWhereFn: AnyMock = vi.fn(() => {
     const result = Promise.resolve([]);
     // Support both .returning() (optimistic lock) and .catch() (rollback) call patterns.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     (result as any).returning = returningFn;
     return result;
   });
@@ -348,7 +347,7 @@ describe('sleepCheckJob', () => {
     );
     updateWhereFn.mockImplementation(() => {
       const result = Promise.resolve([]);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
       (result as any).returning = returningFn;
       return result;
     });

--- a/apps/bullmq/src/scheduled-jobs/__tests__/sleep-check.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/sleep-check.test.ts
@@ -35,13 +35,14 @@ const {
   selectFn,
   inArrayFn,
 } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- suppressed for oxlint; ESLint's own rule is offloaded and reports this directive as unused, which is a false positive
   type AnyMock = Mock<(...args: any[]) => any>;
 
   const returningFn: AnyMock = vi.fn(() => Promise.resolve([]));
   const updateWhereFn: AnyMock = vi.fn(() => {
     const result = Promise.resolve([]);
     // Support both .returning() (optimistic lock) and .catch() (rollback) call patterns.
-
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- suppressed for oxlint (see above)
     (result as any).returning = returningFn;
     return result;
   });
@@ -347,7 +348,7 @@ describe('sleepCheckJob', () => {
     );
     updateWhereFn.mockImplementation(() => {
       const result = Promise.resolve([]);
-
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- suppressed for oxlint (see above)
       (result as any).returning = returningFn;
       return result;
     });

--- a/apps/bullmq/src/scheduled-jobs/__tests__/sleep-check.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/sleep-check.test.ts
@@ -109,6 +109,18 @@ vi.mock('@roomote/compute-providers', () => ({
     mockGetComputeProviderCapabilities(...args) ?? {
       supportsSnapshots: true,
     },
+  // Mirrors the real adapter error: sleep-check finalizes runs only on a
+  // definitive 404 from this class.
+  AzureDataPlaneError: class AzureDataPlaneError extends Error {
+    constructor(
+      message: string,
+      public readonly status: number,
+      public readonly code?: string,
+    ) {
+      super(message);
+      this.name = 'AzureDataPlaneError';
+    }
+  },
 }));
 
 vi.mock('@roomote/sdk/server', () => ({
@@ -892,6 +904,107 @@ describe('sleepCheckJob', () => {
         signal: 'sandbox-destroy',
       }),
     );
+  });
+
+  it('finalizes a run whose azure instance no longer exists instead of retrying forever', async () => {
+    const mockJob = {
+      id: 100,
+      machineId: 'sb-gone',
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Running,
+      taskPhase: 'waiting_for_prompt',
+      vendor: 'azure',
+      snapshotId: null,
+      sleepRequestedAt: null,
+      snapshotRequestedAt: null,
+      sleepAt: new Date(Date.now() + 30 * 60 * 1_000),
+    };
+
+    mockJobQueries({ hardLimitJobs: [mockJob] });
+    const { AzureDataPlaneError } = await import('@roomote/compute-providers');
+    mockGetInstanceStatus.mockRejectedValue(
+      new AzureDataPlaneError('Requested document not found.', 404),
+    );
+
+    await sleepCheckJob();
+
+    expect(mockGetInstanceStatus).toHaveBeenCalledWith({
+      instanceId: 'sb-gone',
+    });
+    expect(mockFinishRun).toHaveBeenCalledWith({
+      id: 100,
+      status: RunStatus.Failed,
+      error: expect.stringContaining('no longer exists'),
+    });
+    // No claim-clearing rollback: the generic retry path must not run, or
+    // the run would be re-evaluated (and fail identically) every minute.
+    expect(setFn).not.toHaveBeenCalledWith({
+      sleepRequestedAt: null,
+      snapshotRequestedAt: null,
+    });
+    expect(mockDestroyInstance).not.toHaveBeenCalled();
+    expect(mockEnterStandby).not.toHaveBeenCalled();
+  });
+
+  it('completes an idle run whose azure instance no longer exists', async () => {
+    mockJobQueries({
+      dueJobs: [
+        {
+          id: 42,
+          machineId: 'sb-gone-idle',
+          payloadKind: TaskPayloadKind.StandardTask,
+          status: RunStatus.Idle,
+          vendor: 'azure',
+          snapshotId: null,
+          sleepRequestedAt: null,
+          snapshotRequestedAt: null,
+        },
+      ],
+    });
+    const { AzureDataPlaneError } = await import('@roomote/compute-providers');
+    mockGetInstanceStatus.mockRejectedValue(
+      new AzureDataPlaneError('Requested document not found.', 404),
+    );
+    returningFn.mockResolvedValue([{ id: 42 }]);
+
+    await sleepCheckJob();
+
+    expect(mockFinishRun).toHaveBeenCalledWith({
+      id: 42,
+      status: RunStatus.Completed,
+      error: 'Instance sb-gone-idle no longer exists.',
+    });
+    expect(mockEnterStandby).not.toHaveBeenCalled();
+  });
+
+  it('keeps retrying on transient provider errors instead of finalizing', async () => {
+    const mockJob = {
+      id: 101,
+      machineId: 'sb-flaky',
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Running,
+      taskPhase: 'waiting_for_prompt',
+      vendor: 'azure',
+      snapshotId: null,
+      sleepRequestedAt: null,
+      snapshotRequestedAt: null,
+      sleepAt: new Date(Date.now() + 30 * 60 * 1_000),
+    };
+
+    mockJobQueries({ hardLimitJobs: [mockJob] });
+    const { AzureDataPlaneError } = await import('@roomote/compute-providers');
+    mockGetInstanceStatus.mockRejectedValue(
+      new AzureDataPlaneError('Upstream timeout.', 502),
+    );
+
+    await sleepCheckJob();
+
+    // Transient error: generic catch clears claims so the next tick retries.
+    expect(mockFinishRun).not.toHaveBeenCalled();
+    expect(setFn).toHaveBeenLastCalledWith({
+      sleepRequestedAt: null,
+      snapshotRequestedAt: null,
+    });
   });
 
   it('skips job when optimistic lock fails', async () => {

--- a/apps/bullmq/src/scheduled-jobs/__tests__/standby-retention.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/standby-retention.test.ts
@@ -14,7 +14,6 @@ const {
   setFn,
   updateWhereFn,
 } = vi.hoisted(() => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   type AnyMock = Mock<(...args: any[]) => any>;
 
   // Each db.select(...) call consumes one entry; entries resolve in call
@@ -24,7 +23,7 @@ const {
 
   const makeQueryResult = (rows: unknown[]) => {
     const result = Promise.resolve(rows);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     (result as any).orderBy = () => Promise.resolve(rows);
     return result;
   };

--- a/apps/bullmq/src/scheduled-jobs/__tests__/standby-retention.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/standby-retention.test.ts
@@ -8,12 +8,9 @@ const {
   mockResolveComputeProviderEnvValues,
   selectResultsQueue,
   selectFn,
-  fromFn,
-  whereFn,
   updateFn,
-  setFn,
-  updateWhereFn,
 } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- suppressed for oxlint; ESLint's own rule is offloaded and reports this directive as unused, which is a false positive
   type AnyMock = Mock<(...args: any[]) => any>;
 
   // Each db.select(...) call consumes one entry; entries resolve in call
@@ -23,7 +20,7 @@ const {
 
   const makeQueryResult = (rows: unknown[]) => {
     const result = Promise.resolve(rows);
-
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- suppressed for oxlint (see above)
     (result as any).orderBy = () => Promise.resolve(rows);
     return result;
   };
@@ -46,11 +43,7 @@ const {
     mockResolveComputeProviderEnvValues: vi.fn() as AnyMock,
     selectResultsQueue,
     selectFn,
-    fromFn,
-    whereFn,
     updateFn,
-    setFn,
-    updateWhereFn,
   };
 });
 

--- a/apps/bullmq/src/scheduled-jobs/__tests__/standby-retention.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/standby-retention.test.ts
@@ -1,0 +1,241 @@
+import type { Mock } from 'vitest';
+
+const {
+  mockCreateComputeProviderClient,
+  mockGetInstanceStatus,
+  mockEnterStandby,
+  mockDestroyInstance,
+  mockResolveComputeProviderEnvValues,
+  selectResultsQueue,
+  selectFn,
+  fromFn,
+  whereFn,
+  updateFn,
+  setFn,
+  updateWhereFn,
+} = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  type AnyMock = Mock<(...args: any[]) => any>;
+
+  // Each db.select(...) call consumes one entry; entries resolve in call
+  // order. getCandidates chains .orderBy(...), the other queries await the
+  // where-result directly, so both shapes must resolve to the same rows.
+  const selectResultsQueue: { current: unknown[][] } = { current: [] };
+
+  const makeQueryResult = (rows: unknown[]) => {
+    const result = Promise.resolve(rows);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (result as any).orderBy = () => Promise.resolve(rows);
+    return result;
+  };
+
+  const whereFn: AnyMock = vi.fn(() =>
+    makeQueryResult(selectResultsQueue.current.shift() ?? []),
+  );
+  const fromFn: AnyMock = vi.fn(() => ({ where: whereFn }));
+  const selectFn: AnyMock = vi.fn(() => ({ from: fromFn }));
+
+  const updateWhereFn: AnyMock = vi.fn(() => Promise.resolve([]));
+  const setFn: AnyMock = vi.fn(() => ({ where: updateWhereFn }));
+  const updateFn: AnyMock = vi.fn(() => ({ set: setFn }));
+
+  return {
+    mockCreateComputeProviderClient: vi.fn() as AnyMock,
+    mockGetInstanceStatus: vi.fn() as AnyMock,
+    mockEnterStandby: vi.fn() as AnyMock,
+    mockDestroyInstance: vi.fn() as AnyMock,
+    mockResolveComputeProviderEnvValues: vi.fn() as AnyMock,
+    selectResultsQueue,
+    selectFn,
+    fromFn,
+    whereFn,
+    updateFn,
+    setFn,
+    updateWhereFn,
+  };
+});
+
+vi.mock('@roomote/db/server', () => ({
+  db: {
+    select: selectFn,
+    update: updateFn,
+  },
+  taskRuns: {
+    id: 'id',
+    taskId: 'taskId',
+    vendor: 'vendor',
+    status: 'status',
+    machineId: 'machineId',
+    snapshotId: 'snapshotId',
+    snapshotCreatedAt: 'snapshotCreatedAt',
+    sourceSnapshotId: 'sourceSnapshotId',
+  },
+  and: vi.fn(),
+  desc: vi.fn(),
+  eq: vi.fn(),
+  inArray: vi.fn(),
+  isNotNull: vi.fn(),
+  or: vi.fn(),
+  resolveComputeProviderEnvValues: mockResolveComputeProviderEnvValues,
+}));
+
+vi.mock('@roomote/compute-providers', () => ({
+  createComputeProviderClient: mockCreateComputeProviderClient,
+}));
+
+// Import after mocks are set up.
+import { standbyRetentionJob } from '../standby-retention';
+
+/**
+ * standbyRetentionJob iterates docker, blaxel, azure. Each provider's
+ * eviction pass runs two selects (candidates, protected handles); azure
+ * additionally runs the orphan re-suspend pass (candidates, protected
+ * handles, in-use handles). Queue entries in consumption order.
+ */
+function queueSelectResults({
+  azureReSuspendCandidates = [],
+  azureReSuspendProtected = [],
+  azureReSuspendInUse = [],
+}: {
+  azureReSuspendCandidates?: unknown[];
+  azureReSuspendProtected?: unknown[];
+  azureReSuspendInUse?: unknown[];
+}) {
+  selectResultsQueue.current = [
+    [], // docker eviction candidates
+    [], // docker eviction protected
+    [], // blaxel eviction candidates
+    [], // blaxel eviction protected
+    [], // azure eviction candidates
+    [], // azure eviction protected
+    azureReSuspendCandidates,
+    azureReSuspendProtected,
+    azureReSuspendInUse,
+  ];
+}
+
+describe('standbyRetentionJob orphan re-suspend', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectResultsQueue.current = [];
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    mockResolveComputeProviderEnvValues.mockResolvedValue({});
+    mockCreateComputeProviderClient.mockReturnValue({
+      destroyInstance: mockDestroyInstance,
+      getInstanceStatus: mockGetInstanceStatus,
+      enterStandby: mockEnterStandby,
+    });
+    mockGetInstanceStatus.mockResolvedValue({ status: 'running' });
+    mockEnterStandby.mockResolvedValue({ resumeHandle: 'sb-1' });
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('re-suspends a retained azure standby found Running with no managing run', async () => {
+    queueSelectResults({
+      azureReSuspendCandidates: [
+        {
+          runId: 32,
+          taskId: 'task-1',
+          provider: 'azure',
+          handle: 'sb-1',
+          createdAt: new Date(),
+        },
+      ],
+    });
+
+    await standbyRetentionJob();
+
+    expect(mockGetInstanceStatus).toHaveBeenCalledWith({
+      instanceId: 'sb-1',
+    });
+    expect(mockEnterStandby).toHaveBeenCalledWith({ instanceId: 'sb-1' });
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('re-suspended orphaned azure standby sb-1'),
+    );
+  });
+
+  it('skips retained handles owned by an active wake session', async () => {
+    queueSelectResults({
+      azureReSuspendCandidates: [
+        {
+          runId: 32,
+          taskId: 'task-1',
+          provider: 'azure',
+          handle: 'sb-1',
+          createdAt: new Date(),
+        },
+      ],
+      azureReSuspendInUse: [{ machineId: 'sb-1', snapshotId: null }],
+    });
+
+    await standbyRetentionJob();
+
+    expect(mockEnterStandby).not.toHaveBeenCalled();
+  });
+
+  it('skips handles protected by an active resume run', async () => {
+    queueSelectResults({
+      azureReSuspendCandidates: [
+        {
+          runId: 32,
+          taskId: 'task-1',
+          provider: 'azure',
+          handle: 'sb-1',
+          createdAt: new Date(),
+        },
+      ],
+      azureReSuspendProtected: [{ handle: 'sb-1' }],
+    });
+
+    await standbyRetentionJob();
+
+    expect(mockEnterStandby).not.toHaveBeenCalled();
+  });
+
+  it('skips handles that are not live instances (genuine snapshot ids)', async () => {
+    queueSelectResults({
+      azureReSuspendCandidates: [
+        {
+          runId: 32,
+          taskId: 'task-1',
+          provider: 'azure',
+          handle: 'snap-1',
+          createdAt: new Date(),
+        },
+      ],
+    });
+    mockGetInstanceStatus.mockRejectedValue(new Error('not found'));
+
+    await standbyRetentionJob();
+
+    expect(mockEnterStandby).not.toHaveBeenCalled();
+  });
+
+  it('does not touch retained instances that are already suspended', async () => {
+    queueSelectResults({
+      azureReSuspendCandidates: [
+        {
+          runId: 32,
+          taskId: 'task-1',
+          provider: 'azure',
+          handle: 'sb-1',
+          createdAt: new Date(),
+        },
+      ],
+    });
+    mockGetInstanceStatus.mockResolvedValue({ status: 'stopped' });
+
+    await standbyRetentionJob();
+
+    expect(mockEnterStandby).not.toHaveBeenCalled();
+  });
+});

--- a/apps/bullmq/src/scheduled-jobs/sleep-check.ts
+++ b/apps/bullmq/src/scheduled-jobs/sleep-check.ts
@@ -31,6 +31,7 @@ import {
   syncTaskStateFromRuns,
 } from '@roomote/db/server';
 import {
+  AzureDataPlaneError,
   createComputeProviderClient,
   type ComputeProviderClient,
 } from '@roomote/compute-providers';
@@ -445,6 +446,16 @@ export const sleepCheckJob = async () => {
         failed += result.failed;
       }
     } catch (error) {
+      if (isInstanceNotFoundError(error)) {
+        // The instance is gone for good — every future evaluation would fail
+        // the same way (observed as an endless hard_limit retry loop on azure
+        // runs whose sandboxes were deleted out-of-band). Finalize the run
+        // instead of retrying forever.
+        failed += 1;
+        await finalizeRunForMissingInstance(preferredJob, fallbackPath);
+        continue;
+      }
+
       await db
         .update(taskRuns)
         .set({
@@ -882,6 +893,62 @@ async function resolveSweptJobFinalStatus(
   });
 
   return job?.cancelRequestedAt ? RunStatus.Canceled : RunStatus.Failed;
+}
+
+/**
+ * Whether the error definitively means the provider instance no longer
+ * exists (as opposed to a transient API failure). Only definitive not-found
+ * errors may finalize runs; anything else must keep retrying. Azure throws
+ * AzureDataPlaneError 404 for deleted sandboxes; other providers' not-found
+ * shapes can extend this classifier as needed.
+ */
+function isInstanceNotFoundError(error: unknown): boolean {
+  return error instanceof AzureDataPlaneError && error.status === 404;
+}
+
+/**
+ * Finalize a candidate whose provider instance is gone. Mirrors the
+ * not-running branch of the timed/heartbeat handlers: idle runs complete
+ * without a snapshot; anything else fails (or cancels after a stop request).
+ */
+async function finalizeRunForMissingInstance(
+  job: SleepCheckJob,
+  path: SleepCheckPath,
+): Promise<void> {
+  const details = {
+    path,
+    decision: 'instance_not_found',
+    ...buildSleepCheckDetails(job),
+  };
+
+  if (job.status === RunStatus.Idle) {
+    await recordSleepCheckEvent(
+      job,
+      'decision',
+      `${describeSleepCheckPath(path)} found that idle instance ${job.machineId} no longer exists; completing task run #${job.id} without a snapshot.`,
+      details,
+    );
+    await completeIdleJobWithoutSnapshot(
+      job,
+      `Instance ${job.machineId} no longer exists.`,
+      details,
+    );
+    return;
+  }
+
+  const finalStatus = await resolveSweptJobFinalStatus(job.id);
+
+  await recordSleepCheckEvent(
+    job,
+    finalStatus === RunStatus.Canceled ? 'decision' : 'failed',
+    `${describeSleepCheckPath(path)} found that instance ${job.machineId} no longer exists; finalizing task run #${job.id} as ${finalStatus}.`,
+    details,
+  );
+  await finishRun({
+    id: job.id,
+    status: finalStatus,
+    error: `${describeSleepCheckPath(path)} found that instance ${job.machineId} no longer exists`,
+  });
 }
 
 async function handleTimedSleepCandidate(params: {

--- a/apps/bullmq/src/scheduled-jobs/standby-retention.ts
+++ b/apps/bullmq/src/scheduled-jobs/standby-retention.ts
@@ -5,6 +5,7 @@ import {
   eq,
   inArray,
   isNotNull,
+  or,
   resolveComputeProviderEnvValues,
   taskRuns,
 } from '@roomote/db/server';
@@ -14,6 +15,12 @@ import { activeRunStatuses, type RunStatus } from '@roomote/types';
 const LOG_PREFIX = '[standbyRetention]';
 const MS_PER_HOUR = 60 * 60 * 1_000;
 const STANDBY_PROVIDERS = ['docker', 'blaxel', 'azure'] as const;
+
+// Providers whose retained handles are live instances that can (and must) be
+// re-suspended when found Running with no managing run.
+const RE_SUSPEND_PROVIDERS = [
+  'azure',
+] as const satisfies readonly StandbyProvider[];
 
 type StandbyProvider = (typeof STANDBY_PROVIDERS)[number];
 
@@ -105,6 +112,43 @@ async function createClient(provider: StandbyProvider) {
     provider: 'blaxel',
     envFallback: await resolveComputeProviderEnvValues('blaxel'),
   });
+}
+
+/**
+ * Handles referenced by any active run — as its machine (a live wake session
+ * owns the sandbox) or as its retained standby handle. Re-suspending one of
+ * these would kill a live session, so the orphan sweep must skip them.
+ */
+async function getInUseHandles(
+  provider: StandbyProvider,
+  handles: string[],
+): Promise<Set<string>> {
+  if (handles.length === 0) return new Set();
+
+  const rows = await db
+    .select({
+      machineId: taskRuns.machineId,
+      snapshotId: taskRuns.snapshotId,
+    })
+    .from(taskRuns)
+    .where(
+      and(
+        eq(taskRuns.vendor, provider),
+        inArray(taskRuns.status, activeRunStatuses as readonly RunStatus[]),
+        or(
+          inArray(taskRuns.machineId, handles),
+          inArray(taskRuns.snapshotId, handles),
+        ),
+      ),
+    );
+
+  return new Set(
+    rows.flatMap((row) =>
+      [row.machineId, row.snapshotId].flatMap((handle) =>
+        handle === null ? [] : [handle],
+      ),
+    ),
+  );
 }
 
 async function getProtectedHandles(provider: StandbyProvider) {
@@ -210,6 +254,76 @@ async function enforceProviderRetention(
   return removed;
 }
 
+/**
+ * Re-suspend retained standby instances found Running. A retained instance
+ * has no living run: its worker token was finalized at suspend time, so any
+ * out-of-band wake (traffic on legacy OnDemand ports, portal actions, a wake
+ * that resumed the sandbox before bootstrap failed) leaves it idling and
+ * billing with no Roomote run to manage it. Sleep-check deliberately
+ * excludes retained runs (its candidacy requires snapshotId IS NULL), so
+ * this sweep is the only re-suspend path.
+ *
+ * Wake-race note: a deliberate wake stamps the resume run's sourceSnapshotId
+ * with the handle at enqueue time, which getProtectedHandles covers, so the
+ * window for stopping a sandbox mid-wake is limited to the wake's own
+ * resume+launch seconds. A lost race fails that wake attempt cleanly and the
+ * user retries; the next sweep re-heals the orphan either way.
+ */
+async function reSuspendOrphanedStandbys(
+  provider: StandbyProvider,
+): Promise<number> {
+  const candidates = await getCandidates(provider);
+  if (candidates.length === 0) return 0;
+
+  const protectedHandles = await getProtectedHandles(provider);
+  const inUseHandles = await getInUseHandles(
+    provider,
+    candidates.map((candidate) => candidate.handle),
+  );
+  const client = await createClient(provider);
+
+  if (!client.enterStandby) return 0;
+
+  let resuspended = 0;
+
+  for (const candidate of candidates) {
+    if (
+      protectedHandles.has(candidate.handle) ||
+      inUseHandles.has(candidate.handle)
+    ) {
+      continue;
+    }
+
+    let status: string;
+    try {
+      const result = await client.getInstanceStatus({
+        instanceId: candidate.handle,
+      });
+      status = result.status;
+    } catch {
+      // Not a live instance (a genuine snapshot id, or already deleted) —
+      // the retention eviction policy owns its lifecycle.
+      continue;
+    }
+
+    if (status !== 'running') continue;
+
+    try {
+      await client.enterStandby({ instanceId: candidate.handle });
+      resuspended += 1;
+      console.log(
+        `${LOG_PREFIX} re-suspended orphaned ${provider} standby ${candidate.handle} from task run #${candidate.runId}`,
+      );
+    } catch (error) {
+      console.error(
+        `${LOG_PREFIX} failed to re-suspend ${provider} standby ${candidate.handle}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  return resuspended;
+}
+
 export async function standbyRetentionJob(
   now: Date = new Date(),
 ): Promise<void> {
@@ -217,12 +331,20 @@ export async function standbyRetentionJob(
     STANDBY_PROVIDERS.map(async (provider) => ({
       provider,
       removed: await enforceProviderRetention(provider, now),
+      resuspended: (RE_SUSPEND_PROVIDERS as readonly string[]).includes(
+        provider,
+      )
+        ? await reSuspendOrphanedStandbys(provider)
+        : 0,
     })),
   );
 
   console.log(
     `${LOG_PREFIX} completed ${results
-      .map(({ provider, removed }) => `${provider}=${removed}`)
+      .map(
+        ({ provider, removed, resuspended }) =>
+          `${provider}(removed=${removed},resuspended=${resuspended})`,
+      )
       .join(' ')}`,
   );
 }

--- a/apps/bullmq/src/scheduled-jobs/standby-retention.ts
+++ b/apps/bullmq/src/scheduled-jobs/standby-retention.ts
@@ -18,9 +18,7 @@ const STANDBY_PROVIDERS = ['docker', 'blaxel', 'azure'] as const;
 
 // Providers whose retained handles are live instances that can (and must) be
 // re-suspended when found Running with no managing run.
-const RE_SUSPEND_PROVIDERS = [
-  'azure',
-] as const satisfies readonly StandbyProvider[];
+const RE_SUSPEND_PROVIDERS: readonly StandbyProvider[] = ['azure'];
 
 type StandbyProvider = (typeof STANDBY_PROVIDERS)[number];
 

--- a/apps/bullmq/src/scheduled-jobs/standby-retention.ts
+++ b/apps/bullmq/src/scheduled-jobs/standby-retention.ts
@@ -331,9 +331,7 @@ export async function standbyRetentionJob(
     STANDBY_PROVIDERS.map(async (provider) => ({
       provider,
       removed: await enforceProviderRetention(provider, now),
-      resuspended: (RE_SUSPEND_PROVIDERS as readonly string[]).includes(
-        provider,
-      )
+      resuspended: RE_SUSPEND_PROVIDERS.includes(provider)
         ? await reSuspendOrphanedStandbys(provider)
         : 0,
     })),

--- a/apps/controller/src/compute-providers/spawn-azure-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-azure-worker.ts
@@ -399,6 +399,29 @@ export async function spawnAzureWorker(
       )}`,
     );
 
+    if (
+      launchOptions.launchMode === 'task_standby' ||
+      launchOptions.launchMode === 'task_snapshot'
+    ) {
+      // Suspend/resume and snapshot/restore revive previously frozen worker
+      // processes whose runs were finalized while they were away — dead
+      // tokens, and they hold the sandbox-server port, which kills the
+      // incoming worker's boot. Reap them before launch. pkill exits 1 when
+      // nothing matches; that is the common case and not an error.
+      await computeClient
+        .runCommand({
+          instanceId: machine.machineId,
+          cmd: 'pkill',
+          args: ['-f', '/sandbox/worker/dist/worker.js'],
+          signal: AbortSignal.timeout(15_000),
+        })
+        .catch((error) => {
+          console.warn(
+            `[spawnAzureWorker] Pre-launch worker reaper failed for task run #${taskRun.id}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        });
+    }
+
     await recordMutation({
       provider: 'azure',
       operation: 'run_command',

--- a/apps/worker/src/run-task/polling/worker-heartbeat.test.ts
+++ b/apps/worker/src/run-task/polling/worker-heartbeat.test.ts
@@ -196,6 +196,36 @@ describe('createWorkerHeartbeatInterval', () => {
     }
   });
 
+  it('terminates the worker when the server reports the run as finalized', async () => {
+    const warn = vi.fn();
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never);
+    mockTouchWorkerHeartbeat.mockRejectedValue(
+      new Error('Cannot access resources from a different run'),
+    );
+
+    const interval = createWorkerHeartbeatInterval({
+      runId: 200,
+      logger: { warn } as never,
+    });
+
+    try {
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(warn).toHaveBeenCalledWith(
+        '[workerHeartbeat] Task run 200 is finalized server-side; terminating this worker.',
+      );
+      expect(exitSpy).toHaveBeenCalledWith(0);
+      // No failure-streak bookkeeping or Sentry noise for an authoritative
+      // terminal signal.
+      expect(captureWorkerMessageMock).not.toHaveBeenCalled();
+    } finally {
+      clearInterval(interval);
+      exitSpy.mockRestore();
+    }
+  });
+
   it('does not start a new heartbeat while the previous request is still pending', async () => {
     const deferred = createDeferred<void>();
     mockTouchWorkerHeartbeat

--- a/apps/worker/src/run-task/polling/worker-heartbeat.ts
+++ b/apps/worker/src/run-task/polling/worker-heartbeat.ts
@@ -3,6 +3,18 @@ import { sdk } from '@roomote/sdk/client';
 import { captureWorkerMessage } from '../../monitoring/sentry';
 
 const HEARTBEAT_SENTRY_THRESHOLD = 3;
+
+/**
+ * Server message (run-token guard) returned when the persisted run is in a
+ * terminal status. The control plane finalizes standby/swept runs while
+ * their workers may still be alive — a suspended-then-woken worker resumes
+ * with a dead token and must terminate itself instead of idling forever as
+ * a zombie (holding the sandbox-server port and killing its successor's
+ * boot). This is authoritative server-side truth, not a transient failure.
+ */
+const RUN_TERMINAL_HEARTBEAT_MESSAGE =
+  'Cannot access resources from a different run';
+
 export const WORKER_HEARTBEAT_RPC_TIMEOUT_MS =
   WORKER_HEARTBEAT_INTERVAL_MS - 5_000;
 
@@ -58,6 +70,21 @@ async function sendHeartbeat({
     hasReportedFailureStreakRef.current = false;
   } catch (error) {
     const heartbeatError = getHeartbeatError(controller, runId, error);
+
+    if (
+      heartbeatError instanceof Error &&
+      heartbeatError.message.includes(RUN_TERMINAL_HEARTBEAT_MESSAGE)
+    ) {
+      logger.warn(
+        `[workerHeartbeat] Task run ${runId} is finalized server-side; terminating this worker.`,
+      );
+      // The run this worker belongs to no longer exists as an active run —
+      // every control-plane call will fail the same way, so graceful
+      // teardown has nothing useful left to do. Exit promptly so the
+      // sandbox is free for its next wake.
+      process.exit(0);
+    }
+
     consecutiveFailureCountRef.current += 1;
     logger.warn(
       `[workerHeartbeat] Failed to update heartbeat for task run ${runId}: ${

--- a/packages/compute-providers/src/__tests__/azure.contract.test.ts
+++ b/packages/compute-providers/src/__tests__/azure.contract.test.ts
@@ -165,7 +165,9 @@ describe('azure adapter contract', () => {
     expect(portAdd?.body).toMatchObject({
       port: 3000,
       auth: { anonymous: true },
-      activationMode: 'OnDemand',
+      // Manual activation: wake stays deliberate; OnDemand wakes orphaned
+      // standby sandboxes on any inbound traffic.
+      activationMode: 'Manual',
     });
   });
 

--- a/packages/compute-providers/src/__tests__/azure.contract.test.ts
+++ b/packages/compute-providers/src/__tests__/azure.contract.test.ts
@@ -240,6 +240,94 @@ describe('azure adapter contract', () => {
     expect(result.domains['8080']).toContain('--8080.');
   });
 
+  it('migrates a legacy OnDemand port to Manual activation on conflict', async () => {
+    let addAttempts = 0;
+    const { fetchImpl, requests } = createFetchMock({
+      onRequest: (request) => {
+        if (request.url.includes('/ports/add')) {
+          addAttempts += 1;
+          // The legacy add conflicts; the post-remove re-add succeeds.
+          if (addAttempts === 1) {
+            return jsonResponse({ title: 'PortAlreadyExists' }, 409);
+          }
+          return jsonResponse({});
+        }
+        if (
+          request.method === 'GET' &&
+          request.url.includes(`${SANDBOX_ID}?`)
+        ) {
+          return jsonResponse({
+            id: SANDBOX_ID,
+            state: 'Running',
+            ports: [
+              {
+                port: 8080,
+                auth: { anonymous: true },
+                activationMode: 'OnDemand',
+              },
+            ],
+          });
+        }
+        return undefined;
+      },
+    });
+    const client = createClient(fetchImpl);
+
+    const result = await client.getInstanceDomains!({
+      instanceId: SANDBOX_ID,
+      ports: [8080],
+    });
+
+    expect(result.domains['8080']).toContain('--8080.');
+    const portRemove = requests.find((r) => r.url.includes('/ports/remove'));
+    expect(portRemove?.body).toMatchObject({ port: 8080 });
+    const portAdds = requests.filter((r) => r.url.includes('/ports/add'));
+    expect(portAdds).toHaveLength(2);
+    expect(portAdds[1]?.body).toMatchObject({
+      port: 8080,
+      auth: { anonymous: true },
+      activationMode: 'Manual',
+    });
+  });
+
+  it('leaves an existing Manual port untouched on conflict', async () => {
+    const { fetchImpl, requests } = createFetchMock({
+      onRequest: (request) => {
+        if (request.url.includes('/ports/add')) {
+          return jsonResponse({ title: 'PortAlreadyExists' }, 409);
+        }
+        if (
+          request.method === 'GET' &&
+          request.url.includes(`${SANDBOX_ID}?`)
+        ) {
+          return jsonResponse({
+            id: SANDBOX_ID,
+            state: 'Running',
+            ports: [
+              {
+                port: 8080,
+                auth: { anonymous: true },
+                activationMode: 'Manual',
+              },
+            ],
+          });
+        }
+        return undefined;
+      },
+    });
+    const client = createClient(fetchImpl);
+
+    await client.getInstanceDomains!({
+      instanceId: SANDBOX_ID,
+      ports: [8080],
+    });
+
+    expect(requests.some((r) => r.url.includes('/ports/remove'))).toBe(false);
+    expect(requests.filter((r) => r.url.includes('/ports/add'))).toHaveLength(
+      1,
+    );
+  });
+
   it('runs a blocking command with cwd and returns output', async () => {
     const { fetchImpl, requests } = createFetchMock({});
     const client = createClient(fetchImpl);

--- a/packages/compute-providers/src/adapters/azure.ts
+++ b/packages/compute-providers/src/adapters/azure.ts
@@ -904,8 +904,11 @@ export class AzureClient implements ComputeProviderClient {
 
   /**
    * Add the requested ports (anonymous, Manual activation) and return
-   * deterministic per-port URLs. Re-adding an existing port is a 409, which
-   * is treated as success.
+   * deterministic per-port URLs. A 409 means the port already exists —
+   * and ports persist across stop/resume, so sandboxes created before
+   * Manual activation shipped would keep OnDemand forever if the conflict
+   * were silently accepted. Conflicts therefore go through a migration
+   * check: legacy (non-Manual) ports are removed and re-added.
    *
    * Activation is deliberately NOT OnDemand: OnDemand resumes a suspended
    * sandbox on ANY inbound traffic (measured 2026-07-28), but Roomote
@@ -933,10 +936,47 @@ export class AzureClient implements ComputeProviderClient {
         });
       } catch (error) {
         if (!isPortConflict(error)) throw error;
+        await this.migrateLegacyPortActivation(sandboxId, port, signal);
       }
       domains[String(port)] = this.computePortUrl(sandboxId, port);
     }
     return domains;
+  }
+
+  /**
+   * Migrate an existing port to Manual activation. Triggered on a 409 from
+   * ports/add: ports persist across stop/resume, so legacy OnDemand ports
+   * keep waking the sandbox out-of-band on any inbound traffic unless they
+   * are recreated. Uses ports/remove + ports/add — the PUT /ports
+   * replace-all endpoint is unreliable (see service reference). A port
+   * already on Manual is left untouched.
+   */
+  private async migrateLegacyPortActivation(
+    sandboxId: string,
+    port: number,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const sandbox = await this.getSandbox(sandboxId, signal);
+    const existing = sandbox.ports?.find((p) => p.port === port);
+
+    if (!existing || existing.activationMode === 'Manual') {
+      return;
+    }
+
+    await this.request('POST', `${this.sandboxPath(sandboxId)}/ports/remove`, {
+      body: { port },
+      signal,
+      abortMessage: `Migrating port ${port} on Azure sandbox ${sandboxId} to Manual activation was aborted`,
+    });
+    await this.request('POST', `${this.sandboxPath(sandboxId)}/ports/add`, {
+      body: {
+        port,
+        auth: { anonymous: true },
+        activationMode: 'Manual',
+      },
+      signal,
+      abortMessage: `Re-adding port ${port} with Manual activation on Azure sandbox ${sandboxId} was aborted`,
+    });
   }
 
   /**

--- a/packages/compute-providers/src/adapters/azure.ts
+++ b/packages/compute-providers/src/adapters/azure.ts
@@ -903,10 +903,16 @@ export class AzureClient implements ComputeProviderClient {
   }
 
   /**
-   * Add the requested ports (anonymous, OnDemand activation so inbound
-   * traffic wakes a suspended sandbox — measured 2026-07-28) and return
+   * Add the requested ports (anonymous, Manual activation) and return
    * deterministic per-port URLs. Re-adding an existing port is a 409, which
    * is treated as success.
+   *
+   * Activation is deliberately NOT OnDemand: OnDemand resumes a suspended
+   * sandbox on ANY inbound traffic (measured 2026-07-28), but Roomote
+   * finalizes standby runs at suspend time — an out-of-band wake resumes a
+   * worker whose run token is dead, the worker exits, and the sandbox idles
+   * Running, invisible to sleep-check (which excludes retained runs). Wake
+   * must stay deliberate (wake prompt / message send → resumeFromStandby).
    */
   private async ensurePorts(
     sandboxId: string,
@@ -920,7 +926,7 @@ export class AzureClient implements ComputeProviderClient {
           body: {
             port,
             auth: { anonymous: true },
-            activationMode: 'OnDemand',
+            activationMode: 'Manual',
           },
           signal,
           abortMessage: `Exposing port ${port} on Azure sandbox ${sandboxId} was aborted`,


### PR DESCRIPTION
## Related issue

N/A

## Why this PR exists

- [x] A maintainer explicitly invited this PR ~~in the linked issue or discussion~~
- [ ] I am a maintainer / this is internal Roomote work

## What changed

Fixes an Azure Container Apps Sandboxes sleep/wake death loop: after a task was suspended (standby), every wake attempt died on "waking up" and the sandbox never stayed suspended.

Four interlocking defects, verified live against sandbox + DB event timelines:

1. **Zombie workers killed every wake.** A suspended sandbox resumes with its worker process frozen mid-run, but the run is finalized (Completed) at suspend time, so the worker's run token is dead. The zombie kept running, held sandbox-server port 4200, and the next wake's worker died ~1 minute into boot — then the 2-minute stale-worker sweep suspended the sandbox mid-boot, and the cycle repeated on every wake.
   → Workers now terminate themselves when the server reports their run as finalized (heartbeat rejects with the terminal run-guard message), and resume launches reap leftover workers (`pkill`) before booting the new one.
2. **Retained-but-Running sandboxes were invisible.** Sleep-check candidacy requires `snapshotId IS NULL`, so a retained standby sandbox left Running (failed wake, portal stop/start, legacy port wake) was never re-suspended.
   → Standby-retention (5-min cadence) now re-suspends azure retained handles whose instance reports `running`, guarded so it never touches a sandbox an active run owns.
3. **Ports woke sandboxes out-of-band.** `OnDemand` activation resumes a suspended sandbox on any inbound traffic, but standby runs are always Completed at suspend time, so traffic-driven wakes could only orphan.
   → All Roomote-added sandbox ports now use `Manual` activation; wake is deliberate-only (wake prompt / message send).
4. **Deleted sandboxes retried forever.** A 404 from `getInstanceStatus` (sandbox deleted out-of-band) went down the generic retry path and re-failed every minute indefinitely.
   → Definitive not-found now finalizes the run (idle → complete; otherwise fail/cancel).

## How it was tested

- New unit tests: sleep-check not-found finalization (404 → finalize, idle-complete, transient-error retry preserved), standby-retention orphan re-suspend (5 tests incl. active-session and genuine-snapshot guards), worker heartbeat terminal-run exit; azure contract test updated to `Manual` port activation.
- Suites: compute-providers 210/210, bullmq 146/146, worker heartbeat 7/7; `pnpm lint` and `pnpm check-types` pass on all four touched packages.
- Live validation on a production deployment after deploying this branch: wake button works (clean boot on the previously looping sandbox), task suspended to `Stopped` at the keepalive deadline, and the standby handle was recorded for the next wake.

## Checklist

- [x] The PR title follows the repo convention: `[Fix]`, `[Feat]`, `[Improve]`, `[Refactor]`, `[Docs]`, or `[Chore]` followed by a user-facing description
- [x] This PR is small and scoped to one change
- [x] `pnpm lint` and `pnpm check-types` pass locally
- [x] I added tests or included a clear manual validation note above
- [x] I removed secrets, tokens, private keys, and customer data from code, logs, and screenshots
- [x] If this change should appear in the changelog, I ran `pnpm changeset`
