### PR TITLE
[Fix] Web Fast turns fail in the standalone production image

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -389,7 +389,8 @@ COPY --from=build-preview-proxy /roomote/apps/preview-proxy/dist ./apps/preview-
 COPY --from=build-preview-proxy /runtime-deps/node_modules ./apps/preview-proxy/node_modules/
 COPY --from=github-cli /usr/bin/gh /usr/local/bin/gh
 RUN command -v gh >/dev/null && command -v opencode >/dev/null && \
-  cd /roomote/apps/bullmq && node -e "require.resolve('zod/package.json')"
+  cd /roomote/apps/bullmq && node -e "require.resolve('zod/package.json')" && \
+  ls -d /roomote/node_modules/.pnpm/zod@*/node_modules/zod >/dev/null
 
 USER roomote-app:roomote-app
 EXPOSE 3000 3001 3002 8081

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -33,6 +33,11 @@ const nextConfig: NextConfig = {
     'bullmq',
     'ioredis',
     'postgres',
+    // The Fast native tool runtime symlinks an on-disk zod into generated
+    // OpenCode tool directories (fast-agent-native-tool-bridge). Bundling it
+    // makes require.resolve return a webpack module id with no file on disk,
+    // which breaks every web-run Fast turn in the standalone image.
+    'zod',
   ],
   // Always bundle the env files the runtime may need so preview deploys can
   // load preview secrets even when build-time env detection resolves differently.

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-native-tool-bridge.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-native-tool-bridge.ts
@@ -6,6 +6,7 @@ import {
 import {
   chmodSync,
   lstatSync,
+  readdirSync,
   mkdirSync,
   rmSync,
   statSync,
@@ -508,12 +509,25 @@ function resolveZodDirectoryForTools(): string {
   } catch (error) {
     resolveError = error;
   }
-  // Bundled hosts (the Next.js web app under Turbopack) rewrite
-  // require.resolve to a virtual '[project]/...' specifier that does not
-  // exist on disk, so validate the resolution and fall back to walking the
-  // real node_modules tree from the working directory.
+  // Bundled hosts rewrite require.resolve: Turbopack dev yields a virtual
+  // '[project]/...' specifier and the webpack production build yields a
+  // numeric module id, neither of which exists on disk. Validate the
+  // resolution and fall back to walking the real node_modules tree from the
+  // working directory, including pnpm stores without a top-level zod link
+  // (the Next standalone output ships zod only under node_modules/.pnpm).
   for (let dir = process.cwd(); ;) {
     candidates.push(join(dir, 'node_modules', 'zod'));
+    const pnpmStore = join(dir, 'node_modules', '.pnpm');
+    try {
+      const storeEntries = readdirSync(pnpmStore)
+        .filter((entry) => entry.startsWith('zod@'))
+        .sort();
+      for (const entry of storeEntries) {
+        candidates.push(join(pnpmStore, entry, 'node_modules', 'zod'));
+      }
+    } catch {
+      // No pnpm store at this level.
+    }
     const parent = dirname(dir);
     if (parent === dir) break;
     dir = parent;
@@ -822,6 +836,10 @@ function createRuntimeDirectory(sessionId: string): string {
   mkdirSync(directory, { recursive: true, mode: 0o700 });
   chmodSync(directory, 0o700);
   const toolsDirectory = join(directory, '.opencode', 'tools');
+  // Recreate the tool directory from scratch: a reused runtime directory may
+  // hold tool files from an older code version, and stale tools would stay
+  // loadable (and invokable) after a deploy that removed them.
+  rmSync(toolsDirectory, { recursive: true, force: true });
   mkdirSync(toolsDirectory, { recursive: true });
   writeFileSync(
     join(directory, '.opencode', 'package.json'),


### PR DESCRIPTION
Every web-initiated Fast turn on a deployed instance fails with:

> Fast native tools need the zod package on disk to link into the OpenCode tool directory… The "path" argument must be of type string. Received type number

Root cause: the webpack production build inlines zod into the server bundle, so `require.resolve('zod/package.json')` returns a numeric module id, and because zod is bundled it is never traced into the Next standalone output — there is no on-disk copy for the Fast native tool runtime to symlink. (The dev-mode variant of this was fixed earlier for Turbopack's virtual specifiers; this is the prod-build twin.)

## Fixes

- **`serverExternalPackages: ['zod']`** in the web Next config: the standalone output now traces a real zod copy, and `require.resolve` stays a native filesystem resolution.
- **Image-build assertion**: the app image now asserts the standalone pnpm store ships zod, alongside the existing per-service runtime-deps checks.
- **Resolver hardening**: the fallback walk now also checks pnpm stores without a top-level `node_modules/zod` link (the standalone layout), and the comment documents both bundler failure modes.
- **Stale tool cleanup**: `createRuntimeDirectory` recreates the OpenCode tools directory instead of writing into a reused one, so tool files from an older code version cannot linger and stay invokable after a deploy. This also fixes a stale-tmpdir test failure on develop (the bridge test found a `save_memory.js` left behind by another checkout's run).

## Verification

- Built the web standalone bundle with the image's env: zod now ships at `.next/standalone/node_modules/.pnpm/zod@…/node_modules/zod`.
- Full cloud-agents fast-agent suite (166 tests) passes; lint, typecheck, and knip clean.