### PR TITLE
[Feat] Enable Slack Agent messaging in generated apps

### DIFF
--- a/apps/docs/providers/communications/slack.mdx
+++ b/apps/docs/providers/communications/slack.mdx
@@ -88,6 +88,7 @@ Scopes**:
 
 ```text
 app_mentions:read
+assistant:write
 channels:read
 channels:history
 chat:write
@@ -122,6 +123,8 @@ Turn on **Event Subscriptions** and set **Request URL** to:
 Subscribe to these bot events:
 
 ```text
+app_context_changed
+app_home_opened
 app_mention
 message.im
 message.channels
@@ -143,11 +146,18 @@ Turn on **Interactivity & Shortcuts** and use the same request URL:
 Roomote uses this endpoint for button clicks and other interactive Slack
 payloads.
 
-## App home and messages
+## Agent messaging experience
 
-If you want to start tasks by direct message, make sure the app can receive DMs.
-Enable the app surfaces needed for messages to the bot, then keep the
-`message.im` event subscription enabled.
+Roomote-created apps enable Slack's current **Agent messaging experience**
+(`features.agent_view`). This keeps conversations in the app's Messages tab,
+opens Fast-mode responses in threads, and allows Slack to render native loading
+states and streamed task cards.
+
+For an existing manually configured app, open its Slack app settings, enable
+the **Agents** feature, and select the Agent messaging experience. Add the
+`assistant:write` scope and the `app_home_opened` and `app_context_changed`
+events listed above, then reinstall the app and hard-refresh Slack. Keep
+`message.im` enabled so direct messages continue reaching Roomote.
 
 ## Local URL changes
 

--- a/apps/web/src/lib/slack-app-manifest.client.test.ts
+++ b/apps/web/src/lib/slack-app-manifest.client.test.ts
@@ -77,6 +77,16 @@ describe('Slack app manifest builder', () => {
     });
   });
 
+  it("enables Slack's Agent messaging experience", () => {
+    const manifest = buildSlackAppManifest({
+      publicOrigin: 'https://roomote.example.com',
+    });
+
+    expect(manifest.features.agent_view).toEqual({
+      agent_description: SLACK_MANIFEST_DESCRIPTION,
+    });
+  });
+
   it('includes Slack OAuth callback URLs from the deployment origin', () => {
     const manifest = buildSlackAppManifest({
       publicOrigin: 'https://roomote.example.com/',
@@ -116,6 +126,7 @@ describe('Slack app manifest builder', () => {
     expect(manifest.oauth_config.scopes.bot).toEqual(
       expect.arrayContaining([
         'app_mentions:read',
+        'assistant:write',
         'chat:write',
         'reactions:write',
         'users:read',
@@ -123,6 +134,8 @@ describe('Slack app manifest builder', () => {
     );
     expect(manifest.settings.event_subscriptions.bot_events).toEqual(
       expect.arrayContaining([
+        'app_context_changed',
+        'app_home_opened',
         'app_mention',
         'function_executed',
         'message.im',

--- a/apps/web/src/lib/slack-app-manifest.ts
+++ b/apps/web/src/lib/slack-app-manifest.ts
@@ -5,6 +5,7 @@ import {
 
 export const SLACK_MANIFEST_BOT_SCOPES = [
   'app_mentions:read',
+  'assistant:write',
   'channels:read',
   'channels:history',
   'chat:write',
@@ -25,6 +26,8 @@ export const SLACK_MANIFEST_BOT_SCOPES = [
 ] as const;
 
 export const SLACK_MANIFEST_BOT_EVENTS = [
+  'app_context_changed',
+  'app_home_opened',
   'app_mention',
   'entity_details_requested',
   'function_executed',
@@ -63,6 +66,9 @@ export function buildSlackAppManifest({
         home_tab_enabled: false,
         messages_tab_enabled: true,
         messages_tab_read_only_enabled: false,
+      },
+      agent_view: {
+        agent_description: SLACK_MANIFEST_DESCRIPTION,
       },
       bot_user: {
         display_name: appName,

--- a/apps/web/src/trpc/commands/slack/create-app-from-manifest.test.ts
+++ b/apps/web/src/trpc/commands/slack/create-app-from-manifest.test.ts
@@ -148,6 +148,11 @@ describe('createSlackAppFromManifestCommand', () => {
     const manifest = JSON.parse(body.manifest);
     expect(manifest).toMatchObject({
       display_information: { name: 'Roomote' },
+      features: {
+        agent_view: {
+          agent_description: 'Cloud coding agents for all',
+        },
+      },
       settings: {
         event_subscriptions: {
           request_url: 'https://roomote.example.com/api/webhooks/slack',


### PR DESCRIPTION
## Related issue

Internal Roomote work; no linked issue.

## Why this PR exists

- [x] I am a maintainer / this is internal Roomote work

Generated Roomote Slack apps were configured as standard bot apps. Slack could accept native streaming API calls while not rendering the Agent task-card experience. Declaring `features.agent_view` aligns generated apps with Slack's current agent surface.

## What changed

- enable Slack's current Agent messaging experience in generated app manifests
- request `assistant:write` and subscribe to Agent-view context events
- document the one-time update required for manually configured Slack apps

## Impact

Newly generated Slack apps can render native agent loading states and streamed task cards. Existing manually configured apps need the Agents feature enabled, the added scope/events, a reinstall, and a Slack hard refresh.

## How it was tested

- Slack manifest client tests (9 passed)
- Slack app creation server tests (10 passed)
- `@roomote/web` typecheck
- targeted ESLint
- docs validation

## Checklist

- [x] The PR title follows the repo convention
- [x] This PR is small and scoped to one change
- [ ] Full-repo `pnpm lint` and `pnpm check-types` (focused checks are listed above)
- [x] I added tests and included validation notes above
- [x] I removed secrets, tokens, private keys, and customer data
- [ ] Changelog entry (not included in this scoped PR)
