### PR TITLE
[Fix] Recover Fast sessions orphaned during quiet retries

### DIFF
--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-conversation-repository.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-conversation-repository.test.ts
@@ -701,6 +701,52 @@ describe('Fast conversation repository', () => {
     });
   });
 
+  it('reveals a quiet durable retry marker after its turn is orphaned', async () => {
+    const user = await createUser();
+    const session = await fastAgentConversationRepository.getOrCreate({
+      userId: user.id,
+      conversation: slackConversation,
+    });
+    await fastAgentConversationRepository.upsertMessage({
+      conversationId: session.id,
+      message: {
+        eventId: 'turn-stale:retry-notice:0',
+        turnId: 'turn-stale',
+        turnSeq: 1,
+        ts: 100,
+        eventType: 'roomote_runtime.assistant_message',
+        role: 'assistant',
+        contentBlocks: [{ type: 'text', text: 'Retrying automatically…' }],
+        metadata: {
+          visibleInTranscript: false,
+          purpose: 'progress',
+          inferenceRetryNotice: true,
+          inferenceRetryActive: true,
+        },
+        payload: { purpose: 'progress' },
+        source: 'web',
+      },
+    });
+
+    await expect(
+      reconcileFastAgentInferenceRetryNotices(session.id),
+    ).resolves.toBe(1);
+
+    const [notice] = await db
+      .select()
+      .from(fastAgentMessages)
+      .where(eq(fastAgentMessages.conversationId, session.id));
+    expect(notice?.contentBlocks).toEqual([
+      { type: 'text', text: INTERRUPTED_INFERENCE_RETRY_MESSAGE },
+    ]);
+    expect(notice?.metadata).toMatchObject({
+      visibleInTranscript: true,
+      purpose: 'closeout',
+      inferenceRetryNotice: true,
+      inferenceRetryActive: false,
+    });
+  });
+
   it('reconciles only retry notices whose session lease is inactive', async () => {
     const user = await createUser();
     const expired = await fastAgentConversationRepository.getOrCreate({

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -3525,6 +3525,31 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
         'It coordinates incoming requests.',
       );
       expect(mocks.generateText).toHaveBeenCalledTimes(2);
+      expect(mocks.upsertMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.objectContaining({
+            eventId: '100.2:retry-notice:0',
+            metadata: expect.objectContaining({
+              visibleInTranscript: false,
+              purpose: 'progress',
+              inferenceRetryNotice: true,
+              inferenceRetryActive: true,
+            }),
+          }),
+        }),
+      );
+      const retryWrites = mocks.upsertMessage.mock.calls
+        .map(([input]) => input.message)
+        .filter((message) => message.eventId === '100.2:retry-notice:0');
+      expect(retryWrites.at(-1)?.contentBlocks).toEqual([
+        { type: 'text', text: 'It coordinates incoming requests.' },
+      ]);
+      expect(retryWrites.at(-1)?.metadata).toMatchObject({
+        visibleInTranscript: false,
+        purpose: 'closeout',
+        inferenceRetryNotice: true,
+        inferenceRetryActive: false,
+      });
       expect(mocks.captureInferenceContext).toHaveBeenNthCalledWith(
         1,
         expect.objectContaining({

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -1827,6 +1827,8 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
   it('posts a terminal closeout when API shutdown interrupts silent retry backoff', async () => {
     const controller = new AbortController();
     const shutdown = new FastAgentProcessShutdownError('SIGTERM');
+    const expectedCloseout =
+      'The inference retry was interrupted before it completed. Please send the request again.';
     const postReply = vi.fn().mockResolvedValue({ messageId: 'closeout-1' });
     const originalSetTimeout = globalThis.setTimeout;
     let shouldAbort = true;
@@ -1856,16 +1858,31 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
       expect(postReply).toHaveBeenCalledOnce();
       expect(postReply).toHaveBeenCalledWith({
         purpose: 'closeout',
-        message:
-          'The inference retry was interrupted before it completed. Please send the request again.',
+        message: expectedCloseout,
       });
-      expect(mocks.upsertMessage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: expect.objectContaining({
-            metadata: expect.objectContaining({ purpose: 'closeout' }),
-          }),
-        }),
-      );
+      const retryWrites = mocks.upsertMessage.mock.calls
+        .map(([input]) => input.message)
+        .filter((message) => message.eventId === '100.2:retry-notice:0');
+      expect(retryWrites.at(-1)).toMatchObject({
+        contentBlocks: [
+          {
+            type: 'text',
+            text: expectedCloseout,
+          },
+        ],
+        metadata: {
+          visibleInTranscript: true,
+          purpose: 'closeout',
+          platformMessageId: 'closeout-1',
+          inferenceRetryNotice: true,
+          inferenceRetryActive: false,
+        },
+      });
+      expect(
+        mocks.upsertMessage.mock.calls
+          .map(([input]) => input.message.eventId)
+          .filter((eventId) => eventId.startsWith('100.2:assistant:')),
+      ).toHaveLength(0);
     } finally {
       timeout.mockRestore();
     }

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -169,6 +169,12 @@ vi.mock('../fast-agent-title', () => ({
 }));
 
 vi.mock('../fast-agent-turn-lock', () => ({
+  FastAgentTurnLockLostError: class extends Error {
+    constructor() {
+      super('Fast conversation lock ownership was lost.');
+      this.name = 'FastAgentTurnLockLostError';
+    }
+  },
   FastAgentProcessShutdownError: class extends Error {
     constructor(public readonly signal: NodeJS.Signals) {
       super(`Fast turn interrupted by API shutdown (${signal}).`);
@@ -196,7 +202,10 @@ import {
   type FastAgentTurnAdapter,
   type LaunchFastAgentTask,
 } from '../fast-agent-conversation';
-import { FastAgentProcessShutdownError } from '../fast-agent-turn-lock';
+import {
+  FastAgentProcessShutdownError,
+  FastAgentTurnLockLostError,
+} from '../fast-agent-turn-lock';
 
 const baseParams = {
   question: 'What does this service do?',
@@ -1702,9 +1711,9 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
     }
   });
 
-  it('stops a cancelled turn without posting a stale error closeout', async () => {
+  it('stops a lock-lost turn without posting a stale error closeout', async () => {
     const controller = new AbortController();
-    const lockLost = new Error('Fast conversation lock ownership was lost.');
+    const lockLost = new FastAgentTurnLockLostError();
     mocks.generateText.mockImplementationOnce(
       async (_params, _session, options) => {
         expect(options.signal).toBeInstanceOf(AbortSignal);
@@ -1735,12 +1744,13 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
     expect(mocks.generateText).toHaveBeenCalledOnce();
     expect(adapter.postReply).not.toHaveBeenCalled();
     expect(mocks.invalidateSession).toHaveBeenCalledWith('conversation-1');
+    expect(mocks.reconcileRetryNotices).toHaveBeenCalledOnce();
   });
 
-  it('closes a retry notice when conversation lock loss cancels backoff', async () => {
+  it('leaves a visible retry notice for the successor when lock loss cancels backoff', async () => {
     vi.useFakeTimers();
     const controller = new AbortController();
-    const lockLost = new Error('Fast conversation lock ownership was lost.');
+    const lockLost = new FastAgentTurnLockLostError();
     const postReply = vi.fn().mockImplementation(async () => {
       controller.abort(lockLost);
       return { messageId: 'retry-1' };
@@ -1771,15 +1781,18 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
         purpose: 'progress',
         message: expect.stringContaining('attempt 1/3'),
       });
-      expect(replaceReply).toHaveBeenCalledWith(
-        { messageId: 'retry-1' },
-        {
-          purpose: 'closeout',
-          message:
-            'The inference retry was interrupted before it completed. Please send the request again.',
-        },
-      );
+      expect(replaceReply).not.toHaveBeenCalled();
+      const retryWrites = mocks.upsertMessage.mock.calls
+        .map(([input]) => input.message)
+        .filter((message) => message.eventId === '100.2:retry-notice:0');
+      expect(retryWrites.at(-1)?.metadata).toMatchObject({
+        visibleInTranscript: true,
+        purpose: 'progress',
+        inferenceRetryNotice: true,
+        inferenceRetryActive: true,
+      });
       expect(mocks.invalidateSession).toHaveBeenCalledWith('conversation-1');
+      expect(mocks.reconcileRetryNotices).toHaveBeenCalledOnce();
     } finally {
       vi.useRealTimers();
     }
@@ -1787,7 +1800,7 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
 
   it('does not start another attempt when lock loss follows backoff expiry', async () => {
     const controller = new AbortController();
-    const lockLost = new Error('Fast conversation lock ownership was lost.');
+    const lockLost = new FastAgentTurnLockLostError();
     const postReply = vi.fn().mockResolvedValue({ messageId: 'retry-1' });
     const replaceReply = vi.fn().mockResolvedValue({ messageId: 'retry-1' });
     const originalSetTimeout = globalThis.setTimeout;
@@ -1819,6 +1832,16 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
       // retry notice to close after the lock is lost.
       expect(postReply).not.toHaveBeenCalled();
       expect(replaceReply).not.toHaveBeenCalled();
+      const retryWrites = mocks.upsertMessage.mock.calls
+        .map(([input]) => input.message)
+        .filter((message) => message.eventId === '100.2:retry-notice:0');
+      expect(retryWrites.at(-1)?.metadata).toMatchObject({
+        visibleInTranscript: false,
+        purpose: 'progress',
+        inferenceRetryNotice: true,
+        inferenceRetryActive: true,
+      });
+      expect(mocks.reconcileRetryNotices).toHaveBeenCalledOnce();
     } finally {
       timeout.mockRestore();
     }

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -28,6 +28,8 @@ const mocks = vi.hoisted(() => ({
   markShutdownCloseoutSettled: vi.fn(),
   revokeMcpCapabilities: vi.fn(),
   reconcileRetryNotices: vi.fn(),
+  getUnifiedSession: vi.fn(),
+  touchSessionActivity: vi.fn(),
   getSessionForTask: vi.fn(),
   nativeExecutor: undefined as
     | ((call: {
@@ -93,9 +95,9 @@ vi.mock('@roomote/db/server', () => ({
   appendFastAgentMemory: mocks.appendMemory,
   isBrainEnabled: mocks.isBrainEnabled,
   db: {},
-  getSessionForFastConversation: vi.fn().mockResolvedValue(null),
+  getSessionForFastConversation: mocks.getUnifiedSession,
   getSessionForTask: mocks.getSessionForTask,
-  touchSessionActivity: vi.fn().mockResolvedValue(undefined),
+  touchSessionActivity: mocks.touchSessionActivity,
 }));
 
 vi.mock('../../non-task-provider-usage', () => ({
@@ -278,6 +280,8 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
     mocks.nativeExecutor = undefined;
     mocks.mcpExecutor = undefined;
     mocks.mcpCapabilityAvailable = false;
+    mocks.getUnifiedSession.mockResolvedValue(null);
+    mocks.touchSessionActivity.mockResolvedValue(undefined);
     mocks.getSessionForTask.mockResolvedValue(null);
     mocks.getNativeRuntime.mockImplementation(async () => {
       mocks.mcpCapabilityAvailable = true;
@@ -1801,6 +1805,7 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
   it('does not start another attempt when lock loss follows backoff expiry', async () => {
     const controller = new AbortController();
     const lockLost = new FastAgentTurnLockLostError();
+    mocks.getUnifiedSession.mockResolvedValue({ id: 'session-1' });
     const postReply = vi.fn().mockResolvedValue({ messageId: 'retry-1' });
     const replaceReply = vi.fn().mockResolvedValue({ messageId: 'retry-1' });
     const originalSetTimeout = globalThis.setTimeout;
@@ -1842,6 +1847,13 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
         inferenceRetryActive: true,
       });
       expect(mocks.reconcileRetryNotices).toHaveBeenCalledOnce();
+      expect(mocks.touchSessionActivity).toHaveBeenCalledOnce();
+      expect(mocks.touchSessionActivity).toHaveBeenCalledWith(
+        expect.anything(),
+        'session-1',
+        expect.any(Number),
+        { respondingUntil: expect.any(Date) },
+      );
     } finally {
       timeout.mockRestore();
     }

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -2578,12 +2578,14 @@ export async function answerFastAgentQuestion({
           try {
             const posted = await adapter.postReply(reply);
             diagnostics.recordVisibleReply();
+            const retryEvent = inferenceRetryCanonicalEvent;
             await persistAssistantReply({
               reply,
-              event: allocateCanonicalEvent(
-                `assistant:${nextAssistantOrdinal++}`,
-              ),
+              event:
+                retryEvent ??
+                allocateCanonicalEvent(`assistant:${nextAssistantOrdinal++}`),
               platformMessageId: posted?.messageId,
+              inferenceRetryNotice: Boolean(retryEvent),
             });
           } catch (postError) {
             console.error(

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -104,6 +104,7 @@ import { getFastAgentUserIdentity } from './fast-agent-user-identity';
 import { FastAgentTurnDiagnostics } from './fast-agent-turn-diagnostics';
 import {
   FastAgentProcessShutdownError,
+  FastAgentTurnLockLostError,
   markFastAgentShutdownCloseoutPending,
   markFastAgentShutdownCloseoutSettled,
 } from './fast-agent-turn-lock';
@@ -2558,11 +2559,13 @@ export async function answerFastAgentQuestion({
     if (signal?.aborted) {
       const shutdownInterrupted =
         terminalError instanceof FastAgentProcessShutdownError;
+      const lockOwnershipLost =
+        terminalError instanceof FastAgentTurnLockLostError;
       try {
         if (canonicalConversationId) {
           fastAgentOpenCodeSessionManager.invalidate(canonicalConversationId);
         }
-        if (inferenceRetryReply) {
+        if (!lockOwnershipLost && inferenceRetryReply) {
           await replaceInferenceRetryReply(
             {
               purpose: 'closeout',
@@ -2658,7 +2661,15 @@ export async function answerFastAgentQuestion({
     }
     return lastVisibleMessage || message;
   } finally {
-    if (canonicalConversationId) {
+    // Once Redis reports ownership loss, this invocation is fenced off from
+    // the canonical lease/retry state below. A successor may already own and
+    // have renewed the Session lease; clearing it or reconciling the prior
+    // retry here would let the stale owner write an interruption over the
+    // successor. The new owner reconciles on entry, or the lease-gated
+    // scheduled reconciler repairs the marker later when no successor appears.
+    const lockOwnershipLost =
+      signal?.aborted && signal.reason instanceof FastAgentTurnLockLostError;
+    if (canonicalConversationId && !lockOwnershipLost) {
       await setFastSessionResponding(canonicalConversationId, false).catch(
         (error) => {
           console.warn(

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -1415,9 +1415,24 @@ export async function answerFastAgentQuestion({
       notice: FastAgentInferenceRetryNotice,
     ) => {
       inferenceRetryAttempted = true;
-      if (platformEvent) {
-        return;
-      }
+      const message = formatFastAgentInferenceRetryNotice(notice);
+      const reply = { purpose: 'progress' as const, message };
+
+      // Silence is a presentation choice, not permission to keep recovery
+      // entirely in memory. Persist the first retry immediately so an owner
+      // crash during quiet backoff leaves a durable marker for the expired-
+      // lease reconciler to turn into a terminal interruption.
+      inferenceRetryCanonicalEvent ??= allocateCanonicalEvent(
+        `retry-notice:${nextRetryNoticeOrdinal++}`,
+      );
+      await persistAssistantReply({
+        reply,
+        event: inferenceRetryCanonicalEvent,
+        inferenceRetryNotice: true,
+        visibleInTranscript: false,
+      });
+
+      if (platformEvent) return;
 
       // Stay silent while recovery is short enough that a standard task
       // would absorb it invisibly. A notice is only worth interrupting the
@@ -1431,7 +1446,6 @@ export async function answerFastAgentQuestion({
         return;
       }
 
-      const message = formatFastAgentInferenceRetryNotice(notice);
       if (reportedInferenceNotices.has(message)) {
         return;
       }
@@ -1439,16 +1453,10 @@ export async function answerFastAgentQuestion({
       reportedInferenceNotices.add(message);
       // Deliberately not the postReply closure: a system retry notice must
       // not satisfy the model's acknowledgement gate or close the turn.
-      const reply = { purpose: 'progress' as const, message };
       if (!(await replaceInferenceRetryReply(reply))) {
         inferenceRetryReply = (await adapter.postReply(reply)) || undefined;
         inferenceRetryMessageIndex = turnVisibleMessages.length;
         turnVisibleMessages.push(buildAssistantTextMessage(message));
-        // Ordinal-suffixed so a second retry episode in the same turn gets
-        // its own row instead of overwriting the first notice's upsert slot.
-        inferenceRetryCanonicalEvent ??= allocateCanonicalEvent(
-          `retry-notice:${nextRetryNoticeOrdinal++}`,
-        );
         await persistAssistantReply({
           reply,
           event: inferenceRetryCanonicalEvent,


### PR DESCRIPTION
## Why this PR exists

- [x] I am a maintainer / this is internal Roomote work

## What changed

- Persist a hidden canonical retry marker as soon as Fast enters retry recovery.
- Keep short retries quiet on the user-facing surface while preserving enough durable state to recover an orphaned turn.
- Retire the marker on successful recovery and let expired-lease reconciliation turn abandoned markers into terminal closeouts.

The quiet-retry window previously suppressed both the user-facing notice and its canonical persistence. If the turn owner disappeared during that window, the Session retained its prompt and tool activity but had no durable retry marker or terminal assistant event for reconciliation to repair.

## How it was tested

- Fast service and conversation repository tests: 123 passed.
- Scheduled Session reconciliation tests: 7 passed.
- `pnpm lint:fast`, `pnpm check-types:fast`, and `pnpm knip` passed.
- Controlled smoke: forced a retryable provider outage through the real Fast/OpenCode path, hard-killed the turn owner while the retry marker was still hidden, expired the responding lease, and ran the real scheduled reconciliation function. The same marker became a visible inactive closeout, and the local Session UI showed a terminal interruption with `ready` status instead of an orphaned turn.

## Checklist

- [x] The PR title follows the repository convention.
- [x] This PR is small and scoped to one change.
- [x] Lint and type checks pass locally.
- [x] Tests and manual validation are included above.
- [x] No secrets, private data, or customer details are included.