### PR TITLE
[Fix] Parallel task launches from one Fast turn deadlock and block their own retry

### DIFF
--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -2324,6 +2324,42 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
     expect(adapter.postReply).toHaveBeenCalledOnce();
   });
 
+  it('allows retrying an identical launch after the first attempt fails', async () => {
+    const launchTask = vi.fn<LaunchFastAgentTask>();
+    launchTask
+      .mockResolvedValueOnce({
+        success: false,
+        error: 'deadlock detected',
+      })
+      .mockImplementationOnce(async ({ postKickoff }) => {
+        await postKickoff({ taskId: 'task-retried' });
+        return { success: true, taskId: 'task-retried' };
+      });
+    const adapter = callbacks({ launchTask });
+    mocks.generateText.mockImplementation(
+      async (_params, _session, options) => {
+        await options.onSessionReady('opencode-session-1');
+        const launch = {
+          prompt: 'Fix checkout.',
+          environmentId: 'env-1',
+          kickoffMessage: 'I’m delegating the checkout fix.',
+        };
+        await expect(
+          invokeTool(nativeToolNames.launchTask, launch),
+        ).resolves.toMatchObject({ success: false });
+        // The failed attempt must not poison the duplicate-launch signature.
+        await expect(
+          invokeTool(nativeToolNames.launchTask, launch),
+        ).resolves.toMatchObject({ success: true, taskId: 'task-retried' });
+        return '';
+      },
+    );
+
+    await answerFastAgentQuestion({ ...baseParams, adapter });
+
+    expect(launchTask).toHaveBeenCalledTimes(2);
+  });
+
   it('allows a corrected launch after rejecting an unavailable model', async () => {
     const launchTask = vi.fn<LaunchFastAgentTask>(async () => ({
       success: true,

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -1848,16 +1848,28 @@ export async function answerFastAgentQuestion({
                   attachmentTexts,
                 })
               : args.prompt;
-            const result = await adapter.launchTask({
-              prompt,
-              ...(args.includeAttachments && images.length > 0
-                ? { images }
-                : {}),
-              environmentId: args.environmentId ?? null,
-              model: args.model ?? null,
-              parentSessionId: session.id,
-              postKickoff: deliverKickoff,
-            });
+            let result: Awaited<ReturnType<typeof adapter.launchTask>>;
+            try {
+              result = await adapter.launchTask({
+                prompt,
+                ...(args.includeAttachments && images.length > 0
+                  ? { images }
+                  : {}),
+                environmentId: args.environmentId ?? null,
+                model: args.model ?? null,
+                parentSessionId: session.id,
+                postKickoff: deliverKickoff,
+              });
+            } catch (error) {
+              completedTaskActions.delete(signature);
+              throw error;
+            }
+            if (!result.success) {
+              // A failed launch created nothing, so the model may retry the
+              // same task in this turn; keeping the signature would reject
+              // the retry as a duplicate.
+              completedTaskActions.delete(signature);
+            }
             if (result.success) {
               currentTasks.set(result.taskId, { taskId: result.taskId });
               if (result.kickoffDelivered) {

--- a/packages/cloud-agents/src/server/task-run-queue.ts
+++ b/packages/cloud-agents/src/server/task-run-queue.ts
@@ -105,6 +105,26 @@ enum TaskRunQueueKeys {
 
 const SNAPSHOT_RESUME_ADVISORY_LOCK_NAMESPACE = 0x52534d45;
 
+/** True when the error (or any of its causes) is a Postgres deadlock (40P01). */
+function isPostgresDeadlockError(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current; depth += 1) {
+    if (
+      typeof current === 'object' &&
+      current !== null &&
+      'code' in current &&
+      (current as { code?: unknown }).code === '40P01'
+    ) {
+      return true;
+    }
+    current =
+      typeof current === 'object' && current !== null && 'cause' in current
+        ? (current as { cause?: unknown }).cause
+        : undefined;
+  }
+  return false;
+}
+
 export class SnapshotResumeAlreadyExistsError extends Error {
   constructor(public readonly existingRunId: number) {
     super(`Snapshot resume run ${existingRunId} already exists.`);
@@ -1538,10 +1558,22 @@ async function enqueueFreshLaunch(
     githubUserId: 'githubUserId' in task ? task.githubUserId : null,
   };
 
+  const fastParent = getFastAgentParentFromPayload(
+    taskWithHarnessOverrides.payload,
+  );
+
   // Fresh runs are persisted atomically with either a new task or the existing
   // durable task they continue.
-  const { taskRun, createdRun, reusedTask } = await db.transaction(
-    async (tx) => {
+  const runPersistTransaction = () =>
+    db.transaction(async (tx) => {
+      if (fastParent) {
+        // Parallel launch_task calls from one Fast turn write the same
+        // session and conversation rows; serializing per parent conversation
+        // prevents lock-order deadlocks (40P01) between them.
+        await tx.execute(
+          sql`select pg_advisory_xact_lock(hashtextextended(${`fast-parent-launch:${fastParent.sessionId}`}, 0))`,
+        );
+      }
       const chatgptConnected = effectiveTaskModel.startsWith('openai/')
         ? await isChatGptSubscriptionConnected(tx)
         : false;
@@ -1695,9 +1727,6 @@ async function enqueueFreshLaunch(
         taskId = createdTask.id;
       }
 
-      const fastParent = getFastAgentParentFromPayload(
-        taskWithHarnessOverrides.payload,
-      );
       await ensureSessionForTask(tx, {
         taskId,
         fastConversationId: fastParent?.sessionId ?? null,
@@ -1818,8 +1847,25 @@ async function enqueueFreshLaunch(
         createdRun: true,
         reusedTask: Boolean(existingTask),
       };
-    },
-  );
+    });
+
+  let persisted: Awaited<ReturnType<typeof runPersistTransaction>>;
+  try {
+    persisted = await runPersistTransaction();
+  } catch (error) {
+    if (!isPostgresDeadlockError(error)) {
+      throw error;
+    }
+    // The aborted transaction persisted nothing, so one retry is safe and
+    // absorbs any remaining lock-order conflict with an unrelated writer.
+    console.warn(
+      `[task-run-queue] Retrying task persistence after a deadlock: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    persisted = await runPersistTransaction();
+  }
+  const { taskRun, createdRun, reusedTask } = persisted;
 
   if (!createdRun) {
     return taskRun;


### PR DESCRIPTION
## Problem

When a Fast turn launches multiple tasks concurrently (which the prompt explicitly permits, and which the new setup kickoff makes common), the launch transactions can deadlock: each locks the shared `sessions` row and the parent Fast-conversation row in conflicting order, and Postgres aborts one with `40P01`. Worse, the per-turn duplicate-launch guard records its signature *before* executing and never clears it on failure, so the model's reasonable retry of the failed launch is rejected with "The same task was already launched in this turn" and the work is silently dropped until a human intervenes.

Observed in a live setup session: one launch died with `deadlock detected`, the in-turn retry was blocked, and a manual "Retry it" (fresh turn, fresh signature set) succeeded immediately.

## Fix

1. **Serialize per parent conversation.** Task persistence takes `pg_advisory_xact_lock` keyed on the Fast parent conversation at the start of the transaction, so parallel launches into one session queue instead of interleaving row locks. A single retry on `40P01` remains as a backstop for lock-order conflicts with unrelated writers.
2. **Unpoison the signature on failure.** A failed or thrown launch deletes its duplicate-launch signature (the aborted transaction persisted nothing), so an identical in-turn retry is allowed. Successful launches keep the existing dedupe behavior.

## Testing

- New service test: an identical launch retried after a failed first attempt succeeds instead of being rejected as a duplicate; the existing dedupe-after-success test still passes.
- Full fast-agent service suite (85) and enqueue-task suite pass, except one pre-existing failure on develop ("allows retrying a resume that was canceled before queue publication") that reproduces identically without this change and is tracked separately.
- `check-types:fast`, `lint:fast`, `knip`, and repo-wide `format:check` pass.