### PR TITLE
Restore agent access to authenticated previews

### DIFF
--- a/.docker/sandbox/install-browser-agent.sh
+++ b/.docker/sandbox/install-browser-agent.sh
@@ -475,6 +475,7 @@ seed_preview_cookies() {
   local session_hash
   local cache_file
   local url
+  local -a cookie_security_args
 
   cache_key="$(printf '%s\0' "$AGENT_BROWSER_SESSION_VALUE" "$header_name" "$bypass_value" "${AGENT_BROWSER_PREFIX_ARGS[*]}" "${preview_urls[@]}" | sha256sum | awk '{print $1}')"
   session_hash="$(hash_value "$AGENT_BROWSER_SESSION_VALUE")"
@@ -488,11 +489,16 @@ seed_preview_cookies() {
   resolve_cli_paths
 
   for url in "${preview_urls[@]}"; do
+    cookie_security_args=()
+    case "$url" in
+      https://*) cookie_security_args+=(--secure) ;;
+    esac
+
     if [ -n "$bypass_value" ]; then
-      AGENT_BROWSER_HEADED=false "$AGENT_BROWSER_BIN" "${AGENT_BROWSER_PREFIX_ARGS[@]}" cookies set "$header_name" "$bypass_value" --url "$url" --secure --sameSite Lax >/dev/null
+      AGENT_BROWSER_HEADED=false "$AGENT_BROWSER_BIN" "${AGENT_BROWSER_PREFIX_ARGS[@]}" cookies set "$header_name" "$bypass_value" --url "$url" "${cookie_security_args[@]}" --sameSite Lax >/dev/null
     fi
 
-    AGENT_BROWSER_HEADED=false "$AGENT_BROWSER_BIN" "${AGENT_BROWSER_PREFIX_ARGS[@]}" cookies set "$HIDE_PREVIEW_WIDGET_COOKIE" "1" --url "$url" --secure --sameSite Lax >/dev/null
+    AGENT_BROWSER_HEADED=false "$AGENT_BROWSER_BIN" "${AGENT_BROWSER_PREFIX_ARGS[@]}" cookies set "$HIDE_PREVIEW_WIDGET_COOKIE" "1" --url "$url" "${cookie_security_args[@]}" --sameSite Lax >/dev/null
   done
 
   : > "$cache_file"

--- a/.docker/sandbox/install-browser-agent.sh
+++ b/.docker/sandbox/install-browser-agent.sh
@@ -441,10 +441,10 @@ collect_preview_urls() {
   local name value
   while IFS='=' read -r name value; do
     case "$name" in
-      ROOMOTE_EDITOR_HOST|ROOMOTE_SANDBOX_SERVER_HOST)
+      ROOMOTE_EDITOR_HOST|ROOMOTE_SANDBOX_SERVER_HOST|ROOMOTE_EDITOR_PREVIEW_URL|ROOMOTE_SANDBOX_SERVER_PREVIEW_URL)
         continue
         ;;
-      ROOMOTE_*_HOST)
+      ROOMOTE_*_HOST|ROOMOTE_*_PREVIEW_URL)
         case "$value" in
           http://*|https://*)
             printf '%s\n' "$value"

--- a/.docker/sandbox/install-browser-agent.sh
+++ b/.docker/sandbox/install-browser-agent.sh
@@ -441,7 +441,7 @@ collect_preview_urls() {
   local name value
   while IFS='=' read -r name value; do
     case "$name" in
-      ROOMOTE_EDITOR_HOST|ROOMOTE_SANDBOX_SERVER_HOST|ROOMOTE_EDITOR_PREVIEW_URL|ROOMOTE_SANDBOX_SERVER_PREVIEW_URL)
+      ROOMOTE_EDITOR_HOST|ROOMOTE_SANDBOX_SERVER_HOST|ROOMOTE_SANDBOX_SERVER_PREVIEW_URL)
         continue
         ;;
       ROOMOTE_*_HOST|ROOMOTE_*_PREVIEW_URL)

--- a/apps/controller/src/__tests__/utils.test.ts
+++ b/apps/controller/src/__tests__/utils.test.ts
@@ -465,7 +465,7 @@ describe('shouldEnableAuthBypassForTaskRun', () => {
     ).toBe(false);
   });
 
-  it('does not generate a bypass for ordinary unproxied preview ports', () => {
+  it('generates a bypass for authenticated unproxied preview entrypoints', () => {
     expect(
       shouldEnableAuthBypassForTaskRun({
         environmentConfig: mockEnvironmentConfig({
@@ -476,7 +476,7 @@ describe('shouldEnableAuthBypassForTaskRun', () => {
           { name: 'WEB', port: 3000, proxied: false },
         ],
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 });
 

--- a/apps/controller/src/utils.ts
+++ b/apps/controller/src/utils.ts
@@ -44,10 +44,6 @@ function requiresPreviewAuth(
   return port.unauthenticated !== true;
 }
 
-function configuredPreviewPortNeedsAuthBypass(port: NamedPort): boolean {
-  return requiresPreviewAuth(port) && port.proxied !== false;
-}
-
 async function isPreviewRuntimeReady(): Promise<boolean> {
   const previewRuntimeConfig = await resolveEffectivePreviewRuntimeConfig({
     runtimeEnv: process.env,
@@ -75,7 +71,10 @@ export function shouldEnableAuthBypassForTaskRun({
       continue;
     }
 
-    if (configuredPreviewPortNeedsAuthBypass(configuredPort)) {
+    // Unproxied ports still enter through the authenticated preview URL before
+    // the preview proxy redirects to the direct machine domain. Agents need a
+    // task-scoped bypass credential for that entrypoint too.
+    if (requiresPreviewAuth(configuredPort)) {
       return true;
     }
   }

--- a/apps/web/src/lib/environment-definition.test.ts
+++ b/apps/web/src/lib/environment-definition.test.ts
@@ -10,6 +10,7 @@ import {
 
 import {
   buildEnvironmentDefinitionFingerprint,
+  buildEnvironmentPreviewRepairPrompt,
   buildSetupEnvironmentTaskTitle,
   buildUpdateEnvironmentDefinitionPrompt,
   findMatchingDefinedEnvironment,
@@ -156,6 +157,19 @@ describe('environment definition helpers', () => {
     );
     expect(prompt).toContain('action "update" and environmentId "env-123"');
     expect(prompt).toContain('name: Roomote App');
+  });
+
+  it('directs preview repair tasks through the public preview URL', () => {
+    const prompt = buildEnvironmentPreviewRepairPrompt({
+      environmentId: 'env-123',
+      environmentName: 'Roomote App',
+      config,
+    });
+
+    expect(prompt).toContain('ROOMOTE_<PORT_NAME>_PREVIEW_URL');
+    expect(prompt).toContain(
+      'falling back to `ROOMOTE_<PORT_NAME>_HOST` only when the preview URL variable is unavailable',
+    );
   });
 
   it('finds a created environment that matches the repository set after the task started', () => {

--- a/apps/web/src/lib/environment-definition.test.ts
+++ b/apps/web/src/lib/environment-definition.test.ts
@@ -167,9 +167,7 @@ describe('environment definition helpers', () => {
     });
 
     expect(prompt).toContain('ROOMOTE_<PORT_NAME>_PREVIEW_URL');
-    expect(prompt).toContain(
-      'falling back to `ROOMOTE_<PORT_NAME>_HOST` only when the preview URL variable is unavailable',
-    );
+    expect(prompt).not.toContain('ROOMOTE_<PORT_NAME>_HOST');
   });
 
   it('finds a created environment that matches the repository set after the task started', () => {

--- a/apps/web/src/lib/environment-definition.ts
+++ b/apps/web/src/lib/environment-definition.ts
@@ -142,14 +142,14 @@ export function buildEnvironmentPreviewRepairPrompt(input: {
 }): string {
   return `Fix live previews for the ${PRODUCT_NAME} environment "${input.environmentName}" (id ${input.environmentId}).
 
-Live previews are configured for this environment, but the user reports the preview does not load or work correctly behind the preview proxy. You are running inside the environment, so its commands and services have already started, and each configured port's public preview origin is available in the sandbox as \`ROOMOTE_<PORT_NAME>_PREVIEW_URL\`. For compatibility with older runtimes where that variable is unavailable, fall back to \`ROOMOTE_<PORT_NAME>_HOST\`.
+Live previews are configured for this environment, but the user reports the preview does not load or work correctly behind the preview proxy. You are running inside the environment, so its commands and services have already started, and each configured port's public preview origin is available in the sandbox as \`ROOMOTE_<PORT_NAME>_PREVIEW_URL\`.
 
 Current environment YAML:
 \`\`\`yaml
 ${configToYaml(input.config).trim()}
 \`\`\`
 
-1. Reproduce: check each configured port's surface on localhost, then through its public preview origin from \`ROOMOTE_<PORT_NAME>_PREVIEW_URL\` (falling back to \`ROOMOTE_<PORT_NAME>_HOST\` only when the preview URL variable is unavailable). Compare the two to isolate proxy-specific failures.
+1. Reproduce: check each configured port's surface on localhost, then through its public preview origin from \`ROOMOTE_<PORT_NAME>_PREVIEW_URL\`. Compare the two to isolate proxy-specific failures.
 2. Diagnose the common causes: dev servers that reject unknown hosts (allowed-hosts or host-header checks) or listen only on a loopback interface, hardcoded localhost or 127.0.0.1 origins in client code or API calls, CORS failures on cross-origin API requests, response headers that block framing (\`X-Frame-Options\`, \`Content-Security-Policy\` \`frame-ancestors\`), and websocket or HMR endpoints that bypass the proxy.
 3. Fix the root cause:
    - For environment-definition problems (commands, env vars, port settings, services, docker projects), update the environment using the ${PRODUCT_NAME} MCP tool \`manage_environments\` with \`action: "update"\` and \`environmentId: "${input.environmentId}"\`. Keep every other environment setting unchanged.

--- a/apps/web/src/lib/environment-definition.ts
+++ b/apps/web/src/lib/environment-definition.ts
@@ -142,14 +142,14 @@ export function buildEnvironmentPreviewRepairPrompt(input: {
 }): string {
   return `Fix live previews for the ${PRODUCT_NAME} environment "${input.environmentName}" (id ${input.environmentId}).
 
-Live previews are configured for this environment, but the user reports the preview does not load or work correctly behind the preview proxy. You are running inside the environment, so its commands and services have already started, and each configured port's public preview origin is available in the sandbox as \`ROOMOTE_<PORT_NAME>_HOST\`.
+Live previews are configured for this environment, but the user reports the preview does not load or work correctly behind the preview proxy. You are running inside the environment, so its commands and services have already started, and each configured port's public preview origin is available in the sandbox as \`ROOMOTE_<PORT_NAME>_PREVIEW_URL\`. For compatibility with older runtimes where that variable is unavailable, fall back to \`ROOMOTE_<PORT_NAME>_HOST\`.
 
 Current environment YAML:
 \`\`\`yaml
 ${configToYaml(input.config).trim()}
 \`\`\`
 
-1. Reproduce: check each configured port's surface on localhost, then through its public preview origin from \`ROOMOTE_<PORT_NAME>_HOST\`. Compare the two to isolate proxy-specific failures.
+1. Reproduce: check each configured port's surface on localhost, then through its public preview origin from \`ROOMOTE_<PORT_NAME>_PREVIEW_URL\` (falling back to \`ROOMOTE_<PORT_NAME>_HOST\` only when the preview URL variable is unavailable). Compare the two to isolate proxy-specific failures.
 2. Diagnose the common causes: dev servers that reject unknown hosts (allowed-hosts or host-header checks) or listen only on a loopback interface, hardcoded localhost or 127.0.0.1 origins in client code or API calls, CORS failures on cross-origin API requests, response headers that block framing (\`X-Frame-Options\`, \`Content-Security-Policy\` \`frame-ancestors\`), and websocket or HMR endpoints that bypass the proxy.
 3. Fix the root cause:
    - For environment-definition problems (commands, env vars, port settings, services, docker projects), update the environment using the ${PRODUCT_NAME} MCP tool \`manage_environments\` with \`action: "update"\` and \`environmentId: "${input.environmentId}"\`. Keep every other environment setting unchanged.

--- a/apps/worker/src/commands/__tests__/utils.test.ts
+++ b/apps/worker/src/commands/__tests__/utils.test.ts
@@ -193,6 +193,25 @@ describe('injectEnvVars', () => {
     );
   });
 
+  it('does not expose a preview URL for the retired editor identity', async () => {
+    const envVars: Record<string, string> = {
+      ROOMOTE_EDITOR_PREVIEW_URL: 'https://stale-editor.example.com',
+    };
+    const taskRun = {
+      taskId: 'task-123',
+      machineDomains: {
+        EDITOR: 'https://sandbox-editor.modal.host',
+      },
+      proxyPorts: {},
+    } as unknown as TaskRun;
+
+    await injectEnvVars(envVars, taskRun, {
+      previewProxyBaseUrl: 'https://preview.octomote.run',
+    });
+
+    expect(envVars.ROOMOTE_EDITOR_PREVIEW_URL).toBeUndefined();
+  });
+
   describe('PREVIEW_DOMAINS derivation', () => {
     it('derives PREVIEW_DOMAINS from the preview-proxy base URL hostname', async () => {
       const envVars: Record<string, string> = {};

--- a/apps/worker/src/commands/__tests__/utils.test.ts
+++ b/apps/worker/src/commands/__tests__/utils.test.ts
@@ -168,6 +168,29 @@ describe('injectEnvVars', () => {
     expect(envVars.ROOMOTE_WEB_HOST).toBe(
       'https://task-123-web.preview.octomote.run',
     );
+    expect(envVars.ROOMOTE_WEB_PREVIEW_URL).toBe(
+      'https://task-123-web.preview.octomote.run',
+    );
+  });
+
+  it('keeps direct hosts while exposing preview-proxy URLs for unproxied ports', async () => {
+    const envVars: Record<string, string> = {};
+    const taskRun = {
+      taskId: 'task-123',
+      machineDomains: {
+        WEB: 'https://sandbox-web.modal.host',
+      },
+      proxyPorts: {},
+    } as unknown as TaskRun;
+
+    await injectEnvVars(envVars, taskRun, {
+      previewProxyBaseUrl: 'https://preview.octomote.run',
+    });
+
+    expect(envVars.ROOMOTE_WEB_HOST).toBe('https://sandbox-web.modal.host');
+    expect(envVars.ROOMOTE_WEB_PREVIEW_URL).toBe(
+      'https://task-123-web.preview.octomote.run',
+    );
   });
 
   describe('PREVIEW_DOMAINS derivation', () => {

--- a/apps/worker/src/commands/setup/__tests__/legacy-runtime-tools.test.ts
+++ b/apps/worker/src/commands/setup/__tests__/legacy-runtime-tools.test.ts
@@ -98,6 +98,7 @@ describe('install-browser-agent.sh', () => {
       'HIDE_PREVIEW_WIDGET_COOKIE="roomote_hide_preview_widget"',
     );
     expect(script).toContain('ROOMOTE_AUTH_BYPASS_VALUE');
+    expect(script).toContain('ROOMOTE_*_PREVIEW_URL');
     expect(script).toContain('open|goto|navigate');
     expect(script).toContain('cookies set "$header_name" "$bypass_value"');
     expect(script).toContain('cookies set "$HIDE_PREVIEW_WIDGET_COOKIE" "1"');

--- a/apps/worker/src/commands/setup/__tests__/legacy-runtime-tools.test.ts
+++ b/apps/worker/src/commands/setup/__tests__/legacy-runtime-tools.test.ts
@@ -102,6 +102,9 @@ describe('install-browser-agent.sh', () => {
     expect(script).toContain('open|goto|navigate');
     expect(script).toContain('cookies set "$header_name" "$bypass_value"');
     expect(script).toContain('cookies set "$HIDE_PREVIEW_WIDGET_COOKIE" "1"');
+    expect(script).toContain('https://*) cookie_security_args+=(--secure)');
+    expect(script).toContain('"${cookie_security_args[@]}" --sameSite Lax');
+    expect(script).not.toContain('--url "$url" --secure');
     expect(script).toContain(
       'export AGENT_BROWSER_EXECUTABLE_PATH="${AGENT_BROWSER_EXECUTABLE_PATH:-/opt/agent-browser/chrome}"',
     );

--- a/apps/worker/src/commands/setup/__tests__/legacy-runtime-tools.test.ts
+++ b/apps/worker/src/commands/setup/__tests__/legacy-runtime-tools.test.ts
@@ -99,6 +99,7 @@ describe('install-browser-agent.sh', () => {
     );
     expect(script).toContain('ROOMOTE_AUTH_BYPASS_VALUE');
     expect(script).toContain('ROOMOTE_*_PREVIEW_URL');
+    expect(script).not.toContain('ROOMOTE_EDITOR_PREVIEW_URL');
     expect(script).toContain('open|goto|navigate');
     expect(script).toContain('cookies set "$header_name" "$bypass_value"');
     expect(script).toContain('cookies set "$HIDE_PREVIEW_WIDGET_COOKIE" "1"');

--- a/apps/worker/src/commands/utils/env-vars.ts
+++ b/apps/worker/src/commands/utils/env-vars.ts
@@ -212,7 +212,11 @@ export async function injectEnvVars(
       // Keep *_HOST pointing at the direct machine domain for unproxied ports,
       // while also exposing the authenticated shareable URL that agents and
       // browser tooling must use to exercise the preview entrypoint itself.
-      envVars[previewUrlEnvVarName] = previewUrl;
+      if (name === CODE_SERVER_NAMED_PORT.name) {
+        delete envVars[previewUrlEnvVarName];
+      } else {
+        envVars[previewUrlEnvVarName] = previewUrl;
+      }
 
       if (isProxied) {
         envVars[envVarName] = previewUrl;

--- a/apps/worker/src/commands/utils/env-vars.ts
+++ b/apps/worker/src/commands/utils/env-vars.ts
@@ -199,16 +199,23 @@ export async function injectEnvVars(
   if (identity && identity.taskId && previewProxyBaseUrl) {
     for (const [name, domain] of Object.entries(identity.machineDomains)) {
       const envVarName = `ROOMOTE_${name}_HOST`;
+      const previewUrlEnvVarName = `ROOMOTE_${name}_PREVIEW_URL`;
       const isProxied =
         name === CODE_SERVER_NAMED_PORT.name || name in identity.proxyPorts;
+      const previewUrl = buildPreviewProxyUrl(
+        identity.taskId,
+        portNameToSlug(name),
+        previewProxyBaseUrl,
+        previewProxySubdomainSuffix,
+      );
+
+      // Keep *_HOST pointing at the direct machine domain for unproxied ports,
+      // while also exposing the authenticated shareable URL that agents and
+      // browser tooling must use to exercise the preview entrypoint itself.
+      envVars[previewUrlEnvVarName] = previewUrl;
 
       if (isProxied) {
-        envVars[envVarName] = buildPreviewProxyUrl(
-          identity.taskId,
-          portNameToSlug(name),
-          previewProxyBaseUrl,
-          previewProxySubdomainSuffix,
-        );
+        envVars[envVarName] = previewUrl;
       } else {
         envVars[envVarName] = domain;
       }

--- a/apps/worker/src/run-task/__tests__/sandbox-instruction.test.ts
+++ b/apps/worker/src/run-task/__tests__/sandbox-instruction.test.ts
@@ -210,6 +210,7 @@ describe('buildSandboxInstruction', () => {
     const instruction = buildSandboxInstruction(true, environmentConfig, {
       envVars: {
         ROOMOTE_WEB_HOST: 'https://task-123-web.preview.roomote.run',
+        ROOMOTE_AUTH_BYPASS_VALUE: 'runtime-only-bypass',
       },
     });
 
@@ -224,13 +225,14 @@ describe('buildSandboxInstruction', () => {
       'This environment exposes a sandbox-local browser surface for delegated visual proof.',
     );
     expect(instruction).toContain(
-      "Use the exact hostname and port from the environment configuration's local browser URL for proof capture. Preserve `localhost` versus `127.0.0.1` exactly as configured, and treat configured external preview URLs as shareable links only.",
+      "Use the exact hostname and port from the environment configuration's local browser URL for proof capture, preserving `localhost` versus `127.0.0.1` exactly as configured. Use configured external preview URLs only when the public proxy or hostname itself is part of what you need to validate.",
     );
     expect(instruction).not.toContain('super-secret-value');
     expect(instruction).not.toContain('API_KEY');
     expect(instruction).not.toContain('agentInstructions');
     expect(instruction).not.toContain('ROOT_SECRET');
     expect(instruction).not.toContain('top-secret-bypass');
+    expect(instruction).not.toContain('runtime-only-bypass');
     expect(instruction).toContain('http://127.0.0.1:3000/auth/dev-login');
     expect(instruction).toContain('Configured external preview URLs:');
     expect(instruction).toContain(
@@ -238,6 +240,12 @@ describe('buildSandboxInstruction', () => {
     );
     expect(instruction).toContain(
       'Use these shareable preview URLs when referring to external previews in replies or proof. Do not share raw machine hosts instead.',
+    );
+    expect(instruction).toContain(
+      'The installed `agent-browser` wrapper automatically applies the task-scoped preview authentication cookie before `open`, `goto`, or `navigate`',
+    );
+    expect(instruction).toContain(
+      'Never print, log, or share the bypass credential.',
     );
   });
 
@@ -251,7 +259,7 @@ describe('buildSandboxInstruction', () => {
     const browserSurfaceLine =
       'This environment exposes a sandbox-local browser surface for delegated visual proof.';
     const localhostProofLine =
-      "Use the exact hostname and port from the environment configuration's local browser URL for proof capture. Preserve `localhost` versus `127.0.0.1` exactly as configured, and treat configured external preview URLs as shareable links only.";
+      "Use the exact hostname and port from the environment configuration's local browser URL for proof capture, preserving `localhost` versus `127.0.0.1` exactly as configured. Use configured external preview URLs only when the public proxy or hostname itself is part of what you need to validate.";
 
     expect(renderedInstruction).toContain(browserSurfaceLine);
     expect(renderedInstruction).toContain(localhostProofLine);

--- a/apps/worker/src/run-task/__tests__/sandbox-instruction.test.ts
+++ b/apps/worker/src/run-task/__tests__/sandbox-instruction.test.ts
@@ -394,7 +394,7 @@ describe('buildSandboxInstruction', () => {
     expect(instruction).not.toContain('Configured external preview URLs:');
   });
 
-  it('omits non-proxied hosts from the configured preview URL list', () => {
+  it('uses dedicated preview URLs for non-proxied hosts', () => {
     const instruction = buildSandboxInstruction(
       false,
       {
@@ -420,6 +420,7 @@ describe('buildSandboxInstruction', () => {
       {
         envVars: {
           ROOMOTE_WEB_HOST: 'https://sandbox-raw-host.modal.host',
+          ROOMOTE_WEB_PREVIEW_URL: 'https://task-123-web.preview.roomote.run',
           ROOMOTE_API_HOST: 'https://task-123-api.preview.roomote.run',
         },
       },
@@ -429,7 +430,9 @@ describe('buildSandboxInstruction', () => {
     expect(instruction).toContain(
       '- API: https://task-123-api.preview.roomote.run/trpc',
     );
+    expect(instruction).toContain(
+      '- WEB (primary): https://task-123-web.preview.roomote.run/auth/dev-login',
+    );
     expect(instruction).not.toContain('https://sandbox-raw-host.modal.host');
-    expect(instruction).not.toContain('- WEB (primary):');
   });
 });

--- a/apps/worker/src/run-task/run-task.ts
+++ b/apps/worker/src/run-task/run-task.ts
@@ -1018,8 +1018,9 @@ export const runTask = async ({
     }
 
     // Build sandbox environment context for the agent.
-    // Reads ROOMOTE_*_HOST vars from the unsanitized env so the generated
-    // environment note always sees the injected preview URLs.
+    // Reads ROOMOTE_*_HOST and ROOMOTE_*_PREVIEW_URL vars from the unsanitized
+    // env so the generated environment note always sees the injected preview
+    // URLs.
     const sandboxInstruction = buildSandboxInstruction(
       Boolean(environmentConfig?.initialUrl),
       environmentConfig,

--- a/apps/worker/src/run-task/sandbox-instruction.ts
+++ b/apps/worker/src/run-task/sandbox-instruction.ts
@@ -236,6 +236,12 @@ export function buildSandboxInstruction(
       lines.push(
         'Use these shareable preview URLs when referring to external previews in replies or proof. Do not share raw machine hosts instead.',
       );
+
+      if (options?.envVars?.ROOMOTE_AUTH_BYPASS_VALUE) {
+        lines.push(
+          'These external preview URLs are also reachable from this sandbox. The installed `agent-browser` wrapper automatically applies the task-scoped preview authentication cookie before `open`, `goto`, or `navigate`, so use the external URL when you need to validate public-proxy, redirect, cookie, or hostname-dependent behavior. Never print, log, or share the bypass credential.',
+        );
+      }
     }
   }
 
@@ -243,7 +249,7 @@ export function buildSandboxInstruction(
     lines.push(
       '',
       'This environment exposes a sandbox-local browser surface for delegated visual proof.',
-      "Use the exact hostname and port from the environment configuration's local browser URL for proof capture. Preserve `localhost` versus `127.0.0.1` exactly as configured, and treat configured external preview URLs as shareable links only.",
+      "Use the exact hostname and port from the environment configuration's local browser URL for proof capture, preserving `localhost` versus `127.0.0.1` exactly as configured. Use configured external preview URLs only when the public proxy or hostname itself is part of what you need to validate.",
     );
   }
 

--- a/apps/worker/src/run-task/sandbox-instruction.ts
+++ b/apps/worker/src/run-task/sandbox-instruction.ts
@@ -137,18 +137,18 @@ function getConfiguredPreviewUrls(
 
   return environmentConfig.ports
     .map((port) => {
-      if (port.proxied === false) {
-        return null;
-      }
-
-      const host = envVars[`ROOMOTE_${port.name.toUpperCase()}_HOST`];
+      const name = port.name.toUpperCase();
+      const previewUrl = envVars[`ROOMOTE_${name}_PREVIEW_URL`];
+      const host =
+        previewUrl ??
+        (port.proxied === false ? undefined : envVars[`ROOMOTE_${name}_HOST`]);
 
       if (!host) {
         return null;
       }
 
       return {
-        name: port.name.toUpperCase(),
+        name,
         url: appendInitialPath(host, port.initial_path),
         primary: Boolean(port.primary),
       };
@@ -239,7 +239,7 @@ export function buildSandboxInstruction(
 
       if (options?.envVars?.ROOMOTE_AUTH_BYPASS_VALUE) {
         lines.push(
-          'These external preview URLs are also reachable from this sandbox. The installed `agent-browser` wrapper automatically applies the task-scoped preview authentication cookie before `open`, `goto`, or `navigate`, so use the external URL when you need to validate public-proxy, redirect, cookie, or hostname-dependent behavior. Never print, log, or share the bypass credential.',
+          'These external preview URLs are also reachable from this sandbox. The installed `agent-browser` wrapper automatically applies the task-scoped preview authentication cookie before `open`, `goto`, or `navigate`. Use the corresponding `ROOMOTE_<NAME>_PREVIEW_URL` when available and append the route you need to test; use the listed external URL otherwise. Use an external URL when you need to validate public-proxy, redirect, cookie, or hostname-dependent behavior. Never print, log, or share the bypass credential.',
         );
       }
     }

--- a/packages/types/src/environment-config.ts
+++ b/packages/types/src/environment-config.ts
@@ -727,8 +727,9 @@ export const environmentConfigSchema = z
     oidc: environmentOidcSchema.optional(),
     /**
      * Named preview ports for human-facing application URLs.
-     * Each port gets a preview-proxy URL and a corresponding `ROOMOTE_<NAME>_HOST`
-     * environment variable inside the sandbox.
+     * Each port gets an authenticated shareable URL in
+     * `ROOMOTE_<NAME>_PREVIEW_URL`. `ROOMOTE_<NAME>_HOST` points to that same
+     * URL for proxied ports and to the direct machine URL for unproxied ports.
      */
     ports: z
       .array(namedPortSchema)


### PR DESCRIPTION
## Summary

- expose each authenticated shareable preview as `ROOMOTE_<NAME>_PREVIEW_URL`, including ports that ultimately redirect to a direct machine URL
- seed the task-scoped bypass cookie for both `ROOMOTE_*_HOST` and `ROOMOTE_*_PREVIEW_URL` domains before `agent-browser` navigation
- mint bypass credentials for authenticated unproxied preview entrypoints as well as proxied ports
- tell agents to use the dedicated preview URL when validating proxy, redirect, cookie, or hostname behavior
- keep bypass values out of generated instructions

## Why

For an unproxied port, `ROOMOTE_<NAME>_HOST` intentionally points at the direct machine domain, while the human-facing Live Preview first enters through an authenticated preview-proxy domain. The browser wrapper previously seeded only the direct host. The credential was present, but its cookie was scoped to the wrong domain, so opening the shareable URL redirected the agent to Roomote sign-in.

This preserves the existing direct-host contract while separately exposing and authenticating the shareable preview entrypoint.

## Validation

- `pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/worker exec vitest run src/commands/__tests__/utils.test.ts src/run-task/__tests__/sandbox-instruction.test.ts src/commands/setup/__tests__/legacy-runtime-tools.test.ts`
- `pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/controller exec vitest run src/__tests__/utils.test.ts`
- `pnpm --filter @roomote/worker check-types`
- `pnpm --filter @roomote/controller check-types`
- worker and controller package lint
- `bash -n .docker/sandbox/install-browser-agent.sh`
- pre-push checks: oxlint, residual lint, fast typecheck, and knip
