### PR TITLE
[Fix] Test DB keeps stale partial-index predicates after push

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -33,7 +33,8 @@
     "db:migrate": "pnpm drizzle-kit:development migrate",
     "db:migrate:standalone": "DRIZZLE_MIGRATIONS_FOLDER=drizzle tsx src/run-migrations.ts",
     "db:push": "pnpm drizzle-kit:development push",
-    "db:push:test": "pnpm drizzle-kit:test push --force",
+    "db:push:test": "pnpm drizzle-kit:test push --force && pnpm db:reconcile-test-indexes",
+    "db:reconcile-test-indexes": "NODE_ENV=test dotenvx run --quiet --ignore=MISSING_ENV_FILE -f ../../.env.test -- sh -c 'DATABASE_URL=${DATABASE_URL:-postgres://postgres:password@localhost:15432/roomote_test} tsx scripts/reconcile-test-indexes.ts' --",
     "db:seed": "dotenvx run --quiet -f ../../.env.local -- tsx src/fixtures/seed.ts",
     "db:seed:demo": "dotenvx run --quiet --ignore=MISSING_ENV_FILE -f ../../.env.local -- tsx src/fixtures/seed-demo.ts",
     "development:create-env-var": "dotenvx run --quiet -f ../../.env.local -- tsx scripts/create-env-var.ts"

--- a/packages/db/scripts/reconcile-test-indexes.ts
+++ b/packages/db/scripts/reconcile-test-indexes.ts
@@ -1,0 +1,76 @@
+/**
+ * Re-assert index definitions that `drizzle-kit push` cannot reconcile.
+ *
+ * push does not detect changes to the WHERE predicate of expression indexes,
+ * so a persistent test database keeps whatever predicate an index had when it
+ * was first created. Real deployments pick up predicate changes through
+ * generated migrations (e.g. drizzle/0067_clean_storm.sql), but the test
+ * database is synced exclusively via push, which reports "Changes applied"
+ * while silently leaving the stale index in place. This runs after every
+ * `db:push:test` to close that gap.
+ *
+ * Each entry mirrors the definition in src/schema.ts; `mustContain` lists
+ * predicate fragments (as Postgres normalizes them in pg_indexes.indexdef)
+ * whose absence marks the index as stale.
+ */
+import { assertSafeTestDatabaseUrl, postgres } from '../src/server';
+
+interface ManagedIndex {
+  name: string;
+  mustContain: string[];
+  createSql: string;
+}
+
+const MANAGED_INDEXES: ManagedIndex[] = [
+  {
+    name: 'task_runs_launch_idempotency_key_unique',
+    mustContain: ['canceled_at IS NULL'],
+    createSql: `CREATE UNIQUE INDEX "task_runs_launch_idempotency_key_unique" ON "task_runs" USING btree (("payload"->>'launchIdempotencyKey')) WHERE "task_runs"."payload"->>'launchIdempotencyKey' IS NOT NULL AND "task_runs"."canceled_at" IS NULL`,
+  },
+  {
+    name: 'task_runs_discord_source_event_unique',
+    mustContain: ['canceled_at IS NULL'],
+    createSql: `CREATE UNIQUE INDEX "task_runs_discord_source_event_unique" ON "task_runs" USING btree (("payload"->>'communicationSourceEventId')) WHERE "task_runs"."payload"->>'communicationProvider' = 'discord' AND "task_runs"."payload"->>'communicationSourceEventId' IS NOT NULL AND "task_runs"."canceled_at" IS NULL`,
+  },
+];
+
+const databaseUrl =
+  process.env.DATABASE_URL ??
+  'postgres://postgres:password@localhost:15432/roomote_test';
+
+assertSafeTestDatabaseUrl(databaseUrl, 'test');
+
+const sql = postgres(databaseUrl, {
+  prepare: false,
+  max: 1,
+  onnotice: () => {},
+});
+
+try {
+  for (const index of MANAGED_INDEXES) {
+    const rows = await sql<{ indexdef: string }[]>`
+      SELECT indexdef
+      FROM pg_indexes
+      WHERE schemaname = 'public' AND indexname = ${index.name}
+    `;
+    const indexdef = rows[0]?.indexdef;
+
+    if (
+      indexdef &&
+      index.mustContain.every((fragment) => indexdef.includes(fragment))
+    ) {
+      continue;
+    }
+
+    await sql.begin(async (tx) => {
+      await tx.unsafe(`DROP INDEX IF EXISTS "${index.name}"`);
+      await tx.unsafe(index.createSql);
+    });
+
+    console.log(
+      `[reconcile-test-indexes] Recreated ${index.name} (was ${indexdef ? 'stale' : 'missing'}).`,
+    );
+  }
+} finally {
+  await sql.end();
+}


### PR DESCRIPTION
## Problem

The enqueue-task test "allows retrying a resume that was canceled before queue publication" fails against a persistent `roomote_test` database with:

```
duplicate key value violates unique constraint "task_runs_launch_idempotency_key_unique"
```

#1779 added `AND canceled_at IS NULL` to that index's predicate (migration `0067_clean_storm.sql`) so canceled runs release their launch idempotency key. Real databases pick that up via migrations, but the test database is synced exclusively through `drizzle-kit push`, which cannot detect WHERE-predicate changes on expression indexes: it reports "Changes applied" while leaving the old index in place. Any test DB created before #1779 keeps the stale predicate, so the canceled run still blocks the retry insert.

## Fix

- Add `packages/db/scripts/reconcile-test-indexes.ts`: after push, recreate predicate-bearing expression indexes whose live `pg_indexes.indexdef` is missing the expected predicate fragments (currently the launch-idempotency and Discord source-event unique indexes).
- Chain it into `db:push:test`, so `pnpm test`, `infra:up`, and `db:up` self-heal a drifted test database.

The script guards with `assertSafeTestDatabaseUrl`, so it refuses to run against anything but a localhost test database.

## Verification

- On a stale test DB, `pnpm --filter @roomote/db db:push:test` logs `Recreated task_runs_launch_idempotency_key_unique (was stale).`
- `packages/cloud-agents/src/server/__tests__/enqueue-task.test.ts` then passes twice consecutively (69 tests per run).
- oxfmt, oxlint, tsc, and pre-push (check-types:fast + knip) all clean.