### PR TITLE
[Fix] Normalize nullable array MCP schemas for Gemini

### DIFF
--- a/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/integration-mcp.test.ts
@@ -452,4 +452,78 @@ describe('createIntegrationMcpProxy acting-user scoping', () => {
       type: 'string',
     });
   });
+
+  it('normalizes simple nullable array tool input schemas', async () => {
+    mockFindTaskRun.mockResolvedValue({ id: 42, actingUserId: null });
+    mockFindConnection.mockResolvedValue({ id: 'conn-1', userId: null });
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          result: {
+            tools: [
+              {
+                name: 'search_issues',
+                inputSchema: {
+                  type: 'object',
+                  properties: {
+                    tags: {
+                      type: ['null', 'array'],
+                      items: { type: 'string' },
+                      description: 'Tags to filter by',
+                    },
+                    constrained: {
+                      type: ['array', 'null'],
+                      items: { type: 'string' },
+                      minItems: 1,
+                    },
+                  },
+                },
+                outputSchema: {
+                  type: ['array', 'null'],
+                  items: { type: 'string' },
+                },
+              },
+            ],
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await postMcp(
+      createApp('pylon', createRunToken()),
+      createToolsListRequest(1),
+    );
+    const body = (await response.json()) as {
+      result: {
+        tools: Array<{
+          inputSchema: { properties: Record<string, unknown> };
+          outputSchema: Record<string, unknown>;
+        }>;
+      };
+    };
+
+    const tool = body.result.tools[0];
+    expect(response.status).toBe(200);
+    expect(tool?.inputSchema.properties.tags).toEqual({
+      description: 'Tags to filter by',
+      anyOf: [{ type: 'array', items: { type: 'string' } }, { type: 'null' }],
+    });
+    expect(tool?.inputSchema.properties.constrained).toEqual({
+      type: ['array', 'null'],
+      items: { type: 'string' },
+      minItems: 1,
+    });
+    expect(tool?.outputSchema).toEqual({
+      type: ['array', 'null'],
+      items: { type: 'string' },
+    });
+  });
 });

--- a/apps/api/src/handlers/mcp/proxy-utils.ts
+++ b/apps/api/src/handlers/mcp/proxy-utils.ts
@@ -409,6 +409,75 @@ function stripToolSchemaPatterns(value: unknown): unknown {
   );
 }
 
+const NULLABLE_ARRAY_SCHEMA_KEYS = new Set([
+  'type',
+  'items',
+  'description',
+  'title',
+  'default',
+  'examples',
+  'deprecated',
+  'readOnly',
+  'writeOnly',
+]);
+
+/**
+ * OpenCode's Gemini schema conversion splits `type: ["array", "null"]`
+ * into `anyOf` branches but leaves `items` on the wrapper. Gemini then rejects
+ * the array branch because it has no item schema. Rewrite only that simple,
+ * semantics-preserving shape and leave more complex schemas untouched.
+ */
+function normalizeNullableArraySchema(value: unknown): unknown {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return value;
+  }
+
+  const schema = { ...(value as Record<string, unknown>) };
+
+  if (
+    schema.properties &&
+    typeof schema.properties === 'object' &&
+    !Array.isArray(schema.properties)
+  ) {
+    schema.properties = Object.fromEntries(
+      Object.entries(schema.properties).map(([name, propertySchema]) => [
+        name,
+        normalizeNullableArraySchema(propertySchema),
+      ]),
+    );
+  }
+
+  if ('items' in schema) {
+    schema.items = Array.isArray(schema.items)
+      ? schema.items.map(normalizeNullableArraySchema)
+      : normalizeNullableArraySchema(schema.items);
+  }
+
+  const types = schema.type;
+  const isNullableArray =
+    Array.isArray(types) &&
+    types.length === 2 &&
+    types.includes('array') &&
+    types.includes('null');
+  const hasOnlyUnderstoodKeys = Object.keys(schema).every((key) =>
+    NULLABLE_ARRAY_SCHEMA_KEYS.has(key),
+  );
+
+  if (
+    !isNullableArray ||
+    schema.items === undefined ||
+    !hasOnlyUnderstoodKeys
+  ) {
+    return schema;
+  }
+
+  const { type: _type, items, ...annotations } = schema;
+  return {
+    ...annotations,
+    anyOf: [{ type: 'array', items }, { type: 'null' }],
+  };
+}
+
 function filterToolsListPayload(
   payload: unknown,
   toolPolicy: {
@@ -446,7 +515,15 @@ function filterToolsListPayload(
       ),
   );
 
-  const filteredTools = filterMcpToolDefinitions(namedTools, toolPolicy);
+  const filteredTools = filterMcpToolDefinitions(namedTools, toolPolicy).map(
+    (tool) =>
+      'inputSchema' in tool
+        ? {
+            ...tool,
+            inputSchema: normalizeNullableArraySchema(tool.inputSchema),
+          }
+        : tool,
+  );
 
   return {
     ...payload,
@@ -982,7 +1059,9 @@ export function createMcpProxy(config: McpProxyConfig) {
       }
 
       if (
-        (hasToolRestrictions || shouldStripToolSchemaPatterns) &&
+        (hasToolRestrictions ||
+          shouldStripToolSchemaPatterns ||
+          isJsonResponse(contentType)) &&
         method === 'POST' &&
         getJsonRpcMethod(parsedBody) === 'tools/list' &&
         upstreamResponse.ok
@@ -1007,6 +1086,8 @@ export function createMcpProxy(config: McpProxyConfig) {
           );
           const headers = buildProxyResponseHeaders(upstreamResponse.headers);
           headers.set('content-type', 'application/json');
+
+          upstreamResponse.body?.cancel().catch(() => {});
 
           return new Response(JSON.stringify(filteredPayload), {
             status: upstreamResponse.status,


### PR DESCRIPTION
## What changed

- Rewrite simple MCP tool input schemas shaped as `type: ["array", "null"]` with declared `items` into equivalent `anyOf` branches.
- Apply the compatibility rewrite to successful JSON `tools/list` responses across MCP integrations.
- Leave complex schemas, schemas without `items`, and tool output schemas unchanged.

## Why

OpenCode's Gemini schema conversion splits nullable array types into `anyOf` branches while leaving `items` on the wrapper. Gemini rejects the resulting array branch because it has no item schema, causing the entire task turn to fail when an affected MCP integration is enabled.

This keeps the workaround deliberately narrow: it fixes the known provider incompatibility without introducing a general JSON Schema normalization layer or changing SSE transport behavior.

## Impact

Gemini-backed tasks can load MCP tools that use ordinary nullable arrays. Other schema shapes retain the upstream MCP server's contract.

## Validation

- `pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/api exec vitest run src/handlers/mcp/__tests__/integration-mcp.test.ts` (11 tests passed; the worktree has no `.env.test`, and this test is fully mocked)
- `pnpm --filter @roomote/api check-types`
- Changed-file ESLint, oxlint, and oxfmt checks

The package-wide API ESLint command still reports the unrelated pre-existing unused-disable warning in `apps/api/src/handlers/github/__tests__/notifyPullRequestTerminalStatus.test.ts`.
