### PR TITLE
Make the Brain readiness gate provider-agnostic

### DIFF
--- a/apps/api/src/handlers/mcp/__tests__/gbrain.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/gbrain.test.ts
@@ -9,14 +9,16 @@ import {
 
 import type { Variables } from '../../../types';
 
-const { mockResolveConnection, mockResolveBrainProvider } = vi.hoisted(() => ({
-  mockResolveConnection: vi.fn(),
-  mockResolveBrainProvider: vi.fn(),
-}));
+const { mockResolveConnection, mockIsBrainEmbeddingAvailable } = vi.hoisted(
+  () => ({
+    mockResolveConnection: vi.fn(),
+    mockIsBrainEmbeddingAvailable: vi.fn(),
+  }),
+);
 
 vi.mock('@roomote/sdk/server', () => ({
   resolveBrainConnection: mockResolveConnection,
-  resolveBrainInferenceProvider: mockResolveBrainProvider,
+  isBrainEmbeddingAvailable: mockIsBrainEmbeddingAvailable,
 }));
 
 import { createGbrainMcpProxy, GBRAIN_READ_TOOL_NAMES } from '../gbrain';
@@ -71,16 +73,9 @@ describe('createGbrainMcpProxy', () => {
     upstreamRequests = [];
     mockResolveConnection.mockReset();
     // A Brain is only offered to agents when it can actually embed, so the
-    // default for these cases is "a provider is configured".
-    mockResolveBrainProvider.mockReset();
-    mockResolveBrainProvider.mockResolvedValue({
-      providerId: 'openrouter',
-      apiKey: 'sk-or-test',
-      models: {
-        embedding: 'openai/text-embedding-3-small',
-        chat: 'openai/gpt-5.6-luna',
-      },
-    });
+    // default for these cases is "an embedder is available".
+    mockIsBrainEmbeddingAvailable.mockReset();
+    mockIsBrainEmbeddingAvailable.mockResolvedValue(true);
   });
 
   afterEach(async () => {
@@ -120,18 +115,35 @@ describe('createGbrainMcpProxy', () => {
     expect(mockResolveConnection).toHaveBeenCalledWith('agent');
   });
 
-  it('hides the Brain from agents when no model provider is configured', async () => {
+  it('hides the Brain from agents when it cannot embed', async () => {
     mockResolveConnection.mockResolvedValue({
       baseUrl: 'http://brain.test',
       token: 'agent-token',
     });
-    mockResolveBrainProvider.mockResolvedValue(null);
+    mockIsBrainEmbeddingAvailable.mockResolvedValue(false);
 
     const response = await postMcp(createApp(), toolCall('query'));
 
     // Worse than absent: a Brain that cannot embed still answers keyword
     // queries, so retrieval would look real while missing everything semantic.
     expect(response.status).toBe(404);
+  });
+
+  it('serves agents on an embedder-only deployment with no provider key', async () => {
+    // The trial / Anthropic-only case: a self-run embedder is configured and
+    // no OpenAI/OpenRouter key exists. The drain ingests such a Brain, so the
+    // read path must let agents query it too.
+    mockResolveConnection.mockResolvedValue({
+      baseUrl: await startUpstream(),
+      token: 'agent-token',
+    });
+    mockIsBrainEmbeddingAvailable.mockResolvedValue(true);
+
+    const response = await postMcp(createApp(), toolCall('query'));
+
+    expect(response.status).toBe(200);
+    expect(upstreamRequests).toHaveLength(1);
+    expect(upstreamRequests[0]?.authorization).toBe('Bearer agent-token');
   });
 
   it.each(['remember', 'forget'])(

--- a/apps/api/src/handlers/mcp/gbrain.ts
+++ b/apps/api/src/handlers/mcp/gbrain.ts
@@ -1,5 +1,5 @@
 import {
-  resolveBrainInferenceProvider,
+  isBrainEmbeddingAvailable,
   resolveBrainConnection,
 } from '@roomote/sdk/server';
 
@@ -63,16 +63,20 @@ export function createGbrainMcpProxy(options?: { allowAuthTokens?: boolean }) {
       // service has a Brain, and the read-only agent client is provisioned
       // headlessly on first use.
       //
-      // Both halves are required before an agent is told the Brain exists. A
-      // Brain container with no provider key configured yet can still answer
-      // keyword queries, which is worse than absent: recall would look real
-      // while silently missing everything semantic.
-      const [connection, provider] = await Promise.all([
+      // Both halves are required before an agent is told the Brain exists: a
+      // place to read from (connection) and a way to embed the query. Without
+      // an embedding path a Brain can still answer keyword queries, which is
+      // worse than absent — recall would look real while silently missing
+      // everything semantic. The embedding check is provider-agnostic, matching
+      // the ingest side (isBrainEmbeddingAvailable): a self-run embedder is
+      // enough, so a trial or Anthropic-only tenant whose pages the drain
+      // ingested can also query them, instead of accumulating unreadable memory.
+      const [connection, embeddingAvailable] = await Promise.all([
         resolveBrainConnection('agent'),
-        resolveBrainInferenceProvider(),
+        isBrainEmbeddingAvailable(),
       ]);
 
-      if (!connection || !provider) {
+      if (!connection || !embeddingAvailable) {
         throw new McpProxyError(
           404,
           'The Brain is not configured on this deployment',

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-maintenance.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-maintenance.test.ts
@@ -3,14 +3,14 @@ const {
   mockGetBrainSyncState,
   mockPostToBrain,
   mockResolveConnection,
-  mockResolveProvider,
+  mockIsBrainEmbeddingAvailable,
   mockUpsertBrainSyncState,
 } = vi.hoisted(() => ({
   mockEnv: { TRPC_URL: 'http://api.test:3001' },
   mockGetBrainSyncState: vi.fn(),
   mockPostToBrain: vi.fn(),
   mockResolveConnection: vi.fn(),
-  mockResolveProvider: vi.fn(),
+  mockIsBrainEmbeddingAvailable: vi.fn(),
   mockUpsertBrainSyncState: vi.fn(),
 }));
 
@@ -20,7 +20,7 @@ vi.mock('@roomote/sdk/server', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@roomote/sdk/server')>()),
   getBrainGatewayToken: () => 'brain-gateway-token',
   resolveBrainConnection: mockResolveConnection,
-  resolveBrainInferenceProvider: mockResolveProvider,
+  isBrainEmbeddingAvailable: mockIsBrainEmbeddingAvailable,
 }));
 
 vi.mock('@roomote/env', () => ({
@@ -47,11 +47,6 @@ import {
   runBrainDailyDigest,
   runBrainWeeklySynthesis,
 } from '../brain-maintenance';
-
-const TEST_PROVIDER = {
-  providerId: 'openrouter' as const,
-  apiKey: 'brain-provider-key',
-};
 
 function synthesisResponse(input?: {
   answer?: string;
@@ -180,7 +175,7 @@ describe('brainMaintenanceJob', () => {
     mockGetBrainSyncState.mockResolvedValue(null);
     mockPostToBrain.mockReset();
     mockResolveConnection.mockReset();
-    mockResolveProvider.mockReset();
+    mockIsBrainEmbeddingAvailable.mockReset();
     mockUpsertBrainSyncState.mockReset();
   });
 
@@ -189,7 +184,7 @@ describe('brainMaintenanceJob', () => {
   });
 
   it('does nothing when the Brain provider is disabled', async () => {
-    mockResolveProvider.mockResolvedValue(null);
+    mockIsBrainEmbeddingAvailable.mockResolvedValue(false);
     const fetchSpy = vi.spyOn(globalThis, 'fetch');
 
     await brainMaintenanceJob();
@@ -199,7 +194,7 @@ describe('brainMaintenanceJob', () => {
   });
 
   it('submits the built-in autopilot cycle with the maintenance credential', async () => {
-    mockResolveProvider.mockResolvedValue(TEST_PROVIDER);
+    mockIsBrainEmbeddingAvailable.mockResolvedValue(true);
     mockResolveConnection.mockImplementation(async (credential: string) => ({
       baseUrl: 'http://gbrain.test/',
       token: `${credential}-token`,
@@ -264,7 +259,7 @@ describe('brainMaintenanceJob', () => {
     // Synthesis failures are rethrown after the submission so they stay
     // visible, and the scheduler retries the job; without the day marker
     // each retry queued another full cycle over the whole corpus.
-    mockResolveProvider.mockResolvedValue(TEST_PROVIDER);
+    mockIsBrainEmbeddingAvailable.mockResolvedValue(true);
     mockResolveConnection.mockImplementation(async (credential: string) => ({
       baseUrl: 'http://gbrain.test',
       token: `${credential}-token`,
@@ -297,7 +292,7 @@ describe('brainMaintenanceJob', () => {
   });
 
   it('fails the scheduler job when gbrain rejects the submission', async () => {
-    mockResolveProvider.mockResolvedValue(TEST_PROVIDER);
+    mockIsBrainEmbeddingAvailable.mockResolvedValue(true);
     mockResolveConnection.mockResolvedValue({
       baseUrl: 'http://gbrain.test',
       token: 'maintenance-token',
@@ -325,7 +320,7 @@ describe('brainMaintenanceJob', () => {
   it('keeps the claim on a 5xx, which can follow an accepted submission', async () => {
     // A gateway can answer 5xx after gbrain already queued the job, so the
     // claim must stand and the retry must not resubmit.
-    mockResolveProvider.mockResolvedValue(TEST_PROVIDER);
+    mockIsBrainEmbeddingAvailable.mockResolvedValue(true);
     mockResolveConnection.mockResolvedValue({
       baseUrl: 'http://gbrain.test',
       token: 'maintenance-token',
@@ -347,7 +342,7 @@ describe('brainMaintenanceJob', () => {
   });
 
   it('releases the claim when gbrain answers with a tool error', async () => {
-    mockResolveProvider.mockResolvedValue(TEST_PROVIDER);
+    mockIsBrainEmbeddingAvailable.mockResolvedValue(true);
     mockResolveConnection.mockResolvedValue({
       baseUrl: 'http://gbrain.test',
       token: 'maintenance-token',
@@ -378,7 +373,7 @@ describe('brainMaintenanceJob', () => {
   it('keeps the claim when the submission fails in transport', async () => {
     // No HTTP answer means gbrain may already have queued the job; releasing
     // the claim would let the retry queue a second corpus-wide cycle.
-    mockResolveProvider.mockResolvedValue(TEST_PROVIDER);
+    mockIsBrainEmbeddingAvailable.mockResolvedValue(true);
     mockResolveConnection.mockResolvedValue({
       baseUrl: 'http://gbrain.test',
       token: 'maintenance-token',
@@ -400,7 +395,7 @@ describe('brainMaintenanceJob', () => {
     // A crash between the submission and a marker written afterwards would
     // let the retry queue a second corpus-wide cycle; the claim has to land
     // first.
-    mockResolveProvider.mockResolvedValue(TEST_PROVIDER);
+    mockIsBrainEmbeddingAvailable.mockResolvedValue(true);
     mockResolveConnection.mockResolvedValue({
       baseUrl: 'http://gbrain.test',
       token: 'maintenance-token',
@@ -426,7 +421,7 @@ describe('brainMaintenanceJob', () => {
   });
 
   it('still submits maintenance when daily synthesis fails', async () => {
-    mockResolveProvider.mockResolvedValue(TEST_PROVIDER);
+    mockIsBrainEmbeddingAvailable.mockResolvedValue(true);
     mockResolveConnection.mockImplementation(async (credential: string) => ({
       baseUrl: 'http://gbrain.test',
       token: `${credential}-token`,
@@ -452,8 +447,8 @@ describe('runBrainDailyDigest', () => {
     mockEnv.TRPC_URL = 'http://api.test:3001';
     mockGetBrainSyncState.mockReset();
     mockPostToBrain.mockReset();
-    mockResolveProvider.mockReset();
-    mockResolveProvider.mockResolvedValue(TEST_PROVIDER);
+    mockIsBrainEmbeddingAvailable.mockReset();
+    mockIsBrainEmbeddingAvailable.mockResolvedValue(true);
     mockUpsertBrainSyncState.mockReset();
   });
 

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-outbox-drain.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-outbox-drain.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   mockResolveConnection,
-  mockResolveBrainProvider,
+  mockIsBrainEmbeddingAvailable,
   mockBackfillEvents,
   mockClaimEvents,
   mockClaimFastEvents,
@@ -15,7 +15,7 @@ const {
   mockRunBrainCollectors,
 } = vi.hoisted(() => ({
   mockResolveConnection: vi.fn(),
-  mockResolveBrainProvider: vi.fn(),
+  mockIsBrainEmbeddingAvailable: vi.fn(),
   mockBackfillEvents: vi.fn(),
   mockClaimEvents: vi.fn(),
   mockClaimFastEvents: vi.fn(),
@@ -33,7 +33,7 @@ vi.mock('@roomote/sdk/server', async (importOriginal) => ({
   // through the mocked global fetch.
   ...(await importOriginal<typeof import('@roomote/sdk/server')>()),
   resolveBrainConnection: mockResolveConnection,
-  resolveBrainInferenceProvider: mockResolveBrainProvider,
+  isBrainEmbeddingAvailable: mockIsBrainEmbeddingAvailable,
 }));
 
 vi.mock('@roomote/db/server', async (importOriginal) => {
@@ -308,10 +308,7 @@ describe('collector continuation orchestration', () => {
       baseUrl: 'http://brain.test',
       token: 'ingest-token',
     });
-    mockResolveBrainProvider.mockResolvedValue({
-      providerId: 'openrouter',
-      apiKey: 'sk-or',
-    });
+    mockIsBrainEmbeddingAvailable.mockResolvedValue(true);
   });
 
   it('runs incremental integrations only on the scheduled pass', async () => {
@@ -670,7 +667,7 @@ describe('Brain readiness gate', () => {
     // cannot embed, burn every memory through its retry budget into a
     // terminal state, and mark the one-shot history backfill complete before
     // a single page landed.
-    mockResolveBrainProvider.mockResolvedValue(null);
+    mockIsBrainEmbeddingAvailable.mockResolvedValue(false);
 
     await brainOutboxDrainJob();
 
@@ -683,10 +680,7 @@ describe('Brain readiness gate', () => {
       baseUrl: 'http://brain.test',
       token: 'ingest-token',
     });
-    mockResolveBrainProvider.mockResolvedValue({
-      providerId: 'openrouter',
-      apiKey: 'sk-or',
-    });
+    mockIsBrainEmbeddingAvailable.mockResolvedValue(true);
     mockGetSyncState.mockResolvedValue({ backfillCompletedAt: new Date() });
     mockClaimEvents.mockResolvedValue([]);
 
@@ -750,10 +744,7 @@ describe('fast conversation memory drain', () => {
       baseUrl: 'http://brain.test',
       token: 'ingest-token',
     });
-    mockResolveBrainProvider.mockResolvedValue({
-      providerId: 'openrouter',
-      apiKey: 'sk-or',
-    });
+    mockIsBrainEmbeddingAvailable.mockResolvedValue(true);
     mockGetSyncState.mockResolvedValue({ backfillCompletedAt: new Date() });
   });
 

--- a/apps/bullmq/src/scheduled-jobs/brain-maintenance.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-maintenance.ts
@@ -3,7 +3,7 @@ import {
   parseBrainToolPayloads as parseToolPayloads,
   postBrainToolCall,
   resolveBrainConnection,
-  resolveBrainInferenceProvider,
+  isBrainEmbeddingAvailable,
 } from '@roomote/sdk/server';
 import {
   db,
@@ -842,9 +842,13 @@ export async function runBrainDailyDigest(
  * gbrain owns the maintenance algorithm and its cycle locking.
  */
 export async function brainMaintenanceJob(): Promise<void> {
-  const provider = await resolveBrainInferenceProvider();
-
-  if (!provider) {
+  // Provider-agnostic, like the collector/outbox gate: a Brain with a
+  // configured embedder is a real Brain, and the digest's synthesis rides the
+  // deployment's helper model through the inference gateway, so no
+  // OpenAI/OpenRouter key is required. If a deployment somehow cannot
+  // synthesize at all, the nightly digest errors for that night (already
+  // caught below) rather than the whole Brain being dark.
+  if (!(await isBrainEmbeddingAvailable())) {
     return;
   }
 

--- a/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
@@ -30,7 +30,7 @@ import {
 import {
   parseBrainToolPayloads,
   postBrainToolCall,
-  resolveBrainInferenceProvider,
+  isBrainEmbeddingAvailable,
   resolveBrainConnection,
 } from '@roomote/sdk/server';
 import {
@@ -343,27 +343,31 @@ export async function brainOutboxDrainJob(): Promise<void> {
 
 /**
  * A Brain worth writing to needs both halves: somewhere to put pages, and a
- * model provider to embed them with.
+ * way to embed them.
  *
- * The provider half is not optional caution. Every page written to a Brain
+ * The embedding half is not optional caution. Every page written to a Brain
  * that cannot embed fails outright — gbrain retries the embed three times and
- * returns an error — so draining ahead of a configured provider would burn
- * each memory through its retry budget into a terminal 'failed' state that no
- * later claim picks up, and would mark the one-shot history backfill complete
- * before a single page landed. Holding here instead is what makes turning the
- * Brain on later actually pick up everything that happened before.
+ * returns an error — so draining ahead of an embedding path would burn each
+ * memory through its retry budget into a terminal 'failed' state that no later
+ * claim picks up, and would mark the one-shot history backfill complete before
+ * a single page landed. Holding here instead is what makes turning the Brain
+ * on later actually pick up everything that happened before.
+ *
+ * The check is provider-agnostic: a configured embedder (the shared Modal
+ * endpoint for managed tenants, or a local model self-hosted) is enough, and
+ * synthesis rides the deployment's helper model through the inference gateway,
+ * so no OpenAI/OpenRouter key is required — an Anthropic-only or trial-key
+ * tenant is just as ready. See isBrainEmbeddingAvailable.
  */
 async function resolveReadyBrain(): Promise<{
   baseUrl: string;
   token: string;
 } | null> {
-  // Provider first, and not in parallel: resolving a connection registers
-  // scoped OAuth clients against the Brain as a side effect, which is not
-  // worth doing for a Brain that cannot embed yet. This check is cached, so
-  // the common unconfigured tick costs nothing.
-  const provider = await resolveBrainInferenceProvider();
-
-  if (!provider) {
+  // Embedding path first, and not in parallel: resolving a connection
+  // registers scoped OAuth clients against the Brain as a side effect, which
+  // is not worth doing for a Brain that cannot embed yet. This check is
+  // cached, so the common unconfigured tick costs nothing.
+  if (!(await isBrainEmbeddingAvailable())) {
     return null;
   }
 

--- a/packages/sdk/src/server/lib/__tests__/brain-inference.test.ts
+++ b/packages/sdk/src/server/lib/__tests__/brain-inference.test.ts
@@ -4,12 +4,23 @@ vi.mock('@roomote/db/server', () => ({
   resolveModelProviderEnvValue: vi.fn(),
 }));
 
-const mockEnv: { R_BRAIN_MODEL?: string; R_BRAIN_EMBEDDING_MODEL?: string } =
-  {};
+const mockEnv: {
+  R_BRAIN_MODEL?: string;
+  R_BRAIN_EMBEDDING_MODEL?: string;
+  R_BRAIN_EMBEDDINGS_UPSTREAM_URL?: string;
+} = {};
 
 vi.mock('@roomote/env', () => ({ Env: mockEnv }));
 
-const { mapBrainModelName } = await import('../brain-inference');
+const {
+  mapBrainModelName,
+  isBrainEmbeddingAvailable,
+  resetBrainInferenceProviderCache,
+} = await import('../brain-inference');
+const { resolveModelProviderEnvValue } = await import('@roomote/db/server');
+const mockResolveModelProviderEnvValue = vi.mocked(
+  resolveModelProviderEnvValue,
+);
 
 const OPENROUTER = { providerId: 'openrouter', apiKey: 'sk-or' } as const;
 const OPENAI = { providerId: 'openai', apiKey: 'sk' } as const;
@@ -17,6 +28,10 @@ const OPENAI = { providerId: 'openai', apiKey: 'sk' } as const;
 beforeEach(() => {
   delete mockEnv.R_BRAIN_MODEL;
   delete mockEnv.R_BRAIN_EMBEDDING_MODEL;
+  delete mockEnv.R_BRAIN_EMBEDDINGS_UPSTREAM_URL;
+  mockResolveModelProviderEnvValue.mockReset();
+  mockResolveModelProviderEnvValue.mockResolvedValue(undefined);
+  resetBrainInferenceProviderCache();
 });
 
 describe('mapBrainModelName', () => {
@@ -65,5 +80,28 @@ describe('mapBrainModelName', () => {
     expect(mapBrainModelName('some-custom-model', OPENROUTER)).toBe(
       'some-custom-model',
     );
+  });
+});
+
+describe('isBrainEmbeddingAvailable', () => {
+  it('is ready when a self-run embedder is configured, with no provider key', async () => {
+    mockEnv.R_BRAIN_EMBEDDINGS_UPSTREAM_URL = 'https://embedder.example/v1';
+    // No provider key of any kind — the trial/Anthropic-only case.
+    await expect(isBrainEmbeddingAvailable()).resolves.toBe(true);
+    expect(mockResolveModelProviderEnvValue).not.toHaveBeenCalled();
+  });
+
+  it('falls back to an embeddings-capable provider key when no embedder is set', async () => {
+    mockResolveModelProviderEnvValue.mockResolvedValue('sk-or');
+    await expect(isBrainEmbeddingAvailable()).resolves.toBe(true);
+  });
+
+  it('is not ready with neither an embedder nor a provider key', async () => {
+    await expect(isBrainEmbeddingAvailable()).resolves.toBe(false);
+  });
+
+  it('treats a whitespace-only upstream as unset', async () => {
+    mockEnv.R_BRAIN_EMBEDDINGS_UPSTREAM_URL = '   ';
+    await expect(isBrainEmbeddingAvailable()).resolves.toBe(false);
   });
 });

--- a/packages/sdk/src/server/lib/brain-inference.ts
+++ b/packages/sdk/src/server/lib/brain-inference.ts
@@ -112,6 +112,34 @@ export async function resolveBrainInferenceProvider(): Promise<ResolvedBrainInfe
   return resolved;
 }
 
+/**
+ * Whether this deployment has a way to embed Brain pages at all — the
+ * readiness bar for running collectors and draining the memory outbox.
+ *
+ * Provider-agnostic by design. A dedicated embedder is the normal path:
+ * `R_BRAIN_EMBEDDINGS_UPSTREAM_URL` points embeddings at a self-run model
+ * (the shared Modal endpoint for every hosting-managed tenant; the local
+ * Infinity service for the self-host compose local-inference profile), so no
+ * model-provider key is involved in embedding at all. Only when no embedder
+ * is configured does this fall back to requiring an embeddings-capable
+ * provider key (the direct self-host path, where OpenAI/OpenRouter does the
+ * embedding).
+ *
+ * Synthesis is deliberately NOT part of this gate: it rides the deployment's
+ * helper model through the inference gateway and therefore works with whatever
+ * provider runs the deployment's tasks — Anthropic, OpenAI, OpenRouter, or a
+ * minted trial key alike. Gating on an OpenAI/OpenRouter key would have locked
+ * every Anthropic-only or trial tenant out of Memory even though both halves
+ * of its inference are actually available.
+ */
+export async function isBrainEmbeddingAvailable(): Promise<boolean> {
+  if (Env.R_BRAIN_EMBEDDINGS_UPSTREAM_URL?.trim()) {
+    return true;
+  }
+
+  return Boolean(await resolveBrainInferenceProvider());
+}
+
 async function readBrainInferenceProvider(): Promise<ResolvedBrainInference | null> {
   for (const providerId of BRAIN_PROVIDER_PREFERENCE) {
     const apiKey = await resolveModelProviderEnvValue(


### PR DESCRIPTION
## Problem

A newly provisioned managed tenant enables Memory, gets its trial inference key, and then **no memories ever appear**. The outbox drain runs every tick and "completes successfully" doing nothing; no collector starts.

Root cause: `brainCollectorsJob` / `brainOutboxDrainJob` (via `resolveReadyBrain`) and `brainMaintenanceJob` gate on `resolveBrainInferenceProvider()` — a configured **OpenAI/OpenRouter** key. That gate predates two changes: embeddings now go to a **self-run embedder** (shared Modal endpoint for managed tenants; local Infinity for self-host compose) via `R_BRAIN_EMBEDDINGS_UPSTREAM_URL` with no provider key, and synthesis now rides the deployment's **helper model** through the inference gateway (any provider).

So a trial tenant (only a spend-capped `R_TRIAL_OPENROUTER_API_KEY`) or an Anthropic-only tenant has fully working Brain inference but fails the gate. Confirmed on a live staging tenant: gbrain provisioned, toggle on, embeddings + helper-chat both 200 through its own gateway, yet the drain no-ops every tick.

## Fix

New `isBrainEmbeddingAvailable()` is the readiness bar: ready when a self-run embedder is configured, else fall back to an embeddings-capable provider key (direct self-host). Embedding stays gated because a page written to a Brain that can't embed burns its retry budget into a terminal failed state; synthesis is excluded (provider-agnostic via helper model, non-fatal). Activation remains the `isBrainEnabled` toggle. Applied to both `resolveReadyBrain` and `brainMaintenanceJob`.

## Testing

New `isBrainEmbeddingAvailable` unit tests (embedder-only → ready with no key; provider fallback; neither → not ready; whitespace ignored). Updated outbox-drain + maintenance job tests to the new gate. @roomote/sdk brain-inference 9/9, @roomote/bullmq brain jobs 70/70; both typecheck clean.