### PR TITLE
[Feat] Sticky reply footers on Fast messages in Slack and Discord

### DIFF
--- a/apps/api/src/handlers/discord/__tests__/fast-agent.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/fast-agent.test.ts
@@ -13,6 +13,9 @@ vi.mock('@roomote/cloud-agents/server', () => ({
   acquireFastAgentTurnLock: mocks.acquireLock,
   answerFastAgentQuestion: mocks.answerQuestion,
   resolveApiBaseUrl: () => 'https://roomote.example.com',
+  getOrCreateFastAgentSession: vi
+    .fn()
+    .mockResolvedValue({ id: 'fast-session-1' }),
 }));
 
 vi.mock('@roomote/communication/discord-event', () => ({

--- a/apps/api/src/handlers/discord/__tests__/fast-agent.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/fast-agent.test.ts
@@ -9,6 +9,20 @@ const mocks = vi.hoisted(() => ({
   startTask: vi.fn(),
 }));
 
+vi.mock('@roomote/redis', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@roomote/redis')>();
+  return {
+    ...actual,
+    // The sticky-footer lock and state live in Redis; unit tests run without
+    // a server, so satisfy lock acquisition and empty prior state.
+    getRedis: () => ({
+      set: async () => 'OK',
+      get: async () => null,
+      eval: async () => 1,
+    }),
+  };
+});
+
 vi.mock('@roomote/cloud-agents/server', () => ({
   acquireFastAgentTurnLock: mocks.acquireLock,
   answerFastAgentQuestion: mocks.answerQuestion,

--- a/apps/api/src/handlers/discord/__tests__/index.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/index.test.ts
@@ -177,6 +177,9 @@ vi.mock('@roomote/cloud-agents/server', () => ({
   resolveApiBaseUrl: () => 'https://roomote.example.com',
   getTaskUrl: mocks.getTaskUrl,
   hasFastAgentSession: mocks.hasFastSession,
+  getOrCreateFastAgentSession: vi
+    .fn()
+    .mockResolvedValue({ id: 'fast-session-1' }),
 }));
 
 vi.mock('../../fast-agent-entry.js', () => ({
@@ -766,7 +769,9 @@ describe('Discord Gateway event handler', () => {
     expect(mocks.reply).toHaveBeenCalledWith(
       expect.objectContaining({
         replyToMessageId: 'message-1',
-        text: 'A quick answer',
+        text: expect.stringMatching(
+          /^A quick answer\n\n-# Reply or use the \[web app\]\(.*\/sessions\/fast-session-1.*\)\.$/,
+        ),
       }),
     );
     expect(mocks.startNewTask).not.toHaveBeenCalled();

--- a/apps/api/src/handlers/discord/fast-agent.ts
+++ b/apps/api/src/handlers/discord/fast-agent.ts
@@ -20,6 +20,8 @@ import {
   buildFastSessionReplyFooterText,
   deliverManagedThreadReplyFooter,
   getDiscordFooterlessFinalChunk,
+  getThreadReplyFooterRecord,
+  setThreadReplyFooterRecord,
 } from '@roomote/communication';
 import { resolveUserMcpServerConfigs } from '@roomote/sdk/server';
 import { ALL_REPOSITORIES } from '@roomote/types';
@@ -274,29 +276,61 @@ export async function processDiscordFastAgentMessage(input: {
           return { messageId: posted.messageId };
         },
         replaceReply: async ({ messageId }, { message: text }) => {
-          if (text.length > DISCORD_MAX_MESSAGE_LENGTH) {
+          const footerText = buildFastSessionReplyFooterText({
+            provider: 'discord',
+            sessionId: session.id,
+          });
+          const footerChannelId = conversation.replyTarget.channelId;
+          const footerStateThreadId =
+            conversation.replyTarget.threadId ?? 'root';
+          const footerRecord = await getThreadReplyFooterRecord(
+            'discord',
+            footerChannelId,
+            footerStateThreadId,
+          ).catch(() => null);
+          const isFooterCarrier = footerRecord?.messageId === messageId;
+          const replacementText = isFooterCarrier
+            ? `${text}\n\n${footerText}`
+            : text;
+
+          if (replacementText.length > DISCORD_MAX_MESSAGE_LENGTH) {
+            const placeholder = 'Reconnected to the inference provider.';
             await input.provider.editMessage({
               channelId: input.channel.channelId,
               messageId,
-              text: 'Reconnected to the inference provider.',
+              text: isFooterCarrier
+                ? `${placeholder}\n\n${footerText}`
+                : placeholder,
             });
-            const posted = await replyToDiscordEvent({
-              provider: input.provider,
-              applicationId: input.applicationId,
-              channel: input.channel,
-              ...(message ? { replyToMessageId: message.id } : {}),
-              text,
-            });
+            if (isFooterCarrier) {
+              // The relocation that follows rewrites this message to its
+              // stored footerless text; keep that text current so the edit
+              // does not resurrect the pre-retry notice.
+              await setThreadReplyFooterRecord(
+                'discord',
+                footerChannelId,
+                footerStateThreadId,
+                { messageId, textWithoutFooter: placeholder },
+              ).catch(() => {});
+            }
+            const posted = await postFastReplyWithFooter(text);
             didSendVisibleResponse = true;
-            return {
-              messageId: posted.lastTextMessageId ?? posted.messageId,
-            };
+            return { messageId: posted.messageId };
           }
+
           await input.provider.editMessage({
             channelId: input.channel.channelId,
             messageId,
-            text,
+            text: replacementText,
           });
+          if (isFooterCarrier) {
+            await setThreadReplyFooterRecord(
+              'discord',
+              footerChannelId,
+              footerStateThreadId,
+              { messageId, textWithoutFooter: text },
+            ).catch(() => {});
+          }
           didSendVisibleResponse = true;
           return { messageId };
         },

--- a/apps/api/src/handlers/discord/fast-agent.ts
+++ b/apps/api/src/handlers/discord/fast-agent.ts
@@ -22,6 +22,7 @@ import {
   getDiscordFooterlessFinalChunk,
   getThreadReplyFooterRecord,
   setThreadReplyFooterRecord,
+  withThreadReplyFooterLock,
 } from '@roomote/communication';
 import { resolveUserMcpServerConfigs } from '@roomote/sdk/server';
 import { ALL_REPOSITORIES } from '@roomote/types';
@@ -283,53 +284,69 @@ export async function processDiscordFastAgentMessage(input: {
           const footerChannelId = conversation.replyTarget.channelId;
           const footerStateThreadId =
             conversation.replyTarget.threadId ?? 'root';
-          const footerRecord = await getThreadReplyFooterRecord(
-            'discord',
-            footerChannelId,
-            footerStateThreadId,
-          ).catch(() => null);
-          const isFooterCarrier = footerRecord?.messageId === messageId;
-          const replacementText = isFooterCarrier
-            ? `${text}\n\n${footerText}`
-            : text;
 
-          if (replacementText.length > DISCORD_MAX_MESSAGE_LENGTH) {
-            const placeholder = 'Reconnected to the inference provider.';
-            await input.provider.editMessage({
-              channelId: input.channel.channelId,
-              messageId,
-              text: isFooterCarrier
-                ? `${placeholder}\n\n${footerText}`
-                : placeholder,
-            });
-            if (isFooterCarrier) {
-              // The relocation that follows rewrites this message to its
-              // stored footerless text; keep that text current so the edit
-              // does not resurrect the pre-retry notice.
-              await setThreadReplyFooterRecord(
+          // The carrier check, edit, and record write must share the footer
+          // lock, or a concurrent reply can relocate the footer in between
+          // and this replacement would re-mark the old message as carrier.
+          const replaced = await withThreadReplyFooterLock({
+            lockKey: `discord:thread_reply_footer_lock:${footerChannelId}:${footerStateThreadId}`,
+            fn: async () => {
+              const footerRecord = await getThreadReplyFooterRecord(
                 'discord',
                 footerChannelId,
                 footerStateThreadId,
-                { messageId, textWithoutFooter: placeholder },
-              ).catch(() => {});
-            }
+              ).catch(() => null);
+              const isFooterCarrier = footerRecord?.messageId === messageId;
+              const replacementText = isFooterCarrier
+                ? `${text}\n\n${footerText}`
+                : text;
+
+              if (replacementText.length > DISCORD_MAX_MESSAGE_LENGTH) {
+                const placeholder = 'Reconnected to the inference provider.';
+                await input.provider.editMessage({
+                  channelId: input.channel.channelId,
+                  messageId,
+                  text: isFooterCarrier
+                    ? `${placeholder}\n\n${footerText}`
+                    : placeholder,
+                });
+                if (isFooterCarrier) {
+                  // The relocation that follows rewrites this message to its
+                  // stored footerless text; keep that text current so the
+                  // edit does not resurrect the pre-retry notice.
+                  await setThreadReplyFooterRecord(
+                    'discord',
+                    footerChannelId,
+                    footerStateThreadId,
+                    { messageId, textWithoutFooter: placeholder },
+                  ).catch(() => {});
+                }
+                return false;
+              }
+
+              await input.provider.editMessage({
+                channelId: input.channel.channelId,
+                messageId,
+                text: replacementText,
+              });
+              if (isFooterCarrier) {
+                await setThreadReplyFooterRecord(
+                  'discord',
+                  footerChannelId,
+                  footerStateThreadId,
+                  { messageId, textWithoutFooter: text },
+                ).catch(() => {});
+              }
+              return true;
+            },
+          });
+
+          if (!replaced) {
+            // The oversized replacement posts as a new message; the sticky
+            // post takes the lock itself, so it runs outside ours.
             const posted = await postFastReplyWithFooter(text);
             didSendVisibleResponse = true;
             return { messageId: posted.messageId };
-          }
-
-          await input.provider.editMessage({
-            channelId: input.channel.channelId,
-            messageId,
-            text: replacementText,
-          });
-          if (isFooterCarrier) {
-            await setThreadReplyFooterRecord(
-              'discord',
-              footerChannelId,
-              footerStateThreadId,
-              { messageId, textWithoutFooter: text },
-            ).catch(() => {});
           }
           didSendVisibleResponse = true;
           return { messageId };

--- a/apps/api/src/handlers/discord/fast-agent.ts
+++ b/apps/api/src/handlers/discord/fast-agent.ts
@@ -11,10 +11,16 @@ import {
   type DiscordCommunicationProvider,
 } from '@roomote/communication/discord-provider';
 import {
+  getOrCreateFastAgentSession,
   acquireFastAgentTurnLock,
   answerFastAgentQuestion,
   resolveApiBaseUrl,
 } from '@roomote/cloud-agents/server';
+import {
+  buildFastSessionReplyFooterText,
+  deliverManagedThreadReplyFooter,
+  getDiscordFooterlessFinalChunk,
+} from '@roomote/communication';
 import { resolveUserMcpServerConfigs } from '@roomote/sdk/server';
 import { ALL_REPOSITORIES } from '@roomote/types';
 
@@ -103,6 +109,57 @@ export async function processDiscordFastAgentMessage(input: {
           })
         : [];
     const message = getDiscordMessageCreate(input.event);
+    // Resolved ahead of the turn so replies can carry the session footer;
+    // the service's own getOrCreate finds this same row.
+    const session = await getOrCreateFastAgentSession({
+      userId: input.senderUserId,
+      conversation,
+    });
+    const postFastReplyWithFooter = async (text: string) => {
+      const footerText = buildFastSessionReplyFooterText({
+        provider: 'discord',
+        sessionId: session.id,
+      });
+      const textWithFooter = `${text}\n\n${footerText}`;
+      const channelId = conversation.replyTarget.channelId;
+      const footerStateThreadId = conversation.replyTarget.threadId ?? 'root';
+      const footerMessageChannelId =
+        conversation.replyTarget.threadId ?? channelId;
+
+      return deliverManagedThreadReplyFooter({
+        provider: 'discord',
+        providerLabel: 'Discord',
+        channelId,
+        footerStateThreadId,
+        lockKey: `discord:thread_reply_footer_lock:${channelId}:${footerStateThreadId}`,
+        logRef: `fast session ${session.id}`,
+        logContext: 'DiscordFastAgent',
+        postReplyWithFooter: async () => {
+          const posted = await replyToDiscordEvent({
+            provider: input.provider,
+            applicationId: input.applicationId,
+            channel: input.channel,
+            ...(input.interaction ? { interaction: input.interaction } : {}),
+            ...(message ? { replyToMessageId: message.id } : {}),
+            text: textWithFooter,
+          });
+          return {
+            messageId: posted.lastTextMessageId ?? posted.messageId,
+            textWithoutFooter: getDiscordFooterlessFinalChunk({
+              textWithFooter,
+              footerText,
+            }),
+          };
+        },
+        clearPreviousFooter: async (previousFooterRecord) => {
+          await input.provider.editMessage({
+            channelId: footerMessageChannelId,
+            messageId: previousFooterRecord.messageId,
+            text: previousFooterRecord.textWithoutFooter,
+          });
+        },
+      });
+    };
     let didSendVisibleResponse = false;
     const apiBaseUrl = resolveApiBaseUrl() ?? undefined;
     const response = await answerFastAgentQuestion({
@@ -212,18 +269,9 @@ export async function processDiscordFastAgentMessage(input: {
           };
         },
         postReply: async ({ message: text }) => {
-          const posted = await replyToDiscordEvent({
-            provider: input.provider,
-            applicationId: input.applicationId,
-            channel: input.channel,
-            ...(input.interaction ? { interaction: input.interaction } : {}),
-            ...(message ? { replyToMessageId: message.id } : {}),
-            text,
-          });
+          const posted = await postFastReplyWithFooter(text);
           didSendVisibleResponse = true;
-          return {
-            messageId: posted.lastTextMessageId ?? posted.messageId,
-          };
+          return { messageId: posted.messageId };
         },
         replaceReply: async ({ messageId }, { message: text }) => {
           if (text.length > DISCORD_MAX_MESSAGE_LENGTH) {
@@ -255,14 +303,7 @@ export async function processDiscordFastAgentMessage(input: {
       },
     });
     if (response && !didSendVisibleResponse) {
-      await replyToDiscordEvent({
-        provider: input.provider,
-        applicationId: input.applicationId,
-        channel: input.channel,
-        ...(input.interaction ? { interaction: input.interaction } : {}),
-        ...(message ? { replyToMessageId: message.id } : {}),
-        text: response,
-      });
+      await postFastReplyWithFooter(response);
     }
   } finally {
     await releaseFastAgentLock().catch(() => {});

--- a/apps/api/src/handlers/slack/events/fast-agent-processing.test.ts
+++ b/apps/api/src/handlers/slack/events/fast-agent-processing.test.ts
@@ -6,6 +6,21 @@ const mocks = vi.hoisted(() => ({
   postThreadMessage: vi.fn(),
 }));
 
+vi.mock('@roomote/redis', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@roomote/redis')>();
+  return {
+    ...actual,
+    // The sticky-footer state lives in Redis; unit tests run without a
+    // server (a real client would wait on commands forever), so serve
+    // empty state.
+    getRedis: () => ({
+      set: async () => 'OK',
+      get: async () => null,
+      eval: async () => 1,
+    }),
+  };
+});
+
 vi.mock('@roomote/cloud-agents/server', () => ({
   acquireFastAgentTurnLock: mocks.acquireLock,
   answerFastAgentQuestion: mocks.answerQuestion,

--- a/apps/api/src/handlers/slack/events/fast-agent-processing.test.ts
+++ b/apps/api/src/handlers/slack/events/fast-agent-processing.test.ts
@@ -10,6 +10,9 @@ vi.mock('@roomote/cloud-agents/server', () => ({
   acquireFastAgentTurnLock: mocks.acquireLock,
   answerFastAgentQuestion: mocks.answerQuestion,
   hasFastAgentSession: mocks.hasSession,
+  getOrCreateFastAgentSession: vi
+    .fn()
+    .mockResolvedValue({ id: 'fast-session-1' }),
 }));
 
 vi.mock('@roomote/cloud-agents', () => ({

--- a/apps/api/src/handlers/slack/events/fast-agent.ts
+++ b/apps/api/src/handlers/slack/events/fast-agent.ts
@@ -10,6 +10,7 @@ import { buildFastSessionReplyFooterText } from '@roomote/communication';
 import {
   buildSlackThreadReplyFooterBlock,
   getSlackThreadReplyFooterMessageTs,
+  withSlackThreadReplyFooterLock,
   resolveCurrentSlackMessageFiles,
   type SlackEvent,
   type SlackNotifier,
@@ -228,29 +229,36 @@ export async function processFastAgentMessage(params: {
         },
         replaceReply: async ({ messageId }, { message }) => {
           // Keep the sticky footer when the edited message is its current
-          // carrier; a bare block replacement would silently drop it.
-          const footerMessageTs = await getSlackThreadReplyFooterMessageTs(
-            event.channel,
-            threadId,
-          ).catch(() => null);
-          const updated = await slack.updateMessage({
+          // carrier; the lookup and edit share the footer lock so a
+          // concurrent relocation cannot slip in between them.
+          const updated = await withSlackThreadReplyFooterLock({
             channel: event.channel,
-            ts: messageId,
-            message: {
-              text: message,
-              blocks: [
-                { type: 'markdown', text: message },
-                ...(footerMessageTs === messageId
-                  ? [
-                      buildSlackThreadReplyFooterBlock({
-                        footerText: buildFastSessionReplyFooterText({
-                          provider: 'slack',
-                          sessionId: session.id,
-                        }),
-                      }),
-                    ]
-                  : []),
-              ],
+            threadTs: threadId,
+            fn: async () => {
+              const footerMessageTs = await getSlackThreadReplyFooterMessageTs(
+                event.channel,
+                threadId,
+              ).catch(() => null);
+              return slack.updateMessage({
+                channel: event.channel,
+                ts: messageId,
+                message: {
+                  text: message,
+                  blocks: [
+                    { type: 'markdown', text: message },
+                    ...(footerMessageTs === messageId
+                      ? [
+                          buildSlackThreadReplyFooterBlock({
+                            footerText: buildFastSessionReplyFooterText({
+                              provider: 'slack',
+                              sessionId: session.id,
+                            }),
+                          }),
+                        ]
+                      : []),
+                  ],
+                },
+              });
             },
           });
           if (!updated) {

--- a/apps/api/src/handlers/slack/events/fast-agent.ts
+++ b/apps/api/src/handlers/slack/events/fast-agent.ts
@@ -1,4 +1,5 @@
 import {
+  getOrCreateFastAgentSession,
   acquireFastAgentTurnLock,
   answerFastAgentQuestion,
   hasFastAgentSession,
@@ -117,6 +118,10 @@ export async function processFastAgentMessage(params: {
       });
     }
 
+    // Resolved ahead of the turn so replies can carry the session footer;
+    // the service's own getOrCreate finds this same row.
+    const session = await getOrCreateFastAgentSession({ userId, conversation });
+
     let threadContext: Awaited<ReturnType<typeof slack.fetchThreadMessages>> =
       [];
 
@@ -197,6 +202,7 @@ export async function processFastAgentMessage(params: {
               slackTeamId: teamId,
               source: 'fast_agent',
             },
+            fastSessionFooter: { sessionId: session.id },
           });
           if (posted === 'failed') {
             throw new Error('Slack did not accept the Fast parent reply.');
@@ -270,6 +276,7 @@ export async function processFastAgentMessage(params: {
           slackTeamId: teamId,
           source: 'fast_agent',
         },
+        fastSessionFooter: { sessionId: session.id },
       });
     }
   } finally {

--- a/apps/api/src/handlers/slack/events/fast-agent.ts
+++ b/apps/api/src/handlers/slack/events/fast-agent.ts
@@ -6,7 +6,10 @@ import {
   type FastAgentActiveTask,
   type LaunchFastAgentTask,
 } from '@roomote/cloud-agents/server';
+import { buildFastSessionReplyFooterText } from '@roomote/communication';
 import {
+  buildSlackThreadReplyFooterBlock,
+  getSlackThreadReplyFooterMessageTs,
   resolveCurrentSlackMessageFiles,
   type SlackEvent,
   type SlackNotifier,
@@ -224,12 +227,30 @@ export async function processFastAgentMessage(params: {
             : undefined;
         },
         replaceReply: async ({ messageId }, { message }) => {
+          // Keep the sticky footer when the edited message is its current
+          // carrier; a bare block replacement would silently drop it.
+          const footerMessageTs = await getSlackThreadReplyFooterMessageTs(
+            event.channel,
+            threadId,
+          ).catch(() => null);
           const updated = await slack.updateMessage({
             channel: event.channel,
             ts: messageId,
             message: {
               text: message,
-              blocks: [{ type: 'markdown', text: message }],
+              blocks: [
+                { type: 'markdown', text: message },
+                ...(footerMessageTs === messageId
+                  ? [
+                      buildSlackThreadReplyFooterBlock({
+                        footerText: buildFastSessionReplyFooterText({
+                          provider: 'slack',
+                          sessionId: session.id,
+                        }),
+                      }),
+                    ]
+                  : []),
+              ],
             },
           });
           if (!updated) {

--- a/apps/api/src/handlers/slack/helpers/thread-posting.ts
+++ b/apps/api/src/handlers/slack/helpers/thread-posting.ts
@@ -4,9 +4,11 @@ import {
   findSlackConversationSubjectByUserId,
   recordSlackConversationMessageBestEffort,
 } from '@roomote/sdk/server';
+import { buildFastSessionReplyFooterText } from '@roomote/communication';
 import {
   buildStartedBlocks,
   persistPostedSlackKickoff,
+  postSlackThreadMessageWithFooterText,
   type SlackNotifier,
 } from '@roomote/slack';
 
@@ -24,6 +26,7 @@ export async function postSlackThreadMarkdownMessage({
   text,
   sourceMessageTs,
   conversationLog,
+  fastSessionFooter,
 }: {
   slack: SlackNotifier;
   channel: string;
@@ -35,6 +38,8 @@ export async function postSlackThreadMarkdownMessage({
     slackTeamId: string;
     source: string;
   };
+  /** Attach the sticky Fast session reply footer to this message. */
+  fastSessionFooter?: { sessionId: string };
 }): Promise<SlackThreadMarkdownPostResult> {
   if (sourceMessageTs) {
     const sourceMessageExists = await slack.hasMessageInThread({
@@ -53,17 +58,29 @@ export async function postSlackThreadMarkdownMessage({
     }
   }
 
-  const messageTs = await slack.postMessage({
-    channel,
-    thread_ts: threadTs,
-    text,
-    blocks: [
-      {
-        type: 'markdown',
+  const messageTs = fastSessionFooter
+    ? await postSlackThreadMessageWithFooterText({
+        slack,
+        channel,
+        threadTs,
         text,
-      },
-    ],
-  });
+        bodyBlocks: [{ type: 'markdown', text }],
+        footerText: buildFastSessionReplyFooterText({
+          provider: 'slack',
+          sessionId: fastSessionFooter.sessionId,
+        }),
+      })
+    : await slack.postMessage({
+        channel,
+        thread_ts: threadTs,
+        text,
+        blocks: [
+          {
+            type: 'markdown',
+            text,
+          },
+        ],
+      });
 
   if (!messageTs) {
     return 'failed';

--- a/apps/docs/fast-sessions.mdx
+++ b/apps/docs/fast-sessions.mdx
@@ -34,4 +34,6 @@ Every session has a reply box at the bottom of the transcript; follow-ups
 continue the same conversation with full context. For conversations that live
 on another surface, such as a Slack thread, Roomote's answer is posted back
 into the originating thread with a quoted copy of your web message, so the
-conversation stays in one place for everyone following it there.
+conversation stays in one place for everyone following it there. Fast replies
+in Slack and Discord carry the same "Reply or use the web app" footer as task
+replies, linking to the session view.

--- a/packages/communication/src/fast-session-footer.ts
+++ b/packages/communication/src/fast-session-footer.ts
@@ -1,0 +1,64 @@
+import { Env } from '@roomote/env';
+
+import {
+  buildThreadReplyFooterText,
+  formatMarkdownLink,
+} from './chat-messages';
+import { chunkDiscordMessage } from './discord-provider';
+
+export type FastSessionFooterProvider = 'slack' | 'discord';
+
+export function buildFastSessionUrl(
+  provider: FastSessionFooterProvider,
+  sessionId: string,
+): string {
+  const url = new URL(`${Env.R_APP_URL}/sessions/${sessionId}`);
+  url.searchParams.set('utm_source', provider);
+  url.searchParams.set('utm_medium', 'link');
+  url.searchParams.set('utm_campaign', `${provider}.fast_reply`);
+  return url.toString();
+}
+
+/**
+ * The Fast-session variant of the task thread-reply footer: always the plain
+ * "Reply or use the web app." shape, linking to the session view.
+ */
+export function buildFastSessionReplyFooterText(params: {
+  provider: FastSessionFooterProvider;
+  sessionId: string;
+}): string {
+  const sessionUrl = buildFastSessionUrl(params.provider, params.sessionId);
+
+  return buildThreadReplyFooterText({
+    taskUrl: sessionUrl,
+    linkedPrs: [],
+    livePreviewUrl: null,
+    explicitMentionRequired: false,
+    ...(params.provider === 'slack'
+      ? { formatLink: (label: string, url: string) => `<${url}|${label}>` }
+      : {
+          formatLink: formatMarkdownLink,
+          formatFooterText: (text: string) => `-# ${text}`,
+        }),
+  });
+}
+
+/**
+ * The last Discord chunk of a footer-bearing message with the footer removed,
+ * for rewriting that message when the footer relocates to a newer reply.
+ */
+export function getDiscordFooterlessFinalChunk(params: {
+  textWithFooter: string;
+  footerText: string;
+}): string {
+  const finalChunk = chunkDiscordMessage(params.textWithFooter).at(-1) ?? '';
+
+  if (finalChunk === params.footerText) {
+    return '';
+  }
+
+  const footerSuffix = `\n\n${params.footerText}`;
+  return finalChunk.endsWith(footerSuffix)
+    ? finalChunk.slice(0, -footerSuffix.length)
+    : finalChunk;
+}

--- a/packages/communication/src/index.ts
+++ b/packages/communication/src/index.ts
@@ -14,5 +14,7 @@ export * from './teams-graph-client';
 export * from './teams-provider';
 export * from './telegram-provider';
 export * from './telegram-update';
+export * from './fast-session-footer';
 export * from './thread-reply-footer-context';
+export * from './thread-reply-footer-delivery';
 export * from './thread-reply-footer-state';

--- a/packages/communication/src/thread-reply-footer-delivery.ts
+++ b/packages/communication/src/thread-reply-footer-delivery.ts
@@ -1,0 +1,148 @@
+import crypto from 'node:crypto';
+
+import { getRedis } from '@roomote/redis';
+
+import {
+  getThreadReplyFooterRecord,
+  setThreadReplyFooterRecord,
+  type ThreadReplyFooterRecord,
+} from './thread-reply-footer-state';
+import type { CommunicationProvider } from '@roomote/types';
+
+const THREAD_REPLY_FOOTER_LOCK_TTL_SECONDS = 30;
+const THREAD_REPLY_FOOTER_LOCK_MAX_ATTEMPTS = 8;
+const THREAD_REPLY_FOOTER_LOCK_RETRY_MS = 100;
+const RELEASE_LOCK_SCRIPT =
+  "if redis.call('get',KEYS[1])==ARGV[1] then return redis.call('del',KEYS[1]) else return 0 end";
+
+export const THREAD_REPLY_FOOTER_LOCK_TIMEOUT_MESSAGE =
+  'Timed out acquiring thread reply footer lock';
+
+export async function withThreadReplyFooterLock<T>(params: {
+  lockKey: string;
+  maxAcquireAttempts?: number;
+  fn: () => Promise<T>;
+}): Promise<T> {
+  const redis = getRedis();
+  const maxAcquireAttempts =
+    params.maxAcquireAttempts ?? THREAD_REPLY_FOOTER_LOCK_MAX_ATTEMPTS;
+
+  for (let attempt = 0; attempt < maxAcquireAttempts; attempt += 1) {
+    const ownerId = crypto.randomUUID();
+    const acquired = await redis.set(
+      params.lockKey,
+      ownerId,
+      'EX',
+      THREAD_REPLY_FOOTER_LOCK_TTL_SECONDS,
+      'NX',
+    );
+
+    if (acquired) {
+      try {
+        return await params.fn();
+      } finally {
+        await redis
+          .eval(RELEASE_LOCK_SCRIPT, 1, params.lockKey, ownerId)
+          .catch(() => {});
+      }
+    }
+
+    await new Promise((resolve) =>
+      setTimeout(resolve, THREAD_REPLY_FOOTER_LOCK_RETRY_MS),
+    );
+  }
+
+  throw new Error(THREAD_REPLY_FOOTER_LOCK_TIMEOUT_MESSAGE);
+}
+
+type PostedFooterRecord<T extends { messageId: string }> = T & {
+  textWithoutFooter: string;
+  images?: ThreadReplyFooterRecord['images'];
+};
+
+/**
+ * Post a reply that becomes the thread's footer-bearing message: read the
+ * previous footer record, post the new reply (with footer attached by the
+ * caller), rewrite the previous message without its footer, and persist the
+ * new record. Managed-provider counterpart of the Slack sticky footer ops.
+ *
+ * apps/api's MCP thread replies keep their own copy of this flow
+ * (handlers/mcp/communication-thread-reply-shared.ts) because its tests mock
+ * this package's barrel; keep behavior changes in sync.
+ */
+export async function deliverManagedThreadReplyFooter<
+  TReply extends { messageId: string },
+>(params: {
+  provider: CommunicationProvider;
+  providerLabel: string;
+  channelId: string;
+  footerStateThreadId: string;
+  lockKey: string;
+  /** Identifies the subject in failure logs (e.g. "task run 42"). */
+  logRef: string;
+  logContext: string;
+  postReplyWithFooter: () => Promise<PostedFooterRecord<TReply>>;
+  clearPreviousFooter: (
+    previousFooterRecord: ThreadReplyFooterRecord,
+  ) => Promise<void>;
+}): Promise<TReply> {
+  return withThreadReplyFooterLock({
+    lockKey: params.lockKey,
+    fn: async () => {
+      let previousFooterRecord: ThreadReplyFooterRecord | null = null;
+      try {
+        previousFooterRecord = await getThreadReplyFooterRecord(
+          params.provider,
+          params.channelId,
+          params.footerStateThreadId,
+        );
+      } catch (error) {
+        console.error(
+          `[${params.logContext}] Failed to read previous ${params.providerLabel} footer record for ${params.logRef}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+
+      const posted = await params.postReplyWithFooter();
+
+      if (
+        previousFooterRecord &&
+        previousFooterRecord.messageId !== posted.messageId
+      ) {
+        try {
+          await params.clearPreviousFooter(previousFooterRecord);
+        } catch (error) {
+          console.error(
+            `[${params.logContext}] Failed to clear prior ${params.providerLabel} footer message ${previousFooterRecord.messageId}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }
+
+      try {
+        await setThreadReplyFooterRecord(
+          params.provider,
+          params.channelId,
+          params.footerStateThreadId,
+          {
+            messageId: posted.messageId,
+            textWithoutFooter: posted.textWithoutFooter,
+            ...(posted.images && posted.images.length > 0
+              ? { images: posted.images }
+              : {}),
+          },
+        );
+      } catch (error) {
+        console.error(
+          `[${params.logContext}] Failed to persist latest ${params.providerLabel} footer record ${posted.messageId}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+
+      return posted;
+    },
+  });
+}

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
@@ -23,6 +23,20 @@ const mocks = vi.hoisted(() => ({
   resolveUserMcpServerConfigs: vi.fn(),
 }));
 
+vi.mock('@roomote/redis', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@roomote/redis')>();
+  return {
+    ...actual,
+    // The sticky-footer lock and state live in Redis; these tests run without
+    // a server, so satisfy lock acquisition and empty prior state.
+    getRedis: () => ({
+      set: async () => 'OK',
+      get: async () => null,
+      eval: async () => 1,
+    }),
+  };
+});
+
 vi.mock('@roomote/cloud-agents/server', () => ({
   acquireFastAgentTurnLock: mocks.acquireTurnLock,
   answerFastAgentQuestion: mocks.answerQuestion,

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
@@ -274,6 +274,16 @@ describe('deliverFastAgentParentEvent', () => {
               'https://api.roomote.example/api/artifacts/artifact-1/raw?signed=1',
             alt_text: 'result.png',
           },
+          {
+            type: 'context',
+            block_id: 'roomote_thread_reply_footer',
+            elements: [
+              {
+                type: 'mrkdwn',
+                text: expect.stringContaining('Reply or use the'),
+              },
+            ],
+          },
         ],
       }),
     );
@@ -530,7 +540,9 @@ describe('deliverFastAgentParentEvent', () => {
     expect(mocks.discordPostMessage).toHaveBeenCalledWith({
       channelId: 'channel-1',
       idempotencyKey: 'fast-parent-artifact:artifact-1:v1',
-      text: 'The proof is ready.',
+      text: expect.stringMatching(
+        /^The proof is ready\.\n\n-# Reply or use the \[web app\]\(.*\/sessions\/.*\)\.$/,
+      ),
       textFormat: 'markdown',
       images: [
         {
@@ -851,7 +863,9 @@ describe('deliverFastAgentParentEvent', () => {
       channelId: 'channel-1',
       threadId: 'thread-1',
       idempotencyKey: 'fast-parent-pr-feedback:feedback-123',
-      text: 'There is new PR feedback.\nWant me to resolve these issues?',
+      text: expect.stringMatching(
+        /^There is new PR feedback\.\nWant me to resolve these issues\?\n\n-# Reply or use the \[web app\]\(.*\/sessions\/.*\)\.$/,
+      ),
       textFormat: 'markdown',
       images: [],
       buttons: [

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.ts
@@ -28,9 +28,15 @@ import { Env, getArtifactSigningKey } from '@roomote/env';
 import {
   buildSlackPrReviewActionBlocks,
   createFastAgentSlackLiveTaskLauncher,
+  postSlackThreadMessageWithFooterText,
   resolveSlackReactionNames,
   SlackNotifier,
 } from '@roomote/slack';
+import {
+  buildFastSessionReplyFooterText,
+  deliverManagedThreadReplyFooter,
+  getDiscordFooterlessFinalChunk,
+} from '@roomote/communication';
 import {
   ALL_REPOSITORIES,
   buildFastAgentChildTaskMetadata,
@@ -579,11 +585,12 @@ async function createSlackFastAgentParentTurn(params: {
             followUpPrompt: action.followUpPrompt,
           });
         }
-        const messageTs = await slack.postMessage({
+        const messageTs = await postSlackThreadMessageWithFooterText({
+          slack,
           channel: conversation.replyTarget.channelId,
-          thread_ts: conversation.replyTarget.threadId,
+          threadTs: conversation.replyTarget.threadId,
           text: action ? `${message}\n${action.question}` : message,
-          blocks: action
+          bodyBlocks: action
             ? buildSlackPrReviewActionBlocks({
                 text: message,
                 question: action.question,
@@ -597,9 +604,11 @@ async function createSlackFastAgentParentTurn(params: {
                   alt_text: image.altText,
                 })),
               ],
-          unfurl_links: false,
-          unfurl_media: false,
-          client_msg_id: buildSlackClientMessageId(
+          footerText: buildFastSessionReplyFooterText({
+            provider: 'slack',
+            sessionId: params.parent.sessionId,
+          }),
+          clientMsgId: buildSlackClientMessageId(
             buildEventClientMessageSeed(params.event),
           ),
         });
@@ -679,6 +688,52 @@ export function createFastAgentDiscordTaskLauncher(params: {
             : {}),
         },
       } satisfies StandardTask;
+    },
+  });
+}
+
+async function postDiscordFastParentMessageWithFooter(params: {
+  provider: NonNullable<
+    Awaited<
+      ReturnType<
+        typeof createDiscordCommunicationProviderFromRuntimeCredentials
+      >
+    >
+  >;
+  conversation: Extract<FastAgentConversation, { surface: 'discord' }>;
+  sessionId: string;
+  footerText: string;
+  textWithFooter: string;
+  post: () => Promise<{ messageId: string; lastTextMessageId?: string }>;
+}): Promise<{ messageId: string }> {
+  const channelId = params.conversation.replyTarget.channelId;
+  const footerStateThreadId =
+    params.conversation.replyTarget.threadId ?? 'root';
+
+  return deliverManagedThreadReplyFooter({
+    provider: 'discord',
+    providerLabel: 'Discord',
+    channelId,
+    footerStateThreadId,
+    lockKey: `discord:thread_reply_footer_lock:${channelId}:${footerStateThreadId}`,
+    logRef: `fast session ${params.sessionId}`,
+    logContext: 'fastAgentParentEvent',
+    postReplyWithFooter: async () => {
+      const result = await params.post();
+      return {
+        messageId: result.lastTextMessageId ?? result.messageId,
+        textWithoutFooter: getDiscordFooterlessFinalChunk({
+          textWithFooter: params.textWithFooter,
+          footerText: params.footerText,
+        }),
+      };
+    },
+    clearPreviousFooter: async (previousFooterRecord) => {
+      await params.provider.editMessage({
+        channelId: params.conversation.replyTarget.threadId ?? channelId,
+        messageId: previousFooterRecord.messageId,
+        text: previousFooterRecord.textWithoutFooter,
+      });
     },
   });
 }
@@ -769,46 +824,60 @@ async function createDiscordFastAgentParentTurn(params: {
           });
         }
 
-        const posted = await provider.postMessage({
-          ...conversation.replyTarget,
-          idempotencyKey: buildEventClientMessageSeed(params.event),
-          text: action ? `${message}\n${action.question}` : message,
-          textFormat: 'markdown',
-          images,
-          ...(action
-            ? {
-                buttons: [
-                  [
-                    {
-                      text: 'Resolve these issues',
-                      callbackData: buildPrReviewActionCallbackData(
-                        'yes',
-                        action.nonce,
-                      ),
-                    },
-                    {
-                      text: 'Auto-resolve on this PR',
-                      callbackData: buildPrReviewActionCallbackData(
-                        'auto',
-                        action.nonce,
-                      ),
-                    },
-                    {
-                      text: 'Dismiss',
-                      callbackData: buildPrReviewActionCallbackData(
-                        'dismiss',
-                        action.nonce,
-                      ),
-                    },
-                  ],
-                ],
-              }
-            : {}),
+        const footerText = buildFastSessionReplyFooterText({
+          provider: 'discord',
+          sessionId: params.parent.sessionId,
+        });
+        const bodyText = action ? `${message}\n${action.question}` : message;
+        const textWithFooter = `${bodyText}\n\n${footerText}`;
+        const posted = await postDiscordFastParentMessageWithFooter({
+          provider,
+          conversation,
+          sessionId: params.parent.sessionId,
+          footerText,
+          textWithFooter,
+          post: () =>
+            provider.postMessage({
+              ...conversation.replyTarget,
+              idempotencyKey: buildEventClientMessageSeed(params.event),
+              text: textWithFooter,
+              textFormat: 'markdown',
+              images,
+              ...(action
+                ? {
+                    buttons: [
+                      [
+                        {
+                          text: 'Resolve these issues',
+                          callbackData: buildPrReviewActionCallbackData(
+                            'yes',
+                            action.nonce,
+                          ),
+                        },
+                        {
+                          text: 'Auto-resolve on this PR',
+                          callbackData: buildPrReviewActionCallbackData(
+                            'auto',
+                            action.nonce,
+                          ),
+                        },
+                        {
+                          text: 'Dismiss',
+                          callbackData: buildPrReviewActionCallbackData(
+                            'dismiss',
+                            action.nonce,
+                          ),
+                        },
+                      ],
+                    ],
+                  }
+                : {}),
+            }),
         });
         if (action) {
           await attachPendingPrReviewActionMessage(
             action.nonce,
-            posted.lastTextMessageId ?? posted.messageId,
+            posted.messageId,
           );
         }
         params.onReplyPosted();

--- a/packages/sdk/src/server/lib/fast-agent-surface-reply.ts
+++ b/packages/sdk/src/server/lib/fast-agent-surface-reply.ts
@@ -14,6 +14,7 @@ import {
   createFastAgentSlackLiveTaskLauncher,
   getSlackThreadReplyFooterMessageTs,
   postSlackThreadMessageWithFooterText,
+  withSlackThreadReplyFooterLock,
   buildSlackThreadReplyFooterBlock,
   SlackNotifier,
   ROOMOTE_THREAD_REPLY_QUOTE_BLOCK_ID,
@@ -194,29 +195,36 @@ export async function buildFastAgentSurfaceReplyDelivery(params: {
         },
         replaceReply: async (handle, { message }) => {
           // Keep the sticky footer when the edited message is its current
-          // carrier; a bare block replacement would silently drop it.
-          const footerMessageTs = await getSlackThreadReplyFooterMessageTs(
-            conversation.replyTarget.channelId,
-            conversation.replyTarget.threadId,
-          ).catch(() => null);
-          const updated = await slack.updateMessage({
+          // carrier; the lookup and edit share the footer lock so a
+          // concurrent relocation cannot slip in between them.
+          const updated = await withSlackThreadReplyFooterLock({
             channel: conversation.replyTarget.channelId,
-            ts: handle.messageId,
-            message: {
-              text: message,
-              blocks: [
-                { type: 'markdown', text: message },
-                ...(footerMessageTs === handle.messageId
-                  ? [
-                      buildSlackThreadReplyFooterBlock({
-                        footerText: buildFastSessionReplyFooterText({
-                          provider: 'slack',
-                          sessionId: session.id,
-                        }),
-                      }),
-                    ]
-                  : []),
-              ],
+            threadTs: conversation.replyTarget.threadId,
+            fn: async () => {
+              const footerMessageTs = await getSlackThreadReplyFooterMessageTs(
+                conversation.replyTarget.channelId,
+                conversation.replyTarget.threadId,
+              ).catch(() => null);
+              return slack.updateMessage({
+                channel: conversation.replyTarget.channelId,
+                ts: handle.messageId,
+                message: {
+                  text: message,
+                  blocks: [
+                    { type: 'markdown', text: message },
+                    ...(footerMessageTs === handle.messageId
+                      ? [
+                          buildSlackThreadReplyFooterBlock({
+                            footerText: buildFastSessionReplyFooterText({
+                              provider: 'slack',
+                              sessionId: session.id,
+                            }),
+                          }),
+                        ]
+                      : []),
+                  ],
+                },
+              });
             },
           });
           if (!updated) {

--- a/packages/sdk/src/server/lib/fast-agent-surface-reply.ts
+++ b/packages/sdk/src/server/lib/fast-agent-surface-reply.ts
@@ -6,7 +6,15 @@ import {
 } from '@roomote/cloud-agents/server';
 import { and, db, eq, slackInstallations } from '@roomote/db/server';
 import {
+  buildFastSessionReplyFooterText,
+  deliverManagedThreadReplyFooter,
+  getDiscordFooterlessFinalChunk,
+} from '@roomote/communication';
+import {
   createFastAgentSlackLiveTaskLauncher,
+  getSlackThreadReplyFooterMessageTs,
+  postSlackThreadMessageWithFooterText,
+  buildSlackThreadReplyFooterBlock,
   SlackNotifier,
   ROOMOTE_THREAD_REPLY_QUOTE_BLOCK_ID,
 } from '@roomote/slack';
@@ -157,11 +165,12 @@ export async function buildFastAgentSurfaceReplyDelivery(params: {
         postReply: async ({ message }) => {
           const quote = pendingQuote;
           pendingQuote = null;
-          const messageTs = await slack.postMessage({
+          const messageTs = await postSlackThreadMessageWithFooterText({
+            slack,
             channel: conversation.replyTarget.channelId,
-            thread_ts: conversation.replyTarget.threadId,
+            threadTs: conversation.replyTarget.threadId,
             text: quote ? `${quote}\n${message}` : message,
-            blocks: [
+            bodyBlocks: [
               ...(quote
                 ? [
                     {
@@ -173,8 +182,10 @@ export async function buildFastAgentSurfaceReplyDelivery(params: {
                 : []),
               { type: 'markdown' as const, text: message },
             ],
-            unfurl_links: false,
-            unfurl_media: false,
+            footerText: buildFastSessionReplyFooterText({
+              provider: 'slack',
+              sessionId: session.id,
+            }),
           });
           if (!messageTs) {
             throw new Error('Slack did not return a Fast reply timestamp.');
@@ -182,12 +193,30 @@ export async function buildFastAgentSurfaceReplyDelivery(params: {
           return { messageId: messageTs };
         },
         replaceReply: async (handle, { message }) => {
+          // Keep the sticky footer when the edited message is its current
+          // carrier; a bare block replacement would silently drop it.
+          const footerMessageTs = await getSlackThreadReplyFooterMessageTs(
+            conversation.replyTarget.channelId,
+            conversation.replyTarget.threadId,
+          ).catch(() => null);
           const updated = await slack.updateMessage({
             channel: conversation.replyTarget.channelId,
             ts: handle.messageId,
             message: {
               text: message,
-              blocks: [{ type: 'markdown', text: message }],
+              blocks: [
+                { type: 'markdown', text: message },
+                ...(footerMessageTs === handle.messageId
+                  ? [
+                      buildSlackThreadReplyFooterBlock({
+                        footerText: buildFastSessionReplyFooterText({
+                          provider: 'slack',
+                          sessionId: session.id,
+                        }),
+                      }),
+                    ]
+                  : []),
+              ],
             },
           });
           if (!updated) {
@@ -222,12 +251,49 @@ export async function buildFastAgentSurfaceReplyDelivery(params: {
         postReply: async ({ message }) => {
           const quote = pendingQuote;
           pendingQuote = null;
-          const posted = await provider.postMessage({
-            ...conversation.replyTarget,
-            text: quote ? `${quote}\n\n${message}` : message,
-            textFormat: 'markdown',
+          const footerText = buildFastSessionReplyFooterText({
+            provider: 'discord',
+            sessionId: session.id,
           });
-          return { messageId: posted.lastTextMessageId ?? posted.messageId };
+          const bodyText = quote ? `${quote}\n\n${message}` : message;
+          const textWithFooter = `${bodyText}\n\n${footerText}`;
+          const channelId = conversation.replyTarget.channelId;
+          const footerStateThreadId =
+            conversation.replyTarget.threadId ?? 'root';
+          const footerMessageChannelId =
+            conversation.replyTarget.threadId ?? channelId;
+
+          const posted = await deliverManagedThreadReplyFooter({
+            provider: 'discord',
+            providerLabel: 'Discord',
+            channelId,
+            footerStateThreadId,
+            lockKey: `discord:thread_reply_footer_lock:${channelId}:${footerStateThreadId}`,
+            logRef: `fast session ${session.id}`,
+            logContext: 'fastAgentSurfaceReply',
+            postReplyWithFooter: async () => {
+              const result = await provider.postMessage({
+                ...conversation.replyTarget,
+                text: textWithFooter,
+                textFormat: 'markdown',
+              });
+              return {
+                messageId: result.lastTextMessageId ?? result.messageId,
+                textWithoutFooter: getDiscordFooterlessFinalChunk({
+                  textWithFooter,
+                  footerText,
+                }),
+              };
+            },
+            clearPreviousFooter: async (previousFooterRecord) => {
+              await provider.editMessage({
+                channelId: footerMessageChannelId,
+                messageId: previousFooterRecord.messageId,
+                text: previousFooterRecord.textWithoutFooter,
+              });
+            },
+          });
+          return { messageId: posted.messageId };
         },
       },
     };

--- a/packages/slack/src/thread-reply-footer-ops.ts
+++ b/packages/slack/src/thread-reply-footer-ops.ts
@@ -177,64 +177,27 @@ function buildOutOfBandTaskUrl(taskId: string, utmCampaign: string): string {
 }
 
 /**
- * Posts a Slack thread reply that becomes the sticky "Working on..." footer
- * message for the thread: attaches the current footer, then removes it from
- * whatever prior reply still carries the tracked footer.
- *
- * Used by out-of-band posts (PR review updates, PR terminal status) so the
- * footer rides on the latest thread message the same way MCP thread replies do.
+ * Post a Slack thread message carrying the given footer text as the thread's
+ * sticky footer: attach the footer block, remove the footer from the prior
+ * tracked message, and persist the new location.
  */
-export async function postSlackThreadMessageWithStickyFooter(params: {
+export async function postSlackThreadMessageWithFooterText(params: {
   slack: Pick<
     SlackNotifier,
     'postMessage' | 'getMessageBlocks' | 'updateMessage'
   >;
   channel: string;
   threadTs: string;
-  taskId: string;
   text: string;
   /** Body blocks without the footer context block. */
-  blocks?: unknown[];
-  utmCampaign?: string;
-  /**
-   * Footer content style. `active` keeps linked PR / live preview when the
-   * shared resolver still considers the task active. `reply-only` is for
-   * terminal events (merged/closed PRs) so the relocated sticky line never
-   * reads as "still working on this" after the task becomes terminal.
-   */
-  footerStyle?: 'active' | 'reply-only';
+  bodyBlocks: unknown[];
+  footerText: string;
+  clientMsgId?: string;
 }): Promise<string | null> {
-  const taskUrl = buildOutOfBandTaskUrl(
-    params.taskId,
-    params.utmCampaign ?? 'slack.out_of_band',
-  );
-  const footerContext = await resolveSlackThreadFooterContext({
-    taskId: params.taskId,
-    prRepo: null,
-    prNumber: null,
-    channelId: params.channel,
-    threadTs: params.threadTs,
+  const footerBlock = buildSlackThreadReplyFooterBlock({
+    footerText: params.footerText,
   });
-  const replyOnly = params.footerStyle === 'reply-only';
-  const footerText = buildSlackThreadFooterText({
-    taskUrl,
-    linkedPrs: replyOnly ? [] : footerContext.linkedPrs,
-    livePreviewUrl: replyOnly ? null : footerContext.livePreviewUrl,
-    explicitMentionRequired: footerContext.explicitMentionRequired,
-  });
-  const footerBlock = buildSlackThreadReplyFooterBlock({ footerText });
-  const bodyBlocks =
-    params.blocks && params.blocks.length > 0
-      ? params.blocks
-      : [
-          {
-            type: 'section',
-            text: {
-              type: 'mrkdwn',
-              text: params.text,
-            },
-          },
-        ];
+  const bodyBlocks = params.bodyBlocks;
 
   return withSlackThreadReplyFooterLock({
     channel: params.channel,
@@ -252,6 +215,7 @@ export async function postSlackThreadMessageWithStickyFooter(params: {
         unfurl_links: false,
         unfurl_media: false,
         blocks: [...bodyBlocks, footerBlock],
+        ...(params.clientMsgId ? { client_msg_id: params.clientMsgId } : {}),
       });
 
       if (!nextMessageTs) {
@@ -310,5 +274,74 @@ export async function postSlackThreadMessageWithStickyFooter(params: {
 
       return nextMessageTs;
     },
+  });
+}
+
+/**
+ * Posts a Slack thread reply that becomes the sticky "Working on..." footer
+ * message for the thread: attaches the current footer, then removes it from
+ * whatever prior reply still carries the tracked footer.
+ *
+ * Used by out-of-band posts (PR review updates, PR terminal status) so the
+ * footer rides on the latest thread message the same way MCP thread replies do.
+ */
+export async function postSlackThreadMessageWithStickyFooter(params: {
+  slack: Pick<
+    SlackNotifier,
+    'postMessage' | 'getMessageBlocks' | 'updateMessage'
+  >;
+  channel: string;
+  threadTs: string;
+  taskId: string;
+  text: string;
+  /** Body blocks without the footer context block. */
+  blocks?: unknown[];
+  utmCampaign?: string;
+  /**
+   * Footer content style. `active` keeps linked PR / live preview when the
+   * shared resolver still considers the task active. `reply-only` is for
+   * terminal events (merged/closed PRs) so the relocated sticky line never
+   * reads as "still working on this" after the task becomes terminal.
+   */
+  footerStyle?: 'active' | 'reply-only';
+}): Promise<string | null> {
+  const taskUrl = buildOutOfBandTaskUrl(
+    params.taskId,
+    params.utmCampaign ?? 'slack.out_of_band',
+  );
+  const footerContext = await resolveSlackThreadFooterContext({
+    taskId: params.taskId,
+    prRepo: null,
+    prNumber: null,
+    channelId: params.channel,
+    threadTs: params.threadTs,
+  });
+  const replyOnly = params.footerStyle === 'reply-only';
+  const footerText = buildSlackThreadFooterText({
+    taskUrl,
+    linkedPrs: replyOnly ? [] : footerContext.linkedPrs,
+    livePreviewUrl: replyOnly ? null : footerContext.livePreviewUrl,
+    explicitMentionRequired: footerContext.explicitMentionRequired,
+  });
+  const bodyBlocks =
+    params.blocks && params.blocks.length > 0
+      ? params.blocks
+      : [
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: params.text,
+            },
+          },
+        ];
+
+  return postSlackThreadMessageWithFooterText({
+    slack: params.slack,
+    channel: params.channel,
+    threadTs: params.threadTs,
+    text: params.text,
+    bodyBlocks,
+    footerText,
   });
 }


### PR DESCRIPTION
Fast replies in Slack and Discord now carry the same "Reply or use the web app" footer that task thread replies use, linking to the Fast session view, with the same sticky behavior: one footer per thread, always riding the newest reply.

## How

- **Shared pieces**: `packages/communication` gains `buildFastSessionReplyFooterText` (the plain footer variant pointing at `/sessions/[id]`), a shared `deliverManagedThreadReplyFooter`/`withThreadReplyFooterLock` flow, and the Discord footerless-final-chunk helper. `packages/slack` gains `postSlackThreadMessageWithFooterText`, extracted from the task sticky-footer poster (which now delegates to it).
- **Attach points** (kept in sync across providers):
  - Slack fast-agent handler (`postSlackThreadMarkdownMessage` gains an opt-in `fastSessionFooter`), with the session resolved ahead of the turn
  - Discord fast-agent handler (footer appended + managed relocation)
  - Web-initiated surface replies (Slack and Discord adapters)
  - Parent-event deliveries (PR feedback/status, artifacts) on both providers
- Slack retry-notice in-place edits preserve the footer when the edited message is the thread's current footer carrier.

## Notes

- apps/api's MCP thread replies keep their local copy of the managed-footer flow: their tests mock the `@roomote/communication` barrel, so pointing them at the package internals would break the test seams. The twin implementations carry cross-referencing comments.
- Telegram intentionally remains footer-less, matching task replies there.

## Testing

- Full api suite (212 files), slack (42), communication (16), and the sdk fast-agent suites pass; parent-event tests updated to expect the footer block/suffix; lint, typecheck, and knip clean.