### PR TITLE
[Fix] Re-harden the Brain mirror credential on every boot

### DIFF
--- a/.changeset/brain-mirror-credential.md
+++ b/.changeset/brain-mirror-credential.md
@@ -1,0 +1,5 @@
+---
+"@roomote/bullmq": patch
+---
+
+Re-harden the Brain's git mirror on every gbrain container boot when GBRAIN_GITHUB_PAT is set, so the push credential survives redeploys instead of living in the container's ephemeral home directory and silently stranding every commit after the next deploy.

--- a/.docker/gbrain/entrypoint.sh
+++ b/.docker/gbrain/entrypoint.sh
@@ -379,9 +379,32 @@ echo "[gbrain-entrypoint] starting gbrain serve on :$PORT (full surface)"
 gbrain serve --http --port "$PORT" --bind "${GBRAIN_BIND:-0.0.0.0}" --surface full &
 SERVER_PID=$!
 
+# The brain repo's git mirror (gbrain's durability hardening: a post-commit
+# auto-push plus a repo-scoped credential helper) is set up by
+# `gbrain sources harden`, which reads the PAT from GBRAIN_GITHUB_PAT. It
+# writes the credential file under $HOME/.gbrain. Run by hand in an ssh
+# session that meant /root, which the next deploy rebuilt, and every commit
+# since sat local-only (observed: 9.7k unpushed commits, three days of
+# silent "LOCAL-ONLY, NEEDS ATTENTION" in the push log). Re-run it on every
+# boot, under the volume-anchored HOME above, so the credential survives
+# redeploys and a freshly provisioned brain is hardened as soon as the PAT
+# is set. Idempotent by design, DB-backed (needs the server's registry, so
+# it runs after startup), and never fatal.
+if [ -n "${GBRAIN_GITHUB_PAT:-}" ]; then
+  (
+    sleep 30
+    echo "[gbrain-entrypoint] hardening the brain repo mirror (GBRAIN_GITHUB_PAT is set)"
+    gbrain sources harden --all --no-cron 2>&1 \
+      | sed 's/^/[gbrain-entrypoint] mirror: /' || true
+  ) &
+  HARDEN_PID=$!
+else
+  HARDEN_PID=""
+fi
+
 TERMINATING=0
 stop_processes() {
-  kill -TERM "$SERVER_PID" "$WORKER_PID" 2>/dev/null || true
+  kill -TERM "$SERVER_PID" "$WORKER_PID" ${HARDEN_PID:+"$HARDEN_PID"} 2>/dev/null || true
 }
 trap 'TERMINATING=1; stop_processes' TERM INT
 


### PR DESCRIPTION
Why the `roomote-brain` mirror stopped updating on Aug 19.

**Root cause.** The brain repo's auto-push is gbrain's durability hardening (`gbrain sources harden`): a post-commit hook plus a repo-scoped credential helper whose file lands under `$HOME/.gbrain`. It was run by hand in an ssh session on Aug 18, where `$HOME` was `/root`, which is not on the volume. The next deploy rebuilt the container, the hook kept firing on every write-through commit, and every push failed with `could not read Username for 'https://github.com'`. From Aug 19 16:36 UTC the push log has nothing but `LOCAL-ONLY, NEEDS ATTENTION`; by today 9,698 commits were unpushed. Nothing surfaced it: the remote just looked quiet.

**Fix.** The service env still carries `GBRAIN_GITHUB_PAT`, which is exactly what the hardening reads. The entrypoint now re-runs `gbrain sources harden --all --no-cron` on every boot (when the PAT is set), under the entrypoint's volume-anchored `HOME=/data`, so the credential file is durable and a freshly provisioned brain is hardened as soon as the PAT is configured. It is idempotent by design (the dry run on the live brain reported hook, helper, and rules "already current" and only the credential missing), runs after the server is up because it needs the source registry, and is never fatal.

**Live repair.** I re-ran the hardening on the preview brain over `railway ssh` under `HOME=/data` and pushed the backlog; results in a comment below.