### PR TITLE
[Fix] Request Agent scope during Slack installs

### DIFF
--- a/apps/web/src/lib/slack-install-url.client.test.ts
+++ b/apps/web/src/lib/slack-install-url.client.test.ts
@@ -1,0 +1,26 @@
+import { SLACK_MANIFEST_BOT_SCOPES } from './slack-app-manifest';
+import { buildSlackInstallUrl } from './slack-install-url';
+
+describe('Slack install URL builder', () => {
+  it('requests the same bot scopes as the generated app manifest', () => {
+    const url = new URL(
+      buildSlackInstallUrl({
+        clientId: 'client-id',
+        state: 'signed-state',
+        redirectUri: 'https://roomote.example.com/api/slack/callback',
+      }),
+    );
+
+    expect(url.searchParams.get('scope')?.split(',')).toEqual([
+      ...SLACK_MANIFEST_BOT_SCOPES,
+    ]);
+    expect(url.searchParams.get('scope')?.split(',')).toContain(
+      'assistant:write',
+    );
+    expect(url.searchParams.get('client_id')).toBe('client-id');
+    expect(url.searchParams.get('state')).toBe('signed-state');
+    expect(url.searchParams.get('redirect_uri')).toBe(
+      'https://roomote.example.com/api/slack/callback',
+    );
+  });
+});

--- a/apps/web/src/lib/slack-install-url.ts
+++ b/apps/web/src/lib/slack-install-url.ts
@@ -1,0 +1,13 @@
+import { SLACK_MANIFEST_BOT_SCOPES } from './slack-app-manifest';
+
+export function buildSlackInstallUrl({
+  clientId,
+  state,
+  redirectUri,
+}: {
+  clientId: string;
+  state: string;
+  redirectUri: string;
+}) {
+  return `https://slack.com/oauth/v2/authorize?client_id=${clientId}&scope=${SLACK_MANIFEST_BOT_SCOPES.join(',')}&state=${state}&redirect_uri=${encodeURIComponent(redirectUri)}`;
+}

--- a/apps/web/src/trpc/commands/slack/index.ts
+++ b/apps/web/src/trpc/commands/slack/index.ts
@@ -28,6 +28,7 @@ import type { UserAuthSuccess } from '@/types';
 import { bootstrapWebRuntimeEnv } from '@/lib/server/bootstrap-runtime-env';
 import { getSlackRedirectUri } from '@/lib/server/slack-redirect-uri';
 import { syncUser } from '@/lib/server/sync-internal';
+import { buildSlackInstallUrl } from '@/lib/slack-install-url';
 import {
   createSignedSlackInstallState,
   createSignedSlackLinkAccountState,
@@ -546,30 +547,13 @@ export async function connectSlackAppCommand(
     }
     const slackOAuthConfig = await resolveSlackOAuthConfig();
 
-    const permissions = [
-      'app_mentions:read',
-      'channels:read',
-      'channels:history',
-      'chat:write',
-      'files:read',
-      'groups:read',
-      'groups:history',
-      'im:read',
-      'im:history',
-      'im:write',
-      'links:read',
-      'links:write',
-      'mpim:read',
-      'mpim:history',
-      'reactions:read',
-      'reactions:write',
-      'team:read',
-      'users:read',
-    ];
-
     const redirectPath = input.redirectPath ?? '/settings';
     const state = await createSignedSlackInstallState({ redirectPath });
-    const url = `https://slack.com/oauth/v2/authorize?client_id=${slackOAuthConfig.clientId}&scope=${permissions.join(',')}&state=${state}&redirect_uri=${encodeURIComponent(getSlackRedirectUri())}`;
+    const url = buildSlackInstallUrl({
+      clientId: slackOAuthConfig.clientId,
+      state,
+      redirectUri: getSlackRedirectUri(),
+    });
 
     return { success: true, url };
   } catch (error) {


### PR DESCRIPTION
## Related issue

Internal Roomote work; no linked issue.

## Why this PR exists

- [x] I am a maintainer / this is internal Roomote work

The generated Slack app manifest and the OAuth installer maintained separate hard-coded bot-scope lists. After Agent messaging added `assistant:write` to the manifest, the install URL continued requesting the older list, so newly installed bot tokens did not receive the Agent scope.

## What changed

- build Slack installation URLs from the manifest's canonical bot scopes
- remove the duplicated scope list from the Slack connection command
- add regression coverage proving OAuth installs request `assistant:write`

## Impact

Generated Slack apps now receive the same scopes during OAuth installation that their manifests declare, enabling Slack's Agent messaging APIs after reinstalling the app.

## How it was tested

- Slack install URL and manifest client tests (10 passed)
- `@roomote/web` typecheck
- targeted ESLint
- focused formatting check

## Checklist

- [x] The PR title follows the repo convention
- [x] This PR is small and scoped to one change
- [x] Focused lint and typecheck pass locally
- [x] I added tests and included validation notes above
- [x] I removed secrets, tokens, private keys, and customer data
- [ ] Changelog entry (not included in this scoped fix)
