### PR TITLE
Validate inference providers before saving credentials

### DIFF
--- a/apps/docs/models.mdx
+++ b/apps/docs/models.mdx
@@ -36,6 +36,15 @@ in the setup wizard and from **Settings > Models**. You stay in control: you
 can disable or remove any of the added models, add more later, and reconnecting
 a provider never re-adds models you removed.
 
+When you connect or update an API-key provider, Roomote first checks the
+submitted credentials with a small live model request. If the provider rejects
+the key, or the account has no remaining credits, nothing is saved: fix the
+credential and save again. Other failures (a rate limit, a model your account
+cannot access, or a transient provider outage) never block the save.
+Self-hosted OpenAI-compatible endpoint connections are checked by listing the
+endpoint's models instead. Saving again without changing any credential skips
+the live check.
+
 ### API and gateway providers
 
 These connections use metered API billing or a provider-managed gateway:

--- a/apps/web/src/trpc/commands/setup-new/index.test.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.test.ts
@@ -19,7 +19,7 @@ const {
   mockGetLinkedDiscordAccount,
   mockGetTeamsIntegrationStatus,
   mockInvalidateTelegramRuntimeCredentialsCache,
-  mockAssertInferenceProviderConnection,
+  mockValidateSetupModelProviderCredentials,
 } = vi.hoisted(() => ({
   mockValidateTeamsBotCredentials: vi.fn(async () => undefined),
   mockTxSelect: vi.fn(),
@@ -44,11 +44,14 @@ const {
   mockGetLinkedDiscordAccount: vi.fn(),
   mockGetTeamsIntegrationStatus: vi.fn(),
   mockInvalidateTelegramRuntimeCredentialsCache: vi.fn(),
-  mockAssertInferenceProviderConnection: vi.fn().mockResolvedValue(undefined),
+  mockValidateSetupModelProviderCredentials: vi
+    .fn()
+    .mockResolvedValue(undefined),
 }));
 
 vi.mock('../task-models/provider-validation', () => ({
-  assertInferenceProviderConnection: mockAssertInferenceProviderConnection,
+  validateSetupModelProviderCredentials:
+    mockValidateSetupModelProviderCredentials,
 }));
 
 vi.mock('@/lib/server/setup-funnel-telemetry', () => ({

--- a/apps/web/src/trpc/commands/setup-new/index.test.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.test.ts
@@ -19,6 +19,7 @@ const {
   mockGetLinkedDiscordAccount,
   mockGetTeamsIntegrationStatus,
   mockInvalidateTelegramRuntimeCredentialsCache,
+  mockAssertInferenceProviderConnection,
 } = vi.hoisted(() => ({
   mockValidateTeamsBotCredentials: vi.fn(async () => undefined),
   mockTxSelect: vi.fn(),
@@ -43,6 +44,11 @@ const {
   mockGetLinkedDiscordAccount: vi.fn(),
   mockGetTeamsIntegrationStatus: vi.fn(),
   mockInvalidateTelegramRuntimeCredentialsCache: vi.fn(),
+  mockAssertInferenceProviderConnection: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../task-models/provider-validation', () => ({
+  assertInferenceProviderConnection: mockAssertInferenceProviderConnection,
 }));
 
 vi.mock('@/lib/server/setup-funnel-telemetry', () => ({

--- a/apps/web/src/trpc/commands/setup-new/index.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.ts
@@ -73,6 +73,7 @@ import {
   getComputeFieldValidationError,
   getSetupModelProvider,
   getSetupModelProviderAdditionalEnvFields,
+  getSetupModelProviderEnvVarNames,
   SETUP_MODEL_PROVIDER_CATALOG,
   buildOpenAiCompatibleProviderId,
   buildOpenAiCompatibleProviderInstance,
@@ -175,6 +176,7 @@ import {
   buildAutoAddedTaskModelSettings,
   collectConnectedTaskModelProviderIds,
 } from '../task-models/auto-add-models';
+import { assertInferenceProviderConnection } from '../task-models/provider-validation';
 import { triggerTaskSuggestionsCommand } from '../task-suggestions';
 
 type PersistedSetupNewState = ReturnType<typeof createEmptySetupNewState>;
@@ -1580,6 +1582,53 @@ export async function saveSetupNewModelConfigCommand(
     );
   }
 
+  let selectedDynamicModel = input.modelId?.trim();
+
+  // Discovery in the wizard uses the catalog id `openai-compatible/...`.
+  // After naming the connection, remap model ids onto the named provider.
+  if (
+    selectedDynamicModel?.startsWith(`${OPENAI_COMPATIBLE_PROVIDER_ID}/`) &&
+    provider.id !== OPENAI_COMPATIBLE_PROVIDER_ID &&
+    isOpenAiCompatibleProviderId(provider.id)
+  ) {
+    selectedDynamicModel = `${provider.id}/${selectedDynamicModel.slice(
+      OPENAI_COMPATIBLE_PROVIDER_ID.length + 1,
+    )}`;
+  }
+
+  if (provider.dynamicModels && !selectedDynamicModel) {
+    throw new Error(`Choose a discovered ${provider.label} model to continue.`);
+  }
+
+  const runtimeModelConfig = provider.dynamicModels
+    ? {
+        ...createEmptyDeploymentModelConfig(),
+        roomoteModel: selectedDynamicModel!,
+      }
+    : buildRecommendedDeploymentModelConfig(provider);
+
+  if (!isOauthProvider) {
+    const persistedEnvVarNames = await getPersistedEnvironmentVariableNames();
+    const persistedEnvVarNameSet = new Set(persistedEnvVarNames);
+    const validationCredentials = collectSetupModelProviderCredentialValues({
+      provider,
+      apiKey,
+      additionalEnvValues,
+      isEnvVarSatisfied: (envVarName) =>
+        persistedEnvVarNameSet.has(envVarName) ||
+        isConfiguredEnvValue(process.env[envVarName]),
+      action: 'continue',
+    });
+
+    await assertInferenceProviderConnection({
+      providerLabel: provider.label,
+      providerEnvVarNames: getSetupModelProviderEnvVarNames(provider),
+      modelId: runtimeModelConfig.roomoteModel!,
+      credentialValues: validationCredentials.values,
+      clearedEnvVarNames: validationCredentials.clearedEnvVarNames,
+    });
+  }
+
   return db.transaction(async (tx) => {
     const [currentState, persistedEnvVarNames, persistedTaskModelSettings] =
       await Promise.all([
@@ -1631,36 +1680,6 @@ export async function saveSetupNewModelConfigCommand(
       modelProvider: provider.id,
       lastInteractedByUserId: userId,
     });
-    // Connecting a provider applies its recommended per-role model defaults:
-    // the provider's default coding model plus any recommended helper,
-    // vision, code review, explore, and planning models.
-    let selectedDynamicModel = input.modelId?.trim();
-
-    // Discovery in the wizard uses the catalog id `openai-compatible/...`.
-    // After naming the connection, remap model ids onto the named premium.
-    if (
-      selectedDynamicModel?.startsWith(`${OPENAI_COMPATIBLE_PROVIDER_ID}/`) &&
-      provider.id !== OPENAI_COMPATIBLE_PROVIDER_ID &&
-      isOpenAiCompatibleProviderId(provider.id)
-    ) {
-      selectedDynamicModel = `${provider.id}/${selectedDynamicModel.slice(
-        OPENAI_COMPATIBLE_PROVIDER_ID.length + 1,
-      )}`;
-    }
-
-    if (provider.dynamicModels && !selectedDynamicModel) {
-      throw new Error(
-        `Choose a discovered ${provider.label} model to continue.`,
-      );
-    }
-
-    const runtimeModelConfig = provider.dynamicModels
-      ? {
-          ...createEmptyDeploymentModelConfig(),
-          roomoteModel: selectedDynamicModel!,
-        }
-      : buildRecommendedDeploymentModelConfig(provider);
-
     // Mirror the models settings page: connecting a provider the deployment
     // has no models for yet auto-adds its recommended models so the first
     // launch offers a usable model list.

--- a/apps/web/src/trpc/commands/setup-new/index.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.ts
@@ -73,7 +73,6 @@ import {
   getComputeFieldValidationError,
   getSetupModelProvider,
   getSetupModelProviderAdditionalEnvFields,
-  getSetupModelProviderEnvVarNames,
   SETUP_MODEL_PROVIDER_CATALOG,
   buildOpenAiCompatibleProviderId,
   buildOpenAiCompatibleProviderInstance,
@@ -176,7 +175,7 @@ import {
   buildAutoAddedTaskModelSettings,
   collectConnectedTaskModelProviderIds,
 } from '../task-models/auto-add-models';
-import { assertInferenceProviderConnection } from '../task-models/provider-validation';
+import { validateSetupModelProviderCredentials } from '../task-models/provider-validation';
 import { triggerTaskSuggestionsCommand } from '../task-suggestions';
 
 type PersistedSetupNewState = ReturnType<typeof createEmptySetupNewState>;
@@ -1608,24 +1607,12 @@ export async function saveSetupNewModelConfigCommand(
     : buildRecommendedDeploymentModelConfig(provider);
 
   if (!isOauthProvider) {
-    const persistedEnvVarNames = await getPersistedEnvironmentVariableNames();
-    const persistedEnvVarNameSet = new Set(persistedEnvVarNames);
-    const validationCredentials = collectSetupModelProviderCredentialValues({
+    await validateSetupModelProviderCredentials({
       provider,
       apiKey,
       additionalEnvValues,
-      isEnvVarSatisfied: (envVarName) =>
-        persistedEnvVarNameSet.has(envVarName) ||
-        isConfiguredEnvValue(process.env[envVarName]),
       action: 'continue',
-    });
-
-    await assertInferenceProviderConnection({
-      providerLabel: provider.label,
-      providerEnvVarNames: getSetupModelProviderEnvVarNames(provider),
       modelId: runtimeModelConfig.roomoteModel!,
-      credentialValues: validationCredentials.values,
-      clearedEnvVarNames: validationCredentials.clearedEnvVarNames,
     });
   }
 

--- a/apps/web/src/trpc/commands/task-models/index.test.ts
+++ b/apps/web/src/trpc/commands/task-models/index.test.ts
@@ -15,6 +15,7 @@ const {
   mockIsChatGptSubscriptionConnected,
   mockIsGitHubCopilotSubscriptionConnected,
   mockIsXaiSubscriptionConnected,
+  mockAssertInferenceProviderConnection,
 } = vi.hoisted(() => ({
   mockFindDeploymentSettings: vi.fn(),
   mockInsertDeploymentSettings: vi.fn(),
@@ -28,6 +29,11 @@ const {
   mockIsChatGptSubscriptionConnected: vi.fn(),
   mockIsGitHubCopilotSubscriptionConnected: vi.fn(),
   mockIsXaiSubscriptionConnected: vi.fn(),
+  mockAssertInferenceProviderConnection: vi.fn(),
+}));
+
+vi.mock('./provider-validation', () => ({
+  assertInferenceProviderConnection: mockAssertInferenceProviderConnection,
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -146,6 +152,7 @@ describe('lookupTaskModelCommand', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockAssertInferenceProviderConnection.mockResolvedValue(undefined);
     vi.stubGlobal('fetch', fetchMock);
     for (const name of PROVIDER_ENV_VAR_NAMES) {
       originalProviderEnvValues.set(name, process.env[name]);
@@ -1429,6 +1436,14 @@ describe('task model provider commands', () => {
       apiKey: '  sk-ant-test  ',
     });
 
+    expect(mockAssertInferenceProviderConnection).toHaveBeenCalledWith({
+      providerLabel: 'Anthropic',
+      providerEnvVarNames: ['ANTHROPIC_API_KEY'],
+      modelId: 'anthropic/claude-sonnet-5',
+      credentialValues: [{ name: 'ANTHROPIC_API_KEY', value: 'sk-ant-test' }],
+      clearedEnvVarNames: [],
+    });
+
     expect(mockUpsertDeploymentEnvironmentVariables).toHaveBeenCalledWith(
       expect.anything(),
       {
@@ -1483,6 +1498,26 @@ describe('task model provider commands', () => {
         (provider) => provider.id === 'anthropic',
       ),
     ).toMatchObject({ savedApiKeySatisfied: true });
+  });
+
+  it('does not persist credentials when inference validation fails', async () => {
+    mockAssertInferenceProviderConnection.mockRejectedValueOnce(
+      new Error(
+        'Anthropic: The inference provider rejected these credentials.',
+      ),
+    );
+
+    await expect(
+      saveTaskModelProviderCommand(buildMockAuth(), {
+        provider: 'anthropic',
+        apiKey: 'bad-key',
+      }),
+    ).rejects.toThrow(
+      'Anthropic: The inference provider rejected these credentials.',
+    );
+
+    expect(mockUpsertDeploymentEnvironmentVariables).not.toHaveBeenCalled();
+    expect(txInsert).not.toHaveBeenCalled();
   });
 
   it('keeps other connected providers models when seeding a fresh deployment', async () => {

--- a/apps/web/src/trpc/commands/task-models/index.test.ts
+++ b/apps/web/src/trpc/commands/task-models/index.test.ts
@@ -16,6 +16,7 @@ const {
   mockIsGitHubCopilotSubscriptionConnected,
   mockIsXaiSubscriptionConnected,
   mockValidateSetupModelProviderCredentials,
+  mockCollectCandidateProviderCredentials,
 } = vi.hoisted(() => ({
   mockFindDeploymentSettings: vi.fn(),
   mockInsertDeploymentSettings: vi.fn(),
@@ -30,11 +31,13 @@ const {
   mockIsGitHubCopilotSubscriptionConnected: vi.fn(),
   mockIsXaiSubscriptionConnected: vi.fn(),
   mockValidateSetupModelProviderCredentials: vi.fn(),
+  mockCollectCandidateProviderCredentials: vi.fn(),
 }));
 
 vi.mock('./provider-validation', () => ({
   validateSetupModelProviderCredentials:
     mockValidateSetupModelProviderCredentials,
+  collectCandidateProviderCredentials: mockCollectCandidateProviderCredentials,
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -154,6 +157,13 @@ describe('lookupTaskModelCommand', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockValidateSetupModelProviderCredentials.mockResolvedValue(undefined);
+    mockCollectCandidateProviderCredentials.mockResolvedValue({
+      values: [],
+      clearedEnvVarNames: [],
+      changedValues: [],
+      clearedPersistedEnvVarNames: [],
+      persistedEnv: {},
+    });
     vi.stubGlobal('fetch', fetchMock);
     for (const name of PROVIDER_ENV_VAR_NAMES) {
       originalProviderEnvValues.set(name, process.env[name]);

--- a/apps/web/src/trpc/commands/task-models/index.test.ts
+++ b/apps/web/src/trpc/commands/task-models/index.test.ts
@@ -15,7 +15,7 @@ const {
   mockIsChatGptSubscriptionConnected,
   mockIsGitHubCopilotSubscriptionConnected,
   mockIsXaiSubscriptionConnected,
-  mockAssertInferenceProviderConnection,
+  mockValidateSetupModelProviderCredentials,
 } = vi.hoisted(() => ({
   mockFindDeploymentSettings: vi.fn(),
   mockInsertDeploymentSettings: vi.fn(),
@@ -29,11 +29,12 @@ const {
   mockIsChatGptSubscriptionConnected: vi.fn(),
   mockIsGitHubCopilotSubscriptionConnected: vi.fn(),
   mockIsXaiSubscriptionConnected: vi.fn(),
-  mockAssertInferenceProviderConnection: vi.fn(),
+  mockValidateSetupModelProviderCredentials: vi.fn(),
 }));
 
 vi.mock('./provider-validation', () => ({
-  assertInferenceProviderConnection: mockAssertInferenceProviderConnection,
+  validateSetupModelProviderCredentials:
+    mockValidateSetupModelProviderCredentials,
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -152,7 +153,7 @@ describe('lookupTaskModelCommand', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockAssertInferenceProviderConnection.mockResolvedValue(undefined);
+    mockValidateSetupModelProviderCredentials.mockResolvedValue(undefined);
     vi.stubGlobal('fetch', fetchMock);
     for (const name of PROVIDER_ENV_VAR_NAMES) {
       originalProviderEnvValues.set(name, process.env[name]);
@@ -1436,13 +1437,14 @@ describe('task model provider commands', () => {
       apiKey: '  sk-ant-test  ',
     });
 
-    expect(mockAssertInferenceProviderConnection).toHaveBeenCalledWith({
-      providerLabel: 'Anthropic',
-      providerEnvVarNames: ['ANTHROPIC_API_KEY'],
-      modelId: 'anthropic/claude-sonnet-5',
-      credentialValues: [{ name: 'ANTHROPIC_API_KEY', value: 'sk-ant-test' }],
-      clearedEnvVarNames: [],
-    });
+    expect(mockValidateSetupModelProviderCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: expect.objectContaining({ id: 'anthropic' }),
+        apiKey: '  sk-ant-test  ',
+        action: 'save it',
+        modelId: 'anthropic/claude-sonnet-5',
+      }),
+    );
 
     expect(mockUpsertDeploymentEnvironmentVariables).toHaveBeenCalledWith(
       expect.anything(),
@@ -1501,7 +1503,7 @@ describe('task model provider commands', () => {
   });
 
   it('does not persist credentials when inference validation fails', async () => {
-    mockAssertInferenceProviderConnection.mockRejectedValueOnce(
+    mockValidateSetupModelProviderCredentials.mockRejectedValueOnce(
       new Error(
         'Anthropic: The inference provider rejected these credentials.',
       ),

--- a/apps/web/src/trpc/commands/task-models/index.ts
+++ b/apps/web/src/trpc/commands/task-models/index.ts
@@ -69,7 +69,10 @@ import {
   buildAutoAddedTaskModelSettings,
   collectConnectedTaskModelProviderIds,
 } from './auto-add-models';
-import { validateSetupModelProviderCredentials } from './provider-validation';
+import {
+  collectCandidateProviderCredentials,
+  validateSetupModelProviderCredentials,
+} from './provider-validation';
 import {
   discoverProviderModels,
   getLocalTaskModelProviderIdFromModelId,
@@ -694,26 +697,38 @@ export async function saveTaskModelProviderCommand(
         buildRecommendedDeploymentModelConfig(provider).roomoteModel ??
         provider.defaultRoomoteModel,
     });
-  } else if (
-    isConfiguredEnvValue(input.apiKey) ||
-    Object.values(suppliedAdditionalEnvValues ?? {}).some((value) =>
-      isConfiguredEnvValue(value),
-    )
-  ) {
-    const secretField = getSetupModelProviderAdditionalEnvFields(provider).find(
-      (field) => field.secret,
-    );
-    const probe = await discoverProviderModels({
-      provider: provider.id as LocalTaskModelProviderId,
-      baseUrl: input.apiKey?.trim() || undefined,
-      apiKey: secretField
-        ? suppliedAdditionalEnvValues?.[secretField.envVarName]?.trim() ||
-          undefined
-        : undefined,
-    });
+  } else {
+    // UIs resubmit unchanged fields (connection names, keys echoed back
+    // from saved state), so gate the probe on what the save would actually
+    // alter, not on non-empty form fields.
+    const { values, changedValues, clearedPersistedEnvVarNames } =
+      await collectCandidateProviderCredentials({
+        provider,
+        apiKey: input.apiKey,
+        additionalEnvValues: suppliedAdditionalEnvValues,
+        action: 'save it',
+      });
 
-    if (probe.error) {
-      throw new Error(`${provider.label}: ${probe.error}`);
+    if (changedValues.length > 0 || clearedPersistedEnvVarNames.length > 0) {
+      const candidateValueByName = new Map(
+        values.map(({ name, value }) => [name, value]),
+      );
+      const secretField = getSetupModelProviderAdditionalEnvFields(
+        provider,
+      ).find((field) => field.secret);
+      const probe = await discoverProviderModels({
+        provider: provider.id as LocalTaskModelProviderId,
+        baseUrl: provider.envVarName
+          ? candidateValueByName.get(provider.envVarName)
+          : undefined,
+        apiKey: secretField
+          ? candidateValueByName.get(secretField.envVarName)
+          : undefined,
+      });
+
+      if (probe.error) {
+        throw new Error(`${provider.label}: ${probe.error}`);
+      }
     }
   }
 

--- a/apps/web/src/trpc/commands/task-models/index.ts
+++ b/apps/web/src/trpc/commands/task-models/index.ts
@@ -701,13 +701,17 @@ export async function saveTaskModelProviderCommand(
     // UIs resubmit unchanged fields (connection names, keys echoed back
     // from saved state), so gate the probe on what the save would actually
     // alter, not on non-empty form fields.
-    const { values, changedValues, clearedPersistedEnvVarNames } =
-      await collectCandidateProviderCredentials({
-        provider,
-        apiKey: input.apiKey,
-        additionalEnvValues: suppliedAdditionalEnvValues,
-        action: 'save it',
-      });
+    const {
+      values,
+      clearedEnvVarNames,
+      changedValues,
+      clearedPersistedEnvVarNames,
+    } = await collectCandidateProviderCredentials({
+      provider,
+      apiKey: input.apiKey,
+      additionalEnvValues: suppliedAdditionalEnvValues,
+      action: 'save it',
+    });
 
     if (changedValues.length > 0 || clearedPersistedEnvVarNames.length > 0) {
       const candidateValueByName = new Map(
@@ -721,8 +725,12 @@ export async function saveTaskModelProviderCommand(
         baseUrl: provider.envVarName
           ? candidateValueByName.get(provider.envVarName)
           : undefined,
+        // A cleared key probes as `null` so the resolver cannot fall back
+        // to the persisted value the transaction is about to delete.
         apiKey: secretField
-          ? candidateValueByName.get(secretField.envVarName)
+          ? clearedEnvVarNames.includes(secretField.envVarName)
+            ? null
+            : candidateValueByName.get(secretField.envVarName)
           : undefined,
       });
 

--- a/apps/web/src/trpc/commands/task-models/index.ts
+++ b/apps/web/src/trpc/commands/task-models/index.ts
@@ -18,6 +18,7 @@ import {
   SETUP_MODEL_PROVIDER_CATALOG,
   buildOpenAiCompatibleProviderId,
   buildOpenAiCompatibleProviderInstance,
+  buildRecommendedDeploymentModelConfig,
   buildSetupModelStatus,
   buildTaskModelOption,
   collectSetupModelProviderCredentialValues,
@@ -68,6 +69,7 @@ import {
   buildAutoAddedTaskModelSettings,
   collectConnectedTaskModelProviderIds,
 } from './auto-add-models';
+import { assertInferenceProviderConnection } from './provider-validation';
 import {
   discoverProviderModels,
   getLocalTaskModelProviderIdFromModelId,
@@ -677,6 +679,33 @@ export async function saveTaskModelProviderCommand(
     isChatGptSubscriptionConnected(),
     isXaiSubscriptionConnected(),
   ]);
+
+  // Dynamic endpoints are qualified after model discovery because there is
+  // no model to request at connection time. Static providers can be checked
+  // before any submitted credential is persisted.
+  if (!provider.dynamicModels) {
+    const persistedEnvVarNames = await getPersistedEnvironmentVariableNames();
+    const persistedEnvVarNameSet = new Set(persistedEnvVarNames);
+    const validationCredentials = collectSetupModelProviderCredentialValues({
+      provider,
+      apiKey: input.apiKey,
+      additionalEnvValues: suppliedAdditionalEnvValues,
+      isEnvVarSatisfied: (envVarName) =>
+        persistedEnvVarNameSet.has(envVarName) ||
+        isConfiguredEnvValue(process.env[envVarName]),
+      action: 'save it',
+    });
+
+    await assertInferenceProviderConnection({
+      providerLabel: provider.label,
+      providerEnvVarNames: getSetupModelProviderEnvVarNames(provider),
+      modelId:
+        buildRecommendedDeploymentModelConfig(provider).roomoteModel ??
+        provider.defaultRoomoteModel,
+      credentialValues: validationCredentials.values,
+      clearedEnvVarNames: validationCredentials.clearedEnvVarNames,
+    });
+  }
 
   let addedRecommendedModelCount = 0;
 

--- a/apps/web/src/trpc/commands/task-models/index.ts
+++ b/apps/web/src/trpc/commands/task-models/index.ts
@@ -69,7 +69,7 @@ import {
   buildAutoAddedTaskModelSettings,
   collectConnectedTaskModelProviderIds,
 } from './auto-add-models';
-import { assertInferenceProviderConnection } from './provider-validation';
+import { validateSetupModelProviderCredentials } from './provider-validation';
 import {
   discoverProviderModels,
   getLocalTaskModelProviderIdFromModelId,
@@ -680,31 +680,41 @@ export async function saveTaskModelProviderCommand(
     isXaiSubscriptionConnected(),
   ]);
 
-  // Dynamic endpoints are qualified after model discovery because there is
-  // no model to request at connection time. Static providers can be checked
-  // before any submitted credential is persisted.
+  // Static providers can be checked with the provider's recommended model
+  // before any submitted credential is persisted. Dynamic endpoints have no
+  // model to request at connection time, so a submitted connection is
+  // qualified by listing the endpoint's models instead.
   if (!provider.dynamicModels) {
-    const persistedEnvVarNames = await getPersistedEnvironmentVariableNames();
-    const persistedEnvVarNameSet = new Set(persistedEnvVarNames);
-    const validationCredentials = collectSetupModelProviderCredentialValues({
+    await validateSetupModelProviderCredentials({
       provider,
       apiKey: input.apiKey,
       additionalEnvValues: suppliedAdditionalEnvValues,
-      isEnvVarSatisfied: (envVarName) =>
-        persistedEnvVarNameSet.has(envVarName) ||
-        isConfiguredEnvValue(process.env[envVarName]),
       action: 'save it',
-    });
-
-    await assertInferenceProviderConnection({
-      providerLabel: provider.label,
-      providerEnvVarNames: getSetupModelProviderEnvVarNames(provider),
       modelId:
         buildRecommendedDeploymentModelConfig(provider).roomoteModel ??
         provider.defaultRoomoteModel,
-      credentialValues: validationCredentials.values,
-      clearedEnvVarNames: validationCredentials.clearedEnvVarNames,
     });
+  } else if (
+    isConfiguredEnvValue(input.apiKey) ||
+    Object.values(suppliedAdditionalEnvValues ?? {}).some((value) =>
+      isConfiguredEnvValue(value),
+    )
+  ) {
+    const secretField = getSetupModelProviderAdditionalEnvFields(provider).find(
+      (field) => field.secret,
+    );
+    const probe = await discoverProviderModels({
+      provider: provider.id as LocalTaskModelProviderId,
+      baseUrl: input.apiKey?.trim() || undefined,
+      apiKey: secretField
+        ? suppliedAdditionalEnvValues?.[secretField.envVarName]?.trim() ||
+          undefined
+        : undefined,
+    });
+
+    if (probe.error) {
+      throw new Error(`${provider.label}: ${probe.error}`);
+    }
   }
 
   let addedRecommendedModelCount = 0;

--- a/apps/web/src/trpc/commands/task-models/local-provider-discovery.ts
+++ b/apps/web/src/trpc/commands/task-models/local-provider-discovery.ts
@@ -40,7 +40,9 @@ export type LocalTaskModelProviderId =
 
 export type LocalProviderConnectionInput = {
   baseUrl?: string;
-  apiKey?: string;
+  /** `null` marks a key the caller is clearing: the still-persisted value
+   * must not serve as a fallback, because the save is about to delete it. */
+  apiKey?: string | null;
 };
 
 type LocalProviderConnection = {
@@ -282,12 +284,19 @@ async function resolveLocalProviderConnection(
     return null;
   }
 
+  // A cleared key still resolves from the runtime env (deleting the
+  // persisted row does not unset a process-level value), but must not fall
+  // back to the persisted value the save is about to delete.
+  const clearingApiKey = input?.apiKey === null;
+
   return {
     baseUrl,
     apiKey:
-      input?.apiKey?.trim() ||
+      (clearingApiKey ? undefined : input?.apiKey?.trim()) ||
       (envNames.apiKey ? process.env[envNames.apiKey] : null) ||
-      (envNames.apiKey ? persisted[envNames.apiKey] : null) ||
+      (envNames.apiKey && !clearingApiKey
+        ? persisted[envNames.apiKey]
+        : null) ||
       null,
   };
 }

--- a/apps/web/src/trpc/commands/task-models/provider-validation.test.ts
+++ b/apps/web/src/trpc/commands/task-models/provider-validation.test.ts
@@ -163,6 +163,17 @@ describe('validateSetupModelProviderCredentials', () => {
     expect(mockValidateNonTaskInference).not.toHaveBeenCalled();
   });
 
+  it('skips the live check when the UI resubmits the persisted value unchanged', async () => {
+    await validateSetupModelProviderCredentials({
+      provider: getSetupModelProvider('anthropic'),
+      apiKey: 'saved-key',
+      action: 'save it',
+      modelId: 'anthropic/claude-sonnet-5',
+    });
+
+    expect(mockValidateNonTaskInference).not.toHaveBeenCalled();
+  });
+
   it('validates a submitted credential once against the persisted env', async () => {
     await validateSetupModelProviderCredentials({
       provider: getSetupModelProvider('anthropic'),

--- a/apps/web/src/trpc/commands/task-models/provider-validation.test.ts
+++ b/apps/web/src/trpc/commands/task-models/provider-validation.test.ts
@@ -1,0 +1,104 @@
+const { mockResolveEffectiveDeploymentEnvVars, mockValidateNonTaskInference } =
+  vi.hoisted(() => ({
+    mockResolveEffectiveDeploymentEnvVars: vi.fn(),
+    mockValidateNonTaskInference: vi.fn(),
+  }));
+
+vi.mock('@roomote/db/server', () => ({
+  resolveEffectiveDeploymentEnvVars: mockResolveEffectiveDeploymentEnvVars,
+}));
+
+vi.mock('@roomote/cloud-agents/server', () => ({
+  validateNonTaskInference: mockValidateNonTaskInference,
+}));
+
+import {
+  assertInferenceProviderConnection,
+  InferenceProviderValidationError,
+} from './provider-validation';
+
+describe('assertInferenceProviderConnection', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.ANTHROPIC_API_KEY;
+    mockResolveEffectiveDeploymentEnvVars.mockResolvedValue({
+      ANTHROPIC_API_KEY: 'saved-key',
+      AWS_REGION: 'us-east-1',
+    });
+    mockValidateNonTaskInference.mockResolvedValue({
+      success: true,
+      checkedAt: '2026-08-13T12:00:00.000Z',
+      latencyMs: 25,
+      model: 'anthropic/claude-sonnet-5',
+    });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('overlays submitted credentials without persisting them first', async () => {
+    await assertInferenceProviderConnection({
+      providerLabel: 'Anthropic',
+      providerEnvVarNames: ['ANTHROPIC_API_KEY'],
+      modelId: 'anthropic/claude-sonnet-5',
+      credentialValues: [{ name: 'ANTHROPIC_API_KEY', value: 'candidate-key' }],
+    });
+
+    expect(mockValidateNonTaskInference).toHaveBeenCalledWith({
+      model: 'anthropic/claude-sonnet-5',
+      runtimeEnv: {
+        ANTHROPIC_API_KEY: 'candidate-key',
+      },
+    });
+  });
+
+  it('keeps runtime env precedence over saved and submitted values', async () => {
+    process.env.ANTHROPIC_API_KEY = 'runtime-key';
+
+    await assertInferenceProviderConnection({
+      providerLabel: 'Anthropic',
+      providerEnvVarNames: ['ANTHROPIC_API_KEY'],
+      modelId: 'anthropic/claude-sonnet-5',
+      credentialValues: [{ name: 'ANTHROPIC_API_KEY', value: 'candidate-key' }],
+    });
+
+    expect(mockValidateNonTaskInference).toHaveBeenCalledWith({
+      model: 'anthropic/claude-sonnet-5',
+      runtimeEnv: {},
+    });
+  });
+
+  it('throws only the sanitized provider failure', async () => {
+    mockValidateNonTaskInference.mockResolvedValue({
+      success: false,
+      checkedAt: '2026-08-13T12:00:00.000Z',
+      latencyMs: 25,
+      message: 'The inference provider rejected these credentials.',
+      model: 'anthropic/claude-sonnet-5',
+      reason: 'invalid_credentials',
+      retryable: false,
+    });
+
+    await expect(
+      assertInferenceProviderConnection({
+        providerLabel: 'Anthropic',
+        providerEnvVarNames: ['ANTHROPIC_API_KEY'],
+        modelId: 'anthropic/claude-sonnet-5',
+        credentialValues: [
+          { name: 'ANTHROPIC_API_KEY', value: 'candidate-key' },
+        ],
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<InferenceProviderValidationError>>({
+        code: 'invalid_credentials',
+        message:
+          'Anthropic: The inference provider rejected these credentials.',
+        retryable: false,
+      }),
+    );
+  });
+});

--- a/apps/web/src/trpc/commands/task-models/provider-validation.test.ts
+++ b/apps/web/src/trpc/commands/task-models/provider-validation.test.ts
@@ -12,9 +12,12 @@ vi.mock('@roomote/cloud-agents/server', () => ({
   validateNonTaskInference: mockValidateNonTaskInference,
 }));
 
+import { getSetupModelProvider } from '@roomote/types';
+
 import {
   assertInferenceProviderConnection,
   InferenceProviderValidationError,
+  validateSetupModelProviderCredentials,
 } from './provider-validation';
 
 describe('assertInferenceProviderConnection', () => {
@@ -56,7 +59,7 @@ describe('assertInferenceProviderConnection', () => {
     });
   });
 
-  it('keeps runtime env precedence over saved and submitted values', async () => {
+  it('still validates the submitted credential when a runtime env var shadows it', async () => {
     process.env.ANTHROPIC_API_KEY = 'runtime-key';
 
     await assertInferenceProviderConnection({
@@ -66,10 +69,35 @@ describe('assertInferenceProviderConnection', () => {
       credentialValues: [{ name: 'ANTHROPIC_API_KEY', value: 'candidate-key' }],
     });
 
+    // The submitted value is what the save persists, so it is the value
+    // exercised even though this process would resolve the runtime key.
     expect(mockValidateNonTaskInference).toHaveBeenCalledWith({
       model: 'anthropic/claude-sonnet-5',
-      runtimeEnv: {},
+      runtimeEnv: { ANTHROPIC_API_KEY: 'candidate-key' },
     });
+  });
+
+  it('does not block the save on failures that do not indict the credentials', async () => {
+    mockValidateNonTaskInference.mockResolvedValue({
+      success: false,
+      checkedAt: '2026-08-13T12:00:00.000Z',
+      latencyMs: 25,
+      message: 'The selected model is unavailable with these credentials.',
+      model: 'anthropic/claude-sonnet-5',
+      reason: 'model_unavailable',
+      retryable: false,
+    });
+
+    await expect(
+      assertInferenceProviderConnection({
+        providerLabel: 'Anthropic',
+        providerEnvVarNames: ['ANTHROPIC_API_KEY'],
+        modelId: 'anthropic/claude-sonnet-5',
+        credentialValues: [
+          { name: 'ANTHROPIC_API_KEY', value: 'candidate-key' },
+        ],
+      }),
+    ).resolves.toBeUndefined();
   });
 
   it('throws only the sanitized provider failure', async () => {
@@ -100,5 +128,53 @@ describe('assertInferenceProviderConnection', () => {
         retryable: false,
       }),
     );
+  });
+});
+
+describe('validateSetupModelProviderCredentials', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.ANTHROPIC_API_KEY;
+    mockResolveEffectiveDeploymentEnvVars.mockResolvedValue({
+      ANTHROPIC_API_KEY: 'saved-key',
+    });
+    mockValidateNonTaskInference.mockResolvedValue({
+      success: true,
+      checkedAt: '2026-08-13T12:00:00.000Z',
+      latencyMs: 25,
+      model: 'anthropic/claude-sonnet-5',
+    });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('skips the live check when the save changes no credentials', async () => {
+    await validateSetupModelProviderCredentials({
+      provider: getSetupModelProvider('anthropic'),
+      action: 'save it',
+      modelId: 'anthropic/claude-sonnet-5',
+    });
+
+    expect(mockValidateNonTaskInference).not.toHaveBeenCalled();
+  });
+
+  it('validates a submitted credential once against the persisted env', async () => {
+    await validateSetupModelProviderCredentials({
+      provider: getSetupModelProvider('anthropic'),
+      apiKey: 'candidate-key',
+      action: 'save it',
+      modelId: 'anthropic/claude-sonnet-5',
+    });
+
+    expect(mockResolveEffectiveDeploymentEnvVars).toHaveBeenCalledTimes(1);
+    expect(mockValidateNonTaskInference).toHaveBeenCalledWith({
+      model: 'anthropic/claude-sonnet-5',
+      runtimeEnv: { ANTHROPIC_API_KEY: 'candidate-key' },
+    });
   });
 });

--- a/apps/web/src/trpc/commands/task-models/provider-validation.ts
+++ b/apps/web/src/trpc/commands/task-models/provider-validation.ts
@@ -1,17 +1,15 @@
+import type { NonTaskInferenceValidationFailureReason } from '@roomote/cloud-agents/server';
 import { validateNonTaskInference } from '@roomote/cloud-agents/server';
 import { resolveEffectiveDeploymentEnvVars } from '@roomote/db/server';
-import { isConfiguredEnvValue } from '@roomote/types';
+import {
+  collectSetupModelProviderCredentialValues,
+  getSetupModelProviderEnvVarNames,
+  isConfiguredEnvValue,
+} from '@roomote/types';
 
 export class InferenceProviderValidationError extends Error {
   constructor(
-    readonly code:
-      | 'endpoint_unreachable'
-      | 'insufficient_credits'
-      | 'invalid_credentials'
-      | 'model_unavailable'
-      | 'provider_error'
-      | 'rate_limited'
-      | 'timeout',
+    readonly code: NonTaskInferenceValidationFailureReason,
     message: string,
     readonly retryable: boolean,
   ) {
@@ -20,24 +18,66 @@ export class InferenceProviderValidationError extends Error {
   }
 }
 
+// Only failures that squarely indict the submitted credentials may block a
+// save. Model access, rate limits, and unreachable endpoints also arise from
+// catalog defaults the account legitimately lacks (Azure models are
+// customer-named deployments) or from Roomote's own validation helper, and
+// must not lock an operator out of connecting a working provider.
+const BLOCKING_FAILURE_REASONS =
+  new Set<NonTaskInferenceValidationFailureReason>([
+    'insufficient_credits',
+    'invalid_credentials',
+  ]);
+
+type CollectCredentialParams = Parameters<
+  typeof collectSetupModelProviderCredentialValues
+>[0];
+
+/**
+ * Resolves the persisted deployment env once and collects the candidate
+ * credential values a save would persist for the provider.
+ */
+async function collectCandidateProviderCredentials(
+  params: Omit<CollectCredentialParams, 'isEnvVarSatisfied'>,
+): Promise<
+  ReturnType<typeof collectSetupModelProviderCredentialValues> & {
+    persistedEnv: Record<string, string>;
+  }
+> {
+  const persistedEnv = await resolveEffectiveDeploymentEnvVars();
+  const persistedEnvVarNameSet = new Set(Object.keys(persistedEnv));
+
+  return {
+    ...collectSetupModelProviderCredentialValues({
+      ...params,
+      isEnvVarSatisfied: (envVarName) =>
+        persistedEnvVarNameSet.has(envVarName) ||
+        isConfiguredEnvValue(process.env[envVarName]),
+    }),
+    persistedEnv,
+  };
+}
+
 /**
  * Validates the effective provider configuration before it is persisted.
- * Runtime env values retain their normal precedence over database values;
- * submitted values replace only credentials that the UI is allowed to own.
+ * Persisted values the runtime env does not override fill in surrounding
+ * context (regions, base URLs); submitted values are always the values
+ * exercised, because they are exactly what the save will persist.
  */
 export async function assertInferenceProviderConnection(params: {
   clearedEnvVarNames?: string[];
   credentialValues: Array<{ name: string; value: string }>;
   modelId: string;
+  persistedEnv?: Record<string, string>;
   providerEnvVarNames: string[];
   providerLabel: string;
 }): Promise<void> {
-  const persistedEnv = await resolveEffectiveDeploymentEnvVars();
+  const persistedEnv =
+    params.persistedEnv ?? (await resolveEffectiveDeploymentEnvVars());
   const clearedEnvVarNames = new Set(params.clearedEnvVarNames ?? []);
   const allowedEnvVarNames = new Set([
     ...params.providerEnvVarNames,
     ...params.credentialValues.map(({ name }) => name),
-    'OPENCODE_CONFIG_CONTENT',
     'R_MODEL_ENV_KEYS',
   ]);
   const candidateEnv: Record<string, string> = {};
@@ -52,10 +92,11 @@ export async function assertInferenceProviderConnection(params: {
     }
   }
 
+  // A runtime env var shadowing a submitted value must not exempt it from
+  // validation: another service resolving the persisted value would receive
+  // a credential that was never tested.
   for (const { name, value } of params.credentialValues) {
-    if (!isConfiguredEnvValue(process.env[name])) {
-      candidateEnv[name] = value;
-    }
+    candidateEnv[name] = value;
   }
 
   const result = await validateNonTaskInference({
@@ -63,11 +104,42 @@ export async function assertInferenceProviderConnection(params: {
     runtimeEnv: candidateEnv,
   });
 
-  if (!result.success) {
+  if (!result.success && BLOCKING_FAILURE_REASONS.has(result.reason)) {
     throw new InferenceProviderValidationError(
       result.reason,
       `${params.providerLabel}: ${result.message}`,
       result.retryable,
     );
   }
+}
+
+/**
+ * Pre-save credential validation shared by the setup wizard and the Models
+ * settings page: collect the candidate credentials once, skip the live check
+ * when the save changes nothing, and qualify the rest through the non-task
+ * inference canary.
+ */
+export async function validateSetupModelProviderCredentials(
+  params: Omit<CollectCredentialParams, 'isEnvVarSatisfied'> & {
+    modelId: string;
+  },
+): Promise<void> {
+  const { modelId, ...collectParams } = params;
+  const { values, clearedEnvVarNames, persistedEnv } =
+    await collectCandidateProviderCredentials(collectParams);
+
+  // An unchanged save must not depend on the provider being reachable right
+  // now; only submitted or cleared values need qualification.
+  if (values.length === 0 && clearedEnvVarNames.length === 0) {
+    return;
+  }
+
+  await assertInferenceProviderConnection({
+    providerLabel: params.provider.label,
+    providerEnvVarNames: getSetupModelProviderEnvVarNames(params.provider),
+    modelId,
+    credentialValues: values,
+    clearedEnvVarNames,
+    persistedEnv,
+  });
 }

--- a/apps/web/src/trpc/commands/task-models/provider-validation.ts
+++ b/apps/web/src/trpc/commands/task-models/provider-validation.ts
@@ -1,0 +1,73 @@
+import { validateNonTaskInference } from '@roomote/cloud-agents/server';
+import { resolveEffectiveDeploymentEnvVars } from '@roomote/db/server';
+import { isConfiguredEnvValue } from '@roomote/types';
+
+export class InferenceProviderValidationError extends Error {
+  constructor(
+    readonly code:
+      | 'endpoint_unreachable'
+      | 'insufficient_credits'
+      | 'invalid_credentials'
+      | 'model_unavailable'
+      | 'provider_error'
+      | 'rate_limited'
+      | 'timeout',
+    message: string,
+    readonly retryable: boolean,
+  ) {
+    super(message);
+    this.name = 'InferenceProviderValidationError';
+  }
+}
+
+/**
+ * Validates the effective provider configuration before it is persisted.
+ * Runtime env values retain their normal precedence over database values;
+ * submitted values replace only credentials that the UI is allowed to own.
+ */
+export async function assertInferenceProviderConnection(params: {
+  clearedEnvVarNames?: string[];
+  credentialValues: Array<{ name: string; value: string }>;
+  modelId: string;
+  providerEnvVarNames: string[];
+  providerLabel: string;
+}): Promise<void> {
+  const persistedEnv = await resolveEffectiveDeploymentEnvVars();
+  const clearedEnvVarNames = new Set(params.clearedEnvVarNames ?? []);
+  const allowedEnvVarNames = new Set([
+    ...params.providerEnvVarNames,
+    ...params.credentialValues.map(({ name }) => name),
+    'OPENCODE_CONFIG_CONTENT',
+    'R_MODEL_ENV_KEYS',
+  ]);
+  const candidateEnv: Record<string, string> = {};
+
+  for (const [name, value] of Object.entries(persistedEnv)) {
+    if (
+      allowedEnvVarNames.has(name) &&
+      !clearedEnvVarNames.has(name) &&
+      !isConfiguredEnvValue(process.env[name])
+    ) {
+      candidateEnv[name] = value;
+    }
+  }
+
+  for (const { name, value } of params.credentialValues) {
+    if (!isConfiguredEnvValue(process.env[name])) {
+      candidateEnv[name] = value;
+    }
+  }
+
+  const result = await validateNonTaskInference({
+    model: params.modelId,
+    runtimeEnv: candidateEnv,
+  });
+
+  if (!result.success) {
+    throw new InferenceProviderValidationError(
+      result.reason,
+      `${params.providerLabel}: ${result.message}`,
+      result.retryable,
+    );
+  }
+}

--- a/apps/web/src/trpc/commands/task-models/provider-validation.ts
+++ b/apps/web/src/trpc/commands/task-models/provider-validation.ts
@@ -35,25 +35,37 @@ type CollectCredentialParams = Parameters<
 
 /**
  * Resolves the persisted deployment env once and collects the candidate
- * credential values a save would persist for the provider.
+ * credential values a save would persist for the provider. `changedValues`
+ * and `clearedPersistedEnvVarNames` describe what the save would actually
+ * alter: UIs routinely resubmit unchanged fields (connection names, saved
+ * keys echoed back from state), and those must not count as changes.
  */
-async function collectCandidateProviderCredentials(
+export async function collectCandidateProviderCredentials(
   params: Omit<CollectCredentialParams, 'isEnvVarSatisfied'>,
 ): Promise<
   ReturnType<typeof collectSetupModelProviderCredentialValues> & {
+    changedValues: Array<{ name: string; value: string }>;
+    clearedPersistedEnvVarNames: string[];
     persistedEnv: Record<string, string>;
   }
 > {
   const persistedEnv = await resolveEffectiveDeploymentEnvVars();
   const persistedEnvVarNameSet = new Set(Object.keys(persistedEnv));
+  const collected = collectSetupModelProviderCredentialValues({
+    ...params,
+    isEnvVarSatisfied: (envVarName) =>
+      persistedEnvVarNameSet.has(envVarName) ||
+      isConfiguredEnvValue(process.env[envVarName]),
+  });
 
   return {
-    ...collectSetupModelProviderCredentialValues({
-      ...params,
-      isEnvVarSatisfied: (envVarName) =>
-        persistedEnvVarNameSet.has(envVarName) ||
-        isConfiguredEnvValue(process.env[envVarName]),
-    }),
+    ...collected,
+    changedValues: collected.values.filter(
+      ({ name, value }) => persistedEnv[name] !== value,
+    ),
+    clearedPersistedEnvVarNames: collected.clearedEnvVarNames.filter((name) =>
+      persistedEnvVarNameSet.has(name),
+    ),
     persistedEnv,
   };
 }
@@ -125,12 +137,18 @@ export async function validateSetupModelProviderCredentials(
   },
 ): Promise<void> {
   const { modelId, ...collectParams } = params;
-  const { values, clearedEnvVarNames, persistedEnv } =
-    await collectCandidateProviderCredentials(collectParams);
+  const {
+    values,
+    clearedEnvVarNames,
+    changedValues,
+    clearedPersistedEnvVarNames,
+    persistedEnv,
+  } = await collectCandidateProviderCredentials(collectParams);
 
   // An unchanged save must not depend on the provider being reachable right
-  // now; only submitted or cleared values need qualification.
-  if (values.length === 0 && clearedEnvVarNames.length === 0) {
+  // now; only a value that differs from what is persisted, or a clear that
+  // removes a persisted value, needs qualification.
+  if (changedValues.length === 0 && clearedPersistedEnvVarNames.length === 0) {
     return;
   }
 

--- a/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
@@ -992,6 +992,68 @@ describe('resolveOpenCodeSmallModel', () => {
       expect(result.success || result.message).not.toContain(providerError);
     },
   );
+
+  // Real provider rejections arrive as structured `{name, data: {message,
+  // statusCode, responseBody}}` assistant errors whose wording varies too
+  // much for keyword matching — Anthropic says "API key is invalid.",
+  // Bedrock Mantle says "Invalid bearer token". The status code decides.
+  it.each([
+    {
+      providerMessage: 'API key is invalid.',
+      statusCode: 401,
+      reason: 'invalid_credentials',
+      retryable: false,
+    },
+    {
+      providerMessage: 'Invalid bearer token',
+      statusCode: 403,
+      reason: 'invalid_credentials',
+      retryable: false,
+    },
+    {
+      providerMessage: 'upgrade your plan',
+      statusCode: 402,
+      reason: 'insufficient_credits',
+      retryable: false,
+    },
+    {
+      providerMessage: 'slow down',
+      statusCode: 429,
+      reason: 'rate_limited',
+      retryable: true,
+    },
+  ])(
+    'classifies a structured status-$statusCode provider error as $reason',
+    async ({ providerMessage, statusCode, reason, retryable }) => {
+      process.env = { ...originalEnv };
+      sessionPromptMock.mockResolvedValue({
+        data: {
+          info: {
+            error: {
+              name: 'APIError',
+              data: {
+                message: providerMessage,
+                statusCode,
+                responseBody: `{"type":"error","error":{"message":"${providerMessage}"}}`,
+              },
+            },
+          },
+          parts: [],
+        },
+        error: undefined,
+      });
+
+      const { validateNonTaskInference } =
+        await import('../non-task-provider-usage.js');
+      const result = await validateNonTaskInference({
+        model: 'anthropic/claude-sonnet-5',
+        runtimeEnv: { ANTHROPIC_API_KEY: 'candidate-key' },
+      });
+
+      expect(result).toMatchObject({ success: false, reason, retryable });
+      expect(result.success || result.message).not.toContain(providerMessage);
+    },
+  );
 });
 
 describe('createOpenCodeSdkFetch', () => {

--- a/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
@@ -911,6 +911,87 @@ describe('resolveOpenCodeSmallModel', () => {
       expect.any(Object),
     );
   });
+  it('validates candidate credentials with a managed non-task OpenCode server', async () => {
+    process.env = {
+      ...originalEnv,
+      OPENCODE_SDK_SERVER_URL: 'http://127.0.0.1:4999',
+    };
+    sessionPromptMock.mockResolvedValue({
+      data: {
+        info: { structured: { ok: true } },
+        parts: [],
+      },
+      error: undefined,
+    });
+
+    const { validateNonTaskInference } =
+      await import('../non-task-provider-usage.js');
+    const result = await validateNonTaskInference({
+      model: 'anthropic/claude-sonnet-5',
+      runtimeEnv: { ANTHROPIC_API_KEY: 'candidate-key' },
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      model: 'anthropic/claude-sonnet-5',
+    });
+    // Validation must not use the configured server, whose process may have
+    // entirely different credentials from the candidate being checked.
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(spawnMock.mock.calls[0]?.[2]?.env).toMatchObject({
+      ANTHROPIC_API_KEY: 'candidate-key',
+      R_MODEL: 'anthropic/claude-sonnet-5',
+    });
+    expect(sessionPromptMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        format: expect.objectContaining({ retryCount: 0 }),
+        model: {
+          providerID: 'anthropic',
+          modelID: 'claude-sonnet-5',
+        },
+        tools: { '*': false, StructuredOutput: true },
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it.each([
+    {
+      providerError: '401 invalid API key sk-secret-that-must-not-leak',
+      reason: 'invalid_credentials',
+      retryable: false,
+    },
+    {
+      providerError: '402 payment required: insufficient credits',
+      reason: 'insufficient_credits',
+      retryable: false,
+    },
+    {
+      providerError: '429 too many requests',
+      reason: 'rate_limited',
+      retryable: true,
+    },
+  ])(
+    'sanitizes a $reason provider validation failure',
+    async ({ providerError, reason, retryable }) => {
+      process.env = { ...originalEnv };
+      sessionPromptMock.mockResolvedValue({
+        data: undefined,
+        error: { data: { message: providerError } },
+      });
+
+      const { validateNonTaskInference } =
+        await import('../non-task-provider-usage.js');
+      const result = await validateNonTaskInference({
+        model: 'openrouter/openai/gpt-5.6-terra',
+        runtimeEnv: { OPENROUTER_API_KEY: 'candidate-key' },
+      });
+
+      expect(result).toMatchObject({ success: false, reason, retryable });
+      expect(result.success || result.message).not.toContain('sk-secret');
+      expect(result.success || result.message).not.toContain(providerError);
+    },
+  );
 });
 
 describe('createOpenCodeSdkFetch', () => {

--- a/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
@@ -975,21 +975,31 @@ describe('resolveOpenCodeSmallModel', () => {
     'sanitizes a $reason provider validation failure',
     async ({ providerError, reason, retryable }) => {
       process.env = { ...originalEnv };
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       sessionPromptMock.mockResolvedValue({
         data: undefined,
         error: { data: { message: providerError } },
       });
 
-      const { validateNonTaskInference } =
-        await import('../non-task-provider-usage.js');
-      const result = await validateNonTaskInference({
-        model: 'openrouter/openai/gpt-5.6-terra',
-        runtimeEnv: { OPENROUTER_API_KEY: 'candidate-key' },
-      });
+      try {
+        const { validateNonTaskInference } =
+          await import('../non-task-provider-usage.js');
+        const result = await validateNonTaskInference({
+          model: 'openrouter/openai/gpt-5.6-terra',
+          // The provider error above echoes this submitted key back, the
+          // way real 401 responses can.
+          runtimeEnv: { OPENROUTER_API_KEY: 'sk-secret-that-must-not-leak' },
+        });
 
-      expect(result).toMatchObject({ success: false, reason, retryable });
-      expect(result.success || result.message).not.toContain('sk-secret');
-      expect(result.success || result.message).not.toContain(providerError);
+        expect(result).toMatchObject({ success: false, reason, retryable });
+        expect(result.success || result.message).not.toContain('sk-secret');
+        expect(result.success || result.message).not.toContain(providerError);
+        // The server-side log keeps provider detail but must redact the
+        // candidate credential the provider echoed.
+        expect(warnSpy.mock.calls.flat().join(' ')).not.toContain('sk-secret');
+      } finally {
+        warnSpy.mockRestore();
+      }
     },
   );
 

--- a/packages/cloud-agents/src/server/non-task-provider-usage.ts
+++ b/packages/cloud-agents/src/server/non-task-provider-usage.ts
@@ -637,7 +637,25 @@ function classifyNonTaskInferenceValidationError(
   Extract<NonTaskInferenceValidationResult, { success: false }>,
   'message' | 'reason' | 'retryable'
 > {
-  const detail = formatOpenCodeSdkError(error).toLowerCase();
+  // OpenCode surfaces provider rejections as `{name, data: {message,
+  // statusCode, responseBody}}`. The status code is authoritative when
+  // present — provider wording varies too much for substring matching to be
+  // the primary signal (Anthropic says "API key is invalid.", which no
+  // keyword list reliably catches).
+  const record =
+    error && typeof error === 'object'
+      ? (error as Record<string, unknown>)
+      : undefined;
+  const data =
+    record?.data && typeof record.data === 'object'
+      ? (record.data as Record<string, unknown>)
+      : undefined;
+  const statusCode =
+    typeof data?.statusCode === 'number' ? data.statusCode : undefined;
+  const responseBody =
+    typeof data?.responseBody === 'string' ? data.responseBody : '';
+  const detail =
+    `${formatOpenCodeSdkError(error)} ${responseBody}`.toLowerCase();
 
   // Failures inside Roomote's own validation helper (the managed OpenCode
   // server) must not read as provider failures — the candidate credentials
@@ -651,6 +669,39 @@ function classifyNonTaskInferenceValidationError(
       message:
         'Roomote could not run its validation helper. Try again, or check the server logs.',
       reason: 'provider_error',
+      retryable: true,
+    };
+  }
+
+  if (statusCode === 401 || statusCode === 403) {
+    return {
+      message: 'The inference provider rejected these credentials.',
+      reason: 'invalid_credentials',
+      retryable: false,
+    };
+  }
+
+  if (statusCode === 402) {
+    return {
+      message:
+        'The inference provider account does not have enough credits or quota.',
+      reason: 'insufficient_credits',
+      retryable: false,
+    };
+  }
+
+  if (statusCode === 404) {
+    return {
+      message: 'The selected model is unavailable with these credentials.',
+      reason: 'model_unavailable',
+      retryable: false,
+    };
+  }
+
+  if (statusCode === 429) {
+    return {
+      message: 'The inference provider is rate limiting requests. Try again.',
+      reason: 'rate_limited',
       retryable: true,
     };
   }
@@ -858,12 +909,22 @@ export async function validateNonTaskInference(params: {
       model,
     };
   } catch (error) {
+    const classified = classifyNonTaskInferenceValidationError(error);
+
+    // The sanitized result hides the provider detail from the UI on purpose;
+    // keep the raw detail in the server log so misclassifications and
+    // non-blocking failures stay diagnosable.
+    console.warn(
+      `[validateNonTaskInference] ${model} failed (${classified.reason}): ${formatOpenCodeSdkError(error)}` +
+        (process.env.DEBUG_VALIDATE ? ` RAW=${JSON.stringify(error)}` : ''),
+    );
+
     return {
       success: false,
       checkedAt,
       latencyMs: Date.now() - startedAt,
       model,
-      ...classifyNonTaskInferenceValidationError(error),
+      ...classified,
     };
   }
 }

--- a/packages/cloud-agents/src/server/non-task-provider-usage.ts
+++ b/packages/cloud-agents/src/server/non-task-provider-usage.ts
@@ -934,11 +934,18 @@ export async function validateNonTaskInference(params: {
     const classified = classifyNonTaskInferenceValidationError(error);
 
     // The sanitized result hides the provider detail from the UI on purpose;
-    // keep the raw detail in the server log so misclassifications and
-    // non-blocking failures stay diagnosable.
+    // keep the detail in the server log so misclassifications stay
+    // diagnosable. Provider rejections can echo the submitted credential
+    // ("invalid API key sk-..."), so every candidate env value is redacted
+    // from the detail before it reaches the log.
+    let detail = formatOpenCodeSdkError(error);
+    for (const value of Object.values(params.runtimeEnv)) {
+      if (value && value.length >= 4) {
+        detail = detail.split(value).join('[redacted]');
+      }
+    }
     console.warn(
-      `[validateNonTaskInference] ${model} failed (${classified.reason}): ${formatOpenCodeSdkError(error)}` +
-        (process.env.DEBUG_VALIDATE ? ` RAW=${JSON.stringify(error)}` : ''),
+      `[validateNonTaskInference] ${model} failed (${classified.reason}): ${detail}`,
     );
 
     return {

--- a/packages/cloud-agents/src/server/non-task-provider-usage.ts
+++ b/packages/cloud-agents/src/server/non-task-provider-usage.ts
@@ -449,7 +449,11 @@ async function runNonTaskSdkPrompt(
     resolvedModelRuntimeEnv: Partial<Record<string, string>>;
   },
   promptOptions: NonTaskSdkPromptOptions,
-  options: { ephemeral?: boolean; useConfiguredServer?: boolean } = {},
+  options: {
+    ephemeral?: boolean;
+    signal?: AbortSignal;
+    useConfiguredServer?: boolean;
+  } = {},
 ): Promise<{
   info: { error?: unknown };
   parts: Array<{ type?: unknown; text?: unknown }>;
@@ -473,6 +477,20 @@ async function runNonTaskSdkPrompt(
       ),
     );
   }, timeoutMs);
+  const externalSignal = options.signal;
+  const abortFromExternalSignal = () => {
+    abortController.abort(
+      externalSignal?.reason ?? new Error('The prompt was aborted.'),
+    );
+  };
+
+  if (externalSignal?.aborted) {
+    abortFromExternalSignal();
+  } else {
+    externalSignal?.addEventListener('abort', abortFromExternalSignal, {
+      once: true,
+    });
+  }
 
   try {
     const client = createOpencodeClient({
@@ -518,6 +536,7 @@ async function runNonTaskSdkPrompt(
 
     return promptResult.data;
   } finally {
+    externalSignal?.removeEventListener('abort', abortFromExternalSignal);
     clearTimeout(timeout);
     server.release();
   }
@@ -840,51 +859,54 @@ export async function validateNonTaskInference(params: {
       throw new Error('ProviderModelNotFound: model must use provider/model');
     }
 
-    // The prompt timeout only starts after the helper server lease, so race
-    // the whole call: the save mutation is bounded by one timeoutMs of wall
-    // clock rather than lease plus prompt sequentially.
-    let deadlineTimer: NodeJS.Timeout | undefined;
-    const deadline = new Promise<never>((_, reject) => {
-      deadlineTimer = setTimeout(() => {
-        reject(
-          new Error(`Inference validation timed out after ${timeoutMs}ms.`),
-        );
-      }, timeoutMs);
-      deadlineTimer.unref();
-    });
+    // The prompt timeout only starts after the helper server lease. The
+    // lease is already bounded by its own start timeout, and this deadline
+    // aborts the session/prompt phase, keeping the save mutation to roughly
+    // one timeoutMs of wall clock — while always awaiting the call to
+    // completion. Returning before the call settles (a race) would let a
+    // slow-starting validation discover an invalid key after the save
+    // already went through.
+    const deadlineController = new AbortController();
+    const deadlineTimer = setTimeout(() => {
+      deadlineController.abort(
+        new Error(`Inference validation timed out after ${timeoutMs}ms.`),
+      );
+    }, timeoutMs);
+    deadlineTimer.unref();
 
     let data;
     try {
-      data = await Promise.race([
-        runNonTaskSdkPrompt(
-          {
-            surface: NON_TASK_INFERENCE_SURFACES.inferenceValidation,
-            prompt: 'Return an object with ok set to true.',
-            timeoutMs,
-          },
-          runtime,
-          {
-            format: {
-              type: 'json_schema',
-              schema: {
-                type: 'object',
-                properties: { ok: { const: true, type: 'boolean' } },
-                required: ['ok'],
-                additionalProperties: false,
-              },
-              retryCount: 0,
+      data = await runNonTaskSdkPrompt(
+        {
+          surface: NON_TASK_INFERENCE_SURFACES.inferenceValidation,
+          prompt: 'Return an object with ok set to true.',
+          timeoutMs,
+        },
+        runtime,
+        {
+          format: {
+            type: 'json_schema',
+            schema: {
+              type: 'object',
+              properties: { ok: { const: true, type: 'boolean' } },
+              required: ['ok'],
+              additionalProperties: false,
             },
-            parts: [
-              {
-                type: 'text',
-                text: 'Return an object with ok set to true.',
-              },
-            ],
+            retryCount: 0,
           },
-          { ephemeral: true, useConfiguredServer: false },
-        ),
-        deadline,
-      ]);
+          parts: [
+            {
+              type: 'text',
+              text: 'Return an object with ok set to true.',
+            },
+          ],
+        },
+        {
+          ephemeral: true,
+          signal: deadlineController.signal,
+          useConfiguredServer: false,
+        },
+      );
     } finally {
       clearTimeout(deadlineTimer);
     }

--- a/packages/cloud-agents/src/server/non-task-provider-usage.ts
+++ b/packages/cloud-agents/src/server/non-task-provider-usage.ts
@@ -938,9 +938,11 @@ export async function validateNonTaskInference(params: {
     // diagnosable. Provider rejections can echo the submitted credential
     // ("invalid API key sk-..."), so every candidate env value is redacted
     // from the detail before it reaches the log.
+    // Every non-empty value is redacted, even implausibly short ones — a
+    // noisier log line is preferable to leaking any real token.
     let detail = formatOpenCodeSdkError(error);
     for (const value of Object.values(params.runtimeEnv)) {
-      if (value && value.length >= 4) {
+      if (value) {
         detail = detail.split(value).join('[redacted]');
       }
     }

--- a/packages/cloud-agents/src/server/non-task-provider-usage.ts
+++ b/packages/cloud-agents/src/server/non-task-provider-usage.ts
@@ -449,7 +449,7 @@ async function runNonTaskSdkPrompt(
     resolvedModelRuntimeEnv: Partial<Record<string, string>>;
   },
   promptOptions: NonTaskSdkPromptOptions,
-  options: { useConfiguredServer?: boolean } = {},
+  options: { ephemeral?: boolean; useConfiguredServer?: boolean } = {},
 ): Promise<{
   info: { error?: unknown };
   parts: Array<{ type?: unknown; text?: unknown }>;
@@ -458,6 +458,7 @@ async function runNonTaskSdkPrompt(
   const timeoutMs = params.timeoutMs ?? 120_000;
   const server = await leaseOpenCodeSdkServer({
     env: resolvedModelRuntimeEnv,
+    ephemeral: options.ephemeral,
     startTimeoutMs: Math.min(
       timeoutMs,
       DEFAULT_OPENCODE_SDK_SERVER_START_TIMEOUT_MS,
@@ -638,6 +639,22 @@ function classifyNonTaskInferenceValidationError(
 > {
   const detail = formatOpenCodeSdkError(error).toLowerCase();
 
+  // Failures inside Roomote's own validation helper (the managed OpenCode
+  // server) must not read as provider failures — the candidate credentials
+  // were never exercised.
+  if (
+    detail.includes('opencode sdk server') ||
+    detail.includes('spawn opencode') ||
+    detail.includes('enoent')
+  ) {
+    return {
+      message:
+        'Roomote could not run its validation helper. Try again, or check the server logs.',
+      reason: 'provider_error',
+      retryable: true,
+    };
+  }
+
   if (
     detail.includes('timed out') ||
     detail.includes('timeout') ||
@@ -750,6 +767,8 @@ export async function validateNonTaskInference(params: {
 }): Promise<NonTaskInferenceValidationResult> {
   const startedAt = Date.now();
   const checkedAt = new Date(startedAt).toISOString();
+  const timeoutMs =
+    params.timeoutMs ?? NON_TASK_INFERENCE_VALIDATION_TIMEOUT_MS;
   const configuredModel = params.model.trim();
   const model = toBedrockMantleRuntimeModelId(configuredModel);
   const runtime = {
@@ -757,6 +776,11 @@ export async function validateNonTaskInference(params: {
     resolvedModelRuntimeEnv: {
       ...params.runtimeEnv,
       R_MODEL: configuredModel,
+      // Validation must exercise the model-backed provider config the task
+      // runtime builds for this model. An operator-supplied OpenCode config
+      // predates the provider being connected and would fail the canary with
+      // ProviderModelNotFound.
+      OPENCODE_CONFIG_CONTENT: '',
     },
   };
 
@@ -765,33 +789,54 @@ export async function validateNonTaskInference(params: {
       throw new Error('ProviderModelNotFound: model must use provider/model');
     }
 
-    const data = await runNonTaskSdkPrompt(
-      {
-        surface: NON_TASK_INFERENCE_SURFACES.inferenceValidation,
-        prompt: 'Return an object with ok set to true.',
-        timeoutMs: params.timeoutMs ?? NON_TASK_INFERENCE_VALIDATION_TIMEOUT_MS,
-      },
-      runtime,
-      {
-        format: {
-          type: 'json_schema',
-          schema: {
-            type: 'object',
-            properties: { ok: { const: true, type: 'boolean' } },
-            required: ['ok'],
-            additionalProperties: false,
-          },
-          retryCount: 0,
-        },
-        parts: [
+    // The prompt timeout only starts after the helper server lease, so race
+    // the whole call: the save mutation is bounded by one timeoutMs of wall
+    // clock rather than lease plus prompt sequentially.
+    let deadlineTimer: NodeJS.Timeout | undefined;
+    const deadline = new Promise<never>((_, reject) => {
+      deadlineTimer = setTimeout(() => {
+        reject(
+          new Error(`Inference validation timed out after ${timeoutMs}ms.`),
+        );
+      }, timeoutMs);
+      deadlineTimer.unref();
+    });
+
+    let data;
+    try {
+      data = await Promise.race([
+        runNonTaskSdkPrompt(
           {
-            type: 'text',
-            text: 'Return an object with ok set to true.',
+            surface: NON_TASK_INFERENCE_SURFACES.inferenceValidation,
+            prompt: 'Return an object with ok set to true.',
+            timeoutMs,
           },
-        ],
-      },
-      { useConfiguredServer: false },
-    );
+          runtime,
+          {
+            format: {
+              type: 'json_schema',
+              schema: {
+                type: 'object',
+                properties: { ok: { const: true, type: 'boolean' } },
+                required: ['ok'],
+                additionalProperties: false,
+              },
+              retryCount: 0,
+            },
+            parts: [
+              {
+                type: 'text',
+                text: 'Return an object with ok set to true.',
+              },
+            ],
+          },
+          { ephemeral: true, useConfiguredServer: false },
+        ),
+        deadline,
+      ]);
+    } finally {
+      clearTimeout(deadlineTimer);
+    }
 
     if (data.info.error) {
       throw data.info.error;

--- a/packages/cloud-agents/src/server/non-task-provider-usage.ts
+++ b/packages/cloud-agents/src/server/non-task-provider-usage.ts
@@ -79,6 +79,7 @@ export const NON_TASK_INFERENCE_SURFACES = {
   customAutomationScheduleResolution: 'custom_automation_schedule_resolution',
   fastAgentOnboardingSuggestions: 'fast_agent_onboarding_suggestions',
   fastAgentQuestionAnswering: 'fast_agent_question_answering',
+  inferenceValidation: 'inference_validation',
   prReviewNotificationTriage: 'pr_review_notification_triage',
   routerChannelLaunchGate: 'router_channel_launch_gate',
   routerDiscordForumTag: 'router_discord_forum_tag',
@@ -90,6 +91,34 @@ export const NON_TASK_INFERENCE_SURFACES = {
   taskSummaryGeneration: 'task_summary_generation',
   taskTitleGeneration: 'task_title_generation',
 } as const;
+
+const NON_TASK_INFERENCE_VALIDATION_TIMEOUT_MS = 15_000;
+
+export type NonTaskInferenceValidationFailureReason =
+  | 'endpoint_unreachable'
+  | 'insufficient_credits'
+  | 'invalid_credentials'
+  | 'model_unavailable'
+  | 'provider_error'
+  | 'rate_limited'
+  | 'timeout';
+
+export type NonTaskInferenceValidationResult =
+  | {
+      success: true;
+      checkedAt: string;
+      latencyMs: number;
+      model: string;
+    }
+  | {
+      success: false;
+      checkedAt: string;
+      latencyMs: number;
+      message: string;
+      model: string;
+      reason: NonTaskInferenceValidationFailureReason;
+      retryable: boolean;
+    };
 
 interface GenerateTrackedNonTaskBaseParams extends NonTaskInferenceTrackingInput {
   prompt: string;
@@ -420,6 +449,7 @@ async function runNonTaskSdkPrompt(
     resolvedModelRuntimeEnv: Partial<Record<string, string>>;
   },
   promptOptions: NonTaskSdkPromptOptions,
+  options: { useConfiguredServer?: boolean } = {},
 ): Promise<{
   info: { error?: unknown };
   parts: Array<{ type?: unknown; text?: unknown }>;
@@ -432,6 +462,7 @@ async function runNonTaskSdkPrompt(
       timeoutMs,
       DEFAULT_OPENCODE_SDK_SERVER_START_TIMEOUT_MS,
     ),
+    useConfiguredServer: options.useConfiguredServer,
   });
   const abortController = new AbortController();
   const timeout = setTimeout(() => {
@@ -597,4 +628,197 @@ export async function generateTrackedNonTaskObject<
   params: GenerateTrackedNonTaskObjectParams<TSchema>,
 ): Promise<{ object: z.output<TSchema> }> {
   return generateTrackedNonTaskObjectWithSdk(params);
+}
+
+function classifyNonTaskInferenceValidationError(
+  error: unknown,
+): Pick<
+  Extract<NonTaskInferenceValidationResult, { success: false }>,
+  'message' | 'reason' | 'retryable'
+> {
+  const detail = formatOpenCodeSdkError(error).toLowerCase();
+
+  if (
+    detail.includes('timed out') ||
+    detail.includes('timeout') ||
+    detail.includes('aborterror') ||
+    detail.includes('aborted')
+  ) {
+    return {
+      message: 'The inference provider did not respond in time. Try again.',
+      reason: 'timeout',
+      retryable: true,
+    };
+  }
+
+  if (
+    detail.includes('insufficient_quota') ||
+    detail.includes('insufficient quota') ||
+    detail.includes('insufficient credit') ||
+    detail.includes('payment required') ||
+    detail.includes('billing') ||
+    /\b402\b/u.test(detail)
+  ) {
+    return {
+      message:
+        'The inference provider account does not have enough credits or quota.',
+      reason: 'insufficient_credits',
+      retryable: false,
+    };
+  }
+
+  if (
+    detail.includes('unauthorized') ||
+    detail.includes('authentication') ||
+    detail.includes('invalid api key') ||
+    detail.includes('invalid_api_key') ||
+    detail.includes('incorrect api key') ||
+    detail.includes('revoked') ||
+    /\b401\b/u.test(detail)
+  ) {
+    return {
+      message: 'The inference provider rejected these credentials.',
+      reason: 'invalid_credentials',
+      retryable: false,
+    };
+  }
+
+  if (
+    detail.includes('providermodelnotfound') ||
+    detail.includes('model not found') ||
+    detail.includes('unknown model') ||
+    detail.includes('unsupported model') ||
+    detail.includes('does not have access to model') ||
+    /\b404\b/u.test(detail)
+  ) {
+    return {
+      message: 'The selected model is unavailable with these credentials.',
+      reason: 'model_unavailable',
+      retryable: false,
+    };
+  }
+
+  if (
+    detail.includes('rate limit') ||
+    detail.includes('rate_limit') ||
+    detail.includes('too many requests') ||
+    /\b429\b/u.test(detail)
+  ) {
+    return {
+      message: 'The inference provider is rate limiting requests. Try again.',
+      reason: 'rate_limited',
+      retryable: true,
+    };
+  }
+
+  if (
+    detail.includes('econnrefused') ||
+    detail.includes('econnreset') ||
+    detail.includes('enotfound') ||
+    detail.includes('fetch failed') ||
+    detail.includes('network error') ||
+    detail.includes('socket')
+  ) {
+    return {
+      message: 'Roomote could not reach the inference provider endpoint.',
+      reason: 'endpoint_unreachable',
+      retryable: true,
+    };
+  }
+
+  return {
+    message: 'The inference provider rejected the validation request.',
+    reason: 'provider_error',
+    retryable: true,
+  };
+}
+
+/**
+ * Qualifies candidate inference credentials through the same restricted
+ * OpenCode provider wiring used for control-plane model calls. This is
+ * deliberately not a Roomote task: it creates no work item or sandbox, runs
+ * in the empty non-task directory, and exposes no executable tools.
+ *
+ * Candidate env values are sent only to a managed helper process. Reusing an
+ * operator-supplied OpenCode server would validate that server's credentials
+ * instead of the submitted values, so this path explicitly bypasses it.
+ */
+export async function validateNonTaskInference(params: {
+  model: string;
+  runtimeEnv: Partial<Record<string, string>>;
+  timeoutMs?: number;
+}): Promise<NonTaskInferenceValidationResult> {
+  const startedAt = Date.now();
+  const checkedAt = new Date(startedAt).toISOString();
+  const configuredModel = params.model.trim();
+  const model = toBedrockMantleRuntimeModelId(configuredModel);
+  const runtime = {
+    model,
+    resolvedModelRuntimeEnv: {
+      ...params.runtimeEnv,
+      R_MODEL: configuredModel,
+    },
+  };
+
+  try {
+    if (!configuredModel.includes('/')) {
+      throw new Error('ProviderModelNotFound: model must use provider/model');
+    }
+
+    const data = await runNonTaskSdkPrompt(
+      {
+        surface: NON_TASK_INFERENCE_SURFACES.inferenceValidation,
+        prompt: 'Return an object with ok set to true.',
+        timeoutMs: params.timeoutMs ?? NON_TASK_INFERENCE_VALIDATION_TIMEOUT_MS,
+      },
+      runtime,
+      {
+        format: {
+          type: 'json_schema',
+          schema: {
+            type: 'object',
+            properties: { ok: { const: true, type: 'boolean' } },
+            required: ['ok'],
+            additionalProperties: false,
+          },
+          retryCount: 0,
+        },
+        parts: [
+          {
+            type: 'text',
+            text: 'Return an object with ok set to true.',
+          },
+        ],
+      },
+      { useConfiguredServer: false },
+    );
+
+    if (data.info.error) {
+      throw data.info.error;
+    }
+
+    const structured = (data.info as { structured?: unknown }).structured;
+    if (
+      !structured ||
+      typeof structured !== 'object' ||
+      (structured as { ok?: unknown }).ok !== true
+    ) {
+      throw new Error('Validation response did not contain the expected data.');
+    }
+
+    return {
+      success: true,
+      checkedAt,
+      latencyMs: Date.now() - startedAt,
+      model,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      checkedAt,
+      latencyMs: Date.now() - startedAt,
+      model,
+      ...classifyNonTaskInferenceValidationError(error),
+    };
+  }
 }

--- a/packages/cloud-agents/src/server/opencode-runtime.ts
+++ b/packages/cloud-agents/src/server/opencode-runtime.ts
@@ -764,6 +764,7 @@ class OpenCodeSdkServerPool {
 
   async lease(params: {
     env?: Partial<Record<string, string>>;
+    ephemeral?: boolean;
     startTimeoutMs: number;
     useConfiguredServer?: boolean;
   }): Promise<OpenCodeSdkServerLease> {
@@ -785,7 +786,7 @@ class OpenCodeSdkServerPool {
     const cached = this.cache.get(cacheKey);
 
     if (cached) {
-      return this.createLease(cached);
+      return this.createLease(cached, params.ephemeral);
     }
 
     let startPromise = this.startPromises.get(cacheKey);
@@ -802,7 +803,7 @@ class OpenCodeSdkServerPool {
       this.startPromises.set(cacheKey, startPromise);
     }
 
-    return this.createLease(await startPromise);
+    return this.createLease(await startPromise, params.ephemeral);
   }
 
   private cacheStartedServer(
@@ -844,7 +845,10 @@ class OpenCodeSdkServerPool {
     server.close();
   }
 
-  private createLease(server: CachedOpenCodeSdkServer): OpenCodeSdkServerLease {
+  private createLease(
+    server: CachedOpenCodeSdkServer,
+    ephemeral = false,
+  ): OpenCodeSdkServerLease {
     server.activeLeases += 1;
 
     if (server.idleTimeout) {
@@ -863,6 +867,15 @@ class OpenCodeSdkServerPool {
 
         released = true;
         server.activeLeases = Math.max(0, server.activeLeases - 1);
+
+        // One-shot callers (credential validation) hold candidate secrets in
+        // the server env and never reuse it, so the process must die with the
+        // lease instead of idling out the TTL.
+        if (ephemeral && server.activeLeases === 0) {
+          this.close(server);
+          return;
+        }
+
         this.scheduleIdleClose(server);
       },
     };
@@ -910,6 +923,12 @@ const sharedOpenCodeSdkServerPool = new OpenCodeSdkServerPool();
 
 export function leaseOpenCodeSdkServer(params: {
   env?: Partial<Record<string, string>>;
+  /**
+   * Close the managed server as soon as the last lease is released instead
+   * of caching it for the idle TTL. For one-shot calls whose env carries
+   * candidate secrets that must not outlive the request.
+   */
+  ephemeral?: boolean;
   startTimeoutMs: number;
   /**
    * Whether an operator-supplied OpenCode server may serve the request.

--- a/packages/cloud-agents/src/server/opencode-runtime.ts
+++ b/packages/cloud-agents/src/server/opencode-runtime.ts
@@ -765,8 +765,12 @@ class OpenCodeSdkServerPool {
   async lease(params: {
     env?: Partial<Record<string, string>>;
     startTimeoutMs: number;
+    useConfiguredServer?: boolean;
   }): Promise<OpenCodeSdkServerLease> {
-    const configuredUrl = resolveConfiguredOpenCodeSdkServerUrl();
+    const configuredUrl =
+      params.useConfiguredServer === false
+        ? undefined
+        : resolveConfiguredOpenCodeSdkServerUrl();
 
     if (configuredUrl) {
       return {
@@ -907,6 +911,12 @@ const sharedOpenCodeSdkServerPool = new OpenCodeSdkServerPool();
 export function leaseOpenCodeSdkServer(params: {
   env?: Partial<Record<string, string>>;
   startTimeoutMs: number;
+  /**
+   * Whether an operator-supplied OpenCode server may serve the request.
+   * Credential validation disables this so candidate env values necessarily
+   * reach the process that performs the provider request.
+   */
+  useConfiguredServer?: boolean;
 }): Promise<OpenCodeSdkServerLease> {
   return sharedOpenCodeSdkServerPool.lease(params);
 }


### PR DESCRIPTION
## Summary

- add a restricted non-task OpenCode canary for inference-provider validation
- validate candidate provider credentials and the selected model before saving setup configuration
- classify provider failures into sanitized credential, quota, model, rate-limit, timeout, endpoint, and generic errors
- force validation through a managed helper so candidate credentials cannot be bypassed by an externally configured OpenCode server

## Why

Inference setup previously verified that required values were present, but it did not prove that the credentials, model access, quota, and OpenCode provider wiring could complete an inference request. Invalid configuration could therefore survive setup and fail only when the first real task launched.

## Impact

Static providers are now qualified before their credentials are persisted. Dynamic endpoints are qualified during setup after a model is selected, while the existing Models settings discovery and qualification flow remains available when connection happens before model selection. Validation creates no Roomote task or sandbox and exposes no executable tools.

## Validation

- 117 targeted Vitest tests passed
- web and cloud-agents TypeScript checks passed
- changed-file ESLint passed
- full pre-push oxlint, residual lint, fast type checks, and knip passed