### PR TITLE
[Fix] Discord commands silently fail when TRPC_URL carries a path prefix

### DIFF
--- a/.changeset/discord-events-api-prefix.md
+++ b/.changeset/discord-events-api-prefix.md
@@ -1,0 +1,5 @@
+---
+"@roomote/bullmq": patch
+---
+
+Fix Discord commands silently failing on self-hosted installs that serve the API under a path prefix. The queue worker built its `/api/internal/discord/events/process` URL with `new URL(path, base)`, which discards the prefix in the installer default `TRPC_URL` of `https://<domain>/_roomote-api`, so events were routed to the web app instead of the API. The endpoint is now appended to the configured base URL, and the worker requires the API's JSON acknowledgement before marking a job complete, so a misrouted request fails visibly rather than passing as success.

--- a/.changeset/discord-events-api-prefix.md
+++ b/.changeset/discord-events-api-prefix.md
@@ -2,4 +2,4 @@
 "@roomote/bullmq": patch
 ---
 
-Fix Discord commands silently failing on self-hosted installs that serve the API under a path prefix. The queue worker built its `/api/internal/discord/events/process` URL with `new URL(path, base)`, which discards the prefix in the installer default `TRPC_URL` of `https://<domain>/_roomote-api`, so events were routed to the web app instead of the API. The endpoint is now appended to the configured base URL, and the worker requires the API's JSON acknowledgement before marking a job complete, so a misrouted request fails visibly rather than passing as success.
+Fix Discord commands silently failing on self-hosted installs that serve the API under a path prefix. The queue worker built its `/api/internal/discord/events/process` URL with `new URL(path, base)`, which discards the prefix in the installer default `TRPC_URL` of `https://<domain>/_roomote-api`, so events were routed to the web app instead of the API and every command completed as a no-op. The endpoint is now appended to the configured base URL.

--- a/apps/bullmq/src/discord-gateway-events-queue.test.ts
+++ b/apps/bullmq/src/discord-gateway-events-queue.test.ts
@@ -19,6 +19,13 @@ vi.mock('@roomote/sdk/server', () => ({
   DISCORD_GATEWAY_EVENTS_QUEUE_NAME: 'discord-gateway-events',
 }));
 
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
 import { processDiscordGatewayEventJob } from './discord-gateway-events-queue';
 
 const event = {
@@ -44,7 +51,7 @@ describe('processDiscordGatewayEventJob', () => {
   });
 
   it('posts the event to the internal processing endpoint with gateway auth', async () => {
-    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }));
 
     await processDiscordGatewayEventJob({ data: event } as Job<typeof event>);
 
@@ -63,7 +70,9 @@ describe('processDiscordGatewayEventJob', () => {
   });
 
   it('treats an already completed event as successful', async () => {
-    fetchMock.mockResolvedValue(new Response(null, { status: 409 }));
+    fetchMock.mockResolvedValue(
+      jsonResponse({ ok: true, duplicate: true }, 409),
+    );
 
     await expect(
       processDiscordGatewayEventJob({ data: event } as Job<typeof event>),
@@ -84,6 +93,64 @@ describe('processDiscordGatewayEventJob', () => {
     await expect(
       processDiscordGatewayEventJob({ data: event } as Job<typeof event>),
     ).rejects.toThrow('HTTP 425');
+  });
+
+  it('preserves a TRPC_URL path prefix without a trailing slash', async () => {
+    envMock.TRPC_URL = 'https://roomote.example.com/_roomote-api';
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }));
+
+    await processDiscordGatewayEventJob({ data: event } as Job<typeof event>);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://roomote.example.com/_roomote-api/api/internal/discord/events/process',
+      expect.any(Object),
+    );
+  });
+
+  it('preserves a TRPC_URL path prefix with a trailing slash', async () => {
+    envMock.TRPC_URL = 'https://roomote.example.com/_roomote-api/';
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }));
+
+    await processDiscordGatewayEventJob({ data: event } as Job<typeof event>);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://roomote.example.com/_roomote-api/api/internal/discord/events/process',
+      expect.any(Object),
+    );
+  });
+
+  it('throws when a misrouted request answers 200 with an HTML page', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('<!DOCTYPE html><title>404</title>', {
+        status: 200,
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      }),
+    );
+
+    await expect(
+      processDiscordGatewayEventJob({ data: event } as Job<typeof event>),
+    ).rejects.toThrow('non-JSON HTTP 200 response');
+  });
+
+  it('throws when a 2xx response carries an unreadable acknowledgement', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('not json', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    await expect(
+      processDiscordGatewayEventJob({ data: event } as Job<typeof event>),
+    ).rejects.toThrow('unreadable HTTP 200 acknowledgement');
+  });
+
+  it('throws when a 2xx acknowledgement reports failure', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ ok: false, error: 'nope' }));
+
+    await expect(
+      processDiscordGatewayEventJob({ data: event } as Job<typeof event>),
+    ).rejects.toThrow('reported failure in its HTTP 200 acknowledgement');
   });
 
   it('fails fast when the worker API URL is missing', async () => {

--- a/apps/bullmq/src/discord-gateway-events-queue.test.ts
+++ b/apps/bullmq/src/discord-gateway-events-queue.test.ts
@@ -19,13 +19,6 @@ vi.mock('@roomote/sdk/server', () => ({
   DISCORD_GATEWAY_EVENTS_QUEUE_NAME: 'discord-gateway-events',
 }));
 
-function jsonResponse(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'content-type': 'application/json' },
-  });
-}
-
 import { processDiscordGatewayEventJob } from './discord-gateway-events-queue';
 
 const event = {
@@ -51,7 +44,7 @@ describe('processDiscordGatewayEventJob', () => {
   });
 
   it('posts the event to the internal processing endpoint with gateway auth', async () => {
-    fetchMock.mockResolvedValue(jsonResponse({ ok: true }));
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
 
     await processDiscordGatewayEventJob({ data: event } as Job<typeof event>);
 
@@ -70,9 +63,7 @@ describe('processDiscordGatewayEventJob', () => {
   });
 
   it('treats an already completed event as successful', async () => {
-    fetchMock.mockResolvedValue(
-      jsonResponse({ ok: true, duplicate: true }, 409),
-    );
+    fetchMock.mockResolvedValue(new Response(null, { status: 409 }));
 
     await expect(
       processDiscordGatewayEventJob({ data: event } as Job<typeof event>),
@@ -97,7 +88,7 @@ describe('processDiscordGatewayEventJob', () => {
 
   it('preserves a TRPC_URL path prefix without a trailing slash', async () => {
     envMock.TRPC_URL = 'https://roomote.example.com/_roomote-api';
-    fetchMock.mockResolvedValue(jsonResponse({ ok: true }));
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
 
     await processDiscordGatewayEventJob({ data: event } as Job<typeof event>);
 
@@ -109,7 +100,7 @@ describe('processDiscordGatewayEventJob', () => {
 
   it('preserves a TRPC_URL path prefix with a trailing slash', async () => {
     envMock.TRPC_URL = 'https://roomote.example.com/_roomote-api/';
-    fetchMock.mockResolvedValue(jsonResponse({ ok: true }));
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
 
     await processDiscordGatewayEventJob({ data: event } as Job<typeof event>);
 
@@ -117,63 +108,6 @@ describe('processDiscordGatewayEventJob', () => {
       'https://roomote.example.com/_roomote-api/api/internal/discord/events/process',
       expect.any(Object),
     );
-  });
-
-  it('throws when a misrouted request answers 200 with an HTML page', async () => {
-    fetchMock.mockResolvedValue(
-      new Response('<!DOCTYPE html><title>404</title>', {
-        status: 200,
-        headers: { 'content-type': 'text/html; charset=utf-8' },
-      }),
-    );
-
-    await expect(
-      processDiscordGatewayEventJob({ data: event } as Job<typeof event>),
-    ).rejects.toThrow('non-JSON HTTP 200 response');
-  });
-
-  it('throws when a 2xx response carries an unreadable acknowledgement', async () => {
-    fetchMock.mockResolvedValue(
-      new Response('not json', {
-        status: 200,
-        headers: { 'content-type': 'application/json' },
-      }),
-    );
-
-    await expect(
-      processDiscordGatewayEventJob({ data: event } as Job<typeof event>),
-    ).rejects.toThrow('unreadable HTTP 200 acknowledgement');
-  });
-
-  it('throws when a 2xx acknowledgement reports failure', async () => {
-    fetchMock.mockResolvedValue(jsonResponse({ ok: false, error: 'nope' }));
-
-    await expect(
-      processDiscordGatewayEventJob({ data: event } as Job<typeof event>),
-    ).rejects.toThrow('did not acknowledge HTTP 200 with ok: true');
-  });
-
-  it.each([
-    ['an empty object', {}],
-    ['an unrelated JSON body', { status: 'ok' }],
-    ['a non-boolean ok field', { ok: 'true' }],
-  ])(
-    'throws when a misrouted 2xx answers with %s',
-    async (_label, body: unknown) => {
-      fetchMock.mockResolvedValue(jsonResponse(body));
-
-      await expect(
-        processDiscordGatewayEventJob({ data: event } as Job<typeof event>),
-      ).rejects.toThrow('did not acknowledge HTTP 200 with ok: true');
-    },
-  );
-
-  it('throws when a 409 duplicate answers without ok: true', async () => {
-    fetchMock.mockResolvedValue(jsonResponse({ duplicate: true }, 409));
-
-    await expect(
-      processDiscordGatewayEventJob({ data: event } as Job<typeof event>),
-    ).rejects.toThrow('did not acknowledge HTTP 409 with ok: true');
   });
 
   it('fails fast when the worker API URL is missing', async () => {

--- a/apps/bullmq/src/discord-gateway-events-queue.test.ts
+++ b/apps/bullmq/src/discord-gateway-events-queue.test.ts
@@ -150,7 +150,30 @@ describe('processDiscordGatewayEventJob', () => {
 
     await expect(
       processDiscordGatewayEventJob({ data: event } as Job<typeof event>),
-    ).rejects.toThrow('reported failure in its HTTP 200 acknowledgement');
+    ).rejects.toThrow('did not acknowledge HTTP 200 with ok: true');
+  });
+
+  it.each([
+    ['an empty object', {}],
+    ['an unrelated JSON body', { status: 'ok' }],
+    ['a non-boolean ok field', { ok: 'true' }],
+  ])(
+    'throws when a misrouted 2xx answers with %s',
+    async (_label, body: unknown) => {
+      fetchMock.mockResolvedValue(jsonResponse(body));
+
+      await expect(
+        processDiscordGatewayEventJob({ data: event } as Job<typeof event>),
+      ).rejects.toThrow('did not acknowledge HTTP 200 with ok: true');
+    },
+  );
+
+  it('throws when a 409 duplicate answers without ok: true', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ duplicate: true }, 409));
+
+    await expect(
+      processDiscordGatewayEventJob({ data: event } as Job<typeof event>),
+    ).rejects.toThrow('did not acknowledge HTTP 409 with ok: true');
   });
 
   it('fails fast when the worker API URL is missing', async () => {

--- a/apps/bullmq/src/discord-gateway-events-queue.ts
+++ b/apps/bullmq/src/discord-gateway-events-queue.ts
@@ -4,6 +4,7 @@ import { resolveDiscordGatewaySecret } from '@roomote/db/server';
 import { Env } from '@roomote/env';
 import type { DiscordGatewayEvent } from '@roomote/communication/discord-event';
 import { DISCORD_GATEWAY_EVENTS_QUEUE_NAME } from '@roomote/sdk/server';
+import { resolveApiUrl } from '@roomote/types';
 
 import { getRedis } from './redis';
 
@@ -15,10 +16,37 @@ function processUrl(): string {
     throw new Error('TRPC_URL is required to process Discord gateway events');
   }
 
-  return new URL(
-    '/api/internal/discord/events/process',
-    Env.TRPC_URL,
-  ).toString();
+  // TRPC_URL may carry a path prefix — the self-hosted installer default is
+  // `https://<domain>/_roomote-api`, which the edge strips before proxying to
+  // the API. The endpoint has to be appended to that prefix, not resolved
+  // against it, or the request misses the API route entirely.
+  return resolveApiUrl(Env.TRPC_URL, '/api/internal/discord/events/process');
+}
+
+// A misrouted request can still answer 2xx: an edge that does not recognize the
+// API prefix falls through to the web app, whose not-found page is HTML with a
+// 200 status. Requiring the API's JSON acknowledgement keeps that from
+// completing the job as if the event had been handled.
+async function assertProcessingAcknowledged(response: Response): Promise<void> {
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!contentType.toLowerCase().includes('application/json')) {
+    throw new Error(
+      `Discord event processing returned a non-JSON HTTP ${response.status} response (content-type: ${contentType || 'none'})`,
+    );
+  }
+
+  const acknowledgement: unknown = await response.json().catch(() => undefined);
+  if (typeof acknowledgement !== 'object' || acknowledgement === null) {
+    throw new Error(
+      `Discord event processing returned an unreadable HTTP ${response.status} acknowledgement`,
+    );
+  }
+
+  if ((acknowledgement as { ok?: unknown }).ok === false) {
+    throw new Error(
+      `Discord event processing reported failure in its HTTP ${response.status} acknowledgement`,
+    );
+  }
 }
 
 export async function processDiscordGatewayEventJob(
@@ -43,7 +71,10 @@ export async function processDiscordGatewayEventJob(
 
   // A completed event can outlive its retained BullMQ job. The API's durable
   // idempotency gate reports that state as a conflict, which is successful work.
-  if (response.ok || response.status === 409) return;
+  if (response.ok || response.status === 409) {
+    await assertProcessingAcknowledged(response);
+    return;
+  }
 
   throw new Error(
     `Discord event processing failed with HTTP ${response.status}`,

--- a/apps/bullmq/src/discord-gateway-events-queue.ts
+++ b/apps/bullmq/src/discord-gateway-events-queue.ts
@@ -23,36 +23,6 @@ function processUrl(): string {
   return resolveApiUrl(Env.TRPC_URL, '/api/internal/discord/events/process');
 }
 
-// A misrouted request can still answer 2xx: an edge that does not recognize the
-// API prefix falls through to a catch-all, and the web app's not-found page is
-// HTML with a 200 status. Other topologies front the deployment with proxies
-// that answer JSON, so a JSON content type alone does not prove the request
-// reached the API. Every success and duplicate path of `/events/process`
-// answers `{ ok: true, ... }`, so require exactly that: a handler return that
-// ever stops matching fails loudly through the queue's retries, which is the
-// safe direction to fail when the alternative is completing events silently.
-async function assertProcessingAcknowledged(response: Response): Promise<void> {
-  const contentType = response.headers.get('content-type') ?? '';
-  if (!contentType.toLowerCase().includes('application/json')) {
-    throw new Error(
-      `Discord event processing returned a non-JSON HTTP ${response.status} response (content-type: ${contentType || 'none'})`,
-    );
-  }
-
-  const acknowledgement: unknown = await response.json().catch(() => undefined);
-  if (typeof acknowledgement !== 'object' || acknowledgement === null) {
-    throw new Error(
-      `Discord event processing returned an unreadable HTTP ${response.status} acknowledgement`,
-    );
-  }
-
-  if ((acknowledgement as { ok?: unknown }).ok !== true) {
-    throw new Error(
-      `Discord event processing did not acknowledge HTTP ${response.status} with ok: true`,
-    );
-  }
-}
-
 export async function processDiscordGatewayEventJob(
   job: Job<DiscordGatewayEvent>,
 ): Promise<void> {
@@ -75,10 +45,7 @@ export async function processDiscordGatewayEventJob(
 
   // A completed event can outlive its retained BullMQ job. The API's durable
   // idempotency gate reports that state as a conflict, which is successful work.
-  if (response.ok || response.status === 409) {
-    await assertProcessingAcknowledged(response);
-    return;
-  }
+  if (response.ok || response.status === 409) return;
 
   throw new Error(
     `Discord event processing failed with HTTP ${response.status}`,

--- a/apps/bullmq/src/discord-gateway-events-queue.ts
+++ b/apps/bullmq/src/discord-gateway-events-queue.ts
@@ -24,9 +24,13 @@ function processUrl(): string {
 }
 
 // A misrouted request can still answer 2xx: an edge that does not recognize the
-// API prefix falls through to the web app, whose not-found page is HTML with a
-// 200 status. Requiring the API's JSON acknowledgement keeps that from
-// completing the job as if the event had been handled.
+// API prefix falls through to a catch-all, and the web app's not-found page is
+// HTML with a 200 status. Other topologies front the deployment with proxies
+// that answer JSON, so a JSON content type alone does not prove the request
+// reached the API. Every success and duplicate path of `/events/process`
+// answers `{ ok: true, ... }`, so require exactly that: a handler return that
+// ever stops matching fails loudly through the queue's retries, which is the
+// safe direction to fail when the alternative is completing events silently.
 async function assertProcessingAcknowledged(response: Response): Promise<void> {
   const contentType = response.headers.get('content-type') ?? '';
   if (!contentType.toLowerCase().includes('application/json')) {
@@ -42,9 +46,9 @@ async function assertProcessingAcknowledged(response: Response): Promise<void> {
     );
   }
 
-  if ((acknowledgement as { ok?: unknown }).ok === false) {
+  if ((acknowledgement as { ok?: unknown }).ok !== true) {
     throw new Error(
-      `Discord event processing reported failure in its HTTP ${response.status} acknowledgement`,
+      `Discord event processing did not acknowledge HTTP ${response.status} with ok: true`,
     );
   }
 }

--- a/packages/types/src/api-url.test.ts
+++ b/packages/types/src/api-url.test.ts
@@ -1,0 +1,36 @@
+import { resolveApiUrl } from './api-url';
+
+describe('resolveApiUrl', () => {
+  it('appends the path to a bare origin', () => {
+    expect(resolveApiUrl('http://api:3001', '/api/webhooks/github')).toBe(
+      'http://api:3001/api/webhooks/github',
+    );
+  });
+
+  it('preserves a path prefix that carries no trailing slash', () => {
+    expect(
+      resolveApiUrl('https://roomote.example.com/_roomote-api', '/api/status'),
+    ).toBe('https://roomote.example.com/_roomote-api/api/status');
+  });
+
+  it('collapses trailing slashes on the base URL', () => {
+    expect(
+      resolveApiUrl(
+        'https://roomote.example.com/_roomote-api///',
+        '/api/status',
+      ),
+    ).toBe('https://roomote.example.com/_roomote-api/api/status');
+  });
+
+  it('accepts a path without a leading slash', () => {
+    expect(
+      resolveApiUrl('https://roomote.example.com/_roomote-api', 'api/status'),
+    ).toBe('https://roomote.example.com/_roomote-api/api/status');
+  });
+
+  it('keeps an explicit port', () => {
+    expect(resolveApiUrl('https://roomote.fly.dev:8443', '/api/status')).toBe(
+      'https://roomote.fly.dev:8443/api/status',
+    );
+  });
+});

--- a/packages/types/src/api-url.ts
+++ b/packages/types/src/api-url.ts
@@ -1,0 +1,27 @@
+/**
+ * Joins an API endpoint path onto a configured base URL, preserving any path
+ * prefix the base carries.
+ *
+ * `new URL(path, base)` is the wrong tool here: it resolves `path` against
+ * `base` as a *document* URL, so unless `base` ends in `/` its last segment is
+ * replaced rather than kept. Deployments that reverse-proxy the API under a
+ * prefix — the self-hosted installer default is
+ * `https://<domain>/_roomote-api` — lose that prefix and the request silently
+ * lands on whatever the edge routes as its catch-all.
+ */
+export function resolveApiUrl(baseUrl: string, path: string): string {
+  const normalizedBaseUrl = normalizeApiBaseUrl(baseUrl);
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+
+  return `${normalizedBaseUrl}${normalizedPath}`;
+}
+
+/** Trims trailing slashes so a base URL can be concatenated with a path. */
+function normalizeApiBaseUrl(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47 /* / */) {
+    end -= 1;
+  }
+
+  return value.slice(0, end);
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,6 +1,7 @@
 export * from './compute-providers';
 
 export * from './acp';
+export * from './api-url';
 export * from './auth';
 export * from './automation-label';
 export * from './background-agents';


### PR DESCRIPTION
## Related issue

Fixes #1456

## Why this PR exists

- [ ] A maintainer explicitly invited this PR in the linked issue or discussion
- [x] I am a maintainer / this is internal Roomote work

## What changed

Every Discord command silently no-ops on a standard self-hosted install. `/link`, `/new`, `/goal`, `/fast`, `/help`, and task-thread replies all time out with "The application did not respond," and nothing is logged anywhere.

The BullMQ worker that forwards gateway events to the API built its URL like this:

```ts
new URL('/api/internal/discord/events/process', Env.TRPC_URL)
```

`new URL(path, base)` resolves `path` against `base` as a *document* URL, so unless `base` ends in a slash its last segment is replaced rather than kept. The installer sets `TRPC_URL` to `https://<domain>/_roomote-api` (and `docker-compose.prod.yml` falls back to the same shape), so `/_roomote-api` was dropped on every standard install.

The resulting URL then missed Caddy's `/_roomote-api/*` rule, fell through to the catch-all, and hit the **web** container instead of **api** — collecting Next.js's not-found page, which answers **HTTP 200**. The worker treated any `response.ok` as success, so the job completed normally with zero retries and no error. The real handler never ran.

This PR appends the endpoint to the configured base URL instead of resolving against it, so a path prefix survives with or without a trailing slash. Direct origins like `http://api:3001` and explicit ports like `https://<app>.fly.dev:8443` are unaffected.

The join itself lives in a new `resolveApiUrl` in `@roomote/types`. Four private copies of this normalization already existed (`sdk/client`, `discord-gateway/config`, `cloud-agents/shared-utils`, `web/api/webhooks`) and none was importable from `apps/bullmq`, so new call sites now have a canonical home. Existing ones are deliberately left alone.

No installer, Compose, Caddy, or self-hosting docs changes: `https://<domain>/_roomote-api` was always the intended value, and it works once the client stops discarding the prefix.

Two related notes for reviewers, both deliberately out of scope here:

- `getGitHubWebhookUrl` (`apps/web/src/trpc/commands/github/mutations.ts`) and `getSourceControlWebhookUrl` (`apps/web/src/trpc/commands/source-control/index.ts`) use the same `new URL(path, base)` shape and also drop the prefix. They are not broken, because `apps/web/src/app/api/webhooks/[...path]/route.ts` proxies `/api/webhooks/*` back to the API and handles the prefix correctly — so "fixing" them would double-prefix.
- The issue's suggested workaround of setting `TRPC_URL` to an internal address is worse than the bug. Both webhook builders fall back to the public URL only when the host is loopback (`localhost`, `*.localhost`, `127.x`), so a Docker service name registers webhooks at an unreachable URL. The safe stopgap before this lands is a trailing slash: `TRPC_URL=https://<domain>/_roomote-api/`.

An earlier revision of this PR also hardened the worker to reject a 2xx that isn't the API's `ok: true` acknowledgement, so that a *future* misroute would fail loudly instead of silently. That was defense-in-depth rather than part of this fix, and it coupled worker success to an invariant the handler's return type does not enforce, so it has been removed to keep this PR to the one change.

## How it was tested

Added regression coverage:

- `packages/types/src/api-url.test.ts` — bare origin, prefix without a trailing slash, collapsed trailing slashes, path without a leading slash, explicit port.
- `apps/bullmq/src/discord-gateway-events-queue.test.ts` — a prefixed `TRPC_URL` both with and without a trailing slash produces the correct URL. The existing 200/409/425/503 and missing-`TRPC_URL` cases are unchanged.

CI is green on this branch, including the `Test`, `Type Check`, `Lint`, and `Knip` gates.

## Checklist

- [x] The PR title follows the repo convention
- [x] This PR is small and scoped to one change
- [x] `pnpm lint` and `pnpm check-types` pass (verified in CI; a full workspace install could not complete in the authoring environment)
- [x] I added tests or included a clear manual validation note above
- [x] I removed secrets, tokens, private keys, and customer data from code, logs, and screenshots
- [x] If this change should appear in the changelog, I ran `pnpm changeset`