### PR TITLE
[Refactor] Generalize Fast parent event delivery

### DIFF
--- a/apps/worker/src/callbacks/__tests__/communication-ack-reaction.test.ts
+++ b/apps/worker/src/callbacks/__tests__/communication-ack-reaction.test.ts
@@ -63,9 +63,12 @@ describe('getCommunicationRunTaskCallbacks ack reaction cleanup', () => {
       communicationThreadId: '100.001',
       fastAgentParent: {
         sessionId: '11111111-1111-4111-8111-111111111111',
-        slackTeamId: 'T123',
-        slackChannel: 'C123',
-        slackThreadTs: '100.001',
+        conversation: {
+          surface: 'slack',
+          workspaceId: 'T123',
+          channelId: 'C123',
+          threadId: '100.001',
+        },
       },
     });
     const callbacks = getCommunicationRunTaskCallbacks(run);

--- a/apps/worker/src/run-task/__tests__/mcp-task-env.test.ts
+++ b/apps/worker/src/run-task/__tests__/mcp-task-env.test.ts
@@ -63,9 +63,12 @@ describe('getCommunicationReplyContext', () => {
         communicationContextInherited: true,
         fastAgentParent: {
           sessionId: '11111111-1111-4111-8111-111111111111',
-          slackTeamId: 'T123',
-          slackChannel: 'C123',
-          slackThreadTs: '111.222',
+          conversation: {
+            surface: 'slack',
+            workspaceId: 'T123',
+            channelId: 'C123',
+            threadId: '111.222',
+          },
         },
       },
     };

--- a/packages/cloud-agents/src/server/__tests__/enqueue-task.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/enqueue-task.test.ts
@@ -673,7 +673,7 @@ describe('enqueueTask initiator stamping', () => {
     const parentRun = await launchFresh({
       initiator: { kind: 'user', userId },
       workflow: 'standard',
-      surface: 'slack',
+      surface: 'slack' as const,
       trigger: 'message',
       channels: { slackChannelId: 'C123', slackThreadTs: '123.456' },
       task: standardTaskInput({
@@ -714,7 +714,7 @@ describe('enqueueTask initiator stamping', () => {
     const parentRun = await launchFresh({
       initiator: { kind: 'user', userId },
       workflow: 'standard',
-      surface: 'slack',
+      surface: 'slack' as const,
       trigger: 'message',
       channels: { slackChannelId: 'C123', slackThreadTs: '123.456' },
       task: standardTaskInput({
@@ -770,7 +770,7 @@ describe('enqueueTask initiator stamping', () => {
         displayName: 'Octo Fan',
       },
       workflow: 'standard',
-      surface: 'slack',
+      surface: 'slack' as const,
       trigger: 'message',
       channels: {
         slackChannelId: 'C42',
@@ -839,7 +839,7 @@ describe('enqueueTask initiator stamping', () => {
         matchedUserId: userId,
       },
       workflow: 'standard',
-      surface: 'slack',
+      surface: 'slack' as const,
       trigger: 'message',
     });
 
@@ -930,7 +930,7 @@ describe('enqueueTask snapshot resume', () => {
       }),
       initiator: { kind: 'user', userId },
       workflow: 'standard',
-      surface: 'slack',
+      surface: 'slack' as const,
       trigger: 'message',
     });
 
@@ -970,9 +970,12 @@ describe('enqueueTask snapshot resume', () => {
     const fastAgentSessionId = '11111111-1111-4111-8111-111111111111';
     const fastAgentParent = {
       sessionId: fastAgentSessionId,
-      slackTeamId: 'T123',
-      slackChannel: 'C123',
-      slackThreadTs: '111.222',
+      conversation: {
+        surface: 'slack' as const,
+        workspaceId: 'T123',
+        channelId: 'C123',
+        threadId: '111.222',
+      },
     };
     const freshRun = await launchFresh({
       task: standardTaskInput({
@@ -989,7 +992,7 @@ describe('enqueueTask snapshot resume', () => {
       }),
       initiator: { kind: 'user', userId },
       workflow: 'standard',
-      surface: 'slack',
+      surface: 'slack' as const,
       trigger: 'message',
     });
     const resumeTask: SnapshotResumeTask = {
@@ -1054,9 +1057,12 @@ describe('enqueueTask snapshot resume', () => {
     const userId = await createUser();
     const fastAgentParent = {
       sessionId: '22222222-2222-4222-8222-222222222222',
-      slackTeamId: 'T123',
-      slackChannel: 'C123',
-      slackThreadTs: '333.444',
+      conversation: {
+        surface: 'slack' as const,
+        workspaceId: 'T123',
+        channelId: 'C123',
+        threadId: '333.444',
+      },
     };
     const freshRun = await launchFresh({
       task: standardTaskInput({
@@ -1069,7 +1075,7 @@ describe('enqueueTask snapshot resume', () => {
       }),
       initiator: { kind: 'user', userId },
       workflow: 'standard',
-      surface: 'slack',
+      surface: 'slack' as const,
       trigger: 'message',
     });
     const [legacyResume] = await db
@@ -1219,7 +1225,7 @@ describe('enqueueTask snapshot resume', () => {
       }),
       initiator: { kind: 'user', userId },
       workflow: 'standard',
-      surface: 'slack',
+      surface: 'slack' as const,
       trigger: 'message',
     });
 
@@ -1478,7 +1484,7 @@ describe('enqueueTaskRelaunch failed start', () => {
     const failedRun = await launchFresh({
       initiator: { kind: 'user', userId },
       workflow: 'standard',
-      surface: 'slack',
+      surface: 'slack' as const,
       trigger: 'message',
     });
 

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-active-tasks.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-active-tasks.test.ts
@@ -1,5 +1,9 @@
 import { db, inArray, taskFactory, taskRuns, tasks } from '@roomote/db/server';
-import { RunStatus, TaskPayloadKind } from '@roomote/types';
+import {
+  RunStatus,
+  TaskPayloadKind,
+  type FastAgentParent,
+} from '@roomote/types';
 
 import { getActiveFastAgentTasks } from '../fast-agent-session';
 
@@ -19,12 +23,7 @@ async function createRun(input: {
   createdAt: Date;
   canceledAt?: Date;
   fastAgentSessionId?: string;
-  fastAgentParent?: {
-    sessionId: string;
-    slackTeamId: string;
-    slackChannel: string;
-    slackThreadTs: string;
-  };
+  fastAgentParent?: FastAgentParent;
 }) {
   const [run] = await db
     .insert(taskRuns)
@@ -157,9 +156,12 @@ describe('getActiveFastAgentTasks', () => {
       createdAt: new Date('2026-08-17T00:01:00Z'),
       fastAgentParent: {
         sessionId: SESSION_ID,
-        slackTeamId: 'T123',
-        slackChannel: 'C123',
-        slackThreadTs: '111.222',
+        conversation: {
+          surface: 'slack',
+          workspaceId: 'T123',
+          channelId: 'C123',
+          threadId: '111.222',
+        },
       },
     });
 

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-task-launcher.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-task-launcher.test.ts
@@ -86,9 +86,12 @@ describe('createFastAgentSlackTaskLauncher', () => {
             fastAgentSessionId: '11111111-1111-4111-8111-111111111111',
             fastAgentParent: {
               sessionId: '11111111-1111-4111-8111-111111111111',
-              slackTeamId: 'T123',
-              slackChannel: 'C123',
-              slackThreadTs: '100.001',
+              conversation: {
+                surface: 'slack',
+                workspaceId: 'T123',
+                channelId: 'C123',
+                threadId: '100.001',
+              },
             },
             environmentId: 'env-1',
           },

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation.ts
@@ -1,13 +1,6 @@
-export type FastAgentSurface = 'slack' | 'discord';
+import type { FastAgentConversation } from '@roomote/types';
 
-/** Provider-neutral identity for one persisted Fast conversation. */
-export type FastAgentConversation = {
-  surface: FastAgentSurface;
-  /** Provider workspace/account boundary (for example a Slack team or Discord guild). */
-  workspaceId: string;
-  channelId: string;
-  threadId: string;
-};
+export type { FastAgentConversation, FastAgentSurface } from '@roomote/types';
 
 /** Preserve existing persisted/Redis workspace keys while the storage schema
  * remains Slack-shaped. New provider adapters always pass raw provider IDs. */

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-task-launcher.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-task-launcher.ts
@@ -36,9 +36,12 @@ export function createFastAgentSlackTaskLauncher(params: {
         fastAgentSessionId: parentSessionId,
         fastAgentParent: {
           sessionId: parentSessionId,
-          slackTeamId: params.teamId,
-          slackChannel: params.channelId,
-          slackThreadTs: params.threadTs,
+          conversation: {
+            surface: 'slack',
+            workspaceId: params.teamId,
+            channelId: params.channelId,
+            threadId: params.threadTs,
+          },
         },
         ...(environmentId && environmentId !== ALL_REPOSITORIES
           ? { environmentId }

--- a/packages/sdk/src/server/lib/artifacts/__tests__/notify-fast-agent-parent.test.ts
+++ b/packages/sdk/src/server/lib/artifacts/__tests__/notify-fast-agent-parent.test.ts
@@ -1,14 +1,14 @@
 const mocks = vi.hoisted(() => {
   class FastAgentParentEventDeliveryError extends Error {
-    readonly slackPosted: boolean;
+    readonly replyPosted: boolean;
     readonly permanent: boolean;
 
     constructor(
       message: string,
-      options: { slackPosted: boolean; permanent?: boolean },
+      options: { replyPosted: boolean; permanent?: boolean },
     ) {
       super(message);
-      this.slackPosted = options.slackPosted;
+      this.replyPosted = options.replyPosted;
       this.permanent = options.permanent ?? false;
     }
   }
@@ -62,9 +62,12 @@ import { notifyFastAgentParentOnArtifact } from '../notify-fast-agent-parent';
 
 const fastParent = {
   sessionId: '11111111-1111-4111-8111-111111111111',
-  slackTeamId: 'T123',
-  slackChannel: 'C123',
-  slackThreadTs: '100.001',
+  conversation: {
+    surface: 'slack' as const,
+    workspaceId: 'T123',
+    channelId: 'C123',
+    threadId: '100.001',
+  },
 };
 
 function artifact(
@@ -174,7 +177,7 @@ describe('notifyFastAgentParentOnArtifact', () => {
   it('keeps the claim when the failure happened after the Slack post', async () => {
     mocks.deliverParentEvent.mockRejectedValueOnce(
       new mocks.FastAgentParentEventDeliveryError('lifecycle write failed', {
-        slackPosted: true,
+        replyPosted: true,
       }),
     );
 
@@ -192,7 +195,7 @@ describe('notifyFastAgentParentOnArtifact', () => {
   it('settles the claim as skipped when no retry can ever succeed', async () => {
     mocks.deliverParentEvent.mockRejectedValueOnce(
       new mocks.FastAgentParentEventDeliveryError('parent session gone', {
-        slackPosted: false,
+        replyPosted: false,
         permanent: true,
       }),
     );

--- a/packages/sdk/src/server/lib/artifacts/notify-fast-agent-parent.ts
+++ b/packages/sdk/src/server/lib/artifacts/notify-fast-agent-parent.ts
@@ -151,7 +151,7 @@ export async function notifyFastAgentParentOnArtifact(input: {
     const deliveryError =
       error instanceof FastAgentParentEventDeliveryError ? error : null;
 
-    if (delivered || deliveryError?.slackPosted) {
+    if (delivered || deliveryError?.replyPosted) {
       // The parent thread already saw the event; releasing the claim would
       // make a retry double-post. Settle the marker best-effort instead.
       await writeDeliveryMarker('delivered').catch(() => {});

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
@@ -65,9 +65,12 @@ import { deliverFastAgentParentEvent } from './fast-agent-parent-event';
 
 const parent = {
   sessionId: '11111111-1111-4111-8111-111111111111',
-  slackTeamId: 'T123',
-  slackChannel: 'C123',
-  slackThreadTs: '100.001',
+  conversation: {
+    surface: 'slack' as const,
+    workspaceId: 'T123',
+    channelId: 'C123',
+    threadId: '100.001',
+  },
 };
 
 const event = {
@@ -126,7 +129,7 @@ describe('deliverFastAgentParentEvent', () => {
 
     expect(mocks.acquireTurnLock).toHaveBeenCalledWith({
       conversation: {
-        surface: 'slack',
+        surface: 'slack' as const,
         workspaceId: 'T123',
         channelId: 'C123',
         threadId: '100.001',
@@ -170,6 +173,29 @@ describe('deliverFastAgentParentEvent', () => {
       deliverFastAgentParentEvent({ parent, event }),
     ).rejects.toThrow('turn lock did not become available');
     expect(mocks.answerQuestion).not.toHaveBeenCalled();
+  });
+
+  it('fails permanently when the parent surface has no delivery adapter', async () => {
+    const delivery = deliverFastAgentParentEvent({
+      parent: {
+        ...parent,
+        conversation: {
+          surface: 'discord',
+          workspaceId: 'guild-1',
+          channelId: 'channel-1',
+          threadId: 'thread-1',
+        },
+      },
+      event,
+    });
+
+    await expect(delivery).rejects.toMatchObject({
+      replyPosted: false,
+      permanent: true,
+    });
+    expect(mocks.findSession).not.toHaveBeenCalled();
+    expect(mocks.answerQuestion).not.toHaveBeenCalled();
+    expect(mocks.releaseTurnLock).toHaveBeenCalledOnce();
   });
 
   it('delivers a pull request event with a stable Slack idempotency key', async () => {

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.ts
@@ -5,6 +5,7 @@ import {
   acquireFastAgentTurnLock,
   answerFastAgentQuestion,
   createFastAgentSlackTaskLauncher,
+  type FastAgentTurnAdapter,
 } from '@roomote/cloud-agents/server';
 import {
   asc,
@@ -45,20 +46,20 @@ export function buildSlackClientMessageId(seed: string): string {
 }
 
 export class FastAgentParentEventDeliveryError extends Error {
-  /** True once the orchestrator's reply reached Slack; callers must not
+  /** True once the orchestrator's reply reached the chat; callers must not
    * release their delivery claim in that case or a retry double-posts. */
-  readonly slackPosted: boolean;
-  /** True when no retry can ever succeed (parent session or Slack
+  readonly replyPosted: boolean;
+  /** True when no retry can ever succeed (parent session or surface
    * installation is gone); callers should stop retrying. */
   readonly permanent: boolean;
 
   constructor(
     message: string,
-    options: { cause?: unknown; slackPosted: boolean; permanent?: boolean },
+    options: { cause?: unknown; replyPosted: boolean; permanent?: boolean },
   ) {
     super(message, options.cause !== undefined ? { cause: options.cause } : {});
     this.name = 'FastAgentParentEventDeliveryError';
-    this.slackPosted = options.slackPosted;
+    this.replyPosted = options.replyPosted;
     this.permanent = options.permanent ?? false;
   }
 }
@@ -200,6 +201,103 @@ function buildEventClientMessageSeed(event: FastAgentParentEvent): string {
   }
 }
 
+type FastAgentParentTurn = {
+  userId: string;
+  adapter: FastAgentTurnAdapter;
+};
+
+async function createSlackFastAgentParentTurn(params: {
+  parent: FastAgentParent;
+  event: FastAgentParentEvent;
+  onReplyPosted: () => void;
+}): Promise<FastAgentParentTurn> {
+  const conversation = params.parent.conversation;
+  if (conversation.surface !== 'slack') {
+    throw new Error('Expected a Slack Fast parent conversation.');
+  }
+
+  const scopedChannel = `${conversation.workspaceId}:${conversation.channelId}`;
+  const [session, installation] = await Promise.all([
+    db.query.slackQuickAnswers.findFirst({
+      where: and(
+        eq(slackQuickAnswers.id, params.parent.sessionId),
+        eq(slackQuickAnswers.slackChannel, scopedChannel),
+        eq(slackQuickAnswers.slackThreadTs, conversation.threadId),
+      ),
+      columns: { id: true, userId: true },
+    }),
+    db.query.slackInstallations.findFirst({
+      where: and(
+        eq(slackInstallations.isActive, true),
+        eq(slackInstallations.teamId, conversation.workspaceId),
+      ),
+      columns: { botAccessToken: true, teamDomain: true },
+    }),
+  ]);
+
+  if (!session || !installation?.botAccessToken) {
+    throw new FastAgentParentEventDeliveryError(
+      'Fast parent session or Slack installation was not found.',
+      { replyPosted: false, permanent: true },
+    );
+  }
+
+  const slack = new SlackNotifier(installation.botAccessToken);
+  return {
+    userId: session.userId,
+    adapter: {
+      launchTask: createFastAgentSlackTaskLauncher({
+        userId: session.userId,
+        teamId: conversation.workspaceId,
+        ...(installation.teamDomain
+          ? { teamDomain: installation.teamDomain }
+          : {}),
+        channelId: conversation.channelId,
+        threadTs: conversation.threadId,
+      }),
+      postReply: async ({ message, imageArtifactIds = [] }) => {
+        const imageBlocks = await buildSelectedImageBlocks({
+          artifactIds: imageArtifactIds,
+          event: params.event,
+        });
+        const messageTs = await slack.postMessage({
+          channel: conversation.channelId,
+          thread_ts: conversation.threadId,
+          text: message,
+          blocks: [{ type: 'markdown', text: message }, ...imageBlocks],
+          unfurl_links: false,
+          unfurl_media: false,
+          client_msg_id: buildSlackClientMessageId(
+            buildEventClientMessageSeed(params.event),
+          ),
+        });
+        if (!messageTs) {
+          throw new Error(
+            'Slack did not return a Fast parent event timestamp.',
+          );
+        }
+        params.onReplyPosted();
+      },
+    },
+  };
+}
+
+async function createFastAgentParentTurn(params: {
+  parent: FastAgentParent;
+  event: FastAgentParentEvent;
+  onReplyPosted: () => void;
+}): Promise<FastAgentParentTurn> {
+  switch (params.parent.conversation.surface) {
+    case 'slack':
+      return createSlackFastAgentParentTurn(params);
+    case 'discord':
+      throw new FastAgentParentEventDeliveryError(
+        'Fast parent delivery is not configured for discord.',
+        { replyPosted: false, permanent: true },
+      );
+  }
+}
+
 /** Give a structured child event to the Fast orchestrator for presentation. */
 export async function deliverFastAgentParentEvent(params: {
   parent: FastAgentParent;
@@ -211,12 +309,7 @@ export async function deliverFastAgentParentEvent(params: {
    * and lean on their own retry instead of blocking. */
   lockWaitMs?: number;
 }): Promise<'delivered' | 'skipped'> {
-  const conversation = {
-    surface: 'slack' as const,
-    workspaceId: params.parent.slackTeamId,
-    channelId: params.parent.slackChannel,
-    threadId: params.parent.slackThreadTs,
-  };
+  const conversation = params.parent.conversation;
   const releaseTurnLock = await acquireFastAgentTurnLock({
     conversation,
     ...(params.lockWaitMs !== undefined
@@ -226,11 +319,11 @@ export async function deliverFastAgentParentEvent(params: {
   if (!releaseTurnLock) {
     throw new FastAgentParentEventDeliveryError(
       'Fast parent turn lock did not become available.',
-      { slackPosted: false },
+      { replyPosted: false },
     );
   }
 
-  let slackPosted = false;
+  let replyPosted = false;
 
   try {
     if (params.event.type === 'pull_request_opened') {
@@ -243,75 +336,23 @@ export async function deliverFastAgentParentEvent(params: {
       }
     }
 
-    const scopedChannel = `${params.parent.slackTeamId}:${params.parent.slackChannel}`;
-    const [session, installation] = await Promise.all([
-      db.query.slackQuickAnswers.findFirst({
-        where: and(
-          eq(slackQuickAnswers.id, params.parent.sessionId),
-          eq(slackQuickAnswers.slackChannel, scopedChannel),
-          eq(slackQuickAnswers.slackThreadTs, params.parent.slackThreadTs),
-        ),
-        columns: { id: true, userId: true },
-      }),
-      db.query.slackInstallations.findFirst({
-        where: and(
-          eq(slackInstallations.isActive, true),
-          eq(slackInstallations.teamId, params.parent.slackTeamId),
-        ),
-        columns: { botAccessToken: true, teamDomain: true },
-      }),
-    ]);
-
-    if (!session || !installation?.botAccessToken) {
-      throw new FastAgentParentEventDeliveryError(
-        'Fast parent session or Slack installation was not found.',
-        { slackPosted: false, permanent: true },
-      );
-    }
-
-    const slack = new SlackNotifier(installation.botAccessToken);
-    const launchTask = createFastAgentSlackTaskLauncher({
-      userId: session.userId,
-      teamId: params.parent.slackTeamId,
-      ...(installation.teamDomain
-        ? { teamDomain: installation.teamDomain }
-        : {}),
-      channelId: params.parent.slackChannel,
-      threadTs: params.parent.slackThreadTs,
+    const parentTurn = await createFastAgentParentTurn({
+      parent: params.parent,
+      event: params.event,
+      onReplyPosted: () => {
+        replyPosted = true;
+      },
     });
     await answerFastAgentQuestion({
       question: `<delegated_task_event>${JSON.stringify(params.event)}</delegated_task_event>`,
-      userId: session.userId,
+      userId: parentTurn.userId,
       conversation,
       turnSource: 'platform_event',
       adapter: {
-        launchTask,
+        ...parentTurn.adapter,
         ...(params.retryTaskStart
           ? { retryTaskStart: params.retryTaskStart }
           : {}),
-        postReply: async ({ message, imageArtifactIds = [] }) => {
-          const imageBlocks = await buildSelectedImageBlocks({
-            artifactIds: imageArtifactIds,
-            event: params.event,
-          });
-          const messageTs = await slack.postMessage({
-            channel: params.parent.slackChannel,
-            thread_ts: params.parent.slackThreadTs,
-            text: message,
-            blocks: [{ type: 'markdown', text: message }, ...imageBlocks],
-            unfurl_links: false,
-            unfurl_media: false,
-            client_msg_id: buildSlackClientMessageId(
-              buildEventClientMessageSeed(params.event),
-            ),
-          });
-          if (!messageTs) {
-            throw new Error(
-              'Slack did not return a Fast parent event timestamp.',
-            );
-          }
-          slackPosted = true;
-        },
       },
     });
     return 'delivered';
@@ -321,7 +362,7 @@ export async function deliverFastAgentParentEvent(params: {
     }
     throw new FastAgentParentEventDeliveryError(
       error instanceof Error ? error.message : String(error),
-      { cause: error, slackPosted },
+      { cause: error, replyPosted },
     );
   } finally {
     await releaseTurnLock();

--- a/packages/sdk/src/server/lib/task-runs/__tests__/finish-run.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/finish-run.test.ts
@@ -1492,9 +1492,12 @@ describe('finishRun', () => {
           communicationContextInherited: true,
           fastAgentParent: {
             sessionId: '11111111-1111-4111-8111-111111111111',
-            slackTeamId: 'T123',
-            slackChannel: 'C123',
-            slackThreadTs: '111.222',
+            conversation: {
+              surface: 'slack',
+              workspaceId: 'T123',
+              channelId: 'C123',
+              threadId: '111.222',
+            },
           },
         },
       });

--- a/packages/sdk/src/server/lib/task-runs/__tests__/notify-fast-agent-parent-on-pull-request-opened.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/notify-fast-agent-parent-on-pull-request-opened.test.ts
@@ -2,15 +2,15 @@ import type { TaskRun } from '@roomote/db/server';
 
 const mocks = vi.hoisted(() => {
   class FastAgentParentEventDeliveryError extends Error {
-    readonly slackPosted: boolean;
+    readonly replyPosted: boolean;
     readonly permanent: boolean;
 
     constructor(
       message: string,
-      options: { slackPosted: boolean; permanent?: boolean },
+      options: { replyPosted: boolean; permanent?: boolean },
     ) {
       super(message);
-      this.slackPosted = options.slackPosted;
+      this.replyPosted = options.replyPosted;
       this.permanent = options.permanent ?? false;
     }
   }
@@ -66,9 +66,12 @@ import { notifyFastAgentParentOnPullRequestOpened } from '../notify-fast-agent-p
 
 const fastParent = {
   sessionId: '11111111-1111-4111-8111-111111111111',
-  slackTeamId: 'T123',
-  slackChannel: 'C123',
-  slackThreadTs: '100.001',
+  conversation: {
+    surface: 'slack' as const,
+    workspaceId: 'T123',
+    channelId: 'C123',
+    threadId: '100.001',
+  },
 };
 
 function makeRun(payload: Record<string, unknown>): TaskRun {

--- a/packages/sdk/src/server/lib/task-runs/__tests__/notify-fast-agent-parent-on-settle.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/notify-fast-agent-parent-on-settle.test.ts
@@ -3,15 +3,15 @@ import { RunStatus, TaskRunErrorCode } from '@roomote/types';
 
 const mocks = vi.hoisted(() => {
   class FastAgentParentEventDeliveryError extends Error {
-    readonly slackPosted: boolean;
+    readonly replyPosted: boolean;
     readonly permanent: boolean;
 
     constructor(
       message: string,
-      options: { slackPosted: boolean; permanent?: boolean },
+      options: { replyPosted: boolean; permanent?: boolean },
     ) {
       super(message);
-      this.slackPosted = options.slackPosted;
+      this.replyPosted = options.replyPosted;
       this.permanent = options.permanent ?? false;
     }
   }
@@ -74,9 +74,12 @@ import { notifyFastAgentParentOnSettle } from '../notify-fast-agent-parent-on-se
 
 const fastParent = {
   sessionId: '11111111-1111-4111-8111-111111111111',
-  slackTeamId: 'T123',
-  slackChannel: 'C123',
-  slackThreadTs: '100.001',
+  conversation: {
+    surface: 'slack' as const,
+    workspaceId: 'T123',
+    channelId: 'C123',
+    threadId: '100.001',
+  },
 };
 
 function makeRun(
@@ -385,7 +388,7 @@ describe('notifyFastAgentParentOnSettle', () => {
   it('keeps the claim when the failure happened after the Slack post', async () => {
     mocks.deliverParentEvent.mockRejectedValueOnce(
       new mocks.FastAgentParentEventDeliveryError('lifecycle write failed', {
-        slackPosted: true,
+        replyPosted: true,
       }),
     );
 

--- a/packages/sdk/src/server/lib/task-runs/notify-fast-agent-parent-on-pull-request-opened.ts
+++ b/packages/sdk/src/server/lib/task-runs/notify-fast-agent-parent-on-pull-request-opened.ts
@@ -138,7 +138,7 @@ export async function notifyFastAgentParentOnPullRequestOpened(params: {
     const deliveryError =
       error instanceof FastAgentParentEventDeliveryError ? error : null;
 
-    if (delivered || deliveryError?.slackPosted || deliveryError?.permanent) {
+    if (delivered || deliveryError?.replyPosted || deliveryError?.permanent) {
       await markDelivered().catch(() => {});
       return;
     }

--- a/packages/sdk/src/server/lib/task-runs/notify-fast-agent-parent-on-settle.ts
+++ b/packages/sdk/src/server/lib/task-runs/notify-fast-agent-parent-on-settle.ts
@@ -244,7 +244,7 @@ export async function notifyFastAgentParentOnSettle(
     const deliveryError =
       error instanceof FastAgentParentEventDeliveryError ? error : null;
 
-    if (delivered || deliveryError?.slackPosted) {
+    if (delivered || deliveryError?.replyPosted) {
       // The parent thread already saw the settle message; releasing the claim
       // would let the other settle caller double-post. Settle the marker.
       await markSettled().catch(() => {});

--- a/packages/sdk/src/server/lib/task-runs/publish-fast-agent-request-user-input.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/publish-fast-agent-request-user-input.test.ts
@@ -51,9 +51,12 @@ import { publishFastAgentRequestUserInput } from './publish-fast-agent-request-u
 
 const parent = {
   sessionId: '11111111-1111-4111-8111-111111111111',
-  slackTeamId: 'T123',
-  slackChannel: 'C123',
-  slackThreadTs: '100.001',
+  conversation: {
+    surface: 'slack' as const,
+    workspaceId: 'T123',
+    channelId: 'C123',
+    threadId: '100.001',
+  },
 };
 
 const input = {

--- a/packages/sdk/src/server/lib/task-runs/publish-fast-agent-request-user-input.ts
+++ b/packages/sdk/src/server/lib/task-runs/publish-fast-agent-request-user-input.ts
@@ -45,24 +45,25 @@ export async function publishFastAgentRequestUserInput(input: {
   });
   const parent = getFastAgentParentFromPayload(run?.payload);
 
-  if (!run || !parent) {
+  if (!run || !parent || parent.conversation.surface !== 'slack') {
     return { published: false };
   }
 
-  const scopedChannel = `${parent.slackTeamId}:${parent.slackChannel}`;
+  const { workspaceId, channelId, threadId } = parent.conversation;
+  const scopedChannel = `${workspaceId}:${channelId}`;
   const [session, installation] = await Promise.all([
     db.query.slackQuickAnswers.findFirst({
       where: and(
         eq(slackQuickAnswers.id, parent.sessionId),
         eq(slackQuickAnswers.slackChannel, scopedChannel),
-        eq(slackQuickAnswers.slackThreadTs, parent.slackThreadTs),
+        eq(slackQuickAnswers.slackThreadTs, threadId),
       ),
       columns: { id: true },
     }),
     db.query.slackInstallations.findFirst({
       where: and(
         eq(slackInstallations.isActive, true),
-        eq(slackInstallations.teamId, parent.slackTeamId),
+        eq(slackInstallations.teamId, workspaceId),
       ),
       columns: { botAccessToken: true },
     }),
@@ -72,7 +73,7 @@ export async function publishFastAgentRequestUserInput(input: {
     return { published: false };
   }
 
-  const lockKey = `fast-agent:request-user-input:publish:${parent.slackTeamId}:${parent.slackChannel}:${parent.slackThreadTs}`;
+  const lockKey = `fast-agent:request-user-input:publish:${workspaceId}:${channelId}:${threadId}`;
   let releaseLock: Awaited<ReturnType<typeof acquireRedisLock>> = null;
 
   for (
@@ -93,9 +94,7 @@ export async function publishFastAgentRequestUserInput(input: {
   }
 
   try {
-    const existing = await getPendingSlackRequestUserInput(
-      parent.slackThreadTs,
-    );
+    const existing = await getPendingSlackRequestUserInput(threadId);
 
     if (existing && existing.requestId !== input.requestId) {
       // A child can only wait on one structured prompt at a time. Preserve the
@@ -123,7 +122,7 @@ export async function publishFastAgentRequestUserInput(input: {
         : {}),
     };
 
-    await setPendingSlackRequestUserInput(parent.slackThreadTs, pendingRequest);
+    await setPendingSlackRequestUserInput(threadId, pendingRequest);
 
     const slack = new SlackNotifier(installation.botAccessToken);
     const blocks = buildSlackRequestUserInputBlocks({
@@ -134,7 +133,7 @@ export async function publishFastAgentRequestUserInput(input: {
     });
     const updated = existing?.promptMessageTs
       ? await slack.updateMessage({
-          channel: parent.slackChannel,
+          channel: channelId,
           ts: existing.promptMessageTs,
           message: { blocks },
         })
@@ -142,8 +141,8 @@ export async function publishFastAgentRequestUserInput(input: {
     const messageTs = updated
       ? existing?.promptMessageTs
       : await slack.postMessage({
-          channel: parent.slackChannel,
-          thread_ts: parent.slackThreadTs,
+          channel: channelId,
+          thread_ts: threadId,
           blocks,
           client_msg_id: buildSlackClientMessageId(input.requestId),
         });
@@ -152,7 +151,7 @@ export async function publishFastAgentRequestUserInput(input: {
       throw new Error('Slack did not return a request_user_input timestamp.');
     }
 
-    await setPendingSlackRequestUserInput(parent.slackThreadTs, {
+    await setPendingSlackRequestUserInput(threadId, {
       ...pendingRequest,
       promptMessageTs: messageTs,
     });

--- a/packages/slack/src/handle-followup-answer.ts
+++ b/packages/slack/src/handle-followup-answer.ts
@@ -174,8 +174,9 @@ async function findFastAgentChildRunForPendingInput(params: {
   const parent = getFastAgentParentFromPayload(run.payload);
   if (
     !parent ||
-    parent.slackTeamId !== params.slackTeamId ||
-    parent.slackThreadTs !== params.threadId
+    parent.conversation.surface !== 'slack' ||
+    parent.conversation.workspaceId !== params.slackTeamId ||
+    parent.conversation.threadId !== params.threadId
   ) {
     return null;
   }

--- a/packages/types/src/__tests__/task-runs.test.ts
+++ b/packages/types/src/__tests__/task-runs.test.ts
@@ -498,9 +498,12 @@ describe('taskSpecSchema', () => {
         communicationContextInherited: true,
         fastAgentParent: {
           sessionId: '11111111-1111-4111-8111-111111111111',
-          slackTeamId: 'T123',
-          slackChannel: 'C123',
-          slackThreadTs: '111.222',
+          conversation: {
+            surface: 'slack',
+            workspaceId: 'T123',
+            channelId: 'C123',
+            threadId: '111.222',
+          },
         },
       },
     });
@@ -516,6 +519,12 @@ describe('taskSpecSchema', () => {
     expect(parsed.payload.fastAgentParent?.sessionId).toBe(
       '11111111-1111-4111-8111-111111111111',
     );
+    expect(parsed.payload.fastAgentParent?.conversation).toEqual({
+      surface: 'slack',
+      workspaceId: 'T123',
+      channelId: 'C123',
+      threadId: '111.222',
+    });
   });
 
   it('parses Dependabot suggestion sources on SuggestedTasks payloads', () => {

--- a/packages/types/src/fast-agent.ts
+++ b/packages/types/src/fast-agent.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+export const fastAgentSurfaces = ['slack', 'discord'] as const;
+export const fastAgentSurfaceSchema = z.enum(fastAgentSurfaces);
+
+export type FastAgentSurface = z.infer<typeof fastAgentSurfaceSchema>;
+
+export const fastAgentConversationSchema = z.object({
+  surface: fastAgentSurfaceSchema,
+  workspaceId: z.string().min(1),
+  channelId: z.string().min(1),
+  threadId: z.string().min(1),
+});
+
+export type FastAgentConversation = z.infer<typeof fastAgentConversationSchema>;
+
+export const fastAgentParentSchema = z.object({
+  sessionId: z.string().uuid(),
+  conversation: fastAgentConversationSchema,
+});
+
+export type FastAgentParent = z.infer<typeof fastAgentParentSchema>;
+
+export function getFastAgentParentFromPayload(
+  payload: unknown,
+): FastAgentParent | null {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return null;
+  }
+
+  const parsed = z
+    .object({ fastAgentParent: fastAgentParentSchema })
+    .safeParse(payload);
+
+  return parsed.success ? parsed.data.fastAgentParent : null;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -10,6 +10,7 @@ export * from './automation-destination-fields';
 export * from './cloud-agents';
 export * from './pr-review-action';
 export * from './task-runs';
+export * from './fast-agent';
 export * from './chatgpt-subscription';
 export * from './github-copilot-subscription';
 export * from './xai-subscription';

--- a/packages/types/src/task-runs.ts
+++ b/packages/types/src/task-runs.ts
@@ -11,6 +11,7 @@ import {
   type CommunicationProvider,
   queuedCommunicationMessageSchema,
 } from './communication';
+import { fastAgentParentSchema } from './fast-agent';
 import { SANDBOX_SNAPSHOT_EXPIRY_MS } from './compute-providers/worker-runtime';
 import { prActions } from './cloud-agents';
 import { ALL_REPOSITORIES } from './constants';
@@ -886,13 +887,6 @@ export type LinkedWorkItem = z.infer<typeof linkedWorkItemSchema>;
  * workspace configuration. When using environments, the `repo` field is ignored
  * (but still populated for backwards compatibility).
  */
-const fastAgentParentSchema = z.object({
-  sessionId: z.string().uuid(),
-  slackTeamId: z.string().min(1),
-  slackChannel: z.string().min(1),
-  slackThreadTs: z.string().min(1),
-});
-
 const sharedTaskPayloadSchema = z.object({
   /**
    * Legacy single-repository field in owner/repo format, or the
@@ -1357,22 +1351,6 @@ const delegatedTaskPayloadSchema = sharedTaskPayloadSchema.extend({
    */
   notifySourceRunOnSettle: z.boolean().optional(),
 });
-
-export type FastAgentParent = z.infer<typeof fastAgentParentSchema>;
-
-export function getFastAgentParentFromPayload(
-  payload: unknown,
-): FastAgentParent | null {
-  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
-    return null;
-  }
-
-  const parsed = z
-    .object({ fastAgentParent: fastAgentParentSchema })
-    .safeParse(payload);
-
-  return parsed.success ? parsed.data.fastAgentParent : null;
-}
 
 export function getNotifySourceRunOnSettleFromPayload(
   payload: unknown,


### PR DESCRIPTION
## What

- make `FastAgentConversation` and `FastAgentParent` shared, validated contracts in `@roomote/types`
- replace Slack-specific parent payload fields with a provider-neutral conversation identity
- separate parent-event coordination from the Slack delivery adapter
- rename delivery state from `slackPosted` to the provider-neutral `replyPosted`
- keep Slack-only structured input rendering behind an explicit surface guard

## Why

The Fast core can now treat Slack and Discord as adapters, but delegated tasks still persisted their parent as Slack coordinates and the lifecycle coordinator contained Slack delivery inline. This stacked refactor removes that coupling and leaves an explicit surface adapter seam for adding Discord lifecycle delivery without changing the orchestration loop again.

This is stacked on #1452. Discord parent stamping and delivery are intentionally the next follow-up; this PR makes that addition isolated instead of mixing it into the contract migration.

## Validation

- `@roomote/types`: 55 files, 849 tests
- `@roomote/cloud-agents`: 95 files, 769 tests
- `@roomote/slack`: 38 files, 402 tests
- `@roomote/sdk`: 99 files, 996 tests
- affected Worker suites: 2 files, 24 tests
- `pnpm lint:fast`
- `pnpm check-types:fast`
- `pnpm knip`

The full Worker suite reached 1,747/1,748 tests; the unrelated `tail-file-path.test.ts` symlink assertion failed outside this diff. The affected Worker suites pass.
