### PR TITLE
[Fix] Treat an unreachable Brain as backpressure, not page failures

### DIFF
--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-outbox-drain.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-outbox-drain.test.ts
@@ -89,6 +89,7 @@ import {
   buildPullRequestFactPage,
   buildMemoryPage,
   callBrainWriteTool,
+  isBrainUnreachable,
   drainBrainHistoricalIngestion,
   getPullRequestFactsResumeCursor,
   isBrainNotReady,
@@ -559,6 +560,56 @@ describe('postToBrain failure classification', () => {
     await expect(postToBrain(page, connection)).rejects.toSatisfy(
       isBrainRateLimited,
     );
+  });
+
+  it('classifies a transport-level failure as backpressure, not a page failure', async () => {
+    // undici's contract: fetch rejects with TypeError('fetch failed') and the
+    // real network error under `cause` — the shape produced when gbrain is
+    // mid-restart during a fleet image roll.
+    const cause = Object.assign(new Error('connect ECONNREFUSED'), {
+      code: 'ECONNREFUSED',
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('fetch failed', { cause });
+      }),
+    );
+
+    await expect(postToBrain(page, connection)).rejects.toSatisfy(
+      isBrainNotReady,
+    );
+  });
+
+  it('keeps an HTTP error from a reachable brain as a per-page failure', async () => {
+    stubUpstream('internal error', 500);
+
+    const error = await postToBrain(page, connection).catch(
+      (thrown: unknown) => thrown,
+    );
+
+    // A reachable server rejecting one payload must keep consuming that
+    // page's attempts, or a poison memory would block the queue forever.
+    expect(isBrainNotReady(error)).toBe(false);
+    expect(isBrainRateLimited(error)).toBe(false);
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it('recognizes network-level causes at any nesting depth', () => {
+    expect(
+      isBrainUnreachable(
+        new TypeError('fetch failed', {
+          cause: Object.assign(new Error('read ECONNRESET'), {
+            code: 'ECONNRESET',
+          }),
+        }),
+      ),
+    ).toBe(true);
+    expect(isBrainUnreachable(new Error('socket hang up'))).toBe(true);
+    expect(isBrainUnreachable(new Error('gbrain put_page failed: 500'))).toBe(
+      false,
+    );
+    expect(isBrainUnreachable('fetch failed')).toBe(false);
   });
 
   it('calls supported gbrain write operations with the ingest credential', async () => {

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-outbox-drain.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-outbox-drain.test.ts
@@ -581,6 +581,29 @@ describe('postToBrain failure classification', () => {
     );
   });
 
+  it('classifies a mid-stream disconnect while reading the body as backpressure', async () => {
+    // The connection dropped while gbrain streamed its MCP response: headers
+    // arrived, the body read rejects with undici's terminated shape.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        status: 200,
+        ok: true,
+        text: async () => {
+          throw new TypeError('terminated', {
+            cause: Object.assign(new Error('other side closed'), {
+              code: 'UND_ERR_SOCKET',
+            }),
+          });
+        },
+      })),
+    );
+
+    await expect(postToBrain(page, connection)).rejects.toSatisfy(
+      isBrainNotReady,
+    );
+  });
+
   it('keeps an HTTP error from a reachable brain as a per-page failure', async () => {
     stubUpstream('internal error', 500);
 

--- a/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
@@ -109,6 +109,52 @@ export function isBrainNotReady(error: unknown): boolean {
   return error instanceof BrainNotReadyError;
 }
 
+const NETWORK_ERROR_CODES = new Set([
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'EAI_AGAIN',
+  'ENOTFOUND',
+  'EPIPE',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_SOCKET',
+]);
+
+/**
+ * A throw from the transport itself — fetch rejects only when no HTTP
+ * response exists (connection refused during a gbrain deploy swap, DNS,
+ * reset), and undici wraps the real cause under `error.cause` with the
+ * top-level message being just "fetch failed". This is a property of the
+ * moment, not of the page being written, so it must never consume a
+ * memory's retry budget: with staging rolling images on every develop
+ * build, a two-minute restart window would otherwise walk perfectly good
+ * memories into a terminal state (observed 2026-08-27: 29 memories
+ * "exhausted their attempts. fetch failed").
+ */
+export function isBrainUnreachable(error: unknown): boolean {
+  let current: unknown = error;
+
+  for (let depth = 0; current && depth < 5; depth++) {
+    if (current instanceof Error) {
+      const code = (current as NodeJS.ErrnoException).code;
+      if (code && NETWORK_ERROR_CODES.has(code)) {
+        return true;
+      }
+      if (
+        current.message === 'fetch failed' ||
+        /socket hang up|other side closed/i.test(current.message)
+      ) {
+        return true;
+      }
+      current = current.cause;
+    } else {
+      break;
+    }
+  }
+
+  return false;
+}
+
 export async function callBrainWriteTool(
   connection: { baseUrl: string; token: string },
   name: string,
@@ -117,7 +163,22 @@ export async function callBrainWriteTool(
   // Shared transport; the backpressure classification below is this write
   // path's own and deliberately stays here. No timeout: put_page embeds
   // synchronously and a slow embed is backpressure, not a failure.
-  const { status, ok, body } = await postBrainToolCall(connection, name, args);
+  let response: Awaited<ReturnType<typeof postBrainToolCall>>;
+
+  try {
+    response = await postBrainToolCall(connection, name, args);
+  } catch (error) {
+    if (isBrainUnreachable(error)) {
+      throw new BrainNotReadyError(
+        `gbrain ${name} unreachable: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+    throw error;
+  }
+
+  const { status, ok, body } = response;
 
   if (status === 429) {
     throw new BrainRateLimitedError(
@@ -555,7 +616,9 @@ async function drainOneBatch(connection: {
         ]);
         console.log(
           `${LOG_PREFIX} ${
-            isBrainRateLimited(error) ? 'rate limited by' : 'cannot embed into'
+            isBrainRateLimited(error)
+              ? 'rate limited by'
+              : 'cannot reach or embed into'
           } the brain; pausing until next tick`,
         );
         return false;
@@ -713,7 +776,9 @@ async function drainOneFastMemoryBatch(connection: {
         ]);
         console.log(
           `${LOG_PREFIX} ${
-            isBrainRateLimited(error) ? 'rate limited by' : 'cannot embed into'
+            isBrainRateLimited(error)
+              ? 'rate limited by'
+              : 'cannot reach or embed into'
           } the brain; pausing conversation-memory drain until next tick`,
         );
         return false;

--- a/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
@@ -142,7 +142,9 @@ export function isBrainUnreachable(error: unknown): boolean {
       }
       if (
         current.message === 'fetch failed' ||
-        /socket hang up|other side closed/i.test(current.message)
+        /socket hang up|other side closed|terminated|premature close/i.test(
+          current.message,
+        )
       ) {
         return true;
       }

--- a/packages/sdk/src/server/lib/brain-mcp.ts
+++ b/packages/sdk/src/server/lib/brain-mcp.ts
@@ -51,7 +51,13 @@ export async function postBrainToolCall(
       ? { signal: AbortSignal.timeout(options.timeoutMs) }
       : {}),
   });
-  const body = await response.text().catch(() => '');
+  // A body-read rejection is a transport failure (the connection dropped
+  // while gbrain streamed its response), not an empty response. Swallowing
+  // it here made mid-stream disconnects surface downstream as JSON-RPC
+  // parse errors — misclassified as payload problems. Callers already
+  // handle pre-header transport throws, so body-read throws propagate the
+  // same way.
+  const body = await response.text();
 
   return { status: response.status, ok: response.ok, body };
 }


### PR DESCRIPTION
## What changed

During a fleet image roll the gbrain service restarts for ~1–2 minutes. Outbox drain batches in flight fail with undici's generic `TypeError: fetch failed` (real cause nested under `error.cause`), and the drain counted each as a per-memory failure — burning retry budgets against an outage that has nothing to do with the pages. On staging (which rolls on every develop build) during a large re-drain, 29 memories reached terminal `exhausted their attempts. fetch failed` and surfaced in the web UI's Memory issues panel needing a manual retry.

The drain already has the right machinery: `BrainNotReadyError` ends the pass, releases the claimed batch, and `releaseBrainMemoryEvents` restores the attempt counts. The gap was classification. `callBrainWriteTool` — the single write chokepoint every sink uses — now catches transport-level throws and raises them as `BrainNotReadyError`. The classifier (`isBrainUnreachable`) walks the `cause` chain up to five levels for network error codes (`ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`, `EAI_AGAIN`, `ENOTFOUND`, `EPIPE`, undici's connect/socket codes) and the known message shapes (`fetch failed`, `socket hang up`).

The line it deliberately does not cross: **HTTP errors from a reachable Brain stay per-page failures.** A server that answered and rejected one payload is that page's problem — reclassifying it as backpressure would let a single poison memory pause the whole queue forever. Non-Error values and error *prose* mentioning network terms don't classify either, keeping page content from masquerading as transport state (same principle as the existing 429 handling).

The per-page budget (`MAX_ATTEMPTS = 5`) is untouched — with outage windows no longer consuming attempts, it's ample.

## How it was tested

New tests alongside the existing transport tests: undici-shaped `TypeError('fetch failed', {cause: ECONNREFUSED})` classifies as not-ready backpressure; a 500 from a reachable Brain remains a plain per-page error (neither backpressure class); the classifier unit-checks nested causes, `socket hang up`, and rejects both error prose mentioning failures and non-Error values. Drain suite 41 passed; full bullmq suite 415; `check-types`, `format:check`, `knip` clean.