### PR TITLE
[Fix] Make Brain-first retrieval reliable

### DIFF
--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-outbox-drain.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-outbox-drain.test.ts
@@ -63,6 +63,26 @@ describe('task memory page identity', () => {
     expect(first.slug).toBe('tasks/task-1/runs/101');
     expect(followUp.slug).toBe('tasks/task-1/runs/102');
   });
+
+  it('dates live and backfilled memories by task completion', () => {
+    const page = buildMemoryPage({ ...base, runId: 101 });
+
+    expect(page.content).toContain('\ndate: 2026-08-13\n');
+    expect(page.content).toContain(
+      '\ncompleted_at: 2026-08-13T10:00:00.000Z\n',
+    );
+  });
+
+  it('does not emit an invalid date when legacy completion time is missing', () => {
+    const page = buildMemoryPage({
+      ...base,
+      completedAt: null,
+      runId: 101,
+    });
+
+    expect(page.content).not.toContain('\ndate:');
+    expect(page.content).toContain('\ncompleted_at: unknown\n');
+  });
 });
 
 describe('redactBrainText', () => {

--- a/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
@@ -178,7 +178,9 @@ export function buildMemoryPage(input: {
     prUrl: string;
   }>;
 }): IngestPage {
-  const completed = input.completedAt?.toISOString() ?? 'unknown';
+  const completedAtIso = input.completedAt?.toISOString();
+  const completed = completedAtIso ?? 'unknown';
+  const completedDate = completedAtIso?.slice(0, 10);
   const prLines = input.pullRequests.map((pr) => {
     const label =
       pr.repository && pr.prNumber
@@ -192,6 +194,10 @@ export function buildMemoryPage(input: {
     '---',
     `roomote_task_id: ${input.taskId}`,
     `roomote_run_id: ${input.runId}`,
+    // GBrain derives effective_date from this conventional field. Keep the
+    // full timestamp below as provenance, but make backfilled pages sort and
+    // filter by when the task completed rather than when it was ingested.
+    ...(completedDate ? [`date: ${completedDate}`] : []),
     `completed_at: ${completed}`,
     // Environment stamp: costs nothing now, enables environment-scoped
     // retrieval (gbrain sources) or admin triage later without re-ingesting.

--- a/packages/cloud-agents/src/server/workflows/__tests__/skillInvocationRouting.test.ts
+++ b/packages/cloud-agents/src/server/workflows/__tests__/skillInvocationRouting.test.ts
@@ -85,6 +85,15 @@ describe('packaged skill invocation routing', () => {
       'Do not assume repository inspection is relevant',
     );
     expect(generalSkill).toContain(
+      'call `query` and wait for its result before choosing or calling any overlapping source',
+    );
+    expect(generalSkill).toContain(
+      'Never put the Brain query and an overlapping integration lookup in the same parallel batch',
+    );
+    expect(generalSkill).toContain(
+      'freshness beyond its collection window could materially change the answer',
+    );
+    expect(generalSkill).toContain(
       'repository or workspace file edits or commands, validation of repository changes, or code delivery',
     );
     expect(generalSkill).not.toContain(

--- a/packages/cloud-agents/src/server/workflows/skills/standard/explore-and-act/SKILL.md
+++ b/packages/cloud-agents/src/server/workflows/skills/standard/explore-and-act/SKILL.md
@@ -28,6 +28,7 @@ You are a general task execution specialist. Determine whether the user needs a 
           <action>Prefer a targeted integration or domain tool over indirect repository guesses, broad shell exploration, or generic web search.</action>
           <action>When an available specialist skill clearly matches the named system and requested work, load it before deeper tool use.</action>
           <action>If a specialist skill has stricter safety, mutation, approval, or reporting rules, those narrower rules override this general workflow.</action>
+          <action>When the `gbrain` server is connected, treat its Brain instructions as a required sequential preflight for every new substantive topic: call `query` and wait for its result before choosing or calling any overlapping source. Never put the Brain query and an overlapping integration lookup in the same parallel batch.</action>
           <action>Verify that the required tool, integration, credentials, and scope are available with the narrowest useful lookup.</action>
           <action>Do not assume repository inspection is relevant. Read code only when it helps answer or validate the request.</action>
         </actions>
@@ -41,6 +42,7 @@ You are a general task execution specialist. Determine whether the user needs a 
         <title>Gather evidence when needed</title>
         <actions>
           <action>Query the narrowest useful evidence first and broaden only when the initial result is insufficient.</action>
+          <action>After a Brain preflight, consult an underlying source that the Brain ingests only when its result lacks sufficient coverage, freshness beyond its collection window could materially change the answer, or the user explicitly requested live verification. Use the narrowest lookup that closes that gap instead of sweeping the integration.</action>
           <action>Check mutable facts live instead of relying on remembered state.</action>
           <action>Cross-check another source only when it can materially change confidence or resolve a contradiction.</action>
           <action>Stop when the user's question is answered; do not expand a focused request into a general audit.</action>

--- a/packages/types/src/brain.test.ts
+++ b/packages/types/src/brain.test.ts
@@ -1,0 +1,21 @@
+import { BRAIN_MCP_INSTRUCTIONS } from './brain';
+
+describe('BRAIN_MCP_INSTRUCTIONS', () => {
+  it('makes Brain recall a sequential gate before overlapping sources', () => {
+    expect(BRAIN_MCP_INSTRUCTIONS).toContain(
+      'run one `query` about the area you are about to touch and wait for its result',
+    );
+    expect(BRAIN_MCP_INSTRUCTIONS).toContain(
+      'Never issue the Brain query and an overlapping Slack, GitHub, meeting, task-history, or pull-request lookup in the same parallel batch',
+    );
+  });
+
+  it('allows narrow live-source fallback only for an explicit coverage or freshness gap', () => {
+    expect(BRAIN_MCP_INSTRUCTIONS).toContain(
+      'the Brain lacks enough coverage, freshness beyond its collection window could materially change the answer, or the user explicitly asks for live verification',
+    );
+    expect(BRAIN_MCP_INSTRUCTIONS).toContain(
+      'do not sweep an entire integration when the Brain already answers the question',
+    );
+  });
+});

--- a/packages/types/src/brain.ts
+++ b/packages/types/src/brain.ts
@@ -36,7 +36,11 @@ export const BRAIN_MCP_INSTRUCTIONS = `The \`gbrain\` server is this deployment'
 
 ## Using what it knows
 
-Start substantive work with one \`query\` pass, before assuming there is no prior context. Ask it about the area you are about to touch. You will often not know in advance that a convention exists, that this was attempted before, or that the user has already corrected someone on it, which is exactly why the pass is unprompted rather than something you do once a question occurs to you. Reading is read-only and cheap next to the work it saves; one pass at the start beats skipping it.
+Treat Brain recall as a sequential preflight, not one source in a parallel research batch. Before drafting the first answer on a new substantive topic, run one \`query\` about the area you are about to touch and wait for its result. Do this before deciding that your existing knowledge is sufficient and before selecting or calling another source that overlaps with what the Brain ingests. Never issue the Brain query and an overlapping Slack, GitHub, meeting, task-history, or pull-request lookup in the same parallel batch.
+
+This gate applies when the request involves factual claims, recommendations, company practices, prior decisions, product strategy, people, activity history, or other nontrivial reasoning. Skip it only for greetings and casual conversation, simple calculations or transformations, exact actions requiring no contextual judgment, and follow-ups already covered by a Brain query in the current thread. You will often not know in advance that a convention exists, that something was attempted before, or that the user already corrected someone on it, which is exactly why the pass is unprompted.
+
+Brain-first does not mean Brain-only. After evaluating its result, consult an underlying live source only when the Brain lacks enough coverage, freshness beyond its collection window could materially change the answer, or the user explicitly asks for live verification. Use the narrowest lookup needed to close that specific gap; do not sweep an entire integration when the Brain already answers the question. Reading is read-only and cheap next to the work it saves, and this ordering lets the Brain prevent redundant source exploration.
 
 Which tool:
 - \`query\` when you are describing a concept and do not know how the Brain words it. It expands your phrasing into related queries, so it finds pages that talk about the same thing in different language. This is the default, and the right choice for that first pass.


### PR DESCRIPTION
## Summary

- make Brain recall a sequential preflight for substantive `explore-and-act` work
- require agents to await the Brain result before calling overlapping integrations
- limit live-source fallback to concrete coverage, freshness, or explicit verification needs
- date task-memory pages by task completion for both live ingestion and initial backfill
- add prompt and task-page contract coverage

## Why

Two issues made time-sensitive Brain retrieval unreliable:

1. The existing guidance said to start substantive work with a Brain query, but it did not make that query a gate. Agents could skip recall entirely or launch Brain and an underlying source such as Slack in parallel, defeating shared memory and triggering broad, redundant integration reads.
2. Task-memory pages recorded `completed_at`, but GBrain derives `effective_date` from the conventional `date` frontmatter field. Backfilled July tasks therefore appeared to be from the day they were ingested and polluted queries about activity “today.”

With this change, deployments that expose `gbrain` query it first and evaluate the result before selecting an overlapping source. Task pages include the UTC completion day GBrain expects while retaining the full completion timestamp for provenance. Deployments without Brain continue using the normal workflow.

## Validation

- targeted Vitest coverage for `@roomote/types`, `@roomote/cloud-agents`, and `@roomote/bullmq`
- package typechecks, formatting, and targeted lint
- `pnpm lint:fast`
- `pnpm check-types:fast`
- pre-push oxlint, residual lint, typecheck, and knip gates
