### PR TITLE
Disable Infinity anonymous telemetry in the compose bundle

### DIFF
--- a/deploy/compose/docker-compose.prod.yml
+++ b/deploy/compose/docker-compose.prod.yml
@@ -587,6 +587,10 @@ services:
       - ${INFINITY_EMBEDDING_MODEL:-BAAI/bge-m3}
       - --model-id
       - ${INFINITY_RERANKER_MODEL:-BAAI/bge-reranker-v2-m3}
+    environment:
+      # Infinity posts an anonymous hardware/config fingerprint to PostHog
+      # on startup; a self-hosted stack should not phone home.
+      DO_NOT_TRACK: '1'
     volumes:
       - infinity_cache:/app/.cache
     security_opt:


### PR DESCRIPTION
The bundled `local-inference` Infinity service sends an anonymous startup event (hardware, engine config, cloud-provider detection) to PostHog by default. A self-hosted stack shouldn't phone home — set `DO_NOT_TRACK: '1'` on the service.

Verified `docker compose config` resolves the profile with the new environment block.