### PR TITLE
[Fix] Reduce GitHub installation token pressure

### DIFF
--- a/.changeset/calm-github-token-mints.md
+++ b/.changeset/calm-github-token-mints.md
@@ -1,0 +1,5 @@
+---
+"@roomote/auth": patch
+---
+
+Reduce GitHub App rate-limit pressure by caching and coalescing installation-token requests, reusing bootstrap credentials until their scheduled refresh, and stopping immediate retries when GitHub asks clients to back off.

--- a/.changeset/calm-github-token-mints.md
+++ b/.changeset/calm-github-token-mints.md
@@ -2,4 +2,4 @@
 "@roomote/auth": patch
 ---
 
-Reduce GitHub App rate-limit pressure by caching and coalescing installation-token requests, reusing bootstrap credentials until their scheduled refresh, and stopping immediate retries when GitHub asks clients to back off.
+Reduce GitHub App rate-limit pressure by coalescing installation-token requests, briefly caching the PR-notification hot path with one fresh-token retry, reusing bootstrap credentials until their scheduled refresh, and honoring provider backoff signals.

--- a/apps/bullmq/src/jobs/pr-review-notification.test.ts
+++ b/apps/bullmq/src/jobs/pr-review-notification.test.ts
@@ -98,6 +98,7 @@ vi.mock('@roomote/sdk/server', () => ({
   PrReviewNotificationRateLimitError: MockPrReviewNotificationRateLimitError,
   createPrReviewNotificationTelemetry: (eventsReceived: number) => ({
     githubApiCalls: 0,
+    githubTokenMintRequests: 0,
     eventsReceived,
     eventsTriaged: 0,
     triageInvoked: false,

--- a/apps/bullmq/src/jobs/pr-review-notification.ts
+++ b/apps/bullmq/src/jobs/pr-review-notification.ts
@@ -68,6 +68,7 @@ function logPrReviewNotificationTriage(input: {
       eventsDrained: input.eventsDrained,
       eventsTriaged: input.telemetry.eventsTriaged,
       githubApiCalls: input.telemetry.githubApiCalls,
+      githubTokenMintRequests: input.telemetry.githubTokenMintRequests,
       triageInvoked: input.telemetry.triageInvoked,
       triageCacheHit: input.telemetry.triageCacheHit,
       triageInputChars: input.telemetry.triageInputChars,

--- a/apps/worker/src/run-task/polling.test.ts
+++ b/apps/worker/src/run-task/polling.test.ts
@@ -287,4 +287,21 @@ describe('startPolling', () => {
     });
     expect(options.state.communicationMessageIntervals?.discord).toBeDefined();
   });
+
+  it('passes the bootstrap source-control expiry to the refresh loop', () => {
+    const expiresAt = new Date('2030-01-01T01:00:00.000Z');
+    const options = createListenerOptions({
+      payloadKind: TaskPayloadKind.StandardTask,
+      payload: { repo: 'owner/repo', description: 'Use bootstrap token' },
+    });
+    options.sourceControlTokenExpiresAt = expiresAt;
+
+    startPolling(options);
+
+    expect(mockCreateGitHubTokenRefreshInterval).toHaveBeenCalledWith({
+      runId: 42,
+      logger: options.logger,
+      initialExpiresAt: expiresAt,
+    });
+  });
 });

--- a/apps/worker/src/run-task/polling.ts
+++ b/apps/worker/src/run-task/polling.ts
@@ -62,6 +62,7 @@ export const startPolling = (options: ListenerOptions) => {
   state.githubTokenRefreshInterval = createGitHubTokenRefreshInterval({
     runId: taskRun.id,
     logger,
+    initialExpiresAt: options.sourceControlTokenExpiresAt,
   });
 };
 

--- a/apps/worker/src/run-task/polling/github-token-refresh.test.ts
+++ b/apps/worker/src/run-task/polling/github-token-refresh.test.ts
@@ -91,4 +91,29 @@ describe('createGitHubTokenRefreshInterval', () => {
     expect(mockEnsureFiles).not.toHaveBeenCalled();
     expect(mockApplyMetadata).not.toHaveBeenCalled();
   });
+
+  it('defers the first refresh when the bootstrap token expiry is known', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-24T12:00:00.000Z'));
+
+    try {
+      const interval = createGitHubTokenRefreshInterval({
+        runId: 7,
+        logger: createLogger(),
+        initialExpiresAt: new Date('2026-08-24T13:00:00.000Z'),
+      });
+
+      await flushAsync();
+      expect(mockRefreshGitHubTokenWithMetadata).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(45 * 60 * 1000);
+      await flushAsync();
+      clearInterval(interval);
+
+      expect(mockRefreshGitHubTokenWithMetadata).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
 });

--- a/apps/worker/src/run-task/polling/github-token-refresh.ts
+++ b/apps/worker/src/run-task/polling/github-token-refresh.ts
@@ -14,6 +14,32 @@ const DEFAULT_GITHUB_TOKEN_REFRESH_INTERVAL_MS = 45 * 60 * 1000;
 interface GitHubTokenRefreshOptions {
   runId: number;
   logger: Pick<HarnessLogger, 'info' | 'error'>;
+  initialExpiresAt?: Date | string | null;
+}
+
+function getRefreshAtMs(expiresAt: Date | string | null | undefined): number {
+  if (!expiresAt) {
+    return Date.now();
+  }
+
+  const expiresAtMs =
+    expiresAt instanceof Date ? expiresAt.getTime() : Date.parse(expiresAt);
+  if (Number.isNaN(expiresAtMs)) {
+    return Date.now();
+  }
+
+  const now = Date.now();
+  const remainingMs = expiresAtMs - now;
+  const refreshBufferMs =
+    remainingMs > 0 ? Math.min(5 * 60 * 1000, remainingMs / 4) : 5 * 60 * 1000;
+
+  return Math.max(
+    now,
+    Math.min(
+      now + DEFAULT_GITHUB_TOKEN_REFRESH_INTERVAL_MS,
+      expiresAtMs - refreshBufferMs,
+    ),
+  );
 }
 
 export async function refreshGitHubToken({
@@ -70,7 +96,7 @@ export async function refreshGitHubToken({
 export function createGitHubTokenRefreshInterval(
   options: GitHubTokenRefreshOptions,
 ): NodeJS.Timeout {
-  let nextRefreshAtMs = Date.now();
+  let nextRefreshAtMs = getRefreshAtMs(options.initialExpiresAt);
   let refreshInFlight = false;
 
   const tick = async () => {
@@ -95,8 +121,9 @@ export function createGitHubTokenRefreshInterval(
     }
   };
 
-  // Refresh once immediately so long workspace preparation time does not
-  // consume most of the token window before runtime polling starts.
+  // Legacy dequeue responses without expiry metadata still refresh
+  // immediately. Current responses reuse the bootstrap credential until the
+  // normal pre-expiry refresh window.
   void tick();
 
   return setInterval(() => {

--- a/apps/worker/src/run-task/run-task.ts
+++ b/apps/worker/src/run-task/run-task.ts
@@ -650,6 +650,7 @@ function getQueuedSnapshotResumeLinearMessages(
 
 export const runTask = async ({
   taskRun,
+  sourceControlToken,
   envVars,
   userEnvVars,
   workspacePath,
@@ -2278,6 +2279,7 @@ export const runTask = async ({
     // (syncPollingState was already called above, before task start/resume.)
     startPolling({
       taskRun,
+      sourceControlTokenExpiresAt: sourceControlToken?.expiresAt,
       task,
       state: pollingState,
       logger,

--- a/apps/worker/src/run-task/types.ts
+++ b/apps/worker/src/run-task/types.ts
@@ -180,6 +180,8 @@ export type CallbackDeliveryContext = {
 
 export type RunTaskOptions = {
   taskRun: DequeuedTaskRun['taskRun'];
+  /** Source-control credential metadata returned by dequeue/resume. */
+  sourceControlToken?: DequeuedTaskRun['sourceControlToken'];
   envVars: Record<string, string | undefined>;
   /**
    * Snapshot of the dequeue-provided env vars taken before injectEnvVars adds
@@ -297,6 +299,8 @@ export type RunTaskState = TaskState &
 
 export interface ListenerOptions {
   taskRun: DequeuedTaskRun['taskRun'];
+  /** Expiry of the already-installed bootstrap credential, when known. */
+  sourceControlTokenExpiresAt?: Date | string | null;
   /**
    * Task-level channel bindings from the SDK dequeue/resume response.
    * Preferred over payload-derived extraction when deciding which polling

--- a/packages/auth/src/__tests__/github-token.test.ts
+++ b/packages/auth/src/__tests__/github-token.test.ts
@@ -80,7 +80,9 @@ vi.mock('@roomote/db/server', () => ({
 }));
 
 import {
+  clearGitHubTokenCacheForTesting,
   createGitHubToken,
+  createGitHubTokenWithMetadata,
   resolveGitHubAppCredentials,
   resolveRuntimeGitHubAppCredentials,
 } from '../github-token';
@@ -171,6 +173,7 @@ describe('resolveRuntimeGitHubAppCredentials', () => {
 describe('createGitHubToken', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearGitHubTokenCacheForTesting();
     mockEnv.R_GITHUB_APP_ID = '';
     mockEnv.R_GITHUB_APP_PRIVATE_KEY = '';
     mockFindActiveInstallations.mockResolvedValue([
@@ -179,7 +182,10 @@ describe('createGitHubToken', () => {
       },
     ]);
     mockCreateInstallationAccessToken.mockResolvedValue({
-      data: { token: 'ghs_installation_token' },
+      data: {
+        token: 'ghs_installation_token',
+        expires_at: '2030-01-01T01:00:00.000Z',
+      },
     });
     mockJwtSign.mockReturnValue('app-jwt');
     mockResolveDeploymentEnvVar.mockImplementation(async (name: string) =>
@@ -237,6 +243,107 @@ describe('createGitHubToken', () => {
 
     expect(mockCreateInstallationAccessToken).toHaveBeenCalledWith({
       installation_id: 999,
+    });
+  });
+
+  it('caches a valid installation token and reports only the actual mint request', async () => {
+    const onTokenMintRequest = vi.fn();
+
+    await expect(
+      createGitHubToken({ type: 'activeInstallation' }, undefined, {
+        onTokenMintRequest,
+      }),
+    ).resolves.toBe('ghs_installation_token');
+    await expect(
+      createGitHubToken({ type: 'activeInstallation' }, undefined, {
+        onTokenMintRequest,
+      }),
+    ).resolves.toBe('ghs_installation_token');
+
+    expect(mockCreateInstallationAccessToken).toHaveBeenCalledTimes(1);
+    expect(onTokenMintRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('normalizes equivalent repository scopes without crossing scope boundaries', async () => {
+    mockFindInstallation.mockResolvedValue({ installationId: 999 });
+
+    await createGitHubToken({
+      type: 'installationId',
+      installationId: 'inst-row-id',
+      repositoryIds: [8, 7, 8],
+    });
+    await createGitHubToken({
+      type: 'installationId',
+      installationId: 'inst-row-id',
+      repositoryIds: [7, 8],
+    });
+    await createGitHubToken({
+      type: 'installationId',
+      installationId: 'inst-row-id',
+      repositoryIds: [7],
+    });
+
+    expect(mockCreateInstallationAccessToken).toHaveBeenCalledTimes(2);
+    expect(mockCreateInstallationAccessToken).toHaveBeenNthCalledWith(1, {
+      installation_id: 999,
+      repository_ids: [7, 8],
+    });
+    expect(mockCreateInstallationAccessToken).toHaveBeenNthCalledWith(2, {
+      installation_id: 999,
+      repository_ids: [7],
+    });
+  });
+
+  it('single-flights concurrent token requests for the same scope', async () => {
+    let resolveMint:
+      | ((value: { data: { token: string; expires_at: string } }) => void)
+      | undefined;
+    mockCreateInstallationAccessToken.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveMint = resolve;
+      }),
+    );
+
+    const first = createGitHubToken({ type: 'activeInstallation' });
+    const second = createGitHubToken({ type: 'activeInstallation' });
+
+    await vi.waitFor(() => {
+      expect(mockCreateInstallationAccessToken).toHaveBeenCalledTimes(1);
+    });
+    resolveMint?.({
+      data: {
+        token: 'ghs_shared_token',
+        expires_at: '2030-01-01T01:00:00.000Z',
+      },
+    });
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      'ghs_shared_token',
+      'ghs_shared_token',
+    ]);
+    expect(mockCreateInstallationAccessToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reuse a token inside the refresh buffer', async () => {
+    mockCreateInstallationAccessToken.mockResolvedValue({
+      data: {
+        token: 'ghs_expiring_token',
+        expires_at: new Date(Date.now() + 4 * 60 * 1000).toISOString(),
+      },
+    });
+
+    await createGitHubToken({ type: 'activeInstallation' });
+    await createGitHubToken({ type: 'activeInstallation' });
+
+    expect(mockCreateInstallationAccessToken).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns the installation token expiry metadata', async () => {
+    await expect(
+      createGitHubTokenWithMetadata({ type: 'activeInstallation' }),
+    ).resolves.toEqual({
+      token: 'ghs_installation_token',
+      expiresAt: new Date('2030-01-01T01:00:00.000Z'),
     });
   });
 });

--- a/packages/auth/src/__tests__/github-token.test.ts
+++ b/packages/auth/src/__tests__/github-token.test.ts
@@ -251,11 +251,13 @@ describe('createGitHubToken', () => {
 
     await expect(
       createGitHubToken({ type: 'activeInstallation' }, undefined, {
+        cache: true,
         onTokenMintRequest,
       }),
     ).resolves.toBe('ghs_installation_token');
     await expect(
       createGitHubToken({ type: 'activeInstallation' }, undefined, {
+        cache: true,
         onTokenMintRequest,
       }),
     ).resolves.toBe('ghs_installation_token');
@@ -267,21 +269,33 @@ describe('createGitHubToken', () => {
   it('normalizes equivalent repository scopes without crossing scope boundaries', async () => {
     mockFindInstallation.mockResolvedValue({ installationId: 999 });
 
-    await createGitHubToken({
-      type: 'installationId',
-      installationId: 'inst-row-id',
-      repositoryIds: [8, 7, 8],
-    });
-    await createGitHubToken({
-      type: 'installationId',
-      installationId: 'inst-row-id',
-      repositoryIds: [7, 8],
-    });
-    await createGitHubToken({
-      type: 'installationId',
-      installationId: 'inst-row-id',
-      repositoryIds: [7],
-    });
+    await createGitHubToken(
+      {
+        type: 'installationId',
+        installationId: 'inst-row-id',
+        repositoryIds: [8, 7, 8],
+      },
+      undefined,
+      { cache: true },
+    );
+    await createGitHubToken(
+      {
+        type: 'installationId',
+        installationId: 'inst-row-id',
+        repositoryIds: [7, 8],
+      },
+      undefined,
+      { cache: true },
+    );
+    await createGitHubToken(
+      {
+        type: 'installationId',
+        installationId: 'inst-row-id',
+        repositoryIds: [7],
+      },
+      undefined,
+      { cache: true },
+    );
 
     expect(mockCreateInstallationAccessToken).toHaveBeenCalledTimes(2);
     expect(mockCreateInstallationAccessToken).toHaveBeenNthCalledWith(1, {
@@ -332,8 +346,74 @@ describe('createGitHubToken', () => {
       },
     });
 
-    await createGitHubToken({ type: 'activeInstallation' });
-    await createGitHubToken({ type: 'activeInstallation' });
+    await createGitHubToken({ type: 'activeInstallation' }, undefined, {
+      cache: true,
+    });
+    await createGitHubToken({ type: 'activeInstallation' }, undefined, {
+      cache: true,
+    });
+
+    expect(mockCreateInstallationAccessToken).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not reuse a token beyond the configured cache age', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-24T12:00:00.000Z'));
+    mockCreateInstallationAccessToken.mockResolvedValue({
+      data: {
+        token: 'ghs_cached_token',
+        expires_at: '2026-08-24T13:00:00.000Z',
+      },
+    });
+
+    try {
+      await createGitHubToken({ type: 'activeInstallation' }, undefined, {
+        cache: true,
+        maxCacheAgeMs: 15 * 60 * 1000,
+      });
+      await vi.advanceTimersByTimeAsync(15 * 60 * 1000);
+      await createGitHubToken({ type: 'activeInstallation' }, undefined, {
+        cache: true,
+        maxCacheAgeMs: 15 * 60 * 1000,
+      });
+
+      expect(mockCreateInstallationAccessToken).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('force-refreshes and replaces a cached token', async () => {
+    mockCreateInstallationAccessToken
+      .mockResolvedValueOnce({
+        data: {
+          token: 'ghs_first_token',
+          expires_at: '2030-01-01T01:00:00.000Z',
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          token: 'ghs_fresh_token',
+          expires_at: '2030-01-01T01:00:00.000Z',
+        },
+      });
+
+    await expect(
+      createGitHubToken({ type: 'activeInstallation' }, undefined, {
+        cache: true,
+      }),
+    ).resolves.toBe('ghs_first_token');
+    await expect(
+      createGitHubToken({ type: 'activeInstallation' }, undefined, {
+        cache: true,
+        forceRefresh: true,
+      }),
+    ).resolves.toBe('ghs_fresh_token');
+    await expect(
+      createGitHubToken({ type: 'activeInstallation' }, undefined, {
+        cache: true,
+      }),
+    ).resolves.toBe('ghs_fresh_token');
 
     expect(mockCreateInstallationAccessToken).toHaveBeenCalledTimes(2);
   });

--- a/packages/auth/src/github-token.ts
+++ b/packages/auth/src/github-token.ts
@@ -42,14 +42,24 @@ export type GitHubTokenMetadata = {
 };
 
 export type CreateGitHubTokenRuntimeOptions = {
+  /** Reuse a valid token for this exact app, installation, and repo scope. */
+  cache?: boolean;
+  /** Ignore and replace any cached token for this scope. */
+  forceRefresh?: boolean;
+  /** Upper bound on token reuse, independent of the provider expiry. */
+  maxCacheAgeMs?: number;
   /** Called only when this process sends a token-mint POST to GitHub. */
   onTokenMintRequest?: () => void;
 };
 
 const GITHUB_TOKEN_CACHE_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+const GITHUB_TOKEN_CACHE_MAX_AGE_MS = 15 * 60 * 1000;
 const GITHUB_TOKEN_CACHE_MAX_ENTRIES = 500;
 
-const githubTokenCache = new Map<string, GitHubTokenMetadata>();
+const githubTokenCache = new Map<
+  string,
+  { metadata: GitHubTokenMetadata; storedAt: number }
+>();
 const githubTokenMintsInFlight = new Map<
   string,
   Promise<GitHubTokenMetadata>
@@ -85,13 +95,17 @@ function getGitHubTokenCacheKey({
 
 function getCachedGitHubToken(
   cacheKey: string,
+  maxCacheAgeMs: number,
   now = Date.now(),
 ): GitHubTokenMetadata | null {
   const cached = githubTokenCache.get(cacheKey);
 
   if (
-    !cached?.expiresAt ||
-    cached.expiresAt.getTime() - GITHUB_TOKEN_CACHE_REFRESH_BUFFER_MS <= now
+    !cached?.metadata.expiresAt ||
+    cached.metadata.expiresAt.getTime() -
+      GITHUB_TOKEN_CACHE_REFRESH_BUFFER_MS <=
+      now ||
+    cached.storedAt + maxCacheAgeMs <= now
   ) {
     githubTokenCache.delete(cacheKey);
     return null;
@@ -101,7 +115,7 @@ function getCachedGitHubToken(
   // used scope first.
   githubTokenCache.delete(cacheKey);
   githubTokenCache.set(cacheKey, cached);
-  return cached;
+  return cached.metadata;
 }
 
 function cacheGitHubToken(
@@ -113,7 +127,7 @@ function cacheGitHubToken(
   }
 
   githubTokenCache.delete(cacheKey);
-  githubTokenCache.set(cacheKey, metadata);
+  githubTokenCache.set(cacheKey, { metadata, storedAt: Date.now() });
 
   while (githubTokenCache.size > GITHUB_TOKEN_CACHE_MAX_ENTRIES) {
     const oldestKey = githubTokenCache.keys().next().value;
@@ -304,9 +318,22 @@ export async function createGitHubTokenWithMetadata(
     installationId: installation.installationId,
     repositoryIds,
   });
-  const cached = getCachedGitHubToken(cacheKey);
-  if (cached) {
-    return cached;
+  const cacheEnabled = runtimeOptions?.cache === true;
+  const forceRefresh = runtimeOptions?.forceRefresh === true;
+  const maxCacheAgeMs = Math.max(
+    0,
+    runtimeOptions?.maxCacheAgeMs ?? GITHUB_TOKEN_CACHE_MAX_AGE_MS,
+  );
+
+  if (cacheEnabled && forceRefresh) {
+    githubTokenCache.delete(cacheKey);
+  }
+
+  if (cacheEnabled && !forceRefresh) {
+    const cached = getCachedGitHubToken(cacheKey, maxCacheAgeMs);
+    if (cached) {
+      return cached;
+    }
   }
 
   const existingMint = githubTokenMintsInFlight.get(cacheKey);
@@ -321,7 +348,9 @@ export async function createGitHubTokenWithMetadata(
     runtimeOptions,
   })
     .then((metadata) => {
-      cacheGitHubToken(cacheKey, metadata);
+      if (cacheEnabled) {
+        cacheGitHubToken(cacheKey, metadata);
+      }
       return metadata;
     })
     .finally(() => {

--- a/packages/auth/src/github-token.ts
+++ b/packages/auth/src/github-token.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import { Octokit } from '@octokit/rest';
 import jwt from 'jsonwebtoken';
 import { z } from 'zod';
@@ -32,10 +34,213 @@ export type CreateGitHubTokenOptions = z.infer<
   typeof createGitHubTokenOptionsSchema
 >;
 
+export type GitHubAppCredentials = { appId: string; privateKey: string };
+
+export type GitHubTokenMetadata = {
+  token: string;
+  expiresAt: Date | null;
+};
+
+export type CreateGitHubTokenRuntimeOptions = {
+  /** Called only when this process sends a token-mint POST to GitHub. */
+  onTokenMintRequest?: () => void;
+};
+
+const GITHUB_TOKEN_CACHE_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+const GITHUB_TOKEN_CACHE_MAX_ENTRIES = 500;
+
+const githubTokenCache = new Map<string, GitHubTokenMetadata>();
+const githubTokenMintsInFlight = new Map<
+  string,
+  Promise<GitHubTokenMetadata>
+>();
+
+function normalizeRepositoryIds(repositoryIds?: number[]): number[] {
+  return [...new Set(repositoryIds ?? [])].sort((left, right) => left - right);
+}
+
+function getCredentialFingerprint(credentials: GitHubAppCredentials): string {
+  return createHash('sha256')
+    .update(credentials.appId)
+    .update('\0')
+    .update(normalizePemEnvValue(credentials.privateKey))
+    .digest('hex');
+}
+
+function getGitHubTokenCacheKey({
+  credentials,
+  installationId,
+  repositoryIds,
+}: {
+  credentials: GitHubAppCredentials;
+  installationId: number;
+  repositoryIds: number[];
+}): string {
+  return [
+    getCredentialFingerprint(credentials),
+    String(installationId),
+    repositoryIds.join(','),
+  ].join(':');
+}
+
+function getCachedGitHubToken(
+  cacheKey: string,
+  now = Date.now(),
+): GitHubTokenMetadata | null {
+  const cached = githubTokenCache.get(cacheKey);
+
+  if (
+    !cached?.expiresAt ||
+    cached.expiresAt.getTime() - GITHUB_TOKEN_CACHE_REFRESH_BUFFER_MS <= now
+  ) {
+    githubTokenCache.delete(cacheKey);
+    return null;
+  }
+
+  // Refresh insertion order so the bounded cache evicts the least recently
+  // used scope first.
+  githubTokenCache.delete(cacheKey);
+  githubTokenCache.set(cacheKey, cached);
+  return cached;
+}
+
+function cacheGitHubToken(
+  cacheKey: string,
+  metadata: GitHubTokenMetadata,
+): void {
+  if (!metadata.expiresAt) {
+    return;
+  }
+
+  githubTokenCache.delete(cacheKey);
+  githubTokenCache.set(cacheKey, metadata);
+
+  while (githubTokenCache.size > GITHUB_TOKEN_CACHE_MAX_ENTRIES) {
+    const oldestKey = githubTokenCache.keys().next().value;
+    if (typeof oldestKey !== 'string') {
+      break;
+    }
+    githubTokenCache.delete(oldestKey);
+  }
+}
+
+function getErrorHeader(error: unknown, name: string): string | null {
+  if (
+    typeof error !== 'object' ||
+    error === null ||
+    !('response' in error) ||
+    typeof error.response !== 'object' ||
+    error.response === null ||
+    !('headers' in error.response) ||
+    typeof error.response.headers !== 'object' ||
+    error.response.headers === null
+  ) {
+    return null;
+  }
+
+  const entry = Object.entries(
+    error.response.headers as Record<string, unknown>,
+  ).find(([key]) => key.toLowerCase() === name.toLowerCase());
+  const value = entry?.[1];
+
+  return typeof value === 'string' || typeof value === 'number'
+    ? String(value)
+    : null;
+}
+
+function getErrorStatus(error: unknown): number | null {
+  if (typeof error !== 'object' || error === null || !('status' in error)) {
+    return null;
+  }
+
+  const status = Number(error.status);
+  return Number.isFinite(status) ? status : null;
+}
+
+function getRateLimitResetAt(error: unknown): string | null {
+  const resetSeconds = Number(getErrorHeader(error, 'x-ratelimit-reset'));
+  return Number.isFinite(resetSeconds) && resetSeconds > 0
+    ? new Date(resetSeconds * 1000).toISOString()
+    : null;
+}
+
+async function mintGitHubToken({
+  installationId,
+  repositoryIds,
+  appCredentials,
+  runtimeOptions,
+}: {
+  installationId: number;
+  repositoryIds: number[];
+  appCredentials: GitHubAppCredentials;
+  runtimeOptions?: CreateGitHubTokenRuntimeOptions;
+}): Promise<GitHubTokenMetadata> {
+  const startedAt = Date.now();
+  runtimeOptions?.onTokenMintRequest?.();
+
+  try {
+    const {
+      data: { token, expires_at: expiresAtValue },
+    } = await getOctokit(
+      appCredentials,
+    ).rest.apps.createInstallationAccessToken({
+      installation_id: installationId,
+      ...(repositoryIds.length > 0 ? { repository_ids: repositoryIds } : {}),
+    });
+    const parsedExpiresAt = expiresAtValue ? new Date(expiresAtValue) : null;
+    const expiresAt =
+      parsedExpiresAt && !Number.isNaN(parsedExpiresAt.getTime())
+        ? parsedExpiresAt
+        : null;
+
+    console.log(
+      JSON.stringify({
+        event: 'github_installation_token_mint',
+        outcome: 'success',
+        installationId,
+        repositoryCount: repositoryIds.length,
+        expiresAt: expiresAt?.toISOString() ?? null,
+        durationMs: Date.now() - startedAt,
+      }),
+    );
+
+    return { token, expiresAt };
+  } catch (error) {
+    console.warn(
+      JSON.stringify({
+        event: 'github_installation_token_mint',
+        outcome: 'error',
+        installationId,
+        repositoryCount: repositoryIds.length,
+        status: getErrorStatus(error),
+        remaining: getErrorHeader(error, 'x-ratelimit-remaining'),
+        resetAt: getRateLimitResetAt(error),
+        retryAfter: getErrorHeader(error, 'retry-after'),
+        durationMs: Date.now() - startedAt,
+      }),
+    );
+    throw error;
+  }
+}
+
 export async function createGitHubToken(
   options: CreateGitHubTokenOptions,
   octokitOptions?: GitHubAppCredentials,
+  runtimeOptions?: CreateGitHubTokenRuntimeOptions,
 ): Promise<string> {
+  const metadata = await createGitHubTokenWithMetadata(
+    options,
+    octokitOptions,
+    runtimeOptions,
+  );
+  return metadata.token;
+}
+
+export async function createGitHubTokenWithMetadata(
+  options: CreateGitHubTokenOptions,
+  octokitOptions?: GitHubAppCredentials,
+  runtimeOptions?: CreateGitHubTokenRuntimeOptions,
+): Promise<GitHubTokenMetadata> {
   let installation: GitHubInstallation | undefined;
 
   if (options.type === 'activeInstallation') {
@@ -91,22 +296,46 @@ export async function createGitHubToken(
 
   // Scope the token to specific repositories when the caller supplied them, so
   // a task token cannot read or write other repositories in the installation.
-  const repositoryIds =
-    options.type === 'installationId' ? options.repositoryIds : undefined;
-
-  const {
-    data: { token },
-  } = await getOctokit(appCredentials).rest.apps.createInstallationAccessToken({
-    installation_id: installation.installationId,
-    ...(repositoryIds && repositoryIds.length > 0
-      ? { repository_ids: repositoryIds }
-      : {}),
+  const repositoryIds = normalizeRepositoryIds(
+    options.type === 'installationId' ? options.repositoryIds : undefined,
+  );
+  const cacheKey = getGitHubTokenCacheKey({
+    credentials: appCredentials,
+    installationId: installation.installationId,
+    repositoryIds,
   });
+  const cached = getCachedGitHubToken(cacheKey);
+  if (cached) {
+    return cached;
+  }
 
-  return token;
+  const existingMint = githubTokenMintsInFlight.get(cacheKey);
+  if (existingMint) {
+    return existingMint;
+  }
+
+  const mint = mintGitHubToken({
+    installationId: installation.installationId,
+    repositoryIds,
+    appCredentials,
+    runtimeOptions,
+  })
+    .then((metadata) => {
+      cacheGitHubToken(cacheKey, metadata);
+      return metadata;
+    })
+    .finally(() => {
+      githubTokenMintsInFlight.delete(cacheKey);
+    });
+  githubTokenMintsInFlight.set(cacheKey, mint);
+
+  return mint;
 }
 
-export type GitHubAppCredentials = { appId: string; privateKey: string };
+export function clearGitHubTokenCacheForTesting(): void {
+  githubTokenCache.clear();
+  githubTokenMintsInFlight.clear();
+}
 
 export function resolveGitHubAppCredentials(
   options?: GitHubAppCredentials,

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -36,10 +36,13 @@ export {
 } from './mcp-access-token';
 
 export {
+  type CreateGitHubTokenRuntimeOptions,
   type GitHubAppCredentials,
+  type GitHubTokenMetadata,
   type CreateGitHubTokenOptions,
   createGitHubTokenOptionsSchema,
   createGitHubToken,
+  createGitHubTokenWithMetadata,
   resolveGitHubAppCredentials,
 } from './github-token';
 

--- a/packages/github/src/__tests__/api-client.test.ts
+++ b/packages/github/src/__tests__/api-client.test.ts
@@ -260,6 +260,15 @@ describe('getGitHubRateLimitRetryAfterMs', () => {
     expect(getGitHubRateLimitRetryAfterMs(error)).toBe(15 * 60 * 1_000);
   });
 
+  it('treats GitHub token endpoint spam protection as a secondary limit', () => {
+    const error = Object.assign(
+      new Error('Validation failed, or the endpoint has been spammed.'),
+      { status: 422, response: { headers: {} } },
+    );
+
+    expect(getGitHubRateLimitRetryAfterMs(error)).toBe(15 * 60 * 1_000);
+  });
+
   it('rejects ordinary permission failures', () => {
     const error = Object.assign(new Error('Resource not accessible'), {
       status: 403,

--- a/packages/github/src/__tests__/task-run-token.test.ts
+++ b/packages/github/src/__tests__/task-run-token.test.ts
@@ -51,6 +51,7 @@ import type { TaskRun } from '@roomote/db/server';
 import {
   createTaskRunGitHubToken,
   createTaskRunWorkerGitHubTokenWithMetadata,
+  withTaskRunGitHubTokenRetry,
 } from '../api';
 
 function buildTaskRun(payload: TaskRun['payload']): TaskRun {
@@ -333,5 +334,71 @@ describe('createTaskRunGitHubToken', () => {
       source: 'app',
       expiresAt: new Date('2030-01-01T01:00:00.000Z'),
     });
+  });
+
+  it('evicts a cached task token and retries once after a 401', async () => {
+    mockCreateGitHubTokenWithMetadata
+      .mockResolvedValueOnce({
+        token: 'ghs_cached_token',
+        expiresAt: new Date('2030-01-01T01:00:00.000Z'),
+      })
+      .mockResolvedValueOnce({
+        token: 'ghs_fresh_token',
+        expiresAt: new Date('2030-01-01T01:00:00.000Z'),
+      });
+    const unauthorized = Object.assign(new Error('Bad credentials'), {
+      status: 401,
+    });
+    const operation = vi
+      .fn<(token: string) => Promise<string>>()
+      .mockRejectedValueOnce(unauthorized)
+      .mockResolvedValueOnce('ok');
+    const taskRun = buildTaskRun({
+      repo: '__all_repositories__',
+    } as TaskRun['payload']);
+
+    await expect(withTaskRunGitHubTokenRetry(taskRun, operation)).resolves.toBe(
+      'ok',
+    );
+
+    expect(operation).toHaveBeenNthCalledWith(1, 'ghs_cached_token');
+    expect(operation).toHaveBeenNthCalledWith(2, 'ghs_fresh_token');
+    expect(mockCreateGitHubTokenWithMetadata).toHaveBeenNthCalledWith(
+      1,
+      { type: 'activeInstallation' },
+      undefined,
+      {
+        cache: true,
+        maxCacheAgeMs: 15 * 60 * 1000,
+      },
+    );
+    expect(mockCreateGitHubTokenWithMetadata).toHaveBeenNthCalledWith(
+      2,
+      { type: 'activeInstallation' },
+      undefined,
+      {
+        cache: true,
+        forceRefresh: true,
+        maxCacheAgeMs: 15 * 60 * 1000,
+      },
+    );
+  });
+
+  it('does not retry non-authentication failures', async () => {
+    const operation = vi
+      .fn<(token: string) => Promise<string>>()
+      .mockRejectedValueOnce(
+        Object.assign(new Error('Forbidden'), { status: 403 }),
+      );
+
+    await expect(
+      withTaskRunGitHubTokenRetry(
+        buildTaskRun({ repo: '__all_repositories__' } as TaskRun['payload']),
+        operation,
+      ),
+    ).rejects.toThrow('Forbidden');
+
+    expect(operation).toHaveBeenCalledTimes(1);
+    expect(mockCreateGitHubTokenWithMetadata).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/github/src/__tests__/task-run-token.test.ts
+++ b/packages/github/src/__tests__/task-run-token.test.ts
@@ -1,17 +1,17 @@
 const {
-  mockCreateGitHubToken,
+  mockCreateGitHubTokenWithMetadata,
   mockFindMany,
   mockFindFirst,
   mockFindEnvironmentFirst,
 } = vi.hoisted(() => ({
-  mockCreateGitHubToken: vi.fn(),
+  mockCreateGitHubTokenWithMetadata: vi.fn(),
   mockFindMany: vi.fn(),
   mockFindFirst: vi.fn(),
   mockFindEnvironmentFirst: vi.fn(),
 }));
 
 vi.mock('@roomote/auth', () => ({
-  createGitHubToken: mockCreateGitHubToken,
+  createGitHubTokenWithMetadata: mockCreateGitHubTokenWithMetadata,
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -48,7 +48,10 @@ vi.mock('@roomote/db/server', () => ({
 
 import type { TaskRun } from '@roomote/db/server';
 
-import { createTaskRunGitHubToken } from '../api';
+import {
+  createTaskRunGitHubToken,
+  createTaskRunWorkerGitHubTokenWithMetadata,
+} from '../api';
 
 function buildTaskRun(payload: TaskRun['payload']): TaskRun {
   return {
@@ -87,7 +90,10 @@ function buildEnvironmentConfig(repositories: string[]) {
 describe('createTaskRunGitHubToken', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCreateGitHubToken.mockResolvedValue('ghs_test_token');
+    mockCreateGitHubTokenWithMetadata.mockResolvedValue({
+      token: 'ghs_test_token',
+      expiresAt: new Date('2030-01-01T01:00:00.000Z'),
+    });
   });
 
   it('uses the selected repositories installation for scoped multi-repo tasks', async () => {
@@ -117,11 +123,15 @@ describe('createTaskRunGitHubToken', () => {
     ).resolves.toBe('ghs_test_token');
 
     expect(mockFindFirst).not.toHaveBeenCalled();
-    expect(mockCreateGitHubToken).toHaveBeenCalledWith({
-      type: 'installationId',
-      installationId: 'install-exampleorg',
-      repositoryIds: [101, 102],
-    });
+    expect(mockCreateGitHubTokenWithMetadata).toHaveBeenCalledWith(
+      {
+        type: 'installationId',
+        installationId: 'install-exampleorg',
+        repositoryIds: [101, 102],
+      },
+      undefined,
+      undefined,
+    );
   });
 
   it('ignores selected repositories mapped to another provider', async () => {
@@ -146,11 +156,15 @@ describe('createTaskRunGitHubToken', () => {
       ),
     ).resolves.toBe('ghs_test_token');
 
-    expect(mockCreateGitHubToken).toHaveBeenCalledWith({
-      type: 'installationId',
-      installationId: 'install-exampleorg',
-      repositoryIds: [101],
-    });
+    expect(mockCreateGitHubTokenWithMetadata).toHaveBeenCalledWith(
+      {
+        type: 'installationId',
+        installationId: 'install-exampleorg',
+        repositoryIds: [101],
+      },
+      undefined,
+      undefined,
+    );
   });
 
   it('ignores selected repository names omitted from a provider map', async () => {
@@ -203,11 +217,15 @@ describe('createTaskRunGitHubToken', () => {
     ).resolves.toBe('ghs_test_token');
 
     expect(mockFindFirst).not.toHaveBeenCalled();
-    expect(mockCreateGitHubToken).toHaveBeenCalledWith({
-      type: 'installationId',
-      installationId: 'install-roomote',
-      repositoryIds: [201],
-    });
+    expect(mockCreateGitHubTokenWithMetadata).toHaveBeenCalledWith(
+      {
+        type: 'installationId',
+        installationId: 'install-roomote',
+        repositoryIds: [201],
+      },
+      undefined,
+      undefined,
+    );
   });
 
   it('rejects environment repository sets that span multiple installations', async () => {
@@ -237,7 +255,7 @@ describe('createTaskRunGitHubToken', () => {
       'Environment repositories for task run 123 span multiple GitHub installations',
     );
 
-    expect(mockCreateGitHubToken).not.toHaveBeenCalled();
+    expect(mockCreateGitHubTokenWithMetadata).not.toHaveBeenCalled();
   });
 
   it('rejects selected repository sets that span multiple installations', async () => {
@@ -263,7 +281,7 @@ describe('createTaskRunGitHubToken', () => {
       'Selected repositories for task run 123 span multiple GitHub installations',
     );
 
-    expect(mockCreateGitHubToken).not.toHaveBeenCalled();
+    expect(mockCreateGitHubTokenWithMetadata).not.toHaveBeenCalled();
   });
 
   it('fails closed when selected repositories resolve no GitHub repo ids', async () => {
@@ -286,7 +304,7 @@ describe('createTaskRunGitHubToken', () => {
       'Selected repositories for task run 123 resolved no GitHub repository ids',
     );
 
-    expect(mockCreateGitHubToken).not.toHaveBeenCalled();
+    expect(mockCreateGitHubTokenWithMetadata).not.toHaveBeenCalled();
   });
 
   it('falls back to the active installation for true all-repository tasks', async () => {
@@ -298,8 +316,22 @@ describe('createTaskRunGitHubToken', () => {
 
     expect(mockFindMany).not.toHaveBeenCalled();
     expect(mockFindFirst).not.toHaveBeenCalled();
-    expect(mockCreateGitHubToken).toHaveBeenCalledWith({
-      type: 'activeInstallation',
+    expect(mockCreateGitHubTokenWithMetadata).toHaveBeenCalledWith(
+      { type: 'activeInstallation' },
+      undefined,
+      undefined,
+    );
+  });
+
+  it('preserves the installation token expiry for worker refresh scheduling', async () => {
+    await expect(
+      createTaskRunWorkerGitHubTokenWithMetadata(
+        buildTaskRun({ repo: '__all_repositories__' } as TaskRun['payload']),
+      ),
+    ).resolves.toEqual({
+      token: 'ghs_test_token',
+      source: 'app',
+      expiresAt: new Date('2030-01-01T01:00:00.000Z'),
     });
   });
 });

--- a/packages/github/src/api.ts
+++ b/packages/github/src/api.ts
@@ -38,6 +38,7 @@ const ALL_REPOSITORIES = '__all_repositories__';
 const ANALYTICS_CONCURRENCY = 4;
 const ANALYTICS_PULL_REQUESTS_PER_PAGE = 100;
 const ANALYTICS_MAX_ALL_TIME_PULL_REQUEST_PAGES = 50;
+const TASK_RUN_GITHUB_TOKEN_CACHE_MAX_AGE_MS = 15 * 60 * 1000;
 
 async function resolveTokenOptionsForRepositoryNames({
   taskRun,
@@ -266,6 +267,55 @@ export const createTaskRunGitHubToken = async (
   );
   return metadata.token;
 };
+
+export function isGitHubUnauthorizedError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+
+  const topLevelStatus = 'status' in error ? Number(error.status) : null;
+  const responseStatus =
+    'response' in error &&
+    typeof error.response === 'object' &&
+    error.response !== null &&
+    'status' in error.response
+      ? Number(error.response.status)
+      : null;
+
+  return topLevelStatus === 401 || responseStatus === 401;
+}
+
+/**
+ * Run a GitHub operation with a short-lived, task-scoped cached token. A 401
+ * evicts the cached credential and retries the operation exactly once with a
+ * freshly minted token; all other errors preserve their original behavior.
+ */
+export async function withTaskRunGitHubTokenRetry<T>(
+  taskRun: TaskRun,
+  operation: (token: string) => Promise<T>,
+  runtimeOptions?: CreateGitHubTokenRuntimeOptions,
+): Promise<T> {
+  const cacheOptions: CreateGitHubTokenRuntimeOptions = {
+    ...runtimeOptions,
+    cache: true,
+    maxCacheAgeMs: TASK_RUN_GITHUB_TOKEN_CACHE_MAX_AGE_MS,
+  };
+  const token = await createTaskRunGitHubToken(taskRun, cacheOptions);
+
+  try {
+    return await operation(token);
+  } catch (error) {
+    if (!isGitHubUnauthorizedError(error)) {
+      throw error;
+    }
+
+    const refreshedToken = await createTaskRunGitHubToken(taskRun, {
+      ...cacheOptions,
+      forceRefresh: true,
+    });
+    return operation(refreshedToken);
+  }
+}
 
 export type TaskRunWorkerGitHubToken = {
   token: string;

--- a/packages/github/src/api.ts
+++ b/packages/github/src/api.ts
@@ -4,7 +4,13 @@ import jwt from 'jsonwebtoken';
 import { z } from 'zod';
 import pMap from 'p-map';
 
-import { createGitHubToken, resolveGitHubAppCredentials } from '@roomote/auth';
+import {
+  type CreateGitHubTokenOptions,
+  type CreateGitHubTokenRuntimeOptions,
+  type GitHubTokenMetadata,
+  createGitHubTokenWithMetadata,
+  resolveGitHubAppCredentials,
+} from '@roomote/auth';
 import {
   DEFAULT_SOURCE_CONTROL_PROVIDER,
   filterRepositoryNamesForSourceControlProvider,
@@ -33,7 +39,7 @@ const ANALYTICS_CONCURRENCY = 4;
 const ANALYTICS_PULL_REQUESTS_PER_PAGE = 100;
 const ANALYTICS_MAX_ALL_TIME_PULL_REQUEST_PAGES = 50;
 
-async function createTokenForRepositoryNames({
+async function resolveTokenOptionsForRepositoryNames({
   taskRun,
   repositoryNames,
   missingMessagePrefix,
@@ -43,7 +49,7 @@ async function createTokenForRepositoryNames({
   repositoryNames: string[];
   missingMessagePrefix: string;
   spanningMessagePrefix: string;
-}): Promise<string> {
+}): Promise<CreateGitHubTokenOptions> {
   const uniqueRepositoryNames = [
     ...new Set(
       filterRepositoryNamesForSourceControlProvider(
@@ -99,11 +105,11 @@ async function createTokenForRepositoryNames({
       );
     }
 
-    return createGitHubToken({
+    return {
       type: 'installationId',
       installationId: installationIds[0],
       repositoryIds,
-    });
+    };
   }
 
   throw new Error(
@@ -178,9 +184,9 @@ type Checks = RestEndpointMethodTypes['checks'];
  * Authentication
  */
 
-export const createTaskRunGitHubToken = async (
+async function resolveTaskRunGitHubTokenOptions(
   taskRun: TaskRun,
-): Promise<string> => {
+): Promise<CreateGitHubTokenOptions> {
   if (taskRun.payload.environmentId) {
     const environment = await db.query.environments.findFirst({
       where: eq(environments.id, taskRun.payload.environmentId),
@@ -197,7 +203,7 @@ export const createTaskRunGitHubToken = async (
     );
 
     if (environmentRepositories.length > 0) {
-      return createTokenForRepositoryNames({
+      return resolveTokenOptionsForRepositoryNames({
         taskRun,
         repositoryNames: environmentRepositories,
         missingMessagePrefix: 'Environment repositories not found',
@@ -213,7 +219,7 @@ export const createTaskRunGitHubToken = async (
     : [];
 
   if (selectedRepositories.length > 0) {
-    return createTokenForRepositoryNames({
+    return resolveTokenOptionsForRepositoryNames({
       taskRun,
       repositoryNames: selectedRepositories,
       missingMessagePrefix: 'Selected repositories not found',
@@ -237,11 +243,28 @@ export const createTaskRunGitHubToken = async (
 
   const installationId = repo?.installationId;
 
-  const gitHubToken = installationId
-    ? await createGitHubToken({ type: 'installationId', installationId })
-    : await createGitHubToken({ type: 'activeInstallation' });
+  return installationId
+    ? { type: 'installationId', installationId }
+    : { type: 'activeInstallation' };
+}
 
-  return gitHubToken;
+export async function createTaskRunGitHubTokenWithMetadata(
+  taskRun: TaskRun,
+  runtimeOptions?: CreateGitHubTokenRuntimeOptions,
+): Promise<GitHubTokenMetadata> {
+  const options = await resolveTaskRunGitHubTokenOptions(taskRun);
+  return createGitHubTokenWithMetadata(options, undefined, runtimeOptions);
+}
+
+export const createTaskRunGitHubToken = async (
+  taskRun: TaskRun,
+  runtimeOptions?: CreateGitHubTokenRuntimeOptions,
+): Promise<string> => {
+  const metadata = await createTaskRunGitHubTokenWithMetadata(
+    taskRun,
+    runtimeOptions,
+  );
+  return metadata.token;
 };
 
 export type TaskRunWorkerGitHubToken = {
@@ -265,10 +288,11 @@ export type TaskRunWorkerGitHubToken = {
 export async function createTaskRunWorkerGitHubTokenWithMetadata(
   taskRun: TaskRun,
 ): Promise<TaskRunWorkerGitHubToken> {
+  const metadata = await createTaskRunGitHubTokenWithMetadata(taskRun);
   return {
-    token: await createTaskRunGitHubToken(taskRun),
+    token: metadata.token,
     source: 'app',
-    expiresAt: null,
+    expiresAt: metadata.expiresAt,
   };
 }
 
@@ -466,15 +490,26 @@ export function getGitHubRateLimitRetryAfterMs(
 
   const status = 'status' in error ? Number(error.status) : null;
   const graphQlRateLimited = isGraphQlRateLimitError(error);
-  if (status !== 403 && status !== 429 && !graphQlRateLimited) {
-    return null;
-  }
-
   const retryAfter = getErrorHeader(error, 'retry-after');
   const remaining = getErrorHeader(error, 'x-ratelimit-remaining');
   const message = error instanceof Error ? error.message.toLowerCase() : '';
+  const endpointSpammed =
+    status === 422 &&
+    (message.includes('endpoint has been spammed') ||
+      message.includes('abuse detection'));
+
+  if (
+    status !== 403 &&
+    status !== 429 &&
+    !graphQlRateLimited &&
+    !endpointSpammed
+  ) {
+    return null;
+  }
+
   const isRateLimit =
     graphQlRateLimited ||
+    endpointSpammed ||
     status === 429 ||
     retryAfter !== null ||
     remaining === '0' ||

--- a/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-reads.test.ts
+++ b/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-reads.test.ts
@@ -39,6 +39,11 @@ vi.mock('@roomote/github', () => ({
   getOctokit: (...args: unknown[]) => mockGetOctokit(...args),
   getGitHubRateLimitRetryAfterMs: (...args: unknown[]) =>
     mockGetGitHubRateLimitRetryAfterMs(...args),
+  isGitHubUnauthorizedError: (error: unknown) =>
+    typeof error === 'object' &&
+    error !== null &&
+    'status' in error &&
+    Number(error.status) === 401,
 }));
 
 vi.mock('@roomote/gitlab', () => ({
@@ -617,6 +622,42 @@ describe('readSourceControlPullRequestForTaskRun', () => {
         },
       }),
     ).rejects.toBe(rateLimitError);
+  });
+
+  it('propagates GitHub 401s so a task-scoped caller can refresh once', async () => {
+    mockRepositoriesFindFirst.mockResolvedValue({
+      installationId: 'installation-1',
+      externalRepoId: null,
+      fullName: 'acme/backend',
+      htmlUrl: 'https://github.com/acme/backend',
+    });
+    const unauthorized = Object.assign(new Error('Bad credentials'), {
+      status: 401,
+    });
+    mockGetOctokit.mockReturnValue({
+      graphql: vi.fn().mockRejectedValue(unauthorized),
+      paginate: vi.fn().mockResolvedValue([]),
+      rest: {
+        pulls: { listReviewComments: vi.fn() },
+        issues: { listComments: vi.fn() },
+      },
+    });
+
+    await expect(
+      readSourceControlPullRequestForTaskRun({
+        taskRun: makeTaskRun({
+          repo: 'acme/backend',
+          sourceControlProvider: 'github',
+        }),
+        input: {
+          action: 'list_pull_request_comments',
+          repositoryFullName: 'acme/backend',
+          prNumber: 55,
+          sourceControlProvider: 'github',
+        },
+        githubToken: 'github-token',
+      }),
+    ).rejects.toBe(unauthorized);
   });
 
   it('paginates every GitHub review thread and every comment in a thread', async () => {

--- a/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-reads.ts
+++ b/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-reads.ts
@@ -650,12 +650,15 @@ export async function readSourceControlPullRequestForTaskRun({
   fetchImpl = fetch,
   useGitHubConditionalRequests = false,
   onGitHubApiRequest,
+  githubToken,
 }: {
   taskRun: TaskRun;
   input: SourceControlPullRequestReadInput;
   fetchImpl?: FetchImpl;
   useGitHubConditionalRequests?: boolean;
   onGitHubApiRequest?: () => void;
+  /** Optional task-scoped token reused by a larger GitHub read workflow. */
+  githubToken?: string;
 }): Promise<SourceControlPullRequestReadResult> {
   const payloadRecord = getPayloadRecord(taskRun.payload);
   const payloadProvider = resolveSourceControlProviderForRepositoryFromPayload(
@@ -719,6 +722,7 @@ export async function readSourceControlPullRequestForTaskRun({
         provider,
         useConditionalRequests: useGitHubConditionalRequests,
         onGitHubApiRequest,
+        githubToken,
       });
     case 'gitlab':
       return listGitLabMergeRequestComments({
@@ -1003,17 +1007,19 @@ async function listGitHubPullRequestComments({
   provider,
   useConditionalRequests,
   onGitHubApiRequest,
+  githubToken,
 }: {
   prNumber: number;
   repository: RepositoryRow;
   provider: 'github';
   useConditionalRequests: boolean;
   onGitHubApiRequest?: () => void;
+  githubToken?: string;
 }): Promise<SourceControlPullRequestCommentsResult> {
-  const { octokit, owner, repo } = await createGitHubReadClient(
-    repository,
-    provider,
-  );
+  const [owner, repo] = splitRepositoryFullName(repository.fullName, provider);
+  const octokit = githubToken
+    ? getOctokit(githubToken)
+    : (await createGitHubReadClient(repository, provider)).octokit;
   const warnings: string[] = [];
 
   const [reviewComments, restIssueComments] = useConditionalRequests

--- a/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-reads.ts
+++ b/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-reads.ts
@@ -1,5 +1,9 @@
 import { createGitHubToken } from '@roomote/auth';
-import { getGitHubRateLimitRetryAfterMs, getOctokit } from '@roomote/github';
+import {
+  getGitHubRateLimitRetryAfterMs,
+  getOctokit,
+  isGitHubUnauthorizedError,
+} from '@roomote/github';
 import { type TaskRun } from '@roomote/db/server';
 import {
   buildPullRequestUrl,
@@ -1088,7 +1092,10 @@ async function listGitHubPullRequestComments({
       onGitHubApiRequest,
     });
   } catch (error) {
-    if (getGitHubRateLimitRetryAfterMs(error) !== null) {
+    if (
+      isGitHubUnauthorizedError(error) ||
+      getGitHubRateLimitRetryAfterMs(error) !== null
+    ) {
       throw error;
     }
     warnings.push(

--- a/packages/sdk/src/server/lib/task-runs/__tests__/dequeue-helpers.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/dequeue-helpers.test.ts
@@ -726,6 +726,47 @@ describe('createSourceControlTokenForTaskRun', () => {
     }
   });
 
+  it('caps repeated short GitHub rate limits at one inline retry', async () => {
+    const rateLimitError = Object.assign(new Error('Secondary rate limit'), {
+      status: 429,
+    });
+    mockCreateTaskRunWorkerGitHubTokenWithMetadata.mockRejectedValue(
+      rateLimitError,
+    );
+    mockGetGitHubRateLimitRetryAfterMs.mockReturnValue(1);
+    const consoleWarnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    try {
+      const result = await createSourceControlTokenForTaskRun(
+        makeTaskRun({
+          repo: 'owner/repo',
+          description: 'Work on GitHub',
+        }),
+        '[test]',
+        { maxRetries: 3, baseDelayMs: 0 },
+      );
+
+      expect(result).toBeNull();
+      expect(
+        mockCreateTaskRunWorkerGitHubTokenWithMetadata,
+      ).toHaveBeenCalledTimes(2);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"action":"retry"'),
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"action":"abort"'),
+      );
+    } finally {
+      consoleWarnSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
   it('returns null when GitLab token is missing', async () => {
     mockCreateTaskRunScopedGitLabTokens.mockRejectedValueOnce(
       new Error('GITLAB_TOKEN is required for GitLab source control jobs.'),

--- a/packages/sdk/src/server/lib/task-runs/__tests__/dequeue-helpers.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/dequeue-helpers.test.ts
@@ -4,7 +4,8 @@ import type { TaskRun } from '@roomote/db/server';
 const {
   mockDecryptSecrets,
   mockEnvironmentVariablesFindMany,
-  mockCreateTaskRunWorkerGitHubToken,
+  mockCreateTaskRunWorkerGitHubTokenWithMetadata,
+  mockGetGitHubRateLimitRetryAfterMs,
   mockCreateTaskRunScopedGitLabTokens,
   mockCreateTaskRunGiteaCredentials,
   mockCreateTaskRunAdoCredentials,
@@ -16,7 +17,8 @@ const {
 } = vi.hoisted(() => ({
   mockDecryptSecrets: vi.fn(),
   mockEnvironmentVariablesFindMany: vi.fn(),
-  mockCreateTaskRunWorkerGitHubToken: vi.fn(),
+  mockCreateTaskRunWorkerGitHubTokenWithMetadata: vi.fn(),
+  mockGetGitHubRateLimitRetryAfterMs: vi.fn(),
   mockCreateTaskRunScopedGitLabTokens: vi.fn(),
   mockCreateTaskRunGiteaCredentials: vi.fn(),
   mockCreateTaskRunAdoCredentials: vi.fn(),
@@ -69,8 +71,10 @@ vi.mock('@roomote/db/server', () => ({
 }));
 
 vi.mock('@roomote/github', () => ({
-  createTaskRunWorkerGitHubToken: (...args: unknown[]) =>
-    mockCreateTaskRunWorkerGitHubToken(...args),
+  createTaskRunWorkerGitHubTokenWithMetadata: (...args: unknown[]) =>
+    mockCreateTaskRunWorkerGitHubTokenWithMetadata(...args),
+  getGitHubRateLimitRetryAfterMs: (...args: unknown[]) =>
+    mockGetGitHubRateLimitRetryAfterMs(...args),
 }));
 
 vi.mock('@roomote/gitlab', () => ({
@@ -143,7 +147,12 @@ describe('createSourceControlTokenForTaskRun', () => {
     );
     mockDecryptSecrets.mockImplementation(async (value) => value);
     mockEnvironmentVariablesFindMany.mockResolvedValue([]);
-    mockCreateTaskRunWorkerGitHubToken.mockResolvedValue('ghs_app_token');
+    mockCreateTaskRunWorkerGitHubTokenWithMetadata.mockResolvedValue({
+      token: 'ghs_app_token',
+      source: 'app',
+      expiresAt: new Date('2030-01-01T01:00:00.000Z'),
+    });
+    mockGetGitHubRateLimitRetryAfterMs.mockReturnValue(null);
     mockCreateTaskRunScopedGitLabTokens.mockResolvedValue({
       credentials: [
         {
@@ -211,9 +220,11 @@ describe('createSourceControlTokenForTaskRun', () => {
       envVar: 'GH_TOKEN',
       envVars: { GH_TOKEN: 'ghs_app_token' },
       source: 'app',
-      expiresAt: null,
+      expiresAt: new Date('2030-01-01T01:00:00.000Z'),
     });
-    expect(mockCreateTaskRunWorkerGitHubToken).toHaveBeenCalledWith(taskRun);
+    expect(mockCreateTaskRunWorkerGitHubTokenWithMetadata).toHaveBeenCalledWith(
+      taskRun,
+    );
   });
 
   it('creates GitLab token metadata from repo-scoped credentials', async () => {
@@ -252,7 +263,9 @@ describe('createSourceControlTokenForTaskRun', () => {
         ],
       },
     });
-    expect(mockCreateTaskRunWorkerGitHubToken).not.toHaveBeenCalled();
+    expect(
+      mockCreateTaskRunWorkerGitHubTokenWithMetadata,
+    ).not.toHaveBeenCalled();
     expect(mockCreateTaskRunScopedGitLabTokens).toHaveBeenCalledWith(
       expect.objectContaining({
         id: 123,
@@ -377,7 +390,9 @@ describe('createSourceControlTokenForTaskRun', () => {
       source: 'app',
       expiresAt: new Date('2026-08-10T15:00:00.000Z'),
     });
-    expect(mockCreateTaskRunWorkerGitHubToken).not.toHaveBeenCalled();
+    expect(
+      mockCreateTaskRunWorkerGitHubTokenWithMetadata,
+    ).not.toHaveBeenCalled();
     expect(mockCreateTaskRunGiteaCredentials).toHaveBeenCalledWith(
       expect.objectContaining({
         id: 123,
@@ -417,7 +432,9 @@ describe('createSourceControlTokenForTaskRun', () => {
       source: 'app',
       expiresAt: new Date('2026-08-10T14:00:00.000Z'),
     });
-    expect(mockCreateTaskRunWorkerGitHubToken).not.toHaveBeenCalled();
+    expect(
+      mockCreateTaskRunWorkerGitHubTokenWithMetadata,
+    ).not.toHaveBeenCalled();
     expect(mockCreateTaskRunAdoCredentials).toHaveBeenCalledWith(
       expect.objectContaining({
         id: 123,
@@ -467,7 +484,9 @@ describe('createSourceControlTokenForTaskRun', () => {
     );
 
     expect(result).toMatchObject({ provider: 'gitlab' });
-    expect(mockCreateTaskRunWorkerGitHubToken).not.toHaveBeenCalled();
+    expect(
+      mockCreateTaskRunWorkerGitHubTokenWithMetadata,
+    ).not.toHaveBeenCalled();
     expect(mockCreateTaskRunScopedGitLabTokens).toHaveBeenCalled();
   });
 
@@ -538,7 +557,8 @@ describe('createSourceControlTokenForTaskRun', () => {
       },
     });
     expect(
-      mockCreateTaskRunWorkerGitHubToken.mock.invocationCallOrder[0],
+      mockCreateTaskRunWorkerGitHubTokenWithMetadata.mock
+        .invocationCallOrder[0],
     ).toBeLessThan(
       mockCreateTaskRunScopedGitLabTokens.mock.invocationCallOrder[0]!,
     );
@@ -588,7 +608,9 @@ describe('createSourceControlTokenForTaskRun', () => {
       );
 
       expect(result).toBeNull();
-      expect(mockCreateTaskRunWorkerGitHubToken).toHaveBeenCalledTimes(1);
+      expect(
+        mockCreateTaskRunWorkerGitHubTokenWithMetadata,
+      ).toHaveBeenCalledTimes(1);
       expect(mockCreateTaskRunScopedGitLabTokens).toHaveBeenCalledTimes(2);
     } finally {
       consoleWarnSpy.mockRestore();
@@ -627,6 +649,41 @@ describe('createSourceControlTokenForTaskRun', () => {
       expect(mockCreateTaskRunScopedGitLabTokens).not.toHaveBeenCalled();
     } finally {
       consoleWarnSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it('does not retry GitHub token creation before a provider reset', async () => {
+    const rateLimitError = Object.assign(
+      new Error('API rate limit exceeded for installation ID'),
+      { status: 403 },
+    );
+    mockCreateTaskRunWorkerGitHubTokenWithMetadata.mockRejectedValue(
+      rateLimitError,
+    );
+    mockGetGitHubRateLimitRetryAfterMs.mockReturnValue(15 * 60 * 1000);
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    try {
+      const result = await createSourceControlTokenForTaskRun(
+        makeTaskRun({
+          repo: 'owner/repo',
+          description: 'Work on GitHub',
+        }),
+        '[test]',
+        { maxRetries: 3, baseDelayMs: 0 },
+      );
+
+      expect(result).toBeNull();
+      expect(
+        mockCreateTaskRunWorkerGitHubTokenWithMetadata,
+      ).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('source_control_token_creation_rate_limited'),
+      );
+    } finally {
       consoleErrorSpy.mockRestore();
     }
   });

--- a/packages/sdk/src/server/lib/task-runs/__tests__/dequeue-helpers.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/dequeue-helpers.test.ts
@@ -688,6 +688,44 @@ describe('createSourceControlTokenForTaskRun', () => {
     }
   });
 
+  it('honors a short GitHub retry-after delay once before succeeding', async () => {
+    const rateLimitError = Object.assign(new Error('Secondary rate limit'), {
+      status: 429,
+    });
+    mockCreateTaskRunWorkerGitHubTokenWithMetadata
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValueOnce({
+        token: 'ghs_recovered_token',
+        source: 'app',
+        expiresAt: new Date('2030-01-01T01:00:00.000Z'),
+      });
+    mockGetGitHubRateLimitRetryAfterMs.mockReturnValue(1);
+    const consoleWarnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+
+    try {
+      const result = await createSourceControlTokenForTaskRun(
+        makeTaskRun({
+          repo: 'owner/repo',
+          description: 'Work on GitHub',
+        }),
+        '[test]',
+        { maxRetries: 3, baseDelayMs: 0 },
+      );
+
+      expect(result?.token).toBe('ghs_recovered_token');
+      expect(
+        mockCreateTaskRunWorkerGitHubTokenWithMetadata,
+      ).toHaveBeenCalledTimes(2);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"action":"retry"'),
+      );
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
+  });
+
   it('returns null when GitLab token is missing', async () => {
     mockCreateTaskRunScopedGitLabTokens.mockRejectedValueOnce(
       new Error('GITLAB_TOKEN is required for GitLab source control jobs.'),

--- a/packages/sdk/src/server/lib/task-runs/__tests__/pr-review-notification-delivery.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/pr-review-notification-delivery.test.ts
@@ -111,6 +111,16 @@ vi.mock('@roomote/github', () => ({
   }),
   getGitHubRateLimitRetryAfterMs: (...args: unknown[]) =>
     mockGetGitHubRateLimitRetryAfterMs(...args),
+  isGitHubUnauthorizedError: (error: unknown) =>
+    typeof error === 'object' &&
+    error !== null &&
+    'status' in error &&
+    Number(error.status) === 401,
+  withTaskRunGitHubTokenRetry: async (
+    taskRun: unknown,
+    operation: (token: string) => Promise<unknown>,
+    runtimeOptions?: unknown,
+  ) => operation(await mockCreateTaskRunGitHubToken(taskRun, runtimeOptions)),
 }));
 
 import type { TaskRun } from '@roomote/db/server';

--- a/packages/sdk/src/server/lib/task-runs/__tests__/pr-review-notification-delivery.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/pr-review-notification-delivery.test.ts
@@ -163,7 +163,15 @@ beforeEach(() => {
 });
 
 function mockGreenCiChecks() {
-  mockCreateTaskRunGitHubToken.mockResolvedValue('github-token');
+  mockCreateTaskRunGitHubToken.mockImplementation(
+    async (
+      _taskRun: unknown,
+      runtimeOptions?: { onTokenMintRequest?: () => void },
+    ) => {
+      runtimeOptions?.onTokenMintRequest?.();
+      return 'github-token';
+    },
+  );
   mockPullsGet.mockResolvedValue({
     data: { head: { sha: 'abc123' }, mergeable: true },
   });
@@ -1296,10 +1304,12 @@ describe('gatherPrReviewTriageContext', () => {
   });
 
   it('collects thread counts and the latest review status', async () => {
+    const telemetry = createPrReviewNotificationTelemetry(1);
     const context = await gatherPrReviewTriageContext({
       taskRun,
       repository: request.repository,
       prNumber: request.prNumber,
+      telemetry,
     });
 
     expect(context).toEqual({
@@ -1324,8 +1334,13 @@ describe('gatherPrReviewTriageContext', () => {
       mergeable: true,
     });
     expect(mockReadSourceControlPullRequest).toHaveBeenCalledWith(
-      expect.objectContaining({ useGitHubConditionalRequests: true }),
+      expect.objectContaining({
+        useGitHubConditionalRequests: true,
+        githubToken: 'github-token',
+      }),
     );
+    expect(mockCreateTaskRunGitHubToken).toHaveBeenCalledTimes(1);
+    expect(telemetry.githubTokenMintRequests).toBe(1);
   });
 
   it('uses ETags for every GitHub live-head polling read', async () => {

--- a/packages/sdk/src/server/lib/task-runs/dequeue-helpers.ts
+++ b/packages/sdk/src/server/lib/task-runs/dequeue-helpers.ts
@@ -645,6 +645,7 @@ async function createProviderTokenWithRetry(
   baseDelayMs: number,
 ): Promise<SourceControlRuntimeToken | null> {
   const label = getSourceControlProviderLabel(provider);
+  let githubInlineRateLimitRetries = 0;
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
@@ -656,6 +657,7 @@ async function createProviderTokenWithRetry(
 
       if (githubRetryAfterMs !== null) {
         const canRetryInline =
+          githubInlineRateLimitRetries === 0 &&
           attempt < maxRetries &&
           githubRetryAfterMs <= GITHUB_TOKEN_MAX_INLINE_RATE_LIMIT_DELAY_MS;
         const log = canRetryInline ? console.warn : console.error;
@@ -672,6 +674,7 @@ async function createProviderTokenWithRetry(
         );
 
         if (canRetryInline) {
+          githubInlineRateLimitRetries += 1;
           await new Promise((resolve) =>
             setTimeout(resolve, githubRetryAfterMs),
           );

--- a/packages/sdk/src/server/lib/task-runs/dequeue-helpers.ts
+++ b/packages/sdk/src/server/lib/task-runs/dequeue-helpers.ts
@@ -33,7 +33,10 @@ import {
 } from '@roomote/db/server';
 import { captureTaskSettled } from '@roomote/telemetry/server';
 import { decryptSecrets } from '@roomote/db/encryption';
-import { createTaskRunWorkerGitHubToken } from '@roomote/github';
+import {
+  createTaskRunWorkerGitHubTokenWithMetadata,
+  getGitHubRateLimitRetryAfterMs,
+} from '@roomote/github';
 import { createTaskRunScopedGitLabTokens } from '@roomote/gitlab';
 import { createTaskRunBitbucketCredentials } from '@roomote/bitbucket';
 import { createTaskRunGiteaCredentials } from '@roomote/gitea';
@@ -511,11 +514,12 @@ async function createProviderToken(
 ): Promise<SourceControlRuntimeToken> {
   switch (provider) {
     case 'github': {
-      const token = await createTaskRunWorkerGitHubToken(taskRun);
+      const metadata =
+        await createTaskRunWorkerGitHubTokenWithMetadata(taskRun);
       return {
-        ...buildSourceControlTokenMetadata(provider, token),
-        source: 'app',
-        expiresAt: null,
+        ...buildSourceControlTokenMetadata(provider, metadata.token),
+        source: metadata.source,
+        expiresAt: metadata.expiresAt,
       };
     }
     case 'gitlab': {
@@ -646,6 +650,25 @@ async function createProviderTokenWithRetry(
       return await createProviderToken(taskRun, provider);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      const githubRetryAfterMs =
+        provider === 'github' ? getGitHubRateLimitRetryAfterMs(error) : null;
+
+      if (githubRetryAfterMs !== null) {
+        console.error(
+          JSON.stringify({
+            event: 'source_control_token_creation_rate_limited',
+            provider,
+            taskRunId: taskRun.id,
+            attempt,
+            maxRetries,
+            retryAfterMs: githubRetryAfterMs,
+          }),
+        );
+        // A dequeue cannot safely hold a run claim for a provider-directed
+        // delay that may last minutes. Stop immediately instead of converting
+        // one rate-limited POST into two more premature retries.
+        return null;
+      }
 
       if (attempt < maxRetries) {
         const delayMs = baseDelayMs * 2 ** (attempt - 1);

--- a/packages/sdk/src/server/lib/task-runs/dequeue-helpers.ts
+++ b/packages/sdk/src/server/lib/task-runs/dequeue-helpers.ts
@@ -431,6 +431,7 @@ export async function notifyCanceledTaskRunOnSettle(
 
 const SOURCE_CONTROL_TOKEN_MAX_RETRIES = 3;
 const SOURCE_CONTROL_TOKEN_BASE_DELAY_MS = 1_000;
+const GITHUB_TOKEN_MAX_INLINE_RATE_LIMIT_DELAY_MS = 30 * 1_000;
 
 export type SourceControlRuntimeToken = SourceControlTokenMetadata & {
   source: 'user' | 'app';
@@ -654,7 +655,11 @@ async function createProviderTokenWithRetry(
         provider === 'github' ? getGitHubRateLimitRetryAfterMs(error) : null;
 
       if (githubRetryAfterMs !== null) {
-        console.error(
+        const canRetryInline =
+          attempt < maxRetries &&
+          githubRetryAfterMs <= GITHUB_TOKEN_MAX_INLINE_RATE_LIMIT_DELAY_MS;
+        const log = canRetryInline ? console.warn : console.error;
+        log(
           JSON.stringify({
             event: 'source_control_token_creation_rate_limited',
             provider,
@@ -662,8 +667,17 @@ async function createProviderTokenWithRetry(
             attempt,
             maxRetries,
             retryAfterMs: githubRetryAfterMs,
+            action: canRetryInline ? 'retry' : 'abort',
           }),
         );
+
+        if (canRetryInline) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, githubRetryAfterMs),
+          );
+          continue;
+        }
+
         // A dequeue cannot safely hold a run claim for a provider-directed
         // delay that may last minutes. Stop immediately instead of converting
         // one rate-limited POST into two more premature retries.

--- a/packages/sdk/src/server/lib/task-runs/pr-review-notification-delivery.ts
+++ b/packages/sdk/src/server/lib/task-runs/pr-review-notification-delivery.ts
@@ -51,6 +51,7 @@ const PR_REVIEW_TRIAGE_CACHE_MAX_ENTRIES = 500;
 
 type PrReviewNotificationTelemetry = {
   githubApiCalls: number;
+  githubTokenMintRequests: number;
   eventsReceived: number;
   eventsTriaged: number;
   triageInvoked: boolean;
@@ -81,6 +82,7 @@ export function createPrReviewNotificationTelemetry(
 ): PrReviewNotificationTelemetry {
   return {
     githubApiCalls: 0,
+    githubTokenMintRequests: 0,
     eventsReceived,
     eventsTriaged: 0,
     triageInvoked: false,
@@ -430,12 +432,14 @@ async function fetchPrReviewLiveHeadState({
   prNumber,
   sourceControlProvider,
   telemetry,
+  githubToken,
 }: {
   taskRun: TaskRun;
   repository: string;
   prNumber: number;
   sourceControlProvider?: SourceControlProvider;
   telemetry: PrReviewNotificationTelemetry;
+  githubToken?: string;
 }): Promise<PrReviewLiveHeadState> {
   const provider = normalizeSourceControlProvider(sourceControlProvider);
 
@@ -450,7 +454,7 @@ async function fetchPrReviewLiveHeadState({
   }
 
   try {
-    const token = await createTaskRunGitHubToken(taskRun);
+    const token = githubToken ?? (await createTaskRunGitHubToken(taskRun));
     const octokit = getOctokit(token);
 
     const { data: pullRequest } =
@@ -861,11 +865,13 @@ async function fetchPrDiscussionSignals({
   repository,
   prNumber,
   telemetry,
+  githubToken,
 }: {
   taskRun: TaskRun;
   repository: string;
   prNumber: number;
   telemetry: PrReviewNotificationTelemetry;
+  githubToken?: string;
 }): Promise<Omit<PrReviewTriageContext, 'ciStatus' | 'mergeable'>> {
   const result = await readSourceControlPullRequestForTaskRun({
     taskRun,
@@ -878,6 +884,7 @@ async function fetchPrDiscussionSignals({
     onGitHubApiRequest: () => {
       telemetry.githubApiCalls += 1;
     },
+    githubToken,
   });
 
   if (!('threads' in result)) {
@@ -972,6 +979,37 @@ export async function gatherPrReviewTriageContext({
   sourceControlProvider?: SourceControlProvider;
   telemetry?: PrReviewNotificationTelemetry;
 }): Promise<PrReviewTriageContext> {
+  const provider = normalizeSourceControlProvider(sourceControlProvider);
+  let githubToken: string | undefined;
+
+  if (provider === 'github') {
+    try {
+      githubToken = await createTaskRunGitHubToken(taskRun, {
+        onTokenMintRequest: () => {
+          telemetry.githubTokenMintRequests += 1;
+        },
+      });
+    } catch (error) {
+      rethrowGitHubRateLimit(error, telemetry);
+      console.warn(
+        `[PrReviewNotification] Could not create task-scoped GitHub client for ${repository}#${prNumber}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return {
+        resolvedThreadCount: null,
+        unresolvedThreadCount: null,
+        latestReviewStatus: null,
+        latestReviewSummaryComment: null,
+        latestTerminalReviewSummaryHeadSha: null,
+        currentHeadSha: null,
+        reviewThreads: [],
+        ciStatus: null,
+        mergeable: null,
+      };
+    }
+  }
+
   let discussionResult: Omit<PrReviewTriageContext, 'ciStatus' | 'mergeable'>;
   try {
     discussionResult = await fetchPrDiscussionSignals({
@@ -979,9 +1017,10 @@ export async function gatherPrReviewTriageContext({
       repository,
       prNumber,
       telemetry,
+      githubToken,
     });
   } catch (error) {
-    if (normalizeSourceControlProvider(sourceControlProvider) === 'github') {
+    if (provider === 'github') {
       rethrowGitHubRateLimit(error, telemetry);
     }
     console.warn(
@@ -1009,6 +1048,7 @@ export async function gatherPrReviewTriageContext({
     prNumber,
     sourceControlProvider,
     telemetry,
+    githubToken,
   });
 
   return {

--- a/packages/sdk/src/server/lib/task-runs/pr-review-notification-delivery.ts
+++ b/packages/sdk/src/server/lib/task-runs/pr-review-notification-delivery.ts
@@ -17,7 +17,9 @@ import {
   createTaskRunGitHubToken,
   getGitHubRateLimitRetryAfterMs,
   getOctokit,
+  isGitHubUnauthorizedError,
   resolveConfiguredGitHubAppSlug,
+  withTaskRunGitHubTokenRetry,
 } from '@roomote/github';
 import { setLatestSlackBotReply, trackSlackBotReply } from '@roomote/slack';
 import {
@@ -150,6 +152,10 @@ function rethrowGitHubRateLimit(
   error: unknown,
   telemetry: PrReviewNotificationTelemetry,
 ): void {
+  if (isGitHubUnauthorizedError(error)) {
+    throw error;
+  }
+
   if (error instanceof PrReviewNotificationRateLimitError) {
     throw error;
   }
@@ -980,23 +986,29 @@ export async function gatherPrReviewTriageContext({
   telemetry?: PrReviewNotificationTelemetry;
 }): Promise<PrReviewTriageContext> {
   const provider = normalizeSourceControlProvider(sourceControlProvider);
-  let githubToken: string | undefined;
-
-  if (provider === 'github') {
+  const gatherWithToken = async (
+    githubToken?: string,
+  ): Promise<PrReviewTriageContext> => {
+    let discussionResult: Omit<PrReviewTriageContext, 'ciStatus' | 'mergeable'>;
     try {
-      githubToken = await createTaskRunGitHubToken(taskRun, {
-        onTokenMintRequest: () => {
-          telemetry.githubTokenMintRequests += 1;
-        },
+      discussionResult = await fetchPrDiscussionSignals({
+        taskRun,
+        repository,
+        prNumber,
+        telemetry,
+        githubToken,
       });
     } catch (error) {
-      rethrowGitHubRateLimit(error, telemetry);
+      if (provider === 'github') {
+        rethrowGitHubRateLimit(error, telemetry);
+      }
       console.warn(
-        `[PrReviewNotification] Could not create task-scoped GitHub client for ${repository}#${prNumber}: ${
+        `[PrReviewNotification] Could not fetch PR discussion signals for ${repository}#${prNumber}: ${
           error instanceof Error ? error.message : String(error)
         }`,
       );
-      return {
+
+      discussionResult = {
         resolvedThreadCount: null,
         unresolvedThreadCount: null,
         latestReviewStatus: null,
@@ -1004,32 +1016,46 @@ export async function gatherPrReviewTriageContext({
         latestTerminalReviewSummaryHeadSha: null,
         currentHeadSha: null,
         reviewThreads: [],
-        ciStatus: null,
-        mergeable: null,
       };
     }
-  }
 
-  let discussionResult: Omit<PrReviewTriageContext, 'ciStatus' | 'mergeable'>;
-  try {
-    discussionResult = await fetchPrDiscussionSignals({
+    // Avoid starting the live-head request burst when discussion reads have
+    // already established that the installation is rate limited.
+    const liveHeadState = await fetchPrReviewLiveHeadState({
       taskRun,
       repository,
       prNumber,
+      sourceControlProvider,
       telemetry,
       githubToken,
     });
+
+    return {
+      ...discussionResult,
+      currentHeadSha: liveHeadState.currentHeadSha,
+      ciStatus: liveHeadState.ciStatus,
+      mergeable: liveHeadState.mergeable,
+    };
+  };
+
+  if (provider !== 'github') {
+    return gatherWithToken();
+  }
+
+  try {
+    return await withTaskRunGitHubTokenRetry(taskRun, gatherWithToken, {
+      onTokenMintRequest: () => {
+        telemetry.githubTokenMintRequests += 1;
+      },
+    });
   } catch (error) {
-    if (provider === 'github') {
-      rethrowGitHubRateLimit(error, telemetry);
-    }
+    rethrowGitHubRateLimit(error, telemetry);
     console.warn(
-      `[PrReviewNotification] Could not fetch PR discussion signals for ${repository}#${prNumber}: ${
+      `[PrReviewNotification] Could not create task-scoped GitHub client for ${repository}#${prNumber}: ${
         error instanceof Error ? error.message : String(error)
       }`,
     );
-
-    discussionResult = {
+    return {
       resolvedThreadCount: null,
       unresolvedThreadCount: null,
       latestReviewStatus: null,
@@ -1037,26 +1063,10 @@ export async function gatherPrReviewTriageContext({
       latestTerminalReviewSummaryHeadSha: null,
       currentHeadSha: null,
       reviewThreads: [],
+      ciStatus: null,
+      mergeable: null,
     };
   }
-
-  // Avoid starting the live-head request burst when discussion reads have
-  // already established that the installation is rate limited.
-  const liveHeadState = await fetchPrReviewLiveHeadState({
-    taskRun,
-    repository,
-    prNumber,
-    sourceControlProvider,
-    telemetry,
-    githubToken,
-  });
-
-  return {
-    ...discussionResult,
-    currentHeadSha: liveHeadState.currentHeadSha,
-    ciStatus: liveHeadState.ciStatus,
-    mergeable: liveHeadState.mergeable,
-  };
 }
 
 function buildCiContextLines(context: PrReviewTriageContext): string[] {


### PR DESCRIPTION
## What changed

- Coalesce concurrent GitHub App installation-token requests for the same app, installation, and normalized repository scope without caching generic GitHub callers.
- Cache only the PR-notification task-token hot path, with a 15-minute maximum reuse window and the existing five-minute expiry buffer.
- Evict that cached task token and retry the authenticated PR read exactly once when GitHub returns 401.
- Preserve token expiry through task dequeue and resume so workers reuse the bootstrap credential instead of immediately minting another one.
- Recognize primary limits, secondary limits, and GitHub 422 endpoint-spam protection. Dequeue honors Retry-After values up to 30 seconds and aborts longer delays rather than retrying prematurely.
- Reuse one task-scoped GitHub token across PR-notification discussion and live-state reads.
- Add structured mint telemetry without logging token material, and expose actual mint-request counts in PR-notification telemetry.

## Why

Installation tokens are valid for one hour, but Roomote minted a new token for each helper call and immediately refreshed newly bootstrapped worker credentials. Bursty task launches and PR-notification work could therefore create avoidable token POSTs and amplify provider rate limits.

The cache is intentionally narrow: process-local, bounded to 500 exact scopes, opt-in, and used only where Roomote owns the authenticated request boundary and can recover from a rejected cached token.

## Validation

- Focused lint and formatting checks for every modified file
- TURBO_CONCURRENCY=1 pnpm check-types:fast
- pnpm knip
- Full TypeScript checks for auth, GitHub, and SDK after the guardrail changes
- 16 auth tests
- 25 GitHub tests
- 104 SDK unit tests
- 13 worker polling tests from the bootstrap-expiry change
- 32 BullMQ PR-notification tests from the telemetry change

The normal SDK database global setup was unavailable locally because Docker Postgres could not checkpoint. The affected SDK tests mock their persistence boundaries and passed with the database global setup omitted.