### PR TITLE
[Feature] Per-task model switcher with live apply and agent tool

### DIFF
--- a/.changeset/per-task-model-switcher.md
+++ b/.changeset/per-task-model-switcher.md
@@ -1,0 +1,7 @@
+---
+'@roomote/web': minor
+'@roomote/worker': minor
+'@roomote/api': minor
+---
+
+Add a per-task model switcher: a model chip in the web task composer switches the coding model and reasoning level (with per-role overrides for planning, code review, explore, helper, and vision behind "All roles"), changes apply from the next message and persist across snapshot resumes, and agents can switch their own task's models on request via the new `manage_tasks` `update_models` action.

--- a/apps/api/src/handlers/tasks/__tests__/updateModelSelection.test.ts
+++ b/apps/api/src/handlers/tasks/__tests__/updateModelSelection.test.ts
@@ -1,0 +1,161 @@
+import { Hono } from 'hono';
+
+import type { Variables } from '../../../types';
+import type { McpAuth } from '../../mcp/middleware';
+
+const {
+  mockApplyTaskModelSelectionToRun,
+  mockFindLatestTaskRun,
+  mockTokenRunFindFirst,
+} = vi.hoisted(() => ({
+  mockApplyTaskModelSelectionToRun: vi.fn(),
+  mockFindLatestTaskRun: vi.fn(),
+  mockTokenRunFindFirst: vi.fn(),
+}));
+
+vi.mock('@roomote/cloud-agents/server', () => ({
+  TaskModelSelectionError: class TaskModelSelectionError extends Error {
+    constructor(
+      message: string,
+      public readonly code: string,
+    ) {
+      super(message);
+    }
+  },
+  applyTaskModelSelectionToRun: mockApplyTaskModelSelectionToRun,
+}));
+
+vi.mock('@roomote/db/server', () => ({
+  db: {
+    query: {
+      taskRuns: {
+        findFirst: mockTokenRunFindFirst,
+      },
+    },
+  },
+  eq: vi.fn((...args) => ({ type: 'eq', args })),
+  taskRuns: { id: 'task_runs.id' },
+}));
+
+vi.mock('@roomote/sdk/server', () => ({
+  withSandboxServerRpcClient: vi.fn(),
+}));
+
+vi.mock('../helpers', () => ({
+  findLatestTaskRun: mockFindLatestTaskRun,
+}));
+
+import { updateTaskModelSelection } from '../updateModelSelection';
+
+function createApp(auth: McpAuth) {
+  const app = new Hono<{ Variables: Variables & { mcpAuth: McpAuth } }>();
+
+  app.use('*', async (c, next) => {
+    c.set('mcpAuth', auth);
+    await next();
+  });
+  app.post('/tasks/:taskId/model_selection', updateTaskModelSelection);
+  return app;
+}
+
+function postModelSelection(app: Hono<never>, taskId: string) {
+  return app.request(`/tasks/${taskId}/model_selection`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      role: 'coding',
+      model: null,
+      reasoningEffort: null,
+    }),
+  });
+}
+
+describe('updateTaskModelSelection', () => {
+  beforeEach(() => {
+    mockApplyTaskModelSelectionToRun.mockReset();
+    mockApplyTaskModelSelectionToRun.mockResolvedValue({
+      stampedTaskModel: null,
+    });
+    mockFindLatestTaskRun.mockReset();
+    mockFindLatestTaskRun.mockResolvedValue({
+      id: 42,
+      status: 'completed',
+      sandboxServerUrl: null,
+      actingUserId: null,
+    });
+    mockTokenRunFindFirst.mockReset();
+  });
+
+  it('rejects a run token bound to a different task without applying', async () => {
+    mockTokenRunFindFirst.mockResolvedValue({ taskId: 'other-task' });
+    const app = createApp({
+      userId: undefined,
+      authContext: { runId: 7 } as never,
+    });
+
+    const response = await postModelSelection(app as never, 'target-task');
+
+    expect(response.status).toBe(403);
+    expect(mockApplyTaskModelSelectionToRun).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the run token target no longer exists', async () => {
+    mockTokenRunFindFirst.mockResolvedValue(undefined);
+    const app = createApp({
+      userId: undefined,
+      authContext: { runId: 7 } as never,
+    });
+
+    const response = await postModelSelection(app as never, 'target-task');
+
+    expect(response.status).toBe(404);
+    expect(mockApplyTaskModelSelectionToRun).not.toHaveBeenCalled();
+  });
+
+  it('applies for a run token bound to the requested task', async () => {
+    mockTokenRunFindFirst.mockResolvedValue({ taskId: 'target-task' });
+    const app = createApp({
+      userId: undefined,
+      authContext: { runId: 7 } as never,
+    });
+
+    const response = await postModelSelection(app as never, 'target-task');
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: true,
+      application: 'offline',
+    });
+    expect(mockApplyTaskModelSelectionToRun).toHaveBeenCalledWith({
+      runId: 42,
+      role: 'coding',
+      model: null,
+      reasoningEffort: null,
+    });
+  });
+
+  it('applies for a user-token context without a bound run', async () => {
+    const app = createApp({
+      userId: 'user-1',
+      authContext: { userId: 'user-1' } as never,
+    });
+
+    const response = await postModelSelection(app as never, 'target-task');
+
+    expect(response.status).toBe(200);
+    expect(mockTokenRunFindFirst).not.toHaveBeenCalled();
+    expect(mockApplyTaskModelSelectionToRun).toHaveBeenCalled();
+  });
+
+  it('rejects contexts with neither a run token nor a user', async () => {
+    const app = createApp({
+      userId: undefined,
+      authContext: { deployment: true } as never,
+    });
+
+    const response = await postModelSelection(app as never, 'target-task');
+
+    expect(response.status).toBe(403);
+    expect(mockApplyTaskModelSelectionToRun).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/handlers/tasks/index.ts
+++ b/apps/api/src/handlers/tasks/index.ts
@@ -15,6 +15,7 @@ import { submitMcpRecommendations } from './submitMcpRecommendations';
 import { getTaskComputeLogs } from './getTaskComputeLogs';
 import { describeVideo } from './describeVideo';
 import { manageSourceControl } from './manageSourceControl';
+import { updateTaskModelSelection } from './updateModelSelection';
 
 export const tasksRouter = new Hono<{ Variables: Variables }>();
 
@@ -29,6 +30,7 @@ tasksRouter.post('/:taskId/send_message', sendMessage);
 tasksRouter.post('/:taskId/steer_message', steerMessage);
 tasksRouter.post('/:taskId/describe_video', describeVideo);
 tasksRouter.post('/:taskId/source_control', manageSourceControl);
+tasksRouter.post('/:taskId/model_selection', updateTaskModelSelection);
 tasksRouter.post('/:taskId/automation_work_items', submitAutomationWorkItems);
 tasksRouter.post('/:taskId/task_suggestions', submitTaskSuggestions);
 tasksRouter.post('/:taskId/mcp_recommendations', submitMcpRecommendations);

--- a/apps/api/src/handlers/tasks/updateModelSelection.ts
+++ b/apps/api/src/handlers/tasks/updateModelSelection.ts
@@ -1,0 +1,126 @@
+import type { Context } from 'hono';
+import { z } from 'zod';
+
+import {
+  TaskModelSelectionError,
+  applyTaskModelSelectionToRun,
+} from '@roomote/cloud-agents/server';
+import { withSandboxServerRpcClient } from '@roomote/sdk/server';
+import { REASONING_EFFORT_VALUES, isExitedRunStatus } from '@roomote/types';
+
+import type { Variables } from '../../types';
+import type { McpAuth } from '../mcp/middleware';
+import { findLatestTaskRun } from './helpers';
+import { logHandlerError } from '../utils';
+
+const updateModelSelectionBodySchema = z.object({
+  role: z.enum([
+    'coding',
+    'helper',
+    'vision',
+    'codeReview',
+    'explore',
+    'planning',
+  ]),
+  /** Desired model id, or null/omitted for the deployment default. */
+  model: z.string().trim().min(1).nullish(),
+  /** Desired reasoning level, or null/omitted for the deployment level. */
+  reasoningEffort: z.enum(REASONING_EFFORT_VALUES).nullish(),
+});
+
+/**
+ * POST /api/tasks/:taskId/model_selection
+ *
+ * Update one model role for a task (agent-facing surface of the in-task
+ * model switcher). Persists the selection on the task's latest run and asks
+ * the live sandbox to apply it; from a running turn the change applies at
+ * the next turn boundary.
+ */
+export async function updateTaskModelSelection(
+  c: Context<{ Variables: Variables & { mcpAuth: McpAuth } }>,
+): Promise<Response> {
+  const taskId = c.req.param('taskId');
+
+  if (!taskId?.trim()) {
+    return c.json({ error: 'taskId is required' }, 400);
+  }
+
+  const parsedBody = updateModelSelectionBodySchema.safeParse(
+    await c.req.json().catch(() => null),
+  );
+
+  if (!parsedBody.success) {
+    return c.json(
+      {
+        success: false,
+        error: parsedBody.error.issues[0]?.message ?? 'Invalid request body',
+      },
+      400,
+    );
+  }
+
+  try {
+    const run = await findLatestTaskRun(taskId, {
+      id: true,
+      status: true,
+      sandboxServerUrl: true,
+      actingUserId: true,
+    });
+
+    if (!run) {
+      return c.json({ success: false, error: 'Task not found' }, 404);
+    }
+
+    await applyTaskModelSelectionToRun({
+      runId: run.id,
+      role: parsedBody.data.role,
+      model: parsedBody.data.model ?? null,
+      reasoningEffort: parsedBody.data.reasoningEffort ?? null,
+    });
+
+    let application: 'restarted' | 'deferred' | 'unavailable' | 'offline' =
+      'offline';
+
+    if (run.sandboxServerUrl && !isExitedRunStatus(run.status)) {
+      try {
+        const result = await withSandboxServerRpcClient({
+          runId: run.id,
+          userId: run.actingUserId ?? null,
+          sandboxServerUrl: run.sandboxServerUrl,
+          call: (client) => client.commands.applyTaskModelSettings.mutate(),
+        });
+
+        application = result.application;
+      } catch (error) {
+        // The selection is persisted; a failed live apply only means it
+        // takes effect at the next resume instead of the next turn.
+        logHandlerError('updateTaskModelSelection.liveApply', error);
+      }
+    }
+
+    return c.json({ success: true, application });
+  } catch (error) {
+    if (error instanceof TaskModelSelectionError) {
+      const status =
+        error.code === 'run_not_found'
+          ? 404
+          : error.code === 'payload_missing'
+            ? 409
+            : 400;
+
+      return c.json({ success: false, error: error.message }, status);
+    }
+
+    logHandlerError('updateTaskModelSelection', error);
+    return c.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to update the task model selection',
+      },
+      500,
+    );
+  }
+}

--- a/apps/api/src/handlers/tasks/updateModelSelection.ts
+++ b/apps/api/src/handlers/tasks/updateModelSelection.ts
@@ -5,11 +5,13 @@ import {
   TaskModelSelectionError,
   applyTaskModelSelectionToRun,
 } from '@roomote/cloud-agents/server';
+import { db, eq, taskRuns } from '@roomote/db/server';
 import { withSandboxServerRpcClient } from '@roomote/sdk/server';
 import { REASONING_EFFORT_VALUES, isExitedRunStatus } from '@roomote/types';
 
 import type { Variables } from '../../types';
 import type { McpAuth } from '../mcp/middleware';
+import { isRunTokenContext } from '../mcp/proxy-utils';
 import { findLatestTaskRun } from './helpers';
 import { logHandlerError } from '../utils';
 
@@ -35,14 +37,54 @@ const updateModelSelectionBodySchema = z.object({
  * model switcher). Persists the selection on the task's latest run and asks
  * the live sandbox to apply it; from a running turn the change applies at
  * the next turn boundary.
+ *
+ * A sandbox run token must be bound to the target task: unlike the read and
+ * lifecycle actions on this router, this mutates persistent task state and
+ * force-restarts the harness, so one sandbox must not be able to point it at
+ * another task (mirrors `manageSourceControl`). User-token contexts carry
+ * the same authority as the web mutation and pass through.
  */
 export async function updateTaskModelSelection(
   c: Context<{ Variables: Variables & { mcpAuth: McpAuth } }>,
 ): Promise<Response> {
+  const auth = c.get('mcpAuth');
   const taskId = c.req.param('taskId');
 
   if (!taskId?.trim()) {
     return c.json({ error: 'taskId is required' }, 400);
+  }
+
+  if (isRunTokenContext(auth.authContext)) {
+    const tokenRun = await db.query.taskRuns.findFirst({
+      where: eq(taskRuns.id, auth.authContext.runId),
+      columns: { taskId: true },
+    });
+
+    if (!tokenRun) {
+      return c.json(
+        { success: false, error: 'Task run not found for this token' },
+        404,
+      );
+    }
+
+    if (tokenRun.taskId !== taskId) {
+      return c.json(
+        {
+          success: false,
+          error: 'Task run token does not match the requested task',
+        },
+        403,
+      );
+    }
+  } else if (!auth.userId) {
+    return c.json(
+      {
+        success: false,
+        error:
+          'Model selection updates require a task run token or user context',
+      },
+      403,
+    );
   }
 
   const parsedBody = updateModelSelectionBodySchema.safeParse(

--- a/apps/docs/models.mdx
+++ b/apps/docs/models.mdx
@@ -239,6 +239,23 @@ A practical starting point:
 If a model does not support reasoning controls, Roomote hides or ignores the
 reasoning selector for that role.
 
+## Per-task model switching
+
+Deployment settings define the defaults, but each task can override them from
+the web task view. The model chip in the message composer shows the task's
+current coding model and reasoning level; open it to switch the coding model,
+or expand **All roles** to override the planning, code review, explore,
+helper, or vision role for that task only.
+
+Changes apply from the next message: a turn that is already running finishes
+on the old settings, and the next turn (including its sub-agents) uses the new
+ones. Overrides persist for the life of the task, including snapshot resumes,
+and **Reset to defaults** returns every role to the deployment configuration.
+
+You can also just ask the agent — for example "switch to Fable 5 with max
+reasoning for the rest of this task". The agent applies the same change
+through its task-management tool, subject to the same allowed-models list.
+
 ## Choosing models
 
 Start by choosing for reliability, then optimize for cost and speed once tasks

--- a/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/PromptInput.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/PromptInput.tsx
@@ -57,6 +57,7 @@ import { useOptimisticPromptSubmission } from './useOptimisticPromptSubmission';
 import { AttachmentsDisplay } from './AttachmentsDisplay';
 import { ContextUsage } from './ContextUsage';
 import { SubmitWithAttachments } from './SubmitWithAttachments';
+import { TaskModelSwitcher } from './TaskModelSwitcher';
 import { TaskStatus } from './TaskStatus';
 
 const DRAFT_SAVE_DEBOUNCE_MS = 1_000;
@@ -748,6 +749,9 @@ export const PromptInput = forwardRef<PromptInputHandle, PromptInputProps>(
                 shouldShowTaskToolsActions(taskRun.payloadKind) && (
                   <TaskToolsButton taskRun={taskRun} />
                 )}
+              {taskRun && taskRun.harness === 'opencode-server' && (
+                <TaskModelSwitcher taskRun={taskRun} disabled={readOnly} />
+              )}
             </PromptInputTools>
             <div className="flex items-center gap-2">
               {showConnectingStatus && (

--- a/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/TaskModelSwitcher.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/TaskModelSwitcher.tsx
@@ -1,0 +1,372 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import {
+  DEFAULT_MODEL_ROLE_REASONING_EFFORTS,
+  getHarnessModelOverride,
+  getReasoningEffortLabel,
+  getTaskModelDisplayName,
+  type ReasoningEffort,
+  type TaskModelOverrideRole,
+  type TaskModelRoleOverride,
+} from '@roomote/types';
+
+import {
+  BasicTooltip,
+  Button,
+  ChevronDown,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/system';
+import { ModelSelect } from '@/components/tasks/ModelSelect';
+import { ReasoningEffortSelect } from '@/components/tasks/ReasoningEffortSelect';
+import { useLaunchTaskModels } from '@/hooks/task-models/useLaunchTaskModels';
+import type { TaskRunDetail } from '@/lib/server/task-runs';
+import { useTRPC } from '@/trpc/client';
+
+type SwitcherRole = 'coding' | TaskModelOverrideRole;
+
+const OVERRIDE_ROLE_ROWS: Array<{
+  role: TaskModelOverrideRole;
+  label: string;
+}> = [
+  { role: 'planning', label: 'Planning' },
+  { role: 'codeReview', label: 'Code review' },
+  { role: 'explore', label: 'Explore' },
+  { role: 'helper', label: 'Helper' },
+  { role: 'vision', label: 'Vision' },
+];
+
+type RoleSelection = {
+  model: string | null;
+  reasoningEffort: ReasoningEffort | null;
+};
+
+/**
+ * Per-task model switcher rendered in the task composer footer. Shows the
+ * coding model up front; the other model roles live behind the "All roles"
+ * expander. Every change persists to the run and applies from the next
+ * message.
+ */
+export function TaskModelSwitcher({
+  taskRun,
+  disabled = false,
+}: {
+  taskRun: TaskRunDetail;
+  disabled?: boolean;
+}) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [showAllRoles, setShowAllRoles] = useState(false);
+  // Selections applied locally while the mutation + session refetch settle,
+  // so the pickers do not snap back between change and refresh.
+  const [localSelections, setLocalSelections] = useState<
+    Partial<Record<SwitcherRole, RoleSelection>>
+  >({});
+
+  const { data: roleDefaults } = useQuery(
+    trpc.taskModels.roleDefaults.queryOptions(undefined, { enabled: open }),
+  );
+  const { data: launchModels } = useLaunchTaskModels();
+  const modelDisplayNames = useMemo(
+    () =>
+      new Map(
+        (launchModels?.models ?? []).map((model) => [
+          model.id,
+          model.displayName,
+        ]),
+      ),
+    [launchModels?.models],
+  );
+  // Alias-provider ids (bedrock-mantle/..., subscription aliases) are not in
+  // the launch catalog under their runtime id; the generic formatter is the
+  // fallback for those.
+  const displayModelName = (modelId: string) =>
+    modelDisplayNames.get(modelId) ?? getTaskModelDisplayName(modelId);
+
+  const payloadCodingModel = getHarnessModelOverride(
+    taskRun.payload?.harnessModelOverrides,
+    'opencode-server',
+  );
+  const payloadCodingEffort = taskRun.payload?.reasoningEffort ?? null;
+  const payloadRoleOverrides = taskRun.payload?.modelRoleOverrides;
+
+  // Server state is the source of truth: whenever the session payload
+  // reflects new model settings (our own write landing, or an external
+  // change such as the agent's update_models tool), drop the local optimistic
+  // selections so the pickers track it.
+  const payloadStateKey = JSON.stringify([
+    payloadCodingModel ?? null,
+    payloadCodingEffort,
+    payloadRoleOverrides ?? null,
+  ]);
+
+  useEffect(() => {
+    setLocalSelections({});
+  }, [payloadStateKey]);
+
+  const invalidateSession = () =>
+    queryClient.invalidateQueries({
+      queryKey: trpc.sandboxSession.byTaskId.queryKey({
+        taskId: taskRun.taskId,
+      }),
+    });
+
+  const updateModelSelection = useMutation(
+    trpc.sandboxSession.updateTaskModelSelection.mutationOptions({
+      onSuccess: (result) => {
+        void invalidateSession();
+
+        if (result.application === 'restarted') {
+          toast.success('Model settings updated');
+        } else if (result.application === 'deferred') {
+          toast.success('Model settings updated for the next message');
+        } else {
+          toast.success('Model settings saved for when the task resumes');
+        }
+      },
+      onError: (error, variables) => {
+        setLocalSelections((current) => {
+          const next = { ...current };
+
+          delete next[variables.role as SwitcherRole];
+          return next;
+        });
+        toast.error(error.message || 'Failed to update the model settings');
+      },
+    }),
+  );
+
+  const applyRoleSelection = (role: SwitcherRole, selection: RoleSelection) => {
+    setLocalSelections((current) => ({ ...current, [role]: selection }));
+    updateModelSelection.mutate({
+      taskId: taskRun.taskId,
+      role,
+      model: selection.model,
+      reasoningEffort: selection.reasoningEffort,
+    });
+  };
+
+  const resolveRoleSelection = (role: TaskModelOverrideRole): RoleSelection => {
+    const local = localSelections[role];
+
+    if (local) {
+      return local;
+    }
+
+    const override: TaskModelRoleOverride | undefined =
+      payloadRoleOverrides?.[role];
+
+    return {
+      model: override?.model ?? null,
+      reasoningEffort: override?.reasoningEffort ?? null,
+    };
+  };
+
+  const codingSelection: RoleSelection = localSelections.coding ?? {
+    model: payloadCodingModel ?? null,
+    reasoningEffort: payloadCodingEffort,
+  };
+  const effectiveCodingModel =
+    codingSelection.model ?? roleDefaults?.defaultModelId ?? null;
+  const effectiveCodingEffort =
+    codingSelection.reasoningEffort ??
+    roleDefaults?.roles.coding.reasoningEffort ??
+    DEFAULT_MODEL_ROLE_REASONING_EFFORTS.coding;
+
+  const hasRoleOverrides = useMemo(
+    () =>
+      OVERRIDE_ROLE_ROWS.some(({ role }) => {
+        const selection = resolveRoleSelection(role);
+
+        return selection.model !== null || selection.reasoningEffort !== null;
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [localSelections, payloadRoleOverrides],
+  );
+
+  const chipLabel = effectiveCodingModel
+    ? displayModelName(effectiveCodingModel)
+    : 'Model';
+
+  const handleReset = () => {
+    applyRoleSelection('coding', { model: null, reasoningEffort: null });
+
+    for (const { role } of OVERRIDE_ROLE_ROWS) {
+      const selection = resolveRoleSelection(role);
+
+      if (selection.model !== null || selection.reasoningEffort !== null) {
+        applyRoleSelection(role, { model: null, reasoningEffort: null });
+      }
+    }
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <BasicTooltip content="Models for this task">
+        <PopoverTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground hover:bg-secondary h-8 gap-1 px-2 text-xs font-normal"
+            aria-label="Models for this task"
+          >
+            <span className="max-w-40 truncate">{chipLabel}</span>
+            <span className="text-muted-foreground/70">
+              {getReasoningEffortLabel(effectiveCodingEffort)}
+            </span>
+            {hasRoleOverrides && (
+              <span
+                className="bg-primary size-1.5 shrink-0 rounded-full"
+                aria-label="Some roles are customized"
+              />
+            )}
+            <ChevronDown className="size-3 shrink-0" />
+          </Button>
+        </PopoverTrigger>
+      </BasicTooltip>
+      <PopoverContent align="start" className="w-96 p-3">
+        <div className="space-y-3">
+          <p className="text-sm font-medium">Models for this task</p>
+
+          <div className="flex items-center gap-2">
+            <ModelSelect
+              value={effectiveCodingModel ?? undefined}
+              onValueChange={(model) => {
+                if (!model) {
+                  return;
+                }
+
+                applyRoleSelection('coding', {
+                  model,
+                  reasoningEffort: codingSelection.reasoningEffort,
+                });
+              }}
+              disabled={disabled}
+              className="min-w-0 flex-1"
+              ariaLabel="Coding model"
+            />
+            <ReasoningEffortSelect
+              value={codingSelection.reasoningEffort}
+              defaultEffort={effectiveCodingEffort}
+              onChange={(effort) => {
+                if (!effort) {
+                  return;
+                }
+
+                applyRoleSelection('coding', {
+                  model: codingSelection.model,
+                  reasoningEffort: effort,
+                });
+              }}
+              disabled={disabled}
+              ariaLabel="Coding reasoning level"
+              className="w-28 shrink-0"
+              size="sm"
+            />
+          </div>
+
+          <Collapsible open={showAllRoles} onOpenChange={setShowAllRoles}>
+            <CollapsibleTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-muted-foreground h-7 gap-1 px-1 text-xs"
+              >
+                <ChevronDown
+                  className={`size-3 transition-transform ${showAllRoles ? '' : '-rotate-90'}`}
+                />
+                All roles
+              </Button>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <div className="mt-2 space-y-2">
+                {OVERRIDE_ROLE_ROWS.map(({ role, label }) => {
+                  const selection = resolveRoleSelection(role);
+                  const roleDefault = roleDefaults?.roles[role];
+                  const defaultModelName = roleDefault?.effectiveModelId
+                    ? displayModelName(roleDefault.effectiveModelId)
+                    : 'same as coding';
+                  const isOverridden =
+                    selection.model !== null ||
+                    selection.reasoningEffort !== null;
+
+                  return (
+                    <div key={role} className="flex items-center gap-2">
+                      <span className="text-muted-foreground flex w-24 shrink-0 items-center gap-1.5 text-xs">
+                        {label}
+                        {isOverridden && (
+                          <span
+                            className="bg-primary size-1.5 shrink-0 rounded-full"
+                            aria-label="Customized"
+                          />
+                        )}
+                      </span>
+                      <ModelSelect
+                        value={selection.model ?? ''}
+                        onValueChange={(model) =>
+                          applyRoleSelection(role, {
+                            model: model || null,
+                            reasoningEffort: selection.reasoningEffort,
+                          })
+                        }
+                        disabled={disabled}
+                        className="min-w-0 flex-1"
+                        ariaLabel={`${label} model`}
+                        emptyOptionLabel={`Default (${defaultModelName})`}
+                      />
+                      <ReasoningEffortSelect
+                        value={selection.reasoningEffort}
+                        defaultEffort={
+                          roleDefault?.reasoningEffort ??
+                          DEFAULT_MODEL_ROLE_REASONING_EFFORTS[role]
+                        }
+                        onChange={(effort) => {
+                          if (!effort) {
+                            return;
+                          }
+
+                          applyRoleSelection(role, {
+                            model: selection.model,
+                            reasoningEffort: effort,
+                          });
+                        }}
+                        disabled={disabled}
+                        ariaLabel={`${label} reasoning level`}
+                        className="w-24 shrink-0"
+                        size="sm"
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+
+          <div className="border-border flex items-center justify-between border-t pt-2">
+            <span className="text-muted-foreground text-xs">
+              Applies from the next message
+            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 text-xs"
+              onClick={handleReset}
+              disabled={disabled}
+            >
+              Reset to defaults
+            </Button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/TaskModelSwitcher.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/TaskModelSwitcher.tsx
@@ -145,6 +145,12 @@ export function TaskModelSwitcher({
     }),
   );
 
+  // Toast-free twin of `updateModelSelection` for the reset loop, which
+  // reports a single outcome after the last role clears.
+  const resetModelSelection = useMutation(
+    trpc.sandboxSession.updateTaskModelSelection.mutationOptions(),
+  );
+
   const applyRoleSelection = (role: SwitcherRole, selection: RoleSelection) => {
     setLocalSelections((current) => ({ ...current, [role]: selection }));
     updateModelSelection.mutate({
@@ -197,15 +203,60 @@ export function TaskModelSwitcher({
     ? displayModelName(effectiveCodingModel)
     : 'Model';
 
-  const handleReset = () => {
-    applyRoleSelection('coding', { model: null, reasoningEffort: null });
+  const [resetting, setResetting] = useState(false);
 
-    for (const { role } of OVERRIDE_ROLE_ROWS) {
-      const selection = resolveRoleSelection(role);
+  // Reset clears roles sequentially: firing the per-role mutations
+  // concurrently would race their payload read-modify-writes (the server
+  // also row-locks, but sequencing keeps the toasts to one and the sandbox
+  // restarts collapsed), and each role only needs a call when it actually
+  // holds an override.
+  const handleReset = async () => {
+    const rolesToClear: SwitcherRole[] = [
+      'coding',
+      ...OVERRIDE_ROLE_ROWS.filter(({ role }) => {
+        const selection = resolveRoleSelection(role);
 
-      if (selection.model !== null || selection.reasoningEffort !== null) {
-        applyRoleSelection(role, { model: null, reasoningEffort: null });
+        return selection.model !== null || selection.reasoningEffort !== null;
+      }).map(({ role }) => role),
+    ];
+    const cleared: RoleSelection = { model: null, reasoningEffort: null };
+
+    setResetting(true);
+    setLocalSelections(
+      Object.fromEntries(rolesToClear.map((role) => [role, cleared])),
+    );
+
+    try {
+      let application: string = 'offline';
+
+      for (const role of rolesToClear) {
+        const result = await resetModelSelection.mutateAsync({
+          taskId: taskRun.taskId,
+          role,
+          model: null,
+          reasoningEffort: null,
+        });
+
+        application = result.application;
       }
+
+      if (application === 'restarted') {
+        toast.success('Model settings reset');
+      } else if (application === 'deferred') {
+        toast.success('Model settings reset for the next message');
+      } else {
+        toast.success('Model settings reset for when the task resumes');
+      }
+    } catch (error) {
+      setLocalSelections({});
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : 'Failed to reset the model settings',
+      );
+    } finally {
+      setResetting(false);
+      void invalidateSession();
     }
   };
 
@@ -359,10 +410,10 @@ export function TaskModelSwitcher({
               variant="ghost"
               size="sm"
               className="h-7 px-2 text-xs"
-              onClick={handleReset}
-              disabled={disabled}
+              onClick={() => void handleReset()}
+              disabled={disabled || resetting}
             >
-              Reset to defaults
+              {resetting ? 'Resetting…' : 'Reset to defaults'}
             </Button>
           </div>
         </div>

--- a/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/TaskModelSwitcher.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/TaskModelSwitcher.tsx
@@ -120,18 +120,13 @@ export function TaskModelSwitcher({
       }),
     });
 
+  // Success is silent: the picker shows the new value and the popover's
+  // "Applies from the next message" hint carries the semantics. Only
+  // failures interrupt.
   const updateModelSelection = useMutation(
     trpc.sandboxSession.updateTaskModelSelection.mutationOptions({
-      onSuccess: (result) => {
+      onSuccess: () => {
         void invalidateSession();
-
-        if (result.application === 'restarted') {
-          toast.success('Model settings updated');
-        } else if (result.application === 'deferred') {
-          toast.success('Model settings updated for the next message');
-        } else {
-          toast.success('Model settings saved for when the task resumes');
-        }
       },
       onError: (error, variables) => {
         setLocalSelections((current) => {
@@ -145,8 +140,8 @@ export function TaskModelSwitcher({
     }),
   );
 
-  // Toast-free twin of `updateModelSelection` for the reset loop, which
-  // reports a single outcome after the last role clears.
+  // Handler-free twin of `updateModelSelection` for the reset loop, whose
+  // catch block owns error reporting for the whole batch.
   const resetModelSelection = useMutation(
     trpc.sandboxSession.updateTaskModelSelection.mutationOptions(),
   );
@@ -207,9 +202,8 @@ export function TaskModelSwitcher({
 
   // Reset clears roles sequentially: firing the per-role mutations
   // concurrently would race their payload read-modify-writes (the server
-  // also row-locks, but sequencing keeps the toasts to one and the sandbox
-  // restarts collapsed), and each role only needs a call when it actually
-  // holds an override.
+  // also row-locks, but sequencing keeps the sandbox restarts collapsed),
+  // and each role only needs a call when it actually holds an override.
   const handleReset = async () => {
     const rolesToClear: SwitcherRole[] = [
       'coding',
@@ -227,25 +221,13 @@ export function TaskModelSwitcher({
     );
 
     try {
-      let application: string = 'offline';
-
       for (const role of rolesToClear) {
-        const result = await resetModelSelection.mutateAsync({
+        await resetModelSelection.mutateAsync({
           taskId: taskRun.taskId,
           role,
           model: null,
           reasoningEffort: null,
         });
-
-        application = result.application;
-      }
-
-      if (application === 'restarted') {
-        toast.success('Model settings reset');
-      } else if (application === 'deferred') {
-        toast.success('Model settings reset for the next message');
-      } else {
-        toast.success('Model settings reset for when the task resumes');
       }
     } catch (error) {
       setLocalSelections({});

--- a/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/TaskModelSwitcher.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/TaskModelSwitcher.tsx
@@ -312,7 +312,7 @@ export function TaskModelSwitcher({
               <Button
                 variant="ghost"
                 size="sm"
-                className="text-muted-foreground h-7 gap-1 px-1 text-xs"
+                className="text-muted-foreground h-7 justify-start gap-1 px-0 text-xs hover:bg-transparent"
               >
                 <ChevronDown
                   className={`size-3 transition-transform ${showAllRoles ? '' : '-rotate-90'}`}

--- a/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/TaskModelSwitcher.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/TaskModelSwitcher.tsx
@@ -312,7 +312,7 @@ export function TaskModelSwitcher({
               <Button
                 variant="ghost"
                 size="sm"
-                className="text-muted-foreground h-7 justify-start gap-1 px-0 text-xs hover:bg-transparent"
+                className="text-muted-foreground h-7 justify-start gap-1 px-0 text-xs hover:bg-transparent has-[>svg]:px-0"
               >
                 <ChevronDown
                   className={`size-3 transition-transform ${showAllRoles ? '' : '-rotate-90'}`}

--- a/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-panels/TaskInfoPanel.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-panels/TaskInfoPanel.tsx
@@ -32,6 +32,8 @@ import {
   Loader2,
   RefreshCcw,
   Avatar,
+  Badge,
+  BasicTooltip,
   Button,
   CopyIconButton,
   Calendar,
@@ -390,6 +392,11 @@ export function TaskInfoPanel({
                     <span className="inline-flex items-center gap-1.5">
                       <Brain className="size-3.5 shrink-0 text-muted-foreground" />
                       <span className="truncate">{taskModelLabel}</span>
+                      {taskRun.payload?.modelRoleOverrides && (
+                        <BasicTooltip content="Some model roles are customized for this task">
+                          <Badge variant="secondary">Customized</Badge>
+                        </BasicTooltip>
+                      )}
                     </span>
                   </td>
                 </tr>

--- a/apps/web/src/components/settings/ModelSettingsSection.tsx
+++ b/apps/web/src/components/settings/ModelSettingsSection.tsx
@@ -52,17 +52,16 @@ import {
 } from '@/components/system';
 import type { LucideIcon } from '@/components/system';
 import { Section } from '@/components/settings';
+import { ReasoningEffortSelect } from '@/components/tasks/ReasoningEffortSelect';
 import { formatMetadataSummary } from './model-metadata';
 import {
   CHATGPT_SUBSCRIPTION_PROVIDER_ID,
   DEFAULT_MODEL_ROLE_REASONING_EFFORTS,
-  REASONING_EFFORT_OPTIONS,
   XAI_SUBSCRIPTION_PROVIDER_ID,
   buildRecommendedDeploymentModelConfig,
   getRecommendedModelPresets,
   groupModelsByDisplayProvider,
   getSetupModelProvider,
-  normalizeOptionalReasoningEffort,
 } from '@roomote/types';
 import type {
   DisplayModelProviderGroup,
@@ -252,43 +251,6 @@ const TASK_MODEL_ROLE_CONFIGS: readonly TaskModelRoleConfig[] = [
     allowSameAsCoding: true,
   },
 ];
-function ReasoningEffortSelect({
-  value,
-  defaultEffort,
-  onChange,
-  disabled,
-  ariaLabel,
-}: {
-  value: ReasoningEffort | null;
-  defaultEffort: ReasoningEffort;
-  onChange: (value: ReasoningEffort | null) => void;
-  disabled?: boolean;
-  ariaLabel: string;
-}) {
-  return (
-    <Select
-      value={value ?? defaultEffort}
-      onValueChange={(nextValue) =>
-        onChange(normalizeOptionalReasoningEffort(nextValue))
-      }
-      disabled={disabled}
-    >
-      <SelectTrigger className="w-36 shrink-0" aria-label={ariaLabel}>
-        <SelectValue />
-      </SelectTrigger>
-      <SelectContent align="end">
-        <SelectGroup>
-          <SelectLabel className="mt-0">Reasoning Level</SelectLabel>
-          {REASONING_EFFORT_OPTIONS.map((option) => (
-            <SelectItem key={option.value} value={option.value}>
-              {option.label}
-            </SelectItem>
-          ))}
-        </SelectGroup>
-      </SelectContent>
-    </Select>
-  );
-}
 
 function TaskModelRoleEditor({
   config,

--- a/apps/web/src/components/tasks/ReasoningEffortSelect.tsx
+++ b/apps/web/src/components/tasks/ReasoningEffortSelect.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import {
+  REASONING_EFFORT_OPTIONS,
+  normalizeOptionalReasoningEffort,
+  type ReasoningEffort,
+} from '@roomote/types';
+
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/system';
+
+/**
+ * Reasoning-level picker shared by the admin model settings page and the
+ * in-task model switcher. Shows the effective level (explicit value or the
+ * provided default) and reports every change as an explicit selection.
+ */
+export function ReasoningEffortSelect({
+  value,
+  defaultEffort,
+  onChange,
+  disabled,
+  ariaLabel,
+  className = 'w-36 shrink-0',
+  size,
+}: {
+  value: ReasoningEffort | null;
+  defaultEffort: ReasoningEffort;
+  onChange: (value: ReasoningEffort | null) => void;
+  disabled?: boolean;
+  ariaLabel: string;
+  className?: string;
+  size?: 'sm' | 'default';
+}) {
+  return (
+    <Select
+      value={value ?? defaultEffort}
+      onValueChange={(nextValue) =>
+        onChange(normalizeOptionalReasoningEffort(nextValue))
+      }
+      disabled={disabled}
+    >
+      <SelectTrigger className={className} aria-label={ariaLabel} size={size}>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent align="end">
+        <SelectGroup>
+          <SelectLabel className="mt-0">Reasoning Level</SelectLabel>
+          {REASONING_EFFORT_OPTIONS.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  );
+}

--- a/apps/web/src/trpc/commands/sandbox-session/index.ts
+++ b/apps/web/src/trpc/commands/sandbox-session/index.ts
@@ -1,5 +1,10 @@
-import { canRetryFailedStart } from '@roomote/cloud-agents/server';
 import {
+  TaskModelSelectionError,
+  applyTaskModelSelectionToRun,
+  canRetryFailedStart,
+} from '@roomote/cloud-agents/server';
+import {
+  REASONING_EFFORT_VALUES,
   RunStatus,
   TaskPayloadKind,
   activeRunStatuses,
@@ -603,6 +608,116 @@ async function getResolvedSandboxTaskRunForTaskAccess(
       canRetryFailedStart: await canRetryFailedStart(taskRun),
     },
   };
+}
+
+export const updateTaskModelSelectionInputSchema = z.object({
+  taskId: z.string(),
+  role: z.enum([
+    'coding',
+    'helper',
+    'vision',
+    'codeReview',
+    'explore',
+    'planning',
+  ]),
+  /**
+   * Desired model for the role, or null for the deployment default (for the
+   * coding role this re-stamps the deployment's default launch model).
+   */
+  model: z
+    .string()
+    .trim()
+    .min(1)
+    .regex(/^[^/\s]+\/.+$/u, 'Model must use provider/model format.')
+    .nullable(),
+  /** Desired reasoning level, or null for the deployment role level. */
+  reasoningEffort: z.enum(REASONING_EFFORT_VALUES).nullable(),
+});
+
+/**
+ * Updates one model role for a task: persists the selection on the current
+ * run's payload (the worker re-reads it at every harness spawn and snapshot
+ * resumes inherit it), then asks the live sandbox to apply it. `application`
+ * reports how the live sandbox took the change: `restarted` (idle harness
+ * restarted now), `deferred` (applies at the next message), `unavailable`
+ * (harness is shutting down), or `offline` (no live sandbox; applies on the
+ * next resume).
+ */
+export async function updateTaskModelSelectionCommand(
+  auth: UserAuthSuccess,
+  input: z.input<typeof updateTaskModelSelectionInputSchema>,
+) {
+  const parsed = updateTaskModelSelectionInputSchema.parse(input);
+  const { taskRun } = await getResolvedSandboxTaskRunByTaskId(auth, {
+    taskId: parsed.taskId,
+  });
+
+  try {
+    await applyTaskModelSelectionToRun({
+      runId: taskRun.id,
+      role: parsed.role,
+      model: parsed.model,
+      reasoningEffort: parsed.reasoningEffort,
+    });
+  } catch (error) {
+    if (error instanceof TaskModelSelectionError) {
+      throw new TRPCError({
+        code:
+          error.code === 'model_not_allowed' || error.code === 'invalid_model'
+            ? 'BAD_REQUEST'
+            : 'PRECONDITION_FAILED',
+        message: error.message,
+      });
+    }
+
+    throw error;
+  }
+
+  let application: 'restarted' | 'deferred' | 'unavailable' | 'offline' =
+    'offline';
+
+  if (taskRun.sandboxServerUrl && !isExitedRunStatus(taskRun.status)) {
+    try {
+      const authToken = await createRunToken({
+        runId: taskRun.id,
+        userId: auth.userId,
+        timeoutMs: SANDBOX_PROMPT_TOKEN_TIMEOUT_MS,
+      });
+      const controller = new AbortController();
+      const timeoutId = setTimeout(
+        () => controller.abort(),
+        SANDBOX_PROMPT_TIMEOUT_MS,
+      );
+
+      try {
+        const client = createSandboxServerRpcClient({
+          links: [
+            httpBatchLink({
+              url: `${taskRun.sandboxServerUrl}/trpc`,
+              transformer: superjson,
+              headers: () => ({ Authorization: `Bearer ${authToken}` }),
+              fetch: (url, init) =>
+                fetch(url, { ...init, signal: controller.signal }),
+            }),
+          ],
+        });
+        const result = await client.commands.applyTaskModelSettings.mutate();
+        application = result.application;
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    } catch (error) {
+      // The selection is persisted; a failed live apply only means it takes
+      // effect at the next resume instead of immediately.
+      console.warn(
+        `[updateTaskModelSelection] Live apply failed for task run ${taskRun.id}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  return { success: true as const, application };
 }
 
 export async function takeOverBrowserControlCommand(

--- a/apps/web/src/trpc/commands/task-models/index.ts
+++ b/apps/web/src/trpc/commands/task-models/index.ts
@@ -371,6 +371,52 @@ export async function getTaskModelSettingsCommand(
   };
 }
 
+type TaskModelRoleDefault = {
+  effectiveModelId: string | null;
+  reasoningEffort: ReasoningEffort | null;
+};
+
+/**
+ * The deployment's effective per-role models and reasoning levels for
+ * non-admin surfaces (the in-task model switcher labels its "Default"
+ * options with these). Exposes only the resolved ids/levels — no env
+ * management state or provider credentials.
+ */
+export async function getTaskModelRoleDefaultsCommand(
+  _auth: UserAuthSuccess,
+): Promise<{
+  defaultModelId: string;
+  roles: Record<
+    'coding' | 'helper' | 'vision' | 'codeReview' | 'explore' | 'planning',
+    TaskModelRoleDefault
+  >;
+}> {
+  const [settings, persistedRuntimeModelConfig] = await Promise.all([
+    getDeploymentTaskModelSettings(),
+    getDeploymentRuntimeModelConfig(),
+  ]);
+  const runtimeModels = resolveRuntimeModelStatus({
+    settingsDefaultModelId: settings.defaultModelId,
+    persisted: persistedRuntimeModelConfig,
+  });
+  const pick = (status: RuntimeModelFieldStatus): TaskModelRoleDefault => ({
+    effectiveModelId: status.effectiveModelId,
+    reasoningEffort: status.reasoningEffort,
+  });
+
+  return {
+    defaultModelId: settings.defaultModelId,
+    roles: {
+      coding: pick(runtimeModels.codingModel),
+      helper: pick(runtimeModels.helperModel),
+      vision: pick(runtimeModels.visionModel),
+      codeReview: pick(runtimeModels.codeReviewModel),
+      explore: pick(runtimeModels.exploreModel),
+      planning: pick(runtimeModels.planningModel),
+    },
+  };
+}
+
 async function getDeploymentSetupNewState(
   executor: DatabaseOrTransaction = db,
 ) {

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -197,6 +197,8 @@ import {
   sendSandboxPromptCommand,
   sendSandboxPromptInputSchema,
   takeOverBrowserControlCommand,
+  updateTaskModelSelectionCommand,
+  updateTaskModelSelectionInputSchema,
 } from '../commands/sandbox-session';
 import {
   getDeploymentMcpEnablementsCommand,
@@ -353,6 +355,7 @@ import {
   discoverProviderModelsCommand,
   getLaunchTaskModelsCommand,
   getTaskModelProviderSetupCommand,
+  getTaskModelRoleDefaultsCommand,
   getTaskModelSettingsCommand,
   lookupTaskModelCommand,
   qualifyProviderModelCommand,
@@ -2030,6 +2033,12 @@ export const appRouter = createRouter({
       .mutation(({ ctx: { auth }, input }) =>
         takeOverBrowserControlCommand(auth, input),
       ),
+
+    updateTaskModelSelection: protectedProcedure
+      .input(updateTaskModelSelectionInputSchema)
+      .mutation(({ ctx: { auth }, input }) =>
+        updateTaskModelSelectionCommand(auth, input),
+      ),
   }),
 
   filters: createRouter({
@@ -2092,6 +2101,10 @@ export const appRouter = createRouter({
   taskModels: createRouter({
     launchOptions: protectedProcedure.query(({ ctx: { auth } }) =>
       getLaunchTaskModelsCommand(auth),
+    ),
+
+    roleDefaults: protectedProcedure.query(({ ctx: { auth } }) =>
+      getTaskModelRoleDefaultsCommand(auth),
     ),
 
     get: protectedProcedure.query(({ ctx: { auth } }) =>

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/tool-descriptions.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/tool-descriptions.test.ts
@@ -278,6 +278,7 @@ describe('roomote MCP tool descriptions', () => {
       'launch',
       'cancel',
       'send_message',
+      'update_models',
       'list_environments',
     ]);
     expect(taskIdField.description).toBe(

--- a/apps/worker/src/mcp/roomote-mcp-server/index.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/index.ts
@@ -36,6 +36,7 @@ import { handleGetTaskMessages } from './task-messages.js';
 import { handleGetTaskSummary } from './task-summary.js';
 import { handleGetTaskComputeLogs } from './task-compute-logs.js';
 import { handleCancelTask } from './cancel-task.js';
+import { handleUpdateTaskModels } from './update-task-models.js';
 import { handleSendMessage } from './send-message.js';
 import { handleListEnvironments } from './list-environments.js';
 import {
@@ -550,7 +551,8 @@ const manageTasksToolDescription =
   'Use action "get_messages" to retrieve the latest message history for a task (requires taskId, returns newest first). ' +
   `Use action "launch" to create and start a new task against an environment using ${PRODUCT_NAME}'s default standard workflow (requires prompt and environmentId). ` +
   'Use action "cancel" to cancel an active task (requires taskId). ' +
-  'Use action "send_message" to send a follow-up message to a running task (requires taskId and message).';
+  'Use action "send_message" to send a follow-up message to a running task (requires taskId and message). ' +
+  'Use action "update_models" ONLY when the user explicitly asks to change the model or reasoning level for a task (requires role; taskId defaults to the current task). Pass the desired model id and/or reasoningEffort; omit both to reset the role to the deployment default. Changes apply from the next turn, so a change to the current task does not affect the turn that is already running.';
 
 const manageTasksInputSchema = {
   action: z
@@ -562,6 +564,7 @@ const manageTasksInputSchema = {
       'launch',
       'cancel',
       'send_message',
+      'update_models',
       'list_environments',
     ])
     .describe(
@@ -621,6 +624,24 @@ const manageTasksInputSchema = {
         'Call "list_environments" immediately before launching and copy one of the returned environmentId values.',
     ),
   branch: z.string().optional().describe('Branch to use (for launch)'),
+  role: z
+    .enum(['coding', 'helper', 'vision', 'codeReview', 'explore', 'planning'])
+    .optional()
+    .describe(
+      'Model role to change (required for update_models). "coding" is the main agent; the others cover sub-agent roles.',
+    ),
+  model: z
+    .string()
+    .optional()
+    .describe(
+      'For update_models: desired model id in provider/model format (must be enabled for the deployment). Omit to keep the deployment default model for the role.',
+    ),
+  reasoningEffort: z
+    .enum(['low', 'medium', 'high', 'xhigh', 'max'])
+    .optional()
+    .describe(
+      'For update_models: desired reasoning level for the role. Omit to use the deployment default level.',
+    ),
   notifyOnSettle: z
     .boolean()
     .optional()
@@ -754,6 +775,26 @@ roomoteMcpServer.registerTool(
           return errorResult('taskId is required for cancel');
         }
         return handleCancelTask({ taskId: params.taskId }, config);
+      }
+      case 'update_models': {
+        const taskId = params.taskId?.trim() || process.env.ROOMOTE_TASK_ID;
+        if (!taskId) {
+          return errorResult(
+            'taskId is required for update_models (provide it or set ROOMOTE_TASK_ID)',
+          );
+        }
+        if (!params.role) {
+          return errorResult('role is required for update_models');
+        }
+        return handleUpdateTaskModels(
+          {
+            taskId,
+            role: params.role,
+            model: params.model ?? null,
+            reasoningEffort: params.reasoningEffort ?? null,
+          },
+          config,
+        );
       }
       case 'send_message': {
         if (!params.taskId?.trim()) {

--- a/apps/worker/src/mcp/roomote-mcp-server/index.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/index.ts
@@ -552,7 +552,7 @@ const manageTasksToolDescription =
   `Use action "launch" to create and start a new task against an environment using ${PRODUCT_NAME}'s default standard workflow (requires prompt and environmentId). ` +
   'Use action "cancel" to cancel an active task (requires taskId). ' +
   'Use action "send_message" to send a follow-up message to a running task (requires taskId and message). ' +
-  'Use action "update_models" ONLY when the user explicitly asks to change the model or reasoning level for a task (requires role; taskId defaults to the current task). Pass the desired model id and/or reasoningEffort; omit both to reset the role to the deployment default. Changes apply from the next turn, so a change to the current task does not affect the turn that is already running.';
+  'Use action "update_models" ONLY when the user explicitly asks to change the model or reasoning level for a task (requires role; taskId defaults to the current task). Pass the desired model id and/or reasoningEffort; omit both to reset the role to the deployment default. Users usually phrase both together: in "switch to Luna Max" or "use GPT 5.4 medium", the trailing low/medium/high/extra high/max word is the reasoningEffort and the rest names the model — set BOTH fields in one call. Changes apply from the next turn, so a change to the current task does not affect the turn that is already running.';
 
 const manageTasksInputSchema = {
   action: z
@@ -640,7 +640,7 @@ const manageTasksInputSchema = {
     .enum(['low', 'medium', 'high', 'xhigh', 'max'])
     .optional()
     .describe(
-      'For update_models: desired reasoning level for the role. Omit to use the deployment default level.',
+      'For update_models: desired reasoning level for the role ("extra high" maps to xhigh). A level qualifier trailing a model name ("Luna Max", "Sonnet high") is this field, not part of the model id — pass it here alongside the model. Omit to use the deployment default level.',
     ),
   notifyOnSettle: z
     .boolean()

--- a/apps/worker/src/mcp/roomote-mcp-server/tasks-api-client.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/tasks-api-client.ts
@@ -21,6 +21,7 @@ import type {
   LaunchTaskResponse,
   CancelTaskResponse,
   StopTaskResponse,
+  UpdateTaskModelSelectionResponse,
   SendMessageResponse,
   ListEnvironmentsResponse,
   CreateEnvironmentResponse,
@@ -195,6 +196,30 @@ export async function cancelTask(
     `/api/mcp/tasks/${encodeURIComponent(taskId)}/cancel`,
     { method: 'POST' },
     'Failed to cancel task',
+  );
+}
+
+/**
+ * Update one model role for a task via the platform API.
+ */
+export async function updateTaskModelSelection(
+  config: RoomoteConfig,
+  taskId: string,
+  params: {
+    role: string;
+    model?: string | null;
+    reasoningEffort?: string | null;
+  },
+): Promise<UpdateTaskModelSelectionResponse> {
+  return apiFetch(
+    config,
+    `/api/mcp/tasks/${encodeURIComponent(taskId)}/model_selection`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(params),
+    },
+    'Failed to update task model selection',
   );
 }
 

--- a/apps/worker/src/mcp/roomote-mcp-server/types.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/types.ts
@@ -240,6 +240,13 @@ export interface CancelTaskResponse {
   error?: string;
 }
 
+export interface UpdateTaskModelSelectionResponse {
+  success: boolean;
+  /** How the live sandbox took the change; absent on failure. */
+  application?: 'restarted' | 'deferred' | 'unavailable' | 'offline';
+  error?: string;
+}
+
 export interface SubmitTaskSuggestionsResponse {
   success: boolean;
   suggestionCount?: number;

--- a/apps/worker/src/mcp/roomote-mcp-server/update-task-models.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/update-task-models.ts
@@ -1,0 +1,44 @@
+import { updateTaskModelSelection } from './tasks-api-client.js';
+import { errorResult, successResult, catchError } from './tool-result.js';
+import type { RoomoteConfig, ToolResult } from './types.js';
+
+const APPLICATION_MESSAGES: Record<string, string> = {
+  restarted: 'The new model settings are active now.',
+  deferred: 'The new model settings apply from the next turn.',
+  unavailable:
+    'The selection was saved, but the sandbox is shutting down; it applies when the task resumes.',
+  offline: 'The selection was saved and applies when the task resumes.',
+};
+
+export async function handleUpdateTaskModels(
+  params: {
+    taskId: string;
+    role: string;
+    model?: string | null;
+    reasoningEffort?: string | null;
+  },
+  config: RoomoteConfig,
+): Promise<ToolResult> {
+  try {
+    const result = await updateTaskModelSelection(config, params.taskId, {
+      role: params.role,
+      model: params.model ?? null,
+      reasoningEffort: params.reasoningEffort ?? null,
+    });
+
+    if (!result.success) {
+      return errorResult(
+        result.error || 'Failed to update the task model selection',
+      );
+    }
+
+    return successResult({
+      message: `Updated the ${params.role} model selection. ${
+        APPLICATION_MESSAGES[result.application ?? 'offline'] ??
+        'The selection was saved.'
+      }`,
+    });
+  } catch (error) {
+    return catchError(error);
+  }
+}

--- a/apps/worker/src/run-task/__tests__/create-harness.test.ts
+++ b/apps/worker/src/run-task/__tests__/create-harness.test.ts
@@ -233,6 +233,81 @@ describe('createHarness', () => {
     expect(getHarnessModelOverrideMock).toHaveBeenCalledTimes(1);
   });
 
+  it('overlays per-task model role overrides onto the spawn env and re-reads them on respawn', async () => {
+    const firstHarness = createConnectedHarness();
+    const secondHarness = createConnectedHarness();
+
+    startOpenCodeServerHarnessMock
+      .mockResolvedValueOnce({
+        harness: firstHarness,
+        subprocess: createPendingSubprocess(),
+      })
+      .mockResolvedValueOnce({
+        harness: secondHarness,
+        subprocess: createPendingSubprocess(),
+      });
+
+    const taskRun = {
+      id: 7,
+      taskId: 'task-7',
+      payload: {
+        modelRoleOverrides: {
+          planning: {
+            model: 'openrouter/test/planner',
+            reasoningEffort: 'max',
+          },
+          explore: { reasoningEffort: 'low' },
+        },
+      },
+    };
+
+    await createHarness({
+      harnessType: 'opencode-server',
+      workspacePath: '/tmp/workspace',
+      runtimeEnv: {
+        OPENAI_API_KEY: 'sk-test-openai',
+      },
+      harnessSessionId: undefined,
+      cancelSignal: new AbortController().signal,
+      integrations: {} as never,
+      mcpTaskEnv: {},
+      taskRun: taskRun as never,
+      callbacks: {} as never,
+      context: {} as never,
+      logger: createLogger(),
+    });
+
+    expect(startOpenCodeServerHarnessMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeEnv: {
+          OPENAI_API_KEY: 'sk-test-openai',
+          R_PLANNING_MODEL: 'openrouter/test/planner',
+          R_PLANNING_MODEL_REASONING_EFFORT: 'max',
+          R_EXPLORE_MODEL_REASONING_EFFORT: 'low',
+        },
+      }),
+    );
+
+    // A live model-settings update mutates the shared payload and restarts
+    // the harness; the respawn must pick up the current overrides.
+    taskRun.payload.modelRoleOverrides = {
+      planning: { model: 'openrouter/test/other-planner' },
+    } as never;
+    firstHarness.emit('disconnected');
+
+    await vi.waitFor(() =>
+      expect(startOpenCodeServerHarnessMock).toHaveBeenCalledTimes(2),
+    );
+    expect(startOpenCodeServerHarnessMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        runtimeEnv: {
+          OPENAI_API_KEY: 'sk-test-openai',
+          R_PLANNING_MODEL: 'openrouter/test/other-planner',
+        },
+      }),
+    );
+  });
+
   it('starts opencode-server with its model override and generated prompt inputs', async () => {
     const subprocess = createPendingSubprocess();
 
@@ -314,15 +389,23 @@ describe('createHarness', () => {
 
     const startOptions = startOpenCodeServerHarnessMock.mock.calls[0]?.[0] as
       | {
-          beforeQueuedPrompt?: (input: { userId?: string }) => Promise<unknown>;
+          beforeQueuedPrompt?: (input: {
+            userId?: string;
+            kind: 'queuedPrompt' | 'userInputAnswer';
+          }) => Promise<unknown>;
         }
       | undefined;
 
     expect(startOptions?.beforeQueuedPrompt).toBeTypeOf('function');
     await expect(
-      startOptions?.beforeQueuedPrompt?.({ userId: 'user-2' }),
+      startOptions?.beforeQueuedPrompt?.({
+        userId: 'user-2',
+        kind: 'queuedPrompt',
+      }),
     ).resolves.toBeUndefined();
-    expect(beforeQueuedPrompt).toHaveBeenCalledWith('user-2');
+    expect(beforeQueuedPrompt).toHaveBeenCalledWith('user-2', {
+      kind: 'queuedPrompt',
+    });
   });
 
   it('stamps harnessStartedAt once the harness subprocess is alive', async () => {

--- a/apps/worker/src/run-task/create-harness.ts
+++ b/apps/worker/src/run-task/create-harness.ts
@@ -2,6 +2,7 @@ import type { ResultPromise } from 'execa';
 
 import { type DequeuedTaskRun, sdk } from '@roomote/sdk/client';
 import {
+  buildTaskModelRoleOverrideEnv,
   getHarnessModelOverride,
   isReasoningEffort,
   type EnvironmentMcpServers,
@@ -48,7 +49,10 @@ interface CreateHarnessOptions {
   callbacks: RunTaskCallbacks;
   context: RunTaskContext;
   logger: HarnessLogger;
-  prepareQueuedPromptActorScope?: (targetUserId?: string) => Promise<{
+  prepareQueuedPromptActorScope?: (
+    targetUserId?: string,
+    delivery?: { kind: 'queuedPrompt' | 'userInputAnswer' },
+  ) => Promise<{
     shouldReconnect: boolean;
     shouldBlockPrompt?: boolean;
     shouldSkipPrompt?: boolean;
@@ -121,17 +125,31 @@ export async function createHarness({
     )
       ? taskRun.payload.reasoningEffort
       : undefined;
+    // Read at every spawn (not just the first) so a config-update restart
+    // regenerates the OpenCode config from the task's current overrides.
+    const modelRoleOverrideEnv = buildTaskModelRoleOverrideEnv(
+      taskRun.payload?.modelRoleOverrides,
+    );
+    const spawnRuntimeEnv =
+      Object.keys(modelRoleOverrideEnv).length > 0
+        ? { ...harnessCommandEnv, ...modelRoleOverrideEnv }
+        : harnessCommandEnv;
 
     const commonOptions = {
       workspacePath,
-      runtimeEnv: harnessCommandEnv,
+      runtimeEnv: spawnRuntimeEnv,
       cancelSignal,
       logger,
       mcpServers: resolvedMcps,
       initialSessionId: options?.initialSessionId ?? harnessSessionId,
       beforeQueuedPrompt: prepareQueuedPromptActorScope
-        ? async ({ userId }: { userId?: string }) =>
-            await prepareQueuedPromptActorScope(userId)
+        ? async ({
+            userId,
+            kind,
+          }: {
+            userId?: string;
+            kind: 'queuedPrompt' | 'userInputAnswer';
+          }) => await prepareQueuedPromptActorScope(userId, { kind })
         : undefined,
       ...(modelOverride ? { modelOverride } : {}),
       ...(reasoningEffortOverride ? { reasoningEffortOverride } : {}),

--- a/apps/worker/src/run-task/run-task.ts
+++ b/apps/worker/src/run-task/run-task.ts
@@ -1140,7 +1140,63 @@ export const runTask = async ({
         refreshActorScopedIntegrations,
       });
 
-    const prepareQueuedPromptActorScope = async (targetUserId?: string) => {
+    // Set when the task's model settings changed while a restart was unsafe
+    // (active turn or pending user-input request). Consumed by the next
+    // queued-prompt delivery: the prompt is restored, the harness restarts
+    // with a regenerated OpenCode config, and the prompt replays on the new
+    // models. User-input answers never consume it — a reconnect there fails
+    // the answer delivery instead of replaying it.
+    let pendingTaskModelSettingsRestart = false;
+
+    const applyTaskModelSettingsUpdate = async (): Promise<{
+      application: 'restarted' | 'deferred' | 'unavailable';
+    }> => {
+      const freshRun = await sdk.taskRuns.findFirstById(taskRun.id);
+
+      if (freshRun?.payload && typeof freshRun.payload === 'object') {
+        // createHarness closed over this taskRun object and re-reads its
+        // payload at every harness spawn, so refreshing it here is what a
+        // restart (or crash reconnect) applies.
+        taskRun.payload = freshRun.payload;
+      }
+
+      const phase = harnessManager?.getStatus().phase ?? 'idle';
+
+      if (phase === 'shutting_down' || phase === 'stopped') {
+        // Too late to apply live; the persisted payload applies on resume.
+        return { application: 'unavailable' };
+      }
+
+      if (
+        phase === 'running' ||
+        phase === 'waiting_for_user_input' ||
+        !harness.requestReconnect
+      ) {
+        pendingTaskModelSettingsRestart = true;
+        return { application: 'deferred' };
+      }
+
+      await harness.requestReconnect({
+        reason: 'Task model settings updated',
+      });
+      return { application: 'restarted' };
+    };
+
+    const prepareQueuedPromptActorScope = async (
+      targetUserId?: string,
+      delivery?: { kind: 'queuedPrompt' | 'userInputAnswer' },
+    ) => {
+      if (
+        pendingTaskModelSettingsRestart &&
+        delivery?.kind !== 'userInputAnswer'
+      ) {
+        pendingTaskModelSettingsRestart = false;
+        return {
+          shouldReconnect: true,
+          reason: 'Applying updated task model settings before the next turn',
+        };
+      }
+
       if (!targetUserId) {
         return {
           shouldReconnect: false,
@@ -1971,6 +2027,7 @@ export const runTask = async ({
       taskRuntime: { homeDir, runtimeEnv },
       allowTerminal: runtimeEnv.ROOMOTE_TASK_TERMINAL === 'true',
       prepareActorScopedTurn,
+      applyTaskModelSettingsUpdate,
       validateToken,
     });
 

--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
@@ -3805,6 +3805,7 @@ describe('OpenCodeServerHarness', () => {
       });
       expect(beforeQueuedPrompt).toHaveBeenCalledWith({
         userId: 'answer-user-1',
+        kind: 'userInputAnswer',
       });
       expect(client.abort).not.toHaveBeenCalled();
       expect(client.promptAsync).toHaveBeenCalledTimes(1);

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
@@ -140,7 +140,15 @@ interface OpenCodeServerHarnessOptions {
     message: string;
     details?: Record<string, unknown>;
   }) => void;
-  beforeQueuedPrompt?: (input: { userId?: string }) => Promise<void | {
+  beforeQueuedPrompt?: (input: {
+    userId?: string;
+    /**
+     * Distinguishes deliveries that survive a reconnect (queued prompts are
+     * restored and replayed) from ones that do not (user-input answers fail
+     * with an error when the hook asks for a reconnect).
+     */
+    kind: 'queuedPrompt' | 'userInputAnswer';
+  }) => Promise<void | {
     shouldReconnect: boolean;
     shouldBlockPrompt?: boolean;
     shouldSkipPrompt?: boolean;
@@ -3228,7 +3236,10 @@ export class OpenCodeServerHarness
       return true;
     }
 
-    const result = await this.beforeQueuedPrompt({ userId });
+    const result = await this.beforeQueuedPrompt({
+      userId,
+      kind: 'userInputAnswer',
+    });
 
     if (!result) {
       return true;
@@ -5216,7 +5227,10 @@ export class OpenCodeServerHarness
       return true;
     }
 
-    const result = await this.beforeQueuedPrompt({ userId: prompt.userId });
+    const result = await this.beforeQueuedPrompt({
+      userId: prompt.userId,
+      kind: 'queuedPrompt',
+    });
 
     if (!result) {
       return true;

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/start.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/start.ts
@@ -44,7 +44,10 @@ interface StartOpenCodeServerHarnessOptions {
     message: string;
     details?: Record<string, unknown>;
   }) => void;
-  beforeQueuedPrompt?: (input: { userId?: string }) => Promise<void | {
+  beforeQueuedPrompt?: (input: {
+    userId?: string;
+    kind: 'queuedPrompt' | 'userInputAnswer';
+  }) => Promise<void | {
     shouldReconnect: boolean;
     shouldBlockPrompt?: boolean;
     shouldSkipPrompt?: boolean;

--- a/apps/worker/src/sandbox-server/procedures/applyTaskModelSettings.ts
+++ b/apps/worker/src/sandbox-server/procedures/applyTaskModelSettings.ts
@@ -1,0 +1,25 @@
+import { TRPCError } from '@trpc/server';
+
+import { publicProcedure } from '../trpc';
+
+/**
+ * Applies the run's persisted per-task model settings to the live harness.
+ * The caller (web/API) persists the settings to `task_runs.payload` first;
+ * this procedure re-reads them and restarts the harness so the regenerated
+ * OpenCode config takes effect — immediately when no turn is active,
+ * otherwise at the next queued-prompt delivery.
+ */
+export const applyTaskModelSettings = publicProcedure.mutation(
+  async ({ ctx }) => {
+    if (!ctx.applyTaskModelSettingsUpdate) {
+      throw new TRPCError({
+        code: 'PRECONDITION_FAILED',
+        message: 'Model settings updates are not available for this sandbox',
+      });
+    }
+
+    const { application } = await ctx.applyTaskModelSettingsUpdate();
+
+    return { success: true as const, application };
+  },
+);

--- a/apps/worker/src/sandbox-server/procedures/index.ts
+++ b/apps/worker/src/sandbox-server/procedures/index.ts
@@ -13,6 +13,7 @@ export { deleteQueuedPrompt } from './deleteQueuedPrompt';
 export { answerUserInputRequest } from './answerUserInputRequest';
 export { touchKeepalive } from './touchKeepalive';
 export { reloadDeploymentEnvVars } from './reloadDeploymentEnvVars';
+export { applyTaskModelSettings } from './applyTaskModelSettings';
 export { scrubSnapshotSecrets } from './scrubSnapshotSecrets';
 export { restoreScrubbedCredentials } from './restoreScrubbedCredentials';
 

--- a/apps/worker/src/sandbox-server/routers/commands.ts
+++ b/apps/worker/src/sandbox-server/routers/commands.ts
@@ -17,6 +17,7 @@ import {
   cancelTask,
   touchKeepalive,
   reloadDeploymentEnvVars,
+  applyTaskModelSettings,
   scrubSnapshotSecrets,
   restoreScrubbedCredentials,
 } from '../procedures';
@@ -38,6 +39,7 @@ export const commandsRouter = router({
   cancelTask,
   touchKeepalive,
   reloadDeploymentEnvVars,
+  applyTaskModelSettings,
   scrubSnapshotSecrets,
   restoreScrubbedCredentials,
 });

--- a/apps/worker/src/sandbox-server/server.ts
+++ b/apps/worker/src/sandbox-server/server.ts
@@ -102,6 +102,7 @@ export function createServer({
   codingHarness,
   taskRuntime,
   prepareActorScopedTurn,
+  applyTaskModelSettingsUpdate,
 }: {
   /** Port to listen on. */
   port: number;
@@ -142,6 +143,13 @@ export function createServer({
     },
   ) => Promise<PrepareActorScopedTurnResult>;
   /**
+   * Re-read the run's persisted model settings and apply them to the live
+   * harness (restart now, or defer to the next turn boundary).
+   */
+  applyTaskModelSettingsUpdate?: () => Promise<{
+    application: 'restarted' | 'deferred' | 'unavailable';
+  }>;
+  /**
    * Token validator.
    * For tRPC: reads `Authorization: Bearer <token>` header.
    * For WebSocket: reads `connectionParams.token`.
@@ -161,6 +169,7 @@ export function createServer({
     workerEnv,
     taskRuntime,
     prepareActorScopedTurn,
+    applyTaskModelSettingsUpdate,
   });
 
   const app = new Hono();

--- a/apps/worker/src/sandbox-server/trpc.ts
+++ b/apps/worker/src/sandbox-server/trpc.ts
@@ -67,6 +67,15 @@ export interface Context {
       onMismatch?: ActorMismatchPolicy;
     },
   ) => Promise<PrepareActorScopedTurnResult>;
+
+  /**
+   * Re-read the run's persisted model settings and apply them to the live
+   * harness: restart immediately when no turn is active, otherwise defer to
+   * the next queued-prompt delivery.
+   */
+  applyTaskModelSettingsUpdate?: () => Promise<{
+    application: 'restarted' | 'deferred' | 'unavailable';
+  }>;
 }
 
 const t = initTRPC.context<Context>().create({ transformer: superjson });

--- a/packages/cloud-agents/src/server/__tests__/enqueue-task.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/enqueue-task.test.ts
@@ -964,6 +964,56 @@ describe('enqueueTask snapshot resume', () => {
     });
   });
 
+  it('inherits per-task model role overrides from the source run payload', async () => {
+    const userId = await createUser();
+
+    const freshRun = await launchFresh({
+      task: standardTaskInput(),
+      initiator: { kind: 'user', userId },
+      workflow: 'standard',
+      surface: 'web',
+      trigger: 'manual',
+    });
+
+    // Simulate a mid-task model change persisted by the task UI: the
+    // overrides live on the run payload, not the launch spec.
+    await db
+      .update(taskRuns)
+      .set({
+        payload: {
+          ...(freshRun.payload as Record<string, unknown>),
+          modelRoleOverrides: {
+            planning: { model: 'openrouter/test/planner' },
+            explore: { reasoningEffort: 'low' },
+          },
+        } as typeof freshRun.payload,
+      })
+      .where(eq(taskRuns.id, freshRun.id));
+
+    const resumeTask: SnapshotResumeTask = {
+      type: TaskPayloadKind.SnapshotResume,
+      payload: {
+        repo: 'acme/widgets',
+        sourceSnapshotId: 'snap-models-1',
+        sourceRunId: freshRun.id,
+      },
+    } as SnapshotResumeTask;
+
+    const resumeRun = await enqueueTask(
+      { task: resumeTask, actingUserId: userId },
+      { enqueue: false },
+    );
+
+    const resumePayload = resumeRun.payload as {
+      modelRoleOverrides?: Record<string, unknown>;
+    };
+
+    expect(resumePayload.modelRoleOverrides).toEqual({
+      planning: { model: 'openrouter/test/planner' },
+      explore: { reasoningEffort: 'low' },
+    });
+  });
+
   it('walks the resume chain for stamps when the source run predates inheritance', async () => {
     const userId = await createUser();
 

--- a/packages/cloud-agents/src/server/__tests__/enqueue-task.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/enqueue-task.test.ts
@@ -58,6 +58,7 @@ import {
   type FreshTaskLaunch,
 } from '../task-run-queue';
 import { LLM_TITLE_LOCKED_CHECKPOINT } from '../llm-task-title';
+import { applyTaskModelSelectionToRun } from '../task-model-selection';
 
 const createdTaskIds: string[] = [];
 const createdUserIds: string[] = [];
@@ -1011,6 +1012,49 @@ describe('enqueueTask snapshot resume', () => {
     expect(resumePayload.modelRoleOverrides).toEqual({
       planning: { model: 'openrouter/test/planner' },
       explore: { reasoningEffort: 'low' },
+    });
+  });
+
+  it('keeps concurrent role updates intact via the run-row lock', async () => {
+    const userId = await createUser();
+
+    const freshRun = await launchFresh({
+      task: standardTaskInput(),
+      initiator: { kind: 'user', userId },
+      workflow: 'standard',
+      surface: 'web',
+      trigger: 'manual',
+    });
+
+    // The UI's reset fan-out and the agent's update_models call can hit the
+    // same run at once; each does a payload read-modify-write, so without
+    // the FOR UPDATE lock one write silently overwrites the other.
+    await Promise.all([
+      applyTaskModelSelectionToRun({
+        runId: freshRun.id,
+        role: 'helper',
+        model: null,
+        reasoningEffort: 'high',
+      }),
+      applyTaskModelSelectionToRun({
+        runId: freshRun.id,
+        role: 'vision',
+        model: null,
+        reasoningEffort: 'low',
+      }),
+    ]);
+
+    const run = await db.query.taskRuns.findFirst({
+      where: eq(taskRuns.id, freshRun.id),
+      columns: { payload: true },
+    });
+    const payload = run?.payload as {
+      modelRoleOverrides?: Record<string, unknown>;
+    };
+
+    expect(payload.modelRoleOverrides).toEqual({
+      helper: { reasoningEffort: 'high' },
+      vision: { reasoningEffort: 'low' },
     });
   });
 

--- a/packages/cloud-agents/src/server/__tests__/enqueue-task.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/enqueue-task.test.ts
@@ -983,6 +983,7 @@ describe('enqueueTask snapshot resume', () => {
       .set({
         payload: {
           ...(freshRun.payload as Record<string, unknown>),
+          reasoningEffort: 'xhigh',
           modelRoleOverrides: {
             planning: { model: 'openrouter/test/planner' },
             explore: { reasoningEffort: 'low' },
@@ -1006,6 +1007,7 @@ describe('enqueueTask snapshot resume', () => {
     );
 
     const resumePayload = resumeRun.payload as {
+      reasoningEffort?: string;
       modelRoleOverrides?: Record<string, unknown>;
     };
 
@@ -1013,6 +1015,9 @@ describe('enqueueTask snapshot resume', () => {
       planning: { model: 'openrouter/test/planner' },
       explore: { reasoningEffort: 'low' },
     });
+    // The explicit coding level must survive the resume; without central
+    // inheritance the enqueue would re-stamp the deployment default.
+    expect(resumePayload.reasoningEffort).toBe('xhigh');
   });
 
   it('keeps concurrent role updates intact via the run-row lock', async () => {

--- a/packages/cloud-agents/src/server/index.ts
+++ b/packages/cloud-agents/src/server/index.ts
@@ -10,6 +10,7 @@ export { ROOMOTE_COMPACT_PROMPT } from '../compact-prompt';
 
 export * from './cloud-agent-workflow';
 export * from './task-url';
+export * from './task-model-selection';
 export * from './task-run-queue';
 export * from './commit-author';
 export { getPrBodyAttributionLine } from './workflows/utils';

--- a/packages/cloud-agents/src/server/task-model-selection.ts
+++ b/packages/cloud-agents/src/server/task-model-selection.ts
@@ -1,0 +1,207 @@
+import {
+  db,
+  deploymentSettings,
+  eq,
+  isChatGptSubscriptionConnected,
+  taskRuns,
+  tasks,
+} from '@roomote/db/server';
+import {
+  DEFAULT_MODEL_ROLE_REASONING_EFFORTS,
+  TASK_MODEL_OVERRIDE_ROLES,
+  getDefaultTaskModelId,
+  getDisplayModelProviderId,
+  getTaskModelCatalog,
+  isReasoningEffort,
+  isTaskModelIdAllowed,
+  normalizeDeploymentModelConfig,
+  normalizeTaskModelSettings,
+  resolveTaskModelIdAlias,
+  type ReasoningEffort,
+  type TaskModelOverrideRole,
+  type TaskModelRoleOverrides,
+} from '@roomote/types';
+
+const DEFAULT_DEPLOYMENT_ID = 'default';
+const MODEL_ID_PATTERN = /^[^/\s]+\/.+$/u;
+
+export type TaskModelSelectionRole = 'coding' | TaskModelOverrideRole;
+
+export const TASK_MODEL_SELECTION_ROLES: readonly TaskModelSelectionRole[] = [
+  'coding',
+  ...TASK_MODEL_OVERRIDE_ROLES,
+];
+
+export class TaskModelSelectionError extends Error {
+  constructor(
+    message: string,
+    public readonly code:
+      | 'invalid_model'
+      | 'model_not_allowed'
+      | 'run_not_found'
+      | 'payload_missing',
+  ) {
+    super(message);
+    this.name = 'TaskModelSelectionError';
+  }
+}
+
+/**
+ * Validates and persists one model-role selection for a task run. Shared by
+ * the web task UI and the agent-facing platform API so both surfaces apply
+ * identical rules:
+ *
+ * - The coding role writes `payload.harnessModelOverrides` +
+ *   `payload.reasoningEffort` (the pair launch/resume/display already use)
+ *   and re-stamps `tasks.model` / `tasks.modelProvider` for display.
+ * - Other roles write sparse `payload.modelRoleOverrides` entries; a fully
+ *   cleared role falls back to the deployment role config.
+ *
+ * `model` / `reasoningEffort` carry the desired state; null means the
+ * deployment default. Persisting does NOT touch the live sandbox — callers
+ * follow up with the sandbox `applyTaskModelSettings` procedure when a live
+ * apply is wanted.
+ */
+export async function applyTaskModelSelectionToRun(options: {
+  runId: number;
+  role: TaskModelSelectionRole;
+  model: string | null;
+  reasoningEffort: ReasoningEffort | null;
+}): Promise<{ stampedTaskModel: string | null }> {
+  const deployment = await db.query.deploymentSettings.findFirst({
+    where: eq(deploymentSettings.id, DEFAULT_DEPLOYMENT_ID),
+    columns: {
+      taskModelSettings: true,
+      runtimeModelConfig: true,
+    },
+  });
+  const modelSettings = normalizeTaskModelSettings(
+    deployment?.taskModelSettings,
+  );
+  const runtimeModelConfig = normalizeDeploymentModelConfig(
+    deployment?.runtimeModelConfig,
+  );
+  const trimmedModel = options.model?.trim() || null;
+
+  if (trimmedModel && !MODEL_ID_PATTERN.test(trimmedModel)) {
+    throw new TaskModelSelectionError(
+      `Model "${trimmedModel}" must use provider/model format.`,
+      'invalid_model',
+    );
+  }
+
+  const requestedModelId = trimmedModel
+    ? resolveTaskModelIdAlias(trimmedModel)
+    : null;
+
+  if (
+    requestedModelId &&
+    !isTaskModelIdAllowed(modelSettings, requestedModelId)
+  ) {
+    throw new TaskModelSelectionError(
+      `Model "${requestedModelId}" is not enabled for tasks.`,
+      'model_not_allowed',
+    );
+  }
+
+  return await db.transaction(async (tx) => {
+    const run = await tx.query.taskRuns.findFirst({
+      where: eq(taskRuns.id, options.runId),
+      columns: { id: true, taskId: true, payload: true },
+    });
+
+    if (!run) {
+      throw new TaskModelSelectionError(
+        `Task run ${options.runId} not found.`,
+        'run_not_found',
+      );
+    }
+
+    if (!run.payload || typeof run.payload !== 'object') {
+      throw new TaskModelSelectionError(
+        'The task run has no payload to update.',
+        'payload_missing',
+      );
+    }
+
+    const payload = { ...run.payload };
+    let stampedTaskModel: string | null = null;
+
+    if (options.role === 'coding') {
+      const effectiveModel =
+        requestedModelId ?? getDefaultTaskModelId(modelSettings);
+      const catalogModel = getTaskModelCatalog(modelSettings).find(
+        (model) => model.id === effectiveModel,
+      );
+      const supportsReasoning =
+        catalogModel?.metadata?.supportsReasoning !== false;
+
+      payload.harnessModelOverrides = {
+        ...(payload.harnessModelOverrides ?? {}),
+        'opencode-server': effectiveModel,
+      };
+
+      if (options.reasoningEffort && supportsReasoning) {
+        payload.reasoningEffort = options.reasoningEffort;
+      } else if (requestedModelId && supportsReasoning) {
+        // Mirror launch-time stamping: an explicitly selected model runs at
+        // the deployment coding level (env wins over the persisted config)
+        // instead of falling through to no reasoning when the role env level
+        // does not match the override model.
+        const envCodingEffort = process.env.R_MODEL_REASONING_EFFORT?.trim();
+
+        payload.reasoningEffort =
+          (isReasoningEffort(envCodingEffort)
+            ? envCodingEffort
+            : runtimeModelConfig.roomoteModelReasoningEffort) ??
+          DEFAULT_MODEL_ROLE_REASONING_EFFORTS.coding;
+      } else {
+        delete payload.reasoningEffort;
+      }
+
+      stampedTaskModel = effectiveModel;
+    } else {
+      const overrides: TaskModelRoleOverrides = {
+        ...(payload.modelRoleOverrides ?? {}),
+      };
+      const entry = {
+        ...(requestedModelId ? { model: requestedModelId } : {}),
+        ...(options.reasoningEffort
+          ? { reasoningEffort: options.reasoningEffort }
+          : {}),
+      };
+
+      if (Object.keys(entry).length > 0) {
+        overrides[options.role] = entry;
+      } else {
+        delete overrides[options.role];
+      }
+
+      if (Object.keys(overrides).length > 0) {
+        payload.modelRoleOverrides = overrides;
+      } else {
+        delete payload.modelRoleOverrides;
+      }
+    }
+
+    await tx.update(taskRuns).set({ payload }).where(eq(taskRuns.id, run.id));
+
+    if (stampedTaskModel && run.taskId) {
+      const chatgptConnected = stampedTaskModel.startsWith('openai/')
+        ? await isChatGptSubscriptionConnected(tx)
+        : false;
+
+      await tx
+        .update(tasks)
+        .set({
+          model: stampedTaskModel,
+          modelProvider:
+            getDisplayModelProviderId(stampedTaskModel, { chatgptConnected }) ??
+            'opencode',
+        })
+        .where(eq(tasks.id, run.taskId));
+    }
+
+    return { stampedTaskModel };
+  });
+}

--- a/packages/cloud-agents/src/server/task-model-selection.ts
+++ b/packages/cloud-agents/src/server/task-model-selection.ts
@@ -105,10 +105,19 @@ export async function applyTaskModelSelectionToRun(options: {
   }
 
   return await db.transaction(async (tx) => {
-    const run = await tx.query.taskRuns.findFirst({
-      where: eq(taskRuns.id, options.runId),
-      columns: { id: true, taskId: true, payload: true },
-    });
+    // Lock the run row for the read-modify-write below: concurrent role
+    // updates (the UI's reset fan-out, or the web mutation racing the
+    // agent's update_models call) would otherwise each derive the next
+    // payload from the same snapshot and silently drop each other's writes.
+    const [run] = await tx
+      .select({
+        id: taskRuns.id,
+        taskId: taskRuns.taskId,
+        payload: taskRuns.payload,
+      })
+      .from(taskRuns)
+      .where(eq(taskRuns.id, options.runId))
+      .for('update');
 
     if (!run) {
       throw new TaskModelSelectionError(

--- a/packages/cloud-agents/src/server/task-run-queue.ts
+++ b/packages/cloud-agents/src/server/task-run-queue.ts
@@ -2189,6 +2189,7 @@ async function enqueueSnapshotResume(
   const sourceRunPayloadModelState = sourceRun.payload as {
     harnessModelOverrides?: import('@roomote/types').HarnessModelOverrides;
     modelRoleOverrides?: import('@roomote/types').TaskModelRoleOverrides;
+    reasoningEffort?: unknown;
   } | null;
   const sourceRunHarnessModelOverrides =
     sourceRunPayloadModelState?.harnessModelOverrides;
@@ -2202,6 +2203,18 @@ async function enqueueSnapshotResume(
   ) {
     task.payload.modelRoleOverrides =
       sourceRunPayloadModelState.modelRoleOverrides;
+  }
+
+  // An explicit coding reasoning level inherits centrally too. Entry points
+  // that build richer resume prompts already copy it via
+  // restoreSnapshotResumeVisiblePromptFields, but resumes that skip that
+  // helper would otherwise keep the model override while
+  // applyOverrideTaskReasoningEffort re-stamps the deployment default level.
+  if (
+    !task.payload.reasoningEffort &&
+    isReasoningEffort(sourceRunPayloadModelState?.reasoningEffort)
+  ) {
+    task.payload.reasoningEffort = sourceRunPayloadModelState.reasoningEffort;
   }
 
   let sourceTaskType = sourceRun.payloadKind;

--- a/packages/cloud-agents/src/server/task-run-queue.ts
+++ b/packages/cloud-agents/src/server/task-run-queue.ts
@@ -2186,11 +2186,24 @@ async function enqueueSnapshotResume(
 
   const sourceJobHarness = sourceRun.harness;
   const sourceJobVendor = resolveComputeProviderTarget(sourceRun.vendor);
-  const sourceRunHarnessModelOverrides = (
-    sourceRun.payload as {
-      harnessModelOverrides?: import('@roomote/types').HarnessModelOverrides;
-    }
-  )?.harnessModelOverrides;
+  const sourceRunPayloadModelState = sourceRun.payload as {
+    harnessModelOverrides?: import('@roomote/types').HarnessModelOverrides;
+    modelRoleOverrides?: import('@roomote/types').TaskModelRoleOverrides;
+  } | null;
+  const sourceRunHarnessModelOverrides =
+    sourceRunPayloadModelState?.harnessModelOverrides;
+
+  // Per-role model overrides ride the same inheritance: every resume
+  // re-stamps them onto its own payload, so reading the immediate source run
+  // is enough to carry them through arbitrarily long resume chains.
+  if (
+    !task.payload.modelRoleOverrides &&
+    sourceRunPayloadModelState?.modelRoleOverrides
+  ) {
+    task.payload.modelRoleOverrides =
+      sourceRunPayloadModelState.modelRoleOverrides;
+  }
+
   let sourceTaskType = sourceRun.payloadKind;
   let parentRunId = sourceRun.sourceRunId;
 

--- a/packages/sdk/src/sandbox-router.ts
+++ b/packages/sdk/src/sandbox-router.ts
@@ -190,6 +190,16 @@ export interface SandboxSuccessResult {
   success: true;
 }
 
+export interface SandboxApplyTaskModelSettingsResult {
+  success: true;
+  /**
+   * How the live harness took the persisted model settings: restarted now
+   * (idle), deferred to the next queued-prompt delivery, or unavailable
+   * because the harness is shutting down.
+   */
+  application: 'restarted' | 'deferred' | 'unavailable';
+}
+
 export interface SandboxSubscriptionObserver<TData> {
   onStarted?: () => void;
   onData?: (data: TData) => void;
@@ -261,6 +271,10 @@ export interface SandboxServerRpcClient {
     >;
     touchKeepalive: SandboxMutation<undefined, SandboxSuccessResult>;
     reloadDeploymentEnvVars: SandboxMutation<undefined, SandboxSuccessResult>;
+    applyTaskModelSettings: SandboxMutation<
+      undefined,
+      SandboxApplyTaskModelSettingsResult
+    >;
     scrubSnapshotSecrets: SandboxMutation<undefined, SandboxSuccessResult>;
     restoreScrubbedCredentials: SandboxMutation<
       undefined,

--- a/packages/types/src/model-provider-config.ts
+++ b/packages/types/src/model-provider-config.ts
@@ -1,7 +1,10 @@
 import {
   isReasoningEffort,
   REASONING_EFFORT_VALUES,
+  TASK_MODEL_OVERRIDE_ROLES,
   type ReasoningEffort,
+  type TaskModelOverrideRole,
+  type TaskModelRoleOverrides,
 } from './task-runs';
 import {
   OPENROUTER_RECOMMENDED_TASK_MODEL_SLUGS,
@@ -1101,6 +1104,72 @@ export const DEFAULT_MODEL_ROLE_REASONING_EFFORTS = {
   explore: 'low',
   planning: 'high',
 } as const satisfies Record<TaskModelRole, ReasoningEffort>;
+
+/**
+ * Runtime env var names carrying each overridable non-coding role's model and
+ * reasoning level into the sandbox. Must stay in sync with the env bag
+ * emitted by `resolveModelRuntimeEnv` in packages/db and consumed by the
+ * worker's OpenCode config generation.
+ */
+export const TASK_MODEL_OVERRIDE_ROLE_ENV_VARS = {
+  helper: {
+    model: 'R_SMALL_MODEL',
+    reasoningEffort: 'R_SMALL_MODEL_REASONING_EFFORT',
+  },
+  vision: {
+    model: 'R_VISION_MODEL',
+    reasoningEffort: 'R_VISION_MODEL_REASONING_EFFORT',
+  },
+  codeReview: {
+    model: 'R_CODE_REVIEW_MODEL',
+    reasoningEffort: 'R_CODE_REVIEW_MODEL_REASONING_EFFORT',
+  },
+  explore: {
+    model: 'R_EXPLORE_MODEL',
+    reasoningEffort: 'R_EXPLORE_MODEL_REASONING_EFFORT',
+  },
+  planning: {
+    model: 'R_PLANNING_MODEL',
+    reasoningEffort: 'R_PLANNING_MODEL_REASONING_EFFORT',
+  },
+} as const satisfies Record<
+  TaskModelOverrideRole,
+  { model: string; reasoningEffort: string }
+>;
+
+/**
+ * Materializes a task's per-role overrides into the runtime env var overlay
+ * the worker applies on top of the deployment role env vars at harness spawn.
+ */
+export function buildTaskModelRoleOverrideEnv(
+  overrides: TaskModelRoleOverrides | null | undefined,
+): Record<string, string> {
+  const env: Record<string, string> = {};
+
+  if (!overrides) {
+    return env;
+  }
+
+  for (const role of TASK_MODEL_OVERRIDE_ROLES) {
+    const override = overrides[role];
+
+    if (!override) {
+      continue;
+    }
+
+    const envVarNames = TASK_MODEL_OVERRIDE_ROLE_ENV_VARS[role];
+
+    if (override.model?.trim()) {
+      env[envVarNames.model] = override.model.trim();
+    }
+
+    if (override.reasoningEffort) {
+      env[envVarNames.reasoningEffort] = override.reasoningEffort;
+    }
+  }
+
+  return env;
+}
 
 const DEFAULT_RECOMMENDED_PRESET_ID = 'default';
 

--- a/packages/types/src/task-runs.ts
+++ b/packages/types/src/task-runs.ts
@@ -332,6 +332,44 @@ const openCodeModelOverrideSchema = z
   .min(1)
   .regex(/^[^/\s]+\/.+$/u, 'OpenCode model must use provider/model format.');
 
+/**
+ * Non-coding model roles a task can override per run. The coding role is
+ * intentionally absent: per-task coding model and reasoning selections keep
+ * flowing through `payload.harnessModelOverrides` and
+ * `payload.reasoningEffort`, which launch, resume, and display paths already
+ * understand. Keys mirror `TaskModelRole` in model-provider-config.
+ */
+export const TASK_MODEL_OVERRIDE_ROLES = [
+  'helper',
+  'vision',
+  'codeReview',
+  'explore',
+  'planning',
+] as const;
+
+export type TaskModelOverrideRole = (typeof TASK_MODEL_OVERRIDE_ROLES)[number];
+
+export const taskModelRoleOverrideSchema = z.object({
+  /** Model id in provider/model format; unset roles keep the deployment model. */
+  model: openCodeModelOverrideSchema.optional(),
+  /** Reasoning level for the role; unset keeps the deployment level. */
+  reasoningEffort: z.enum(REASONING_EFFORT_VALUES).optional(),
+});
+
+export type TaskModelRoleOverride = z.infer<typeof taskModelRoleOverrideSchema>;
+
+export const taskModelRoleOverridesSchema = z.object({
+  helper: taskModelRoleOverrideSchema.optional(),
+  vision: taskModelRoleOverrideSchema.optional(),
+  codeReview: taskModelRoleOverrideSchema.optional(),
+  explore: taskModelRoleOverrideSchema.optional(),
+  planning: taskModelRoleOverrideSchema.optional(),
+} satisfies Record<TaskModelOverrideRole, unknown>);
+
+export type TaskModelRoleOverrides = z.infer<
+  typeof taskModelRoleOverridesSchema
+>;
+
 export const SUGGESTION_CATEGORIES: readonly SuggestionCategory[] = [
   'bug',
   'security',
@@ -971,6 +1009,15 @@ const sharedTaskPayloadSchema = z.object({
       'opencode-server': openCodeModelOverrideSchema.optional(),
     })
     .optional(),
+
+  /**
+   * Per-task model and reasoning overrides for the non-coding model roles,
+   * editable from the task UI mid-run. Applied by the worker on top of the
+   * deployment role env vars at every harness spawn, so a config-update
+   * restart or snapshot resume picks up the current values. The coding role
+   * uses `harnessModelOverrides` + `reasoningEffort` above.
+   */
+  modelRoleOverrides: taskModelRoleOverridesSchema.optional(),
 
   /**
    * Optional provider-neutral work-item references that PR-delivery workflows


### PR DESCRIPTION
## What

Each task now has a local, editable set of model and reasoning selections per role. A model chip in the web task composer shows the task's current coding model and reasoning level; opening it lets you switch the coding model, and an **All roles** expander overrides the planning, code review, explore, helper, or vision role for that task only. Changes apply from the next message, persist across snapshot resumes, and **Reset to defaults** returns every role to the deployment configuration.

The agent can also change its own task's models when asked in-conversation, via a new `manage_tasks` action `update_models` backed by `POST /api/mcp/tasks/:taskId/model_selection`.

## How

- **Storage** — the coding role keeps using `payload.harnessModelOverrides` + `payload.reasoningEffort` (the pair launch, resume, display, and billing already understand); the five non-coding roles persist in a new sparse `payload.modelRoleOverrides` map (`packages/types`). Snapshot resumes inherit the map; each resume re-stamps it so reading the immediate source run covers arbitrarily long chains.
- **Runtime** — the worker overlays the role overrides onto the deployment `R_*` env at every harness spawn, so any respawn regenerates the OpenCode config from current settings. A new sandbox procedure `applyTaskModelSettings` re-reads the persisted payload and restarts the harness: immediately when idle, otherwise deferred to the next queued-prompt delivery (the prompt is restored and replayed on the new models). `beforeQueuedPrompt` now carries a delivery `kind` so the deferred restart can never fail a pending user-input answer.
- **Validation** — a shared `applyTaskModelSelectionToRun` core in `cloud-agents` enforces the allowed-models list, stamps the coding reasoning level the same way launch does, and updates run payload + `tasks.model`/`modelProvider` in one transaction. Both the web tRPC mutation (`sandboxSession.updateTaskModelSelection`) and the MCP API handler use it.
- **UI** — new `TaskModelSwitcher` popover in the composer footer (reuses `ModelSelect`; `ReasoningEffortSelect` extracted from the admin models page into a shared component), overridden-role indicators, a non-admin `taskModels.roleDefaults` query for labeling deployment defaults, and a Customized badge in the Task Info panel.

## Semantics

An in-flight turn finishes on the old settings; the next turn (including its sub-agents) uses the new ones. If no live sandbox is reachable the selection still persists and applies on the next resume. The mutation reports which of these happened so the UI can phrase the toast accordingly.

## Testing

- Unit coverage: payload schema, env-overlay builder, per-spawn re-read on harness respawn, resume inheritance (real-DB test), `beforeQueuedPrompt` kind plumbing, MCP tool action list.
- `pnpm lint`, `pnpm check-types`, `pnpm knip`, and the test suites for `types`, `cloud-agents`, `worker`, `web`, and `api` pass.
- Verified end-to-end on a live deployment: switched an active task's coding model mid-task and the next reply came from the newly selected model; role override + reset + Task Info badge verified; asked the agent to switch models conversationally and it applied the change through `update_models` with the helper-role override preserved.

## Docs

`apps/docs/models.mdx` gains a "Per-task model switching" section.