### PR TITLE
[Fix] Brain activates without opt-in and Slack answers stall after rollback

### DIFF
--- a/.changeset/brain-explicit-opt-in.md
+++ b/.changeset/brain-explicit-opt-in.md
@@ -1,0 +1,5 @@
+---
+"@roomote/web": patch
+---
+
+Require an explicit Brain provider key (`R_BRAIN_OPENROUTER_API_KEY` or `R_BRAIN_OPENAI_API_KEY`) to activate the Brain, so template-generated plumbing and general task provider keys never turn it on for deployments that did not opt in, and keep Slack follow-up delivery working against a rolled-back API by routing canonically when the reply-target procedures are unavailable.

--- a/apps/api/src/handlers/tasks/saveTaskMemory.ts
+++ b/apps/api/src/handlers/tasks/saveTaskMemory.ts
@@ -1,8 +1,11 @@
 import type { Context } from 'hono';
 import { z } from 'zod';
 
-import { db, saveBrainAgentSummary } from '@roomote/db/server';
-import { Env, isBrainConfigured } from '@roomote/env';
+import {
+  db,
+  isBrainProviderConfigured,
+  saveBrainAgentSummary,
+} from '@roomote/db/server';
 
 import type { Variables } from '../../types';
 import type { McpAuth } from '../mcp/middleware';
@@ -77,7 +80,7 @@ export async function saveTaskMemory(
     );
   }
 
-  if (!isBrainConfigured(Env)) {
+  if (!(await isBrainProviderConfigured())) {
     return c.json(
       { saved: false, reason: 'This deployment has no Brain configured.' },
       200,

--- a/apps/docs/brain.mdx
+++ b/apps/docs/brain.mdx
@@ -50,21 +50,24 @@ The Brain runs as its own service alongside Roomote, reachable only on your
 deployment's internal network. On the hosted templates (Railway, Render,
 Coolify) that service is already there after a deploy, sitting idle.
 
-It holds no model provider key of its own. Instead it asks Roomote for
-embeddings and synthesis, and Roomote uses whichever provider key your
-deployment has configured under **Settings → Models**. So if you already set
-up a provider for tasks, the Brain has what it needs and there is nothing else
-to do. Changing that key later takes effect on the Brain's next request, with
-no redeploy.
+Setting a Brain provider key, `R_BRAIN_OPENROUTER_API_KEY` or
+`R_BRAIN_OPENAI_API_KEY`, is what turns it on. Set either one as an
+environment variable or a Settings environment value; the value can be the
+same key you already use for tasks, or a separate one to bill the Brain
+independently. The explicit `R_BRAIN_*` name is the opt-in: the general
+provider keys your deployment uses for tasks never activate the Brain on
+their own, so configuring task models leaves the Brain off.
+
+The Brain service holds no provider key of its own. It asks Roomote for
+embeddings and synthesis, and Roomote forwards them under the Brain key.
+Changing that key later takes effect on the Brain's next request, with no
+redeploy.
 
 OpenRouter and OpenAI both support the Brain's embedding and synthesis calls,
-but search reranking requires OpenRouter. To bill the Brain separately from
-task inference, set
-`R_BRAIN_OPENROUTER_API_KEY` or `R_BRAIN_OPENAI_API_KEY`; those take
-precedence over the deployment's general provider keys.
+but search reranking requires OpenRouter.
 
-With no provider configured anywhere, the Brain stays inert. Agents are not
-told it exists, and nothing is ingested.
+Without a Brain key, the Brain stays inert. Agents are not told it exists,
+and nothing is ingested.
 
 Roomote schedules one maintenance pass each night. It retrieves a bounded,
 source-balanced evidence set from gbrain, produces a cited digest of material

--- a/apps/worker/src/run-task/__tests__/run-task.test.ts
+++ b/apps/worker/src/run-task/__tests__/run-task.test.ts
@@ -6,6 +6,7 @@ const {
   buildSandboxInstructionMock,
   taskRunsDoneMock,
   taskRunsActivateSlackReplyTargetMock,
+  taskRunsClearActiveSlackReplyTargetMock,
   taskRunsGetGoalMock,
   taskRunsClaimGoalContinuationMock,
   taskRunsRecordEventMock,
@@ -48,6 +49,7 @@ const {
     threadTs: '1710000000.456',
     reactionsAllowed: false,
   }),
+  taskRunsClearActiveSlackReplyTargetMock: vi.fn().mockResolvedValue(undefined),
   taskRunsGetGoalMock: vi.fn().mockResolvedValue(null),
   taskRunsClaimGoalContinuationMock: vi.fn(),
   taskRunsRecordEventMock: vi.fn().mockResolvedValue(undefined),
@@ -160,6 +162,7 @@ vi.mock('@roomote/sdk/client', () => ({
   sdk: {
     taskRuns: {
       activateSlackReplyTarget: taskRunsActivateSlackReplyTargetMock,
+      clearActiveSlackReplyTarget: taskRunsClearActiveSlackReplyTargetMock,
       done: taskRunsDoneMock,
       getGoal: taskRunsGetGoalMock,
       claimGoalContinuation: taskRunsClaimGoalContinuationMock,
@@ -2325,6 +2328,108 @@ describe('runTask', () => {
         turnMessageTs: '1710000000.456',
       }),
     );
+  });
+
+  const runMinimalTask = async (runId: number) => {
+    await runTask({
+      taskRun: {
+        id: runId,
+        taskId: `task-${runId}`,
+        payloadKind: TaskPayloadKind.StandardTask,
+        harness: 'opencode-server',
+        payload: {},
+        result: null,
+      } as never,
+      envVars: {},
+      workspacePath: '/tmp/workspace',
+      prompt: '',
+      harnessInstructions: undefined,
+      agentInstructions: undefined,
+      environmentConfig: undefined,
+      callbacks: {},
+      context: {},
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        log: vi.fn(),
+      } as never,
+      workerEnv: {
+        buildUserFacingEnv: vi.fn(() => ({})),
+        roomoteAppUrl: 'http://localhost:3000',
+        trpcUrl: 'http://localhost:3001',
+        authToken: 'auth-token',
+        appEnv: 'test',
+        setRuntimeEnv: vi.fn(),
+      } as never,
+    });
+
+    return createHarnessMock.mock.calls[0]?.[0].prepareQueuedPromptActorScope;
+  };
+
+  /**
+   * A rolled-back API (the supported N-1 target) has no reply-target
+   * procedures, and tRPC reports the missing procedure as NOT_FOUND. That
+   * release routed replies canonically, so canonical delivery is the correct
+   * degraded behavior; blocking would stall every queued prompt until the
+   * snapshot is replaced.
+   */
+  const missingProcedureError = (path: string) =>
+    Object.assign(new Error(`No "mutation"-procedure on path "${path}"`), {
+      name: 'TRPCClientError',
+      data: { code: 'NOT_FOUND', httpStatus: 404 },
+    });
+
+  it('falls back to canonical routing when the activate procedure is missing on a rolled-back API', async () => {
+    taskRunsActivateSlackReplyTargetMock.mockRejectedValueOnce(
+      missingProcedureError('taskRuns.activateSlackReplyTarget'),
+    );
+
+    const prepareQueuedPromptActorScope = await runMinimalTask(406);
+
+    await expect(
+      prepareQueuedPromptActorScope?.(undefined, {
+        kind: 'queuedPrompt',
+        clientMessageId: 'slack:1710000000.456',
+      }),
+    ).resolves.toEqual({ shouldReconnect: false });
+    expect(recordChatTurnStartMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ turnMessageTs: '1710000000.456' }),
+    );
+  });
+
+  it('falls back to canonical routing when the clear procedure is missing on a rolled-back API', async () => {
+    taskRunsClearActiveSlackReplyTargetMock.mockRejectedValueOnce(
+      missingProcedureError('taskRuns.clearActiveSlackReplyTarget'),
+    );
+
+    const prepareQueuedPromptActorScope = await runMinimalTask(407);
+
+    await expect(
+      prepareQueuedPromptActorScope?.(undefined, {
+        kind: 'queuedPrompt',
+        clientMessageId: 'web:abc-123',
+      }),
+    ).resolves.toEqual({ shouldReconnect: false });
+  });
+
+  it('still blocks queued prompt delivery on transient reply-target failures', async () => {
+    taskRunsActivateSlackReplyTargetMock.mockRejectedValueOnce(
+      new Error('socket hang up'),
+    );
+
+    const prepareQueuedPromptActorScope = await runMinimalTask(408);
+
+    await expect(
+      prepareQueuedPromptActorScope?.(undefined, {
+        kind: 'queuedPrompt',
+        clientMessageId: 'slack:1710000000.456',
+      }),
+    ).resolves.toEqual({
+      shouldReconnect: false,
+      shouldBlockPrompt: true,
+      reason: 'Slack reply target activation failed: socket hang up',
+    });
   });
 
   it('retries blocked deferred resume prompts instead of marking them rejected immediately', async () => {

--- a/apps/worker/src/run-task/polling/slack.test.ts
+++ b/apps/worker/src/run-task/polling/slack.test.ts
@@ -583,6 +583,77 @@ describe('createSlackMessageInterval', () => {
     }
   });
 
+  it('delivers request_user_input answers canonically when the reply-target procedure is missing', async () => {
+    mockActivateSlackReplyTarget.mockRejectedValueOnce(
+      Object.assign(
+        new Error(
+          'No "mutation"-procedure on path "taskRuns.activateSlackReplyTarget"',
+        ),
+        {
+          name: 'TRPCClientError',
+          data: { code: 'NOT_FOUND', httpStatus: 404 },
+        },
+      ),
+    );
+    mockGetSlackRequestUserInputAnswers.mockResolvedValueOnce([
+      {
+        requestId: 'rui:session:turn:call',
+        answers: { language: { answers: ['Rust'] } },
+        user: 'U234',
+        userId: 'user-2',
+        ts: '1710000000.903',
+        channel: 'C_ALERT',
+        threadTs: '1710000000.100',
+      },
+    ]);
+    const { options, logger, answerUserInputRequest } = createListenerOptions();
+
+    const interval = createSlackMessageInterval(options);
+
+    try {
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(answerUserInputRequest).toHaveBeenCalledTimes(1);
+      expect(mockPrependSlackRequestUserInputAnswers).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('delivering request_user_input answer'),
+      );
+    } finally {
+      clearInterval(interval);
+    }
+  });
+
+  it('requeues request_user_input answers on transient reply-target failures', async () => {
+    mockActivateSlackReplyTarget.mockRejectedValueOnce(
+      new Error('socket hang up'),
+    );
+    mockGetSlackRequestUserInputAnswers.mockResolvedValueOnce([
+      {
+        requestId: 'rui:session:turn:call',
+        answers: { language: { answers: ['Rust'] } },
+        user: 'U234',
+        userId: 'user-2',
+        ts: '1710000000.904',
+        channel: 'C_ALERT',
+        threadTs: '1710000000.100',
+      },
+    ]);
+    const { options, answerUserInputRequest } = createListenerOptions();
+
+    const interval = createSlackMessageInterval(options);
+
+    try {
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(answerUserInputRequest).not.toHaveBeenCalled();
+      expect(mockPrependSlackRequestUserInputAnswers).toHaveBeenCalledWith(42, [
+        expect.objectContaining({ ts: '1710000000.904' }),
+      ]);
+    } finally {
+      clearInterval(interval);
+    }
+  });
+
   it('sends multiple queued Slack messages in reverse drain order so auto-steer preserves chronology', async () => {
     mockGetSlackMessages.mockResolvedValueOnce([
       {

--- a/apps/worker/src/run-task/polling/slack.ts
+++ b/apps/worker/src/run-task/polling/slack.ts
@@ -11,6 +11,7 @@ import {
 import { recordChatTurnStart } from '../../mcp/roomote-mcp-server/chat-reply-satisfaction';
 import { isActiveTaskPhase } from '../../sandbox-server/lib/harness-manager';
 import type { ListenerOptions } from '../types';
+import { isMissingSlackReplyTargetProcedureError } from '../slack-reply-target';
 import {
   logPollingTransportError,
   runPollingSdkCall,
@@ -131,21 +132,36 @@ export function createSlackMessageInterval({
           }
 
           if (answer.channel && answer.threadTs) {
-            const activated = await runPollingSdkCall({
-              execute: () =>
-                sdk.taskRuns.activateSlackReplyTarget({
+            let activated:
+              | Awaited<
+                  ReturnType<typeof sdk.taskRuns.activateSlackReplyTarget>
+                >
+              | undefined;
+            try {
+              activated = await sdk.taskRuns.activateSlackReplyTarget({
+                runId: taskRun.id,
+                messageTs: answer.ts,
+              });
+            } catch (error) {
+              if (isMissingSlackReplyTargetProcedureError(error)) {
+                activated = false;
+                logger.warn(
+                  `[listenForSlackEvents] Slack reply target procedures are unavailable on this API (rolled-back release?); delivering request_user_input answer with canonical routing`,
+                );
+              } else {
+                logPollingTransportError({
+                  error,
+                  stage: 'listenForSlackEvents',
                   runId: taskRun.id,
-                  messageTs: answer.ts,
-                }),
-              stage: 'listenForSlackEvents',
-              runId: taskRun.id,
-              sessionId: state.sessionId,
-              sdkMethod: 'taskRuns.activateSlackReplyTarget',
-              failurePoint: 'slackReplyTargetActivation',
-              logger,
-              message: `[listenForSlackEvents] Failed to activate Slack reply target for request_user_input answer on job ${taskRun.id}`,
-            });
-            if (activated === null) {
+                  sessionId: state.sessionId,
+                  sdkMethod: 'taskRuns.activateSlackReplyTarget',
+                  failurePoint: 'slackReplyTargetActivation',
+                  logger,
+                  message: `[listenForSlackEvents] Failed to activate Slack reply target for request_user_input answer on job ${taskRun.id}`,
+                });
+              }
+            }
+            if (activated === undefined) {
               await requeueSlackRequestUserInputAnswers(
                 taskRun.id,
                 queuedAnswers,

--- a/apps/worker/src/run-task/run-task.ts
+++ b/apps/worker/src/run-task/run-task.ts
@@ -105,6 +105,7 @@ import {
 import { wrapCommunicationMessage } from './communication-message-prompt';
 import { buildTaskGoalContinuationPrompt } from './task-goal';
 import { settleMissingChatCloseoutFallback } from './missing-chat-closeout-fallback-settlement';
+import { isMissingSlackReplyTargetProcedureError } from './slack-reply-target';
 
 function formatEnvironmentInstructions(
   instructions?: string,
@@ -222,29 +223,6 @@ function buildEnvironmentSetupSettledWakePrompt(
     "If any part of the user's request was deferred or reported as blocked because setup had not finished, continue that work now and report the outcome as you normally would.",
     'If the request was already fully handled, end this turn immediately without calling any tools and without posting any message — this update needs no acknowledgement.',
   ].join('\n');
-}
-
-/**
- * True when a tRPC call failed because the procedure does not exist on the
- * server, which for the Slack reply-target procedures means the API is the
- * previous release (the supported N-1 rollback target). Those procedures
- * never answer NOT_FOUND themselves (a missing authorization is a null
- * result and auth failures map to UNAUTHORIZED/FORBIDDEN), so NOT_FOUND can
- * only mean the router has no such procedure.
- */
-function isMissingSlackReplyTargetProcedureError(error: unknown): boolean {
-  if (!(error instanceof Error) || error.name !== 'TRPCClientError') {
-    return false;
-  }
-
-  const data = (error as { data?: { code?: string } }).data;
-
-  return (
-    data?.code === 'NOT_FOUND' ||
-    // Backstop for responses that lose the typed code (e.g. a proxy rewrote
-    // the body): tRPC's unknown-procedure message across versions.
-    /no .*procedure.* on path/i.test(error.message)
-  );
 }
 
 function getInitialSlackTurnMessageTs(taskRun: {

--- a/apps/worker/src/run-task/run-task.ts
+++ b/apps/worker/src/run-task/run-task.ts
@@ -224,6 +224,29 @@ function buildEnvironmentSetupSettledWakePrompt(
   ].join('\n');
 }
 
+/**
+ * True when a tRPC call failed because the procedure does not exist on the
+ * server, which for the Slack reply-target procedures means the API is the
+ * previous release (the supported N-1 rollback target). Those procedures
+ * never answer NOT_FOUND themselves (a missing authorization is a null
+ * result and auth failures map to UNAUTHORIZED/FORBIDDEN), so NOT_FOUND can
+ * only mean the router has no such procedure.
+ */
+function isMissingSlackReplyTargetProcedureError(error: unknown): boolean {
+  if (!(error instanceof Error) || error.name !== 'TRPCClientError') {
+    return false;
+  }
+
+  const data = (error as { data?: { code?: string } }).data;
+
+  return (
+    data?.code === 'NOT_FOUND' ||
+    // Backstop for responses that lose the typed code (e.g. a proxy rewrote
+    // the body): tRPC's unknown-procedure message across versions.
+    /no .*procedure.* on path/i.test(error.message)
+  );
+}
+
 function getInitialSlackTurnMessageTs(taskRun: {
   payloadKind: string;
   payload: unknown;
@@ -1222,6 +1245,22 @@ export const runTask = async ({
           }
           return result;
         } catch (error) {
+          // A rolled-back API (the supported N-1 target) predates these
+          // procedures entirely, and tRPC reports that as NOT_FOUND. The
+          // procedures themselves never answer NOT_FOUND (a missing
+          // authorization is a null result), so this is unambiguous version
+          // skew. Reply-target routing did not exist on that release either,
+          // so canonical routing IS its correct behavior; blocking would
+          // instead stall every queued prompt until the snapshot is
+          // replaced.
+          if (isMissingSlackReplyTargetProcedureError(error)) {
+            delete context.slackReplyTarget;
+            logger.warn(
+              `[runTask] Slack reply target procedures are unavailable on this API (rolled-back release?); delivering with canonical routing`,
+            );
+            return result;
+          }
+
           return {
             shouldReconnect: false,
             shouldBlockPrompt: true,

--- a/apps/worker/src/run-task/slack-reply-target.ts
+++ b/apps/worker/src/run-task/slack-reply-target.ts
@@ -1,0 +1,19 @@
+/**
+ * True when a tRPC call failed because the Slack reply-target procedure does
+ * not exist on the API, which identifies the supported N-1 rollback target.
+ */
+export function isMissingSlackReplyTargetProcedureError(
+  error: unknown,
+): boolean {
+  if (!(error instanceof Error) || error.name !== 'TRPCClientError') {
+    return false;
+  }
+
+  const data = (error as { data?: { code?: string } }).data;
+
+  return (
+    data?.code === 'NOT_FOUND' ||
+    // Backstop for responses that lose the typed code after a proxy rewrite.
+    /no .*procedure.* on path/i.test(error.message)
+  );
+}

--- a/deploy/coolify/README.md
+++ b/deploy/coolify/README.md
@@ -239,16 +239,16 @@ channels, meeting notes, GitHub issues) become pages that agents consult
 with citations, and agents record what they decided and why when they
 finish substantial work.
 
-One variable turns it on. Add it to the resource's environment variables
-panel in Coolify:
+One variable turns it on:
 
-1. Configure a model provider under **Settings → Models** after first boot,
-   if you have not already. The gbrain service holds no provider key; it asks
-   the api service for embeddings and synthesis, and the api service uses the
-   key your deployment already has. Changing it later needs no redeploy.
-2. To bill the Brain separately from task inference, set
-   `R_BRAIN_OPENROUTER_API_KEY` or `R_BRAIN_OPENAI_API_KEY` in the
-   resource's environment variables panel. Those take precedence.
+1. Set `R_BRAIN_OPENROUTER_API_KEY` or `R_BRAIN_OPENAI_API_KEY` in the
+   resource's environment variables panel. The explicit `R_BRAIN_*` name is
+   the Brain's on switch: a deployment that only configured task models
+   under **Settings → Models** keeps no Brain, no ingestion, and agents are
+   never told one exists. The value can be the same key you use for tasks,
+   or a separate one to bill the Brain independently. The gbrain service
+   holds no provider key; it asks the api service for embeddings and
+   synthesis using this key, and changing it later needs no redeploy.
 2. Redeploy the resource. Within a minute the deployment registers its own
    scoped clients against the Brain (read-only agent access, ingestion, and
    maintenance), backfills the task history it already has,

--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -398,17 +398,17 @@ integrations (pull requests, public Slack channels, meeting notes, GitHub
 issues) become pages that agents consult with citations, and agents record
 what they decided and why when they finish substantial work.
 
-Nothing here, in most cases:
+One variable turns it on: set `R_BRAIN_OPENROUTER_API_KEY` or
+`R_BRAIN_OPENAI_API_KEY` on **api** (or as a Settings environment value).
+The explicit `R_BRAIN_*` name is the Brain's on switch: a deployment that
+only configured task models under **Settings → Models** keeps no Brain, no
+ingestion, and agents are never told one exists. The value can be the same
+key you use for tasks, or a separate one to bill the Brain independently.
+The Brain has no provider key of its own; it asks the api service for
+embeddings and synthesis using this key, and changing it later takes effect
+on the Brain's next request, with no redeploy.
 
-1. Configure a model provider under **Settings → Models** after first boot, if
-   you have not already. The Brain has no provider key of its own; it asks the
-   api service for embeddings and synthesis, and the api service uses the key
-   your deployment already has. Changing that key later takes effect on the
-   Brain's next request, with no redeploy.
-2. To bill the Brain separately from task inference, set
-   `R_BRAIN_OPENROUTER_API_KEY` or `R_BRAIN_OPENAI_API_KEY` on **api**.
-   Those take precedence over the deployment's general provider keys.
-Within a minute of a provider being configured, the deployment registers
+Within a minute of the Brain key being configured, the deployment registers
 its own scoped clients against the Brain (a read-only one for agents, a
 write-only one for ingestion), backfills the task history it already has, and
 starts delivering the Brain to new tasks. Watch the bullmq service logs for

--- a/deploy/render/README.md
+++ b/deploy/render/README.md
@@ -356,14 +356,19 @@ agents record what they decided and why when they finish substantial work.
 Render's Blueprint cannot generate the admin token for you (`generateValue`
 produces base64, and gbrain requires at least 32 characters of
 `[A-Za-z0-9_-]` or it refuses to boot), so enabling the Brain is two values
-rather than Railway's one. Both go on the **roomote-gbrain** service:
+rather than Railway's one:
 
-1. Configure a model provider under **Settings → Models** after first boot,
-   if you have not already. The roomote-gbrain service holds no provider key;
-   it asks roomote-api for embeddings and synthesis, and roomote-api uses the
-   key your deployment already has. Changing it later needs no redeploy. To
-   bill the Brain separately, set `R_BRAIN_OPENROUTER_API_KEY` or
-   `R_BRAIN_OPENAI_API_KEY` on the app services instead.
+1. Set `R_BRAIN_OPENROUTER_API_KEY` or `R_BRAIN_OPENAI_API_KEY` as a
+   Settings environment value, which reaches every app service from one
+   place. (Setting it as a Render environment variable also works, but the
+   Blueprint duplicates the env block per service, so it must be set on all
+   four app services.) The explicit `R_BRAIN_*` name is the Brain's on
+   switch: a deployment that only configured task models under
+   **Settings → Models** keeps no Brain, no ingestion, and agents are never
+   told one exists. The value can be the same key you use for tasks, or a
+   separate one to bill the Brain independently. The roomote-gbrain service
+   holds no provider key; it asks roomote-api for embeddings and synthesis
+   using this key, and changing it later needs no redeploy.
 2. Set `GBRAIN_ADMIN_BOOTSTRAP_TOKEN` to a fresh random value. Generate one
    with `openssl rand -hex 24`, which is 48 conforming characters. Roomote
    uses it only to register its own scoped clients; it is never handed to an

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-integration-broker.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-integration-broker.test.ts
@@ -8,7 +8,7 @@ const mocks = vi.hoisted(() => ({
   select: vi.fn(),
   findGithubInstallation: vi.fn(),
   brainEnv: { R_GBRAIN_URL: undefined as string | undefined },
-  isBrainConfigured: vi.fn(),
+  isBrainProviderConfigured: vi.fn(),
 }));
 
 vi.mock('@roomote/auth', () => ({
@@ -17,7 +17,6 @@ vi.mock('@roomote/auth', () => ({
 
 vi.mock('@roomote/env', () => ({
   Env: mocks.brainEnv,
-  isBrainConfigured: mocks.isBrainConfigured,
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -36,6 +35,7 @@ vi.mock('@roomote/db/server', () => ({
   },
   eq: vi.fn(() => 'enabled-filter'),
   githubInstallations: { suspendedAt: 'suspendedAt' },
+  isBrainProviderConfigured: mocks.isBrainProviderConfigured,
   isNull: vi.fn(() => 'not-suspended-filter'),
 }));
 
@@ -77,7 +77,7 @@ describe('fast-agent integration broker', () => {
     mocks.createAuthToken.mockResolvedValue('control-plane-token');
     mocks.findGithubInstallation.mockResolvedValue(undefined);
     mocks.brainEnv.R_GBRAIN_URL = undefined;
-    mocks.isBrainConfigured.mockReturnValue(false);
+    mocks.isBrainProviderConfigured.mockResolvedValue(false);
     mocks.beginIntegrationCall.mockResolvedValue({
       id: 'audit-1',
       startedAt: new Date('2026-08-16T00:00:00.000Z'),
@@ -107,7 +107,7 @@ describe('fast-agent integration broker', () => {
 
   it('exposes the read-only Brain proxy when the Brain is configured', async () => {
     mocks.brainEnv.R_GBRAIN_URL = 'http://gbrain:8931';
-    mocks.isBrainConfigured.mockReturnValue(true);
+    mocks.isBrainProviderConfigured.mockResolvedValue(true);
 
     const integrations = await listFastAgentIntegrations({
       userId: 'user-1',
@@ -132,7 +132,7 @@ describe('fast-agent integration broker', () => {
 
   it('does not probe or expose Brain when it is not fully configured', async () => {
     mocks.brainEnv.R_GBRAIN_URL = 'http://gbrain:8931';
-    mocks.isBrainConfigured.mockReturnValue(false);
+    mocks.isBrainProviderConfigured.mockResolvedValue(false);
 
     await expect(
       listFastAgentIntegrations({
@@ -146,7 +146,7 @@ describe('fast-agent integration broker', () => {
 
   it('does not expose a wired Brain whose proxy is not usable yet', async () => {
     mocks.brainEnv.R_GBRAIN_URL = 'http://gbrain:8931';
-    mocks.isBrainConfigured.mockReturnValue(true);
+    mocks.isBrainProviderConfigured.mockResolvedValue(true);
     mocks.listMcpTools.mockRejectedValue(
       new Error('The Brain inference provider is not configured'),
     );

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-integration-broker.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-integration-broker.ts
@@ -1,5 +1,5 @@
 import { createAuthToken } from '@roomote/auth';
-import { Env, isBrainConfigured } from '@roomote/env';
+import { Env } from '@roomote/env';
 import {
   beginSlackFastIntegrationCall,
   completeSlackFastIntegrationCall,
@@ -7,6 +7,7 @@ import {
   deploymentMcpEnablements,
   eq,
   githubInstallations,
+  isBrainProviderConfigured,
   isNull,
 } from '@roomote/db/server';
 import {
@@ -162,7 +163,10 @@ export async function listFastAgentIntegrations(
     },
   );
 
-  if (isBrainConfigured(Env) && Env.R_GBRAIN_URL) {
+  // Same activation rule as sandbox MCP delivery: only an explicit R_BRAIN_*
+  // provider key means the deployment has a Brain, because the URL and
+  // gateway token are template-defaulted plumbing on some platforms.
+  if (Env.R_GBRAIN_URL && (await isBrainProviderConfigured())) {
     candidates.push({
       id: BRAIN_MCP_ID,
       name: 'Brain',

--- a/packages/db/src/lib/model-runtime-config.test.ts
+++ b/packages/db/src/lib/model-runtime-config.test.ts
@@ -35,9 +35,18 @@ vi.mock('../db', () => ({
   },
 }));
 
-vi.mock('./environment-variables', () => ({
-  stringifyDecryptedEnvVarValue: (value: unknown) => String(value),
-}));
+vi.mock('./environment-variables', async (importOriginal) => {
+  // Keep the real resolveDeploymentEnvVar: it reads through the mocked db
+  // and encryption modules above, and isBrainProviderConfigured exercises
+  // that persisted-settings path for real.
+  const actual =
+    await importOriginal<typeof import('./environment-variables')>();
+
+  return {
+    ...actual,
+    stringifyDecryptedEnvVarValue: (value: unknown) => String(value),
+  };
+});
 
 vi.mock('./chatgpt-subscription', () => ({
   resolveOpenCodeAuthContent: (...args: unknown[]) =>
@@ -62,6 +71,8 @@ vi.mock('../schema', () => ({
 }));
 
 import {
+  isBrainProviderConfigured,
+  resetBrainProviderConfiguredCache,
   resolveEffectiveModelRuntimeEnv,
   resolveSandboxModelRuntimeEnv,
 } from './model-runtime-config';
@@ -1050,5 +1061,61 @@ describe('resolveEffectiveModelRuntimeEnv', () => {
       expect(env).not.toHaveProperty('LITELLM_API_KEY');
       expect(env).not.toHaveProperty('LITELLM_BASE_URL');
     });
+  });
+});
+
+describe('isBrainProviderConfigured', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    resetBrainProviderConfiguredCache();
+    mockDecryptSecrets.mockImplementation(async (value) => value);
+    mockEnvironmentVariablesFindMany.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    resetBrainProviderConfiguredCache();
+  });
+
+  it('is off with nothing configured', async () => {
+    await expect(isBrainProviderConfigured()).resolves.toBe(false);
+  });
+
+  it('is never satisfied by the general task provider keys', async () => {
+    // Nearly every deployment has one of these to run tasks. Counting them
+    // would activate the Brain everywhere the templates generate the gateway
+    // token, which is the auto-activation bug this predicate exists to close.
+    vi.stubEnv('OPENROUTER_API_KEY', 'sk-or-general');
+    vi.stubEnv('OPENAI_API_KEY', 'sk-general');
+
+    await expect(isBrainProviderConfigured()).resolves.toBe(false);
+  });
+
+  it('activates on an explicit Brain key in the runtime env', async () => {
+    vi.stubEnv('R_BRAIN_OPENROUTER_API_KEY', 'sk-or-brain');
+
+    await expect(isBrainProviderConfigured()).resolves.toBe(true);
+  });
+
+  it('activates on an explicit Brain key persisted in Settings', async () => {
+    mockEnvironmentVariablesFindMany.mockResolvedValue([
+      { name: 'R_BRAIN_OPENAI_API_KEY', value: 'sk-brain-persisted' },
+    ]);
+
+    await expect(isBrainProviderConfigured()).resolves.toBe(true);
+  });
+
+  it('caches the answer between calls', async () => {
+    vi.stubEnv('R_BRAIN_OPENAI_API_KEY', 'sk-brain');
+
+    await expect(isBrainProviderConfigured()).resolves.toBe(true);
+    await expect(isBrainProviderConfigured()).resolves.toBe(true);
+
+    // The second call answers from cache; only the first resolution may have
+    // touched persisted settings at all.
+    expect(
+      mockEnvironmentVariablesFindMany.mock.calls.length,
+    ).toBeLessThanOrEqual(1);
   });
 });

--- a/packages/db/src/lib/model-runtime-config.ts
+++ b/packages/db/src/lib/model-runtime-config.ts
@@ -198,6 +198,72 @@ export async function resolveModelProviderEnvValue(
   return undefined;
 }
 
+/**
+ * The R_BRAIN_* names alone, in Settings or the environment, are the Brain's
+ * activation signal. The general provider keys (OPENROUTER_API_KEY,
+ * OPENAI_API_KEY) exist on nearly every deployment because they run tasks,
+ * and some platform templates auto-generate the Brain's gateway token and
+ * URL as plumbing, so none of those can carry an operator's intent to turn
+ * the Brain on. Setting a brain-specific key is the one signal that cannot
+ * happen by accident.
+ */
+const EXPLICIT_BRAIN_PROVIDER_ENV_VAR_NAMES = [
+  'R_BRAIN_OPENROUTER_API_KEY',
+  'R_BRAIN_OPENAI_API_KEY',
+] as const;
+
+/**
+ * Cached like the Brain provider resolution in @roomote/sdk and for the same
+ * reason: this predicate sits in front of per-event paths (sandbox MCP
+ * delivery, fast-agent integration listing) and per-minute scheduled jobs,
+ * and the answer only changes when an admin edits Settings.
+ */
+const BRAIN_PROVIDER_CONFIGURED_CACHE_TTL_MS = 30_000;
+
+let brainProviderConfiguredCache: {
+  value: boolean;
+  expiresAtMs: number;
+} | null = null;
+
+/** Drop the cached answer, so the next call re-reads settings. */
+export function resetBrainProviderConfiguredCache(): void {
+  brainProviderConfiguredCache = null;
+}
+
+/**
+ * Whether an operator explicitly enabled the Brain by configuring a
+ * brain-specific provider key.
+ *
+ * This is the activation predicate for everything user-visible: delivering
+ * the gbrain MCP server to sandboxes, listing the Brain as a fast-agent
+ * integration, resolving Brain connections, and accepting task memories. It
+ * is deliberately narrower than the Brain's inference-provider resolution,
+ * whose general-key fallback exists so an already-enabled Brain can bill
+ * through the deployment's regular provider key; counting that fallback (or
+ * template-generated plumbing) as activation would turn the Brain on for
+ * deployments that never asked for one.
+ */
+export async function isBrainProviderConfigured(): Promise<boolean> {
+  const cached = brainProviderConfiguredCache;
+
+  if (cached && cached.expiresAtMs > Date.now()) {
+    return cached.value;
+  }
+
+  const value = Boolean(
+    (
+      await resolveModelProviderEnvValue(EXPLICIT_BRAIN_PROVIDER_ENV_VAR_NAMES)
+    )?.trim(),
+  );
+
+  brainProviderConfiguredCache = {
+    value,
+    expiresAtMs: Date.now() + BRAIN_PROVIDER_CONFIGURED_CACHE_TTL_MS,
+  };
+
+  return value;
+}
+
 type ModelRuntimeEnvOptions = {
   runtimeEnv?: Partial<Record<string, string | undefined>>;
   deploymentEnvVars?: Record<string, string>;

--- a/packages/env/src/__tests__/index.test.ts
+++ b/packages/env/src/__tests__/index.test.ts
@@ -1178,9 +1178,11 @@ describe('isBrainConfigured', () => {
     ).toBe(true);
   });
 
-  it('activates on the gateway token, which is the whole point of it', () => {
-    // A deployment can leave the provider key to Settings, so the token is
-    // what says a Brain was wired up at all.
+  it('counts the gateway token as Brain wiring', () => {
+    // The token means a Brain could be wired here (templates generate it as
+    // plumbing), so held-memory enqueueing may begin. It is NOT activation:
+    // user-visible Brain behavior additionally requires an explicit
+    // R_BRAIN_* provider key via isBrainProviderConfigured in @roomote/db.
     expect(isBrainConfigured({ R_BRAIN_GATEWAY_TOKEN: 'gateway-token' })).toBe(
       true,
     );

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -680,26 +680,27 @@ export function isRoomoteCloudEnabled(
  * deployment. Enabled unless explicitly disabled.
  */
 /**
- * Whether this deployment has a Brain at all. Deliberately a topology
- * question, not a credential one: the gateway token is only ever set when
- * someone wired a Brain on purpose (templates generate it, compose operators
- * set it), so the provider key that makes it useful can arrive later from
- * Settings without a redeploy.
+ * Whether this deployment *might* have a Brain: some Brain wiring exists in
+ * the environment. This is deliberately a superset question, not activation.
+ * The Render and Coolify templates auto-generate the gateway token as
+ * plumbing between the gbrain service and the inference gateway, so a set
+ * token means "a Brain could be wired here", never "an operator turned the
+ * Brain on". Activation — everything user-visible, from delivering the
+ * gbrain MCP server to agents to running ingestion — additionally requires
+ * an explicit R_BRAIN_* provider key and lives in isBrainProviderConfigured
+ * (@roomote/db), which also reads Settings.
  *
  * Not R_GBRAIN_URL, which every compose file defaults to a service address
  * whether or not that service runs. Keying on a defaulted value made this
  * true everywhere and quietly enqueued memories on deployments that have no
  * Brain and never will.
  *
- * The two are separate on purpose. This gates the cheap, synchronous paths
- * that only need to know a Brain exists, above all the outbox insert inside
- * the run-completion transaction, which must not do a database lookup of its
- * own. Whether the Brain is usable right now is an async question answered
- * where it is actually needed, by resolving a connection and a provider.
- *
- * Enqueuing memories for a Brain that has no key yet is intentional: the
- * drainer holds them until one is configured, so turning the Brain on later
- * picks up the history rather than starting from that moment.
+ * The split exists because this gates the cheap, synchronous paths that only
+ * need to know a Brain might exist, above all the outbox insert inside the
+ * run-completion transaction, which must not do a database lookup of its
+ * own. Enqueuing memories for a Brain that has no key yet is intentional:
+ * the drainer holds them until one is configured, so turning the Brain on
+ * later picks up the history rather than starting from that moment.
  */
 export function isBrainConfigured(env: {
   R_BRAIN_GATEWAY_TOKEN?: string;

--- a/packages/sdk/src/server/lib/brain-clients.ts
+++ b/packages/sdk/src/server/lib/brain-clients.ts
@@ -19,12 +19,13 @@ import {
   and,
   db,
   eq,
+  isBrainProviderConfigured,
   isNull,
   mcpConnections,
   resetBrainIngestionState,
 } from '@roomote/db/server';
 import { decrypt, encrypt } from '@roomote/db/encryption';
-import { Env, isBrainConfigured } from '@roomote/env';
+import { Env } from '@roomote/env';
 import {
   BRAIN_MCP_ID,
   isMcpConnectionGbrainConfig,
@@ -235,7 +236,10 @@ export async function mintGbrainAccessToken(
 export async function resolveBrainConnection(
   role: 'agent' | 'ingest' | 'maintenance',
 ): Promise<{ baseUrl: string; token: string } | null> {
-  if (!isBrainConfigured(Env)) {
+  // Explicit R_BRAIN_* provider key only: the gateway token and R_GBRAIN_URL
+  // are template-generated plumbing on some platforms, so neither can carry
+  // the operator's intent to turn the Brain on.
+  if (!(await isBrainProviderConfigured())) {
     return null;
   }
 

--- a/packages/sdk/src/server/routers/mcp-connections.test.ts
+++ b/packages/sdk/src/server/routers/mcp-connections.test.ts
@@ -3,6 +3,7 @@ import type { AuthTokenContext, RunTokenContext } from '@roomote/types';
 const mockEnv = vi.hoisted(() => ({
   R_CURATED_INTEGRATIONS_DISABLED: false,
   R_CUSTOM_MCP_DISABLED: false,
+  R_GBRAIN_URL: undefined as string | undefined,
 }));
 
 vi.mock('@roomote/env', () => ({
@@ -10,14 +11,6 @@ vi.mock('@roomote/env', () => ({
   areCuratedIntegrationsDisabled: (value: boolean | undefined) =>
     value === true,
   isCustomMcpDisabled: (value: boolean | undefined) => value === true,
-  // Mirrors the real signal so a fixture that sets a Brain key behaves as it
-  // would in production rather than silently never delivering the Brain.
-  isBrainConfigured: (env: Record<string, string | undefined> | undefined) =>
-    Boolean(
-      env?.R_BRAIN_GATEWAY_TOKEN?.trim() ||
-      env?.R_BRAIN_OPENROUTER_API_KEY?.trim() ||
-      env?.R_BRAIN_OPENAI_API_KEY?.trim(),
-    ),
 }));
 
 const {
@@ -38,6 +31,7 @@ const {
   mockDesc,
   mockFindCustomServers,
   mockFindConnectionFirst,
+  mockIsBrainProviderConfigured,
 } = vi.hoisted(() => {
   const mockOrderBy = vi.fn();
   const mockWhere = vi.fn(() => ({
@@ -81,6 +75,9 @@ const {
     ),
     mockFindConnectionFirst: vi.fn<(...args: unknown[]) => Promise<unknown>>(
       async () => undefined,
+    ),
+    mockIsBrainProviderConfigured: vi.fn<() => Promise<boolean>>(
+      async () => false,
     ),
   };
 });
@@ -131,6 +128,7 @@ vi.mock('@roomote/db/server', () => ({
   isNull: mockIsNull,
   isNotNull: vi.fn((column: unknown) => ({ type: 'isNotNull', column })),
   inArray: mockInArray,
+  isBrainProviderConfigured: mockIsBrainProviderConfigured,
 }));
 
 vi.mock('@roomote/db/encryption', () => ({
@@ -230,6 +228,8 @@ describe('mcpConnectionsRouter.getMcpServerConfigs', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockEnv.R_CURATED_INTEGRATIONS_DISABLED = false;
+    mockEnv.R_GBRAIN_URL = undefined;
+    mockIsBrainProviderConfigured.mockResolvedValue(false);
     mockFindTaskRun.mockResolvedValue({
       actingUserId: null,
     });
@@ -246,6 +246,45 @@ describe('mcpConnectionsRouter.getMcpServerConfigs', () => {
     expect(result).toEqual({ servers: {} });
     expect(mockSelect).not.toHaveBeenCalled();
     expect(mockGetValidAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('delivers the Brain when an explicit Brain provider key is configured', async () => {
+    mockEnv.R_GBRAIN_URL = 'http://gbrain:8931';
+    mockIsBrainProviderConfigured.mockResolvedValue(true);
+
+    const result = await createCaller(
+      'https://api.preview.roomote.run/trpc/mcpConnections.getMcpServerConfigs',
+    ).getMcpServerConfigs();
+
+    expect(result.servers.gbrain).toEqual({
+      url: 'https://api.preview.roomote.run/api/mcp/gbrain',
+      headers: {},
+    });
+  });
+
+  it('never delivers the Brain on plumbing alone', async () => {
+    // Templates default R_GBRAIN_URL and auto-generate the gateway token, so
+    // neither can mean an operator turned the Brain on. Delivering here would
+    // point every agent's required preflight at a Brain nobody enabled.
+    mockEnv.R_GBRAIN_URL = 'http://gbrain:8931';
+    mockIsBrainProviderConfigured.mockResolvedValue(false);
+
+    const result = await createCaller(
+      'https://api.preview.roomote.run/trpc/mcpConnections.getMcpServerConfigs',
+    ).getMcpServerConfigs();
+
+    expect(result.servers).not.toHaveProperty('gbrain');
+  });
+
+  it('never delivers the Brain without an address to proxy to', async () => {
+    mockEnv.R_GBRAIN_URL = undefined;
+    mockIsBrainProviderConfigured.mockResolvedValue(true);
+
+    const result = await createCaller(
+      'https://api.preview.roomote.run/trpc/mcpConnections.getMcpServerConfigs',
+    ).getMcpServerConfigs();
+
+    expect(result.servers).not.toHaveProperty('gbrain');
   });
 
   it('returns the native Notion proxy without resolving an OAuth token', async () => {

--- a/packages/sdk/src/server/routers/mcp-connections.ts
+++ b/packages/sdk/src/server/routers/mcp-connections.ts
@@ -3,7 +3,6 @@ import { z } from 'zod';
 import {
   Env,
   areCuratedIntegrationsDisabled,
-  isBrainConfigured,
   isCustomMcpDisabled,
 } from '@roomote/env';
 import {
@@ -15,6 +14,7 @@ import {
   eq,
   and,
   inArray,
+  isBrainProviderConfigured,
   isNull,
   isNotNull,
   or,
@@ -189,7 +189,19 @@ export const mcpConnectionsRouter = router({
     // collide ('gbrain' is reserved for custom servers); the worker injects
     // the run token sandbox-side and the read-only upstream credential never
     // leaves the API proxy.
-    if (isBrainConfigured(Env) && Env.R_GBRAIN_URL && !servers[BRAIN_MCP_ID]) {
+    //
+    // Delivery requires the operator's explicit R_BRAIN_* provider key, not
+    // just Brain plumbing (R_GBRAIN_URL and the gateway token are
+    // template-defaulted on some platforms): an agent told the Brain exists
+    // starts every substantive topic with a preflight against it, which must
+    // never happen on a deployment that only *could* have a Brain. The check
+    // is cached alongside provider resolution, so the common off state costs
+    // nothing.
+    if (
+      Env.R_GBRAIN_URL &&
+      !servers[BRAIN_MCP_ID] &&
+      (await isBrainProviderConfigured())
+    ) {
       servers[BRAIN_MCP_ID] = {
         url: `${getRequestOrigin(ctx.req) ?? ''}${BRAIN_PROXY_PATH}`,
         headers: {},

--- a/render.yaml
+++ b/render.yaml
@@ -37,13 +37,15 @@
 #   the generated `MINIO_ROOT_PASSWORD` and the app services mirror it into
 #   `S3_SECRET_ACCESS_KEY` with a `fromService` reference.
 # - The Brain (roomote-gbrain) is a private service with a disk and no
-#   public hostname. It is inert until GBRAIN_ADMIN_BOOTSTRAP_TOKEN and one
-#   of OPENROUTER_API_KEY / OPENAI_API_KEY are set on that service; the
-#   app services mirror them with fromService references, so blank there is blank
-#   everywhere and the deployment simply has no memory. The token cannot use
-#   generateValue (Render generates base64; gbrain requires [A-Za-z0-9_-]),
-#   which is why it is sync: false rather than generated. Deployments that
-#   want no memory at all can delete the service.
+#   public hostname. It is inert until an explicit Brain provider key
+#   (R_BRAIN_OPENROUTER_API_KEY or R_BRAIN_OPENAI_API_KEY, on roomote-api or
+#   as a Settings environment value) and GBRAIN_ADMIN_BOOTSTRAP_TOKEN are
+#   set. The R_BRAIN_* name is the on switch: the deployment's general task
+#   provider keys never activate the Brain, and the generated gateway token
+#   is plumbing, not activation. The admin token cannot use generateValue
+#   (Render generates base64; gbrain requires [A-Za-z0-9_-]), which is why it
+#   is sync: false rather than generated. Deployments that want no memory at
+#   all can delete the service.
 # - Render has no Docker socket, so task execution must use a hosted
 #   sandbox provider (modal by default; e2b, daytona, blaxel, box, and azure
 #   also work).
@@ -240,9 +242,21 @@ services:
           type: pserv
           name: roomote-gbrain
           envVarKey: GBRAIN_ADMIN_BOOTSTRAP_TOKEN
+      # The Brain's on switch. Leave blank and the gbrain service idles
+      # unused: no ingestion, no delivery to agents. Fill in either key (the
+      # same value as your task provider key works, or a separate one to
+      # bill the Brain independently) to turn the Brain on; the general
+      # OPENROUTER_API_KEY / OPENAI_API_KEY never activate it. This anchored
+      # env block is duplicated per app service, so set the value on all four
+      # services, or set it once as a Settings environment value instead.
+      - key: R_BRAIN_OPENROUTER_API_KEY
+        value: ''
+      - key: R_BRAIN_OPENAI_API_KEY
+        value: ''
       # Shared secret the Brain presents to /api/brain/inference; the gateway
-      # swaps it for the provider key configured in Settings. Owned here, on
-      # the service that verifies it, and mirrored onto the Brain.
+      # swaps it for the configured Brain provider key. Owned here, on the
+      # service that verifies it, and mirrored onto the Brain. Plumbing only:
+      # a generated value never turns the Brain on.
       - key: R_BRAIN_GATEWAY_TOKEN
         generateValue: true
       # Which models the Brain runs, in the configured provider's own naming.


### PR DESCRIPTION
> &#8203;<!-- roomote:pr-attribution:start -->Opened on behalf of @mrubens.<!-- roomote:pr-attribution:end --> [View the task](https://community.roomote.ai/task/0qa8uzb7onnqx?utm_source=github-comment&utm_medium=link&utm_campaign=github_pr_review_follow_up) or mention @roomote for follow-up asks.

## What changed

- Require an explicit `R_BRAIN_OPENROUTER_API_KEY` or `R_BRAIN_OPENAI_API_KEY` before exposing the Brain to agents, starting ingestion, resolving Brain connections, or saving task memories. Template-generated gateway plumbing and general task-provider keys no longer activate it.
- Treat a missing Slack reply-target procedure as supported N-1 API version skew. Queued prompts and polled `request_user_input` answers now fall back to canonical Slack routing, while transient failures continue to block and retry.
- Update Brain documentation and deployment guidance so the Brain-specific provider key is clearly documented as the opt-in switch.

## Why this change was made

Fresh template deployments could activate Brain behavior without operator intent, causing agent preflights, ingestion, and inference spend. Separately, workers connected to a rolled-back API could requeue Slack prompts or answers forever because the older API does not expose reply-target procedures.

This addresses the release-blocking findings identified during the v0.40.0 promotion review in #1457.

## Impact

Deployments that configure only task models keep the Brain fully inactive until a Brain-specific provider key is added. Slack follow-ups and `request_user_input` answers continue to reach tasks during an N-1 API rollback through canonical routing, without weakening retries for real transport failures.