### PR TITLE
[Fix] Prevent Fast integration discovery from holding turns

### DIFF
--- a/packages/cloud-agents/package.json
+++ b/packages/cloud-agents/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "@ai-sdk/mcp": "^1.0.25",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@opencode-ai/sdk": "1.18.10",
     "@roomote/auth": "workspace:^",
     "@roomote/db": "workspace:^",

--- a/packages/cloud-agents/src/server/__tests__/mcp-tool-client.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/mcp-tool-client.test.ts
@@ -1,0 +1,60 @@
+import { createServer } from 'node:http';
+
+import { listMcpTools } from '../mcp-tool-client';
+
+describe('MCP tool client cancellation', () => {
+  it('aborts the initialization transport when discovery is cancelled', async () => {
+    let markRequestStarted!: () => void;
+    const requestStarted = new Promise<void>((resolve) => {
+      markRequestStarted = resolve;
+    });
+    let markRequestClosed!: () => void;
+    const requestClosed = new Promise<void>((resolve) => {
+      markRequestClosed = resolve;
+    });
+    const server = createServer((request) => {
+      markRequestStarted();
+      request.once('aborted', markRequestClosed);
+      request.once('close', markRequestClosed);
+      // Deliberately leave MCP initialization unanswered until the caller
+      // aborts, reproducing a nonresponsive integration proxy.
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => {
+        server.off('error', reject);
+        resolve();
+      });
+    });
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Test MCP server did not receive a TCP address.');
+    }
+
+    try {
+      const abortController = new AbortController();
+      const discovery = listMcpTools({
+        url: `http://127.0.0.1:${address.port}/mcp`,
+        signal: abortController.signal,
+      });
+      const rejected = expect(discovery).rejects.toThrow();
+      await requestStarted;
+
+      abortController.abort(new Error('test discovery timeout'));
+
+      await rejected;
+      await Promise.race([
+        requestClosed,
+        new Promise<never>((_resolve, reject) => {
+          setTimeout(
+            () => reject(new Error('MCP request remained open after abort.')),
+            1_000,
+          );
+        }),
+      ]);
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-integration-broker.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-integration-broker.test.ts
@@ -91,6 +91,10 @@ describe('fast-agent integration broker', () => {
     ]);
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('exposes the deployment GitHub App through its read-only router MCP', async () => {
     mocks.findGithubInstallation.mockResolvedValue({ id: 42 });
 
@@ -195,6 +199,55 @@ describe('fast-agent integration broker', () => {
     expect(mocks.listMcpTools).toHaveBeenCalledOnce();
   });
 
+  it('serves stale tools immediately while a bounded refresh hangs', async () => {
+    vi.useFakeTimers({ now: new Date('2026-08-19T00:00:00.000Z') });
+    mocks.enabledRows = [{ mcpId: 'notion' }];
+
+    await expect(
+      listFastAgentIntegrations({
+        userId: 'user-1',
+        apiBaseUrl: 'https://api.example.com',
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: 'notion',
+        tools: [expect.objectContaining({ name: 'search' })],
+      }),
+    ]);
+
+    mocks.listMcpTools.mockImplementationOnce(
+      () => new Promise(() => undefined),
+    );
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+
+    await expect(
+      listFastAgentIntegrations({
+        userId: 'user-1',
+        apiBaseUrl: 'https://api.example.com',
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: 'notion',
+        tools: [expect.objectContaining({ name: 'search' })],
+      }),
+    ]);
+    expect(mocks.listMcpTools).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    await expect(
+      listFastAgentIntegrations({
+        userId: 'user-1',
+        apiBaseUrl: 'https://api.example.com',
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: 'notion',
+        tools: [expect.objectContaining({ name: 'search' })],
+      }),
+    ]);
+    expect(mocks.listMcpTools).toHaveBeenCalledTimes(2);
+  });
+
   it('excludes tools disabled by the deployment', async () => {
     mocks.enabledRows = [{ mcpId: 'notion', disabledTools: ['search'] }];
 
@@ -227,6 +280,31 @@ describe('fast-agent integration broker', () => {
       expect.objectContaining({ id: 'notion', tools: [{ name: 'search' }] }),
     ]);
 
+    expect(mocks.listMcpTools).toHaveBeenCalledTimes(2);
+  });
+
+  it('times out hung tool discovery without poisoning the cache', async () => {
+    vi.useFakeTimers();
+    mocks.enabledRows = [{ mcpId: 'notion' }];
+    mocks.listMcpTools
+      .mockImplementationOnce(() => new Promise(() => undefined))
+      .mockResolvedValueOnce([{ name: 'search' }]);
+
+    const timedOut = listFastAgentIntegrations({
+      userId: 'user-1',
+      apiBaseUrl: 'https://api.example.com',
+    });
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await expect(timedOut).resolves.toEqual([]);
+    await expect(
+      listFastAgentIntegrations({
+        userId: 'user-1',
+        apiBaseUrl: 'https://api.example.com',
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({ id: 'notion', tools: [{ name: 'search' }] }),
+    ]);
     expect(mocks.listMcpTools).toHaveBeenCalledTimes(2);
   });
 
@@ -338,6 +416,40 @@ describe('fast-agent integration broker', () => {
       id: 'audit-1',
       status: 'failed',
       error: 'integration unavailable',
+      startedAt: new Date('2026-08-16T00:00:00.000Z'),
+    });
+  });
+
+  it('times out a hung integration call and records the failure', async () => {
+    vi.useFakeTimers();
+    mocks.callMcpTool.mockImplementation(() => new Promise(() => undefined));
+
+    const call = callFastAgentIntegration(
+      auditContext,
+      [
+        {
+          id: 'notion',
+          name: 'Notion',
+          description: 'Knowledge',
+          tools: [{ name: 'search' }],
+        },
+      ],
+      {
+        integrationId: 'notion',
+        toolName: 'search',
+        args: { query: 'roadmap' },
+      },
+    );
+    const timedOut = expect(call).rejects.toThrow(
+      'Fast notion/search integration call timed out after 60000ms.',
+    );
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    await timedOut;
+    expect(mocks.completeIntegrationCall).toHaveBeenCalledWith({
+      id: 'audit-1',
+      status: 'failed',
+      error: 'Fast notion/search integration call timed out after 60000ms.',
       startedAt: new Date('2026-08-16T00:00:00.000Z'),
     });
   });

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-integration-broker.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-integration-broker.test.ts
@@ -109,6 +109,7 @@ describe('fast-agent integration broker', () => {
     expect(mocks.listMcpTools).toHaveBeenCalledWith({
       url: 'https://api.example.com/api/mcp-routing/github',
       headers: { Authorization: 'Bearer control-plane-token' },
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -134,6 +135,7 @@ describe('fast-agent integration broker', () => {
     expect(mocks.listMcpTools).toHaveBeenCalledWith({
       url: 'https://api.example.com/api/mcp/gbrain',
       headers: { Authorization: 'Bearer control-plane-token' },
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -353,6 +355,7 @@ describe('fast-agent integration broker', () => {
       toolName: 'search',
       args: { query: 'roadmap' },
       toolCallId: 'fast:audit-1:notion:search',
+      signal: expect.any(AbortSignal),
     });
     expect(mocks.beginIntegrationCall).toHaveBeenCalledWith({
       slackQuickAnswerId: 'session-1',

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-integration-broker.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-integration-broker.ts
@@ -67,20 +67,28 @@ type IntegrationToolCacheEntry = {
 const integrationToolCache = new Map<string, IntegrationToolCacheEntry>();
 
 async function withFastIntegrationTimeout<T>(
-  operation: Promise<T>,
+  operation: (signal: AbortSignal) => Promise<T>,
   timeoutMs: number,
   operationName: string,
 ): Promise<T> {
+  const abortController = new AbortController();
   let timeout: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<never>((_resolve, reject) => {
     timeout = setTimeout(() => {
-      reject(new Error(`${operationName} timed out after ${timeoutMs}ms.`));
+      const error = new Error(
+        `${operationName} timed out after ${timeoutMs}ms.`,
+      );
+      abortController.abort(error);
+      reject(error);
     }, timeoutMs);
     timeout.unref?.();
   });
 
   try {
-    return await Promise.race([operation, timeoutPromise]);
+    return await Promise.race([
+      operation(abortController.signal),
+      timeoutPromise,
+    ]);
   } finally {
     if (timeout) clearTimeout(timeout);
   }
@@ -99,7 +107,7 @@ async function listCachedIntegrationTools(options: {
       cached.expiresAt =
         Date.now() + FAST_AGENT_INTEGRATION_TOOL_CACHE_RETRY_MS;
       const refresh = withFastIntegrationTimeout(
-        listMcpTools(options),
+        (signal) => listMcpTools({ ...options, signal }),
         FAST_AGENT_INTEGRATION_DISCOVERY_TIMEOUT_MS,
         'Fast integration tool discovery',
       );
@@ -124,7 +132,7 @@ async function listCachedIntegrationTools(options: {
   }
 
   const tools = withFastIntegrationTimeout(
-    listMcpTools(options),
+    (signal) => listMcpTools({ ...options, signal }),
     FAST_AGENT_INTEGRATION_DISCOVERY_TIMEOUT_MS,
     'Fast integration tool discovery',
   );
@@ -324,13 +332,15 @@ export async function callFastAgentIntegration(
   try {
     const { apiBaseUrl, authToken } = await resolveBrokerAuth(context);
     const result = await withFastIntegrationTimeout(
-      callMcpTool({
-        url: integrationProxyUrl(apiBaseUrl, integration.id),
-        headers: { Authorization: `Bearer ${authToken}` },
-        toolName: request.toolName,
-        args: request.args,
-        toolCallId: `fast:${audit.id}:${integration.id}:${request.toolName}`,
-      }),
+      (signal) =>
+        callMcpTool({
+          url: integrationProxyUrl(apiBaseUrl, integration.id),
+          headers: { Authorization: `Bearer ${authToken}` },
+          toolName: request.toolName,
+          args: request.args,
+          toolCallId: `fast:${audit.id}:${integration.id}:${request.toolName}`,
+          signal,
+        }),
       FAST_AGENT_INTEGRATION_CALL_TIMEOUT_MS,
       `Fast ${integration.id}/${request.toolName} integration call`,
     );

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-integration-broker.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-integration-broker.ts
@@ -55,6 +55,9 @@ type IntegrationAuditContext = BrokerContext & {
 };
 
 const FAST_AGENT_INTEGRATION_TOOL_CACHE_TTL_MS = 5 * 60_000;
+const FAST_AGENT_INTEGRATION_TOOL_CACHE_RETRY_MS = 30_000;
+const FAST_AGENT_INTEGRATION_DISCOVERY_TIMEOUT_MS = 10_000;
+const FAST_AGENT_INTEGRATION_CALL_TIMEOUT_MS = 60_000;
 
 type IntegrationToolCacheEntry = {
   expiresAt: number;
@@ -63,16 +66,68 @@ type IntegrationToolCacheEntry = {
 
 const integrationToolCache = new Map<string, IntegrationToolCacheEntry>();
 
+async function withFastIntegrationTimeout<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+  operationName: string,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(() => {
+      reject(new Error(`${operationName} timed out after ${timeoutMs}ms.`));
+    }, timeoutMs);
+    timeout.unref?.();
+  });
+
+  try {
+    return await Promise.race([operation, timeoutPromise]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
 async function listCachedIntegrationTools(options: {
   url: string;
   headers: Record<string, string>;
 }): Promise<McpToolDefinition[]> {
   const cached = integrationToolCache.get(options.url);
-  if (cached && cached.expiresAt > Date.now()) {
+  if (cached) {
+    if (cached.expiresAt <= Date.now()) {
+      // Keep serving the last known-good catalog while refreshing. Fast turns
+      // must never wait behind a deployment integration that stopped answering
+      // after it was previously discovered successfully.
+      cached.expiresAt =
+        Date.now() + FAST_AGENT_INTEGRATION_TOOL_CACHE_RETRY_MS;
+      const refresh = withFastIntegrationTimeout(
+        listMcpTools(options),
+        FAST_AGENT_INTEGRATION_DISCOVERY_TIMEOUT_MS,
+        'Fast integration tool discovery',
+      );
+      void refresh
+        .then((tools) => {
+          if (integrationToolCache.get(options.url) === cached) {
+            integrationToolCache.set(options.url, {
+              expiresAt: Date.now() + FAST_AGENT_INTEGRATION_TOOL_CACHE_TTL_MS,
+              tools: Promise.resolve(tools),
+            });
+          }
+        })
+        .catch(() => {
+          if (integrationToolCache.get(options.url) === cached) {
+            cached.expiresAt =
+              Date.now() + FAST_AGENT_INTEGRATION_TOOL_CACHE_RETRY_MS;
+          }
+        });
+    }
+
     return cached.tools;
   }
 
-  const tools = listMcpTools(options);
+  const tools = withFastIntegrationTimeout(
+    listMcpTools(options),
+    FAST_AGENT_INTEGRATION_DISCOVERY_TIMEOUT_MS,
+    'Fast integration tool discovery',
+  );
   integrationToolCache.set(options.url, {
     expiresAt: Date.now() + FAST_AGENT_INTEGRATION_TOOL_CACHE_TTL_MS,
     tools,
@@ -268,13 +323,17 @@ export async function callFastAgentIntegration(
 
   try {
     const { apiBaseUrl, authToken } = await resolveBrokerAuth(context);
-    const result = await callMcpTool({
-      url: integrationProxyUrl(apiBaseUrl, integration.id),
-      headers: { Authorization: `Bearer ${authToken}` },
-      toolName: request.toolName,
-      args: request.args,
-      toolCallId: `fast:${audit.id}:${integration.id}:${request.toolName}`,
-    });
+    const result = await withFastIntegrationTimeout(
+      callMcpTool({
+        url: integrationProxyUrl(apiBaseUrl, integration.id),
+        headers: { Authorization: `Bearer ${authToken}` },
+        toolName: request.toolName,
+        args: request.args,
+        toolCallId: `fast:${audit.id}:${integration.id}:${request.toolName}`,
+      }),
+      FAST_AGENT_INTEGRATION_CALL_TIMEOUT_MS,
+      `Fast ${integration.id}/${request.toolName} integration call`,
+    );
 
     try {
       await completeSlackFastIntegrationCall({

--- a/packages/cloud-agents/src/server/mcp-tool-client.ts
+++ b/packages/cloud-agents/src/server/mcp-tool-client.ts
@@ -11,6 +11,36 @@ type McpToolResult = {
   content?: Array<{ type?: string; text?: string }>;
 };
 
+async function createCancellableMcpClient(options: {
+  url: string;
+  headers?: Record<string, string>;
+  signal?: AbortSignal;
+}) {
+  const [{ createMCPClient }, { StreamableHTTPClientTransport }] =
+    await Promise.all([
+      import('@ai-sdk/mcp'),
+      import('@modelcontextprotocol/sdk/client/streamableHttp.js'),
+    ]);
+  const signal = options.signal;
+  signal?.throwIfAborted();
+  const transport = new StreamableHTTPClientTransport(new URL(options.url), {
+    requestInit: { headers: options.headers },
+    ...(signal
+      ? {
+          fetch: (url: string | URL, init?: RequestInit) =>
+            fetch(url, {
+              ...init,
+              signal: init?.signal
+                ? AbortSignal.any([signal, init.signal])
+                : signal,
+            }),
+        }
+      : {}),
+  });
+
+  return createMCPClient({ transport });
+}
+
 export type McpToolDefinition = {
   name: string;
   description?: string;
@@ -21,18 +51,14 @@ export type McpToolDefinition = {
 export async function listMcpTools(options: {
   url: string;
   headers?: Record<string, string>;
+  signal?: AbortSignal;
 }): Promise<McpToolDefinition[]> {
-  const { createMCPClient } = await import('@ai-sdk/mcp');
-  const client = await createMCPClient({
-    transport: {
-      type: 'http',
-      url: options.url,
-      headers: options.headers,
-    },
-  });
+  const client = await createCancellableMcpClient(options);
 
   try {
-    const definitions = await client.listTools();
+    const definitions = await client.listTools({
+      options: { signal: options.signal },
+    });
     return definitions.tools.map((definition) => ({
       name: definition.name,
       ...(definition.description
@@ -97,18 +123,14 @@ export async function callMcpTool(options: {
   toolName: string;
   args?: Record<string, unknown>;
   toolCallId?: string;
+  signal?: AbortSignal;
 }): Promise<unknown | null> {
-  const { createMCPClient } = await import('@ai-sdk/mcp');
-  const client = await createMCPClient({
-    transport: {
-      type: 'http',
-      url: options.url,
-      headers: options.headers,
-    },
-  });
+  const client = await createCancellableMcpClient(options);
 
   try {
-    const definitions = await client.listTools();
+    const definitions = await client.listTools({
+      options: { signal: options.signal },
+    });
     const toolDefinition = definitions.tools.find(
       (tool) => tool.name === options.toolName,
     );
@@ -125,6 +147,7 @@ export async function callMcpTool(options: {
     }
 
     const result = await tool.execute(options.args ?? {}, {
+      abortSignal: options.signal,
       toolCallId: options.toolCallId ?? `mcp-tool-call:${options.toolName}`,
       messages: [],
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1139,6 +1139,9 @@ importers:
       '@ai-sdk/mcp':
         specifier: ^1.0.25
         version: 1.0.25(zod@3.25.76)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       '@opencode-ai/sdk':
         specifier: 1.18.10
         version: 1.18.10


### PR DESCRIPTION
## What

- serve the last known-good Fast integration tool catalog immediately while an expired cache entry refreshes in the background
- bound first-time MCP tool discovery to 10 seconds so an unavailable deployment integration cannot hold a Fast conversation turn indefinitely
- bound native Fast integration calls to 60 seconds and return the timeout through the normal tool-failure path
- abort and close the underlying streamable-HTTP transport when either timeout fires
- retain stale catalog entries after a failed refresh and retry discovery later

## Why

Fast discovers enabled deployment integrations before entering its OpenCode prompt. The tool catalog cache previously refreshed synchronously after five minutes, and MCP initialization/tool discovery had no timeout. A nonresponsive integration could therefore leave the Fast turn and its conversation lock open indefinitely, preventing later chat turns and child lifecycle delivery.

## Validation

- regression: an expired catalog serves stale tools while a refresh never settles
- regression: first-time discovery times out without poisoning the cache
- regression: an integration call timeout is recorded in the durable audit
- regression: cancellation aborts a nonresponsive MCP initialization request and closes its connection
- cloud-agents suite: 99 files, 770 tests passed
- `pnpm format:check`
- `pnpm lint:fast`
- `pnpm check-types:fast`
- `pnpm knip`
