### PR TITLE
fix(brain): hydrate Granola meeting summaries

### DIFF
--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-collectors.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-collectors.test.ts
@@ -11,6 +11,7 @@ import { NotionApiError } from '@roomote/sdk/server/notion-api';
 
 import {
   buildGranolaMeetingPage,
+  fetchGranolaNoteDetail,
   buildNotionPage,
   buildNotionSearchBody,
   buildNotionSweepInventory,
@@ -947,6 +948,30 @@ describe('buildGranolaMeetingPage', () => {
     );
   });
 
+  it('uses Granola detail response summary fields', () => {
+    const result = buildGranolaMeetingPage({
+      ...fixture,
+      summary: undefined,
+      summary_markdown: '## Decisions\n\nShip the detail collector.',
+      summary_text: 'Plain-text fallback.',
+    });
+
+    expect(result?.page.content).toContain(
+      '## Decisions\n\nShip the detail collector.',
+    );
+    expect(result?.page.content).not.toContain('Plain-text fallback.');
+  });
+
+  it('falls back to Granola plain-text summaries', () => {
+    const result = buildGranolaMeetingPage({
+      ...fixture,
+      summary: undefined,
+      summary_text: 'Plain-text meeting summary.',
+    });
+
+    expect(result?.page.content).toContain('Plain-text meeting summary.');
+  });
+
   it('caps the notes excerpt at 3000 characters', () => {
     const result = buildGranolaMeetingPage(fixture);
     const notesSection = result?.page.content.split('## Notes')[1] ?? '';
@@ -1018,6 +1043,33 @@ describe('buildGranolaMeetingPage', () => {
       '- [Dan Riccio](people/roomote-member-abc)',
     );
     expect(result?.page.content).not.toContain('dan@example.com');
+  });
+
+  it('fetches the full Granola note record before mapping it', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      Response.json({
+        ...fixture,
+        summary_markdown: '## Full meeting summary',
+      }),
+    );
+
+    const detail = await fetchGranolaNoteDetail(fixture, 'granola-test-key');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      new URL('https://public-api.granola.ai/v1/notes/not_abc123def45678'),
+      {
+        headers: {
+          Accept: 'application/json',
+          Authorization: 'Bearer granola-test-key',
+        },
+      },
+    );
+    expect(detail).toMatchObject({
+      id: 'not_abc123def45678',
+      summary_markdown: '## Full meeting summary',
+    });
+
+    fetchSpy.mockRestore();
   });
 });
 

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors.ts
@@ -1917,7 +1917,7 @@ const slackPersonDirectoryCollector: BrainCollector = {
 const PERSON_IDENTITIES_STATE_ID =
   'person-identities:members:occurrence-date-v2';
 const PERSON_IDENTITIES_RECONCILIATION_MS = 24 * 60 * 60 * 1000;
-const GRANOLA_MEETINGS_COLLECTOR_ID = 'granola-meetings';
+const GRANOLA_MEETINGS_COLLECTOR_ID = 'granola-meetings:detail-v2';
 
 type PersonIdentityCursor = {
   mode: 'idle' | 'sweep' | 'incremental';
@@ -2855,6 +2855,8 @@ const GRANOLA_PAGE_SIZE = 30; // Granola's documented per-page maximum.
 const GRANOLA_MAX_NOTES_PER_TICK = 50;
 /** Enough to page to the note ceiling, with headroom for short pages. */
 const GRANOLA_MAX_REQUESTS_PER_TICK = 10;
+/** Granola allows five sustained requests per second. */
+const GRANOLA_REQUEST_INTERVAL_MS = 210;
 
 type GranolaAttendee = { display: string; identityCandidates: string[] };
 
@@ -2938,6 +2940,8 @@ export function buildGranolaMeetingPage(
     ),
   ];
   const body =
+    asString(record.summary_markdown) ??
+    asString(record.summary_text) ??
     asString(record.summary) ??
     asString(record.overview) ??
     asString(record.notes_markdown) ??
@@ -2980,6 +2984,77 @@ export function buildGranolaMeetingPage(
     page: { slug: `meetings/${day}-${slugTail}`, title, content },
     updatedAt,
   };
+}
+
+export async function fetchGranolaNoteDetail(
+  note: unknown,
+  apiKey: string,
+): Promise<unknown | null> {
+  if (!note || typeof note !== 'object') {
+    return null;
+  }
+
+  const id = asString((note as Record<string, unknown>).id);
+
+  if (!id) {
+    return null;
+  }
+
+  const url = new URL(
+    `v1/notes/${encodeURIComponent(id)}`,
+    `${GRANOLA_API_BASE_URL}/`,
+  );
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+
+  // A note can disappear between the list and detail requests. Skipping that
+  // one note lets the remaining accessible history continue rebuilding.
+  if (response.status === 404) {
+    console.warn(
+      `${LOG_PREFIX} granola note ${id} disappeared before its details were fetched`,
+    );
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Granola get-note failed for ${id} with status ${response.status}`,
+    );
+  }
+
+  const detail = await response.json().catch(() => null);
+
+  if (!detail || typeof detail !== 'object') {
+    throw new Error(`Granola get-note returned an invalid payload for ${id}`);
+  }
+
+  return detail;
+}
+
+async function hydrateGranolaNotes(
+  notes: unknown[],
+  apiKey: string,
+): Promise<unknown[]> {
+  const details: unknown[] = [];
+
+  for (const note of notes) {
+    // List calls count against the same workspace limit, so leave a full
+    // request interval before every detail request rather than bursting.
+    await new Promise((resolve) =>
+      setTimeout(resolve, GRANOLA_REQUEST_INTERVAL_MS),
+    );
+    const detail = await fetchGranolaNoteDetail(note, apiKey);
+
+    if (detail) {
+      details.push(detail);
+    }
+  }
+
+  return details;
 }
 
 async function findGranolaConnectionConfig(): Promise<McpConnectionGranolaConfig | null> {
@@ -3081,13 +3156,17 @@ async function collectGranolaMeetings(input: {
     }
   }
 
+  const detailedNotes = await hydrateGranolaNotes(
+    notes.slice(0, GRANOLA_MAX_NOTES_PER_TICK),
+    apiKey,
+  );
   const pages: CollectorPage[] = [];
   let nextSince: Date | null = null;
   const identities = buildPersonIdentityLookup(
     await loadPersonIdentityRecords(),
   );
 
-  for (const note of notes.slice(0, GRANOLA_MAX_NOTES_PER_TICK)) {
+  for (const note of detailedNotes) {
     const mapped = buildGranolaMeetingPage(note, identities);
 
     if (!mapped) {
@@ -3165,12 +3244,13 @@ async function backfillGranolaNotesStep(cursor: string | null): Promise<{
     return noProgress;
   }
 
+  const detailedNotes = await hydrateGranolaNotes(payload.notes, apiKey);
   const pages: CollectorPage[] = [];
   const identities = buildPersonIdentityLookup(
     await loadPersonIdentityRecords(),
   );
 
-  for (const note of payload.notes) {
+  for (const note of detailedNotes) {
     const mapped = buildGranolaMeetingPage(note, identities);
 
     if (mapped) {


### PR DESCRIPTION
## Summary

- hydrate Granola list results through the note-detail endpoint before creating Brain pages
- index `summary_markdown`, falling back to `summary_text`
- pace detail requests within Granola's documented sustained rate limit
- version the collector state so existing metadata-only meeting pages are rebuilt

## Root cause

Granola's list-notes endpoint returns only note metadata. The collector mapped those list records directly and also checked field names that do not match the detail response, so meeting pages contained a title and date but no notes.

The collector now fetches each listed note's detail record and stores its enhanced summary. Full transcripts remain available through the Granola integration without copying that much raw content into shared Brain memory.

## Validation

- `pnpm exec dotenvx run -f .env.test -- pnpm --filter @roomote/bullmq exec vitest run src/scheduled-jobs/__tests__/brain-collectors.test.ts` (58 tests passed)
- `pnpm --filter @roomote/bullmq check-types`
- ESLint on both changed files with zero warnings

The package-wide BullMQ lint command also encounters six pre-existing unused-disable warnings in unrelated test files.
