### PR TITLE
Use the primary coding model for Fast mode

### DIFF
--- a/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
@@ -583,6 +583,44 @@ describe('resolveOpenCodeSmallModel', () => {
     expect(sessionPromptMock.mock.calls[0]?.[0]).not.toHaveProperty('format');
   });
 
+  it('uses the deployment primary model for text when requested', async () => {
+    process.env = {
+      ...originalEnv,
+      OPENCODE_SDK_SERVER_URL: 'http://127.0.0.1:4096',
+    };
+    mockResolveEffectiveModelRuntimeEnv.mockResolvedValue({
+      R_MODEL: 'openrouter/z-ai/glm-5.2',
+      R_SMALL_MODEL: 'openrouter/openai/gpt-5.4',
+    });
+    sessionPromptMock.mockResolvedValue({
+      data: {
+        info: { error: null },
+        parts: [{ type: 'text', text: 'primary answer' }],
+      },
+      error: undefined,
+    });
+
+    const { generateTrackedNonTaskText, NON_TASK_INFERENCE_SURFACES } =
+      await import('../non-task-provider-usage.js');
+
+    const result = await generateTrackedNonTaskText({
+      surface: NON_TASK_INFERENCE_SURFACES.fastAgentQuestionAnswering,
+      modelRole: 'primary',
+      prompt: 'Answer.',
+    });
+
+    expect(result).toBe('primary answer');
+    expect(sessionPromptMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: {
+          providerID: 'openrouter',
+          modelID: 'z-ai/glm-5.2',
+        },
+      }),
+      expect.any(Object),
+    );
+  });
+
   it('addresses Mantle GPT helper models by their runtime provider id', async () => {
     process.env = {
       ...originalEnv,

--- a/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
@@ -250,6 +250,46 @@ describe('resolveOpenCodeSmallModel', () => {
     );
   });
 
+  it('uses the deployment primary model when requested', async () => {
+    process.env = {
+      ...originalEnv,
+    };
+    mockResolveEffectiveModelRuntimeEnv.mockResolvedValue({
+      R_MODEL: 'openrouter/z-ai/glm-5.2',
+      R_SMALL_MODEL: 'openrouter/openai/gpt-5.4',
+      OPENROUTER_API_KEY: 'test-key',
+    });
+    sessionPromptMock.mockResolvedValue({
+      data: {
+        info: {
+          structured: { answer: 'ok' },
+        },
+        parts: [],
+      },
+      error: undefined,
+    });
+
+    const { generateTrackedNonTaskObject, NON_TASK_INFERENCE_SURFACES } =
+      await import('../non-task-provider-usage.js');
+
+    await generateTrackedNonTaskObject({
+      surface: NON_TASK_INFERENCE_SURFACES.fastAgentQuestionAnswering,
+      modelRole: 'primary',
+      schema: z.object({ answer: z.string() }),
+      prompt: 'Answer.',
+    });
+
+    expect(sessionPromptMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: {
+          providerID: 'openrouter',
+          modelID: 'z-ai/glm-5.2',
+        },
+      }),
+      expect.any(Object),
+    );
+  });
+
   it('starts a separate managed OpenCode SDK server when model env changes', async () => {
     process.env = {
       ...originalEnv,

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -100,6 +100,9 @@ describe('answerFastAgentQuestion', () => {
     expect(postSlackReply).toHaveBeenCalledWith(
       expect.objectContaining({ text: 'It coordinates incoming requests.' }),
     );
+    expect(mocks.generateObject).toHaveBeenCalledWith(
+      expect.objectContaining({ modelRole: 'primary' }),
+    );
     expect(mocks.appendSessionMessages).toHaveBeenCalledOnce();
   });
 

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-constants.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-constants.ts
@@ -1,4 +1,4 @@
-export const FAST_AGENT_MODEL = 'openai/gpt-5.4';
+export const FAST_AGENT_MODEL_ROLE = 'primary' as const;
 export const FAST_AGENT_MAX_STEPS = 50;
 export const FAST_AGENT_BRAIN_INSTRUCTIONS = `Use Brain as lightweight conversational context, not as an exhaustive research assignment.
 

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -9,7 +9,10 @@ import {
   type SlackThreadPromptMessage,
 } from '../../utils';
 import { getAvailableEnvironments, type RoutableEnvironment } from '../router';
-import { FAST_AGENT_MAX_STEPS, FAST_AGENT_MODEL } from './fast-agent-constants';
+import {
+  FAST_AGENT_MAX_STEPS,
+  FAST_AGENT_MODEL_ROLE,
+} from './fast-agent-constants';
 import { buildFastAgentSystemPrompt } from './fast-agent-prompt';
 import {
   appendFastAgentSessionMessages,
@@ -443,6 +446,7 @@ export async function answerFastAgentQuestion({
         const generated = await generateTrackedNonTaskObject({
           userId,
           surface: NON_TASK_INFERENCE_SURFACES.fastAgentQuestionAnswering,
+          modelRole: FAST_AGENT_MODEL_ROLE,
           schema: mustFinish
             ? fastAgentFinalDecisionSchema
             : fastAgentDecisionSchema,
@@ -625,5 +629,5 @@ export async function answerFastAgentQuestion({
   }
 }
 
-export { FAST_AGENT_MAX_STEPS, FAST_AGENT_MODEL };
+export { FAST_AGENT_MAX_STEPS, FAST_AGENT_MODEL_ROLE };
 export type { RoutableEnvironment };

--- a/packages/cloud-agents/src/server/non-task-provider-usage.ts
+++ b/packages/cloud-agents/src/server/non-task-provider-usage.ts
@@ -124,6 +124,7 @@ interface GenerateTrackedNonTaskBaseParams extends NonTaskInferenceTrackingInput
   prompt: string;
   system?: string;
   model?: string;
+  modelRole?: 'primary' | 'small';
   maxOutputTokens?: number;
   timeoutMs?: number;
 }
@@ -282,7 +283,10 @@ function formatOpenCodeSdkError(error: unknown): string {
   }
 }
 
-async function resolveNonTaskModelRuntime(model?: string): Promise<{
+async function resolveNonTaskModelRuntime(
+  model?: string,
+  modelRole: 'primary' | 'small' = 'small',
+): Promise<{
   model: string;
   resolvedModelRuntimeEnv: Partial<Record<string, string>>;
 }> {
@@ -305,9 +309,13 @@ async function resolveNonTaskModelRuntime(model?: string): Promise<{
 
   const resolvedModel =
     requestedModel ||
-    resolvedModelRuntimeEnv.R_SMALL_MODEL ||
-    resolvedModelRuntimeEnv.R_MODEL ||
-    resolveOpenCodeSmallModel();
+    (modelRole === 'primary'
+      ? resolvedModelRuntimeEnv.R_MODEL
+      : resolvedModelRuntimeEnv.R_SMALL_MODEL ||
+        resolvedModelRuntimeEnv.R_MODEL) ||
+    (modelRole === 'primary'
+      ? asString(parseOpenCodeConfigJson(readOpenCodeDebugConfig()).model)
+      : resolveOpenCodeSmallModel());
 
   if (!resolvedModel) {
     throw new Error(
@@ -603,7 +611,8 @@ async function generateTrackedNonTaskObjectWithSdk<
   },
 ): Promise<{ object: z.output<TSchema> }> {
   const resolvedRuntime =
-    runtime ?? (await resolveNonTaskModelRuntime(params.model));
+    runtime ??
+    (await resolveNonTaskModelRuntime(params.model, params.modelRole));
 
   const data = await runNonTaskSdkPrompt(params, resolvedRuntime, {
     system: params.system,

--- a/packages/cloud-agents/src/server/non-task-provider-usage.ts
+++ b/packages/cloud-agents/src/server/non-task-provider-usage.ts
@@ -553,7 +553,10 @@ async function runNonTaskSdkPrompt(
 export async function generateTrackedNonTaskText(
   params: GenerateTrackedNonTaskTextParams,
 ): Promise<string> {
-  const runtime = await resolveNonTaskModelRuntime(params.model);
+  const runtime = await resolveNonTaskModelRuntime(
+    params.model,
+    params.modelRole,
+  );
   const model = await resolveModelForInputModality(params, runtime);
 
   const data = await runNonTaskSdkPrompt(


### PR DESCRIPTION
## Summary
- let non-task inference callers select the deployment primary or small model role
- run Fast mode with the configured primary coding model
- remove the stale hard-coded Fast model identifier

## Validation
- focused Fast agent and non-task provider tests (50 tests)
- cloud-agents TypeScript check
- pre-push lint, fast typecheck, and Knip gates