### PR TITLE
[Fix] Log discarded automated Slack messages that mention other users

### DIFF
--- a/apps/api/src/handlers/slack/helpers/event-normalization.test.ts
+++ b/apps/api/src/handlers/slack/helpers/event-normalization.test.ts
@@ -4,6 +4,7 @@ import type { SlackEvent } from '@roomote/slack';
 
 import {
   enrichSlackMessageEvent,
+  getIgnoredAutomatedSlackMentionLog,
   isRoutableAutomatedSlackAppMention,
 } from './event-normalization';
 
@@ -156,5 +157,90 @@ describe('event-normalization', () => {
     expect(isRoutableAutomatedSlackAppMention(event, slackInstallation)).toBe(
       false,
     );
+  });
+
+  describe('getIgnoredAutomatedSlackMentionLog', () => {
+    it('logs a workflow message mentioning a stale bot user instead of Roomote', () => {
+      // Real-world shape: a Slack Workflow Builder message whose template still
+      // mentions the bot user of a previous Roomote installation.
+      const event = {
+        type: 'message',
+        subtype: 'bot_message',
+        channel: 'C123',
+        bot_id: 'B_WORKFLOW',
+        app_id: 'A_WORKFLOW',
+        username: 'Roomote - Quick Win',
+        text: '<@U_OLD_ROOMOTE> fix this using the attached Jira card',
+        ts: '1712345678.000600',
+        thread_ts: '1712345678.000100',
+      } as unknown as SlackEvent;
+
+      const log = getIgnoredAutomatedSlackMentionLog(event, slackInstallation);
+
+      expect(log).toContain('U_OLD_ROOMOTE');
+      expect(log).toContain('U_ROOMOTE');
+      expect(log).toContain('subtype=bot_message');
+      expect(log).toContain('app_id=A_WORKFLOW');
+    });
+
+    it('returns null when the message mentions the Roomote bot user', () => {
+      const event = {
+        type: 'message',
+        subtype: 'bot_message',
+        channel: 'C123',
+        bot_id: 'B_WORKFLOW',
+        app_id: 'A_WORKFLOW',
+        text: '<@U_ROOMOTE> investigate this deployment',
+        ts: '1712345678.000700',
+      } as unknown as SlackEvent;
+
+      expect(
+        getIgnoredAutomatedSlackMentionLog(event, slackInstallation),
+      ).toBeNull();
+    });
+
+    it('returns null for messages without any user mention', () => {
+      const event = {
+        type: 'message',
+        subtype: 'bot_message',
+        channel: 'C123',
+        bot_id: 'B_WORKFLOW',
+        app_id: 'A_WORKFLOW',
+        text: 'deployment finished',
+        ts: '1712345678.000800',
+      } as unknown as SlackEvent;
+
+      expect(
+        getIgnoredAutomatedSlackMentionLog(event, slackInstallation),
+      ).toBeNull();
+    });
+
+    it('returns null for Roomote-authored messages', () => {
+      const event = {
+        type: 'message',
+        subtype: 'bot_message',
+        channel: 'C123',
+        bot_id: 'B_WORKFLOW',
+        app_id: 'A_ROOMOTE',
+        text: '<@U_SOMEONE> here is the summary you asked for',
+        ts: '1712345678.000900',
+      } as unknown as SlackEvent;
+
+      expect(
+        getIgnoredAutomatedSlackMentionLog(event, slackInstallation),
+      ).toBeNull();
+    });
+
+    it('returns null for non-message events', () => {
+      const event = {
+        type: 'reaction_added',
+        user: 'U123',
+        item: { channel: 'C123', ts: '1712345678.001000' },
+      } as never;
+
+      expect(
+        getIgnoredAutomatedSlackMentionLog(event, slackInstallation),
+      ).toBeNull();
+    });
   });
 });

--- a/apps/api/src/handlers/slack/helpers/event-normalization.ts
+++ b/apps/api/src/handlers/slack/helpers/event-normalization.ts
@@ -11,7 +11,10 @@ import type {
   AutomatedSlackAppMentionEvent,
   SlackWebhookEvent,
 } from '../types.js';
-import { mentionsSlackBot } from './mention-routing.js';
+import {
+  getMentionedSlackUserIds,
+  mentionsSlackBot,
+} from './mention-routing.js';
 
 function normalizeSlackReactionName(reaction: string): string {
   return reaction.trim().toLowerCase().split('::')[0] ?? '';
@@ -204,6 +207,46 @@ export function isRoomoteAuthoredSlackEvent(
     (Boolean(eventUser) && eventUser === slackInstallation.botUserId) ||
     (Boolean(eventAppId) && eventAppId === slackInstallation.appId) ||
     (Boolean(eventBotId) && eventBotId === slackInstallation.botUserId)
+  );
+}
+
+// Automated (app/bot-authored) messages that mention users without mentioning
+// the installed Roomote bot are discarded, which is invisible in logs and has
+// hidden real misconfigurations — e.g. a Slack workflow whose message template
+// still mentions the bot user of a previous Roomote installation. Surface a
+// log line naming the mentioned IDs so those drops are diagnosable.
+export function getIgnoredAutomatedSlackMentionLog(
+  event: SlackWebhookEvent,
+  slackInstallation: SlackInstallation,
+): string | null {
+  if (event.type !== 'message' && event.type !== 'app_mention') {
+    return null;
+  }
+
+  if (isRoomoteAuthoredSlackEvent(event, slackInstallation)) {
+    return null;
+  }
+
+  const slackEvent = event as SlackEvent;
+  const mentionedUserIds = getMentionedSlackUserIds(slackEvent);
+
+  if (
+    mentionedUserIds.length === 0 ||
+    (slackInstallation.botUserId &&
+      mentionedUserIds.includes(slackInstallation.botUserId))
+  ) {
+    return null;
+  }
+
+  const subtype = getSlackEventStringField(event, 'subtype') ?? 'none';
+  const appId = getSlackEventStringField(event, 'app_id') ?? 'none';
+  const botId = getSlackEventStringField(event, 'bot_id') ?? 'none';
+
+  return (
+    `[SlackWebhook] Ignoring automated message mentioning [${mentionedUserIds.join(', ')}] ` +
+    `but not the Roomote bot user ${slackInstallation.botUserId} ` +
+    `(channel=${slackEvent.channel}, ts=${slackEvent.ts}, thread_ts=${slackEvent.thread_ts ?? 'none'}, ` +
+    `subtype=${subtype}, app_id=${appId}, bot_id=${botId})`
   );
 }
 

--- a/apps/api/src/handlers/slack/helpers/mention-routing.ts
+++ b/apps/api/src/handlers/slack/helpers/mention-routing.ts
@@ -55,7 +55,9 @@ export function getSlackMentionDirectiveText(
   return candidateLines.join(' ');
 }
 
-function getMentionedSlackUserIds(message: SlackMentionTextSource): string[] {
+export function getMentionedSlackUserIds(
+  message: SlackMentionTextSource,
+): string[] {
   return Array.from(
     getSlackMentionDirectiveText(message).matchAll(/<@([^>|]+)(?:\|[^>]+)?>/g),
   )

--- a/apps/api/src/handlers/slack/index.ts
+++ b/apps/api/src/handlers/slack/index.ts
@@ -18,6 +18,7 @@ import {
 import { dispatchSlackEvent } from './dispatch/events.js';
 import { handleSlackInteractivePayload } from './dispatch/interactive.js';
 import {
+  getIgnoredAutomatedSlackMentionLog,
   getSlackWebhookEventLogDetails,
   isAppAuthoredSlackEvent,
   isRoomoteAuthoredSlackEvent,
@@ -155,6 +156,15 @@ slack.post('/', async (c) => {
       (!isTopLevelAppMessageEvent ||
         isRoomoteAuthoredSlackEvent(event, slackInstallation))
     ) {
+      const ignoredMentionLog = getIgnoredAutomatedSlackMentionLog(
+        event,
+        slackInstallation,
+      );
+
+      if (ignoredMentionLog) {
+        apiLogger.info(ignoredMentionLog);
+      }
+
       return c.json({ ok: true });
     }
 


### PR DESCRIPTION
## What changed

Automated (app/bot-authored) Slack `message` events that mention users without mentioning the installed Roomote bot are discarded by design, but the discard was completely silent. The webhook now emits an info-level log naming the mentioned user IDs, the installed bot user ID, and the event's channel/ts/subtype/app_id/bot_id before dropping such an event.

## Why this change was made

The silent drop hid real misconfigurations. Concretely: a Slack Workflow Builder message template can carry a mention token for the bot user of a *previous* Roomote installation. Slack renders the stale mention identically to a live one (a blue @Roomote), so the workflow looks correct while its mentions reach a deleted bot user and Roomote never reacts. Diagnosing this required manually fetching message payloads from the Slack API; with this log line it is visible directly in api logs, including the exact stale user ID.

Routing behavior is intentionally unchanged: automation still only engages Roomote via an explicit mention of the currently installed bot user (or configured channel auto-start). This PR only makes the existing discard observable.

## Impact

No behavior change for routing, task launch, or replies. Operators debugging "Roomote ignored an automated mention" reports can now find a log line identifying which user IDs were mentioned instead of the installed bot user.

Focused coverage: unit tests for the new log helper, including the real-world workflow payload shape (`bot_message` + `app_id` + stale mention), plus null cases for bot-mentioning, mention-free, Roomote-authored, and non-message events.