### PR TITLE
Fix Fast provider retry settlement

### DIFF
--- a/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/non-task-provider-usage.test.ts
@@ -723,18 +723,28 @@ describe('resolveOpenCodeSmallModel', () => {
     sessionPromptMock.mockReturnValue(new Promise(() => undefined));
     const onProviderRetry = vi.fn();
 
-    const { generateTrackedNonTaskObject, NON_TASK_INFERENCE_SURFACES } =
-      await import('../non-task-provider-usage.js');
+    const {
+      classifyNonTaskInferenceError,
+      generateTrackedNonTaskObject,
+      NON_TASK_INFERENCE_SURFACES,
+    } = await import('../non-task-provider-usage.js');
 
-    await expect(
-      generateTrackedNonTaskObject({
-        surface: NON_TASK_INFERENCE_SURFACES.fastAgentQuestionAnswering,
-        modelRole: 'primary',
-        schema: z.object({ answer: z.string() }),
-        prompt: 'Answer.',
-        onProviderRetry,
-      }),
-    ).rejects.toBe(providerError);
+    const result = generateTrackedNonTaskObject({
+      surface: NON_TASK_INFERENCE_SURFACES.fastAgentQuestionAnswering,
+      modelRole: 'primary',
+      schema: z.object({ answer: z.string() }),
+      prompt: 'Answer.',
+      onProviderRetry,
+    });
+    const error = await result.catch((caught: unknown) => caught);
+    expect(error).toMatchObject({
+      name: 'NonTaskOpenCodePromptError',
+      providerError,
+    });
+    expect(classifyNonTaskInferenceError(error)).toMatchObject({
+      reason: 'rate_limited',
+      retryable: true,
+    });
     expect(onProviderRetry).toHaveBeenCalledWith(
       expect.objectContaining({
         attempt: 1,
@@ -744,6 +754,167 @@ describe('resolveOpenCodeSmallModel', () => {
     expect(sessionAbortMock).toHaveBeenCalledWith({
       sessionID: 'session-1',
       directory: expect.stringContaining('roomote-non-task-'),
+    });
+  });
+
+  it.each(['prompt_result', 'session_event'] as const)(
+    'preserves and classifies a gateway block when %s settles first',
+    async (settlement) => {
+      process.env = {
+        ...originalEnv,
+        OPENCODE_SDK_SERVER_URL: 'http://127.0.0.1:4096',
+      };
+      mockResolveEffectiveModelRuntimeEnv.mockResolvedValue({
+        R_MODEL: 'openai/gpt-5.6-sol',
+      });
+      const providerError = {
+        name: 'APIError',
+        data: {
+          message:
+            'Forbidden: request was blocked by a gateway or proxy. You may not have permission to access this resource.',
+          statusCode: 403,
+          responseBody: '<html><title>Forbidden</title></html>',
+        },
+      };
+      eventSubscribeMock.mockResolvedValue({
+        stream:
+          settlement === 'session_event'
+            ? (async function* () {
+                yield {
+                  type: 'session.error' as const,
+                  properties: { sessionID: 'session-1', error: providerError },
+                };
+              })()
+            : [],
+      });
+      sessionPromptMock.mockImplementation(() =>
+        settlement === 'prompt_result'
+          ? Promise.resolve({
+              data: { info: { error: providerError }, parts: [] },
+              error: undefined,
+            })
+          : new Promise(() => undefined),
+      );
+
+      const {
+        classifyNonTaskInferenceError,
+        generateTrackedNonTaskObject,
+        NON_TASK_INFERENCE_SURFACES,
+      } = await import('../non-task-provider-usage.js');
+      const result = generateTrackedNonTaskObject({
+        surface: NON_TASK_INFERENCE_SURFACES.fastAgentQuestionAnswering,
+        modelRole: 'primary',
+        schema: z.object({ answer: z.string() }),
+        prompt: 'Answer.',
+        onProviderRetry: vi.fn(),
+      });
+
+      const error = await result.catch((caught: unknown) => caught);
+      expect(error).toMatchObject({
+        name: 'NonTaskOpenCodePromptError',
+        providerError,
+      });
+      expect(classifyNonTaskInferenceError(error)).toEqual({
+        message: 'The inference provider gateway blocked the request.',
+        reason: 'gateway_blocked',
+        retryable: true,
+      });
+      expect(sessionAbortMock).toHaveBeenCalledWith({
+        sessionID: 'session-1',
+        directory: expect.stringContaining('roomote-non-task-'),
+      });
+    },
+  );
+
+  it('keeps named terminal OpenCode errors out of outer retry loops', async () => {
+    const { classifyNonTaskInferenceError } =
+      await import('../non-task-provider-usage.js');
+
+    for (const [providerError, expectedReason] of [
+      [
+        {
+          name: 'ProviderAuthError',
+          data: { providerID: 'openai', message: 'No API key found' },
+        },
+        'invalid_credentials',
+      ],
+      [
+        {
+          name: 'ContextOverflowError',
+          data: { message: 'Input exceeds the context window' },
+        },
+        'provider_error',
+      ],
+      [
+        {
+          name: 'ContentFilterError',
+          data: { message: 'The response was blocked' },
+        },
+        'provider_error',
+      ],
+      [
+        {
+          name: 'MessageOutputLengthError',
+          data: {},
+        },
+        'provider_error',
+      ],
+    ] as const) {
+      expect(classifyNonTaskInferenceError(providerError)).toMatchObject({
+        reason: expectedReason,
+        retryable: false,
+      });
+    }
+  });
+
+  it('continues observing provider errors when retry reporting fails', async () => {
+    process.env = {
+      ...originalEnv,
+      OPENCODE_SDK_SERVER_URL: 'http://127.0.0.1:4096',
+    };
+    mockResolveEffectiveModelRuntimeEnv.mockResolvedValue({
+      R_MODEL: 'openai/gpt-5.6-sol',
+    });
+    const providerError = {
+      name: 'APIError',
+      data: { message: 'Unauthorized', statusCode: 401 },
+    };
+    eventSubscribeMock.mockResolvedValue({
+      stream: (async function* () {
+        yield {
+          type: 'session.status' as const,
+          properties: {
+            sessionID: 'session-1',
+            status: {
+              type: 'retry' as const,
+              attempt: 1,
+              message: 'Retrying',
+              next: Date.now() + 1_000,
+            },
+          },
+        };
+        yield {
+          type: 'session.error' as const,
+          properties: { sessionID: 'session-1', error: providerError },
+        };
+      })(),
+    });
+    sessionPromptMock.mockReturnValue(new Promise(() => undefined));
+
+    const { generateTrackedNonTaskObject, NON_TASK_INFERENCE_SURFACES } =
+      await import('../non-task-provider-usage.js');
+
+    await expect(
+      generateTrackedNonTaskObject({
+        surface: NON_TASK_INFERENCE_SURFACES.fastAgentQuestionAnswering,
+        modelRole: 'primary',
+        schema: z.object({ answer: z.string() }),
+        prompt: 'Answer.',
+        onProviderRetry: vi.fn().mockRejectedValue(new Error('Slack failed')),
+      }),
+    ).rejects.toMatchObject({
+      name: 'NonTaskOpenCodePromptError',
+      providerError,
     });
   });
 

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-opencode-session.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-opencode-session.test.ts
@@ -99,6 +99,38 @@ describe('FastAgentOpenCodeSessionManager', () => {
     expect(execute).toHaveBeenCalledTimes(3);
   });
 
+  it('rebuilds an invalidated conversation from compatibility history', async () => {
+    const manager = new FastAgentOpenCodeSessionManager();
+    const prompts: Array<{ prompt: string; sessionId?: string }> = [];
+    const execute = vi.fn(async (session, prompt: string) => {
+      prompts.push({ prompt, sessionId: session.id });
+      session.id ??= `session-${prompts.length}`;
+      return prompt;
+    });
+
+    await manager.run({
+      conversationId: 'conversation-1',
+      prompt: 'turn one',
+      bootstrapPrompt: 'bootstrap turn one',
+      execute,
+    });
+    manager.invalidate('conversation-1');
+    await manager.run({
+      conversationId: 'conversation-1',
+      prompt: 'turn two only',
+      bootstrapPrompt: 'visible history including the failure and turn two',
+      execute,
+    });
+
+    expect(prompts).toEqual([
+      { prompt: 'bootstrap turn one', sessionId: undefined },
+      {
+        prompt: 'visible history including the failure and turn two',
+        sessionId: undefined,
+      },
+    ]);
+  });
+
   it('forgets idle and least-recently-used sessions', async () => {
     let now = 0;
     const manager = new FastAgentOpenCodeSessionManager({

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   getEnvironments: vi.fn(),
   generateText: vi.fn(),
   classifyInferenceError: vi.fn(),
+  invalidateSession: vi.fn(),
   listIntegrations: vi.fn(),
   callIntegration: vi.fn(),
   sendTaskMessage: vi.fn(),
@@ -49,6 +50,9 @@ vi.mock('../../non-task-provider-usage', () => ({
   },
   classifyNonTaskInferenceError: mocks.classifyInferenceError,
   generateTrackedNonTaskTextInOpenCodeSession: mocks.generateText,
+  isNonTaskOpenCodePromptTimeoutError: (error: unknown) =>
+    error instanceof Error &&
+    error.name === 'NonTaskOpenCodePromptTimeoutError',
   isNonTaskOpenCodeSessionNotFoundError: (error: unknown) =>
     error instanceof Error &&
     error.name === 'NonTaskOpenCodeSessionNotFoundError',
@@ -56,13 +60,14 @@ vi.mock('../../non-task-provider-usage', () => ({
 
 vi.mock('../fast-agent-opencode-session', () => ({
   fastAgentOpenCodeSessionManager: {
+    invalidate: mocks.invalidateSession,
     run: ({
       prompt,
       execute,
     }: {
       prompt: string;
       execute: (
-        session: { id: string },
+        session: { id?: string },
         selectedPrompt: string,
       ) => Promise<unknown>;
     }) => execute({ id: 'opencode-session-1' }, prompt),
@@ -173,6 +178,13 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
         return {
           message: 'The inference provider is rate limiting requests.',
           reason: 'rate_limited',
+          retryable: true,
+        };
+      }
+      if (detail.includes('gateway or proxy')) {
+        return {
+          message: 'The inference provider gateway blocked the request.',
+          reason: 'gateway_blocked',
           retryable: true,
         };
       }
@@ -521,6 +533,91 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
     expect(adapter.postReply).toHaveBeenCalledWith(
       expect.objectContaining({ purpose: 'closeout' }),
     );
+    expect(mocks.invalidateSession).toHaveBeenCalledWith('conversation-1');
+  });
+
+  it('retries a gateway block from a clean compatibility bootstrap', async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.getSession.mockResolvedValue({
+        id: 'conversation-1',
+        compatibilityMessages: [
+          { role: 'user', content: 'Earlier question' },
+          { role: 'assistant', content: 'Earlier answer' },
+        ],
+      });
+      mocks.generateText
+        .mockRejectedValueOnce(
+          new Error('Forbidden: request was blocked by a gateway or proxy.'),
+        )
+        .mockImplementationOnce(async (_params, _session, options) => {
+          await options.onSessionReady('replacement-session');
+          await invokeTool(nativeToolNames.sendChatReply, {
+            purpose: 'closeout',
+            message: 'The retry recovered.',
+          });
+          return '';
+        });
+      const adapter = callbacks();
+
+      const resultPromise = answerFastAgentQuestion({ ...baseParams, adapter });
+      await vi.runAllTimersAsync();
+
+      await expect(resultPromise).resolves.toBe('The retry recovered.');
+      expect(mocks.generateText).toHaveBeenCalledTimes(2);
+      expect(mocks.generateText.mock.calls[0]?.[0].prompt).not.toContain(
+        'Earlier answer',
+      );
+      expect(mocks.generateText.mock.calls[1]?.[0].prompt).toContain(
+        'Earlier answer',
+      );
+      expect(adapter.postReply).toHaveBeenNthCalledWith(1, {
+        purpose: 'progress',
+        message:
+          'Fast mode’s request was blocked by the inference provider gateway. Retrying in 1s (attempt 1/3).',
+      });
+      expect(mocks.invalidateSession).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not replay a failed turn after a native tool was invoked', async () => {
+    mocks.generateText.mockImplementationOnce(
+      async (_params, _session, options) => {
+        await options.onSessionReady('opencode-session-1');
+        await invokeTool(nativeToolNames.sendChatReply, {
+          purpose: 'ack',
+          message: 'I’m checking.',
+        });
+        throw new Error('TypeError: fetch failed');
+      },
+    );
+    const adapter = callbacks();
+
+    await answerFastAgentQuestion({ ...baseParams, adapter });
+
+    expect(mocks.generateText).toHaveBeenCalledOnce();
+    expect(adapter.postReply).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        purpose: 'progress',
+        message: expect.stringContaining('Retrying in'),
+      }),
+    );
+    expect(mocks.invalidateSession).toHaveBeenCalledWith('conversation-1');
+  });
+
+  it('leaves the OpenCode prompt deadline as the single retry budget', async () => {
+    const timeout = new Error(
+      'Timed out waiting for OpenCode output after 120000ms.',
+    );
+    timeout.name = 'NonTaskOpenCodePromptTimeoutError';
+    mocks.generateText.mockRejectedValue(timeout);
+
+    await answerFastAgentQuestion({ ...baseParams, adapter: callbacks() });
+
+    expect(mocks.generateText).toHaveBeenCalledOnce();
+    expect(mocks.invalidateSession).toHaveBeenCalledWith('conversation-1');
   });
 
   it('retries a transient native prompt failure with a visible notice', async () => {

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-opencode-session.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-opencode-session.ts
@@ -89,6 +89,17 @@ export class FastAgentOpenCodeSessionManager {
     this.entries.clear();
   }
 
+  /**
+   * Discard a failed live transcript without disturbing queued turns. The next
+   * run will rebuild the conversation from Roomote's compatibility history.
+   */
+  invalidate(conversationId: string): void {
+    const entry = this.entries.get(conversationId);
+    if (entry) {
+      entry.session.id = undefined;
+    }
+  }
+
   get size(): number {
     return this.entries.size;
   }

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -20,6 +20,7 @@ import {
 import {
   classifyNonTaskInferenceError,
   generateTrackedNonTaskTextInOpenCodeSession,
+  isNonTaskOpenCodePromptTimeoutError,
   isNonTaskOpenCodeSessionNotFoundError,
   NON_TASK_INFERENCE_SURFACES,
   type NonTaskPromptFile,
@@ -132,6 +133,11 @@ type FastAgentInferenceRetryNotice = {
   delayMs?: number;
 };
 
+type FastAgentInferenceRetryOptions = {
+  canRetry?: (error: unknown, failure: FastAgentInferenceFailure) => boolean;
+  prepareRetry?: () => Promise<void> | void;
+};
+
 class FastAgentInferenceError extends Error {
   constructor(
     public readonly failure: FastAgentInferenceFailure,
@@ -166,9 +172,11 @@ function formatFastAgentInferenceRetryNotice(
   const headline =
     notice.failure.reason === 'rate_limited'
       ? 'Fast mode’s inference provider is rate limiting requests.'
-      : notice.failure.reason === 'timeout'
-        ? 'Fast mode’s inference provider did not respond in time.'
-        : 'Fast mode’s inference provider returned a temporary error.';
+      : notice.failure.reason === 'gateway_blocked'
+        ? 'Fast mode’s request was blocked by the inference provider gateway.'
+        : notice.failure.reason === 'timeout'
+          ? 'Fast mode’s inference provider did not respond in time.'
+          : 'Fast mode’s inference provider returned a temporary error.';
 
   if (notice.delayMs === undefined || notice.maxAttempts === undefined) {
     return `${headline} Retrying automatically…`;
@@ -188,6 +196,8 @@ function formatFastAgentInferenceFailure(
       return 'Fast mode’s inference provider did not respond after retrying. Any delegated tasks can keep running; please try again in a moment.';
     case 'endpoint_unreachable':
       return 'Fast mode could not reach the inference provider after retrying. Please try again in a moment.';
+    case 'gateway_blocked':
+      return 'Fast mode’s request is still being blocked by the inference provider gateway after retrying. Please try again in a moment.';
     case 'insufficient_credits':
       return 'Fast mode cannot use the inference provider because the account has insufficient credits or quota.';
     case 'invalid_credentials':
@@ -208,6 +218,7 @@ function waitForFastAgentInferenceRetry(delayMs: number): Promise<void> {
 async function runFastAgentInferenceWithRetries<T>(
   run: () => Promise<T>,
   onRetry?: (notice: FastAgentInferenceRetryNotice) => Promise<void>,
+  options: FastAgentInferenceRetryOptions = {},
 ): Promise<T> {
   for (
     let retryNumber = 0;
@@ -226,6 +237,7 @@ async function runFastAgentInferenceWithRetries<T>(
       const failure = classifyNonTaskInferenceError(error);
       if (
         !failure.retryable ||
+        options.canRetry?.(error, failure) === false ||
         retryNumber >= FAST_AGENT_INFERENCE_MAX_RETRIES
       ) {
         throw new FastAgentInferenceError(failure, error);
@@ -239,12 +251,19 @@ async function runFastAgentInferenceWithRetries<T>(
       console.warn(
         `[Fast Agent] Retrying inference failure attempt=${attemptNumber}/${FAST_AGENT_INFERENCE_MAX_RETRIES} delayMs=${delayMs} reason=${failure.reason}: ${formatErrorForLog(error)}`,
       );
-      await onRetry?.({
-        failure,
-        attemptNumber,
-        maxAttempts: FAST_AGENT_INFERENCE_MAX_RETRIES,
-        delayMs,
-      });
+      try {
+        await onRetry?.({
+          failure,
+          attemptNumber,
+          maxAttempts: FAST_AGENT_INFERENCE_MAX_RETRIES,
+          delayMs,
+        });
+      } catch (noticeError) {
+        console.warn(
+          `[Fast Agent] Failed to post inference retry notice: ${formatErrorForLog(noticeError)}`,
+        );
+      }
+      await options.prepareRetry?.();
       await waitForFastAgentInferenceRetry(delayMs);
     }
   }
@@ -541,6 +560,7 @@ export async function answerFastAgentQuestion({
     const completedTaskActions = new Set<string>();
     let visibleUpdatePosted = false;
     let closed = false;
+    let nativeToolInvoked = false;
     let retriedTaskStart = false;
 
     const mirrorPendingMessages = async (strict = false) => {
@@ -622,6 +642,7 @@ export async function answerFastAgentQuestion({
     ): Promise<unknown> => {
       const closedError = requireOpen();
       if (closedError) return closedError;
+      nativeToolInvoked = true;
 
       try {
         switch (call.name) {
@@ -837,12 +858,16 @@ export async function answerFastAgentQuestion({
 
     const nativeRuntime = await getFastAgentNativeToolRuntime();
     const imageFiles = getFastAgentImageFiles(images);
+    const serializedTurnPrompt = serializeFastAgentMessages([turnMessage]);
+    const serializedBootstrapPrompt =
+      serializeFastAgentMessages(bootstrapMessages);
     const promptText = await fastAgentOpenCodeSessionManager.run({
       conversationId: session.id,
-      prompt: serializeFastAgentMessages([turnMessage]),
-      bootstrapPrompt: serializeFastAgentMessages(bootstrapMessages),
+      prompt: serializedTurnPrompt,
+      bootstrapPrompt: serializedBootstrapPrompt,
       execute: async (openCodeSession, selectedPrompt) => {
         let unbind: (() => void) | undefined;
+        let promptForAttempt = selectedPrompt;
         try {
           return await runFastAgentInferenceWithRetries(
             () =>
@@ -853,7 +878,7 @@ export async function answerFastAgentQuestion({
                     NON_TASK_INFERENCE_SURFACES.fastAgentQuestionAnswering,
                   modelRole: FAST_AGENT_MODEL_ROLE,
                   system,
-                  prompt: selectedPrompt,
+                  prompt: promptForAttempt,
                   onProviderRetry: reportProviderRetryEvent,
                   ...(imageFiles.length
                     ? {
@@ -877,6 +902,23 @@ export async function answerFastAgentQuestion({
                 },
               ),
             reportInferenceRetry,
+            {
+              // OpenCode already owns retries while a provider turn remains
+              // active. Roomote retries only a terminal failure that happened
+              // before the model invoked any native tool, so replay cannot
+              // duplicate a visible reply or external side effect.
+              canRetry: (error) =>
+                !nativeToolInvoked &&
+                !isNonTaskOpenCodePromptTimeoutError(error),
+              prepareRetry: () => {
+                // OpenCode persists the user message before inference starts,
+                // and abort does not roll it back. Discard the failed session
+                // and rebuild from visible compatibility history instead of
+                // appending the same turn to a poisoned transcript.
+                openCodeSession.id = undefined;
+                promptForAttempt = serializedBootstrapPrompt;
+              },
+            },
           );
         } finally {
           unbind?.();
@@ -896,6 +938,12 @@ export async function answerFastAgentQuestion({
     console.error(
       `[Fast Agent] Failed to answer question: ${formatErrorForLog(error)}`,
     );
+    if (canonicalConversationId) {
+      // The system-posted closeout below is mirrored to compatibility history,
+      // not to OpenCode's live transcript. Force the next turn to bootstrap so
+      // the model can see the failure the user saw in Slack or Discord.
+      fastAgentOpenCodeSessionManager.invalidate(canonicalConversationId);
+    }
     if (platformEvent) throw error;
 
     const message = launchedTaskMessage

--- a/packages/cloud-agents/src/server/non-task-provider-usage.ts
+++ b/packages/cloud-agents/src/server/non-task-provider-usage.ts
@@ -99,6 +99,7 @@ const NON_TASK_INFERENCE_VALIDATION_TIMEOUT_MS = 15_000;
 
 export type NonTaskInferenceValidationFailureReason =
   | 'endpoint_unreachable'
+  | 'gateway_blocked'
   | 'insufficient_credits'
   | 'invalid_credentials'
   | 'model_unavailable'
@@ -193,6 +194,31 @@ export class NonTaskOpenCodeSessionNotFoundError extends Error {
     super('The OpenCode session is no longer available.');
     this.name = 'NonTaskOpenCodeSessionNotFoundError';
   }
+}
+
+export class NonTaskOpenCodePromptError extends Error {
+  constructor(
+    public readonly providerError: unknown,
+    label: string,
+  ) {
+    super(`${label}: ${formatOpenCodeSdkError(providerError)}`, {
+      cause: providerError,
+    });
+    this.name = 'NonTaskOpenCodePromptError';
+  }
+}
+
+export class NonTaskOpenCodePromptTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Timed out waiting for OpenCode output after ${timeoutMs}ms.`);
+    this.name = 'NonTaskOpenCodePromptTimeoutError';
+  }
+}
+
+export function isNonTaskOpenCodePromptTimeoutError(
+  error: unknown,
+): error is NonTaskOpenCodePromptTimeoutError {
+  return error instanceof NonTaskOpenCodePromptTimeoutError;
 }
 
 export function isNonTaskOpenCodeSessionNotFoundError(
@@ -513,9 +539,10 @@ async function resolveModelForInputModality(
 /**
  * Shared OpenCode SDK plumbing for non-task inference: leases a managed SDK
  * server, wires the abort/timeout controller, creates a session, and issues the
- * prompt. Returns the raw prompt payload (`{ info, parts }`) so each caller can
- * interpret it — structured object extraction or plain-text joining — without
- * duplicating the boilerplate or the terminal-scraping apparatus it replaced.
+ * prompt. Provider errors from either the event stream or prompt result are
+ * normalized before returning, so callers receive the same structured cause
+ * regardless of which transport settles first. Successful calls return the raw
+ * prompt payload for structured-object extraction or plain-text joining.
  */
 async function runNonTaskSdkPrompt(
   params: GenerateTrackedNonTaskBaseParams,
@@ -530,6 +557,7 @@ async function runNonTaskSdkPrompt(
     env?: Partial<Record<string, string>>;
     onSessionReady?: (sessionID: string) => Promise<void> | void;
     permission?: PermissionRuleset;
+    promptErrorLabel?: string;
     session?: NonTaskOpenCodeSession;
     signal?: AbortSignal;
     useConfiguredServer?: boolean;
@@ -540,6 +568,9 @@ async function runNonTaskSdkPrompt(
 }> {
   const { model, resolvedModelRuntimeEnv } = runtime;
   const timeoutMs = params.timeoutMs ?? 120_000;
+  const promptErrorLabel =
+    options.promptErrorLabel ??
+    `OpenCode structured prompt failed (model ${model})`;
   const sessionDirectory =
     options.directory ?? resolveNonTaskSessionDirectory();
   const server = await leaseOpenCodeSdkServer({
@@ -553,9 +584,7 @@ async function runNonTaskSdkPrompt(
   });
   const abortController = new AbortController();
   const timeout = setTimeout(() => {
-    abortController.abort(
-      new Error(`Timed out waiting for OpenCode output after ${timeoutMs}ms.`),
-    );
+    abortController.abort(new NonTaskOpenCodePromptTimeoutError(timeoutMs));
   }, timeoutMs);
   const externalSignal = options.signal;
   const abortFromExternalSignal = () => {
@@ -632,20 +661,34 @@ async function runNonTaskSdkPrompt(
                 event.properties.sessionID === sessionId &&
                 event.properties.status.type === 'retry'
               ) {
-                await params.onProviderRetry?.({
-                  attempt: event.properties.status.attempt,
-                  message: event.properties.status.message,
-                  ...(Number.isFinite(event.properties.status.next)
-                    ? { nextRetryAtMs: event.properties.status.next }
-                    : {}),
-                });
+                try {
+                  await params.onProviderRetry?.({
+                    attempt: event.properties.status.attempt,
+                    message: event.properties.status.message,
+                    ...(Number.isFinite(event.properties.status.next)
+                      ? { nextRetryAtMs: event.properties.status.next }
+                      : {}),
+                  });
+                } catch (error) {
+                  // Retry reporting is auxiliary. A transient Slack or Discord
+                  // post failure must not stop observation of the provider's
+                  // eventual session error.
+                  console.warn(
+                    `[NonTaskProviderUsage] OpenCode provider retry reporter failed: ${formatOpenCodeSdkError(error)}`,
+                  );
+                }
               } else if (
                 event.type === 'session.error' &&
                 event.properties.sessionID === sessionId
               ) {
                 rejectSessionError(
-                  event.properties.error ??
-                    new Error('OpenCode session failed without error detail.'),
+                  new NonTaskOpenCodePromptError(
+                    event.properties.error ??
+                      new Error(
+                        'OpenCode session failed without error detail.',
+                      ),
+                    promptErrorLabel,
+                  ),
                 );
                 return;
               }
@@ -669,7 +712,6 @@ async function runNonTaskSdkPrompt(
       }
     }
 
-    let promptResult;
     try {
       const promptRequest = client.session.prompt(
         {
@@ -681,9 +723,29 @@ async function runNonTaskSdkPrompt(
         },
         { signal: abortController.signal },
       );
-      promptResult = params.onProviderRetry
+      const promptResult = params.onProviderRetry
         ? await Promise.race([promptRequest, sessionError])
         : await promptRequest;
+
+      if (promptResult.error || !promptResult.data) {
+        if (isOpenCodeSessionMissing(promptResult.error)) {
+          throw new NonTaskOpenCodeSessionNotFoundError();
+        }
+
+        throw new NonTaskOpenCodePromptError(
+          promptResult.error,
+          promptErrorLabel,
+        );
+      }
+
+      if (promptResult.data.info.error) {
+        throw new NonTaskOpenCodePromptError(
+          promptResult.data.info.error,
+          promptErrorLabel,
+        );
+      }
+
+      return promptResult.data;
     } catch (error) {
       // Aborting the HTTP request does not guarantee that an OpenCode server
       // stopped its model turn. Explicitly cancel it before the session or a
@@ -697,22 +759,6 @@ async function runNonTaskSdkPrompt(
       eventAbortController.abort();
       void eventMonitor?.catch(() => undefined);
     }
-
-    if (promptResult.error || !promptResult.data) {
-      if (isOpenCodeSessionMissing(promptResult.error)) {
-        throw new NonTaskOpenCodeSessionNotFoundError();
-      }
-
-      // The resolved `provider/model` id rides in the message because callers
-      // (the router's fallback log among them) only know the role alias —
-      // production diagnosis of a provider-specific rejection needs the real
-      // id and provider without a database lookup.
-      throw new Error(
-        `OpenCode structured prompt failed (model ${model}): ${formatOpenCodeSdkError(promptResult.error)}`,
-      );
-    }
-
-    return promptResult.data;
   } finally {
     externalSignal?.removeEventListener('abort', abortFromExternalSignal);
     clearTimeout(timeout);
@@ -750,13 +796,8 @@ export async function generateTrackedNonTaskText(
         })),
       ],
     },
+    { promptErrorLabel: 'OpenCode text prompt failed' },
   );
-
-  if (data.info.error) {
-    throw new Error(
-      `OpenCode text prompt failed: ${formatOpenCodeSdkError(data.info.error)}`,
-    );
-  }
 
   const text = data.parts
     .filter(
@@ -811,16 +852,11 @@ export async function generateTrackedNonTaskTextInOpenCodeSession(
       env: options.env,
       onSessionReady: options.onSessionReady,
       permission: options.permission,
+      promptErrorLabel: 'OpenCode native Fast prompt failed',
       session,
       useConfiguredServer: false,
     },
   );
-
-  if (data.info.error) {
-    throw new Error(
-      `OpenCode native Fast prompt failed: ${formatOpenCodeSdkError(data.info.error)}`,
-    );
-  }
 
   return data.parts
     .filter(
@@ -842,32 +878,33 @@ async function generateTrackedNonTaskObjectWithSdk<
     params.modelRole,
   );
 
-  const data = await runNonTaskSdkPrompt(params, resolvedRuntime, {
-    system: params.system,
-    format: {
-      type: 'json_schema',
-      schema: zodToJsonSchema(params.schema, {
-        $refStrategy: 'none',
-        target: 'jsonSchema7',
-      }) as Record<string, unknown>,
-      retryCount: DEFAULT_OPENCODE_STRUCTURED_OUTPUT_RETRY_COUNT,
-    },
-    parts: [
-      {
-        type: 'text',
-        text: buildOpenCodePrompt({
-          prompt: params.prompt,
-          maxOutputTokens: params.maxOutputTokens,
-        }),
+  const data = await runNonTaskSdkPrompt(
+    params,
+    resolvedRuntime,
+    {
+      system: params.system,
+      format: {
+        type: 'json_schema',
+        schema: zodToJsonSchema(params.schema, {
+          $refStrategy: 'none',
+          target: 'jsonSchema7',
+        }) as Record<string, unknown>,
+        retryCount: DEFAULT_OPENCODE_STRUCTURED_OUTPUT_RETRY_COUNT,
       },
-    ],
-  });
-
-  if (data.info.error) {
-    throw new Error(
-      `OpenCode structured prompt failed (model ${resolvedRuntime.model}): ${formatOpenCodeSdkError(data.info.error)}`,
-    );
-  }
+      parts: [
+        {
+          type: 'text',
+          text: buildOpenCodePrompt({
+            prompt: params.prompt,
+            maxOutputTokens: params.maxOutputTokens,
+          }),
+        },
+      ],
+    },
+    {
+      promptErrorLabel: `OpenCode structured prompt failed (model ${resolvedRuntime.model})`,
+    },
+  );
 
   const structured = (data.info as { structured?: unknown }).structured;
   if (structured == null) {
@@ -885,6 +922,12 @@ export async function generateTrackedNonTaskObject<
   params: GenerateTrackedNonTaskObjectParams<TSchema>,
 ): Promise<{ object: z.output<TSchema> }> {
   return generateTrackedNonTaskObjectWithSdk(params);
+}
+
+function unwrapNonTaskInferenceError(error: unknown): unknown {
+  return error instanceof NonTaskOpenCodePromptError
+    ? error.providerError
+    : error;
 }
 
 function findInferenceErrorStatusCode(error: unknown): number | undefined {
@@ -951,19 +994,25 @@ export function classifyNonTaskInferenceError(
   // present — provider wording varies too much for substring matching to be
   // the primary signal (Anthropic says "API key is invalid.", which no
   // keyword list reliably catches).
+  const inferenceError = unwrapNonTaskInferenceError(error);
   const record =
-    error && typeof error === 'object'
-      ? (error as Record<string, unknown>)
+    inferenceError && typeof inferenceError === 'object'
+      ? (inferenceError as Record<string, unknown>)
       : undefined;
   const data =
     record?.data && typeof record.data === 'object'
       ? (record.data as Record<string, unknown>)
       : undefined;
-  const statusCode = findInferenceErrorStatusCode(error);
+  const statusCode = findInferenceErrorStatusCode(inferenceError);
   const responseBody =
     typeof data?.responseBody === 'string' ? data.responseBody : '';
   const detail =
-    `${formatOpenCodeSdkError(error)} ${responseBody}`.toLowerCase();
+    `${formatOpenCodeSdkError(inferenceError)} ${responseBody}`.toLowerCase();
+  const errorName = typeof record?.name === 'string' ? record.name : '';
+  const gatewayBlocked =
+    (statusCode === 403 && /^\s*(?:<!doctype|<html)/iu.test(responseBody)) ||
+    (detail.includes('forbidden:') &&
+      detail.includes('request was blocked by a gateway or proxy'));
 
   // Failures inside Roomote's own validation helper (the managed OpenCode
   // server) must not read as provider failures — the candidate credentials
@@ -978,6 +1027,47 @@ export function classifyNonTaskInferenceError(
         'Roomote could not run its validation helper. Try again, or check the server logs.',
       reason: 'provider_error',
       retryable: true,
+    };
+  }
+
+  // OpenCode normalizes HTML 403 responses from provider gateways and WAFs
+  // into this error. These are distinct from structured credential failures:
+  // the same request can succeed when routed through a healthy edge shortly
+  // afterward, so Fast may recover with its bounded outer retry.
+  if (gatewayBlocked) {
+    return {
+      message: 'The inference provider gateway blocked the request.',
+      reason: 'gateway_blocked',
+      retryable: true,
+    };
+  }
+
+  if (errorName === 'ProviderAuthError') {
+    return {
+      message: 'The inference provider rejected these credentials.',
+      reason: 'invalid_credentials',
+      retryable: false,
+    };
+  }
+
+  if (errorName === 'MessageAbortedError') {
+    return {
+      message: 'The inference provider did not respond in time. Try again.',
+      reason: 'timeout',
+      retryable: true,
+    };
+  }
+
+  if (
+    errorName === 'ContextOverflowError' ||
+    errorName === 'ContentFilterError' ||
+    errorName === 'MessageOutputLengthError' ||
+    errorName === 'StructuredOutputError'
+  ) {
+    return {
+      message: 'The inference provider rejected the request.',
+      reason: 'provider_error',
+      retryable: false,
     };
   }
 
@@ -1208,6 +1298,7 @@ export async function validateNonTaskInference(params: {
         },
         {
           ephemeral: true,
+          promptErrorLabel: `OpenCode inference validation prompt failed (model ${model})`,
           signal: deadlineController.signal,
           useConfiguredServer: false,
         },
@@ -1215,11 +1306,6 @@ export async function validateNonTaskInference(params: {
     } finally {
       clearTimeout(deadlineTimer);
     }
-
-    if (data.info.error) {
-      throw data.info.error;
-    }
-
     const structured = (data.info as { structured?: unknown }).structured;
     if (
       !structured ||


### PR DESCRIPTION
## What changed

- normalize OpenCode provider errors from both `session.error` events and resolved prompt results while preserving the original structured cause
- classify HTML 403 gateway/WAF blocks separately from credential failures and keep named terminal OpenCode errors out of outer retry loops
- leave OpenCode's prompt deadline as the single budget for its internal provider retries
- retry terminal Fast failures only before any native tool invocation, then rebuild from compatibility history in a fresh OpenCode session
- invalidate failed warm sessions so system-posted terminal closeouts are included when the next turn bootstraps
- keep retry notices best-effort so a progress-post failure cannot hide the eventual provider error

## Why

The same provider rejection could previously follow two different paths: a streamed session error preserved the status code, while a resolved prompt result wrapped it in a plain `Error` and lost the structured metadata. That made retry and terminal reporting depend on event ordering.

Retrying in the same persistent session also appended the same user turn after abort, and retrying after native tools had run could replay visible or external side effects. Terminal closeouts posted by Roomote were mirrored for rollback compatibility but were absent from the live OpenCode transcript, so a follow-up could not explain the error the user had just seen.

This PR is stacked on #1466 and is intended to merge into `codex/fast-mode-provider-retries`.

## Validation

- `pnpm --filter @roomote/cloud-agents exec vitest run` (99 files, 792 tests)
- `pnpm check-types`
- `pnpm lint`
- `pnpm knip`
- targeted ESLint for all six changed files