### PR TITLE
[Fix] Refresh GitLab OAuth tokens before they expire in sandboxes

### DIFF
--- a/packages/gitlab/src/__tests__/api.test.ts
+++ b/packages/gitlab/src/__tests__/api.test.ts
@@ -8,11 +8,17 @@ const {
   mockRepositoriesFindMany,
   mockEnvironmentsFindFirst,
   mockGitLabOAuthAccessToken,
+  mockIsGitLabOAuthAccessToken,
+  mockGetCachedGitLabOAuthAccessTokenExpiresAt,
 } = vi.hoisted(() => ({
   mockEnvironmentVariablesFindMany: vi.fn(),
   mockRepositoriesFindMany: vi.fn(),
   mockEnvironmentsFindFirst: vi.fn(),
   mockGitLabOAuthAccessToken: vi.fn(),
+  mockIsGitLabOAuthAccessToken: vi.fn((_token?: string) => false),
+  mockGetCachedGitLabOAuthAccessTokenExpiresAt: vi.fn(
+    (): Date | null => null,
+  ),
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -63,8 +69,11 @@ vi.mock('@roomote/db/encryption', () => ({
 }));
 
 vi.mock('../oauth', () => ({
-  isGitLabOAuthAccessToken: () => false,
+  isGitLabOAuthAccessToken: (token: string) =>
+    mockIsGitLabOAuthAccessToken(token),
   resolveGitLabOAuthAccessToken: () => mockGitLabOAuthAccessToken(),
+  getCachedGitLabOAuthAccessTokenExpiresAt: () =>
+    mockGetCachedGitLabOAuthAccessTokenExpiresAt(),
 }));
 
 import {
@@ -456,6 +465,8 @@ describe('createTaskRunScopedGitLabTokens', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGitLabOAuthAccessToken.mockResolvedValue('oauth_access_token');
+    mockIsGitLabOAuthAccessToken.mockReturnValue(false);
+    mockGetCachedGitLabOAuthAccessTokenExpiresAt.mockReturnValue(null);
     delete process.env.GITLAB_BASE_URL;
     mockEnvironmentVariablesFindMany.mockResolvedValue([]);
     mockEnvironmentsFindFirst.mockResolvedValue(null);
@@ -516,6 +527,7 @@ describe('createTaskRunScopedGitLabTokens', () => {
           },
         ],
       },
+      expiresAt: null,
     });
     expect(fetchMock).toHaveBeenCalledWith(
       'https://gitlab.com/api/v4/projects/42/access_tokens',
@@ -869,6 +881,40 @@ describe('createTaskRunScopedGitLabTokens', () => {
     );
   });
 
+  it('routes OAuth access tokens through the proxy and surfaces their expiry', async () => {
+    const expiresAt = new Date(Date.now() + 90 * 60 * 1000);
+    mockIsGitLabOAuthAccessToken.mockReturnValue(true);
+    mockGetCachedGitLabOAuthAccessTokenExpiresAt.mockReturnValue(expiresAt);
+
+    const fetchMock = vi.fn<typeof fetch>();
+    const result = await createTaskRunScopedGitLabTokens(
+      makeTaskRun({
+        repo: 'group/project',
+        description: 'Work on GitLab',
+        sourceControlProvider: 'gitlab',
+      }),
+      { fetchImpl: fetchMock },
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      credentials: [],
+      proxyCredentials: [
+        {
+          host: 'gitlab.com',
+          originBaseUrl: 'https://gitlab.com',
+          repositoryFullName: 'group/project',
+          username: 'oauth2',
+          token: 'oauth_access_token',
+        },
+      ],
+      artifactsPatch: {
+        gitlabScopedProjectTokens: [],
+      },
+      expiresAt,
+    });
+  });
+
   it('falls back to deployment-token proxy credentials when the token cannot mint project access tokens', async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(JSON.stringify({ error: 'permission denied' }), {
@@ -900,6 +946,7 @@ describe('createTaskRunScopedGitLabTokens', () => {
       artifactsPatch: {
         gitlabScopedProjectTokens: [],
       },
+      expiresAt: null,
     });
   });
 

--- a/packages/gitlab/src/__tests__/api.test.ts
+++ b/packages/gitlab/src/__tests__/api.test.ts
@@ -8,17 +8,15 @@ const {
   mockRepositoriesFindMany,
   mockEnvironmentsFindFirst,
   mockGitLabOAuthAccessToken,
+  mockGitLabOAuthAccessTokenWithMetadata,
   mockIsGitLabOAuthAccessToken,
-  mockGetCachedGitLabOAuthAccessTokenExpiresAt,
 } = vi.hoisted(() => ({
   mockEnvironmentVariablesFindMany: vi.fn(),
   mockRepositoriesFindMany: vi.fn(),
   mockEnvironmentsFindFirst: vi.fn(),
   mockGitLabOAuthAccessToken: vi.fn(),
+  mockGitLabOAuthAccessTokenWithMetadata: vi.fn(),
   mockIsGitLabOAuthAccessToken: vi.fn((_token?: string) => false),
-  mockGetCachedGitLabOAuthAccessTokenExpiresAt: vi.fn(
-    (): Date | null => null,
-  ),
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -72,8 +70,8 @@ vi.mock('../oauth', () => ({
   isGitLabOAuthAccessToken: (token: string) =>
     mockIsGitLabOAuthAccessToken(token),
   resolveGitLabOAuthAccessToken: () => mockGitLabOAuthAccessToken(),
-  getCachedGitLabOAuthAccessTokenExpiresAt: () =>
-    mockGetCachedGitLabOAuthAccessTokenExpiresAt(),
+  resolveGitLabOAuthAccessTokenWithMetadata: () =>
+    mockGitLabOAuthAccessTokenWithMetadata(),
 }));
 
 import {
@@ -465,8 +463,11 @@ describe('createTaskRunScopedGitLabTokens', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGitLabOAuthAccessToken.mockResolvedValue('oauth_access_token');
+    mockGitLabOAuthAccessTokenWithMetadata.mockResolvedValue({
+      accessToken: 'oauth_access_token',
+      expiresAt: new Date(Date.now() + 90 * 60 * 1000),
+    });
     mockIsGitLabOAuthAccessToken.mockReturnValue(false);
-    mockGetCachedGitLabOAuthAccessTokenExpiresAt.mockReturnValue(null);
     delete process.env.GITLAB_BASE_URL;
     mockEnvironmentVariablesFindMany.mockResolvedValue([]);
     mockEnvironmentsFindFirst.mockResolvedValue(null);
@@ -884,7 +885,10 @@ describe('createTaskRunScopedGitLabTokens', () => {
   it('routes OAuth access tokens through the proxy and surfaces their expiry', async () => {
     const expiresAt = new Date(Date.now() + 90 * 60 * 1000);
     mockIsGitLabOAuthAccessToken.mockReturnValue(true);
-    mockGetCachedGitLabOAuthAccessTokenExpiresAt.mockReturnValue(expiresAt);
+    mockGitLabOAuthAccessTokenWithMetadata.mockResolvedValue({
+      accessToken: 'oauth_access_token',
+      expiresAt,
+    });
 
     const fetchMock = vi.fn<typeof fetch>();
     const result = await createTaskRunScopedGitLabTokens(

--- a/packages/gitlab/src/__tests__/oauth.test.ts
+++ b/packages/gitlab/src/__tests__/oauth.test.ts
@@ -136,6 +136,63 @@ describe('GitLab deployment OAuth', () => {
     await deleteGitLabOAuthConnection();
   });
 
+  it('scales the proactive refresh window to a short instance token lifetime', async () => {
+    // Self-managed instances can configure a much shorter OAuth TTL than
+    // GitLab's ~2h default. A fixed 10m skew would then exceed the whole
+    // lifetime and refresh on every single resolve.
+    executeMock.mockResolvedValue([{ value: 'encrypted-connection' }]);
+    decryptMock.mockResolvedValue({
+      baseUrl: 'https://gitlab.example',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      accountId: '42',
+      username: 'roomote',
+      accessToken: 'short-lived-access-token',
+      refreshToken: 'refresh-token',
+      expiresInSeconds: 300,
+      // 4 of its 5 minutes left: well inside a fixed 10m skew, but nowhere
+      // near the quarter-life mark for a 5m token.
+      expiresAt: new Date(Date.now() + 4 * 60 * 1000).toISOString(),
+      scopes: ['api'],
+      status: 'active',
+    });
+    const fetchImpl = vi.fn();
+
+    await expect(
+      resolveGitLabOAuthAccessToken({ fetchImpl: fetchImpl as typeof fetch }),
+    ).resolves.toBe('short-lived-access-token');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('still refreshes a short-lived token once it passes its quarter-life mark', async () => {
+    executeMock.mockResolvedValue([{ value: 'encrypted-connection' }]);
+    decryptMock.mockResolvedValue({
+      baseUrl: 'https://gitlab.example',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      accountId: '42',
+      username: 'roomote',
+      accessToken: 'short-lived-access-token',
+      refreshToken: 'refresh-token',
+      expiresInSeconds: 300,
+      expiresAt: new Date(Date.now() + 60 * 1000).toISOString(),
+      scopes: ['api'],
+      status: 'active',
+    });
+    const fetchImpl = vi.fn().mockResolvedValue(
+      Response.json({
+        access_token: 'short-lived-refreshed-token',
+        refresh_token: 'new-refresh-token',
+        expires_in: 300,
+      }),
+    );
+
+    await expect(
+      resolveGitLabOAuthAccessToken({ fetchImpl: fetchImpl as typeof fetch }),
+    ).resolves.toBe('short-lived-refreshed-token');
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
   it('marks reauthorization required when a failed refresh was not preempted', async () => {
     // The connection re-read after the failure is unchanged, so no peer
     // rotated the tokens and the refusal is a genuine invalid_grant.

--- a/packages/gitlab/src/__tests__/oauth.test.ts
+++ b/packages/gitlab/src/__tests__/oauth.test.ts
@@ -102,6 +102,41 @@ describe('GitLab deployment OAuth', () => {
     expect(isGitLabOAuthAccessToken('gitlab-access-token')).toBe(false);
   });
 
+  it('proactively refreshes OAuth access tokens inside the 10-minute skew window', async () => {
+    executeMock.mockResolvedValue([{ value: 'encrypted-connection' }]);
+    decryptMock.mockResolvedValue({
+      baseUrl: 'https://gitlab.example',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      accountId: '42',
+      username: 'roomote',
+      accessToken: 'near-expiry-access-token',
+      refreshToken: 'refresh-token',
+      // Still valid, but inside the proactive refresh skew.
+      expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+      scopes: ['api'],
+      status: 'active',
+    });
+    const fetchImpl = vi.fn().mockResolvedValue(
+      Response.json({
+        access_token: 'proactively-refreshed-token',
+        refresh_token: 'new-refresh-token',
+        expires_in: 7200,
+      }),
+    );
+
+    const token = await resolveGitLabOAuthAccessToken({
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    expect(token).toBe('proactively-refreshed-token');
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(isGitLabOAuthAccessToken('proactively-refreshed-token')).toBe(true);
+    // Prior access token is still treated as OAuth for mid-flight API calls.
+    expect(isGitLabOAuthAccessToken('near-expiry-access-token')).toBe(true);
+    expect(isGitLabOAuthAccessToken('glpat-personal-token')).toBe(false);
+  });
+
   it('waits for an in-flight refresh and prevents it from recreating the connection', async () => {
     executeMock.mockResolvedValue([{ value: 'encrypted-connection' }]);
     decryptMock.mockResolvedValue({

--- a/packages/gitlab/src/__tests__/oauth.test.ts
+++ b/packages/gitlab/src/__tests__/oauth.test.ts
@@ -102,6 +102,50 @@ describe('GitLab deployment OAuth', () => {
     expect(isGitLabOAuthAccessToken('gitlab-access-token')).toBe(false);
   });
 
+  it('uses a still-valid token when concurrent refresh fails', async () => {
+    const stillValidUntil = new Date(Date.now() + 30 * 60 * 1000).toISOString();
+    executeMock.mockResolvedValue([{ value: 'encrypted-connection' }]);
+    decryptMock
+      .mockResolvedValueOnce({
+        baseUrl: 'https://gitlab.example',
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+        accountId: '42',
+        username: 'roomote',
+        accessToken: 'stale-access-token',
+        refreshToken: 'stale-refresh-token',
+        expiresAt: new Date(0).toISOString(),
+        scopes: ['api'],
+        status: 'active',
+      })
+      .mockResolvedValueOnce({
+        baseUrl: 'https://gitlab.example',
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+        accountId: '42',
+        username: 'roomote',
+        accessToken: 'peer-refreshed-access-token',
+        refreshToken: 'peer-refreshed-refresh-token',
+        expiresAt: stillValidUntil,
+        scopes: ['api'],
+        status: 'active',
+      });
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'invalid_grant' }), {
+        status: 400,
+        statusText: 'Bad Request',
+      }),
+    );
+
+    await expect(
+      resolveGitLabOAuthAccessToken({
+        fetchImpl: fetchImpl as typeof fetch,
+        forceRefresh: true,
+      }),
+    ).resolves.toBe('peer-refreshed-access-token');
+    expect(writeMock).not.toHaveBeenCalled();
+  });
+
   it('proactively refreshes OAuth access tokens inside the 10-minute skew window', async () => {
     executeMock.mockResolvedValue([{ value: 'encrypted-connection' }]);
     decryptMock.mockResolvedValue({

--- a/packages/gitlab/src/__tests__/oauth.test.ts
+++ b/packages/gitlab/src/__tests__/oauth.test.ts
@@ -112,7 +112,6 @@ describe('GitLab deployment OAuth', () => {
       username: 'roomote',
       accessToken: 'near-expiry-access-token',
       refreshToken: 'refresh-token',
-      // Still valid, but inside the proactive refresh skew.
       expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
       scopes: ['api'],
       status: 'active',
@@ -132,7 +131,6 @@ describe('GitLab deployment OAuth', () => {
     expect(token).toBe('proactively-refreshed-token');
     expect(fetchImpl).toHaveBeenCalledOnce();
     expect(isGitLabOAuthAccessToken('proactively-refreshed-token')).toBe(true);
-    // Prior access token is still treated as OAuth for mid-flight API calls.
     expect(isGitLabOAuthAccessToken('near-expiry-access-token')).toBe(true);
     expect(isGitLabOAuthAccessToken('glpat-personal-token')).toBe(false);
   });

--- a/packages/gitlab/src/__tests__/oauth.test.ts
+++ b/packages/gitlab/src/__tests__/oauth.test.ts
@@ -7,6 +7,7 @@ const {
   insertMock,
   writeMock,
   decryptMock,
+  encryptMock,
 } = vi.hoisted(() => {
   const deleteWhereMock = vi.fn(async () => undefined);
   const writeMock = vi.fn(async () => undefined);
@@ -21,6 +22,7 @@ const {
     })),
     writeMock,
     decryptMock: vi.fn(),
+    encryptMock: vi.fn(() => 'encrypted-connection'),
   };
 });
 
@@ -33,7 +35,7 @@ vi.mock('@roomote/db/server', () => ({
 
 vi.mock('@roomote/db/encryption', () => ({
   decryptSecrets: decryptMock,
-  encryptJSON: vi.fn(() => 'encrypted-connection'),
+  encryptJSON: encryptMock,
 }));
 
 import {
@@ -100,6 +102,113 @@ describe('GitLab deployment OAuth', () => {
 
     expect(deleteWhereMock).toHaveBeenCalledOnce();
     expect(isGitLabOAuthAccessToken('gitlab-access-token')).toBe(false);
+  });
+
+  it('does not classify unrelated tokens as OAuth while a session is active', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'session-access-token',
+          refresh_token: 'session-refresh-token',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 42, username: 'roomote' }),
+      });
+    await exchangeGitLabOAuthCode({
+      baseUrl: 'https://gitlab.example',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      code: 'code',
+      redirectUri: 'https://roomote.example/callback',
+      fetchImpl,
+    });
+
+    expect(isGitLabOAuthAccessToken('session-access-token')).toBe(true);
+    // Self-managed instances can customise the PAT prefix, and deploy/CI job
+    // tokens carry none, so an unrecognised token must not become a Bearer.
+    expect(isGitLabOAuthAccessToken('acme-pat-abc123')).toBe(false);
+    expect(isGitLabOAuthAccessToken('glpat-personal-token')).toBe(false);
+
+    await deleteGitLabOAuthConnection();
+  });
+
+  it('marks reauthorization required when a failed refresh was not preempted', async () => {
+    // The connection re-read after the failure is unchanged, so no peer
+    // rotated the tokens and the refusal is a genuine invalid_grant.
+    executeMock.mockResolvedValue([{ value: 'encrypted-connection' }]);
+    decryptMock.mockResolvedValue({
+      baseUrl: 'https://gitlab.example',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      accountId: '42',
+      username: 'roomote',
+      accessToken: 'revoked-access-token',
+      refreshToken: 'revoked-refresh-token',
+      // Inside the proactive skew but not yet expired.
+      expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+      scopes: ['api'],
+      status: 'active',
+    });
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'invalid_grant' }), {
+        status: 400,
+        statusText: 'Bad Request',
+      }),
+    );
+
+    await expect(
+      resolveGitLabOAuthAccessToken({ fetchImpl: fetchImpl as typeof fetch }),
+    ).rejects.toThrow(/must be renewed/);
+    expect(encryptMock).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'reauthorization_required' }),
+    );
+  });
+
+  it('ignores a peer rotation that is already inside the refresh window', async () => {
+    executeMock.mockResolvedValue([{ value: 'encrypted-connection' }]);
+    decryptMock
+      .mockResolvedValueOnce({
+        baseUrl: 'https://gitlab.example',
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+        accountId: '42',
+        username: 'roomote',
+        accessToken: 'stale-access-token',
+        refreshToken: 'stale-refresh-token',
+        expiresAt: new Date(0).toISOString(),
+        scopes: ['api'],
+        status: 'active',
+      })
+      .mockResolvedValueOnce({
+        baseUrl: 'https://gitlab.example',
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+        accountId: '42',
+        username: 'roomote',
+        accessToken: 'peer-refreshed-access-token',
+        refreshToken: 'peer-refreshed-refresh-token',
+        // Changed, but dies before the worker could refresh again.
+        expiresAt: new Date(Date.now() + 30 * 1000).toISOString(),
+        scopes: ['api'],
+        status: 'active',
+      });
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'invalid_grant' }), {
+        status: 400,
+        statusText: 'Bad Request',
+      }),
+    );
+
+    await expect(
+      resolveGitLabOAuthAccessToken({
+        fetchImpl: fetchImpl as typeof fetch,
+        forceRefresh: true,
+      }),
+    ).rejects.toThrow(/must be renewed/);
   });
 
   it('uses a still-valid token when concurrent refresh fails', async () => {
@@ -175,8 +284,52 @@ describe('GitLab deployment OAuth', () => {
     expect(token).toBe('proactively-refreshed-token');
     expect(fetchImpl).toHaveBeenCalledOnce();
     expect(isGitLabOAuthAccessToken('proactively-refreshed-token')).toBe(true);
-    expect(isGitLabOAuthAccessToken('near-expiry-access-token')).toBe(true);
+  });
+
+  it('keeps the just-rotated token classified as OAuth for in-flight callers', async () => {
+    executeMock.mockResolvedValue([{ value: 'encrypted-connection' }]);
+    const connection = {
+      baseUrl: 'https://gitlab.example',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      accountId: '42',
+      username: 'roomote',
+      accessToken: 'rotating-access-token',
+      refreshToken: 'refresh-token',
+      scopes: ['api'],
+      status: 'active',
+    };
+    decryptMock
+      .mockResolvedValueOnce({
+        ...connection,
+        expiresAt: new Date(Date.now() + 90 * 60 * 1000).toISOString(),
+      })
+      .mockResolvedValueOnce({
+        ...connection,
+        expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+      });
+
+    // A caller resolves and holds this token...
+    await expect(resolveGitLabOAuthAccessToken()).resolves.toBe(
+      'rotating-access-token',
+    );
+    // ...while a later resolve rotates it out from under them.
+    await expect(
+      resolveGitLabOAuthAccessToken({
+        fetchImpl: vi.fn().mockResolvedValue(
+          Response.json({
+            access_token: 'rotated-access-token',
+            refresh_token: 'new-refresh-token',
+            expires_in: 7200,
+          }),
+        ) as typeof fetch,
+      }),
+    ).resolves.toBe('rotated-access-token');
+
+    expect(isGitLabOAuthAccessToken('rotated-access-token')).toBe(true);
+    expect(isGitLabOAuthAccessToken('rotating-access-token')).toBe(true);
     expect(isGitLabOAuthAccessToken('glpat-personal-token')).toBe(false);
+    expect(isGitLabOAuthAccessToken('acme-pat-abc123')).toBe(false);
   });
 
   it('waits for an in-flight refresh and prevents it from recreating the connection', async () => {

--- a/packages/gitlab/src/api.ts
+++ b/packages/gitlab/src/api.ts
@@ -1197,11 +1197,10 @@ export async function createTaskRunScopedGitLabTokens(
   /** OAuth access-token expiry for the worker refresh loop, if known. */
   expiresAt: Date | null;
 }> {
-  const oauthToken = await resolveGitLabOAuthAccessTokenWithMetadata({
-    fetchImpl: options?.fetchImpl,
-  });
-  const deploymentToken =
-    oauthToken?.accessToken ?? (await resolveGitLabToken());
+  // `options.fetchImpl` is the GitLab *API* fetch used to mint project tokens
+  // below, so it is deliberately not forwarded to the OAuth token endpoint.
+  const oauthToken = await resolveGitLabOAuthAccessTokenWithMetadata();
+  const deploymentToken = oauthToken?.accessToken;
 
   if (!deploymentToken?.trim()) {
     throw new Error(

--- a/packages/gitlab/src/api.ts
+++ b/packages/gitlab/src/api.ts
@@ -18,9 +18,9 @@ import {
   resolveDeploymentEnvVar,
 } from '@roomote/db/server';
 import {
-  getCachedGitLabOAuthAccessTokenExpiresAt,
   isGitLabOAuthAccessToken,
   resolveGitLabOAuthAccessToken,
+  resolveGitLabOAuthAccessTokenWithMetadata,
 } from './oauth';
 
 export * from './ci';
@@ -1197,7 +1197,11 @@ export async function createTaskRunScopedGitLabTokens(
   /** OAuth access-token expiry for the worker refresh loop, if known. */
   expiresAt: Date | null;
 }> {
-  const deploymentToken = await resolveGitLabToken();
+  const oauthToken = await resolveGitLabOAuthAccessTokenWithMetadata({
+    fetchImpl: options?.fetchImpl,
+  });
+  const deploymentToken =
+    oauthToken?.accessToken ?? (await resolveGitLabToken());
 
   if (!deploymentToken?.trim()) {
     throw new Error(
@@ -1209,9 +1213,6 @@ export async function createTaskRunScopedGitLabTokens(
   const apiBaseUrl = options?.apiBaseUrl ?? buildGitLabApiBaseUrl(baseUrl);
   const host = hostFromBaseUrl(baseUrl);
   const repositoriesList = await resolveGitLabRepositoryRowsForTaskRun(taskRun);
-  const oauthExpiresAt = isGitLabOAuthAccessToken(deploymentToken)
-    ? getCachedGitLabOAuthAccessTokenExpiresAt()
-    : null;
 
   // OAuth grants are deployment-scoped and already carry the repository
   // permissions needed by the worker. Do not attempt to mint GitLab project
@@ -1230,7 +1231,7 @@ export async function createTaskRunScopedGitLabTokens(
       artifactsPatch: {
         [GITLAB_SCOPED_PROJECT_TOKENS_ARTIFACT_KEY]: [],
       },
-      expiresAt: oauthExpiresAt,
+      expiresAt: oauthToken?.expiresAt ?? null,
     };
   }
 

--- a/packages/gitlab/src/api.ts
+++ b/packages/gitlab/src/api.ts
@@ -1194,11 +1194,7 @@ export async function createTaskRunScopedGitLabTokens(
   credentials: GitLabScopedProjectTokenCredential[];
   proxyCredentials: GitLabScopedProjectTokenCredential[];
   artifactsPatch: Record<string, GitLabScopedProjectTokenDescriptor[]>;
-  /**
-   * When set, the worker refresh loop schedules the next mint before this
-   * instant (with a small buffer). OAuth access tokens expire in ~2h; without
-   * this the fixed 45m cadence can leave a dead token in the sandbox.
-   */
+  /** OAuth access-token expiry for the worker refresh loop, if known. */
   expiresAt: Date | null;
 }> {
   const deploymentToken = await resolveGitLabToken();
@@ -1340,8 +1336,6 @@ export async function createTaskRunScopedGitLabTokens(
     artifactsPatch: {
       [GITLAB_SCOPED_PROJECT_TOKENS_ARTIFACT_KEY]: nextDescriptors,
     },
-    // Scoped project tokens are rotated on every mint/refresh; the fixed
-    // worker cadence is enough for their day-long TTL.
     expiresAt: null,
   };
 }

--- a/packages/gitlab/src/api.ts
+++ b/packages/gitlab/src/api.ts
@@ -18,6 +18,7 @@ import {
   resolveDeploymentEnvVar,
 } from '@roomote/db/server';
 import {
+  getCachedGitLabOAuthAccessTokenExpiresAt,
   isGitLabOAuthAccessToken,
   resolveGitLabOAuthAccessToken,
 } from './oauth';
@@ -1193,6 +1194,12 @@ export async function createTaskRunScopedGitLabTokens(
   credentials: GitLabScopedProjectTokenCredential[];
   proxyCredentials: GitLabScopedProjectTokenCredential[];
   artifactsPatch: Record<string, GitLabScopedProjectTokenDescriptor[]>;
+  /**
+   * When set, the worker refresh loop schedules the next mint before this
+   * instant (with a small buffer). OAuth access tokens expire in ~2h; without
+   * this the fixed 45m cadence can leave a dead token in the sandbox.
+   */
+  expiresAt: Date | null;
 }> {
   const deploymentToken = await resolveGitLabToken();
 
@@ -1206,6 +1213,9 @@ export async function createTaskRunScopedGitLabTokens(
   const apiBaseUrl = options?.apiBaseUrl ?? buildGitLabApiBaseUrl(baseUrl);
   const host = hostFromBaseUrl(baseUrl);
   const repositoriesList = await resolveGitLabRepositoryRowsForTaskRun(taskRun);
+  const oauthExpiresAt = isGitLabOAuthAccessToken(deploymentToken)
+    ? getCachedGitLabOAuthAccessTokenExpiresAt()
+    : null;
 
   // OAuth grants are deployment-scoped and already carry the repository
   // permissions needed by the worker. Do not attempt to mint GitLab project
@@ -1224,6 +1234,7 @@ export async function createTaskRunScopedGitLabTokens(
       artifactsPatch: {
         [GITLAB_SCOPED_PROJECT_TOKENS_ARTIFACT_KEY]: [],
       },
+      expiresAt: oauthExpiresAt,
     };
   }
 
@@ -1316,6 +1327,7 @@ export async function createTaskRunScopedGitLabTokens(
         artifactsPatch: {
           [GITLAB_SCOPED_PROJECT_TOKENS_ARTIFACT_KEY]: [],
         },
+        expiresAt: null,
       };
     }
 
@@ -1328,6 +1340,9 @@ export async function createTaskRunScopedGitLabTokens(
     artifactsPatch: {
       [GITLAB_SCOPED_PROJECT_TOKENS_ARTIFACT_KEY]: nextDescriptors,
     },
+    // Scoped project tokens are rotated on every mint/refresh; the fixed
+    // worker cadence is enough for their day-long TTL.
+    expiresAt: null,
   };
 }
 

--- a/packages/gitlab/src/oauth.ts
+++ b/packages/gitlab/src/oauth.ts
@@ -69,9 +69,7 @@ function toAccessTokenResult(
   expiresAt: string | Date,
 ): GitLabOAuthAccessToken {
   const resolvedExpiresAt =
-    expiresAt instanceof Date
-      ? expiresAt
-      : parseConnectionExpiresAt(expiresAt);
+    expiresAt instanceof Date ? expiresAt : parseConnectionExpiresAt(expiresAt);
   rememberAccessToken(accessToken, resolvedExpiresAt);
   return { accessToken, expiresAt: resolvedExpiresAt };
 }

--- a/packages/gitlab/src/oauth.ts
+++ b/packages/gitlab/src/oauth.ts
@@ -20,6 +20,11 @@ export type GitLabOAuthConnection = {
   accessToken: string;
   refreshToken: string;
   expiresAt: string;
+  /**
+   * Access-token lifetime reported by the instance. Absent on connections
+   * written before adaptive refresh, which fall back to the default skew.
+   */
+  expiresInSeconds?: number;
   scopes: string[];
   status: GitLabOAuthConnectionStatus;
 };
@@ -38,8 +43,38 @@ export type GitLabOAuthAccessToken = {
   expiresAt: Date | null;
 };
 
-/** Proactive OAuth refresh window (~2h access tokens). */
+/** Proactive OAuth refresh window for GitLab's default ~2h access tokens. */
 const OAUTH_ACCESS_TOKEN_REFRESH_SKEW_MS = 10 * 60 * 1000;
+
+/** GitLab's default access-token lifetime, used when none is reported. */
+const DEFAULT_ACCESS_TOKEN_LIFETIME_SECONDS = 7200;
+
+/** Expiry fields for a freshly issued access token, in the instance's own terms. */
+function accessTokenLifetime(token: GitLabOAuthTokenResponse): {
+  expiresAt: string;
+  expiresInSeconds: number;
+} {
+  const expiresInSeconds =
+    token.expires_in ?? DEFAULT_ACCESS_TOKEN_LIFETIME_SECONDS;
+
+  return {
+    expiresAt: new Date(Date.now() + expiresInSeconds * 1000).toISOString(),
+    expiresInSeconds,
+  };
+}
+
+/**
+ * Self-managed instances can configure a much shorter OAuth lifetime than the
+ * ~2h default. A fixed skew wider than the lifetime itself would refresh on
+ * every resolve, so cap it at a quarter of the token's life.
+ */
+function refreshSkewMsFor(connection: GitLabOAuthConnection): number {
+  const lifetimeMs = (connection.expiresInSeconds ?? 0) * 1000;
+
+  return lifetimeMs > 0
+    ? Math.min(OAUTH_ACCESS_TOKEN_REFRESH_SKEW_MS, lifetimeMs / 4)
+    : OAUTH_ACCESS_TOKEN_REFRESH_SKEW_MS;
+}
 
 let refreshPromise: Promise<GitLabOAuthAccessToken | null> | null = null;
 let deletionPromise: Promise<void> | null = null;
@@ -205,9 +240,7 @@ export async function exchangeGitLabOAuthCode(input: {
     username: '',
     accessToken: token.access_token,
     refreshToken: token.refresh_token,
-    expiresAt: new Date(
-      Date.now() + (token.expires_in ?? 7200) * 1000,
-    ).toISOString(),
+    ...accessTokenLifetime(token),
     scopes: token.scope?.split(/\s+/).filter(Boolean) ?? [...DEFAULT_SCOPES],
     status: 'active',
   };
@@ -250,8 +283,7 @@ export async function resolveGitLabOAuthAccessTokenWithMetadata(options?: {
   if (!connection || connection.status !== 'active') return null;
   if (
     !options?.forceRefresh &&
-    Date.parse(connection.expiresAt) >
-      Date.now() + OAUTH_ACCESS_TOKEN_REFRESH_SKEW_MS
+    Date.parse(connection.expiresAt) > Date.now() + refreshSkewMsFor(connection)
   ) {
     return toAccessTokenResult(connection.accessToken, connection.expiresAt);
   }
@@ -285,8 +317,7 @@ export async function resolveGitLabOAuthAccessTokenWithMetadata(options?: {
       if (
         latest?.status === 'active' &&
         latest.accessToken !== connection.accessToken &&
-        Date.parse(latest.expiresAt) >
-          Date.now() + OAUTH_ACCESS_TOKEN_REFRESH_SKEW_MS
+        Date.parse(latest.expiresAt) > Date.now() + refreshSkewMsFor(latest)
       ) {
         return toAccessTokenResult(latest.accessToken, latest.expiresAt);
       }
@@ -303,9 +334,7 @@ export async function resolveGitLabOAuthAccessTokenWithMetadata(options?: {
       ...connection,
       accessToken: token.access_token,
       refreshToken: token.refresh_token ?? connection.refreshToken,
-      expiresAt: new Date(
-        Date.now() + (token.expires_in ?? 7200) * 1000,
-      ).toISOString(),
+      ...accessTokenLifetime(token),
       scopes: token.scope?.split(/\s+/).filter(Boolean) ?? connection.scopes,
       status: 'active' as const,
     };

--- a/packages/gitlab/src/oauth.ts
+++ b/packages/gitlab/src/oauth.ts
@@ -32,10 +32,54 @@ type GitLabOAuthTokenResponse = {
   scope?: string;
 };
 
-let refreshPromise: Promise<string | null> | null = null;
+export type GitLabOAuthAccessToken = {
+  accessToken: string;
+  expiresAt: Date;
+};
+
+// Refresh before the access token is within this window so long-running
+// worker jobs can pick up a fresh token before git operations start failing.
+// GitLab access tokens typically last ~2 hours; 10 minutes leaves headroom
+// for the worker's refresh tick and network latency.
+const OAUTH_ACCESS_TOKEN_REFRESH_SKEW_MS = 10 * 60 * 1000;
+
+// Personal/project/group/deploy tokens use known prefixes. OAuth access
+// tokens do not, so prefix detection stays reliable after a rotate when the
+// previous access token no longer equals the in-memory cache.
+const GITLAB_STATIC_TOKEN_PREFIX = /^(glpat-|glptt-|gldt-|glsoat-)/i;
+
+let refreshPromise: Promise<GitLabOAuthAccessToken | null> | null = null;
 let deletionPromise: Promise<void> | null = null;
 let connectionGeneration = 0;
 let cachedAccessToken: string | null = null;
+let cachedAccessTokenExpiresAt: Date | null = null;
+
+function rememberAccessToken(accessToken: string, expiresAt: Date): void {
+  cachedAccessToken = accessToken;
+  cachedAccessTokenExpiresAt = expiresAt;
+}
+
+function clearCachedAccessToken(): void {
+  cachedAccessToken = null;
+  cachedAccessTokenExpiresAt = null;
+}
+
+function parseConnectionExpiresAt(expiresAt: string): Date {
+  const parsed = Date.parse(expiresAt);
+  return Number.isNaN(parsed) ? new Date(0) : new Date(parsed);
+}
+
+function toAccessTokenResult(
+  accessToken: string,
+  expiresAt: string | Date,
+): GitLabOAuthAccessToken {
+  const resolvedExpiresAt =
+    expiresAt instanceof Date
+      ? expiresAt
+      : parseConnectionExpiresAt(expiresAt);
+  rememberAccessToken(accessToken, resolvedExpiresAt);
+  return { accessToken, expiresAt: resolvedExpiresAt };
+}
 
 function tokenEndpoint(baseUrl: string): string {
   return new URL('oauth/token', `${baseUrl.replace(/\/$/, '')}/`).toString();
@@ -116,7 +160,7 @@ export async function deleteGitLabOAuthConnection(): Promise<void> {
         .delete(deploymentSecrets)
         .where(eq(deploymentSecrets.name, SECRET_NAME));
       refreshPromise = null;
-      cachedAccessToken = null;
+      clearCachedAccessToken();
     })();
   }
 
@@ -191,14 +235,22 @@ export async function exchangeGitLabOAuthCode(input: {
     // Token exchange is still valid when the identity lookup is temporarily unavailable.
   }
   await writeConnection(connection);
-  cachedAccessToken = connection.accessToken;
+  rememberAccessToken(
+    connection.accessToken,
+    parseConnectionExpiresAt(connection.expiresAt),
+  );
   return connection;
 }
 
-export async function resolveGitLabOAuthAccessToken(options?: {
+/**
+ * Resolve a usable GitLab OAuth access token, refreshing when it is missing or
+ * inside the proactive refresh window. Returns expiry so callers (worker token
+ * mint, refresh loop) can schedule the next rotation before the token dies.
+ */
+export async function resolveGitLabOAuthAccessTokenWithMetadata(options?: {
   fetchImpl?: typeof fetch;
   forceRefresh?: boolean;
-}): Promise<string | null> {
+}): Promise<GitLabOAuthAccessToken | null> {
   if (deletionPromise) {
     await deletionPromise;
     return null;
@@ -212,10 +264,10 @@ export async function resolveGitLabOAuthAccessToken(options?: {
   if (!connection || connection.status !== 'active') return null;
   if (
     !options?.forceRefresh &&
-    Date.parse(connection.expiresAt) > Date.now() + 60_000
+    Date.parse(connection.expiresAt) >
+      Date.now() + OAUTH_ACCESS_TOKEN_REFRESH_SKEW_MS
   ) {
-    cachedAccessToken = connection.accessToken;
-    return connection.accessToken;
+    return toAccessTokenResult(connection.accessToken, connection.expiresAt);
   }
   if (refreshPromise) return refreshPromise;
 
@@ -259,8 +311,7 @@ export async function resolveGitLabOAuthAccessToken(options?: {
     };
     if (generation !== connectionGeneration) return null;
     await writeConnection(next);
-    cachedAccessToken = next.accessToken;
-    return next.accessToken;
+    return toAccessTokenResult(next.accessToken, next.expiresAt);
   })();
   try {
     return await refreshPromise;
@@ -269,8 +320,36 @@ export async function resolveGitLabOAuthAccessToken(options?: {
   }
 }
 
+export async function resolveGitLabOAuthAccessToken(options?: {
+  fetchImpl?: typeof fetch;
+  forceRefresh?: boolean;
+}): Promise<string | null> {
+  const result = await resolveGitLabOAuthAccessTokenWithMetadata(options);
+  return result?.accessToken ?? null;
+}
+
+/**
+ * True when `token` should be sent as an OAuth Bearer credential (not a
+ * PRIVATE-TOKEN personal/project token). Matches the current cache, and also
+ * treats non-prefixed tokens as OAuth while a session is active so a just
+ * rotated prior access token still uses the correct header mid-flight.
+ */
 export function isGitLabOAuthAccessToken(token: string): boolean {
-  return token === cachedAccessToken;
+  if (!token) {
+    return false;
+  }
+  if (token === cachedAccessToken) {
+    return true;
+  }
+  if (GITLAB_STATIC_TOKEN_PREFIX.test(token)) {
+    return false;
+  }
+  return cachedAccessToken !== null;
+}
+
+/** Expiry of the last resolved OAuth access token, if any. */
+export function getCachedGitLabOAuthAccessTokenExpiresAt(): Date | null {
+  return cachedAccessTokenExpiresAt;
 }
 
 export async function markGitLabOAuthReauthorizationRequired(): Promise<void> {

--- a/packages/gitlab/src/oauth.ts
+++ b/packages/gitlab/src/oauth.ts
@@ -37,15 +37,10 @@ export type GitLabOAuthAccessToken = {
   expiresAt: Date;
 };
 
-// Refresh before the access token is within this window so long-running
-// worker jobs can pick up a fresh token before git operations start failing.
-// GitLab access tokens typically last ~2 hours; 10 minutes leaves headroom
-// for the worker's refresh tick and network latency.
+/** Proactive OAuth refresh window (~2h access tokens). */
 const OAUTH_ACCESS_TOKEN_REFRESH_SKEW_MS = 10 * 60 * 1000;
 
-// Personal/project/group/deploy tokens use known prefixes. OAuth access
-// tokens do not, so prefix detection stays reliable after a rotate when the
-// previous access token no longer equals the in-memory cache.
+/** PAT/project/deploy prefixes. OAuth access tokens have no gl* prefix. */
 const GITLAB_STATIC_TOKEN_PREFIX = /^(glpat-|glptt-|gldt-|glsoat-)/i;
 
 let refreshPromise: Promise<GitLabOAuthAccessToken | null> | null = null;
@@ -242,11 +237,7 @@ export async function exchangeGitLabOAuthCode(input: {
   return connection;
 }
 
-/**
- * Resolve a usable GitLab OAuth access token, refreshing when it is missing or
- * inside the proactive refresh window. Returns expiry so callers (worker token
- * mint, refresh loop) can schedule the next rotation before the token dies.
- */
+/** Resolve OAuth access token + expiry, refreshing inside the skew window. */
 export async function resolveGitLabOAuthAccessTokenWithMetadata(options?: {
   fetchImpl?: typeof fetch;
   forceRefresh?: boolean;
@@ -328,12 +319,7 @@ export async function resolveGitLabOAuthAccessToken(options?: {
   return result?.accessToken ?? null;
 }
 
-/**
- * True when `token` should be sent as an OAuth Bearer credential (not a
- * PRIVATE-TOKEN personal/project token). Matches the current cache, and also
- * treats non-prefixed tokens as OAuth while a session is active so a just
- * rotated prior access token still uses the correct header mid-flight.
- */
+/** Bearer (OAuth) vs PRIVATE-TOKEN (static gl* tokens). */
 export function isGitLabOAuthAccessToken(token: string): boolean {
   if (!token) {
     return false;
@@ -347,7 +333,6 @@ export function isGitLabOAuthAccessToken(token: string): boolean {
   return cachedAccessToken !== null;
 }
 
-/** Expiry of the last resolved OAuth access token, if any. */
 export function getCachedGitLabOAuthAccessTokenExpiresAt(): Date | null {
   return cachedAccessTokenExpiresAt;
 }

--- a/packages/gitlab/src/oauth.ts
+++ b/packages/gitlab/src/oauth.ts
@@ -281,8 +281,17 @@ export async function resolveGitLabOAuthAccessTokenWithMetadata(options?: {
     );
     if (!response.ok) {
       if (generation !== connectionGeneration) return null;
+      // Another replica may have already rotated the tokens. Prefer a still
+      // valid access token over marking reauthorization_required.
+      const latest = await readConnection();
+      if (
+        latest?.status === 'active' &&
+        Date.parse(latest.expiresAt) > Date.now()
+      ) {
+        return toAccessTokenResult(latest.accessToken, latest.expiresAt);
+      }
       await writeConnection({
-        ...connection,
+        ...(latest ?? connection),
         status: 'reauthorization_required',
       });
       throw new Error(

--- a/packages/gitlab/src/oauth.ts
+++ b/packages/gitlab/src/oauth.ts
@@ -34,44 +34,44 @@ type GitLabOAuthTokenResponse = {
 
 export type GitLabOAuthAccessToken = {
   accessToken: string;
-  expiresAt: Date;
+  /** Null when the stored expiry is unreadable; callers keep their default cadence. */
+  expiresAt: Date | null;
 };
 
 /** Proactive OAuth refresh window (~2h access tokens). */
 const OAUTH_ACCESS_TOKEN_REFRESH_SKEW_MS = 10 * 60 * 1000;
 
-/** PAT/project/deploy prefixes. OAuth access tokens have no gl* prefix. */
-const GITLAB_STATIC_TOKEN_PREFIX = /^(glpat-|glptt-|gldt-|glsoat-)/i;
-
 let refreshPromise: Promise<GitLabOAuthAccessToken | null> | null = null;
 let deletionPromise: Promise<void> | null = null;
 let connectionGeneration = 0;
 let cachedAccessToken: string | null = null;
-let cachedAccessTokenExpiresAt: Date | null = null;
+// A rotate leaves in-flight callers holding the token they resolved a moment
+// ago. Keep it so those calls still pick the Bearer header.
+let previousAccessToken: string | null = null;
 
-function rememberAccessToken(accessToken: string, expiresAt: Date): void {
+function rememberAccessToken(accessToken: string): void {
+  if (cachedAccessToken && cachedAccessToken !== accessToken) {
+    previousAccessToken = cachedAccessToken;
+  }
   cachedAccessToken = accessToken;
-  cachedAccessTokenExpiresAt = expiresAt;
 }
 
 function clearCachedAccessToken(): void {
   cachedAccessToken = null;
-  cachedAccessTokenExpiresAt = null;
+  previousAccessToken = null;
 }
 
-function parseConnectionExpiresAt(expiresAt: string): Date {
+function parseConnectionExpiresAt(expiresAt: string): Date | null {
   const parsed = Date.parse(expiresAt);
-  return Number.isNaN(parsed) ? new Date(0) : new Date(parsed);
+  return Number.isNaN(parsed) ? null : new Date(parsed);
 }
 
 function toAccessTokenResult(
   accessToken: string,
-  expiresAt: string | Date,
+  expiresAt: string,
 ): GitLabOAuthAccessToken {
-  const resolvedExpiresAt =
-    expiresAt instanceof Date ? expiresAt : parseConnectionExpiresAt(expiresAt);
-  rememberAccessToken(accessToken, resolvedExpiresAt);
-  return { accessToken, expiresAt: resolvedExpiresAt };
+  rememberAccessToken(accessToken);
+  return { accessToken, expiresAt: parseConnectionExpiresAt(expiresAt) };
 }
 
 function tokenEndpoint(baseUrl: string): string {
@@ -228,10 +228,7 @@ export async function exchangeGitLabOAuthCode(input: {
     // Token exchange is still valid when the identity lookup is temporarily unavailable.
   }
   await writeConnection(connection);
-  rememberAccessToken(
-    connection.accessToken,
-    parseConnectionExpiresAt(connection.expiresAt),
-  );
+  rememberAccessToken(connection.accessToken);
   return connection;
 }
 
@@ -279,12 +276,17 @@ export async function resolveGitLabOAuthAccessTokenWithMetadata(options?: {
     );
     if (!response.ok) {
       if (generation !== connectionGeneration) return null;
-      // Another replica may have already rotated the tokens. Prefer a still
-      // valid access token over marking reauthorization_required.
+      // Another replica may have already rotated the tokens. Only a connection
+      // that actually changed proves that; re-reading our own unchanged
+      // connection would mask a real invalid_grant and re-enter this refresh on
+      // every later call. Require the same headroom as a normal resolve so we
+      // never hand back a token that dies before the next refresh tick.
       const latest = await readConnection();
       if (
         latest?.status === 'active' &&
-        Date.parse(latest.expiresAt) > Date.now()
+        latest.accessToken !== connection.accessToken &&
+        Date.parse(latest.expiresAt) >
+          Date.now() + OAUTH_ACCESS_TOKEN_REFRESH_SKEW_MS
       ) {
         return toAccessTokenResult(latest.accessToken, latest.expiresAt);
       }
@@ -326,22 +328,16 @@ export async function resolveGitLabOAuthAccessToken(options?: {
   return result?.accessToken ?? null;
 }
 
-/** Bearer (OAuth) vs PRIVATE-TOKEN (static gl* tokens). */
+/**
+ * Bearer (OAuth) vs PRIVATE-TOKEN. Only tokens this process actually minted
+ * qualify: guessing from prefixes misclassifies deploy tokens, CI job tokens,
+ * and self-managed instances with a customised PAT prefix.
+ */
 export function isGitLabOAuthAccessToken(token: string): boolean {
   if (!token) {
     return false;
   }
-  if (token === cachedAccessToken) {
-    return true;
-  }
-  if (GITLAB_STATIC_TOKEN_PREFIX.test(token)) {
-    return false;
-  }
-  return cachedAccessToken !== null;
-}
-
-export function getCachedGitLabOAuthAccessTokenExpiresAt(): Date | null {
-  return cachedAccessTokenExpiresAt;
+  return token === cachedAccessToken || token === previousAccessToken;
 }
 
 export async function markGitLabOAuthReauthorizationRequired(): Promise<void> {

--- a/packages/sdk/src/server/lib/task-runs/__tests__/dequeue-helpers.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/dequeue-helpers.test.ts
@@ -159,6 +159,7 @@ describe('createSourceControlTokenForTaskRun', () => {
           },
         ],
       },
+      expiresAt: null,
     });
     mockCreateTaskRunGiteaCredentials.mockResolvedValue({
       credentials: [
@@ -269,6 +270,7 @@ describe('createSourceControlTokenForTaskRun', () => {
       artifactsPatch: {
         gitlabScopedProjectTokens: [],
       },
+      expiresAt: null,
     });
 
     const result = await createSourceControlTokenForTaskRun(
@@ -292,6 +294,48 @@ describe('createSourceControlTokenForTaskRun', () => {
           repositoryFullName: 'group/project',
           username: 'oauth2',
           token: 'glpat_deployment_token',
+        },
+      ],
+    });
+  });
+
+  it('threads GitLab OAuth access-token expiry into runtime token metadata', async () => {
+    const expiresAt = new Date(Date.now() + 90 * 60 * 1000);
+    mockCreateTaskRunScopedGitLabTokens.mockResolvedValue({
+      credentials: [],
+      proxyCredentials: [
+        {
+          host: 'gitlab.com',
+          repositoryFullName: 'group/project',
+          username: 'oauth2',
+          token: 'oauth_access_token',
+          originBaseUrl: 'https://gitlab.com',
+        },
+      ],
+      artifactsPatch: {
+        gitlabScopedProjectTokens: [],
+      },
+      expiresAt,
+    });
+
+    const result = await createSourceControlTokenForTaskRun(
+      makeTaskRun({
+        repo: 'group/project',
+        description: 'Work on GitLab',
+        sourceControlProvider: 'gitlab',
+      }),
+      '[test]',
+      { maxRetries: 1 },
+    );
+
+    expect(result).toMatchObject({
+      provider: 'gitlab',
+      source: 'app',
+      expiresAt,
+      gitProxyCredentials: [
+        {
+          provider: 'gitlab',
+          token: 'oauth_access_token',
         },
       ],
     });

--- a/packages/sdk/src/server/lib/task-runs/__tests__/dequeue-helpers.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/dequeue-helpers.test.ts
@@ -447,6 +447,29 @@ describe('createSourceControlTokenForTaskRun', () => {
   });
 
   it('mints the stamped primary provider first and merges aggregate metadata', async () => {
+    const gitlabExpiresAt = new Date(Date.now() + 90 * 60 * 1000);
+    mockCreateTaskRunScopedGitLabTokens.mockResolvedValue({
+      credentials: [
+        {
+          host: 'gitlab.com',
+          repositoryFullName: 'group/project',
+          username: 'oauth2',
+          token: 'glptt_scoped_token',
+        },
+      ],
+      proxyCredentials: [],
+      artifactsPatch: {
+        gitlabScopedProjectTokens: [
+          {
+            repositoryFullName: 'group/project',
+            projectId: '101',
+            tokenId: 202,
+          },
+        ],
+      },
+      expiresAt: gitlabExpiresAt,
+    });
+
     const taskRun = makeTaskRun({
       repo: 'group/project',
       selectedRepositories: ['owner/repo', 'group/project'],
@@ -477,7 +500,8 @@ describe('createSourceControlTokenForTaskRun', () => {
       ],
       gitProxyCredentials: [],
       source: 'app',
-      expiresAt: null,
+      // GitHub has null expiry; keep GitLab OAuth expiry for the refresh loop.
+      expiresAt: gitlabExpiresAt,
       artifactsPatch: {
         gitlabScopedProjectTokens: [
           {

--- a/packages/sdk/src/server/lib/task-runs/__tests__/refresh-github-token.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/refresh-github-token.test.ts
@@ -77,6 +77,30 @@ describe('refreshGitHubTokenWithMetadata', () => {
     expect(result.expiresAt).toBe(expiresAt.toISOString());
   });
 
+  it('never schedules past the default cadence for a long-lived expiry', async () => {
+    // Multi-provider runs merge to the soonest *known* expiry, but a GitHub
+    // installation token reports no expiry and still dies after ~1h. Expiry
+    // may only pull the refresh earlier, never push it out.
+    const before = Date.now();
+    mockCreateSourceControlTokenForTaskRun.mockResolvedValue({
+      provider: 'github',
+      token: 'ghs_app_token',
+      envVar: 'GH_TOKEN',
+      envVars: { GH_TOKEN: 'ghs_app_token' },
+      source: 'app',
+      expiresAt: new Date(before + 2 * 60 * 60 * 1000),
+    });
+
+    const result = await refreshGitHubTokenWithMetadata(
+      { type: 'run', runId: 42 } as never,
+      42,
+    );
+
+    expect(Date.parse(result.nextRefreshAt)).toBeLessThanOrEqual(
+      before + 45 * 60 * 1000,
+    );
+  });
+
   it('keeps the default cadence when expiry is unknown', async () => {
     const before = Date.now();
     mockCreateSourceControlTokenForTaskRun.mockResolvedValue({

--- a/packages/sdk/src/server/lib/task-runs/__tests__/refresh-github-token.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/refresh-github-token.test.ts
@@ -69,7 +69,6 @@ describe('refreshGitHubTokenWithMetadata', () => {
     );
 
     const nextRefreshAtMs = Date.parse(result.nextRefreshAt);
-    // 5-minute buffer before expiry, not the fixed 45-minute cadence.
     expect(nextRefreshAtMs).toBeGreaterThan(Date.now());
     expect(nextRefreshAtMs).toBeLessThanOrEqual(
       expiresAt.getTime() - 4 * 60 * 1000,
@@ -98,7 +97,6 @@ describe('refreshGitHubTokenWithMetadata', () => {
     );
 
     const nextRefreshAtMs = Date.parse(result.nextRefreshAt);
-    // Default interval is 45 minutes.
     expect(nextRefreshAtMs).toBeGreaterThanOrEqual(before + 44 * 60 * 1000);
     expect(nextRefreshAtMs).toBeLessThanOrEqual(before + 46 * 60 * 1000);
   });

--- a/packages/sdk/src/server/lib/task-runs/__tests__/refresh-github-token.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/refresh-github-token.test.ts
@@ -1,18 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const {
-  mockFindFirst,
-  mockUpdate,
-  mockCreateSourceControlTokenForTaskRun,
-} = vi.hoisted(() => ({
-  mockFindFirst: vi.fn() as ReturnType<typeof vi.fn>,
-  mockUpdate: vi.fn(() => ({
-    set: vi.fn(() => ({
-      where: vi.fn(async () => undefined),
-    })),
-  })) as ReturnType<typeof vi.fn>,
-  mockCreateSourceControlTokenForTaskRun: vi.fn() as ReturnType<typeof vi.fn>,
-}));
+const { mockFindFirst, mockUpdate, mockCreateSourceControlTokenForTaskRun } =
+  vi.hoisted(() => ({
+    mockFindFirst: vi.fn() as ReturnType<typeof vi.fn>,
+    mockUpdate: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(async () => undefined),
+      })),
+    })) as ReturnType<typeof vi.fn>,
+    mockCreateSourceControlTokenForTaskRun: vi.fn() as ReturnType<typeof vi.fn>,
+  }));
 
 vi.mock('@roomote/db/server', () => ({
   db: {

--- a/packages/sdk/src/server/lib/task-runs/__tests__/refresh-github-token.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/refresh-github-token.test.ts
@@ -101,6 +101,35 @@ describe('refreshGitHubTokenWithMetadata', () => {
     );
   });
 
+  it('scales the refresh buffer to a token that lives less than the buffer', async () => {
+    // A 5-minute token minus the fixed 5-minute buffer lands on the 1-minute
+    // floor, re-minting for most of its life. Cap the buffer at a quarter of
+    // the remaining life so the schedule stays proportionate.
+    const before = Date.now();
+    mockCreateSourceControlTokenForTaskRun.mockResolvedValue({
+      provider: 'gitlab',
+      token: 'oauth_access_token',
+      envVar: 'GITLAB_TOKEN',
+      envVars: {},
+      source: 'app',
+      expiresAt: new Date(before + 5 * 60 * 1000),
+    });
+
+    const result = await refreshGitHubTokenWithMetadata(
+      { type: 'run', runId: 42 } as never,
+      42,
+    );
+
+    // Quarter-life of 5m is 75s, so the refresh lands ~3m45s out, not at the
+    // 60-second floor.
+    expect(Date.parse(result.nextRefreshAt)).toBeGreaterThan(
+      before + 3 * 60 * 1000,
+    );
+    expect(Date.parse(result.nextRefreshAt)).toBeLessThan(
+      before + 4 * 60 * 1000,
+    );
+  });
+
   it('keeps the default cadence when expiry is unknown', async () => {
     const before = Date.now();
     mockCreateSourceControlTokenForTaskRun.mockResolvedValue({

--- a/packages/sdk/src/server/lib/task-runs/__tests__/refresh-github-token.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/refresh-github-token.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockFindFirst,
+  mockUpdate,
+  mockCreateSourceControlTokenForTaskRun,
+} = vi.hoisted(() => ({
+  mockFindFirst: vi.fn() as ReturnType<typeof vi.fn>,
+  mockUpdate: vi.fn(() => ({
+    set: vi.fn(() => ({
+      where: vi.fn(async () => undefined),
+    })),
+  })) as ReturnType<typeof vi.fn>,
+  mockCreateSourceControlTokenForTaskRun: vi.fn() as ReturnType<typeof vi.fn>,
+}));
+
+vi.mock('@roomote/db/server', () => ({
+  db: {
+    query: {
+      taskRuns: {
+        findFirst: mockFindFirst,
+      },
+    },
+    update: mockUpdate,
+  },
+  taskRuns: { id: 'task_runs.id' },
+  eq: (left: unknown, right: unknown) => ({ left, right }),
+}));
+
+vi.mock('../dequeue-helpers', () => ({
+  createSourceControlTokenForTaskRun: mockCreateSourceControlTokenForTaskRun,
+}));
+
+import { refreshGitHubTokenWithMetadata } from '../refresh-github-token';
+
+describe('refreshGitHubTokenWithMetadata', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindFirst.mockResolvedValue({
+      id: 42,
+      artifacts: {},
+    });
+  });
+
+  it('schedules the next refresh from token expiry for app-sourced OAuth tokens', async () => {
+    const expiresAt = new Date(Date.now() + 30 * 60 * 1000);
+    mockCreateSourceControlTokenForTaskRun.mockResolvedValue({
+      provider: 'gitlab',
+      token: 'oauth_access_token',
+      envVar: 'GITLAB_TOKEN',
+      envVars: {},
+      gitProxyCredentials: [
+        {
+          provider: 'gitlab',
+          host: 'gitlab.com',
+          repositoryFullName: 'group/project',
+          username: 'oauth2',
+          token: 'oauth_access_token',
+        },
+      ],
+      source: 'app',
+      expiresAt,
+      artifactsPatch: { gitlabScopedProjectTokens: [] },
+    });
+
+    const result = await refreshGitHubTokenWithMetadata(
+      { type: 'run', runId: 42 } as never,
+      42,
+    );
+
+    const nextRefreshAtMs = Date.parse(result.nextRefreshAt);
+    // 5-minute buffer before expiry, not the fixed 45-minute cadence.
+    expect(nextRefreshAtMs).toBeGreaterThan(Date.now());
+    expect(nextRefreshAtMs).toBeLessThanOrEqual(
+      expiresAt.getTime() - 4 * 60 * 1000,
+    );
+    expect(nextRefreshAtMs).toBeGreaterThanOrEqual(
+      expiresAt.getTime() - 6 * 60 * 1000,
+    );
+    expect(result.provider).toBe('gitlab');
+    expect(result.expiresAt).toBe(expiresAt.toISOString());
+  });
+
+  it('keeps the default cadence when expiry is unknown', async () => {
+    const before = Date.now();
+    mockCreateSourceControlTokenForTaskRun.mockResolvedValue({
+      provider: 'github',
+      token: 'ghs_app_token',
+      envVar: 'GH_TOKEN',
+      envVars: { GH_TOKEN: 'ghs_app_token' },
+      source: 'app',
+      expiresAt: null,
+    });
+
+    const result = await refreshGitHubTokenWithMetadata(
+      { type: 'run', runId: 42 } as never,
+      42,
+    );
+
+    const nextRefreshAtMs = Date.parse(result.nextRefreshAt);
+    // Default interval is 45 minutes.
+    expect(nextRefreshAtMs).toBeGreaterThanOrEqual(before + 44 * 60 * 1000);
+    expect(nextRefreshAtMs).toBeLessThanOrEqual(before + 46 * 60 * 1000);
+  });
+});

--- a/packages/sdk/src/server/lib/task-runs/dequeue-helpers.ts
+++ b/packages/sdk/src/server/lib/task-runs/dequeue-helpers.ts
@@ -519,8 +519,6 @@ async function createProviderToken(
           }),
         ),
         source: 'app',
-        // OAuth access tokens expire (~2h). Surface expiry so the worker
-        // refresh loop rotates them before git/proxy auth starts failing.
         expiresAt: scopedTokens.expiresAt,
         artifactsPatch: scopedTokens.artifactsPatch,
       };

--- a/packages/sdk/src/server/lib/task-runs/dequeue-helpers.ts
+++ b/packages/sdk/src/server/lib/task-runs/dequeue-helpers.ts
@@ -519,7 +519,9 @@ async function createProviderToken(
           }),
         ),
         source: 'app',
-        expiresAt: null,
+        // OAuth access tokens expire (~2h). Surface expiry so the worker
+        // refresh loop rotates them before git/proxy auth starts failing.
+        expiresAt: scopedTokens.expiresAt,
         artifactsPatch: scopedTokens.artifactsPatch,
       };
     }

--- a/packages/sdk/src/server/lib/task-runs/dequeue-helpers.ts
+++ b/packages/sdk/src/server/lib/task-runs/dequeue-helpers.ts
@@ -574,6 +574,16 @@ async function createProviderToken(
   }
 }
 
+function earliestExpiry(left: Date | null, right: Date | null): Date | null {
+  if (!left) {
+    return right;
+  }
+  if (!right) {
+    return left;
+  }
+  return left.getTime() <= right.getTime() ? left : right;
+}
+
 function mergeProviderTokens(
   tokens: SourceControlRuntimeToken[],
 ): SourceControlRuntimeToken {
@@ -599,6 +609,9 @@ function mergeProviderTokens(
         ...(merged.artifactsPatch ?? {}),
         ...(token.artifactsPatch ?? {}),
       },
+      // Keep the soonest known expiry so multi-provider runs still refresh
+      // short-lived credentials (e.g. GitLab OAuth) on time.
+      expiresAt: earliestExpiry(merged.expiresAt, token.expiresAt),
     }),
     primaryToken,
   );

--- a/packages/sdk/src/server/lib/task-runs/refresh-github-token.ts
+++ b/packages/sdk/src/server/lib/task-runs/refresh-github-token.ts
@@ -74,7 +74,8 @@ export async function refreshGitHubTokenWithMetadata(
   const nextRefreshAtMs = tokenResult.expiresAt
     ? Math.max(
         now + MIN_SOURCE_CONTROL_TOKEN_REFRESH_DELAY_MS,
-        tokenResult.expiresAt.getTime() - SOURCE_CONTROL_TOKEN_REFRESH_BUFFER_MS,
+        tokenResult.expiresAt.getTime() -
+          SOURCE_CONTROL_TOKEN_REFRESH_BUFFER_MS,
       )
     : now + DEFAULT_SOURCE_CONTROL_TOKEN_REFRESH_INTERVAL_MS;
 

--- a/packages/sdk/src/server/lib/task-runs/refresh-github-token.ts
+++ b/packages/sdk/src/server/lib/task-runs/refresh-github-token.ts
@@ -71,11 +71,6 @@ export async function refreshGitHubTokenWithMetadata(
 
   const now = Date.now();
 
-  // Prefer token expiry whenever we know it. GitLab OAuth access tokens are
-  // "app" source but only live ~2 hours; the old user-only branch left them on
-  // the fixed 45m cadence and could keep a dead token in the sandbox for a
-  // stretch after expiry. Fall back to the default interval when expiry is
-  // unknown (GitHub app installation tokens, day-long scoped PATs, etc.).
   const nextRefreshAtMs = tokenResult.expiresAt
     ? Math.max(
         now + MIN_GITHUB_TOKEN_REFRESH_DELAY_MS,

--- a/packages/sdk/src/server/lib/task-runs/refresh-github-token.ts
+++ b/packages/sdk/src/server/lib/task-runs/refresh-github-token.ts
@@ -71,13 +71,17 @@ export async function refreshGitHubTokenWithMetadata(
 
   const now = Date.now();
 
-  const nextRefreshAtMs =
-    tokenResult.source === 'user' && tokenResult.expiresAt
-      ? Math.max(
-          now + MIN_GITHUB_TOKEN_REFRESH_DELAY_MS,
-          tokenResult.expiresAt.getTime() - USER_GITHUB_TOKEN_REFRESH_BUFFER_MS,
-        )
-      : now + DEFAULT_GITHUB_TOKEN_REFRESH_INTERVAL_MS;
+  // Prefer token expiry whenever we know it. GitLab OAuth access tokens are
+  // "app" source but only live ~2 hours; the old user-only branch left them on
+  // the fixed 45m cadence and could keep a dead token in the sandbox for a
+  // stretch after expiry. Fall back to the default interval when expiry is
+  // unknown (GitHub app installation tokens, day-long scoped PATs, etc.).
+  const nextRefreshAtMs = tokenResult.expiresAt
+    ? Math.max(
+        now + MIN_GITHUB_TOKEN_REFRESH_DELAY_MS,
+        tokenResult.expiresAt.getTime() - USER_GITHUB_TOKEN_REFRESH_BUFFER_MS,
+      )
+    : now + DEFAULT_GITHUB_TOKEN_REFRESH_INTERVAL_MS;
 
   return {
     token: tokenResult.token,

--- a/packages/sdk/src/server/lib/task-runs/refresh-github-token.ts
+++ b/packages/sdk/src/server/lib/task-runs/refresh-github-token.ts
@@ -9,9 +9,9 @@ import { db, taskRuns, eq } from '@roomote/db/server';
 
 import { createSourceControlTokenForTaskRun } from './dequeue-helpers';
 
-const DEFAULT_GITHUB_TOKEN_REFRESH_INTERVAL_MS = 45 * 60 * 1000;
-const USER_GITHUB_TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
-const MIN_GITHUB_TOKEN_REFRESH_DELAY_MS = 60 * 1000;
+const DEFAULT_SOURCE_CONTROL_TOKEN_REFRESH_INTERVAL_MS = 45 * 60 * 1000;
+const SOURCE_CONTROL_TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+const MIN_SOURCE_CONTROL_TOKEN_REFRESH_DELAY_MS = 60 * 1000;
 
 /**
  * Generate a fresh source-control token for a task run within the caller's
@@ -73,10 +73,10 @@ export async function refreshGitHubTokenWithMetadata(
 
   const nextRefreshAtMs = tokenResult.expiresAt
     ? Math.max(
-        now + MIN_GITHUB_TOKEN_REFRESH_DELAY_MS,
-        tokenResult.expiresAt.getTime() - USER_GITHUB_TOKEN_REFRESH_BUFFER_MS,
+        now + MIN_SOURCE_CONTROL_TOKEN_REFRESH_DELAY_MS,
+        tokenResult.expiresAt.getTime() - SOURCE_CONTROL_TOKEN_REFRESH_BUFFER_MS,
       )
-    : now + DEFAULT_GITHUB_TOKEN_REFRESH_INTERVAL_MS;
+    : now + DEFAULT_SOURCE_CONTROL_TOKEN_REFRESH_INTERVAL_MS;
 
   return {
     token: tokenResult.token,

--- a/packages/sdk/src/server/lib/task-runs/refresh-github-token.ts
+++ b/packages/sdk/src/server/lib/task-runs/refresh-github-token.ts
@@ -14,6 +14,19 @@ const SOURCE_CONTROL_TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 const MIN_SOURCE_CONTROL_TOKEN_REFRESH_DELAY_MS = 60 * 1000;
 
 /**
+ * Reserve time to re-mint before expiry. A self-managed provider can issue
+ * tokens that live for less than the fixed buffer, so cap it at a quarter of
+ * the token's remaining life rather than scheduling straight into the floor.
+ */
+function refreshBufferMs(expiresAt: Date, now: number): number {
+  const remainingMs = expiresAt.getTime() - now;
+
+  return remainingMs > 0
+    ? Math.min(SOURCE_CONTROL_TOKEN_REFRESH_BUFFER_MS, remainingMs / 4)
+    : SOURCE_CONTROL_TOKEN_REFRESH_BUFFER_MS;
+}
+
+/**
  * Generate a fresh source-control token for a task run within the caller's
  * scope. The exported name stays GitHub-specific for existing SDK callers.
  */
@@ -79,7 +92,7 @@ export async function refreshGitHubTokenWithMetadata(
     ? Math.max(
         now + MIN_SOURCE_CONTROL_TOKEN_REFRESH_DELAY_MS,
         tokenResult.expiresAt.getTime() -
-          SOURCE_CONTROL_TOKEN_REFRESH_BUFFER_MS,
+          refreshBufferMs(tokenResult.expiresAt, now),
       )
     : Number.POSITIVE_INFINITY;
   const nextRefreshAtMs = Math.min(

--- a/packages/sdk/src/server/lib/task-runs/refresh-github-token.ts
+++ b/packages/sdk/src/server/lib/task-runs/refresh-github-token.ts
@@ -71,13 +71,21 @@ export async function refreshGitHubTokenWithMetadata(
 
   const now = Date.now();
 
-  const nextRefreshAtMs = tokenResult.expiresAt
+  // A known expiry may only pull the refresh earlier, never push it out. Not
+  // every short-lived credential reports one: GitHub installation tokens die
+  // after ~1h with `expiresAt: null`, and a multi-provider run merges to the
+  // soonest *known* expiry, so the default cadence stays the upper bound.
+  const expiryDrivenRefreshAtMs = tokenResult.expiresAt
     ? Math.max(
         now + MIN_SOURCE_CONTROL_TOKEN_REFRESH_DELAY_MS,
         tokenResult.expiresAt.getTime() -
           SOURCE_CONTROL_TOKEN_REFRESH_BUFFER_MS,
       )
-    : now + DEFAULT_SOURCE_CONTROL_TOKEN_REFRESH_INTERVAL_MS;
+    : Number.POSITIVE_INFINITY;
+  const nextRefreshAtMs = Math.min(
+    now + DEFAULT_SOURCE_CONTROL_TOKEN_REFRESH_INTERVAL_MS,
+    expiryDrivenRefreshAtMs,
+  );
 
   return {
     token: tokenResult.token,


### PR DESCRIPTION
## Summary
- GitLab OAuth access tokens (~2h) were re-minted on a fixed 45m worker cadence with no expiry, so the last refresh could leave a dead token in the sandbox for a stretch after expiry.
- Surface OAuth `expiresAt` through token minting and schedule the next worker refresh from it (5m buffer), plus proactively rotate OAuth tokens 10m before expiry.
- Expiry may only ever *shorten* the refresh interval. Not every short-lived credential reports one: GitHub installation tokens die after ~1h with `expiresAt: null`, so a run spanning GitHub and GitLab must not inherit GitLab's later expiry as its schedule.
- Treat a failed refresh as terminal unless the connection was demonstrably rotated by another replica, so a genuine `invalid_grant` is not masked into a retry loop against the token endpoint.
- Classify OAuth vs `PRIVATE-TOKEN` from the tokens this process actually minted (current + just-rotated) rather than guessing from `gl*` prefixes.

## Notes for reviewers

The refresh-scheduling change deserves the closest look. `mergeProviderTokens` reduces to the soonest *known* expiry, and `null` there means "unknown", not "never expires" — GitHub app tokens report `null` but only live ~1h. Capping at the default 45m cadence keeps that case correct without special-casing providers.

Self-managed instances with a short OAuth TTL are supported: both the proactive skew and the worker refresh buffer cap at a quarter of the token's life rather than assuming the ~2h default. The instance-reported lifetime rides on the encrypted connection blob as an optional field, so an older release ignores it and pre-existing connections keep the default windows.

## Test plan
- [x] `@roomote/gitlab` vitest: oauth + api (54 tests)
- [x] `@roomote/sdk` vitest: full package suite (869 tests)
- [x] `@roomote/web` vitest: source-control trpc commands (36 tests)
- [x] `pnpm lint`, `pnpm check-types:fast`, `pnpm knip`
- [ ] Manual: long-running GitLab task past OAuth token lifetime still clones/pushes after refresh tick
- [ ] Manual: multi-provider (GitHub + GitLab) run still pushes to GitHub past the 1h installation-token lifetime
- [ ] Manual: self-managed instance with a short OAuth TTL rotates without refreshing on every resolve
