### PR TITLE
[Fix] Brain composition chart shows only the newest 100 pages

### DIFF
--- a/packages/sdk/src/server/lib/__tests__/brain-corpus.test.ts
+++ b/packages/sdk/src/server/lib/__tests__/brain-corpus.test.ts
@@ -1,7 +1,16 @@
 import {
   extractBrainCorpusPages,
   extractBrainPageContent,
+  readBrainCorpusSample,
+  resetBrainCorpusSampleCache,
 } from '../brain-corpus';
+
+vi.mock('../brain-clients', () => ({
+  resolveBrainConnection: vi.fn(async () => ({
+    baseUrl: 'http://brain.test',
+    token: 'read-token',
+  })),
+}));
 
 describe('extractBrainCorpusPages', () => {
   it('reads a bare array of page objects', () => {
@@ -90,5 +99,109 @@ describe('extractBrainPageContent', () => {
 
   it('returns null when the answer carries neither body nor title', () => {
     expect(extractBrainPageContent('tasks/run-9', [{ ok: true }])).toBeNull();
+  });
+});
+
+describe('readBrainCorpusSample', () => {
+  const originalFetch = global.fetch;
+
+  function toolResponse(payload: unknown, isError = false) {
+    return new Response(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: isError
+          ? { isError: true, content: [{ type: 'text', text: 'bad args' }] }
+          : { content: [{ type: 'text', text: JSON.stringify(payload) }] },
+      }),
+      { status: 200 },
+    );
+  }
+
+  function windowOf(start: number, count: number) {
+    return Array.from({ length: count }, (_, index) => ({
+      slug: `tasks/run-${start + index}`,
+      title: `Run ${start + index}`,
+      updated_at: '2026-08-19T10:00:00Z',
+    }));
+  }
+
+  function listedOffsets(mock: ReturnType<typeof vi.fn>) {
+    return mock.mock.calls.map((call) => {
+      const body = JSON.parse(call[1].body as string) as {
+        params: { arguments: Record<string, unknown> };
+      };
+      return body.params.arguments.offset;
+    });
+  }
+
+  beforeEach(() => {
+    resetBrainCorpusSampleCache();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('pages past the listing window and reports a capped sample as truncated', async () => {
+    // gbrain caps list_pages at 100 per call; five full windows reach the
+    // 500-page sample bound with every window full, so more likely exist.
+    const fetchMock = vi.fn(async (_url: unknown, init: RequestInit) => {
+      const body = JSON.parse(init.body as string) as {
+        params: { arguments: { offset?: number } };
+      };
+      return toolResponse(windowOf(body.params.arguments.offset ?? 0, 100));
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const snapshot = await readBrainCorpusSample();
+
+    expect(snapshot).not.toBeNull();
+    expect(snapshot!.pages).toHaveLength(500);
+    expect(snapshot!.truncated).toBe(true);
+    expect(listedOffsets(fetchMock)).toEqual([0, 100, 200, 300, 400]);
+  });
+
+  it('treats a short window as the end of the corpus', async () => {
+    const windows = [windowOf(0, 100), windowOf(100, 37)];
+    const fetchMock = vi.fn(async () => toolResponse(windows.shift() ?? []));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const snapshot = await readBrainCorpusSample();
+
+    expect(snapshot!.pages).toHaveLength(137);
+    expect(snapshot!.truncated).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops and reports truncation when the server ignores offset', async () => {
+    // The same full window answered twice means paging would loop on the
+    // newest slice forever; the sample must say it only saw that slice.
+    const fetchMock = vi.fn(async () => toolResponse(windowOf(0, 100)));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const snapshot = await readBrainCorpusSample();
+
+    expect(snapshot!.pages).toHaveLength(100);
+    expect(snapshot!.truncated).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to a bare listing on an argument-shape error, as a sample', async () => {
+    let first = true;
+    const fetchMock = vi.fn(async () => {
+      if (first) {
+        first = false;
+        return toolResponse(null, true);
+      }
+      return toolResponse(windowOf(0, 42));
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const snapshot = await readBrainCorpusSample();
+
+    expect(snapshot!.pages).toHaveLength(42);
+    expect(snapshot!.truncated).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/sdk/src/server/lib/__tests__/brain-corpus.test.ts
+++ b/packages/sdk/src/server/lib/__tests__/brain-corpus.test.ts
@@ -187,6 +187,27 @@ describe('readBrainCorpusSample', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it('skips the argument-shape fallback when the probe consumed the deadline', async () => {
+    // The first call burns the whole listing budget before failing with a
+    // tool error. Retrying with a fresh floor would hold the settings page
+    // past its stated bound, so the listing gives up as unavailable.
+    vi.useFakeTimers();
+    try {
+      const fetchMock = vi.fn(async () => {
+        vi.advanceTimersByTime(9_000);
+        return toolResponse(null, true);
+      });
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const snapshot = await readBrainCorpusSample();
+
+      expect(snapshot).toBeNull();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('spends one deadline across all windows instead of one per window', async () => {
     // Three seconds per window against an eight-second listing budget: the
     // third window ends past the deadline, so a fourth is never attempted

--- a/packages/sdk/src/server/lib/__tests__/brain-corpus.test.ts
+++ b/packages/sdk/src/server/lib/__tests__/brain-corpus.test.ts
@@ -187,6 +187,33 @@ describe('readBrainCorpusSample', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it('spends one deadline across all windows instead of one per window', async () => {
+    // Three seconds per window against an eight-second listing budget: the
+    // third window ends past the deadline, so a fourth is never attempted
+    // and the result is honestly a truncated sample. Without the shared
+    // deadline this listing would run five windows and hold the settings
+    // page for the sum of the per-window timeouts.
+    vi.useFakeTimers();
+    try {
+      const fetchMock = vi.fn(async (_url: unknown, init: RequestInit) => {
+        vi.advanceTimersByTime(3_000);
+        const body = JSON.parse(init.body as string) as {
+          params: { arguments: { offset?: number } };
+        };
+        return toolResponse(windowOf(body.params.arguments.offset ?? 0, 100));
+      });
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const snapshot = await readBrainCorpusSample();
+
+      expect(snapshot!.pages).toHaveLength(300);
+      expect(snapshot!.truncated).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('falls back to a bare listing on an argument-shape error, as a sample', async () => {
     let first = true;
     const fetchMock = vi.fn(async () => {

--- a/packages/sdk/src/server/lib/brain-corpus.ts
+++ b/packages/sdk/src/server/lib/brain-corpus.ts
@@ -233,16 +233,20 @@ async function fetchBrainCorpusSample(): Promise<BrainCorpusSnapshot | null> {
         // versions. A default-window listing still describes the corpus, so
         // fall back to it rather than reporting the Brain as unreachable —
         // presented as a sample, since the default window's size is unknown.
+        // The fallback draws on the same listing deadline: if the failed
+        // probe already consumed it, retrying would push the page past its
+        // stated bound for a listing that failed once, so give up instead.
+        const fallbackBudgetMs = deadlineAtMs - Date.now();
+
+        if (fallbackBudgetMs < CORPUS_MIN_WINDOW_BUDGET_MS) {
+          throw error;
+        }
+
         payloads = await callBrainTool(
           connection,
           'list_pages',
           {},
-          {
-            timeoutMs: Math.max(
-              deadlineAtMs - Date.now(),
-              CORPUS_MIN_WINDOW_BUDGET_MS,
-            ),
-          },
+          { timeoutMs: fallbackBudgetMs },
         );
         const fallbackPages = extractBrainCorpusPages(payloads);
 

--- a/packages/sdk/src/server/lib/brain-corpus.ts
+++ b/packages/sdk/src/server/lib/brain-corpus.ts
@@ -166,6 +166,15 @@ export function resetBrainCorpusSampleCache(): void {
   corpusCache = null;
 }
 
+/**
+ * The most pages one `list_pages` call returns. gbrain caps `limit` at 100
+ * regardless of what is requested (verified empirically: `limit: 500`
+ * answers 100), so the sample must page with `offset` to see past the
+ * newest window — otherwise the composition chart lurches to whichever
+ * source backfilled most recently and presents that batch as the corpus.
+ */
+const CORPUS_LISTING_WINDOW = 100;
+
 async function fetchBrainCorpusSample(): Promise<BrainCorpusSnapshot | null> {
   const connection = await resolveBrainConnection('agent');
 
@@ -174,44 +183,81 @@ async function fetchBrainCorpusSample(): Promise<BrainCorpusSnapshot | null> {
   }
 
   try {
-    let payloads: unknown[];
-    let usedFallback = false;
+    const pages = new Map<string, BrainCorpusPage>();
+    let truncated = false;
 
-    try {
-      payloads = await callBrainTool(
-        connection,
-        'list_pages',
-        { limit: CORPUS_SAMPLE_LIMIT },
-        { timeoutMs: CORPUS_REQUEST_TIMEOUT_MS },
-      );
-    } catch (error) {
-      if (!isRetryableToolError(error)) {
-        throw error;
+    for (let offset = 0; offset < CORPUS_SAMPLE_LIMIT;) {
+      let payloads: unknown[];
+
+      try {
+        payloads = await callBrainTool(
+          connection,
+          'list_pages',
+          { limit: CORPUS_LISTING_WINDOW, offset },
+          { timeoutMs: CORPUS_REQUEST_TIMEOUT_MS },
+        );
+      } catch (error) {
+        if (offset > 0 || !isRetryableToolError(error)) {
+          // A later window failing (an offset the tool does not accept, or a
+          // mid-listing hiccup) does not invalidate what already came back:
+          // report it as a truncated sample rather than an unreachable Brain.
+          if (offset > 0) {
+            truncated = true;
+            break;
+          }
+
+          throw error;
+        }
+
+        // The listing tool's arguments have changed shape between gbrain
+        // versions. A default-window listing still describes the corpus, so
+        // fall back to it rather than reporting the Brain as unreachable —
+        // presented as a sample, since the default window's size is unknown.
+        payloads = await callBrainTool(
+          connection,
+          'list_pages',
+          {},
+          { timeoutMs: CORPUS_REQUEST_TIMEOUT_MS },
+        );
+        const fallbackPages = extractBrainCorpusPages(payloads);
+
+        return {
+          pages: fallbackPages,
+          truncated: fallbackPages.length > 0,
+        };
       }
 
-      // The listing tool's arguments have changed shape between gbrain
-      // versions. A default-window listing still describes the corpus, so
-      // fall back to it rather than reporting the Brain as unreachable.
-      payloads = await callBrainTool(
-        connection,
-        'list_pages',
-        {},
-        { timeoutMs: CORPUS_REQUEST_TIMEOUT_MS },
-      );
-      usedFallback = true;
+      const window = extractBrainCorpusPages(payloads);
+      const before = pages.size;
+
+      for (const page of window) {
+        if (!pages.has(page.slug)) {
+          pages.set(page.slug, page);
+        }
+      }
+
+      // A short window is the end of the corpus. A window of nothing new is
+      // a server that ignored `offset` and answered the first window again;
+      // paging further would loop forever on the same pages, so stop and be
+      // honest that only the newest window was seen.
+      if (window.length < CORPUS_LISTING_WINDOW) {
+        break;
+      }
+
+      if (pages.size === before) {
+        truncated = true;
+        break;
+      }
+
+      offset += CORPUS_LISTING_WINDOW;
+
+      if (offset >= CORPUS_SAMPLE_LIMIT) {
+        // Every window filled up to the cap, so more pages likely exist.
+        truncated = true;
+      }
     }
 
-    const pages = extractBrainCorpusPages(payloads);
-
-    return {
-      pages,
-      // The fallback listing used the tool's own default window, whose size
-      // is unknown, so its result is presented as a recent sample rather
-      // than risked as a total.
-      truncated:
-        pages.length >= CORPUS_SAMPLE_LIMIT ||
-        (usedFallback && pages.length > 0),
-    };
+    return { pages: [...pages.values()], truncated };
   } catch (error) {
     console.warn(
       `[brain] corpus listing failed: ${

--- a/packages/sdk/src/server/lib/brain-corpus.ts
+++ b/packages/sdk/src/server/lib/brain-corpus.ts
@@ -22,9 +22,17 @@ const CORPUS_SAMPLE_LIMIT = 500;
 /**
  * A settings page must not hold a request open on an unreachable service.
  * Short enough that an admin gets the rest of the page promptly; the corpus
- * section degrades to "unavailable" on its own.
+ * section degrades to "unavailable" on its own. This bounds the WHOLE
+ * listing, not each paged window: five windows must not multiply it.
  */
 const CORPUS_REQUEST_TIMEOUT_MS = 8_000;
+
+/**
+ * Below this remaining budget a further window is not attempted, and it is
+ * also the floor passed to a window that still runs, so a request always
+ * gets a workable timeout even at the very edge of the deadline.
+ */
+const CORPUS_MIN_WINDOW_BUDGET_MS = 500;
 
 export type BrainCorpusPage = {
   slug: string;
@@ -185,8 +193,20 @@ async function fetchBrainCorpusSample(): Promise<BrainCorpusSnapshot | null> {
   try {
     const pages = new Map<string, BrainCorpusPage>();
     let truncated = false;
+    // One deadline across every window, so paging cannot multiply the
+    // page's latency bound: each window gets whatever budget remains.
+    const deadlineAtMs = Date.now() + CORPUS_REQUEST_TIMEOUT_MS;
 
     for (let offset = 0; offset < CORPUS_SAMPLE_LIMIT;) {
+      const remainingMs = deadlineAtMs - Date.now();
+
+      if (offset > 0 && remainingMs < CORPUS_MIN_WINDOW_BUDGET_MS) {
+        // Firing a window that would be aborted almost immediately only adds
+        // a doomed round trip to a listing already reported as truncated.
+        truncated = true;
+        break;
+      }
+
       let payloads: unknown[];
 
       try {
@@ -194,7 +214,7 @@ async function fetchBrainCorpusSample(): Promise<BrainCorpusSnapshot | null> {
           connection,
           'list_pages',
           { limit: CORPUS_LISTING_WINDOW, offset },
-          { timeoutMs: CORPUS_REQUEST_TIMEOUT_MS },
+          { timeoutMs: Math.max(remainingMs, CORPUS_MIN_WINDOW_BUDGET_MS) },
         );
       } catch (error) {
         if (offset > 0 || !isRetryableToolError(error)) {
@@ -217,7 +237,12 @@ async function fetchBrainCorpusSample(): Promise<BrainCorpusSnapshot | null> {
           connection,
           'list_pages',
           {},
-          { timeoutMs: CORPUS_REQUEST_TIMEOUT_MS },
+          {
+            timeoutMs: Math.max(
+              deadlineAtMs - Date.now(),
+              CORPUS_MIN_WINDOW_BUDGET_MS,
+            ),
+          },
         );
         const fallbackPages = extractBrainCorpusPages(payloads);
 


### PR DESCRIPTION
## Problem

gbrain's `list_pages` caps `limit` at 100 per call (verified empirically: requesting 500 returns 100; the default with no args is 50). The corpus sampler asked for 500 in a single call, so the Settings page's composition chart described only the newest 100 pages — and since the `truncated` flag compared the count against 500, the caveat never rendered. During a backfill the chart lurches to whichever source ingested most recently: a 99-page Notion batch read as "the Brain holds 99 meetings and one Slack page."

## Fix

`readBrainCorpusSample` now pages with `offset` (verified supported) in 100-page windows up to the 500-page sample bound, deduplicating by slug:

- a short window ends the listing (whole corpus seen, `truncated: false`);
- a full window with no new slugs means the server ignored `offset` — stop and report `truncated: true` rather than looping on the newest slice;
- reaching the bound with full windows reports `truncated: true`;
- a failure after the first window keeps the pages already fetched as a truncated sample instead of reporting the Brain unreachable;
- the argument-shape fallback (bare listing) is always presented as a sample.

## Testing

Four new unit tests with a stubbed transport cover the paging offsets, the short-window stop, the offset-ignored stop, and the fallback. SDK suite, web brain component tests, types, lint, and knip all green.