### PR TITLE
[Refactor] Extract shared device-code polling lifecycle into useDeviceCodeFlow

### DIFF
--- a/.changeset/shared-device-code-flow-hook.md
+++ b/.changeset/shared-device-code-flow-hook.md
@@ -1,0 +1,7 @@
+---
+'@roomote/web': patch
+---
+
+Extract the OAuth device-code polling lifecycle shared by the ChatGPT, xAI, and GitHub Copilot connect dialogs into one `useDeviceCodeFlow` hook, leaving each dialog a thin presentational shell that supplies its provider-specific mutations, query invalidations, and copy. The three dialogs had drifted: each reimplemented the start-once guard, expiry deadline, slow-down backoff, and terminal states with small differences.
+
+The hook combines the strongest behavior from each implementation. From the ChatGPT dialog: the client-side expiry deadline, distinct failure reasons driving dedicated copy, rate-limit backoff, and surfacing a rejected poll instead of leaving the promise unhandled. From the xAI dialog: monotonic generation-counter cancellation instead of a shared boolean, closing a race where cancelling and quickly reopening a dialog could revive a stale polling loop still holding the previous device code. The xAI and GitHub Copilot dialogs gain that race protection plus the polished terminal handling, and all three now hide the dead device code once a terminal error is shown instead of leaving it next to the error message.

--- a/apps/web/src/components/settings/ChatGptConnectDialog.tsx
+++ b/apps/web/src/components/settings/ChatGptConnectDialog.tsx
@@ -1,11 +1,9 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { ExternalLink, Loader2 } from 'lucide-react';
-import { toast } from 'sonner';
 
 import { useTRPC } from '@/trpc/client';
+import { useDeviceCodeFlow } from '@/hooks/useDeviceCodeFlow';
 import {
   Badge,
   Button,
@@ -27,16 +25,6 @@ type DeviceAuthStartResult = {
   expiresInMs: number;
 };
 
-type DevicePollFailureReason = 'blocked' | 'expired';
-
-type DevicePollResult =
-  | { status: 'pending'; intervalMs?: number }
-  | { status: 'success' }
-  | { status: 'failed'; error: string; reason?: DevicePollFailureReason };
-
-const EXPIRED_CODE_ERROR =
-  'ChatGPT authorization code expired. Restart the connection to get a new code.';
-
 type ChatGptConnectDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -55,183 +43,48 @@ export function ChatGptConnectDialog({
   onConnected,
 }: ChatGptConnectDialogProps) {
   const trpc = useTRPC();
-  const queryClient = useQueryClient();
-  const [deviceAuth, setDeviceAuth] = useState<DeviceAuthStartResult | null>(
-    null,
-  );
-  const [polling, setPolling] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [failureReason, setFailureReason] =
-    useState<DevicePollFailureReason | null>(null);
-  const pollingRef = useRef(false);
 
-  function stopPolling(
-    message: string,
-    reason: DevicePollFailureReason | null = null,
-  ) {
-    pollingRef.current = false;
-    setPolling(false);
-    setError(message);
-    setFailureReason(reason);
-  }
-
-  const startMutation = useMutation(
-    trpc.chatgptSubscription.startDeviceAuth.mutationOptions({
-      onSuccess: (result) => {
-        setDeviceAuth(result);
-        setError(null);
-      },
-      onError: (mutationError) => {
-        setError(
-          mutationError instanceof Error
-            ? mutationError.message
-            : 'Failed to start ChatGPT authorization.',
-        );
-      },
+  const {
+    deviceAuth,
+    error,
+    failureReason,
+    polling,
+    isStartPending,
+    handleOpenChange,
+    restart,
+  } = useDeviceCodeFlow<
+    DeviceAuthStartResult,
+    {
+      deviceAuthId: string;
+      userCode: string;
+    }
+  >({
+    open,
+    onOpenChange,
+    onConnected,
+    startMutationOptions: (handlers) =>
+      trpc.chatgptSubscription.startDeviceAuth.mutationOptions(handlers),
+    pollMutationOptions: () =>
+      trpc.chatgptSubscription.pollDeviceAuth.mutationOptions(),
+    getPollInput: (auth) => ({
+      deviceAuthId: auth.deviceAuthId,
+      userCode: auth.userCode,
     }),
-  );
-
-  // Poll results drive the loop below rather than mutation callbacks, so a
-  // single code path owns both stopping the loop and reporting the outcome.
-  const pollMutation = useMutation(
-    trpc.chatgptSubscription.pollDeviceAuth.mutationOptions(),
-  );
-
-  useEffect(() => {
-    if (!open) {
-      pollingRef.current = false;
-      setPolling(false);
-      setDeviceAuth(null);
-      setError(null);
-      setFailureReason(null);
-      return;
-    }
-
-    // Only auto-start the device-code flow once per open. Guard on
-    // startMutation.isError so a failed start does not re-fire on the next
-    // render (deviceAuth stays null and isPending returns to false, which
-    // would otherwise loop with no backoff). The user clicks Restart to
-    // retry explicitly.
-    if (
-      open &&
-      !deviceAuth &&
-      !startMutation.isPending &&
-      !startMutation.isError
-    ) {
-      startMutation.mutate();
-    }
-  }, [open, deviceAuth, startMutation]);
-
-  useEffect(() => {
-    if (!open || !deviceAuth || pollingRef.current) {
-      return;
-    }
-
-    pollingRef.current = true;
-    setPolling(true);
-
-    // The issuer stops accepting the code at this deadline; polling past it
-    // only ever yields `deviceauth_not_found`.
-    const expiresAt = Date.now() + deviceAuth.expiresInMs;
-
-    const poll = async () => {
-      let intervalMs = deviceAuth.intervalMs;
-
-      while (pollingRef.current) {
-        if (Date.now() >= expiresAt) {
-          stopPolling(EXPIRED_CODE_ERROR, 'expired');
-          return;
-        }
-
-        const result: DevicePollResult = await pollMutation.mutateAsync({
-          deviceAuthId: deviceAuth.deviceAuthId,
-          userCode: deviceAuth.userCode,
-        });
-
-        if (!pollingRef.current) {
-          return;
-        }
-
-        if (result.status === 'success') {
-          pollingRef.current = false;
-          setPolling(false);
-          toast.success('ChatGPT subscription connected.');
-          await Promise.all([
-            queryClient.invalidateQueries({
-              queryKey: trpc.taskModels.providerSetup.queryKey(),
-            }),
-            queryClient.invalidateQueries({
-              queryKey: trpc.taskModels.get.queryKey(),
-            }),
-            queryClient.invalidateQueries({
-              queryKey: trpc.taskModels.launchOptions.queryKey(),
-            }),
-            queryClient.invalidateQueries({
-              queryKey: trpc.chatgptSubscription.status.queryKey(),
-            }),
-            queryClient.invalidateQueries({
-              queryKey: trpc.subscriptionUsage.list.queryKey(),
-            }),
-          ]);
-          await onConnected?.();
-          handleOpenChange(false);
-          return;
-        }
-
-        if (result.status === 'failed') {
-          stopPolling(result.error, result.reason ?? null);
-          return;
-        }
-
-        // A rate-limited poll returns the interval to back off to.
-        if (result.intervalMs) {
-          intervalMs = result.intervalMs;
-        }
-
-        const remainingMs = expiresAt - Date.now();
-        if (remainingMs <= 0) {
-          stopPolling(EXPIRED_CODE_ERROR, 'expired');
-          return;
-        }
-
-        await new Promise((resolve) =>
-          setTimeout(resolve, Math.min(intervalMs, remainingMs)),
-        );
-      }
-    };
-
-    void poll().catch((pollError: unknown) => {
-      stopPolling(
-        pollError instanceof Error
-          ? pollError.message
-          : 'ChatGPT authorization polling failed.',
-      );
-    });
-
-    return () => {
-      pollingRef.current = false;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, deviceAuth]);
-
-  function handleOpenChange(next: boolean) {
-    pollingRef.current = false;
-    setPolling(false);
-    onOpenChange(next);
-  }
-
-  function handleRestart() {
-    setDeviceAuth(null);
-    setError(null);
-    setFailureReason(null);
-    // Clear the prior failed mutation state so the start effect can fire
-    // again, then kick off a fresh device-code request.
-    startMutation.reset();
-    startMutation.mutate();
-  }
-
-  const userCode = deviceAuth?.userCode;
-  const verificationUrl = deviceAuth?.verificationUrl;
+    invalidateQueryKeys: () => [
+      trpc.taskModels.providerSetup.queryKey(),
+      trpc.taskModels.get.queryKey(),
+      trpc.taskModels.launchOptions.queryKey(),
+      trpc.chatgptSubscription.status.queryKey(),
+      trpc.subscriptionUsage.list.queryKey(),
+    ],
+    successToast: 'ChatGPT subscription connected.',
+    copy: {
+      expired:
+        'ChatGPT authorization code expired. Restart the connection to get a new code.',
+      startFailed: 'Failed to start ChatGPT authorization.',
+      pollFailed: 'ChatGPT authorization polling failed.',
+    },
+  });
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -245,7 +98,7 @@ export function ChatGptConnectDialog({
         </DialogHeader>
 
         <div className="space-y-4">
-          {startMutation.isPending && !deviceAuth ? (
+          {isStartPending && !deviceAuth ? (
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <Spinner />
               Starting authorization…
@@ -273,13 +126,13 @@ export function ChatGptConnectDialog({
                 </p>
                 <Input
                   readOnly
-                  value={userCode ?? ''}
+                  value={deviceAuth.userCode}
                   aria-label="ChatGPT device authorization code"
                   className="font-mono text-lg tracking-wider"
                   onFocus={(event) => event.currentTarget.select()}
                 />
                 <a
-                  href={verificationUrl}
+                  href={deviceAuth.verificationUrl}
                   target="_blank"
                   rel="noreferrer"
                   className="inline-flex items-center gap-1 text-sm underline underline-offset-4"
@@ -306,12 +159,12 @@ export function ChatGptConnectDialog({
           <Button
             variant="ghost"
             onClick={() => handleOpenChange(false)}
-            disabled={startMutation.isPending}
+            disabled={isStartPending}
           >
             Cancel
           </Button>
           {error ? (
-            <Button variant="outline" onClick={handleRestart}>
+            <Button variant="outline" onClick={restart}>
               Restart
             </Button>
           ) : null}

--- a/apps/web/src/components/settings/GitHubCopilotConnectDialog.tsx
+++ b/apps/web/src/components/settings/GitHubCopilotConnectDialog.tsx
@@ -1,10 +1,7 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner';
-
 import { useTRPC } from '@/trpc/client';
+import { useDeviceCodeFlow } from '@/hooks/useDeviceCodeFlow';
 import {
   Button,
   Dialog,
@@ -36,125 +33,36 @@ export function GitHubCopilotConnectDialog({
   onConnected?: () => void | Promise<void>;
 }) {
   const trpc = useTRPC();
-  const queryClient = useQueryClient();
-  const [deviceAuth, setDeviceAuth] = useState<DeviceAuth | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const pollingRef = useRef(false);
 
-  const startMutation = useMutation(
-    trpc.githubCopilotSubscription.startDeviceAuth.mutationOptions({
-      onSuccess: (result) => {
-        setDeviceAuth(result);
-        setError(null);
+  const { deviceAuth, error, isStartPending, handleOpenChange, restart } =
+    useDeviceCodeFlow<DeviceAuth, { deviceCode: string }>({
+      open,
+      onOpenChange,
+      onConnected,
+      startMutationOptions: (handlers) =>
+        trpc.githubCopilotSubscription.startDeviceAuth.mutationOptions(
+          handlers,
+        ),
+      pollMutationOptions: () =>
+        trpc.githubCopilotSubscription.pollDeviceAuth.mutationOptions(),
+      getPollInput: (auth) => ({ deviceCode: auth.deviceCode }),
+      invalidateQueryKeys: () => [
+        trpc.taskModels.providerSetup.queryKey(),
+        trpc.taskModels.get.queryKey(),
+        trpc.taskModels.launchOptions.queryKey(),
+        trpc.githubCopilotSubscription.status.queryKey(),
+        trpc.subscriptionUsage.list.queryKey(),
+      ],
+      successToast: 'GitHub Copilot subscription connected.',
+      copy: {
+        expired: 'GitHub authorization code expired. Restart the connection.',
+        startFailed: 'Failed to start GitHub authorization.',
+        pollFailed: 'GitHub authorization polling failed.',
       },
-      onError: (mutationError) => setError(mutationError.message),
-    }),
-  );
-  const pollMutation = useMutation(
-    trpc.githubCopilotSubscription.pollDeviceAuth.mutationOptions(),
-  );
-
-  function close(next: boolean) {
-    if (!next) pollingRef.current = false;
-    onOpenChange(next);
-  }
-
-  useEffect(() => {
-    if (!open) {
-      pollingRef.current = false;
-      setDeviceAuth(null);
-      setError(null);
-      return;
-    }
-    if (!deviceAuth && !startMutation.isPending && !startMutation.isError) {
-      startMutation.mutate();
-    }
-  }, [deviceAuth, open, startMutation]);
-
-  useEffect(() => {
-    if (!open || !deviceAuth || pollingRef.current) return;
-    pollingRef.current = true;
-
-    const expiresAt = Date.now() + deviceAuth.expiresInMs;
-
-    const poll = async () => {
-      let intervalMs = deviceAuth.intervalMs;
-      while (pollingRef.current) {
-        if (Date.now() >= expiresAt) {
-          pollingRef.current = false;
-          setError(
-            'GitHub authorization code expired. Restart the connection.',
-          );
-          return;
-        }
-
-        const result = await pollMutation.mutateAsync({
-          deviceCode: deviceAuth.deviceCode,
-        });
-        if (result.status === 'success') {
-          pollingRef.current = false;
-          toast.success('GitHub Copilot subscription connected.');
-          await Promise.all([
-            queryClient.invalidateQueries({
-              queryKey: trpc.taskModels.providerSetup.queryKey(),
-            }),
-            queryClient.invalidateQueries({
-              queryKey: trpc.taskModels.get.queryKey(),
-            }),
-            queryClient.invalidateQueries({
-              queryKey: trpc.taskModels.launchOptions.queryKey(),
-            }),
-            queryClient.invalidateQueries({
-              queryKey: trpc.githubCopilotSubscription.status.queryKey(),
-            }),
-            queryClient.invalidateQueries({
-              queryKey: trpc.subscriptionUsage.list.queryKey(),
-            }),
-          ]);
-          await onConnected?.();
-          close(false);
-          return;
-        }
-        if (result.status === 'failed') {
-          pollingRef.current = false;
-          setError(result.error);
-          return;
-        }
-        // slow_down returns the new absolute poll interval, not a delta.
-        if (result.intervalMs) intervalMs = result.intervalMs;
-
-        const remainingMs = expiresAt - Date.now();
-        if (remainingMs <= 0) {
-          pollingRef.current = false;
-          setError(
-            'GitHub authorization code expired. Restart the connection.',
-          );
-          return;
-        }
-        await new Promise((resolve) =>
-          setTimeout(resolve, Math.min(intervalMs, remainingMs)),
-        );
-      }
-    };
-
-    void poll().catch((pollError: unknown) => {
-      pollingRef.current = false;
-      setError(
-        pollError instanceof Error
-          ? pollError.message
-          : 'GitHub authorization polling failed.',
-      );
     });
-    return () => {
-      pollingRef.current = false;
-    };
-    // The polling lifecycle is intentionally keyed only to the active device
-    // flow; mutation/query objects are recreated by hooks between renders.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [deviceAuth, open]);
 
   return (
-    <Dialog open={open} onOpenChange={close}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent size="md">
         <DialogHeader>
           <DialogTitle>Connect GitHub Copilot</DialogTitle>
@@ -163,7 +71,7 @@ export function GitHubCopilotConnectDialog({
           </DialogDescription>
         </DialogHeader>
 
-        {deviceAuth ? (
+        {deviceAuth && !error ? (
           <div className="space-y-3">
             <p className="text-sm text-muted-foreground">
               Open GitHub, then enter this one-time code:
@@ -188,29 +96,23 @@ export function GitHubCopilotConnectDialog({
               Waiting for authorization…
             </p>
           </div>
-        ) : startMutation.isPending ? (
+        ) : isStartPending ? (
           <div className="flex justify-center py-8">
             <Spinner />
           </div>
         ) : null}
 
-        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        {error ? (
+          <p className="text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        ) : null}
 
         <DialogFooter>
-          <Button variant="outline" onClick={() => close(false)}>
+          <Button variant="outline" onClick={() => handleOpenChange(false)}>
             Cancel
           </Button>
-          {error ? (
-            <Button
-              onClick={() => {
-                setError(null);
-                setDeviceAuth(null);
-                startMutation.reset();
-              }}
-            >
-              Restart
-            </Button>
-          ) : null}
+          {error ? <Button onClick={restart}>Restart</Button> : null}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/web/src/components/settings/XaiConnectDialog.tsx
+++ b/apps/web/src/components/settings/XaiConnectDialog.tsx
@@ -1,10 +1,7 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner';
-
 import { useTRPC } from '@/trpc/client';
+import { useDeviceCodeFlow } from '@/hooks/useDeviceCodeFlow';
 import {
   Button,
   Dialog,
@@ -36,153 +33,35 @@ export function XaiConnectDialog({
   onConnected?: () => void | Promise<void>;
 }) {
   const trpc = useTRPC();
-  const queryClient = useQueryClient();
-  const [deviceAuth, setDeviceAuth] = useState<DeviceAuth | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  /**
-   * Monotonic generation bumped whenever a poll loop must die (close, restart,
-   * unmount). A shared boolean is not enough: cancel + reopen can flip the
-   * flag back to true and revive a stale loop that still holds the previous
-   * device code.
-   */
-  const pollGenerationRef = useRef(0);
 
-  const startMutation = useMutation(
-    trpc.xaiSubscription.startDeviceAuth.mutationOptions({
-      onSuccess: (result) => {
-        setDeviceAuth(result);
-        setError(null);
+  const { deviceAuth, error, isStartPending, handleOpenChange, restart } =
+    useDeviceCodeFlow<DeviceAuth, { deviceCode: string }>({
+      open,
+      onOpenChange,
+      onConnected,
+      startMutationOptions: (handlers) =>
+        trpc.xaiSubscription.startDeviceAuth.mutationOptions(handlers),
+      pollMutationOptions: () =>
+        trpc.xaiSubscription.pollDeviceAuth.mutationOptions(),
+      getPollInput: (auth) => ({ deviceCode: auth.deviceCode }),
+      invalidateQueryKeys: () => [
+        trpc.taskModels.providerSetup.queryKey(),
+        trpc.taskModels.get.queryKey(),
+        trpc.taskModels.launchOptions.queryKey(),
+        trpc.xaiSubscription.status.queryKey(),
+        trpc.subscriptionUsage.list.queryKey(),
+      ],
+      successToast: 'xAI Grok subscription connected.',
+      copy: {
+        expired:
+          'xAI device authorization code expired. Restart the connection.',
+        startFailed: 'Failed to start xAI authorization.',
+        pollFailed: 'xAI authorization polling failed.',
       },
-      onError: (mutationError) => setError(mutationError.message),
-    }),
-  );
-  const pollMutation = useMutation(
-    trpc.xaiSubscription.pollDeviceAuth.mutationOptions(),
-  );
-
-  function invalidatePollLoops() {
-    pollGenerationRef.current += 1;
-  }
-
-  function close(next: boolean) {
-    if (!next) {
-      invalidatePollLoops();
-    }
-    onOpenChange(next);
-  }
-
-  useEffect(() => {
-    if (!open) {
-      invalidatePollLoops();
-      setDeviceAuth(null);
-      setError(null);
-      return;
-    }
-    if (!deviceAuth && !startMutation.isPending && !startMutation.isError) {
-      startMutation.mutate();
-    }
-  }, [deviceAuth, open, startMutation]);
-
-  useEffect(() => {
-    if (!open || !deviceAuth) {
-      return;
-    }
-
-    const generation = ++pollGenerationRef.current;
-    const activeDeviceCode = deviceAuth.deviceCode;
-    const expiresAt = Date.now() + deviceAuth.expiresInMs;
-
-    const poll = async () => {
-      let intervalMs = deviceAuth.intervalMs;
-      while (pollGenerationRef.current === generation) {
-        if (Date.now() >= expiresAt) {
-          setError(
-            'xAI device authorization code expired. Restart the connection.',
-          );
-          return;
-        }
-
-        const result = await pollMutation.mutateAsync({
-          deviceCode: activeDeviceCode,
-        });
-        // Another open/close/restart may have started while we awaited.
-        if (pollGenerationRef.current !== generation) {
-          return;
-        }
-        if (result.status === 'success') {
-          toast.success('xAI Grok subscription connected.');
-          await Promise.all([
-            queryClient.invalidateQueries({
-              queryKey: trpc.taskModels.providerSetup.queryKey(),
-            }),
-            queryClient.invalidateQueries({
-              queryKey: trpc.taskModels.get.queryKey(),
-            }),
-            queryClient.invalidateQueries({
-              queryKey: trpc.taskModels.launchOptions.queryKey(),
-            }),
-            queryClient.invalidateQueries({
-              queryKey: trpc.xaiSubscription.status.queryKey(),
-            }),
-            queryClient.invalidateQueries({
-              queryKey: trpc.subscriptionUsage.list.queryKey(),
-            }),
-          ]);
-          if (pollGenerationRef.current !== generation) {
-            return;
-          }
-          await onConnected?.();
-          if (pollGenerationRef.current !== generation) {
-            return;
-          }
-          close(false);
-          return;
-        }
-        if (result.status === 'failed') {
-          setError(result.error);
-          return;
-        }
-        // slow_down returns the new absolute poll interval, not a delta.
-        if (result.intervalMs) {
-          intervalMs = result.intervalMs;
-        }
-
-        const remainingMs = expiresAt - Date.now();
-        if (remainingMs <= 0) {
-          setError(
-            'xAI device authorization code expired. Restart the connection.',
-          );
-          return;
-        }
-        await new Promise((resolve) =>
-          setTimeout(resolve, Math.min(intervalMs, remainingMs)),
-        );
-      }
-    };
-
-    void poll().catch((pollError: unknown) => {
-      if (pollGenerationRef.current !== generation) {
-        return;
-      }
-      setError(
-        pollError instanceof Error
-          ? pollError.message
-          : 'xAI authorization polling failed.',
-      );
     });
-    return () => {
-      // Invalidate only this effect's generation when deviceAuth/open change.
-      if (pollGenerationRef.current === generation) {
-        pollGenerationRef.current += 1;
-      }
-    };
-    // The polling lifecycle is intentionally keyed only to the active device
-    // flow; mutation/query objects are recreated by hooks between renders.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [deviceAuth, open]);
 
   return (
-    <Dialog open={open} onOpenChange={close}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent size="md">
         <DialogHeader>
           <DialogTitle>Connect xAI Grok subscription</DialogTitle>
@@ -192,7 +71,7 @@ export function XaiConnectDialog({
           </DialogDescription>
         </DialogHeader>
 
-        {deviceAuth ? (
+        {deviceAuth && !error ? (
           <div className="space-y-3">
             <p className="text-sm text-muted-foreground">
               Open xAI, then enter this one-time code:
@@ -217,30 +96,23 @@ export function XaiConnectDialog({
               Waiting for authorization…
             </p>
           </div>
-        ) : startMutation.isPending ? (
+        ) : isStartPending ? (
           <div className="flex justify-center py-8">
             <Spinner />
           </div>
         ) : null}
 
-        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        {error ? (
+          <p className="text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        ) : null}
 
         <DialogFooter>
-          <Button variant="outline" onClick={() => close(false)}>
+          <Button variant="outline" onClick={() => handleOpenChange(false)}>
             Cancel
           </Button>
-          {error ? (
-            <Button
-              onClick={() => {
-                invalidatePollLoops();
-                setError(null);
-                setDeviceAuth(null);
-                startMutation.reset();
-              }}
-            >
-              Restart
-            </Button>
-          ) : null}
+          {error ? <Button onClick={restart}>Restart</Button> : null}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/web/src/hooks/useDeviceCodeFlow.ts
+++ b/apps/web/src/hooks/useDeviceCodeFlow.ts
@@ -1,0 +1,282 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { QueryKey, UseMutationOptions } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+/**
+ * Shared lifecycle for OAuth device-code connect dialogs (ChatGPT, xAI,
+ * GitHub Copilot). The dialogs supply provider-specific config (mutations,
+ * query keys, copy) and render the result; this hook owns the polling loop.
+ *
+ * Lifecycle semantics follow the hardened ChatGPT dialog (expiry deadline,
+ * failure reasons, slow-down backoff, rejected-poll surfacing). Cancellation
+ * uses the xAI dialog's monotonic generation counter rather than a shared
+ * boolean: cancel + reopen can flip a boolean back to true and revive a stale
+ * loop that still holds the previous device code, while a retired generation
+ * can never match again.
+ */
+
+/** Minimum shape every provider's start mutation must resolve to. */
+type DeviceCodeStartResult = {
+  userCode: string;
+  verificationUrl: string;
+  intervalMs: number;
+  /**
+   * Relative validity window rather than an absolute timestamp so clock skew
+   * between server and browser cannot expire a code early or late.
+   */
+  expiresInMs: number;
+};
+
+/**
+ * Why a poll ended terminally. `blocked` is a refusal waiting cannot resolve
+ * (e.g. an org policy blocking the OAuth app); `expired` means the code aged
+ * out, whether reported by the issuer or by the client-side deadline.
+ */
+type DeviceCodePollFailureReason = 'blocked' | 'expired';
+
+type DeviceCodePollResult =
+  | { status: 'pending'; intervalMs?: number }
+  | { status: 'success' }
+  | { status: 'failed'; error: string; reason?: DeviceCodePollFailureReason };
+
+type StartMutationHandlers<TAuth> = {
+  onSuccess: (result: TAuth) => void;
+  onError: (error: unknown) => void;
+};
+
+type UseDeviceCodeFlowConfig<
+  TAuth extends DeviceCodeStartResult,
+  TPollInput,
+> = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Invoked once after a successful connect, after query invalidations. */
+  onConnected?: () => void | Promise<void>;
+  /**
+   * Build the start mutation's options with the hook's handlers attached,
+   * e.g. `(handlers) => trpc.x.startDeviceAuth.mutationOptions(handlers)`.
+   * The handlers must reach the returned options untouched; the hook relies
+   * on them to receive the device auth result.
+   *
+   * Typed as `object` rather than tanstack's `UseMutationOptions` because
+   * tRPC's generated option type carries its own error and context generics
+   * that do not structurally assign to the plain tanstack shape; the runtime
+   * contract is identical and the hook casts at the `useMutation` boundary.
+   */
+  startMutationOptions: (handlers: StartMutationHandlers<TAuth>) => object;
+  /** Build the poll mutation's options, with no handlers attached. */
+  pollMutationOptions: () => object;
+  /** Map the start result to the poll mutation's input payload. */
+  getPollInput: (auth: TAuth) => TPollInput;
+  /** Query keys to invalidate after a successful connect. */
+  invalidateQueryKeys: () => QueryKey[];
+  successToast: string;
+  copy: {
+    /** Shown when the client-side expiry deadline passes. */
+    expired: string;
+    /** Fallback when the start mutation rejects without an Error message. */
+    startFailed: string;
+    /** Fallback when a poll rejects without an Error message. */
+    pollFailed: string;
+  };
+};
+
+export function useDeviceCodeFlow<
+  TAuth extends DeviceCodeStartResult,
+  TPollInput,
+>(config: UseDeviceCodeFlowConfig<TAuth, TPollInput>) {
+  const {
+    open,
+    onOpenChange,
+    onConnected,
+    getPollInput,
+    invalidateQueryKeys,
+    successToast,
+    copy,
+  } = config;
+  const queryClient = useQueryClient();
+  const [deviceAuth, setDeviceAuth] = useState<TAuth | null>(null);
+  const [polling, setPolling] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [failureReason, setFailureReason] =
+    useState<DeviceCodePollFailureReason | null>(null);
+  /**
+   * Monotonic generation bumped whenever every in-flight poll loop must die
+   * (close, restart, terminal outcome, effect cleanup). A loop only acts
+   * while its own generation is still current.
+   */
+  const generationRef = useRef(0);
+
+  const startMutation = useMutation(
+    config.startMutationOptions({
+      onSuccess: (result) => {
+        setDeviceAuth(result);
+        setError(null);
+      },
+      onError: (startError) => {
+        setError(
+          startError instanceof Error ? startError.message : copy.startFailed,
+        );
+      },
+    }) as UseMutationOptions<TAuth, Error, void>,
+  );
+
+  // Poll results drive the loop below rather than mutation callbacks, so a
+  // single code path owns both stopping the loop and reporting the outcome.
+  const pollMutation = useMutation(
+    config.pollMutationOptions() as UseMutationOptions<
+      DeviceCodePollResult,
+      Error,
+      TPollInput
+    >,
+  );
+
+  useEffect(() => {
+    if (!open) {
+      generationRef.current += 1;
+      setPolling(false);
+      setDeviceAuth(null);
+      setError(null);
+      setFailureReason(null);
+      return;
+    }
+
+    // Only auto-start the device-code flow once per open. Guard on
+    // startMutation.isError so a failed start does not re-fire on the next
+    // render (deviceAuth stays null and isPending returns to false, which
+    // would otherwise loop with no backoff). The user clicks Restart to
+    // retry explicitly.
+    if (!deviceAuth && !startMutation.isPending && !startMutation.isError) {
+      startMutation.mutate();
+    }
+  }, [open, deviceAuth, startMutation]);
+
+  useEffect(() => {
+    if (!open || !deviceAuth) {
+      return;
+    }
+
+    const generation = ++generationRef.current;
+    const isCurrent = () => generationRef.current === generation;
+    // The issuer stops accepting the code at this deadline; polling past it
+    // can never succeed.
+    const expiresAt = Date.now() + deviceAuth.expiresInMs;
+    setPolling(true);
+
+    const fail = (
+      message: string,
+      reason: DeviceCodePollFailureReason | null = null,
+    ) => {
+      generationRef.current += 1;
+      setPolling(false);
+      setError(message);
+      setFailureReason(reason);
+    };
+
+    const poll = async () => {
+      let intervalMs = deviceAuth.intervalMs;
+
+      while (isCurrent()) {
+        if (Date.now() >= expiresAt) {
+          fail(copy.expired, 'expired');
+          return;
+        }
+
+        const result = await pollMutation.mutateAsync(getPollInput(deviceAuth));
+
+        // Another open/close/restart may have started while we awaited.
+        if (!isCurrent()) {
+          return;
+        }
+
+        if (result.status === 'success') {
+          // Retire this loop before the awaits below so a slow invalidation
+          // cannot overlap a restarted flow.
+          generationRef.current += 1;
+          setPolling(false);
+          toast.success(successToast);
+          await Promise.all(
+            invalidateQueryKeys().map((queryKey) =>
+              queryClient.invalidateQueries({ queryKey }),
+            ),
+          );
+          await onConnected?.();
+          onOpenChange(false);
+          return;
+        }
+
+        if (result.status === 'failed') {
+          fail(result.error, result.reason ?? null);
+          return;
+        }
+
+        // A slow-down/rate-limited poll returns the new absolute interval to
+        // back off to, not a delta.
+        if (result.intervalMs) {
+          intervalMs = result.intervalMs;
+        }
+
+        const remainingMs = expiresAt - Date.now();
+        if (remainingMs <= 0) {
+          fail(copy.expired, 'expired');
+          return;
+        }
+
+        await new Promise((resolve) =>
+          setTimeout(resolve, Math.min(intervalMs, remainingMs)),
+        );
+      }
+    };
+
+    void poll().catch((pollError: unknown) => {
+      // A stale loop's rejection must not clobber a newer flow's state.
+      if (!isCurrent()) {
+        return;
+      }
+      fail(pollError instanceof Error ? pollError.message : copy.pollFailed);
+    });
+
+    return () => {
+      // Invalidate only this effect's generation when deviceAuth/open change.
+      if (isCurrent()) {
+        generationRef.current += 1;
+      }
+    };
+    // The polling lifecycle is intentionally keyed only to the active device
+    // flow; mutation/query objects are recreated by hooks between renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, deviceAuth]);
+
+  function handleOpenChange(next: boolean) {
+    if (!next) {
+      generationRef.current += 1;
+      setPolling(false);
+    }
+    onOpenChange(next);
+  }
+
+  function restart() {
+    generationRef.current += 1;
+    setPolling(false);
+    setDeviceAuth(null);
+    setError(null);
+    setFailureReason(null);
+    // Clear the prior failed mutation state so the start effect can fire
+    // again, then kick off a fresh device-code request.
+    startMutation.reset();
+    startMutation.mutate();
+  }
+
+  return {
+    deviceAuth,
+    error,
+    failureReason,
+    polling,
+    isStartPending: startMutation.isPending,
+    handleOpenChange,
+    restart,
+  };
+}


### PR DESCRIPTION
## Problem

Three OAuth device-code connect dialogs each reimplemented the same polling lifecycle, and they had drifted:

| Dialog | Lines before | Expiry deadline | Failure reasons | 429 backoff | Poll `.catch()` | Stale-loop protection |
| --- | --- | --- | --- | --- | --- | --- |
| ChatGPT | 322 | yes | yes | yes | yes | boolean (racy) |
| xAI | 248 | yes | no | yes | yes | generation counter |
| GitHub Copilot | 218 | yes | no | yes | yes | boolean (racy) |

Every future fix had to be made three times, and drift shows it wasn't: the ChatGPT hardening in #1025 never reached the other two, and xAI's stale-loop fix never reached ChatGPT or Copilot.

## Change

One `useDeviceCodeFlow` hook owns the lifecycle: start-once-per-open guard, client-side expiry deadline, slow-down backoff, terminal success (toast, query invalidations, `onConnected`, close), terminal failure with reasons, restart, and the poll `.catch()`. The dialogs become presentational shells (175/120/120 lines) supplying provider-specific mutations, query keys, and copy.

The hook merges the strongest behavior from each source rather than crowning one:

- **From ChatGPT (#1025):** expiry deadline, `blocked`/`expired` failure reasons driving dedicated copy, rate-limit backoff, rejected-poll surfacing.
- **From xAI:** monotonic generation-counter cancellation instead of a shared boolean. The boolean has a real race the xAI dialog documented: cancel plus a quick reopen flips it back to `true` and revives a stale loop still polling the previous device code. A retired generation can never match again. ChatGPT and Copilot gain this fix.

Behavior gains for xAI and Copilot: failure-reason plumbing, and hiding the dead device code once a terminal error is shown instead of leaving it next to the error. The per-provider "authorization code expired" sentence becomes one config value per dialog instead of duplicated literals; server-side copies are untouched and remain produce-only.

## Notes

- Both existing dialog test suites (`ChatGptConnectDialog.test.tsx`, `XaiConnectDialog.test.tsx`) pass **unchanged** — they mock `@/trpc/client` and `@tanstack/react-query` directly, and the hook preserves the mutation-options shapes they discriminate on.
- The hook types its two mutation-options config fields as `object` and casts at the `useMutation` boundary: tRPC's generated option types carry their own error/context generics that don't structurally assign to tanstack's plain `UseMutationOptions`. The handlers contract stays fully typed.
- No server-side changes; client-only refactor.

## Testing

- Settings + setup suites: 58 files / 619 tests green.
- Full web suite: 2651/2652 green; the failing automations tests (`settings-read`, `settings-update-discord`) fail identically on clean develop with this diff stashed — pre-existing, unrelated.
- `pnpm lint`, `pnpm check-types`, `pnpm knip` clean.

🤖 Generated with Claude Code
