### PR TITLE
[Fix] Stop closeout retry loops when chat delivery permanently fails

### DIFF
--- a/apps/api/src/handlers/mcp/__tests__/slack-thread-reply-quotes.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/slack-thread-reply-quotes.test.ts
@@ -10,7 +10,7 @@ const {
   getLatestUserMessageMock,
   getTaskChannelBindingsMock,
   maybeSendCommunicationThreadReplyMock,
-  postMessageMock,
+  postMessageDetailedMock,
   slackInstallationFindFirstMock,
   taskRunFindFirstMock,
 } = vi.hoisted(() => ({
@@ -20,7 +20,7 @@ const {
   getLatestUserMessageMock: vi.fn(),
   getTaskChannelBindingsMock: vi.fn(),
   maybeSendCommunicationThreadReplyMock: vi.fn(),
-  postMessageMock: vi.fn(),
+  postMessageDetailedMock: vi.fn(),
   slackInstallationFindFirstMock: vi.fn(),
   taskRunFindFirstMock: vi.fn(),
 }));
@@ -50,7 +50,10 @@ vi.mock('@roomote/db/server', () => ({
   workItems: { id: 'id' },
 }));
 
-vi.mock('@roomote/slack', () => ({
+vi.mock('@roomote/slack', async (importOriginal) => ({
+  SlackPostDeliveryError: (
+    await importOriginal<typeof import('@roomote/slack')>()
+  ).SlackPostDeliveryError,
   buildSlackThreadFooterText: vi.fn().mockReturnValue('Task footer'),
   buildSlackThreadReplyFooterBlock: vi.fn(({ footerText }) => ({
     type: 'context',
@@ -73,7 +76,7 @@ vi.mock('@roomote/slack', () => ({
   setSlackThreadReplyFooterMessageTs: vi.fn(),
   SlackNotifier: vi.fn(
     class {
-      postMessage = postMessageMock;
+      postMessageDetailed = postMessageDetailedMock;
     },
   ),
   trackLatestUserMessageForSlackQuote: vi.fn(),
@@ -177,7 +180,7 @@ describe('Slack thread reply quotes', () => {
         alt_text: 'Screenshot',
       },
     ]);
-    postMessageMock.mockResolvedValue('333.444');
+    postMessageDetailedMock.mockResolvedValue({ ts: '333.444' });
     clearLatestUserMessageForReplyQuoteIfIdMock.mockResolvedValue(true);
   });
 
@@ -191,7 +194,7 @@ describe('Slack thread reply quotes', () => {
     });
 
     expect(response.status).toBe(200);
-    expect(postMessageMock).toHaveBeenCalledWith(
+    expect(postMessageDetailedMock).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: 'C123',
         thread_ts: '111.222',
@@ -221,7 +224,7 @@ describe('Slack thread reply quotes', () => {
     });
 
     expect(response.status).toBe(200);
-    expect(postMessageMock).toHaveBeenCalledWith(
+    expect(postMessageDetailedMock).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: 'C123',
         thread_ts: '111.222',
@@ -230,7 +233,7 @@ describe('Slack thread reply quotes', () => {
         ]),
       }),
     );
-    expect(postMessageMock.mock.calls[0]?.[0]?.blocks).not.toEqual(
+    expect(postMessageDetailedMock.mock.calls[0]?.[0]?.blocks).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           block_id: 'roomote_thread_reply_quote',
@@ -264,7 +267,7 @@ describe('Slack thread reply quotes', () => {
     });
 
     expect(response.status).toBe(200);
-    expect(postMessageMock).toHaveBeenCalledWith(
+    expect(postMessageDetailedMock).toHaveBeenCalledWith(
       expect.objectContaining({
         blocks: expect.arrayContaining([
           expect.objectContaining({
@@ -273,7 +276,7 @@ describe('Slack thread reply quotes', () => {
         ]),
       }),
     );
-    expect(postMessageMock.mock.calls[0]?.[0]?.blocks).not.toEqual(
+    expect(postMessageDetailedMock.mock.calls[0]?.[0]?.blocks).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ block_id: 'footer' })]),
     );
     expect(clearLatestUserMessageForReplyQuoteIfIdMock).toHaveBeenCalledWith(
@@ -285,7 +288,9 @@ describe('Slack thread reply quotes', () => {
 
   it('keeps the pending quote when Slack delivery fails', async () => {
     buildThreadReplyImageBlocksMock.mockResolvedValue([]);
-    postMessageMock.mockRejectedValueOnce(new Error('Slack unavailable'));
+    postMessageDetailedMock.mockRejectedValueOnce(
+      new Error('Slack unavailable'),
+    );
 
     const response = await createApp().request('/mcp/thread_reply', {
       method: 'POST',
@@ -295,6 +300,62 @@ describe('Slack thread reply quotes', () => {
 
     expect(response.status).toBe(500);
     expect(clearLatestUserMessageForReplyQuoteIfIdMock).not.toHaveBeenCalled();
+  });
+
+  it('maps a permanent Slack posting error to a non-retryable structured response', async () => {
+    buildThreadReplyImageBlocksMock.mockResolvedValue([]);
+    postMessageDetailedMock.mockResolvedValue({
+      slackErrorCode: 'not_in_channel',
+    });
+
+    const response = await createApp().request('/mcp/thread_reply', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text: 'On it' }),
+    });
+
+    expect(response.status).toBe(422);
+    expect(await response.json()).toEqual({
+      error: 'Slack chat.postMessage failed: not_in_channel',
+      slackErrorCode: 'not_in_channel',
+      retryable: false,
+    });
+  });
+
+  it('maps a transport-level Slack posting failure to a retryable 502', async () => {
+    buildThreadReplyImageBlocksMock.mockResolvedValue([]);
+    postMessageDetailedMock.mockResolvedValue({ transportError: true });
+
+    const response = await createApp().request('/mcp/thread_reply', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text: 'On it' }),
+    });
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({
+      error: 'Slack chat.postMessage failed: transport error',
+      slackErrorCode: null,
+      retryable: true,
+    });
+  });
+
+  it('keeps reporting a deleted thread root as a 409', async () => {
+    buildThreadReplyImageBlocksMock.mockResolvedValue([]);
+    postMessageDetailedMock.mockResolvedValue({
+      skippedMissingThreadRoot: true,
+    });
+
+    const response = await createApp().request('/mcp/thread_reply', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text: 'On it' }),
+    });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      error: 'Slack thread source message no longer exists',
+    });
   });
 
   it('clears exactly by id when the clear request carries a quoteId', async () => {

--- a/apps/api/src/handlers/mcp/slack.ts
+++ b/apps/api/src/handlers/mcp/slack.ts
@@ -33,6 +33,7 @@ import {
   setLatestSlackBotReply,
   setSlackThreadReplyFooterMessageTs,
   SlackNotifier,
+  SlackPostDeliveryError,
   trackSlackBotReply,
   withSlackThreadReplyFooterLock,
   THREAD_REPLY_FOOTER_LOCK_TIMEOUT_MESSAGE as SLACK_THREAD_REPLY_FOOTER_LOCK_TIMEOUT_MESSAGE,
@@ -971,16 +972,17 @@ slackMcp.post('/thread_reply', async (c) => {
     blocks.push(...imageBlocks);
     blocks.push(...rootFooterBlocks);
 
-    const rootMessageTs = await slack.postMessage({
+    const rootPostResult = await slack.postMessageDetailed({
       channel: slackReplyTarget.channel,
       text: getSlackFallbackText(fallbackText, imageBlocks.length),
       unfurl_links: false,
       unfurl_media: false,
       blocks,
     });
+    const rootMessageTs = rootPostResult.ts;
 
     if (!rootMessageTs) {
-      throw new Error('Slack chat.postMessage returned no message timestamp');
+      throw new SlackPostDeliveryError(rootPostResult);
     }
 
     // The root message is already visible in Slack; failing the reply here
@@ -1141,7 +1143,7 @@ slackMcp.post('/thread_reply', async (c) => {
           );
         }
 
-        const nextMessageTs = await slack.postMessage({
+        const replyPostResult = await slack.postMessageDetailed({
           channel: slackReplyTarget.channel,
           thread_ts: existingThreadTs,
           text: getSlackFallbackText(fallbackText, imageBlocks.length),
@@ -1149,9 +1151,13 @@ slackMcp.post('/thread_reply', async (c) => {
           unfurl_media: false,
           blocks,
         });
+        const nextMessageTs = replyPostResult.ts;
 
         if (!nextMessageTs) {
-          throw new Error('Slack thread source message no longer exists');
+          if (replyPostResult.skippedMissingThreadRoot) {
+            throw new Error('Slack thread source message no longer exists');
+          }
+          throw new SlackPostDeliveryError(replyPostResult);
         }
 
         if (pendingQuote) {
@@ -1340,6 +1346,17 @@ slackMcp.post('/thread_reply', async (c) => {
       return c.json(
         { error: 'Slack thread reply is busy; please retry shortly' },
         503,
+      );
+    }
+
+    if (error instanceof SlackPostDeliveryError) {
+      return c.json(
+        {
+          error: error.message,
+          slackErrorCode: error.slackErrorCode ?? null,
+          retryable: error.retryable,
+        },
+        error.retryable ? 502 : 422,
       );
     }
 

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/reply-to-slack-thread.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/reply-to-slack-thread.test.ts
@@ -12,6 +12,7 @@ import {
   uploadPreparedArtifact,
 } from '../local-file-upload.js';
 import { replyToChatThread } from '../chat-api-client.js';
+import { ChatDeliveryError } from '../chat-delivery-error.js';
 import { handleSendChatReply } from '../send-chat-reply.js';
 import type { ArtifactConfig, RoomoteConfig } from '../types.js';
 
@@ -293,6 +294,71 @@ describe('handleReplyToSlackThread', () => {
       success: false,
       error: 'Slack API unavailable',
       uploadedArtifactIds: ['art-1'],
+      deliveryFailure: { retryable: true },
     });
+  });
+
+  it('flags unclassified delivery errors as retryable delivery failures', async () => {
+    vi.mocked(replyToChatThread).mockRejectedValue(
+      new Error('Failed to reply to chat thread: 502 transport hiccup'),
+    );
+
+    const result = await handleSendChatReply(
+      { taskId: 'task-1', summary: 'closeout text' },
+      artifactConfig,
+      roomoteConfig,
+    );
+
+    expect(JSON.parse(result.content[0]!.text)).toEqual({
+      success: false,
+      error: 'Failed to reply to chat thread: 502 transport hiccup',
+      deliveryFailure: { retryable: true },
+    });
+  });
+
+  it('carries the structured verdict for non-retryable delivery errors', async () => {
+    vi.mocked(replyToChatThread).mockRejectedValue(
+      new ChatDeliveryError({
+        message: 'Failed to reply to chat thread: 422 not_in_channel',
+        status: 422,
+        retryable: false,
+        providerErrorCode: 'not_in_channel',
+      }),
+    );
+
+    const result = await handleSendChatReply(
+      { taskId: 'task-1', summary: 'closeout text' },
+      artifactConfig,
+      roomoteConfig,
+    );
+
+    expect(JSON.parse(result.content[0]!.text)).toEqual({
+      success: false,
+      error: 'Failed to reply to chat thread: 422 not_in_channel',
+      deliveryFailure: {
+        retryable: false,
+        providerErrorCode: 'not_in_channel',
+      },
+    });
+  });
+
+  it('does not flag pre-delivery failures as delivery failures', async () => {
+    const result = await handleSendChatReply(
+      {
+        taskId: 'task-1',
+        summary: 'has image',
+        imagePaths: ['screenshots/after.png'],
+      },
+      { ...artifactConfig, workspacePath: undefined },
+      roomoteConfig,
+    );
+
+    const parsed = JSON.parse(result.content[0]!.text) as Record<
+      string,
+      unknown
+    >;
+    expect(parsed.success).toBe(false);
+    expect(parsed.deliveryFailure).toBeUndefined();
+    expect(replyToChatThread).not.toHaveBeenCalled();
   });
 });

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/slack-api-client.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/slack-api-client.test.ts
@@ -7,6 +7,7 @@ import {
   replyToSlackThread,
   trackSlackReplyQuote,
 } from '../slack-api-client.js';
+import { ChatDeliveryError } from '../chat-delivery-error.js';
 import type { RoomoteConfig } from '../types.js';
 
 const config: RoomoteConfig = {
@@ -172,6 +173,31 @@ describe('replyToSlackThread', () => {
       replyToSlackThread(config, { text: 'blocked' }),
     ).rejects.toThrow('Failed to reply to Slack thread: 403 forbidden');
     expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws a typed delivery error when the platform marks the failure non-retryable', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      text: async () =>
+        JSON.stringify({
+          error: 'Slack chat.postMessage failed: not_in_channel',
+          slackErrorCode: 'not_in_channel',
+          retryable: false,
+        }),
+    });
+
+    const error = (await replyToSlackThread(config, { text: 'blocked' }).catch(
+      (thrown: unknown) => thrown,
+    )) as ChatDeliveryError;
+
+    expect(error).toBeInstanceOf(ChatDeliveryError);
+    expect(error.message).toBe(
+      'Failed to reply to Slack thread: 422 Slack chat.postMessage failed: not_in_channel',
+    );
+    expect(error.status).toBe(422);
+    expect(error.retryable).toBe(false);
+    expect(error.providerErrorCode).toBe('not_in_channel');
   });
 });
 

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/slack-reply-satisfaction.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/slack-reply-satisfaction.test.ts
@@ -825,6 +825,28 @@ describe('Slack reply satisfaction state', () => {
       });
     });
 
+    it('is not cleared by a successful reaction', () => {
+      const stateFilePath = writeStateFile({
+        startedAtMs: 1000,
+        currentTurnMessageTs: '111.222',
+        deliveryFailureCount: 3,
+        lastDeliveryFailureCode: 'not_in_channel',
+        terminalDeliveryFailureAtMs: 2000,
+      });
+
+      recordSlackReplySatisfaction({
+        stateFilePath,
+        messageTs: '111.222',
+        tool: 'send_chat_reaction_emoji',
+        nowMs: 3000,
+      });
+
+      const state = JSON.parse(fs.readFileSync(stateFilePath, 'utf8'));
+      expect(state.deliveryFailureCount).toBe(3);
+      expect(state.lastDeliveryFailureCode).toBe('not_in_channel');
+      expect(state.terminalDeliveryFailureAtMs).toBe(2000);
+    });
+
     it('is cleared by a later successful post', () => {
       const stateFilePath = writeStateFile({
         startedAtMs: 1000,

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/slack-reply-satisfaction.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/slack-reply-satisfaction.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 
 import {
   CHAT_REPLY_SATISFACTION_STATE_FILE_ENV as SLACK_REPLY_SATISFACTION_STATE_FILE_ENV,
+  recordChatReplyDeliveryFailure,
   recordChatReplySatisfaction as recordSlackReplySatisfaction,
   recordChatTurnStart as recordSlackTurnStart,
 } from '../chat-reply-satisfaction';
@@ -713,6 +714,160 @@ describe('Slack reply satisfaction state', () => {
       tool: 'add_reaction_to_slack_message',
       recordedAtMs: 1234,
       satisfiedTurnMessageTs: '111.222',
+    });
+  });
+
+  describe('recordChatReplyDeliveryFailure', () => {
+    function writeStateFile(state: Record<string, unknown>): string {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'roomote-slack-'));
+      tempDirs.push(tempDir);
+      const stateFilePath = path.join(tempDir, 'reply-state.json');
+      fs.writeFileSync(stateFilePath, JSON.stringify(state), 'utf8');
+      return stateFilePath;
+    }
+
+    it('counts a retryable failure without stamping a terminal outcome', () => {
+      const stateFilePath = writeStateFile({ startedAtMs: 1000 });
+
+      const result = recordChatReplyDeliveryFailure({
+        stateFilePath,
+        retryable: true,
+        nowMs: 2000,
+      });
+
+      expect(result).toEqual({ terminalDeliveryFailure: false });
+      expect(JSON.parse(fs.readFileSync(stateFilePath, 'utf8'))).toEqual({
+        startedAtMs: 1000,
+        deliveryFailureCount: 1,
+        lastDeliveryFailureAtMs: 2000,
+      });
+    });
+
+    it('stamps a terminal outcome on a non-retryable failure', () => {
+      const stateFilePath = writeStateFile({ startedAtMs: 1000 });
+
+      const result = recordChatReplyDeliveryFailure({
+        stateFilePath,
+        retryable: false,
+        providerErrorCode: 'not_in_channel',
+        nowMs: 2000,
+      });
+
+      expect(result).toEqual({ terminalDeliveryFailure: true });
+      expect(JSON.parse(fs.readFileSync(stateFilePath, 'utf8'))).toEqual({
+        startedAtMs: 1000,
+        deliveryFailureCount: 1,
+        lastDeliveryFailureAtMs: 2000,
+        lastDeliveryFailureCode: 'not_in_channel',
+        terminalDeliveryFailureAtMs: 2000,
+      });
+    });
+
+    it('stamps a terminal outcome when the bounded retry budget is spent', () => {
+      const stateFilePath = writeStateFile({
+        startedAtMs: 1000,
+        deliveryFailureCount: 4,
+        lastDeliveryFailureAtMs: 1900,
+      });
+
+      const result = recordChatReplyDeliveryFailure({
+        stateFilePath,
+        retryable: true,
+        nowMs: 2000,
+      });
+
+      expect(result).toEqual({ terminalDeliveryFailure: true });
+      expect(JSON.parse(fs.readFileSync(stateFilePath, 'utf8'))).toEqual({
+        startedAtMs: 1000,
+        deliveryFailureCount: 5,
+        lastDeliveryFailureAtMs: 2000,
+        terminalDeliveryFailureAtMs: 2000,
+      });
+    });
+
+    it('keeps the earliest terminal stamp across later failures', () => {
+      const stateFilePath = writeStateFile({
+        startedAtMs: 1000,
+        deliveryFailureCount: 5,
+        lastDeliveryFailureAtMs: 2000,
+        terminalDeliveryFailureAtMs: 2000,
+      });
+
+      const result = recordChatReplyDeliveryFailure({
+        stateFilePath,
+        retryable: true,
+        nowMs: 3000,
+      });
+
+      expect(result).toEqual({ terminalDeliveryFailure: true });
+      const state = JSON.parse(fs.readFileSync(stateFilePath, 'utf8'));
+      expect(state.terminalDeliveryFailureAtMs).toBe(2000);
+      expect(state.deliveryFailureCount).toBe(6);
+    });
+
+    it('ignores failures reported from non-parent sessions', () => {
+      const stateFilePath = writeStateFile({
+        startedAtMs: 1000,
+        parentThreadId: 'thread-parent',
+      });
+
+      const result = recordChatReplyDeliveryFailure({
+        stateFilePath,
+        retryable: false,
+        sessionId: 'thread-subagent',
+        nowMs: 2000,
+      });
+
+      expect(result).toEqual({ terminalDeliveryFailure: false });
+      expect(JSON.parse(fs.readFileSync(stateFilePath, 'utf8'))).toEqual({
+        startedAtMs: 1000,
+        parentThreadId: 'thread-parent',
+      });
+    });
+
+    it('is cleared by a later successful post', () => {
+      const stateFilePath = writeStateFile({
+        startedAtMs: 1000,
+        deliveryFailureCount: 3,
+        lastDeliveryFailureAtMs: 2000,
+        lastDeliveryFailureCode: 'not_in_channel',
+        terminalDeliveryFailureAtMs: 2000,
+      });
+
+      recordSlackReplySatisfaction({
+        stateFilePath,
+        messageTs: '111.222',
+        tool: 'send_chat_reply',
+        replyPurpose: 'closeout',
+        nowMs: 3000,
+      });
+
+      const state = JSON.parse(fs.readFileSync(stateFilePath, 'utf8'));
+      expect(state.deliveryFailureCount).toBeUndefined();
+      expect(state.lastDeliveryFailureAtMs).toBeUndefined();
+      expect(state.lastDeliveryFailureCode).toBeUndefined();
+      expect(state.terminalDeliveryFailureAtMs).toBeUndefined();
+      expect(state.messageTs).toBe('111.222');
+    });
+
+    it('is reset by a new inbound turn', () => {
+      const stateFilePath = writeStateFile({
+        currentTurnMessageTs: '111.222',
+        deliveryFailureCount: 3,
+        lastDeliveryFailureAtMs: 2000,
+        terminalDeliveryFailureAtMs: 2000,
+      });
+
+      recordSlackTurnStart({
+        stateFilePath,
+        turnMessageTs: '333.444',
+        nowMs: 3000,
+      });
+
+      const state = JSON.parse(fs.readFileSync(stateFilePath, 'utf8'));
+      expect(state.deliveryFailureCount).toBeUndefined();
+      expect(state.terminalDeliveryFailureAtMs).toBeUndefined();
+      expect(state.currentTurnMessageTs).toBe('333.444');
     });
   });
 });

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/slack-tool-session-propagation.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/slack-tool-session-propagation.test.ts
@@ -13,6 +13,7 @@ const mockState = vi.hoisted(() => ({
   handleSendChatReactionEmoji: vi.fn(),
   handleAddReactionToSlackMessage: vi.fn(),
   recordChatReplySatisfaction: vi.fn(),
+  recordChatReplyDeliveryFailure: vi.fn(),
 }));
 
 vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
@@ -54,6 +55,7 @@ vi.mock('../add-reaction-to-slack-message.js', () => ({
 
 vi.mock('../chat-reply-satisfaction.js', () => ({
   recordChatReplySatisfaction: mockState.recordChatReplySatisfaction,
+  recordChatReplyDeliveryFailure: mockState.recordChatReplyDeliveryFailure,
 }));
 
 function getRegisteredTool(toolName: string): RegisteredTool {
@@ -75,6 +77,10 @@ describe('roomote MCP Slack tool session propagation', () => {
     mockState.handleSendChatReactionEmoji.mockReset();
     mockState.handleAddReactionToSlackMessage.mockReset();
     mockState.recordChatReplySatisfaction.mockReset();
+    mockState.recordChatReplyDeliveryFailure.mockReset();
+    mockState.recordChatReplyDeliveryFailure.mockReturnValue({
+      terminalDeliveryFailure: false,
+    });
 
     process.env = {
       ...originalEnv,
@@ -113,6 +119,98 @@ describe('roomote MCP Slack tool session propagation', () => {
       replyPurpose: 'closeout',
       sessionId: 'thread-child',
     });
+  });
+
+  it('records failed deliveries with the MCP session id and keeps the result unchanged while retryable', async () => {
+    const failedResult = {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            success: false,
+            error: 'Failed to reply to chat thread: 502 transport hiccup',
+            deliveryFailure: { retryable: true },
+          }),
+        },
+      ],
+    };
+    mockState.handleSendChatReply.mockResolvedValue(failedResult);
+
+    const result = await getRegisteredTool('send_chat_reply').handler!(
+      { message: 'done', purpose: 'closeout' },
+      { sessionId: 'thread-child' },
+    );
+
+    expect(mockState.recordChatReplyDeliveryFailure).toHaveBeenCalledWith({
+      retryable: true,
+      providerErrorCode: undefined,
+      sessionId: 'thread-child',
+    });
+    expect(mockState.recordChatReplySatisfaction).not.toHaveBeenCalled();
+    expect(result).toBe(failedResult);
+  });
+
+  it('rewrites the result with do-not-retry guidance once delivery is terminal', async () => {
+    mockState.recordChatReplyDeliveryFailure.mockReturnValue({
+      terminalDeliveryFailure: true,
+    });
+    mockState.handleSendChatReply.mockResolvedValue({
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            success: false,
+            error: 'Failed to reply to chat thread: 422 not_in_channel',
+            deliveryFailure: {
+              retryable: false,
+              providerErrorCode: 'not_in_channel',
+            },
+          }),
+        },
+      ],
+    });
+
+    const result = (await getRegisteredTool('send_chat_reply').handler!(
+      { message: 'done', purpose: 'closeout' },
+      { sessionId: 'thread-child' },
+    )) as { content: Array<{ type: string; text: string }> };
+
+    expect(mockState.recordChatReplyDeliveryFailure).toHaveBeenCalledWith({
+      retryable: false,
+      providerErrorCode: 'not_in_channel',
+      sessionId: 'thread-child',
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text) as Record<
+      string,
+      unknown
+    >;
+    expect(parsed.success).toBe(false);
+    expect(parsed.deliveryPermanentlyFailed).toBe(true);
+    expect(parsed.error).toContain('not_in_channel');
+    expect(parsed.error).toContain('failing permanently');
+    expect(parsed.error).toContain('do not retry');
+  });
+
+  it('does not record a delivery failure for non-delivery errors', async () => {
+    mockState.handleSendChatReply.mockResolvedValue({
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            success: false,
+            error: 'ROOMOTE_WORKSPACE_PATH not set',
+          }),
+        },
+      ],
+    });
+
+    await getRegisteredTool('send_chat_reply').handler!(
+      { message: 'done', purpose: 'closeout' },
+      { sessionId: 'thread-child' },
+    );
+
+    expect(mockState.recordChatReplyDeliveryFailure).not.toHaveBeenCalled();
   });
 
   it('passes the MCP session id into send_chat_reaction_emoji satisfaction writes', async () => {

--- a/apps/worker/src/mcp/roomote-mcp-server/chat-api-client.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/chat-api-client.ts
@@ -1,8 +1,5 @@
-import {
-  buildApiHeaders,
-  fetchWithTimeout,
-  parseApiError,
-} from './api-client.js';
+import { buildApiHeaders, fetchWithTimeout } from './api-client.js';
+import { ChatDeliveryError } from './chat-delivery-error.js';
 import type {
   CommunicationChannelMessagesResponse,
   CommunicationMessageContextResponse,
@@ -52,8 +49,39 @@ async function postToMcpEndpoint<
       continue;
     }
 
-    const error = await parseApiError(response);
-    throw new Error(`${errorPrefix}: ${response.status} ${error}`);
+    const bodyText = await response.text();
+    let parsedBody: {
+      error?: unknown;
+      retryable?: unknown;
+      slackErrorCode?: unknown;
+    } | null = null;
+    try {
+      parsedBody = JSON.parse(bodyText) as {
+        error?: unknown;
+        retryable?: unknown;
+        slackErrorCode?: unknown;
+      };
+    } catch {
+      parsedBody = null;
+    }
+
+    const errorDetail =
+      typeof parsedBody?.error === 'string' ? parsedBody.error : bodyText;
+    const message = `${errorPrefix}: ${response.status} ${errorDetail}`;
+
+    if (parsedBody?.retryable === false) {
+      throw new ChatDeliveryError({
+        message,
+        status: response.status,
+        retryable: false,
+        providerErrorCode:
+          typeof parsedBody.slackErrorCode === 'string'
+            ? parsedBody.slackErrorCode
+            : undefined,
+      });
+    }
+
+    throw new Error(message);
   }
 }
 

--- a/apps/worker/src/mcp/roomote-mcp-server/chat-delivery-error.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/chat-delivery-error.ts
@@ -1,0 +1,48 @@
+/**
+ * A chat delivery endpoint rejected the post. Carries the platform API's
+ * structured retryability verdict and provider error code so callers can act
+ * on fields instead of matching on message wording.
+ */
+export class ChatDeliveryError extends Error {
+  readonly status: number;
+  readonly retryable: boolean;
+  readonly providerErrorCode?: string;
+
+  constructor(input: {
+    message: string;
+    status: number;
+    retryable: boolean;
+    providerErrorCode?: string;
+  }) {
+    super(input.message);
+    this.name = 'ChatDeliveryError';
+    this.status = input.status;
+    this.retryable = input.retryable;
+    this.providerErrorCode = input.providerErrorCode;
+  }
+}
+
+interface ChatDeliveryFailure {
+  retryable: boolean;
+  providerErrorCode?: string;
+}
+
+/**
+ * Describes a failed delivery attempt. Errors without a structured verdict
+ * default to retryable; the bounded attempt budget in the satisfaction state
+ * still caps how long that optimism lasts.
+ */
+export function describeChatDeliveryFailure(
+  error: unknown,
+): ChatDeliveryFailure {
+  if (error instanceof ChatDeliveryError) {
+    return {
+      retryable: error.retryable,
+      ...(error.providerErrorCode
+        ? { providerErrorCode: error.providerErrorCode }
+        : {}),
+    };
+  }
+
+  return { retryable: true };
+}

--- a/apps/worker/src/mcp/roomote-mcp-server/chat-reply-satisfaction.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/chat-reply-satisfaction.ts
@@ -43,6 +43,19 @@ interface ChatReplySatisfactionState {
   terminalSatisfactionTool?: 'send_chat_reply';
   lastNonSlackWorkAfterTerminalAtMs?: number;
   lastSilenceReminderAtMs?: number;
+  /** Failed chat delivery attempts since the last successful post this turn. */
+  deliveryFailureCount?: number;
+  lastDeliveryFailureAtMs?: number;
+  /** Structured provider error code (e.g. Slack `not_in_channel`) from the latest failed delivery. */
+  lastDeliveryFailureCode?: string;
+  /**
+   * Stamped when delivery to the bound chat channel has permanently failed:
+   * a non-retryable provider error, or the bounded attempt budget is spent.
+   * The stop and silence hooks treat this as the terminal outcome so the
+   * task can complete instead of being reminded into a closeout it has no
+   * way to deliver. Cleared by any later successful post or a new turn.
+   */
+  terminalDeliveryFailureAtMs?: number;
 }
 
 function trimString(value: unknown): string {
@@ -146,11 +159,82 @@ export function recordChatTurnStart(input: {
           terminalSatisfiedAtMs: undefined,
           terminalSatisfactionTool: undefined,
           lastNonSlackWorkAfterTerminalAtMs: undefined,
+          deliveryFailureCount: undefined,
+          lastDeliveryFailureAtMs: undefined,
+          lastDeliveryFailureCode: undefined,
+          terminalDeliveryFailureAtMs: undefined,
         }
       : {}),
   };
 
   writeState(stateFilePath, state);
+}
+
+/**
+ * Bounded budget of failed delivery attempts before the failure is treated
+ * as terminal even without a structured non-retryable verdict. Keeps a task
+ * whose channel fails with an unclassified error from retrying forever.
+ */
+const MAX_RETRYABLE_DELIVERY_FAILURES_BEFORE_TERMINAL = 5;
+
+/**
+ * Records a failed chat delivery attempt. When the failure is non-retryable,
+ * or the bounded attempt budget is spent, stamps `terminalDeliveryFailureAtMs`
+ * so the stop and silence hooks stop demanding an undeliverable closeout.
+ */
+export function recordChatReplyDeliveryFailure(input: {
+  retryable: boolean;
+  providerErrorCode?: string;
+  sessionId?: string;
+  stateFilePath?: string;
+  nowMs?: number;
+}): { terminalDeliveryFailure: boolean } {
+  const stateFilePath = getStateFilePath(input.stateFilePath);
+
+  if (!stateFilePath) {
+    return { terminalDeliveryFailure: false };
+  }
+
+  const existingState = readState(stateFilePath);
+  const sessionId = trimString(input.sessionId);
+  const parentThreadId = trimString(existingState.parentThreadId);
+
+  if (parentThreadId && sessionId && sessionId !== parentThreadId) {
+    return { terminalDeliveryFailure: false };
+  }
+
+  const nowMs = input.nowMs ?? Date.now();
+  const previousCount =
+    typeof existingState.deliveryFailureCount === 'number' &&
+    Number.isFinite(existingState.deliveryFailureCount)
+      ? existingState.deliveryFailureCount
+      : 0;
+  const deliveryFailureCount = previousCount + 1;
+  const providerErrorCode = trimString(input.providerErrorCode);
+  const previousTerminalAtMs =
+    typeof existingState.terminalDeliveryFailureAtMs === 'number' &&
+    Number.isFinite(existingState.terminalDeliveryFailureAtMs)
+      ? existingState.terminalDeliveryFailureAtMs
+      : undefined;
+  const terminalDeliveryFailure =
+    previousTerminalAtMs !== undefined ||
+    !input.retryable ||
+    deliveryFailureCount >= MAX_RETRYABLE_DELIVERY_FAILURES_BEFORE_TERMINAL;
+  const state: ChatReplySatisfactionState = {
+    ...existingState,
+    deliveryFailureCount,
+    lastDeliveryFailureAtMs: nowMs,
+    ...(providerErrorCode
+      ? { lastDeliveryFailureCode: providerErrorCode }
+      : {}),
+    ...(terminalDeliveryFailure
+      ? { terminalDeliveryFailureAtMs: previousTerminalAtMs ?? nowMs }
+      : {}),
+  };
+
+  writeState(stateFilePath, state);
+
+  return { terminalDeliveryFailure };
 }
 
 export function recordChatReplySatisfaction(input: {
@@ -197,6 +281,11 @@ export function recordChatReplySatisfaction(input: {
     replyPurpose:
       input.tool === 'send_chat_reply' ? input.replyPurpose : undefined,
     recordedAtMs: nowMs,
+    // A successful post proves the channel is deliverable again.
+    deliveryFailureCount: undefined,
+    lastDeliveryFailureAtMs: undefined,
+    lastDeliveryFailureCode: undefined,
+    terminalDeliveryFailureAtMs: undefined,
     ...(satisfiesCurrentTurn
       ? {
           satisfiedTurnMessageTs: currentTurnMessageTs,

--- a/apps/worker/src/mcp/roomote-mcp-server/chat-reply-satisfaction.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/chat-reply-satisfaction.ts
@@ -281,11 +281,18 @@ export function recordChatReplySatisfaction(input: {
     replyPurpose:
       input.tool === 'send_chat_reply' ? input.replyPurpose : undefined,
     recordedAtMs: nowMs,
-    // A successful post proves the channel is deliverable again.
-    deliveryFailureCount: undefined,
-    lastDeliveryFailureAtMs: undefined,
-    lastDeliveryFailureCode: undefined,
-    terminalDeliveryFailureAtMs: undefined,
+    // A successful post proves the channel is deliverable again. Reactions
+    // do not: they go through reactions.add, not chat.postMessage, so a
+    // reaction succeeding must not re-arm closeout enforcement against a
+    // posting path that is still broken.
+    ...(input.tool === 'send_chat_reply'
+      ? {
+          deliveryFailureCount: undefined,
+          lastDeliveryFailureAtMs: undefined,
+          lastDeliveryFailureCode: undefined,
+          terminalDeliveryFailureAtMs: undefined,
+        }
+      : {}),
     ...(satisfiesCurrentTurn
       ? {
           satisfiedTurnMessageTs: currentTurnMessageTs,

--- a/apps/worker/src/mcp/roomote-mcp-server/index.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/index.ts
@@ -47,6 +47,7 @@ import { handleShowWidget } from './show-widget.js';
 import { handleSendChatReply } from './send-chat-reply.js';
 import {
   type ChatReplyPurpose,
+  recordChatReplyDeliveryFailure,
   recordChatReplySatisfaction,
 } from './chat-reply-satisfaction.js';
 import { handlePostToChannel } from './post-to-channel.js';
@@ -1358,7 +1359,9 @@ if (shouldRegisterSlackThreadReplyTool()) {
         replyPurpose: params.purpose,
         sessionId: extra.sessionId,
       });
-      return result;
+      return recordFailedChatDeliveryResult(result, {
+        sessionId: extra.sessionId,
+      });
     },
   );
 }
@@ -1399,6 +1402,78 @@ function recordSuccessfulSlackTurnSatisfactionResult(
   } catch {
     return;
   }
+}
+
+/**
+ * Records a failed delivery attempt flagged by the tool handler. When the
+ * failure becomes terminal (non-retryable, or the bounded attempt budget is
+ * spent), rewrites the tool result so the agent stops retrying an
+ * undeliverable post; the stop and silence hooks now allow completion.
+ */
+function recordFailedChatDeliveryResult(
+  result: ToolResult,
+  options: { sessionId?: string } = {},
+): ToolResult {
+  const text = result.content
+    .map((entry) => (entry.type === 'text' ? entry.text : ''))
+    .join('\n');
+
+  if (!text.trim()) {
+    return result;
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return result;
+  }
+
+  const deliveryFailure = parsed.deliveryFailure;
+  if (
+    parsed.success !== false ||
+    typeof deliveryFailure !== 'object' ||
+    deliveryFailure === null
+  ) {
+    return result;
+  }
+
+  const { retryable, providerErrorCode } = deliveryFailure as {
+    retryable?: unknown;
+    providerErrorCode?: unknown;
+  };
+  const failureRecord = recordChatReplyDeliveryFailure({
+    retryable: retryable !== false,
+    providerErrorCode:
+      typeof providerErrorCode === 'string' ? providerErrorCode : undefined,
+    sessionId: options.sessionId,
+  });
+
+  if (!failureRecord.terminalDeliveryFailure) {
+    return result;
+  }
+
+  const codeSuffix =
+    typeof providerErrorCode === 'string' && providerErrorCode
+      ? ` (${providerErrorCode})`
+      : '';
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify({
+          ...parsed,
+          deliveryPermanentlyFailed: true,
+          error:
+            `${typeof parsed.error === 'string' ? parsed.error : 'Chat delivery failed'}. ` +
+            `Delivery to the configured chat channel is failing permanently${codeSuffix}. ` +
+            'This has been recorded as the terminal delivery outcome: do not retry this or any other posting tool. ' +
+            'Finish the task now; the task transcript carries the result.',
+        }),
+      },
+    ],
+  };
 }
 
 if (shouldRegisterChannelPostTool()) {

--- a/apps/worker/src/mcp/roomote-mcp-server/send-chat-reply.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/send-chat-reply.ts
@@ -1,4 +1,5 @@
 import { replyToChatThread } from './chat-api-client.js';
+import { describeChatDeliveryFailure } from './chat-delivery-error.js';
 import {
   errorResultWithArtifacts,
   normalizeOptionalSlackText,
@@ -29,6 +30,7 @@ export async function handleSendChatReply(
 
   const uploadedArtifactIds: string[] = [];
   const allArtifactIds = [...imageArtifactIds];
+  let reachedDeliveryCall = false;
 
   try {
     const uploads = await uploadSlackImagePaths({
@@ -50,6 +52,7 @@ export async function handleSendChatReply(
       return contentValidation;
     }
 
+    reachedDeliveryCall = true;
     const reply = await replyToChatThread(roomoteConfig, {
       ...(summary && { text: summary }),
       ...(allArtifactIds.length > 0 && {
@@ -64,11 +67,23 @@ export async function handleSendChatReply(
       ...(imageArtifactIds.length > 0 && { imageArtifactIds }),
     });
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    // Only the thread_reply call itself counts as a delivery attempt; image
+    // upload or validation failures say nothing about channel deliverability.
+    const deliveryFailureFields = reachedDeliveryCall
+      ? { deliveryFailure: describeChatDeliveryFailure(error) }
+      : undefined;
+
     if (uploadedArtifactIds.length > 0) {
       return errorResultWithArtifacts(
-        error instanceof Error ? error.message : String(error),
+        message,
         uploadedArtifactIds,
+        deliveryFailureFields,
       );
+    }
+
+    if (deliveryFailureFields) {
+      return errorResult(message, deliveryFailureFields);
     }
 
     return catchError(error);

--- a/apps/worker/src/mcp/roomote-mcp-server/slack-post-helpers.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/slack-post-helpers.ts
@@ -33,6 +33,7 @@ export function uniqueNonEmpty(values?: string[]): string[] {
 export function errorResultWithArtifacts(
   message: string,
   uploadedArtifactIds: string[],
+  fields?: Record<string, unknown>,
 ): ToolResult {
   return {
     content: [
@@ -42,6 +43,7 @@ export function errorResultWithArtifacts(
           success: false,
           error: message,
           ...(uploadedArtifactIds.length > 0 && { uploadedArtifactIds }),
+          ...fields,
         }),
       },
     ],

--- a/apps/worker/src/mcp/roomote-mcp-server/tool-result.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/tool-result.ts
@@ -1,11 +1,14 @@
 import type { ToolResult } from './types.js';
 
-export function errorResult(message: string): ToolResult {
+export function errorResult(
+  message: string,
+  fields?: Record<string, unknown>,
+): ToolResult {
   return {
     content: [
       {
         type: 'text',
-        text: JSON.stringify({ success: false, error: message }),
+        text: JSON.stringify({ success: false, error: message, ...fields }),
       },
     ],
   };

--- a/apps/worker/src/run-task/__tests__/slack-silence-hook-script.test.ts
+++ b/apps/worker/src/run-task/__tests__/slack-silence-hook-script.test.ts
@@ -485,6 +485,28 @@ describe('SLACK_SILENCE_HOOK_SCRIPT', () => {
     expect(result.stderr).toContain('reason="slack_update_overdue"');
   });
 
+  it('stands down entirely when delivery to the bound channel has permanently failed', () => {
+    const stateFilePath = writeState({
+      startedAtMs: Date.now() - 7 * 60_000 - 1_000,
+      deliveryFailureCount: 5,
+      lastDeliveryFailureCode: 'not_in_channel',
+      terminalDeliveryFailureAtMs: Date.now() - 5_000,
+    });
+
+    const result = runHook({
+      input: { hook_event_name: 'PostToolUse', tool_name: 'shell' },
+      env: {
+        ROOMOTE_SLACK_HOOK_DEBUG: '1',
+        ROOMOTE_SLACK_REPLY_SATISFACTION_STATE_FILE: stateFilePath,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('decision="allow"');
+    expect(result.stderr).toContain('reason="terminal_delivery_failure"');
+  });
+
   it('names the communication surface in the silence reminder for non-Slack providers', () => {
     const stateFilePath = writeState({
       startedAtMs: Date.now() - 7 * 60_000 - 1_000,

--- a/apps/worker/src/run-task/__tests__/slack-stop-hook-script.test.ts
+++ b/apps/worker/src/run-task/__tests__/slack-stop-hook-script.test.ts
@@ -214,6 +214,67 @@ describe('SLACK_STOP_HOOK_SCRIPT', () => {
     );
   });
 
+  it('allows Stop when delivery to the bound channel has permanently failed', () => {
+    const stateFilePath = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'roomote-stop-state-')),
+      'state.json',
+    );
+    tempDirs.push(path.dirname(stateFilePath));
+    fs.writeFileSync(
+      stateFilePath,
+      JSON.stringify({
+        startedAtMs: Date.now() - 60_000,
+        requiresTerminalCloseoutWithoutTurn: true,
+        deliveryFailureCount: 1,
+        lastDeliveryFailureCode: 'not_in_channel',
+        terminalDeliveryFailureAtMs: Date.now() - 5_000,
+      }),
+      'utf8',
+    );
+
+    const result = runHook({
+      env: {
+        ROOMOTE_SLACK_HOOK_DEBUG: 'true',
+        ROOMOTE_SLACK_REPLY_SATISFACTION_STATE_FILE: stateFilePath,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('decision="allow"');
+    expect(result.stderr).toContain('reason="terminal_delivery_failure"');
+  });
+
+  it('allows Stop on an unsatisfied turn when delivery has permanently failed', () => {
+    const stateFilePath = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'roomote-stop-state-')),
+      'state.json',
+    );
+    tempDirs.push(path.dirname(stateFilePath));
+    fs.writeFileSync(
+      stateFilePath,
+      JSON.stringify({
+        currentTurnMessageTs: '111.222',
+        currentTurnStartedAtMs: Date.now() - 60_000,
+        deliveryFailureCount: 5,
+        terminalDeliveryFailureAtMs: Date.now() - 5_000,
+      }),
+      'utf8',
+    );
+
+    const result = runHook({
+      env: {
+        ROOMOTE_SLACK_HOOK_DEBUG: 'true',
+        ROOMOTE_SLACK_REPLY_SATISFACTION_STATE_FILE: stateFilePath,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('decision="allow"');
+    expect(result.stderr).toContain('reason="terminal_delivery_failure"');
+  });
+
   it('allows Stop when an automation-started task posted its closeout without an inbound turn', () => {
     const stateFilePath = path.join(
       fs.mkdtempSync(path.join(os.tmpdir(), 'roomote-stop-state-')),

--- a/apps/worker/src/run-task/slack-silence-hook-script.ts
+++ b/apps/worker/src/run-task/slack-silence-hook-script.ts
@@ -581,6 +581,21 @@ function writeInitialAckReminderState(stateFilePath, state, nowMs) {
     process.exit(0);
   }
 
+  // Delivery to the bound channel has permanently failed; ack and silence
+  // reminders would demand posts that cannot succeed, so stand down entirely.
+  const terminalDeliveryFailureAtMs = readFiniteMs(
+    state && state.terminalDeliveryFailureAtMs,
+  );
+  if (terminalDeliveryFailureAtMs !== null) {
+    logAllow({
+      trigger: hookEventName,
+      reason: 'terminal_delivery_failure',
+      tool: getToolName(hookInput),
+      terminalDeliveryFailureAtMs,
+    });
+    process.exit(0);
+  }
+
   if (
     hookEventName === 'PreToolUse' &&
     isPrematureAutomationReply(hookInput, state)

--- a/apps/worker/src/run-task/slack-stop-hook-script.ts
+++ b/apps/worker/src/run-task/slack-stop-hook-script.ts
@@ -404,6 +404,19 @@ function getTerminalCurrentTurnFailureReason(state) {
     process.exit(0);
   }
 
+  // Delivery to the bound channel has permanently failed; every reminder this
+  // hook could issue demands a post that cannot succeed, so let the turn end.
+  const terminalDeliveryFailureAtMs = readFiniteMs(
+    state && state.terminalDeliveryFailureAtMs,
+  );
+  if (terminalDeliveryFailureAtMs !== null) {
+    logAllow({
+      reason: 'terminal_delivery_failure',
+      terminalDeliveryFailureAtMs,
+    });
+    process.exit(0);
+  }
+
   if (hasConfiguredSlackReplyStateWithoutTurn(state)) {
     if (state && state.requiresTerminalCloseoutWithoutTurn === true) {
       logBlock({

--- a/packages/slack/src/__tests__/post-message-delivery.test.ts
+++ b/packages/slack/src/__tests__/post-message-delivery.test.ts
@@ -1,0 +1,54 @@
+// pnpm --filter @roomote/slack test src/__tests__/post-message-delivery.test.ts
+
+import {
+  isNonRetryableSlackPostErrorCode,
+  SlackPostDeliveryError,
+} from '../post-message-delivery';
+
+describe('isNonRetryableSlackPostErrorCode', () => {
+  it('classifies channel and credential errors as non-retryable', () => {
+    expect(isNonRetryableSlackPostErrorCode('not_in_channel')).toBe(true);
+    expect(isNonRetryableSlackPostErrorCode('channel_not_found')).toBe(true);
+    expect(isNonRetryableSlackPostErrorCode('is_archived')).toBe(true);
+    expect(isNonRetryableSlackPostErrorCode('invalid_auth')).toBe(true);
+    expect(isNonRetryableSlackPostErrorCode('token_revoked')).toBe(true);
+  });
+
+  it('keeps content-dependent and unknown errors retryable', () => {
+    expect(isNonRetryableSlackPostErrorCode('msg_too_long')).toBe(false);
+    expect(isNonRetryableSlackPostErrorCode('invalid_blocks')).toBe(false);
+    expect(isNonRetryableSlackPostErrorCode('rate_limited')).toBe(false);
+    expect(isNonRetryableSlackPostErrorCode('unknown_error')).toBe(false);
+    expect(isNonRetryableSlackPostErrorCode(undefined)).toBe(false);
+  });
+});
+
+describe('SlackPostDeliveryError', () => {
+  it('is non-retryable for permanent Slack error codes', () => {
+    const error = new SlackPostDeliveryError({
+      slackErrorCode: 'not_in_channel',
+    });
+
+    expect(error.message).toBe('Slack chat.postMessage failed: not_in_channel');
+    expect(error.slackErrorCode).toBe('not_in_channel');
+    expect(error.retryable).toBe(false);
+  });
+
+  it('is retryable for transport failures', () => {
+    const error = new SlackPostDeliveryError({ transportError: true });
+
+    expect(error.message).toBe(
+      'Slack chat.postMessage failed: transport error',
+    );
+    expect(error.transportError).toBe(true);
+    expect(error.retryable).toBe(true);
+  });
+
+  it('is retryable for content-dependent Slack error codes', () => {
+    const error = new SlackPostDeliveryError({
+      slackErrorCode: 'msg_too_long',
+    });
+
+    expect(error.retryable).toBe(true);
+  });
+});

--- a/packages/slack/src/__tests__/slack-notifier.test.ts
+++ b/packages/slack/src/__tests__/slack-notifier.test.ts
@@ -131,6 +131,20 @@ describe('SlackNotifier', () => {
       expect(ts).toBeUndefined();
     });
 
+    it('returns undefined when Slack rejects the message', async () => {
+      getGlobalWithFetch().fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ ok: false, error: 'not_in_channel' }),
+      });
+
+      const ts = await notifier.postMessage({
+        channel: 'C123',
+        text: 'rejected case',
+      });
+
+      expect(ts).toBeUndefined();
+    });
+
     it('does not change unfurl behavior for plain text messages', async () => {
       getGlobalWithFetch().fetch = vi.fn().mockResolvedValue({
         ok: true,
@@ -184,6 +198,66 @@ describe('SlackNotifier', () => {
           }),
         }),
       );
+    });
+  });
+
+  describe('postMessageDetailed', () => {
+    it('returns the message ts on success', async () => {
+      getGlobalWithFetch().fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ ok: true, ts: '123.456' }),
+      });
+
+      const result = await notifier.postMessageDetailed({
+        channel: 'C123',
+        text: 'hello world',
+      });
+
+      expect(result).toEqual({ ts: '123.456' });
+    });
+
+    it('returns the Slack error code when Slack rejects the message', async () => {
+      getGlobalWithFetch().fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ ok: false, error: 'not_in_channel' }),
+      });
+
+      const result = await notifier.postMessageDetailed({
+        channel: 'C123',
+        text: 'rejected case',
+      });
+
+      expect(result).toEqual({ slackErrorCode: 'not_in_channel' });
+    });
+
+    it('flags a transport error for non-2xx responses', async () => {
+      getGlobalWithFetch().fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
+
+      const result = await notifier.postMessageDetailed({
+        channel: 'C123',
+        text: 'failure case',
+      });
+
+      expect(result).toEqual({ transportError: true });
+    });
+
+    it('flags a skipped threaded reply when the thread root is gone', async () => {
+      getGlobalWithFetch().fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: false, error: 'thread_not_found' }),
+      });
+
+      const result = await notifier.postMessageDetailed({
+        channel: 'C123',
+        thread_ts: '123.000',
+        text: 'hello thread',
+      });
+
+      expect(result).toEqual({ skippedMissingThreadRoot: true });
     });
   });
 

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -20,6 +20,7 @@ export * from './slack-api-base-url';
 export * from './slack-api-fetch';
 export * from './slack-channel-info-cache';
 export * from './slack-messages';
+export * from './post-message-delivery';
 export * from './slack-notifier';
 export * from './slack-system-messages';
 export * from './slack-thread-message-utils';
@@ -49,6 +50,7 @@ export type {
   SlackFile,
   SlackMessage,
   SlackMessageMetadata,
+  SlackPostMessageResult,
   SlackResponse,
   SlackEvent,
   SlackThreadMessage,

--- a/packages/slack/src/post-message-delivery.ts
+++ b/packages/slack/src/post-message-delivery.ts
@@ -1,0 +1,57 @@
+/**
+ * Slack error codes for chat.postMessage that cannot succeed by retrying the
+ * same request against the same target: the channel is gone or inaccessible,
+ * or the installation's credentials are dead. Content-dependent errors such
+ * as `msg_too_long` and `invalid_blocks` are deliberately excluded — a
+ * rewritten message can still go through.
+ */
+const NON_RETRYABLE_SLACK_POST_ERROR_CODES = new Set([
+  'account_inactive',
+  'channel_not_found',
+  'ekm_access_denied',
+  'invalid_auth',
+  'is_archived',
+  'messages_tab_disabled',
+  'no_permission',
+  'not_in_channel',
+  'org_login_required',
+  'restricted_action',
+  'team_access_not_granted',
+  'token_expired',
+  'token_revoked',
+]);
+
+export function isNonRetryableSlackPostErrorCode(
+  code: string | undefined,
+): boolean {
+  return code !== undefined && NON_RETRYABLE_SLACK_POST_ERROR_CODES.has(code);
+}
+
+/**
+ * A chat.postMessage attempt failed. Carries the structured Slack error code
+ * (or transport-failure flag) so API handlers can report retryability to the
+ * calling agent instead of collapsing every failure into a generic 502.
+ */
+export class SlackPostDeliveryError extends Error {
+  readonly slackErrorCode?: string;
+  readonly transportError: boolean;
+
+  constructor(result: { slackErrorCode?: string; transportError?: boolean }) {
+    super(
+      `Slack chat.postMessage failed: ${
+        result.slackErrorCode ??
+        (result.transportError ? 'transport error' : 'unknown error')
+      }`,
+    );
+    this.name = 'SlackPostDeliveryError';
+    this.slackErrorCode = result.slackErrorCode;
+    this.transportError = result.transportError === true;
+  }
+
+  get retryable(): boolean {
+    return (
+      this.transportError ||
+      !isNonRetryableSlackPostErrorCode(this.slackErrorCode)
+    );
+  }
+}

--- a/packages/slack/src/slack-notifier.ts
+++ b/packages/slack/src/slack-notifier.ts
@@ -3,6 +3,7 @@ import type {
   SlackConversationMessage,
   SlackMessage,
   SlackMessageMetadata,
+  SlackPostMessageResult,
   SlackResponse,
   SlackFile,
   SlackThreadMessage,
@@ -862,6 +863,18 @@ export class SlackNotifier {
   }
 
   public async postMessage(message: SlackMessage) {
+    return (await this.postMessageDetailed(message)).ts;
+  }
+
+  /**
+   * Like postMessage, but preserves why a post produced no timestamp: the
+   * Slack API error code, a transport failure, or a skipped reply into a
+   * deleted thread. Callers that report failures to an agent or decide
+   * retryability must use this instead of inferring from a missing ts.
+   */
+  public async postMessageDetailed(
+    message: SlackMessage,
+  ): Promise<SlackPostMessageResult> {
     if (message.channel && message.thread_ts) {
       const threadRootExists = await this.hasMessageInThread({
         channel: message.channel,
@@ -873,7 +886,7 @@ export class SlackNotifier {
         console.warn(
           `[postMessage] Skipping threaded Slack reply because thread root ${message.thread_ts} is no longer available in channel ${message.channel}`,
         );
-        return undefined;
+        return { skippedMissingThreadRoot: true };
       }
     }
 
@@ -883,7 +896,15 @@ export class SlackNotifier {
       'regular',
     );
 
-    return response?.ts;
+    if (!response) {
+      return { transportError: true };
+    }
+
+    if (!response.ok || !response.ts) {
+      return { slackErrorCode: response.error ?? 'unknown_error' };
+    }
+
+    return { ts: response.ts };
   }
 
   public async postEphemeralMessage(message: SlackMessage & { user: string }) {

--- a/packages/slack/src/types.ts
+++ b/packages/slack/src/types.ts
@@ -28,6 +28,20 @@ export interface SlackResponse {
   message?: Record<string, unknown>;
 }
 
+/**
+ * Structured outcome of a chat.postMessage attempt. Exactly one of the
+ * fields is set: `ts` on success, otherwise the failure discriminator.
+ */
+export interface SlackPostMessageResult {
+  ts?: string;
+  /** Slack API error code (e.g. `not_in_channel`) when Slack rejected the post. */
+  slackErrorCode?: string;
+  /** The HTTP call itself failed (non-2xx status or network error); retryable. */
+  transportError?: boolean;
+  /** Threaded reply skipped because the thread root message no longer exists. */
+  skippedMissingThreadRoot?: boolean;
+}
+
 export interface SlackMessageMetadata {
   event_type: string;
   event_payload: Record<string, unknown>;


### PR DESCRIPTION
## Problem

An automation-started task whose Slack channel rejects every `chat.postMessage` gets wedged in a closeout retry loop:

1. The task finishes its work and goes idle without a delivered closeout.
2. The stop hook blocks the idle (`automation_missing_terminal_closeout`) and reminds the agent to post with `send_chat_reply` purpose `closeout`.
3. The post fails, but the real Slack error is swallowed twice: `SlackNotifier.sendMessage` logs it server-side and returns nothing, and the `thread_reply` MCP handler collapses it into a generic `502 Slack chat.postMessage returned no message timestamp`.
4. A 502 reads as transient, so the agent retries; the hook re-blocks on the next idle; repeat.

In a real occurrence the agent made 15 failed post attempts over ~6 minutes before the harness reminder cap fired, and the run then completed silently with the deliverable never posted anywhere. The closeout requirement had no escape path: satisfaction is only recordable from a successful post, which was impossible.

## Fix

**Propagate the real Slack error (API side)**

- `SlackNotifier.postMessageDetailed` returns a structured outcome: `ts` on success, otherwise the Slack error code, a transport-error flag, or the skipped-missing-thread-root marker. `postMessage` keeps its existing signature and delegates.
- The `thread_reply` MCP handler throws a typed `SlackPostDeliveryError` and maps it to a structured response: `{ error, slackErrorCode, retryable }`, status 422 for permanent errors (`not_in_channel`, `channel_not_found`, `is_archived`, `invalid_auth`, `token_revoked`, ...) and 502 for transient ones. Content-dependent errors (`msg_too_long`, `invalid_blocks`) stay retryable since a rewritten message can succeed.
- The previously conflated "no ts" case in the existing-thread path now distinguishes a deleted thread root (still 409) from a real delivery failure.

## Escape hatch (worker side)

- The worker's chat API client turns a `retryable: false` response into a typed `ChatDeliveryError` carrying the provider error code (structured fields, no message-wording matching).
- `send_chat_reply` failures from the delivery call are recorded in the reply-satisfaction state file: a non-retryable error, or 5 failed attempts (bounded fallback for unclassified errors), stamps `terminalDeliveryFailureAtMs`.
- Once terminal, the tool result tells the agent explicitly that delivery is failing permanently and not to retry.
- The stop hook and silence hook treat the terminal delivery failure as the turn's terminal outcome (`terminal_delivery_failure` allow) instead of demanding an undeliverable closeout, so the task completes cleanly with the outcome in the transcript.
- A later successful post or a new inbound turn clears the failure state, so recovery restores normal closeout enforcement.

## Not in this PR

- The escape hatch covers `send_chat_reply` on every provider (Slack, Teams, Telegram, Discord) via the bounded failure budget, since it instruments the shared tool path. The fast path (immediate terminal on a structured non-retryable code) is Slack-only for now; surfacing structured error codes from the other providers is a follow-up.
- `post_to_channel` keeps its generic errors and deliberately does not feed the delivery-failure budget: it can target arbitrary channels, so its failures must not poison the bound thread's closeout state. Structured error codes for it are part of the same follow-up.
- Surfacing the delivery failure on the automation run record (beyond the transcript) is a follow-up.

## Validation

- `pnpm lint`, `pnpm check-types`, `pnpm knip` all pass.
- Full `@roomote/slack` suite (350 tests), full `@roomote/worker` suite (1619 tests; the 4 failures in `tail-file-path`/`command-executor` are pre-existing on develop in this environment), and `apps/api` MCP handler suite (165 tests) pass.
- New coverage: `postMessageDetailed` outcomes, error-code classification, the 422/502/409 handler mapping, delivery-failure recording (count, terminal stamp, clear-on-success, reset-on-new-turn, non-parent-session guard), the terminal rewrite of the tool result, and `terminal_delivery_failure` allows in both hook scripts.
