### PR TITLE
fix Brain digest SSE parsing

### DIFF
--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-maintenance.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-maintenance.test.ts
@@ -98,6 +98,16 @@ function submitResponse(): Response {
   );
 }
 
+function asServerSentEvent(response: Response): Promise<Response> {
+  return response.text().then(
+    (body) =>
+      new Response(`event: message\ndata: ${body}\n\n`, {
+        status: response.status,
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+  );
+}
+
 describe('brainMaintenanceJob', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -292,6 +302,24 @@ describe('runBrainDailyDigest', () => {
       {},
       'roomote-daily-digest',
       { watermark: expectedUntil },
+    );
+  });
+
+  it('parses MCP server-sent events with a leading event field', async () => {
+    mockGetBrainSyncState.mockResolvedValue(null);
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(await asServerSentEvent(searchResponse()))
+      .mockResolvedValueOnce(await asServerSentEvent(synthesisResponse()));
+
+    await runBrainDailyDigest(
+      { baseUrl: 'http://gbrain.test', token: 'read-token' },
+      { baseUrl: 'http://gbrain.test', token: 'write-token' },
+      new Date('2026-08-16T07:00:00.000Z'),
+    );
+
+    expect(mockPostToBrain).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: 'daily/digests/2026-08-16' }),
+      { baseUrl: 'http://gbrain.test', token: 'write-token' },
     );
   });
 

--- a/apps/bullmq/src/scheduled-jobs/brain-maintenance.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-maintenance.ts
@@ -55,17 +55,17 @@ Every factual claim must cite the supporting Brain page slug. Preserve specific 
 
 function parseJsonRpcBody(body: string): unknown {
   const trimmed = body.trim();
-
-  if (!trimmed.startsWith('data:')) {
-    return JSON.parse(trimmed);
-  }
-
-  const events = trimmed
+  const dataLines = trimmed
     .split(/\r?\n/)
     .filter((line) => line.startsWith('data:'))
     .map((line) => line.slice('data:'.length).trim())
-    .filter((line) => line && line !== '[DONE]')
-    .map((line) => JSON.parse(line));
+    .filter((line) => line && line !== '[DONE]');
+
+  if (dataLines.length === 0) {
+    return JSON.parse(trimmed);
+  }
+
+  const events = dataLines.map((line) => JSON.parse(line));
 
   return events.at(-1);
 }


### PR DESCRIPTION
## Summary

- recognize MCP server-sent events even when an `event:` field precedes `data:`
- preserve ordinary JSON response parsing
- cover query and synthesis responses with the server-sent event shape used by gbrain

## Root cause

The nightly digest parser classified a response as SSE only when the body began with `data:`. MCP responses can begin with `event: message`, causing the valid stream to be passed to `JSON.parse` as a plain JSON document.

## Impact

Nightly Brain digests can consume gbrain MCP responses without failing before synthesis.

## Validation

- focused Brain maintenance suite: 12 passing
- BullMQ TypeScript check
- changed-file ESLint
- BullMQ formatting check
- repository pre-push checks