### PR TITLE
fix: enable brain gateway synthesis

### DIFF
--- a/.docker/gbrain/entrypoint.sh
+++ b/.docker/gbrain/entrypoint.sh
@@ -265,6 +265,11 @@ mkdir -p "$BRAIN_DIR"
 gbrain config set sync.repo_path "$BRAIN_DIR" >/dev/null
 gbrain config set dream.synthesize.session_corpus_dir "$BRAIN_DIR" >/dev/null
 gbrain config set dream.synthesize.enabled true >/dev/null
+# Roomote routes synthesis through an OpenAI-compatible gateway. gbrain's
+# legacy subagent loop only supports Anthropic directly, so non-Anthropic
+# models need the provider-neutral gateway loop or every dream child is
+# rejected before inference.
+gbrain config set agent.use_gateway_loop true >/dev/null
 echo "[gbrain-entrypoint] corpus checkout: $BRAIN_DIR (filesystem + Postgres index)"
 
 # Route gbrain's OpenRouter reranker through the same Roomote credential

--- a/deploy/ci/validate-deployment-artifacts.mjs
+++ b/deploy/ci/validate-deployment-artifacts.mjs
@@ -217,6 +217,12 @@ assert(
 );
 
 const gbrainEntrypoint = read('.docker/gbrain/entrypoint.sh');
+assert(
+  gbrainEntrypoint.includes(
+    'gbrain config set agent.use_gateway_loop true >/dev/null',
+  ),
+  'gbrain: Roomote gateway models require the gateway-native agent loop',
+);
 const gbrainResetIndex = gbrainEntrypoint.indexOf(
   'write_storage_layout "$STORAGE_LAYOUT_RESETTING"',
 );


### PR DESCRIPTION
## What changed

- Enable gbrain’s provider-neutral gateway agent loop at startup.
- Validate the required setting in deployment artifacts.

## Why

Brain synthesis uses Roomote’s OpenAI-compatible inference gateway. Without the gateway loop, gbrain rejects non-Anthropic child jobs before inference, so maintenance can finish without producing synthesized pages.

## Validation

- Shell syntax validation for the gbrain entrypoint
- Deployment artifact validation
- Pre-push checks: oxlint, residual lint, fast type checks, knip