### PR TITLE
Show actionable provider error links

### DIFF
--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
@@ -3366,6 +3366,59 @@ describe('OpenCodeServerHarness', () => {
     }
   });
 
+  it('preserves actionable links in readable provider errors', async () => {
+    const { client, harness } = createHarness();
+    const persistedEnvelopes: AcpPersistedEnvelope[] = [];
+
+    harness.subscribeRuntimePersistedEnvelope((envelope) =>
+      persistedEnvelopes.push(envelope),
+    );
+
+    try {
+      await connectHarness(harness, client);
+      expect(
+        harness.sendCommand({
+          commandName: TaskCommandName.StartNewTask,
+          data: { text: 'Start work.', visibleInTranscript: true },
+        }),
+      ).toBe(true);
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(1);
+      });
+
+      await client.emit({
+        type: 'session.error',
+        properties: {
+          sessionID: 'ses_1',
+          error: {
+            name: 'APIError',
+            data: {
+              message:
+                'This model requires explicit region opt in: https://provider.example/settings/region',
+              statusCode: 403,
+              isRetryable: false,
+              responseBody: '{"type":"error","error":{"type":"RegionError"}}',
+            },
+          },
+        },
+      });
+
+      const errorMessage = persistedEnvelopes.find(
+        (envelope) =>
+          envelope.eventType === ACP_ENVELOPE_EVENT_TYPES.AssistantMessage &&
+          String(envelope.payload.text ?? '').includes(
+            'The provider returned an error',
+          ),
+      );
+
+      expect(String(errorMessage?.payload.text)).toBe(
+        'The provider returned an error: This model requires explicit region opt in: https://provider.example/settings/region',
+      );
+    } finally {
+      harness.dispose();
+    }
+  });
+
   it('does not persist credential-shaped provider headers', async () => {
     const { client, harness } = createHarness();
     const persistedEnvelopes: AcpPersistedEnvelope[] = [];

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
@@ -1055,7 +1055,7 @@ function isOpenCodeMessageAbortedError(error: unknown): boolean {
 const MAX_RESOLVED_USER_INPUT_REQUEST_IDS = 256;
 const MAX_PROVIDER_ERROR_SUMMARY_CHARS = 500;
 const UNSAFE_PROVIDER_ERROR_SUMMARY_PATTERN =
-  /\r|\n|https?:\/\/|\b(?:headers?|response[_ -]?body|stack|traceback)\b|\b(?:[a-z][a-z0-9-]*-[a-z0-9-]+|authorization|cookie|host|user-agent)\s*:\s*\S+/i;
+  /\r|\n|\b(?:headers?|response[_ -]?body|stack|traceback)\b|\b(?:[a-z][a-z0-9-]*-[a-z0-9-]+|authorization|cookie|host|user-agent)\s*:\s*\S+/i;
 
 function isJsonProviderErrorMessage(message: string): boolean {
   if (!message.startsWith('{') && !message.startsWith('[')) {


### PR DESCRIPTION
## Summary

- preserve actionable links in human-readable provider error messages
- continue redacting secrets and rejecting raw JSON or header diagnostics
- add regression coverage for a non-retryable region opt-in error

## Root cause

The terminal provider-error formatter treated any message containing an HTTP URL as unsafe. That discarded otherwise useful provider guidance and caused the task UI to show only the generic fallback.

## Impact

The existing provider-error card can now show the provider's specific explanation and action link while the diagnostic payload remains excluded.

## Validation

- `pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/worker exec vitest run src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts`
- `pnpm --filter @roomote/worker check-types`
- `pnpm --filter @roomote/worker lint`
- pre-push Oxlint, residual lint, fast typechecks, and Knip
