### PR TITLE
Make Slack automation configuration less prominent

### DIFF
--- a/apps/api/src/handlers/mcp/__tests__/slack-thread-reply-quotes.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/slack-thread-reply-quotes.test.ts
@@ -409,8 +409,13 @@ describe('Slack thread reply quotes', () => {
                 action_id: 'late_bound_automation_view_task',
               }),
               expect.objectContaining({
+                type: 'overflow',
                 action_id: 'late_bound_automation_configure',
-                url: 'https://app.example.com/automations#custom-automation-automation-1',
+                options: [
+                  expect.objectContaining({
+                    url: 'https://app.example.com/automations#custom-automation-automation-1',
+                  }),
+                ],
               }),
             ]),
           }),

--- a/packages/sdk/src/server/automations/__tests__/merge-announcer.test.ts
+++ b/packages/sdk/src/server/automations/__tests__/merge-announcer.test.ts
@@ -131,6 +131,15 @@ describe('handleMergeAnnouncerPush', () => {
                 type: 'mrkdwn',
                 text: 'Adds exports and strengthens widget validation.',
               },
+              accessory: expect.objectContaining({
+                type: 'overflow',
+                action_id: 'late_bound_automation_configure',
+                options: [
+                  expect.objectContaining({
+                    text: expect.objectContaining({ text: 'Configure' }),
+                  }),
+                ],
+              }),
             }),
             expect.objectContaining({
               type: 'actions',
@@ -139,10 +148,6 @@ describe('handleMergeAnnouncerPush', () => {
                   action_id: 'merge_announcer_view_changes',
                   text: expect.objectContaining({ text: 'View changes' }),
                   url: 'https://github.com/acme/widgets/compare/before...after',
-                }),
-                expect.objectContaining({
-                  action_id: 'late_bound_automation_configure',
-                  text: expect.objectContaining({ text: 'Configure' }),
                 }),
               ]),
             }),

--- a/packages/sdk/src/server/automations/__tests__/provider-usage-limit.test.ts
+++ b/packages/sdk/src/server/automations/__tests__/provider-usage-limit.test.ts
@@ -151,14 +151,18 @@ describe('provider usage limit automation', () => {
               url: expect.stringContaining('/settings/models'),
             }),
             expect.objectContaining({
-              type: 'button',
+              type: 'overflow',
               action_id: 'late_bound_automation_configure',
-              text: {
-                type: 'plain_text',
-                text: 'Configure alert',
-                emoji: false,
-              },
-              url: expect.stringContaining('#provider-usage-limit'),
+              options: [
+                expect.objectContaining({
+                  text: {
+                    type: 'plain_text',
+                    text: 'Configure alert',
+                    emoji: false,
+                  },
+                  url: expect.stringContaining('#provider-usage-limit'),
+                }),
+              ],
             }),
           ],
         },

--- a/packages/sdk/src/server/lib/__tests__/manager-slack.test.ts
+++ b/packages/sdk/src/server/lib/__tests__/manager-slack.test.ts
@@ -63,16 +63,16 @@ describe('manager slack helpers', () => {
           {
             type: 'section',
             text: { type: 'mrkdwn', text: 'Hello managers' },
+            accessory: {
+              type: 'overflow',
+              action_id: 'late_bound_automation_configure',
+              options: [
+                expect.objectContaining({
+                  url: 'https://app.example.com/automations#suggest-ideas',
+                }),
+              ],
+            },
           },
-          expect.objectContaining({
-            type: 'actions',
-            elements: [
-              expect.objectContaining({
-                action_id: 'late_bound_automation_configure',
-                url: 'https://app.example.com/automations#suggest-ideas',
-              }),
-            ],
-          }),
         ],
       }),
     ]);
@@ -118,8 +118,13 @@ describe('manager slack helpers', () => {
               ),
             }),
             expect.objectContaining({
+              type: 'overflow',
               action_id: 'late_bound_automation_configure',
-              url: 'https://app.example.com/automations#custom-automation-automation-1',
+              options: [
+                expect.objectContaining({
+                  url: 'https://app.example.com/automations#custom-automation-automation-1',
+                }),
+              ],
             }),
           ],
         },
@@ -174,8 +179,11 @@ describe('manager slack helpers', () => {
             type: 'mrkdwn',
             text: '- Do the important thing\n\nReact on a thread item to start it.',
           },
+          accessory: expect.objectContaining({
+            type: 'overflow',
+            action_id: 'late_bound_automation_configure',
+          }),
         },
-        { type: 'actions' },
       ],
     });
   });

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
@@ -572,10 +572,15 @@ describe('deliverFastAgentParentEvent', () => {
                 url: expect.stringContaining(`/sessions/${parent.sessionId}`),
               }),
               expect.objectContaining({
+                type: 'overflow',
                 action_id: 'late_bound_automation_configure',
-                url: expect.stringContaining(
-                  '/automations#custom-automation-automation-1',
-                ),
+                options: [
+                  expect.objectContaining({
+                    url: expect.stringContaining(
+                      '/automations#custom-automation-automation-1',
+                    ),
+                  }),
+                ],
               }),
             ],
           }),

--- a/packages/sdk/src/server/lib/task-runs/__tests__/platform-issue-alert-delivery.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/platform-issue-alert-delivery.test.ts
@@ -258,15 +258,23 @@ describe('platform issue alert delivery', () => {
         }),
         child_blocks: expect.arrayContaining([
           expect.objectContaining({
+            type: 'section',
+            accessory: expect.objectContaining({
+              type: 'overflow',
+              action_id: 'late_bound_automation_configure',
+              options: [
+                expect.objectContaining({
+                  url: 'https://app.example.com/automations#platform-issue-alerts',
+                }),
+              ],
+            }),
+          }),
+          expect.objectContaining({
             type: 'actions',
             elements: expect.arrayContaining([
               expect.objectContaining({
                 action_id: 'late_bound_automation_view_task',
                 url: expect.stringContaining('utm_source=slack'),
-              }),
-              expect.objectContaining({
-                action_id: 'late_bound_automation_configure',
-                url: 'https://app.example.com/automations#platform-issue-alerts',
               }),
             ]),
           }),
@@ -485,6 +493,10 @@ describe('platform issue alert delivery', () => {
                 type: 'mrkdwn',
                 text: `Platform issue reported: *${REPORT.title}*\n> ${REPORT.summary}`,
               },
+              accessory: expect.objectContaining({
+                type: 'overflow',
+                action_id: 'late_bound_automation_configure',
+              }),
             },
           ]),
         }),

--- a/packages/slack/src/__tests__/automation-result-blocks.test.ts
+++ b/packages/slack/src/__tests__/automation-result-blocks.test.ts
@@ -103,10 +103,18 @@ describe('automation result blocks', () => {
             url: 'https://app.example.com/task/1',
           },
           {
-            type: 'button',
+            type: 'overflow',
             action_id: 'late_bound_automation_configure',
-            text: { type: 'plain_text', text: 'Configure', emoji: false },
-            url: 'https://app.example.com/automations#custom-automation-1',
+            options: [
+              {
+                text: {
+                  type: 'plain_text',
+                  text: 'Configure',
+                  emoji: false,
+                },
+                url: 'https://app.example.com/automations#custom-automation-1',
+              },
+            ],
           },
         ],
       },
@@ -151,7 +159,7 @@ describe('automation result blocks', () => {
     ).toBe('Weekly · GPT 5.6 Max · $0.00 · 1d 2h 3m 4s');
   });
 
-  it('places additional actions before a custom Configure label', () => {
+  it('places additional actions before a custom Configure overflow', () => {
     const blocks = buildAutomationResultBlocks({
       title: 'Usage alert',
       iconUrl: 'https://app.example.com/automation-icons/battery-warning.png',
@@ -176,14 +184,67 @@ describe('automation result blocks', () => {
       elements: [
         expect.objectContaining({ action_id: 'manage_models' }),
         expect.objectContaining({
+          type: 'overflow',
           action_id: 'late_bound_automation_configure',
-          text: expect.objectContaining({ text: 'Configure alert' }),
+          options: [
+            expect.objectContaining({
+              text: expect.objectContaining({ text: 'Configure alert' }),
+            }),
+          ],
         }),
       ],
     });
   });
 
-  it('reserves action capacity for task and configure buttons', () => {
+  it('places Configure in the first available section accessory', () => {
+    const [container] = buildAutomationResultBlocks({
+      title: 'Merge Announcer',
+      iconUrl: 'https://app.example.com/automation-icons/git-merge.png',
+      configureUrl: 'https://app.example.com/automations#merge-announcer',
+      contentBlocks: [
+        {
+          type: 'section',
+          text: { type: 'mrkdwn', text: 'The release branch was updated.' },
+        },
+      ],
+      additionalActions: [
+        {
+          type: 'button',
+          action_id: 'view_changes',
+          text: { type: 'plain_text', text: 'View changes' },
+          url: 'https://github.com/acme/app/compare/one...two',
+        },
+      ],
+    });
+
+    expect(container?.type).toBe('container');
+    if (container?.type !== 'container') return;
+    expect(container.child_blocks).toEqual([
+      expect.objectContaining({
+        type: 'section',
+        accessory: {
+          type: 'overflow',
+          action_id: 'late_bound_automation_configure',
+          options: [
+            {
+              text: {
+                type: 'plain_text',
+                text: 'Configure',
+                emoji: false,
+              },
+              url: 'https://app.example.com/automations#merge-announcer',
+            },
+          ],
+        },
+      }),
+      expect.objectContaining({
+        type: 'actions',
+        elements: [expect.objectContaining({ action_id: 'view_changes' })],
+      }),
+    ]);
+  });
+
+  it('reserves action capacity for task and configure controls', () => {
     const blocks = buildAutomationResultBlocks({
       title: 'Audit',
       iconUrl: 'https://app.example.com/automation-icons/wrench.png',

--- a/packages/slack/src/__tests__/automation-root-footer.test.ts
+++ b/packages/slack/src/__tests__/automation-root-footer.test.ts
@@ -127,22 +127,31 @@ describe('refreshAutomationRootFooter', () => {
       type: 'plain_text',
       text: 'Weekly · GPT 5.6 High · $0.56 · 02:37s',
     });
-    const actionIds = blocks
-      .flatMap(
-        (block: { child_blocks?: Array<Record<string, unknown>> }) =>
-          block.child_blocks ?? [],
-      )
+    const childBlocks = blocks.flatMap(
+      (block: { child_blocks?: Array<Record<string, unknown>> }) =>
+        block.child_blocks ?? [],
+    );
+    const actionIds = childBlocks
       .filter((block: { type?: unknown }) => block.type === 'actions')
       .flatMap(
         (block: { elements?: Array<{ action_id?: string }> }) =>
           block.elements ?? [],
       )
       .map((element: { action_id?: string }) => element.action_id);
-    expect(
-      actionIds.filter((id: string | undefined) =>
-        id?.includes('automation_configure'),
-      ),
-    ).toEqual(['late_bound_automation_configure']);
+    expect(childBlocks).toContainEqual(
+      expect.objectContaining({
+        type: 'section',
+        accessory: expect.objectContaining({
+          type: 'overflow',
+          action_id: 'late_bound_automation_configure',
+          options: [
+            expect.objectContaining({
+              url: 'https://app.example.com/automations#audit',
+            }),
+          ],
+        }),
+      }),
+    );
     expect(blocks[0]?.child_blocks).not.toContainEqual(
       expect.objectContaining({
         block_id: 'roomote_automation_result_settings',

--- a/packages/slack/src/automation-result-blocks.ts
+++ b/packages/slack/src/automation-result-blocks.ts
@@ -8,8 +8,8 @@ export const AUTOMATION_RESULT_ACTIONS_BLOCK_ID =
   'roomote_automation_result_actions';
 export const AUTOMATION_RESULT_HEADER_BLOCK_ID =
   'roomote_automation_result_header';
-// Kept for removing the settings accessory from messages created before the
-// Configure button returned to the actions row.
+// Kept for removing the dedicated settings section from messages created
+// before configuration moved to the content overflow menu.
 const AUTOMATION_RESULT_SETTINGS_BLOCK_ID =
   'roomote_automation_result_settings';
 
@@ -26,6 +26,45 @@ function normalizeContentBlocks(blocks: SlackBlock[]): SlackBlock[] {
       ? buildAutomationResultContentBlocks(block.text)
       : [block],
   );
+}
+
+function buildConfigureOverflow(params: {
+  configureUrl: string;
+  configureLabel?: string;
+}): Record<string, unknown> {
+  return {
+    type: 'overflow',
+    action_id: 'late_bound_automation_configure',
+    options: [
+      {
+        text: {
+          type: 'plain_text',
+          text: params.configureLabel ?? 'Configure',
+          emoji: false,
+        },
+        url: params.configureUrl,
+      },
+    ],
+  };
+}
+
+function attachConfigureOverflow(
+  blocks: SlackBlock[],
+  overflow: Record<string, unknown>,
+): { blocks: SlackBlock[]; attached: boolean } {
+  const sectionIndex = blocks.findIndex(
+    (block) => block.type === 'section' && !block.accessory,
+  );
+  if (sectionIndex === -1) return { blocks, attached: false };
+
+  return {
+    blocks: blocks.map((block, index) =>
+      index === sectionIndex && block.type === 'section'
+        ? { ...block, accessory: overflow }
+        : block,
+    ),
+    attached: true,
+  };
 }
 
 export function formatAutomationResultSubtitle(params: {
@@ -64,6 +103,20 @@ export function buildAutomationResultBlocks(params: {
   additionalActions?: Record<string, unknown>[];
   configureLabel?: string;
 }): SlackBlock[] {
+  const normalizedContentBlocks = (
+    params.contentBlocks
+      ? normalizeContentBlocks(params.contentBlocks)
+      : buildAutomationResultContentBlocks(params.contentText ?? '')
+  ).filter(
+    (block) =>
+      !(
+        'block_id' in block &&
+        block.block_id === AUTOMATION_RESULT_SETTINGS_BLOCK_ID
+      ),
+  );
+  const configureOverflow = buildConfigureOverflow(params);
+  const { blocks: contentBlocks, attached: configureOverflowAttached } =
+    attachConfigureOverflow(normalizedContentBlocks, configureOverflow);
   const actionElements = [...(params.additionalActions ?? [])];
   const linkedPrUrls = params.linkedPrUrls ?? [];
   const reservedActions = actionElements.length + (params.taskUrl ? 1 : 0);
@@ -91,33 +144,15 @@ export function buildAutomationResultBlocks(params: {
       url: params.taskUrl,
     });
   }
-  actionElements.push({
-    type: 'button',
-    action_id: 'late_bound_automation_configure',
-    text: {
-      type: 'plain_text',
-      text: params.configureLabel ?? 'Configure',
-      emoji: false,
-    },
-    url: params.configureUrl,
-  });
-  const configureAction = actionElements.pop();
+  const configureAction = configureOverflowAttached
+    ? undefined
+    : configureOverflow;
   const actionGroups =
     actionElements.length === 25 && configureAction
       ? [actionElements, [configureAction]]
-      : [[...actionElements, ...(configureAction ? [configureAction] : [])]];
-
-  const contentBlocks = (
-    params.contentBlocks
-      ? normalizeContentBlocks(params.contentBlocks)
-      : buildAutomationResultContentBlocks(params.contentText ?? '')
-  ).filter(
-    (block) =>
-      !(
-        'block_id' in block &&
-        block.block_id === AUTOMATION_RESULT_SETTINGS_BLOCK_ID
-      ),
-  );
+      : actionElements.length > 0 || configureAction
+        ? [[...actionElements, ...(configureAction ? [configureAction] : [])]]
+        : [];
 
   if (!contentBlocks.some((block) => block.type === 'markdown')) {
     const groups: SlackBlock[][] = [];


### PR DESCRIPTION
## Summary

- replace Configure buttons in Slack automation result cards with a single-item overflow menu
- place the overflow in the first available section accessory so it appears at the upper right of compact cards
- fall back to the actions row for Markdown, table, image, or otherwise occupied layouts
- preserve primary task, pull request, and automation-specific actions

## Validation

- 460 Slack package tests
- 74 affected SDK tests
- 17 affected API tests
- Slack, SDK, and API TypeScript checks
- repository pre-push lint, fast typecheck, and knip gates