### PR TITLE
[Fix] Restore Grok subscription usage bar in Models settings

### DIFF
--- a/.changeset/restore-grok-usage-bar.md
+++ b/.changeset/restore-grok-usage-bar.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Restore the xAI Grok subscription usage bar in Models settings. The unofficial billing proxy now omits usage percent unless the request sends Grok CLI identity headers.

--- a/packages/db/src/lib/__tests__/subscription-provider-usage.test.ts
+++ b/packages/db/src/lib/__tests__/subscription-provider-usage.test.ts
@@ -633,6 +633,29 @@ describe('parseXaiSubscriptionUsage', () => {
     expect(parseXaiSubscriptionUsage({})).toEqual([]);
     expect(parseXaiSubscriptionUsage({ plan: 'pro' })).toEqual([]);
   });
+
+  it('does not invent a window from period metadata without creditUsagePercent', () => {
+    // Live cli-chat-proxy response when Grok CLI identity headers are omitted:
+    // 200 with weekly period fields, but no creditUsagePercent / productUsage.
+    expect(
+      parseXaiSubscriptionUsage({
+        config: {
+          currentPeriod: {
+            type: 'USAGE_PERIOD_TYPE_WEEKLY',
+            start: '2026-08-07T01:21:57.505552+00:00',
+            end: '2026-08-14T01:21:57.505552+00:00',
+          },
+          onDemandCap: { val: 0 },
+          onDemandUsed: { val: 0 },
+          isUnifiedBillingUser: true,
+          prepaidBalance: { val: 0 },
+          topUpMethod: 'TOP_UP_METHOD_SAVED_PAYMENT_METHOD',
+          billingPeriodStart: '2026-08-07T01:21:57.505552+00:00',
+          billingPeriodEnd: '2026-08-14T01:21:57.505552+00:00',
+        },
+      }),
+    ).toEqual([]);
+  });
 });
 
 describe('fetchXaiSubscriptionUsage', () => {
@@ -686,6 +709,50 @@ describe('fetchXaiSubscriptionUsage', () => {
       expect.objectContaining({
         headers: expect.objectContaining({
           authorization: 'Bearer xai-access',
+        }),
+      }),
+    );
+  });
+
+  it('sends Grok CLI identity headers so the billing proxy returns usage', async () => {
+    mockGetFreshXaiAccessToken.mockResolvedValue({
+      access: 'xai-access',
+      expires: Date.now() + 3_600_000,
+    });
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ userId: 'user-1' }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          config: { creditUsagePercent: 27 },
+        }),
+      );
+
+    await fetchXaiSubscriptionUsage({ fetchImpl });
+
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      'https://cli-chat-proxy.grok.com/v1/user',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: 'Bearer xai-access',
+          'user-agent': 'roomote',
+        }),
+      }),
+    );
+    expect(
+      (fetchImpl.mock.calls[0]?.[1] as { headers: Record<string, string> })
+        .headers,
+    ).not.toHaveProperty('X-XAI-Token-Auth');
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      'https://cli-chat-proxy.grok.com/v1/billing?format=credits',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: 'Bearer xai-access',
+          'X-XAI-Token-Auth': 'xai-grok-cli',
+          'x-grok-client-identifier': 'grok-shell',
+          'x-grok-client-mode': 'billing',
         }),
       }),
     );

--- a/packages/db/src/lib/__tests__/subscription-provider-usage.test.ts
+++ b/packages/db/src/lib/__tests__/subscription-provider-usage.test.ts
@@ -728,8 +728,12 @@ describe('fetchXaiSubscriptionUsage', () => {
         }),
       );
 
-    await fetchXaiSubscriptionUsage({ fetchImpl });
+    const usage = await fetchXaiSubscriptionUsage({ fetchImpl });
 
+    expect(usage).toMatchObject({
+      providerId: 'xai-subscription',
+      windows: [{ label: 'Included usage', usedPercent: 27 }],
+    });
     expect(fetchImpl).toHaveBeenNthCalledWith(
       1,
       'https://cli-chat-proxy.grok.com/v1/user',
@@ -740,10 +744,12 @@ describe('fetchXaiSubscriptionUsage', () => {
         }),
       }),
     );
-    expect(
-      (fetchImpl.mock.calls[0]?.[1] as { headers: Record<string, string> })
-        .headers,
-    ).not.toHaveProperty('X-XAI-Token-Auth');
+    const userHeaders = (
+      fetchImpl.mock.calls[0]?.[1] as { headers: Record<string, string> }
+    ).headers;
+    expect(userHeaders).not.toHaveProperty('X-XAI-Token-Auth');
+    expect(userHeaders).not.toHaveProperty('x-grok-client-identifier');
+    expect(userHeaders).not.toHaveProperty('x-grok-client-mode');
     expect(fetchImpl).toHaveBeenNthCalledWith(
       2,
       'https://cli-chat-proxy.grok.com/v1/billing?format=credits',

--- a/packages/db/src/lib/__tests__/subscription-provider-usage.test.ts
+++ b/packages/db/src/lib/__tests__/subscription-provider-usage.test.ts
@@ -709,6 +709,10 @@ describe('fetchXaiSubscriptionUsage', () => {
       expect.objectContaining({
         headers: expect.objectContaining({
           authorization: 'Bearer xai-access',
+          'X-XAI-Token-Auth': 'xai-grok-cli',
+          'x-grok-client-identifier': 'grok-shell',
+          'x-grok-client-mode': 'billing',
+          'x-userid': 'user-1',
         }),
       }),
     );
@@ -750,6 +754,7 @@ describe('fetchXaiSubscriptionUsage', () => {
     expect(userHeaders).not.toHaveProperty('X-XAI-Token-Auth');
     expect(userHeaders).not.toHaveProperty('x-grok-client-identifier');
     expect(userHeaders).not.toHaveProperty('x-grok-client-mode');
+    expect(userHeaders).not.toHaveProperty('x-userid');
     expect(fetchImpl).toHaveBeenNthCalledWith(
       2,
       'https://cli-chat-proxy.grok.com/v1/billing?format=credits',
@@ -759,6 +764,7 @@ describe('fetchXaiSubscriptionUsage', () => {
           'X-XAI-Token-Auth': 'xai-grok-cli',
           'x-grok-client-identifier': 'grok-shell',
           'x-grok-client-mode': 'billing',
+          'x-userid': 'user-1',
         }),
       }),
     );

--- a/packages/db/src/lib/subscription-provider-usage/xai.ts
+++ b/packages/db/src/lib/subscription-provider-usage/xai.ts
@@ -193,15 +193,14 @@ export async function fetchXaiSubscriptionUsage(
   };
   const user = await fetchJson(fetchImpl, XAI_USAGE_USER_ENDPOINT, headers);
   const identity = asRecord(user.payload);
-  if (
-    user.status !== 200 ||
-    (!firstString(identity, ['userId', 'user_id', 'id']) &&
-      !firstNumber(identity, ['userId', 'id']))
-  )
-    return null;
+  const userId =
+    firstString(identity, ['userId', 'user_id', 'id']) ??
+    firstNumber(identity, ['userId', 'id'])?.toString();
+  if (user.status !== 200 || !userId) return null;
   const billing = await fetchJson(fetchImpl, XAI_USAGE_BILLING_ENDPOINT, {
     ...headers,
     ...XAI_USAGE_CLI_IDENTITY_HEADERS,
+    'x-userid': userId,
   });
   const windows = parseXaiSubscriptionUsage(billing.payload, Date.now());
   return windows.length > 0

--- a/packages/db/src/lib/subscription-provider-usage/xai.ts
+++ b/packages/db/src/lib/subscription-provider-usage/xai.ts
@@ -1,5 +1,6 @@
 import {
   XAI_USAGE_BILLING_ENDPOINT,
+  XAI_USAGE_CLI_IDENTITY_HEADERS,
   XAI_USAGE_USER_ENDPOINT,
   type SubscriptionProviderUsage,
   type SubscriptionUsageWindow,
@@ -198,11 +199,10 @@ export async function fetchXaiSubscriptionUsage(
       !firstNumber(identity, ['userId', 'id']))
   )
     return null;
-  const billing = await fetchJson(
-    fetchImpl,
-    XAI_USAGE_BILLING_ENDPOINT,
-    headers,
-  );
+  const billing = await fetchJson(fetchImpl, XAI_USAGE_BILLING_ENDPOINT, {
+    ...headers,
+    ...XAI_USAGE_CLI_IDENTITY_HEADERS,
+  });
   const windows = parseXaiSubscriptionUsage(billing.payload, Date.now());
   return windows.length > 0
     ? {

--- a/packages/types/src/subscription-provider-usage.ts
+++ b/packages/types/src/subscription-provider-usage.ts
@@ -103,8 +103,9 @@ export const OPENCODE_GO_USAGE_ENDPOINT = 'https://opencode.ai/zen/go/v1/usage';
  * The proxy strips `creditUsagePercent` / `productUsage` unless the request
  * carries the Grok CLI identity fingerprint below. A bare Bearer request
  * still returns 200 with period metadata, so callers must send these
- * headers or the Settings usage bar silently disappears. Do not add
- * `x-grok-client-version`: a pinned version 426s once Grok CLI moves on.
+ * headers or the Settings usage bar silently disappears. Billing also
+ * forwards `x-userid` from `/v1/user`. Do not add `x-grok-client-version`:
+ * a pinned version 426s once Grok CLI moves on.
  */
 export const XAI_CLI_CHAT_PROXY_BASE_URL = 'https://cli-chat-proxy.grok.com';
 export const XAI_USAGE_USER_ENDPOINT = `${XAI_CLI_CHAT_PROXY_BASE_URL}/v1/user`;

--- a/packages/types/src/subscription-provider-usage.ts
+++ b/packages/types/src/subscription-provider-usage.ts
@@ -99,10 +99,20 @@ export const OPENCODE_GO_USAGE_ENDPOINT = 'https://opencode.ai/zen/go/v1/usage';
  * Unofficial Grok CLI session proxy used for SuperGrok / Premium+ billing
  * lookups (same surface Grok Build and peer OAuth tools poll). Not a stable
  * public API; parse defensively and omit usage on failure.
+ *
+ * The proxy now strips `creditUsagePercent` / `productUsage` unless the
+ * request carries the Grok CLI identity fingerprint below. A bare Bearer
+ * request still returns 200 with period metadata, so callers must send
+ * these headers or the Settings usage bar silently disappears.
  */
 export const XAI_CLI_CHAT_PROXY_BASE_URL = 'https://cli-chat-proxy.grok.com';
 export const XAI_USAGE_USER_ENDPOINT = `${XAI_CLI_CHAT_PROXY_BASE_URL}/v1/user`;
 export const XAI_USAGE_BILLING_ENDPOINT = `${XAI_CLI_CHAT_PROXY_BASE_URL}/v1/billing?format=credits`;
+export const XAI_USAGE_CLI_IDENTITY_HEADERS = {
+  'X-XAI-Token-Auth': 'xai-grok-cli',
+  'x-grok-client-identifier': 'grok-shell',
+  'x-grok-client-mode': 'billing',
+} as const;
 
 /**
  * Undocumented Z.AI / BigModel monitor quota endpoint polled by Coding Plan

--- a/packages/types/src/subscription-provider-usage.ts
+++ b/packages/types/src/subscription-provider-usage.ts
@@ -100,10 +100,11 @@ export const OPENCODE_GO_USAGE_ENDPOINT = 'https://opencode.ai/zen/go/v1/usage';
  * lookups (same surface Grok Build and peer OAuth tools poll). Not a stable
  * public API; parse defensively and omit usage on failure.
  *
- * The proxy now strips `creditUsagePercent` / `productUsage` unless the
- * request carries the Grok CLI identity fingerprint below. A bare Bearer
- * request still returns 200 with period metadata, so callers must send
- * these headers or the Settings usage bar silently disappears.
+ * The proxy strips `creditUsagePercent` / `productUsage` unless the request
+ * carries the Grok CLI identity fingerprint below. A bare Bearer request
+ * still returns 200 with period metadata, so callers must send these
+ * headers or the Settings usage bar silently disappears. Do not add
+ * `x-grok-client-version`: a pinned version 426s once Grok CLI moves on.
  */
 export const XAI_CLI_CHAT_PROXY_BASE_URL = 'https://cli-chat-proxy.grok.com';
 export const XAI_USAGE_USER_ENDPOINT = `${XAI_CLI_CHAT_PROXY_BASE_URL}/v1/user`;


### PR DESCRIPTION
## Related issue

No GitHub issue. Reported directly: the xAI Grok usage bar in Models settings disappeared.

## Why this PR exists

- [ ] A maintainer explicitly invited this PR in the linked issue or discussion
- [ ] I am a maintainer / this is internal Roomote work

Opened from a working session after reproducing the missing bar against the live billing proxy.

## What changed

The unofficial Grok billing proxy (`cli-chat-proxy.grok.com/v1/billing?format=credits`) still returns HTTP 200, but it now omits `creditUsagePercent` unless the request sends Grok CLI identity headers. Roomote was sending only Bearer + `user-agent: roomote`, so the parser saw an empty payload and hid the bar.

Usage fetches now send the same identity fingerprint Grok CLI uses for `/usage`:

- `X-XAI-Token-Auth: xai-grok-cli`
- `x-grok-client-identifier: grok-shell`
- `x-grok-client-mode: billing`

Those headers are attached only to the billing request, not `/v1/user`. The parser is unchanged. Client version is not pinned (avoids a future 426).

## How it was tested

- Live probe: bare Bearer request returns period metadata and no `creditUsagePercent`; adding the identity headers restores the percent.
- `pnpm --filter @roomote/db exec vitest run src/lib/__tests__/subscription-provider-usage.test.ts` — 36 passed
- `pnpm --filter @roomote/db check-types` and `pnpm --filter @roomote/types check-types` — clean
- New tests: fetch sends the billing identity headers; the stripped live payload does not invent a usage window

## Checklist

- [x] The PR title follows the repo convention: `[Fix]`, `[Feat]`, `[Improve]`, `[Refactor]`, `[Docs]`, or `[Chore]` followed by a user-facing description
- [x] This PR is small and scoped to one change
- [ ] `pnpm lint` and `pnpm check-types` pass locally
- [x] I added tests or included a clear manual validation note above
- [x] I removed secrets, tokens, private keys, and customer data from code, logs, and screenshots
- [x] If this change should appear in the changelog, I ran `pnpm changeset`

Full-repo `pnpm lint` / `pnpm check-types` were not run. Package-scoped usage tests and db/types `check-types` passed.