### PR TITLE
[Fix] HMR WebSockets rejected in sandbox previews

### DIFF
--- a/apps/worker/src/commands/__tests__/utils.test.ts
+++ b/apps/worker/src/commands/__tests__/utils.test.ts
@@ -1,5 +1,7 @@
 import * as fs from 'fs';
 
+import { CODE_SERVER_NAMED_PORT } from '@roomote/types';
+
 import {
   injectEnvVars,
   writeBashrc,
@@ -210,6 +212,138 @@ describe('injectEnvVars', () => {
     });
 
     expect(envVars.ROOMOTE_EDITOR_PREVIEW_URL).toBeUndefined();
+  });
+
+  describe('Vite allowed-hosts derivation', () => {
+    it('pins the additional allowed hosts to the exact preview hostnames', async () => {
+      const envVars: Record<string, string> = {};
+      const taskRun = {
+        taskId: 'task-123',
+        machineDomains: {
+          WEB: 'https://sandbox-web.modal.host',
+          MY_APP: 'https://sandbox-my-app.modal.host',
+        },
+        proxyPorts: { WEB: 4321, MY_APP: 3000 },
+      } as unknown as TaskRun;
+
+      await injectEnvVars(envVars, taskRun, {
+        previewProxyBaseUrl: 'https://preview.octomote.run',
+      });
+
+      expect(
+        envVars.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS?.split(','),
+      ).toEqual([
+        'task-123-web.preview.octomote.run',
+        'task-123-my-app.preview.octomote.run',
+        'sandbox-web.modal.host',
+        'sandbox-my-app.modal.host',
+      ]);
+    });
+
+    it('includes the subdomain suffix used by nested previews', async () => {
+      const envVars: Record<string, string> = {};
+      const taskRun = {
+        taskId: 'task-123',
+        machineDomains: { WEB: 'https://sandbox-web.modal.host' },
+        proxyPorts: { WEB: 4321 },
+      } as unknown as TaskRun;
+
+      await injectEnvVars(envVars, taskRun, {
+        previewProxyBaseUrl: 'https://preview.octomote.run',
+        previewProxySubdomainSuffix: 'outer-task',
+      });
+
+      expect(
+        envVars.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS?.split(','),
+      ).toContain('task-123-web-outer-task.preview.octomote.run');
+    });
+
+    it('allowlists the sandbox host that proxied HTTP requests arrive with', async () => {
+      const envVars: Record<string, string> = {};
+      const taskRun = {
+        taskId: 'task-123',
+        machineDomains: { WEB: 'https://sandbox-web.modal.host' },
+        proxyPorts: { WEB: 4321 },
+      } as unknown as TaskRun;
+
+      await injectEnvVars(envVars, taskRun, {
+        previewProxyBaseUrl: 'https://preview.octomote.run',
+      });
+
+      expect(
+        envVars.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS?.split(','),
+      ).toContain('sandbox-web.modal.host');
+    });
+
+    it('deduplicates hosts shared across named ports', async () => {
+      const envVars: Record<string, string> = {};
+      const taskRun = {
+        taskId: 'task-123',
+        machineDomains: {
+          WEB: 'http://sandbox-abc:4321',
+          API: 'http://sandbox-abc:3001',
+        },
+        proxyPorts: { WEB: 4321, API: 3001 },
+      } as unknown as TaskRun;
+
+      await injectEnvVars(envVars, taskRun, {
+        previewProxyBaseUrl: 'https://preview.octomote.run',
+      });
+
+      const hosts =
+        envVars.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS?.split(',') ?? [];
+
+      expect(hosts.filter((host) => host === 'sandbox-abc')).toHaveLength(1);
+    });
+
+    it('omits the code-server host, which is not a user dev server', async () => {
+      const envVars: Record<string, string> = {};
+      const taskRun = {
+        taskId: 'task-123',
+        machineDomains: {
+          [CODE_SERVER_NAMED_PORT.name]: 'https://sandbox-editor.modal.host',
+        },
+        proxyPorts: {},
+      } as unknown as TaskRun;
+
+      await injectEnvVars(envVars, taskRun, {
+        previewProxyBaseUrl: 'https://preview.octomote.run',
+      });
+
+      expect(envVars.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS).toBeUndefined();
+    });
+
+    it('keeps a deployment-provided allowed-hosts value', async () => {
+      const envVars: Record<string, string> = {
+        __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: 'custom.example.com',
+      };
+      const taskRun = {
+        taskId: 'task-123',
+        machineDomains: { WEB: 'https://sandbox-web.modal.host' },
+        proxyPorts: { WEB: 4321 },
+      } as unknown as TaskRun;
+
+      await injectEnvVars(envVars, taskRun, {
+        previewProxyBaseUrl: 'https://preview.octomote.run',
+      });
+
+      expect(envVars.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS).toBe(
+        'custom.example.com',
+      );
+    });
+
+    it('leaves the variable unset without a preview-proxy base URL', async () => {
+      const envVars: Record<string, string> = {};
+      const taskRun = {
+        taskId: 'task-123',
+        machineDomains: { WEB: 'https://sandbox-web.modal.host' },
+        proxyPorts: { WEB: 4321 },
+      } as unknown as TaskRun;
+
+      await injectEnvVars(envVars, taskRun);
+
+      expect(envVars.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS).toBeUndefined();
+    });
   });
 
   describe('PREVIEW_DOMAINS derivation', () => {

--- a/apps/worker/src/commands/utils/env-vars.ts
+++ b/apps/worker/src/commands/utils/env-vars.ts
@@ -31,6 +31,12 @@ const ENV_VARS_END = `# END ${PRODUCT_NAME} environment variables`;
 const VALID_ENV_VAR_NAME = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
 /**
+ * Characters Vite treats as reserved in __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS.
+ * A single occurrence makes Vite skip the entire variable.
+ */
+const VITE_UNSAFE_ALLOWED_HOST_CHARS = /["'\\]/;
+
+/**
  * Returns true when `name` is a safe POSIX environment variable name.
  * Rejects names containing shell metacharacters that could lead to command
  * injection when interpolated into a shell export statement.
@@ -195,6 +201,8 @@ export async function injectEnvVars(
   const previewProxySubdomainSuffix =
     options?.previewProxySubdomainSuffix ??
     process.env.PREVIEW_PROXY_SUBDOMAIN_SUFFIX;
+  const previewHostnames: string[] = [];
+  const machineHostnames: string[] = [];
 
   if (identity && identity.taskId && previewProxyBaseUrl) {
     for (const [name, domain] of Object.entries(identity.machineDomains)) {
@@ -216,6 +224,17 @@ export async function injectEnvVars(
         delete envVars[previewUrlEnvVarName];
       } else {
         envVars[previewUrlEnvVarName] = previewUrl;
+        previewHostnames.push(new URL(previewUrl).hostname);
+
+        // Requests that arrive through the preview proxy reach the dev server
+        // with the sandbox's own host (http-proxy rewrites Host when it changes
+        // origin), and unproxied ports are browsed at that host directly.
+        try {
+          machineHostnames.push(new URL(domain).hostname);
+        } catch {
+          // Providers that report a bare host rather than a URL have nothing
+          // extra to allowlist beyond the preview hostname above.
+        }
       }
 
       if (isProxied) {
@@ -227,6 +246,28 @@ export async function injectEnvVars(
   } else if (identity) {
     for (const [name, domain] of Object.entries(identity.machineDomains)) {
       envVars[`ROOMOTE_${name}_HOST`] = domain;
+    }
+  }
+
+  // Vite rejects requests and HMR WebSocket upgrades whose Host header is not
+  // in `server.allowedHosts` (Astro, Nuxt and SvelteKit inherit this). Two
+  // different hosts reach a sandbox dev server: the sandbox's own host on plain
+  // HTTP, because the preview proxy changes origin, and the public preview host
+  // on upgrades, because the auth-proxy rewrites Host there. Allowlisting only
+  // the first is why previews render but HMR dies with a 400. Vite reads this
+  // variable when it resolves config and appends it to allowedHosts, so setting
+  // both fixes HMR without every repo hardcoding a preview domain of its own.
+  // Pin exact hostnames rather than a wildcard suffix, and let an explicit
+  // deployment-provided value win.
+  if (!envVars.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS) {
+    // Vite discards the whole list when it contains quoting metacharacters;
+    // hostnames never do, so drop anything malformed instead of losing the rest.
+    const allowedHosts = [
+      ...new Set([...previewHostnames, ...machineHostnames]),
+    ].filter((hostname) => !VITE_UNSAFE_ALLOWED_HOST_CHARS.test(hostname));
+
+    if (allowedHosts.length > 0) {
+      envVars.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS = allowedHosts.join(',');
     }
   }
 


### PR DESCRIPTION
## Problem

HMR is broken in sandbox previews for any Vite-based app (Astro, Nuxt, SvelteKit included). The page renders and every HTTP request returns 200, but the HMR WebSocket never connects, so live reload silently does nothing.

Vite gates both requests and HMR upgrades on `server.allowedHosts`. Two different hosts reach a sandbox dev server:

- **Plain HTTP** arrives with the sandbox's own host, because preview-proxy creates its proxy with `changeOrigin: true`.
- **WebSocket upgrades** arrive with the public preview host, because the auth-proxy rewrites `Host` on the upgrade path (`startMultiplexAuthProxy`).

Only the first was ever allowlisted, and only because individual repos hardcoded a preview domain in their own config. The upgrade is therefore rejected with a 400 — which is why previews render but HMR does not work.

## Fix

Set `__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS` in the worker-managed shell env file (`~/.roomote/env.sh`, sourced via `BASH_ENV` and `.bashrc`) to both hosts. Vite reads the variable when it resolves config and appends it to `allowedHosts`, so HMR works with no per-repo configuration.

The value is pinned to the current task's **exact** hostnames rather than a wildcard suffix, deduplicated across named ports, and reuses the preview URLs `injectEnvVars` already builds:

```
__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=task-123-web.preview.example.run,sandbox-web.<provider-host>
```

The code-server port is excluded (it is not a user dev server), the nested-preview subdomain suffix is carried through, and an explicit deployment-provided value still wins — matching how `PREVIEW_DOMAINS` behaves directly below it.

## Trade-off worth knowing

Exact hostnames mean a port registered *after* the env file is written is not covered until the file is refreshed and the dev server restarts (Vite reads the variable at startup). Nested previews are covered only for the suffix the task was spawned with. Switching to `.${previewDomain}` is a one-line change if either becomes a problem.

## Testing

- `pnpm vitest run src/commands/__tests__/utils.test.ts` in `apps/worker` — 38 pass, 7 new: exact preview hostnames, sandbox machine host, dedup across ports, nested subdomain suffix, code-server exclusion, deployment override, and no-base-URL.
- `pnpm check-types`, `pnpm lint`, `pnpm format:check` clean; pre-push checks pass.

## Follow-up in another repo

Once this ships, repos no longer need their own preview-domain allowlists. The website's `astro.config.mjs` has a stale one ready to delete — **but it must land after this rolls out to the sandbox image**, since one of its entries is currently what makes HTTP previews work.
