### PR TITLE
Fix Fast image-only Slack follow-ups

### DIFF
--- a/apps/api/src/handlers/slack/events/fast-agent-processing.test.ts
+++ b/apps/api/src/handlers/slack/events/fast-agent-processing.test.ts
@@ -8,9 +8,11 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@roomote/cloud-agents/server', () => ({
   acquireFastAgentTurnLock: mocks.acquireLock,
   answerFastAgentQuestion: mocks.answerQuestion,
+  FAST_AGENT_MAX_IMAGE_ATTACHMENTS: 3,
 }));
 
-vi.mock('@roomote/cloud-agents', () => ({
+vi.mock('@roomote/cloud-agents', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@roomote/cloud-agents')>()),
   stripLeadingSlackProductMention: (text: string) => text,
 }));
 
@@ -197,6 +199,71 @@ describe('processFastAgentMessage', () => {
         question: 'What about this one?',
         images: [image],
       }),
+    );
+  });
+
+  it('treats an image-only follow-up from thread history as a Fast question and caps downloads', async () => {
+    const images = [
+      'data:image/png;base64,aW1hZ2UtMQ==',
+      'data:image/png;base64,aW1hZ2UtMg==',
+      'data:image/png;base64,aW1hZ2UtMw==',
+    ];
+    const files = Array.from({ length: 4 }, (_, index) => ({
+      id: `F_FOLLOW_UP_${index}`,
+      name: `follow-up-${index}.png`,
+      mimetype: 'image/png',
+      filetype: 'png',
+      url_private: `https://files.slack.com/F_FOLLOW_UP_${index}`,
+      url_private_download: `https://files.slack.com/F_FOLLOW_UP_${index}/download`,
+      size: 1024,
+    }));
+    const slack = {
+      addReaction: vi.fn().mockResolvedValue(true),
+      removeReaction: vi.fn().mockResolvedValue(true),
+      normalizeIncomingText: vi.fn(async (text: string) => text),
+      fetchThreadMessages: vi.fn(async () => [
+        {
+          user: 'U123',
+          text: '!fast inspect this screenshot',
+          ts: '100.001',
+          type: 'message',
+        },
+        {
+          user: 'U123',
+          text: '',
+          ts: '100.002',
+          type: 'message',
+          files,
+        },
+      ]),
+      processSlackFiles: vi.fn().mockResolvedValue(images),
+    };
+
+    await processFastAgentMessage({
+      event: {
+        type: 'message',
+        channel: 'D123',
+        channel_type: 'im',
+        thread_ts: '100.001',
+        user: 'U123',
+        text: '',
+        ts: '100.002',
+      } as never,
+      slack: slack as never,
+      userId: 'user-1',
+      teamId: 'T123',
+      continuation: true,
+    });
+
+    expect(slack.processSlackFiles).toHaveBeenCalledWith(files.slice(0, 3));
+    expect(mocks.answerQuestion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        question: expect.stringContaining('shared an image'),
+        images,
+      }),
+    );
+    expect(mocks.postThreadMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining('!fast') }),
     );
   });
 

--- a/apps/api/src/handlers/slack/events/fast-agent.ts
+++ b/apps/api/src/handlers/slack/events/fast-agent.ts
@@ -2,18 +2,30 @@ import { PRODUCT_NAME } from '@roomote/types';
 import {
   acquireFastAgentTurnLock,
   answerFastAgentQuestion,
+  FAST_AGENT_MAX_IMAGE_ATTACHMENTS,
   type FastAgentActiveTask,
   type LaunchFastAgentTask,
 } from '@roomote/cloud-agents/server';
 import {
+  isSlackImageFile,
   resolveCurrentSlackMessageFiles,
   type SlackEvent,
+  type SlackFile,
   type SlackNotifier,
 } from '@roomote/slack';
 import { stripLeadingSlackProductMention } from '@roomote/cloud-agents';
 
 import { LEADING_FAST_COMMAND_MENTION_PATTERN } from '../constants.js';
 import { postSlackThreadMarkdownMessage } from '../helpers/thread-posting.js';
+
+const IMAGE_ONLY_FAST_QUESTION =
+  'The user shared an image without additional text. Respond using the attached image and the preceding thread context.';
+
+function selectFastAgentImageFiles(files?: SlackFile[]): SlackFile[] {
+  return (files ?? [])
+    .filter(isSlackImageFile)
+    .slice(0, FAST_AGENT_MAX_IMAGE_ATTACHMENTS);
+}
 
 export function stripLeadingFastCommandMention(text: string): string {
   return text.replace(LEADING_FAST_COMMAND_MENTION_PATTERN, '').trimStart();
@@ -98,7 +110,7 @@ export async function processFastAgentMessage(params: {
       stripLeadingFastCommandMention(event.authoredText ?? event.text),
     ),
   );
-  const question = extractFastQuestion(normalizedText, continuation);
+  const textQuestion = extractFastQuestion(normalizedText, continuation);
 
   let didAddProcessingReaction = false;
 
@@ -108,22 +120,6 @@ export async function processFastAgentMessage(params: {
       timestamp: event.ts,
       name: processingReactionName,
     });
-
-    if (!question) {
-      await postSlackThreadMarkdownMessage({
-        slack,
-        channel: event.channel,
-        threadTs: threadId,
-        text: usageText,
-        sourceMessageTs: event.ts,
-        conversationLog: {
-          userId,
-          slackTeamId: teamId,
-          source: 'fast_agent',
-        },
-      });
-      return;
-    }
 
     let threadContext: Awaited<ReturnType<typeof slack.fetchThreadMessages>> =
       [];
@@ -148,14 +144,33 @@ export async function processFastAgentMessage(params: {
       eventFiles: event.files,
       messages: threadContext,
     });
-    const images = currentMessageFiles?.length
-      ? await slack.processSlackFiles(currentMessageFiles).catch((error) => {
+    const imageFiles = selectFastAgentImageFiles(currentMessageFiles);
+    const images = imageFiles.length
+      ? await slack.processSlackFiles(imageFiles).catch((error) => {
           console.error(
             `[SlackWebhook] Failed to process Fast message images: ${error instanceof Error ? error.message : String(error)}`,
           );
           return [];
         })
       : [];
+    const question =
+      textQuestion ?? (images.length > 0 ? IMAGE_ONLY_FAST_QUESTION : null);
+
+    if (!question) {
+      await postSlackThreadMarkdownMessage({
+        slack,
+        channel: event.channel,
+        threadTs: threadId,
+        text: usageText,
+        sourceMessageTs: event.ts,
+        conversationLog: {
+          userId,
+          slackTeamId: teamId,
+          source: 'fast_agent',
+        },
+      });
+      return;
+    }
     const serializedThreadContext = threadContext
       .filter((message) => message.ts !== event.ts)
       .map((message) => ({

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -211,7 +211,13 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
   it('passes image data URLs to the Fast model as image-capable file input', async () => {
     await answerFastAgentQuestion({
       ...baseParams,
-      images: ['data:image/png;base64,aGVsbG8=', 'not-an-image'],
+      images: [
+        'data:image/png;base64,aW1hZ2UtMQ==',
+        'not-an-image',
+        'data:image/png;base64,aW1hZ2UtMg==',
+        'data:image/png;base64,aW1hZ2UtMw==',
+        'data:image/png;base64,aW1hZ2UtNA==',
+      ],
       adapter: callbacks(),
     });
 
@@ -220,7 +226,15 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
         files: [
           {
             mime: 'image/png',
-            url: 'data:image/png;base64,aGVsbG8=',
+            url: 'data:image/png;base64,aW1hZ2UtMQ==',
+          },
+          {
+            mime: 'image/png',
+            url: 'data:image/png;base64,aW1hZ2UtMg==',
+          },
+          {
+            mime: 'image/png',
+            url: 'data:image/png;base64,aW1hZ2UtMw==',
           },
         ],
         requiredInputModality: 'image',

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-constants.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-constants.ts
@@ -1,4 +1,5 @@
 export const FAST_AGENT_MODEL_ROLE = 'primary' as const;
+export const FAST_AGENT_MAX_IMAGE_ATTACHMENTS = 3;
 export const FAST_AGENT_BRAIN_INSTRUCTIONS = `Use Brain as lightweight conversational context, not as an exhaustive research assignment.
 
 - When Brain context would help, make the narrowest native integration call that is likely to answer the user's request.

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -9,7 +9,10 @@ import {
   type SlackThreadPromptMessage,
 } from '../../utils';
 import { getAvailableEnvironments, type RoutableEnvironment } from '../router';
-import { FAST_AGENT_MODEL_ROLE } from './fast-agent-constants';
+import {
+  FAST_AGENT_MAX_IMAGE_ATTACHMENTS,
+  FAST_AGENT_MODEL_ROLE,
+} from './fast-agent-constants';
 import { buildFastAgentSystemPrompt } from './fast-agent-prompt';
 import {
   appendFastAgentVisibleMessages,
@@ -134,11 +137,13 @@ function buildAssistantTextMessage(text: string): ModelMessage {
 }
 
 function getFastAgentImageFiles(images: string[]): NonTaskPromptFile[] {
-  return images.flatMap((image) => {
-    const url = image.trim();
-    const mime = /^data:(image\/[^;,]+);base64,/i.exec(url)?.[1];
-    return mime ? [{ mime, url }] : [];
-  });
+  return images
+    .flatMap((image) => {
+      const url = image.trim();
+      const mime = /^data:(image\/[^;,]+);base64,/i.exec(url)?.[1];
+      return mime ? [{ mime, url }] : [];
+    })
+    .slice(0, FAST_AGENT_MAX_IMAGE_ATTACHMENTS);
 }
 
 function extractModelMessageText(message: ModelMessage): string[] {
@@ -767,5 +772,5 @@ export async function answerFastAgentQuestion({
   }
 }
 
-export { FAST_AGENT_MODEL_ROLE };
+export { FAST_AGENT_MAX_IMAGE_ATTACHMENTS, FAST_AGENT_MODEL_ROLE };
 export type { RoutableEnvironment };


### PR DESCRIPTION
## What changed

- resolve the current Slack message's files from the event or thread history before deciding a Fast turn is empty
- treat an image-only Fast follow-up as a multimodal question instead of showing the `!fast` usage hint
- download at most three Slack images per Fast turn
- enforce the same three-image cap when building native OpenCode file parts

## Why

Slack can omit file metadata from the event while returning it through `conversations.replies`. Fast already recovers that thread metadata for text-plus-image turns, but it decided an empty-text turn was invalid before fetching the thread, so image-only follow-ups never reached the model.

Bounding the images before download and again before inference keeps large Slack posts from creating unbounded multimodal payloads.

This supersedes the remaining useful behavior from #1446; the underlying native-session screenshot support already shipped in #1474.

## Validation

- `@roomote/api`: 207 test files, 1,799 tests
- `@roomote/cloud-agents`: 99 test files, 775 tests
- `pnpm check-types`
- `pnpm lint`
- `pnpm knip`
- targeted ESLint for all five changed files

## Smoke test

Mock Slack `app-mention-fast` passed against pushed head `50a39ba7` using OpenCode 1.18.10:

- a normal Fast root established the conversation
- an image-only follow-up with four real PNG attachments produced a visual answer instead of the usage hint
- the three-file selection is asserted at the Slack download boundary and again at native OpenCode file construction