### PR TITLE
Run gbrain on Postgres with native maintenance

### DIFF
--- a/.docker/gbrain/Dockerfile
+++ b/.docker/gbrain/Dockerfile
@@ -11,6 +11,10 @@ FROM oven/bun:1.3.14
 
 ARG GBRAIN_REF=ac402f5
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends postgresql-client \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN bun install -g "github:garrytan/gbrain#${GBRAIN_REF}"
 
 # bun hoists global deps, but gbrain resolves its PGLite wasm assets relative

--- a/.docker/gbrain/Dockerfile
+++ b/.docker/gbrain/Dockerfile
@@ -4,9 +4,8 @@
 # tracking master. Install comes from the GitHub repo, NOT npm: an unrelated
 # npm package shadows the name.
 #
-# v1 runs PGLite-on-volume (verified in the M0 spike; a single long-lived
-# serve process is exactly our topology, and gbrain locks the brain to one
-# process anyway). Postgres + pgvector is the at-scale upgrade path.
+# Postgres + pgvector backs both the HTTP server and gbrain's durable job
+# worker. The worker is required for Roomote-scheduled maintenance cycles.
 FROM oven/bun:1.3.14
 
 ARG GBRAIN_REF=ac402f5
@@ -31,7 +30,8 @@ RUN set -e; \
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# Brain data, minted tokens, and config live on the volume.
+# Generated tokens and local service config live on the volume; corpus data
+# lives in Postgres.
 VOLUME /data
 ENV GBRAIN_DATA_DIR=/data
 

--- a/.docker/gbrain/entrypoint.sh
+++ b/.docker/gbrain/entrypoint.sh
@@ -56,15 +56,31 @@ if [ -n "${GBRAIN_DATABASE_URL:-}" ]; then
       ;;
   esac
 
-  : "${PGHOST:?PGHOST is required with GBRAIN_DATABASE_URL}"
-  : "${PGUSER:?PGUSER is required with GBRAIN_DATABASE_URL}"
-  : "${PGPASSWORD:?PGPASSWORD is required with GBRAIN_DATABASE_URL}"
-  : "${PGDATABASE:?PGDATABASE is required with GBRAIN_DATABASE_URL}"
+  DATABASE_SEED_URL="${GBRAIN_DATABASE_BOOTSTRAP_URL:-$GBRAIN_DATABASE_URL}"
+  if [ -n "${GBRAIN_DATABASE_BOOTSTRAP_URL:-}" ]; then
+    DATABASE_BOOTSTRAP_URL="$GBRAIN_DATABASE_BOOTSTRAP_URL"
+  else
+    DATABASE_BOOTSTRAP_URL="$(DATABASE_BOOTSTRAP_URL="$DATABASE_SEED_URL" \
+      bun -e '
+        const url = new URL(Bun.env.DATABASE_BOOTSTRAP_URL);
+        url.pathname = "/postgres";
+        console.log(url.toString());
+      ')"
+  fi
+
+  GBRAIN_DATABASE_URL="$(DATABASE_SEED_URL="$DATABASE_SEED_URL" \
+    GBRAIN_DATABASE_NAME="$GBRAIN_DATABASE_NAME" \
+    bun -e '
+      const url = new URL(Bun.env.DATABASE_SEED_URL);
+      url.pathname = `/${Bun.env.GBRAIN_DATABASE_NAME}`;
+      console.log(url.toString());
+    ')"
+  export GBRAIN_DATABASE_URL
 
   echo "[gbrain-entrypoint] ensuring isolated Postgres database $GBRAIN_DATABASE_NAME"
   # Both the server and cron service can boot during the first deployment.
   # A session advisory lock keeps their check-and-create sequence atomic.
-  psql --no-psqlrc --quiet -v ON_ERROR_STOP=1 \
+  psql --dbname="$DATABASE_BOOTSTRAP_URL" --no-psqlrc --quiet -v ON_ERROR_STOP=1 \
     -v brain_database="$GBRAIN_DATABASE_NAME" <<'SQL'
 SELECT pg_advisory_lock(hashtext('roomote-gbrain-database-bootstrap')) AS locked \gset
 SELECT format('CREATE DATABASE %I', :'brain_database')

--- a/.docker/gbrain/entrypoint.sh
+++ b/.docker/gbrain/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Brain bootstrap: init-once, then serve.
+# Brain bootstrap: init-once, then serve or run one maintenance cycle.
 #
 # Credential provisioning happens over gbrain's admin HTTP API at connect
 # time (Roomote registers its own scoped OAuth clients), so nothing is
@@ -15,6 +15,7 @@ BRAIN_DIR="$DATA_DIR/brain"
 TOKEN_FILE="$DATA_DIR/admin-bootstrap-token"
 CONFIG_FILE="$DATA_DIR/.gbrain/config.json"
 PORT="${GBRAIN_PORT:-8931}"
+PROCESS="${GBRAIN_PROCESS:-serve}"
 # Width of the vector column, fixed when the brain is created. Defaults to
 # text-embedding-3-small, which is what both providers serve by default.
 # Overriding it means overriding the embedding model to match: a column sized
@@ -24,6 +25,14 @@ EMBEDDING_DIMENSIONS="${GBRAIN_EMBEDDING_DIMENSIONS:-1536}"
 
 mkdir -p "$DATA_DIR"
 
+case "$PROCESS" in
+  serve | dream) ;;
+  *)
+    echo "[gbrain-entrypoint] unknown GBRAIN_PROCESS '$PROCESS' (expected serve or dream)" >&2
+    exit 2
+    ;;
+esac
+
 # gbrain keeps its registration in $HOME/.gbrain, not in the data dir.
 # Anchor HOME on the volume so a rebuilt container still knows its brain.
 export HOME="$DATA_DIR"
@@ -32,6 +41,39 @@ export HOME="$DATA_DIR"
 # exactly one gbrain process, and a killed container leaves a lock recording
 # PID 1, which a fresh container's serve (also PID 1) mistakes for live.
 rm -rf "$BRAIN_DIR/.gbrain-lock"
+
+# Hosted deployments reuse their existing Postgres service while keeping the
+# Brain in its own database. gbrain installs database-wide maintenance and RLS
+# machinery in public, so pointing it at Roomote's application database would
+# let its migrations affect application tables. Creating a sibling database
+# gives it an independent public schema without another Railway service.
+if [ -n "${GBRAIN_DATABASE_URL:-}" ]; then
+  GBRAIN_DATABASE_NAME="${GBRAIN_DATABASE_NAME:-gbrain}"
+  case "$GBRAIN_DATABASE_NAME" in
+    *[!A-Za-z0-9_]* | '')
+      echo "[gbrain-entrypoint] GBRAIN_DATABASE_NAME must contain only letters, numbers, and underscores" >&2
+      exit 2
+      ;;
+  esac
+
+  : "${PGHOST:?PGHOST is required with GBRAIN_DATABASE_URL}"
+  : "${PGUSER:?PGUSER is required with GBRAIN_DATABASE_URL}"
+  : "${PGPASSWORD:?PGPASSWORD is required with GBRAIN_DATABASE_URL}"
+  : "${PGDATABASE:?PGDATABASE is required with GBRAIN_DATABASE_URL}"
+
+  echo "[gbrain-entrypoint] ensuring isolated Postgres database $GBRAIN_DATABASE_NAME"
+  # Both the server and cron service can boot during the first deployment.
+  # A session advisory lock keeps their check-and-create sequence atomic.
+  psql --no-psqlrc --quiet -v ON_ERROR_STOP=1 \
+    -v brain_database="$GBRAIN_DATABASE_NAME" <<'SQL'
+SELECT pg_advisory_lock(hashtext('roomote-gbrain-database-bootstrap')) AS locked \gset
+SELECT format('CREATE DATABASE %I', :'brain_database')
+WHERE NOT EXISTS (
+  SELECT FROM pg_database WHERE datname = :'brain_database'
+) \gexec
+SELECT pg_advisory_unlock(hashtext('roomote-gbrain-database-bootstrap')) AS unlocked \gset
+SQL
+fi
 
 if [ -z "${GBRAIN_ADMIN_BOOTSTRAP_TOKEN:-}" ]; then
   if [ ! -s "$TOKEN_FILE" ]; then
@@ -149,16 +191,33 @@ fi
 # with --no-embedding writes a permanent `embedding_disabled: true` sentinel
 # that blocks every embed callsite, which silently degrades retrieval to
 # lexical-only no matter what model variables are set later.
+if [ -n "${GBRAIN_DATABASE_URL:-}" ] &&
+  grep -q '"engine": *"pglite"' "$CONFIG_FILE" 2>/dev/null; then
+  echo "[gbrain-entrypoint] replacing the legacy PGLite brain with Postgres"
+  rm -rf "$BRAIN_DIR"
+  rm -f "$CONFIG_FILE"
+fi
+
 if [ ! -s "$CONFIG_FILE" ]; then
-  if [ "$BRAIN_PROVIDER" = "none" ]; then
-    echo "[gbrain-entrypoint] initializing brain at $BRAIN_DIR (PGLite, no provider key: embedding deferred)"
-    gbrain init --pglite --no-embedding --non-interactive --path "$BRAIN_DIR"
+  if [ -n "${GBRAIN_DATABASE_URL:-}" ]; then
+    ENGINE_LABEL="Postgres"
+    INIT_ENGINE_ARGS=""
   else
-    echo "[gbrain-entrypoint] initializing brain at $BRAIN_DIR (PGLite, embedding: $DEFAULT_EMBEDDING_MODEL)"
+    ENGINE_LABEL="PGLite"
+    INIT_ENGINE_ARGS="--pglite --path $BRAIN_DIR"
+  fi
+
+  if [ "$BRAIN_PROVIDER" = "none" ]; then
+    echo "[gbrain-entrypoint] initializing brain ($ENGINE_LABEL, no provider key: embedding deferred)"
+    # shellcheck disable=SC2086 -- the optional PGLite flags are intentionally split.
+    gbrain init $INIT_ENGINE_ARGS --no-embedding --non-interactive
+  else
+    echo "[gbrain-entrypoint] initializing brain ($ENGINE_LABEL, embedding: $DEFAULT_EMBEDDING_MODEL)"
     # --skip-embed-check: the key is not exercised at init time, so a brain
     # still comes up on a temporarily unreachable provider instead of leaving
     # the volume half-initialized.
-    gbrain init --pglite \
+    # shellcheck disable=SC2086 -- the optional PGLite flags are intentionally split.
+    gbrain init $INIT_ENGINE_ARGS \
       --embedding-model "$DEFAULT_EMBEDDING_MODEL" \
       --embedding-dimensions "$EMBEDDING_DIMENSIONS" \
       --skip-embed-check \
@@ -221,6 +280,11 @@ if [ -n "$CONFIGURED_DIMENSIONS" ] && [ "$CONFIGURED_DIMENSIONS" != "$EMBEDDING_
   echo "[gbrain-entrypoint] WARNING: the column keeps its original width; the setting is ignored."
   echo "[gbrain-entrypoint] WARNING: to change it, stop this service and run:"
   echo "[gbrain-entrypoint] WARNING:   gbrain migrate embeddings --to <provider:model> --yes"
+fi
+
+if [ "$PROCESS" = "dream" ]; then
+  echo "[gbrain-entrypoint] starting one built-in dream maintenance cycle"
+  exec gbrain dream --json
 fi
 
 echo "[gbrain-entrypoint] starting gbrain serve on :$PORT (full surface)"

--- a/.docker/gbrain/entrypoint.sh
+++ b/.docker/gbrain/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Brain bootstrap: init-once, then serve or run one maintenance cycle.
+# Brain bootstrap: init-once, then run the HTTP server and durable job worker.
 #
 # Credential provisioning happens over gbrain's admin HTTP API at connect
 # time (Roomote registers its own scoped OAuth clients), so nothing is
@@ -15,7 +15,6 @@ BRAIN_DIR="$DATA_DIR/brain"
 TOKEN_FILE="$DATA_DIR/admin-bootstrap-token"
 CONFIG_FILE="$DATA_DIR/.gbrain/config.json"
 PORT="${GBRAIN_PORT:-8931}"
-PROCESS="${GBRAIN_PROCESS:-serve}"
 # Width of the vector column, fixed when the brain is created. Defaults to
 # text-embedding-3-small, which is what both providers serve by default.
 # Overriding it means overriding the embedding model to match: a column sized
@@ -25,63 +24,52 @@ EMBEDDING_DIMENSIONS="${GBRAIN_EMBEDDING_DIMENSIONS:-1536}"
 
 mkdir -p "$DATA_DIR"
 
-case "$PROCESS" in
-  serve | dream) ;;
-  *)
-    echo "[gbrain-entrypoint] unknown GBRAIN_PROCESS '$PROCESS' (expected serve or dream)" >&2
-    exit 2
-    ;;
-esac
-
 # gbrain keeps its registration in $HOME/.gbrain, not in the data dir.
 # Anchor HOME on the volume so a rebuilt container still knows its brain.
 export HOME="$DATA_DIR"
-
-# A lock present at entrypoint time is always stale: this container runs
-# exactly one gbrain process, and a killed container leaves a lock recording
-# PID 1, which a fresh container's serve (also PID 1) mistakes for live.
-rm -rf "$BRAIN_DIR/.gbrain-lock"
 
 # Hosted deployments reuse their existing Postgres service while keeping the
 # Brain in its own database. gbrain installs database-wide maintenance and RLS
 # machinery in public, so pointing it at Roomote's application database would
 # let its migrations affect application tables. Creating a sibling database
 # gives it an independent public schema without another Railway service.
-if [ -n "${GBRAIN_DATABASE_URL:-}" ]; then
-  GBRAIN_DATABASE_NAME="${GBRAIN_DATABASE_NAME:-gbrain}"
-  case "$GBRAIN_DATABASE_NAME" in
-    *[!A-Za-z0-9_]* | '')
-      echo "[gbrain-entrypoint] GBRAIN_DATABASE_NAME must contain only letters, numbers, and underscores" >&2
-      exit 2
-      ;;
-  esac
+if [ -z "${GBRAIN_DATABASE_URL:-}" ]; then
+  echo "[gbrain-entrypoint] GBRAIN_DATABASE_URL is required (gbrain maintenance needs Postgres)" >&2
+  exit 2
+fi
 
-  DATABASE_SEED_URL="${GBRAIN_DATABASE_BOOTSTRAP_URL:-$GBRAIN_DATABASE_URL}"
-  if [ -n "${GBRAIN_DATABASE_BOOTSTRAP_URL:-}" ]; then
-    DATABASE_BOOTSTRAP_URL="$GBRAIN_DATABASE_BOOTSTRAP_URL"
-  else
-    DATABASE_BOOTSTRAP_URL="$(DATABASE_BOOTSTRAP_URL="$DATABASE_SEED_URL" \
-      bun -e '
-        const url = new URL(Bun.env.DATABASE_BOOTSTRAP_URL);
-        url.pathname = "/postgres";
-        console.log(url.toString());
-      ')"
-  fi
+GBRAIN_DATABASE_NAME="${GBRAIN_DATABASE_NAME:-gbrain}"
+case "$GBRAIN_DATABASE_NAME" in
+  *[!A-Za-z0-9_]* | '')
+    echo "[gbrain-entrypoint] GBRAIN_DATABASE_NAME must contain only letters, numbers, and underscores" >&2
+    exit 2
+    ;;
+esac
 
-  GBRAIN_DATABASE_URL="$(DATABASE_SEED_URL="$DATABASE_SEED_URL" \
-    GBRAIN_DATABASE_NAME="$GBRAIN_DATABASE_NAME" \
+DATABASE_SEED_URL="${GBRAIN_DATABASE_BOOTSTRAP_URL:-$GBRAIN_DATABASE_URL}"
+if [ -n "${GBRAIN_DATABASE_BOOTSTRAP_URL:-}" ]; then
+  DATABASE_BOOTSTRAP_URL="$GBRAIN_DATABASE_BOOTSTRAP_URL"
+else
+  DATABASE_BOOTSTRAP_URL="$(DATABASE_BOOTSTRAP_URL="$DATABASE_SEED_URL" \
     bun -e '
-      const url = new URL(Bun.env.DATABASE_SEED_URL);
-      url.pathname = `/${Bun.env.GBRAIN_DATABASE_NAME}`;
+      const url = new URL(Bun.env.DATABASE_BOOTSTRAP_URL);
+      url.pathname = "/postgres";
       console.log(url.toString());
     ')"
-  export GBRAIN_DATABASE_URL
+fi
 
-  echo "[gbrain-entrypoint] ensuring isolated Postgres database $GBRAIN_DATABASE_NAME"
-  # Both the server and cron service can boot during the first deployment.
-  # A session advisory lock keeps their check-and-create sequence atomic.
-  psql --dbname="$DATABASE_BOOTSTRAP_URL" --no-psqlrc --quiet -v ON_ERROR_STOP=1 \
-    -v brain_database="$GBRAIN_DATABASE_NAME" <<'SQL'
+GBRAIN_DATABASE_URL="$(DATABASE_SEED_URL="$DATABASE_SEED_URL" \
+  GBRAIN_DATABASE_NAME="$GBRAIN_DATABASE_NAME" \
+  bun -e '
+    const url = new URL(Bun.env.DATABASE_SEED_URL);
+    url.pathname = `/${Bun.env.GBRAIN_DATABASE_NAME}`;
+    console.log(url.toString());
+  ')"
+export GBRAIN_DATABASE_URL
+
+echo "[gbrain-entrypoint] ensuring isolated Postgres database $GBRAIN_DATABASE_NAME"
+psql --dbname="$DATABASE_BOOTSTRAP_URL" --no-psqlrc --quiet -v ON_ERROR_STOP=1 \
+  -v brain_database="$GBRAIN_DATABASE_NAME" <<'SQL'
 SELECT pg_advisory_lock(hashtext('roomote-gbrain-database-bootstrap')) AS locked \gset
 SELECT format('CREATE DATABASE %I', :'brain_database')
 WHERE NOT EXISTS (
@@ -89,7 +77,6 @@ WHERE NOT EXISTS (
 ) \gexec
 SELECT pg_advisory_unlock(hashtext('roomote-gbrain-database-bootstrap')) AS unlocked \gset
 SQL
-fi
 
 if [ -z "${GBRAIN_ADMIN_BOOTSTRAP_TOKEN:-}" ]; then
   if [ ! -s "$TOKEN_FILE" ]; then
@@ -207,33 +194,22 @@ fi
 # with --no-embedding writes a permanent `embedding_disabled: true` sentinel
 # that blocks every embed callsite, which silently degrades retrieval to
 # lexical-only no matter what model variables are set later.
-if [ -n "${GBRAIN_DATABASE_URL:-}" ] &&
-  grep -q '"engine": *"pglite"' "$CONFIG_FILE" 2>/dev/null; then
+if grep -q '"engine": *"pglite"' "$CONFIG_FILE" 2>/dev/null; then
   echo "[gbrain-entrypoint] replacing the legacy PGLite brain with Postgres"
   rm -rf "$BRAIN_DIR"
   rm -f "$CONFIG_FILE"
 fi
 
 if [ ! -s "$CONFIG_FILE" ]; then
-  if [ -n "${GBRAIN_DATABASE_URL:-}" ]; then
-    ENGINE_LABEL="Postgres"
-    INIT_ENGINE_ARGS=""
-  else
-    ENGINE_LABEL="PGLite"
-    INIT_ENGINE_ARGS="--pglite --path $BRAIN_DIR"
-  fi
-
   if [ "$BRAIN_PROVIDER" = "none" ]; then
-    echo "[gbrain-entrypoint] initializing brain ($ENGINE_LABEL, no provider key: embedding deferred)"
-    # shellcheck disable=SC2086 -- the optional PGLite flags are intentionally split.
-    gbrain init $INIT_ENGINE_ARGS --no-embedding --non-interactive
+    echo "[gbrain-entrypoint] initializing brain (Postgres, no provider key: embedding deferred)"
+    gbrain init --no-embedding --non-interactive
   else
-    echo "[gbrain-entrypoint] initializing brain ($ENGINE_LABEL, embedding: $DEFAULT_EMBEDDING_MODEL)"
+    echo "[gbrain-entrypoint] initializing brain (Postgres, embedding: $DEFAULT_EMBEDDING_MODEL)"
     # --skip-embed-check: the key is not exercised at init time, so a brain
     # still comes up on a temporarily unreachable provider instead of leaving
     # the volume half-initialized.
-    # shellcheck disable=SC2086 -- the optional PGLite flags are intentionally split.
-    gbrain init $INIT_ENGINE_ARGS \
+    gbrain init \
       --embedding-model "$DEFAULT_EMBEDDING_MODEL" \
       --embedding-dimensions "$EMBEDDING_DIMENSIONS" \
       --skip-embed-check \
@@ -298,13 +274,38 @@ if [ -n "$CONFIGURED_DIMENSIONS" ] && [ "$CONFIGURED_DIMENSIONS" != "$EMBEDDING_
   echo "[gbrain-entrypoint] WARNING:   gbrain migrate embeddings --to <provider:model> --yes"
 fi
 
-if [ "$PROCESS" = "dream" ]; then
-  echo "[gbrain-entrypoint] starting one built-in dream maintenance cycle"
-  exec gbrain dream --json
-fi
+echo "[gbrain-entrypoint] starting durable job worker"
+rm -f "$DATA_DIR/gbrain-worker-supervisor.pid"
+gbrain jobs supervisor \
+  --concurrency "${GBRAIN_WORKER_CONCURRENCY:-1}" \
+  --pid-file "$DATA_DIR/gbrain-worker-supervisor.pid" &
+WORKER_PID=$!
 
 echo "[gbrain-entrypoint] starting gbrain serve on :$PORT (full surface)"
 # gbrain binds loopback by default, which no container network can reach.
 # 0.0.0.0 covers Docker/compose; platforms whose private network is IPv6-only
 # (Railway) set GBRAIN_BIND=:: so the service is reachable there.
-exec gbrain serve --http --port "$PORT" --bind "${GBRAIN_BIND:-0.0.0.0}" --surface full
+gbrain serve --http --port "$PORT" --bind "${GBRAIN_BIND:-0.0.0.0}" --surface full &
+SERVER_PID=$!
+
+TERMINATING=0
+stop_processes() {
+  kill -TERM "$SERVER_PID" "$WORKER_PID" 2>/dev/null || true
+}
+trap 'TERMINATING=1; stop_processes' TERM INT
+
+while kill -0 "$SERVER_PID" 2>/dev/null && kill -0 "$WORKER_PID" 2>/dev/null; do
+  sleep 1 &
+  wait $! || true
+done
+
+stop_processes
+wait "$SERVER_PID" 2>/dev/null || true
+wait "$WORKER_PID" 2>/dev/null || true
+
+if [ "$TERMINATING" -eq 1 ]; then
+  exit 0
+fi
+
+echo "[gbrain-entrypoint] server or job worker exited unexpectedly" >&2
+exit 1

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-maintenance.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-maintenance.test.ts
@@ -1,0 +1,83 @@
+const { mockResolveConnection, mockResolveProvider } = vi.hoisted(() => ({
+  mockResolveConnection: vi.fn(),
+  mockResolveProvider: vi.fn(),
+}));
+
+vi.mock('@roomote/sdk/server', () => ({
+  resolveBrainConnection: mockResolveConnection,
+  resolveBrainInferenceProvider: mockResolveProvider,
+}));
+
+import { brainMaintenanceJob } from '../brain-maintenance';
+
+describe('brainMaintenanceJob', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockResolveConnection.mockReset();
+    mockResolveProvider.mockReset();
+  });
+
+  it('does nothing when the Brain provider is disabled', async () => {
+    mockResolveProvider.mockResolvedValue(null);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    await brainMaintenanceJob();
+
+    expect(mockResolveConnection).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('submits the built-in autopilot cycle with the maintenance credential', async () => {
+    mockResolveProvider.mockResolvedValue({ providerId: 'openrouter' });
+    mockResolveConnection.mockResolvedValue({
+      baseUrl: 'http://gbrain.test/',
+      token: 'maintenance-token',
+    });
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ jsonrpc: '2.0', id: 1, result: { content: [] } }),
+          { status: 200 },
+        ),
+      );
+
+    await brainMaintenanceJob();
+
+    expect(mockResolveConnection).toHaveBeenCalledWith('maintenance');
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://gbrain.test/mcp',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          authorization: 'Bearer maintenance-token',
+        }),
+      }),
+    );
+    const request = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(String(request.body))).toMatchObject({
+      params: {
+        name: 'submit_job',
+        arguments: {
+          name: 'autopilot-cycle',
+          data: { pull: false },
+        },
+      },
+    });
+  });
+
+  it('fails the scheduler job when gbrain rejects the submission', async () => {
+    mockResolveProvider.mockResolvedValue({ providerId: 'openrouter' });
+    mockResolveConnection.mockResolvedValue({
+      baseUrl: 'http://gbrain.test',
+      token: 'maintenance-token',
+    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('{"error":"nope"}', { status: 500 }),
+    );
+
+    await expect(brainMaintenanceJob()).rejects.toThrow(
+      'gbrain maintenance submission failed: 500',
+    );
+  });
+});

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors.ts
@@ -115,9 +115,8 @@ export type BrainSink = (
 
 /**
  * Run every registered collector once, writing collected pages to the brain
- * through the outbox-drain `put_page` path (never gbrain's /ingest webhook:
- * its job worker is Postgres-only, so on the PGLite topology those events
- * would never become pages).
+ * through the outbox-drain `put_page` path so collected pages are immediately
+ * retrievable instead of waiting behind gbrain's maintenance queue.
  *
  * Per collector and per pass: the incremental phase runs first (keeps the
  * brain fresh), then, while the initial deep backfill has not completed, a

--- a/apps/bullmq/src/scheduled-jobs/brain-maintenance.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-maintenance.ts
@@ -1,0 +1,52 @@
+import {
+  resolveBrainConnection,
+  resolveBrainInferenceProvider,
+} from '@roomote/sdk/server';
+
+/**
+ * Ask gbrain's durable Postgres worker to run one built-in maintenance cycle.
+ * Roomote owns the clock so hosted and self-hosted deployments behave alike;
+ * gbrain owns the maintenance algorithm and its cycle locking.
+ */
+export async function brainMaintenanceJob(): Promise<void> {
+  const provider = await resolveBrainInferenceProvider();
+
+  if (!provider) {
+    return;
+  }
+
+  const connection = await resolveBrainConnection('maintenance');
+
+  if (!connection) {
+    return;
+  }
+
+  const response = await fetch(`${connection.baseUrl.replace(/\/$/, '')}/mcp`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream',
+      authorization: `Bearer ${connection.token}`,
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: {
+        name: 'submit_job',
+        arguments: {
+          name: 'autopilot-cycle',
+          data: { pull: false },
+          max_attempts: 2,
+        },
+      },
+    }),
+  });
+  const body = await response.text().catch(() => '');
+
+  if (!response.ok || /"isError"\s*:\s*true/.test(body)) {
+    throw new Error(
+      `gbrain maintenance submission failed: ${response.status} ${body.slice(0, 300)}`,
+    );
+  }
+}

--- a/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
@@ -106,10 +106,8 @@ export function isBrainNotReady(error: unknown): boolean {
 
 /**
  * Write one memory page via gbrain's MCP `put_page` op with a write-scoped
- * access token. Synchronous and immediately retrievable, which matters:
- * the `/ingest` webhook path only enqueues jobs whose worker
- * (`gbrain jobs work`) is Postgres-only, so on the PGLite topology those
- * events would never become pages (verified against gbrain 0.45.10.0).
+ * access token. Synchronous and immediately retrievable, so task completion
+ * does not wait behind gbrain's background maintenance queue.
  */
 export async function postToBrain(
   page: IngestPage,

--- a/apps/bullmq/src/scheduled-jobs/index.ts
+++ b/apps/bullmq/src/scheduled-jobs/index.ts
@@ -8,3 +8,4 @@ export { webhookCleanupJob } from './webhook-cleanup';
 export { standbyRetentionJob } from './standby-retention';
 export { prReviewNotificationDispatchJob } from './pr-review-notification-dispatch';
 export { brainOutboxDrainJob, brainCollectorsJob } from './brain-outbox-drain';
+export { brainMaintenanceJob } from './brain-maintenance';

--- a/apps/bullmq/src/scheduler.test.ts
+++ b/apps/bullmq/src/scheduler.test.ts
@@ -60,6 +60,9 @@ vi.mock('./scheduled-jobs', () => ({
   webhookCleanupJob: vi.fn(),
   standbyRetentionJob: vi.fn(),
   prReviewNotificationDispatchJob: vi.fn(),
+  brainOutboxDrainJob: vi.fn(),
+  brainCollectorsJob: vi.fn(),
+  brainMaintenanceJob: vi.fn(),
 }));
 
 import { ScheduledJobName } from './types';
@@ -99,5 +102,14 @@ describe('startScheduler', () => {
     expect(
       mocks.queue.upsertJobScheduler.mock.invocationCallOrder.at(-1),
     ).toBeLessThan(mocks.workerConstructor.mock.invocationCallOrder[0]!);
+  });
+
+  it('schedules Brain maintenance nightly', async () => {
+    await startScheduler();
+
+    expect(mocks.queue.upsertJobScheduler).toHaveBeenCalledWith(
+      ScheduledJobName.BrainMaintenance,
+      { pattern: '0 7 * * *' },
+    );
   });
 });

--- a/apps/bullmq/src/scheduler.ts
+++ b/apps/bullmq/src/scheduler.ts
@@ -33,6 +33,7 @@ import {
   prReviewNotificationDispatchJob,
   brainOutboxDrainJob,
   brainCollectorsJob,
+  brainMaintenanceJob,
 } from './scheduled-jobs';
 
 const QUEUE_NAME = 'scheduled-jobs';
@@ -207,6 +208,13 @@ async function createJobs(queue: Queue): Promise<void> {
     { every: 15 * 60 * 1000 },
   );
 
+  await queue.upsertJobScheduler(
+    ScheduledJobName.BrainMaintenance,
+    // 07:00 UTC daily. Roomote owns the schedule; gbrain's durable worker
+    // owns the built-in cycle and prevents overlapping work internally.
+    { pattern: '0 7 * * *' },
+  );
+
   const schedulers = await queue.getJobSchedulers();
   console.log('[createJobs] getJobSchedulers ->', schedulers);
 }
@@ -244,6 +252,8 @@ const runJobs = async (job: ScheduledJob): Promise<void> => {
       return brainOutboxDrainJob();
     case ScheduledJobName.BrainCollectors:
       return brainCollectorsJob();
+    case ScheduledJobName.BrainMaintenance:
+      return brainMaintenanceJob();
     case ScheduledJobName.CustomAutomations:
       await customAutomationsJob();
       return;

--- a/apps/bullmq/src/types.ts
+++ b/apps/bullmq/src/types.ts
@@ -17,6 +17,7 @@ export enum ScheduledJobName {
   PrReviewNotificationDispatch = 'PrReviewNotificationDispatch',
   BrainOutboxDrain = 'BrainOutboxDrain',
   BrainCollectors = 'BrainCollectors',
+  BrainMaintenance = 'BrainMaintenance',
 }
 
 /**

--- a/apps/docs/brain.mdx
+++ b/apps/docs/brain.mdx
@@ -55,6 +55,10 @@ precedence over the deployment's general provider keys.
 With no provider configured anywhere, the Brain stays inert. Agents are not
 told it exists, and nothing is ingested.
 
+Roomote schedules one maintenance pass each night. The gbrain service runs
+gbrain's own durable worker, so synthesis, embedding catch-up, and the rest of
+the maintenance algorithm stay upstream behavior rather than a Roomote fork.
+
 <Note>
   Self-hosted Compose deployments start the Brain from the `brain`
   profile, so set a Brain key in your environment file to bring the container
@@ -124,12 +128,13 @@ matching on keywords alone.
 
 ## Operating it
 
-- **Back up the Brain's volume** along with your database. The corpus lives
-  there.
-- **Losing the volume is recoverable but not free.** Task history and
-  integration sources re-ingest from scratch, and Roomote re-registers its
-  credentials automatically when the Brain no longer recognizes them, but the
-  deployment starts cold until that finishes.
+- **Back up Postgres.** The Brain uses an isolated `gbrain` database in the
+  same Postgres instance as Roomote, so the normal database backup covers the
+  corpus. Its small container volume holds only service configuration and
+  generated bootstrap credentials.
+- **Losing the Brain database is recoverable but not free.** Task history and
+  integration sources re-ingest from scratch, but the deployment starts cold
+  until that finishes.
 - **The Brain has no public route.** It is never exposed to the internet, and
   task sandboxes reach it only through Roomote's API with their run token,
   which grants read access only.

--- a/deploy/compose/docker-compose.prod.yml
+++ b/deploy/compose/docker-compose.prod.yml
@@ -291,7 +291,7 @@ x-roomote-service: &roomote-service
 
 services:
   postgres:
-    image: postgres:17.5@sha256:aadf2c0696f5ef357aa7a68da995137f0cf17bad0bf6e1f17de06ae5c769b302
+    image: pgvector/pgvector:0.8.1-pg17@sha256:3e8b3adfd27b5707128f60956f62a793c3c9326ea8cfaf0eab7adccb5d700b21
     profiles:
       - local-postgres
     restart: unless-stopped
@@ -526,6 +526,7 @@ services:
     restart: unless-stopped
     networks: [default]
     environment:
+      GBRAIN_DATABASE_URL: ${DATABASE_URL:-postgres://postgres:roomote-postgres-password@postgres:5432/roomote}
       GBRAIN_ADMIN_BOOTSTRAP_TOKEN: ${GBRAIN_ADMIN_BOOTSTRAP_TOKEN:-}
       # The Brain holds no provider key. It calls back into this deployment,
       # which injects whichever provider key an admin configured in Settings,

--- a/deploy/coolify/README.md
+++ b/deploy/coolify/README.md
@@ -102,7 +102,7 @@ follow the image.
 
 | Service         | Image                   | Public domain              | Healthcheck                  |
 | --------------- | ----------------------- | -------------------------- | ---------------------------- |
-| `postgres`      | pinned `postgres:17.5`  | no                         | `pg_isready`                 |
+| `postgres`      | pinned PostgreSQL 17 + pgvector | no                  | `pg_isready`                 |
 | `redis`         | pinned `redis:7-alpine` | no                         | `redis-cli ping`             |
 | `minio`         | pinned MinIO + volume   | yes (routed to port 9000)  | `mc ready local`             |
 | `gbrain`        | `roomote-gbrain:develop` + volume | no (internal only) | `/health` via bun           |
@@ -250,8 +250,8 @@ panel in Coolify:
    `R_BRAIN_OPENROUTER_API_KEY` or `R_BRAIN_OPENAI_API_KEY` in the
    resource's environment variables panel. Those take precedence.
 2. Redeploy the resource. Within a minute the deployment registers its own
-   scoped clients against the Brain (a read-only one for agents, a
-   write-only one for ingestion), backfills the task history it already has,
+   scoped clients against the Brain (read-only agent access, ingestion, and
+   maintenance), backfills the task history it already has,
    and starts delivering the Brain to new tasks. Watch the `bullmq` service
    logs for `[brain] provisioned scoped clients`.
 
@@ -269,15 +269,14 @@ the key is set, because Coolify's compose parser does not honour `profiles`.
 That is a supported state and costs about 370 MB of idle memory. With the
 key empty, agents are told nothing about the Brain and no ingestion runs.
 Deployments that want no memory at all can delete the `gbrain` service and
-the `gbrain_data` volume from the compose file before deploying.
+the `gbrain_data` configuration volume from the compose file before deploying.
 
 Two operational notes:
 
-- **Back up the volume.** `gbrain_data` holds the corpus, so treat it like
-  `pg_data`. Losing it is recoverable — task history and integration
-  sources re-ingest, and Roomote re-registers its clients automatically when
-  the Brain no longer recognizes them — but the deployment starts cold until
-  that finishes.
+- **Back up Postgres.** The corpus lives in an isolated `gbrain` database in
+  the same Postgres instance as Roomote, so the normal `pg_data` backup covers
+  it. `gbrain_data` only holds service configuration and generated bootstrap
+  credentials.
 - **Model choice is a variable, not a rebuild.** `R_BRAIN_MODEL` selects the
   synthesis model and `R_BRAIN_EMBEDDING_MODEL` the embedding model, both in
   your provider's own naming, both set on the app services. Leave them empty for the

--- a/deploy/coolify/docker-compose.yaml
+++ b/deploy/coolify/docker-compose.yaml
@@ -83,15 +83,15 @@ x-roomote-shared-env: &roomote-shared-env
   R_BRAIN_EMBEDDING_MODEL: ${R_BRAIN_EMBEDDING_MODEL:-}
   R_BRAIN_EMBEDDING_DIMENSIONS: ${R_BRAIN_EMBEDDING_DIMENSIONS:-}
   R_GBRAIN_URL: http://gbrain:8931
-  # Roomote uses this only to register its own read-only and write-only
-  # clients against the Brain. Coolify's SERVICE_PASSWORD_64_* generates an
+  # Roomote uses this only to register its own scoped clients against the
+  # Brain. Coolify's SERVICE_PASSWORD_64_* generates an
   # alphanumeric value, which satisfies gbrain's >= 32 characters of
   # [A-Za-z0-9_-]; SERVICE_BASE64_* would not.
   R_GBRAIN_ADMIN_TOKEN: ${SERVICE_PASSWORD_64_GBRAINADMIN}
 
 services:
   postgres:
-    image: postgres:17.5@sha256:aadf2c0696f5ef357aa7a68da995137f0cf17bad0bf6e1f17de06ae5c769b302
+    image: pgvector/pgvector:0.8.1-pg17@sha256:3e8b3adfd27b5707128f60956f62a793c3c9326ea8cfaf0eab7adccb5d700b21
     restart: unless-stopped
     volumes:
       - pg_data:/var/lib/postgresql/data
@@ -144,16 +144,20 @@ services:
   # domain and no SERVICE_FQDN_*, so Coolify never routes to it; agents read
   # it through the api service's proxy with their run token. It runs
   # unconditionally because Coolify's compose parser does not honour
-  # `profiles`, and idling costs about 370 MB. Delete this service and the
-  # gbrain_data volume if the deployment should have no memory at all.
+  # `profiles`, and idling costs about 370 MB. Delete this service and its
+  # small configuration volume if the deployment should have no memory.
   gbrain:
     image: ghcr.io/roocodeinc/roomote-gbrain:develop
     restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
     networks:
       - default
     volumes:
       - gbrain_data:/data
     environment:
+      GBRAIN_DATABASE_URL: postgres://postgres:${SERVICE_PASSWORD_POSTGRES}@postgres:5432/roomote
       GBRAIN_ADMIN_BOOTSTRAP_TOKEN: ${SERVICE_PASSWORD_64_GBRAINADMIN}
       # The Brain holds no provider key. It calls back into this deployment,
       # which injects whichever provider key an admin configured in Settings,

--- a/deploy/deployment-catalog.json
+++ b/deploy/deployment-catalog.json
@@ -1,6 +1,6 @@
 {
   "criticalImages": {
-    "postgres": "postgres:17.5@sha256:aadf2c0696f5ef357aa7a68da995137f0cf17bad0bf6e1f17de06ae5c769b302",
+    "postgres": "pgvector/pgvector:0.8.1-pg17@sha256:3e8b3adfd27b5707128f60956f62a793c3c9326ea8cfaf0eab7adccb5d700b21",
     "redis": "redis:7-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99",
     "minio": "minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e",
     "minioClient": "minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727",

--- a/deploy/host/roomote
+++ b/deploy/host/roomote
@@ -218,10 +218,10 @@ postgres_command() {
 
   if [ -n "$input_file" ]; then
     docker run --rm --network "$(compose_network_name)" --env-file "$env_file" -i \
-      postgres:17.5@sha256:aadf2c0696f5ef357aa7a68da995137f0cf17bad0bf6e1f17de06ae5c769b302 sh -c "$*" <"$input_file"
+      pgvector/pgvector:0.8.1-pg17@sha256:3e8b3adfd27b5707128f60956f62a793c3c9326ea8cfaf0eab7adccb5d700b21 sh -c "$*" <"$input_file"
   else
     docker run --rm --network "$(compose_network_name)" --env-file "$env_file" \
-      postgres:17.5@sha256:aadf2c0696f5ef357aa7a68da995137f0cf17bad0bf6e1f17de06ae5c769b302 sh -c "$*"
+      pgvector/pgvector:0.8.1-pg17@sha256:3e8b3adfd27b5707128f60956f62a793c3c9326ea8cfaf0eab7adccb5d700b21 sh -c "$*"
   fi
 }
 

--- a/deploy/host/tests/backup-restore.integration.sh
+++ b/deploy/host/tests/backup-restore.integration.sh
@@ -50,7 +50,7 @@ name: roomote-backup-ci
 
 services:
   postgres:
-    image: postgres:17.5
+    image: pgvector/pgvector:0.8.1-pg17
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password

--- a/deploy/railway/template.yaml
+++ b/deploy/railway/template.yaml
@@ -131,6 +131,7 @@ services:
     public_domain: no # private network only; the api service proxies agent access
     volume: /data
     env:
+      GBRAIN_DATABASE_URL: ${{Postgres.DATABASE_URL}}
       # Railway's private network is IPv6-only, so the Brain must bind :: to
       # be reachable at all. Compose deployments keep the 0.0.0.0 default.
       GBRAIN_BIND: '::'
@@ -214,8 +215,8 @@ services:
       # Railway's private network is IPv6-only and never leaves the project,
       # so the Brain is unreachable from the internet by construction.
       R_GBRAIN_URL: http://${{gbrain.RAILWAY_PRIVATE_DOMAIN}}:8931
-      # Roomote uses this once to register its own read-only and write-only
-      # clients against the Brain. Generated here and passed to the gbrain
+      # Roomote uses this once to register its own scoped clients against the
+      # Brain. Generated here and passed to the gbrain
       # service as its bootstrap token; gbrain requires >= 32 characters of
       # [A-Za-z0-9_-], so keep the generated form.
       R_GBRAIN_ADMIN_TOKEN: ${{secret(48)}}

--- a/docker-compose.self-host.yml
+++ b/docker-compose.self-host.yml
@@ -284,8 +284,12 @@ services:
     container_name: roomote-gbrain
     build: .docker/gbrain
     restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
     networks: [default]
     environment:
+      GBRAIN_DATABASE_URL: postgres://postgres:password@postgres:5432/roomote_development
       GBRAIN_ADMIN_BOOTSTRAP_TOKEN: ${GBRAIN_ADMIN_BOOTSTRAP_TOKEN:-}
       # The Brain holds no provider key. It calls back into this deployment,
       # which injects whichever provider key an admin configured in Settings,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ name: roomote
 services:
   postgres:
     container_name: roomote-postgres
-    image: postgres:17.5@sha256:aadf2c0696f5ef357aa7a68da995137f0cf17bad0bf6e1f17de06ae5c769b302
+    image: pgvector/pgvector:0.8.1-pg17@sha256:3e8b3adfd27b5707128f60956f62a793c3c9326ea8cfaf0eab7adccb5d700b21
     # Publish datastore ports to loopback only so Postgres, Redis, and MinIO are
     # never reachable from another host. The production Caddy overlay resets
     # these to none; use an SSH tunnel or reverse proxy if remote access is
@@ -93,7 +93,11 @@ services:
     container_name: roomote-gbrain
     build: .docker/gbrain
     restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
     environment:
+      GBRAIN_DATABASE_URL: postgres://postgres:password@postgres:5432/roomote_development
       GBRAIN_ADMIN_BOOTSTRAP_TOKEN: ${R_GBRAIN_ADMIN_TOKEN:-}
       # The Brain holds no provider key. It calls back into this deployment,
       # which injects whichever provider key an admin configured in Settings,

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -339,6 +339,9 @@ const serverSchema = {
   // queries. Distinct credential class from the ingest token by design: a
   // compromised agent path must be structurally incapable of writes.
   R_GBRAIN_AGENT_TOKEN: z.string().min(1).optional(),
+  // Admin-scoped bearer token used only by the scheduler to enqueue gbrain's
+  // built-in maintenance cycle. Normally Roomote provisions this itself.
+  R_GBRAIN_MAINTENANCE_TOKEN: z.string().min(1).optional(),
   // gbrain's admin bootstrap token, given directly or as a file path (the
   // compose profile mounts the gbrain volume read-only and points this at
   // the token the entrypoint generates). Roomote uses it once, headlessly,
@@ -504,6 +507,7 @@ const OPTIONAL_NON_EMPTY_KEYS = new Set([
   'R_GBRAIN_URL',
   'R_GBRAIN_INGEST_TOKEN',
   'R_GBRAIN_AGENT_TOKEN',
+  'R_GBRAIN_MAINTENANCE_TOKEN',
   'R_GBRAIN_ADMIN_TOKEN',
   'R_GBRAIN_ADMIN_TOKEN_FILE',
   'R_BRAIN_OPENROUTER_API_KEY',

--- a/packages/sdk/src/server/lib/brain-clients.ts
+++ b/packages/sdk/src/server/lib/brain-clients.ts
@@ -99,11 +99,13 @@ async function registerClient(
 export type ProvisionedGbrainClients = {
   agent: { clientId: string; clientSecret: string };
   ingest: { clientId: string; clientSecret: string };
+  maintenance: { clientId: string; clientSecret: string };
 };
 
 /**
- * Register the two Roomote credential classes against a gbrain server:
- * a read-only agent client and a write-capable ingest client. The admin
+ * Register Roomote's three credential classes against a gbrain server:
+ * a read-only agent client, a write-capable ingest client, and an
+ * admin-scoped maintenance client. The admin
  * bootstrap token is used transiently for the session and never stored.
  * Previously provisioned clients (when re-connecting) should be revoked by
  * the caller via revokeGbrainClient, best-effort.
@@ -121,8 +123,14 @@ export async function provisionGbrainClients(
     'roomote-ingest',
     'read write',
   );
+  const maintenance = await registerClient(
+    baseUrl,
+    cookie,
+    'roomote-maintenance',
+    'admin',
+  );
 
-  return { agent, ingest };
+  return { agent, ingest, maintenance };
 }
 
 /** Best-effort revocation of a previously provisioned client. */
@@ -218,7 +226,7 @@ export async function mintGbrainAccessToken(
  * hatch: static tokens win over provisioning when present.
  */
 export async function resolveBrainConnection(
-  role: 'agent' | 'ingest',
+  role: 'agent' | 'ingest' | 'maintenance',
 ): Promise<{ baseUrl: string; token: string } | null> {
   if (!isBrainConfigured(Env)) {
     return null;
@@ -230,8 +238,11 @@ export async function resolveBrainConnection(
     return null;
   }
 
-  const staticToken =
-    role === 'agent' ? Env.R_GBRAIN_AGENT_TOKEN : Env.R_GBRAIN_INGEST_TOKEN;
+  const staticToken = {
+    agent: Env.R_GBRAIN_AGENT_TOKEN,
+    ingest: Env.R_GBRAIN_INGEST_TOKEN,
+    maintenance: Env.R_GBRAIN_MAINTENANCE_TOKEN,
+  }[role];
 
   if (staticToken) {
     return { baseUrl, token: staticToken };
@@ -259,12 +270,16 @@ export async function resolveBrainConnection(
   const mint = async (
     resolved: McpConnectionGbrainConfig,
   ): Promise<{ baseUrl: string; token: string }> => {
-    const clientId =
-      role === 'agent' ? resolved.agentClientId : resolved.ingestClientId;
-    const encryptedSecret =
-      role === 'agent'
-        ? resolved.encryptedAgentClientSecret
-        : resolved.encryptedIngestClientSecret;
+    const clientId = {
+      agent: resolved.agentClientId,
+      ingest: resolved.ingestClientId,
+      maintenance: resolved.maintenanceClientId,
+    }[role];
+    const encryptedSecret = {
+      agent: resolved.encryptedAgentClientSecret,
+      ingest: resolved.encryptedIngestClientSecret,
+      maintenance: resolved.encryptedMaintenanceClientSecret,
+    }[role];
 
     return {
       baseUrl: resolved.url,
@@ -356,6 +371,10 @@ async function provisionAndStoreBrainClients(
       encryptedAgentClientSecret: encrypt(clients.agent.clientSecret),
       ingestClientId: clients.ingest.clientId,
       encryptedIngestClientSecret: encrypt(clients.ingest.clientSecret),
+      maintenanceClientId: clients.maintenance.clientId,
+      encryptedMaintenanceClientSecret: encrypt(
+        clients.maintenance.clientSecret,
+      ),
     };
 
     await db

--- a/packages/types/src/__tests__/mcp-oauth.test.ts
+++ b/packages/types/src/__tests__/mcp-oauth.test.ts
@@ -6,6 +6,7 @@ import {
   getMcpIntegrationOauthScopeMode,
   getMcpIntegrationOauthScopes,
   isMcpConnectionElevenLabsConfig,
+  isMcpConnectionGbrainConfig,
   LINEAR_APP_OAUTH_SCOPES,
   MONDAY_MCP_READ_ONLY_OAUTH_SCOPES,
   RESEND_DEFAULT_DISABLED_TOOL_NAMES,
@@ -112,6 +113,29 @@ describe('ElevenLabs credential-only integration', () => {
       }),
     ).toBe(false);
     expect(isMcpConnectionElevenLabsConfig({})).toBe(false);
+  });
+});
+
+describe('gbrain connection config', () => {
+  const config = {
+    type: 'gbrain' as const,
+    url: 'http://gbrain:8931',
+    agentClientId: 'agent',
+    encryptedAgentClientSecret: 'encrypted-agent',
+    ingestClientId: 'ingest',
+    encryptedIngestClientSecret: 'encrypted-ingest',
+    maintenanceClientId: 'maintenance',
+    encryptedMaintenanceClientSecret: 'encrypted-maintenance',
+  };
+
+  it('requires the dedicated maintenance credential', () => {
+    expect(isMcpConnectionGbrainConfig(config)).toBe(true);
+    expect(
+      isMcpConnectionGbrainConfig({
+        ...config,
+        maintenanceClientId: undefined,
+      } as never),
+    ).toBe(false);
   });
 });
 

--- a/packages/types/src/mcp-oauth.ts
+++ b/packages/types/src/mcp-oauth.ts
@@ -191,11 +191,13 @@ export interface McpConnectionGrafanaConfig {
  * service (typically deployment-internal).
  *
  * Provisioned automatically at connect time: the admin supplies gbrain's
- * bootstrap token once (never persisted), and Roomote registers two OAuth
+ * bootstrap token once (never persisted), and Roomote registers three OAuth
  * clients via gbrain's admin API. Scopes are enforced server-side by gbrain:
  * the agent client is `read`-scoped (structurally incapable of mutation; the
  * proxy's tool allowlist is defense-in-depth on top), and the ingest client
- * carries `write` for the server-side ingestion worker only. Secrets are
+ * carries `write` for the server-side ingestion worker only. A third,
+ * admin-scoped maintenance client is held only by the scheduler, which uses
+ * it to enqueue the built-in nightly maintenance cycle. Secrets are
  * encrypted before persistence; short-lived access tokens are minted on
  * demand via the client_credentials grant. R_GBRAIN_* env, when set,
  * overrides this config entirely (operator-managed deployments, static
@@ -208,6 +210,8 @@ export interface McpConnectionGbrainConfig {
   encryptedAgentClientSecret: string;
   ingestClientId: string;
   encryptedIngestClientSecret: string;
+  maintenanceClientId: string;
+  encryptedMaintenanceClientSecret: string;
 }
 
 /**
@@ -989,7 +993,11 @@ export function isMcpConnectionGbrainConfig(
     'ingestClientId' in authConfig &&
     typeof authConfig.ingestClientId === 'string' &&
     'encryptedIngestClientSecret' in authConfig &&
-    typeof authConfig.encryptedIngestClientSecret === 'string',
+    typeof authConfig.encryptedIngestClientSecret === 'string' &&
+    'maintenanceClientId' in authConfig &&
+    typeof authConfig.maintenanceClientId === 'string' &&
+    'encryptedMaintenanceClientSecret' in authConfig &&
+    typeof authConfig.encryptedMaintenanceClientSecret === 'string',
   );
 }
 

--- a/render.yaml
+++ b/render.yaml
@@ -133,6 +133,10 @@ services:
       mountPath: /data
       sizeGB: 10
     envVars:
+      - key: GBRAIN_DATABASE_URL
+        fromDatabase:
+          name: roomote-postgres
+          property: connectionString
       - key: PORT
         value: 8931
       - key: GBRAIN_PORT


### PR DESCRIPTION
## What changed

- Teach the gbrain image to initialize against an external Postgres database.
- Create the isolated Brain database safely when multiple containers start together.
- Add a one-shot `GBRAIN_PROCESS=dream` mode that runs gbrain's built-in maintenance cycle.
- Replace a legacy PGLite checkout when Postgres is configured so collectors can rebuild it.

## Why

Hosted Brain needs durable shared storage so the API service and scheduled maintenance process operate on the same data. Keeping gbrain in a separate database also prevents its schema and RLS migrations from affecting Roomote application tables.

## Validation

- `sh -n .docker/gbrain/entrypoint.sh`
- Built the gbrain Docker image locally.
- Exercised a destructive PGLite-to-Postgres cutover against Railway's Postgres 18 image.
- Ran two independent native dream cycles against the resulting database.
- Passed the repository pre-push lint, typecheck, and knip checks.
