### PR TITLE
[Fix] Order resumed OpenCode prompts after restored history

### DIFF
--- a/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/__tests__/opencode-server.test.ts
@@ -111,6 +111,7 @@ function createHarness(
     providerErrorMaxDelayMs?: number;
     mcpServerNames?: string[];
     model?: string;
+    initialSessionId?: string;
   } = {},
 ) {
   const harness = new OpenCodeServerHarness({
@@ -118,6 +119,7 @@ function createHarness(
     workspacePath: '/tmp/workspace',
     logger: createLogger(),
     commandEnv: options.commandEnv,
+    initialSessionId: options.initialSessionId,
     model: options.model ?? TEST_OPENCODE_MODEL,
     eventStreamReadyTimeoutMs: 100,
     executeToolProgressInitialDelayMs:
@@ -5470,13 +5472,62 @@ describe('OpenCodeServerHarness', () => {
       // The prior session is validated server-side, then reused — no new
       // session is created behind the user's back.
       expect(client.messages).toHaveBeenCalledWith(
-        expect.objectContaining({ sessionId: 'ses_prior', limit: 1 }),
+        expect.objectContaining({ sessionId: 'ses_prior', limit: 20 }),
       );
       expect(client.createSession).not.toHaveBeenCalled();
       expect(client.promptAsync.mock.calls[0]?.[0]).toMatchObject({
         sessionId: 'ses_prior',
       });
     } finally {
+      harness.dispose();
+    }
+  });
+
+  it('orders the first resumed prompt after the restored session history', async () => {
+    const client = new FakeOpenCodeServerClient();
+    const restoredMessageId = `msg_000000000100${'z'.repeat(14)}`;
+    client.messages.mockResolvedValueOnce([
+      // The API returns newest-by-time first. This simulates a prompt already
+      // accepted after restore with an id that still sorts below the older
+      // assistant; the floor must be the greatest id in the tail.
+      createFinalAssistantMessage({
+        messageId: `msg_000000000010${'0'.repeat(14)}`,
+      }),
+      createFinalAssistantMessage({ messageId: restoredMessageId }),
+    ]);
+    let resolveSubmittedPrompt: (prompt: unknown) => void = () => {};
+    const submittedPrompt = new Promise<unknown>((resolve) => {
+      resolveSubmittedPrompt = resolve;
+    });
+    client.promptAsync.mockImplementationOnce(async (prompt: unknown) => {
+      resolveSubmittedPrompt(prompt);
+    });
+    const { harness } = createHarness(client, {
+      initialSessionId: 'ses_prior',
+    });
+    let dateNow: ReturnType<typeof vi.spyOn> | undefined;
+
+    try {
+      await connectHarness(harness, client);
+      dateNow = vi.spyOn(Date, 'now').mockReturnValue(0);
+
+      harness.sendCommand({
+        commandName: TaskCommandName.SendMessage,
+        data: { text: 'Continue.', visibleInTranscript: true },
+      });
+
+      const prompt = (await submittedPrompt) as
+        | { request?: { messageID?: string }; sessionId?: string }
+        | undefined;
+      const submittedMessageId = prompt?.request?.messageID;
+      expect(prompt?.sessionId).toBe('ses_prior');
+      expect(submittedMessageId).toMatch(/^msg_[a-f0-9]{12}0{14}$/u);
+      expect(submittedMessageId && submittedMessageId > restoredMessageId).toBe(
+        true,
+      );
+      expect(client.createSession).not.toHaveBeenCalled();
+    } finally {
+      dateNow?.mockRestore();
       harness.dispose();
     }
   });

--- a/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
+++ b/apps/worker/src/sandbox-server/lib/harnesses/opencode-server/harness.ts
@@ -335,7 +335,34 @@ type OpenCodeMessageRole = OpenCodeMessageInfo['role'];
 let lastOpenCodeMessageIdTimestamp = 0;
 let openCodeMessageIdCounter = 0;
 
-function createOpenCodeMessageId(): string {
+const OPENCODE_MESSAGE_ID_RANDOM_LENGTH = 14;
+const MAX_OPENCODE_MESSAGE_ID_SORTABLE = (BigInt(1) << BigInt(48)) - BigInt(1);
+
+function formatOpenCodeMessageId(sortable: bigint): string {
+  const timeBytes = Buffer.alloc(6);
+
+  for (let index = 0; index < 6; index += 1) {
+    timeBytes[index] = Number(
+      (sortable >> BigInt(40 - 8 * index)) & BigInt(0xff),
+    );
+  }
+
+  return `msg_${timeBytes.toString('hex')}${'0'.repeat(
+    OPENCODE_MESSAGE_ID_RANDOM_LENGTH,
+  )}`;
+}
+
+function openCodeMessageIdSortable(messageId: string): bigint | undefined {
+  const match = /^msg_([a-f0-9]{12})/u.exec(messageId);
+
+  if (!match?.[1]) {
+    return undefined;
+  }
+
+  return BigInt(`0x${match[1]}`);
+}
+
+function createOpenCodeMessageId(afterMessageId?: string): string {
   const currentTimestamp = Date.now();
 
   if (currentTimestamp !== lastOpenCodeMessageIdTimestamp) {
@@ -347,18 +374,27 @@ function createOpenCodeMessageId(): string {
 
   let sortable = BigInt(currentTimestamp) * BigInt(0x1000);
   sortable += BigInt(openCodeMessageIdCounter);
+  sortable &= MAX_OPENCODE_MESSAGE_ID_SORTABLE;
 
-  const timeBytes = Buffer.alloc(6);
+  const candidate = formatOpenCodeMessageId(sortable);
 
-  for (let index = 0; index < 6; index += 1) {
-    timeBytes[index] = Number(
-      (sortable >> BigInt(40 - 8 * index)) & BigInt(0xff),
-    );
+  if (!afterMessageId || candidate > afterMessageId) {
+    return candidate;
   }
 
-  // OpenCode compares message IDs lexicographically to decide whether an
-  // assistant answered after the latest user prompt.
-  return `msg_${timeBytes.toString('hex')}${'0'.repeat(14)}`;
+  const afterSortable = openCodeMessageIdSortable(afterMessageId);
+
+  if (
+    afterSortable !== undefined &&
+    afterSortable < MAX_OPENCODE_MESSAGE_ID_SORTABLE
+  ) {
+    return formatOpenCodeMessageId(afterSortable + BigInt(1));
+  }
+
+  // OpenCode only requires message IDs to start with `msg`. If an unknown ID
+  // shape (or the maximum 48-bit prefix) reaches us, extending it is the one
+  // format-agnostic way to preserve the ordering invariant.
+  return `${afterMessageId}0`;
 }
 
 function visibleQueuedMessages(
@@ -1571,6 +1607,8 @@ export class OpenCodeServerHarness
   private disposed = false;
   private sessionId: string | undefined;
   private resumedSessionPendingValidation = false;
+  /** Greatest message id observed in the current OpenCode session. */
+  private latestSessionMessageId: string | undefined;
   private inFlight = false;
   private nativeSteerSubmissionsInFlight = 0;
   private recoveringWedgedTurn = false;
@@ -2078,6 +2116,7 @@ export class OpenCodeServerHarness
         // session.
         this.sessionId = command.data;
         this.resumedSessionPendingValidation = true;
+        this.latestSessionMessageId = undefined;
         this.runtimeEvents.taskStarted(command.data);
         return;
       case TaskCommandName.RestoreQueuedMessages:
@@ -3361,6 +3400,7 @@ export class OpenCodeServerHarness
         signal: this.composeSessionCreateSignal(),
       });
       this.sessionId = session.id;
+      this.latestSessionMessageId = undefined;
       this.logger.info(
         `Created OpenCode session sessionId=${session.id} elapsedMs=${
           Date.now() - startedAt
@@ -3520,12 +3560,22 @@ export class OpenCodeServerHarness
   }
 
   private async validateResumedSession(sessionId: string): Promise<boolean> {
+    this.latestSessionMessageId = undefined;
+
     try {
-      await this.client.messages({
+      const messages = await this.client.messages({
         sessionId,
-        limit: 1,
+        // A failed prompt can be newer by wall-clock time while still sorting
+        // below an older assistant by id, so inspect a short tail and keep the
+        // greatest id rather than trusting the first result alone.
+        limit: 20,
         signal: this.eventAbortController.signal,
       });
+
+      for (const message of messages) {
+        this.recordSessionMessageId(message.info.id);
+      }
+
       return true;
     } catch (error) {
       this.logger.warn(
@@ -3621,7 +3671,12 @@ export class OpenCodeServerHarness
   private async submitPrompt(prompt: PromptInput): Promise<void> {
     this.suppressAssistantOutputUntilNextPrompt = false;
     const sessionId = await this.ensureSession(prompt.text);
-    const messageID = createOpenCodeMessageId();
+    // OpenCode determines whether a user turn is pending by comparing message
+    // IDs lexicographically. A snapshot can resume on a process whose clock or
+    // generator state trails the process that wrote the restored assistant
+    // message, so seed the new ID from the session history validated above.
+    const messageID = createOpenCodeMessageId(this.latestSessionMessageId);
+    this.recordSessionMessageId(messageID);
     const nonEmptyImages = (prompt.images ?? []).filter(
       (image) => image.trim().length > 0,
     );
@@ -4760,6 +4815,8 @@ export class OpenCodeServerHarness
       return;
     }
 
+    this.recordSessionMessageId(info.id);
+
     const role = parseOpenCodeMessageRole(info.role);
 
     if (role) {
@@ -5138,6 +5195,7 @@ export class OpenCodeServerHarness
   private persistAssistantMessage(
     message: OpenCodeSessionMessage,
   ): FinalizedAssistantTurn {
+    this.recordSessionMessageId(message.info.id);
     const text = extractAssistantText(message);
     const tokenUsage = createTokenUsage(message.info);
     const finalized = {
@@ -5178,6 +5236,15 @@ export class OpenCodeServerHarness
     this.finalizedAssistantTurn = finalized;
 
     return finalized;
+  }
+
+  private recordSessionMessageId(messageId: string | undefined): void {
+    if (
+      messageId &&
+      (!this.latestSessionMessageId || messageId > this.latestSessionMessageId)
+    ) {
+      this.latestSessionMessageId = messageId;
+    }
   }
 
   private scheduleQueuedPromptRetry(): void {


### PR DESCRIPTION
## Why this PR exists

- [x] I am a maintainer / this is internal Roomote work

## What was happening

After a snapshot resume, OpenCode could accept a follow-up prompt but exit its loop at step 0 without calling the provider.

OpenCode determines whether a turn is pending by comparing message IDs lexicographically. Roomote's message-ID generator starts with fresh process-local clock and counter state, so a new user message could sort below an assistant message restored from the snapshot. OpenCode then treated the restored assistant message as newer than the follow-up and returned immediately.

## What changed

- During resumed-session validation, inspect the recent message tail and retain the greatest message ID.
- Generate every subsequent user message strictly after the greatest ID observed in that session.
- Continue tracking assistant and user message IDs during live turns.
- Keep the original OpenCode session so its conversation context and lifecycle remain intact.

## How it was tested

- Added a regression test covering the real `initialSessionId` snapshot-resume path, including restored history that sorts ahead of the new process clock.
- OpenCode harness test file: 68 passing.
- Full harness suite with file parallelism disabled: 254 passing across 17 files.
- `pnpm --filter @roomote/worker check-types`
- `pnpm --filter @roomote/worker lint`
- `pnpm --filter @roomote/worker format:check`

The harness suite's existing OpenCode bootstrap timing test passed in isolation and in the complete serial run.
