### PR TITLE
[Refactor] Generalize Fast conversation routing for Discord

### DIFF
--- a/apps/api/src/handlers/discord/__tests__/channel-auto-start.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/channel-auto-start.test.ts
@@ -57,6 +57,11 @@ vi.mock('../attachments.js', () => ({
 }));
 
 vi.mock('../fast-agent.js', () => ({
+  getDiscordFastConversationId: (
+    channel: DiscordChannelContext,
+    eventId: string,
+  ) =>
+    channel.isDirectMessage || channel.isThread ? channel.channelId : eventId,
   processDiscordFastAgentMessage: mocks.processFast,
 }));
 
@@ -213,7 +218,7 @@ describe('maybeHandleDiscordChannelAutoStart', () => {
       expect.objectContaining({
         question: 'The login page 500s on refresh',
         senderUserId: 'roomote-user-1',
-        sessionThreadId: 'message-1',
+        conversationId: 'message-1',
       }),
     );
     expect(mocks.evaluateGate).not.toHaveBeenCalled();

--- a/apps/api/src/handlers/discord/__tests__/index.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/index.test.ts
@@ -1986,6 +1986,15 @@ describe('Discord Gateway event handler', () => {
       expect.objectContaining({
         forceNewThread: true,
         fastAgentSessionId: '11111111-1111-4111-8111-111111111111',
+        fastAgentParent: {
+          sessionId: '11111111-1111-4111-8111-111111111111',
+          conversation: {
+            surface: 'discord',
+            workspaceId: 'dm',
+            channelId: 'dm-1',
+            threadId: 'interaction-fast',
+          },
+        },
         skipRoutingConfirmation: true,
         workspaceOverride: {
           repoForPayload: '__all_repositories__',

--- a/apps/api/src/handlers/discord/__tests__/index.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/index.test.ts
@@ -751,8 +751,8 @@ describe('Discord Gateway event handler', () => {
         conversation: {
           surface: 'discord',
           workspaceId: 'dm',
-          channelId: 'dm-1',
-          threadId: 'dm-1',
+          conversationId: 'dm-1',
+          replyTarget: { channelId: 'dm-1' },
         },
         activeTasks: [],
       }),
@@ -1245,8 +1245,8 @@ describe('Discord Gateway event handler', () => {
     expect(mocks.hasFastSession).toHaveBeenCalledWith({
       surface: 'discord',
       workspaceId: 'guild-1',
-      channelId: 'channel-1',
-      threadId: 'thread-1',
+      conversationId: 'thread-1',
+      replyTarget: { channelId: 'channel-1', threadId: 'thread-1' },
     });
     expect(mocks.shouldRouteUnmentioned).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1991,8 +1991,8 @@ describe('Discord Gateway event handler', () => {
           conversation: {
             surface: 'discord',
             workspaceId: 'dm',
-            channelId: 'dm-1',
-            threadId: 'interaction-fast',
+            conversationId: 'dm-1',
+            replyTarget: { channelId: 'dm-1' },
           },
         },
         skipRoutingConfirmation: true,
@@ -2011,6 +2011,100 @@ describe('Discord Gateway event handler', () => {
       expect.objectContaining({
         interaction: { interaction, interactionDeferred: true },
         text: 'Started task-17',
+      }),
+    );
+  });
+
+  it('keeps guild /fast session identity separate from its reply destination', async () => {
+    mocks.getChannel.mockResolvedValue({
+      id: 'channel-1',
+      name: 'general',
+      type: 0,
+      guildId: 'guild-1',
+    });
+    mocks.answerFast.mockImplementationOnce(async ({ adapter }) => {
+      await adapter.launchTask({
+        prompt: 'Investigate the flaky build',
+        environmentId: null,
+        parentSessionId: '11111111-1111-4111-8111-111111111111',
+      });
+      return 'Started';
+    });
+    const interaction = {
+      id: 'interaction-fast-guild',
+      application_id: 'app-1',
+      type: 2,
+      token: 'interaction-token',
+      channel_id: 'channel-1',
+      guild_id: 'guild-1',
+      member: {
+        user: { id: 'discord-user-1', username: 'matt' },
+      },
+      data: {
+        name: 'fast',
+        type: 1,
+        options: [{ name: 'request', type: 3, value: 'Fix the flaky build' }],
+      },
+    };
+
+    const response = await postEvent(
+      envelope(interaction, 'INTERACTION_CREATE'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.startNewTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fastAgentParent: {
+          sessionId: '11111111-1111-4111-8111-111111111111',
+          conversation: {
+            surface: 'discord',
+            workspaceId: 'guild-1',
+            conversationId: 'interaction-fast-guild',
+            replyTarget: { channelId: 'channel-1' },
+          },
+        },
+      }),
+    );
+  });
+
+  it('reuses the durable guild thread as the /fast conversation', async () => {
+    mocks.getChannel.mockResolvedValue({
+      id: 'thread-1',
+      name: 'investigation',
+      type: 11,
+      guildId: 'guild-1',
+      parentId: 'channel-1',
+    });
+    const interaction = {
+      id: 'interaction-fast-thread',
+      application_id: 'app-1',
+      type: 2,
+      token: 'interaction-token',
+      channel_id: 'thread-1',
+      guild_id: 'guild-1',
+      member: {
+        user: { id: 'discord-user-1', username: 'matt' },
+      },
+      data: {
+        name: 'fast',
+        type: 1,
+        options: [{ name: 'request', type: 3, value: 'What changed?' }],
+      },
+    };
+
+    const response = await postEvent(
+      envelope(interaction, 'INTERACTION_CREATE'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.answerFast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversation: {
+          surface: 'discord',
+          workspaceId: 'guild-1',
+          conversationId: 'thread-1',
+          replyTarget: { channelId: 'channel-1', threadId: 'thread-1' },
+        },
       }),
     );
   });

--- a/apps/api/src/handlers/discord/__tests__/task-launch.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/task-launch.test.ts
@@ -1009,6 +1009,7 @@ describe('launchDiscordTask', () => {
         task: expect.objectContaining({
           payload: expect.objectContaining({
             communicationThreadId: 'new-thread',
+            communicationContextInherited: true,
             fastAgentSessionId: '11111111-1111-4111-8111-111111111111',
             fastAgentParent: {
               sessionId: '11111111-1111-4111-8111-111111111111',

--- a/apps/api/src/handlers/discord/__tests__/task-launch.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/task-launch.test.ts
@@ -995,8 +995,8 @@ describe('launchDiscordTask', () => {
         conversation: {
           surface: 'discord',
           workspaceId: 'guild-1',
-          channelId: 'channel-1',
-          threadId: 'old-thread',
+          conversationId: 'old-thread',
+          replyTarget: { channelId: 'channel-1', threadId: 'old-thread' },
         },
       },
     });
@@ -1015,8 +1015,11 @@ describe('launchDiscordTask', () => {
               conversation: {
                 surface: 'discord',
                 workspaceId: 'guild-1',
-                channelId: 'channel-1',
-                threadId: 'old-thread',
+                conversationId: 'old-thread',
+                replyTarget: {
+                  channelId: 'channel-1',
+                  threadId: 'old-thread',
+                },
               },
             },
           }),

--- a/apps/api/src/handlers/discord/__tests__/task-launch.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/task-launch.test.ts
@@ -990,6 +990,15 @@ describe('launchDiscordTask', () => {
       },
       forceNewThread: true,
       fastAgentSessionId: '11111111-1111-4111-8111-111111111111',
+      fastAgentParent: {
+        sessionId: '11111111-1111-4111-8111-111111111111',
+        conversation: {
+          surface: 'discord',
+          workspaceId: 'guild-1',
+          channelId: 'channel-1',
+          threadId: 'old-thread',
+        },
+      },
     });
 
     expect(provider.reserveTaskThread).toHaveBeenCalledWith(
@@ -1001,6 +1010,15 @@ describe('launchDiscordTask', () => {
           payload: expect.objectContaining({
             communicationThreadId: 'new-thread',
             fastAgentSessionId: '11111111-1111-4111-8111-111111111111',
+            fastAgentParent: {
+              sessionId: '11111111-1111-4111-8111-111111111111',
+              conversation: {
+                surface: 'discord',
+                workspaceId: 'guild-1',
+                channelId: 'channel-1',
+                threadId: 'old-thread',
+              },
+            },
           }),
         }),
       }),

--- a/apps/api/src/handlers/discord/channel-auto-start.ts
+++ b/apps/api/src/handlers/discord/channel-auto-start.ts
@@ -38,7 +38,10 @@ import {
   releaseAccountLinkDmSlot,
 } from './account-link.js';
 import { processDiscordAttachments } from './attachments.js';
-import { processDiscordFastAgentMessage } from './fast-agent.js';
+import {
+  getDiscordFastConversationId,
+  processDiscordFastAgentMessage,
+} from './fast-agent.js';
 import { rememberPendingDiscordAccountLinkTask } from './pending-account-link-task.js';
 import { startNewDiscordTask } from './task-orchestration.js';
 import {
@@ -293,7 +296,7 @@ export async function maybeHandleDiscordChannelAutoStart(input: {
           messageId: message.id,
           anchorMessageId: message.id,
         }),
-        sessionThreadId: message.id,
+        conversationId: getDiscordFastConversationId(channel, message.id),
       }).catch((error) => {
         apiLogger.error(
           `[DiscordChannelAutoStart] Failed to answer in Fast mode for ${logContext}: ${error instanceof Error ? error.message : String(error)}`,

--- a/apps/api/src/handlers/discord/fast-agent.ts
+++ b/apps/api/src/handlers/discord/fast-agent.ts
@@ -111,6 +111,10 @@ export async function processDiscordFastAgentMessage(input: {
           channel: input.channel,
           forceNewThread: true,
           fastAgentSessionId: parentSessionId,
+          fastAgentParent: {
+            sessionId: parentSessionId,
+            conversation,
+          },
           skipRoutingConfirmation: true,
           workspaceOverride,
         });

--- a/apps/api/src/handlers/discord/fast-agent.ts
+++ b/apps/api/src/handlers/discord/fast-agent.ts
@@ -23,6 +23,15 @@ type DiscordInteractionReplyContext = {
   interactionDeferred: boolean;
 };
 
+export function getDiscordFastConversationId(
+  channel: DiscordChannelContext,
+  eventId: string,
+): string {
+  return channel.isDirectMessage || channel.isThread
+    ? channel.channelId
+    : eventId;
+}
+
 export async function processDiscordFastAgentMessage(input: {
   event: DiscordGatewayEvent;
   question: string;
@@ -32,7 +41,7 @@ export async function processDiscordFastAgentMessage(input: {
   applicationId: string;
   channel: DiscordChannelContext;
   metadata: ReturnType<typeof discordMetadataForChannel>;
-  sessionThreadId: string;
+  conversationId: string;
   interaction?: DiscordInteractionReplyContext;
   activeTasks?: { taskId: string }[];
 }): Promise<void> {
@@ -51,8 +60,13 @@ export async function processDiscordFastAgentMessage(input: {
   const conversation = {
     surface: 'discord' as const,
     workspaceId: input.channel.guildId ?? 'dm',
-    channelId: input.metadata.communicationChannelId,
-    threadId: input.sessionThreadId,
+    conversationId: input.conversationId,
+    replyTarget: {
+      channelId: input.metadata.communicationChannelId,
+      ...(input.metadata.communicationThreadId
+        ? { threadId: input.metadata.communicationThreadId }
+        : {}),
+    },
   };
   const response = await answerFastAgentQuestion({
     question: input.question,

--- a/apps/api/src/handlers/discord/index.ts
+++ b/apps/api/src/handlers/discord/index.ts
@@ -69,7 +69,10 @@ import {
   handleDiscordSuggestionReaction,
 } from './callback-actions.js';
 import { maybeHandleDiscordChannelAutoStart } from './channel-auto-start.js';
-import { processDiscordFastAgentMessage } from './fast-agent.js';
+import {
+  getDiscordFastConversationId,
+  processDiscordFastAgentMessage,
+} from './fast-agent.js';
 import {
   claimPendingDiscordAccountLinkTask,
   rememberPendingDiscordAccountLinkTask,
@@ -582,8 +585,11 @@ async function processDiscordGatewayEvent(
     ? await hasFastAgentSession({
         surface: 'discord',
         workspaceId: channel.guildId ?? 'dm',
-        channelId: metadata.communicationChannelId,
-        threadId: channel.channelId,
+        conversationId: channel.channelId,
+        replyTarget: {
+          channelId: metadata.communicationChannelId,
+          threadId: channel.channelId,
+        },
       })
     : false;
   const isRoomoteThread = Boolean(
@@ -772,7 +778,10 @@ async function processDiscordGatewayEvent(
       applicationId: resolved.applicationId,
       channel,
       metadata,
-      sessionThreadId: interaction?.id ?? event.eventId,
+      conversationId: getDiscordFastConversationId(
+        channel,
+        interaction?.id ?? event.eventId,
+      ),
       interaction: interactionReplyContext(event),
     });
     return { ok: true, fastAnswered: true };
@@ -794,10 +803,10 @@ async function processDiscordGatewayEvent(
       applicationId: resolved.applicationId,
       channel,
       metadata,
-      sessionThreadId:
-        channel.isDirectMessage || channel.isThread
-          ? channel.channelId
-          : defaultFastMessage.id,
+      conversationId: getDiscordFastConversationId(
+        channel,
+        defaultFastMessage.id,
+      ),
       activeTasks: activeRun ? [{ taskId: activeRun.taskId }] : [],
     });
     return { ok: true, fastAnswered: true, fastDefaulted: true };

--- a/apps/api/src/handlers/discord/task-launch.ts
+++ b/apps/api/src/handlers/discord/task-launch.ts
@@ -1,5 +1,6 @@
 import {
   ALL_REPOSITORIES,
+  buildFastAgentChildTaskMetadata,
   TaskPayloadKind,
   type FastAgentParent,
   type QueuedCommunicationMessage,
@@ -455,12 +456,11 @@ export async function launchDiscordTask(input: {
           ? { images: input.queuedMessage.images }
           : {}),
         communicationProvider: 'discord',
-        ...(input.fastAgentSessionId
-          ? { fastAgentSessionId: input.fastAgentSessionId }
-          : {}),
         ...(input.fastAgentParent
-          ? { fastAgentParent: input.fastAgentParent }
-          : {}),
+          ? buildFastAgentChildTaskMetadata(input.fastAgentParent)
+          : input.fastAgentSessionId
+            ? { fastAgentSessionId: input.fastAgentSessionId }
+            : {}),
         communicationChannelId,
         ...(input.metadata.communicationGuildId
           ? { communicationGuildId: input.metadata.communicationGuildId }

--- a/apps/api/src/handlers/discord/task-launch.ts
+++ b/apps/api/src/handlers/discord/task-launch.ts
@@ -1,6 +1,7 @@
 import {
   ALL_REPOSITORIES,
   TaskPayloadKind,
+  type FastAgentParent,
   type QueuedCommunicationMessage,
   type TaskInitiator,
   type TaskSpec,
@@ -364,6 +365,7 @@ export async function launchDiscordTask(input: {
   /** `/new` in an existing task thread creates a sibling, never a second run in-place. */
   forceNewThread?: boolean;
   fastAgentSessionId?: string;
+  fastAgentParent?: FastAgentParent;
   /**
    * An already-posted message to turn into the acknowledgement instead of
    * posting a new one — a routing card sitting in the task thread becomes the
@@ -455,6 +457,9 @@ export async function launchDiscordTask(input: {
         communicationProvider: 'discord',
         ...(input.fastAgentSessionId
           ? { fastAgentSessionId: input.fastAgentSessionId }
+          : {}),
+        ...(input.fastAgentParent
+          ? { fastAgentParent: input.fastAgentParent }
           : {}),
         communicationChannelId,
         ...(input.metadata.communicationGuildId

--- a/apps/api/src/handlers/discord/task-orchestration.ts
+++ b/apps/api/src/handlers/discord/task-orchestration.ts
@@ -13,6 +13,7 @@ import type { DiscordCommunicationProvider } from '@roomote/communication/discor
 import { findDiscordInstallationByGuildId } from '@roomote/sdk/server';
 import {
   ALL_REPOSITORIES,
+  type FastAgentParent,
   type QueuedCommunicationMessage,
   type TaskInitiator,
 } from '@roomote/types';
@@ -102,6 +103,7 @@ export async function startNewDiscordTask(input: {
   };
   forceNewThread?: boolean;
   fastAgentSessionId?: string;
+  fastAgentParent?: FastAgentParent;
   workspaceOverride?: DiscordWorkspaceSelection;
   /**
    * True when the Discord intake path successfully pinned 👀 on the origin
@@ -369,6 +371,9 @@ export async function startNewDiscordTask(input: {
       forceNewThread: input.forceNewThread,
       ...(input.fastAgentSessionId
         ? { fastAgentSessionId: input.fastAgentSessionId }
+        : {}),
+      ...(input.fastAgentParent
+        ? { fastAgentParent: input.fastAgentParent }
         : {}),
       ...(kickoffMessage ? { kickoffMessage } : {}),
       ...(input.intakeAckPinned ? { intakeAckPinned: true } : {}),

--- a/apps/api/src/handlers/slack/events/fast-agent-processing.test.ts
+++ b/apps/api/src/handlers/slack/events/fast-agent-processing.test.ts
@@ -418,8 +418,8 @@ describe('processFastAgentMessage', () => {
         conversation: {
           surface: 'slack',
           workspaceId: 'T123',
-          channelId: 'D123',
-          threadId: '100.001',
+          conversationId: '100.001',
+          replyTarget: { channelId: 'D123', threadId: '100.001' },
         },
         senderDisplayName: 'Matt',
         senderExternalId: 'U123',
@@ -430,8 +430,8 @@ describe('processFastAgentMessage', () => {
       conversation: {
         surface: 'slack',
         workspaceId: 'T123',
-        channelId: 'D123',
-        threadId: '100.001',
+        conversationId: '100.001',
+        replyTarget: { channelId: 'D123', threadId: '100.001' },
       },
     });
     expect(mocks.postThreadMessage).toHaveBeenCalledOnce();

--- a/apps/api/src/handlers/slack/events/fast-agent.ts
+++ b/apps/api/src/handlers/slack/events/fast-agent.ts
@@ -72,8 +72,11 @@ export async function processFastAgentMessage(params: {
   const conversation = {
     surface: 'slack' as const,
     workspaceId: teamId,
-    channelId: event.channel,
-    threadId,
+    conversationId: threadId,
+    replyTarget: {
+      channelId: event.channel,
+      threadId,
+    },
   };
   const releaseFastAgentLock = await acquireFastAgentTurnLock({
     conversation,

--- a/apps/api/src/handlers/slack/events/message-entry-unmentioned-routing.test.ts
+++ b/apps/api/src/handlers/slack/events/message-entry-unmentioned-routing.test.ts
@@ -146,8 +146,8 @@ describe('shouldRouteUnmentionedSlackThreadReplyToAgent', () => {
     expect(hasFastAgentSessionMock).toHaveBeenCalledWith({
       surface: 'slack',
       workspaceId: 'T123',
-      channelId: 'C123',
-      threadId: THREAD_TS,
+      conversationId: THREAD_TS,
+      replyTarget: { channelId: 'C123', threadId: THREAD_TS },
     });
     expect(findRoomoteOwnedSlackThreadMock).not.toHaveBeenCalled();
   }, 15_000);

--- a/apps/api/src/handlers/slack/events/message-entry.ts
+++ b/apps/api/src/handlers/slack/events/message-entry.ts
@@ -503,8 +503,8 @@ export async function shouldRouteUnmentionedSlackThreadReplyToAgent(params: {
     isFastAgentThread = await hasFastAgentSession({
       surface: 'slack',
       workspaceId: teamId,
-      channelId: event.channel,
-      threadId: event.thread_ts,
+      conversationId: event.thread_ts,
+      replyTarget: { channelId: event.channel, threadId: event.thread_ts },
     });
 
     roomoteThreadMatch = isFastAgentThread
@@ -1764,8 +1764,8 @@ async function handleSlackEntryEvent(params: {
     : await hasFastAgentSession({
         surface: 'slack',
         workspaceId: teamId,
-        channelId: event.channel,
-        threadId,
+        conversationId: threadId,
+        replyTarget: { channelId: event.channel, threadId },
       });
 
   if (isFastAgentContinuation) {

--- a/apps/worker/src/callbacks/__tests__/communication-ack-reaction.test.ts
+++ b/apps/worker/src/callbacks/__tests__/communication-ack-reaction.test.ts
@@ -66,8 +66,8 @@ describe('getCommunicationRunTaskCallbacks ack reaction cleanup', () => {
         conversation: {
           surface: 'slack',
           workspaceId: 'T123',
-          channelId: 'C123',
-          threadId: '100.001',
+          conversationId: '100.001',
+          replyTarget: { channelId: 'C123', threadId: '100.001' },
         },
       },
     });

--- a/apps/worker/src/run-task/__tests__/mcp-task-env.test.ts
+++ b/apps/worker/src/run-task/__tests__/mcp-task-env.test.ts
@@ -126,6 +126,29 @@ describe('getCommunicationReplyContext', () => {
     });
   });
 
+  it('does not activate direct Discord replies for a Fast child task', () => {
+    const taskRun = {
+      payload: {
+        communicationProvider: 'discord',
+        communicationChannelId: 'channel-1',
+        communicationThreadId: 'child-thread-1',
+        communicationContextInherited: true,
+        fastAgentParent: {
+          sessionId: '11111111-1111-4111-8111-111111111111',
+          conversation: {
+            surface: 'discord',
+            workspaceId: 'guild-1',
+            conversationId: 'interaction-1',
+            replyTarget: { channelId: 'channel-1' },
+          },
+        },
+      },
+    };
+
+    expect(getCommunicationReplyContext(taskRun)).toBeNull();
+    expect(isFastAgentChildTaskRun(taskRun)).toBe(true);
+  });
+
   it('does not activate inherited provider-neutral source context', () => {
     expect(
       getCommunicationReplyContext({

--- a/apps/worker/src/run-task/__tests__/mcp-task-env.test.ts
+++ b/apps/worker/src/run-task/__tests__/mcp-task-env.test.ts
@@ -66,8 +66,8 @@ describe('getCommunicationReplyContext', () => {
           conversation: {
             surface: 'slack',
             workspaceId: 'T123',
-            channelId: 'C123',
-            threadId: '111.222',
+            conversationId: '111.222',
+            replyTarget: { channelId: 'C123', threadId: '111.222' },
           },
         },
       },

--- a/packages/cloud-agents/src/server/__tests__/enqueue-task.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/enqueue-task.test.ts
@@ -973,8 +973,8 @@ describe('enqueueTask snapshot resume', () => {
       conversation: {
         surface: 'slack' as const,
         workspaceId: 'T123',
-        channelId: 'C123',
-        threadId: '111.222',
+        conversationId: '111.222',
+        replyTarget: { channelId: 'C123', threadId: '111.222' },
       },
     };
     const freshRun = await launchFresh({
@@ -1060,8 +1060,8 @@ describe('enqueueTask snapshot resume', () => {
       conversation: {
         surface: 'slack' as const,
         workspaceId: 'T123',
-        channelId: 'C123',
-        threadId: '333.444',
+        conversationId: '333.444',
+        replyTarget: { channelId: 'C123', threadId: '333.444' },
       },
     };
     const freshRun = await launchFresh({

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-active-tasks.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-active-tasks.test.ts
@@ -159,8 +159,8 @@ describe('getActiveFastAgentTasks', () => {
         conversation: {
           surface: 'slack',
           workspaceId: 'T123',
-          channelId: 'C123',
-          threadId: '111.222',
+          conversationId: '111.222',
+          replyTarget: { channelId: 'C123', threadId: '111.222' },
         },
       },
     });

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-integration-broker.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-integration-broker.test.ts
@@ -61,8 +61,8 @@ const auditContext = {
   conversation: {
     surface: 'slack' as const,
     workspaceId: 'team-1',
-    channelId: 'channel-1',
-    threadId: '100.1',
+    conversationId: '100.1',
+    replyTarget: { channelId: 'channel-1', threadId: '100.1' },
   },
   messageId: '100.2',
 };

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -58,8 +58,8 @@ const baseParams = {
   conversation: {
     surface: 'slack' as const,
     workspaceId: 'team-1',
-    channelId: 'channel-1',
-    threadId: '100.1',
+    conversationId: '100.1',
+    replyTarget: { channelId: 'channel-1', threadId: '100.1' },
   },
   currentMessageId: '100.2',
   senderDisplayName: 'Matt',

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-session.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-session.test.ts
@@ -6,13 +6,15 @@ describe('fast-agent session scoping', () => {
       buildFastAgentSessionChannelKey({
         surface: 'slack',
         workspaceId: 'team-1',
-        channelId: 'channel-1',
+        conversationId: 'thread-1',
+        replyTarget: { channelId: 'channel-1', threadId: 'thread-1' },
       }),
     ).not.toBe(
       buildFastAgentSessionChannelKey({
         surface: 'slack',
         workspaceId: 'team-2',
-        channelId: 'channel-1',
+        conversationId: 'thread-1',
+        replyTarget: { channelId: 'channel-1', threadId: 'thread-1' },
       }),
     );
   });
@@ -22,7 +24,8 @@ describe('fast-agent session scoping', () => {
       buildFastAgentSessionChannelKey({
         surface: 'discord',
         workspaceId: 'guild-1',
-        channelId: 'channel-1',
+        conversationId: 'interaction-1',
+        replyTarget: { channelId: 'channel-1' },
       }),
     ).toBe('discord:guild-1:channel-1');
   });

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-task-launcher.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-task-launcher.test.ts
@@ -89,8 +89,11 @@ describe('createFastAgentSlackTaskLauncher', () => {
               conversation: {
                 surface: 'slack',
                 workspaceId: 'T123',
-                channelId: 'C123',
-                threadId: '100.001',
+                conversationId: '100.001',
+                replyTarget: {
+                  channelId: 'C123',
+                  threadId: '100.001',
+                },
               },
             },
             environmentId: 'env-1',

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-integration-broker.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-integration-broker.ts
@@ -254,8 +254,8 @@ export async function callFastAgentIntegration(
     slackTeamId: getFastAgentConversationStorageWorkspaceId(
       context.conversation,
     ),
-    slackChannel: context.conversation.channelId,
-    slackThreadTs: context.conversation.threadId,
+    slackChannel: context.conversation.replyTarget.channelId,
+    slackThreadTs: context.conversation.conversationId,
     slackMessageTs: context.messageId,
     integrationId: integration.id,
     toolName: request.toolName,

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -612,7 +612,7 @@ export async function answerFastAgentQuestion({
             apiBaseUrl,
             sessionId: session.id,
             conversation,
-            messageId: currentMessageId ?? conversation.threadId,
+            messageId: currentMessageId ?? conversation.conversationId,
           },
           availableIntegrations,
           {
@@ -747,7 +747,7 @@ export async function answerFastAgentQuestion({
         await postReaction({
           name,
           purpose,
-          messageId: currentMessageId ?? conversation.threadId,
+          messageId: currentMessageId ?? conversation.conversationId,
         });
         turnSessionMessages.push(
           buildAssistantTextMessage(`[Reacted with :${name}:]`),
@@ -803,7 +803,7 @@ export async function answerFastAgentQuestion({
                 apiBaseUrl,
                 sessionId: session.id,
                 conversation,
-                messageId: currentMessageId ?? conversation.threadId,
+                messageId: currentMessageId ?? conversation.conversationId,
               },
               availableIntegrations,
               {

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-session.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-session.ts
@@ -29,30 +29,20 @@ export type FastAgentActiveTask = {
 };
 
 function buildFastAgentSessionWhere(conversation: FastAgentConversation) {
-  const scopedSlackChannel = buildFastAgentSessionChannelKey({
-    surface: conversation.surface,
-    workspaceId: conversation.workspaceId,
-    channelId: conversation.channelId,
-  });
+  const scopedSlackChannel = buildFastAgentSessionChannelKey(conversation);
 
   return and(
     eq(slackQuickAnswers.slackChannel, scopedSlackChannel),
-    eq(slackQuickAnswers.slackThreadTs, conversation.threadId),
+    eq(slackQuickAnswers.slackThreadTs, conversation.conversationId),
   );
 }
 
-export function buildFastAgentSessionChannelKey({
-  surface,
-  workspaceId,
-  channelId,
-}: {
-  surface: FastAgentConversation['surface'];
-  workspaceId: string;
-  channelId: string;
-}): string {
+export function buildFastAgentSessionChannelKey(
+  conversation: FastAgentConversation,
+): string {
   // The existing column and unique index predate multi-workspace scoping.
   // Qualifying the value keeps N-1 rollback compatibility without a migration.
-  return `${getFastAgentConversationStorageWorkspaceId({ surface, workspaceId })}:${channelId}`;
+  return `${getFastAgentConversationStorageWorkspaceId(conversation)}:${conversation.replyTarget.channelId}`;
 }
 
 export async function getOrCreateFastAgentSession({
@@ -63,11 +53,7 @@ export async function getOrCreateFastAgentSession({
   conversation: FastAgentConversation;
 }): Promise<FastAgentSessionRecord> {
   const where = buildFastAgentSessionWhere(conversation);
-  const scopedSlackChannel = buildFastAgentSessionChannelKey({
-    surface: conversation.surface,
-    workspaceId: conversation.workspaceId,
-    channelId: conversation.channelId,
-  });
+  const scopedSlackChannel = buildFastAgentSessionChannelKey(conversation);
 
   const existingSession = await db.query.slackQuickAnswers.findFirst({
     where,
@@ -89,7 +75,7 @@ export async function getOrCreateFastAgentSession({
     .values({
       userId,
       slackChannel: scopedSlackChannel,
-      slackThreadTs: conversation.threadId,
+      slackThreadTs: conversation.conversationId,
       messages: [],
     })
     .onConflictDoNothing({

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-task-launcher.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-task-launcher.ts
@@ -1,5 +1,6 @@
 import {
   ALL_REPOSITORIES,
+  buildFastAgentChildTaskMetadata,
   TaskPayloadKind,
   type FastAgentSurface,
   type StandardTask,
@@ -81,9 +82,7 @@ export function createFastAgentSlackTaskLauncher(params: {
         ...(params.messageId
           ? { communicationMessageId: params.messageId }
           : {}),
-        communicationContextInherited: true,
-        fastAgentSessionId: parentSessionId,
-        fastAgentParent: {
+        ...buildFastAgentChildTaskMetadata({
           sessionId: parentSessionId,
           conversation: {
             surface: 'slack',
@@ -94,7 +93,7 @@ export function createFastAgentSlackTaskLauncher(params: {
               threadId: params.threadTs,
             },
           },
-        },
+        }),
         ...(environmentId && environmentId !== ALL_REPOSITORIES
           ? { environmentId }
           : {}),

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-task-launcher.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-task-launcher.ts
@@ -1,12 +1,58 @@
 import {
   ALL_REPOSITORIES,
   TaskPayloadKind,
+  type FastAgentSurface,
   type StandardTask,
 } from '@roomote/types';
 
 import { enqueueTask } from '../task-run-queue';
 import { getTaskUrl } from '../task-url';
 import type { LaunchFastAgentTask } from './fast-agent-conversation';
+
+export function createFastAgentTaskLauncher(params: {
+  userId: string;
+  surface: FastAgentSurface;
+  taskUrlCampaign: string;
+  buildTask: (input: {
+    prompt: string;
+    environmentId: string | null;
+    parentSessionId: string;
+  }) => StandardTask | Promise<StandardTask>;
+}): LaunchFastAgentTask {
+  return async ({ prompt, environmentId, parentSessionId, postKickoff }) => {
+    const task = await params.buildTask({
+      prompt,
+      environmentId,
+      parentSessionId,
+    });
+    let taskUrl: string | undefined;
+    const launch = await enqueueTask(
+      {
+        task,
+        initiator: { kind: 'user', userId: params.userId },
+        workflow: 'standard',
+        surface: params.surface,
+        trigger: 'message',
+      },
+      {
+        beforeEnqueue: async (taskRun) => {
+          taskUrl = getTaskUrl({
+            taskId: taskRun.taskId,
+            utm: {
+              source: params.surface,
+              campaign: params.taskUrlCampaign,
+            },
+          });
+          await postKickoff({ taskId: taskRun.taskId, taskUrl });
+        },
+      },
+    );
+
+    return launch.taskId
+      ? { success: true, taskId: launch.taskId, taskUrl }
+      : { success: false, error: 'The task launch did not return a task ID.' };
+  };
+}
 
 export function createFastAgentSlackTaskLauncher(params: {
   userId: string;
@@ -16,8 +62,11 @@ export function createFastAgentSlackTaskLauncher(params: {
   threadTs: string;
   messageId?: string;
 }): LaunchFastAgentTask {
-  return async ({ prompt, environmentId, parentSessionId, postKickoff }) => {
-    const task: StandardTask = {
+  return createFastAgentTaskLauncher({
+    userId: params.userId,
+    surface: 'slack',
+    taskUrlCampaign: 'fast-delegation',
+    buildTask: ({ prompt, environmentId, parentSessionId }) => ({
       type: TaskPayloadKind.StandardTask,
       payload: {
         repo: ALL_REPOSITORIES,
@@ -39,46 +88,17 @@ export function createFastAgentSlackTaskLauncher(params: {
           conversation: {
             surface: 'slack',
             workspaceId: params.teamId,
-            channelId: params.channelId,
-            threadId: params.threadTs,
+            conversationId: params.threadTs,
+            replyTarget: {
+              channelId: params.channelId,
+              threadId: params.threadTs,
+            },
           },
         },
         ...(environmentId && environmentId !== ALL_REPOSITORIES
           ? { environmentId }
           : {}),
       },
-    };
-    let taskUrl: string | undefined;
-    const launch = await enqueueTask(
-      {
-        task,
-        initiator: { kind: 'user', userId: params.userId },
-        workflow: 'standard',
-        surface: 'slack',
-        trigger: 'message',
-      },
-      {
-        beforeEnqueue: async (taskRun) => {
-          taskUrl = getTaskUrl({
-            taskId: taskRun.taskId,
-            utm: { source: 'slack', campaign: 'fast-delegation' },
-          });
-          await postKickoff({ taskId: taskRun.taskId, taskUrl });
-        },
-      },
-    );
-
-    if (!launch.taskId) {
-      return {
-        success: false,
-        error: 'The task launch did not return a task ID.',
-      };
-    }
-
-    return {
-      success: true,
-      taskId: launch.taskId,
-      taskUrl,
-    };
-  };
+    }),
+  });
 }

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-turn-lock.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-turn-lock.ts
@@ -19,11 +19,11 @@ export async function acquireFastAgentTurnLock(params: {
    * user-feedback path can fail fast instead of blocking their context. */
   maxWaitMs?: number;
 }) {
-  const { channelId, threadId } = params.conversation;
+  const { conversationId, replyTarget } = params.conversation;
   const storageWorkspaceId = getFastAgentConversationStorageWorkspaceId(
     params.conversation,
   );
-  const key = `${FAST_AGENT_TURN_LOCK_PREFIX}${storageWorkspaceId}:${channelId}:${threadId}`;
+  const key = `${FAST_AGENT_TURN_LOCK_PREFIX}${storageWorkspaceId}:${replyTarget.channelId}:${conversationId}`;
   const maxAttempts =
     params.maxWaitMs === undefined
       ? FAST_AGENT_TURN_LOCK_MAX_ATTEMPTS

--- a/packages/communication/src/__tests__/discord-provider.test.ts
+++ b/packages/communication/src/__tests__/discord-provider.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { MockDiscordServer } from '../mock-discord-server';
 import {
+  buildDiscordMessageNonce,
   chunkDiscordMessage,
   DiscordApiTransportError,
   DiscordCommunicationProvider,
@@ -23,6 +24,31 @@ function createHarness(options: { nonceFactory?: () => string } = {}) {
 }
 
 describe('DiscordCommunicationProvider', () => {
+  it('deduplicates the same logical send across provider instances', async () => {
+    const server = new MockDiscordServer();
+    const createProvider = () =>
+      new DiscordCommunicationProvider({
+        botToken: server.botToken,
+        applicationId: server.application.id,
+        apiBaseUrl: 'https://discord.example.test/api/v10',
+        fetch: server.fetch as typeof fetch,
+      });
+    const input = {
+      channelId: '400000000000000001',
+      text: 'Task finished.',
+      idempotencyKey: 'fast-parent-settle:42',
+    };
+
+    const first = await createProvider().postMessage(input);
+    const retried = await createProvider().postMessage(input);
+
+    expect(retried.messageId).toBe(first.messageId);
+    expect(server.state.messages[input.channelId]).toHaveLength(1);
+    expect(server.state.messages[input.channelId]?.[0]?.nonce).toBe(
+      buildDiscordMessageNonce(input.idempotencyKey),
+    );
+  });
+
   it('chunks messages at 2000 characters and disables every allowed mention', async () => {
     const nonces = ['123456789012345678', '123456789012345679'];
     const { server, provider } = createHarness({

--- a/packages/communication/src/discord-provider.ts
+++ b/packages/communication/src/discord-provider.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import type {
   CommunicationChannelMessagesResult,
   CommunicationMessage,
@@ -15,6 +17,17 @@ const DEFAULT_DISCORD_API_BASE_URL = 'https://discord.com/api/v10';
 const DEFAULT_DISCORD_TIMEOUT_MS = 10_000;
 const DEFAULT_DISCORD_MAX_RETRIES = 2;
 const DISCORD_RETRY_BASE_DELAY_MS = 250;
+
+/** Discord accepts string nonces up to an unsigned 64-bit integer. */
+export function buildDiscordMessageNonce(
+  idempotencyKey: string,
+  partIndex = 0,
+): string {
+  const digest = createHash('sha256')
+    .update(`${idempotencyKey}:${partIndex}`)
+    .digest();
+  return digest.readBigUInt64BE(0).toString();
+}
 
 export type DiscordCommunicationProviderOptions = {
   botToken: string;
@@ -531,7 +544,9 @@ export class DiscordCommunicationProvider implements CommunicationProviderAdapte
     let lastTextMessage: DiscordApiMessage | null = null;
 
     for (let index = 0; index < batchCount; index += 1) {
-      const nonce = this.nonceFactory();
+      const nonce = input.idempotencyKey
+        ? buildDiscordMessageNonce(input.idempotencyKey, index)
+        : this.nonceFactory();
       const imageGroup = imageGroups[index] ?? [];
       const body = {
         ...(textChunks[index] ? { content: textChunks[index] } : {}),

--- a/packages/communication/src/provider.ts
+++ b/packages/communication/src/provider.ts
@@ -36,6 +36,8 @@ export type CommunicationMessageButton = {
 export type CommunicationPostMessageInput = {
   channelId: string;
   threadId?: string;
+  /** Stable logical-send key used by providers that support deduplication. */
+  idempotencyKey?: string;
   text?: string;
   blocks?: unknown[];
   images?: Array<{ url: string; altText: string; contentType?: string }>;

--- a/packages/sdk/src/server/lib/artifacts/__tests__/notify-fast-agent-parent.test.ts
+++ b/packages/sdk/src/server/lib/artifacts/__tests__/notify-fast-agent-parent.test.ts
@@ -65,8 +65,8 @@ const fastParent = {
   conversation: {
     surface: 'slack' as const,
     workspaceId: 'T123',
-    channelId: 'C123',
-    threadId: '100.001',
+    conversationId: '100.001',
+    replyTarget: { channelId: 'C123', threadId: '100.001' },
   },
 };
 

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
@@ -22,16 +22,39 @@ vi.mock('@roomote/cloud-agents/server', () => ({
   buildFastAgentSessionChannelKey: ({
     surface,
     workspaceId,
-    channelId,
+    replyTarget,
   }: {
     surface: string;
     workspaceId: string;
-    channelId: string;
+    replyTarget: { channelId: string };
   }) =>
-    `${surface === 'slack' ? workspaceId : `${surface}:${workspaceId}`}:${channelId}`,
+    `${surface === 'slack' ? workspaceId : `${surface}:${workspaceId}`}:${replyTarget.channelId}`,
   createFastAgentSlackTaskLauncher: mocks.createLauncher,
-  enqueueTask: mocks.enqueueTask,
-  getTaskUrl: mocks.getTaskUrl,
+  createFastAgentTaskLauncher:
+    ({
+      buildTask,
+    }: {
+      buildTask: (input: {
+        prompt: string;
+        environmentId: string | null;
+        parentSessionId: string;
+      }) => unknown | Promise<unknown>;
+    }) =>
+    async (input: {
+      prompt: string;
+      environmentId: string | null;
+      parentSessionId: string;
+      postKickoff: (task: {
+        taskId: string;
+        taskUrl?: string;
+      }) => Promise<void>;
+    }) => {
+      const task = await buildTask(input);
+      const taskUrl = mocks.getTaskUrl();
+      await input.postKickoff({ taskId: 'child-task-1', taskUrl });
+      await mocks.enqueueTask({ task });
+      return { success: true, taskId: 'child-task-1', taskUrl };
+    },
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -90,8 +113,8 @@ const parent = {
   conversation: {
     surface: 'slack' as const,
     workspaceId: 'T123',
-    channelId: 'C123',
-    threadId: '100.001',
+    conversationId: '100.001',
+    replyTarget: { channelId: 'C123', threadId: '100.001' },
   },
 };
 
@@ -184,8 +207,8 @@ describe('deliverFastAgentParentEvent', () => {
       conversation: {
         surface: 'slack' as const,
         workspaceId: 'T123',
-        channelId: 'C123',
-        threadId: '100.001',
+        conversationId: '100.001',
+        replyTarget: { channelId: 'C123', threadId: '100.001' },
       },
     });
     expect(mocks.answerQuestion).toHaveBeenCalledWith(
@@ -228,14 +251,14 @@ describe('deliverFastAgentParentEvent', () => {
     expect(mocks.answerQuestion).not.toHaveBeenCalled();
   });
 
-  it('delivers the same parent event into a Discord Fast conversation', async () => {
+  it('delivers a guild parent event to its routable channel, not its session identity', async () => {
     const discordParent = {
       ...parent,
       conversation: {
         surface: 'discord' as const,
         workspaceId: 'guild-1',
-        channelId: 'channel-1',
-        threadId: 'thread-1',
+        conversationId: 'interaction-fast-guild',
+        replyTarget: { channelId: 'channel-1' },
       },
     };
 
@@ -245,7 +268,7 @@ describe('deliverFastAgentParentEvent', () => {
 
     expect(mocks.discordPostMessage).toHaveBeenCalledWith({
       channelId: 'channel-1',
-      threadId: 'thread-1',
+      idempotencyKey: 'fast-parent-artifact:artifact-1:v1',
       text: 'The proof is ready.',
       textFormat: 'markdown',
       images: [
@@ -257,6 +280,28 @@ describe('deliverFastAgentParentEvent', () => {
       ],
     });
     expect(mocks.releaseTurnLock).toHaveBeenCalledOnce();
+  });
+
+  it('delivers a threaded Discord parent event inside the provider thread', async () => {
+    await deliverFastAgentParentEvent({
+      parent: {
+        ...parent,
+        conversation: {
+          surface: 'discord',
+          workspaceId: 'guild-1',
+          conversationId: 'thread-1',
+          replyTarget: { channelId: 'channel-1', threadId: 'thread-1' },
+        },
+      },
+      event,
+    });
+
+    expect(mocks.discordPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: 'channel-1',
+        threadId: 'thread-1',
+      }),
+    );
   });
 
   it('keeps launch_task available during a Discord parent event', async () => {
@@ -281,8 +326,8 @@ describe('deliverFastAgentParentEvent', () => {
         conversation: {
           surface: 'discord',
           workspaceId: 'guild-1',
-          channelId: 'channel-1',
-          threadId: 'thread-1',
+          conversationId: 'thread-1',
+          replyTarget: { channelId: 'channel-1', threadId: 'thread-1' },
         },
       },
       event,
@@ -303,14 +348,16 @@ describe('deliverFastAgentParentEvent', () => {
               conversation: {
                 surface: 'discord',
                 workspaceId: 'guild-1',
-                channelId: 'channel-1',
-                threadId: 'thread-1',
+                conversationId: 'thread-1',
+                replyTarget: {
+                  channelId: 'channel-1',
+                  threadId: 'thread-1',
+                },
               },
             },
           }),
         }),
       }),
-      expect.any(Object),
     );
     expect(postKickoff).toHaveBeenCalledWith({
       taskId: 'child-task-1',

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
@@ -9,12 +9,29 @@ const mocks = vi.hoisted(() => ({
   findArtifacts: vi.fn(),
   findTaskRun: vi.fn(),
   postMessage: vi.fn(),
+  createDiscordProvider: vi.fn(),
+  discordPostMessage: vi.fn(),
+  createDiscordThread: vi.fn(),
+  enqueueTask: vi.fn(),
+  getTaskUrl: vi.fn(),
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
   acquireFastAgentTurnLock: mocks.acquireTurnLock,
   answerFastAgentQuestion: mocks.answerQuestion,
+  buildFastAgentSessionChannelKey: ({
+    surface,
+    workspaceId,
+    channelId,
+  }: {
+    surface: string;
+    workspaceId: string;
+    channelId: string;
+  }) =>
+    `${surface === 'slack' ? workspaceId : `${surface}:${workspaceId}`}:${channelId}`,
   createFastAgentSlackTaskLauncher: mocks.createLauncher,
+  enqueueTask: mocks.enqueueTask,
+  getTaskUrl: mocks.getTaskUrl,
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -59,6 +76,11 @@ vi.mock('./artifacts/raw-url', () => ({
       `https://api.roomote.example/api/artifacts/${artifactId}/raw?signed=1`,
   ),
   currentEpochSeconds: vi.fn(() => 1234),
+}));
+
+vi.mock('./discord-communication', () => ({
+  createDiscordCommunicationProviderFromRuntimeCredentials:
+    mocks.createDiscordProvider,
 }));
 
 import { deliverFastAgentParentEvent } from './fast-agent-parent-event';
@@ -110,6 +132,37 @@ describe('deliverFastAgentParentEvent', () => {
     ]);
     mocks.findTaskRun.mockResolvedValue({ status: 'running' });
     mocks.postMessage.mockResolvedValue('101.001');
+    mocks.discordPostMessage.mockResolvedValue({
+      provider: 'discord',
+      channelId: 'channel-1',
+      threadId: 'thread-1',
+      messageId: 'message-1',
+    });
+    mocks.createDiscordThread.mockResolvedValue({
+      channelId: 'child-thread-1',
+      parentChannelId: 'channel-1',
+      messageId: 'child-message-1',
+      name: 'Child task',
+      kind: 'thread',
+    });
+    mocks.createDiscordProvider.mockResolvedValue({
+      postMessage: mocks.discordPostMessage,
+      createTaskThread: mocks.createDiscordThread,
+    });
+    mocks.getTaskUrl.mockReturnValue(
+      'https://roomote.example/task/child-task-1',
+    );
+    mocks.enqueueTask.mockImplementation(
+      async (
+        _input: unknown,
+        options?: {
+          beforeEnqueue?: (run: { taskId: string }) => Promise<void>;
+        },
+      ) => {
+        await options?.beforeEnqueue?.({ taskId: 'child-task-1' });
+        return { taskId: 'child-task-1' };
+      },
+    );
     mocks.answerQuestion.mockImplementation(
       async ({
         adapter,
@@ -175,8 +228,54 @@ describe('deliverFastAgentParentEvent', () => {
     expect(mocks.answerQuestion).not.toHaveBeenCalled();
   });
 
-  it('fails permanently when the parent surface has no delivery adapter', async () => {
-    const delivery = deliverFastAgentParentEvent({
+  it('delivers the same parent event into a Discord Fast conversation', async () => {
+    const discordParent = {
+      ...parent,
+      conversation: {
+        surface: 'discord' as const,
+        workspaceId: 'guild-1',
+        channelId: 'channel-1',
+        threadId: 'thread-1',
+      },
+    };
+
+    await expect(
+      deliverFastAgentParentEvent({ parent: discordParent, event }),
+    ).resolves.toBe('delivered');
+
+    expect(mocks.discordPostMessage).toHaveBeenCalledWith({
+      channelId: 'channel-1',
+      threadId: 'thread-1',
+      text: 'The proof is ready.',
+      textFormat: 'markdown',
+      images: [
+        {
+          url: 'https://api.roomote.example/api/artifacts/artifact-1/raw?signed=1',
+          altText: 'result.png',
+          contentType: 'image/png',
+        },
+      ],
+    });
+    expect(mocks.releaseTurnLock).toHaveBeenCalledOnce();
+  });
+
+  it('keeps launch_task available during a Discord parent event', async () => {
+    const postKickoff = vi.fn().mockResolvedValue(undefined);
+    mocks.answerQuestion.mockImplementationOnce(
+      async ({
+        adapter,
+      }: {
+        adapter: { launchTask: (input: unknown) => unknown };
+      }) =>
+        adapter.launchTask({
+          prompt: 'Fix the follow-up regression',
+          environmentId: null,
+          parentSessionId: parent.sessionId,
+          postKickoff,
+        }),
+    );
+
+    await deliverFastAgentParentEvent({
       parent: {
         ...parent,
         conversation: {
@@ -189,13 +288,34 @@ describe('deliverFastAgentParentEvent', () => {
       event,
     });
 
-    await expect(delivery).rejects.toMatchObject({
-      replyPosted: false,
-      permanent: true,
+    expect(mocks.createDiscordThread).toHaveBeenCalledWith(
+      expect.objectContaining({ channelId: 'channel-1' }),
+    );
+    expect(mocks.enqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            communicationProvider: 'discord',
+            communicationThreadId: 'child-thread-1',
+            fastAgentSessionId: parent.sessionId,
+            fastAgentParent: {
+              sessionId: parent.sessionId,
+              conversation: {
+                surface: 'discord',
+                workspaceId: 'guild-1',
+                channelId: 'channel-1',
+                threadId: 'thread-1',
+              },
+            },
+          }),
+        }),
+      }),
+      expect.any(Object),
+    );
+    expect(postKickoff).toHaveBeenCalledWith({
+      taskId: 'child-task-1',
+      taskUrl: 'https://roomote.example/task/child-task-1',
     });
-    expect(mocks.findSession).not.toHaveBeenCalled();
-    expect(mocks.answerQuestion).not.toHaveBeenCalled();
-    expect(mocks.releaseTurnLock).toHaveBeenCalledOnce();
   });
 
   it('delivers a pull request event with a stable Slack idempotency key', async () => {

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
@@ -342,6 +342,7 @@ describe('deliverFastAgentParentEvent', () => {
           payload: expect.objectContaining({
             communicationProvider: 'discord',
             communicationThreadId: 'child-thread-1',
+            communicationContextInherited: true,
             fastAgentSessionId: parent.sessionId,
             fastAgentParent: {
               sessionId: parent.sessionId,

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.ts
@@ -27,6 +27,7 @@ import { Env, getArtifactSigningKey } from '@roomote/env';
 import { SlackNotifier } from '@roomote/slack';
 import {
   ALL_REPOSITORIES,
+  buildFastAgentChildTaskMetadata,
   TaskPayloadKind,
   exitedRunStatuses,
   type FastAgentConversation,
@@ -353,11 +354,10 @@ function createFastAgentDiscordTaskLauncher(params: {
             ? {}
             : { communicationGuildId: params.conversation.workspaceId }),
           ...(thread ? { discordTaskThread: true } : {}),
-          fastAgentSessionId: parentSessionId,
-          fastAgentParent: {
+          ...buildFastAgentChildTaskMetadata({
             sessionId: parentSessionId,
             conversation: params.conversation,
-          },
+          }),
           ...(environmentId && environmentId !== ALL_REPOSITORIES
             ? { environmentId }
             : {}),

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.ts
@@ -4,9 +4,14 @@ import { basename } from 'node:path';
 import {
   acquireFastAgentTurnLock,
   answerFastAgentQuestion,
+  buildFastAgentSessionChannelKey,
   createFastAgentSlackTaskLauncher,
+  enqueueTask,
+  getTaskUrl,
   type FastAgentTurnAdapter,
+  type LaunchFastAgentTask,
 } from '@roomote/cloud-agents/server';
+import { buildCommunicationTaskThreadName } from '@roomote/communication/task-thread-title';
 import {
   asc,
   and,
@@ -22,19 +27,23 @@ import {
 import { Env, getArtifactSigningKey } from '@roomote/env';
 import { SlackNotifier } from '@roomote/slack';
 import {
+  ALL_REPOSITORIES,
+  TaskPayloadKind,
   exitedRunStatuses,
+  type FastAgentConversation,
   type FastAgentParent,
   type PullRequestStatus,
   type RunStatus,
   type TaskRunErrorCode,
-  type SlackBlock,
   type SourceControlProvider,
+  type StandardTask,
 } from '@roomote/types';
 
 import {
   buildSignedArtifactRawUrl,
   currentEpochSeconds,
 } from './artifacts/raw-url';
+import { createDiscordCommunicationProviderFromRuntimeCredentials } from './discord-communication';
 
 const EXITED_RUN_STATUSES = new Set<RunStatus>(exitedRunStatuses);
 
@@ -137,10 +146,16 @@ export async function listFastAgentPullRequestContexts(
   }));
 }
 
-async function buildSelectedImageBlocks(params: {
+type FastAgentEventImage = {
+  url: string;
+  altText: string;
+  contentType: string;
+};
+
+async function buildSelectedImages(params: {
   artifactIds: string[];
   event: FastAgentParentEvent;
-}): Promise<SlackBlock[]> {
+}): Promise<FastAgentEventImage[]> {
   const artifactIds = [...new Set(params.artifactIds)];
   if (params.event.type !== 'artifact_published' || artifactIds.length === 0) {
     return [];
@@ -178,14 +193,14 @@ async function buildSelectedImageBlocks(params: {
     }
 
     return {
-      type: 'image' as const,
-      image_url: buildSignedArtifactRawUrl({
+      url: buildSignedArtifactRawUrl({
         artifactId: artifact.id,
         ts,
         apiBaseUrl: Env.R_APP_URL,
         signingKey: getArtifactSigningKey(),
       }),
-      alt_text: basename(artifact.path) || 'Task artifact',
+      altText: basename(artifact.path) || 'Task artifact',
+      contentType: artifact.contentType,
     };
   });
 }
@@ -256,7 +271,7 @@ async function createSlackFastAgentParentTurn(params: {
         threadTs: conversation.threadId,
       }),
       postReply: async ({ message, imageArtifactIds = [] }) => {
-        const imageBlocks = await buildSelectedImageBlocks({
+        const images = await buildSelectedImages({
           artifactIds: imageArtifactIds,
           event: params.event,
         });
@@ -264,7 +279,14 @@ async function createSlackFastAgentParentTurn(params: {
           channel: conversation.channelId,
           thread_ts: conversation.threadId,
           text: message,
-          blocks: [{ type: 'markdown', text: message }, ...imageBlocks],
+          blocks: [
+            { type: 'markdown', text: message },
+            ...images.map((image) => ({
+              type: 'image' as const,
+              image_url: image.url,
+              alt_text: image.altText,
+            })),
+          ],
           unfurl_links: false,
           unfurl_media: false,
           client_msg_id: buildSlackClientMessageId(
@@ -282,6 +304,141 @@ async function createSlackFastAgentParentTurn(params: {
   };
 }
 
+function createFastAgentDiscordTaskLauncher(params: {
+  provider: NonNullable<
+    Awaited<
+      ReturnType<
+        typeof createDiscordCommunicationProviderFromRuntimeCredentials
+      >
+    >
+  >;
+  userId: string;
+  conversation: FastAgentConversation;
+}): LaunchFastAgentTask {
+  return async ({ prompt, environmentId, parentSessionId, postKickoff }) => {
+    const isDirectMessage = params.conversation.workspaceId === 'dm';
+    const thread = isDirectMessage
+      ? null
+      : await params.provider.createTaskThread({
+          channelId: params.conversation.channelId,
+          name: buildCommunicationTaskThreadName(prompt),
+          initialText: `Delegated by Fast:\n\n${prompt}`,
+        });
+    const task: StandardTask = {
+      type: TaskPayloadKind.StandardTask,
+      payload: {
+        repo: ALL_REPOSITORIES,
+        description: prompt,
+        communicationProvider: 'discord',
+        communicationChannelId:
+          thread?.parentChannelId ?? params.conversation.channelId,
+        ...(thread?.channelId
+          ? { communicationThreadId: thread.channelId }
+          : isDirectMessage
+            ? {}
+            : { communicationThreadId: params.conversation.threadId }),
+        ...(thread?.messageId
+          ? { communicationMessageId: thread.messageId }
+          : {}),
+        ...(isDirectMessage
+          ? {}
+          : { communicationGuildId: params.conversation.workspaceId }),
+        ...(thread ? { discordTaskThread: true } : {}),
+        fastAgentSessionId: parentSessionId,
+        fastAgentParent: {
+          sessionId: parentSessionId,
+          conversation: params.conversation,
+        },
+        ...(environmentId && environmentId !== ALL_REPOSITORIES
+          ? { environmentId }
+          : {}),
+      },
+    };
+    let taskUrl: string | undefined;
+    const launch = await enqueueTask(
+      {
+        task,
+        initiator: { kind: 'user', userId: params.userId },
+        workflow: 'standard',
+        surface: 'discord',
+        trigger: 'message',
+      },
+      {
+        beforeEnqueue: async (taskRun) => {
+          taskUrl = getTaskUrl({
+            taskId: taskRun.taskId,
+            utm: { source: 'discord', campaign: 'fast-delegation' },
+          });
+          await postKickoff({ taskId: taskRun.taskId, taskUrl });
+        },
+      },
+    );
+
+    return launch.taskId
+      ? { success: true, taskId: launch.taskId, taskUrl }
+      : { success: false, error: 'The task launch did not return a task ID.' };
+  };
+}
+
+async function createDiscordFastAgentParentTurn(params: {
+  parent: FastAgentParent;
+  event: FastAgentParentEvent;
+  onReplyPosted: () => void;
+}): Promise<FastAgentParentTurn> {
+  const conversation = params.parent.conversation;
+  if (conversation.surface !== 'discord') {
+    throw new Error('Expected a Discord Fast parent conversation.');
+  }
+
+  const [session, provider] = await Promise.all([
+    db.query.slackQuickAnswers.findFirst({
+      where: and(
+        eq(slackQuickAnswers.id, params.parent.sessionId),
+        eq(
+          slackQuickAnswers.slackChannel,
+          buildFastAgentSessionChannelKey(conversation),
+        ),
+        eq(slackQuickAnswers.slackThreadTs, conversation.threadId),
+      ),
+      columns: { id: true, userId: true },
+    }),
+    createDiscordCommunicationProviderFromRuntimeCredentials(),
+  ]);
+  if (!session || !provider) {
+    throw new FastAgentParentEventDeliveryError(
+      'Fast parent session or Discord credentials were not found.',
+      { replyPosted: false, permanent: true },
+    );
+  }
+
+  return {
+    userId: session.userId,
+    adapter: {
+      launchTask: createFastAgentDiscordTaskLauncher({
+        provider,
+        userId: session.userId,
+        conversation,
+      }),
+      postReply: async ({ message, imageArtifactIds = [] }) => {
+        const images = await buildSelectedImages({
+          artifactIds: imageArtifactIds,
+          event: params.event,
+        });
+        await provider.postMessage({
+          channelId: conversation.channelId,
+          ...(conversation.workspaceId === 'dm'
+            ? {}
+            : { threadId: conversation.threadId }),
+          text: message,
+          textFormat: 'markdown',
+          images,
+        });
+        params.onReplyPosted();
+      },
+    },
+  };
+}
+
 async function createFastAgentParentTurn(params: {
   parent: FastAgentParent;
   event: FastAgentParentEvent;
@@ -291,10 +448,7 @@ async function createFastAgentParentTurn(params: {
     case 'slack':
       return createSlackFastAgentParentTurn(params);
     case 'discord':
-      throw new FastAgentParentEventDeliveryError(
-        'Fast parent delivery is not configured for discord.',
-        { replyPosted: false, permanent: true },
-      );
+      return createDiscordFastAgentParentTurn(params);
   }
 }
 

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.ts
@@ -6,8 +6,7 @@ import {
   answerFastAgentQuestion,
   buildFastAgentSessionChannelKey,
   createFastAgentSlackTaskLauncher,
-  enqueueTask,
-  getTaskUrl,
+  createFastAgentTaskLauncher,
   type FastAgentTurnAdapter,
   type LaunchFastAgentTask,
 } from '@roomote/cloud-agents/server';
@@ -231,13 +230,13 @@ async function createSlackFastAgentParentTurn(params: {
     throw new Error('Expected a Slack Fast parent conversation.');
   }
 
-  const scopedChannel = `${conversation.workspaceId}:${conversation.channelId}`;
+  const scopedChannel = buildFastAgentSessionChannelKey(conversation);
   const [session, installation] = await Promise.all([
     db.query.slackQuickAnswers.findFirst({
       where: and(
         eq(slackQuickAnswers.id, params.parent.sessionId),
         eq(slackQuickAnswers.slackChannel, scopedChannel),
-        eq(slackQuickAnswers.slackThreadTs, conversation.threadId),
+        eq(slackQuickAnswers.slackThreadTs, conversation.conversationId),
       ),
       columns: { id: true, userId: true },
     }),
@@ -267,8 +266,8 @@ async function createSlackFastAgentParentTurn(params: {
         ...(installation.teamDomain
           ? { teamDomain: installation.teamDomain }
           : {}),
-        channelId: conversation.channelId,
-        threadTs: conversation.threadId,
+        channelId: conversation.replyTarget.channelId,
+        threadTs: conversation.replyTarget.threadId,
       }),
       postReply: async ({ message, imageArtifactIds = [] }) => {
         const images = await buildSelectedImages({
@@ -276,8 +275,8 @@ async function createSlackFastAgentParentTurn(params: {
           event: params.event,
         });
         const messageTs = await slack.postMessage({
-          channel: conversation.channelId,
-          thread_ts: conversation.threadId,
+          channel: conversation.replyTarget.channelId,
+          thread_ts: conversation.replyTarget.threadId,
           text: message,
           blocks: [
             { type: 'markdown', text: message },
@@ -313,71 +312,59 @@ function createFastAgentDiscordTaskLauncher(params: {
     >
   >;
   userId: string;
-  conversation: FastAgentConversation;
+  conversation: Extract<FastAgentConversation, { surface: 'discord' }>;
 }): LaunchFastAgentTask {
-  return async ({ prompt, environmentId, parentSessionId, postKickoff }) => {
-    const isDirectMessage = params.conversation.workspaceId === 'dm';
-    const thread = isDirectMessage
-      ? null
-      : await params.provider.createTaskThread({
-          channelId: params.conversation.channelId,
-          name: buildCommunicationTaskThreadName(prompt),
-          initialText: `Delegated by Fast:\n\n${prompt}`,
-        });
-    const task: StandardTask = {
-      type: TaskPayloadKind.StandardTask,
-      payload: {
-        repo: ALL_REPOSITORIES,
-        description: prompt,
-        communicationProvider: 'discord',
-        communicationChannelId:
-          thread?.parentChannelId ?? params.conversation.channelId,
-        ...(thread?.channelId
-          ? { communicationThreadId: thread.channelId }
-          : isDirectMessage
-            ? {}
-            : { communicationThreadId: params.conversation.threadId }),
-        ...(thread?.messageId
-          ? { communicationMessageId: thread.messageId }
-          : {}),
-        ...(isDirectMessage
-          ? {}
-          : { communicationGuildId: params.conversation.workspaceId }),
-        ...(thread ? { discordTaskThread: true } : {}),
-        fastAgentSessionId: parentSessionId,
-        fastAgentParent: {
-          sessionId: parentSessionId,
-          conversation: params.conversation,
-        },
-        ...(environmentId && environmentId !== ALL_REPOSITORIES
-          ? { environmentId }
-          : {}),
-      },
-    };
-    let taskUrl: string | undefined;
-    const launch = await enqueueTask(
-      {
-        task,
-        initiator: { kind: 'user', userId: params.userId },
-        workflow: 'standard',
-        surface: 'discord',
-        trigger: 'message',
-      },
-      {
-        beforeEnqueue: async (taskRun) => {
-          taskUrl = getTaskUrl({
-            taskId: taskRun.taskId,
-            utm: { source: 'discord', campaign: 'fast-delegation' },
+  return createFastAgentTaskLauncher({
+    userId: params.userId,
+    surface: 'discord',
+    taskUrlCampaign: 'fast-delegation',
+    buildTask: async ({ prompt, environmentId, parentSessionId }) => {
+      const isDirectMessage = params.conversation.workspaceId === 'dm';
+      const thread = isDirectMessage
+        ? null
+        : await params.provider.createTaskThread({
+            channelId: params.conversation.replyTarget.channelId,
+            name: buildCommunicationTaskThreadName(prompt),
+            initialText: `Delegated by Fast:\n\n${prompt}`,
           });
-          await postKickoff({ taskId: taskRun.taskId, taskUrl });
+      return {
+        type: TaskPayloadKind.StandardTask,
+        payload: {
+          repo: ALL_REPOSITORIES,
+          description: prompt,
+          communicationProvider: 'discord',
+          communicationChannelId:
+            thread?.parentChannelId ??
+            params.conversation.replyTarget.channelId,
+          ...(thread?.channelId
+            ? { communicationThreadId: thread.channelId }
+            : isDirectMessage
+              ? {}
+              : params.conversation.replyTarget.threadId
+                ? {
+                    communicationThreadId:
+                      params.conversation.replyTarget.threadId,
+                  }
+                : {}),
+          ...(thread?.messageId
+            ? { communicationMessageId: thread.messageId }
+            : {}),
+          ...(isDirectMessage
+            ? {}
+            : { communicationGuildId: params.conversation.workspaceId }),
+          ...(thread ? { discordTaskThread: true } : {}),
+          fastAgentSessionId: parentSessionId,
+          fastAgentParent: {
+            sessionId: parentSessionId,
+            conversation: params.conversation,
+          },
+          ...(environmentId && environmentId !== ALL_REPOSITORIES
+            ? { environmentId }
+            : {}),
         },
-      },
-    );
-
-    return launch.taskId
-      ? { success: true, taskId: launch.taskId, taskUrl }
-      : { success: false, error: 'The task launch did not return a task ID.' };
-  };
+      } satisfies StandardTask;
+    },
+  });
 }
 
 async function createDiscordFastAgentParentTurn(params: {
@@ -398,7 +385,7 @@ async function createDiscordFastAgentParentTurn(params: {
           slackQuickAnswers.slackChannel,
           buildFastAgentSessionChannelKey(conversation),
         ),
-        eq(slackQuickAnswers.slackThreadTs, conversation.threadId),
+        eq(slackQuickAnswers.slackThreadTs, conversation.conversationId),
       ),
       columns: { id: true, userId: true },
     }),
@@ -425,10 +412,8 @@ async function createDiscordFastAgentParentTurn(params: {
           event: params.event,
         });
         await provider.postMessage({
-          channelId: conversation.channelId,
-          ...(conversation.workspaceId === 'dm'
-            ? {}
-            : { threadId: conversation.threadId }),
+          ...conversation.replyTarget,
+          idempotencyKey: buildEventClientMessageSeed(params.event),
           text: message,
           textFormat: 'markdown',
           images,

--- a/packages/sdk/src/server/lib/task-runs/__tests__/finish-run.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/finish-run.test.ts
@@ -1495,8 +1495,8 @@ describe('finishRun', () => {
             conversation: {
               surface: 'slack',
               workspaceId: 'T123',
-              channelId: 'C123',
-              threadId: '111.222',
+              conversationId: '111.222',
+              replyTarget: { channelId: 'C123', threadId: '111.222' },
             },
           },
         },

--- a/packages/sdk/src/server/lib/task-runs/__tests__/notify-fast-agent-parent-on-pull-request-opened.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/notify-fast-agent-parent-on-pull-request-opened.test.ts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => {
     not: vi.fn((...args: unknown[]) => args),
     recordLifecycle: vi.fn(),
     deliverParentEvent: vi.fn(),
+    getTaskUrl: vi.fn(() => 'https://roomote.example/task/child-task'),
     FastAgentParentEventDeliveryError,
   };
 });
@@ -54,7 +55,7 @@ vi.mock('@roomote/db/server', () => ({
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
-  getTaskUrl: vi.fn(() => 'https://roomote.example/task/child-task'),
+  getTaskUrl: mocks.getTaskUrl,
 }));
 
 vi.mock('../../fast-agent-parent-event', () => ({
@@ -69,8 +70,18 @@ const fastParent = {
   conversation: {
     surface: 'slack' as const,
     workspaceId: 'T123',
-    channelId: 'C123',
-    threadId: '100.001',
+    conversationId: '100.001',
+    replyTarget: { channelId: 'C123', threadId: '100.001' },
+  },
+};
+
+const discordFastParent = {
+  sessionId: '22222222-2222-4222-8222-222222222222',
+  conversation: {
+    surface: 'discord' as const,
+    workspaceId: 'guild-1',
+    conversationId: 'interaction-1',
+    replyTarget: { channelId: 'channel-1' },
   },
 };
 
@@ -104,12 +115,12 @@ describe('notifyFastAgentParentOnPullRequestOpened', () => {
 
   it('passes structured pull request context to the Fast parent', async () => {
     await notifyFastAgentParentOnPullRequestOpened({
-      run: makeRun({ fastAgentParent: fastParent }),
+      run: makeRun({ fastAgentParent: discordFastParent }),
       pullRequest,
     });
 
     expect(mocks.deliverParentEvent).toHaveBeenCalledWith({
-      parent: fastParent,
+      parent: discordFastParent,
       lockWaitMs: 30_000,
       event: {
         type: 'pull_request_opened',
@@ -117,6 +128,13 @@ describe('notifyFastAgentParentOnPullRequestOpened', () => {
         runId: 200,
         taskUrl: 'https://roomote.example/task/child-task',
         pullRequest,
+      },
+    });
+    expect(mocks.getTaskUrl).toHaveBeenCalledWith({
+      taskId: 'child-task',
+      utm: {
+        source: 'discord',
+        campaign: 'fast-delegation-pr-opened',
       },
     });
     expect(mocks.inArray).toHaveBeenCalledWith(

--- a/packages/sdk/src/server/lib/task-runs/__tests__/notify-fast-agent-parent-on-settle.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/notify-fast-agent-parent-on-settle.test.ts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => {
     recordLifecycle: vi.fn(),
     deliverParentEvent: vi.fn(),
     listPullRequests: vi.fn(),
+    getTaskUrl: vi.fn(() => 'https://roomote.example/task/child-task'),
     findTaskRun: vi.fn(),
     canRetryFailedStart: vi.fn(),
     enqueueTaskRelaunch: vi.fn(),
@@ -61,7 +62,7 @@ vi.mock('@roomote/db/server', () => ({
 vi.mock('@roomote/cloud-agents/server', () => ({
   canRetryFailedStart: mocks.canRetryFailedStart,
   enqueueTaskRelaunch: mocks.enqueueTaskRelaunch,
-  getTaskUrl: vi.fn(() => 'https://roomote.example/task/child-task'),
+  getTaskUrl: mocks.getTaskUrl,
 }));
 
 vi.mock('../../fast-agent-parent-event', () => ({
@@ -77,8 +78,18 @@ const fastParent = {
   conversation: {
     surface: 'slack' as const,
     workspaceId: 'T123',
-    channelId: 'C123',
-    threadId: '100.001',
+    conversationId: '100.001',
+    replyTarget: { channelId: 'C123', threadId: '100.001' },
+  },
+};
+
+const discordFastParent = {
+  sessionId: '22222222-2222-4222-8222-222222222222',
+  conversation: {
+    surface: 'discord' as const,
+    workspaceId: 'guild-1',
+    conversationId: 'interaction-1',
+    replyTarget: { channelId: 'channel-1' },
   },
 };
 
@@ -112,13 +123,13 @@ describe('notifyFastAgentParentOnSettle', () => {
 
   it('passes child lifecycle state to the Fast orchestrator', async () => {
     await notifyFastAgentParentOnSettle(
-      makeRun({ fastAgentParent: fastParent }),
+      makeRun({ fastAgentParent: discordFastParent }),
       RunStatus.Idle,
       'Implement the fix',
     );
 
     expect(mocks.deliverParentEvent).toHaveBeenCalledWith({
-      parent: fastParent,
+      parent: discordFastParent,
       event: {
         type: 'task_settled',
         taskId: 'child-task',
@@ -127,6 +138,13 @@ describe('notifyFastAgentParentOnSettle', () => {
         status: RunStatus.Idle,
         taskUrl: 'https://roomote.example/task/child-task',
         pullRequests: [],
+      },
+    });
+    expect(mocks.getTaskUrl).toHaveBeenCalledWith({
+      taskId: 'child-task',
+      utm: {
+        source: 'discord',
+        campaign: 'fast-delegation-settle',
       },
     });
     expect(mocks.recordLifecycle).toHaveBeenCalledWith(

--- a/packages/sdk/src/server/lib/task-runs/notify-fast-agent-parent-on-pull-request-opened.ts
+++ b/packages/sdk/src/server/lib/task-runs/notify-fast-agent-parent-on-pull-request-opened.ts
@@ -101,7 +101,10 @@ export async function notifyFastAgentParentOnPullRequestOpened(params: {
         runId: params.run.id,
         taskUrl: getTaskUrl({
           taskId: params.run.taskId,
-          utm: { source: 'slack', campaign: 'fast-delegation-pr-opened' },
+          utm: {
+            source: parent.conversation.surface,
+            campaign: 'fast-delegation-pr-opened',
+          },
         }),
         pullRequest,
       },

--- a/packages/sdk/src/server/lib/task-runs/notify-fast-agent-parent-on-settle.ts
+++ b/packages/sdk/src/server/lib/task-runs/notify-fast-agent-parent-on-settle.ts
@@ -215,7 +215,10 @@ export async function notifyFastAgentParentOnSettle(
           : {}),
         taskUrl: getTaskUrl({
           taskId: run.taskId,
-          utm: { source: 'slack', campaign: 'fast-delegation-settle' },
+          utm: {
+            source: parent.conversation.surface,
+            campaign: 'fast-delegation-settle',
+          },
         }),
         pullRequests,
       },

--- a/packages/sdk/src/server/lib/task-runs/publish-fast-agent-request-user-input.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/publish-fast-agent-request-user-input.test.ts
@@ -54,8 +54,8 @@ const parent = {
   conversation: {
     surface: 'slack' as const,
     workspaceId: 'T123',
-    channelId: 'C123',
-    threadId: '100.001',
+    conversationId: '100.001',
+    replyTarget: { channelId: 'C123', threadId: '100.001' },
   },
 };
 

--- a/packages/sdk/src/server/lib/task-runs/publish-fast-agent-request-user-input.ts
+++ b/packages/sdk/src/server/lib/task-runs/publish-fast-agent-request-user-input.ts
@@ -1,3 +1,4 @@
+import { buildFastAgentSessionChannelKey } from '@roomote/cloud-agents/server';
 import {
   and,
   db,
@@ -49,8 +50,9 @@ export async function publishFastAgentRequestUserInput(input: {
     return { published: false };
   }
 
-  const { workspaceId, channelId, threadId } = parent.conversation;
-  const scopedChannel = `${workspaceId}:${channelId}`;
+  const { workspaceId, replyTarget } = parent.conversation;
+  const { channelId, threadId } = replyTarget;
+  const scopedChannel = buildFastAgentSessionChannelKey(parent.conversation);
   const [session, installation] = await Promise.all([
     db.query.slackQuickAnswers.findFirst({
       where: and(

--- a/packages/slack/src/handle-followup-answer.ts
+++ b/packages/slack/src/handle-followup-answer.ts
@@ -176,7 +176,7 @@ async function findFastAgentChildRunForPendingInput(params: {
     !parent ||
     parent.conversation.surface !== 'slack' ||
     parent.conversation.workspaceId !== params.slackTeamId ||
-    parent.conversation.threadId !== params.threadId
+    parent.conversation.replyTarget.threadId !== params.threadId
   ) {
     return null;
   }

--- a/packages/types/src/__tests__/task-runs.test.ts
+++ b/packages/types/src/__tests__/task-runs.test.ts
@@ -501,8 +501,8 @@ describe('taskSpecSchema', () => {
           conversation: {
             surface: 'slack',
             workspaceId: 'T123',
-            channelId: 'C123',
-            threadId: '111.222',
+            conversationId: '111.222',
+            replyTarget: { channelId: 'C123', threadId: '111.222' },
           },
         },
       },
@@ -522,8 +522,8 @@ describe('taskSpecSchema', () => {
     expect(parsed.payload.fastAgentParent?.conversation).toEqual({
       surface: 'slack',
       workspaceId: 'T123',
-      channelId: 'C123',
-      threadId: '111.222',
+      conversationId: '111.222',
+      replyTarget: { channelId: 'C123', threadId: '111.222' },
     });
   });
 

--- a/packages/types/src/fast-agent.ts
+++ b/packages/types/src/fast-agent.ts
@@ -5,12 +5,35 @@ export const fastAgentSurfaceSchema = z.enum(fastAgentSurfaces);
 
 export type FastAgentSurface = z.infer<typeof fastAgentSurfaceSchema>;
 
-export const fastAgentConversationSchema = z.object({
-  surface: fastAgentSurfaceSchema,
-  workspaceId: z.string().min(1),
+export const fastAgentReplyTargetSchema = z.object({
   channelId: z.string().min(1),
-  threadId: z.string().min(1),
+  threadId: z.string().min(1).optional(),
 });
+
+export type FastAgentReplyTarget = z.infer<typeof fastAgentReplyTargetSchema>;
+
+const fastAgentConversationIdentitySchema = {
+  workspaceId: z.string().min(1),
+  /** Stable provider-native identity used to scope Fast memory and turns. */
+  conversationId: z.string().min(1),
+};
+
+export const fastAgentConversationSchema = z.discriminatedUnion('surface', [
+  z.object({
+    surface: z.literal('slack'),
+    ...fastAgentConversationIdentitySchema,
+    replyTarget: z.object({
+      channelId: z.string().min(1),
+      threadId: z.string().min(1),
+    }),
+  }),
+  z.object({
+    surface: z.literal('discord'),
+    ...fastAgentConversationIdentitySchema,
+    /** Routable provider address. It is deliberately separate from identity. */
+    replyTarget: fastAgentReplyTargetSchema,
+  }),
+]);
 
 export type FastAgentConversation = z.infer<typeof fastAgentConversationSchema>;
 

--- a/packages/types/src/fast-agent.ts
+++ b/packages/types/src/fast-agent.ts
@@ -44,6 +44,23 @@ export const fastAgentParentSchema = z.object({
 
 export type FastAgentParent = z.infer<typeof fastAgentParentSchema>;
 
+/**
+ * A delegated Fast child keeps its parent's coordinates for lifecycle routing,
+ * but the child runtime must not treat those coordinates as a direct reply
+ * surface. Fast owns all chat delivery for the child.
+ */
+export function buildFastAgentChildTaskMetadata(parent: FastAgentParent): {
+  communicationContextInherited: true;
+  fastAgentSessionId: string;
+  fastAgentParent: FastAgentParent;
+} {
+  return {
+    communicationContextInherited: true,
+    fastAgentSessionId: parent.sessionId,
+    fastAgentParent: parent,
+  };
+}
+
 export function getFastAgentParentFromPayload(
   payload: unknown,
 ): FastAgentParent | null {


### PR DESCRIPTION
## What

- separate durable Fast conversation identity from the provider address used to post replies
- reuse one Fast session for Discord DMs and real Discord threads while keeping top-level guild invocations isolated
- deliver delegated-task artifact, pull-request, and settled events to the explicit Discord reply target
- keep `launch_task` available during Discord lifecycle turns through a shared Fast task launcher
- stamp Fast child ownership metadata atomically so child runtimes cannot also reply directly
- deduplicate retried Discord lifecycle messages with deterministic nonces
- derive lifecycle task-link attribution from the parent surface instead of assuming Slack

## Why

Discord slash interaction IDs were serving two unrelated jobs: identifying Fast memory and identifying where later lifecycle messages should be posted. An interaction ID is not a Discord channel or thread, so a delegated task could retain the right parent session but later attempt delivery to an invalid destination.

The Fast conversation contract now models those concerns independently:

- `conversationId` scopes memory and turn serialization
- `replyTarget` is the provider-native channel/thread address

Fast child metadata is also constructed as one invariant: the parent stamp, session ID, and inherited-context flag are emitted together. This keeps lifecycle routing coordinates available while preventing the child runtime from treating them as its own direct reply surface.

Slack and Discord use the same contract and shared enqueue/kickoff mechanics, while provider-specific code only constructs the provider task payload and performs delivery.

## Impact

- Discord Fast DMs and threads behave as continuous chat sessions.
- Top-level guild Fast invocations do not share memory with unrelated channel messages.
- Delegated-task lifecycle events return to the real parent channel or thread.
- A lifecycle turn can launch another task without a Discord-only runtime gap.
- Fast children cannot emit a second direct chat response alongside the parent lifecycle response.
- Retried lifecycle delivery does not duplicate the Discord message.

## Validation

- `pnpm lint`
- `pnpm check-types`
- `pnpm knip`
- focused ownership suites: API 84 tests, SDK 8 tests, cloud-agents 3 tests, worker 17 tests
- full API suite: 206 files, 1,788 tests passed
- full web server/client suites: 389 files, 2,981 tests passed
- repository-wide test run passed all changed packages and stopped on one unrelated worker test whose premise is incompatible with this isolated checkout: it treats `process.cwd()` as outside `/tmp`, while the PR worktree itself is under `/private/tmp`

### Mock Discord smoke

The checked-in Discord mock harness exercised a guild `/fast` request through delegation, child-thread creation, a settled child event, and Fast lifecycle closeout. The closeout posted to the real parent channel, and no request targeted the slash interaction ID.

A second focused guild `/fast` smoke inspected the persisted child payload. Both the initial child run and its automatic startup retry carried `communicationContextInherited: true`; the worker regression test resolves the same payload to no direct Discord reply context. The local compute provider failed before the child reached an agent turn, so this proves launch-payload ownership rather than a successful sandbox execution.

Temporary smoke fixtures were removed after verification.
