### PR TITLE
[Fix] Release communication threads after task deletion

### DIFF
--- a/apps/api/src/handlers/slack/helpers/__tests__/conversation-log.test.ts
+++ b/apps/api/src/handlers/slack/helpers/__tests__/conversation-log.test.ts
@@ -2,10 +2,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   taskRunRowsMock,
+  whereMock,
   findBackgroundAutomationSlackThreadMock,
   getLatestSlackBotReplyMock,
 } = vi.hoisted(() => ({
   taskRunRowsMock: vi.fn(),
+  whereMock: vi.fn(),
   findBackgroundAutomationSlackThreadMock: vi.fn(),
   getLatestSlackBotReplyMock: vi.fn(),
 }));
@@ -27,7 +29,7 @@ vi.mock('@roomote/db/server', () => {
   const chain = {
     from: vi.fn(),
     innerJoin: vi.fn(),
-    where: vi.fn(),
+    where: whereMock,
     orderBy: vi.fn(),
     limit: vi.fn(async () => taskRunRowsMock()),
   };
@@ -41,6 +43,7 @@ vi.mock('@roomote/db/server', () => {
     db: { select: vi.fn(() => chain) },
     desc: vi.fn((value: unknown) => value),
     eq: vi.fn((left: unknown, right: unknown) => ({ left, right })),
+    isNull: vi.fn((value: unknown) => ({ isNull: value })),
     findBackgroundAutomationSlackThread:
       findBackgroundAutomationSlackThreadMock,
     taskRuns: {
@@ -51,6 +54,7 @@ vi.mock('@roomote/db/server', () => {
       taskId: 'taskRuns.taskId',
     },
     tasks: {
+      deletedAt: 'tasks.deletedAt',
       id: 'tasks.id',
       initiatorUserId: 'tasks.initiatorUserId',
       slackThreadTs: 'tasks.slackThreadTs',
@@ -100,5 +104,16 @@ describe('findRoomoteOwnedSlackThread', () => {
     });
 
     await expect(findRoomoteOwnedSlackThread(THREAD)).resolves.toBeNull();
+  });
+
+  it('does not treat soft-deleted task bindings as thread ownership', async () => {
+    await findRoomoteOwnedSlackThread(THREAD);
+
+    expect(whereMock).toHaveBeenNthCalledWith(1, {
+      conditions: [
+        { left: 'tasks.slackThreadTs', right: THREAD.threadTs },
+        { isNull: 'tasks.deletedAt' },
+      ],
+    });
   });
 });

--- a/apps/api/src/handlers/slack/helpers/conversation-log.ts
+++ b/apps/api/src/handlers/slack/helpers/conversation-log.ts
@@ -14,6 +14,7 @@ import {
   desc,
   eq,
   findBackgroundAutomationSlackThread,
+  isNull,
   taskRuns,
   tasks,
   type SlackUserMapping,
@@ -79,7 +80,9 @@ export async function findRoomoteOwnedSlackThread(params: {
     })
     .from(tasks)
     .innerJoin(taskRuns, eq(taskRuns.taskId, tasks.id))
-    .where(eq(tasks.slackThreadTs, params.threadTs))
+    .where(
+      and(eq(tasks.slackThreadTs, params.threadTs), isNull(tasks.deletedAt)),
+    )
     .limit(10);
 
   const existingSlackTaskRuns = existingSlackRows.map((row) => ({
@@ -168,6 +171,7 @@ export async function findRoomoteOwnedSlackThread(params: {
         and(
           eq(tasks.id, sourceTaskId),
           eq(tasks.slackThreadTs, params.threadTs),
+          isNull(tasks.deletedAt),
         ),
       )
       .orderBy(desc(taskRuns.createdAt))

--- a/apps/api/src/handlers/teams/__tests__/find-active-teams-run.test.ts
+++ b/apps/api/src/handlers/teams/__tests__/find-active-teams-run.test.ts
@@ -30,7 +30,9 @@ vi.mock('@roomote/db/server', () => ({
     result: 'result',
   },
   tasks: {
+    deletedAt: 'tasks.deletedAt',
     id: 'tasks.id',
+    initiatorKind: 'tasks.initiatorKind',
     initiatorUserId: 'tasks.initiatorUserId',
   },
   db: {
@@ -66,6 +68,9 @@ import { activeRunStatuses } from '@roomote/types';
 import {
   buildTeamsTaskRunMatchConditions,
   findActiveTeamsTaskRun,
+  findCompletedTeamsTaskRunWithSnapshot,
+  findLatestTeamsThreadTaskRun,
+  findTaskBackedTeamsAutomationReportRun,
   stripTeamsMessageIdSuffix,
 } from '../find-active-teams-run';
 
@@ -185,8 +190,8 @@ describe('findActiveTeamsTaskRun', () => {
     };
     // The where clause includes the Teams provider match, the conversation
     // match (or-group), the thread match, the active-status filter, and the
-    // not-canceled filter.
-    expect(where.and).toHaveLength(5);
+    // not-canceled and not-deleted filters.
+    expect(where.and).toHaveLength(6);
 
     const conversationMatch = where.and.find(
       (entry) =>
@@ -203,5 +208,20 @@ describe('findActiveTeamsTaskRun', () => {
       expect(condition.values).toContain('19:conv@thread.tacv2');
     }
     expect([...activeRunStatuses]).toContain('running');
+  });
+
+  it.each([
+    ['active', findActiveTeamsTaskRun],
+    ['snapshot', findCompletedTeamsTaskRunWithSnapshot],
+    ['thread ownership', findLatestTeamsThreadTaskRun],
+    ['automation ownership', findTaskBackedTeamsAutomationReportRun],
+  ])('excludes deleted tasks from %s lookup', async (_name, lookup) => {
+    await lookup({
+      conversationId: '19:conv@thread.tacv2;messageid=root-1',
+      threadId: 'root-1',
+    });
+
+    const where = selectWhereMock.mock.calls[0]?.[0] as { and: unknown[] };
+    expect(where.and).toContainEqual({ isNull: 'tasks.deletedAt' });
   });
 });

--- a/apps/api/src/handlers/teams/find-active-teams-run.ts
+++ b/apps/api/src/handlers/teams/find-active-teams-run.ts
@@ -132,6 +132,7 @@ export async function findActiveTeamsTaskRun(input: {
         threadMatch,
         inArray(taskRuns.status, [...activeRunStatuses]),
         isNull(taskRuns.canceledAt),
+        isNull(tasks.deletedAt),
       ),
     )
     .orderBy(desc(taskRuns.createdAt))
@@ -157,6 +158,7 @@ export async function findCompletedTeamsTaskRunWithSnapshot(input: {
         threadMatch,
         inArray(taskRuns.status, [RunStatus.Completed]),
         isNull(taskRuns.canceledAt),
+        isNull(tasks.deletedAt),
         sql`${taskRuns.snapshotId} IS NOT NULL`,
         sql`${taskRuns.snapshotCreatedAt} IS NOT NULL`,
       ),
@@ -193,7 +195,14 @@ export async function findLatestTeamsThreadTaskRun(input: {
     })
     .from(taskRuns)
     .innerJoin(tasks, eq(taskRuns.taskId, tasks.id))
-    .where(and(teamsProviderMatch, conversationMatch, threadMatch))
+    .where(
+      and(
+        teamsProviderMatch,
+        conversationMatch,
+        threadMatch,
+        isNull(tasks.deletedAt),
+      ),
+    )
     .orderBy(desc(taskRuns.createdAt))
     .limit(1);
 
@@ -222,6 +231,7 @@ export async function findTaskBackedTeamsAutomationReportRun(input: {
         threadMatch,
         eq(tasks.initiatorKind, 'automation'),
         isNull(taskRuns.canceledAt),
+        isNull(tasks.deletedAt),
       ),
     )
     .orderBy(asc(taskRuns.createdAt))

--- a/packages/sdk/src/server/lib/communication/__tests__/communication-task-run-lookup.db.test.ts
+++ b/packages/sdk/src/server/lib/communication/__tests__/communication-task-run-lookup.db.test.ts
@@ -1,0 +1,83 @@
+import { randomUUID } from 'node:crypto';
+
+import { db, eq, taskFactory, taskRuns, tasks } from '@roomote/db/server';
+import { RunStatus, TaskPayloadKind } from '@roomote/types';
+
+import {
+  findActiveCommunicationTaskRun,
+  findCompletedCommunicationTaskRunWithSnapshot,
+} from '../communication-task-run-lookup';
+
+function discordConversation(suffix: string) {
+  return {
+    provider: 'discord' as const,
+    channelId: `channel-${suffix}`,
+    threadId: `thread-${suffix}`,
+  };
+}
+
+function discordPayload(conversation: ReturnType<typeof discordConversation>) {
+  return {
+    repo: 'acme/repo',
+    description: 'Test Discord task',
+    communicationProvider: conversation.provider,
+    communicationChannelId: conversation.channelId,
+    communicationThreadId: conversation.threadId,
+  };
+}
+
+describe('communication task lookup deletion boundaries (real database)', () => {
+  it('releases a Discord thread when its active task is soft-deleted', async () => {
+    const conversation = discordConversation(randomUUID());
+    const task = await taskFactory.create();
+    const [run] = await db
+      .insert(taskRuns)
+      .values({
+        taskId: task.id,
+        payloadKind: TaskPayloadKind.StandardTask,
+        status: RunStatus.Running,
+        payload: discordPayload(conversation),
+      })
+      .returning({ id: taskRuns.id });
+    if (!run) throw new Error('Expected task run to be created');
+
+    await expect(
+      findActiveCommunicationTaskRun(conversation),
+    ).resolves.toMatchObject({ id: run.id, taskId: task.id });
+
+    await db
+      .update(tasks)
+      .set({ deletedAt: new Date() })
+      .where(eq(tasks.id, task.id));
+
+    await expect(
+      findActiveCommunicationTaskRun(conversation),
+    ).resolves.toBeUndefined();
+  });
+
+  it('does not resume a deleted task snapshot from its former Discord thread', async () => {
+    const conversation = discordConversation(randomUUID());
+    const task = await taskFactory.create();
+    await db.insert(taskRuns).values({
+      taskId: task.id,
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Completed,
+      payload: discordPayload(conversation),
+      snapshotId: `snapshot-${randomUUID()}`,
+      snapshotCreatedAt: new Date(),
+    });
+
+    await expect(
+      findCompletedCommunicationTaskRunWithSnapshot(conversation),
+    ).resolves.toMatchObject({ taskId: task.id });
+
+    await db
+      .update(tasks)
+      .set({ deletedAt: new Date() })
+      .where(eq(tasks.id, task.id));
+
+    await expect(
+      findCompletedCommunicationTaskRunWithSnapshot(conversation),
+    ).resolves.toBeNull();
+  });
+});

--- a/packages/sdk/src/server/lib/communication/__tests__/communication-task-run-lookup.test.ts
+++ b/packages/sdk/src/server/lib/communication/__tests__/communication-task-run-lookup.test.ts
@@ -45,6 +45,7 @@ vi.mock('@roomote/db/server', () => {
       taskId: 'taskRuns.taskId',
     },
     tasks: {
+      deletedAt: 'tasks.deletedAt',
       id: 'tasks.id',
       initiatorKind: 'tasks.initiatorKind',
       initiatorUserId: 'tasks.initiatorUserId',
@@ -194,5 +195,17 @@ describe('findActiveCommunicationTaskRun', () => {
       left: 'taskRuns.taskId',
       right: 'task-1',
     });
+  });
+
+  it('does not let a soft-deleted task retain conversation ownership', async () => {
+    queryResults.push([]);
+
+    await findActiveCommunicationTaskRun({
+      provider: 'discord',
+      channelId: 'channel-1',
+      threadId: 'thread-1',
+    });
+
+    expect(whereConditions()).toContainEqual({ isNull: 'tasks.deletedAt' });
   });
 });

--- a/packages/sdk/src/server/lib/communication/communication-task-run-lookup.ts
+++ b/packages/sdk/src/server/lib/communication/communication-task-run-lookup.ts
@@ -85,6 +85,7 @@ export async function findActiveCommunicationTaskRun(
         ...(input.taskId ? [eq(taskRuns.taskId, input.taskId)] : []),
         inArray(taskRuns.status, [...activeRunStatuses]),
         isNull(taskRuns.canceledAt),
+        isNull(tasks.deletedAt),
       ),
     )
     .orderBy(desc(taskRuns.createdAt))
@@ -109,6 +110,7 @@ export async function findCompletedCommunicationTaskRunWithSnapshot(
         ...(input.taskId ? [eq(taskRuns.taskId, input.taskId)] : []),
         inArray(taskRuns.status, [RunStatus.Completed]),
         isNull(taskRuns.canceledAt),
+        isNull(tasks.deletedAt),
         sql`${taskRuns.snapshotId} IS NOT NULL`,
         sql`${taskRuns.snapshotCreatedAt} IS NOT NULL`,
       ),
@@ -147,6 +149,7 @@ export async function findTaskBackedAutomationReportRun(input: {
         sql`${taskRuns.payload}->>'communicationMessageId' = ${input.messageId}`,
         eq(tasks.initiatorKind, 'automation'),
         isNull(taskRuns.canceledAt),
+        isNull(tasks.deletedAt),
       ),
     )
     // A report root is immutable. Prefer its first binding if historical data
@@ -185,7 +188,13 @@ export async function findTaskBackedAutomationReportRun(input: {
     .select(ACTIVE_SELECTION)
     .from(taskRuns)
     .innerJoin(tasks, eq(taskRuns.taskId, tasks.id))
-    .where(and(eq(taskRuns.taskId, sourceTaskId), isNull(taskRuns.canceledAt)))
+    .where(
+      and(
+        eq(taskRuns.taskId, sourceTaskId),
+        isNull(taskRuns.canceledAt),
+        isNull(tasks.deletedAt),
+      ),
+    )
     .orderBy(asc(taskRuns.createdAt))
     .limit(1);
 

--- a/packages/slack/src/__tests__/find-active-slack-task-run.test.ts
+++ b/packages/slack/src/__tests__/find-active-slack-task-run.test.ts
@@ -17,6 +17,7 @@ vi.mock('@roomote/db/server', () => {
   return {
     and: vi.fn((...args: unknown[]) => ({ and: args })),
     tasks: {
+      deletedAt: 'tasks.deletedAt',
       id: 'tasks.id',
       slackThreadTs: 'tasks.slackThreadTs',
     },
@@ -73,6 +74,7 @@ describe('findActiveSlackTaskRun', () => {
         }),
         { inArray: ['taskRuns.status', [...activeRunStatuses]] },
         { isNull: 'taskRuns.canceledAt' },
+        { isNull: 'tasks.deletedAt' },
       ],
     });
   });
@@ -114,6 +116,7 @@ describe('findActiveSlackTaskRun', () => {
         }),
         { inArray: ['taskRuns.status', [...activeRunStatuses]] },
         { isNull: 'taskRuns.canceledAt' },
+        { isNull: 'tasks.deletedAt' },
       ],
     });
   });

--- a/packages/slack/src/__tests__/find-completed-slack-task-run-with-snapshot.test.ts
+++ b/packages/slack/src/__tests__/find-completed-slack-task-run-with-snapshot.test.ts
@@ -16,6 +16,7 @@ vi.mock('@roomote/db/server', () => {
   return {
     and: vi.fn((...args: unknown[]) => ({ and: args })),
     tasks: {
+      deletedAt: 'tasks.deletedAt',
       id: 'tasks.id',
       slackThreadTs: 'tasks.slackThreadTs',
     },
@@ -69,6 +70,7 @@ describe('findCompletedSlackTaskRunWithSnapshot', () => {
             'T-second',
           ]),
         }),
+        { isNull: 'tasks.deletedAt' },
       ]),
     });
   });

--- a/packages/slack/src/find-active-slack-task-run.ts
+++ b/packages/slack/src/find-active-slack-task-run.ts
@@ -53,6 +53,7 @@ export async function findActiveSlackTaskRun(
           : []),
         inArray(taskRuns.status, [...activeRunStatuses]),
         isNull(taskRuns.canceledAt),
+        isNull(tasks.deletedAt),
       ),
     )
     .orderBy(desc(taskRuns.createdAt))
@@ -86,6 +87,7 @@ export async function findActiveSlackTaskRun(
           ...(scope.slackTeamId
             ? [getSlackTaskRunWorkspacePredicate(scope.slackTeamId)]
             : []),
+          isNull(tasks.deletedAt),
         ),
       )
       .orderBy(desc(taskRuns.createdAt))

--- a/packages/slack/src/find-completed-slack-task-run-with-snapshot.ts
+++ b/packages/slack/src/find-completed-slack-task-run-with-snapshot.ts
@@ -64,6 +64,7 @@ export async function findCompletedSlackTaskRunWithSnapshot(
         isNotNull(taskRuns.snapshotId),
         isNull(taskRuns.snapshotFailedAt),
         isNull(taskRuns.canceledAt),
+        isNull(tasks.deletedAt),
         gt(taskRuns.snapshotCreatedAt, snapshotCutoff),
       ),
     )


### PR DESCRIPTION
## Summary

- exclude soft-deleted tasks from active communication-run lookup
- exclude soft-deleted tasks from resumable snapshot and automation-report lookup
- add unit and real-database regression coverage for releasing a communication thread after task deletion

## Root cause

Task deletion sets `tasks.deletedAt`, but the communication conversation lookup joined `tasks` without filtering deleted rows. A deleted task could therefore continue to own its Slack, Discord, Telegram, or Teams conversation invisibly, preventing a replacement task from starting there.

## Validation

- `pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/sdk exec vitest run src/server/lib/communication/__tests__/communication-task-run-lookup.test.ts src/server/lib/communication/__tests__/communication-task-run-lookup.db.test.ts`
- `pnpm --filter @roomote/sdk check-types`
- targeted ESLint for the three changed files
- `git diff --check`
