### PR TITLE
feat: preflight fast replies with Brain

### DIFF
--- a/apps/api/src/handlers/slack/events/fast-agent-processing.test.ts
+++ b/apps/api/src/handlers/slack/events/fast-agent-processing.test.ts
@@ -46,7 +46,15 @@ describe('processFastAgentMessage', () => {
       addReaction: vi.fn(),
       removeReaction: vi.fn(),
       normalizeIncomingText: vi.fn(async (text: string) => text),
-      fetchThreadMessages: vi.fn(async () => []),
+      fetchThreadMessages: vi.fn(async () => [
+        {
+          user: 'U123',
+          username: 'Matt',
+          text: '!fast hi how are you',
+          ts: '100.001',
+          type: 'message',
+        },
+      ]),
     };
 
     await processFastAgentMessage({
@@ -67,7 +75,11 @@ describe('processFastAgentMessage', () => {
     expect(slack.removeReaction).not.toHaveBeenCalled();
     expect(mocks.answerQuestion).toHaveBeenCalledOnce();
     expect(mocks.answerQuestion).toHaveBeenCalledWith(
-      expect.objectContaining({ slackTeamId: 'T123' }),
+      expect.objectContaining({
+        slackTeamId: 'T123',
+        senderDisplayName: 'Matt',
+        threadContext: [],
+      }),
     );
     expect(mocks.acquireLock).toHaveBeenCalledWith(
       expect.stringContaining('T123:D123:100.001'),

--- a/apps/api/src/handlers/slack/events/fast-agent.ts
+++ b/apps/api/src/handlers/slack/events/fast-agent.ts
@@ -131,6 +131,9 @@ export async function processFastAgentMessage(params: {
 
     let didFailToReplyToSlack = false;
     let didPostFinalAnswer = false;
+    const currentMessage = threadContext.find(
+      (message) => message.ts === event.ts,
+    );
     const serializedThreadContext = threadContext
       .filter((message) => message.ts !== event.ts)
       .map((message) => ({
@@ -150,6 +153,7 @@ export async function processFastAgentMessage(params: {
       slackChannel: event.channel,
       slackThreadTs: threadId,
       currentMessageTs: event.ts,
+      senderDisplayName: currentMessage?.username,
       activeTaskId,
       launchTask,
       postSlackReply: async ({ type, text }) => {

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-prompt.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-prompt.test.ts
@@ -45,6 +45,9 @@ describe('buildFastAgentSystemPrompt', () => {
 
     expect(prompt).toContain('Brain [integrationId: gbrain]');
     expect(prompt).toContain('lightweight conversational context');
+    expect(prompt).toContain(
+      'automatically performs one Brain query before making its first decision',
+    );
     expect(prompt).toContain('one useful Brain result is usually enough');
     expect(prompt).not.toContain('sequential preflight');
     expect(prompt).not.toContain('proof of coverage');

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -174,7 +174,7 @@ describe('answerFastAgentQuestion', () => {
     );
   });
 
-  it('allows chained brokered integration calls before responding', async () => {
+  it('runs a Brain preflight before deciding and can chain another integration', async () => {
     mocks.listIntegrations.mockResolvedValue([
       {
         id: 'gbrain',
@@ -190,15 +190,6 @@ describe('answerFastAgentQuestion', () => {
       },
     ]);
     mocks.generateObject
-      .mockResolvedValueOnce({
-        object: decision({
-          action: 'call_integration',
-          response: '',
-          integrationId: 'gbrain',
-          toolName: 'query',
-          toolArguments: { query: 'orchestrator' },
-        }),
-      })
       .mockResolvedValueOnce({
         object: decision({
           action: 'call_integration',
@@ -236,7 +227,7 @@ describe('answerFastAgentQuestion', () => {
       {
         integrationId: 'gbrain',
         toolName: 'query',
-        args: { query: 'orchestrator' },
+        args: { query: 'What does this service do?' },
       },
     );
     expect(mocks.callIntegration).toHaveBeenNthCalledWith(
@@ -257,7 +248,13 @@ describe('answerFastAgentQuestion', () => {
         args: { query: 'orchestrator' },
       },
     );
-    expect(mocks.generateObject).toHaveBeenCalledTimes(3);
+    expect(mocks.generateObject).toHaveBeenCalledTimes(2);
+    expect(mocks.generateObject.mock.calls[0]?.[0]?.prompt).toContain(
+      'AUTOMATIC BRAIN PREFLIGHT',
+    );
+    expect(mocks.generateObject.mock.calls[0]?.[0]?.prompt).toContain(
+      'Fast mode uses an orchestrator.',
+    );
     expect(result).toBe('The code is in the fast-agent module.');
   });
 

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -48,6 +48,7 @@ const baseParams = {
   slackChannel: 'channel-1',
   slackThreadTs: '100.1',
   currentMessageTs: '100.2',
+  senderDisplayName: 'Matt',
 };
 
 function decision(overrides: Record<string, unknown> = {}) {
@@ -227,7 +228,7 @@ describe('answerFastAgentQuestion', () => {
       {
         integrationId: 'gbrain',
         toolName: 'query',
-        args: { query: 'What does this service do?' },
+        args: { query: 'Matt: What does this service do?' },
       },
     );
     expect(mocks.callIntegration).toHaveBeenNthCalledWith(

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-constants.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-constants.ts
@@ -2,6 +2,7 @@ export const FAST_AGENT_MODEL = 'openai/gpt-5.4';
 export const FAST_AGENT_MAX_STEPS = 50;
 export const FAST_AGENT_BRAIN_INSTRUCTIONS = `Use Brain as lightweight conversational context, not as an exhaustive research assignment.
 
+- Fast mode automatically performs one Brain query before making its first decision. Treat that preflight result as the lay of the land; do not repeat it.
 - Make the narrowest lookup that is likely to help with the user's request.
 - For ordinary conversation, one useful Brain result is usually enough. Answer as soon as you have helpful context.
 - Do not try to prove complete coverage, enumerate every possible source, or keep searching merely because more context might exist.

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -1,5 +1,5 @@
 import type { ModelMessage } from 'ai';
-import { formatErrorForLog } from '@roomote/types';
+import { BRAIN_MCP_ID, formatErrorForLog } from '@roomote/types';
 import { z } from 'zod';
 
 import {
@@ -128,6 +128,23 @@ function buildIntegrationCallSignature({
     toolName,
     canonicalizeIntegrationCallValue(args),
   ]);
+}
+
+function buildBrainPreflightQuery({
+  question,
+  threadContext,
+  currentMessageTs,
+}: {
+  question: string;
+  threadContext: FastAgentSlackThreadMessage[];
+  currentMessageTs?: string;
+}): string {
+  const currentMessage = currentMessageTs
+    ? threadContext.find((message) => message.ts === currentMessageTs)
+    : undefined;
+  const displayName = currentMessage?.username?.trim();
+
+  return displayName ? `${displayName}: ${question}` : question;
 }
 
 function buildUserTextMessage(text: string): ModelMessage {
@@ -370,6 +387,54 @@ export async function answerFastAgentQuestion({
     let decision: z.infer<typeof fastAgentDecisionSchema> | null = null;
     let requireFinalDecision = false;
     const integrationCallSignatures = new Set<string>();
+    const brain = availableIntegrations.find(
+      (integration) =>
+        integration.id === BRAIN_MCP_ID &&
+        integration.tools.some((tool) => tool.name === 'query'),
+    );
+
+    if (brain) {
+      const toolName = 'query';
+      const toolArguments = {
+        query: buildBrainPreflightQuery({
+          question: normalizedQuestion,
+          threadContext,
+          currentMessageTs,
+        }),
+      };
+      integrationCallSignatures.add(
+        buildIntegrationCallSignature({
+          integrationId: brain.id,
+          toolName,
+          args: toolArguments,
+        }),
+      );
+      let brainResult: unknown;
+
+      try {
+        brainResult = await callFastAgentIntegration(
+          {
+            userId,
+            apiBaseUrl,
+            sessionId: session.id,
+            slackTeamId,
+            slackChannel,
+            slackThreadTs,
+            slackMessageTs: currentMessageTs ?? slackThreadTs,
+          },
+          availableIntegrations,
+          {
+            integrationId: brain.id,
+            toolName,
+            args: toolArguments,
+          },
+        );
+      } catch (error) {
+        brainResult = { error: formatErrorForLog(error) };
+      }
+
+      prompt += `\n\n[AUTOMATIC BRAIN PREFLIGHT]\nResult: ${JSON.stringify(brainResult).slice(0, 30_000)}\n[END AUTOMATIC BRAIN PREFLIGHT]\n\nUse this as lightweight context while deciding the best way to answer. The required initial Brain lookup is complete; do not repeat it.`;
+    }
 
     for (
       let generation = 0;

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -132,17 +132,12 @@ function buildIntegrationCallSignature({
 
 function buildBrainPreflightQuery({
   question,
-  threadContext,
-  currentMessageTs,
+  senderDisplayName,
 }: {
   question: string;
-  threadContext: FastAgentSlackThreadMessage[];
-  currentMessageTs?: string;
+  senderDisplayName?: string;
 }): string {
-  const currentMessage = currentMessageTs
-    ? threadContext.find((message) => message.ts === currentMessageTs)
-    : undefined;
-  const displayName = currentMessage?.username?.trim();
+  const displayName = senderDisplayName?.trim();
 
   return displayName ? `${displayName}: ${question}` : question;
 }
@@ -334,6 +329,7 @@ export async function answerFastAgentQuestion({
   slackChannel,
   slackThreadTs,
   currentMessageTs,
+  senderDisplayName,
   activeTaskId = null,
   launchTask,
   postSlackReply,
@@ -346,6 +342,7 @@ export async function answerFastAgentQuestion({
   slackChannel: string;
   slackThreadTs: string;
   currentMessageTs?: string;
+  senderDisplayName?: string;
   activeTaskId?: string | null;
   launchTask?: LaunchFastAgentSlackTask;
   postSlackReply: PostFastAgentSlackReply;
@@ -398,8 +395,7 @@ export async function answerFastAgentQuestion({
       const toolArguments = {
         query: buildBrainPreflightQuery({
           question: normalizedQuestion,
-          threadContext,
-          currentMessageTs,
+          senderDisplayName,
         }),
       };
       integrationCallSignatures.add(


### PR DESCRIPTION
## Summary

- run one audited Brain query before fast mode makes its first decision when Brain is available
- inject the preflight result as lightweight context for response and delegation decisions
- prevent the orchestrator from immediately repeating the automatic lookup

## Validation

- 24 focused fast-agent tests
- cloud-agents typecheck
- lint:fast, check-types:fast, and knip