### PR TITLE
[Fix] Harden the daily environment snapshot refresh

### DIFF
--- a/apps/bullmq/src/scheduled-jobs/__tests__/refresh-snapshots.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/refresh-snapshots.test.ts
@@ -125,6 +125,12 @@ describe('refreshSnapshotsJob launch pacing', () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(mockEnqueueTask).toHaveBeenCalledTimes(1);
 
+    // The second candidate reserves its pending claim BEFORE the pacing
+    // sleep, so concurrent claimants are locked out during the wait.
+    expect(
+      mockClaimPendingEnvironmentSnapshotForAttachment,
+    ).toHaveBeenCalledTimes(2);
+
     // The second launch waits out the full spacing interval.
     await vi.advanceTimersByTimeAsync(SNAPSHOT_REFRESH_LAUNCH_SPACING_MS - 1);
     expect(mockEnqueueTask).toHaveBeenCalledTimes(1);
@@ -164,6 +170,28 @@ describe('refreshSnapshotsJob launch pacing', () => {
       });
 
     // Real timers: a trailing pacing sleep would blow the test timeout.
+    await refreshSnapshotsJob();
+
+    expect(mockEnqueueTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not sleep for candidates whose claim was taken by a concurrent claimant', async () => {
+    mockEnvironmentsFindMany.mockResolvedValue([
+      makeEnvironment('env-1'),
+      makeEnvironment('env-2'),
+      makeEnvironment('env-3'),
+    ]);
+    // env-1 claims and launches; env-2 and env-3 lose their claim (e.g. the
+    // admin snapshot command got there first). The claim precedes pacing, so
+    // the lost claims skip without ever sleeping.
+    mockClaimPendingEnvironmentSnapshotForAttachment
+      .mockImplementationOnce(
+        async (_db: unknown, params: { environmentId: string }) =>
+          makeClaim(params.environmentId),
+      )
+      .mockResolvedValue(null);
+
+    // Real timers: a pacing sleep for a lost claim would blow the test timeout.
     await refreshSnapshotsJob();
 
     expect(mockEnqueueTask).toHaveBeenCalledTimes(1);

--- a/apps/bullmq/src/scheduled-jobs/__tests__/refresh-snapshots.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/refresh-snapshots.test.ts
@@ -148,6 +148,27 @@ describe('refreshSnapshotsJob launch pacing', () => {
     expect(mockEnqueueTask).toHaveBeenCalledTimes(1);
   });
 
+  it('does not sleep after a launch when every remaining candidate is skipped', async () => {
+    mockEnvironmentsFindMany.mockResolvedValue([
+      makeEnvironment('env-1'),
+      makeEnvironment('env-2'),
+      makeEnvironment('env-3'),
+    ]);
+    // env-1 launches; env-2 and env-3 already hold a fresh pending claim, so
+    // their skip check fires before any pacing sleep.
+    mockEnvironmentSnapshotsFindFirst
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValue({
+        snapshotStatus: 'pending',
+        updatedAt: new Date(),
+      });
+
+    // Real timers: a trailing pacing sleep would blow the test timeout.
+    await refreshSnapshotsJob();
+
+    expect(mockEnqueueTask).toHaveBeenCalledTimes(1);
+  });
+
   it('does not sleep for skipped candidates', async () => {
     mockEnvironmentsFindMany.mockResolvedValue([
       makeEnvironment('env-1'),

--- a/apps/bullmq/src/scheduled-jobs/__tests__/refresh-snapshots.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/refresh-snapshots.test.ts
@@ -1,0 +1,165 @@
+// Hoist mock functions so they're available inside vi.mock factories.
+const {
+  mockEnvironmentSnapshotsFindMany,
+  mockEnvironmentSnapshotsFindFirst,
+  mockEnvironmentsFindMany,
+  mockClaimPendingEnvironmentSnapshotForAttachment,
+  mockResolveDefaultComputeProvider,
+  mockUpdatePendingEnvironmentSnapshot,
+  mockEnqueueTask,
+} = vi.hoisted(() => ({
+  mockEnvironmentSnapshotsFindMany: vi.fn(),
+  mockEnvironmentSnapshotsFindFirst: vi.fn(),
+  mockEnvironmentsFindMany: vi.fn(),
+  mockClaimPendingEnvironmentSnapshotForAttachment: vi.fn(),
+  mockResolveDefaultComputeProvider: vi.fn(),
+  mockUpdatePendingEnvironmentSnapshot: vi.fn(),
+  mockEnqueueTask: vi.fn(),
+}));
+
+// findActiveSnapshotRefreshJob's select().from().innerJoin().where()
+// .orderBy().limit() chain; always resolves to "no active run".
+function makeSelectChain() {
+  const chain: Record<string, unknown> = {};
+
+  for (const method of ['from', 'innerJoin', 'where', 'orderBy']) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+
+  chain.limit = vi.fn().mockResolvedValue([]);
+
+  return chain;
+}
+
+vi.mock('@roomote/db/server', async () => {
+  const actual =
+    await vi.importActual<typeof import('@roomote/db/server')>(
+      '@roomote/db/server',
+    );
+  return {
+    ...actual,
+    db: {
+      query: {
+        environmentSnapshots: {
+          findMany: (...args: unknown[]) =>
+            mockEnvironmentSnapshotsFindMany(...args),
+          findFirst: (...args: unknown[]) =>
+            mockEnvironmentSnapshotsFindFirst(...args),
+        },
+        environments: {
+          findMany: (...args: unknown[]) => mockEnvironmentsFindMany(...args),
+        },
+      },
+      select: () => makeSelectChain(),
+    },
+    claimPendingEnvironmentSnapshotForAttachment: (...args: unknown[]) =>
+      mockClaimPendingEnvironmentSnapshotForAttachment(...args),
+    resolveDefaultComputeProvider: (...args: unknown[]) =>
+      mockResolveDefaultComputeProvider(...args),
+    updatePendingEnvironmentSnapshot: (...args: unknown[]) =>
+      mockUpdatePendingEnvironmentSnapshot(...args),
+  };
+});
+
+vi.mock('@roomote/cloud-agents/server', () => ({
+  enqueueTask: (...args: unknown[]) => mockEnqueueTask(...args),
+}));
+
+import {
+  refreshSnapshotsJob,
+  SNAPSHOT_REFRESH_LAUNCH_SPACING_MS,
+} from '../refresh-snapshots';
+
+function makeEnvironment(id: string) {
+  return {
+    id,
+    name: `env ${id}`,
+    updatedAt: new Date('2026-08-01T00:00:00.000Z'),
+  };
+}
+
+function makeClaim(environmentId: string) {
+  const claimedAt = new Date('2026-08-13T00:00:00.000Z');
+  return {
+    environmentSnapshotId: `snapshot-row-${environmentId}`,
+    claimedAt,
+    attachmentSource: {
+      source: 'pending_snapshot_row' as const,
+      environmentSnapshotId: `snapshot-row-${environmentId}`,
+      claimedAt: claimedAt.toISOString(),
+    },
+  };
+}
+
+describe('refreshSnapshotsJob launch pacing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // No snapshot rows: every environment becomes a
+    // 'missing_default_provider_snapshot' candidate that wants a launch.
+    mockEnvironmentSnapshotsFindMany.mockResolvedValue([]);
+    mockEnvironmentSnapshotsFindFirst.mockResolvedValue(undefined);
+    mockResolveDefaultComputeProvider.mockResolvedValue('modal');
+    mockClaimPendingEnvironmentSnapshotForAttachment.mockImplementation(
+      async (_db: unknown, params: { environmentId: string }) =>
+        makeClaim(params.environmentId),
+    );
+    let nextRunId = 100;
+    mockEnqueueTask.mockImplementation(async () => ({ id: nextRunId++ }));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('spaces consecutive launches by the launch spacing interval', async () => {
+    vi.useFakeTimers();
+    mockEnvironmentsFindMany.mockResolvedValue([
+      makeEnvironment('env-1'),
+      makeEnvironment('env-2'),
+      makeEnvironment('env-3'),
+    ]);
+
+    const jobPromise = refreshSnapshotsJob();
+
+    // The first launch happens immediately, without any pacing delay.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockEnqueueTask).toHaveBeenCalledTimes(1);
+
+    // The second launch waits out the full spacing interval.
+    await vi.advanceTimersByTimeAsync(SNAPSHOT_REFRESH_LAUNCH_SPACING_MS - 1);
+    expect(mockEnqueueTask).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(mockEnqueueTask).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(SNAPSHOT_REFRESH_LAUNCH_SPACING_MS);
+    expect(mockEnqueueTask).toHaveBeenCalledTimes(3);
+
+    // No trailing sleep after the last candidate: the job settles without
+    // advancing the clock any further.
+    await jobPromise;
+  });
+
+  it('finishes without sleeping when there is a single candidate', async () => {
+    mockEnvironmentsFindMany.mockResolvedValue([makeEnvironment('env-1')]);
+
+    // Real timers: a stray pacing sleep would blow the test timeout.
+    await refreshSnapshotsJob();
+
+    expect(mockEnqueueTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not sleep for skipped candidates', async () => {
+    mockEnvironmentsFindMany.mockResolvedValue([
+      makeEnvironment('env-1'),
+      makeEnvironment('env-2'),
+      makeEnvironment('env-3'),
+    ]);
+    // Every claim is already held elsewhere, so no launches happen at all.
+    mockClaimPendingEnvironmentSnapshotForAttachment.mockResolvedValue(null);
+
+    // Real timers: any pacing sleep for a skip would blow the test timeout.
+    await refreshSnapshotsJob();
+
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
+  });
+});

--- a/apps/bullmq/src/scheduled-jobs/refresh-snapshots.ts
+++ b/apps/bullmq/src/scheduled-jobs/refresh-snapshots.ts
@@ -378,16 +378,23 @@ export const refreshSnapshotsJob = async () => {
     const errors: Array<Record<string, unknown>> = [];
     // The controller dequeues each run within seconds of its enqueue, so
     // spacing the enqueues here is what spaces the sandbox creations at the
-    // broker. Skipped candidates never sleep; the delay only follows an
-    // actual launch with candidates still left to process.
-    const paceAfterLaunch = async (hasRemainingCandidates: boolean) => {
-      if (hasRemainingCandidates) {
-        await sleep(SNAPSHOT_REFRESH_LAUNCH_SPACING_MS);
+    // broker. The sleep happens lazily, immediately before the NEXT launch:
+    // skipped candidates never sleep, a trailing launch never sleeps, and no
+    // sleep ever runs inside the snapshot lock.
+    let lastLaunchAtMs: number | null = null;
+    const paceBeforeNextLaunch = async () => {
+      if (lastLaunchAtMs !== null) {
+        const elapsedMs = Date.now() - lastLaunchAtMs;
+
+        if (elapsedMs < SNAPSHOT_REFRESH_LAUNCH_SPACING_MS) {
+          await sleep(SNAPSHOT_REFRESH_LAUNCH_SPACING_MS - elapsedMs);
+        }
       }
     };
-    for (const [candidateIndex, candidate] of refreshCandidates.entries()) {
-      const hasRemainingCandidates =
-        candidateIndex < refreshCandidates.length - 1;
+    const recordLaunch = () => {
+      lastLaunchAtMs = Date.now();
+    };
+    for (const candidate of refreshCandidates) {
       const snapshotAgeHours = getSnapshotAgeHours(
         candidate.snapshotCreatedAt,
         startedAt,
@@ -429,6 +436,10 @@ export const refreshSnapshotsJob = async () => {
           if (await hasRecentPendingSnapshotClaim(candidate, new Date())) {
             continue;
           }
+
+          // The skip checks passed, so a launch is imminent: pace it before
+          // claiming, keeping the claim→enqueue window tight.
+          await paceBeforeNextLaunch();
 
           pendingSnapshotClaim =
             await claimPendingEnvironmentSnapshotForAttachment(db, {
@@ -488,8 +499,19 @@ export const refreshSnapshotsJob = async () => {
           });
 
           refreshed++;
-          await paceAfterLaunch(hasRemainingCandidates);
+          recordLaunch();
           continue;
+        }
+
+        // Lock-free pre-check mirroring the locked skip conditions, used only
+        // to decide whether to pace — sleeping must never happen inside the
+        // snapshot lock, and a candidate about to be skipped must not sleep.
+        // The locked re-check below stays authoritative.
+        if (
+          !(await findActiveSnapshotRefreshJob(candidate)) &&
+          !(await hasRecentPendingSnapshotClaim(candidate, new Date()))
+        ) {
+          await paceBeforeNextLaunch();
         }
 
         const lockResult = await withEnvironmentSnapshotLock(
@@ -595,7 +617,7 @@ export const refreshSnapshotsJob = async () => {
         });
 
         refreshed++;
-        await paceAfterLaunch(hasRemainingCandidates);
+        recordLaunch();
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
 

--- a/apps/bullmq/src/scheduled-jobs/refresh-snapshots.ts
+++ b/apps/bullmq/src/scheduled-jobs/refresh-snapshots.ts
@@ -28,6 +28,21 @@ const SNAPSHOT_REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const PENDING_SNAPSHOT_RECOVERY_GRACE_MS = 5 * 60 * 1000;
 const LOG_PREFIX = '[refreshSnapshots]';
 
+/**
+ * Minimum delay between snapshot refresh launches. The compute broker's
+ * per-tenant sandbox-creation budget is a small token bucket (burst 6,
+ * refilling ~6/minute) shared with interactive task launches, so enqueueing
+ * every candidate in one burst can drain the whole budget and rate-limit both
+ * the refresh itself and user-initiated tasks. Spacing background launches
+ * 30s apart caps the refresh at ~2 creations/minute, leaving most of the
+ * budget for interactive load.
+ */
+export const SNAPSHOT_REFRESH_LAUNCH_SPACING_MS = 30_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 interface SnapshotRefreshCandidateBase {
   environmentId: string;
   environmentName: string;
@@ -347,6 +362,7 @@ export const refreshSnapshotsJob = async () => {
 
     logRefreshSnapshots('Found environments due for snapshot maintenance', {
       cutoff: cutoff.toISOString(),
+      launchSpacingMs: SNAPSHOT_REFRESH_LAUNCH_SPACING_MS,
       candidateCount: refreshCandidates.length,
       candidatesByProvider: summarizeCandidatesByProvider(refreshCandidates),
       targetProvider: discovery.targetProvider,
@@ -360,7 +376,18 @@ export const refreshSnapshotsJob = async () => {
     let refreshed = 0;
     let skippedActiveRefreshCount = 0;
     const errors: Array<Record<string, unknown>> = [];
-    for (const candidate of refreshCandidates) {
+    // The controller dequeues each run within seconds of its enqueue, so
+    // spacing the enqueues here is what spaces the sandbox creations at the
+    // broker. Skipped candidates never sleep; the delay only follows an
+    // actual launch with candidates still left to process.
+    const paceAfterLaunch = async (hasRemainingCandidates: boolean) => {
+      if (hasRemainingCandidates) {
+        await sleep(SNAPSHOT_REFRESH_LAUNCH_SPACING_MS);
+      }
+    };
+    for (const [candidateIndex, candidate] of refreshCandidates.entries()) {
+      const hasRemainingCandidates =
+        candidateIndex < refreshCandidates.length - 1;
       const snapshotAgeHours = getSnapshotAgeHours(
         candidate.snapshotCreatedAt,
         startedAt,
@@ -461,6 +488,7 @@ export const refreshSnapshotsJob = async () => {
           });
 
           refreshed++;
+          await paceAfterLaunch(hasRemainingCandidates);
           continue;
         }
 
@@ -567,6 +595,7 @@ export const refreshSnapshotsJob = async () => {
         });
 
         refreshed++;
+        await paceAfterLaunch(hasRemainingCandidates);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
 

--- a/apps/bullmq/src/scheduled-jobs/refresh-snapshots.ts
+++ b/apps/bullmq/src/scheduled-jobs/refresh-snapshots.ts
@@ -437,17 +437,21 @@ export const refreshSnapshotsJob = async () => {
             continue;
           }
 
-          // The skip checks passed, so a launch is imminent: pace it before
-          // claiming, keeping the claim→enqueue window tight.
-          await paceBeforeNextLaunch();
-
+          // Claim first, pace after: the pending claim is the reservation
+          // that keeps concurrent claimants (the admin snapshot command, a
+          // competing cycle) off this environment during the wait, so a lost
+          // claim is always a skip that never slept. The claim is stamped
+          // with the current time rather than job start — pacing stretches
+          // this job over minutes, and a claim carrying an old timestamp
+          // would look stale and be stolen mid-wait.
+          const claimedAt = new Date();
           pendingSnapshotClaim =
             await claimPendingEnvironmentSnapshotForAttachment(db, {
               environmentId: candidate.environmentId,
               provider: candidate.provider,
-              updatedAt: startedAt,
+              updatedAt: claimedAt,
               allowStalePendingBefore: new Date(
-                startedAt.getTime() - PENDING_SNAPSHOT_RECOVERY_GRACE_MS,
+                claimedAt.getTime() - PENDING_SNAPSHOT_RECOVERY_GRACE_MS,
               ),
               requireMissingSnapshot: true,
             });
@@ -455,6 +459,8 @@ export const refreshSnapshotsJob = async () => {
           if (!pendingSnapshotClaim) {
             continue;
           }
+
+          await paceBeforeNextLaunch();
 
           logRefreshSnapshots('Queueing snapshot refresh job', {
             environmentId: candidate.environmentId,
@@ -506,7 +512,11 @@ export const refreshSnapshotsJob = async () => {
         // Lock-free pre-check mirroring the locked skip conditions, used only
         // to decide whether to pace — sleeping must never happen inside the
         // snapshot lock, and a candidate about to be skipped must not sleep.
-        // The locked re-check below stays authoritative.
+        // The locked re-check below stays authoritative. Unlike the missing-
+        // snapshot branch there is no claim primitive to reserve a ready-row
+        // refresh outside the lock, so a state change during the wait can at
+        // worst cost this one delay before the authoritative skip — it can
+        // never double-launch.
         if (
           !(await findActiveSnapshotRefreshJob(candidate)) &&
           !(await hasRecentPendingSnapshotClaim(candidate, new Date()))

--- a/apps/controller/src/BaseController.ts
+++ b/apps/controller/src/BaseController.ts
@@ -5,7 +5,6 @@ import { fileURLToPath } from 'node:url';
 import {
   type ComputeProvider,
   RunStatus,
-  TaskPayloadKind,
   TaskRunErrorCode,
   type TaskRunErrorCode as TaskRunErrorCodeValue,
   resolveComputeProviderTarget,
@@ -20,12 +19,10 @@ import {
   type TaskRun,
   db,
   taskRuns,
-  buildPendingEnvironmentSnapshotMatchForTaskRun,
   readManagedDeploymentAccess,
   recordTaskRunLifecycleEvent,
   resolveDefaultComputeProvider,
   syncTaskStateFromRuns,
-  updatePendingEnvironmentSnapshot,
   eq,
   and,
   asc,
@@ -914,37 +911,13 @@ export abstract class BaseController {
     errorCode?: TaskRunErrorCodeValue,
   ): Promise<void> {
     // Use the centralized termination path so all side-effects (email, Slack,
-    // Linear notifications, lock release, etc.) are applied consistently.
+    // Linear notifications, lock release, snapshot pending→failed, etc.) are
+    // applied consistently.
     await finishRun({
       id: taskRun.id,
       status: RunStatus.Failed,
       error: errorMessage,
       ...(errorCode ? { errorCode } : {}),
     });
-
-    // Snapshot-specific: only fail snapshots that are currently pending.
-    // Scheduled refreshes keep the last ready snapshot in place while the
-    // replacement is being created, so spawn failures must not overwrite it.
-    if (taskRun.payloadKind === TaskPayloadKind.SnapshotEnvironment) {
-      const environmentId = taskRun.payload.environmentId;
-
-      if (environmentId) {
-        const provider = resolveComputeProviderTarget(
-          taskRun.vendor,
-          await resolveDefaultComputeProvider(),
-        );
-        const pendingSnapshotMatch =
-          buildPendingEnvironmentSnapshotMatchForTaskRun(taskRun);
-        await updatePendingEnvironmentSnapshot(db, {
-          environmentId,
-          provider,
-          snapshotId: null,
-          snapshotStatus: 'failed',
-          snapshotCreatedAt: null,
-          snapshotExpiresAt: null,
-          ...pendingSnapshotMatch,
-        });
-      }
-    }
   }
 }

--- a/apps/controller/src/BaseController.ts
+++ b/apps/controller/src/BaseController.ts
@@ -609,13 +609,25 @@ export abstract class BaseController {
   protected async handleWorkerExitBeforeStart(
     taskRun: TaskRun,
     exitCode: number,
+    launchDiagnostics?: string,
   ): Promise<WorkerBootstrapExitDisposition> {
-    if (await this.claimWorkerBootstrapRestart(taskRun, exitCode)) {
+    if (
+      await this.claimWorkerBootstrapRestart(
+        taskRun,
+        exitCode,
+        launchDiagnostics,
+      )
+    ) {
       this.workerBootstrapRestartsAwaitingCleanup.add(taskRun.id);
       return 'restart';
     }
 
-    const errorMessage = `Worker process exited before claiming task run (exit code ${exitCode})`;
+    // Fold any captured launch output (stderr/stdout/probe) into the run's
+    // persisted error: this finalization is the only record the 'failed'
+    // disposition leaves, so a bare exit code here is undiagnosable.
+    const errorMessage = `Worker process exited before claiming task run (exit code ${exitCode})${
+      launchDiagnostics ? `; ${launchDiagnostics}` : ''
+    }`;
     const failed = await this.claimWorkerBootstrapFailure(
       taskRun,
       errorMessage,
@@ -816,6 +828,7 @@ export abstract class BaseController {
   private async claimWorkerBootstrapRestart(
     taskRun: TaskRun,
     exitCode: number,
+    launchDiagnostics?: string,
   ): Promise<boolean> {
     const claimed = await db.transaction(async (tx) => {
       const [lockedRun] = await tx.execute<{ id: number }>(sql`
@@ -875,6 +888,7 @@ export abstract class BaseController {
           provider: taskRun.vendor ?? null,
           previousMachineId: taskRun.machineId ?? null,
           exitCode,
+          launchDiagnostics: launchDiagnostics ?? null,
           restartAttempt: 1,
         },
       });

--- a/apps/controller/src/RoomoteController.ts
+++ b/apps/controller/src/RoomoteController.ts
@@ -159,8 +159,12 @@ export class RoomoteController extends BaseController {
           modalVmMemoryMiB: Env.MODAL_VM_MEMORY_MIB,
           modalTimeoutMs: timeoutMs,
           localTarballPath: this.localWorkerReleasePath,
-          onWorkerExit: ({ exitCode }) =>
-            this.handleWorkerExitBeforeStart(taskRun, exitCode),
+          onWorkerExit: ({ exitCode, launchDiagnostics }) =>
+            this.handleWorkerExitBeforeStart(
+              taskRun,
+              exitCode,
+              launchDiagnostics,
+            ),
           onWorkerRestart: () => this.scheduleWorkerBootstrapRestart(taskRun),
         });
         return;

--- a/apps/controller/src/__tests__/BaseController.test.ts
+++ b/apps/controller/src/__tests__/BaseController.test.ts
@@ -167,8 +167,13 @@ class TestController extends BaseController {
   public async testHandleWorkerExitBeforeStart(
     taskRun: TaskRun,
     exitCode: number,
+    launchDiagnostics?: string,
   ) {
-    return this.handleWorkerExitBeforeStart(taskRun, exitCode);
+    return this.handleWorkerExitBeforeStart(
+      taskRun,
+      exitCode,
+      launchDiagnostics,
+    );
   }
 
   public async testFailTimedOutWorkerBootstraps() {
@@ -697,6 +702,65 @@ describe('BaseController.handleWorkerExitBeforeStart', () => {
       status: RunStatus.Failed,
       error: 'Worker process exited before claiming task run (exit code 1)',
     });
+  });
+
+  it('persists launch diagnostics on the run when the bootstrap failure is finalized', async () => {
+    mockDbExecute
+      .mockResolvedValueOnce([{ id: 42 }])
+      .mockResolvedValueOnce([{ id: 'restart-event' }]);
+
+    await expect(
+      controller.testHandleWorkerExitBeforeStart(
+        makeTaskRun({ id: 42, status: RunStatus.Dequeued }),
+        1,
+        'probe "worker --version" exited with code 1; probe stderr: Error: WORKER_API_URL is required',
+      ),
+    ).resolves.toBe('failed');
+
+    const expectedError =
+      'Worker process exited before claiming task run (exit code 1); ' +
+      'probe "worker --version" exited with code 1; probe stderr: Error: WORKER_API_URL is required';
+
+    // The diagnostics reach both the durable run write and finishRun.
+    expect(mockDbUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: RunStatus.Failed,
+        error: expectedError,
+      }),
+    );
+    expect(mockFinishRun).toHaveBeenCalledWith({
+      id: 42,
+      status: RunStatus.Failed,
+      error: expectedError,
+    });
+  });
+
+  it('records launch diagnostics on the bootstrap restart decision event', async () => {
+    mockDbExecute.mockResolvedValueOnce([{ id: 42 }]).mockResolvedValueOnce([]);
+
+    await expect(
+      controller.testHandleWorkerExitBeforeStart(
+        makeTaskRun({
+          id: 42,
+          status: RunStatus.Dequeued,
+          machineId: 'sandbox-old',
+          startedAt: null,
+          workerHeartbeatAt: null,
+        }),
+        1,
+        'stderr: worker failed before claim',
+      ),
+    ).resolves.toBe('restart');
+
+    expect(mockRecordTaskRunLifecycleEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        details: expect.objectContaining({
+          stage: 'worker_bootstrap_restart',
+          launchDiagnostics: 'stderr: worker failed before claim',
+        }),
+      }),
+    );
   });
 
   it('ignores an exit when the run already advanced', async () => {

--- a/apps/controller/src/__tests__/BaseController.test.ts
+++ b/apps/controller/src/__tests__/BaseController.test.ts
@@ -280,7 +280,7 @@ describe('BaseController.handleSpawnTaskRunError', () => {
     });
   });
 
-  it('marks pending snapshots as failed when job is SnapshotEnvironment', async () => {
+  it('routes SnapshotEnvironment spawn failures through finishRun, which owns the snapshot pending→failed flip', async () => {
     const attachmentSource = {
       source: 'pending_snapshot_row' as const,
       environmentSnapshotId: '80e3ceee-7d21-491a-96d8-7b0c72b90b4e',
@@ -308,19 +308,9 @@ describe('BaseController.handleSpawnTaskRunError', () => {
       error: 'Snapshot failed',
     });
 
-    expect(mockUpdatePendingEnvironmentSnapshot).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        environmentId: 'env-123',
-        provider: 'modal',
-        snapshotId: null,
-        snapshotStatus: 'failed',
-        snapshotCreatedAt: null,
-        snapshotExpiresAt: null,
-        attachmentSource,
-        maxPendingUpdatedAt: null,
-      }),
-    );
+    // The environment_snapshots pending→failed transition lives inside
+    // finishRun (covered by finish-run.test.ts), not in the controller.
+    expect(mockUpdatePendingEnvironmentSnapshot).not.toHaveBeenCalled();
   });
 
   it('re-throws a sanitized error after calling finishRun (no token-bearing cause)', async () => {

--- a/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
+++ b/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
@@ -316,7 +316,10 @@ describe('spawnModalWorker', () => {
           exitCode: 17,
           stderr: 'Unauthorized',
           stdout: 'booting worker',
-          error: 'Detached "worker run" exited immediately with code 17',
+          // The captured output is folded into the error message so the
+          // failure is diagnosable from controller logs alone.
+          error:
+            'Detached "worker run" exited immediately with code 17; stderr: Unauthorized; stdout: booting worker',
         }),
       }),
     );
@@ -411,6 +414,79 @@ describe('spawnModalWorker', () => {
         phase: 'spawn_worker',
       }),
     );
+  });
+
+  it('probes the sandbox for diagnostics when an immediate detached exit captured no output', async () => {
+    mockRunCommand
+      // Detached launch: dies instantly and Modal delivers no output.
+      .mockResolvedValueOnce({ exitCode: 1, commandId: undefined })
+      // Non-detached probe: reproduces the startup crash with real stderr.
+      .mockResolvedValueOnce({
+        exitCode: 1,
+        stderr: 'Error: WORKER_API_URL is required\n',
+      });
+
+    await expect(
+      spawnModalWorker(
+        mockTaskRun({
+          payloadKind: TaskPayloadKind.SnapshotEnvironment,
+          payload: { repo: '', environmentId: 'env_1' },
+        }),
+        'auth_token',
+        {
+          deploymentSlug: 'roomote',
+          modalTokenId: 'token-id',
+          modalTokenSecret: 'token-secret',
+          modalBaseImageRef: 'ghcr.io/roomote/modal-worker:test',
+          modalVmMemoryMiB: 8192,
+          modalTimeoutMs: 60_000,
+        },
+      ),
+    ).rejects.toThrow(
+      'Detached "worker snapshot" exited immediately with code 1; ' +
+        'probe "worker --version" exited with code 1; ' +
+        'probe stderr: Error: WORKER_API_URL is required',
+    );
+
+    expect(mockRunCommand).toHaveBeenCalledTimes(2);
+    expect(mockRunCommand).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        instanceId: 'modal-machine-123',
+        cmd: 'worker',
+        args: ['--version'],
+      }),
+    );
+  });
+
+  it('skips the diagnostic probe when the immediate exit already captured output', async () => {
+    mockRunCommand.mockResolvedValue({
+      exitCode: 1,
+      commandId: undefined,
+      stderr: 'worker failed before claim\n',
+    });
+
+    await expect(
+      spawnModalWorker(
+        mockTaskRun({
+          payloadKind: TaskPayloadKind.StandardTask,
+          payload: { repo: 'test/repo', environmentId: 'env_1' },
+        }),
+        'auth_token',
+        {
+          deploymentSlug: 'roomote',
+          modalTokenId: 'token-id',
+          modalTokenSecret: 'token-secret',
+          modalBaseImageRef: 'ghcr.io/roomote/modal-worker:test',
+          modalVmMemoryMiB: 8192,
+          modalTimeoutMs: 60_000,
+        },
+      ),
+    ).rejects.toThrow(
+      'Detached "worker run" exited immediately with code 1; stderr: worker failed before claim',
+    );
+
+    // Only the detached launch itself — no probe.
+    expect(mockRunCommand).toHaveBeenCalledTimes(1);
   });
 
   it('restarts when an immediate detached exit is claimed as the first bootstrap failure', async () => {

--- a/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
+++ b/apps/controller/src/compute-providers/__tests__/spawn-modal-worker.test.ts
@@ -518,7 +518,10 @@ describe('spawnModalWorker', () => {
       ),
     ).resolves.toEqual({ machineId: 'modal-machine-123' });
 
-    expect(onWorkerExit).toHaveBeenCalledWith({ exitCode: 1 });
+    expect(onWorkerExit).toHaveBeenCalledWith({
+      exitCode: 1,
+      launchDiagnostics: 'stderr: worker failed before claim',
+    });
     expect(mockCleanupModalInstance).toHaveBeenCalledWith(
       expect.objectContaining({
         instanceId: 'modal-machine-123',
@@ -526,6 +529,46 @@ describe('spawnModalWorker', () => {
       }),
     );
     expect(onWorkerRestart).toHaveBeenCalledOnce();
+  });
+
+  it('passes probe diagnostics to the exit classifier when a silent immediate exit is finalized as failed', async () => {
+    const onWorkerExit = vi.fn().mockResolvedValue('failed');
+    mockRunCommand
+      // Detached launch: dies instantly with no output.
+      .mockResolvedValueOnce({ exitCode: 1, commandId: undefined })
+      // Non-detached probe reproduces the crash.
+      .mockResolvedValueOnce({
+        exitCode: 1,
+        stderr: 'Error: WORKER_API_URL is required\n',
+      });
+
+    // The classifier owns finalization on 'failed', so the spawn itself
+    // resolves instead of rethrowing.
+    await expect(
+      spawnModalWorker(
+        mockTaskRun({
+          payloadKind: TaskPayloadKind.SnapshotEnvironment,
+          payload: { repo: '', environmentId: 'env_1' },
+        }),
+        'auth_token',
+        {
+          deploymentSlug: 'roomote',
+          modalTokenId: 'token-id',
+          modalTokenSecret: 'token-secret',
+          modalBaseImageRef: 'ghcr.io/roomote/modal-worker:test',
+          modalVmMemoryMiB: 8192,
+          modalTimeoutMs: 60_000,
+          onWorkerExit,
+        },
+      ),
+    ).resolves.toEqual({ machineId: 'modal-machine-123' });
+
+    expect(onWorkerExit).toHaveBeenCalledWith({
+      exitCode: 1,
+      launchDiagnostics:
+        'probe "worker --version" exited with code 1; ' +
+        'probe stderr: Error: WORKER_API_URL is required',
+    });
   });
 
   it('cleans up when a later detached exit is claimed as a bootstrap failure', async () => {

--- a/apps/controller/src/compute-providers/spawn-modal-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-modal-worker.ts
@@ -65,6 +65,27 @@ function truncateLaunchOutput(value: string | undefined): string | undefined {
     : trimmed;
 }
 
+/**
+ * Everything captured about a dead launch — stderr, stdout, and any probe
+ * output — as a single string, or undefined when nothing was captured. This
+ * is what makes the failure actionable, so it travels both in the thrown
+ * error and through onWorkerExit into the bootstrap-failure run error.
+ */
+function buildLaunchOutputSummary(
+  result: { stdout?: string; stderr?: string },
+  probeDiagnostics?: string,
+): string | undefined {
+  const stdout = truncateLaunchOutput(result.stdout);
+  const stderr = truncateLaunchOutput(result.stderr);
+  const parts = [
+    ...(stderr ? [`stderr: ${stderr}`] : []),
+    ...(stdout ? [`stdout: ${stdout}`] : []),
+    ...(probeDiagnostics ? [probeDiagnostics] : []),
+  ];
+
+  return parts.length > 0 ? parts.join('; ') : undefined;
+}
+
 function buildDetachedWorkerExitError(
   command: string,
   result: {
@@ -73,32 +94,21 @@ function buildDetachedWorkerExitError(
     stdout?: string;
     stderr?: string;
   },
-  launchDiagnostics?: string,
+  probeDiagnostics?: string,
 ): DetachedWorkerLaunchError {
   const stdout = truncateLaunchOutput(result.stdout);
   const stderr = truncateLaunchOutput(result.stderr);
-  const parts = [
-    `Detached "worker ${command}" exited immediately with code ${result.exitCode}`,
-  ];
+  const summary = buildLaunchOutputSummary(result, probeDiagnostics);
+  const message = `Detached "worker ${command}" exited immediately with code ${result.exitCode}${
+    summary ? `; ${summary}` : ''
+  }`;
 
-  if (stderr) {
-    parts.push(`stderr: ${stderr}`);
-  }
-
-  if (stdout) {
-    parts.push(`stdout: ${stdout}`);
-  }
-
-  if (launchDiagnostics) {
-    parts.push(launchDiagnostics);
-  }
-
-  return new DetachedWorkerLaunchError(parts.join('; '), {
+  return new DetachedWorkerLaunchError(message, {
     commandId: result.commandId ?? null,
     exitCode: result.exitCode,
     ...(stdout ? { stdout } : {}),
     ...(stderr ? { stderr } : {}),
-    ...(launchDiagnostics ? { launchDiagnostics } : {}),
+    ...(probeDiagnostics ? { launchDiagnostics: probeDiagnostics } : {}),
   });
 }
 
@@ -200,10 +210,14 @@ export async function spawnModalWorker(
     modalTags?: Record<string, string>;
     /**
      * Classifies a post-launch exit so the provider can clean up before an
-     * optional fresh launch is scheduled.
+     * optional fresh launch is scheduled. Grace-period exits pass everything
+     * captured about the dead launch (stderr/stdout/probe output) as
+     * `launchDiagnostics` so the bootstrap-failure finalization can persist
+     * it on the run instead of a bare exit code.
      */
     onWorkerExit?: (event: {
       exitCode: number;
+      launchDiagnostics?: string;
     }) => Promise<'ignore' | 'restart' | 'failed'>;
     onWorkerRestart?: () => void;
   },
@@ -547,7 +561,7 @@ export async function spawnModalWorker(
     if (result.exitCode !== null) {
       // Without any captured output the exit is undiagnosable from logs, so
       // probe the still-alive sandbox before classification/cleanup.
-      const launchDiagnostics =
+      const probeDiagnostics =
         truncateLaunchOutput(result.stdout) ||
         truncateLaunchOutput(result.stderr)
           ? undefined
@@ -555,14 +569,24 @@ export async function spawnModalWorker(
               computeClient,
               machine.machineId,
             );
+      const launchDiagnostics = buildLaunchOutputSummary(
+        result,
+        probeDiagnostics,
+      );
       const exitError = buildDetachedWorkerExitError(
         command,
         result,
-        launchDiagnostics,
+        probeDiagnostics,
       );
 
       if (onWorkerExit) {
-        const disposition = await onWorkerExit({ exitCode: result.exitCode });
+        // The classifier finalizes the run itself on the 'failed' disposition
+        // (this spawn then returns without rethrowing), so the diagnostics
+        // must travel with the exit event to reach the run's error.
+        const disposition = await onWorkerExit({
+          exitCode: result.exitCode,
+          ...(launchDiagnostics ? { launchDiagnostics } : {}),
+        });
 
         if (disposition !== 'ignore') {
           immediateExitDisposition = disposition;

--- a/apps/controller/src/compute-providers/spawn-modal-worker.ts
+++ b/apps/controller/src/compute-providers/spawn-modal-worker.ts
@@ -13,6 +13,7 @@ import {
 } from '@roomote/db/server';
 import { stampTaskRunMilestone } from '@roomote/sdk/server';
 import {
+  type ComputeProviderClient,
   buildComputeProviderMutationDetails,
   buildModalWorkerEnv,
   cleanupModalInstance,
@@ -37,6 +38,7 @@ import {
 } from './timeouts';
 
 const MODAL_LAUNCH_OUTPUT_TEXT_LIMIT = 500;
+const LAUNCH_DIAGNOSTIC_PROBE_TIMEOUT_MS = 15_000;
 
 class DetachedWorkerLaunchError extends Error {
   public readonly details: Record<string, unknown>;
@@ -71,11 +73,13 @@ function buildDetachedWorkerExitError(
     stdout?: string;
     stderr?: string;
   },
+  launchDiagnostics?: string,
 ): DetachedWorkerLaunchError {
   const stdout = truncateLaunchOutput(result.stdout);
   const stderr = truncateLaunchOutput(result.stderr);
-  const message = `Detached "worker ${command}" exited immediately with code ${result.exitCode}`;
-  const parts = [message];
+  const parts = [
+    `Detached "worker ${command}" exited immediately with code ${result.exitCode}`,
+  ];
 
   if (stderr) {
     parts.push(`stderr: ${stderr}`);
@@ -85,12 +89,52 @@ function buildDetachedWorkerExitError(
     parts.push(`stdout: ${stdout}`);
   }
 
-  return new DetachedWorkerLaunchError(message, {
+  if (launchDiagnostics) {
+    parts.push(launchDiagnostics);
+  }
+
+  return new DetachedWorkerLaunchError(parts.join('; '), {
     commandId: result.commandId ?? null,
     exitCode: result.exitCode,
     ...(stdout ? { stdout } : {}),
     ...(stderr ? { stderr } : {}),
+    ...(launchDiagnostics ? { launchDiagnostics } : {}),
   });
+}
+
+/**
+ * Modal regularly loses the output of a detached process that dies within the
+ * launch grace window, leaving "exited immediately with code N" with no
+ * stderr to act on. A non-detached `worker --version` in the same sandbox
+ * reproduces any crash that happens before the CLI dispatches a command
+ * (module-level env validation, a broken bundle, a missing runtime
+ * dependency) and its output streams back reliably. The probe parses no
+ * command, so it cannot claim the task run or mutate anything.
+ */
+async function captureWorkerLaunchDiagnostics(
+  computeClient: ComputeProviderClient,
+  instanceId: string,
+): Promise<string> {
+  try {
+    const probe = await computeClient.runCommand({
+      instanceId,
+      cmd: 'worker',
+      args: ['--version'],
+      signal: AbortSignal.timeout(LAUNCH_DIAGNOSTIC_PROBE_TIMEOUT_MS),
+    });
+    const probeStderr = truncateLaunchOutput(probe.stderr);
+    const probeStdout = truncateLaunchOutput(probe.stdout);
+
+    return [
+      `probe "worker --version" exited with code ${probe.exitCode}`,
+      ...(probeStderr ? [`probe stderr: ${probeStderr}`] : []),
+      ...(probeStdout ? [`probe stdout: ${probeStdout}`] : []),
+    ].join('; ');
+  } catch (error) {
+    return `probe "worker --version" failed: ${
+      error instanceof Error ? error.message : String(error)
+    }`;
+  }
 }
 
 function getWorkerLaunchCommand(
@@ -501,7 +545,21 @@ export async function spawnModalWorker(
     // grace-period exits through the same classifier as later exits so the
     // first bootstrap failure gets its one durable replacement.
     if (result.exitCode !== null) {
-      const exitError = buildDetachedWorkerExitError(command, result);
+      // Without any captured output the exit is undiagnosable from logs, so
+      // probe the still-alive sandbox before classification/cleanup.
+      const launchDiagnostics =
+        truncateLaunchOutput(result.stdout) ||
+        truncateLaunchOutput(result.stderr)
+          ? undefined
+          : await captureWorkerLaunchDiagnostics(
+              computeClient,
+              machine.machineId,
+            );
+      const exitError = buildDetachedWorkerExitError(
+        command,
+        result,
+        launchDiagnostics,
+      );
 
       if (onWorkerExit) {
         const disposition = await onWorkerExit({ exitCode: result.exitCode });

--- a/packages/sdk/src/server/lib/task-runs/__tests__/finish-run.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/finish-run.test.ts
@@ -24,6 +24,8 @@ const mockDiscordPostMessage = vi.fn();
 const mockNotifySourceRunOnSettle = vi.fn().mockResolvedValue(undefined);
 const mockDbTransaction = vi.fn();
 const mockCaptureTaskSettled = vi.fn();
+const mockResolveDefaultComputeProvider = vi.fn().mockResolvedValue('modal');
+const mockUpdatePendingEnvironmentSnapshot = vi.fn().mockResolvedValue(true);
 
 /**
  * Rows resolved by db.select() chains that join tasks with task_runs (the
@@ -146,8 +148,12 @@ vi.mock('@roomote/db/server', async () => {
     },
     recordTaskRunLifecycleEvent: (...args: unknown[]) =>
       mockRecordTaskRunLifecycleEvent(...args),
+    resolveDefaultComputeProvider: (...args: unknown[]) =>
+      mockResolveDefaultComputeProvider(...args),
     resolveDiscordRuntimeCredentials: (...args: unknown[]) =>
       mockResolveDiscordRuntimeCredentials(...args),
+    updatePendingEnvironmentSnapshot: (...args: unknown[]) =>
+      mockUpdatePendingEnvironmentSnapshot(...args),
   };
 });
 
@@ -376,6 +382,8 @@ describe('finishRun', () => {
     mockRedisDel.mockResolvedValue(1);
     mockUpdateMessage.mockResolvedValue(true);
     mockDbExecute.mockResolvedValue([]);
+    mockResolveDefaultComputeProvider.mockResolvedValue('modal');
+    mockUpdatePendingEnvironmentSnapshot.mockResolvedValue(true);
     syncRunRows = [];
     mockDbTransaction.mockImplementation(
       async (callback: (tx: unknown) => unknown) =>
@@ -701,6 +709,142 @@ describe('finishRun', () => {
         }),
       }),
     );
+  });
+
+  describe('environment snapshot failure state', () => {
+    const attachmentSource = {
+      source: 'pending_snapshot_row' as const,
+      environmentSnapshotId: '80e3ceee-7d21-491a-96d8-7b0c72b90b4e',
+      claimedAt: '2026-05-29T00:00:00.000Z',
+    };
+
+    function makeSnapshotRun(overrides: Partial<TaskRun> = {}) {
+      return makeRun({
+        id: 55,
+        payloadKind: TaskPayloadKind.SnapshotEnvironment,
+        vendor: 'modal',
+        payload: {
+          repo: '',
+          environmentId: 'env-123',
+          environmentSnapshotAttachment: attachmentSource,
+        },
+        ...overrides,
+      });
+    }
+
+    it('flips the pending environment snapshot row to failed when the run fails', async () => {
+      mockFindFirstRun.mockResolvedValue(makeSnapshotRun());
+
+      await finishRun({
+        id: 55,
+        status: RunStatus.Failed,
+        error: 'Detached "worker snapshot" exited immediately with code 1',
+      });
+
+      expect(mockUpdatePendingEnvironmentSnapshot).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          environmentId: 'env-123',
+          provider: 'modal',
+          snapshotId: null,
+          snapshotStatus: 'failed',
+          snapshotCreatedAt: null,
+          snapshotExpiresAt: null,
+          attachmentSource,
+          maxPendingUpdatedAt: null,
+        }),
+      );
+    });
+
+    it('flips the pending row to failed when the run is canceled', async () => {
+      mockFindFirstRun.mockResolvedValue(makeSnapshotRun());
+
+      await finishRun({ id: 55, status: RunStatus.Canceled });
+
+      expect(mockUpdatePendingEnvironmentSnapshot).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ snapshotStatus: 'failed' }),
+      );
+    });
+
+    it('flips the pending row when a stop request normalizes the failure to canceled', async () => {
+      mockFindFirstRun.mockResolvedValue(
+        makeSnapshotRun({ cancelRequestedAt: new Date() }),
+      );
+
+      await finishRun({
+        id: 55,
+        status: RunStatus.Failed,
+        error: 'sandbox died during stop',
+      });
+
+      expect(mockUpdatePendingEnvironmentSnapshot).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ snapshotStatus: 'failed' }),
+      );
+    });
+
+    it('bounds legacy payloads without an attachment by the run creation time', async () => {
+      const createdAt = new Date('2026-08-13T15:57:00.000Z');
+      mockFindFirstRun.mockResolvedValue(
+        makeSnapshotRun({
+          createdAt,
+          payload: { repo: '', environmentId: 'env-123' },
+        }),
+      );
+
+      await finishRun({ id: 55, status: RunStatus.Failed, error: 'boom' });
+
+      expect(mockUpdatePendingEnvironmentSnapshot).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          attachmentSource: null,
+          maxPendingUpdatedAt: createdAt,
+        }),
+      );
+    });
+
+    it('does not touch the snapshot row when the run completes', async () => {
+      mockFindFirstRun.mockResolvedValue(makeSnapshotRun());
+
+      await finishRun({ id: 55, status: RunStatus.Completed });
+
+      expect(mockUpdatePendingEnvironmentSnapshot).not.toHaveBeenCalled();
+    });
+
+    it('does not touch the snapshot row for non-snapshot runs', async () => {
+      mockFindFirstRun.mockResolvedValue(makeRun());
+
+      await finishRun({ id: 1, status: RunStatus.Failed, error: 'boom' });
+
+      expect(mockUpdatePendingEnvironmentSnapshot).not.toHaveBeenCalled();
+    });
+
+    it('skips the flip when the payload has no environmentId', async () => {
+      mockFindFirstRun.mockResolvedValue(
+        makeSnapshotRun({ payload: { repo: '' } }),
+      );
+
+      await finishRun({ id: 55, status: RunStatus.Failed, error: 'boom' });
+
+      expect(mockUpdatePendingEnvironmentSnapshot).not.toHaveBeenCalled();
+    });
+
+    it('still finishes the run when recording the snapshot failure state throws', async () => {
+      mockFindFirstRun.mockResolvedValue(makeSnapshotRun());
+      mockUpdatePendingEnvironmentSnapshot.mockRejectedValue(
+        new Error('db unavailable'),
+      );
+
+      await expect(
+        finishRun({ id: 55, status: RunStatus.Failed, error: 'boom' }),
+      ).resolves.toBeUndefined();
+
+      // The terminal run write still happened.
+      expect(mockDbUpdateSet).toHaveBeenCalledWith(
+        expect.objectContaining({ status: RunStatus.Failed }),
+      );
+    });
   });
 
   describe('Slack completion handling', () => {

--- a/packages/sdk/src/server/lib/task-runs/finish-run.ts
+++ b/packages/sdk/src/server/lib/task-runs/finish-run.ts
@@ -8,6 +8,7 @@ import {
   getCommunicationThreadIdFromTaskPayload,
   getEnvironmentDefinitionIdFromPayload,
   parseConflictResolutionSummary,
+  resolveComputeProviderTarget,
   stripRunErrorMarkers,
   type TaskRunErrorCode,
 } from '@roomote/types';
@@ -23,15 +24,18 @@ import {
   type TaskRun,
   type Task,
   type TaskPullRequest,
+  buildPendingEnvironmentSnapshotMatchForTaskRun,
   db,
   taskRuns,
   taskPullRequests,
   deploymentSettings,
   markTaskStartParallelCountEndedAt,
   recordTaskRunLifecycleEvent,
+  resolveDefaultComputeProvider,
   slackInstallations,
   slackUserMappings,
   syncTaskStateFromRuns,
+  updatePendingEnvironmentSnapshot,
   asc,
   eq,
   and,
@@ -241,6 +245,28 @@ export const finishRun = async ({
     });
   });
 
+  // Truthful snapshot state: a snapshot refresh that dies on any terminal
+  // path — spawn failure, worker crash before claiming, watchdog cleanup,
+  // user stop — must not leave the environment_snapshots row 'pending' (the
+  // settings UI renders pending as "Snapshotting…" until the next daily
+  // cycle). The guarded update only matches rows still pending for this run's
+  // claim, so a ready row (the last known-good snapshot a refresh
+  // deliberately preserves) is never overwritten.
+  if (
+    payloadKind === TaskPayloadKind.SnapshotEnvironment &&
+    (status === RunStatus.Failed || status === RunStatus.Canceled)
+  ) {
+    try {
+      await failPendingEnvironmentSnapshotForRun(run);
+    } catch (err) {
+      console.error(
+        `[finishRun] Failed to record environment snapshot failure for run ${id}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+
   // Deterministic spawned-task feedback: when this run was launched by
   // another task's run with notify-on-settle requested, deliver the outcome
   // into that launching run's session (waking it if idle) so the parent
@@ -449,6 +475,38 @@ export const finishRun = async ({
     }
   }
 };
+
+/**
+ * Flip this snapshot run's environment_snapshots row from 'pending' to
+ * 'failed'. The match built from the run's payload attachment (or, for legacy
+ * payloads, the run's createdAt upper bound) keeps the update scoped to the
+ * claim this run owned: a row that already advanced — re-claimed by a newer
+ * refresh, or 'ready' from a preserved last known-good snapshot — no-ops.
+ */
+async function failPendingEnvironmentSnapshotForRun(
+  run: FinishedRun,
+): Promise<void> {
+  const environmentId = run.payload.environmentId;
+
+  if (!environmentId) {
+    return;
+  }
+
+  const provider = resolveComputeProviderTarget(
+    run.vendor,
+    await resolveDefaultComputeProvider(),
+  );
+
+  await updatePendingEnvironmentSnapshot(db, {
+    environmentId,
+    provider,
+    snapshotId: null,
+    snapshotStatus: 'failed',
+    snapshotCreatedAt: null,
+    snapshotExpiresAt: null,
+    ...buildPendingEnvironmentSnapshotMatchForTaskRun(run),
+  });
+}
 
 /**
  * Returns the task's PR rows ordered by detection time. For PR-triggered


### PR DESCRIPTION
## Problem

Production evidence (roo tenant, 2026-08-13 15:57 UTC, runs #5032–#5037): the daily RefreshSnapshots job enqueued six `snapshot_environment` runs in the same second. Two got sandboxes whose detached `worker snapshot` process exited code 1 instantly; the rest (plus retries) tripped the compute broker's per-tenant sandbox-creation rate limit within 10 seconds. The affected `environment_snapshots` rows then stayed `pending` for up to 24 hours, rendering as a spinning "Snapshotting…" badge the whole time.

## Changes

**1. Truthful failure state — flip `pending` → `failed` from the centralized terminal path**

The transition only lived in the controller's `finishFailedTaskRun` wrapper, so any terminal path that calls `finishRun` directly (the worker's finish mutation, sleep-check watchdogs, stop-normalized cancellations) left the row `pending` forever. The transition now lives inside `finishRun` itself, firing on Failed and Canceled outcomes, and the controller-local copy is removed. The guarded update is unchanged: it only matches rows still pending for this run's claim, so a preserved last-known-good `ready` snapshot is never overwritten.

**2. Pace refresh launches — respect the broker's creation budget**

The broker's per-tenant creation budget is a token bucket of burst 6, refilling ~6/minute, shared with interactive task launches — one refresh burst drains it entirely. The refresh job now sleeps 30s after each successful launch (`SNAPSHOT_REFRESH_LAUNCH_SPACING_MS`), capping background refreshes at ~2 creations/minute and leaving the rest of the budget for interactive load. Skipped candidates never pay the delay, and the sleep sits outside the advisory-lock transaction.

**3. Diagnosable silent launch deaths**

Modal regularly loses the output of a detached process that dies within the 1s launch grace window, and the broker exec stream is not at fault (it orders output before exit). On an immediate exit with no captured output, the controller now runs a non-detached `worker --version` probe in the still-alive sandbox before cleanup — it reproduces any pre-dispatch crash (module-level env validation, broken bundle, missing runtime dependency) with reliable output and cannot claim the run. Captured stderr/stdout and probe output are folded into the run error message (previously collected but dropped), so the next occurrence is diagnosable from Railway logs and `task_run_events` alone.

## Not in scope

- Root cause of the `worker snapshot` instant exit-1 on worker-vmain-11ac3c86 — needs the probe output from the next occurrence. Lead: snapshot runs launch with `launchMode: 'fresh'` (base image + bootstrap) while normal runs launch from cached environment snapshots, so a broken fresh-bootstrap path selectively kills snapshot workers.
- Task-sleep snapshots (SnapshotQueue) are untouched.

## Testing

- 8 new `finishRun` tests: failed/canceled/stop-normalized flips, ready-row preservation, legacy-payload bound, no-op on completion/non-snapshot runs, flip error doesn't break finalization.
- 3 new refresh pacing tests (fake timers): spacing interval, no trailing sleep, no sleep on skipped candidates.
- 2 new spawn tests: probe fires only on silent immediate exits, probe output lands in the error.
- Full suites pass: sdk 921, controller 169, bullmq 168; `tsc --noEmit` clean in all three.