### PR TITLE
[Fix] Generalize MCP OAuth callback validation

### DIFF
--- a/.changeset/allow-codex-mcp-app-callback.md
+++ b/.changeset/allow-codex-mcp-app-callback.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Allow Codex Desktop to register its connector OAuth callback so Roomote can return browser authorization to the originating app connection flow.

--- a/.changeset/allow-codex-mcp-app-callback.md
+++ b/.changeset/allow-codex-mcp-app-callback.md
@@ -2,4 +2,4 @@
 '@roomote/web': patch
 ---
 
-Allow Codex Desktop to register its connector OAuth callback so Roomote can return browser authorization to the originating app connection flow.
+Support and document the OAuth callbacks requested by Claude Code, Codex, and Cursor, including the Codex Desktop connector app link.

--- a/.changeset/allow-codex-mcp-app-callback.md
+++ b/.changeset/allow-codex-mcp-app-callback.md
@@ -2,4 +2,4 @@
 '@roomote/web': patch
 ---
 
-Support and document the OAuth callbacks requested by Claude Code, Codex, and Cursor, including the Codex Desktop connector app link.
+Validate MCP OAuth callbacks by callback class instead of client-specific URLs, supporting secure hosted, loopback, and native app callbacks.

--- a/apps/docs/integrations/roomote-mcp.mdx
+++ b/apps/docs/integrations/roomote-mcp.mdx
@@ -83,6 +83,10 @@ claude mcp login roomote
 You can also open `/mcp` inside Claude Code to manage the connection and sign
 in.
 
+Claude Code requests a temporary `http://localhost:<port>/callback` URL for the
+browser to return the authorization result to the running CLI. Roomote accepts
+both `localhost` and `127.0.0.1` loopback callbacks with client-selected ports.
+
 ### Codex
 
 Add the streamable HTTP server, then authenticate it:
@@ -118,13 +122,22 @@ Add Roomote to `~/.cursor/mcp.json` to use it in every project, or to
 Open **Customize** in Cursor, find Roomote under MCP servers, and complete the
 browser sign-in.
 
+Cursor can request its registered
+`cursor://anysphere.cursor-mcp/oauth/callback` app link, its hosted HTTPS
+callback, or a loopback HTTP callback. Roomote accepts each form and returns the
+authorization result to the exact callback Cursor registered.
+
 In each client, Roomote opens a browser so you can sign in and approve the
-connection. You do not need to create or copy an API token.
+connection. During OAuth dynamic client registration, the client sends Roomote
+its callback URL in `redirect_uris`. Roomote validates and saves that URL, then
+only sends the result to the same registered URL after approval. You do not
+need to create or copy an API token.
 
 <Note>
   On a self-hosted deployment, the configured `R_PUBLIC_URL` (or `R_APP_URL`)
   must be a browser-reachable HTTPS address. Desktop clients may use a loopback
-  HTTP callback.
+  HTTP callback. Roomote supports the callback forms described above for all
+  three documented clients.
 </Note>
 
 ## Access and safety

--- a/apps/docs/integrations/roomote-mcp.mdx
+++ b/apps/docs/integrations/roomote-mcp.mdx
@@ -83,9 +83,9 @@ claude mcp login roomote
 You can also open `/mcp` inside Claude Code to manage the connection and sign
 in.
 
-Claude Code requests a temporary `http://localhost:<port>/callback` URL for the
-browser to return the authorization result to the running CLI. Roomote accepts
-both `localhost` and `127.0.0.1` loopback callbacks with client-selected ports.
+Claude Code requests a temporary loopback URL for the browser to return the
+authorization result to the running CLI. Roomote accepts localhost, IPv4, and
+IPv6 loopback callbacks with client-selected ports.
 
 ### Codex
 
@@ -98,11 +98,9 @@ codex mcp login roomote
 
 The Codex CLI and IDE extension share this MCP configuration.
 
-Codex Desktop can request its registered
-`codex://connector/oauth_callback` app link during OAuth. Roomote accepts that
-exact callback so the browser can return the authorization result to the
-originating Codex connection flow. The CLI and IDE extension may instead use a
-loopback HTTP callback.
+Codex Desktop can request a native app link during OAuth so the browser returns
+the authorization result to the originating connection flow. The CLI and IDE
+extension may instead use a loopback HTTP callback.
 
 ### Cursor
 
@@ -122,16 +120,21 @@ Add Roomote to `~/.cursor/mcp.json` to use it in every project, or to
 Open **Customize** in Cursor, find Roomote under MCP servers, and complete the
 browser sign-in.
 
-Cursor can request its registered
-`cursor://anysphere.cursor-mcp/oauth/callback` app link, its hosted HTTPS
-callback, or a loopback HTTP callback. Roomote accepts each form and returns the
-authorization result to the exact callback Cursor registered.
+Cursor can request a native app link, a hosted HTTPS callback, or a loopback
+HTTP callback. Roomote accepts each form and returns the authorization result
+to the exact callback Cursor registered.
 
 In each client, Roomote opens a browser so you can sign in and approve the
 connection. During OAuth dynamic client registration, the client sends Roomote
 its callback URL in `redirect_uris`. Roomote validates and saves that URL, then
 only sends the result to the same registered URL after approval. You do not
 need to create or copy an API token.
+
+Roomote validates callbacks by callback class instead of maintaining a list of
+client-specific URLs: HTTPS for hosted clients, HTTP only on loopback
+interfaces for local clients, and non-browser private URI schemes for native
+apps. Unsafe browser, file, and network schemes are rejected. The approval page
+shows the exact registered callback before Roomote redirects to it.
 
 <Note>
   On a self-hosted deployment, the configured `R_PUBLIC_URL` (or `R_APP_URL`)

--- a/apps/docs/integrations/roomote-mcp.mdx
+++ b/apps/docs/integrations/roomote-mcp.mdx
@@ -94,6 +94,12 @@ codex mcp login roomote
 
 The Codex CLI and IDE extension share this MCP configuration.
 
+Codex Desktop can request its registered
+`codex://connector/oauth_callback` app link during OAuth. Roomote accepts that
+exact callback so the browser can return the authorization result to the
+originating Codex connection flow. The CLI and IDE extension may instead use a
+loopback HTTP callback.
+
 ### Cursor
 
 Add Roomote to `~/.cursor/mcp.json` to use it in every project, or to

--- a/apps/web/src/app/api/mcp-remote-oauth/authorize/__tests__/route.test.ts
+++ b/apps/web/src/app/api/mcp-remote-oauth/authorize/__tests__/route.test.ts
@@ -188,6 +188,84 @@ describe('GET /api/mcp-remote-oauth/authorize', () => {
     );
   });
 
+  it('returns Cursor through its requested app callback', async () => {
+    const cursorRedirectUri = 'cursor://anysphere.cursor-mcp/oauth/callback';
+    mockAuthorize.mockResolvedValue({ success: true, userId: 'user-1' });
+    mockGetClient.mockResolvedValue({
+      clientId,
+      clientName: 'Cursor',
+      redirectUris: [cursorRedirectUri],
+    });
+    mockCreateCode.mockResolvedValue('authorization-code');
+
+    const consentResponse = await GET(
+      authorizeRequest({ redirectUri: cursorRedirectUri }),
+    );
+    const html = await consentResponse.text();
+
+    expect(html).toContain(
+      'After approval, you’ll return to <strong>Cursor</strong>.',
+    );
+    expect(consentResponse.headers.get('content-security-policy')).toContain(
+      "form-action 'self' cursor:",
+    );
+
+    const response = await POST(
+      authorizeRequest({
+        approved: true,
+        consentToken: 'consent-token',
+        redirectUri: cursorRedirectUri,
+      }),
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toBe(
+      'cursor://anysphere.cursor-mcp/oauth/callback?code=authorization-code&state=client-state',
+    );
+    expect(mockCreateCode).toHaveBeenCalledWith(
+      expect.objectContaining({ redirectUri: cursorRedirectUri }),
+    );
+  });
+
+  it('returns Claude Code through its requested loopback callback', async () => {
+    const claudeRedirectUri = 'http://localhost:54545/callback';
+    mockAuthorize.mockResolvedValue({ success: true, userId: 'user-1' });
+    mockGetClient.mockResolvedValue({
+      clientId,
+      clientName: 'Claude Code',
+      redirectUris: [claudeRedirectUri],
+    });
+    mockCreateCode.mockResolvedValue('authorization-code');
+
+    const consentResponse = await GET(
+      authorizeRequest({ redirectUri: claudeRedirectUri }),
+    );
+    const html = await consentResponse.text();
+
+    expect(html).toContain(
+      'After approval, you’ll return to <strong>localhost:54545</strong>.',
+    );
+    expect(consentResponse.headers.get('content-security-policy')).toContain(
+      "form-action 'self' http://localhost:54545",
+    );
+
+    const response = await POST(
+      authorizeRequest({
+        approved: true,
+        consentToken: 'consent-token',
+        redirectUri: claudeRedirectUri,
+      }),
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:54545/callback?code=authorization-code&state=client-state',
+    );
+    expect(mockCreateCode).toHaveBeenCalledWith(
+      expect.objectContaining({ redirectUri: claudeRedirectUri }),
+    );
+  });
+
   it('defaults an omitted resource to the Roomote MCP endpoint', async () => {
     mockAuthorize.mockResolvedValue({ success: true, userId: 'user-1' });
     mockCreateCode.mockResolvedValue('authorization-code');

--- a/apps/web/src/app/api/mcp-remote-oauth/authorize/__tests__/route.test.ts
+++ b/apps/web/src/app/api/mcp-remote-oauth/authorize/__tests__/route.test.ts
@@ -165,7 +165,7 @@ describe('GET /api/mcp-remote-oauth/authorize', () => {
     const html = await consentResponse.text();
 
     expect(html).toContain(
-      'After approval, you’ll return to <strong>the Codex app</strong>.',
+      'Roomote will send the authorization result to <code>codex://connector/oauth_callback</code>.',
     );
     expect(consentResponse.headers.get('content-security-policy')).toContain(
       "form-action 'self' codex:",
@@ -204,7 +204,7 @@ describe('GET /api/mcp-remote-oauth/authorize', () => {
     const html = await consentResponse.text();
 
     expect(html).toContain(
-      'After approval, you’ll return to <strong>Cursor</strong>.',
+      'Roomote will send the authorization result to <code>cursor://anysphere.cursor-mcp/oauth/callback</code>.',
     );
     expect(consentResponse.headers.get('content-security-policy')).toContain(
       "form-action 'self' cursor:",
@@ -243,7 +243,7 @@ describe('GET /api/mcp-remote-oauth/authorize', () => {
     const html = await consentResponse.text();
 
     expect(html).toContain(
-      'After approval, you’ll return to <strong>localhost:54545</strong>.',
+      'Roomote will send the authorization result to <code>http://localhost:54545/callback</code>.',
     );
     expect(consentResponse.headers.get('content-security-policy')).toContain(
       "form-action 'self' http://localhost:54545",
@@ -264,6 +264,26 @@ describe('GET /api/mcp-remote-oauth/authorize', () => {
     expect(mockCreateCode).toHaveBeenCalledWith(
       expect.objectContaining({ redirectUri: claudeRedirectUri }),
     );
+  });
+
+  it('rejects a callback that does not exactly match the registered URI', async () => {
+    mockGetClient.mockResolvedValue({
+      clientId,
+      clientName: 'Example App',
+      redirectUris: ['example-app:/oauth/callback'],
+    });
+
+    const response = await GET(
+      authorizeRequest({ redirectUri: 'example-app:/oauth/other' }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'invalid_request',
+    });
+    expect(mockAuthorize).not.toHaveBeenCalled();
+    expect(mockCreateConsentToken).not.toHaveBeenCalled();
+    expect(mockCreateCode).not.toHaveBeenCalled();
   });
 
   it('defaults an omitted resource to the Roomote MCP endpoint', async () => {

--- a/apps/web/src/app/api/mcp-remote-oauth/authorize/__tests__/route.test.ts
+++ b/apps/web/src/app/api/mcp-remote-oauth/authorize/__tests__/route.test.ts
@@ -36,12 +36,13 @@ const redirectUri = 'https://client.example/callback';
 function authorizeRequest(options?: {
   approved?: boolean;
   consentToken?: string;
+  redirectUri?: string;
   resource?: string | null;
 }) {
   const url = new URL('https://roomote.example/api/mcp-remote-oauth/authorize');
   url.searchParams.set('response_type', 'code');
   url.searchParams.set('client_id', clientId);
-  url.searchParams.set('redirect_uri', redirectUri);
+  url.searchParams.set('redirect_uri', options?.redirectUri ?? redirectUri);
   url.searchParams.set('state', 'client-state');
   url.searchParams.set('code_challenge', 'a'.repeat(43));
   url.searchParams.set('code_challenge_method', 'S256');
@@ -146,6 +147,45 @@ describe('GET /api/mcp-remote-oauth/authorize', () => {
         '/api/mcp-remote-oauth/authorize?',
       ),
     });
+  });
+
+  it('returns Codex Desktop clients through their requested app callback', async () => {
+    const codexRedirectUri = 'codex://connector/oauth_callback';
+    mockAuthorize.mockResolvedValue({ success: true, userId: 'user-1' });
+    mockGetClient.mockResolvedValue({
+      clientId,
+      clientName: 'Codex',
+      redirectUris: [codexRedirectUri],
+    });
+    mockCreateCode.mockResolvedValue('authorization-code');
+
+    const consentResponse = await GET(
+      authorizeRequest({ redirectUri: codexRedirectUri }),
+    );
+    const html = await consentResponse.text();
+
+    expect(html).toContain(
+      'After approval, you’ll return to <strong>the Codex app</strong>.',
+    );
+    expect(consentResponse.headers.get('content-security-policy')).toContain(
+      "form-action 'self' codex:",
+    );
+
+    const response = await POST(
+      authorizeRequest({
+        approved: true,
+        consentToken: 'consent-token',
+        redirectUri: codexRedirectUri,
+      }),
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toBe(
+      'codex://connector/oauth_callback?code=authorization-code&state=client-state',
+    );
+    expect(mockCreateCode).toHaveBeenCalledWith(
+      expect.objectContaining({ redirectUri: codexRedirectUri }),
+    );
   });
 
   it('defaults an omitted resource to the Roomote MCP endpoint', async () => {

--- a/apps/web/src/app/api/mcp-remote-oauth/authorize/route.ts
+++ b/apps/web/src/app/api/mcp-remote-oauth/authorize/route.ts
@@ -54,7 +54,11 @@ function consentResponse(options: {
   const callbackUrl = new URL(options.redirectUri);
   const callbackHost = escapeHtml(callbackUrl.host);
   const callbackDestination =
-    callbackUrl.protocol === 'codex:' ? 'the Codex app' : callbackHost;
+    callbackUrl.protocol === 'codex:'
+      ? 'the Codex app'
+      : callbackUrl.protocol === 'cursor:'
+        ? 'Cursor'
+        : callbackHost;
   const callbackFormActionSource =
     callbackUrl.protocol === 'http:' || callbackUrl.protocol === 'https:'
       ? callbackUrl.origin

--- a/apps/web/src/app/api/mcp-remote-oauth/authorize/route.ts
+++ b/apps/web/src/app/api/mcp-remote-oauth/authorize/route.ts
@@ -53,6 +53,12 @@ function consentResponse(options: {
   const clientName = escapeHtml(options.clientName ?? 'An MCP client');
   const callbackUrl = new URL(options.redirectUri);
   const callbackHost = escapeHtml(callbackUrl.host);
+  const callbackDestination =
+    callbackUrl.protocol === 'codex:' ? 'the Codex app' : callbackHost;
+  const callbackFormActionSource =
+    callbackUrl.protocol === 'http:' || callbackUrl.protocol === 'https:'
+      ? callbackUrl.origin
+      : callbackUrl.protocol;
   const consentToken = escapeHtml(options.consentToken);
 
   return new NextResponse(
@@ -239,7 +245,7 @@ function consentResponse(options: {
                 <li>Send follow-up messages</li>
               </ul>
             </div>
-            <p class="return-to">After approval, you’ll return to <strong>${callbackHost}</strong>.</p>
+            <p class="return-to">After approval, you’ll return to <strong>${callbackDestination}</strong>.</p>
             <form method="post" action="${action}">
               <input type="hidden" name="consent_token" value="${consentToken}">
               <button type="submit"><span>Allow access</span><span aria-hidden="true">&rarr;</span></button>
@@ -256,7 +262,7 @@ function consentResponse(options: {
       headers: {
         'Cache-Control': 'no-store',
         'Content-Type': 'text/html; charset=utf-8',
-        'Content-Security-Policy': `default-src 'none'; img-src 'self'; style-src 'unsafe-inline'; form-action 'self' ${callbackUrl.origin}; base-uri 'none'; frame-ancestors 'none'`,
+        'Content-Security-Policy': `default-src 'none'; img-src 'self'; style-src 'unsafe-inline'; form-action 'self' ${callbackFormActionSource}; base-uri 'none'; frame-ancestors 'none'`,
         'X-Frame-Options': 'DENY',
       },
     },

--- a/apps/web/src/app/api/mcp-remote-oauth/authorize/route.ts
+++ b/apps/web/src/app/api/mcp-remote-oauth/authorize/route.ts
@@ -52,13 +52,7 @@ function consentResponse(options: {
   );
   const clientName = escapeHtml(options.clientName ?? 'An MCP client');
   const callbackUrl = new URL(options.redirectUri);
-  const callbackHost = escapeHtml(callbackUrl.host);
-  const callbackDestination =
-    callbackUrl.protocol === 'codex:'
-      ? 'the Codex app'
-      : callbackUrl.protocol === 'cursor:'
-        ? 'Cursor'
-        : callbackHost;
+  const callbackDestination = escapeHtml(options.redirectUri);
   const callbackFormActionSource =
     callbackUrl.protocol === 'http:' || callbackUrl.protocol === 'https:'
       ? callbackUrl.origin
@@ -178,7 +172,7 @@ function consentResponse(options: {
         line-height: 1.5;
       }
 
-      .return-to strong {
+      .return-to code {
         overflow-wrap: anywhere;
         font-weight: 700;
       }
@@ -249,7 +243,7 @@ function consentResponse(options: {
                 <li>Send follow-up messages</li>
               </ul>
             </div>
-            <p class="return-to">After approval, you’ll return to <strong>${callbackDestination}</strong>.</p>
+            <p class="return-to">After approval, Roomote will send the authorization result to <code>${callbackDestination}</code>.</p>
             <form method="post" action="${action}">
               <input type="hidden" name="consent_token" value="${consentToken}">
               <button type="submit"><span>Allow access</span><span aria-hidden="true">&rarr;</span></button>

--- a/apps/web/src/app/api/mcp-remote-oauth/register/__tests__/route.test.ts
+++ b/apps/web/src/app/api/mcp-remote-oauth/register/__tests__/route.test.ts
@@ -134,11 +134,11 @@ describe('POST /api/mcp-remote-oauth/register', () => {
     });
   });
 
-  it('registers the exact Codex Desktop connector callback', async () => {
-    const redirectUri = 'codex://connector/oauth_callback';
+  it('registers a native app callback without a vendor allowlist', async () => {
+    const redirectUri = 'example-app:/oauth/callback';
     mockRegisterClient.mockResolvedValue({
       clientId: '2a871f7c-9fac-4b4a-a7d3-cd3f4a329568',
-      clientName: 'Codex',
+      clientName: 'Example App',
       redirectUris: [redirectUri],
       grantTypes: ['authorization_code', 'refresh_token'],
     });
@@ -148,7 +148,7 @@ describe('POST /api/mcp-remote-oauth/register', () => {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
-          client_name: 'Codex',
+          client_name: 'Example App',
           redirect_uris: [redirectUri],
           token_endpoint_auth_method: 'none',
           grant_types: ['authorization_code', 'refresh_token'],
@@ -159,11 +159,11 @@ describe('POST /api/mcp-remote-oauth/register', () => {
 
     expect(response.status).toBe(201);
     await expect(response.json()).resolves.toMatchObject({
-      client_name: 'Codex',
+      client_name: 'Example App',
       redirect_uris: [redirectUri],
     });
     expect(mockRegisterClient).toHaveBeenCalledWith({
-      clientName: 'Codex',
+      clientName: 'Example App',
       redirectUris: [redirectUri],
       grantTypes: ['authorization_code', 'refresh_token'],
     });

--- a/apps/web/src/app/api/mcp-remote-oauth/register/__tests__/route.test.ts
+++ b/apps/web/src/app/api/mcp-remote-oauth/register/__tests__/route.test.ts
@@ -125,6 +125,41 @@ describe('POST /api/mcp-remote-oauth/register', () => {
     });
   });
 
+  it('registers the exact Codex Desktop connector callback', async () => {
+    const redirectUri = 'codex://connector/oauth_callback';
+    mockRegisterClient.mockResolvedValue({
+      clientId: '2a871f7c-9fac-4b4a-a7d3-cd3f4a329568',
+      clientName: 'Codex',
+      redirectUris: [redirectUri],
+      grantTypes: ['authorization_code', 'refresh_token'],
+    });
+
+    const response = await POST(
+      new NextRequest('https://roomote.example/api/mcp-remote-oauth/register', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          client_name: 'Codex',
+          redirect_uris: [redirectUri],
+          token_endpoint_auth_method: 'none',
+          grant_types: ['authorization_code', 'refresh_token'],
+          response_types: ['code'],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      client_name: 'Codex',
+      redirect_uris: [redirectUri],
+    });
+    expect(mockRegisterClient).toHaveBeenCalledWith({
+      clientName: 'Codex',
+      redirectUris: [redirectUri],
+      grantTypes: ['authorization_code', 'refresh_token'],
+    });
+  });
+
   it('rejects a non-loopback HTTP callback', async () => {
     const response = await POST(
       registrationRequest('http://client.example/callback'),

--- a/apps/web/src/app/api/mcp-remote-oauth/register/__tests__/route.test.ts
+++ b/apps/web/src/app/api/mcp-remote-oauth/register/__tests__/route.test.ts
@@ -16,6 +16,7 @@ import { POST } from '../route';
 function registrationRequest(
   redirectUri: string,
   grantTypes: string[] = ['authorization_code'],
+  clientName = 'Test client',
 ) {
   return new NextRequest(
     'https://roomote.example/api/mcp-remote-oauth/register',
@@ -23,7 +24,7 @@ function registrationRequest(
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
-        client_name: 'Test client',
+        client_name: clientName,
         redirect_uris: [redirectUri],
         token_endpoint_auth_method: 'none',
         grant_types: grantTypes,
@@ -64,24 +65,32 @@ describe('POST /api/mcp-remote-oauth/register', () => {
     );
   });
 
-  it('accepts clients that advertise refresh-token fallback support', async () => {
+  it('registers Claude Code with its loopback callback', async () => {
     mockRegisterClient.mockResolvedValue({
       clientId: '2a871f7c-9fac-4b4a-a7d3-cd3f4a329568',
-      clientName: 'Test client',
+      clientName: 'Claude Code',
       redirectUris: ['http://localhost:54545/callback'],
       grantTypes: ['authorization_code', 'refresh_token'],
     });
 
     const response = await POST(
-      registrationRequest('http://localhost:54545/callback', [
-        'authorization_code',
-        'refresh_token',
-      ]),
+      registrationRequest(
+        'http://localhost:54545/callback',
+        ['authorization_code', 'refresh_token'],
+        'Claude Code',
+      ),
     );
 
     expect(response.status).toBe(201);
     await expect(response.json()).resolves.toMatchObject({
+      client_name: 'Claude Code',
+      redirect_uris: ['http://localhost:54545/callback'],
       grant_types: ['authorization_code', 'refresh_token'],
+    });
+    expect(mockRegisterClient).toHaveBeenCalledWith({
+      clientName: 'Claude Code',
+      redirectUris: ['http://localhost:54545/callback'],
+      grantTypes: ['authorization_code', 'refresh_token'],
     });
   });
 

--- a/apps/web/src/lib/server/mcp-remote-oauth.test.ts
+++ b/apps/web/src/lib/server/mcp-remote-oauth.test.ts
@@ -193,7 +193,7 @@ describe('remote MCP OAuth state', () => {
     redisSortedSets.clear();
   });
 
-  it('accepts HTTPS, loopback, and the Cursor desktop callback', () => {
+  it('accepts HTTPS, loopback, and exact desktop app callbacks', () => {
     expect(isAllowedOAuthRedirectUri('https://client.example/callback')).toBe(
       true,
     );
@@ -203,12 +203,21 @@ describe('remote MCP OAuth state', () => {
     expect(
       isAllowedOAuthRedirectUri('cursor://anysphere.cursor-mcp/oauth/callback'),
     ).toBe(true);
+    expect(isAllowedOAuthRedirectUri('codex://connector/oauth_callback')).toBe(
+      true,
+    );
     expect(isAllowedOAuthRedirectUri('http://client.example/callback')).toBe(
       false,
     );
     expect(isAllowedOAuthRedirectUri('cursor://other-client/callback')).toBe(
       false,
     );
+    expect(isAllowedOAuthRedirectUri('codex://threads/new')).toBe(false);
+    expect(
+      isAllowedOAuthRedirectUri(
+        'codex://connector/oauth_callback?return_to=threads/new',
+      ),
+    ).toBe(false);
   });
 
   it('stores registered client redirect URIs', async () => {

--- a/apps/web/src/lib/server/mcp-remote-oauth.test.ts
+++ b/apps/web/src/lib/server/mcp-remote-oauth.test.ts
@@ -193,19 +193,22 @@ describe('remote MCP OAuth state', () => {
     redisSortedSets.clear();
   });
 
-  it('accepts HTTPS, loopback, and exact desktop app callbacks', () => {
-    expect(isAllowedOAuthRedirectUri('https://client.example/callback')).toBe(
-      true,
-    );
-    expect(isAllowedOAuthRedirectUri('http://127.0.0.1:43110/callback')).toBe(
-      true,
-    );
-    expect(
-      isAllowedOAuthRedirectUri('cursor://anysphere.cursor-mcp/oauth/callback'),
-    ).toBe(true);
-    expect(isAllowedOAuthRedirectUri('codex://connector/oauth_callback')).toBe(
-      true,
-    );
+  it.each([
+    ['Claude Code loopback', 'http://localhost:43110/callback'],
+    ['Claude Code IPv4 loopback', 'http://127.0.0.1:43110/callback'],
+    ['Cursor desktop app', 'cursor://anysphere.cursor-mcp/oauth/callback'],
+    [
+      'Cursor hosted callback',
+      'https://www.cursor.com/agents/mcp/oauth/callback',
+    ],
+    ['Cursor loopback', 'http://localhost:8787/callback'],
+    ['Codex desktop app', 'codex://connector/oauth_callback'],
+    ['Codex loopback', 'http://127.0.0.1:1455/callback'],
+  ])('accepts the %s callback', (_client, redirectUri) => {
+    expect(isAllowedOAuthRedirectUri(redirectUri)).toBe(true);
+  });
+
+  it('rejects unsafe or unrecognized callbacks', () => {
     expect(isAllowedOAuthRedirectUri('http://client.example/callback')).toBe(
       false,
     );

--- a/apps/web/src/lib/server/mcp-remote-oauth.test.ts
+++ b/apps/web/src/lib/server/mcp-remote-oauth.test.ts
@@ -220,6 +220,16 @@ describe('remote MCP OAuth state', () => {
     expect(isAllowedOAuthRedirectUri(redirectUri)).toBe(true);
   });
 
+  it.each([
+    ['Chromium', 'chrome-extension://extension-id/oauth/callback'],
+    ['Firefox', 'moz-extension://extension-id/oauth/callback'],
+    ['Safari', 'safari-web-extension://extension-id/oauth/callback'],
+    ['legacy Edge', 'ms-browser-extension://extension-id/oauth/callback'],
+    ['generic', 'extension:/oauth/callback'],
+  ])('rejects the %s browser-extension callback', (_browser, redirectUri) => {
+    expect(isAllowedOAuthRedirectUri(redirectUri)).toBe(false);
+  });
+
   it('rejects unsafe or malformed callbacks', () => {
     expect(isAllowedOAuthRedirectUri('http://client.example/callback')).toBe(
       false,

--- a/apps/web/src/lib/server/mcp-remote-oauth.test.ts
+++ b/apps/web/src/lib/server/mcp-remote-oauth.test.ts
@@ -196,30 +196,63 @@ describe('remote MCP OAuth state', () => {
   it.each([
     ['Claude Code loopback', 'http://localhost:43110/callback'],
     ['Claude Code IPv4 loopback', 'http://127.0.0.1:43110/callback'],
+    ['IPv4 loopback range', 'http://127.42.10.9:43110/callback'],
+    ['IPv6 loopback', 'http://[::1]:43110/callback'],
     ['Cursor desktop app', 'cursor://anysphere.cursor-mcp/oauth/callback'],
     [
       'Cursor hosted callback',
       'https://www.cursor.com/agents/mcp/oauth/callback',
     ],
     ['Cursor loopback', 'http://localhost:8787/callback'],
+    ['another Cursor app route', 'cursor://other-client/callback'],
     ['Codex desktop app', 'codex://connector/oauth_callback'],
     ['Codex loopback', 'http://127.0.0.1:1455/callback'],
+    [
+      'RFC 8252 private-use app callback',
+      'com.example.app:/oauth2redirect/roomote',
+    ],
+    ['vendor-independent native app callback', 'example-app:/oauth/callback'],
+    [
+      'native app callback with registered query state',
+      'example-app:/oauth/callback?connection=roomote',
+    ],
   ])('accepts the %s callback', (_client, redirectUri) => {
     expect(isAllowedOAuthRedirectUri(redirectUri)).toBe(true);
   });
 
-  it('rejects unsafe or unrecognized callbacks', () => {
+  it('rejects unsafe or malformed callbacks', () => {
     expect(isAllowedOAuthRedirectUri('http://client.example/callback')).toBe(
       false,
     );
-    expect(isAllowedOAuthRedirectUri('cursor://other-client/callback')).toBe(
+    expect(isAllowedOAuthRedirectUri('http://0.0.0.0:43110/callback')).toBe(
       false,
     );
-    expect(isAllowedOAuthRedirectUri('codex://threads/new')).toBe(false);
+    expect(isAllowedOAuthRedirectUri('http://[::2]:43110/callback')).toBe(
+      false,
+    );
+    expect(isAllowedOAuthRedirectUri('example-app:callback')).toBe(false);
+    expect(isAllowedOAuthRedirectUri('example-app:/')).toBe(false);
+    expect(isAllowedOAuthRedirectUri('file:///tmp/oauth-callback')).toBe(false);
+    expect(isAllowedOAuthRedirectUri('javascript:/oauth/callback')).toBe(false);
+    expect(isAllowedOAuthRedirectUri('data:/oauth/callback')).toBe(false);
+    expect(isAllowedOAuthRedirectUri('mailto:/oauth/callback')).toBe(false);
+    expect(isAllowedOAuthRedirectUri('ssh:/oauth/callback')).toBe(false);
+    expect(isAllowedOAuthRedirectUri('c:/oauth/callback')).toBe(false);
     expect(
       isAllowedOAuthRedirectUri(
-        'codex://connector/oauth_callback?return_to=threads/new',
+        String.raw`https:\\client.example\oauth\callback`,
       ),
+    ).toBe(false);
+    expect(
+      isAllowedOAuthRedirectUri(' https://client.example/oauth/callback'),
+    ).toBe(false);
+    expect(
+      isAllowedOAuthRedirectUri(
+        'example-app://user@example.com/oauth/callback',
+      ),
+    ).toBe(false);
+    expect(
+      isAllowedOAuthRedirectUri('example-app:/oauth/callback#fragment'),
     ).toBe(false);
   });
 

--- a/apps/web/src/lib/server/mcp-remote-oauth.ts
+++ b/apps/web/src/lib/server/mcp-remote-oauth.ts
@@ -233,6 +233,9 @@ function parseRefreshToken(token: string): string | null {
 export function isAllowedOAuthRedirectUri(value: string): boolean {
   try {
     const url = new URL(value);
+    const isLoopbackCallback =
+      url.protocol === 'http:' &&
+      (url.hostname === '127.0.0.1' || url.hostname === 'localhost');
     const isCursorDesktopCallback =
       url.protocol === 'cursor:' &&
       url.hostname === 'anysphere.cursor-mcp' &&
@@ -250,8 +253,7 @@ export function isAllowedOAuthRedirectUri(value: string): boolean {
       url.username === '' &&
       url.password === '' &&
       (url.protocol === 'https:' ||
-        (url.protocol === 'http:' &&
-          (url.hostname === '127.0.0.1' || url.hostname === 'localhost')) ||
+        isLoopbackCallback ||
         isCursorDesktopCallback ||
         isCodexDesktopCallback)
     );

--- a/apps/web/src/lib/server/mcp-remote-oauth.ts
+++ b/apps/web/src/lib/server/mcp-remote-oauth.ts
@@ -239,6 +239,12 @@ export function isAllowedOAuthRedirectUri(value: string): boolean {
       url.port === '' &&
       url.pathname === '/oauth/callback' &&
       url.search === '';
+    const isCodexDesktopCallback =
+      url.protocol === 'codex:' &&
+      url.hostname === 'connector' &&
+      url.port === '' &&
+      url.pathname === '/oauth_callback' &&
+      url.search === '';
     return (
       url.hash === '' &&
       url.username === '' &&
@@ -246,7 +252,8 @@ export function isAllowedOAuthRedirectUri(value: string): boolean {
       (url.protocol === 'https:' ||
         (url.protocol === 'http:' &&
           (url.hostname === '127.0.0.1' || url.hostname === 'localhost')) ||
-        isCursorDesktopCallback)
+        isCursorDesktopCallback ||
+        isCodexDesktopCallback)
     );
   } catch {
     return false;

--- a/apps/web/src/lib/server/mcp-remote-oauth.ts
+++ b/apps/web/src/lib/server/mcp-remote-oauth.ts
@@ -234,7 +234,6 @@ const NON_NATIVE_APP_REDIRECT_SCHEMES = new Set([
   'about:',
   'blob:',
   'chrome:',
-  'chrome-extension:',
   'data:',
   'file:',
   'filesystem:',
@@ -277,12 +276,17 @@ function hasUnsafeOAuthRedirectUriCharacters(value: string): boolean {
   return false;
 }
 
+function isBrowserExtensionScheme(protocol: string): boolean {
+  return protocol === 'extension:' || protocol.endsWith('-extension:');
+}
+
 function isNativeAppOAuthRedirectUri(url: URL): boolean {
   // Native MCP clients use RFC 8252 private-use schemes to resume the app
   // after browser authorization. Treat them as a class instead of coupling
   // the authorization server to individual client callback URLs.
   return (
     !NON_NATIVE_APP_REDIRECT_SCHEMES.has(url.protocol) &&
+    !isBrowserExtensionScheme(url.protocol) &&
     url.protocol.length > 2 &&
     url.protocol.length <= 65 &&
     /^[a-z][a-z0-9+.-]*:$/.test(url.protocol) &&

--- a/apps/web/src/lib/server/mcp-remote-oauth.ts
+++ b/apps/web/src/lib/server/mcp-remote-oauth.ts
@@ -230,32 +230,83 @@ function parseRefreshToken(token: string): string | null {
     : null;
 }
 
+const NON_NATIVE_APP_REDIRECT_SCHEMES = new Set([
+  'about:',
+  'blob:',
+  'chrome:',
+  'chrome-extension:',
+  'data:',
+  'file:',
+  'filesystem:',
+  'ftp:',
+  'http:',
+  'https:',
+  'intent:',
+  'javascript:',
+  'ldap:',
+  'ldaps:',
+  'mailto:',
+  'news:',
+  'nntp:',
+  'resource:',
+  'sftp:',
+  'smb:',
+  'ssh:',
+  'tel:',
+  'telnet:',
+  'vbscript:',
+  'ws:',
+  'wss:',
+]);
+
+function isLoopbackHostname(hostname: string): boolean {
+  return (
+    hostname === 'localhost' ||
+    hostname === '[::1]' ||
+    /^127(?:\.\d{1,3}){3}$/.test(hostname)
+  );
+}
+
+function hasUnsafeOAuthRedirectUriCharacters(value: string): boolean {
+  for (const character of value) {
+    const code = character.charCodeAt(0);
+    if (code <= 0x20 || (code >= 0x7f && code <= 0x9f) || character === '\\') {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isNativeAppOAuthRedirectUri(url: URL): boolean {
+  // Native MCP clients use RFC 8252 private-use schemes to resume the app
+  // after browser authorization. Treat them as a class instead of coupling
+  // the authorization server to individual client callback URLs.
+  return (
+    !NON_NATIVE_APP_REDIRECT_SCHEMES.has(url.protocol) &&
+    url.protocol.length > 2 &&
+    url.protocol.length <= 65 &&
+    /^[a-z][a-z0-9+.-]*:$/.test(url.protocol) &&
+    url.port === '' &&
+    url.pathname.startsWith('/') &&
+    url.pathname !== '/'
+  );
+}
+
 export function isAllowedOAuthRedirectUri(value: string): boolean {
   try {
+    if (hasUnsafeOAuthRedirectUriCharacters(value)) {
+      return false;
+    }
     const url = new URL(value);
     const isLoopbackCallback =
-      url.protocol === 'http:' &&
-      (url.hostname === '127.0.0.1' || url.hostname === 'localhost');
-    const isCursorDesktopCallback =
-      url.protocol === 'cursor:' &&
-      url.hostname === 'anysphere.cursor-mcp' &&
-      url.port === '' &&
-      url.pathname === '/oauth/callback' &&
-      url.search === '';
-    const isCodexDesktopCallback =
-      url.protocol === 'codex:' &&
-      url.hostname === 'connector' &&
-      url.port === '' &&
-      url.pathname === '/oauth_callback' &&
-      url.search === '';
+      url.protocol === 'http:' && isLoopbackHostname(url.hostname);
     return (
       url.hash === '' &&
       url.username === '' &&
       url.password === '' &&
       (url.protocol === 'https:' ||
         isLoopbackCallback ||
-        isCursorDesktopCallback ||
-        isCodexDesktopCallback)
+        isNativeAppOAuthRedirectUri(url))
     );
   } catch {
     return false;


### PR DESCRIPTION
## Summary

- validate MCP OAuth callbacks by callback class instead of maintaining client-specific URL exceptions
- support HTTPS callbacks, HTTP callbacks restricted to localhost/IPv4/IPv6 loopback interfaces, and RFC 8252 native-app private URI schemes
- reject fragments, userinfo, raw control/whitespace/backslash characters, malformed native callbacks, and browser/file/generic-network schemes
- preserve exact registered-URI matching during authorization and PKCE-bound code exchange
- show the exact registered callback on the consent page and support its origin or app scheme in the consent CSP
- document the shared behavior for Claude Code, Codex, and Cursor and add a patch changeset

## Why

MCP clients choose different browser return mechanisms depending on where they run: CLIs commonly use ephemeral loopback listeners, hosted clients use HTTPS, and desktop applications may resume through a private app URI scheme. Encoding individual Cursor and Codex callback URLs in Roomote coupled the authorization server to current vendor implementation details and required a code change for every new compatible native client.

This change replaces that vendor allowlist with a standards-based callback policy. Dynamic registration remains the trust boundary: Roomote validates and stores the callback, requires an exact string match on the authorization request, presents the exact destination for explicit user consent, and only then returns a short-lived PKCE-bound code.

## Impact

Claude Code, Codex, Cursor, and other compatible MCP clients can use the callback appropriate to their runtime without new Roomote-specific URL entries. Arbitrary remote HTTP callbacks and unsafe URI classes remain rejected. IPv6 loopback clients are now supported.

## Validation

- targeted web OAuth tests: 4 files, 58 tests
- `pnpm --filter @roomote/web check-types`
- `pnpm --filter @roomote/web lint`
- `pnpm --filter @roomote/docs check`
- `pnpm lint:fast`
- `pnpm check-types:fast`
- `pnpm knip`
