### PR TITLE
Fix MCP OAuth client compatibility

### DIFF
--- a/apps/web/src/app/api/mcp-remote-oauth/authorize/__tests__/route.test.ts
+++ b/apps/web/src/app/api/mcp-remote-oauth/authorize/__tests__/route.test.ts
@@ -36,6 +36,7 @@ const redirectUri = 'https://client.example/callback';
 function authorizeRequest(options?: {
   approved?: boolean;
   consentToken?: string;
+  resource?: string | null;
 }) {
   const url = new URL('https://roomote.example/api/mcp-remote-oauth/authorize');
   url.searchParams.set('response_type', 'code');
@@ -44,7 +45,12 @@ function authorizeRequest(options?: {
   url.searchParams.set('state', 'client-state');
   url.searchParams.set('code_challenge', 'a'.repeat(43));
   url.searchParams.set('code_challenge_method', 'S256');
-  url.searchParams.set('resource', 'https://roomote.example/mcp');
+  if (options?.resource !== null) {
+    url.searchParams.set(
+      'resource',
+      options?.resource ?? 'https://roomote.example/mcp',
+    );
+  }
   url.searchParams.set('scope', 'mcp:roomote');
   if (!options?.approved) return new NextRequest(url);
 
@@ -140,6 +146,24 @@ describe('GET /api/mcp-remote-oauth/authorize', () => {
         '/api/mcp-remote-oauth/authorize?',
       ),
     });
+  });
+
+  it('defaults an omitted resource to the Roomote MCP endpoint', async () => {
+    mockAuthorize.mockResolvedValue({ success: true, userId: 'user-1' });
+    mockCreateCode.mockResolvedValue('authorization-code');
+
+    const response = await POST(
+      authorizeRequest({
+        approved: true,
+        consentToken: 'consent-token',
+        resource: null,
+      }),
+    );
+
+    expect(response.status).toBe(303);
+    expect(mockCreateCode).toHaveBeenCalledWith(
+      expect.objectContaining({ resource: 'https://roomote.example/mcp' }),
+    );
   });
 
   it('rejects approval POSTs without the one-time consent token', async () => {

--- a/apps/web/src/app/api/mcp-remote-oauth/authorize/route.ts
+++ b/apps/web/src/app/api/mcp-remote-oauth/authorize/route.ts
@@ -23,7 +23,7 @@ const authorizeSchema = z.object({
   state: z.string().min(1),
   code_challenge: z.string().regex(/^[A-Za-z0-9_-]{43}$/),
   code_challenge_method: z.literal('S256'),
-  resource: z.string().url(),
+  resource: z.string().url().optional(),
   scope: z.string().optional(),
 });
 
@@ -288,11 +288,12 @@ async function handleAuthorize(request: NextRequest, approved: boolean) {
   const expectedResource = getRoomoteMcpResourceUrl(
     env.R_PUBLIC_URL ?? env.R_APP_URL,
   );
+  const resource = input.resource ?? expectedResource;
   const scopes = (input.scope ?? ROOMOTE_MCP_SCOPE)
     .split(/\s+/)
     .filter(Boolean);
   if (
-    input.resource !== expectedResource ||
+    resource !== expectedResource ||
     scopes.length !== 1 ||
     scopes[0] !== ROOMOTE_MCP_SCOPE
   ) {
@@ -348,7 +349,7 @@ async function handleAuthorize(request: NextRequest, approved: boolean) {
     clientId: input.client_id,
     redirectUri: input.redirect_uri,
     codeChallenge: input.code_challenge,
-    resource: input.resource,
+    resource,
     scopes,
   });
   const redirect = new URL(input.redirect_uri);

--- a/apps/web/src/app/api/mcp-remote-oauth/register/__tests__/route.test.ts
+++ b/apps/web/src/app/api/mcp-remote-oauth/register/__tests__/route.test.ts
@@ -85,6 +85,46 @@ describe('POST /api/mcp-remote-oauth/register', () => {
     });
   });
 
+  it('registers Cursor with its desktop, web, and loopback callbacks', async () => {
+    const redirectUris = [
+      'cursor://anysphere.cursor-mcp/oauth/callback',
+      'https://www.cursor.com/agents/mcp/oauth/callback',
+      'http://localhost:8787/callback',
+    ];
+    mockRegisterClient.mockResolvedValue({
+      clientId: '2a871f7c-9fac-4b4a-a7d3-cd3f4a329568',
+      clientName: 'Cursor',
+      redirectUris,
+      grantTypes: ['authorization_code', 'refresh_token'],
+    });
+
+    const response = await POST(
+      new NextRequest('https://roomote.example/api/mcp-remote-oauth/register', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          client_name: 'Cursor',
+          redirect_uris: redirectUris,
+          token_endpoint_auth_method: 'none',
+          grant_types: ['authorization_code', 'refresh_token'],
+          response_types: ['code'],
+          logo_uri: 'https://cursor.example/logo.svg',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      client_name: 'Cursor',
+      redirect_uris: redirectUris,
+    });
+    expect(mockRegisterClient).toHaveBeenCalledWith({
+      clientName: 'Cursor',
+      redirectUris,
+      grantTypes: ['authorization_code', 'refresh_token'],
+    });
+  });
+
   it('rejects a non-loopback HTTP callback', async () => {
     const response = await POST(
       registrationRequest('http://client.example/callback'),

--- a/apps/web/src/app/api/mcp-remote-oauth/token/__tests__/route.test.ts
+++ b/apps/web/src/app/api/mcp-remote-oauth/token/__tests__/route.test.ts
@@ -50,8 +50,11 @@ const verifier =
 const challenge = createHash('sha256').update(verifier).digest('base64url');
 const resource = 'https://api.example.com/mcp';
 
-function tokenRequest(overrides: Record<string, string> = {}) {
-  const body = new URLSearchParams({
+function tokenRequest(
+  overrides: Record<string, string> = {},
+  options?: { omitResource?: boolean },
+) {
+  const values: Record<string, string> = {
     grant_type: 'authorization_code',
     code: 'authorization-code',
     client_id: '2a871f7c-9fac-4b4a-a7d3-cd3f4a329568',
@@ -59,7 +62,9 @@ function tokenRequest(overrides: Record<string, string> = {}) {
     code_verifier: verifier,
     resource,
     ...overrides,
-  });
+  };
+  if (options?.omitResource) delete values.resource;
+  const body = new URLSearchParams(values);
   return new NextRequest('https://roomote.example/api/mcp-remote-oauth/token', {
     method: 'POST',
     headers: { 'content-type': 'application/x-www-form-urlencoded' },
@@ -67,14 +72,19 @@ function tokenRequest(overrides: Record<string, string> = {}) {
   });
 }
 
-function refreshRequest(overrides: Record<string, string> = {}) {
-  const body = new URLSearchParams({
+function refreshRequest(
+  overrides: Record<string, string> = {},
+  options?: { omitResource?: boolean },
+) {
+  const values: Record<string, string> = {
     grant_type: 'refresh_token',
     refresh_token: 'session.refresh-token',
     client_id: '2a871f7c-9fac-4b4a-a7d3-cd3f4a329568',
     resource,
     ...overrides,
-  });
+  };
+  if (options?.omitResource) delete values.resource;
+  const body = new URLSearchParams(values);
   return new NextRequest('https://roomote.example/api/mcp-remote-oauth/token', {
     method: 'POST',
     headers: { 'content-type': 'application/x-www-form-urlencoded' },
@@ -153,6 +163,15 @@ describe('POST /api/mcp-remote-oauth/token', () => {
     });
   });
 
+  it('uses the authorization resource when the token request omits it', async () => {
+    const response = await POST(tokenRequest({}, { omitResource: true }));
+
+    expect(response.status).toBe(200);
+    expect(mockCreateToken).toHaveBeenCalledWith(
+      expect.objectContaining({ resource }),
+    );
+  });
+
   it('rotates a refresh token and issues a new access token', async () => {
     const response = await POST(refreshRequest());
 
@@ -167,6 +186,15 @@ describe('POST /api/mcp-remote-oauth/token', () => {
     expect(mockRotateRefreshToken).toHaveBeenCalledWith(
       'session.refresh-token',
       expect.objectContaining({ userId: 'user-1' }),
+    );
+  });
+
+  it('uses the session resource when a refresh request omits it', async () => {
+    const response = await POST(refreshRequest({}, { omitResource: true }));
+
+    expect(response.status).toBe(200);
+    expect(mockCreateToken).toHaveBeenCalledWith(
+      expect.objectContaining({ resource }),
     );
   });
 

--- a/apps/web/src/app/api/mcp-remote-oauth/token/route.ts
+++ b/apps/web/src/app/api/mcp-remote-oauth/token/route.ts
@@ -28,13 +28,13 @@ const tokenSchema = z.discriminatedUnion('grant_type', [
     client_id: z.string().uuid(),
     redirect_uri: z.string().url(),
     code_verifier: z.string().regex(/^[A-Za-z0-9._~-]{43,128}$/),
-    resource: z.string().url(),
+    resource: z.string().url().optional(),
   }),
   z.object({
     grant_type: z.literal('refresh_token'),
     refresh_token: z.string().min(1),
     client_id: z.string().uuid(),
-    resource: z.string().url(),
+    resource: z.string().url().optional(),
     scope: z.string().optional(),
   }),
 ]);
@@ -85,7 +85,7 @@ export async function POST(request: NextRequest) {
       !client ||
       !client.grantTypes.includes('refresh_token') ||
       session.clientId !== input.client_id ||
-      session.resource !== input.resource ||
+      (input.resource !== undefined && session.resource !== input.resource) ||
       session.scopes.length !== 1 ||
       session.scopes[0] !== ROOMOTE_MCP_SCOPE ||
       (input.scope !== undefined && input.scope !== ROOMOTE_MCP_SCOPE)
@@ -116,7 +116,8 @@ export async function POST(request: NextRequest) {
     !client ||
     authorization.clientId !== input.client_id ||
     authorization.redirectUri !== input.redirect_uri ||
-    input.resource !== authorization.resource ||
+    (input.resource !== undefined &&
+      input.resource !== authorization.resource) ||
     authorization.scopes.length !== 1 ||
     authorization.scopes[0] !== ROOMOTE_MCP_SCOPE ||
     !verifyPkceChallenge(input.code_verifier, authorization.codeChallenge)

--- a/apps/web/src/lib/server/mcp-remote-oauth.test.ts
+++ b/apps/web/src/lib/server/mcp-remote-oauth.test.ts
@@ -178,14 +178,20 @@ describe('remote MCP OAuth state', () => {
     redisSortedSets.clear();
   });
 
-  it('accepts HTTPS and loopback redirects only', () => {
+  it('accepts HTTPS, loopback, and the Cursor desktop callback', () => {
     expect(isAllowedOAuthRedirectUri('https://client.example/callback')).toBe(
       true,
     );
     expect(isAllowedOAuthRedirectUri('http://127.0.0.1:43110/callback')).toBe(
       true,
     );
+    expect(
+      isAllowedOAuthRedirectUri('cursor://anysphere.cursor-mcp/oauth/callback'),
+    ).toBe(true);
     expect(isAllowedOAuthRedirectUri('http://client.example/callback')).toBe(
+      false,
+    );
+    expect(isAllowedOAuthRedirectUri('cursor://other-client/callback')).toBe(
       false,
     );
   });

--- a/apps/web/src/lib/server/mcp-remote-oauth.ts
+++ b/apps/web/src/lib/server/mcp-remote-oauth.ts
@@ -219,13 +219,20 @@ function parseRefreshToken(token: string): string | null {
 export function isAllowedOAuthRedirectUri(value: string): boolean {
   try {
     const url = new URL(value);
+    const isCursorDesktopCallback =
+      url.protocol === 'cursor:' &&
+      url.hostname === 'anysphere.cursor-mcp' &&
+      url.port === '' &&
+      url.pathname === '/oauth/callback' &&
+      url.search === '';
     return (
       url.hash === '' &&
       url.username === '' &&
       url.password === '' &&
       (url.protocol === 'https:' ||
         (url.protocol === 'http:' &&
-          (url.hostname === '127.0.0.1' || url.hostname === 'localhost')))
+          (url.hostname === '127.0.0.1' || url.hostname === 'localhost')) ||
+        isCursorDesktopCallback)
     );
   } catch {
     return false;


### PR DESCRIPTION
## Summary

- accept OAuth authorization, token, and refresh requests that omit the optional resource parameter, defaulting to the canonical Roomote MCP resource
- allow Cursor's fixed desktop callback during dynamic client registration while continuing to reject arbitrary custom URI schemes
- add regression coverage for Codex-style requests and Cursor's complete registration payload

## Root cause

MCP clients vary in how they implement OAuth metadata. Some clients omit the resource parameter when the protected resource is already unambiguous, while Cursor registers a fixed desktop callback in addition to HTTPS and loopback callbacks. Roomote previously rejected both request shapes before the OAuth flow could complete.

## Impact

Codex and Cursor can authenticate with the Roomote MCP server without weakening resource binding or broadly allowing custom callback schemes. Explicit resource mismatches remain rejected.

## Validation

- `mise exec -- pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/web exec vitest run src/lib/server/mcp-remote-oauth.test.ts src/app/api/mcp-remote-oauth/register/__tests__/route.test.ts src/app/api/mcp-remote-oauth/authorize/__tests__/route.test.ts src/app/api/mcp-remote-oauth/token/__tests__/route.test.ts`
- `mise exec -- pnpm --filter @roomote/web check-types`
- repository pre-push checks (oxlint, residual lint, fast type checks, and knip)
