### PR TITLE
[Fix] Deflake instance-report task usage isolation test

### DIFF
--- a/packages/db/src/lib/__tests__/instance-report.test.ts
+++ b/packages/db/src/lib/__tests__/instance-report.test.ts
@@ -508,9 +508,13 @@ describe('collectInstanceReportStats pullRequests7d isolation', () => {
 
 describe('collectInstanceReportStats task usage isolation', () => {
   it('excludes environment snapshots from task usage aggregates', async () => {
-    // Keep this aggregate assertion isolated from test files sharing the database.
-    const now = new Date('2040-01-01T00:00:00.000Z');
-    const baseline = await collectInstanceReportStats(now);
+    // The report window is [now - 24h, ∞) with no upper bound, and other test
+    // files write/delete rows in the shared database concurrently (some with
+    // timestamps as late as 2099). Pick a `now` whose window no other suite's
+    // timestamps can reach so the aggregates below cover exactly the rows this
+    // test creates, letting us assert exact values instead of racy baseline
+    // deltas.
+    const now = new Date('2200-01-01T00:00:00.000Z');
     const suffix = Date.now().toString();
     const productModel = `product-model-${suffix}`;
     const snapshotModel = `snapshot-model-${suffix}`;
@@ -570,24 +574,24 @@ describe('collectInstanceReportStats task usage isolation', () => {
 
     const report = await collectInstanceReportStats(now);
 
-    expect(report.tasks24h.created).toBe(baseline.tasks24h.created + 1);
-    expect(report.tasks24h.completed).toBe(baseline.tasks24h.completed + 1);
-    expect(report.tasks24h.byHarness['opencode-server']).toBe(
-      (baseline.tasks24h.byHarness['opencode-server'] ?? 0) + 1,
-    );
-    expect(report.tasks24h.byModel).toContainEqual({
-      provider: 'openai',
-      model: productModel,
-      count: 1,
-    });
+    expect(report.tasks24h.created).toBe(1);
+    expect(report.tasks24h.completed).toBe(1);
+    expect(report.tasks24h.byHarness).toEqual({ 'opencode-server': 1 });
+    expect(report.tasks24h.byModel).toEqual([
+      {
+        provider: 'openai',
+        model: productModel,
+        count: 1,
+      },
+    ]);
     expect(report.tasks24h.byModel).not.toContainEqual(
       expect.objectContaining({ model: snapshotModel }),
     );
     expect(report.tasks24h.tokens).toEqual({
-      input: baseline.tasks24h.tokens.input + 10,
-      output: baseline.tasks24h.tokens.output + 20,
-      total: baseline.tasks24h.tokens.total + 30,
-      costMicroUsd: baseline.tasks24h.tokens.costMicroUsd + 40,
+      input: 10,
+      output: 20,
+      total: 30,
+      costMicroUsd: 40,
     });
   });
 });


### PR DESCRIPTION
## Problem

The test `collectInstanceReportStats task usage isolation > excludes environment snapshots from task usage aggregates` is flaky in CI (e.g. `expected 2, received 1` on the completed-count delta), while passing locally and on re-runs.

The test compared global 24h aggregates against a baseline read taken moments earlier. But vitest runs test files in parallel against the shared test database, and the report window is `[now - 24h, ∞)` with no upper bound. Other suites (`brain.test.ts`, `task-start-parallel-counts.test.ts`, `pr-review-notification-units.test.ts`) create and delete rows with far-future timestamps (up to 2099) that land inside the test's 2040 window, shifting the counts between the baseline read and the report read.

## Fix

- Move the test's `now` to 2200-01-01 so no other suite's timestamps can reach its window (the suite's globalSetup truncates all tables per vitest invocation, so nothing leaks across runs either).
- Drop the baseline read and assert exact values for the rows the test creates: created/completed counts, exact `byHarness` and `byModel` contents, and exact token totals.

This also strengthens the original intent: the env-snapshot task and its usage are now provably absent from every aggregate, not just non-additive relative to a racy baseline.

## Validation

- `pnpm --filter @roomote/db test` run 22 times back to back: the target test passed every time (one early unrelated run failure never reproduced across 18 subsequent instrumented runs).
- `pnpm --filter @roomote/db check-types` and oxfmt clean.