### PR TITLE
Ignore external bot activity in PR review notifications

### DIFF
--- a/apps/api/src/handlers/github/__tests__/notifyPrReviewActivity.test.ts
+++ b/apps/api/src/handlers/github/__tests__/notifyPrReviewActivity.test.ts
@@ -293,6 +293,33 @@ describe('buildPrReviewActivityNotificationInput', () => {
     });
   });
 
+  it('skips top-level PR comments authored by bots', () => {
+    expect(
+      buildPrReviewActivityNotificationInput(
+        issueCommentPayload({
+          body: 'The preview deployment is ready.',
+          login: 'vercel[bot]',
+          userId: 35613825,
+          userType: 'Bot',
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('skips edited bot comments before resolving their revision', () => {
+    expect(
+      buildPrReviewActivityNotificationInput(
+        issueCommentPayload({
+          body: 'Updated deployment status.',
+          edited: true,
+          login: 'deployment-bot[bot]',
+          userId: 9002,
+          userType: 'Bot',
+        }),
+      ),
+    ).toBeNull();
+  });
+
   it('uses the webhook delivery as the revision when an edit omits updated_at', () => {
     const payload = issueCommentPayload({
       body: 'Edited without a timestamp',
@@ -319,27 +346,36 @@ describe('buildPrReviewActivityNotificationInput', () => {
     );
   });
 
-  it('maps one external bot identity across summary and review activity', () => {
+  it('skips submitted reviews and inline comments from external bots', () => {
     const bot = {
       login: 'reviewer[bot]',
       userId: 9001,
       userType: 'Bot',
     };
-    const events = [
-      issueCommentPayload(bot),
-      reviewPayload(bot),
-      reviewCommentPayload(bot),
-    ].map((payload) => buildPrReviewActivityNotificationInput(payload));
+    const events = [reviewPayload(bot), reviewCommentPayload(bot)].map(
+      (payload) => buildPrReviewActivityNotificationInput(payload),
+    );
 
-    expect(events).toEqual(
-      Array.from({ length: 3 }, () =>
-        expect.objectContaining({
-          event: expect.objectContaining({
-            automatedAuthorId: 'github:9001',
-          }),
+    expect(events).toEqual([null, null]);
+  });
+
+  it('keeps submitted reviews authored by Roomote', () => {
+    expect(
+      buildPrReviewActivityNotificationInput(
+        reviewPayload({
+          body: 'I found an issue.',
+          login: 'roomote[bot]',
+          userId: 9001,
+          userType: 'Bot',
         }),
       ),
-    );
+    ).toMatchObject({
+      event: {
+        kind: 'review',
+        authorLogin: 'roomote[bot]',
+        roomoteAuthored: true,
+      },
+    });
   });
 
   it('skips top-level PR comments handled by the mention flow', () => {

--- a/apps/api/src/handlers/github/notifyPrReviewActivity.ts
+++ b/apps/api/src/handlers/github/notifyPrReviewActivity.ts
@@ -43,6 +43,15 @@ function getReviewBody(value: string | null | undefined): string | undefined {
   return body ? body.slice(0, MAX_REVIEW_BODY_LENGTH) : undefined;
 }
 
+function isExternalBotAuthor(
+  user: { login?: string; type?: string } | null | undefined,
+): boolean {
+  return (
+    user?.type === 'Bot' &&
+    (!user.login || !GitHubSchemas.isRoomoteGitHubLogin(user.login))
+  );
+}
+
 function getAutomatedAuthorMetadata(
   user: { id?: number; type?: string } | null | undefined,
 ): { automatedAuthorId: string } | Record<string, never> {
@@ -112,12 +121,24 @@ export function buildPrReviewActivityNotificationInput(
   eventPayload: PrReviewActivityWebhookPayload,
   context: GitHubWebhookContext = {},
 ): EnqueuePrReviewNotificationInput | null {
+  const author =
+    'issue' in eventPayload
+      ? eventPayload.comment.user
+      : 'review' in eventPayload
+        ? eventPayload.review.user
+        : eventPayload.comment.user;
+
+  if (isExternalBotAuthor(author)) {
+    return null;
+  }
+
   if ('issue' in eventPayload) {
     if (!eventPayload.issue.pull_request) {
       return null;
     }
 
     const comment = eventPayload.comment;
+
     const revision = getIssueCommentRevision(eventPayload, context);
     const authorLogin = comment.user?.login;
     const body = getReviewBody(comment.body);


### PR DESCRIPTION
## Summary

- ignore PR activity authored by external bots before revision handling, persistence, batching, and live PR context reads
- keep Roomote-authored review summaries, submitted reviews, and inline findings on their existing lifecycle
- avoid treating deployment, CI, integration, and third-party bot activity as feedback for an owning task

## Validation

- focused PR review activity tests (43 passed)
- API fast typecheck
- targeted ESLint and formatting checks