### PR TITLE
[Feat] Route Brain embeddings and rerank to a self-run inference upstream

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -143,11 +143,21 @@ DEFAULT_COMPUTE_PROVIDER=docker
 # Optional comma-separated GitHub App slugs that are also trusted as Roomote-managed.
 # R_GITHUB_ADDITIONAL_APP_SLUGS=
 # Self-run Brain inference (embeddings/rerank stay on your hardware; chat
-# synthesis keeps using the configured provider). With the bundled service:
-# COMPOSE_PROFILES=brain,local-inference and the URLs below.
+# synthesis keeps using the configured provider). With the bundled service,
+# set COMPOSE_PROFILES=brain,local-inference and ALL of the settings below —
+# the model names and dimensions must match what the inference server
+# serves, and the embedding pair is create-time: set everything BEFORE the
+# Brain's first boot. gbrain's defaults (text-embedding-3-small, 1536) name
+# models the bundled server does not serve, so the URLs alone are not a
+# working configuration. The openrouter: prefix on the reranker routes it
+# through this deployment's gateway, which strips the prefix before
+# forwarding.
 # R_BRAIN_EMBEDDINGS_UPSTREAM_URL=http://infinity:7997
 # R_BRAIN_RERANK_UPSTREAM_URL=http://infinity:7997
 # R_BRAIN_INFERENCE_UPSTREAM_API_KEY=
+# R_BRAIN_EMBEDDING_MODEL=BAAI/bge-small-en-v1.5
+# R_BRAIN_EMBEDDING_DIMENSIONS=384
+# R_BRAIN_RERANKER_MODEL=openrouter:BAAI/bge-reranker-base
 # R_GITHUB_APP_ID=
 # Raw GitHub App private-key PEM with newlines escaped as \n; do not base64 it.
 # R_GITHUB_APP_PRIVATE_KEY=

--- a/.env.production.example
+++ b/.env.production.example
@@ -142,6 +142,12 @@ DEFAULT_COMPUTE_PROVIDER=docker
 # R_GITHUB_APP_SLUG=
 # Optional comma-separated GitHub App slugs that are also trusted as Roomote-managed.
 # R_GITHUB_ADDITIONAL_APP_SLUGS=
+# Self-run Brain inference (embeddings/rerank stay on your hardware; chat
+# synthesis keeps using the configured provider). With the bundled service:
+# COMPOSE_PROFILES=brain,local-inference and the URLs below.
+# R_BRAIN_EMBEDDINGS_UPSTREAM_URL=http://infinity:7997
+# R_BRAIN_RERANK_UPSTREAM_URL=http://infinity:7997
+# R_BRAIN_INFERENCE_UPSTREAM_API_KEY=
 # R_GITHUB_APP_ID=
 # Raw GitHub App private-key PEM with newlines escaped as \n; do not base64 it.
 # R_GITHUB_APP_PRIVATE_KEY=

--- a/apps/api/src/handlers/brain-inference/__tests__/brain-inference.test.ts
+++ b/apps/api/src/handlers/brain-inference/__tests__/brain-inference.test.ts
@@ -6,11 +6,15 @@ const {
   mockGetBrainGatewayToken,
   mockResolveBrainInferenceProvider,
   mockMapBrainModelName,
+  mockEnv,
 } = vi.hoisted(() => ({
   mockGetBrainGatewayToken: vi.fn(),
   mockResolveBrainInferenceProvider: vi.fn(),
   mockMapBrainModelName: vi.fn(),
+  mockEnv: {} as Record<string, string | undefined>,
 }));
+
+vi.mock('@roomote/env', () => ({ Env: mockEnv }));
 
 vi.mock('@roomote/sdk/server', () => ({
   getBrainGatewayToken: mockGetBrainGatewayToken,
@@ -54,6 +58,9 @@ async function post(
 beforeEach(() => {
   vi.clearAllMocks();
   vi.unstubAllGlobals();
+  for (const key of Object.keys(mockEnv)) {
+    delete mockEnv[key];
+  }
   mockGetBrainGatewayToken.mockReturnValue(GATEWAY_TOKEN);
   mockResolveBrainInferenceProvider.mockResolvedValue(OPENROUTER);
   mockMapBrainModelName.mockImplementation((requested: string) =>
@@ -225,5 +232,103 @@ describe('brain inference gateway', () => {
 
     const init = fetchMock.mock.calls[0]![1];
     expect(JSON.parse(init.body as string).model).toBe('openai/gpt-5.6-mini');
+  });
+});
+
+describe('local inference upstreams', () => {
+  it('routes embeddings to the configured upstream without touching the provider', async () => {
+    mockEnv.R_BRAIN_EMBEDDINGS_UPSTREAM_URL = 'http://infinity:7997';
+    mockEnv.R_BRAIN_INFERENCE_UPSTREAM_API_KEY = 'local-upstream-key';
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await post('/v1/embeddings', {
+      token: GATEWAY_TOKEN,
+      body: { model: 'bge-small-en-v1.5', input: 'hello' },
+    });
+
+    expect(response.status).toBe(200);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('http://infinity:7997/v1/embeddings');
+    const headers = new Headers((init as RequestInit).headers);
+    expect(headers.get('authorization')).toBe('Bearer local-upstream-key');
+    // Model name passes through unrewritten: the upstream owns its names.
+    expect(JSON.parse((init as RequestInit).body as string)).toMatchObject({
+      model: 'bge-small-en-v1.5',
+    });
+    expect(mockMapBrainModelName).not.toHaveBeenCalled();
+    expect(mockResolveBrainInferenceProvider).not.toHaveBeenCalled();
+  });
+
+  it('allows rerank without OpenRouter when a rerank upstream is set', async () => {
+    mockEnv.R_BRAIN_RERANK_UPSTREAM_URL = 'http://infinity:7997/';
+    mockResolveBrainInferenceProvider.mockResolvedValue({
+      providerId: 'openai' as const,
+      apiKey: 'sk-openai',
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ results: [] }), { status: 200 }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await post('/v1/rerank', {
+      token: GATEWAY_TOKEN,
+      body: { model: 'bge-reranker-base', query: 'q', documents: ['a'] },
+    });
+
+    expect(response.status).toBe(200);
+    // Trailing slash on the configured URL must not double up.
+    expect(fetchMock.mock.calls[0]![0]).toBe('http://infinity:7997/v1/rerank');
+  });
+
+  it('sends no authorization header when the upstream has no key', async () => {
+    mockEnv.R_BRAIN_EMBEDDINGS_UPSTREAM_URL = 'http://infinity:7997';
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await post('/v1/embeddings', { token: GATEWAY_TOKEN, body: {} });
+
+    // The gateway token must never be forwarded, and no invented key either.
+    const headers = new Headers(
+      (fetchMock.mock.calls[0]![1] as RequestInit).headers,
+    );
+    expect(headers.get('authorization')).toBeNull();
+  });
+
+  it('keeps chat on the provider even when upstreams are configured', async () => {
+    mockEnv.R_BRAIN_EMBEDDINGS_UPSTREAM_URL = 'http://infinity:7997';
+    mockEnv.R_BRAIN_RERANK_UPSTREAM_URL = 'http://infinity:7997';
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await post('/v1/chat/completions', {
+      token: GATEWAY_TOKEN,
+      body: { model: 'gpt-5.6-luna', messages: [] },
+    });
+
+    expect(mockResolveBrainInferenceProvider).toHaveBeenCalled();
+    expect(String(fetchMock.mock.calls[0]![0])).toContain('openrouter.ai');
+  });
+
+  it('still authenticates the caller before proxying to a local upstream', async () => {
+    mockEnv.R_BRAIN_EMBEDDINGS_UPSTREAM_URL = 'http://infinity:7997';
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await post('/v1/embeddings', { token: 'wrong-token' });
+
+    expect(response.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/handlers/brain-inference/index.ts
+++ b/apps/api/src/handlers/brain-inference/index.ts
@@ -2,6 +2,8 @@ import { timingSafeEqual } from 'node:crypto';
 
 import { Hono } from 'hono';
 
+import { Env } from '@roomote/env';
+
 import {
   formatSingleLineLog,
   getInferenceGatewayProvider,
@@ -117,6 +119,35 @@ async function rewriteBody(
 }
 
 /**
+ * A self-run inference upstream for one gateway path. Embeddings and rerank
+ * are the Brain's bulk data paths (memory text in, vectors/scores out), so
+ * they are the ones a deployment may want on its own hardware; chat synthesis
+ * stays with the configured model provider. Model names pass through
+ * unrewritten — the upstream owns its own model registry, and every Brain is
+ * locked to its embedding model at creation, so the name must mean exactly
+ * one thing forever.
+ */
+function resolveLocalUpstream(
+  upstreamPath: string,
+): { baseUrl: string; apiKey?: string } | null {
+  const baseUrl =
+    upstreamPath === '/v1/embeddings'
+      ? Env.R_BRAIN_EMBEDDINGS_UPSTREAM_URL
+      : upstreamPath === '/v1/rerank'
+        ? Env.R_BRAIN_RERANK_UPSTREAM_URL
+        : undefined;
+
+  if (!baseUrl?.trim()) {
+    return null;
+  }
+
+  return {
+    baseUrl: baseUrl.trim().replace(/\/$/, ''),
+    apiKey: Env.R_BRAIN_INFERENCE_UPSTREAM_API_KEY?.trim() || undefined,
+  };
+}
+
+/**
  * Inference gateway for this deployment's Brain.
  *
  * The Brain container holds no provider credential. It is pointed at this
@@ -163,6 +194,64 @@ brainInference.post('/*', async (c) => {
     return c.json({ error: 'Path is not allowed through this gateway' }, 403);
   }
 
+  const localUpstream = resolveLocalUpstream(upstreamPath);
+
+  if (localUpstream) {
+    const headers = new Headers();
+
+    // Same denylist as the provider path: the gateway token in
+    // `authorization` must never reach any upstream.
+    for (const [name, value] of c.req.raw.headers.entries()) {
+      if (!REQUEST_HEADER_DENYLIST.has(name.toLowerCase())) {
+        headers.set(name, value);
+      }
+    }
+
+    if (localUpstream.apiKey) {
+      headers.set('authorization', `Bearer ${localUpstream.apiKey}`);
+    }
+
+    let upstream: Response;
+
+    try {
+      upstream = await fetch(
+        `${localUpstream.baseUrl}${upstreamPath}${requestUrl.search}`,
+        { method: 'POST', headers, body: await c.req.text() },
+      );
+    } catch (error) {
+      console.warn(
+        formatSingleLineLog(`${LOG_PREFIX} Local upstream request failed`, {
+          upstreamPath,
+          error: error instanceof Error ? error.message : String(error),
+        }),
+      );
+
+      return c.json({ error: 'Brain inference upstream is unreachable' }, 502);
+    }
+
+    if (!upstream.ok) {
+      console.warn(
+        formatSingleLineLog(`${LOG_PREFIX} Local upstream returned an error`, {
+          upstreamPath,
+          status: upstream.status,
+        }),
+      );
+    }
+
+    const responseHeaders = new Headers();
+
+    for (const [name, value] of upstream.headers.entries()) {
+      if (!RESPONSE_HEADER_DENYLIST.has(name.toLowerCase())) {
+        responseHeaders.set(name, value);
+      }
+    }
+
+    return new Response(upstream.body, {
+      status: upstream.status,
+      headers: responseHeaders,
+    });
+  }
+
   const resolved = await resolveBrainInferenceProvider();
 
   if (!resolved) {
@@ -185,7 +274,7 @@ brainInference.post('/*', async (c) => {
     return c.json(
       {
         error:
-          'Brain reranking requires an OpenRouter provider configured in Settings.',
+          'Brain reranking requires an OpenRouter provider configured in Settings, or a local rerank upstream (R_BRAIN_RERANK_UPSTREAM_URL).',
       },
       503,
     );

--- a/deploy/compose/docker-compose.prod.yml
+++ b/deploy/compose/docker-compose.prod.yml
@@ -556,9 +556,12 @@ services:
       - no-new-privileges:true
 
   # Self-run embedding/reranking models for the Brain (opt-in, CPU).
-  # Enable with the `local-inference` compose profile, then set
-  # R_BRAIN_EMBEDDINGS_UPSTREAM_URL=http://infinity:7997 (and the rerank URL
-  # if serving a reranker). Serve models by pinned name and keep serving old
+  # Enable with the `local-inference` compose profile. The upstream URLs are
+  # NOT sufficient on their own: R_BRAIN_EMBEDDING_MODEL and
+  # R_BRAIN_EMBEDDING_DIMENSIONS must name what this server serves (gbrain's
+  # defaults name a provider model it does not serve), and the embedding pair
+  # is create-time — the full set is documented together in
+  # .env.production.example. Serve models by pinned name and keep serving old
   # names: every Brain is locked to its embedding model at creation.
   infinity:
     profiles:

--- a/deploy/compose/docker-compose.prod.yml
+++ b/deploy/compose/docker-compose.prod.yml
@@ -566,11 +566,13 @@ services:
   infinity:
     profiles:
       - local-inference
-    image: michaelf34/infinity:0.0.76
+    image: michaelf34/infinity:0.0.76-cpu
     restart: unless-stopped
     networks: [default]
     command:
       - v2
+      - --device
+      - cpu
       - --url-prefix
       - /v1
       - --port

--- a/deploy/compose/docker-compose.prod.yml
+++ b/deploy/compose/docker-compose.prod.yml
@@ -25,6 +25,12 @@ x-roomote-base-env: &roomote-base-env
   R_BRAIN_EMBEDDING_MODEL: ${R_BRAIN_EMBEDDING_MODEL:-}
   R_BRAIN_EMBEDDING_DIMENSIONS: ${R_BRAIN_EMBEDDING_DIMENSIONS:-}
   R_BRAIN_RERANKER_MODEL: ${R_BRAIN_RERANKER_MODEL:-}
+  # Optional self-run inference: point embeddings/rerank at the bundled
+  # `infinity` service (profile local-inference) or any OpenAI-compatible
+  # server. Chat synthesis keeps flowing to the configured model provider.
+  R_BRAIN_EMBEDDINGS_UPSTREAM_URL: ${R_BRAIN_EMBEDDINGS_UPSTREAM_URL:-}
+  R_BRAIN_RERANK_UPSTREAM_URL: ${R_BRAIN_RERANK_UPSTREAM_URL:-}
+  R_BRAIN_INFERENCE_UPSTREAM_API_KEY: ${R_BRAIN_INFERENCE_UPSTREAM_API_KEY:-}
   R_GBRAIN_URL: ${R_GBRAIN_URL:-http://gbrain:8931}
   R_GBRAIN_ADMIN_TOKEN_FILE: /gbrain-data/admin-bootstrap-token
   # Written by the Brain on first boot when no token was supplied, so a stack
@@ -549,6 +555,32 @@ services:
     security_opt:
       - no-new-privileges:true
 
+  # Self-run embedding/reranking models for the Brain (opt-in, CPU).
+  # Enable with the `local-inference` compose profile, then set
+  # R_BRAIN_EMBEDDINGS_UPSTREAM_URL=http://infinity:7997 (and the rerank URL
+  # if serving a reranker). Serve models by pinned name and keep serving old
+  # names: every Brain is locked to its embedding model at creation.
+  infinity:
+    profiles:
+      - local-inference
+    image: michaelf34/infinity:0.0.76
+    restart: unless-stopped
+    networks: [default]
+    command:
+      - v2
+      - --url-prefix
+      - /v1
+      - --port
+      - '7997'
+      - --model-id
+      - ${INFINITY_EMBEDDING_MODEL:-BAAI/bge-small-en-v1.5}
+      - --model-id
+      - ${INFINITY_RERANKER_MODEL:-BAAI/bge-reranker-base}
+    volumes:
+      - infinity_cache:/app/.cache
+    security_opt:
+      - no-new-privileges:true
+
   preview-proxy:
     <<: *roomote-service
     image: *roomote-app-image
@@ -604,6 +636,7 @@ volumes:
   caddy_data:
   caddy_config:
   gbrain_data:
+  infinity_cache:
 
 networks:
   default:

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -364,6 +364,17 @@ const serverSchema = {
   // an OpenAI key for something else never silently re-points an existing
   // Brain at a different embedding path.
   R_BRAIN_OPENAI_API_KEY: z.string().min(1).optional(),
+  // Optional self-run inference upstreams for the Brain gateway. When set,
+  // the gateway routes that path's requests there instead of the configured
+  // model provider — embeddings and rerank can move to a local or fleet
+  // inference service while chat synthesis keeps flowing to the provider.
+  // Model names pass through unrewritten: the upstream owns its own names.
+  R_BRAIN_EMBEDDINGS_UPSTREAM_URL: z.string().url().optional(),
+  R_BRAIN_RERANK_UPSTREAM_URL: z.string().url().optional(),
+  // One key for both paths: they are the same service in every planned
+  // deployment shape. Optional because a compose-network upstream may have
+  // no auth at all.
+  R_BRAIN_INFERENCE_UPSTREAM_API_KEY: z.string().min(1).optional(),
   // Shared secret between this deployment and its Brain container, so the
   // Brain can reach /api/brain/inference without holding a provider key of
   // its own. It is the Brain's whole credential: the real provider key stays
@@ -515,6 +526,9 @@ const OPTIONAL_NON_EMPTY_KEYS = new Set([
   'R_GBRAIN_ADMIN_TOKEN_FILE',
   'R_BRAIN_OPENROUTER_API_KEY',
   'R_BRAIN_OPENAI_API_KEY',
+  'R_BRAIN_EMBEDDINGS_UPSTREAM_URL',
+  'R_BRAIN_RERANK_UPSTREAM_URL',
+  'R_BRAIN_INFERENCE_UPSTREAM_API_KEY',
   'R_BRAIN_GATEWAY_TOKEN',
   'R_BRAIN_GATEWAY_TOKEN_FILE',
   'R_BRAIN_MODEL',
@@ -710,6 +724,9 @@ export function isBrainConfigured(env: {
   R_BRAIN_GATEWAY_TOKEN_FILE?: string;
   R_BRAIN_OPENROUTER_API_KEY?: string;
   R_BRAIN_OPENAI_API_KEY?: string;
+  R_BRAIN_EMBEDDINGS_UPSTREAM_URL?: string;
+  R_BRAIN_RERANK_UPSTREAM_URL?: string;
+  R_BRAIN_INFERENCE_UPSTREAM_API_KEY?: string;
 }): boolean {
   return Boolean(
     env.R_BRAIN_GATEWAY_TOKEN?.trim() ||


### PR DESCRIPTION
## What changed

Lets a deployment run its own embedding and reranking models for the Brain.

**Why the gateway is the right seam:** gbrain sends embeddings, rerank, *and* chat synthesis to a single base URL (the deployment's Brain gateway), so pointing gbrain itself at an inference server would break synthesis — embedding servers have no `/v1/chat/completions`. The gateway already resolves per request, so it gains per-path upstream overrides instead:

- `R_BRAIN_EMBEDDINGS_UPSTREAM_URL` / `R_BRAIN_RERANK_UPSTREAM_URL` — any OpenAI-compatible server; each path routes independently; chat always stays with the configured provider.
- `R_BRAIN_INFERENCE_UPSTREAM_API_KEY` — one optional bearer key for both (a private-network upstream may run authless; the existing header denylist already guarantees the gateway token itself is never forwarded to any upstream).
- Model names pass through **unrewritten** on override paths: the upstream owns its model registry. This is deliberate and load-bearing — every Brain is locked to its embedding model at creation, so a served model name must mean exactly one thing forever.
- The "rerank requires OpenRouter" gate admits a configured rerank upstream.

**Self-host:** a bundled `infinity` service (CPU, `michaelf34/infinity`) behind the opt-in `local-inference` compose profile serves `/v1/embeddings` + `/v1/rerank` from one process with a model-cache volume. Enable with `COMPOSE_PROFILES=brain,local-inference` plus the two URLs (documented in `.env.production.example`).

Reranker defaults are untouched.

## How it was tested

5 new gateway tests alongside the existing 9 (all 14 pass): embeddings route to the upstream with the bearer key and *without* model rewriting or provider resolution; rerank works with a non-OpenRouter provider when the upstream is set (including trailing-slash normalization); no auth header is invented for keyless upstreams; chat still resolves the provider even with both overrides configured; caller auth still gates the local path. Env package tests pass (80); `check-types`, `format:check`, `oxlint` clean. Compose structure validated; the interpolation warnings during full `docker compose config` are pre-existing required-var prompts unrelated to the new service.