### PR TITLE
Start Brain with local development

### DIFF
--- a/apps/dev/src/services/__tests__/docker.test.ts
+++ b/apps/dev/src/services/__tests__/docker.test.ts
@@ -23,6 +23,7 @@ vi.mock('ora', () => ({
     info: vi.fn(),
     start: () => ({
       succeed: vi.fn(),
+      fail: vi.fn(),
       warn: vi.fn(),
       info: vi.fn(),
     }),
@@ -71,10 +72,44 @@ describe('DockerService.checkContainers', () => {
         extendEnv: false,
       }),
     );
+    expect(execa).toHaveBeenCalledWith(
+      'docker',
+      ['compose', '--profile', 'brain', 'up', 'gbrain', '-d', '--wait'],
+      expect.objectContaining({
+        cwd: expectedCwd,
+        extendEnv: false,
+      }),
+    );
     expect(execa).not.toHaveBeenCalledWith(
       'pnpm',
       ['infra:up'],
       expect.anything(),
+    );
+  });
+
+  it('fails startup when the Brain does not become healthy', async () => {
+    const listContainers = vi
+      .fn()
+      .mockResolvedValue([
+        { Names: ['/roomote-postgres'] },
+        { Names: ['/roomote-redis'] },
+        { Names: ['/roomote-minio'] },
+        { Names: ['/roomote-caddy-dev'] },
+      ]);
+
+    vi.mocked(Docker).mockImplementation(function MockDocker() {
+      return {
+        ping: vi.fn().mockResolvedValue(undefined),
+        listContainers,
+      } as unknown as Docker;
+    } as unknown as typeof Docker);
+
+    vi.mocked(execa)
+      .mockResolvedValueOnce({} as Awaited<ReturnType<typeof execa>>)
+      .mockRejectedValueOnce(new Error('gbrain health check failed'));
+
+    await expect(DockerService.checkContainers(false)).rejects.toThrow(
+      'gbrain health check failed',
     );
   });
 

--- a/apps/dev/src/services/docker.ts
+++ b/apps/dev/src/services/docker.ts
@@ -4,7 +4,6 @@ import { execa } from 'execa';
 import ora from 'ora';
 import Docker from 'dockerode';
 import { WORKER_RUNTIME_SCHEMA_VERSION } from '@roomote/types';
-import { isBrainConfigured } from '@roomote/env';
 
 export const WORKER_IMAGE_SCHEMA_LABEL =
   'dev.roomote.worker-image.schema-version';
@@ -187,7 +186,7 @@ export class DockerService {
       },
     );
 
-    await this.startBrainIfConfigured(rootDir, verbose);
+    await this.startBrain(rootDir, verbose);
 
     if (missing.length === 0) {
       checkContainers.succeed();
@@ -215,26 +214,21 @@ export class DockerService {
   }
 
   /**
-   * Started under exactly the condition the app uses to decide it has a
-   * Brain (isBrainConfigured), because the app enqueues memories on that
-   * belief: if the two ever disagree, one side accumulates rows the other
-   * side has nothing to drain. Naming the profiled service explicitly enables
-   * its compose profile, so no COMPOSE_PROFILES juggling is needed.
+   * The Brain is standard local infrastructure even when no model provider is
+   * configured yet. Naming the service explicitly enables its Compose profile
+   * without COMPOSE_PROFILES, while --wait makes `pnpm dev` return only after
+   * gbrain is healthy like the rest of the local datastores.
    */
-  private static async startBrainIfConfigured(
+  private static async startBrain(
     rootDir: string,
     verbose: boolean,
   ): Promise<void> {
-    if (!isBrainConfigured(process.env)) {
-      return;
-    }
-
     const startBrain = ora('Starting the Brain').start();
 
     try {
       await execa(
         'docker',
-        ['compose', '--profile', 'brain', 'up', 'gbrain', '-d'],
+        ['compose', '--profile', 'brain', 'up', 'gbrain', '-d', '--wait'],
         {
           cwd: rootDir,
           env: this.getInfraUpEnv(),
@@ -245,13 +239,8 @@ export class DockerService {
 
       startBrain.succeed();
     } catch (error) {
-      // A Brain that will not start must not block the dev stack: the app
-      // degrades to no memory rather than failing to boot.
-      startBrain.warn(
-        `Brain container did not start: ${
-          error instanceof Error ? error.message.split('\n')[0] : String(error)
-        }`,
-      );
+      startBrain.fail('Brain container did not become healthy');
+      throw error;
     }
   }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,8 +83,9 @@ services:
       - 'host.docker.internal:host-gateway'
 
   # The Brain (deployment-hosted gbrain), managed alongside the other local
-  # datastores. Opt in with COMPOSE_PROFILES=brain (or `pnpm
-  # brain:up`). The port is published to loopback only because the local
+  # datastores. `pnpm dev` starts this profiled service explicitly; `pnpm
+  # brain:up` remains available to operate it independently. The port is
+  # published to loopback only because the local
   # api/bullmq processes run on the host rather than in this network; in the
   # self-host and installer stacks the Brain publishes no ports at all and is
   # reachable only from the app services.


### PR DESCRIPTION
## Summary

- start gbrain as standard infrastructure on every `pnpm dev` run
- wait for the Brain health check before reporting the local stack ready
- fail local startup when gbrain cannot become healthy
- keep `pnpm brain:up` available for focused Brain operation

## Why

The Brain is now a normal Roomote capability, but local startup still treated its container as conditional on a configured model provider and silently ignored startup failures. Provider configuration should control whether Roomote exposes and uses the Brain, not whether its local infrastructure exists.

## Validation

- focused Docker service tests (13 passed)
- `@roomote/dev` type-check, lint, and format check
- full pre-push checks: oxlint, residual lint, fast type-check, and knip
- real `pnpm dev --skip-worker-release-build` startup with gbrain healthy
