### PR TITLE
Anchor sync reviews on the previously reviewed head

### DIFF
--- a/packages/cloud-agents/src/server/__tests__/enqueue-task.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/enqueue-task.test.ts
@@ -61,6 +61,7 @@ import {
 } from '../task-run-queue';
 import { LLM_TITLE_LOCKED_CHECKPOINT } from '../llm-task-title';
 import { applyTaskModelSelectionToRun } from '../task-model-selection';
+import { getPrSha } from '../workflows/utils';
 
 const createdTaskIds: string[] = [];
 const createdUserIds: string[] = [];
@@ -1807,6 +1808,93 @@ describe('enqueueTask PR linkage', () => {
     expect(persistedLinkage?.githubReactionId).toBe(101);
     expect(persistedLinkage?.githubCheckRunId).toBe(202);
     expect(persistedLinkage?.githubReviewCommentId).toBe(303);
+  });
+
+  it('anchors getPrSha on the previously reviewed head, not the bumped linkage', async () => {
+    const prNumber = 81;
+    const reviewedSha = '1'.repeat(40);
+    const pushedSha = '2'.repeat(40);
+    const prUrl = `https://github.com/acme/widgets/pull/${prNumber}`;
+    const makeTask = (headSha: string) =>
+      ({
+        type:
+          headSha === reviewedSha
+            ? TaskPayloadKind.GithubPrReview
+            : TaskPayloadKind.GithubPrReviewSync,
+        requestedWorkKindDecision: explicitWorkKind,
+        payload: {
+          repo: 'acme/widgets',
+          prNumber,
+          prTitle: 'Anchor on the reviewed head',
+          prUrl,
+          headSha,
+        },
+      }) as FreshTaskLaunch['task'];
+    const makeLinkage = (prSha: string) => ({
+      provider: 'github' as const,
+      repository: 'acme/widgets',
+      prNumber,
+      prUrl,
+      prTitle: 'Anchor on the reviewed head',
+      prSha,
+    });
+
+    const reviewRun = await enqueueTask(
+      {
+        task: makeTask(reviewedSha),
+        initiator: { kind: 'automation', key: 'review_code' },
+        workflow: 'pr_review',
+        surface: 'github',
+        trigger: 'webhook',
+        prLinkage: makeLinkage(reviewedSha),
+      },
+      { enqueue: false, skipEarlyTitleGeneration: true },
+    );
+    createdTaskIds.push(reviewRun.taskId);
+
+    await db
+      .update(taskRuns)
+      .set({
+        status: RunStatus.Completed,
+        startedAt: new Date(),
+        completedAt: new Date(),
+      })
+      .where(eq(taskRuns.id, reviewRun.id));
+    await db
+      .update(tasks)
+      .set({ state: 'completed' })
+      .where(eq(tasks.id, reviewRun.taskId));
+
+    // A push launches the sync onto the same task and bumps the shared
+    // linkage row to the new head before the sync run builds its prompt.
+    const syncRun = await enqueueTask(
+      {
+        existingTaskId: reviewRun.taskId,
+        task: makeTask(pushedSha),
+        initiator: { kind: 'automation', key: 'review_code' },
+        workflow: 'pr_review',
+        surface: 'github',
+        trigger: 'webhook',
+        prLinkage: makeLinkage(pushedSha),
+      },
+      { enqueue: false, skipEarlyTitleGeneration: true },
+    );
+
+    const linkage = await db.query.taskPullRequests.findFirst({
+      where: eq(taskPullRequests.taskId, reviewRun.taskId),
+    });
+    expect(linkage?.prSha).toBe(pushedSha);
+
+    // The sync's anchor must be the head the prior review actually covered.
+    // Reading the bumped linkage here made last_review_sha equal the fresh
+    // head, so syncs reported "no new commits" despite real pushes.
+    await expect(
+      getPrSha({
+        currentRunId: syncRun.id,
+        repo: 'acme/widgets',
+        prNumber,
+      }),
+    ).resolves.toBe(reviewedSha);
   });
 
   it('serializes concurrent first reviews into one durable PR task', async () => {

--- a/packages/cloud-agents/src/server/__tests__/enqueue-task.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/enqueue-task.test.ts
@@ -1897,6 +1897,110 @@ describe('enqueueTask PR linkage', () => {
     ).resolves.toBe(reviewedSha);
   });
 
+  it('anchors past follow-up runs that carry no payload headSha', async () => {
+    const prNumber = 82;
+    const reviewedSha = '3'.repeat(40);
+    const pushedSha = '4'.repeat(40);
+    const prUrl = `https://github.com/acme/widgets/pull/${prNumber}`;
+    const makeLinkage = (prSha: string) => ({
+      provider: 'github' as const,
+      repository: 'acme/widgets',
+      prNumber,
+      prUrl,
+      prTitle: 'Anchor past follow-ups',
+      prSha,
+    });
+    const launch = (
+      task: FreshTaskLaunch['task'],
+      existingTaskId?: string,
+      prSha = reviewedSha,
+    ) =>
+      enqueueTask(
+        {
+          ...(existingTaskId ? { existingTaskId } : {}),
+          task,
+          initiator: { kind: 'automation', key: 'review_code' },
+          workflow: 'pr_review',
+          surface: 'github',
+          trigger: 'webhook',
+          prLinkage: makeLinkage(prSha),
+        },
+        { enqueue: false, skipEarlyTitleGeneration: true },
+      );
+    const finishRun = async (runId: number, taskId: string) => {
+      await db
+        .update(taskRuns)
+        .set({
+          status: RunStatus.Completed,
+          startedAt: new Date(),
+          completedAt: new Date(),
+        })
+        .where(eq(taskRuns.id, runId));
+      await db
+        .update(tasks)
+        .set({ state: 'completed' })
+        .where(eq(tasks.id, taskId));
+    };
+
+    const reviewRun = await launch({
+      type: TaskPayloadKind.GithubPrReview,
+      requestedWorkKindDecision: explicitWorkKind,
+      payload: {
+        repo: 'acme/widgets',
+        prNumber,
+        prTitle: 'Anchor past follow-ups',
+        prUrl,
+        headSha: reviewedSha,
+      },
+    } as FreshTaskLaunch['task']);
+    createdTaskIds.push(reviewRun.taskId);
+    await finishRun(reviewRun.id, reviewRun.taskId);
+
+    // A mention follow-up runs between the review and the next push. Its
+    // payload records no headSha, so it must not become the anchor.
+    const followUpRun = await launch(
+      {
+        type: TaskPayloadKind.GithubPrReviewFollowUp,
+        requestedWorkKindDecision: explicitWorkKind,
+        payload: {
+          repo: 'acme/widgets',
+          prNumber,
+          prTitle: 'Anchor past follow-ups',
+          commentBody: 'Please tweak the error message',
+        },
+      } as FreshTaskLaunch['task'],
+      reviewRun.taskId,
+    );
+    await finishRun(followUpRun.id, reviewRun.taskId);
+
+    const syncRun = await launch(
+      {
+        type: TaskPayloadKind.GithubPrReviewSync,
+        requestedWorkKindDecision: explicitWorkKind,
+        payload: {
+          repo: 'acme/widgets',
+          prNumber,
+          prTitle: 'Anchor past follow-ups',
+          prUrl,
+          headSha: pushedSha,
+        },
+      } as FreshTaskLaunch['task'],
+      reviewRun.taskId,
+      pushedSha,
+    );
+
+    // The newest sibling (the follow-up) has no payload headSha; falling
+    // back to the bumped linkage there would resurrect the "no new
+    // commits" bug. The anchor must skip to the run that recorded one.
+    await expect(
+      getPrSha({
+        currentRunId: syncRun.id,
+        repo: 'acme/widgets',
+        prNumber,
+      }),
+    ).resolves.toBe(reviewedSha);
+  });
+
   it('serializes concurrent first reviews into one durable PR task', async () => {
     const prNumber = 80;
     const prUrl = `https://github.com/acme/widgets/pull/${prNumber}`;

--- a/packages/cloud-agents/src/server/workflows/utils.ts
+++ b/packages/cloud-agents/src/server/workflows/utils.ts
@@ -23,6 +23,7 @@ import {
   isNotNull,
   desc,
   asc,
+  sql,
 } from '@roomote/db/server';
 import {
   Schemas,
@@ -896,7 +897,17 @@ export async function getPrSha({
   }
 
   const [result] = await db
-    .select({ prSha: taskPullRequests.prSha })
+    .select({
+      prSha: taskPullRequests.prSha,
+      // The run's own payload head, immutable once launched. The linkage
+      // row's prSha is NOT a reliable anchor: a sync launched onto the
+      // existing review task updates that shared row to the incoming head
+      // before this query runs, so reading it through a sibling run returns
+      // the new head as the "previous" one — the sync then sees
+      // last_review_sha == current_head_sha and reports no new commits
+      // despite real pushes (observed on live sync reviews, 2026-08-27).
+      payloadHeadSha: sql<string | null>`${taskRuns.payload}->>'headSha'`,
+    })
     .from(taskPullRequests)
     .innerJoin(tasks, eq(tasks.id, taskPullRequests.taskId))
     .innerJoin(taskRuns, eq(taskRuns.taskId, tasks.id))
@@ -904,7 +915,7 @@ export async function getPrSha({
     .orderBy(desc(taskRuns.createdAt))
     .limit(1);
 
-  return result?.prSha ?? undefined;
+  return result?.payloadHeadSha ?? result?.prSha ?? undefined;
 }
 
 export async function getPrReviewCommentId({

--- a/packages/cloud-agents/src/server/workflows/utils.ts
+++ b/packages/cloud-agents/src/server/workflows/utils.ts
@@ -896,18 +896,28 @@ export async function getPrSha({
     conditions.push(ne(taskRuns.id, currentRunId));
   }
 
+  // Anchor on a run's own payload headSha, immutable once launched. The
+  // linkage row's prSha is NOT a reliable anchor: a sync launched onto the
+  // existing review task updates that shared row to the incoming head
+  // before this query runs, so reading it through a sibling run returns
+  // the new head as the "previous" one — the sync then sees
+  // last_review_sha == current_head_sha and reports no new commits despite
+  // real pushes (observed on live sync reviews, 2026-08-27). Follow-up runs
+  // carry no payload headSha, so pick the newest sibling that has one; the
+  // linkage prSha is only a last resort when no run recorded a head.
+  const payloadHeadSha = sql<string | null>`${taskRuns.payload}->>'headSha'`;
+  const [anchored] = await db
+    .select({ headSha: payloadHeadSha })
+    .from(taskPullRequests)
+    .innerJoin(tasks, eq(tasks.id, taskPullRequests.taskId))
+    .innerJoin(taskRuns, eq(taskRuns.taskId, tasks.id))
+    .where(and(...conditions, isNotNull(payloadHeadSha)))
+    .orderBy(desc(taskRuns.createdAt))
+    .limit(1);
+  if (anchored?.headSha) return anchored.headSha;
+
   const [result] = await db
-    .select({
-      prSha: taskPullRequests.prSha,
-      // The run's own payload head, immutable once launched. The linkage
-      // row's prSha is NOT a reliable anchor: a sync launched onto the
-      // existing review task updates that shared row to the incoming head
-      // before this query runs, so reading it through a sibling run returns
-      // the new head as the "previous" one — the sync then sees
-      // last_review_sha == current_head_sha and reports no new commits
-      // despite real pushes (observed on live sync reviews, 2026-08-27).
-      payloadHeadSha: sql<string | null>`${taskRuns.payload}->>'headSha'`,
-    })
+    .select({ prSha: taskPullRequests.prSha })
     .from(taskPullRequests)
     .innerJoin(tasks, eq(tasks.id, taskPullRequests.taskId))
     .innerJoin(taskRuns, eq(taskRuns.taskId, tasks.id))
@@ -915,7 +925,7 @@ export async function getPrSha({
     .orderBy(desc(taskRuns.createdAt))
     .limit(1);
 
-  return result?.payloadHeadSha ?? result?.prSha ?? undefined;
+  return result?.prSha ?? undefined;
 }
 
 export async function getPrReviewCommentId({


### PR DESCRIPTION
## Problem

Sync reviews have been reporting **"No new commits since the prior review"** on PRs that clearly had new pushes, skipping the re-review.

`getPrSha` derives the last-reviewed head from `taskPullRequests.prSha` of the prior pr_review run. But when a push launches the sync onto the existing review task, the launch path updates that same linkage row to the incoming head *before* the sync prompt is built (that bump is intentional — the linkage tracks the latest head for dedupe/routing, and an existing test asserts it). The anchor query excludes the current run but joins the linkage through the completed sibling run — reading the row the launch just overwrote. Result: `last_review_sha == current_head_sha`, and the agent correctly no-ops on an empty delta.

Confirmed against production data: after a push, both the original review run and the sync run resolved to the same (new) head even though the original review's own payload still recorded the head it actually covered.

## Fix

Anchor on the sibling run's immutable `payload.headSha` — by definition "the head the review actually started from" — and fall back to the linkage `prSha` only when the payload has none (e.g. follow-up runs, legacy rows). No write-path changes.

## Testing

- New regression test in the real-database enqueue harness reproduces the full sequence (review at head A → push launches sync, linkage bumped to head B → `getPrSha` must return A). Fails with the exact production symptom without the fix, passes with it.
- Full `@roomote/cloud-agents` suite: 977 passed.