### PR TITLE
Fix gbrain publish build context

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -207,24 +207,28 @@ jobs:
       matrix:
         include:
           - app: app
+            context: .
             dockerfile: .docker/app/Dockerfile
             target: runtime-app
             image: roomote-app
             arch: amd64
             runner: blacksmith-4vcpu-ubuntu-2404
           - app: app
+            context: .
             dockerfile: .docker/app/Dockerfile
             target: runtime-app
             image: roomote-app
             arch: arm64
             runner: blacksmith-4vcpu-ubuntu-2404-arm
           - app: worker
+            context: .
             dockerfile: apps/worker/Dockerfile
             target: runtime
             image: roomote-worker
             arch: amd64
             runner: blacksmith-4vcpu-ubuntu-2404
           - app: worker
+            context: .
             dockerfile: apps/worker/Dockerfile
             target: runtime
             image: roomote-worker
@@ -233,11 +237,13 @@ jobs:
           # The Brain (deployment-hosted gbrain). Published so template-based
           # deployments (Railway) can run it without a build step.
           - app: gbrain
+            context: .docker/gbrain
             dockerfile: .docker/gbrain/Dockerfile
             image: roomote-gbrain
             arch: amd64
             runner: blacksmith-4vcpu-ubuntu-2404
           - app: gbrain
+            context: .docker/gbrain
             dockerfile: .docker/gbrain/Dockerfile
             image: roomote-gbrain
             arch: arm64
@@ -264,7 +270,7 @@ jobs:
         id: build
         uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2
         with:
-          context: .
+          context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           target: ${{ matrix.target }}
           platforms: linux/${{ matrix.arch }}


### PR DESCRIPTION
## What changed

- Add an explicit build context to every GHCR image matrix entry.
- Build the gbrain image from `.docker/gbrain` while preserving the repository-root context for the app and worker images.

## Why

The gbrain Dockerfile copies `entrypoint.sh` relative to its own directory, but the publish workflow invoked BuildKit with the repository root as its context. Both architecture jobs therefore failed before the image build with `"/entrypoint.sh": not found`.

## Impact

The amd64 and arm64 gbrain publish jobs can now include their entrypoint and produce image digests. App and worker publishing behavior is unchanged.

## Validation

- Built the complete amd64 gbrain image locally with BuildKit using the corrected context.
- `pnpm test:release-scripts` (16 tests passed).
- Repository pre-push checks passed: oxlint, residual lint, fast type checks, and knip.
- `git diff --check` passed.
