### PR TITLE
[Improve] Retire superseded Brain Slack day pages

### DIFF
--- a/.changeset/brainy-slack-slug-retirement.md
+++ b/.changeset/brainy-slack-slug-retirement.md
@@ -1,0 +1,5 @@
+---
+"@roomote/bullmq": minor
+---
+
+Heal Brain Slack day pages from the incremental era: the Slack collector now tracks every page slug it emits, a one-time census inventories pages that predate tracking, and a replay retires (soft-deletes) superseded pages whose message range it fully re-read. Merging triggers a one-time re-read of the last 90 days of Slack history per deployment, paced by the existing collector budgets; pages older than that window are deliberately kept.

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-collector-engine.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-collector-engine.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   deleteBrainCollectorItems,
@@ -9,10 +9,14 @@ import {
 import { runBrainCollectors } from '../brain-collectors';
 import type {
   BrainCollector,
+  BrainRetireSink,
   BrainSink,
   CollectorPage,
 } from '../brain-collectors/contracts';
-import { writeCollectorPages } from '../brain-collectors/write-pages';
+import {
+  retireBrainPage,
+  writeCollectorPages,
+} from '../brain-collectors/write-pages';
 import { BrainRateLimitedError } from '../brain-outbox-drain';
 
 type FakeSyncState = {
@@ -128,6 +132,47 @@ describe('writeCollectorPages', () => {
   });
 });
 
+describe('retireBrainPage', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  function bodyOf(status: number, body: string) {
+    global.fetch = vi.fn(
+      async () => new Response(body, { status }),
+    ) as unknown as typeof fetch;
+  }
+
+  it('treats an already-deleted page as retired', async () => {
+    bodyOf(
+      200,
+      '{"jsonrpc":"2.0","id":1,"result":{"isError":true,"content":[{"type":"text","text":"page_not_found: slack/T1/C1"}]}}',
+    );
+
+    await expect(
+      retireBrainPage('slack/T1/C1/2026-08-13/1-0-2-0', connection),
+    ).resolves.toBeUndefined();
+  });
+
+  it('keeps backpressure typed so the engine ends the pass', async () => {
+    bodyOf(429, 'rate limited');
+
+    await expect(
+      retireBrainPage('slack/T1/C1/2026-08-13/1-0-2-0', connection),
+    ).rejects.toBeInstanceOf(BrainRateLimitedError);
+  });
+
+  it('propagates other failures', async () => {
+    bodyOf(500, 'internal error');
+
+    await expect(
+      retireBrainPage('slack/T1/C1/2026-08-13/1-0-2-0', connection),
+    ).rejects.toThrow('delete_page failed');
+  });
+});
+
 describe('runBrainCollectors', () => {
   it('advances the watermark between runs', async () => {
     const firstNextSince = new Date('2026-08-13T10:00:00Z');
@@ -229,6 +274,113 @@ describe('runBrainCollectors', () => {
       'notion-pages',
       ['revoked-page'],
     );
+  });
+
+  it('retires superseded pages once the batch has landed', async () => {
+    const order: string[] = [];
+    const collector = makeCollector({
+      collect: async () => ({
+        pages: makePages(1),
+        nextSince: null,
+        pageRetirements: [
+          {
+            collectorId: 'slack-public-channels:day-pages',
+            itemId: 'slack/T1/C1/2026-08-13/1-0-2-0',
+            slug: 'slack/T1/C1/2026-08-13/1-0-2-0',
+          },
+        ],
+      }),
+    });
+    const sink: BrainSink = vi.fn(async (page) => {
+      order.push(`write:${page.slug}`);
+    });
+    const retireSink: BrainRetireSink = vi.fn(async (slug) => {
+      order.push(`retire:${slug}`);
+    });
+
+    await runBrainCollectors(connection, {
+      sink,
+      retireSink,
+      collectors: [collector],
+    });
+
+    // The superseding page lands before the superseded one goes, and only a
+    // successful retirement drops the inventory row.
+    expect(order).toEqual([
+      'write:page/0',
+      'retire:slack/T1/C1/2026-08-13/1-0-2-0',
+    ]);
+    expect(mockedDeleteCollectorItems).toHaveBeenCalledWith(
+      expect.anything(),
+      'slack-public-channels:day-pages',
+      ['slack/T1/C1/2026-08-13/1-0-2-0'],
+    );
+  });
+
+  it('holds retirements when a page fails', async () => {
+    const retireSink: BrainRetireSink = vi.fn(async () => {});
+    const collector = makeCollector({
+      collect: async () => ({
+        pages: makePages(1),
+        nextSince: null,
+        pageRetirements: [{ collectorId: 'c', itemId: 'i', slug: 'slack/old' }],
+      }),
+    });
+
+    await runBrainCollectors(connection, {
+      sink: vi.fn(async () => {
+        throw new Error('boom');
+      }),
+      retireSink,
+      collectors: [collector],
+    });
+
+    expect(retireSink).not.toHaveBeenCalled();
+    expect(mockedDeleteCollectorItems).not.toHaveBeenCalled();
+  });
+
+  it('holds retirements when the collector overshoots the page cap', async () => {
+    // On overshoot part of the emission never landed, so pages the dropped
+    // remainder would have superseded must stay until it does.
+    const retireSink: BrainRetireSink = vi.fn(async () => {});
+    const collector = makeCollector({
+      collect: async () => ({
+        pages: makePages(150),
+        nextSince: null,
+        pageRetirements: [{ collectorId: 'c', itemId: 'i', slug: 'slack/old' }],
+      }),
+    });
+
+    await runBrainCollectors(connection, {
+      sink: vi.fn(async () => {}),
+      retireSink,
+      collectors: [collector],
+    });
+
+    expect(retireSink).not.toHaveBeenCalled();
+  });
+
+  it('keeps the inventory row when a retirement fails, and holds state', async () => {
+    const collector = makeCollector({
+      collect: async () => ({
+        pages: makePages(1),
+        nextSince: new Date('2026-08-13T10:00:00Z'),
+        pageRetirements: [{ collectorId: 'c', itemId: 'i', slug: 'slack/old' }],
+      }),
+    });
+
+    await runBrainCollectors(connection, {
+      sink: vi.fn(async () => {}),
+      retireSink: vi.fn(async () => {
+        throw new Error('delete_page exploded');
+      }),
+      collectors: [collector],
+    });
+
+    // The failed retirement is retried next pass: its row survives and the
+    // watermark stays behind so the same window is recomputed.
+    expect(mockedDeleteCollectorItems).not.toHaveBeenCalled();
+    expect(syncStateStore.get(collector.id)).toBeUndefined();
   });
 
   it('holds collector inventory changes when a page fails', async () => {
@@ -566,6 +718,54 @@ describe('runBrainCollectors deep backfill', () => {
     // The first step's cursor landed; the failed second step's did not.
     expect(syncStateStore.get(collector.id)?.backfillCursor).toBe('c1');
     expect(syncStateStore.get(collector.id)?.backfillCompletedAt).toBeNull();
+  });
+
+  it("retires a step's superseded pages before its cursor persists", async () => {
+    const retireSink: BrainRetireSink = vi
+      .fn<BrainRetireSink>()
+      .mockRejectedValueOnce(new Error('delete_page exploded'))
+      .mockResolvedValue(undefined);
+    const backfill = vi
+      .fn<NonNullable<BrainCollector['backfill']>>()
+      .mockImplementation(async ({ cursor }) =>
+        cursor === null
+          ? {
+              pages: makePages(1, 'replay'),
+              nextCursor: 'c1',
+              done: false,
+              pageRetirements: [
+                { collectorId: 'c', itemId: 'i', slug: 'slack/old' },
+              ],
+            }
+          : { pages: [], nextCursor: cursor, done: false },
+      );
+    const collector = makeCollector({
+      collect: async () => ({ pages: [], nextSince: null }),
+      backfill,
+    });
+
+    await runBrainCollectors(connection, {
+      sink: vi.fn(async () => {}),
+      retireSink,
+      collectors: [collector],
+    });
+
+    // The failed retirement held the cursor, so the same step re-runs.
+    expect(syncStateStore.get(collector.id)?.backfillCursor).toBeUndefined();
+
+    await runBrainCollectors(connection, {
+      sink: vi.fn(async () => {}),
+      retireSink,
+      collectors: [collector],
+    });
+
+    expect(retireSink).toHaveBeenCalledTimes(2);
+    expect(syncStateStore.get(collector.id)?.backfillCursor).toBe('c1');
+    expect(mockedDeleteCollectorItems).toHaveBeenCalledWith(
+      expect.anything(),
+      'c',
+      ['i'],
+    );
   });
 
   it('marks the backfill complete when a step reports done', async () => {

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-slack-collector.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-slack-collector.test.ts
@@ -20,14 +20,29 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 type FakeMessage = { ts: string; text: string; user: string };
 type FakeChannel = { id: string; name: string; messages: FakeMessage[] };
+type FakeItem = { collectorId: string; itemId: string; slug: string };
 
 const workspace = vi.hoisted(() => ({
   channels: [] as FakeChannel[],
   /** Channel ids whose next history read throws, to exercise failure paths. */
   failing: new Set<string>(),
   historyCalls: 0,
-  syncState: new Map<string, { watermark: Date | null }>(),
+  syncState: new Map<
+    string,
+    { watermark: Date | null; backfillCompletedAt?: Date | null }
+  >(),
   brainPages: new Map<string, string>(),
+  /** The day-page inventory, as the engine would persist it. */
+  items: new Map<string, FakeItem>(),
+  retired: [] as string[],
+}));
+
+// The inventory module reaches for gbrain reads only in the census, which
+// these tests bypass by seeding its sync state as complete.
+vi.mock('@roomote/sdk/server', () => ({
+  callBrainTool: vi.fn(async () => []),
+  extractBrainCorpusPages: vi.fn(() => []),
+  resolveBrainConnection: vi.fn(async () => null),
 }));
 
 vi.mock('@roomote/db/server', async (importOriginal) => {
@@ -44,12 +59,22 @@ vi.mock('@roomote/db/server', async (importOriginal) => {
             collectorId,
             watermark: state.watermark,
             backfillCursor: null,
-            backfillCompletedAt: null,
+            backfillCompletedAt: state.backfillCompletedAt ?? null,
             createdAt: new Date(),
             updatedAt: new Date(),
           }
         : null;
     }),
+    listBrainCollectorItemsBySlugPrefix: vi.fn(
+      async (_db: unknown, collectorId: string, prefix: string) =>
+        [...workspace.items.values()]
+          .filter(
+            (item) =>
+              item.collectorId === collectorId &&
+              item.itemId.startsWith(prefix),
+          )
+          .sort((a, b) => a.itemId.localeCompare(b.itemId)),
+    ),
     db: {
       select: () => ({
         from: () => ({
@@ -144,10 +169,35 @@ vi.mock('@roomote/slack', () => ({
 
 const { slackPublicChannelsCollector } =
   await import('../brain-collectors/slack-public-channels');
+const { SLACK_DAY_PAGE_ITEMS_ID } =
+  await import('../brain-collectors/slack-day-page-inventory');
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+const CENSUS_STATE_ID = 'slack-public-channels:day-pages:census';
 const slackStateId = (channelId: string) =>
   `${slackPublicChannelsCollector.id}:T1/${channelId}`;
+
+/** Seed a page as the pre-tracking era left it: in the Brain and (as the
+ * census would record it) in the inventory, with a batch-timestamp slug. */
+function seedLegacyPage(slug: string, content = 'legacy content') {
+  workspace.brainPages.set(slug, content);
+  workspace.items.set(slug, {
+    collectorId: SLACK_DAY_PAGE_ITEMS_ID,
+    itemId: slug,
+    slug,
+  });
+}
+
+function legacyChunkSlug(
+  channelId: string,
+  day: string,
+  firstIso: string,
+  lastIso: string,
+) {
+  const part = (iso: string) =>
+    (Date.parse(iso) / 1000).toFixed(6).replace('.', '-');
+  return `slack/T1/${channelId}/${day}/${part(firstIso)}-${part(lastIso)}`;
+}
 
 function seedChannel(
   id: string,
@@ -172,14 +222,33 @@ function seedChannel(
 }
 
 /**
- * Apply a successful engine write: pages land first, then every independent
- * source watermark advances.
+ * Apply a successful engine write in the engine's order: pages land first,
+ * then retirements soft-delete superseded pages and drop their inventory
+ * rows, then fresh inventory rows persist, then every independent source
+ * watermark advances.
  */
-function applyResult(
-  result: Awaited<ReturnType<typeof slackPublicChannelsCollector.collect>>,
-) {
+function applyResult(result: {
+  pages: Array<{ slug: string; content: string }>;
+  stateUpdates?: Array<{ collectorId: string; watermark?: Date }>;
+  itemUpdates?: Array<{ collectorId: string; itemId: string; slug: string }>;
+  pageRetirements?: Array<{ itemId: string; slug: string }>;
+}) {
   for (const page of result.pages) {
     workspace.brainPages.set(page.slug, page.content);
+  }
+
+  for (const retirement of result.pageRetirements ?? []) {
+    workspace.brainPages.delete(retirement.slug);
+    workspace.items.delete(retirement.itemId);
+    workspace.retired.push(retirement.slug);
+  }
+
+  for (const update of result.itemUpdates ?? []) {
+    workspace.items.set(update.itemId, {
+      collectorId: update.collectorId,
+      itemId: update.itemId,
+      slug: update.slug,
+    });
   }
 
   for (const update of result.stateUpdates ?? []) {
@@ -239,9 +308,19 @@ async function drainToCaughtUp(from: Date | null = null, maxTicks = 60) {
 
   return {
     ingested: ingestedMessages(),
-    watermarks: new Map(workspace.syncState),
+    // Channel watermarks only; the census state row is not one of them.
+    watermarks: new Map(
+      [...workspace.syncState].filter(([key]) => key !== CENSUS_STATE_ID),
+    ),
     ticks,
   };
+}
+
+function seedCensusComplete() {
+  workspace.syncState.set(CENSUS_STATE_ID, {
+    watermark: null,
+    backfillCompletedAt: new Date('2026-08-01T00:00:00Z'),
+  });
 }
 
 beforeEach(() => {
@@ -250,6 +329,10 @@ beforeEach(() => {
   workspace.historyCalls = 0;
   workspace.syncState.clear();
   workspace.brainPages.clear();
+  workspace.items.clear();
+  workspace.retired = [];
+  // Collection holds until the one-time inventory census completes.
+  seedCensusComplete();
 });
 
 describe('slack collector against a fake Slack', () => {
@@ -386,6 +469,7 @@ describe('slack collector against a fake Slack', () => {
     const first = await drainToCaughtUp(new Date(now - 2 * DAY_MS));
     const callsAfterFirst = workspace.historyCalls;
     workspace.syncState.clear();
+    seedCensusComplete();
     const second = await drainToCaughtUp(new Date(now - 2 * DAY_MS));
 
     expect(second.ingested).toEqual(first.ingested);
@@ -434,6 +518,44 @@ describe('slack collector against a fake Slack', () => {
     expect(ingestedMessages()).toEqual(
       new Set(['C1 message 0', 'C1 message 1']),
     );
+    // The later partial-day tick covers only its own window, so the earlier
+    // chunk's range is never contained and retirement must not fire.
+    expect(workspace.retired).toEqual([]);
+  });
+
+  it('holds all collection until the inventory census completes', async () => {
+    workspace.syncState.delete(CENSUS_STATE_ID);
+    workspace.channels = [seedChannel('C1', 'general', 5, DAY_MS, Date.now())];
+
+    const incremental = await slackPublicChannelsCollector.collect({
+      since: null,
+      now: new Date(),
+      limit: 100,
+    });
+    const backfill = await slackPublicChannelsCollector.backfill!({
+      cursor: null,
+      limit: 100,
+    });
+
+    expect(incremental.pages).toEqual([]);
+    expect(incremental.stateUpdates ?? []).toEqual([]);
+    expect(backfill.pages).toEqual([]);
+    expect(backfill.done).toBe(false);
+    expect(workspace.historyCalls).toBe(0);
+  });
+
+  it('steady-state incremental ticks never retire pages', async () => {
+    const now = Date.now();
+    workspace.channels = [seedChannel('C1', 'general', 60, 3 * DAY_MS, now)];
+
+    const { ingested } = await drainToCaughtUp(new Date(now - 4 * DAY_MS));
+
+    expect(ingested.size).toBe(60);
+    expect(workspace.retired).toEqual([]);
+    // Every emitted page is inventoried under its own slug.
+    expect(new Set(workspace.items.keys())).toEqual(
+      new Set(workspace.brainPages.keys()),
+    );
   });
 
   it('lets quiet channels advance when one pathological channel holds', async () => {
@@ -462,5 +584,203 @@ describe('slack collector against a fake Slack', () => {
     expect(
       workspace.syncState.get(slackStateId('C2'))?.watermark?.getTime(),
     ).toBe(now);
+  });
+});
+
+describe('slug retirement heals pages from the incremental era', () => {
+  it('a replay retires the partial-day chunks it fully supersedes', async () => {
+    // Phase 1: the incremental era. Two ticks land the same day as two
+    // immutable partial-day chunks, tracked in the inventory as the engine
+    // would have.
+    workspace.channels = [
+      {
+        id: 'C1',
+        name: 'general',
+        messages: [
+          {
+            ts: (Date.parse('2026-08-13T10:05:00Z') / 1000).toFixed(6),
+            text: 'C1 message 0',
+            user: 'U1',
+          },
+          {
+            ts: (Date.parse('2026-08-13T10:20:00Z') / 1000).toFixed(6),
+            text: 'C1 message 1',
+            user: 'U1',
+          },
+        ],
+      },
+    ];
+    workspace.syncState.set(slackStateId('C1'), {
+      watermark: new Date('2026-08-13T10:00:00Z'),
+    });
+
+    for (const tick of ['2026-08-13T10:15:00Z', '2026-08-13T10:30:00Z']) {
+      applyResult(
+        await slackPublicChannelsCollector.collect({
+          since: null,
+          now: new Date(tick),
+          limit: 100,
+        }),
+      );
+    }
+
+    const legacySlugs = [...workspace.brainPages.keys()];
+    expect(legacySlugs).toHaveLength(2);
+
+    // Phase 2: a version bump. Collector state starts over (the census has
+    // already run — the inventory survives, keyed off the unversioned id),
+    // and the fresh watermark re-reads the whole day in one window.
+    workspace.syncState.clear();
+    seedCensusComplete();
+    workspace.syncState.set(slackStateId('C1'), {
+      watermark: new Date('2026-08-13T00:00:00Z'),
+    });
+
+    applyResult(
+      await slackPublicChannelsCollector.collect({
+        since: null,
+        now: new Date('2026-08-14T00:30:00Z'),
+        limit: 100,
+      }),
+    );
+
+    // Both messages live in exactly one whole-day page; the superseded
+    // chunks are gone from the Brain and from the inventory.
+    expect(workspace.retired.sort()).toEqual(legacySlugs.sort());
+    expect(workspace.brainPages.size).toBe(1);
+    expect(ingestedMessages()).toEqual(
+      new Set(['C1 message 0', 'C1 message 1']),
+    );
+    expect(new Set(workspace.items.keys())).toEqual(
+      new Set(workspace.brainPages.keys()),
+    );
+  });
+
+  it('keeps a page whose range reaches outside what was re-read', async () => {
+    // A census-seeded legacy page claims messages from 09:00, but the only
+    // messages Slack still serves are later. Retiring it would discard the
+    // only record of whatever the 09:00 half described.
+    const wide = legacyChunkSlug(
+      'C1',
+      '2026-08-13',
+      '2026-08-13T09:00:00Z',
+      '2026-08-13T10:20:00Z',
+    );
+    // Strictly inside the re-read range and different from any re-emitted
+    // slug (a legacy batch boundary the replay does not reproduce).
+    const inside = legacyChunkSlug(
+      'C1',
+      '2026-08-13',
+      '2026-08-13T10:06:00Z',
+      '2026-08-13T10:19:00Z',
+    );
+    seedLegacyPage(wide);
+    seedLegacyPage(inside);
+    workspace.channels = [
+      {
+        id: 'C1',
+        name: 'general',
+        messages: [
+          {
+            ts: (Date.parse('2026-08-13T10:05:00Z') / 1000).toFixed(6),
+            text: 'C1 message 0',
+            user: 'U1',
+          },
+          {
+            ts: (Date.parse('2026-08-13T10:20:00Z') / 1000).toFixed(6),
+            text: 'C1 message 1',
+            user: 'U1',
+          },
+        ],
+      },
+    ];
+    workspace.syncState.set(slackStateId('C1'), {
+      watermark: new Date('2026-08-13T00:00:00Z'),
+    });
+
+    applyResult(
+      await slackPublicChannelsCollector.collect({
+        since: null,
+        now: new Date('2026-08-14T00:30:00Z'),
+        limit: 100,
+      }),
+    );
+
+    expect(workspace.retired).toEqual([inside]);
+    expect(workspace.brainPages.has(wide)).toBe(true);
+  });
+
+  it('retires nothing for a day the re-read returns no messages for', async () => {
+    // Retention or upstream deletion can empty a day. No emission means no
+    // coverage, so the old pages — possibly the only surviving record —
+    // stay.
+    const orphan = legacyChunkSlug(
+      'C1',
+      '2026-08-13',
+      '2026-08-13T10:05:00Z',
+      '2026-08-13T10:20:00Z',
+    );
+    seedLegacyPage(orphan);
+    workspace.channels = [{ id: 'C1', name: 'general', messages: [] }];
+    workspace.syncState.set(slackStateId('C1'), {
+      watermark: new Date('2026-08-13T00:00:00Z'),
+    });
+
+    applyResult(
+      await slackPublicChannelsCollector.collect({
+        since: null,
+        now: new Date('2026-08-14T00:30:00Z'),
+        limit: 100,
+      }),
+    );
+
+    expect(workspace.retired).toEqual([]);
+    expect(workspace.brainPages.has(orphan)).toBe(true);
+  });
+
+  it('the deep backfill replay heals covered chunks and keeps straddlers', async () => {
+    // Anchor at UTC noon three days ago: old enough for the backfill window
+    // (which ends a day before now), and a two-minute span that can never
+    // straddle a UTC day boundary.
+    const anchor = new Date(Date.now() - 3 * DAY_MS);
+    anchor.setUTCHours(12, 0, 0, 0);
+    const messageAt = (offsetMs: number) => anchor.getTime() + offsetMs;
+    workspace.channels = [
+      {
+        id: 'C1',
+        name: 'general',
+        messages: [0, 60_000, 120_000].map((offset, index) => ({
+          ts: (messageAt(offset) / 1000).toFixed(6),
+          text: `C1 message ${index}`,
+          user: 'U1',
+        })),
+      },
+    ];
+    const day = new Date(messageAt(0)).toISOString().slice(0, 10);
+    const iso = (offsetMs: number) =>
+      new Date(messageAt(offsetMs)).toISOString();
+    const covered = legacyChunkSlug('C1', day, iso(0), iso(60_000));
+    const straddler = legacyChunkSlug('C1', day, iso(-3_600_000), iso(60_000));
+    seedLegacyPage(covered);
+    seedLegacyPage(straddler);
+
+    let cursor: string | null = null;
+    for (let steps = 0; steps < 10; steps++) {
+      const step = await slackPublicChannelsCollector.backfill!({
+        cursor,
+        limit: 100,
+      });
+      applyResult(step);
+      if (step.nextCursor === cursor) break;
+      cursor = step.nextCursor;
+    }
+
+    // The chunk whose whole range was re-read is retired; the one reaching
+    // an hour before the earliest surviving message is kept.
+    expect(workspace.retired).toEqual([covered]);
+    expect(workspace.brainPages.has(straddler)).toBe(true);
+    expect(ingestedMessages()).toEqual(
+      new Set(['C1 message 0', 'C1 message 1', 'C1 message 2']),
+    );
   });
 });

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-slack-slug-inventory.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-slack-slug-inventory.test.ts
@@ -10,8 +10,8 @@ const store = vi.hoisted(() => ({
   items: new Map<string, FakeItem>(),
   seeded: [] as Array<{ itemId: string; slug: string; lastSeenAt: Date }>,
   /** Each entry is one list_pages window answered in order. */
-  listings: [] as Array<Array<{ slug: string }>>,
-  listCalls: [] as Array<{ limit: number; offset: number }>,
+  listings: [] as Array<Array<{ slug: string; updated_at?: string }>>,
+  listCalls: [] as Array<Record<string, unknown>>,
   connection: { baseUrl: 'http://brain.test', token: 'read' } as {
     baseUrl: string;
     token: string;
@@ -24,18 +24,20 @@ vi.mock('@roomote/sdk/server', () => ({
     async (
       _connection: unknown,
       _tool: string,
-      args: { limit: number; offset: number },
+      args: Record<string, unknown>,
     ) => {
       store.listCalls.push(args);
       return [store.listings.shift() ?? []];
     },
   ),
   extractBrainCorpusPages: vi.fn((payloads: unknown[]) =>
-    (payloads[0] as Array<{ slug: string }>).map((page) => ({
-      slug: page.slug,
-      title: null,
-      updatedAt: null,
-    })),
+    (payloads[0] as Array<{ slug: string; updated_at?: string }>).map(
+      (page) => ({
+        slug: page.slug,
+        title: null,
+        updatedAt: page.updated_at ? new Date(page.updated_at) : null,
+      }),
+    ),
   ),
 }));
 
@@ -247,14 +249,28 @@ describe('reconcileSlackDayPages', () => {
 });
 
 describe('runSlackDayPageCensus', () => {
-  function listingOf(count: number, baseMinutes: number) {
-    const base = Date.parse('2026-08-01T00:00:00Z') + baseMinutes * 60_000;
+  const minuteIso = (minute: number) =>
+    new Date(
+      Date.parse('2026-08-01T00:00:00Z') + minute * 60_000,
+    ).toISOString();
+
+  /** Rows in ascending updated_at order, one per minute from `fromMinute`. */
+  function listingOf(count: number, fromMinute: number) {
     return Array.from({ length: count }, (_, index) => ({
       slug: daySlug(
-        new Date(base + index * 60_000).toISOString(),
-        new Date(base + index * 60_000 + 30_000).toISOString(),
+        minuteIso(fromMinute + index),
+        minuteIso(fromMinute + index),
         '2026-08-01',
       ),
+      updated_at: minuteIso(fromMinute + index),
+    }));
+  }
+
+  /** Rows all sharing ONE updated_at, with distinct slugs. */
+  function clusterOf(count: number, fromMinute: number, stampedAt: string) {
+    return listingOf(count, fromMinute).map((row) => ({
+      ...row,
+      updated_at: stampedAt,
     }));
   }
 
@@ -277,40 +293,128 @@ describe('runSlackDayPageCensus', () => {
     expect(await isSlackDayPageCensusComplete()).toBe(true);
   });
 
-  it('pages with offset and persists the cursor between windows', async () => {
-    store.listings = [listingOf(100, 0), listingOf(37, 200)];
+  it('walks by updated_at keyset, not by listing offset', async () => {
+    // The first full window advances the boundary to its last FULLY seen
+    // timestamp (minute 98) and re-reads the trailing row from there, so a
+    // page written between windows can shift positions without any row being
+    // skipped.
+    store.listings = [listingOf(100, 0), listingOf(38, 99)];
 
     await runSlackDayPageCensus();
 
-    expect(store.listCalls.map((call) => call.offset)).toEqual([0, 100]);
-    expect(store.seeded).toHaveLength(137);
+    expect(store.listCalls[0]).toMatchObject({ sort: 'updated_asc' });
+    expect(store.listCalls[0]!.updated_after).toBeUndefined();
+    expect(store.listCalls[0]!.offset).toBeUndefined();
+    expect(store.listCalls[1]).toMatchObject({
+      sort: 'updated_asc',
+      updated_after: minuteIso(98),
+    });
+    // Minutes 0..136, with the boundary row read twice and seeded once.
+    expect(store.seeded).toHaveLength(138);
+    expect(store.items.size).toBe(137);
     expect(store.syncState.get(CENSUS_STATE_ID)?.backfillCursor).toBeNull();
     expect(await isSlackDayPageCensusComplete()).toBe(true);
   });
 
-  it('resumes from the persisted cursor after an interrupted run', async () => {
+  it('resumes from the persisted keyset cursor after an interrupted run', async () => {
+    store.syncState.set(CENSUS_STATE_ID, {
+      backfillCursor: JSON.stringify({
+        after: minuteIso(500),
+        offset: 0,
+        lastSlug: null,
+      }),
+      backfillCompletedAt: null,
+    });
+    store.listings = [listingOf(10, 501)];
+
+    await runSlackDayPageCensus();
+
+    expect(store.listCalls[0]).toMatchObject({
+      updated_after: minuteIso(500),
+    });
+    expect(await isSlackDayPageCensusComplete()).toBe(true);
+  });
+
+  it('restarts a cursor from before the keyset walk existed', async () => {
+    // A raw listing offset is not stable under concurrent writes, so a
+    // stored pre-keyset cursor is not trusted as a position.
     store.syncState.set(CENSUS_STATE_ID, {
       backfillCursor: JSON.stringify({ offset: 200 }),
       backfillCompletedAt: null,
     });
-    store.listings = [listingOf(10, 400)];
+    store.listings = [listingOf(10, 0)];
 
     await runSlackDayPageCensus();
 
-    expect(store.listCalls.map((call) => call.offset)).toEqual([200]);
+    expect(store.listCalls[0]!.updated_after).toBeUndefined();
+    expect(store.listCalls[0]!.offset).toBeUndefined();
     expect(await isSlackDayPageCensusComplete()).toBe(true);
   });
 
-  it('completes with a partial inventory when the listing ignores offset', async () => {
+  it('pages through a tie cluster wider than one window with an overlap row', async () => {
+    // Bulk imports stamp identical updated_at across a transaction; strict
+    // updated_after alone can never cross such a cluster. The walk holds the
+    // boundary, pages by offset, and re-reads the last seen row so a shifted
+    // cluster is detected rather than skipped over.
+    const stamp = minuteIso(700);
+    const cluster = clusterOf(120, 0, stamp);
+    store.listings = [cluster.slice(0, 100), cluster.slice(99)];
+
+    await runSlackDayPageCensus();
+
+    expect(store.listCalls[1]).toMatchObject({ offset: 99 });
+    expect(store.listCalls[1]!.updated_after).toBeUndefined();
+    expect(store.items.size).toBe(120);
+    expect(await isSlackDayPageCensusComplete()).toBe(true);
+  });
+
+  it('restarts a tie cluster whose overlap row moved', async () => {
+    const stamp = minuteIso(700);
+    const cluster = clusterOf(30, 0, stamp);
+    store.syncState.set(CENSUS_STATE_ID, {
+      backfillCursor: JSON.stringify({
+        after: null,
+        offset: 100,
+        lastSlug: 'slack/T1/C1/2026-08-01/re-stamped-away',
+      }),
+      backfillCompletedAt: null,
+    });
+    // The row at the overlap position is not the one the cursor remembers:
+    // a cluster member was re-stamped and everything shifted.
+    store.listings = [cluster.slice(5, 25), cluster];
+
+    await runSlackDayPageCensus();
+
+    expect(store.listCalls[0]).toMatchObject({ offset: 99 });
+    // Restarted from the cluster's beginning; nothing was skipped.
+    expect(store.listCalls[1]!.offset).toBeUndefined();
+    expect(store.items.size).toBe(30);
+    expect(await isSlackDayPageCensusComplete()).toBe(true);
+  });
+
+  it('completes with a partial inventory when the listing ignores the cursor', async () => {
     const repeated = listingOf(100, 600);
     store.listings = [repeated, repeated];
 
     await runSlackDayPageCensus();
 
-    // Two identical full windows: seeding is idempotent and the census
-    // completes rather than walking the same window forever.
+    // Two identical full windows advance nothing: seeding is idempotent and
+    // the census completes rather than walking the same window forever.
     expect(store.listCalls).toHaveLength(2);
     expect(store.items.size).toBe(100);
+    expect(await isSlackDayPageCensusComplete()).toBe(true);
+  });
+
+  it('completes with a partial inventory when rows carry no timestamps', async () => {
+    store.listings = [
+      Array.from({ length: 100 }, (_, index) => ({
+        slug: `notion/page${index}`,
+      })),
+    ];
+
+    await runSlackDayPageCensus();
+
+    expect(store.listCalls).toHaveLength(1);
     expect(await isSlackDayPageCensusComplete()).toBe(true);
   });
 

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-slack-slug-inventory.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-slack-slug-inventory.test.ts
@@ -1,0 +1,336 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type FakeItem = { collectorId: string; itemId: string; slug: string };
+
+const store = vi.hoisted(() => ({
+  syncState: new Map<
+    string,
+    { backfillCursor: string | null; backfillCompletedAt: Date | null }
+  >(),
+  items: new Map<string, FakeItem>(),
+  seeded: [] as Array<{ itemId: string; slug: string; lastSeenAt: Date }>,
+  /** Each entry is one list_pages window answered in order. */
+  listings: [] as Array<Array<{ slug: string }>>,
+  listCalls: [] as Array<{ limit: number; offset: number }>,
+  connection: { baseUrl: 'http://brain.test', token: 'read' } as {
+    baseUrl: string;
+    token: string;
+  } | null,
+}));
+
+vi.mock('@roomote/sdk/server', () => ({
+  resolveBrainConnection: vi.fn(async () => store.connection),
+  callBrainTool: vi.fn(
+    async (
+      _connection: unknown,
+      _tool: string,
+      args: { limit: number; offset: number },
+    ) => {
+      store.listCalls.push(args);
+      return [store.listings.shift() ?? []];
+    },
+  ),
+  extractBrainCorpusPages: vi.fn((payloads: unknown[]) =>
+    (payloads[0] as Array<{ slug: string }>).map((page) => ({
+      slug: page.slug,
+      title: null,
+      updatedAt: null,
+    })),
+  ),
+}));
+
+vi.mock('@roomote/db/server', () => ({
+  db: {},
+  getBrainSyncState: vi.fn(async (_db: unknown, collectorId: string) => {
+    const state = store.syncState.get(collectorId);
+    return state
+      ? {
+          id: collectorId,
+          collectorId,
+          watermark: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          ...state,
+        }
+      : null;
+  }),
+  upsertBrainSyncState: vi.fn(
+    async (
+      _db: unknown,
+      collectorId: string,
+      patch: {
+        backfillCursor?: string | null;
+        backfillCompletedAt?: Date | null;
+      },
+    ) => {
+      const existing = store.syncState.get(collectorId) ?? {
+        backfillCursor: null,
+        backfillCompletedAt: null,
+      };
+      store.syncState.set(collectorId, { ...existing, ...patch });
+    },
+  ),
+  seedBrainCollectorItems: vi.fn(
+    async (
+      _db: unknown,
+      collectorId: string,
+      items: Array<{ itemId: string; slug: string; lastSeenAt: Date }>,
+    ) => {
+      for (const item of items) {
+        store.seeded.push(item);
+        if (!store.items.has(item.itemId)) {
+          store.items.set(item.itemId, { collectorId, ...item });
+        }
+      }
+    },
+  ),
+  listBrainCollectorItemsBySlugPrefix: vi.fn(
+    async (_db: unknown, collectorId: string, prefix: string) =>
+      [...store.items.values()]
+        .filter(
+          (item) =>
+            item.collectorId === collectorId && item.itemId.startsWith(prefix),
+        )
+        .sort((a, b) => a.itemId.localeCompare(b.itemId)),
+  ),
+}));
+
+const {
+  SLACK_DAY_PAGE_ITEMS_ID,
+  isSlackDayPageCensusComplete,
+  parseSlackDayPageSlug,
+  reconcileSlackDayPages,
+  runSlackDayPageCensus,
+} = await import('../brain-collectors/slack-day-page-inventory');
+
+const CENSUS_STATE_ID = 'slack-public-channels:day-pages:census';
+
+function daySlug(first: string, last: string, day = '2026-08-13') {
+  const part = (iso: string) =>
+    (Date.parse(iso) / 1000).toFixed(6).replace('.', '-');
+  return `slack/T1/C1/${day}/${part(first)}-${part(last)}`;
+}
+
+function trackItem(slug: string) {
+  store.items.set(slug, {
+    collectorId: SLACK_DAY_PAGE_ITEMS_ID,
+    itemId: slug,
+    slug,
+  });
+}
+
+function page(slug: string) {
+  return { slug, title: 'day page', content: 'content' };
+}
+
+beforeEach(() => {
+  store.syncState.clear();
+  store.items.clear();
+  store.seeded = [];
+  store.listings = [];
+  store.listCalls = [];
+  store.connection = { baseUrl: 'http://brain.test', token: 'read' };
+});
+
+describe('parseSlackDayPageSlug', () => {
+  it('parses the channel-day prefix and the embedded range', () => {
+    const parsed = parseSlackDayPageSlug(
+      'slack/T1/C1/2026-08-13/1755079500-123456-1755080400-000001',
+    );
+
+    expect(parsed).not.toBeNull();
+    expect(parsed!.dayPrefix).toBe('slack/T1/C1/2026-08-13/');
+    expect(parsed!.firstKey).toBe(1755079500123456);
+    expect(parsed!.lastKey).toBe(1755080400000001);
+  });
+
+  it('rejects anything that is not a slack day page', () => {
+    expect(parseSlackDayPageSlug('notion/abc123')).toBeNull();
+    expect(parseSlackDayPageSlug('people/roomote-member-abc')).toBeNull();
+    // Namespace without the day/range tail (e.g. a hypothetical index page).
+    expect(parseSlackDayPageSlug('slack/T1/C1/2026-08-13')).toBeNull();
+    expect(parseSlackDayPageSlug('slack/T1/C1/2026-08-13/summary')).toBeNull();
+  });
+});
+
+describe('reconcileSlackDayPages', () => {
+  it('tracks every emitted page and retires only fully covered chunks', async () => {
+    const covered = daySlug('2026-08-13T10:10:00Z', '2026-08-13T10:50:00Z');
+    const reachesOut = daySlug('2026-08-13T09:00:00Z', '2026-08-13T10:50:00Z');
+    trackItem(covered);
+    trackItem(reachesOut);
+
+    const emitted = [
+      page(daySlug('2026-08-13T10:00:00Z', '2026-08-13T11:00:00Z')),
+    ];
+    const result = await reconcileSlackDayPages({
+      pages: emitted,
+      now: new Date('2026-08-19T00:00:00Z'),
+    });
+
+    expect(result.itemUpdates).toEqual([
+      {
+        collectorId: SLACK_DAY_PAGE_ITEMS_ID,
+        itemId: emitted[0]!.slug,
+        slug: emitted[0]!.slug,
+        lastSeenAt: new Date('2026-08-19T00:00:00Z'),
+      },
+    ]);
+    expect(result.pageRetirements).toEqual([
+      {
+        collectorId: SLACK_DAY_PAGE_ITEMS_ID,
+        itemId: covered,
+        slug: covered,
+      },
+    ]);
+  });
+
+  it('unions coverage across the chunks of one day', async () => {
+    // A busy day splits into several 200-message chunks; an old page inside
+    // the union is superseded even though no single chunk contains it.
+    const straddlesChunks = daySlug(
+      '2026-08-13T10:30:00Z',
+      '2026-08-13T11:30:00Z',
+    );
+    trackItem(straddlesChunks);
+
+    const result = await reconcileSlackDayPages({
+      pages: [
+        page(daySlug('2026-08-13T10:00:00Z', '2026-08-13T11:00:00Z')),
+        page(daySlug('2026-08-13T11:00:01Z', '2026-08-13T12:00:00Z')),
+      ],
+      now: new Date(),
+    });
+
+    expect(result.pageRetirements.map((r) => r.slug)).toEqual([
+      straddlesChunks,
+    ]);
+  });
+
+  it('never retires a page it just re-emitted', async () => {
+    const unchanged = daySlug('2026-08-13T10:00:00Z', '2026-08-13T11:00:00Z');
+    trackItem(unchanged);
+
+    const result = await reconcileSlackDayPages({
+      pages: [page(unchanged)],
+      now: new Date(),
+    });
+
+    expect(result.pageRetirements).toEqual([]);
+  });
+
+  it('leaves tracked rows it cannot parse alone', async () => {
+    // An inventory row from a future slug shape must not be deleted by an
+    // older reader that cannot prove coverage.
+    store.items.set('slack/T1/C1/2026-08-13/unparseable', {
+      collectorId: SLACK_DAY_PAGE_ITEMS_ID,
+      itemId: 'slack/T1/C1/2026-08-13/unparseable',
+      slug: 'slack/T1/C1/2026-08-13/unparseable',
+    });
+
+    const result = await reconcileSlackDayPages({
+      pages: [page(daySlug('2026-08-13T00:00:01Z', '2026-08-13T23:59:59Z'))],
+      now: new Date(),
+    });
+
+    expect(result.pageRetirements).toEqual([]);
+  });
+
+  it('does nothing for an empty emission', async () => {
+    trackItem(daySlug('2026-08-13T10:00:00Z', '2026-08-13T11:00:00Z'));
+
+    const result = await reconcileSlackDayPages({ pages: [], now: new Date() });
+
+    expect(result.itemUpdates).toEqual([]);
+    expect(result.pageRetirements).toEqual([]);
+  });
+});
+
+describe('runSlackDayPageCensus', () => {
+  function listingOf(count: number, baseMinutes: number) {
+    const base = Date.parse('2026-08-01T00:00:00Z') + baseMinutes * 60_000;
+    return Array.from({ length: count }, (_, index) => ({
+      slug: daySlug(
+        new Date(base + index * 60_000).toISOString(),
+        new Date(base + index * 60_000 + 30_000).toISOString(),
+        '2026-08-01',
+      ),
+    }));
+  }
+
+  it('seeds only slack day pages and completes on a short window', async () => {
+    store.listings = [
+      [
+        { slug: daySlug('2026-08-13T10:00:00Z', '2026-08-13T11:00:00Z') },
+        { slug: 'notion/abc123' },
+        { slug: 'people/roomote-member-abc' },
+        { slug: 'slack/T1/C1/2026-08-13/summary' },
+      ],
+    ];
+
+    await runSlackDayPageCensus();
+
+    expect(store.seeded.map((item) => item.slug)).toEqual([
+      daySlug('2026-08-13T10:00:00Z', '2026-08-13T11:00:00Z'),
+    ]);
+    expect(store.seeded[0]!.lastSeenAt).toEqual(new Date(0));
+    expect(await isSlackDayPageCensusComplete()).toBe(true);
+  });
+
+  it('pages with offset and persists the cursor between windows', async () => {
+    store.listings = [listingOf(100, 0), listingOf(37, 200)];
+
+    await runSlackDayPageCensus();
+
+    expect(store.listCalls.map((call) => call.offset)).toEqual([0, 100]);
+    expect(store.seeded).toHaveLength(137);
+    expect(store.syncState.get(CENSUS_STATE_ID)?.backfillCursor).toBeNull();
+    expect(await isSlackDayPageCensusComplete()).toBe(true);
+  });
+
+  it('resumes from the persisted cursor after an interrupted run', async () => {
+    store.syncState.set(CENSUS_STATE_ID, {
+      backfillCursor: JSON.stringify({ offset: 200 }),
+      backfillCompletedAt: null,
+    });
+    store.listings = [listingOf(10, 400)];
+
+    await runSlackDayPageCensus();
+
+    expect(store.listCalls.map((call) => call.offset)).toEqual([200]);
+    expect(await isSlackDayPageCensusComplete()).toBe(true);
+  });
+
+  it('completes with a partial inventory when the listing ignores offset', async () => {
+    const repeated = listingOf(100, 600);
+    store.listings = [repeated, repeated];
+
+    await runSlackDayPageCensus();
+
+    // Two identical full windows: seeding is idempotent and the census
+    // completes rather than walking the same window forever.
+    expect(store.listCalls).toHaveLength(2);
+    expect(store.items.size).toBe(100);
+    expect(await isSlackDayPageCensusComplete()).toBe(true);
+  });
+
+  it('stays incomplete without a read connection', async () => {
+    store.connection = null;
+
+    await runSlackDayPageCensus();
+
+    expect(store.listCalls).toHaveLength(0);
+    expect(await isSlackDayPageCensusComplete()).toBe(false);
+  });
+
+  it('never lists again once complete', async () => {
+    store.syncState.set(CENSUS_STATE_ID, {
+      backfillCursor: null,
+      backfillCompletedAt: new Date('2026-08-01T00:00:00Z'),
+    });
+
+    await runSlackDayPageCensus();
+
+    expect(store.listCalls).toHaveLength(0);
+  });
+});

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors.ts
@@ -14,12 +14,15 @@ import {
 import type {
   BrainCollector,
   BrainConnection,
+  BrainRetireSink,
   BrainSink,
   BrainTimelineSink,
   CollectorItemUpdate,
+  CollectorPageRetirement,
 } from './brain-collectors/contracts';
 import {
   appendBrainTimelineEvidence,
+  retireBrainPage,
   writeCollectorPages,
 } from './brain-collectors/write-pages';
 import { githubIssuesCollector } from './brain-collectors/github-issues';
@@ -52,6 +55,25 @@ async function persistCollectorItemUpdates(
 
   for (const [collectorId, items] of byCollector) {
     await upsertBrainCollectorItems(db, collectorId, items);
+  }
+}
+
+/**
+ * Soft-delete superseded pages, dropping each inventory row only once its
+ * page retirement succeeded. Row by row on purpose: a failure mid-list keeps
+ * every completed retirement durable, and the retire sink tolerates a page
+ * that is already gone, so the retry converges.
+ */
+async function retireCollectorPages(
+  retirements: CollectorPageRetirement[],
+  connection: BrainConnection,
+  retireSink: BrainRetireSink,
+): Promise<void> {
+  for (const retirement of retirements) {
+    await retireSink(retirement.slug, connection);
+    await deleteBrainCollectorItems(db, retirement.collectorId, [
+      retirement.itemId,
+    ]);
   }
 }
 
@@ -108,6 +130,7 @@ export async function runBrainCollectors(
   options: {
     sink?: BrainSink;
     timelineSink?: BrainTimelineSink;
+    retireSink?: BrainRetireSink;
     collectors?: BrainCollector[];
     /** Skip upstream incremental polls during fast historical continuation. */
     includeIncremental?: boolean;
@@ -115,6 +138,7 @@ export async function runBrainCollectors(
 ): Promise<BrainCollectorRunResult> {
   const sink = options.sink ?? postToBrain;
   const timelineSink = options.timelineSink ?? appendBrainTimelineEvidence;
+  const retireSink = options.retireSink ?? retireBrainPage;
   const collectors = options.collectors ?? BRAIN_COLLECTORS;
   const includeIncremental = options.includeIncremental ?? true;
   let backfillProgressed = false;
@@ -137,6 +161,7 @@ export async function runBrainCollectors(
           stateUpdates = [],
           itemUpdates = [],
           itemDeletes = [],
+          pageRetirements = [],
         } = await collector.collect({
           since: state?.watermark ?? null,
           now: new Date(),
@@ -158,15 +183,24 @@ export async function runBrainCollectors(
           );
         }
 
-        // Advance only after every page landed; a mid-batch failure leaves the
-        // watermark behind so the next tick retries the same idempotent slugs.
-        if (nextSince && !overshot) {
-          await upsertBrainSyncState(db, collector.id, {
-            watermark: nextSince,
-          });
-        }
-
         if (!overshot) {
+          // Retirements were computed against the full emission; on overshoot
+          // part of that emission never landed, so retiring would delete
+          // pages whose replacements do not exist yet. Superseded pages come
+          // out only after every superseding page is in — and before any
+          // watermark advances, so a failed retirement is recomputed from the
+          // same window next tick instead of being lost behind a checkpoint.
+          await retireCollectorPages(pageRetirements, connection, retireSink);
+
+          // Advance only after every page landed; a mid-batch failure leaves
+          // the watermark behind so the next tick retries the same
+          // idempotent slugs.
+          if (nextSince) {
+            await upsertBrainSyncState(db, collector.id, {
+              watermark: nextSince,
+            });
+          }
+
           await persistCollectorItemUpdates(itemUpdates);
           for (const deletion of itemDeletes) {
             await deleteBrainCollectorItems(
@@ -208,6 +242,7 @@ export async function runBrainCollectors(
             connection,
             sink,
             timelineSink,
+            retireSink,
           })) || backfillProgressed;
       }
     } catch (error) {
@@ -247,9 +282,17 @@ async function drainCollectorBackfill(input: {
   connection: BrainConnection;
   sink: BrainSink;
   timelineSink: BrainTimelineSink;
+  retireSink: BrainRetireSink;
 }): Promise<boolean> {
-  const { collectorId, backfill, startCursor, connection, sink, timelineSink } =
-    input;
+  const {
+    collectorId,
+    backfill,
+    startCursor,
+    connection,
+    sink,
+    timelineSink,
+    retireSink,
+  } = input;
   let cursor = startCursor;
   let budget = MAX_BACKFILL_PAGES_PER_COLLECTOR_PER_PASS;
   let steps = 0;
@@ -267,6 +310,11 @@ async function drainCollectorBackfill(input: {
     });
 
     await persistCollectorItemUpdates(step.itemUpdates ?? []);
+    await retireCollectorPages(
+      step.pageRetirements ?? [],
+      connection,
+      retireSink,
+    );
 
     budget -= step.pages.length;
     ingested += step.pages.length;

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/contracts.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/contracts.ts
@@ -32,12 +32,24 @@ export type CollectorItemDelete = {
   itemIds: string[];
 };
 
+/**
+ * A previously emitted page this pass supersedes. The engine soft-deletes it
+ * from the Brain (gbrain keeps a recovery window) and then drops its
+ * inventory row, only after this pass's own pages have landed.
+ */
+export type CollectorPageRetirement = {
+  collectorId: string;
+  itemId: string;
+  slug: string;
+};
+
 export type CollectorResult = {
   pages: CollectorPage[];
   nextSince: Date | null;
   stateUpdates?: CollectorStateUpdate[];
   itemUpdates?: CollectorItemUpdate[];
   itemDeletes?: CollectorItemDelete[];
+  pageRetirements?: CollectorPageRetirement[];
 };
 
 export interface BrainCollector {
@@ -54,6 +66,7 @@ export interface BrainCollector {
     nextCursor: string | null;
     done: boolean;
     itemUpdates?: CollectorItemUpdate[];
+    pageRetirements?: CollectorPageRetirement[];
   }>;
 }
 
@@ -66,5 +79,10 @@ export type BrainSink = (
 
 export type BrainTimelineSink = (
   evidence: EntityTimelineEvidence,
+  connection: BrainConnection,
+) => Promise<void>;
+
+export type BrainRetireSink = (
+  slug: string,
   connection: BrainConnection,
 ) => Promise<void>;

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/slack-day-page-inventory.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/slack-day-page-inventory.ts
@@ -1,0 +1,322 @@
+import {
+  callBrainTool,
+  extractBrainCorpusPages,
+  resolveBrainConnection,
+} from '@roomote/sdk/server';
+import {
+  db,
+  getBrainSyncState,
+  listBrainCollectorItemsBySlugPrefix,
+  seedBrainCollectorItems,
+  upsertBrainSyncState,
+} from '@roomote/db/server';
+import { brainNamespacePrefix } from '@roomote/types';
+
+import type {
+  CollectorItemUpdate,
+  CollectorPage,
+  CollectorPageRetirement,
+} from './contracts';
+
+const LOG_PREFIX = '[brainCollectors]';
+
+/**
+ * Slack day pages: slug inventory and retirement
+ * ----------------------------------------------
+ *
+ * A Slack day page's slug embeds the first/last message timestamps of the
+ * batch that emitted it, and batch boundaries depend on when past reads ran.
+ * That makes the pages immutable by construction — a later tick can never
+ * replace an earlier partial day — but it also means a replay mints DIFFERENT
+ * slugs for the same messages and leaves the old pages standing next to
+ * duplicates of their content. Healing therefore needs retirement, not
+ * replacement: know which slugs this collector emitted, and soft-delete the
+ * ones a re-read fully supersedes.
+ *
+ * Two pieces make that possible:
+ *
+ * 1. An inventory (brain_collector_items, itemId = slug) of every emitted day
+ *    page, written alongside the pages themselves. gbrain's `list_pages` has
+ *    no slug-prefix filter, so this local inventory is the only way to ask
+ *    "which pages exist for this channel-day".
+ * 2. A one-time census that walks gbrain's full page listing and seeds the
+ *    inventory with day pages emitted before tracking existed. Collection is
+ *    held until the census completes so a replay can never re-emit a day
+ *    while its legacy slugs are still invisible.
+ *
+ * Retirement itself is decided by RANGE COVERAGE, not by day re-emission
+ * alone: an old page is superseded only when the union of ranges emitted for
+ * its channel-day in one pass contains the old page's entire embedded range.
+ * One pass's messages for a day are a contiguous time slice (one bounded
+ * incremental window, or one Slack history cursor page), so containment
+ * proves every message the old page could describe was just re-read and
+ * re-emitted — or was deleted upstream. This is what keeps every hard case
+ * safe by construction:
+ *
+ * - Steady-state incremental ticks fetch disjoint windows, so they never
+ *   cover an earlier chunk's range and never retire anything.
+ * - A partial-day fetch (window opens mid-day, busy day spanning history
+ *   cursor pages) covers only its own slice; older chunks outside it stay.
+ * - A day Slack no longer serves (retention) re-emits nothing, covers
+ *   nothing, and retires nothing — pages holding history the API has lost
+ *   are deliberately kept.
+ */
+
+/**
+ * Inventory id for emitted Slack day pages. Deliberately NOT the versioned
+ * collector id: a version bump exists to replay and retire the pages the
+ * previous version emitted, so the inventory has to survive the bump.
+ */
+export const SLACK_DAY_PAGE_ITEMS_ID = 'slack-public-channels:day-pages';
+
+/** Upper bound on tracked pages considered per channel-day. */
+const SLACK_DAY_PAGE_TRACKED_LIMIT = 1_000;
+
+/**
+ * Microsecond-precision sort key for one half of a slug's timestamp range.
+ * Slack timestamps are "seconds.micros"; slugs store them with the dot
+ * replaced by a dash. Seconds since epoch times 1e6 stays far below
+ * Number.MAX_SAFE_INTEGER.
+ */
+function slackTsKey(seconds: string, fraction: string): number {
+  return (
+    Number(seconds) * 1_000_000 + Number(fraction.padEnd(6, '0').slice(0, 6))
+  );
+}
+
+type SlackDayPageSlugRange = {
+  /** Everything through the trailing slash: `slack/{team}/{channel}/{day}/`. */
+  dayPrefix: string;
+  firstKey: number;
+  lastKey: number;
+};
+
+/**
+ * Parse a Slack day-page slug's channel-day prefix and embedded timestamp
+ * range, or return null for anything that is not a day page (person pages,
+ * other namespaces, malformed slugs). The shape is
+ * `slack/{team}/{channel}/{YYYY-MM-DD}/{firstTs}-{lastTs}` with each ts's dot
+ * written as a dash.
+ */
+export function parseSlackDayPageSlug(
+  slug: string,
+): SlackDayPageSlugRange | null {
+  const match = slug.match(
+    /^(slack\/[^/]+\/[^/]+\/\d{4}-\d{2}-\d{2}\/)(\d+)-(\d+)-(\d+)-(\d+)$/,
+  );
+
+  if (!match) {
+    return null;
+  }
+
+  const firstKey = slackTsKey(match[2]!, match[3]!);
+  const lastKey = slackTsKey(match[4]!, match[5]!);
+
+  return Number.isFinite(firstKey) && Number.isFinite(lastKey)
+    ? { dayPrefix: match[1]!, firstKey, lastKey }
+    : null;
+}
+
+/**
+ * Inventory updates and retirements for one batch of freshly grouped day
+ * pages. `pages` must come from ONE contiguous fetch (an incremental window
+ * or one backfill history page) — contiguity is what lets the per-day union
+ * of emitted ranges stand in for "everything in this interval was re-read".
+ */
+export async function reconcileSlackDayPages(input: {
+  pages: CollectorPage[];
+  now: Date;
+}): Promise<{
+  itemUpdates: CollectorItemUpdate[];
+  pageRetirements: CollectorPageRetirement[];
+}> {
+  const itemUpdates = input.pages.map((page) => ({
+    collectorId: SLACK_DAY_PAGE_ITEMS_ID,
+    itemId: page.slug,
+    slug: page.slug,
+    lastSeenAt: input.now,
+  }));
+
+  const emitted = new Set(input.pages.map((page) => page.slug));
+  const coverage = new Map<string, { firstKey: number; lastKey: number }>();
+
+  for (const page of input.pages) {
+    const parsed = parseSlackDayPageSlug(page.slug);
+
+    if (!parsed) {
+      continue;
+    }
+
+    const existing = coverage.get(parsed.dayPrefix);
+    coverage.set(parsed.dayPrefix, {
+      firstKey: Math.min(
+        existing?.firstKey ?? parsed.firstKey,
+        parsed.firstKey,
+      ),
+      lastKey: Math.max(existing?.lastKey ?? parsed.lastKey, parsed.lastKey),
+    });
+  }
+
+  const pageRetirements: CollectorPageRetirement[] = [];
+
+  for (const [dayPrefix, range] of coverage) {
+    const tracked = await listBrainCollectorItemsBySlugPrefix(
+      db,
+      SLACK_DAY_PAGE_ITEMS_ID,
+      dayPrefix,
+      SLACK_DAY_PAGE_TRACKED_LIMIT,
+    );
+
+    for (const item of tracked) {
+      if (emitted.has(item.itemId)) {
+        continue;
+      }
+
+      const parsed = parseSlackDayPageSlug(item.itemId);
+
+      // Retire only when the old page's whole range was just re-read. A page
+      // reaching outside the emitted interval may describe messages this
+      // fetch never saw, so it stays even though its day was re-emitted.
+      if (
+        !parsed ||
+        parsed.firstKey < range.firstKey ||
+        parsed.lastKey > range.lastKey
+      ) {
+        continue;
+      }
+
+      pageRetirements.push({
+        collectorId: SLACK_DAY_PAGE_ITEMS_ID,
+        itemId: item.itemId,
+        slug: item.slug,
+      });
+    }
+  }
+
+  return { itemUpdates, pageRetirements };
+}
+
+const SLACK_DAY_PAGE_CENSUS_STATE_ID = 'slack-public-channels:day-pages:census';
+/** One `list_pages` window; gbrain caps `limit` at 100 regardless of ask. */
+const CENSUS_LISTING_WINDOW = 100;
+/** Windows per run, so one census pass cannot monopolize a collector tick. */
+const CENSUS_MAX_WINDOWS_PER_RUN = 200;
+const CENSUS_REQUEST_TIMEOUT_MS = 30_000;
+
+function parseCensusOffset(raw: string | null): number {
+  if (!raw) {
+    return 0;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as { offset?: unknown };
+
+    return typeof parsed.offset === 'number' && parsed.offset >= 0
+      ? Math.floor(parsed.offset)
+      : 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Whether the one-time inventory census has finished. Slack collection (both
+ * incremental and backfill) holds until it has: re-emitting a day before its
+ * legacy slugs are in the inventory would let those pages dodge retirement
+ * permanently, because nothing revisits a day after its watermark passes.
+ */
+export async function isSlackDayPageCensusComplete(): Promise<boolean> {
+  const state = await getBrainSyncState(db, SLACK_DAY_PAGE_CENSUS_STATE_ID);
+
+  return Boolean(state?.backfillCompletedAt);
+}
+
+/**
+ * Walk gbrain's full page listing once and seed the inventory with every
+ * Slack day page that predates item tracking. Paged with `offset` under a
+ * durable cursor, so a large corpus can span ticks; typically it completes in
+ * the first one. Seeding never overwrites rows the live collector already
+ * wrote. Corpus recreation wipes brain_sync_state, which re-arms this census
+ * against the fresh (empty) corpus automatically.
+ */
+export async function runSlackDayPageCensus(): Promise<void> {
+  const state = await getBrainSyncState(db, SLACK_DAY_PAGE_CENSUS_STATE_ID);
+
+  if (state?.backfillCompletedAt) {
+    return;
+  }
+
+  // The read-scoped connection, same as every other list_pages caller. The
+  // collectors' write scope is not known to include listing.
+  const connection = await resolveBrainConnection('agent');
+
+  if (!connection) {
+    console.warn(
+      `${LOG_PREFIX} slack day-page census has no read connection; slack collection stays held until one resolves`,
+    );
+    return;
+  }
+
+  let offset = parseCensusOffset(state?.backfillCursor ?? null);
+  let previousWindowKey: string | null = null;
+
+  for (let windows = 0; windows < CENSUS_MAX_WINDOWS_PER_RUN; windows++) {
+    const payloads = await callBrainTool(
+      connection,
+      'list_pages',
+      { limit: CENSUS_LISTING_WINDOW, offset },
+      { timeoutMs: CENSUS_REQUEST_TIMEOUT_MS },
+    );
+    const listed = extractBrainCorpusPages(payloads);
+    const windowKey = listed.map((page) => page.slug).join('\n');
+    const slackPrefix = brainNamespacePrefix('slack');
+    const dayPages = listed.filter(
+      (page) =>
+        page.slug.startsWith(slackPrefix) &&
+        parseSlackDayPageSlug(page.slug) !== null,
+    );
+
+    await seedBrainCollectorItems(
+      db,
+      SLACK_DAY_PAGE_ITEMS_ID,
+      dayPages.map((page) => ({
+        itemId: page.slug,
+        slug: page.slug,
+        // Epoch marks "known from the census, never seen by live collection".
+        lastSeenAt: new Date(0),
+      })),
+    );
+
+    if (windows > 0 && windowKey === previousWindowKey) {
+      // The server ignored `offset` and answered the first window again.
+      // Complete rather than spin: retirement only ever touches slugs that
+      // ARE in the inventory, so an incomplete census costs healing coverage
+      // for the unlisted pages, never safety.
+      console.warn(
+        `${LOG_PREFIX} slack day-page census: listing ignored offset; completing with a partial inventory`,
+      );
+      break;
+    }
+
+    if (listed.length < CENSUS_LISTING_WINDOW) {
+      break;
+    }
+
+    previousWindowKey = windowKey;
+    offset += listed.length;
+    await upsertBrainSyncState(db, SLACK_DAY_PAGE_CENSUS_STATE_ID, {
+      backfillCursor: JSON.stringify({ offset }),
+    });
+
+    if (windows === CENSUS_MAX_WINDOWS_PER_RUN - 1) {
+      // Out of window budget; the cursor above resumes next tick.
+      return;
+    }
+  }
+
+  await upsertBrainSyncState(db, SLACK_DAY_PAGE_CENSUS_STATE_ID, {
+    backfillCursor: null,
+    backfillCompletedAt: new Date(),
+  });
+  console.log(`${LOG_PREFIX} slack day-page census complete`);
+}

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/slack-day-page-inventory.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/slack-day-page-inventory.ts
@@ -203,19 +203,68 @@ const CENSUS_LISTING_WINDOW = 100;
 const CENSUS_MAX_WINDOWS_PER_RUN = 200;
 const CENSUS_REQUEST_TIMEOUT_MS = 30_000;
 
-function parseCensusOffset(raw: string | null): number {
+/**
+ * Durable census position. A raw listing offset would not survive concurrent
+ * writes: `list_pages` defaults to recency order, so pages written between
+ * windows shift every position and a resumed offset silently skips (or
+ * re-reads) rows — skips being the fatal case, because a skipped legacy slug
+ * is missing from the inventory forever and the census then reports itself
+ * complete. Instead the census walks `sort: 'updated_asc'` with an
+ * `updated_after` keyset, gbrain's own documented idiom for exhaustive
+ * pagination. Under ascending updated_at a row can only ever move LATER (its
+ * updated_at is monotonically non-decreasing), so anything that shifts out
+ * from under the cursor reappears ahead of it and deletions shift nothing:
+ * churn produces duplicate reads, never skips, and duplicate seeding is a
+ * no-op.
+ *
+ * `updated_after` is a strict > filter, so a cluster of pages sharing one
+ * updated_at (bulk imports stamp identical now() across a transaction) that
+ * is wider than one window cannot be crossed by timestamp alone. Inside such
+ * a cluster the walk holds `after` fixed and pages by `offset`, verifying an
+ * overlap row on each continuation so a cluster member re-stamped mid-walk
+ * (which shifts the remaining rows) restarts the cluster instead of skipping
+ * one.
+ */
+type SlackCensusCursor = {
+  /** Every page with updated_at at or before this boundary is inventoried. */
+  after: string | null;
+  /** Position inside one same-updated_at cluster wider than a window. */
+  offset: number;
+  /** Last slug seen in cluster mode; the continuation's overlap check. */
+  lastSlug: string | null;
+};
+
+const CENSUS_START: SlackCensusCursor = {
+  after: null,
+  offset: 0,
+  lastSlug: null,
+};
+
+function parseCensusCursor(raw: string | null): SlackCensusCursor {
   if (!raw) {
-    return 0;
+    return CENSUS_START;
   }
 
   try {
-    const parsed = JSON.parse(raw) as { offset?: unknown };
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
 
-    return typeof parsed.offset === 'number' && parsed.offset >= 0
-      ? Math.floor(parsed.offset)
-      : 0;
+    // Anything but this shape (including the pre-keyset `{offset}` cursor,
+    // whose position is not trustworthy) restarts the walk; re-seeding is
+    // idempotent.
+    if (typeof parsed.after !== 'string' && parsed.after !== null) {
+      return CENSUS_START;
+    }
+
+    return {
+      after: (parsed.after as string | null) ?? null,
+      offset:
+        typeof parsed.offset === 'number' && parsed.offset > 0
+          ? Math.floor(parsed.offset)
+          : 0,
+      lastSlug: typeof parsed.lastSlug === 'string' ? parsed.lastSlug : null,
+    };
   } catch {
-    return 0;
+    return CENSUS_START;
   }
 }
 
@@ -233,9 +282,10 @@ export async function isSlackDayPageCensusComplete(): Promise<boolean> {
 
 /**
  * Walk gbrain's full page listing once and seed the inventory with every
- * Slack day page that predates item tracking. Paged with `offset` under a
- * durable cursor, so a large corpus can span ticks; typically it completes in
- * the first one. Seeding never overwrites rows the live collector already
+ * Slack day page that predates item tracking. The walk is a keyset scan in
+ * updated_at order (see SlackCensusCursor for why a raw offset would skip
+ * rows under concurrent writes), durable across ticks; typically it completes
+ * in the first one. Seeding never overwrites rows the live collector already
  * wrote. Corpus recreation wipes brain_sync_state, which re-arms this census
  * against the fresh (empty) corpus automatically.
  */
@@ -257,18 +307,42 @@ export async function runSlackDayPageCensus(): Promise<void> {
     return;
   }
 
-  let offset = parseCensusOffset(state?.backfillCursor ?? null);
-  let previousWindowKey: string | null = null;
+  let cursor = parseCensusCursor(state?.backfillCursor ?? null);
+  let complete = false;
+  let partialReason: string | null = null;
 
   for (let windows = 0; windows < CENSUS_MAX_WINDOWS_PER_RUN; windows++) {
+    // Continuing inside a tie cluster re-reads the last seen row, so a
+    // cluster that shifted between windows (a member re-stamped and moved
+    // later) is detected instead of silently skipping its successor.
+    const overlapping = cursor.offset > 0 && cursor.lastSlug !== null;
+    const requestOffset = overlapping ? cursor.offset - 1 : cursor.offset;
     const payloads = await callBrainTool(
       connection,
       'list_pages',
-      { limit: CENSUS_LISTING_WINDOW, offset },
+      {
+        limit: CENSUS_LISTING_WINDOW,
+        sort: 'updated_asc',
+        ...(cursor.after ? { updated_after: cursor.after } : {}),
+        ...(requestOffset > 0 ? { offset: requestOffset } : {}),
+      },
       { timeoutMs: CENSUS_REQUEST_TIMEOUT_MS },
     );
-    const listed = extractBrainCorpusPages(payloads);
-    const windowKey = listed.map((page) => page.slug).join('\n');
+    let listed = extractBrainCorpusPages(payloads);
+    const windowFull = listed.length >= CENSUS_LISTING_WINDOW;
+
+    if (overlapping) {
+      if (listed[0]?.slug === cursor.lastSlug) {
+        listed = listed.slice(1);
+      } else {
+        cursor = { after: cursor.after, offset: 0, lastSlug: null };
+        await upsertBrainSyncState(db, SLACK_DAY_PAGE_CENSUS_STATE_ID, {
+          backfillCursor: JSON.stringify(cursor),
+        });
+        continue;
+      }
+    }
+
     const slackPrefix = brainNamespacePrefix('slack');
     const dayPages = listed.filter(
       (page) =>
@@ -287,31 +361,80 @@ export async function runSlackDayPageCensus(): Promise<void> {
       })),
     );
 
-    if (windows > 0 && windowKey === previousWindowKey) {
-      // The server ignored `offset` and answered the first window again.
-      // Complete rather than spin: retirement only ever touches slugs that
-      // ARE in the inventory, so an incomplete census costs healing coverage
-      // for the unlisted pages, never safety.
-      console.warn(
-        `${LOG_PREFIX} slack day-page census: listing ignored offset; completing with a partial inventory`,
+    if (!windowFull) {
+      complete = true;
+      break;
+    }
+
+    // Timestamps drive the keyset. A server that answers without them (or
+    // ignores the ascending sort, leaving nothing older than the window's
+    // last row) cannot be walked exhaustively; completing with what was
+    // seeded costs healing coverage for the unlisted pages, never safety —
+    // retirement only ever touches slugs that ARE in the inventory.
+    const lastAt = listed.at(-1)?.updatedAt ?? null;
+    const earlier = lastAt
+      ? listed.filter((page) => page.updatedAt && page.updatedAt < lastAt)
+      : [];
+    const someEarlier = Boolean(
+      lastAt &&
+      listed.some(
+        (page) =>
+          !page.updatedAt || page.updatedAt.getTime() !== lastAt.getTime(),
+      ),
+    );
+
+    let next: SlackCensusCursor;
+
+    if (!lastAt || (someEarlier && earlier.length === 0)) {
+      partialReason = 'listing is not walkable in updated_at order';
+      complete = true;
+      break;
+    } else if (someEarlier) {
+      // Advance the boundary to the last timestamp known to be fully seen
+      // and drop the window's trailing cluster: in ascending order every row
+      // older than the boundary sat inside this window. The trailing cluster
+      // is re-read (and idempotently re-seeded) from the new boundary.
+      const boundary = earlier.reduce((max, page) =>
+        page.updatedAt! > max.updatedAt! ? page : max,
       );
+      next = {
+        after: boundary.updatedAt!.toISOString(),
+        offset: 0,
+        lastSlug: null,
+      };
+    } else {
+      // The whole window shares one updated_at: a tie cluster wider than a
+      // window. Hold the boundary and page inside the cluster by offset.
+      next = {
+        after: cursor.after,
+        offset: cursor.offset + listed.length,
+        lastSlug: listed.at(-1)!.slug,
+      };
+    }
+
+    if (next.after === cursor.after && next.offset === cursor.offset) {
+      // No progress means the server ignored the keyset filter; walking
+      // further would loop on the same window forever.
+      partialReason = 'listing ignored the pagination cursor';
+      complete = true;
       break;
     }
 
-    if (listed.length < CENSUS_LISTING_WINDOW) {
-      break;
-    }
-
-    previousWindowKey = windowKey;
-    offset += listed.length;
+    cursor = next;
     await upsertBrainSyncState(db, SLACK_DAY_PAGE_CENSUS_STATE_ID, {
-      backfillCursor: JSON.stringify({ offset }),
+      backfillCursor: JSON.stringify(cursor),
     });
+  }
 
-    if (windows === CENSUS_MAX_WINDOWS_PER_RUN - 1) {
-      // Out of window budget; the cursor above resumes next tick.
-      return;
-    }
+  if (!complete) {
+    // Out of window budget; the persisted cursor resumes next tick.
+    return;
+  }
+
+  if (partialReason) {
+    console.warn(
+      `${LOG_PREFIX} slack day-page census: ${partialReason}; completing with a partial inventory`,
+    );
   }
 
   await upsertBrainSyncState(db, SLACK_DAY_PAGE_CENSUS_STATE_ID, {

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/slack-public-channels.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/slack-public-channels.ts
@@ -9,7 +9,9 @@ import { createSlackWebClient } from '@roomote/slack';
 
 import type {
   BrainCollector,
+  CollectorItemUpdate,
   CollectorPage,
+  CollectorPageRetirement,
   CollectorResult,
   CollectorStateUpdate,
 } from './contracts';
@@ -18,6 +20,10 @@ import {
   personIdentitySlug,
   type PersonIdentityReference,
 } from './identity';
+import {
+  isSlackDayPageCensusComplete,
+  reconcileSlackDayPages,
+} from './slack-day-page-inventory';
 
 const LOG_PREFIX = '[brainCollectors]';
 
@@ -358,6 +364,14 @@ async function collectSlackPublicChannelMessages(input: {
   now: Date;
   limit: number;
 }): Promise<CollectorResult> {
+  if (!(await isSlackDayPageCensusComplete())) {
+    // Emitting a day before its legacy slugs are in the inventory would let
+    // those pages dodge retirement forever, because nothing revisits a day
+    // once its watermark passes. Watermarks have not started, so holding
+    // costs ticks, never messages.
+    return { pages: [], nextSince: null };
+  }
+
   const userLabels = await loadSlackAuthorLabels();
   const installations = await db
     .select()
@@ -421,6 +435,8 @@ async function collectSlackPublicChannelMessages(input: {
 
   const pages: CollectorPage[] = [];
   const stateUpdates: CollectorStateUpdate[] = [];
+  const itemUpdates: CollectorItemUpdate[] = [];
+  const pageRetirements: CollectorPageRetirement[] = [];
   const nowMs = input.now.getTime();
 
   for (const entry of entriesWithState) {
@@ -533,6 +549,13 @@ async function collectSlackPublicChannelMessages(input: {
 
     pages.push(...channelPages);
 
+    const reconciliation = await reconcileSlackDayPages({
+      pages: channelPages,
+      now: input.now,
+    });
+    itemUpdates.push(...reconciliation.itemUpdates);
+    pageRetirements.push(...reconciliation.pageRetirements);
+
     if (complete) {
       stateUpdates.push({
         collectorId: entry.stateId,
@@ -541,7 +564,7 @@ async function collectSlackPublicChannelMessages(input: {
     }
   }
 
-  return { pages, nextSince: null, stateUpdates };
+  return { pages, nextSince: null, stateUpdates, itemUpdates, pageRetirements };
 }
 
 /** Deep backfill reaches back this far through channel history. */
@@ -609,9 +632,19 @@ async function backfillSlackHistoryStep(rawCursor: string | null): Promise<{
   pages: CollectorPage[];
   nextCursor: string | null;
   done: boolean;
+  itemUpdates?: CollectorItemUpdate[];
+  pageRetirements?: CollectorPageRetirement[];
 }> {
-  const userLabels = await loadSlackAuthorLabels();
   const noProgress = { pages: [], nextCursor: rawCursor, done: false };
+
+  if (!(await isSlackDayPageCensusComplete())) {
+    // Same hold as the incremental path: the deep backfill is the replay
+    // that heals old pages, and it must not re-emit a day while that day's
+    // legacy slugs are still invisible to retirement.
+    return noProgress;
+  }
+
+  const userLabels = await loadSlackAuthorLabels();
   const installations = await db
     .select()
     .from(slackInstallations)
@@ -736,6 +769,13 @@ async function backfillSlackHistoryStep(rawCursor: string | null): Promise<{
       userLabels,
     ),
   );
+  // One Slack history page is a contiguous time slice of the channel, which
+  // is exactly what the range-coverage retirement rule needs: a day chunk
+  // spanning two cursor pages stays until a pass covers its whole range.
+  const { itemUpdates, pageRetirements } = await reconcileSlackDayPages({
+    pages,
+    now: new Date(),
+  });
 
   if (nextSlackCursor) {
     return {
@@ -747,6 +787,8 @@ async function backfillSlackHistoryStep(rawCursor: string | null): Promise<{
         latest,
       }),
       done: false,
+      itemUpdates,
+      pageRetirements,
     };
   }
 
@@ -764,19 +806,22 @@ async function backfillSlackHistoryStep(rawCursor: string | null): Promise<{
       latest: null,
     }),
     done: false,
+    itemUpdates,
+    pageRetirements,
   };
 }
 
 /** Exported for the fake-Slack integration test, which drives it directly. */
 export const slackPublicChannelsCollector: BrainCollector = {
-  // Deliberately NOT version-bumped for the title-heading change: a page's
-  // slug embeds the first/last message timestamps of the batch that emitted
-  // it, and batch boundaries depend on when past incremental reads ran. A
-  // replay would group whole days at once, mint different slugs, and leave
-  // the old timestamp-titled pages standing next to duplicates of their
-  // content. Healing existing pages needs slug retirement (collector-item
-  // tracking plus a reconciliation sweep), not a replay.
-  id: 'slack-public-channels:entity-timeline-v2',
+  // v3 is the healing replay the title-heading change (#1486) could not have:
+  // back then a replay would have minted different slugs (batch boundaries
+  // depend on when past reads ran) and left the old timestamp-titled pages
+  // standing next to duplicates. With the day-page inventory, the census,
+  // and range-coverage retirement in place, the replay's re-emissions now
+  // retire the pages they supersede. Pages older than the 90-day backfill
+  // window are never re-read and deliberately stay: they may hold history
+  // Slack no longer serves.
+  id: 'slack-public-channels:entity-timeline-v3',
   displayName: 'Slack public channels',
   async isEnabled() {
     const installation = await db.query.slackInstallations.findFirst({

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/write-pages.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/write-pages.ts
@@ -1,4 +1,9 @@
-import { callBrainWriteTool, redactBrainText } from '../brain-outbox-drain';
+import {
+  callBrainWriteTool,
+  isBrainNotReady,
+  isBrainRateLimited,
+  redactBrainText,
+} from '../brain-outbox-drain';
 import type {
   BrainConnection,
   BrainSink,
@@ -6,6 +11,34 @@ import type {
   CollectorPage,
   EntityTimelineEvidence,
 } from './contracts';
+
+/**
+ * Soft-delete one superseded page via gbrain's `delete_page` (write scope;
+ * gbrain keeps a recovery window before the purge). Idempotent by design: a
+ * retirement pass that partially applied before a restart retries the same
+ * slugs, so a page that is already gone counts as retired. Backpressure keeps
+ * its type so the engine ends the pass instead of burying it.
+ */
+export async function retireBrainPage(
+  slug: string,
+  connection: BrainConnection,
+): Promise<void> {
+  try {
+    await callBrainWriteTool(connection, 'delete_page', { slug });
+  } catch (error) {
+    if (isBrainRateLimited(error) || isBrainNotReady(error)) {
+      throw error;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (/page_not_found|not[ _]found/i.test(message)) {
+      return;
+    }
+
+    throw error;
+  }
+}
 
 export async function appendBrainTimelineEvidence(
   evidence: EntityTimelineEvidence,

--- a/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
@@ -28,6 +28,7 @@ import {
 } from '@roomote/types';
 
 import { runBrainCollectors } from './brain-collectors';
+import { runSlackDayPageCensus } from './brain-collectors/slack-day-page-inventory';
 
 const LOG_PREFIX = '[brainOutboxDrain]';
 /** Sync-state key for the one-time task-history backfill. */
@@ -316,6 +317,19 @@ export async function brainCollectorsJob(): Promise<void> {
 
   if (!connection) {
     return;
+  }
+
+  try {
+    // Before any Slack collection: the one-time inventory census the Slack
+    // collector holds on. Running it here, ahead of the pass, normally
+    // completes it within the first tick after a deploy.
+    await runSlackDayPageCensus();
+  } catch (error) {
+    console.warn(
+      `${LOG_PREFIX} slack day-page census failed; slack collection stays held: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
   }
 
   let includeIncremental = true;

--- a/packages/db/src/lib/__tests__/brain.test.ts
+++ b/packages/db/src/lib/__tests__/brain.test.ts
@@ -24,6 +24,8 @@ import {
   deleteBrainCollectorItems,
   listBrainCollectorItems,
   listBrainCollectorItemsBefore,
+  listBrainCollectorItemsBySlugPrefix,
+  seedBrainCollectorItems,
   upsertBrainCollectorItems,
   upsertBrainSyncState,
 } from '../../server';
@@ -141,6 +143,82 @@ describe('Brain collector item inventory', () => {
     await deleteBrainCollectorItems(db, 'notion-pages', ['revoked']);
     const remaining = await listBrainCollectorItems(db, 'notion-pages', 100);
     expect(remaining.map((item) => item.itemId)).toEqual(['still-shared']);
+  });
+
+  it('seeding never overwrites a row the live collector already wrote', async () => {
+    const liveSeenAt = new Date('2026-08-15T00:00:00Z');
+    await upsertBrainCollectorItems(db, 'slack-public-channels:day-pages', [
+      {
+        itemId: 'slack/T1/C1/2026-08-13/1-0-2-0',
+        slug: 'slack/T1/C1/2026-08-13/1-0-2-0',
+        lastSeenAt: liveSeenAt,
+      },
+    ]);
+
+    await seedBrainCollectorItems(db, 'slack-public-channels:day-pages', [
+      {
+        itemId: 'slack/T1/C1/2026-08-13/1-0-2-0',
+        slug: 'slack/T1/C1/2026-08-13/1-0-2-0',
+        lastSeenAt: new Date(0),
+      },
+      {
+        itemId: 'slack/T1/C1/2026-08-12/3-0-4-0',
+        slug: 'slack/T1/C1/2026-08-12/3-0-4-0',
+        lastSeenAt: new Date(0),
+      },
+    ]);
+
+    const rows = await listBrainCollectorItems(
+      db,
+      'slack-public-channels:day-pages',
+      100,
+    );
+    expect(rows.map((row) => [row.itemId, row.lastSeenAt.getTime()])).toEqual([
+      ['slack/T1/C1/2026-08-12/3-0-4-0', 0],
+      ['slack/T1/C1/2026-08-13/1-0-2-0', liveSeenAt.getTime()],
+    ]);
+  });
+
+  it('lists items under a literal slug prefix', async () => {
+    await upsertBrainCollectorItems(db, 'slack-public-channels:day-pages', [
+      {
+        itemId: 'slack/T1/C1/2026-08-13/1-0-2-0',
+        slug: 'slack/T1/C1/2026-08-13/1-0-2-0',
+        lastSeenAt: new Date('2026-08-15T00:00:00Z'),
+      },
+      {
+        itemId: 'slack/T1/C1/2026-08-14/5-0-6-0',
+        slug: 'slack/T1/C1/2026-08-14/5-0-6-0',
+        lastSeenAt: new Date('2026-08-15T00:00:00Z'),
+      },
+      // LIKE metacharacters in the stored id must not widen the prefix.
+      {
+        itemId: 'slack/T_/C1/2026-08-13/7-0-8-0',
+        slug: 'slack/T_/C1/2026-08-13/7-0-8-0',
+        lastSeenAt: new Date('2026-08-15T00:00:00Z'),
+      },
+    ]);
+
+    const day = await listBrainCollectorItemsBySlugPrefix(
+      db,
+      'slack-public-channels:day-pages',
+      'slack/T1/C1/2026-08-13/',
+      100,
+    );
+    expect(day.map((item) => item.itemId)).toEqual([
+      'slack/T1/C1/2026-08-13/1-0-2-0',
+    ]);
+
+    // An underscore in the requested prefix matches itself, not any char.
+    const underscored = await listBrainCollectorItemsBySlugPrefix(
+      db,
+      'slack-public-channels:day-pages',
+      'slack/T_/',
+      100,
+    );
+    expect(underscored.map((item) => item.itemId)).toEqual([
+      'slack/T_/C1/2026-08-13/7-0-8-0',
+    ]);
   });
 });
 

--- a/packages/db/src/lib/brain.ts
+++ b/packages/db/src/lib/brain.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, inArray, lt, max, sql } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, like, lt, max, sql } from 'drizzle-orm';
 import { MISSING_MEMORY_EVENT_COUNT_CAP, RunStatus } from '@roomote/types';
 
 import { type DatabaseOrTransaction } from '../db';
@@ -32,6 +32,56 @@ export async function upsertBrainCollectorItems(
         updatedAt: sql`now()`,
       },
     });
+}
+
+/**
+ * Record inventory rows without touching ones that already exist. This is the
+ * census path: a one-time walk over the Brain's listing seeds pages emitted
+ * before item tracking existed, and must never overwrite the fresher
+ * lastSeenAt a live collector wrote for the same slug.
+ */
+export async function seedBrainCollectorItems(
+  database: DatabaseOrTransaction,
+  collectorId: string,
+  items: Array<{ itemId: string; slug: string; lastSeenAt: Date }>,
+): Promise<void> {
+  if (items.length === 0) {
+    return;
+  }
+
+  await database
+    .insert(brainCollectorItems)
+    .values(items.map((item) => ({ collectorId, ...item })))
+    .onConflictDoNothing({
+      target: [brainCollectorItems.collectorId, brainCollectorItems.itemId],
+    });
+}
+
+/**
+ * Inventory rows whose itemId starts with a literal prefix. gbrain's
+ * list_pages has no slug-prefix filter, so collectors that key items by slug
+ * (itemId = slug) use this local inventory to find the pages they previously
+ * emitted under a namespace, e.g. one Slack channel-day.
+ */
+export async function listBrainCollectorItemsBySlugPrefix(
+  database: DatabaseOrTransaction,
+  collectorId: string,
+  slugPrefix: string,
+  limit: number,
+): Promise<BrainCollectorItemRow[]> {
+  const literalPrefix = slugPrefix.replace(/[\\%_]/g, (char) => `\\${char}`);
+
+  return database
+    .select()
+    .from(brainCollectorItems)
+    .where(
+      and(
+        eq(brainCollectorItems.collectorId, collectorId),
+        like(brainCollectorItems.itemId, `${literalPrefix}%`),
+      ),
+    )
+    .orderBy(brainCollectorItems.itemId)
+    .limit(limit);
 }
 
 export async function listBrainCollectorItemsBefore(


### PR DESCRIPTION
Follow-up promised in #1486: Slack day-page slugs embed the emitting batch's timestamp range (`slack/{team}/{channel}/{day}/{firstTs}-{lastTs}`), so pages from the incremental era could never be corrected or superseded by replay — old timestamp-titled pages persist forever, and any future content-shape change hits the same wall.

## What this builds

**1. Slug inventory.** The `slack-public-channels` collector now records every emitted day-page slug as a `brain_collector_items` row (the mechanism `notion-pages` already uses; `itemId` = slug). The inventory lives under an unversioned id (`slack-public-channels:day-pages`) so it survives collector version bumps — a bump exists precisely to retire the previous version's pages.

**2. One-time census.** Pages emitted before tracking existed have no inventory rows, and gbrain's `list_pages` has no slug-prefix filter, so a one-time census walks the full listing (offset-paged, durable cursor, resumable across ticks) and seeds legacy day pages into the inventory with `ON CONFLICT DO NOTHING`. Slack collection (incremental and backfill) holds until the census completes, so a replay can never re-emit a day while that day's legacy slugs are still invisible to retirement. It runs at the top of the collectors job and typically finishes in the first tick.

**3. Range-coverage retirement.** When a pass re-emits pages for a channel-day, tracked pages for that day that were not re-emitted are soft-deleted via gbrain `delete_page` (write scope, recovery window) — but **only when the old page's entire embedded timestamp range is contained in the union of ranges just emitted for that day**. One pass's messages for a day are a contiguous time slice, so containment proves everything the old page could describe was just re-read. That single rule makes the hard cases safe by construction:

- Steady-state incremental ticks fetch disjoint windows → never retire anything.
- A partial-day fetch (window opens mid-day; busy day spanning Slack cursor pages) covers only its own slice → older chunks outside it stay.
- A day Slack no longer serves (retention) re-emits nothing → its pages stay; we never delete content we cannot re-fetch.
- An unchanged re-read reproduces the identical slug → refreshed, not retired.

The engine gains a `retireSink` (default: `delete_page`, tolerant of already-deleted pages) that runs after a batch's pages land and **before any watermark or cursor advances**; each inventory row is dropped only after its page retirement succeeds, so a mid-pass failure replays the same window and converges. Retirements are held on page-cap overshoot, since part of the superseding emission never landed.

**4. The version bump (v2 → v3).** With the rails above in place, this PR bumps the collector id, which resets its watermarks and deep-backfill cursor and triggers the healing replay.

## Operational notes

- Merging causes a **one-time re-read of the last 90 days of Slack history per deployment**, paced by the existing per-pass page/step budgets and Brain backpressure handling. Expect collector churn (re-embeds plus soft-deleted duplicates) while it drains.
- Pages older than the 90-day backfill window are never re-read and deliberately stay, timestamp titles and all — they may hold history Slack no longer serves.
- Known conservative leak: a legacy chunk straddling a coverage boundary (e.g. the incremental/backfill seam, or a busy day's Slack cursor page boundary) is never fully covered by one pass and survives as a duplicate. Safe by design; rare in practice.

## Tests

- Fake-Slack integration harness now applies retirements/inventory the way the engine would, and adds: census hold, steady-state-never-retires, the full incremental-era → bump → heal scenario, outside-range and empty-day conservation, and a deep-backfill replay case.
- New unit suite for slug parsing, reconciliation (union coverage, re-emitted slug, unparseable rows), and the census (paging, resume, offset-ignored guard, no-connection hold).
- Engine tests for retirement ordering, overshoot/page-failure holds, retry-after-failed-retirement (incremental and backfill), and `delete_page` error classification.
- Real-DB tests for the new `seedBrainCollectorItems` and `listBrainCollectorItemsBySlugPrefix` helpers (including LIKE-metacharacter escaping).