### PR TITLE
[Fix] Ship zod on disk for the Fast native tool runtime

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -178,9 +178,16 @@ RUN cd /roomote && pnpm dlx esbuild@0.25.5 packages/db/src/run-migrations.ts \
 # Runtime-only dependency tree for the externals tsup does not bundle. Install
 # from its standalone lockfile so unrelated workspace packages stay excluded.
 COPY .docker/app/runtime-deps/api /runtime-deps/
+# The zod parity check guards the Fast agent's native tool runtime: it
+# symlinks an on-disk zod into each generated OpenCode tool directory via
+# require.resolve, which the api bundle (noExternal) cannot satisfy on its
+# own. A version drifting from the workspace would silently change what the
+# generated tool sources execute against.
 RUN cd /runtime-deps && pnpm install --prod --frozen-lockfile && \
   test "$(node -p "require('snowflake-sdk/package.json').version")" = \
-    "$(cd /roomote/apps/api && node -p "require('snowflake-sdk/package.json').version")"
+    "$(cd /roomote/apps/api && node -p "require('snowflake-sdk/package.json').version")" && \
+  test "$(node -p "require('zod/package.json').version")" = \
+    "$(cd /roomote/apps/api && node -p "require('zod/package.json').version")"
 
 # ---------------------------------------------------------------------------
 # controller: bundled dist plus the packaged worker release archives that the

--- a/.docker/app/runtime-deps/api/package.json
+++ b/.docker/app/runtime-deps/api/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "packageManager": "pnpm@10.29.3",
   "dependencies": {
-    "snowflake-sdk": "2.4.3"
+    "snowflake-sdk": "2.4.3",
+    "zod": "3.25.76"
   },
   "pnpm": {
     "overrides": {

--- a/.docker/app/runtime-deps/api/pnpm-lock.yaml
+++ b/.docker/app/runtime-deps/api/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       snowflake-sdk:
         specifier: 2.4.3
         version: 2.4.3(asn1.js@5.4.1)
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
 
 packages:
 
@@ -721,6 +724,9 @@ packages:
   xml-naming@0.3.0:
     resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
     engines: {node: '>=16.0.0'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
@@ -1678,3 +1684,5 @@ snapshots:
       is-wsl: 3.1.1
 
   xml-naming@0.3.0: {}
+
+  zod@3.25.76: {}

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-native-tool-bridge.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-native-tool-bridge.ts
@@ -233,6 +233,30 @@ async function readRequestBody(request: IncomingMessage): Promise<unknown> {
   return JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown;
 }
 
+/**
+ * The generated tool sources import zod, and OpenCode's own runtime loads
+ * them from the tool directory — so a real zod package must exist on disk to
+ * symlink there. In development that's the workspace install; in the app
+ * image, where the api bundle inlines zod, it's the runtime-deps tree that
+ * ships next to the dist (the same mechanism as snowflake-sdk, asserted at
+ * image build). This wrapper exists so a packaging regression names the
+ * requirement instead of surfacing as a bare module-not-found mid-turn.
+ */
+function resolveZodDirectoryForTools(): string {
+  try {
+    return dirname(require.resolve('zod/package.json'));
+  } catch (error) {
+    throw new Error(
+      'Fast native tools need the zod package on disk to link into the ' +
+        'OpenCode tool directory, and none is resolvable from this process. ' +
+        'In the app image zod ships via .docker/app/runtime-deps/api ' +
+        '(asserted at image build); if this error reaches production, that ' +
+        'packaging step regressed. ' +
+        `${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
 async function startRuntime(): Promise<FastAgentNativeToolRuntime> {
   const token = randomBytes(32).toString('hex');
   const directory = mkdtempSync(join(tmpdir(), 'roomote-fast-opencode-'));
@@ -246,7 +270,7 @@ async function startRuntime(): Promise<FastAgentNativeToolRuntime> {
   const toolNodeModules = join(directory, '.opencode', 'node_modules');
   mkdirSync(toolNodeModules, { recursive: true });
   symlinkSync(
-    dirname(require.resolve('zod/package.json')),
+    resolveZodDirectoryForTools(),
     join(toolNodeModules, 'zod'),
     'dir',
   );


### PR DESCRIPTION
## What changed

Fast mode is fully broken on develop: every turn on the nightly tenant fails with

```
[Fast Agent] Failed to answer question: Cannot find module 'zod/package.json'
```

**Root cause.** #1460's native tool runtime writes generated OpenCode tool files (which `import { z } from "zod"`) into a temp directory and symlinks a real zod package next to them via `require.resolve('zod/package.json')`. That needs zod to exist as files on disk — and in the app image it doesn't: `apps/api/tsup.config.ts` bundles every dependency (`noExternal: [/.*/]`), so zod is inlined into the dist with no package directory to resolve. Dev and vitest resolve from the workspace install, which is why every local check passed.

**Blast radius:** develop only, but release-blocking — develop is currently ahead of main by exactly this feature, so the next release ships broken Fast mode to every tenant. Nightly shows the failures; roo/work/currents (on main) show zero.

**Fix.** zod ships via the api runtime-deps tree — the mechanism this Dockerfile already uses for "the externals tsup does not bundle" (snowflake-sdk) — pinned to `3.25.76`, the workspace's exact resolved version. The final image places that tree at `apps/api/node_modules/` beside `apps/api/dist/`, which is precisely the ancestor path the bundle's `createRequire(import.meta.url)` walks, so the existing `require.resolve` call works unchanged.

Two guards on top:
- **Image-build assertion** mirroring the snowflake one: the build fails if zod is unresolvable from the runtime-deps tree or its version drifts from the workspace's. A packaging regression becomes a build failure, not a customer-facing turn failure.
- The resolve is wrapped so, if it ever does fail at runtime, the error names the packaging requirement instead of a bare module-not-found (this one cost a log-diving session to attribute).

**Approaches considered and rejected:** rewriting the generated tools without zod means guessing at the sealed OpenCode binary's tool contract that #1460 verified against the real thing; externalizing zod in tsup changes module identity for a dependency used across the whole api bundle to fix one symlink; a soft-degrade guard just moves the failure into OpenCode's tool loading, which fails less legibly than the bridge.

## How it was tested

- **Simulated the exact image layout** (`apps/api/dist/probe.mjs` + runtime-deps `node_modules` beside it): `createRequire(import.meta.url)` resolves `zod/package.json` → 3.25.76 through the pnpm `.pnpm` indirection to a complete package directory, a valid symlink target.
- Regenerated the standalone lockfile with the pinned pnpm (10.29.3, `--ignore-workspace` — the tree lives inside the repo, so a plain install wrongly resolves against the monorepo; the image's `/runtime-deps` is outside `/roomote` and needs no flag) and verified `--prod --frozen-lockfile` installs cleanly.
- Bridge + OpenCode-session tests pass (8); `check-types`, `format:check`, `oxlint --deny-warnings` clean.
- The DB-backed fast-agent test failures in this area are pre-existing on clean develop (local test DB lacking #1460's migration) — verified by stash.