### PR TITLE
Fix DeepSeek Flash model ID for OpenCode Zen

### DIFF
--- a/packages/cloud-agents/src/server/__tests__/harness-model-overrides.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/harness-model-overrides.test.ts
@@ -197,4 +197,20 @@ describe('resolveEffectiveHarnessModelState', () => {
 
     expect(task.payload.reasoningEffort).toBe('xhigh');
   });
+
+  it('migrates a legacy OpenCode model override during snapshot resume', () => {
+    const { model, task } = resolveEffectiveHarnessModelState({
+      task: makeTask(),
+      targetHarness: 'opencode-server',
+      isSnapshotResume: true,
+      sourceRunHarnessModelOverrides: {
+        'opencode-server': 'opencode/deepseek-v4-flash-0731',
+      },
+    });
+
+    expect(model).toBe('opencode/deepseek-v4-flash');
+    expect(task.payload.harnessModelOverrides).toEqual({
+      'opencode-server': 'opencode/deepseek-v4-flash',
+    });
+  });
 });

--- a/packages/cloud-agents/src/server/harness-model-overrides.ts
+++ b/packages/cloud-agents/src/server/harness-model-overrides.ts
@@ -49,8 +49,12 @@ function applyHarnessModelOverrides<T extends TaskSpec>(
     task.payload.harnessModelOverrides,
     'opencode-server',
   );
+  const sourceOverride = getHarnessModelOverride(
+    harnessModelOverrides,
+    'opencode-server',
+  );
 
-  if (!harnessModelOverrides || currentOverride) {
+  if (!sourceOverride || currentOverride) {
     return task;
   }
 
@@ -60,7 +64,7 @@ function applyHarnessModelOverrides<T extends TaskSpec>(
       ...task.payload,
       harnessModelOverrides: {
         ...(task.payload.harnessModelOverrides ?? {}),
-        ...harnessModelOverrides,
+        'opencode-server': sourceOverride,
       },
     },
   };

--- a/packages/types/src/__tests__/task-runs.test.ts
+++ b/packages/types/src/__tests__/task-runs.test.ts
@@ -11,6 +11,7 @@ import {
   getCommunicationThreadIdFromTaskPayload,
   getDiscordReactionTargetFromTaskPayload,
   getDiscordIntakeAckReactionTargetFromTaskPayload,
+  getHarnessModelOverride,
   getSlackChannelFromTaskPayload,
   getSlackThreadTsFromTaskPayload,
   getTaskToolActionIdFromInvocation,
@@ -652,6 +653,17 @@ describe('taskSpecSchema', () => {
     expect(parsed.payload.harnessModelOverrides?.['opencode-server']).toBe(
       'provider-id/model-id',
     );
+  });
+
+  it('resolves legacy OpenCode model aliases from harness overrides', () => {
+    expect(
+      getHarnessModelOverride(
+        {
+          'opencode-server': 'opencode/deepseek-v4-flash-0731',
+        },
+        'opencode-server',
+      ),
+    ).toBe('opencode/deepseek-v4-flash');
   });
 
   it('parses hidden StandardTask bootstrap metadata without changing the description', () => {

--- a/packages/types/src/model-provider-config.test.ts
+++ b/packages/types/src/model-provider-config.test.ts
@@ -54,6 +54,26 @@ describe('normalizeDeploymentModelConfig', () => {
     });
   });
 
+  it('migrates persisted OpenCode DeepSeek Flash role models', () => {
+    expect(
+      normalizeDeploymentModelConfig({
+        roomoteModel: 'opencode/deepseek-v4-flash-0731',
+        roomoteSmallModel: 'opencode/deepseek-v4-flash-0731',
+        roomoteVisionModel: 'opencode/deepseek-v4-flash-0731',
+        roomoteCodeReviewModel: 'opencode/deepseek-v4-flash-0731',
+        roomoteExploreModel: 'opencode/deepseek-v4-flash-0731',
+        roomotePlanningModel: 'opencode/deepseek-v4-flash-0731',
+      }),
+    ).toMatchObject({
+      roomoteModel: 'opencode/deepseek-v4-flash',
+      roomoteSmallModel: 'opencode/deepseek-v4-flash',
+      roomoteVisionModel: 'opencode/deepseek-v4-flash',
+      roomoteCodeReviewModel: 'opencode/deepseek-v4-flash',
+      roomoteExploreModel: 'opencode/deepseek-v4-flash',
+      roomotePlanningModel: 'opencode/deepseek-v4-flash',
+    });
+  });
+
   it('coerces missing fields to null without dropping model keys', () => {
     expect(
       normalizeDeploymentModelConfig({ roomoteModel: 'openai/gpt-5.4' }),

--- a/packages/types/src/model-provider-config.test.ts
+++ b/packages/types/src/model-provider-config.test.ts
@@ -438,6 +438,37 @@ describe('SETUP_MODEL_PROVIDER_CATALOG', () => {
     ]);
   });
 
+  it("uses each provider's DeepSeek V4 Flash 0731 model slug", () => {
+    const deepSeekFlashByProvider = SETUP_MODEL_PROVIDER_CATALOG.flatMap(
+      (provider) => {
+        const model = provider.suggestedTaskModels.find(
+          (suggestion) => suggestion.displayName === 'DeepSeek V4 Flash 0731',
+        );
+
+        return model ? [{ providerId: provider.id, modelId: model.id }] : [];
+      },
+    );
+
+    expect(deepSeekFlashByProvider).toEqual([
+      {
+        providerId: 'openrouter',
+        modelId: 'openrouter/deepseek/deepseek-v4-flash-0731',
+      },
+      {
+        providerId: 'vercel',
+        modelId: 'vercel/deepseek/deepseek-v4-flash-0731',
+      },
+      {
+        providerId: 'baseten',
+        modelId: 'baseten/deepseek-ai/DeepSeek-V4-Flash-0731',
+      },
+      {
+        providerId: 'opencode',
+        modelId: 'opencode/deepseek-v4-flash',
+      },
+    ]);
+  });
+
   it('registers Kimi for Coding as an Anthropic-style API-key provider', () => {
     expect(getSetupModelProvider('kimi-for-coding')).toMatchObject({
       id: 'kimi-for-coding',

--- a/packages/types/src/model-provider-config.ts
+++ b/packages/types/src/model-provider-config.ts
@@ -14,6 +14,7 @@ import {
   ENABLED_DIRECT_TASK_MODEL_PROVIDER_IDS,
   getTaskModelProviderId,
   isTaskModelIdDisabled,
+  resolveTaskModelIdAlias,
 } from './task-models';
 import {
   OPENAI_COMPATIBLE_PROVIDER_ID,
@@ -1192,7 +1193,10 @@ export function normalizeDeploymentModelConfig(
   const normalizeEnabledModel = (
     model: string | null | undefined,
   ): string | null => {
-    const normalizedModel = normalizeOptionalString(model);
+    const trimmedModel = normalizeOptionalString(model);
+    const normalizedModel = trimmedModel
+      ? resolveTaskModelIdAlias(trimmedModel)
+      : null;
 
     return normalizedModel && !isTaskModelIdDisabled(normalizedModel)
       ? normalizedModel

--- a/packages/types/src/model-provider-config.ts
+++ b/packages/types/src/model-provider-config.ts
@@ -579,7 +579,8 @@ export const SETUP_MODEL_PROVIDER_CATALOG = [
       'gpt-5-6-luna': 'opencode/gpt-5.6-luna',
       'gemini-3-1-pro': 'opencode/gemini-3.1-pro',
       'gemini-3-6-flash': 'opencode/gemini-3.6-flash',
-      'deepseek-v4-flash-0731': 'opencode/deepseek-v4-flash-0731',
+      // Zen serves the dated Flash release under this stable model alias.
+      'deepseek-v4-flash-0731': 'opencode/deepseek-v4-flash',
       'deepseek-v4-pro': 'opencode/deepseek-v4-pro',
       'glm-5-2': 'opencode/glm-5.2',
       'kimi-k3': 'opencode/kimi-k3',

--- a/packages/types/src/task-models.test.ts
+++ b/packages/types/src/task-models.test.ts
@@ -136,6 +136,32 @@ describe('task model settings', () => {
     });
   });
 
+  it('migrates persisted OpenCode DeepSeek Flash model settings', () => {
+    const settings = normalizeTaskModelSettings({
+      models: [
+        {
+          id: 'opencode/deepseek-v4-flash-0731',
+          displayName: 'DeepSeek V4 Flash 0731',
+          family: 'DeepSeek',
+        },
+      ],
+      allowedModelIds: ['opencode/deepseek-v4-flash-0731'],
+      defaultModelId: 'opencode/deepseek-v4-flash-0731',
+    });
+
+    expect(settings).toEqual({
+      models: [
+        {
+          id: 'opencode/deepseek-v4-flash',
+          displayName: 'DeepSeek V4 Flash 0731',
+          family: 'DeepSeek',
+        },
+      ],
+      allowedModelIds: ['opencode/deepseek-v4-flash'],
+      defaultModelId: 'opencode/deepseek-v4-flash',
+    });
+  });
+
   it('uses only enabled models when building launch options', () => {
     const settings = {
       models: DEFAULT_TASK_MODEL_SETTINGS.models,

--- a/packages/types/src/task-models.ts
+++ b/packages/types/src/task-models.ts
@@ -219,8 +219,18 @@ export function isTaskModelIdDisabled(modelId: string): boolean {
     : false;
 }
 
+const TASK_MODEL_ID_ALIASES: Readonly<Record<string, string>> = {
+  // OpenCode Zen serves this dated release through an undated stable alias.
+  'opencode/deepseek-v4-flash-0731': 'opencode/deepseek-v4-flash',
+};
+
+/** Rewrites model IDs that Roomote persisted before a provider slug changed. */
+export function resolveTaskModelIdAlias(modelId: string): string {
+  return TASK_MODEL_ID_ALIASES[modelId] ?? modelId;
+}
+
 export function normalizeTaskModelId(modelId: string): string {
-  const trimmedModelId = modelId.trim();
+  const trimmedModelId = resolveTaskModelIdAlias(modelId.trim());
 
   if (
     trimmedModelId &&

--- a/packages/types/src/task-runs.ts
+++ b/packages/types/src/task-runs.ts
@@ -15,6 +15,7 @@ import { SANDBOX_SNAPSHOT_EXPIRY_MS } from './compute-providers/worker-runtime';
 import { prActions } from './cloud-agents';
 import { ALL_REPOSITORIES } from './constants';
 import { sourceControlProviderSchema } from './source-control';
+import { resolveTaskModelIdAlias } from './task-models';
 
 /**
  * Task classification vocabulary.
@@ -488,7 +489,7 @@ export function getHarnessModelOverride(
   const override = overrides?.[harness];
 
   return typeof override === 'string' && override.trim().length > 0
-    ? override.trim()
+    ? resolveTaskModelIdAlias(override.trim())
     : undefined;
 }
 


### PR DESCRIPTION
## Summary

- map the recommended DeepSeek V4 Flash 0731 model to OpenCode Zen's stable `opencode/deepseek-v4-flash` alias
- keep the dated provider slugs for OpenRouter, Vercel AI Gateway, and Baseten
- add regression coverage for each provider-specific model ID

## Root cause

The dated `deepseek-v4-flash-0731` slug was applied to every supported provider. OpenCode Zen serves that release through its stable `deepseek-v4-flash` alias, so requests using the dated OpenCode slug were rejected as unsupported.

## Impact

Roomote's OpenCode Zen model recommendation now launches tasks with the provider-supported model ID. Other providers continue using their existing dated IDs.

## Validation

- `pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/types exec vitest run src/model-provider-config.test.ts`
- `pnpm --filter @roomote/types check-types`
- `pnpm --filter @roomote/types lint`
- pre-push oxlint, residual lint, fast type checks, and knip
