### PR TITLE
[Feat] End setup in one Roomote session that launches the starter tasks

### DIFF
--- a/apps/web/src/app/(onboarding)/setup/StepInvoke.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepInvoke.client.test.tsx
@@ -26,8 +26,7 @@ const userState = vi.hoisted(() => ({
 }));
 const starterResultState = vi.hoisted(() => ({
   queue: [] as Array<{
-    launched: Array<{ starterTaskId: string; sessionId: string }>;
-    failed: Array<{ starterTaskId: string; error: string }>;
+    sessionId: string | null;
     setupCompleted: boolean;
     completionError: string | null;
   }>,
@@ -59,11 +58,7 @@ vi.mock('@tanstack/react-query', async () => {
           mutate: async (input: { selectedStarterTaskIds: string[] }) => {
             starterMutateMock(input);
             const result = starterResultState.queue.shift() ?? {
-              launched: input.selectedStarterTaskIds.map((starterTaskId) => ({
-                starterTaskId,
-                sessionId: `session-${starterTaskId}`,
-              })),
-              failed: [],
+              sessionId: 'setup-session-1',
               setupCompleted: true,
               completionError: null,
             };
@@ -307,7 +302,7 @@ describe('Setup StepInvoke', () => {
     }
   });
 
-  it('launches a single selected Session and routes to it', async () => {
+  it('submits a single selected starter task and routes to the setup session', async () => {
     render(<StepInvoke />);
 
     for (const title of STARTER_TASK_TITLES.slice(1)) {
@@ -325,7 +320,7 @@ describe('Setup StepInvoke', () => {
     });
 
     await waitFor(() => {
-      expect(replaceMock).toHaveBeenCalledWith('/sessions/session-speed-up-ci');
+      expect(replaceMock).toHaveBeenCalledWith('/sessions/setup-session-1');
     });
 
     expect(setQueryDataMock).toHaveBeenCalledWith(
@@ -347,7 +342,7 @@ describe('Setup StepInvoke', () => {
     expect(mutateMock).not.toHaveBeenCalled();
   });
 
-  it('launches every selected Session and routes to the Sessions list', async () => {
+  it('submits the full selection and routes to the one setup session', async () => {
     render(<StepInvoke />);
 
     clickGo();
@@ -367,22 +362,15 @@ describe('Setup StepInvoke', () => {
     });
 
     await waitFor(() => {
-      expect(replaceMock).toHaveBeenCalledWith('/sessions');
+      expect(replaceMock).toHaveBeenCalledWith('/sessions/setup-session-1');
     });
   });
 
-  it('keeps failures visible and retries only tasks that have not launched', async () => {
+  it('surfaces a completion error and retries with the same selection', async () => {
     starterResultState.queue.push({
-      launched: [
-        { starterTaskId: 'speed-up-ci', sessionId: 'session-ci' },
-        { starterTaskId: 'security-scan', sessionId: 'session-security' },
-      ],
-      failed: [
-        { starterTaskId: 'fix-test-flakes', error: 'No repositories.' },
-        { starterTaskId: 'update-dependencies', error: 'No repositories.' },
-      ],
+      sessionId: null,
       setupCompleted: false,
-      completionError: null,
+      completionError: 'settings write failed',
     });
 
     render(<StepInvoke />);
@@ -390,45 +378,36 @@ describe('Setup StepInvoke', () => {
     clickGo();
 
     await waitFor(() => {
-      expect(
-        screen.getByText(
-          /Couldn't start: Fix test flakes, Update dependencies/,
-        ),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/settings write failed/)).toBeInTheDocument();
     });
     expect(replaceMock).not.toHaveBeenCalled();
-    expect(
-      screen.getByRole('checkbox', { name: 'Speed up CI' }),
-    ).toBeDisabled();
-    expect(screen.getAllByText('Started.')).toHaveLength(2);
 
     fireEvent.click(screen.getByRole('button', { name: /retry/i }));
 
     await waitFor(() => {
       expect(starterMutateMock).toHaveBeenLastCalledWith({
         launchBatchId: '11111111-1111-4111-8111-111111111111',
-        selectedStarterTaskIds: ['fix-test-flakes', 'update-dependencies'],
+        selectedStarterTaskIds: [
+          'speed-up-ci',
+          'security-scan',
+          'fix-test-flakes',
+          'update-dependencies',
+        ],
         anonymousAnalyticsEnabled: true,
         productUpdatesEnabled: true,
       });
     });
 
     await waitFor(() => {
-      expect(replaceMock).toHaveBeenCalledWith('/sessions');
+      expect(replaceMock).toHaveBeenCalledWith('/sessions/setup-session-1');
     });
   });
 
   it('reuses the launch batch id after an ambiguous result and remount', async () => {
     starterResultState.queue.push({
-      launched: [],
-      failed: [
-        { starterTaskId: 'speed-up-ci', error: 'Request timed out.' },
-        { starterTaskId: 'security-scan', error: 'Request timed out.' },
-        { starterTaskId: 'fix-test-flakes', error: 'Request timed out.' },
-        { starterTaskId: 'update-dependencies', error: 'Request timed out.' },
-      ],
+      sessionId: null,
       setupCompleted: false,
-      completionError: null,
+      completionError: 'Request timed out.',
     });
 
     const firstRender = render(<StepInvoke />);
@@ -453,44 +432,6 @@ describe('Setup StepInvoke', () => {
     expect(starterMutateMock.mock.calls[1]?.[0].launchBatchId).toBe(
       starterMutateMock.mock.calls[0]?.[0].launchBatchId,
     );
-  });
-
-  it('keeps setup incomplete and offers retry when completion fails after launches', async () => {
-    starterResultState.queue.push({
-      launched: [{ starterTaskId: 'speed-up-ci', sessionId: 'session-ci' }],
-      failed: [],
-      setupCompleted: false,
-      completionError: 'settings write failed',
-    });
-
-    render(<StepInvoke />);
-
-    for (const title of STARTER_TASK_TITLES.slice(1)) {
-      fireEvent.click(screen.getByRole('checkbox', { name: title }));
-    }
-    clickGo();
-
-    await waitFor(() => {
-      expect(screen.getByText(/settings write failed/)).toBeInTheDocument();
-    });
-    expect(replaceMock).not.toHaveBeenCalled();
-
-    // The remaining selection is empty, so the retry completes setup through
-    // the starter mutation and routes to the already-launched Session.
-    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
-
-    await waitFor(() => {
-      expect(starterMutateMock).toHaveBeenLastCalledWith({
-        launchBatchId: '11111111-1111-4111-8111-111111111111',
-        selectedStarterTaskIds: [],
-        anonymousAnalyticsEnabled: true,
-        productUpdatesEnabled: true,
-      });
-    });
-
-    await waitFor(() => {
-      expect(replaceMock).toHaveBeenCalledWith('/sessions/session-ci');
-    });
   });
 
   it('optimistically completes setup and onboarding before routing away when nothing is selected', async () => {

--- a/apps/web/src/app/(onboarding)/setup/StepInvoke.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepInvoke.tsx
@@ -333,7 +333,9 @@ function StarterTasksStepContent({
 
         // Leave before awaiting invalidation so /setup's completed-setup
         // guard cannot race and flash Home before the destination page.
-        router.replace(result.sessionId ? `/sessions/${result.sessionId}` : '/');
+        router.replace(
+          result.sessionId ? `/sessions/${result.sessionId}` : '/',
+        );
 
         await Promise.all([
           queryClient.invalidateQueries({

--- a/apps/web/src/app/(onboarding)/setup/StepInvoke.tsx
+++ b/apps/web/src/app/(onboarding)/setup/StepInvoke.tsx
@@ -22,7 +22,6 @@ import { useEnvironments } from '@/hooks/environments/useEnvironments';
 import { useUser } from '@/hooks/useUser';
 import {
   SETUP_STARTER_TASKS,
-  getSetupStarterTask,
   type SetupStarterTaskId,
 } from '@/lib/setup-starter-tasks';
 import { buildInvokeMethods } from '../invokeMethods';
@@ -285,28 +284,6 @@ function CompletionPreferences({
   );
 }
 
-type StarterTaskLaunch = {
-  starterTaskId: SetupStarterTaskId;
-  sessionId: string;
-};
-
-function buildLaunchErrorMessage(result: {
-  failed: Array<{ starterTaskId: SetupStarterTaskId; error: string }>;
-  completionError: string | null;
-}) {
-  const [firstFailure] = result.failed;
-
-  if (firstFailure) {
-    const failedTitles = result.failed
-      .map((failure) => getSetupStarterTask(failure.starterTaskId).title)
-      .join(', ');
-
-    return `Couldn't start: ${failedTitles} (${firstFailure.error}). Press Retry to try again.`;
-  }
-
-  return `${result.completionError ?? 'Setup could not be completed.'} Press Retry to try again.`;
-}
-
 function StarterTasksStepContent({
   onTryItOut,
   linkSuggestedTasks = false,
@@ -321,7 +298,6 @@ function StarterTasksStepContent({
   const [selectedIds, setSelectedIds] = useState<SetupStarterTaskId[]>(() =>
     SETUP_STARTER_TASKS.map((starterTask) => starterTask.id),
   );
-  const [launchedTasks, setLaunchedTasks] = useState<StarterTaskLaunch[]>([]);
   const [launchError, setLaunchError] = useState<string | null>(null);
   const [anonymousAnalyticsEnabled, setAnonymousAnalyticsEnabled] =
     useState(true);
@@ -336,14 +312,9 @@ function StarterTasksStepContent({
   const launchStarterTasks = useMutation(
     trpc.setup.completeWithStarterTasks.mutationOptions({
       onSuccess: async (result) => {
-        const allLaunched = [...launchedTasks, ...(result?.launched ?? [])];
-        setLaunchedTasks(allLaunched);
-
-        if (!result || result.failed.length > 0 || !result.setupCompleted) {
+        if (!result?.setupCompleted) {
           setLaunchError(
-            result
-              ? buildLaunchErrorMessage(result)
-              : 'The tasks could not be started. Press Retry to try again.',
+            `${result?.completionError ?? 'Setup could not be completed.'} Press Retry to try again.`,
           );
           return;
         }
@@ -362,14 +333,7 @@ function StarterTasksStepContent({
 
         // Leave before awaiting invalidation so /setup's completed-setup
         // guard cannot race and flash Home before the destination page.
-        const [firstLaunched] = allLaunched;
-        router.replace(
-          allLaunched.length === 0
-            ? '/'
-            : allLaunched.length === 1 && firstLaunched
-              ? `/sessions/${firstLaunched.sessionId}`
-              : '/sessions',
-        );
+        router.replace(result.sessionId ? `/sessions/${result.sessionId}` : '/');
 
         await Promise.all([
           queryClient.invalidateQueries({
@@ -389,10 +353,6 @@ function StarterTasksStepContent({
     }),
   );
 
-  const launchedIds = new Set(
-    launchedTasks.map((launch) => launch.starterTaskId),
-  );
-  const remainingIds = selectedIds.filter((id) => !launchedIds.has(id));
   const isPending = completeSetup.isPending || launchStarterTasks.isPending;
 
   const toggleStarterTask = (id: SetupStarterTaskId, checked: boolean) => {
@@ -413,9 +373,9 @@ function StarterTasksStepContent({
       ...(!isCloudAdmin ? { productUpdatesEnabled } : {}),
     };
 
-    if (remainingIds.length === 0 && launchedTasks.length === 0) {
-      // Nothing selected and nothing launched: plain setup completion with
-      // the existing Home routing.
+    if (selectedIds.length === 0) {
+      // Nothing selected: plain setup completion with the existing Home
+      // routing.
       completeSetup.mutate(preferences);
       return;
     }
@@ -423,7 +383,7 @@ function StarterTasksStepContent({
     setLaunchError(null);
     launchStarterTasks.mutate({
       launchBatchId,
-      selectedStarterTaskIds: remainingIds,
+      selectedStarterTaskIds: selectedIds,
       ...preferences,
     });
   };
@@ -440,8 +400,7 @@ function StarterTasksStepContent({
       />
       <div className="space-y-2 rounded-xl bg-card py-2 divide-y">
         {SETUP_STARTER_TASKS.map((starterTask) => {
-          const isLaunched = launchedIds.has(starterTask.id);
-          const checked = isLaunched || selectedIds.includes(starterTask.id);
+          const checked = selectedIds.includes(starterTask.id);
           const inputId = `setup-starter-task-${starterTask.id}`;
 
           return (
@@ -455,7 +414,7 @@ function StarterTasksStepContent({
                 aria-label={starterTask.title}
                 className="relative top-0.5 shrink-0"
                 checked={checked}
-                disabled={isLaunched || isPending}
+                disabled={isPending}
                 onCheckedChange={(nextChecked) =>
                   toggleStarterTask(starterTask.id, nextChecked === true)
                 }
@@ -463,7 +422,7 @@ function StarterTasksStepContent({
               <span className="flex-1">
                 <span className="font-semibold">{starterTask.title}</span>
                 <span className="block text-muted-foreground">
-                  {isLaunched ? 'Started.' : starterTask.description}
+                  {starterTask.description}
                 </span>
               </span>
             </label>

--- a/apps/web/src/trpc/commands/fast-sessions/index.test.ts
+++ b/apps/web/src/trpc/commands/fast-sessions/index.test.ts
@@ -229,6 +229,60 @@ describe('startSetupFastSessionCommand', () => {
     expect(mocks.dbSelect).not.toHaveBeenCalled();
   });
 
+  it('skips a scheduled kickoff whose transcript gained messages before the turn lock', async () => {
+    mocks.getOrCreateSession.mockResolvedValue({
+      id: 'setup-conversation-1',
+      created: true,
+    });
+    let scheduled: (() => Promise<void>) | undefined;
+    mocks.after.mockImplementation((callback) => {
+      scheduled = callback;
+    });
+    const release = Object.assign(vi.fn().mockResolvedValue(undefined), {
+      signal: new AbortController().signal,
+    });
+    mocks.acquireTurnLock.mockResolvedValue(release);
+
+    await startSetupFastSessionCommand(auth, input);
+    expect(scheduled).toBeDefined();
+
+    // A concurrent submit's kickoff persisted its event row first: the
+    // re-check under the turn lock sees the message and skips this turn.
+    mocks.dbSelectLimit.mockResolvedValue([{ id: 'message-1' }]);
+    await scheduled?.();
+
+    expect(mocks.answerQuestion).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it('runs a scheduled kickoff whose transcript is still empty at the turn lock', async () => {
+    mocks.getOrCreateSession.mockResolvedValue({
+      id: 'setup-conversation-1',
+      created: true,
+    });
+    let scheduled: (() => Promise<void>) | undefined;
+    mocks.after.mockImplementation((callback) => {
+      scheduled = callback;
+    });
+    const release = Object.assign(vi.fn().mockResolvedValue(undefined), {
+      signal: new AbortController().signal,
+    });
+    mocks.acquireTurnLock.mockResolvedValue(release);
+    mocks.answerQuestion.mockResolvedValue('Welcome');
+
+    await startSetupFastSessionCommand(auth, input);
+    await scheduled?.();
+
+    expect(mocks.answerQuestion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        turnSource: 'platform_event',
+        platformEventKind: 'setup',
+        platformEventVisibility: 'required',
+      }),
+    );
+    expect(release).toHaveBeenCalledOnce();
+  });
+
   it('recovers a lost kickoff when reusing a conversation with an empty transcript', async () => {
     mocks.getOrCreateSession.mockResolvedValue({
       id: 'setup-conversation-1',

--- a/apps/web/src/trpc/commands/fast-sessions/index.test.ts
+++ b/apps/web/src/trpc/commands/fast-sessions/index.test.ts
@@ -36,6 +36,7 @@ vi.mock('@roomote/sdk/server', () => ({
 vi.mock('@roomote/db/server', () => ({
   db: { update: mocks.dbUpdate, select: mocks.dbSelect },
   retireCanonicalPrReviewActionsForDestinationKey: mocks.retireReviewActions,
+  and: vi.fn(),
   eq: vi.fn(),
   fastAgentConversations: {},
   fastAgentMessages: {},
@@ -246,8 +247,8 @@ describe('startSetupFastSessionCommand', () => {
     await startSetupFastSessionCommand(auth, input);
     expect(scheduled).toBeDefined();
 
-    // A concurrent submit's kickoff persisted its event row first: the
-    // re-check under the turn lock sees the message and skips this turn.
+    // A concurrent submit's kickoff persisted its prompt row first: the
+    // re-check under the turn lock sees the kickoff event and skips.
     mocks.dbSelectLimit.mockResolvedValue([{ id: 'message-1' }]);
     await scheduled?.();
 
@@ -278,6 +279,7 @@ describe('startSetupFastSessionCommand', () => {
         turnSource: 'platform_event',
         platformEventKind: 'setup',
         platformEventVisibility: 'required',
+        currentMessageId: 'setup-kickoff:setup-conversation-1',
       }),
     );
     expect(release).toHaveBeenCalledOnce();
@@ -298,7 +300,7 @@ describe('startSetupFastSessionCommand', () => {
     expect(mocks.after).toHaveBeenCalledOnce();
   });
 
-  it('does not schedule a second kickoff once the transcript has messages', async () => {
+  it('does not schedule a second kickoff once the kickoff event row exists', async () => {
     mocks.getOrCreateSession.mockResolvedValue({
       id: 'setup-conversation-1',
       created: false,

--- a/apps/web/src/trpc/commands/fast-sessions/index.test.ts
+++ b/apps/web/src/trpc/commands/fast-sessions/index.test.ts
@@ -14,6 +14,8 @@ const mocks = vi.hoisted(() => ({
   dbUpdate: vi.fn(),
   dbSet: vi.fn(),
   dbWhere: vi.fn(),
+  dbSelect: vi.fn(),
+  dbSelectLimit: vi.fn(),
 }));
 
 vi.mock('next/server', () => ({ after: mocks.after }));
@@ -32,10 +34,12 @@ vi.mock('@roomote/sdk/server', () => ({
 }));
 
 vi.mock('@roomote/db/server', () => ({
-  db: { update: mocks.dbUpdate },
+  db: { update: mocks.dbUpdate, select: mocks.dbSelect },
   retireCanonicalPrReviewActionsForDestinationKey: mocks.retireReviewActions,
   eq: vi.fn(),
   fastAgentConversations: {},
+  fastAgentMessages: {},
+  sessions: {},
   getSessionForFastConversation: mocks.getUnifiedSession,
 }));
 
@@ -56,6 +60,7 @@ import {
   replyToFastSessionCommand,
   scheduleWebFastAgentTurn,
   startFastSessionCommand,
+  startSetupFastSessionCommand,
   updateFastSessionModelSelectionCommand,
 } from './index';
 
@@ -178,6 +183,95 @@ describe('startFastSessionCommand', () => {
         conversationId: input.conversationId,
       },
     });
+    expect(mocks.after).toHaveBeenCalledOnce();
+  });
+});
+
+describe('startSetupFastSessionCommand', () => {
+  const input = {
+    conversationId: 'setup-session:batch-1',
+    title: 'Set up Roomote',
+    event: { type: 'setup_session_started' },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createWebTaskLauncher.mockReturnValue(vi.fn());
+    mocks.getUnifiedSession.mockResolvedValue({ id: 'unified-session-1' });
+    mocks.dbUpdate.mockReturnValue({ set: mocks.dbSet });
+    mocks.dbSet.mockReturnValue({ where: mocks.dbWhere });
+    mocks.dbWhere.mockResolvedValue(undefined);
+    mocks.dbSelect.mockReturnValue({
+      from: () => ({ where: () => ({ limit: mocks.dbSelectLimit }) }),
+    });
+    mocks.dbSelectLimit.mockResolvedValue([]);
+  });
+
+  it('schedules the kickoff and titles the session on creation', async () => {
+    mocks.getOrCreateSession.mockResolvedValue({
+      id: 'setup-conversation-1',
+      created: true,
+    });
+
+    await expect(startSetupFastSessionCommand(auth, input)).resolves.toEqual({
+      sessionId: 'unified-session-1',
+      created: true,
+    });
+
+    expect(mocks.after).toHaveBeenCalledOnce();
+    expect(mocks.dbSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Set up Roomote',
+        titleEditedByUserAt: expect.any(Date),
+      }),
+    );
+    // No transcript probe is needed when the conversation was just created.
+    expect(mocks.dbSelect).not.toHaveBeenCalled();
+  });
+
+  it('recovers a lost kickoff when reusing a conversation with an empty transcript', async () => {
+    mocks.getOrCreateSession.mockResolvedValue({
+      id: 'setup-conversation-1',
+      created: false,
+    });
+    mocks.dbSelectLimit.mockResolvedValue([]);
+
+    await expect(startSetupFastSessionCommand(auth, input)).resolves.toEqual({
+      sessionId: 'unified-session-1',
+      created: false,
+    });
+
+    expect(mocks.after).toHaveBeenCalledOnce();
+  });
+
+  it('does not schedule a second kickoff once the transcript has messages', async () => {
+    mocks.getOrCreateSession.mockResolvedValue({
+      id: 'setup-conversation-1',
+      created: false,
+    });
+    mocks.dbSelectLimit.mockResolvedValue([{ id: 'message-1' }]);
+
+    await expect(startSetupFastSessionCommand(auth, input)).resolves.toEqual({
+      sessionId: 'unified-session-1',
+      created: false,
+    });
+
+    expect(mocks.after).not.toHaveBeenCalled();
+    expect(mocks.dbUpdate).not.toHaveBeenCalled();
+  });
+
+  it('still schedules the kickoff when the title updates fail', async () => {
+    mocks.getOrCreateSession.mockResolvedValue({
+      id: 'setup-conversation-1',
+      created: true,
+    });
+    mocks.dbWhere.mockRejectedValue(new Error('title write failed'));
+
+    await expect(startSetupFastSessionCommand(auth, input)).resolves.toEqual({
+      sessionId: 'unified-session-1',
+      created: true,
+    });
+
     expect(mocks.after).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/src/trpc/commands/fast-sessions/index.ts
+++ b/apps/web/src/trpc/commands/fast-sessions/index.ts
@@ -17,6 +17,7 @@ import {
   db,
   eq,
   fastAgentConversations,
+  fastAgentMessages,
   getSessionForFastConversation,
   retireCanonicalPrReviewActionsForDestinationKey,
   sessions,
@@ -232,10 +233,12 @@ export async function startFastSessionCommand(
 }
 
 /**
- * Creates (or reuses) the first-run setup session and, on creation, schedules
- * its kickoff as a trusted setup platform event instead of a human message.
- * The deterministic conversationId makes creation idempotent per launch batch,
- * and the `created` guard means a re-submit never schedules a second kickoff.
+ * Creates (or reuses) the first-run setup session and schedules its kickoff
+ * as a trusted setup platform event instead of a human message. The
+ * deterministic conversationId makes creation idempotent per launch batch. A
+ * kickoff is scheduled on creation, and again on reuse while the transcript
+ * is still empty: creation can commit while a later failure (or a process
+ * crash) loses the kickoff, and an empty transcript means it never ran.
  */
 export async function startSetupFastSessionCommand(
   auth: UserAuthSuccess,
@@ -256,20 +259,37 @@ export async function startSetupFastSessionCommand(
     conversation,
   });
 
-  if (session.created) {
+  let scheduleKickoff = session.created;
+  if (!scheduleKickoff) {
+    const [existingMessage] = await db
+      .select({ id: fastAgentMessages.id })
+      .from(fastAgentMessages)
+      .where(eq(fastAgentMessages.conversationId, session.id))
+      .limit(1);
+    scheduleKickoff = !existingMessage;
+  }
+
+  if (scheduleKickoff) {
     // Fixed, human-authored-style title: marking it user-edited keeps the
-    // LLM title refresh from renaming the setup session later.
+    // LLM title refresh from renaming the setup session later. Best-effort:
+    // a failed rename must never cost the kickoff and the starter launches.
     const titleEditedByUserAt = new Date();
-    await Promise.all([
-      db
-        .update(fastAgentConversations)
-        .set({ title: input.title, titleEditedByUserAt })
-        .where(eq(fastAgentConversations.id, session.id)),
-      db
-        .update(sessions)
-        .set({ title: input.title, titleEditedByUserAt })
-        .where(eq(sessions.fastConversationId, session.id)),
-    ]);
+    try {
+      await Promise.all([
+        db
+          .update(fastAgentConversations)
+          .set({ title: input.title, titleEditedByUserAt })
+          .where(eq(fastAgentConversations.id, session.id)),
+        db
+          .update(sessions)
+          .set({ title: input.title, titleEditedByUserAt })
+          .where(eq(sessions.fastConversationId, session.id)),
+      ]);
+    } catch (error) {
+      console.error(
+        `[Fast Web] Failed to title setup session ${session.id}: ${formatErrorForLog(error)}`,
+      );
+    }
 
     scheduleWebFastAgentTurn({
       userId: auth.userId,

--- a/apps/web/src/trpc/commands/fast-sessions/index.ts
+++ b/apps/web/src/trpc/commands/fast-sessions/index.ts
@@ -19,6 +19,7 @@ import {
   fastAgentConversations,
   getSessionForFastConversation,
   retireCanonicalPrReviewActionsForDestinationKey,
+  sessions,
 } from '@roomote/db/server';
 import {
   formatErrorForLog,
@@ -97,6 +98,9 @@ type WebFastAgentTurnInput = {
   model?: string;
   reasoningEffort?: ReasoningEffort;
   senderDisplayName?: string;
+  /** Present for trusted platform-generated turns (e.g. the setup kickoff);
+   * absent for human-authored web messages. */
+  platformEventKind?: 'setup';
 };
 
 /**
@@ -116,6 +120,7 @@ async function runWebFastAgentTurn({
   model,
   reasoningEffort,
   senderDisplayName,
+  platformEventKind,
 }: WebFastAgentTurnInput): Promise<void> {
   const conversation = delivery.conversation;
   const release = await acquireFastAgentTurnLock({ conversation });
@@ -140,6 +145,13 @@ async function runWebFastAgentTurn({
       model,
       reasoningEffort,
       senderDisplayName,
+      ...(platformEventKind
+        ? {
+            turnSource: 'platform_event' as const,
+            platformEventKind,
+            platformEventVisibility: 'required' as const,
+          }
+        : {}),
       adapter: {
         resolveMcpServerConfigs: () =>
           resolveUserMcpServerConfigs({
@@ -216,6 +228,70 @@ export async function startFastSessionCommand(
   return {
     sessionId: unifiedSession?.id ?? session.id,
     fastConversationId: session.id,
+  };
+}
+
+/**
+ * Creates (or reuses) the first-run setup session and, on creation, schedules
+ * its kickoff as a trusted setup platform event instead of a human message.
+ * The deterministic conversationId makes creation idempotent per launch batch,
+ * and the `created` guard means a re-submit never schedules a second kickoff.
+ */
+export async function startSetupFastSessionCommand(
+  auth: UserAuthSuccess,
+  input: {
+    conversationId: string;
+    title: string;
+    event: Record<string, unknown>;
+  },
+): Promise<{ sessionId: string; created: boolean }> {
+  const conversation: WebFastAgentConversation = {
+    surface: 'web',
+    workspaceId: auth.userId,
+    conversationId: input.conversationId,
+  };
+
+  const session = await getOrCreateFastAgentSession({
+    userId: auth.userId,
+    conversation,
+  });
+
+  if (session.created) {
+    // Fixed, human-authored-style title: marking it user-edited keeps the
+    // LLM title refresh from renaming the setup session later.
+    const titleEditedByUserAt = new Date();
+    await Promise.all([
+      db
+        .update(fastAgentConversations)
+        .set({ title: input.title, titleEditedByUserAt })
+        .where(eq(fastAgentConversations.id, session.id)),
+      db
+        .update(sessions)
+        .set({ title: input.title, titleEditedByUserAt })
+        .where(eq(sessions.fastConversationId, session.id)),
+    ]);
+
+    scheduleWebFastAgentTurn({
+      userId: auth.userId,
+      delivery: {
+        conversation,
+        adapter: {
+          launchTask: createFastAgentWebTaskLauncher({
+            userId: auth.userId,
+            conversation,
+          }),
+          postReply: async () => {},
+        },
+      },
+      question: `<platform_event>${JSON.stringify(input.event)}</platform_event>`,
+      platformEventKind: 'setup',
+    });
+  }
+
+  const unifiedSession = await getSessionForFastConversation(db, session.id);
+  return {
+    sessionId: unifiedSession?.id ?? session.id,
+    created: session.created,
   };
 }
 

--- a/apps/web/src/trpc/commands/fast-sessions/index.ts
+++ b/apps/web/src/trpc/commands/fast-sessions/index.ts
@@ -14,6 +14,7 @@ import {
   type FastAgentSurfaceReplyDelivery,
 } from '@roomote/sdk/server';
 import {
+  and,
   db,
   eq,
   fastAgentConversations,
@@ -102,12 +103,16 @@ type WebFastAgentTurnInput = {
   /** Present for trusted platform-generated turns (e.g. the setup kickoff);
    * absent for human-authored web messages. */
   platformEventKind?: 'setup';
-  /** Fast conversation ID whose transcript must still be empty when the turn
-   * acquires its lock, or the turn is skipped. This is the atomic claim for
-   * the setup kickoff: concurrent submits can both pass the pre-schedule
-   * empty-transcript check, but the first kickoff persists its event row
-   * under the turn lock, so the re-check under the same lock is race-free. */
-  skipUnlessConversationEmpty?: string;
+  /** Deterministic turn ID override. Canonical event IDs derive from it, so a
+   * fixed value lets a turn be claimed idempotently across retries. */
+  currentMessageId?: string;
+  /** Skip the turn if this exact canonical event row already exists when the
+   * turn acquires its lock. This is the atomic claim for the setup kickoff:
+   * concurrent submits can both pass the pre-schedule check, but the first
+   * kickoff persists its prompt row under the turn lock, so the re-check
+   * under the same lock is race-free — and unlike a transcript-emptiness
+   * probe it is not fooled by an early human reply in the new session. */
+  skipIfEventExists?: { conversationId: string; eventId: string };
 };
 
 /**
@@ -128,7 +133,8 @@ async function runWebFastAgentTurn({
   reasoningEffort,
   senderDisplayName,
   platformEventKind,
-  skipUnlessConversationEmpty,
+  currentMessageId,
+  skipIfEventExists,
 }: WebFastAgentTurnInput): Promise<void> {
   const conversation = delivery.conversation;
   const release = await acquireFastAgentTurnLock({ conversation });
@@ -141,17 +147,23 @@ async function runWebFastAgentTurn({
 
   const apiBaseUrl = resolveApiBaseUrl() ?? undefined;
   try {
-    if (skipUnlessConversationEmpty) {
-      const [existingMessage] = await db
+    if (skipIfEventExists) {
+      const [existingEvent] = await db
         .select({ id: fastAgentMessages.id })
         .from(fastAgentMessages)
         .where(
-          eq(fastAgentMessages.conversationId, skipUnlessConversationEmpty),
+          and(
+            eq(
+              fastAgentMessages.conversationId,
+              skipIfEventExists.conversationId,
+            ),
+            eq(fastAgentMessages.eventId, skipIfEventExists.eventId),
+          ),
         )
         .limit(1);
-      if (existingMessage) {
+      if (existingEvent) {
         console.log(
-          `[Fast Web] Skipping duplicate kickoff turn for ${conversation.conversationId}: the transcript is no longer empty.`,
+          `[Fast Web] Skipping duplicate turn for ${conversation.conversationId}: event ${skipIfEventExists.eventId} already ran.`,
         );
         return;
       }
@@ -164,7 +176,7 @@ async function runWebFastAgentTurn({
       userId,
       apiBaseUrl,
       conversation,
-      currentMessageId: `web-${randomUUID()}`,
+      currentMessageId: currentMessageId ?? `web-${randomUUID()}`,
       signal: release.signal,
       model,
       reasoningEffort,
@@ -282,14 +294,26 @@ export async function startSetupFastSessionCommand(
     conversation,
   });
 
+  // The kickoff turn runs under a deterministic turn ID, so its persisted
+  // prompt row has a knowable event ID. Claiming on that exact row (rather
+  // than transcript emptiness) means an early human reply in the new session
+  // can never masquerade as an already-run kickoff.
+  const kickoffTurnId = `setup-kickoff:${session.id}`;
+  const kickoffPromptEventId = `${kickoffTurnId}:user`;
+
   let scheduleKickoff = session.created;
   if (!scheduleKickoff) {
-    const [existingMessage] = await db
+    const [existingKickoff] = await db
       .select({ id: fastAgentMessages.id })
       .from(fastAgentMessages)
-      .where(eq(fastAgentMessages.conversationId, session.id))
+      .where(
+        and(
+          eq(fastAgentMessages.conversationId, session.id),
+          eq(fastAgentMessages.eventId, kickoffPromptEventId),
+        ),
+      )
       .limit(1);
-    scheduleKickoff = !existingMessage;
+    scheduleKickoff = !existingKickoff;
   }
 
   if (scheduleKickoff) {
@@ -328,7 +352,11 @@ export async function startSetupFastSessionCommand(
       },
       question: `<platform_event>${JSON.stringify(input.event)}</platform_event>`,
       platformEventKind: 'setup',
-      skipUnlessConversationEmpty: session.id,
+      currentMessageId: kickoffTurnId,
+      skipIfEventExists: {
+        conversationId: session.id,
+        eventId: kickoffPromptEventId,
+      },
     });
   }
 

--- a/apps/web/src/trpc/commands/fast-sessions/index.ts
+++ b/apps/web/src/trpc/commands/fast-sessions/index.ts
@@ -102,6 +102,12 @@ type WebFastAgentTurnInput = {
   /** Present for trusted platform-generated turns (e.g. the setup kickoff);
    * absent for human-authored web messages. */
   platformEventKind?: 'setup';
+  /** Fast conversation ID whose transcript must still be empty when the turn
+   * acquires its lock, or the turn is skipped. This is the atomic claim for
+   * the setup kickoff: concurrent submits can both pass the pre-schedule
+   * empty-transcript check, but the first kickoff persists its event row
+   * under the turn lock, so the re-check under the same lock is race-free. */
+  skipUnlessConversationEmpty?: string;
 };
 
 /**
@@ -122,6 +128,7 @@ async function runWebFastAgentTurn({
   reasoningEffort,
   senderDisplayName,
   platformEventKind,
+  skipUnlessConversationEmpty,
 }: WebFastAgentTurnInput): Promise<void> {
   const conversation = delivery.conversation;
   const release = await acquireFastAgentTurnLock({ conversation });
@@ -134,6 +141,22 @@ async function runWebFastAgentTurn({
 
   const apiBaseUrl = resolveApiBaseUrl() ?? undefined;
   try {
+    if (skipUnlessConversationEmpty) {
+      const [existingMessage] = await db
+        .select({ id: fastAgentMessages.id })
+        .from(fastAgentMessages)
+        .where(
+          eq(fastAgentMessages.conversationId, skipUnlessConversationEmpty),
+        )
+        .limit(1);
+      if (existingMessage) {
+        console.log(
+          `[Fast Web] Skipping duplicate kickoff turn for ${conversation.conversationId}: the transcript is no longer empty.`,
+        );
+        return;
+      }
+    }
+
     await answerFastAgentQuestion({
       question,
       images,
@@ -305,6 +328,7 @@ export async function startSetupFastSessionCommand(
       },
       question: `<platform_event>${JSON.stringify(input.event)}</platform_event>`,
       platformEventKind: 'setup',
+      skipUnlessConversationEmpty: session.id,
     });
   }
 

--- a/apps/web/src/trpc/commands/setup/starter-tasks.test.ts
+++ b/apps/web/src/trpc/commands/setup/starter-tasks.test.ts
@@ -3,12 +3,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const {
   mockAssertAdmin,
   mockCompleteSetup,
-  mockStartFastSession,
+  mockStartSetupFastSession,
   mockCaptureEvent,
 } = vi.hoisted(() => ({
   mockAssertAdmin: vi.fn(),
   mockCompleteSetup: vi.fn(),
-  mockStartFastSession: vi.fn(),
+  mockStartSetupFastSession: vi.fn(),
   mockCaptureEvent: vi.fn(),
 }));
 
@@ -21,8 +21,8 @@ vi.mock('./index', () => ({
 }));
 
 vi.mock('../fast-sessions', () => ({
-  startFastSessionCommand: (...args: unknown[]) =>
-    mockStartFastSession(...args),
+  startSetupFastSessionCommand: (...args: unknown[]) =>
+    mockStartSetupFastSession(...args),
 }));
 
 vi.mock('@roomote/telemetry/server', () => ({
@@ -61,18 +61,13 @@ describe('completeSetupWithStarterTasksCommand', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCompleteSetup.mockResolvedValue({ success: true });
-    mockStartFastSession.mockImplementation(
-      async (_auth: unknown, input: { text: string }) => ({
-        sessionId: `session-for:${input.text.slice(0, 20)}`,
-      }),
-    );
+    mockStartSetupFastSession.mockResolvedValue({
+      sessionId: 'setup-session-1',
+      created: true,
+    });
   });
 
-  it('starts a Session for each selected starter prompt and completes setup', async () => {
-    mockStartFastSession
-      .mockResolvedValueOnce({ sessionId: 'session-ci' })
-      .mockResolvedValueOnce({ sessionId: 'session-security' });
-
+  it('completes setup first, then starts one setup session carrying the selected starter tasks', async () => {
     const result = await completeSetupWithStarterTasksCommand(buildAuth(), {
       launchBatchId: '11111111-1111-4111-8111-111111111111',
       selectedStarterTaskIds: ['speed-up-ci', 'security-scan'],
@@ -81,35 +76,38 @@ describe('completeSetupWithStarterTasksCommand', () => {
     });
 
     expect(mockAssertAdmin).toHaveBeenCalledOnce();
-    expect(mockStartFastSession).toHaveBeenCalledTimes(2);
-    expect(mockStartFastSession).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({ userId: 'admin-1' }),
-      {
-        text: getSetupStarterTask('speed-up-ci').prompt,
-        conversationId:
-          'setup-starter:11111111-1111-4111-8111-111111111111:speed-up-ci',
-      },
-    );
-    expect(mockStartFastSession).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({ userId: 'admin-1' }),
-      {
-        text: getSetupStarterTask('security-scan').prompt,
-        conversationId:
-          'setup-starter:11111111-1111-4111-8111-111111111111:security-scan',
-      },
-    );
     expect(mockCompleteSetup).toHaveBeenCalledWith(expect.anything(), {
       anonymousAnalyticsEnabled: true,
       productUpdatesEnabled: false,
     });
+    expect(mockCompleteSetup.mock.invocationCallOrder[0]).toBeLessThan(
+      mockStartSetupFastSession.mock.invocationCallOrder[0] ?? Infinity,
+    );
+    expect(mockStartSetupFastSession).toHaveBeenCalledTimes(1);
+    expect(mockStartSetupFastSession).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'admin-1' }),
+      {
+        conversationId:
+          'setup-session:11111111-1111-4111-8111-111111111111',
+        title: 'Set up Roomote',
+        event: expect.objectContaining({
+          type: 'setup_session_started',
+          adminName: 'Admin',
+          starterTasks: [
+            expect.objectContaining({
+              id: 'speed-up-ci',
+              prompt: getSetupStarterTask('speed-up-ci').prompt,
+            }),
+            expect.objectContaining({
+              id: 'security-scan',
+              prompt: getSetupStarterTask('security-scan').prompt,
+            }),
+          ],
+        }),
+      },
+    );
     expect(result).toEqual({
-      launched: [
-        { starterTaskId: 'speed-up-ci', sessionId: 'session-ci' },
-        { starterTaskId: 'security-scan', sessionId: 'session-security' },
-      ],
-      failed: [],
+      sessionId: 'setup-session-1',
       setupCompleted: true,
       completionError: null,
     });
@@ -119,65 +117,46 @@ describe('completeSetupWithStarterTasksCommand', () => {
         userId: 'admin-1',
         properties: {
           selectedCount: 2,
-          launchedCount: 2,
-          failedCount: 0,
           starterTaskIds: 'speed-up-ci,security-scan',
+          setupSessionCreated: true,
         },
       },
     );
   });
 
   it('deduplicates repeated starter task ids', async () => {
-    const result = await completeSetupWithStarterTasksCommand(buildAuth(), {
+    await completeSetupWithStarterTasksCommand(buildAuth(), {
       launchBatchId: '11111111-1111-4111-8111-111111111111',
       selectedStarterTaskIds: ['speed-up-ci', 'speed-up-ci'],
     });
 
-    expect(mockStartFastSession).toHaveBeenCalledTimes(1);
-    expect(result.launched).toHaveLength(1);
+    expect(mockStartSetupFastSession).toHaveBeenCalledTimes(1);
+    const [, input] = mockStartSetupFastSession.mock.calls[0] as [
+      unknown,
+      { event: { starterTasks: unknown[] } },
+    ];
+    expect(input.event.starterTasks).toHaveLength(1);
   });
 
-  it('keeps setup incomplete and reports failures when a Session fails to start', async () => {
-    mockStartFastSession
-      .mockResolvedValueOnce({ sessionId: 'session-ci' })
-      .mockRejectedValueOnce(new Error('session startup failed'));
-
-    const result = await completeSetupWithStarterTasksCommand(buildAuth(), {
-      launchBatchId: '11111111-1111-4111-8111-111111111111',
-      selectedStarterTaskIds: ['speed-up-ci', 'security-scan'],
-    });
-
-    expect(mockCompleteSetup).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      launched: [{ starterTaskId: 'speed-up-ci', sessionId: 'session-ci' }],
-      failed: [
-        { starterTaskId: 'security-scan', error: 'session startup failed' },
-      ],
-      setupCompleted: false,
-      completionError: null,
-    });
-  });
-
-  it('completes setup without launching anything for an empty selection', async () => {
+  it('completes setup without a session for an empty selection', async () => {
     const result = await completeSetupWithStarterTasksCommand(buildAuth(), {
       launchBatchId: '11111111-1111-4111-8111-111111111111',
       selectedStarterTaskIds: [],
       productUpdatesEnabled: true,
     });
 
-    expect(mockStartFastSession).not.toHaveBeenCalled();
+    expect(mockStartSetupFastSession).not.toHaveBeenCalled();
     expect(mockCompleteSetup).toHaveBeenCalledWith(expect.anything(), {
       productUpdatesEnabled: true,
     });
     expect(result).toEqual({
-      launched: [],
-      failed: [],
+      sessionId: null,
       setupCompleted: true,
       completionError: null,
     });
   });
 
-  it('reports a completion error without losing launched Sessions', async () => {
+  it('reports a completion error and creates no session when setup completion fails', async () => {
     mockCompleteSetup.mockRejectedValueOnce(new Error('settings write failed'));
 
     const result = await completeSetupWithStarterTasksCommand(buildAuth(), {
@@ -185,9 +164,11 @@ describe('completeSetupWithStarterTasksCommand', () => {
       selectedStarterTaskIds: ['fix-test-flakes'],
     });
 
-    expect(result.launched).toHaveLength(1);
-    expect(result.failed).toEqual([]);
-    expect(result.setupCompleted).toBe(false);
-    expect(result.completionError).toBe('settings write failed');
+    expect(mockStartSetupFastSession).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      sessionId: null,
+      setupCompleted: false,
+      completionError: 'settings write failed',
+    });
   });
 });

--- a/apps/web/src/trpc/commands/setup/starter-tasks.test.ts
+++ b/apps/web/src/trpc/commands/setup/starter-tasks.test.ts
@@ -87,8 +87,7 @@ describe('completeSetupWithStarterTasksCommand', () => {
     expect(mockStartSetupFastSession).toHaveBeenCalledWith(
       expect.objectContaining({ userId: 'admin-1' }),
       {
-        conversationId:
-          'setup-session:11111111-1111-4111-8111-111111111111',
+        conversationId: 'setup-session:11111111-1111-4111-8111-111111111111',
         title: 'Set up Roomote',
         event: expect.objectContaining({
           type: 'setup_session_started',

--- a/apps/web/src/trpc/commands/setup/starter-tasks.ts
+++ b/apps/web/src/trpc/commands/setup/starter-tasks.ts
@@ -1,27 +1,30 @@
 import { captureEvent } from '@roomote/telemetry/server';
+import { getUserDisplayName } from '@roomote/types';
 
 import type { UserAuthSuccess } from '@/types';
 import {
   getSetupStarterTask,
   type SetupStarterTaskId,
 } from '@/lib/setup-starter-tasks';
-import { startFastSessionCommand } from '../fast-sessions';
+import { startSetupFastSessionCommand } from '../fast-sessions';
 import { completeSetupCommand } from './index';
 import { assertAdmin } from './shared';
 
 type CompleteSetupWithStarterTasksResult = {
-  launched: Array<{ starterTaskId: SetupStarterTaskId; sessionId: string }>;
-  failed: Array<{ starterTaskId: SetupStarterTaskId; error: string }>;
+  /** Setup session to land in, or null when nothing was selected. */
+  sessionId: string | null;
   setupCompleted: boolean;
   completionError: string | null;
 };
 
 /**
- * Launches the selected setup starter tasks as ordinary web Sessions and
- * completes setup once every requested launch succeeded.
+ * Completes setup, then drops the administrator into one "Set up Roomote"
+ * Fast session whose kickoff turn launches the selected starter tasks and
+ * opens the conversation around them.
  *
- * An empty selection simply completes setup, and setup stays incomplete while
- * any requested launch is still failing.
+ * Setup completion is deterministic and happens before the session's first
+ * turn runs, so a failed or slow model turn can never leave setup incomplete.
+ * An empty selection simply completes setup with no session.
  */
 export async function completeSetupWithStarterTasksCommand(
   auth: UserAuthSuccess,
@@ -34,83 +37,64 @@ export async function completeSetupWithStarterTasksCommand(
 ): Promise<CompleteSetupWithStarterTasksResult> {
   assertAdmin(auth);
 
-  type StarterTaskLaunchOutcome =
-    | { starterTaskId: SetupStarterTaskId; sessionId: string }
-    | { starterTaskId: SetupStarterTaskId; error: string };
-
   const selectedStarterTaskIds = [...new Set(input.selectedStarterTaskIds)];
 
-  const outcomes = await Promise.all(
-    selectedStarterTaskIds.map(
-      async (starterTaskId): Promise<StarterTaskLaunchOutcome> => {
+  try {
+    await completeSetupCommand(auth, {
+      ...(input.anonymousAnalyticsEnabled === undefined
+        ? {}
+        : { anonymousAnalyticsEnabled: input.anonymousAnalyticsEnabled }),
+      ...(input.productUpdatesEnabled === undefined
+        ? {}
+        : { productUpdatesEnabled: input.productUpdatesEnabled }),
+    });
+  } catch (error) {
+    return {
+      sessionId: null,
+      setupCompleted: false,
+      completionError:
+        error instanceof Error ? error.message : 'Setup could not be completed.',
+    };
+  }
+
+  if (selectedStarterTaskIds.length === 0) {
+    return { sessionId: null, setupCompleted: true, completionError: null };
+  }
+
+  const adminName = getUserDisplayName({
+    name: auth.name,
+    email: auth.primaryEmail,
+  });
+
+  const { sessionId, created } = await startSetupFastSessionCommand(auth, {
+    conversationId: `setup-session:${input.launchBatchId}`,
+    title: 'Set up Roomote',
+    event: {
+      type: 'setup_session_started',
+      description:
+        'The administrator finished initial setup and selected these starter tasks to launch.',
+      ...(adminName ? { adminName } : {}),
+      starterTasks: selectedStarterTaskIds.map((starterTaskId) => {
         const starterTask = getSetupStarterTask(starterTaskId);
-
-        try {
-          const result = await startFastSessionCommand(auth, {
-            text: starterTask.prompt,
-            conversationId: [
-              'setup-starter',
-              input.launchBatchId,
-              starterTaskId,
-            ].join(':'),
-          });
-          return { starterTaskId, sessionId: result.sessionId };
-        } catch (error) {
-          return {
-            starterTaskId,
-            error:
-              error instanceof Error
-                ? error.message
-                : 'The task could not be started.',
-          };
-        }
-      },
-    ),
-  );
-
-  const launched: CompleteSetupWithStarterTasksResult['launched'] = [];
-  const failed: CompleteSetupWithStarterTasksResult['failed'] = [];
-
-  for (const outcome of outcomes) {
-    if ('sessionId' in outcome) {
-      launched.push(outcome);
-    } else {
-      failed.push(outcome);
-    }
-  }
-
-  let setupCompleted = false;
-  let completionError: string | null = null;
-
-  if (failed.length === 0) {
-    try {
-      await completeSetupCommand(auth, {
-        ...(input.anonymousAnalyticsEnabled === undefined
-          ? {}
-          : { anonymousAnalyticsEnabled: input.anonymousAnalyticsEnabled }),
-        ...(input.productUpdatesEnabled === undefined
-          ? {}
-          : { productUpdatesEnabled: input.productUpdatesEnabled }),
-      });
-      setupCompleted = true;
-    } catch (error) {
-      completionError =
-        error instanceof Error
-          ? error.message
-          : 'Setup could not be completed.';
-    }
-  }
+        return {
+          id: starterTask.id,
+          title: starterTask.title,
+          description: starterTask.description,
+          prompt: starterTask.prompt,
+        };
+      }),
+    },
+  });
 
   // Anonymous analytics: fixed catalog ids and counts only, never prompt text.
   void captureEvent('setup_starter_tasks_submitted', {
     userId: auth.userId,
     properties: {
       selectedCount: selectedStarterTaskIds.length,
-      launchedCount: launched.length,
-      failedCount: failed.length,
       starterTaskIds: selectedStarterTaskIds.join(','),
+      setupSessionCreated: created,
     },
   });
 
-  return { launched, failed, setupCompleted, completionError };
+  return { sessionId, setupCompleted: true, completionError: null };
 }

--- a/apps/web/src/trpc/commands/setup/starter-tasks.ts
+++ b/apps/web/src/trpc/commands/setup/starter-tasks.ts
@@ -53,7 +53,9 @@ export async function completeSetupWithStarterTasksCommand(
       sessionId: null,
       setupCompleted: false,
       completionError:
-        error instanceof Error ? error.message : 'Setup could not be completed.',
+        error instanceof Error
+          ? error.message
+          : 'Setup could not be completed.',
     };
   }
 

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation.ts
@@ -25,7 +25,8 @@ export type FastAgentPlatformEventHandling = 'default' | 'present_only';
 export type FastAgentPlatformEventKind =
   | 'delegated_task'
   | 'automation'
-  | 'external_input';
+  | 'external_input'
+  | 'setup';
 
 export type FastAgentSuggestedTask = {
   title: string;

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-prompt.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-prompt.ts
@@ -237,8 +237,8 @@ ${reactionGuidance}
 - Select an environment ID only when the target is clear. Otherwise use null to use the deployment default.
 ${
   platformEvent
-    ? `## ${platformEventKind === 'automation' ? 'Automation Platform Event' : platformEventKind === 'external_input' ? 'External Platform Input' : 'Delegated Task Platform Event'}
-- The current input is a trusted platform-generated ${platformEventKind === 'automation' ? 'custom automation request' : platformEventKind === 'external_input' ? 'external interaction associated with this conversation' : 'event about a delegated task'}, not a human-authored request.
+    ? `## ${platformEventKind === 'automation' ? 'Automation Platform Event' : platformEventKind === 'external_input' ? 'External Platform Input' : platformEventKind === 'setup' ? 'Setup Session Kickoff' : 'Delegated Task Platform Event'}
+- The current input is a trusted platform-generated ${platformEventKind === 'automation' ? 'custom automation request' : platformEventKind === 'external_input' ? 'external interaction associated with this conversation' : platformEventKind === 'setup' ? 'first-run setup kickoff for this deployment' : 'event about a delegated task'}, not a human-authored request.
 ${
   platformEventVisibility === 'required'
     ? '- This event requires a user-visible closeout because it carries user-useful substance. Present its result, changed expectation, required decision, or recovery action; never narrate lifecycle state alone. Do not call "ignore_event".'
@@ -263,6 +263,15 @@ ${
     ? `- Execute the automation prompt now. Use integrations directly when sufficient, and launch a task only when repository or workspace execution is actually required. The configured model is a delegated-task default, not the Fast inference model.
 - When the automation asks for launchable suggested tasks and this is a Slack, Discord, Teams, or Telegram report, put each concrete follow-up in the closeout's \`suggestions\` array. Keep the report summary in \`message\`; do not render suggestion cards or launch instructions as inline prose because the delivery layer adds them.
 - If launchable suggestions are unavailable on the current surface, keep follow-ups as ordinary report text and do not promise reaction-triggered launching.
+`
+    : ''
+}
+${
+  platformEventKind === 'setup'
+    ? `- The deployment's administrator just finished initial setup and is arriving in this session right now. The event lists the starter tasks they selected on the final setup screen.
+- First launch every listed starter task with "launch_task", one call per listed task, using that task's \`prompt\` field verbatim as the task prompt and null for the environment. Launch each listed task exactly once and do not invent tasks beyond the list on this turn.
+- Then post exactly one closeout that welcomes the administrator by name when the event provides one, explains in a sentence or two what you are and the kinds of work they can ask for here (coding tasks across their connected repositories, questions about their code, follow-ups on running work), and notes that the tasks just started will report progress and results back into this conversation. Keep it warm and brief; do not repeat per-task links or details already visible in the kickoff cards.
+- If a launch fails, name the task that could not start in the closeout and tell the administrator they can ask you to retry it.
 `
     : ''
 }

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-prompt.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-prompt.ts
@@ -249,7 +249,11 @@ ${
           ? 'This event is presentation-only. Post its supplied information, then stop. Do not inspect, launch, message, retry, cancel, or otherwise act on a task or integration.'
           : 'The normal tools remain available. Use them only when the event and conversation context justify the action.'
       }
-- When the event is useful, post exactly one closeout. Never use acknowledgement or progress replies for a platform event.
+${
+  platformEventKind === 'setup'
+    ? '- End the turn with exactly one closeout. The setup kickoff acknowledgement described below is the only additional reply allowed.'
+    : '- When the event is useful, post exactly one closeout. Never use acknowledgement or progress replies for a platform event.'
+}
 - Child-message events with concrete findings, blockers, meaningful work milestones, required input, or roughly 10 minutes of silence during active work carry useful substance even when expectations have not changed. Apply the same narrow ignore rule above to every other platform event.
 ${
   retryTaskStartAvailable
@@ -269,8 +273,10 @@ ${
 ${
   platformEventKind === 'setup'
     ? `- The deployment's administrator just finished initial setup and is arriving in this session right now. The event lists the starter tasks they selected on the final setup screen.
-- First launch every listed starter task with "launch_task", one call per listed task, using that task's \`prompt\` field verbatim as the task prompt and null for the environment. Launch each listed task exactly once and do not invent tasks beyond the list on this turn.
-- Then post exactly one closeout that welcomes the administrator by name when the event provides one, explains in a sentence or two what you are and the kinds of work they can ask for here (coding tasks across their connected repositories, questions about their code, follow-ups on running work), and notes that the tasks just started will report progress and results back into this conversation. Keep it warm and brief; do not repeat per-task links or details already visible in the kickoff cards.
+- This kickoff turn has three beats, in order:
+  1. Post one brief "ack" reply before any launch: welcome the administrator by name when the event provides one, introduce yourself in a sentence (you are Roomote, ready to take on work across their connected repositories), and say you are about to start the starter tasks they picked, naming them in plain words.
+  2. Launch every listed starter task with "launch_task", one call per listed task, using that task's \`prompt\` field verbatim as the task prompt and null for the environment. Launch each listed task exactly once and do not invent tasks beyond the list on this turn.
+  3. Post one "closeout" saying you will keep an eye on the tasks and report progress and results back into this conversation as they work, and that the administrator should feel free to talk to you about anything in the meantime (questions about their code, new work to start, or how Roomote works) without disturbing the running tasks. Keep both replies warm and brief; do not repeat per-task links or details already visible in the kickoff cards.
 - If a launch fails, name the task that could not start in the closeout and tell the administrator they can ask you to retry it.
 `
     : ''

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -2329,6 +2329,14 @@ export async function answerFastAgentQuestion({
           message:
             'I could not complete that request within the available turn.',
         });
+      } else if (platformEvent && platformEventVisibility === 'required') {
+        // A visibility-required platform event promises a closeout even when
+        // an intro ack or launch kickoff already posted a visible update
+        // (e.g. the setup kickoff ending on an empty terminal response).
+        await postReply({
+          purpose: 'closeout',
+          message: 'I will post updates here as this progresses.',
+        });
       }
     }
     await mirrorPendingMessages();

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -1538,11 +1538,14 @@ export async function answerFastAgentQuestion({
             }
             if (
               platformEvent &&
+              // On chat surfaces every reply is a separate message and push
+              // notification, so automated events are held to one closeout.
+              // Web platform events render in a session transcript where
+              // extra replies are ordinary conversation; the prompt alone
+              // governs reply style there (e.g. the setup kickoff's intro).
+              conversation.surface !== 'web' &&
               args.purpose !== 'closeout' &&
-              args.purpose !== 'clarification' &&
-              // The setup kickoff introduces itself with one ack before
-              // launching the starter tasks, then still ends on a closeout.
-              !(platformEventKind === 'setup' && args.purpose === 'ack')
+              args.purpose !== 'clarification'
             ) {
               return {
                 success: false,

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -1539,7 +1539,10 @@ export async function answerFastAgentQuestion({
             if (
               platformEvent &&
               args.purpose !== 'closeout' &&
-              args.purpose !== 'clarification'
+              args.purpose !== 'clarification' &&
+              // The setup kickoff introduces itself with one ack before
+              // launching the starter tasks, then still ends on a closeout.
+              !(platformEventKind === 'setup' && args.purpose === 'ack')
             ) {
               return {
                 success: false,


### PR DESCRIPTION
## What this does

Setup now ends inside the product instead of on a wizard screen. When the first admin submits the final starter-task picker:

1. Setup completes deterministically (before any model call, so a failed or slow turn can never leave setup incomplete).
2. One "Set up Roomote" Fast web session is created with a deterministic conversation ID (`setup-session:{launchBatchId}`), so refreshes and double submits reuse it and never re-fire the kickoff.
3. The admin is routed straight to `/sessions/{id}`.
4. The session's first turn is a trusted `setup` platform event (new `FastAgentPlatformEventKind`) carrying the selected starter tasks with their exact catalog prompts. Roomote launches each one via the existing `launch_task` tool, then posts a single welcome closeout introducing itself and setting expectations.
5. Ongoing narration needs no new plumbing: delegated-task lifecycle events already flow back into parent web sessions as platform events.

This replaces the previous behavior where each selected starter task was fanned out into its own silent Fast session with the prompt injected as a fake first user message.

## Implementation notes

- `completeSetupWithStarterTasksCommand` reworked: complete setup first, then create/reuse the session via a new `startSetupFastSessionCommand`. Empty selection still completes setup with no session.
- The setup session is titled "Set up Roomote" with `titleEditedByUserAt` set on both the Fast conversation and the unified session so the LLM titler never renames it.
- Web platform-event plumbing: `scheduleWebFastAgentTurn` accepts an optional `platformEventKind`, mapped to `turnSource: 'platform_event'` with visibility `required`.
- Setup-kind prompt guidance instructs: launch each listed task exactly once with the prompt verbatim, then one warm closeout; name any failed launch and offer retry.
- Client: the picker routes to the session on success; the per-task launch-progress/retry UI is removed since launch status now lives in the conversation.

## Deliberately held off (prototype scope)

- No launch idempotency key: a provider-retried kickoff turn could double-launch a starter task, and a process crash between the kickoff prompt persisting and the first launch loses the kickoff (recoverable conversationally; the key makes the kickoff safely retryable and closes both).
- No `SetupNewState` linkage to the session, and no docs updates yet.
- Telemetry only adjusts the existing `setup_starter_tasks_submitted` event.

## Testing

- Rewrote `starter-tasks.test.ts` (command ordering, dedupe, empty selection, completion failure) and updated `StepInvoke.client.test.tsx` (22 tests).
- Full cloud-agents fast-agent suite passes (263 tests), plus `check-types:fast`, `lint:fast`, and `knip`.
- Not yet exercised end to end in a live deployment; the main thing to vibe-check is whether the welcome closeout duplicates the auto-posted kickoff cards.
