### PR TITLE
chore: amend v1.0.0 release notes with Fast restart fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Roomote 1.0 makes Fast the default entry point for conversations, enables Memory
 - Include authorized Settings skills in Fast mode's unscoped skill inventory.
 - Keep running nested-task activity visible when a Session is loaded directly or reconnects, while still hiding it during genuine new parent responses.
 - Restore authorized deployment MCP tools in Fast advisor and judge consultations while keeping Fast-native orchestration and custom automation tools confined to the parent Session.
+- Keep Fast conversations responsive through API restarts by closing out in-flight turns gracefully during shutdown, so replies no longer disappear and sessions no longer get stuck waiting on an abandoned turn.
 
 ## 0.45.1 (2026-08-29)
 


### PR DESCRIPTION
Amends the unshipped 1.0.0 changelog section on develop so the pending release candidate can be refreshed from the latest develop tip.

## What changed

- Adds one patch bullet to the existing `## 1.0.0` section covering #1944 (Fast sessions stuck when the API restarts mid-conversation), generated via `pnpm run version -- --amend`.
- #1934 (internal refactor) and #1951 (release-CI fix) ship without changelog bullets; no public docs updates are needed for any of the three post-cut commits.

## Validation

- `pnpm test:release-scripts` — pass
- Diff is exactly one generated `CHANGELOG.md` line; root version stays `1.0.0`, no pending changesets remain, no workspace package versions changed.

## Follow-up

After this merges, the Release workflow will be dispatched with `version=1.0.0` to fast-forward `release/v1.0.0` (Promote PR #1950) from develop.