### PR TITLE
[Feat] In-app Brain key management and managed-Brain visibility

### DIFF
--- a/apps/web/src/components/settings/SettingsShell.tsx
+++ b/apps/web/src/components/settings/SettingsShell.tsx
@@ -28,13 +28,15 @@ export function SettingsShell({
   children,
 }: SettingsShellProps) {
   const router = useRouter();
-  const { isAdmin, cloudEnabled, brainConfigured } = useAuthorizedUser();
+  const { isAdmin, cloudEnabled, brainConfigured, brainNeedsKey } =
+    useAuthorizedUser();
 
   const navigationItem = getSettingsNavigationItem(pageId);
   const accessibleItems = getAccessibleSettingsNavigation({
     isAdmin,
     cloudEnabled,
     brainConfigured,
+    brainNeedsKey,
   });
   const activeItemId =
     (accessibleItems.some((item) => item.id === pageId)

--- a/apps/web/src/components/settings/SettingsShell.tsx
+++ b/apps/web/src/components/settings/SettingsShell.tsx
@@ -28,15 +28,13 @@ export function SettingsShell({
   children,
 }: SettingsShellProps) {
   const router = useRouter();
-  const { isAdmin, cloudEnabled, brainConfigured, brainNeedsKey } =
-    useAuthorizedUser();
+  const { isAdmin, cloudEnabled, brainConfigured } = useAuthorizedUser();
 
   const navigationItem = getSettingsNavigationItem(pageId);
   const accessibleItems = getAccessibleSettingsNavigation({
     isAdmin,
     cloudEnabled,
     brainConfigured,
-    brainNeedsKey,
   });
   const activeItemId =
     (accessibleItems.some((item) => item.id === pageId)

--- a/apps/web/src/components/settings/brain/BrainConfigurationSection.tsx
+++ b/apps/web/src/components/settings/brain/BrainConfigurationSection.tsx
@@ -1,10 +1,26 @@
 'use client';
 
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import Link from 'next/link';
+import { toast } from 'sonner';
 
 import { Section } from '@/components/settings';
-import { Badge, Lock, Settings2 } from '@/components/system';
+import {
+  Badge,
+  Button,
+  Input,
+  Loader2,
+  Lock,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Settings2,
+} from '@/components/system';
 import { SETTINGS_PATHS } from '@/lib/settings';
+import { useTRPC } from '@/trpc/client';
 
 import type { BrainSettings } from '@/trpc/commands/brain';
 import { BRAIN_INFERENCE_PROVIDER_LABELS } from './brain-presentation';
@@ -32,69 +48,162 @@ function ConfigRow({
 }
 
 /**
- * What the Brain runs on, read-only by design. The provider key lives with
- * the other model credentials in Settings, the synthesis model is an env
- * override applied at forward time, and the embedding model was fixed when
- * the Brain was created. A page that displayed editable controls for values
- * it cannot change would be lying about where the levers are.
+ * Sets the Brain's provider key from the page itself: the key lives in the
+ * persisted deployment environment store, which survives fleet reprovisions
+ * (a Railway-side variable would be reconciled away by the Cloud manager).
+ * This is the whole opt-in for a managed Brain, so the form is the main
+ * event in the needs-key state.
+ */
+function BrainProviderKeyForm({ onSaved }: { onSaved: () => void }) {
+  const trpc = useTRPC();
+  const [provider, setProvider] = useState<'openrouter' | 'openai'>(
+    'openrouter',
+  );
+  const [key, setKey] = useState('');
+
+  const save = useMutation(
+    trpc.brain.setProviderKey.mutationOptions({
+      onSuccess: () => {
+        toast.success('Brain provider key saved');
+        setKey('');
+        onSaved();
+      },
+      onError: (error) => toast.error(error.message),
+    }),
+  );
+
+  return (
+    <div className="flex w-full max-w-xl flex-wrap items-center gap-2">
+      <Select
+        value={provider}
+        onValueChange={(value) => setProvider(value as typeof provider)}
+      >
+        <SelectTrigger size="sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="openrouter">OpenRouter</SelectItem>
+          <SelectItem value="openai">OpenAI</SelectItem>
+        </SelectContent>
+      </Select>
+      <Input
+        secret={true}
+        aria-label="Brain provider key"
+        placeholder="Provider API key"
+        className="min-w-48 flex-1"
+        value={key}
+        onChange={(event) => setKey(event.target.value)}
+      />
+      <Button
+        size="sm"
+        disabled={key.trim().length < 16 || save.isPending}
+        onClick={() => save.mutate({ provider, key: key.trim() })}
+      >
+        {save.isPending ? <Loader2 className="animate-spin" /> : null}
+        Save key
+      </Button>
+    </div>
+  );
+}
+
+/**
+ * What the Brain runs on. The models are read-only by design (the synthesis
+ * model is an env override applied at forward time; the embedding model was
+ * fixed when the Brain was created), while the provider key — the Brain's
+ * actual opt-in — is editable right here.
  */
 export function BrainConfigurationSection({
   settings,
 }: {
   settings: BrainSettings;
 }) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const [replacingKey, setReplacingKey] = useState(false);
   const providerLabel = settings.inferenceProvider
     ? BRAIN_INFERENCE_PROVIDER_LABELS[settings.inferenceProvider]
     : null;
 
+  const onKeySaved = () => {
+    setReplacingKey(false);
+    void queryClient.invalidateQueries({
+      queryKey: trpc.brain.get.queryKey(),
+    });
+  };
+
   return (
     <Section icon={Settings2} title="Configuration">
       <div className="space-y-4">
-        <ConfigRow
-          label="Synthesis model"
-          helper="Answers synthesize queries across pages, on the deployment's inference key. Set R_BRAIN_MODEL to change it; changes apply immediately."
-        >
-          <code className="rounded bg-foreground/10 px-1.5 py-0.5 font-mono text-xs">
-            {settings.models?.synthesisModel ?? 'Not resolved'}
-          </code>
-          {settings.models?.synthesisSource === 'override' ? (
-            <Badge variant="secondary">Override</Badge>
-          ) : null}
-        </ConfigRow>
-
-        <ConfigRow
-          label="Embedding model"
-          helper="Fixed when this Brain was created. It sizes the vector store, and changing it requires a migration that re-embeds every page."
-        >
-          <Lock className="size-3.5 text-muted-foreground" />
-          <code className="rounded bg-foreground/10 px-1.5 py-0.5 font-mono text-xs">
-            {settings.models?.embeddingModel ?? 'Not resolved'}
-          </code>
-          {settings.models?.embeddingDimensions ? (
-            <span className="text-muted-foreground">
-              {settings.models.embeddingDimensions.toLocaleString()} dimensions
-            </span>
-          ) : null}
-        </ConfigRow>
-
-        <ConfigRow
-          label="Inference key"
-          helper="The Brain holds no provider credential. Every call routes through Roomote, so rotating the key applies on the next call with no restart."
-        >
-          <span>
-            {providerLabel
-              ? settings.keySource === 'brain'
-                ? `Brain-specific ${providerLabel} key`
-                : `The deployment's ${providerLabel} key`
-              : 'No provider key resolves'}
-          </span>
-          <Link
-            className="text-secondary-foreground underline-offset-4 hover:underline"
-            href={SETTINGS_PATHS.models}
+        {settings.needsKey ? (
+          <ConfigRow
+            label="Provider key"
+            helper="Stored encrypted with the deployment settings, so it survives fleet upgrades. Saving it turns the Brain on."
           >
-            Manage in Models
-          </Link>
-        </ConfigRow>
+            <BrainProviderKeyForm onSaved={onKeySaved} />
+          </ConfigRow>
+        ) : (
+          <>
+            <ConfigRow
+              label="Synthesis model"
+              helper="Answers synthesize queries across pages, on the deployment's inference key. Set R_BRAIN_MODEL to change it; changes apply immediately."
+            >
+              <code className="rounded bg-foreground/10 px-1.5 py-0.5 font-mono text-xs">
+                {settings.models?.synthesisModel ?? 'Not resolved'}
+              </code>
+              {settings.models?.synthesisSource === 'override' ? (
+                <Badge variant="secondary">Override</Badge>
+              ) : null}
+            </ConfigRow>
+
+            <ConfigRow
+              label="Embedding model"
+              helper="Fixed when this Brain was created. It sizes the vector store, and changing it requires a migration that re-embeds every page."
+            >
+              <Lock className="size-3.5 text-muted-foreground" />
+              <code className="rounded bg-foreground/10 px-1.5 py-0.5 font-mono text-xs">
+                {settings.models?.embeddingModel ?? 'Not resolved'}
+              </code>
+              {settings.models?.embeddingDimensions ? (
+                <span className="text-muted-foreground">
+                  {settings.models.embeddingDimensions.toLocaleString()}{' '}
+                  dimensions
+                </span>
+              ) : null}
+            </ConfigRow>
+
+            <ConfigRow
+              label="Inference key"
+              helper="The Brain holds no provider credential. Every call routes through Roomote, so rotating the key applies on the next call with no restart."
+            >
+              {replacingKey ? (
+                <BrainProviderKeyForm onSaved={onKeySaved} />
+              ) : (
+                <>
+                  <span>
+                    {providerLabel
+                      ? settings.keySource === 'brain'
+                        ? `Brain-specific ${providerLabel} key`
+                        : `The deployment's ${providerLabel} key`
+                      : 'No provider key resolves'}
+                  </span>
+                  <Link
+                    className="text-secondary-foreground underline-offset-4 hover:underline"
+                    href={SETTINGS_PATHS.models}
+                  >
+                    Manage in Models
+                  </Link>
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    onClick={() => setReplacingKey(true)}
+                  >
+                    Replace key
+                  </Button>
+                </>
+              )}
+            </ConfigRow>
+          </>
+        )}
       </div>
     </Section>
   );

--- a/apps/web/src/components/settings/brain/BrainConfigurationSection.tsx
+++ b/apps/web/src/components/settings/brain/BrainConfigurationSection.tsx
@@ -1,26 +1,10 @@
 'use client';
 
-import { useState } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import Link from 'next/link';
-import { toast } from 'sonner';
 
 import { Section } from '@/components/settings';
-import {
-  Badge,
-  Button,
-  Input,
-  Loader2,
-  Lock,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-  Settings2,
-} from '@/components/system';
+import { Badge, Lock, Settings2 } from '@/components/system';
 import { SETTINGS_PATHS } from '@/lib/settings';
-import { useTRPC } from '@/trpc/client';
 
 import type { BrainSettings } from '@/trpc/commands/brain';
 import { BRAIN_INFERENCE_PROVIDER_LABELS } from './brain-presentation';
@@ -48,162 +32,69 @@ function ConfigRow({
 }
 
 /**
- * Sets the Brain's provider key from the page itself: the key lives in the
- * persisted deployment environment store, which survives fleet reprovisions
- * (a Railway-side variable would be reconciled away by the Cloud manager).
- * This is the whole opt-in for a managed Brain, so the form is the main
- * event in the needs-key state.
- */
-function BrainProviderKeyForm({ onSaved }: { onSaved: () => void }) {
-  const trpc = useTRPC();
-  const [provider, setProvider] = useState<'openrouter' | 'openai'>(
-    'openrouter',
-  );
-  const [key, setKey] = useState('');
-
-  const save = useMutation(
-    trpc.brain.setProviderKey.mutationOptions({
-      onSuccess: () => {
-        toast.success('Brain provider key saved');
-        setKey('');
-        onSaved();
-      },
-      onError: (error) => toast.error(error.message),
-    }),
-  );
-
-  return (
-    <div className="flex w-full max-w-xl flex-wrap items-center gap-2">
-      <Select
-        value={provider}
-        onValueChange={(value) => setProvider(value as typeof provider)}
-      >
-        <SelectTrigger size="sm">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="openrouter">OpenRouter</SelectItem>
-          <SelectItem value="openai">OpenAI</SelectItem>
-        </SelectContent>
-      </Select>
-      <Input
-        secret={true}
-        aria-label="Brain provider key"
-        placeholder="Provider API key"
-        className="min-w-48 flex-1"
-        value={key}
-        onChange={(event) => setKey(event.target.value)}
-      />
-      <Button
-        size="sm"
-        disabled={key.trim().length < 16 || save.isPending}
-        onClick={() => save.mutate({ provider, key: key.trim() })}
-      >
-        {save.isPending ? <Loader2 className="animate-spin" /> : null}
-        Save key
-      </Button>
-    </div>
-  );
-}
-
-/**
- * What the Brain runs on. The models are read-only by design (the synthesis
- * model is an env override applied at forward time; the embedding model was
- * fixed when the Brain was created), while the provider key — the Brain's
- * actual opt-in — is editable right here.
+ * What the Brain runs on, read-only by design. The provider key lives with
+ * the other model credentials in Settings, the synthesis model is an env
+ * override applied at forward time, and the embedding model was fixed when
+ * the Brain was created. A page that displayed editable controls for values
+ * it cannot change would be lying about where the levers are.
  */
 export function BrainConfigurationSection({
   settings,
 }: {
   settings: BrainSettings;
 }) {
-  const trpc = useTRPC();
-  const queryClient = useQueryClient();
-  const [replacingKey, setReplacingKey] = useState(false);
   const providerLabel = settings.inferenceProvider
     ? BRAIN_INFERENCE_PROVIDER_LABELS[settings.inferenceProvider]
     : null;
 
-  const onKeySaved = () => {
-    setReplacingKey(false);
-    void queryClient.invalidateQueries({
-      queryKey: trpc.brain.get.queryKey(),
-    });
-  };
-
   return (
     <Section icon={Settings2} title="Configuration">
       <div className="space-y-4">
-        {settings.needsKey ? (
-          <ConfigRow
-            label="Provider key"
-            helper="Stored encrypted with the deployment settings, so it survives fleet upgrades. Saving it turns the Brain on."
+        <ConfigRow
+          label="Synthesis model"
+          helper="Answers synthesize queries across pages, on the deployment's inference key. Set R_BRAIN_MODEL to change it; changes apply immediately."
+        >
+          <code className="rounded bg-foreground/10 px-1.5 py-0.5 font-mono text-xs">
+            {settings.models?.synthesisModel ?? 'Not resolved'}
+          </code>
+          {settings.models?.synthesisSource === 'override' ? (
+            <Badge variant="secondary">Override</Badge>
+          ) : null}
+        </ConfigRow>
+
+        <ConfigRow
+          label="Embedding model"
+          helper="Fixed when this Brain was created. It sizes the vector store, and changing it requires a migration that re-embeds every page."
+        >
+          <Lock className="size-3.5 text-muted-foreground" />
+          <code className="rounded bg-foreground/10 px-1.5 py-0.5 font-mono text-xs">
+            {settings.models?.embeddingModel ?? 'Not resolved'}
+          </code>
+          {settings.models?.embeddingDimensions ? (
+            <span className="text-muted-foreground">
+              {settings.models.embeddingDimensions.toLocaleString()} dimensions
+            </span>
+          ) : null}
+        </ConfigRow>
+
+        <ConfigRow
+          label="Inference key"
+          helper="The Brain holds no provider credential. Every call routes through Roomote, so rotating the key applies on the next call with no restart."
+        >
+          <span>
+            {providerLabel
+              ? settings.keySource === 'brain'
+                ? `Brain-specific ${providerLabel} key`
+                : `The deployment's ${providerLabel} key`
+              : 'No provider key resolves'}
+          </span>
+          <Link
+            className="text-secondary-foreground underline-offset-4 hover:underline"
+            href={SETTINGS_PATHS.models}
           >
-            <BrainProviderKeyForm onSaved={onKeySaved} />
-          </ConfigRow>
-        ) : (
-          <>
-            <ConfigRow
-              label="Synthesis model"
-              helper="Answers synthesize queries across pages, on the deployment's inference key. Set R_BRAIN_MODEL to change it; changes apply immediately."
-            >
-              <code className="rounded bg-foreground/10 px-1.5 py-0.5 font-mono text-xs">
-                {settings.models?.synthesisModel ?? 'Not resolved'}
-              </code>
-              {settings.models?.synthesisSource === 'override' ? (
-                <Badge variant="secondary">Override</Badge>
-              ) : null}
-            </ConfigRow>
-
-            <ConfigRow
-              label="Embedding model"
-              helper="Fixed when this Brain was created. It sizes the vector store, and changing it requires a migration that re-embeds every page."
-            >
-              <Lock className="size-3.5 text-muted-foreground" />
-              <code className="rounded bg-foreground/10 px-1.5 py-0.5 font-mono text-xs">
-                {settings.models?.embeddingModel ?? 'Not resolved'}
-              </code>
-              {settings.models?.embeddingDimensions ? (
-                <span className="text-muted-foreground">
-                  {settings.models.embeddingDimensions.toLocaleString()}{' '}
-                  dimensions
-                </span>
-              ) : null}
-            </ConfigRow>
-
-            <ConfigRow
-              label="Inference key"
-              helper="The Brain holds no provider credential. Every call routes through Roomote, so rotating the key applies on the next call with no restart."
-            >
-              {replacingKey ? (
-                <BrainProviderKeyForm onSaved={onKeySaved} />
-              ) : (
-                <>
-                  <span>
-                    {providerLabel
-                      ? settings.keySource === 'brain'
-                        ? `Brain-specific ${providerLabel} key`
-                        : `The deployment's ${providerLabel} key`
-                      : 'No provider key resolves'}
-                  </span>
-                  <Link
-                    className="text-secondary-foreground underline-offset-4 hover:underline"
-                    href={SETTINGS_PATHS.models}
-                  >
-                    Manage in Models
-                  </Link>
-                  <Button
-                    variant="ghost"
-                    size="xs"
-                    onClick={() => setReplacingKey(true)}
-                  >
-                    Replace key
-                  </Button>
-                </>
-              )}
-            </ConfigRow>
-          </>
-        )}
+            Manage in Models
+          </Link>
+        </ConfigRow>
       </div>
     </Section>
   );

--- a/apps/web/src/components/settings/brain/BrainConfigurationSection.tsx
+++ b/apps/web/src/components/settings/brain/BrainConfigurationSection.tsx
@@ -63,8 +63,17 @@ function BrainProviderKeyForm({ onSaved }: { onSaved: () => void }) {
 
   const save = useMutation(
     trpc.brain.setProviderKey.mutationOptions({
-      onSuccess: () => {
-        toast.success('Brain provider key saved');
+      onSuccess: ({ activeProvider }, { provider: selected }) => {
+        if (activeProvider && activeProvider !== selected) {
+          // The deployment's general provider keys outrank the Brain key by
+          // design; say which provider actually serves rather than implying
+          // the selection won.
+          toast.info(
+            `Key saved. The Brain serves through ${BRAIN_INFERENCE_PROVIDER_LABELS[activeProvider]}: the deployment's ${BRAIN_INFERENCE_PROVIDER_LABELS[activeProvider]} key takes precedence.`,
+          );
+        } else {
+          toast.success('Brain provider key saved');
+        }
         setKey('');
         onSaved();
       },

--- a/apps/web/src/components/settings/brain/BrainCorpusSection.tsx
+++ b/apps/web/src/components/settings/brain/BrainCorpusSection.tsx
@@ -41,6 +41,22 @@ function ActivityChart({
     );
   }
 
+  // A freshly enabled Brain has all of its activity in the last day or two,
+  // which renders as one tower over 29 empty days and reads as a broken
+  // chart rather than a young corpus. Say what is actually happening.
+  const firstActiveIndex = days.findIndex((day) => day.pages > 0);
+
+  if (firstActiveIndex >= days.length - 2) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Ingestion started{' '}
+        {firstActiveIndex === days.length - 1 ? 'today' : 'yesterday'}.{' '}
+        {formatNumber(total)} pages written so far; the chart appears as history
+        accumulates.
+      </p>
+    );
+  }
+
   return (
     <div className="space-y-1">
       <div className="flex h-20 items-end gap-[3px] border-b border-foreground/10">

--- a/apps/web/src/components/settings/brain/BrainSettings.render.client.test.tsx
+++ b/apps/web/src/components/settings/brain/BrainSettings.render.client.test.tsx
@@ -47,6 +47,9 @@ vi.mock('@/trpc/client', () => ({
       getPage: {
         queryOptions: () => ({ queryKey: ['brain', 'getPage'] }),
       },
+      setProviderKey: {
+        mutationOptions: () => ({ mutationKind: 'setProviderKey' }),
+      },
       backfillTaskMemories: {
         mutationOptions: () => ({ mutationKind: 'backfill' }),
       },
@@ -68,6 +71,7 @@ function buildSettings(
     url: 'http://gbrain:8080',
     inferenceProvider: 'openrouter',
     keySource: 'brain',
+    needsKey: false,
     recall: { mode: 'semantic', embeddedCount: 771, chunkCount: 771 },
     models: {
       synthesisModel: 'openai/gpt-5.6-luna',
@@ -260,6 +264,28 @@ describe('BrainSettings', () => {
     // would have said semantic here (an OpenRouter provider resolves).
     expect(screen.getByText('Keyword only')).toBeInTheDocument();
     expect(screen.queryByText('Semantic + keyword')).not.toBeInTheDocument();
+  });
+
+  it('offers the provider-key form on a managed Brain awaiting its key', () => {
+    const settings = buildSettings();
+    state.query.data = {
+      ...settings,
+      status: 'incomplete',
+      statusDetail:
+        'A Brain is provisioned for this deployment. Add a provider key below to turn it on.',
+      needsKey: true,
+      inferenceProvider: null,
+      keySource: null,
+      models: null,
+    };
+
+    render(<BrainSettings />);
+
+    expect(screen.getByText('Needs attention')).toBeInTheDocument();
+    expect(screen.getByLabelText('Brain provider key')).toBeInTheDocument();
+    expect(screen.getByText('Save key')).toBeInTheDocument();
+    // The read-only model rows wait until the Brain actually runs.
+    expect(screen.queryByText('Synthesis model')).not.toBeInTheDocument();
   });
 
   it('shows the namespace badge only when it differs from the source label', () => {

--- a/apps/web/src/components/settings/brain/BrainSettings.render.client.test.tsx
+++ b/apps/web/src/components/settings/brain/BrainSettings.render.client.test.tsx
@@ -47,9 +47,6 @@ vi.mock('@/trpc/client', () => ({
       getPage: {
         queryOptions: () => ({ queryKey: ['brain', 'getPage'] }),
       },
-      setProviderKey: {
-        mutationOptions: () => ({ mutationKind: 'setProviderKey' }),
-      },
       backfillTaskMemories: {
         mutationOptions: () => ({ mutationKind: 'backfill' }),
       },
@@ -71,7 +68,6 @@ function buildSettings(
     url: 'http://gbrain:8080',
     inferenceProvider: 'openrouter',
     keySource: 'brain',
-    needsKey: false,
     recall: { mode: 'semantic', embeddedCount: 771, chunkCount: 771 },
     models: {
       synthesisModel: 'openai/gpt-5.6-luna',
@@ -264,28 +260,6 @@ describe('BrainSettings', () => {
     // would have said semantic here (an OpenRouter provider resolves).
     expect(screen.getByText('Keyword only')).toBeInTheDocument();
     expect(screen.queryByText('Semantic + keyword')).not.toBeInTheDocument();
-  });
-
-  it('offers the provider-key form on a managed Brain awaiting its key', () => {
-    const settings = buildSettings();
-    state.query.data = {
-      ...settings,
-      status: 'incomplete',
-      statusDetail:
-        'A Brain is provisioned for this deployment. Add a provider key below to turn it on.',
-      needsKey: true,
-      inferenceProvider: null,
-      keySource: null,
-      models: null,
-    };
-
-    render(<BrainSettings />);
-
-    expect(screen.getByText('Needs attention')).toBeInTheDocument();
-    expect(screen.getByLabelText('Brain provider key')).toBeInTheDocument();
-    expect(screen.getByText('Save key')).toBeInTheDocument();
-    // The read-only model rows wait until the Brain actually runs.
-    expect(screen.queryByText('Synthesis model')).not.toBeInTheDocument();
   });
 
   it('shows the namespace badge only when it differs from the source label', () => {

--- a/apps/web/src/components/settings/brain/BrainSettings.render.client.test.tsx
+++ b/apps/web/src/components/settings/brain/BrainSettings.render.client.test.tsx
@@ -47,6 +47,9 @@ vi.mock('@/trpc/client', () => ({
       getPage: {
         queryOptions: () => ({ queryKey: ['brain', 'getPage'] }),
       },
+      setProviderKey: {
+        mutationOptions: () => ({ mutationKind: 'setProviderKey' }),
+      },
       backfillTaskMemories: {
         mutationOptions: () => ({ mutationKind: 'backfill' }),
       },
@@ -68,6 +71,8 @@ function buildSettings(
     url: 'http://gbrain:8080',
     inferenceProvider: 'openrouter',
     keySource: 'brain',
+    needsKey: false,
+    recall: { mode: 'semantic', embeddedCount: 771, chunkCount: 771 },
     models: {
       synthesisModel: 'openai/gpt-5.6-luna',
       synthesisSource: 'default',
@@ -78,6 +83,7 @@ function buildSettings(
       reachable: true,
       sampledPages: 30,
       truncated: false,
+      totalPages: null,
       namespaces: [
         { id: 'slack', label: 'Slack', pages: 20 },
         { id: 'tasks', label: 'Task memories', pages: 10 },
@@ -228,6 +234,7 @@ describe('BrainSettings', () => {
         reachable: false,
         sampledPages: 0,
         truncated: false,
+        totalPages: null,
         namespaces: [],
         activityByDay: [],
         recentPages: [],
@@ -239,6 +246,57 @@ describe('BrainSettings', () => {
     expect(screen.getByText('Unreachable')).toBeInTheDocument();
     expect(screen.getByText('Corpus unavailable')).toBeInTheDocument();
     expect(screen.queryByText('Nothing collected yet')).not.toBeInTheDocument();
+  });
+
+  it('prefers the measured census: exact totals and measured recall', () => {
+    const settings = buildSettings();
+    state.query.data = {
+      ...settings,
+      recall: { mode: 'keyword-only', embeddedCount: 0, chunkCount: 771 },
+      corpus: { ...settings.corpus, totalPages: 625, truncated: true },
+    };
+
+    render(<BrainSettings />);
+
+    // The census total replaces the sampled "N+" reading on the tile.
+    expect(screen.getByText('625')).toBeInTheDocument();
+    // Measured keyword-only wins over the provider-presence inference, which
+    // would have said semantic here (an OpenRouter provider resolves).
+    expect(screen.getByText('Keyword only')).toBeInTheDocument();
+    expect(screen.queryByText('Semantic + keyword')).not.toBeInTheDocument();
+  });
+
+  it('offers the provider-key form on a managed Brain awaiting its key', () => {
+    const settings = buildSettings();
+    state.query.data = {
+      ...settings,
+      status: 'incomplete',
+      statusDetail:
+        'A Brain is provisioned for this deployment. Add a provider key below to turn it on.',
+      needsKey: true,
+      inferenceProvider: null,
+      keySource: null,
+      models: null,
+    };
+
+    render(<BrainSettings />);
+
+    expect(screen.getByText('Needs attention')).toBeInTheDocument();
+    expect(screen.getByLabelText('Brain provider key')).toBeInTheDocument();
+    expect(screen.getByText('Save key')).toBeInTheDocument();
+    // The read-only model rows wait until the Brain actually runs.
+    expect(screen.queryByText('Synthesis model')).not.toBeInTheDocument();
+  });
+
+  it('shows the namespace badge only when it differs from the source label', () => {
+    render(<BrainSettings />);
+
+    // "Slack public channels" carries its "Slack" namespace badge (the other
+    // "Slack" is the composition legend's namespace entry)...
+    expect(screen.getAllByText('Slack')).toHaveLength(2);
+    // ...while a source whose namespace repeats its own name gets no badge:
+    // exactly one "Notion" (the row title), not a second badge copy.
+    expect(screen.getAllByText('Notion')).toHaveLength(1);
   });
 
   it('stops at the explanation on a deployment with no Brain', () => {

--- a/apps/web/src/components/settings/brain/BrainSettings.tsx
+++ b/apps/web/src/components/settings/brain/BrainSettings.tsx
@@ -33,16 +33,20 @@ function SummaryTiles({ settings }: { settings: BrainSettingsData }) {
       <AnalyticsSummaryCard
         label="Pages stored"
         value={
-          settings.corpus.reachable
-            ? `${formatNumber(settings.corpus.sampledPages)}${
-                settings.corpus.truncated ? '+' : ''
-              }`
-            : 'Unknown'
+          settings.corpus.totalPages !== null
+            ? formatNumber(settings.corpus.totalPages)
+            : settings.corpus.reachable
+              ? `${formatNumber(settings.corpus.sampledPages)}${
+                  settings.corpus.truncated ? '+' : ''
+                }`
+              : 'Unknown'
         }
         secondary={
-          settings.corpus.truncated
-            ? 'most recent pages, more in the corpus'
-            : 'in the corpus'
+          settings.corpus.totalPages !== null
+            ? 'in the corpus'
+            : settings.corpus.truncated
+              ? 'most recent pages, more in the corpus'
+              : 'in the corpus'
         }
       />
       <AnalyticsSummaryCard

--- a/apps/web/src/components/settings/brain/BrainSourcesSection.tsx
+++ b/apps/web/src/components/settings/brain/BrainSourcesSection.tsx
@@ -18,7 +18,9 @@ function SourceRow({ source }: { source: BrainSourceSummary }) {
     <li className="space-y-2 py-3 first:pt-0 last:pb-0">
       <div className="flex items-center gap-2">
         <span className="font-medium">{source.label}</span>
-        <Badge variant="outline">{source.namespaceLabel}</Badge>
+        {source.namespaceLabel !== source.label ? (
+          <Badge variant="outline">{source.namespaceLabel}</Badge>
+        ) : null}
         <Badge variant={status.variant} className="ml-auto">
           {status.label}
         </Badge>

--- a/apps/web/src/components/settings/brain/BrainStatusSection.tsx
+++ b/apps/web/src/components/settings/brain/BrainStatusSection.tsx
@@ -48,7 +48,14 @@ export function BrainStatusSection({ settings }: { settings: BrainSettings }) {
           <Fact
             label="Recall"
             value={
-              settings.inferenceProvider ? 'Semantic + keyword' : 'Keyword only'
+              settings.recall.mode === 'semantic'
+                ? 'Semantic + keyword'
+                : settings.recall.mode === 'keyword-only'
+                  ? 'Keyword only'
+                  : // The admin census did not answer; fall back to inference.
+                    settings.inferenceProvider
+                    ? 'Semantic + keyword'
+                    : 'Keyword only'
             }
           />
           <Fact

--- a/apps/web/src/components/settings/settings-navigation.ts
+++ b/apps/web/src/components/settings/settings-navigation.ts
@@ -198,8 +198,6 @@ export function getAccessibleSettingsNavigation(opts: {
   isAdmin: boolean;
   cloudEnabled: boolean;
   brainConfigured?: boolean;
-  /** A managed Brain awaits its key: the page shows so an admin can add it. */
-  brainNeedsKey?: boolean;
 }) {
   return SETTINGS_NAVIGATION_ITEMS.filter((item) => {
     if (item.adminOnly && !opts.isAdmin) {
@@ -208,7 +206,7 @@ export function getAccessibleSettingsNavigation(opts: {
     if (item.hiddenWhenCloud && opts.cloudEnabled) {
       return false;
     }
-    if (item.requiresBrain && !opts.brainConfigured && !opts.brainNeedsKey) {
+    if (item.requiresBrain && !opts.brainConfigured) {
       return false;
     }
     return true;

--- a/apps/web/src/components/settings/settings-navigation.ts
+++ b/apps/web/src/components/settings/settings-navigation.ts
@@ -198,6 +198,8 @@ export function getAccessibleSettingsNavigation(opts: {
   isAdmin: boolean;
   cloudEnabled: boolean;
   brainConfigured?: boolean;
+  /** A managed Brain awaits its key: the page shows so an admin can add it. */
+  brainNeedsKey?: boolean;
 }) {
   return SETTINGS_NAVIGATION_ITEMS.filter((item) => {
     if (item.adminOnly && !opts.isAdmin) {
@@ -206,7 +208,7 @@ export function getAccessibleSettingsNavigation(opts: {
     if (item.hiddenWhenCloud && opts.cloudEnabled) {
       return false;
     }
-    if (item.requiresBrain && !opts.brainConfigured) {
+    if (item.requiresBrain && !opts.brainConfigured && !opts.brainNeedsKey) {
       return false;
     }
     return true;

--- a/apps/web/src/lib/server/auth-context.test.ts
+++ b/apps/web/src/lib/server/auth-context.test.ts
@@ -41,7 +41,7 @@ vi.mock('next/headers', () => ({
 
 vi.mock('@roomote/db/server', () => ({
   recordLicenseUsageObservation: vi.fn(async () => undefined),
-  isBrainProviderConfigured: vi.fn(async () => false),
+  resolveBrainAvailability: vi.fn(async () => 'unconfigured'),
   db: {
     query: {
       deploymentSettings: {

--- a/apps/web/src/lib/server/auth-context.test.ts
+++ b/apps/web/src/lib/server/auth-context.test.ts
@@ -41,7 +41,7 @@ vi.mock('next/headers', () => ({
 
 vi.mock('@roomote/db/server', () => ({
   recordLicenseUsageObservation: vi.fn(async () => undefined),
-  resolveBrainAvailability: vi.fn(async () => 'unconfigured'),
+  isBrainProviderConfigured: vi.fn(async () => false),
   db: {
     query: {
       deploymentSettings: {

--- a/apps/web/src/lib/server/auth-context.ts
+++ b/apps/web/src/lib/server/auth-context.ts
@@ -6,7 +6,7 @@ import {
   deploymentSettings,
   eq,
   invites,
-  resolveBrainAvailability,
+  isBrainProviderConfigured,
   recordLicenseUsageObservation,
   users,
 } from '@roomote/db/server';
@@ -443,13 +443,7 @@ export async function authorize(): Promise<UserAuthSuccess | AuthError> {
     featureFlags,
     anonymousAnalyticsEnabled,
     cloudEnabled: isRoomoteCloudEnabled(Env.R_CLOUD_ENABLED),
-    ...(await (async () => {
-      const brainAvailability = await resolveBrainAvailability();
-      return {
-        brainConfigured: brainAvailability === 'configured',
-        brainNeedsKey: brainAvailability === 'managed_needs_key',
-      };
-    })()),
+    brainConfigured: await isBrainProviderConfigured(),
     cookieConsentedAt: authContext.cookieConsentedAt,
     managedAccess: getManagedDeploymentAccessFromMetadata(
       authContext.deploymentMetadata,

--- a/apps/web/src/lib/server/auth-context.ts
+++ b/apps/web/src/lib/server/auth-context.ts
@@ -6,7 +6,7 @@ import {
   deploymentSettings,
   eq,
   invites,
-  isBrainProviderConfigured,
+  resolveBrainAvailability,
   recordLicenseUsageObservation,
   users,
 } from '@roomote/db/server';
@@ -443,7 +443,13 @@ export async function authorize(): Promise<UserAuthSuccess | AuthError> {
     featureFlags,
     anonymousAnalyticsEnabled,
     cloudEnabled: isRoomoteCloudEnabled(Env.R_CLOUD_ENABLED),
-    brainConfigured: await isBrainProviderConfigured(),
+    ...(await (async () => {
+      const brainAvailability = await resolveBrainAvailability();
+      return {
+        brainConfigured: brainAvailability === 'configured',
+        brainNeedsKey: brainAvailability === 'managed_needs_key',
+      };
+    })()),
     cookieConsentedAt: authContext.cookieConsentedAt,
     managedAccess: getManagedDeploymentAccessFromMetadata(
       authContext.deploymentMetadata,

--- a/apps/web/src/trpc/commands/brain/index.ts
+++ b/apps/web/src/trpc/commands/brain/index.ts
@@ -41,7 +41,10 @@ import {
 import type { UserAuthSuccess } from '@/types';
 import { Env } from '@/lib/server/env';
 
-import { upsertDeploymentEnvironmentVariables } from '../environment-variables';
+import {
+  deleteDeploymentEnvironmentVariables,
+  upsertDeploymentEnvironmentVariables,
+} from '../environment-variables';
 import { assertAdmin } from '../setup/shared';
 
 /**
@@ -715,21 +718,39 @@ export async function getBrainPageCommand(
 export async function setBrainProviderKeyCommand(
   auth: UserAuthSuccess,
   input: { provider: 'openrouter' | 'openai'; key: string },
-): Promise<{ success: true }> {
+): Promise<{ success: true; activeProvider: 'openrouter' | 'openai' | null }> {
   assertAdmin(auth);
 
   const name =
     input.provider === 'openrouter'
       ? 'R_BRAIN_OPENROUTER_API_KEY'
       : 'R_BRAIN_OPENAI_API_KEY';
+  const alternate =
+    input.provider === 'openrouter'
+      ? 'R_BRAIN_OPENAI_API_KEY'
+      : 'R_BRAIN_OPENROUTER_API_KEY';
 
-  await upsertDeploymentEnvironmentVariables(db, {
-    userId: auth.userId,
-    values: [{ name, value: input.key.trim() }],
+  // The selection is authoritative between the two Brain keys: the resolver
+  // prefers OpenRouter, so a stale alternate key would silently keep serving
+  // over the one the admin just chose. Clearing it rides the same
+  // transaction as the write.
+  await db.transaction(async (tx) => {
+    await upsertDeploymentEnvironmentVariables(tx, {
+      userId: auth.userId,
+      values: [{ name, value: input.key.trim() }],
+    });
+    await deleteDeploymentEnvironmentVariables(tx, [alternate]);
   });
 
   resetBrainProviderConfiguredCache();
   resetBrainInferenceProviderCache();
 
-  return { success: true };
+  // The deployment's GENERAL provider keys still outrank the other Brain
+  // key by design (a deployment with only a general OpenRouter key gets a
+  // working Brain for free). Report which provider actually serves so the
+  // UI can say when it differs from the selection instead of implying the
+  // choice won.
+  const active = await resolveBrainInferenceProvider();
+
+  return { success: true, activeProvider: active?.providerId ?? null };
 }

--- a/apps/web/src/trpc/commands/brain/index.ts
+++ b/apps/web/src/trpc/commands/brain/index.ts
@@ -6,8 +6,9 @@ import {
   deploymentMcpEnablements,
   eq,
   getBrainMemoryEventSummary,
-  isBrainProviderConfigured,
   isNull,
+  resetBrainProviderConfiguredCache,
+  resolveBrainAvailability,
   resolveModelProviderEnvValue,
   listBrainSyncStates,
   mcpConnections,
@@ -20,6 +21,7 @@ import {
   readBrainCorpusSample,
   readBrainPage,
   readBrainStats,
+  resetBrainInferenceProviderCache,
   resolveBrainInferenceProvider,
   type BrainModelSummary,
 } from '@roomote/sdk/server';
@@ -39,6 +41,7 @@ import {
 import type { UserAuthSuccess } from '@/types';
 import { Env } from '@/lib/server/env';
 
+import { upsertDeploymentEnvironmentVariables } from '../environment-variables';
 import { assertAdmin } from '../setup/shared';
 
 /**
@@ -143,6 +146,11 @@ export type BrainSettings = {
   keySource: 'brain' | 'deployment' | null;
   /** The models the Brain runs, or null when no provider resolves. */
   models: BrainModelSummary | null;
+  /**
+   * A managed Brain is provisioned but awaits its provider key; the page
+   * renders the key form prominently in this state.
+   */
+  needsKey: boolean;
   /**
    * Recall health. `semantic`/`keyword-only` are measured from gbrain's own
    * embedding counts; `unknown` means the admin census did not answer and
@@ -430,7 +438,10 @@ export async function getBrainSettingsCommand(
   // Activation is the explicit brain-specific provider key, in Settings or
   // the environment. The gateway token and R_GBRAIN_URL exist as plumbing on
   // deployments that never opted in, so neither can mean "the Brain is on".
-  const configured = await isBrainProviderConfigured();
+  // A fleet-provisioned Brain awaiting its key is a distinct, visible state.
+  const availability = await resolveBrainAvailability();
+  const configured = availability === 'configured';
+  const present = availability !== 'unconfigured';
   const url = Env.R_GBRAIN_URL ?? null;
 
   // The rollups only describe a Brain that exists; on an unconfigured
@@ -447,10 +458,10 @@ export async function getBrainSettingsCommand(
   ] = await Promise.all([
     resolveBrainInferenceProvider(),
     configured ? readBrainCorpusSample() : null,
-    configured ? readBrainStats() : null,
-    configured ? listBrainSyncStates(db) : [],
-    configured ? countBrainCollectorItemsByCollector(db) : [],
-    configured ? getBrainMemoryEventSummary(db) : EMPTY_MEMORY_SUMMARY,
+    present ? readBrainStats() : null,
+    present ? listBrainSyncStates(db) : [],
+    present ? countBrainCollectorItemsByCollector(db) : [],
+    present ? getBrainMemoryEventSummary(db) : EMPTY_MEMORY_SUMMARY,
     resolveSourceRequirements(),
   ]);
 
@@ -496,11 +507,19 @@ export async function getBrainSettingsCommand(
     status: BrainStatus;
     statusDetail: string | null;
   } => {
-    if (!configured) {
+    if (availability === 'unconfigured') {
       return {
         status: 'not_configured',
         statusDetail:
           'This deployment has no Brain. Set a Brain provider key to give agents shared memory.',
+      };
+    }
+
+    if (availability === 'managed_needs_key') {
+      return {
+        status: 'incomplete',
+        statusDetail:
+          'A Brain is provisioned for this deployment. Add a provider key below to turn it on.',
       };
     }
 
@@ -546,6 +565,7 @@ export async function getBrainSettingsCommand(
     inferenceProvider: inference?.providerId ?? null,
     keySource,
     models: inference ? describeBrainModels(inference.providerId) : null,
+    needsKey: availability === 'managed_needs_key',
     recall,
     corpus,
     sources: summarizeSources({
@@ -683,4 +703,33 @@ export async function getBrainPageCommand(
       : page.content,
     contentTruncated,
   };
+}
+
+/**
+ * Store the Brain's provider key in the persisted deployment environment
+ * store — the one place that survives fleet reprovisions, unlike a
+ * Railway-side variable the Cloud manager reconciles. Setting it IS the
+ * Brain opt-in: both activation caches are dropped so the nav entry, MCP
+ * delivery, and ingestion react on the next request instead of a TTL later.
+ */
+export async function setBrainProviderKeyCommand(
+  auth: UserAuthSuccess,
+  input: { provider: 'openrouter' | 'openai'; key: string },
+): Promise<{ success: true }> {
+  assertAdmin(auth);
+
+  const name =
+    input.provider === 'openrouter'
+      ? 'R_BRAIN_OPENROUTER_API_KEY'
+      : 'R_BRAIN_OPENAI_API_KEY';
+
+  await upsertDeploymentEnvironmentVariables(db, {
+    userId: auth.userId,
+    values: [{ name, value: input.key.trim() }],
+  });
+
+  resetBrainProviderConfiguredCache();
+  resetBrainInferenceProviderCache();
+
+  return { success: true };
 }

--- a/apps/web/src/trpc/commands/brain/index.ts
+++ b/apps/web/src/trpc/commands/brain/index.ts
@@ -6,9 +6,8 @@ import {
   deploymentMcpEnablements,
   eq,
   getBrainMemoryEventSummary,
+  isBrainProviderConfigured,
   isNull,
-  resetBrainProviderConfiguredCache,
-  resolveBrainAvailability,
   resolveModelProviderEnvValue,
   listBrainSyncStates,
   mcpConnections,
@@ -21,7 +20,6 @@ import {
   readBrainCorpusSample,
   readBrainPage,
   readBrainStats,
-  resetBrainInferenceProviderCache,
   resolveBrainInferenceProvider,
   type BrainModelSummary,
 } from '@roomote/sdk/server';
@@ -41,7 +39,6 @@ import {
 import type { UserAuthSuccess } from '@/types';
 import { Env } from '@/lib/server/env';
 
-import { upsertDeploymentEnvironmentVariables } from '../environment-variables';
 import { assertAdmin } from '../setup/shared';
 
 /**
@@ -146,11 +143,6 @@ export type BrainSettings = {
   keySource: 'brain' | 'deployment' | null;
   /** The models the Brain runs, or null when no provider resolves. */
   models: BrainModelSummary | null;
-  /**
-   * A managed Brain is provisioned but awaits its provider key; the page
-   * renders the key form prominently in this state.
-   */
-  needsKey: boolean;
   /**
    * Recall health. `semantic`/`keyword-only` are measured from gbrain's own
    * embedding counts; `unknown` means the admin census did not answer and
@@ -438,10 +430,7 @@ export async function getBrainSettingsCommand(
   // Activation is the explicit brain-specific provider key, in Settings or
   // the environment. The gateway token and R_GBRAIN_URL exist as plumbing on
   // deployments that never opted in, so neither can mean "the Brain is on".
-  // A fleet-provisioned Brain awaiting its key is a distinct, visible state.
-  const availability = await resolveBrainAvailability();
-  const configured = availability === 'configured';
-  const present = availability !== 'unconfigured';
+  const configured = await isBrainProviderConfigured();
   const url = Env.R_GBRAIN_URL ?? null;
 
   // The rollups only describe a Brain that exists; on an unconfigured
@@ -458,10 +447,10 @@ export async function getBrainSettingsCommand(
   ] = await Promise.all([
     resolveBrainInferenceProvider(),
     configured ? readBrainCorpusSample() : null,
-    present ? readBrainStats() : null,
-    present ? listBrainSyncStates(db) : [],
-    present ? countBrainCollectorItemsByCollector(db) : [],
-    present ? getBrainMemoryEventSummary(db) : EMPTY_MEMORY_SUMMARY,
+    configured ? readBrainStats() : null,
+    configured ? listBrainSyncStates(db) : [],
+    configured ? countBrainCollectorItemsByCollector(db) : [],
+    configured ? getBrainMemoryEventSummary(db) : EMPTY_MEMORY_SUMMARY,
     resolveSourceRequirements(),
   ]);
 
@@ -507,19 +496,11 @@ export async function getBrainSettingsCommand(
     status: BrainStatus;
     statusDetail: string | null;
   } => {
-    if (availability === 'unconfigured') {
+    if (!configured) {
       return {
         status: 'not_configured',
         statusDetail:
           'This deployment has no Brain. Set a Brain provider key to give agents shared memory.',
-      };
-    }
-
-    if (availability === 'managed_needs_key') {
-      return {
-        status: 'incomplete',
-        statusDetail:
-          'A Brain is provisioned for this deployment. Add a provider key below to turn it on.',
       };
     }
 
@@ -565,7 +546,6 @@ export async function getBrainSettingsCommand(
     inferenceProvider: inference?.providerId ?? null,
     keySource,
     models: inference ? describeBrainModels(inference.providerId) : null,
-    needsKey: availability === 'managed_needs_key',
     recall,
     corpus,
     sources: summarizeSources({
@@ -703,33 +683,4 @@ export async function getBrainPageCommand(
       : page.content,
     contentTruncated,
   };
-}
-
-/**
- * Store the Brain's provider key in the persisted deployment environment
- * store — the one place that survives fleet reprovisions, unlike a
- * Railway-side variable the Cloud manager reconciles. Setting it IS the
- * Brain opt-in: both activation caches are dropped so the nav entry, MCP
- * delivery, and ingestion react on the next request instead of a TTL later.
- */
-export async function setBrainProviderKeyCommand(
-  auth: UserAuthSuccess,
-  input: { provider: 'openrouter' | 'openai'; key: string },
-): Promise<{ success: true }> {
-  assertAdmin(auth);
-
-  const name =
-    input.provider === 'openrouter'
-      ? 'R_BRAIN_OPENROUTER_API_KEY'
-      : 'R_BRAIN_OPENAI_API_KEY';
-
-  await upsertDeploymentEnvironmentVariables(db, {
-    userId: auth.userId,
-    values: [{ name, value: input.key.trim() }],
-  });
-
-  resetBrainProviderConfiguredCache();
-  resetBrainInferenceProviderCache();
-
-  return { success: true };
 }

--- a/apps/web/src/trpc/commands/brain/index.ts
+++ b/apps/web/src/trpc/commands/brain/index.ts
@@ -6,8 +6,9 @@ import {
   deploymentMcpEnablements,
   eq,
   getBrainMemoryEventSummary,
-  isBrainProviderConfigured,
   isNull,
+  resetBrainProviderConfiguredCache,
+  resolveBrainAvailability,
   resolveModelProviderEnvValue,
   listBrainSyncStates,
   mcpConnections,
@@ -19,6 +20,8 @@ import {
   hasBrainGithubSources,
   readBrainCorpusSample,
   readBrainPage,
+  readBrainStats,
+  resetBrainInferenceProviderCache,
   resolveBrainInferenceProvider,
   type BrainModelSummary,
 } from '@roomote/sdk/server';
@@ -38,6 +41,7 @@ import {
 import type { UserAuthSuccess } from '@/types';
 import { Env } from '@/lib/server/env';
 
+import { upsertDeploymentEnvironmentVariables } from '../environment-variables';
 import { assertAdmin } from '../setup/shared';
 
 /**
@@ -105,6 +109,12 @@ export type BrainCorpusSummary = {
   /** Pages in the sample, which is the whole corpus unless `truncated`. */
   sampledPages: number;
   truncated: boolean;
+  /**
+   * The corpus's exact page count from gbrain's admin census, or null when
+   * the admin API did not answer. The sample above stays authoritative for
+   * composition; this keeps the total honest past the sample bound.
+   */
+  totalPages: number | null;
   namespaces: BrainNamespaceSummary[];
   /**
    * Pages written per UTC day over the trailing window, oldest first,
@@ -136,6 +146,21 @@ export type BrainSettings = {
   keySource: 'brain' | 'deployment' | null;
   /** The models the Brain runs, or null when no provider resolves. */
   models: BrainModelSummary | null;
+  /**
+   * A managed Brain is provisioned but awaits its provider key; the page
+   * renders the key form prominently in this state.
+   */
+  needsKey: boolean;
+  /**
+   * Recall health. `semantic`/`keyword-only` are measured from gbrain's own
+   * embedding counts; `unknown` means the admin census did not answer and
+   * the UI falls back to inferring from provider presence.
+   */
+  recall: {
+    mode: 'semantic' | 'keyword-only' | 'unknown';
+    embeddedCount: number | null;
+    chunkCount: number | null;
+  };
   corpus: BrainCorpusSummary;
   sources: BrainSourceSummary[];
   taskMemories: {
@@ -252,6 +277,7 @@ function summarizeCorpus(
       reachable: false,
       sampledPages: 0,
       truncated: false,
+      totalPages: null,
       namespaces: [],
       activityByDay: [],
       recentPages: [],
@@ -293,6 +319,7 @@ function summarizeCorpus(
     reachable: true,
     sampledPages: snapshot.pages.length,
     truncated: snapshot.truncated,
+    totalPages: null,
     namespaces,
     activityByDay: buildActivityByDay(snapshot.pages),
     recentPages,
@@ -411,7 +438,10 @@ export async function getBrainSettingsCommand(
   // Activation is the explicit brain-specific provider key, in Settings or
   // the environment. The gateway token and R_GBRAIN_URL exist as plumbing on
   // deployments that never opted in, so neither can mean "the Brain is on".
-  const configured = await isBrainProviderConfigured();
+  // A fleet-provisioned Brain awaiting its key is a distinct, visible state.
+  const availability = await resolveBrainAvailability();
+  const configured = availability === 'configured';
+  const present = availability !== 'unconfigured';
   const url = Env.R_GBRAIN_URL ?? null;
 
   // The rollups only describe a Brain that exists; on an unconfigured
@@ -420,6 +450,7 @@ export async function getBrainSettingsCommand(
   const [
     inference,
     corpusSnapshot,
+    stats,
     syncStates,
     itemCounts,
     memories,
@@ -427,13 +458,28 @@ export async function getBrainSettingsCommand(
   ] = await Promise.all([
     resolveBrainInferenceProvider(),
     configured ? readBrainCorpusSample() : null,
-    configured ? listBrainSyncStates(db) : [],
-    configured ? countBrainCollectorItemsByCollector(db) : [],
-    configured ? getBrainMemoryEventSummary(db) : EMPTY_MEMORY_SUMMARY,
+    present ? readBrainStats() : null,
+    present ? listBrainSyncStates(db) : [],
+    present ? countBrainCollectorItemsByCollector(db) : [],
+    present ? getBrainMemoryEventSummary(db) : EMPTY_MEMORY_SUMMARY,
     resolveSourceRequirements(),
   ]);
 
   const corpus = summarizeCorpus(corpusSnapshot);
+
+  corpus.totalPages = stats?.pageCount ?? null;
+
+  // Measured, not inferred: gbrain's own census says whether chunks are
+  // actually embedded. Chunks with zero embeddings is the keyword-only
+  // silent failure this page exists to catch.
+  const recall: BrainSettings['recall'] =
+    stats && (stats.chunkCount ?? 0) > 0
+      ? {
+          mode: (stats.embeddedCount ?? 0) > 0 ? 'semantic' : 'keyword-only',
+          embeddedCount: stats.embeddedCount,
+          chunkCount: stats.chunkCount,
+        }
+      : { mode: 'unknown', embeddedCount: null, chunkCount: null };
 
   // Read only after (and only when) the corpus failed to answer: it decides
   // between "credentials not provisioned yet" and "service down", and the
@@ -461,11 +507,19 @@ export async function getBrainSettingsCommand(
     status: BrainStatus;
     statusDetail: string | null;
   } => {
-    if (!configured) {
+    if (availability === 'unconfigured') {
       return {
         status: 'not_configured',
         statusDetail:
           'This deployment has no Brain. Set a Brain provider key to give agents shared memory.',
+      };
+    }
+
+    if (availability === 'managed_needs_key') {
+      return {
+        status: 'incomplete',
+        statusDetail:
+          'A Brain is provisioned for this deployment. Add a provider key below to turn it on.',
       };
     }
 
@@ -511,6 +565,8 @@ export async function getBrainSettingsCommand(
     inferenceProvider: inference?.providerId ?? null,
     keySource,
     models: inference ? describeBrainModels(inference.providerId) : null,
+    needsKey: availability === 'managed_needs_key',
+    recall,
     corpus,
     sources: summarizeSources({
       syncStates,
@@ -647,4 +703,33 @@ export async function getBrainPageCommand(
       : page.content,
     contentTruncated,
   };
+}
+
+/**
+ * Store the Brain's provider key in the persisted deployment environment
+ * store — the one place that survives fleet reprovisions, unlike a
+ * Railway-side variable the Cloud manager reconciles. Setting it IS the
+ * Brain opt-in: both activation caches are dropped so the nav entry, MCP
+ * delivery, and ingestion react on the next request instead of a TTL later.
+ */
+export async function setBrainProviderKeyCommand(
+  auth: UserAuthSuccess,
+  input: { provider: 'openrouter' | 'openai'; key: string },
+): Promise<{ success: true }> {
+  assertAdmin(auth);
+
+  const name =
+    input.provider === 'openrouter'
+      ? 'R_BRAIN_OPENROUTER_API_KEY'
+      : 'R_BRAIN_OPENAI_API_KEY';
+
+  await upsertDeploymentEnvironmentVariables(db, {
+    userId: auth.userId,
+    values: [{ name, value: input.key.trim() }],
+  });
+
+  resetBrainProviderConfiguredCache();
+  resetBrainInferenceProviderCache();
+
+  return { success: true };
 }

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -437,6 +437,7 @@ import {
   getBrainSettingsCommand,
   listBrainPagesCommand,
   retryFailedBrainTaskMemoriesCommand,
+  setBrainProviderKeyCommand,
 } from '../commands/brain';
 import {
   getReleaseNotesCommand,
@@ -2972,6 +2973,17 @@ export const appRouter = createRouter({
     getPage: protectedProcedure
       .input(z.object({ slug: z.string().min(1).max(512) }))
       .query(({ ctx: { auth }, input }) => getBrainPageCommand(auth, input)),
+
+    setProviderKey: protectedProcedure
+      .input(
+        z.object({
+          provider: z.enum(['openrouter', 'openai']),
+          key: z.string().trim().min(16).max(512),
+        }),
+      )
+      .mutation(({ ctx: { auth }, input }) =>
+        setBrainProviderKeyCommand(auth, input),
+      ),
 
     backfillTaskMemories: protectedProcedure.mutation(({ ctx: { auth } }) =>
       backfillBrainTaskMemoriesCommand(auth),

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -437,7 +437,6 @@ import {
   getBrainSettingsCommand,
   listBrainPagesCommand,
   retryFailedBrainTaskMemoriesCommand,
-  setBrainProviderKeyCommand,
 } from '../commands/brain';
 import {
   getReleaseNotesCommand,
@@ -2973,17 +2972,6 @@ export const appRouter = createRouter({
     getPage: protectedProcedure
       .input(z.object({ slug: z.string().min(1).max(512) }))
       .query(({ ctx: { auth }, input }) => getBrainPageCommand(auth, input)),
-
-    setProviderKey: protectedProcedure
-      .input(
-        z.object({
-          provider: z.enum(['openrouter', 'openai']),
-          key: z.string().trim().min(16).max(512),
-        }),
-      )
-      .mutation(({ ctx: { auth }, input }) =>
-        setBrainProviderKeyCommand(auth, input),
-      ),
 
     backfillTaskMemories: protectedProcedure.mutation(({ ctx: { auth } }) =>
       backfillBrainTaskMemoriesCommand(auth),

--- a/apps/web/src/types/auth.ts
+++ b/apps/web/src/types/auth.ts
@@ -37,13 +37,6 @@ export type AuthorizedUser = {
    * `managedAccess`, so test fixtures and older payloads read as "no Brain".
    */
   brainConfigured?: boolean;
-  /**
-   * The fleet manager provisioned a Brain for this deployment but no
-   * provider key has been supplied yet. Shows the Brain page in a
-   * needs-your-key state instead of hiding it. Optional like
-   * `brainConfigured`.
-   */
-  brainNeedsKey?: boolean;
   /** When this user accepted optional Cloud cookies, serialized as epoch ms. */
   cookieConsentedAt: number | null;
   managedAccess?: ManagedDeploymentAccess;

--- a/apps/web/src/types/auth.ts
+++ b/apps/web/src/types/auth.ts
@@ -37,6 +37,13 @@ export type AuthorizedUser = {
    * `managedAccess`, so test fixtures and older payloads read as "no Brain".
    */
   brainConfigured?: boolean;
+  /**
+   * The fleet manager provisioned a Brain for this deployment but no
+   * provider key has been supplied yet. Shows the Brain page in a
+   * needs-your-key state instead of hiding it. Optional like
+   * `brainConfigured`.
+   */
+  brainNeedsKey?: boolean;
   /** When this user accepted optional Cloud cookies, serialized as epoch ms. */
   cookieConsentedAt: number | null;
   managedAccess?: ManagedDeploymentAccess;

--- a/packages/db/src/lib/model-runtime-config.ts
+++ b/packages/db/src/lib/model-runtime-config.ts
@@ -264,6 +264,33 @@ export async function isBrainProviderConfigured(): Promise<boolean> {
   return value;
 }
 
+/**
+ * - `configured`: an operator set a brain-specific provider key; the Brain is
+ *   fully on.
+ * - `managed_needs_key`: the fleet manager provisioned a Brain for this
+ *   deployment (it stamps ROOMOTE_MANAGED_GBRAIN_DIGEST on the app services)
+ *   but no provider key has been supplied yet. The Brain exists and should be
+ *   visible in Settings so an admin can add the key there, but nothing may
+ *   ingest or serve recall until the key arrives.
+ * - `unconfigured`: this deployment has no Brain.
+ */
+export type BrainAvailability =
+  | 'configured'
+  | 'managed_needs_key'
+  | 'unconfigured';
+
+export async function resolveBrainAvailability(): Promise<BrainAvailability> {
+  if (await isBrainProviderConfigured()) {
+    return 'configured';
+  }
+
+  // Read from the process environment directly: the digest is fleet plumbing
+  // stamped by the Cloud manager, not part of the app's own env contract.
+  return process.env.ROOMOTE_MANAGED_GBRAIN_DIGEST?.trim()
+    ? 'managed_needs_key'
+    : 'unconfigured';
+}
+
 type ModelRuntimeEnvOptions = {
   runtimeEnv?: Partial<Record<string, string | undefined>>;
   deploymentEnvVars?: Record<string, string>;

--- a/packages/db/src/lib/model-runtime-config.ts
+++ b/packages/db/src/lib/model-runtime-config.ts
@@ -264,33 +264,6 @@ export async function isBrainProviderConfigured(): Promise<boolean> {
   return value;
 }
 
-/**
- * - `configured`: an operator set a brain-specific provider key; the Brain is
- *   fully on.
- * - `managed_needs_key`: the fleet manager provisioned a Brain for this
- *   deployment (it stamps ROOMOTE_MANAGED_GBRAIN_DIGEST on the app services)
- *   but no provider key has been supplied yet. The Brain exists and should be
- *   visible in Settings so an admin can add the key there, but nothing may
- *   ingest or serve recall until the key arrives.
- * - `unconfigured`: this deployment has no Brain.
- */
-export type BrainAvailability =
-  | 'configured'
-  | 'managed_needs_key'
-  | 'unconfigured';
-
-export async function resolveBrainAvailability(): Promise<BrainAvailability> {
-  if (await isBrainProviderConfigured()) {
-    return 'configured';
-  }
-
-  // Read from the process environment directly: the digest is fleet plumbing
-  // stamped by the Cloud manager, not part of the app's own env contract.
-  return process.env.ROOMOTE_MANAGED_GBRAIN_DIGEST?.trim()
-    ? 'managed_needs_key'
-    : 'unconfigured';
-}
-
 type ModelRuntimeEnvOptions = {
   runtimeEnv?: Partial<Record<string, string | undefined>>;
   deploymentEnvVars?: Record<string, string>;

--- a/packages/sdk/src/server/lib/brain-clients.ts
+++ b/packages/sdk/src/server/lib/brain-clients.ts
@@ -41,11 +41,13 @@ function normalizeBaseUrl(url: string): string {
 async function adminLogin(
   baseUrl: string,
   adminToken: string,
+  signal?: AbortSignal,
 ): Promise<string> {
   const response = await fetch(`${normalizeBaseUrl(baseUrl)}/admin/login`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ token: adminToken }),
+    ...(signal ? { signal } : {}),
   });
 
   if (!response.ok) {
@@ -507,12 +509,16 @@ async function fetchBrainStats(): Promise<BrainAdminStats | null> {
   }
 
   try {
-    const cookie = await adminLogin(baseUrl, adminToken);
+    // One deadline across the login and the stats read: a Brain that accepts
+    // the connection but hangs the login must not hold brain.get beyond the
+    // stats budget — degrading to null is the whole contract here.
+    const deadline = AbortSignal.timeout(BRAIN_STATS_TIMEOUT_MS);
+    const cookie = await adminLogin(baseUrl, adminToken, deadline);
     const response = await fetch(
       `${normalizeBaseUrl(baseUrl)}/admin/api/full-stats`,
       {
         headers: { cookie },
-        signal: AbortSignal.timeout(BRAIN_STATS_TIMEOUT_MS),
+        signal: deadline,
       },
     );
 

--- a/packages/sdk/src/server/lib/brain-clients.ts
+++ b/packages/sdk/src/server/lib/brain-clients.ts
@@ -430,3 +430,111 @@ async function provisionAndStoreBrainClients(
     return null;
   }
 }
+
+// ─── Admin stats ────────────────────────────────────────────────────────────
+
+export type BrainAdminStats = {
+  version: string | null;
+  pageCount: number | null;
+  chunkCount: number | null;
+  embeddedCount: number | null;
+};
+
+/**
+ * A settings page must not hold a request open on an unresponsive admin API;
+ * the stats consumer degrades to the sampled/inferred values on its own.
+ */
+const BRAIN_STATS_TIMEOUT_MS = 4_000;
+
+/**
+ * Same rationale as the corpus sample's cache: one settings view asks more
+ * than once, and the answer only moves as fast as ingestion does. Failures
+ * are cached briefly so a Brain coming back is noticed promptly.
+ */
+const BRAIN_STATS_CACHE_TTL_MS = 30_000;
+const BRAIN_STATS_FAILURE_CACHE_TTL_MS = 5_000;
+
+let brainStatsCache: {
+  value: BrainAdminStats | null;
+  expiresAtMs: number;
+} | null = null;
+
+/** Drop the cached stats, so the next call re-reads the admin API. */
+export function resetBrainStatsCache(): void {
+  brainStatsCache = null;
+}
+
+function toCount(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? value
+    : null;
+}
+
+/**
+ * gbrain's own census of the corpus, from `/admin/api/full-stats`: the exact
+ * page count (the MCP listing answers a bounded recency window, never a
+ * total) and embedding coverage (`embedded_count` vs `chunk_count`), which
+ * is the direct measurement of whether semantic recall actually works —
+ * unlike inferring it from provider-key presence. Returns null when the
+ * deployment holds no admin token or the Brain does not answer; callers keep
+ * their inferred fallbacks.
+ */
+export async function readBrainStats(): Promise<BrainAdminStats | null> {
+  const cached = brainStatsCache;
+
+  if (cached && cached.expiresAtMs > Date.now()) {
+    return cached.value;
+  }
+
+  const value = await fetchBrainStats();
+
+  brainStatsCache = {
+    value,
+    expiresAtMs:
+      Date.now() +
+      (value ? BRAIN_STATS_CACHE_TTL_MS : BRAIN_STATS_FAILURE_CACHE_TTL_MS),
+  };
+
+  return value;
+}
+
+async function fetchBrainStats(): Promise<BrainAdminStats | null> {
+  const baseUrl = Env.R_GBRAIN_URL;
+  const adminToken = readGbrainAdminToken();
+
+  if (!baseUrl || !adminToken) {
+    return null;
+  }
+
+  try {
+    const cookie = await adminLogin(baseUrl, adminToken);
+    const response = await fetch(
+      `${normalizeBaseUrl(baseUrl)}/admin/api/full-stats`,
+      {
+        headers: { cookie },
+        signal: AbortSignal.timeout(BRAIN_STATS_TIMEOUT_MS),
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`full-stats answered ${response.status}`);
+    }
+
+    const stats = (await response.json()) as Record<string, unknown>;
+
+    return {
+      version: typeof stats.version === 'string' ? stats.version : null,
+      pageCount: toCount(stats.page_count),
+      chunkCount: toCount(stats.chunk_count),
+      embeddedCount: toCount(stats.embedded_count),
+    };
+  } catch (error) {
+    console.warn(
+      `[brain] admin stats read failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+
+    return null;
+  }
+}


### PR DESCRIPTION
Stacked on #1487 (it retargets to develop automatically when that merges). Draft on purpose: **merging this makes a fleet-provisioned Brain visible to every managed tenant's admin** in a "needs your key" state, which is a product-exposure decision — hold it until the Brain is ready for that audience.

## What it does

- `resolveBrainAvailability()` adds a `managed_needs_key` state, detected via the `ROOMOTE_MANAGED_GBRAIN_DIGEST` the Cloud manager already stamps on app services (no Cloud-side change needed).
- The auth payload carries `brainNeedsKey`; the Settings nav shows the Brain page in that state; the status section explains it ("Add a provider key below to turn it on").
- The Configuration section renders a provider-key form (OpenRouter/OpenAI select + secret input). The admin-only mutation writes `R_BRAIN_OPENROUTER_API_KEY` / `R_BRAIN_OPENAI_API_KEY` into the persisted deployment env store — encrypted at rest, and it survives fleet reprovisions, unlike Railway-side variables that the fleet manager reconciles — then drops both activation caches so the Brain turns on with the next request instead of a TTL later.
- A configured Brain gets a "Replace key" affordance on the Inference key row.

## Why the deployment env store

Today the only way to enable a managed tenant's Brain is a Railway-side variable that tenant admins cannot reach and (before Roomote-Cloud#202) fleet upgrades wiped. This closes the loop: the fleet provisions, the tenant admin opts in from the page itself, and the key lives where reprovisions cannot touch it.

## Options if partial exposure is wanted sooner

The visibility could be gated further (behind the Show Debug UI setting per the internal-UI convention, or a feature flag) if we want the key form available to ourselves before tenants see it — say the word and I'll add that gate.

## Testing

Render tests cover the needs-key form state; auth-context tests cover the availability plumbing. Types, lint, knip green on the stack.