### PR TITLE
[Fix] Brain Slack day pages show timestamp ranges as titles

### DIFF
--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-slack-pages.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-slack-pages.test.ts
@@ -57,8 +57,16 @@ describe('groupSlackMessagesIntoDayPages', () => {
       `slack/T1/C1/2026-08-14/${day2Ts}-${day2Ts}`.replaceAll('.', '-'),
     ]);
     expect(pages[0]?.title).toBe('#general — 2026-08-13');
-    expect(pages[0]?.content).toMatch(/^---\ndate: 2026-08-13\n---\n\n/);
-    expect(pages[2]?.content).toMatch(/^---\ndate: 2026-08-14\n---\n\n/);
+    // The title must also lead the content as a markdown heading: put_page
+    // carries no title field, and gbrain derives a page's title from the
+    // first heading — without it the slug's timestamp range becomes the
+    // title on every surface.
+    expect(pages[0]?.content).toMatch(
+      /^---\ndate: 2026-08-13\n---\n\n# #general — 2026-08-13\n/,
+    );
+    expect(pages[2]?.content).toMatch(
+      /^---\ndate: 2026-08-14\n---\n\n# #general — 2026-08-14\n/,
+    );
     expect(pages[0]?.content).toContain(
       'Slack public channel #general (C1), messages on 2026-08-13',
     );

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/slack-public-channels.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/slack-public-channels.ts
@@ -769,10 +769,14 @@ async function backfillSlackHistoryStep(rawCursor: string | null): Promise<{
 
 /** Exported for the fake-Slack integration test, which drives it directly. */
 export const slackPublicChannelsCollector: BrainCollector = {
-  // v3: day pages gained a title heading. Versioned so existing pages are
-  // replayed and corrected (idempotent slug upserts) instead of keeping
-  // slug-derived timestamp titles forever.
-  id: 'slack-public-channels:entity-timeline-v3',
+  // Deliberately NOT version-bumped for the title-heading change: a page's
+  // slug embeds the first/last message timestamps of the batch that emitted
+  // it, and batch boundaries depend on when past incremental reads ran. A
+  // replay would group whole days at once, mint different slugs, and leave
+  // the old timestamp-titled pages standing next to duplicates of their
+  // content. Healing existing pages needs slug retirement (collector-item
+  // tracking plus a reconciliation sweep), not a replay.
+  id: 'slack-public-channels:entity-timeline-v2',
   displayName: 'Slack public channels',
   async isEnabled() {
     const installation = await db.query.slackInstallations.findFirst({

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/slack-public-channels.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/slack-public-channels.ts
@@ -196,6 +196,12 @@ export function groupSlackMessagesIntoDayPages(
             `date: ${group.day}`,
             '---',
             '',
+            // put_page has no title parameter: gbrain derives a page's title
+            // from the first markdown heading, and without one it falls back
+            // to the slug tail — a raw timestamp range on these pages. Every
+            // sibling collector leads with its title as a heading.
+            `# #${group.channelName} — ${group.day}`,
+            '',
             `Slack public channel #${group.channelName} (${group.channelId}), messages on ${group.day} (times UTC).`,
             '',
             ...lines,
@@ -763,7 +769,10 @@ async function backfillSlackHistoryStep(rawCursor: string | null): Promise<{
 
 /** Exported for the fake-Slack integration test, which drives it directly. */
 export const slackPublicChannelsCollector: BrainCollector = {
-  id: 'slack-public-channels:entity-timeline-v2',
+  // v3: day pages gained a title heading. Versioned so existing pages are
+  // replayed and corrected (idempotent slug upserts) instead of keeping
+  // slug-derived timestamp titles forever.
+  id: 'slack-public-channels:entity-timeline-v3',
   displayName: 'Slack public channels',
   async isEnabled() {
     const installation = await db.query.slackInstallations.findFirst({

--- a/packages/types/src/brain.test.ts
+++ b/packages/types/src/brain.test.ts
@@ -92,7 +92,7 @@ describe('resolveBrainSourceIdForCollector', () => {
   it('survives the version suffix collectors bump when page semantics change', () => {
     expect(
       resolveBrainSourceIdForCollector(
-        'slack-public-channels:entity-timeline-v2',
+        'slack-public-channels:entity-timeline-v3',
       ),
     ).toBe('slack-public-channels');
     expect(
@@ -103,7 +103,7 @@ describe('resolveBrainSourceIdForCollector', () => {
   it('folds a fanned-out collector’s per-partition rows into one source', () => {
     expect(
       resolveBrainSourceIdForCollector(
-        'slack-public-channels:entity-timeline-v2:T123/C456',
+        'slack-public-channels:entity-timeline-v3:T123/C456',
       ),
     ).toBe('slack-public-channels');
     expect(resolveBrainSourceIdForCollector('notion-pages:incremental')).toBe(

--- a/packages/types/src/brain.test.ts
+++ b/packages/types/src/brain.test.ts
@@ -92,7 +92,7 @@ describe('resolveBrainSourceIdForCollector', () => {
   it('survives the version suffix collectors bump when page semantics change', () => {
     expect(
       resolveBrainSourceIdForCollector(
-        'slack-public-channels:entity-timeline-v3',
+        'slack-public-channels:entity-timeline-v2',
       ),
     ).toBe('slack-public-channels');
     expect(
@@ -103,7 +103,7 @@ describe('resolveBrainSourceIdForCollector', () => {
   it('folds a fanned-out collector’s per-partition rows into one source', () => {
     expect(
       resolveBrainSourceIdForCollector(
-        'slack-public-channels:entity-timeline-v3:T123/C456',
+        'slack-public-channels:entity-timeline-v2:T123/C456',
       ),
     ).toBe('slack-public-channels');
     expect(resolveBrainSourceIdForCollector('notion-pages:incremental')).toBe(


### PR DESCRIPTION
## Problem

Slack day pages in the Brain render titles like `1787180739 921059 1787180739 921059` on the Settings page's Recently learned list, the browse dialog, and agent recall results. The collector computes a proper title (`#channel — day`) but gbrain's `put_page` has no title parameter: it derives titles from the first markdown heading in the content, and Slack day pages had none, so the slug's timestamp-range tail became the title. Every sibling collector (task memories, Granola meetings, person cards) leads its content with a `# title` heading, which is why those pages were titled correctly all along.

## Fix

The day page content now leads with `# #channel — day`, matching its computed title and the sibling collectors' convention. New pages are titled correctly from here on.

## Existing pages are deliberately not replayed

An earlier revision bumped the collector id to replay history, on the assumption that idempotent slug upserts would correct existing pages. Review caught that this is wrong: day-page slugs embed the first/last message timestamps of the emitting batch, and batch boundaries depend on when past incremental reads ran — a fresh backfill groups whole days at once, mints different slugs, and would leave the old timestamp-titled pages standing next to duplicates of their content. The bump is reverted and the collector id now documents why content-shape changes must not bump it.

Healing existing pages needs slug retirement: collector-item tracking of emitted slugs plus a reconciliation sweep (gbrain's `list_pages` has no slug-prefix filter to lean on). That is follow-up work; in practice fleet Brains are days old, so the population of stale-titled pages is small and stops growing with this change.

## Testing

Day-page tests assert the heading leads the content after the frontmatter for both fixture days. Full bullmq brain suite, types, lint, and knip green.