### PR TITLE
[Fix] Raise web's Node heap cap to 4096MB

### DIFF
--- a/.docker/app/entrypoint.sh
+++ b/.docker/app/entrypoint.sh
@@ -104,7 +104,13 @@ case "$service" in
     # HOSTNAME env is the container id, so pin it to all interfaces.
     export HOSTNAME=0.0.0.0
     export PORT="${PORT:-3000}"
-    apply_node_heap_cap 768
+    # web serves whole-task tRPC payloads (messageEnvelopes/runEvents load a
+    # task's full history in one response), and the task page re-requests them
+    # while polling, so its heap ceiling must absorb several such responses at
+    # once — 768 was GC-thrashed to death by a single task page (2026-08-12).
+    # On memory-constrained hosts apply_node_heap_cap still clamps this to 75%
+    # of the container limit, so only boxes with more than ~5.3GB see 4096.
+    apply_node_heap_cap 4096
     cd /roomote/apps/web
     exec /roomote/.docker/run-with-dotenvx.sh node server.js "$@"
     ;;


### PR DESCRIPTION
## Problem

The app entrypoint caps every service's Node heap via `apply_node_heap_cap`; `web` gets 768MB. That was fine for a young instance but is undersized for what web actually serves: `tasks.messageEnvelopes` and `tasks.runEvents` return a task's **entire history in one response** (taskId-only input, no pagination), and the task page re-requests them while polling for sandbox readiness — so one heavy task multiplies into several full-history responses in flight at once.

On 2026-08-12 a production web hit exactly this: repeated `Reached heap limit Allocation failed` at the 768MB ceiling while a single task page was open. The preceding GC death spiral made the whole site slow for everyone on that instance (multi-second responses to trivial requests), then the process OOM'd fatally and restarted. The container had 24GB available — the process died at 3% of the machine.

## Change

One line plus a comment: `web`'s cap goes 768 → 4096.

Safety on small hosts is preserved by machinery that already exists:

- `apply_node_heap_cap` clamps to **75% of the container's cgroup limit** whenever that's lower, so a 2GB self-host box still derives ~1536MB. Only containers with more than ~5.3GB ever see 4096.
- An operator-set `--max-old-space-size` in `NODE_OPTIONS` always wins — the function returns early without touching it.

`api` / `controller` / `bullmq` are unchanged: they stream per-request data and haven't shown pressure.

## Not the root fix

The unbounded envelope/event queries are the underlying defect (a not-especially-long task can still be tens of MB of tool output per fetch). That's tracked separately — this change restores enough headroom that one task page can't take down a tenant's web while the query fix lands.

## Testing

- `bash -n` on the entrypoint.
- No CI or host tests pin the cap values (checked `deploy/ci`, `deploy/host/tests`).
- The incident tenant has been running with this exact value via a hand-set `NODE_OPTIONS` override since the incident; the affected task page loads in ~600ms with a flat heap. That override should be removed after this ships so the tenant rejoins image policy.
