### PR TITLE
[Feat] Restore line-anchored inline PR review comments on all providers

### DIFF
--- a/apps/api/src/handlers/tasks/__tests__/manageSourceControl.test.ts
+++ b/apps/api/src/handlers/tasks/__tests__/manageSourceControl.test.ts
@@ -9,11 +9,13 @@ const {
   mockClaimLatestUserMessageForReplyQuote,
   mockFindTaskRunForSourceControlMutation,
   mockManageSourceControlIssueForTaskRun,
+  mockWriteSourceControlPullRequestForTaskRun,
 } = vi.hoisted(() => ({
   mockAssertTaskRunTokenTargetExists: vi.fn(),
   mockClaimLatestUserMessageForReplyQuote: vi.fn(),
   mockFindTaskRunForSourceControlMutation: vi.fn(),
   mockManageSourceControlIssueForTaskRun: vi.fn(),
+  mockWriteSourceControlPullRequestForTaskRun: vi.fn(),
 }));
 
 vi.mock('@roomote/communication/messages', () => ({
@@ -26,6 +28,8 @@ vi.mock('@roomote/sdk/server', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@roomote/sdk/server')>()),
   findTaskRunForSourceControlMutation: mockFindTaskRunForSourceControlMutation,
   manageSourceControlIssueForTaskRun: mockManageSourceControlIssueForTaskRun,
+  writeSourceControlPullRequestForTaskRun:
+    mockWriteSourceControlPullRequestForTaskRun,
 }));
 
 vi.mock('../../mcp/proxy-utils', async (importOriginal) => ({
@@ -100,6 +104,50 @@ describe('manageSourceControl', () => {
       input: expect.objectContaining({
         repositoryFullName: 'acme/backend',
         body: 'Fixed in the latest branch.',
+      }),
+    });
+  });
+
+  it('dispatches create_pull_request_review_comment to the write surface without reply quoting', async () => {
+    mockWriteSourceControlPullRequestForTaskRun.mockResolvedValue({
+      success: true,
+      action: 'create_pull_request_review_comment',
+      provider: 'github',
+      repositoryFullName: 'acme/frontend',
+      number: 55,
+      threadId: null,
+      commentId: '3001',
+      url: 'https://github.com/acme/frontend/pull/55#discussion_r3001',
+      applied: true,
+      warnings: [],
+    });
+
+    const response = await createApp().request('/task-1/source_control', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        action: 'create_pull_request_review_comment',
+        repositoryFullName: 'acme/frontend',
+        prNumber: 55,
+        path: 'src/index.ts',
+        line: 42,
+        side: 'RIGHT',
+        body: 'Missing error handling here.',
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    // Inline review findings are agent-authored, so the pending user message
+    // must never be quoted above them even on a GitHub target with a body.
+    expect(mockClaimLatestUserMessageForReplyQuote).not.toHaveBeenCalled();
+    expect(mockWriteSourceControlPullRequestForTaskRun).toHaveBeenCalledWith({
+      taskRun: expect.objectContaining({ id: 123 }),
+      input: expect.objectContaining({
+        action: 'create_pull_request_review_comment',
+        path: 'src/index.ts',
+        line: 42,
+        side: 'RIGHT',
+        body: 'Missing error handling here.',
       }),
     });
   });

--- a/apps/api/src/handlers/tasks/manageSourceControl.ts
+++ b/apps/api/src/handlers/tasks/manageSourceControl.ts
@@ -108,6 +108,9 @@ export async function manageSourceControl(
       );
     }
     const bodyInput = 'body' in input ? input : null;
+    // create_pull_request_review_comment is deliberately excluded: inline
+    // review findings are agent-authored, not replies to a pending user
+    // message, so quoting the latest user message above one would be wrong.
     const shouldQuote =
       targetProvider === 'github' &&
       (input.action === 'reply_to_pull_request_comment' ||
@@ -176,6 +179,7 @@ export async function manageSourceControl(
         );
       case 'reply_to_pull_request_comment':
       case 'create_pull_request_comment':
+      case 'create_pull_request_review_comment':
       case 'resolve_pull_request_thread':
       case 'submit_pull_request_review':
       case 'update_pull_request_comment': {

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/source-control.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/source-control.test.ts
@@ -285,4 +285,107 @@ describe('handleManageSourceControl issue actions', () => {
     });
     expect(tasksApiClient.manageSourceControlIssue).not.toHaveBeenCalled();
   });
+
+  it('forwards create_pull_request_review_comment anchor fields to the write surface', async () => {
+    vi.mocked(tasksApiClient.writeSourceControl).mockResolvedValueOnce({
+      success: true,
+      action: 'create_pull_request_review_comment',
+      provider: 'github',
+      repositoryFullName: 'acme/web',
+      number: 12,
+      threadId: null,
+      commentId: '3001',
+      url: 'https://github.com/acme/web/pull/12#discussion_r3001',
+      applied: true,
+      warnings: [],
+    } as never);
+
+    const result = await handleManageSourceControl(
+      {
+        action: 'create_pull_request_review_comment',
+        repositoryFullName: 'acme/web',
+        prNumber: 12,
+        path: '  src/index.ts  ',
+        line: 42,
+        side: 'RIGHT',
+        startLine: 40,
+        startSide: 'RIGHT',
+        body: 'Missing error handling here.',
+      },
+      config,
+      'task-1',
+    );
+
+    expect(JSON.parse(result.content[0]?.text ?? '')).toMatchObject({
+      success: true,
+      commentId: '3001',
+    });
+    expect(tasksApiClient.writeSourceControl).toHaveBeenCalledWith(
+      config,
+      'task-1',
+      expect.objectContaining({
+        action: 'create_pull_request_review_comment',
+        repositoryFullName: 'acme/web',
+        prNumber: 12,
+        path: 'src/index.ts',
+        line: 42,
+        side: 'RIGHT',
+        startLine: 40,
+        startSide: 'RIGHT',
+        body: 'Missing error handling here.',
+      }),
+    );
+  });
+
+  it('requires path, a positive integer line, and a body for inline review comments', async () => {
+    const missingPath = await handleManageSourceControl(
+      {
+        action: 'create_pull_request_review_comment',
+        repositoryFullName: 'acme/web',
+        prNumber: 12,
+        line: 42,
+        body: 'Missing error handling here.',
+      },
+      config,
+      'task-1',
+    );
+    const badLine = await handleManageSourceControl(
+      {
+        action: 'create_pull_request_review_comment',
+        repositoryFullName: 'acme/web',
+        prNumber: 12,
+        path: 'src/index.ts',
+        line: 0,
+        body: 'Missing error handling here.',
+      },
+      config,
+      'task-1',
+    );
+    const missingBody = await handleManageSourceControl(
+      {
+        action: 'create_pull_request_review_comment',
+        repositoryFullName: 'acme/web',
+        prNumber: 12,
+        path: 'src/index.ts',
+        line: 42,
+      },
+      config,
+      'task-1',
+    );
+
+    expect(JSON.parse(missingPath.content[0]?.text ?? '')).toMatchObject({
+      success: false,
+      error: 'path is required for create_pull_request_review_comment',
+    });
+    expect(JSON.parse(badLine.content[0]?.text ?? '')).toMatchObject({
+      success: false,
+      error:
+        'line is required for create_pull_request_review_comment and must be a positive integer',
+    });
+    expect(JSON.parse(missingBody.content[0]?.text ?? '')).toMatchObject({
+      success: false,
+      error: 'body is required for create_pull_request_review_comment',
+    });
+    expect(tasksApiClient.writeSourceControl).not.toHaveBeenCalled();
+  });
 });

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/tool-descriptions.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/tool-descriptions.test.ts
@@ -837,4 +837,69 @@ describe('roomote MCP tool descriptions', () => {
       ],
     });
   });
+
+  it('forwards inline review comment anchor fields from manage_source_control tool params', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          success: true,
+          action: 'create_pull_request_review_comment',
+          provider: 'github',
+          repositoryFullName: 'RooCodeInc/Roomote',
+          number: 12,
+          threadId: null,
+          commentId: '3001',
+          url: 'https://github.com/RooCodeInc/Roomote/pull/12#discussion_r3001',
+          applied: true,
+          warnings: [],
+        }),
+      }),
+    );
+
+    const { registeredTools } = await importRoomoteMcpServer({
+      ROOMOTE_CLOUD_TOKEN: 'run-token',
+      ROOMOTE_PLATFORM_API_URL: 'https://platform.example.com',
+      ROOMOTE_TASK_ID: 'task_123',
+    });
+    const sourceControlTool = getRegisteredTool(
+      registeredTools,
+      'manage_source_control',
+    );
+
+    const result = await sourceControlTool.handler?.({
+      action: 'create_pull_request_review_comment',
+      repositoryFullName: 'RooCodeInc/Roomote',
+      prNumber: 12,
+      path: 'src/index.ts',
+      line: 42,
+      side: 'RIGHT',
+      body: 'Missing error handling here.',
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://platform.example.com/api/mcp/tasks/task_123/source_control',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'create_pull_request_review_comment',
+          repositoryFullName: 'RooCodeInc/Roomote',
+          prNumber: 12,
+          body: 'Missing error handling here.',
+          path: 'src/index.ts',
+          line: 42,
+          side: 'RIGHT',
+        }),
+      }),
+    );
+    expect(result).toMatchObject({
+      content: [
+        {
+          type: 'text',
+          text: expect.stringContaining('"commentId":"3001"'),
+        },
+      ],
+    });
+  });
 });

--- a/apps/worker/src/mcp/roomote-mcp-server/index.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/index.ts
@@ -729,6 +729,7 @@ roomoteMcpServer.registerTool(
       '"list_pull_requests" to list open PRs/MRs in a repository (summaries with branches, labels, and mergeability where the provider exposes it), and ' +
       '"list_pull_request_comments" to read review threads (with resolution state) and issue comments. ' +
       'Use "reply_to_pull_request_comment" to answer a review thread, "create_pull_request_comment" for a top-level comment, ' +
+      '"create_pull_request_review_comment" for a new inline comment anchored to a file and line of the current diff, ' +
       '"resolve_pull_request_thread" to resolve or reopen a thread, and "submit_pull_request_review" to approve, request changes, or leave a review comment. ' +
       'Provider gaps are reported as warnings with applied:false instead of errors. ' +
       'For the PR diff, use local git against the returned SHAs instead of a provider CLI. ' +
@@ -742,6 +743,7 @@ roomoteMcpServer.registerTool(
           'list_pull_request_comments',
           'reply_to_pull_request_comment',
           'create_pull_request_comment',
+          'create_pull_request_review_comment',
           'resolve_pull_request_thread',
           'submit_pull_request_review',
           'update_pull_request_comment',
@@ -750,7 +752,7 @@ roomoteMcpServer.registerTool(
           'create_issue_comment',
         ])
         .describe(
-          'get_issue reads a plain issue; list_issue_comments reads its comments; create_issue_comment posts a top-level issue comment. create_or_update_pull_request creates or refreshes the PR/MR for a branch; get_pull_request reads PR/MR details; list_pull_requests lists open PRs/MRs in the repository; list_pull_request_comments reads review threads and issue comments; reply_to_pull_request_comment answers a review thread; create_pull_request_comment posts a top-level PR comment; resolve_pull_request_thread resolves or reopens a thread; submit_pull_request_review approves, requests changes, or leaves a review comment; update_pull_request_comment edits an existing comment in place.',
+          'get_issue reads a plain issue; list_issue_comments reads its comments; create_issue_comment posts a top-level issue comment. create_or_update_pull_request creates or refreshes the PR/MR for a branch; get_pull_request reads PR/MR details; list_pull_requests lists open PRs/MRs in the repository; list_pull_request_comments reads review threads and issue comments; reply_to_pull_request_comment answers a review thread; create_pull_request_comment posts a top-level PR comment; create_pull_request_review_comment posts one new inline review comment anchored to a file and line of the current diff (one finding per call); resolve_pull_request_thread resolves or reopens a thread; submit_pull_request_review approves, requests changes, or leaves a review comment; update_pull_request_comment edits an existing comment in place.',
         ),
       repositoryFullName: z
         .string()
@@ -812,6 +814,38 @@ roomoteMcpServer.registerTool(
         .describe(
           'Required for submit_pull_request_review: the review outcome to submit.',
         ),
+      path: z
+        .string()
+        .optional()
+        .describe(
+          'Required for create_pull_request_review_comment: repository-relative path of the file the comment anchors to.',
+        ),
+      line: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe(
+          'Required for create_pull_request_review_comment: 1-based line number in the file version named by side. The line must be part of the current PR/MR diff; if the provider rejects the anchor, the call errors so you can correct the anchor and retry once, then fall back to carrying the finding in the review summary comment.',
+        ),
+      side: z
+        .enum(['LEFT', 'RIGHT'])
+        .optional()
+        .describe(
+          'Optional for create_pull_request_review_comment. RIGHT (default) anchors on the new version of the file (added or changed lines); LEFT anchors on the old version (deleted lines).',
+        ),
+      startLine: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe(
+          'Optional multi-line range start for create_pull_request_review_comment; must not exceed line. GitHub and Azure DevOps honor the range; other providers anchor to line and report a warning.',
+        ),
+      startSide: z
+        .enum(['LEFT', 'RIGHT'])
+        .optional()
+        .describe('Optional side for startLine on GitHub; defaults to side.'),
       sourceBranch: z
         .string()
         .optional()
@@ -882,6 +916,11 @@ roomoteMcpServer.registerTool(
         commentId: params.commentId,
         resolved: params.resolved,
         reviewEvent: params.reviewEvent,
+        path: params.path,
+        line: params.line,
+        side: params.side,
+        startLine: params.startLine,
+        startSide: params.startSide,
         sourceBranch: params.sourceBranch,
         targetBranch: params.targetBranch,
         title: params.title,

--- a/apps/worker/src/mcp/roomote-mcp-server/source-control.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/source-control.ts
@@ -17,6 +17,7 @@ type ManageSourceControlParams = {
     | 'list_pull_request_comments'
     | 'reply_to_pull_request_comment'
     | 'create_pull_request_comment'
+    | 'create_pull_request_review_comment'
     | 'resolve_pull_request_thread'
     | 'submit_pull_request_review'
     | 'update_pull_request_comment'
@@ -32,6 +33,11 @@ type ManageSourceControlParams = {
   commentId?: string;
   resolved?: boolean;
   reviewEvent?: 'approve' | 'request_changes' | 'comment';
+  path?: string;
+  line?: number;
+  side?: 'LEFT' | 'RIGHT';
+  startLine?: number;
+  startSide?: 'LEFT' | 'RIGHT';
   sourceBranch?: string;
   targetBranch?: string;
   title?: string;
@@ -173,10 +179,29 @@ export async function handleManageSourceControl(
     if (
       (params.action === 'reply_to_pull_request_comment' ||
         params.action === 'create_pull_request_comment' ||
+        params.action === 'create_pull_request_review_comment' ||
         params.action === 'update_pull_request_comment') &&
       !params.body?.trim()
     ) {
       return errorResult(`body is required for ${params.action}`);
+    }
+
+    if (params.action === 'create_pull_request_review_comment') {
+      if (!params.path?.trim()) {
+        return errorResult(
+          'path is required for create_pull_request_review_comment',
+        );
+      }
+
+      if (
+        typeof params.line !== 'number' ||
+        !Number.isInteger(params.line) ||
+        params.line <= 0
+      ) {
+        return errorResult(
+          'line is required for create_pull_request_review_comment and must be a positive integer',
+        );
+      }
     }
 
     if (
@@ -208,6 +233,7 @@ export async function handleManageSourceControl(
     // comment updates using the presence of threadId).
     const threadId = params.threadId?.trim() || undefined;
     const commentId = params.commentId?.trim() || undefined;
+    const path = params.path?.trim() || undefined;
 
     return jsonResult(
       await writeSourceControl(config, taskId, {
@@ -219,6 +245,11 @@ export async function handleManageSourceControl(
         body: params.body,
         resolved: params.resolved,
         reviewEvent: params.reviewEvent,
+        path,
+        line: params.line,
+        side: params.side,
+        startLine: params.startLine,
+        startSide: params.startSide,
         sourceControlProvider: params.sourceControlProvider,
       }),
     );

--- a/apps/worker/src/mcp/roomote-mcp-server/tasks-api-client.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/tasks-api-client.ts
@@ -311,6 +311,7 @@ export async function writeSourceControl(
     action:
       | 'reply_to_pull_request_comment'
       | 'create_pull_request_comment'
+      | 'create_pull_request_review_comment'
       | 'resolve_pull_request_thread'
       | 'submit_pull_request_review'
       | 'update_pull_request_comment';
@@ -321,6 +322,11 @@ export async function writeSourceControl(
     body?: string;
     resolved?: boolean;
     reviewEvent?: 'approve' | 'request_changes' | 'comment';
+    path?: string;
+    line?: number;
+    side?: 'LEFT' | 'RIGHT';
+    startLine?: number;
+    startSide?: 'LEFT' | 'RIGHT';
     sourceControlProvider?: SourceControlProvider;
   },
 ): Promise<SourceControlPullRequestReadResponse> {

--- a/packages/cloud-agents/src/server/workflows/__tests__/githubPrReviewSkill.test.ts
+++ b/packages/cloud-agents/src/server/workflows/__tests__/githubPrReviewSkill.test.ts
@@ -336,6 +336,37 @@ describe('review-code GitHub workflow paths', () => {
     );
   });
 
+  it('publishes new findings as line-anchored inline comments with a retry-then-summary-carry recovery', () => {
+    for (const appendixName of [
+      'review-github-pr',
+      'review-github-pr-with-approval',
+      'sync-github-pr-review',
+      'sync-github-pr-review-with-approval',
+    ]) {
+      const appendix = readAppendix(skillContent, appendixName);
+      expect(appendix).toContain(
+        'post one new line-anchored inline comment per finding with `mcp__roomote__manage_source_control` `action: "create_pull_request_review_comment"`',
+      );
+      expect(appendix).toContain(
+        'If the provider rejects the anchor because the line is not part of the current diff, re-check the hunk, correct `path`, `line`, or `side`, and retry exactly once.',
+      );
+      expect(appendix).toContain(
+        'Match the suggestion syntax to `source_control_provider`: a fenced code block with info string `suggestion` on github and gitea, a fenced code block with info string `suggestion:-0+0` on gitlab, and a plain fenced code block with prose (no suggestion syntax) on bitbucket and ado.',
+      );
+      expect(appendix).toContain(
+        'Bitbucket and Azure DevOps do not validate anchors against the diff',
+      );
+    }
+    expect(skillContent).toContain(
+      '<scenario name="inline_comment_anchor_rejected">',
+    );
+    expect(skillContent).not.toContain('finding_without_thread_anchor');
+    expect(skillContent).not.toContain(
+      'no batch API for creating new line-anchored inline comments',
+    );
+    expect(skillContent).not.toContain('summary-carried on all providers');
+  });
+
   it('removes CI and check-state language from the shared skill contract', () => {
     expect(skillContent).not.toContain(
       'If unresolved findings remain after combining the published code findings with the latest fetched CI state',

--- a/packages/cloud-agents/src/server/workflows/skills/standard/review-code/SKILL.md
+++ b/packages/cloud-agents/src/server/workflows/skills/standard/review-code/SKILL.md
@@ -284,12 +284,13 @@ You are a pull request review workflow specialist. Review the assigned pull requ
         <description>Attach each accepted code finding to the most precise provider comment surface available.</description>
         <actions>
           <action>Use one published finding per issue. Keep the prose brief, concrete, and matter-of-fact.</action>
-          <action>The provider-neutral review surface has no batch API for creating new line-anchored inline comments; line-anchored new comments are currently summary-carried on all providers.</action>
           <action>For each finding, check the fetched review threads for an existing thread anchored on the same file and overlapping lines. When one exists, post the finding as a reply on that thread with `mcp__roomote__manage_source_control` `action: "reply_to_pull_request_comment"` and that thread's `threadId`, and record the returned `commentId` so the linked-task handoff can reference it.</action>
-          <action>When no matching thread exists, carry the finding in the canonical summary comment instead: include it in the hidden checklist block as an unchecked item with an explicit `path/to/file.ts:42`-style file and line reference so the author can locate it without an inline anchor.</action>
-          <action>Use this body structure for each actionable finding: concise explanation plus an optional `suggestion` block when a concrete code replacement is helpful. Do not append Roomote-authored action links or hidden fix markers.</action>
+          <action>When no matching thread exists and the finding maps to the current PR diff, post one new line-anchored inline comment per finding with `mcp__roomote__manage_source_control` `action: "create_pull_request_review_comment"`, passing `path`, `line`, and `side` (`RIGHT` for added or changed lines, `LEFT` only for findings on deleted lines; pass `startLine` for a multi-line range where the provider supports it), and record the returned `commentId` and `threadId` so the linked-task handoff can reference them.</action>
+          <action>If the provider rejects the anchor because the line is not part of the current diff, re-check the hunk, correct `path`, `line`, or `side`, and retry exactly once. If it is still rejected, carry the finding in the canonical summary comment instead: include it in the hidden checklist block as an unchecked item with an explicit `path/to/file.ts:42`-style file and line reference so the author can locate it without an inline anchor.</action>
+          <action>Bitbucket and Azure DevOps do not validate anchors against the diff, so choose the file and line carefully there; an out-of-diff anchor silently lands as a non-diff comment instead of erroring.</action>
+          <action>Use this body structure for each actionable finding: concise explanation plus an optional suggestion block when a concrete, self-contained code replacement is helpful. Match the suggestion syntax to `source_control_provider`: a fenced code block with info string `suggestion` on github and gitea, a fenced code block with info string `suggestion:-0+0` on gitlab, and a plain fenced code block with prose (no suggestion syntax) on bitbucket and ado. Do not append Roomote-authored action links or hidden fix markers.</action>
         </actions>
-        <validation>Every accepted finding was either posted as a reply on a matching existing review thread or carried in the canonical summary comment with a concrete file and line reference.</validation>
+        <validation>Every accepted finding was posted as a reply on a matching existing review thread, posted as a new line-anchored inline comment, or carried in the canonical summary comment with a concrete file and line reference after a failed anchor retry.</validation>
       </step>
       <step number="6">
         <title>Update the canonical summary comment</title>
@@ -445,13 +446,13 @@ You are a pull request review workflow specialist. Review the assigned pull requ
 </causes>
 <recovery>Create a new canonical summary comment with the required hidden marker and continue using that new comment only.</recovery>
 </scenario>
-<scenario name="finding_without_thread_anchor">
-<problem>An accepted finding has no existing review thread on the same file and lines to reply to.</problem>
+<scenario name="inline_comment_anchor_rejected">
+<problem>The provider rejected a new line-anchored inline comment because the anchor does not map onto the current diff.</problem>
 <causes>
-<cause>The finding targets code that no prior review discussion touched.</cause>
-<cause>The provider result did not expose a matching thread anchor for the target location.</cause>
+<cause>The target line is not part of the current PR diff, or the side is wrong for the change.</cause>
+<cause>The diff moved because new commits landed after the review read it.</cause>
 </causes>
-<recovery>Carry the finding in the canonical summary comment with an explicit file and line reference instead of attempting an unsupported line-anchored comment.</recovery>
+<recovery>Re-check the hunk, correct `path`, `line`, or `side`, and retry exactly once. If the anchor is still rejected, carry the finding in the canonical summary comment with an explicit file and line reference instead of forcing an invalid anchor.</recovery>
 </scenario>
 </error_handling>
 
@@ -559,12 +560,13 @@ You are a pull request review workflow specialist. Review the assigned pull requ
         <description>Attach each accepted code finding to the most precise provider comment surface available.</description>
         <actions>
           <action>Use one published finding per issue. Keep the prose brief, concrete, and matter-of-fact.</action>
-          <action>The provider-neutral review surface has no batch API for creating new line-anchored inline comments; line-anchored new comments are currently summary-carried on all providers.</action>
           <action>For each finding, check the fetched review threads for an existing thread anchored on the same file and overlapping lines. When one exists, post the finding as a reply on that thread with `mcp__roomote__manage_source_control` `action: "reply_to_pull_request_comment"` and that thread's `threadId`, and record the returned `commentId` so the linked-task handoff can reference it.</action>
-          <action>When no matching thread exists, carry the finding in the canonical summary comment instead: include it in the hidden checklist block as an unchecked item with an explicit `path/to/file.ts:42`-style file and line reference so the author can locate it without an inline anchor.</action>
-          <action>Use this body structure for each actionable finding: concise explanation plus an optional `suggestion` block when a concrete code replacement is helpful. Do not append Roomote-authored action links or hidden fix markers.</action>
+          <action>When no matching thread exists and the finding maps to the current PR diff, post one new line-anchored inline comment per finding with `mcp__roomote__manage_source_control` `action: "create_pull_request_review_comment"`, passing `path`, `line`, and `side` (`RIGHT` for added or changed lines, `LEFT` only for findings on deleted lines; pass `startLine` for a multi-line range where the provider supports it), and record the returned `commentId` and `threadId` so the linked-task handoff can reference them.</action>
+          <action>If the provider rejects the anchor because the line is not part of the current diff, re-check the hunk, correct `path`, `line`, or `side`, and retry exactly once. If it is still rejected, carry the finding in the canonical summary comment instead: include it in the hidden checklist block as an unchecked item with an explicit `path/to/file.ts:42`-style file and line reference so the author can locate it without an inline anchor.</action>
+          <action>Bitbucket and Azure DevOps do not validate anchors against the diff, so choose the file and line carefully there; an out-of-diff anchor silently lands as a non-diff comment instead of erroring.</action>
+          <action>Use this body structure for each actionable finding: concise explanation plus an optional suggestion block when a concrete, self-contained code replacement is helpful. Match the suggestion syntax to `source_control_provider`: a fenced code block with info string `suggestion` on github and gitea, a fenced code block with info string `suggestion:-0+0` on gitlab, and a plain fenced code block with prose (no suggestion syntax) on bitbucket and ado. Do not append Roomote-authored action links or hidden fix markers.</action>
         </actions>
-        <validation>Every accepted finding was either posted as a reply on a matching existing review thread or carried in the canonical summary comment with a concrete file and line reference.</validation>
+        <validation>Every accepted finding was posted as a reply on a matching existing review thread, posted as a new line-anchored inline comment, or carried in the canonical summary comment with a concrete file and line reference after a failed anchor retry.</validation>
       </step>
       <step number="6">
         <title>Update the canonical summary comment</title>
@@ -745,13 +747,13 @@ You are a pull request review workflow specialist. Review the assigned pull requ
 </causes>
 <recovery>Create a new canonical summary comment with the required hidden marker and continue using that new comment only.</recovery>
 </scenario>
-<scenario name="finding_without_thread_anchor">
-<problem>An accepted finding has no existing review thread on the same file and lines to reply to.</problem>
+<scenario name="inline_comment_anchor_rejected">
+<problem>The provider rejected a new line-anchored inline comment because the anchor does not map onto the current diff.</problem>
 <causes>
-<cause>The finding targets code that no prior review discussion touched.</cause>
-<cause>The provider result did not expose a matching thread anchor for the target location.</cause>
+<cause>The target line is not part of the current PR diff, or the side is wrong for the change.</cause>
+<cause>The diff moved because new commits landed after the review read it.</cause>
 </causes>
-<recovery>Carry the finding in the canonical summary comment with an explicit file and line reference instead of attempting an unsupported line-anchored comment.</recovery>
+<recovery>Re-check the hunk, correct `path`, `line`, or `side`, and retry exactly once. If the anchor is still rejected, carry the finding in the canonical summary comment with an explicit file and line reference instead of forcing an invalid anchor.</recovery>
 </scenario>
 </error_handling>
 
@@ -878,12 +880,13 @@ You are a sync-review workflow specialist. Re-review pull requests after new com
         <description>Attach each accepted net-new finding to the most precise provider comment surface available.</description>
         <actions>
           <action>Publish only net-new findings from this sync pass; surviving prior issues stay carried through the summary checklist instead of being re-posted.</action>
-          <action>The provider-neutral review surface has no batch API for creating new line-anchored inline comments; line-anchored new comments are currently summary-carried on all providers.</action>
           <action>For each net-new finding, check the fetched review threads for an existing thread anchored on the same file and overlapping lines. When one exists, post the finding as a reply on that thread with `mcp__roomote__manage_source_control` `action: "reply_to_pull_request_comment"` and that thread's `threadId`, and record the returned `commentId` so the linked-task handoff can reference it.</action>
-          <action>When no matching thread exists, carry the finding in the canonical summary comment instead: include it in the hidden checklist block as an unchecked item with an explicit `path/to/file.ts:42`-style file and line reference so the author can locate it without an inline anchor.</action>
-          <action>Use this body structure for each actionable finding: concise explanation plus an optional `suggestion` block when a concrete code replacement is helpful. Do not append Roomote-authored action links or hidden fix markers.</action>
+          <action>When no matching thread exists and the finding maps to the current PR diff, post one new line-anchored inline comment per finding with `mcp__roomote__manage_source_control` `action: "create_pull_request_review_comment"`, passing `path`, `line`, and `side` (`RIGHT` for added or changed lines, `LEFT` only for findings on deleted lines; pass `startLine` for a multi-line range where the provider supports it), and record the returned `commentId` and `threadId` so the linked-task handoff can reference them.</action>
+          <action>If the provider rejects the anchor because the line is not part of the current diff, re-check the hunk, correct `path`, `line`, or `side`, and retry exactly once. If it is still rejected, carry the finding in the canonical summary comment instead: include it in the hidden checklist block as an unchecked item with an explicit `path/to/file.ts:42`-style file and line reference so the author can locate it without an inline anchor.</action>
+          <action>Bitbucket and Azure DevOps do not validate anchors against the diff, so choose the file and line carefully there; an out-of-diff anchor silently lands as a non-diff comment instead of erroring.</action>
+          <action>Use this body structure for each actionable finding: concise explanation plus an optional suggestion block when a concrete, self-contained code replacement is helpful. Match the suggestion syntax to `source_control_provider`: a fenced code block with info string `suggestion` on github and gitea, a fenced code block with info string `suggestion:-0+0` on gitlab, and a plain fenced code block with prose (no suggestion syntax) on bitbucket and ado. Do not append Roomote-authored action links or hidden fix markers.</action>
         </actions>
-        <validation>Every accepted net-new finding was either posted as a reply on a matching existing review thread or carried in the canonical summary comment with a concrete file and line reference.</validation>
+        <validation>Every accepted net-new finding was posted as a reply on a matching existing review thread, posted as a new line-anchored inline comment, or carried in the canonical summary comment with a concrete file and line reference after a failed anchor retry.</validation>
       </step>
       <step number="7">
         <title>Refresh the canonical summary comment</title>
@@ -1189,12 +1192,13 @@ You are a sync-review workflow specialist. Re-review pull requests after new com
         <description>Attach each accepted net-new finding to the most precise provider comment surface available.</description>
         <actions>
           <action>Publish only net-new findings from this sync pass; surviving prior issues stay carried through the summary checklist instead of being re-posted.</action>
-          <action>The provider-neutral review surface has no batch API for creating new line-anchored inline comments; line-anchored new comments are currently summary-carried on all providers.</action>
           <action>For each net-new finding, check the fetched review threads for an existing thread anchored on the same file and overlapping lines. When one exists, post the finding as a reply on that thread with `mcp__roomote__manage_source_control` `action: "reply_to_pull_request_comment"` and that thread's `threadId`, and record the returned `commentId` so the linked-task handoff can reference it.</action>
-          <action>When no matching thread exists, carry the finding in the canonical summary comment instead: include it in the hidden checklist block as an unchecked item with an explicit `path/to/file.ts:42`-style file and line reference so the author can locate it without an inline anchor.</action>
-          <action>Use this body structure for each actionable finding: concise explanation plus an optional `suggestion` block when a concrete code replacement is helpful. Do not append Roomote-authored action links or hidden fix markers.</action>
+          <action>When no matching thread exists and the finding maps to the current PR diff, post one new line-anchored inline comment per finding with `mcp__roomote__manage_source_control` `action: "create_pull_request_review_comment"`, passing `path`, `line`, and `side` (`RIGHT` for added or changed lines, `LEFT` only for findings on deleted lines; pass `startLine` for a multi-line range where the provider supports it), and record the returned `commentId` and `threadId` so the linked-task handoff can reference them.</action>
+          <action>If the provider rejects the anchor because the line is not part of the current diff, re-check the hunk, correct `path`, `line`, or `side`, and retry exactly once. If it is still rejected, carry the finding in the canonical summary comment instead: include it in the hidden checklist block as an unchecked item with an explicit `path/to/file.ts:42`-style file and line reference so the author can locate it without an inline anchor.</action>
+          <action>Bitbucket and Azure DevOps do not validate anchors against the diff, so choose the file and line carefully there; an out-of-diff anchor silently lands as a non-diff comment instead of erroring.</action>
+          <action>Use this body structure for each actionable finding: concise explanation plus an optional suggestion block when a concrete, self-contained code replacement is helpful. Match the suggestion syntax to `source_control_provider`: a fenced code block with info string `suggestion` on github and gitea, a fenced code block with info string `suggestion:-0+0` on gitlab, and a plain fenced code block with prose (no suggestion syntax) on bitbucket and ado. Do not append Roomote-authored action links or hidden fix markers.</action>
         </actions>
-        <validation>Every accepted net-new finding was either posted as a reply on a matching existing review thread or carried in the canonical summary comment with a concrete file and line reference.</validation>
+        <validation>Every accepted net-new finding was posted as a reply on a matching existing review thread, posted as a new line-anchored inline comment, or carried in the canonical summary comment with a concrete file and line reference after a failed anchor retry.</validation>
       </step>
       <step number="7">
         <title>Refresh the canonical summary comment</title>

--- a/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-reads.test.ts
+++ b/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-reads.test.ts
@@ -469,6 +469,64 @@ describe('readSourceControlPullRequestForTaskRun', () => {
     ]);
   });
 
+  it('anchors GitLab old-side diff notes with old_path and old_line', async () => {
+    mockRepositoriesFindFirst.mockResolvedValue({
+      installationId: null,
+      externalRepoId: '101',
+      fullName: 'acme/backend',
+      htmlUrl: 'https://gitlab.com/acme/backend',
+    });
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      jsonResponse([
+        {
+          id: 'discussion-old-side',
+          notes: [
+            {
+              id: 9,
+              type: 'DiffNote',
+              body: 'This deletion drops the retry path.',
+              resolvable: true,
+              resolved: false,
+              author: { username: 'reviewer' },
+              position: {
+                new_path: null,
+                new_line: null,
+                old_path: 'src/index.ts',
+                old_line: 17,
+              },
+            },
+          ],
+        },
+      ]),
+    );
+
+    const result = await readSourceControlPullRequestForTaskRun({
+      taskRun: makeTaskRun({
+        repo: 'acme/backend',
+        sourceControlProvider: 'gitlab',
+      }),
+      input: {
+        action: 'list_pull_request_comments',
+        repositoryFullName: 'acme/backend',
+        prNumber: 42,
+        sourceControlProvider: 'gitlab',
+      },
+      fetchImpl,
+    });
+
+    if (!('threads' in result)) {
+      throw new Error('Expected a comments result.');
+    }
+
+    expect(result.threads).toEqual([
+      expect.objectContaining({
+        id: 'discussion-old-side',
+        path: 'src/index.ts',
+        line: 17,
+      }),
+    ]);
+  });
+
   it('maps Azure DevOps threads with resolution states', async () => {
     mockRepositoriesFindFirst.mockResolvedValue({
       installationId: null,

--- a/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-writes.test.ts
+++ b/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-writes.test.ts
@@ -52,6 +52,17 @@ vi.mock('@roomote/gitea', () => ({
     mockBuildGiteaApiBaseUrl(...args),
 }));
 
+vi.mock('@roomote/bitbucket', () => ({
+  resolveBitbucketAuth: async () => ({
+    token: 'bitbucket-token',
+    username: 'bb-bot',
+    baseUrl: 'https://bitbucket.org',
+    apiBaseUrl: 'https://api.bitbucket.org/2.0',
+    authScheme: 'bearer',
+  }),
+  buildBitbucketApiBaseUrl: () => 'https://api.bitbucket.org/2.0',
+}));
+
 vi.mock('@roomote/ado', () => ({
   resolveAdoToken: (...args: unknown[]) => mockResolveAdoToken(...args),
   resolveAdoBaseUrl: (...args: unknown[]) => mockResolveAdoBaseUrl(...args),
@@ -694,6 +705,763 @@ describe('writeSourceControlPullRequestForTaskRun', () => {
     ).rejects.toThrow('commentId is required for update_pull_request_comment.');
     expect(fetchImpl).not.toHaveBeenCalled();
     expect(mockRepositoriesFindFirst).not.toHaveBeenCalled();
+  });
+
+  describe('create_pull_request_review_comment', () => {
+    const githubRepoRow = {
+      installationId: 'installation-1',
+      externalRepoId: null,
+      fullName: 'acme/backend',
+      htmlUrl: 'https://github.com/acme/backend',
+    };
+
+    it('posts a GitHub inline comment anchored on the head SHA resolved at call time', async () => {
+      mockRepositoriesFindFirst.mockResolvedValue(githubRepoRow);
+      mockCreateGitHubToken.mockResolvedValue('github-token');
+      const get = vi
+        .fn()
+        .mockResolvedValue({ data: { head: { sha: 'headsha123' } } });
+      const createReviewComment = vi.fn().mockResolvedValue({
+        data: {
+          id: 3001,
+          html_url: 'https://github.com/acme/backend/pull/55#discussion_r3001',
+        },
+      });
+      mockGetOctokit.mockReturnValue({
+        rest: { pulls: { get, createReviewComment } },
+      });
+
+      const result = await writeSourceControlPullRequestForTaskRun({
+        taskRun: makeTaskRun({
+          repo: 'acme/backend',
+          sourceControlProvider: 'github',
+        }),
+        input: {
+          action: 'create_pull_request_review_comment',
+          repositoryFullName: 'acme/backend',
+          prNumber: 55,
+          path: 'src/index.ts',
+          line: 42,
+          body: 'Missing error handling here.',
+          sourceControlProvider: 'github',
+        },
+      });
+
+      expect(get).toHaveBeenCalledWith({
+        owner: 'acme',
+        repo: 'backend',
+        pull_number: 55,
+      });
+      expect(createReviewComment).toHaveBeenCalledWith({
+        owner: 'acme',
+        repo: 'backend',
+        pull_number: 55,
+        commit_id: 'headsha123',
+        path: 'src/index.ts',
+        line: 42,
+        side: 'RIGHT',
+        body: 'Missing error handling here.',
+      });
+      expect(result).toMatchObject({
+        success: true,
+        action: 'create_pull_request_review_comment',
+        provider: 'github',
+        number: 55,
+        threadId: null,
+        commentId: '3001',
+        url: 'https://github.com/acme/backend/pull/55#discussion_r3001',
+        applied: true,
+        warnings: [],
+      });
+    });
+
+    it('passes a GitHub multi-line range through as start_line and start_side', async () => {
+      mockRepositoriesFindFirst.mockResolvedValue(githubRepoRow);
+      mockCreateGitHubToken.mockResolvedValue('github-token');
+      const get = vi
+        .fn()
+        .mockResolvedValue({ data: { head: { sha: 'headsha123' } } });
+      const createReviewComment = vi
+        .fn()
+        .mockResolvedValue({ data: { id: 3002, html_url: null } });
+      mockGetOctokit.mockReturnValue({
+        rest: { pulls: { get, createReviewComment } },
+      });
+
+      const result = await writeSourceControlPullRequestForTaskRun({
+        taskRun: makeTaskRun({
+          repo: 'acme/backend',
+          sourceControlProvider: 'github',
+        }),
+        input: {
+          action: 'create_pull_request_review_comment',
+          repositoryFullName: 'acme/backend',
+          prNumber: 55,
+          path: 'src/index.ts',
+          startLine: 40,
+          line: 42,
+          body: 'This whole block can be simplified.',
+          sourceControlProvider: 'github',
+        },
+      });
+
+      expect(createReviewComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          start_line: 40,
+          start_side: 'RIGHT',
+          line: 42,
+          side: 'RIGHT',
+        }),
+      );
+      expect(result).toMatchObject({ applied: true, warnings: [] });
+    });
+
+    it('maps a GitHub 422 to a retryable anchor rejection carrying the provider message', async () => {
+      mockRepositoriesFindFirst.mockResolvedValue(githubRepoRow);
+      mockCreateGitHubToken.mockResolvedValue('github-token');
+      const get = vi
+        .fn()
+        .mockResolvedValue({ data: { head: { sha: 'headsha123' } } });
+      const createReviewComment = vi
+        .fn()
+        .mockRejectedValue(
+          Object.assign(
+            new Error(
+              'Validation Failed: Pull request review thread line must be part of the diff',
+            ),
+            { status: 422 },
+          ),
+        );
+      mockGetOctokit.mockReturnValue({
+        rest: { pulls: { get, createReviewComment } },
+      });
+
+      await expect(
+        writeSourceControlPullRequestForTaskRun({
+          taskRun: makeTaskRun({
+            repo: 'acme/backend',
+            sourceControlProvider: 'github',
+          }),
+          input: {
+            action: 'create_pull_request_review_comment',
+            repositoryFullName: 'acme/backend',
+            prNumber: 55,
+            path: 'src/index.ts',
+            line: 9999,
+            body: 'Missing error handling here.',
+            sourceControlProvider: 'github',
+          },
+        }),
+      ).rejects.toMatchObject({
+        name: 'SourceControlWriteError',
+        httpStatus: 422,
+        message: expect.stringContaining(
+          'rejected the inline comment anchor (path=src/index.ts, line=9999, side=RIGHT)',
+        ),
+      });
+    });
+
+    it('posts a GitLab positioned discussion using the merge request diff_refs', async () => {
+      mockRepositoriesFindFirst.mockResolvedValue({
+        installationId: null,
+        externalRepoId: '101',
+        fullName: 'acme/backend',
+        htmlUrl: 'https://gitlab.com/acme/backend',
+      });
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse({
+            diff_refs: {
+              base_sha: 'base1',
+              start_sha: 'start1',
+              head_sha: 'head1',
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({ id: 'disc-9', notes: [{ id: 601 }] }, 201),
+        );
+
+      const result = await writeSourceControlPullRequestForTaskRun({
+        taskRun: makeTaskRun({
+          repo: 'acme/backend',
+          sourceControlProvider: 'gitlab',
+        }),
+        input: {
+          action: 'create_pull_request_review_comment',
+          repositoryFullName: 'acme/backend',
+          prNumber: 42,
+          path: 'src/index.ts',
+          line: 42,
+          body: 'Missing error handling here.',
+          sourceControlProvider: 'gitlab',
+        },
+        fetchImpl,
+      });
+
+      expect(fetchImpl).toHaveBeenNthCalledWith(
+        1,
+        'https://gitlab.com/api/v4/projects/101/merge_requests/42',
+        expect.objectContaining({ method: 'GET' }),
+      );
+      expect(fetchImpl).toHaveBeenNthCalledWith(
+        2,
+        'https://gitlab.com/api/v4/projects/101/merge_requests/42/discussions',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            body: 'Missing error handling here.',
+            position: {
+              position_type: 'text',
+              base_sha: 'base1',
+              start_sha: 'start1',
+              head_sha: 'head1',
+              new_path: 'src/index.ts',
+              old_path: 'src/index.ts',
+              new_line: 42,
+            },
+          }),
+        }),
+      );
+      expect(result).toMatchObject({
+        success: true,
+        provider: 'gitlab',
+        threadId: 'disc-9',
+        commentId: '601',
+        applied: true,
+        warnings: [],
+      });
+    });
+
+    it('anchors LEFT-side GitLab comments with old_line instead of new_line', async () => {
+      mockRepositoriesFindFirst.mockResolvedValue({
+        installationId: null,
+        externalRepoId: '101',
+        fullName: 'acme/backend',
+        htmlUrl: 'https://gitlab.com/acme/backend',
+      });
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse({
+            diff_refs: {
+              base_sha: 'base1',
+              start_sha: 'start1',
+              head_sha: 'head1',
+            },
+          }),
+        )
+        .mockResolvedValueOnce(jsonResponse({ id: 'disc-9' }, 201));
+
+      await writeSourceControlPullRequestForTaskRun({
+        taskRun: makeTaskRun({
+          repo: 'acme/backend',
+          sourceControlProvider: 'gitlab',
+        }),
+        input: {
+          action: 'create_pull_request_review_comment',
+          repositoryFullName: 'acme/backend',
+          prNumber: 42,
+          path: 'src/index.ts',
+          line: 17,
+          side: 'LEFT',
+          body: 'This deletion drops the retry path.',
+          sourceControlProvider: 'gitlab',
+        },
+        fetchImpl,
+      });
+
+      const discussionBody = JSON.parse(
+        (fetchImpl.mock.calls[1]?.[1] as { body: string }).body,
+      ) as { position: Record<string, unknown> };
+      expect(discussionBody.position.old_line).toBe(17);
+      expect(discussionBody.position.new_line).toBeUndefined();
+    });
+
+    it('maps a GitLab 400 on discussions to a retryable anchor rejection', async () => {
+      mockRepositoriesFindFirst.mockResolvedValue({
+        installationId: null,
+        externalRepoId: '101',
+        fullName: 'acme/backend',
+        htmlUrl: 'https://gitlab.com/acme/backend',
+      });
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse({
+            diff_refs: {
+              base_sha: 'base1',
+              start_sha: 'start1',
+              head_sha: 'head1',
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({ message: 'line_code must be a valid line code' }, 400),
+        );
+
+      await expect(
+        writeSourceControlPullRequestForTaskRun({
+          taskRun: makeTaskRun({
+            repo: 'acme/backend',
+            sourceControlProvider: 'gitlab',
+          }),
+          input: {
+            action: 'create_pull_request_review_comment',
+            repositoryFullName: 'acme/backend',
+            prNumber: 42,
+            path: 'src/index.ts',
+            line: 9999,
+            body: 'Missing error handling here.',
+            sourceControlProvider: 'gitlab',
+          },
+          fetchImpl,
+        }),
+      ).rejects.toMatchObject({
+        name: 'SourceControlWriteError',
+        httpStatus: 422,
+        message: expect.stringContaining(
+          'target a line changed in this merge request',
+        ),
+      });
+    });
+
+    it('reports missing GitLab diff_refs as a retryable 409', async () => {
+      mockRepositoriesFindFirst.mockResolvedValue({
+        installationId: null,
+        externalRepoId: '101',
+        fullName: 'acme/backend',
+        htmlUrl: 'https://gitlab.com/acme/backend',
+      });
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse({ diff_refs: null }));
+
+      await expect(
+        writeSourceControlPullRequestForTaskRun({
+          taskRun: makeTaskRun({
+            repo: 'acme/backend',
+            sourceControlProvider: 'gitlab',
+          }),
+          input: {
+            action: 'create_pull_request_review_comment',
+            repositoryFullName: 'acme/backend',
+            prNumber: 42,
+            path: 'src/index.ts',
+            line: 42,
+            body: 'Missing error handling here.',
+            sourceControlProvider: 'gitlab',
+          },
+          fetchImpl,
+        }),
+      ).rejects.toMatchObject({
+        name: 'SourceControlWriteError',
+        httpStatus: 409,
+      });
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+
+    it('degrades a GitLab multi-line range to the end line with a warning', async () => {
+      mockRepositoriesFindFirst.mockResolvedValue({
+        installationId: null,
+        externalRepoId: '101',
+        fullName: 'acme/backend',
+        htmlUrl: 'https://gitlab.com/acme/backend',
+      });
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse({
+            diff_refs: {
+              base_sha: 'base1',
+              start_sha: 'start1',
+              head_sha: 'head1',
+            },
+          }),
+        )
+        .mockResolvedValueOnce(jsonResponse({ id: 'disc-9' }, 201));
+
+      const result = await writeSourceControlPullRequestForTaskRun({
+        taskRun: makeTaskRun({
+          repo: 'acme/backend',
+          sourceControlProvider: 'gitlab',
+        }),
+        input: {
+          action: 'create_pull_request_review_comment',
+          repositoryFullName: 'acme/backend',
+          prNumber: 42,
+          path: 'src/index.ts',
+          startLine: 40,
+          line: 42,
+          body: 'This whole block can be simplified.',
+          sourceControlProvider: 'gitlab',
+        },
+        fetchImpl,
+      });
+
+      expect(result).toMatchObject({
+        applied: true,
+        warnings: [
+          'GitLab does not support multi-line comment positions through this surface; the comment is anchored to line 42.',
+        ],
+      });
+    });
+
+    it('posts a Gitea single-comment review with a positioned comment', async () => {
+      mockRepositoriesFindFirst.mockResolvedValue({
+        installationId: null,
+        externalRepoId: null,
+        fullName: 'acme/backend',
+        htmlUrl: 'https://git.example.com/acme/backend',
+      });
+      const fetchImpl = vi.fn().mockResolvedValueOnce(
+        jsonResponse(
+          {
+            id: 71,
+            html_url: 'https://git.example.com/acme/backend/pulls/9#review-71',
+          },
+          201,
+        ),
+      );
+
+      const result = await writeSourceControlPullRequestForTaskRun({
+        taskRun: makeTaskRun({
+          repo: 'acme/backend',
+          sourceControlProvider: 'gitea',
+        }),
+        input: {
+          action: 'create_pull_request_review_comment',
+          repositoryFullName: 'acme/backend',
+          prNumber: 9,
+          path: 'src/index.ts',
+          line: 42,
+          body: 'Missing error handling here.',
+          sourceControlProvider: 'gitea',
+        },
+        fetchImpl,
+      });
+
+      expect(fetchImpl).toHaveBeenCalledWith(
+        'https://git.example.com/api/v1/repos/acme/backend/pulls/9/reviews',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            event: 'COMMENT',
+            body: '',
+            comments: [
+              {
+                path: 'src/index.ts',
+                body: 'Missing error handling here.',
+                new_position: 42,
+              },
+            ],
+          }),
+        }),
+      );
+      expect(result).toMatchObject({
+        success: true,
+        provider: 'gitea',
+        threadId: '71',
+        url: 'https://git.example.com/acme/backend/pulls/9#review-71',
+        applied: true,
+        warnings: [],
+      });
+    });
+
+    it('maps a Gitea 422 to a retryable anchor rejection', async () => {
+      mockRepositoriesFindFirst.mockResolvedValue({
+        installationId: null,
+        externalRepoId: null,
+        fullName: 'acme/backend',
+        htmlUrl: 'https://git.example.com/acme/backend',
+      });
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse({ message: 'position is invalid' }, 422),
+        );
+
+      await expect(
+        writeSourceControlPullRequestForTaskRun({
+          taskRun: makeTaskRun({
+            repo: 'acme/backend',
+            sourceControlProvider: 'gitea',
+          }),
+          input: {
+            action: 'create_pull_request_review_comment',
+            repositoryFullName: 'acme/backend',
+            prNumber: 9,
+            path: 'src/index.ts',
+            line: 9999,
+            body: 'Missing error handling here.',
+            sourceControlProvider: 'gitea',
+          },
+          fetchImpl,
+        }),
+      ).rejects.toMatchObject({
+        name: 'SourceControlWriteError',
+        httpStatus: 422,
+        message: expect.stringContaining('rejected the inline comment anchor'),
+      });
+    });
+
+    it('posts a Bitbucket inline comment anchored with to on the destination side', async () => {
+      mockRepositoriesFindFirst.mockResolvedValue({
+        installationId: null,
+        externalRepoId: null,
+        fullName: 'acme/backend',
+        htmlUrl: 'https://bitbucket.org/acme/backend',
+      });
+      const fetchImpl = vi.fn().mockResolvedValueOnce(
+        jsonResponse(
+          {
+            id: 88,
+            links: {
+              html: {
+                href: 'https://bitbucket.org/acme/backend/pull-requests/5#comment-88',
+              },
+            },
+          },
+          201,
+        ),
+      );
+
+      const result = await writeSourceControlPullRequestForTaskRun({
+        taskRun: makeTaskRun({
+          repo: 'acme/backend',
+          sourceControlProvider: 'bitbucket',
+        }),
+        input: {
+          action: 'create_pull_request_review_comment',
+          repositoryFullName: 'acme/backend',
+          prNumber: 5,
+          path: 'src/index.ts',
+          line: 42,
+          body: 'Missing error handling here.',
+          sourceControlProvider: 'bitbucket',
+        },
+        fetchImpl,
+      });
+
+      const [url, request] = fetchImpl.mock.calls[0] as [
+        string,
+        { method: string; body: string },
+      ];
+      expect(url).toContain('/pullrequests/5/comments');
+      expect(JSON.parse(request.body)).toEqual({
+        content: { raw: 'Missing error handling here.' },
+        inline: { path: 'src/index.ts', to: 42 },
+      });
+      expect(result).toMatchObject({
+        success: true,
+        provider: 'bitbucket',
+        threadId: '88',
+        commentId: '88',
+        applied: true,
+        warnings: [],
+      });
+    });
+
+    it('anchors LEFT-side Bitbucket comments with from instead of to', async () => {
+      mockRepositoriesFindFirst.mockResolvedValue({
+        installationId: null,
+        externalRepoId: null,
+        fullName: 'acme/backend',
+        htmlUrl: 'https://bitbucket.org/acme/backend',
+      });
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse({ id: 89 }, 201));
+
+      await writeSourceControlPullRequestForTaskRun({
+        taskRun: makeTaskRun({
+          repo: 'acme/backend',
+          sourceControlProvider: 'bitbucket',
+        }),
+        input: {
+          action: 'create_pull_request_review_comment',
+          repositoryFullName: 'acme/backend',
+          prNumber: 5,
+          path: 'src/index.ts',
+          line: 17,
+          side: 'LEFT',
+          body: 'This deletion drops the retry path.',
+          sourceControlProvider: 'bitbucket',
+        },
+        fetchImpl,
+      });
+
+      const request = fetchImpl.mock.calls[0]?.[1] as { body: string };
+      expect(JSON.parse(request.body)).toMatchObject({
+        inline: { path: 'src/index.ts', from: 17 },
+      });
+    });
+
+    it('creates an Azure DevOps thread with a right-side file range including startLine', async () => {
+      mockRepositoriesFindFirst.mockResolvedValue({
+        installationId: null,
+        externalRepoId: 'repo-uuid',
+        fullName: 'acme/Platform/backend',
+        htmlUrl: 'https://dev.azure.com/acme/Platform/_git/backend',
+      });
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse({ id: 31, comments: [{ id: 1 }] }, 200),
+        );
+
+      const result = await writeSourceControlPullRequestForTaskRun({
+        taskRun: makeTaskRun({
+          repo: 'acme/Platform/backend',
+          sourceControlProvider: 'ado',
+        }),
+        input: {
+          action: 'create_pull_request_review_comment',
+          repositoryFullName: 'acme/Platform/backend',
+          prNumber: 7,
+          path: 'src/index.ts',
+          startLine: 40,
+          line: 42,
+          body: 'This whole block can be simplified.',
+          sourceControlProvider: 'ado',
+        },
+        fetchImpl,
+      });
+
+      expect(fetchImpl).toHaveBeenCalledWith(
+        'https://dev.azure.com/acme/Platform/_apis/git/repositories/repo-uuid/pullrequests/7/threads?api-version=7.1',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            comments: [
+              {
+                content: 'This whole block can be simplified.',
+                commentType: 'text',
+              },
+            ],
+            status: 'active',
+            threadContext: {
+              filePath: '/src/index.ts',
+              rightFileStart: { line: 40, offset: 1 },
+              rightFileEnd: { line: 42, offset: 1 },
+            },
+          }),
+        }),
+      );
+      expect(result).toMatchObject({
+        success: true,
+        provider: 'ado',
+        threadId: '31',
+        commentId: '1',
+        applied: true,
+        warnings: [],
+      });
+    });
+
+    it('anchors LEFT-side Azure DevOps comments with leftFileStart and leftFileEnd', async () => {
+      mockRepositoriesFindFirst.mockResolvedValue({
+        installationId: null,
+        externalRepoId: 'repo-uuid',
+        fullName: 'acme/Platform/backend',
+        htmlUrl: 'https://dev.azure.com/acme/Platform/_git/backend',
+      });
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse({ id: 32 }, 200));
+
+      await writeSourceControlPullRequestForTaskRun({
+        taskRun: makeTaskRun({
+          repo: 'acme/Platform/backend',
+          sourceControlProvider: 'ado',
+        }),
+        input: {
+          action: 'create_pull_request_review_comment',
+          repositoryFullName: 'acme/Platform/backend',
+          prNumber: 7,
+          path: 'src/index.ts',
+          line: 17,
+          side: 'LEFT',
+          body: 'This deletion drops the retry path.',
+          sourceControlProvider: 'ado',
+        },
+        fetchImpl,
+      });
+
+      const request = fetchImpl.mock.calls[0]?.[1] as { body: string };
+      expect(JSON.parse(request.body)).toMatchObject({
+        threadContext: {
+          filePath: '/src/index.ts',
+          leftFileStart: { line: 17, offset: 1 },
+          leftFileEnd: { line: 17, offset: 1 },
+        },
+      });
+    });
+
+    it('rejects requests without a path, line, or body before touching the database', async () => {
+      const fetchImpl = vi.fn();
+      const base = {
+        action: 'create_pull_request_review_comment' as const,
+        repositoryFullName: 'acme/backend',
+        prNumber: 1,
+        sourceControlProvider: 'github' as const,
+      };
+      const taskRun = makeTaskRun({
+        repo: 'acme/backend',
+        sourceControlProvider: 'github',
+      });
+
+      await expect(
+        writeSourceControlPullRequestForTaskRun({
+          taskRun,
+          input: { ...base, line: 42, body: 'x' },
+          fetchImpl,
+        }),
+      ).rejects.toThrow(
+        'path is required for create_pull_request_review_comment.',
+      );
+      await expect(
+        writeSourceControlPullRequestForTaskRun({
+          taskRun,
+          input: { ...base, path: 'src/index.ts', body: 'x' },
+          fetchImpl,
+        }),
+      ).rejects.toThrow(
+        'line is required for create_pull_request_review_comment.',
+      );
+      await expect(
+        writeSourceControlPullRequestForTaskRun({
+          taskRun,
+          input: { ...base, path: 'src/index.ts', line: 42 },
+          fetchImpl,
+        }),
+      ).rejects.toThrow(
+        'body is required for create_pull_request_review_comment.',
+      );
+      expect(fetchImpl).not.toHaveBeenCalled();
+      expect(mockRepositoriesFindFirst).not.toHaveBeenCalled();
+    });
+
+    it('rejects a startLine greater than line', async () => {
+      await expect(
+        writeSourceControlPullRequestForTaskRun({
+          taskRun: makeTaskRun({
+            repo: 'acme/backend',
+            sourceControlProvider: 'github',
+          }),
+          input: {
+            action: 'create_pull_request_review_comment',
+            repositoryFullName: 'acme/backend',
+            prNumber: 1,
+            path: 'src/index.ts',
+            startLine: 50,
+            line: 42,
+            body: 'x',
+            sourceControlProvider: 'github',
+          },
+        }),
+      ).rejects.toThrow('startLine must not be greater than line');
+    });
   });
 
   it('rejects resolve requests without a threadId before touching the database', async () => {

--- a/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-writes.test.ts
+++ b/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-writes.test.ts
@@ -1043,6 +1043,64 @@ describe('writeSourceControlPullRequestForTaskRun', () => {
       expect(discussionBody.position.old_path).toBe('src/legacy/index.ts');
     });
 
+    it('keeps scanning diff pages until the renamed file is found', async () => {
+      mockRepositoriesFindFirst.mockResolvedValue({
+        installationId: null,
+        externalRepoId: '101',
+        fullName: 'acme/backend',
+        htmlUrl: 'https://gitlab.com/acme/backend',
+      });
+      const fillerPage = Array.from({ length: 100 }, (_, i) => ({
+        old_path: `src/other-${i}.ts`,
+        new_path: `src/other-${i}.ts`,
+      }));
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse({
+            diff_refs: {
+              base_sha: 'base1',
+              start_sha: 'start1',
+              head_sha: 'head1',
+            },
+          }),
+        )
+        .mockResolvedValueOnce(jsonResponse(fillerPage))
+        .mockResolvedValueOnce(
+          jsonResponse([
+            { old_path: 'src/legacy/index.ts', new_path: 'src/index.ts' },
+          ]),
+        )
+        .mockResolvedValueOnce(jsonResponse({ id: 'disc-9' }, 201));
+
+      await writeSourceControlPullRequestForTaskRun({
+        taskRun: makeTaskRun({
+          repo: 'acme/backend',
+          sourceControlProvider: 'gitlab',
+        }),
+        input: {
+          action: 'create_pull_request_review_comment',
+          repositoryFullName: 'acme/backend',
+          prNumber: 42,
+          path: 'src/index.ts',
+          line: 42,
+          body: 'Missing error handling here.',
+          sourceControlProvider: 'gitlab',
+        },
+        fetchImpl,
+      });
+
+      expect(fetchImpl).toHaveBeenNthCalledWith(
+        3,
+        'https://gitlab.com/api/v4/projects/101/merge_requests/42/diffs?page=2&per_page=100',
+        expect.objectContaining({ method: 'GET' }),
+      );
+      const discussionBody = JSON.parse(
+        (fetchImpl.mock.calls[3]?.[1] as { body: string }).body,
+      ) as { position: Record<string, unknown> };
+      expect(discussionBody.position.old_path).toBe('src/legacy/index.ts');
+    });
+
     it('falls back to the same-path pair when the diff listing is unavailable', async () => {
       mockRepositoriesFindFirst.mockResolvedValue({
         installationId: null,

--- a/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-writes.test.ts
+++ b/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-writes.test.ts
@@ -1101,6 +1101,61 @@ describe('writeSourceControlPullRequestForTaskRun', () => {
       expect(discussionBody.position.old_path).toBe('src/legacy/index.ts');
     });
 
+    it('surfaces an explicit warning when the diff scan backstop ends before the listing', async () => {
+      mockRepositoriesFindFirst.mockResolvedValue({
+        installationId: null,
+        externalRepoId: '101',
+        fullName: 'acme/backend',
+        htmlUrl: 'https://gitlab.com/acme/backend',
+      });
+      const fillerPage = Array.from({ length: 100 }, (_, i) => ({
+        old_path: `src/other-${i}.ts`,
+        new_path: `src/other-${i}.ts`,
+      }));
+      const fetchImpl = vi.fn().mockImplementation(async (url: string) => {
+        if (url.includes('/diffs')) {
+          return jsonResponse(fillerPage);
+        }
+        if (url.endsWith('/discussions')) {
+          return jsonResponse({ id: 'disc-9' }, 201);
+        }
+        return jsonResponse({
+          diff_refs: {
+            base_sha: 'base1',
+            start_sha: 'start1',
+            head_sha: 'head1',
+          },
+        });
+      });
+
+      const result = await writeSourceControlPullRequestForTaskRun({
+        taskRun: makeTaskRun({
+          repo: 'acme/backend',
+          sourceControlProvider: 'gitlab',
+        }),
+        input: {
+          action: 'create_pull_request_review_comment',
+          repositoryFullName: 'acme/backend',
+          prNumber: 42,
+          path: 'src/index.ts',
+          line: 42,
+          body: 'Missing error handling here.',
+          sourceControlProvider: 'gitlab',
+        },
+        fetchImpl,
+      });
+
+      const diffCalls = fetchImpl.mock.calls.filter(([url]) =>
+        String(url).includes('/diffs'),
+      );
+      expect(diffCalls).toHaveLength(50);
+      expect(result.warnings).toEqual([
+        expect.stringContaining(
+          'rename resolution fell back to the request path',
+        ),
+      ]);
+    });
+
     it('falls back to the same-path pair when the diff listing is unavailable', async () => {
       mockRepositoriesFindFirst.mockResolvedValue({
         installationId: null,

--- a/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-writes.test.ts
+++ b/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-writes.test.ts
@@ -880,6 +880,11 @@ describe('writeSourceControlPullRequestForTaskRun', () => {
           }),
         )
         .mockResolvedValueOnce(
+          jsonResponse([
+            { old_path: 'src/index.ts', new_path: 'src/index.ts' },
+          ]),
+        )
+        .mockResolvedValueOnce(
           jsonResponse({ id: 'disc-9', notes: [{ id: 601 }] }, 201),
         );
 
@@ -907,6 +912,11 @@ describe('writeSourceControlPullRequestForTaskRun', () => {
       );
       expect(fetchImpl).toHaveBeenNthCalledWith(
         2,
+        'https://gitlab.com/api/v4/projects/101/merge_requests/42/diffs?page=1&per_page=100',
+        expect.objectContaining({ method: 'GET' }),
+      );
+      expect(fetchImpl).toHaveBeenNthCalledWith(
+        3,
         'https://gitlab.com/api/v4/projects/101/merge_requests/42/discussions',
         expect.objectContaining({
           method: 'POST',
@@ -952,6 +962,11 @@ describe('writeSourceControlPullRequestForTaskRun', () => {
             },
           }),
         )
+        .mockResolvedValueOnce(
+          jsonResponse([
+            { old_path: 'src/index.ts', new_path: 'src/index.ts' },
+          ]),
+        )
         .mockResolvedValueOnce(jsonResponse({ id: 'disc-9' }, 201));
 
       await writeSourceControlPullRequestForTaskRun({
@@ -973,10 +988,104 @@ describe('writeSourceControlPullRequestForTaskRun', () => {
       });
 
       const discussionBody = JSON.parse(
-        (fetchImpl.mock.calls[1]?.[1] as { body: string }).body,
+        (fetchImpl.mock.calls[2]?.[1] as { body: string }).body,
       ) as { position: Record<string, unknown> };
       expect(discussionBody.position.old_line).toBe(17);
       expect(discussionBody.position.new_line).toBeUndefined();
+    });
+
+    it('resolves the real old_path for renamed files from the merge request diffs', async () => {
+      mockRepositoriesFindFirst.mockResolvedValue({
+        installationId: null,
+        externalRepoId: '101',
+        fullName: 'acme/backend',
+        htmlUrl: 'https://gitlab.com/acme/backend',
+      });
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse({
+            diff_refs: {
+              base_sha: 'base1',
+              start_sha: 'start1',
+              head_sha: 'head1',
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse([
+            { old_path: 'src/legacy/index.ts', new_path: 'src/index.ts' },
+          ]),
+        )
+        .mockResolvedValueOnce(jsonResponse({ id: 'disc-9' }, 201));
+
+      await writeSourceControlPullRequestForTaskRun({
+        taskRun: makeTaskRun({
+          repo: 'acme/backend',
+          sourceControlProvider: 'gitlab',
+        }),
+        input: {
+          action: 'create_pull_request_review_comment',
+          repositoryFullName: 'acme/backend',
+          prNumber: 42,
+          path: 'src/index.ts',
+          line: 42,
+          body: 'Missing error handling here.',
+          sourceControlProvider: 'gitlab',
+        },
+        fetchImpl,
+      });
+
+      const discussionBody = JSON.parse(
+        (fetchImpl.mock.calls[2]?.[1] as { body: string }).body,
+      ) as { position: Record<string, unknown> };
+      expect(discussionBody.position.new_path).toBe('src/index.ts');
+      expect(discussionBody.position.old_path).toBe('src/legacy/index.ts');
+    });
+
+    it('falls back to the same-path pair when the diff listing is unavailable', async () => {
+      mockRepositoriesFindFirst.mockResolvedValue({
+        installationId: null,
+        externalRepoId: '101',
+        fullName: 'acme/backend',
+        htmlUrl: 'https://gitlab.com/acme/backend',
+      });
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse({
+            diff_refs: {
+              base_sha: 'base1',
+              start_sha: 'start1',
+              head_sha: 'head1',
+            },
+          }),
+        )
+        .mockResolvedValueOnce(jsonResponse({ message: 'nope' }, 500))
+        .mockResolvedValueOnce(jsonResponse({ id: 'disc-9' }, 201));
+
+      await writeSourceControlPullRequestForTaskRun({
+        taskRun: makeTaskRun({
+          repo: 'acme/backend',
+          sourceControlProvider: 'gitlab',
+        }),
+        input: {
+          action: 'create_pull_request_review_comment',
+          repositoryFullName: 'acme/backend',
+          prNumber: 42,
+          path: 'src/index.ts',
+          line: 42,
+          body: 'Missing error handling here.',
+          sourceControlProvider: 'gitlab',
+        },
+        fetchImpl,
+      });
+
+      const discussionBody = JSON.parse(
+        (fetchImpl.mock.calls[2]?.[1] as { body: string }).body,
+      ) as { position: Record<string, unknown> };
+      expect(discussionBody.position.new_path).toBe('src/index.ts');
+      expect(discussionBody.position.old_path).toBe('src/index.ts');
     });
 
     it('maps a GitLab 400 on discussions to a retryable anchor rejection', async () => {
@@ -996,6 +1105,11 @@ describe('writeSourceControlPullRequestForTaskRun', () => {
               head_sha: 'head1',
             },
           }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse([
+            { old_path: 'src/index.ts', new_path: 'src/index.ts' },
+          ]),
         )
         .mockResolvedValueOnce(
           jsonResponse({ message: 'line_code must be a valid line code' }, 400),
@@ -1079,6 +1193,11 @@ describe('writeSourceControlPullRequestForTaskRun', () => {
               head_sha: 'head1',
             },
           }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse([
+            { old_path: 'src/index.ts', new_path: 'src/index.ts' },
+          ]),
         )
         .mockResolvedValueOnce(jsonResponse({ id: 'disc-9' }, 201));
 

--- a/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-reads.ts
+++ b/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-reads.ts
@@ -255,6 +255,8 @@ const gitLabDiscussionNoteSchema = z
       .object({
         new_path: z.string().nullable().optional(),
         new_line: z.number().nullable().optional(),
+        old_path: z.string().nullable().optional(),
+        old_line: z.number().nullable().optional(),
       })
       .nullable()
       .optional(),
@@ -1271,8 +1273,14 @@ async function listGitLabMergeRequestComments({
         resolvableNotes.length > 0
           ? resolvableNotes.every((note) => Boolean(note.resolved))
           : null,
-      path: isDiffNote ? (firstNote.position?.new_path ?? null) : null,
-      line: isDiffNote ? (firstNote.position?.new_line ?? null) : null,
+      // Old-side comments (deleted lines) carry only old_path/old_line, so
+      // fall back to the old-side anchor to keep those threads matchable.
+      path: isDiffNote
+        ? (firstNote.position?.new_path ?? firstNote.position?.old_path ?? null)
+        : null,
+      line: isDiffNote
+        ? (firstNote.position?.new_line ?? firstNote.position?.old_line ?? null)
+        : null,
       comments,
     });
   }

--- a/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-writes.ts
+++ b/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-writes.ts
@@ -1115,7 +1115,11 @@ async function resolveGitLabPositionPaths({
   mergeRequestPath: string;
   path: string;
 }): Promise<{ oldPath: string; newPath: string }> {
-  const maxPages = 5;
+  // Scan the complete diff listing (a page shorter than per_page ends it).
+  // GitLab's own diff rendering hard-caps merge requests around 3,000
+  // changed files, so this backstop is unreachable in practice and exists
+  // only as a runaway guard.
+  const maxPages = 50;
 
   for (let page = 1; page <= maxPages; page++) {
     const response = await performRequest({

--- a/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-writes.ts
+++ b/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-writes.ts
@@ -59,6 +59,7 @@ export const sourceControlPullRequestWriteInputSchema = z.object({
   action: z.enum([
     'reply_to_pull_request_comment',
     'create_pull_request_comment',
+    'create_pull_request_review_comment',
     'update_pull_request_comment',
     'resolve_pull_request_thread',
     'submit_pull_request_review',
@@ -83,6 +84,29 @@ export const sourceControlPullRequestWriteInputSchema = z.object({
   commentId: optionalTrimmedNonEmptyStringSchema,
   /** Required for reply, create_comment, and update_comment; optional for review. */
   body: z.string().optional(),
+  /**
+   * Required for create_pull_request_review_comment: repository-relative
+   * POSIX path of the file the comment anchors to.
+   */
+  path: optionalTrimmedNonEmptyStringSchema,
+  /**
+   * Required for create_pull_request_review_comment: 1-based line number in
+   * the file version named by side.
+   */
+  line: z.number().int().positive().optional(),
+  /**
+   * Optional for create_pull_request_review_comment: RIGHT (default) anchors
+   * on the new/head version of the file, LEFT on the old/base version
+   * (deleted lines).
+   */
+  side: z.enum(['LEFT', 'RIGHT']).optional(),
+  /**
+   * Optional multi-line range start for create_pull_request_review_comment.
+   * GitHub and Azure DevOps honor the range; the other providers anchor to
+   * `line` and report a warning.
+   */
+  startLine: z.number().int().positive().optional(),
+  startSide: z.enum(['LEFT', 'RIGHT']).optional(),
   /** Required for resolve_pull_request_thread: true resolves, false reopens. */
   resolved: z.boolean().optional(),
   /** Required for submit_pull_request_review. */
@@ -169,6 +193,26 @@ const gitHubResolveMutationResponseSchema = z.object({
 
 const gitLabNoteSchema = z
   .object({ id: z.union([z.number(), z.string()]) })
+  .passthrough();
+
+const gitLabMergeRequestDiffRefsSchema = z
+  .object({
+    diff_refs: z
+      .object({
+        base_sha: z.string().nullable().optional(),
+        start_sha: z.string().nullable().optional(),
+        head_sha: z.string().nullable().optional(),
+      })
+      .nullable()
+      .optional(),
+  })
+  .passthrough();
+
+const gitLabDiscussionSchema = z
+  .object({
+    id: z.union([z.string(), z.number()]),
+    notes: z.array(gitLabNoteSchema).optional(),
+  })
   .passthrough();
 
 const giteaCreatedCommentSchema = z
@@ -290,6 +334,7 @@ function normalizeOptionalWriteIds(
     ...input,
     threadId: blankToUndefined(input.threadId),
     commentId: blankToUndefined(input.commentId),
+    path: blankToUndefined(input.path),
   };
 }
 
@@ -311,6 +356,11 @@ function assertWriteInputFields(
       requireBody(input);
       break;
     case 'create_pull_request_comment':
+      requireBody(input);
+      break;
+    case 'create_pull_request_review_comment':
+      requirePath(input);
+      requireLine(input);
       requireBody(input);
       break;
     case 'update_pull_request_comment':
@@ -358,6 +408,84 @@ function requireBody(input: SourceControlPullRequestWriteInput): string {
   }
 
   return input.body;
+}
+
+function requirePath(input: SourceControlPullRequestWriteInput): string {
+  if (!input.path) {
+    throw new SourceControlWriteError(
+      400,
+      `path is required for ${input.action}.`,
+    );
+  }
+
+  return input.path;
+}
+
+function requireLine(input: SourceControlPullRequestWriteInput): number {
+  if (input.line === undefined) {
+    throw new SourceControlWriteError(
+      400,
+      `line is required for ${input.action}.`,
+    );
+  }
+
+  if (input.startLine !== undefined && input.startLine > input.line) {
+    throw new SourceControlWriteError(
+      400,
+      `startLine must not be greater than line (got startLine=${input.startLine}, line=${input.line}); line is the end of the range.`,
+    );
+  }
+
+  return input.line;
+}
+
+function resolveSide(
+  input: SourceControlPullRequestWriteInput,
+): 'LEFT' | 'RIGHT' {
+  return input.side ?? 'RIGHT';
+}
+
+/**
+ * The provider could not map the requested anchor onto the current PR diff.
+ * Surfaced as a 422 error (not an applied:false capability gap) so the agent
+ * can correct the anchor and retry, or fall back to the summary comment.
+ */
+function anchorRejectionError(
+  provider: SourceControlProvider,
+  input: SourceControlPullRequestWriteInput,
+  detail: string,
+): SourceControlWriteError {
+  return new SourceControlWriteError(
+    422,
+    `${getSourceControlProviderLabel(provider)} rejected the inline comment anchor (path=${input.path}, line=${input.line}, side=${resolveSide(input)}): ${detail}. The anchor must target a line in the current pull request diff; re-check the hunk and retry once with a corrected anchor, or carry the finding in the review summary comment instead.`,
+  );
+}
+
+/** Reads the HTTP status carried by errors such as octokit's RequestError. */
+function getHttpErrorStatus(error: unknown): number | undefined {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'status' in error &&
+    typeof (error as { status: unknown }).status === 'number'
+  ) {
+    return (error as { status: number }).status;
+  }
+
+  return undefined;
+}
+
+function multiLineRangeWarnings(
+  provider: SourceControlProvider,
+  input: SourceControlPullRequestWriteInput,
+): string[] {
+  if (input.startLine === undefined) {
+    return [];
+  }
+
+  return [
+    `${getSourceControlProviderLabel(provider)} does not support multi-line comment positions through this surface; the comment is anchored to line ${input.line}.`,
+  ];
 }
 
 function requireResolved(input: SourceControlPullRequestWriteInput): boolean {
@@ -473,6 +601,57 @@ async function writeGitHubPullRequest({
         commentId: String(data.id),
         url: data.html_url ?? null,
       });
+    }
+    case 'create_pull_request_review_comment': {
+      const path = requirePath(input);
+      const line = requireLine(input);
+      const side = resolveSide(input);
+      const body = requireBody(input);
+      // Anchor against the head SHA resolved at call time: a caller-supplied
+      // SHA that has since moved would only produce an "outdated" comment or
+      // a hard 422 with no useful recovery.
+      const { data: pullRequest } = await octokit.rest.pulls.get({
+        owner,
+        repo,
+        pull_number: input.prNumber,
+      });
+
+      try {
+        const { data } = await octokit.rest.pulls.createReviewComment({
+          owner,
+          repo,
+          pull_number: input.prNumber,
+          commit_id: pullRequest.head.sha,
+          path,
+          line,
+          side,
+          ...(input.startLine !== undefined
+            ? {
+                start_line: input.startLine,
+                start_side: input.startSide ?? side,
+              }
+            : {}),
+          body,
+        });
+
+        return buildWriteResult({
+          input,
+          provider,
+          repository,
+          commentId: String(data.id),
+          url: data.html_url ?? null,
+        });
+      } catch (error) {
+        if (getHttpErrorStatus(error) === 422) {
+          throw anchorRejectionError(
+            provider,
+            input,
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+
+        throw error;
+      }
     }
     case 'update_pull_request_comment': {
       const commentId = requireCommentId(input);
@@ -635,6 +814,76 @@ async function writeGitLabMergeRequest({
         provider,
         repository,
         commentId: String(note.id),
+      });
+    }
+    case 'create_pull_request_review_comment': {
+      const path = requirePath(input);
+      const line = requireLine(input);
+      const side = resolveSide(input);
+      const body = requireBody(input);
+      // Diff positions must carry the merge request's diff_refs SHA triple.
+      const mergeRequest = await requestJson({
+        fetchImpl,
+        url: buildApiUrl(apiBaseUrl, mergeRequestPath, {}),
+        tokenHeader,
+        schema: gitLabMergeRequestDiffRefsSchema,
+        acceptedStatuses: [200],
+      });
+      const diffRefs = mergeRequest.diff_refs;
+
+      if (!diffRefs?.base_sha || !diffRefs.start_sha || !diffRefs.head_sha) {
+        throw new SourceControlWriteError(
+          409,
+          'GitLab has not computed diff refs for this merge request yet; retry shortly or carry the finding in the review summary comment instead.',
+        );
+      }
+
+      const response = await performRequest({
+        fetchImpl,
+        method: 'POST',
+        url: buildApiUrl(apiBaseUrl, `${mergeRequestPath}/discussions`, {}),
+        tokenHeader,
+        body: {
+          body,
+          position: {
+            position_type: 'text',
+            base_sha: diffRefs.base_sha,
+            start_sha: diffRefs.start_sha,
+            head_sha: diffRefs.head_sha,
+            new_path: path,
+            old_path: path,
+            ...(side === 'RIGHT' ? { new_line: line } : { old_line: line }),
+          },
+        },
+      });
+
+      // GitLab answers 400 for positions it cannot map onto the current diff
+      // (including unchanged context lines, which need both old and new line
+      // numbers to anchor).
+      if (response.status === 400) {
+        throw anchorRejectionError(
+          provider,
+          input,
+          `GitLab could not map the position onto the merge request diff${await formatResponseBody(response)}; target a line changed in this merge request`,
+        );
+      }
+
+      if (![200, 201].includes(response.status)) {
+        throw new Error(
+          await buildSourceControlRequestFailureMessage(response),
+        );
+      }
+
+      const discussion = gitLabDiscussionSchema.parse(await response.json());
+      const firstNote = discussion.notes?.[0];
+
+      return buildWriteResult({
+        input,
+        provider,
+        repository,
+        threadId: String(discussion.id),
+        commentId: firstNote ? String(firstNote.id) : null,
+        warnings: multiLineRangeWarnings(provider, input),
       });
     }
     case 'update_pull_request_comment': {
@@ -923,6 +1172,63 @@ async function writeGiteaPullRequest({
         url: comment.html_url ?? null,
       });
     }
+    case 'create_pull_request_review_comment': {
+      const path = requirePath(input);
+      const line = requireLine(input);
+      const side = resolveSide(input);
+      const body = requireBody(input);
+      // Gitea's review API is GitHub-shaped: one review with a single
+      // positioned comment. commit_id is omitted so Gitea anchors against
+      // the latest diff.
+      const response = await performRequest({
+        fetchImpl,
+        method: 'POST',
+        url: buildApiUrl(
+          apiBaseUrl,
+          `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${input.prNumber}/reviews`,
+          {},
+        ),
+        tokenHeader,
+        body: {
+          event: 'COMMENT',
+          body: '',
+          comments: [
+            {
+              path,
+              body,
+              ...(side === 'RIGHT'
+                ? { new_position: line }
+                : { old_position: line }),
+            },
+          ],
+        },
+      });
+
+      if (response.status === 422) {
+        throw anchorRejectionError(
+          provider,
+          input,
+          `Gitea rejected the review position${await formatResponseBody(response)}`,
+        );
+      }
+
+      if (![200, 201].includes(response.status)) {
+        throw new Error(
+          await buildSourceControlRequestFailureMessage(response),
+        );
+      }
+
+      const review = giteaCreatedReviewSchema.parse(await response.json());
+
+      return buildWriteResult({
+        input,
+        provider,
+        repository,
+        threadId: String(review.id),
+        url: review.html_url ?? null,
+        warnings: multiLineRangeWarnings(provider, input),
+      });
+    }
     case 'update_pull_request_comment': {
       const commentId = requireCommentId(input);
       const comment = await requestJson({
@@ -1058,6 +1364,43 @@ async function writeBitbucketPullRequest({
             ? null
             : String(comment.id),
         url: comment.links?.html?.href ?? null,
+      });
+    }
+    case 'create_pull_request_review_comment': {
+      const path = requirePath(input);
+      const line = requireLine(input);
+      const side = resolveSide(input);
+      // Bitbucket anchors inline comments by destination (`to`) or source
+      // (`from`) line and does not validate the anchor against the diff;
+      // out-of-diff anchors render under "Other comments" instead of erroring.
+      const comment = await requestJson({
+        fetchImpl,
+        method: 'POST',
+        url: commentsUrl,
+        tokenHeader,
+        body: {
+          content: { raw: requireBody(input) },
+          inline: {
+            path,
+            ...(side === 'RIGHT' ? { to: line } : { from: line }),
+          },
+        },
+        schema: bitbucketCreatedCommentSchema,
+      });
+      const commentId =
+        comment.id === undefined || comment.id === null
+          ? null
+          : String(comment.id);
+
+      return buildWriteResult({
+        input,
+        provider,
+        repository,
+        // The read surface keys Bitbucket threads by the top comment id.
+        threadId: commentId,
+        commentId,
+        url: comment.links?.html?.href ?? null,
+        warnings: multiLineRangeWarnings(provider, input),
       });
     }
     case 'update_pull_request_comment': {
@@ -1270,6 +1613,37 @@ async function writeAdoPullRequest({
         commentId: getFirstAdoCommentId(thread),
       });
     }
+    case 'create_pull_request_review_comment': {
+      const path = requirePath(input);
+      const line = requireLine(input);
+      const side = resolveSide(input);
+      const startLine = input.startLine ?? line;
+      const start = { line: startLine, offset: 1 };
+      const end = { line, offset: 1 };
+      // ADO does not validate threadContext against the diff; anchors outside
+      // the diff render as file-level comments instead of erroring.
+      const thread = await createAdoCommentThread({
+        fetchImpl,
+        tokenHeader,
+        organizationApiBaseUrl,
+        threadsPath,
+        content: requireBody(input),
+        threadContext: {
+          filePath: path.startsWith('/') ? path : `/${path}`,
+          ...(side === 'RIGHT'
+            ? { rightFileStart: start, rightFileEnd: end }
+            : { leftFileStart: start, leftFileEnd: end }),
+        },
+      });
+
+      return buildWriteResult({
+        input,
+        provider,
+        repository,
+        threadId: String(thread.id),
+        commentId: getFirstAdoCommentId(thread),
+      });
+    }
     case 'update_pull_request_comment': {
       const commentId = requireCommentId(input);
 
@@ -1412,12 +1786,15 @@ async function createAdoCommentThread({
   organizationApiBaseUrl,
   threadsPath,
   content,
+  threadContext,
 }: {
   fetchImpl: FetchImpl;
   tokenHeader: { name: string; value: string };
   organizationApiBaseUrl: string;
   threadsPath: string;
   content: string;
+  /** File/line anchor for inline review comments; omit for PR-level threads. */
+  threadContext?: Record<string, unknown>;
 }): Promise<z.infer<typeof adoThreadSchema>> {
   return requestJson({
     fetchImpl,
@@ -1429,6 +1806,7 @@ async function createAdoCommentThread({
     body: {
       comments: [{ content, commentType: 'text' }],
       status: 'active',
+      ...(threadContext ? { threadContext } : {}),
     },
     schema: adoThreadSchema,
   });

--- a/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-writes.ts
+++ b/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-writes.ts
@@ -879,7 +879,11 @@ async function writeGitLabMergeRequest({
         throw anchorRejectionError(
           provider,
           input,
-          `GitLab could not map the position onto the merge request diff${await formatResponseBody(response)}; target a line changed in this merge request`,
+          `GitLab could not map the position onto the merge request diff${await formatResponseBody(response)}; target a line changed in this merge request${
+            positionPaths.warnings.length
+              ? `. ${positionPaths.warnings.join(' ')}`
+              : ''
+          }`,
         );
       }
 
@@ -898,7 +902,10 @@ async function writeGitLabMergeRequest({
         repository,
         threadId: String(discussion.id),
         commentId: firstNote ? String(firstNote.id) : null,
-        warnings: multiLineRangeWarnings(provider, input),
+        warnings: [
+          ...positionPaths.warnings,
+          ...multiLineRangeWarnings(provider, input),
+        ],
       });
     }
     case 'update_pull_request_comment': {
@@ -1101,6 +1108,8 @@ async function submitGitLabReview({
  * renamed files they differ and a same-path position is rejected. Scan the
  * merge request diff list for the entry matching the requested path by either
  * name, falling back to the same-path pair when the file cannot be found.
+ * When the runaway backstop ends the scan before the listing does, the
+ * fallback is surfaced explicitly through `warnings`.
  */
 async function resolveGitLabPositionPaths({
   fetchImpl,
@@ -1114,19 +1123,20 @@ async function resolveGitLabPositionPaths({
   tokenHeader: { name: string; value: string };
   mergeRequestPath: string;
   path: string;
-}): Promise<{ oldPath: string; newPath: string }> {
+}): Promise<{ oldPath: string; newPath: string; warnings: string[] }> {
   // Scan the complete diff listing (a page shorter than per_page ends it).
   // GitLab's own diff rendering hard-caps merge requests around 3,000
   // changed files, so this backstop is unreachable in practice and exists
-  // only as a runaway guard.
+  // only as a runaway guard against a misbehaving server.
   const maxPages = 50;
+  const perPage = 100;
 
   for (let page = 1; page <= maxPages; page++) {
     const response = await performRequest({
       fetchImpl,
       url: buildApiUrl(apiBaseUrl, `${mergeRequestPath}/diffs`, {
         page,
-        per_page: 100,
+        per_page: perPage,
       }),
       tokenHeader,
     });
@@ -1146,15 +1156,26 @@ async function resolveGitLabPositionPaths({
       return {
         oldPath: entry.old_path ?? path,
         newPath: entry.new_path ?? path,
+        warnings: [],
       };
     }
 
-    if (entries.length < 100) {
+    if (page === maxPages && entries.length === perPage) {
+      return {
+        oldPath: path,
+        newPath: path,
+        warnings: [
+          `The merge request diff listing exceeded ${maxPages * perPage} files before ${path} was found; rename resolution fell back to the request path, so an anchor on a renamed file may be rejected.`,
+        ],
+      };
+    }
+
+    if (entries.length < perPage) {
       break;
     }
   }
 
-  return { oldPath: path, newPath: path };
+  return { oldPath: path, newPath: path, warnings: [] };
 }
 
 async function createGitLabNote({

--- a/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-writes.ts
+++ b/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-writes.ts
@@ -215,6 +215,13 @@ const gitLabDiscussionSchema = z
   })
   .passthrough();
 
+const gitLabMergeRequestDiffEntrySchema = z
+  .object({
+    old_path: z.string().optional(),
+    new_path: z.string().optional(),
+  })
+  .passthrough();
+
 const giteaCreatedCommentSchema = z
   .object({
     id: z.number().int(),
@@ -838,6 +845,14 @@ async function writeGitLabMergeRequest({
         );
       }
 
+      const positionPaths = await resolveGitLabPositionPaths({
+        fetchImpl,
+        apiBaseUrl,
+        tokenHeader,
+        mergeRequestPath,
+        path,
+      });
+
       const response = await performRequest({
         fetchImpl,
         method: 'POST',
@@ -850,8 +865,8 @@ async function writeGitLabMergeRequest({
             base_sha: diffRefs.base_sha,
             start_sha: diffRefs.start_sha,
             head_sha: diffRefs.head_sha,
-            new_path: path,
-            old_path: path,
+            new_path: positionPaths.newPath,
+            old_path: positionPaths.oldPath,
             ...(side === 'RIGHT' ? { new_line: line } : { old_line: line }),
           },
         },
@@ -1079,6 +1094,63 @@ async function submitGitLabReview({
     applied: !approveRejected,
     warnings,
   });
+}
+
+/**
+ * GitLab positions must carry the file's real old_path and new_path; for
+ * renamed files they differ and a same-path position is rejected. Scan the
+ * merge request diff list for the entry matching the requested path by either
+ * name, falling back to the same-path pair when the file cannot be found.
+ */
+async function resolveGitLabPositionPaths({
+  fetchImpl,
+  apiBaseUrl,
+  tokenHeader,
+  mergeRequestPath,
+  path,
+}: {
+  fetchImpl: FetchImpl;
+  apiBaseUrl: string;
+  tokenHeader: { name: string; value: string };
+  mergeRequestPath: string;
+  path: string;
+}): Promise<{ oldPath: string; newPath: string }> {
+  const maxPages = 5;
+
+  for (let page = 1; page <= maxPages; page++) {
+    const response = await performRequest({
+      fetchImpl,
+      url: buildApiUrl(apiBaseUrl, `${mergeRequestPath}/diffs`, {
+        page,
+        per_page: 100,
+      }),
+      tokenHeader,
+    });
+
+    if (response.status !== 200) {
+      break;
+    }
+
+    const entries = z
+      .array(gitLabMergeRequestDiffEntrySchema)
+      .parse(await response.json());
+    const entry = entries.find(
+      (candidate) => candidate.new_path === path || candidate.old_path === path,
+    );
+
+    if (entry) {
+      return {
+        oldPath: entry.old_path ?? path,
+        newPath: entry.new_path ?? path,
+      };
+    }
+
+    if (entries.length < 100) {
+      break;
+    }
+  }
+
+  return { oldPath: path, newPath: path };
 }
 
 async function createGitLabNote({


### PR DESCRIPTION
## Summary

When the review workflow moved to the provider-neutral `manage_source_control` surface, it lost the ability to create new line-anchored inline comments: findings could only reply to existing review threads or be carried in the canonical summary comment as `file.ts:42` references.

This restores inline commenting by adding a `create_pull_request_review_comment` action to `manage_source_control`, implemented for all five providers, and updating the review-code skill to use it.

## Design

- **One comment per call.** Each finding is its own API call, so a single bad anchor can never reject a batch of findings.
- **Server-resolved anchor SHA.** The platform resolves the PR head SHA (GitHub) or `diff_refs` (GitLab) at call time; callers pass only `path`, `line`, `side`, and an optional `startLine`/`startSide` range.
- **Anchor rejection is a retryable error, not a capability gap.** GitHub 422 / GitLab 400 / Gitea 422 anchor failures surface as a 422 with the provider message and retry guidance. `applied:false` stays reserved for genuine provider capability gaps, and this action never returns it.
- **Multi-line ranges** are honored natively on GitHub and Azure DevOps and degrade to the end line with a warning on GitLab, Gitea, and Bitbucket.
- **Returned `threadId` matches the read surface** per provider so the agent can immediately reply to or resolve the thread it just created.
- The GitHub reply-quote injection explicitly excludes this action: review findings are agent-authored, not replies to a pending user message.

## Provider mappings

| Provider | API | Anchor validation |
|---|---|---|
| GitHub | `pulls.createReviewComment` with call-time head SHA | 422 on out-of-diff anchors |
| GitLab | `POST .../discussions` with a `position` built from MR `diff_refs` | 400 on unmappable positions (mapped to 422) |
| Gitea | `POST .../pulls/{n}/reviews` with one positioned comment | 422 |
| Bitbucket | `POST .../comments` with `inline: {path, to/from}` | none (out-of-diff anchors land as non-diff comments) |
| Azure DevOps | thread `POST` with `threadContext` file range | none |

## Skill changes

All four review appendices in `review-code/SKILL.md` now:
- prefer replying to an existing matching thread (unchanged), then post a new line-anchored inline comment per finding,
- use provider-aware suggestion syntax (`suggestion` fences on GitHub/Gitea, `suggestion:-0+0` on GitLab, plain code blocks on Bitbucket/ADO),
- on anchor rejection: re-check the hunk, retry exactly once, then fall back to carrying the finding in the summary checklist with a `file.ts:42` reference (the pre-migration recovery contract),
- warn that Bitbucket/ADO do not validate anchors against the diff.

The `finding_without_thread_anchor` error scenario is replaced by `inline_comment_anchor_rejected`.

## Review feedback addressed

- GitLab positions now carry the file's real `old_path`/`new_path` resolved from the merge request diff list, so anchors on renamed files work (same-path fallback when the diff listing is unavailable).
- The GitLab thread reader now falls back to `old_path`/`old_line` for old-side diff notes, so deleted-line threads stay matchable in sync reviews instead of being duplicated.

## Known limitations

- GitLab comments on unchanged context lines will be rejected (GitLab needs both old and new line numbers on the same position, which requires hunk-level diff parsing this change does not do); the skill steers agents toward changed lines and the retry/summary-carry path absorbs misses.
- GitLab/Gitea/Bitbucket get single-line anchors only for now.

## Testing

- SDK: per-provider payload-asserting tests including LEFT-side variants, multi-line ranges, anchor-rejection mapping, missing `diff_refs` handling, renamed-file path resolution, and old-side thread anchoring.
- API: dispatch + a regression test pinning that reply quoting is not applied to the new action.
- Worker MCP: validation, param forwarding, and an end-to-end registered-tool test.
- Skill text: assertions pinning the new inline-comment instructions, suggestion guidance, and recovery scenario.
- `pnpm lint`, `pnpm check-types`, `pnpm knip` all pass.
- Verified end-to-end on a local deployment: a `github_pr_review` task against a seeded-bug PR posted four correctly line-anchored inline review comments, catching all three seeded bugs plus one unseeded real issue.
