### PR TITLE
Add Roomote icon to MCP docs

### DIFF
--- a/apps/docs/integrations/roomote-mcp.mdx
+++ b/apps/docs/integrations/roomote-mcp.mdx
@@ -1,6 +1,6 @@
 ---
 title: Roomote MCP
-icon: '/favicon.svg'
+icon: '/favicon.png'
 description: Run and manage Roomote agent tasks from your MCP client.
 ---
 

--- a/apps/docs/integrations/roomote-mcp.mdx
+++ b/apps/docs/integrations/roomote-mcp.mdx
@@ -1,6 +1,6 @@
 ---
 title: Roomote MCP
-icon: plug-circle-bolt
+icon: '/favicon.svg'
 description: Run and manage Roomote agent tasks from your MCP client.
 ---
 

--- a/apps/docs/integrations/roomote-mcp.mdx
+++ b/apps/docs/integrations/roomote-mcp.mdx
@@ -1,6 +1,6 @@
 ---
 title: Roomote MCP
-icon: '/favicon.png'
+icon: '/favicon.svg'
 description: Run and manage Roomote agent tasks from your MCP client.
 ---
 

--- a/apps/docs/roomote.css
+++ b/apps/docs/roomote.css
@@ -93,6 +93,15 @@ nav a[href='https://roomote.dev'] svg,
   vertical-align: middle;
 }
 
+/* Keep integration marks in their original silhouette instead of clipping them. */
+.integration-logo,
+img[src^='https://api.iconify.design/simple-icons:'],
+img[src^='https://unpkg.com/@lobehub/icons-static-svg@'],
+img[src*='/logo/integrations/'],
+img[src*='/favicon.svg'] {
+  border-radius: 0;
+}
+
 .integration-name [data-rmiz],
 .integration-name [data-rmiz-content] {
   display: inline-flex !important;
@@ -121,5 +130,9 @@ nav a[href='https://roomote.dev'] svg,
 }
 
 .dark img[src*='/logo/integrations/'] {
+  filter: invert(1);
+}
+
+.dark img[src*='/favicon.svg'] {
   filter: invert(1);
 }


### PR DESCRIPTION
## What changed

- Replace the generic plug icon on the Roomote MCP guide with the existing Roomote brand mark.

## Why

This makes the guide recognizable as a Roomote-owned integration and keeps it visually consistent with other branded integration pages.

## Validation

- `mise exec -- pnpm run validate` in `apps/docs`
- Repository pre-push checks (oxlint, residual lint, fast type checks, and knip)