### PR TITLE
[Fix] Stable session task ordering on attachedAt ties

### DIFF
--- a/apps/web/src/lib/server/sessions.test.ts
+++ b/apps/web/src/lib/server/sessions.test.ts
@@ -839,11 +839,17 @@ describe('unified Session queries', () => {
       title: 'Second task',
     });
     await db.insert(sessionTasks).values([
-      { sessionId: session.id, taskId: firstTask.id, origin: 'direct_launch' },
+      {
+        sessionId: session.id,
+        taskId: firstTask.id,
+        origin: 'direct_launch',
+        attachedAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
       {
         sessionId: session.id,
         taskId: secondTask.id,
         origin: 'fast_delegation',
+        attachedAt: new Date('2026-01-01T00:00:01.000Z'),
       },
     ]);
     await db.insert(taskArtifacts).values([

--- a/apps/web/src/lib/server/sessions.ts
+++ b/apps/web/src/lib/server/sessions.ts
@@ -799,7 +799,9 @@ async function getSessionTasks(sessionId: string) {
     .from(sessionTasks)
     .innerJoin(tasks, eq(tasks.id, sessionTasks.taskId))
     .where(and(eq(sessionTasks.sessionId, sessionId), isNull(tasks.deletedAt)))
-    .orderBy(sessionTasks.attachedAt);
+    // attachedAt ties are common (tasks attached in one statement share a
+    // timestamp), so break them deterministically.
+    .orderBy(sessionTasks.attachedAt, sessionTasks.taskId);
 
   if (linked.length === 0) return [];
 


### PR DESCRIPTION
## Problem

`getSessionTasks` orders a Session's tasks by `attachedAt` alone. Tasks attached in a single insert share the same timestamp, so Postgres returns them in arbitrary order — visible as nondeterministic task ordering in Session views and as a flaky assertion in `sessions.test.ts > hydrates uploaded artifacts for every associated task` (it failed on an unrelated PR's CI run, #1965).

## Fix

- Add `taskId` as a deterministic tie-breaker to the `orderBy`.
- Give the artifact-hydration test explicit distinct `attachedAt` values so it asserts the intended ordering rather than insertion luck.

## Validation

- `vitest run src/lib/server/sessions.test.ts --project server` — 16 passed, repeated runs stable.