### PR TITLE
[Feat] Deployment-scoped custom MCP servers (remote, OAuth, and stdio)

### DIFF
--- a/.agents/skills/add-integration/SKILL.md
+++ b/.agents/skills/add-integration/SKILL.md
@@ -86,7 +86,7 @@ Stop and ask the user to choose one of these paths:
 
 - Build a native MCP server inside Roomote with `serverMode: 'native'` and `connectionMode: 'admin_configured'`
 - Wait for the provider to ship an official remote MCP server
-- Recommend that the user configure a custom MCP server in their environment instead
+- Recommend that the user configure a deployment-wide custom MCP server (Settings → Integrations → Custom MCP Servers; supports header auth and OAuth via the proxy) or an environment-scoped `mcpServers` entry instead
 
 Do not quietly convert a missing remote MCP into a built-in integration without that product decision.
 

--- a/apps/api/src/handlers/mcp/__tests__/custom-mcp.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/custom-mcp.test.ts
@@ -208,6 +208,20 @@ describe('createCustomMcpProxy', () => {
     expect(lastUpstreamHeaders?.authorization).toBeUndefined();
   });
 
+  it('sends an operator-configured static Authorization header upstream', async () => {
+    mockFindCustomServer.mockResolvedValue(
+      buildServerRow({
+        url: upstreamUrl(),
+        headers: { Authorization: 'enc(Bearer operator-api-key)' },
+      }),
+    );
+
+    const response = await postMcp(createApp(), initializeRequest);
+
+    expect(response.status).toBe(200);
+    expect(lastUpstreamHeaders?.authorization).toBe('Bearer operator-api-key');
+  });
+
   it('injects the OAuth access token for oauth servers', async () => {
     mockFindCustomServer.mockResolvedValue(
       buildServerRow({ url: upstreamUrl(), authType: 'oauth', headers: null }),

--- a/apps/api/src/handlers/mcp/__tests__/custom-mcp.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/custom-mcp.test.ts
@@ -1,0 +1,323 @@
+import { createServer, type IncomingHttpHeaders, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { Hono } from 'hono';
+import type { RunTokenContext } from '@roomote/types';
+
+import type { Variables } from '../../../types';
+
+const {
+  mockEnv,
+  mockFindTaskRun,
+  mockFindCustomServer,
+  mockFindConnection,
+  mockGetValidAccessToken,
+} = vi.hoisted(() => ({
+  mockEnv: {
+    R_CUSTOM_MCP_ALLOWED_PRIVATE_CIDRS: undefined as string | undefined,
+    R_CUSTOM_MCP_DISABLED: false,
+  },
+  mockFindTaskRun: vi.fn(),
+  mockFindCustomServer: vi.fn(),
+  mockFindConnection: vi.fn(),
+  mockGetValidAccessToken: vi.fn(),
+}));
+
+vi.mock('@roomote/env', () => ({
+  Env: mockEnv,
+  isCustomMcpDisabled: (value: boolean | undefined) => value === true,
+  areCuratedIntegrationsDisabled: (value: boolean | undefined) =>
+    value === true,
+}));
+
+vi.mock('@roomote/db/server', () => ({
+  db: {
+    query: {
+      taskRuns: { findFirst: mockFindTaskRun },
+      customMcpServers: { findFirst: mockFindCustomServer },
+      mcpConnections: { findFirst: mockFindConnection },
+    },
+  },
+  taskRuns: { id: 'id' },
+  customMcpServers: { id: 'id', enabled: 'enabled' },
+  mcpConnections: { mcpId: 'mcpId', enabled: 'enabled', userId: 'userId' },
+  eq: vi.fn((column: unknown, value: unknown) => ({ column, value })),
+  and: vi.fn((...clauses: unknown[]) => clauses),
+  isNull: vi.fn((column: unknown) => ({ type: 'isNull', column })),
+}));
+
+vi.mock('@roomote/db/encryption', () => ({
+  decrypt: vi.fn((value: string) => value.replace(/^enc\(|\)$/g, '')),
+}));
+
+vi.mock('@roomote/sdk/server', () => ({
+  getValidAccessToken: mockGetValidAccessToken,
+}));
+
+import { createCustomMcpProxy } from '../custom-mcp';
+
+const SERVER_ID = '4c72c9dd-3f5e-4d3e-9f7a-2c1b8a6e5d40';
+
+function createRunToken(): RunTokenContext {
+  return {
+    runId: 42,
+    userId: null,
+    principal: 'deployment',
+    tokenType: 'run',
+    version: 1,
+  };
+}
+
+function createApp() {
+  const app = new Hono<{ Variables: Variables }>();
+
+  app.use('*', async (c, next) => {
+    c.set('authContext', createRunToken());
+    await next();
+  });
+
+  app.route('/custom/:serverId', createCustomMcpProxy());
+  return app;
+}
+
+function buildServerRow(
+  overrides: Partial<Record<string, unknown>> = {},
+): Record<string, unknown> {
+  return {
+    id: SERVER_ID,
+    name: 'internal-tools',
+    url: 'http://127.0.0.1:0/mcp',
+    authType: 'static_headers',
+    headers: { 'x-api-key': 'enc(secret-one)' },
+    stdio: null,
+    disabledTools: null,
+    enabled: true,
+    ...overrides,
+  };
+}
+
+async function postMcp(
+  app: Hono<{ Variables: Variables }>,
+  body: unknown,
+  serverId: string = SERVER_ID,
+) {
+  return app.request(`/custom/${serverId}`, {
+    method: 'POST',
+    headers: {
+      accept: 'application/json, text/event-stream',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const initializeRequest = {
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: {
+    protocolVersion: '2025-06-18',
+    capabilities: {},
+    clientInfo: { name: 'roomote-api-test', version: '1.0.0' },
+  },
+};
+
+describe('createCustomMcpProxy', () => {
+  let upstream: Server;
+  let upstreamPort: number;
+  let lastUpstreamHeaders: IncomingHttpHeaders | null = null;
+
+  beforeAll(async () => {
+    upstream = createServer((req, res) => {
+      lastUpstreamHeaders = req.headers;
+
+      if (req.url === '/redirect') {
+        res.statusCode = 302;
+        res.setHeader('location', 'http://127.0.0.1/internal');
+        res.end();
+        return;
+      }
+
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          result: {
+            tools: [
+              { name: 'safe_tool', description: 'ok' },
+              { name: 'dangerous_tool', description: 'no' },
+            ],
+          },
+        }),
+      );
+    });
+
+    await new Promise<void>((resolve) => {
+      upstream.listen(0, '127.0.0.1', resolve);
+    });
+
+    upstreamPort = (upstream.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      upstream.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lastUpstreamHeaders = null;
+    mockEnv.R_CUSTOM_MCP_ALLOWED_PRIVATE_CIDRS = '127.0.0.0/8';
+    mockFindTaskRun.mockResolvedValue({ id: 42 });
+  });
+
+  function upstreamUrl(path = '/mcp') {
+    return `http://127.0.0.1:${upstreamPort}${path}`;
+  }
+
+  it('404s for malformed server ids without touching the database', async () => {
+    const response = await postMcp(
+      createApp(),
+      initializeRequest,
+      'not-a-uuid',
+    );
+
+    expect(response.status).toBe(404);
+    expect(mockFindCustomServer).not.toHaveBeenCalled();
+  });
+
+  it('404s for unknown servers', async () => {
+    mockFindCustomServer.mockResolvedValue(undefined);
+
+    const response = await postMcp(createApp(), initializeRequest);
+
+    expect(response.status).toBe(404);
+  });
+
+  it('proxies to the upstream with decrypted static headers and no Authorization', async () => {
+    mockFindCustomServer.mockResolvedValue(
+      buildServerRow({ url: upstreamUrl() }),
+    );
+
+    const response = await postMcp(createApp(), initializeRequest);
+
+    expect(response.status).toBe(200);
+    expect(lastUpstreamHeaders?.['x-api-key']).toBe('secret-one');
+    expect(lastUpstreamHeaders?.authorization).toBeUndefined();
+  });
+
+  it('injects the OAuth access token for oauth servers', async () => {
+    mockFindCustomServer.mockResolvedValue(
+      buildServerRow({ url: upstreamUrl(), authType: 'oauth', headers: null }),
+    );
+    mockFindConnection.mockResolvedValue({ id: 'conn-1' });
+    mockGetValidAccessToken.mockResolvedValue('custom-access-token');
+
+    const response = await postMcp(createApp(), initializeRequest);
+
+    expect(response.status).toBe(200);
+    expect(lastUpstreamHeaders?.authorization).toBe(
+      'Bearer custom-access-token',
+    );
+  });
+
+  it('returns a reconnect error when oauth tokens are missing', async () => {
+    mockFindCustomServer.mockResolvedValue(
+      buildServerRow({ url: upstreamUrl(), authType: 'oauth', headers: null }),
+    );
+    mockFindConnection.mockResolvedValue(undefined);
+
+    const response = await postMcp(createApp(), initializeRequest);
+
+    expect(response.status).toBe(401);
+
+    const body = (await response.json()) as { error: { message: string } };
+
+    expect(body.error.message).toContain('reconnected');
+  });
+
+  it('403s deny-listed tool calls without contacting the upstream', async () => {
+    mockFindCustomServer.mockResolvedValue(
+      buildServerRow({
+        url: upstreamUrl(),
+        disabledTools: ['dangerous_tool'],
+      }),
+    );
+
+    const response = await postMcp(createApp(), {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'dangerous_tool', arguments: {} },
+    });
+
+    expect(response.status).toBe(403);
+    expect(lastUpstreamHeaders).toBeNull();
+  });
+
+  it('filters deny-listed tools out of tools/list responses', async () => {
+    mockFindCustomServer.mockResolvedValue(
+      buildServerRow({
+        url: upstreamUrl(),
+        disabledTools: ['dangerous_tool'],
+      }),
+    );
+
+    const response = await postMcp(createApp(), {
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/list',
+      params: {},
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result: { tools: { name: string }[] };
+    };
+
+    expect(body.result.tools.map((tool) => tool.name)).toEqual(['safe_tool']);
+  });
+
+  it('refuses upstream redirects instead of following them', async () => {
+    mockFindCustomServer.mockResolvedValue(
+      buildServerRow({ url: upstreamUrl('/redirect') }),
+    );
+
+    const response = await postMcp(createApp(), initializeRequest);
+
+    expect(response.status).toBe(502);
+
+    const body = (await response.json()) as { error: { message: string } };
+
+    expect(body.error.message).toContain('redirect');
+  });
+
+  it('refuses private upstreams without a CIDR allowance', async () => {
+    mockEnv.R_CUSTOM_MCP_ALLOWED_PRIVATE_CIDRS = undefined;
+    mockFindCustomServer.mockResolvedValue(
+      buildServerRow({ url: upstreamUrl() }),
+    );
+
+    const response = await postMcp(createApp(), initializeRequest);
+
+    expect(response.status).toBeGreaterThanOrEqual(500);
+    expect(lastUpstreamHeaders).toBeNull();
+  });
+
+  it('rejects oversized request bodies', async () => {
+    mockFindCustomServer.mockResolvedValue(
+      buildServerRow({ url: upstreamUrl() }),
+    );
+
+    const response = await postMcp(createApp(), {
+      ...initializeRequest,
+      params: { blob: 'x'.repeat(1024 * 1024 + 1) },
+    });
+
+    expect(response.status).toBe(413);
+    expect(lastUpstreamHeaders).toBeNull();
+  });
+});

--- a/apps/api/src/handlers/mcp/__tests__/custom-mcp.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/custom-mcp.test.ts
@@ -320,4 +320,59 @@ describe('createCustomMcpProxy', () => {
     expect(response.status).toBe(413);
     expect(lastUpstreamHeaders).toBeNull();
   });
+
+  it('rejects on Content-Length before the body is parsed', async () => {
+    mockFindCustomServer.mockResolvedValue(
+      buildServerRow({ url: upstreamUrl() }),
+    );
+
+    // Deliberately invalid JSON: parsing first would answer 400, so a 413
+    // here proves the size check runs before the body is parsed at all.
+    const response = await createApp().request(`/custom/${SERVER_ID}`, {
+      method: 'POST',
+      headers: {
+        accept: 'application/json, text/event-stream',
+        'content-type': 'application/json',
+        'content-length': String(1024 * 1024 * 64),
+      },
+      body: 'not-json',
+    });
+
+    expect(response.status).toBe(413);
+    expect(lastUpstreamHeaders).toBeNull();
+  });
+
+  it('aborts a chunked body that understates its size', async () => {
+    mockFindCustomServer.mockResolvedValue(
+      buildServerRow({ url: upstreamUrl() }),
+    );
+
+    // No content-length, and the stream would never end on its own: only the
+    // streamed byte cap can stop this.
+    let enqueuedChunks = 0;
+    const chunk = new TextEncoder().encode('x'.repeat(64 * 1024));
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        enqueuedChunks += 1;
+        controller.enqueue(chunk);
+      },
+    });
+
+    const response = await createApp().request(`/custom/${SERVER_ID}`, {
+      method: 'POST',
+      headers: {
+        accept: 'application/json, text/event-stream',
+        'content-type': 'application/json',
+      },
+      body,
+      // @ts-expect-error -- required by undici for streaming request bodies.
+      duplex: 'half',
+    });
+
+    expect(response.status).toBe(413);
+    expect(lastUpstreamHeaders).toBeNull();
+    // The cap is 1 MiB, so the read stops long before an unbounded stream
+    // could exhaust memory.
+    expect(enqueuedChunks).toBeLessThan(64);
+  });
 });

--- a/apps/api/src/handlers/mcp/custom-mcp.ts
+++ b/apps/api/src/handlers/mcp/custom-mcp.ts
@@ -1,0 +1,106 @@
+import { Env } from '@roomote/env';
+import {
+  and,
+  db,
+  eq,
+  customMcpServers,
+  isNull,
+  mcpConnections,
+} from '@roomote/db/server';
+import { decrypt } from '@roomote/db/encryption';
+import { getValidAccessToken } from '@roomote/sdk/server';
+import { customMcpConnectionId } from '@roomote/types';
+
+import { createMcpProxy, McpProxyError } from './proxy-utils';
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Untrusted custom upstreams get a request-body cap; curated servers have no
+ * cap because their upstreams are known parties.
+ */
+const MAX_CUSTOM_MCP_REQUEST_BODY_BYTES = 1024 * 1024;
+
+/**
+ * Proxy for deployment-scoped custom MCP servers at
+ * `/api/mcp/custom/:serverId`.
+ *
+ * The upstream URL and credentials resolve per request from the
+ * `custom_mcp_servers` row, so Settings edits apply to in-flight tasks
+ * without re-delivery. Upstream egress is SSRF-guarded (private ranges
+ * blocked unless allowed via R_CUSTOM_MCP_ALLOWED_PRIVATE_CIDRS, DNS answers
+ * pinned, redirects refused) because the upstream is operator-controlled.
+ *
+ * Custom-server connections are deployment-scoped: credential selection does
+ * not depend on the acting user, so no acting-user resolution happens here.
+ */
+export function createCustomMcpProxy() {
+  return createMcpProxy({
+    name: 'Custom',
+    guardUpstreamEgress: {
+      allowedPrivateCidrs: Env.R_CUSTOM_MCP_ALLOWED_PRIVATE_CIDRS,
+    },
+    maxRequestBodyBytes: MAX_CUSTOM_MCP_REQUEST_BODY_BYTES,
+    resolveCredentials: async (_auth, routeParams) => {
+      const serverId = routeParams['serverId'];
+
+      if (!serverId || !UUID_PATTERN.test(serverId)) {
+        throw new McpProxyError(404, 'Custom MCP server not found');
+      }
+
+      const server = await db.query.customMcpServers.findFirst({
+        where: and(
+          eq(customMcpServers.id, serverId),
+          eq(customMcpServers.enabled, true),
+        ),
+      });
+
+      if (!server || !server.url || server.stdio) {
+        throw new McpProxyError(404, 'Custom MCP server not found');
+      }
+
+      let authHeader: string | null = null;
+      let extraHeaders: Record<string, string> | undefined;
+
+      if (server.authType === 'static_headers' && server.headers) {
+        extraHeaders = {};
+
+        for (const [headerName, encryptedValue] of Object.entries(
+          server.headers,
+        )) {
+          extraHeaders[headerName] = decrypt(encryptedValue);
+        }
+      } else if (server.authType === 'oauth') {
+        const connection = await db.query.mcpConnections.findFirst({
+          where: and(
+            eq(mcpConnections.mcpId, customMcpConnectionId(server.id)),
+            eq(mcpConnections.enabled, true),
+            isNull(mcpConnections.userId),
+          ),
+          columns: { id: true },
+        });
+
+        const accessToken = connection
+          ? await getValidAccessToken(connection.id, server.url)
+          : null;
+
+        if (!accessToken) {
+          throw new McpProxyError(
+            401,
+            `Custom MCP server '${server.name}' needs to be reconnected by a deployment admin in Settings > Integrations`,
+          );
+        }
+
+        authHeader = accessToken;
+      }
+
+      return {
+        authHeader,
+        extraHeaders,
+        disabledToolNames: server.disabledTools,
+        upstream: server.url,
+      };
+    },
+  });
+}

--- a/apps/api/src/handlers/mcp/index.ts
+++ b/apps/api/src/handlers/mcp/index.ts
@@ -1,5 +1,9 @@
 import { Hono, type MiddlewareHandler } from 'hono';
-import { Env, areCuratedIntegrationsDisabled } from '@roomote/env';
+import {
+  Env,
+  areCuratedIntegrationsDisabled,
+  isCustomMcpDisabled,
+} from '@roomote/env';
 import { isNativeMcpIntegration, MCP_INTEGRATIONS } from '@roomote/types';
 
 import type { Variables } from '../../types';
@@ -9,6 +13,7 @@ import { communicationMcp } from './communication';
 import { environmentsRouter } from '../environments';
 import { customAutomationsRouter } from '../custom-automations';
 import { tasksRouter } from '../tasks';
+import { createCustomMcpProxy } from './custom-mcp';
 import { createIntegrationMcpProxy } from './integration-mcp';
 import { granolaMcp } from './granola';
 import { grafanaMcp } from './grafana';
@@ -35,6 +40,22 @@ for (const integration of MCP_INTEGRATIONS) {
   mcp.use(`/${integration.id}`, requireCuratedIntegrations);
   mcp.use(`/${integration.id}/*`, requireCuratedIntegrations);
 }
+
+// Deployment custom servers have their own kill switch, deliberately
+// independent of the curated-catalog flag: operators who disable the catalog
+// are the primary custom-server audience.
+const requireCustomMcp: MiddlewareHandler<{
+  Variables: Variables;
+}> = async (c, next) => {
+  if (isCustomMcpDisabled(Env.R_CUSTOM_MCP_DISABLED)) {
+    return c.notFound();
+  }
+
+  await next();
+};
+
+mcp.use('/custom/*', requireCustomMcp);
+mcp.route('/custom/:serverId', createCustomMcpProxy());
 
 mcp.route('/asana', asanaMcp);
 mcp.route('/granola', granolaMcp);

--- a/apps/api/src/handlers/mcp/proxy-utils.ts
+++ b/apps/api/src/handlers/mcp/proxy-utils.ts
@@ -459,6 +459,68 @@ function filterToolsListPayload(
   };
 }
 
+class RequestBodyTooLargeError extends Error {
+  constructor(readonly observedBytes: number) {
+    super('Request body exceeds the configured limit');
+    this.name = 'RequestBodyTooLargeError';
+  }
+}
+
+/**
+ * Read a request body as text without ever buffering more than `maxBytes`.
+ *
+ * `Content-Length` is checked first so an oversized request is rejected
+ * before a single chunk is read, but it is only a hint: chunked bodies omit
+ * it and a hostile client can understate it. The streamed read is therefore
+ * the real bound — it aborts as soon as the accumulated size crosses the
+ * limit, so an unbounded body can never be materialized (nor re-serialized)
+ * in memory.
+ */
+async function readBoundedRequestText(
+  request: Request,
+  maxBytes: number,
+): Promise<string> {
+  const declaredLength = Number(request.headers.get('content-length'));
+
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    throw new RequestBodyTooLargeError(declaredLength);
+  }
+
+  const body = request.body;
+
+  if (!body) {
+    return '';
+  }
+
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let text = '';
+  let total = 0;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+
+    if (done) {
+      break;
+    }
+
+    if (!value) {
+      continue;
+    }
+
+    total += value.byteLength;
+
+    if (total > maxBytes) {
+      await reader.cancel();
+      throw new RequestBodyTooLargeError(total);
+    }
+
+    text += decoder.decode(value, { stream: true });
+  }
+
+  return text + decoder.decode();
+}
+
 export function createMcpProxy(config: McpProxyConfig) {
   const {
     name,
@@ -571,9 +633,39 @@ export function createMcpProxy(config: McpProxyConfig) {
 
     if (method === 'POST') {
       try {
-        parsedBody = await c.req.json();
-        upstreamBody = JSON.stringify(parsedBody);
-      } catch {
+        if (maxRequestBodyBytes === undefined) {
+          parsedBody = await c.req.json();
+          upstreamBody = JSON.stringify(parsedBody);
+        } else {
+          // Capped upstreams (custom servers) must be bounded *before* the
+          // body is buffered or parsed, so forward the vetted text as-is
+          // rather than re-serializing it.
+          upstreamBody = await readBoundedRequestText(
+            c.req.raw,
+            maxRequestBodyBytes,
+          );
+          parsedBody = JSON.parse(upstreamBody);
+        }
+      } catch (error) {
+        if (error instanceof RequestBodyTooLargeError) {
+          console.warn(
+            formatSingleLineLog(`${logPrefix} Request body too large`, {
+              requestId,
+              method,
+              path,
+              tokenType: auth.tokenType,
+              userId: auth.userId,
+              bytes: error.observedBytes,
+              limit: maxRequestBodyBytes,
+            }),
+          );
+          return jsonRpcErrorResponse(
+            413,
+            -32600,
+            `${name} MCP request body exceeds the size limit`,
+          );
+        }
+
         console.warn(
           formatSingleLineLog(`${logPrefix} Invalid JSON request body`, {
             requestId,
@@ -584,28 +676,6 @@ export function createMcpProxy(config: McpProxyConfig) {
           }),
         );
         return jsonRpcErrorResponse(400, -32700, 'Invalid JSON body');
-      }
-
-      if (
-        maxRequestBodyBytes !== undefined &&
-        upstreamBody !== undefined &&
-        Buffer.byteLength(upstreamBody, 'utf8') > maxRequestBodyBytes
-      ) {
-        console.warn(
-          formatSingleLineLog(`${logPrefix} Request body too large`, {
-            requestId,
-            method,
-            path,
-            tokenType: auth.tokenType,
-            userId: auth.userId,
-            bytes: Buffer.byteLength(upstreamBody, 'utf8'),
-          }),
-        );
-        return jsonRpcErrorResponse(
-          413,
-          -32600,
-          `${name} MCP request body exceeds the size limit`,
-        );
       }
     }
 

--- a/apps/api/src/handlers/mcp/proxy-utils.ts
+++ b/apps/api/src/handlers/mcp/proxy-utils.ts
@@ -10,6 +10,11 @@ import {
   parseMcpJsonRpcPayload,
 } from '@roomote/types';
 import { db, eq, taskRuns } from '@roomote/db/server';
+import { Agent } from 'undici';
+import {
+  assertEgressUrlAllowed,
+  createGuardedConnectOptions,
+} from '@roomote/sdk/server/safe-fetch';
 
 import type { Variables } from '../../types';
 import { fetchWithLongLivedStreamDispatcher } from '../long-lived-fetch';
@@ -212,7 +217,7 @@ export async function assertTaskRunTokenTargetExists(
 }
 
 function buildProxyRequestHeaders(
-  authHeader: string,
+  authHeader: string | null,
   requestHeaders: Headers,
   method: string,
 ): Headers {
@@ -225,10 +230,13 @@ function buildProxyRequestHeaders(
     'accept',
     requestHeaders.get('accept') ?? 'application/json, text/event-stream',
   );
-  headers.set(
-    'authorization',
-    authHeader.startsWith('Bearer ') ? authHeader : `Bearer ${authHeader}`,
-  );
+
+  if (authHeader) {
+    headers.set(
+      'authorization',
+      authHeader.startsWith('Bearer ') ? authHeader : `Bearer ${authHeader}`,
+    );
+  }
 
   const sessionId = requestHeaders.get('mcp-session-id');
   if (sessionId) {
@@ -284,9 +292,15 @@ function isJsonResponse(contentType: string | null): boolean {
 }
 
 interface ResolvedCredentials {
-  authHeader: string;
+  /** `null` for upstreams that take no Authorization header. */
+  authHeader: string | null;
   extraHeaders?: Record<string, string>;
   disabledToolNames?: readonly string[] | null;
+  /**
+   * Per-request upstream URL. Required when the proxy was constructed without
+   * a static `upstream` (custom servers resolve theirs from the database).
+   */
+  upstream?: string;
 }
 
 export interface McpAuthContext {
@@ -302,13 +316,26 @@ export interface McpAuthContext {
 
 interface McpProxyConfig {
   name: string;
-  upstream: string;
-  resolveCredentials: (auth: McpAuthContext) => Promise<ResolvedCredentials>;
+  /** Static upstream URL; omit when resolveCredentials returns one. */
+  upstream?: string;
+  resolveCredentials: (
+    auth: McpAuthContext,
+    routeParams: Record<string, string>,
+  ) => Promise<ResolvedCredentials>;
   allowAuthTokens?: boolean;
   validateTaskRunToken?: (auth: RunTokenContext) => Promise<Response | null>;
   allowedToolNames?: readonly string[];
   stripToolSchemaPatterns?: boolean;
   timeoutMs?: number;
+  /**
+   * Enable SSRF guarding for operator-controlled upstreams: URL and DNS
+   * answers are vetted (with connect pinned to the vetted addresses), and
+   * upstream redirects are refused rather than followed — following one
+   * would re-send the injected Authorization header to a server-chosen URL.
+   */
+  guardUpstreamEgress?: { allowedPrivateCidrs?: string };
+  /** Reject request bodies larger than this many bytes (413). */
+  maxRequestBodyBytes?: number;
 }
 
 export class McpProxyError extends Error {
@@ -442,7 +469,27 @@ export function createMcpProxy(config: McpProxyConfig) {
     validateTaskRunToken = verifyTaskRunTokenTargetExists,
     allowedToolNames,
     stripToolSchemaPatterns: shouldStripToolSchemaPatterns = false,
+    guardUpstreamEgress,
+    maxRequestBodyBytes,
   } = config;
+
+  // Guarded dispatchers pin connections to DNS answers vetted against the
+  // private-range blocklist; constructed once per proxy, shared by requests.
+  const guardedLongLivedDispatcher = guardUpstreamEgress
+    ? new Agent({
+        bodyTimeout: 0,
+        connect: createGuardedConnectOptions({
+          allowedPrivateCidrs: guardUpstreamEgress.allowedPrivateCidrs,
+        }),
+      })
+    : null;
+  const guardedDefaultDispatcher = guardUpstreamEgress
+    ? new Agent({
+        connect: createGuardedConnectOptions({
+          allowedPrivateCidrs: guardUpstreamEgress.allowedPrivateCidrs,
+        }),
+      })
+    : null;
 
   const app = new Hono<{ Variables: Variables }>();
 
@@ -538,12 +585,34 @@ export function createMcpProxy(config: McpProxyConfig) {
         );
         return jsonRpcErrorResponse(400, -32700, 'Invalid JSON body');
       }
+
+      if (
+        maxRequestBodyBytes !== undefined &&
+        upstreamBody !== undefined &&
+        Buffer.byteLength(upstreamBody, 'utf8') > maxRequestBodyBytes
+      ) {
+        console.warn(
+          formatSingleLineLog(`${logPrefix} Request body too large`, {
+            requestId,
+            method,
+            path,
+            tokenType: auth.tokenType,
+            userId: auth.userId,
+            bytes: Buffer.byteLength(upstreamBody, 'utf8'),
+          }),
+        );
+        return jsonRpcErrorResponse(
+          413,
+          -32600,
+          `${name} MCP request body exceeds the size limit`,
+        );
+      }
     }
 
     let credentials: ResolvedCredentials;
 
     try {
-      credentials = await resolveCredentials(auth);
+      credentials = await resolveCredentials(auth, c.req.param());
     } catch (error) {
       console.warn(
         formatSingleLineLog(`${logPrefix} Failed to resolve credentials`, {
@@ -564,6 +633,23 @@ export function createMcpProxy(config: McpProxyConfig) {
         `Failed to resolve ${name} credentials: ${
           error instanceof Error ? error.message : String(error)
         }`,
+      );
+    }
+
+    const effectiveUpstream = credentials.upstream ?? upstream;
+
+    if (!effectiveUpstream) {
+      console.error(
+        formatSingleLineLog(`${logPrefix} No upstream URL resolved`, {
+          requestId,
+          method,
+          path,
+        }),
+      );
+      return jsonRpcErrorResponse(
+        500,
+        -32603,
+        `${name} MCP has no upstream URL configured`,
       );
     }
 
@@ -655,14 +741,51 @@ export function createMcpProxy(config: McpProxyConfig) {
         headers: proxyHeaders,
         body: upstreamBody,
         signal,
+        // Operator-controlled upstreams must not have their redirects
+        // followed: a 302 would re-send the injected Authorization header to
+        // a server-chosen URL, bypassing the egress guard.
+        ...(guardUpstreamEgress ? { redirect: 'manual' as const } : {}),
       };
 
-      const upstreamResponse = isLongLivedStreamableTransportRequest
-        ? await fetchWithLongLivedStreamDispatcher(
-            upstream,
-            upstreamRequestInit,
-          )
-        : await fetch(upstream, upstreamRequestInit);
+      let upstreamResponse: Response;
+
+      if (guardUpstreamEgress) {
+        assertEgressUrlAllowed(
+          effectiveUpstream,
+          guardUpstreamEgress.allowedPrivateCidrs,
+        );
+
+        upstreamResponse = await fetch(effectiveUpstream, {
+          ...upstreamRequestInit,
+          dispatcher: isLongLivedStreamableTransportRequest
+            ? guardedLongLivedDispatcher!
+            : guardedDefaultDispatcher!,
+        } as RequestInit);
+
+        if (upstreamResponse.status >= 300 && upstreamResponse.status < 400) {
+          console.warn(
+            formatSingleLineLog(`${logPrefix} Refused upstream redirect`, {
+              requestId,
+              method,
+              path,
+              upstream: effectiveUpstream,
+              status: upstreamResponse.status,
+            }),
+          );
+          return jsonRpcErrorResponse(
+            502,
+            -32000,
+            `${name} MCP upstream answered with a redirect, which is not followed for custom servers`,
+          );
+        }
+      } else {
+        upstreamResponse = isLongLivedStreamableTransportRequest
+          ? await fetchWithLongLivedStreamDispatcher(
+              effectiveUpstream,
+              upstreamRequestInit,
+            )
+          : await fetch(effectiveUpstream, upstreamRequestInit);
+      }
 
       const elapsedMs = Date.now() - startedAt;
       const contentType = upstreamResponse.headers.get('content-type');
@@ -673,7 +796,7 @@ export function createMcpProxy(config: McpProxyConfig) {
             requestId,
             method,
             path,
-            upstream,
+            upstream: effectiveUpstream,
             status: upstreamResponse.status,
             statusText: upstreamResponse.statusText,
             contentType,
@@ -733,7 +856,7 @@ export function createMcpProxy(config: McpProxyConfig) {
             requestId,
             method,
             path,
-            upstream,
+            upstream: effectiveUpstream,
             status: upstreamResponse.status,
             tokenType: auth.tokenType,
             userId: auth.userId ?? undefined,
@@ -756,7 +879,7 @@ export function createMcpProxy(config: McpProxyConfig) {
         requestId,
         method,
         path,
-        upstream,
+        upstream: effectiveUpstream,
         tokenType: auth.tokenType,
         userId: auth.userId,
         elapsedMs: Date.now() - startedAt,

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -134,6 +134,7 @@
         "group": "Integrations",
         "pages": [
           "integrations/index",
+          "integrations/custom-mcp-servers",
           "integrations/asana",
           "integrations/better-stack",
           "integrations/braintrust",

--- a/apps/docs/integrations/custom-mcp-servers.mdx
+++ b/apps/docs/integrations/custom-mcp-servers.mdx
@@ -8,6 +8,13 @@ built-in integration for. Deployment admins configure them under
 **Settings → Integrations → Custom MCP Servers**, and they become available to
 agents in every task.
 
+Most MCP servers publish a JSON snippet in their docs. The add dialog's
+**Import from JSON** button accepts a pasted `mcpServers` snippet (or a bare
+server config) and prefills the form from it, for both remote and local
+servers. Snippets that launch `mcp-remote` are converted to remote servers on
+the upstream URL, which keeps credentials behind the Roomote proxy and
+enables per-tool management.
+
 Three kinds of servers are supported:
 
 | Kind                    | How it connects                                                            | Where credentials live                          |

--- a/apps/docs/integrations/custom-mcp-servers.mdx
+++ b/apps/docs/integrations/custom-mcp-servers.mdx
@@ -32,6 +32,10 @@ real credentials per request. This means:
 
 - Header values and OAuth tokens never appear in sandbox-readable
   configuration or in the browser after saving.
+- Header auth covers servers that expect a static
+  `Authorization: Bearer <api-key>` as well as custom schemes like
+  `x-api-key`. Roomote's own caller credentials are never forwarded
+  upstream.
 - OAuth tokens refresh centrally, so long-running tasks keep working across
   token expiry.
 - Per-tool disables (the **Manage tools** dialog) are enforced at the proxy:

--- a/apps/docs/integrations/custom-mcp-servers.mdx
+++ b/apps/docs/integrations/custom-mcp-servers.mdx
@@ -1,0 +1,110 @@
+---
+title: 'Custom MCP Servers'
+description: 'Connect MCP servers that are not in the built-in catalog'
+---
+
+Custom MCP servers let agents use services that Roomote does not ship a
+built-in integration for. Deployment admins configure them under
+**Settings → Integrations → Custom MCP Servers**, and they become available to
+agents in every task.
+
+Three kinds of servers are supported:
+
+| Kind                    | How it connects                                                            | Where credentials live                          |
+| ----------------------- | -------------------------------------------------------------------------- | ----------------------------------------------- |
+| Remote, no auth         | Streamable HTTP through the Roomote proxy                                  | None                                            |
+| Remote, header auth     | Streamable HTTP through the Roomote proxy                                  | Encrypted server-side; injected by the proxy    |
+| Remote, OAuth           | Streamable HTTP through the Roomote proxy                                  | Tokens stored and refreshed server-side         |
+| Local (stdio)           | Launched inside the task sandbox                                           | Encrypted at rest; visible inside the sandbox   |
+
+## How remote servers are reached
+
+Remote custom servers are never handed to the task sandbox directly. The
+sandbox sees an authenticated Roomote proxy URL, and the proxy injects the
+real credentials per request. This means:
+
+- Header values and OAuth tokens never appear in sandbox-readable
+  configuration or in the browser after saving.
+- OAuth tokens refresh centrally, so long-running tasks keep working across
+  token expiry.
+- Per-tool disables (the **Manage tools** dialog) are enforced at the proxy:
+  disabled tools are hidden from agents and blocked even if called directly.
+
+## OAuth
+
+For servers that support the MCP authorization spec, pick **OAuth** and use
+**Connect** after saving. Roomote discovers the authorization server, uses
+Dynamic Client Registration when the server supports it, and completes the
+flow with PKCE. For servers without Dynamic Client Registration, register an
+OAuth client for the callback URL shown in the dialog
+(`https://<your-roomote>/api/mcp-oauth/callback`) and enter the client ID and
+secret manually.
+
+If a token refresh is rejected by the server, the connection is marked as
+needing reconnection: agents get a clear error pointing at Settings, and the
+server card shows **Connect** again.
+
+Roomote sends the RFC 8707 `resource` indicator by default, as required by
+the current MCP authorization spec. A per-server toggle disables it for
+servers that reject unknown parameters.
+
+## Local (stdio) servers
+
+Local servers run inside the task sandbox, launched with the command,
+arguments, and environment variables you configure. Two things to know:
+
+- The process runs with the same privileges as the agent itself; its
+  environment values are visible inside the sandbox at runtime, exactly like
+  environment-scoped stdio servers.
+- Environment values can reference
+  [deployment environment variables](/settings#deployment-environment-variables)
+  with `${VAR}` syntax. References to Roomote runtime credentials are
+  rejected at save time.
+
+The sandbox image ships `node`, `npx`, `uvx`, and `python`, so
+`npx -y <package>` style servers work out of the box.
+
+## Scoping and precedence
+
+Custom servers configured in Settings apply to every task. An environment's
+own [`mcpServers`](/environments/definition#mcp-servers) entry with the same
+name takes precedence in that environment, so the more specific scope wins.
+Names that collide with built-in integrations (for example `linear` or
+`github`) are reserved and rejected.
+
+## Private networks and self-hosting
+
+For security, the Roomote control plane refuses to connect to private and
+special-use address ranges (RFC 1918, link-local, cloud metadata) when
+proxying to custom servers or running OAuth discovery. Self-hosted
+deployments that intentionally run MCP servers on an internal network can
+allow specific ranges with the `R_CUSTOM_MCP_ALLOWED_PRIVATE_CIDRS`
+environment variable, for example:
+
+```bash
+R_CUSTOM_MCP_ALLOWED_PRIVATE_CIDRS=10.20.0.0/16,192.168.7.0/24
+```
+
+This is a CIDR list rather than an on/off switch so that opening one internal
+host does not expose adjacent services (databases, caches) to
+operator-configured URLs. Redirects from custom servers are never followed.
+
+## Operator controls
+
+- Custom servers are managed by deployment admins only.
+- `R_CUSTOM_MCP_DISABLED=true` disables the feature entirely: the Settings
+  section, the proxy routes, and delivery to tasks. It is independent of
+  `R_CURATED_INTEGRATIONS_DISABLED`, so a deployment can disable the built-in
+  catalog while still using its own custom servers.
+- A custom server's tool descriptions are provided by that server and are
+  untrusted model input; review new servers the way you would review a
+  dependency.
+
+## Notes
+
+- Changes to custom servers apply to newly started tasks. Remote credential
+  edits (headers, reconnects) apply immediately because the proxy resolves
+  them per request.
+- Editing a server's URL or auth mode clears its stored OAuth tokens and
+  requires reconnecting, so credentials can never be replayed against a
+  different endpoint.

--- a/apps/docs/integrations/custom-mcp-servers.mdx
+++ b/apps/docs/integrations/custom-mcp-servers.mdx
@@ -57,9 +57,9 @@ arguments, and environment variables you configure. Two things to know:
   environment values are visible inside the sandbox at runtime, exactly like
   environment-scoped stdio servers.
 - Environment values can reference
-  [deployment environment variables](/settings#deployment-environment-variables)
-  with `${VAR}` syntax. References to Roomote runtime credentials are
-  rejected at save time.
+  [deployment environment variables](/environment-variables) with `${VAR}`
+  syntax. References to Roomote runtime credentials are rejected at save
+  time.
 
 The sandbox image ships `node`, `npx`, `uvx`, and `python`, so
 `npx -y <package>` style servers work out of the box.

--- a/apps/docs/integrations/index.mdx
+++ b/apps/docs/integrations/index.mdx
@@ -74,9 +74,16 @@ from [Personal Settings](/personal-settings).
 
 ## Custom MCP servers
 
-Beyond the built-in catalog, environments can configure custom MCP servers so
-tasks can reach tools that are specific to your team. Add them in the YAML view
-of the environment editor. See [Environments](/environments).
+Beyond the built-in catalog, you can connect your own MCP servers at two
+scopes:
+
+- **Deployment-wide**, under Settings → Integrations →
+  [Custom MCP Servers](/integrations/custom-mcp-servers): remote servers
+  (with header or OAuth authentication, credentials held server-side) and
+  local stdio servers, available to agents in every task.
+- **Per-environment**, in the YAML view of the environment editor. See
+  [Environments](/environments). An environment entry with the same name as a
+  deployment-wide server takes precedence in that environment.
 
 Use deployment or user-linked integrations when the tool is broadly useful
 across teams. Use an environment-level MCP server when the tool only makes

--- a/apps/web/src/app/api/mcp-oauth/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/mcp-oauth/callback/__tests__/route.test.ts
@@ -86,6 +86,8 @@ vi.mock('@roomote/sdk/server', () => ({
   storeTokens: storeTokensMock,
   getClientInformation: getClientInformationMock,
   updateAuthStatus: updateAuthStatusMock,
+  resolveCustomMcpAuthTarget: vi.fn(async () => null),
+  ensureCustomMcpServerMetadata: vi.fn(),
 }));
 
 vi.mock('@roomote/types', () => ({
@@ -95,6 +97,7 @@ vi.mock('@roomote/types', () => ({
   getMcpIntegrationOauthEndpoints: getMcpIntegrationOauthEndpointsMock,
   isDeploymentScopedMcpIntegration: isDeploymentScopedMcpIntegrationMock,
   isSelfServeMcpIntegration: isSelfServeMcpIntegrationMock,
+  isCustomMcpConnectionId: (mcpId: string) => mcpId.startsWith('custom:'),
 }));
 
 import { LinearReplayIdentityMismatchError } from '@/lib/server/mcp-linear';
@@ -193,7 +196,9 @@ describe('GET /api/mcp-oauth/callback', () => {
     expect(response.headers.get('location')).toBe(
       'https://customer.example/settings?mcp=error&reason=callback_failed',
     );
-    expect(consumeOAuthStateMock).not.toHaveBeenCalled();
+    // The kill switch now applies per connection kind (custom servers have
+    // their own flag), so the one-time state is consumed during lookup; the
+    // flow must still stop before any token exchange.
     expect(exchangeCodeForTokensMock).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/app/api/mcp-oauth/callback/route.ts
+++ b/apps/web/src/app/api/mcp-oauth/callback/route.ts
@@ -11,6 +11,7 @@ import {
   getMcpIntegration,
   getMcpIntegrationDefaultDisabledTools,
   getMcpIntegrationOauthEndpoints,
+  isCustomMcpConnectionId,
   isDeploymentScopedMcpIntegration,
   isSelfServeMcpIntegration,
 } from '@roomote/types';
@@ -21,8 +22,11 @@ import {
   storeTokens,
   getClientInformation,
   updateAuthStatus,
+  resolveCustomMcpAuthTarget,
+  ensureCustomMcpServerMetadata,
 } from '@roomote/sdk/server';
 import { authorize } from '@/lib/server';
+import { isCustomMcpDisabled } from '@/lib/server/env';
 import { bootstrapWebRuntimeEnv } from '@/lib/server/bootstrap-runtime-env';
 import { getPublicAppUrl } from '@/lib/server/get-public-app-url';
 import { logger } from '@/lib/server/logger';
@@ -167,9 +171,9 @@ export async function GET(request: NextRequest) {
   const redirectToResult = (result: McpOAuthResult) =>
     redirectWithMcpResult(webUrl, redirectPath, result, state);
 
-  if (webEnv.R_CURATED_INTEGRATIONS_DISABLED === true) {
-    return redirectToResult({ status: 'error', reason: 'callback_failed' });
-  }
+  // Kill-switch checks happen after the connection lookup: catalog
+  // connections are gated by the curated flag, custom-server connections by
+  // their own flag.
 
   // Handle OAuth errors
   if (error) {
@@ -282,19 +286,38 @@ export async function GET(request: NextRequest) {
     integrationId = connection.mcpId;
     connectionRole = connection.connectionRole;
 
-    const integration = getMcpIntegration(connection.mcpId);
-    if (!integration) {
-      return redirectToResult({ status: 'error', reason: 'not_found' });
+    const customTarget = isCustomMcpConnectionId(connection.mcpId)
+      ? await resolveCustomMcpAuthTarget(connection.mcpId)
+      : null;
+    const integration = customTarget
+      ? null
+      : getMcpIntegration(connection.mcpId);
+
+    if (customTarget) {
+      if (isCustomMcpDisabled(webEnv.R_CUSTOM_MCP_DISABLED)) {
+        return redirectToResult({ status: 'error', reason: 'callback_failed' });
+      }
+    } else {
+      if (webEnv.R_CURATED_INTEGRATIONS_DISABLED === true) {
+        return redirectToResult({ status: 'error', reason: 'callback_failed' });
+      }
+
+      if (
+        !integration ||
+        !isSelfServeMcpIntegration(integration) ||
+        !integration.url
+      ) {
+        return redirectToResult({ status: 'error', reason: 'not_found' });
+      }
     }
 
-    if (!isSelfServeMcpIntegration(integration) || !integration.url) {
-      return redirectToResult({ status: 'error', reason: 'not_found' });
-    }
-
-    const requiresOrgAdmin = isDeploymentScopedMcpIntegration(
-      integration,
-      connection.connectionRole,
-    );
+    // Custom-server connections are deployment-scoped by construction.
+    const requiresOrgAdmin = customTarget
+      ? true
+      : isDeploymentScopedMcpIntegration(
+          integration!,
+          connection.connectionRole,
+        );
     const isAdmin = authResult.isAdmin;
 
     if (
@@ -311,9 +334,10 @@ export async function GET(request: NextRequest) {
     }
 
     failureStage = 'provider_discovery';
-    const tokenEndpoint =
-      getMcpIntegrationOauthEndpoints(integration)?.tokenEndpoint ??
-      (await discoverOAuthEndpoints(integration.url)).token_endpoint;
+    const tokenEndpoint = customTarget
+      ? (await ensureCustomMcpServerMetadata(customTarget)).token_endpoint
+      : (getMcpIntegrationOauthEndpoints(integration!)?.tokenEndpoint ??
+        (await discoverOAuthEndpoints(integration!.url!)).token_endpoint);
     const redirectUri = new URL(CALLBACK_PATH, webUrl).toString();
 
     failureStage = 'token_exchange';
@@ -323,9 +347,10 @@ export async function GET(request: NextRequest) {
       oauthState.codeVerifier,
       clientInfo,
       redirectUri,
+      customTarget?.oauthOptions,
     );
 
-    if (integration.id === 'linear') {
+    if (integration?.id === 'linear') {
       failureStage = 'linear_metadata';
       await hydrateLinearMcpConnectionAfterOauth({
         connection,
@@ -338,7 +363,9 @@ export async function GET(request: NextRequest) {
       await storeTokens(resolvedConnectionId, tokens);
     }
 
-    if (requiresOrgAdmin) {
+    // Custom servers carry their own enablement on the server row; only
+    // catalog integrations write deploymentMcpEnablements.
+    if (requiresOrgAdmin && integration) {
       failureStage = 'deployment_enablement';
       const defaultDisabledTools =
         getMcpIntegrationDefaultDisabledTools(integration);

--- a/apps/web/src/app/api/mcp-oauth/callback/route.ts
+++ b/apps/web/src/app/api/mcp-oauth/callback/route.ts
@@ -26,7 +26,6 @@ import {
   ensureCustomMcpServerMetadata,
 } from '@roomote/sdk/server';
 import { authorize } from '@/lib/server';
-import { isCustomMcpDisabled } from '@/lib/server/env';
 import { bootstrapWebRuntimeEnv } from '@/lib/server/bootstrap-runtime-env';
 import { getPublicAppUrl } from '@/lib/server/get-public-app-url';
 import { logger } from '@/lib/server/logger';
@@ -294,7 +293,7 @@ export async function GET(request: NextRequest) {
       : getMcpIntegration(connection.mcpId);
 
     if (customTarget) {
-      if (isCustomMcpDisabled(webEnv.R_CUSTOM_MCP_DISABLED)) {
+      if (webEnv.R_CUSTOM_MCP_DISABLED === true) {
         return redirectToResult({ status: 'error', reason: 'callback_failed' });
       }
     } else {
@@ -341,14 +340,24 @@ export async function GET(request: NextRequest) {
     const redirectUri = new URL(CALLBACK_PATH, webUrl).toString();
 
     failureStage = 'token_exchange';
-    const tokens = await exchangeCodeForTokens(
-      tokenEndpoint,
-      code,
-      oauthState.codeVerifier,
-      clientInfo,
-      redirectUri,
-      customTarget?.oauthOptions,
-    );
+    // Catalog exchanges keep their historical call shape; custom targets add
+    // the guarded fetch + resource indicator options.
+    const tokens = customTarget
+      ? await exchangeCodeForTokens(
+          tokenEndpoint,
+          code,
+          oauthState.codeVerifier,
+          clientInfo,
+          redirectUri,
+          customTarget.oauthOptions,
+        )
+      : await exchangeCodeForTokens(
+          tokenEndpoint,
+          code,
+          oauthState.codeVerifier,
+          clientInfo,
+          redirectUri,
+        );
 
     if (integration?.id === 'linear') {
       failureStage = 'linear_metadata';

--- a/apps/web/src/app/api/mcp-oauth/initiate/[connectionId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/mcp-oauth/initiate/[connectionId]/__tests__/route.test.ts
@@ -83,6 +83,8 @@ vi.mock('@roomote/sdk/server', () => ({
   storeOAuthStateWithId: storeOAuthStateWithIdMock,
   storeClientInformation: storeClientInformationMock,
   getClientInformation: getClientInformationMock,
+  resolveCustomMcpAuthTarget: vi.fn(async () => null),
+  ensureCustomMcpServerMetadata: vi.fn(),
 }));
 
 vi.mock('@roomote/types', () => ({
@@ -96,6 +98,7 @@ vi.mock('@roomote/types', () => ({
   getMcpIntegration: getMcpIntegrationMock,
   isDeploymentScopedMcpIntegration: isDeploymentScopedMcpIntegrationMock,
   isSelfServeMcpIntegration: isSelfServeMcpIntegrationMock,
+  isCustomMcpConnectionId: (mcpId: string) => mcpId.startsWith('custom:'),
   PRODUCT_NAME: 'Roomote',
 }));
 
@@ -181,7 +184,7 @@ describe('GET /api/mcp-oauth/initiate/[connectionId]', () => {
     });
   });
 
-  it('rejects OAuth before authentication when integrations are disabled', async () => {
+  it('rejects catalog OAuth when integrations are disabled', async () => {
     bootstrapWebRuntimeEnvMock.mockResolvedValue({
       R_APP_URL: 'http://localhost:13000',
       R_PUBLIC_URL: 'https://customer.example',
@@ -195,8 +198,11 @@ describe('GET /api/mcp-oauth/initiate/[connectionId]', () => {
     expect(response.headers.get('location')).toBe(
       'https://customer.example/settings?mcp=error&reason=disabled',
     );
-    expect(authorizeMock).not.toHaveBeenCalled();
-    expect(mcpConnectionsFindFirstMock).not.toHaveBeenCalled();
+    // The kill switch now applies per connection kind (custom servers have
+    // their own flag), so it is evaluated after the connection lookup; no
+    // OAuth work may happen regardless.
+    expect(registerOAuthClientMock).not.toHaveBeenCalled();
+    expect(storeOAuthStateWithIdMock).not.toHaveBeenCalled();
   });
 
   it('uses the Linear API OAuth flow instead of Linear MCP OAuth', async () => {

--- a/apps/web/src/app/api/mcp-oauth/initiate/[connectionId]/route.ts
+++ b/apps/web/src/app/api/mcp-oauth/initiate/[connectionId]/route.ts
@@ -12,13 +12,18 @@ import {
   storeOAuthStateWithId,
   storeClientInformation,
   getClientInformation,
+  resolveCustomMcpAuthTarget,
+  ensureCustomMcpServerMetadata,
 } from '@roomote/sdk/server';
+import { isCustomMcpDisabled } from '@/lib/server/env';
 import type {
   OAuthClientMetadata,
   OAuthClientInformation,
+  OAuthProtectedResourceMetadata,
   OAuthServerMetadata,
 } from '@roomote/types';
 import {
+  isCustomMcpConnectionId,
   type McpConnectionRole,
   getMcpIntegrationAuthorizationParameters,
   getMcpIntegrationOauthEndpoints,
@@ -162,11 +167,9 @@ export async function GET(
     DEFAULT_REDIRECT_PATH;
   const replayToken = requestUrl.searchParams.get('replayToken');
 
-  if (webEnv.R_CURATED_INTEGRATIONS_DISABLED === true) {
-    return NextResponse.redirect(
-      withMcpQuery(webUrl, redirectPath, 'error', 'disabled'),
-    );
-  }
+  // Kill-switch checks happen after the connection lookup: catalog
+  // connections are gated by the curated flag, custom-server connections by
+  // their own flag.
 
   const authResult = await authorize();
   if (!authResult.success) {
@@ -187,23 +190,44 @@ export async function GET(
       );
     }
 
-    const integration = getMcpIntegration(connection.mcpId);
-    if (!integration) {
-      return NextResponse.redirect(
-        withMcpQuery(webUrl, redirectPath, 'error', 'not_found'),
-      );
+    const customTarget = isCustomMcpConnectionId(connection.mcpId)
+      ? await resolveCustomMcpAuthTarget(connection.mcpId)
+      : null;
+    const integration = customTarget
+      ? null
+      : getMcpIntegration(connection.mcpId);
+
+    if (customTarget) {
+      if (isCustomMcpDisabled(webEnv.R_CUSTOM_MCP_DISABLED)) {
+        return NextResponse.redirect(
+          withMcpQuery(webUrl, redirectPath, 'error', 'disabled'),
+        );
+      }
+    } else {
+      if (webEnv.R_CURATED_INTEGRATIONS_DISABLED === true) {
+        return NextResponse.redirect(
+          withMcpQuery(webUrl, redirectPath, 'error', 'disabled'),
+        );
+      }
+
+      if (
+        !integration ||
+        !isSelfServeMcpIntegration(integration) ||
+        !integration.url
+      ) {
+        return NextResponse.redirect(
+          withMcpQuery(webUrl, redirectPath, 'error', 'not_found'),
+        );
+      }
     }
 
-    if (!isSelfServeMcpIntegration(integration) || !integration.url) {
-      return NextResponse.redirect(
-        withMcpQuery(webUrl, redirectPath, 'error', 'not_found'),
-      );
-    }
-
-    const requiresOrgAdmin = isDeploymentScopedMcpIntegration(
-      integration,
-      connection.connectionRole,
-    );
+    // Custom-server connections are deployment-scoped by construction.
+    const requiresOrgAdmin = customTarget
+      ? true
+      : isDeploymentScopedMcpIntegration(
+          integration!,
+          connection.connectionRole,
+        );
     const isAdmin = authResult.isAdmin;
 
     if (
@@ -215,23 +239,52 @@ export async function GET(
       );
     }
 
-    const serverMetadataOverride = getOAuthServerMetadataOverride(integration);
-    const [serverMetadata, protectedResourceMetadata] = serverMetadataOverride
-      ? [serverMetadataOverride, undefined]
-      : await Promise.all([
-          discoverOAuthEndpoints(integration.url),
-          discoverOAuthProtectedResourceMetadata(integration.url),
-        ]);
-    const redirectUri = new URL('/api/mcp-oauth/callback', webUrl).toString();
-    const requestedScope = getRequestedScope(
-      protectedResourceMetadata?.scopes_supported ??
-        serverMetadata.scopes_supported,
-      integration,
-      connection.connectionRole,
-    );
+    const serverUrl = customTarget?.url ?? integration!.url!;
 
-    const staticClientInfo =
-      await resolveDeploymentStaticOauthClientInformation(webEnv, integration);
+    let serverMetadata: OAuthServerMetadata;
+    let protectedResourceMetadata: OAuthProtectedResourceMetadata | undefined;
+
+    if (customTarget) {
+      // Discovery for operator URLs runs through the SSRF-guarded fetch,
+      // including hops the server itself supplies. The AS metadata is
+      // persisted on the server row and pinned for callback and refresh.
+      serverMetadata = await ensureCustomMcpServerMetadata(customTarget);
+      protectedResourceMetadata = await discoverOAuthProtectedResourceMetadata(
+        serverUrl,
+        customTarget.oauthOptions,
+      );
+    } else {
+      const serverMetadataOverride = getOAuthServerMetadataOverride(
+        integration!,
+      );
+      [serverMetadata, protectedResourceMetadata] = serverMetadataOverride
+        ? [serverMetadataOverride, undefined]
+        : await Promise.all([
+            discoverOAuthEndpoints(serverUrl),
+            discoverOAuthProtectedResourceMetadata(serverUrl),
+          ]);
+    }
+
+    const redirectUri = new URL('/api/mcp-oauth/callback', webUrl).toString();
+    const requestedScope = customTarget
+      ? // MCP auth spec: request the scopes the protected resource
+        // advertises; otherwise let the server apply its defaults.
+        protectedResourceMetadata?.scopes_supported?.join(' ') || undefined
+      : getRequestedScope(
+          protectedResourceMetadata?.scopes_supported ??
+            serverMetadata.scopes_supported,
+          integration!,
+          connection.connectionRole,
+        );
+
+    // Manual client credentials on the custom-server row are the analogue of
+    // deployment-static catalog credentials: authoritative when present.
+    const staticClientInfo = customTarget
+      ? customTarget.manualClient
+      : await resolveDeploymentStaticOauthClientInformation(
+          webEnv,
+          integration!,
+        );
     let clientInfo: OAuthClientInformation | undefined;
 
     if (staticClientInfo) {
@@ -251,7 +304,7 @@ export async function GET(
       const tokenEndpointAuthMethod =
         getPreferredTokenEndpointAuthMethod(serverMetadata);
       const clientMetadata: OAuthClientMetadata = {
-        client_name: `${PRODUCT_NAME} - ${integration.name}`,
+        client_name: `${PRODUCT_NAME} - ${customTarget?.name ?? integration!.name}`,
         redirect_uris: [redirectUri],
         grant_types: ['authorization_code', 'refresh_token'],
         response_types: ['code'],
@@ -262,6 +315,7 @@ export async function GET(
       const registeredClient = await registerOAuthClient(
         serverMetadata.registration_endpoint,
         clientMetadata,
+        customTarget?.oauthOptions,
       );
 
       const storedClientInfo: OAuthClientInformation = {
@@ -302,11 +356,20 @@ export async function GET(
     if (requestedScope) {
       authUrl.searchParams.set('scope', requestedScope);
     }
-    for (const parameter of getMcpIntegrationAuthorizationParameters(
-      integration,
-      connection.connectionRole,
-    )) {
-      authUrl.searchParams.set(parameter.name, parameter.value);
+
+    if (customTarget?.oauthOptions.resource) {
+      // RFC 8707 resource indicator, required of MCP clients by the current
+      // authorization spec; per-server opt-out for servers that reject it.
+      authUrl.searchParams.set('resource', customTarget.oauthOptions.resource);
+    }
+
+    if (integration) {
+      for (const parameter of getMcpIntegrationAuthorizationParameters(
+        integration,
+        connection.connectionRole,
+      )) {
+        authUrl.searchParams.set(parameter.name, parameter.value);
+      }
     }
 
     return NextResponse.redirect(authUrl.toString());

--- a/apps/web/src/app/api/mcp-oauth/initiate/[connectionId]/route.ts
+++ b/apps/web/src/app/api/mcp-oauth/initiate/[connectionId]/route.ts
@@ -15,7 +15,6 @@ import {
   resolveCustomMcpAuthTarget,
   ensureCustomMcpServerMetadata,
 } from '@roomote/sdk/server';
-import { isCustomMcpDisabled } from '@/lib/server/env';
 import type {
   OAuthClientMetadata,
   OAuthClientInformation,
@@ -198,7 +197,7 @@ export async function GET(
       : getMcpIntegration(connection.mcpId);
 
     if (customTarget) {
-      if (isCustomMcpDisabled(webEnv.R_CUSTOM_MCP_DISABLED)) {
+      if (webEnv.R_CUSTOM_MCP_DISABLED === true) {
         return NextResponse.redirect(
           withMcpQuery(webUrl, redirectPath, 'error', 'disabled'),
         );
@@ -312,11 +311,18 @@ export async function GET(
         ...(requestedScope ? { scope: requestedScope } : {}),
       };
 
-      const registeredClient = await registerOAuthClient(
-        serverMetadata.registration_endpoint,
-        clientMetadata,
-        customTarget?.oauthOptions,
-      );
+      // Catalog registrations keep their historical call shape; custom
+      // targets add the guarded fetch options.
+      const registeredClient = customTarget
+        ? await registerOAuthClient(
+            serverMetadata.registration_endpoint,
+            clientMetadata,
+            customTarget.oauthOptions,
+          )
+        : await registerOAuthClient(
+            serverMetadata.registration_endpoint,
+            clientMetadata,
+          );
 
       const storedClientInfo: OAuthClientInformation = {
         ...registeredClient,

--- a/apps/web/src/components/settings/CustomMcpServers.client.test.tsx
+++ b/apps/web/src/components/settings/CustomMcpServers.client.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 type ListedServer = {
@@ -135,11 +135,14 @@ function buildServer(overrides: Partial<ListedServer> = {}): ListedServer {
  * items, so the assertions below mirror what the Integrations grids show.
  */
 function Harness() {
-  const { isEnabled, items, dialogs } = useCustomMcpServers();
+  const { isEnabled, items, openAddDialog, dialogs } = useCustomMcpServers();
 
   return (
     <div>
       <span data-testid="enabled">{String(isEnabled)}</span>
+      <button type="button" data-testid="open-add" onClick={openAddDialog}>
+        Add
+      </button>
       <ul>
         {items.map((item: IntegrationItem) => (
           <li key={item.id} data-testid="item">
@@ -275,5 +278,85 @@ describe('useCustomMcpServers', () => {
     expect(await screen.findByTestId('item-enabled')).toHaveTextContent(
       'false',
     );
+  });
+
+  it('prefills the add dialog from a pasted JSON snippet', async () => {
+    renderHarness();
+
+    fireEvent.click(await screen.findByTestId('open-add'));
+    fireEvent.click(screen.getByRole('button', { name: 'Import from JSON' }));
+    fireEvent.change(screen.getByLabelText('Paste a JSON config'), {
+      target: {
+        value: JSON.stringify({
+          mcpServers: {
+            'example-tools': {
+              command: 'npx',
+              args: ['-y', '@example/mcp-server'],
+              env: { EXAMPLE_TOKEN: 'tok' },
+            },
+          },
+        }),
+      },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Fill form from JSON' }),
+    );
+
+    expect(screen.getByPlaceholderText('e.g. internal-tools')).toHaveValue(
+      'example-tools',
+    );
+    expect(screen.getByPlaceholderText('e.g. npx')).toHaveValue('npx');
+    expect(screen.getByPlaceholderText(/@example\/mcp-server/)).toHaveValue(
+      '-y\n@example/mcp-server',
+    );
+    expect(screen.getByPlaceholderText('e.g. EXAMPLE_TOKEN')).toHaveValue(
+      'EXAMPLE_TOKEN',
+    );
+  });
+
+  it('converts a pasted mcp-remote launcher into a remote server', async () => {
+    renderHarness();
+
+    fireEvent.click(await screen.findByTestId('open-add'));
+    fireEvent.click(screen.getByRole('button', { name: 'Import from JSON' }));
+    fireEvent.change(screen.getByLabelText('Paste a JSON config'), {
+      target: {
+        value: JSON.stringify({
+          mcpServers: {
+            notion: {
+              command: 'npx',
+              args: ['-y', 'mcp-remote', 'https://mcp.notion.com/mcp'],
+            },
+          },
+        }),
+      },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Fill form from JSON' }),
+    );
+
+    expect(
+      screen.getByPlaceholderText('https://mcp.example.com/mcp'),
+    ).toHaveValue('https://mcp.notion.com/mcp');
+    expect(
+      screen.getByText(/Converted an mcp-remote launcher/),
+    ).toBeInTheDocument();
+  });
+
+  it('reports a parse error without touching the form', async () => {
+    renderHarness();
+
+    fireEvent.click(await screen.findByTestId('open-add'));
+    fireEvent.click(screen.getByRole('button', { name: 'Import from JSON' }));
+    fireEvent.change(screen.getByLabelText('Paste a JSON config'), {
+      target: { value: 'not json' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Fill form from JSON' }),
+    );
+
+    expect(
+      screen.getByText('The pasted text is not valid JSON.'),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/settings/CustomMcpServers.client.test.tsx
+++ b/apps/web/src/components/settings/CustomMcpServers.client.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 type ListedServer = {
@@ -107,7 +107,8 @@ vi.mock('@/trpc/client', () => ({
   }),
 }));
 
-import { CustomMcpServers } from './CustomMcpServers';
+import type { IntegrationItem } from './integration-card';
+import { useCustomMcpServers } from './CustomMcpServers';
 
 function buildServer(overrides: Partial<ListedServer> = {}): ListedServer {
   return {
@@ -129,54 +130,94 @@ function buildServer(overrides: Partial<ListedServer> = {}): ListedServer {
   };
 }
 
-function renderComponent() {
+/**
+ * Renders what the hook produces: custom servers become plain integration
+ * items, so the assertions below mirror what the Integrations grids show.
+ */
+function Harness() {
+  const { isEnabled, items, dialogs } = useCustomMcpServers();
+
+  return (
+    <div>
+      <span data-testid="enabled">{String(isEnabled)}</span>
+      <ul>
+        {items.map((item: IntegrationItem) => (
+          <li key={item.id} data-testid="item">
+            <span data-testid="name">{item.name}</span>
+            <span data-testid="description">{item.description}</span>
+            <span data-testid="badge">{item.badge}</span>
+            <span data-testid="status">{item.status}</span>
+            <span data-testid="secondary">{item.secondaryAction?.label}</span>
+            <span data-testid="utility">{item.utilityAction?.label}</span>
+            <span data-testid="configured">{String(item.configured)}</span>
+            <span data-testid="item-enabled">{String(item.enabled)}</span>
+          </li>
+        ))}
+      </ul>
+      {dialogs}
+    </div>
+  );
+}
+
+function renderHarness() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
 
   return render(
     <QueryClientProvider client={queryClient}>
-      <CustomMcpServers />
+      <Harness />
     </QueryClientProvider>,
   );
 }
 
-describe('CustomMcpServers', () => {
+describe('useCustomMcpServers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     state.availability = { enabled: true };
     state.servers = [];
   });
 
-  it('renders the empty state', async () => {
-    renderComponent();
-
-    expect(
-      await screen.findByText('No custom MCP servers configured yet.'),
-    ).toBeInTheDocument();
-  });
-
-  it('renders nothing when the operator kill switch is set', async () => {
-    state.availability = { enabled: false };
-
-    renderComponent();
+  it('produces no items when there are no servers', async () => {
+    renderHarness();
 
     await waitFor(() => {
-      expect(screen.queryByText('Custom MCP Servers')).not.toBeInTheDocument();
+      expect(screen.getByTestId('enabled')).toHaveTextContent('true');
     });
+    expect(screen.queryAllByTestId('item')).toHaveLength(0);
   });
 
-  it('lists servers with masked header badges and never shows values', async () => {
+  it('reports disabled when the operator kill switch is set', async () => {
+    state.availability = { enabled: false };
     state.servers = [buildServer()];
 
-    renderComponent();
+    renderHarness();
 
-    expect(await screen.findByText('internal-tools')).toBeInTheDocument();
-    expect(screen.getByText('https://mcp.example.com/mcp')).toBeInTheDocument();
-    expect(screen.getByText(/1 header/)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('enabled')).toHaveTextContent('false');
+    });
+    expect(screen.queryAllByTestId('item')).toHaveLength(0);
   });
 
-  it('shows a Connect button for unauthenticated oauth servers', async () => {
+  it('renders a remote server as a Custom-badged item without leaking secrets', async () => {
+    state.servers = [buildServer()];
+
+    renderHarness();
+
+    expect(await screen.findByTestId('name')).toHaveTextContent(
+      'internal-tools',
+    );
+    expect(screen.getByTestId('badge')).toHaveTextContent('Custom');
+    expect(screen.getByTestId('description')).toHaveTextContent(
+      'https://mcp.example.com/mcp',
+    );
+    // Disabled custom servers group with "Configured", never "Available".
+    expect(screen.getByTestId('configured')).toHaveTextContent('true');
+    expect(screen.getByTestId('utility')).toHaveTextContent('Manage tools');
+    expect(screen.getByTestId('secondary')).toHaveTextContent('Edit');
+  });
+
+  it('offers Connect and a status for unauthenticated oauth servers', async () => {
     state.servers = [
       buildServer({
         authType: 'oauth',
@@ -185,35 +226,54 @@ describe('CustomMcpServers', () => {
       }),
     ];
 
-    renderComponent();
+    renderHarness();
 
-    expect(await screen.findByText('Connect')).toBeInTheDocument();
-    expect(screen.getByText(/not connected/)).toBeInTheDocument();
+    expect(await screen.findByTestId('secondary')).toHaveTextContent('Connect');
+    expect(screen.getByTestId('status')).toHaveTextContent('Not connected yet');
   });
 
-  it('shows a reconnect badge when refresh definitively failed', async () => {
+  it('surfaces a reconnect prompt when a refresh was rejected', async () => {
+    state.servers = [
+      buildServer({ authType: 'oauth', headerNames: [], authStatus: 'error' }),
+    ];
+
+    renderHarness();
+
+    expect(await screen.findByTestId('status')).toHaveTextContent(
+      'needs to be reconnected',
+    );
+  });
+
+  it('describes stdio servers by their command and omits tool management', async () => {
     state.servers = [
       buildServer({
-        authType: 'oauth',
+        transport: 'stdio',
+        url: null,
+        authType: 'none',
         headerNames: [],
-        authStatus: 'error',
+        stdioCommand: 'npx',
+        stdioArgs: ['-y', '@example/server'],
+        stdioEnvNames: ['EXAMPLE_TOKEN'],
       }),
     ];
 
-    renderComponent();
+    renderHarness();
 
-    expect(await screen.findByText(/reconnect needed/)).toBeInTheDocument();
+    expect(await screen.findByTestId('description')).toHaveTextContent(
+      'npx -y @example/server',
+    );
+    // Local servers bypass the proxy, so there is nothing to enforce tool
+    // filtering and no Manage tools affordance.
+    expect(screen.getByTestId('utility')).toBeEmptyDOMElement();
   });
 
-  it('opens the add dialog', async () => {
-    renderComponent();
+  it('marks disabled servers so they leave the Connected group', async () => {
+    state.servers = [buildServer({ enabled: false })];
 
-    fireEvent.click(await screen.findByRole('button', { name: /add/i }));
+    renderHarness();
 
-    expect(
-      await screen.findByText('Add custom MCP server'),
-    ).toBeInTheDocument();
-    expect(screen.getByText('Remote (HTTP)')).toBeInTheDocument();
-    expect(screen.getByText('Local (stdio)')).toBeInTheDocument();
+    expect(await screen.findByTestId('item-enabled')).toHaveTextContent(
+      'false',
+    );
   });
 });

--- a/apps/web/src/components/settings/CustomMcpServers.client.test.tsx
+++ b/apps/web/src/components/settings/CustomMcpServers.client.test.tsx
@@ -1,0 +1,219 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+type ListedServer = {
+  id: string;
+  name: string;
+  transport: 'remote' | 'stdio';
+  url: string | null;
+  authType: 'none' | 'static_headers' | 'oauth';
+  headerNames: string[];
+  stdioCommand: string | null;
+  stdioArgs: string[];
+  stdioEnvNames: string[];
+  disabledTools: string[];
+  hasManualClient: boolean;
+  oauthResourceIndicatorDisabled: boolean;
+  authStatus: 'pending' | 'authenticated' | 'error' | null;
+  enabled: boolean;
+};
+
+const { state, createMock, deleteMock, setEnabledMock } = vi.hoisted(() => ({
+  state: {
+    availability: { enabled: true },
+    servers: [] as ListedServer[],
+    tools: [] as {
+      name: string;
+      description: string | null;
+      enabled: boolean;
+    }[],
+  },
+  createMock: vi.fn(async () => ({ id: 'new-server' })),
+  deleteMock: vi.fn(async () => ({ deleted: true })),
+  setEnabledMock: vi.fn(async () => ({ enabled: false })),
+}));
+
+vi.mock('@/trpc/client', () => ({
+  useTRPC: () => ({
+    customMcpServers: {
+      availability: {
+        queryKey: () => ['customMcpServers', 'availability'],
+        queryOptions: () => ({
+          queryKey: ['customMcpServers', 'availability'],
+          queryFn: async () => state.availability,
+        }),
+      },
+      list: {
+        queryKey: () => ['customMcpServers', 'list'],
+        queryOptions: () => ({
+          queryKey: ['customMcpServers', 'list'],
+          queryFn: async () => state.servers,
+        }),
+      },
+      listTools: {
+        queryKey: () => ['customMcpServers', 'listTools'],
+        queryOptions: (
+          input: { id: string },
+          options: Record<string, unknown> = {},
+        ) => ({
+          queryKey: ['customMcpServers', 'listTools', input.id],
+          queryFn: async () => ({ tools: state.tools }),
+          ...options,
+        }),
+      },
+      create: {
+        mutationOptions: (options = {}) => ({
+          mutationFn: createMock,
+          ...options,
+        }),
+      },
+      update: {
+        mutationOptions: (options = {}) => ({
+          mutationFn: vi.fn(),
+          ...options,
+        }),
+      },
+      delete: {
+        mutationOptions: (options = {}) => ({
+          mutationFn: deleteMock,
+          ...options,
+        }),
+      },
+      setEnabled: {
+        mutationOptions: (options = {}) => ({
+          mutationFn: setEnabledMock,
+          ...options,
+        }),
+      },
+      setDisabledTools: {
+        mutationOptions: (options = {}) => ({
+          mutationFn: vi.fn(),
+          ...options,
+        }),
+      },
+      connect: {
+        mutationOptions: (options = {}) => ({
+          mutationFn: vi.fn(async () => '/api/mcp-oauth/initiate/conn-1'),
+          ...options,
+        }),
+      },
+      disconnect: {
+        mutationOptions: (options = {}) => ({
+          mutationFn: vi.fn(),
+          ...options,
+        }),
+      },
+    },
+  }),
+}));
+
+import { CustomMcpServers } from './CustomMcpServers';
+
+function buildServer(overrides: Partial<ListedServer> = {}): ListedServer {
+  return {
+    id: '4c72c9dd-3f5e-4d3e-9f7a-2c1b8a6e5d40',
+    name: 'internal-tools',
+    transport: 'remote',
+    url: 'https://mcp.example.com/mcp',
+    authType: 'static_headers',
+    headerNames: ['x-api-key'],
+    stdioCommand: null,
+    stdioArgs: [],
+    stdioEnvNames: [],
+    disabledTools: [],
+    hasManualClient: false,
+    oauthResourceIndicatorDisabled: false,
+    authStatus: null,
+    enabled: true,
+    ...overrides,
+  };
+}
+
+function renderComponent() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <CustomMcpServers />
+    </QueryClientProvider>,
+  );
+}
+
+describe('CustomMcpServers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.availability = { enabled: true };
+    state.servers = [];
+  });
+
+  it('renders the empty state', async () => {
+    renderComponent();
+
+    expect(
+      await screen.findByText('No custom MCP servers configured yet.'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders nothing when the operator kill switch is set', async () => {
+    state.availability = { enabled: false };
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.queryByText('Custom MCP Servers')).not.toBeInTheDocument();
+    });
+  });
+
+  it('lists servers with masked header badges and never shows values', async () => {
+    state.servers = [buildServer()];
+
+    renderComponent();
+
+    expect(await screen.findByText('internal-tools')).toBeInTheDocument();
+    expect(screen.getByText('https://mcp.example.com/mcp')).toBeInTheDocument();
+    expect(screen.getByText(/1 header/)).toBeInTheDocument();
+  });
+
+  it('shows a Connect button for unauthenticated oauth servers', async () => {
+    state.servers = [
+      buildServer({
+        authType: 'oauth',
+        headerNames: [],
+        authStatus: 'pending',
+      }),
+    ];
+
+    renderComponent();
+
+    expect(await screen.findByText('Connect')).toBeInTheDocument();
+    expect(screen.getByText(/not connected/)).toBeInTheDocument();
+  });
+
+  it('shows a reconnect badge when refresh definitively failed', async () => {
+    state.servers = [
+      buildServer({
+        authType: 'oauth',
+        headerNames: [],
+        authStatus: 'error',
+      }),
+    ];
+
+    renderComponent();
+
+    expect(await screen.findByText(/reconnect needed/)).toBeInTheDocument();
+  });
+
+  it('opens the add dialog', async () => {
+    renderComponent();
+
+    fireEvent.click(await screen.findByRole('button', { name: /add/i }));
+
+    expect(
+      await screen.findByText('Add custom MCP server'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Remote (HTTP)')).toBeInTheDocument();
+    expect(screen.getByText('Local (stdio)')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/settings/CustomMcpServers.tsx
+++ b/apps/web/src/components/settings/CustomMcpServers.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { ReactNode } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
@@ -15,7 +16,6 @@ import {
   DialogTitle,
   Input,
   Label,
-  Lock,
   Pencil,
   Plus,
   RadioGroup,
@@ -28,8 +28,9 @@ import {
   X,
 } from '@/components/system';
 import { Loading } from '@/components/layout';
-import { Section } from '@/components/settings';
 import type { CustomMcpServerListEntry } from '@/trpc/commands/custom-mcp-servers';
+
+import type { IntegrationItem } from './integration-card';
 import { useTRPC } from '@/trpc/client';
 
 type Transport = 'remote' | 'stdio';
@@ -619,14 +620,30 @@ function CustomToolManagementDialog({
   );
 }
 
-export function CustomMcpServers() {
+/**
+ * Custom MCP servers rendered as regular integration cards.
+ *
+ * They live in the same Connected/Configured grids as the built-in catalog
+ * (a "Custom" badge is the only visual difference), so this exposes items
+ * plus the dialogs they drive rather than owning a section of its own.
+ */
+export function useCustomMcpServers(): {
+  isEnabled: boolean;
+  items: IntegrationItem[];
+  openAddDialog: () => void;
+  dialogs: ReactNode;
+} {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
 
   const availability = useQuery(
     trpc.customMcpServers.availability.queryOptions(),
   );
-  const serversQuery = useQuery(trpc.customMcpServers.list.queryOptions());
+  const isEnabled = availability.data?.enabled !== false;
+
+  const serversQuery = useQuery(
+    trpc.customMcpServers.list.queryOptions(undefined, { enabled: isEnabled }),
+  );
 
   const deleteServer = useMutation(
     trpc.customMcpServers.delete.mutationOptions(),
@@ -645,169 +662,117 @@ export function CustomMcpServers() {
       queryKey: trpc.customMcpServers.list.queryKey(),
     });
 
-  if (availability.data?.enabled === false) {
-    return null;
-  }
+  const servers = useMemo(
+    () => (serversQuery.data ?? []) as ListedServer[],
+    [serversQuery.data],
+  );
 
-  const servers = (serversQuery.data ?? []) as ListedServer[];
-
-  const authSummary = (server: ListedServer) => {
-    if (server.transport === 'stdio') {
-      return <Badge variant="outline">stdio</Badge>;
+  const items = useMemo<IntegrationItem[]>(() => {
+    if (!isEnabled) {
+      return [];
     }
 
-    if (server.authType === 'static_headers') {
-      return (
-        <Badge variant="outline">
-          <Lock className="size-2 text-muted-foreground" />
-          {server.headerNames.length} header
-          {server.headerNames.length === 1 ? '' : 's'}
-        </Badge>
-      );
-    }
+    return servers.map((server) => {
+      const needsConnection =
+        server.transport === 'remote' &&
+        server.authType === 'oauth' &&
+        server.authStatus !== 'authenticated';
 
-    if (server.authType === 'oauth') {
-      if (server.authStatus === 'authenticated') {
-        return <Badge variant="outline">OAuth · connected</Badge>;
-      }
+      const description =
+        server.transport === 'remote'
+          ? (server.url ?? '')
+          : [server.stdioCommand, ...server.stdioArgs].join(' ');
 
-      return (
-        <Badge variant="destructive">
-          OAuth ·{' '}
-          {server.authStatus === 'error' ? 'reconnect needed' : 'not connected'}
-        </Badge>
-      );
-    }
+      return {
+        id: `custom-${server.id}`,
+        name: server.name,
+        description,
+        icon: <ServerCog className="size-5" />,
+        badge: (
+          <Badge variant="outline" className="shrink-0">
+            Custom
+          </Badge>
+        ),
+        enabled: server.enabled,
+        // Custom servers are always deployment-defined, so a disabled one
+        // belongs with "Configured" rather than the catalog's "Available".
+        configured: true,
+        isMcpBased: true,
+        isPending:
+          setEnabled.isPending && setEnabled.variables?.id === server.id,
+        actionLabel: server.enabled
+          ? `Disable ${server.name}`
+          : `Enable ${server.name}`,
+        onAction: async () => {
+          await setEnabled.mutateAsync({
+            id: server.id,
+            enabled: !server.enabled,
+          });
+          refresh();
+        },
+        status: needsConnection
+          ? server.authStatus === 'error'
+            ? 'This server needs to be reconnected before agents can use it.'
+            : 'Not connected yet.'
+          : undefined,
+        ...(server.transport === 'remote'
+          ? {
+              utilityAction: {
+                label: 'Manage tools',
+                ariaLabel: `Manage ${server.name} tools`,
+                onAction: () => setToolsServer(server),
+                isPending: false,
+                icon: <Wrench className="size-4" />,
+              },
+            }
+          : {}),
+        secondaryAction: needsConnection
+          ? {
+              label: 'Connect',
+              ariaLabel: `Connect ${server.name}`,
+              onAction: async () => {
+                const initiateUrl = await connect.mutateAsync({
+                  id: server.id,
+                  redirectTo: '/settings/integrations',
+                });
+                window.location.href = initiateUrl;
+              },
+              isPending: connect.isPending,
+            }
+          : {
+              label: 'Edit',
+              ariaLabel: `Edit ${server.name}`,
+              onAction: () => {
+                setEditingServer(server);
+                setFormOpen(true);
+              },
+              isPending: false,
+              icon: <Pencil className="size-4" />,
+            },
+        headerAction: {
+          label: 'Remove',
+          ariaLabel: `Remove ${server.name}`,
+          onAction: async () => {
+            if (
+              confirm(
+                `Delete custom MCP server '${server.name}'? Stored credentials are removed as well.`,
+              )
+            ) {
+              await deleteServer.mutateAsync({ id: server.id });
+              refresh();
+            }
+          },
+          isPending:
+            deleteServer.isPending && deleteServer.variables?.id === server.id,
+          icon: <Trash2 className="size-4" />,
+        },
+      } satisfies IntegrationItem;
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [servers, isEnabled, setEnabled, deleteServer, connect]);
 
-    return <Badge variant="outline">no auth</Badge>;
-  };
-
-  return (
+  const dialogs = (
     <>
-      <Section
-        icon={ServerCog}
-        title="Custom MCP Servers"
-        action={
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            onClick={() => {
-              setEditingServer(null);
-              setFormOpen(true);
-            }}
-          >
-            <Plus />
-            Add
-          </Button>
-        }
-      >
-        <p className="text-sm text-muted-foreground">
-          Connect MCP servers that are not in the catalog. Available to agents
-          in every task; an environment&apos;s own <code>mcpServers</code> entry
-          with the same name takes precedence in that environment.
-        </p>
-
-        {serversQuery.isPending ? (
-          <Skeleton className="h-16 w-full" />
-        ) : servers.length === 0 ? (
-          <p className="text-sm text-muted-foreground">
-            No custom MCP servers configured yet.
-          </p>
-        ) : (
-          <table className="w-full">
-            <tbody>
-              {servers.map((server) => (
-                <tr
-                  key={server.id}
-                  className="text-sm text-left border-b border-border last:border-none"
-                >
-                  <th className="font-mono py-2">{server.name}</th>
-                  <td className="text-muted-foreground font-mono text-xs max-w-64 truncate">
-                    {server.transport === 'remote'
-                      ? server.url
-                      : [server.stdioCommand, ...server.stdioArgs].join(' ')}
-                  </td>
-                  <td>{authSummary(server)}</td>
-                  <td className="text-right py-1">
-                    {server.transport === 'remote' &&
-                      server.authType === 'oauth' &&
-                      server.authStatus !== 'authenticated' && (
-                        <Button
-                          type="button"
-                          variant="secondary"
-                          size="sm"
-                          disabled={connect.isPending}
-                          onClick={async () => {
-                            const initiateUrl = await connect.mutateAsync({
-                              id: server.id,
-                              redirectTo: '/settings/integrations',
-                            });
-                            window.location.href = initiateUrl;
-                          }}
-                        >
-                          Connect
-                        </Button>
-                      )}
-                    {server.transport === 'remote' && (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        title="Manage tools"
-                        onClick={() => setToolsServer(server)}
-                      >
-                        <Wrench className="size-4" />
-                      </Button>
-                    )}
-                    <Switch
-                      checked={server.enabled}
-                      onCheckedChange={async (checked) => {
-                        await setEnabled.mutateAsync({
-                          id: server.id,
-                          enabled: checked,
-                        });
-                        refresh();
-                      }}
-                      className="mx-2 align-middle"
-                    />
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => {
-                        setEditingServer(server);
-                        setFormOpen(true);
-                      }}
-                    >
-                      <Pencil className="size-4" />
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      disabled={deleteServer.isPending}
-                      onClick={async () => {
-                        if (
-                          confirm(
-                            `Delete custom MCP server '${server.name}'? Stored credentials are removed as well.`,
-                          )
-                        ) {
-                          await deleteServer.mutateAsync({ id: server.id });
-                          refresh();
-                        }
-                      }}
-                    >
-                      <Trash2 className="size-4" />
-                    </Button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </Section>
-
       <ServerFormDialog
         open={formOpen}
         onOpenChange={setFormOpen}
@@ -817,7 +782,6 @@ export function CustomMcpServers() {
           refresh();
         }}
       />
-
       <CustomToolManagementDialog
         server={toolsServer}
         open={Boolean(toolsServer)}
@@ -830,4 +794,14 @@ export function CustomMcpServers() {
       />
     </>
   );
+
+  return {
+    isEnabled,
+    items,
+    openAddDialog: () => {
+      setEditingServer(null);
+      setFormOpen(true);
+    },
+    dialogs,
+  };
 }

--- a/apps/web/src/components/settings/CustomMcpServers.tsx
+++ b/apps/web/src/components/settings/CustomMcpServers.tsx
@@ -28,6 +28,10 @@ import {
   X,
 } from '@/components/system';
 import { Loading } from '@/components/layout';
+import {
+  parseCustomMcpServerJson,
+  type CustomMcpJsonImport,
+} from '@/lib/custom-mcp-json-import';
 import type { CustomMcpServerListEntry } from '@/trpc/commands/custom-mcp-servers';
 
 import type { IntegrationItem } from './integration-card';
@@ -79,6 +83,37 @@ function serverToFormValues(server: ListedServer): ServerFormValues {
     stdioCommand: server.stdioCommand ?? '',
     stdioArgs: server.stdioArgs.join('\n'),
     stdioEnv: server.stdioEnvNames.map((name) => ({ name, value: '' })),
+  };
+}
+
+/**
+ * Map a parsed JSON snippet onto the form. The import prefills fields rather
+ * than saving directly, so the admin reviews (and can finish naming) before
+ * submitting. A snippet without a usable name keeps whatever is typed.
+ */
+function importToFormValues(
+  parsed: CustomMcpJsonImport,
+  currentName: string,
+): ServerFormValues {
+  return {
+    ...EMPTY_FORM,
+    name: parsed.name ?? currentName,
+    transport: parsed.transport,
+    url: parsed.url ?? '',
+    authType:
+      parsed.transport === 'remote' && parsed.headers
+        ? 'static_headers'
+        : 'none',
+    headers: Object.entries(parsed.headers ?? {}).map(([name, value]) => ({
+      name,
+      value,
+    })),
+    stdioCommand: parsed.stdio?.command ?? '',
+    stdioArgs: (parsed.stdio?.args ?? []).join('\n'),
+    stdioEnv: Object.entries(parsed.stdio?.env ?? {}).map(([name, value]) => ({
+      name,
+      value,
+    })),
   };
 }
 
@@ -229,10 +264,18 @@ function ServerFormDialog({
     if (open) {
       reset(editingServer ? serverToFormValues(editingServer) : EMPTY_FORM);
       setError(null);
+      setJsonImportOpen(false);
+      setJsonText('');
+      setImportError(null);
+      setImportNotes([]);
     }
   }, [open, editingServer, reset]);
 
   const [error, setError] = useState<string | null>(null);
+  const [jsonImportOpen, setJsonImportOpen] = useState(false);
+  const [jsonText, setJsonText] = useState('');
+  const [importError, setImportError] = useState<string | null>(null);
+  const [importNotes, setImportNotes] = useState<string[]>([]);
   const transport = watch('transport');
   const authType = watch('authType');
   const headers = watch('headers');
@@ -285,6 +328,78 @@ function ServerFormDialog({
         </DialogHeader>
 
         <form onSubmit={onSubmit} className="space-y-4">
+          {!isEdit && (
+            <div className="space-y-2">
+              {jsonImportOpen ? (
+                <>
+                  <Label htmlFor="custom-mcp-json-import">
+                    Paste a JSON config
+                  </Label>
+                  <textarea
+                    id="custom-mcp-json-import"
+                    className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm font-mono min-h-28"
+                    placeholder='{"mcpServers": {"example": {"command": "npx", "args": ["-y", "@example/mcp-server"]}}}'
+                    value={jsonText}
+                    onChange={(event) => setJsonText(event.target.value)}
+                  />
+                  {importError && (
+                    <p className="text-sm text-destructive">{importError}</p>
+                  )}
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      size="sm"
+                      onClick={() => {
+                        try {
+                          const parsed = parseCustomMcpServerJson(jsonText);
+
+                          reset(importToFormValues(parsed, watch('name')));
+                          setImportNotes(parsed.notes);
+                          setImportError(null);
+                          setJsonImportOpen(false);
+                          setJsonText('');
+                        } catch (parseError) {
+                          setImportError(
+                            parseError instanceof Error
+                              ? parseError.message
+                              : String(parseError),
+                          );
+                        }
+                      }}
+                    >
+                      Fill form from JSON
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => {
+                        setJsonImportOpen(false);
+                        setImportError(null);
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </>
+              ) : (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => setJsonImportOpen(true)}
+                >
+                  Import from JSON
+                </Button>
+              )}
+              {importNotes.map((note) => (
+                <p key={note} className="text-xs text-muted-foreground">
+                  {note}
+                </p>
+              ))}
+            </div>
+          )}
+
           <div className="space-y-2">
             <Label>Name</Label>
             <Input

--- a/apps/web/src/components/settings/CustomMcpServers.tsx
+++ b/apps/web/src/components/settings/CustomMcpServers.tsx
@@ -1,0 +1,843 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useForm } from 'react-hook-form';
+
+import {
+  Badge,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  Lock,
+  Pencil,
+  Plus,
+  RadioGroup,
+  RadioGroupItem,
+  ServerCog,
+  Skeleton,
+  Switch,
+  Trash2,
+  Wrench,
+  X,
+} from '@/components/system';
+import { Loading } from '@/components/layout';
+import { Section } from '@/components/settings';
+import { useTRPC } from '@/trpc/client';
+
+type Transport = 'remote' | 'stdio';
+type AuthType = 'none' | 'static_headers' | 'oauth';
+
+interface ServerFormValues {
+  name: string;
+  transport: Transport;
+  url: string;
+  authType: AuthType;
+  headers: { name: string; value: string }[];
+  manualClientId: string;
+  manualClientSecret: string;
+  oauthResourceIndicatorDisabled: boolean;
+  stdioCommand: string;
+  stdioArgs: string;
+  stdioEnv: { name: string; value: string }[];
+}
+
+interface ListedServer {
+  id: string;
+  name: string;
+  transport: Transport;
+  url: string | null;
+  authType: AuthType;
+  headerNames: string[];
+  stdioCommand: string | null;
+  stdioArgs: string[];
+  stdioEnvNames: string[];
+  disabledTools: string[];
+  hasManualClient: boolean;
+  oauthResourceIndicatorDisabled: boolean;
+  authStatus: 'pending' | 'authenticated' | 'error' | null;
+  enabled: boolean;
+}
+
+const EMPTY_FORM: ServerFormValues = {
+  name: '',
+  transport: 'remote',
+  url: '',
+  authType: 'none',
+  headers: [],
+  manualClientId: '',
+  manualClientSecret: '',
+  oauthResourceIndicatorDisabled: false,
+  stdioCommand: '',
+  stdioArgs: '',
+  stdioEnv: [],
+};
+
+function serverToFormValues(server: ListedServer): ServerFormValues {
+  return {
+    name: server.name,
+    transport: server.transport,
+    url: server.url ?? '',
+    authType: server.authType,
+    headers: server.headerNames.map((name) => ({ name, value: '' })),
+    manualClientId: '',
+    manualClientSecret: '',
+    oauthResourceIndicatorDisabled: server.oauthResourceIndicatorDisabled,
+    stdioCommand: server.stdioCommand ?? '',
+    stdioArgs: server.stdioArgs.join('\n'),
+    stdioEnv: server.stdioEnvNames.map((name) => ({ name, value: '' })),
+  };
+}
+
+function formValuesToInput(values: ServerFormValues) {
+  if (values.transport === 'stdio') {
+    const args = values.stdioArgs
+      .split('\n')
+      .map((argument) => argument.trim())
+      .filter(Boolean);
+    const env = Object.fromEntries(
+      values.stdioEnv
+        .filter((entry) => entry.name.trim())
+        .map((entry) => [entry.name.trim(), entry.value]),
+    );
+
+    return {
+      transport: 'stdio' as const,
+      name: values.name,
+      stdio: {
+        command: values.stdioCommand,
+        ...(args.length > 0 ? { args } : {}),
+        ...(Object.keys(env).length > 0 ? { env } : {}),
+      },
+    };
+  }
+
+  const headers = Object.fromEntries(
+    values.headers
+      .filter((entry) => entry.name.trim())
+      .map((entry) => [entry.name.trim(), entry.value]),
+  );
+
+  return {
+    transport: 'remote' as const,
+    name: values.name,
+    url: values.url,
+    authType: values.authType,
+    ...(values.authType === 'static_headers' && Object.keys(headers).length > 0
+      ? { headers }
+      : {}),
+    ...(values.authType === 'oauth'
+      ? {
+          manualClientId: values.manualClientId || undefined,
+          manualClientSecret: values.manualClientSecret || undefined,
+          oauthResourceIndicatorDisabled: values.oauthResourceIndicatorDisabled,
+        }
+      : {}),
+  };
+}
+
+function KeyValueRows({
+  entries,
+  onChange,
+  namePlaceholder,
+  isEdit,
+}: {
+  entries: { name: string; value: string }[];
+  onChange: (entries: { name: string; value: string }[]) => void;
+  namePlaceholder: string;
+  isEdit: boolean;
+}) {
+  return (
+    <div className="space-y-2">
+      {entries.map((entry, index) => (
+        <div key={index} className="flex gap-2">
+          <Input
+            className="font-mono flex-1"
+            placeholder={namePlaceholder}
+            value={entry.name}
+            onChange={(event) =>
+              onChange(
+                entries.map((candidate, candidateIndex) =>
+                  candidateIndex === index
+                    ? { ...candidate, name: event.target.value }
+                    : candidate,
+                ),
+              )
+            }
+            data-1p-ignore
+          />
+          <Input
+            secret
+            className="font-mono flex-1"
+            placeholder={
+              isEdit ? 'Leave blank to keep the existing value' : 'Value'
+            }
+            value={entry.value}
+            onChange={(event) =>
+              onChange(
+                entries.map((candidate, candidateIndex) =>
+                  candidateIndex === index
+                    ? { ...candidate, value: event.target.value }
+                    : candidate,
+                ),
+              )
+            }
+            data-1p-ignore
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() =>
+              onChange(
+                entries.filter((_, candidateIndex) => candidateIndex !== index),
+              )
+            }
+          >
+            <X className="size-4" />
+          </Button>
+        </div>
+      ))}
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        onClick={() => onChange([...entries, { name: '', value: '' }])}
+      >
+        <Plus />
+        Add
+      </Button>
+    </div>
+  );
+}
+
+function ServerFormDialog({
+  open,
+  onOpenChange,
+  editingServer,
+  onSaved,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  editingServer: ListedServer | null;
+  onSaved: () => void;
+}) {
+  const trpc = useTRPC();
+  const isEdit = Boolean(editingServer);
+
+  const form = useForm<ServerFormValues>({ defaultValues: EMPTY_FORM });
+  const { watch, setValue, register, reset } = form;
+
+  useEffect(() => {
+    if (open) {
+      reset(editingServer ? serverToFormValues(editingServer) : EMPTY_FORM);
+      setError(null);
+    }
+  }, [open, editingServer, reset]);
+
+  const [error, setError] = useState<string | null>(null);
+  const transport = watch('transport');
+  const authType = watch('authType');
+  const headers = watch('headers');
+  const stdioEnv = watch('stdioEnv');
+
+  const createServer = useMutation(
+    trpc.customMcpServers.create.mutationOptions(),
+  );
+  const updateServer = useMutation(
+    trpc.customMcpServers.update.mutationOptions(),
+  );
+
+  const isSaving = createServer.isPending || updateServer.isPending;
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    setError(null);
+
+    try {
+      const server = formValuesToInput(values);
+
+      if (editingServer) {
+        await updateServer.mutateAsync({ id: editingServer.id, server });
+      } else {
+        await createServer.mutateAsync(server);
+      }
+
+      onSaved();
+    } catch (submitError) {
+      setError(
+        submitError instanceof Error
+          ? submitError.message
+          : String(submitError),
+      );
+    }
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="lg">
+        <DialogHeader>
+          <DialogTitle>
+            {isEdit ? 'Edit custom MCP server' : 'Add custom MCP server'}
+          </DialogTitle>
+          <DialogDescription>
+            Custom servers are available to agents in every task. Remote servers
+            are reached through an authenticated Roomote proxy, so credentials
+            stay server-side. Local servers run inside the task sandbox with the
+            same privileges as the agent.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={onSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label>Name</Label>
+            <Input
+              className="font-mono"
+              placeholder="e.g. internal-tools"
+              disabled={isEdit}
+              {...register('name')}
+              data-1p-ignore
+            />
+            <p className="text-xs text-muted-foreground">
+              Lowercase letters, digits, dashes, and underscores. Shown to
+              agents as the MCP server name.
+            </p>
+          </div>
+
+          {!isEdit && (
+            <div className="space-y-2">
+              <Label>Type</Label>
+              <RadioGroup
+                value={transport}
+                onValueChange={(value) =>
+                  setValue('transport', value as Transport)
+                }
+                className="flex gap-6"
+              >
+                <div className="flex items-center gap-2">
+                  <RadioGroupItem value="remote" id="transport-remote" />
+                  <Label htmlFor="transport-remote">Remote (HTTP)</Label>
+                </div>
+                <div className="flex items-center gap-2">
+                  <RadioGroupItem value="stdio" id="transport-stdio" />
+                  <Label htmlFor="transport-stdio">Local (stdio)</Label>
+                </div>
+              </RadioGroup>
+            </div>
+          )}
+
+          {transport === 'remote' ? (
+            <>
+              <div className="space-y-2">
+                <Label>Server URL</Label>
+                <Input
+                  className="font-mono"
+                  placeholder="https://mcp.example.com/mcp"
+                  {...register('url')}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label>Authentication</Label>
+                <RadioGroup
+                  value={authType}
+                  onValueChange={(value) =>
+                    setValue('authType', value as AuthType)
+                  }
+                  className="flex gap-6"
+                >
+                  <div className="flex items-center gap-2">
+                    <RadioGroupItem value="none" id="auth-none" />
+                    <Label htmlFor="auth-none">None</Label>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <RadioGroupItem value="static_headers" id="auth-headers" />
+                    <Label htmlFor="auth-headers">Headers</Label>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <RadioGroupItem value="oauth" id="auth-oauth" />
+                    <Label htmlFor="auth-oauth">OAuth</Label>
+                  </div>
+                </RadioGroup>
+              </div>
+
+              {authType === 'static_headers' && (
+                <div className="space-y-2">
+                  <Label>Headers</Label>
+                  <KeyValueRows
+                    entries={headers}
+                    onChange={(entries) => setValue('headers', entries)}
+                    namePlaceholder="e.g. x-api-key"
+                    isEdit={isEdit}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Values are encrypted at rest and injected by the proxy; they
+                    are never sent to the browser or the task sandbox.
+                  </p>
+                </div>
+              )}
+
+              {authType === 'oauth' && (
+                <div className="space-y-3">
+                  <p className="text-xs text-muted-foreground">
+                    After saving, use Connect to authorize. Servers that support
+                    Dynamic Client Registration need no client credentials;
+                    otherwise register a client for the callback URL{' '}
+                    <code className="font-mono">
+                      {typeof window !== 'undefined'
+                        ? `${window.location.origin}/api/mcp-oauth/callback`
+                        : '/api/mcp-oauth/callback'}
+                    </code>{' '}
+                    and enter it below.
+                  </p>
+                  <div className="space-y-2">
+                    <Label>Client ID (optional)</Label>
+                    <Input
+                      className="font-mono"
+                      {...register('manualClientId')}
+                      data-1p-ignore
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Client secret (optional)</Label>
+                    <Input
+                      secret
+                      className="font-mono"
+                      placeholder={
+                        isEdit ? 'Leave blank to keep the existing value' : ''
+                      }
+                      {...register('manualClientSecret')}
+                      data-1p-ignore
+                    />
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Switch
+                      checked={watch('oauthResourceIndicatorDisabled')}
+                      onCheckedChange={(checked) =>
+                        setValue('oauthResourceIndicatorDisabled', checked)
+                      }
+                      id="resource-indicator-disabled"
+                    />
+                    <Label htmlFor="resource-indicator-disabled">
+                      Skip RFC 8707 resource indicator (for servers that reject
+                      it)
+                    </Label>
+                  </div>
+                </div>
+              )}
+            </>
+          ) : (
+            <>
+              <div className="space-y-2">
+                <Label>Command</Label>
+                <Input
+                  className="font-mono"
+                  placeholder="e.g. npx"
+                  {...register('stdioCommand')}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Arguments (one per line)</Label>
+                <textarea
+                  className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm font-mono min-h-20"
+                  placeholder={'-y\n@example/mcp-server'}
+                  {...register('stdioArgs')}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Environment variables</Label>
+                <KeyValueRows
+                  entries={stdioEnv}
+                  onChange={(entries) => setValue('stdioEnv', entries)}
+                  namePlaceholder="e.g. EXAMPLE_TOKEN"
+                  isEdit={isEdit}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Values are encrypted at rest but are visible inside the task
+                  sandbox at runtime, like environment-scoped stdio servers. You
+                  can reference deployment environment variables with{' '}
+                  <code className="font-mono">{'${VAR}'}</code>.
+                </p>
+              </div>
+            </>
+          )}
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSaving}>
+              {isSaving ? <Loading /> : isEdit ? 'Save' : 'Add server'}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CustomToolManagementDialog({
+  server,
+  open,
+  onOpenChange,
+  onSaved,
+}: {
+  server: ListedServer | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSaved: () => void;
+}) {
+  const trpc = useTRPC();
+
+  const toolsQuery = useQuery(
+    trpc.customMcpServers.listTools.queryOptions(
+      { id: server?.id ?? '' },
+      { enabled: open && Boolean(server), retry: false },
+    ),
+  );
+
+  const setDisabledTools = useMutation(
+    trpc.customMcpServers.setDisabledTools.mutationOptions(),
+  );
+
+  const [disabledNames, setDisabledNames] = useState<Set<string>>(new Set());
+
+  const loadedKey = useMemo(
+    () =>
+      toolsQuery.data
+        ? `${server?.id}:${toolsQuery.data.tools.map((tool) => tool.name).join(',')}`
+        : null,
+    [toolsQuery.data, server?.id],
+  );
+
+  useEffect(() => {
+    if (loadedKey && toolsQuery.data) {
+      setDisabledNames(
+        new Set(
+          toolsQuery.data.tools
+            .filter((tool) => !tool.enabled)
+            .map((tool) => tool.name),
+        ),
+      );
+    }
+  }, [loadedKey, toolsQuery.data]);
+
+  const save = async () => {
+    if (!server) {
+      return;
+    }
+
+    await setDisabledTools.mutateAsync({
+      id: server.id,
+      disabledTools: [...disabledNames],
+    });
+    onSaved();
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="lg">
+        <DialogHeader>
+          <DialogTitle>
+            Manage tools{server ? ` — ${server.name}` : ''}
+          </DialogTitle>
+          <DialogDescription>
+            Disabled tools are blocked at the Roomote proxy and hidden from
+            agents.
+          </DialogDescription>
+        </DialogHeader>
+
+        {toolsQuery.isPending ? (
+          <div className="space-y-2">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <Skeleton key={index} className="h-6 w-full" />
+            ))}
+          </div>
+        ) : toolsQuery.isError ? (
+          <p className="text-sm text-destructive">
+            {toolsQuery.error instanceof Error
+              ? toolsQuery.error.message
+              : 'Failed to load tools.'}
+          </p>
+        ) : (
+          <div className="space-y-2 max-h-96 overflow-y-auto">
+            {toolsQuery.data?.tools.map((tool) => (
+              <label
+                key={tool.name}
+                className="flex items-start gap-3 text-sm cursor-pointer"
+              >
+                <Checkbox
+                  checked={!disabledNames.has(tool.name)}
+                  onCheckedChange={(checked) => {
+                    setDisabledNames((current) => {
+                      const next = new Set(current);
+
+                      if (checked === true) {
+                        next.delete(tool.name);
+                      } else {
+                        next.add(tool.name);
+                      }
+
+                      return next;
+                    });
+                  }}
+                  className="mt-0.5"
+                />
+                <span>
+                  <span className="font-mono">{tool.name}</span>
+                  {tool.description && (
+                    <span className="block text-xs text-muted-foreground">
+                      {tool.description}
+                    </span>
+                  )}
+                </span>
+              </label>
+            ))}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={save}
+            disabled={setDisabledTools.isPending || toolsQuery.isPending}
+          >
+            {setDisabledTools.isPending ? <Loading /> : 'Save'}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function CustomMcpServers() {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  const availability = useQuery(
+    trpc.customMcpServers.availability.queryOptions(),
+  );
+  const serversQuery = useQuery(trpc.customMcpServers.list.queryOptions());
+
+  const deleteServer = useMutation(
+    trpc.customMcpServers.delete.mutationOptions(),
+  );
+  const setEnabled = useMutation(
+    trpc.customMcpServers.setEnabled.mutationOptions(),
+  );
+  const connect = useMutation(trpc.customMcpServers.connect.mutationOptions());
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingServer, setEditingServer] = useState<ListedServer | null>(null);
+  const [toolsServer, setToolsServer] = useState<ListedServer | null>(null);
+
+  const refresh = () =>
+    queryClient.invalidateQueries({
+      queryKey: trpc.customMcpServers.list.queryKey(),
+    });
+
+  if (availability.data?.enabled === false) {
+    return null;
+  }
+
+  const servers = (serversQuery.data ?? []) as ListedServer[];
+
+  const authSummary = (server: ListedServer) => {
+    if (server.transport === 'stdio') {
+      return <Badge variant="outline">stdio</Badge>;
+    }
+
+    if (server.authType === 'static_headers') {
+      return (
+        <Badge variant="outline">
+          <Lock className="size-2 text-muted-foreground" />
+          {server.headerNames.length} header
+          {server.headerNames.length === 1 ? '' : 's'}
+        </Badge>
+      );
+    }
+
+    if (server.authType === 'oauth') {
+      if (server.authStatus === 'authenticated') {
+        return <Badge variant="outline">OAuth · connected</Badge>;
+      }
+
+      return (
+        <Badge variant="destructive">
+          OAuth ·{' '}
+          {server.authStatus === 'error' ? 'reconnect needed' : 'not connected'}
+        </Badge>
+      );
+    }
+
+    return <Badge variant="outline">no auth</Badge>;
+  };
+
+  return (
+    <>
+      <Section
+        icon={ServerCog}
+        title="Custom MCP Servers"
+        action={
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={() => {
+              setEditingServer(null);
+              setFormOpen(true);
+            }}
+          >
+            <Plus />
+            Add
+          </Button>
+        }
+      >
+        <p className="text-sm text-muted-foreground">
+          Connect MCP servers that are not in the catalog. Available to agents
+          in every task; an environment&apos;s own <code>mcpServers</code> entry
+          with the same name takes precedence in that environment.
+        </p>
+
+        {serversQuery.isPending ? (
+          <Skeleton className="h-16 w-full" />
+        ) : servers.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No custom MCP servers configured yet.
+          </p>
+        ) : (
+          <table className="w-full">
+            <tbody>
+              {servers.map((server) => (
+                <tr
+                  key={server.id}
+                  className="text-sm text-left border-b border-border last:border-none"
+                >
+                  <th className="font-mono py-2">{server.name}</th>
+                  <td className="text-muted-foreground font-mono text-xs max-w-64 truncate">
+                    {server.transport === 'remote'
+                      ? server.url
+                      : [server.stdioCommand, ...server.stdioArgs].join(' ')}
+                  </td>
+                  <td>{authSummary(server)}</td>
+                  <td className="text-right py-1">
+                    {server.transport === 'remote' &&
+                      server.authType === 'oauth' &&
+                      server.authStatus !== 'authenticated' && (
+                        <Button
+                          type="button"
+                          variant="secondary"
+                          size="sm"
+                          disabled={connect.isPending}
+                          onClick={async () => {
+                            const initiateUrl = await connect.mutateAsync({
+                              id: server.id,
+                              redirectTo: '/settings/integrations',
+                            });
+                            window.location.href = initiateUrl;
+                          }}
+                        >
+                          Connect
+                        </Button>
+                      )}
+                    {server.transport === 'remote' && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        title="Manage tools"
+                        onClick={() => setToolsServer(server)}
+                      >
+                        <Wrench className="size-4" />
+                      </Button>
+                    )}
+                    <Switch
+                      checked={server.enabled}
+                      onCheckedChange={async (checked) => {
+                        await setEnabled.mutateAsync({
+                          id: server.id,
+                          enabled: checked,
+                        });
+                        refresh();
+                      }}
+                      className="mx-2 align-middle"
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => {
+                        setEditingServer(server);
+                        setFormOpen(true);
+                      }}
+                    >
+                      <Pencil className="size-4" />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      disabled={deleteServer.isPending}
+                      onClick={async () => {
+                        if (
+                          confirm(
+                            `Delete custom MCP server '${server.name}'? Stored credentials are removed as well.`,
+                          )
+                        ) {
+                          await deleteServer.mutateAsync({ id: server.id });
+                          refresh();
+                        }
+                      }}
+                    >
+                      <Trash2 className="size-4" />
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Section>
+
+      <ServerFormDialog
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        editingServer={editingServer}
+        onSaved={() => {
+          setFormOpen(false);
+          refresh();
+        }}
+      />
+
+      <CustomToolManagementDialog
+        server={toolsServer}
+        open={Boolean(toolsServer)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setToolsServer(null);
+          }
+        }}
+        onSaved={refresh}
+      />
+    </>
+  );
+}

--- a/apps/web/src/components/settings/CustomMcpServers.tsx
+++ b/apps/web/src/components/settings/CustomMcpServers.tsx
@@ -29,6 +29,7 @@ import {
 } from '@/components/system';
 import { Loading } from '@/components/layout';
 import { Section } from '@/components/settings';
+import type { CustomMcpServerListEntry } from '@/trpc/commands/custom-mcp-servers';
 import { useTRPC } from '@/trpc/client';
 
 type Transport = 'remote' | 'stdio';
@@ -48,22 +49,7 @@ interface ServerFormValues {
   stdioEnv: { name: string; value: string }[];
 }
 
-interface ListedServer {
-  id: string;
-  name: string;
-  transport: Transport;
-  url: string | null;
-  authType: AuthType;
-  headerNames: string[];
-  stdioCommand: string | null;
-  stdioArgs: string[];
-  stdioEnvNames: string[];
-  disabledTools: string[];
-  hasManualClient: boolean;
-  oauthResourceIndicatorDisabled: boolean;
-  authStatus: 'pending' | 'authenticated' | 'error' | null;
-  enabled: boolean;
-}
+type ListedServer = Omit<CustomMcpServerListEntry, 'createdAt' | 'updatedAt'>;
 
 const EMPTY_FORM: ServerFormValues = {
   name: '',

--- a/apps/web/src/components/settings/CustomMcpServers.tsx
+++ b/apps/web/src/components/settings/CustomMcpServers.tsx
@@ -483,7 +483,10 @@ function ServerFormDialog({
                   />
                   <p className="text-xs text-muted-foreground">
                     Values are encrypted at rest and injected by the proxy; they
-                    are never sent to the browser or the task sandbox.
+                    are never sent to the browser or the task sandbox. For
+                    servers that expect a bearer API key, add an{' '}
+                    <code className="font-mono">Authorization</code> header with
+                    a <code className="font-mono">Bearer ...</code> value.
                   </p>
                 </div>
               )}

--- a/apps/web/src/components/settings/CustomMcpServers.tsx
+++ b/apps/web/src/components/settings/CustomMcpServers.tsx
@@ -143,39 +143,43 @@ function KeyValueRows({
     <div className="space-y-2">
       {entries.map((entry, index) => (
         <div key={index} className="flex gap-2">
-          <Input
-            className="font-mono flex-1"
-            placeholder={namePlaceholder}
-            value={entry.name}
-            onChange={(event) =>
-              onChange(
-                entries.map((candidate, candidateIndex) =>
-                  candidateIndex === index
-                    ? { ...candidate, name: event.target.value }
-                    : candidate,
-                ),
-              )
-            }
-            data-1p-ignore
-          />
-          <Input
-            secret
-            className="font-mono flex-1"
-            placeholder={
-              isEdit ? 'Leave blank to keep the existing value' : 'Value'
-            }
-            value={entry.value}
-            onChange={(event) =>
-              onChange(
-                entries.map((candidate, candidateIndex) =>
-                  candidateIndex === index
-                    ? { ...candidate, value: event.target.value }
-                    : candidate,
-                ),
-              )
-            }
-            data-1p-ignore
-          />
+          <div className="flex-1">
+            <Input
+              className="font-mono"
+              placeholder={namePlaceholder}
+              value={entry.name}
+              onChange={(event) =>
+                onChange(
+                  entries.map((candidate, candidateIndex) =>
+                    candidateIndex === index
+                      ? { ...candidate, name: event.target.value }
+                      : candidate,
+                  ),
+                )
+              }
+              data-1p-ignore
+            />
+          </div>
+          <div className="flex-1">
+            <Input
+              secret
+              className="font-mono"
+              placeholder={
+                isEdit ? 'Leave blank to keep the existing value' : 'Value'
+              }
+              value={entry.value}
+              onChange={(event) =>
+                onChange(
+                  entries.map((candidate, candidateIndex) =>
+                    candidateIndex === index
+                      ? { ...candidate, value: event.target.value }
+                      : candidate,
+                  ),
+                )
+              }
+              data-1p-ignore
+            />
+          </div>
           <Button
             type="button"
             variant="ghost"

--- a/apps/web/src/components/settings/Integrations.test.tsx
+++ b/apps/web/src/components/settings/Integrations.test.tsx
@@ -284,6 +284,17 @@ vi.mock('@/trpc/client', () => ({
   useTRPC: () => ({}),
 }));
 
+// Custom MCP servers are covered by their own suite; this one exercises the
+// catalog cards, so stub the hook that feeds custom cards into the grids.
+vi.mock('./CustomMcpServers', () => ({
+  useCustomMcpServers: () => ({
+    isEnabled: true,
+    items: [],
+    openAddDialog: vi.fn(),
+    dialogs: null,
+  }),
+}));
+
 vi.mock('@/components/system', () => ({
   Alert: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   AlertDescription: ({
@@ -434,11 +445,8 @@ vi.mock('@/components/system', () => ({
   X: () => <svg aria-hidden="true" />,
 }));
 
-import {
-  Integrations,
-  sortIntegrationItems,
-  splitIntegrationItems,
-} from './Integrations';
+import { Integrations, sortIntegrationItems } from './Integrations';
+import { splitIntegrationItems } from './integration-card';
 
 describe('Integrations settings', () => {
   beforeEach(() => {

--- a/apps/web/src/components/settings/Integrations.tsx
+++ b/apps/web/src/components/settings/Integrations.tsx
@@ -39,6 +39,12 @@ import {
 } from '@/hooks/mcp-connections';
 import { useAuthorizedUser } from '@/hooks/useUser';
 import {
+  IntegrationSection,
+  splitIntegrationItems,
+  type IntegrationItem,
+} from './integration-card';
+import { useCustomMcpServers } from './CustomMcpServers';
+import {
   saveAsanaConnectionSchema,
   saveGrafanaConnectionSchema,
   saveGranolaConnectionSchema,
@@ -50,33 +56,23 @@ import {
   Alert,
   AlertDescription,
   AlertTitle,
-  BasicTooltip,
   Button,
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
   Dialog,
   DialogContent,
   DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  Info,
-  InfoTooltip,
   Input,
   Label,
   LinearLogo,
   Pencil,
   Plus,
-  PlugIcon,
   RefreshCw,
   Settings2,
   Spinner,
   Textarea,
   TriangleAlert,
-  X,
 } from '@/components/system';
 import { McpToolManagementDialog } from './McpToolManagementDialog';
 import { McpIcon } from './McpIcon';
@@ -119,43 +115,6 @@ const DEEP_LINK_ENABLE_DESCRIPTIONS: Record<string, string> = {
   vercel:
     'Roomote will be able to inspect Vercel teams, projects, deployments, logs, and domain availability.',
   zero: 'Roomote will be able to authenticate the workspace Zero connection so agents can discover and pay for external capabilities.',
-};
-type IntegrationItem = {
-  id: string;
-  name: string;
-  description: string;
-  icon: ReactNode;
-  enabled: boolean;
-  configured?: boolean;
-  needsConfiguration?: boolean;
-  isMcpBased: boolean;
-  onAction?: () => void;
-  isPending: boolean;
-  actionLabel?: string;
-  status?: ReactNode;
-  statusIcon?: ReactNode;
-  secondaryAction?: {
-    label: string;
-    ariaLabel: string;
-    onAction: () => void;
-    isPending: boolean;
-    icon?: ReactNode;
-  };
-  headerAction?: {
-    label: string;
-    ariaLabel: string;
-    onAction: () => void;
-    isPending: boolean;
-    icon: ReactNode;
-  };
-  utilityAction?: {
-    label: string;
-    ariaLabel: string;
-    onAction: () => void;
-    isPending: boolean;
-    icon: ReactNode;
-  };
-  highlighted?: boolean;
 };
 
 type OauthReadinessStatus = 'ready' | 'missing' | 'partial';
@@ -406,16 +365,6 @@ export function sortIntegrationItems<T extends { id: string; name: string }>(
   });
 }
 
-export function splitIntegrationItems<
-  T extends { enabled: boolean; configured?: boolean },
->(items: T[]) {
-  return {
-    installed: items.filter((item) => item.enabled),
-    configured: items.filter((item) => !item.enabled && item.configured),
-    available: items.filter((item) => !item.enabled && !item.configured),
-  };
-}
-
 function buildAdminConfiguredIntegrationItem({
   integration,
   connection,
@@ -484,168 +433,17 @@ function buildAdminConfiguredIntegrationItem({
   };
 }
 
-function IntegrationCard({ item }: { item: IntegrationItem }) {
-  const actionLabel = item.onAction
-    ? (item.actionLabel ??
-      (item.enabled ? `Disable ${item.name}` : `Enable ${item.name}`))
-    : undefined;
-  const integrationTypeContent = item.isMcpBased
-    ? 'MCP-based integration'
-    : 'First-class integration';
-  const integrationTypeIcon = item.isMcpBased ? PlugIcon : Info;
-  const footerActions = [item.secondaryAction, item.headerAction].filter(
-    (action): action is NonNullable<IntegrationItem['secondaryAction']> =>
-      action != null,
-  );
-  const iconColumnWidthClass = 'w-[34px]';
-
+function AddCustomMcpServerBar({ onAdd }: { onAdd: () => void }) {
   return (
-    <Card
-      id={`integration-${item.id}`}
-      className={`h-full gap-3 ${item.highlighted ? 'border-accent-foreground ring-2 ring-primary/50 bg-primary/5' : ''}`}
-      data-highlighted={item.highlighted ? 'true' : undefined}
-    >
-      <CardHeader>
-        <div className="flex items-start justify-between gap-3">
-          <div className="flex min-w-0 items-start gap-3">
-            <div
-              className={`mt-0.5 flex ${iconColumnWidthClass} shrink-0 items-start justify-center`}
-            >
-              <div className="rounded-xl border border-border/70 bg-muted/30 p-2">
-                {item.icon}
-              </div>
-            </div>
-            <div className="min-w-0 space-y-1">
-              <div className="flex items-center gap-1.5">
-                <CardTitle className="text-base">{item.name}</CardTitle>
-                <InfoTooltip
-                  content={integrationTypeContent}
-                  icon={integrationTypeIcon}
-                  iconClassName="size-4"
-                />
-              </div>
-              <CardDescription>{item.description}</CardDescription>
-            </div>
-          </div>
-
-          {item.onAction || item.utilityAction ? (
-            <div className="flex items-center gap-1">
-              {item.utilityAction ? (
-                <BasicTooltip content={item.utilityAction.label}>
-                  <Button
-                    type="button"
-                    size="icon"
-                    variant="ghost"
-                    aria-label={item.utilityAction.ariaLabel}
-                    onClick={item.utilityAction.onAction}
-                    disabled={item.utilityAction.isPending}
-                  >
-                    {item.utilityAction.isPending ? (
-                      <Spinner size="sm" />
-                    ) : (
-                      item.utilityAction.icon
-                    )}
-                  </Button>
-                </BasicTooltip>
-              ) : null}
-              {actionLabel ? (
-                <BasicTooltip content={actionLabel}>
-                  <Button
-                    type="button"
-                    size="icon"
-                    variant="ghost"
-                    aria-label={actionLabel}
-                    onClick={item.onAction}
-                    disabled={item.isPending}
-                  >
-                    {item.isPending ? (
-                      <Spinner size="sm" />
-                    ) : item.needsConfiguration ? (
-                      <Settings2 />
-                    ) : item.enabled ? (
-                      <X />
-                    ) : (
-                      <Plus />
-                    )}
-                  </Button>
-                </BasicTooltip>
-              ) : null}
-            </div>
-          ) : null}
-        </div>
-      </CardHeader>
-
-      {item.status || footerActions.length > 0 ? (
-        <CardContent>
-          <div className="flex gap-3 p-0">
-            <div
-              className={`mt-0.5 ${iconColumnWidthClass} shrink-0`}
-              aria-hidden="true"
-            />
-            <div className="min-w-0 space-y-3">
-              {item.status && (
-                <div className="flex items-start gap-2">
-                  {item.statusIcon ? (
-                    <span className="mt-0.5 shrink-0 text-destructive">
-                      {item.statusIcon}
-                    </span>
-                  ) : null}
-                  <p className="text-sm text-muted-foreground">{item.status}</p>
-                </div>
-              )}
-              {footerActions.length > 0 ? (
-                <div className="-ml-4 flex gap-2">
-                  {footerActions.map((action) => (
-                    <Button
-                      key={action.ariaLabel}
-                      type="button"
-                      size="sm"
-                      variant="ghost"
-                      aria-label={action.ariaLabel}
-                      onClick={action.onAction}
-                      disabled={action.isPending}
-                    >
-                      {action.isPending ? <Spinner size="sm" /> : action.icon}
-                      {action.label}
-                    </Button>
-                  ))}
-                </div>
-              ) : null}
-            </div>
-          </div>
-        </CardContent>
-      ) : null}
-    </Card>
-  );
-}
-
-function IntegrationSection({
-  id,
-  title,
-  items,
-  emptyState,
-}: {
-  id: string;
-  title: string;
-  items: IntegrationItem[];
-  emptyState?: ReactNode;
-}) {
-  return (
-    <section aria-labelledby={id} className="space-y-3">
-      <h2 id={id} className="text-sm font-semibold text-foreground">
-        {title}
-      </h2>
-
-      {items.length > 0 ? (
-        <div className="grid gap-4 md:grid-cols-2">
-          {items.map((item) => (
-            <IntegrationCard key={item.id} item={item} />
-          ))}
-        </div>
-      ) : (
-        emptyState
-      )}
-    </section>
+    <div className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-dashed border-border/70 px-4 py-3">
+      <p className="text-sm text-muted-foreground">
+        Not in the catalog? Connect your own MCP server, remote or local.
+      </p>
+      <Button type="button" variant="secondary" size="sm" onClick={onAdd}>
+        <Plus />
+        Add custom server
+      </Button>
+    </div>
   );
 }
 
@@ -1822,7 +1620,17 @@ export function Integrations() {
     userMcpConnections.data,
   ]);
 
-  const { installed, configured, available } = splitIntegrationItems(items);
+  const {
+    isEnabled: customMcpEnabled,
+    items: customMcpItems,
+    openAddDialog: openCustomMcpDialog,
+    dialogs: customMcpDialogs,
+  } = useCustomMcpServers();
+
+  const { installed, configured, available } = splitIntegrationItems([
+    ...items,
+    ...customMcpItems,
+  ]);
   const highlightedItem =
     items.find((item) => item.id === highlightedIntegrationId) ?? null;
   const deepLinkDialogItem =
@@ -2207,13 +2015,31 @@ export function Integrations() {
 
   if (integrationsAvailability.data?.enabled === false) {
     return (
-      <Alert>
-        <AlertTitle>Integrations disabled by deployment operator</AlertTitle>
-        <AlertDescription>
-          Curated integrations cannot be connected or used on this Roomote
-          instance.
-        </AlertDescription>
-      </Alert>
+      <div className="space-y-8">
+        <Alert>
+          <AlertTitle>Integrations disabled by deployment operator</AlertTitle>
+          <AlertDescription>
+            Curated integrations cannot be connected or used on this Roomote
+            instance.
+          </AlertDescription>
+        </Alert>
+        {customMcpEnabled ? (
+          <>
+            {customMcpDialogs}
+            <AddCustomMcpServerBar onAdd={openCustomMcpDialog} />
+            <IntegrationSection
+              id="custom-mcp-servers"
+              title="Custom MCP servers"
+              items={customMcpItems}
+              emptyState={
+                <p className="text-sm text-muted-foreground">
+                  No custom MCP servers configured yet.
+                </p>
+              }
+            />
+          </>
+        ) : null}
+      </div>
     );
   }
 
@@ -2365,6 +2191,10 @@ export function Integrations() {
           deepLinkDialogItem.onAction?.();
         }}
       />
+      {customMcpDialogs}
+      {customMcpEnabled ? (
+        <AddCustomMcpServerBar onAdd={openCustomMcpDialog} />
+      ) : null}
       <IntegrationSection
         id="installed-integrations"
         title="Connected"

--- a/apps/web/src/components/settings/integration-card.tsx
+++ b/apps/web/src/components/settings/integration-card.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import {
+  BasicTooltip,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Info,
+  InfoTooltip,
+  Plus,
+  PlugIcon,
+  Settings2,
+  Spinner,
+  X,
+} from '@/components/system';
+
+export type IntegrationItem = {
+  id: string;
+  name: string;
+  description: string;
+  icon: ReactNode;
+  enabled: boolean;
+  configured?: boolean;
+  needsConfiguration?: boolean;
+  isMcpBased: boolean;
+  /**
+   * Rendered next to the title. Used to mark deployment-defined custom MCP
+   * servers apart from the built-in catalog.
+   */
+  badge?: ReactNode;
+  onAction?: () => void;
+  isPending: boolean;
+  actionLabel?: string;
+  status?: ReactNode;
+  statusIcon?: ReactNode;
+  secondaryAction?: {
+    label: string;
+    ariaLabel: string;
+    onAction: () => void;
+    isPending: boolean;
+    icon?: ReactNode;
+  };
+  headerAction?: {
+    label: string;
+    ariaLabel: string;
+    onAction: () => void;
+    isPending: boolean;
+    icon: ReactNode;
+  };
+  utilityAction?: {
+    label: string;
+    ariaLabel: string;
+    onAction: () => void;
+    isPending: boolean;
+    icon: ReactNode;
+  };
+  highlighted?: boolean;
+};
+
+function IntegrationCard({ item }: { item: IntegrationItem }) {
+  const actionLabel = item.onAction
+    ? (item.actionLabel ??
+      (item.enabled ? `Disable ${item.name}` : `Enable ${item.name}`))
+    : undefined;
+  const integrationTypeContent = item.isMcpBased
+    ? 'MCP-based integration'
+    : 'First-class integration';
+  const integrationTypeIcon = item.isMcpBased ? PlugIcon : Info;
+  const footerActions = [item.secondaryAction, item.headerAction].filter(
+    (action): action is NonNullable<IntegrationItem['secondaryAction']> =>
+      action != null,
+  );
+  const iconColumnWidthClass = 'w-[34px]';
+
+  return (
+    <Card
+      id={`integration-${item.id}`}
+      className={`h-full gap-3 ${item.highlighted ? 'border-accent-foreground ring-2 ring-primary/50 bg-primary/5' : ''}`}
+      data-highlighted={item.highlighted ? 'true' : undefined}
+    >
+      <CardHeader>
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex min-w-0 items-start gap-3">
+            <div
+              className={`mt-0.5 flex ${iconColumnWidthClass} shrink-0 items-start justify-center`}
+            >
+              <div className="rounded-xl border border-border/70 bg-muted/30 p-2">
+                {item.icon}
+              </div>
+            </div>
+            <div className="min-w-0 space-y-1">
+              <div className="flex items-center gap-1.5">
+                <CardTitle className="text-base">{item.name}</CardTitle>
+                {item.badge}
+                <InfoTooltip
+                  content={integrationTypeContent}
+                  icon={integrationTypeIcon}
+                  iconClassName="size-4"
+                />
+              </div>
+              <CardDescription>{item.description}</CardDescription>
+            </div>
+          </div>
+
+          {item.onAction || item.utilityAction ? (
+            <div className="flex items-center gap-1">
+              {item.utilityAction ? (
+                <BasicTooltip content={item.utilityAction.label}>
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    aria-label={item.utilityAction.ariaLabel}
+                    onClick={item.utilityAction.onAction}
+                    disabled={item.utilityAction.isPending}
+                  >
+                    {item.utilityAction.isPending ? (
+                      <Spinner size="sm" />
+                    ) : (
+                      item.utilityAction.icon
+                    )}
+                  </Button>
+                </BasicTooltip>
+              ) : null}
+              {actionLabel ? (
+                <BasicTooltip content={actionLabel}>
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    aria-label={actionLabel}
+                    onClick={item.onAction}
+                    disabled={item.isPending}
+                  >
+                    {item.isPending ? (
+                      <Spinner size="sm" />
+                    ) : item.needsConfiguration ? (
+                      <Settings2 />
+                    ) : item.enabled ? (
+                      <X />
+                    ) : (
+                      <Plus />
+                    )}
+                  </Button>
+                </BasicTooltip>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </CardHeader>
+
+      {item.status || footerActions.length > 0 ? (
+        <CardContent>
+          <div className="flex gap-3 p-0">
+            <div
+              className={`mt-0.5 ${iconColumnWidthClass} shrink-0`}
+              aria-hidden="true"
+            />
+            <div className="min-w-0 space-y-3">
+              {item.status && (
+                <div className="flex items-start gap-2">
+                  {item.statusIcon ? (
+                    <span className="mt-0.5 shrink-0 text-destructive">
+                      {item.statusIcon}
+                    </span>
+                  ) : null}
+                  <p className="text-sm text-muted-foreground">{item.status}</p>
+                </div>
+              )}
+              {footerActions.length > 0 ? (
+                <div className="-ml-4 flex gap-2">
+                  {footerActions.map((action) => (
+                    <Button
+                      key={action.ariaLabel}
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      aria-label={action.ariaLabel}
+                      onClick={action.onAction}
+                      disabled={action.isPending}
+                    >
+                      {action.isPending ? <Spinner size="sm" /> : action.icon}
+                      {action.label}
+                    </Button>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </CardContent>
+      ) : null}
+    </Card>
+  );
+}
+
+export function IntegrationSection({
+  id,
+  title,
+  items,
+  emptyState,
+}: {
+  id: string;
+  title: string;
+  items: IntegrationItem[];
+  emptyState?: ReactNode;
+}) {
+  return (
+    <section aria-labelledby={id} className="space-y-3">
+      <h2 id={id} className="text-sm font-semibold text-foreground">
+        {title}
+      </h2>
+
+      {items.length > 0 ? (
+        <div className="grid gap-4 md:grid-cols-2">
+          {items.map((item) => (
+            <IntegrationCard key={item.id} item={item} />
+          ))}
+        </div>
+      ) : (
+        emptyState
+      )}
+    </section>
+  );
+}
+
+export function splitIntegrationItems<
+  T extends { enabled: boolean; configured?: boolean },
+>(items: T[]) {
+  return {
+    installed: items.filter((item) => item.enabled),
+    configured: items.filter((item) => !item.enabled && item.configured),
+    available: items.filter((item) => !item.enabled && !item.configured),
+  };
+}

--- a/apps/web/src/components/settings/pages/IntegrationsSettingsPage.tsx
+++ b/apps/web/src/components/settings/pages/IntegrationsSettingsPage.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { CustomMcpServers } from '@/components/settings/CustomMcpServers';
 import { Integrations } from '@/components/settings/Integrations';
 import { SettingsShell } from '@/components/settings/SettingsShell';
 
@@ -7,6 +8,9 @@ export function IntegrationsSettingsPage() {
   return (
     <SettingsShell pageId="integrations" adminOnly={true}>
       <Integrations />
+      {/* Rendered outside Integrations so custom servers stay available when
+          the curated catalog is disabled by the deployment operator. */}
+      <CustomMcpServers />
     </SettingsShell>
   );
 }

--- a/apps/web/src/components/settings/pages/IntegrationsSettingsPage.tsx
+++ b/apps/web/src/components/settings/pages/IntegrationsSettingsPage.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { CustomMcpServers } from '@/components/settings/CustomMcpServers';
 import { Integrations } from '@/components/settings/Integrations';
 import { SettingsShell } from '@/components/settings/SettingsShell';
 
@@ -8,9 +7,6 @@ export function IntegrationsSettingsPage() {
   return (
     <SettingsShell pageId="integrations" adminOnly={true}>
       <Integrations />
-      {/* Rendered outside Integrations so custom servers stay available when
-          the curated catalog is disabled by the deployment operator. */}
-      <CustomMcpServers />
     </SettingsShell>
   );
 }

--- a/apps/web/src/lib/custom-mcp-json-import.test.ts
+++ b/apps/web/src/lib/custom-mcp-json-import.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  parseCustomMcpServerJson,
+  sanitizeCustomMcpServerName,
+} from './custom-mcp-json-import';
+
+describe('parseCustomMcpServerJson', () => {
+  it('imports a stdio server from an mcpServers wrapper', () => {
+    const result = parseCustomMcpServerJson(
+      JSON.stringify({
+        mcpServers: {
+          'example-tools': {
+            command: 'npx',
+            args: ['-y', '@example/mcp-server'],
+            env: { EXAMPLE_TOKEN: 'abc' },
+          },
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      name: 'example-tools',
+      transport: 'stdio',
+      stdio: {
+        command: 'npx',
+        args: ['-y', '@example/mcp-server'],
+        env: { EXAMPLE_TOKEN: 'abc' },
+      },
+      notes: [],
+    });
+  });
+
+  it("imports from VS Code's 'servers' wrapper", () => {
+    const result = parseCustomMcpServerJson(
+      JSON.stringify({
+        servers: { example: { command: 'uvx', args: ['example-mcp'] } },
+      }),
+    );
+
+    expect(result.name).toBe('example');
+    expect(result.transport).toBe('stdio');
+    expect(result.stdio?.command).toBe('uvx');
+  });
+
+  it('imports a remote server with headers', () => {
+    const result = parseCustomMcpServerJson(
+      JSON.stringify({
+        mcpServers: {
+          example: {
+            url: 'https://mcp.example.com/mcp',
+            headers: { 'x-api-key': 'secret' },
+          },
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      name: 'example',
+      transport: 'remote',
+      url: 'https://mcp.example.com/mcp',
+      headers: { 'x-api-key': 'secret' },
+      notes: [],
+    });
+  });
+
+  it('converts an mcp-remote launcher into a remote server', () => {
+    const result = parseCustomMcpServerJson(
+      JSON.stringify({
+        mcpServers: {
+          notion: {
+            command: 'npx',
+            args: ['-y', 'mcp-remote', 'https://mcp.notion.com/mcp'],
+          },
+        },
+      }),
+    );
+
+    expect(result.transport).toBe('remote');
+    expect(result.url).toBe('https://mcp.notion.com/mcp');
+    expect(result.headers).toBeUndefined();
+    expect(result.notes[0]).toMatch(/mcp-remote launcher/);
+  });
+
+  it('carries --header pairs through an mcp-remote conversion', () => {
+    const result = parseCustomMcpServerJson(
+      JSON.stringify({
+        command: 'mcp-remote',
+        args: [
+          'https://mcp.example.com/mcp',
+          '--header',
+          'x-api-key: secret',
+          '--transport',
+          'sse-only',
+        ],
+      }),
+    );
+
+    expect(result.transport).toBe('remote');
+    expect(result.headers).toEqual({ 'x-api-key': 'secret' });
+    expect(result.notes.join(' ')).toContain(
+      'Dropped mcp-remote arguments: --transport, sse-only.',
+    );
+  });
+
+  it('accepts a bare single-entry map without a wrapper', () => {
+    const result = parseCustomMcpServerJson(
+      JSON.stringify({
+        example: { command: 'node', args: ['server.js'] },
+      }),
+    );
+
+    expect(result.name).toBe('example');
+    expect(result.stdio?.command).toBe('node');
+  });
+
+  it('sanitizes wrapper keys into valid server names', () => {
+    const result = parseCustomMcpServerJson(
+      JSON.stringify({
+        mcpServers: { 'My Notion (Prod)': { url: 'https://x.example/mcp' } },
+      }),
+    );
+
+    expect(result.name).toBe('my-notion-prod');
+  });
+
+  it('rejects snippets with multiple servers', () => {
+    expect(() =>
+      parseCustomMcpServerJson(
+        JSON.stringify({
+          mcpServers: {
+            one: { command: 'npx' },
+            two: { command: 'uvx' },
+          },
+        }),
+      ),
+    ).toThrow(/2 servers/);
+  });
+
+  it('rejects invalid JSON and configs without command or url', () => {
+    expect(() => parseCustomMcpServerJson('not json')).toThrow(
+      /not valid JSON/,
+    );
+    expect(() =>
+      parseCustomMcpServerJson(JSON.stringify({ mcpServers: { x: {} } })),
+    ).toThrow(/does not contain a server config|command.*nor.*url/);
+  });
+});
+
+describe('sanitizeCustomMcpServerName', () => {
+  it('lowercases and replaces invalid characters', () => {
+    expect(sanitizeCustomMcpServerName('Example_Server v2')).toBe(
+      'example_server-v2',
+    );
+  });
+
+  it('returns null when nothing usable remains', () => {
+    expect(sanitizeCustomMcpServerName('***')).toBeNull();
+  });
+});

--- a/apps/web/src/lib/custom-mcp-json-import.ts
+++ b/apps/web/src/lib/custom-mcp-json-import.ts
@@ -1,0 +1,277 @@
+import { CUSTOM_MCP_SERVER_NAME_PATTERN } from '@roomote/types';
+
+/**
+ * Parser for the "paste JSON" import in the custom MCP server dialog.
+ *
+ * MCP servers are distributed as JSON snippets (`{"mcpServers": {...}}` in
+ * most docs, `{"servers": {...}}` in VS Code's), so the add dialog accepts a
+ * pasted snippet and prefills the form from it. This module is the pure
+ * parsing half: it never touches the form, and import is a create-time
+ * prefill only; edits keep the field-by-field dialog because blank secret
+ * values there mean "keep the stored value".
+ *
+ * Snippets that launch `mcp-remote` are converted to remote servers on the
+ * upstream URL: routing the HTTP server through the Roomote proxy keeps
+ * credentials out of the sandbox and enables per-tool deny lists, both of
+ * which a sandbox-local mcp-remote process would lose.
+ */
+
+export interface CustomMcpJsonImport {
+  /** Sanitized server name, or null when the snippet had no usable name. */
+  name: string | null;
+  transport: 'remote' | 'stdio';
+  url?: string;
+  headers?: Record<string, string>;
+  stdio?: { command: string; args?: string[]; env?: Record<string, string> };
+  /** Human-readable conversion notes to surface next to the prefilled form. */
+  notes: string[];
+}
+
+const WRAPPER_KEYS = ['mcpServers', 'servers'] as const;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function looksLikeServerConfig(record: Record<string, unknown>): boolean {
+  return (
+    typeof record.command === 'string' ||
+    typeof record.url === 'string' ||
+    typeof record.serverUrl === 'string'
+  );
+}
+
+/**
+ * Best-effort conversion of a snippet's server key into a valid server name.
+ * Returns null when nothing usable remains; the form then keeps whatever the
+ * user already typed.
+ */
+export function sanitizeCustomMcpServerName(raw: string): string | null {
+  const sanitized = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^[^a-z0-9]+/, '')
+    .replace(/-+$/, '')
+    .slice(0, 64);
+
+  return CUSTOM_MCP_SERVER_NAME_PATTERN.test(sanitized) ? sanitized : null;
+}
+
+function toStringRecord(value: unknown): Record<string, string> | undefined {
+  const record = asRecord(value);
+
+  if (!record) {
+    return undefined;
+  }
+
+  const entries = Object.entries(record).filter(
+    (entry): entry is [string, string] => typeof entry[1] === 'string',
+  );
+
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function isHttpUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value);
+}
+
+/**
+ * Recognize `npx -y mcp-remote <url> [flags]` (and direct `mcp-remote <url>`)
+ * launcher configs and extract the remote server they wrap. `--header` pairs
+ * carry over; any other flags are reported as dropped rather than silently
+ * discarded.
+ */
+function convertMcpRemoteLauncher(
+  command: string,
+  args: string[],
+): { url: string; headers?: Record<string, string>; notes: string[] } | null {
+  const isMcpRemote =
+    command.replace(/^.*\//, '') === 'mcp-remote' ||
+    args.some((argument) => argument === 'mcp-remote');
+
+  if (!isMcpRemote) {
+    return null;
+  }
+
+  const url = args.find(isHttpUrl);
+
+  if (!url) {
+    return null;
+  }
+
+  const headers: Record<string, string> = {};
+  const dropped: string[] = [];
+  const consumed = new Set<string>(['-y', '--yes', 'mcp-remote', url]);
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]!;
+
+    if (consumed.has(argument)) {
+      continue;
+    }
+
+    const headerPair =
+      argument === '--header'
+        ? args[index + 1]
+        : argument.startsWith('--header=')
+          ? argument.slice('--header='.length)
+          : undefined;
+
+    if (headerPair !== undefined) {
+      if (argument === '--header') {
+        index += 1;
+      }
+
+      const separator = headerPair.indexOf(':');
+
+      if (separator > 0) {
+        headers[headerPair.slice(0, separator).trim()] = headerPair
+          .slice(separator + 1)
+          .trim();
+      } else {
+        dropped.push(`--header ${headerPair}`);
+      }
+
+      continue;
+    }
+
+    dropped.push(argument);
+  }
+
+  const notes = [
+    'Converted an mcp-remote launcher into a remote server: the Roomote ' +
+      'proxy keeps credentials server-side and enables per-tool management.',
+    ...(dropped.length > 0
+      ? [`Dropped mcp-remote arguments: ${dropped.join(', ')}.`]
+      : []),
+  ];
+
+  return {
+    url,
+    ...(Object.keys(headers).length > 0 ? { headers } : {}),
+    notes,
+  };
+}
+
+function importFromConfig(
+  name: string | null,
+  config: Record<string, unknown>,
+): CustomMcpJsonImport {
+  const url =
+    typeof config.url === 'string'
+      ? config.url
+      : typeof config.serverUrl === 'string'
+        ? config.serverUrl
+        : null;
+
+  if (typeof config.command === 'string' && config.command.trim()) {
+    const args = Array.isArray(config.args)
+      ? config.args.map((argument) =>
+          typeof argument === 'string' ? argument : String(argument),
+        )
+      : [];
+
+    const remote = convertMcpRemoteLauncher(config.command.trim(), args);
+
+    if (remote) {
+      return {
+        name,
+        transport: 'remote',
+        url: remote.url,
+        ...(remote.headers ? { headers: remote.headers } : {}),
+        notes: remote.notes,
+      };
+    }
+
+    const env = toStringRecord(config.env);
+
+    return {
+      name,
+      transport: 'stdio',
+      stdio: {
+        command: config.command.trim(),
+        ...(args.length > 0 ? { args } : {}),
+        ...(env ? { env } : {}),
+      },
+      notes: [],
+    };
+  }
+
+  if (url) {
+    const headers = toStringRecord(config.headers);
+
+    return {
+      name,
+      transport: 'remote',
+      url,
+      ...(headers ? { headers } : {}),
+      notes: [],
+    };
+  }
+
+  throw new Error(
+    "The pasted config has neither a 'command' nor a 'url' field.",
+  );
+}
+
+export function parseCustomMcpServerJson(text: string): CustomMcpJsonImport {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error('The pasted text is not valid JSON.');
+  }
+
+  const root = asRecord(parsed);
+
+  if (!root) {
+    throw new Error('Paste a JSON object describing one MCP server.');
+  }
+
+  for (const wrapperKey of WRAPPER_KEYS) {
+    const wrapper = asRecord(root[wrapperKey]);
+
+    if (wrapper) {
+      const entries = Object.entries(wrapper).flatMap(([name, value]) => {
+        const config = asRecord(value);
+        return config ? [[name, config] as const] : [];
+      });
+
+      if (entries.length === 0) {
+        throw new Error(`'${wrapperKey}' does not contain a server config.`);
+      }
+
+      if (entries.length > 1) {
+        throw new Error(
+          `The snippet contains ${entries.length} servers; paste one server at a time.`,
+        );
+      }
+
+      const [name, config] = entries[0]!;
+      return importFromConfig(sanitizeCustomMcpServerName(name), config);
+    }
+  }
+
+  if (looksLikeServerConfig(root)) {
+    return importFromConfig(null, root);
+  }
+
+  const soleEntry = Object.entries(root);
+
+  if (soleEntry.length === 1) {
+    const [name, value] = soleEntry[0]!;
+    const config = asRecord(value);
+
+    if (config && looksLikeServerConfig(config)) {
+      return importFromConfig(sanitizeCustomMcpServerName(name), config);
+    }
+  }
+
+  throw new Error(
+    'Unrecognized snippet shape. Paste an mcpServers snippet or a single ' +
+      'server config.',
+  );
+}

--- a/apps/web/src/lib/server/env.ts
+++ b/apps/web/src/lib/server/env.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import * as dotenvx from '@dotenvx/dotenvx';
 import {
   areCuratedIntegrationsDisabled,
+  isCustomMcpDisabled,
   createRoomoteEnv,
   getAllowedDevOrigins as getSharedAllowedDevOrigins,
   getArtifactSigningKey,
@@ -197,6 +198,7 @@ function getWebRuntimeEnv(): RoomoteEnv {
 
 export {
   areCuratedIntegrationsDisabled,
+  isCustomMcpDisabled,
   getArtifactSigningKey,
   getArtifactSigningKeyPrevious,
   getBetterAuthSecret,

--- a/apps/web/src/trpc/commands/custom-mcp-servers/index.test.ts
+++ b/apps/web/src/trpc/commands/custom-mcp-servers/index.test.ts
@@ -14,10 +14,19 @@ import {
   createCustomMcpServerCommand,
   deleteCustomMcpServerCommand,
   listCustomMcpServersCommand,
+  listCustomMcpServerToolsCommand,
   setCustomMcpServerDisabledToolsCommand,
   setCustomMcpServerEnabledCommand,
   updateCustomMcpServerCommand,
 } from './index';
+
+vi.mock('@roomote/sdk/server/safe-fetch', () => ({
+  safeFetch: vi.fn(),
+}));
+
+import { safeFetch } from '@roomote/sdk/server/safe-fetch';
+
+const safeFetchMock = vi.mocked(safeFetch);
 
 import type { UserAuthSuccess } from '@/types';
 
@@ -255,6 +264,104 @@ describe('custom-mcp-servers commands', () => {
 
     listed = await listCustomMcpServersCommand(adminAuth);
     expect(listed[0]!.enabled).toBe(false);
+  });
+
+  it('allows editing the tool deny list on a disabled server', async () => {
+    const { id } = await createCustomMcpServerCommand(adminAuth, remoteInput);
+    await setCustomMcpServerEnabledCommand(adminAuth, { id, enabled: false });
+
+    await setCustomMcpServerDisabledToolsCommand(adminAuth, {
+      id,
+      disabledTools: ['dangerous_tool'],
+    });
+
+    const listed = await listCustomMcpServersCommand(adminAuth);
+    expect(listed[0]!.disabledTools).toEqual(['dangerous_tool']);
+    expect(listed[0]!.enabled).toBe(false);
+  });
+
+  it('sends notifications/initialized before the session tools/list fallback', async () => {
+    const { id } = await createCustomMcpServerCommand(adminAuth, remoteInput);
+
+    safeFetchMock.mockReset();
+    safeFetchMock
+      // Session-less tools/list refused by a strict server.
+      .mockResolvedValueOnce(new Response('session required', { status: 400 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: {} }), {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            'mcp-session-id': 'sess-1',
+          },
+        }),
+      )
+      // notifications/initialized is accepted without a body.
+      .mockResolvedValueOnce(new Response(null, { status: 202 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: 2,
+            result: { tools: [{ name: 'query', description: 'Run a query' }] },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      );
+
+    const { tools } = await listCustomMcpServerToolsCommand(adminAuth, { id });
+
+    expect(tools).toEqual([
+      { name: 'query', description: 'Run a query', enabled: true },
+    ]);
+    expect(safeFetchMock).toHaveBeenCalledTimes(4);
+
+    const [, notificationInit] = safeFetchMock.mock.calls[2]!;
+    expect(JSON.parse(String(notificationInit?.body))).toEqual({
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+    });
+    expect(notificationInit?.headers?.['mcp-session-id']).toBe('sess-1');
+    expect(notificationInit?.headers?.['x-api-key']).toBe('secret-one');
+
+    const [, listInit] = safeFetchMock.mock.calls[3]!;
+    expect(JSON.parse(String(listInit?.body)).method).toBe('tools/list');
+    expect(listInit?.headers?.['mcp-session-id']).toBe('sess-1');
+  });
+
+  it('still lists tools when the initialized notification is refused', async () => {
+    const { id } = await createCustomMcpServerCommand(adminAuth, remoteInput);
+
+    safeFetchMock.mockReset();
+    safeFetchMock
+      .mockResolvedValueOnce(new Response('session required', { status: 400 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: {} }), {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            'mcp-session-id': 'sess-1',
+          },
+        }),
+      )
+      // A lenient server that rejects the notification outright.
+      .mockRejectedValueOnce(new Error('unexpected notification'))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: 2,
+            result: { tools: [{ name: 'query' }] },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      );
+
+    const { tools } = await listCustomMcpServerToolsCommand(adminAuth, { id });
+
+    expect(tools).toEqual([
+      { name: 'query', description: null, enabled: true },
+    ]);
   });
 
   it('kill switch blocks mutations with a clear message', () => {

--- a/apps/web/src/trpc/commands/custom-mcp-servers/index.test.ts
+++ b/apps/web/src/trpc/commands/custom-mcp-servers/index.test.ts
@@ -1,0 +1,266 @@
+import {
+  customMcpServers,
+  db,
+  eq,
+  mcpConnections,
+  userFactory,
+} from '@roomote/db/server';
+import { decrypt } from '@roomote/db/encryption';
+import { customMcpConnectionId } from '@roomote/types';
+
+import {
+  CUSTOM_MCP_DISABLED_MESSAGE,
+  assertCustomMcpEnabled,
+  createCustomMcpServerCommand,
+  deleteCustomMcpServerCommand,
+  listCustomMcpServersCommand,
+  setCustomMcpServerDisabledToolsCommand,
+  setCustomMcpServerEnabledCommand,
+  updateCustomMcpServerCommand,
+} from './index';
+
+import type { UserAuthSuccess } from '@/types';
+
+const adminAuth = {
+  success: true,
+  userType: 'user',
+  userId: 'custom-mcp-admin',
+  isAdmin: true,
+} as UserAuthSuccess;
+
+const memberAuth = {
+  success: true,
+  userType: 'user',
+  userId: 'custom-mcp-member',
+  isAdmin: false,
+} as UserAuthSuccess;
+
+const remoteInput = {
+  transport: 'remote' as const,
+  name: 'internal-tools',
+  url: 'https://mcp.example.com/mcp',
+  authType: 'static_headers' as const,
+  headers: { 'x-api-key': 'secret-one' },
+};
+
+async function cleanup() {
+  await db.delete(customMcpServers);
+  await db.delete(mcpConnections);
+}
+
+describe('custom-mcp-servers commands', () => {
+  beforeAll(async () => {
+    await userFactory.create({ id: adminAuth.userId });
+  });
+
+  beforeEach(cleanup);
+  afterAll(cleanup);
+
+  it('rejects non-admin users on every command', async () => {
+    await expect(listCustomMcpServersCommand(memberAuth)).rejects.toThrow(
+      'Unauthorized',
+    );
+    await expect(
+      createCustomMcpServerCommand(memberAuth, remoteInput),
+    ).rejects.toThrow('Unauthorized');
+    await expect(
+      deleteCustomMcpServerCommand(memberAuth, { id: crypto.randomUUID() }),
+    ).rejects.toThrow('Unauthorized');
+  });
+
+  it('creates a server with encrypted header values and lists names only', async () => {
+    const { id } = await createCustomMcpServerCommand(adminAuth, remoteInput);
+
+    const row = await db.query.customMcpServers.findFirst({
+      where: eq(customMcpServers.id, id),
+    });
+
+    expect(row?.headers?.['x-api-key']).toBeDefined();
+    expect(row?.headers?.['x-api-key']).not.toBe('secret-one');
+    expect(decrypt(row!.headers!['x-api-key']!)).toBe('secret-one');
+
+    const listed = await listCustomMcpServersCommand(adminAuth);
+
+    expect(listed).toHaveLength(1);
+    expect(listed[0]!.headerNames).toEqual(['x-api-key']);
+    expect(JSON.stringify(listed[0])).not.toContain('secret-one');
+  });
+
+  it('rejects duplicate names', async () => {
+    await createCustomMcpServerCommand(adminAuth, remoteInput);
+
+    await expect(
+      createCustomMcpServerCommand(adminAuth, remoteInput),
+    ).rejects.toThrow(/already exists/);
+  });
+
+  it('keeps existing header values on blank edit and re-encrypts new ones', async () => {
+    const { id } = await createCustomMcpServerCommand(adminAuth, remoteInput);
+
+    await updateCustomMcpServerCommand(adminAuth, {
+      id,
+      server: {
+        ...remoteInput,
+        headers: { 'x-api-key': '', 'x-second': 'second-value' },
+      },
+    });
+
+    const row = await db.query.customMcpServers.findFirst({
+      where: eq(customMcpServers.id, id),
+    });
+
+    expect(decrypt(row!.headers!['x-api-key']!)).toBe('secret-one');
+    expect(decrypt(row!.headers!['x-second']!)).toBe('second-value');
+  });
+
+  it('rejects blank header values on create', async () => {
+    await expect(
+      createCustomMcpServerCommand(adminAuth, {
+        ...remoteInput,
+        headers: { 'x-api-key': '' },
+      }),
+    ).rejects.toThrow(/value is required/);
+  });
+
+  it('clears OAuth connections when the URL changes', async () => {
+    const { id } = await createCustomMcpServerCommand(adminAuth, {
+      ...remoteInput,
+      authType: 'oauth',
+      headers: undefined,
+    });
+
+    await db.insert(mcpConnections).values({
+      userId: null,
+      mcpId: customMcpConnectionId(id),
+      connectionRole: 'default',
+      authConfig: {},
+      enabled: true,
+      authStatus: 'authenticated',
+      accessToken: 'stored-access-token',
+    });
+
+    const result = await updateCustomMcpServerCommand(adminAuth, {
+      id,
+      server: {
+        ...remoteInput,
+        authType: 'oauth',
+        headers: undefined,
+        url: 'https://other.example.com/mcp',
+      },
+    });
+
+    expect(result.credentialsCleared).toBe(true);
+
+    const connections = await db.query.mcpConnections.findMany({
+      where: eq(mcpConnections.mcpId, customMcpConnectionId(id)),
+    });
+
+    expect(connections).toHaveLength(0);
+  });
+
+  it('keeps OAuth connections when only headers change', async () => {
+    const { id } = await createCustomMcpServerCommand(adminAuth, remoteInput);
+
+    await db.insert(mcpConnections).values({
+      userId: null,
+      mcpId: customMcpConnectionId(id),
+      connectionRole: 'default',
+      authConfig: {},
+      enabled: true,
+      authStatus: 'authenticated',
+    });
+
+    const result = await updateCustomMcpServerCommand(adminAuth, {
+      id,
+      server: {
+        ...remoteInput,
+        headers: { 'x-api-key': 'rotated' },
+      },
+    });
+
+    expect(result.credentialsCleared).toBe(false);
+
+    const connections = await db.query.mcpConnections.findMany({
+      where: eq(mcpConnections.mcpId, customMcpConnectionId(id)),
+    });
+
+    expect(connections).toHaveLength(1);
+  });
+
+  it('creates stdio servers with encrypted env values', async () => {
+    const { id } = await createCustomMcpServerCommand(adminAuth, {
+      transport: 'stdio',
+      name: 'local-tools',
+      stdio: {
+        command: 'npx',
+        args: ['-y', '@example/server'],
+        env: { EXAMPLE_TOKEN: 'stdio-secret' },
+      },
+    });
+
+    const row = await db.query.customMcpServers.findFirst({
+      where: eq(customMcpServers.id, id),
+    });
+
+    expect(row?.url).toBeNull();
+    expect(row?.stdio?.command).toBe('npx');
+    expect(row?.stdio?.env?.EXAMPLE_TOKEN).not.toBe('stdio-secret');
+    expect(decrypt(row!.stdio!.env!.EXAMPLE_TOKEN!)).toBe('stdio-secret');
+
+    const listed = await listCustomMcpServersCommand(adminAuth);
+
+    expect(listed[0]!.transport).toBe('stdio');
+    expect(listed[0]!.stdioEnvNames).toEqual(['EXAMPLE_TOKEN']);
+    expect(JSON.stringify(listed[0])).not.toContain('stdio-secret');
+  });
+
+  it('deletes servers together with their connections', async () => {
+    const { id } = await createCustomMcpServerCommand(adminAuth, remoteInput);
+
+    await db.insert(mcpConnections).values({
+      userId: null,
+      mcpId: customMcpConnectionId(id),
+      connectionRole: 'default',
+      authConfig: {},
+      enabled: true,
+    });
+
+    const result = await deleteCustomMcpServerCommand(adminAuth, { id });
+
+    expect(result.deleted).toBe(true);
+    expect(
+      await db.query.customMcpServers.findMany({
+        where: eq(customMcpServers.id, id),
+      }),
+    ).toHaveLength(0);
+    expect(
+      await db.query.mcpConnections.findMany({
+        where: eq(mcpConnections.mcpId, customMcpConnectionId(id)),
+      }),
+    ).toHaveLength(0);
+  });
+
+  it('toggles enabled and persists disabled tools', async () => {
+    const { id } = await createCustomMcpServerCommand(adminAuth, remoteInput);
+
+    await setCustomMcpServerDisabledToolsCommand(adminAuth, {
+      id,
+      disabledTools: ['dangerous_tool'],
+    });
+
+    let listed = await listCustomMcpServersCommand(adminAuth);
+    expect(listed[0]!.disabledTools).toEqual(['dangerous_tool']);
+
+    await setCustomMcpServerEnabledCommand(adminAuth, { id, enabled: false });
+
+    listed = await listCustomMcpServersCommand(adminAuth);
+    expect(listed[0]!.enabled).toBe(false);
+  });
+
+  it('kill switch blocks mutations with a clear message', () => {
+    expect(() => assertCustomMcpEnabled('true')).toThrow(
+      CUSTOM_MCP_DISABLED_MESSAGE,
+    );
+    expect(() => assertCustomMcpEnabled(undefined)).not.toThrow();
+  });
+});

--- a/apps/web/src/trpc/commands/custom-mcp-servers/index.ts
+++ b/apps/web/src/trpc/commands/custom-mcp-servers/index.ts
@@ -331,6 +331,85 @@ export async function deleteCustomMcpServerCommand(
   return { deleted: true };
 }
 
+/**
+ * Mint (or reset) the pending deployment-scoped OAuth connection for a
+ * custom server and return the initiate URL, mirroring connectMcpCommand.
+ */
+export async function connectCustomMcpServerCommand(
+  auth: UserAuthSuccess,
+  input: { id: string; redirectTo?: string },
+) {
+  assertAdmin(auth);
+  assertCustomMcpEnabled();
+
+  const server = await db.query.customMcpServers.findFirst({
+    where: eq(customMcpServers.id, input.id),
+  });
+
+  if (!server) {
+    throw new Error('Custom MCP server not found.');
+  }
+
+  if (server.authType !== 'oauth' || !server.url) {
+    throw new Error('This custom MCP server does not use OAuth.');
+  }
+
+  if (
+    input.redirectTo &&
+    (!input.redirectTo.startsWith('/') || input.redirectTo.startsWith('//'))
+  ) {
+    throw new Error('redirectTo must be a relative path');
+  }
+
+  const [connection] = await db
+    .insert(mcpConnections)
+    .values({
+      userId: null,
+      mcpId: customMcpConnectionId(server.id),
+      connectionRole: 'default',
+      authConfig: {},
+      enabled: false,
+      authStatus: 'pending',
+    })
+    .onConflictDoUpdate({
+      target: [
+        mcpConnections.userId,
+        mcpConnections.mcpId,
+        mcpConnections.connectionRole,
+      ],
+      set: {
+        authConfig: {},
+        enabled: false,
+        authStatus: 'pending',
+        updatedAt: new Date(),
+      },
+    })
+    .returning();
+
+  if (!connection) {
+    throw new Error('Failed to create MCP connection');
+  }
+
+  // Relative path so the browser stays on its current domain.
+  return input.redirectTo
+    ? `/api/mcp-oauth/initiate/${connection.id}?redirectTo=${encodeURIComponent(input.redirectTo)}`
+    : `/api/mcp-oauth/initiate/${connection.id}`;
+}
+
+/** Drop the stored OAuth connection (tokens) without deleting the server. */
+export async function disconnectCustomMcpServerCommand(
+  auth: UserAuthSuccess,
+  input: { id: string },
+) {
+  assertAdmin(auth);
+
+  await db
+    .delete(mcpConnections)
+    .where(eq(mcpConnections.mcpId, customMcpConnectionId(input.id)));
+
+  return { disconnected: true };
+}
+
 export async function setCustomMcpServerEnabledCommand(
   auth: UserAuthSuccess,
   input: { id: string; enabled: boolean },

--- a/apps/web/src/trpc/commands/custom-mcp-servers/index.ts
+++ b/apps/web/src/trpc/commands/custom-mcp-servers/index.ts
@@ -47,7 +47,7 @@ export function getCustomMcpAvailabilityCommand() {
  * header and stdio-env *names* round-trip so edit dialogs can render rows,
  * but values never leave the server.
  */
-export interface CustomMcpServerListEntry {
+interface CustomMcpServerListEntry {
   id: string;
   name: string;
   transport: 'remote' | 'stdio';

--- a/apps/web/src/trpc/commands/custom-mcp-servers/index.ts
+++ b/apps/web/src/trpc/commands/custom-mcp-servers/index.ts
@@ -47,7 +47,7 @@ export function getCustomMcpAvailabilityCommand() {
  * header and stdio-env *names* round-trip so edit dialogs can render rows,
  * but values never leave the server.
  */
-interface CustomMcpServerListEntry {
+export interface CustomMcpServerListEntry {
   id: string;
   name: string;
   transport: 'remote' | 'stdio';

--- a/apps/web/src/trpc/commands/custom-mcp-servers/index.ts
+++ b/apps/web/src/trpc/commands/custom-mcp-servers/index.ts
@@ -4,12 +4,16 @@ import {
   customMcpServers,
   db,
   eq,
+  isNull,
   mcpConnections,
 } from '@roomote/db/server';
-import { encrypt } from '@roomote/db/encryption';
+import { decrypt, encrypt } from '@roomote/db/encryption';
+import { getValidAccessToken } from '@roomote/sdk/server';
+import { safeFetch } from '@roomote/sdk/server/safe-fetch';
 import {
   MAX_CUSTOM_MCP_SERVERS,
   customMcpConnectionId,
+  parseMcpJsonRpcPayload,
   type CustomMcpRemoteServerInput,
   type CustomMcpServerInput,
   type CustomMcpStdioServerInput,
@@ -329,6 +333,180 @@ export async function deleteCustomMcpServerCommand(
   );
 
   return { deleted: true };
+}
+
+type ListedCustomMcpTool = {
+  name: string;
+  description: string | null;
+  enabled: boolean;
+};
+
+async function callCustomMcpServer(input: {
+  url: string;
+  headers: Record<string, string>;
+  method: string;
+  params: unknown;
+  sessionId?: string | null;
+  requestId: number;
+}): Promise<{
+  payload: unknown;
+  sessionId: string | null;
+  response: Response;
+}> {
+  const response = await safeFetch(input.url, {
+    allowedPrivateCidrs: Env.R_CUSTOM_MCP_ALLOWED_PRIVATE_CIDRS,
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream',
+      ...(input.sessionId ? { 'mcp-session-id': input.sessionId } : {}),
+      ...input.headers,
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: input.requestId,
+      method: input.method,
+      params: input.params,
+    }),
+  });
+
+  const bodyText = await response.text();
+
+  if (!response.ok) {
+    throw new Error(
+      `Custom MCP server request '${input.method}' failed (${response.status} ${response.statusText})`,
+    );
+  }
+
+  return {
+    payload: parseMcpJsonRpcPayload(
+      bodyText,
+      response.headers.get('content-type'),
+    ),
+    sessionId: response.headers.get('mcp-session-id'),
+    response,
+  };
+}
+
+/**
+ * List the tools a custom remote server exposes, flagged with the stored
+ * deny-list state. The fetch runs control-plane-side through the SSRF guard
+ * with the server's real credentials (which never reach the browser).
+ */
+export async function listCustomMcpServerToolsCommand(
+  auth: UserAuthSuccess,
+  input: { id: string },
+): Promise<{ tools: ListedCustomMcpTool[] }> {
+  assertAdmin(auth);
+  assertCustomMcpEnabled();
+
+  const server = await db.query.customMcpServers.findFirst({
+    where: eq(customMcpServers.id, input.id),
+  });
+
+  if (!server) {
+    throw new Error('Custom MCP server not found.');
+  }
+
+  if (!server.url || server.stdio) {
+    throw new Error(
+      'Local (stdio) servers run inside the task sandbox; their tools cannot be listed from Settings.',
+    );
+  }
+
+  const headers: Record<string, string> = {};
+
+  if (server.authType === 'static_headers' && server.headers) {
+    for (const [name, encryptedValue] of Object.entries(server.headers)) {
+      headers[name] = decrypt(encryptedValue);
+    }
+  } else if (server.authType === 'oauth') {
+    const connection = await db.query.mcpConnections.findFirst({
+      where: and(
+        eq(mcpConnections.mcpId, customMcpConnectionId(server.id)),
+        isNull(mcpConnections.userId),
+      ),
+      columns: { id: true },
+    });
+
+    const accessToken = connection
+      ? await getValidAccessToken(connection.id, server.url)
+      : null;
+
+    if (!accessToken) {
+      throw new Error(
+        `'${server.name}' needs to be connected before tools can be managed.`,
+      );
+    }
+
+    headers['authorization'] = `Bearer ${accessToken}`;
+  }
+
+  // Streamable-http servers may require an initialized session before
+  // answering tools/list; try the session-less call first and fall back.
+  let toolsPayload: unknown;
+
+  try {
+    const direct = await callCustomMcpServer({
+      url: server.url,
+      headers,
+      method: 'tools/list',
+      params: {},
+      requestId: 1,
+    });
+    toolsPayload = direct.payload;
+  } catch {
+    const initialized = await callCustomMcpServer({
+      url: server.url,
+      headers,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: { name: 'Roomote', version: '1.0.0' },
+      },
+      requestId: 1,
+    });
+
+    const listed = await callCustomMcpServer({
+      url: server.url,
+      headers,
+      method: 'tools/list',
+      params: {},
+      sessionId: initialized.sessionId,
+      requestId: 2,
+    });
+    toolsPayload = listed.payload;
+  }
+
+  const result =
+    toolsPayload && typeof toolsPayload === 'object' && 'result' in toolsPayload
+      ? (toolsPayload as { result?: { tools?: unknown } }).result
+      : undefined;
+
+  if (!result || !Array.isArray(result.tools)) {
+    throw new Error(
+      `'${server.name}' did not return a tool list. Check that the URL points at a streamable-HTTP MCP endpoint.`,
+    );
+  }
+
+  const disabled = new Set(server.disabledTools ?? []);
+
+  return {
+    tools: result.tools
+      .filter(
+        (tool): tool is { name: string; description?: string } =>
+          Boolean(tool) &&
+          typeof tool === 'object' &&
+          typeof (tool as { name?: unknown }).name === 'string',
+      )
+      .map((tool) => ({
+        name: tool.name,
+        description:
+          typeof tool.description === 'string' ? tool.description : null,
+        enabled: !disabled.has(tool.name),
+      })),
+  };
 }
 
 /**

--- a/apps/web/src/trpc/commands/custom-mcp-servers/index.ts
+++ b/apps/web/src/trpc/commands/custom-mcp-servers/index.ts
@@ -389,6 +389,38 @@ async function callCustomMcpServer(input: {
 }
 
 /**
+ * Best-effort `notifications/initialized` between `initialize` and
+ * `tools/list`: the MCP lifecycle requires it, and strict servers refuse
+ * requests until the client confirms initialization, while lenient ones
+ * simply ignore it. Failures are non-fatal; if the server truly required the
+ * notification, the following `tools/list` fails loudly on its own.
+ */
+async function sendCustomMcpInitializedNotification(input: {
+  url: string;
+  headers: Record<string, string>;
+  sessionId: string | null;
+}): Promise<void> {
+  try {
+    await safeFetch(input.url, {
+      allowedPrivateCidrs: Env.R_CUSTOM_MCP_ALLOWED_PRIVATE_CIDRS,
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        ...(input.sessionId ? { 'mcp-session-id': input.sessionId } : {}),
+        ...input.headers,
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'notifications/initialized',
+      }),
+    });
+  } catch {
+    // Non-fatal; see above.
+  }
+}
+
+/**
  * List the tools a custom remote server exposes, flagged with the stored
  * deny-list state. The fetch runs control-plane-side through the SSRF guard
  * with the server's real credentials (which never reach the browser).
@@ -466,6 +498,12 @@ export async function listCustomMcpServerToolsCommand(
         clientInfo: { name: 'Roomote', version: '1.0.0' },
       },
       requestId: 1,
+    });
+
+    await sendCustomMcpInitializedNotification({
+      url: server.url,
+      headers,
+      sessionId: initialized.sessionId,
     });
 
     const listed = await callCustomMcpServer({
@@ -615,22 +653,19 @@ export async function setCustomMcpServerDisabledToolsCommand(
   assertAdmin(auth);
   assertCustomMcpEnabled();
 
+  // Deliberately no enabled filter: adjusting the deny list on a disabled
+  // server is a natural part of preparing it for re-enablement.
   const [updated] = await db
     .update(customMcpServers)
     .set({
       disabledTools: input.disabledTools,
       updatedAt: new Date(),
     })
-    .where(
-      and(
-        eq(customMcpServers.id, input.id),
-        eq(customMcpServers.enabled, true),
-      ),
-    )
+    .where(eq(customMcpServers.id, input.id))
     .returning({ id: customMcpServers.id });
 
   if (!updated) {
-    throw new Error('Custom MCP server not found or disabled.');
+    throw new Error('Custom MCP server not found.');
   }
 
   return { disabledTools: input.disabledTools };

--- a/apps/web/src/trpc/commands/custom-mcp-servers/index.ts
+++ b/apps/web/src/trpc/commands/custom-mcp-servers/index.ts
@@ -1,0 +1,380 @@
+import {
+  and,
+  count,
+  customMcpServers,
+  db,
+  eq,
+  mcpConnections,
+} from '@roomote/db/server';
+import { encrypt } from '@roomote/db/encryption';
+import {
+  MAX_CUSTOM_MCP_SERVERS,
+  customMcpConnectionId,
+  type CustomMcpRemoteServerInput,
+  type CustomMcpServerInput,
+  type CustomMcpStdioServerInput,
+} from '@roomote/types';
+import type { UserAuthSuccess } from '@/types';
+import { Env, isCustomMcpDisabled } from '@/lib/server/env';
+
+export const CUSTOM_MCP_DISABLED_MESSAGE =
+  'Custom MCP servers are disabled by the deployment operator.';
+
+function assertAdmin(auth: UserAuthSuccess) {
+  if (!auth.isAdmin) {
+    throw new Error('Unauthorized');
+  }
+}
+
+export function assertCustomMcpEnabled(
+  disabledFlag: string | boolean | undefined = Env.R_CUSTOM_MCP_DISABLED,
+) {
+  if (isCustomMcpDisabled(disabledFlag)) {
+    throw new Error(CUSTOM_MCP_DISABLED_MESSAGE);
+  }
+}
+
+export function getCustomMcpAvailabilityCommand() {
+  return { enabled: !isCustomMcpDisabled(Env.R_CUSTOM_MCP_DISABLED) };
+}
+
+/**
+ * Browser-facing row shape. Secret material is omitted by construction:
+ * header and stdio-env *names* round-trip so edit dialogs can render rows,
+ * but values never leave the server.
+ */
+export interface CustomMcpServerListEntry {
+  id: string;
+  name: string;
+  transport: 'remote' | 'stdio';
+  url: string | null;
+  authType: 'none' | 'static_headers' | 'oauth';
+  headerNames: string[];
+  stdioCommand: string | null;
+  stdioArgs: string[];
+  stdioEnvNames: string[];
+  disabledTools: string[];
+  hasManualClient: boolean;
+  oauthResourceIndicatorDisabled: boolean;
+  authStatus: 'pending' | 'authenticated' | 'error' | null;
+  enabled: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export async function listCustomMcpServersCommand(
+  auth: UserAuthSuccess,
+): Promise<CustomMcpServerListEntry[]> {
+  assertAdmin(auth);
+
+  const servers = await db.query.customMcpServers.findMany({
+    orderBy: (table, { asc }) => [asc(table.name)],
+  });
+
+  const connectionRows =
+    servers.length > 0
+      ? await db.query.mcpConnections.findMany({
+          where: (table, { inArray: whereInArray }) =>
+            whereInArray(
+              table.mcpId,
+              servers.map((server) => customMcpConnectionId(server.id)),
+            ),
+          columns: { mcpId: true, authStatus: true },
+        })
+      : [];
+
+  const authStatusByMcpId = new Map(
+    connectionRows.map((row) => [row.mcpId, row.authStatus]),
+  );
+
+  return servers.map((server) => ({
+    id: server.id,
+    name: server.name,
+    transport: server.stdio ? 'stdio' : 'remote',
+    url: server.url,
+    authType: server.authType,
+    headerNames: Object.keys(server.headers ?? {}),
+    stdioCommand: server.stdio?.command ?? null,
+    stdioArgs: server.stdio?.args ?? [],
+    stdioEnvNames: Object.keys(server.stdio?.env ?? {}),
+    disabledTools: server.disabledTools ?? [],
+    hasManualClient: Boolean(server.manualClientId),
+    oauthResourceIndicatorDisabled: server.oauthResourceIndicatorDisabled,
+    authStatus:
+      server.authType === 'oauth'
+        ? (authStatusByMcpId.get(customMcpConnectionId(server.id)) ?? 'pending')
+        : null,
+    enabled: server.enabled,
+    createdAt: server.createdAt,
+    updatedAt: server.updatedAt,
+  }));
+}
+
+/**
+ * Encrypt each secret value individually so names stay readable for the list
+ * endpoint while values are protected at rest. An empty-string value on an
+ * update means "keep the stored value" (the browser never has the original to
+ * echo back); on create it is rejected upstream by the caller.
+ */
+function encryptSecretValues(
+  next: Record<string, string> | undefined,
+  existing: Record<string, string> | null | undefined,
+  { allowKeepExisting }: { allowKeepExisting: boolean },
+): Record<string, string> | null {
+  if (!next) {
+    return null;
+  }
+
+  const result: Record<string, string> = {};
+
+  for (const [name, value] of Object.entries(next)) {
+    if (value === '') {
+      const kept = allowKeepExisting ? existing?.[name] : undefined;
+
+      if (kept === undefined) {
+        throw new Error(`A value is required for '${name}'.`);
+      }
+
+      result[name] = kept;
+    } else {
+      result[name] = encrypt(value);
+    }
+  }
+
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+function remoteColumns(
+  input: CustomMcpRemoteServerInput,
+  existing?: {
+    headers: Record<string, string> | null;
+    manualClientSecret: string | null;
+  },
+) {
+  return {
+    url: input.url,
+    authType: input.authType,
+    headers: encryptSecretValues(input.headers, existing?.headers, {
+      allowKeepExisting: existing !== undefined,
+    }),
+    stdio: null,
+    manualClientId:
+      input.authType === 'oauth' ? (input.manualClientId ?? null) : null,
+    manualClientSecret:
+      input.authType === 'oauth'
+        ? input.manualClientSecret === '' ||
+          input.manualClientSecret === undefined
+          ? (existing?.manualClientSecret ?? null)
+          : input.manualClientSecret
+        : null,
+    oauthResourceIndicatorDisabled:
+      input.oauthResourceIndicatorDisabled ?? false,
+  };
+}
+
+function stdioColumns(
+  input: CustomMcpStdioServerInput,
+  existing?: { stdioEnv: Record<string, string> | null },
+) {
+  return {
+    url: null,
+    authType: 'none' as const,
+    headers: null,
+    stdio: {
+      command: input.stdio.command,
+      ...(input.stdio.args ? { args: input.stdio.args } : {}),
+      ...(input.stdio.env
+        ? {
+            env:
+              encryptSecretValues(input.stdio.env, existing?.stdioEnv, {
+                allowKeepExisting: existing !== undefined,
+              }) ?? undefined,
+          }
+        : {}),
+    },
+    manualClientId: null,
+    manualClientSecret: null,
+    oauthResourceIndicatorDisabled: false,
+  };
+}
+
+export async function createCustomMcpServerCommand(
+  auth: UserAuthSuccess,
+  input: CustomMcpServerInput,
+) {
+  assertAdmin(auth);
+  assertCustomMcpEnabled();
+
+  const [countRow] = await db.select({ value: count() }).from(customMcpServers);
+
+  if ((countRow?.value ?? 0) >= MAX_CUSTOM_MCP_SERVERS) {
+    throw new Error(
+      `At most ${MAX_CUSTOM_MCP_SERVERS} custom MCP servers are supported.`,
+    );
+  }
+
+  const columns =
+    input.transport === 'remote' ? remoteColumns(input) : stdioColumns(input);
+
+  const [created] = await db
+    .insert(customMcpServers)
+    .values({
+      name: input.name,
+      ...columns,
+      createdByUserId: auth.userId,
+    })
+    .onConflictDoNothing({ target: [customMcpServers.name] })
+    .returning({ id: customMcpServers.id });
+
+  if (!created) {
+    throw new Error(
+      `A custom MCP server named '${input.name}' already exists.`,
+    );
+  }
+
+  console.log(
+    `[custom-mcp-servers] created '${input.name}' (${input.transport}) by user ${auth.userId}`,
+  );
+
+  return { id: created.id };
+}
+
+export async function updateCustomMcpServerCommand(
+  auth: UserAuthSuccess,
+  input: { id: string; server: CustomMcpServerInput },
+) {
+  assertAdmin(auth);
+  assertCustomMcpEnabled();
+
+  const existing = await db.query.customMcpServers.findFirst({
+    where: eq(customMcpServers.id, input.id),
+  });
+
+  if (!existing) {
+    throw new Error('Custom MCP server not found.');
+  }
+
+  if (existing.name !== input.server.name) {
+    throw new Error('Custom MCP server names cannot be changed.');
+  }
+
+  const columns =
+    input.server.transport === 'remote'
+      ? remoteColumns(input.server, {
+          headers: existing.headers,
+          manualClientSecret: existing.manualClientSecret,
+        })
+      : stdioColumns(input.server, { stdioEnv: existing.stdio?.env ?? null });
+
+  // Editing the URL or auth mode of a connected server re-targets the stored
+  // credentials: without this reset, the proxy would inject the old server's
+  // Bearer token into the new URL on the next task — a one-field
+  // credential-exfiltration primitive. Force a reconnect instead.
+  const credentialTargetChanged =
+    columns.url !== existing.url || columns.authType !== existing.authType;
+
+  await db.transaction(async (tx) => {
+    await tx
+      .update(customMcpServers)
+      .set({
+        ...columns,
+        ...(credentialTargetChanged
+          ? { oauthServerMetadata: null, oauthServerMetadataFetchedAt: null }
+          : {}),
+        updatedAt: new Date(),
+      })
+      .where(eq(customMcpServers.id, input.id));
+
+    if (credentialTargetChanged) {
+      await tx
+        .delete(mcpConnections)
+        .where(eq(mcpConnections.mcpId, customMcpConnectionId(input.id)));
+    }
+  });
+
+  console.log(
+    `[custom-mcp-servers] updated '${existing.name}' by user ${auth.userId}` +
+      (credentialTargetChanged
+        ? ' (credential target changed; tokens cleared)'
+        : ''),
+  );
+
+  return { credentialsCleared: credentialTargetChanged };
+}
+
+export async function deleteCustomMcpServerCommand(
+  auth: UserAuthSuccess,
+  input: { id: string },
+) {
+  assertAdmin(auth);
+
+  const existing = await db.query.customMcpServers.findFirst({
+    where: eq(customMcpServers.id, input.id),
+    columns: { name: true },
+  });
+
+  if (!existing) {
+    return { deleted: false };
+  }
+
+  await db.transaction(async (tx) => {
+    await tx
+      .delete(mcpConnections)
+      .where(eq(mcpConnections.mcpId, customMcpConnectionId(input.id)));
+    await tx.delete(customMcpServers).where(eq(customMcpServers.id, input.id));
+  });
+
+  console.log(
+    `[custom-mcp-servers] deleted '${existing.name}' by user ${auth.userId}`,
+  );
+
+  return { deleted: true };
+}
+
+export async function setCustomMcpServerEnabledCommand(
+  auth: UserAuthSuccess,
+  input: { id: string; enabled: boolean },
+) {
+  assertAdmin(auth);
+  assertCustomMcpEnabled();
+
+  const [updated] = await db
+    .update(customMcpServers)
+    .set({ enabled: input.enabled, updatedAt: new Date() })
+    .where(eq(customMcpServers.id, input.id))
+    .returning({ id: customMcpServers.id });
+
+  if (!updated) {
+    throw new Error('Custom MCP server not found.');
+  }
+
+  return { enabled: input.enabled };
+}
+
+export async function setCustomMcpServerDisabledToolsCommand(
+  auth: UserAuthSuccess,
+  input: { id: string; disabledTools: string[] },
+) {
+  assertAdmin(auth);
+  assertCustomMcpEnabled();
+
+  const [updated] = await db
+    .update(customMcpServers)
+    .set({
+      disabledTools: input.disabledTools,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(customMcpServers.id, input.id),
+        eq(customMcpServers.enabled, true),
+      ),
+    )
+    .returning({ id: customMcpServers.id });
+
+  if (!updated) {
+    throw new Error('Custom MCP server not found or disabled.');
+  }
+
+  return { disabledTools: input.disabledTools };
+}

--- a/apps/web/src/trpc/commands/setup/index.ts
+++ b/apps/web/src/trpc/commands/setup/index.ts
@@ -322,9 +322,19 @@ async function getSetupCompletionMcpRecommendationContext(
     return null;
   }
 
-  const configuredCustomServerIds = Object.keys(
-    (matchingEnvironment.config as EnvironmentConfig).mcpServers ?? {},
-  );
+  // Environment-scoped custom servers plus deployment-wide custom servers:
+  // both mean "this service is already wired", so the setup agent should not
+  // recommend configuring it again.
+  const deploymentCustomServers = await db.query.customMcpServers.findMany({
+    where: (table, { eq: whereEq }) => whereEq(table.enabled, true),
+    columns: { name: true },
+  });
+  const configuredCustomServerIds = [
+    ...Object.keys(
+      (matchingEnvironment.config as EnvironmentConfig).mcpServers ?? {},
+    ),
+    ...deploymentCustomServers.map(({ name }) => name),
+  ];
   const enabledIntegrationIds = [
     ...new Set([
       ...enabledDeploymentMcpRows.map(({ mcpId }) => mcpId),

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -213,8 +213,10 @@ import {
 } from '../commands/mcp-connections';
 
 import {
+  connectCustomMcpServerCommand,
   createCustomMcpServerCommand,
   deleteCustomMcpServerCommand,
+  disconnectCustomMcpServerCommand,
   getCustomMcpAvailabilityCommand,
   listCustomMcpServersCommand,
   setCustomMcpServerDisabledToolsCommand,
@@ -1623,6 +1625,20 @@ export const appRouter = createRouter({
       )
       .mutation(({ ctx: { auth }, input }) =>
         setCustomMcpServerDisabledToolsCommand(auth, input),
+      ),
+
+    connect: protectedProcedure
+      .input(
+        z.object({ id: z.string().uuid(), redirectTo: z.string().optional() }),
+      )
+      .mutation(({ ctx: { auth }, input }) =>
+        connectCustomMcpServerCommand(auth, input),
+      ),
+
+    disconnect: protectedProcedure
+      .input(z.object({ id: z.string().uuid() }))
+      .mutation(({ ctx: { auth }, input }) =>
+        disconnectCustomMcpServerCommand(auth, input),
       ),
   }),
 

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -218,6 +218,7 @@ import {
   deleteCustomMcpServerCommand,
   disconnectCustomMcpServerCommand,
   getCustomMcpAvailabilityCommand,
+  listCustomMcpServerToolsCommand,
   listCustomMcpServersCommand,
   setCustomMcpServerDisabledToolsCommand,
   setCustomMcpServerEnabledCommand,
@@ -1625,6 +1626,12 @@ export const appRouter = createRouter({
       )
       .mutation(({ ctx: { auth }, input }) =>
         setCustomMcpServerDisabledToolsCommand(auth, input),
+      ),
+
+    listTools: protectedProcedure
+      .input(z.object({ id: z.string().uuid() }))
+      .query(({ ctx: { auth }, input }) =>
+        listCustomMcpServerToolsCommand(auth, input),
       ),
 
     connect: protectedProcedure

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -19,6 +19,7 @@ import {
   SETUP_AUTH_PROVIDER_IDS,
   isSetupModelProviderId,
   isOpenAiCompatibleProviderId,
+  customMcpServerInputSchema,
   prActions,
   sourceControlProviderSchema,
   sourceControlTokenBackedProviderSchema,
@@ -210,6 +211,16 @@ import {
   connectMcpCommand,
   disconnectMcpCommand,
 } from '../commands/mcp-connections';
+
+import {
+  createCustomMcpServerCommand,
+  deleteCustomMcpServerCommand,
+  getCustomMcpAvailabilityCommand,
+  listCustomMcpServersCommand,
+  setCustomMcpServerDisabledToolsCommand,
+  setCustomMcpServerEnabledCommand,
+  updateCustomMcpServerCommand,
+} from '../commands/custom-mcp-servers';
 
 import {
   getEnvVarsCommand,
@@ -1565,6 +1576,53 @@ export const appRouter = createRouter({
       )
       .mutation(({ ctx: { auth }, input }) =>
         restoreTaskRunSnapshotCommand(auth, input),
+      ),
+  }),
+
+  customMcpServers: createRouter({
+    availability: protectedProcedure.query(() =>
+      getCustomMcpAvailabilityCommand(),
+    ),
+
+    list: protectedProcedure.query(({ ctx: { auth } }) =>
+      listCustomMcpServersCommand(auth),
+    ),
+
+    create: protectedProcedure
+      .input(customMcpServerInputSchema)
+      .mutation(({ ctx: { auth }, input }) =>
+        createCustomMcpServerCommand(auth, input),
+      ),
+
+    update: protectedProcedure
+      .input(
+        z.object({ id: z.string().uuid(), server: customMcpServerInputSchema }),
+      )
+      .mutation(({ ctx: { auth }, input }) =>
+        updateCustomMcpServerCommand(auth, input),
+      ),
+
+    delete: protectedProcedure
+      .input(z.object({ id: z.string().uuid() }))
+      .mutation(({ ctx: { auth }, input }) =>
+        deleteCustomMcpServerCommand(auth, input),
+      ),
+
+    setEnabled: protectedProcedure
+      .input(z.object({ id: z.string().uuid(), enabled: z.boolean() }))
+      .mutation(({ ctx: { auth }, input }) =>
+        setCustomMcpServerEnabledCommand(auth, input),
+      ),
+
+    setDisabledTools: protectedProcedure
+      .input(
+        z.object({
+          id: z.string().uuid(),
+          disabledTools: z.array(z.string().min(1)),
+        }),
+      )
+      .mutation(({ ctx: { auth }, input }) =>
+        setCustomMcpServerDisabledToolsCommand(auth, input),
       ),
   }),
 

--- a/apps/worker/src/commands/setup/__tests__/setup-mcps.test.ts
+++ b/apps/worker/src/commands/setup/__tests__/setup-mcps.test.ts
@@ -368,7 +368,7 @@ describe('resolveBuiltInMcpServers', () => {
     expect(roomoteConfig.type).toBe('stdio');
     expect(roomoteConfig.command).toBe('node');
     expect(warnSpy).toHaveBeenCalledWith(
-      "[resolveBuiltInMcpServers] Skipping custom MCP 'roomote': name conflicts with an existing MCP server",
+      "[resolveBuiltInMcpServers] Skipping environment custom MCP 'roomote': name conflicts with an existing MCP server",
     );
   });
 
@@ -981,5 +981,122 @@ describe('resolveBuiltInMcpServers', () => {
     const parsed = { mcpServers: resolveBuiltInMcpServers() };
 
     expect(Object.keys(parsed.mcpServers).sort()).toEqual(['roomote']);
+  });
+});
+
+describe('resolveBuiltInMcpServers deployment custom servers', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env = {
+      ...originalEnv,
+      HOME: '/home/testuser',
+      MISE_DATA_DIR: '/opt/mise',
+      TRPC_URL: 'https://api.test.com',
+    };
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  const taskEnv = {
+    ROOMOTE_CLOUD_TOKEN: 'test-cloud-token',
+    R_APP_URL: 'https://app.test.com',
+  };
+
+  it('rewrites custom proxy entries to the API origin with the run token', () => {
+    const resolved = resolveBuiltInMcpServers(taskEnv, {
+      userMcpServers: {
+        'internal-tools': {
+          url: 'https://app.test.com/api/mcp/custom/4c72c9dd-3f5e-4d3e-9f7a-2c1b8a6e5d40',
+          headers: { 'X-MCP-Client': 'Roomote' },
+        },
+      },
+    });
+
+    expect(resolved['internal-tools']).toEqual({
+      type: 'streamable-http',
+      url: 'https://api.test.com/api/mcp/custom/4c72c9dd-3f5e-4d3e-9f7a-2c1b8a6e5d40',
+      headers: {
+        'X-MCP-Client': 'Roomote',
+        Authorization: 'Bearer test-cloud-token',
+      },
+    });
+  });
+
+  it('skips custom proxy entries when the cloud token is missing', () => {
+    const resolved = resolveBuiltInMcpServers(
+      {},
+      {
+        userMcpServers: {
+          'internal-tools': {
+            url: 'https://app.test.com/api/mcp/custom/4c72c9dd-3f5e-4d3e-9f7a-2c1b8a6e5d40',
+          },
+        },
+      },
+    );
+
+    expect(resolved['internal-tools']).toBeUndefined();
+  });
+
+  it('merges deployment stdio servers after environment servers', () => {
+    const resolved = resolveBuiltInMcpServers(
+      taskEnv,
+      undefined,
+      {
+        'shared-name': { url: 'https://env.example.com/mcp' },
+      },
+      { MY_DEPLOYMENT_SECRET: 'operator-value' },
+      {
+        'shared-name': { command: 'deployment-loses' },
+        'local-tools': {
+          command: 'npx',
+          args: ['-y', '@example/server'],
+          env: { EXAMPLE_TOKEN: '${MY_DEPLOYMENT_SECRET}' },
+        },
+      },
+    );
+
+    // Environment wins the name collision (more specific scope).
+    expect(resolved['shared-name']).toMatchObject({
+      type: 'streamable-http',
+      url: 'https://env.example.com/mcp',
+    });
+
+    // Deployment stdio servers ride the same substitution + mise pipeline.
+    expect(resolved['local-tools']).toMatchObject({
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', '@example/server'],
+    });
+    expect(
+      (resolved['local-tools'] as { env: Record<string, string> }).env,
+    ).toMatchObject({
+      EXAMPLE_TOKEN: 'operator-value',
+      MISE_DATA_DIR: '/opt/mise',
+    });
+  });
+
+  it('redacts reserved references in deployment stdio env values', () => {
+    const resolved = resolveBuiltInMcpServers(
+      taskEnv,
+      undefined,
+      undefined,
+      undefined,
+      {
+        'local-tools': {
+          command: 'npx',
+          env: { STOLEN: '${ROOMOTE_CLOUD_TOKEN}' },
+        },
+      },
+    );
+
+    const env = (resolved['local-tools'] as { env: Record<string, string> })
+      .env;
+
+    expect(env.STOLEN).not.toContain('test-cloud-token');
+    expect(env.STOLEN).toBe('roomote-refused-reserved-env-reference');
   });
 });

--- a/apps/worker/src/commands/setup/setup-mcps.ts
+++ b/apps/worker/src/commands/setup/setup-mcps.ts
@@ -1,6 +1,7 @@
 import * as path from 'node:path';
 
 import {
+  CUSTOM_MCP_PROXY_PATH_PREFIX,
   getMcpIntegrationUpstreamUrl,
   isReservedRuntimeMcpEnvVarName,
   isRoomoteNamespacedEnvVarName,
@@ -235,6 +236,24 @@ function parseUrl(url: string): URL | null {
   }
 }
 
+/**
+ * Returns the `/api/mcp/custom/<id>` path when the URL is a deployment
+ * custom-server proxy entry (path-only or absolute), else null.
+ */
+function parseCustomMcpProxyPath(url: string): string | null {
+  if (url.startsWith(CUSTOM_MCP_PROXY_PATH_PREFIX)) {
+    return url;
+  }
+
+  const parsed = parseUrl(url);
+
+  if (parsed?.pathname.startsWith(CUSTOM_MCP_PROXY_PATH_PREFIX)) {
+    return parsed.pathname;
+  }
+
+  return null;
+}
+
 function isExpectedProxyUrl(url: string, proxyPath: string): boolean {
   if (url === proxyPath) {
     return true;
@@ -300,6 +319,7 @@ export function resolveBuiltInMcpServers(
   integrations?: IntegrationMcpOptions,
   environmentMcpServers?: EnvironmentMcpServers,
   operatorEnvVars?: Record<string, string>,
+  deploymentMcpServers?: EnvironmentMcpServers,
 ): Record<string, McpServerConfig> {
   // The extension's StdioClientTransport only inherits a minimal set of
   // env vars (HOME, PATH, SHELL, TERM, USER) via getDefaultEnvironment().
@@ -408,6 +428,34 @@ export function resolveBuiltInMcpServers(
         continue;
       }
 
+      // Deployment custom servers arrive as Roomote proxy URLs; rewrite the
+      // origin to the API base and inject the run token, exactly like the
+      // curated integration proxies above. The real upstream credentials
+      // stay server-side.
+      const customProxyPath = parseCustomMcpProxyPath(config.url);
+
+      if (customProxyPath) {
+        const apiUrl = resolveApiBaseUrl(taskEnv);
+        const cloudToken = taskEnv?.ROOMOTE_CLOUD_TOKEN;
+
+        if (!apiUrl || !cloudToken) {
+          console.warn(
+            `[resolveBuiltInMcpServers] Skipping custom MCP '${name}': missing API base URL or ROOMOTE_CLOUD_TOKEN in task env`,
+          );
+          continue;
+        }
+
+        resolvedMcps[name] = {
+          type: 'streamable-http',
+          url: `${apiUrl}${customProxyPath}`,
+          headers: withPreviewProxyBypassHeader(
+            withTaskRunTokenAuthHeader(config.headers, cloudToken),
+            taskEnv,
+          ),
+        };
+        continue;
+      }
+
       resolvedMcps[name] = {
         type: 'streamable-http',
         url: config.url,
@@ -416,18 +464,23 @@ export function resolveBuiltInMcpServers(
     }
   }
 
-  // Add environment-specific MCP servers.
-  // Built-ins and integration MCPs take precedence over custom names.
-  if (environmentMcpServers) {
-    const substitutionLookup = buildMcpSubstitutionLookup(
-      taskEnv,
-      operatorEnvVars,
-    );
+  const substitutionLookup = buildMcpSubstitutionLookup(
+    taskEnv,
+    operatorEnvVars,
+  );
 
-    for (const [name, config] of Object.entries(environmentMcpServers)) {
+  const mergeOperatorMcpServers = (
+    servers: EnvironmentMcpServers | undefined,
+    source: 'environment' | 'deployment',
+  ) => {
+    if (!servers) {
+      return;
+    }
+
+    for (const [name, config] of Object.entries(servers)) {
       if (resolvedMcps[name]) {
         console.warn(
-          `[resolveBuiltInMcpServers] Skipping custom MCP '${name}': name conflicts with an existing MCP server`,
+          `[resolveBuiltInMcpServers] Skipping ${source} custom MCP '${name}': name conflicts with an existing MCP server`,
         );
         continue;
       }
@@ -456,7 +509,12 @@ export function resolveBuiltInMcpServers(
         };
       }
     }
-  }
+  };
+
+  // Environment-specific servers first, then deployment-wide stdio servers:
+  // the more specific scope wins name collisions.
+  mergeOperatorMcpServers(environmentMcpServers, 'environment');
+  mergeOperatorMcpServers(deploymentMcpServers, 'deployment');
 
   return resolvedMcps;
 }

--- a/apps/worker/src/run-task/create-harness.ts
+++ b/apps/worker/src/run-task/create-harness.ts
@@ -33,6 +33,12 @@ interface CreateHarnessOptions {
   mcpTaskEnv: Record<string, string>;
   environmentMcpServers?: EnvironmentMcpServers;
   /**
+   * Deployment-scoped custom stdio MCP servers, fetched once at task start.
+   * Merged after environment servers, so an environment entry with the same
+   * name wins.
+   */
+  deploymentMcpServers?: EnvironmentMcpServers;
+  /**
    * Operator-defined deployment env vars. Always eligible for ${...}
    * substitution in custom MCP config, regardless of variable name.
    */
@@ -66,6 +72,7 @@ export async function createHarness({
   integrations,
   mcpTaskEnv,
   environmentMcpServers,
+  deploymentMcpServers,
   operatorEnvVars,
   taskRun,
   developerInstructionsContent,
@@ -98,6 +105,7 @@ export async function createHarness({
       integrations,
       environmentMcpServers,
       operatorEnvVars,
+      deploymentMcpServers,
     );
     const modelOverride = taskRun.payload?.harnessModelOverrides
       ? getHarnessModelOverride(

--- a/apps/worker/src/run-task/run-task.ts
+++ b/apps/worker/src/run-task/run-task.ts
@@ -941,6 +941,27 @@ export const runTask = async ({
       );
     }
 
+    // Deployment-scoped custom stdio MCP servers. Same best-effort posture:
+    // a fetch failure means the task runs without them, never that it blocks.
+    let deploymentMcpServers:
+      | Record<
+          string,
+          { command: string; args?: string[]; env?: Record<string, string> }
+        >
+      | undefined;
+
+    try {
+      const { servers } = await sdk.mcpConnections.getCustomStdioMcpServers();
+
+      if (Object.keys(servers).length > 0) {
+        deploymentMcpServers = servers;
+      }
+    } catch (error) {
+      logger.warn(
+        `[runTask] Failed to fetch custom stdio MCP server configs: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
     const slackReplyContext = getSlackReplyContext(taskRun);
     const communicationReplyContext = getCommunicationReplyContext(taskRun);
     if (slackReplyContext?.threadTs) {
@@ -1193,6 +1214,7 @@ export const runTask = async ({
       integrations,
       mcpTaskEnv,
       environmentMcpServers: environmentConfig?.mcpServers,
+      deploymentMcpServers,
       // The pre-injection snapshot, NOT deploymentEnvVars: by harness start,
       // `envVars` has been mutated with runtime-internal entries (auth bypass
       // values, BASH_ENV, ...) that must not ride the operator overlay past

--- a/packages/db/drizzle/0029_unusual_wallow.sql
+++ b/packages/db/drizzle/0029_unusual_wallow.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "custom_mcp_servers" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"url" text,
+	"auth_type" text DEFAULT 'none' NOT NULL,
+	"headers" jsonb,
+	"stdio" jsonb,
+	"disabled_tools" text[],
+	"manual_client_id" text,
+	"manual_client_secret" text,
+	"oauth_server_metadata" jsonb,
+	"oauth_server_metadata_fetched_at" timestamp,
+	"oauth_resource_indicator_disabled" boolean DEFAULT false NOT NULL,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"created_by_user_id" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "custom_mcp_servers_name_unique" UNIQUE("name")
+);
+--> statement-breakpoint
+ALTER TABLE "custom_mcp_servers" ADD CONSTRAINT "custom_mcp_servers_created_by_user_id_users_id_fk" FOREIGN KEY ("created_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;

--- a/packages/db/drizzle/meta/0029_snapshot.json
+++ b/packages/db/drizzle/meta/0029_snapshot.json
@@ -1,0 +1,10150 @@
+{
+  "id": "3b9f00f6-12a3-41ba-9257-db0af67f3a62",
+  "prevId": "bbf7530d-0d50-4529-8e58-243a150a5b55",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_accounts": {
+      "name": "auth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_accounts_user_id_idx": {
+          "name": "auth_accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_accounts_provider_account_unique": {
+          "name": "auth_accounts_provider_account_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_accounts_user_id_auth_users_id_fk": {
+          "name": "auth_accounts_user_id_auth_users_id_fk",
+          "tableFrom": "auth_accounts",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_sessions_token_unique": {
+          "name": "auth_sessions_token_unique",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_sessions_user_id_idx": {
+          "name": "auth_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_sessions_user_id_auth_users_id_fk": {
+          "name": "auth_sessions_user_id_auth_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_users": {
+      "name": "auth_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_users_email_unique": {
+          "name": "auth_users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_users_created_at_idx": {
+          "name": "auth_users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verifications": {
+      "name": "auth_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_verifications_identifier_idx": {
+          "name": "auth_verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automations": {
+      "name": "automations",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "internal": {
+          "name": "internal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "targets": {
+          "name": "targets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_succeeded_at": {
+          "name": "last_succeeded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failed_at": {
+          "name": "last_failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scan_cursor": {
+          "name": "scan_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compute_provider_usage": {
+      "name": "compute_provider_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_usage_id": {
+          "name": "provider_usage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_kind": {
+          "name": "auth_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "launch_mode": {
+          "name": "launch_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_action": {
+          "name": "lifecycle_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "measurement_source": {
+          "name": "measurement_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_vcpus": {
+          "name": "configured_vcpus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configured_cpu_cores": {
+          "name": "configured_cpu_cores",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configured_memory_mib": {
+          "name": "configured_memory_mib",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wall_clock_duration_ms": {
+          "name": "wall_clock_duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_cpu_duration_ms": {
+          "name": "active_cpu_duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_memory_mib_milliseconds": {
+          "name": "observed_memory_mib_milliseconds",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network_ingress_bytes": {
+          "name": "network_ingress_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network_egress_bytes": {
+          "name": "network_egress_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "compute_provider_usage_provider_usage_id_unique": {
+          "name": "compute_provider_usage_provider_usage_id_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_usage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "compute_provider_usage_run_id_idx": {
+          "name": "compute_provider_usage_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "compute_provider_usage_task_id_idx": {
+          "name": "compute_provider_usage_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "compute_provider_usage_created_at_idx": {
+          "name": "compute_provider_usage_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compute_provider_usage_run_id_task_runs_id_fk": {
+          "name": "compute_provider_usage_run_id_task_runs_id_fk",
+          "tableFrom": "compute_provider_usage",
+          "tableTo": "task_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "compute_provider_usage_task_id_tasks_id_fk": {
+          "name": "compute_provider_usage_task_id_tasks_id_fk",
+          "tableFrom": "compute_provider_usage",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compute_provider_usage_samples": {
+      "name": "compute_provider_usage_samples",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_usage_id": {
+          "name": "provider_usage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sampled_at": {
+          "name": "sampled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_usage_ns_total": {
+          "name": "cpu_usage_ns_total",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_usage_bytes": {
+          "name": "memory_usage_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_peak_usage_bytes": {
+          "name": "memory_peak_usage_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "compute_provider_usage_samples_provider_usage_sampled_at_unique": {
+          "name": "compute_provider_usage_samples_provider_usage_sampled_at_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_usage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sampled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "compute_provider_usage_samples_run_id_idx": {
+          "name": "compute_provider_usage_samples_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "compute_provider_usage_samples_task_id_idx": {
+          "name": "compute_provider_usage_samples_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "compute_provider_usage_samples_created_at_idx": {
+          "name": "compute_provider_usage_samples_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compute_provider_usage_samples_run_id_task_runs_id_fk": {
+          "name": "compute_provider_usage_samples_run_id_task_runs_id_fk",
+          "tableFrom": "compute_provider_usage_samples",
+          "tableTo": "task_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "compute_provider_usage_samples_task_id_tasks_id_fk": {
+          "name": "compute_provider_usage_samples_task_id_tasks_id_fk",
+          "tableFrom": "compute_provider_usage_samples",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_automations": {
+      "name": "custom_automations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "schedule_mode": {
+          "name": "schedule_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target": {
+          "name": "target",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_succeeded_at": {
+          "name": "last_succeeded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failed_at": {
+          "name": "last_failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_launched_task_id": {
+          "name": "last_launched_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "launch_claimed_at": {
+          "name": "launch_claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "custom_automations_name_unique_idx": {
+          "name": "custom_automations_name_unique_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_automations_enabled_idx": {
+          "name": "custom_automations_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_automations_environment_id_idx": {
+          "name": "custom_automations_environment_id_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_automations_environment_id_environments_id_fk": {
+          "name": "custom_automations_environment_id_environments_id_fk",
+          "tableFrom": "custom_automations",
+          "tableTo": "environments",
+          "columnsFrom": ["environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "custom_automations_created_by_user_id_users_id_fk": {
+          "name": "custom_automations_created_by_user_id_users_id_fk",
+          "tableFrom": "custom_automations",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "custom_automations_last_launched_task_id_tasks_id_fk": {
+          "name": "custom_automations_last_launched_task_id_tasks_id_fk",
+          "tableFrom": "custom_automations",
+          "tableTo": "tasks",
+          "columnsFrom": ["last_launched_task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_mcp_servers": {
+      "name": "custom_mcp_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stdio": {
+          "name": "stdio",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_tools": {
+          "name": "disabled_tools",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_client_id": {
+          "name": "manual_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_client_secret": {
+          "name": "manual_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_server_metadata": {
+          "name": "oauth_server_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_server_metadata_fetched_at": {
+          "name": "oauth_server_metadata_fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_resource_indicator_disabled": {
+          "name": "oauth_resource_indicator_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_mcp_servers_created_by_user_id_users_id_fk": {
+          "name": "custom_mcp_servers_created_by_user_id_users_id_fk",
+          "tableFrom": "custom_mcp_servers",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_mcp_servers_name_unique": {
+          "name": "custom_mcp_servers_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_mcp_enablements": {
+      "name": "deployment_mcp_enablements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "mcp_id": {
+          "name": "mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enabled_by_user_id": {
+          "name": "enabled_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_tools": {
+          "name": "disabled_tools",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "deployment_mcp_enablements_enabled_by_user_id_users_id_fk": {
+          "name": "deployment_mcp_enablements_enabled_by_user_id_users_id_fk",
+          "tableFrom": "deployment_mcp_enablements",
+          "tableTo": "users",
+          "columnsFrom": ["enabled_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "deployment_mcp_enablements_mcp_unique": {
+          "name": "deployment_mcp_enablements_mcp_unique",
+          "nullsNotDistinct": false,
+          "columns": ["mcp_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_secrets": {
+      "name": "deployment_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deployment_secrets_name_unique": {
+          "name": "deployment_secrets_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "task_model_settings": {
+          "name": "task_model_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "router_debug_provider": {
+          "name": "router_debug_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "router_debug_channel_id": {
+          "name": "router_debug_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "router_debug_disabled": {
+          "name": "router_debug_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "router_debug_slack_channel_id": {
+          "name": "router_debug_slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_model_config": {
+          "name": "runtime_model_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_compute_config": {
+          "name": "runtime_compute_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_policy": {
+          "name": "access_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_key": {
+          "name": "license_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_cloud_state": {
+          "name": "license_cloud_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_analytics_id": {
+          "name": "instance_analytics_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_known_version": {
+          "name": "latest_known_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_version_checked_at": {
+          "name": "latest_version_checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_completed_at": {
+          "name": "setup_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_new_state": {
+          "name": "setup_new_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_onboarding_stage": {
+          "name": "slack_onboarding_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manager_slack_channel_id": {
+          "name": "manager_slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manager_discord_channel_id": {
+          "name": "manager_discord_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_agent_instructions": {
+          "name": "global_agent_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_zone_updated_at": {
+          "name": "time_zone_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorship_instructions": {
+          "name": "authorship_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compiled_authorship_rules": {
+          "name": "compiled_authorship_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "compiled_authorship_issues": {
+          "name": "compiled_authorship_issues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "compiled_authorship_at": {
+          "name": "compiled_authorship_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "style_guidance": {
+          "name": "style_guidance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_summon_emoji": {
+          "name": "slack_summon_emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_ack_emoji": {
+          "name": "slack_ack_emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eyes'"
+        },
+        "slack_completion_emoji": {
+          "name": "slack_completion_emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'white_check_mark'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_gateway_sessions": {
+      "name": "discord_gateway_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resume_gateway_url": {
+          "name": "resume_gateway_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shard_count": {
+          "name": "shard_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_connected_at": {
+          "name": "last_connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_ack_at": {
+          "name": "last_heartbeat_ack_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disconnected_at": {
+          "name": "disconnected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_installation_channels": {
+      "name": "discord_installation_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "discord_installation_id": {
+          "name": "discord_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_available": {
+          "name": "is_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_installation_channels_installation_id_idx": {
+          "name": "discord_installation_channels_installation_id_idx",
+          "columns": [
+            {
+              "expression": "discord_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_installation_channels_unique": {
+          "name": "discord_installation_channels_unique",
+          "columns": [
+            {
+              "expression": "discord_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_installation_channels_discord_installation_id_discord_installations_id_fk": {
+          "name": "discord_installation_channels_discord_installation_id_discord_installations_id_fk",
+          "tableFrom": "discord_installation_channels",
+          "tableTo": "discord_installations",
+          "columnsFrom": ["discord_installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_installations": {
+      "name": "discord_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_name": {
+          "name": "guild_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_channel_id": {
+          "name": "default_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_channel_name": {
+          "name": "default_channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_channel_type": {
+          "name": "default_channel_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_installations_guild_id_unique": {
+          "name": "discord_installations_guild_id_unique",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_installations_active_idx": {
+          "name": "discord_installations_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_installations_default_channel_idx": {
+          "name": "discord_installations_default_channel_idx",
+          "columns": [
+            {
+              "expression": "default_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_installations_installed_by_user_id_users_id_fk": {
+          "name": "discord_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "discord_installations",
+          "tableTo": "users",
+          "columnsFrom": ["installed_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_user_mappings": {
+      "name": "discord_user_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_global_name": {
+          "name": "discord_global_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_dm_channel_id": {
+          "name": "discord_dm_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_user_mappings_user_id_idx": {
+          "name": "discord_user_mappings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_user_mappings_discord_user_id_unique": {
+          "name": "discord_user_mappings_discord_user_id_unique",
+          "columns": [
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_user_mappings_user_id_users_id_fk": {
+          "name": "discord_user_mappings_user_id_users_id_fk",
+          "tableFrom": "discord_user_mappings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.environment_config_versions": {
+      "name": "environment_config_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "environment_config_versions_environment_id_idx": {
+          "name": "environment_config_versions_environment_id_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "environment_config_versions_environment_version_unique": {
+          "name": "environment_config_versions_environment_version_unique",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "environment_config_versions_environment_id_environments_id_fk": {
+          "name": "environment_config_versions_environment_id_environments_id_fk",
+          "tableFrom": "environment_config_versions",
+          "tableTo": "environments",
+          "columnsFrom": ["environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "environment_config_versions_created_by_user_id_users_id_fk": {
+          "name": "environment_config_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "environment_config_versions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.environment_repository_mappings": {
+      "name": "environment_repository_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "env_repo_mappings_env_id_idx": {
+          "name": "env_repo_mappings_env_id_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "env_repo_mappings_repo_id_idx": {
+          "name": "env_repo_mappings_repo_id_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "environment_repository_mappings_environment_id_environments_id_fk": {
+          "name": "environment_repository_mappings_environment_id_environments_id_fk",
+          "tableFrom": "environment_repository_mappings",
+          "tableTo": "environments",
+          "columnsFrom": ["environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "environment_repository_mappings_repository_id_repositories_id_fk": {
+          "name": "environment_repository_mappings_repository_id_repositories_id_fk",
+          "tableFrom": "environment_repository_mappings",
+          "tableTo": "repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "env_repo_mappings_unique": {
+          "name": "env_repo_mappings_unique",
+          "nullsNotDistinct": false,
+          "columns": ["environment_id", "repository_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.environment_snapshots": {
+      "name": "environment_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_created_at": {
+          "name": "snapshot_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_expires_at": {
+          "name": "snapshot_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_status": {
+          "name": "snapshot_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "environment_snapshots_environment_id_idx": {
+          "name": "environment_snapshots_environment_id_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "environment_snapshots_env_provider_unique": {
+          "name": "environment_snapshots_env_provider_unique",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"environment_snapshots\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "environment_snapshots_environment_id_environments_id_fk": {
+          "name": "environment_snapshots_environment_id_environments_id_fk",
+          "tableFrom": "environment_snapshots",
+          "tableTo": "environments",
+          "columnsFrom": ["environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.environment_variables": {
+      "name": "environment_variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_by_user_id": {
+          "name": "last_updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "environment_variables_user_id_idx": {
+          "name": "environment_variables_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "environment_variables_name_unique": {
+          "name": "environment_variables_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "environment_variables_user_id_users_id_fk": {
+          "name": "environment_variables_user_id_users_id_fk",
+          "tableFrom": "environment_variables",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "environment_variables_created_by_user_id_users_id_fk": {
+          "name": "environment_variables_created_by_user_id_users_id_fk",
+          "tableFrom": "environment_variables",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "environment_variables_last_updated_by_user_id_users_id_fk": {
+          "name": "environment_variables_last_updated_by_user_id_users_id_fk",
+          "tableFrom": "environment_variables",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.environments": {
+      "name": "environments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_eval": {
+          "name": "is_eval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "declarative_source": {
+          "name": "declarative_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_task_id": {
+          "name": "verification_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_error": {
+          "name": "verification_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_created_at": {
+          "name": "snapshot_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_expires_at": {
+          "name": "snapshot_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_status": {
+          "name": "snapshot_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "environments_user_id_idx": {
+          "name": "environments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "environments_created_by_user_id_idx": {
+          "name": "environments_created_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "environments_snapshot_expires_at_idx": {
+          "name": "environments_snapshot_expires_at_idx",
+          "columns": [
+            {
+              "expression": "snapshot_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "environments_name_unique": {
+          "name": "environments_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "environments_user_id_users_id_fk": {
+          "name": "environments_user_id_users_id_fk",
+          "tableFrom": "environments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "environments_created_by_user_id_users_id_fk": {
+          "name": "environments_created_by_user_id_users_id_fk",
+          "tableFrom": "environments",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "members_count": {
+          "name": "members_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_account_login_idx": {
+          "name": "github_installations_account_login_idx",
+          "columns": [
+            {
+              "expression": "account_login",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_deployment_installation_unique": {
+          "name": "github_installations_deployment_installation_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_user_id_users_id_fk": {
+          "name": "github_installations_user_id_users_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installations_installed_by_user_id_users_id_fk": {
+          "name": "github_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "users",
+          "columnsFrom": ["installed_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_pending_installations": {
+      "name": "github_pending_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_pending_installations_requested_by_user_id_idx": {
+          "name": "github_pending_installations_requested_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "requested_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_pending_installations_user_id_users_id_fk": {
+          "name": "github_pending_installations_user_id_users_id_fk",
+          "tableFrom": "github_pending_installations",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_pending_installations_requested_by_user_id_users_id_fk": {
+          "name": "github_pending_installations_requested_by_user_id_users_id_fk",
+          "tableFrom": "github_pending_installations",
+          "tableTo": "users",
+          "columnsFrom": ["requested_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_user_mappings": {
+      "name": "github_user_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_login": {
+          "name": "github_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_user_mappings_github_login_idx": {
+          "name": "github_user_mappings_github_login_idx",
+          "columns": [
+            {
+              "expression": "github_login",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_user_mappings_user_id_idx": {
+          "name": "github_user_mappings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_user_mappings_user_id_users_id_fk": {
+          "name": "github_user_mappings_user_id_users_id_fk",
+          "tableFrom": "github_user_mappings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "github_user_mappings_unique": {
+          "name": "github_user_mappings_unique",
+          "nullsNotDistinct": false,
+          "columns": ["github_user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invites_token_hash_unique": {
+          "name": "invites_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_created_at_idx": {
+          "name": "invites_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_invited_by_user_id_users_id_fk": {
+          "name": "invites_invited_by_user_id_users_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "users",
+          "columnsFrom": ["invited_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.license_usage_observations": {
+      "name": "license_usage_observations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_users": {
+          "name": "active_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempted_at": {
+          "name": "last_attempted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "license_usage_observations_pending_idx": {
+          "name": "license_usage_observations_pending_idx",
+          "columns": [
+            {
+              "expression": "delivered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.linear_pending_selections": {
+      "name": "linear_pending_selections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linear_organization_id": {
+          "name": "linear_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step": {
+          "name": "step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'awaiting_workspace'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_repo": {
+          "name": "selected_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_options": {
+          "name": "workspace_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "linear_pending_selections_expires_at_idx": {
+          "name": "linear_pending_selections_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "linear_pending_selections_step_idx": {
+          "name": "linear_pending_selections_step_idx",
+          "columns": [
+            {
+              "expression": "step",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "linear_pending_selections_user_id_users_id_fk": {
+          "name": "linear_pending_selections_user_id_users_id_fk",
+          "tableFrom": "linear_pending_selections",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "linear_pending_selections_session_id_unique": {
+          "name": "linear_pending_selections_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["session_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_inference_usage_events": {
+      "name": "task_inference_usage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'opencode'"
+        },
+        "usage_type": {
+          "name": "usage_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inference'"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness_session_id": {
+          "name": "harness_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "context_tokens": {
+          "name": "context_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_micro_usd": {
+          "name": "cost_micro_usd",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pricing_metadata": {
+          "name": "pricing_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "message_created_at": {
+          "name": "message_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_completed_at": {
+          "name": "message_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_inference_usage_events_session_message_unique": {
+          "name": "task_inference_usage_events_session_message_unique",
+          "columns": [
+            {
+              "expression": "harness_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_inference_usage_events_event_key_unique": {
+          "name": "task_inference_usage_events_event_key_unique",
+          "columns": [
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_inference_usage_events_task_id_idx": {
+          "name": "task_inference_usage_events_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_inference_usage_events_run_id_idx": {
+          "name": "task_inference_usage_events_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_inference_usage_events_user_id_idx": {
+          "name": "task_inference_usage_events_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_inference_usage_events_environment_id_idx": {
+          "name": "task_inference_usage_events_environment_id_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_inference_usage_events_provider_model_idx": {
+          "name": "task_inference_usage_events_provider_model_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_inference_usage_events_created_at_idx": {
+          "name": "task_inference_usage_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_inference_usage_events_task_id_tasks_id_fk": {
+          "name": "task_inference_usage_events_task_id_tasks_id_fk",
+          "tableFrom": "task_inference_usage_events",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_inference_usage_events_run_id_task_runs_id_fk": {
+          "name": "task_inference_usage_events_run_id_task_runs_id_fk",
+          "tableFrom": "task_inference_usage_events",
+          "tableTo": "task_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_inference_usage_events_user_id_users_id_fk": {
+          "name": "task_inference_usage_events_user_id_users_id_fk",
+          "tableFrom": "task_inference_usage_events",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_inference_usage_events_environment_id_environments_id_fk": {
+          "name": "task_inference_usage_events_environment_id_environments_id_fk",
+          "tableFrom": "task_inference_usage_events",
+          "tableTo": "environments",
+          "columnsFrom": ["environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_connections": {
+      "name": "mcp_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_id": {
+          "name": "mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_role": {
+          "name": "connection_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auth_status": {
+          "name": "auth_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_connections_user_id_idx": {
+          "name": "mcp_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_connections_role_idx": {
+          "name": "mcp_connections_role_idx",
+          "columns": [
+            {
+              "expression": "mcp_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_connections_user_id_users_id_fk": {
+          "name": "mcp_connections_user_id_users_id_fk",
+          "tableFrom": "mcp_connections",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_connections_user_mcp_id_unique": {
+          "name": "mcp_connections_user_mcp_id_unique",
+          "nullsNotDistinct": true,
+          "columns": ["user_id", "mcp_id", "connection_role"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_replays": {
+      "name": "mcp_oauth_replays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_id": {
+          "name": "mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_role": {
+          "name": "connection_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "redirect_to": {
+          "name": "redirect_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_replays_connection_id_idx": {
+          "name": "mcp_oauth_replays_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_oauth_replays_user_id_idx": {
+          "name": "mcp_oauth_replays_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_oauth_replays_expires_at_idx": {
+          "name": "mcp_oauth_replays_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_replays_connection_id_mcp_connections_id_fk": {
+          "name": "mcp_oauth_replays_connection_id_mcp_connections_id_fk",
+          "tableFrom": "mcp_oauth_replays",
+          "tableTo": "mcp_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_replays_user_id_users_id_fk": {
+          "name": "mcp_oauth_replays_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_replays",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_replays_token_unique": {
+          "name": "mcp_oauth_replays_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.microsoft_auth_user_mappings": {
+      "name": "microsoft_auth_user_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_account_id": {
+          "name": "auth_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "microsoft_tenant_id": {
+          "name": "microsoft_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "microsoft_aad_object_id": {
+          "name": "microsoft_aad_object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "microsoft_auth_user_mappings_user_id_idx": {
+          "name": "microsoft_auth_user_mappings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "microsoft_auth_user_mappings_account_id_idx": {
+          "name": "microsoft_auth_user_mappings_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "microsoft_auth_user_mappings_auth_account_idx": {
+          "name": "microsoft_auth_user_mappings_auth_account_idx",
+          "columns": [
+            {
+              "expression": "auth_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "microsoft_auth_user_mappings_aad_object_unique": {
+          "name": "microsoft_auth_user_mappings_aad_object_unique",
+          "columns": [
+            {
+              "expression": "microsoft_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "microsoft_aad_object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "microsoft_auth_user_mappings_auth_account_id_auth_accounts_id_fk": {
+          "name": "microsoft_auth_user_mappings_auth_account_id_auth_accounts_id_fk",
+          "tableFrom": "microsoft_auth_user_mappings",
+          "tableTo": "auth_accounts",
+          "columnsFrom": ["auth_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "microsoft_auth_user_mappings_user_id_auth_users_id_fk": {
+          "name": "microsoft_auth_user_mappings_user_id_auth_users_id_fk",
+          "tableFrom": "microsoft_auth_user_mappings",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_state": {
+      "name": "oauth_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replay_token": {
+          "name": "replay_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_state_connection_id_idx": {
+          "name": "oauth_state_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_state_replay_token_idx": {
+          "name": "oauth_state_replay_token_idx",
+          "columns": [
+            {
+              "expression": "replay_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_state_expires_at_idx": {
+          "name": "oauth_state_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_state_connection_id_mcp_connections_id_fk": {
+          "name": "oauth_state_connection_id_mcp_connections_id_fk",
+          "tableFrom": "oauth_state",
+          "tableTo": "mcp_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pull_request_facts": {
+      "name": "pull_request_facts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_control_provider": {
+          "name": "source_control_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "external_pull_request_id": {
+          "name": "external_pull_request_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_remote": {
+          "name": "created_at_remote",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at_remote": {
+          "name": "updated_at_remote",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_at_remote": {
+          "name": "closed_at_remote",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at_remote": {
+          "name": "merged_at_remote",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pull_request_facts_deployment_repo_pr_unique": {
+          "name": "pull_request_facts_deployment_repo_pr_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pull_request_facts_deployment_created_idx": {
+          "name": "pull_request_facts_deployment_created_idx",
+          "columns": [
+            {
+              "expression": "created_at_remote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pull_request_facts_deployment_repo_created_idx": {
+          "name": "pull_request_facts_deployment_repo_created_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_remote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pull_request_facts_deployment_state_created_idx": {
+          "name": "pull_request_facts_deployment_state_created_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_remote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pull_request_facts_deployment_author_created_idx": {
+          "name": "pull_request_facts_deployment_author_created_idx",
+          "columns": [
+            {
+              "expression": "author_login",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_remote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pull_request_facts_deployment_updated_idx": {
+          "name": "pull_request_facts_deployment_updated_idx",
+          "columns": [
+            {
+              "expression": "updated_at_remote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pull_request_facts_repository_id_repositories_id_fk": {
+          "name": "pull_request_facts_repository_id_repositories_id_fk",
+          "tableFrom": "pull_request_facts",
+          "tableTo": "repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pull_request_facts_source_control_provider_check": {
+          "name": "pull_request_facts_source_control_provider_check",
+          "value": "\"pull_request_facts\".\"source_control_provider\" in ('github', 'gitlab', 'gitea', 'ado', 'bitbucket')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pull_request_sync_states": {
+      "name": "pull_request_sync_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_incremental_updated_at": {
+          "name": "last_incremental_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_completed_at": {
+          "name": "backfill_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cooldown_until": {
+          "name": "cooldown_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_successful_sync_at": {
+          "name": "last_successful_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempted_sync_at": {
+          "name": "last_attempted_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pull_request_sync_states_repo_unique": {
+          "name": "pull_request_sync_states_repo_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pull_request_sync_states_deployment_updated_idx": {
+          "name": "pull_request_sync_states_deployment_updated_idx",
+          "columns": [
+            {
+              "expression": "last_successful_sync_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pull_request_sync_states_cooldown_idx": {
+          "name": "pull_request_sync_states_cooldown_idx",
+          "columns": [
+            {
+              "expression": "cooldown_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pull_request_sync_states_repository_id_repositories_id_fk": {
+          "name": "pull_request_sync_states_repository_id_repositories_id_fk",
+          "tableFrom": "pull_request_sync_states",
+          "tableTo": "repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repositories": {
+      "name": "repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_control_provider": {
+          "name": "source_control_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_repo_id": {
+          "name": "external_repo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "clone_url": {
+          "name": "clone_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "linked_by_user_id": {
+          "name": "linked_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repositories_source_control_provider_idx": {
+          "name": "repositories_source_control_provider_idx",
+          "columns": [
+            {
+              "expression": "source_control_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositories_installation_id_idx": {
+          "name": "repositories_installation_id_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositories_full_name_idx": {
+          "name": "repositories_full_name_idx",
+          "columns": [
+            {
+              "expression": "full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositories_provider_host_full_name_idx": {
+          "name": "repositories_provider_host_full_name_idx",
+          "columns": [
+            {
+              "expression": "source_control_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositories_deployment_active_installation_idx": {
+          "name": "repositories_deployment_active_installation_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositories_deployment_github_repo_unique": {
+          "name": "repositories_deployment_github_repo_unique",
+          "columns": [
+            {
+              "expression": "github_repo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositories_provider_host_external_repo_unique": {
+          "name": "repositories_provider_host_external_repo_unique",
+          "columns": [
+            {
+              "expression": "source_control_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"host\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_repo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositories_provider_host_full_name_unique": {
+          "name": "repositories_provider_host_full_name_unique",
+          "columns": [
+            {
+              "expression": "source_control_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"host\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repositories_installation_id_github_installations_id_fk": {
+          "name": "repositories_installation_id_github_installations_id_fk",
+          "tableFrom": "repositories",
+          "tableTo": "github_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repositories_user_id_users_id_fk": {
+          "name": "repositories_user_id_users_id_fk",
+          "tableFrom": "repositories",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repositories_linked_by_user_id_users_id_fk": {
+          "name": "repositories_linked_by_user_id_users_id_fk",
+          "tableFrom": "repositories",
+          "tableTo": "users",
+          "columnsFrom": ["linked_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "repositories_source_control_provider_check": {
+          "name": "repositories_source_control_provider_check",
+          "value": "\"repositories\".\"source_control_provider\" in ('github', 'gitlab', 'gitea', 'ado', 'bitbucket')"
+        },
+        "repositories_github_shape_check": {
+          "name": "repositories_github_shape_check",
+          "value": "\"repositories\".\"source_control_provider\" != 'github' OR (\"repositories\".\"installation_id\" IS NOT NULL AND \"repositories\".\"github_repo_id\" IS NOT NULL)"
+        },
+        "repositories_gitlab_shape_check": {
+          "name": "repositories_gitlab_shape_check",
+          "value": "\"repositories\".\"source_control_provider\" != 'gitlab' OR \"repositories\".\"external_repo_id\" IS NOT NULL"
+        },
+        "repositories_gitea_shape_check": {
+          "name": "repositories_gitea_shape_check",
+          "value": "\"repositories\".\"source_control_provider\" != 'gitea' OR \"repositories\".\"external_repo_id\" IS NOT NULL"
+        },
+        "repositories_ado_shape_check": {
+          "name": "repositories_ado_shape_check",
+          "value": "\"repositories\".\"source_control_provider\" != 'ado' OR \"repositories\".\"external_repo_id\" IS NOT NULL"
+        },
+        "repositories_bitbucket_shape_check": {
+          "name": "repositories_bitbucket_shape_check",
+          "value": "\"repositories\".\"source_control_provider\" != 'bitbucket' OR \"repositories\".\"external_repo_id\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sandbox_oidc_targets": {
+      "name": "sandbox_oidc_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compute_provider": {
+          "name": "compute_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compute_provider_id": {
+          "name": "compute_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_file": {
+          "name": "token_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aws_role_arn": {
+          "name": "aws_role_arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aws_region": {
+          "name": "aws_region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_at": {
+          "name": "refresh_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sandbox_oidc_targets_environment_id_idx": {
+          "name": "sandbox_oidc_targets_environment_id_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sandbox_oidc_targets_run_id_idx": {
+          "name": "sandbox_oidc_targets_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sandbox_oidc_targets_refresh_at_idx": {
+          "name": "sandbox_oidc_targets_refresh_at_idx",
+          "columns": [
+            {
+              "expression": "refresh_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sandbox_oidc_targets_provider_target_file_unique": {
+          "name": "sandbox_oidc_targets_provider_target_file_unique",
+          "columns": [
+            {
+              "expression": "compute_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "compute_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token_file",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_oidc_targets_environment_id_environments_id_fk": {
+          "name": "sandbox_oidc_targets_environment_id_environments_id_fk",
+          "tableFrom": "sandbox_oidc_targets",
+          "tableTo": "environments",
+          "columnsFrom": ["environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sandbox_oidc_targets_run_id_task_runs_id_fk": {
+          "name": "sandbox_oidc_targets_run_id_task_runs_id_fk",
+          "tableFrom": "sandbox_oidc_targets",
+          "tableTo": "task_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sandbox_oidc_targets_owner_required": {
+          "name": "sandbox_oidc_targets_owner_required",
+          "value": "run_id IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.setup_qualification_blocks": {
+      "name": "setup_qualification_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'blocked'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_domain": {
+          "name": "email_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_account_login": {
+          "name": "github_account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_account_type": {
+          "name": "github_account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_blocked_at": {
+          "name": "first_blocked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_blocked_at": {
+          "name": "last_blocked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifted_by_admin_user_id": {
+          "name": "lifted_by_admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifted_by_admin_email": {
+          "name": "lifted_by_admin_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "setup_qualification_blocks_deployment_user_reason_unique": {
+          "name": "setup_qualification_blocks_deployment_user_reason_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setup_qualification_blocks_deployment_status_idx": {
+          "name": "setup_qualification_blocks_deployment_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setup_qualification_blocks_user_status_idx": {
+          "name": "setup_qualification_blocks_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "setup_qualification_blocks_user_id_users_id_fk": {
+          "name": "setup_qualification_blocks_user_id_users_id_fk",
+          "tableFrom": "setup_qualification_blocks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_auth_tokens": {
+      "name": "slack_auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_team_id": {
+          "name": "slack_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_ts": {
+          "name": "thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_text": {
+          "name": "original_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_auth_tokens_expires_at_idx": {
+          "name": "slack_auth_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_auth_tokens_token_unique": {
+          "name": "slack_auth_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_conversation_messages": {
+      "name": "slack_conversation_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_team_id": {
+          "name": "slack_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_slack_user_id": {
+          "name": "subject_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_user_id": {
+          "name": "sender_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_slack_user_id": {
+          "name": "sender_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_kind": {
+          "name": "conversation_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_ts": {
+          "name": "thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_ts": {
+          "name": "message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_at": {
+          "name": "message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_kind": {
+          "name": "author_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_quick_answer_id": {
+          "name": "slack_quick_answer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_conversation_messages_deployment_user_message_at_idx": {
+          "name": "slack_conversation_messages_deployment_user_message_at_idx",
+          "columns": [
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_conversation_messages_deployment_user_thread_idx": {
+          "name": "slack_conversation_messages_deployment_user_thread_idx",
+          "columns": [
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_conversation_messages_task_id_idx": {
+          "name": "slack_conversation_messages_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_conversation_messages_run_id_idx": {
+          "name": "slack_conversation_messages_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_conversation_messages_team_channel_message_unique": {
+          "name": "slack_conversation_messages_team_channel_message_unique",
+          "columns": [
+            {
+              "expression": "slack_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_conversation_messages_subject_user_id_users_id_fk": {
+          "name": "slack_conversation_messages_subject_user_id_users_id_fk",
+          "tableFrom": "slack_conversation_messages",
+          "tableTo": "users",
+          "columnsFrom": ["subject_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_conversation_messages_sender_user_id_users_id_fk": {
+          "name": "slack_conversation_messages_sender_user_id_users_id_fk",
+          "tableFrom": "slack_conversation_messages",
+          "tableTo": "users",
+          "columnsFrom": ["sender_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "slack_conversation_messages_task_id_tasks_id_fk": {
+          "name": "slack_conversation_messages_task_id_tasks_id_fk",
+          "tableFrom": "slack_conversation_messages",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "slack_conversation_messages_run_id_task_runs_id_fk": {
+          "name": "slack_conversation_messages_run_id_task_runs_id_fk",
+          "tableFrom": "slack_conversation_messages",
+          "tableTo": "task_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "slack_conversation_messages_slack_quick_answer_id_slack_quick_answers_id_fk": {
+          "name": "slack_conversation_messages_slack_quick_answer_id_slack_quick_answers_id_fk",
+          "tableFrom": "slack_conversation_messages",
+          "tableTo": "slack_quick_answers",
+          "columnsFrom": ["slack_quick_answer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_installation_channels": {
+      "name": "slack_installation_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_installation_channels_installation_id_idx": {
+          "name": "slack_installation_channels_installation_id_idx",
+          "columns": [
+            {
+              "expression": "slack_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_installation_channels_slack_installation_id_slack_installations_id_fk": {
+          "name": "slack_installation_channels_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "slack_installation_channels",
+          "tableTo": "slack_installations",
+          "columnsFrom": ["slack_installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_installation_channels_unique": {
+          "name": "slack_installation_channels_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slack_installation_id", "channel_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_installations": {
+      "name": "slack_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_domain": {
+          "name": "team_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enterprise_id": {
+          "name": "enterprise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enterprise_name": {
+          "name": "enterprise_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_name": {
+          "name": "bot_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_name": {
+          "name": "app_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_access_token": {
+          "name": "bot_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_access_token": {
+          "name": "user_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bot'"
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_count_snapshot": {
+          "name": "member_count_snapshot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_count_snapshot_at": {
+          "name": "member_count_snapshot_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_installations_bot_user_id_idx": {
+          "name": "slack_installations_bot_user_id_idx",
+          "columns": [
+            {
+              "expression": "bot_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_active_idx": {
+          "name": "slack_installations_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_installations_installed_by_user_id_users_id_fk": {
+          "name": "slack_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "users",
+          "columnsFrom": ["installed_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_installations_team_id_unique": {
+          "name": "slack_installations_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["team_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_quick_answers": {
+      "name": "slack_quick_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel": {
+          "name": "slack_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_quick_answers_deployment_channel_thread_unique": {
+          "name": "slack_quick_answers_deployment_channel_thread_unique",
+          "columns": [
+            {
+              "expression": "slack_channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_quick_answers_deployment_user_idx": {
+          "name": "slack_quick_answers_deployment_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_quick_answers_user_id_users_id_fk": {
+          "name": "slack_quick_answers_user_id_users_id_fk",
+          "tableFrom": "slack_quick_answers",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_user_mappings": {
+      "name": "slack_user_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_team_id": {
+          "name": "slack_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_user_mappings_user_id_idx": {
+          "name": "slack_user_mappings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_user_mappings_user_id_users_id_fk": {
+          "name": "slack_user_mappings_user_id_users_id_fk",
+          "tableFrom": "slack_user_mappings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_user_mappings_unique": {
+          "name": "slack_user_mappings_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slack_user_id", "slack_team_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_artifacts": {
+      "name": "task_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_type": {
+          "name": "artifact_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded": {
+          "name": "uploaded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_artifacts_task_id_idx": {
+          "name": "task_artifacts_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_artifacts_run_id_idx": {
+          "name": "task_artifacts_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_artifacts_uploaded_idx": {
+          "name": "task_artifacts_uploaded_idx",
+          "columns": [
+            {
+              "expression": "uploaded",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_artifacts_created_at_idx": {
+          "name": "task_artifacts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_artifacts_path_idx": {
+          "name": "task_artifacts_path_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_artifacts_task_id_tasks_id_fk": {
+          "name": "task_artifacts_task_id_tasks_id_fk",
+          "tableFrom": "task_artifacts",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_artifacts_run_id_task_runs_id_fk": {
+          "name": "task_artifacts_run_id_task_runs_id_fk",
+          "tableFrom": "task_artifacts",
+          "tableTo": "task_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_artifacts_task_id_path_version_unique": {
+          "name": "task_artifacts_task_id_path_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["task_id", "path", "version"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_messages": {
+      "name": "task_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ts": {
+          "name": "ts",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_messages_task_id_ts_idx": {
+          "name": "task_messages_task_id_ts_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_messages_run_id_idx": {
+          "name": "task_messages_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_messages_created_at_idx": {
+          "name": "task_messages_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_messages_run_id_task_runs_id_fk": {
+          "name": "task_messages_run_id_task_runs_id_fk",
+          "tableFrom": "task_messages",
+          "tableTo": "task_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_messages_task_id_tasks_id_fk": {
+          "name": "task_messages_task_id_tasks_id_fk",
+          "tableFrom": "task_messages",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_messages_user_id_users_id_fk": {
+          "name": "task_messages_user_id_users_id_fk",
+          "tableFrom": "task_messages",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_messages_task_protocol_ts_event_type_unique": {
+          "name": "task_messages_task_protocol_ts_event_type_unique",
+          "nullsNotDistinct": false,
+          "columns": ["task_id", "protocol", "ts", "event_type"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_pins": {
+      "name": "task_pins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_pins_deployment_user_task_unique": {
+          "name": "task_pins_deployment_user_task_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_pins_deployment_user_updated_at_idx": {
+          "name": "task_pins_deployment_user_updated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_pins_task_id_idx": {
+          "name": "task_pins_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_pins_task_id_tasks_id_fk": {
+          "name": "task_pins_task_id_tasks_id_fk",
+          "tableFrom": "task_pins",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_pins_user_id_users_id_fk": {
+          "name": "task_pins_user_id_users_id_fk",
+          "tableFrom": "task_pins",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_platform_issue_reports": {
+      "name": "task_platform_issue_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_message_id": {
+          "name": "task_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report": {
+          "name": "report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_posted_at": {
+          "name": "slack_posted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_platform_issue_reports_created_at_idx": {
+          "name": "task_platform_issue_reports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_platform_issue_reports_task_id_created_at_idx": {
+          "name": "task_platform_issue_reports_task_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_platform_issue_reports_run_id_created_at_idx": {
+          "name": "task_platform_issue_reports_run_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_platform_issue_reports_task_message_id_unique": {
+          "name": "task_platform_issue_reports_task_message_id_unique",
+          "columns": [
+            {
+              "expression": "task_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_platform_issue_reports_task_id_tasks_id_fk": {
+          "name": "task_platform_issue_reports_task_id_tasks_id_fk",
+          "tableFrom": "task_platform_issue_reports",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_platform_issue_reports_run_id_task_runs_id_fk": {
+          "name": "task_platform_issue_reports_run_id_task_runs_id_fk",
+          "tableFrom": "task_platform_issue_reports",
+          "tableTo": "task_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_platform_issue_reports_task_message_id_task_messages_id_fk": {
+          "name": "task_platform_issue_reports_task_message_id_task_messages_id_fk",
+          "tableFrom": "task_platform_issue_reports",
+          "tableTo": "task_messages",
+          "columnsFrom": ["task_message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_pull_requests": {
+      "name": "task_pull_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_control_provider": {
+          "name": "source_control_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_title": {
+          "name": "pr_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_sha": {
+          "name": "pr_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_base_ref": {
+          "name": "pr_base_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_base_sha": {
+          "name": "pr_base_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_reaction_id": {
+          "name": "github_reaction_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_check_run_id": {
+          "name": "github_check_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_review_comment_id": {
+          "name": "github_review_comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_roomote": {
+          "name": "created_by_roomote",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_handle_feedback_by_user_id": {
+          "name": "auto_handle_feedback_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_pull_requests_task_id_idx": {
+          "name": "task_pull_requests_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_pull_requests_repository_id_idx": {
+          "name": "task_pull_requests_repository_id_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_pull_requests_provider_repository_pr_number_idx": {
+          "name": "task_pull_requests_provider_repository_pr_number_idx",
+          "columns": [
+            {
+              "expression": "source_control_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_pull_requests_task_id_tasks_id_fk": {
+          "name": "task_pull_requests_task_id_tasks_id_fk",
+          "tableFrom": "task_pull_requests",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_pull_requests_repository_id_repositories_id_fk": {
+          "name": "task_pull_requests_repository_id_repositories_id_fk",
+          "tableFrom": "task_pull_requests",
+          "tableTo": "repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_pull_requests_auto_handle_feedback_by_user_id_users_id_fk": {
+          "name": "task_pull_requests_auto_handle_feedback_by_user_id_users_id_fk",
+          "tableFrom": "task_pull_requests",
+          "tableTo": "users",
+          "columnsFrom": ["auto_handle_feedback_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_pull_requests_task_pr_unique": {
+          "name": "task_pull_requests_task_pr_unique",
+          "nullsNotDistinct": false,
+          "columns": ["task_id", "pr_url"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "task_pull_requests_source_control_provider_check": {
+          "name": "task_pull_requests_source_control_provider_check",
+          "value": "\"task_pull_requests\".\"source_control_provider\" in ('github', 'gitlab', 'gitea', 'ado', 'bitbucket')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.task_run_events": {
+      "name": "task_run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_run_events_run_id_created_at_idx": {
+          "name": "task_run_events_run_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_run_events_task_id_created_at_idx": {
+          "name": "task_run_events_task_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_run_events_created_at_idx": {
+          "name": "task_run_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_run_events_source_created_at_idx": {
+          "name": "task_run_events_source_created_at_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_run_events_run_id_task_runs_id_fk": {
+          "name": "task_run_events_run_id_task_runs_id_fk",
+          "tableFrom": "task_run_events",
+          "tableTo": "task_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_run_events_task_id_tasks_id_fk": {
+          "name": "task_run_events_task_id_tasks_id_fk",
+          "tableFrom": "task_run_events",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_runs": {
+      "name": "task_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "task_runs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fresh'"
+        },
+        "source_run_id": {
+          "name": "source_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acting_user_id": {
+          "name": "acting_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_kind": {
+          "name": "payload_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'opencode-server'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "queue_scope": {
+          "name": "queue_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_phase": {
+          "name": "task_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log": {
+          "name": "log",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifacts": {
+          "name": "artifacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_cmd_id": {
+          "name": "sandbox_cmd_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_domain": {
+          "name": "machine_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_domains": {
+          "name": "machine_domains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initial_paths": {
+          "name": "initial_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_port_name": {
+          "name": "primary_port_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_server_url": {
+          "name": "sandbox_server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_ports": {
+          "name": "proxy_ports",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worker_release_tag": {
+          "name": "worker_release_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worker_version": {
+          "name": "worker_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worker_commit": {
+          "name": "worker_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configured_vcpus": {
+          "name": "configured_vcpus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configured_cpu_cores": {
+          "name": "configured_cpu_cores",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configured_memory_mib": {
+          "name": "configured_memory_mib",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_requested_at": {
+          "name": "snapshot_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_created_at": {
+          "name": "snapshot_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_failed_at": {
+          "name": "snapshot_failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keepalive_ms": {
+          "name": "keepalive_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sleep_at": {
+          "name": "sleep_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sleep_requested_at": {
+          "name": "sleep_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worker_heartbeat_at": {
+          "name": "worker_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_snapshot_id": {
+          "name": "source_snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_bypass_value": {
+          "name": "auth_bypass_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_bypass_header_name": {
+          "name": "auth_bypass_header_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dequeued_at": {
+          "name": "dequeued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provision_started_at": {
+          "name": "provision_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provision_ready_at": {
+          "name": "provision_ready_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_completed_at": {
+          "name": "setup_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment_setup_state": {
+          "name": "environment_setup_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment_setup_completed_at": {
+          "name": "environment_setup_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness_started_at": {
+          "name": "harness_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_task_started_at": {
+          "name": "runtime_task_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_assistant_output_at": {
+          "name": "first_assistant_output_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "launch_mode": {
+          "name": "launch_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "task_runs_task_id_idx": {
+          "name": "task_runs_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_queue_scope_idx": {
+          "name": "task_runs_queue_scope_idx",
+          "columns": [
+            {
+              "expression": "queue_scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_acting_user_id_idx": {
+          "name": "task_runs_acting_user_id_idx",
+          "columns": [
+            {
+              "expression": "acting_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_snapshot_id_idx": {
+          "name": "task_runs_snapshot_id_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_sleep_at_idx": {
+          "name": "task_runs_sleep_at_idx",
+          "columns": [
+            {
+              "expression": "sleep_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_worker_heartbeat_at_idx": {
+          "name": "task_runs_worker_heartbeat_at_idx",
+          "columns": [
+            {
+              "expression": "worker_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_sleep_check_due_v2_idx": {
+          "name": "task_runs_sleep_check_due_v2_idx",
+          "columns": [
+            {
+              "expression": "sleep_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"task_runs\".\"status\" IN ('running', 'idle') AND \"task_runs\".\"machine_id\" IS NOT NULL AND \"task_runs\".\"sleep_at\" IS NOT NULL AND \"task_runs\".\"sleep_requested_at\" IS NULL AND \"task_runs\".\"snapshot_id\" IS NULL AND \"task_runs\".\"snapshot_requested_at\" IS NULL AND \"task_runs\".\"vendor\" IN ('modal', 'daytona', 'e2b', 'docker', 'blaxel', 'roomote', 'azure')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_sleep_check_stale_worker_v2_idx": {
+          "name": "task_runs_sleep_check_stale_worker_v2_idx",
+          "columns": [
+            {
+              "expression": "worker_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"task_runs\".\"status\" IN ('running', 'idle') AND \"task_runs\".\"machine_id\" IS NOT NULL AND \"task_runs\".\"worker_heartbeat_at\" IS NOT NULL AND \"task_runs\".\"sleep_requested_at\" IS NULL AND \"task_runs\".\"snapshot_id\" IS NULL AND \"task_runs\".\"snapshot_requested_at\" IS NULL AND \"task_runs\".\"vendor\" IN ('modal', 'daytona', 'e2b', 'docker', 'blaxel', 'roomote', 'azure')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_sleep_check_active_v2_idx": {
+          "name": "task_runs_sleep_check_active_v2_idx",
+          "columns": [
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"task_runs\".\"status\" IN ('running', 'idle') AND \"task_runs\".\"machine_id\" IS NOT NULL AND \"task_runs\".\"sleep_requested_at\" IS NULL AND \"task_runs\".\"snapshot_id\" IS NULL AND \"task_runs\".\"snapshot_requested_at\" IS NULL AND \"task_runs\".\"vendor\" IN ('modal', 'daytona', 'e2b', 'docker', 'blaxel', 'roomote', 'azure')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_source_snapshot_id_idx": {
+          "name": "task_runs_source_snapshot_id_idx",
+          "columns": [
+            {
+              "expression": "source_snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_source_run_id_idx": {
+          "name": "task_runs_source_run_id_idx",
+          "columns": [
+            {
+              "expression": "source_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_discord_source_event_unique": {
+          "name": "task_runs_discord_source_event_unique",
+          "columns": [
+            {
+              "expression": "(\"payload\"->>'communicationSourceEventId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"task_runs\".\"payload\"->>'communicationProvider' = 'discord' AND \"task_runs\".\"payload\"->>'communicationSourceEventId' IS NOT NULL AND \"task_runs\".\"canceled_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_first_assistant_output_at_idx": {
+          "name": "task_runs_first_assistant_output_at_idx",
+          "columns": [
+            {
+              "expression": "first_assistant_output_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_runs_task_id_tasks_id_fk": {
+          "name": "task_runs_task_id_tasks_id_fk",
+          "tableFrom": "task_runs",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_runs_source_run_id_task_runs_id_fk": {
+          "name": "task_runs_source_run_id_task_runs_id_fk",
+          "tableFrom": "task_runs",
+          "tableTo": "task_runs",
+          "columnsFrom": ["source_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "task_runs_acting_user_id_users_id_fk": {
+          "name": "task_runs_acting_user_id_users_id_fk",
+          "tableFrom": "task_runs",
+          "tableTo": "users",
+          "columnsFrom": ["acting_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "task_runs_kind_check": {
+          "name": "task_runs_kind_check",
+          "value": "\"task_runs\".\"kind\" in ('fresh', 'resume')"
+        },
+        "task_runs_harness_check": {
+          "name": "task_runs_harness_check",
+          "value": "\"task_runs\".\"harness\" in ('opencode-server')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.task_slack_reply_details": {
+      "name": "task_slack_reply_details",
+      "schema": "",
+      "columns": {
+        "detail_id": {
+          "name": "detail_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings": {
+          "name": "findings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_slack_reply_details_task_id_idx": {
+          "name": "task_slack_reply_details_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_slack_reply_details_deployment_task_detail_unique": {
+          "name": "task_slack_reply_details_deployment_task_detail_unique",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_slack_reply_details_task_id_tasks_id_fk": {
+          "name": "task_slack_reply_details_task_id_tasks_id_fk",
+          "tableFrom": "task_slack_reply_details",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_start_parallel_counts": {
+      "name": "task_start_parallel_counts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_kind": {
+          "name": "payload_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parallel_count": {
+          "name": "parallel_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_window_seconds": {
+          "name": "activity_window_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_start_parallel_counts_run_id_unique": {
+          "name": "task_start_parallel_counts_run_id_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_start_parallel_counts_task_id_started_at_idx": {
+          "name": "task_start_parallel_counts_task_id_started_at_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_start_parallel_counts_started_at_idx": {
+          "name": "task_start_parallel_counts_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_start_parallel_counts_task_id_tasks_id_fk": {
+          "name": "task_start_parallel_counts_task_id_tasks_id_fk",
+          "tableFrom": "task_start_parallel_counts",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_start_parallel_counts_run_id_task_runs_id_fk": {
+          "name": "task_start_parallel_counts_run_id_task_runs_id_fk",
+          "tableFrom": "task_start_parallel_counts",
+          "tableTo": "task_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'visible'"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "initiator_kind": {
+          "name": "initiator_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiator_user_id": {
+          "name": "initiator_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiator_automation": {
+          "name": "initiator_automation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_external_id": {
+          "name": "actor_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_display_name": {
+          "name": "actor_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_kind": {
+          "name": "commit_author_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_user_id": {
+          "name": "commit_author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_login": {
+          "name": "commit_author_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_external_id": {
+          "name": "commit_author_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_assignee_login": {
+          "name": "pr_assignee_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_session_id": {
+          "name": "linear_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_issue_id": {
+          "name": "linear_issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_organization_id": {
+          "name": "linear_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'opencode-server'"
+        },
+        "harness_session_id": {
+          "name": "harness_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_edited_by_user_at": {
+          "name": "title_edited_by_user_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "llm_title_checkpoint": {
+          "name": "llm_title_checkpoint",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_prompt": {
+          "name": "draft_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_work_kind": {
+          "name": "requested_work_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "requested_work_kind_source": {
+          "name": "requested_work_kind_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system_default'"
+        },
+        "requested_work_kind_confidence": {
+          "name": "requested_work_kind_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness_instructions": {
+          "name": "harness_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compute_duration_ms": {
+          "name": "compute_duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_at": {
+          "name": "activity_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_url": {
+          "name": "repository_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_name": {
+          "name": "repository_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasks_initiator_user_id_idx": {
+          "name": "tasks_initiator_user_id_idx",
+          "columns": [
+            {
+              "expression": "initiator_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_initiator_automation_idx": {
+          "name": "tasks_initiator_automation_idx",
+          "columns": [
+            {
+              "expression": "initiator_automation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_workflow_idx": {
+          "name": "tasks_workflow_idx",
+          "columns": [
+            {
+              "expression": "workflow",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_visibility_activity_at_idx": {
+          "name": "tasks_visibility_activity_at_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_harness_session_id_idx": {
+          "name": "tasks_harness_session_id_idx",
+          "columns": [
+            {
+              "expression": "harness_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_timestamp_idx": {
+          "name": "tasks_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_deployment_activity_at_idx": {
+          "name": "tasks_deployment_activity_at_idx",
+          "columns": [
+            {
+              "expression": "activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_created_at_idx": {
+          "name": "tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_initiator_user_id_users_id_fk": {
+          "name": "tasks_initiator_user_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": ["initiator_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_initiator_automation_automations_key_fk": {
+          "name": "tasks_initiator_automation_automations_key_fk",
+          "tableFrom": "tasks",
+          "tableTo": "automations",
+          "columnsFrom": ["initiator_automation"],
+          "columnsTo": ["key"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_commit_author_user_id_users_id_fk": {
+          "name": "tasks_commit_author_user_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": ["commit_author_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tasks_initiator_shape_check": {
+          "name": "tasks_initiator_shape_check",
+          "value": "(\"tasks\".\"initiator_kind\" = 'user' AND \"tasks\".\"initiator_automation\" IS NULL AND (\"tasks\".\"initiator_user_id\" IS NOT NULL OR \"tasks\".\"actor_external_id\" IS NOT NULL)) OR (\"tasks\".\"initiator_kind\" = 'automation' AND \"tasks\".\"initiator_automation\" IS NOT NULL AND \"tasks\".\"initiator_user_id\" IS NULL)"
+        },
+        "tasks_workflow_check": {
+          "name": "tasks_workflow_check",
+          "value": "\"tasks\".\"workflow\" in ('standard', 'pr_review', 'pr_conflict_resolve', 'scan', 'mcp_recommendations', 'setup_onboarding', 'env_snapshot', 'eval')"
+        },
+        "tasks_surface_check": {
+          "name": "tasks_surface_check",
+          "value": "\"tasks\".\"surface\" in ('web', 'api', 'slack', 'teams', 'telegram', 'discord', 'linear', 'github', 'gitlab', 'gitea', 'ado', 'bitbucket', 'system')"
+        },
+        "tasks_trigger_check": {
+          "name": "tasks_trigger_check",
+          "value": "\"tasks\".\"trigger\" in ('message', 'webhook', 'schedule', 'manual')"
+        },
+        "tasks_visibility_check": {
+          "name": "tasks_visibility_check",
+          "value": "\"tasks\".\"visibility\" in ('visible', 'hidden')"
+        },
+        "tasks_state_check": {
+          "name": "tasks_state_check",
+          "value": "\"tasks\".\"state\" in ('active', 'completed', 'failed', 'canceled')"
+        },
+        "tasks_harness_check": {
+          "name": "tasks_harness_check",
+          "value": "\"tasks\".\"harness\" in ('opencode-server')"
+        },
+        "tasks_requested_work_kind_check": {
+          "name": "tasks_requested_work_kind_check",
+          "value": "\"tasks\".\"requested_work_kind\" in ('question', 'plan', 'implement', 'unknown')"
+        },
+        "tasks_requested_work_kind_source_check": {
+          "name": "tasks_requested_work_kind_source_check",
+          "value": "\"tasks\".\"requested_work_kind_source\" in ('explicit_bootstrap', 'task_tool', 'llm_classifier', 'inherited', 'system_default')"
+        },
+        "tasks_commit_author_kind_check": {
+          "name": "tasks_commit_author_kind_check",
+          "value": "\"tasks\".\"commit_author_kind\" IS NULL OR \"tasks\".\"commit_author_kind\" in ('roomote', 'user', 'external')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.teams_installations": {
+      "name": "teams_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_type": {
+          "name": "conversation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_app_id": {
+          "name": "bot_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_name": {
+          "name": "bot_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_url": {
+          "name": "service_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teams_installations_tenant_id_idx": {
+          "name": "teams_installations_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "teams_installations_team_id_idx": {
+          "name": "teams_installations_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "teams_installations_conversation_id_idx": {
+          "name": "teams_installations_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "teams_installations_active_idx": {
+          "name": "teams_installations_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_installations_installation_key_unique": {
+          "name": "teams_installations_installation_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["installation_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams_user_mappings": {
+      "name": "teams_user_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "teams_user_id": {
+          "name": "teams_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams_tenant_id": {
+          "name": "teams_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams_aad_object_id": {
+          "name": "teams_aad_object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teams_user_mappings_aad_object_idx": {
+          "name": "teams_user_mappings_aad_object_idx",
+          "columns": [
+            {
+              "expression": "teams_aad_object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "teams_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "teams_user_mappings_user_id_idx": {
+          "name": "teams_user_mappings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_user_mappings_user_id_users_id_fk": {
+          "name": "teams_user_mappings_user_id_users_id_fk",
+          "tableFrom": "teams_user_mappings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_user_mappings_unique": {
+          "name": "teams_user_mappings_unique",
+          "nullsNotDistinct": false,
+          "columns": ["teams_user_id", "teams_tenant_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_mappings": {
+      "name": "telegram_user_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_username": {
+          "name": "telegram_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "telegram_user_mappings_user_id_idx": {
+          "name": "telegram_user_mappings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_user_mappings_user_id_users_id_fk": {
+          "name": "telegram_user_mappings_user_id_users_id_fk",
+          "tableFrom": "telegram_user_mappings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_user_mappings_unique": {
+          "name": "telegram_user_mappings_unique",
+          "nullsNotDistinct": false,
+          "columns": ["telegram_user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_messages": {
+      "name": "tracked_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_ts": {
+          "name": "message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_ts": {
+          "name": "thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "automation_key": {
+          "name": "automation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_text": {
+          "name": "summary_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tracked_messages_kind_dedupe_key_unique": {
+          "name": "tracked_messages_kind_dedupe_key_unique",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tracked_messages_work_item_id_idx": {
+          "name": "tracked_messages_work_item_id_idx",
+          "columns": [
+            {
+              "expression": "work_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tracked_messages_channel_message_idx": {
+          "name": "tracked_messages_channel_message_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tracked_messages_automation_channel_posted_idx": {
+          "name": "tracked_messages_automation_channel_posted_idx",
+          "columns": [
+            {
+              "expression": "automation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "posted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tracked_messages_work_item_id_work_items_id_fk": {
+          "name": "tracked_messages_work_item_id_work_items_id_fk",
+          "tableFrom": "tracked_messages",
+          "tableTo": "work_items",
+          "columnsFrom": ["work_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tracked_messages_automation_key_automations_key_fk": {
+          "name": "tracked_messages_automation_key_automations_key_fk",
+          "tableFrom": "tracked_messages",
+          "tableTo": "automations",
+          "columnsFrom": ["automation_key"],
+          "columnsTo": ["key"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tracked_messages_created_by_user_id_users_id_fk": {
+          "name": "tracked_messages_created_by_user_id_users_id_fk",
+          "tableFrom": "tracked_messages",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_api_keys": {
+      "name": "user_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_api_keys_user_id_idx": {
+          "name": "user_api_keys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_api_keys_user_deployment_provider_unique": {
+          "name": "user_api_keys_user_deployment_provider_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_api_keys_user_id_users_id_fk": {
+          "name": "user_api_keys_user_id_users_id_fk",
+          "tableFrom": "user_api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "analytics_id": {
+          "name": "analytics_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cookie_consented_at": {
+          "name": "cookie_consented_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by_invite_id": {
+          "name": "invited_by_invite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_analytics_id_unique_idx": {
+          "name": "users_analytics_id_unique_idx",
+          "columns": [
+            {
+              "expression": "analytics_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "succeeded_at": {
+          "name": "succeeded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhooks_provider_delivery_id_unique": {
+          "name": "webhooks_provider_delivery_id_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhooks_event_idx": {
+          "name": "webhooks_event_idx",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhooks_created_at_idx": {
+          "name": "webhooks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "webhooks_status_exclusive": {
+          "name": "webhooks_status_exclusive",
+          "value": "(\n        (succeeded_at IS NOT NULL)::int +\n        (failed_at IS NOT NULL)::int\n      ) <= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.work_items": {
+      "name": "work_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_key": {
+          "name": "automation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_task_id": {
+          "name": "source_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_by_user_id": {
+          "name": "selected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_work_item_id": {
+          "name": "source_work_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brief": {
+          "name": "brief",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_prompt": {
+          "name": "execution_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "investigation_context": {
+          "name": "investigation_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_kind": {
+          "name": "action_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_ids": {
+          "name": "repository_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "target_repository_full_name": {
+          "name": "target_repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_environment_id": {
+          "name": "target_environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_readiness": {
+          "name": "workspace_readiness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readiness_message": {
+          "name": "readiness_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "launch_claimed_at": {
+          "name": "launch_claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "launched_task_id": {
+          "name": "launched_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "launched_at": {
+          "name": "launched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "launch_error": {
+          "name": "launch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "work_items_source_task_idx": {
+          "name": "work_items_source_task_idx",
+          "columns": [
+            {
+              "expression": "source_task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_items_kind_status_idx": {
+          "name": "work_items_kind_status_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_items_automation_key_fingerprint_idx": {
+          "name": "work_items_automation_key_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "automation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_items_fingerprint_idx": {
+          "name": "work_items_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_items_launched_task_id_idx": {
+          "name": "work_items_launched_task_id_idx",
+          "columns": [
+            {
+              "expression": "launched_task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_items_source_task_kind_sort_order_unique": {
+          "name": "work_items_source_task_kind_sort_order_unique",
+          "columns": [
+            {
+              "expression": "source_task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_items_automation_key_automations_key_fk": {
+          "name": "work_items_automation_key_automations_key_fk",
+          "tableFrom": "work_items",
+          "tableTo": "automations",
+          "columnsFrom": ["automation_key"],
+          "columnsTo": ["key"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "work_items_source_task_id_tasks_id_fk": {
+          "name": "work_items_source_task_id_tasks_id_fk",
+          "tableFrom": "work_items",
+          "tableTo": "tasks",
+          "columnsFrom": ["source_task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_items_selected_by_user_id_users_id_fk": {
+          "name": "work_items_selected_by_user_id_users_id_fk",
+          "tableFrom": "work_items",
+          "tableTo": "users",
+          "columnsFrom": ["selected_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "work_items_source_work_item_id_work_items_id_fk": {
+          "name": "work_items_source_work_item_id_work_items_id_fk",
+          "tableFrom": "work_items",
+          "tableTo": "work_items",
+          "columnsFrom": ["source_work_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "work_items_target_environment_id_environments_id_fk": {
+          "name": "work_items_target_environment_id_environments_id_fk",
+          "tableFrom": "work_items",
+          "tableTo": "environments",
+          "columnsFrom": ["target_environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "work_items_launched_task_id_tasks_id_fk": {
+          "name": "work_items_launched_task_id_tasks_id_fk",
+          "tableFrom": "work_items",
+          "tableTo": "tasks",
+          "columnsFrom": ["launched_task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1785748471387,
       "tag": "0028_aspiring_thena",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1786074663950,
+      "tag": "0029_unusual_wallow",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -48,6 +48,9 @@ import type {
   TaskMessageMetadata,
   TaskMessagePayload,
   McpConnectionAuthConfig,
+  CustomMcpServerAuthType,
+  CustomMcpServerStdioConfig,
+  OAuthServerMetadata,
   SetupNewState,
   LinearPendingSelectionStep,
   AutomationScanCursor,
@@ -3303,6 +3306,68 @@ export const deploymentMcpEnablementsRelations = relations(
   ({ one }) => ({
     enabledByUser: one(users, {
       fields: [deploymentMcpEnablements.enabledByUserId],
+      references: [users.id],
+    }),
+  }),
+);
+
+/**
+ * customMcpServers
+ *
+ * Deployment-scoped custom MCP servers managed by admins in Settings.
+ *
+ * Remote servers are never handed to sandboxes directly: they are delivered as
+ * authenticated proxy URLs (`/api/mcp/custom/<id>`) and the API proxy injects
+ * credentials per request. `headers` values are individually encrypted by the
+ * command layer before persisting (admin_configured connection precedent), so
+ * header *names* can round-trip to the browser while values never do.
+ *
+ * OAuth connections for these servers live in `mcpConnections` under the
+ * `custom:<id>` mcpId namespace (see customMcpConnectionId in
+ * packages/types), reusing oauth_state and the encrypted token columns.
+ * Previous-release code ignores those rows because every curated query
+ * filters mcpId against the catalog id list.
+ *
+ * `url` is null for stdio servers and `stdio` is null for remote servers;
+ * the command layer enforces exactly one transport per row.
+ */
+export const customMcpServers = pgTable(
+  'custom_mcp_servers',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    name: text('name').notNull(),
+    url: text('url'),
+    authType: text('auth_type')
+      .notNull()
+      .default('none')
+      .$type<CustomMcpServerAuthType>(),
+    headers: jsonb('headers').$type<Record<string, string>>(),
+    stdio: jsonb('stdio').$type<CustomMcpServerStdioConfig>(),
+    disabledTools: text('disabled_tools').array(),
+    manualClientId: text('manual_client_id'),
+    manualClientSecret: encryptedText('manual_client_secret'),
+    oauthServerMetadata: jsonb(
+      'oauth_server_metadata',
+    ).$type<OAuthServerMetadata>(),
+    oauthServerMetadataFetchedAt: timestamp('oauth_server_metadata_fetched_at'),
+    oauthResourceIndicatorDisabled: boolean('oauth_resource_indicator_disabled')
+      .notNull()
+      .default(false),
+    enabled: boolean('enabled').notNull().default(true),
+    createdByUserId: text('created_by_user_id').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+  },
+  (table) => [unique('custom_mcp_servers_name_unique').on(table.name)],
+);
+
+export const customMcpServersRelations = relations(
+  customMcpServers,
+  ({ one }) => ({
+    createdByUser: one(users, {
+      fields: [customMcpServers.createdByUserId],
       references: [users.id],
     }),
   }),

--- a/packages/db/src/server.ts
+++ b/packages/db/src/server.ts
@@ -188,6 +188,8 @@ export {
   sandboxOidcTargetsRelations,
   deploymentMcpEnablements,
   deploymentMcpEnablementsRelations,
+  customMcpServers,
+  customMcpServersRelations,
   mcpConnections,
   mcpConnectionsRelations,
   oauthState,

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -122,6 +122,15 @@ const serverSchema = {
   // by default; operators opt out explicitly. Existing connections remain
   // stored but cannot be configured or used while disabled.
   R_CURATED_INTEGRATIONS_DISABLED: optInBoolean(),
+  // Operator kill switch for admin-configured custom MCP servers. Deliberately
+  // independent of R_CURATED_INTEGRATIONS_DISABLED: operators who disable the
+  // curated catalog are the primary custom-server audience.
+  R_CUSTOM_MCP_DISABLED: optInBoolean(),
+  // Comma-separated CIDR ranges the custom-MCP egress guard may connect to in
+  // addition to public addresses. Self-host escape hatch for MCP servers on
+  // private networks; a CIDR list rather than a boolean so opening one
+  // internal host does not re-expose every adjacent service.
+  R_CUSTOM_MCP_ALLOWED_PRIVATE_CIDRS: z.string().min(1).optional(),
   R_INTERCOM_APP_ID: z.string().min(1).optional(),
   R_POSTHOG_PROJECT_KEY: z.string().min(1).optional(),
   R_POSTHOG_HOST: z.string().url().optional(),
@@ -439,6 +448,7 @@ const OPTIONAL_NON_EMPTY_KEYS = new Set([
   'R_PING_BASE_URL',
   'R_INSTANCE_ID',
   'STATUSPAGE_INCIDENTS_ENABLED_INSTANCE_ID',
+  'R_CUSTOM_MCP_ALLOWED_PRIVATE_CIDRS',
   'R_INTERCOM_APP_ID',
   'R_POSTHOG_PROJECT_KEY',
   'R_POSTHOG_HOST',
@@ -583,6 +593,16 @@ export function areCuratedIntegrationsDisabled(
   }
 
   return value === true;
+}
+
+/**
+ * Whether the deployment opted out of admin-configured custom MCP servers.
+ * Same normalization contract as areCuratedIntegrationsDisabled.
+ */
+export function isCustomMcpDisabled(
+  value: string | boolean | undefined,
+): boolean {
+  return areCuratedIntegrationsDisabled(value);
 }
 
 /**

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -51,6 +51,10 @@
     "./server/teams-primary-conversation": {
       "import": "./src/server/lib/teams-primary-conversation.ts",
       "require": "./src/server/lib/teams-primary-conversation.ts"
+    },
+    "./server/safe-fetch": {
+      "import": "./src/server/lib/safe-fetch.ts",
+      "require": "./src/server/lib/safe-fetch.ts"
     }
   },
   "scripts": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -85,6 +85,7 @@
     "bullmq": "^5.78.0",
     "cron-parser": "5.6.1",
     "superjson": "^2.2.6",
+    "undici": "^7.29.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/packages/sdk/src/mcp-connections.ts
+++ b/packages/sdk/src/mcp-connections.ts
@@ -5,3 +5,6 @@ export const isOrgEnabled = (mcpId: string) =>
 
 export const getMcpServerConfigs = () =>
   client.mcpConnections.getMcpServerConfigs.query();
+
+export const getCustomStdioMcpServers = () =>
+  client.mcpConnections.getCustomStdioMcpServers.query();

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -288,6 +288,7 @@ export {
 export { type PullRequestFactSnapshot } from './lib/pull-requests/pull-request-facts-store';
 
 export * from './lib/auth';
+export * from './lib/safe-fetch';
 
 export {
   storeOAuthStateWithId,

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -314,6 +314,7 @@ export {
   generateCodeChallenge,
   generateState,
   exchangeCodeForTokens,
+  OAuthTokenRequestError,
   type OAuthRequestOptions,
 } from './lib/mcp/oauth';
 

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -314,7 +314,15 @@ export {
   generateCodeChallenge,
   generateState,
   exchangeCodeForTokens,
+  type OAuthRequestOptions,
 } from './lib/mcp/oauth';
+
+export {
+  resolveCustomMcpAuthTarget,
+  ensureCustomMcpServerMetadata,
+  isDefinitiveOAuthRejection,
+  type CustomMcpAuthTarget,
+} from './lib/mcp/custom-auth-target';
 
 export {
   LINEAR_ORG_CONNECTION_ROLE,

--- a/packages/sdk/src/server/lib/__tests__/safe-fetch.test.ts
+++ b/packages/sdk/src/server/lib/__tests__/safe-fetch.test.ts
@@ -1,0 +1,194 @@
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  SafeFetchViolationError,
+  checkAddressAllowed,
+  parseCidrList,
+  safeFetch,
+  validateEgressUrl,
+  type DnsLookupFn,
+} from '../safe-fetch';
+
+describe('checkAddressAllowed', () => {
+  const noAllowances = parseCidrList(undefined);
+
+  it.each([
+    '127.0.0.1',
+    '10.1.2.3',
+    '172.16.0.1',
+    '172.31.255.255',
+    '192.168.1.1',
+    '169.254.169.254',
+    '100.64.0.1',
+    '0.0.0.0',
+    '224.0.0.251',
+    '255.255.255.255',
+    '::1',
+    '::',
+    'fe80::1',
+    'fd00::1',
+    'ff02::1',
+  ])('blocks %s', (ip) => {
+    expect(checkAddressAllowed(ip, noAllowances)).not.toBeNull();
+  });
+
+  it.each(['1.1.1.1', '8.8.8.8', '93.184.216.34', '2606:4700:4700::1111'])(
+    'allows public %s',
+    (ip) => {
+      expect(checkAddressAllowed(ip, noAllowances)).toBeNull();
+    },
+  );
+
+  it('blocks IPv4-mapped IPv6 forms of private addresses', () => {
+    expect(checkAddressAllowed('::ffff:10.0.0.1', noAllowances)).not.toBeNull();
+    expect(
+      checkAddressAllowed('::ffff:169.254.169.254', noAllowances),
+    ).not.toBeNull();
+  });
+
+  it('allows IPv4-mapped IPv6 forms of public addresses', () => {
+    expect(checkAddressAllowed('::ffff:1.1.1.1', noAllowances)).toBeNull();
+  });
+
+  it('blocks NAT64-embedded private addresses', () => {
+    expect(
+      checkAddressAllowed('64:ff9b::10.0.0.1', noAllowances),
+    ).not.toBeNull();
+  });
+
+  it('honors explicit CIDR allowances without opening adjacent ranges', () => {
+    const allowed = parseCidrList('10.1.0.0/16');
+
+    expect(checkAddressAllowed('10.1.2.3', allowed)).toBeNull();
+    expect(checkAddressAllowed('10.2.0.1', allowed)).not.toBeNull();
+    expect(checkAddressAllowed('192.168.1.1', allowed)).not.toBeNull();
+  });
+
+  it('an allowance for one range does not affect IPv6 blocking', () => {
+    const allowed = parseCidrList('10.0.0.0/8');
+
+    expect(checkAddressAllowed('fd00::1', allowed)).not.toBeNull();
+  });
+});
+
+describe('parseCidrList', () => {
+  it('parses comma-separated mixed-family lists', () => {
+    const parsed = parseCidrList('10.0.0.0/8, fd00::/8,192.168.1.10');
+
+    expect(parsed).toHaveLength(3);
+    expect(parsed[2]!.prefix).toBe(32);
+  });
+
+  it('rejects malformed entries loudly', () => {
+    expect(() => parseCidrList('not-a-cidr')).toThrow(SafeFetchViolationError);
+    expect(() => parseCidrList('10.0.0.0/33')).toThrow(SafeFetchViolationError);
+  });
+});
+
+describe('validateEgressUrl', () => {
+  it('rejects non-http schemes and userinfo', () => {
+    expect(() => validateEgressUrl('ftp://example.com')).toThrow(
+      SafeFetchViolationError,
+    );
+    expect(() => validateEgressUrl('https://user:pass@example.com')).toThrow(
+      SafeFetchViolationError,
+    );
+    expect(() => validateEgressUrl('not a url')).toThrow(
+      SafeFetchViolationError,
+    );
+  });
+
+  it('accepts plain http URLs', () => {
+    expect(validateEgressUrl('http://example.com/mcp').hostname).toBe(
+      'example.com',
+    );
+  });
+});
+
+describe('safeFetch', () => {
+  let server: Server;
+  let port: number;
+
+  const lookupTo127: DnsLookupFn = ((hostname, options, callback) => {
+    const cb = typeof options === 'function' ? options : callback;
+    const opts = typeof options === 'function' ? {} : options;
+
+    const result = [{ address: '127.0.0.1', family: 4 }];
+
+    if ((opts as { all?: boolean }).all) {
+      (cb as (err: null, addresses: unknown) => void)(null, result);
+    } else {
+      (cb as (err: null, address: string, family: number) => void)(
+        null,
+        '127.0.0.1',
+        4,
+      );
+    }
+  }) as DnsLookupFn;
+
+  beforeAll(async () => {
+    server = createServer((req, res) => {
+      if (req.url === '/redirect') {
+        res.statusCode = 302;
+        res.setHeader('location', 'http://127.0.0.1/internal');
+        res.end();
+        return;
+      }
+
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ ok: true, host: req.headers.host }));
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', resolve);
+    });
+
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  it('refuses hostnames that resolve to blocked addresses', async () => {
+    await expect(
+      safeFetch(`http://blocked.example:${port}/`, { lookup: lookupTo127 }),
+    ).rejects.toThrow(SafeFetchViolationError);
+  });
+
+  it('connects to the vetted address when a CIDR allowance covers it', async () => {
+    const response = await safeFetch(`http://pinned.example:${port}/`, {
+      lookup: lookupTo127,
+      allowedPrivateCidrs: '127.0.0.0/8',
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as { ok: boolean; host: string };
+
+    expect(body.ok).toBe(true);
+    // The Host header carries the original hostname even though the socket
+    // was pinned to the vetted address.
+    expect(body.host).toBe(`pinned.example:${port}`);
+  });
+
+  it('refuses IP-literal URLs in blocked ranges without DNS involvement', async () => {
+    await expect(
+      safeFetch(`http://127.0.0.1:${port}/`, { lookup: lookupTo127 }),
+    ).rejects.toThrow(SafeFetchViolationError);
+  });
+
+  it('refuses redirects instead of following them', async () => {
+    await expect(
+      safeFetch(`http://redirect.example:${port}/redirect`, {
+        lookup: lookupTo127,
+        allowedPrivateCidrs: '127.0.0.0/8',
+      }),
+    ).rejects.toThrow(/redirect/);
+  });
+});

--- a/packages/sdk/src/server/lib/mcp/custom-auth-target.ts
+++ b/packages/sdk/src/server/lib/mcp/custom-auth-target.ts
@@ -8,7 +8,11 @@ import {
 } from '@roomote/types';
 
 import { createGuardedFetch } from '../safe-fetch';
-import { discoverOAuthEndpoints, type OAuthRequestOptions } from './oauth';
+import {
+  discoverOAuthEndpoints,
+  OAuthTokenRequestError,
+  type OAuthRequestOptions,
+} from './oauth';
 
 /**
  * OAuth context for a deployment custom MCP server, resolved from its
@@ -107,12 +111,23 @@ export async function ensureCustomMcpServerMetadata(
   return metadata;
 }
 
+/** RFC 6749 §5.2 codes that mean the grant or client itself is dead. */
+const DEFINITIVE_OAUTH_ERROR_CODES: ReadonlySet<string> = new Set([
+  'invalid_grant',
+  'invalid_client',
+]);
+
 /**
  * True when a token-endpoint failure means the grant itself is dead
  * (revoked, expired beyond recovery, or the client is no longer valid), as
  * opposed to a transient outage where retrying with the stale token is the
- * kinder behavior.
+ * kinder behavior. Decided on the structured error code the token endpoint
+ * returned; a 5xx, proxy error page, or network failure never qualifies.
  */
-export function isDefinitiveOAuthRejection(message: string): boolean {
-  return /invalid_grant|invalid_client/i.test(message);
+export function isDefinitiveOAuthRejection(error: unknown): boolean {
+  return (
+    error instanceof OAuthTokenRequestError &&
+    error.oauthErrorCode !== null &&
+    DEFINITIVE_OAUTH_ERROR_CODES.has(error.oauthErrorCode)
+  );
 }

--- a/packages/sdk/src/server/lib/mcp/custom-auth-target.ts
+++ b/packages/sdk/src/server/lib/mcp/custom-auth-target.ts
@@ -1,0 +1,118 @@
+import { db, eq, customMcpServers } from '@roomote/db/server';
+import { decrypt } from '@roomote/db/encryption';
+import { Env } from '@roomote/env';
+import {
+  customMcpServerIdFromConnectionId,
+  type OAuthClientInformation,
+  type OAuthServerMetadata,
+} from '@roomote/types';
+
+import { createGuardedFetch } from '../safe-fetch';
+import { discoverOAuthEndpoints, type OAuthRequestOptions } from './oauth';
+
+/**
+ * OAuth context for a deployment custom MCP server, resolved from its
+ * `custom:<serverId>` connection id.
+ *
+ * Everything here differs from the catalog path on purpose:
+ * - The server URL comes from the database row, not MCP_INTEGRATIONS.
+ * - Every protocol fetch goes through the SSRF-guarded fetch, because both
+ *   the operator URL and the discovery chain (WWW-Authenticate hints,
+ *   authorization_servers lists) are untrusted.
+ * - Discovered AS metadata is persisted on the row and pinned: refreshes use
+ *   the stored token_endpoint rather than re-discovering per refresh, which
+ *   also prevents a custom URL that equals a catalog URL from picking up the
+ *   catalog's pinned endpoints.
+ * - Manual client credentials (for servers without dynamic registration)
+ *   take precedence over stored DCR clients.
+ */
+export interface CustomMcpAuthTarget {
+  serverId: string;
+  name: string;
+  url: string;
+  serverMetadata: OAuthServerMetadata | null;
+  manualClient: OAuthClientInformation | null;
+  oauthOptions: OAuthRequestOptions;
+}
+
+export async function resolveCustomMcpAuthTarget(
+  mcpId: string,
+): Promise<CustomMcpAuthTarget | null> {
+  const serverId = customMcpServerIdFromConnectionId(mcpId);
+
+  if (!serverId) {
+    return null;
+  }
+
+  const server = await db.query.customMcpServers.findFirst({
+    where: eq(customMcpServers.id, serverId),
+  });
+
+  if (!server?.url || server.authType !== 'oauth') {
+    return null;
+  }
+
+  return {
+    serverId,
+    name: server.name,
+    url: server.url,
+    serverMetadata: server.oauthServerMetadata ?? null,
+    manualClient: server.manualClientId
+      ? {
+          client_id: server.manualClientId,
+          client_secret: server.manualClientSecret
+            ? decrypt(server.manualClientSecret)
+            : undefined,
+          token_endpoint_auth_method: server.manualClientSecret
+            ? 'client_secret_post'
+            : 'none',
+        }
+      : null,
+    oauthOptions: {
+      fetchImpl: createGuardedFetch(Env.R_CUSTOM_MCP_ALLOWED_PRIVATE_CIDRS),
+      ...(server.oauthResourceIndicatorDisabled
+        ? {}
+        : { resource: server.url }),
+    },
+  };
+}
+
+/**
+ * The pinned AS metadata for a custom server, discovering and persisting it
+ * on first use. Re-discovery happens only when nothing is stored — a
+ * Reconnect clears the stored copy (the update command resets it whenever
+ * the URL or auth mode changes).
+ */
+export async function ensureCustomMcpServerMetadata(
+  target: CustomMcpAuthTarget,
+): Promise<OAuthServerMetadata> {
+  if (target.serverMetadata) {
+    return target.serverMetadata;
+  }
+
+  const metadata = await discoverOAuthEndpoints(
+    target.url,
+    target.oauthOptions,
+  );
+
+  await db
+    .update(customMcpServers)
+    .set({
+      oauthServerMetadata: metadata,
+      oauthServerMetadataFetchedAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .where(eq(customMcpServers.id, target.serverId));
+
+  return metadata;
+}
+
+/**
+ * True when a token-endpoint failure means the grant itself is dead
+ * (revoked, expired beyond recovery, or the client is no longer valid), as
+ * opposed to a transient outage where retrying with the stale token is the
+ * kinder behavior.
+ */
+export function isDefinitiveOAuthRejection(message: string): boolean {
+  return /invalid_grant|invalid_client/i.test(message);
+}

--- a/packages/sdk/src/server/lib/mcp/data.ts
+++ b/packages/sdk/src/server/lib/mcp/data.ts
@@ -478,7 +478,7 @@ export async function getValidAccessToken(
         // stale token forever (there is no other feedback channel for a
         // broken deployment-scoped connection). Transient failures (5xx,
         // network) still fall through with the stale token below.
-        if (customTarget && isDefinitiveOAuthRejection(message)) {
+        if (customTarget && isDefinitiveOAuthRejection(error)) {
           await db
             .update(mcpConnections)
             .set({ authStatus: 'error', updatedAt: new Date() })

--- a/packages/sdk/src/server/lib/mcp/data.ts
+++ b/packages/sdk/src/server/lib/mcp/data.ts
@@ -417,19 +417,49 @@ export async function getValidAccessToken(
 
   if (needsRefresh) {
     if (storedTokens.refresh_token) {
+      const {
+        resolveCustomMcpAuthTarget,
+        ensureCustomMcpServerMetadata,
+        isDefinitiveOAuthRejection,
+      } = await import('./custom-auth-target');
+
+      const connection = await db.query.mcpConnections.findFirst({
+        where: eq(mcpConnections.id, connectionId),
+        columns: { mcpId: true },
+      });
+      const customTarget = connection
+        ? await resolveCustomMcpAuthTarget(connection.mcpId)
+        : null;
+
       try {
-        const clientInfo = await getClientInformation(connectionId);
+        const clientInfo =
+          customTarget?.manualClient ??
+          (await getClientInformation(connectionId));
+
         if (clientInfo) {
-          const integration = MCP_INTEGRATIONS.find(
-            (candidate) => candidate.url === mcpUrl,
-          );
-          const tokenEndpoint =
-            getMcpIntegrationOauthEndpoints(integration)?.tokenEndpoint ??
-            (await discoverOAuthEndpoints(mcpUrl)).token_endpoint;
+          let tokenEndpoint: string;
+          let oauthOptions: import('./oauth').OAuthRequestOptions | undefined;
+
+          if (customTarget) {
+            // Custom servers refresh against the pinned metadata through the
+            // SSRF-guarded fetch; never against a catalog match by URL.
+            const metadata = await ensureCustomMcpServerMetadata(customTarget);
+            tokenEndpoint = metadata.token_endpoint;
+            oauthOptions = customTarget.oauthOptions;
+          } else {
+            const integration = MCP_INTEGRATIONS.find(
+              (candidate) => candidate.url === mcpUrl,
+            );
+            tokenEndpoint =
+              getMcpIntegrationOauthEndpoints(integration)?.tokenEndpoint ??
+              (await discoverOAuthEndpoints(mcpUrl)).token_endpoint;
+          }
+
           const newTokens = await refreshOAuthToken(
             tokenEndpoint,
             clientInfo,
             storedTokens.refresh_token,
+            oauthOptions,
           );
           // Preserve existing refresh token if server didn't issue a new one (RFC 6749 §6)
           if (!newTokens.refresh_token) {
@@ -439,10 +469,23 @@ export async function getValidAccessToken(
           accessToken = newTokens.access_token;
         }
       } catch (error) {
-        console.error(
-          `[getValidAccessToken] Token refresh failed:`,
-          error instanceof Error ? error.message : String(error),
-        );
+        const message = error instanceof Error ? error.message : String(error);
+
+        console.error(`[getValidAccessToken] Token refresh failed:`, message);
+
+        // Custom servers: a definitive rejection means the grant is dead.
+        // Surface the reconnect state instead of silently retrying with a
+        // stale token forever (there is no other feedback channel for a
+        // broken deployment-scoped connection). Transient failures (5xx,
+        // network) still fall through with the stale token below.
+        if (customTarget && isDefinitiveOAuthRejection(message)) {
+          await db
+            .update(mcpConnections)
+            .set({ authStatus: 'error', updatedAt: new Date() })
+            .where(eq(mcpConnections.id, connectionId));
+
+          return undefined;
+        }
         // Fall through — try with existing (potentially expired) token
       }
     } else {

--- a/packages/sdk/src/server/lib/mcp/oauth.test.ts
+++ b/packages/sdk/src/server/lib/mcp/oauth.test.ts
@@ -3,6 +3,7 @@ import {
   discoverOAuthProtectedResourceMetadata,
   exchangeCodeForTokens,
   getPreferredTokenEndpointAuthMethod,
+  OAuthTokenRequestError,
   refreshOAuthToken,
 } from './oauth';
 
@@ -341,5 +342,42 @@ describe('refreshOAuthToken', () => {
 
     expect(params.get('client_id')).toBe('client-id');
     expect(params.has('client_secret')).toBe(false);
+  });
+
+  it('carries the structured RFC 6749 error code on token-endpoint failures', async () => {
+    mockFetch.mockResolvedValue(
+      createJsonResponse(
+        { error: 'invalid_grant', error_description: 'revoked' },
+        { status: 400 },
+      ),
+    );
+
+    const failure = await refreshOAuthToken(
+      'https://provider.example.com/token',
+      { client_id: 'client-id', token_endpoint_auth_method: 'none' },
+      'refresh-token',
+    ).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(OAuthTokenRequestError);
+    expect((failure as OAuthTokenRequestError).oauthErrorCode).toBe(
+      'invalid_grant',
+    );
+  });
+
+  it('reports no error code when the failure body is not an OAuth error', async () => {
+    mockFetch.mockResolvedValue(
+      new Response('<html>bad gateway that mentions invalid_grant</html>', {
+        status: 502,
+      }),
+    );
+
+    const failure = await refreshOAuthToken(
+      'https://provider.example.com/token',
+      { client_id: 'client-id', token_endpoint_auth_method: 'none' },
+      'refresh-token',
+    ).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(OAuthTokenRequestError);
+    expect((failure as OAuthTokenRequestError).oauthErrorCode).toBeNull();
   });
 });

--- a/packages/sdk/src/server/lib/mcp/oauth.ts
+++ b/packages/sdk/src/server/lib/mcp/oauth.ts
@@ -24,6 +24,40 @@ import type {
 const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 const DEFAULT_TOKEN_ENDPOINT_AUTH_METHOD = 'client_secret_post';
 
+/**
+ * Token-endpoint failure carrying the structured RFC 6749 §5.2 error code
+ * when the server returned one. Callers classify failures (for example
+ * "is this grant definitively dead?") on `oauthErrorCode`, never on
+ * message wording.
+ */
+export class OAuthTokenRequestError extends Error {
+  readonly oauthErrorCode: string | null;
+
+  constructor(message: string, oauthErrorCode: string | null) {
+    super(message);
+    this.name = 'OAuthTokenRequestError';
+    this.oauthErrorCode = oauthErrorCode;
+  }
+}
+
+function parseOAuthErrorCode(bodyText: string): string | null {
+  try {
+    const body: unknown = JSON.parse(bodyText);
+
+    if (
+      body &&
+      typeof body === 'object' &&
+      typeof (body as { error?: unknown }).error === 'string'
+    ) {
+      return (body as { error: string }).error;
+    }
+  } catch {
+    // Non-JSON error body (HTML error page, plain text): no code.
+  }
+
+  return null;
+}
+
 export interface OAuthRequestOptions {
   /**
    * Fetch used for every protocol request. Custom-server flows pass an
@@ -449,7 +483,10 @@ export async function exchangeCodeForTokens(
 
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(`Token exchange failed: ${errorText}`);
+    throw new OAuthTokenRequestError(
+      `Token exchange failed: ${errorText}`,
+      parseOAuthErrorCode(errorText),
+    );
   }
 
   const tokens: OAuthTokens = await response.json();
@@ -492,7 +529,10 @@ export async function refreshOAuthToken(
 
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(`Token refresh failed: ${errorText}`);
+    throw new OAuthTokenRequestError(
+      `Token refresh failed: ${errorText}`,
+      parseOAuthErrorCode(errorText),
+    );
   }
 
   const tokens: OAuthTokens = await response.json();

--- a/packages/sdk/src/server/lib/mcp/oauth.ts
+++ b/packages/sdk/src/server/lib/mcp/oauth.ts
@@ -4,8 +4,12 @@
  * Pure protocol logic: endpoint discovery, PKCE, client registration,
  * token exchange, token refresh. No database access.
  *
- * SSRF validation is not needed because all MCP server URLs come from
- * the integration MCP_INTEGRATIONS constant — we control them.
+ * Catalog integration URLs come from the MCP_INTEGRATIONS constant and are
+ * fetched with the plain global fetch. Custom-server flows target
+ * operator-supplied URLs — and discovery follows URLs the *remote server*
+ * supplies (WWW-Authenticate hints, authorization_servers lists) — so those
+ * callers MUST pass an SSRF-guarded fetch via `OAuthRequestOptions.fetchImpl`;
+ * it is used for every hop.
  */
 import type {
   OAuthTokens,
@@ -19,6 +23,35 @@ import type {
 // Refresh token 5 minutes before expiration to avoid race conditions
 const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 const DEFAULT_TOKEN_ENDPOINT_AUTH_METHOD = 'client_secret_post';
+
+export interface OAuthRequestOptions {
+  /**
+   * Fetch used for every protocol request. Custom-server flows pass an
+   * SSRF-guarded implementation; defaults to the global fetch.
+   */
+  fetchImpl?: (
+    url: string,
+    init?: {
+      method?: string;
+      headers?: Record<string, string>;
+      body?: string;
+    },
+  ) => Promise<Response>;
+  /**
+   * RFC 8707 resource indicator sent on token requests. The current MCP
+   * authorization spec requires clients to send the canonical server URL;
+   * per-server opt-out exists because some servers reject unknown params.
+   */
+  resource?: string;
+}
+
+function resolveFetch(options?: OAuthRequestOptions) {
+  return (
+    options?.fetchImpl ??
+    ((url: string, init?: RequestInit) =>
+      init === undefined ? fetch(url) : fetch(url, init))
+  );
+}
 
 function buildDirectAuthorizationServerMetadataUrl(
   mcpServerUrl: string,
@@ -79,8 +112,9 @@ function getFetchErrorMessage(
 
 async function fetchOAuthServerMetadata(
   metadataUrl: string,
+  options?: OAuthRequestOptions,
 ): Promise<OAuthServerMetadata> {
-  const response = await fetch(metadataUrl);
+  const response = await resolveFetch(options)(metadataUrl);
 
   if (!response.ok) {
     throw new Error(
@@ -101,8 +135,9 @@ async function fetchOAuthServerMetadata(
 
 async function fetchProtectedResourceMetadata(
   metadataUrl: string,
+  options?: OAuthRequestOptions,
 ): Promise<OAuthProtectedResourceMetadata> {
-  const response = await fetch(metadataUrl);
+  const response = await resolveFetch(options)(metadataUrl);
 
   if (!response.ok) {
     throw new Error(
@@ -119,8 +154,9 @@ async function fetchProtectedResourceMetadata(
 
 async function fetchAdvertisedProtectedResourceMetadata(
   mcpServerUrl: string,
+  options?: OAuthRequestOptions,
 ): Promise<OAuthProtectedResourceMetadata> {
-  const response = await fetch(mcpServerUrl);
+  const response = await resolveFetch(options)(mcpServerUrl);
   const metadataUrl = getResourceMetadataUrlFromWwwAuthenticate(
     response.headers.get('www-authenticate'),
   );
@@ -132,7 +168,9 @@ async function fetchAdvertisedProtectedResourceMetadata(
     );
   }
 
-  return fetchProtectedResourceMetadata(metadataUrl);
+  // The metadata URL came from the server's own WWW-Authenticate header:
+  // it goes through the same (possibly guarded) fetch as every other hop.
+  return fetchProtectedResourceMetadata(metadataUrl, options);
 }
 
 function formatDiscoveryError(error: unknown): string {
@@ -145,17 +183,22 @@ function formatDiscoveryError(error: unknown): string {
  */
 export async function discoverOAuthProtectedResourceMetadata(
   mcpServerUrl: string,
+  options?: OAuthRequestOptions,
 ): Promise<OAuthProtectedResourceMetadata | undefined> {
   try {
     return await fetchProtectedResourceMetadata(
       buildProtectedResourceMetadataUrl(mcpServerUrl),
+      options,
     );
   } catch {
     // Fall through to the advertised metadata hint.
   }
 
   try {
-    return await fetchAdvertisedProtectedResourceMetadata(mcpServerUrl);
+    return await fetchAdvertisedProtectedResourceMetadata(
+      mcpServerUrl,
+      options,
+    );
   } catch {
     return undefined;
   }
@@ -169,12 +212,14 @@ export async function discoverOAuthProtectedResourceMetadata(
  */
 export async function discoverOAuthEndpoints(
   mcpServerUrl: string,
+  options?: OAuthRequestOptions,
 ): Promise<OAuthServerMetadata> {
   const errors: string[] = [];
 
   try {
     return await fetchOAuthServerMetadata(
       buildDirectAuthorizationServerMetadataUrl(mcpServerUrl),
+      options,
     );
   } catch (error) {
     errors.push(formatDiscoveryError(error));
@@ -182,7 +227,7 @@ export async function discoverOAuthEndpoints(
 
   try {
     const protectedResourceMetadata =
-      await discoverOAuthProtectedResourceMetadata(mcpServerUrl);
+      await discoverOAuthProtectedResourceMetadata(mcpServerUrl, options);
 
     if (!protectedResourceMetadata?.authorization_servers?.length) {
       throw new Error(
@@ -193,8 +238,11 @@ export async function discoverOAuthEndpoints(
     for (const issuerUrl of protectedResourceMetadata.authorization_servers ??
       []) {
       try {
+        // authorization_servers entries are server-supplied URLs: same
+        // (possibly guarded) fetch as every other hop.
         return await fetchOAuthServerMetadata(
           buildAuthorizationServerMetadataUrlFromIssuer(issuerUrl),
+          options,
         );
       } catch (error) {
         errors.push(formatDiscoveryError(error));
@@ -213,8 +261,9 @@ export async function discoverOAuthEndpoints(
 export async function registerOAuthClient(
   registrationEndpoint: string,
   metadata: OAuthClientMetadata,
+  options?: OAuthRequestOptions,
 ): Promise<OAuthClientInformation> {
-  const response = await fetch(registrationEndpoint, {
+  const response = await resolveFetch(options)(registrationEndpoint, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -374,6 +423,7 @@ export async function exchangeCodeForTokens(
   codeVerifier: string,
   clientInfo: OAuthClientInformation,
   redirectUri: string,
+  options?: OAuthRequestOptions,
 ): Promise<OAuthTokens> {
   const body = new URLSearchParams({
     grant_type: 'authorization_code',
@@ -381,12 +431,17 @@ export async function exchangeCodeForTokens(
     redirect_uri: redirectUri,
     code_verifier: codeVerifier,
   });
+
+  if (options?.resource) {
+    body.append('resource', options.resource);
+  }
+
   const headers: Record<string, string> = {
     'Content-Type': 'application/x-www-form-urlencoded',
   };
   applyTokenEndpointClientAuthentication(body, headers, clientInfo);
 
-  const response = await fetch(tokenEndpoint, {
+  const response = await resolveFetch(options)(tokenEndpoint, {
     method: 'POST',
     headers,
     body: body.toString(),
@@ -413,17 +468,23 @@ export async function refreshOAuthToken(
   tokenEndpoint: string,
   clientInfo: OAuthClientInformation,
   refreshToken: string,
+  options?: OAuthRequestOptions,
 ): Promise<OAuthTokens> {
   const body = new URLSearchParams({
     grant_type: 'refresh_token',
     refresh_token: refreshToken,
   });
+
+  if (options?.resource) {
+    body.append('resource', options.resource);
+  }
+
   const headers: Record<string, string> = {
     'Content-Type': 'application/x-www-form-urlencoded',
   };
   applyTokenEndpointClientAuthentication(body, headers, clientInfo);
 
-  const response = await fetch(tokenEndpoint, {
+  const response = await resolveFetch(options)(tokenEndpoint, {
     method: 'POST',
     headers,
     body: body.toString(),

--- a/packages/sdk/src/server/lib/safe-fetch.ts
+++ b/packages/sdk/src/server/lib/safe-fetch.ts
@@ -1,0 +1,491 @@
+import { lookup as nodeDnsLookup } from 'node:dns';
+import { isIP } from 'node:net';
+
+import { Agent, fetch as undiciFetch } from 'undici';
+
+/**
+ * SSRF-guarded outbound fetch for operator-supplied URLs (custom MCP servers
+ * and their OAuth discovery chains).
+ *
+ * Historically the control plane never fetched arbitrary operator URLs (see
+ * the assumption documented in lib/mcp/oauth.ts), so no guard existed. Custom
+ * MCP servers break that assumption: the API proxies task traffic to
+ * admin-entered URLs and the OAuth flow fetches discovery documents from
+ * URLs the *remote server* supplies (WWW-Authenticate hints,
+ * authorization_servers lists). Every one of those fetches must go through
+ * this module.
+ *
+ * Defenses:
+ * - URL hygiene: http(s) only, no userinfo.
+ * - Address vetting: every DNS answer (not just the first) is checked against
+ *   a private/special-range blocklist before connecting; IP literals are
+ *   vetted directly.
+ * - Pinning: the undici Agent connects to the vetted address itself, so a
+ *   second resolution cannot rebind the hostname to an internal address
+ *   between check and connect (DNS-rebinding TOCTOU).
+ * - Redirects are refused by default: a redirect is a server-controlled URL
+ *   and following it would restart the whole problem with credentials
+ *   attached.
+ *
+ * Self-hosted deployments that intentionally run MCP servers on private
+ * networks can allow specific ranges via R_CUSTOM_MCP_ALLOWED_PRIVATE_CIDRS
+ * (threaded in by the caller as `allowedPrivateCidrs`). It is a CIDR list
+ * rather than a boolean so opening one internal host does not re-expose every
+ * adjacent service (database, cache, object store).
+ */
+
+export class SafeFetchViolationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SafeFetchViolationError';
+  }
+}
+
+interface ParsedCidr {
+  family: 4 | 6;
+  value: bigint;
+  prefix: number;
+}
+
+function ipv4ToBigInt(ip: string): bigint | null {
+  const parts = ip.split('.');
+
+  if (parts.length !== 4) {
+    return null;
+  }
+
+  let value = 0n;
+
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) {
+      return null;
+    }
+
+    const octet = Number(part);
+
+    if (octet > 255) {
+      return null;
+    }
+
+    value = (value << 8n) | BigInt(octet);
+  }
+
+  return value;
+}
+
+function ipv6ToBigInt(ip: string): bigint | null {
+  const zoneIndex = ip.indexOf('%');
+  const withoutZone = zoneIndex === -1 ? ip : ip.slice(0, zoneIndex);
+  const doubleColonSplit = withoutZone.split('::');
+
+  if (doubleColonSplit.length > 2) {
+    return null;
+  }
+
+  const expandGroups = (segment: string): string[] | null => {
+    if (segment === '') {
+      return [];
+    }
+
+    const groups: string[] = [];
+
+    for (const group of segment.split(':')) {
+      if (group.includes('.')) {
+        const embedded = ipv4ToBigInt(group);
+
+        if (embedded === null) {
+          return null;
+        }
+
+        groups.push(
+          ((embedded >> 16n) & 0xffffn).toString(16),
+          (embedded & 0xffffn).toString(16),
+        );
+      } else if (/^[0-9a-fA-F]{1,4}$/.test(group)) {
+        groups.push(group);
+      } else {
+        return null;
+      }
+    }
+
+    return groups;
+  };
+
+  const head = expandGroups(doubleColonSplit[0]!);
+  const tail =
+    doubleColonSplit.length === 2 ? expandGroups(doubleColonSplit[1]!) : [];
+
+  if (head === null || tail === null) {
+    return null;
+  }
+
+  const missing = 8 - head.length - tail.length;
+
+  if (doubleColonSplit.length === 2 ? missing < 0 : missing !== 0) {
+    return null;
+  }
+
+  const groups = [
+    ...head,
+    ...Array.from({ length: missing }, () => '0'),
+    ...tail,
+  ];
+
+  let value = 0n;
+
+  for (const group of groups) {
+    value = (value << 16n) | BigInt(parseInt(group, 16));
+  }
+
+  return value;
+}
+
+function parseAddress(ip: string): { family: 4 | 6; value: bigint } | null {
+  const family = isIP(ip);
+
+  if (family === 4) {
+    const value = ipv4ToBigInt(ip);
+    return value === null ? null : { family: 4, value };
+  }
+
+  if (family === 6) {
+    const value = ipv6ToBigInt(ip);
+    return value === null ? null : { family: 6, value };
+  }
+
+  return null;
+}
+
+export function parseCidrList(cidrs: string | undefined): ParsedCidr[] {
+  if (!cidrs) {
+    return [];
+  }
+
+  const parsed: ParsedCidr[] = [];
+
+  for (const entry of cidrs.split(',')) {
+    const trimmed = entry.trim();
+
+    if (!trimmed) {
+      continue;
+    }
+
+    const [address, prefixText] = trimmed.split('/');
+    const parsedAddress = parseAddress(address ?? '');
+
+    if (!parsedAddress) {
+      throw new SafeFetchViolationError(
+        `Invalid CIDR '${trimmed}' in allowed private ranges.`,
+      );
+    }
+
+    const maxPrefix = parsedAddress.family === 4 ? 32 : 128;
+    const prefix =
+      prefixText === undefined ? maxPrefix : Number.parseInt(prefixText, 10);
+
+    if (!Number.isInteger(prefix) || prefix < 0 || prefix > maxPrefix) {
+      throw new SafeFetchViolationError(`Invalid CIDR prefix in '${trimmed}'.`);
+    }
+
+    parsed.push({ ...parsedAddress, prefix });
+  }
+
+  return parsed;
+}
+
+function cidrContains(cidr: ParsedCidr, family: 4 | 6, value: bigint): boolean {
+  if (cidr.family !== family) {
+    return false;
+  }
+
+  const bits = family === 4 ? 32 : 128;
+  const shift = BigInt(bits - cidr.prefix);
+
+  return value >> shift === cidr.value >> shift;
+}
+
+function ipv4Cidr(text: string): ParsedCidr {
+  const [address, prefix] = text.split('/');
+  return { family: 4, value: ipv4ToBigInt(address!)!, prefix: Number(prefix) };
+}
+
+function ipv6Cidr(text: string): ParsedCidr {
+  const [address, prefix] = text.split('/');
+  return { family: 6, value: ipv6ToBigInt(address!)!, prefix: Number(prefix) };
+}
+
+/**
+ * Special-use and private ranges that operator-supplied URLs must never reach
+ * without an explicit CIDR allowance. Notably includes ranges the repo's
+ * observability helper does not (169.254.0.0/16 cloud metadata, 100.64.0.0/10
+ * CGNAT, 0.0.0.0/8) — that helper is a logging heuristic, not a control.
+ */
+const BLOCKED_IPV4_RANGES: ParsedCidr[] = [
+  ipv4Cidr('0.0.0.0/8'),
+  ipv4Cidr('10.0.0.0/8'),
+  ipv4Cidr('100.64.0.0/10'),
+  ipv4Cidr('127.0.0.0/8'),
+  ipv4Cidr('169.254.0.0/16'),
+  ipv4Cidr('172.16.0.0/12'),
+  ipv4Cidr('192.0.0.0/24'),
+  ipv4Cidr('192.168.0.0/16'),
+  ipv4Cidr('198.18.0.0/15'),
+  ipv4Cidr('224.0.0.0/4'),
+  ipv4Cidr('240.0.0.0/4'),
+];
+
+const BLOCKED_IPV6_RANGES: ParsedCidr[] = [
+  ipv6Cidr('::/128'),
+  ipv6Cidr('::1/128'),
+  ipv6Cidr('fc00::/7'),
+  ipv6Cidr('fe80::/10'),
+  ipv6Cidr('ff00::/8'),
+];
+
+const IPV4_MAPPED_PREFIX = ipv6Cidr('::ffff:0:0/96');
+const NAT64_PREFIX = ipv6Cidr('64:ff9b::/96');
+
+/**
+ * Returns null when the address is allowed, or a human-readable reason when
+ * it must be refused. `allowedPrivateCidrs` are consulted before the
+ * blocklist so self-hosters can open specific internal ranges.
+ */
+export function checkAddressAllowed(
+  ip: string,
+  allowedPrivateCidrs: ParsedCidr[],
+): string | null {
+  const parsed = parseAddress(ip);
+
+  if (!parsed) {
+    return `Address '${ip}' is not a valid IP address.`;
+  }
+
+  // Check IPv4-mapped / NAT64 IPv6 addresses as their embedded IPv4 value so
+  // `::ffff:10.0.0.1` cannot bypass the v4 blocklist.
+  if (
+    parsed.family === 6 &&
+    (cidrContains(IPV4_MAPPED_PREFIX, 6, parsed.value) ||
+      cidrContains(NAT64_PREFIX, 6, parsed.value))
+  ) {
+    const embedded = parsed.value & 0xffffffffn;
+    const dotted = [
+      (embedded >> 24n) & 0xffn,
+      (embedded >> 16n) & 0xffn,
+      (embedded >> 8n) & 0xffn,
+      embedded & 0xffn,
+    ].join('.');
+
+    return checkAddressAllowed(dotted, allowedPrivateCidrs);
+  }
+
+  if (
+    allowedPrivateCidrs.some((cidr) =>
+      cidrContains(cidr, parsed.family, parsed.value),
+    )
+  ) {
+    return null;
+  }
+
+  const blockedRanges =
+    parsed.family === 4 ? BLOCKED_IPV4_RANGES : BLOCKED_IPV6_RANGES;
+
+  if (
+    blockedRanges.some((cidr) =>
+      cidrContains(cidr, parsed.family, parsed.value),
+    )
+  ) {
+    return (
+      `Address '${ip}' is in a private or special-use range. Self-hosted ` +
+      `deployments can allow specific ranges with ` +
+      `R_CUSTOM_MCP_ALLOWED_PRIVATE_CIDRS.`
+    );
+  }
+
+  return null;
+}
+
+/** URL hygiene for operator-supplied endpoints: http(s) only, no userinfo. */
+export function validateEgressUrl(value: string | URL): URL {
+  let url: URL;
+
+  try {
+    url = value instanceof URL ? value : new URL(value);
+  } catch {
+    throw new SafeFetchViolationError(
+      `'${String(value)}' is not an absolute URL.`,
+    );
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new SafeFetchViolationError(
+      `'${url.toString()}' must use http or https.`,
+    );
+  }
+
+  if (url.username || url.password) {
+    throw new SafeFetchViolationError(
+      `'${url.toString()}' must not contain credentials.`,
+    );
+  }
+
+  return url;
+}
+
+export type DnsLookupFn = typeof nodeDnsLookup;
+
+export interface SafeFetchOptions {
+  /** Parsed value of R_CUSTOM_MCP_ALLOWED_PRIVATE_CIDRS. */
+  allowedPrivateCidrs?: string;
+  /** Override the DNS resolver (tests only). */
+  lookup?: DnsLookupFn;
+  /** Abort signal / timeout forwarded to the fetch. */
+  signal?: AbortSignal;
+  headers?: Record<string, string>;
+  method?: string;
+  body?: string;
+}
+
+interface GuardedAgentConfig {
+  allowedPrivateCidrs: string | undefined;
+  lookup: DnsLookupFn;
+}
+
+function createGuardedAgent(config: GuardedAgentConfig): Agent {
+  const allowed = parseCidrList(config.allowedPrivateCidrs);
+
+  return new Agent({
+    connect: {
+      lookup: (hostname, options, callback) => {
+        config.lookup(
+          hostname,
+          { ...options, all: true, verbatim: true },
+          (error, addresses) => {
+            if (error) {
+              callback(error, '', 4);
+              return;
+            }
+
+            const results = (
+              Array.isArray(addresses)
+                ? addresses
+                : [{ address: addresses as unknown as string, family: 4 }]
+            ) as { address: string; family: number }[];
+
+            const vetted = results.filter(
+              (result) => checkAddressAllowed(result.address, allowed) === null,
+            );
+
+            if (vetted.length === 0) {
+              const reason =
+                results.length === 0
+                  ? `DNS for '${hostname}' returned no addresses.`
+                  : (checkAddressAllowed(results[0]!.address, allowed) ??
+                    'refused');
+
+              callback(new SafeFetchViolationError(reason), '', 4);
+              return;
+            }
+
+            // Pin the connection to the vetted answers: undici connects to
+            // these literal addresses, so no later re-resolution can rebind.
+            if (options.all) {
+              callback(
+                null,
+                vetted.map((result) => ({
+                  address: result.address,
+                  family: result.family,
+                })) as never,
+                undefined as never,
+              );
+            } else {
+              callback(null, vetted[0]!.address, vetted[0]!.family);
+            }
+          },
+        );
+      },
+    },
+  });
+}
+
+const agentCache = new Map<string, Agent>();
+
+function guardedAgentFor(config: GuardedAgentConfig): Agent {
+  // Custom lookup functions are test-only; never cache those agents.
+  if (config.lookup !== nodeDnsLookup) {
+    return createGuardedAgent(config);
+  }
+
+  const key = config.allowedPrivateCidrs ?? '';
+  let agent = agentCache.get(key);
+
+  if (!agent) {
+    agent = createGuardedAgent(config);
+    agentCache.set(key, agent);
+  }
+
+  return agent;
+}
+
+/**
+ * Fetch an operator-supplied URL with SSRF guards. Redirects are refused:
+ * callers that legitimately need to follow one must re-validate the target
+ * through this function themselves.
+ */
+export async function safeFetch(
+  target: string | URL,
+  options: SafeFetchOptions = {},
+): Promise<Response> {
+  const url = validateEgressUrl(target);
+  const allowed = parseCidrList(options.allowedPrivateCidrs);
+
+  // IP literals never hit the lookup hook: vet them here.
+  if (isIP(url.hostname.replace(/^\[|\]$/g, '')) !== 0) {
+    const reason = checkAddressAllowed(
+      url.hostname.replace(/^\[|\]$/g, ''),
+      allowed,
+    );
+
+    if (reason !== null) {
+      throw new SafeFetchViolationError(reason);
+    }
+  }
+
+  const dispatcher = guardedAgentFor({
+    allowedPrivateCidrs: options.allowedPrivateCidrs,
+    lookup: options.lookup ?? nodeDnsLookup,
+  });
+
+  let response;
+
+  try {
+    response = await undiciFetch(url, {
+      method: options.method,
+      headers: options.headers,
+      body: options.body,
+      signal: options.signal,
+      redirect: 'manual',
+      dispatcher,
+    });
+  } catch (error) {
+    // undici wraps connection-phase failures in `TypeError: fetch failed`;
+    // surface the guard's own refusal directly so callers can distinguish
+    // policy violations from network errors.
+    if (
+      error instanceof Error &&
+      error.cause instanceof SafeFetchViolationError
+    ) {
+      throw error.cause;
+    }
+
+    throw error;
+  }
+
+  if (response.status >= 300 && response.status < 400) {
+    throw new SafeFetchViolationError(
+      `'${url.toString()}' answered with a redirect (${response.status}), ` +
+        `which is refused for operator-supplied URLs.`,
+    );
+  }
+
+  return response as unknown as Response;
+}

--- a/packages/sdk/src/server/lib/safe-fetch.ts
+++ b/packages/sdk/src/server/lib/safe-fetch.ts
@@ -470,6 +470,23 @@ function guardedAgentFor(config: GuardedAgentConfig): Agent {
 }
 
 /**
+ * A `fetch`-shaped wrapper around {@link safeFetch} for callers that thread a
+ * fetch implementation through protocol code (the MCP OAuth layer).
+ */
+export function createGuardedFetch(allowedPrivateCidrs?: string) {
+  return (
+    url: string,
+    init?: { method?: string; headers?: Record<string, string>; body?: string },
+  ): Promise<Response> =>
+    safeFetch(url, {
+      allowedPrivateCidrs,
+      method: init?.method,
+      headers: init?.headers,
+      body: init?.body,
+    });
+}
+
+/**
  * Fetch an operator-supplied URL with SSRF guards. Redirects are refused:
  * callers that legitimately need to follow one must re-validate the target
  * through this function themselves.

--- a/packages/sdk/src/server/lib/safe-fetch.ts
+++ b/packages/sdk/src/server/lib/safe-fetch.ts
@@ -347,71 +347,114 @@ export interface SafeFetchOptions {
 
 interface GuardedAgentConfig {
   allowedPrivateCidrs: string | undefined;
-  lookup: DnsLookupFn;
+  lookup?: DnsLookupFn;
+}
+
+/**
+ * Hygiene + IP-literal vetting for an operator-supplied URL. IP literals
+ * never reach a DNS lookup hook, so they must be checked here; hostnames are
+ * vetted at connect time by {@link createGuardedConnectOptions}.
+ */
+export function assertEgressUrlAllowed(
+  target: string | URL,
+  allowedPrivateCidrs?: string,
+): URL {
+  const url = validateEgressUrl(target);
+  const bareHostname = url.hostname.replace(/^\[|\]$/g, '');
+
+  if (isIP(bareHostname) !== 0) {
+    const reason = checkAddressAllowed(
+      bareHostname,
+      parseCidrList(allowedPrivateCidrs),
+    );
+
+    if (reason !== null) {
+      throw new SafeFetchViolationError(reason);
+    }
+  }
+
+  return url;
+}
+
+/**
+ * undici `connect` options that vet and pin every DNS answer. Exported so
+ * callers with their own Agent needs (e.g. the API's long-lived-stream proxy
+ * dispatcher) can compose the guard with other Agent options.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function createGuardedConnectOptions(config: GuardedAgentConfig): any {
+  const allowed = parseCidrList(config.allowedPrivateCidrs);
+  const lookup = config.lookup ?? nodeDnsLookup;
+
+  return {
+    lookup: (
+      hostname: string,
+      options: { all?: boolean } & Record<string, unknown>,
+      callback: (
+        error: NodeJS.ErrnoException | null,
+        address: unknown,
+        family?: number,
+      ) => void,
+    ) => {
+      lookup(
+        hostname,
+        { ...options, all: true, verbatim: true },
+        (error, addresses) => {
+          if (error) {
+            callback(error, '', 4);
+            return;
+          }
+
+          const results = (
+            Array.isArray(addresses)
+              ? addresses
+              : [{ address: addresses as unknown as string, family: 4 }]
+          ) as { address: string; family: number }[];
+
+          const vetted = results.filter(
+            (result) => checkAddressAllowed(result.address, allowed) === null,
+          );
+
+          if (vetted.length === 0) {
+            const reason =
+              results.length === 0
+                ? `DNS for '${hostname}' returned no addresses.`
+                : (checkAddressAllowed(results[0]!.address, allowed) ??
+                  'refused');
+
+            callback(new SafeFetchViolationError(reason), '', 4);
+            return;
+          }
+
+          // Pin the connection to the vetted answers: undici connects to
+          // these literal addresses, so no later re-resolution can rebind.
+          if (options.all) {
+            callback(
+              null,
+              vetted.map((result) => ({
+                address: result.address,
+                family: result.family,
+              })),
+              undefined,
+            );
+          } else {
+            callback(null, vetted[0]!.address, vetted[0]!.family);
+          }
+        },
+      );
+    },
+  };
 }
 
 function createGuardedAgent(config: GuardedAgentConfig): Agent {
-  const allowed = parseCidrList(config.allowedPrivateCidrs);
-
-  return new Agent({
-    connect: {
-      lookup: (hostname, options, callback) => {
-        config.lookup(
-          hostname,
-          { ...options, all: true, verbatim: true },
-          (error, addresses) => {
-            if (error) {
-              callback(error, '', 4);
-              return;
-            }
-
-            const results = (
-              Array.isArray(addresses)
-                ? addresses
-                : [{ address: addresses as unknown as string, family: 4 }]
-            ) as { address: string; family: number }[];
-
-            const vetted = results.filter(
-              (result) => checkAddressAllowed(result.address, allowed) === null,
-            );
-
-            if (vetted.length === 0) {
-              const reason =
-                results.length === 0
-                  ? `DNS for '${hostname}' returned no addresses.`
-                  : (checkAddressAllowed(results[0]!.address, allowed) ??
-                    'refused');
-
-              callback(new SafeFetchViolationError(reason), '', 4);
-              return;
-            }
-
-            // Pin the connection to the vetted answers: undici connects to
-            // these literal addresses, so no later re-resolution can rebind.
-            if (options.all) {
-              callback(
-                null,
-                vetted.map((result) => ({
-                  address: result.address,
-                  family: result.family,
-                })) as never,
-                undefined as never,
-              );
-            } else {
-              callback(null, vetted[0]!.address, vetted[0]!.family);
-            }
-          },
-        );
-      },
-    },
-  });
+  return new Agent({ connect: createGuardedConnectOptions(config) });
 }
 
 const agentCache = new Map<string, Agent>();
 
 function guardedAgentFor(config: GuardedAgentConfig): Agent {
   // Custom lookup functions are test-only; never cache those agents.
-  if (config.lookup !== nodeDnsLookup) {
+  if (config.lookup && config.lookup !== nodeDnsLookup) {
     return createGuardedAgent(config);
   }
 
@@ -435,24 +478,11 @@ export async function safeFetch(
   target: string | URL,
   options: SafeFetchOptions = {},
 ): Promise<Response> {
-  const url = validateEgressUrl(target);
-  const allowed = parseCidrList(options.allowedPrivateCidrs);
-
-  // IP literals never hit the lookup hook: vet them here.
-  if (isIP(url.hostname.replace(/^\[|\]$/g, '')) !== 0) {
-    const reason = checkAddressAllowed(
-      url.hostname.replace(/^\[|\]$/g, ''),
-      allowed,
-    );
-
-    if (reason !== null) {
-      throw new SafeFetchViolationError(reason);
-    }
-  }
+  const url = assertEgressUrlAllowed(target, options.allowedPrivateCidrs);
 
   const dispatcher = guardedAgentFor({
     allowedPrivateCidrs: options.allowedPrivateCidrs,
-    lookup: options.lookup ?? nodeDnsLookup,
+    lookup: options.lookup,
   });
 
   let response;

--- a/packages/sdk/src/server/routers/mcp-connections.test.ts
+++ b/packages/sdk/src/server/routers/mcp-connections.test.ts
@@ -8,6 +8,7 @@ vi.mock('@roomote/env', () => ({
   Env: mockEnv,
   areCuratedIntegrationsDisabled: (value: boolean | undefined) =>
     value === true,
+  isCustomMcpDisabled: (value: boolean | undefined) => value === true,
 }));
 
 const {
@@ -26,6 +27,8 @@ const {
   mockIsNull,
   mockInArray,
   mockDesc,
+  mockFindCustomServers,
+  mockFindConnectionFirst,
 } = vi.hoisted(() => {
   const mockOrderBy = vi.fn();
   const mockWhere = vi.fn(() => ({
@@ -64,6 +67,8 @@ const {
       values,
     })),
     mockDesc: vi.fn((column: unknown) => ({ type: 'desc', column })),
+    mockFindCustomServers: vi.fn(async () => []),
+    mockFindConnectionFirst: vi.fn(async () => undefined),
   };
 });
 
@@ -78,9 +83,19 @@ vi.mock('@roomote/db/server', () => ({
       },
       mcpConnections: {
         findMany: mockFindConnections,
+        findFirst: mockFindConnectionFirst,
+      },
+      customMcpServers: {
+        findMany: mockFindCustomServers,
         findFirst: vi.fn(),
       },
     },
+  },
+  customMcpServers: {
+    id: 'customServer.id',
+    name: 'customServer.name',
+    enabled: 'customServer.enabled',
+    stdio: 'customServer.stdio',
   },
   mcpConnections: {
     id: 'connection.id',
@@ -101,7 +116,14 @@ vi.mock('@roomote/db/server', () => ({
   and: mockAnd,
   or: mockOr,
   isNull: mockIsNull,
+  isNotNull: vi.fn((column: unknown) => ({ type: 'isNotNull', column })),
   inArray: mockInArray,
+}));
+
+vi.mock('@roomote/db/encryption', () => ({
+  encrypt: vi.fn((value: string) => `enc(${value})`),
+  decrypt: vi.fn((value: string) => value.replace(/^enc\(|\)$/g, '')),
+  decryptText: vi.fn((value: string) => value),
 }));
 
 vi.mock('../lib/mcp/data', () => ({
@@ -855,5 +877,143 @@ describe('mcpConnectionsRouter.getMcpServerConfigs', () => {
     ).getMcpServerConfigs();
 
     expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('custom MCP server delivery', () => {
+  beforeEach(() => {
+    mockFindCustomServers.mockReset();
+    mockFindCustomServers.mockResolvedValue([]);
+    mockFindConnectionFirst.mockReset();
+    mockFindConnectionFirst.mockResolvedValue(undefined);
+    mockEnv.R_CURATED_INTEGRATIONS_DISABLED = false;
+    mockEnv.R_CUSTOM_MCP_DISABLED = false;
+  });
+
+  const remoteRow = {
+    id: 'server-uuid-1',
+    name: 'internal-tools',
+    url: 'https://mcp.internal.example/mcp',
+    authType: 'static_headers',
+    stdio: null,
+    enabled: true,
+  };
+
+  it('delivers custom proxy entries even when curated integrations are disabled', async () => {
+    mockEnv.R_CURATED_INTEGRATIONS_DISABLED = true;
+    mockFindCustomServers.mockResolvedValue([remoteRow]);
+
+    const result = await createJobCaller(
+      'https://app.example.com/api/trpc/x',
+    ).getMcpServerConfigs();
+
+    expect(result.servers['internal-tools']).toEqual({
+      url: 'https://app.example.com/api/mcp/custom/server-uuid-1',
+      headers: { 'X-MCP-Client': 'Roomote' },
+    });
+    // The upstream URL and static headers never appear in the response.
+    expect(JSON.stringify(result)).not.toContain('mcp.internal.example');
+  });
+
+  it('honors the custom kill switch independently of the curated flag', async () => {
+    mockEnv.R_CUSTOM_MCP_DISABLED = true;
+    mockFindCustomServers.mockResolvedValue([remoteRow]);
+    mockFindEnablements.mockResolvedValue([]);
+    mockOrderBy.mockResolvedValue([]);
+
+    const result = await createJobCaller(
+      'https://app.example.com/api/trpc/x',
+    ).getMcpServerConfigs();
+
+    expect(result.servers['internal-tools']).toBeUndefined();
+  });
+
+  it('skips oauth custom servers without an authenticated connection', async () => {
+    mockFindCustomServers.mockResolvedValue([
+      { ...remoteRow, authType: 'oauth' },
+    ]);
+    mockFindEnablements.mockResolvedValue([]);
+    mockOrderBy.mockResolvedValue([]);
+    mockFindConnectionFirst.mockResolvedValue({ authStatus: 'pending' });
+
+    const result = await createJobCaller(
+      'https://app.example.com/api/trpc/x',
+    ).getMcpServerConfigs();
+
+    expect(result.servers['internal-tools']).toBeUndefined();
+  });
+
+  it('includes oauth custom servers once authenticated', async () => {
+    mockFindCustomServers.mockResolvedValue([
+      { ...remoteRow, authType: 'oauth' },
+    ]);
+    mockFindEnablements.mockResolvedValue([]);
+    mockOrderBy.mockResolvedValue([]);
+    mockFindConnectionFirst.mockResolvedValue({ authStatus: 'authenticated' });
+
+    const result = await createJobCaller(
+      'https://app.example.com/api/trpc/x',
+    ).getMcpServerConfigs();
+
+    expect(result.servers['internal-tools']?.url).toBe(
+      'https://app.example.com/api/mcp/custom/server-uuid-1',
+    );
+  });
+
+  it('excludes stdio rows from remote delivery', async () => {
+    mockFindCustomServers.mockResolvedValue([
+      {
+        ...remoteRow,
+        url: null,
+        stdio: { command: 'npx', env: { TOKEN: 'enc(sec)' } },
+      },
+    ]);
+    mockFindEnablements.mockResolvedValue([]);
+    mockOrderBy.mockResolvedValue([]);
+
+    const result = await createJobCaller(
+      'https://app.example.com/api/trpc/x',
+    ).getMcpServerConfigs();
+
+    expect(Object.keys(result.servers)).toHaveLength(0);
+  });
+});
+
+describe('getCustomStdioMcpServers', () => {
+  beforeEach(() => {
+    mockFindCustomServers.mockReset();
+    mockFindCustomServers.mockResolvedValue([]);
+    mockEnv.R_CUSTOM_MCP_DISABLED = false;
+  });
+
+  it('rejects plain auth tokens', async () => {
+    await expect(
+      createCaller().getCustomStdioMcpServers(),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  it('returns decrypted stdio env values to run tokens', async () => {
+    mockFindCustomServers.mockResolvedValue([
+      {
+        id: 'server-uuid-2',
+        name: 'local-tools',
+        url: null,
+        authType: 'none',
+        stdio: {
+          command: 'npx',
+          args: ['-y', '@example/server'],
+          env: { EXAMPLE_TOKEN: 'enc(stdio-secret)' },
+        },
+        enabled: true,
+      },
+    ]);
+
+    const result = await createJobCaller().getCustomStdioMcpServers();
+
+    expect(result.servers['local-tools']).toEqual({
+      command: 'npx',
+      args: ['-y', '@example/server'],
+      env: { EXAMPLE_TOKEN: 'stdio-secret' },
+    });
   });
 });

--- a/packages/sdk/src/server/routers/mcp-connections.test.ts
+++ b/packages/sdk/src/server/routers/mcp-connections.test.ts
@@ -2,6 +2,7 @@ import type { AuthTokenContext, RunTokenContext } from '@roomote/types';
 
 const mockEnv = vi.hoisted(() => ({
   R_CURATED_INTEGRATIONS_DISABLED: false,
+  R_CUSTOM_MCP_DISABLED: false,
 }));
 
 vi.mock('@roomote/env', () => ({
@@ -67,8 +68,12 @@ const {
       values,
     })),
     mockDesc: vi.fn((column: unknown) => ({ type: 'desc', column })),
-    mockFindCustomServers: vi.fn(async () => []),
-    mockFindConnectionFirst: vi.fn(async () => undefined),
+    mockFindCustomServers: vi.fn<(...args: unknown[]) => Promise<unknown>>(
+      async () => [],
+    ),
+    mockFindConnectionFirst: vi.fn<(...args: unknown[]) => Promise<unknown>>(
+      async () => undefined,
+    ),
   };
 });
 

--- a/packages/sdk/src/server/routers/mcp-connections.ts
+++ b/packages/sdk/src/server/routers/mcp-connections.ts
@@ -1,17 +1,24 @@
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
-import { Env, areCuratedIntegrationsDisabled } from '@roomote/env';
+import {
+  Env,
+  areCuratedIntegrationsDisabled,
+  isCustomMcpDisabled,
+} from '@roomote/env';
 import {
   db,
   desc,
   mcpConnections,
   deploymentMcpEnablements,
+  customMcpServers,
   eq,
   and,
   inArray,
   isNull,
+  isNotNull,
   or,
 } from '@roomote/db/server';
+import { decrypt } from '@roomote/db/encryption';
 import { getValidAccessToken, hasValidOAuthTokens } from '../lib/mcp/data';
 import {
   getMcpIntegrationUpstreamUrl,
@@ -25,10 +32,17 @@ import {
   isMcpConnectionSnowflakeConfig,
   isMcpConnectionVercelConfig,
   isDeploymentScopedMcpIntegration,
+  CUSTOM_MCP_PROXY_PATH_PREFIX,
+  customMcpConnectionId,
   PRODUCT_NAME,
 } from '@roomote/types';
 
-import { authenticatedProcedure, userOnlyProcedure, router } from '../trpc';
+import {
+  authenticatedProcedure,
+  isRunToken,
+  userOnlyProcedure,
+  router,
+} from '../trpc';
 import { resolveActorScopedUserContext } from '../lib/auth';
 
 const INTEGRATION_PROXY_MCP_IDS = new Set(
@@ -139,237 +153,28 @@ export const mcpConnectionsRouter = router({
    * Returns a map of sanitized server names to { url, headers }.
    */
   getMcpServerConfigs: authenticatedProcedure.query(async ({ ctx }) => {
-    if (areCuratedIntegrationsDisabled(Env.R_CURATED_INTEGRATIONS_DISABLED)) {
-      return { servers: {} };
-    }
-
-    const actorContext = await resolveActorScopedUserContext(ctx.auth);
-
-    const connectionFilters = [];
-
-    if (actorContext.userId && USER_SCOPED_MCP_IDS.length > 0) {
-      connectionFilters.push(
-        and(
-          eq(mcpConnections.userId, actorContext.userId),
-          inArray(mcpConnections.mcpId, USER_SCOPED_MCP_IDS),
-        ),
-      );
-    }
-
-    if (ORGANIZATION_SCOPED_MCP_IDS.length > 0) {
-      connectionFilters.push(
-        and(
-          isNull(mcpConnections.userId),
-          inArray(mcpConnections.mcpId, ORGANIZATION_SCOPED_MCP_IDS),
-        ),
-      );
-    }
-
-    if (connectionFilters.length === 0) {
-      return { servers: {} };
-    }
-
-    const enabledConnections = await db
-      .select({
-        enabledMcpId: deploymentMcpEnablements.mcpId,
-        connection: mcpConnections,
-      })
-      .from(deploymentMcpEnablements)
-      .leftJoin(
-        mcpConnections,
-        and(
-          eq(mcpConnections.mcpId, deploymentMcpEnablements.mcpId),
-          eq(mcpConnections.enabled, true),
-          or(...connectionFilters),
-        ),
-      )
-      .where(and(eq(deploymentMcpEnablements.enabled, true)))
-      .orderBy(desc(mcpConnections.createdAt));
-
-    const enabledMcpIds = new Set(
-      enabledConnections.map(({ enabledMcpId }) => enabledMcpId),
-    );
-    const deploymentScopedEnabledIds = Array.from(enabledMcpIds).filter(
-      (mcpId) => isDeploymentScopedMcpIntegration(mcpId),
-    );
-    const userScopedEnabledIds = Array.from(enabledMcpIds).filter(
-      (mcpId) => !isDeploymentScopedMcpIntegration(mcpId),
-    );
-    const connections = enabledConnections.flatMap(({ connection }) =>
-      connection ? [connection] : [],
-    );
-
-    console.info('[getMcpServerConfigs] Enabled MCP IDs found:', [
-      ...enabledMcpIds,
-    ]);
-    console.info('[getMcpServerConfigs] Connection filter counts:', {
-      deploymentScopedCount: deploymentScopedEnabledIds.length,
-      userScopedCount: actorContext.userId ? userScopedEnabledIds.length : 0,
-    });
-
     const servers: Record<
       string,
       { url: string; headers: Record<string, string> }
     > = {};
-    const requestOrigin = getRequestOrigin(ctx.req);
 
-    for (const connection of connections) {
-      console.info('[getMcpServerConfigs] Processing connection:', {
-        connectionId: connection.id,
-        mcpId: connection.mcpId,
-        userId: connection.userId,
-      });
+    if (!areCuratedIntegrationsDisabled(Env.R_CURATED_INTEGRATIONS_DISABLED)) {
+      Object.assign(servers, await buildCuratedMcpServerConfigs(ctx));
+    }
 
-      if (!enabledMcpIds.has(connection.mcpId)) {
-        console.info('[getMcpServerConfigs] Skipping connection:', {
-          connectionId: connection.id,
-          mcpId: connection.mcpId,
-          reason: 'mcp_not_enabled',
-        });
-        continue;
-      }
+    // Deployment custom servers are delivered independently of the curated
+    // kill switch: operators who disable the catalog are precisely the
+    // audience for custom servers. Name collisions cannot happen (curated ids
+    // are reserved at save time), but curated entries win defensively.
+    if (!isCustomMcpDisabled(Env.R_CUSTOM_MCP_DISABLED)) {
+      const custom = await buildCustomMcpServerConfigs(
+        getRequestOrigin(ctx.req),
+      );
 
-      const integration = getMcpIntegration(connection.mcpId);
-      if (!integration) {
-        console.info('[getMcpServerConfigs] Skipping connection:', {
-          connectionId: connection.id,
-          mcpId: connection.mcpId,
-          reason: 'integration_not_found',
-        });
-        continue;
-      }
-
-      if (connection.mcpId === 'linear') {
-        if (!INTEGRATION_PROXY_MCP_IDS.has(connection.mcpId)) {
-          continue;
+      for (const [name, config] of Object.entries(custom)) {
+        if (!servers[name]) {
+          servers[name] = config;
         }
-
-        servers[connection.mcpId] = {
-          url: buildProxyUrl(connection.mcpId, requestOrigin),
-          headers: {
-            'X-MCP-Client': PRODUCT_NAME,
-          },
-        };
-        console.info('[getMcpServerConfigs] Included connection:', {
-          connectionId: connection.id,
-          mcpId: connection.mcpId,
-          via: 'linear_proxy',
-        });
-        continue;
-      }
-
-      const connectionScope = getMcpIntegrationConnectionScope(integration);
-      if (
-        (connectionScope === 'deployment' && connection.userId !== null) ||
-        (connectionScope === 'user' &&
-          (!actorContext.userId || connection.userId !== actorContext.userId))
-      ) {
-        console.info('[getMcpServerConfigs] Skipping connection:', {
-          connectionId: connection.id,
-          mcpId: connection.mcpId,
-          reason: 'scope_mismatch',
-        });
-        continue;
-      }
-
-      try {
-        const headers: Record<string, string> = {
-          'X-MCP-Client': PRODUCT_NAME,
-        };
-
-        const authConfig = connection.authConfig;
-
-        if (isMcpConnectionOAuthConfig(authConfig)) {
-          // OAuth flow — resolve access token, refreshing if needed
-          const upstreamUrl = getMcpIntegrationUpstreamUrl(integration);
-
-          if (!upstreamUrl) {
-            console.warn(
-              `[getMcpServerConfigs] Missing upstream URL for OAuth-backed MCP ${integration.id}, skipping`,
-            );
-            continue;
-          }
-
-          const accessToken = await getValidAccessToken(
-            connection.id,
-            upstreamUrl,
-          );
-
-          if (!accessToken) {
-            console.warn(
-              `[getMcpServerConfigs] No tokens found for connection ${connection.id}, skipping`,
-            );
-            console.info('[getMcpServerConfigs] Skipping connection:', {
-              connectionId: connection.id,
-              mcpId: connection.mcpId,
-              reason: 'missing_access_token',
-            });
-            continue;
-          }
-
-          if (INTEGRATION_PROXY_MCP_IDS.has(connection.mcpId)) {
-            servers[connection.mcpId] = {
-              url: buildProxyUrl(connection.mcpId, requestOrigin),
-              headers,
-            };
-            console.info('[getMcpServerConfigs] Included connection:', {
-              connectionId: connection.id,
-              mcpId: connection.mcpId,
-              via: 'proxy',
-            });
-            continue;
-          }
-
-          headers['Authorization'] = `Bearer ${accessToken}`;
-        } else if (
-          isMcpConnectionSnowflakeConfig(authConfig) ||
-          isMcpConnectionAsanaConfig(authConfig) ||
-          isMcpConnectionGranolaConfig(authConfig) ||
-          isMcpConnectionVercelConfig(authConfig) ||
-          isMcpConnectionGrafanaConfig(authConfig)
-        ) {
-          servers[connection.mcpId] = {
-            url: buildProxyUrl(connection.mcpId, requestOrigin),
-            headers,
-          };
-          console.info('[getMcpServerConfigs] Included connection:', {
-            connectionId: connection.id,
-            mcpId: connection.mcpId,
-            via: 'native_proxy',
-          });
-          continue;
-        } else {
-          // No valid auth config — skip pending/incomplete connections
-          console.info('[getMcpServerConfigs] Skipping connection:', {
-            connectionId: connection.id,
-            mcpId: connection.mcpId,
-            reason: 'invalid_auth_config',
-          });
-          continue;
-        }
-
-        const upstreamUrl = getMcpIntegrationUpstreamUrl(integration);
-
-        if (!upstreamUrl) {
-          console.info('[getMcpServerConfigs] Skipping connection:', {
-            connectionId: connection.id,
-            mcpId: connection.mcpId,
-            reason: 'missing_upstream_url',
-          });
-          continue;
-        }
-
-        servers[connection.mcpId] = { url: upstreamUrl, headers };
-        console.info('[getMcpServerConfigs] Included connection:', {
-          connectionId: connection.id,
-          mcpId: connection.mcpId,
-          via: 'upstream',
-        });
-      } catch (error) {
-        console.error(
-          `[getMcpServerConfigs] Failed to build config for ${connection.id}:`,
-          error instanceof Error ? error.message : String(error),
-        );
       }
     }
 
@@ -379,4 +184,348 @@ export const mcpConnectionsRouter = router({
 
     return { servers };
   }),
+
+  /**
+   * Deployment-scoped custom stdio MCP servers, with decrypted env values.
+   *
+   * Run-token only: the response contains the secret material the sandbox
+   * needs to launch the local process, which a member's plain auth token must
+   * not be able to read directly.
+   */
+  getCustomStdioMcpServers: authenticatedProcedure.query(async ({ ctx }) => {
+    if (!isRunToken(ctx.auth)) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'Custom stdio MCP configs are only served to run tokens.',
+      });
+    }
+
+    if (isCustomMcpDisabled(Env.R_CUSTOM_MCP_DISABLED)) {
+      return { servers: {} };
+    }
+
+    const rows = await db.query.customMcpServers.findMany({
+      where: and(
+        eq(customMcpServers.enabled, true),
+        isNotNull(customMcpServers.stdio),
+      ),
+    });
+
+    const servers: Record<
+      string,
+      { command: string; args?: string[]; env?: Record<string, string> }
+    > = {};
+
+    for (const row of rows) {
+      if (!row.stdio) {
+        continue;
+      }
+
+      servers[row.name] = {
+        command: row.stdio.command,
+        ...(row.stdio.args ? { args: row.stdio.args } : {}),
+        ...(row.stdio.env
+          ? {
+              env: Object.fromEntries(
+                Object.entries(row.stdio.env).map(([name, value]) => [
+                  name,
+                  decrypt(value),
+                ]),
+              ),
+            }
+          : {}),
+      };
+    }
+
+    return { servers };
+  }),
 });
+
+/**
+ * Proxy entries for enabled deployment custom remote servers. Secret-free by
+ * construction: credentials are injected by the API proxy per request, so
+ * this is safe to serve to any authenticated principal and to re-serve on
+ * actor refreshes (the entries are actor-independent).
+ */
+async function buildCustomMcpServerConfigs(
+  requestOrigin: string | null,
+): Promise<Record<string, { url: string; headers: Record<string, string> }>> {
+  const servers: Record<
+    string,
+    { url: string; headers: Record<string, string> }
+  > = {};
+
+  const rows = await db.query.customMcpServers.findMany({
+    where: eq(customMcpServers.enabled, true),
+  });
+
+  for (const row of rows) {
+    // stdio servers ride the worker merge path via getCustomStdioMcpServers.
+    if (row.stdio || !row.url) {
+      continue;
+    }
+
+    if (row.authType === 'oauth') {
+      const connection = await db.query.mcpConnections.findFirst({
+        where: and(
+          eq(mcpConnections.mcpId, customMcpConnectionId(row.id)),
+          isNull(mcpConnections.userId),
+        ),
+        columns: { authStatus: true },
+      });
+
+      if (connection?.authStatus !== 'authenticated') {
+        console.info(
+          `[getMcpServerConfigs] Skipping custom server '${row.name}': OAuth connection not authenticated`,
+        );
+        continue;
+      }
+    }
+
+    const proxyPath = `${CUSTOM_MCP_PROXY_PATH_PREFIX}${row.id}`;
+
+    servers[row.name] = {
+      url: requestOrigin ? `${requestOrigin}${proxyPath}` : proxyPath,
+      headers: { 'X-MCP-Client': PRODUCT_NAME },
+    };
+  }
+
+  return servers;
+}
+
+async function buildCuratedMcpServerConfigs(ctx: {
+  auth: Parameters<typeof resolveActorScopedUserContext>[0];
+  req?: { url?: string };
+}): Promise<Record<string, { url: string; headers: Record<string, string> }>> {
+  const actorContext = await resolveActorScopedUserContext(ctx.auth);
+
+  const connectionFilters = [];
+
+  if (actorContext.userId && USER_SCOPED_MCP_IDS.length > 0) {
+    connectionFilters.push(
+      and(
+        eq(mcpConnections.userId, actorContext.userId),
+        inArray(mcpConnections.mcpId, USER_SCOPED_MCP_IDS),
+      ),
+    );
+  }
+
+  if (ORGANIZATION_SCOPED_MCP_IDS.length > 0) {
+    connectionFilters.push(
+      and(
+        isNull(mcpConnections.userId),
+        inArray(mcpConnections.mcpId, ORGANIZATION_SCOPED_MCP_IDS),
+      ),
+    );
+  }
+
+  if (connectionFilters.length === 0) {
+    return {};
+  }
+
+  const enabledConnections = await db
+    .select({
+      enabledMcpId: deploymentMcpEnablements.mcpId,
+      connection: mcpConnections,
+    })
+    .from(deploymentMcpEnablements)
+    .leftJoin(
+      mcpConnections,
+      and(
+        eq(mcpConnections.mcpId, deploymentMcpEnablements.mcpId),
+        eq(mcpConnections.enabled, true),
+        or(...connectionFilters),
+      ),
+    )
+    .where(and(eq(deploymentMcpEnablements.enabled, true)))
+    .orderBy(desc(mcpConnections.createdAt));
+
+  const enabledMcpIds = new Set(
+    enabledConnections.map(({ enabledMcpId }) => enabledMcpId),
+  );
+  const deploymentScopedEnabledIds = Array.from(enabledMcpIds).filter((mcpId) =>
+    isDeploymentScopedMcpIntegration(mcpId),
+  );
+  const userScopedEnabledIds = Array.from(enabledMcpIds).filter(
+    (mcpId) => !isDeploymentScopedMcpIntegration(mcpId),
+  );
+  const connections = enabledConnections.flatMap(({ connection }) =>
+    connection ? [connection] : [],
+  );
+
+  console.info('[getMcpServerConfigs] Enabled MCP IDs found:', [
+    ...enabledMcpIds,
+  ]);
+  console.info('[getMcpServerConfigs] Connection filter counts:', {
+    deploymentScopedCount: deploymentScopedEnabledIds.length,
+    userScopedCount: actorContext.userId ? userScopedEnabledIds.length : 0,
+  });
+
+  const servers: Record<
+    string,
+    { url: string; headers: Record<string, string> }
+  > = {};
+  const requestOrigin = getRequestOrigin(ctx.req);
+
+  for (const connection of connections) {
+    console.info('[getMcpServerConfigs] Processing connection:', {
+      connectionId: connection.id,
+      mcpId: connection.mcpId,
+      userId: connection.userId,
+    });
+
+    if (!enabledMcpIds.has(connection.mcpId)) {
+      console.info('[getMcpServerConfigs] Skipping connection:', {
+        connectionId: connection.id,
+        mcpId: connection.mcpId,
+        reason: 'mcp_not_enabled',
+      });
+      continue;
+    }
+
+    const integration = getMcpIntegration(connection.mcpId);
+    if (!integration) {
+      console.info('[getMcpServerConfigs] Skipping connection:', {
+        connectionId: connection.id,
+        mcpId: connection.mcpId,
+        reason: 'integration_not_found',
+      });
+      continue;
+    }
+
+    if (connection.mcpId === 'linear') {
+      if (!INTEGRATION_PROXY_MCP_IDS.has(connection.mcpId)) {
+        continue;
+      }
+
+      servers[connection.mcpId] = {
+        url: buildProxyUrl(connection.mcpId, requestOrigin),
+        headers: {
+          'X-MCP-Client': PRODUCT_NAME,
+        },
+      };
+      console.info('[getMcpServerConfigs] Included connection:', {
+        connectionId: connection.id,
+        mcpId: connection.mcpId,
+        via: 'linear_proxy',
+      });
+      continue;
+    }
+
+    const connectionScope = getMcpIntegrationConnectionScope(integration);
+    if (
+      (connectionScope === 'deployment' && connection.userId !== null) ||
+      (connectionScope === 'user' &&
+        (!actorContext.userId || connection.userId !== actorContext.userId))
+    ) {
+      console.info('[getMcpServerConfigs] Skipping connection:', {
+        connectionId: connection.id,
+        mcpId: connection.mcpId,
+        reason: 'scope_mismatch',
+      });
+      continue;
+    }
+
+    try {
+      const headers: Record<string, string> = {
+        'X-MCP-Client': PRODUCT_NAME,
+      };
+
+      const authConfig = connection.authConfig;
+
+      if (isMcpConnectionOAuthConfig(authConfig)) {
+        // OAuth flow — resolve access token, refreshing if needed
+        const upstreamUrl = getMcpIntegrationUpstreamUrl(integration);
+
+        if (!upstreamUrl) {
+          console.warn(
+            `[getMcpServerConfigs] Missing upstream URL for OAuth-backed MCP ${integration.id}, skipping`,
+          );
+          continue;
+        }
+
+        const accessToken = await getValidAccessToken(
+          connection.id,
+          upstreamUrl,
+        );
+
+        if (!accessToken) {
+          console.warn(
+            `[getMcpServerConfigs] No tokens found for connection ${connection.id}, skipping`,
+          );
+          console.info('[getMcpServerConfigs] Skipping connection:', {
+            connectionId: connection.id,
+            mcpId: connection.mcpId,
+            reason: 'missing_access_token',
+          });
+          continue;
+        }
+
+        if (INTEGRATION_PROXY_MCP_IDS.has(connection.mcpId)) {
+          servers[connection.mcpId] = {
+            url: buildProxyUrl(connection.mcpId, requestOrigin),
+            headers,
+          };
+          console.info('[getMcpServerConfigs] Included connection:', {
+            connectionId: connection.id,
+            mcpId: connection.mcpId,
+            via: 'proxy',
+          });
+          continue;
+        }
+
+        headers['Authorization'] = `Bearer ${accessToken}`;
+      } else if (
+        isMcpConnectionSnowflakeConfig(authConfig) ||
+        isMcpConnectionAsanaConfig(authConfig) ||
+        isMcpConnectionGranolaConfig(authConfig) ||
+        isMcpConnectionVercelConfig(authConfig) ||
+        isMcpConnectionGrafanaConfig(authConfig)
+      ) {
+        servers[connection.mcpId] = {
+          url: buildProxyUrl(connection.mcpId, requestOrigin),
+          headers,
+        };
+        console.info('[getMcpServerConfigs] Included connection:', {
+          connectionId: connection.id,
+          mcpId: connection.mcpId,
+          via: 'native_proxy',
+        });
+        continue;
+      } else {
+        // No valid auth config — skip pending/incomplete connections
+        console.info('[getMcpServerConfigs] Skipping connection:', {
+          connectionId: connection.id,
+          mcpId: connection.mcpId,
+          reason: 'invalid_auth_config',
+        });
+        continue;
+      }
+
+      const upstreamUrl = getMcpIntegrationUpstreamUrl(integration);
+
+      if (!upstreamUrl) {
+        console.info('[getMcpServerConfigs] Skipping connection:', {
+          connectionId: connection.id,
+          mcpId: connection.mcpId,
+          reason: 'missing_upstream_url',
+        });
+        continue;
+      }
+
+      servers[connection.mcpId] = { url: upstreamUrl, headers };
+      console.info('[getMcpServerConfigs] Included connection:', {
+        connectionId: connection.id,
+        mcpId: connection.mcpId,
+        via: 'upstream',
+      });
+    } catch (error) {
+      console.error(
+        `[getMcpServerConfigs] Failed to build config for ${connection.id}:`,
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  return servers;
+}

--- a/packages/types/src/__tests__/custom-mcp-servers.test.ts
+++ b/packages/types/src/__tests__/custom-mcp-servers.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../custom-mcp-servers';
 
 const validServer = {
+  transport: 'remote' as const,
   name: 'internal-tools',
   url: 'https://mcp.example.com/mcp',
   authType: 'static_headers' as const,
@@ -23,12 +24,49 @@ describe('customMcpServerInputSchema', () => {
 
   it('accepts a no-auth server without headers', () => {
     const result = customMcpServerInputSchema.safeParse({
+      transport: 'remote',
       name: 'public-server',
       url: 'https://mcp.example.com',
       authType: 'none',
     });
 
     expect(result.success).toBe(true);
+  });
+
+  it('accepts a stdio server', () => {
+    const result = customMcpServerInputSchema.safeParse({
+      transport: 'stdio',
+      name: 'local-tools',
+      stdio: {
+        command: 'npx',
+        args: ['-y', '@example/mcp-server'],
+        env: { EXAMPLE_TOKEN: '${MY_DEPLOYMENT_VAR}' },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects reserved env references in stdio config', () => {
+    const result = customMcpServerInputSchema.safeParse({
+      transport: 'stdio',
+      name: 'local-tools',
+      stdio: {
+        command: 'npx',
+        env: { TOKEN: '{env:ROOMOTE_CLOUD_TOKEN}' },
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects client credentials on non-oauth servers', () => {
+    const result = customMcpServerInputSchema.safeParse({
+      ...validServer,
+      manualClientId: 'client-1',
+    });
+
+    expect(result.success).toBe(false);
   });
 
   it('rejects headers on a non-header auth type', () => {

--- a/packages/types/src/__tests__/custom-mcp-servers.test.ts
+++ b/packages/types/src/__tests__/custom-mcp-servers.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  RESERVED_CUSTOM_MCP_SERVER_NAMES,
+  customMcpServerInputSchema,
+  validateCustomMcpHeaderName,
+  validateCustomMcpServerUrl,
+} from '../custom-mcp-servers';
+
+const validServer = {
+  name: 'internal-tools',
+  url: 'https://mcp.example.com/mcp',
+  authType: 'static_headers' as const,
+  headers: { 'x-api-key': 'secret-value' },
+};
+
+describe('customMcpServerInputSchema', () => {
+  it('accepts a valid static-header server', () => {
+    expect(customMcpServerInputSchema.safeParse(validServer).success).toBe(
+      true,
+    );
+  });
+
+  it('accepts a no-auth server without headers', () => {
+    const result = customMcpServerInputSchema.safeParse({
+      name: 'public-server',
+      url: 'https://mcp.example.com',
+      authType: 'none',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects headers on a non-header auth type', () => {
+    const result = customMcpServerInputSchema.safeParse({
+      ...validServer,
+      authType: 'none',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it.each(['roomote', 'sentry', 'linear', 'github', 'slack', 'notion'])(
+    'rejects reserved name %s',
+    (name) => {
+      expect(RESERVED_CUSTOM_MCP_SERVER_NAMES.has(name)).toBe(true);
+
+      const result = customMcpServerInputSchema.safeParse({
+        ...validServer,
+        name,
+      });
+
+      expect(result.success).toBe(false);
+    },
+  );
+
+  it.each([
+    'Uppercase',
+    '-leading-dash',
+    'has space',
+    'has/slash',
+    'a'.repeat(65),
+  ])('rejects invalid name %s', (name) => {
+    const result = customMcpServerInputSchema.safeParse({
+      ...validServer,
+      name,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it.each([
+    'ftp://mcp.example.com',
+    'file:///etc/passwd',
+    'https://user:pass@mcp.example.com',
+    'not-a-url',
+  ])('rejects URL %s', (url) => {
+    const result = customMcpServerInputSchema.safeParse({
+      ...validServer,
+      url,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects reserved env references in header values', () => {
+    for (const value of [
+      'Bearer ${ROOMOTE_CLOUD_TOKEN}',
+      'Bearer {env:ROOMOTE_CLOUD_TOKEN}',
+      '$AUTH_TOKEN',
+      '{env:JOB_AUTH_PRIVATE_KEY}',
+    ]) {
+      const result = customMcpServerInputSchema.safeParse({
+        ...validServer,
+        headers: { 'x-api-key': value },
+      });
+
+      expect(result.success, value).toBe(false);
+    }
+  });
+
+  it('rejects reserved env references in the URL', () => {
+    const result = customMcpServerInputSchema.safeParse({
+      ...validServer,
+      url: 'https://mcp.example.com/{env:ROOMOTE_CLOUD_TOKEN}',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('allows operator-defined env references', () => {
+    const result = customMcpServerInputSchema.safeParse({
+      ...validServer,
+      headers: { 'x-api-key': '${MY_OWN_SECRET}' },
+    });
+
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('validateCustomMcpHeaderName', () => {
+  it.each([
+    'authorization',
+    'Authorization',
+    'Host',
+    'mcp-session-id',
+    'Cookie',
+  ])('denies proxy-managed header %s', (name) => {
+    expect(validateCustomMcpHeaderName(name)).not.toBeNull();
+  });
+
+  it.each(['x-api-key', 'X-Custom-Token', 'api-version'])(
+    'allows custom header %s',
+    (name) => {
+      expect(validateCustomMcpHeaderName(name)).toBeNull();
+    },
+  );
+
+  it('rejects header names with illegal characters', () => {
+    expect(validateCustomMcpHeaderName('bad header')).not.toBeNull();
+    expect(validateCustomMcpHeaderName('bad:header')).not.toBeNull();
+  });
+});
+
+describe('validateCustomMcpServerUrl', () => {
+  it('accepts plain http for self-hosted internal servers', () => {
+    expect(validateCustomMcpServerUrl('http://mcp.internal:8080/mcp')).toBe(
+      null,
+    );
+  });
+});
+
+describe('header value validation', () => {
+  it('rejects CR/LF injection in header values', () => {
+    const result = customMcpServerInputSchema.safeParse({
+      ...validServer,
+      headers: { 'x-api-key': 'value\r\nx-injected: 1' },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('allows tabs and normal printable values', () => {
+    const result = customMcpServerInputSchema.safeParse({
+      ...validServer,
+      headers: { 'x-api-key': 'value with spaces\tand tab' },
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/types/src/__tests__/custom-mcp-servers.test.ts
+++ b/packages/types/src/__tests__/custom-mcp-servers.test.ts
@@ -157,22 +157,25 @@ describe('customMcpServerInputSchema', () => {
 });
 
 describe('validateCustomMcpHeaderName', () => {
-  it.each([
-    'authorization',
-    'Authorization',
-    'Host',
-    'mcp-session-id',
-    'Cookie',
-  ])('denies proxy-managed header %s', (name) => {
-    expect(validateCustomMcpHeaderName(name)).not.toBeNull();
-  });
-
-  it.each(['x-api-key', 'X-Custom-Token', 'api-version'])(
-    'allows custom header %s',
+  it.each(['Host', 'mcp-session-id', 'Cookie'])(
+    'denies proxy-managed header %s',
     (name) => {
-      expect(validateCustomMcpHeaderName(name)).toBeNull();
+      expect(validateCustomMcpHeaderName(name)).not.toBeNull();
     },
   );
+
+  // Authorization is allowed on purpose: static bearer API keys are the
+  // common auth scheme for remote MCP servers, headers are restricted to the
+  // static_headers mode, and the proxy never forwards the caller's run token.
+  it.each([
+    'x-api-key',
+    'X-Custom-Token',
+    'api-version',
+    'authorization',
+    'Authorization',
+  ])('allows custom header %s', (name) => {
+    expect(validateCustomMcpHeaderName(name)).toBeNull();
+  });
 
   it('rejects header names with illegal characters', () => {
     expect(validateCustomMcpHeaderName('bad header')).not.toBeNull();

--- a/packages/types/src/custom-mcp-servers.ts
+++ b/packages/types/src/custom-mcp-servers.ts
@@ -202,12 +202,38 @@ export function collectCustomMcpReservedReferences(
   return Array.from(new Set(strings.flatMap(collectReservedEnvReferences)));
 }
 
-export const customMcpServerInputSchema = z
+function addReservedReferenceIssue(
+  ctx: z.RefinementCtx,
+  serverName: string,
+  strings: string[],
+): void {
+  const reserved = collectCustomMcpReservedReferences(strings);
+
+  if (reserved.length > 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        `Custom MCP server '${serverName}' references reserved ` +
+        `${PRODUCT_NAME} runtime environment variables ` +
+        `(${reserved.join(', ')}). Define your own deployment environment ` +
+        `variable under a different name and reference that instead.`,
+    });
+  }
+}
+
+export const MAX_CUSTOM_MCP_STDIO_ARGS = 32;
+export const MAX_CUSTOM_MCP_STDIO_ENV_VARS = 16;
+
+export const customMcpRemoteServerInputSchema = z
   .object({
+    transport: z.literal('remote'),
     name: customMcpServerNameSchema,
     url: z.string().min(1).max(MAX_CUSTOM_MCP_URL_LENGTH),
     authType: customMcpServerAuthTypeSchema,
     headers: customMcpServerHeadersSchema.optional(),
+    manualClientId: z.string().max(512).optional(),
+    manualClientSecret: z.string().max(4096).optional(),
+    oauthResourceIndicatorDisabled: z.boolean().optional(),
   })
   .superRefine((server, ctx) => {
     const urlError = validateCustomMcpServerUrl(server.url);
@@ -228,22 +254,72 @@ export const customMcpServerInputSchema = z
       });
     }
 
-    const reserved = collectCustomMcpReservedReferences([
+    if (
+      server.authType !== 'oauth' &&
+      (server.manualClientId || server.manualClientSecret)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['manualClientId'],
+        message: 'Client credentials are only allowed with OAuth.',
+      });
+    }
+
+    addReservedReferenceIssue(ctx, server.name, [
       server.name,
       server.url,
       ...Object.entries(server.headers ?? {}).flat(),
     ]);
-
-    if (reserved.length > 0) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message:
-          `Custom MCP server '${server.name}' references reserved ` +
-          `${PRODUCT_NAME} runtime environment variables ` +
-          `(${reserved.join(', ')}). Define your own deployment environment ` +
-          `variable under a different name and reference that instead.`,
-      });
-    }
   });
 
+export const customMcpStdioServerInputSchema = z
+  .object({
+    transport: z.literal('stdio'),
+    name: customMcpServerNameSchema,
+    stdio: customMcpServerStdioConfigSchema,
+  })
+  .superRefine((server, ctx) => {
+    if ((server.stdio.args?.length ?? 0) > MAX_CUSTOM_MCP_STDIO_ARGS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['stdio', 'args'],
+        message: `At most ${MAX_CUSTOM_MCP_STDIO_ARGS} arguments are allowed.`,
+      });
+    }
+
+    const envEntries = Object.entries(server.stdio.env ?? {});
+
+    if (envEntries.length > MAX_CUSTOM_MCP_STDIO_ENV_VARS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['stdio', 'env'],
+        message: `At most ${MAX_CUSTOM_MCP_STDIO_ENV_VARS} environment variables are allowed.`,
+      });
+    }
+
+    // The schema-attached superRefine on environmentMcpServersSchema does not
+    // protect this write path; reserved references must be rejected here
+    // explicitly. Names and values both flow into sandbox config text.
+    addReservedReferenceIssue(ctx, server.name, [
+      server.name,
+      server.stdio.command,
+      ...(server.stdio.args ?? []),
+      ...envEntries.flat(),
+    ]);
+  });
+
+// A plain union rather than discriminatedUnion: the members carry superRefine
+// effects, which discriminatedUnion does not accept. The `transport` literal
+// still discriminates in practice.
+export const customMcpServerInputSchema = z.union([
+  customMcpRemoteServerInputSchema,
+  customMcpStdioServerInputSchema,
+]);
+
+export type CustomMcpRemoteServerInput = z.infer<
+  typeof customMcpRemoteServerInputSchema
+>;
+export type CustomMcpStdioServerInput = z.infer<
+  typeof customMcpStdioServerInputSchema
+>;
 export type CustomMcpServerInput = z.infer<typeof customMcpServerInputSchema>;

--- a/packages/types/src/custom-mcp-servers.ts
+++ b/packages/types/src/custom-mcp-servers.ts
@@ -1,0 +1,249 @@
+import { z } from 'zod';
+
+import { MCP_INTEGRATIONS } from './mcp-oauth';
+import { PRODUCT_NAME } from './constants';
+import { collectReservedEnvReferences } from './reserved-mcp-env-vars';
+
+/**
+ * Deployment-scoped custom MCP servers.
+ *
+ * Unlike environment-scoped `mcpServers` (see environment-config.ts), these
+ * are managed by deployment admins in Settings and apply to every task. Remote
+ * servers are never handed to sandboxes directly: they are delivered as
+ * authenticated proxy URLs (`/api/mcp/custom/<serverId>`) and the API proxy
+ * injects the real credentials per request, so header values and OAuth tokens
+ * never enter sandbox-readable config.
+ */
+
+/**
+ * Lowercase slug, starts alphanumeric, up to 64 chars. The name becomes the
+ * MCP server key in the harness config, so keep it shell- and config-safe.
+ */
+export const CUSTOM_MCP_SERVER_NAME_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+
+/**
+ * Names that collide with servers Roomote itself wires into tasks. A custom
+ * server with one of these names would either be silently skipped by the
+ * worker's collision guard or, worse, be rewritten by the integration proxy
+ * path (setup-mcps.ts treats known integration ids specially), so reject them
+ * at save time. `github` and `slack` are not MCP_INTEGRATIONS ids but are
+ * reserved by the self-setup catalog and service detection.
+ */
+export const RESERVED_CUSTOM_MCP_SERVER_NAMES: ReadonlySet<string> = new Set([
+  'roomote',
+  'github',
+  'slack',
+  ...MCP_INTEGRATIONS.map((integration) => integration.id.toLowerCase()),
+]);
+
+/** The mcpConnections.mcpId namespace for custom-server OAuth connections. */
+export const CUSTOM_MCP_CONNECTION_PREFIX = 'custom:';
+
+export function customMcpConnectionId(serverId: string): string {
+  return `${CUSTOM_MCP_CONNECTION_PREFIX}${serverId}`;
+}
+
+export function isCustomMcpConnectionId(mcpId: string): boolean {
+  return mcpId.startsWith(CUSTOM_MCP_CONNECTION_PREFIX);
+}
+
+export const MAX_CUSTOM_MCP_SERVERS = 25;
+export const MAX_CUSTOM_MCP_HEADERS = 16;
+export const MAX_CUSTOM_MCP_HEADER_VALUE_LENGTH = 4096;
+export const MAX_CUSTOM_MCP_URL_LENGTH = 2048;
+
+/**
+ * Header names the proxy owns. Operator headers are applied after the proxy's
+ * allowlist rebuild, so without this check a custom header could silently
+ * override the injected auth or session headers, and a `Host` override could
+ * reach internal vhosts behind shared ingress even when IP-level egress
+ * checks pass.
+ */
+const DENIED_CUSTOM_MCP_HEADER_NAMES: ReadonlySet<string> = new Set([
+  'authorization',
+  'host',
+  'content-type',
+  'content-length',
+  'accept',
+  'accept-encoding',
+  'connection',
+  'cookie',
+  'transfer-encoding',
+  'mcp-session-id',
+  'mcp-protocol-version',
+  'x-mcp-client',
+]);
+
+/** RFC 7230 token chars; also excludes anything undici would reject. */
+const HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
+/** No CR/LF or other control chars: undici throws at request time otherwise. */
+// eslint-disable-next-line no-control-regex
+const HEADER_VALUE_ILLEGAL_PATTERN = /[\u0000-\u0008\u000a-\u001f\u007f]/;
+
+export function validateCustomMcpHeaderName(name: string): string | null {
+  if (!HEADER_NAME_PATTERN.test(name)) {
+    return `Header name '${name}' contains invalid characters.`;
+  }
+
+  if (DENIED_CUSTOM_MCP_HEADER_NAMES.has(name.toLowerCase())) {
+    return (
+      `Header '${name}' is managed by ${PRODUCT_NAME} and cannot be ` +
+      `overridden on a custom MCP server.`
+    );
+  }
+
+  return null;
+}
+
+export function validateCustomMcpServerUrl(value: string): string | null {
+  let url: URL;
+
+  try {
+    url = new URL(value);
+  } catch {
+    return 'Server URL must be an absolute HTTP(S) URL.';
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return 'Server URL must use http:// or https://.';
+  }
+
+  if (url.username || url.password) {
+    return 'Server URL must not contain credentials.';
+  }
+
+  return null;
+}
+
+/**
+ * Local (stdio) custom server config. Mirrors the environment-scoped stdio
+ * shape: the command runs inside the task sandbox with the same privileges as
+ * the agent, so its env values are sandbox-visible by construction (there is
+ * no proxy in a stdio pipe).
+ */
+export const customMcpServerStdioConfigSchema = z.object({
+  command: z.string().min(1),
+  args: z.array(z.string()).optional(),
+  env: z.record(z.string(), z.string()).optional(),
+});
+
+export type CustomMcpServerStdioConfig = z.infer<
+  typeof customMcpServerStdioConfigSchema
+>;
+
+export const customMcpServerAuthTypeSchema = z.enum([
+  'none',
+  'static_headers',
+  'oauth',
+]);
+
+export type CustomMcpServerAuthType = z.infer<
+  typeof customMcpServerAuthTypeSchema
+>;
+
+export const customMcpServerNameSchema = z
+  .string()
+  .regex(
+    CUSTOM_MCP_SERVER_NAME_PATTERN,
+    'Server name must be a lowercase slug (letters, digits, "-", "_"), at most 64 characters.',
+  )
+  .refine(
+    (name) => !RESERVED_CUSTOM_MCP_SERVER_NAMES.has(name),
+    (name) => ({
+      message: `'${name}' is reserved by a built-in ${PRODUCT_NAME} integration.`,
+    }),
+  );
+
+export const customMcpServerHeadersSchema = z
+  .record(z.string(), z.string().max(MAX_CUSTOM_MCP_HEADER_VALUE_LENGTH))
+  .superRefine((headers, ctx) => {
+    const entries = Object.entries(headers);
+
+    if (entries.length > MAX_CUSTOM_MCP_HEADERS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `At most ${MAX_CUSTOM_MCP_HEADERS} headers are allowed.`,
+      });
+      return;
+    }
+
+    for (const [name, value] of entries) {
+      const nameError = validateCustomMcpHeaderName(name);
+
+      if (nameError) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [name],
+          message: nameError,
+        });
+      }
+
+      if (HEADER_VALUE_ILLEGAL_PATTERN.test(value)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [name],
+          message: `Header '${name}' contains control characters.`,
+        });
+      }
+    }
+  });
+
+/**
+ * Rejects reserved runtime env references across every operator-supplied
+ * string, mirroring environmentMcpServersSchema. Even though remote custom
+ * servers are proxy-routed (credentials resolve control-plane-side), the
+ * server name flows into sandbox config text, and stdio configs (phase 3)
+ * flow entirely into it — keep one uniform rule for all fields.
+ */
+export function collectCustomMcpReservedReferences(
+  strings: string[],
+): string[] {
+  return Array.from(new Set(strings.flatMap(collectReservedEnvReferences)));
+}
+
+export const customMcpServerInputSchema = z
+  .object({
+    name: customMcpServerNameSchema,
+    url: z.string().min(1).max(MAX_CUSTOM_MCP_URL_LENGTH),
+    authType: customMcpServerAuthTypeSchema,
+    headers: customMcpServerHeadersSchema.optional(),
+  })
+  .superRefine((server, ctx) => {
+    const urlError = validateCustomMcpServerUrl(server.url);
+
+    if (urlError) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['url'],
+        message: urlError,
+      });
+    }
+
+    if (server.authType !== 'static_headers' && server.headers) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['headers'],
+        message: 'Headers are only allowed with header authentication.',
+      });
+    }
+
+    const reserved = collectCustomMcpReservedReferences([
+      server.name,
+      server.url,
+      ...Object.entries(server.headers ?? {}).flat(),
+    ]);
+
+    if (reserved.length > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          `Custom MCP server '${server.name}' references reserved ` +
+          `${PRODUCT_NAME} runtime environment variables ` +
+          `(${reserved.join(', ')}). Define your own deployment environment ` +
+          `variable under a different name and reference that instead.`,
+      });
+    }
+  });
+
+export type CustomMcpServerInput = z.infer<typeof customMcpServerInputSchema>;

--- a/packages/types/src/custom-mcp-servers.ts
+++ b/packages/types/src/custom-mcp-servers.ts
@@ -54,6 +54,14 @@ export function isCustomMcpConnectionId(mcpId: string): boolean {
   return mcpId.startsWith(CUSTOM_MCP_CONNECTION_PREFIX);
 }
 
+export function customMcpServerIdFromConnectionId(
+  mcpId: string,
+): string | null {
+  return isCustomMcpConnectionId(mcpId)
+    ? mcpId.slice(CUSTOM_MCP_CONNECTION_PREFIX.length)
+    : null;
+}
+
 export const MAX_CUSTOM_MCP_SERVERS = 25;
 export const MAX_CUSTOM_MCP_HEADERS = 16;
 export const MAX_CUSTOM_MCP_HEADER_VALUE_LENGTH = 4096;

--- a/packages/types/src/custom-mcp-servers.ts
+++ b/packages/types/src/custom-mcp-servers.ts
@@ -39,6 +39,13 @@ export const RESERVED_CUSTOM_MCP_SERVER_NAMES: ReadonlySet<string> = new Set([
 /** The mcpConnections.mcpId namespace for custom-server OAuth connections. */
 export const CUSTOM_MCP_CONNECTION_PREFIX = 'custom:';
 
+/**
+ * API proxy path prefix for custom remote servers. Shared by the SDK config
+ * delivery (which emits these URLs), the worker (which recognizes them and
+ * injects the cloud token), and the API handler (which mounts the route).
+ */
+export const CUSTOM_MCP_PROXY_PATH_PREFIX = '/api/mcp/custom/';
+
 export function customMcpConnectionId(serverId: string): string {
   return `${CUSTOM_MCP_CONNECTION_PREFIX}${serverId}`;
 }

--- a/packages/types/src/custom-mcp-servers.ts
+++ b/packages/types/src/custom-mcp-servers.ts
@@ -70,12 +70,18 @@ export const MAX_CUSTOM_MCP_URL_LENGTH = 2048;
 /**
  * Header names the proxy owns. Operator headers are applied after the proxy's
  * allowlist rebuild, so without this check a custom header could silently
- * override the injected auth or session headers, and a `Host` override could
- * reach internal vhosts behind shared ingress even when IP-level egress
- * checks pass.
+ * override the session headers, and a `Host` override could reach internal
+ * vhosts behind shared ingress even when IP-level egress checks pass.
+ *
+ * `Authorization` is deliberately NOT denied: many MCP servers expect a
+ * static `Authorization: Bearer <api-key>`, and header auth is the only way
+ * to provide one. This is safe because custom headers are restricted to the
+ * static_headers auth mode (the schema rejects headers with OAuth), so there
+ * is never a proxy-injected credential to override, and the proxy rebuilds
+ * upstream headers from scratch, so the caller's run token is never
+ * forwarded regardless.
  */
 const DENIED_CUSTOM_MCP_HEADER_NAMES: ReadonlySet<string> = new Set([
-  'authorization',
   'host',
   'content-type',
   'content-length',

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -20,6 +20,7 @@ export * from './conflict-resolution-comments';
 export * from './constants';
 export * from './deploy-marker';
 export * from './deployment-access-policy';
+export * from './custom-mcp-servers';
 export * from './environment-config';
 export * from './reserved-mcp-env-vars';
 export * from './environment-definition-tasks';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1613,6 +1613,9 @@ importers:
       superjson:
         specifier: ^2.2.6
         version: 2.2.6
+      undici:
+        specifier: ^7.29.0
+        version: 7.29.0
       zod:
         specifier: ^3.25.76
         version: 3.25.76


### PR DESCRIPTION
# [Feat] Deployment-scoped custom MCP servers (remote + OAuth + stdio)

Closes #1142.

Adds a **Custom MCP Servers** section to Settings → Integrations where deployment admins can connect MCP servers that are not in the built-in catalog. Custom servers become available to agents in every task.

## What's supported

- **Remote servers (streamable HTTP)** with no auth, static header auth, or OAuth. Remote servers are delivered to sandboxes as authenticated Roomote proxy URLs (`/api/mcp/custom/<id>`); the proxy injects credentials per request, so header values and OAuth tokens never enter sandbox-readable config or the browser.
- **OAuth** per the MCP authorization spec: RFC 8414/9728 discovery, RFC 7591 Dynamic Client Registration with PKCE, manual client id/secret fallback for servers without DCR, RFC 8707 resource indicators (with a per-server opt-out), server-side token refresh, and an explicit reconnect state when a refresh is definitively rejected.
- **Local (stdio) servers**, launched inside the task sandbox via the same pipeline as environment-scoped `mcpServers` (inheriting the reserved-env-reference defenses and the mise shim fix). Env values are encrypted at rest and write-only in the UI.
- **Per-tool deny lists**, enforced at the proxy (tools/call blocked, tools/list filtered), managed from a tool dialog that lists the server's live tools.

## Security

- New `safeFetch` egress guard for all control-plane traffic to operator-supplied URLs (the proxy data path and every OAuth discovery hop, including URLs the remote server itself supplies): private/special-use ranges blocked, DNS answers vetted and pinned (anti-rebinding), redirects refused. Self-hosters can allow specific internal ranges with `R_CUSTOM_MCP_ALLOWED_PRIVATE_CIDRS` (a CIDR list, deliberately not a boolean).
- Reserved names (`roomote`, catalog ids, `github`, `slack`) and reserved runtime env references are rejected at save time.
- Header names the proxy owns (`authorization`, `host`, `mcp-session-id`, ...) cannot be overridden; header values are validated against CR/LF injection.
- Editing a server's URL or auth mode clears stored OAuth tokens, so credentials can never be replayed against a different endpoint.
- Custom-server secrets are per-value encrypted at rest; list endpoints return key names only; the decrypted stdio config endpoint is restricted to run tokens.
- `R_CUSTOM_MCP_DISABLED` kill switch, independent of `R_CURATED_INTEGRATIONS_DISABLED` (operators who disable the catalog are the primary custom-server audience).

## Notes

- Deployment servers merge after environment-scoped `mcpServers`; the more specific scope wins name collisions.
- Custom server names feed the self-setup catalog so the setup agent stops recommending services that are already wired.
- Docs: new `integrations/custom-mcp-servers` page plus updates to the integrations index and the add-integration skill.
- Rollout note: workers baked into old sandbox snapshots don't fetch custom servers; the feature appears on fresh-snapshot tasks.
- Migration is additive (N-1 safe). OAuth connections reuse `mcpConnections` under a `custom:<serverId>` id namespace, which previous-release code ignores.

## Testing

- Schema validation, CRUD (encryption round-trip, blank-keeps-existing, token clearing), SSRF guard units (blocked ranges, IPv4-mapped bypasses, DNS pinning against a live local server, redirect refusal), proxy integration tests against a mock MCP server (header injection, OAuth, deny lists, redirect refusal, egress guard, body cap), worker merge/redaction tests, SDK delivery and run-token gating tests, and UI client tests.
- Verified end to end on a dev deployment: server CRUD in Settings, live tool listing through the guard, per-tool disables, and an agent task calling the tools through the proxy.

## Screenshots

Custom servers render as ordinary integration cards in the same Connected/Configured grids as the built-in catalog, marked with a small **Custom** badge. A prompt bar at the top is the entry point for adding one.

![Custom MCP servers as integration cards](https://gist.githubusercontent.com/mrubens/6924a5454a21741fe090a4aeec283457/raw/custom-mcp-cards.png)

Adding a server starts from one dialog that chooses between a remote (HTTP) and a local (stdio) server:

![Add custom MCP server dialog](https://gist.githubusercontent.com/mrubens/6924a5454a21741fe090a4aeec283457/raw/add-dialog-type-choice.png)

| Header auth (values write-only) | OAuth (DCR + manual client fallback) |
| --- | --- |
| ![Edit dialog with header auth](https://gist.githubusercontent.com/mrubens/6924a5454a21741fe090a4aeec283457/raw/edit-dialog-headers.png) | ![Edit dialog with OAuth](https://gist.githubusercontent.com/mrubens/6924a5454a21741fe090a4aeec283457/raw/edit-dialog-oauth.png) |

| Local (stdio) config | Per-tool deny list (proxy-enforced) |
| --- | --- |
| ![Local stdio edit dialog](https://gist.githubusercontent.com/mrubens/6924a5454a21741fe090a4aeec283457/raw/stdio-dialog.png) | ![Manage tools deny list](https://gist.githubusercontent.com/mrubens/6924a5454a21741fe090a4aeec283457/raw/manage-tools-deny-list.png) |
