### PR TITLE
feat: top up the cached corpus so fresh memories are visible instantly

### DIFF
--- a/packages/sdk/src/server/lib/__tests__/brain-corpus.test.ts
+++ b/packages/sdk/src/server/lib/__tests__/brain-corpus.test.ts
@@ -337,7 +337,7 @@ describe('readBrainCorpus', () => {
     expect(fetchMock).toHaveBeenCalled();
   });
 
-  it('hydrates a completed census from shared storage without listing again', async () => {
+  it('hydrates a completed census from shared storage with one top-up, not a walk', async () => {
     redisGet.mockResolvedValue(
       JSON.stringify({
         generatedAt: new Date().toISOString(),
@@ -350,19 +350,24 @@ describe('readBrainCorpus', () => {
         ],
       }),
     );
-    const fetchMock = vi.fn();
+    // The stored census may predate pages written while this process was
+    // down; hydration makes the same bounded updated_after call as a warm
+    // read instead of trusting it blind (or re-walking).
+    const fetchMock = vi.fn(async () => toolResponse(windowOf(90, 1)));
     global.fetch = fetchMock as unknown as typeof fetch;
 
     const snapshot = await readBrainCorpus();
 
-    expect(snapshot?.pages).toEqual([
-      {
-        slug: 'tasks/shared-run',
-        title: 'Shared run',
-        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
-      },
+    expect(snapshot?.pages.map((page) => page.slug).sort()).toEqual([
+      'tasks/run-90',
+      'tasks/shared-run',
     ]);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(listedArguments(fetchMock)[0]).toMatchObject({
+      limit: 100,
+      sort: 'updated_asc',
+      updated_after: '2026-01-01T00:00:00.000Z',
+    });
   });
 
   it('throttles refresh attempts when a stale cache loses its connection', async () => {
@@ -389,9 +394,10 @@ describe('readBrainCorpus', () => {
       await Promise.resolve();
       await Promise.resolve();
       expect((await readBrainCorpus())?.pages).toHaveLength(1);
-      // Load, then on expiry one top-up attempt plus one refresh; the second
-      // read inside the failure window resolves nothing further.
-      expect(resolveBrainConnection).toHaveBeenCalledTimes(3);
+      // Load + its hydration top-up, then on expiry one top-up attempt plus
+      // one refresh; the second read inside the failure window resolves
+      // nothing further.
+      expect(resolveBrainConnection).toHaveBeenCalledTimes(4);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/sdk/src/server/lib/__tests__/brain-corpus.test.ts
+++ b/packages/sdk/src/server/lib/__tests__/brain-corpus.test.ts
@@ -274,6 +274,29 @@ describe('readBrainCorpus', () => {
     }
   });
 
+  it('sees a new page that shares the cached newest timestamp', async () => {
+    vi.useFakeTimers();
+    try {
+      // Two pages stamped with one timestamp, as a bulk import writes them.
+      let windows = [windowOf(0, 2, true)];
+      const fetchMock = vi.fn(async () => toolResponse(windows.shift() ?? []));
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const first = await readBrainCorpus();
+      expect(first?.pages).toHaveLength(2);
+
+      // A third page lands with that same updated_at. A strict > query from
+      // the boundary would never return it.
+      vi.advanceTimersByTime(4_000);
+      windows = [windowOf(0, 3, true)];
+      const second = await readBrainCorpus();
+
+      expect(second?.pages).toHaveLength(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('serves the cached snapshot when a top-up fails', async () => {
     vi.useFakeTimers();
     try {
@@ -366,7 +389,9 @@ describe('readBrainCorpus', () => {
     expect(listedArguments(fetchMock)[0]).toMatchObject({
       limit: 100,
       sort: 'updated_asc',
-      updated_after: '2026-01-01T00:00:00.000Z',
+      // One millisecond before the stored newest row: the boundary's tie
+      // cluster is deliberately re-read.
+      updated_after: '2025-12-31T23:59:59.999Z',
     });
   });
 

--- a/packages/sdk/src/server/lib/__tests__/brain-corpus.test.ts
+++ b/packages/sdk/src/server/lib/__tests__/brain-corpus.test.ts
@@ -213,6 +213,86 @@ describe('readBrainCorpus', () => {
     expect(redisSet).toHaveBeenCalledTimes(1);
   });
 
+  it('tops up a fresh cached snapshot with pages written since its newest row', async () => {
+    vi.useFakeTimers();
+    try {
+      const calls: unknown[] = [];
+      let windows = [windowOf(0, 42)];
+      const fetchMock = vi.fn(async (_url: unknown, init: RequestInit) => {
+        calls.push(
+          (
+            JSON.parse(init.body as string) as {
+              params: { arguments: unknown };
+            }
+          ).params.arguments,
+        );
+        return toolResponse(windows.shift() ?? []);
+      });
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const first = await readBrainCorpus();
+      expect(first?.pages).toHaveLength(42);
+
+      // Ingestion lands one more page; a read past the top-up window sees it
+      // immediately without waiting for the ten-minute census.
+      vi.advanceTimersByTime(4_000);
+      windows = [windowOf(42, 1)];
+      const second = await readBrainCorpus();
+
+      expect(second?.pages).toHaveLength(43);
+      expect(second?.pages.some((page) => page.slug === 'tasks/run-42')).toBe(
+        true,
+      );
+      expect(calls.at(-1)).toMatchObject({
+        limit: 100,
+        sort: 'updated_asc',
+        updated_after: expect.stringContaining('2026-01-01'),
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('shares one top-up across a burst of reads', async () => {
+    vi.useFakeTimers();
+    try {
+      let windows = [windowOf(0, 42)];
+      const fetchMock = vi.fn(async () => toolResponse(windows.shift() ?? []));
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      await readBrainCorpus();
+      vi.advanceTimersByTime(4_000);
+      windows = [[]] as never;
+      await readBrainCorpus();
+      const callsAfterTopUp = fetchMock.mock.calls.length;
+      await readBrainCorpus();
+      await readBrainCorpus();
+
+      expect(fetchMock.mock.calls.length).toBe(callsAfterTopUp);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('serves the cached snapshot when a top-up fails', async () => {
+    vi.useFakeTimers();
+    try {
+      const windows = [windowOf(0, 42)];
+      const fetchMock = vi.fn(async () => toolResponse(windows.shift() ?? []));
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const first = await readBrainCorpus();
+      vi.advanceTimersByTime(4_000);
+      fetchMock.mockRejectedValueOnce(new Error('brain restarting'));
+
+      const second = await readBrainCorpus();
+
+      expect(second).toBe(first);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('serves an empty census but neither stores it nor trusts it for the full TTL', async () => {
     vi.useFakeTimers();
     try {
@@ -309,7 +389,9 @@ describe('readBrainCorpus', () => {
       await Promise.resolve();
       await Promise.resolve();
       expect((await readBrainCorpus())?.pages).toHaveLength(1);
-      expect(resolveBrainConnection).toHaveBeenCalledTimes(2);
+      // Load, then on expiry one top-up attempt plus one refresh; the second
+      // read inside the failure window resolves nothing further.
+      expect(resolveBrainConnection).toHaveBeenCalledTimes(3);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/sdk/src/server/lib/brain-corpus.ts
+++ b/packages/sdk/src/server/lib/brain-corpus.ts
@@ -222,7 +222,12 @@ async function topUpCachedCorpus(): Promise<void> {
       {
         limit: CORPUS_LISTING_WINDOW,
         sort: 'updated_asc',
-        updated_after: boundary.toISOString(),
+        // `updated_after` is a strict > filter, and bulk writes stamp one
+        // updated_at across a whole transaction — a new page sharing the
+        // boundary timestamp would be invisible to an exact query. Start one
+        // millisecond earlier so the boundary's tie cluster is re-read; the
+        // slug merge below makes the overlap free.
+        updated_after: new Date(boundary.getTime() - 1).toISOString(),
       },
       { timeoutMs: CORPUS_REQUEST_TIMEOUT_MS },
     );
@@ -230,6 +235,14 @@ async function topUpCachedCorpus(): Promise<void> {
 
     if (fresh.length === 0) {
       return;
+    }
+
+    // A saturated window means more changed than one call can see — new
+    // pages beyond the window, or a tie cluster wider than it. Mark the
+    // census due so the next read walks instead of trusting this partial
+    // merge for the rest of the TTL.
+    if (fresh.length >= CORPUS_LISTING_WINDOW) {
+      corpusCache.expiresAtMs = 0;
     }
 
     const merged = new Map(

--- a/packages/sdk/src/server/lib/brain-corpus.ts
+++ b/packages/sdk/src/server/lib/brain-corpus.ts
@@ -557,11 +557,16 @@ export async function readBrainCorpus(): Promise<BrainCorpusSnapshot | null> {
         Date.now() + CORPUS_FAILURE_CACHE_TTL_MS,
       );
 
+      // The shared census may be minutes old by the time a new process
+      // hydrates it; the same bounded top-up the warm paths make keeps a
+      // restart from reintroducing the stale listing.
+      await topUpCachedCorpus();
+
       if (stored.generatedAtMs + CORPUS_CACHE_TTL_MS <= Date.now()) {
         void refresh(connection);
       }
 
-      return stored.snapshot;
+      return corpusCache.snapshot;
     })()
       .catch((error) => {
         console.warn(

--- a/packages/sdk/src/server/lib/brain-corpus.ts
+++ b/packages/sdk/src/server/lib/brain-corpus.ts
@@ -139,7 +139,16 @@ let corpusCache: {
   expiresAtMs: number;
   load: Promise<BrainCorpusSnapshot | null> | null;
   refresh: Promise<BrainCorpusSnapshot | null> | null;
-} = { snapshot: null, expiresAtMs: 0, load: null, refresh: null };
+  topUp: Promise<void> | null;
+  topUpAtMs: number;
+} = {
+  snapshot: null,
+  expiresAtMs: 0,
+  load: null,
+  refresh: null,
+  topUp: null,
+  topUpAtMs: 0,
+};
 
 /** Drop the cached census, so the next call re-reads the corpus. */
 export function resetBrainCorpusCache(): void {
@@ -148,7 +157,111 @@ export function resetBrainCorpusCache(): void {
     expiresAtMs: 0,
     load: null,
     refresh: null,
+    topUp: null,
+    topUpAtMs: 0,
   };
+}
+
+/**
+ * Reads within this window share one top-up: a settings page load issues a
+ * handful of corpus reads back to back, and one incremental call answers for
+ * all of them.
+ */
+const CORPUS_TOP_UP_MIN_INTERVAL_MS = 3_000;
+
+/**
+ * Pull pages written since the cached snapshot's newest row into the cache,
+ * awaited by the read that triggered it. One bounded `list_pages` call
+ * (measured in single-digit milliseconds against a live Brain), so fresh
+ * ingestion is visible on the very next read instead of at the next
+ * ten-minute census. The full walk remains the source of truth for
+ * deletions and for anything wider than one window; a full window here just
+ * means more landed than one call returns, and the scheduled refresh
+ * reconciles.
+ */
+async function topUpCachedCorpus(): Promise<void> {
+  const snapshot = corpusCache.snapshot;
+
+  // Nothing to top up, a full walk already running owns the snapshot, or a
+  // recent top-up already answered for this page load.
+  if (
+    !snapshot ||
+    snapshot.pages.length === 0 ||
+    corpusCache.refresh ||
+    Date.now() - corpusCache.topUpAtMs < CORPUS_TOP_UP_MIN_INTERVAL_MS
+  ) {
+    return;
+  }
+
+  if (corpusCache.topUp) {
+    return corpusCache.topUp;
+  }
+
+  corpusCache.topUp = (async () => {
+    const boundary = snapshot.pages.reduce<Date | null>(
+      (latest, page) =>
+        page.updatedAt && (!latest || page.updatedAt > latest)
+          ? page.updatedAt
+          : latest,
+      null,
+    );
+
+    if (!boundary) {
+      return;
+    }
+
+    const connection = await resolveBrainConnection('agent');
+
+    if (!connection) {
+      return;
+    }
+
+    const payloads = await callBrainTool(
+      connection,
+      'list_pages',
+      {
+        limit: CORPUS_LISTING_WINDOW,
+        sort: 'updated_asc',
+        updated_after: boundary.toISOString(),
+      },
+      { timeoutMs: CORPUS_REQUEST_TIMEOUT_MS },
+    );
+    const fresh = extractBrainCorpusPages(payloads);
+
+    if (fresh.length === 0) {
+      return;
+    }
+
+    const merged = new Map(
+      (corpusCache.snapshot ?? snapshot).pages.map((page) => [page.slug, page]),
+    );
+
+    for (const page of fresh) {
+      merged.set(page.slug, page);
+    }
+
+    corpusCache.snapshot = {
+      pages: [...merged.values()].sort(
+        (left, right) =>
+          (right.updatedAt?.getTime() ?? 0) -
+            (left.updatedAt?.getTime() ?? 0) ||
+          left.slug.localeCompare(right.slug),
+      ),
+    };
+  })()
+    .catch((error) => {
+      console.warn(
+        `[brain] corpus top-up failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    })
+    .finally(() => {
+      corpusCache.topUpAtMs = Date.now();
+      corpusCache.topUp = null;
+    });
+
+  return corpusCache.topUp;
 }
 
 /**
@@ -350,6 +463,7 @@ async function fetchBrainCorpus(
  */
 export async function readBrainCorpus(): Promise<BrainCorpusSnapshot | null> {
   if (corpusCache.expiresAtMs > Date.now()) {
+    await topUpCachedCorpus();
     return corpusCache.snapshot;
   }
 
@@ -371,6 +485,9 @@ export async function readBrainCorpus(): Promise<BrainCorpusSnapshot | null> {
       if (snapshot && snapshot.pages.length > 0) {
         corpusCache.snapshot = snapshot;
         corpusCache.expiresAtMs = Date.now() + CORPUS_CACHE_TTL_MS;
+        // A walk that just finished IS the freshest read; the next top-up
+        // window starts now.
+        corpusCache.topUpAtMs = Date.now();
         await storeCorpus(resolved, snapshot);
       } else if (snapshot) {
         // An empty census is served but never trusted for the full TTL: a
@@ -412,6 +529,7 @@ export async function readBrainCorpus(): Promise<BrainCorpusSnapshot | null> {
       return (await refresh()) ?? corpusCache.snapshot;
     }
 
+    await topUpCachedCorpus();
     void refresh();
     return corpusCache.snapshot;
   }


### PR DESCRIPTION
## Problem

The /settings/memory corpus listing serves a cached census for its full 10-minute TTL. #1837 fixed the empty-corpus case, but during active ingestion a non-empty snapshot still ages up to ten minutes between full walks, so newly ingested memories appear in ten-minute steps — the page looks laggy exactly when the user is watching their brain fill.

## Why this is safe to do on every read

Measured against a live gbrain (677 pages): one `list_pages` window of 100 rows costs 6-15 ms. The full walk is what the cache exists to avoid; a single incremental window is essentially free.

## Change

Reads that would serve a cached non-empty snapshot first make one bounded `list_pages` call with `updated_after` = the snapshot's newest `updatedAt`, merge the rows in by slug, and answer with the merged snapshot — so anything ingested since the last read is visible immediately.

- Throttled: one top-up per 3-second window, shared across a page load's burst of corpus reads; a completed full walk stamps the window too
- Skipped while a full refresh is in flight (the walk owns the snapshot)
- Failures are swallowed and the cached snapshot served — never worse than before
- The full census stays the source of truth for deletions and for change sets wider than one window (a full top-up window just means the scheduled refresh reconciles)

## Testing

New tests: top-up merges new pages on a fresh cached read (asserting the `updated_after` call shape), burst sharing/throttling, failure fallback; existing census/pagination/TTL tests all pass. `pnpm lint` and `pnpm check-types` clean.