### PR TITLE
[Feat] Route automated Slack and Discord entries through Fast

### DIFF
--- a/apps/api/src/handlers/discord/__tests__/channel-auto-start.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/channel-auto-start.test.ts
@@ -502,6 +502,11 @@ describe('maybeHandleDiscordChannelAutoStart', () => {
       expect.objectContaining({
         senderUserId: 'installer-1',
         directedAtRoomote: true,
+        delegatedTaskInitiator: {
+          kind: 'automation',
+          key: 'slack_channel_auto_start',
+          actor: { externalId: 'alert-bot', displayName: 'alerts' },
+        },
       }),
     );
     expect(mocks.startNewTask).not.toHaveBeenCalled();

--- a/apps/api/src/handlers/discord/__tests__/channel-auto-start.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/channel-auto-start.test.ts
@@ -21,6 +21,8 @@ const mocks = vi.hoisted(() => ({
   postMessage: vi.fn(),
   addReaction: vi.fn(),
   processFast: vi.fn(),
+  startFastResponse: vi.fn(),
+  findInstallation: vi.fn(),
 }));
 
 vi.mock('@roomote/redis', async (importOriginal) => {
@@ -38,6 +40,7 @@ vi.mock('@roomote/db/server', () => ({
 
 vi.mock('@roomote/sdk/server', () => ({
   findDiscordMappedUserId: mocks.findMappedUserId,
+  findDiscordInstallationByGuildId: mocks.findInstallation,
 }));
 
 vi.mock('../../shared/channel-launch-gate.js', async (importOriginal) => ({
@@ -58,6 +61,7 @@ vi.mock('../fast-agent.js', () => ({
   ) =>
     channel.isDirectMessage || channel.isThread ? channel.channelId : eventId,
   processDiscordFastAgentMessage: mocks.processFast,
+  startDiscordFastAgentResponse: mocks.startFastResponse,
 }));
 
 vi.mock('../task-orchestration.js', () => ({
@@ -204,6 +208,15 @@ describe('maybeHandleDiscordChannelAutoStart', () => {
       ]),
     );
     mocks.findMappedUserId.mockResolvedValue('roomote-user-1');
+    mocks.findInstallation.mockResolvedValue({
+      installedByUserId: 'installer-1',
+    });
+    // Bot-authored coverage below exercises the direct-task fallback unless a
+    // test opts into an accepted Fast turn explicitly.
+    mocks.startFastResponse.mockResolvedValue({
+      accepted: false,
+      reason: 'Fast session is busy.',
+    });
     mocks.evaluateGate.mockResolvedValue({
       shouldLaunch: true,
       debug: { llmDecision: 'launch', reason: 'ok' },
@@ -469,6 +482,46 @@ describe('maybeHandleDiscordChannelAutoStart', () => {
       });
     },
   );
+
+  it('routes a bot-authored message to Fast under the installer identity when the turn is accepted', async () => {
+    mocks.startFastResponse.mockResolvedValue({
+      accepted: true,
+      abort: vi.fn(),
+    });
+
+    await expect(
+      runHandler({
+        payload: messagePayload({
+          author: { id: 'alert-bot', username: 'alerts', bot: true },
+        }),
+      }),
+    ).resolves.toBe(true);
+    await flushBackgroundWork();
+
+    expect(mocks.startFastResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        senderUserId: 'installer-1',
+        directedAtRoomote: true,
+      }),
+    );
+    expect(mocks.startNewTask).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a direct task launch when no installer identity exists', async () => {
+    mocks.findInstallation.mockResolvedValue(null);
+
+    await expect(
+      runHandler({
+        payload: messagePayload({
+          author: { id: 'alert-bot', username: 'alerts', bot: true },
+        }),
+      }),
+    ).resolves.toBe(true);
+    await flushBackgroundWork();
+
+    expect(mocks.startFastResponse).not.toHaveBeenCalled();
+    expect(mocks.startNewTask).toHaveBeenCalledTimes(1);
+  });
 
   it('consults the launch gate when criteria are configured and stays silent on skip', async () => {
     mocks.getBackgroundAgentSettings.mockResolvedValue(

--- a/apps/api/src/handlers/discord/channel-auto-start.ts
+++ b/apps/api/src/handlers/discord/channel-auto-start.ts
@@ -16,7 +16,10 @@ import {
   REDIS_KEYS,
   syncAutoStartChannelCacheBestEffort,
 } from '@roomote/redis';
-import { findDiscordMappedUserId } from '@roomote/sdk/server';
+import {
+  findDiscordInstallationByGuildId,
+  findDiscordMappedUserId,
+} from '@roomote/sdk/server';
 import {
   MANAGED_DEPLOYMENT_READ_ONLY_MESSAGE,
   isDeploymentReadOnlyError,
@@ -40,6 +43,7 @@ import { processDiscordAttachments } from './attachments.js';
 import {
   getDiscordFastConversationId,
   processDiscordFastAgentMessage,
+  startDiscordFastAgentResponse,
 } from './fast-agent.js';
 import { rememberPendingDiscordAccountLinkTask } from './pending-account-link-task.js';
 import { startNewDiscordTask } from './task-orchestration.js';
@@ -391,6 +395,48 @@ export async function maybeHandleDiscordChannelAutoStart(input: {
           }
           await releaseRoutingLock();
           return;
+        }
+      }
+
+      // Bot/webhook-authored feed messages get the same first hop as a human
+      // post in this channel: a Fast turn under the automation launch
+      // identity (the guild installer), with the direct task launch below as
+      // the fallback — mirroring the Slack auto-start path. The launch gate
+      // above still decides whether the message warrants any response.
+      if (isBotAuthored) {
+        const installation = channel.guildId
+          ? await findDiscordInstallationByGuildId(channel.guildId)
+          : null;
+        const automationLaunchUserId = installation?.installedByUserId ?? null;
+
+        if (automationLaunchUserId) {
+          const fastStart = await startDiscordFastAgentResponse({
+            event,
+            question: queuedMessage.text,
+            sender: message.author,
+            senderUserId: automationLaunchUserId,
+            provider,
+            applicationId: input.applicationId,
+            channel,
+            metadata,
+            conversationId: getDiscordFastConversationId(channel, message.id),
+            directedAtRoomote: true,
+          });
+
+          if (fastStart.accepted) {
+            apiLogger.info(
+              `[DiscordChannelAutoStart] Routed ${logContext} to Fast under the automation identity`,
+            );
+            return;
+          }
+
+          apiLogger.warn(
+            `[DiscordChannelAutoStart] Fast entry not accepted (${fastStart.reason}) for ${logContext}; falling back to direct task launch`,
+          );
+        } else {
+          apiLogger.warn(
+            `[DiscordChannelAutoStart] No installer launch identity for ${logContext}; falling back to direct task launch`,
+          );
         }
       }
 

--- a/apps/api/src/handlers/discord/channel-auto-start.ts
+++ b/apps/api/src/handlers/discord/channel-auto-start.ts
@@ -421,6 +421,7 @@ export async function maybeHandleDiscordChannelAutoStart(input: {
             metadata,
             conversationId: getDiscordFastConversationId(channel, message.id),
             directedAtRoomote: true,
+            delegatedTaskInitiator: initiator,
           });
 
           if (fastStart.accepted) {

--- a/apps/api/src/handlers/discord/fast-agent.ts
+++ b/apps/api/src/handlers/discord/fast-agent.ts
@@ -29,7 +29,7 @@ import {
   recordFastAgentConversationMessageBestEffort,
   resolveUserMcpServerConfigs,
 } from '@roomote/sdk/server';
-import { ALL_REPOSITORIES } from '@roomote/types';
+import { ALL_REPOSITORIES, type TaskInitiator } from '@roomote/types';
 
 import { buildCommunicationTaskThreadName } from '../tasks/communication-task-thread.js';
 import {
@@ -99,6 +99,10 @@ export async function processDiscordFastAgentMessage(
     interaction?: DiscordInteractionReplyContext;
     activeTasks?: { taskId: string }[];
     directedAtRoomote?: boolean;
+    /** Attribution for tasks Fast delegates from this turn; automation-identity
+     * turns pass their automation initiator so delegated work keeps automation
+     * provenance instead of appearing installer-initiated. */
+    delegatedTaskInitiator?: TaskInitiator;
     onAccepted?: (abort: () => Promise<void>) => void;
     onRejected?: () => void;
   } & DiscordFastAgentSource,
@@ -301,6 +305,9 @@ export async function processDiscordFastAgentMessage(
             applicationId: input.applicationId,
             requesterDiscordUserId: input.sender.id,
             launchOwnerUserId: input.senderUserId,
+            ...(input.delegatedTaskInitiator
+              ? { initiator: input.delegatedTaskInitiator }
+              : {}),
             queuedMessage: {
               provider: 'discord',
               text: prompt,

--- a/apps/api/src/handlers/discord/task-orchestration.ts
+++ b/apps/api/src/handlers/discord/task-orchestration.ts
@@ -83,6 +83,9 @@ export async function startNewDiscordTask(input: {
   requesterDiscordUserId: string;
   /** Absent only for automation-owned channel auto-start launches. */
   launchOwnerUserId?: string;
+  /** Attribution override; takes precedence over the default user initiator
+   * (and over `channelAutoStart.initiator` when both are set). */
+  initiator?: TaskInitiator;
   queuedMessage: QueuedCommunicationMessage;
   metadata: DiscordEventCommunicationMetadata;
   channel: DiscordChannelContext;
@@ -364,9 +367,11 @@ export async function startNewDiscordTask(input: {
     const launched = await launchDiscordTask({
       provider: input.provider,
       launchOwnerUserId: input.launchOwnerUserId,
-      ...(input.channelAutoStart
-        ? { initiator: input.channelAutoStart.initiator }
-        : {}),
+      ...(input.initiator
+        ? { initiator: input.initiator }
+        : input.channelAutoStart
+          ? { initiator: input.channelAutoStart.initiator }
+          : {}),
       ...(agentPromptText ? { agentPromptText } : {}),
       queuedMessage: {
         ...input.queuedMessage,

--- a/apps/api/src/handlers/slack/events/channel-auto-start-failure.test.ts
+++ b/apps/api/src/handlers/slack/events/channel-auto-start-failure.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   recordInboundMessage: vi.fn(),
   postRoutingDebug: vi.fn(),
   automationLaunchIdentity: vi.fn(),
+  processFastAgentMessage: vi.fn(),
   logWarn: vi.fn(),
 }));
 
@@ -56,6 +57,11 @@ vi.mock('../../shared/channel-launch-gate.js', async (importOriginal) => ({
     typeof import('../../shared/channel-launch-gate.js')
   >()),
   evaluateChannelLaunchGate: mocks.evaluateGate,
+}));
+
+vi.mock('./fast-agent.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./fast-agent.js')>()),
+  processFastAgentMessage: mocks.processFastAgentMessage,
 }));
 
 vi.mock('../helpers/attachments.js', () => ({
@@ -140,6 +146,13 @@ describe('Slack channel auto-start failures', () => {
       launchUserId: 'installer-1',
       slackUserId: 'UBOT',
     });
+    // Bot-authored coverage below exercises the direct-task fallback unless a
+    // test opts into an accepted Fast turn explicitly.
+    mocks.processFastAgentMessage.mockImplementation(
+      async ({ onRejected }: { onRejected?: () => void }) => {
+        onRejected?.();
+      },
+    );
     postMessage.mockResolvedValue({ ts: 'reply-1' });
     vi.mocked(slack.addReaction).mockResolvedValue(undefined);
     vi.mocked(slack.getChannelName).mockResolvedValue('forge');
@@ -254,6 +267,29 @@ describe('Slack channel auto-start failures', () => {
 
     expect(postMessage).not.toHaveBeenCalled();
     expect(mocks.startTask).not.toHaveBeenCalled();
+  });
+
+  it('routes a bot-authored message to Fast under the automation identity when the turn is accepted', async () => {
+    mocks.processFastAgentMessage.mockImplementation(
+      async ({ onAccepted }: { onAccepted?: (abort: () => void) => void }) => {
+        onAccepted?.(() => {});
+      },
+    );
+
+    await expect(runHandler(undefined, { isBotAuthored: true })).resolves.toBe(
+      true,
+    );
+    await flushBackgroundWork();
+
+    expect(mocks.processFastAgentMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'installer-1',
+        continuation: true,
+        event: expect.objectContaining({ user: 'UBOT' }),
+      }),
+    );
+    expect(mocks.startTask).not.toHaveBeenCalled();
+    expect(postMessage).not.toHaveBeenCalled();
   });
 
   it('stays silent when task startup throws for a bot-authored message', async () => {

--- a/apps/api/src/handlers/slack/events/channel-auto-start-failure.test.ts
+++ b/apps/api/src/handlers/slack/events/channel-auto-start-failure.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   postRoutingDebug: vi.fn(),
   automationLaunchIdentity: vi.fn(),
   processFastAgentMessage: vi.fn(),
+  liveTaskLauncher: vi.fn(() => vi.fn()),
   logWarn: vi.fn(),
 }));
 
@@ -48,7 +49,7 @@ vi.mock('@roomote/redis', async (importOriginal) => ({
 
 vi.mock('@roomote/slack', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@roomote/slack')>()),
-  createFastAgentSlackLiveTaskLauncher: vi.fn(() => vi.fn()),
+  createFastAgentSlackLiveTaskLauncher: mocks.liveTaskLauncher,
   startAutoRoutedSlackTask: mocks.startTask,
 }));
 
@@ -286,6 +287,15 @@ describe('Slack channel auto-start failures', () => {
         userId: 'installer-1',
         continuation: true,
         event: expect.objectContaining({ user: 'UBOT' }),
+      }),
+    );
+    expect(mocks.liveTaskLauncher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initiator: {
+          kind: 'automation',
+          key: 'slack_channel_auto_start',
+          actor: { externalId: 'U123' },
+        },
       }),
     );
     expect(mocks.startTask).not.toHaveBeenCalled();

--- a/apps/api/src/handlers/slack/events/message-entry-automated-mention.test.ts
+++ b/apps/api/src/handlers/slack/events/message-entry-automated-mention.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   processAttachments: vi.fn(),
   automationLaunchIdentity: vi.fn(),
   processFastAgentMessage: vi.fn(),
+  liveTaskLauncher: vi.fn(() => vi.fn()),
   lookupSlackUserMapping: vi.fn(),
 }));
 
@@ -32,7 +33,7 @@ vi.mock('@roomote/redis', async (importOriginal) => ({
 
 vi.mock('@roomote/slack', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@roomote/slack')>()),
-  createFastAgentSlackLiveTaskLauncher: vi.fn(() => vi.fn()),
+  createFastAgentSlackLiveTaskLauncher: mocks.liveTaskLauncher,
   startAutoRoutedSlackTask: mocks.startTask,
 }));
 
@@ -134,6 +135,15 @@ describe('automated Slack message mentions', () => {
           channel: 'C123',
           user: 'U_INSTALLER',
         }),
+      }),
+    );
+    expect(mocks.liveTaskLauncher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initiator: {
+          kind: 'automation',
+          key: 'slack_channel_auto_start',
+          actor: { externalId: 'U_WORKFLOW' },
+        },
       }),
     );
     expect(mocks.startTask).not.toHaveBeenCalled();

--- a/apps/api/src/handlers/slack/events/message-entry-automated-mention.test.ts
+++ b/apps/api/src/handlers/slack/events/message-entry-automated-mention.test.ts
@@ -8,6 +8,8 @@ const mocks = vi.hoisted(() => ({
   startTask: vi.fn(),
   processAttachments: vi.fn(),
   automationLaunchIdentity: vi.fn(),
+  processFastAgentMessage: vi.fn(),
+  lookupSlackUserMapping: vi.fn(),
 }));
 
 vi.mock('@roomote/env', () => ({
@@ -42,6 +44,15 @@ vi.mock('../helpers/launch-identity.js', () => ({
   getSlackAutomationLaunchIdentity: mocks.automationLaunchIdentity,
 }));
 
+vi.mock('./fast-agent.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./fast-agent.js')>()),
+  processFastAgentMessage: mocks.processFastAgentMessage,
+}));
+
+vi.mock('../helpers/user-mapping.js', () => ({
+  lookupSlackUserMapping: mocks.lookupSlackUserMapping,
+}));
+
 vi.mock('./thread-follow-up-dispatch.js', () => ({
   resolveSlackThreadFollowUpRoute: vi.fn().mockResolvedValue({ kind: 'fresh' }),
   dispatchSlackThreadFollowUp: vi.fn(
@@ -72,9 +83,69 @@ describe('automated Slack message mentions', () => {
       runId: 'RUN_123',
       taskId: 'TASK_123',
     });
+    mocks.lookupSlackUserMapping.mockResolvedValue({
+      activeMapping: null,
+      hasInactiveMapping: false,
+    });
+    mocks.processFastAgentMessage.mockImplementation(
+      async ({ onAccepted }: { onAccepted?: (abort: () => void) => void }) => {
+        onAccepted?.(() => {});
+      },
+    );
   });
 
-  it('starts an automation task for an external bot_message mentioning Roomote', async () => {
+  it('routes an external bot_message mentioning Roomote to Fast under the automation identity', async () => {
+    const { handleMessageOrAppMentionEvent } =
+      await import('./message-entry.js');
+
+    await handleMessageOrAppMentionEvent({
+      event: {
+        type: 'message',
+        subtype: 'bot_message',
+        channel: 'C123',
+        channel_type: 'channel',
+        user: 'U_WORKFLOW',
+        bot_id: 'B_WORKFLOW',
+        app_id: 'A_WORKFLOW',
+        text: '<@U_ROOMOTE> investigate this deployment',
+        ts: '1712345678.000200',
+      },
+      context: {
+        slackInstallation: {
+          appId: 'A_ROOMOTE',
+          botUserId: 'U_ROOMOTE',
+          installedByUserId: 'USER_INSTALLER',
+        } as never,
+        slack: {} as never,
+        teamId: 'T123',
+      },
+    });
+
+    await vi.waitFor(() =>
+      expect(mocks.processFastAgentMessage).toHaveBeenCalledTimes(1),
+    );
+    expect(mocks.processFastAgentMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'USER_INSTALLER',
+        teamId: 'T123',
+        continuation: true,
+        directedAtRoomote: true,
+        event: expect.objectContaining({
+          channel: 'C123',
+          user: 'U_INSTALLER',
+        }),
+      }),
+    );
+    expect(mocks.startTask).not.toHaveBeenCalled();
+  }, 30000);
+
+  it('falls back to an automation task when the Fast turn is not accepted', async () => {
+    mocks.processFastAgentMessage.mockImplementation(
+      async ({ onRejected }: { onRejected?: () => void }) => {
+        onRejected?.();
+      },
+    );
+
     const { handleMessageOrAppMentionEvent } =
       await import('./message-entry.js');
 

--- a/apps/api/src/handlers/slack/events/message-entry.ts
+++ b/apps/api/src/handlers/slack/events/message-entry.ts
@@ -1479,6 +1479,49 @@ async function processAutomatedAppMentionTask(params: {
       return { handled: false };
     },
     onFresh: async () => {
+      // Same first hop as a human mention: give Fast the turn under the
+      // automation launch identity and let it delegate coding work itself.
+      // The direct task launch below stays as the fallback so an automated
+      // ticket is never dropped when the Fast turn cannot start.
+      const { ackEmoji } = await resolveSlackReactionNames();
+      const { activeMapping: launchUserMapping } =
+        launchIdentity.slackUserId === slackInstallation.botUserId
+          ? { activeMapping: null }
+          : await lookupSlackUserMapping({
+              slackUserId: launchIdentity.slackUserId,
+              teamId,
+            });
+      const fastStart = await startFastAgentResponse({
+        event: threadEvent,
+        slackInstallation,
+        ...(launchUserMapping ? { userMapping: launchUserMapping } : {}),
+        slack,
+        userId: launchIdentity.launchUserId,
+        teamId,
+        continuation: true,
+        directedAtRoomote: true,
+        resolveActiveTasks: () =>
+          resolveFastAgentReplyTasks({
+            slack,
+            slackTeamId: teamId,
+            channelId: event.channel,
+            threadTs: threadId,
+          }),
+        processingReactionName: ackEmoji,
+        errorLogPrefix: `❌ Background fast-agent response failed for automated mention thread ${threadId}:`,
+      });
+
+      if (fastStart.accepted) {
+        apiLogger.info(
+          `[SlackWebhook] Automated app_mention routed to Fast thread_id=${threadId} channel=${event.channel} app_id=${event.app_id}`,
+        );
+        return true;
+      }
+
+      apiLogger.warn(
+        `[SlackWebhook] Automated app_mention Fast entry not accepted (${fastStart.reason}); falling back to direct task launch for thread ${threadId}`,
+      );
+
       const { images, attachmentTexts, videoDescriptions } =
         await processSlackAttachments({
           slack,
@@ -1624,7 +1667,8 @@ async function startAutomatedAppMentionTaskWithLock(params: {
 export function startFastAgentResponse(params: {
   event: SlackEvent;
   slackInstallation: SlackInstallation;
-  userMapping: SlackUserMapping;
+  /** Absent only for automation-identity turns (no linked human author). */
+  userMapping?: SlackUserMapping;
   slack: SlackNotifier;
   userId: string;
   teamId: string;

--- a/apps/api/src/handlers/slack/events/message-entry.ts
+++ b/apps/api/src/handlers/slack/events/message-entry.ts
@@ -975,6 +975,13 @@ export async function processSlackChannelAutoStartTask(params: {
             event,
             slackInstallation.botUserId,
           ),
+          delegatedTaskInitiator: {
+            kind: 'automation',
+            key: 'slack_channel_auto_start',
+            ...(typeof event.user === 'string'
+              ? { actor: { externalId: event.user } }
+              : {}),
+          },
           processingReactionName: ackEmoji,
           errorLogPrefix: `❌ Background fast-agent response failed for configured channel auto-start thread ${threadId}:`,
         });
@@ -1546,6 +1553,13 @@ async function processAutomatedAppMentionTask(params: {
         teamId,
         continuation: true,
         directedAtRoomote: true,
+        delegatedTaskInitiator: {
+          kind: 'automation',
+          key: 'slack_channel_auto_start',
+          ...(typeof event.user === 'string'
+            ? { actor: { externalId: event.user } }
+            : {}),
+        },
         resolveActiveTasks: () =>
           resolveFastAgentReplyTasks({
             slack,
@@ -1724,9 +1738,13 @@ export function startFastAgentResponse(params: {
   processingReactionName: string;
   isExistingConversation?: boolean;
   directedAtRoomote?: boolean;
+  /** Attribution for tasks Fast delegates from this turn; automation-identity
+   * turns pass their automation initiator so delegated work keeps automation
+   * provenance instead of appearing installer-initiated. */
+  delegatedTaskInitiator?: TaskInitiator;
   errorLogPrefix: string;
 }): Promise<FastAgentStartResult> {
-  const { errorLogPrefix, ...fastAgentParams } = params;
+  const { errorLogPrefix, delegatedTaskInitiator, ...fastAgentParams } = params;
   return startAcceptedFastAgentTurn({
     run: ({ onAccepted, onRejected }) =>
       processFastAgentMessage({
@@ -1737,6 +1755,9 @@ export function startFastAgentResponse(params: {
           slack: params.slack,
           userId: params.userId,
           teamId: params.teamId,
+          ...(delegatedTaskInitiator
+            ? { initiator: delegatedTaskInitiator }
+            : {}),
           ...(params.slackInstallation.teamDomain
             ? { teamDomain: params.slackInstallation.teamDomain }
             : {}),

--- a/apps/api/src/handlers/slack/events/message-entry.ts
+++ b/apps/api/src/handlers/slack/events/message-entry.ts
@@ -959,6 +959,52 @@ export async function processSlackChannelAutoStartTask(params: {
         }
       }
 
+      // Bot-authored feed messages get the same first hop as a human post in
+      // this channel: a Fast turn under the automation launch identity, with
+      // the direct task launch below as the fallback. The launch gate above
+      // still decides whether the message warrants any response at all.
+      if (isBotAuthored) {
+        const fastStart = await startFastAgentResponse({
+          event: { ...event, user: launchIdentity.slackUserId },
+          slackInstallation,
+          slack,
+          userId: launchIdentity.launchUserId,
+          teamId,
+          continuation: true,
+          directedAtRoomote: mentionsSlackBot(
+            event,
+            slackInstallation.botUserId,
+          ),
+          processingReactionName: ackEmoji,
+          errorLogPrefix: `❌ Background fast-agent response failed for configured channel auto-start thread ${threadId}:`,
+        });
+
+        if (fastStart.accepted) {
+          if (channelAutoStartDebug) {
+            await postChannelAutoStartRoutingDebugBestEffort({
+              slack,
+              sourceChannelId: event.channel,
+              sourceChannelName,
+              threadId,
+              messageText: event.text,
+              launchMode: channelAutoStartLaunchMode,
+              llmDecision: channelAutoStartDebug.llmDecision,
+              llmReason: channelAutoStartDebug.reason,
+              taskOutcome: 'started',
+              taskOutcomeDetails: 'Routed to Fast.',
+            });
+          }
+          apiLogger.info(
+            `[SlackWebhook] Configured channel auto-start routed to Fast thread_id=${threadId} channel=${event.channel}`,
+          );
+          return;
+        }
+
+        apiLogger.warn(
+          `[SlackWebhook] Configured channel auto-start Fast entry not accepted (${fastStart.reason}); falling back to direct task launch for thread ${threadId}`,
+        );
+      }
+
       if (humanUserMapping && typeof event.user === 'string') {
         await recordInboundSlackConversationMessage({
           event: { ...event, user: event.user },

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-task-launcher.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-task-launcher.ts
@@ -131,6 +131,10 @@ export type FastAgentSlackTaskLauncherParams = {
   channelId: string;
   threadTs: string;
   messageId?: string;
+  /** Attribution override for delegated tasks; automation-identity Fast
+   * turns pass their automation initiator so delegated work is not
+   * persisted as user-initiated by the launch owner. */
+  initiator?: TaskInitiator;
   /** Opt the child into the native Slack task card in the parent thread. */
   liveTaskStream?: boolean;
 } & FastAgentTaskLaunchHooks;
@@ -149,6 +153,7 @@ export function createFastAgentSlackTaskLauncher(
   return createFastAgentTaskLauncher({
     userId: params.userId,
     surface: 'slack',
+    ...(params.initiator ? { initiator: params.initiator } : {}),
     taskUrlCampaign: 'fast-delegation',
     afterKickoff: params.afterKickoff,
     onQueueFailure: params.onQueueFailure,


### PR DESCRIPTION
## What changed

Bot- and workflow-authored entries previously bypassed Fast and launched coding tasks directly, because Fast entry required a linked human author. All three such paths now get the same first hop as human messages: a Fast turn in the thread under the deployment's automation launch identity, with the previous direct task launch kept as an explicit fallback whenever the Fast turn is not accepted — so automated tickets and feeds are never dropped.

1. **Slack automated @mentions** (`processAutomatedAppMentionTask`): fresh threads start a Fast turn (`continuation`/`directedAtRoomote`, installer identity, installer's user mapping when one exists). Active-run continuations and snapshot resumes still route to the owning task.
2. **Slack channel auto-start, bot-authored** (`processSlackChannelAutoStartTask`): after the existing launch gate approves a feed message, it now enters Fast under the automation identity instead of `startAutoRoutedSlackTask`. Launch criteria, rate limiting, and routing-debug reporting are unchanged; a Fast-handled message reports `Routed to Fast.` in the routing debug.
3. **Discord channel auto-start, bot/webhook-authored** (`maybeHandleDiscordChannelAutoStart`): same mirror using the guild installation's `installedByUserId` as the automation identity; falls back to the direct task launch when the turn is not accepted or no installer identity exists.

Also: `startFastAgentResponse`'s `userMapping` becomes optional for automation-identity turns (not consumed downstream).

## Validation

- `pnpm --filter @roomote/api exec vitest run src/handlers/slack src/handlers/discord` — 49 files, 454 tests passed, including new coverage for each path: Fast accepted, Fast not accepted → task fallback, and (Discord) missing installer identity → task fallback.
- `pnpm lint`, `pnpm --filter @roomote/api check-types` — clean.

## Notes

- Human behavior is untouched; the launch gate still filters bot feeds before any response.
- Teams and Telegram never process bot-authored messages, so no further provider parity is owed for this change.