### PR TITLE
[Fix] Sleep check aborts entirely when one provider's client cannot be built

### DIFF
--- a/apps/bullmq/src/scheduled-jobs/__tests__/sleep-check.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/sleep-check.test.ts
@@ -1225,6 +1225,111 @@ describe('sleepCheckJob', () => {
     expect(mockCreateSnapshot).toHaveBeenCalledTimes(2);
   });
 
+  it('continues evaluating other vendors when one provider client cannot be constructed', async () => {
+    const modalJob = {
+      id: 200,
+      machineId: 'sb-modal-unconfigured',
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Idle,
+      taskPhase: 'waiting_for_prompt',
+      vendor: 'modal',
+      snapshotId: null,
+      sleepRequestedAt: null,
+      snapshotRequestedAt: null,
+    };
+    const blaxelJob = {
+      id: 201,
+      machineId: 'sb-blaxel-healthy',
+      sandboxCmdId: 'worker-command-3',
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Idle,
+      taskPhase: 'waiting_for_prompt',
+      vendor: 'blaxel',
+      taskId: 'task-blaxel-2',
+      snapshotId: null,
+      sleepRequestedAt: null,
+      snapshotRequestedAt: null,
+    };
+
+    mockJobQueries({ dueJobs: [modalJob, blaxelJob] });
+    mockCreateComputeProviderClient.mockImplementation(({ provider }) => {
+      if (provider === 'modal') {
+        throw new Error('Missing MODAL_BASE_IMAGE_REF');
+      }
+      return {
+        destroyInstance: mockDestroyInstance,
+        enterStandby: mockEnterStandby,
+        getInstanceStatus: mockGetInstanceStatus,
+      };
+    });
+    mockGetInstanceStatus.mockResolvedValue({
+      status: 'running',
+      timeoutRemainingMs: 5 * 60 * 60 * 1_000,
+    });
+    returningFn.mockResolvedValue([{ id: 201 }]);
+
+    await sleepCheckJob();
+
+    // The unconfigured provider's candidate records a failed skip event...
+    expect(mockRecordTaskRunEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        runId: 200,
+        eventType: 'failed',
+        source: 'sleep_check',
+        details: expect.objectContaining({
+          decision: 'skip_provider_client_unavailable',
+          error: 'Missing MODAL_BASE_IMAGE_REF',
+        }),
+      }),
+    );
+    // ...and the other vendor's machine is still evaluated and retained.
+    expect(mockGetInstanceStatus).toHaveBeenCalledWith({
+      instanceId: 'sb-blaxel-healthy',
+    });
+    expect(mockEnterStandby).toHaveBeenCalledWith({
+      instanceId: 'sb-blaxel-healthy',
+      commandId: 'worker-command-3',
+    });
+  });
+
+  it('does not rebuild a failed provider client for every candidate in the same sweep', async () => {
+    const makeModalJob = (id: number) => ({
+      id,
+      machineId: `sb-modal-unconfigured-${id}`,
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Idle,
+      taskPhase: 'waiting_for_prompt',
+      vendor: 'modal',
+      snapshotId: null,
+      sleepRequestedAt: null,
+      snapshotRequestedAt: null,
+    });
+
+    mockJobQueries({ dueJobs: [makeModalJob(210), makeModalJob(211)] });
+    mockCreateComputeProviderClient.mockImplementation(() => {
+      throw new Error('Missing MODAL_BASE_IMAGE_REF');
+    });
+
+    await sleepCheckJob();
+
+    expect(mockCreateComputeProviderClient).toHaveBeenCalledTimes(1);
+    for (const runId of [210, 211]) {
+      expect(mockRecordTaskRunEvent).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          runId,
+          eventType: 'failed',
+          source: 'sleep_check',
+          details: expect.objectContaining({
+            decision: 'skip_provider_client_unavailable',
+          }),
+        }),
+      );
+    }
+    expect(mockGetInstanceStatus).not.toHaveBeenCalled();
+  });
+
   it('extends stale active deadlines instead of snapshotting running jobs with plenty of sandbox time left', async () => {
     const mockJob = {
       id: 85,

--- a/apps/bullmq/src/scheduled-jobs/sleep-check.ts
+++ b/apps/bullmq/src/scheduled-jobs/sleep-check.ts
@@ -326,6 +326,11 @@ export const sleepCheckJob = async () => {
     ComputeProvider,
     Awaited<ReturnType<typeof getSleepCheckClient>>
   >();
+  // Client construction can throw for providers that are not configured on
+  // this deployment (e.g. stale rows from another vendor). Cache the failure
+  // per sweep so one bad provider skips only its own candidates instead of
+  // aborting the whole job — and isn't rebuilt for every candidate.
+  const providerClientFailures = new Map<ComputeProvider, string>();
 
   await mergeSleepCheckCandidates(candidateJobsByMachineId, dueJobs, 'dueJob', {
     path: 'due_sleep',
@@ -390,9 +395,38 @@ export const sleepCheckJob = async () => {
 
     let client = providerClients.get(provider);
 
+    if (!client && !providerClientFailures.has(provider)) {
+      try {
+        client = await getSleepCheckClient(provider);
+        providerClients.set(provider, client);
+      } catch (error) {
+        providerClientFailures.set(
+          provider,
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    }
+
     if (!client) {
-      client = await getSleepCheckClient(provider);
-      providerClients.set(provider, client);
+      const clientError =
+        providerClientFailures.get(provider) ?? 'unknown error';
+
+      await recordSleepCheckEvent(
+        preferredJob,
+        'failed',
+        `Skipped ${describeSleepCheckPath(fallbackPath).toLowerCase()} for task run #${preferredJob.id} because the ${provider} compute client could not be created.`,
+        {
+          path: fallbackPath,
+          decision: 'skip_provider_client_unavailable',
+          error: clientError,
+          ...buildSleepCheckDetails(preferredJob),
+        },
+      );
+      console.error(
+        `[sleepCheck] Skipping task run #${preferredJob.id}: could not create ${provider} compute client:`,
+        clientError,
+      );
+      continue;
     }
 
     try {


### PR DESCRIPTION
## Problem

In the sleep-check scheduled job, `getSleepCheckClient(provider)` for each machine's vendor was called outside the per-machine `try/catch`. If any candidate run's provider couldn't build a compute client (e.g. `Missing MODAL_BASE_IMAGE_REF` on a deployment that doesn't have Modal configured but has stale runs with that vendor), the entire job threw and **no machine of any vendor was processed**. Zombie sandboxes were never slept or reaped, and every tick failed the same way until the stale rows were cleaned up by hand.

## Fix

- Wrap client construction in a per-machine `try/catch`. On failure, the candidate records a `failed` sleep-check event with decision `skip_provider_client_unavailable` (mirroring the existing `skip_unsupported_provider` pattern, with the construction error in the event details) and the loop continues to the next machine.
- Cache the failure in a per-sweep map so an unconfigured provider with many stale candidates is only attempted once per tick instead of once per candidate. The cache is sweep-local, so a provider that gets configured later is retried on the next tick.

## Tests

- Two due candidates with different vendors where the first vendor's client constructor throws: asserts the second machine is still evaluated (and retained on standby) and the first records the failed skip event.
- Two candidates on the same failing vendor: asserts the client constructor is only invoked once per sweep and both runs record failed events.

`vitest run` on the sleep-check suite passes (43 tests), plus package typecheck and repo lint.