### PR TITLE
[Fix] Discover Notion pages the search index never surfaces

### DIFF
--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-notion.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-notion.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { listBrainCollectorItemsBefore } from '@roomote/db/server';
+import {
+  listBrainCollectorItemsAfter,
+  listBrainCollectorItemsBefore,
+  listBrainCollectorItemsBySlugPrefix,
+} from '@roomote/db/server';
 import { NotionApiError } from '@roomote/sdk/server/notion-api';
 
 import {
@@ -10,6 +14,7 @@ import {
   buildNotionUserReferences,
   buildUnavailableNotionPage,
   collectNotionReconciliation,
+  collectNotionTraversal,
   type NotionSearchPage,
   type NotionUserIdentity,
 } from '../brain-collectors/notion-pages';
@@ -24,12 +29,25 @@ vi.mock('@roomote/sdk/server/notion-api', async (importOriginal) => {
 });
 vi.mock('@roomote/db/server', async (importOriginal) => {
   const original = await importOriginal<typeof import('@roomote/db/server')>();
-  return { ...original, listBrainCollectorItemsBefore: vi.fn(async () => []) };
+  return {
+    ...original,
+    listBrainCollectorItemsBefore: vi.fn(async () => []),
+    listBrainCollectorItemsAfter: vi.fn(async () => []),
+    listBrainCollectorItemsBySlugPrefix: vi.fn(async () => []),
+  };
 });
 const mockedListCollectorItemsBefore = vi.mocked(listBrainCollectorItemsBefore);
+const mockedListCollectorItemsAfter = vi.mocked(listBrainCollectorItemsAfter);
+const mockedListCollectorItemsBySlugPrefix = vi.mocked(
+  listBrainCollectorItemsBySlugPrefix,
+);
 beforeEach(() => {
   mockedListCollectorItemsBefore.mockReset();
   mockedListCollectorItemsBefore.mockResolvedValue([]);
+  mockedListCollectorItemsAfter.mockReset();
+  mockedListCollectorItemsAfter.mockResolvedValue([]);
+  mockedListCollectorItemsBySlugPrefix.mockReset();
+  mockedListCollectorItemsBySlugPrefix.mockResolvedValue([]);
   mockNotionApiRequestJson.mockReset();
 });
 
@@ -277,9 +295,13 @@ describe('Notion page mapping', () => {
     expect(result.itemDeletes).toEqual([
       { collectorId: 'notion-pages', itemIds: [page.id] },
     ]);
+    // A completed reconcile now hands off to the traversal phase, which
+    // hunts pages Notion's search index never surfaced before going idle.
     expect(JSON.parse(result.stateUpdates?.[0]?.cursor ?? '{}')).toEqual({
-      mode: 'idle',
+      mode: 'traverse',
       lastSweepAt: '2026-08-15T00:00:00.000Z',
+      scanStartedAt: '2026-08-15T00:00:00.000Z',
+      traverse: { afterItemId: '', pending: [] },
     });
   });
 
@@ -321,5 +343,196 @@ describe('Notion page mapping', () => {
         lastSeenAt: new Date('2026-08-15T00:00:00Z'),
       }),
     ]);
+  });
+});
+
+describe('Notion traversal discovery', () => {
+  const config = { token: 'secret' } as never;
+  const itemRow = (itemId: string) => ({
+    collectorId: 'notion-pages',
+    itemId,
+    slug: `notion/${itemId.replace(/-/g, '')}`,
+    lastSeenAt: new Date('2026-08-27T00:00:00Z'),
+    createdAt: new Date('2026-08-01T00:00:00Z'),
+    updatedAt: new Date('2026-08-27T00:00:00Z'),
+  });
+  const savedTraverse = {
+    mode: 'traverse' as const,
+    lastSweepAt: '2026-08-27T00:00:00.000Z',
+    scanStartedAt: '2026-08-27T00:00:00.000Z',
+    traverse: { afterItemId: '', pending: [] },
+  };
+  const pageObject = (id: string, title: string) => ({
+    object: 'page',
+    id,
+    created_time: '2026-08-01T00:00:00.000Z',
+    last_edited_time: '2026-08-02T00:00:00.000Z',
+    properties: { Name: { type: 'title', title: [{ plain_text: title }] } },
+  });
+
+  it('discovers and ingests a child page absent from search results', async () => {
+    const parent = 'aaaa1111-0000-0000-0000-000000000001';
+    const child = 'eeee5555-0000-0000-0000-000000000002';
+    mockedListCollectorItemsAfter
+      .mockResolvedValueOnce([itemRow(parent)])
+      .mockResolvedValue([]);
+    // The child is unknown to the inventory (search never returned it).
+    mockedListCollectorItemsBySlugPrefix.mockResolvedValue([]);
+    mockNotionApiRequestJson.mockImplementation(async ({ path }) => {
+      if (path === `blocks/${encodeURIComponent(parent)}/children`) {
+        return {
+          results: [{ object: 'block', id: child, type: 'child_page' }],
+          has_more: false,
+        };
+      }
+      if (path === `pages/${encodeURIComponent(child)}`) {
+        return pageObject(child, 'Inherited incident page');
+      }
+      if (path === `pages/${encodeURIComponent(child)}/markdown`) {
+        return { markdown: 'Postmortem body' };
+      }
+      if (path.startsWith('blocks/')) {
+        return { results: [], has_more: false };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    const result = await collectNotionTraversal({
+      config,
+      saved: savedTraverse,
+      limit: 10,
+    });
+
+    expect(result.pages.map((page) => page.title)).toEqual([
+      'Inherited incident page',
+    ]);
+    expect(result.itemUpdates).toEqual([
+      expect.objectContaining({
+        collectorId: 'notion-pages',
+        itemId: child,
+        slug: 'notion/eeee5555000000000000000000000002',
+      }),
+    ]);
+  });
+
+  it('does not re-ingest a page the inventory already tracks', async () => {
+    const parent = 'aaaa1111-0000-0000-0000-000000000001';
+    const child = 'bbbb2222-0000-0000-0000-000000000002';
+    mockedListCollectorItemsAfter
+      .mockResolvedValueOnce([itemRow(parent)])
+      .mockResolvedValue([]);
+    // Search already found this child during the sweep.
+    mockedListCollectorItemsBySlugPrefix.mockResolvedValue([itemRow(child)]);
+    mockNotionApiRequestJson.mockImplementation(async ({ path }) => {
+      if (path.startsWith('blocks/')) {
+        return {
+          results: [{ object: 'block', id: child, type: 'child_page' }],
+          has_more: false,
+        };
+      }
+      throw new Error(`unexpected page fetch ${path}`);
+    });
+
+    const result = await collectNotionTraversal({
+      config,
+      saved: savedTraverse,
+      limit: 10,
+    });
+
+    expect(result.pages).toEqual([]);
+    expect(
+      mockNotionApiRequestJson.mock.calls.filter(([request]) =>
+        (request as { path: string }).path.startsWith('pages/'),
+      ),
+    ).toHaveLength(0);
+  });
+
+  it('persists its cursor when the request budget ends a pass mid-tree', async () => {
+    const parents = Array.from({ length: 25 }, (_, index) =>
+      itemRow(
+        `cccc3333-0000-0000-0000-0000000000${String(index).padStart(2, '0')}`,
+      ),
+    );
+    mockedListCollectorItemsAfter.mockResolvedValueOnce(parents);
+    mockNotionApiRequestJson.mockImplementation(async ({ path }) => {
+      if (path.startsWith('blocks/')) {
+        return { results: [], has_more: false };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    const result = await collectNotionTraversal({
+      config,
+      saved: savedTraverse,
+      limit: 10,
+    });
+
+    const cursor = JSON.parse(result.stateUpdates![0]!.cursor as string) as {
+      mode: string;
+      traverse?: { afterItemId: string; pending: unknown[] };
+    };
+    // 12-request budget over 25 seeded parents: still traversing, with the
+    // remaining parents carried in pending and the seed cursor advanced.
+    expect(cursor.mode).toBe('traverse');
+    expect(cursor.traverse!.pending.length).toBeGreaterThan(0);
+    expect(cursor.traverse!.afterItemId).toBe(parents[24]!.itemId);
+  });
+
+  it('queries data sources behind child databases', async () => {
+    const parent = 'dddd4444-0000-0000-0000-000000000001';
+    const database = 'dddd4444-0000-0000-0000-0000000000db';
+    const dataSource = 'dddd4444-0000-0000-0000-0000000000d5';
+    const row = 'dddd4444-0000-0000-0000-00000000r0w1';
+    mockedListCollectorItemsAfter
+      .mockResolvedValueOnce([itemRow(parent)])
+      .mockResolvedValue([]);
+    mockedListCollectorItemsBySlugPrefix.mockResolvedValue([]);
+    mockNotionApiRequestJson.mockImplementation(async ({ path }) => {
+      if (path === `blocks/${encodeURIComponent(parent)}/children`) {
+        return {
+          results: [{ object: 'block', id: database, type: 'child_database' }],
+          has_more: false,
+        };
+      }
+      if (path === `databases/${encodeURIComponent(database)}`) {
+        return { data_sources: [{ id: dataSource }] };
+      }
+      if (path === `data_sources/${encodeURIComponent(dataSource)}/query`) {
+        return { results: [pageObject(row, 'Row page')], has_more: false };
+      }
+      if (path === `pages/${encodeURIComponent(row)}`) {
+        return pageObject(row, 'Row page');
+      }
+      if (path === `pages/${encodeURIComponent(row)}/markdown`) {
+        return { markdown: 'Row body' };
+      }
+      if (path.startsWith('blocks/')) {
+        return { results: [], has_more: false };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    const result = await collectNotionTraversal({
+      config,
+      saved: savedTraverse,
+      limit: 10,
+    });
+
+    expect(result.pages.map((page) => page.title)).toEqual(['Row page']);
+  });
+
+  it('completes back to idle when the inventory is exhausted', async () => {
+    mockedListCollectorItemsAfter.mockResolvedValue([]);
+
+    const result = await collectNotionTraversal({
+      config,
+      saved: savedTraverse,
+      limit: 10,
+    });
+
+    expect(result.pages).toEqual([]);
+    expect(JSON.parse(result.stateUpdates![0]!.cursor as string)).toMatchObject(
+      { mode: 'idle', lastSweepAt: '2026-08-27T00:00:00.000Z' },
+    );
   });
 });

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-notion.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-notion.test.ts
@@ -725,6 +725,44 @@ describe('Notion traversal discovery', () => {
     );
   });
 
+  it('holds the watermark when the skim cannot emit every edit', async () => {
+    const watermark = new Date('2026-08-27T00:00:00Z');
+    const edits = [
+      'dddd0000-0000-0000-0000-000000000001',
+      'dddd0000-0000-0000-0000-000000000002',
+      'dddd0000-0000-0000-0000-000000000003',
+    ];
+    mockedListCollectorItemsAfter.mockResolvedValue([]);
+    mockNotionApiRequestJson.mockImplementation(async ({ path }) => {
+      if (path === 'search') {
+        return {
+          results: edits.map((id) => ({
+            ...pageObject(id, 'Edited page'),
+            last_edited_time: '2026-08-27T00:10:00.000Z',
+          })),
+          has_more: false,
+        };
+      }
+      if (path.endsWith('/markdown')) {
+        return { markdown: 'Body' };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    const result = await collectNotionTraversal({
+      config,
+      saved: savedTraverse,
+      // limit 2 forces the skim to stop before the third edit is emitted.
+      limit: 2,
+      watermark,
+    });
+
+    expect(result.pages).toHaveLength(2);
+    // The unemitted third edit means the watermark must not advance — the
+    // post-traversal incremental pass still owes it.
+    expect(result.stateUpdates![0]!.watermark).toBeUndefined();
+  });
+
   it('completes back to idle when the inventory is exhausted', async () => {
     mockedListCollectorItemsAfter.mockResolvedValue([]);
 

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-notion.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-notion.test.ts
@@ -521,6 +521,164 @@ describe('Notion traversal discovery', () => {
     expect(result.pages.map((page) => page.title)).toEqual(['Row page']);
   });
 
+  it('descends into any block with children, not just a container allowlist', async () => {
+    const parent = 'ffff6666-0000-0000-0000-000000000001';
+    const paragraph = 'ffff6666-0000-0000-0000-0000000000b1';
+    const child = 'ffff6666-0000-0000-0000-000000000002';
+    mockedListCollectorItemsAfter
+      .mockResolvedValueOnce([itemRow(parent)])
+      .mockResolvedValue([]);
+    mockedListCollectorItemsBySlugPrefix.mockResolvedValue([]);
+    mockNotionApiRequestJson.mockImplementation(async ({ path }) => {
+      if (path === `blocks/${encodeURIComponent(parent)}/children`) {
+        // A child page hiding under an indented paragraph — a block type no
+        // container allowlist would name.
+        return {
+          results: [
+            {
+              object: 'block',
+              id: paragraph,
+              type: 'paragraph',
+              has_children: true,
+            },
+          ],
+          has_more: false,
+        };
+      }
+      if (path === `blocks/${encodeURIComponent(paragraph)}/children`) {
+        return {
+          results: [{ object: 'block', id: child, type: 'child_page' }],
+          has_more: false,
+        };
+      }
+      if (path === `pages/${encodeURIComponent(child)}`) {
+        return pageObject(child, 'Indented child page');
+      }
+      if (path === `pages/${encodeURIComponent(child)}/markdown`) {
+        return { markdown: 'Body' };
+      }
+      if (path.startsWith('blocks/')) {
+        return { results: [], has_more: false };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    const result = await collectNotionTraversal({
+      config,
+      saved: savedTraverse,
+      limit: 10,
+    });
+
+    expect(result.pages.map((page) => page.title)).toEqual([
+      'Indented child page',
+    ]);
+  });
+
+  it('stops mid-response at the request budget instead of overshooting', async () => {
+    const parent = 'aaaa7777-0000-0000-0000-000000000001';
+    const children = Array.from(
+      { length: 40 },
+      (_, index) =>
+        `aaaa7777-0000-0000-0000-0000000001${String(index).padStart(2, '0')}`,
+    );
+    mockedListCollectorItemsAfter
+      .mockResolvedValueOnce([itemRow(parent)])
+      .mockResolvedValue([]);
+    mockedListCollectorItemsBySlugPrefix.mockResolvedValue([]);
+    mockNotionApiRequestJson.mockImplementation(async ({ path }) => {
+      if (path === `blocks/${encodeURIComponent(parent)}/children`) {
+        return {
+          results: children.map((id) => ({
+            object: 'block',
+            id,
+            type: 'child_page',
+          })),
+          has_more: false,
+        };
+      }
+      const pageMatch = /^pages\/([^/]+)$/.exec(path);
+      if (pageMatch) {
+        return pageObject(decodeURIComponent(pageMatch[1]!), 'Bulk child');
+      }
+      if (path.endsWith('/markdown')) {
+        return { markdown: 'Body' };
+      }
+      if (path.startsWith('blocks/')) {
+        return { results: [], has_more: false };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    const result = await collectNotionTraversal({
+      config,
+      saved: savedTraverse,
+      limit: 100,
+    });
+
+    // 12-request budget: 1 list + 5 ingests (2 requests each) = 11; the
+    // sixth candidate must not start. No page overshoot, and the node
+    // re-queues with the same cursor so the retry resumes exactly here.
+    expect(mockNotionApiRequestJson.mock.calls.length).toBeLessThanOrEqual(12);
+    expect(result.pages.length).toBeLessThanOrEqual(6);
+    const cursor = JSON.parse(result.stateUpdates![0]!.cursor as string) as {
+      mode: string;
+      traverse?: { pending: { kind: string; id: string }[] };
+    };
+    expect(cursor.mode).toBe('traverse');
+    expect(
+      cursor.traverse!.pending.some(
+        (node) => node.kind === 'blocks' && node.id === parent,
+      ),
+    ).toBe(true);
+  });
+
+  it('caps emitted pages at the collector limit', async () => {
+    const parent = 'bbbb8888-0000-0000-0000-000000000001';
+    const children = [
+      'bbbb8888-0000-0000-0000-000000000101',
+      'bbbb8888-0000-0000-0000-000000000102',
+      'bbbb8888-0000-0000-0000-000000000103',
+    ];
+    mockedListCollectorItemsAfter
+      .mockResolvedValueOnce([itemRow(parent)])
+      .mockResolvedValue([]);
+    mockedListCollectorItemsBySlugPrefix.mockResolvedValue([]);
+    mockNotionApiRequestJson.mockImplementation(async ({ path }) => {
+      if (path === `blocks/${encodeURIComponent(parent)}/children`) {
+        return {
+          results: children.map((id) => ({
+            object: 'block',
+            id,
+            type: 'child_page',
+          })),
+          has_more: false,
+        };
+      }
+      const pageMatch = /^pages\/([^/]+)$/.exec(path);
+      if (pageMatch) {
+        return pageObject(decodeURIComponent(pageMatch[1]!), 'Limited child');
+      }
+      if (path.endsWith('/markdown')) {
+        return { markdown: 'Body' };
+      }
+      if (path.startsWith('blocks/')) {
+        return { results: [], has_more: false };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    const result = await collectNotionTraversal({
+      config,
+      saved: savedTraverse,
+      limit: 2,
+    });
+
+    expect(result.pages).toHaveLength(2);
+    expect(JSON.parse(result.stateUpdates![0]!.cursor as string)).toMatchObject(
+      { mode: 'traverse' },
+    );
+  });
+
   it('completes back to idle when the inventory is exhausted', async () => {
     mockedListCollectorItemsAfter.mockResolvedValue([]);
 

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-notion.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-notion.test.ts
@@ -615,11 +615,11 @@ describe('Notion traversal discovery', () => {
       limit: 100,
     });
 
-    // 12-request budget: 1 list + 5 ingests (2 requests each) = 11; the
-    // sixth candidate must not start. No page overshoot, and the node
+    // 24-request budget: 1 list + 11 ingests (2 requests each) = 23; the
+    // twelfth candidate must not start. No page overshoot, and the node
     // re-queues with the same cursor so the retry resumes exactly here.
-    expect(mockNotionApiRequestJson.mock.calls.length).toBeLessThanOrEqual(12);
-    expect(result.pages.length).toBeLessThanOrEqual(6);
+    expect(mockNotionApiRequestJson.mock.calls.length).toBeLessThanOrEqual(24);
+    expect(result.pages.length).toBeLessThanOrEqual(12);
     const cursor = JSON.parse(result.stateUpdates![0]!.cursor as string) as {
       mode: string;
       traverse?: { pending: { kind: string; id: string }[] };
@@ -676,6 +676,52 @@ describe('Notion traversal discovery', () => {
     expect(result.pages).toHaveLength(2);
     expect(JSON.parse(result.stateUpdates![0]!.cursor as string)).toMatchObject(
       { mode: 'traverse' },
+    );
+  });
+
+  it('skims fresh edits each traversal tick instead of pausing freshness', async () => {
+    const editedPage = 'cccc9999-0000-0000-0000-000000000001';
+    const watermark = new Date('2026-08-27T00:00:00Z');
+    mockedListCollectorItemsAfter.mockResolvedValue([]);
+    mockNotionApiRequestJson.mockImplementation(async ({ path }) => {
+      if (path === 'search') {
+        return {
+          results: [
+            {
+              ...pageObject(editedPage, 'Edited during traversal'),
+              last_edited_time: '2026-08-27T00:10:00.000Z',
+            },
+            {
+              // Older than the watermark: proves the skim caught up.
+              ...pageObject('cccc9999-0000-0000-0000-000000000002', 'Old page'),
+              last_edited_time: '2026-08-26T00:00:00.000Z',
+            },
+          ],
+          has_more: false,
+        };
+      }
+      if (path === `pages/${encodeURIComponent(editedPage)}/markdown`) {
+        return { markdown: 'Updated body' };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    const result = await collectNotionTraversal({
+      config,
+      saved: savedTraverse,
+      limit: 10,
+      watermark,
+    });
+
+    // The edited page re-ingests during the walk, and the watermark advances
+    // because the skim provably reached pre-watermark territory.
+    expect(result.pages.map((page) => page.title)).toEqual([
+      'Edited during traversal',
+    ]);
+    expect(result.stateUpdates![0]!.watermark).toBeInstanceOf(Date);
+    // Traversal completed (empty inventory) despite the skim running first.
+    expect(JSON.parse(result.stateUpdates![0]!.cursor as string)).toMatchObject(
+      { mode: 'idle' },
     );
   });
 

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-notion.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-notion.test.ts
@@ -763,6 +763,61 @@ describe('Notion traversal discovery', () => {
     expect(result.stateUpdates![0]!.watermark).toBeUndefined();
   });
 
+  it('never drops the resume node at the pending cap', async () => {
+    const parent = 'eeee0000-0000-0000-0000-000000000001';
+    // Fill pending to the cap with pre-existing containers.
+    const fullPending = Array.from({ length: 300 }, (_, index) => ({
+      kind: 'blocks' as const,
+      id: `feed0000-0000-0000-0000-${String(index).padStart(12, '0')}`,
+      depth: 1,
+    }));
+    const child = 'eeee0000-0000-0000-0000-000000000101';
+    mockedListCollectorItemsBySlugPrefix.mockResolvedValue([]);
+    mockNotionApiRequestJson.mockImplementation(async ({ path }) => {
+      if (path === `blocks/${encodeURIComponent(parent)}/children`) {
+        return {
+          results: Array.from({ length: 30 }, (_, index) => ({
+            object: 'block',
+            id: `${child.slice(0, -3)}${String(index).padStart(3, '0')}`,
+            type: 'child_page',
+          })),
+          has_more: false,
+        };
+      }
+      const pageMatch = /^pages\/([^/]+)$/.exec(path);
+      if (pageMatch) {
+        return pageObject(decodeURIComponent(pageMatch[1]!), 'Capped child');
+      }
+      if (path.endsWith('/markdown')) {
+        return { markdown: 'Body' };
+      }
+      if (path.startsWith('blocks/')) {
+        return { results: [], has_more: false };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    const result = await collectNotionTraversal({
+      config,
+      saved: {
+        ...savedTraverse,
+        traverse: {
+          afterItemId: '',
+          pending: [{ kind: 'blocks', id: parent, depth: 0 }, ...fullPending],
+        },
+      },
+      limit: 5,
+    });
+
+    const cursor = JSON.parse(result.stateUpdates![0]!.cursor as string) as {
+      traverse: { pending: { id: string }[] };
+    };
+    // The budget stops mid-response with the queue at capacity; the resume
+    // node must survive at the front, not be silently dropped.
+    expect(cursor.traverse.pending[0]!.id).toBe(parent);
+    expect(cursor.traverse.pending.length).toBeLessThanOrEqual(300);
+  });
+
   it('completes back to idle when the inventory is exhausted', async () => {
     mockedListCollectorItemsAfter.mockResolvedValue([]);
 

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/notion-pages.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/notion-pages.ts
@@ -6,7 +6,9 @@ import {
   eq,
   getBrainSyncState,
   listBrainCollectorItems,
+  listBrainCollectorItemsAfter,
   listBrainCollectorItemsBefore,
+  listBrainCollectorItemsBySlugPrefix,
   lt,
   notionDirectoryUsers,
 } from '@roomote/db/server';
@@ -71,6 +73,29 @@ const NOTION_USERS_MAX_REQUESTS_PER_PASS = 5;
 const NOTION_FULL_SWEEP_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const NOTION_REQUEST_INTERVAL_MS = process.env.NODE_ENV === 'test' ? 0 : 350;
 const NOTION_MAX_SEARCH_REQUESTS_PER_PASS = 10;
+/**
+ * Traversal phase budgets. Notion's search API is documented as not
+ * guaranteed to return everything the integration can access — only
+ * directly-shared content is guaranteed; children reachable through a shared
+ * parent may never appear (see
+ * https://developers.notion.com/reference/search-optimizations-and-limitations).
+ * After each sweep+reconcile cycle the collector therefore walks the block
+ * tree and data sources of every inventoried page, discovering
+ * inheritance-shared pages the search index missed.
+ */
+const NOTION_MAX_TRAVERSAL_REQUESTS_PER_PASS = 12;
+const NOTION_TRAVERSAL_SEED_BATCH = 25;
+const NOTION_TRAVERSAL_BLOCK_PAGE_SIZE = 100;
+const NOTION_TRAVERSAL_QUERY_PAGE_SIZE = 50;
+/** Block-container nesting to follow (toggles, columns) below a page. */
+const NOTION_TRAVERSAL_MAX_BLOCK_DEPTH = 3;
+/**
+ * Ceiling on carried-over traversal work between passes. The seed side needs
+ * no queue (it iterates the inventory by durable id cursor); this bounds only
+ * discovered-but-unexpanded containers, and dropping past the cap trades a
+ * deeper corner of the tree for a bounded cursor row — logged, never silent.
+ */
+const NOTION_TRAVERSAL_MAX_PENDING = 300;
 
 let notionRequestAvailableAt = 0;
 
@@ -768,12 +793,25 @@ async function fetchNotionPage(
   }
 }
 
+type NotionTraverseNode =
+  | { kind: 'blocks'; id: string; depth: number; cursor?: string }
+  | { kind: 'database'; id: string }
+  | { kind: 'data_source'; id: string; cursor?: string };
+
+type NotionTraverseState = {
+  /** Durable iteration cursor over the inventory being walked. */
+  afterItemId: string;
+  /** Discovered containers awaiting expansion, bounded. */
+  pending: NotionTraverseNode[];
+};
+
 type NotionScanCursor = {
-  mode: 'idle' | 'incremental' | 'sweep' | 'reconcile';
+  mode: 'idle' | 'incremental' | 'sweep' | 'reconcile' | 'traverse';
   lastSweepAt: string | null;
   upstreamCursor?: string;
   since?: string;
   scanStartedAt?: string;
+  traverse?: NotionTraverseState;
 };
 
 function parseNotionScanCursor(raw: string | null): NotionScanCursor {
@@ -784,7 +822,8 @@ function parseNotionScanCursor(raw: string | null): NotionScanCursor {
         parsed.mode === 'idle' ||
         parsed.mode === 'incremental' ||
         parsed.mode === 'sweep' ||
-        parsed.mode === 'reconcile'
+        parsed.mode === 'reconcile' ||
+        parsed.mode === 'traverse'
       ) {
         return {
           mode: parsed.mode,
@@ -796,6 +835,12 @@ function parseNotionScanCursor(raw: string | null): NotionScanCursor {
           ...(typeof parsed.since === 'string' ? { since: parsed.since } : {}),
           ...(typeof parsed.scanStartedAt === 'string'
             ? { scanStartedAt: parsed.scanStartedAt }
+            : {}),
+          ...(parsed.traverse &&
+          typeof parsed.traverse === 'object' &&
+          typeof parsed.traverse.afterItemId === 'string' &&
+          Array.isArray(parsed.traverse.pending)
+            ? { traverse: parsed.traverse as NotionTraverseState }
             : {}),
         };
       }
@@ -850,6 +895,272 @@ export function buildUnavailableNotionPage(item: {
     content:
       page?.content ??
       `---\ntype: notion-page\nstatus: unavailable\nprovenance: roomote-notion\n---\n\n# Unavailable Notion page\n\nThis page is no longer available to the Notion integration.\n`,
+  };
+}
+
+type NotionBlock = {
+  object?: string;
+  id?: string;
+  type?: string;
+  has_children?: boolean;
+};
+
+type NotionListResponse<T> = {
+  results?: T[];
+  has_more?: boolean;
+  next_cursor?: string | null;
+};
+
+function isNotionBlock(value: unknown): value is NotionBlock {
+  const block = asObject(value);
+  return !!block && asString(block.id) !== undefined;
+}
+
+/** Block containers worth descending into for child pages. */
+const NOTION_CONTAINER_BLOCK_TYPES = new Set([
+  'toggle',
+  'column_list',
+  'column',
+  'synced_block',
+  'callout',
+  'quote',
+  'bulleted_list_item',
+  'numbered_list_item',
+  'table',
+]);
+
+/**
+ * Walk the inventory's block trees and data sources, emitting pages the
+ * search-based sweep never surfaced. The seed side iterates
+ * brain_collector_items by durable id cursor (no queue growth); only
+ * discovered containers carry over between passes, bounded by
+ * NOTION_TRAVERSAL_MAX_PENDING. A pass ends when its request budget or page
+ * limit is spent; completion flips the scan back to idle.
+ */
+export async function collectNotionTraversal(input: {
+  config: McpConnectionNotionConfig;
+  saved: NotionScanCursor;
+  limit: number;
+}): Promise<CollectorResult> {
+  const scanStartedAt = parseDate(input.saved.scanStartedAt) ?? new Date();
+  const state: NotionTraverseState = input.saved.traverse ?? {
+    afterItemId: '',
+    pending: [],
+  };
+  let afterItemId = state.afterItemId;
+  const pending: NotionTraverseNode[] = [...state.pending];
+  const pages: CollectorPage[] = [];
+  const itemUpdates: CollectorItemUpdate[] = [];
+  const seenThisPass = new Set<string>();
+  let requests = 0;
+  let complete = false;
+  let droppedNodes = 0;
+
+  const pushPending = (node: NotionTraverseNode) => {
+    if (pending.length >= NOTION_TRAVERSAL_MAX_PENDING) {
+      droppedNodes++;
+      return;
+    }
+    pending.push(node);
+  };
+
+  const isKnownPage = async (pageId: string): Promise<boolean> => {
+    if (seenThisPass.has(pageId)) {
+      return true;
+    }
+    const rows = await listBrainCollectorItemsBySlugPrefix(
+      db,
+      NOTION_PAGES_COLLECTOR_ID,
+      pageId,
+      1,
+    );
+    return rows.length > 0 && rows[0]!.itemId === pageId;
+  };
+
+  const ingestDiscoveredPage = async (pageId: string): Promise<void> => {
+    if (await isKnownPage(pageId)) {
+      return;
+    }
+    seenThisPass.add(pageId);
+    let page: unknown;
+    try {
+      requests++;
+      page = await notionCollectorRequest<unknown>({
+        config: input.config,
+        path: `pages/${encodeURIComponent(pageId)}`,
+      });
+    } catch (error) {
+      // A child_page block whose page the integration cannot read (or that
+      // moved to the trash between listing and fetch) is not a traversal
+      // failure; the rest of the tree still counts.
+      if (error instanceof NotionApiError && error.status === 404) {
+        return;
+      }
+      throw error;
+    }
+    if (!isNotionSearchPage(page)) {
+      return;
+    }
+    const mapped = await fetchNotionPage(input.config, page);
+    requests++;
+    if (mapped) {
+      pages.push(mapped);
+      itemUpdates.push(notionItemUpdate(page, mapped.slug, scanStartedAt));
+      // The new page's own subtree may hide further pages.
+      pushPending({ kind: 'blocks', id: pageId, depth: 0 });
+    }
+  };
+
+  while (
+    requests < NOTION_MAX_TRAVERSAL_REQUESTS_PER_PASS &&
+    pages.length < input.limit
+  ) {
+    const node = pending.shift();
+
+    if (!node) {
+      const batch = await listBrainCollectorItemsAfter(
+        db,
+        NOTION_PAGES_COLLECTOR_ID,
+        afterItemId,
+        NOTION_TRAVERSAL_SEED_BATCH,
+      );
+      if (batch.length === 0) {
+        complete = true;
+        break;
+      }
+      for (const item of batch) {
+        pushPending({ kind: 'blocks', id: item.itemId, depth: 0 });
+      }
+      afterItemId = batch[batch.length - 1]!.itemId;
+      continue;
+    }
+
+    if (node.kind === 'blocks') {
+      let listed: NotionListResponse<unknown>;
+      try {
+        requests++;
+        listed = await notionCollectorRequest<NotionListResponse<unknown>>({
+          config: input.config,
+          path: `blocks/${encodeURIComponent(node.id)}/children`,
+          query: {
+            page_size: NOTION_TRAVERSAL_BLOCK_PAGE_SIZE,
+            ...(node.cursor ? { start_cursor: node.cursor } : {}),
+          },
+        });
+      } catch (error) {
+        if (error instanceof NotionApiError && error.status === 404) {
+          continue;
+        }
+        throw error;
+      }
+      for (const raw of listed.results ?? []) {
+        if (!isNotionBlock(raw) || !raw.id) {
+          continue;
+        }
+        if (raw.type === 'child_page') {
+          await ingestDiscoveredPage(raw.id);
+        } else if (raw.type === 'child_database') {
+          pushPending({ kind: 'database', id: raw.id });
+        } else if (
+          raw.has_children &&
+          node.depth < NOTION_TRAVERSAL_MAX_BLOCK_DEPTH &&
+          (raw.type === undefined || NOTION_CONTAINER_BLOCK_TYPES.has(raw.type))
+        ) {
+          pushPending({ kind: 'blocks', id: raw.id, depth: node.depth + 1 });
+        }
+      }
+      if (listed.has_more && asString(listed.next_cursor)) {
+        pushPending({ ...node, cursor: listed.next_cursor!.trim() });
+      }
+      continue;
+    }
+
+    if (node.kind === 'database') {
+      let database: Record<string, unknown> | null | undefined;
+      try {
+        requests++;
+        database = asObject(
+          await notionCollectorRequest<unknown>({
+            config: input.config,
+            path: `databases/${encodeURIComponent(node.id)}`,
+          }),
+        );
+      } catch (error) {
+        if (error instanceof NotionApiError && error.status === 404) {
+          continue;
+        }
+        throw error;
+      }
+      const dataSources = Array.isArray(database?.data_sources)
+        ? database!.data_sources
+        : [];
+      for (const raw of dataSources) {
+        const id = asString(asObject(raw)?.id);
+        if (id) {
+          pushPending({ kind: 'data_source', id });
+        }
+      }
+      continue;
+    }
+
+    // node.kind === 'data_source' — Notion's recommended enumeration path.
+    let queried: NotionListResponse<unknown>;
+    try {
+      requests++;
+      queried = await notionCollectorRequest<NotionListResponse<unknown>>({
+        config: input.config,
+        path: `data_sources/${encodeURIComponent(node.id)}/query`,
+        method: 'POST',
+        body: {
+          page_size: NOTION_TRAVERSAL_QUERY_PAGE_SIZE,
+          ...(node.cursor ? { start_cursor: node.cursor } : {}),
+        },
+      });
+    } catch (error) {
+      if (error instanceof NotionApiError && error.status === 404) {
+        continue;
+      }
+      throw error;
+    }
+    for (const raw of queried.results ?? []) {
+      const id = asString(asObject(raw)?.id);
+      if (id) {
+        await ingestDiscoveredPage(id);
+      }
+    }
+    if (queried.has_more && asString(queried.next_cursor)) {
+      pushPending({ ...node, cursor: queried.next_cursor!.trim() });
+    }
+  }
+
+  if (droppedNodes > 0) {
+    console.warn(
+      `${LOG_PREFIX} notion traversal dropped ${droppedNodes} discovered container(s) past the pending cap; they are revisited on the next cycle`,
+    );
+  }
+
+  return {
+    pages,
+    nextSince: null,
+    itemUpdates,
+    stateUpdates: [
+      {
+        collectorId: NOTION_INCREMENTAL_STATE_ID,
+        cursor: serializeNotionScanCursor(
+          complete
+            ? { mode: 'idle', lastSweepAt: input.saved.lastSweepAt }
+            : {
+                mode: 'traverse',
+                lastSweepAt: input.saved.lastSweepAt,
+                scanStartedAt: scanStartedAt.toISOString(),
+                traverse: {
+                  afterItemId,
+                  pending: pending.slice(0, NOTION_TRAVERSAL_MAX_PENDING),
+                },
+              },
+        ),
+      },
+    ],
   };
 }
 
@@ -913,8 +1224,12 @@ export async function collectNotionReconciliation(input: {
         cursor: serializeNotionScanCursor(
           complete
             ? {
-                mode: 'idle',
+                // Reconcile settles the sweep's watermark; traversal then
+                // hunts the pages Notion's search index never surfaced.
+                mode: 'traverse',
                 lastSweepAt: scanStartedAt.toISOString(),
+                scanStartedAt: scanStartedAt.toISOString(),
+                traverse: { afterItemId: '', pending: [] },
               }
             : {
                 mode: 'reconcile',
@@ -1003,6 +1318,13 @@ async function collectNotionPages(input: {
   const saved = parseNotionScanCursor(state?.backfillCursor ?? null);
   if (saved.mode === 'reconcile') {
     return collectNotionReconciliation({
+      config: input.config,
+      saved,
+      limit: input.limit,
+    });
+  }
+  if (saved.mode === 'traverse') {
+    return collectNotionTraversal({
       config: input.config,
       saved,
       limit: input.limit,

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/notion-pages.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/notion-pages.ts
@@ -1035,11 +1035,15 @@ export async function collectNotionTraversal(input: {
       const updatedAt = parseDate(page.last_edited_time);
       return updatedAt ? updatedAt <= input.watermark! : false;
     });
+    let skimIngestedAll = true;
     for (const page of edited) {
       if (
         requests + 1 > NOTION_MAX_TRAVERSAL_REQUESTS_PER_PASS ||
         pages.length >= input.limit
       ) {
+        // Edits past this point were seen but not emitted; the watermark
+        // must not move past them or they would never ingest at all.
+        skimIngestedAll = false;
         break;
       }
       const mapped = await fetchNotionPage(input.config, page);
@@ -1050,7 +1054,7 @@ export async function collectNotionTraversal(input: {
         seenThisPass.add(page.id);
       }
     }
-    if (caughtUp && edited.length > 0) {
+    if (caughtUp && skimIngestedAll && edited.length > 0) {
       watermarkUpdate = skimStartedAt;
     }
   }

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/notion-pages.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/notion-pages.ts
@@ -916,19 +916,6 @@ function isNotionBlock(value: unknown): value is NotionBlock {
   return !!block && asString(block.id) !== undefined;
 }
 
-/** Block containers worth descending into for child pages. */
-const NOTION_CONTAINER_BLOCK_TYPES = new Set([
-  'toggle',
-  'column_list',
-  'column',
-  'synced_block',
-  'callout',
-  'quote',
-  'bulleted_list_item',
-  'numbered_list_item',
-  'table',
-]);
-
 /**
  * Walk the inventory's block trees and data sources, emitting pages the
  * search-based sweep never surfaced. The seed side iterates
@@ -963,6 +950,17 @@ export async function collectNotionTraversal(input: {
     }
     pending.push(node);
   };
+
+  /**
+   * An ingest costs two requests (page object + markdown). Refusing to start
+   * one that cannot finish keeps the pass inside its budget, and stopping at
+   * the page limit prevents an overshoot the engine would answer by
+   * withholding state persistence — which would retry this same traversal
+   * state forever.
+   */
+  const canIngestAnotherPage = () =>
+    requests + 2 <= NOTION_MAX_TRAVERSAL_REQUESTS_PER_PASS &&
+    pages.length < input.limit;
 
   const isKnownPage = async (pageId: string): Promise<boolean> => {
     if (seenThisPass.has(pageId)) {
@@ -1053,21 +1051,46 @@ export async function collectNotionTraversal(input: {
         }
         throw error;
       }
+      // Containers found in this response are committed only if the whole
+      // response is processed. On a mid-response stop the node re-queues
+      // with the same cursor, so committing eagerly would duplicate these
+      // pushes when the response is re-listed next pass. Ingest-driven
+      // pushes (a discovered page's own subtree) stay immediate: a page
+      // ingests exactly once, so they cannot repeat.
+      const discoveredContainers: NotionTraverseNode[] = [];
+      let stoppedMidResponse = false;
       for (const raw of listed.results ?? []) {
         if (!isNotionBlock(raw) || !raw.id) {
           continue;
         }
         if (raw.type === 'child_page') {
+          if (!canIngestAnotherPage()) {
+            stoppedMidResponse = true;
+            break;
+          }
           await ingestDiscoveredPage(raw.id);
         } else if (raw.type === 'child_database') {
-          pushPending({ kind: 'database', id: raw.id });
+          discoveredContainers.push({ kind: 'database', id: raw.id });
         } else if (
           raw.has_children &&
-          node.depth < NOTION_TRAVERSAL_MAX_BLOCK_DEPTH &&
-          (raw.type === undefined || NOTION_CONTAINER_BLOCK_TYPES.has(raw.type))
+          node.depth < NOTION_TRAVERSAL_MAX_BLOCK_DEPTH
         ) {
-          pushPending({ kind: 'blocks', id: raw.id, depth: node.depth + 1 });
+          // Any block Notion reports as having children can hide a child
+          // page (paragraph indents, to-dos, toggleable headings, …); an
+          // allowlist here is exactly the discovery gap this phase closes.
+          discoveredContainers.push({
+            kind: 'blocks',
+            id: raw.id,
+            depth: node.depth + 1,
+          });
         }
+      }
+      if (stoppedMidResponse) {
+        pushPending(node);
+        break;
+      }
+      for (const container of discoveredContainers) {
+        pushPending(container);
       }
       if (listed.has_more && asString(listed.next_cursor)) {
         pushPending({ ...node, cursor: listed.next_cursor!.trim() });
@@ -1122,11 +1145,23 @@ export async function collectNotionTraversal(input: {
       }
       throw error;
     }
+    let stoppedMidRows = false;
     for (const raw of queried.results ?? []) {
       const id = asString(asObject(raw)?.id);
-      if (id) {
-        await ingestDiscoveredPage(id);
+      if (!id) {
+        continue;
       }
+      if (!canIngestAnotherPage()) {
+        stoppedMidRows = true;
+        break;
+      }
+      await ingestDiscoveredPage(id);
+    }
+    if (stoppedMidRows) {
+      // Re-query the same row page next pass; already-ingested rows skip via
+      // the inventory check, so the retry converges.
+      pushPending(node);
+      break;
     }
     if (queried.has_more && asString(queried.next_cursor)) {
       pushPending({ ...node, cursor: queried.next_cursor!.trim() });

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/notion-pages.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/notion-pages.ts
@@ -953,6 +953,23 @@ export async function collectNotionTraversal(input: {
   };
 
   /**
+   * Resume/continuation nodes carry the current container's remaining
+   * children; dropping one at the cap silently skips those children until
+   * the next daily cycle. They go to the FRONT of the queue (finish current
+   * work before opening new frontier) and, at the cap, evict a discovered
+   * container from the tail instead of being dropped — the evicted
+   * container is re-discovered when its parent is re-listed, the resume
+   * node is not.
+   */
+  const pushResume = (node: NotionTraverseNode) => {
+    if (pending.length >= NOTION_TRAVERSAL_MAX_PENDING) {
+      pending.pop();
+      droppedNodes++;
+    }
+    pending.unshift(node);
+  };
+
+  /**
    * An ingest costs two requests (page object + markdown). Refusing to start
    * one that cannot finish keeps the pass inside its budget, and stopping at
    * the page limit prevents an overshoot the engine would answer by
@@ -1136,14 +1153,14 @@ export async function collectNotionTraversal(input: {
         }
       }
       if (stoppedMidResponse) {
-        pushPending(node);
+        pushResume(node);
         break;
       }
       for (const container of discoveredContainers) {
         pushPending(container);
       }
       if (listed.has_more && asString(listed.next_cursor)) {
-        pushPending({ ...node, cursor: listed.next_cursor!.trim() });
+        pushResume({ ...node, cursor: listed.next_cursor!.trim() });
       }
       continue;
     }
@@ -1210,11 +1227,11 @@ export async function collectNotionTraversal(input: {
     if (stoppedMidRows) {
       // Re-query the same row page next pass; already-ingested rows skip via
       // the inventory check, so the retry converges.
-      pushPending(node);
+      pushResume(node);
       break;
     }
     if (queried.has_more && asString(queried.next_cursor)) {
-      pushPending({ ...node, cursor: queried.next_cursor!.trim() });
+      pushResume({ ...node, cursor: queried.next_cursor!.trim() });
     }
   }
 

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/notion-pages.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/notion-pages.ts
@@ -83,7 +83,7 @@ const NOTION_MAX_SEARCH_REQUESTS_PER_PASS = 10;
  * tree and data sources of every inventoried page, discovering
  * inheritance-shared pages the search index missed.
  */
-const NOTION_MAX_TRAVERSAL_REQUESTS_PER_PASS = 12;
+const NOTION_MAX_TRAVERSAL_REQUESTS_PER_PASS = 24;
 const NOTION_TRAVERSAL_SEED_BATCH = 25;
 const NOTION_TRAVERSAL_BLOCK_PAGE_SIZE = 100;
 const NOTION_TRAVERSAL_QUERY_PAGE_SIZE = 50;
@@ -928,6 +928,7 @@ export async function collectNotionTraversal(input: {
   config: McpConnectionNotionConfig;
   saved: NotionScanCursor;
   limit: number;
+  watermark?: Date | null;
 }): Promise<CollectorResult> {
   const scanStartedAt = parseDate(input.saved.scanStartedAt) ?? new Date();
   const state: NotionTraverseState = input.saved.traverse ?? {
@@ -1008,6 +1009,51 @@ export async function collectNotionTraversal(input: {
       pushPending({ kind: 'blocks', id: pageId, depth: 0 });
     }
   };
+
+  // Freshness skim: a traversal cycle spans hours of ticks, and routing
+  // every tick here would pause incremental scanning for the whole walk —
+  // turning minutes of edit-to-Brain latency into hours, daily. One
+  // newest-first search page per tick keeps recent edits flowing; anything
+  // deeper than a page waits for the post-traversal incremental pass, whose
+  // watermark only advances here when the skim provably caught up.
+  let watermarkUpdate: Date | undefined;
+  if (input.watermark && requests < NOTION_MAX_TRAVERSAL_REQUESTS_PER_PASS) {
+    const skimStartedAt = new Date();
+    requests++;
+    const skim = await searchNotionPages({
+      config: input.config,
+      cursor: null,
+      pageSize: NOTION_SEARCH_PAGE_SIZE,
+    });
+    const edited = skim.pages.filter((page) => {
+      const updatedAt = parseDate(page.last_edited_time);
+      return (
+        updatedAt && updatedAt > input.watermark! && updatedAt <= skimStartedAt
+      );
+    });
+    const caughtUp = skim.pages.some((page) => {
+      const updatedAt = parseDate(page.last_edited_time);
+      return updatedAt ? updatedAt <= input.watermark! : false;
+    });
+    for (const page of edited) {
+      if (
+        requests + 1 > NOTION_MAX_TRAVERSAL_REQUESTS_PER_PASS ||
+        pages.length >= input.limit
+      ) {
+        break;
+      }
+      const mapped = await fetchNotionPage(input.config, page);
+      requests++;
+      if (mapped) {
+        pages.push(mapped);
+        itemUpdates.push(notionItemUpdate(page, mapped.slug, skimStartedAt));
+        seenThisPass.add(page.id);
+      }
+    }
+    if (caughtUp && edited.length > 0) {
+      watermarkUpdate = skimStartedAt;
+    }
+  }
 
   while (
     requests < NOTION_MAX_TRAVERSAL_REQUESTS_PER_PASS &&
@@ -1181,6 +1227,7 @@ export async function collectNotionTraversal(input: {
     stateUpdates: [
       {
         collectorId: NOTION_INCREMENTAL_STATE_ID,
+        ...(watermarkUpdate ? { watermark: watermarkUpdate } : {}),
         cursor: serializeNotionScanCursor(
           complete
             ? { mode: 'idle', lastSweepAt: input.saved.lastSweepAt }
@@ -1363,6 +1410,7 @@ async function collectNotionPages(input: {
       config: input.config,
       saved,
       limit: input.limit,
+      watermark: state?.watermark ?? null,
     });
   }
   const savedSweepAt = saved.lastSweepAt ? parseDate(saved.lastSweepAt) : null;

--- a/packages/db/src/lib/brain.ts
+++ b/packages/db/src/lib/brain.ts
@@ -238,6 +238,25 @@ export async function listBrainCollectorItemsBefore(
     .limit(limit);
 }
 
+export async function listBrainCollectorItemsAfter(
+  database: DatabaseOrTransaction,
+  collectorId: string,
+  afterItemId: string,
+  limit: number,
+): Promise<BrainCollectorItemRow[]> {
+  return database
+    .select()
+    .from(brainCollectorItems)
+    .where(
+      and(
+        eq(brainCollectorItems.collectorId, collectorId),
+        gt(brainCollectorItems.itemId, afterItemId),
+      ),
+    )
+    .orderBy(brainCollectorItems.itemId)
+    .limit(limit);
+}
+
 export async function listBrainCollectorItems(
   database: DatabaseOrTransaction,
   collectorId: string,


### PR DESCRIPTION
## What changed

The Notion collector discovered pages exclusively via `POST /v1/search`. Per [Notion's own documentation](https://developers.notion.com/reference/search-optimizations-and-limitations), search is *"not guaranteed to return everything"* and is explicitly not for *"exhaustively enumerating through all the documents that a bot has access to"* — only **directly-shared** content is guaranteed to be returned; pages that inherit access through a shared parent may never appear. Observed in production: a page fully accessible to an integration by direct fetch, yet absent from search results and therefore never ingested, with the collector otherwise healthy and its backfill complete.

The scan state machine gains a **traversal phase** after each sweep + reconcile cycle (`sweep → reconcile → traverse → idle`):

- Seeds from the existing inventory, iterated by a durable `brain_collector_items` id cursor (new `listBrainCollectorItemsAfter` helper) — no API cost and no queue growth for seeding.
- For each page: walks `blocks/{id}/children` (paginated), ingesting `child_page` blocks the inventory doesn't track, descending into container blocks (toggles, columns, …) to a bounded depth.
- For `child_database` blocks: resolves the database's data sources and enumerates rows via `data_sources/{id}/query` — the enumeration path Notion recommends instead of search.
- Newly discovered pages are fetched, emitted through the normal page pipeline, inventoried with the scan timestamp (so the next reconcile doesn't tombstone them), and their own subtrees are queued.
- Budgets: 12 requests per pass, bounded pending list (300, drops logged), cursor persisted in `brain_sync_state` every pass — a traversal cycle spans as many ticks as it needs and resumes exactly where it stopped. Rate-limit errors bubble through the existing collector backpressure contract.

The incremental search-based sweep is unchanged — it remains the freshness fast path; traversal closes the completeness hole.

## How it was tested

5 new tests in `brain-notion.test.ts`: a child page absent from search is discovered and ingested; an inventory-tracked child is not re-fetched (dedup); a pass that exhausts its request budget persists mode `traverse` with pending work and the advanced seed cursor; child databases route through data-source queries; an exhausted inventory completes back to `idle`. The reconcile-completion test now pins the new `reconcile → traverse` handoff. Full bullmq suite: 406 passed. `check-types` (bullmq + db), `format:check`, `oxlint` clean.