### PR TITLE
Fix Fast mode provider retries and reporting

### DIFF
--- a/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
@@ -1328,6 +1328,27 @@ describe('resolveOpenCodeSmallModel', () => {
       reason: 'rate_limited',
       retryable: true,
     },
+    // Other structured 4xx responses are client errors that resending the
+    // same request cannot recover, so retry loops must not absorb them.
+    {
+      providerMessage: 'prompt is too long',
+      statusCode: 400,
+      reason: 'provider_error',
+      retryable: false,
+    },
+    {
+      providerMessage: 'unprocessable entity',
+      statusCode: 422,
+      reason: 'provider_error',
+      retryable: false,
+    },
+    // Server-side failures stay retryable.
+    {
+      providerMessage: 'overloaded',
+      statusCode: 529,
+      reason: 'provider_error',
+      retryable: true,
+    },
   ])(
     'classifies a structured status-$statusCode provider error as $reason',
     async ({ providerMessage, statusCode, reason, retryable }) => {

--- a/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
@@ -1499,6 +1499,12 @@ describe('resolveOpenCodeSmallModel', () => {
       reason: 'rate_limited',
       retryable: true,
     },
+    {
+      providerMessage: 'request expired',
+      statusCode: 408,
+      reason: 'timeout',
+      retryable: true,
+    },
     // Other structured 4xx responses are client errors that resending the
     // same request cannot recover, so retry loops must not absorb them.
     {

--- a/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
@@ -723,18 +723,28 @@ describe('resolveOpenCodeSmallModel', () => {
     sessionPromptMock.mockReturnValue(new Promise(() => undefined));
     const onProviderRetry = vi.fn();
 
-    const { generateTrackedNonTaskObject, NON_TASK_INFERENCE_SURFACES } =
-      await import('../non-task-provider-usage.js');
+    const {
+      classifyNonTaskInferenceError,
+      generateTrackedNonTaskObject,
+      NON_TASK_INFERENCE_SURFACES,
+    } = await import('../non-task-provider-usage.js');
 
-    await expect(
-      generateTrackedNonTaskObject({
-        surface: NON_TASK_INFERENCE_SURFACES.fastAgentQuestionAnswering,
-        modelRole: 'primary',
-        schema: z.object({ answer: z.string() }),
-        prompt: 'Answer.',
-        onProviderRetry,
-      }),
-    ).rejects.toBe(providerError);
+    const result = generateTrackedNonTaskObject({
+      surface: NON_TASK_INFERENCE_SURFACES.fastAgentQuestionAnswering,
+      modelRole: 'primary',
+      schema: z.object({ answer: z.string() }),
+      prompt: 'Answer.',
+      onProviderRetry,
+    });
+    const error = await result.catch((caught: unknown) => caught);
+    expect(error).toMatchObject({
+      name: 'NonTaskOpenCodePromptError',
+      providerError,
+    });
+    expect(classifyNonTaskInferenceError(error)).toMatchObject({
+      reason: 'rate_limited',
+      retryable: true,
+    });
     expect(onProviderRetry).toHaveBeenCalledWith(
       expect.objectContaining({
         attempt: 1,
@@ -744,6 +754,167 @@ describe('resolveOpenCodeSmallModel', () => {
     expect(sessionAbortMock).toHaveBeenCalledWith({
       sessionID: 'session-1',
       directory: expect.stringContaining('roomote-non-task-'),
+    });
+  });
+
+  it.each(['prompt_result', 'session_event'] as const)(
+    'preserves and classifies a gateway block when %s settles first',
+    async (settlement) => {
+      process.env = {
+        ...originalEnv,
+        OPENCODE_SDK_SERVER_URL: 'http://127.0.0.1:4096',
+      };
+      mockResolveEffectiveModelRuntimeEnv.mockResolvedValue({
+        R_MODEL: 'openai/gpt-5.6-sol',
+      });
+      const providerError = {
+        name: 'APIError',
+        data: {
+          message:
+            'Forbidden: request was blocked by a gateway or proxy. You may not have permission to access this resource.',
+          statusCode: 403,
+          responseBody: '<html><title>Forbidden</title></html>',
+        },
+      };
+      eventSubscribeMock.mockResolvedValue({
+        stream:
+          settlement === 'session_event'
+            ? (async function* () {
+                yield {
+                  type: 'session.error' as const,
+                  properties: { sessionID: 'session-1', error: providerError },
+                };
+              })()
+            : [],
+      });
+      sessionPromptMock.mockImplementation(() =>
+        settlement === 'prompt_result'
+          ? Promise.resolve({
+              data: { info: { error: providerError }, parts: [] },
+              error: undefined,
+            })
+          : new Promise(() => undefined),
+      );
+
+      const {
+        classifyNonTaskInferenceError,
+        generateTrackedNonTaskObject,
+        NON_TASK_INFERENCE_SURFACES,
+      } = await import('../non-task-provider-usage.js');
+      const result = generateTrackedNonTaskObject({
+        surface: NON_TASK_INFERENCE_SURFACES.fastAgentQuestionAnswering,
+        modelRole: 'primary',
+        schema: z.object({ answer: z.string() }),
+        prompt: 'Answer.',
+        onProviderRetry: vi.fn(),
+      });
+
+      const error = await result.catch((caught: unknown) => caught);
+      expect(error).toMatchObject({
+        name: 'NonTaskOpenCodePromptError',
+        providerError,
+      });
+      expect(classifyNonTaskInferenceError(error)).toEqual({
+        message: 'The inference provider gateway blocked the request.',
+        reason: 'gateway_blocked',
+        retryable: true,
+      });
+      expect(sessionAbortMock).toHaveBeenCalledWith({
+        sessionID: 'session-1',
+        directory: expect.stringContaining('roomote-non-task-'),
+      });
+    },
+  );
+
+  it('keeps named terminal OpenCode errors out of outer retry loops', async () => {
+    const { classifyNonTaskInferenceError } =
+      await import('../non-task-provider-usage.js');
+
+    for (const [providerError, expectedReason] of [
+      [
+        {
+          name: 'ProviderAuthError',
+          data: { providerID: 'openai', message: 'No API key found' },
+        },
+        'invalid_credentials',
+      ],
+      [
+        {
+          name: 'ContextOverflowError',
+          data: { message: 'Input exceeds the context window' },
+        },
+        'provider_error',
+      ],
+      [
+        {
+          name: 'ContentFilterError',
+          data: { message: 'The response was blocked' },
+        },
+        'provider_error',
+      ],
+      [
+        {
+          name: 'MessageOutputLengthError',
+          data: {},
+        },
+        'provider_error',
+      ],
+    ] as const) {
+      expect(classifyNonTaskInferenceError(providerError)).toMatchObject({
+        reason: expectedReason,
+        retryable: false,
+      });
+    }
+  });
+
+  it('continues observing provider errors when retry reporting fails', async () => {
+    process.env = {
+      ...originalEnv,
+      OPENCODE_SDK_SERVER_URL: 'http://127.0.0.1:4096',
+    };
+    mockResolveEffectiveModelRuntimeEnv.mockResolvedValue({
+      R_MODEL: 'openai/gpt-5.6-sol',
+    });
+    const providerError = {
+      name: 'APIError',
+      data: { message: 'Unauthorized', statusCode: 401 },
+    };
+    eventSubscribeMock.mockResolvedValue({
+      stream: (async function* () {
+        yield {
+          type: 'session.status' as const,
+          properties: {
+            sessionID: 'session-1',
+            status: {
+              type: 'retry' as const,
+              attempt: 1,
+              message: 'Retrying',
+              next: Date.now() + 1_000,
+            },
+          },
+        };
+        yield {
+          type: 'session.error' as const,
+          properties: { sessionID: 'session-1', error: providerError },
+        };
+      })(),
+    });
+    sessionPromptMock.mockReturnValue(new Promise(() => undefined));
+
+    const { generateTrackedNonTaskObject, NON_TASK_INFERENCE_SURFACES } =
+      await import('../non-task-provider-usage.js');
+
+    await expect(
+      generateTrackedNonTaskObject({
+        surface: NON_TASK_INFERENCE_SURFACES.fastAgentQuestionAnswering,
+        modelRole: 'primary',
+        schema: z.object({ answer: z.string() }),
+        prompt: 'Answer.',
+        onProviderRetry: vi.fn().mockRejectedValue(new Error('Slack failed')),
+      }),
+    ).rejects.toMatchObject({
+      name: 'NonTaskOpenCodePromptError',
+      providerError,
     });
   });
 

--- a/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
@@ -7,9 +7,11 @@ const {
   createOpencodeClientMock,
   configProvidersMock,
   createServerMock,
+  eventSubscribeMock,
   execFileMock,
   execFileSyncMock,
   mockResolveEffectiveModelRuntimeEnv,
+  sessionAbortMock,
   spawnMock,
   sessionCreateMock,
   sessionPromptMock,
@@ -17,9 +19,11 @@ const {
   createOpencodeClientMock: vi.fn(),
   configProvidersMock: vi.fn(),
   createServerMock: vi.fn(),
+  eventSubscribeMock: vi.fn(),
   execFileMock: vi.fn(),
   execFileSyncMock: vi.fn(),
   mockResolveEffectiveModelRuntimeEnv: vi.fn(),
+  sessionAbortMock: vi.fn(),
   spawnMock: vi.fn(),
   sessionCreateMock: vi.fn(),
   sessionPromptMock: vi.fn(),
@@ -125,11 +129,16 @@ describe('resolveOpenCodeSmallModel', () => {
       config: {
         providers: configProvidersMock,
       },
+      event: {
+        subscribe: eventSubscribeMock,
+      },
       session: {
+        abort: sessionAbortMock,
         create: sessionCreateMock,
         prompt: sessionPromptMock,
       },
     });
+    sessionAbortMock.mockResolvedValue({ data: true, error: undefined });
     sessionCreateMock.mockResolvedValue({
       data: { id: 'session-1' },
       error: undefined,
@@ -671,6 +680,71 @@ describe('resolveOpenCodeSmallModel', () => {
       // fallback log names the model without a database lookup.
       'OpenCode structured prompt failed (model openrouter/z-ai/glm-5.2): StructuredOutputError: failed to satisfy schema',
     );
+  });
+
+  it('reports OpenCode provider retries and rejects with the live session error', async () => {
+    process.env = {
+      ...originalEnv,
+      OPENCODE_SDK_SERVER_URL: 'http://127.0.0.1:4096',
+    };
+    mockResolveEffectiveModelRuntimeEnv.mockResolvedValue({
+      R_MODEL: 'openai/gpt-5.6-sol',
+    });
+    const providerError = {
+      name: 'APIError',
+      data: {
+        message: 'Too Many Requests',
+        statusCode: 429,
+      },
+    };
+    eventSubscribeMock.mockResolvedValue({
+      stream: (async function* () {
+        yield {
+          type: 'session.status' as const,
+          properties: {
+            sessionID: 'session-1',
+            status: {
+              type: 'retry' as const,
+              attempt: 1,
+              message: 'Too Many Requests',
+              next: Date.now() + 5_000,
+            },
+          },
+        };
+        yield {
+          type: 'session.error' as const,
+          properties: {
+            sessionID: 'session-1',
+            error: providerError,
+          },
+        };
+      })(),
+    });
+    sessionPromptMock.mockReturnValue(new Promise(() => undefined));
+    const onProviderRetry = vi.fn();
+
+    const { generateTrackedNonTaskObject, NON_TASK_INFERENCE_SURFACES } =
+      await import('../non-task-provider-usage.js');
+
+    await expect(
+      generateTrackedNonTaskObject({
+        surface: NON_TASK_INFERENCE_SURFACES.fastAgentQuestionAnswering,
+        modelRole: 'primary',
+        schema: z.object({ answer: z.string() }),
+        prompt: 'Answer.',
+        onProviderRetry,
+      }),
+    ).rejects.toBe(providerError);
+    expect(onProviderRetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attempt: 1,
+        message: 'Too Many Requests',
+      }),
+    );
+    expect(sessionAbortMock).toHaveBeenCalledWith({
+      sessionID: 'session-1',
+      directory: expect.stringContaining('roomote-non-task-'),
+    });
   });
 
   it('returns the joined text parts from a plain SDK prompt', async () => {

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-opencode-session.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-opencode-session.test.ts
@@ -67,6 +67,52 @@ describe('FastAgentOpenCodeSessionManager', () => {
     expect(started).toEqual(['bootstrap one', 'delta two']);
   });
 
+  it('invalidates a failed session before a queued turn resumes', async () => {
+    const manager = new FastAgentOpenCodeSessionManager();
+    let releaseFailure!: () => void;
+    const failureGate = new Promise<void>((resolve) => {
+      releaseFailure = resolve;
+    });
+    const calls: Array<{ prompt: string; sessionId?: string }> = [];
+    const execute = vi.fn(async (session, prompt: string) => {
+      calls.push({ prompt, sessionId: session.id });
+      if (prompt === 'bootstrap one') {
+        session.id = 'failed-session';
+        await failureGate;
+        throw new Error('provider failed');
+      }
+      session.id ??= 'replacement-session';
+      return prompt;
+    });
+
+    const first = manager.run({
+      conversationId: 'conversation-1',
+      prompt: 'delta one',
+      bootstrapPrompt: 'bootstrap one',
+      execute,
+    });
+    await vi.waitFor(() => expect(calls).toHaveLength(1));
+    const second = manager.run({
+      conversationId: 'conversation-1',
+      prompt: 'delta two',
+      bootstrapPrompt: 'bootstrap two with visible error',
+      execute,
+    });
+    const firstFailure = expect(first).rejects.toThrow('provider failed');
+
+    releaseFailure();
+
+    await firstFailure;
+    await expect(second).resolves.toBe('bootstrap two with visible error');
+    expect(calls).toEqual([
+      { prompt: 'bootstrap one', sessionId: undefined },
+      {
+        prompt: 'bootstrap two with visible error',
+        sessionId: undefined,
+      },
+    ]);
+  });
+
   it('recreates a missing OpenCode session from the bootstrap prompt once', async () => {
     const manager = new FastAgentOpenCodeSessionManager();
     const execute = vi

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-opencode-session.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-opencode-session.test.ts
@@ -99,6 +99,38 @@ describe('FastAgentOpenCodeSessionManager', () => {
     expect(execute).toHaveBeenCalledTimes(3);
   });
 
+  it('rebuilds an invalidated conversation from compatibility history', async () => {
+    const manager = new FastAgentOpenCodeSessionManager();
+    const prompts: Array<{ prompt: string; sessionId?: string }> = [];
+    const execute = vi.fn(async (session, prompt: string) => {
+      prompts.push({ prompt, sessionId: session.id });
+      session.id ??= `session-${prompts.length}`;
+      return prompt;
+    });
+
+    await manager.run({
+      conversationId: 'conversation-1',
+      prompt: 'turn one',
+      bootstrapPrompt: 'bootstrap turn one',
+      execute,
+    });
+    manager.invalidate('conversation-1');
+    await manager.run({
+      conversationId: 'conversation-1',
+      prompt: 'turn two only',
+      bootstrapPrompt: 'visible history including the failure and turn two',
+      execute,
+    });
+
+    expect(prompts).toEqual([
+      { prompt: 'bootstrap turn one', sessionId: undefined },
+      {
+        prompt: 'visible history including the failure and turn two',
+        sessionId: undefined,
+      },
+    ]);
+  });
+
   it('forgets idle and least-recently-used sessions', async () => {
     let now = 0;
     const manager = new FastAgentOpenCodeSessionManager({

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   getEnvironments: vi.fn(),
   generateText: vi.fn(),
   classifyInferenceError: vi.fn(),
+  invalidateSession: vi.fn(),
   listIntegrations: vi.fn(),
   callIntegration: vi.fn(),
   sendTaskMessage: vi.fn(),
@@ -49,6 +50,9 @@ vi.mock('../../non-task-provider-usage', () => ({
   },
   classifyNonTaskInferenceError: mocks.classifyInferenceError,
   generateTrackedNonTaskTextInOpenCodeSession: mocks.generateText,
+  isNonTaskOpenCodePromptTimeoutError: (error: unknown) =>
+    error instanceof Error &&
+    error.name === 'NonTaskOpenCodePromptTimeoutError',
   isNonTaskOpenCodeSessionNotFoundError: (error: unknown) =>
     error instanceof Error &&
     error.name === 'NonTaskOpenCodeSessionNotFoundError',
@@ -56,13 +60,14 @@ vi.mock('../../non-task-provider-usage', () => ({
 
 vi.mock('../fast-agent-opencode-session', () => ({
   fastAgentOpenCodeSessionManager: {
+    invalidate: mocks.invalidateSession,
     run: ({
       prompt,
       execute,
     }: {
       prompt: string;
       execute: (
-        session: { id: string },
+        session: { id?: string },
         selectedPrompt: string,
       ) => Promise<unknown>;
     }) => execute({ id: 'opencode-session-1' }, prompt),
@@ -173,6 +178,13 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
         return {
           message: 'The inference provider is rate limiting requests.',
           reason: 'rate_limited',
+          retryable: true,
+        };
+      }
+      if (detail.includes('gateway or proxy')) {
+        return {
+          message: 'The inference provider gateway blocked the request.',
+          reason: 'gateway_blocked',
           retryable: true,
         };
       }
@@ -521,6 +533,91 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
     expect(adapter.postReply).toHaveBeenCalledWith(
       expect.objectContaining({ purpose: 'closeout' }),
     );
+    expect(mocks.invalidateSession).toHaveBeenCalledWith('conversation-1');
+  });
+
+  it('retries a gateway block from a clean compatibility bootstrap', async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.getSession.mockResolvedValue({
+        id: 'conversation-1',
+        compatibilityMessages: [
+          { role: 'user', content: 'Earlier question' },
+          { role: 'assistant', content: 'Earlier answer' },
+        ],
+      });
+      mocks.generateText
+        .mockRejectedValueOnce(
+          new Error('Forbidden: request was blocked by a gateway or proxy.'),
+        )
+        .mockImplementationOnce(async (_params, _session, options) => {
+          await options.onSessionReady('replacement-session');
+          await invokeTool(nativeToolNames.sendChatReply, {
+            purpose: 'closeout',
+            message: 'The retry recovered.',
+          });
+          return '';
+        });
+      const adapter = callbacks();
+
+      const resultPromise = answerFastAgentQuestion({ ...baseParams, adapter });
+      await vi.runAllTimersAsync();
+
+      await expect(resultPromise).resolves.toBe('The retry recovered.');
+      expect(mocks.generateText).toHaveBeenCalledTimes(2);
+      expect(mocks.generateText.mock.calls[0]?.[0].prompt).not.toContain(
+        'Earlier answer',
+      );
+      expect(mocks.generateText.mock.calls[1]?.[0].prompt).toContain(
+        'Earlier answer',
+      );
+      expect(adapter.postReply).toHaveBeenNthCalledWith(1, {
+        purpose: 'progress',
+        message:
+          'Fast mode’s request was blocked by the inference provider gateway. Retrying in 1s (attempt 1/3).',
+      });
+      expect(mocks.invalidateSession).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not replay a failed turn after a native tool was invoked', async () => {
+    mocks.generateText.mockImplementationOnce(
+      async (_params, _session, options) => {
+        await options.onSessionReady('opencode-session-1');
+        await invokeTool(nativeToolNames.sendChatReply, {
+          purpose: 'ack',
+          message: 'I’m checking.',
+        });
+        throw new Error('TypeError: fetch failed');
+      },
+    );
+    const adapter = callbacks();
+
+    await answerFastAgentQuestion({ ...baseParams, adapter });
+
+    expect(mocks.generateText).toHaveBeenCalledOnce();
+    expect(adapter.postReply).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        purpose: 'progress',
+        message: expect.stringContaining('Retrying in'),
+      }),
+    );
+    expect(mocks.invalidateSession).toHaveBeenCalledWith('conversation-1');
+  });
+
+  it('leaves the OpenCode prompt deadline as the single retry budget', async () => {
+    const timeout = new Error(
+      'Timed out waiting for OpenCode output after 120000ms.',
+    );
+    timeout.name = 'NonTaskOpenCodePromptTimeoutError';
+    mocks.generateText.mockRejectedValue(timeout);
+
+    await answerFastAgentQuestion({ ...baseParams, adapter: callbacks() });
+
+    expect(mocks.generateText).toHaveBeenCalledOnce();
+    expect(mocks.invalidateSession).toHaveBeenCalledWith('conversation-1');
   });
 
   it('retries a transient native prompt failure with a visible notice', async () => {

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   getSession: vi.fn(),
   getEnvironments: vi.fn(),
   generateText: vi.fn(),
+  classifyInferenceError: vi.fn(),
   listIntegrations: vi.fn(),
   callIntegration: vi.fn(),
   sendTaskMessage: vi.fn(),
@@ -46,7 +47,11 @@ vi.mock('../../non-task-provider-usage', () => ({
   NON_TASK_INFERENCE_SURFACES: {
     fastAgentQuestionAnswering: 'fast_agent_question_answering',
   },
+  classifyNonTaskInferenceError: mocks.classifyInferenceError,
   generateTrackedNonTaskTextInOpenCodeSession: mocks.generateText,
+  isNonTaskOpenCodeSessionNotFoundError: (error: unknown) =>
+    error instanceof Error &&
+    error.name === 'NonTaskOpenCodeSessionNotFoundError',
 }));
 
 vi.mock('../fast-agent-opencode-session', () => ({
@@ -160,6 +165,37 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
     mocks.getUserIdentity.mockResolvedValue({
       displayName: 'Matt Rubens',
       githubLogin: 'mrubens',
+    });
+    mocks.classifyInferenceError.mockImplementation((error: unknown) => {
+      const detail = error instanceof Error ? error.message.toLowerCase() : '';
+
+      if (detail.includes('429') || detail.includes('rate limit')) {
+        return {
+          message: 'The inference provider is rate limiting requests.',
+          reason: 'rate_limited',
+          retryable: true,
+        };
+      }
+      if (detail.includes('fetch failed') || detail.includes('network error')) {
+        return {
+          message: 'Roomote could not reach the inference provider endpoint.',
+          reason: 'endpoint_unreachable',
+          retryable: true,
+        };
+      }
+      if (detail.includes('timed out') || detail.includes('timeout')) {
+        return {
+          message: 'The inference provider did not respond in time.',
+          reason: 'timeout',
+          retryable: true,
+        };
+      }
+
+      return {
+        message: 'The inference provider rejected the request.',
+        reason: 'provider_error',
+        retryable: false,
+      };
     });
     mocks.generateText.mockImplementation(
       async (_params, _session, options) => {
@@ -487,21 +523,188 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
     );
   });
 
-  it('does not claim a retry after a transient native prompt failure', async () => {
-    mocks.generateText.mockRejectedValue(new Error('fetch failed'));
+  it('retries a transient native prompt failure with a visible notice', async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.generateText
+        .mockRejectedValueOnce(new Error('TypeError: fetch failed'))
+        .mockImplementationOnce(async (_params, _session, options) => {
+          await options.onSessionReady('opencode-session-1');
+          await invokeTool(nativeToolNames.sendChatReply, {
+            purpose: 'closeout',
+            message: 'It coordinates incoming requests.',
+          });
+          return '';
+        });
+      const adapter = callbacks();
+
+      const resultPromise = answerFastAgentQuestion({ ...baseParams, adapter });
+      await vi.runAllTimersAsync();
+
+      await expect(resultPromise).resolves.toBe(
+        'It coordinates incoming requests.',
+      );
+      expect(mocks.generateText).toHaveBeenCalledTimes(2);
+      expect(adapter.postReply).toHaveBeenNthCalledWith(1, {
+        purpose: 'progress',
+        message: expect.stringContaining('Retrying in 1s (attempt 1/3)'),
+      });
+      expect(adapter.postReply).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ purpose: 'closeout' }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('backs off longer and reports a provider 429 before retrying', async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.generateText
+        .mockRejectedValueOnce(
+          new Error('OpenCode structured prompt failed: 429 Too Many Requests'),
+        )
+        .mockImplementationOnce(async (_params, _session, options) => {
+          await options.onSessionReady('opencode-session-1');
+          await invokeTool(nativeToolNames.sendChatReply, {
+            purpose: 'closeout',
+            message: 'It coordinates incoming requests.',
+          });
+          return '';
+        });
+      const adapter = callbacks();
+
+      const resultPromise = answerFastAgentQuestion({ ...baseParams, adapter });
+      await vi.runAllTimersAsync();
+
+      await expect(resultPromise).resolves.toBe(
+        'It coordinates incoming requests.',
+      );
+      expect(adapter.postReply).toHaveBeenNthCalledWith(1, {
+        purpose: 'progress',
+        message:
+          'Fast mode’s inference provider is rate limiting requests. Retrying in 5s (attempt 1/3).',
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reports OpenCode internal provider retries while the prompt is pending', async () => {
+    mocks.generateText.mockImplementationOnce(
+      async (params, _session, options) => {
+        await params.onProviderRetry?.({
+          attempt: 1,
+          message: '429 Too Many Requests',
+        });
+        await options.onSessionReady('opencode-session-1');
+        await invokeTool(nativeToolNames.sendChatReply, {
+          purpose: 'closeout',
+          message: 'It coordinates incoming requests.',
+        });
+        return '';
+      },
+    );
     const adapter = callbacks();
 
     await expect(
       answerFastAgentQuestion({ ...baseParams, adapter }),
-    ).resolves.toBe(
-      'Fast mode could not reach the model. Please try again in a moment.',
-    );
-    expect(mocks.generateText).toHaveBeenCalledOnce();
-    expect(adapter.postReply).toHaveBeenCalledWith({
-      purpose: 'closeout',
+    ).resolves.toBe('It coordinates incoming requests.');
+    expect(adapter.postReply).toHaveBeenNthCalledWith(1, {
+      purpose: 'progress',
       message:
-        'Fast mode could not reach the model. Please try again in a moment.',
+        'Fast mode’s inference provider is rate limiting requests. Retrying automatically…',
     });
+  });
+
+  it('reports the classified provider failure after retries are exhausted', async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.generateText.mockRejectedValue(
+        new Error('TypeError: fetch failed'),
+      );
+      const adapter = callbacks();
+
+      const resultPromise = answerFastAgentQuestion({ ...baseParams, adapter });
+      await vi.runAllTimersAsync();
+
+      await expect(resultPromise).resolves.toBe(
+        'Fast mode could not reach the inference provider after retrying. Please try again in a moment.',
+      );
+      expect(mocks.generateText).toHaveBeenCalledTimes(4);
+      expect(adapter.postReply).toHaveBeenLastCalledWith({
+        purpose: 'closeout',
+        message:
+          'Fast mode could not reach the inference provider after retrying. Please try again in a moment.',
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not surface a duplicate retry notice for repeated failures', async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.generateText
+        .mockRejectedValueOnce(new Error('TypeError: fetch failed'))
+        .mockRejectedValueOnce(new Error('TypeError: fetch failed'))
+        .mockImplementationOnce(async (_params, _session, options) => {
+          await options.onSessionReady('opencode-session-1');
+          await invokeTool(nativeToolNames.sendChatReply, {
+            purpose: 'closeout',
+            message: 'It coordinates incoming requests.',
+          });
+          return '';
+        });
+      const adapter = callbacks();
+
+      const resultPromise = answerFastAgentQuestion({ ...baseParams, adapter });
+      await vi.runAllTimersAsync();
+      await resultPromise;
+
+      const progressMessages = vi
+        .mocked(adapter.postReply)
+        .mock.calls.filter(([reply]) => reply.purpose === 'progress');
+      expect(progressMessages).toHaveLength(2);
+      expect(progressMessages[0]?.[0]?.message).toContain('attempt 1/3');
+      expect(progressMessages[1]?.[0]?.message).toContain('attempt 2/3');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('retries platform events without posting retry notices', async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.generateText
+        .mockRejectedValueOnce(new Error('TypeError: fetch failed'))
+        .mockImplementationOnce(async (_params, _session, options) => {
+          await options.onSessionReady('opencode-session-1');
+          await invokeTool(nativeToolNames.sendChatReply, {
+            purpose: 'closeout',
+            message: 'Startup recovered.',
+          });
+          return '';
+        });
+      const adapter = callbacks();
+
+      const resultPromise = answerFastAgentQuestion({
+        ...baseParams,
+        turnSource: 'platform_event',
+        adapter,
+      });
+      await vi.runAllTimersAsync();
+      await resultPromise;
+
+      expect(mocks.generateText).toHaveBeenCalledTimes(2);
+      expect(adapter.postReply).toHaveBeenCalledOnce();
+      expect(adapter.postReply).toHaveBeenCalledWith(
+        expect.objectContaining({ purpose: 'closeout' }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('rethrows native prompt failures for platform event retry', async () => {

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-opencode-session.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-opencode-session.ts
@@ -65,16 +65,28 @@ export class FastAgentOpenCodeSessionManager {
 
     try {
       const selectedPrompt = entry.session.id ? prompt : bootstrapPrompt;
+      const executeAndInvalidateOnFailure = async (
+        nextPrompt: string,
+      ): Promise<T> => {
+        try {
+          return await execute(entry.session, nextPrompt);
+        } catch (error) {
+          // OpenCode persists the user turn before inference. Clear the failed
+          // session before releasing queued work so the next turn cannot send
+          // a delta into a poisoned transcript.
+          entry.session.id = undefined;
+          throw error;
+        }
+      };
 
       try {
-        return await execute(entry.session, selectedPrompt);
+        return await executeAndInvalidateOnFailure(selectedPrompt);
       } catch (error) {
         if (!isNonTaskOpenCodeSessionNotFoundError(error)) {
           throw error;
         }
 
-        entry.session.id = undefined;
-        return await execute(entry.session, bootstrapPrompt);
+        return await executeAndInvalidateOnFailure(bootstrapPrompt);
       }
     } finally {
       entry.pending -= 1;

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-opencode-session.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-opencode-session.ts
@@ -89,6 +89,17 @@ export class FastAgentOpenCodeSessionManager {
     this.entries.clear();
   }
 
+  /**
+   * Discard a failed live transcript without disturbing queued turns. The next
+   * run will rebuild the conversation from Roomote's compatibility history.
+   */
+  invalidate(conversationId: string): void {
+    const entry = this.entries.get(conversationId);
+    if (entry) {
+      entry.session.id = undefined;
+    }
+  }
+
   get size(): number {
     return this.entries.size;
   }

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -18,9 +18,12 @@ import {
   type FastAgentActiveTask,
 } from './fast-agent-session';
 import {
+  classifyNonTaskInferenceError,
   generateTrackedNonTaskTextInOpenCodeSession,
+  isNonTaskOpenCodeSessionNotFoundError,
   NON_TASK_INFERENCE_SURFACES,
   type NonTaskPromptFile,
+  type NonTaskProviderRetryEvent,
 } from '../non-task-provider-usage';
 import { fastAgentOpenCodeSessionManager } from './fast-agent-opencode-session';
 import {
@@ -113,16 +116,140 @@ function buildIntegrationCallSignature({
   ]);
 }
 
-function isRetryableFastAgentInferenceError(error: unknown): boolean {
-  const detail = formatErrorForLog(error).toLowerCase();
-  return [
-    'fetch failed',
-    'econnreset',
-    'econnrefused',
-    'enotfound',
-    'network error',
-    'socket hang up',
-  ].some((signature) => detail.includes(signature));
+export const FAST_AGENT_INFERENCE_MAX_RETRIES = 3;
+const FAST_AGENT_RATE_LIMIT_RETRY_BASE_DELAY_MS = 5_000;
+const FAST_AGENT_PROVIDER_RETRY_BASE_DELAY_MS = 1_000;
+const FAST_AGENT_RETRY_MAX_DELAY_MS = 60_000;
+
+type FastAgentInferenceFailure = ReturnType<
+  typeof classifyNonTaskInferenceError
+>;
+
+type FastAgentInferenceRetryNotice = {
+  failure: FastAgentInferenceFailure;
+  attemptNumber: number;
+  maxAttempts?: number;
+  delayMs?: number;
+};
+
+class FastAgentInferenceError extends Error {
+  constructor(
+    public readonly failure: FastAgentInferenceFailure,
+    cause: unknown,
+  ) {
+    super(
+      `Fast mode inference failed (${failure.reason}): ${formatErrorForLog(cause)}`,
+      { cause },
+    );
+    this.name = 'FastAgentInferenceError';
+  }
+}
+
+function resolveFastAgentInferenceRetryDelayMs(
+  failure: FastAgentInferenceFailure,
+  retryNumber: number,
+): number {
+  const baseDelayMs =
+    failure.reason === 'rate_limited'
+      ? FAST_AGENT_RATE_LIMIT_RETRY_BASE_DELAY_MS
+      : FAST_AGENT_PROVIDER_RETRY_BASE_DELAY_MS;
+
+  return Math.min(
+    baseDelayMs * 2 ** Math.max(0, retryNumber - 1),
+    FAST_AGENT_RETRY_MAX_DELAY_MS,
+  );
+}
+
+function formatFastAgentInferenceRetryNotice(
+  notice: FastAgentInferenceRetryNotice,
+): string {
+  const headline =
+    notice.failure.reason === 'rate_limited'
+      ? 'Fast mode’s inference provider is rate limiting requests.'
+      : notice.failure.reason === 'timeout'
+        ? 'Fast mode’s inference provider did not respond in time.'
+        : 'Fast mode’s inference provider returned a temporary error.';
+
+  if (notice.delayMs === undefined || notice.maxAttempts === undefined) {
+    return `${headline} Retrying automatically…`;
+  }
+
+  const seconds = Math.max(1, Math.round(notice.delayMs / 1_000));
+  return `${headline} Retrying in ${seconds}s (attempt ${notice.attemptNumber}/${notice.maxAttempts}).`;
+}
+
+function formatFastAgentInferenceFailure(
+  failure: FastAgentInferenceFailure,
+): string {
+  switch (failure.reason) {
+    case 'rate_limited':
+      return 'Fast mode is still being rate limited by the inference provider after retrying. Any delegated tasks can keep running; please try again when provider capacity is available.';
+    case 'timeout':
+      return 'Fast mode’s inference provider did not respond after retrying. Any delegated tasks can keep running; please try again in a moment.';
+    case 'endpoint_unreachable':
+      return 'Fast mode could not reach the inference provider after retrying. Please try again in a moment.';
+    case 'insufficient_credits':
+      return 'Fast mode cannot use the inference provider because the account has insufficient credits or quota.';
+    case 'invalid_credentials':
+      return 'Fast mode cannot authenticate with the configured inference provider. An administrator needs to reconnect or replace its credentials.';
+    case 'model_unavailable':
+      return 'Fast mode’s configured model is not available from the inference provider. An administrator needs to select an available model.';
+    default:
+      return 'Fast mode could not complete the request because its inference provider returned an error. Please try again in a moment.';
+  }
+}
+
+function waitForFastAgentInferenceRetry(delayMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
+async function runFastAgentInferenceWithRetries<T>(
+  run: () => Promise<T>,
+  onRetry?: (notice: FastAgentInferenceRetryNotice) => Promise<void>,
+): Promise<T> {
+  for (
+    let retryNumber = 0;
+    retryNumber <= FAST_AGENT_INFERENCE_MAX_RETRIES;
+    retryNumber += 1
+  ) {
+    try {
+      return await run();
+    } catch (error) {
+      // Session loss is the session manager's bootstrap signal, not a
+      // provider failure this loop should absorb.
+      if (isNonTaskOpenCodeSessionNotFoundError(error)) {
+        throw error;
+      }
+
+      const failure = classifyNonTaskInferenceError(error);
+      if (
+        !failure.retryable ||
+        retryNumber >= FAST_AGENT_INFERENCE_MAX_RETRIES
+      ) {
+        throw new FastAgentInferenceError(failure, error);
+      }
+
+      const attemptNumber = retryNumber + 1;
+      const delayMs = resolveFastAgentInferenceRetryDelayMs(
+        failure,
+        attemptNumber,
+      );
+      console.warn(
+        `[Fast Agent] Retrying inference failure attempt=${attemptNumber}/${FAST_AGENT_INFERENCE_MAX_RETRIES} delayMs=${delayMs} reason=${failure.reason}: ${formatErrorForLog(error)}`,
+      );
+      await onRetry?.({
+        failure,
+        attemptNumber,
+        maxAttempts: FAST_AGENT_INFERENCE_MAX_RETRIES,
+        delayMs,
+      });
+      await waitForFastAgentInferenceRetry(delayMs);
+    }
+  }
+
+  throw new Error('Fast mode exhausted its inference retry loop.');
 }
 
 function buildUserTextMessage(text: string): ModelMessage {
@@ -449,6 +576,34 @@ export async function answerFastAgentQuestion({
       }
     };
 
+    const reportedInferenceNotices = new Set<string>();
+    const reportInferenceRetry = async (
+      notice: FastAgentInferenceRetryNotice,
+    ) => {
+      if (platformEvent) {
+        return;
+      }
+
+      const message = formatFastAgentInferenceRetryNotice(notice);
+      if (reportedInferenceNotices.has(message)) {
+        return;
+      }
+
+      reportedInferenceNotices.add(message);
+      // Deliberately not the postReply closure: a system retry notice must
+      // not satisfy the model's acknowledgement gate or close the turn.
+      await adapter.postReply({ purpose: 'progress', message });
+      turnVisibleMessages.push(buildAssistantTextMessage(message));
+    };
+    const reportProviderRetryEvent = async (
+      event: NonTaskProviderRetryEvent,
+    ) => {
+      await reportInferenceRetry({
+        failure: classifyNonTaskInferenceError(new Error(event.message)),
+        attemptNumber: event.attempt,
+      });
+    };
+
     const requireOpen = () =>
       closed
         ? { success: false as const, error: 'This Fast turn is closed.' }
@@ -689,33 +844,39 @@ export async function answerFastAgentQuestion({
       execute: async (openCodeSession, selectedPrompt) => {
         let unbind: (() => void) | undefined;
         try {
-          return await generateTrackedNonTaskTextInOpenCodeSession(
-            {
-              userId,
-              surface: NON_TASK_INFERENCE_SURFACES.fastAgentQuestionAnswering,
-              modelRole: FAST_AGENT_MODEL_ROLE,
-              system,
-              prompt: selectedPrompt,
-              ...(imageFiles.length
-                ? {
-                    files: imageFiles,
-                    requiredInputModality: 'image' as const,
-                  }
-                : {}),
-            },
-            openCodeSession,
-            {
-              directory: nativeRuntime.directory,
-              env: nativeRuntime.env,
-              tools: FAST_AGENT_NATIVE_TOOL_FILTER,
-              onSessionReady: (openCodeSessionID) => {
-                unbind?.();
-                unbind = bindFastAgentNativeToolExecutor(
-                  openCodeSessionID,
-                  executeNativeTool,
-                );
-              },
-            },
+          return await runFastAgentInferenceWithRetries(
+            () =>
+              generateTrackedNonTaskTextInOpenCodeSession(
+                {
+                  userId,
+                  surface:
+                    NON_TASK_INFERENCE_SURFACES.fastAgentQuestionAnswering,
+                  modelRole: FAST_AGENT_MODEL_ROLE,
+                  system,
+                  prompt: selectedPrompt,
+                  onProviderRetry: reportProviderRetryEvent,
+                  ...(imageFiles.length
+                    ? {
+                        files: imageFiles,
+                        requiredInputModality: 'image' as const,
+                      }
+                    : {}),
+                },
+                openCodeSession,
+                {
+                  directory: nativeRuntime.directory,
+                  env: nativeRuntime.env,
+                  tools: FAST_AGENT_NATIVE_TOOL_FILTER,
+                  onSessionReady: (openCodeSessionID) => {
+                    unbind?.();
+                    unbind = bindFastAgentNativeToolExecutor(
+                      openCodeSessionID,
+                      executeNativeTool,
+                    );
+                  },
+                },
+              ),
+            reportInferenceRetry,
           );
         } finally {
           unbind?.();
@@ -739,8 +900,8 @@ export async function answerFastAgentQuestion({
 
     const message = launchedTaskMessage
       ? 'I posted the task kickoff, but the task could not be queued. Please retry.'
-      : isRetryableFastAgentInferenceError(error)
-        ? 'Fast mode could not reach the model. Please try again in a moment.'
+      : error instanceof FastAgentInferenceError
+        ? formatFastAgentInferenceFailure(error.failure)
         : 'I hit an error while handling that request. Please try again in a moment.';
     try {
       await adapter.postReply({ purpose: 'closeout', message });

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -20,6 +20,7 @@ import {
 import {
   classifyNonTaskInferenceError,
   generateTrackedNonTaskTextInOpenCodeSession,
+  isNonTaskOpenCodePromptTimeoutError,
   isNonTaskOpenCodeSessionNotFoundError,
   NON_TASK_INFERENCE_SURFACES,
   type NonTaskPromptFile,
@@ -132,6 +133,11 @@ type FastAgentInferenceRetryNotice = {
   delayMs?: number;
 };
 
+type FastAgentInferenceRetryOptions = {
+  canRetry?: (error: unknown, failure: FastAgentInferenceFailure) => boolean;
+  prepareRetry?: () => Promise<void> | void;
+};
+
 class FastAgentInferenceError extends Error {
   constructor(
     public readonly failure: FastAgentInferenceFailure,
@@ -166,9 +172,11 @@ function formatFastAgentInferenceRetryNotice(
   const headline =
     notice.failure.reason === 'rate_limited'
       ? 'Fast mode’s inference provider is rate limiting requests.'
-      : notice.failure.reason === 'timeout'
-        ? 'Fast mode’s inference provider did not respond in time.'
-        : 'Fast mode’s inference provider returned a temporary error.';
+      : notice.failure.reason === 'gateway_blocked'
+        ? 'Fast mode’s request was blocked by the inference provider gateway.'
+        : notice.failure.reason === 'timeout'
+          ? 'Fast mode’s inference provider did not respond in time.'
+          : 'Fast mode’s inference provider returned a temporary error.';
 
   if (notice.delayMs === undefined || notice.maxAttempts === undefined) {
     return `${headline} Retrying automatically…`;
@@ -188,6 +196,8 @@ function formatFastAgentInferenceFailure(
       return 'Fast mode’s inference provider did not respond after retrying. Any delegated tasks can keep running; please try again in a moment.';
     case 'endpoint_unreachable':
       return 'Fast mode could not reach the inference provider after retrying. Please try again in a moment.';
+    case 'gateway_blocked':
+      return 'Fast mode’s request is still being blocked by the inference provider gateway after retrying. Please try again in a moment.';
     case 'insufficient_credits':
       return 'Fast mode cannot use the inference provider because the account has insufficient credits or quota.';
     case 'invalid_credentials':
@@ -208,6 +218,7 @@ function waitForFastAgentInferenceRetry(delayMs: number): Promise<void> {
 async function runFastAgentInferenceWithRetries<T>(
   run: () => Promise<T>,
   onRetry?: (notice: FastAgentInferenceRetryNotice) => Promise<void>,
+  options: FastAgentInferenceRetryOptions = {},
 ): Promise<T> {
   for (
     let retryNumber = 0;
@@ -226,6 +237,7 @@ async function runFastAgentInferenceWithRetries<T>(
       const failure = classifyNonTaskInferenceError(error);
       if (
         !failure.retryable ||
+        options.canRetry?.(error, failure) === false ||
         retryNumber >= FAST_AGENT_INFERENCE_MAX_RETRIES
       ) {
         throw new FastAgentInferenceError(failure, error);
@@ -239,12 +251,19 @@ async function runFastAgentInferenceWithRetries<T>(
       console.warn(
         `[Fast Agent] Retrying inference failure attempt=${attemptNumber}/${FAST_AGENT_INFERENCE_MAX_RETRIES} delayMs=${delayMs} reason=${failure.reason}: ${formatErrorForLog(error)}`,
       );
-      await onRetry?.({
-        failure,
-        attemptNumber,
-        maxAttempts: FAST_AGENT_INFERENCE_MAX_RETRIES,
-        delayMs,
-      });
+      try {
+        await onRetry?.({
+          failure,
+          attemptNumber,
+          maxAttempts: FAST_AGENT_INFERENCE_MAX_RETRIES,
+          delayMs,
+        });
+      } catch (noticeError) {
+        console.warn(
+          `[Fast Agent] Failed to post inference retry notice: ${formatErrorForLog(noticeError)}`,
+        );
+      }
+      await options.prepareRetry?.();
       await waitForFastAgentInferenceRetry(delayMs);
     }
   }
@@ -541,6 +560,7 @@ export async function answerFastAgentQuestion({
     const completedTaskActions = new Set<string>();
     let visibleUpdatePosted = false;
     let closed = false;
+    let nativeToolInvoked = false;
     let retriedTaskStart = false;
 
     const mirrorPendingMessages = async (strict = false) => {
@@ -622,6 +642,7 @@ export async function answerFastAgentQuestion({
     ): Promise<unknown> => {
       const closedError = requireOpen();
       if (closedError) return closedError;
+      nativeToolInvoked = true;
 
       try {
         switch (call.name) {
@@ -837,12 +858,16 @@ export async function answerFastAgentQuestion({
 
     const nativeRuntime = await getFastAgentNativeToolRuntime();
     const imageFiles = getFastAgentImageFiles(images);
+    const serializedTurnPrompt = serializeFastAgentMessages([turnMessage]);
+    const serializedBootstrapPrompt =
+      serializeFastAgentMessages(bootstrapMessages);
     const promptText = await fastAgentOpenCodeSessionManager.run({
       conversationId: session.id,
-      prompt: serializeFastAgentMessages([turnMessage]),
-      bootstrapPrompt: serializeFastAgentMessages(bootstrapMessages),
+      prompt: serializedTurnPrompt,
+      bootstrapPrompt: serializedBootstrapPrompt,
       execute: async (openCodeSession, selectedPrompt) => {
         let unbind: (() => void) | undefined;
+        let promptForAttempt = selectedPrompt;
         try {
           return await runFastAgentInferenceWithRetries(
             () =>
@@ -853,7 +878,7 @@ export async function answerFastAgentQuestion({
                     NON_TASK_INFERENCE_SURFACES.fastAgentQuestionAnswering,
                   modelRole: FAST_AGENT_MODEL_ROLE,
                   system,
-                  prompt: selectedPrompt,
+                  prompt: promptForAttempt,
                   onProviderRetry: reportProviderRetryEvent,
                   ...(imageFiles.length
                     ? {
@@ -877,6 +902,23 @@ export async function answerFastAgentQuestion({
                 },
               ),
             reportInferenceRetry,
+            {
+              // OpenCode already owns retries while a provider turn remains
+              // active. Roomote retries only a terminal failure that happened
+              // before the model invoked any native tool, so replay cannot
+              // duplicate a visible reply or external side effect.
+              canRetry: (error) =>
+                !nativeToolInvoked &&
+                !isNonTaskOpenCodePromptTimeoutError(error),
+              prepareRetry: () => {
+                // OpenCode persists the user message before inference starts,
+                // and abort does not roll it back. Discard the failed session
+                // and rebuild from visible compatibility history instead of
+                // appending the same turn to a poisoned transcript.
+                openCodeSession.id = undefined;
+                promptForAttempt = serializedBootstrapPrompt;
+              },
+            },
           );
         } finally {
           unbind?.();
@@ -896,6 +938,12 @@ export async function answerFastAgentQuestion({
     console.error(
       `[Fast Agent] Failed to answer question: ${formatErrorForLog(error)}`,
     );
+    if (canonicalConversationId) {
+      // The system-posted closeout below is mirrored to compatibility history,
+      // not to OpenCode's live transcript. Force the next turn to bootstrap so
+      // the model can see the failure the user saw in Slack or Discord.
+      fastAgentOpenCodeSessionManager.invalidate(canonicalConversationId);
+    }
     if (platformEvent) throw error;
 
     const message = launchedTaskMessage

--- a/packages/cloud-agents/src/server/non-task-provider-usage.ts
+++ b/packages/cloud-agents/src/server/non-task-provider-usage.ts
@@ -99,6 +99,7 @@ const NON_TASK_INFERENCE_VALIDATION_TIMEOUT_MS = 15_000;
 
 export type NonTaskInferenceValidationFailureReason =
   | 'endpoint_unreachable'
+  | 'gateway_blocked'
   | 'insufficient_credits'
   | 'invalid_credentials'
   | 'model_unavailable'
@@ -193,6 +194,31 @@ export class NonTaskOpenCodeSessionNotFoundError extends Error {
     super('The OpenCode session is no longer available.');
     this.name = 'NonTaskOpenCodeSessionNotFoundError';
   }
+}
+
+export class NonTaskOpenCodePromptError extends Error {
+  constructor(
+    public readonly providerError: unknown,
+    label: string,
+  ) {
+    super(`${label}: ${formatOpenCodeSdkError(providerError)}`, {
+      cause: providerError,
+    });
+    this.name = 'NonTaskOpenCodePromptError';
+  }
+}
+
+export class NonTaskOpenCodePromptTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Timed out waiting for OpenCode output after ${timeoutMs}ms.`);
+    this.name = 'NonTaskOpenCodePromptTimeoutError';
+  }
+}
+
+export function isNonTaskOpenCodePromptTimeoutError(
+  error: unknown,
+): error is NonTaskOpenCodePromptTimeoutError {
+  return error instanceof NonTaskOpenCodePromptTimeoutError;
 }
 
 export function isNonTaskOpenCodeSessionNotFoundError(
@@ -513,9 +539,10 @@ async function resolveModelForInputModality(
 /**
  * Shared OpenCode SDK plumbing for non-task inference: leases a managed SDK
  * server, wires the abort/timeout controller, creates a session, and issues the
- * prompt. Returns the raw prompt payload (`{ info, parts }`) so each caller can
- * interpret it — structured object extraction or plain-text joining — without
- * duplicating the boilerplate or the terminal-scraping apparatus it replaced.
+ * prompt. Provider errors from either the event stream or prompt result are
+ * normalized before returning, so callers receive the same structured cause
+ * regardless of which transport settles first. Successful calls return the raw
+ * prompt payload for structured-object extraction or plain-text joining.
  */
 async function runNonTaskSdkPrompt(
   params: GenerateTrackedNonTaskBaseParams,
@@ -530,6 +557,7 @@ async function runNonTaskSdkPrompt(
     env?: Partial<Record<string, string>>;
     onSessionReady?: (sessionID: string) => Promise<void> | void;
     permission?: PermissionRuleset;
+    promptErrorLabel?: string;
     session?: NonTaskOpenCodeSession;
     signal?: AbortSignal;
     useConfiguredServer?: boolean;
@@ -540,6 +568,9 @@ async function runNonTaskSdkPrompt(
 }> {
   const { model, resolvedModelRuntimeEnv } = runtime;
   const timeoutMs = params.timeoutMs ?? 120_000;
+  const promptErrorLabel =
+    options.promptErrorLabel ??
+    `OpenCode structured prompt failed (model ${model})`;
   const sessionDirectory =
     options.directory ?? resolveNonTaskSessionDirectory();
   const server = await leaseOpenCodeSdkServer({
@@ -553,9 +584,7 @@ async function runNonTaskSdkPrompt(
   });
   const abortController = new AbortController();
   const timeout = setTimeout(() => {
-    abortController.abort(
-      new Error(`Timed out waiting for OpenCode output after ${timeoutMs}ms.`),
-    );
+    abortController.abort(new NonTaskOpenCodePromptTimeoutError(timeoutMs));
   }, timeoutMs);
   const externalSignal = options.signal;
   const abortFromExternalSignal = () => {
@@ -632,20 +661,34 @@ async function runNonTaskSdkPrompt(
                 event.properties.sessionID === sessionId &&
                 event.properties.status.type === 'retry'
               ) {
-                await params.onProviderRetry?.({
-                  attempt: event.properties.status.attempt,
-                  message: event.properties.status.message,
-                  ...(Number.isFinite(event.properties.status.next)
-                    ? { nextRetryAtMs: event.properties.status.next }
-                    : {}),
-                });
+                try {
+                  await params.onProviderRetry?.({
+                    attempt: event.properties.status.attempt,
+                    message: event.properties.status.message,
+                    ...(Number.isFinite(event.properties.status.next)
+                      ? { nextRetryAtMs: event.properties.status.next }
+                      : {}),
+                  });
+                } catch (error) {
+                  // Retry reporting is auxiliary. A transient Slack or Discord
+                  // post failure must not stop observation of the provider's
+                  // eventual session error.
+                  console.warn(
+                    `[NonTaskProviderUsage] OpenCode provider retry reporter failed: ${formatOpenCodeSdkError(error)}`,
+                  );
+                }
               } else if (
                 event.type === 'session.error' &&
                 event.properties.sessionID === sessionId
               ) {
                 rejectSessionError(
-                  event.properties.error ??
-                    new Error('OpenCode session failed without error detail.'),
+                  new NonTaskOpenCodePromptError(
+                    event.properties.error ??
+                      new Error(
+                        'OpenCode session failed without error detail.',
+                      ),
+                    promptErrorLabel,
+                  ),
                 );
                 return;
               }
@@ -669,7 +712,6 @@ async function runNonTaskSdkPrompt(
       }
     }
 
-    let promptResult;
     try {
       const promptRequest = client.session.prompt(
         {
@@ -681,9 +723,29 @@ async function runNonTaskSdkPrompt(
         },
         { signal: abortController.signal },
       );
-      promptResult = params.onProviderRetry
+      const promptResult = params.onProviderRetry
         ? await Promise.race([promptRequest, sessionError])
         : await promptRequest;
+
+      if (promptResult.error || !promptResult.data) {
+        if (isOpenCodeSessionMissing(promptResult.error)) {
+          throw new NonTaskOpenCodeSessionNotFoundError();
+        }
+
+        throw new NonTaskOpenCodePromptError(
+          promptResult.error,
+          promptErrorLabel,
+        );
+      }
+
+      if (promptResult.data.info.error) {
+        throw new NonTaskOpenCodePromptError(
+          promptResult.data.info.error,
+          promptErrorLabel,
+        );
+      }
+
+      return promptResult.data;
     } catch (error) {
       // Aborting the HTTP request does not guarantee that an OpenCode server
       // stopped its model turn. Explicitly cancel it before the session or a
@@ -697,22 +759,6 @@ async function runNonTaskSdkPrompt(
       eventAbortController.abort();
       void eventMonitor?.catch(() => undefined);
     }
-
-    if (promptResult.error || !promptResult.data) {
-      if (isOpenCodeSessionMissing(promptResult.error)) {
-        throw new NonTaskOpenCodeSessionNotFoundError();
-      }
-
-      // The resolved `provider/model` id rides in the message because callers
-      // (the router's fallback log among them) only know the role alias —
-      // production diagnosis of a provider-specific rejection needs the real
-      // id and provider without a database lookup.
-      throw new Error(
-        `OpenCode structured prompt failed (model ${model}): ${formatOpenCodeSdkError(promptResult.error)}`,
-      );
-    }
-
-    return promptResult.data;
   } finally {
     externalSignal?.removeEventListener('abort', abortFromExternalSignal);
     clearTimeout(timeout);
@@ -750,13 +796,8 @@ export async function generateTrackedNonTaskText(
         })),
       ],
     },
+    { promptErrorLabel: 'OpenCode text prompt failed' },
   );
-
-  if (data.info.error) {
-    throw new Error(
-      `OpenCode text prompt failed: ${formatOpenCodeSdkError(data.info.error)}`,
-    );
-  }
 
   const text = data.parts
     .filter(
@@ -811,16 +852,11 @@ export async function generateTrackedNonTaskTextInOpenCodeSession(
       env: options.env,
       onSessionReady: options.onSessionReady,
       permission: options.permission,
+      promptErrorLabel: 'OpenCode native Fast prompt failed',
       session,
       useConfiguredServer: false,
     },
   );
-
-  if (data.info.error) {
-    throw new Error(
-      `OpenCode native Fast prompt failed: ${formatOpenCodeSdkError(data.info.error)}`,
-    );
-  }
 
   return data.parts
     .filter(
@@ -842,32 +878,33 @@ async function generateTrackedNonTaskObjectWithSdk<
     params.modelRole,
   );
 
-  const data = await runNonTaskSdkPrompt(params, resolvedRuntime, {
-    system: params.system,
-    format: {
-      type: 'json_schema',
-      schema: zodToJsonSchema(params.schema, {
-        $refStrategy: 'none',
-        target: 'jsonSchema7',
-      }) as Record<string, unknown>,
-      retryCount: DEFAULT_OPENCODE_STRUCTURED_OUTPUT_RETRY_COUNT,
-    },
-    parts: [
-      {
-        type: 'text',
-        text: buildOpenCodePrompt({
-          prompt: params.prompt,
-          maxOutputTokens: params.maxOutputTokens,
-        }),
+  const data = await runNonTaskSdkPrompt(
+    params,
+    resolvedRuntime,
+    {
+      system: params.system,
+      format: {
+        type: 'json_schema',
+        schema: zodToJsonSchema(params.schema, {
+          $refStrategy: 'none',
+          target: 'jsonSchema7',
+        }) as Record<string, unknown>,
+        retryCount: DEFAULT_OPENCODE_STRUCTURED_OUTPUT_RETRY_COUNT,
       },
-    ],
-  });
-
-  if (data.info.error) {
-    throw new Error(
-      `OpenCode structured prompt failed (model ${resolvedRuntime.model}): ${formatOpenCodeSdkError(data.info.error)}`,
-    );
-  }
+      parts: [
+        {
+          type: 'text',
+          text: buildOpenCodePrompt({
+            prompt: params.prompt,
+            maxOutputTokens: params.maxOutputTokens,
+          }),
+        },
+      ],
+    },
+    {
+      promptErrorLabel: `OpenCode structured prompt failed (model ${resolvedRuntime.model})`,
+    },
+  );
 
   const structured = (data.info as { structured?: unknown }).structured;
   if (structured == null) {
@@ -885,6 +922,12 @@ export async function generateTrackedNonTaskObject<
   params: GenerateTrackedNonTaskObjectParams<TSchema>,
 ): Promise<{ object: z.output<TSchema> }> {
   return generateTrackedNonTaskObjectWithSdk(params);
+}
+
+function unwrapNonTaskInferenceError(error: unknown): unknown {
+  return error instanceof NonTaskOpenCodePromptError
+    ? error.providerError
+    : error;
 }
 
 function findInferenceErrorStatusCode(error: unknown): number | undefined {
@@ -951,19 +994,25 @@ export function classifyNonTaskInferenceError(
   // present — provider wording varies too much for substring matching to be
   // the primary signal (Anthropic says "API key is invalid.", which no
   // keyword list reliably catches).
+  const inferenceError = unwrapNonTaskInferenceError(error);
   const record =
-    error && typeof error === 'object'
-      ? (error as Record<string, unknown>)
+    inferenceError && typeof inferenceError === 'object'
+      ? (inferenceError as Record<string, unknown>)
       : undefined;
   const data =
     record?.data && typeof record.data === 'object'
       ? (record.data as Record<string, unknown>)
       : undefined;
-  const statusCode = findInferenceErrorStatusCode(error);
+  const statusCode = findInferenceErrorStatusCode(inferenceError);
   const responseBody =
     typeof data?.responseBody === 'string' ? data.responseBody : '';
   const detail =
-    `${formatOpenCodeSdkError(error)} ${responseBody}`.toLowerCase();
+    `${formatOpenCodeSdkError(inferenceError)} ${responseBody}`.toLowerCase();
+  const errorName = typeof record?.name === 'string' ? record.name : '';
+  const gatewayBlocked =
+    (statusCode === 403 && /^\s*(?:<!doctype|<html)/iu.test(responseBody)) ||
+    (detail.includes('forbidden:') &&
+      detail.includes('request was blocked by a gateway or proxy'));
 
   // Failures inside Roomote's own validation helper (the managed OpenCode
   // server) must not read as provider failures — the candidate credentials
@@ -978,6 +1027,47 @@ export function classifyNonTaskInferenceError(
         'Roomote could not run its validation helper. Try again, or check the server logs.',
       reason: 'provider_error',
       retryable: true,
+    };
+  }
+
+  // OpenCode normalizes HTML 403 responses from provider gateways and WAFs
+  // into this error. These are distinct from structured credential failures:
+  // the same request can succeed when routed through a healthy edge shortly
+  // afterward, so Fast may recover with its bounded outer retry.
+  if (gatewayBlocked) {
+    return {
+      message: 'The inference provider gateway blocked the request.',
+      reason: 'gateway_blocked',
+      retryable: true,
+    };
+  }
+
+  if (errorName === 'ProviderAuthError') {
+    return {
+      message: 'The inference provider rejected these credentials.',
+      reason: 'invalid_credentials',
+      retryable: false,
+    };
+  }
+
+  if (errorName === 'MessageAbortedError') {
+    return {
+      message: 'The inference provider did not respond in time. Try again.',
+      reason: 'timeout',
+      retryable: true,
+    };
+  }
+
+  if (
+    errorName === 'ContextOverflowError' ||
+    errorName === 'ContentFilterError' ||
+    errorName === 'MessageOutputLengthError' ||
+    errorName === 'StructuredOutputError'
+  ) {
+    return {
+      message: 'The inference provider rejected the request.',
+      reason: 'provider_error',
+      retryable: false,
     };
   }
 
@@ -1208,6 +1298,7 @@ export async function validateNonTaskInference(params: {
         },
         {
           ephemeral: true,
+          promptErrorLabel: `OpenCode inference validation prompt failed (model ${model})`,
           signal: deadlineController.signal,
           useConfiguredServer: false,
         },
@@ -1215,11 +1306,6 @@ export async function validateNonTaskInference(params: {
     } finally {
       clearTimeout(deadlineTimer);
     }
-
-    if (data.info.error) {
-      throw data.info.error;
-    }
-
     const structured = (data.info as { structured?: unknown }).structured;
     if (
       !structured ||

--- a/packages/cloud-agents/src/server/non-task-provider-usage.ts
+++ b/packages/cloud-agents/src/server/non-task-provider-usage.ts
@@ -1102,6 +1102,22 @@ export function classifyNonTaskInferenceError(
     };
   }
 
+  // Remaining structured 4xx responses (400, 413, 422, …) are client errors:
+  // resending the same request cannot recover them. 408 stays retryable as a
+  // timeout; 401/402/403/404/429 were classified above.
+  if (
+    statusCode !== undefined &&
+    statusCode >= 400 &&
+    statusCode < 500 &&
+    statusCode !== 408
+  ) {
+    return {
+      message: 'The inference provider rejected the request.',
+      reason: 'provider_error',
+      retryable: false,
+    };
+  }
+
   return {
     message: 'The inference provider rejected the validation request.',
     reason: 'provider_error',

--- a/packages/cloud-agents/src/server/non-task-provider-usage.ts
+++ b/packages/cloud-agents/src/server/non-task-provider-usage.ts
@@ -1042,6 +1042,14 @@ export function classifyNonTaskInferenceError(
     };
   }
 
+  if (statusCode === 408) {
+    return {
+      message: 'The inference provider did not respond in time. Try again.',
+      reason: 'timeout',
+      retryable: true,
+    };
+  }
+
   if (errorName === 'ProviderAuthError') {
     return {
       message: 'The inference provider rejected these credentials.',

--- a/packages/cloud-agents/src/server/non-task-provider-usage.ts
+++ b/packages/cloud-agents/src/server/non-task-provider-usage.ts
@@ -130,7 +130,20 @@ interface GenerateTrackedNonTaskBaseParams extends NonTaskInferenceTrackingInput
   modelRole?: 'primary' | 'small';
   maxOutputTokens?: number;
   timeoutMs?: number;
+  /**
+   * OpenCode retries some provider failures internally before the prompt
+   * request settles. Long-running, user-visible callers such as Fast Mode can
+   * subscribe to those retry transitions instead of appearing hung until the
+   * outer timeout fires.
+   */
+  onProviderRetry?: (event: NonTaskProviderRetryEvent) => void | Promise<void>;
 }
+
+export type NonTaskProviderRetryEvent = {
+  attempt: number;
+  message: string;
+  nextRetryAtMs?: number;
+};
 
 export interface GenerateTrackedNonTaskTextParams extends GenerateTrackedNonTaskBaseParams {
   files?: NonTaskPromptFile[];
@@ -588,16 +601,102 @@ async function runNonTaskSdkPrompt(
     }
     await options.onSessionReady?.(sessionId);
 
-    const promptResult = await client.session.prompt(
-      {
-        sessionID: sessionId,
-        directory: sessionDirectory,
-        model: splitOpenCodeModelId(model),
-        tools: promptOptions.tools ?? NON_TASK_SESSION_TOOL_DISABLES,
-        ...promptOptions,
-      },
-      { signal: abortController.signal },
-    );
+    const eventAbortController = new AbortController();
+    const abortEventMonitor = () => {
+      eventAbortController.abort(abortController.signal.reason);
+    };
+    if (abortController.signal.aborted) {
+      abortEventMonitor();
+    } else {
+      abortController.signal.addEventListener('abort', abortEventMonitor, {
+        once: true,
+      });
+    }
+    let rejectSessionError: (error: unknown) => void = () => undefined;
+    const sessionError = new Promise<never>((_resolve, reject) => {
+      rejectSessionError = reject;
+    });
+    let eventMonitor: Promise<void> | undefined;
+
+    if (params.onProviderRetry) {
+      try {
+        const subscription = await client.event.subscribe(
+          { directory: sessionDirectory },
+          { signal: eventAbortController.signal },
+        );
+        eventMonitor = (async () => {
+          try {
+            for await (const event of subscription.stream) {
+              if (
+                event.type === 'session.status' &&
+                event.properties.sessionID === sessionId &&
+                event.properties.status.type === 'retry'
+              ) {
+                await params.onProviderRetry?.({
+                  attempt: event.properties.status.attempt,
+                  message: event.properties.status.message,
+                  ...(Number.isFinite(event.properties.status.next)
+                    ? { nextRetryAtMs: event.properties.status.next }
+                    : {}),
+                });
+              } else if (
+                event.type === 'session.error' &&
+                event.properties.sessionID === sessionId
+              ) {
+                rejectSessionError(
+                  event.properties.error ??
+                    new Error('OpenCode session failed without error detail.'),
+                );
+                return;
+              }
+            }
+          } catch (error) {
+            if (!eventAbortController.signal.aborted) {
+              console.warn(
+                `[NonTaskProviderUsage] OpenCode event monitor failed: ${formatOpenCodeSdkError(error)}`,
+              );
+            }
+          }
+        })();
+      } catch (error) {
+        // Event reporting is additive. Keep the prompt path available if an
+        // older externally configured OpenCode server cannot stream events.
+        if (!eventAbortController.signal.aborted) {
+          console.warn(
+            `[NonTaskProviderUsage] Could not subscribe to OpenCode events: ${formatOpenCodeSdkError(error)}`,
+          );
+        }
+      }
+    }
+
+    let promptResult;
+    try {
+      const promptRequest = client.session.prompt(
+        {
+          sessionID: sessionId,
+          directory: sessionDirectory,
+          model: splitOpenCodeModelId(model),
+          tools: promptOptions.tools ?? NON_TASK_SESSION_TOOL_DISABLES,
+          ...promptOptions,
+        },
+        { signal: abortController.signal },
+      );
+      promptResult = params.onProviderRetry
+        ? await Promise.race([promptRequest, sessionError])
+        : await promptRequest;
+    } catch (error) {
+      // Aborting the HTTP request does not guarantee that an OpenCode server
+      // stopped its model turn. Explicitly cancel it before the session or a
+      // leased server is reused for a bounded retry.
+      await client.session
+        .abort({ sessionID: sessionId, directory: sessionDirectory })
+        .catch(() => undefined);
+      throw error;
+    } finally {
+      abortController.signal.removeEventListener('abort', abortEventMonitor);
+      eventAbortController.abort();
+      void eventMonitor?.catch(() => undefined);
+    }
 
     if (promptResult.error || !promptResult.data) {
       if (isOpenCodeSessionMissing(promptResult.error)) {
@@ -788,7 +887,60 @@ export async function generateTrackedNonTaskObject<
   return generateTrackedNonTaskObjectWithSdk(params);
 }
 
-function classifyNonTaskInferenceValidationError(
+function findInferenceErrorStatusCode(error: unknown): number | undefined {
+  const pending: Array<{ value: unknown; depth: number }> = [
+    { value: error, depth: 0 },
+  ];
+  const seen = new Set<object>();
+
+  while (pending.length > 0) {
+    const current = pending.shift();
+    if (!current || current.depth > 4) {
+      continue;
+    }
+
+    const { value, depth } = current;
+    if (typeof value === 'string') {
+      try {
+        pending.push({ value: JSON.parse(value), depth: depth + 1 });
+      } catch {
+        // Provider prose is handled by the fallback signatures below.
+      }
+      continue;
+    }
+    if (!value || typeof value !== 'object' || seen.has(value)) {
+      continue;
+    }
+
+    seen.add(value);
+    const record = value as Record<string, unknown>;
+    for (const key of ['statusCode', 'status', 'code'] as const) {
+      const candidate = record[key];
+      const parsed =
+        typeof candidate === 'number'
+          ? candidate
+          : typeof candidate === 'string' && /^\d{3}$/u.test(candidate.trim())
+            ? Number(candidate.trim())
+            : undefined;
+      if (
+        parsed !== undefined &&
+        Number.isInteger(parsed) &&
+        parsed >= 400 &&
+        parsed <= 599
+      ) {
+        return parsed;
+      }
+    }
+
+    for (const nested of Object.values(record)) {
+      pending.push({ value: nested, depth: depth + 1 });
+    }
+  }
+
+  return undefined;
+}
+
+export function classifyNonTaskInferenceError(
   error: unknown,
 ): Pick<
   Extract<NonTaskInferenceValidationResult, { success: false }>,
@@ -807,8 +959,7 @@ function classifyNonTaskInferenceValidationError(
     record?.data && typeof record.data === 'object'
       ? (record.data as Record<string, unknown>)
       : undefined;
-  const statusCode =
-    typeof data?.statusCode === 'number' ? data.statusCode : undefined;
+  const statusCode = findInferenceErrorStatusCode(error);
   const responseBody =
     typeof data?.responseBody === 'string' ? data.responseBody : '';
   const detail =
@@ -1069,7 +1220,7 @@ export async function validateNonTaskInference(params: {
       model,
     };
   } catch (error) {
-    const classified = classifyNonTaskInferenceValidationError(error);
+    const classified = classifyNonTaskInferenceError(error);
 
     // The sanitized result hides the provider detail from the UI on purpose;
     // keep the detail in the server log so misclassifications stay


### PR DESCRIPTION
## What changed

- subscribe non-task OpenCode prompts to live provider retry and session-error events
- report Fast Mode provider retries visibly instead of appearing stalled
- retry transient Fast Mode inference failures up to three times with bounded exponential backoff
- use longer 5/10/20-second backoff for rate limits and shorter 1/2/4-second backoff for other transient provider failures
- abort failed OpenCode prompts before retrying so a reused conversation session (or leased server) is not still running the old turn
- replace the generic failure reply with provider-specific terminal reporting for rate limits, timeouts, connectivity, credentials, quota, and unavailable models

## Why

Fast Mode shared the deployment's inference provider with standard tasks but did not share their provider recovery behavior. OpenCode could retry a 429 internally while the control-plane request appeared hung, then Roomote would hit its 120-second timeout and post a generic apology. Standard tasks remained alive and recovered, making Fast Mode appear uniquely broken.

This gives Fast Mode the same essential behavior: observe live retry state, tell the user what is happening, apply bounded recovery, and preserve a useful terminal cause when recovery is exhausted.

## Update (Aug 19)

Rebased and re-ported onto the native OpenCode tools/sessions architecture from #1460, which had rewritten the Fast agent turn loop and conflicted with the original branch:

- the retry loop now wraps the native-session prompt inside `fastAgentOpenCodeSessionManager.run`'s `execute`, and `NonTaskOpenCodeSessionNotFoundError` still propagates so the manager can bootstrap a fresh session with its own retry budget
- retry notices post through the adapter directly so a system-posted notice never satisfies the model's acknowledgement gate, marks the turn closed, or becomes the recorded answer
- the event subscription and session-abort behavior live in `runNonTaskSdkPrompt`, which now serves both ephemeral and persistent (Fast conversation) sessions

## Validation

- `pnpm --filter @roomote/cloud-agents exec vitest run` (781 tests, includes new retry/backoff/notice/terminal-classification coverage)
- `pnpm lint`, `pnpm check-types`, `pnpm knip`
