### PR TITLE
fix(gbrain): install CA certificates for git sync

### DIFF
--- a/.docker/gbrain/Dockerfile
+++ b/.docker/gbrain/Dockerfile
@@ -11,7 +11,7 @@ FROM oven/bun:1.3.14
 ARG GBRAIN_REF=d995508731ac85710c05486536a5458a00c37d73
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends git postgresql-client \
+  && apt-get install -y --no-install-recommends ca-certificates git postgresql-client \
   && rm -rf /var/lib/apt/lists/*
 
 RUN bun install -g "github:garrytan/gbrain#${GBRAIN_REF}"


### PR DESCRIPTION
## Summary

- install the system CA certificate bundle in the gbrain image
- allow gbrain Git synchronization to use HTTPS remotes reliably

## Root cause

The image included Git but omitted a trusted CA bundle, so HTTPS Git operations could fail certificate verification. Installing `ca-certificates` makes the image self-contained across deployments.

## Validation

- built `.docker/gbrain/Dockerfile` successfully
- verified the resulting image contains a non-empty CA bundle
- verified `git --version` and `gbrain --version` in the resulting image
- ran `git diff --check`