### PR TITLE
[Fix] Routing fails when a Bedrock helper model has reasoning enabled

### DIFF
--- a/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
@@ -483,7 +483,9 @@ describe('resolveOpenCodeSmallModel', () => {
         prompt: 'Answer.',
       }),
     ).rejects.toThrow(
-      'OpenCode structured prompt failed: StructuredOutputError: failed to satisfy schema',
+      // The resolved provider/model id rides in the message so a router
+      // fallback log names the model without a database lookup.
+      'OpenCode structured prompt failed (model openrouter/z-ai/glm-5.2): StructuredOutputError: failed to satisfy schema',
     );
   });
 

--- a/packages/cloud-agents/src/server/__tests__/opencode-runtime.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/opencode-runtime.test.ts
@@ -141,7 +141,10 @@ describe('buildOpenCodeCliEnv', () => {
     });
   });
 
-  it('applies per-role reasoning options to the model-backed config', () => {
+  it('strips per-role reasoning options from the restricted helper config', () => {
+    // Non-task structured output forces tool choice, which Amazon Bedrock
+    // rejects when thinking is enabled — so helper servers run without the
+    // operator's coding-harness reasoning levels on every provider.
     const env = buildOpenCodeCliEnv({
       R_MODEL: 'openrouter/openai/gpt-5.4',
       R_SMALL_MODEL: 'openrouter/z-ai/glm-5.2',
@@ -153,18 +156,45 @@ describe('buildOpenCodeCliEnv', () => {
       model: 'openrouter/openai/gpt-5.4',
       small_model: 'openrouter/z-ai/glm-5.2',
       permission: NON_TASK_TOOL_PERMISSION_DENIALS,
-      provider: {
-        openrouter: {
-          models: {
-            'openai/gpt-5.4': {
-              options: { reasoning: { effort: 'high' } },
-            },
-            'z-ai/glm-5.2': {
-              options: { reasoning: { effort: 'low' } },
+    });
+  });
+
+  it('strips Bedrock thinking config while keeping the model selection', () => {
+    const env = buildOpenCodeCliEnv({
+      R_MODEL: 'amazon-bedrock/anthropic.claude-sonnet-5-v1:0',
+      R_SMALL_MODEL: 'amazon-bedrock/anthropic.claude-haiku-4-5-v1:0',
+      R_SMALL_MODEL_REASONING_EFFORT: 'medium',
+    });
+
+    expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
+      model: 'amazon-bedrock/anthropic.claude-sonnet-5-v1:0',
+      small_model: 'amazon-bedrock/anthropic.claude-haiku-4-5-v1:0',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
+    });
+  });
+
+  it('strips thinking options from operator-supplied config content', () => {
+    const env = buildOpenCodeCliEnv({
+      OPENCODE_CONFIG_CONTENT: JSON.stringify({
+        model: 'anthropic/claude-sonnet-5',
+        provider: {
+          anthropic: {
+            models: {
+              'claude-sonnet-5': {
+                options: {
+                  thinking: { type: 'adaptive' },
+                  effort: 'high',
+                },
+              },
             },
           },
         },
-      },
+      }),
+    });
+
+    expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
+      model: 'anthropic/claude-sonnet-5',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
     });
   });
 
@@ -184,10 +214,9 @@ describe('buildOpenCodeCliEnv', () => {
         openai: {
           models: {
             'gpt-5.6-terra': {
-              options: {
-                reasoningEffort: 'high',
-                serviceTier: 'priority',
-              },
+              // reasoningEffort is stripped for helper servers; the fast-mode
+              // service tier is not a reasoning option and survives.
+              options: { serviceTier: 'priority' },
             },
             'gpt-5.6-luna': {
               options: { serviceTier: 'priority' },
@@ -212,10 +241,9 @@ describe('buildOpenCodeCliEnv', () => {
         openrouter: {
           models: {
             'z-ai/glm-5.2': {
-              options: {
-                reasoning: { effort: 'high' },
-                provider: { sort: 'throughput' },
-              },
+              // The variant's routing options survive; the reasoning option
+              // is stripped for helper servers.
+              options: { provider: { sort: 'throughput' } },
             },
           },
         },
@@ -243,7 +271,11 @@ describe('buildOpenCodeCliEnv', () => {
     });
   });
 
-  it('lets the coding model reasoning level win when both roles share a model', () => {
+  it('prunes the provider subtree when reasoning was its only content', () => {
+    // Role precedence for shared models is covered by the
+    // mergeOpenCodeModelReasoningOptions tests in @roomote/types; here the
+    // merged reasoning is stripped again for helper servers, so nothing of
+    // the provider subtree remains.
     const env = buildOpenCodeCliEnv({
       R_MODEL: 'openrouter/openai/gpt-5.4',
       R_SMALL_MODEL: 'openrouter/openai/gpt-5.4',
@@ -255,15 +287,6 @@ describe('buildOpenCodeCliEnv', () => {
       model: 'openrouter/openai/gpt-5.4',
       small_model: 'openrouter/openai/gpt-5.4',
       permission: NON_TASK_TOOL_PERMISSION_DENIALS,
-      provider: {
-        openrouter: {
-          models: {
-            'openai/gpt-5.4': {
-              options: { reasoning: { effort: 'high' } },
-            },
-          },
-        },
-      },
     });
   });
 

--- a/packages/cloud-agents/src/server/non-task-provider-usage.ts
+++ b/packages/cloud-agents/src/server/non-task-provider-usage.ts
@@ -443,7 +443,7 @@ async function runNonTaskSdkPrompt(
 
     if (sessionResult.error || !sessionResult.data) {
       throw new Error(
-        `OpenCode structured session creation failed: ${formatOpenCodeSdkError(sessionResult.error)}`,
+        `OpenCode structured session creation failed (model ${model}): ${formatOpenCodeSdkError(sessionResult.error)}`,
       );
     }
 
@@ -459,8 +459,12 @@ async function runNonTaskSdkPrompt(
     );
 
     if (promptResult.error || !promptResult.data) {
+      // The resolved `provider/model` id rides in the message because callers
+      // (the router's fallback log among them) only know the role alias —
+      // production diagnosis of a provider-specific rejection needs the real
+      // id and provider without a database lookup.
       throw new Error(
-        `OpenCode structured prompt failed: ${formatOpenCodeSdkError(promptResult.error)}`,
+        `OpenCode structured prompt failed (model ${model}): ${formatOpenCodeSdkError(promptResult.error)}`,
       );
     }
 
@@ -557,7 +561,7 @@ async function generateTrackedNonTaskObjectWithSdk<
 
   if (data.info.error) {
     throw new Error(
-      `OpenCode structured prompt failed: ${formatOpenCodeSdkError(data.info.error)}`,
+      `OpenCode structured prompt failed (model ${resolvedRuntime.model}): ${formatOpenCodeSdkError(data.info.error)}`,
     );
   }
 

--- a/packages/cloud-agents/src/server/opencode-runtime.ts
+++ b/packages/cloud-agents/src/server/opencode-runtime.ts
@@ -12,6 +12,7 @@ import {
   mergeOpenCodeChatGptFastModeOptions,
   mergeOpenRouterVariantAliasModels,
   normalizeOptionalReasoningEffort,
+  stripOpenCodeModelReasoningOptions,
   type OpenRouterVariantModelAlias,
 } from '@roomote/types';
 
@@ -216,6 +217,30 @@ function toRestrictedNonTaskConfigContent(
     for (const key of NON_TASK_CONFIG_ALLOWED_KEYS) {
       if (config[key] !== undefined) {
         restricted[key] = config[key];
+      }
+    }
+
+    // Non-task calls must never run with thinking enabled: structured output
+    // (`format: json_schema`) forces tool choice, and Amazon Bedrock rejects
+    // thinking combined with forced tool use — a helper-model reasoning
+    // effort would fail every routing call on such deployments. Reasoning is
+    // a coding-harness setting; title/summary/routing inference never needs
+    // it, so strip it for every provider rather than special-casing Bedrock.
+    // Applied to the merged config so operator-supplied
+    // OPENCODE_CONFIG_CONTENT cannot reintroduce thinking either.
+    if (
+      restricted.provider &&
+      typeof restricted.provider === 'object' &&
+      !Array.isArray(restricted.provider)
+    ) {
+      const strippedProvider = stripOpenCodeModelReasoningOptions(
+        restricted.provider as Record<string, unknown>,
+      );
+
+      if (Object.keys(strippedProvider).length > 0) {
+        restricted.provider = strippedProvider;
+      } else {
+        delete restricted.provider;
       }
     }
 

--- a/packages/types/src/__tests__/opencode-reasoning.test.ts
+++ b/packages/types/src/__tests__/opencode-reasoning.test.ts
@@ -1,6 +1,7 @@
 import {
   buildOpenCodeModelReasoningOptions,
   mergeOpenCodeModelReasoningOptions,
+  stripOpenCodeModelReasoningOptions,
 } from '../opencode-reasoning';
 
 describe('buildOpenCodeModelReasoningOptions', () => {
@@ -290,5 +291,101 @@ describe('mergeOpenCodeModelReasoningOptions', () => {
     expect(
       mergeOpenCodeModelReasoningOptions({}, 'no-provider', 'high'),
     ).toEqual({});
+  });
+});
+
+describe('stripOpenCodeModelReasoningOptions', () => {
+  it('removes every provider reasoning shape the builders can emit', () => {
+    const merged = [
+      'anthropic/claude-sonnet-5',
+      'amazon-bedrock/anthropic.claude-sonnet-5-v1:0',
+      'openrouter/z-ai/glm-5.2',
+      'litellm/coding',
+      'github-copilot/claude-3.7-sonnet-thought',
+    ].reduce<Record<string, unknown>>(
+      (config, modelId) =>
+        mergeOpenCodeModelReasoningOptions(config, modelId, 'high'),
+      {},
+    );
+
+    expect(stripOpenCodeModelReasoningOptions(merged)).toEqual({});
+  });
+
+  it('keeps non-reasoning model options and provider metadata intact', () => {
+    expect(
+      stripOpenCodeModelReasoningOptions({
+        openai: {
+          models: {
+            'gpt-5.6-terra': {
+              options: { reasoningEffort: 'high', serviceTier: 'priority' },
+            },
+          },
+        },
+        litellm: {
+          npm: '@ai-sdk/openai-compatible',
+          name: 'LiteLLM',
+          options: { baseURL: 'https://litellm.example.com/v1' },
+          models: {
+            coding: { name: 'coding' },
+          },
+        },
+      }),
+    ).toEqual({
+      openai: {
+        models: {
+          'gpt-5.6-terra': {
+            options: { serviceTier: 'priority' },
+          },
+        },
+      },
+      litellm: {
+        npm: '@ai-sdk/openai-compatible',
+        name: 'LiteLLM',
+        options: { baseURL: 'https://litellm.example.com/v1' },
+        models: {
+          coding: { name: 'coding' },
+        },
+      },
+    });
+  });
+
+  it('prunes model, models, and provider entries emptied by the strip', () => {
+    expect(
+      stripOpenCodeModelReasoningOptions({
+        anthropic: {
+          models: {
+            'claude-sonnet-5': {
+              options: { thinking: { type: 'adaptive' }, effort: 'high' },
+            },
+            'claude-haiku-4-5': {
+              name: 'claude-haiku-4-5',
+              options: { thinking: { type: 'adaptive' } },
+            },
+          },
+        },
+      }),
+    ).toEqual({
+      anthropic: {
+        models: {
+          'claude-haiku-4-5': { name: 'claude-haiku-4-5' },
+        },
+      },
+    });
+  });
+
+  it('passes malformed provider and model entries through unchanged', () => {
+    expect(
+      stripOpenCodeModelReasoningOptions({
+        broken: 'not-an-object',
+        listShaped: ['a'],
+        noModels: { name: 'provider-without-models' },
+        oddModels: { models: { entry: 'not-an-object' } },
+      }),
+    ).toEqual({
+      broken: 'not-an-object',
+      listShaped: ['a'],
+      noModels: { name: 'provider-without-models' },
+      oddModels: { models: { entry: 'not-an-object' } },
+    });
   });
 });

--- a/packages/types/src/opencode-reasoning.ts
+++ b/packages/types/src/opencode-reasoning.ts
@@ -308,3 +308,88 @@ export function mergeOpenCodeModelReasoningOptions(
     },
   };
 }
+
+/**
+ * Every per-model `options` key that {@link buildOpenCodeModelReasoningOptions}
+ * can emit, across all providers. Kept next to the builders so a new provider
+ * shape and its strip coverage change together.
+ */
+const OPENCODE_MODEL_REASONING_OPTION_KEYS = [
+  'thinking',
+  'effort',
+  'reasoning',
+  'reasoningEffort',
+  'reasoningConfig',
+  'thinking_budget',
+] as const;
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Removes reasoning options from every `provider.<id>.models.<model>.options`
+ * entry of an OpenCode `provider` config subtree, leaving all other model
+ * options (variant routing, service tiers, modalities) untouched.
+ *
+ * Exists for calls that must never run with thinking enabled: OpenCode
+ * fulfils `format: json_schema` structured output by forcing tool choice,
+ * and Amazon Bedrock rejects thinking combined with forced tool use — so a
+ * reasoning effort configured for the coding harness would otherwise fail
+ * every structured call routed through the same model. Entries emptied by
+ * the strip are pruned so a config that only carried reasoning collapses to
+ * one without a `provider` subtree at all.
+ */
+export function stripOpenCodeModelReasoningOptions(
+  providerConfig: Record<string, unknown>,
+): Record<string, unknown> {
+  const strippedProviders: Record<string, unknown> = {};
+
+  for (const [providerID, providerEntry] of Object.entries(providerConfig)) {
+    if (!isPlainRecord(providerEntry) || !isPlainRecord(providerEntry.models)) {
+      strippedProviders[providerID] = providerEntry;
+      continue;
+    }
+
+    const strippedModels: Record<string, unknown> = {};
+
+    for (const [modelID, modelEntry] of Object.entries(providerEntry.models)) {
+      if (!isPlainRecord(modelEntry) || !isPlainRecord(modelEntry.options)) {
+        strippedModels[modelID] = modelEntry;
+        continue;
+      }
+
+      const options = { ...modelEntry.options };
+
+      for (const key of OPENCODE_MODEL_REASONING_OPTION_KEYS) {
+        delete options[key];
+      }
+
+      const stripped: Record<string, unknown> = { ...modelEntry };
+
+      if (Object.keys(options).length > 0) {
+        stripped.options = options;
+      } else {
+        delete stripped.options;
+      }
+
+      if (Object.keys(stripped).length > 0) {
+        strippedModels[modelID] = stripped;
+      }
+    }
+
+    const strippedEntry: Record<string, unknown> = { ...providerEntry };
+
+    if (Object.keys(strippedModels).length > 0) {
+      strippedEntry.models = strippedModels;
+    } else {
+      delete strippedEntry.models;
+    }
+
+    if (Object.keys(strippedEntry).length > 0) {
+      strippedProviders[providerID] = strippedEntry;
+    }
+  }
+
+  return strippedProviders;
+}


### PR DESCRIPTION
## Problem

A tenant configured a reasoning effort on its helper (small) model and lost automatic workspace routing entirely: every Slack task start showed **"Automatic routing is temporarily unavailable"** with the manual picker. Production incident 2026-08-13 ~09:15–10:00 UTC; every router attempt logged:

```
[LLM Router] Routing fallback model="roomote-small-model" cause="exception"
  reason="OpenCode structured prompt failed: APIError: undefined:
  The model returned the following errors: Thinking may not be enabled when tool_choice forces tool use."
```

The chain:

1. The dashboard's helper-model reasoning setting becomes `R_SMALL_MODEL_REASONING_EFFORT`, which `buildModelBackedOpenCodeConfigContent` merges into the OpenCode provider config for the **non-task helper servers** — enabling thinking on every call to that model.
2. Non-task structured output (`format: json_schema`) forces tool choice.
3. **Amazon Bedrock rejects thinking combined with forced tool use** (the "The model returned the following errors" wrapper is Bedrock's ValidationException format). Per Anthropic's docs this is Bedrock-specific — the direct Anthropic API and Vertex accept adaptive thinking with forced `tool_choice` — which is why the same setting works fine on direct-Anthropic deployments and the bug went unnoticed.

## Fix

**Strip reasoning options from the restricted non-task config, for every provider.** `toRestrictedNonTaskConfigContent` now removes all reasoning option shapes the builders can emit (`thinking`, `effort`, `reasoning`, `reasoningEffort`, `reasoningConfig`, `thinking_budget`) from `provider.*.models.*.options`, pruning entries the strip empties. Non-reasoning options (variant routing, fast-mode service tiers, LiteLLM provider metadata) survive untouched.

Why every provider and not just Bedrock: reasoning levels are a coding-harness setting; titles, summaries, and routing never needed them, uniform behavior is easier to reason about, and stripping at the restriction layer also covers operator-supplied `OPENCODE_CONFIG_CONTENT`, so external config can't reintroduce thinking on these servers.

**Scope check:** `buildOpenCodeCliEnv` is used only by the non-task helper servers, so this covers every `runNonTaskSdkPrompt` caller (router, summaries, titles, fast-agent QA) at once. **Task execution is unaffected** — the worker builds its own reasoning options in `apps/worker/src/run-task/agent-home.ts`.

## Diagnosability

The non-task failure messages now carry the resolved `provider/model` id (`OpenCode structured prompt failed (model amazon-bedrock/anthropic.claude-…): …`), which flows into the router's fallback log. The log previously named only the role alias `roomote-small-model`; diagnosing this incident required inferring the provider from the error-wrapper format.

## Testing

- New `stripOpenCodeModelReasoningOptions` unit tests: every provider reasoning shape stripped, non-reasoning options preserved, emptied entries pruned, malformed shapes passed through.
- `opencode-runtime` tests updated: reasoning env vars no longer surface in helper configs (incl. an explicit Bedrock case and an operator-supplied-config case); variant routing and fast-mode service tiers still survive.
- `non-task-provider-usage` test updated to assert the resolved model id in the failure message.
- Full `packages/cloud-agents` (687) and `packages/types` (815) suites pass; typecheck clean. (Pre-existing lint warnings in unrelated files `capture.mjs` / `utils.test.ts` are untouched.)

## Behavior change worth noting

Deployments that set a helper-model reasoning effort on **working** providers (direct Anthropic, OpenRouter, …) will see their non-task calls (titles, summaries, routing) run without thinking from this change on — faster and cheaper, and in line with what the setting was meant to control (the coding harness). If someone deliberately wanted reasoning on utility inference, that would need a dedicated setting.

## Operator note

For the affected tenant, the immediate unblock (before this ships) is clearing the reasoning effort on the helper model, or moving the helper to direct Anthropic.
