### PR TITLE
[Fix] ChatGPT device-code dialog waits forever on codes that can never succeed

### DIFF
--- a/.changeset/chatgpt-device-auth-terminal-states.md
+++ b/.changeset/chatgpt-device-auth-terminal-states.md
@@ -1,0 +1,11 @@
+---
+'@roomote/types': patch
+'@roomote/db': patch
+'@roomote/web': patch
+---
+
+Fix the ChatGPT subscription connect dialog waiting forever on a device code that can never succeed. The device-code endpoint returns an `expires_at` roughly fifteen minutes out, but Roomote dropped it and the dialog had no expiry timer, so once a code aged out the dialog kept polling a dead code behind a "Waiting for authorization…" spinner with no way to tell that the code was gone. The dialog now stops at the issuer's stated expiry and prompts for a restart.
+
+Polling also treated every HTTP 403 and 404 from the device-token endpoint as "pending". Only 403 with the structured error code `deviceauth_authorization_pending` actually means the user has not entered the code yet: 404 means the issuer no longer recognizes the code, and a 403 carrying any other code is a refusal that waiting cannot resolve, most commonly an organization policy blocking the OAuth app. Polling now classifies on the structured error code and gives each terminal case its own message, so a blocked deployment says the workspace policy blocks the app and to contact an admin instead of rendering the same spinner as a code nobody has typed in yet. An unrecognized error body still falls back to pending, now bounded by the expiry deadline rather than looping indefinitely.
+
+Rate-limited polls back off instead of failing, and a rejected poll request surfaces its error in the dialog rather than stopping the loop while leaving the promise unhandled.

--- a/apps/web/src/components/settings/ChatGptConnectDialog.test.tsx
+++ b/apps/web/src/components/settings/ChatGptConnectDialog.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, waitFor } from '@testing-library/react';
+
+const { pollMock, startResult } = vi.hoisted(() => ({
+  pollMock: vi.fn(),
+  startResult: {
+    current: {
+      deviceAuthId: 'dev-1',
+      userCode: 'ABCD-EFGHI',
+      verificationUrl: 'https://auth.openai.com/codex/device',
+      intervalMs: 5,
+      expiresInMs: 60_000,
+    },
+  },
+}));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+vi.mock('@/trpc/client', () => {
+  const queryKey = () => ['stub'];
+  return {
+    useTRPC: () => ({
+      chatgptSubscription: {
+        startDeviceAuth: {
+          mutationOptions: (options: Record<string, unknown>) => ({
+            mutationKey: ['start'],
+            ...options,
+          }),
+        },
+        pollDeviceAuth: { mutationOptions: () => ({ mutationKey: ['poll'] }) },
+        status: { queryKey },
+      },
+      taskModels: {
+        providerSetup: { queryKey },
+        get: { queryKey },
+        launchOptions: { queryKey },
+      },
+      subscriptionUsage: { list: { queryKey } },
+    }),
+  };
+});
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({
+    invalidateQueries: vi.fn().mockResolvedValue(undefined),
+  }),
+  useMutation: (options: {
+    mutationKey: string[];
+    onSuccess?: (result: unknown) => void;
+  }) =>
+    options.mutationKey[0] === 'start'
+      ? {
+          mutate: () => options.onSuccess?.(startResult.current),
+          isPending: false,
+          isError: false,
+          reset: vi.fn(),
+        }
+      : { mutateAsync: pollMock },
+}));
+
+import { ChatGptConnectDialog } from './ChatGptConnectDialog';
+
+describe('ChatGptConnectDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    startResult.current = {
+      deviceAuthId: 'dev-1',
+      userCode: 'ABCD-EFGHI',
+      verificationUrl: 'https://auth.openai.com/codex/device',
+      intervalMs: 5,
+      expiresInMs: 60_000,
+    };
+  });
+
+  it('stops polling and prompts a restart once the device code expires', async () => {
+    startResult.current = { ...startResult.current, expiresInMs: 30 };
+    pollMock.mockResolvedValue({ status: 'pending' });
+
+    render(<ChatGptConnectDialog open onOpenChange={vi.fn()} />);
+
+    await screen.findByText(/authorization code expired/i);
+
+    const callsAtExpiry = pollMock.mock.calls.length;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(pollMock.mock.calls.length).toBe(callsAtExpiry);
+    expect(screen.getByRole('button', { name: 'Restart' })).toBeInTheDocument();
+  });
+
+  it('reports an org policy block instead of waiting forever', async () => {
+    pollMock.mockResolvedValue({
+      status: 'failed',
+      error: 'ChatGPT device authorization was refused (deviceauth_forbidden).',
+      reason: 'blocked',
+    });
+
+    render(<ChatGptConnectDialog open onOpenChange={vi.fn()} />);
+
+    await screen.findByText(/deviceauth_forbidden/);
+    expect(
+      screen.getByText(/workspace policy blocks the Codex app/i),
+    ).toBeInTheDocument();
+    // The dead code is no longer presented as something to type in.
+    expect(
+      screen.queryByText(/Waiting for authorization/i),
+    ).not.toBeInTheDocument();
+    await waitFor(() => expect(pollMock).toHaveBeenCalledTimes(1));
+  });
+
+  it('surfaces a rejected poll instead of leaving the promise unhandled', async () => {
+    pollMock.mockRejectedValue(new Error('network down'));
+
+    render(<ChatGptConnectDialog open onOpenChange={vi.fn()} />);
+
+    await screen.findByText('network down');
+    expect(
+      screen.queryByText(/Waiting for authorization/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/settings/ChatGptConnectDialog.tsx
+++ b/apps/web/src/components/settings/ChatGptConnectDialog.tsx
@@ -24,12 +24,18 @@ type DeviceAuthStartResult = {
   userCode: string;
   verificationUrl: string;
   intervalMs: number;
+  expiresInMs: number;
 };
 
+type DevicePollFailureReason = 'blocked' | 'expired';
+
 type DevicePollResult =
-  | { status: 'pending' }
+  | { status: 'pending'; intervalMs?: number }
   | { status: 'success' }
-  | { status: 'failed'; error: string };
+  | { status: 'failed'; error: string; reason?: DevicePollFailureReason };
+
+const EXPIRED_CODE_ERROR =
+  'ChatGPT authorization code expired. Restart the connection to get a new code.';
 
 type ChatGptConnectDialogProps = {
   open: boolean;
@@ -55,7 +61,19 @@ export function ChatGptConnectDialog({
   );
   const [polling, setPolling] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [failureReason, setFailureReason] =
+    useState<DevicePollFailureReason | null>(null);
   const pollingRef = useRef(false);
+
+  function stopPolling(
+    message: string,
+    reason: DevicePollFailureReason | null = null,
+  ) {
+    pollingRef.current = false;
+    setPolling(false);
+    setError(message);
+    setFailureReason(reason);
+  }
 
   const startMutation = useMutation(
     trpc.chatgptSubscription.startDeviceAuth.mutationOptions({
@@ -73,44 +91,10 @@ export function ChatGptConnectDialog({
     }),
   );
 
+  // Poll results drive the loop below rather than mutation callbacks, so a
+  // single code path owns both stopping the loop and reporting the outcome.
   const pollMutation = useMutation(
-    trpc.chatgptSubscription.pollDeviceAuth.mutationOptions({
-      onSuccess: async (result: DevicePollResult) => {
-        if (result.status === 'success') {
-          toast.success('ChatGPT subscription connected.');
-          await queryClient.invalidateQueries({
-            queryKey: trpc.taskModels.providerSetup.queryKey(),
-          });
-          await queryClient.invalidateQueries({
-            queryKey: trpc.taskModels.get.queryKey(),
-          });
-          await queryClient.invalidateQueries({
-            queryKey: trpc.taskModels.launchOptions.queryKey(),
-          });
-          await queryClient.invalidateQueries({
-            queryKey: trpc.chatgptSubscription.status.queryKey(),
-          });
-          await queryClient.invalidateQueries({
-            queryKey: trpc.subscriptionUsage.list.queryKey(),
-          });
-          await onConnected?.();
-          handleOpenChange(false);
-        } else if (result.status === 'failed') {
-          setError(result.error);
-          pollingRef.current = false;
-          setPolling(false);
-        }
-      },
-      onError: (mutationError) => {
-        setError(
-          mutationError instanceof Error
-            ? mutationError.message
-            : 'ChatGPT authorization polling failed.',
-        );
-        pollingRef.current = false;
-        setPolling(false);
-      },
-    }),
+    trpc.chatgptSubscription.pollDeviceAuth.mutationOptions(),
   );
 
   useEffect(() => {
@@ -119,6 +103,7 @@ export function ChatGptConnectDialog({
       setPolling(false);
       setDeviceAuth(null);
       setError(null);
+      setFailureReason(null);
       return;
     }
 
@@ -145,24 +130,83 @@ export function ChatGptConnectDialog({
     pollingRef.current = true;
     setPolling(true);
 
+    // The issuer stops accepting the code at this deadline; polling past it
+    // only ever yields `deviceauth_not_found`.
+    const expiresAt = Date.now() + deviceAuth.expiresInMs;
+
     const poll = async () => {
-      while (pollingRef.current && deviceAuth) {
-        await pollMutation.mutateAsync({
+      let intervalMs = deviceAuth.intervalMs;
+
+      while (pollingRef.current) {
+        if (Date.now() >= expiresAt) {
+          stopPolling(EXPIRED_CODE_ERROR, 'expired');
+          return;
+        }
+
+        const result: DevicePollResult = await pollMutation.mutateAsync({
           deviceAuthId: deviceAuth.deviceAuthId,
           userCode: deviceAuth.userCode,
         });
 
         if (!pollingRef.current) {
-          break;
+          return;
+        }
+
+        if (result.status === 'success') {
+          pollingRef.current = false;
+          setPolling(false);
+          toast.success('ChatGPT subscription connected.');
+          await Promise.all([
+            queryClient.invalidateQueries({
+              queryKey: trpc.taskModels.providerSetup.queryKey(),
+            }),
+            queryClient.invalidateQueries({
+              queryKey: trpc.taskModels.get.queryKey(),
+            }),
+            queryClient.invalidateQueries({
+              queryKey: trpc.taskModels.launchOptions.queryKey(),
+            }),
+            queryClient.invalidateQueries({
+              queryKey: trpc.chatgptSubscription.status.queryKey(),
+            }),
+            queryClient.invalidateQueries({
+              queryKey: trpc.subscriptionUsage.list.queryKey(),
+            }),
+          ]);
+          await onConnected?.();
+          handleOpenChange(false);
+          return;
+        }
+
+        if (result.status === 'failed') {
+          stopPolling(result.error, result.reason ?? null);
+          return;
+        }
+
+        // A rate-limited poll returns the interval to back off to.
+        if (result.intervalMs) {
+          intervalMs = result.intervalMs;
+        }
+
+        const remainingMs = expiresAt - Date.now();
+        if (remainingMs <= 0) {
+          stopPolling(EXPIRED_CODE_ERROR, 'expired');
+          return;
         }
 
         await new Promise((resolve) =>
-          setTimeout(resolve, deviceAuth.intervalMs),
+          setTimeout(resolve, Math.min(intervalMs, remainingMs)),
         );
       }
     };
 
-    void poll();
+    void poll().catch((pollError: unknown) => {
+      stopPolling(
+        pollError instanceof Error
+          ? pollError.message
+          : 'ChatGPT authorization polling failed.',
+      );
+    });
 
     return () => {
       pollingRef.current = false;
@@ -179,6 +223,7 @@ export function ChatGptConnectDialog({
   function handleRestart() {
     setDeviceAuth(null);
     setError(null);
+    setFailureReason(null);
     // Clear the prior failed mutation state so the start effect can fire
     // again, then kick off a fresh device-code request.
     startMutation.reset();
@@ -208,12 +253,19 @@ export function ChatGptConnectDialog({
           ) : null}
 
           {error ? (
-            <p className="text-sm text-destructive" role="alert">
-              {error}
-            </p>
+            <div className="space-y-2" role="alert">
+              <p className="text-sm text-destructive">{error}</p>
+              {failureReason === 'blocked' ? (
+                <p className="text-sm text-muted-foreground">
+                  This usually means your ChatGPT workspace policy blocks the
+                  Codex app. Ask an admin of that workspace to allow it, then
+                  restart the connection. Waiting will not clear this.
+                </p>
+              ) : null}
+            </div>
           ) : null}
 
-          {deviceAuth ? (
+          {deviceAuth && !error ? (
             <>
               <div className="space-y-2">
                 <p className="text-sm">

--- a/apps/web/src/trpc/commands/chatgpt-subscription/index.ts
+++ b/apps/web/src/trpc/commands/chatgpt-subscription/index.ts
@@ -5,6 +5,7 @@ import {
   pollChatGptDeviceAuth,
   startChatGptDeviceAuth,
   updateChatGptSubscriptionFastMode,
+  type ChatGptDevicePollFailureReason,
   type ChatGptSubscriptionPublicStatus,
 } from '@roomote/db/server';
 
@@ -39,9 +40,13 @@ export async function startChatGptDeviceAuthCommand(
 }
 
 type PollChatGptDeviceAuthResult =
-  | { status: 'pending' }
+  | { status: 'pending'; intervalMs?: number }
   | { status: 'success' }
-  | { status: 'failed'; error: string };
+  | {
+      status: 'failed';
+      error: string;
+      reason?: ChatGptDevicePollFailureReason;
+    };
 
 export async function pollChatGptDeviceAuthCommand(
   auth: UserAuthSuccess,
@@ -58,10 +63,17 @@ export async function pollChatGptDeviceAuthCommand(
   }
 
   if (result.status === 'failed') {
-    return { status: 'failed', error: result.error };
+    return {
+      status: 'failed',
+      error: result.error,
+      ...(result.reason && { reason: result.reason }),
+    };
   }
 
-  return { status: 'pending' };
+  return {
+    status: 'pending',
+    ...(result.intervalMs && { intervalMs: result.intervalMs }),
+  };
 }
 
 export async function disconnectChatGptSubscriptionCommand(

--- a/packages/db/src/lib/__tests__/chatgpt-subscription.test.ts
+++ b/packages/db/src/lib/__tests__/chatgpt-subscription.test.ts
@@ -347,9 +347,78 @@ describe('getFreshChatGptAccessToken', () => {
   });
 });
 
+describe('startChatGptDeviceAuth', () => {
+  function makeStartFetch(body: Record<string, unknown>) {
+    return vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        device_auth_id: 'dev-1',
+        user_code: 'CODE',
+        interval: '5',
+        ...body,
+      }),
+    });
+  }
+
+  it('derives the poll deadline from the issuer expires_at', async () => {
+    const now = Date.parse('2026-07-31T22:04:00.000Z');
+    const fetchImpl = makeStartFetch({
+      expires_at: '2026-07-31T22:19:00.000Z',
+    });
+    const { startChatGptDeviceAuth } = await import('../chatgpt-subscription');
+
+    const result = await startChatGptDeviceAuth(fetchImpl as never, now);
+
+    expect(result.expiresInMs).toBe(15 * 60 * 1000);
+    expect(result.intervalMs).toBe(5000);
+  });
+
+  it('falls back to the default TTL when expires_at is absent or unparseable', async () => {
+    const now = Date.now();
+    const { startChatGptDeviceAuth } = await import('../chatgpt-subscription');
+
+    const missing = await startChatGptDeviceAuth(
+      makeStartFetch({}) as never,
+      now,
+    );
+    const garbage = await startChatGptDeviceAuth(
+      makeStartFetch({ expires_at: 'not-a-date' }) as never,
+      now,
+    );
+
+    expect(missing.expiresInMs).toBe(900 * 1000);
+    expect(garbage.expiresInMs).toBe(900 * 1000);
+  });
+
+  it('never returns a non-positive window for an already expired code', async () => {
+    const now = Date.parse('2026-07-31T22:30:00.000Z');
+    const fetchImpl = makeStartFetch({
+      expires_at: '2026-07-31T22:19:00.000Z',
+    });
+    const { startChatGptDeviceAuth } = await import('../chatgpt-subscription');
+
+    const result = await startChatGptDeviceAuth(fetchImpl as never, now);
+
+    expect(result.expiresInMs).toBeGreaterThan(0);
+  });
+});
+
 describe('pollChatGptDeviceAuth', () => {
+  function makeErrorFetch(status: number, code?: string) {
+    return vi.fn().mockResolvedValue({
+      status,
+      json: async () => ({
+        error: {
+          message: 'irrelevant prose',
+          type: 'invalid_request_error',
+          code,
+        },
+      }),
+    });
+  }
+
   it('returns pending while the user has not authorized', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue({ status: 403 });
+    const fetchImpl = makeErrorFetch(403, 'deviceauth_authorization_pending');
     const { pollChatGptDeviceAuth } = await import('../chatgpt-subscription');
 
     const result = await pollChatGptDeviceAuth({
@@ -359,6 +428,70 @@ describe('pollChatGptDeviceAuth', () => {
     });
 
     expect(result).toEqual({ status: 'pending' });
+  });
+
+  it('fails as blocked on a 403 that is not the pending code', async () => {
+    const fetchImpl = makeErrorFetch(403, 'deviceauth_forbidden');
+    const { pollChatGptDeviceAuth } = await import('../chatgpt-subscription');
+
+    const result = await pollChatGptDeviceAuth({
+      deviceAuthId: 'dev-1',
+      userCode: 'CODE',
+      fetchImpl: fetchImpl as never,
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result).toMatchObject({ reason: 'blocked' });
+  });
+
+  it('fails as expired when the issuer no longer knows the code', async () => {
+    const fetchImpl = makeErrorFetch(404, 'deviceauth_not_found');
+    const { pollChatGptDeviceAuth } = await import('../chatgpt-subscription');
+
+    const result = await pollChatGptDeviceAuth({
+      deviceAuthId: 'dev-1',
+      userCode: 'CODE',
+      fetchImpl: fetchImpl as never,
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result).toMatchObject({ reason: 'expired' });
+  });
+
+  it('stays pending when the error body carries no structured code', async () => {
+    const { pollChatGptDeviceAuth } = await import('../chatgpt-subscription');
+
+    const noCode = await pollChatGptDeviceAuth({
+      deviceAuthId: 'dev-1',
+      userCode: 'CODE',
+      fetchImpl: makeErrorFetch(403) as never,
+    });
+    const unparseable = await pollChatGptDeviceAuth({
+      deviceAuthId: 'dev-1',
+      userCode: 'CODE',
+      fetchImpl: vi.fn().mockResolvedValue({
+        status: 403,
+        json: async () => {
+          throw new Error('not json');
+        },
+      }) as never,
+    });
+
+    expect(noCode).toEqual({ status: 'pending' });
+    expect(unparseable).toEqual({ status: 'pending' });
+  });
+
+  it('backs off instead of failing when polling is rate limited', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ status: 429 });
+    const { pollChatGptDeviceAuth } = await import('../chatgpt-subscription');
+
+    const result = await pollChatGptDeviceAuth({
+      deviceAuthId: 'dev-1',
+      userCode: 'CODE',
+      fetchImpl: fetchImpl as never,
+    });
+
+    expect(result).toEqual({ status: 'pending', intervalMs: 5000 });
   });
 
   it('returns success after exchanging the device authorization code', async () => {

--- a/packages/db/src/lib/__tests__/chatgpt-subscription.test.ts
+++ b/packages/db/src/lib/__tests__/chatgpt-subscription.test.ts
@@ -403,6 +403,39 @@ describe('startChatGptDeviceAuth', () => {
   });
 });
 
+describe('classifyDeviceAuthRefusal', () => {
+  it('maps each structured error code to its poll result', async () => {
+    const { classifyDeviceAuthRefusal } =
+      await import('../chatgpt-subscription');
+
+    expect(
+      classifyDeviceAuthRefusal('deviceauth_authorization_pending'),
+    ).toEqual({ status: 'pending' });
+    expect(classifyDeviceAuthRefusal('deviceauth_not_found')).toMatchObject({
+      status: 'failed',
+      reason: 'expired',
+    });
+    expect(classifyDeviceAuthRefusal('deviceauth_forbidden')).toMatchObject({
+      status: 'failed',
+      reason: 'blocked',
+    });
+    // No usable code: stay pending, bounded by the caller's expiry deadline.
+    expect(classifyDeviceAuthRefusal(undefined)).toEqual({ status: 'pending' });
+  });
+
+  it('names the offending code so a blocked deployment is diagnosable', async () => {
+    const { classifyDeviceAuthRefusal } =
+      await import('../chatgpt-subscription');
+
+    const result = classifyDeviceAuthRefusal('deviceauth_org_policy');
+
+    expect(result).toMatchObject({ status: 'failed', reason: 'blocked' });
+    expect(result.status === 'failed' && result.error).toContain(
+      'deviceauth_org_policy',
+    );
+  });
+});
+
 describe('pollChatGptDeviceAuth', () => {
   function makeErrorFetch(status: number, code?: string) {
     return vi.fn().mockResolvedValue({

--- a/packages/db/src/lib/chatgpt-subscription.ts
+++ b/packages/db/src/lib/chatgpt-subscription.ts
@@ -603,6 +603,42 @@ async function readDeviceAuthErrorCode(
   }
 }
 
+/**
+ * Map a refused device-token poll to a result, keyed only on the structured
+ * `error.code`. The HTTP status is deliberately not part of the decision: the
+ * issuer reuses 403 for both "not entered yet" and refusals no amount of
+ * waiting resolves, so the status alone cannot tell them apart.
+ *
+ * `undefined` means the body carried no usable code, which stays `pending` to
+ * preserve the behavior that shipped before this was classified at all. The
+ * caller stops at the device code's expiry, so that fallback is bounded.
+ *
+ * Pure, so the branch table is testable without an HTTP mock.
+ */
+export function classifyDeviceAuthRefusal(
+  errorCode: string | undefined,
+): ChatGptDevicePollResult {
+  switch (errorCode) {
+    case CHATGPT_DEVICE_AUTH_PENDING_ERROR_CODE:
+      return { status: 'pending' };
+    case CHATGPT_DEVICE_AUTH_NOT_FOUND_ERROR_CODE:
+      return {
+        status: 'failed',
+        reason: 'expired',
+        error:
+          'ChatGPT authorization code expired. Restart the connection to get a new code.',
+      };
+    case undefined:
+      return { status: 'pending' };
+    default:
+      return {
+        status: 'failed',
+        reason: 'blocked',
+        error: `ChatGPT device authorization was refused (${errorCode}).`,
+      };
+  }
+}
+
 export async function pollChatGptDeviceAuth(input: {
   deviceAuthId: string;
   userCode: string;
@@ -629,33 +665,7 @@ export async function pollChatGptDeviceAuth(input: {
   }
 
   if (response.status === 403 || response.status === 404) {
-    const errorCode = await readDeviceAuthErrorCode(response);
-
-    if (errorCode === CHATGPT_DEVICE_AUTH_PENDING_ERROR_CODE) {
-      return { status: 'pending' };
-    }
-
-    if (errorCode === CHATGPT_DEVICE_AUTH_NOT_FOUND_ERROR_CODE) {
-      return {
-        status: 'failed',
-        reason: 'expired',
-        error:
-          'ChatGPT authorization code expired. Restart the connection to get a new code.',
-      };
-    }
-
-    if (!errorCode) {
-      // Unrecognized body shape: keep the pre-existing pending behavior rather
-      // than failing a flow that may still be live. The caller stops at the
-      // device code's expiry, so this cannot spin forever.
-      return { status: 'pending' };
-    }
-
-    return {
-      status: 'failed',
-      reason: 'blocked',
-      error: `ChatGPT device authorization was refused (${errorCode}).`,
-    };
+    return classifyDeviceAuthRefusal(await readDeviceAuthErrorCode(response));
   }
 
   if (!response.ok) {

--- a/packages/db/src/lib/chatgpt-subscription.ts
+++ b/packages/db/src/lib/chatgpt-subscription.ts
@@ -2,6 +2,9 @@ import { sql } from 'drizzle-orm';
 
 import {
   CHATGPT_DEFAULT_ACCESS_TOKEN_TTL_MS,
+  CHATGPT_DEVICE_AUTH_NOT_FOUND_ERROR_CODE,
+  CHATGPT_DEVICE_AUTH_PENDING_ERROR_CODE,
+  CHATGPT_DEVICE_CODE_DEFAULT_TTL_MS,
   CHATGPT_OAUTH_CLIENT_ID,
   CHATGPT_OAUTH_DEVICE_CODE_ENDPOINT,
   CHATGPT_OAUTH_DEVICE_CALLBACK_REDIRECT_URI,
@@ -10,6 +13,7 @@ import {
   CHATGPT_OAUTH_ISSUER,
   CHATGPT_OAUTH_TOKEN_ENDPOINT,
   CHATGPT_OPENCODE_PROVIDER_ID,
+  CHATGPT_POLL_SLOW_DOWN_MS,
   CHATGPT_REFRESH_SAFETY_MARGIN_MS,
 } from '@roomote/types';
 
@@ -88,11 +92,21 @@ interface DeviceUserCodeResponse {
   device_auth_id: string;
   user_code: string;
   interval: string;
+  /** ISO 8601 timestamp after which the user code stops being accepted. */
+  expires_at?: string;
 }
 
 interface DeviceTokenPendingResponse {
   authorization_code: string;
   code_verifier: string;
+}
+
+/** Error envelope the deviceauth endpoints return on a non-2xx response. */
+interface DeviceAuthErrorResponse {
+  error?: {
+    code?: string;
+    message?: string;
+  };
 }
 
 function parseJwtClaims(token: string): IdTokenClaims | undefined {
@@ -481,15 +495,22 @@ export async function resolveOpenCodeAuthContent(
  * Initiate the OpenAI device-code authorization flow. Returns the user code
  * and verification URL the operator enters in a browser. The caller polls
  * {@link pollChatGptDeviceAuth} with the returned `deviceAuthId` and
- * `userCode` until it resolves to tokens.
+ * `userCode` until it resolves to tokens, and stops once `expiresInMs`
+ * elapses. The issuer stops accepting the code at that point and every later
+ * poll returns `deviceauth_not_found`.
+ *
+ * `expiresInMs` is relative rather than absolute so a clock skew between this
+ * server and the operator's browser cannot expire the code early or late.
  */
 export async function startChatGptDeviceAuth(
   fetchImpl: typeof fetch = fetch,
+  now: number = Date.now(),
 ): Promise<{
   deviceAuthId: string;
   userCode: string;
   verificationUrl: string;
   intervalMs: number;
+  expiresInMs: number;
 }> {
   const response = await fetchImpl(CHATGPT_OAUTH_DEVICE_CODE_ENDPOINT, {
     method: 'POST',
@@ -514,20 +535,74 @@ export async function startChatGptDeviceAuth(
     userCode: data.user_code,
     verificationUrl: CHATGPT_OAUTH_DEVICE_VERIFICATION_URL,
     intervalMs: intervalSeconds * 1000,
+    expiresInMs: resolveDeviceCodeExpiresInMs(data.expires_at, now),
   };
 }
 
+function resolveDeviceCodeExpiresInMs(
+  expiresAt: string | undefined,
+  now: number,
+): number {
+  const parsed = expiresAt ? Date.parse(expiresAt) : Number.NaN;
+
+  if (Number.isNaN(parsed)) {
+    return CHATGPT_DEVICE_CODE_DEFAULT_TTL_MS;
+  }
+
+  // Never hand back a non-positive window; a code that is already expired
+  // should still give the dialog one poll before it reports expiry.
+  return Math.max(parsed - now, 1_000);
+}
+
+/**
+ * Why a poll ended terminally, so the dialog can show guidance the operator
+ * can act on instead of a generic error:
+ * - `blocked`: the issuer refused the app, typically an org policy on the
+ *   ChatGPT workspace. Only an admin of that workspace can clear it.
+ * - `expired`: the code aged out or was already consumed; restart the flow.
+ */
+export type ChatGptDevicePollFailureReason = 'blocked' | 'expired';
+
 export type ChatGptDevicePollResult =
-  | { status: 'pending' }
+  | { status: 'pending'; intervalMs?: number }
   | { status: 'success'; record: ChatGptSubscriptionRecord }
-  | { status: 'failed'; error: string };
+  | {
+      status: 'failed';
+      error: string;
+      reason?: ChatGptDevicePollFailureReason;
+    };
 
 /**
  * Poll the OpenAI device-token endpoint once. Returns `pending` while the
- * operator has not yet completed authorization (HTTP 403/404), `success`
- * with the persisted subscription record once tokens are exchanged, or
- * `failed` on a terminal error.
+ * operator has not yet completed authorization, `success` with the persisted
+ * subscription record once tokens are exchanged, or `failed` on a terminal
+ * error.
+ *
+ * The endpoint signals pending with HTTP 403 and the structured error code
+ * `deviceauth_authorization_pending`, and reuses 403 for refusals that no
+ * amount of waiting resolves (an org policy blocking the OAuth app). Classify
+ * on the structured code rather than the status alone so a blocked deployment
+ * is not rendered as an endless "waiting" spinner. When the body carries no
+ * recognizable code we fall back to `pending`; the caller's expiry deadline
+ * bounds that fallback.
  */
+/**
+ * Read the structured `error.code` from a deviceauth error response, or
+ * `undefined` when the body is absent, unparseable, or carries no code. Only
+ * the code is inspected; the human-readable `message` is not matched on.
+ */
+async function readDeviceAuthErrorCode(
+  response: Response,
+): Promise<string | undefined> {
+  try {
+    const body = (await response.json()) as DeviceAuthErrorResponse;
+    const code = body?.error?.code;
+    return typeof code === 'string' && code.length > 0 ? code : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export async function pollChatGptDeviceAuth(input: {
   deviceAuthId: string;
   userCode: string;
@@ -549,8 +624,38 @@ export async function pollChatGptDeviceAuth(input: {
     }),
   });
 
+  if (response.status === 429) {
+    return { status: 'pending', intervalMs: CHATGPT_POLL_SLOW_DOWN_MS };
+  }
+
   if (response.status === 403 || response.status === 404) {
-    return { status: 'pending' };
+    const errorCode = await readDeviceAuthErrorCode(response);
+
+    if (errorCode === CHATGPT_DEVICE_AUTH_PENDING_ERROR_CODE) {
+      return { status: 'pending' };
+    }
+
+    if (errorCode === CHATGPT_DEVICE_AUTH_NOT_FOUND_ERROR_CODE) {
+      return {
+        status: 'failed',
+        reason: 'expired',
+        error:
+          'ChatGPT authorization code expired. Restart the connection to get a new code.',
+      };
+    }
+
+    if (!errorCode) {
+      // Unrecognized body shape: keep the pre-existing pending behavior rather
+      // than failing a flow that may still be live. The caller stops at the
+      // device code's expiry, so this cannot spin forever.
+      return { status: 'pending' };
+    }
+
+    return {
+      status: 'failed',
+      reason: 'blocked',
+      error: `ChatGPT device authorization was refused (${errorCode}).`,
+    };
   }
 
   if (!response.ok) {

--- a/packages/types/src/chatgpt-subscription.ts
+++ b/packages/types/src/chatgpt-subscription.ts
@@ -114,3 +114,27 @@ export const CHATGPT_REFRESH_SAFETY_MARGIN_MS = 10 * 60 * 1000;
  * `expires_in`. Matches opencode's fallback.
  */
 export const CHATGPT_DEFAULT_ACCESS_TOKEN_TTL_MS = 3600 * 1000;
+
+/**
+ * Fallback device-code lifetime (15 minutes) when the device-code endpoint
+ * omits `expires_at` or returns an unparseable value. Matches the ~15 minute
+ * window OpenAI currently issues.
+ */
+export const CHATGPT_DEVICE_CODE_DEFAULT_TTL_MS = 900 * 1000;
+
+/** Poll backoff applied when OpenAI rate-limits the device-token endpoint. */
+export const CHATGPT_POLL_SLOW_DOWN_MS = 5_000;
+
+/**
+ * Structured `error.code` the device-token endpoint returns (alongside HTTP
+ * 403) while the operator has not yet entered the code. Any other 403 code is
+ * terminal, most commonly an org policy that blocks the Codex OAuth app.
+ */
+export const CHATGPT_DEVICE_AUTH_PENDING_ERROR_CODE =
+  'deviceauth_authorization_pending';
+
+/**
+ * Structured `error.code` returned (alongside HTTP 404) for a device code the
+ * issuer no longer recognizes, i.e. expired or already consumed.
+ */
+export const CHATGPT_DEVICE_AUTH_NOT_FOUND_ERROR_CODE = 'deviceauth_not_found';


### PR DESCRIPTION
## Problem

The ChatGPT subscription connect dialog could wait forever on a device code that would never succeed, with no way for an admin to tell an expired code apart from a policy refusal.

Two separate causes:

1. **No expiry.** `startChatGptDeviceAuth` returned the poll interval but dropped the issuer's expiry, and the dialog had no expiry timer. Its `while (pollingRef.current && deviceAuth)` loop polled a dead code indefinitely behind a "Waiting for authorization…" spinner.
2. **Terminal refusals looked identical to pending.** `pollChatGptDeviceAuth` mapped both HTTP 403 and 404 to `pending`, so a code the issuer no longer recognizes, and a refusal that no amount of waiting resolves, both rendered as the same spinner as "the user hasn't typed the code in yet".

The polling loop was also invoked as `void poll()` with no `.catch()` while awaiting `mutateAsync`, so the awaited promise rejected unobserved.

## What the endpoints actually return

I probed the live endpoints before changing the classification (unauthenticated, no credentials involved):

- `deviceauth/usercode` already returns `expires_at`, an ISO timestamp ~15 minutes out. We were discarding it.
- `deviceauth/token` returns **HTTP 403 with `error.code: "deviceauth_authorization_pending"` as the normal pending response**, on every poll before the user enters the code.
- An unknown or aged-out code returns **HTTP 404 with `error.code: "deviceauth_not_found"`**.

So 403 could not simply be made terminal: that is the pending path, and treating it as terminal would break every connect. 404 was the branch silently mapped to `pending` forever.

## Fix

- `startChatGptDeviceAuth` returns `expiresInMs`, derived from the issuer's `expires_at`. It is relative rather than absolute so clock skew between server and browser cannot expire a code early or late, and it falls back to 900s when the field is absent or unparseable.
- Poll classification keys on the structured `error.code`, never on message wording: the pending code stays `pending`, `deviceauth_not_found` becomes `failed`/`expired`, and any other explicit code on 403/404 becomes `failed`/`blocked`. An unrecognized body still falls back to `pending`, preserving prior behavior for response shapes not seen here, now bounded by the expiry deadline so it cannot spin forever.
- HTTP 429 backs off instead of failing.
- The dialog stops at the deadline with a restart prompt, renders dedicated copy for a blocked deployment (workspace policy blocks the app, contact an admin, waiting will not clear it), honors the backoff interval, and drops the dead code from the UI on any terminal state instead of leaving it next to a spinner.
- Poll results now drive the loop directly instead of being split across `onSuccess`/`onError`. That split was what let the awaited promise reject unobserved; a single code path now owns both stopping the loop and reporting the outcome, and it has the missing `.catch()`.

## Testing

Unit: 23 db tests and new dialog tests covering expiry, blocked, expired, rate-limit backoff and the rejected-poll path. Full suites green (db 45 files / 423 tests, web 359 files / 2641 tests).

Live smoke against the real endpoints, using the shipped functions:

| Check | Result |
| --- | --- |
| Issuer expiry parsed | `expiresInMs: 900229` (15.00 min) |
| Live un-authorized poll | `pending`, no regression on the normal path |
| Unknown code poll | `failed` / `reason: expired` |

End-to-end in the browser against a real device code:

| Scenario | Result |
| --- | --- |
| Real 15-minute expiry, nothing mocked | Last poll at 22:46:58, expiry ~22:47:00, loop stopped, expired message and Restart shown, zero polls in the following 7 minutes |
| Shortened window | Stops at the deadline, no further polls |
| Blocked | Error plus org-policy guidance, stopped after exactly one poll, code removed, Restart offered |
| Restart after blocked | Fresh code issued, polling resumes |
| Rejected poll | Error surfaced, spinner gone, polling stopped, no unhandled rejection in console |

## Note for reviewers

The blocked branch is verified for behavior but not against a genuinely policy-blocked account, since I have no way to produce one. It treats any non-pending 403 code as blocked, so it covers that case whatever the specific code turns out to be.

🤖 Generated with Claude Code
