### PR TITLE
feat: make a freshly enabled Memory usable within minutes

### DIFF
--- a/apps/api/src/handlers/github/__tests__/handleInstallationCreated.test.ts
+++ b/apps/api/src/handlers/github/__tests__/handleInstallationCreated.test.ts
@@ -1,8 +1,12 @@
-const { mockCompletePendingGitHubInstallation, mockSendUserDirectMessage } =
-  vi.hoisted(() => ({
-    mockCompletePendingGitHubInstallation: vi.fn(),
-    mockSendUserDirectMessage: vi.fn(),
-  }));
+const {
+  mockCompletePendingGitHubInstallation,
+  mockSendUserDirectMessage,
+  mockRequestBrainBackfill,
+} = vi.hoisted(() => ({
+  mockCompletePendingGitHubInstallation: vi.fn(),
+  mockSendUserDirectMessage: vi.fn(),
+  mockRequestBrainBackfill: vi.fn(async () => undefined),
+}));
 
 vi.mock('@roomote/github', () => ({
   completePendingGitHubInstallation: mockCompletePendingGitHubInstallation,
@@ -10,6 +14,10 @@ vi.mock('@roomote/github', () => ({
 
 vi.mock('@roomote/sdk/server', () => ({
   sendUserDirectMessageBestEffort: mockSendUserDirectMessage,
+}));
+
+vi.mock('@roomote/sdk/server/request-instance-ping', () => ({
+  requestBrainBackfill: mockRequestBrainBackfill,
 }));
 
 vi.mock('@roomote/env', () => ({
@@ -58,6 +66,19 @@ describe('handleInstallationCreated', () => {
 
     expect(response).toEqual({ status: 'ok' });
     expect(mockSendUserDirectMessage).not.toHaveBeenCalled();
+  });
+
+  it('kicks the Memory backfill for pending and direct installs alike', async () => {
+    mockCompletePendingGitHubInstallation.mockResolvedValue({
+      success: false,
+      error: 'no pending installation',
+    });
+
+    await handleInstallationCreated(payload);
+
+    expect(mockRequestBrainBackfill).toHaveBeenCalledWith(
+      'github-installation-created',
+    );
   });
 
   it('still acks the webhook when completion throws', async () => {

--- a/apps/api/src/handlers/github/handleInstallationCreated.ts
+++ b/apps/api/src/handlers/github/handleInstallationCreated.ts
@@ -1,5 +1,6 @@
 import { completePendingGitHubInstallation } from '@roomote/github';
 import { sendUserDirectMessageBestEffort } from '@roomote/sdk/server';
+import { requestBrainBackfill } from '@roomote/sdk/server/request-instance-ping';
 import { Env } from '@roomote/env';
 
 import type { WebhookResponse } from '../../types';
@@ -19,6 +20,12 @@ export async function handleInstallationCreated(
     const result = await completePendingGitHubInstallation(
       payload.installation.id,
     );
+
+    // The webhook is the universal completion point for new installations
+    // (pending-approval and direct installs alike): repositories just became
+    // reachable, so start Memory ingestion now rather than waiting out the
+    // 15-minute schedules.
+    void requestBrainBackfill('github-installation-created');
 
     if (result.success) {
       // The requester was waiting on a GitHub org owner's approval; let them

--- a/apps/web/src/trpc/commands/github/mutations.test.ts
+++ b/apps/web/src/trpc/commands/github/mutations.test.ts
@@ -80,6 +80,10 @@ vi.mock('@roomote/sdk/server/automation-recommendations', () => ({
   enqueueAutomationSignalPrefetch: vi.fn(async () => undefined),
 }));
 
+vi.mock('@roomote/sdk/server/request-instance-ping', () => ({
+  requestBrainBackfill: vi.fn(async () => undefined),
+}));
+
 import {
   finishCreateGitHubAppManifestCommand,
   resolvePendingGitHubInstallationsCommand,

--- a/apps/web/src/trpc/commands/github/mutations.ts
+++ b/apps/web/src/trpc/commands/github/mutations.ts
@@ -5,6 +5,7 @@ import { createAuthToken } from '@roomote/auth';
 import * as GitHub from '@roomote/github';
 import { createClient } from '@roomote/sdk/client';
 import { enqueueAutomationSignalPrefetch } from '@roomote/sdk/server/automation-recommendations';
+import { requestBrainBackfill } from '@roomote/sdk/server/request-instance-ping';
 import { isLoopbackHostname } from '@roomote/types';
 import {
   db,
@@ -674,6 +675,8 @@ export async function enableGitHubAppCommand(
       );
 
       if (results.some((result) => result.success)) {
+        // Repositories just came back online for Memory ingestion.
+        void requestBrainBackfill('github-connected');
         return { success: true, mode: 'synced' };
       }
     }
@@ -822,6 +825,12 @@ export async function resolvePendingGitHubInstallationsCommand(
     const result = await GitHub.resolvePendingGitHubInstallations({
       userId: auth.userId,
     });
+
+    if (result.completed > 0) {
+      // A pending installation just resolved into live repositories — start
+      // Memory ingestion now rather than waiting out the 15-minute schedules.
+      void requestBrainBackfill('github-connected');
+    }
 
     return { success: true, ...result };
   } catch (error) {

--- a/apps/web/src/trpc/commands/setup/index.test.ts
+++ b/apps/web/src/trpc/commands/setup/index.test.ts
@@ -82,6 +82,7 @@ vi.mock('@roomote/cloud-agents/server', () => ({
 
 vi.mock('@roomote/sdk/server/request-instance-ping', () => ({
   requestInstancePing: (...args: unknown[]) => mockRequestInstancePing(...args),
+  requestBrainBackfill: vi.fn(async () => undefined),
 }));
 
 vi.mock('@roomote/telemetry/server', () => ({

--- a/apps/web/src/trpc/commands/setup/index.ts
+++ b/apps/web/src/trpc/commands/setup/index.ts
@@ -17,7 +17,10 @@ import {
   type EnvironmentConfig,
   normalizeSetupNewState,
 } from '@roomote/types';
-import { requestInstancePing } from '@roomote/sdk/server/request-instance-ping';
+import {
+  requestBrainBackfill,
+  requestInstancePing,
+} from '@roomote/sdk/server/request-instance-ping';
 import {
   captureActivationEnvironmentSaved,
   captureActivationSetupCompleted,
@@ -527,6 +530,12 @@ export async function completeSetupCommand(
   // Ping service sees the founding admin within minutes instead of at the
   // next daily tick.
   void requestInstancePing('setup-completed');
+
+  // Sources typically get connected during setup, and no toggle fires
+  // afterwards — kick the initial Memory backfill now so a fresh deployment's
+  // brain starts filling the moment setup finishes. No-ops harmlessly when
+  // Memory is off; the jobs hold their checkpoints.
+  void requestBrainBackfill('setup-completed');
 
   if (
     (input?.productUpdatesEnabled ?? true) &&

--- a/apps/web/src/trpc/commands/source-control/index.ts
+++ b/apps/web/src/trpc/commands/source-control/index.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from 'node:crypto';
 
+import { requestBrainBackfill } from '@roomote/sdk/server/request-instance-ping';
 import * as Ado from '@roomote/ado';
 import * as Bitbucket from '@roomote/bitbucket';
 import * as Gitea from '@roomote/gitea';
@@ -1010,7 +1011,7 @@ export async function saveSourceControlConfigCommand(
     allowIncompleteDelegated: true,
   });
 
-  return db.transaction(async (tx) => {
+  const result = await db.transaction(async (tx) => {
     const providerStatus = await saveSourceControlConfigValues({
       executor: tx,
       actorUserId: auth.userId,
@@ -1024,6 +1025,15 @@ export async function saveSourceControlConfigCommand(
       configSatisfied: providerStatus.configSatisfied,
     };
   });
+
+  if (result.configSatisfied) {
+    // A newly satisfied provider config means repositories (and their PRs
+    // and issues) just became reachable — start Memory ingestion now rather
+    // than waiting out the 15-minute schedules.
+    void requestBrainBackfill('source-control-connected');
+  }
+
+  return result;
 }
 
 type ClearSourceControlConfigWarning = {

--- a/apps/web/src/trpc/commands/source-control/index.ts
+++ b/apps/web/src/trpc/commands/source-control/index.ts
@@ -1026,12 +1026,13 @@ export async function saveSourceControlConfigCommand(
     };
   });
 
-  if (result.configSatisfied) {
-    // A newly satisfied provider config means repositories (and their PRs
-    // and issues) just became reachable — start Memory ingestion now rather
-    // than waiting out the 15-minute schedules.
-    void requestBrainBackfill('source-control-connected');
-  }
+  // A successful save means every required value is satisfied (the save
+  // throws otherwise), and `result.configSatisfied` reflects the state
+  // BEFORE this save — so kick unconditionally: repositories (and their PRs
+  // and issues) may have just become reachable, and Memory ingestion should
+  // start now rather than waiting out the 15-minute schedules. Harmless when
+  // nothing changed; the jobs are idempotent and no-op without Memory.
+  void requestBrainBackfill('source-control-connected');
 
   return result;
 }

--- a/packages/sdk/src/server/lib/__tests__/brain-corpus.test.ts
+++ b/packages/sdk/src/server/lib/__tests__/brain-corpus.test.ts
@@ -228,15 +228,17 @@ describe('readBrainCorpus', () => {
       await readBrainCorpus();
       expect(fetchMock).toHaveBeenCalledTimes(1);
 
-      // First ingestion lands moments later; the next read past the short
-      // window re-walks instead of serving "nothing here" for ten minutes.
+      // First ingestion lands moments later; the very next read past the
+      // short window awaits a fresh walk and returns the new pages, rather
+      // than serving "nothing here" once more via stale-while-revalidate.
       vi.advanceTimersByTime(31_000);
       const windows = [windowOf(0, 42)];
       fetchMock.mockImplementation(async () =>
         toolResponse(windows.shift() ?? []),
       );
-      await readBrainCorpus();
-      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+      const third = await readBrainCorpus();
+      expect(third?.pages).toHaveLength(42);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/sdk/src/server/lib/__tests__/brain-corpus.test.ts
+++ b/packages/sdk/src/server/lib/__tests__/brain-corpus.test.ts
@@ -213,6 +213,48 @@ describe('readBrainCorpus', () => {
     expect(redisSet).toHaveBeenCalledTimes(1);
   });
 
+  it('serves an empty census but neither stores it nor trusts it for the full TTL', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchMock = vi.fn(async () => toolResponse([]));
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const first = await readBrainCorpus();
+      expect(first?.pages).toEqual([]);
+      expect(redisSet).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // Within the short window the empty snapshot is served from memory.
+      await readBrainCorpus();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // First ingestion lands moments later; the next read past the short
+      // window re-walks instead of serving "nothing here" for ten minutes.
+      vi.advanceTimersByTime(31_000);
+      const windows = [windowOf(0, 42)];
+      fetchMock.mockImplementation(async () =>
+        toolResponse(windows.shift() ?? []),
+      );
+      await readBrainCorpus();
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('re-walks instead of hydrating a stored empty census', async () => {
+    redisGet.mockResolvedValue(
+      JSON.stringify({ generatedAt: new Date().toISOString(), pages: [] }),
+    );
+    const fetchMock = vi.fn(async () => toolResponse(windowOf(0, 3)));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const snapshot = await readBrainCorpus();
+
+    expect(snapshot?.pages).toHaveLength(3);
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
   it('hydrates a completed census from shared storage without listing again', async () => {
     redisGet.mockResolvedValue(
       JSON.stringify({

--- a/packages/sdk/src/server/lib/brain-corpus.ts
+++ b/packages/sdk/src/server/lib/brain-corpus.ts
@@ -403,6 +403,15 @@ export async function readBrainCorpus(): Promise<BrainCorpusSnapshot | null> {
   };
 
   if (corpusCache.snapshot) {
+    // An expired empty snapshot must not ride stale-while-revalidate: the
+    // whole point of its short TTL is that first ingestion is probably
+    // landing right now, and serving "nothing here" once more while the
+    // refresh runs re-creates the empty settings page this path exists to
+    // avoid. The awaited walk is cheap — the corpus was empty moments ago.
+    if (corpusCache.snapshot.pages.length === 0) {
+      return (await refresh()) ?? corpusCache.snapshot;
+    }
+
     void refresh();
     return corpusCache.snapshot;
   }

--- a/packages/sdk/src/server/lib/brain-corpus.ts
+++ b/packages/sdk/src/server/lib/brain-corpus.ts
@@ -368,10 +368,18 @@ export async function readBrainCorpus(): Promise<BrainCorpusSnapshot | null> {
 
       const snapshot = await fetchBrainCorpus(resolved);
 
-      if (snapshot) {
+      if (snapshot && snapshot.pages.length > 0) {
         corpusCache.snapshot = snapshot;
         corpusCache.expiresAtMs = Date.now() + CORPUS_CACHE_TTL_MS;
         await storeCorpus(resolved, snapshot);
+      } else if (snapshot) {
+        // An empty census is served but never trusted for the full TTL: a
+        // brain's first ingestion typically lands minutes after the first
+        // (empty) settings-page read, and a ten-minute cached "nothing here"
+        // makes fresh Memory look broken. An empty walk is also the cheapest
+        // walk (one call), so re-reading soon costs nothing.
+        corpusCache.snapshot = snapshot;
+        corpusCache.expiresAtMs = Date.now() + CORPUS_FAILURE_CACHE_TTL_MS;
       } else {
         corpusCache.expiresAtMs = Date.now() + CORPUS_FAILURE_CACHE_TTL_MS;
       }
@@ -410,7 +418,9 @@ export async function readBrainCorpus(): Promise<BrainCorpusSnapshot | null> {
 
       const stored = await readStoredCorpus(connection);
 
-      if (!stored) {
+      // A stored empty census (including ones persisted before empties
+      // stopped being stored) is as cheap to redo as to trust — walk fresh.
+      if (!stored || stored.snapshot.pages.length === 0) {
         return refresh(connection);
       }
 


### PR DESCRIPTION
Follow-up to #1833, closing the two remaining gaps between "Memory enabled" and "usable brain".

## 1. Ingestion kicks off automatically — no off/on toggle required

#1833 kicked the backfill from the Settings enable mutation, but a deployment provisioned with Memory already on never fires that mutation, and connecting a source after enabling waited on the 15-minute schedules. `requestBrainBackfill` now also fires from:

- **Setup completion** (`setup/index.ts`) — the standard onboarding path
- **Source-control config satisfied** (`saveSourceControlConfigCommand`) — GitLab/Bitbucket/Gitea/ADO connects
- **GitHub `installation.created` webhook** (`handleInstallationCreated`) — the universal completion point for new installs, pending-approval and direct alike
- **Pending-installation resolution** and **GitHub App re-enable** (`resolvePendingGitHubInstallationsCommand`, `enableGitHubAppCommand`)

All fire-and-forget with per-minute debounce ids; jobs are idempotent and no-op when Memory is off.

## 2. First ingestion is visible immediately — no more 5-7 minute empty page

The /settings/memory corpus listing cached a successful-but-**empty** census for the full 10-minute TTL and persisted it to Redis without expiry, so pages written moments later stayed invisible (observed live: 74 PR facts landed at 05:06, UI showed "Nothing collected yet" until ~05:14). Verified against a live gbrain that `put_page` → `list_pages` is read-your-writes consistent, so the lag was entirely this cache. Now:

- an empty census is served only for the short 30s failure window, never the 10-minute TTL
- empty censuses are not persisted to Redis
- a previously stored empty census is re-walked instead of hydrated

An empty walk is a single `list_pages` call, so re-reading costs nothing.

## Testing

- New tests: empty-census TTL/persistence behavior, stored-empty re-walk, webhook backfill kick
- Updated mocks in setup/github/api tests
- `pnpm lint` and `pnpm check-types` clean