### PR TITLE
[Fix] Record real cost for Roomote inference usage

### DIFF
--- a/apps/web/src/trpc/commands/setup-new/index.test.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.test.ts
@@ -70,7 +70,11 @@ const {
 const { mockFetchModelsDevCatalog, mockLookupModelMetadataFromCatalog } =
   vi.hoisted(() => ({
     mockFetchModelsDevCatalog: vi.fn(async () => null),
-    mockLookupModelMetadataFromCatalog: vi.fn(() => ({ metadata: {} })),
+    mockLookupModelMetadataFromCatalog: vi.fn(
+      (_catalog: unknown, _modelId: string): { metadata: object } => ({
+        metadata: {},
+      }),
+    ),
   }));
 
 vi.mock('../task-models/models-dev', async (importOriginal) => {
@@ -1459,7 +1463,7 @@ describe('chooseSetupTrialInferenceCommand', () => {
       providers: {},
       gatewayModelsByLowerSlug: {},
     } as never);
-    mockLookupModelMetadataFromCatalog.mockImplementation((_c, modelId) =>
+    mockLookupModelMetadataFromCatalog.mockImplementation((_catalog, modelId) =>
       modelId === 'roomote/openai/gpt-5.6-luna'
         ? {
             metadata: {

--- a/apps/web/src/trpc/commands/setup-new/index.test.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.test.ts
@@ -67,6 +67,22 @@ const {
   })),
 }));
 
+const { mockFetchModelsDevCatalog, mockLookupModelMetadataFromCatalog } =
+  vi.hoisted(() => ({
+    mockFetchModelsDevCatalog: vi.fn(async () => null),
+    mockLookupModelMetadataFromCatalog: vi.fn(() => ({ metadata: {} })),
+  }));
+
+vi.mock('../task-models/models-dev', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../task-models/models-dev')>();
+  return {
+    ...actual,
+    fetchModelsDevCatalog: mockFetchModelsDevCatalog,
+    lookupModelMetadataFromCatalog: mockLookupModelMetadataFromCatalog,
+  };
+});
+
 vi.mock('../task-models/provider-validation', () => ({
   validateSetupModelProviderCredentials:
     mockValidateSetupModelProviderCredentials,
@@ -1430,6 +1446,51 @@ describe('chooseSetupTrialInferenceCommand', () => {
     });
     expect(taskModelSettingsInsert?.taskModelSettings).toMatchObject({
       defaultModelId: 'roomote/openai/gpt-5.6-luna',
+    });
+  });
+
+  it('seeds trial models with catalog metadata when the catalog is reachable', async () => {
+    vi.stubEnv('R_TRIAL_OPENROUTER_API_KEY', 'sk-trial');
+    mockGetPersistedEnvironmentVariableNames.mockResolvedValue([
+      'R_TRIAL_OPENROUTER_API_KEY',
+    ]);
+    mockFetchModelsDevCatalog.mockResolvedValueOnce({
+      models: {},
+      providers: {},
+      gatewayModelsByLowerSlug: {},
+    } as never);
+    mockLookupModelMetadataFromCatalog.mockImplementation((_c, modelId) =>
+      modelId === 'roomote/openai/gpt-5.6-luna'
+        ? {
+            metadata: {
+              contextWindow: 400_000,
+              inputPricePerToken: 0.000002,
+              outputPricePerToken: 0.00001,
+            },
+          }
+        : { metadata: {} },
+    );
+    const { tx, inserted } = createTxStub({
+      setupNewState: {},
+      runtimeModelConfig: null,
+      taskModelSettings: null,
+    });
+    mockDbTransaction.mockImplementation(
+      async (callback: (tx: unknown) => Promise<unknown>) => callback(tx),
+    );
+
+    await chooseSetupTrialInferenceCommand(buildMockAuth());
+
+    const settingsInsert = inserted.find(
+      (values) => 'taskModelSettings' in values,
+    ) as { taskModelSettings?: { models?: Array<Record<string, unknown>> } };
+    const luna = settingsInsert.taskModelSettings?.models?.find(
+      (model) => model.id === 'roomote/openai/gpt-5.6-luna',
+    );
+    expect(luna?.metadata).toMatchObject({
+      contextWindow: 400_000,
+      inputPricePerToken: 0.000002,
+      outputPricePerToken: 0.00001,
     });
   });
 

--- a/apps/web/src/trpc/commands/setup-new/index.ts
+++ b/apps/web/src/trpc/commands/setup-new/index.ts
@@ -168,6 +168,11 @@ import {
 } from '../source-control';
 import { getPersistedRawTaskModelSettings } from '../task-models';
 import {
+  fetchModelsDevCatalog,
+  lookupModelMetadataFromCatalog,
+  mergeMetadata,
+} from '../task-models/models-dev';
+import {
   buildAutoAddedTaskModelSettings,
   collectConnectedTaskModelProviderIds,
 } from '../task-models/auto-add-models';
@@ -490,13 +495,27 @@ export async function chooseSetupTrialInferenceCommand(auth: UserAuthSuccess) {
       ROOMOTE_TRIAL_MODEL_PRESET_ID,
     );
     const defaultModelId = runtimeModelConfig.roomoteModel;
-    const trialModels = provider.suggestedTaskModels.map((suggestion) =>
-      buildTaskModelOption({
+    // Best-effort metadata for the seeded catalog: without pricing and
+    // context windows every trial message records zero cost and models run
+    // on default limits. The roomote-aware catalog lookup resolves each
+    // model through its OpenRouter upstream; a failed fetch seeds without
+    // metadata, exactly as before, and the Settings refresh backfills.
+    const metadataCatalog = await fetchModelsDevCatalog(
+      AbortSignal.timeout(10_000),
+    ).catch(() => null);
+    const trialModels = provider.suggestedTaskModels.map((suggestion) => {
+      const lookup = metadataCatalog
+        ? lookupModelMetadataFromCatalog(metadataCatalog, suggestion.id)
+        : null;
+      return buildTaskModelOption({
         id: suggestion.id,
         displayName: suggestion.displayName,
         family: suggestion.family,
-      }),
-    );
+        ...(lookup?.metadata && Object.keys(lookup.metadata).length > 0
+          ? { metadata: mergeMetadata(null, lookup.metadata) }
+          : {}),
+      });
+    });
     const setupNewState = normalizeSetupNewState({
       ...currentState,
       modelProvider: provider.id,

--- a/apps/web/src/trpc/commands/task-models/models-dev.test.ts
+++ b/apps/web/src/trpc/commands/task-models/models-dev.test.ts
@@ -106,6 +106,34 @@ describe('lookupModelMetadataFromCatalog', () => {
     expect(result.displayName).toBe('GLM 5.2');
   });
 
+  it('resolves Roomote inference models through their OpenRouter upstream', () => {
+    const catalog = buildCatalog({
+      gatewayModelsByLowerSlug: {
+        openrouter: {
+          'openai/gpt-5.6-luna': {
+            id: 'openai/gpt-5.6-luna',
+            name: 'GPT 5.6 Luna',
+            modalities: { input: ['text'] },
+            limit: { context: 400000, output: 32768 },
+            cost: { input: 2, output: 10 },
+          },
+        },
+      },
+    });
+
+    const result = lookupModelMetadataFromCatalog(
+      catalog,
+      'roomote/openai/gpt-5.6-luna',
+    );
+
+    expect(result.metadata).toEqual({
+      contextWindow: 400000,
+      inputTypes: ['text'],
+      inputPricePerToken: 2 / 1_000_000,
+      outputPricePerToken: 10 / 1_000_000,
+    });
+  });
+
   it('matches case-insensitively for mixed-case slugs', () => {
     const catalog = buildCatalog({
       gatewayModelsByLowerSlug: {

--- a/apps/web/src/trpc/commands/task-models/models-dev.ts
+++ b/apps/web/src/trpc/commands/task-models/models-dev.ts
@@ -2,6 +2,7 @@ import {
   GATEWAY_TASK_MODEL_PROVIDER_IDS,
   type TaskModelInputType,
   type TaskModelMetadata,
+  rebaseRoomoteModelIdToUpstream,
 } from '@roomote/types';
 
 const MODELS_DEV_CATALOG_URL = 'https://models.dev/catalog.json';
@@ -275,6 +276,16 @@ export function lookupModelMetadataFromCatalog(
   catalog: ModelsDevCatalog,
   modelId: string,
 ): ExtractedMetadata {
+  // Roomote inference models are OpenRouter models under a separate id
+  // namespace; resolve their metadata (context window, pricing) through the
+  // upstream OpenRouter identity or every trial model stays metadata-less
+  // and OpenCode reports zero cost for trial usage.
+  const upstreamSlug = rebaseRoomoteModelIdToUpstream(modelId);
+  if (upstreamSlug !== null)
+    return lookupModelMetadataFromCatalog(
+      catalog,
+      `openrouter/${upstreamSlug}`,
+    );
   const slug = resolveModelsDevSlug(modelId);
   const gatewayProviderId = GATEWAY_TASK_MODEL_PROVIDER_IDS.find((providerId) =>
     modelId.startsWith(`${providerId}/`),

--- a/apps/worker/src/run-task/agent-home.test.ts
+++ b/apps/worker/src/run-task/agent-home.test.ts
@@ -984,6 +984,33 @@ describe('generateOpenCodeConfig provider support', () => {
     expect(runtimeEnv).not.toHaveProperty('R_TASK_MODEL_COSTS');
   });
 
+  it('creates a model entry for a price-only switchable model', () => {
+    // Known by pricing alone (no context-window metadata): the entry must
+    // still be generated so the cost block lands.
+    const runtimeEnv = {
+      R_MODEL: 'roomote/openai/gpt-5.6-luna',
+      R_TRIAL_OPENROUTER_API_KEY: 'sk-or-trial',
+      R_TASK_MODEL_COSTS: JSON.stringify({
+        'roomote/openai/gpt-5.6-terra': { input: 4, output: 16 },
+      }),
+      R_INFERENCE_GATEWAY_URL: 'https://api.example.com/api/inference/',
+    };
+    const result = generateOpenCodeConfig({
+      homeDir: createHomeDir(),
+      runtimeEnv,
+    });
+    const config = JSON.parse(result.configContent) as {
+      provider: Record<
+        string,
+        { models: Record<string, { cost?: Record<string, number> }> }
+      >;
+    };
+
+    expect(
+      config.provider.roomote?.models['openai/gpt-5.6-terra']?.cost,
+    ).toEqual({ input: 4, output: 16 });
+  });
+
   it('configures trusted LiteLLM context limits for proactive compaction', () => {
     const runtimeEnv = {
       R_MODEL: 'openrouter/openai/gpt-5.4',

--- a/apps/worker/src/run-task/agent-home.test.ts
+++ b/apps/worker/src/run-task/agent-home.test.ts
@@ -958,6 +958,32 @@ describe('generateOpenCodeConfig provider support', () => {
     expect(result.configContent).toContain('litellm');
   });
 
+  it('writes catalog pricing into custom-provider model config', () => {
+    const runtimeEnv = {
+      R_MODEL: 'roomote/openai/gpt-5.6-luna',
+      R_TRIAL_OPENROUTER_API_KEY: 'sk-or-trial',
+      R_TASK_MODEL_COSTS: JSON.stringify({
+        'roomote/openai/gpt-5.6-luna': { input: 2, output: 10 },
+      }),
+      R_INFERENCE_GATEWAY_URL: 'https://api.example.com/api/inference/',
+    };
+    const result = generateOpenCodeConfig({
+      homeDir: createHomeDir(),
+      runtimeEnv,
+    });
+    const config = JSON.parse(result.configContent) as {
+      provider: Record<
+        string,
+        { models: Record<string, { cost?: Record<string, number> }> }
+      >;
+    };
+
+    expect(
+      config.provider.roomote?.models['openai/gpt-5.6-luna']?.cost,
+    ).toEqual({ input: 2, output: 10 });
+    expect(runtimeEnv).not.toHaveProperty('R_TASK_MODEL_COSTS');
+  });
+
   it('configures trusted LiteLLM context limits for proactive compaction', () => {
     const runtimeEnv = {
       R_MODEL: 'openrouter/openai/gpt-5.4',

--- a/apps/worker/src/run-task/agent-home.ts
+++ b/apps/worker/src/run-task/agent-home.ts
@@ -49,12 +49,14 @@ import {
   normalizeOptionalReasoningEffort,
   parseInferenceGatewayKeys,
   parseTaskModelContextWindows,
+  parseTaskModelCosts,
   renderManualSkillMarkdown,
   resolveOpenRouterVariantModelAlias,
   toBedrockMantleRuntimeModelId,
   OPENCODE_ARCHITECT_AGENT,
   OPENCODE_GO_API_KEY_ENV_VAR_NAME,
   TASK_MODEL_CONTEXT_WINDOWS_ENV_VAR_NAME,
+  TASK_MODEL_COSTS_ENV_VAR_NAME,
   TaskPayloadKind,
   type EnvironmentManualSkill,
   type OpenRouterVariantModelAlias,
@@ -1305,6 +1307,10 @@ function resolveModelBackedOpenCodeConfig(
     runtimeEnv[TASK_MODEL_CONTEXT_WINDOWS_ENV_VAR_NAME],
   );
   delete runtimeEnv[TASK_MODEL_CONTEXT_WINDOWS_ENV_VAR_NAME];
+  const modelCosts = parseTaskModelCosts(
+    runtimeEnv[TASK_MODEL_COSTS_ENV_VAR_NAME],
+  );
+  delete runtimeEnv[TASK_MODEL_COSTS_ENV_VAR_NAME];
   const rawModel = applyImplicitLiteLlmModelPrefix(
     runtimeEnv.R_MODEL?.trim() ?? '',
     isLiteLlmConfigured,
@@ -1626,6 +1632,7 @@ function resolveModelBackedOpenCodeConfig(
                 openAiCompatibleModelIds,
                 visionModel ?? effectiveCodingModel,
                 modelContextWindows,
+                modelCosts,
               ),
               runtimeEnv,
               configuredModelIds,

--- a/apps/worker/src/run-task/agent-home.ts
+++ b/apps/worker/src/run-task/agent-home.ts
@@ -1610,6 +1610,9 @@ function resolveModelBackedOpenCodeConfig(
   const openAiCompatibleModelIds = [
     ...configuredModelIds,
     ...Object.keys(modelContextWindows),
+    // A switchable model may be known only by its pricing; it still needs a
+    // config entry or its cost block is silently dropped.
+    ...Object.keys(modelCosts),
   ];
   const providerModelConfig = chatGptFastMode
     ? mergeOpenCodeChatGptFastModeOptions(

--- a/packages/db/src/lib/model-runtime-config.test.ts
+++ b/packages/db/src/lib/model-runtime-config.test.ts
@@ -1201,6 +1201,42 @@ describe('managed Roomote inference key', () => {
     expect(env).not.toHaveProperty('R_TRIAL_OPENROUTER_API_KEY');
   });
 
+  it('emits per-model costs for the sandbox from catalog metadata', async () => {
+    mockDeploymentSettingsFindFirst.mockResolvedValue({
+      runtimeModelConfig: { roomoteModel: 'roomote/openai/gpt-5.6-luna' },
+      taskModelSettings: {
+        models: [
+          {
+            id: 'roomote/openai/gpt-5.6-luna',
+            displayName: 'GPT 5.6 Luna',
+            family: 'GPT',
+            metadata: {
+              contextWindow: 400_000,
+              inputTypes: ['text'],
+              inputPricePerToken: 0.000002,
+              outputPricePerToken: 0.00001,
+              lastRefreshedAt: '2026-08-27T00:00:00.000Z',
+            },
+          },
+        ],
+        allowedModelIds: ['roomote/openai/gpt-5.6-luna'],
+        defaultModelId: 'roomote/openai/gpt-5.6-luna',
+      },
+    });
+
+    const env = await resolveSandboxModelRuntimeEnv({
+      runtimeEnv: {},
+      deploymentEnvVars: { R_TRIAL_OPENROUTER_API_KEY: 'sk-trial' },
+    });
+
+    expect(JSON.parse(env.R_TASK_MODEL_COSTS ?? '{}')).toEqual({
+      'roomote/openai/gpt-5.6-luna': { input: 2, output: 10 },
+    });
+    expect(JSON.parse(env.R_TASK_MODEL_CONTEXT_WINDOWS ?? '{}')).toEqual({
+      'roomote/openai/gpt-5.6-luna': 400_000,
+    });
+  });
+
   it('materializes the stored key on the control plane for Roomote models', async () => {
     mockDeploymentSettingsFindFirst.mockResolvedValue({
       runtimeModelConfig: { roomoteModel: 'roomote/openai/gpt-5.6-luna' },

--- a/packages/db/src/lib/model-runtime-config.ts
+++ b/packages/db/src/lib/model-runtime-config.ts
@@ -24,6 +24,7 @@ import {
   TASK_MODEL_ROLE_DESCRIPTORS,
   TASK_MODEL_ROLES,
   TASK_MODEL_CONTEXT_WINDOWS_ENV_VAR_NAME,
+  TASK_MODEL_COSTS_ENV_VAR_NAME,
   XAI_OPENCODE_PROVIDER_ID,
   type TaskModelRole,
   type TaskModelOption,
@@ -423,6 +424,35 @@ async function resolveModelRuntimeEnv(
         }),
       )
     : {};
+  // Per-model pricing for the generated OpenCode config, in USD per million
+  // tokens. Custom providers (Roomote inference included) are invisible to
+  // OpenCode's own models.dev pricing, so without this every message on them
+  // records zero cost in the task usage ledger.
+  const taskModelCosts = inferenceGateway
+    ? Object.fromEntries(
+        enabledCatalogModels.flatMap((model) => {
+          const inputPricePerToken = model.metadata?.inputPricePerToken;
+          const outputPricePerToken = model.metadata?.outputPricePerToken;
+
+          return typeof inputPricePerToken === 'number' &&
+            Number.isFinite(inputPricePerToken) &&
+            inputPricePerToken >= 0 &&
+            typeof outputPricePerToken === 'number' &&
+            Number.isFinite(outputPricePerToken) &&
+            outputPricePerToken >= 0
+            ? [
+                [
+                  model.id,
+                  {
+                    input: inputPricePerToken * 1_000_000,
+                    output: outputPricePerToken * 1_000_000,
+                  },
+                ],
+              ]
+            : [];
+        }),
+      )
+    : {};
   const gatewayProviderKeyNames = [
     ...new Set([
       ...providerKeyNames,
@@ -587,6 +617,9 @@ async function resolveModelRuntimeEnv(
       [TASK_MODEL_CONTEXT_WINDOWS_ENV_VAR_NAME]: JSON.stringify(
         taskModelContextWindows,
       ),
+    }),
+    ...(Object.keys(taskModelCosts).length > 0 && {
+      [TASK_MODEL_COSTS_ENV_VAR_NAME]: JSON.stringify(taskModelCosts),
     }),
     ...(routeChatGptThroughGateway
       ? { [INFERENCE_GATEWAY_CHATGPT_ENV_VAR_NAME]: '1' }

--- a/packages/types/src/__tests__/opencode-provider-config.test.ts
+++ b/packages/types/src/__tests__/opencode-provider-config.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { mergeOpenAiCompatibleProviderConfig } from '../opencode-provider-config';
+import {
+  mergeOpenAiCompatibleProviderConfig,
+  parseTaskModelCosts,
+} from '../opencode-provider-config';
 
 describe('mergeOpenAiCompatibleProviderConfig', () => {
   it('materializes managed Roomote models as an isolated OpenAI-compatible provider', () => {
@@ -93,6 +96,46 @@ describe('mergeOpenAiCompatibleProviderConfig', () => {
       'limit',
       'input',
     ]);
+  });
+
+  it('writes per-model cost so OpenCode reports real trial spend', () => {
+    const config = mergeOpenAiCompatibleProviderConfig(
+      {},
+      { R_TRIAL_OPENROUTER_API_KEY: 'sk-or-trial' },
+      ['roomote/openai/gpt-5.6-luna', 'roomote/unknown'],
+      undefined,
+      {},
+      { 'roomote/openai/gpt-5.6-luna': { input: 2, output: 10 } },
+    );
+
+    expect(config).toMatchObject({
+      roomote: {
+        models: {
+          'openai/gpt-5.6-luna': {
+            cost: { input: 2, output: 10 },
+          },
+          // No pricing known: no cost block rather than a fabricated zero,
+          // which OpenCode would report as free.
+          unknown: { name: 'unknown' },
+        },
+      },
+    });
+    expect(config).not.toHaveProperty(['roomote', 'models', 'unknown', 'cost']);
+  });
+
+  it('parses only well-formed cost maps', () => {
+    expect(parseTaskModelCosts(undefined)).toEqual({});
+    expect(parseTaskModelCosts('not json')).toEqual({});
+    expect(
+      parseTaskModelCosts(
+        JSON.stringify({
+          'roomote/openai/gpt-5.6-luna': { input: 2, output: 10 },
+          'bad-id': { input: 1, output: 1 },
+          'roomote/negative': { input: -1, output: 1 },
+          'roomote/partial': { input: 1 },
+        }),
+      ),
+    ).toEqual({ 'roomote/openai/gpt-5.6-luna': { input: 2, output: 10 } });
   });
 
   it('preserves independently configured input limits', () => {

--- a/packages/types/src/opencode-provider-config.ts
+++ b/packages/types/src/opencode-provider-config.ts
@@ -17,6 +17,46 @@ const DEFAULT_OPENAI_COMPATIBLE_INSTANCE =
 export const TASK_MODEL_CONTEXT_WINDOWS_ENV_VAR_NAME =
   'R_TASK_MODEL_CONTEXT_WINDOWS' as const;
 
+export const TASK_MODEL_COSTS_ENV_VAR_NAME = 'R_TASK_MODEL_COSTS' as const;
+
+/** USD per million tokens, the models.dev/OpenCode cost convention. */
+export type TaskModelCost = { input: number; output: number };
+
+export function parseTaskModelCosts(
+  value: string | undefined,
+): Record<string, TaskModelCost> {
+  if (!value?.trim()) {
+    return {};
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(value);
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {};
+    }
+
+    return Object.fromEntries(
+      Object.entries(parsed).flatMap(([modelId, cost]) => {
+        if (!modelId.includes('/') || !cost || typeof cost !== 'object')
+          return [];
+        const input = (cost as { input?: unknown }).input;
+        const output = (cost as { output?: unknown }).output;
+        return typeof input === 'number' &&
+          Number.isFinite(input) &&
+          input >= 0 &&
+          typeof output === 'number' &&
+          Number.isFinite(output) &&
+          output >= 0
+          ? [[modelId, { input, output }]]
+          : [];
+      }),
+    );
+  } catch {
+    return {};
+  }
+}
+
 export function parseTaskModelContextWindows(
   value: string | undefined,
 ): Record<string, number> {
@@ -198,6 +238,7 @@ export function mergeOpenAiCompatibleProviderConfig(
   modelIds: Array<string | undefined>,
   visionModel?: string,
   modelContextWindows: Readonly<Record<string, number>> = {},
+  modelCosts: Readonly<Record<string, TaskModelCost>> = {},
 ): Record<string, unknown> {
   let merged = providerConfig;
   const runtimeConfigs = getOpenAiCompatibleRuntimeConfigs(
@@ -260,6 +301,11 @@ export function mergeOpenAiCompatibleProviderConfig(
               const qualifiedModelId = `${providerId}/${modelId}`;
               const existingModel = asRecord(existingModels[modelId]);
               const contextWindow = modelContextWindows[qualifiedModelId];
+              // Without cost data OpenCode reports zero spend for these
+              // models: custom providers are invisible to its models.dev
+              // pricing, so the catalog's prices ride in explicitly.
+              const cost = modelCosts[qualifiedModelId];
+              const existingCost = asRecord(existingModel.cost);
               const existingLimit = asRecord(existingModel.limit);
               const existingOutputLimit = existingLimit.output;
               const outputLimit =
@@ -294,6 +340,15 @@ export function mergeOpenAiCompatibleProviderConfig(
                           ...existingLimit,
                           context: contextWindow,
                           output: outputLimit,
+                        },
+                      }
+                    : {}),
+                  ...(cost
+                    ? {
+                        cost: {
+                          input: cost.input,
+                          output: cost.output,
+                          ...existingCost,
                         },
                       }
                     : {}),


### PR DESCRIPTION
Trial tasks tracked tokens but recorded $0 cost everywhere in the app while OpenRouter billed normally (observed on the first staging trial tenant: 77 usage events, all `cost_micro_usd = 0`, key burndown at $0.22).

## Why

OpenCode prices messages from its own models.dev catalog, which cannot see the custom `roomote` provider — and the seeded trial models carried no pricing metadata for the app to supply instead. Result: `opencode_message` cost of 0 on every trial event, so task cards and cost analytics show nothing. (The $5 cap and the Settings credits burndown were unaffected — they read the key's own `limit_remaining`.)

## How

- **models.dev lookups resolve `roomote/...` ids through their OpenRouter upstream** (`rebaseRoomoteModelIdToUpstream`), so metadata refresh and seeding find pricing and context windows for trial models.
- **Choosing the trial seeds its models with catalog metadata up front** (best-effort with a 10s timeout; a failed fetch seeds without metadata exactly as before, and the Settings refresh backfills).
- **Per-model pricing rides to the worker as `R_TASK_MODEL_COSTS`**, mirroring the existing `R_TASK_MODEL_CONTEXT_WINDOWS` plumbing, and lands as `cost: {input, output}` (USD per 1M tokens, the models.dev convention) on custom-provider model entries in the generated OpenCode config. Models with unknown pricing get no cost block rather than a fabricated zero. This fixes cost reporting for any custom OpenAI-compatible provider with known pricing, not just the trial.

## Tests

- types: cost emission on model entries + cost-map parser edge cases
- db: resolver emits `R_TASK_MODEL_COSTS` (and context windows) from catalog metadata in gateway mode
- web: roomote→openrouter metadata alias; trial seeding attaches catalog metadata
- worker: env parsed, stripped, and written into the generated config

Note for verification on the existing staging trial tenant: its models were seeded before this fix, so hit **Refresh metadata** in Settings > Models (or re-choose on a fresh workspace) after the rollout to pick up pricing; new events then record real cost.