### PR TITLE
[Fix] Bedrock helper models fail non-task calls with ProviderModelNotFoundError

### DIFF
--- a/apps/worker/src/run-task/agent-home.ts
+++ b/apps/worker/src/run-task/agent-home.ts
@@ -13,7 +13,6 @@ import {
   CHATGPT_GATEWAY_PROVIDER_ID,
   CHATGPT_OPENCODE_PROVIDER_ID,
   collectOpenRouterVariantModelAlias,
-  DEFAULT_BEDROCK_MANTLE_REGION,
   DISABLED_MODEL_PROVIDER_ENV_VAR_NAMES,
   getInferenceGatewayProvider,
   getInferenceGatewayProviderByEnvVarName,
@@ -22,13 +21,15 @@ import {
   INFERENCE_GATEWAY_CHATGPT_ENV_VAR_NAME,
   INFERENCE_GATEWAY_GITHUB_COPILOT_ENV_VAR_NAME,
   INFERENCE_GATEWAY_KEYS_ENV_VAR_NAME,
-  INFERENCE_GATEWAY_REGION_PATTERN,
   INFERENCE_GATEWAY_URL_ENV_VAR_NAME,
   INFERENCE_GATEWAY_XAI_ENV_VAR_NAME,
   XAI_OPENCODE_PROVIDER_ID,
   type InferenceGatewayProvider,
   isConfiguredEnvValue,
   isTaskModelIdDisabled,
+  mergeAmazonBedrockProviderConfig,
+  mergeBedrockMantleOpenAiProviderConfig,
+  mergeBedrockMantleProviderConfig,
   mergeOpenAiCompatibleProviderConfig,
   mergeOpenCodeModelReasoningOptions,
   mergeOpenCodeChatGptFastModeOptions,
@@ -37,6 +38,7 @@ import {
   parseInferenceGatewayKeys,
   renderManualSkillMarkdown,
   resolveOpenRouterVariantModelAlias,
+  toBedrockMantleRuntimeModelId,
   OPENCODE_ARCHITECT_AGENT,
   OPENCODE_AUTH_CONTENT_ENV_VAR_NAME,
   OPENCODE_GO_API_KEY_ENV_VAR_NAME,
@@ -693,216 +695,6 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? { ...(value as Record<string, unknown>) }
     : {};
-}
-
-function mergeBedrockMantleProviderConfig(
-  providerConfig: Record<string, unknown>,
-  runtimeEnv: Record<string, string>,
-  modelIds: Array<string | undefined>,
-): Record<string, unknown> {
-  const mantleModelIds = [
-    ...new Set(
-      modelIds.flatMap((modelId) => {
-        const prefix = `${BEDROCK_MANTLE_OPENCODE_PROVIDER_ID}/`;
-        const normalized = modelId?.trim();
-
-        return normalized?.startsWith(prefix)
-          ? [normalized.slice(prefix.length)]
-          : [];
-      }),
-    ),
-  ];
-
-  if (mantleModelIds.length === 0) {
-    return providerConfig;
-  }
-
-  const region = runtimeEnv.AWS_REGION?.trim() || DEFAULT_BEDROCK_MANTLE_REGION;
-
-  if (!INFERENCE_GATEWAY_REGION_PATTERN.test(region)) {
-    throw new Error(
-      `AWS_REGION must be a valid AWS region for Amazon Bedrock. Received "${region}".`,
-    );
-  }
-
-  const existingProvider = asRecord(
-    providerConfig[BEDROCK_MANTLE_OPENCODE_PROVIDER_ID],
-  );
-  const existingOptions = asRecord(existingProvider.options);
-  const existingModels = asRecord(existingProvider.models);
-  const models = Object.fromEntries(
-    mantleModelIds.map((modelId) => [
-      modelId,
-      {
-        name: modelId,
-        ...asRecord(existingModels[modelId]),
-      },
-    ]),
-  );
-
-  return {
-    ...providerConfig,
-    [BEDROCK_MANTLE_OPENCODE_PROVIDER_ID]: {
-      ...existingProvider,
-      npm: '@ai-sdk/anthropic',
-      name: 'Amazon Bedrock',
-      options: {
-        ...existingOptions,
-        baseURL: `https://bedrock-mantle.${region}.api.aws/anthropic/v1`,
-        apiKey: '{env:AWS_BEARER_TOKEN_BEDROCK}',
-      },
-      models: {
-        ...existingModels,
-        ...models,
-      },
-    },
-  };
-}
-
-function mergeBedrockMantleOpenAiProviderConfig(
-  providerConfig: Record<string, unknown>,
-  runtimeEnv: Record<string, string>,
-  modelIds: Array<string | undefined>,
-): Record<string, unknown> {
-  const prefix = `${BEDROCK_MANTLE_OPENAI_OPENCODE_PROVIDER_ID}/`;
-  const mantleModelIds = [
-    ...new Set(
-      modelIds.flatMap((modelId) => {
-        const normalized = modelId?.trim();
-
-        return normalized?.startsWith(prefix)
-          ? [normalized.slice(prefix.length)]
-          : [];
-      }),
-    ),
-  ];
-
-  if (mantleModelIds.length === 0) {
-    return providerConfig;
-  }
-
-  const region = runtimeEnv.AWS_REGION?.trim() || DEFAULT_BEDROCK_MANTLE_REGION;
-
-  if (!INFERENCE_GATEWAY_REGION_PATTERN.test(region)) {
-    throw new Error(
-      `AWS_REGION must be a valid AWS region for Amazon Bedrock. Received "${region}".`,
-    );
-  }
-
-  const existingProvider = asRecord(
-    providerConfig[BEDROCK_MANTLE_OPENAI_OPENCODE_PROVIDER_ID],
-  );
-  const existingOptions = asRecord(existingProvider.options);
-  const existingModels = asRecord(existingProvider.models);
-
-  return {
-    ...providerConfig,
-    [BEDROCK_MANTLE_OPENAI_OPENCODE_PROVIDER_ID]: {
-      ...existingProvider,
-      // Mantle GPT models support the OpenAI Responses API, not Chat
-      // Completions. The native provider selects the Responses transport.
-      npm: '@ai-sdk/openai',
-      name: 'Amazon Bedrock',
-      options: {
-        ...existingOptions,
-        baseURL: `https://bedrock-mantle.${region}.api.aws/openai/v1`,
-        apiKey: '{env:AWS_BEARER_TOKEN_BEDROCK}',
-      },
-      models: {
-        ...existingModels,
-        ...Object.fromEntries(
-          mantleModelIds.map((modelId) => [
-            modelId,
-            {
-              name: modelId,
-              ...asRecord(existingModels[modelId]),
-            },
-          ]),
-        ),
-      },
-    },
-  };
-}
-
-function mergeAmazonBedrockProviderConfig(
-  providerConfig: Record<string, unknown>,
-  runtimeEnv: Record<string, string>,
-  modelIds: Array<string | undefined>,
-): Record<string, unknown> {
-  const prefix = `${AMAZON_BEDROCK_OPENCODE_PROVIDER_ID}/`;
-  const bedrockModelIds = [
-    ...new Set(
-      modelIds.flatMap((modelId) => {
-        const normalized = modelId?.trim();
-
-        return normalized?.startsWith(prefix)
-          ? [normalized.slice(prefix.length)]
-          : [];
-      }),
-    ),
-  ];
-
-  if (bedrockModelIds.length === 0) {
-    return providerConfig;
-  }
-
-  const region = runtimeEnv.AWS_REGION?.trim() || DEFAULT_BEDROCK_MANTLE_REGION;
-
-  if (!INFERENCE_GATEWAY_REGION_PATTERN.test(region)) {
-    throw new Error(
-      `AWS_REGION must be a valid AWS region for Amazon Bedrock. Received "${region}".`,
-    );
-  }
-
-  const existingProvider = asRecord(
-    providerConfig[AMAZON_BEDROCK_OPENCODE_PROVIDER_ID],
-  );
-  const existingOptions = asRecord(existingProvider.options);
-  const existingModels = asRecord(existingProvider.models);
-
-  return {
-    ...providerConfig,
-    [AMAZON_BEDROCK_OPENCODE_PROVIDER_ID]: {
-      ...existingProvider,
-      npm: '@ai-sdk/amazon-bedrock',
-      name: 'Amazon Bedrock',
-      options: {
-        apiKey: '{env:AWS_BEARER_TOKEN_BEDROCK}',
-        ...existingOptions,
-      },
-      models: {
-        ...existingModels,
-        ...Object.fromEntries(
-          bedrockModelIds.map((modelId) => [
-            modelId,
-            {
-              name: modelId,
-              ...asRecord(existingModels[modelId]),
-            },
-          ]),
-        ),
-      },
-    },
-  };
-}
-
-function toBedrockMantleRuntimeModelId(modelId: string): string {
-  const mantlePrefix = `${BEDROCK_MANTLE_OPENCODE_PROVIDER_ID}/openai.`;
-  const nativePrefix = `${AMAZON_BEDROCK_OPENCODE_PROVIDER_ID}/openai.`;
-
-  if (modelId.startsWith(mantlePrefix)) {
-    return `${BEDROCK_MANTLE_OPENAI_OPENCODE_PROVIDER_ID}/${modelId.slice(
-      BEDROCK_MANTLE_OPENCODE_PROVIDER_ID.length + 1,
-    )}`;
-  }
-
-  if (modelId.startsWith(nativePrefix)) {
-    return `${BEDROCK_MANTLE_OPENAI_OPENCODE_PROVIDER_ID}/${modelId.slice(
-      AMAZON_BEDROCK_OPENCODE_PROVIDER_ID.length + 1,
-    )}`;
-  }
-
-  return modelId;
 }
 
 /**

--- a/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
@@ -543,6 +543,45 @@ describe('resolveOpenCodeSmallModel', () => {
     expect(sessionPromptMock.mock.calls[0]?.[0]).not.toHaveProperty('format');
   });
 
+  it('addresses Mantle GPT helper models by their runtime provider id', async () => {
+    process.env = {
+      ...originalEnv,
+      OPENCODE_SDK_SERVER_URL: 'http://127.0.0.1:4096',
+    };
+    mockResolveEffectiveModelRuntimeEnv.mockResolvedValue({
+      R_MODEL: 'openrouter/z-ai/glm-5.2',
+      // The dashboard saves Mantle GPT helper models under `bedrock-mantle/`;
+      // the runtime provider that actually serves them (and that the helper
+      // server's config registers) is `bedrock-mantle-openai`.
+      R_SMALL_MODEL: 'bedrock-mantle/openai.gpt-5.6-luna',
+    });
+    sessionPromptMock.mockResolvedValue({
+      data: {
+        info: { error: null },
+        parts: [{ type: 'text', text: 'routed' }],
+      },
+      error: undefined,
+    });
+
+    const { generateTrackedNonTaskText, NON_TASK_INFERENCE_SURFACES } =
+      await import('../non-task-provider-usage.js');
+
+    await generateTrackedNonTaskText({
+      surface: NON_TASK_INFERENCE_SURFACES.routerTaskRouting,
+      prompt: 'Choose a workspace.',
+    });
+
+    expect(sessionPromptMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: {
+          providerID: 'bedrock-mantle-openai',
+          modelID: 'openai.gpt-5.6-luna',
+        },
+      }),
+      expect.any(Object),
+    );
+  });
+
   it('uses an audio-capable configured model for native file prompts', async () => {
     process.env = {
       ...originalEnv,

--- a/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
@@ -582,6 +582,60 @@ describe('resolveOpenCodeSmallModel', () => {
     );
   });
 
+  it('registers an explicit Bedrock model on the helper server it leases', async () => {
+    process.env = {
+      ...originalEnv,
+    };
+    // The deployment's role models do not include the explicit model — its
+    // provider registration must come from the explicit model itself.
+    mockResolveEffectiveModelRuntimeEnv.mockResolvedValue({
+      R_MODEL: 'openrouter/z-ai/glm-5.2',
+      AWS_REGION: 'us-east-1',
+    });
+    sessionPromptMock.mockResolvedValue({
+      data: {
+        info: { error: null },
+        parts: [{ type: 'text', text: 'ok' }],
+      },
+      error: undefined,
+    });
+
+    const { generateTrackedNonTaskText, NON_TASK_INFERENCE_SURFACES } =
+      await import('../non-task-provider-usage.js');
+
+    await generateTrackedNonTaskText({
+      surface: NON_TASK_INFERENCE_SURFACES.routerTaskRouting,
+      model: 'bedrock-mantle/openai.gpt-5.6-luna',
+      prompt: 'Choose a workspace.',
+    });
+
+    const spawnEnv = spawnMock.mock.calls[0]?.[2]?.env as
+      | NodeJS.ProcessEnv
+      | undefined;
+    const spawnedConfig = JSON.parse(
+      spawnEnv?.OPENCODE_CONFIG_CONTENT ?? '{}',
+    ) as {
+      provider?: Record<string, unknown>;
+    };
+
+    expect(spawnedConfig.provider).toMatchObject({
+      'bedrock-mantle-openai': {
+        models: {
+          'openai.gpt-5.6-luna': { name: 'openai.gpt-5.6-luna' },
+        },
+      },
+    });
+    expect(sessionPromptMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: {
+          providerID: 'bedrock-mantle-openai',
+          modelID: 'openai.gpt-5.6-luna',
+        },
+      }),
+      expect.any(Object),
+    );
+  });
+
   it('uses an audio-capable configured model for native file prompts', async () => {
     process.env = {
       ...originalEnv,

--- a/packages/cloud-agents/src/server/__tests__/opencode-runtime.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/opencode-runtime.test.ts
@@ -276,6 +276,51 @@ describe('buildOpenCodeCliEnv', () => {
     });
   });
 
+  it('adds Bedrock registrations to operator-supplied config content', () => {
+    // Operator config skips the model-backed builder, but Bedrock role
+    // models still need their providers registered or they fail with
+    // ProviderModelNotFoundError.
+    const env = buildOpenCodeCliEnv({
+      R_MODEL: 'bedrock-mantle/openai.gpt-5.6-luna',
+      AWS_REGION: 'us-east-1',
+      OPENCODE_CONFIG_CONTENT: JSON.stringify({
+        model: 'litellm/coding',
+        provider: {
+          litellm: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'LiteLLM',
+            options: { baseURL: 'https://litellm.example.com/v1' },
+            models: { coding: { name: 'coding' } },
+          },
+        },
+      }),
+    });
+
+    expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
+      model: 'litellm/coding',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
+      provider: {
+        litellm: {
+          npm: '@ai-sdk/openai-compatible',
+          name: 'LiteLLM',
+          options: { baseURL: 'https://litellm.example.com/v1' },
+          models: { coding: { name: 'coding' } },
+        },
+        'bedrock-mantle-openai': {
+          npm: '@ai-sdk/openai',
+          name: 'Amazon Bedrock',
+          options: {
+            baseURL: 'https://bedrock-mantle.us-east-1.api.aws/openai/v1',
+            apiKey: '{env:AWS_BEARER_TOKEN_BEDROCK}',
+          },
+          models: {
+            'openai.gpt-5.6-luna': { name: 'openai.gpt-5.6-luna' },
+          },
+        },
+      },
+    });
+  });
+
   it('strips thinking options from operator-supplied config content', () => {
     const env = buildOpenCodeCliEnv({
       OPENCODE_CONFIG_CONTENT: JSON.stringify({

--- a/packages/cloud-agents/src/server/__tests__/opencode-runtime.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/opencode-runtime.test.ts
@@ -24,6 +24,8 @@ describe('buildOpenCodeCliEnv', () => {
     'R_CHATGPT_FAST_MODE',
     'LITELLM_BASE_URL',
     'LITELLM_API_KEY',
+    'AWS_REGION',
+    'AWS_BEARER_TOKEN_BEDROCK',
     'GOOGLE_APPLICATION_CREDENTIALS',
     'MISTRAL_API_KEY',
     'BASH_ENV',
@@ -159,17 +161,118 @@ describe('buildOpenCodeCliEnv', () => {
     });
   });
 
-  it('strips Bedrock thinking config while keeping the model selection', () => {
+  it('rewrites Mantle GPT ids and registers their OpenAI-compatible provider', () => {
+    // A helper model saved as `bedrock-mantle/openai.*` is served by Mantle's
+    // OpenAI Responses endpoint under the dedicated runtime provider — the
+    // same alignment the task worker applies. Without it, OpenCode rejects
+    // the id with ProviderModelNotFoundError.
+    const env = buildOpenCodeCliEnv({
+      R_MODEL: 'openrouter/openai/gpt-5.4',
+      R_SMALL_MODEL: 'bedrock-mantle/openai.gpt-5.6-luna',
+      AWS_REGION: 'us-east-1',
+    });
+
+    expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
+      model: 'openrouter/openai/gpt-5.4',
+      small_model: 'bedrock-mantle-openai/openai.gpt-5.6-luna',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
+      provider: {
+        'bedrock-mantle-openai': {
+          npm: '@ai-sdk/openai',
+          name: 'Amazon Bedrock',
+          options: {
+            baseURL: 'https://bedrock-mantle.us-east-1.api.aws/openai/v1',
+            apiKey: '{env:AWS_BEARER_TOKEN_BEDROCK}',
+          },
+          models: {
+            'openai.gpt-5.6-luna': { name: 'openai.gpt-5.6-luna' },
+          },
+        },
+      },
+    });
+  });
+
+  it('registers the Mantle Anthropic provider for Claude Mantle helper models', () => {
+    const env = buildOpenCodeCliEnv({
+      R_MODEL: 'bedrock-mantle/anthropic.claude-sonnet-5',
+      AWS_REGION: 'eu-west-1',
+    });
+
+    expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
+      model: 'bedrock-mantle/anthropic.claude-sonnet-5',
+      small_model: 'bedrock-mantle/anthropic.claude-sonnet-5',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
+      provider: {
+        'bedrock-mantle': {
+          npm: '@ai-sdk/anthropic',
+          name: 'Amazon Bedrock',
+          options: {
+            baseURL: 'https://bedrock-mantle.eu-west-1.api.aws/anthropic/v1',
+            apiKey: '{env:AWS_BEARER_TOKEN_BEDROCK}',
+          },
+          models: {
+            'anthropic.claude-sonnet-5': {
+              name: 'anthropic.claude-sonnet-5',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('registers bearer-token credentials on the native Bedrock provider', () => {
+    const env = buildOpenCodeCliEnv({
+      R_MODEL: 'amazon-bedrock/anthropic.claude-sonnet-5-v1:0',
+      AWS_REGION: 'us-east-1',
+    });
+
+    expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
+      model: 'amazon-bedrock/anthropic.claude-sonnet-5-v1:0',
+      small_model: 'amazon-bedrock/anthropic.claude-sonnet-5-v1:0',
+      permission: NON_TASK_TOOL_PERMISSION_DENIALS,
+      provider: {
+        'amazon-bedrock': {
+          npm: '@ai-sdk/amazon-bedrock',
+          name: 'Amazon Bedrock',
+          options: { apiKey: '{env:AWS_BEARER_TOKEN_BEDROCK}' },
+          models: {
+            'anthropic.claude-sonnet-5-v1:0': {
+              name: 'anthropic.claude-sonnet-5-v1:0',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('strips Bedrock thinking config while keeping the provider registration', () => {
     const env = buildOpenCodeCliEnv({
       R_MODEL: 'amazon-bedrock/anthropic.claude-sonnet-5-v1:0',
       R_SMALL_MODEL: 'amazon-bedrock/anthropic.claude-haiku-4-5-v1:0',
       R_SMALL_MODEL_REASONING_EFFORT: 'medium',
+      AWS_REGION: 'us-east-1',
     });
 
     expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toEqual({
       model: 'amazon-bedrock/anthropic.claude-sonnet-5-v1:0',
       small_model: 'amazon-bedrock/anthropic.claude-haiku-4-5-v1:0',
       permission: NON_TASK_TOOL_PERMISSION_DENIALS,
+      provider: {
+        'amazon-bedrock': {
+          npm: '@ai-sdk/amazon-bedrock',
+          name: 'Amazon Bedrock',
+          options: { apiKey: '{env:AWS_BEARER_TOKEN_BEDROCK}' },
+          models: {
+            // The reasoning options are stripped; the registration survives.
+            'anthropic.claude-sonnet-5-v1:0': {
+              name: 'anthropic.claude-sonnet-5-v1:0',
+            },
+            'anthropic.claude-haiku-4-5-v1:0': {
+              name: 'anthropic.claude-haiku-4-5-v1:0',
+            },
+          },
+        },
+      },
     });
   });
 

--- a/packages/cloud-agents/src/server/non-task-provider-usage.ts
+++ b/packages/cloud-agents/src/server/non-task-provider-usage.ts
@@ -7,6 +7,7 @@ import {
   type PermissionRuleset,
 } from '@opencode-ai/sdk/v2/client';
 import { resolveEffectiveModelRuntimeEnv } from '@roomote/db/server';
+import { toBedrockMantleRuntimeModelId } from '@roomote/types';
 import type { z } from 'zod';
 import zodToJsonSchema from 'zod-to-json-schema';
 
@@ -286,7 +287,10 @@ async function resolveNonTaskModelRuntime(model?: string): Promise<{
   }
 
   return {
-    model: resolvedModel,
+    // The prompt must address the same runtime provider id the helper
+    // server's config registered (Bedrock Mantle GPT ids run under
+    // `bedrock-mantle-openai`), mirroring the task worker's rewrite.
+    model: toBedrockMantleRuntimeModelId(resolvedModel),
     resolvedModelRuntimeEnv,
   };
 }
@@ -342,10 +346,14 @@ async function resolveModelForInputModality(
     ...modalityModels,
     runtime.resolvedModelRuntimeEnv.R_MODEL,
     runtime.model,
-  ].filter(
-    (candidate, index, values): candidate is string =>
-      Boolean(candidate) && values.indexOf(candidate) === index,
-  );
+  ]
+    .map((candidate) =>
+      candidate ? toBedrockMantleRuntimeModelId(candidate) : candidate,
+    )
+    .filter(
+      (candidate, index, values): candidate is string =>
+        Boolean(candidate) && values.indexOf(candidate) === index,
+    );
   const timeoutMs = params.timeoutMs ?? 120_000;
   const server = await leaseOpenCodeSdkServer({
     env: runtime.resolvedModelRuntimeEnv,

--- a/packages/cloud-agents/src/server/non-task-provider-usage.ts
+++ b/packages/cloud-agents/src/server/non-task-provider-usage.ts
@@ -291,7 +291,15 @@ async function resolveNonTaskModelRuntime(model?: string): Promise<{
     // server's config registered (Bedrock Mantle GPT ids run under
     // `bedrock-mantle-openai`), mirroring the task worker's rewrite.
     model: toBedrockMantleRuntimeModelId(resolvedModel),
-    resolvedModelRuntimeEnv,
+    // An explicit model rides into the server lease env as the primary role
+    // model so the config builder registers its provider — the deployment's
+    // role models may not include it, and an unregistered Bedrock (or
+    // OpenAI-compatible) id fails with ProviderModelNotFoundError before any
+    // request is made. The lease cache keys on env, so distinct explicit
+    // models get their own servers instead of colliding.
+    resolvedModelRuntimeEnv: requestedModel
+      ? { ...resolvedModelRuntimeEnv, R_MODEL: requestedModel }
+      : resolvedModelRuntimeEnv,
   };
 }
 

--- a/packages/cloud-agents/src/server/opencode-runtime.ts
+++ b/packages/cloud-agents/src/server/opencode-runtime.ts
@@ -7,12 +7,16 @@ import {
   CHATGPT_FAST_MODE_ENV_VAR_NAME,
   DISABLED_MODEL_PROVIDER_ENV_VAR_NAMES,
   isTaskModelIdDisabled,
+  mergeAmazonBedrockProviderConfig,
+  mergeBedrockMantleOpenAiProviderConfig,
+  mergeBedrockMantleProviderConfig,
   mergeOpenAiCompatibleProviderConfig,
   mergeOpenCodeModelReasoningOptions,
   mergeOpenCodeChatGptFastModeOptions,
   mergeOpenRouterVariantAliasModels,
   normalizeOptionalReasoningEffort,
   stripOpenCodeModelReasoningOptions,
+  toBedrockMantleRuntimeModelId,
   type OpenRouterVariantModelAlias,
 } from '@roomote/types';
 
@@ -45,18 +49,30 @@ function buildModelBackedOpenCodeConfigContent(
   // OpenRouter variant models (`:nitro`, `:free`, ...) are rewritten to their
   // catalog base model and mapped back to the variant through provider model
   // aliases below, because OpenCode rejects model IDs its catalog does not
-  // contain.
+  // contain. Bedrock Mantle GPT ids are rewritten onto their dedicated
+  // OpenAI-compatible provider first, mirroring the task worker — without the
+  // rewrite (and the provider registrations below) a Bedrock helper model
+  // fails with ProviderModelNotFoundError before any request is made.
   const variantAliases = new Map<string, OpenRouterVariantModelAlias>();
-  const model = collectOpenRouterVariantModelAlias(variantAliases, rawModel);
+  const model = collectOpenRouterVariantModelAlias(
+    variantAliases,
+    toBedrockMantleRuntimeModelId(rawModel),
+  );
   const rawSmallModel = env.R_SMALL_MODEL?.trim();
   const smallModel =
     rawSmallModel && !isTaskModelIdDisabled(rawSmallModel)
-      ? collectOpenRouterVariantModelAlias(variantAliases, rawSmallModel)
+      ? collectOpenRouterVariantModelAlias(
+          variantAliases,
+          toBedrockMantleRuntimeModelId(rawSmallModel),
+        )
       : undefined;
   const rawVisionModel = env.R_VISION_MODEL?.trim();
   const visionModel =
     rawVisionModel && !isTaskModelIdDisabled(rawVisionModel)
-      ? collectOpenRouterVariantModelAlias(variantAliases, rawVisionModel)
+      ? collectOpenRouterVariantModelAlias(
+          variantAliases,
+          toBedrockMantleRuntimeModelId(rawVisionModel),
+        )
       : undefined;
   const modelReasoningEffort = normalizeOptionalReasoningEffort(
     env.R_MODEL_REASONING_EFFORT?.trim(),
@@ -110,11 +126,30 @@ function buildModelBackedOpenCodeConfigContent(
           visionModel,
         ])
       : providerReasoningConfig;
-  const providerConfig = mergeOpenAiCompatibleProviderConfig(
-    mergeOpenRouterVariantAliasModels(providerModelConfig, variantAliases),
+  const configuredModelIds = [model, smallModel, visionModel];
+  // Same Bedrock provider registrations the task worker applies: OpenCode's
+  // catalog knows neither Mantle endpoint, and the native provider does not
+  // read the deployment's bearer token on its own.
+  const providerConfig = mergeAmazonBedrockProviderConfig(
+    mergeBedrockMantleProviderConfig(
+      mergeBedrockMantleOpenAiProviderConfig(
+        mergeOpenAiCompatibleProviderConfig(
+          mergeOpenRouterVariantAliasModels(
+            providerModelConfig,
+            variantAliases,
+          ),
+          env,
+          configuredModelIds,
+          visionModel,
+        ),
+        env,
+        configuredModelIds,
+      ),
+      env,
+      configuredModelIds,
+    ),
     env,
-    [model, smallModel, visionModel],
-    visionModel,
+    configuredModelIds,
   );
 
   return JSON.stringify({

--- a/packages/cloud-agents/src/server/opencode-runtime.ts
+++ b/packages/cloud-agents/src/server/opencode-runtime.ts
@@ -287,6 +287,71 @@ function toRestrictedNonTaskConfigContent(
   }
 }
 
+/**
+ * Merges the Bedrock provider registrations for the env's role models into an
+ * operator-supplied config content string. Malformed content is returned
+ * unchanged — `toRestrictedNonTaskConfigContent` already fails it closed.
+ */
+function mergeBedrockRegistrationsIntoConfigContent(
+  configContent: string,
+  env: NodeJS.ProcessEnv,
+): string {
+  const roleModelIds = (
+    [env.R_MODEL, env.R_SMALL_MODEL, env.R_VISION_MODEL] as const
+  )
+    .map((modelId) => modelId?.trim())
+    .filter(
+      (modelId): modelId is string =>
+        Boolean(modelId) && !isTaskModelIdDisabled(modelId!),
+    )
+    .map(toBedrockMantleRuntimeModelId);
+
+  if (roleModelIds.length === 0) {
+    return configContent;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(configContent);
+
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      return configContent;
+    }
+
+    const config = parsed as Record<string, unknown>;
+    const existingProvider =
+      config.provider &&
+      typeof config.provider === 'object' &&
+      !Array.isArray(config.provider)
+        ? (config.provider as Record<string, unknown>)
+        : {};
+    const provider = mergeAmazonBedrockProviderConfig(
+      mergeBedrockMantleProviderConfig(
+        mergeBedrockMantleOpenAiProviderConfig(
+          existingProvider,
+          env,
+          roleModelIds,
+        ),
+        env,
+        roleModelIds,
+      ),
+      env,
+      roleModelIds,
+    );
+
+    if (Object.keys(provider).length === 0) {
+      return configContent;
+    }
+
+    return JSON.stringify({ ...config, provider });
+  } catch {
+    return configContent;
+  }
+}
+
 export function buildOpenCodeCliEnv(
   extraEnv?: Partial<Record<string, string>>,
 ): NodeJS.ProcessEnv {
@@ -314,6 +379,15 @@ export function buildOpenCodeCliEnv(
     if (modelBackedConfigContent) {
       env.OPENCODE_CONFIG_CONTENT = modelBackedConfigContent;
     }
+  } else {
+    // Operator-supplied config skips the model-backed builder, but the role
+    // models still need their Bedrock providers registered — otherwise a
+    // Bedrock helper model fails with ProviderModelNotFoundError whenever a
+    // deployment also sets OPENCODE_CONFIG_CONTENT.
+    env.OPENCODE_CONFIG_CONTENT = mergeBedrockRegistrationsIntoConfigContent(
+      env.OPENCODE_CONFIG_CONTENT,
+      env,
+    );
   }
 
   // Applied unconditionally, after any operator-supplied config content is

--- a/packages/types/src/bedrock-opencode-provider.ts
+++ b/packages/types/src/bedrock-opencode-provider.ts
@@ -1,0 +1,247 @@
+import {
+  AMAZON_BEDROCK_OPENCODE_PROVIDER_ID,
+  BEDROCK_MANTLE_OPENAI_OPENCODE_PROVIDER_ID,
+  BEDROCK_MANTLE_OPENCODE_PROVIDER_ID,
+  DEFAULT_BEDROCK_MANTLE_REGION,
+  INFERENCE_GATEWAY_REGION_PATTERN,
+} from './inference-gateway';
+
+/**
+ * Amazon Bedrock OpenCode wiring shared by the task worker and the non-task
+ * helper servers. OpenCode's catalog knows the native `amazon-bedrock`
+ * provider but none of the Bedrock Mantle endpoints, and none of the three
+ * read the deployment's bearer-token credential on their own — so a Bedrock
+ * model id from deployment settings only resolves once these helpers have
+ * rewritten it and registered its provider in the OpenCode config. The worker
+ * has always done this for task execution; helper servers must apply the same
+ * alignment or Bedrock-configured helper models fail with
+ * ProviderModelNotFoundError before any request is made.
+ */
+
+type RuntimeEnv = Readonly<Record<string, string | undefined>>;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? { ...(value as Record<string, unknown>) }
+    : {};
+}
+
+function resolveBedrockRegion(runtimeEnv: RuntimeEnv): string {
+  const region = runtimeEnv.AWS_REGION?.trim() || DEFAULT_BEDROCK_MANTLE_REGION;
+
+  if (!INFERENCE_GATEWAY_REGION_PATTERN.test(region)) {
+    throw new Error(
+      `AWS_REGION must be a valid AWS region for Amazon Bedrock. Received "${region}".`,
+    );
+  }
+
+  return region;
+}
+
+function collectModelIdsForPrefix(
+  modelIds: Array<string | undefined>,
+  providerId: string,
+): string[] {
+  const prefix = `${providerId}/`;
+
+  return [
+    ...new Set(
+      modelIds.flatMap((modelId) => {
+        const normalized = modelId?.trim();
+
+        return normalized?.startsWith(prefix)
+          ? [normalized.slice(prefix.length)]
+          : [];
+      }),
+    ),
+  ];
+}
+
+/**
+ * Bedrock Mantle serves GPT models through its OpenAI-compatible endpoint
+ * (Responses API), not the Anthropic Messages endpoint the `bedrock-mantle`
+ * provider targets. Rewrite `bedrock-mantle/openai.*` — and the equivalent
+ * native spelling `amazon-bedrock/openai.*` — onto the dedicated
+ * `bedrock-mantle-openai` provider that
+ * {@link mergeBedrockMantleOpenAiProviderConfig} registers.
+ */
+export function toBedrockMantleRuntimeModelId(modelId: string): string {
+  const mantlePrefix = `${BEDROCK_MANTLE_OPENCODE_PROVIDER_ID}/openai.`;
+  const nativePrefix = `${AMAZON_BEDROCK_OPENCODE_PROVIDER_ID}/openai.`;
+
+  if (modelId.startsWith(mantlePrefix)) {
+    return `${BEDROCK_MANTLE_OPENAI_OPENCODE_PROVIDER_ID}/${modelId.slice(
+      BEDROCK_MANTLE_OPENCODE_PROVIDER_ID.length + 1,
+    )}`;
+  }
+
+  if (modelId.startsWith(nativePrefix)) {
+    return `${BEDROCK_MANTLE_OPENAI_OPENCODE_PROVIDER_ID}/${modelId.slice(
+      AMAZON_BEDROCK_OPENCODE_PROVIDER_ID.length + 1,
+    )}`;
+  }
+
+  return modelId;
+}
+
+/**
+ * Registers the `bedrock-mantle` provider (Anthropic Messages endpoint) for
+ * any selected `bedrock-mantle/...` model, wiring the region-scoped base URL
+ * and the deployment's bearer token.
+ */
+export function mergeBedrockMantleProviderConfig(
+  providerConfig: Record<string, unknown>,
+  runtimeEnv: RuntimeEnv,
+  modelIds: Array<string | undefined>,
+): Record<string, unknown> {
+  const mantleModelIds = collectModelIdsForPrefix(
+    modelIds,
+    BEDROCK_MANTLE_OPENCODE_PROVIDER_ID,
+  );
+
+  if (mantleModelIds.length === 0) {
+    return providerConfig;
+  }
+
+  const region = resolveBedrockRegion(runtimeEnv);
+  const existingProvider = asRecord(
+    providerConfig[BEDROCK_MANTLE_OPENCODE_PROVIDER_ID],
+  );
+  const existingOptions = asRecord(existingProvider.options);
+  const existingModels = asRecord(existingProvider.models);
+  const models = Object.fromEntries(
+    mantleModelIds.map((modelId) => [
+      modelId,
+      {
+        name: modelId,
+        ...asRecord(existingModels[modelId]),
+      },
+    ]),
+  );
+
+  return {
+    ...providerConfig,
+    [BEDROCK_MANTLE_OPENCODE_PROVIDER_ID]: {
+      ...existingProvider,
+      npm: '@ai-sdk/anthropic',
+      name: 'Amazon Bedrock',
+      options: {
+        ...existingOptions,
+        baseURL: `https://bedrock-mantle.${region}.api.aws/anthropic/v1`,
+        apiKey: '{env:AWS_BEARER_TOKEN_BEDROCK}',
+      },
+      models: {
+        ...existingModels,
+        ...models,
+      },
+    },
+  };
+}
+
+/**
+ * Registers the `bedrock-mantle-openai` provider for any selected
+ * `bedrock-mantle-openai/...` model (the rewrite target of
+ * {@link toBedrockMantleRuntimeModelId}).
+ */
+export function mergeBedrockMantleOpenAiProviderConfig(
+  providerConfig: Record<string, unknown>,
+  runtimeEnv: RuntimeEnv,
+  modelIds: Array<string | undefined>,
+): Record<string, unknown> {
+  const mantleModelIds = collectModelIdsForPrefix(
+    modelIds,
+    BEDROCK_MANTLE_OPENAI_OPENCODE_PROVIDER_ID,
+  );
+
+  if (mantleModelIds.length === 0) {
+    return providerConfig;
+  }
+
+  const region = resolveBedrockRegion(runtimeEnv);
+  const existingProvider = asRecord(
+    providerConfig[BEDROCK_MANTLE_OPENAI_OPENCODE_PROVIDER_ID],
+  );
+  const existingOptions = asRecord(existingProvider.options);
+  const existingModels = asRecord(existingProvider.models);
+
+  return {
+    ...providerConfig,
+    [BEDROCK_MANTLE_OPENAI_OPENCODE_PROVIDER_ID]: {
+      ...existingProvider,
+      // Mantle GPT models support the OpenAI Responses API, not Chat
+      // Completions. The native provider selects the Responses transport.
+      npm: '@ai-sdk/openai',
+      name: 'Amazon Bedrock',
+      options: {
+        ...existingOptions,
+        baseURL: `https://bedrock-mantle.${region}.api.aws/openai/v1`,
+        apiKey: '{env:AWS_BEARER_TOKEN_BEDROCK}',
+      },
+      models: {
+        ...existingModels,
+        ...Object.fromEntries(
+          mantleModelIds.map((modelId) => [
+            modelId,
+            {
+              name: modelId,
+              ...asRecord(existingModels[modelId]),
+            },
+          ]),
+        ),
+      },
+    },
+  };
+}
+
+/**
+ * Registers bearer-token credentials and model entries on OpenCode's native
+ * `amazon-bedrock` provider for any selected `amazon-bedrock/...` model. The
+ * catalog knows the provider, but not the deployment's credential.
+ */
+export function mergeAmazonBedrockProviderConfig(
+  providerConfig: Record<string, unknown>,
+  runtimeEnv: RuntimeEnv,
+  modelIds: Array<string | undefined>,
+): Record<string, unknown> {
+  const bedrockModelIds = collectModelIdsForPrefix(
+    modelIds,
+    AMAZON_BEDROCK_OPENCODE_PROVIDER_ID,
+  );
+
+  if (bedrockModelIds.length === 0) {
+    return providerConfig;
+  }
+
+  resolveBedrockRegion(runtimeEnv);
+
+  const existingProvider = asRecord(
+    providerConfig[AMAZON_BEDROCK_OPENCODE_PROVIDER_ID],
+  );
+  const existingOptions = asRecord(existingProvider.options);
+  const existingModels = asRecord(existingProvider.models);
+
+  return {
+    ...providerConfig,
+    [AMAZON_BEDROCK_OPENCODE_PROVIDER_ID]: {
+      ...existingProvider,
+      npm: '@ai-sdk/amazon-bedrock',
+      name: 'Amazon Bedrock',
+      options: {
+        apiKey: '{env:AWS_BEARER_TOKEN_BEDROCK}',
+        ...existingOptions,
+      },
+      models: {
+        ...existingModels,
+        ...Object.fromEntries(
+          bedrockModelIds.map((modelId) => [
+            modelId,
+            {
+              name: modelId,
+              ...asRecord(existingModels[modelId]),
+            },
+          ]),
+        ),
+      },
+    },
+  };
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -38,6 +38,7 @@ export * from './llm-citation-artifacts';
 export * from './live-previews';
 export * from './logging';
 export * from './llm-usage';
+export * from './bedrock-opencode-provider';
 export * from './inference-gateway';
 export * from './model-provider-config';
 export * from './openai-compatible-providers';


### PR DESCRIPTION
## Problem

Non-task inference (LLM Router, titles, summaries, fast-agent QA) cannot use Amazon Bedrock helper models at all. A helper model saved as `bedrock-mantle/openai.gpt-5.6-luna` — a value the dashboard legitimately produces — fails every call with:

```
ProviderModelNotFoundError: Model not found: bedrock-mantle/openai.gpt-5.6-luna
```

surfacing in Slack as **"Automatic routing is temporarily unavailable"** before any model request is made. (Found while verifying #1291 on a local dev stack — the improved fallback log from that PR named the model directly.)

The same tasks work fine, because the **task worker** carries alignment machinery the non-task path lacks:

1. `toBedrockMantleRuntimeModelId` rewrites `bedrock-mantle/openai.*` and `amazon-bedrock/openai.*` onto the dedicated `bedrock-mantle-openai` provider (Mantle GPT models speak the OpenAI Responses API, not the Anthropic Messages endpoint).
2. Three provider merges register `bedrock-mantle` (Anthropic endpoint), `bedrock-mantle-openai` (Responses endpoint), and the native `amazon-bedrock` provider — with the region-scoped base URLs and the deployment's `AWS_BEARER_TOKEN_BEDROCK`. OpenCode's catalog knows neither Mantle endpoint, and its native provider doesn't read the bearer token on its own.

So the entire Bedrock family was task-only: Mantle GPT and Mantle Claude helper models could never resolve on the non-task path, and native-Bedrock helper models could resolve but not authenticate with bearer-token deployments.

## Fix

Extract the worker's Bedrock wiring into `@roomote/types` (`bedrock-opencode-provider.ts`) **byte-for-byte in behavior** — same rewrite rules, same provider config shapes, same option-precedence quirks (native Bedrock lets existing options win over the injected `apiKey`; the Mantle merges override) — and use it from both sides:

- **Worker:** imports the shared functions; local copies deleted. No behavior change (agent-home suite: 47/47).
- **Non-task config builder** (`buildModelBackedOpenCodeConfigContent`): rewrites `R_MODEL`/`R_SMALL_MODEL`/`R_VISION_MODEL` through the Mantle rewrite and applies the three provider merges in the worker's order.
- **Non-task prompt path** (`resolveNonTaskModelRuntime` + modality candidates): addresses the rewritten runtime id, so `session.prompt` targets the provider the config registered.

Interplay with #1291's reasoning strip: registration happens with the reasoning options merged, then the strip removes only the reasoning keys — so a Bedrock model with a configured reasoning effort keeps its `{name}` registration entry. There's an explicit test for that.

## Testing

- New runtime tests: Mantle GPT id rewritten + `bedrock-mantle-openai` registered (exact repro of the found case), Mantle Claude registration, native Bedrock bearer-token registration, and strip-vs-registration interplay.
- New non-task test: `session.prompt` receives `{providerID: 'bedrock-mantle-openai', modelID: 'openai.gpt-5.6-luna'}` for a `bedrock-mantle/`-saved helper model.
- Full suites: `packages/cloud-agents` 693 passed, `packages/types` passed, worker `agent-home` 47 passed; typecheck + lint clean on all three. (5 pre-existing worker failures in `command-executor`/`tail-file-path` reproduce on a clean develop checkout — macOS `/tmp` host issue, untouched by this PR.)

## Notes for reviewers

- The shared module widens the env parameter to `Readonly<Record<string, string | undefined>>` so both the worker's `Record<string, string>` and the runtime's `NodeJS.ProcessEnv` fit; no call-site casts.
- Non-task servers cache by env-derived key, so deployments changing model settings get fresh servers as before; nothing about leasing changed.
