### PR TITLE
[Fix] Deliver fallback after closeout reminder exhaustion

### DIFF
--- a/apps/worker/src/run-task/__tests__/missing-chat-closeout-fallback-delivery.test.ts
+++ b/apps/worker/src/run-task/__tests__/missing-chat-closeout-fallback-delivery.test.ts
@@ -1,0 +1,139 @@
+const { claimDelivery, releaseDelivery, replyToChatThread } = vi.hoisted(
+  () => ({
+    claimDelivery: vi.fn(),
+    releaseDelivery: vi.fn(),
+    replyToChatThread: vi.fn(),
+  }),
+);
+
+vi.mock('@roomote/sdk/client', () => ({
+  sdk: {
+    taskRuns: {
+      claimMissingChatCloseoutFallbackDelivery: claimDelivery,
+      releaseMissingChatCloseoutFallbackDelivery: releaseDelivery,
+    },
+  },
+}));
+
+vi.mock('../../mcp/roomote-mcp-server/chat-api-client', () => ({
+  replyToChatThread,
+}));
+
+import {
+  deliverMissingChatCloseoutFallback,
+  EMPTY_CHAT_CLOSEOUT_FALLBACK_TEXT,
+} from '../missing-chat-closeout-fallback-delivery';
+
+const logger = {
+  runId: 42,
+  filePath: '/tmp/test.log',
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  log: vi.fn(),
+};
+
+const mcpTaskEnv = {
+  ROOMOTE_CLOUD_TOKEN: 'token',
+  ROOMOTE_PLATFORM_API_URL: 'https://platform.example.com/',
+  ROOMOTE_COMMUNICATION_PROVIDER: 'discord',
+  ROOMOTE_COMMUNICATION_CHANNEL_ID: 'channel-1',
+};
+
+describe('deliverMissingChatCloseoutFallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    claimDelivery.mockResolvedValue({ claimed: true });
+    releaseDelivery.mockResolvedValue(undefined);
+    replyToChatThread.mockResolvedValue({ messageTs: '123.456' });
+  });
+
+  it('posts the last finalized assistant message through the shared chat path', async () => {
+    await deliverMissingChatCloseoutFallback({
+      runId: 42,
+      completionId: 'completion-1',
+      text: 'Final answer from the assistant.',
+      mcpTaskEnv,
+      logger,
+    });
+
+    expect(claimDelivery).toHaveBeenCalledWith({
+      runId: 42,
+      completionId: 'completion-1',
+    });
+    expect(replyToChatThread).toHaveBeenCalledWith(
+      {
+        token: 'token',
+        platformApiUrl: 'https://platform.example.com',
+      },
+      { text: 'Final answer from the assistant.' },
+    );
+    expect(releaseDelivery).not.toHaveBeenCalled();
+  });
+
+  it('posts a neutral fallback when the finalized assistant message is empty', async () => {
+    await deliverMissingChatCloseoutFallback({
+      runId: 42,
+      completionId: 'completion-1',
+      text: '   ',
+      mcpTaskEnv,
+      logger,
+    });
+
+    expect(replyToChatThread).toHaveBeenCalledWith(expect.any(Object), {
+      text: EMPTY_CHAT_CLOSEOUT_FALLBACK_TEXT,
+    });
+  });
+
+  it('skips a fallback another delivery already claimed', async () => {
+    claimDelivery.mockResolvedValue({ claimed: false });
+
+    await deliverMissingChatCloseoutFallback({
+      runId: 42,
+      completionId: 'completion-1',
+      text: 'Final answer.',
+      mcpTaskEnv,
+      logger,
+    });
+
+    expect(replyToChatThread).not.toHaveBeenCalled();
+  });
+
+  it('releases the claim without failing settlement when chat delivery fails', async () => {
+    replyToChatThread.mockRejectedValue(new Error('chat unavailable'));
+
+    await expect(
+      deliverMissingChatCloseoutFallback({
+        runId: 42,
+        completionId: 'completion-1',
+        text: 'Final answer.',
+        mcpTaskEnv,
+        logger,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(releaseDelivery).toHaveBeenCalledWith({
+      runId: 42,
+      completionId: 'completion-1',
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('chat unavailable'),
+    );
+  });
+
+  it('does nothing when the task did not originate from chat', async () => {
+    await deliverMissingChatCloseoutFallback({
+      runId: 42,
+      completionId: 'completion-1',
+      text: 'Final answer.',
+      mcpTaskEnv: {
+        ROOMOTE_CLOUD_TOKEN: 'token',
+        ROOMOTE_PLATFORM_API_URL: 'https://platform.example.com',
+      },
+      logger,
+    });
+
+    expect(claimDelivery).not.toHaveBeenCalled();
+    expect(replyToChatThread).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker/src/run-task/__tests__/missing-chat-closeout-fallback-delivery.test.ts
+++ b/apps/worker/src/run-task/__tests__/missing-chat-closeout-fallback-delivery.test.ts
@@ -23,6 +23,11 @@ import {
   deliverMissingChatCloseoutFallback,
   EMPTY_CHAT_CLOSEOUT_FALLBACK_TEXT,
 } from '../missing-chat-closeout-fallback-delivery';
+import {
+  recordMissingChatCloseoutFallback,
+  settleMissingChatCloseoutFallback,
+  waitForMissingChatCloseoutFallbackDelivery,
+} from '../missing-chat-closeout-fallback-settlement';
 
 const logger = {
   runId: 42,
@@ -46,6 +51,62 @@ describe('deliverMissingChatCloseoutFallback', () => {
     claimDelivery.mockResolvedValue({ claimed: true });
     releaseDelivery.mockResolvedValue(undefined);
     replyToChatThread.mockResolvedValue({ messageTs: '123.456' });
+  });
+
+  it('holds the fallback until the matching completion is settled', async () => {
+    const context = {};
+    recordMissingChatCloseoutFallback(context, {
+      runId: 42,
+      completionId: 'completion-settled',
+      text: 'Final answer after the goal settles.',
+      mcpTaskEnv,
+      logger,
+    });
+
+    expect(replyToChatThread).not.toHaveBeenCalled();
+
+    await settleMissingChatCloseoutFallback(context, 'another-completion');
+    expect(replyToChatThread).not.toHaveBeenCalled();
+
+    await settleMissingChatCloseoutFallback(context, 'completion-settled');
+    expect(replyToChatThread).toHaveBeenCalledWith(expect.any(Object), {
+      text: 'Final answer after the goal settles.',
+    });
+  });
+
+  it('drops an exhausted closeout when a later completion supersedes it', async () => {
+    const context = {};
+    recordMissingChatCloseoutFallback(context, {
+      runId: 42,
+      completionId: 'continued-completion',
+      text: 'Intermediate answer.',
+      mcpTaskEnv,
+      logger,
+    });
+
+    recordMissingChatCloseoutFallback(context, null);
+    await settleMissingChatCloseoutFallback(context, 'continued-completion');
+    await waitForMissingChatCloseoutFallbackDelivery(context);
+
+    expect(replyToChatThread).not.toHaveBeenCalled();
+  });
+
+  it('delivers when settlement wins the event-ordering race', async () => {
+    const context = {};
+    await settleMissingChatCloseoutFallback(context, 'completion-late-record');
+
+    recordMissingChatCloseoutFallback(context, {
+      runId: 42,
+      completionId: 'completion-late-record',
+      text: 'Final answer recorded after settlement.',
+      mcpTaskEnv,
+      logger,
+    });
+    await waitForMissingChatCloseoutFallbackDelivery(context);
+
+    expect(replyToChatThread).toHaveBeenCalledWith(expect.any(Object), {
+      text: 'Final answer recorded after settlement.',
+    });
   });
 
   it('posts the last finalized assistant message through the shared chat path', async () => {

--- a/apps/worker/src/run-task/__tests__/runtime-envelope-subscription.test.ts
+++ b/apps/worker/src/run-task/__tests__/runtime-envelope-subscription.test.ts
@@ -1,6 +1,10 @@
 import { TaskEventName, type TaskEvent } from '@roomote/types';
 
-const { mockDeliverShowWidgetFallback } = vi.hoisted(() => ({
+const {
+  mockDeliverMissingChatCloseoutFallback,
+  mockDeliverShowWidgetFallback,
+} = vi.hoisted(() => ({
+  mockDeliverMissingChatCloseoutFallback: vi.fn().mockResolvedValue(undefined),
   mockDeliverShowWidgetFallback: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -16,6 +20,10 @@ vi.mock('@roomote/sdk/client', () => ({
 
 vi.mock('../show-widget-fallback-delivery', () => ({
   deliverShowWidgetFallback: mockDeliverShowWidgetFallback,
+}));
+
+vi.mock('../missing-chat-closeout-fallback-delivery', () => ({
+  deliverMissingChatCloseoutFallback: mockDeliverMissingChatCloseoutFallback,
 }));
 
 vi.mock('../../monitoring/sentry', () => ({
@@ -119,6 +127,7 @@ describe('subscribeHarnessCallbacks', () => {
     recordInferenceUsageMock.mockClear();
     recordInferenceUsageMock.mockResolvedValue({ recorded: true });
     captureWorkerExceptionMock.mockClear();
+    mockDeliverMissingChatCloseoutFallback.mockClear();
     mockDeliverShowWidgetFallback.mockClear();
   });
 
@@ -368,6 +377,115 @@ describe('subscribeHarnessCallbacks', () => {
       taskId: 'task-fallback',
       envelope: pendingEnvelope,
     });
+
+    await unsubscribe();
+  });
+
+  it('delivers the latest finalized assistant message when chat closeout reminders are exhausted', async () => {
+    const { harness, emitTaskEvent, emitTurnCompleted } =
+      createRuntimeHarness();
+    const logger = {
+      runId: 146,
+      filePath: '/tmp/test.log',
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      log: vi.fn(),
+    };
+    const mcpTaskEnv = {
+      ROOMOTE_CLOUD_TOKEN: 'token',
+      ROOMOTE_PLATFORM_API_URL: 'https://platform.example.com',
+      ROOMOTE_COMMUNICATION_PROVIDER: 'discord',
+      ROOMOTE_COMMUNICATION_CHANNEL_ID: 'channel-1',
+    };
+    const unsubscribe = subscribeHarnessCallbacks({
+      harness: harness as never,
+      taskRun: { id: 146, taskId: 'task-closeout' } as never,
+      callbacks: { onMessage: vi.fn().mockResolvedValue(undefined) },
+      context: {},
+      logger,
+      mcpTaskEnv,
+    });
+
+    emitTurnCompleted({
+      protocol: 'roomote_runtime',
+      sessionId: 'runtime-session-closeout',
+      ts: 1772823377001,
+      text: 'The final assistant answer.',
+    });
+    emitTaskEvent({
+      eventName: TaskEventName.TaskCompleted,
+      payload: [
+        'runtime-session-closeout',
+        {},
+        {},
+        {
+          isSubtask: false,
+          completionId: 'completion-closeout-1',
+          missingChatCloseout: { reminderCount: 3 },
+        },
+      ],
+    } as TaskEvent);
+
+    await vi.waitFor(() => {
+      expect(mockDeliverMissingChatCloseoutFallback).toHaveBeenCalledWith({
+        runId: 146,
+        completionId: 'completion-closeout-1',
+        text: 'The final assistant answer.',
+        mcpTaskEnv,
+        logger,
+      });
+    });
+
+    await unsubscribe();
+  });
+
+  it('uses the empty-message fallback only for completion events marked as missing closeout', async () => {
+    const { harness, emitTaskEvent } = createRuntimeHarness();
+    const logger = {
+      runId: 147,
+      filePath: '/tmp/test.log',
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      log: vi.fn(),
+    };
+    const unsubscribe = subscribeHarnessCallbacks({
+      harness: harness as never,
+      taskRun: { id: 147, taskId: 'task-empty-closeout' } as never,
+      callbacks: {},
+      context: {},
+      logger,
+    });
+
+    emitTaskEvent({
+      eventName: TaskEventName.TaskCompleted,
+      payload: [
+        'runtime-session-empty-closeout',
+        {},
+        {},
+        { isSubtask: false, missingChatCloseout: { reminderCount: 3 } },
+      ],
+    } as TaskEvent);
+
+    await vi.waitFor(() => {
+      expect(mockDeliverMissingChatCloseoutFallback).toHaveBeenCalledWith({
+        runId: 147,
+        completionId: 'runtime-session-empty-closeout',
+        text: null,
+        mcpTaskEnv: undefined,
+        logger,
+      });
+    });
+
+    mockDeliverMissingChatCloseoutFallback.mockClear();
+    emitTaskEvent({
+      eventName: TaskEventName.TaskCompleted,
+      payload: ['runtime-session-empty-closeout', {}, {}, { isSubtask: false }],
+    } as TaskEvent);
+
+    await Promise.resolve();
+    expect(mockDeliverMissingChatCloseoutFallback).not.toHaveBeenCalled();
 
     await unsubscribe();
   });

--- a/apps/worker/src/run-task/__tests__/runtime-envelope-subscription.test.ts
+++ b/apps/worker/src/run-task/__tests__/runtime-envelope-subscription.test.ts
@@ -1,11 +1,15 @@
 import { TaskEventName, type TaskEvent } from '@roomote/types';
 
 const {
-  mockDeliverMissingChatCloseoutFallback,
+  mockRecordMissingChatCloseoutFallback,
   mockDeliverShowWidgetFallback,
+  mockWaitForMissingChatCloseoutFallbackDelivery,
 } = vi.hoisted(() => ({
-  mockDeliverMissingChatCloseoutFallback: vi.fn().mockResolvedValue(undefined),
+  mockRecordMissingChatCloseoutFallback: vi.fn(),
   mockDeliverShowWidgetFallback: vi.fn().mockResolvedValue(undefined),
+  mockWaitForMissingChatCloseoutFallbackDelivery: vi
+    .fn()
+    .mockResolvedValue(undefined),
 }));
 
 vi.mock('@roomote/sdk/client', () => ({
@@ -22,8 +26,10 @@ vi.mock('../show-widget-fallback-delivery', () => ({
   deliverShowWidgetFallback: mockDeliverShowWidgetFallback,
 }));
 
-vi.mock('../missing-chat-closeout-fallback-delivery', () => ({
-  deliverMissingChatCloseoutFallback: mockDeliverMissingChatCloseoutFallback,
+vi.mock('../missing-chat-closeout-fallback-settlement', () => ({
+  recordMissingChatCloseoutFallback: mockRecordMissingChatCloseoutFallback,
+  waitForMissingChatCloseoutFallbackDelivery:
+    mockWaitForMissingChatCloseoutFallbackDelivery,
 }));
 
 vi.mock('../../monitoring/sentry', () => ({
@@ -127,7 +133,8 @@ describe('subscribeHarnessCallbacks', () => {
     recordInferenceUsageMock.mockClear();
     recordInferenceUsageMock.mockResolvedValue({ recorded: true });
     captureWorkerExceptionMock.mockClear();
-    mockDeliverMissingChatCloseoutFallback.mockClear();
+    mockRecordMissingChatCloseoutFallback.mockClear();
+    mockWaitForMissingChatCloseoutFallbackDelivery.mockClear();
     mockDeliverShowWidgetFallback.mockClear();
   });
 
@@ -381,7 +388,7 @@ describe('subscribeHarnessCallbacks', () => {
     await unsubscribe();
   });
 
-  it('delivers the latest finalized assistant message when chat closeout reminders are exhausted', async () => {
+  it('records the latest finalized assistant message until completion settles', async () => {
     const { harness, emitTaskEvent, emitTurnCompleted } =
       createRuntimeHarness();
     const logger = {
@@ -398,11 +405,12 @@ describe('subscribeHarnessCallbacks', () => {
       ROOMOTE_COMMUNICATION_PROVIDER: 'discord',
       ROOMOTE_COMMUNICATION_CHANNEL_ID: 'channel-1',
     };
+    const context = {};
     const unsubscribe = subscribeHarnessCallbacks({
       harness: harness as never,
       taskRun: { id: 146, taskId: 'task-closeout' } as never,
       callbacks: { onMessage: vi.fn().mockResolvedValue(undefined) },
-      context: {},
+      context,
       logger,
       mcpTaskEnv,
     });
@@ -428,19 +436,22 @@ describe('subscribeHarnessCallbacks', () => {
     } as TaskEvent);
 
     await vi.waitFor(() => {
-      expect(mockDeliverMissingChatCloseoutFallback).toHaveBeenCalledWith({
-        runId: 146,
-        completionId: 'completion-closeout-1',
-        text: 'The final assistant answer.',
-        mcpTaskEnv,
-        logger,
-      });
+      expect(mockRecordMissingChatCloseoutFallback).toHaveBeenCalledWith(
+        context,
+        {
+          runId: 146,
+          completionId: 'completion-closeout-1',
+          text: 'The final assistant answer.',
+          mcpTaskEnv,
+          logger,
+        },
+      );
     });
 
     await unsubscribe();
   });
 
-  it('uses the empty-message fallback only for completion events marked as missing closeout', async () => {
+  it('records an empty fallback only for completion events marked as missing closeout', async () => {
     const { harness, emitTaskEvent } = createRuntimeHarness();
     const logger = {
       runId: 147,
@@ -450,11 +461,12 @@ describe('subscribeHarnessCallbacks', () => {
       error: vi.fn(),
       log: vi.fn(),
     };
+    const context = {};
     const unsubscribe = subscribeHarnessCallbacks({
       harness: harness as never,
       taskRun: { id: 147, taskId: 'task-empty-closeout' } as never,
       callbacks: {},
-      context: {},
+      context,
       logger,
     });
 
@@ -469,23 +481,29 @@ describe('subscribeHarnessCallbacks', () => {
     } as TaskEvent);
 
     await vi.waitFor(() => {
-      expect(mockDeliverMissingChatCloseoutFallback).toHaveBeenCalledWith({
-        runId: 147,
-        completionId: 'runtime-session-empty-closeout',
-        text: null,
-        mcpTaskEnv: undefined,
-        logger,
-      });
+      expect(mockRecordMissingChatCloseoutFallback).toHaveBeenCalledWith(
+        context,
+        {
+          runId: 147,
+          completionId: 'runtime-session-empty-closeout',
+          text: null,
+          mcpTaskEnv: undefined,
+          logger,
+        },
+      );
     });
 
-    mockDeliverMissingChatCloseoutFallback.mockClear();
+    mockRecordMissingChatCloseoutFallback.mockClear();
     emitTaskEvent({
       eventName: TaskEventName.TaskCompleted,
       payload: ['runtime-session-empty-closeout', {}, {}, { isSubtask: false }],
     } as TaskEvent);
 
     await Promise.resolve();
-    expect(mockDeliverMissingChatCloseoutFallback).not.toHaveBeenCalled();
+    expect(mockRecordMissingChatCloseoutFallback).toHaveBeenCalledWith(
+      context,
+      null,
+    );
 
     await unsubscribe();
   });

--- a/apps/worker/src/run-task/chat-fallback-delivery-config.ts
+++ b/apps/worker/src/run-task/chat-fallback-delivery-config.ts
@@ -1,0 +1,34 @@
+import type { RoomoteConfig } from '../mcp/roomote-mcp-server/types';
+
+export function getChatFallbackDeliveryConfig(
+  mcpTaskEnv: Record<string, string> | undefined,
+): RoomoteConfig | null {
+  if (!mcpTaskEnv) {
+    return null;
+  }
+
+  const hasSlackContext = Boolean(mcpTaskEnv.ROOMOTE_SLACK_CHANNEL?.trim());
+  const hasCommunicationContext = Boolean(
+    mcpTaskEnv.ROOMOTE_COMMUNICATION_PROVIDER?.trim() &&
+    mcpTaskEnv.ROOMOTE_COMMUNICATION_CHANNEL_ID?.trim(),
+  );
+  const token =
+    mcpTaskEnv.ROOMOTE_CLOUD_TOKEN?.trim() || mcpTaskEnv.AUTH_TOKEN?.trim();
+  const platformApiUrl =
+    mcpTaskEnv.ROOMOTE_PLATFORM_API_URL?.trim() ||
+    mcpTaskEnv.TRPC_URL?.trim() ||
+    'http://localhost:13001';
+
+  if ((!hasSlackContext && !hasCommunicationContext) || !token) {
+    return null;
+  }
+
+  return {
+    token,
+    platformApiUrl: platformApiUrl.replace(/\/+$/, ''),
+    authBypassHeaderName:
+      mcpTaskEnv.ROOMOTE_AUTH_BYPASS_HEADER_NAME?.trim() || undefined,
+    authBypassHeaderValue:
+      mcpTaskEnv.ROOMOTE_AUTH_BYPASS_VALUE?.trim() || undefined,
+  };
+}

--- a/apps/worker/src/run-task/missing-chat-closeout-fallback-delivery.ts
+++ b/apps/worker/src/run-task/missing-chat-closeout-fallback-delivery.ts
@@ -1,0 +1,68 @@
+import { sdk } from '@roomote/sdk/client';
+
+import { replyToChatThread } from '../mcp/roomote-mcp-server/chat-api-client';
+import type { HarnessLogger } from '../logging';
+import { getChatFallbackDeliveryConfig } from './chat-fallback-delivery-config';
+
+export const EMPTY_CHAT_CLOSEOUT_FALLBACK_TEXT =
+  'Roomote finished this turn without producing a final response. Reply here to continue or open the task for details.';
+
+export async function deliverMissingChatCloseoutFallback(input: {
+  runId: number;
+  completionId: string;
+  text: string | null | undefined;
+  mcpTaskEnv?: Record<string, string>;
+  logger: HarnessLogger;
+}): Promise<void> {
+  const config = getChatFallbackDeliveryConfig(input.mcpTaskEnv);
+  if (!config) {
+    return;
+  }
+
+  let claimed: boolean;
+
+  try {
+    ({ claimed } = await sdk.taskRuns.claimMissingChatCloseoutFallbackDelivery({
+      runId: input.runId,
+      completionId: input.completionId,
+    }));
+  } catch (error) {
+    input.logger.warn(
+      `[missingChatCloseoutFallback] Failed to claim chat fallback delivery for task run ${input.runId}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return;
+  }
+
+  if (!claimed) {
+    return;
+  }
+
+  const text = input.text?.trim() || EMPTY_CHAT_CLOSEOUT_FALLBACK_TEXT;
+
+  try {
+    await replyToChatThread(config, { text });
+  } catch (error) {
+    await sdk.taskRuns
+      .releaseMissingChatCloseoutFallbackDelivery({
+        runId: input.runId,
+        completionId: input.completionId,
+      })
+      .catch((releaseError: unknown) => {
+        input.logger.warn(
+          `[missingChatCloseoutFallback] Failed to release delivery claim for task run ${input.runId}: ${
+            releaseError instanceof Error
+              ? releaseError.message
+              : String(releaseError)
+          }`,
+        );
+      });
+
+    input.logger.warn(
+      `[missingChatCloseoutFallback] Failed to post chat fallback for task run ${input.runId}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}

--- a/apps/worker/src/run-task/missing-chat-closeout-fallback-settlement.ts
+++ b/apps/worker/src/run-task/missing-chat-closeout-fallback-settlement.ts
@@ -1,0 +1,86 @@
+import type { HarnessLogger } from '../logging';
+import type { RunTaskContext } from './types';
+import { deliverMissingChatCloseoutFallback } from './missing-chat-closeout-fallback-delivery';
+
+interface PendingMissingChatCloseoutFallback {
+  runId: number;
+  completionId: string;
+  text: string | null;
+  mcpTaskEnv?: Record<string, string>;
+  logger: HarnessLogger;
+}
+
+interface MissingChatCloseoutFallbackState {
+  pending: PendingMissingChatCloseoutFallback | null;
+  settledCompletionIds: Set<string>;
+  deliveryWork: Set<Promise<void>>;
+}
+
+const stateByContext = new WeakMap<
+  RunTaskContext,
+  MissingChatCloseoutFallbackState
+>();
+
+function getState(context: RunTaskContext): MissingChatCloseoutFallbackState {
+  const existing = stateByContext.get(context);
+  if (existing) {
+    return existing;
+  }
+
+  const state: MissingChatCloseoutFallbackState = {
+    pending: null,
+    settledCompletionIds: new Set(),
+    deliveryWork: new Set(),
+  };
+  stateByContext.set(context, state);
+  return state;
+}
+
+function startDeliveryIfSettled(
+  state: MissingChatCloseoutFallbackState,
+): Promise<void> | null {
+  const pending = state.pending;
+  if (!pending || !state.settledCompletionIds.has(pending.completionId)) {
+    return null;
+  }
+
+  state.pending = null;
+  state.settledCompletionIds.delete(pending.completionId);
+  const work = deliverMissingChatCloseoutFallback(pending);
+  state.deliveryWork.add(work);
+  void work.finally(() => {
+    state.deliveryWork.delete(work);
+  });
+  return work;
+}
+
+export function recordMissingChatCloseoutFallback(
+  context: RunTaskContext,
+  pending: PendingMissingChatCloseoutFallback | null,
+): void {
+  const state = getState(context);
+  state.pending = pending;
+  void startDeliveryIfSettled(state);
+}
+
+export async function settleMissingChatCloseoutFallback(
+  context: RunTaskContext,
+  completionId: string,
+): Promise<void> {
+  const state = getState(context);
+  state.settledCompletionIds.add(completionId);
+  await startDeliveryIfSettled(state);
+}
+
+export async function waitForMissingChatCloseoutFallbackDelivery(
+  context: RunTaskContext,
+): Promise<void> {
+  const state = stateByContext.get(context);
+  if (!state) {
+    return;
+  }
+
+  while (state.deliveryWork.size > 0) {
+    await Promise.allSettled([...state.deliveryWork]);
+  }
+}

--- a/apps/worker/src/run-task/run-task.ts
+++ b/apps/worker/src/run-task/run-task.ts
@@ -103,6 +103,7 @@ import {
 } from './workflow-phase';
 import { wrapCommunicationMessage } from './communication-message-prompt';
 import { buildTaskGoalContinuationPrompt } from './task-goal';
+import { settleMissingChatCloseoutFallback } from './missing-chat-closeout-fallback-settlement';
 
 function formatEnvironmentInstructions(
   instructions?: string,
@@ -1335,6 +1336,9 @@ export const runTask = async ({
       taskId: taskRun.taskId,
       logger,
       callbacks: {
+        onTaskCompletionSettled: async (completionId: string) => {
+          await settleMissingChatCloseoutFallback(context, completionId);
+        },
         onBeforeTaskCompletion: async (completionId: string) => {
           if (taskCancellation.signal.aborted) {
             return 'finalize' as const;

--- a/apps/worker/src/run-task/show-widget-fallback-delivery.ts
+++ b/apps/worker/src/run-task/show-widget-fallback-delivery.ts
@@ -2,41 +2,8 @@ import { sdk } from '@roomote/sdk/client';
 import type { ShowWidgetFallbackDelivery } from '@roomote/types';
 
 import { replyToChatThread } from '../mcp/roomote-mcp-server/chat-api-client';
-import type { RoomoteConfig } from '../mcp/roomote-mcp-server/types';
 import type { HarnessLogger } from '../logging';
-
-function getDeliveryConfig(
-  mcpTaskEnv: Record<string, string> | undefined,
-): RoomoteConfig | null {
-  if (!mcpTaskEnv) {
-    return null;
-  }
-
-  const hasSlackContext = Boolean(mcpTaskEnv.ROOMOTE_SLACK_CHANNEL?.trim());
-  const hasCommunicationContext = Boolean(
-    mcpTaskEnv.ROOMOTE_COMMUNICATION_PROVIDER?.trim() &&
-    mcpTaskEnv.ROOMOTE_COMMUNICATION_CHANNEL_ID?.trim(),
-  );
-  const token =
-    mcpTaskEnv.ROOMOTE_CLOUD_TOKEN?.trim() || mcpTaskEnv.AUTH_TOKEN?.trim();
-  const platformApiUrl =
-    mcpTaskEnv.ROOMOTE_PLATFORM_API_URL?.trim() ||
-    mcpTaskEnv.TRPC_URL?.trim() ||
-    'http://localhost:13001';
-
-  if ((!hasSlackContext && !hasCommunicationContext) || !token) {
-    return null;
-  }
-
-  return {
-    token,
-    platformApiUrl: platformApiUrl.replace(/\/+$/, ''),
-    authBypassHeaderName:
-      mcpTaskEnv.ROOMOTE_AUTH_BYPASS_HEADER_NAME?.trim() || undefined,
-    authBypassHeaderValue:
-      mcpTaskEnv.ROOMOTE_AUTH_BYPASS_VALUE?.trim() || undefined,
-  };
-}
+import { getChatFallbackDeliveryConfig } from './chat-fallback-delivery-config';
 
 export async function deliverShowWidgetFallback(input: {
   runId: number;
@@ -44,7 +11,7 @@ export async function deliverShowWidgetFallback(input: {
   mcpTaskEnv?: Record<string, string>;
   logger: HarnessLogger;
 }): Promise<void> {
-  const config = getDeliveryConfig(input.mcpTaskEnv);
+  const config = getChatFallbackDeliveryConfig(input.mcpTaskEnv);
   if (!input.delivery || !config) {
     return;
   }

--- a/apps/worker/src/run-task/subscribe-harness-callbacks.ts
+++ b/apps/worker/src/run-task/subscribe-harness-callbacks.ts
@@ -18,7 +18,10 @@ import { captureWorkerException } from '../monitoring/sentry';
 
 import type { CallbackEvent, RunTaskCallbacks, RunTaskContext } from './types';
 import { fromRuntimeEnvelope } from './runtime-events/envelope';
-import { deliverMissingChatCloseoutFallback } from './missing-chat-closeout-fallback-delivery';
+import {
+  recordMissingChatCloseoutFallback,
+  waitForMissingChatCloseoutFallbackDelivery,
+} from './missing-chat-closeout-fallback-settlement';
 import { deliverShowWidgetFallback } from './show-widget-fallback-delivery';
 
 interface PendingCompletionEvents {
@@ -374,20 +377,21 @@ export function subscribeHarnessCallbacks({
       const completionMetadata = event.payload[3] as
         | TaskCompletionMetadata
         | undefined;
-      trackPendingTaskCompletionWork(
-        (async () => {
-          await waitForPendingPersistenceWrites();
-
-          if (completionMetadata?.missingChatCloseout) {
-            await deliverMissingChatCloseoutFallback({
+      recordMissingChatCloseoutFallback(
+        context,
+        completionMetadata?.missingChatCloseout
+          ? {
               runId: taskRun.id,
               completionId: completionMetadata.completionId ?? taskId,
               text: getLatestPendingCompletionText(taskId),
               mcpTaskEnv,
               logger,
-            });
-          }
-
+            }
+          : null,
+      );
+      trackPendingTaskCompletionWork(
+        (async () => {
+          await waitForPendingPersistenceWrites();
           flushPendingCompletionEvents(taskId);
         })(),
       );
@@ -411,6 +415,7 @@ export function subscribeHarnessCallbacks({
     await assistantOutputStampInFlight;
     await waitForPendingPersistenceWrites();
     await waitForPendingTaskCompletionWork();
+    await waitForMissingChatCloseoutFallbackDelivery(context);
 
     for (const callbackTaskId of pendingCompletionEventsByCallbackId.keys()) {
       flushPendingCompletionEvents(callbackTaskId);

--- a/apps/worker/src/run-task/subscribe-harness-callbacks.ts
+++ b/apps/worker/src/run-task/subscribe-harness-callbacks.ts
@@ -3,6 +3,7 @@ import {
   type AcpTurnCompletedEvent,
   TaskEventName,
   type TaskEvent,
+  type TaskCompletionMetadata,
   asRecord,
   asString,
   deepStripCitations,
@@ -17,6 +18,7 @@ import { captureWorkerException } from '../monitoring/sentry';
 
 import type { CallbackEvent, RunTaskCallbacks, RunTaskContext } from './types';
 import { fromRuntimeEnvelope } from './runtime-events/envelope';
+import { deliverMissingChatCloseoutFallback } from './missing-chat-closeout-fallback-delivery';
 import { deliverShowWidgetFallback } from './show-widget-fallback-delivery';
 
 interface PendingCompletionEvents {
@@ -51,6 +53,7 @@ export function subscribeHarnessCallbacks({
     PendingCompletionEvents
   >();
   const pendingPersistenceWrites = new Set<Promise<void>>();
+  const pendingTaskCompletionWork = new Set<Promise<void>>();
   let consecutivePersistenceFailures = 0;
   let assistantOutputStamped = false;
   let assistantOutputStampInFlight: Promise<void> | null = null;
@@ -73,6 +76,19 @@ export function subscribeHarnessCallbacks({
   const waitForPendingPersistenceWrites = async () => {
     while (pendingPersistenceWrites.size > 0) {
       await Promise.allSettled([...pendingPersistenceWrites]);
+    }
+  };
+
+  const trackPendingTaskCompletionWork = (work: Promise<void>) => {
+    pendingTaskCompletionWork.add(work);
+    void work.finally(() => {
+      pendingTaskCompletionWork.delete(work);
+    });
+  };
+
+  const waitForPendingTaskCompletionWork = async () => {
+    while (pendingTaskCompletionWork.size > 0) {
+      await Promise.allSettled([...pendingTaskCompletionWork]);
     }
   };
 
@@ -240,6 +256,24 @@ export function subscribeHarnessCallbacks({
     pendingCompletionEventsByCallbackId.delete(callbackTaskId);
   };
 
+  const getLatestPendingCompletionText = (
+    callbackTaskId: string,
+  ): string | null => {
+    const pending = pendingCompletionEventsByCallbackId.get(callbackTaskId);
+    if (!pending) {
+      return null;
+    }
+
+    for (let index = pending.events.length - 1; index >= 0; index -= 1) {
+      const event = pending.events[index];
+      if (event?.type === 'completion' && event.text.trim()) {
+        return event.text;
+      }
+    }
+
+    return null;
+  };
+
   const unsubscribeTurnCompleted = harness.subscribeRuntimeTurnCompleted(
     (event: AcpTurnCompletedEvent) => {
       const text = stripLlmCitationArtifacts(event.text);
@@ -337,10 +371,26 @@ export function subscribeHarnessCallbacks({
     }
 
     if (event.eventName === TaskEventName.TaskCompleted) {
-      void (async () => {
-        await waitForPendingPersistenceWrites();
-        flushPendingCompletionEvents(taskId);
-      })();
+      const completionMetadata = event.payload[3] as
+        | TaskCompletionMetadata
+        | undefined;
+      trackPendingTaskCompletionWork(
+        (async () => {
+          await waitForPendingPersistenceWrites();
+
+          if (completionMetadata?.missingChatCloseout) {
+            await deliverMissingChatCloseoutFallback({
+              runId: taskRun.id,
+              completionId: completionMetadata.completionId ?? taskId,
+              text: getLatestPendingCompletionText(taskId),
+              mcpTaskEnv,
+              logger,
+            });
+          }
+
+          flushPendingCompletionEvents(taskId);
+        })(),
+      );
       return;
     }
 
@@ -360,6 +410,7 @@ export function subscribeHarnessCallbacks({
     unsubscribeTaskEvents();
     await assistantOutputStampInFlight;
     await waitForPendingPersistenceWrites();
+    await waitForPendingTaskCompletionWork();
 
     for (const callbackTaskId of pendingCompletionEventsByCallbackId.keys()) {
       flushPendingCompletionEvents(callbackTaskId);

--- a/apps/worker/src/sandbox-server/lib/__tests__/harness-manager.test.ts
+++ b/apps/worker/src/sandbox-server/lib/__tests__/harness-manager.test.ts
@@ -2144,6 +2144,75 @@ describe('HarnessManager touchKeepalive', () => {
     }
   });
 
+  it('notifies settlement only after a goal continuation actually finalizes', async () => {
+    const onTaskCompletionSettled = vi.fn().mockResolvedValue(undefined);
+    const onBeforeTaskCompletion = vi.fn(async (completionId: string) =>
+      completionId === 'completion-1'
+        ? {
+            disposition: 'continue' as const,
+            prompt: { prompt: 'hidden continuation' },
+          }
+        : ('finalize' as const),
+    );
+    const { harness, manager } = createManager({
+      onBeforeTaskCompletion,
+      onTaskCompletionSettled,
+    });
+    const completion = (completionId: string) =>
+      ({
+        eventName: TaskEventName.TaskCompleted,
+        payload: [
+          'task-goal-settlement',
+          {
+            totalTokensIn: 0,
+            totalTokensOut: 0,
+            totalCost: 0,
+            contextTokens: 0,
+          },
+          {},
+          { isSubtask: false, completionId },
+        ],
+      }) as TaskEvent;
+
+    try {
+      manager.initializeWithoutPrompt();
+      manager.startNewTaskFromPrompt({ prompt: 'hello' });
+      harness.emitTaskEvent({
+        eventName: TaskEventName.TaskStarted,
+        payload: ['task-goal-settlement'],
+      } as TaskEvent);
+
+      harness.emitTaskEvent(completion('completion-1'));
+      await vi.waitFor(() => {
+        expect(onBeforeTaskCompletion).toHaveBeenCalledWith('completion-1');
+      });
+      expect(onTaskCompletionSettled).not.toHaveBeenCalled();
+
+      harness.emitRuntimeOutput({
+        id: 'task-goal-settlement:prompt-2',
+        ts: 10,
+        eventType: ACP_ENVELOPE_EVENT_TYPES.UserPrompt,
+        kind: 'text',
+        role: 'user',
+        contentBlocks: [{ type: 'text', text: 'hidden continuation' }],
+        metadata: { sessionId: 'task-goal-settlement', sequence: 2 },
+        payload: {
+          sessionId: 'task-goal-settlement',
+          text: 'hidden continuation',
+        },
+      } as AcpMessage);
+      harness.emitTaskEvent(completion('completion-2'));
+
+      await vi.waitFor(() => {
+        expect(onTaskCompletionSettled).toHaveBeenCalledWith('completion-2');
+      });
+      expect(onTaskCompletionSettled).toHaveBeenCalledTimes(1);
+    } finally {
+      manager.dispose();
+      harness.dispose();
+    }
+  });
+
   it('marks continuation pending before dispatch can synchronously start and finish it', async () => {
     const onExit = vi.fn();
     const onBeforeTaskCompletion = vi.fn(async (completionId: string) =>

--- a/apps/worker/src/sandbox-server/lib/harness-manager.ts
+++ b/apps/worker/src/sandbox-server/lib/harness-manager.ts
@@ -128,6 +128,7 @@ export interface HarnessManagerCallbacks {
   onBeforeTaskCompletion?: (
     completionId: string,
   ) => Promise<HarnessManagerCompletionDecision>;
+  onTaskCompletionSettled?: (completionId: string) => Promise<void>;
 }
 
 interface HarnessFollowUpPromptOptions {
@@ -921,12 +922,21 @@ export class HarnessManager extends EventEmitter<HarnessManagerEvents> {
     });
   }
 
-  private finalizeTaskCompletionNow(): void {
+  private finalizeTaskCompletionNow(completionId: string): void {
     this.deferredTurnSettlement = null;
     this.state.taskFinishedAt = Date.now();
 
     if (this.phase === 'running') {
       this.setPhase('waiting_for_prompt');
+    }
+
+    const settlement = this.callbacks.onTaskCompletionSettled?.(completionId);
+    if (settlement) {
+      void settlement.catch((error) => {
+        this.logger.warn(
+          `[HarnessManager] onTaskCompletionSettled callback failed: ${formatCallbackError(error)}`,
+        );
+      });
     }
 
     this.invokeOnExit();
@@ -935,20 +945,21 @@ export class HarnessManager extends EventEmitter<HarnessManagerEvents> {
 
   private finalizeTaskCompletion(): void {
     const decide = this.callbacks.onBeforeTaskCompletion;
-    if (!decide) {
-      this.finalizeTaskCompletionNow();
+    if (this.completionDecisionPending || this.continuationStartPending) {
       return;
     }
-    if (this.completionDecisionPending || this.continuationStartPending) {
+
+    const sessionId = this.state.sessionId;
+    const completionId =
+      this.pendingCompletionId ??
+      `${sessionId ?? 'unknown'}:fallback:${++this.fallbackCompletionSequence}`;
+    if (!decide) {
+      this.finalizeTaskCompletionNow(completionId);
       return;
     }
 
     this.completionDecisionPending = true;
     const decisionSequence = ++this.completionDecisionSequence;
-    const sessionId = this.state.sessionId;
-    const completionId =
-      this.pendingCompletionId ??
-      `${sessionId ?? 'unknown'}:fallback:${++this.fallbackCompletionSequence}`;
     void decide(completionId)
       .then(async (disposition) => {
         if (decisionSequence !== this.completionDecisionSequence) {
@@ -1004,14 +1015,14 @@ export class HarnessManager extends EventEmitter<HarnessManagerEvents> {
             !isStoppingPhase(this.phase) &&
             !this.state.cancelTriggeredAt
           ) {
-            this.finalizeTaskCompletionNow();
+            this.finalizeTaskCompletionNow(completionId);
           }
           return;
         }
         if (disposition === 'ignore') {
           return;
         }
-        this.finalizeTaskCompletionNow();
+        this.finalizeTaskCompletionNow(completionId);
       })
       .catch((error) => {
         if (decisionSequence !== this.completionDecisionSequence) {
@@ -1026,7 +1037,7 @@ export class HarnessManager extends EventEmitter<HarnessManagerEvents> {
           `[HarnessManager] Pre-completion decision failed: ${formatCallbackError(error)}`,
         );
         if (this.phase !== 'shutting_down' && this.phase !== 'stopped') {
-          this.finalizeTaskCompletionNow();
+          this.finalizeTaskCompletionNow(completionId);
         }
       });
   }

--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
@@ -180,10 +180,14 @@ async function connectHarness(
   await connectPromise;
 }
 
-function createFinalAssistantMessage(): OpenCodeSessionMessage {
+function createFinalAssistantMessage(
+  options: { messageId?: string; text?: string } = {},
+): OpenCodeSessionMessage {
+  const messageId = options.messageId ?? 'msg_1';
+
   return {
     info: {
-      id: 'msg_1',
+      id: messageId,
       sessionID: 'ses_1',
       role: 'assistant',
       providerID: 'openrouter',
@@ -206,11 +210,11 @@ function createFinalAssistantMessage(): OpenCodeSessionMessage {
     },
     parts: [
       {
-        id: 'part_1',
+        id: `part_${messageId}`,
         sessionID: 'ses_1',
-        messageID: 'msg_1',
+        messageID: messageId,
         type: 'text',
-        text: 'OK',
+        text: options.text ?? 'OK',
       },
     ],
   };
@@ -2022,8 +2026,12 @@ describe('OpenCodeServerHarness', () => {
       },
     });
     const taskEvents: TaskEvent[] = [];
+    const turnCompletedEvents: AcpTurnCompletedEvent[] = [];
 
     harness.subscribe((event) => taskEvents.push(event));
+    harness.subscribeRuntimeTurnCompleted((event) =>
+      turnCompletedEvents.push(event),
+    );
 
     try {
       await connectHarness(harness, client);
@@ -2073,6 +2081,24 @@ describe('OpenCodeServerHarness', () => {
         expect(client.promptAsync).toHaveBeenCalledTimes(4);
       });
 
+      client.message.mockResolvedValueOnce(
+        createFinalAssistantMessage({
+          messageId: 'msg_final_closeout_fallback',
+          text: 'The last finalized assistant answer.',
+        }),
+      );
+      await client.emit({
+        type: 'message.updated',
+        properties: {
+          info: {
+            id: 'msg_final_closeout_fallback',
+            sessionID: 'ses_1',
+            role: 'assistant',
+            time: { completed: 1 },
+          },
+        },
+      });
+
       // The next blocked turn-end gives up and completes the turn instead of
       // aborting the task or injecting more reminders.
       await client.emit({
@@ -2095,6 +2121,22 @@ describe('OpenCodeServerHarness', () => {
         ),
       ).toBe(false);
       expect(client.promptAsync).toHaveBeenCalledTimes(4);
+      expect(turnCompletedEvents).toEqual([
+        expect.objectContaining({
+          sessionId: 'ses_1',
+          text: 'The last finalized assistant answer.',
+        }),
+      ]);
+      expect(
+        taskEvents.find(
+          (event) => event.eventName === TaskEventName.TaskCompleted,
+        )?.payload[3],
+      ).toEqual(
+        expect.objectContaining({
+          isSubtask: false,
+          missingChatCloseout: { reminderCount: 3 },
+        }),
+      );
     } finally {
       harness.dispose();
       fs.rmSync(tempDir, { recursive: true, force: true });
@@ -2126,8 +2168,12 @@ describe('OpenCodeServerHarness', () => {
       stopHookReminderStallTimeoutMs: 50,
     });
     const taskEvents: TaskEvent[] = [];
+    const turnCompletedEvents: AcpTurnCompletedEvent[] = [];
 
     harness.subscribe((event) => taskEvents.push(event));
+    harness.subscribeRuntimeTurnCompleted((event) =>
+      turnCompletedEvents.push(event),
+    );
 
     try {
       await connectHarness(harness, client);
@@ -2141,6 +2187,24 @@ describe('OpenCodeServerHarness', () => {
 
       await vi.waitFor(() => {
         expect(client.promptAsync).toHaveBeenCalledTimes(1);
+      });
+
+      client.message.mockResolvedValueOnce(
+        createFinalAssistantMessage({
+          messageId: 'msg_before_wedged_reminder',
+          text: 'The answer before the reminder wedged.',
+        }),
+      );
+      await client.emit({
+        type: 'message.updated',
+        properties: {
+          info: {
+            id: 'msg_before_wedged_reminder',
+            sessionID: 'ses_1',
+            role: 'assistant',
+            time: { completed: 1 },
+          },
+        },
       });
 
       // The blocked turn-end injects a closeout reminder and then awaits a
@@ -2170,6 +2234,22 @@ describe('OpenCodeServerHarness', () => {
       ).toBe(false);
       // No extra reminder was injected — the fail-safe completed the turn.
       expect(client.promptAsync).toHaveBeenCalledTimes(2);
+      expect(turnCompletedEvents).toEqual([
+        expect.objectContaining({
+          sessionId: 'ses_1',
+          text: 'The answer before the reminder wedged.',
+        }),
+      ]);
+      expect(
+        taskEvents.find(
+          (event) => event.eventName === TaskEventName.TaskCompleted,
+        )?.payload[3],
+      ).toEqual(
+        expect.objectContaining({
+          isSubtask: false,
+          missingChatCloseout: { reminderCount: 1 },
+        }),
+      );
     } finally {
       harness.dispose();
       fs.rmSync(tempDir, { recursive: true, force: true });

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
@@ -1607,6 +1607,7 @@ export class OpenCodeServerHarness
   private activeWorkflowSkill: string | null = null;
   private commandEnv: Record<string, string> | undefined;
   private stopHookReminderCount = 0;
+  private lastBlockedCloseoutAssistantText: string | null = null;
   private stopHookReminderStallTimer: ReturnType<typeof setTimeout> | null =
     null;
   // OpenCode 1.17 emits session.status(idle) followed by session.idle for the
@@ -2117,6 +2118,7 @@ export class OpenCodeServerHarness
     this.clearProviderErrorRecoveryState();
     this.clearAllExecuteToolProgress();
     this.stopHookReminderCount = 0;
+    this.lastBlockedCloseoutAssistantText = null;
     this.ignoreNextStopHookSessionIdle = false;
     this.ignoreNextQueuedDrainSessionIdle = false;
     this.currentWorkflowPhase = command.data.workflowPhase ?? null;
@@ -2158,6 +2160,7 @@ export class OpenCodeServerHarness
   private async handleSendMessage(command: SendMessageCommand): Promise<void> {
     const text = command.data.text ?? '';
     this.stopHookReminderCount = 0;
+    this.lastBlockedCloseoutAssistantText = null;
 
     // A soft cancel can race with the very first session creation and abort
     // its dedicated controller before a session id exists. SendMessage is the
@@ -4820,10 +4823,15 @@ export class OpenCodeServerHarness
 
     if (sessionId) {
       const stopDecision = this.evaluateSlackStopHook(sessionId);
+      let missingChatCloseoutReminderCount: number | null = null;
 
       if (stopDecision.blocked) {
         const reason =
           stopDecision.reason ?? FALLBACK_OPENCODE_STOP_HOOK_REMINDER;
+
+        if (finalized?.text.trim()) {
+          this.lastBlockedCloseoutAssistantText = finalized.text;
+        }
 
         if (this.stopHookReminderCount >= MAX_OPENCODE_STOP_HOOK_REMINDERS) {
           // Give up gracefully: complete the turn without a Slack closeout
@@ -4831,6 +4839,7 @@ export class OpenCodeServerHarness
           this.logger.warn(
             `OpenCode Slack closeout hook still blocked after ${MAX_OPENCODE_STOP_HOOK_REMINDERS} reminders; completing the turn without a Slack closeout reason=${reason}`,
           );
+          missingChatCloseoutReminderCount = this.stopHookReminderCount;
         } else {
           if (await this.hasUnsettledToolWork(sessionId)) {
             // The idle that triggered enforcement was stale: the session
@@ -4871,11 +4880,25 @@ export class OpenCodeServerHarness
 
       this.stopHookReminderCount = 0;
 
-      if (finalized?.text.trim()) {
-        this.runtimeEvents.turnCompleted(sessionId, finalized.text);
+      const completionText =
+        missingChatCloseoutReminderCount !== null && !finalized?.text.trim()
+          ? this.lastBlockedCloseoutAssistantText
+          : finalized?.text;
+
+      if (completionText?.trim()) {
+        this.runtimeEvents.turnCompleted(sessionId, completionText);
       }
 
-      this.runtimeEvents.taskCompleted(sessionId, finalized?.tokenUsage);
+      this.runtimeEvents.taskCompleted(sessionId, finalized?.tokenUsage, {
+        ...(missingChatCloseoutReminderCount !== null
+          ? {
+              missingChatCloseout: {
+                reminderCount: missingChatCloseoutReminderCount,
+              },
+            }
+          : {}),
+      });
+      this.lastBlockedCloseoutAssistantText = null;
     }
 
     await this.drainQueuedPrompts();
@@ -4925,8 +4948,20 @@ export class OpenCodeServerHarness
     );
 
     this.inFlight = false;
+    const reminderCount = this.stopHookReminderCount;
     this.stopHookReminderCount = 0;
-    this.runtimeEvents.taskCompleted(sessionId, undefined);
+
+    if (this.lastBlockedCloseoutAssistantText?.trim()) {
+      this.runtimeEvents.turnCompleted(
+        sessionId,
+        this.lastBlockedCloseoutAssistantText,
+      );
+    }
+
+    this.lastBlockedCloseoutAssistantText = null;
+    this.runtimeEvents.taskCompleted(sessionId, undefined, {
+      missingChatCloseout: { reminderCount },
+    });
 
     await this.drainQueuedPrompts();
   }

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/runtime-event-emitter.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/runtime-event-emitter.ts
@@ -11,6 +11,7 @@ import {
   type AcpRequestUserInputAnswers,
   type AcpRequestUserInputPayload,
   type AcpRequestUserInputResponsePayload,
+  type TaskCompletionMetadata,
   type TaskMessageContentBlock,
 } from '@roomote/types';
 
@@ -598,6 +599,7 @@ export class OpenCodeRuntimeEventEmitter extends RuntimeEnvelopeBuilder {
   taskCompleted(
     taskId: string,
     tokenUsage: Record<string, unknown> | undefined,
+    metadata: Partial<TaskCompletionMetadata> = {},
   ): void {
     const completionId = `${taskId}:${this.nextTs()}`;
     this.emitTaskEvent({
@@ -613,7 +615,7 @@ export class OpenCodeRuntimeEventEmitter extends RuntimeEnvelopeBuilder {
           contextTokens: Number(tokenUsage?.contextTokens ?? 0),
         },
         {},
-        { isSubtask: false, completionId },
+        { isSubtask: false, completionId, ...metadata },
       ],
     });
   }

--- a/packages/sdk/src/server/lib/task-runs/__tests__/missing-chat-closeout-fallback.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/missing-chat-closeout-fallback.test.ts
@@ -1,0 +1,60 @@
+const { redisDel, redisSet } = vi.hoisted(() => ({
+  redisDel: vi.fn(),
+  redisSet: vi.fn(),
+}));
+
+vi.mock('@roomote/redis', () => ({
+  getRedis: () => ({ del: redisDel, set: redisSet }),
+}));
+
+import {
+  claimMissingChatCloseoutFallbackDelivery,
+  releaseMissingChatCloseoutFallbackDelivery,
+} from '../missing-chat-closeout-fallback';
+
+describe('missing chat closeout fallback delivery claims', () => {
+  beforeEach(() => {
+    redisDel.mockReset();
+    redisSet.mockReset();
+  });
+
+  it('claims a run once with a bounded TTL', async () => {
+    redisSet.mockResolvedValue('OK');
+
+    await expect(
+      claimMissingChatCloseoutFallbackDelivery({
+        runId: 42,
+        completionId: 'completion-1',
+      }),
+    ).resolves.toEqual({ claimed: true });
+
+    expect(redisSet).toHaveBeenCalledWith(
+      'missing-chat-closeout-fallback:42:completion-1',
+      '1',
+      'EX',
+      604_800,
+      'NX',
+    );
+  });
+
+  it('reports duplicate claims and can release a failed delivery', async () => {
+    redisSet.mockResolvedValue(null);
+    redisDel.mockResolvedValue(1);
+
+    await expect(
+      claimMissingChatCloseoutFallbackDelivery({
+        runId: 42,
+        completionId: 'completion-1',
+      }),
+    ).resolves.toEqual({ claimed: false });
+
+    await releaseMissingChatCloseoutFallbackDelivery({
+      runId: 42,
+      completionId: 'completion-1',
+    });
+
+    expect(redisDel).toHaveBeenCalledWith(
+      'missing-chat-closeout-fallback:42:completion-1',
+    );
+  });
+});

--- a/packages/sdk/src/server/lib/task-runs/index.ts
+++ b/packages/sdk/src/server/lib/task-runs/index.ts
@@ -18,6 +18,7 @@ export * from './stamp-milestone';
 export * from './update-environment-setup';
 export * from './record-task-message-envelope';
 export * from './show-widget-fallback-delivery';
+export * from './missing-chat-closeout-fallback';
 export * from './record-task-inference-usage';
 export * from './record-compute-provider-usage';
 export * from './has-message-from-source';

--- a/packages/sdk/src/server/lib/task-runs/missing-chat-closeout-fallback.ts
+++ b/packages/sdk/src/server/lib/task-runs/missing-chat-closeout-fallback.ts
@@ -1,0 +1,31 @@
+import { getRedis } from '@roomote/redis';
+
+const MISSING_CHAT_CLOSEOUT_FALLBACK_CLAIM_TTL_SECONDS = 7 * 24 * 60 * 60;
+const MISSING_CHAT_CLOSEOUT_FALLBACK_CLAIM_KEY_PREFIX =
+  'missing-chat-closeout-fallback:';
+
+function getClaimKey(runId: number, completionId: string): string {
+  return `${MISSING_CHAT_CLOSEOUT_FALLBACK_CLAIM_KEY_PREFIX}${runId}:${completionId}`;
+}
+
+export async function claimMissingChatCloseoutFallbackDelivery(input: {
+  runId: number;
+  completionId: string;
+}): Promise<{ claimed: boolean }> {
+  const claim = await getRedis().set(
+    getClaimKey(input.runId, input.completionId),
+    '1',
+    'EX',
+    MISSING_CHAT_CLOSEOUT_FALLBACK_CLAIM_TTL_SECONDS,
+    'NX',
+  );
+
+  return { claimed: claim === 'OK' };
+}
+
+export async function releaseMissingChatCloseoutFallbackDelivery(input: {
+  runId: number;
+  completionId: string;
+}): Promise<void> {
+  await getRedis().del(getClaimKey(input.runId, input.completionId));
+}

--- a/packages/sdk/src/server/routers/task-runs.test.ts
+++ b/packages/sdk/src/server/routers/task-runs.test.ts
@@ -23,6 +23,8 @@ const {
   mockClaimShowWidgetFallbackDelivery,
   mockClearPendingSlackRequestUserInput,
   mockReleaseShowWidgetFallbackDelivery,
+  mockClaimMissingChatCloseoutFallbackDelivery,
+  mockReleaseMissingChatCloseoutFallbackDelivery,
   mockUpdateTaskRun,
 } = vi.hoisted(() => ({
   mockEnqueueTask: vi.fn(),
@@ -40,6 +42,8 @@ const {
   mockClaimShowWidgetFallbackDelivery: vi.fn(),
   mockClearPendingSlackRequestUserInput: vi.fn(),
   mockReleaseShowWidgetFallbackDelivery: vi.fn(),
+  mockClaimMissingChatCloseoutFallbackDelivery: vi.fn(),
+  mockReleaseMissingChatCloseoutFallbackDelivery: vi.fn(),
   mockUpdateTaskRun: vi.fn(),
 }));
 
@@ -103,6 +107,10 @@ vi.mock('../lib/task-runs', () => ({
   recordTaskMessageEnvelope: mockRecordTaskMessageEnvelope,
   claimShowWidgetFallbackDelivery: mockClaimShowWidgetFallbackDelivery,
   releaseShowWidgetFallbackDelivery: mockReleaseShowWidgetFallbackDelivery,
+  claimMissingChatCloseoutFallbackDelivery:
+    mockClaimMissingChatCloseoutFallbackDelivery,
+  releaseMissingChatCloseoutFallbackDelivery:
+    mockReleaseMissingChatCloseoutFallbackDelivery,
   refreshGitHubTokenWithMetadata: vi.fn(),
   revertPrCommit: vi.fn(),
   setTaskHarnessSessionId: vi.fn(),
@@ -548,6 +556,37 @@ describe('taskRunsRouter queue message guards', () => {
       runId: 42,
       toolCallId: 'call-1',
     });
+  });
+
+  it('claims and releases missing chat closeout fallback delivery for the matching run token', async () => {
+    mockClaimMissingChatCloseoutFallbackDelivery.mockResolvedValueOnce({
+      claimed: true,
+    });
+
+    await expect(
+      createRunCaller().claimMissingChatCloseoutFallbackDelivery({
+        runId: 42,
+        completionId: 'completion-1',
+      }),
+    ).resolves.toEqual({ claimed: true });
+
+    await expect(
+      createRunCaller().releaseMissingChatCloseoutFallbackDelivery({
+        runId: 42,
+        completionId: 'completion-1',
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mockClaimMissingChatCloseoutFallbackDelivery).toHaveBeenCalledWith({
+      runId: 42,
+      completionId: 'completion-1',
+    });
+    expect(mockReleaseMissingChatCloseoutFallbackDelivery).toHaveBeenCalledWith(
+      {
+        runId: 42,
+        completionId: 'completion-1',
+      },
+    );
   });
 
   it('rejects recordInferenceUsage for auth-token callers', async () => {

--- a/packages/sdk/src/server/routers/task-runs.ts
+++ b/packages/sdk/src/server/routers/task-runs.ts
@@ -111,6 +111,8 @@ import {
   findTaskRunByRunTokenClaims,
   claimShowWidgetFallbackDelivery,
   releaseShowWidgetFallbackDelivery,
+  claimMissingChatCloseoutFallbackDelivery,
+  releaseMissingChatCloseoutFallbackDelivery,
 } from '../lib/task-runs';
 import {
   findSlackConversationSubjectByUserId,
@@ -482,6 +484,20 @@ export const taskRunsRouter = router({
     }),
     'runId',
   ).mutation(({ input }) => releaseShowWidgetFallbackDelivery(input)),
+  claimMissingChatCloseoutFallbackDelivery: runTokenOnlyScoped(
+    z.object({
+      runId: z.number(),
+      completionId: z.string().trim().min(1).max(500),
+    }),
+    'runId',
+  ).mutation(({ input }) => claimMissingChatCloseoutFallbackDelivery(input)),
+  releaseMissingChatCloseoutFallbackDelivery: runTokenOnlyScoped(
+    z.object({
+      runId: z.number(),
+      completionId: z.string().trim().min(1).max(500),
+    }),
+    'runId',
+  ).mutation(({ input }) => releaseMissingChatCloseoutFallbackDelivery(input)),
   recordComputeProviderUsage: runScoped(
     z.object({
       runId: z.number(),

--- a/packages/sdk/src/task-runs.ts
+++ b/packages/sdk/src/task-runs.ts
@@ -232,6 +232,14 @@ export const releaseShowWidgetFallbackDelivery = (
   options: AppRouterInput['taskRuns']['releaseShowWidgetFallbackDelivery'],
 ) => client.taskRuns.releaseShowWidgetFallbackDelivery.mutate(options);
 
+export const claimMissingChatCloseoutFallbackDelivery = (
+  options: AppRouterInput['taskRuns']['claimMissingChatCloseoutFallbackDelivery'],
+) => client.taskRuns.claimMissingChatCloseoutFallbackDelivery.mutate(options);
+
+export const releaseMissingChatCloseoutFallbackDelivery = (
+  options: AppRouterInput['taskRuns']['releaseMissingChatCloseoutFallbackDelivery'],
+) => client.taskRuns.releaseMissingChatCloseoutFallbackDelivery.mutate(options);
+
 export const recordInferenceUsage = (
   options: AppRouterInput['taskRuns']['recordInferenceUsage'],
 ) => client.taskRuns.recordInferenceUsage.mutate(options);

--- a/packages/types/src/task-events.ts
+++ b/packages/types/src/task-events.ts
@@ -45,6 +45,14 @@ export type TaskToolUsage = Record<string, TaskToolUsageEntry>;
 export interface TaskCompletionMetadata {
   isSubtask: boolean;
   completionId?: string;
+  /**
+   * Present when a chat-backed turn exhausted its model closeout reminders
+   * without posting a terminal reply. The worker uses this to deliver the
+   * last finalized assistant message through the platform-owned chat path.
+   */
+  missingChatCloseout?: {
+    reminderCount: number;
+  };
 }
 
 export type TaskEventStartedPayload = [taskId: string];


### PR DESCRIPTION
## Summary

- retain the latest finalized assistant text while closeout reminders are active
- mark exhausted or wedged closeout completion events and deliver the retained text through the platform-owned chat reply path
- use a neutral message when no assistant text exists and a per-completion Redis claim to prevent duplicate delivery
- share chat fallback configuration with the existing widget fallback path

## Why

A task could exhaust its bounded closeout reminder loop and finish successfully without ever producing a channel-visible terminal reply. The reminder loop should remain bounded, but the originating chat should still receive the final assistant output.

## Impact

Chat-originated tasks no longer end silently when closeout reminders are exhausted. The task still completes normally, and the worker posts the last finalized assistant message to the originating thread.

## Validation

- `@roomote/worker`: 90 focused tests passed
- `@roomote/sdk`: 26 focused tests passed
- worker, SDK, and types TypeScript checks passed
- worker lint and changed-file SDK lint passed
- formatting and diff checks passed
- pre-push oxlint, residual lint, fast typechecks, and knip passed

Package-wide SDK ESLint still reports three pre-existing unused-disable warnings in unrelated files.
