### PR TITLE
Rewrite the Roomote MCP guide around common workflows

### DIFF
--- a/apps/docs/integrations/roomote-mcp.mdx
+++ b/apps/docs/integrations/roomote-mcp.mdx
@@ -1,78 +1,138 @@
 ---
 title: Roomote MCP
 icon: plug-circle-bolt
-description: Connect an OAuth-capable MCP client to Roomote's member task tools.
+description: Run and manage Roomote agent tasks from Claude Code or another MCP client.
 ---
 
-Roomote exposes member task management, environment discovery, and connected
-chat context as a remote MCP server. OAuth-capable clients can connect without
-manually creating or copying an API token.
+Roomote MCP brings your Roomote workspace into Claude Code and other
+OAuth-capable MCP clients. You can kick off a new Roomote task, check on its
+progress, and follow up without switching back and forth between tools.
 
-## Prerequisites
+## What you can do
 
-Before connecting a client, `R_PUBLIC_URL`, or `R_APP_URL` when no public URL
-is set, must be a browser-reachable HTTPS origin. The web and API services must
-also share Redis and the same Roomote signing keys.
+### Kick off a new task
 
-Loopback HTTP callback URLs are accepted for desktop clients. Other client
-callback URLs must use HTTPS.
+Ask your MCP client to start a Roomote task with a clear prompt. Roomote MCP
+finds the available launch environments and uses the right one for the work.
+For example, you can delegate an investigation or implementation from Claude
+Code, keep working locally, and come back for the result when the task finishes.
+You can also push work in progress to a remote branch and hand that branch to a
+Roomote agent to continue.
 
-## Connect a client
+### Check on and steer existing work
 
-Configure the MCP client with this server URL:
+Search active or completed tasks by keyword, status, or pull request. Once you
+find a task, you can read its summary, conversation, and compute logs to
+understand what happened and where the work stands.
+
+This is useful when you want to:
+
+- catch up on a task that is already running
+- find an earlier investigation or implementation
+- understand why a task failed
+- pull the result of a Roomote task into your current conversation
+- send follow-up instructions or cancel work that is no longer needed
+
+### Bring in Roomote and chat context
+
+Ask what your Roomote deployment can do or which integrations are connected.
+You can also read relevant conversation history from connected chat channels.
+For Slack and Discord, provide a channel or message link when you want context
+from a specific conversation.
+
+Roomote still applies the access rules from the connected service, so the MCP
+only returns conversations your signed-in user is allowed to read.
+
+## Things to try
+
+- “Push what I’m working on to a remote branch, then start a Roomote task from
+  that branch to take over.”
+- “Start a Roomote task in the web app environment to investigate this bug.”
+- “Find my active tasks related to OAuth and summarize their progress.”
+- “Show me the messages and compute logs from the task that failed this
+  morning.”
+- “Tell the running task to add a regression test before it opens the PR.”
+- “Use this Slack message as context and explain what the team decided.”
+- “Cancel the task working on the old approach.”
+
+## Connect your MCP client
+
+Use your Roomote URL with `/mcp` appended:
 
 ```text
 <ROOMOTE_URL>/mcp
 ```
 
-For example, if Roomote is available at `https://roomote.example`, use:
+For example:
 
 ```text
 https://roomote.example/mcp
 ```
 
-For Claude Code, add it at user scope and start the browser login:
+### Claude Code
+
+Add Roomote at user scope so it is available across your projects, then start
+the browser sign-in:
 
 ```bash
-claude mcp add --transport http roomote --scope user <ROOMOTE_URL>/mcp
+claude mcp add --transport http --scope user roomote <ROOMOTE_URL>/mcp
 claude mcp login roomote
 ```
 
-The client discovers the OAuth authorization server automatically. Roomote
-opens the browser, asks the user to sign in when needed, and returns the client
-to its registered callback after the user explicitly approves access. The
-client must support OAuth authorization code flow with S256 PKCE and dynamic
-client registration.
+You can also open `/mcp` inside Claude Code to manage the connection and sign
+in.
 
-Roomote issues one-hour access tokens and rotates an opaque refresh token for
-up to 30 days. The client returns to browser authorization when that session
-expires or is revoked.
+### Codex
 
-## Integration boundary
+Add the streamable HTTP server, then authenticate it:
 
-The browser-issued credential is intentionally narrower than Roomote's
-internal user and task-run credentials:
+```bash
+codex mcp add roomote --url <ROOMOTE_URL>/mcp
+codex mcp login roomote
+```
 
-- it is valid only for the advertised Roomote MCP resource URL
-- it grants only the `mcp:roomote` scope
-- it cannot authenticate tRPC, task, artifact, inference, integration proxy,
-  or other MCP endpoints
-- authorization codes are single-use, expire after five minutes, and are
-  bound to the client ID, redirect URI, resource, and PKCE challenge
-- anonymous client registrations must complete OAuth within one hour; clients
-  that complete the exchange remain registered for 30 days and can use only
-  HTTPS or loopback HTTP callback URLs
+The Codex CLI and IDE extension share this MCP configuration.
 
-The endpoint acts as the signed-in member. It can inspect Roomote and connected
-chat context, search and read tasks, list launch environments, launch or cancel
-tasks, and send follow-up messages. Existing member and admin authorization
-still applies to every operation; the OAuth token does not grant a task-run or
-administrator identity.
+### Cursor
+
+Add Roomote to `~/.cursor/mcp.json` to use it in every project, or to
+`.cursor/mcp.json` to keep it project-specific:
+
+```json
+{
+  "mcpServers": {
+    "roomote": {
+      "url": "<ROOMOTE_URL>/mcp"
+    }
+  }
+}
+```
+
+Open **Customize** in Cursor, find Roomote under MCP servers, and complete the
+browser sign-in.
+
+In each client, Roomote opens a browser so you can sign in and approve the
+connection. You do not need to create or copy an API token.
+
+<Note>
+  On a self-hosted deployment, the configured `R_PUBLIC_URL` (or `R_APP_URL`)
+  must be a browser-reachable HTTPS address. Desktop clients may use a loopback
+  HTTP callback.
+</Note>
+
+## Access and safety
+
+Roomote MCP works with the permissions of your signed-in Roomote user. It can
+use the task and context tools described above, but it does not provide general
+Roomote API access or administrator privileges. Existing Roomote permissions
+and connected-service access checks still apply to every request.
+
+You can revoke the connection from your MCP client. If a saved session expires
+or is revoked, Roomote asks you to approve access again in the browser.
 
 ## Troubleshooting
 
-If the client does not open a browser, verify that it follows the
-`WWW-Authenticate` protected-resource metadata link returned by the MCP
-endpoint. If the browser opens but authorization fails, confirm that the
-client sends the exact resource URL above in both authorization and token
-requests and uses the `mcp:roomote` scope.
+If your client does not open a browser or complete sign-in, make sure it
+supports OAuth for remote MCP servers and that you entered the exact Roomote
+MCP URL. On a self-hosted deployment, confirm that the URL is reachable from
+the browser and uses HTTPS.

--- a/apps/docs/integrations/roomote-mcp.mdx
+++ b/apps/docs/integrations/roomote-mcp.mdx
@@ -1,12 +1,13 @@
 ---
 title: Roomote MCP
 icon: plug-circle-bolt
-description: Run and manage Roomote agent tasks from Claude Code or another MCP client.
+description: Run and manage Roomote agent tasks from your MCP client.
 ---
 
-Roomote MCP brings your Roomote workspace into Claude Code and other
-OAuth-capable MCP clients. You can kick off a new Roomote task, check on its
-progress, and follow up without switching back and forth between tools.
+Roomote MCP brings your Roomote workspace into the coding tools you already
+use. From any OAuth-capable MCP client, you can kick off a new Roomote task,
+check on its progress, and follow up without switching back and forth between
+tools.
 
 ## What you can do
 
@@ -14,10 +15,10 @@ progress, and follow up without switching back and forth between tools.
 
 Ask your MCP client to start a Roomote task with a clear prompt. Roomote MCP
 finds the available launch environments and uses the right one for the work.
-For example, you can delegate an investigation or implementation from Claude
-Code, keep working locally, and come back for the result when the task finishes.
-You can also push work in progress to a remote branch and hand that branch to a
-Roomote agent to continue.
+For example, you can delegate an investigation or implementation, keep working
+locally, and come back for the result when the task finishes. You can also push
+work in progress to a remote branch and hand that branch to a Roomote agent to
+continue.
 
 ### Check on and steer existing work
 


### PR DESCRIPTION
## Summary

- rewrite the Roomote MCP guide around launching and managing Roomote agent tasks
- add practical prompts for task handoff, progress checks, follow-ups, and chat context
- add setup examples for Claude Code, Codex, and Cursor

## Why

The original page led with OAuth implementation details before explaining what someone could accomplish with Roomote MCP. This rewrite makes the primary workflows clear first and keeps setup, access boundaries, and troubleshooting concise.

## User impact

Readers can quickly understand how to hand work to Roomote from their existing coding client and copy the setup instructions for the client they use.

## Validation

- `mise exec -- pnpm run validate` from `apps/docs`
- repository pre-push lint, typecheck, and knip checks
