### PR TITLE
[Fix] Restore the license public key and unblock Cloud-hosted seat limits

### DIFF
--- a/apps/web/src/lib/server/__tests__/license.test.ts
+++ b/apps/web/src/lib/server/__tests__/license.test.ts
@@ -2,7 +2,9 @@ import { generateKeyPairSync, sign } from 'node:crypto';
 
 import {
   FREE_SEAT_LIMIT,
+  getEffectiveSeatLimit,
   getEnvLicenseKey,
+  LICENSE_PUBLIC_KEY_SPKI_B64,
   resolveConfiguredLicenseKey,
   resolveLicenseState,
   verifyLicenseKey,
@@ -169,6 +171,89 @@ describe('resolveLicenseState', () => {
         publicKeySpkiB64,
       ),
     ).toMatchObject({ status: 'expired', seatLimit: FREE_SEAT_LIMIT });
+  });
+});
+
+describe('LICENSE_PUBLIC_KEY_SPKI_B64', () => {
+  // Every other test in this file injects its own generated keypair, so none of
+  // them notice if this constant drifts away from the key Roomote Cloud signs
+  // with. It drifted once (PR #937) and silently capped every deployment at the
+  // free tier, so pin the value here.
+  it('matches the public half of the Cloud license signing key', () => {
+    expect(LICENSE_PUBLIC_KEY_SPKI_B64).toBe(
+      'MCowBQYDK2VwAyEALp8Px1N98T1Gh4a8zbj6EnpyWbxF3VJNqTKmXvxK8xc=',
+    );
+  });
+});
+
+describe('getEffectiveSeatLimit', () => {
+  const DEPLOYMENT_ID = 'deployment-1';
+  const now = new Date('2026-06-01T00:00:00.000Z');
+  const licensed = () =>
+    resolveLicenseState(issueKey(validPayload), now, publicKeySpkiB64);
+  const currentLease = {
+    licenseId: 'lic_test123',
+    deploymentId: DEPLOYMENT_ID,
+    activationExpiresAt: '2026-06-02T00:00:00.000Z',
+    entitlementsVersion: 'v1',
+    entitlements: {},
+    entitlementsExpiresAt: '2026-06-02T00:00:00.000Z',
+    lastSyncedAt: '2026-06-01T00:00:00.000Z',
+  };
+
+  function setCloudHosted(enabled: boolean) {
+    vi.stubEnv('R_CLOUD_ENABLED', enabled ? 'true' : 'false');
+    initializeWebRuntimeEnv();
+  }
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    initializeWebRuntimeEnv();
+  });
+
+  it('honors a valid key without a lease on a Cloud-hosted deployment', () => {
+    setCloudHosted(true);
+
+    expect(getEffectiveSeatLimit(licensed(), null, DEPLOYMENT_ID, now)).toBe(
+      50,
+    );
+  });
+
+  it('still requires a lease when self-hosted', () => {
+    setCloudHosted(false);
+
+    expect(getEffectiveSeatLimit(licensed(), null, DEPLOYMENT_ID, now)).toBe(
+      FREE_SEAT_LIMIT,
+    );
+    expect(
+      getEffectiveSeatLimit(licensed(), currentLease, DEPLOYMENT_ID, now),
+    ).toBe(50);
+  });
+
+  it('does not let a Cloud deployment ride an unverifiable key', () => {
+    setCloudHosted(true);
+
+    expect(
+      getEffectiveSeatLimit(
+        resolveLicenseState(issueKey(validPayload), now),
+        null,
+        DEPLOYMENT_ID,
+        now,
+      ),
+    ).toBe(FREE_SEAT_LIMIT);
+  });
+
+  it('does not let a Cloud deployment ride an expired key', () => {
+    setCloudHosted(true);
+    const expired = resolveLicenseState(
+      issueKey({ ...validPayload, expiresAt: '2026-05-01T00:00:00.000Z' }),
+      now,
+      publicKeySpkiB64,
+    );
+
+    expect(getEffectiveSeatLimit(expired, null, DEPLOYMENT_ID, now)).toBe(
+      FREE_SEAT_LIMIT,
+    );
   });
 });
 

--- a/apps/web/src/lib/server/license.ts
+++ b/apps/web/src/lib/server/license.ts
@@ -1,8 +1,10 @@
 export {
   FREE_SEAT_LIMIT,
+  LICENSE_PUBLIC_KEY_SPKI_B64,
   SeatLimitExceededError,
   assertSeatAvailable,
   getEffectiveDeploymentSeatLimit,
+  getEffectiveSeatLimit,
   getDeploymentLicenseState,
   getEnvLicenseKey,
   hasSeatAvailable,

--- a/packages/db/src/lib/deployment-license.ts
+++ b/packages/db/src/lib/deployment-license.ts
@@ -1,6 +1,6 @@
 import { createPublicKey, verify as verifySignature } from 'node:crypto';
 
-import { Env } from '@roomote/env';
+import { Env, isRoomoteCloudEnabled } from '@roomote/env';
 
 import { db, type DatabaseOrTransaction } from '../db';
 import {
@@ -17,8 +17,15 @@ const DEFAULT_DEPLOYMENT_ID = 'default';
 export const FREE_SEAT_LIMIT = 10;
 
 const LICENSE_KEY_PREFIX = 'RMLK1';
-const LICENSE_PUBLIC_KEY_SPKI_B64 =
-  'MCowBQYDK2VwAyEAs8vzncSsZYeJCxOYCeSbzH5VEDFJNhh/c6HTBu4N+Sk=';
+/**
+ * Ed25519 public half of the Roomote license signing key (SPKI DER, base64).
+ *
+ * This must stay in lockstep with the private key Roomote Cloud signs licenses
+ * with. Exported so a test can pin the value: the unit tests all inject their
+ * own generated keypair, so they cannot catch this constant drifting.
+ */
+export const LICENSE_PUBLIC_KEY_SPKI_B64 =
+  'MCowBQYDK2VwAyEALp8Px1N98T1Gh4a8zbj6EnpyWbxF3VJNqTKmXvxK8xc=';
 
 export type LicensePayload = {
   licenseId: string;
@@ -165,12 +172,34 @@ export function hasCurrentLicenseActivation(
   );
 }
 
+/**
+ * Whether Roomote Cloud hosts this deployment. `R_CLOUD_ENABLED` is set by
+ * Cloud provisioning and documented as "do not set this for self-hosted
+ * deployments", so it is the discriminator between the two seat gates below.
+ */
+function isCloudHostedDeployment(): boolean {
+  return isRoomoteCloudEnabled(Env.R_CLOUD_ENABLED);
+}
+
 export function getEffectiveSeatLimit(
   licenseState: DeploymentLicenseState,
   cloudState: LicenseCloudLease | null | undefined,
   deploymentId: string,
   now: Date = new Date(),
 ): number {
+  if (licenseState.status !== 'valid') {
+    return FREE_SEAT_LIMIT;
+  }
+
+  // Cloud provisions a `lic_cloud_<deploymentId>` key onto deployments it hosts,
+  // on infrastructure it controls, so the one-installation binding an activation
+  // lease provides buys nothing here. Self-hosted keeps the lease requirement:
+  // that binding is what stops a single purchased key raising seats across many
+  // installations.
+  if (isCloudHostedDeployment()) {
+    return licenseState.seatLimit;
+  }
+
   return hasCurrentLicenseActivation(
     licenseState,
     cloudState,


### PR DESCRIPTION
## Problem

Two regressions from the licensing move in #937, either of which alone caps a deployment at `FREE_SEAT_LIMIT`:

1. **The license public key changed.** `LICENSE_PUBLIC_KEY_SPKI_B64` moved from `apps/web/src/lib/server/license.ts` to `packages/db/src/lib/deployment-license.ts` and picked up a different value on the way. The new value is not the public half of the key licenses are signed with, so `verifyLicenseKey` rejects every issued key and `resolveLicenseState` reports `invalid`.

2. **An activation lease became mandatory.** `getEffectiveSeatLimit` now requires `hasCurrentLicenseActivation` before a key raises the limit. That lease binds one license to one installation, which is the point for self-hosted, but Roomote Cloud provisions a `lic_cloud_<deploymentId>` key onto deployments it hosts, on infrastructure it controls, where the binding buys nothing.

Both are invisible below 10 active users, so this only surfaces on a deployment that crosses the free tier, where it blocks every new sign-up.

## Fix

- Restore `LICENSE_PUBLIC_KEY_SPKI_B64` to the value it had before #937.
- Gate the lease requirement on `R_CLOUD_ENABLED`, which Cloud provisioning sets and which `apps/docs/environment-variables.mdx` tells self-hosters never to set. Self-hosted behavior is unchanged: a valid signature still is not enough on its own.
- An invalid, expired, or absent key still falls back to `FREE_SEAT_LIMIT` on both paths.

## Tests

Every existing test in `license.test.ts` injects its own generated keypair, so none of them could notice the constant drifting. This exports it and pins the value, plus covers the four `getEffectiveSeatLimit` paths (Cloud-hosted without a lease, self-hosted with and without a lease, and Cloud-hosted with an unverifiable or expired key).

## Follow-ups, not in this PR

- A seat rejection reaches the browser as a bare sign-in redirect loop with no message. The thrown text contains spaces and a period, so Better Auth's `/api/auth/error` sanitizer rewrites the code to `UNKNOWN` and redirects to `/?error=UNKNOWN`. Worth a machine-readable error code.
- `licenseUsageSyncJob` marks a rejected observation as delivered and only `console.warn`s, so a deployment that can never activate looks healthy forever.