### PR TITLE
Fix Slack Brain page dates

### DIFF
--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-collectors.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-collectors.test.ts
@@ -536,6 +536,8 @@ describe('groupSlackMessagesIntoDayPages', () => {
       `slack/T1/C1/2026-08-14/${day2Ts}-${day2Ts}`.replaceAll('.', '-'),
     ]);
     expect(pages[0]?.title).toBe('#general — 2026-08-13');
+    expect(pages[0]?.content).toMatch(/^---\ndate: 2026-08-13\n---\n\n/);
+    expect(pages[2]?.content).toMatch(/^---\ndate: 2026-08-14\n---\n\n/);
     expect(pages[0]?.content).toContain(
       'Slack public channel #general (C1), messages on 2026-08-13',
     );

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors.ts
@@ -452,6 +452,10 @@ export function groupSlackMessagesIntoDayPages(
           slug: `slack/${group.teamId}/${group.channelId}/${group.day}/${firstTs}-${lastTs}`,
           title: `#${group.channelName} — ${group.day}`,
           content: [
+            '---',
+            `date: ${group.day}`,
+            '---',
+            '',
             `Slack public channel #${group.channelName} (${group.channelId}), messages on ${group.day} (times UTC).`,
             '',
             ...lines,


### PR DESCRIPTION
## Summary

- add each Slack page's source day as YAML `date` frontmatter
- cover pages from different Slack days with a regression test

## Why

Slack page slugs end with message timestamp bounds so incremental batches remain immutable. GBrain derives a page's effective date from date frontmatter or a date-prefixed final slug segment; without either, it fell back to the ingestion time. Historical Slack pages ingested during a backfill therefore appeared to be current.

This change preserves the immutable slug scheme while giving GBrain the actual day represented by each page.

## Validation

- `pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/bullmq exec vitest run src/scheduled-jobs/__tests__/brain-collectors.test.ts src/scheduled-jobs/__tests__/brain-slack-collector.test.ts`
- `pnpm --filter @roomote/bullmq check-types`
- targeted ESLint and formatting checks for the changed files
- repository pre-push checks
