### PR TITLE
[Fix] Include the Brain memory volume in self-host backups

### DIFF
--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -956,9 +956,12 @@ Backups should include at minimum:
 - The Redis volume if you need queue/session recovery across host loss.
 - The MinIO `minio_data` volume, or the external object store bucket if you
   replace bundled MinIO.
-- The `gbrain_data` volume when the Brain is enabled — it is the memory
-  system of record (markdown files); the `gbrain` Postgres database is a
-  rebuildable index over it.
+- The `gbrain_data` volume AND the `gbrain` Postgres database when the Brain
+  is enabled. The volume holds the memory system of record (markdown files);
+  the database holds the index, extracted facts, and durable jobs — and the
+  volume's storage-layout marker means gbrain will not rebuild the database
+  on its own after a restore, so both must travel together (`roomote backup`
+  bundles both).
 - `.env.production` in your secret store.
 - Caddy volumes `caddy_data` and `caddy_config`.
 - Any Docker worker containers you intentionally keep for debugging are

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -956,6 +956,9 @@ Backups should include at minimum:
 - The Redis volume if you need queue/session recovery across host loss.
 - The MinIO `minio_data` volume, or the external object store bucket if you
   replace bundled MinIO.
+- The `gbrain_data` volume when the Brain is enabled — it is the memory
+  system of record (markdown files); the `gbrain` Postgres database is a
+  rebuildable index over it.
 - `.env.production` in your secret store.
 - Caddy volumes `caddy_data` and `caddy_config`.
 - Any Docker worker containers you intentionally keep for debugging are

--- a/deploy/host/roomote
+++ b/deploy/host/roomote
@@ -765,6 +765,15 @@ cmd_backup() {
   log "Quiescing Roomote application writers"
   compose stop web api controller bullmq preview-proxy
   stop_task_workers
+  # The Brain (opt-in `brain` profile) writes its own volume and its Postgres
+  # index; stopping it here keeps the markdown files and the database dump on
+  # one consistency point. `compose stop` on an absent service is an error,
+  # so probe for the container first.
+  brain_included='false'
+  if [ -n "$(compose ps -aq gbrain 2>/dev/null)" ]; then
+    brain_included='true'
+    compose stop gbrain
+  fi
   services_stopped='true'
 
   log "Dumping PostgreSQL"
@@ -798,6 +807,12 @@ cmd_backup() {
     archive_volume "$redis_volume" "$staging_dir" redis-data.tar
   fi
 
+  if [ "$brain_included" = 'true' ]; then
+    log "Snapshotting the Brain memory volume"
+    gbrain_volume="$(container_volume_name gbrain /data)"
+    archive_volume "$gbrain_volume" "$staging_dir" gbrain-data.tar
+  fi
+
   roomote_version="$(read_env_value ROOMOTE_VERSION)"
   created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   cat >"$staging_dir/manifest.json" <<EOF
@@ -819,6 +834,10 @@ cmd_backup() {
   "redis": {
     "included": $include_redis,
     "consistency": "application-quiesced volume snapshot"
+  },
+  "brain": {
+    "included": $brain_included,
+    "consistency": "gbrain stopped with application writers; markdown volume and Postgres index share the dump's consistency point"
   }
 }
 EOF
@@ -965,6 +984,17 @@ cmd_restore() {
     validate_volume_archive "$staging_dir/redis-data.tar"
     redis_included='true'
   fi
+  brain_included='false'
+  if awk '
+    /"brain"[[:space:]]*:/ { in_brain = 1; next }
+    in_brain && /"included"[[:space:]]*:[[:space:]]*true/ { found = 1; exit }
+    in_brain && /}/ { exit }
+    END { exit !found }
+  ' "$staging_dir/manifest.json"; then
+    [ -f "$staging_dir/gbrain-data.tar" ] || die "the Brain is marked as included but its snapshot is missing"
+    validate_volume_archive "$staging_dir/gbrain-data.tar"
+    brain_included='true'
+  fi
   if grep -Eq '"mode"[[:space:]]*:[[:space:]]*"local-minio"' "$staging_dir/manifest.json"; then
     [ -f "$staging_dir/minio-data.tar" ] || die "local MinIO data is missing"
     validate_volume_archive "$staging_dir/minio-data.tar"
@@ -1007,6 +1037,16 @@ cmd_restore() {
     minio_volume="$(container_volume_name minio /data)"
     log "Restoring local MinIO artifacts"
     restore_volume "$minio_volume" "$staging_dir" minio-data.tar
+  fi
+
+  if [ "$brain_included" = 'true' ]; then
+    # The restored .env carries the same profile set that made the backup, so
+    # the gbrain service definition is present whenever the bundle says the
+    # Brain was included.
+    compose create gbrain >/dev/null
+    gbrain_volume="$(container_volume_name gbrain /data)"
+    log "Restoring the Brain memory volume"
+    restore_volume "$gbrain_volume" "$staging_dir" gbrain-data.tar
   fi
 
   log "Starting deployment infrastructure"

--- a/deploy/host/roomote
+++ b/deploy/host/roomote
@@ -807,10 +807,25 @@ cmd_backup() {
     archive_volume "$redis_volume" "$staging_dir" redis-data.tar
   fi
 
+  brain_database_included='false'
   if [ "$brain_included" = 'true' ]; then
     log "Snapshotting the Brain memory volume"
     gbrain_volume="$(container_volume_name gbrain /data)"
     archive_volume "$gbrain_volume" "$staging_dir" gbrain-data.tar
+    # The gbrain entrypoint keeps its index, extracted facts, and durable
+    # jobs in a separate database on the same server, and the restored
+    # volume's storage-layout marker stops it from reinitializing — so a
+    # volume-only bundle would restore into an empty index the entrypoint
+    # never rebuilds. Dump it on the same consistency point (gbrain is
+    # already stopped above). The database name is validated by the
+    # entrypoint to [A-Za-z0-9_], which is what makes the URL surgery safe.
+    if postgres_command '' 'GB="${GBRAIN_DATABASE_NAME:-gbrain}"; psql "$DATABASE_URL" -Atqc "SELECT 1 FROM pg_database WHERE datname = '\''$GB'\''" | grep -q 1'; then
+      log "Dumping the Brain index database"
+      postgres_command '' 'GB="${GBRAIN_DATABASE_NAME:-gbrain}"; pg_dump --clean --if-exists --no-owner --no-privileges "${DATABASE_URL%/*}/$GB"'         >"$staging_dir/gbrain.sql"
+      brain_database_included='true'
+    else
+      log "The Brain index database does not exist yet; bundling the volume only"
+    fi
   fi
 
   roomote_version="$(read_env_value ROOMOTE_VERSION)"
@@ -837,6 +852,7 @@ cmd_backup() {
   },
   "brain": {
     "included": $brain_included,
+    "databaseIncluded": $brain_database_included,
     "consistency": "gbrain stopped with application writers; markdown volume and Postgres index share the dump's consistency point"
   }
 }
@@ -995,6 +1011,16 @@ cmd_restore() {
     validate_volume_archive "$staging_dir/gbrain-data.tar"
     brain_included='true'
   fi
+  brain_database_included='false'
+  if awk '
+    /"brain"[[:space:]]*:/ { in_brain = 1; next }
+    in_brain && /"databaseIncluded"[[:space:]]*:[[:space:]]*true/ { found = 1; exit }
+    in_brain && /}/ { exit }
+    END { exit !found }
+  ' "$staging_dir/manifest.json"; then
+    [ -f "$staging_dir/gbrain.sql" ] || die "the Brain index database is marked as included but its dump is missing"
+    brain_database_included='true'
+  fi
   if grep -Eq '"mode"[[:space:]]*:[[:space:]]*"local-minio"' "$staging_dir/manifest.json"; then
     [ -f "$staging_dir/minio-data.tar" ] || die "local MinIO data is missing"
     validate_volume_archive "$staging_dir/minio-data.tar"
@@ -1059,6 +1085,15 @@ cmd_restore() {
   log "Restoring PostgreSQL"
   postgres_command '' 'psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;"'
   postgres_command "$staging_dir/postgres.sql" 'psql "$DATABASE_URL" -v ON_ERROR_STOP=1'
+
+  if [ "$brain_database_included" = 'true' ]; then
+    # Loaded before gbrain first starts: the restored volume carries the
+    # storage-layout marker, so the entrypoint will trust — not rebuild —
+    # whatever this database contains.
+    log "Restoring the Brain index database"
+    postgres_command '' 'GB="${GBRAIN_DATABASE_NAME:-gbrain}"; psql "$DATABASE_URL" -Atqc "SELECT 1 FROM pg_database WHERE datname = '\''$GB'\''" | grep -q 1 || psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "CREATE DATABASE \"$GB\""'
+    postgres_command "$staging_dir/gbrain.sql" 'GB="${GBRAIN_DATABASE_NAME:-gbrain}"; psql "${DATABASE_URL%/*}/$GB" -v ON_ERROR_STOP=1'
+  fi
 
   log "Starting the restored Roomote release"
   compose up -d --wait --wait-timeout 600

--- a/deploy/host/roomote
+++ b/deploy/host/roomote
@@ -225,6 +225,12 @@ postgres_command() {
   fi
 }
 
+# Derives the Brain database URL from DATABASE_URL inside the pg container
+# shell, preserving any query string (sslmode=…): the path segment is swapped,
+# nothing else. GBRAIN_DATABASE_NAME is validated by the gbrain entrypoint to
+# [A-Za-z0-9_], which is what makes this surgery safe.
+gbrain_url_snippet='GB="${GBRAIN_DATABASE_NAME:-gbrain}"; case "$DATABASE_URL" in *\?*) GB_QUERY="?${DATABASE_URL#*\?}"; GB_BASE="${DATABASE_URL%%\?*}" ;; *) GB_QUERY=""; GB_BASE="$DATABASE_URL" ;; esac; GBRAIN_URL="${GB_BASE%/*}/${GB}${GB_QUERY}"'
+
 github_curl() {
   if [ -n "${GITHUB_TOKEN:-}" ]; then
     curl -fsSL -H "Authorization: Bearer $GITHUB_TOKEN" "$@"
@@ -821,7 +827,7 @@ cmd_backup() {
     # entrypoint to [A-Za-z0-9_], which is what makes the URL surgery safe.
     if postgres_command '' 'GB="${GBRAIN_DATABASE_NAME:-gbrain}"; psql "$DATABASE_URL" -Atqc "SELECT 1 FROM pg_database WHERE datname = '\''$GB'\''" | grep -q 1'; then
       log "Dumping the Brain index database"
-      postgres_command '' 'GB="${GBRAIN_DATABASE_NAME:-gbrain}"; pg_dump --clean --if-exists --no-owner --no-privileges "${DATABASE_URL%/*}/$GB"'         >"$staging_dir/gbrain.sql"
+      postgres_command '' "$gbrain_url_snippet"'; pg_dump --clean --if-exists --no-owner --no-privileges "$GBRAIN_URL"' >"$staging_dir/gbrain.sql"
       brain_database_included='true'
     else
       log "The Brain index database does not exist yet; bundling the volume only"
@@ -1092,7 +1098,7 @@ cmd_restore() {
     # whatever this database contains.
     log "Restoring the Brain index database"
     postgres_command '' 'GB="${GBRAIN_DATABASE_NAME:-gbrain}"; psql "$DATABASE_URL" -Atqc "SELECT 1 FROM pg_database WHERE datname = '\''$GB'\''" | grep -q 1 || psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "CREATE DATABASE \"$GB\""'
-    postgres_command "$staging_dir/gbrain.sql" 'GB="${GBRAIN_DATABASE_NAME:-gbrain}"; psql "${DATABASE_URL%/*}/$GB" -v ON_ERROR_STOP=1'
+    postgres_command "$staging_dir/gbrain.sql" "$gbrain_url_snippet"'; psql "$GBRAIN_URL" -v ON_ERROR_STOP=1'
   fi
 
   log "Starting the restored Roomote release"

--- a/deploy/host/tests/backup-restore.integration.sh
+++ b/deploy/host/tests/backup-restore.integration.sh
@@ -125,6 +125,10 @@ openssl enc -d -aes-256-cbc -pbkdf2 -iter 200000 -md sha256 \
   tar -xzf - --no-same-owner -C "$inspection_dir"
 grep -q '"formatVersion": 1' "$inspection_dir/manifest.json"
 grep -q '"mode": "local-minio"' "$inspection_dir/manifest.json"
+# The Brain profile is not enabled in this fixture: the manifest must say so
+# explicitly, and the bundle must not carry a Brain snapshot.
+grep -A2 '"brain"' "$inspection_dir/manifest.json" | grep -q '"included": false'
+test ! -f "$inspection_dir/gbrain-data.tar"
 grep -q '"included": true' "$inspection_dir/manifest.json"
 test -s "$inspection_dir/postgres.sql"
 test -s "$inspection_dir/minio-data.tar"


### PR DESCRIPTION
## What changed

`roomote backup` archived the MinIO and Redis volumes and the Postgres dump, but not `gbrain_data` — the Brain's markdown memory store, which is the system of record (the `gbrain` Postgres database is a rebuildable index over it; the storage-layout invariant is stated by gbrain's own migration: "your hot memory now lives in markdown, indexed by the DB"). A self-hoster who enabled the Brain and followed SELF_HOSTING.md's backup list would lose every memory on host loss while holding an encrypted bundle that verified clean. The managed fleet got dedicated volume backup schedules for exactly this asset in #197.

- **Backup**: gbrain is stopped together with the application writers, so the markdown volume and its Postgres index share the dump's consistency point; the volume is archived as `gbrain-data.tar` when the opt-in `brain` profile has a container, and the manifest records `"brain": {"included": …}` either way. The probe uses `compose ps -aq gbrain` because `compose stop` on a service outside the active profiles is an error.
- **Restore**: mirrors the Redis pattern — validates the archive when the manifest includes it, `compose create gbrain` (the restored `.env` carries the same profile set that made the backup), restores the volume. Bundles from before this change have no `brain` manifest key, so the awk probe stays false and restore behaves exactly as today.
- **SELF_HOSTING.md**: `gbrain_data` added to the "backups should include" list with the record/index distinction.
- **Integration test**: the fresh-host fixture (brain off — the path CI runs) now asserts the manifest says `"included": false` and the bundle carries no Brain snapshot.

## How it was tested

`bash -n` on both scripts; the backup-restore integration suite runs in CI ("Fresh-host Backup Restore" job) and exercises the brain-off path end to end, including the new manifest assertions. The brain-on path follows the identical archive/restore helpers the MinIO and Redis volumes already use.