### PR TITLE
fix: allow brain maintenance cycles to finish

### DIFF
--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-maintenance.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-maintenance.test.ts
@@ -61,6 +61,7 @@ describe('brainMaintenanceJob', () => {
         arguments: {
           name: 'autopilot-cycle',
           data: { pull: false },
+          timeout_ms: 60 * 60 * 1000,
         },
       },
     });

--- a/apps/bullmq/src/scheduled-jobs/brain-maintenance.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-maintenance.ts
@@ -3,6 +3,8 @@ import {
   resolveBrainInferenceProvider,
 } from '@roomote/sdk/server';
 
+const BRAIN_MAINTENANCE_TIMEOUT_MS = 60 * 60 * 1000;
+
 /**
  * Ask gbrain's durable Postgres worker to run one built-in maintenance cycle.
  * Roomote owns the clock so hosted and self-hosted deployments behave alike;
@@ -38,6 +40,7 @@ export async function brainMaintenanceJob(): Promise<void> {
           name: 'autopilot-cycle',
           data: { pull: false },
           max_attempts: 2,
+          timeout_ms: BRAIN_MAINTENANCE_TIMEOUT_MS,
         },
       },
     }),


### PR DESCRIPTION
## What changed

Roomote now gives the built-in gbrain autopilot cycle an explicit 60-minute wall-clock timeout. The scheduler test pins the submitted timeout.

## Why

gbrain defaults autopilot cycles to 30 minutes. A healthy cycle can legitimately exceed that while synthesis and proposed-take generation are still progressing, causing the durable worker to dead-letter useful maintenance work near completion.

The longer timeout is only a ceiling and does not change the maintenance schedule or make successful runs take longer.

## Validation

- Targeted Brain maintenance scheduler test
- BullMQ TypeScript check
- Pre-push oxlint, residual lint, fast type checks, and knip