### PR TITLE
[Fix] Slack day-page retirement misses pages during healing

### DIFF
--- a/.changeset/slack-slug-case-heal.md
+++ b/.changeset/slack-slug-case-heal.md
@@ -1,0 +1,5 @@
+---
+"@roomote/bullmq": patch
+---
+
+Fix Brain Slack day-page retirement finding nothing to heal: gbrain stores slugs lowercased, but the collector tracked its raw mixed-case emissions, so the healing replay's reconciliation never matched the census inventory. Day-page slugs are now emitted in gbrain's canonical lowercase form, mixed-case inventory rows are rewritten and merged once on startup, deployments that ran the replay with the mismatch live get it re-armed automatically, and sync-state rows left behind by superseded collector versions are cleaned up.

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-slack-collector.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-slack-collector.test.ts
@@ -196,7 +196,9 @@ function legacyChunkSlug(
 ) {
   const part = (iso: string) =>
     (Date.parse(iso) / 1000).toFixed(6).replace('.', '-');
-  return `slack/T1/${channelId}/${day}/${part(firstIso)}-${part(lastIso)}`;
+  // Lowercase like the corpus stores it (and like the census seeds it),
+  // even though the fake Slack's team/channel ids are uppercase.
+  return `slack/T1/${channelId}/${day}/${part(firstIso)}-${part(lastIso)}`.toLowerCase();
 }
 
 function seedChannel(
@@ -348,6 +350,11 @@ describe('slack collector against a fake Slack', () => {
     );
 
     expect(ingested.size).toBe(25);
+    // Emitted slugs are gbrain-canonical: the store lowercases on write, so
+    // tracking any other case would inventory pages that never exist.
+    for (const slug of workspace.brainPages.keys()) {
+      expect(slug).toBe(slug.toLowerCase());
+    }
     expect(watermarks.size).toBe(2);
     expect([...workspace.brainPages.values()].join('\n')).toContain(
       '[Alice Example](people/roomote-member-',

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-slack-pages.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-slack-pages.test.ts
@@ -52,9 +52,9 @@ describe('groupSlackMessagesIntoDayPages', () => {
 
     // Oldest day first, then workspace and channel for deterministic writes.
     expect(pages.map((page) => page.slug)).toEqual([
-      `slack/T1/C1/2026-08-13/${day1Ts}-${day1LaterTs}`.replaceAll('.', '-'),
-      `slack/T1/C2/2026-08-13/${day1Ts}-${day1Ts}`.replaceAll('.', '-'),
-      `slack/T1/C1/2026-08-14/${day2Ts}-${day2Ts}`.replaceAll('.', '-'),
+      `slack/t1/c1/2026-08-13/${day1Ts}-${day1LaterTs}`.replaceAll('.', '-'),
+      `slack/t1/c2/2026-08-13/${day1Ts}-${day1Ts}`.replaceAll('.', '-'),
+      `slack/t1/c1/2026-08-14/${day2Ts}-${day2Ts}`.replaceAll('.', '-'),
     ]);
     expect(pages[0]?.title).toBe('#general — 2026-08-13');
     // The title must also lead the content as a markdown heading: put_page

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-slack-slug-inventory.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-slack-slug-inventory.test.ts
@@ -16,6 +16,9 @@ const store = vi.hoisted(() => ({
     baseUrl: string;
     token: string;
   } | null,
+  canonicalizeResult: 0,
+  canonicalizeCalls: [] as string[],
+  deletedFamilies: [] as string[],
 }));
 
 vi.mock('@roomote/sdk/server', () => ({
@@ -86,6 +89,17 @@ vi.mock('@roomote/db/server', () => ({
       }
     },
   ),
+  canonicalizeBrainCollectorItemSlugs: vi.fn(
+    async (_db: unknown, collectorId: string) => {
+      store.canonicalizeCalls.push(collectorId);
+      return store.canonicalizeResult;
+    },
+  ),
+  deleteBrainSyncStateFamily: vi.fn(
+    async (_db: unknown, collectorId: string) => {
+      store.deletedFamilies.push(collectorId);
+    },
+  ),
   listBrainCollectorItemsBySlugPrefix: vi.fn(
     async (_db: unknown, collectorId: string, prefix: string) =>
       [...store.items.values()]
@@ -103,6 +117,7 @@ const {
   parseSlackDayPageSlug,
   reconcileSlackDayPages,
   runSlackDayPageCensus,
+  runSlackDayPageInventoryMaintenance,
 } = await import('../brain-collectors/slack-day-page-inventory');
 
 const CENSUS_STATE_ID = 'slack-public-channels:day-pages:census';
@@ -110,7 +125,8 @@ const CENSUS_STATE_ID = 'slack-public-channels:day-pages:census';
 function daySlug(first: string, last: string, day = '2026-08-13') {
   const part = (iso: string) =>
     (Date.parse(iso) / 1000).toFixed(6).replace('.', '-');
-  return `slack/T1/C1/${day}/${part(first)}-${part(last)}`;
+  // Canonical (lowercase) like both emission and the corpus store.
+  return `slack/t1/c1/${day}/${part(first)}-${part(last)}`;
 }
 
 function trackItem(slug: string) {
@@ -132,26 +148,40 @@ beforeEach(() => {
   store.listings = [];
   store.listCalls = [];
   store.connection = { baseUrl: 'http://brain.test', token: 'read' };
+  store.canonicalizeResult = 0;
+  store.canonicalizeCalls = [];
+  store.deletedFamilies = [];
 });
 
 describe('parseSlackDayPageSlug', () => {
   it('parses the channel-day prefix and the embedded range', () => {
     const parsed = parseSlackDayPageSlug(
-      'slack/T1/C1/2026-08-13/1755079500-123456-1755080400-000001',
+      'slack/t1/c1/2026-08-13/1755079500-123456-1755080400-000001',
     );
 
     expect(parsed).not.toBeNull();
-    expect(parsed!.dayPrefix).toBe('slack/T1/C1/2026-08-13/');
+    expect(parsed!.dayPrefix).toBe('slack/t1/c1/2026-08-13/');
     expect(parsed!.firstKey).toBe(1755079500123456);
     expect(parsed!.lastKey).toBe(1755080400000001);
+  });
+
+  it('parses a mixed-case slug into the canonical lowercase form', () => {
+    // Inventory rows written before canonicalization carry the raw Slack
+    // team/channel case; they must still parse, into the form the corpus
+    // actually stores, or retirement can never find their pages.
+    const parsed = parseSlackDayPageSlug(
+      'slack/T08ELT3D154/C08ELT40A8N/2026-08-13/1755079500-000000-1755080400-000000',
+    );
+
+    expect(parsed?.dayPrefix).toBe('slack/t08elt3d154/c08elt40a8n/2026-08-13/');
   });
 
   it('rejects anything that is not a slack day page', () => {
     expect(parseSlackDayPageSlug('notion/abc123')).toBeNull();
     expect(parseSlackDayPageSlug('people/roomote-member-abc')).toBeNull();
     // Namespace without the day/range tail (e.g. a hypothetical index page).
-    expect(parseSlackDayPageSlug('slack/T1/C1/2026-08-13')).toBeNull();
-    expect(parseSlackDayPageSlug('slack/T1/C1/2026-08-13/summary')).toBeNull();
+    expect(parseSlackDayPageSlug('slack/t1/c1/2026-08-13')).toBeNull();
+    expect(parseSlackDayPageSlug('slack/t1/c1/2026-08-13/summary')).toBeNull();
   });
 });
 
@@ -224,10 +254,10 @@ describe('reconcileSlackDayPages', () => {
   it('leaves tracked rows it cannot parse alone', async () => {
     // An inventory row from a future slug shape must not be deleted by an
     // older reader that cannot prove coverage.
-    store.items.set('slack/T1/C1/2026-08-13/unparseable', {
+    store.items.set('slack/t1/c1/2026-08-13/unparseable', {
       collectorId: SLACK_DAY_PAGE_ITEMS_ID,
-      itemId: 'slack/T1/C1/2026-08-13/unparseable',
-      slug: 'slack/T1/C1/2026-08-13/unparseable',
+      itemId: 'slack/t1/c1/2026-08-13/unparseable',
+      slug: 'slack/t1/c1/2026-08-13/unparseable',
     });
 
     const result = await reconcileSlackDayPages({
@@ -375,7 +405,7 @@ describe('runSlackDayPageCensus', () => {
       backfillCursor: JSON.stringify({
         after: null,
         offset: 100,
-        lastSlug: 'slack/T1/C1/2026-08-01/re-stamped-away',
+        lastSlug: 'slack/t1/c1/2026-08-01/re-stamped-away',
       }),
       backfillCompletedAt: null,
     });
@@ -436,5 +466,39 @@ describe('runSlackDayPageCensus', () => {
     await runSlackDayPageCensus();
 
     expect(store.listCalls).toHaveLength(0);
+  });
+});
+
+describe('runSlackDayPageInventoryMaintenance', () => {
+  it('re-arms the healing replay only when mixed-case rows were rewritten', async () => {
+    store.canonicalizeResult = 736;
+
+    await runSlackDayPageInventoryMaintenance(
+      'slack-public-channels:entity-timeline-v3',
+    );
+
+    expect(store.canonicalizeCalls).toEqual([SLACK_DAY_PAGE_ITEMS_ID]);
+    // The deployment ran the replay with the case mismatch live and retired
+    // nothing; clearing the cursor makes the backfill re-cover history.
+    expect(
+      store.syncState.get('slack-public-channels:entity-timeline-v3'),
+    ).toMatchObject({ backfillCursor: null, backfillCompletedAt: null });
+    expect(store.deletedFamilies).toEqual([
+      'slack-public-channels:entity-timeline-v2',
+    ]);
+  });
+
+  it('leaves backfill state alone when the inventory is already canonical', async () => {
+    await runSlackDayPageInventoryMaintenance(
+      'slack-public-channels:entity-timeline-v3',
+    );
+
+    expect(
+      store.syncState.has('slack-public-channels:entity-timeline-v3'),
+    ).toBe(false);
+    // Superseded-version rows are still dropped.
+    expect(store.deletedFamilies).toEqual([
+      'slack-public-channels:entity-timeline-v2',
+    ]);
   });
 });

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-slack-slug-inventory.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-slack-slug-inventory.test.ts
@@ -89,9 +89,15 @@ vi.mock('@roomote/db/server', () => ({
       }
     },
   ),
-  canonicalizeBrainCollectorItemSlugs: vi.fn(
-    async (_db: unknown, collectorId: string) => {
+  canonicalizeBrainCollectorItemSlugsAndResetSyncState: vi.fn(
+    async (_db: unknown, collectorId: string, syncStateCollectorId: string) => {
       store.canonicalizeCalls.push(collectorId);
+      if (store.canonicalizeResult > 0) {
+        store.syncState.set(syncStateCollectorId, {
+          backfillCursor: null,
+          backfillCompletedAt: null,
+        });
+      }
       return store.canonicalizeResult;
     },
   ),

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/slack-day-page-inventory.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/slack-day-page-inventory.ts
@@ -4,7 +4,7 @@ import {
   resolveBrainConnection,
 } from '@roomote/sdk/server';
 import {
-  canonicalizeBrainCollectorItemSlugs,
+  canonicalizeBrainCollectorItemSlugsAndResetSyncState,
   db,
   deleteBrainSyncStateFamily,
   getBrainSyncState,
@@ -225,25 +225,24 @@ const SUPERSEDED_SLACK_COLLECTOR_IDS = [
  *   replay with the mismatch live and retired nothing — so re-arm the deep
  *   backfill by clearing its cursor. The replay re-reads the backfill
  *   window and the (now canonical) reconciliation retires what the first
- *   pass missed. Deployments that never tracked mixed-case rows skip this.
+ *   pass missed. The rewrite and reset commit atomically so a restart cannot
+ *   strand the repaired inventory behind the old cursor. Deployments that
+ *   never tracked mixed-case rows skip this.
  * - Drop sync-state rows left behind by superseded collector versions.
  */
 export async function runSlackDayPageInventoryMaintenance(
   activeCollectorId: string,
 ): Promise<void> {
-  const rewritten = await canonicalizeBrainCollectorItemSlugs(
+  const rewritten = await canonicalizeBrainCollectorItemSlugsAndResetSyncState(
     db,
     SLACK_DAY_PAGE_ITEMS_ID,
+    activeCollectorId,
   );
 
   if (rewritten > 0) {
     console.log(
       `${LOG_PREFIX} canonicalized ${rewritten} slack day-page inventory rows; re-arming the healing replay`,
     );
-    await upsertBrainSyncState(db, activeCollectorId, {
-      backfillCursor: null,
-      backfillCompletedAt: null,
-    });
   }
 
   for (const collectorId of SUPERSEDED_SLACK_COLLECTOR_IDS) {

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/slack-day-page-inventory.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/slack-day-page-inventory.ts
@@ -4,7 +4,9 @@ import {
   resolveBrainConnection,
 } from '@roomote/sdk/server';
 import {
+  canonicalizeBrainCollectorItemSlugs,
   db,
+  deleteBrainSyncStateFamily,
   getBrainSyncState,
   listBrainCollectorItemsBySlugPrefix,
   seedBrainCollectorItems,
@@ -101,9 +103,14 @@ type SlackDayPageSlugRange = {
 export function parseSlackDayPageSlug(
   slug: string,
 ): SlackDayPageSlugRange | null {
-  const match = slug.match(
-    /^(slack\/[^/]+\/[^/]+\/\d{4}-\d{2}-\d{2}\/)(\d+)-(\d+)-(\d+)-(\d+)$/,
-  );
+  // gbrain stores slugs lowercased, and emission lowercases to match; a
+  // mixed-case slug can still arrive from inventory rows written before
+  // canonicalization, so parse the canonical form rather than rejecting it.
+  const match = slug
+    .toLowerCase()
+    .match(
+      /^(slack\/[^/]+\/[^/]+\/\d{4}-\d{2}-\d{2}\/)(\d+)-(\d+)-(\d+)-(\d+)$/,
+    );
 
   if (!match) {
     return null;
@@ -194,6 +201,54 @@ export async function reconcileSlackDayPages(input: {
   }
 
   return { itemUpdates, pageRetirements };
+}
+
+/**
+ * Sync-state rows superseded by the collector's version bumps. Their
+ * watermarks and cursors are dead, but the rows linger and pollute anything
+ * that aggregates the source's partitions. Extend when bumping again.
+ */
+const SUPERSEDED_SLACK_COLLECTOR_IDS = [
+  'slack-public-channels:entity-timeline-v2',
+];
+
+/**
+ * One-time repairs for inventories written before slugs were canonicalized,
+ * run each collectors tick ahead of the census (both no-op fast once clean):
+ *
+ * - Rewrite mixed-case inventory rows to gbrain's lowercase form, merging
+ *   case-duplicates. Rows tracked under mixed-case slugs name pages the
+ *   corpus never stores, which made retirement miss every census-seeded
+ *   page: reconciliation compared emitted mixed-case prefixes against
+ *   lowercase inventory rows and found nothing.
+ * - When that rewrite actually changed rows, this deployment ran the healing
+ *   replay with the mismatch live and retired nothing — so re-arm the deep
+ *   backfill by clearing its cursor. The replay re-reads the backfill
+ *   window and the (now canonical) reconciliation retires what the first
+ *   pass missed. Deployments that never tracked mixed-case rows skip this.
+ * - Drop sync-state rows left behind by superseded collector versions.
+ */
+export async function runSlackDayPageInventoryMaintenance(
+  activeCollectorId: string,
+): Promise<void> {
+  const rewritten = await canonicalizeBrainCollectorItemSlugs(
+    db,
+    SLACK_DAY_PAGE_ITEMS_ID,
+  );
+
+  if (rewritten > 0) {
+    console.log(
+      `${LOG_PREFIX} canonicalized ${rewritten} slack day-page inventory rows; re-arming the healing replay`,
+    );
+    await upsertBrainSyncState(db, activeCollectorId, {
+      backfillCursor: null,
+      backfillCompletedAt: null,
+    });
+  }
+
+  for (const collectorId of SUPERSEDED_SLACK_COLLECTOR_IDS) {
+    await deleteBrainSyncStateFamily(db, collectorId);
+  }
 }
 
 const SLACK_DAY_PAGE_CENSUS_STATE_ID = 'slack-public-channels:day-pages:census';

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/slack-public-channels.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/slack-public-channels.ts
@@ -188,7 +188,15 @@ export function groupSlackMessagesIntoDayPages(
         });
         const firstTs = chunk[0]!.ts.replace('.', '-');
         const lastTs = chunk.at(-1)!.ts.replace('.', '-');
-        const slug = `${brainNamespacePrefix('slack')}${group.teamId}/${group.channelId}/${group.day}/${firstTs}-${lastTs}`;
+        // Lowercased to gbrain's canonical form: put_page lowercases slugs
+        // before the row is written, so tracking the raw mixed-case string
+        // would inventory pages under names the corpus never stores — and
+        // retirement would never find them. (Slack team/channel ids are
+        // uppercase.) Timeline `source` keys below stay as-is: they are
+        // dedupe keys, not slugs, and changing their case would duplicate
+        // append-only timeline rows.
+        const slug =
+          `${brainNamespacePrefix('slack')}${group.teamId}/${group.channelId}/${group.day}/${firstTs}-${lastTs}`.toLowerCase();
         const people = new Set<string>();
         for (const message of chunk) {
           if (!message.person) continue;

--- a/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
@@ -28,7 +28,11 @@ import {
 } from '@roomote/types';
 
 import { runBrainCollectors } from './brain-collectors';
-import { runSlackDayPageCensus } from './brain-collectors/slack-day-page-inventory';
+import {
+  runSlackDayPageCensus,
+  runSlackDayPageInventoryMaintenance,
+} from './brain-collectors/slack-day-page-inventory';
+import { slackPublicChannelsCollector } from './brain-collectors/slack-public-channels';
 
 const LOG_PREFIX = '[brainOutboxDrain]';
 /** Sync-state key for the one-time task-history backfill. */
@@ -320,9 +324,12 @@ export async function brainCollectorsJob(): Promise<void> {
   }
 
   try {
-    // Before any Slack collection: the one-time inventory census the Slack
-    // collector holds on. Running it here, ahead of the pass, normally
-    // completes it within the first tick after a deploy.
+    // Before any Slack collection: repair pre-canonicalization inventories
+    // (re-arming the healing replay where the case mismatch neutered it),
+    // then the one-time inventory census the Slack collector holds on.
+    // Running these here, ahead of the pass, normally completes them within
+    // the first tick after a deploy.
+    await runSlackDayPageInventoryMaintenance(slackPublicChannelsCollector.id);
     await runSlackDayPageCensus();
   } catch (error) {
     console.warn(

--- a/packages/db/src/lib/__tests__/brain.test.ts
+++ b/packages/db/src/lib/__tests__/brain.test.ts
@@ -21,7 +21,10 @@ import {
   maybeEnqueueBrainMemoryEvent,
   saveBrainAgentSummary,
   resetBrainIngestionState,
+  canonicalizeBrainCollectorItemSlugs,
   deleteBrainCollectorItems,
+  deleteBrainSyncStateFamily,
+  getBrainSyncState,
   listBrainCollectorItems,
   listBrainCollectorItemsBefore,
   listBrainCollectorItemsBySlugPrefix,
@@ -177,6 +180,100 @@ describe('Brain collector item inventory', () => {
       ['slack/T1/C1/2026-08-12/3-0-4-0', 0],
       ['slack/T1/C1/2026-08-13/1-0-2-0', liveSeenAt.getTime()],
     ]);
+  });
+
+  it('canonicalizes mixed-case rows, merging by freshest lastSeenAt', async () => {
+    const fresh = new Date('2026-08-20T12:00:00Z');
+    await upsertBrainCollectorItems(db, 'slack-public-channels:day-pages', [
+      // A mixed-case row whose lowercase twin already exists with an older
+      // timestamp: merge keeps the freshest.
+      {
+        itemId: 'slack/T1/C1/2026-08-13/1-0-2-0',
+        slug: 'slack/T1/C1/2026-08-13/1-0-2-0',
+        lastSeenAt: fresh,
+      },
+      {
+        itemId: 'slack/t1/c1/2026-08-13/1-0-2-0',
+        slug: 'slack/t1/c1/2026-08-13/1-0-2-0',
+        lastSeenAt: new Date(0),
+      },
+      // A mixed-case row with no twin: simply rewritten.
+      {
+        itemId: 'slack/T1/C1/2026-08-14/3-0-4-0',
+        slug: 'slack/T1/C1/2026-08-14/3-0-4-0',
+        lastSeenAt: new Date('2026-08-20T13:00:00Z'),
+      },
+      // Already canonical: untouched.
+      {
+        itemId: 'slack/t1/c1/2026-08-15/5-0-6-0',
+        slug: 'slack/t1/c1/2026-08-15/5-0-6-0',
+        lastSeenAt: new Date('2026-08-20T14:00:00Z'),
+      },
+    ]);
+
+    const rewritten = await canonicalizeBrainCollectorItemSlugs(
+      db,
+      'slack-public-channels:day-pages',
+    );
+    const rows = await listBrainCollectorItems(
+      db,
+      'slack-public-channels:day-pages',
+      100,
+    );
+
+    expect(rewritten).toBe(2);
+    expect(rows.map((row) => [row.itemId, row.lastSeenAt.getTime()])).toEqual([
+      ['slack/t1/c1/2026-08-13/1-0-2-0', fresh.getTime()],
+      ['slack/t1/c1/2026-08-14/3-0-4-0', Date.parse('2026-08-20T13:00:00Z')],
+      ['slack/t1/c1/2026-08-15/5-0-6-0', Date.parse('2026-08-20T14:00:00Z')],
+    ]);
+
+    // Already canonical: the second pass is a no-op.
+    expect(
+      await canonicalizeBrainCollectorItemSlugs(
+        db,
+        'slack-public-channels:day-pages',
+      ),
+    ).toBe(0);
+  });
+
+  it('deletes a superseded collector version with its child partitions', async () => {
+    await upsertBrainSyncState(db, 'slack-public-channels:entity-timeline-v2', {
+      backfillCursor: '{"completed":[]}',
+    });
+    await upsertBrainSyncState(
+      db,
+      'slack-public-channels:entity-timeline-v2:T1/C1',
+      { watermark: new Date('2026-08-20T00:00:00Z') },
+    );
+    await upsertBrainSyncState(db, 'slack-public-channels:entity-timeline-v3', {
+      backfillCursor: '{"completed":[]}',
+    });
+    // A different family sharing no prefix boundary stays.
+    await upsertBrainSyncState(db, 'slack-public-channels:day-pages:census', {
+      backfillCompletedAt: new Date('2026-08-20T00:00:00Z'),
+    });
+
+    await deleteBrainSyncStateFamily(
+      db,
+      'slack-public-channels:entity-timeline-v2',
+    );
+
+    expect(
+      await getBrainSyncState(db, 'slack-public-channels:entity-timeline-v2'),
+    ).toBeNull();
+    expect(
+      await getBrainSyncState(
+        db,
+        'slack-public-channels:entity-timeline-v2:T1/C1',
+      ),
+    ).toBeNull();
+    expect(
+      await getBrainSyncState(db, 'slack-public-channels:entity-timeline-v3'),
+    ).not.toBeNull();
+    expect(
+      await getBrainSyncState(db, 'slack-public-channels:day-pages:census'),
+    ).not.toBeNull();
   });
 
   it('lists items under a literal slug prefix', async () => {

--- a/packages/db/src/lib/__tests__/brain.test.ts
+++ b/packages/db/src/lib/__tests__/brain.test.ts
@@ -15,6 +15,7 @@ import {
   brainCollectorItems,
   brainSyncState,
   backfillBrainMemoryEvents,
+  canonicalizeBrainCollectorItemSlugsAndResetSyncState,
   claimPendingBrainMemoryEvents,
   markBrainMemoryEvent,
   releaseBrainMemoryEvents,
@@ -235,6 +236,61 @@ describe('Brain collector item inventory', () => {
         'slack-public-channels:day-pages',
       ),
     ).toBe(0);
+  });
+
+  it('atomically canonicalizes inventory and resets its replay', async () => {
+    const inventoryId = 'slack-public-channels:day-pages';
+    const replayId = 'slack-public-channels:entity-timeline-v3';
+    const mixedCaseSlug = 'slack/T1/C1/2026-08-13/1-0-2-0';
+    await upsertBrainCollectorItems(db, inventoryId, [
+      {
+        itemId: mixedCaseSlug,
+        slug: mixedCaseSlug,
+        lastSeenAt: new Date('2026-08-20T12:00:00Z'),
+      },
+    ]);
+    await upsertBrainSyncState(db, replayId, {
+      backfillCursor: '{"completed":["C1"]}',
+      backfillCompletedAt: new Date('2026-08-20T13:00:00Z'),
+    });
+
+    await expect(
+      db.transaction(async (tx) => {
+        await canonicalizeBrainCollectorItemSlugsAndResetSyncState(
+          tx,
+          inventoryId,
+          replayId,
+        );
+        throw new Error('force maintenance rollback');
+      }),
+    ).rejects.toThrow('force maintenance rollback');
+
+    expect(
+      (await listBrainCollectorItems(db, inventoryId, 100)).map(
+        (row) => row.itemId,
+      ),
+    ).toEqual([mixedCaseSlug]);
+    expect(await getBrainSyncState(db, replayId)).toMatchObject({
+      backfillCursor: '{"completed":["C1"]}',
+      backfillCompletedAt: new Date('2026-08-20T13:00:00Z'),
+    });
+
+    expect(
+      await canonicalizeBrainCollectorItemSlugsAndResetSyncState(
+        db,
+        inventoryId,
+        replayId,
+      ),
+    ).toBe(1);
+    expect(
+      (await listBrainCollectorItems(db, inventoryId, 100)).map(
+        (row) => row.itemId,
+      ),
+    ).toEqual([mixedCaseSlug.toLowerCase()]);
+    expect(await getBrainSyncState(db, replayId)).toMatchObject({
+      backfillCursor: null,
+      backfillCompletedAt: null,
+    });
   });
 
   it('deletes a superseded collector version with its child partitions', async () => {

--- a/packages/db/src/lib/brain.ts
+++ b/packages/db/src/lib/brain.ts
@@ -35,6 +35,66 @@ export async function upsertBrainCollectorItems(
 }
 
 /**
+ * Rewrite a slug-keyed collector's inventory rows to their lowercase form,
+ * merging case-duplicates by keeping the freshest lastSeenAt. gbrain
+ * canonicalizes slugs to lowercase before a page row is written, so an
+ * inventory row tracked under a mixed-case slug names a page the corpus
+ * never stores. Returns how many mixed-case rows were rewritten (0 when the
+ * inventory is already canonical, which makes this cheap to run every pass).
+ */
+export async function canonicalizeBrainCollectorItemSlugs(
+  database: DatabaseOrTransaction,
+  collectorId: string,
+): Promise<number> {
+  const mixedCase = and(
+    eq(brainCollectorItems.collectorId, collectorId),
+    sql`${brainCollectorItems.itemId} <> lower(${brainCollectorItems.itemId})`,
+  );
+  const [row] = await database
+    .select({ mixed: count() })
+    .from(brainCollectorItems)
+    .where(mixedCase);
+  const mixed = row?.mixed ?? 0;
+
+  if (mixed === 0) {
+    return 0;
+  }
+
+  // Insert the canonical rows first, then drop the originals: a crash in
+  // between leaves both forms present and the next pass finishes the job.
+  await database.execute(sql`
+    INSERT INTO ${brainCollectorItems} (collector_id, item_id, slug, last_seen_at)
+    SELECT collector_id, lower(item_id), lower(item_id), max(last_seen_at)
+    FROM ${brainCollectorItems}
+    WHERE collector_id = ${collectorId} AND item_id <> lower(item_id)
+    GROUP BY collector_id, lower(item_id)
+    ON CONFLICT (collector_id, item_id) DO UPDATE SET
+      last_seen_at = GREATEST(${brainCollectorItems}.last_seen_at, excluded.last_seen_at),
+      updated_at = now()
+  `);
+  await database.delete(brainCollectorItems).where(mixedCase);
+
+  return mixed;
+}
+
+/**
+ * Delete one collector's sync-state row together with every `:`-suffixed
+ * child row (per-channel or per-repository partitions). Used to drop the
+ * rows a collector version bump superseded, which otherwise linger forever
+ * and pollute anything that aggregates a source's partitions.
+ */
+export async function deleteBrainSyncStateFamily(
+  database: DatabaseOrTransaction,
+  collectorId: string,
+): Promise<void> {
+  await database
+    .delete(brainSyncState)
+    .where(
+      sql`${brainSyncState.collectorId} = ${collectorId} OR ${brainSyncState.collectorId} LIKE ${`${collectorId.replace(/[\\%_]/g, (ch) => `\\${ch}`)}:%`}`,
+    );
+}
+
+/**
  * Record inventory rows without touching ones that already exist. This is the
  * census path: a one-time walk over the Brain's listing seeds pages emitted
  * before item tracking existed, and must never overwrite the fresher

--- a/packages/db/src/lib/brain.ts
+++ b/packages/db/src/lib/brain.ts
@@ -8,6 +8,7 @@ import {
   brainSyncState,
   taskRuns,
 } from '../schema';
+import { runInTransactionIfAvailable } from './transaction-utils';
 
 export type BrainSyncStateRow = typeof brainSyncState.$inferSelect;
 export type BrainCollectorItemRow = typeof brainCollectorItems.$inferSelect;
@@ -75,6 +76,33 @@ export async function canonicalizeBrainCollectorItemSlugs(
   await database.delete(brainCollectorItems).where(mixedCase);
 
   return mixed;
+}
+
+/**
+ * Canonicalize a slug inventory and, when rows changed, reset the replay that
+ * must revisit it. Both mutations commit together so a process exit cannot
+ * leave canonical rows behind with the old replay cursor still completed.
+ */
+export async function canonicalizeBrainCollectorItemSlugsAndResetSyncState(
+  database: DatabaseOrTransaction,
+  collectorId: string,
+  syncStateCollectorId: string,
+): Promise<number> {
+  return runInTransactionIfAvailable(database, async (tx) => {
+    const rewritten = await canonicalizeBrainCollectorItemSlugs(
+      tx,
+      collectorId,
+    );
+
+    if (rewritten > 0) {
+      await upsertBrainSyncState(tx, syncStateCollectorId, {
+        backfillCursor: null,
+        backfillCompletedAt: null,
+      });
+    }
+
+    return rewritten;
+  });
 }
 
 /**


### PR DESCRIPTION
> &#8203;<!-- roomote:pr-attribution:start -->Opened on behalf of @mrubens.<!-- roomote:pr-attribution:end --> [View the task](https://community.roomote.ai/task/2dy9qvwr7jeki?utm_source=github-comment&utm_medium=link&utm_campaign=github_pr_review_follow_up) or mention @roomote for follow-up asks.

## What changed

- Emit and parse Slack day-page slugs in gbrain's canonical lowercase form.
- Repair existing mixed-case inventory rows, merging case duplicates by the freshest observation.
- Re-arm the v3 healing replay whenever repair changes inventory rows, with the rewrite and cursor reset committed atomically so a restart cannot strand the repair behind an old completed cursor.
- Remove sync-state families left behind by superseded Slack collector versions.

## Why this change was made

gbrain stores lowercase slugs, while the Slack collector previously tracked raw mixed-case team and channel IDs. That split the inventory and caused the healing replay to retire no overlapping pages. The repair also needs to survive a worker exit at every point, including between inventory canonicalization and replay rearming.

## Impact

Slack day-page reconciliation can match the stored corpus again, repair affected inventories, and safely replay the backfill window needed to retire superseded pages. Deployments without mixed-case rows keep their existing replay state, and timeline dedupe keys retain their original case. Targeted BullMQ and real-database tests, package type checks, formatting, changed-file lint, and the repository pre-push suite pass; the full BullMQ package lint still reports pre-existing unused-disable warnings in unrelated tests.