### PR TITLE
[Improve] Run Notion historical scans in the fast continuation loop

### DIFF
--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-collector-engine.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-collector-engine.test.ts
@@ -202,6 +202,43 @@ describe('runBrainCollectors', () => {
     );
   });
 
+  it('reports and continues collectors with pending historical scans', async () => {
+    const collect = vi
+      .fn<BrainCollector['collect']>()
+      .mockResolvedValueOnce({
+        pages: makePages(1),
+        nextSince: null,
+        historicalPending: true,
+      })
+      .mockResolvedValueOnce({ pages: [], nextSince: null });
+    const scanning = makeCollector({ collect });
+    const idleCollect = vi
+      .fn<BrainCollector['collect']>()
+      .mockResolvedValue({ pages: [], nextSince: null });
+    const idle = makeCollector({ collect: idleCollect });
+    const sink: BrainSink = vi.fn(async () => {});
+
+    const first = await runBrainCollectors(connection, {
+      sink,
+      collectors: [scanning, idle],
+    });
+    expect(first.historicalPendingCollectorIds).toEqual([scanning.id]);
+
+    // Continuation pass: only the mid-scan collector's collect phase reruns;
+    // the idle collector is not re-polled in the fast loop.
+    const second = await runBrainCollectors(connection, {
+      sink,
+      collectors: [scanning, idle],
+      includeIncremental: false,
+      continueCollectorIds: first.historicalPendingCollectorIds,
+    });
+
+    expect(collect).toHaveBeenCalledTimes(2);
+    expect(idleCollect).toHaveBeenCalledTimes(1);
+    // The scan settled, so nothing holds the loop open.
+    expect(second.historicalPendingCollectorIds).toEqual([]);
+  });
+
   it('persists partition progress only after every page lands', async () => {
     const partitionWatermark = new Date('2026-08-13T11:00:00Z');
     const partitionCursor = '{"page":2}';
@@ -524,7 +561,11 @@ describe('runBrainCollectors', () => {
         sink,
         collectors: [firstCollector, secondCollector],
       }),
-    ).resolves.toEqual({ backfillProgressed: false, interrupted: true });
+    ).resolves.toEqual({
+      backfillProgressed: false,
+      interrupted: true,
+      historicalPendingCollectorIds: [],
+    });
 
     expect(sink).toHaveBeenCalledTimes(1);
     expect(secondCollect).not.toHaveBeenCalled();
@@ -570,7 +611,11 @@ describe('runBrainCollectors', () => {
         sink,
         collectors: [firstCollector, secondCollector],
       }),
-    ).resolves.toEqual({ backfillProgressed: false, interrupted: false });
+    ).resolves.toEqual({
+      backfillProgressed: false,
+      interrupted: false,
+      historicalPendingCollectorIds: [],
+    });
 
     expect(secondCollect).toHaveBeenCalledTimes(1);
     expect(sink).toHaveBeenCalledTimes(1);
@@ -682,6 +727,7 @@ describe('runBrainCollectors deep backfill', () => {
     expect(result).toEqual({
       backfillProgressed: true,
       interrupted: false,
+      historicalPendingCollectorIds: [],
     });
   });
 
@@ -745,7 +791,11 @@ describe('runBrainCollectors deep backfill', () => {
         sink,
         collectors: [collector],
       }),
-    ).resolves.toEqual({ backfillProgressed: false, interrupted: false });
+    ).resolves.toEqual({
+      backfillProgressed: false,
+      interrupted: false,
+      historicalPendingCollectorIds: [],
+    });
 
     // The first step's cursor landed; the failed second step's did not.
     expect(syncStateStore.get(collector.id)?.backfillCursor).toBe('c1');
@@ -894,6 +944,7 @@ describe('runBrainCollectors deep backfill', () => {
     expect(result).toEqual({
       backfillProgressed: false,
       interrupted: false,
+      historicalPendingCollectorIds: [],
     });
   });
 

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-notion.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-notion.test.ts
@@ -386,6 +386,8 @@ describe('Notion page mapping', () => {
       scanStartedAt: '2026-08-15T00:00:00.000Z',
       traverse: { afterItemId: '', pending: [] },
     });
+    // The handed-off traversal keeps the fast continuation loop open.
+    expect(result.historicalPending).toBe(true);
   });
 
   it('refreshes a page that moved during the sweep instead of tombstoning it', async () => {
@@ -561,6 +563,8 @@ describe('Notion traversal discovery', () => {
     expect(cursor.mode).toBe('traverse');
     expect(cursor.traverse!.pending.length).toBeGreaterThan(0);
     expect(cursor.traverse!.afterItemId).toBe(parents[24]!.itemId);
+    // An unfinished walk asks the engine to continue it in the fast loop.
+    expect(result.historicalPending).toBe(true);
   });
 
   it('queries data sources behind child databases', async () => {
@@ -1008,5 +1012,7 @@ describe('Notion traversal discovery', () => {
     expect(JSON.parse(result.stateUpdates![0]!.cursor as string)).toMatchObject(
       { mode: 'idle', lastSweepAt: '2026-08-27T00:00:00.000Z' },
     );
+    // A settled scan releases the fast continuation loop.
+    expect(result.historicalPending).toBe(false);
   });
 });

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-outbox-drain.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-outbox-drain.test.ts
@@ -334,12 +334,45 @@ describe('collector continuation orchestration', () => {
     expect(mockRunBrainCollectors).toHaveBeenNthCalledWith(
       1,
       expect.anything(),
-      { includeIncremental: true },
+      { includeIncremental: true, continueCollectorIds: [] },
     );
     expect(mockRunBrainCollectors).toHaveBeenNthCalledWith(
       2,
       expect.anything(),
-      { includeIncremental: false },
+      { includeIncremental: false, continueCollectorIds: [] },
+    );
+  });
+
+  it('feeds pending historical scans back into continuation passes', async () => {
+    vi.useFakeTimers();
+    mockRunBrainCollectors
+      .mockResolvedValueOnce({
+        backfillProgressed: false,
+        interrupted: false,
+        historicalPendingCollectorIds: ['notion-pages'],
+      })
+      .mockResolvedValueOnce({
+        backfillProgressed: false,
+        interrupted: false,
+        historicalPendingCollectorIds: [],
+      });
+
+    try {
+      const job = brainCollectorsJob();
+      await vi.runAllTimersAsync();
+      await job;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    // The mid-scan collector holds the loop open for one more pass and is
+    // handed back so only its collect phase reruns; a settled second pass
+    // ends the loop.
+    expect(mockRunBrainCollectors).toHaveBeenCalledTimes(2);
+    expect(mockRunBrainCollectors).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      { includeIncremental: false, continueCollectorIds: ['notion-pages'] },
     );
   });
 

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors.ts
@@ -43,6 +43,13 @@ const LOG_PREFIX = '[brainCollectors]';
 type BrainCollectorRunResult = {
   backfillProgressed: boolean;
   interrupted: boolean;
+  /**
+   * Collectors that advanced durable historical scan work this pass and have
+   * more remaining. Feed back as `continueCollectorIds` so the continuation
+   * loop keeps their scans moving; empty once every scan settles, which is
+   * what lets the loop end.
+   */
+  historicalPendingCollectorIds: string[];
 };
 
 async function persistCollectorItemUpdates(
@@ -136,6 +143,12 @@ export async function runBrainCollectors(
     collectors?: BrainCollector[];
     /** Skip upstream incremental polls during fast historical continuation. */
     includeIncremental?: boolean;
+    /**
+     * Collectors whose previous pass reported historicalPending: their
+     * collect phase runs again even on a continuation pass, so an unfinished
+     * sweep/reconcile/discovery scan keeps advancing in the fast loop.
+     */
+    continueCollectorIds?: string[];
   } = {},
 ): Promise<BrainCollectorRunResult> {
   const sink = options.sink ?? postToBrain;
@@ -143,6 +156,8 @@ export async function runBrainCollectors(
   const retireSink = options.retireSink ?? retireBrainPage;
   const collectors = options.collectors ?? BRAIN_COLLECTORS;
   const includeIncremental = options.includeIncremental ?? true;
+  const continueIds = new Set(options.continueCollectorIds ?? []);
+  const historicalPendingCollectorIds: string[] = [];
   let backfillProgressed = false;
 
   for (const collector of collectors) {
@@ -153,10 +168,12 @@ export async function runBrainCollectors(
 
       const state = await getBrainSyncState(db, collector.id);
 
-      if (includeIncremental) {
+      if (includeIncremental || continueIds.has(collector.id)) {
         // Incremental phase runs once per scheduled tick: new activity stays
         // fresh without repeating upstream API polls in the one-second
-        // historical continuation loop.
+        // historical continuation loop. The exception is a collector whose
+        // last pass reported unfinished historical scan work — its collect
+        // phase is productive upstream work, not a wasted poll.
         const {
           pages,
           nextSince,
@@ -164,6 +181,7 @@ export async function runBrainCollectors(
           itemUpdates = [],
           itemDeletes = [],
           pageRetirements = [],
+          historicalPending = false,
         } = await collector.collect({
           since: state?.watermark ?? null,
           now: new Date(),
@@ -226,6 +244,13 @@ export async function runBrainCollectors(
           }
         }
 
+        // An overshot pass persisted nothing, so re-running it in the fast
+        // loop would repeat the same over-limit collect; let the next
+        // scheduled tick retry it instead.
+        if (historicalPending && !overshot) {
+          historicalPendingCollectorIds.push(collector.id);
+        }
+
         if (capped.length > 0) {
           console.log(
             `${LOG_PREFIX} ${collector.id} ingested ${capped.length} pages`,
@@ -258,7 +283,11 @@ export async function runBrainCollectors(
             isBrainRateLimited(error) ? 'rate limited' : 'cannot embed'
           }); ending collector pass until next tick`,
         );
-        return { backfillProgressed, interrupted: true };
+        return {
+          backfillProgressed,
+          interrupted: true,
+          historicalPendingCollectorIds,
+        };
       }
 
       console.warn(
@@ -267,7 +296,11 @@ export async function runBrainCollectors(
     }
   }
 
-  return { backfillProgressed, interrupted: false };
+  return {
+    backfillProgressed,
+    interrupted: false,
+    historicalPendingCollectorIds,
+  };
 }
 
 /**

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/contracts.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/contracts.ts
@@ -50,6 +50,16 @@ export type CollectorResult = {
   itemUpdates?: CollectorItemUpdate[];
   itemDeletes?: CollectorItemDelete[];
   pageRetirements?: CollectorPageRetirement[];
+  /**
+   * Durable historical scan work (a sweep, reconcile, or discovery walk)
+   * advanced this call and remains unfinished. The engine re-runs this
+   * collector's collect phase in the fast historical continuation loop so a
+   * multi-hour scan completes in one session instead of trickling one
+   * bounded pass per scheduled tick. Leave unset for ordinary incremental
+   * polling — the loop must never spin on upstream polls that found
+   * nothing new.
+   */
+  historicalPending?: boolean;
 };
 
 export interface BrainCollector {

--- a/apps/bullmq/src/scheduled-jobs/brain-collectors/notion-pages.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-collectors/notion-pages.ts
@@ -1456,6 +1456,7 @@ export async function collectNotionTraversal(input: {
     pages,
     nextSince: null,
     itemUpdates,
+    historicalPending: !complete,
     stateUpdates: [
       {
         collectorId: NOTION_INCREMENTAL_STATE_ID,
@@ -1527,6 +1528,9 @@ export async function collectNotionReconciliation(input: {
     pages,
     nextSince: null,
     itemUpdates,
+    // Reconcile always hands off to another historical phase (more stale
+    // items, or the traversal walk), so the fast loop keeps going.
+    historicalPending: true,
     itemDeletes: [
       {
         collectorId: NOTION_PAGES_COLLECTOR_ID,
@@ -1572,6 +1576,7 @@ async function collectDisabledNotionPages(
   return {
     pages: batch.map(buildUnavailableNotionPage),
     nextSince: null,
+    historicalPending: !complete,
     itemDeletes: [
       {
         collectorId: NOTION_PAGES_COLLECTOR_ID,
@@ -1724,6 +1729,11 @@ async function collectNotionPages(input: {
     pages,
     nextSince: null,
     itemUpdates,
+    // A sweep (finished or not) always leaves historical phases ahead of it;
+    // ordinary incremental catch-up must NOT hold the fast loop open — it
+    // re-polls the same newest-first search, and its watermark chase settles
+    // on the next scheduled tick.
+    historicalPending: mode === 'sweep',
     stateUpdates: [
       {
         collectorId: NOTION_INCREMENTAL_STATE_ID,

--- a/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
@@ -448,6 +448,7 @@ export async function brainCollectorsJob(): Promise<void> {
   }
 
   let includeIncremental = true;
+  let continueCollectorIds: string[] = [];
 
   await drainBrainHistoricalIngestion({
     async runPass() {
@@ -461,13 +462,20 @@ export async function brainCollectorsJob(): Promise<void> {
 
       const collectorResult = await runBrainCollectors(connection, {
         includeIncremental,
+        continueCollectorIds,
       });
       includeIncremental = false;
+      // Collectors mid-scan (a sweep, reconcile, or discovery walk) keep
+      // their collect phase running across continuation passes; the list
+      // empties as scans settle, letting the loop end.
+      continueCollectorIds =
+        collectorResult.historicalPendingCollectorIds ?? [];
 
       return {
         progressed:
           pullRequestFactsResult.progressed ||
-          collectorResult.backfillProgressed,
+          collectorResult.backfillProgressed ||
+          continueCollectorIds.length > 0,
         interrupted: collectorResult.interrupted,
       };
     },

--- a/apps/docs/integrations/notion.mdx
+++ b/apps/docs/integrations/notion.mdx
@@ -43,7 +43,9 @@ regular Memory collector ticks, and a daily full sweep discovers older pages
 that were newly shared without being edited. Because Notion's search index
 does not reliably surface pages that live inside databases, the sweep also
 enumerates every shared data source and walks page trees to capture database
-rows and other inheritance-shared pages. The same sweep replaces pages
+rows and other inheritance-shared pages, running that discovery to
+completion in a continuous loop rather than trickling across scheduled
+ticks. The same sweep replaces pages
 that are no longer shared with unavailable tombstones, so their former
 content is no longer retained in Memory search results.
 


### PR DESCRIPTION
## Problem

The Notion collector's sweep → reconcile → traverse cycle advances only one bounded pass per 15-minute scheduled tick. The traversal phase (which discovers database rows) gets 24 Notion requests per pass, or roughly 11 pages per tick — about 1,000 pages/day. On a large workspace (observed on a production tenant) the discovery walk saturates its 300-node pending queue every tick and completion is weeks away, even though the initial newest-first backfill finishes in hours because it runs in the fast historical continuation loop.

The asymmetry: for a database-heavy workspace the traversal *is* the deep backfill, but it runs at steady-state pace because `collect()` is skipped on continuation passes (`includeIncremental: false`).

## Changes

- `CollectorResult` gains `historicalPending`: a collector sets it when durable historical scan work (sweep, reconcile, discovery walk) advanced this call and remains unfinished. Ordinary incremental polling never sets it, so the loop cannot spin on empty polls.
- `runBrainCollectors` returns `historicalPendingCollectorIds` and accepts `continueCollectorIds`: on continuation passes, the collect phase reruns for exactly those collectors. An overshot pass (state not persisted) is excluded so the loop can't repeat discarded work.
- `brainCollectorsJob` feeds the pending ids back through the existing `drainBrainHistoricalIngestion` loop; the pass counts as progress while any scan remains.
- The Notion collector reports `historicalPending` from sweep (`true`), reconcile (`true` — it always hands off to another phase), traversal (`!complete`), and disabled-teardown (`!complete`). Incremental mode reports nothing.

Safety properties preserved: the 350ms Notion request spacer bounds upstream load regardless of loop speed; gbrain backpressure (`BrainRateLimitedError`) still ends the loop until the next scheduled tick; a collector that throws is never marked pending, so a wedged scan cannot hold the loop open.

Effect: a full workspace discovery cycle completes in one continuous session (hours, bounded by Notion's rate limit) instead of weeks of 15-minute trickle.

## Tests

- Engine: pending scans are reported and only those collectors' collect phases rerun on continuation passes.
- Drain: pending ids feed back into the next pass and the loop ends when they clear.
- Notion: `historicalPending` asserted for mid-walk, completed-walk, and reconcile-handoff states.
- Full bullmq suite: 471 tests pass; lint and types clean.