### PR TITLE
[Fix] Reuse compute provider clients across sleep-check ticks

### DIFF
--- a/apps/bullmq/src/scheduled-jobs/__tests__/sleep-check.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/sleep-check.test.ts
@@ -183,7 +183,12 @@ vi.mock('@roomote/db/server', () => ({
 }));
 
 // Import after mocks are set up.
-import { sleepCheckJob, sleepTaskRunNow } from '../sleep-check';
+import {
+  clearSleepCheckClientCache,
+  sleepCheckJob,
+  sleepTaskRunNow,
+} from '../sleep-check';
+import { resolveComputeProviderEnvValues } from '@roomote/db/server';
 
 /**
  * Mock the sequential DB select queries in sleepCheckJob.
@@ -224,6 +229,7 @@ function mockJobQueries({
 describe('sleepTaskRunNow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearSleepCheckClientCache();
     transactionFn.mockImplementation(async (callback) =>
       callback({ update: updateFn }),
     );
@@ -312,6 +318,7 @@ describe('sleepCheckJob', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    clearSleepCheckClientCache();
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -715,6 +722,71 @@ describe('sleepCheckJob', () => {
         triggerPath: 'due_sleep',
       }),
     );
+  });
+
+  it('reuses the provider client across scheduler runs', async () => {
+    const mockJob = {
+      id: 6626,
+      machineId: 'modal-reuse',
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Idle,
+      taskPhase: 'waiting_for_prompt',
+      vendor: 'modal',
+      snapshotId: null,
+      sleepRequestedAt: null,
+      snapshotRequestedAt: null,
+    };
+
+    mockGetInstanceStatus.mockResolvedValue({
+      status: 'running',
+      timeoutRemainingMs: 5 * 60 * 60 * 1_000,
+    });
+    returningFn.mockResolvedValue([{ id: 6626 }]);
+    mockCreateSnapshot.mockResolvedValue(true);
+
+    mockJobQueries({ dueJobs: [mockJob] });
+    await sleepCheckJob();
+    mockJobQueries({ dueJobs: [mockJob] });
+    await sleepCheckJob();
+
+    expect(mockGetInstanceStatus).toHaveBeenCalledTimes(2);
+    expect(mockCreateComputeProviderClient).toHaveBeenCalledTimes(1);
+  });
+
+  it('rebuilds the provider client when provider credentials change', async () => {
+    const mockJob = {
+      id: 6627,
+      machineId: 'modal-rotate',
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Idle,
+      taskPhase: 'waiting_for_prompt',
+      vendor: 'modal',
+      snapshotId: null,
+      sleepRequestedAt: null,
+      snapshotRequestedAt: null,
+    };
+
+    mockGetInstanceStatus.mockResolvedValue({
+      status: 'running',
+      timeoutRemainingMs: 5 * 60 * 60 * 1_000,
+    });
+    returningFn.mockResolvedValue([{ id: 6627 }]);
+    mockCreateSnapshot.mockResolvedValue(true);
+
+    mockJobQueries({ dueJobs: [mockJob] });
+    await sleepCheckJob();
+
+    vi.mocked(resolveComputeProviderEnvValues).mockResolvedValueOnce({
+      MODAL_TOKEN_ID: 'rotated',
+    });
+    mockJobQueries({ dueJobs: [mockJob] });
+    await sleepCheckJob();
+
+    expect(mockCreateComputeProviderClient).toHaveBeenCalledTimes(2);
+    expect(mockCreateComputeProviderClient).toHaveBeenLastCalledWith({
+      provider: 'modal',
+      envFallback: { MODAL_TOKEN_ID: 'rotated' },
+    });
   });
 
   it('retains due Blaxel jobs on standby without creating a snapshot', async () => {

--- a/apps/bullmq/src/scheduled-jobs/sleep-check.ts
+++ b/apps/bullmq/src/scheduled-jobs/sleep-check.ts
@@ -141,38 +141,23 @@ function getDestroyInstanceSentryMessage(
   }
 }
 
-async function createSleepCheckClient(provider: ComputeProvider) {
+function buildSleepCheckClient(
+  provider: ComputeProvider,
+  envFallback: Partial<Record<string, string>>,
+) {
   switch (provider) {
     case 'modal':
-      return createComputeProviderClient({
-        provider: 'modal',
-        envFallback: await resolveComputeProviderEnvValues('modal'),
-      });
+      return createComputeProviderClient({ provider: 'modal', envFallback });
     case 'roomote':
-      return createComputeProviderClient({
-        provider: 'roomote',
-        envFallback: await resolveComputeProviderEnvValues('roomote'),
-      });
+      return createComputeProviderClient({ provider: 'roomote', envFallback });
     case 'daytona':
-      return createComputeProviderClient({
-        provider: 'daytona',
-        envFallback: await resolveComputeProviderEnvValues('daytona'),
-      });
+      return createComputeProviderClient({ provider: 'daytona', envFallback });
     case 'e2b':
-      return createComputeProviderClient({
-        provider: 'e2b',
-        envFallback: await resolveComputeProviderEnvValues('e2b'),
-      });
+      return createComputeProviderClient({ provider: 'e2b', envFallback });
     case 'blaxel':
-      return createComputeProviderClient({
-        provider: 'blaxel',
-        envFallback: await resolveComputeProviderEnvValues('blaxel'),
-      });
+      return createComputeProviderClient({ provider: 'blaxel', envFallback });
     case 'azure':
-      return createComputeProviderClient({
-        provider: 'azure',
-        envFallback: await resolveComputeProviderEnvValues('azure'),
-      });
+      return createComputeProviderClient({ provider: 'azure', envFallback });
     case 'docker':
       return createComputeProviderClient({ provider: 'docker' });
     default:
@@ -180,6 +165,52 @@ async function createSleepCheckClient(provider: ComputeProvider) {
         `Sleep check has no compute client for provider "${provider}"`,
       );
   }
+}
+
+interface CachedSleepCheckClient {
+  client: ReturnType<typeof buildSleepCheckClient>;
+  fingerprint: string;
+}
+
+// Reuse one client per provider across scheduler ticks. Building a fresh SDK
+// client every minute retained each client's connection state (pinned via the
+// adapters' static sandbox caches) on deployments that always have active
+// runs, leaking ~1.5 MB/min until the bullmq service hit its heap cap. The
+// fingerprint rebuilds the client when the deployment's provider credentials
+// change.
+const sleepCheckClientCache = new Map<
+  ComputeProvider,
+  CachedSleepCheckClient
+>();
+
+/** Test-only: drop cached clients so mocks do not leak across tests. */
+export function clearSleepCheckClientCache(): void {
+  sleepCheckClientCache.clear();
+}
+
+function fingerprintEnvValues(values: Partial<Record<string, string>>): string {
+  return JSON.stringify(
+    Object.entries(values)
+      .filter(([, value]) => value !== undefined)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)),
+  );
+}
+
+async function getSleepCheckClient(provider: ComputeProvider) {
+  const envValues =
+    provider === 'docker'
+      ? {}
+      : await resolveComputeProviderEnvValues(provider);
+  const fingerprint = fingerprintEnvValues(envValues);
+  const cached = sleepCheckClientCache.get(provider);
+
+  if (cached && cached.fingerprint === fingerprint) {
+    return cached.client;
+  }
+
+  const client = buildSleepCheckClient(provider, envValues);
+  sleepCheckClientCache.set(provider, { client, fingerprint });
+  return client;
 }
 
 /**
@@ -291,7 +322,7 @@ export const sleepCheckJob = async () => {
   const candidateJobsByMachineId = new Map<string, SleepCheckCandidateSet>();
   const providerClients = new Map<
     ComputeProvider,
-    Awaited<ReturnType<typeof createSleepCheckClient>>
+    Awaited<ReturnType<typeof getSleepCheckClient>>
   >();
 
   await mergeSleepCheckCandidates(candidateJobsByMachineId, dueJobs, 'dueJob', {
@@ -358,7 +389,7 @@ export const sleepCheckJob = async () => {
     let client = providerClients.get(provider);
 
     if (!client) {
-      client = await createSleepCheckClient(provider);
+      client = await getSleepCheckClient(provider);
       providerClients.set(provider, client);
     }
 
@@ -809,7 +840,7 @@ export async function sleepTaskRunNow(runId: number): Promise<void> {
     return;
   }
 
-  const client = await createSleepCheckClient(job.vendor);
+  const client = await getSleepCheckClient(job.vendor);
   const { status } = await client.getInstanceStatus({
     instanceId: job.machineId,
   });

--- a/packages/compute-providers/src/adapters/daytona.ts
+++ b/packages/compute-providers/src/adapters/daytona.ts
@@ -60,7 +60,9 @@ export class DaytonaClient implements ComputeProviderClient {
   public readonly capabilities: ComputeProviderCapabilities =
     DAYTONA_CAPABILITIES_VALUE;
 
-  private static readonly sandboxCache = new LRUCache<string, DaytonaSandbox>({
+  // Per-instance so cached sandbox handles die with the client that created
+  // them and never outlive its credentials (see ModalClient.sandboxCache).
+  private readonly sandboxCache = new LRUCache<string, DaytonaSandbox>({
     max: 100,
     ttl: DAYTONA_SANDBOX_CACHE_TTL_MS,
   });
@@ -105,7 +107,7 @@ export class DaytonaClient implements ComputeProviderClient {
   ): Promise<DaytonaSandbox> {
     throwIfAborted(signal);
 
-    const cached = DaytonaClient.sandboxCache.get(sandboxId);
+    const cached = this.sandboxCache.get(sandboxId);
 
     if (cached) {
       return cached;
@@ -118,11 +120,11 @@ export class DaytonaClient implements ComputeProviderClient {
         abortMessage: `Fetching Daytona sandbox ${sandboxId} was aborted`,
       });
 
-      DaytonaClient.sandboxCache.set(sandboxId, sandbox);
+      this.sandboxCache.set(sandboxId, sandbox);
 
       return sandbox;
     } catch (error) {
-      DaytonaClient.sandboxCache.delete(sandboxId);
+      this.sandboxCache.delete(sandboxId);
 
       console.error(
         `[DaytonaClient] Failed to fetch sandbox "${sandboxId}" ${JSON.stringify(
@@ -166,7 +168,7 @@ export class DaytonaClient implements ComputeProviderClient {
         abortMessage: `Fetching Daytona sandbox ${input.instanceId} was aborted`,
       });
 
-      DaytonaClient.sandboxCache.set(input.instanceId, sandbox);
+      this.sandboxCache.set(input.instanceId, sandbox);
 
       return { status: mapSandboxState(sandbox.state) };
     } catch (error) {
@@ -235,7 +237,7 @@ export class DaytonaClient implements ComputeProviderClient {
     }
 
     try {
-      DaytonaClient.sandboxCache.set(sandbox.id, sandbox);
+      this.sandboxCache.set(sandbox.id, sandbox);
 
       const domains = await this.resolvePreviewDomains(
         sandbox,
@@ -691,7 +693,7 @@ export class DaytonaClient implements ComputeProviderClient {
     }
 
     try {
-      DaytonaClient.sandboxCache.set(sandbox.id, sandbox);
+      this.sandboxCache.set(sandbox.id, sandbox);
 
       const domains = await this.resolvePreviewDomains(
         sandbox,
@@ -783,7 +785,7 @@ export class DaytonaClient implements ComputeProviderClient {
   }
 
   private invalidateSandboxCache(instanceId: string): void {
-    DaytonaClient.sandboxCache.delete(instanceId);
+    this.sandboxCache.delete(instanceId);
   }
 
   private async cleanupSandboxAfterFailure(

--- a/packages/compute-providers/src/adapters/e2b.ts
+++ b/packages/compute-providers/src/adapters/e2b.ts
@@ -74,7 +74,9 @@ export class E2bClient implements ComputeProviderClient {
   public readonly capabilities: ComputeProviderCapabilities =
     E2B_CAPABILITIES_VALUE;
 
-  private static readonly sandboxCache = new LRUCache<string, E2bSandbox>({
+  // Per-instance so cached sandbox handles die with the client that created
+  // them and never outlive its credentials (see ModalClient.sandboxCache).
+  private readonly sandboxCache = new LRUCache<string, E2bSandbox>({
     max: 100,
     ttl: E2B_SANDBOX_CACHE_TTL_MS,
   });
@@ -117,7 +119,7 @@ export class E2bClient implements ComputeProviderClient {
   ): Promise<E2bSandbox> {
     throwIfAborted(signal);
 
-    const cached = E2bClient.sandboxCache.get(sandboxId);
+    const cached = this.sandboxCache.get(sandboxId);
 
     if (cached) {
       return cached;
@@ -130,11 +132,11 @@ export class E2bClient implements ComputeProviderClient {
         abortMessage: `Connecting to E2B sandbox ${sandboxId} was aborted`,
       });
 
-      E2bClient.sandboxCache.set(sandboxId, sandbox);
+      this.sandboxCache.set(sandboxId, sandbox);
 
       return sandbox;
     } catch (error) {
-      E2bClient.sandboxCache.delete(sandboxId);
+      this.sandboxCache.delete(sandboxId);
 
       console.error(
         `[E2bClient] Failed to connect to sandbox "${sandboxId}" ${JSON.stringify(
@@ -245,7 +247,7 @@ export class E2bClient implements ComputeProviderClient {
     }
 
     try {
-      E2bClient.sandboxCache.set(sandbox.sandboxId, sandbox);
+      this.sandboxCache.set(sandbox.sandboxId, sandbox);
 
       const domains = resolvePortDomains(sandbox, input.ports);
 
@@ -661,7 +663,7 @@ export class E2bClient implements ComputeProviderClient {
     }
 
     try {
-      E2bClient.sandboxCache.set(sandbox.sandboxId, sandbox);
+      this.sandboxCache.set(sandbox.sandboxId, sandbox);
 
       const domains = resolvePortDomains(sandbox, input.ports);
 
@@ -783,7 +785,7 @@ export class E2bClient implements ComputeProviderClient {
   }
 
   private invalidateSandboxCache(instanceId: string): void {
-    E2bClient.sandboxCache.delete(instanceId);
+    this.sandboxCache.delete(instanceId);
   }
 
   private async cleanupSandboxAfterFailure(

--- a/packages/compute-providers/src/adapters/modal.test.ts
+++ b/packages/compute-providers/src/adapters/modal.test.ts
@@ -71,11 +71,6 @@ describe('ModalClient', () => {
 
   afterEach(() => {
     vi.useRealTimers();
-    (
-      ModalClient as unknown as {
-        sandboxCache: { clear: () => void };
-      }
-    ).sandboxCache.clear();
   });
 
   it('does not mutate the caller config object', () => {

--- a/packages/compute-providers/src/adapters/modal.ts
+++ b/packages/compute-providers/src/adapters/modal.ts
@@ -73,7 +73,11 @@ const MODAL_SNAPSHOT_TIMEOUT_MS = 20 * 60_000;
 export class ModalClient implements ComputeProviderClient {
   public readonly vendor: ComputeProvider;
 
-  private static readonly sandboxCache = new LRUCache<string, Sandbox>({
+  // Per-instance so cached Sandbox handles die with the client that created
+  // them: a static cache pinned every past client's SDK graph (a steady heap
+  // leak under per-tick construction) and kept serving handles built with
+  // rotated-out credentials after a client rebuild.
+  private readonly sandboxCache = new LRUCache<string, Sandbox>({
     max: 100,
     ttl: MODAL_SANDBOX_CACHE_TTL_MS,
   });
@@ -206,7 +210,7 @@ export class ModalClient implements ComputeProviderClient {
   ): Promise<Sandbox> {
     throwIfAborted(signal);
 
-    const cached = ModalClient.sandboxCache.get(sandboxId);
+    const cached = this.sandboxCache.get(sandboxId);
 
     if (cached) {
       return cached;
@@ -221,11 +225,11 @@ export class ModalClient implements ComputeProviderClient {
         abortMessage: `Fetching Modal sandbox ${sandboxId} was aborted`,
       });
 
-      ModalClient.sandboxCache.set(sandboxId, sandbox);
+      this.sandboxCache.set(sandboxId, sandbox);
 
       return sandbox;
     } catch (error) {
-      ModalClient.sandboxCache.delete(sandboxId);
+      this.sandboxCache.delete(sandboxId);
 
       console.error(
         `[ModalClient] Failed to fetch sandbox "${sandboxId}" ${JSON.stringify({
@@ -495,7 +499,7 @@ export class ModalClient implements ComputeProviderClient {
 
     try {
       await this.applySandboxTags(sandbox, input.tags);
-      ModalClient.sandboxCache.set(sandbox.sandboxId, sandbox);
+      this.sandboxCache.set(sandbox.sandboxId, sandbox);
       const domains = await this.resolveTunnelDomains(
         sandbox,
         input.ports,
@@ -1072,7 +1076,7 @@ export class ModalClient implements ComputeProviderClient {
 
     try {
       await this.applySandboxTags(sandbox, input.tags);
-      ModalClient.sandboxCache.set(sandbox.sandboxId, sandbox);
+      this.sandboxCache.set(sandbox.sandboxId, sandbox);
       const domains = await this.resolveTunnelDomains(
         sandbox,
         input.ports,
@@ -1161,7 +1165,7 @@ export class ModalClient implements ComputeProviderClient {
   }
 
   private invalidateSandboxCache(instanceId: string): void {
-    ModalClient.sandboxCache.delete(instanceId);
+    this.sandboxCache.delete(instanceId);
   }
 
   private async cleanupSandboxAfterFailure(


### PR DESCRIPTION
## Problem

The sleep check runs every 60 seconds and built a brand-new compute provider client on every tick that found active or idle runs. Each client carries retained SDK state: connection channels, and the adapters' static sandbox caches (e.g. `ModalClient`'s 100-entry LRU of `Sandbox` objects) pin the client instance that created each cached entry, keeping dead per-tick clients reachable.

On deployments that always have at least one active or idle run, this leaked roughly 1.5 MB per minute of retained heap. Under the default 512 MB heap cap (#1139), the bullmq service filled its heap on a ~5.5 hour cycle and died with `FATAL ERROR: Ineffective mark-compacts near heap limit`, taking the scheduler, sleep checks, and the Discord gateway down until the platform restarted it. Mostly idle deployments take the early return before any client is built, which is why the leak only surfaced on busy ones. Before the heap cap existed, the same leak showed up as unbounded memory drift instead of crashes.

## Change

`sleep-check.ts` now keeps one client per provider in a module-level cache reused across scheduler ticks. The resolved provider env values are fingerprinted, so a credential rotation (or any provider settings change) rebuilds the client on the next tick instead of serving a stale one. Docker keeps its env-free construction.

Unchanged: the per-run memoization map, the frequency of `resolveComputeProviderEnvValues` DB reads, and the constructed client options (`envFallback` shape is identical). Only the repeated client construction stops.

`clearSleepCheckClientCache()` is exported for tests; both test suites reset it in `beforeEach` so mock clients cannot leak across cases.

## Testing

- Two new tests: the client is constructed once across two scheduler runs, and a changed env fingerprint rebuilds the client with the new `envFallback`.
- All 40 sleep-check tests and the full `@roomote/bullmq` suite (156 tests) pass; `tsc --noEmit` clean.

## Follow-ups (not in this PR)

- The controller builds a client per task spawn — same pattern at a much lower rate; worth the same treatment eventually.
- Once this ships fleet-wide, temporarily raised `NODE_OPTIONS` heap overrides can return to the 512 MB default.