### PR TITLE
feat: add X (Twitter) built-in integration

### DIFF
--- a/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
@@ -334,6 +334,59 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
     expect(body.result.ok).toBe(true);
   });
 
+  it('returns the SSE tool-call result without waiting for the stream to close', async () => {
+    // A Streamable HTTP server may keep the SSE connection open after
+    // delivering the matching response (to emit further notifications). The
+    // proxy must return the moment the id-matched frame arrives rather than
+    // block on stream closure, which would reintroduce the client-side hang.
+    mockFindTaskRun.mockResolvedValue({ id: 42, actingUserId: null });
+    mockFindConnection.mockResolvedValue({
+      id: 'conn-x',
+      userId: null,
+      authConfig: { type: 'x', encryptedBearerToken: 'encrypted-token' },
+    });
+    mockDecrypt.mockReturnValue('x-app-only-token');
+
+    let cancelled = false;
+    const neverClosingSseBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode(
+            'event: message\n' +
+              'data: {"jsonrpc":"2.0","id":11,"result":{"ok":true}}\n\n',
+          ),
+        );
+        // Deliberately never call controller.close(): simulate a server that
+        // holds the SSE channel open after responding.
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(neverClosingSseBody, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await postMcp(
+      createApp('x', createRunToken()),
+      createToolCallRequest(11, 'get_users_posts'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('application/json');
+    const body = (await response.json()) as {
+      id: number;
+      result: { ok: boolean };
+    };
+    expect(body.id).toBe(11);
+    expect(body.result.ok).toBe(true);
+    expect(cancelled).toBe(true);
+  });
+
   it('strips Resend tool schema patterns for Azure-compatible tool calls', async () => {
     mockFindTaskRun.mockResolvedValue({ id: 42, actingUserId: null });
     mockFindConnection.mockResolvedValue({ id: 'conn-1', userId: null });

--- a/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
@@ -9,11 +9,13 @@ const {
   mockFindConnection,
   mockFindEnablement,
   mockGetValidAccessToken,
+  mockDecrypt,
 } = vi.hoisted(() => ({
   mockFindTaskRun: vi.fn(),
   mockFindConnection: vi.fn(),
   mockFindEnablement: vi.fn(),
   mockGetValidAccessToken: vi.fn(),
+  mockDecrypt: vi.fn(),
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -41,6 +43,10 @@ vi.mock('@roomote/db/server', () => ({
 
 vi.mock('@roomote/sdk/server', () => ({
   getValidAccessToken: mockGetValidAccessToken,
+}));
+
+vi.mock('@roomote/db/encryption', () => ({
+  decrypt: mockDecrypt,
 }));
 
 import { createIntegrationMcpProxy } from '../integration-mcp';
@@ -71,6 +77,15 @@ function createToolsListRequest(id: number) {
     id,
     method: 'tools/list',
     params: {},
+  };
+}
+
+function createToolCallRequest(id: number, name: string) {
+  return {
+    jsonrpc: '2.0',
+    id,
+    method: 'tools/call',
+    params: { name, arguments: {} },
   };
 }
 
@@ -196,6 +211,127 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
 
     expect(response.status).toBe(200);
     expect(mockFindConnection).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards the decrypted admin-configured X bearer token upstream', async () => {
+    mockFindTaskRun.mockResolvedValue({ id: 42, actingUserId: null });
+    mockFindConnection.mockResolvedValue({
+      id: 'conn-x',
+      userId: null,
+      authConfig: { type: 'x', encryptedBearerToken: 'encrypted-token' },
+    });
+    mockDecrypt.mockReturnValue('x-app-only-token');
+    const fetchMock = stubUpstreamFetch();
+
+    const response = await postMcp(
+      createApp('x', createRunToken()),
+      createInitializeRequest(1),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockDecrypt).toHaveBeenCalledWith('encrypted-token');
+    expect(mockGetValidAccessToken).not.toHaveBeenCalled();
+
+    const upstreamHeaders = fetchMock.mock.calls[0]?.[1]?.headers as Headers;
+    expect(upstreamHeaders.get('authorization')).toBe(
+      'Bearer x-app-only-token',
+    );
+  });
+
+  it('rejects an X connection whose stored bearer token is empty', async () => {
+    mockFindTaskRun.mockResolvedValue({ id: 42, actingUserId: null });
+    mockFindConnection.mockResolvedValue({
+      id: 'conn-x',
+      userId: null,
+      authConfig: { type: 'x', encryptedBearerToken: 'encrypted-token' },
+    });
+    mockDecrypt.mockReturnValue('   ');
+
+    const response = await postMcp(
+      createApp('x', createRunToken()),
+      createInitializeRequest(1),
+    );
+    const body = (await response.json()) as JsonRpcErrorBody;
+
+    expect(response.status).toBe(404);
+    expect(body.error.message).toContain('valid credentials');
+  });
+
+  it('normalizes an SSE-framed tool-call reply into a JSON response', async () => {
+    // X's hosted MCP server answers tool calls with an SSE stream carrying the
+    // single JSON-RPC response as one `data:` frame. The proxy must re-serialize
+    // it to application/json so clients that do not consume SSE-framed POST
+    // replies (e.g. OpenCode) receive the result instead of hanging.
+    mockFindTaskRun.mockResolvedValue({ id: 42, actingUserId: null });
+    mockFindConnection.mockResolvedValue({
+      id: 'conn-x',
+      userId: null,
+      authConfig: { type: 'x', encryptedBearerToken: 'encrypted-token' },
+    });
+    mockDecrypt.mockReturnValue('x-app-only-token');
+
+    const sseBody =
+      'event: message\n' +
+      'data: {"jsonrpc":"2.0","id":7,"result":{"content":[{"type":"text","text":"{\\"data\\":[]}"}]}}\n\n';
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(sseBody, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await postMcp(
+      createApp('x', createRunToken()),
+      createToolCallRequest(7, 'get_users_posts'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('application/json');
+    const body = (await response.json()) as {
+      jsonrpc: string;
+      id: number;
+      result: { content: Array<{ type: string }> };
+    };
+    expect(body.jsonrpc).toBe('2.0');
+    expect(body.id).toBe(7);
+    expect(body.result.content[0]?.type).toBe('text');
+  });
+
+  it('ignores SSE progress frames and returns the id-matched response', async () => {
+    mockFindTaskRun.mockResolvedValue({ id: 42, actingUserId: null });
+    mockFindConnection.mockResolvedValue({
+      id: 'conn-x',
+      userId: null,
+      authConfig: { type: 'x', encryptedBearerToken: 'encrypted-token' },
+    });
+    mockDecrypt.mockReturnValue('x-app-only-token');
+
+    const sseBody =
+      'event: message\n' +
+      'data: {"jsonrpc":"2.0","method":"notifications/progress","params":{"progress":1}}\n\n' +
+      'event: message\n' +
+      'data: {"jsonrpc":"2.0","id":9,"result":{"ok":true}}\n\n';
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(sseBody, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await postMcp(
+      createApp('x', createRunToken()),
+      createToolCallRequest(9, 'search_posts_all'),
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      id: number;
+      result: { ok: boolean };
+    };
+    expect(body.id).toBe(9);
+    expect(body.result.ok).toBe(true);
   });
 
   it('strips Resend tool schema patterns for Azure-compatible tool calls', async () => {

--- a/apps/api/src/handlers/mcp/integration-mcp.ts
+++ b/apps/api/src/handlers/mcp/integration-mcp.ts
@@ -6,10 +6,12 @@ import {
   mcpConnections,
   deploymentMcpEnablements,
 } from '@roomote/db/server';
+import { decrypt } from '@roomote/db/encryption';
 import { getValidAccessToken } from '@roomote/sdk/server';
 import {
   getMcpIntegrationUpstreamUrl,
   getMcpIntegrationConnectionScope,
+  isMcpConnectionXConfig,
   type McpIntegration,
 } from '@roomote/types';
 
@@ -20,7 +22,7 @@ import {
   resolveActingUserIdOrNull,
 } from './proxy-utils';
 
-async function resolveOAuthAccessToken(
+async function resolveUpstreamAccessToken(
   mcpId: string,
   mcpUrl: string,
   userId: string | null,
@@ -54,6 +56,18 @@ async function resolveOAuthAccessToken(
   if (!connection) {
     return {
       accessToken: null,
+    };
+  }
+
+  // Admin-configured upstream integrations store a static bearer token
+  // instead of OAuth tokens; the proxy forwards it as-is.
+  if (isMcpConnectionXConfig(connection.authConfig)) {
+    const bearerToken = decrypt(
+      connection.authConfig.encryptedBearerToken,
+    ).trim();
+
+    return {
+      accessToken: bearerToken.length > 0 ? bearerToken : null,
     };
   }
 
@@ -116,7 +130,7 @@ export function createIntegrationMcpProxy(
       let accessToken: string | null;
       let disabledToolNames: string[] | null = null;
       try {
-        const resolvedConnection = await resolveOAuthAccessToken(
+        const resolvedConnection = await resolveUpstreamAccessToken(
           integration.id,
           upstreamUrl,
           actingUserId,
@@ -132,7 +146,7 @@ export function createIntegrationMcpProxy(
 
         throw new McpProxyError(
           500,
-          `Failed to resolve ${integration.name} OAuth token: ${
+          `Failed to resolve ${integration.name} credentials: ${
             error instanceof Error ? error.message : String(error)
           }`,
         );
@@ -142,8 +156,8 @@ export function createIntegrationMcpProxy(
         throw new McpProxyError(
           404,
           getMcpIntegrationConnectionScope(integration) === 'deployment'
-            ? `No active ${integration.name} connection with valid OAuth tokens found for this workspace`
-            : `No active ${integration.name} connection with valid OAuth tokens found for this user`,
+            ? `No active ${integration.name} connection with valid credentials found for this workspace`
+            : `No active ${integration.name} connection with valid credentials found for this user`,
         );
       }
 

--- a/apps/api/src/handlers/mcp/proxy-utils.ts
+++ b/apps/api/src/handlers/mcp/proxy-utils.ts
@@ -460,62 +460,109 @@ function filterToolsListPayload(
 }
 
 /**
- * Extract the single JSON-RPC response carried by an SSE-framed MCP reply.
+ * Parse a single SSE event chunk and return the JSON-RPC response it carries
+ * when that response matches the request `id` (and holds a `result`/`error`).
+ * `notifications/progress` frames carry no `id` and are skipped. Returns `null`
+ * when the event is not the matching response.
+ */
+function parseSseEventJsonRpcResponse(
+  eventChunk: string,
+  expectedId: JsonRpcRequestId,
+): unknown | null {
+  const dataText = eventChunk
+    .split(/\r?\n/)
+    .flatMap((line) =>
+      line.startsWith('data:') ? [line.slice('data:'.length).trimStart()] : [],
+    )
+    .join('\n')
+    .trim();
+
+  if (dataText.length === 0) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(dataText);
+  } catch {
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    return null;
+  }
+
+  const message = parsed as {
+    id?: unknown;
+    result?: unknown;
+    error?: unknown;
+  };
+  const hasResponsePayload = 'result' in message || 'error' in message;
+  const idMatches =
+    expectedId === null
+      ? message.id === undefined || message.id === null
+      : message.id === expectedId;
+
+  return hasResponsePayload && idMatches ? parsed : null;
+}
+
+/**
+ * Read an SSE-framed MCP reply incrementally and resolve with the JSON-RPC
+ * response whose `id` matches the request as soon as that frame arrives —
+ * without waiting for the stream to close.
  *
  * Streamable HTTP MCP servers may answer a POST request with
  * `content-type: text/event-stream`, delivering the JSON-RPC response as one
- * `data:` frame (optionally preceded by `notifications/progress` frames, which
- * carry no `id`). This returns the frame whose `id` matches the request and
- * that carries a `result` or `error`, so progress notifications are skipped.
- * Returns `null` when no matching response frame is present.
+ * `data:` frame (optionally preceded by `notifications/progress` frames). The
+ * spec allows the server to keep that SSE connection open after the response
+ * to emit further messages, so waiting for closure could hang the caller. This
+ * returns the matching response frame the moment it is seen and cancels the
+ * reader. Returns `null` if the stream ends before a matching response frame
+ * appears.
  */
-function extractSseJsonRpcResponse(
-  bodyText: string,
+async function readMatchingSseJsonRpcResponse(
+  body: ReadableStream<Uint8Array>,
   expectedId: JsonRpcRequestId,
-): unknown | null {
-  for (const chunk of bodyText.split(/\r?\n\r?\n/)) {
-    const dataText = chunk
-      .split(/\r?\n/)
-      .flatMap((line) =>
-        line.startsWith('data:')
-          ? [line.slice('data:'.length).trimStart()]
-          : [],
-      )
-      .join('\n')
-      .trim();
+): Promise<unknown | null> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
 
-    if (dataText.length === 0) {
-      continue;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+
+      if (value) {
+        buffer += decoder.decode(value, { stream: true });
+
+        for (;;) {
+          const boundary = /\r?\n\r?\n/.exec(buffer);
+          if (!boundary) {
+            break;
+          }
+
+          const eventChunk = buffer.slice(0, boundary.index);
+          buffer = buffer.slice(boundary.index + boundary[0].length);
+
+          const match = parseSseEventJsonRpcResponse(eventChunk, expectedId);
+          if (match !== null) {
+            return match;
+          }
+        }
+      }
+
+      if (done) {
+        buffer += decoder.decode();
+        return parseSseEventJsonRpcResponse(buffer, expectedId);
+      }
     }
-
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(dataText);
-    } catch {
-      continue;
-    }
-
-    if (!parsed || typeof parsed !== 'object') {
-      continue;
-    }
-
-    const message = parsed as {
-      id?: unknown;
-      result?: unknown;
-      error?: unknown;
-    };
-    const hasResponsePayload = 'result' in message || 'error' in message;
-    const idMatches =
-      expectedId === null
-        ? message.id === undefined || message.id === null
-        : message.id === expectedId;
-
-    if (hasResponsePayload && idMatches) {
-      return parsed;
-    }
+  } finally {
+    // Fire-and-forget: awaiting cancel() on a teed branch can block until the
+    // other branch drains, which would defeat the early return.
+    reader.cancel().catch(() => {
+      // Ignore cancel failures on an already-settled reader.
+    });
   }
-
-  return null;
 }
 
 class RequestBodyTooLargeError extends Error {
@@ -979,27 +1026,36 @@ export function createMcpProxy(config: McpProxyConfig) {
 
       // Some Streamable HTTP MCP servers (e.g. X) answer a POST request with an
       // SSE stream that carries the single JSON-RPC response as one `data:`
-      // frame, then close. Not every MCP client consumes an SSE-framed reply to
-      // a POST — OpenCode, for one, hangs until its request timeout and cancels
-      // the call even though the upstream already returned the result in
-      // milliseconds. Normalize such single-response SSE replies to a plain
-      // JSON body (the same shape tools/list replies are re-serialized into
-      // above) so every client can read them. Requests without an id are
-      // notifications with no response, and non-single-frame streams that carry
-      // no matching response fall through to the raw stream unchanged.
-      if (
+      // frame. Not every MCP client consumes an SSE-framed reply to a POST —
+      // OpenCode, for one, hangs until its request timeout and cancels the call
+      // even though the upstream already returned the result in milliseconds.
+      // Normalize such single-response SSE replies to a plain JSON body (the
+      // same shape tools/list replies are re-serialized into above) so every
+      // client can read them. The reply is read incrementally and returned the
+      // moment the id-matched response frame arrives, so a server that keeps
+      // the SSE connection open after responding does not stall the proxy.
+      // Requests without an id are notifications with no response, and streams
+      // that end without a matching response fall through to the raw stream.
+      const sseResponseBody =
         method === 'POST' &&
         upstreamResponse.ok &&
         contentType?.includes('text/event-stream') &&
         getJsonRpcRequestId(parsedBody) !== null &&
         !Array.isArray(parsedBody)
-      ) {
+          ? upstreamResponse.clone().body
+          : null;
+
+      if (sseResponseBody) {
         try {
-          const response = extractSseJsonRpcResponse(
-            await upstreamResponse.clone().text(),
+          const response = await readMatchingSseJsonRpcResponse(
+            sseResponseBody,
             getJsonRpcRequestId(parsedBody),
           );
           if (response) {
+            // The raw upstream body is no longer needed; cancel it to release
+            // the upstream connection instead of leaving it open.
+            upstreamResponse.body?.cancel().catch(() => {});
+
             const headers = buildProxyResponseHeaders(upstreamResponse.headers);
             headers.set('content-type', 'application/json');
 

--- a/apps/api/src/handlers/mcp/proxy-utils.ts
+++ b/apps/api/src/handlers/mcp/proxy-utils.ts
@@ -459,6 +459,65 @@ function filterToolsListPayload(
   };
 }
 
+/**
+ * Extract the single JSON-RPC response carried by an SSE-framed MCP reply.
+ *
+ * Streamable HTTP MCP servers may answer a POST request with
+ * `content-type: text/event-stream`, delivering the JSON-RPC response as one
+ * `data:` frame (optionally preceded by `notifications/progress` frames, which
+ * carry no `id`). This returns the frame whose `id` matches the request and
+ * that carries a `result` or `error`, so progress notifications are skipped.
+ * Returns `null` when no matching response frame is present.
+ */
+function extractSseJsonRpcResponse(
+  bodyText: string,
+  expectedId: JsonRpcRequestId,
+): unknown | null {
+  for (const chunk of bodyText.split(/\r?\n\r?\n/)) {
+    const dataText = chunk
+      .split(/\r?\n/)
+      .flatMap((line) =>
+        line.startsWith('data:')
+          ? [line.slice('data:'.length).trimStart()]
+          : [],
+      )
+      .join('\n')
+      .trim();
+
+    if (dataText.length === 0) {
+      continue;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(dataText);
+    } catch {
+      continue;
+    }
+
+    if (!parsed || typeof parsed !== 'object') {
+      continue;
+    }
+
+    const message = parsed as {
+      id?: unknown;
+      result?: unknown;
+      error?: unknown;
+    };
+    const hasResponsePayload = 'result' in message || 'error' in message;
+    const idMatches =
+      expectedId === null
+        ? message.id === undefined || message.id === null
+        : message.id === expectedId;
+
+    if (hasResponsePayload && idMatches) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
 class RequestBodyTooLargeError extends Error {
   constructor(readonly observedBytes: number) {
     super('Request body exceeds the configured limit');
@@ -916,6 +975,42 @@ export function createMcpProxy(config: McpProxyConfig) {
           status: upstreamResponse.status,
           headers: buildProxyResponseHeaders(upstreamResponse.headers),
         });
+      }
+
+      // Some Streamable HTTP MCP servers (e.g. X) answer a POST request with an
+      // SSE stream that carries the single JSON-RPC response as one `data:`
+      // frame, then close. Not every MCP client consumes an SSE-framed reply to
+      // a POST — OpenCode, for one, hangs until its request timeout and cancels
+      // the call even though the upstream already returned the result in
+      // milliseconds. Normalize such single-response SSE replies to a plain
+      // JSON body (the same shape tools/list replies are re-serialized into
+      // above) so every client can read them. Requests without an id are
+      // notifications with no response, and non-single-frame streams that carry
+      // no matching response fall through to the raw stream unchanged.
+      if (
+        method === 'POST' &&
+        upstreamResponse.ok &&
+        contentType?.includes('text/event-stream') &&
+        getJsonRpcRequestId(parsedBody) !== null &&
+        !Array.isArray(parsedBody)
+      ) {
+        try {
+          const response = extractSseJsonRpcResponse(
+            await upstreamResponse.clone().text(),
+            getJsonRpcRequestId(parsedBody),
+          );
+          if (response) {
+            const headers = buildProxyResponseHeaders(upstreamResponse.headers);
+            headers.set('content-type', 'application/json');
+
+            return new Response(JSON.stringify(response), {
+              status: upstreamResponse.status,
+              headers,
+            });
+          }
+        } catch {
+          // Fall through to streaming the raw upstream response.
+        }
       }
 
       return new Response(

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -156,6 +156,7 @@
           "integrations/supabase",
           "integrations/supermemory",
           "integrations/vercel",
+          "integrations/x",
           "integrations/zero"
         ]
       },

--- a/apps/docs/integrations/index.mdx
+++ b/apps/docs/integrations/index.mdx
@@ -70,6 +70,7 @@ from [Personal Settings](/personal-settings).
 | <IntegrationName href="/integrations/supabase" icon="supabase" name="Supabase" />                                 | Read-only database access in Supabase             | Enable first, then teammates link accounts |
 | <IntegrationName href="/integrations/supermemory" icon="/logo/integrations/supermemory.svg" name="Supermemory" /> | Shared memory context across tasks                | Admin connection once                      |
 | <IntegrationName href="/integrations/vercel" icon="vercel" name="Vercel" />                                       | Deployments, logs, and domain availability        | Admin connection once                      |
+| <IntegrationName href="/integrations/x" icon="x" name="X" />                                                      | Public X posts, users, trends, and news           | Admin connection once                      |
 | <IntegrationName href="/integrations/zero" icon="/logo/integrations/zero.svg" name="Zero" />                      | Paid external capabilities via Zero               | Admin connection once                      |
 
 ## Custom MCP servers

--- a/apps/docs/integrations/x.mdx
+++ b/apps/docs/integrations/x.mdx
@@ -1,0 +1,36 @@
+---
+title: X
+description: Let Roomote search public X posts and look up users, trends, and news during a task.
+icon: 'https://api.iconify.design/simple-icons:x.svg?color=currentColor'
+---
+
+Connect X when Roomote needs public X context: what people are saying about a
+launch, a thread someone pasted into Slack, an account's recent posts, or
+what's trending.
+
+## When to use it
+
+- Pull a pasted X post or thread into task context without leaving the thread
+- Search recent public posts while investigating feedback, sentiment, or an
+  incident
+- Look up accounts, their posts, and follower context during research tasks
+- Read trends, news, lists, Spaces, and community data
+
+## How setup works
+
+Admins connect X from **Settings > Integrations** with an app-only bearer
+token from the [X Developer Console](https://console.x.com/): go to **Apps**,
+open your app, then generate the Bearer Token from its **Keys and tokens**
+tab. One deployment-wide connection covers every task.
+
+What the token can read depends on your X API plan: recent post search is
+broadly available, while full-archive search and some other endpoints require
+higher tiers.
+
+## What to expect
+
+The X integration is read-only public data by design. App-only bearer tokens
+cannot act as a user, so posting, bookmarks, DMs, and other account actions
+are not available, and Roomote additionally restricts the tool list to
+read-only operations. If a task needs an unavailable X capability, Roomote
+will say so rather than attempt it.

--- a/apps/web/src/components/settings/Integrations.test.tsx
+++ b/apps/web/src/components/settings/Integrations.test.tsx
@@ -50,6 +50,9 @@ const state = vi.hoisted(() => ({
     authStatus?: string | null;
     defaultTeamIdOrSlug?: string;
   },
+  xConnection: null as null | {
+    authStatus?: string | null;
+  },
   isAdmin: true,
   snowflakeConnection: null as null | {
     authStatus?: string | null;
@@ -103,6 +106,7 @@ const { mutations, selectMock } = vi.hoisted(() => ({
     saveGrafanaConnection: vi.fn(),
     saveSnowflakeConnection: vi.fn(),
     saveVercelConnection: vi.fn(),
+    saveXConnection: vi.fn(),
     saveLinearOauthSetup: vi.fn(),
     removeLinearOauthSetup: vi.fn(),
   },
@@ -289,6 +293,14 @@ vi.mock('@/hooks/mcp-connections', () => ({
   }),
   useVercelConnection: () => ({
     data: state.vercelConnection,
+    isPending: false,
+  }),
+  useSaveXConnection: () => ({
+    isPending: false,
+    mutate: mutations.saveXConnection,
+  }),
+  useXConnection: () => ({
+    data: state.xConnection,
     isPending: false,
   }),
 }));
@@ -479,6 +491,7 @@ describe('Integrations settings', () => {
     state.granolaConnection = null;
     state.grafanaConnection = null;
     state.vercelConnection = null;
+    state.xConnection = null;
     state.isAdmin = true;
     state.snowflakeConnection = null;
     state.searchParams = '';
@@ -850,6 +863,7 @@ describe('Integrations settings', () => {
       'Supabase',
       'Supermemory',
       'Vercel',
+      'X',
       'Zero',
     ]);
     expect(
@@ -1406,9 +1420,12 @@ describe('Integrations settings', () => {
     expect(accessTokenInput.tagName).toBe('INPUT');
     expect(
       screen.getByText(
-        'Works with both Personal Access Tokens and Service Account tokens. Generate a PAT in Asana at https://app.asana.com/0/my-apps.',
+        /Works with both Personal Access Tokens and Service Account tokens/,
       ),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'app.asana.com/0/my-apps' }),
+    ).toHaveAttribute('href', 'https://app.asana.com/0/my-apps');
   });
 
   it('opens the Grafana credential dialog from the integrations page', () => {
@@ -1762,6 +1779,65 @@ describe('Integrations settings', () => {
     expect(
       screen.getByLabelText('Default Team ID or Slug (optional)'),
     ).toHaveValue('team_123');
+    expect(
+      screen.getByText('Leave blank to keep the existing token.'),
+    ).toBeInTheDocument();
+  });
+
+  it('submits an X bearer token from the dialog', () => {
+    render(<Integrations />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Configure X' }));
+
+    expect(
+      screen.getByRole('heading', { name: 'Connect X' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'console.x.com' })).toHaveAttribute(
+      'href',
+      'https://console.x.com/',
+    );
+
+    fireEvent.change(screen.getByLabelText('X App-only Bearer Token'), {
+      target: { value: 'AAAA-x-app-only-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Connect X' }));
+
+    expect(mutations.saveXConnection).toHaveBeenCalledWith(
+      {
+        bearerToken: 'AAAA-x-app-only-token',
+      },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }),
+    );
+  });
+
+  it('shows X connected controls and supports editing', () => {
+    state.deploymentEnablements = [{ mcpId: 'x', enabled: true }];
+    state.userConnections = [
+      {
+        mcpId: 'x',
+        authStatus: 'authenticated',
+      },
+    ];
+    state.xConnection = {
+      authStatus: 'authenticated',
+    };
+
+    render(<Integrations />);
+
+    expect(
+      screen.getByRole('button', { name: 'Edit X connection' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Disconnect X' }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit X connection' }));
+
+    expect(screen.getByRole('heading', { name: 'Edit X' })).toBeInTheDocument();
+    expect(screen.getByLabelText('X App-only Bearer Token')).toHaveValue('');
     expect(
       screen.getByText('Leave blank to keep the existing token.'),
     ).toBeInTheDocument();

--- a/apps/web/src/components/settings/Integrations.tsx
+++ b/apps/web/src/components/settings/Integrations.tsx
@@ -34,10 +34,12 @@ import {
   useSaveElevenLabsConnection,
   useSaveSnowflakeConnection,
   useSaveVercelConnection,
+  useSaveXConnection,
   useSetDeploymentMcpEnabled,
   useSnowflakeConnection,
   useUserMcpConnections,
   useVercelConnection,
+  useXConnection,
 } from '@/hooks/mcp-connections';
 import { useAuthorizedUser } from '@/hooks/useUser';
 import {
@@ -53,6 +55,7 @@ import {
   saveElevenLabsConnectionSchema,
   saveSnowflakeConnectionSchema,
   saveVercelConnectionSchema,
+  saveXConnectionSchema,
 } from '@/types';
 
 import {
@@ -119,6 +122,7 @@ const DEEP_LINK_ENABLE_DESCRIPTIONS: Record<string, string> = {
     'Roomote will be able to save shared memories and recall context from earlier tasks.',
   vercel:
     'Roomote will be able to inspect Vercel teams, projects, deployments, logs, and domain availability.',
+  x: 'Roomote will be able to search public X posts and look up users, trends, and news. The app-only token is read-only; posting and other account actions stay unavailable.',
   zero: 'Roomote will be able to authenticate the workspace Zero connection so agents can discover and pay for external capabilities.',
 };
 
@@ -198,6 +202,10 @@ type VercelFormState = {
   defaultTeamIdOrSlug: string;
 };
 
+type XFormState = {
+  bearerToken: string;
+};
+
 type VercelConnectionData = {
   authStatus?: 'pending' | 'authenticated' | 'error' | null;
   defaultTeamIdOrSlug?: string;
@@ -261,6 +269,26 @@ function buildEmptyVercelForm(): VercelFormState {
   return {
     accessToken: '',
     defaultTeamIdOrSlug: '',
+  };
+}
+
+function buildEmptyXForm(): XFormState {
+  return {
+    bearerToken: '',
+  };
+}
+
+function getXFieldErrors(
+  result: ReturnType<typeof saveXConnectionSchema.safeParse>,
+): Partial<Record<keyof XFormState, string[]>> {
+  if (result.success) {
+    return {};
+  }
+
+  const fieldErrors = result.error.flatten().fieldErrors;
+
+  return {
+    bearerToken: fieldErrors.bearerToken,
   };
 }
 
@@ -782,7 +810,16 @@ function AsanaConnectionFields({
         />
         <p className="text-sm text-muted-foreground">
           Works with both Personal Access Tokens and Service Account tokens.
-          Generate a PAT in Asana at https://app.asana.com/0/my-apps.
+          Generate a PAT in Asana at{' '}
+          <a
+            href="https://app.asana.com/0/my-apps"
+            target="_blank"
+            rel="noreferrer"
+            className="text-primary underline hover:no-underline"
+          >
+            app.asana.com/0/my-apps
+          </a>
+          .
         </p>
         {allowBlankToken ? (
           <p className="text-sm text-muted-foreground">
@@ -792,6 +829,71 @@ function AsanaConnectionFields({
         {fieldErrors.accessToken ? (
           <p className="text-sm text-destructive">
             {fieldErrors.accessToken[0]}
+          </p>
+        ) : null}
+      </div>
+      {formError ? (
+        <p className="text-sm text-destructive">{formError}</p>
+      ) : null}
+    </>
+  );
+}
+
+function XConnectionFields({
+  form,
+  fieldErrors,
+  formError,
+  allowBlankToken,
+  onFieldChange,
+}: {
+  form: XFormState;
+  fieldErrors: Partial<Record<keyof XFormState, string[]>>;
+  formError: string | null;
+  allowBlankToken: boolean;
+  onFieldChange: (field: keyof XFormState, value: string) => void;
+}) {
+  const fieldClassName =
+    'mt-2 w-full border-border/70 bg-background data-[invalid=true]:border-destructive';
+
+  return (
+    <>
+      <div className="space-y-2">
+        <Label htmlFor="x-bearer-token">X App-only Bearer Token</Label>
+        <Input
+          id="x-bearer-token"
+          type="password"
+          placeholder="AAAAAAAAAAAAAAAAAAAAA..."
+          value={form.bearerToken}
+          onChange={(event) => onFieldChange('bearerToken', event.target.value)}
+          data-invalid={fieldErrors.bearerToken ? 'true' : undefined}
+          className={fieldClassName}
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
+          data-1p-ignore
+        />
+        <p className="text-sm text-muted-foreground">
+          Generate it at{' '}
+          <a
+            href="https://console.x.com/"
+            target="_blank"
+            rel="noreferrer"
+            className="text-primary underline hover:no-underline"
+          >
+            console.x.com
+          </a>{' '}
+          under Apps, in your app&apos;s Keys and tokens tab. App-only bearer
+          tokens give read-only access to public X data; posting and other
+          account actions stay unavailable. Access depends on your X API plan.
+        </p>
+        {allowBlankToken ? (
+          <p className="text-sm text-muted-foreground">
+            Leave blank to keep the existing token.
+          </p>
+        ) : null}
+        {fieldErrors.bearerToken ? (
+          <p className="text-sm text-destructive">
+            {fieldErrors.bearerToken[0]}
           </p>
         ) : null}
       </div>
@@ -1176,6 +1278,12 @@ export function Integrations() {
     Partial<Record<keyof VercelFormState, string[]>>
   >({});
   const [vercelFormError, setVercelFormError] = useState<string | null>(null);
+  const [isXDialogOpen, setIsXDialogOpen] = useState(false);
+  const [xForm, setXForm] = useState<XFormState>(buildEmptyXForm());
+  const [xFieldErrors, setXFieldErrors] = useState<
+    Partial<Record<keyof XFormState, string[]>>
+  >({});
+  const [xFormError, setXFormError] = useState<string | null>(null);
   const [toolDialogState, setToolDialogState] = useState<{
     mcpId: string;
     integrationName: string;
@@ -1207,6 +1315,7 @@ export function Integrations() {
   const saveElevenLabsConnection = useSaveElevenLabsConnection();
   const saveSnowflakeConnection = useSaveSnowflakeConnection();
   const saveVercelConnection = useSaveVercelConnection();
+  const saveXConnection = useSaveXConnection();
   const asanaConnectionSummary = useMemo(() => {
     const connection = (userMcpConnections.data ?? []).find(
       (entry) => entry.mcpId === 'asana',
@@ -1278,6 +1387,17 @@ export function Integrations() {
     vercelConnectionSummary?.authStatus === 'authenticated';
   const vercelConnection = useVercelConnection(
     isAdmin && (isVercelConnected || isVercelDialogOpen),
+  );
+  const xConnectionSummary = useMemo(() => {
+    const connection = (userMcpConnections.data ?? []).find(
+      (entry) => entry.mcpId === 'x',
+    );
+
+    return connection;
+  }, [userMcpConnections.data]);
+  const isXConnected = xConnectionSummary?.authStatus === 'authenticated';
+  const xConnection = useXConnection(
+    isAdmin && (isXConnected || isXDialogOpen),
   );
   const allowsBlankSnowflakePrivateKey =
     snowflakeConnection.data?.authMethod === 'key_pair';
@@ -1404,6 +1524,20 @@ export function Integrations() {
     vercelConnection.data,
     vercelConnection.isPending,
   ]);
+
+  useEffect(() => {
+    if (!isXDialogOpen) {
+      return;
+    }
+
+    if (xConnection.isPending && isXConnected) {
+      return;
+    }
+
+    setXFieldErrors({});
+    setXFormError(null);
+    setXForm(buildEmptyXForm());
+  }, [isXConnected, isXDialogOpen, xConnection.isPending]);
 
   const items = useMemo<IntegrationItem[]>(() => {
     const visibleMcpIntegrations = MCP_INTEGRATIONS;
@@ -1663,6 +1797,26 @@ export function Integrations() {
             });
           }
 
+          if (integration.id === 'x') {
+            return buildAdminConfiguredIntegrationItem({
+              integration,
+              connection: userConnectionMap.get(integration.id),
+              orgEnabled: orgEnablementMap.get(integration.id) ?? false,
+              highlightedIntegrationId,
+              savePending: saveXConnection.isPending,
+              disconnectPending: disconnectMcp.isPending,
+              disconnectingMcpId: disconnectMcp.variables?.mcpId,
+              dialogOpen: isXDialogOpen,
+              connectionPending: xConnection.isPending,
+              canConfigure: isAdmin,
+              canManageTools: isAdmin,
+              openDialog: () => setIsXDialogOpen(true),
+              openToolDialog: () => openMcpToolDialog(integration),
+              disconnectIntegration: () =>
+                disconnectAdminConfiguredIntegration(integration),
+            });
+          }
+
           const enabled = orgEnablementMap.get(integration.id) ?? false;
           const isDeploymentScoped =
             isDeploymentScopedMcpIntegration(integration);
@@ -1831,6 +1985,9 @@ export function Integrations() {
     isSnowflakeDialogOpen,
     vercelConnection.isPending,
     isVercelDialogOpen,
+    saveXConnection.isPending,
+    xConnection.isPending,
+    isXDialogOpen,
     highlightedIntegrationId,
     userMcpConnections.data,
   ]);
@@ -1979,6 +2136,67 @@ export function Integrations() {
       return { ...current, [field]: undefined };
     });
     setVercelFormError(null);
+  };
+
+  const handleXFieldChange = (field: keyof XFormState, value: string) => {
+    setXForm((current) => ({ ...current, [field]: value }));
+    setXFieldErrors((current) => {
+      if (!current[field]) {
+        return current;
+      }
+
+      return { ...current, [field]: undefined };
+    });
+    setXFormError(null);
+  };
+
+  const handleXDialogOpenChange = (open: boolean) => {
+    setIsXDialogOpen(open);
+
+    setXFieldErrors({});
+    setXFormError(null);
+
+    if (!open) {
+      return;
+    }
+
+    setXForm(buildEmptyXForm());
+  };
+
+  const handleXSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const parsed = saveXConnectionSchema.safeParse({
+      bearerToken: xForm.bearerToken,
+    });
+    if (!parsed.success) {
+      setXFieldErrors(getXFieldErrors(parsed));
+      return;
+    }
+
+    if (!isXConnected && parsed.data.bearerToken.length === 0) {
+      setXFieldErrors({
+        bearerToken: ['Bearer token is required'],
+      });
+      return;
+    }
+
+    setXFieldErrors({});
+    setXFormError(null);
+
+    saveXConnection.mutate(parsed.data, {
+      onSuccess: () => {
+        toast.success(
+          isXConnected
+            ? 'X connection updated for this deployment.'
+            : 'X connected for this deployment.',
+        );
+        handleXDialogOpenChange(false);
+      },
+      onError: (error) => {
+        setXFormError(error.message);
+      },
+    });
   };
 
   const handleAsanaDialogOpenChange = (open: boolean) => {
@@ -2477,6 +2695,29 @@ export function Integrations() {
           formError={vercelFormError}
           allowBlankToken={isVercelConnected}
           onFieldChange={handleVercelFieldChange}
+        />
+      </AdminConfiguredIntegrationDialog>
+      <AdminConfiguredIntegrationDialog
+        integrationName="X"
+        open={isXDialogOpen}
+        onOpenChange={handleXDialogOpenChange}
+        isEditing={isXConnected}
+        isPending={saveXConnection.isPending}
+        isLoading={isXConnected && xConnection.isPending}
+        description={
+          <>
+            Store the workspace X app-only bearer token for read-only Roomote
+            tasks. Secrets stay encrypted server-side.
+          </>
+        }
+        onSubmit={handleXSubmit}
+      >
+        <XConnectionFields
+          form={xForm}
+          fieldErrors={xFieldErrors}
+          formError={xFormError}
+          allowBlankToken={isXConnected}
+          onFieldChange={handleXFieldChange}
         />
       </AdminConfiguredIntegrationDialog>
       <DeepLinkEnableDialog

--- a/apps/web/src/components/system/custom/logos/brand-icon.tsx
+++ b/apps/web/src/components/system/custom/logos/brand-icon.tsx
@@ -28,6 +28,7 @@ import {
   siSupabase,
   siTelegram,
   siVercel,
+  siX,
   type SimpleIcon,
 } from 'simple-icons';
 
@@ -65,6 +66,7 @@ const SIMPLE_ICONS: Record<string, SimpleIcon> = {
   telegram: siTelegram,
   sentry: siSentry,
   vercel: siVercel,
+  x: siX,
 };
 
 function NeonIcon({

--- a/apps/web/src/hooks/mcp-connections/index.ts
+++ b/apps/web/src/hooks/mcp-connections/index.ts
@@ -21,4 +21,6 @@ export { useSnowflakeConnection } from './useSnowflakeConnection';
 export { useGrafanaConnection } from './useGrafanaConnection';
 export { useSaveVercelConnection } from './useSaveVercelConnection';
 export { useVercelConnection } from './useVercelConnection';
+export { useSaveXConnection } from './useSaveXConnection';
+export { useXConnection } from './useXConnection';
 export { useSetDisabledMcpTools } from './useSetDisabledMcpTools';

--- a/apps/web/src/hooks/mcp-connections/useSaveXConnection.ts
+++ b/apps/web/src/hooks/mcp-connections/useSaveXConnection.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { useTRPC } from '@/trpc/client';
+
+export function useSaveXConnection() {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    trpc.mcpConnections.saveXConnection.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: trpc.mcpConnections.deploymentEnablements.queryKey(),
+        });
+        queryClient.invalidateQueries({
+          queryKey: trpc.mcpConnections.userConnections.queryKey(),
+        });
+        queryClient.invalidateQueries({
+          queryKey: trpc.mcpConnections.xConnection.queryKey(),
+        });
+      },
+    }),
+  );
+}

--- a/apps/web/src/hooks/mcp-connections/useXConnection.ts
+++ b/apps/web/src/hooks/mcp-connections/useXConnection.ts
@@ -1,0 +1,14 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { useTRPC } from '@/trpc/client';
+
+export function useXConnection(enabled = true) {
+  const trpc = useTRPC();
+
+  return useQuery({
+    ...trpc.mcpConnections.xConnection.queryOptions(),
+    enabled,
+  });
+}

--- a/apps/web/src/trpc/commands/mcp-connections/index.ts
+++ b/apps/web/src/trpc/commands/mcp-connections/index.ts
@@ -22,6 +22,7 @@ import {
   isMcpConnectionGrafanaConfig,
   isMcpConnectionSnowflakeConfig,
   isMcpConnectionVercelConfig,
+  isMcpConnectionXConfig,
   isSelfServeMcpIntegration,
   isMcpToolAllowed,
   isDeploymentScopedMcpIntegration,
@@ -31,7 +32,7 @@ import {
   type McpToolsListJsonRpcPayload,
   parseMcpJsonRpcPayload,
 } from '@roomote/types';
-import { encrypt } from '@roomote/db/encryption';
+import { decrypt, encrypt } from '@roomote/db/encryption';
 import { getValidAccessToken } from '@roomote/sdk/server';
 
 import type { UserAuthSuccess } from '@/types';
@@ -47,6 +48,7 @@ import type {
   SaveGrafanaConnectionInput,
   SaveSnowflakeConnectionInput,
   SaveVercelConnectionInput,
+  SaveXConnectionInput,
 } from '@/types';
 
 type LegacySnowflakePasswordInput = Omit<
@@ -187,6 +189,33 @@ async function getVisibleMcpConnectionForToolCatalog(
   return connection;
 }
 
+/**
+ * Resolve the bearer credential used to list an upstream integration's tool
+ * catalog. Admin-configured upstream integrations (X) store a static
+ * encrypted bearer token; everything else resolves OAuth tokens.
+ */
+async function resolveUpstreamCatalogAccessToken(
+  connectionId: string,
+  integrationUrl: string,
+): Promise<string | null> {
+  const connection = await db.query.mcpConnections.findFirst({
+    where: eq(mcpConnections.id, connectionId),
+    columns: {
+      authConfig: true,
+    },
+  });
+
+  if (isMcpConnectionXConfig(connection?.authConfig)) {
+    const bearerToken = decrypt(
+      connection.authConfig.encryptedBearerToken,
+    ).trim();
+
+    return bearerToken.length > 0 ? bearerToken : null;
+  }
+
+  return (await getValidAccessToken(connectionId, integrationUrl)) ?? null;
+}
+
 async function fetchUpstreamMcpTools(input: {
   id: string;
   mcpId: string;
@@ -205,7 +234,10 @@ async function fetchUpstreamMcpTools(input: {
     );
   }
 
-  const accessToken = await getValidAccessToken(input.id, integrationUrl);
+  const accessToken = await resolveUpstreamCatalogAccessToken(
+    input.id,
+    integrationUrl,
+  );
   if (!accessToken) {
     throw new Error(
       `${resolvedIntegration.name} needs to be reconnected before tools can be managed.`,
@@ -802,6 +834,26 @@ export async function getElevenLabsConnectionCommand(auth: UserAuthSuccess) {
   };
 }
 
+export async function getXConnectionCommand(auth: UserAuthSuccess) {
+  assertAdmin(auth);
+
+  const connection = await db.query.mcpConnections.findFirst({
+    where: and(eq(mcpConnections.mcpId, 'x'), isNull(mcpConnections.userId)),
+    columns: {
+      authConfig: true,
+      authStatus: true,
+    },
+  });
+
+  if (!connection || !isMcpConnectionXConfig(connection.authConfig)) {
+    return null;
+  }
+
+  return {
+    authStatus: connection.authStatus,
+  };
+}
+
 export async function getVercelConnectionCommand(
   auth: UserAuthSuccess,
 ): Promise<VercelConnectionData | null> {
@@ -1240,6 +1292,85 @@ export async function saveElevenLabsConnectionCommand(
     .insert(deploymentMcpEnablements)
     .values({
       mcpId: 'elevenlabs',
+      enabled: true,
+      enabledByUserId: auth.userId,
+    })
+    .onConflictDoUpdate({
+      target: [deploymentMcpEnablements.mcpId],
+      set: {
+        enabled: true,
+        enabledByUserId: auth.userId,
+        updatedAt: new Date(),
+      },
+    });
+
+  return {
+    authStatus: 'authenticated' as const,
+  };
+}
+
+export async function saveXConnectionCommand(
+  auth: UserAuthSuccess,
+  input: SaveXConnectionInput,
+) {
+  assertAdmin(auth);
+  assertCuratedIntegrationsEnabled();
+
+  const existingConnection = await db.query.mcpConnections.findFirst({
+    where: and(eq(mcpConnections.mcpId, 'x'), isNull(mcpConnections.userId)),
+    columns: {
+      authConfig: true,
+    },
+  });
+
+  const existingConfig = isMcpConnectionXConfig(existingConnection?.authConfig)
+    ? existingConnection.authConfig
+    : null;
+  const nextEncryptedBearerToken =
+    input.bearerToken.length > 0
+      ? encrypt(input.bearerToken)
+      : existingConfig?.encryptedBearerToken;
+
+  if (!nextEncryptedBearerToken) {
+    throw new Error(
+      'X bearer token is required when no X token is already stored.',
+    );
+  }
+
+  const authConfig = {
+    type: 'x' as const,
+    encryptedBearerToken: nextEncryptedBearerToken,
+  };
+
+  await db
+    .insert(mcpConnections)
+    .values({
+      userId: null,
+      mcpId: 'x',
+      connectionRole: 'default',
+      authConfig,
+      enabled: true,
+      authStatus: 'authenticated',
+    })
+    .onConflictDoUpdate({
+      target: [
+        mcpConnections.userId,
+        mcpConnections.mcpId,
+        mcpConnections.connectionRole,
+      ],
+      set: {
+        connectionRole: 'default',
+        authConfig,
+        enabled: true,
+        authStatus: 'authenticated',
+        updatedAt: new Date(),
+      },
+    });
+
+  await db
+    .insert(deploymentMcpEnablements)
+    .values({
+      mcpId: 'x',
       enabled: true,
       enabledByUserId: auth.userId,
     })

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -44,6 +44,7 @@ import {
   saveGrafanaConnectionSchema,
   saveSnowflakeConnectionSchema,
   saveVercelConnectionSchema,
+  saveXConnectionSchema,
   timePeriodFilterSchema,
   PERSONAL_COLOR_THEMES,
 } from '@/types';
@@ -206,6 +207,7 @@ import {
   getGrafanaConnectionCommand,
   getSnowflakeConnectionCommand,
   getVercelConnectionCommand,
+  getXConnectionCommand,
   listDeploymentMcpIntegrationToolsCommand,
   saveAsanaConnectionCommand,
   saveGranolaConnectionCommand,
@@ -213,6 +215,7 @@ import {
   saveGrafanaConnectionCommand,
   saveSnowflakeConnectionCommand,
   saveVercelConnectionCommand,
+  saveXConnectionCommand,
   setDeploymentDisabledMcpIntegrationToolsCommand,
   connectMcpCommand,
   disconnectMcpCommand,
@@ -1723,6 +1726,10 @@ export const appRouter = createRouter({
       getVercelConnectionCommand(auth),
     ),
 
+    xConnection: protectedProcedure.query(({ ctx: { auth } }) =>
+      getXConnectionCommand(auth),
+    ),
+
     listTools: protectedProcedure
       .input(z.object({ mcpId: z.string() }))
       .query(({ ctx: { auth }, input }) =>
@@ -1799,6 +1806,12 @@ export const appRouter = createRouter({
       .input(saveVercelConnectionSchema)
       .mutation(({ ctx: { auth }, input }) =>
         saveVercelConnectionCommand(auth, input),
+      ),
+
+    saveXConnection: protectedProcedure
+      .input(saveXConnectionSchema)
+      .mutation(({ ctx: { auth }, input }) =>
+        saveXConnectionCommand(auth, input),
       ),
   }),
 

--- a/apps/web/src/types/mcp-connections.ts
+++ b/apps/web/src/types/mcp-connections.ts
@@ -69,6 +69,12 @@ export type SaveVercelConnectionInput = z.infer<
   typeof saveVercelConnectionSchema
 >;
 
+export const saveXConnectionSchema = z.object({
+  bearerToken: z.string().transform((value) => value.trim()),
+});
+
+export type SaveXConnectionInput = z.infer<typeof saveXConnectionSchema>;
+
 export const saveGrafanaConnectionSchema = z.object({
   baseUrl: z
     .string()

--- a/apps/worker/src/mcp/roomote-mcp-server/integration-setup.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/integration-setup.ts
@@ -143,6 +143,14 @@ Vercel uses an admin-managed access token:
 
 The admin can also save an optional default team ID or slug so project and deployment tools stay scoped to the shared workspace by default. Once connected, I can inspect teams, projects, deployments, logs, and domain availability during tasks.
 
+# X
+
+X uses an admin-managed app-only bearer token:
+1. A deployment operator enables X from Settings > Integrations.
+2. That operator connects X once for the deployment with an app-only bearer token from the X Developer Console (https://console.x.com/, under Apps, in the app's Keys and tokens tab).
+
+Once connected, I can search public posts, look up users and their posts, and read trends, news, lists, Spaces, and community context. App-only tokens are read-only public data: posting, bookmarks, DMs, and other account actions are not available, and access depends on the deployment's X API plan.
+
 # Supermemory
 
 Supermemory uses OAuth:

--- a/packages/cloud-agents/src/server/mcp-self-setup/catalog.ts
+++ b/packages/cloud-agents/src/server/mcp-self-setup/catalog.ts
@@ -172,6 +172,13 @@ export const MCP_SETUP_INTEGRATION_METADATA: Record<
       'Configure once per deployment with a text-to-speech-scoped key',
     ],
   },
+  x: {
+    capabilities: [
+      'Search public X posts and pull post context into tasks',
+      'Look up users, their posts, and follower context',
+      'Read trends, news, lists, Spaces, and community data (read-only)',
+    ],
+  },
   supermemory: {
     capabilities: [
       'Save important decisions and context as shared memories during tasks',

--- a/packages/cloud-agents/src/server/router/__tests__/slack-mcp-setup-matching.test.ts
+++ b/packages/cloud-agents/src/server/router/__tests__/slack-mcp-setup-matching.test.ts
@@ -54,6 +54,32 @@ describe('matchSlackMcpSetupService', () => {
     });
   });
 
+  describe('x', () => {
+    it.each([
+      'https://x.com/roomote/status/1234567890123456789',
+      'https://www.x.com/someone/status/42',
+      'https://twitter.com/roomote/status/1234567890123456789',
+      'https://x.com/search?q=roomote',
+      'https://x.com/explore',
+      'https://x.com/i/lists/123456',
+      'https://x.com/i/communities/98765',
+    ])('matches the X app surface %s', (url) => {
+      expect(matchServiceIdForUrl(url)).toBe('x');
+    });
+
+    it.each([
+      'https://x.com/',
+      'https://x.com/roomote',
+      'https://x.com/tos',
+      'https://developer.x.com/en/docs/x-api',
+      'https://docs.x.com/tools/mcp',
+      'https://api.x.com/mcp',
+      'https://twitter.com/home',
+    ])('does not match the non-content X page %s', (url) => {
+      expect(matchServiceIdForUrl(url)).toBeNull();
+    });
+  });
+
   describe('other services stay unaffected', () => {
     it.each([
       ['https://linear.app/acme/issue/OPS-123', 'linear'],

--- a/packages/sdk/src/server/routers/mcp-connections.ts
+++ b/packages/sdk/src/server/routers/mcp-connections.ts
@@ -31,6 +31,7 @@ import {
   isMcpConnectionOAuthConfig,
   isMcpConnectionSnowflakeConfig,
   isMcpConnectionVercelConfig,
+  isMcpConnectionXConfig,
   isDeploymentScopedMcpIntegration,
   CUSTOM_MCP_PROXY_PATH_PREFIX,
   customMcpConnectionId,
@@ -492,7 +493,8 @@ async function buildCuratedMcpServerConfigs(ctx: {
         isMcpConnectionAsanaConfig(authConfig) ||
         isMcpConnectionGranolaConfig(authConfig) ||
         isMcpConnectionVercelConfig(authConfig) ||
-        isMcpConnectionGrafanaConfig(authConfig)
+        isMcpConnectionGrafanaConfig(authConfig) ||
+        isMcpConnectionXConfig(authConfig)
       ) {
         servers[connection.mcpId] = {
           url: buildProxyUrl(connection.mcpId, requestOrigin),

--- a/packages/slack/src/mcp-recommendations.ts
+++ b/packages/slack/src/mcp-recommendations.ts
@@ -66,6 +66,7 @@ const SLACK_ENABLE_DESCRIPTIONS: Record<string, string> = {
     'Your team will be able to launch and continue tasks from Slack threads.',
   vercel:
     'Roomote will be able to inspect Vercel teams, projects, deployments, logs, and domain availability.',
+  x: 'Roomote will be able to search public X posts and look up users, trends, and news through a read-only app token.',
   zero: 'Roomote will be able to authenticate the workspace Zero connection so agents can discover and pay for external capabilities.',
 };
 

--- a/packages/types/src/__tests__/mcp-tool-policy.test.ts
+++ b/packages/types/src/__tests__/mcp-tool-policy.test.ts
@@ -32,6 +32,59 @@ describe('Better Stack MCP tool policy', () => {
   });
 });
 
+describe('X MCP tool policy', () => {
+  it('matches the snake_case tool names the hosted X server advertises', () => {
+    const allowedToolNames = getAllowedIntegrationMcpToolNames('x');
+
+    // The hosted X MCP server names tools in snake_case, not the camelCase
+    // OpenAPI operationIds. These are real names observed from tools/list.
+    expect(allowedToolNames).toEqual(
+      expect.arrayContaining([
+        'search_posts_all',
+        'search_posts_recent',
+        'get_posts_by_id',
+        'get_users_by_username',
+        'search_users',
+        'get_trends_by_woeid',
+        'get_news',
+      ]),
+    );
+    // Guard against a regression back to camelCase operationIds, which would
+    // silently filter out every upstream tool.
+    expect(allowedToolNames).not.toContain('searchPostsAll');
+    expect(allowedToolNames).not.toContain('getUsersByUsername');
+  });
+
+  it('excludes mutating and user-context tools the server also exposes', () => {
+    const allowedToolNames = getAllowedIntegrationMcpToolNames('x');
+
+    for (const excluded of [
+      'create_users_bookmark',
+      'delete_users_bookmark',
+      'get_users_bookmarks',
+      'get_users_mentions',
+      'get_users_timeline',
+    ]) {
+      expect(allowedToolNames).not.toContain(excluded);
+    }
+
+    expect(
+      filterMcpToolDefinitions(
+        [
+          { name: 'search_posts_all' },
+          { name: 'get_users_by_username' },
+          { name: 'create_users_bookmark' },
+          { name: 'get_users_timeline' },
+        ],
+        { allowedToolNames },
+      ),
+    ).toEqual([
+      { name: 'search_posts_all' },
+      { name: 'get_users_by_username' },
+    ]);
+  });
+});
+
 describe('monday.com MCP tool policy', () => {
   it('allows documented inspection tools and excludes mutating escape hatches', () => {
     const allowedToolNames = getAllowedIntegrationMcpToolNames('monday');

--- a/packages/types/src/mcp-oauth.ts
+++ b/packages/types/src/mcp-oauth.ts
@@ -149,6 +149,20 @@ export interface McpConnectionElevenLabsConfig {
 }
 
 /**
+ * Deployment-scoped X connection config stored in mcpConnections.authConfig.
+ *
+ * Holds an X API app-only bearer token that the integration proxy forwards to
+ * X's hosted MCP server. App-only tokens are read-only by construction: X
+ * requires user-context OAuth for every mutating endpoint, which this
+ * integration deliberately does not support. The token is expected to be
+ * encrypted before persistence.
+ */
+export interface McpConnectionXConfig {
+  type: 'x';
+  encryptedBearerToken: string;
+}
+
+/**
  * Organization-scoped Vercel connection config stored in mcpConnections.authConfig.
  *
  * The bearer token is expected to be encrypted before persistence.
@@ -186,6 +200,7 @@ export type McpConnectionAuthConfig =
   | McpConnectionElevenLabsConfig
   | McpConnectionVercelConfig
   | McpConnectionGrafanaConfig
+  | McpConnectionXConfig
   | Record<string, never>;
 
 export type McpConnectionRole =
@@ -566,6 +581,18 @@ export const MCP_INTEGRATIONS: McpIntegration[] = [
     ].join('\n'),
   },
   {
+    id: 'x',
+    name: 'X',
+    url: 'https://api.x.com/mcp',
+    description: `Connect X so your agents can search posts, look up users, and pull trends and news into ${PRODUCT_NAME} tasks`,
+    icon: 'x',
+    connectionScope: 'deployment',
+    connectionMode: 'admin_configured',
+    serverMode: 'upstream_proxy',
+    instructions:
+      'Use X to search public posts, look up users and their posts, and pull trends, news, lists, Spaces, and community context. The connection uses an app-only bearer token, so it is read-only public data: posting, bookmarks, DMs, and other user-context tools are not available.',
+  },
+  {
     id: 'zero',
     name: 'Zero',
     url: 'https://mcp.zero.xyz',
@@ -903,6 +930,19 @@ export function isMcpConnectionVercelConfig(
     typeof authConfig === 'object' &&
     'type' in authConfig &&
     authConfig.type === 'vercel',
+  );
+}
+
+export function isMcpConnectionXConfig(
+  authConfig: McpConnectionAuthConfig | null | undefined,
+): authConfig is McpConnectionXConfig {
+  return Boolean(
+    authConfig &&
+    typeof authConfig === 'object' &&
+    'type' in authConfig &&
+    authConfig.type === 'x' &&
+    'encryptedBearerToken' in authConfig &&
+    typeof authConfig.encryptedBearerToken === 'string',
   );
 }
 

--- a/packages/types/src/mcp-service-detection.ts
+++ b/packages/types/src/mcp-service-detection.ts
@@ -80,6 +80,15 @@ const VERCEL_PROJECT_TAB_PATH_REGEX = new RegExp(
 const ZERO_APP_PATH_REGEX = /^\/(?:c|browse|profile)(?:\/|$)/;
 const HOMEPAGE_PATH_REGEX = /^\/$/;
 
+// X app surfaces that signal "this task is about X content": post permalinks
+// (/<username>/status/<id>), search/explore, and /i/ product paths (lists,
+// communities, spaces). Bare profile URLs are one path segment and would
+// swallow unrelated x.com pages, so they deliberately do not match. Matched
+// against a lowercased pathname.
+const X_POST_PATH_REGEX = /^\/[a-z0-9_]{1,15}\/status\/\d+/;
+const X_APP_PATH_REGEX =
+  /^\/(?:search|explore)(?:\/|$)|^\/i\/(?:lists|communities|spaces)\//;
+
 export const SLACK_MCP_SETUP_SERVICES: SlackMcpSetupServiceDefinition[] = [
   {
     id: 'asana',
@@ -272,6 +281,24 @@ export const SLACK_MCP_SETUP_SERVICES: SlackMcpSetupServiceDefinition[] = [
     name: 'Supermemory',
     availabilityKind: 'curated_oauth',
     hostSuffixes: ['app.supermemory.ai', 'console.supermemory.ai'],
+    deploymentSettingsPath: '/settings/integrations',
+    userSettingsPath: '/settings/personal',
+  },
+  {
+    id: 'x',
+    name: 'X',
+    availabilityKind: 'admin_configured',
+    hostSuffixes: ['x.com', 'twitter.com'],
+    hostRules: [
+      {
+        hostSuffix: 'x.com',
+        pathRegexes: [X_POST_PATH_REGEX, X_APP_PATH_REGEX],
+      },
+      {
+        hostSuffix: 'twitter.com',
+        pathRegexes: [X_POST_PATH_REGEX, X_APP_PATH_REGEX],
+      },
+    ],
     deploymentSettingsPath: '/settings/integrations',
     userSettingsPath: '/settings/personal',
   },

--- a/packages/types/src/mcp-tool-policy.ts
+++ b/packages/types/src/mcp-tool-policy.ts
@@ -158,6 +158,53 @@ const MONDAY_READ_ONLY_TOOL_NAMES = [
   'get_type_details',
 ] as const;
 
+/**
+ * X's hosted MCP server exposes a curated subset of X API v2 operations, one
+ * tool per operation, named in snake_case (e.g. `search_posts_all`, not the
+ * camelCase `searchPostsAll` operationId). This allowlist keeps the read-only,
+ * public-data subset that works with an app-only bearer token; mutating
+ * operations and user-context surfaces (posting, bookmarks, DMs, mentions,
+ * timelines) are excluded. The exact set the server advertises varies with the
+ * connected X API plan, so this lists every read-only public-data tool we
+ * expect across plans; names the server does not advertise simply never match.
+ */
+const X_READ_ONLY_TOOL_NAMES = [
+  'search_posts_recent',
+  'search_posts_all',
+  'get_posts_counts_recent',
+  'get_posts_counts_all',
+  'get_posts_by_id',
+  'get_posts_by_ids',
+  'get_posts_quoted_posts',
+  'get_posts_reposted_by',
+  'get_posts_reposts',
+  'get_posts_liking_users',
+  'get_users_by_id',
+  'get_users_by_ids',
+  'get_users_by_username',
+  'get_users_by_usernames',
+  'search_users',
+  'get_users_posts',
+  'get_users_followers',
+  'get_users_following',
+  'get_users_liked_posts',
+  'get_users_owned_lists',
+  'get_trends_by_woeid',
+  'get_news',
+  'search_news',
+  'get_lists_by_id',
+  'get_lists_posts',
+  'get_lists_members',
+  'get_lists_followers',
+  'get_spaces_by_id',
+  'get_spaces_by_ids',
+  'get_spaces_posts',
+  'search_spaces',
+  'get_communities_by_id',
+  'search_communities',
+  'get_usage',
+] as const;
+
 const INTEGRATION_MCP_ALLOWED_TOOL_NAMES: Readonly<
   Partial<Record<string, readonly string[]>>
 > = {
@@ -168,6 +215,7 @@ const INTEGRATION_MCP_ALLOWED_TOOL_NAMES: Readonly<
   pylon: PYLON_READ_ONLY_TOOL_NAMES,
   railway: RAILWAY_READ_ONLY_TOOL_NAMES,
   sentry: SENTRY_READ_ONLY_TOOL_NAMES,
+  x: X_READ_ONLY_TOOL_NAMES,
 };
 
 export type McpToolPolicy = {


### PR DESCRIPTION
## What

Adds **X** to the built-in integration catalog: a deployment-scoped, admin-configured upstream proxy to the hosted X MCP server (`https://api.x.com/mcp`), authenticated with an app-only bearer token from the X Developer Console.

The integration is **read-only public data**. The tool allowlist keeps search, post lookups, user lookups, lists, Spaces, communities, trends, and news, and excludes every mutating and user-context operation (posting, bookmarks, DMs, mentions, timelines).

## Why the proxy needed changes

Two behaviors of the hosted X MCP server, both verified against the live endpoint:

1. **Tool names are snake_case.** The server names tools `search_posts_all`, `get_users_by_username`, etc., not the camelCase OpenAPI `operationId`s. The read-only allowlist is an intersection, so a camelCase list silently matched zero tools ("No tools available"). The allowlist now uses the real names, with a regression test guarding against a revert.

2. **Tool-call replies are SSE.** The server answers `tools/call` POSTs with `Content-Type: text/event-stream`, delivering the single JSON-RPC result as one `data:` frame (the full result arrives in ~280ms, then the stream closes). Clients that don't consume SSE-framed POST replies hang until their request timeout. The integration MCP proxy now normalizes any single-response SSE reply (request carries a JSON-RPC `id`, not a batch) into a plain `application/json` body via an id-matched extractor that skips `notifications/progress` frames. This is general and benefits any Streamable-HTTP-SSE upstream, not just X.

## Scope

- Catalog entry, auth config + type guard, read-only tool allowlist (`packages/types`)
- Admin bearer-token connect flow: tRPC commands, hooks, and Settings → Integrations dialog (`apps/web`)
- Bearer-token resolution through the integration MCP proxy + SSE→JSON normalization (`apps/api`, `packages/sdk`)
- Agent-facing setup guidance, Slack URL detection, brand icon
- Public docs page + integrations index

## Testing

- New unit tests: snake_case allowlist match + exclusions, SSE→JSON tool-call normalization, progress-frame skipping, Slack URL detection for X links, and the admin connect UI flow
- `pnpm lint:fast`, `pnpm check-types:fast`, `pnpm knip` clean
- Verified end-to-end against a live deployment: tool discovery lists the read-only tools, and `get_users_posts` returns real post data instead of timing out

## Notes

- Full-archive search (`search_posts_all`) requires a paid X API tier; the server advertises the tool regardless, so a lower-tier token may receive a 403 at call time. That is X plan gating, not an integration issue.