### PR TITLE
[Fix] Cap Node heap by default in the shared app image

### DIFF
--- a/.docker/app/entrypoint.sh
+++ b/.docker/app/entrypoint.sh
@@ -61,17 +61,29 @@ apply_node_heap_cap() {
   # cgroup v1 reports "unlimited" as a page-rounded near-int64 number; the
   # derived_mb < cap_mb comparison below already treats it as no limit.
   self_v2="$(sed -n 's/^0:://p' /proc/self/cgroup 2>/dev/null | head -n 1)"
-  self_v1="$(grep -E '^[0-9]+:([^:]*,)?memory(,[^:]*)?:' /proc/self/cgroup 2>/dev/null | head -n 1 | cut -d: -f3)"
 
   limit_bytes=""
   if [ -n "$self_v2" ] && [ -r "/sys/fs/cgroup${self_v2}/memory.max" ]; then
     limit_bytes="$(cat "/sys/fs/cgroup${self_v2}/memory.max")"
   elif [ -r /sys/fs/cgroup/memory.max ]; then
     limit_bytes="$(cat /sys/fs/cgroup/memory.max)"
-  elif [ -n "$self_v1" ] && [ -r "/sys/fs/cgroup/memory${self_v1}/memory.limit_in_bytes" ]; then
-    limit_bytes="$(cat "/sys/fs/cgroup/memory${self_v1}/memory.limit_in_bytes")"
-  elif [ -r /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
-    limit_bytes="$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)"
+  else
+    self_v1="$(grep -E '^[0-9]+:([^:]*,)?memory(,[^:]*)?:' /proc/self/cgroup 2>/dev/null | head -n 1 | cut -d: -f3)"
+    # The v1 memory hierarchy can be co-mounted with other controllers at a
+    # combined path, so resolve its mount point from /proc/self/mountinfo
+    # (mountpoint is the 5th field before the " - " separator; filesystem
+    # type and super options are the 1st and 3rd after it).
+    v1_mount="$(awk -F' - ' '{
+      split($1, l, " "); split($2, r, " ");
+      if (r[1] == "cgroup" && ("," r[3] ",") ~ /,memory,/) { print l[5]; exit }
+    }' /proc/self/mountinfo 2>/dev/null || :)"
+    [ -n "$v1_mount" ] || v1_mount=/sys/fs/cgroup/memory
+
+    if [ -n "$self_v1" ] && [ -r "${v1_mount}${self_v1}/memory.limit_in_bytes" ]; then
+      limit_bytes="$(cat "${v1_mount}${self_v1}/memory.limit_in_bytes")"
+    elif [ -r "${v1_mount}/memory.limit_in_bytes" ]; then
+      limit_bytes="$(cat "${v1_mount}/memory.limit_in_bytes")"
+    fi
   fi
   case "$limit_bytes" in
     '' | *[!0-9]*) ;; # v2 "max" means unlimited; keep the service default

--- a/.docker/app/entrypoint.sh
+++ b/.docker/app/entrypoint.sh
@@ -45,7 +45,7 @@ fi
 # directly on usage-priced hosts — and a container memory cap OOM-kills the
 # process before V8 ever feels pressure. Cap old space explicitly instead:
 # an operator --max-old-space-size in NODE_OPTIONS always wins, and a
-# readable cgroup v2 memory limit lowers (never raises) the service default
+# readable cgroup memory limit lowers (never raises) the service default
 # to ~75% of the container's memory.
 apply_node_heap_cap() {
   case "${NODE_OPTIONS:-}" in
@@ -54,18 +54,23 @@ apply_node_heap_cap() {
 
   cap_mb="$1"
 
+  limit_bytes=""
   if [ -r /sys/fs/cgroup/memory.max ]; then
     limit_bytes="$(cat /sys/fs/cgroup/memory.max)"
-    case "$limit_bytes" in
-      '' | *[!0-9]*) ;; # "max" means unlimited; keep the service default
-      *)
-        derived_mb=$((limit_bytes / 1048576 * 3 / 4))
-        if [ "$derived_mb" -gt 0 ] && [ "$derived_mb" -lt "$cap_mb" ]; then
-          cap_mb="$derived_mb"
-        fi
-        ;;
-    esac
+  elif [ -r /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
+    # cgroup v1 reports "unlimited" as a page-rounded near-int64 number;
+    # the derived_mb < cap_mb comparison below already treats it as no limit.
+    limit_bytes="$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)"
   fi
+  case "$limit_bytes" in
+    '' | *[!0-9]*) ;; # v2 "max" means unlimited; keep the service default
+    *)
+      derived_mb=$((limit_bytes / 1048576 * 3 / 4))
+      if [ "$derived_mb" -gt 0 ] && [ "$derived_mb" -lt "$cap_mb" ]; then
+        cap_mb="$derived_mb"
+      fi
+      ;;
+  esac
 
   export NODE_OPTIONS="${NODE_OPTIONS:+${NODE_OPTIONS} }--max-old-space-size=${cap_mb}"
 }

--- a/.docker/app/entrypoint.sh
+++ b/.docker/app/entrypoint.sh
@@ -54,12 +54,23 @@ apply_node_heap_cap() {
 
   cap_mb="$1"
 
+  # Container runtimes usually mount the container's own cgroup at
+  # /sys/fs/cgroup, but some expose the host's whole hierarchy; there the
+  # mount-root files read unlimited and the real limit lives under the
+  # process's own path from /proc/self/cgroup, so try that path first.
+  # cgroup v1 reports "unlimited" as a page-rounded near-int64 number; the
+  # derived_mb < cap_mb comparison below already treats it as no limit.
+  self_v2="$(sed -n 's/^0:://p' /proc/self/cgroup 2>/dev/null | head -n 1)"
+  self_v1="$(grep -E '^[0-9]+:([^:]*,)?memory(,[^:]*)?:' /proc/self/cgroup 2>/dev/null | head -n 1 | cut -d: -f3)"
+
   limit_bytes=""
-  if [ -r /sys/fs/cgroup/memory.max ]; then
+  if [ -n "$self_v2" ] && [ -r "/sys/fs/cgroup${self_v2}/memory.max" ]; then
+    limit_bytes="$(cat "/sys/fs/cgroup${self_v2}/memory.max")"
+  elif [ -r /sys/fs/cgroup/memory.max ]; then
     limit_bytes="$(cat /sys/fs/cgroup/memory.max)"
+  elif [ -n "$self_v1" ] && [ -r "/sys/fs/cgroup/memory${self_v1}/memory.limit_in_bytes" ]; then
+    limit_bytes="$(cat "/sys/fs/cgroup/memory${self_v1}/memory.limit_in_bytes")"
   elif [ -r /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
-    # cgroup v1 reports "unlimited" as a page-rounded near-int64 number;
-    # the derived_mb < cap_mb comparison below already treats it as no limit.
     limit_bytes="$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)"
   fi
   case "$limit_bytes" in

--- a/.docker/app/entrypoint.sh
+++ b/.docker/app/entrypoint.sh
@@ -38,24 +38,60 @@ if [ -z "${S3_PRESIGN_ENDPOINT:-}" ] && [ -n "${ROOMOTE_MINIO_HOST:-}" ]; then
   export S3_PRESIGN_ENDPOINT="https://${ROOMOTE_MINIO_HOST}"
 fi
 
+# V8 sizes its default heap ceiling from the memory it can see, which in a
+# container is the host's total, not the container's limit. With that much
+# perceived headroom it defers full GCs for hours, so the long-running
+# services drift multiple GB above their ~300-400 MB working sets — billed
+# directly on usage-priced hosts — and a container memory cap OOM-kills the
+# process before V8 ever feels pressure. Cap old space explicitly instead:
+# an operator --max-old-space-size in NODE_OPTIONS always wins, and a
+# readable cgroup v2 memory limit lowers (never raises) the service default
+# to ~75% of the container's memory.
+apply_node_heap_cap() {
+  case "${NODE_OPTIONS:-}" in
+    *--max-old-space-size*) return 0 ;;
+  esac
+
+  cap_mb="$1"
+
+  if [ -r /sys/fs/cgroup/memory.max ]; then
+    limit_bytes="$(cat /sys/fs/cgroup/memory.max)"
+    case "$limit_bytes" in
+      '' | *[!0-9]*) ;; # "max" means unlimited; keep the service default
+      *)
+        derived_mb=$((limit_bytes / 1048576 * 3 / 4))
+        if [ "$derived_mb" -gt 0 ] && [ "$derived_mb" -lt "$cap_mb" ]; then
+          cap_mb="$derived_mb"
+        fi
+        ;;
+    esac
+  fi
+
+  export NODE_OPTIONS="${NODE_OPTIONS:+${NODE_OPTIONS} }--max-old-space-size=${cap_mb}"
+}
+
 case "$service" in
   web)
     # The Next.js standalone server binds to HOSTNAME; Docker's default
     # HOSTNAME env is the container id, so pin it to all interfaces.
     export HOSTNAME=0.0.0.0
     export PORT="${PORT:-3000}"
+    apply_node_heap_cap 768
     cd /roomote/apps/web
     exec /roomote/.docker/run-with-dotenvx.sh node server.js "$@"
     ;;
   api)
+    apply_node_heap_cap 768
     cd /roomote/apps/api
     exec /roomote/.docker/run-with-dotenvx.sh node dist/index.js "$@"
     ;;
   controller)
+    apply_node_heap_cap 512
     cd /roomote/apps/controller
     exec /roomote/.docker/run-with-dotenvx.sh node --import ./dist/instrument.js ./dist/index.js "$@"
     ;;
   bullmq)
+    apply_node_heap_cap 512
     cd /roomote/apps/bullmq
     exec /roomote/.docker/run-with-dotenvx.sh node dist/index.js "$@"
     ;;

--- a/apps/docs/self-hosting.mdx
+++ b/apps/docs/self-hosting.mdx
@@ -207,3 +207,12 @@ deployment should let you:
   variables, setup commands, or tool versions to the environment.
 - **Chat messages do not reach Roomote.** Confirm the app is installed, invited
   to the channel, and using the current callback URL.
+- **Memory climbs for hours, or a service is OOM-killed under a container
+  memory limit.** Node sizes its heap from the memory it can see (the host's,
+  not the container's), so it defers garbage collection and lets memory drift
+  well above what the service needs; a container memory cap then kills the
+  process before Node ever feels pressure. Current app images cap each Node
+  service's heap by default (768 MB for web and api, 512 MB for controller and
+  bullmq, reduced to ~75% of the container's memory when a cgroup limit is
+  set). Set `NODE_OPTIONS=--max-old-space-size=<MB>` on a service to override
+  the default, or on older images to add the cap manually.

--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -416,6 +416,15 @@ domain, which requires a domain you control:
   controller, bullmq, Postgres, Redis, MinIO), while task execution bills
   through your sandbox provider (Modal/E2B/Daytona) and model usage bills
   through your model provider.
+- **Node memory is capped by default.** Railway bills memory on usage, and
+  an uncapped Node process lets collectable garbage accumulate for hours
+  before a full GC, inflating that usage several times over. The app image
+  therefore caps each Node service's V8 heap (`--max-old-space-size`):
+  768 MB for web and api, 512 MB for controller and bullmq, lowered to ~75%
+  of the container's memory when a cgroup limit is set. To override, set
+  `NODE_OPTIONS=--max-old-space-size=<MB>` on the service — an explicit
+  value always wins. Images published before this change need that variable
+  set manually to get the same effect.
 
 ## Auto-deploying every develop build (optional)
 


### PR DESCRIPTION
## Problem

The shared app image launches web, api, controller, and bullmq with no `--max-old-space-size`. V8 sizes its default heap ceiling from the memory it can see, which in a container is the host's total rather than the container's limit. With that much perceived headroom it defers full garbage collection for hours, which causes two problems:

1. **Memory drift on usage-billed hosts.** Measured over 72 hours on two representative deployments, every Node service has a post-GC working set of roughly 300-400 MB but drifts far above it between full GCs (api up to 4.3 GB, web 2.8 GB, bullmq 1.9 GB, controller 1.7 GB). On platforms that bill memory by usage, that drift is billed directly.
2. **Crash loops under container memory caps.** A container memory limit is enforced by the runtime, but nothing tells V8, so the process is OOM-killed before V8 ever feels heap pressure. Reported by a self-hoster running bullmq under a 1 GB cap: sawtooth memory growth and periodic OOM restarts even with no tasks running.

## Change

`.docker/app/entrypoint.sh` now applies an explicit `--max-old-space-size` to each long-running Node service:

| Service | Default heap cap |
|---|---|
| web, api | 768 MB |
| controller, bullmq | 512 MB |

- When a cgroup v2 memory limit is readable (`/sys/fs/cgroup/memory.max`), the default is lowered (never raised) to ~75% of the container's memory, leaving headroom for native memory outside the V8 heap.
- An operator-provided `--max-old-space-size` in `NODE_OPTIONS` always wins, and unrelated `NODE_OPTIONS` flags are preserved (the cap is appended, never clobbered).
- `preview-proxy` (non-Node) and `db-migrate` (short-lived) are unchanged.

Documented in `deploy/railway/README.md` and the self-hosting docs, including the manual `NODE_OPTIONS=--max-old-space-size=<MB>` override, which is also the workaround for images published before this change.

## Testing

- `sh -n` passes on the modified entrypoint.
- The helper was exercised standalone against: no cgroup file, `max` (unlimited), empty file, 1 GB / 512 MB / 128 MB / 8 GB limits, the near-int64 no-limit value (no arithmetic overflow), an operator-set `--max-old-space-size` (wins untouched), and pre-existing unrelated `NODE_OPTIONS` flags (preserved with the cap appended). A 512 MB limit derives a 384 MB heap; an 8 GB limit keeps the service default.

## Notes for review

- The cgroup-derived value only ever lowers the service default. An operator who wants a larger heap on a big container sets `NODE_OPTIONS` explicitly.
- 75% of the container limit was chosen to leave room for native allocations (buffers, code, connections) outside the V8 heap.