### PR TITLE
Promote v0.32.1 to production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 This file tracks product releases for Roomote (single monorepo version). Automated release entries are prepended by `pnpm run version`.
 
+## 0.32.1 (2026-08-04)
+
+This patch restores licensed Cloud seat limits and keeps custom automation destinations limited to connected communication providers.
+
+### Highlights
+
+- Restore licensed seat limits for Roomote Cloud deployments so valid provisioned licenses no longer fall back to the free-tier limit when no activation lease is present.
+- Choose custom automation destinations from connected communication providers only.
+
+### Patch changes
+
+- Restore licensed seat limits for Roomote Cloud deployments so valid provisioned licenses no longer fall back to the free-tier limit when no activation lease is present.
+- Show only connected communication providers when choosing a custom automation destination, while preserving task-view-only delivery and existing form edits as integration availability loads.
+
 ## 0.32.0 (2026-08-03)
 
 This release adds OpenCode Go subscriptions, restores convenient automation test runs, refreshes recommended models, and makes license syncing more resilient.

--- a/apps/api/src/handlers/tasks/__tests__/getTaskComputeLogs.test.ts
+++ b/apps/api/src/handlers/tasks/__tests__/getTaskComputeLogs.test.ts
@@ -141,7 +141,7 @@ describe('getTaskComputeLogs', () => {
 
   afterEach(() => {});
 
-  it('returns task task runs with output, skipped reasons, and per-job errors', async () => {
+  it('returns task runs with output, skipped reasons, and per-job errors', async () => {
     mockFindMany.mockResolvedValue([
       {
         id: 101,

--- a/apps/web/src/components/ai-elements/todo-list.tsx
+++ b/apps/web/src/components/ai-elements/todo-list.tsx
@@ -32,7 +32,7 @@ export const TodoListItem = ({
   <li
     data-completed={completed}
     className={cn(
-      'group flex flex-col gap-2 rounded-md px-3 py-1 text-sm transition-colors text-muted-foregound cursor-default',
+      'group flex flex-col gap-2 rounded-md px-3 py-1 text-sm transition-colors text-muted-foreground cursor-default',
       !inProgress && 'text-muted-foreground/70',
       className,
     )}

--- a/apps/web/src/components/settings/automations/AutomationsSettings.render.client.test.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.render.client.test.tsx
@@ -503,7 +503,10 @@ describe('AutomationsSettings', () => {
     state.nextUpdateSettingsResult = null;
     mutations.latestSettingsOptions = null;
     mutations.latestTriggerOptions = null;
+    state.settingsQuery.data.capabilities.slackConnected = true;
     state.settingsQuery.data.capabilities.discordConnected = false;
+    state.settingsQuery.data.capabilities.telegramConnected = false;
+    state.settingsQuery.data.capabilities.teamsConnected = false;
     state.discordChannelsQuery.data.channels = [];
     state.settingsQuery.data.settings.managerStatsDiscordChannelId = null;
     state.settingsQuery.data.settings.suggesterDiscordChannelId = null;
@@ -941,6 +944,126 @@ describe('AutomationsSettings', () => {
         'Configure what runs, when it runs, and where the result is sent.',
       ),
     ).not.toBeInTheDocument();
+  });
+
+  it('only offers connected providers as custom automation destinations', async () => {
+    state.settingsQuery.data.capabilities.slackConnected = false;
+    state.settingsQuery.data.capabilities.discordConnected = true;
+    state.settingsQuery.data.capabilities.teamsConnected = true;
+    state.settingsQuery.data.settings.managerSlackChannelId = null as never;
+
+    render(<AutomationsSettings />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'New' }));
+    const destination = screen.getByRole('combobox', {
+      name: 'Destination provider',
+    });
+    expect(destination).toHaveTextContent('Discord');
+
+    fireEvent.click(destination);
+
+    expect(screen.getByRole('option', { name: 'None' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Discord' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Teams' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', { name: 'Slack' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', { name: 'Telegram' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('falls back to None when editing a disconnected destination', async () => {
+    state.settingsQuery.data.capabilities.slackConnected = false;
+    state.customAutomations = [
+      {
+        id: 'automation-1',
+        name: 'Weekly flaky-test scan',
+        prompt: 'Find flaky tests.',
+        enabled: true,
+        scheduleMode: 'weekly',
+        cronExpression: null,
+        model: null,
+        environmentId: 'env-1',
+        target: { provider: 'slack', externalRef: 'C123MANAGER' },
+        lastRunAt: null,
+        lastSucceededAt: null,
+        lastFailedAt: null,
+        lastError: null,
+        lastLaunchedTaskId: null,
+        createdByName: 'Ada',
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        updatedAt: new Date('2026-01-01T00:00:00Z'),
+      },
+    ];
+
+    render(<AutomationsSettings />);
+
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: 'Configure Weekly flaky-test scan',
+      }),
+    );
+
+    const destination = screen.getByRole('combobox', {
+      name: 'Destination provider',
+    });
+    expect(destination).toHaveTextContent('None');
+    fireEvent.click(destination);
+    expect(screen.getAllByRole('option')).toHaveLength(1);
+    expect(screen.getByRole('option', { name: 'None' })).toBeInTheDocument();
+  });
+
+  it('preserves in-progress edits when capabilities finish loading', async () => {
+    state.settingsQuery.isPending = true;
+    state.customAutomations = [
+      {
+        id: 'automation-1',
+        name: 'Weekly flaky-test scan',
+        prompt: 'Find flaky tests.',
+        enabled: true,
+        scheduleMode: 'weekly',
+        cronExpression: null,
+        model: null,
+        environmentId: 'env-1',
+        target: { provider: 'slack', externalRef: 'C123MANAGER' },
+        lastRunAt: null,
+        lastSucceededAt: null,
+        lastFailedAt: null,
+        lastError: null,
+        lastLaunchedTaskId: null,
+        createdByName: 'Ada',
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        updatedAt: new Date('2026-01-01T00:00:00Z'),
+      },
+    ];
+
+    const { rerender } = render(<AutomationsSettings />);
+
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: 'Configure Weekly flaky-test scan',
+      }),
+    );
+
+    expect(
+      screen.getByRole('combobox', { name: 'Destination provider' }),
+    ).toHaveTextContent('Slack');
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: 'Edited while loading' },
+    });
+    state.settingsQuery.isPending = false;
+    rerender(<AutomationsSettings />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Name')).toHaveValue('Edited while loading');
+      expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+    });
+    expect(
+      screen.getByRole('combobox', { name: 'Destination provider' }),
+    ).toHaveTextContent('Slack');
   });
 
   it('reflects the reviewer all-author setting in the review scope copy', async () => {

--- a/apps/web/src/components/settings/automations/AutomationsSettings.render.client.test.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.render.client.test.tsx
@@ -347,7 +347,7 @@ vi.mock('@tanstack/react-query', () => ({
       (Array.isArray(queryOptions.queryKey) &&
         queryOptions.queryKey.includes('environments'))
     ) {
-      // environments.list and any leftover channel listszheimer
+      // environments.list and any leftover channel list keys
       if (queryOptions.queryKey?.[0] === 'environments') {
         return { isPending: false, data: state.environments };
       }

--- a/apps/web/src/components/settings/automations/CustomAutomationsSection.tsx
+++ b/apps/web/src/components/settings/automations/CustomAutomationsSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import {
@@ -56,6 +56,11 @@ type CustomAutomationFormState = {
   targetServiceUrl: string;
 };
 
+type AutomationDestinationProvider = Exclude<
+  CustomAutomationFormState['targetProvider'],
+  'none'
+>;
+
 const EMPTY_FORM: CustomAutomationFormState = {
   name: '',
   prompt: '',
@@ -79,6 +84,21 @@ const SCHEDULE_OPTIONS: Array<{
   { value: 'daily', label: 'Daily' },
   { value: 'weekly', label: 'Weekly' },
   { value: 'cron', label: 'Custom schedule' },
+];
+
+const DESTINATION_OPTIONS: Array<{
+  value: AutomationDestinationProvider;
+  label: string;
+  capability:
+    | 'slackConnected'
+    | 'discordConnected'
+    | 'teamsConnected'
+    | 'telegramConnected';
+}> = [
+  { value: 'slack', label: 'Slack', capability: 'slackConnected' },
+  { value: 'discord', label: 'Discord', capability: 'discordConnected' },
+  { value: 'teams', label: 'Teams', capability: 'teamsConnected' },
+  { value: 'telegram', label: 'Telegram', capability: 'telegramConnected' },
 ];
 
 function scheduleLabel(mode: CustomAutomationScheduleMode): string {
@@ -113,8 +133,15 @@ function targetFromRow(row: CustomAutomationListItem): {
   };
 }
 
-function formFromRow(row: CustomAutomationListItem): CustomAutomationFormState {
+function formFromRow(
+  row: CustomAutomationListItem,
+  connectedProviders: readonly AutomationDestinationProvider[] | null,
+): CustomAutomationFormState {
   const target = targetFromRow(row);
+  const targetIsConnected =
+    connectedProviders === null ||
+    target.provider === 'none' ||
+    connectedProviders.includes(target.provider);
   return {
     name: row.name,
     prompt: row.prompt,
@@ -123,9 +150,9 @@ function formFromRow(row: CustomAutomationListItem): CustomAutomationFormState {
     environmentId: row.environmentId ?? '',
     cronExpression: row.cronExpression ?? '',
     model: row.model ?? '',
-    targetProvider: target.provider,
-    targetChannelId: target.channelId,
-    targetServiceUrl: target.serviceUrl,
+    targetProvider: targetIsConnected ? target.provider : 'none',
+    targetChannelId: targetIsConnected ? target.channelId : '',
+    targetServiceUrl: targetIsConnected ? target.serviceUrl : '',
   };
 }
 
@@ -189,6 +216,32 @@ export function CustomAutomationsSection() {
     settingsQuery.data?.settings.managerSlackChannelId ?? '';
   const managerDiscordChannelId =
     settingsQuery.data?.settings.managerDiscordChannelId ?? '';
+  const capabilities = settingsQuery.data?.capabilities;
+  const capabilitiesLoaded = !settingsQuery.isPending && Boolean(capabilities);
+  const connectedDestinationOptions = useMemo(
+    () =>
+      capabilitiesLoaded
+        ? DESTINATION_OPTIONS.filter(
+            (option) => capabilities?.[option.capability] === true,
+          )
+        : [],
+    [capabilities, capabilitiesLoaded],
+  );
+  const connectedDestinationProviders = useMemo(
+    () => connectedDestinationOptions.map((option) => option.value),
+    [connectedDestinationOptions],
+  );
+  const capabilitiesLoadedRef = useRef(capabilitiesLoaded);
+  const connectedDestinationProvidersRef = useRef(
+    connectedDestinationProviders,
+  );
+  capabilitiesLoadedRef.current = capabilitiesLoaded;
+  connectedDestinationProvidersRef.current = connectedDestinationProviders;
+  const visibleDestinationOptions = capabilitiesLoaded
+    ? connectedDestinationOptions
+    : DESTINATION_OPTIONS.filter(
+        (option) => option.value === form.targetProvider,
+      );
 
   const environmentOptions = useMemo(
     () =>
@@ -387,7 +440,12 @@ export function CustomAutomationsSection() {
   const editAutomation = (row: CustomAutomationListItem) => {
     setEditingId(row.id);
     setIsCreating(false);
-    setForm(formFromRow(row));
+    setForm(
+      formFromRow(
+        row,
+        capabilitiesLoaded ? connectedDestinationProviders : null,
+      ),
+    );
     setResolvedCron(row.cronExpression ?? null);
     setScheduleSummary(null);
     window.history.replaceState(
@@ -411,7 +469,14 @@ export function CustomAutomationsSection() {
       if (row) {
         setEditingId(row.id);
         setIsCreating(false);
-        setForm(formFromRow(row));
+        setForm(
+          formFromRow(
+            row,
+            capabilitiesLoadedRef.current
+              ? connectedDestinationProvidersRef.current
+              : null,
+          ),
+        );
         setResolvedCron(row.cronExpression ?? null);
         setScheduleSummary(null);
       }
@@ -421,6 +486,22 @@ export function CustomAutomationsSection() {
     window.addEventListener('hashchange', openLinkedAutomation);
     return () => window.removeEventListener('hashchange', openLinkedAutomation);
   }, [rows]);
+
+  useEffect(() => {
+    if (!capabilitiesLoaded) return;
+
+    setForm((current) =>
+      current.targetProvider === 'none' ||
+      connectedDestinationProviders.includes(current.targetProvider)
+        ? current
+        : {
+            ...current,
+            targetProvider: 'none',
+            targetChannelId: '',
+            targetServiceUrl: '',
+          },
+    );
+  }, [capabilitiesLoaded, connectedDestinationProviders]);
 
   const saveForm = () => {
     if (!form.environmentId) {
@@ -660,10 +741,11 @@ export function CustomAutomationsSection() {
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="none">None</SelectItem>
-                <SelectItem value="slack">Slack</SelectItem>
-                <SelectItem value="discord">Discord</SelectItem>
-                <SelectItem value="teams">Teams</SelectItem>
-                <SelectItem value="telegram">Telegram</SelectItem>
+                {visibleDestinationOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
 
@@ -789,7 +871,11 @@ export function CustomAutomationsSection() {
             >
               Cancel
             </Button>
-            <Button type="button" disabled={busy} onClick={saveForm}>
+            <Button
+              type="button"
+              disabled={busy || !capabilitiesLoaded}
+              onClick={saveForm}
+            >
               {editingId ? 'Save' : 'Create'}
             </Button>
           </div>
@@ -817,18 +903,31 @@ export function CustomAutomationsSection() {
           <Button
             type="button"
             size="sm"
-            disabled={busy || atCap}
+            disabled={busy || atCap || !capabilitiesLoaded}
             onClick={() => {
+              const managerProvider =
+                managerSlackChannelId &&
+                settingsQuery.data?.capabilities.slackConnected
+                  ? 'slack'
+                  : managerDiscordChannelId &&
+                      settingsQuery.data?.capabilities.discordConnected
+                    ? 'discord'
+                    : null;
+              const targetProvider =
+                managerProvider ??
+                connectedDestinationOptions[0]?.value ??
+                'none';
               setIsCreating(true);
               setEditingId(null);
               setForm({
                 ...EMPTY_FORM,
-                targetProvider:
-                  managerDiscordChannelId && !managerSlackChannelId
-                    ? 'discord'
-                    : 'slack',
+                targetProvider,
                 targetChannelId:
-                  managerSlackChannelId || managerDiscordChannelId,
+                  targetProvider === 'slack'
+                    ? managerSlackChannelId
+                    : targetProvider === 'discord'
+                      ? managerDiscordChannelId
+                      : '',
               });
               setResolvedCron(null);
               setScheduleSummary(null);

--- a/apps/web/src/lib/server/__tests__/license.test.ts
+++ b/apps/web/src/lib/server/__tests__/license.test.ts
@@ -2,7 +2,9 @@ import { generateKeyPairSync, sign } from 'node:crypto';
 
 import {
   FREE_SEAT_LIMIT,
+  getEffectiveSeatLimit,
   getEnvLicenseKey,
+  LICENSE_PUBLIC_KEY_SPKI_B64,
   resolveConfiguredLicenseKey,
   resolveLicenseState,
   verifyLicenseKey,
@@ -169,6 +171,89 @@ describe('resolveLicenseState', () => {
         publicKeySpkiB64,
       ),
     ).toMatchObject({ status: 'expired', seatLimit: FREE_SEAT_LIMIT });
+  });
+});
+
+describe('LICENSE_PUBLIC_KEY_SPKI_B64', () => {
+  // Every other test in this file injects its own generated keypair, so none of
+  // them notice if this constant drifts away from the key Roomote Cloud signs
+  // with. It drifted once (PR #937) and silently capped every deployment at the
+  // free tier, so pin the value here.
+  it('matches the public half of the Cloud license signing key', () => {
+    expect(LICENSE_PUBLIC_KEY_SPKI_B64).toBe(
+      'MCowBQYDK2VwAyEALp8Px1N98T1Gh4a8zbj6EnpyWbxF3VJNqTKmXvxK8xc=',
+    );
+  });
+});
+
+describe('getEffectiveSeatLimit', () => {
+  const DEPLOYMENT_ID = 'deployment-1';
+  const now = new Date('2026-06-01T00:00:00.000Z');
+  const licensed = () =>
+    resolveLicenseState(issueKey(validPayload), now, publicKeySpkiB64);
+  const currentLease = {
+    licenseId: 'lic_test123',
+    deploymentId: DEPLOYMENT_ID,
+    activationExpiresAt: '2026-06-02T00:00:00.000Z',
+    entitlementsVersion: 'v1',
+    entitlements: {},
+    entitlementsExpiresAt: '2026-06-02T00:00:00.000Z',
+    lastSyncedAt: '2026-06-01T00:00:00.000Z',
+  };
+
+  function setCloudHosted(enabled: boolean) {
+    vi.stubEnv('R_CLOUD_ENABLED', enabled ? 'true' : 'false');
+    initializeWebRuntimeEnv();
+  }
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    initializeWebRuntimeEnv();
+  });
+
+  it('honors a valid key without a lease on a Cloud-hosted deployment', () => {
+    setCloudHosted(true);
+
+    expect(getEffectiveSeatLimit(licensed(), null, DEPLOYMENT_ID, now)).toBe(
+      50,
+    );
+  });
+
+  it('still requires a lease when self-hosted', () => {
+    setCloudHosted(false);
+
+    expect(getEffectiveSeatLimit(licensed(), null, DEPLOYMENT_ID, now)).toBe(
+      FREE_SEAT_LIMIT,
+    );
+    expect(
+      getEffectiveSeatLimit(licensed(), currentLease, DEPLOYMENT_ID, now),
+    ).toBe(50);
+  });
+
+  it('does not let a Cloud deployment ride an unverifiable key', () => {
+    setCloudHosted(true);
+
+    expect(
+      getEffectiveSeatLimit(
+        resolveLicenseState(issueKey(validPayload), now),
+        null,
+        DEPLOYMENT_ID,
+        now,
+      ),
+    ).toBe(FREE_SEAT_LIMIT);
+  });
+
+  it('does not let a Cloud deployment ride an expired key', () => {
+    setCloudHosted(true);
+    const expired = resolveLicenseState(
+      issueKey({ ...validPayload, expiresAt: '2026-05-01T00:00:00.000Z' }),
+      now,
+      publicKeySpkiB64,
+    );
+
+    expect(getEffectiveSeatLimit(expired, null, DEPLOYMENT_ID, now)).toBe(
+      FREE_SEAT_LIMIT,
+    );
   });
 });
 

--- a/apps/web/src/lib/server/license.ts
+++ b/apps/web/src/lib/server/license.ts
@@ -1,8 +1,10 @@
 export {
   FREE_SEAT_LIMIT,
+  LICENSE_PUBLIC_KEY_SPKI_B64,
   SeatLimitExceededError,
   assertSeatAvailable,
   getEffectiveDeploymentSeatLimit,
+  getEffectiveSeatLimit,
   getDeploymentLicenseState,
   getEnvLicenseKey,
   hasSeatAvailable,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roomote",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "license": "FCL-1.0-ALv2",
   "packageManager": "pnpm@10.29.3",
   "engines": {

--- a/packages/cloud-agents/src/server/workflows/skills/standard/security-best-practices/references/javascript-express-web-server-security.md
+++ b/packages/cloud-agents/src/server/workflows/skills/standard/security-best-practices/references/javascript-express-web-server-security.md
@@ -372,7 +372,7 @@ Required:
 * MUST protect all state-changing endpoints (POST/PUT/PATCH/DELETE) that rely on cookies for authentication.
 * SHOULD use a well-understood CSRF mitigation (token-based is the typical baseline).
 * MAY add defense-in-depth: Origin/Referer validation, Fetch Metadata enforcement, SameSite cookies, custom header requirements for XHR/fetch—**but do not treat these as a full replacement** unless explicitly designed and justified.
-* MUST use at a minimum require a custom HTTP header if form based CRSF tokens are not practical, as this is the second strongest method.
+* MUST use at a minimum require a custom HTTP header if form based CSRF tokens are not practical, as this is the second strongest method.
 
 IMPORTANT NOTE:
 
@@ -953,7 +953,7 @@ Notes:
 
 Severity: Low
 
-NOTE: It may be hard to tell from the provided application context if the application runs behind a reverse proxy. You can inform the user or recommend one, but do not attempt to configure one without them initiating it. This is highly deployment dependant.
+NOTE: It may be hard to tell from the provided application context if the application runs behind a reverse proxy. You can inform the user or recommend one, but do not attempt to configure one without them initiating it. This is highly deployment dependent.
 
 Required:
 

--- a/packages/db/src/lib/deployment-license.ts
+++ b/packages/db/src/lib/deployment-license.ts
@@ -1,6 +1,6 @@
 import { createPublicKey, verify as verifySignature } from 'node:crypto';
 
-import { Env } from '@roomote/env';
+import { Env, isRoomoteCloudEnabled } from '@roomote/env';
 
 import { db, type DatabaseOrTransaction } from '../db';
 import {
@@ -17,8 +17,15 @@ const DEFAULT_DEPLOYMENT_ID = 'default';
 export const FREE_SEAT_LIMIT = 10;
 
 const LICENSE_KEY_PREFIX = 'RMLK1';
-const LICENSE_PUBLIC_KEY_SPKI_B64 =
-  'MCowBQYDK2VwAyEAs8vzncSsZYeJCxOYCeSbzH5VEDFJNhh/c6HTBu4N+Sk=';
+/**
+ * Ed25519 public half of the Roomote license signing key (SPKI DER, base64).
+ *
+ * This must stay in lockstep with the private key Roomote Cloud signs licenses
+ * with. Exported so a test can pin the value: the unit tests all inject their
+ * own generated keypair, so they cannot catch this constant drifting.
+ */
+export const LICENSE_PUBLIC_KEY_SPKI_B64 =
+  'MCowBQYDK2VwAyEALp8Px1N98T1Gh4a8zbj6EnpyWbxF3VJNqTKmXvxK8xc=';
 
 export type LicensePayload = {
   licenseId: string;
@@ -165,12 +172,34 @@ export function hasCurrentLicenseActivation(
   );
 }
 
+/**
+ * Whether Roomote Cloud hosts this deployment. `R_CLOUD_ENABLED` is set by
+ * Cloud provisioning and documented as "do not set this for self-hosted
+ * deployments", so it is the discriminator between the two seat gates below.
+ */
+function isCloudHostedDeployment(): boolean {
+  return isRoomoteCloudEnabled(Env.R_CLOUD_ENABLED);
+}
+
 export function getEffectiveSeatLimit(
   licenseState: DeploymentLicenseState,
   cloudState: LicenseCloudLease | null | undefined,
   deploymentId: string,
   now: Date = new Date(),
 ): number {
+  if (licenseState.status !== 'valid') {
+    return FREE_SEAT_LIMIT;
+  }
+
+  // Cloud provisions a `lic_cloud_<deploymentId>` key onto deployments it hosts,
+  // on infrastructure it controls, so the one-installation binding an activation
+  // lease provides buys nothing here. Self-hosted keeps the lease requirement:
+  // that binding is what stops a single purchased key raising seats across many
+  // installations.
+  if (isCloudHostedDeployment()) {
+    return licenseState.seatLimit;
+  }
+
   return hasCurrentLicenseActivation(
     licenseState,
     cloudState,


### PR DESCRIPTION
## Promote v0.32.1

Frozen at `572678ab618a028f515cf4b3d3e2b65efc1b70ee` — the commit where `0.32.1` was versioned. Commits merged to `develop` afterward require an explicit candidate refresh or ship in the next release.

- Merge this PR with a **merge commit** (do not squash or rebase).
- If multiple promote PRs are open, merge them in version order (oldest first).
- Merging publishes a GitHub Release for `v0.32.1` and triggers the existing GHCR `v*` image publish (`latest` channel).
- The `release/v0.32.1` branch can be deleted after this PR merges.

### Changelog

## 0.32.1 (2026-08-04)

This patch restores licensed Cloud seat limits and keeps custom automation destinations limited to connected communication providers.

### Highlights

- Restore licensed seat limits for Roomote Cloud deployments so valid provisioned licenses no longer fall back to the free-tier limit when no activation lease is present.
- Choose custom automation destinations from connected communication providers only.

### Patch changes

- Restore licensed seat limits for Roomote Cloud deployments so valid provisioned licenses no longer fall back to the free-tier limit when no activation lease is present.
- Show only connected communication providers when choosing a custom automation destination, while preserving task-view-only delivery and existing form edits as integration availability loads.
