### PR TITLE
[Fix] Paired OpenCode idle events finalize runs while a drained follow-up turn is still running

### DIFF
--- a/apps/worker/src/sandbox-server/lib/harness-manager.ts
+++ b/apps/worker/src/sandbox-server/lib/harness-manager.ts
@@ -1392,7 +1392,9 @@ export class HarnessManager extends EventEmitter<HarnessManagerEvents> {
 
   private onTaskCompleted(payload: TaskEventCompletedPayload): void {
     if (payload[0] === this.state.sessionId) {
-      this.logger.info(`[HarnessManager] Task completed: ${payload[0]}`);
+      this.logger.info(
+        `[HarnessManager] Task completed: ${payload[0]} (phase=${this.phase}, queuedRuntimePrompts=${this.runtimeQueuedMessagesCount}, deferredSettlement=${this.deferredTurnSettlement ?? 'none'})`,
+      );
 
       if (this.runtimeQueuedMessagesCount > 0) {
         // A deferred abort takes priority — don't overwrite it with a

--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/active-review-follow-up-paired-idle.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/active-review-follow-up-paired-idle.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Paired-idle regression coverage for deferred run completion. OpenCode 1.17
+ * emits `session.status(idle)` followed by a legacy `session.idle` for a
+ * single turn boundary. When the status-sourced completion drains a queued
+ * hidden follow-up (submitting a new prompt and re-arming `inFlight`), the
+ * trailing `session.idle` must not re-enter turn completion: doing so emits a
+ * second taskCompleted with an empty queue, which finalizes the run (onExit)
+ * while the drained re-review turn is still running.
+ */
+import { TaskEventName, type TaskEvent } from '@roomote/types';
+
+import { HarnessManager } from '../../harness-manager';
+import type { OpenCodeServerClient } from '../opencode-server/client';
+import { OpenCodeServerHarness } from '../opencode-server/harness';
+import type {
+  OpenCodeGlobalEvent,
+  OpenCodeSessionMessage,
+} from '../opencode-server/types';
+
+vi.mock('../../../../monitoring/sentry', () => ({
+  captureWorkerMessage: vi.fn(),
+}));
+
+const TEST_OPENCODE_MODEL = 'test-provider/main-model';
+const RE_REVIEW_CLIENT_MESSAGE_ID = 'github-pr-synchronize:100:owner/repo:42';
+
+class FakeOpenCodeServerClient {
+  private eventHandler:
+    | ((event: OpenCodeGlobalEvent) => void | Promise<void>)
+    | undefined;
+
+  health = vi.fn(async () => ({ healthy: true as const, version: 'test' }));
+  createSession = vi.fn(
+    async (_options?: { title?: string; signal?: AbortSignal }) => ({
+      id: 'ses_1',
+      title: 'test',
+    }),
+  );
+  promptAsync = vi.fn(async (_options: unknown) => undefined);
+  messages = vi.fn(async () => [] as OpenCodeSessionMessage[]);
+  message = vi.fn<() => Promise<OpenCodeSessionMessage>>();
+  abort = vi.fn(async () => true);
+  get sessionCreateTimeoutMsValue(): number {
+    return 90_000;
+  }
+  streamEvents = vi.fn(
+    async (options: {
+      signal: AbortSignal;
+      onEvent: (event: OpenCodeGlobalEvent) => void | Promise<void>;
+    }) => {
+      this.eventHandler = options.onEvent;
+
+      await new Promise<void>((resolve) => {
+        if (options.signal.aborted) {
+          resolve();
+          return;
+        }
+
+        options.signal.addEventListener('abort', () => resolve(), {
+          once: true,
+        });
+      });
+    },
+  );
+
+  async emit(event: OpenCodeGlobalEvent): Promise<void> {
+    if (!this.eventHandler) {
+      throw new Error('OpenCode event stream is not subscribed.');
+    }
+
+    await this.eventHandler(event);
+  }
+}
+
+function createLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+async function connectHarness(
+  harness: OpenCodeServerHarness,
+  client: FakeOpenCodeServerClient,
+): Promise<void> {
+  const connectPromise = harness.connect();
+
+  await vi.waitFor(() => {
+    expect(client.streamEvents).toHaveBeenCalledTimes(1);
+  });
+  await client.emit({ type: 'server.connected' });
+  await connectPromise;
+}
+
+function createFinalAssistantMessage(
+  messageId: string,
+  text: string,
+): OpenCodeSessionMessage {
+  return {
+    info: {
+      id: messageId,
+      sessionID: 'ses_1',
+      role: 'assistant',
+      providerID: 'openrouter',
+      modelID: 'openai/gpt-5.4',
+      mode: 'build',
+      time: { created: 0, completed: 1 },
+      cost: 0.000123,
+      tokens: {
+        input: 5,
+        output: 2,
+        reasoning: 1,
+        cache: { read: 3, write: 4 },
+      },
+    },
+    parts: [
+      {
+        id: `${messageId}_part`,
+        sessionID: 'ses_1',
+        messageID: messageId,
+        type: 'text',
+        text,
+      },
+    ],
+  };
+}
+
+/**
+ * Finish a turn the way OpenCode 1.17 does live: `session.status` with
+ * `status.type === 'idle'` followed by the paired legacy `session.idle`.
+ */
+async function completeTurnWithPairedIdle(
+  client: FakeOpenCodeServerClient,
+  messageId: string,
+  text: string,
+): Promise<void> {
+  client.message.mockResolvedValueOnce(
+    createFinalAssistantMessage(messageId, text),
+  );
+  await client.emit({
+    type: 'message.part.updated',
+    properties: {
+      part: {
+        id: `${messageId}_part`,
+        sessionID: 'ses_1',
+        messageID: messageId,
+        type: 'text',
+        text,
+      },
+      delta: text,
+    },
+  });
+  await client.emit({
+    type: 'message.updated',
+    properties: {
+      info: {
+        id: messageId,
+        sessionID: 'ses_1',
+        role: 'assistant',
+        time: { completed: 1 },
+      },
+    },
+  });
+  await client.emit({
+    type: 'session.status',
+    properties: { sessionID: 'ses_1', status: { type: 'idle' } },
+  });
+  await client.emit({
+    type: 'session.idle',
+    properties: { sessionID: 'ses_1' },
+  });
+}
+
+function createFixture() {
+  const client = new FakeOpenCodeServerClient();
+  const harness = new OpenCodeServerHarness({
+    client: client as unknown as OpenCodeServerClient,
+    workspacePath: '/tmp/workspace',
+    logger: createLogger(),
+    model: TEST_OPENCODE_MODEL,
+    eventStreamReadyTimeoutMs: 100,
+  });
+
+  const submittedPrompts: string[] = [];
+  client.promptAsync.mockImplementation(async (options: unknown) => {
+    const request = (options as { request?: { parts?: Array<unknown> } })
+      .request;
+    const firstPart = request?.parts?.[0] as { text?: string } | undefined;
+    submittedPrompts.push(firstPart?.text ?? '');
+  });
+
+  const onExit = vi.fn();
+  const manager = new HarnessManager({
+    harness,
+    keepaliveMs: 60_000,
+    runId: 100,
+    taskId: 'task-100',
+    logger: { ...createLogger(), log: vi.fn() },
+    callbacks: { onExit },
+  });
+
+  const taskEvents: TaskEvent[] = [];
+  harness.subscribe((event) => taskEvents.push(event));
+
+  return { client, harness, manager, onExit, submittedPrompts, taskEvents };
+}
+
+describe('active PR review follow-up lifecycle (paired session.status idle + session.idle)', () => {
+  it('defers run completion across the paired idle until the drained re-review turn has run', async () => {
+    const fixture = createFixture();
+    const { client, harness, manager, onExit, submittedPrompts, taskEvents } =
+      fixture;
+
+    try {
+      await connectHarness(harness, client);
+      manager.initializeWithoutPrompt();
+      expect(
+        manager.startNewTaskFromPrompt({
+          prompt: 'Review PR owner/repo#42.',
+          source: 'github',
+        }),
+      ).toBe(true);
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(1);
+      });
+
+      // The new turn's busy status arrives before the hidden follow-up.
+      await client.emit({
+        type: 'session.status',
+        properties: { sessionID: 'ses_1', status: { type: 'busy' } },
+      });
+
+      expect(
+        manager.sendFollowUpPrompt({
+          prompt: 'Re-review the PR head after new commits.',
+          source: 'github-pr-synchronize',
+          clientMessageId: RE_REVIEW_CLIENT_MESSAGE_ID,
+          visibleInTranscript: false,
+        }),
+      ).toBe(true);
+
+      await vi.waitFor(() => {
+        expect(harness.getQueuedMessageSnapshots?.() ?? []).toHaveLength(1);
+      });
+
+      // The review turn finishes with the follow-up still queued, using the
+      // live paired idle sequence. Completion must stay deferred while the
+      // drain starts the re-review turn.
+      await completeTurnWithPairedIdle(
+        client,
+        'msg_1',
+        'Initial review pass done.',
+      );
+
+      await vi.waitFor(() => {
+        expect(client.promptAsync).toHaveBeenCalledTimes(2);
+      });
+
+      expect(onExit).not.toHaveBeenCalled();
+      expect(manager.getStatus().phase).toBe('running');
+      expect(submittedPrompts[1]).toBe(
+        'Re-review the PR head after new commits.',
+      );
+
+      // Only once the re-review turn settles with an empty queue does the
+      // run finalize.
+      await client.emit({
+        type: 'session.status',
+        properties: { sessionID: 'ses_1', status: { type: 'busy' } },
+      });
+      await completeTurnWithPairedIdle(
+        client,
+        'msg_2',
+        'Re-reviewed latest head.',
+      );
+
+      await vi.waitFor(() => {
+        expect(onExit).toHaveBeenCalledTimes(1);
+      });
+      expect(
+        taskEvents.filter(
+          (event) => event.eventName === TaskEventName.TaskCompleted,
+        ),
+      ).toHaveLength(2);
+    } finally {
+      manager.dispose();
+      harness.dispose();
+    }
+  });
+});

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
@@ -1617,6 +1617,13 @@ export class OpenCodeServerHarness
   // duplicate reminder into the fresh reminder turn. This guard swallows that
   // exact follow-up idle; any busy/retry transition clears it first.
   private ignoreNextStopHookSessionIdle = false;
+  // Same paired-idle hazard for the queued-prompt drain: when the
+  // status-sourced turn completion drains a queued follow-up, submitPrompt
+  // re-arms inFlight, so the paired session.idle would re-enter
+  // finishCurrentTurn with an empty queue, emit a second taskCompleted, and
+  // finalize the run while the drained turn is still running. This guard
+  // swallows that exact follow-up idle; any busy/retry transition clears it.
+  private ignoreNextQueuedDrainSessionIdle = false;
   private readonly stallWatchdogs: OpenCodeStallWatchdogs;
   private resolveEventStreamReady: (() => void) | undefined;
   private rejectEventStreamReady: ((error: unknown) => void) | undefined;
@@ -2121,6 +2128,7 @@ export class OpenCodeServerHarness
     this.queuedUserInputReplayPromptId = null;
     this.ignoreNextUserInputReplaySessionIdle = false;
     this.ignoreNextStopHookSessionIdle = false;
+    this.ignoreNextQueuedDrainSessionIdle = false;
     this.currentWorkflowPhase = command.data.workflowPhase ?? null;
     this.activeWorkflowSkill = null;
     this.cancelRequestedBeforeSession = false;
@@ -3749,6 +3757,7 @@ export class OpenCodeServerHarness
       this.ignoreNextProviderRecoverySessionIdle = false;
       this.ignoreNextUserInputReplaySessionIdle = false;
       this.ignoreNextStopHookSessionIdle = false;
+      this.ignoreNextQueuedDrainSessionIdle = false;
       this.inFlight = true;
       this.stallWatchdogs.noteActivity();
       this.stallWatchdogs.ensureTurnStallArmed();
@@ -3761,6 +3770,7 @@ export class OpenCodeServerHarness
       this.ignoreNextProviderRecoverySessionIdle = false;
       this.ignoreNextUserInputReplaySessionIdle = false;
       this.ignoreNextStopHookSessionIdle = false;
+      this.ignoreNextQueuedDrainSessionIdle = false;
       this.inFlight = true;
       // Status transitions prove the session is alive (e.g. a provider retry
       // loop), but not that the turn's loop advanced — a steer awaiting
@@ -3850,6 +3860,11 @@ export class OpenCodeServerHarness
 
     if (this.ignoreNextStopHookSessionIdle) {
       this.ignoreNextStopHookSessionIdle = false;
+      return;
+    }
+
+    if (this.ignoreNextQueuedDrainSessionIdle) {
+      this.ignoreNextQueuedDrainSessionIdle = false;
       return;
     }
 
@@ -4672,6 +4687,19 @@ export class OpenCodeServerHarness
     }
 
     await this.drainQueuedPrompts();
+
+    // If the drain submitted a queued prompt on the status-sourced entry,
+    // inFlight is re-armed and the paired session.idle for the turn that just
+    // ended would complete the drained turn immediately (second taskCompleted,
+    // empty queue, premature run finalization). Swallow that exact idle. The
+    // replay guard set above already covers the queued-replay drain.
+    if (
+      source === 'session_status' &&
+      this.inFlight &&
+      !this.ignoreNextUserInputReplaySessionIdle
+    ) {
+      this.ignoreNextQueuedDrainSessionIdle = true;
+    }
   }
 
   private armStopHookReminderStall(sessionId: string): void {


### PR DESCRIPTION
## Problem

OpenCode 1.17 emits `session.status(idle)` followed by a paired legacy `session.idle` for a single turn boundary. When a turn ends with a deliverable prompt queued (for example the hidden re-review follow-up that active PR reviews receive when commits are pushed mid-review, #1150), the status-sourced completion correctly defers run finalization and drains the queued prompt. But draining submits the prompt and re-arms `inFlight`, so the trailing paired `session.idle` re-entered `finishCurrentTurn`, emitted a second `taskCompleted` against the now-empty queue, and `HarnessManager` finalized the run (`onExit`) while the drained turn was still running.

Consequences:
- The follow-up turn ran in a post-finalization window where only the sleep heartbeat kept the sandbox alive, so it could be lost to sleep.
- The drained turn's real completion later fired a duplicate `onExit`.
- Whether a live run hit this depended on whether OpenCode emitted the paired events for that boundary, which made the deferral look nondeterministic.

The existing lifecycle integration test missed this because its mock emitted only a single `session.idle`, never the paired sequence the real binary produces.

## Fix

Arm a new `ignoreNextQueuedDrainSessionIdle` guard when a status-sourced turn completion's drain submits a queued prompt, mirroring the three existing paired-idle guards (stop-hook reminder, question replay, provider recovery). The trailing `session.idle` is swallowed exactly once; busy/retry status transitions and `StartNewTask` clear the flag like its siblings. Turns that end with only `session.idle`, empty-queue completions, and the other guards are unchanged.

Also includes the deferral decision inputs (phase, queued prompt count, deferred settlement) in the manager's task-completed log line so future bypasses are diagnosable from live logs.

## Testing

- New regression test `active-review-follow-up-paired-idle.test.ts` completes turns with the real paired sequence via the real harness + manager. It fails deterministically without the fix (premature `onExit`) and passes with it.
- A/B smoke against a real `opencode serve` 1.17.8 binary with the real harness + manager, injecting a hidden follow-up mid-turn: pre-fix, the paired idle fired a second `taskCompleted` 16ms after the drain and `onExit` landed between the turns, followed by a third `taskCompleted` and duplicate `onExit` when the follow-up turn actually finished. With the fix: exactly one `taskCompleted` per turn and a single `onExit` after the follow-up turn settled.
- All 257 worker harness/harness-manager tests pass; `tsc --noEmit` clean.