### PR TITLE
[Feat] Render database property values into Notion Memory pages

### DIFF
--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-notion.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-notion.test.ts
@@ -83,6 +83,68 @@ describe('Notion page mapping', () => {
     expect(mapped?.content).toContain('## Decision\n\nShip the collector.');
   });
 
+  it('renders database property values into the page body', () => {
+    const users = buildNotionUserReferences(
+      [{ id: 'notion-ada', name: 'Ada', email: null }],
+      new Map(),
+    );
+    const mapped = buildNotionPage(
+      {
+        ...page,
+        properties: {
+          ...page.properties,
+          Status: { type: 'status', status: { name: 'In review' } },
+          Priority: { type: 'select', select: { name: 'P1' } },
+          Tags: {
+            type: 'multi_select',
+            multi_select: [{ name: 'infra' }, { name: 'memory' }],
+          },
+          Due: { type: 'date', date: { start: '2026-09-01', end: null } },
+          Effort: { type: 'number', number: 3 },
+          Done: { type: 'checkbox', checkbox: false },
+          Owner: {
+            type: 'people',
+            people: [{ object: 'user', id: 'notion-ada' }],
+          },
+          Blocked: {
+            type: 'relation',
+            relation: [{ id: '12345678-90AB-CDEF-1234-567890ABCD00' }],
+          },
+          Ticket: {
+            type: 'unique_id',
+            unique_id: { prefix: 'ROO', number: 42 },
+          },
+          Score: { type: 'formula', formula: { type: 'number', number: 8.5 } },
+          Empty: { type: 'rich_text', rich_text: [] },
+        },
+      },
+      { markdown: 'Body' },
+      { identityContext: { users, identityLookup: new Map() } },
+    );
+
+    expect(mapped?.content).toContain('## Properties');
+    expect(mapped?.content).toContain('- **Status**: In review');
+    expect(mapped?.content).toContain('- **Priority**: P1');
+    expect(mapped?.content).toContain('- **Tags**: infra, memory');
+    expect(mapped?.content).toContain('- **Due**: 2026-09-01');
+    expect(mapped?.content).toContain('- **Effort**: 3');
+    expect(mapped?.content).toContain('- **Done**: No');
+    expect(mapped?.content).toContain('- **Owner**: Ada');
+    expect(mapped?.content).toContain(
+      '- **Blocked**: [notion/1234567890abcdef1234567890abcd00](notion/1234567890abcdef1234567890abcd00)',
+    );
+    expect(mapped?.content).toContain('- **Ticket**: ROO-42');
+    expect(mapped?.content).toContain('- **Score**: 8.5');
+    // Empty values and the title property never render as property lines.
+    expect(mapped?.content).not.toContain('**Empty**');
+    expect(mapped?.content).not.toContain('**Name**');
+  });
+
+  it('omits the properties section for pages with only a title', () => {
+    const mapped = buildNotionPage(page, { markdown: 'Body' });
+    expect(mapped?.content).not.toContain('## Properties');
+  });
+
   it('emits deterministic person and relation references from page metadata', () => {
     const identities: PersonIdentityRecord[] = [
       {

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-notion.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-notion.test.ts
@@ -140,6 +140,27 @@ describe('Notion page mapping', () => {
     expect(mapped?.content).not.toContain('**Name**');
   });
 
+  it('marks property lists Notion truncated at the inline cap', () => {
+    const mapped = buildNotionPage(
+      {
+        ...page,
+        properties: {
+          ...page.properties,
+          Blocked: {
+            type: 'relation',
+            relation: [{ id: '12345678-90AB-CDEF-1234-567890ABCD00' }],
+            has_more: true,
+          },
+        },
+      },
+      { markdown: 'Body' },
+    );
+
+    expect(mapped?.content).toContain(
+      '- **Blocked**: [notion/1234567890abcdef1234567890abcd00](notion/1234567890abcdef1234567890abcd00) _(Notion truncated this list; open the source page for the rest)_',
+    );
+  });
+
   it('omits the properties section for pages with only a title', () => {
     const mapped = buildNotionPage(page, { markdown: 'Body' });
     expect(mapped?.content).not.toContain('## Properties');

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/notion-pages.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/notion-pages.ts
@@ -721,7 +721,15 @@ function renderNotionPropertyLines(
       const record = asObject(property);
       if (!record || record.type === 'title') return [];
       const value = renderNotionPropertyValue(record, context);
-      return value ? [`- **${name}**: ${value}`] : [];
+      if (!value) return [];
+      // Notion caps inline multi-value properties (relations above all) at
+      // 25 entries and signals the rest with has_more; an unmarked subset
+      // would read as the complete list.
+      const truncated =
+        record.has_more === true
+          ? ' _(Notion truncated this list; open the source page for the rest)_'
+          : '';
+      return [`- **${name}**: ${value}${truncated}`];
     })
     .sort((a, b) => a.localeCompare(b));
 }

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/notion-pages.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/notion-pages.ts
@@ -596,6 +596,136 @@ function notionPageEntityReferences(
   };
 }
 
+function notionDateValue(value: unknown): string | null {
+  const record = asObject(value);
+  const start = record ? asString(record.start) : null;
+  if (!start) return null;
+  const end = asString(record?.end);
+  return end ? `${start} → ${end}` : start;
+}
+
+function notionNamedOptions(value: unknown): string | null {
+  const names = Array.isArray(value)
+    ? value.flatMap((option) => {
+        const name = asString(asObject(option)?.name);
+        return name ? [name] : [];
+      })
+    : [];
+  return names.length > 0 ? names.join(', ') : null;
+}
+
+/**
+ * Human-readable value for one database property, or null when the property
+ * is empty or adds nothing beyond the frontmatter (timestamps and authorship
+ * already have fields there). People resolve through the stored directory and
+ * relations render as Brain slug links so property lines stay meaningful
+ * inside Memory search results.
+ */
+function renderNotionPropertyValue(
+  record: Record<string, unknown>,
+  context: NotionPageIdentityContext,
+): string | null {
+  switch (record.type) {
+    case 'rich_text':
+      return notionRichTextPlainText(record.rich_text) || null;
+    case 'number':
+      return typeof record.number === 'number' ? String(record.number) : null;
+    case 'select':
+    case 'status':
+      return asString(asObject(record[record.type])?.name) ?? null;
+    case 'multi_select':
+      return notionNamedOptions(record.multi_select);
+    case 'date':
+      return notionDateValue(record.date);
+    case 'checkbox':
+      return record.checkbox === true
+        ? 'Yes'
+        : record.checkbox === false
+          ? 'No'
+          : null;
+    case 'url':
+    case 'email':
+    case 'phone_number':
+      return asString(record[record.type]) ?? null;
+    case 'files':
+      return notionNamedOptions(record.files);
+    case 'people': {
+      const names = Array.isArray(record.people)
+        ? record.people.flatMap((user) => {
+            const id = notionUserId(user);
+            const name =
+              (id ? context.users.get(id)?.title : null) ??
+              parseNotionUser(user)?.name ??
+              asString(asObject(user)?.name);
+            return name ? [name] : [];
+          })
+        : [];
+      return names.length > 0 ? names.join(', ') : null;
+    }
+    case 'relation': {
+      const links = Array.isArray(record.relation)
+        ? record.relation.flatMap((relation) => {
+            const id = notionUserId(relation);
+            const slug = id ? notionPageSlug(id) : null;
+            return slug ? [`[${slug}](${slug})`] : [];
+          })
+        : [];
+      return links.length > 0 ? links.join(', ') : null;
+    }
+    case 'unique_id': {
+      const uniqueId = asObject(record.unique_id);
+      if (typeof uniqueId?.number !== 'number') return null;
+      const prefix = asString(uniqueId.prefix);
+      return prefix ? `${prefix}-${uniqueId.number}` : String(uniqueId.number);
+    }
+    case 'formula': {
+      const formula = asObject(record.formula);
+      return formula ? renderNotionPropertyValue(formula, context) : null;
+    }
+    case 'rollup': {
+      const rollup = asObject(record.rollup);
+      if (!rollup) return null;
+      if (rollup.type === 'array' && Array.isArray(rollup.array)) {
+        const values = rollup.array.flatMap((entry) => {
+          const item = asObject(entry);
+          const value = item ? renderNotionPropertyValue(item, context) : null;
+          return value ? [value] : [];
+        });
+        return values.length > 0 ? values.join('; ') : null;
+      }
+      return renderNotionPropertyValue(rollup, context);
+    }
+    // Formula results arrive as {type: 'string' | 'boolean', ...}; plain
+    // strings and dates above cover the other two result shapes.
+    case 'string':
+      return asString(record.string) ?? null;
+    case 'boolean':
+      return record.boolean === true
+        ? 'Yes'
+        : record.boolean === false
+          ? 'No'
+          : null;
+    default:
+      // Timestamps and authorship live in the frontmatter; buttons,
+      // verification, and future property types have no stable text value.
+      return null;
+  }
+}
+
+function renderNotionPropertyLines(
+  page: NotionSearchPage,
+  context: NotionPageIdentityContext,
+): string[] {
+  return Object.entries(page.properties ?? {})
+    .flatMap(([name, property]) => {
+      const record = asObject(property);
+      if (!record || record.type === 'title') return [];
+      const value = renderNotionPropertyValue(record, context);
+      return value ? [`- **${name}**: ${value}`] : [];
+    })
+    .sort((a, b) => a.localeCompare(b));
+}
+
 export function buildNotionPage(
   page: NotionSearchPage,
   markdown: NotionMarkdownResponse,
@@ -619,10 +749,11 @@ export function buildNotionPage(
   const updatedAt = parseDate(page.last_edited_time) ?? createdAt;
   const sourceUrl = asString(page.url);
   const body = asString(markdown.markdown);
-  const references = notionPageEntityReferences(
-    page,
-    options.identityContext ?? EMPTY_NOTION_PAGE_IDENTITY_CONTEXT,
-  );
+  const identityContext =
+    options.identityContext ?? EMPTY_NOTION_PAGE_IDENTITY_CONTEXT;
+  const references = notionPageEntityReferences(page, identityContext);
+  const propertyLines =
+    status === 'active' ? renderNotionPropertyLines(page, identityContext) : [];
 
   return {
     slug,
@@ -655,6 +786,12 @@ export function buildNotionPage(
       '',
       `# ${title}`,
       ...(sourceUrl ? ['', `[Open in Notion](${sourceUrl})`] : []),
+      // Database property values: the page-as-Markdown body carries only the
+      // page content, so rows would otherwise lose their Status/Owner/date
+      // columns in Memory.
+      ...(propertyLines.length > 0
+        ? ['', '## Properties', '', ...propertyLines]
+        : []),
       ...(status === 'deleted'
         ? ['', 'This page is in the Notion trash.']
         : status === 'unavailable'


### PR DESCRIPTION
## Problem

Notion's page-as-Markdown endpoint returns only page body content, so database rows collected into Memory carried a title and body but none of their database columns (Status, Owner, dates, selects, relations, etc.). For many rows the properties *are* the substance.

## Changes

`buildNotionPage` now renders a `## Properties` section into active pages, one line per non-empty property, sorted for deterministic output:

- Plain values: rich_text, number, select, status, multi_select, date (start → end), checkbox, url, email, phone_number, files, unique_id (PREFIX-N)
- People resolve through the stored workspace directory to display names
- Relations render as Brain slug links (`[notion/<id>](notion/<id>)`)
- Formulas and rollups unwrap to their result values (including rollup arrays)
- Skipped: the title property (already the heading), empty values, and timestamps/authorship (already in frontmatter)

Pages whose only property is the title get no section, so plain (non-database) pages are unchanged.

## Tests

New mapping tests cover every rendered property type, empty-value/title skipping, and the no-properties case. All 25 collector tests pass; lint and types clean.

Note: existing pages pick up properties when they next re-ingest (edit, daily sweep, or a collector replay).