### PR TITLE
[Fix] Installer health check asserts a marker that never existed

### DIFF
--- a/.github/workflows/installer-endpoint-health.yml
+++ b/.github/workflows/installer-endpoint-health.yml
@@ -19,10 +19,10 @@ jobs:
           set -euo pipefail
 
           installer="$(curl -fsSL --retry 3 https://get.roomote.dev)"
-          grep -Fq '# Roomote self-hosted installer' <<< "$installer"
+          grep -Fq '# Roomote one-command installer' <<< "$installer"
 
           install_sh="$(curl -fsSL --retry 3 https://get.roomote.dev/install.sh)"
-          grep -Fq '# Roomote self-hosted installer' <<< "$install_sh"
+          grep -Fq '# Roomote one-command installer' <<< "$install_sh"
 
           latest="$(curl -fsSL --retry 3 https://get.roomote.dev/latest-version)"
           grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+' <<< "$latest"


### PR DESCRIPTION
## What changed

The scheduled `Installer endpoint health` smoke test (added in #1275) greps the served installer for `# Roomote self-hosted installer`, a string that has never appeared in `deploy/install.sh` — the real header is `# Roomote one-command installer for a single self-managed host.` The first assertion therefore fails on every run regardless of endpoint health (e.g. [this run](https://github.com/RooCodeInc/Roomote/actions/runs/31655249597), which executed after the endpoint was redeployed and verified healthy).

This updates both greps to assert on the header the installer actually serves, verified against the live `get.roomote.dev` response.

## Impact

The health workflow reports real endpoint status instead of a guaranteed failure.