### PR TITLE
[Fix] Stacked pending PR-review action cards in sessions

### DIFF
--- a/packages/db/src/lib/__tests__/pr-review-notification-units.test.ts
+++ b/packages/db/src/lib/__tests__/pr-review-notification-units.test.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import {
   and,
   attachCanonicalPrReviewActionMessage,
@@ -994,5 +996,97 @@ describe('canonical PR review notification ownership', () => {
       destinationKey,
       taskId: task.id,
     });
+  });
+
+  it('retires older awaiting actions in the same destination when a new one attaches', async () => {
+    const sessionConversation = `supersede-session-${randomUUID()}`;
+    const otherConversation = `supersede-other-${randomUUID()}`;
+    const fastParentPayload = (conversationId: string) => ({
+      fastAgentParent: {
+        sessionId: '11111111-1111-4111-8111-111111111111',
+        conversation: {
+          surface: 'web' as const,
+          workspaceId: 'user-1',
+          conversationId,
+        },
+      },
+    });
+
+    const postAction = async (repository: string) => {
+      const claim = (await claimForRepository(repository)).find(
+        ({ repository: claimedRepository }) => claimedRepository === repository,
+      );
+      if (!claim || claim.ownershipVersion !== 'canonical') {
+        throw new Error('expected canonical claim');
+      }
+      await transitionCanonicalPrReviewDelivery({
+        deliveryId: claim.deliveryId,
+        leaseToken: claim.leaseToken,
+        expected: 'claimed',
+        status: 'prepared',
+      });
+      await transitionCanonicalPrReviewDelivery({
+        deliveryId: claim.deliveryId,
+        leaseToken: claim.leaseToken,
+        expected: 'prepared',
+        status: 'prompt_posting',
+        values: { followUpPrompt: 'Resolve the feedback.' },
+      });
+      await expect(
+        attachCanonicalPrReviewActionMessage(
+          claim.deliveryId,
+          claim.deliveryId,
+          claim.leaseToken,
+        ),
+      ).resolves.toBe(true);
+      return claim.deliveryId;
+    };
+    const statusOf = async (deliveryId: string) =>
+      (
+        await db.query.prReviewNotificationDeliveries.findFirst({
+          where: eq(prReviewNotificationDeliveries.id, deliveryId),
+          columns: { status: true },
+        })
+      )?.status;
+
+    const setups = await Promise.all(
+      [
+        { conversationId: sessionConversation, prNumber: 21 },
+        { conversationId: sessionConversation, prNumber: 22 },
+        { conversationId: otherConversation, prNumber: 23 },
+      ].map(async ({ conversationId, prNumber }) => {
+        const task = await taskFactory.create();
+        const repository = `owner/supersede-${task.id}`;
+        await Promise.all([
+          runFactory.create({
+            taskId: task.id,
+            payload: fastParentPayload(conversationId),
+          }),
+          associate(task.id, repository, prNumber),
+        ]);
+        await persistPrReviewEvent(
+          eventInput({
+            repository,
+            prNumber,
+            eventKey: `supersede-${task.id}`,
+          }),
+        );
+        return repository;
+      }),
+    );
+
+    const otherDeliveryId = await postAction(setups[2]!);
+    const firstDeliveryId = await postAction(setups[0]!);
+    const secondDeliveryId = await postAction(setups[1]!);
+
+    // The newest offer in the session stays actionable; the older one is
+    // retired, and a different conversation's offer is untouched.
+    await expect(statusOf(firstDeliveryId)).resolves.toBe('dismissed');
+    await expect(statusOf(secondDeliveryId)).resolves.toBe(
+      'awaiting_user_action',
+    );
+    await expect(statusOf(otherDeliveryId)).resolves.toBe(
+      'awaiting_user_action',
+    );
   });
 });

--- a/packages/db/src/lib/__tests__/pr-review-notification-units.test.ts
+++ b/packages/db/src/lib/__tests__/pr-review-notification-units.test.ts
@@ -9,6 +9,8 @@ import {
   db,
   deferPrReviewDeliveries,
   eq,
+  fastAgentConversations,
+  fastAgentMessages,
   findPrReviewAutoPreference,
   lockPrReviewReference,
   persistPrReviewEvent,
@@ -998,95 +1000,182 @@ describe('canonical PR review notification ownership', () => {
     });
   });
 
+  const fastParentPayload = (conversationId: string) => ({
+    fastAgentParent: {
+      sessionId: '11111111-1111-4111-8111-111111111111',
+      conversation: {
+        surface: 'web' as const,
+        workspaceId: 'user-1',
+        conversationId,
+      },
+    },
+  });
+
+  const setUpSessionDelivery = async (input: {
+    conversationId: string;
+    prNumber: number;
+  }) => {
+    const task = await taskFactory.create();
+    const repository = `owner/supersede-${task.id}`;
+    await Promise.all([
+      runFactory.create({
+        taskId: task.id,
+        payload: fastParentPayload(input.conversationId),
+      }),
+      associate(task.id, repository, input.prNumber),
+    ]);
+    await persistPrReviewEvent(
+      eventInput({
+        repository,
+        prNumber: input.prNumber,
+        eventKey: `supersede-${task.id}`,
+      }),
+    );
+    return repository;
+  };
+
+  const claimToPromptPosting = async (repository: string) => {
+    const claim = (await claimForRepository(repository)).find(
+      ({ repository: claimedRepository }) => claimedRepository === repository,
+    );
+    if (!claim || claim.ownershipVersion !== 'canonical') {
+      throw new Error('expected canonical claim');
+    }
+    await transitionCanonicalPrReviewDelivery({
+      deliveryId: claim.deliveryId,
+      leaseToken: claim.leaseToken,
+      expected: 'claimed',
+      status: 'prepared',
+    });
+    await transitionCanonicalPrReviewDelivery({
+      deliveryId: claim.deliveryId,
+      leaseToken: claim.leaseToken,
+      expected: 'prepared',
+      status: 'prompt_posting',
+      values: { followUpPrompt: 'Resolve the feedback.' },
+    });
+    return claim;
+  };
+
+  const postAction = async (repository: string) => {
+    const claim = await claimToPromptPosting(repository);
+    await expect(
+      attachCanonicalPrReviewActionMessage(
+        claim.deliveryId,
+        claim.deliveryId,
+        claim.leaseToken,
+      ),
+    ).resolves.toBe(true);
+    return claim.deliveryId;
+  };
+
+  const deliveryStatusOf = async (deliveryId: string) =>
+    (
+      await db.query.prReviewNotificationDeliveries.findFirst({
+        where: eq(prReviewNotificationDeliveries.id, deliveryId),
+        columns: { status: true },
+      })
+    )?.status;
+
   it('retires older awaiting actions in the same destination when a new one attaches', async () => {
     const sessionConversation = `supersede-session-${randomUUID()}`;
     const otherConversation = `supersede-other-${randomUUID()}`;
-    const fastParentPayload = (conversationId: string) => ({
-      fastAgentParent: {
-        sessionId: '11111111-1111-4111-8111-111111111111',
-        conversation: {
-          surface: 'web' as const,
-          workspaceId: 'user-1',
-          conversationId,
-        },
-      },
-    });
 
-    const postAction = async (repository: string) => {
-      const claim = (await claimForRepository(repository)).find(
-        ({ repository: claimedRepository }) => claimedRepository === repository,
-      );
-      if (!claim || claim.ownershipVersion !== 'canonical') {
-        throw new Error('expected canonical claim');
-      }
-      await transitionCanonicalPrReviewDelivery({
-        deliveryId: claim.deliveryId,
-        leaseToken: claim.leaseToken,
-        expected: 'claimed',
-        status: 'prepared',
-      });
-      await transitionCanonicalPrReviewDelivery({
-        deliveryId: claim.deliveryId,
-        leaseToken: claim.leaseToken,
-        expected: 'prepared',
-        status: 'prompt_posting',
-        values: { followUpPrompt: 'Resolve the feedback.' },
-      });
-      await expect(
-        attachCanonicalPrReviewActionMessage(
-          claim.deliveryId,
-          claim.deliveryId,
-          claim.leaseToken,
-        ),
-      ).resolves.toBe(true);
-      return claim.deliveryId;
-    };
-    const statusOf = async (deliveryId: string) =>
-      (
-        await db.query.prReviewNotificationDeliveries.findFirst({
-          where: eq(prReviewNotificationDeliveries.id, deliveryId),
-          columns: { status: true },
-        })
-      )?.status;
-
-    const setups = await Promise.all(
+    const [first, second, other] = await Promise.all(
       [
         { conversationId: sessionConversation, prNumber: 21 },
         { conversationId: sessionConversation, prNumber: 22 },
         { conversationId: otherConversation, prNumber: 23 },
-      ].map(async ({ conversationId, prNumber }) => {
-        const task = await taskFactory.create();
-        const repository = `owner/supersede-${task.id}`;
-        await Promise.all([
-          runFactory.create({
-            taskId: task.id,
-            payload: fastParentPayload(conversationId),
-          }),
-          associate(task.id, repository, prNumber),
-        ]);
-        await persistPrReviewEvent(
-          eventInput({
-            repository,
-            prNumber,
-            eventKey: `supersede-${task.id}`,
-          }),
-        );
-        return repository;
-      }),
+      ].map(setUpSessionDelivery),
     );
 
-    const otherDeliveryId = await postAction(setups[2]!);
-    const firstDeliveryId = await postAction(setups[0]!);
-    const secondDeliveryId = await postAction(setups[1]!);
+    const otherDeliveryId = await postAction(other!);
+    const firstDeliveryId = await postAction(first!);
+
+    // The rendered session card caches the offer status in the transcript
+    // message payload; retirement must dismiss it there too.
+    const user = await userFactory.create();
+    const [conversation] = await db
+      .insert(fastAgentConversations)
+      .values({
+        userId: user.id,
+        surface: 'web',
+        workspaceId: user.id,
+        conversationId: `supersede-transcript-${randomUUID()}`,
+      })
+      .returning();
+    await db.insert(fastAgentMessages).values({
+      conversationId: conversation!.id,
+      eventId: 'turn-1:assistant:0',
+      turnId: 'turn-1',
+      turnSeq: 1,
+      ts: 1,
+      eventType: 'roomote_runtime.assistant_message',
+      role: 'assistant',
+      contentBlocks: [{ type: 'text', text: 'Resolve these CI failures?' }],
+      metadata: { visibleInTranscript: true },
+      payload: {
+        prReviewAction: { deliveryId: firstDeliveryId, status: 'pending' },
+      },
+      source: 'web',
+    });
+
+    const secondDeliveryId = await postAction(second!);
 
     // The newest offer in the session stays actionable; the older one is
     // retired, and a different conversation's offer is untouched.
-    await expect(statusOf(firstDeliveryId)).resolves.toBe('dismissed');
-    await expect(statusOf(secondDeliveryId)).resolves.toBe(
+    await expect(deliveryStatusOf(firstDeliveryId)).resolves.toBe('dismissed');
+    await expect(deliveryStatusOf(secondDeliveryId)).resolves.toBe(
       'awaiting_user_action',
     );
-    await expect(statusOf(otherDeliveryId)).resolves.toBe(
+    await expect(deliveryStatusOf(otherDeliveryId)).resolves.toBe(
       'awaiting_user_action',
     );
+    await expect(
+      db.query.fastAgentMessages.findFirst({
+        where: eq(fastAgentMessages.conversationId, conversation!.id),
+        columns: { payload: true },
+      }),
+    ).resolves.toMatchObject({
+      payload: {
+        prReviewAction: { deliveryId: firstDeliveryId, status: 'dismissed' },
+      },
+    });
+  });
+
+  it('keeps exactly one awaiting offer when two actions attach concurrently', async () => {
+    const sessionConversation = `supersede-race-${randomUUID()}`;
+
+    const [firstRepository, secondRepository] = await Promise.all(
+      [
+        { conversationId: sessionConversation, prNumber: 31 },
+        { conversationId: sessionConversation, prNumber: 32 },
+      ].map(setUpSessionDelivery),
+    );
+    const firstClaim = await claimToPromptPosting(firstRepository!);
+    const secondClaim = await claimToPromptPosting(secondRepository!);
+
+    await expect(
+      Promise.all([
+        attachCanonicalPrReviewActionMessage(
+          firstClaim.deliveryId,
+          firstClaim.deliveryId,
+          firstClaim.leaseToken,
+        ),
+        attachCanonicalPrReviewActionMessage(
+          secondClaim.deliveryId,
+          secondClaim.deliveryId,
+          secondClaim.leaseToken,
+        ),
+      ]),
+    ).resolves.toEqual([true, true]);
+
+    const statuses = await Promise.all(
+      [firstClaim.deliveryId, secondClaim.deliveryId].map(deliveryStatusOf),
+    );
+    expect(statuses.filter((s) => s === 'awaiting_user_action')).toHaveLength(
+      1,
+    );
+    expect(statuses.filter((s) => s === 'dismissed')).toHaveLength(1);
   });
 });

--- a/packages/db/src/lib/pr-review-notification-units.ts
+++ b/packages/db/src/lib/pr-review-notification-units.ts
@@ -11,6 +11,7 @@ import {
 
 import { db, type DatabaseOrTransaction } from '../db';
 import {
+  fastAgentMessages,
   prReviewAutoPreferences,
   prReviewEvents,
   prReviewNotificationDeliveries,
@@ -1194,41 +1195,65 @@ export async function getCanonicalPrReviewAction(deliveryId: string): Promise<{
  * older awaiting offer in the same destination conversation, mirroring the
  * legacy Redis path's claim-older-offers-on-attach semantics. Only the newest
  * offer in a conversation stays actionable; earlier ones would otherwise
- * accumulate as a stack of pending cards.
+ * accumulate as a stack of pending cards. Attach and retirement run in one
+ * transaction serialized per destination (claims are only serialized per
+ * repository/PR, so concurrent attaches into the same conversation would
+ * otherwise dismiss each other), and retired offers' cached transcript
+ * payloads are dismissed so already-rendered session cards deactivate.
  */
 export async function attachCanonicalPrReviewActionMessage(
   deliveryId: string,
   messageId: string,
   leaseToken: string,
 ): Promise<boolean> {
-  const rows = await db
-    .update(prReviewNotificationDeliveries)
-    .set({
-      providerMessageId: messageId,
-      status: 'awaiting_user_action',
-      leaseToken: null,
-      leaseExpiresAt: null,
-      updatedAt: new Date(),
-    })
-    .where(
-      and(
-        eq(prReviewNotificationDeliveries.id, deliveryId),
-        eq(prReviewNotificationDeliveries.leaseToken, leaseToken),
-        eq(prReviewNotificationDeliveries.status, 'prompt_posting'),
-      ),
-    )
-    .returning({
-      id: prReviewNotificationDeliveries.id,
-      destinationKind: prReviewNotificationDeliveries.destinationKind,
-      destinationKey: prReviewNotificationDeliveries.destinationKey,
+  return db.transaction(async (tx) => {
+    const delivery = await tx.query.prReviewNotificationDeliveries.findFirst({
+      where: eq(prReviewNotificationDeliveries.id, deliveryId),
+      columns: { destinationKind: true, destinationKey: true },
     });
-  const attached = rows[0];
-  if (!attached) {
-    return false;
-  }
+    if (!delivery) {
+      return false;
+    }
 
-  if (attached.destinationKind && attached.destinationKey) {
-    await db
+    const destination =
+      delivery.destinationKind && delivery.destinationKey
+        ? {
+            kind: delivery.destinationKind,
+            key: delivery.destinationKey,
+          }
+        : null;
+    if (destination) {
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtextextended(${`pr-review-destination:${destination.kind}:${destination.key}`}, 0))`,
+      );
+    }
+
+    const rows = await tx
+      .update(prReviewNotificationDeliveries)
+      .set({
+        providerMessageId: messageId,
+        status: 'awaiting_user_action',
+        leaseToken: null,
+        leaseExpiresAt: null,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(prReviewNotificationDeliveries.id, deliveryId),
+          eq(prReviewNotificationDeliveries.leaseToken, leaseToken),
+          eq(prReviewNotificationDeliveries.status, 'prompt_posting'),
+        ),
+      )
+      .returning({ id: prReviewNotificationDeliveries.id });
+    if (rows.length !== 1) {
+      return false;
+    }
+
+    if (!destination) {
+      return true;
+    }
+
+    const retired = await tx
       .update(prReviewNotificationDeliveries)
       .set({
         status: 'dismissed',
@@ -1239,20 +1264,32 @@ export async function attachCanonicalPrReviewActionMessage(
       .where(
         and(
           eq(prReviewNotificationDeliveries.status, 'awaiting_user_action'),
-          eq(
-            prReviewNotificationDeliveries.destinationKind,
-            attached.destinationKind,
-          ),
-          eq(
-            prReviewNotificationDeliveries.destinationKey,
-            attached.destinationKey,
-          ),
-          ne(prReviewNotificationDeliveries.id, attached.id),
+          eq(prReviewNotificationDeliveries.destinationKind, destination.kind),
+          eq(prReviewNotificationDeliveries.destinationKey, destination.key),
+          ne(prReviewNotificationDeliveries.id, deliveryId),
         ),
-      );
-  }
+      )
+      .returning({ id: prReviewNotificationDeliveries.id });
 
-  return true;
+    if (retired.length > 0) {
+      // Session cards render from the cached message payload, so retiring
+      // the delivery rows alone would leave the old cards actionable.
+      await tx
+        .update(fastAgentMessages)
+        .set({
+          payload: sql`jsonb_set(coalesce(${fastAgentMessages.payload}, '{}'::jsonb), '{prReviewAction,status}', to_jsonb('dismissed'::text), true)`,
+          updatedAt: sql`now()`,
+        })
+        .where(
+          inArray(
+            sql<string>`${fastAgentMessages.payload} -> 'prReviewAction' ->> 'deliveryId'`,
+            retired.map(({ id }) => id),
+          ),
+        );
+    }
+
+    return true;
+  });
 }
 
 export async function claimCanonicalPrReviewAction(input: {

--- a/packages/db/src/lib/pr-review-notification-units.ts
+++ b/packages/db/src/lib/pr-review-notification-units.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-import { and, desc, eq, gt, inArray, isNull, lte, sql } from 'drizzle-orm';
+import { and, desc, eq, gt, inArray, isNull, lte, ne, sql } from 'drizzle-orm';
 
 import {
   activeRunStatuses,
@@ -1189,6 +1189,13 @@ export async function getCanonicalPrReviewAction(deliveryId: string): Promise<{
   return row ?? null;
 }
 
+/**
+ * Marks the posted canonical action as awaiting the user and retires every
+ * older awaiting offer in the same destination conversation, mirroring the
+ * legacy Redis path's claim-older-offers-on-attach semantics. Only the newest
+ * offer in a conversation stays actionable; earlier ones would otherwise
+ * accumulate as a stack of pending cards.
+ */
 export async function attachCanonicalPrReviewActionMessage(
   deliveryId: string,
   messageId: string,
@@ -1210,8 +1217,42 @@ export async function attachCanonicalPrReviewActionMessage(
         eq(prReviewNotificationDeliveries.status, 'prompt_posting'),
       ),
     )
-    .returning({ id: prReviewNotificationDeliveries.id });
-  return rows.length === 1;
+    .returning({
+      id: prReviewNotificationDeliveries.id,
+      destinationKind: prReviewNotificationDeliveries.destinationKind,
+      destinationKey: prReviewNotificationDeliveries.destinationKey,
+    });
+  const attached = rows[0];
+  if (!attached) {
+    return false;
+  }
+
+  if (attached.destinationKind && attached.destinationKey) {
+    await db
+      .update(prReviewNotificationDeliveries)
+      .set({
+        status: 'dismissed',
+        actionClaimedAt: new Date(),
+        completedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(prReviewNotificationDeliveries.status, 'awaiting_user_action'),
+          eq(
+            prReviewNotificationDeliveries.destinationKind,
+            attached.destinationKind,
+          ),
+          eq(
+            prReviewNotificationDeliveries.destinationKey,
+            attached.destinationKey,
+          ),
+          ne(prReviewNotificationDeliveries.id, attached.id),
+        ),
+      );
+  }
+
+  return true;
 }
 
 export async function claimCanonicalPrReviewAction(input: {


### PR DESCRIPTION
## Problem

Each PR-feedback event (failing CI check, new review comments) creates a canonical PR-review action delivery. On web sessions, every one of them rendered as its own pending "Would you like me to resolve these issues?" card and stayed actionable forever, so repeated CI reports for the same PR stacked an unbounded pile of identical cards.

The legacy Redis path already handles this: attaching a new offer atomically claims every older offer for the same conversation. The canonical DB path that backs session cards never got the equivalent, so only a user reply retired old offers.

## Fix

`attachCanonicalPrReviewActionMessage` now retires (dismisses) older `awaiting_user_action` deliveries for the same `destinationKind`/`destinationKey` when a new action attaches, so only the newest offer in a conversation stays actionable. Offers in other conversations are untouched.

## Testing

- New real-database test: two offers to the same Fast web conversation plus one to a different conversation; attaching the second retires the first and leaves the other conversation's offer awaiting.
- `pnpm check-types:fast`, `pnpm lint:fast`, `pnpm knip`, and repo-wide `format:check` pass.