### PR TITLE
[Refactor] Generalize Fast conversation boundaries

### DIFF
--- a/apps/api/src/handlers/discord/__tests__/index.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/index.test.ts
@@ -748,9 +748,13 @@ describe('Discord Gateway event handler', () => {
       expect.objectContaining({
         question: 'Fix the flaky tests',
         userId: 'roomote-user-1',
-        slackThreadTs: 'dm-1',
+        conversation: {
+          surface: 'discord',
+          workspaceId: 'dm',
+          channelId: 'dm-1',
+          threadId: 'dm-1',
+        },
         activeTasks: [],
-        surface: 'discord',
       }),
     );
     expect(mocks.reply).toHaveBeenCalledWith(
@@ -1239,9 +1243,10 @@ describe('Discord Gateway event handler', () => {
 
     expect(response.status).toBe(200);
     expect(mocks.hasFastSession).toHaveBeenCalledWith({
-      slackTeamId: 'discord:guild-1',
-      slackChannel: 'channel-1',
-      slackThreadTs: 'thread-1',
+      surface: 'discord',
+      workspaceId: 'guild-1',
+      channelId: 'channel-1',
+      threadId: 'thread-1',
     });
     expect(mocks.shouldRouteUnmentioned).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1252,7 +1257,7 @@ describe('Discord Gateway event handler', () => {
     expect(mocks.answerFast).toHaveBeenCalledWith(
       expect.objectContaining({
         question: 'Hey Roomote, can you check this too?',
-        surface: 'discord',
+        conversation: expect.objectContaining({ surface: 'discord' }),
       }),
     );
   });
@@ -1939,8 +1944,8 @@ describe('Discord Gateway event handler', () => {
   });
 
   it('uses /fast as a top-level orchestrator that can launch a new task', async () => {
-    mocks.answerFast.mockImplementationOnce(async ({ launchTask }) => {
-      const launched = await launchTask({
+    mocks.answerFast.mockImplementationOnce(async ({ adapter }) => {
+      const launched = await adapter.launchTask({
         prompt: 'Investigate the flaky build',
         environmentId: null,
         parentSessionId: '11111111-1111-4111-8111-111111111111',
@@ -1972,8 +1977,8 @@ describe('Discord Gateway event handler', () => {
       expect.objectContaining({
         question: 'Fix the flaky build',
         userId: 'roomote-user-1',
-        surface: 'discord',
-        launchTask: expect.any(Function),
+        conversation: expect.objectContaining({ surface: 'discord' }),
+        adapter: expect.objectContaining({ launchTask: expect.any(Function) }),
       }),
     );
     expect(mocks.answerFast.mock.calls[0]?.[0].activeTasks).toBeUndefined();

--- a/apps/api/src/handlers/discord/fast-agent.ts
+++ b/apps/api/src/handlers/discord/fast-agent.ts
@@ -48,6 +48,12 @@ export async function processDiscordFastAgentMessage(input: {
       : [];
   const message = getDiscordMessageCreate(input.event);
   let didSendVisibleResponse = false;
+  const conversation = {
+    surface: 'discord' as const,
+    workspaceId: input.channel.guildId ?? 'dm',
+    channelId: input.metadata.communicationChannelId,
+    threadId: input.sessionThreadId,
+  };
   const response = await answerFastAgentQuestion({
     question: input.question,
     threadContext: history.map((entry) => ({
@@ -59,87 +65,86 @@ export async function processDiscordFastAgentMessage(input: {
     })),
     userId: input.senderUserId,
     apiBaseUrl: Env.TRPC_URL ?? Env.R_APP_URL,
-    slackTeamId: `discord:${input.channel.guildId ?? 'dm'}`,
-    slackChannel: input.metadata.communicationChannelId,
-    slackThreadTs: input.sessionThreadId,
+    conversation,
     senderDisplayName:
       input.interaction?.interaction.member?.nick ??
       input.sender.global_name ??
       input.sender.username,
     activeTasks: input.activeTasks,
-    launchTask: async ({ prompt, environmentId, parentSessionId }) => {
-      const workspaceOverride = environmentId
-        ? await resolveDiscordWorkspace({
-            type: 'environment',
-            id: environmentId,
-            name: environmentId,
-          })
-        : {
-            repoForPayload: ALL_REPOSITORIES,
-            workspaceDisplayName: 'all repos',
+    adapter: {
+      launchTask: async ({ prompt, environmentId, parentSessionId }) => {
+        const workspaceOverride = environmentId
+          ? await resolveDiscordWorkspace({
+              type: 'environment',
+              id: environmentId,
+              name: environmentId,
+            })
+          : {
+              repoForPayload: ALL_REPOSITORIES,
+              workspaceDisplayName: 'all repos',
+            };
+        if (!workspaceOverride) {
+          return {
+            success: false,
+            error: 'The selected environment is unavailable.',
           };
-      if (!workspaceOverride) {
+        }
+
+        const started = await startNewDiscordTask({
+          provider: input.provider,
+          applicationId: input.applicationId,
+          requesterDiscordUserId: input.sender.id,
+          launchOwnerUserId: input.senderUserId,
+          queuedMessage: {
+            provider: 'discord',
+            text: prompt,
+            user: input.sender.global_name?.trim() || input.sender.username,
+            userId: input.senderUserId,
+            ts: input.event.eventId,
+            channel: input.metadata.communicationChannelId,
+            ...(input.metadata.communicationThreadId
+              ? { threadTs: input.metadata.communicationThreadId }
+              : {}),
+            turnPolicy: { reactionsAllowed: true },
+          },
+          metadata: input.metadata,
+          channel: input.channel,
+          forceNewThread: true,
+          fastAgentSessionId: parentSessionId,
+          skipRoutingConfirmation: true,
+          workspaceOverride,
+        });
+        if (started.status === 'started') {
+          return {
+            success: true,
+            taskId: started.launchResult.taskId,
+            taskUrl: started.taskUrl,
+          };
+        }
+        if (started.status === 'already_started') {
+          return {
+            success: true,
+            taskId: started.existingRun.taskId,
+            taskUrl: started.taskUrl,
+          };
+        }
         return {
           success: false,
-          error: 'The selected environment is unavailable.',
+          error: `Task launch stopped with status ${started.status}.`,
         };
-      }
-
-      const started = await startNewDiscordTask({
-        provider: input.provider,
-        applicationId: input.applicationId,
-        requesterDiscordUserId: input.sender.id,
-        launchOwnerUserId: input.senderUserId,
-        queuedMessage: {
-          provider: 'discord',
-          text: prompt,
-          user: input.sender.global_name?.trim() || input.sender.username,
-          userId: input.senderUserId,
-          ts: input.event.eventId,
-          channel: input.metadata.communicationChannelId,
-          ...(input.metadata.communicationThreadId
-            ? { threadTs: input.metadata.communicationThreadId }
-            : {}),
-          turnPolicy: { reactionsAllowed: true },
-        },
-        metadata: input.metadata,
-        channel: input.channel,
-        forceNewThread: true,
-        fastAgentSessionId: parentSessionId,
-        skipRoutingConfirmation: true,
-        workspaceOverride,
-      });
-      if (started.status === 'started') {
-        return {
-          success: true,
-          taskId: started.launchResult.taskId,
-          taskUrl: started.taskUrl,
-        };
-      }
-      if (started.status === 'already_started') {
-        return {
-          success: true,
-          taskId: started.existingRun.taskId,
-          taskUrl: started.taskUrl,
-        };
-      }
-      return {
-        success: false,
-        error: `Task launch stopped with status ${started.status}.`,
-      };
+      },
+      postReply: async ({ message: text }) => {
+        await replyToDiscordEvent({
+          provider: input.provider,
+          applicationId: input.applicationId,
+          channel: input.channel,
+          ...(input.interaction ? { interaction: input.interaction } : {}),
+          ...(message ? { replyToMessageId: message.id } : {}),
+          text,
+        });
+        didSendVisibleResponse = true;
+      },
     },
-    postSlackReply: async ({ message: text }) => {
-      await replyToDiscordEvent({
-        provider: input.provider,
-        applicationId: input.applicationId,
-        channel: input.channel,
-        ...(input.interaction ? { interaction: input.interaction } : {}),
-        ...(message ? { replyToMessageId: message.id } : {}),
-        text,
-      });
-      didSendVisibleResponse = true;
-    },
-    surface: 'discord',
   });
   if (response && !didSendVisibleResponse) {
     await replyToDiscordEvent({

--- a/apps/api/src/handlers/discord/index.ts
+++ b/apps/api/src/handlers/discord/index.ts
@@ -580,9 +580,10 @@ async function processDiscordGatewayEvent(
       : null;
   const isFastAgentThread = channel.isThread
     ? await hasFastAgentSession({
-        slackTeamId: `discord:${channel.guildId ?? 'dm'}`,
-        slackChannel: metadata.communicationChannelId,
-        slackThreadTs: channel.channelId,
+        surface: 'discord',
+        workspaceId: channel.guildId ?? 'dm',
+        channelId: metadata.communicationChannelId,
+        threadId: channel.channelId,
       })
     : false;
   const isRoomoteThread = Boolean(

--- a/apps/api/src/handlers/slack/events/fast-agent-processing.test.ts
+++ b/apps/api/src/handlers/slack/events/fast-agent-processing.test.ts
@@ -36,11 +36,11 @@ describe('processFastAgentMessage', () => {
     mocks.postThreadMessage.mockResolvedValue('posted');
     mocks.answerQuestion.mockImplementation(
       async ({
-        postSlackReply,
+        adapter,
       }: {
-        postSlackReply: (reply: unknown) => void;
+        adapter: { postReply: (reply: unknown) => void };
       }) => {
-        await postSlackReply({
+        await adapter.postReply({
           purpose: 'closeout',
           message: 'Doing well.',
         });
@@ -80,7 +80,7 @@ describe('processFastAgentMessage', () => {
       expect.objectContaining({
         question: 'investigate this',
         currentMessageAgentContext: 'Slack block text:\nState: New',
-        launchTask,
+        adapter: expect.objectContaining({ launchTask }),
         activeTasks: [
           { taskId: 'task-1', title: 'Fix API' },
           { taskId: 'task-2', title: 'Update docs' },
@@ -92,14 +92,14 @@ describe('processFastAgentMessage', () => {
   it('can answer with a reaction without posting a text fallback', async () => {
     mocks.answerQuestion.mockImplementationOnce(
       async ({
-        postSlackReaction,
+        adapter,
       }: {
-        postSlackReaction: (reaction: unknown) => void;
+        adapter: { postReaction: (reaction: unknown) => void };
       }) => {
-        await postSlackReaction({
+        await adapter.postReaction({
           name: 'thumbsup',
           purpose: 'closeout',
-          slackMessageTs: '100.001',
+          messageId: '100.001',
         });
         return '';
       },
@@ -146,14 +146,14 @@ describe('processFastAgentMessage', () => {
   it('keeps the processing reaction when it becomes the visible closeout', async () => {
     mocks.answerQuestion.mockImplementationOnce(
       async ({
-        postSlackReaction,
+        adapter,
       }: {
-        postSlackReaction: (reaction: unknown) => void;
+        adapter: { postReaction: (reaction: unknown) => void };
       }) => {
-        await postSlackReaction({
+        await adapter.postReaction({
           name: 'eyes',
           purpose: 'closeout',
-          slackMessageTs: '100.001',
+          messageId: '100.001',
         });
         return '';
       },
@@ -192,18 +192,19 @@ describe('processFastAgentMessage', () => {
   it('clears a same-name processing reaction after an intermediate acknowledgement', async () => {
     mocks.answerQuestion.mockImplementationOnce(
       async ({
-        postSlackReaction,
-        postSlackReply,
+        adapter,
       }: {
-        postSlackReaction: (reaction: unknown) => void;
-        postSlackReply: (reply: unknown) => void;
+        adapter: {
+          postReaction: (reaction: unknown) => void;
+          postReply: (reply: unknown) => void;
+        };
       }) => {
-        await postSlackReaction({
+        await adapter.postReaction({
           name: 'eyes',
           purpose: 'ack',
-          slackMessageTs: '100.001',
+          messageId: '100.001',
         });
-        await postSlackReply({
+        await adapter.postReply({
           purpose: 'closeout',
           message: 'I found the answer.',
         });
@@ -303,11 +304,11 @@ describe('processFastAgentMessage', () => {
     mocks.postThreadMessage.mockResolvedValue('suppressed');
     mocks.answerQuestion.mockImplementationOnce(
       async ({
-        postSlackReply,
+        adapter,
       }: {
-        postSlackReply: (reply: unknown) => void;
+        adapter: { postReply: (reply: unknown) => void };
       }) => {
-        await postSlackReply({
+        await adapter.postReply({
           purpose: 'closeout',
           message: 'Delegated the work.',
           kickoff: true,
@@ -414,16 +415,24 @@ describe('processFastAgentMessage', () => {
     expect(mocks.answerQuestion).toHaveBeenCalledOnce();
     expect(mocks.answerQuestion).toHaveBeenCalledWith(
       expect.objectContaining({
-        slackTeamId: 'T123',
+        conversation: {
+          surface: 'slack',
+          workspaceId: 'T123',
+          channelId: 'D123',
+          threadId: '100.001',
+        },
         senderDisplayName: 'Matt',
-        senderSlackUserId: 'U123',
+        senderExternalId: 'U123',
         threadContext: [],
       }),
     );
     expect(mocks.acquireLock).toHaveBeenCalledWith({
-      slackTeamId: 'T123',
-      slackChannel: 'D123',
-      slackThreadTs: '100.001',
+      conversation: {
+        surface: 'slack',
+        workspaceId: 'T123',
+        channelId: 'D123',
+        threadId: '100.001',
+      },
     });
     expect(mocks.postThreadMessage).toHaveBeenCalledOnce();
     expect(mocks.releaseLock).toHaveBeenCalledOnce();
@@ -462,7 +471,7 @@ describe('processFastAgentMessage', () => {
     expect(mocks.answerQuestion).toHaveBeenCalledWith(
       expect.objectContaining({
         senderDisplayName: undefined,
-        senderSlackUserId: 'U123',
+        senderExternalId: 'U123',
       }),
     );
   });

--- a/apps/api/src/handlers/slack/events/fast-agent.ts
+++ b/apps/api/src/handlers/slack/events/fast-agent.ts
@@ -3,7 +3,7 @@ import {
   acquireFastAgentTurnLock,
   answerFastAgentQuestion,
   type FastAgentActiveTask,
-  type LaunchFastAgentSlackTask,
+  type LaunchFastAgentTask,
 } from '@roomote/cloud-agents/server';
 import { type SlackEvent, type SlackNotifier } from '@roomote/slack';
 import { stripLeadingSlackProductMention } from '@roomote/cloud-agents';
@@ -53,7 +53,7 @@ export async function processFastAgentMessage(params: {
   usageText?: string;
   continuation?: boolean;
   activeTasks?: FastAgentActiveTask[];
-  launchTask: LaunchFastAgentSlackTask;
+  launchTask: LaunchFastAgentTask;
   processingReactionName?: string;
 }): Promise<void> {
   const {
@@ -69,10 +69,14 @@ export async function processFastAgentMessage(params: {
     processingReactionName = 'eyes',
   } = params;
   const threadId = event.thread_ts || event.ts;
+  const conversation = {
+    surface: 'slack' as const,
+    workspaceId: teamId,
+    channelId: event.channel,
+    threadId,
+  };
   const releaseFastAgentLock = await acquireFastAgentTurnLock({
-    slackTeamId: teamId,
-    slackChannel: event.channel,
-    slackThreadTs: threadId,
+    conversation,
   });
 
   if (!releaseFastAgentLock) {
@@ -148,68 +152,68 @@ export async function processFastAgentMessage(params: {
       threadContext: serializedThreadContext,
       userId,
       apiBaseUrl,
-      slackTeamId: teamId,
-      slackChannel: event.channel,
-      slackThreadTs: threadId,
-      currentMessageTs: event.ts,
-      senderSlackUserId: event.user,
+      conversation,
+      currentMessageId: event.ts,
+      senderExternalId: event.user,
       senderDisplayName:
         currentMessage?.user === event.user
           ? currentMessage.username
           : undefined,
       activeTasks,
-      launchTask,
-      postSlackReply: async ({ message, kickoff }) => {
-        const posted = await postSlackThreadMarkdownMessage({
-          slack,
-          channel: event.channel,
-          threadTs: threadId,
-          text: message,
-          sourceMessageTs: event.ts,
-          conversationLog: {
-            userId,
-            slackTeamId: teamId,
-            source: 'fast_agent',
-          },
-        });
-        if (posted === 'failed') {
-          throw new Error('Slack did not accept the Fast parent reply.');
-        }
-        if (posted === 'suppressed' && kickoff) {
-          // The launch gate requires a visible, durable parent kickoff
-          // before the child becomes runnable; a suppressed kickoff must
-          // abort the launch instead of opening the gate silently.
-          throw new Error(
-            'The Fast kickoff was suppressed because the triggering message was deleted.',
-          );
-        }
-        // Suppression of an ordinary reply is deliberate (the triggering
-        // message was deleted); treat it as delivered so the turn is not
-        // aborted mid-flight.
-        didSendVisibleResponse = true;
-      },
-      postSlackReaction: async ({ name, purpose, slackMessageTs }) => {
-        if (
-          didAddProcessingReaction &&
-          name === processingReactionName &&
-          slackMessageTs === event.ts
-        ) {
-          if (purpose === 'closeout') {
-            didAddProcessingReaction = false;
+      adapter: {
+        launchTask,
+        postReply: async ({ message, kickoff }) => {
+          const posted = await postSlackThreadMarkdownMessage({
+            slack,
+            channel: event.channel,
+            threadTs: threadId,
+            text: message,
+            sourceMessageTs: event.ts,
+            conversationLog: {
+              userId,
+              slackTeamId: teamId,
+              source: 'fast_agent',
+            },
+          });
+          if (posted === 'failed') {
+            throw new Error('Slack did not accept the Fast parent reply.');
+          }
+          if (posted === 'suppressed' && kickoff) {
+            // The launch gate requires a visible, durable parent kickoff
+            // before the child becomes runnable; a suppressed kickoff must
+            // abort the launch instead of opening the gate silently.
+            throw new Error(
+              'The Fast kickoff was suppressed because the triggering message was deleted.',
+            );
+          }
+          // Suppression of an ordinary reply is deliberate (the triggering
+          // message was deleted); treat it as delivered so the turn is not
+          // aborted mid-flight.
+          didSendVisibleResponse = true;
+        },
+        postReaction: async ({ name, purpose, messageId }) => {
+          if (
+            didAddProcessingReaction &&
+            name === processingReactionName &&
+            messageId === event.ts
+          ) {
+            if (purpose === 'closeout') {
+              didAddProcessingReaction = false;
+            }
+            didSendVisibleResponse = true;
+            return;
+          }
+
+          const added = await slack.addReaction({
+            channel: event.channel,
+            timestamp: messageId,
+            name,
+          });
+          if (!added) {
+            throw new Error(`Slack rejected the ${name} reaction.`);
           }
           didSendVisibleResponse = true;
-          return;
-        }
-
-        const added = await slack.addReaction({
-          channel: event.channel,
-          timestamp: slackMessageTs,
-          name,
-        });
-        if (!added) {
-          throw new Error(`Slack rejected the ${name} reaction.`);
-        }
-        didSendVisibleResponse = true;
+        },
       },
     });
 

--- a/apps/api/src/handlers/slack/events/message-entry-unmentioned-routing.test.ts
+++ b/apps/api/src/handlers/slack/events/message-entry-unmentioned-routing.test.ts
@@ -144,9 +144,10 @@ describe('shouldRouteUnmentionedSlackThreadReplyToAgent', () => {
       ),
     ).resolves.toMatchObject({ shouldRoute: true });
     expect(hasFastAgentSessionMock).toHaveBeenCalledWith({
-      slackTeamId: 'T123',
-      slackChannel: 'C123',
-      slackThreadTs: THREAD_TS,
+      surface: 'slack',
+      workspaceId: 'T123',
+      channelId: 'C123',
+      threadId: THREAD_TS,
     });
     expect(findRoomoteOwnedSlackThreadMock).not.toHaveBeenCalled();
   }, 15_000);

--- a/apps/api/src/handlers/slack/events/message-entry.ts
+++ b/apps/api/src/handlers/slack/events/message-entry.ts
@@ -501,9 +501,10 @@ export async function shouldRouteUnmentionedSlackThreadReplyToAgent(params: {
     eligibilityReason = 'pending-routing-confirmation';
   } else {
     isFastAgentThread = await hasFastAgentSession({
-      slackTeamId: teamId,
-      slackChannel: event.channel,
-      slackThreadTs: event.thread_ts,
+      surface: 'slack',
+      workspaceId: teamId,
+      channelId: event.channel,
+      threadId: event.thread_ts,
     });
 
     roomoteThreadMatch = isFastAgentThread
@@ -1761,9 +1762,10 @@ async function handleSlackEntryEvent(params: {
   )
     ? false
     : await hasFastAgentSession({
-        slackTeamId: teamId,
-        slackChannel: event.channel,
-        slackThreadTs: threadId,
+        surface: 'slack',
+        workspaceId: teamId,
+        channelId: event.channel,
+        threadId,
       });
 
   if (isFastAgentContinuation) {

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-integration-broker.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-integration-broker.test.ts
@@ -58,10 +58,13 @@ const auditContext = {
   userId: 'user-1',
   apiBaseUrl: 'https://api.example.com',
   sessionId: 'session-1',
-  slackTeamId: 'team-1',
-  slackChannel: 'channel-1',
-  slackThreadTs: '100.1',
-  slackMessageTs: '100.2',
+  conversation: {
+    surface: 'slack' as const,
+    workspaceId: 'team-1',
+    channelId: 'channel-1',
+    threadId: '100.1',
+  },
+  messageId: '100.2',
 };
 
 describe('fast-agent integration broker', () => {

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-prompt.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-prompt.test.ts
@@ -125,7 +125,7 @@ describe('buildFastAgentSystemPrompt', () => {
   it('limits delegated-task platform events to one terminal reply', () => {
     const prompt = buildFastAgentSystemPrompt({
       availableEnvironments: [],
-      platformEvent: true,
+      turnSource: 'platform_event',
       retryTaskStartAvailable: true,
     });
 
@@ -168,7 +168,7 @@ describe('buildFastAgentSystemPrompt', () => {
   it('does not offer a failed-start retry for ineligible platform events', () => {
     const prompt = buildFastAgentSystemPrompt({
       availableEnvironments: [],
-      platformEvent: true,
+      turnSource: 'platform_event',
     });
 
     expect(prompt).toContain(

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -46,19 +46,28 @@ import {
   answerFastAgentQuestion,
   FAST_AGENT_MAX_STEPS,
 } from '../fast-agent-service';
+import type {
+  FastAgentTurnAdapter,
+  LaunchFastAgentTask,
+} from '../fast-agent-conversation';
 
 const baseParams = {
   question: 'What does this service do?',
   userId: 'user-1',
   apiBaseUrl: 'https://api.example.com',
-  slackTeamId: 'team-1',
-  slackChannel: 'channel-1',
-  slackThreadTs: '100.1',
-  currentMessageTs: '100.2',
+  conversation: {
+    surface: 'slack' as const,
+    workspaceId: 'team-1',
+    channelId: 'channel-1',
+    threadId: '100.1',
+  },
+  currentMessageId: '100.2',
   senderDisplayName: 'Matt',
-  senderSlackUserId: 'U123',
-  launchTask: vi.fn(),
-  postSlackReply: vi.fn().mockResolvedValue(undefined),
+  senderExternalId: 'U123',
+  adapter: {
+    launchTask: vi.fn<LaunchFastAgentTask>(),
+    postReply: vi.fn().mockResolvedValue(undefined),
+  },
 };
 
 function decision(overrides: Record<string, unknown> = {}) {
@@ -78,10 +87,25 @@ function decision(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function chatCallbacks() {
+function chatCallbacks(
+  options: {
+    launchTask?: FastAgentTurnAdapter['launchTask'];
+    retryTaskStart?: NonNullable<FastAgentTurnAdapter['retryTaskStart']>;
+  } = {},
+) {
+  const postReply = vi.fn().mockResolvedValue(undefined);
+  const postReaction = vi.fn().mockResolvedValue(undefined);
   return {
-    postSlackReply: vi.fn().mockResolvedValue(undefined),
-    postSlackReaction: vi.fn().mockResolvedValue(undefined),
+    postReply,
+    postReaction,
+    adapter: {
+      launchTask: options.launchTask ?? vi.fn<LaunchFastAgentTask>(),
+      postReply: postReply,
+      postReaction: postReaction,
+      ...(options.retryTaskStart
+        ? { retryTaskStart: options.retryTaskStart }
+        : {}),
+    },
   };
 }
 
@@ -138,13 +162,11 @@ describe('answerFastAgentQuestion', () => {
     });
 
     expect(result).toBe('It coordinates incoming requests.');
-    expect(callbacks.postSlackReply).toHaveBeenCalledWith({
+    expect(callbacks.postReply).toHaveBeenCalledWith({
       purpose: 'closeout',
-      slackChannel: 'channel-1',
-      slackThreadTs: '100.1',
       message: 'It coordinates incoming requests.',
     });
-    expect(callbacks.postSlackReaction).not.toHaveBeenCalled();
+    expect(callbacks.postReaction).not.toHaveBeenCalled();
     expect(mocks.generateObject).toHaveBeenCalledWith(
       expect.objectContaining({ modelRole: 'primary' }),
     );
@@ -187,8 +209,8 @@ describe('answerFastAgentQuestion', () => {
     });
 
     expect(result).toBe('It is configured correctly.');
-    expect(callbacks.postSlackReply).toHaveBeenCalledOnce();
-    expect(callbacks.postSlackReply).toHaveBeenCalledWith(
+    expect(callbacks.postReply).toHaveBeenCalledOnce();
+    expect(callbacks.postReply).toHaveBeenCalledWith(
       expect.objectContaining({
         purpose: 'closeout',
         message: 'It is configured correctly.',
@@ -251,12 +273,12 @@ describe('answerFastAgentQuestion', () => {
         args: { query: 'fast agent' },
       },
     );
-    expect(callbacks.postSlackReply).toHaveBeenCalledTimes(2);
-    expect(callbacks.postSlackReply).toHaveBeenNthCalledWith(
+    expect(callbacks.postReply).toHaveBeenCalledTimes(2);
+    expect(callbacks.postReply).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({ purpose: 'ack' }),
     );
-    expect(callbacks.postSlackReply).toHaveBeenNthCalledWith(
+    expect(callbacks.postReply).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({ purpose: 'closeout' }),
     );
@@ -284,8 +306,8 @@ describe('answerFastAgentQuestion', () => {
 
     expect(result).toBe('Which repository should I inspect?');
     expect(mocks.generateObject).toHaveBeenCalledOnce();
-    expect(callbacks.postSlackReply).toHaveBeenCalledOnce();
-    expect(callbacks.postSlackReply).toHaveBeenCalledWith(
+    expect(callbacks.postReply).toHaveBeenCalledOnce();
+    expect(callbacks.postReply).toHaveBeenCalledWith(
       expect.objectContaining({ purpose: 'clarification' }),
     );
   });
@@ -312,13 +334,13 @@ describe('answerFastAgentQuestion', () => {
       ...baseParams,
       question:
         '<delegated_task_event>{"type":"artifact_published"}</delegated_task_event>',
-      platformEvent: true,
+      turnSource: 'platform_event',
       ...callbacks,
     });
 
     expect(result).toBe('The hedgehog is visible in the selection screen.');
-    expect(callbacks.postSlackReply).toHaveBeenCalledOnce();
-    expect(callbacks.postSlackReply).toHaveBeenCalledWith(
+    expect(callbacks.postReply).toHaveBeenCalledOnce();
+    expect(callbacks.postReply).toHaveBeenCalledWith(
       expect.objectContaining({
         purpose: 'closeout',
         imageArtifactIds: ['artifact-1'],
@@ -351,7 +373,7 @@ describe('answerFastAgentQuestion', () => {
     const result = await answerFastAgentQuestion({
       ...baseParams,
       question: `<delegated_task_event>${JSON.stringify(event)}</delegated_task_event>`,
-      platformEvent: true,
+      turnSource: 'platform_event',
       ...callbacks,
     });
 
@@ -363,7 +385,7 @@ describe('answerFastAgentQuestion', () => {
       }),
     );
     expect(result).toContain('Check the provider configuration');
-    expect(callbacks.postSlackReply).toHaveBeenCalledWith(
+    expect(callbacks.postReply).toHaveBeenCalledWith(
       expect.objectContaining({
         purpose: 'closeout',
         message: expect.stringContaining('Check the provider configuration'),
@@ -386,18 +408,17 @@ describe('answerFastAgentQuestion', () => {
           purpose: 'closeout',
         }),
       });
-    const callbacks = chatCallbacks();
     const retryTaskStart = vi.fn().mockResolvedValue({
       success: true,
       runId: 43,
     });
+    const callbacks = chatCallbacks({ retryTaskStart });
 
     const result = await answerFastAgentQuestion({
       ...baseParams,
       question:
         '<delegated_task_event>{"type":"task_settled","status":"failed","error":"HTTP 503","errorCode":null}</delegated_task_event>',
-      platformEvent: true,
-      retryTaskStart,
+      turnSource: 'platform_event',
       ...callbacks,
     });
 
@@ -408,7 +429,7 @@ describe('answerFastAgentQuestion', () => {
     expect(result).toBe(
       'The sandbox startup looked transient, so I retried it.',
     );
-    expect(callbacks.postSlackReply).toHaveBeenCalledOnce();
+    expect(callbacks.postReply).toHaveBeenCalledOnce();
   });
 
   it('lets a delegated-task platform event launch a separate task', async () => {
@@ -428,15 +449,14 @@ describe('answerFastAgentQuestion', () => {
             'I started a separate investigation. [Follow the task](https://roomote.example/task-2)',
         }),
       });
-    const callbacks = chatCallbacks();
     const launchTask = successfulLaunchTask('task-2');
+    const callbacks = chatCallbacks({ launchTask });
 
     const result = await answerFastAgentQuestion({
       ...baseParams,
       question:
         '<delegated_task_event>{"type":"task_settled","taskId":"task-1","status":"failed"}</delegated_task_event>',
-      platformEvent: true,
-      launchTask,
+      turnSource: 'platform_event',
       ...callbacks,
     });
 
@@ -447,7 +467,7 @@ describe('answerFastAgentQuestion', () => {
       postKickoff: expect.any(Function),
     });
     expect(result).toContain('task-2');
-    expect(callbacks.postSlackReply).toHaveBeenCalledOnce();
+    expect(callbacks.postReply).toHaveBeenCalledOnce();
   });
 
   it('keeps ordinary orchestration tools available for platform events', async () => {
@@ -496,7 +516,7 @@ describe('answerFastAgentQuestion', () => {
       ...baseParams,
       question:
         '<delegated_task_event>{"type":"task_settled","taskId":"task-1","status":"failed"}</delegated_task_event>',
-      platformEvent: true,
+      turnSource: 'platform_event',
       activeTasks: [{ taskId: 'task-2', title: 'Other work' }],
       ...callbacks,
     });
@@ -518,7 +538,7 @@ describe('answerFastAgentQuestion', () => {
       expect.objectContaining({ userId: 'user-1' }),
       'task-2',
     );
-    expect(callbacks.postSlackReply).toHaveBeenCalledOnce();
+    expect(callbacks.postReply).toHaveBeenCalledOnce();
     expect(result).toBe('I handled the task update.');
   });
 
@@ -588,28 +608,25 @@ describe('answerFastAgentQuestion', () => {
       .mockResolvedValueOnce({
         object: decision({ message: 'The checkout task was canceled.' }),
       });
-    const callbacks = chatCallbacks();
     const launchTask = successfulLaunchTask();
+    const callbacks = chatCallbacks({ launchTask });
 
     await answerFastAgentQuestion({
       ...baseParams,
       question: 'Fix checkout.',
-      launchTask,
       ...callbacks,
     });
     await answerFastAgentQuestion({
       ...baseParams,
       question:
         '<delegated_task_event>{"type":"artifact_published","taskId":"task-1"}</delegated_task_event>',
-      currentMessageTs: undefined,
-      platformEvent: true,
-      launchTask,
+      currentMessageId: undefined,
+      turnSource: 'platform_event',
       ...callbacks,
     });
     await answerFastAgentQuestion({
       ...baseParams,
       question: 'Cancel it.',
-      launchTask,
       ...callbacks,
     });
 
@@ -663,13 +680,12 @@ describe('answerFastAgentQuestion', () => {
     });
 
     expect(result).toBe('');
-    expect(callbacks.postSlackReaction).toHaveBeenCalledWith({
+    expect(callbacks.postReaction).toHaveBeenCalledWith({
       name: 'thumbsup',
       purpose: 'closeout',
-      slackChannel: 'channel-1',
-      slackMessageTs: '100.2',
+      messageId: '100.2',
     });
-    expect(callbacks.postSlackReply).not.toHaveBeenCalled();
+    expect(callbacks.postReply).not.toHaveBeenCalled();
     expect(mocks.appendSessionMessages).toHaveBeenCalledWith(
       expect.objectContaining({
         messages: expect.arrayContaining([
@@ -699,11 +715,11 @@ describe('answerFastAgentQuestion', () => {
       ...callbacks,
     });
 
-    expect(callbacks.postSlackReaction).toHaveBeenCalledOnce();
-    expect(callbacks.postSlackReaction).toHaveBeenCalledWith(
+    expect(callbacks.postReaction).toHaveBeenCalledOnce();
+    expect(callbacks.postReaction).toHaveBeenCalledWith(
       expect.objectContaining({ purpose: 'ack' }),
     );
-    expect(callbacks.postSlackReply).toHaveBeenCalledWith(
+    expect(callbacks.postReply).toHaveBeenCalledWith(
       expect.objectContaining({
         purpose: 'closeout',
         message: 'I found the answer.',
@@ -730,12 +746,11 @@ describe('answerFastAgentQuestion', () => {
         }),
       });
     const launchTask = successfulLaunchTask();
-    const callbacks = chatCallbacks();
+    const callbacks = chatCallbacks({ launchTask });
 
     const result = await answerFastAgentQuestion({
       ...baseParams,
       ...callbacks,
-      launchTask,
     });
 
     expect(launchTask).toHaveBeenCalledWith({
@@ -745,8 +760,8 @@ describe('answerFastAgentQuestion', () => {
       postKickoff: expect.any(Function),
     });
     expect(mocks.generateObject).toHaveBeenCalledTimes(2);
-    expect(callbacks.postSlackReply).toHaveBeenCalledOnce();
-    expect(callbacks.postSlackReply).toHaveBeenCalledWith(
+    expect(callbacks.postReply).toHaveBeenCalledOnce();
+    expect(callbacks.postReply).toHaveBeenCalledWith(
       expect.objectContaining({
         purpose: 'closeout',
         message:
@@ -789,15 +804,14 @@ describe('answerFastAgentQuestion', () => {
         throw new Error('queue unavailable');
       },
     );
-    const callbacks = chatCallbacks();
+    const callbacks = chatCallbacks({ launchTask });
 
     const result = await answerFastAgentQuestion({
       ...baseParams,
       ...callbacks,
-      launchTask,
     });
 
-    expect(callbacks.postSlackReply).toHaveBeenCalledTimes(2);
+    expect(callbacks.postReply).toHaveBeenCalledTimes(2);
     expect(result).toContain('could not be queued');
     expect(mocks.appendSessionMessages).toHaveBeenNthCalledWith(
       2,
@@ -835,15 +849,16 @@ describe('answerFastAgentQuestion', () => {
     mocks.appendSessionMessages.mockRejectedValueOnce(
       new Error('database unavailable'),
     );
-    const callbacks = chatCallbacks();
+    const callbacks = chatCallbacks({
+      launchTask: successfulLaunchTask(),
+    });
 
     const result = await answerFastAgentQuestion({
       ...baseParams,
       ...callbacks,
-      launchTask: successfulLaunchTask(),
     });
 
-    expect(callbacks.postSlackReply).toHaveBeenCalledTimes(2);
+    expect(callbacks.postReply).toHaveBeenCalledTimes(2);
     expect(result).toBe(
       'I hit an error while handling that request. Please try again in a moment.',
     );
@@ -870,12 +885,11 @@ describe('answerFastAgentQuestion', () => {
         }),
       });
     const launchTask = successfulLaunchTask('task-2');
-    const callbacks = chatCallbacks();
+    const callbacks = chatCallbacks({ launchTask });
 
     const result = await answerFastAgentQuestion({
       ...baseParams,
       ...callbacks,
-      launchTask,
     });
 
     expect(launchTask).toHaveBeenCalledOnce();
@@ -911,7 +925,7 @@ describe('answerFastAgentQuestion', () => {
       { userId: 'user-1', apiBaseUrl: 'https://api.example.com' },
       { taskId: 'task-2', message: 'Also add a regression test.' },
     );
-    expect(callbacks.postSlackReply).toHaveBeenCalledWith(
+    expect(callbacks.postReply).toHaveBeenCalledWith(
       expect.objectContaining({ message: 'I sent that instruction.' }),
     );
   });
@@ -976,7 +990,7 @@ describe('answerFastAgentQuestion', () => {
       expect.anything(),
       'task-2',
     );
-    expect(callbacks.postSlackReply).toHaveBeenCalledWith(
+    expect(callbacks.postReply).toHaveBeenCalledWith(
       expect.objectContaining({ message: 'I canceled the active task.' }),
     );
   });
@@ -1010,7 +1024,7 @@ describe('answerFastAgentQuestion', () => {
 
     expect(mocks.sendTaskMessage).not.toHaveBeenCalled();
     expect(result).toContain('Which active task');
-    expect(callbacks.postSlackReply).toHaveBeenCalledWith(
+    expect(callbacks.postReply).toHaveBeenCalledWith(
       expect.objectContaining({ purpose: 'clarification' }),
     );
     expect(mocks.generateObject.mock.calls[1]?.[0]?.prompt).toContain(
@@ -1334,8 +1348,8 @@ describe('answerFastAgentQuestion', () => {
 
     expect(mocks.callIntegration).toHaveBeenCalledTimes(FAST_AGENT_MAX_STEPS);
     expect(result).toContain('within the available turn steps');
-    expect(callbacks.postSlackReply).toHaveBeenCalledOnce();
-    expect(callbacks.postSlackReply).toHaveBeenCalledWith(
+    expect(callbacks.postReply).toHaveBeenCalledOnce();
+    expect(callbacks.postReply).toHaveBeenCalledWith(
       expect.objectContaining({ purpose: 'closeout', message: result }),
     );
   });
@@ -1381,12 +1395,12 @@ describe('answerFastAgentQuestion', () => {
     });
 
     expect(result).toContain('within the available turn steps');
-    expect(callbacks.postSlackReply).toHaveBeenCalledTimes(2);
-    expect(callbacks.postSlackReply).toHaveBeenNthCalledWith(
+    expect(callbacks.postReply).toHaveBeenCalledTimes(2);
+    expect(callbacks.postReply).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({ purpose: 'ack', message: "I'll take a look." }),
     );
-    expect(callbacks.postSlackReply).toHaveBeenNthCalledWith(
+    expect(callbacks.postReply).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({ purpose: 'closeout', message: result }),
     );
@@ -1409,8 +1423,8 @@ describe('answerFastAgentQuestion', () => {
     });
 
     expect(result).toContain('hit an error');
-    expect(callbacks.postSlackReply).toHaveBeenCalledOnce();
-    expect(callbacks.postSlackReply).toHaveBeenCalledWith(
+    expect(callbacks.postReply).toHaveBeenCalledOnce();
+    expect(callbacks.postReply).toHaveBeenCalledWith(
       expect.objectContaining({ purpose: 'closeout', message: result }),
     );
   });
@@ -1425,8 +1439,8 @@ describe('answerFastAgentQuestion', () => {
     });
 
     expect(result).toContain('hit an error');
-    expect(callbacks.postSlackReply).toHaveBeenCalledOnce();
-    expect(callbacks.postSlackReply).toHaveBeenCalledWith(
+    expect(callbacks.postReply).toHaveBeenCalledOnce();
+    expect(callbacks.postReply).toHaveBeenCalledWith(
       expect.objectContaining({ purpose: 'closeout', message: result }),
     );
   });
@@ -1448,8 +1462,8 @@ describe('answerFastAgentQuestion', () => {
 
     expect(mocks.generateObject).toHaveBeenCalledTimes(2);
     expect(result).toBe('It coordinates incoming requests.');
-    expect(callbacks.postSlackReply).toHaveBeenCalledOnce();
-    expect(callbacks.postSlackReply).toHaveBeenCalledWith(
+    expect(callbacks.postReply).toHaveBeenCalledOnce();
+    expect(callbacks.postReply).toHaveBeenCalledWith(
       expect.objectContaining({ purpose: 'closeout', message: result }),
     );
   });
@@ -1471,8 +1485,8 @@ describe('answerFastAgentQuestion', () => {
     expect(result).toBe(
       'Fast mode could not reach the model after retrying. Please try again in a moment.',
     );
-    expect(callbacks.postSlackReply).toHaveBeenCalledOnce();
-    expect(callbacks.postSlackReply).toHaveBeenCalledWith(
+    expect(callbacks.postReply).toHaveBeenCalledOnce();
+    expect(callbacks.postReply).toHaveBeenCalledWith(
       expect.objectContaining({ purpose: 'closeout', message: result }),
     );
   });

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-session.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-session.test.ts
@@ -4,14 +4,26 @@ describe('fast-agent session scoping', () => {
   it('keeps identical Slack channels isolated by workspace', () => {
     expect(
       buildFastAgentSessionChannelKey({
-        slackTeamId: 'team-1',
-        slackChannel: 'channel-1',
+        surface: 'slack',
+        workspaceId: 'team-1',
+        channelId: 'channel-1',
       }),
     ).not.toBe(
       buildFastAgentSessionChannelKey({
-        slackTeamId: 'team-2',
-        slackChannel: 'channel-1',
+        surface: 'slack',
+        workspaceId: 'team-2',
+        channelId: 'channel-1',
       }),
     );
+  });
+
+  it('preserves the existing Discord storage namespace for raw provider IDs', () => {
+    expect(
+      buildFastAgentSessionChannelKey({
+        surface: 'discord',
+        workspaceId: 'guild-1',
+        channelId: 'channel-1',
+      }),
+    ).toBe('discord:guild-1:channel-1');
   });
 });

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation.ts
@@ -1,0 +1,60 @@
+export type FastAgentSurface = 'slack' | 'discord';
+
+/** Provider-neutral identity for one persisted Fast conversation. */
+export type FastAgentConversation = {
+  surface: FastAgentSurface;
+  /** Provider workspace/account boundary (for example a Slack team or Discord guild). */
+  workspaceId: string;
+  channelId: string;
+  threadId: string;
+};
+
+/** Preserve existing persisted/Redis workspace keys while the storage schema
+ * remains Slack-shaped. New provider adapters always pass raw provider IDs. */
+export function getFastAgentConversationStorageWorkspaceId(
+  conversation: Pick<FastAgentConversation, 'surface' | 'workspaceId'>,
+): string {
+  return conversation.surface === 'slack'
+    ? conversation.workspaceId
+    : `${conversation.surface}:${conversation.workspaceId}`;
+}
+
+export type FastAgentTurnSource = 'human' | 'platform_event';
+
+export type FastAgentReply = {
+  purpose: 'ack' | 'progress' | 'closeout' | 'clarification';
+  message: string;
+  imageArtifactIds?: string[];
+  /** True for the parent-owned task kickoff. Deliverers must treat anything
+   * short of a visible, durable post (including deliberate suppression) as a
+   * failure so the launch gate never opens without its kickoff. */
+  kickoff?: boolean;
+};
+
+export type FastAgentReaction = {
+  name: string;
+  purpose: 'ack' | 'closeout';
+  messageId: string;
+};
+
+export type LaunchFastAgentTask = (params: {
+  prompt: string;
+  environmentId: string | null;
+  parentSessionId: string;
+  postKickoff: (task: { taskId: string; taskUrl?: string }) => Promise<void>;
+}) => Promise<
+  | { success: true; taskId: string; taskUrl?: string }
+  | { success: false; error: string }
+>;
+
+export type RetryFastAgentTaskStart = () => Promise<
+  { success: true; runId: number } | { success: false; error: string }
+>;
+
+/** Surface adapter for side effects available during one Fast turn. */
+export type FastAgentTurnAdapter = {
+  launchTask: LaunchFastAgentTask;
+  postReply: (reply: FastAgentReply) => Promise<void>;
+  postReaction?: (reaction: FastAgentReaction) => Promise<void>;
+  retryTaskStart?: RetryFastAgentTaskStart;
+};

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-integration-broker.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-integration-broker.ts
@@ -25,6 +25,10 @@ import {
 import { isRouterMcpServerEnabled } from '../router/mcp-policy';
 import { resolveApiBaseUrl } from '../shared-utils';
 import { FAST_AGENT_BRAIN_INSTRUCTIONS } from './fast-agent-constants';
+import {
+  getFastAgentConversationStorageWorkspaceId,
+  type FastAgentConversation,
+} from './fast-agent-conversation';
 
 export type FastAgentIntegration = {
   id: string;
@@ -45,10 +49,8 @@ type BrokerContext = {
 
 type IntegrationAuditContext = BrokerContext & {
   sessionId: string;
-  slackTeamId: string;
-  slackChannel: string;
-  slackThreadTs: string;
-  slackMessageTs: string;
+  conversation: FastAgentConversation;
+  messageId: string;
 };
 
 const FAST_AGENT_INTEGRATION_TOOL_CACHE_TTL_MS = 5 * 60_000;
@@ -247,10 +249,14 @@ export async function callFastAgentIntegration(
   const audit = await beginSlackFastIntegrationCall({
     slackQuickAnswerId: context.sessionId,
     userId: context.userId,
-    slackTeamId: context.slackTeamId,
-    slackChannel: context.slackChannel,
-    slackThreadTs: context.slackThreadTs,
-    slackMessageTs: context.slackMessageTs,
+    // The persisted audit schema is legacy Slack-shaped; the broker boundary
+    // remains provider-neutral while a later N-1-safe migration renames it.
+    slackTeamId: getFastAgentConversationStorageWorkspaceId(
+      context.conversation,
+    ),
+    slackChannel: context.conversation.channelId,
+    slackThreadTs: context.conversation.threadId,
+    slackMessageTs: context.messageId,
     integrationId: integration.id,
     toolName: request.toolName,
     arguments: request.args,

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-prompt.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-prompt.ts
@@ -2,7 +2,10 @@ import { PRODUCT_NAME } from '@roomote/types';
 
 import type { RoutableEnvironment } from '../router';
 import type { FastAgentIntegration } from './fast-agent-integration-broker';
-import type { FastAgentSurface } from './fast-agent-service';
+import type {
+  FastAgentSurface,
+  FastAgentTurnSource,
+} from './fast-agent-conversation';
 import type { FastAgentActiveTask } from './fast-agent-session';
 import { buildRoomoteStyleGuidanceSection } from '../../style-guidance';
 
@@ -49,18 +52,19 @@ export function buildFastAgentSystemPrompt({
   availableIntegrations = [],
   activeTasks = [],
   surface = 'slack',
-  platformEvent = false,
+  turnSource = 'human',
   retryTaskStartAvailable = false,
 }: {
   availableEnvironments: RoutableEnvironment[];
   availableIntegrations?: FastAgentIntegration[];
   activeTasks?: FastAgentActiveTask[];
   surface?: FastAgentSurface;
-  platformEvent?: boolean;
+  turnSource?: FastAgentTurnSource;
   retryTaskStartAvailable?: boolean;
   /** @deprecated GitHub availability is derived from availableIntegrations. */
   hasGitHubTools?: boolean;
 }): string {
+  const platformEvent = turnSource === 'platform_event';
   const surfaceName = surface === 'slack' ? 'Slack' : 'Discord';
   const reactionGuidance =
     surface === 'slack'

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -36,35 +36,15 @@ import {
   getFastAgentUserIdentity,
   type FastAgentUserIdentity,
 } from './fast-agent-user-identity';
+import {
+  type FastAgentConversation,
+  type FastAgentReply,
+  type FastAgentTurnAdapter,
+  type FastAgentTurnSource,
+  type RetryFastAgentTaskStart,
+} from './fast-agent-conversation';
 
-export type FastAgentSlackThreadMessage = SlackThreadPromptMessage;
-
-interface FastAgentSlackReply {
-  purpose: 'ack' | 'progress' | 'closeout' | 'clarification';
-  slackChannel: string;
-  slackThreadTs: string;
-  message: string;
-  imageArtifactIds?: string[];
-  /** True for the parent-owned task kickoff. Deliverers must treat anything
-   * short of a visible, durable post (including deliberate suppression) as a
-   * failure so the launch gate never opens without its kickoff. */
-  kickoff?: boolean;
-}
-
-type PostFastAgentSlackReply = (reply: FastAgentSlackReply) => Promise<void>;
-
-interface FastAgentSlackReaction {
-  name: string;
-  purpose: 'ack' | 'closeout';
-  slackChannel: string;
-  slackMessageTs: string;
-}
-
-type PostFastAgentSlackReaction = (
-  reaction: FastAgentSlackReaction,
-) => Promise<void>;
-
-export type FastAgentSurface = 'slack' | 'discord';
+export type FastAgentThreadMessage = SlackThreadPromptMessage;
 
 const fastAgentDecisionSchema = z
   .object({
@@ -164,20 +144,6 @@ async function generateFastAgentKickoffMessage({
 
   throw new Error('Fast mode did not produce a valid task kickoff reply.');
 }
-
-export type LaunchFastAgentSlackTask = (params: {
-  prompt: string;
-  environmentId: string | null;
-  parentSessionId: string;
-  postKickoff: (task: { taskId: string; taskUrl?: string }) => Promise<void>;
-}) => Promise<
-  | { success: true; taskId: string; taskUrl?: string }
-  | { success: false; error: string }
->;
-
-export type RetryFastAgentTaskStart = () => Promise<
-  { success: true; runId: number } | { success: false; error: string }
->;
 
 function normalizeThreadText(text: string): string {
   return text.replace(/\s+/g, ' ').trim();
@@ -345,7 +311,7 @@ function buildSupplementalSlackThreadContext({
   sessionMessages,
 }: {
   question: string;
-  threadContext: FastAgentSlackThreadMessage[];
+  threadContext: FastAgentThreadMessage[];
   sessionMessages: ModelMessage[];
 }): string | undefined {
   const persistedMessageCounts = new Map<string, number>();
@@ -407,7 +373,7 @@ function buildFastAgentMessages({
 }: {
   question: string;
   currentMessageAgentContext?: string;
-  threadContext: FastAgentSlackThreadMessage[];
+  threadContext: FastAgentThreadMessage[];
   sessionMessages: ModelMessage[];
   currentMessageTs?: string;
   currentMessageSender?: {
@@ -509,44 +475,34 @@ export async function answerFastAgentQuestion({
   threadContext = [],
   userId,
   apiBaseUrl,
-  slackTeamId,
-  slackChannel,
-  slackThreadTs,
-  currentMessageTs,
+  conversation,
+  currentMessageId,
   senderDisplayName,
-  senderSlackUserId,
+  senderExternalId,
   activeTasks = [],
-  launchTask,
-  retryTaskStart,
-  postSlackReply,
-  postSlackReaction,
-  surface = 'slack',
-  platformEvent = false,
+  adapter,
+  turnSource = 'human',
 }: {
   question: string;
   currentMessageAgentContext?: string;
-  threadContext?: FastAgentSlackThreadMessage[];
+  threadContext?: FastAgentThreadMessage[];
   userId: string;
   apiBaseUrl?: string;
-  slackTeamId: string;
-  slackChannel: string;
-  slackThreadTs: string;
-  currentMessageTs?: string;
+  conversation: FastAgentConversation;
+  currentMessageId?: string;
   senderDisplayName?: string;
-  senderSlackUserId?: string;
+  senderExternalId?: string;
   activeTasks?: FastAgentActiveTask[];
-  launchTask: LaunchFastAgentSlackTask;
-  retryTaskStart?: RetryFastAgentTaskStart;
-  postSlackReply: PostFastAgentSlackReply;
-  postSlackReaction?: PostFastAgentSlackReaction;
-  surface?: FastAgentSurface;
-  /** Platform-generated child lifecycle input, not a human-authored turn. */
-  platformEvent?: boolean;
+  adapter: FastAgentTurnAdapter;
+  /** Identifies whether this turn came from a person or an internal task update. */
+  turnSource?: FastAgentTurnSource;
 }): Promise<string> {
+  const { launchTask, postReply, postReaction, retryTaskStart } = adapter;
+  const platformEvent = turnSource === 'platform_event';
   let sessionId: string | null = null;
   let launchedTaskMessage: string | null = null;
   let persistedTurnMessageCount = 0;
-  let pendingLifecycleReply: FastAgentSlackReply | null = null;
+  let pendingLifecycleReply: FastAgentReply | null = null;
   const normalizedQuestion = normalizeThreadText(question);
   const userMessage = buildUserTextMessage(normalizedQuestion);
   const turnSessionMessages: ModelMessage[] = [userMessage];
@@ -557,9 +513,7 @@ export async function answerFastAgentQuestion({
         getAvailableEnvironments(),
         getOrCreateFastAgentSession({
           userId,
-          slackTeamId,
-          slackChannel,
-          slackThreadTs,
+          conversation,
         }),
         listFastAgentIntegrations({ userId, apiBaseUrl }).catch((error) => {
           console.warn(
@@ -595,9 +549,9 @@ export async function answerFastAgentQuestion({
       currentMessageAgentContext,
       threadContext,
       sessionMessages: session.messages,
-      currentMessageTs,
+      currentMessageTs: currentMessageId,
       currentMessageSender: {
-        slackUserId: senderSlackUserId,
+        slackUserId: senderExternalId,
         displayName:
           senderDisplayName?.trim() || currentUser.displayName || undefined,
         githubLogin: currentUser.githubLogin || undefined,
@@ -607,8 +561,8 @@ export async function answerFastAgentQuestion({
       availableEnvironments,
       availableIntegrations,
       activeTasks: resolvedActiveTasks,
-      surface,
-      platformEvent,
+      surface: conversation.surface,
+      turnSource,
       retryTaskStartAvailable: Boolean(retryTaskStart),
     });
     let prompt = serializeFastAgentMessages(fastAgentMessages);
@@ -625,7 +579,7 @@ export async function answerFastAgentQuestion({
 
       const reply = pendingLifecycleReply;
       pendingLifecycleReply = null;
-      await postSlackReply(reply);
+      await postReply(reply);
       turnSessionMessages.push(buildAssistantTextMessage(reply.message));
     };
     const brain = availableIntegrations.find(
@@ -657,10 +611,8 @@ export async function answerFastAgentQuestion({
             userId,
             apiBaseUrl,
             sessionId: session.id,
-            slackTeamId,
-            slackChannel,
-            slackThreadTs,
-            slackMessageTs: currentMessageTs ?? slackThreadTs,
+            conversation,
+            messageId: currentMessageId ?? conversation.threadId,
           },
           availableIntegrations,
           {
@@ -721,13 +673,11 @@ export async function answerFastAgentQuestion({
 
         const reply = {
           purpose,
-          slackChannel,
-          slackThreadTs,
           message,
           ...(decision.imageArtifactIds?.length
             ? { imageArtifactIds: decision.imageArtifactIds }
             : {}),
-        } satisfies FastAgentSlackReply;
+        } satisfies FastAgentReply;
 
         if (purpose === 'ack' || purpose === 'progress') {
           // Hold nonterminal prose until the model actually chooses a tool.
@@ -739,7 +689,7 @@ export async function answerFastAgentQuestion({
         }
 
         pendingLifecycleReply = null;
-        await postSlackReply(reply);
+        await postReply(reply);
         turnSessionMessages.push(buildAssistantTextMessage(message));
 
         await persistFastAgentSessionMessages({
@@ -789,16 +739,15 @@ export async function answerFastAgentQuestion({
           continue;
         }
 
-        if (!postSlackReaction) {
+        if (!postReaction) {
           prompt += `\n\n[CHAT TOOL CALL REJECTED]\nEmoji reactions are unavailable on this conversation surface. Use send_chat_reply instead.\n[END CHAT TOOL CALL REJECTED]`;
           continue;
         }
 
-        await postSlackReaction({
+        await postReaction({
           name,
           purpose,
-          slackChannel,
-          slackMessageTs: currentMessageTs ?? slackThreadTs,
+          messageId: currentMessageId ?? conversation.threadId,
         });
         turnSessionMessages.push(
           buildAssistantTextMessage(`[Reacted with :${name}:]`),
@@ -853,10 +802,8 @@ export async function answerFastAgentQuestion({
                 userId,
                 apiBaseUrl,
                 sessionId: session.id,
-                slackTeamId,
-                slackChannel,
-                slackThreadTs,
-                slackMessageTs: currentMessageTs ?? slackThreadTs,
+                conversation,
+                messageId: currentMessageId ?? conversation.threadId,
               },
               availableIntegrations,
               {
@@ -914,10 +861,8 @@ export async function answerFastAgentQuestion({
                 prompt,
                 task,
               });
-              await postSlackReply({
+              await postReply({
                 purpose: 'closeout',
-                slackChannel,
-                slackThreadTs,
                 message,
                 kickoff: true,
               });
@@ -1034,10 +979,8 @@ export async function answerFastAgentQuestion({
 
     const fallback = buildFastAgentTurnFallbackDecision();
     const fallbackMessage = fallback.message ?? 'How can I help?';
-    await postSlackReply({
+    await postReply({
       purpose: 'closeout',
-      slackChannel,
-      slackThreadTs,
       message: fallbackMessage,
     });
     turnSessionMessages.push(buildAssistantTextMessage(fallbackMessage));
@@ -1065,10 +1008,8 @@ export async function answerFastAgentQuestion({
         : 'I hit an error while handling that request. Please try again in a moment.';
 
     try {
-      await postSlackReply({
+      await postReply({
         purpose: 'closeout',
-        slackChannel,
-        slackThreadTs,
         message,
       });
     } catch (postError) {

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-session.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-session.ts
@@ -13,6 +13,10 @@ import {
   type SlackQuickAnswer,
 } from '@roomote/db/server';
 import { activeRunStatuses, type RunStatus } from '@roomote/types';
+import {
+  getFastAgentConversationStorageWorkspaceId,
+  type FastAgentConversation,
+} from './fast-agent-conversation';
 
 type FastAgentSessionRecord = Pick<SlackQuickAnswer, 'id'> & {
   messages: ModelMessage[];
@@ -24,57 +28,45 @@ export type FastAgentActiveTask = {
   status?: RunStatus;
 };
 
-function buildFastAgentSessionWhere({
-  slackTeamId,
-  slackChannel,
-  slackThreadTs,
-}: {
-  slackTeamId: string;
-  slackChannel: string;
-  slackThreadTs: string;
-}) {
+function buildFastAgentSessionWhere(conversation: FastAgentConversation) {
   const scopedSlackChannel = buildFastAgentSessionChannelKey({
-    slackTeamId,
-    slackChannel,
+    surface: conversation.surface,
+    workspaceId: conversation.workspaceId,
+    channelId: conversation.channelId,
   });
 
   return and(
     eq(slackQuickAnswers.slackChannel, scopedSlackChannel),
-    eq(slackQuickAnswers.slackThreadTs, slackThreadTs),
+    eq(slackQuickAnswers.slackThreadTs, conversation.threadId),
   );
 }
 
 export function buildFastAgentSessionChannelKey({
-  slackTeamId,
-  slackChannel,
+  surface,
+  workspaceId,
+  channelId,
 }: {
-  slackTeamId: string;
-  slackChannel: string;
+  surface: FastAgentConversation['surface'];
+  workspaceId: string;
+  channelId: string;
 }): string {
   // The existing column and unique index predate multi-workspace scoping.
   // Qualifying the value keeps N-1 rollback compatibility without a migration.
-  return `${slackTeamId}:${slackChannel}`;
+  return `${getFastAgentConversationStorageWorkspaceId({ surface, workspaceId })}:${channelId}`;
 }
 
 export async function getOrCreateFastAgentSession({
   userId,
-  slackTeamId,
-  slackChannel,
-  slackThreadTs,
+  conversation,
 }: {
   userId: string;
-  slackTeamId: string;
-  slackChannel: string;
-  slackThreadTs: string;
+  conversation: FastAgentConversation;
 }): Promise<FastAgentSessionRecord> {
-  const where = buildFastAgentSessionWhere({
-    slackTeamId,
-    slackChannel,
-    slackThreadTs,
-  });
+  const where = buildFastAgentSessionWhere(conversation);
   const scopedSlackChannel = buildFastAgentSessionChannelKey({
-    slackTeamId,
-    slackChannel,
+    surface: conversation.surface,
+    workspaceId: conversation.workspaceId,
+    channelId: conversation.channelId,
   });
 
   const existingSession = await db.query.slackQuickAnswers.findFirst({
@@ -97,7 +89,7 @@ export async function getOrCreateFastAgentSession({
     .values({
       userId,
       slackChannel: scopedSlackChannel,
-      slackThreadTs,
+      slackThreadTs: conversation.threadId,
       messages: [],
     })
     .onConflictDoNothing({
@@ -133,21 +125,11 @@ export async function getOrCreateFastAgentSession({
   };
 }
 
-export async function hasFastAgentSession({
-  slackTeamId,
-  slackChannel,
-  slackThreadTs,
-}: {
-  slackTeamId: string;
-  slackChannel: string;
-  slackThreadTs: string;
-}): Promise<boolean> {
+export async function hasFastAgentSession(
+  conversation: FastAgentConversation,
+): Promise<boolean> {
   const session = await db.query.slackQuickAnswers.findFirst({
-    where: buildFastAgentSessionWhere({
-      slackTeamId,
-      slackChannel,
-      slackThreadTs,
-    }),
+    where: buildFastAgentSessionWhere(conversation),
     columns: { id: true },
   });
 

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-task-launcher.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-task-launcher.ts
@@ -6,7 +6,7 @@ import {
 
 import { enqueueTask } from '../task-run-queue';
 import { getTaskUrl } from '../task-url';
-import type { LaunchFastAgentSlackTask } from './fast-agent-service';
+import type { LaunchFastAgentTask } from './fast-agent-conversation';
 
 export function createFastAgentSlackTaskLauncher(params: {
   userId: string;
@@ -15,7 +15,7 @@ export function createFastAgentSlackTaskLauncher(params: {
   channelId: string;
   threadTs: string;
   messageId?: string;
-}): LaunchFastAgentSlackTask {
+}): LaunchFastAgentTask {
   return async ({ prompt, environmentId, parentSessionId, postKickoff }) => {
     const task: StandardTask = {
       type: TaskPayloadKind.StandardTask,

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-turn-lock.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-turn-lock.ts
@@ -1,4 +1,8 @@
 import { acquireRedisLock } from '@roomote/redis';
+import {
+  getFastAgentConversationStorageWorkspaceId,
+  type FastAgentConversation,
+} from './fast-agent-conversation';
 
 const FAST_AGENT_TURN_LOCK_PREFIX = 'slack:fast-agent-lock:';
 const FAST_AGENT_TURN_LOCK_TTL_SECONDS = 600;
@@ -10,14 +14,16 @@ const FAST_AGENT_TURN_LOCK_MAX_ATTEMPTS =
 
 /** Serialize every human and platform-generated Fast turn for one chat. */
 export async function acquireFastAgentTurnLock(params: {
-  slackTeamId: string;
-  slackChannel: string;
-  slackThreadTs: string;
+  conversation: FastAgentConversation;
   /** Cap the wait below the lock TTL so callers with their own retry or
    * user-feedback path can fail fast instead of blocking their context. */
   maxWaitMs?: number;
 }) {
-  const key = `${FAST_AGENT_TURN_LOCK_PREFIX}${params.slackTeamId}:${params.slackChannel}:${params.slackThreadTs}`;
+  const { channelId, threadId } = params.conversation;
+  const storageWorkspaceId = getFastAgentConversationStorageWorkspaceId(
+    params.conversation,
+  );
+  const key = `${FAST_AGENT_TURN_LOCK_PREFIX}${storageWorkspaceId}:${channelId}:${threadId}`;
   const maxAttempts =
     params.maxWaitMs === undefined
       ? FAST_AGENT_TURN_LOCK_MAX_ATTEMPTS

--- a/packages/cloud-agents/src/server/fast-agent/index.ts
+++ b/packages/cloud-agents/src/server/fast-agent/index.ts
@@ -1,4 +1,5 @@
 export * from './fast-agent-constants';
+export * from './fast-agent-conversation';
 export * from './fast-agent-prompt';
 export * from './fast-agent-service';
 export * from './fast-agent-turn-lock';

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
@@ -109,11 +109,11 @@ describe('deliverFastAgentParentEvent', () => {
     mocks.postMessage.mockResolvedValue('101.001');
     mocks.answerQuestion.mockImplementation(
       async ({
-        postSlackReply,
+        adapter,
       }: {
-        postSlackReply: (reply: unknown) => unknown;
+        adapter: { postReply: (reply: unknown) => unknown };
       }) =>
-        postSlackReply({
+        adapter.postReply({
           purpose: 'closeout',
           message: 'The proof is ready.',
           imageArtifactIds: ['artifact-1', 'artifact-1'],
@@ -125,14 +125,17 @@ describe('deliverFastAgentParentEvent', () => {
     await deliverFastAgentParentEvent({ parent, event });
 
     expect(mocks.acquireTurnLock).toHaveBeenCalledWith({
-      slackTeamId: 'T123',
-      slackChannel: 'C123',
-      slackThreadTs: '100.001',
+      conversation: {
+        surface: 'slack',
+        workspaceId: 'T123',
+        channelId: 'C123',
+        threadId: '100.001',
+      },
     });
     expect(mocks.answerQuestion).toHaveBeenCalledWith(
       expect.objectContaining({
-        platformEvent: true,
-        launchTask: mocks.launchTask,
+        turnSource: 'platform_event',
+        adapter: expect.objectContaining({ launchTask: mocks.launchTask }),
       }),
     );
     expect(mocks.createLauncher).toHaveBeenCalledWith({
@@ -187,11 +190,11 @@ describe('deliverFastAgentParentEvent', () => {
     };
     mocks.answerQuestion.mockImplementation(
       async ({
-        postSlackReply,
+        adapter,
       }: {
-        postSlackReply: (reply: unknown) => unknown;
+        adapter: { postReply: (reply: unknown) => unknown };
       }) =>
-        postSlackReply({
+        adapter.postReply({
           purpose: 'closeout',
           message: 'The pull request is open.',
         }),
@@ -208,7 +211,7 @@ describe('deliverFastAgentParentEvent', () => {
     expect(mocks.answerQuestion).toHaveBeenCalledWith(
       expect.objectContaining({
         question: expect.stringContaining(pullRequestEvent.pullRequest.url),
-        platformEvent: true,
+        turnSource: 'platform_event',
       }),
     );
     expect(firstClientMessageId).toEqual(expect.any(String));
@@ -235,7 +238,7 @@ describe('deliverFastAgentParentEvent', () => {
     expect(input).toEqual(
       expect.objectContaining({
         question: expect.stringContaining('"type":"task_settled"'),
-        platformEvent: true,
+        turnSource: 'platform_event',
       }),
     );
     expect(input).not.toHaveProperty('activeTasks');

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.ts
@@ -211,10 +211,14 @@ export async function deliverFastAgentParentEvent(params: {
    * and lean on their own retry instead of blocking. */
   lockWaitMs?: number;
 }): Promise<'delivered' | 'skipped'> {
+  const conversation = {
+    surface: 'slack' as const,
+    workspaceId: params.parent.slackTeamId,
+    channelId: params.parent.slackChannel,
+    threadId: params.parent.slackThreadTs,
+  };
   const releaseTurnLock = await acquireFastAgentTurnLock({
-    slackTeamId: params.parent.slackTeamId,
-    slackChannel: params.parent.slackChannel,
-    slackThreadTs: params.parent.slackThreadTs,
+    conversation,
     ...(params.lockWaitMs !== undefined
       ? { maxWaitMs: params.lockWaitMs }
       : {}),
@@ -278,36 +282,36 @@ export async function deliverFastAgentParentEvent(params: {
     await answerFastAgentQuestion({
       question: `<delegated_task_event>${JSON.stringify(params.event)}</delegated_task_event>`,
       userId: session.userId,
-      slackTeamId: params.parent.slackTeamId,
-      slackChannel: params.parent.slackChannel,
-      slackThreadTs: params.parent.slackThreadTs,
-      platformEvent: true,
-      launchTask,
-      ...(params.retryTaskStart
-        ? { retryTaskStart: params.retryTaskStart }
-        : {}),
-      postSlackReply: async ({ message, imageArtifactIds = [] }) => {
-        const imageBlocks = await buildSelectedImageBlocks({
-          artifactIds: imageArtifactIds,
-          event: params.event,
-        });
-        const messageTs = await slack.postMessage({
-          channel: params.parent.slackChannel,
-          thread_ts: params.parent.slackThreadTs,
-          text: message,
-          blocks: [{ type: 'markdown', text: message }, ...imageBlocks],
-          unfurl_links: false,
-          unfurl_media: false,
-          client_msg_id: buildSlackClientMessageId(
-            buildEventClientMessageSeed(params.event),
-          ),
-        });
-        if (!messageTs) {
-          throw new Error(
-            'Slack did not return a Fast parent event timestamp.',
-          );
-        }
-        slackPosted = true;
+      conversation,
+      turnSource: 'platform_event',
+      adapter: {
+        launchTask,
+        ...(params.retryTaskStart
+          ? { retryTaskStart: params.retryTaskStart }
+          : {}),
+        postReply: async ({ message, imageArtifactIds = [] }) => {
+          const imageBlocks = await buildSelectedImageBlocks({
+            artifactIds: imageArtifactIds,
+            event: params.event,
+          });
+          const messageTs = await slack.postMessage({
+            channel: params.parent.slackChannel,
+            thread_ts: params.parent.slackThreadTs,
+            text: message,
+            blocks: [{ type: 'markdown', text: message }, ...imageBlocks],
+            unfurl_links: false,
+            unfurl_media: false,
+            client_msg_id: buildSlackClientMessageId(
+              buildEventClientMessageSeed(params.event),
+            ),
+          });
+          if (!messageTs) {
+            throw new Error(
+              'Slack did not return a Fast parent event timestamp.',
+            );
+          }
+          slackPosted = true;
+        },
       },
     });
     return 'delivered';


### PR DESCRIPTION
## What

- introduce provider-neutral Fast conversation, reply, reaction, and turn-adapter types
- make the Fast service, session lookup, turn locking, and integration broker consume one conversation identity
- keep Slack and Discord delivery details in their surface adapters
- preserve existing persisted and Redis identities through an explicit compatibility mapping

## Why

Fast already behaves as one conversational orchestrator across human messages and delegated-task updates, but its shared service boundary was still expressed in Slack-specific coordinates and callbacks. This refactor makes that boundary match the product model and gives later lifecycle-delivery work a clean provider-neutral core to build on.

This is intentionally behavior-preserving. The existing Slack-shaped persistence schema and Slack task-event parent remain behind adapters; generalizing lifecycle parent delivery is a separate follow-up.

## Validation

- `pnpm --filter @roomote/cloud-agents check-types`
- `pnpm --filter @roomote/api check-types`
- `pnpm --filter @roomote/sdk check-types`
- full `@roomote/cloud-agents` Vitest suite
- full `@roomote/api` Vitest suite (206 files, 1,786 tests)
- full `@roomote/sdk` Vitest suite (99 files, 995 tests)
- `pnpm lint:fast`
- `pnpm check-types:fast`
- `pnpm knip`
