### PR TITLE
[Fix] Restore command output display in the web task view

### DIFF
--- a/.changeset/task-view-command-output.md
+++ b/.changeset/task-view-command-output.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Show command output again in the web task view. Terminal commands render their output as a collapsible block (collapsed by default, capped at 400px) with a copy button, and expanded details are restored for command items inside grouped tool calls. Expanded file-read contents remain hidden.

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/AcpCommandOutputMessage.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/AcpCommandOutputMessage.tsx
@@ -46,6 +46,7 @@ export const AcpCommandOutputMessage = ({
 
   const output = sanitizeSandboxPathString(cmd.text);
 
+  const isOutputPresent = output.trim().length > 0;
   const isExitCodePresent = cmd.exitCode !== undefined;
   const isPending =
     status === 'in_progress' || (status === null && !isExitCodePresent);
@@ -69,14 +70,14 @@ export const AcpCommandOutputMessage = ({
           code={output}
           language="bash"
           variant="compact"
-          collapsible={false}
-          defaultCollapsed={false}
+          collapsible={isOutputPresent}
+          defaultCollapsed={isOutputPresent}
           forceDark={true}
-          renderContent={false}
-          maxHeight={undefined}
+          renderContent={isOutputPresent}
+          maxHeight={isOutputPresent ? 400 : undefined}
           command={command ?? ''}
           showCommandCopy
-          showOutputCopy={false}
+          showOutputCopy={isOutputPresent}
         >
           <CodeBlockHeader className="w-full">
             <CodeBlockTitle>

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/AcpCommandOutputMessage.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/AcpCommandOutputMessage.client.test.tsx
@@ -50,7 +50,7 @@ describe('AcpCommandOutputMessage', () => {
     codeBlockCommandSpy.mockClear();
   });
 
-  it('renders command headers without expandable raw output', () => {
+  it('renders command output blocks as collapsible and collapsed by default', () => {
     const msg: AcpToolResultUiMessage = {
       ...baseMsg,
       text: '$ pnpm test\nPASS src/example.test.ts',
@@ -75,17 +75,17 @@ describe('AcpCommandOutputMessage', () => {
     expect(codeBlockSpy).toHaveBeenCalledTimes(1);
     expect(codeBlockSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        collapsible: false,
-        defaultCollapsed: false,
-        renderContent: false,
-        maxHeight: undefined,
+        collapsible: true,
+        defaultCollapsed: true,
+        renderContent: true,
+        maxHeight: 400,
         showCommandCopy: true,
-        showOutputCopy: false,
+        showOutputCopy: true,
       }),
     );
   });
 
-  it('keeps command output blocks non-collapsible even when there is no output to show', () => {
+  it('does not enable collapsible mode when there is no output to show', () => {
     const msg: AcpToolCallUiMessage = {
       ...baseMsg,
       text: '   \n',

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/tool-detail-visibility.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/tool-detail-visibility.ts
@@ -84,9 +84,6 @@ export function hidesExpandedToolResult(
   return (
     isInternalDebugToolCallMessage(msg) ||
     msg.data.kind === 'read' ||
-    msg.data.kind === 'execute' ||
-    msg.data.kind === 'execute_command' ||
-    data.isRead === true ||
-    data.isExecute === true
+    data.isRead === true
   );
 }


### PR DESCRIPTION
## Summary

Command output is currently not rendered in the web task view: terminal command messages show only the command line and exit code, and expanded details are suppressed for command items inside grouped tool calls. This restores the output display.

## Changes

- `AcpCommandOutputMessage.tsx` — reintroduces the `isOutputPresent` check, so a command with output renders as a collapsible code block (collapsed by default, 400px max height) with an output copy button. Commands with no output still render as a plain header.
- `tool-detail-visibility.ts` — drops the `execute` / `execute_command` / `isExecute` branches from `hidesExpandedToolResult`, restoring expandable details for command items in grouped tool messages and for execute-flavored calls routed through `AcpToolMessage`.
- Tests updated to match.

## Scope

Expanded **file-read** contents remain hidden. `hidesExpandedToolResult` keeps its `read` / `isRead` branches, along with the internal-debug and subagent-payload handling it has since grown. Only the command path is changed.

The structural changes that introduced `hidesExpandedToolResult` (the `collapsible={showExpandedDetails}` prop and conditional `ToolContent` in `AcpToolMessage` / `AcpGroupedToolMessage`) are left in place, since the subagent and internal-debug features now rely on them.

## Note for reviewers

Hiding this output was a deliberate change, made so that expanding a tool call would not surface raw command output in the transcript. Restoring it re-exposes that output to anyone who can view a task. `sanitizeSandboxPathString` still runs over the text, but it only rewrites sandbox paths and does not redact other content. Worth a look if transcripts are shareable in your deployment.

## Testing

- `vitest run` over the ACP message tests: 185 passed
- `pnpm check-types:fast` and `pnpm lint` clean