### PR TITLE
[Fix] Show attached task rows in Sessions without a Fast conversation

### DIFF
--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionTaskTimeline.tsx
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionTaskTimeline.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { useTRPC } from '@/trpc/client';
+
+import { DelegatedTaskCard } from '../../task/[taskId]/messages/acp/DelegatedTaskCard';
+import { useOpenSessionTaskPanel } from './session-task-panel-context';
+
+/**
+ * Body for a Session with no Fast conversation (automation-owned Sessions such
+ * as code reviews): render each attached task as a started-task row instead of
+ * leaving the Session a bare header. Rows open the nested task panel.
+ */
+export function SessionTaskTimeline({
+  sessionId,
+  initialTasks,
+}: {
+  sessionId: string;
+  initialTasks: Array<{ taskId: string; title: string | null }>;
+}) {
+  const trpc = useTRPC();
+  const openTaskPanel = useOpenSessionTaskPanel();
+  // Same query key as SessionWorkspace's poll, so this reads its cache and
+  // picks up tasks attached after the initial server render.
+  const { data } = useQuery(trpc.sessions.byId.queryOptions({ sessionId }));
+  const tasks = data?.tasks ?? initialTasks;
+
+  if (tasks.length === 0) return null;
+
+  return (
+    <div className="scroll-thin min-h-0 flex-1 overflow-y-auto px-4 py-2 @[600px]:px-6">
+      <div className="mx-auto w-full max-w-3xl">
+        {tasks.map((task) => (
+          <DelegatedTaskCard
+            key={task.taskId}
+            taskId={task.taskId}
+            prompt={task.title}
+            onOpen={(taskId) => openTaskPanel?.(taskId)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/page.test.tsx
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/page.test.tsx
@@ -7,6 +7,7 @@ const {
   getFastSessionTasksMock,
   getSessionByIdCommandMock,
   transcriptMock,
+  sessionTaskTimelineMock,
   sessionWorkspaceMock,
 } = vi.hoisted(() => ({
   authorizeMock: vi.fn(),
@@ -18,6 +19,9 @@ const {
       <div data-testid="transcript">{footer}</div>
     ),
   ),
+  sessionTaskTimelineMock: vi.fn(() => (
+    <div data-testid="session-task-timeline" />
+  )),
   sessionWorkspaceMock: vi.fn(({ children }: { children: ReactNode }) => (
     <main data-testid="workspace-surface">{children}</main>
   )),
@@ -56,6 +60,9 @@ vi.mock('@/components/layout', () => ({
 }));
 vi.mock('./FastSessionTranscript', () => ({
   FastSessionTranscript: transcriptMock,
+}));
+vi.mock('./SessionTaskTimeline', () => ({
+  SessionTaskTimeline: sessionTaskTimelineMock,
 }));
 vi.mock('./SessionWorkspace', () => ({
   SessionWorkspace: sessionWorkspaceMock,
@@ -360,6 +367,19 @@ describe('Session detail page', () => {
     expect(getFastSessionByIdMock).not.toHaveBeenCalled();
     expect(transcriptMock).not.toHaveBeenCalled();
     expect(html).toContain('Task-only session');
+    expect(html).toContain('session-task-timeline');
+    expect(sessionTaskTimelineMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: '6a1f8f1e-0000-4000-8000-000000000004',
+        initialTasks: [
+          expect.objectContaining({
+            taskId: 'task-2',
+            title: 'Delegated task',
+          }),
+        ],
+      }),
+      undefined,
+    );
   });
 
   it('falls back to the Fast conversation lookup when no session row exists', async () => {

--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/page.tsx
@@ -21,6 +21,7 @@ import { getSessionByIdCommand } from '@/trpc/commands/sessions';
 import { WorkspaceHeader } from '@/components/layout';
 
 import { FastSessionTranscript } from './FastSessionTranscript';
+import { SessionTaskTimeline } from './SessionTaskTimeline';
 import {
   SessionHeaderExtras,
   SessionWorkspace,
@@ -143,15 +144,21 @@ export default async function SessionDetailPage({
               }
             />
           ) : (
-            <WorkspaceHeader
-              className="py-4"
-              contentClassName="items-stretch gap-2 pr-12 @[600px]:items-center @[600px]:gap-3 @[600px]:pr-4"
-            >
-              <h1 className="min-w-0 flex-1 break-words text-sm font-medium @[600px]:truncate">
-                {unifiedSession.title}
-              </h1>
-              <SessionHeaderExtras status={unifiedSession.status} />
-            </WorkspaceHeader>
+            <>
+              <WorkspaceHeader
+                className="py-4"
+                contentClassName="items-stretch gap-2 pr-12 @[600px]:items-center @[600px]:gap-3 @[600px]:pr-4"
+              >
+                <h1 className="min-w-0 flex-1 break-words text-sm font-medium @[600px]:truncate">
+                  {unifiedSession.title}
+                </h1>
+                <SessionHeaderExtras status={unifiedSession.status} />
+              </WorkspaceHeader>
+              <SessionTaskTimeline
+                sessionId={unifiedSession.id}
+                initialTasks={unifiedSession.tasks}
+              />
+            </>
           )}
         </div>
       </SessionWorkspace>


### PR DESCRIPTION
## Problem

Sessions with no Fast conversation — automation-owned Sessions like code reviews (`review_code`), Sentry triage, and backfilled task Sessions — rendered only the workspace header with a completely empty body. The review content was reachable only by clicking the task chip in the header, which made review Sessions look broken.

## Fix

Add `SessionTaskTimeline`: when a unified Session has no Fast conversation, render each attached task as the existing `DelegatedTaskCard` "Started coding task" row under the header. Rows show live task status and open the nested task panel, matching how delegated tasks behave in Fast transcripts. The component shares `sessions.byId`'s query cache, so tasks attached after the initial render appear without extra polling.

## Validation

- `pnpm --filter @roomote/web exec vitest run "src/app/(sandbox)/sessions/[sessionId]/page.test.tsx"` — 6 passed, including a new assertion that the task-only branch renders the timeline with the session's tasks
- `pnpm lint`, `pnpm --filter @roomote/web check-types` — clean