### PR TITLE
[Fix] Open Session visibility to every deployment user like tasks

### DIFF
--- a/apps/api/src/handlers/sessions/index.test.ts
+++ b/apps/api/src/handlers/sessions/index.test.ts
@@ -165,7 +165,7 @@ describe('MCP session routes', () => {
     });
   });
 
-  it('hides sessions from users who are not participants', async () => {
+  it('shares sessions with every deployment user like tasks', async () => {
     const owner = await userFactory.create();
     const bystander = await userFactory.create();
     createdUserIds.push(owner.id, bystander.id);
@@ -178,11 +178,15 @@ describe('MCP session routes', () => {
     const response = await createApp(bystander.id).request(
       `/sessions/${session.id}/summary`,
     );
-    expect(response.status).toBe(404);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ id: session.id });
     const messagesResponse = await createApp(bystander.id).request(
       `/sessions/${session.id}/messages`,
     );
-    expect(messagesResponse.status).toBe(404);
+    expect(messagesResponse.status).toBe(200);
+    await expect(messagesResponse.json()).resolves.toMatchObject({
+      sessionId: session.id,
+    });
   });
 
   it('returns visible, sanitized session messages newest first', async () => {

--- a/apps/api/src/handlers/sessions/index.ts
+++ b/apps/api/src/handlers/sessions/index.ts
@@ -8,7 +8,6 @@ import {
   deriveSessionStatus,
   eq,
   exists,
-  fastAgentMessages,
   getSessionForFastConversation,
   ilike,
   inArray,
@@ -16,10 +15,10 @@ import {
   isNull,
   lt,
   or,
-  sessionParticipants,
   sessions,
   sessionTasks,
   sql,
+  type SQL,
   tasks,
 } from '@roomote/db/server';
 import { getOrCreateFastAgentSession } from '@roomote/cloud-agents/server';
@@ -47,44 +46,14 @@ type SessionContext = Context<{
   Variables: Variables & { mcpAuth: McpAuth };
 }>;
 
-function sessionAccessCondition(userId: string) {
-  return or(
-    eq(sessions.ownerUserId, userId),
-    exists(
-      db
-        .select({ one: sql`1` })
-        .from(sessionParticipants)
-        .where(
-          and(
-            eq(sessionParticipants.sessionId, sessions.id),
-            eq(sessionParticipants.userId, userId),
-          ),
-        ),
-    ),
-    exists(
-      db
-        .select({ one: sql`1` })
-        .from(fastAgentMessages)
-        .where(
-          and(
-            eq(fastAgentMessages.conversationId, sessions.fastConversationId),
-            sql`${fastAgentMessages.metadata} ->> 'userId' = ${userId}`,
-          ),
-        ),
-    ),
-  );
-}
-
-async function findAccessibleSession(userId: string, sessionId: string) {
+// Sessions follow the same visibility rules as tasks: every authenticated
+// user of the deployment can read and interact with every visible Session.
+async function findAccessibleSession(sessionId: string) {
   const [session] = await db
     .select()
     .from(sessions)
     .where(
-      and(
-        eq(sessions.id, sessionId),
-        eq(sessions.visibility, 'visible'),
-        sessionAccessCondition(userId),
-      ),
+      and(eq(sessions.id, sessionId), eq(sessions.visibility, 'visible')),
     )
     .limit(1);
   return session ?? null;
@@ -106,7 +75,7 @@ async function sendSessionMessage(c: SessionContext): Promise<Response> {
   if (!message) return c.json({ error: 'message is required' }, 400);
 
   try {
-    const session = await findAccessibleSession(userId, sessionId);
+    const session = await findAccessibleSession(sessionId);
     if (!session) return c.json({ error: 'Session not found' }, 404);
     if (!session.fastConversationId) {
       return c.json({ error: 'Session has no conversation to continue' }, 409);
@@ -281,10 +250,9 @@ async function searchSessions(c: SessionContext): Promise<Response> {
   }
 
   try {
-    const conditions = [
+    const conditions: Array<SQL | undefined> = [
       eq(sessions.visibility, 'visible'),
       isNull(sessions.archivedAt),
-      sessionAccessCondition(userId),
     ];
     if (sessionStatus) {
       conditions.push(eq(sessions.cachedStatus, sessionStatus));
@@ -357,7 +325,7 @@ async function getSessionSummary(c: SessionContext): Promise<Response> {
   if (!sessionId) return c.json({ error: 'sessionId is required' }, 400);
 
   try {
-    const session = await findAccessibleSession(userId, sessionId);
+    const session = await findAccessibleSession(sessionId);
     if (!session) return c.json({ error: 'Session not found' }, 404);
     const childTasks = await getChildTasks([session.id]);
     const response = serializeSession(
@@ -378,7 +346,7 @@ async function getSessionMessages(c: SessionContext): Promise<Response> {
   if (!sessionId) return c.json({ error: 'sessionId is required' }, 400);
 
   try {
-    const session = await findAccessibleSession(userId, sessionId);
+    const session = await findAccessibleSession(sessionId);
     if (!session) return c.json({ error: 'Session not found' }, 404);
     const parsedLimit = Number(c.req.query('limit') ?? 100);
     if (!Number.isFinite(parsedLimit)) {

--- a/apps/api/src/handlers/sessions/index.ts
+++ b/apps/api/src/handlers/sessions/index.ts
@@ -52,9 +52,7 @@ async function findAccessibleSession(sessionId: string) {
   const [session] = await db
     .select()
     .from(sessions)
-    .where(
-      and(eq(sessions.id, sessionId), eq(sessions.visibility, 'visible')),
-    )
+    .where(and(eq(sessions.id, sessionId), eq(sessions.visibility, 'visible')))
     .limit(1);
   return session ?? null;
 }

--- a/apps/api/src/handlers/tasks/__tests__/fastSessionTaskCommunication.test.ts
+++ b/apps/api/src/handlers/tasks/__tests__/fastSessionTaskCommunication.test.ts
@@ -206,12 +206,17 @@ describe('Fast session communication through task routes', () => {
     });
   });
 
-  it('hides Fast sessions from bystanders and rejects absent or invalid IDs', async () => {
+  it('shares Fast sessions with bystanders but rejects absent or invalid IDs', async () => {
     const owner = await userFactory.create();
     const bystander = await userFactory.create();
     const session = await createSession(owner.id);
 
-    for (const taskId of [session.id, crypto.randomUUID(), 'not-an-id']) {
+    const shared = await createApp(userAuth(bystander.id)).request(
+      `/tasks/${session.id}/messages`,
+    );
+    expect(shared.status).toBe(200);
+
+    for (const taskId of [crypto.randomUUID(), 'not-an-id']) {
       const response = await createApp(userAuth(bystander.id)).request(
         `/tasks/${taskId}/messages`,
       );
@@ -332,15 +337,15 @@ describe('Fast session communication through task routes', () => {
     const bystander = await userFactory.create();
     const session = await createSession(owner.id);
 
-    const denied = await createApp(userAuth(bystander.id)).request(
+    const bystanderSend = await createApp(userAuth(bystander.id)).request(
       `/tasks/${session.id}/send_message`,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message: 'Not allowed' }),
+        body: JSON.stringify({ message: 'Deployment users can reply' }),
       },
     );
-    expect(denied.status).toBe(404);
+    expect(bystanderSend.status).toBe(200);
 
     const deploymentRun: RunTokenContext = {
       runId: 1,

--- a/apps/web/src/lib/server/fast-sessions.test.ts
+++ b/apps/web/src/lib/server/fast-sessions.test.ts
@@ -115,7 +115,7 @@ describe('Fast session queries', () => {
     ).resolves.toBe('Manual unified title');
   });
 
-  it('applies the caller scope to detail lookups', async () => {
+  it('shares detail lookups deployment-wide like tasks', async () => {
     const owner = await userFactory.create();
     const otherUser = await userFactory.create();
     const session = await createFastSession({
@@ -126,7 +126,7 @@ describe('Fast session queries', () => {
 
     await expect(
       getFastSessionById({ userId: otherUser.id, isAdmin: false }, session.id),
-    ).resolves.toBeNull();
+    ).resolves.toMatchObject({ id: session.id, userId: owner.id });
     await expect(
       getFastSessionById({ userId: otherUser.id, isAdmin: true }, session.id),
     ).resolves.toMatchObject({ id: session.id, userId: owner.id });
@@ -372,7 +372,7 @@ describe('Fast session queries', () => {
     });
   });
 
-  it('grants participants access to shared conversations they spoke in', async () => {
+  it('grants every deployment user access to shared conversations', async () => {
     const owner = await userFactory.create();
     const participant = await userFactory.create();
     const bystander = await userFactory.create();
@@ -397,7 +397,7 @@ describe('Fast session queries', () => {
 
     await expect(
       getFastSessionById({ userId: bystander.id, isAdmin: false }, session.id),
-    ).resolves.toBeNull();
+    ).resolves.toMatchObject({ id: session.id });
   });
 
   it('excludes transcript-hidden messages such as platform-event prompts', async () => {
@@ -586,7 +586,7 @@ describe('Fast session queries', () => {
     ).resolves.toBe('dismissed');
   });
 
-  it('finds sessions for owners and participants but not bystanders', async () => {
+  it('finds sessions for every deployment user', async () => {
     const owner = await userFactory.create();
     const participant = await userFactory.create();
     const bystander = await userFactory.create();
@@ -621,7 +621,7 @@ describe('Fast session queries', () => {
         { userId: bystander.id, isAdmin: false },
         session.id,
       ),
-    ).resolves.toBeNull();
+    ).resolves.toMatchObject({ id: session.id });
   });
 
   it('keeps a partial newest turn when a single turn overflows the window', async () => {

--- a/apps/web/src/lib/server/fast-sessions.ts
+++ b/apps/web/src/lib/server/fast-sessions.ts
@@ -10,13 +10,11 @@ import {
   db,
   desc,
   eq,
-  exists,
   fastAgentConversations,
   fastAgentMessages,
   llmUsageEvents,
   inArray,
   isNull,
-  or,
   sessions,
   sql,
   taskArtifacts,
@@ -147,29 +145,10 @@ const fastSessionSelection = {
   updatedAt: fastAgentConversations.updatedAt,
 };
 
-function fastSessionScope(auth: FastSessionAuth) {
-  if (auth.isAdmin) {
-    return undefined;
-  }
-
-  // Shared-surface conversations (e.g. Slack channels/threads) are stamped
-  // with the first participant's userId, but every participant's prompts are
-  // persisted with their own userId in the message metadata — so a session is
-  // visible to its owner and to anyone who spoke in it.
-  return or(
-    eq(fastAgentConversations.userId, auth.userId),
-    exists(
-      db
-        .select({ one: sql`1` })
-        .from(fastAgentMessages)
-        .where(
-          and(
-            eq(fastAgentMessages.conversationId, fastAgentConversations.id),
-            sql`${fastAgentMessages.metadata} ->> 'userId' = ${auth.userId}`,
-          ),
-        ),
-    ),
-  );
+function fastSessionScope(_auth: FastSessionAuth) {
+  // Sessions follow the same visibility rules as tasks: every authenticated
+  // user of the deployment can read every conversation and its transcript.
+  return undefined;
 }
 
 /** Light session lookup with the same visibility scope as the list/detail. */

--- a/apps/web/src/lib/server/sessions.test.ts
+++ b/apps/web/src/lib/server/sessions.test.ts
@@ -44,7 +44,7 @@ describe('unified Session queries', () => {
     syncFastSlackTitle.mockReset();
     syncFastSlackTitle.mockResolvedValue(undefined);
   });
-  it('shares list and detail reads deployment-wide like tasks', async () => {
+  it('opens detail reads to everyone but scopes the list like tasks', async () => {
     const owner = await userFactory.create();
     const stranger = await userFactory.create();
     const session = await sessionFactory.create({
@@ -53,6 +53,7 @@ describe('unified Session queries', () => {
       title: 'Visible Session',
     });
 
+    // Anyone with the link can open the Session.
     await expect(
       findAccessibleSession({ userId: owner.id, isAdmin: false }, session.id),
     ).resolves.toMatchObject({ id: session.id });
@@ -62,18 +63,29 @@ describe('unified Session queries', () => {
         session.id,
       ),
     ).resolves.toMatchObject({ id: session.id });
-    await expect(
-      findAccessibleSession({ userId: stranger.id, isAdmin: true }, session.id),
-    ).resolves.toMatchObject({ id: session.id });
 
-    const list = await getSessions(
+    // The list defaults mirror /tasks: admins see everything, other users
+    // see only Sessions they own or participate in.
+    const ownerList = await getSessions(
       { userId: owner.id, isAdmin: false },
       { scope: 'all' },
     );
-    expect(list.sessions.map((row) => row.id)).toContain(session.id);
+    expect(ownerList.sessions.map((row) => row.id)).toContain(session.id);
+    const strangerList = await getSessions(
+      { userId: stranger.id, isAdmin: false },
+      { scope: 'all' },
+    );
+    expect(strangerList.sessions.map((row) => row.id)).not.toContain(
+      session.id,
+    );
+    const adminList = await getSessions(
+      { userId: stranger.id, isAdmin: true },
+      { scope: 'all' },
+    );
+    expect(adminList.sessions.map((row) => row.id)).toContain(session.id);
   });
 
-  it('filters recent-session lookups by id', async () => {
+  it('filters recent-session lookups by id without bypassing list scope', async () => {
     const owner = await userFactory.create();
     const stranger = await userFactory.create();
     const included = await sessionFactory.create({
@@ -91,7 +103,7 @@ describe('unified Session queries', () => {
     const otherOwned = await sessionFactory.create({
       ownerKind: 'user',
       ownerUserId: stranger.id,
-      title: 'Another Included Session',
+      title: 'Outside the list scope',
       activityAt: 200,
     });
 
@@ -100,9 +112,7 @@ describe('unified Session queries', () => {
       { ids: [included.id, otherOwned.id] },
     );
 
-    expect(result.sessions.map((session) => session.id).sort()).toEqual(
-      [included.id, otherOwned.id].sort(),
-    );
+    expect(result.sessions.map((session) => session.id)).toEqual([included.id]);
   });
 
   it('filters Session owners by automation creator values', async () => {
@@ -180,7 +190,7 @@ describe('unified Session queries', () => {
     ]);
   });
 
-  it('lists distinct unarchived sources across the deployment', async () => {
+  it('lists only distinct visible sources within the list scope', async () => {
     const owner = await userFactory.create();
     const stranger = await userFactory.create();
     await sessionFactory.create({
@@ -188,12 +198,15 @@ describe('unified Session queries', () => {
       ownerUserId: owner.id,
       sourceSurface: 'web',
     });
-    // Archived sessions do not contribute their source; 'telegram' is not used
-    // by any other test in this file.
     await sessionFactory.create({
       ownerKind: 'user',
       ownerUserId: owner.id,
-      sourceSurface: 'telegram',
+      sourceSurface: 'web',
+    });
+    await sessionFactory.create({
+      ownerKind: 'user',
+      ownerUserId: owner.id,
+      sourceSurface: 'slack',
       archivedAt: new Date(),
     });
     await sessionFactory.create({
@@ -202,13 +215,9 @@ describe('unified Session queries', () => {
       sourceSurface: 'discord',
     });
 
-    const sources = await getSessionSources({
-      userId: owner.id,
-      isAdmin: false,
-    });
-    expect(sources).toContain('web');
-    expect(sources).toContain('discord');
-    expect(sources).not.toContain('telegram');
+    await expect(
+      getSessionSources({ userId: owner.id, isAdmin: false }),
+    ).resolves.toEqual(['web']);
   });
 
   it('aggregates direct and attached-task inference costs exactly once', async () => {

--- a/apps/web/src/lib/server/sessions.test.ts
+++ b/apps/web/src/lib/server/sessions.test.ts
@@ -44,7 +44,7 @@ describe('unified Session queries', () => {
     syncFastSlackTitle.mockReset();
     syncFastSlackTitle.mockResolvedValue(undefined);
   });
-  it('scopes list and detail reads to owners, participants, and admins', async () => {
+  it('shares list and detail reads deployment-wide like tasks', async () => {
     const owner = await userFactory.create();
     const stranger = await userFactory.create();
     const session = await sessionFactory.create({
@@ -61,7 +61,7 @@ describe('unified Session queries', () => {
         { userId: stranger.id, isAdmin: false },
         session.id,
       ),
-    ).resolves.toBeNull();
+    ).resolves.toMatchObject({ id: session.id });
     await expect(
       findAccessibleSession({ userId: stranger.id, isAdmin: true }, session.id),
     ).resolves.toMatchObject({ id: session.id });
@@ -73,7 +73,7 @@ describe('unified Session queries', () => {
     expect(list.sessions.map((row) => row.id)).toContain(session.id);
   });
 
-  it('filters recent-session lookups by id without bypassing access scope', async () => {
+  it('filters recent-session lookups by id', async () => {
     const owner = await userFactory.create();
     const stranger = await userFactory.create();
     const included = await sessionFactory.create({
@@ -88,19 +88,21 @@ describe('unified Session queries', () => {
       title: 'Newer but not included',
       activityAt: 300,
     });
-    const inaccessible = await sessionFactory.create({
+    const otherOwned = await sessionFactory.create({
       ownerKind: 'user',
       ownerUserId: stranger.id,
-      title: 'Inaccessible Session',
+      title: 'Another Included Session',
       activityAt: 200,
     });
 
     const result = await getSessions(
       { userId: owner.id, isAdmin: false },
-      { ids: [included.id, inaccessible.id] },
+      { ids: [included.id, otherOwned.id] },
     );
 
-    expect(result.sessions.map((session) => session.id)).toEqual([included.id]);
+    expect(result.sessions.map((session) => session.id).sort()).toEqual(
+      [included.id, otherOwned.id].sort(),
+    );
   });
 
   it('filters Session owners by automation creator values', async () => {
@@ -178,7 +180,7 @@ describe('unified Session queries', () => {
     ]);
   });
 
-  it('lists only distinct visible sources available to the current user', async () => {
+  it('lists distinct unarchived sources across the deployment', async () => {
     const owner = await userFactory.create();
     const stranger = await userFactory.create();
     await sessionFactory.create({
@@ -186,15 +188,12 @@ describe('unified Session queries', () => {
       ownerUserId: owner.id,
       sourceSurface: 'web',
     });
+    // Archived sessions do not contribute their source; 'telegram' is not used
+    // by any other test in this file.
     await sessionFactory.create({
       ownerKind: 'user',
       ownerUserId: owner.id,
-      sourceSurface: 'web',
-    });
-    await sessionFactory.create({
-      ownerKind: 'user',
-      ownerUserId: owner.id,
-      sourceSurface: 'slack',
+      sourceSurface: 'telegram',
       archivedAt: new Date(),
     });
     await sessionFactory.create({
@@ -203,9 +202,13 @@ describe('unified Session queries', () => {
       sourceSurface: 'discord',
     });
 
-    await expect(
-      getSessionSources({ userId: owner.id, isAdmin: false }),
-    ).resolves.toEqual(['web']);
+    const sources = await getSessionSources({
+      userId: owner.id,
+      isAdmin: false,
+    });
+    expect(sources).toContain('web');
+    expect(sources).toContain('discord');
+    expect(sources).not.toContain('telegram');
   });
 
   it('aggregates direct and attached-task inference costs exactly once', async () => {
@@ -838,12 +841,20 @@ describe('unified Session queries', () => {
       initiatorUserId: owner.id,
       title: 'Second task',
     });
+    // Explicit attachedAt values: rows inserted in one statement share a
+    // timestamp, which makes the attachedAt ordering below nondeterministic.
     await db.insert(sessionTasks).values([
-      { sessionId: session.id, taskId: firstTask.id, origin: 'direct_launch' },
+      {
+        sessionId: session.id,
+        taskId: firstTask.id,
+        origin: 'direct_launch',
+        attachedAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
       {
         sessionId: session.id,
         taskId: secondTask.id,
         origin: 'fast_delegation',
+        attachedAt: new Date('2026-01-01T00:00:01.000Z'),
       },
     ]);
     await db.insert(taskArtifacts).values([

--- a/apps/web/src/lib/server/sessions.ts
+++ b/apps/web/src/lib/server/sessions.ts
@@ -71,8 +71,39 @@ const SEARCH_SNIPPET_LENGTH = 180;
 
 function sessionScope(_auth: SessionAuth) {
   // Sessions follow the same visibility rules as tasks: every authenticated
-  // user of the deployment can read every Session.
+  // user of the deployment can open and interact with any Session by id.
   return undefined;
+}
+
+// The /sessions listing mirrors the /tasks listing instead: admins see every
+// Session, other users see the Sessions they own, participate in, or spoke in.
+function sessionListScope(auth: SessionAuth) {
+  if (auth.isAdmin) return undefined;
+  return or(
+    eq(sessions.ownerUserId, auth.userId),
+    exists(
+      db
+        .select({ one: sql`1` })
+        .from(sessionParticipants)
+        .where(
+          and(
+            eq(sessionParticipants.sessionId, sessions.id),
+            eq(sessionParticipants.userId, auth.userId),
+          ),
+        ),
+    ),
+    exists(
+      db
+        .select({ one: sql`1` })
+        .from(fastAgentMessages)
+        .where(
+          and(
+            eq(fastAgentMessages.conversationId, sessions.fastConversationId),
+            sql`${fastAgentMessages.metadata} ->> 'userId' = ${auth.userId}`,
+          ),
+        ),
+    ),
+  );
 }
 
 function encodeCursor(
@@ -258,7 +289,7 @@ async function getSessionSearchSnippets(
   if (sessionIds.length === 0 || !search?.searchTranscripts) {
     return new Map<string, string>();
   }
-  const accessCondition = sessionScope(auth) ?? sql`true`;
+  const accessCondition = sessionListScope(auth) ?? sql`true`;
 
   // Keep context retrieval page-bounded so it reuses relationship indexes
   // instead of repeating the global transcript scan used to find matches.
@@ -357,7 +388,7 @@ function listConditions(
   const pullRequestNumber = Number(input.pullRequest);
 
   return and(
-    sessionScope(auth),
+    sessionListScope(auth),
     eq(sessions.visibility, 'visible'),
     isNull(sessions.archivedAt),
     input.ids ? inArray(sessions.id, input.ids) : undefined,
@@ -717,7 +748,7 @@ export async function getSessionSources(auth: SessionAuth) {
     .from(sessions)
     .where(
       and(
-        sessionScope(auth),
+        sessionListScope(auth),
         eq(sessions.visibility, 'visible'),
         isNull(sessions.archivedAt),
       ),

--- a/apps/web/src/lib/server/sessions.ts
+++ b/apps/web/src/lib/server/sessions.ts
@@ -69,33 +69,10 @@ const MIN_TRANSCRIPT_SEARCH_LENGTH = 3;
 const SEARCH_SNIPPET_CONTEXT_CHARS = 60;
 const SEARCH_SNIPPET_LENGTH = 180;
 
-function sessionScope(auth: SessionAuth) {
-  if (auth.isAdmin) return undefined;
-  return or(
-    eq(sessions.ownerUserId, auth.userId),
-    exists(
-      db
-        .select({ one: sql`1` })
-        .from(sessionParticipants)
-        .where(
-          and(
-            eq(sessionParticipants.sessionId, sessions.id),
-            eq(sessionParticipants.userId, auth.userId),
-          ),
-        ),
-    ),
-    exists(
-      db
-        .select({ one: sql`1` })
-        .from(fastAgentMessages)
-        .where(
-          and(
-            eq(fastAgentMessages.conversationId, sessions.fastConversationId),
-            sql`${fastAgentMessages.metadata} ->> 'userId' = ${auth.userId}`,
-          ),
-        ),
-    ),
-  );
+function sessionScope(_auth: SessionAuth) {
+  // Sessions follow the same visibility rules as tasks: every authenticated
+  // user of the deployment can read every Session.
+  return undefined;
 }
 
 function encodeCursor(

--- a/packages/sdk/src/server/lib/fast-agent-surface-reply.test.ts
+++ b/packages/sdk/src/server/lib/fast-agent-surface-reply.test.ts
@@ -143,7 +143,7 @@ describe('buildFastAgentSurfaceReplyDelivery', () => {
     expect(delivery?.conversation.surface).toBe('automation');
   });
 
-  it('allows recorded participants but rejects unrelated users', async () => {
+  it('allows every deployment user to reply, like tasks', async () => {
     const owner = await userFactory.create();
     const participant = await userFactory.create();
     const bystander = await userFactory.create();
@@ -180,7 +180,7 @@ describe('buildFastAgentSurfaceReplyDelivery', () => {
         senderDisplayName: null,
         question: 'Bystander follow-up',
       }),
-    ).resolves.toBeNull();
+    ).resolves.not.toBeNull();
   });
 
   it('returns null for a Slack session without an installation', async () => {

--- a/packages/sdk/src/server/lib/fast-agent-surface-reply.ts
+++ b/packages/sdk/src/server/lib/fast-agent-surface-reply.ts
@@ -9,14 +9,7 @@ import {
   type FastAgentReactionExternalInput,
   type FastAgentTurnAdapter,
 } from '@roomote/cloud-agents/server';
-import {
-  and,
-  db,
-  eq,
-  fastAgentMessages,
-  slackInstallations,
-  sql,
-} from '@roomote/db/server';
+import { and, db, eq, slackInstallations } from '@roomote/db/server';
 import {
   buildFastSessionReplyFooterText,
   deliverManagedThreadReplyFooter,
@@ -127,27 +120,17 @@ type FastAgentSurfaceReplyParams = {
   externalInput?: FastAgentReactionExternalInput;
 };
 
+// Sessions follow the same rules as tasks: every authenticated user of the
+// deployment can read and reply to every conversation, so access reduces to
+// the conversation existing. Replies stay attributed to the sending user.
 export async function canUserAccessFastAgentSession(params: {
   sessionId: string;
   userId: string;
 }): Promise<boolean> {
-  const [session] = await db
-    .select({ id: fastAgentMessages.conversationId })
-    .from(fastAgentMessages)
-    .where(
-      and(
-        eq(fastAgentMessages.conversationId, params.sessionId),
-        sql`${fastAgentMessages.metadata} ->> 'userId' = ${params.userId}`,
-      ),
-    )
-    .limit(1);
-
-  if (session) return true;
-
   const conversation = await fastAgentConversationRepository.findById({
     id: params.sessionId,
   });
-  return conversation?.userId === params.userId;
+  return conversation !== null;
 }
 
 /**


### PR DESCRIPTION
## Problem

Sessions and their Fast transcripts were scoped to owners, participants, and admins everywhere, while tasks are open to any authenticated deployment user. A teammate opening a Session link they had access to (but had not spoken in) got a bare header with no transcript.

## Change

Sessions now follow the same rules as tasks:

- **Anyone with the link can view and contribute.** Detail reads (`findAccessibleSession`, `getFastSessionById`), the deployment API's `/:id/summary`, `/:id/messages`, and `send_message`, and the reply/model-selection/PR-review action paths are open to every authenticated deployment user. Replies stay attributed to the sender.
- **The /sessions listing mirrors /tasks.** Admins see every Session; other users see the Sessions they own, participate in, or spoke in. The same scope applies to the list's source filter options and transcript-search snippets.

## Validation

- Web: `sessions.test.ts`, `fast-sessions.test.ts`, command and page tests
- API: session handler + task-route Fast session tests; SDK: full suite
- `check-types:fast` and `format:check`