### PR TITLE
[Fix] Fast child lifecycle relay uses configured API client

### DIFF
--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/relay-fast-agent-chat-reply.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/relay-fast-agent-chat-reply.test.ts
@@ -1,7 +1,7 @@
-const mocks = vi.hoisted(() => ({ relay: vi.fn() }));
+const mocks = vi.hoisted(() => ({ createClient: vi.fn(), relay: vi.fn() }));
 
 vi.mock('@roomote/sdk/client', () => ({
-  sdk: { taskRuns: { relayFastAgentChildChatReply: mocks.relay } },
+  createClient: mocks.createClient,
 }));
 
 import { handleRelayFastAgentChatReply } from '../relay-fast-agent-chat-reply';
@@ -10,6 +10,11 @@ describe('handleRelayFastAgentChatReply', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.relay.mockResolvedValue({ relayed: true });
+    mocks.createClient.mockReturnValue({
+      taskRuns: {
+        relayFastAgentChildChatReply: { mutate: mocks.relay },
+      },
+    });
   });
 
   it('relays lifecycle text without posting to a communication provider', async () => {
@@ -23,9 +28,22 @@ describe('handleRelayFastAgentChatReply', () => {
       {
         token: 'token',
         platformApiUrl: 'https://api.roomote.example',
+        authBypassHeaderName: 'x-roomote-bypass',
+        authBypassHeaderValue: 'bypass-token',
       },
     );
 
+    expect(mocks.createClient).toHaveBeenCalledWith({
+      url: 'https://api.roomote.example',
+      headers: expect.any(Function),
+    });
+    const clientOptions = mocks.createClient.mock.calls[0]?.[0] as {
+      headers: () => Record<string, string>;
+    };
+    expect(clientOptions.headers()).toEqual({
+      Authorization: 'Bearer token',
+      'x-roomote-bypass': 'bypass-token',
+    });
     expect(mocks.relay).toHaveBeenCalledWith({
       runId: 42,
       taskId: 'task-1',

--- a/apps/worker/src/mcp/roomote-mcp-server/relay-fast-agent-chat-reply.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/relay-fast-agent-chat-reply.ts
@@ -1,7 +1,8 @@
 import { createHash } from 'node:crypto';
 
-import { sdk } from '@roomote/sdk/client';
+import { createClient } from '@roomote/sdk/client';
 
+import { buildApiHeaders } from './api-client.js';
 import {
   errorResultWithArtifacts,
   normalizeOptionalSlackText,
@@ -70,7 +71,11 @@ export async function handleRelayFastAgentChatReply(
       return contentValidation;
     }
 
-    const result = await sdk.taskRuns.relayFastAgentChildChatReply({
+    const client = createClient({
+      url: artifactConfig.platformApiUrl,
+      headers: () => buildApiHeaders(artifactConfig),
+    });
+    const result = await client.taskRuns.relayFastAgentChildChatReply.mutate({
       runId: input.runId,
       taskId: input.taskId,
       deliverySignature,


### PR DESCRIPTION
## Summary

- configure the Fast child lifecycle relay client with the canonical MCP platform URL and run token
- preserve the existing auth-bypass header when the deployment requires it
- add regression coverage for the target URL and authentication headers

## Why

The Roomote MCP subprocess receives ROOMOTE_PLATFORM_API_URL and ROOMOTE_CLOUD_TOKEN. The global worker SDK client instead reads TRPC_URL and AUTH_TOKEN, so child lifecycle relays fell back to localhost and failed before reaching the Fast parent.

This keeps the existing MCP environment contract and uses the same authenticated-header helper as other Roomote MCP platform calls.

## Validation

- focused worker tests: 56 passed
- worker TypeScript check
- worker ESLint and formatting
- full pre-push suite: oxlint, residual lint, fast type checks, and knip
- end-to-end mock Slack smoke: Fast launched a fresh Local Docker task, then received and posted one child progress update and one child closeout without duplicates
