### PR TITLE
feat: kick Brain ingestion jobs immediately when memory is enabled

### DIFF
--- a/apps/bullmq/src/scheduled-jobs/pull-request-analytics-sync.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/pull-request-analytics-sync.test.ts
@@ -1,0 +1,82 @@
+const mocks = vi.hoisted(() => ({
+  enrichPullRequestFacts: vi.fn(),
+  syncGitHubPullRequestFactsForAllOrgs: vi.fn(),
+  syncSourceControlPullRequestFacts: vi.fn(),
+  queueAdd: vi.fn(),
+}));
+
+vi.mock('@roomote/sdk/server', () => ({
+  enrichPullRequestFacts: mocks.enrichPullRequestFacts,
+  syncGitHubPullRequestFactsForAllOrgs:
+    mocks.syncGitHubPullRequestFactsForAllOrgs,
+  syncSourceControlPullRequestFacts: mocks.syncSourceControlPullRequestFacts,
+}));
+
+vi.mock('../redis', () => ({
+  getRedis: () => ({}),
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class MockQueue {
+    add = (...args: unknown[]) => mocks.queueAdd(...args);
+  },
+}));
+
+import {
+  pullRequestAnalyticsSyncJob,
+  resetPullRequestAnalyticsFollowUpQueueForTests,
+} from './pull-request-analytics-sync';
+
+const emptyResult = {
+  eligibleRepositories: 0,
+  processedRepositories: 0,
+  failedRepositories: 0,
+  cooledDownRepositories: 0,
+};
+
+describe('pullRequestAnalyticsSyncJob', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetPullRequestAnalyticsFollowUpQueueForTests();
+    mocks.syncGitHubPullRequestFactsForAllOrgs.mockResolvedValue([]);
+    mocks.syncSourceControlPullRequestFacts.mockResolvedValue(emptyResult);
+    mocks.enrichPullRequestFacts.mockResolvedValue(undefined);
+    mocks.queueAdd.mockResolvedValue(undefined);
+  });
+
+  it('chains a BrainCollectors follow-up when asked, before enrichment', async () => {
+    const order: string[] = [];
+    mocks.queueAdd.mockImplementation(async () => {
+      order.push('follow-up');
+    });
+    mocks.enrichPullRequestFacts.mockImplementation(async () => {
+      order.push('enrich');
+    });
+
+    await pullRequestAnalyticsSyncJob({ chainBrainCollectors: true });
+
+    expect(mocks.queueAdd).toHaveBeenCalledWith(
+      'BrainCollectors',
+      { reason: 'pull-request-analytics-sync' },
+      expect.objectContaining({
+        jobId: expect.stringMatching(/^brain-collectors-post-pr-sync-\d+$/),
+      }),
+    );
+    expect(order).toEqual(['follow-up', 'enrich']);
+  });
+
+  it('does not chain on a plain scheduled run', async () => {
+    await pullRequestAnalyticsSyncJob();
+
+    expect(mocks.queueAdd).not.toHaveBeenCalled();
+  });
+
+  it('swallows follow-up enqueue failures', async () => {
+    mocks.queueAdd.mockRejectedValue(new Error('redis down'));
+
+    await expect(
+      pullRequestAnalyticsSyncJob({ chainBrainCollectors: true }),
+    ).resolves.toBeUndefined();
+    expect(mocks.enrichPullRequestFacts).toHaveBeenCalled();
+  });
+});

--- a/apps/bullmq/src/scheduled-jobs/pull-request-analytics-sync.ts
+++ b/apps/bullmq/src/scheduled-jobs/pull-request-analytics-sync.ts
@@ -1,13 +1,60 @@
+import { Queue } from 'bullmq';
+
 import {
   enrichPullRequestFacts,
   syncGitHubPullRequestFactsForAllOrgs,
   syncSourceControlPullRequestFacts,
 } from '@roomote/sdk/server';
 
+import { getRedis } from '../redis';
+import { ScheduledJobName } from '../types';
+
 const LOG_PREFIX = '[pullRequestAnalyticsSync]';
 
+let followUpQueue: Queue | null = null;
+
+/** Test seam: drop the memoized queue so a fresh connection is created. */
+export function resetPullRequestAnalyticsFollowUpQueueForTests(): void {
+  followUpQueue = null;
+}
+
+/**
+ * The PR-fact → Brain sync lives in BrainCollectors, which reads the local
+ * `pull_request_facts` table this job populates. A one-off collectors run
+ * kicked alongside this job (the memory-enable backfill) can race it and see
+ * an empty table, deferring initial PR ingestion to the next 15-minute tick —
+ * so a kicked run chains a follow-up collectors run once the table is
+ * populated. Fire-and-forget: the schedule is the safety net.
+ */
+async function enqueueBrainCollectorsFollowUp(): Promise<void> {
+  try {
+    if (!followUpQueue) {
+      followUpQueue = new Queue('scheduled-jobs', {
+        connection: getRedis(),
+        defaultJobOptions: {
+          attempts: 1,
+          removeOnComplete: { age: 3600, count: 10 },
+          removeOnFail: { age: 3600 },
+        },
+      });
+    }
+
+    const minuteBucket = Math.floor(Date.now() / 60_000);
+    await followUpQueue.add(
+      ScheduledJobName.BrainCollectors,
+      { reason: 'pull-request-analytics-sync' },
+      { jobId: `brain-collectors-post-pr-sync-${minuteBucket}` },
+    );
+  } catch (error) {
+    console.warn(
+      `${LOG_PREFIX} failed to enqueue BrainCollectors follow-up:`,
+      error instanceof Error ? error.message : error,
+    );
+  }
+}
+
 export async function pullRequestAnalyticsSyncJob(
-  opts: { manualTrigger?: boolean } = {},
+  opts: { manualTrigger?: boolean; chainBrainCollectors?: boolean } = {},
 ) {
   console.log(
     `${LOG_PREFIX} Starting sync${opts.manualTrigger ? ' (manual)' : ''}`,
@@ -40,6 +87,12 @@ export async function pullRequestAnalyticsSyncJob(
   console.log(
     `${LOG_PREFIX} Completed: ${totals.processedRepositories}/${totals.eligibleRepositories} processed, ${totals.failedRepositories} failed, ${totals.cooledDownRepositories} cooled down`,
   );
+
+  // Before the enrichment pass: the facts rows already exist, and enrichment
+  // only adds detail the collector's watermark re-reads later.
+  if (opts.chainBrainCollectors) {
+    await enqueueBrainCollectorsFollowUp();
+  }
 
   // Files touched and reviews need per-PR requests the list sync above
   // does not make; a bounded batch per pass keeps that traffic predictable.

--- a/apps/web/src/trpc/commands/brain/index.ts
+++ b/apps/web/src/trpc/commands/brain/index.ts
@@ -17,6 +17,7 @@ import {
   readBrainCorpus,
   readBrainPage,
   readBrainStats,
+  requestBrainBackfill,
   resolveBrainSourceRequirements,
   resolveBrainInferenceProvider,
   type BrainCorpusSnapshot,
@@ -539,6 +540,13 @@ export async function setMemoryEnabledCommand(
   assertAdmin(auth);
 
   await setBrainEnabled(input.enabled);
+
+  if (input.enabled) {
+    // Start the initial backfill now rather than waiting out the 15-minute
+    // collector and PR-sync schedules: a freshly enabled Memory should show
+    // content landing within moments, not ticks from now.
+    void requestBrainBackfill('memory-enabled');
+  }
 
   return { enabled: input.enabled };
 }

--- a/apps/web/src/trpc/commands/brain/set-enabled.test.ts
+++ b/apps/web/src/trpc/commands/brain/set-enabled.test.ts
@@ -1,10 +1,16 @@
-const { mockSetBrainEnabled } = vi.hoisted(() => ({
+const { mockSetBrainEnabled, mockRequestBrainBackfill } = vi.hoisted(() => ({
   mockSetBrainEnabled: vi.fn(async () => undefined),
+  mockRequestBrainBackfill: vi.fn(async () => undefined),
 }));
 
 vi.mock('@roomote/db/server', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@roomote/db/server')>()),
   setBrainEnabled: mockSetBrainEnabled,
+}));
+
+vi.mock('@roomote/sdk/server', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@roomote/sdk/server')>()),
+  requestBrainBackfill: mockRequestBrainBackfill,
 }));
 
 import type { UserAuthSuccess } from '@/types';
@@ -17,6 +23,7 @@ function auth(isAdmin: boolean): UserAuthSuccess {
 
 beforeEach(() => {
   mockSetBrainEnabled.mockClear();
+  mockRequestBrainBackfill.mockClear();
 });
 
 describe('setMemoryEnabledCommand', () => {
@@ -37,5 +44,14 @@ describe('setMemoryEnabledCommand', () => {
       setMemoryEnabledCommand(auth(true), { enabled: false }),
     ).resolves.toEqual({ enabled: false });
     expect(mockSetBrainEnabled).toHaveBeenLastCalledWith(false);
+  });
+
+  it('kicks the initial backfill on enable, not on disable', async () => {
+    await setMemoryEnabledCommand(auth(true), { enabled: true });
+    expect(mockRequestBrainBackfill).toHaveBeenCalledWith('memory-enabled');
+
+    mockRequestBrainBackfill.mockClear();
+    await setMemoryEnabledCommand(auth(true), { enabled: false });
+    expect(mockRequestBrainBackfill).not.toHaveBeenCalled();
   });
 });

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -429,6 +429,7 @@ export {
 } from './lib/mcp/linear-connections';
 
 export {
+  requestBrainBackfill,
   requestInstancePing,
   requestLicenseUsageSync,
   resetInstancePingQueueForTests,

--- a/packages/sdk/src/server/lib/__tests__/brain-github.test.ts
+++ b/packages/sdk/src/server/lib/__tests__/brain-github.test.ts
@@ -641,6 +641,17 @@ describe('GitHub issue collector progress', () => {
     expect(second.pages[0]?.slug).toBe('github/acme/b/issues/7');
     expect(second.done).toBe(false);
   });
+
+  it('walks history newest first so recent issues land before the stale tail', async () => {
+    githubMocks.repositories = [{ fullName: 'acme/a', installationId: 1 }];
+    githubMocks.listForRepo.mockResolvedValueOnce({ data: [] });
+
+    await backfillBrainGithubIssuesStep({ cursor: null });
+
+    expect(githubMocks.listForRepo).toHaveBeenCalledWith(
+      expect.objectContaining({ sort: 'updated', direction: 'desc' }),
+    );
+  });
 });
 
 describe('deep backfill completion and re-arming', () => {

--- a/packages/sdk/src/server/lib/__tests__/request-instance-ping.test.ts
+++ b/packages/sdk/src/server/lib/__tests__/request-instance-ping.test.ts
@@ -11,6 +11,7 @@ vi.mock('bullmq', () => ({
 }));
 
 import {
+  requestBrainBackfill,
   requestInstancePing,
   resetInstancePingQueueForTests,
 } from '../request-instance-ping';
@@ -55,5 +56,45 @@ describe('requestInstancePing', () => {
     mockQueueAdd.mockRejectedValueOnce(new Error('redis down'));
 
     await expect(requestInstancePing('user-admitted')).resolves.toBeUndefined();
+  });
+});
+
+describe('requestBrainBackfill', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-22T21:30:30.000Z'));
+    resetInstancePingQueueForTests();
+    mockQueueAdd.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('kicks every ingestion job with per-minute debounce ids', async () => {
+    await requestBrainBackfill('memory-enabled');
+
+    const minuteBucket = Math.floor(Date.now() / 60_000);
+    const jobs = mockQueueAdd.mock.calls.map((call) => call[0]);
+    expect(jobs.sort()).toEqual([
+      'BrainCollectors',
+      'BrainOutboxDrain',
+      'PullRequestAnalyticsSync',
+    ]);
+    for (const [jobName, data, opts] of mockQueueAdd.mock.calls) {
+      expect(data).toEqual({ reason: 'memory-enabled' });
+      expect(opts).toEqual({
+        jobId: `brain-backfill-request-${jobName}-${minuteBucket}`,
+      });
+    }
+  });
+
+  it('swallows enqueue failures so the Settings mutation never breaks', async () => {
+    mockQueueAdd.mockRejectedValue(new Error('redis down'));
+
+    await expect(
+      requestBrainBackfill('memory-enabled'),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/sdk/src/server/lib/__tests__/request-instance-ping.test.ts
+++ b/packages/sdk/src/server/lib/__tests__/request-instance-ping.test.ts
@@ -83,7 +83,11 @@ describe('requestBrainBackfill', () => {
       'PullRequestAnalyticsSync',
     ]);
     for (const [jobName, data, opts] of mockQueueAdd.mock.calls) {
-      expect(data).toEqual({ reason: 'memory-enabled' });
+      expect(data).toEqual(
+        jobName === 'PullRequestAnalyticsSync'
+          ? { reason: 'memory-enabled', chainBrainCollectors: true }
+          : { reason: 'memory-enabled' },
+      );
       expect(opts).toEqual({
         jobId: `brain-backfill-request-${jobName}-${minuteBucket}`,
       });

--- a/packages/sdk/src/server/lib/brain-github.ts
+++ b/packages/sdk/src/server/lib/brain-github.ts
@@ -692,9 +692,13 @@ function parseBackfillCursor(cursor: string | null): BackfillCursor {
 
 /**
  * One bounded deep-backfill step: a single page of one repository's full
- * issue history, oldest first. Completed repository identities are retained
- * while the collector stays open, so a repository connected later is found
- * and backfilled without invalidating a positional cursor.
+ * issue history, newest first, so a long backlog surfaces its most useful
+ * (recent) issues before its stale tail. An issue updated mid-walk shifts
+ * toward page 1 and can be missed by the positional cursor, but the
+ * incremental pass owns updates and re-reads it from the watermark.
+ * Completed repository identities are retained while the collector stays
+ * open, so a repository connected later is found and backfilled without
+ * invalidating a positional cursor.
  */
 export async function backfillBrainGithubIssuesStep(input: {
   cursor: string | null;
@@ -764,7 +768,7 @@ export async function backfillBrainGithubIssuesStep(input: {
       repo,
       state: 'all',
       sort: 'updated',
-      direction: 'asc',
+      direction: 'desc',
       per_page: BACKFILL_PER_PAGE,
       page,
     });

--- a/packages/sdk/src/server/lib/request-instance-ping.ts
+++ b/packages/sdk/src/server/lib/request-instance-ping.ts
@@ -92,6 +92,11 @@ export async function requestLicenseUsageSync(reason: string): Promise<void> {
  * backfill — task history, PR facts, integration sources — starts right away
  * and the settings page shows content landing within moments of enabling.
  *
+ * The kicked analytics sync is asked to chain a follow-up BrainCollectors
+ * run: the PR-fact → Brain sync lives in the collectors job and reads the
+ * table the analytics sync populates, so the concurrent one-off collectors
+ * run can race it and see nothing there yet.
+ *
  * Fire-and-forget with per-minute job ids, like the requests above: the
  * regular schedules are the safety net, every job is idempotent against its
  * durable checkpoints, and a failed enqueue must never break the Settings
@@ -104,7 +109,9 @@ export async function requestBrainBackfill(reason: string): Promise<void> {
       BRAIN_BACKFILL_JOBS.map((jobName) =>
         getQueue().add(
           jobName,
-          { reason },
+          jobName === 'PullRequestAnalyticsSync'
+            ? { reason, chainBrainCollectors: true }
+            : { reason },
           { jobId: `brain-backfill-request-${jobName}-${minuteBucket}` },
         ),
       ),

--- a/packages/sdk/src/server/lib/request-instance-ping.ts
+++ b/packages/sdk/src/server/lib/request-instance-ping.ts
@@ -3,14 +3,18 @@ import { Queue } from 'bullmq';
 import { getRedis } from '@roomote/redis';
 
 /**
- * The bullmq scheduled-jobs queue and the InstancePing job name it
- * dispatches on (apps/bullmq ScheduledJobName.InstancePing). Duplicated as
- * literals because the enum lives in the bullmq app, which the SDK cannot
- * depend on.
+ * The bullmq scheduled-jobs queue and the job names it dispatches on
+ * (apps/bullmq ScheduledJobName). Duplicated as literals because the enum
+ * lives in the bullmq app, which the SDK cannot depend on.
  */
 const SCHEDULED_JOBS_QUEUE = 'scheduled-jobs';
 const INSTANCE_PING_JOB = 'InstancePing';
 const LICENSE_USAGE_SYNC_JOB = 'LicenseUsageSync';
+const BRAIN_BACKFILL_JOBS = [
+  'BrainOutboxDrain',
+  'BrainCollectors',
+  'PullRequestAnalyticsSync',
+] as const;
 
 let queue: Queue | null = null;
 
@@ -76,6 +80,38 @@ export async function requestLicenseUsageSync(reason: string): Promise<void> {
   } catch (error) {
     console.warn(
       `[requestLicenseUsageSync] failed to enqueue (reason=${reason}):`,
+      error instanceof Error ? error.message : error,
+    );
+  }
+}
+
+/**
+ * Kicks the Brain ingestion jobs immediately instead of waiting out their
+ * schedules (the outbox drain runs every minute, but collectors and the PR
+ * facts sync only every 15). Used when memory is switched on, so the initial
+ * backfill — task history, PR facts, integration sources — starts right away
+ * and the settings page shows content landing within moments of enabling.
+ *
+ * Fire-and-forget with per-minute job ids, like the requests above: the
+ * regular schedules are the safety net, every job is idempotent against its
+ * durable checkpoints, and a failed enqueue must never break the Settings
+ * mutation that asked for it.
+ */
+export async function requestBrainBackfill(reason: string): Promise<void> {
+  try {
+    const minuteBucket = Math.floor(Date.now() / 60_000);
+    await Promise.all(
+      BRAIN_BACKFILL_JOBS.map((jobName) =>
+        getQueue().add(
+          jobName,
+          { reason },
+          { jobId: `brain-backfill-request-${jobName}-${minuteBucket}` },
+        ),
+      ),
+    );
+  } catch (error) {
+    console.warn(
+      `[requestBrainBackfill] failed to enqueue (reason=${reason}):`,
       error instanceof Error ? error.message : error,
     );
   }


### PR DESCRIPTION
## Problem

Enabling Memory in Settings starts nothing right away. The first backfill pass waits on the job schedules: up to a minute for the task-history outbox drain, and up to 15 minutes for the integration collectors and the pull-request facts sync. A freshly enabled Memory looks broken ("0 pages") for its first quarter hour. And once backfills do run, the GitHub issues walk reads oldest-first, so a big backlog delivers its least useful history before anything recent.

## Changes

**Immediate backfill on enable.** `setMemoryEnabledCommand` now kicks the initial backfill by enqueueing one-off runs of `BrainOutboxDrain`, `BrainCollectors`, and `PullRequestAnalyticsSync` onto the scheduled-jobs queue, via a new `requestBrainBackfill()` in the SDK. Follows the existing `requestInstancePing` / `requestLicenseUsageSync` pattern in the same module: fire-and-forget, per-minute debounce job ids, enqueue failures swallowed so the Settings mutation never breaks. The regular schedules remain the safety net, and every job is idempotent against its durable checkpoints, so an overlapping scheduled run is harmless. Disable does not kick anything.

**GitHub issues backfill walks newest first.** The deep backfill now pages `sort: updated, direction: desc` so recent issues land in the brain before the stale tail — matching the recency-first direction of the other sources (task memories, Slack, Notion). Safe with the positional cursor: an issue updated mid-walk shifts toward page 1 and can be skipped there, but the incremental pass owns updates and re-reads it from the watermark, and page writes are idempotent upserts.

## Testing

- New unit tests for `requestBrainBackfill` (all three jobs enqueued with debounce ids; failures swallowed)
- New test for the command: backfill kicked on enable, not on disable
- New test asserting the issues backfill lists newest first
- `pnpm lint` and `pnpm check-types` clean