### PR TITLE
fix: avoid hydration mismatch from locale date formatting on session pages

### DIFF
--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionWorkspace.tsx
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionWorkspace.tsx
@@ -52,6 +52,7 @@ import {
   Info,
   LayoutGrid,
   Loader2Icon,
+  LocalDateTime,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -613,12 +614,7 @@ function SessionInfoPanel({
           <SandboxInfoRow label="Started At">
             <span className="inline-flex items-center gap-1.5">
               <Calendar className="size-3.5 shrink-0 text-muted-foreground" />
-              <span className="truncate">
-                {session.createdAt.toLocaleString(undefined, {
-                  dateStyle: 'medium',
-                  timeStyle: 'short',
-                })}
-              </span>
+              <LocalDateTime date={session.createdAt} className="truncate" />
             </span>
           </SandboxInfoRow>
           <SandboxInfoRow label="Started From">

--- a/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-panels/TaskInfoPanel.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-panels/TaskInfoPanel.tsx
@@ -37,6 +37,7 @@ import {
   Button,
   CopyIconButton,
   Calendar,
+  LocalDateTime,
   DollarSign,
   Globe,
   Slack,
@@ -93,17 +94,6 @@ const SANDBOX_PROVIDER_ICONS = {
   azure: CloudIcon,
   roomote: CloudIcon,
 } satisfies Record<ComputeProvider, typeof CloudIcon>;
-
-function formatStartedAt(startedAt: Date | null): string {
-  if (!startedAt) {
-    return 'Not started yet';
-  }
-
-  return startedAt.toLocaleString(undefined, {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  });
-}
 
 type StartedFromBrandIcon =
   | 'slack'
@@ -477,9 +467,11 @@ export function TaskInfoPanel({
         <SandboxInfoRow label="Started At">
           <span className="inline-flex items-center gap-1.5">
             <Calendar className="size-3.5 shrink-0 text-muted-foreground" />
-            <span className="truncate">
-              {formatStartedAt(taskRun.startedAt)}
-            </span>
+            {taskRun.startedAt ? (
+              <LocalDateTime date={taskRun.startedAt} className="truncate" />
+            ) : (
+              <span className="truncate">Not started yet</span>
+            )}
           </span>
         </SandboxInfoRow>
 

--- a/apps/web/src/components/system/custom/index.ts
+++ b/apps/web/src/components/system/custom/index.ts
@@ -2,6 +2,7 @@ export * from './ascii-spinner';
 export * from './header-callout';
 export * from './MediaViewer';
 export * from './icons';
+export * from './local-date-time';
 export * from './logos';
 export * from './states';
 export * from './summary-cards';

--- a/apps/web/src/components/system/custom/local-date-time.client.test.tsx
+++ b/apps/web/src/components/system/custom/local-date-time.client.test.tsx
@@ -1,0 +1,35 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { LocalDateTime } from './local-date-time';
+
+describe('LocalDateTime', () => {
+  const date = new Date('2026-05-01T12:34:00.000Z');
+
+  it('emits no locale-dependent text when rendered on the server', () => {
+    const html = renderToStaticMarkup(<LocalDateTime date={date} />);
+    expect(html).toBe('<time dateTime="2026-05-01T12:34:00.000Z"></time>');
+  });
+
+  it('fills in the localized string after mount', () => {
+    const { container } = render(<LocalDateTime date={date} />);
+    const time = container.querySelector('time');
+    expect(time).not.toBeNull();
+    expect(time?.textContent).toBe(
+      date.toLocaleString(undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+      }),
+    );
+  });
+
+  it('honors custom format styles', () => {
+    const { container } = render(
+      <LocalDateTime date={date} dateStyle="full" timeStyle="long" />,
+    );
+    expect(container.querySelector('time')?.textContent).toBe(
+      date.toLocaleString(undefined, { dateStyle: 'full', timeStyle: 'long' }),
+    );
+  });
+});

--- a/apps/web/src/components/system/custom/local-date-time.tsx
+++ b/apps/web/src/components/system/custom/local-date-time.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface LocalDateTimeProps {
+  date: Date;
+  dateStyle?: Intl.DateTimeFormatOptions['dateStyle'];
+  timeStyle?: Intl.DateTimeFormatOptions['timeStyle'];
+  className?: string;
+}
+
+/**
+ * Renders a date in the viewer's locale and timezone without a hydration
+ * mismatch. Locale-dependent formatting can't go into server-rendered HTML:
+ * the server formats in its own locale/timezone while the browser formats in
+ * the viewer's, and the differing text triggers React error #418. Server HTML
+ * and the first client render therefore emit an empty <time> (with the ISO
+ * timestamp in its dateTime attribute), and the localized text fills in after
+ * mount.
+ */
+export function LocalDateTime({
+  date,
+  dateStyle = 'medium',
+  timeStyle = 'short',
+  className,
+}: LocalDateTimeProps) {
+  // Depend on the timestamp value: a Date prop is often a fresh object each
+  // render, and identity-based deps would re-run the effect every render.
+  const timestamp = date.getTime();
+  const [formatted, setFormatted] = useState<string | null>(null);
+  useEffect(() => {
+    setFormatted(
+      new Date(timestamp).toLocaleString(undefined, { dateStyle, timeStyle }),
+    );
+  }, [timestamp, dateStyle, timeStyle]);
+
+  return (
+    <time dateTime={date.toISOString()} className={className}>
+      {formatted}
+    </time>
+  );
+}


### PR DESCRIPTION
## Problem

Session detail pages log React minified error #418 (hydration mismatch) in production. The page is a server component that passes `createdAt` into the client-side `SessionWorkspace`, whose "Started At" row renders `toLocaleString(...)`. The server formats in its own locale/timezone (UTC) while the browser formats in the viewer's, so the SSR HTML text never matches the client render.

## Fix

- Add a shared `LocalDateTime` component (exported from the `@/components/system` barrel) that server-renders an empty `<time dateTime="...">` and fills in the localized `toLocaleString` text after mount, so locale-dependent output is never part of server HTML.
- Use it for the "Started At" rows in `SessionWorkspace` (the actual bug) and `TaskInfoPanel` (identical pattern; its data is client-fetched today, so this is defense in depth), replacing the duplicated inline formatting.

## Audit of other `toLocale*` call sites in `apps/web`

Left alone deliberately: settings components (`SubscriptionUsageLine`, `UsersSettings`, `ModelSettingsSection`, `model-metadata`) and task-page messages render only after client-side `useQuery`/socket fetches, so SSR shows skeletons and there is no mismatch; `TaskCard`/`TaskBoard`/automations usages are tooltip content rendered only on hover; the rest are `title` attributes (not compared during hydration), number formatting, or stories.

## Testing

- New `local-date-time.client.test.tsx` asserts the SSR markup contains no locale-dependent text and the localized string appears after mount.
- Targeted vitest for the new component plus `SessionWorkspace` and `TaskInfoPanel` suites (60 tests pass), `pnpm --filter @roomote/web check-types`, and `pnpm lint` all clean.