### PR TITLE
[Improve] Give Brain pages the frontmatter gbrain expects

### DIFF
--- a/.changeset/brain-page-frontmatter.md
+++ b/.changeset/brain-page-frontmatter.md
@@ -1,0 +1,6 @@
+---
+"@roomote/bullmq": patch
+"@roomote/types": patch
+---
+
+Every page Roomote writes into the Brain now carries the frontmatter gbrain expects: a real `type` (task-memory, pull-request, github-issue, slack, meeting, notion-page, person) instead of defaulting to a generic concept, a quoted `title`, and a stable `created` date. This clears the nightly lint warning on every page and lets gbrain's type-aware features see Roomote's pages for what they are.

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-granola.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-granola.test.ts
@@ -151,6 +151,9 @@ describe('buildGranolaMeetingPage', () => {
     );
 
     expect(result?.page.timelineEvidence).toEqual([]);
+    // No honest date means no `created` at all, never a placeholder.
+    expect(result?.page.content).not.toContain('\ncreated:');
+    expect(result?.page.content).toContain('\ntype: meeting\n');
   });
 
   it('tries both attendee name and email before leaving a person unresolved', () => {

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-outbox-drain.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-outbox-drain.test.ts
@@ -284,7 +284,16 @@ describe('task memory page identity', () => {
     });
 
     expect(page.content).not.toContain('\ndate:');
+    expect(page.content).not.toContain('\ncreated:');
     expect(page.content).toContain('\ncompleted_at: unknown\n');
+  });
+
+  it('stamps type, title, and a stable created on memory pages', () => {
+    const page = buildMemoryPage({ ...base, runId: 101 });
+
+    expect(page.content).toMatch(
+      /^---\ntype: task-memory\ntitle: "[^"]+"\ncreated: 2026-08-13T10:00:00\.000Z\n/,
+    );
   });
 });
 

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-slack-pages.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-slack-pages.test.ts
@@ -61,11 +61,13 @@ describe('groupSlackMessagesIntoDayPages', () => {
     // carries no title field, and gbrain derives a page's title from the
     // first heading — without it the slug's timestamp range becomes the
     // title on every surface.
+    // type/title/created are the fields gbrain's lint requires on every
+    // page; without `type` gbrain files the page as a generic concept.
     expect(pages[0]?.content).toMatch(
-      /^---\ndate: 2026-08-13\n---\n\n# #general — 2026-08-13\n/,
+      /^---\ntype: slack\ntitle: "#general — 2026-08-13"\ncreated: 2026-08-13\ndate: 2026-08-13\n---\n\n# #general — 2026-08-13\n/,
     );
     expect(pages[2]?.content).toMatch(
-      /^---\ndate: 2026-08-14\n---\n\n# #general — 2026-08-14\n/,
+      /^---\ntype: slack\ntitle: "#general — 2026-08-14"\ncreated: 2026-08-14\ndate: 2026-08-14\n---\n\n# #general — 2026-08-14\n/,
     );
     expect(pages[0]?.content).toContain(
       'Slack public channel #general (C1), messages on 2026-08-13',

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/granola-meetings.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/granola-meetings.ts
@@ -139,7 +139,9 @@ export function buildGranolaMeetingPage(
     ...renderBrainFrontmatter({
       type: BRAIN_PAGE_TYPES.meeting,
       title,
-      created: day,
+      // `day` is the literal "undated" when Granola omits the timestamp;
+      // only a real date may stand as `created`.
+      created: createdAt ? day : null,
       fields: [
         id && `granola_note_id: ${id}`,
         `date: ${day}`,

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/granola-meetings.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/granola-meetings.ts
@@ -3,7 +3,12 @@ import {
   findBrainSourceConnectionConfig,
   isBrainSourceAvailable,
 } from '@roomote/sdk/server';
-import { BRAIN_COLLECTOR_IDS, brainNamespacePrefix } from '@roomote/types';
+import {
+  BRAIN_COLLECTOR_IDS,
+  BRAIN_PAGE_TYPES,
+  brainNamespacePrefix,
+  renderBrainFrontmatter,
+} from '@roomote/types';
 
 import type { BrainCollector, CollectorPage } from './contracts';
 import {
@@ -131,14 +136,18 @@ export function buildGranolaMeetingPage(
   const excerpt = body.slice(0, GRANOLA_NOTE_EXCERPT_MAX_CHARS);
 
   const content = [
-    '---',
-    ...(id ? [`granola_note_id: ${id}`] : []),
-    `date: ${day}`,
-    'provenance: roomote-granola-meetings',
-    ...(attendeeSlugs.length > 0
-      ? [`attendees: ${JSON.stringify(attendeeSlugs)}`]
-      : []),
-    '---',
+    ...renderBrainFrontmatter({
+      type: BRAIN_PAGE_TYPES.meeting,
+      title,
+      created: day,
+      fields: [
+        id && `granola_note_id: ${id}`,
+        `date: ${day}`,
+        'provenance: roomote-granola-meetings',
+        attendeeSlugs.length > 0 &&
+          `attendees: ${JSON.stringify(attendeeSlugs)}`,
+      ],
+    }),
     '',
     `# ${title}`,
     '',

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/notion-pages.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/notion-pages.ts
@@ -20,7 +20,9 @@ import {
 } from '@roomote/sdk/server/notion-api';
 import {
   BRAIN_COLLECTOR_IDS,
+  BRAIN_PAGE_TYPES,
   brainNamespacePrefix,
+  renderBrainFrontmatter,
   type McpConnectionNotionConfig,
 } from '@roomote/types';
 
@@ -384,17 +386,22 @@ export function buildNotionUserPage(
     slug: notionUserSlug(user.id),
     title: user.name,
     content: [
-      '---',
-      `type: ${canonical ? 'person-alias' : 'person'}`,
-      `notion_user_id: ${JSON.stringify(user.id)}`,
-      ...(canonical
-        ? [`canonical: ${JSON.stringify(canonical.slug)}`]
-        : [
-            `aliases: ${JSON.stringify(deleted ? [] : [user.id, providerId])}`,
-            `status: ${deleted ? 'deleted' : 'active'}`,
-          ]),
-      'provenance: roomote-notion-users',
-      '---',
+      ...renderBrainFrontmatter({
+        type: canonical
+          ? BRAIN_PAGE_TYPES.personAlias
+          : BRAIN_PAGE_TYPES.person,
+        title: user.name,
+        fields: [
+          `notion_user_id: ${JSON.stringify(user.id)}`,
+          ...(canonical
+            ? [`canonical: ${JSON.stringify(canonical.slug)}`]
+            : [
+                `aliases: ${JSON.stringify(deleted ? [] : [user.id, providerId])}`,
+                `status: ${deleted ? 'deleted' : 'active'}`,
+              ]),
+          'provenance: roomote-notion-users',
+        ],
+      }),
       '',
       `# ${user.name}`,
       '',
@@ -595,31 +602,30 @@ export function buildNotionPage(
     slug,
     title,
     content: [
-      '---',
-      'type: notion-page',
-      `notion_page_id: ${JSON.stringify(pageId)}`,
-      `status: ${status}`,
-      'provenance: roomote-notion',
-      ...(updatedAt ? [`date: ${formatUtcDay(updatedAt)}`] : []),
-      ...(createdAt ? [`created_at: ${createdAt.toISOString()}`] : []),
-      ...(updatedAt ? [`last_edited_at: ${updatedAt.toISOString()}`] : []),
-      ...(sourceUrl ? [`source_url: ${JSON.stringify(sourceUrl)}`] : []),
-      ...(references.createdBy
-        ? [`created_by: ${JSON.stringify(references.createdBy)}`]
-        : []),
-      ...(references.lastEditedBy
-        ? [`last_edited_by: ${JSON.stringify(references.lastEditedBy)}`]
-        : []),
-      ...(references.people.length > 0
-        ? [`people: ${JSON.stringify(references.people)}`]
-        : []),
-      ...(references.mentions.length > 0
-        ? [`mentions: ${JSON.stringify(references.mentions)}`]
-        : []),
-      ...(references.relations.length > 0
-        ? [`relations: ${JSON.stringify(references.relations)}`]
-        : []),
-      '---',
+      ...renderBrainFrontmatter({
+        type: BRAIN_PAGE_TYPES.notionPage,
+        title,
+        created: createdAt ?? updatedAt ?? null,
+        fields: [
+          `notion_page_id: ${JSON.stringify(pageId)}`,
+          `status: ${status}`,
+          'provenance: roomote-notion',
+          updatedAt && `date: ${formatUtcDay(updatedAt)}`,
+          createdAt && `created_at: ${createdAt.toISOString()}`,
+          updatedAt && `last_edited_at: ${updatedAt.toISOString()}`,
+          sourceUrl && `source_url: ${JSON.stringify(sourceUrl)}`,
+          references.createdBy &&
+            `created_by: ${JSON.stringify(references.createdBy)}`,
+          references.lastEditedBy &&
+            `last_edited_by: ${JSON.stringify(references.lastEditedBy)}`,
+          references.people.length > 0 &&
+            `people: ${JSON.stringify(references.people)}`,
+          references.mentions.length > 0 &&
+            `mentions: ${JSON.stringify(references.mentions)}`,
+          references.relations.length > 0 &&
+            `relations: ${JSON.stringify(references.relations)}`,
+        ],
+      }),
       '',
       `# ${title}`,
       ...(sourceUrl ? ['', `[Open in Notion](${sourceUrl})`] : []),

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/person-identities.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/person-identities.ts
@@ -1,4 +1,8 @@
-import { BRAIN_COLLECTOR_IDS } from '@roomote/types';
+import {
+  BRAIN_COLLECTOR_IDS,
+  BRAIN_PAGE_TYPES,
+  renderBrainFrontmatter,
+} from '@roomote/types';
 
 import {
   db,
@@ -105,14 +109,18 @@ export function buildPersonIdentityPage(
     slug: personIdentitySlug(record.userId),
     title: name,
     content: [
-      '---',
-      'type: person',
-      `aliases: ${JSON.stringify(aliases)}`,
-      `status: ${deleted ? 'deleted' : 'active'}`,
-      `event_date: ${formatUtcDay(record.createdAt)}`,
-      ...(jobTitle ? [`job_title: ${JSON.stringify(jobTitle)}`] : []),
-      'provenance: roomote-person-identities',
-      '---',
+      ...renderBrainFrontmatter({
+        type: BRAIN_PAGE_TYPES.person,
+        title: name,
+        created: record.createdAt,
+        fields: [
+          `aliases: ${JSON.stringify(aliases)}`,
+          `status: ${deleted ? 'deleted' : 'active'}`,
+          `event_date: ${formatUtcDay(record.createdAt)}`,
+          jobTitle && `job_title: ${JSON.stringify(jobTitle)}`,
+          'provenance: roomote-person-identities',
+        ],
+      }),
       '',
       `# ${name}`,
       '',

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/rippling-workers.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/rippling-workers.ts
@@ -11,7 +11,9 @@ import {
 import { ripplingApiRequestJson } from '@roomote/sdk/server/rippling-api';
 import {
   BRAIN_COLLECTOR_IDS,
+  BRAIN_PAGE_TYPES,
   brainNamespacePrefix,
+  renderBrainFrontmatter,
   type McpConnectionRipplingConfig,
 } from '@roomote/types';
 import { createHash } from 'node:crypto';
@@ -319,8 +321,13 @@ export function buildRipplingWorkerPage(input: {
     slug: ripplingWorkerSlug(workerId),
     title: name,
     content: [
-      '---',
-      `type: ${canonical ? 'person-alias' : 'person'}`,
+      ...renderBrainFrontmatter({
+        type: canonical
+          ? BRAIN_PAGE_TYPES.personAlias
+          : BRAIN_PAGE_TYPES.person,
+        title: name,
+        created: startDate ?? null,
+      }).slice(0, -1),
       `aliases: ${JSON.stringify(active ? aliases : [])}`,
       `status: ${active ? 'active' : 'inactive'}`,
       `source_status: ${JSON.stringify(exactStatus)}`,
@@ -395,8 +402,10 @@ export function buildUnavailableRipplingWorkerPage(item: {
     slug: item.slug,
     title: 'Unavailable Rippling worker',
     content: [
-      '---',
-      'type: person',
+      ...renderBrainFrontmatter({
+        type: BRAIN_PAGE_TYPES.person,
+        title: 'Unavailable Rippling worker',
+      }).slice(0, -1),
       'aliases: []',
       'status: unavailable',
       `rippling_worker_id: ${JSON.stringify(item.itemId)}`,

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/slack-directory.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/slack-directory.ts
@@ -1,4 +1,9 @@
-import { BRAIN_COLLECTOR_IDS, brainNamespacePrefix } from '@roomote/types';
+import {
+  BRAIN_COLLECTOR_IDS,
+  BRAIN_PAGE_TYPES,
+  brainNamespacePrefix,
+  renderBrainFrontmatter,
+} from '@roomote/types';
 import {
   and,
   db,
@@ -184,12 +189,16 @@ export function buildSlackDirectoryPersonPage(
       slug,
       title: name,
       content: [
-        '---',
-        'type: person-alias',
-        `canonical: ${JSON.stringify(canonical.slug)}`,
-        `event_date: ${formatUtcDay(effectiveDate)}`,
-        'provenance: slack-directory',
-        '---',
+        ...renderBrainFrontmatter({
+          type: BRAIN_PAGE_TYPES.personAlias,
+          title: name,
+          created: effectiveDate,
+          fields: [
+            `canonical: ${JSON.stringify(canonical.slug)}`,
+            `event_date: ${formatUtcDay(effectiveDate)}`,
+            'provenance: slack-directory',
+          ],
+        }),
         '',
         `# ${name}`,
         '',
@@ -213,15 +222,19 @@ export function buildSlackDirectoryPersonPage(
     slug,
     title: name,
     content: [
-      '---',
-      'type: person',
-      `aliases: ${JSON.stringify(aliases)}`,
-      `status: ${profile.isDeleted ? 'deleted' : 'active'}`,
-      `event_date: ${formatUtcDay(effectiveDate)}`,
-      ...(safeTitle ? [`job_title: ${JSON.stringify(safeTitle)}`] : []),
-      'provenance: slack-directory',
-      `workspace: ${JSON.stringify(safeWorkspace)}`,
-      '---',
+      ...renderBrainFrontmatter({
+        type: BRAIN_PAGE_TYPES.person,
+        title: name,
+        created: effectiveDate,
+        fields: [
+          `aliases: ${JSON.stringify(aliases)}`,
+          `status: ${profile.isDeleted ? 'deleted' : 'active'}`,
+          `event_date: ${formatUtcDay(effectiveDate)}`,
+          safeTitle && `job_title: ${JSON.stringify(safeTitle)}`,
+          'provenance: slack-directory',
+          `workspace: ${JSON.stringify(safeWorkspace)}`,
+        ],
+      }),
       '',
       `# ${name}`,
       '',

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/slack-public-channels.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/slack-public-channels.ts
@@ -1,4 +1,9 @@
-import { BRAIN_COLLECTOR_IDS, brainNamespacePrefix } from '@roomote/types';
+import {
+  BRAIN_COLLECTOR_IDS,
+  BRAIN_PAGE_TYPES,
+  brainNamespacePrefix,
+  renderBrainFrontmatter,
+} from '@roomote/types';
 import {
   db,
   eq,
@@ -207,9 +212,12 @@ export function groupSlackMessagesIntoDayPages(
           slug,
           title: `#${group.channelName} — ${group.day}`,
           content: [
-            '---',
-            `date: ${group.day}`,
-            '---',
+            ...renderBrainFrontmatter({
+              type: BRAIN_PAGE_TYPES.slackDay,
+              title: `#${group.channelName} — ${group.day}`,
+              created: group.day,
+              fields: [`date: ${group.day}`],
+            }),
             '',
             // put_page has no title parameter: gbrain derives a page's title
             // from the first markdown heading, and without one it falls back

--- a/apps/bullmq/src/scheduled-jobs/brain-maintenance.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-maintenance.ts
@@ -557,6 +557,7 @@ export function buildDailyDigestPage(input: {
     content: `---
 type: daily
 title: ${yamlString(title)}
+created: ${yamlString(date)}
 date: ${yamlString(date)}
 window_start: ${yamlString(input.since.toISOString())}
 window_end: ${yamlString(input.until.toISOString())}
@@ -614,6 +615,7 @@ export function buildWeeklySynthesisPage(input: {
     content: `---
 type: weekly
 title: ${yamlString(title)}
+created: ${yamlString(input.weekStart.toISOString().slice(0, 10))}
 week: ${yamlString(week)}
 window_start: ${yamlString(input.weekStart.toISOString())}
 window_end: ${yamlString(input.until.toISOString())}

--- a/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
@@ -24,9 +24,11 @@ import {
 } from '@roomote/sdk/server';
 import {
   BRAIN_COLLECTOR_IDS,
+  BRAIN_PAGE_TYPES,
+  RunStatus,
   brainNamespacePrefix,
   getLinkedEnvironmentIdFromPayload,
-  RunStatus,
+  renderBrainFrontmatter,
 } from '@roomote/types';
 
 import { runBrainCollectors } from './brain-collectors';
@@ -200,19 +202,26 @@ export function buildMemoryPage(input: {
   });
 
   const content = [
-    '---',
-    `roomote_task_id: ${input.taskId}`,
-    `roomote_run_id: ${input.runId}`,
-    // GBrain derives effective_date from this conventional field. Keep the
-    // full timestamp below as provenance, but make backfilled pages sort and
-    // filter by when the task completed rather than when it was ingested.
-    ...(completedDate ? [`date: ${completedDate}`] : []),
-    `completed_at: ${completed}`,
-    // Environment stamp: costs nothing now, enables environment-scoped
-    // retrieval (gbrain sources) or admin triage later without re-ingesting.
-    ...(input.environmentName ? [`environment: ${input.environmentName}`] : []),
-    'provenance: roomote-task-memory',
-    '---',
+    ...renderBrainFrontmatter({
+      type: BRAIN_PAGE_TYPES.taskMemory,
+      title: input.taskTitle,
+      created: completed,
+      fields: [
+        `roomote_task_id: ${input.taskId}`,
+        `roomote_run_id: ${input.runId}`,
+        // GBrain derives effective_date from this conventional field. Keep
+        // the full timestamp below as provenance, but make backfilled pages
+        // sort and filter by when the task completed rather than when it
+        // was ingested.
+        completedDate && `date: ${completedDate}`,
+        `completed_at: ${completed}`,
+        // Environment stamp: costs nothing now, enables environment-scoped
+        // retrieval (gbrain sources) or admin triage later without
+        // re-ingesting.
+        input.environmentName && `environment: ${input.environmentName}`,
+        'provenance: roomote-task-memory',
+      ],
+    }),
     '',
     `# ${input.taskTitle}`,
     '',
@@ -624,15 +633,20 @@ export function buildPullRequestFactPage(fact: {
   const occurredAt =
     fact.mergedAtRemote ?? fact.closedAtRemote ?? fact.createdAtRemote;
   const content = [
-    '---',
-    `event_date: ${occurredAt.toISOString().slice(0, 10)}`,
-    `repository: ${fact.repositoryFullName}`,
-    `pr_number: ${fact.prNumber}`,
-    `state: ${fact.state}`,
-    ...(fact.authorLogin ? [`author: ${fact.authorLogin}`] : []),
-    ...(merged ? [`merged_at: ${merged}`] : []),
-    'provenance: roomote-pull-requests',
-    '---',
+    ...renderBrainFrontmatter({
+      type: BRAIN_PAGE_TYPES.pullRequest,
+      title: `${fact.repositoryFullName}#${fact.prNumber}: ${fact.title}`,
+      created: fact.createdAtRemote,
+      fields: [
+        `event_date: ${occurredAt.toISOString().slice(0, 10)}`,
+        `repository: ${fact.repositoryFullName}`,
+        `pr_number: ${fact.prNumber}`,
+        `state: ${fact.state}`,
+        fact.authorLogin && `author: ${fact.authorLogin}`,
+        merged && `merged_at: ${merged}`,
+        'provenance: roomote-pull-requests',
+      ],
+    }),
     '',
     `# ${fact.repositoryFullName}#${fact.prNumber}: ${fact.title}`,
     '',

--- a/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
@@ -205,7 +205,9 @@ export function buildMemoryPage(input: {
     ...renderBrainFrontmatter({
       type: BRAIN_PAGE_TYPES.taskMemory,
       title: input.taskTitle,
-      created: completed,
+      // Legacy completed runs can lack a completion time; `completed` is the
+      // literal "unknown" then, which is no date at all.
+      created: completedAtIso ?? null,
       fields: [
         `roomote_task_id: ${input.taskId}`,
         `roomote_run_id: ${input.runId}`,

--- a/packages/sdk/src/server/lib/brain-github.ts
+++ b/packages/sdk/src/server/lib/brain-github.ts
@@ -10,7 +10,12 @@ import {
   repositories,
 } from '@roomote/db/server';
 import { getInstallationOctokit } from '@roomote/github';
-import { BRAIN_COLLECTOR_IDS, brainNamespacePrefix } from '@roomote/types';
+import {
+  BRAIN_COLLECTOR_IDS,
+  BRAIN_PAGE_TYPES,
+  brainNamespacePrefix,
+  renderBrainFrontmatter,
+} from '@roomote/types';
 
 /**
  * GitHub issues as Brain memory: the discussion around bugs, features, and
@@ -230,18 +235,23 @@ export function buildGithubIssuePage(input: {
   });
 
   const content = [
-    '---',
-    ...(effectiveDate ? [`event_date: ${effectiveDate}`] : []),
-    `repository: ${fullName}`,
-    `issue_number: ${issue.number}`,
-    `state: ${issue.state ?? 'unknown'}`,
-    ...(issue.user?.login ? [`author: ${issue.user.login}`] : []),
-    ...(labels.length > 0 ? [`labels: ${labels.join(', ')}`] : []),
-    ...(issue.created_at ? [`created_at: ${issue.created_at}`] : []),
-    ...(issue.updated_at ? [`updated_at: ${issue.updated_at}`] : []),
-    ...(issue.closed_at ? [`closed_at: ${issue.closed_at}`] : []),
-    'provenance: roomote-github-issues',
-    '---',
+    ...renderBrainFrontmatter({
+      type: BRAIN_PAGE_TYPES.githubIssue,
+      title: `${fullName}#${issue.number}: ${issue.title}`,
+      created: issue.created_at ?? effectiveDate ?? null,
+      fields: [
+        effectiveDate && `event_date: ${effectiveDate}`,
+        `repository: ${fullName}`,
+        `issue_number: ${issue.number}`,
+        `state: ${issue.state ?? 'unknown'}`,
+        issue.user?.login && `author: ${issue.user.login}`,
+        labels.length > 0 && `labels: ${labels.join(', ')}`,
+        issue.created_at && `created_at: ${issue.created_at}`,
+        issue.updated_at && `updated_at: ${issue.updated_at}`,
+        issue.closed_at && `closed_at: ${issue.closed_at}`,
+        'provenance: roomote-github-issues',
+      ],
+    }),
     '',
     `# ${fullName}#${issue.number}: ${issue.title}`,
     '',

--- a/packages/types/src/__tests__/brain-frontmatter.test.ts
+++ b/packages/types/src/__tests__/brain-frontmatter.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { BRAIN_PAGE_TYPES, renderBrainFrontmatter } from '../brain';
+
+describe('renderBrainFrontmatter', () => {
+  it('leads with the fields gbrain lint requires, then the writer fields', () => {
+    expect(
+      renderBrainFrontmatter({
+        type: BRAIN_PAGE_TYPES.slackDay,
+        title: '#general — 2026-08-13',
+        created: '2026-08-13',
+        fields: ['date: 2026-08-13'],
+      }),
+    ).toEqual([
+      '---',
+      'type: slack',
+      'title: "#general — 2026-08-13"',
+      'created: 2026-08-13',
+      'date: 2026-08-13',
+      '---',
+    ]);
+  });
+
+  it('quotes titles so YAML survives colons, hashes, and quotes', () => {
+    const [, , title] = renderBrainFrontmatter({
+      type: BRAIN_PAGE_TYPES.pullRequest,
+      title: 'acme/widgets#42: fix "quoted" thing: really',
+    });
+
+    expect(title).toBe(
+      'title: "acme/widgets#42: fix \\"quoted\\" thing: really"',
+    );
+  });
+
+  it('renders Date instances as ISO timestamps and omits a missing created', () => {
+    expect(
+      renderBrainFrontmatter({
+        type: BRAIN_PAGE_TYPES.person,
+        title: 'Ada',
+        created: new Date('2026-08-20T12:34:56.000Z'),
+      }),
+    ).toContain('created: 2026-08-20T12:34:56.000Z');
+    expect(
+      renderBrainFrontmatter({ type: BRAIN_PAGE_TYPES.person, title: 'Ada' }),
+    ).toEqual(['---', 'type: person', 'title: "Ada"', '---']);
+  });
+
+  it('drops falsy optional fields so writers can inline conditionals', () => {
+    expect(
+      renderBrainFrontmatter({
+        type: BRAIN_PAGE_TYPES.meeting,
+        title: 'Standup',
+        created: '2026-08-13',
+        fields: [
+          undefined,
+          false,
+          null,
+          'provenance: roomote-granola-meetings',
+        ],
+      }),
+    ).toEqual([
+      '---',
+      'type: meeting',
+      'title: "Standup"',
+      'created: 2026-08-13',
+      'provenance: roomote-granola-meetings',
+      '---',
+    ]);
+  });
+});

--- a/packages/types/src/brain.ts
+++ b/packages/types/src/brain.ts
@@ -111,6 +111,63 @@ export const BRAIN_COLLECTOR_IDS = {
   granolaMeetings: 'granola-meetings:entity-timeline-v3',
 } as const;
 
+/**
+ * Page types Roomote writes into the Brain. gbrain treats `type` as an open
+ * string (schema packs may add more), defaults a page without one to
+ * `concept`, and its lint requires the field; these are the values that make
+ * a Roomote-written page recognisable as what it is. `slack`, `meeting`,
+ * `person`, and `person-alias` are gbrain's own base types.
+ */
+export const BRAIN_PAGE_TYPES = {
+  taskMemory: 'task-memory',
+  pullRequest: 'pull-request',
+  githubIssue: 'github-issue',
+  slackDay: 'slack',
+  meeting: 'meeting',
+  notionPage: 'notion-page',
+  person: 'person',
+  personAlias: 'person-alias',
+  dailyDigest: 'daily',
+  weeklySynthesis: 'weekly',
+} as const;
+
+export type BrainPageType =
+  (typeof BRAIN_PAGE_TYPES)[keyof typeof BRAIN_PAGE_TYPES];
+
+/**
+ * The YAML frontmatter block for a Brain page, as a list of lines. Every
+ * page carries the three fields gbrain's lint requires (`type`, `title`,
+ * `created`) ahead of whatever the writer adds. `created` should be the
+ * page's own stable date (the Slack day, the run's completion, the merge),
+ * never the ingestion clock: collectors re-put pages idempotently, and a
+ * timestamp that moves per write would turn every replay into a content
+ * change. Pages without an honest date simply omit it.
+ */
+export function renderBrainFrontmatter(input: {
+  type: BrainPageType;
+  title: string;
+  created?: Date | string | null;
+  fields?: ReadonlyArray<string | false | null | undefined>;
+}): string[] {
+  const created =
+    input.created instanceof Date
+      ? input.created.toISOString()
+      : (input.created ?? null);
+
+  return [
+    '---',
+    `type: ${input.type}`,
+    // JSON string syntax is valid YAML and survives colons, hashes, quotes,
+    // and dashes that a bare scalar would not.
+    `title: ${JSON.stringify(input.title)}`,
+    ...(created ? [`created: ${created}`] : []),
+    ...(input.fields ?? []).filter(
+      (field): field is string => typeof field === 'string',
+    ),
+    '---',
+  ];
+}
+
 export const BRAIN_SOURCES = [
   {
     id: 'task-memories',


### PR DESCRIPTION
Found while looking at why the `roomote-brain` mirror looks scattered and why the nightly autopilot cycle's lint phase flags every page.

**Problem.** gbrain defaults a page without a `type` to `concept`, and its lint requires three frontmatter fields on every page: `title`, `type`, `created`. Roomote's collectors set none of them on most pages. On the live preview brain, 7,595 of ~8,400 pages were filed as generic concepts, and the cycle reported "8,354 lint issues across 8,350 pages" every night (one `missing-*` issue per page).

**Change.** `renderBrainFrontmatter` in `@roomote/types` renders the frontmatter block with those three fields first, then the writer's own fields; every writer goes through it. Types come from a `BRAIN_PAGE_TYPES` registry:

| Writer | type |
|---|---|
| task memories | `task-memory` |
| pull-request facts | `pull-request` |
| GitHub issues | `github-issue` |
| Slack day pages | `slack` (gbrain base type) |
| Granola meetings | `meeting` (gbrain base type) |
| Notion pages | `notion-page` (unchanged) |
| people (identities, Slack directory, Notion users, Rippling) | `person` / `person-alias` (unchanged) |
| daily / weekly synthesis | `daily` / `weekly` (unchanged; now also `created`) |

`created` is deliberately the page's own stable date (the Slack day, the run's completion, the PR's creation, the meeting day), never the ingestion clock: collectors re-put pages idempotently, and a timestamp that moves per write would turn every replay into a content change and a re-embed. Pages with no honest date (Notion users, unavailable Rippling workers) omit it.

**Effect on existing corpora.** Pages get the new frontmatter the next time their writer re-puts them (incremental activity, replays, the PR-facts sync). Nothing is re-emitted just for this.

**Tests.** Unit tests for the helper (field order, YAML-safe quoting, Date vs string `created`, falsy-field dropping); the Slack day-page test now pins the full frontmatter. All existing bullmq and sdk suites pass.