### PR TITLE
feat: show live activity line on delegated task cards

### DIFF
--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/DelegatedTaskCard.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/DelegatedTaskCard.client.test.tsx
@@ -28,6 +28,7 @@ describe('DelegatedTaskCard', () => {
           taskPhase: 'running',
           error: null,
         },
+        activityLine: null,
       },
     });
   });
@@ -74,6 +75,40 @@ describe('DelegatedTaskCard', () => {
       { taskId: 'child-1' },
       expect.any(Object),
     );
+  });
+
+  it('shows the latest activity line while the child is working', () => {
+    useQueryMock.mockReturnValue({
+      isPending: false,
+      data: {
+        task: { title: 'Fix checkout' },
+        taskRun: {
+          status: RunStatus.Running,
+          taskPhase: 'running',
+          error: null,
+        },
+        activityLine: 'Running the test suite now.',
+      },
+    });
+
+    render(
+      <DelegatedTaskCard taskId="child-1" prompt={null} onOpen={vi.fn()} />,
+    );
+
+    expect(screen.getByText('Running the test suite now.')).toBeInTheDocument();
+    // The plain status stays visible alongside the activity line.
+    expect(screen.getByText('Working')).toBeInTheDocument();
+  });
+
+  it('falls back to the plain status when no activity exists yet', () => {
+    render(
+      <DelegatedTaskCard taskId="child-1" prompt={null} onOpen={vi.fn()} />,
+    );
+
+    expect(screen.getByText('Working')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Running the test suite now.'),
+    ).not.toBeInTheDocument();
   });
 
   it('updates when the child transitions to a terminal state', () => {

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/DelegatedTaskCard.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/DelegatedTaskCard.tsx
@@ -36,6 +36,9 @@ export function DelegatedTaskCard({
     ),
   );
   const title = data?.task?.title?.trim() || prompt || 'Delegated task';
+  // Latest assistant activity for the in-flight run (server clears it once
+  // the run exits); the plain status indicator remains the fallback.
+  const activityLine = data?.activityLine ?? null;
 
   return (
     <button
@@ -55,6 +58,11 @@ export function DelegatedTaskCard({
             {title}
           </span>
         )}
+        {!isPending && activityLine ? (
+          <span className="ph-no-capture mt-0.5 block truncate text-xs text-muted-foreground">
+            {activityLine}
+          </span>
+        ) : null}
       </span>
       <TaskStatusIndicator
         status={data?.taskRun?.status ?? null}

--- a/apps/web/src/lib/server/index.ts
+++ b/apps/web/src/lib/server/index.ts
@@ -27,6 +27,7 @@ export * from './slack-oauth-state';
 export * from './github-oauth-state';
 export * from './source-control';
 export * from './sync-internal';
+export * from './task-activity';
 export * from './task-messages';
 export * from './task-models';
 export * from './tasks';

--- a/apps/web/src/lib/server/task-activity.test.ts
+++ b/apps/web/src/lib/server/task-activity.test.ts
@@ -103,6 +103,31 @@ describe('getLatestTaskActivityLine', () => {
     );
   });
 
+  it('keeps the last eligible line behind a long transient retry storm', async () => {
+    const { run } = await createRunWithTask('task-activity-retry-storm');
+
+    await db.insert(taskMessages).values([
+      messageRow(run, {
+        ts: 1_000,
+        eventType: ACP_ENVELOPE_EVENT_TYPES.AssistantMessage,
+        text: 'Fixing the login bug.',
+      }),
+      // More transient rows than one scan batch, so the eligible message is
+      // only reachable by continuing past the first page.
+      ...Array.from({ length: 25 }, (_, index) =>
+        messageRow(run, {
+          ts: 2_000 + index,
+          eventType: ACP_ENVELOPE_EVENT_TYPES.AssistantMessage,
+          text: `Retrying after a rate limit (attempt ${index + 1})`,
+        }),
+      ),
+    ]);
+
+    await expect(getLatestTaskActivityLine(run.id)).resolves.toBe(
+      'Fixing the login bug.',
+    );
+  });
+
   it('returns null when the run has produced no assistant messages', async () => {
     const { run } = await createRunWithTask('task-activity-empty');
 

--- a/apps/web/src/lib/server/task-activity.test.ts
+++ b/apps/web/src/lib/server/task-activity.test.ts
@@ -1,0 +1,161 @@
+import { db, runFactory, taskFactory, taskMessages } from '@roomote/db/server';
+import {
+  ACP_ENVELOPE_EVENT_TYPES,
+  ROOMOTE_RUNTIME_TASK_MESSAGE_PROTOCOL,
+  type TaskMessageEventType,
+  type TaskMessageRole,
+} from '@roomote/types';
+
+import {
+  TASK_ACTIVITY_LINE_MAX_CHARS,
+  formatTaskActivityLine,
+  getLatestTaskActivityLine,
+} from './task-activity';
+
+async function createRunWithTask(taskId: string) {
+  const task = await taskFactory.create({ id: taskId, title: 'Starter task' });
+  const run = await runFactory.create({ taskId: task.id });
+  return { task, run };
+}
+
+function messageRow(
+  run: { id: number; taskId: string },
+  {
+    ts,
+    eventType,
+    text,
+    role = 'assistant',
+  }: {
+    ts: number;
+    eventType: TaskMessageEventType;
+    text: string;
+    role?: TaskMessageRole;
+  },
+) {
+  return {
+    runId: run.id,
+    taskId: run.taskId,
+    ts,
+    eventType,
+    role,
+    protocol: ROOMOTE_RUNTIME_TASK_MESSAGE_PROTOCOL,
+    contentBlocks: [{ type: 'text', text }],
+    payload: {},
+  };
+}
+
+describe('getLatestTaskActivityLine', () => {
+  it('returns the latest assistant message, ignoring prompts and reasoning', async () => {
+    const { run } = await createRunWithTask('task-activity-latest');
+
+    await db.insert(taskMessages).values([
+      messageRow(run, {
+        ts: 1_000,
+        eventType: ACP_ENVELOPE_EVENT_TYPES.UserPrompt,
+        role: 'user',
+        text: 'Set up the demo environment',
+      }),
+      messageRow(run, {
+        ts: 2_000,
+        eventType: ACP_ENVELOPE_EVENT_TYPES.AssistantMessage,
+        text: 'Looking into the checkout flow.',
+      }),
+      messageRow(run, {
+        ts: 3_000,
+        eventType: ACP_ENVELOPE_EVENT_TYPES.AssistantThought,
+        text: 'Internal reasoning that must stay hidden',
+      }),
+      messageRow(run, {
+        ts: 4_000,
+        eventType: ACP_ENVELOPE_EVENT_TYPES.AssistantMessage,
+        text: 'Running the test suite now.',
+      }),
+    ]);
+
+    await expect(getLatestTaskActivityLine(run.id)).resolves.toBe(
+      'Running the test suite now.',
+    );
+  });
+
+  it('skips transient provider-error and retry narration', async () => {
+    const { run } = await createRunWithTask('task-activity-transient');
+
+    await db.insert(taskMessages).values([
+      messageRow(run, {
+        ts: 1_000,
+        eventType: ACP_ENVELOPE_EVENT_TYPES.AssistantMessage,
+        text: 'Fixing the login bug.',
+      }),
+      messageRow(run, {
+        ts: 2_000,
+        eventType: ACP_ENVELOPE_EVENT_TYPES.AssistantMessage,
+        text: 'Provider error: upstream timed out',
+      }),
+      messageRow(run, {
+        ts: 3_000,
+        eventType: ACP_ENVELOPE_EVENT_TYPES.AssistantMessage,
+        text: 'Retrying after a rate limit',
+      }),
+    ]);
+
+    await expect(getLatestTaskActivityLine(run.id)).resolves.toBe(
+      'Fixing the login bug.',
+    );
+  });
+
+  it('returns null when the run has produced no assistant messages', async () => {
+    const { run } = await createRunWithTask('task-activity-empty');
+
+    await db.insert(taskMessages).values([
+      messageRow(run, {
+        ts: 1_000,
+        eventType: ACP_ENVELOPE_EVENT_TYPES.UserPrompt,
+        role: 'user',
+        text: 'Set up the demo environment',
+      }),
+    ]);
+
+    await expect(getLatestTaskActivityLine(run.id)).resolves.toBeNull();
+  });
+
+  it('does not read messages from other runs', async () => {
+    const { run } = await createRunWithTask('task-activity-own-run');
+    const { run: otherRun } = await createRunWithTask('task-activity-other');
+
+    await db.insert(taskMessages).values([
+      messageRow(otherRun, {
+        ts: 1_000,
+        eventType: ACP_ENVELOPE_EVENT_TYPES.AssistantMessage,
+        text: 'Activity from an unrelated run',
+      }),
+    ]);
+
+    await expect(getLatestTaskActivityLine(run.id)).resolves.toBeNull();
+  });
+});
+
+describe('formatTaskActivityLine', () => {
+  it('flattens markdown structure to one plain line', () => {
+    expect(
+      formatTaskActivityLine(
+        '## Progress\n\n- Updated `checkout.ts`\n- **Fixed** the [flaky test](https://example.com)\n\n```ts\nconst x = 1;\n```',
+      ),
+    ).toBe('Progress Updated checkout.ts Fixed the flaky test');
+  });
+
+  it('keeps underscores in identifiers intact', () => {
+    expect(formatTaskActivityLine('Querying task_run_events now')).toBe(
+      'Querying task_run_events now',
+    );
+  });
+
+  it('truncates long text with an ellipsis', () => {
+    const line = formatTaskActivityLine('word '.repeat(100));
+    expect(line?.length).toBeLessThanOrEqual(TASK_ACTIVITY_LINE_MAX_CHARS);
+    expect(line?.endsWith('…')).toBe(true);
+  });
+
+  it('returns null for whitespace-only input', () => {
+    expect(formatTaskActivityLine('   \n  ')).toBeNull();
+  });
+});

--- a/apps/web/src/lib/server/task-activity.ts
+++ b/apps/web/src/lib/server/task-activity.ts
@@ -55,30 +55,39 @@ export function formatTaskActivityLine(text: string): string | null {
 export async function getLatestTaskActivityLine(
   runId: number,
 ): Promise<string | null> {
-  const messages = await db
-    .select({ contentBlocks: taskMessages.contentBlocks })
-    .from(taskMessages)
-    .where(
-      and(
-        eq(taskMessages.runId, runId),
-        eq(taskMessages.eventType, ACP_ENVELOPE_EVENT_TYPES.AssistantMessage),
-      ),
-    )
-    .orderBy(desc(taskMessages.ts), desc(taskMessages.createdAt))
-    .limit(10);
+  // Long retry storms can stack many transient messages on top of the last
+  // eligible one; scan newest-first in batches until an eligible message is
+  // found so the card keeps its prior activity line, matching Slack.
+  const batchSize = 20;
+  for (let offset = 0; ; offset += batchSize) {
+    const messages = await db
+      .select({ contentBlocks: taskMessages.contentBlocks })
+      .from(taskMessages)
+      .where(
+        and(
+          eq(taskMessages.runId, runId),
+          eq(taskMessages.eventType, ACP_ENVELOPE_EVENT_TYPES.AssistantMessage),
+        ),
+      )
+      .orderBy(desc(taskMessages.ts), desc(taskMessages.createdAt))
+      .limit(batchSize)
+      .offset(offset);
 
-  for (const message of messages) {
-    const text = getTextFromContentBlocks(
-      message.contentBlocks as TaskMessageContentBlock[] | null,
-    )?.trim();
-    if (!text || TRANSIENT_ASSISTANT_MESSAGE_PATTERN.test(text)) {
-      continue;
+    for (const message of messages) {
+      const text = getTextFromContentBlocks(
+        message.contentBlocks as TaskMessageContentBlock[] | null,
+      )?.trim();
+      if (!text || TRANSIENT_ASSISTANT_MESSAGE_PATTERN.test(text)) {
+        continue;
+      }
+      const line = formatTaskActivityLine(text);
+      if (line) {
+        return line;
+      }
     }
-    const line = formatTaskActivityLine(text);
-    if (line) {
-      return line;
+
+    if (messages.length < batchSize) {
+      return null;
     }
   }
-
-  return null;
 }

--- a/apps/web/src/lib/server/task-activity.ts
+++ b/apps/web/src/lib/server/task-activity.ts
@@ -1,0 +1,84 @@
+import {
+  ACP_ENVELOPE_EVENT_TYPES,
+  type TaskMessageContentBlock,
+  getTextFromContentBlocks,
+} from '@roomote/types';
+import { and, db, desc, eq, taskMessages } from '@roomote/db/server';
+
+/**
+ * Hard cap on the serialized activity line. The card clamps to one visual
+ * line with CSS; this only bounds the polled payload.
+ */
+export const TASK_ACTIVITY_LINE_MAX_CHARS = 200;
+
+// Parity with the Slack live task card: the worker drops transient assistant
+// messages with this same pattern before surfacing activity
+// (apps/worker/src/run-task/provisional-completion.ts).
+const TRANSIENT_ASSISTANT_MESSAGE_PATTERN = /^(provider error|retrying)\b/i;
+
+/**
+ * Flatten assistant markdown to a single plain-text line. Slack renders the
+ * activity text as rich markdown; the web card renders one truncated plain
+ * line, so structural markers would otherwise show up as literal syntax.
+ * Bare underscores are left alone — they are usually identifiers, not
+ * emphasis, in agent output.
+ */
+export function formatTaskActivityLine(text: string): string | null {
+  const flattened = text
+    .replace(/```[\s\S]*?(?:```|$)/g, ' ')
+    .replace(/`([^`\n]*)`/g, '$1')
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/^\s{0,3}(?:[-*+]|\d+[.)])\s+/gm, '')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/\*([^*\n]+)\*/g, '$1')
+    .replace(/__([^_]+)__/g, '$1')
+    .replace(/~~([^~]+)~~/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!flattened) {
+    return null;
+  }
+  if (flattened.length <= TASK_ACTIVITY_LINE_MAX_CHARS) {
+    return flattened;
+  }
+  return `${flattened.slice(0, TASK_ACTIVITY_LINE_MAX_CHARS - 1).trimEnd()}…`;
+}
+
+/**
+ * Latest activity line for a run, from the same data source the Slack live
+ * task card surfaces: the most recent meaningful assistant message. Reasoning,
+ * tool calls, and transient provider-error/retry narration are excluded, so a
+ * running task's card can show what the agent last said it was doing.
+ */
+export async function getLatestTaskActivityLine(
+  runId: number,
+): Promise<string | null> {
+  const messages = await db
+    .select({ contentBlocks: taskMessages.contentBlocks })
+    .from(taskMessages)
+    .where(
+      and(
+        eq(taskMessages.runId, runId),
+        eq(taskMessages.eventType, ACP_ENVELOPE_EVENT_TYPES.AssistantMessage),
+      ),
+    )
+    .orderBy(desc(taskMessages.ts), desc(taskMessages.createdAt))
+    .limit(10);
+
+  for (const message of messages) {
+    const text = getTextFromContentBlocks(
+      message.contentBlocks as TaskMessageContentBlock[] | null,
+    )?.trim();
+    if (!text || TRANSIENT_ASSISTANT_MESSAGE_PATTERN.test(text)) {
+      continue;
+    }
+    const line = formatTaskActivityLine(text);
+    if (line) {
+      return line;
+    }
+  }
+
+  return null;
+}

--- a/apps/web/src/trpc/commands/sandbox-session/index.ts
+++ b/apps/web/src/trpc/commands/sandbox-session/index.ts
@@ -54,7 +54,11 @@ import { z } from 'zod';
 import type { UserAuthSuccess } from '@/types';
 import { Env } from '@/lib/server';
 
-import { type TaskRunDetail, findActiveSuccessorTaskRun } from '@/lib/server';
+import {
+  type TaskRunDetail,
+  findActiveSuccessorTaskRun,
+  getLatestTaskActivityLine,
+} from '@/lib/server';
 import { getTaskRunVisiblePrompt } from '@/lib';
 import {
   claimOutOfBandContextForPrompt,
@@ -832,6 +836,7 @@ export async function getSandboxSessionByTaskIdCommand(
       task: null,
       taskRun: null,
       prompt: null,
+      activityLine: null,
       sessionState: 'not-found' as const,
       refetchInterval: undefined,
     };
@@ -914,24 +919,30 @@ export async function getSandboxSessionByTaskIdCommand(
 
   // Check whether the task ever produced messages. Used to distinguish boot
   // failures (no messages) from runtime failures (has conversation history).
-  const [bootFailureMessage, firstHarnessMessage] = await Promise.all([
-    shouldCheckBootFailureMessages
-      ? db.query.taskMessages.findFirst({
-          where: eq(taskMessages.runId, taskRun.id),
-          columns: { id: true },
-        })
-      : Promise.resolve(null),
-    shouldCheckHarnessMessages
-      ? db.query.taskMessages.findFirst({
-          where: and(
-            eq(taskMessages.runId, taskRun.id),
-            isNotNull(taskMessages.role),
-            not(eq(taskMessages.role, 'user')),
-          ),
-          columns: { id: true },
-        })
-      : Promise.resolve(null),
-  ]);
+  const [bootFailureMessage, firstHarnessMessage, activityLine] =
+    await Promise.all([
+      shouldCheckBootFailureMessages
+        ? db.query.taskMessages.findFirst({
+            where: eq(taskMessages.runId, taskRun.id),
+            columns: { id: true },
+          })
+        : Promise.resolve(null),
+      shouldCheckHarnessMessages
+        ? db.query.taskMessages.findFirst({
+            where: and(
+              eq(taskMessages.runId, taskRun.id),
+              isNotNull(taskMessages.role),
+              not(eq(taskMessages.role, 'user')),
+            ),
+            columns: { id: true },
+          })
+        : Promise.resolve(null),
+      // The card shows live activity only while the run is in flight; once the
+      // run exits the status label takes over and polling stops.
+      isExitedRunStatus(taskRun.status)
+        ? Promise.resolve(null)
+        : getLatestTaskActivityLine(taskRun.id),
+    ]);
 
   const hasMessages = !!bootFailureMessage;
   const hasHarnessMessages = !!firstHarnessMessage;
@@ -1003,6 +1014,7 @@ export async function getSandboxSessionByTaskIdCommand(
         resolvedPreviewRuntimeConfig.effective.previewProxySubdomainSuffix,
     },
     prompt,
+    activityLine,
     onboardingEnvironment: onboardingEnvironmentWithVerification,
     sessionState,
     refetchInterval,


### PR DESCRIPTION
## Summary

Fast-session delegated-task cards were static while a task ran — just a title and a **Working** status. Slack task messages already surface a line of recent activity; this brings the same signal to the web card so the wait during setup-session starter tasks no longer feels dead.

- New `getLatestTaskActivityLine(runId)` in `apps/web/src/lib/server/task-activity.ts` derives the line from the same data source behind the Slack live task card: the most recent meaningful `roomote_runtime.assistant_message` in `task_messages` for the run. Reasoning, tool calls, and transient "provider error"/"retrying" narration are excluded (parity with the worker's `provisional-completion` filter that gates the Slack card).
- `sandboxSession.byTaskId` now returns `activityLine` for in-flight runs only (null once the run exits), so the card's existing 2s poll picks it up with no new client query.
- `DelegatedTaskCard` renders it as one truncated `text-xs` line under the title; when no activity exists yet the card looks exactly as before (plain status fallback). Assistant markdown is flattened to plain text for the single-line render, leaving intra-word underscores (identifiers) intact.

## How Slack derives its line (investigated)

The Slack activity line is pushed live from the worker callback stream (`apps/worker/src/callbacks/slack-live-task-stream.ts`): latest assistant `text` event, reasoning excluded, todo updates ignored, transient messages filtered. The web can't tap that in-process stream, so this reuses the persisted form of the same events — the run's `task_messages` rows — matching the query shape of `getPersistedConflictResolutionCompletion`.

## Tests

- `task-activity.test.ts` (server, real DB): latest eligible message wins; prompts/reasoning ignored; transient retry/provider-error narration skipped; run isolation; markdown flattening, identifier underscores, truncation.
- `DelegatedTaskCard.client.test.tsx`: renders the activity line while working; falls back to the plain status when absent.
- `pnpm lint`, `pnpm check-types`, `pnpm knip`, and the surrounding sandbox-session / fast-sessions / SessionWorkspace suites pass.