### PR TITLE
Re-add DO_NOT_TRACK to the bundled Infinity service

### DIFF
--- a/deploy/compose/docker-compose.prod.yml
+++ b/deploy/compose/docker-compose.prod.yml
@@ -571,6 +571,9 @@ services:
     networks: [default]
     environment:
       INFINITY_ANONYMOUS_USAGE_STATS: '0'
+      # Standard opt-out honored by Infinity (and many other tools); keeps
+      # the stack quiet even if the Infinity-specific variable is renamed.
+      DO_NOT_TRACK: '1'
     command:
       - v2
       - --device

--- a/deploy/scripts/validate-compose-security.sh
+++ b/deploy/scripts/validate-compose-security.sh
@@ -52,6 +52,7 @@ jq -e '
 
   (.services.infinity.image == "michaelf34/infinity:0.0.76-cpu@sha256:2a464dcc06e659a277bc841b4be196100489076446482925481b2c5c120fce57") and
   (.services.infinity.environment.INFINITY_ANONYMOUS_USAGE_STATS == "0") and
+  (.services.infinity.environment.DO_NOT_TRACK == "1") and
   (.services.infinity.volumes == [{
     "type": "volume",
     "source": "infinity_cache",


### PR DESCRIPTION
Re-lands #1762 (reverted in #1763 after landing in parallel with #1760). #1760's `INFINITY_ANONYMOUS_USAGE_STATS=0` already disables telemetry on the pinned 0.0.76 image — the two flags are AND-ed in `env.py` — so this adds `DO_NOT_TRACK=1` alongside it as the standard cross-tool opt-out, matching how we run the service elsewhere and staying safe if the Infinity-specific variable is ever renamed.

`deploy/scripts/validate-compose-security.sh` passes.