### PR TITLE
[Fix] Land on the task view after launching into an environment from web

### DIFF
--- a/apps/web/src/app/(authenticated)/home/Home.client.test.tsx
+++ b/apps/web/src/app/(authenticated)/home/Home.client.test.tsx
@@ -645,7 +645,7 @@ describe('Home', () => {
     });
   });
 
-  it('opens a new task session on the transcript', async () => {
+  it('opens the task view for a direct environment launch', async () => {
     mockUseCreateStandardTaskRun.mockImplementation(
       (options: { onSuccess: (result: unknown) => void }) => ({
         isPending: false,
@@ -669,7 +669,7 @@ describe('Home', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Submit prompt' }));
 
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith('/sessions/session-1');
+      expect(mockPush).toHaveBeenCalledWith('/task/task-4');
     });
   });
 

--- a/apps/web/src/components/tasks/NewTaskForm.tsx
+++ b/apps/web/src/components/tasks/NewTaskForm.tsx
@@ -233,11 +233,9 @@ export function NewTaskForm({
   }) => {
     if (result.success && 'taskId' in result) {
       onTaskStarted?.();
-      router.push(
-        result.sessionId
-          ? `/sessions/${result.sessionId}`
-          : `/task/${result.taskId}`,
-      );
+      // A direct environment launch is a task, not a conversation — land on
+      // the task view even though a Session wraps it.
+      router.push(`/task/${result.taskId}`);
     } else if ('error' in result) {
       toast.error(result.error);
     }

--- a/apps/web/src/components/tasks/NewTaskForm.tsx
+++ b/apps/web/src/components/tasks/NewTaskForm.tsx
@@ -233,8 +233,8 @@ export function NewTaskForm({
   }) => {
     if (result.success && 'taskId' in result) {
       onTaskStarted?.();
-      // A direct environment launch is a task, not a conversation — land on
-      // the task view even though a Session wraps it.
+      // A direct launch into an environment or repository is a task, not a
+      // conversation — land on the task view even though a Session wraps it.
       router.push(`/task/${result.taskId}`);
     } else if ('error' in result) {
       toast.error(result.error);


### PR DESCRIPTION
## Problem

Launching a task from the web launcher with an environment selected redirected to the wrapping Session (`/sessions/<id>`), which shows task rows rather than the task itself. Users who explicitly picked an environment expect to land in the task they just started.

## Change

`NewTaskForm` now routes direct environment launches straight to `/task/<id>`. Fast prompts are unaffected and keep landing on their Session.

## Validation

- `tsc --noEmit` for @roomote/web