### PR TITLE
[Fix] Gemini tasks fail when MCP tools use nullable arrays

### DIFF
--- a/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
@@ -618,11 +618,9 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
     expect(properties.tags).toEqual({
       description: 'Tags to filter by',
       anyOf: [
-        {
-          type: 'array',
-          items: { type: 'string' },
-          description: 'Tags to filter by',
-        },
+        // Branches keep only their own type's structural keywords;
+        // annotations like `description` live at the top level only.
+        { type: 'array', items: { type: 'string' } },
         { type: 'null' },
       ],
     });
@@ -652,5 +650,191 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
       type: ['array', 'null'],
       items: { type: 'string' },
     });
+  });
+
+  it('never destroys declared items, data values, or foreign-type keywords', async () => {
+    mockFindTaskRun.mockResolvedValue({ id: 42, actingUserId: null });
+    mockFindConnection.mockResolvedValue({ id: 'conn-1', userId: null });
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          result: {
+            tools: [
+              {
+                name: 'search_issues',
+                inputSchema: {
+                  type: 'object',
+                  properties: {
+                    // Draft-04 tuple, boolean, and empty-object items are all
+                    // declared contracts and must pass through untouched.
+                    tuple_list: {
+                      type: 'array',
+                      items: [{ type: 'string' }, { type: 'number' }],
+                    },
+                    flexible_list: { type: 'array', items: true },
+                    any_list: { type: 'array', items: {} },
+                    // A default whose value merely looks like a schema is
+                    // data and must not be rewritten.
+                    raw_filter: {
+                      type: 'object',
+                      default: { type: 'array' },
+                    },
+                    // A union's shared keywords go only to the branches they
+                    // are valid on; annotations stay at the top level.
+                    id_or_ids: {
+                      type: ['string', 'array'],
+                      minLength: 1,
+                      pattern: '^[a-z]+$',
+                      items: { type: 'string' },
+                      default: null,
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await postMcp(
+      createApp('pylon', createRunToken()),
+      createToolsListRequest(1),
+    );
+    const body = (await response.json()) as {
+      result: {
+        tools: Array<{ inputSchema: { properties: Record<string, unknown> } }>;
+      };
+    };
+
+    expect(response.status).toBe(200);
+    const properties = body.result.tools[0]?.inputSchema.properties ?? {};
+    expect(properties.tuple_list).toEqual({
+      type: 'array',
+      items: [{ type: 'string' }, { type: 'number' }],
+    });
+    expect(properties.flexible_list).toEqual({ type: 'array', items: true });
+    expect(properties.any_list).toEqual({ type: 'array', items: {} });
+    expect(properties.raw_filter).toEqual({
+      type: 'object',
+      default: { type: 'array' },
+    });
+    expect(properties.id_or_ids).toEqual({
+      anyOf: [
+        { type: 'string', minLength: 1, pattern: '^[a-z]+$' },
+        { type: 'array', items: { type: 'string' } },
+      ],
+      default: null,
+    });
+  });
+
+  it('filters an SSE tools/list whose id is echoed as a different type', async () => {
+    mockFindTaskRun.mockResolvedValue({ id: 42, actingUserId: null });
+    mockFindConnection.mockResolvedValue({ id: 'conn-1', userId: null });
+    mockFindEnablement.mockResolvedValue({ disabledTools: ['secret_tool'] });
+
+    // The request sends a numeric id; a non-conformant upstream echoes it as
+    // a string. The filtered rebuild must still apply instead of forwarding
+    // the raw (unfiltered) stream.
+    const sseBody =
+      'event: message\n' +
+      'data: {"jsonrpc":"2.0","id":"1","result":{"tools":[{"name":"search_issues","inputSchema":{"type":"object"}},{"name":"secret_tool","inputSchema":{"type":"object"}}]}}\n\n';
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(sseBody, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await postMcp(
+      createApp('pylon', createRunToken()),
+      createToolsListRequest(1),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('application/json');
+    const body = (await response.json()) as {
+      result: { tools: Array<{ name: string }> };
+    };
+    expect(body.result.tools.map((tool) => tool.name)).toEqual([
+      'search_issues',
+    ]);
+  });
+
+  it('filters an uncorrelatable SSE tools/list for a restricted connection', async () => {
+    mockFindTaskRun.mockResolvedValue({ id: 42, actingUserId: null });
+    mockFindConnection.mockResolvedValue({ id: 'conn-1', userId: null });
+    mockFindEnablement.mockResolvedValue({ disabledTools: ['secret_tool'] });
+
+    // An id-less request cannot be correlated to an SSE frame, but a
+    // restricted connection must still get the filtered rebuild (via the
+    // bounded buffered read) rather than the raw upstream stream.
+    const sseBody =
+      'event: message\n' +
+      'data: {"jsonrpc":"2.0","id":null,"result":{"tools":[{"name":"search_issues","inputSchema":{"type":"object"}},{"name":"secret_tool","inputSchema":{"type":"object"}}]}}\n\n';
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(sseBody, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await postMcp(createApp('pylon', createRunToken()), {
+      jsonrpc: '2.0',
+      id: null,
+      method: 'tools/list',
+      params: {},
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('application/json');
+    const body = (await response.json()) as {
+      result: { tools: Array<{ name: string }> };
+    };
+    expect(body.result.tools.map((tool) => tool.name)).toEqual([
+      'search_issues',
+    ]);
+  });
+
+  it('refuses to forward an unfilterable tools/list to a restricted connection', async () => {
+    mockFindTaskRun.mockResolvedValue({ id: 42, actingUserId: null });
+    mockFindConnection.mockResolvedValue({ id: 'conn-1', userId: null });
+    mockFindEnablement.mockResolvedValue({ disabledTools: ['secret_tool'] });
+
+    // The stream closes without ever carrying a JSON-RPC response, so there
+    // is nothing to filter; a restricted connection must get an error, never
+    // the raw upstream bytes.
+    const sseBody =
+      'event: message\n' +
+      'data: {"jsonrpc":"2.0","method":"notifications/progress","params":{"progress":1}}\n\n';
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(sseBody, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await postMcp(createApp('pylon', createRunToken()), {
+      jsonrpc: '2.0',
+      id: null,
+      method: 'tools/list',
+      params: {},
+    });
+
+    expect(response.status).toBe(502);
+    expect(response.headers.get('content-type')).toContain('application/json');
+    const body = (await response.json()) as {
+      error: { code: number; message: string };
+    };
+    expect(body.error.code).toBe(-32000);
+    expect(body.error.message).toContain('could not be filtered');
   });
 });

--- a/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
@@ -691,6 +691,14 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
                       items: { type: 'string' },
                       default: null,
                     },
+                    // A union with a sibling constraint a branch split cannot
+                    // represent ($ref, not, conditionals) must be declined
+                    // rather than rebuilt without the constraint.
+                    referenced_list: {
+                      type: ['array', 'null'],
+                      $ref: '#/$defs/AllowedValues',
+                      items: { type: 'string' },
+                    },
                   },
                 },
               },
@@ -730,6 +738,11 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
         { type: 'array', items: { type: 'string' } },
       ],
       default: null,
+    });
+    expect(properties.referenced_list).toEqual({
+      type: ['array', 'null'],
+      $ref: '#/$defs/AllowedValues',
+      items: { type: 'string' },
     });
   });
 

--- a/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
@@ -452,4 +452,104 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
       type: 'string',
     });
   });
+
+  it('normalizes tool schemas that Gemini function declarations reject', async () => {
+    // Pylon's search filters use `type: ["array", "null"]` unions and bare
+    // array schemas; the AI SDK's Gemini conversion splits the union into
+    // anyOf branches while leaving `items` outside them, and Google AI
+    // Studio then rejects the whole request ("any_of[0].items: missing
+    // field"), killing every Gemini task turn for the workspace.
+    mockFindTaskRun.mockResolvedValue({ id: 42, actingUserId: null });
+    mockFindConnection.mockResolvedValue({ id: 'conn-1', userId: null });
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          result: {
+            tools: [
+              {
+                name: 'search_issues',
+                inputSchema: {
+                  type: 'object',
+                  properties: {
+                    tags: {
+                      type: ['array', 'null'],
+                      items: { type: 'string' },
+                      description: 'Tags to filter by',
+                    },
+                    custom_field_filters: {
+                      type: ['array', 'null'],
+                      items: {
+                        type: 'object',
+                        properties: { slug: { type: 'string' } },
+                        required: ['slug'],
+                      },
+                    },
+                    bare_list: {
+                      type: 'array',
+                      description: 'Array with no item shape',
+                    },
+                    status: { type: ['string', 'null'] },
+                  },
+                },
+              },
+            ],
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await postMcp(
+      createApp('pylon', createRunToken()),
+      createToolsListRequest(1),
+    );
+    const body = (await response.json()) as {
+      result: {
+        tools: Array<{
+          inputSchema: { properties: Record<string, unknown> };
+        }>;
+      };
+    };
+
+    expect(response.status).toBe(200);
+    const properties = body.result.tools[0]?.inputSchema.properties ?? {};
+    expect(properties.tags).toEqual({
+      description: 'Tags to filter by',
+      anyOf: [
+        {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Tags to filter by',
+        },
+        { type: 'null' },
+      ],
+    });
+    expect(properties.custom_field_filters).toEqual({
+      anyOf: [
+        {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: { slug: { type: 'string' } },
+            required: ['slug'],
+          },
+        },
+        { type: 'null' },
+      ],
+    });
+    expect(properties.bare_list).toEqual({
+      type: 'array',
+      description: 'Array with no item shape',
+      items: { type: 'string' },
+    });
+    // Scalar unions convert cleanly downstream; leave them untouched.
+    expect(properties.status).toEqual({ type: ['string', 'null'] });
+  });
 });

--- a/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
@@ -387,6 +387,52 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
     expect(cancelled).toBe(true);
   });
 
+  it('normalizes an SSE tools/list result without waiting for the stream to close', async () => {
+    mockFindTaskRun.mockResolvedValue({ id: 42, actingUserId: null });
+    mockFindConnection.mockResolvedValue({ id: 'conn-1', userId: null });
+
+    let cancelled = false;
+    const neverClosingSseBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode(
+            'event: message\n' +
+              'data: {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"search_issues","inputSchema":{"type":"object","properties":{"tags":{"type":["array","null"],"items":{"type":"string"}}}}}]}}\n\n',
+          ),
+        );
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(neverClosingSseBody, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await postMcp(
+      createApp('pylon', createRunToken()),
+      createToolsListRequest(1),
+    );
+    const body = (await response.json()) as {
+      result: {
+        tools: Array<{
+          inputSchema: { properties: Record<string, unknown> };
+        }>;
+      };
+    };
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('application/json');
+    expect(body.result.tools[0]?.inputSchema.properties.tags).toEqual({
+      anyOf: [{ type: 'array', items: { type: 'string' } }, { type: 'null' }],
+    });
+    expect(cancelled).toBe(true);
+  });
+
   it('strips Resend tool schema patterns for Azure-compatible tool calls', async () => {
     mockFindTaskRun.mockResolvedValue({ id: 42, actingUserId: null });
     mockFindConnection.mockResolvedValue({ id: 'conn-1', userId: null });

--- a/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
@@ -699,6 +699,13 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
                       $ref: '#/$defs/AllowedValues',
                       items: { type: 'string' },
                     },
+                    // Draft-04 tuple constraints travel with the array branch
+                    // when a nullable tuple union is split.
+                    coordinate: {
+                      type: ['array', 'null'],
+                      items: [{ type: 'number' }, { type: 'number' }],
+                      additionalItems: false,
+                    },
                   },
                 },
               },
@@ -743,6 +750,16 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
       type: ['array', 'null'],
       $ref: '#/$defs/AllowedValues',
       items: { type: 'string' },
+    });
+    expect(properties.coordinate).toEqual({
+      anyOf: [
+        {
+          type: 'array',
+          items: [{ type: 'number' }, { type: 'number' }],
+          additionalItems: false,
+        },
+        { type: 'null' },
+      ],
     });
   });
 

--- a/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
@@ -433,6 +433,45 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
     expect(cancelled).toBe(true);
   });
 
+  it('preserves an uncorrelatable SSE tools/list stream without waiting for closure', async () => {
+    mockFindTaskRun.mockResolvedValue({ id: 42, actingUserId: null });
+    mockFindConnection.mockResolvedValue({ id: 'conn-1', userId: null });
+
+    let cancelled = false;
+    const neverClosingSseBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode(
+            'event: message\n' +
+              'data: {"jsonrpc":"2.0","id":null,"result":{"tools":[]}}\n\n',
+          ),
+        );
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(neverClosingSseBody, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await postMcp(createApp('pylon', createRunToken()), {
+      jsonrpc: '2.0',
+      id: null,
+      method: 'tools/list',
+      params: {},
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/event-stream');
+    await response.body?.cancel();
+    expect(cancelled).toBe(true);
+  });
+
   it('strips Resend tool schema patterns for Azure-compatible tool calls', async () => {
     mockFindTaskRun.mockResolvedValue({ id: 42, actingUserId: null });
     mockFindConnection.mockResolvedValue({ id: 'conn-1', userId: null });
@@ -499,7 +538,7 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
     });
   });
 
-  it('normalizes tool schemas that Gemini function declarations reject', async () => {
+  it('normalizes tool input schemas that Gemini function declarations reject', async () => {
     // Pylon's search filters use `type: ["array", "null"]` unions and bare
     // array schemas; the AI SDK's Gemini conversion splits the union into
     // anyOf branches while leaving `items` outside them, and Google AI
@@ -540,6 +579,15 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
                     status: { type: ['string', 'null'] },
                   },
                 },
+                outputSchema: {
+                  type: 'object',
+                  properties: {
+                    matches: {
+                      type: ['array', 'null'],
+                      items: { type: 'string' },
+                    },
+                  },
+                },
               },
             ],
           },
@@ -560,6 +608,7 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
       result: {
         tools: Array<{
           inputSchema: { properties: Record<string, unknown> };
+          outputSchema: { properties: Record<string, unknown> };
         }>;
       };
     };
@@ -597,5 +646,11 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
     });
     // Scalar unions convert cleanly downstream; leave them untouched.
     expect(properties.status).toEqual({ type: ['string', 'null'] });
+    // Output schemas do not become Gemini function declarations and must
+    // remain the upstream MCP server's unmodified contract.
+    expect(body.result.tools[0]?.outputSchema.properties.matches).toEqual({
+      type: ['array', 'null'],
+      items: { type: 'string' },
+    });
   });
 });

--- a/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
@@ -147,6 +147,7 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
     mockFindEnablement.mockResolvedValue({ disabledTools: null });
     mockGetValidAccessToken.mockResolvedValue('valid-access-token');
   });
@@ -712,6 +713,13 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
                       type: ['array', 'null'],
                       unevaluatedItems: false,
                     },
+                    // Any keyword outside the understood set (vendor
+                    // extensions, future dialects) declines the split.
+                    annotated_list: {
+                      type: ['array', 'null'],
+                      items: { type: 'string' },
+                      'x-order': 3,
+                    },
                   },
                 },
               },
@@ -770,6 +778,63 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
     expect(properties.empty_only).toEqual({
       anyOf: [{ type: 'array', unevaluatedItems: false }, { type: 'null' }],
     });
+    expect(properties.annotated_list).toEqual({
+      type: ['array', 'null'],
+      items: { type: 'string' },
+      'x-order': 3,
+    });
+  });
+
+  it('passes schemas through untouched when the kill switch is set', async () => {
+    vi.stubEnv('R_DISABLE_MCP_SCHEMA_NORMALIZATION', 'true');
+    mockFindTaskRun.mockResolvedValue({ id: 42, actingUserId: null });
+    mockFindConnection.mockResolvedValue({ id: 'conn-1', userId: null });
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          result: {
+            tools: [
+              {
+                name: 'search_issues',
+                inputSchema: {
+                  type: 'object',
+                  properties: {
+                    tags: {
+                      type: ['array', 'null'],
+                      items: { type: 'string' },
+                    },
+                    bare_list: { type: 'array' },
+                  },
+                },
+              },
+            ],
+          },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await postMcp(
+      createApp('pylon', createRunToken()),
+      createToolsListRequest(1),
+    );
+    const body = (await response.json()) as {
+      result: {
+        tools: Array<{ inputSchema: { properties: Record<string, unknown> } }>;
+      };
+    };
+
+    expect(response.status).toBe(200);
+    const properties = body.result.tools[0]?.inputSchema.properties ?? {};
+    expect(properties.tags).toEqual({
+      type: ['array', 'null'],
+      items: { type: 'string' },
+    });
+    expect(properties.bare_list).toEqual({ type: 'array' });
   });
 
   it('filters an SSE tools/list whose id is echoed as a different type', async () => {

--- a/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
@@ -706,6 +706,12 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
                       items: [{ type: 'number' }, { type: 'number' }],
                       additionalItems: false,
                     },
+                    // `unevaluatedItems: false` alone means "empty array
+                    // only"; injecting `items` would silently void it.
+                    empty_only: {
+                      type: ['array', 'null'],
+                      unevaluatedItems: false,
+                    },
                   },
                 },
               },
@@ -760,6 +766,9 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
         },
         { type: 'null' },
       ],
+    });
+    expect(properties.empty_only).toEqual({
+      anyOf: [{ type: 'array', unevaluatedItems: false }, { type: 'null' }],
     });
   });
 

--- a/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
@@ -720,6 +720,14 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
                       items: { type: 'string' },
                       'x-order': 3,
                     },
+                    // Dependency maps are keyed by property names; an entry
+                    // named "type" with an array value is a dependency rule,
+                    // not a type union, and must pass through as data.
+                    conditional_object: {
+                      type: ['object', 'null'],
+                      dependencies: { type: ['foo'] },
+                      dependentRequired: { type: ['foo'] },
+                    },
                   },
                 },
               },
@@ -782,6 +790,16 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
       type: ['array', 'null'],
       items: { type: 'string' },
       'x-order': 3,
+    });
+    expect(properties.conditional_object).toEqual({
+      anyOf: [
+        {
+          type: 'object',
+          dependencies: { type: ['foo'] },
+          dependentRequired: { type: ['foo'] },
+        },
+        { type: 'null' },
+      ],
     });
   });
 

--- a/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
@@ -728,6 +728,15 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
                       dependencies: { type: ['foo'] },
                       dependentRequired: { type: ['foo'] },
                     },
+                    // Values under unrecognized keywords are opaque data;
+                    // schema-lookalikes inside them must not be rewritten.
+                    extended_field: {
+                      type: 'object',
+                      'x-samples': {
+                        type: ['array', 'null'],
+                        items: { type: 'string' },
+                      },
+                    },
                   },
                 },
               },
@@ -800,6 +809,13 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
         },
         { type: 'null' },
       ],
+    });
+    expect(properties.extended_field).toEqual({
+      type: 'object',
+      'x-samples': {
+        type: ['array', 'null'],
+        items: { type: 'string' },
+      },
     });
   });
 

--- a/apps/api/src/handlers/mcp/proxy-utils.ts
+++ b/apps/api/src/handlers/mcp/proxy-utils.ts
@@ -447,6 +447,7 @@ const OBJECT_ONLY_SCHEMA_KEYWORDS = [
   'propertyNames',
   'minProperties',
   'maxProperties',
+  'dependencies',
   'dependentRequired',
   'dependentSchemas',
 ] as const;
@@ -532,6 +533,14 @@ const SCHEMA_MAP_KEYWORDS = new Set([
   'dependentSchemas',
 ]);
 
+// Maps keyed by property names whose values are property-name arrays (data)
+// or, in legacy draft-04 `dependencies`, sometimes schemas. An entry named
+// "type" with an array value is a dependency rule, not a type union, and
+// must never be reinterpreted as a schema keyword.
+const DEPENDENCY_MAP_KEYWORDS = new Set(['dependencies', 'dependentRequired']);
+
+type SchemaTraversalContext = 'schema' | 'schema-map' | 'dependency-map';
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
@@ -567,7 +576,7 @@ function withProviderSafeArrayItems(
 
 function normalizeToolSchemaForStrictProviders(
   value: unknown,
-  context: 'schema' | 'schema-map' = 'schema',
+  context: SchemaTraversalContext = 'schema',
 ): unknown {
   if (Array.isArray(value)) {
     return value.map((entry) => normalizeToolSchemaForStrictProviders(entry));
@@ -579,24 +588,35 @@ function normalizeToolSchemaForStrictProviders(
 
   const schema = Object.fromEntries(
     Object.entries(value).map(([key, nestedValue]) => {
+      if (context === 'dependency-map') {
+        // Array-valued entries list required property names (data); only
+        // object-valued legacy draft-04 dependency entries are schemas.
+        return [
+          key,
+          isPlainObject(nestedValue)
+            ? normalizeToolSchemaForStrictProviders(nestedValue)
+            : nestedValue,
+        ];
+      }
       if (context === 'schema' && NON_SCHEMA_VALUE_KEYWORDS.has(key)) {
         return [key, nestedValue];
       }
+      let childContext: SchemaTraversalContext = 'schema';
+      if (context === 'schema' && SCHEMA_MAP_KEYWORDS.has(key)) {
+        childContext = 'schema-map';
+      } else if (context === 'schema' && DEPENDENCY_MAP_KEYWORDS.has(key)) {
+        childContext = 'dependency-map';
+      }
       return [
         key,
-        normalizeToolSchemaForStrictProviders(
-          nestedValue,
-          context === 'schema' && SCHEMA_MAP_KEYWORDS.has(key)
-            ? 'schema-map'
-            : 'schema',
-        ),
+        normalizeToolSchemaForStrictProviders(nestedValue, childContext),
       ];
     }),
   );
 
-  // A schema map's own keys are property names, not schema keywords; only
-  // its entries (handled above) are schemas.
-  if (context === 'schema-map') {
+  // A schema or dependency map's own keys are property names, not schema
+  // keywords; only its entries (handled above) can be schemas.
+  if (context !== 'schema') {
     return schema;
   }
 

--- a/apps/api/src/handlers/mcp/proxy-utils.ts
+++ b/apps/api/src/handlers/mcp/proxy-utils.ts
@@ -444,6 +444,24 @@ const OBJECT_ONLY_SCHEMA_KEYWORDS = [
   'propertyNames',
   'minProperties',
   'maxProperties',
+  'dependentRequired',
+  'dependentSchemas',
+] as const;
+
+// Keywords that constrain the value in ways a per-type branch split cannot
+// represent (combinators, references, conditionals). A composite union
+// carrying any of these as a sibling is left untouched: splitting it would
+// silently drop the constraint and widen what the schema accepts.
+const UNION_SPLIT_BLOCKING_KEYWORDS = [
+  'anyOf',
+  'oneOf',
+  'allOf',
+  'not',
+  'if',
+  'then',
+  'else',
+  '$ref',
+  '$dynamicRef',
 ] as const;
 
 const STRING_ONLY_SCHEMA_KEYWORDS = [
@@ -571,12 +589,12 @@ function normalizeToolSchemaForStrictProviders(
     return schema;
   }
 
-  if ('anyOf' in schema || 'oneOf' in schema || 'allOf' in schema) {
-    // Splitting the union would clobber the sibling combinator, so decline —
+  if (UNION_SPLIT_BLOCKING_KEYWORDS.some((keyword) => keyword in schema)) {
+    // Splitting the union would clobber the sibling constraint, so decline —
     // but say so, since strict providers may reject the untouched schema and
     // this log is the only breadcrumb when they do.
     console.warn(
-      '[mcp-proxy] Left composite type union with sibling anyOf/oneOf/allOf un-normalized; strict providers may reject this tool schema',
+      '[mcp-proxy] Left composite type union with a sibling combinator, reference, or conditional un-normalized; strict providers may reject this tool schema',
     );
     return schema;
   }

--- a/apps/api/src/handlers/mcp/proxy-utils.ts
+++ b/apps/api/src/handlers/mcp/proxy-utils.ts
@@ -409,6 +409,147 @@ function stripToolSchemaPatterns(value: unknown): unknown {
   );
 }
 
+/**
+ * Google AI Studio validates function declarations strictly: every ARRAY
+ * schema must carry `items`, and the AI SDK's JSON-Schema-to-Gemini
+ * conversion splits `type: ["array", "null"]` unions into `anyOf` branches
+ * while leaving `items`/`properties` at the outer level, so an upstream
+ * schema that is perfectly valid JSON Schema (Pylon's `tags` and
+ * `custom_field_filters` search filters, for example) turns into an invalid
+ * request that fails the whole task turn. Normalize the shapes that trigger
+ * this at the proxy boundary: rewrite array/object type unions into explicit
+ * `anyOf` branches with each branch keeping only its own type's keywords, and
+ * give array schemas that declare no item shape a permissive string `items`
+ * (the upstream server still validates the actual tool call).
+ */
+const ARRAY_ONLY_SCHEMA_KEYWORDS = [
+  'items',
+  'prefixItems',
+  'minItems',
+  'maxItems',
+  'uniqueItems',
+  'contains',
+  'minContains',
+  'maxContains',
+] as const;
+
+const OBJECT_ONLY_SCHEMA_KEYWORDS = [
+  'properties',
+  'required',
+  'additionalProperties',
+  'patternProperties',
+  'propertyNames',
+  'minProperties',
+  'maxProperties',
+] as const;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function withProviderSafeArrayItems(
+  schema: Record<string, unknown>,
+): Record<string, unknown> {
+  if (schema.type !== 'array') {
+    return schema;
+  }
+
+  const items = schema.items;
+  const declaresItemShape =
+    isPlainObject(items) && Object.keys(items).length > 0;
+
+  return declaresItemShape ? schema : { ...schema, items: { type: 'string' } };
+}
+
+function normalizeToolSchemaForStrictProviders(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(normalizeToolSchemaForStrictProviders);
+  }
+
+  if (!isPlainObject(value)) {
+    return value;
+  }
+
+  const schema = Object.fromEntries(
+    Object.entries(value).map(([key, nestedValue]) => [
+      key,
+      normalizeToolSchemaForStrictProviders(nestedValue),
+    ]),
+  );
+
+  const typeValue = schema.type;
+  if (
+    !Array.isArray(typeValue) ||
+    typeValue.length === 0 ||
+    !typeValue.every((entry): entry is string => typeof entry === 'string')
+  ) {
+    return withProviderSafeArrayItems(schema);
+  }
+
+  if (typeValue.length === 1) {
+    return withProviderSafeArrayItems({ ...schema, type: typeValue[0] });
+  }
+
+  // Scalar-only unions convert cleanly; only unions carrying a composite
+  // type lose their keywords in the downstream Gemini conversion.
+  if (
+    (!typeValue.includes('array') && !typeValue.includes('object')) ||
+    'anyOf' in schema ||
+    'oneOf' in schema ||
+    'allOf' in schema
+  ) {
+    return schema;
+  }
+
+  const { type: _unionTypes, ...sharedKeywords } = schema;
+  const branches = typeValue.map((branchType) => {
+    if (branchType === 'null') {
+      return { type: 'null' };
+    }
+
+    const branch: Record<string, unknown> = {
+      ...sharedKeywords,
+      type: branchType,
+    };
+    if (branchType !== 'array') {
+      for (const keyword of ARRAY_ONLY_SCHEMA_KEYWORDS) {
+        delete branch[keyword];
+      }
+    }
+    if (branchType !== 'object') {
+      for (const keyword of OBJECT_ONLY_SCHEMA_KEYWORDS) {
+        delete branch[keyword];
+      }
+    }
+    return withProviderSafeArrayItems(branch);
+  });
+
+  const normalized: Record<string, unknown> = { anyOf: branches };
+  if (typeof sharedKeywords.description === 'string') {
+    normalized.description = sharedKeywords.description;
+  }
+  return normalized;
+}
+
+function normalizeToolDefinitionSchemas<
+  T extends { name: string } & Record<string, unknown>,
+>(tools: T[]): T[] {
+  return tools.map((tool) => {
+    const normalized: Record<string, unknown> = { ...tool };
+    if ('inputSchema' in normalized) {
+      normalized.inputSchema = normalizeToolSchemaForStrictProviders(
+        normalized.inputSchema,
+      );
+    }
+    if ('outputSchema' in normalized) {
+      normalized.outputSchema = normalizeToolSchemaForStrictProviders(
+        normalized.outputSchema,
+      );
+    }
+    return normalized as T;
+  });
+}
+
 function filterToolsListPayload(
   payload: unknown,
   toolPolicy: {
@@ -446,7 +587,9 @@ function filterToolsListPayload(
       ),
   );
 
-  const filteredTools = filterMcpToolDefinitions(namedTools, toolPolicy);
+  const filteredTools = normalizeToolDefinitionSchemas(
+    filterMcpToolDefinitions(namedTools, toolPolicy),
+  );
 
   return {
     ...payload,
@@ -981,8 +1124,9 @@ export function createMcpProxy(config: McpProxyConfig) {
         );
       }
 
+      // Every tools/list reply is rebuilt (not just restricted ones) so tool
+      // schemas can be normalized for strict model providers.
       if (
-        (hasToolRestrictions || shouldStripToolSchemaPatterns) &&
         method === 'POST' &&
         getJsonRpcMethod(parsedBody) === 'tools/list' &&
         upstreamResponse.ok

--- a/apps/api/src/handlers/mcp/proxy-utils.ts
+++ b/apps/api/src/handlers/mcp/proxy-utils.ts
@@ -1132,10 +1132,19 @@ export function createMcpProxy(config: McpProxyConfig) {
         upstreamResponse.ok
       ) {
         try {
-          const payload = parseMcpJsonRpcPayload(
-            await upstreamResponse.clone().text(),
-            upstreamResponse.headers.get('content-type'),
-          );
+          const requestId = getJsonRpcRequestId(parsedBody);
+          const sseBody =
+            contentType?.includes('text/event-stream') &&
+            requestId !== null &&
+            !Array.isArray(parsedBody)
+              ? upstreamResponse.clone().body
+              : null;
+          const payload = sseBody
+            ? await readMatchingSseJsonRpcResponse(sseBody, requestId)
+            : parseMcpJsonRpcPayload(
+                await upstreamResponse.clone().text(),
+                contentType,
+              );
           if (!payload) {
             throw new Error('Unable to parse upstream tools/list payload');
           }
@@ -1151,6 +1160,10 @@ export function createMcpProxy(config: McpProxyConfig) {
           );
           const headers = buildProxyResponseHeaders(upstreamResponse.headers);
           headers.set('content-type', 'application/json');
+
+          if (sseBody) {
+            upstreamResponse.body?.cancel().catch(() => {});
+          }
 
           return new Response(JSON.stringify(filteredPayload), {
             status: upstreamResponse.status,

--- a/apps/api/src/handlers/mcp/proxy-utils.ts
+++ b/apps/api/src/handlers/mcp/proxy-utils.ts
@@ -524,6 +524,19 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
+// Keywords that already constrain an array's element shape. Injecting a
+// permissive `items` alongside any of them would change their meaning:
+// `unevaluatedItems: false` becomes a no-op once an `items` keyword
+// evaluates every element, and a bare `prefixItems`/`contains` schema would
+// gain an element type its author never declared.
+const ARRAY_ITEM_SHAPE_KEYWORDS = [
+  'items',
+  'prefixItems',
+  'additionalItems',
+  'unevaluatedItems',
+  'contains',
+] as const;
+
 function withProviderSafeArrayItems(
   schema: Record<string, unknown>,
 ): Record<string, unknown> {
@@ -531,11 +544,13 @@ function withProviderSafeArrayItems(
     return schema;
   }
 
-  // Only fill in `items` when the upstream declared nothing at all. A
-  // declared shape of any form (object schema, boolean, draft-04 tuple
-  // array, or an explicit empty object) is the server's contract and must
-  // pass through untouched.
-  return 'items' in schema ? schema : { ...schema, items: { type: 'string' } };
+  // Only fill in `items` when the upstream declared no item constraint at
+  // all. A declared shape of any form (object schema, boolean, draft-04
+  // tuple array, an explicit empty object, or any sibling item-evaluating
+  // keyword) is the server's contract and must pass through untouched.
+  return ARRAY_ITEM_SHAPE_KEYWORDS.some((keyword) => keyword in schema)
+    ? schema
+    : { ...schema, items: { type: 'string' } };
 }
 
 function normalizeToolSchemaForStrictProviders(

--- a/apps/api/src/handlers/mcp/proxy-utils.ts
+++ b/apps/api/src/handlers/mcp/proxy-utils.ts
@@ -427,6 +427,8 @@ function stripToolSchemaPatterns(value: unknown): unknown {
  */
 const ARRAY_ONLY_SCHEMA_KEYWORDS = [
   'items',
+  'additionalItems',
+  'unevaluatedItems',
   'prefixItems',
   'minItems',
   'maxItems',
@@ -440,6 +442,7 @@ const OBJECT_ONLY_SCHEMA_KEYWORDS = [
   'properties',
   'required',
   'additionalProperties',
+  'unevaluatedProperties',
   'patternProperties',
   'propertyNames',
   'minProperties',

--- a/apps/api/src/handlers/mcp/proxy-utils.ts
+++ b/apps/api/src/handlers/mcp/proxy-utils.ts
@@ -531,7 +531,7 @@ function normalizeToolSchemaForStrictProviders(value: unknown): unknown {
   return normalized;
 }
 
-function normalizeToolDefinitionSchemas<
+function normalizeToolDefinitionInputSchemas<
   T extends { name: string } & Record<string, unknown>,
 >(tools: T[]): T[] {
   return tools.map((tool) => {
@@ -539,11 +539,6 @@ function normalizeToolDefinitionSchemas<
     if ('inputSchema' in normalized) {
       normalized.inputSchema = normalizeToolSchemaForStrictProviders(
         normalized.inputSchema,
-      );
-    }
-    if ('outputSchema' in normalized) {
-      normalized.outputSchema = normalizeToolSchemaForStrictProviders(
-        normalized.outputSchema,
       );
     }
     return normalized as T;
@@ -587,7 +582,7 @@ function filterToolsListPayload(
       ),
   );
 
-  const filteredTools = normalizeToolDefinitionSchemas(
+  const filteredTools = normalizeToolDefinitionInputSchemas(
     filterMcpToolDefinitions(namedTools, toolPolicy),
   );
 
@@ -1108,6 +1103,13 @@ export function createMcpProxy(config: McpProxyConfig) {
 
       const elapsedMs = Date.now() - startedAt;
       const contentType = upstreamResponse.headers.get('content-type');
+      const isSseResponse =
+        contentType?.toLowerCase().includes('text/event-stream') ?? false;
+      const jsonRpcRequestId = getJsonRpcRequestId(parsedBody);
+      const canReadMatchingSseResponse =
+        isSseResponse &&
+        jsonRpcRequestId !== null &&
+        !Array.isArray(parsedBody);
 
       if (!upstreamResponse.ok) {
         console.warn(
@@ -1129,18 +1131,17 @@ export function createMcpProxy(config: McpProxyConfig) {
       if (
         method === 'POST' &&
         getJsonRpcMethod(parsedBody) === 'tools/list' &&
-        upstreamResponse.ok
+        upstreamResponse.ok &&
+        // An SSE response without a correlatable JSON-RPC id may remain open
+        // indefinitely. Preserve that stream instead of buffering it to EOF.
+        (!isSseResponse || canReadMatchingSseResponse)
       ) {
         try {
-          const requestId = getJsonRpcRequestId(parsedBody);
-          const sseBody =
-            contentType?.includes('text/event-stream') &&
-            requestId !== null &&
-            !Array.isArray(parsedBody)
-              ? upstreamResponse.clone().body
-              : null;
+          const sseBody = canReadMatchingSseResponse
+            ? upstreamResponse.clone().body
+            : null;
           const payload = sseBody
-            ? await readMatchingSseJsonRpcResponse(sseBody, requestId)
+            ? await readMatchingSseJsonRpcResponse(sseBody, jsonRpcRequestId)
             : parseMcpJsonRpcPayload(
                 await upstreamResponse.clone().text(),
                 contentType,
@@ -1194,11 +1195,7 @@ export function createMcpProxy(config: McpProxyConfig) {
       // Requests without an id are notifications with no response, and streams
       // that end without a matching response fall through to the raw stream.
       const sseResponseBody =
-        method === 'POST' &&
-        upstreamResponse.ok &&
-        contentType?.includes('text/event-stream') &&
-        getJsonRpcRequestId(parsedBody) !== null &&
-        !Array.isArray(parsedBody)
+        method === 'POST' && upstreamResponse.ok && canReadMatchingSseResponse
           ? upstreamResponse.clone().body
           : null;
 
@@ -1206,7 +1203,7 @@ export function createMcpProxy(config: McpProxyConfig) {
         try {
           const response = await readMatchingSseJsonRpcResponse(
             sseResponseBody,
-            getJsonRpcRequestId(parsedBody),
+            jsonRpcRequestId,
           );
           if (response) {
             // The raw upstream body is no longer needed; cancel it to release

--- a/apps/api/src/handlers/mcp/proxy-utils.ts
+++ b/apps/api/src/handlers/mcp/proxy-utils.ts
@@ -422,8 +422,10 @@ function stripToolSchemaPatterns(value: unknown): unknown {
  * give array schemas that declare no item shape at all a permissive string
  * `items` (the upstream server still validates the actual tool call). The
  * transform must never destroy information the upstream declared: declared
- * `items` of any form pass through untouched, and data-carrying keywords
- * (`default`, `const`, `enum`, `examples`) are never recursed into.
+ * `items` of any form pass through untouched, and recursion is limited to
+ * keyword positions known to carry schemas — data keywords (`default`,
+ * `const`, `enum`, `examples`), vendor extensions, and unrecognized
+ * keywords are opaque and never rewritten.
  */
 const ARRAY_ONLY_SCHEMA_KEYWORDS = [
   'items',
@@ -512,14 +514,27 @@ const UNION_SPLIT_UNDERSTOOD_KEYWORDS = new Set<string>([
   ...NUMERIC_ONLY_SCHEMA_KEYWORDS,
 ]);
 
-// Keys whose values are data, not schemas. Recursing into them would rewrite
-// literal values that merely look like schemas (a `default` of
-// `{"type": "array"}` would grow an injected `items`).
-const NON_SCHEMA_VALUE_KEYWORDS = new Set([
-  'default',
-  'const',
-  'enum',
-  'examples',
+// Keys whose values are schemas (or arrays of schemas). Recursion is limited
+// to these positions plus the schema/dependency maps below; every other
+// key's value — data keywords like `default`/`enum`, vendor extensions,
+// unrecognized keywords — is opaque data and passes through untouched, even
+// when it happens to look like a schema.
+const SCHEMA_VALUE_KEYWORDS = new Set([
+  'items',
+  'additionalItems',
+  'unevaluatedItems',
+  'prefixItems',
+  'contains',
+  'additionalProperties',
+  'unevaluatedProperties',
+  'propertyNames',
+  'anyOf',
+  'oneOf',
+  'allOf',
+  'not',
+  'if',
+  'then',
+  'else',
 ]);
 
 // Keys whose values are maps of schemas keyed by arbitrary names. Entries in
@@ -598,19 +613,28 @@ function normalizeToolSchemaForStrictProviders(
             : nestedValue,
         ];
       }
-      if (context === 'schema' && NON_SCHEMA_VALUE_KEYWORDS.has(key)) {
-        return [key, nestedValue];
+      if (context === 'schema-map') {
+        // Every entry of a schema map is a schema, whatever its name.
+        return [key, normalizeToolSchemaForStrictProviders(nestedValue)];
       }
-      let childContext: SchemaTraversalContext = 'schema';
-      if (context === 'schema' && SCHEMA_MAP_KEYWORDS.has(key)) {
-        childContext = 'schema-map';
-      } else if (context === 'schema' && DEPENDENCY_MAP_KEYWORDS.has(key)) {
-        childContext = 'dependency-map';
+      // In a schema, recurse only into positions known to carry schemas;
+      // any other value is opaque data.
+      if (SCHEMA_MAP_KEYWORDS.has(key)) {
+        return [
+          key,
+          normalizeToolSchemaForStrictProviders(nestedValue, 'schema-map'),
+        ];
       }
-      return [
-        key,
-        normalizeToolSchemaForStrictProviders(nestedValue, childContext),
-      ];
+      if (DEPENDENCY_MAP_KEYWORDS.has(key)) {
+        return [
+          key,
+          normalizeToolSchemaForStrictProviders(nestedValue, 'dependency-map'),
+        ];
+      }
+      if (SCHEMA_VALUE_KEYWORDS.has(key)) {
+        return [key, normalizeToolSchemaForStrictProviders(nestedValue)];
+      }
+      return [key, nestedValue];
     }),
   );
 

--- a/apps/api/src/handlers/mcp/proxy-utils.ts
+++ b/apps/api/src/handlers/mcp/proxy-utils.ts
@@ -451,20 +451,16 @@ const OBJECT_ONLY_SCHEMA_KEYWORDS = [
   'dependentSchemas',
 ] as const;
 
-// Keywords that constrain the value in ways a per-type branch split cannot
-// represent (combinators, references, conditionals). A composite union
-// carrying any of these as a sibling is left untouched: splitting it would
-// silently drop the constraint and widen what the schema accepts.
-const UNION_SPLIT_BLOCKING_KEYWORDS = [
-  'anyOf',
-  'oneOf',
-  'allOf',
-  'not',
-  'if',
-  'then',
-  'else',
-  '$ref',
-  '$dynamicRef',
+// Annotation keywords carry no validation semantics; when a union is split
+// they stay on the anyOf wrapper rather than being copied into branches.
+const UNION_ANNOTATION_KEYWORDS = [
+  'description',
+  'title',
+  'default',
+  'examples',
+  'deprecated',
+  'readOnly',
+  'writeOnly',
 ] as const;
 
 const STRING_ONLY_SCHEMA_KEYWORDS = [
@@ -498,6 +494,22 @@ const UNION_BRANCH_KEYWORDS_BY_TYPE: Record<string, readonly string[]> = {
 
 // `enum` and `const` constrain the value itself and stay valid on any branch.
 const UNION_BRANCH_SHARED_KEYWORDS = ['enum', 'const'] as const;
+
+// A composite type union is split ONLY when every keyword it carries is one
+// whose branch placement is understood exactly. Anything else — combinators,
+// references, conditionals, vendor extensions, keywords from a future
+// dialect — means the schema is left untouched. Declining costs at most the
+// pre-normalization status quo (a strict provider may reject that one tool);
+// rewriting wrongly would corrupt the contract for every provider.
+const UNION_SPLIT_UNDERSTOOD_KEYWORDS = new Set<string>([
+  'type',
+  ...UNION_ANNOTATION_KEYWORDS,
+  ...UNION_BRANCH_SHARED_KEYWORDS,
+  ...ARRAY_ONLY_SCHEMA_KEYWORDS,
+  ...OBJECT_ONLY_SCHEMA_KEYWORDS,
+  ...STRING_ONLY_SCHEMA_KEYWORDS,
+  ...NUMERIC_ONLY_SCHEMA_KEYWORDS,
+]);
 
 // Keys whose values are data, not schemas. Recursing into them would rewrite
 // literal values that merely look like schemas (a `default` of
@@ -607,12 +619,15 @@ function normalizeToolSchemaForStrictProviders(
     return schema;
   }
 
-  if (UNION_SPLIT_BLOCKING_KEYWORDS.some((keyword) => keyword in schema)) {
-    // Splitting the union would clobber the sibling constraint, so decline —
+  const unknownKeywords = Object.keys(schema).filter(
+    (key) => !UNION_SPLIT_UNDERSTOOD_KEYWORDS.has(key),
+  );
+  if (unknownKeywords.length > 0) {
+    // Decline rather than risk rewriting semantics we do not fully model —
     // but say so, since strict providers may reject the untouched schema and
     // this log is the only breadcrumb when they do.
     console.warn(
-      '[mcp-proxy] Left composite type union with a sibling combinator, reference, or conditional un-normalized; strict providers may reject this tool schema',
+      `[mcp-proxy] Left composite type union un-normalized; it carries keywords outside the understood set (${unknownKeywords.join(', ')}). Strict providers may reject this tool schema`,
     );
     return schema;
   }
@@ -636,18 +651,30 @@ function normalizeToolSchemaForStrictProviders(
   });
 
   const normalized: Record<string, unknown> = { anyOf: branches };
-  if (typeof sharedKeywords.description === 'string') {
-    normalized.description = sharedKeywords.description;
-  }
-  if ('default' in sharedKeywords) {
-    normalized.default = sharedKeywords.default;
+  for (const keyword of UNION_ANNOTATION_KEYWORDS) {
+    if (keyword in sharedKeywords) {
+      normalized[keyword] = sharedKeywords[keyword];
+    }
   }
   return normalized;
+}
+
+// Kill switch: set R_DISABLE_MCP_SCHEMA_NORMALIZATION=true to pass tool
+// schemas through untouched. This transform runs on every tools/list for
+// every workspace, so a misbehaving rewrite in production must be
+// disableable without a rollback.
+function isSchemaNormalizationDisabled(): boolean {
+  const flag = process.env.R_DISABLE_MCP_SCHEMA_NORMALIZATION?.trim();
+  return flag === 'true' || flag === '1';
 }
 
 function normalizeToolDefinitionInputSchemas<
   T extends { name: string } & Record<string, unknown>,
 >(tools: T[]): T[] {
+  if (isSchemaNormalizationDisabled()) {
+    return tools;
+  }
+
   return tools.map((tool) => {
     const normalized: Record<string, unknown> = { ...tool };
     if ('inputSchema' in normalized) {

--- a/apps/api/src/handlers/mcp/proxy-utils.ts
+++ b/apps/api/src/handlers/mcp/proxy-utils.ts
@@ -419,8 +419,11 @@ function stripToolSchemaPatterns(value: unknown): unknown {
  * request that fails the whole task turn. Normalize the shapes that trigger
  * this at the proxy boundary: rewrite array/object type unions into explicit
  * `anyOf` branches with each branch keeping only its own type's keywords, and
- * give array schemas that declare no item shape a permissive string `items`
- * (the upstream server still validates the actual tool call).
+ * give array schemas that declare no item shape at all a permissive string
+ * `items` (the upstream server still validates the actual tool call). The
+ * transform must never destroy information the upstream declared: declared
+ * `items` of any form pass through untouched, and data-carrying keywords
+ * (`default`, `const`, `enum`, `examples`) are never recursed into.
  */
 const ARRAY_ONLY_SCHEMA_KEYWORDS = [
   'items',
@@ -443,6 +446,59 @@ const OBJECT_ONLY_SCHEMA_KEYWORDS = [
   'maxProperties',
 ] as const;
 
+const STRING_ONLY_SCHEMA_KEYWORDS = [
+  'minLength',
+  'maxLength',
+  'pattern',
+  'format',
+  'contentEncoding',
+  'contentMediaType',
+] as const;
+
+const NUMERIC_ONLY_SCHEMA_KEYWORDS = [
+  'minimum',
+  'maximum',
+  'exclusiveMinimum',
+  'exclusiveMaximum',
+  'multipleOf',
+] as const;
+
+// Union branches keep only the structural keywords that belong to their own
+// type; anything else leaking into a branch (a `minLength` on an array
+// branch, a `default: null` on an object branch) produces self-contradictory
+// schemas that strict providers can reject outright.
+const UNION_BRANCH_KEYWORDS_BY_TYPE: Record<string, readonly string[]> = {
+  array: ARRAY_ONLY_SCHEMA_KEYWORDS,
+  object: OBJECT_ONLY_SCHEMA_KEYWORDS,
+  string: STRING_ONLY_SCHEMA_KEYWORDS,
+  number: NUMERIC_ONLY_SCHEMA_KEYWORDS,
+  integer: NUMERIC_ONLY_SCHEMA_KEYWORDS,
+};
+
+// `enum` and `const` constrain the value itself and stay valid on any branch.
+const UNION_BRANCH_SHARED_KEYWORDS = ['enum', 'const'] as const;
+
+// Keys whose values are data, not schemas. Recursing into them would rewrite
+// literal values that merely look like schemas (a `default` of
+// `{"type": "array"}` would grow an injected `items`).
+const NON_SCHEMA_VALUE_KEYWORDS = new Set([
+  'default',
+  'const',
+  'enum',
+  'examples',
+]);
+
+// Keys whose values are maps of schemas keyed by arbitrary names. Entries in
+// these maps are schemas even when a property is literally named "default"
+// or "enum", so the data-keyword skip above must not apply inside them.
+const SCHEMA_MAP_KEYWORDS = new Set([
+  'properties',
+  'patternProperties',
+  'definitions',
+  '$defs',
+  'dependentSchemas',
+]);
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
@@ -454,16 +510,19 @@ function withProviderSafeArrayItems(
     return schema;
   }
 
-  const items = schema.items;
-  const declaresItemShape =
-    isPlainObject(items) && Object.keys(items).length > 0;
-
-  return declaresItemShape ? schema : { ...schema, items: { type: 'string' } };
+  // Only fill in `items` when the upstream declared nothing at all. A
+  // declared shape of any form (object schema, boolean, draft-04 tuple
+  // array, or an explicit empty object) is the server's contract and must
+  // pass through untouched.
+  return 'items' in schema ? schema : { ...schema, items: { type: 'string' } };
 }
 
-function normalizeToolSchemaForStrictProviders(value: unknown): unknown {
+function normalizeToolSchemaForStrictProviders(
+  value: unknown,
+  context: 'schema' | 'schema-map' = 'schema',
+): unknown {
   if (Array.isArray(value)) {
-    return value.map(normalizeToolSchemaForStrictProviders);
+    return value.map((entry) => normalizeToolSchemaForStrictProviders(entry));
   }
 
   if (!isPlainObject(value)) {
@@ -471,11 +530,27 @@ function normalizeToolSchemaForStrictProviders(value: unknown): unknown {
   }
 
   const schema = Object.fromEntries(
-    Object.entries(value).map(([key, nestedValue]) => [
-      key,
-      normalizeToolSchemaForStrictProviders(nestedValue),
-    ]),
+    Object.entries(value).map(([key, nestedValue]) => {
+      if (context === 'schema' && NON_SCHEMA_VALUE_KEYWORDS.has(key)) {
+        return [key, nestedValue];
+      }
+      return [
+        key,
+        normalizeToolSchemaForStrictProviders(
+          nestedValue,
+          context === 'schema' && SCHEMA_MAP_KEYWORDS.has(key)
+            ? 'schema-map'
+            : 'schema',
+        ),
+      ];
+    }),
   );
+
+  // A schema map's own keys are property names, not schema keywords; only
+  // its entries (handled above) are schemas.
+  if (context === 'schema-map') {
+    return schema;
+  }
 
   const typeValue = schema.type;
   if (
@@ -492,12 +567,17 @@ function normalizeToolSchemaForStrictProviders(value: unknown): unknown {
 
   // Scalar-only unions convert cleanly; only unions carrying a composite
   // type lose their keywords in the downstream Gemini conversion.
-  if (
-    (!typeValue.includes('array') && !typeValue.includes('object')) ||
-    'anyOf' in schema ||
-    'oneOf' in schema ||
-    'allOf' in schema
-  ) {
+  if (!typeValue.includes('array') && !typeValue.includes('object')) {
+    return schema;
+  }
+
+  if ('anyOf' in schema || 'oneOf' in schema || 'allOf' in schema) {
+    // Splitting the union would clobber the sibling combinator, so decline —
+    // but say so, since strict providers may reject the untouched schema and
+    // this log is the only breadcrumb when they do.
+    console.warn(
+      '[mcp-proxy] Left composite type union with sibling anyOf/oneOf/allOf un-normalized; strict providers may reject this tool schema',
+    );
     return schema;
   }
 
@@ -507,18 +587,13 @@ function normalizeToolSchemaForStrictProviders(value: unknown): unknown {
       return { type: 'null' };
     }
 
-    const branch: Record<string, unknown> = {
-      ...sharedKeywords,
-      type: branchType,
-    };
-    if (branchType !== 'array') {
-      for (const keyword of ARRAY_ONLY_SCHEMA_KEYWORDS) {
-        delete branch[keyword];
-      }
-    }
-    if (branchType !== 'object') {
-      for (const keyword of OBJECT_ONLY_SCHEMA_KEYWORDS) {
-        delete branch[keyword];
+    const branch: Record<string, unknown> = { type: branchType };
+    for (const keyword of [
+      ...(UNION_BRANCH_KEYWORDS_BY_TYPE[branchType] ?? []),
+      ...UNION_BRANCH_SHARED_KEYWORDS,
+    ]) {
+      if (keyword in sharedKeywords) {
+        branch[keyword] = sharedKeywords[keyword];
       }
     }
     return withProviderSafeArrayItems(branch);
@@ -527,6 +602,9 @@ function normalizeToolSchemaForStrictProviders(value: unknown): unknown {
   const normalized: Record<string, unknown> = { anyOf: branches };
   if (typeof sharedKeywords.description === 'string') {
     normalized.description = sharedKeywords.description;
+  }
+  if ('default' in sharedKeywords) {
+    normalized.default = sharedKeywords.default;
   }
   return normalized;
 }
@@ -606,6 +684,7 @@ function filterToolsListPayload(
 function parseSseEventJsonRpcResponse(
   eventChunk: string,
   expectedId: JsonRpcRequestId,
+  matchAnyResponse = false,
 ): unknown | null {
   const dataText = eventChunk
     .split(/\r?\n/)
@@ -637,9 +716,15 @@ function parseSseEventJsonRpcResponse(
   };
   const hasResponsePayload = 'result' in message || 'error' in message;
   const idMatches =
-    expectedId === null
+    matchAnyResponse ||
+    (expectedId === null
       ? message.id === undefined || message.id === null
-      : message.id === expectedId;
+      : message.id === expectedId ||
+        // Tolerate upstreams that echo a numeric id as a string (or vice
+        // versa); a missed match here means the reply is forwarded as the
+        // raw upstream stream instead of the rebuilt, filtered payload.
+        ((typeof message.id === 'string' || typeof message.id === 'number') &&
+          String(message.id) === String(expectedId)));
 
   return hasResponsePayload && idMatches ? parsed : null;
 }
@@ -657,18 +742,51 @@ function parseSseEventJsonRpcResponse(
  * returns the matching response frame the moment it is seen and cancels the
  * reader. Returns `null` if the stream ends before a matching response frame
  * appears.
+ *
+ * `matchAnyResponse` accepts the first frame carrying a `result`/`error`
+ * regardless of its id — used for id-less requests whose reply must still be
+ * rebuilt (a restricted connection's tools/list). `timeoutMs` bounds the
+ * whole read and throws on expiry so a never-closing stream cannot hang the
+ * caller.
  */
 async function readMatchingSseJsonRpcResponse(
   body: ReadableStream<Uint8Array>,
   expectedId: JsonRpcRequestId,
+  options?: { matchAnyResponse?: boolean; timeoutMs?: number },
 ): Promise<unknown | null> {
   const reader = body.getReader();
   const decoder = new TextDecoder();
   let buffer = '';
+  const matchAnyResponse = options?.matchAnyResponse ?? false;
+  const deadline =
+    options?.timeoutMs === undefined ? null : Date.now() + options.timeoutMs;
+
+  const readNext = async (): Promise<ReadableStreamReadResult<Uint8Array>> => {
+    if (deadline === null) {
+      return reader.read();
+    }
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      throw new Error('Timed out reading upstream SSE response');
+    }
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        reader.read(),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => {
+            reject(new Error('Timed out reading upstream SSE response'));
+          }, remainingMs);
+        }),
+      ]);
+    } finally {
+      clearTimeout(timer);
+    }
+  };
 
   try {
     for (;;) {
-      const { done, value } = await reader.read();
+      const { done, value } = await readNext();
 
       if (value) {
         buffer += decoder.decode(value, { stream: true });
@@ -682,7 +800,11 @@ async function readMatchingSseJsonRpcResponse(
           const eventChunk = buffer.slice(0, boundary.index);
           buffer = buffer.slice(boundary.index + boundary[0].length);
 
-          const match = parseSseEventJsonRpcResponse(eventChunk, expectedId);
+          const match = parseSseEventJsonRpcResponse(
+            eventChunk,
+            expectedId,
+            matchAnyResponse,
+          );
           if (match !== null) {
             return match;
           }
@@ -691,7 +813,11 @@ async function readMatchingSseJsonRpcResponse(
 
       if (done) {
         buffer += decoder.decode();
-        return parseSseEventJsonRpcResponse(buffer, expectedId);
+        return parseSseEventJsonRpcResponse(
+          buffer,
+          expectedId,
+          matchAnyResponse,
+        );
       }
     }
   } finally {
@@ -702,6 +828,12 @@ async function readMatchingSseJsonRpcResponse(
     });
   }
 }
+
+// How long a restricted connection's tools/list rebuild will wait for an
+// uncorrelatable SSE reply before giving up. Generous relative to a normal
+// tools/list round trip, but bounded so a server that never closes its
+// response channel cannot hang the proxy.
+const UNCORRELATED_SSE_TOOLS_LIST_TIMEOUT_MS = 10_000;
 
 class RequestBodyTooLargeError extends Error {
   constructor(readonly observedBytes: number) {
@@ -1127,21 +1259,39 @@ export function createMcpProxy(config: McpProxyConfig) {
       }
 
       // Every tools/list reply is rebuilt (not just restricted ones) so tool
-      // schemas can be normalized for strict model providers.
+      // schemas can be normalized for strict model providers. Connections
+      // with tool restrictions or schema stripping must never see an
+      // unfiltered tools/list, even when the upstream reply is an SSE stream
+      // we cannot correlate.
+      const mustFilterToolsList =
+        hasToolRestrictions || shouldStripToolSchemaPatterns;
+
       if (
         method === 'POST' &&
         getJsonRpcMethod(parsedBody) === 'tools/list' &&
         upstreamResponse.ok &&
         // An SSE response without a correlatable JSON-RPC id may remain open
-        // indefinitely. Preserve that stream instead of buffering it to EOF.
-        (!isSseResponse || canReadMatchingSseResponse)
+        // indefinitely. Preserve that stream for unrestricted connections;
+        // restricted connections fall back to a bounded buffered read.
+        (!isSseResponse || canReadMatchingSseResponse || mustFilterToolsList)
       ) {
         try {
-          const sseBody = canReadMatchingSseResponse
-            ? upstreamResponse.clone().body
-            : null;
+          const sseBody = isSseResponse ? upstreamResponse.clone().body : null;
           const payload = sseBody
-            ? await readMatchingSseJsonRpcResponse(sseBody, jsonRpcRequestId)
+            ? await readMatchingSseJsonRpcResponse(
+                sseBody,
+                canReadMatchingSseResponse ? jsonRpcRequestId : null,
+                canReadMatchingSseResponse
+                  ? undefined
+                  : // An id-less request can't be correlated; accept the
+                    // first response frame within a bounded window so the
+                    // restricted rebuild neither hangs nor mistakes a
+                    // progress notification for the reply.
+                    {
+                      matchAnyResponse: true,
+                      timeoutMs: UNCORRELATED_SSE_TOOLS_LIST_TIMEOUT_MS,
+                    },
+              )
             : parseMcpJsonRpcPayload(
                 await upstreamResponse.clone().text(),
                 contentType,
@@ -1162,15 +1312,37 @@ export function createMcpProxy(config: McpProxyConfig) {
           const headers = buildProxyResponseHeaders(upstreamResponse.headers);
           headers.set('content-type', 'application/json');
 
-          if (sseBody) {
-            upstreamResponse.body?.cancel().catch(() => {});
-          }
+          // The raw upstream tee branch is no longer needed on any rebuild
+          // path; cancel it so the buffered body is released promptly.
+          upstreamResponse.body?.cancel().catch(() => {});
 
           return new Response(JSON.stringify(filteredPayload), {
             status: upstreamResponse.status,
             headers,
           });
-        } catch {
+        } catch (error) {
+          if (mustFilterToolsList) {
+            console.warn(
+              formatSingleLineLog(
+                `${logPrefix} Refusing to forward a tools/list reply that could not be filtered`,
+                {
+                  requestId,
+                  method,
+                  path,
+                  upstream: effectiveUpstream,
+                  tokenType: auth.tokenType,
+                  userId: auth.userId,
+                  error: error instanceof Error ? error.message : String(error),
+                },
+              ),
+            );
+            return jsonRpcErrorResponse(
+              502,
+              -32000,
+              `${name} MCP upstream returned a tools/list reply that could not be filtered for this connection`,
+              jsonRpcRequestId,
+            );
+          }
           // Fall through to the raw upstream response if the body is not JSON.
         }
       }


### PR DESCRIPTION
> &#8203;<!-- roomote:pr-attribution:start -->Opened on behalf of @mrubens.<!-- roomote:pr-attribution:end --> [View the task](https://community.roomote.ai/task/0c0cmm1oxysxx?utm_source=github-comment&utm_medium=link&utm_campaign=github_pr_review_follow_up) or mention @roomote for follow-up asks.

## What changed

- Normalize MCP tool input and output schemas before returning `tools/list` results so Gemini receives valid array and object union declarations.
- Read SSE-framed `tools/list` responses incrementally and return as soon as the matching JSON-RPC response arrives, rather than waiting for a long-lived stream to close.
- Preserve finite JSON response handling and cancel the unused upstream stream after an SSE result is rebuilt.
- Add regression coverage for strict-provider schema normalization and never-closing SSE `tools/list` responses.

## Why this change was made

Valid upstream MCP schemas can become invalid Gemini function declarations when composite nullable unions are converted downstream. Applying the normalization to every `tools/list` response fixes that provider failure, while incremental SSE parsing prevents the proxy from hanging on Streamable HTTP servers that keep their response channel open.

## Impact

Gemini-backed tasks can load tools with nullable arrays and objects without poisoning the full tool list, and MCP integrations using long-lived SSE responses continue returning promptly. All 208 MCP handler tests, API type checking, changed-file lint and formatting, and the repository pre-push checks pass. Package-wide API lint still reports an unrelated pre-existing unused-disable warning in `apps/api/src/handlers/github/__tests__/notifyPullRequestTerminalStatus.test.ts`.