### PR TITLE
[Fix] Fast turn interruptions are unattributed and restarts are mislabeled as retry failures

### DIFF
--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-conversation-repository.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-conversation-repository.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   fastAgentConversationRepository,
   INTERRUPTED_INFERENCE_RETRY_MESSAGE,
+  markFastAgentInferenceRetryNoticeInterruption,
   reconcileExpiredFastAgentInferenceRetryNotices,
   reconcileFastAgentInferenceRetryNotices,
 } from '../fast-agent-conversation-repository';
@@ -683,7 +684,10 @@ describe('Fast conversation repository', () => {
     });
 
     await expect(
-      reconcileFastAgentInferenceRetryNotices(session.id),
+      reconcileFastAgentInferenceRetryNotices(
+        session.id,
+        'next_turn_reconcile',
+      ),
     ).resolves.toBe(1);
 
     const [notice] = await db
@@ -698,6 +702,7 @@ describe('Fast conversation repository', () => {
       purpose: 'closeout',
       inferenceRetryNotice: true,
       inferenceRetryActive: false,
+      interruptionReason: 'next_turn_reconcile',
     });
   });
 
@@ -729,7 +734,10 @@ describe('Fast conversation repository', () => {
     });
 
     await expect(
-      reconcileFastAgentInferenceRetryNotices(session.id),
+      reconcileFastAgentInferenceRetryNotices(
+        session.id,
+        'turn_settled_reconcile',
+      ),
     ).resolves.toBe(1);
 
     const [notice] = await db
@@ -744,6 +752,7 @@ describe('Fast conversation repository', () => {
       purpose: 'closeout',
       inferenceRetryNotice: true,
       inferenceRetryActive: false,
+      interruptionReason: 'turn_settled_reconcile',
     });
   });
 
@@ -814,9 +823,97 @@ describe('Fast conversation repository', () => {
       );
     expect(
       rows.find((row) => row.conversationId === expired.id)?.metadata,
-    ).toMatchObject({ inferenceRetryActive: false });
+    ).toMatchObject({
+      inferenceRetryActive: false,
+      interruptionReason: 'expired_lease_reconcile',
+    });
     expect(
       rows.find((row) => row.conversationId === active.id)?.metadata,
     ).toMatchObject({ inferenceRetryActive: true });
+  });
+
+  it('preserves a pre-recorded interruption cause when reconciling', async () => {
+    const user = await createUser();
+    const session = await fastAgentConversationRepository.getOrCreate({
+      userId: user.id,
+      conversation: slackConversation,
+    });
+    await fastAgentConversationRepository.upsertMessage({
+      conversationId: session.id,
+      message: {
+        eventId: 'turn-lost:retry-notice:0',
+        turnId: 'turn-lost',
+        turnSeq: 1,
+        ts: 100,
+        eventType: 'roomote_runtime.assistant_message',
+        role: 'assistant',
+        contentBlocks: [{ type: 'text', text: 'Retrying in 1s' }],
+        metadata: {
+          visibleInTranscript: true,
+          purpose: 'progress',
+          inferenceRetryNotice: true,
+          inferenceRetryActive: true,
+        },
+        payload: { purpose: 'progress' },
+        source: 'web',
+      },
+    });
+
+    await markFastAgentInferenceRetryNoticeInterruption(
+      session.id,
+      'turn-lost:retry-notice:0',
+      'lock_lost',
+    );
+
+    const [stamped] = await db
+      .select({ metadata: fastAgentMessages.metadata })
+      .from(fastAgentMessages)
+      .where(eq(fastAgentMessages.conversationId, session.id));
+    // The stamp records the cause without ending the notice; the reconciler
+    // still owns the terminal flip.
+    expect(stamped?.metadata).toMatchObject({
+      inferenceRetryActive: true,
+      interruptionReason: 'lock_lost',
+    });
+
+    // A second stamp is fill-only and cannot overwrite the recorded cause.
+    await markFastAgentInferenceRetryNoticeInterruption(
+      session.id,
+      'turn-lost:retry-notice:0',
+      'turn_aborted',
+    );
+
+    await expect(
+      reconcileFastAgentInferenceRetryNotices(
+        session.id,
+        'next_turn_reconcile',
+      ),
+    ).resolves.toBe(1);
+
+    const [notice] = await db
+      .select()
+      .from(fastAgentMessages)
+      .where(eq(fastAgentMessages.conversationId, session.id));
+    expect(notice?.contentBlocks).toEqual([
+      { type: 'text', text: INTERRUPTED_INFERENCE_RETRY_MESSAGE },
+    ]);
+    expect(notice?.metadata).toMatchObject({
+      inferenceRetryActive: false,
+      interruptionReason: 'lock_lost',
+    });
+
+    // Once terminal, the notice no longer matches the fill-only stamp.
+    await markFastAgentInferenceRetryNoticeInterruption(
+      session.id,
+      'turn-lost:retry-notice:0',
+      'turn_aborted',
+    );
+    const [settled] = await db
+      .select({ metadata: fastAgentMessages.metadata })
+      .from(fastAgentMessages)
+      .where(eq(fastAgentMessages.conversationId, session.id));
+    expect(settled?.metadata).toMatchObject({
+      interruptionReason: 'lock_lost',
+    });
   });
 });

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-conversation-repository.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-conversation-repository.test.ts
@@ -903,11 +903,13 @@ describe('Fast conversation repository', () => {
     });
 
     // Once terminal, the notice no longer matches the fill-only stamp.
-    await markFastAgentInferenceRetryNoticeInterruption(
-      session.id,
-      'turn-lost:retry-notice:0',
-      'turn_aborted',
-    );
+    await expect(
+      markFastAgentInferenceRetryNoticeInterruption(
+        session.id,
+        'turn-lost:retry-notice:0',
+        'turn_aborted',
+      ),
+    ).resolves.toBe(false);
     const [settled] = await db
       .select({ metadata: fastAgentMessages.metadata })
       .from(fastAgentMessages)
@@ -915,5 +917,67 @@ describe('Fast conversation repository', () => {
     expect(settled?.metadata).toMatchObject({
       interruptionReason: 'lock_lost',
     });
+  });
+
+  it('never loses a concurrently stamped cause to the reconciler', async () => {
+    const user = await createUser();
+    const session = await fastAgentConversationRepository.getOrCreate({
+      userId: user.id,
+      conversation: slackConversation,
+    });
+
+    for (let round = 0; round < 10; round += 1) {
+      const eventId = `turn-race-${round}:retry-notice:0`;
+      await fastAgentConversationRepository.upsertMessage({
+        conversationId: session.id,
+        message: {
+          eventId,
+          turnId: `turn-race-${round}`,
+          turnSeq: 1,
+          ts: 100 + round,
+          eventType: 'roomote_runtime.assistant_message',
+          role: 'assistant',
+          contentBlocks: [{ type: 'text', text: 'Retrying in 1s' }],
+          metadata: {
+            visibleInTranscript: true,
+            purpose: 'progress',
+            inferenceRetryNotice: true,
+            inferenceRetryActive: true,
+          },
+          payload: { purpose: 'progress' },
+          source: 'web',
+        },
+      });
+
+      // Race the fill-only lock-lost stamp against the reconciler on separate
+      // connections. Whenever the stamp reports success (the notice was still
+      // active and unreasoned when it ran), the surviving cause must be
+      // lock_lost regardless of how the two interleaved.
+      const [stamped] = await Promise.all([
+        markFastAgentInferenceRetryNoticeInterruption(
+          session.id,
+          eventId,
+          'lock_lost',
+        ),
+        reconcileFastAgentInferenceRetryNotices(
+          session.id,
+          'next_turn_reconcile',
+        ),
+      ]);
+
+      const [notice] = await db
+        .select({ metadata: fastAgentMessages.metadata })
+        .from(fastAgentMessages)
+        .where(
+          and(
+            eq(fastAgentMessages.conversationId, session.id),
+            eq(fastAgentMessages.eventId, eventId),
+          ),
+        );
+      expect(notice?.metadata).toMatchObject({
+        inferenceRetryActive: false,
+        interruptionReason: stamped ? 'lock_lost' : 'next_turn_reconcile',
+      });
+    }
   });
 });

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -28,6 +28,7 @@ const mocks = vi.hoisted(() => ({
   markShutdownCloseoutSettled: vi.fn(),
   revokeMcpCapabilities: vi.fn(),
   reconcileRetryNotices: vi.fn(),
+  markRetryNoticeInterruption: vi.fn(),
   getUnifiedSession: vi.fn(),
   touchSessionActivity: vi.fn(),
   getSessionForTask: vi.fn(),
@@ -87,7 +88,11 @@ vi.mock('../fast-agent-session', () => ({
 vi.mock('../fast-agent-conversation-repository', () => ({
   INTERRUPTED_INFERENCE_RETRY_MESSAGE:
     'The inference retry was interrupted before it completed. Please send the request again.',
+  RESTARTED_ACTIVE_TURN_MESSAGE:
+    'Roomote restarted while working on this request. Please send it again.',
   reconcileFastAgentInferenceRetryNotices: mocks.reconcileRetryNotices,
+  markFastAgentInferenceRetryNoticeInterruption:
+    mocks.markRetryNoticeInterruption,
 }));
 
 vi.mock('../../router', () => ({
@@ -373,6 +378,7 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
     mocks.setOpenCodeSession.mockResolvedValue(undefined);
     mocks.upsertMessage.mockResolvedValue({ initialHumanTurn: true });
     mocks.reconcileRetryNotices.mockResolvedValue(0);
+    mocks.markRetryNoticeInterruption.mockResolvedValue(undefined);
     mocks.getActiveTasks.mockResolvedValue([]);
     mocks.getEnvironments.mockResolvedValue([
       {
@@ -2480,6 +2486,8 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
     expect(adapter.postReply).not.toHaveBeenCalled();
     expect(mocks.invalidateSession).toHaveBeenCalledWith('conversation-1');
     expect(mocks.reconcileRetryNotices).toHaveBeenCalledOnce();
+    // No retry notice existed, so there is no orphan to attribute.
+    expect(mocks.markRetryNoticeInterruption).not.toHaveBeenCalled();
   });
 
   it('leaves a visible retry notice for the successor when lock loss cancels backoff', async () => {
@@ -2528,6 +2536,11 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
       });
       expect(mocks.invalidateSession).toHaveBeenCalledWith('conversation-1');
       expect(mocks.reconcileRetryNotices).toHaveBeenCalledOnce();
+      expect(mocks.markRetryNoticeInterruption).toHaveBeenCalledWith(
+        'conversation-1',
+        '100.2:retry-notice:0',
+        'lock_lost',
+      );
     } finally {
       vi.useRealTimers();
     }
@@ -2578,6 +2591,11 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
         inferenceRetryActive: true,
       });
       expect(mocks.reconcileRetryNotices).toHaveBeenCalledOnce();
+      expect(mocks.markRetryNoticeInterruption).toHaveBeenCalledWith(
+        'conversation-1',
+        '100.2:retry-notice:0',
+        'lock_lost',
+      );
       expect(mocks.touchSessionActivity).toHaveBeenCalledOnce();
       expect(mocks.touchSessionActivity).toHaveBeenCalledWith(
         expect.anything(),
@@ -2594,7 +2612,7 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
     const controller = new AbortController();
     const shutdown = new FastAgentProcessShutdownError('SIGTERM');
     const expectedCloseout =
-      'The inference retry was interrupted before it completed. Please send the request again.';
+      'Roomote restarted while working on this request. Please send it again.';
     const postReply = vi.fn().mockResolvedValue({ messageId: 'closeout-1' });
     const originalSetTimeout = globalThis.setTimeout;
     let shouldAbort = true;
@@ -2642,6 +2660,7 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
           platformMessageId: 'closeout-1',
           inferenceRetryNotice: true,
           inferenceRetryActive: false,
+          interruptionReason: 'api_shutdown',
         },
       });
       expect(

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation-repository.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation-repository.ts
@@ -125,53 +125,43 @@ async function reconcileInferenceRetryNotices(
     }
   }
 
-  const notices = await database
-    .select({
-      id: fastAgentMessages.id,
-      metadata: fastAgentMessages.metadata,
-      payload: fastAgentMessages.payload,
+  // One set-based statement with no prior read: the terminal metadata is
+  // derived from each row's current value under its row lock, so a cause an
+  // interrupted owner commits concurrently (e.g. lock_lost) cannot be
+  // overwritten by a stale snapshot; the reconciler's own reason only fills
+  // in when nobody recorded one.
+  const reconciled = await database
+    .update(fastAgentMessages)
+    .set({
+      contentBlocks: [
+        { type: 'text', text: INTERRUPTED_INFERENCE_RETRY_MESSAGE },
+      ],
+      metadata: sql`coalesce(${fastAgentMessages.metadata}, '{}'::jsonb)
+        || ${JSON.stringify({
+          visibleInTranscript: true,
+          purpose: 'closeout',
+          inferenceRetryNotice: true,
+          inferenceRetryActive: false,
+        })}::jsonb
+        || jsonb_build_object('interruptionReason', coalesce(${fastAgentMessages.metadata}->>'interruptionReason', ${reason}::text))`,
+      payload: sql`coalesce(${fastAgentMessages.payload}, '{}'::jsonb) || '{"purpose":"closeout"}'::jsonb`,
+      updatedAt: new Date(),
     })
-    .from(fastAgentMessages)
     .where(
       and(
         eq(fastAgentMessages.conversationId, conversationId),
         activeInferenceRetryNoticeWhere(),
       ),
-    );
+    )
+    .returning({ id: fastAgentMessages.id });
 
-  for (const notice of notices) {
-    await database
-      .update(fastAgentMessages)
-      .set({
-        contentBlocks: [
-          { type: 'text', text: INTERRUPTED_INFERENCE_RETRY_MESSAGE },
-        ],
-        metadata: {
-          ...(notice.metadata ?? {}),
-          visibleInTranscript: true,
-          purpose: 'closeout',
-          inferenceRetryNotice: true,
-          inferenceRetryActive: false,
-          // An interrupted owner may have already recorded the specific cause
-          // (e.g. lock_lost); the reconciler only fills in when nobody did.
-          interruptionReason:
-            typeof notice.metadata?.interruptionReason === 'string'
-              ? notice.metadata.interruptionReason
-              : reason,
-        },
-        payload: { ...notice.payload, purpose: 'closeout' },
-        updatedAt: new Date(),
-      })
-      .where(eq(fastAgentMessages.id, notice.id));
-  }
-
-  if (notices.length > 0) {
+  if (reconciled.length > 0) {
     console.warn(
-      `[Fast Agent] Reconciled ${notices.length} interrupted inference retry notice(s) (conversation=${conversationId}, reason=${reason}).`,
+      `[Fast Agent] Reconciled ${reconciled.length} interrupted inference retry notice(s) (conversation=${conversationId}, reason=${reason}).`,
     );
   }
 
-  return notices.length;
+  return reconciled.length;
 }
 
 export async function reconcileFastAgentInferenceRetryNotices(
@@ -198,8 +188,8 @@ export async function markFastAgentInferenceRetryNoticeInterruption(
   conversationId: string,
   eventId: string,
   reason: FastAgentInterruptionReason,
-): Promise<void> {
-  await db
+): Promise<boolean> {
+  const stamped = await db
     .update(fastAgentMessages)
     .set({
       metadata: sql`coalesce(${fastAgentMessages.metadata}, '{}'::jsonb) || ${JSON.stringify({ interruptionReason: reason })}::jsonb`,
@@ -212,7 +202,9 @@ export async function markFastAgentInferenceRetryNoticeInterruption(
         activeInferenceRetryNoticeWhere(),
         sql`${fastAgentMessages.metadata}->>'interruptionReason' IS NULL`,
       ),
-    );
+    )
+    .returning({ id: fastAgentMessages.id });
+  return stamped.length > 0;
 }
 
 export async function reconcileExpiredFastAgentInferenceRetryNotices(

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation-repository.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation-repository.ts
@@ -60,6 +60,22 @@ export type FastAgentMessageUpsertResult = {
 export const INTERRUPTED_INFERENCE_RETRY_MESSAGE =
   'The inference retry was interrupted before it completed. Please send the request again.';
 
+export const RESTARTED_ACTIVE_TURN_MESSAGE =
+  'Roomote restarted while working on this request. Please send it again.';
+
+/**
+ * Why an accepted Fast turn ended without a real answer. Stamped into the
+ * terminal message's metadata by every writer so occurrence counts can be
+ * attributed per cause instead of investigated per incident.
+ */
+export type FastAgentInterruptionReason =
+  | 'api_shutdown'
+  | 'turn_aborted'
+  | 'lock_lost'
+  | 'next_turn_reconcile'
+  | 'turn_settled_reconcile'
+  | 'expired_lease_reconcile';
+
 function isLegacyPlatformEventMessage(message: ModelMessage): boolean {
   if (message.role !== 'user') return false;
 
@@ -93,6 +109,7 @@ async function reconcileInferenceRetryNotices(
   database: DatabaseOrTransaction,
   conversationId: string,
   requireExpiredLease: boolean,
+  reason: FastAgentInterruptionReason,
 ): Promise<number> {
   await database.execute(
     sql`select pg_advisory_xact_lock(hashtextextended(${`fast-agent-conversation:${conversationId}`}, 0))`,
@@ -135,6 +152,12 @@ async function reconcileInferenceRetryNotices(
           purpose: 'closeout',
           inferenceRetryNotice: true,
           inferenceRetryActive: false,
+          // An interrupted owner may have already recorded the specific cause
+          // (e.g. lock_lost); the reconciler only fills in when nobody did.
+          interruptionReason:
+            typeof notice.metadata?.interruptionReason === 'string'
+              ? notice.metadata.interruptionReason
+              : reason,
         },
         payload: { ...notice.payload, purpose: 'closeout' },
         updatedAt: new Date(),
@@ -142,15 +165,54 @@ async function reconcileInferenceRetryNotices(
       .where(eq(fastAgentMessages.id, notice.id));
   }
 
+  if (notices.length > 0) {
+    console.warn(
+      `[Fast Agent] Reconciled ${notices.length} interrupted inference retry notice(s) (conversation=${conversationId}, reason=${reason}).`,
+    );
+  }
+
   return notices.length;
 }
 
 export async function reconcileFastAgentInferenceRetryNotices(
   conversationId: string,
+  reason: Extract<
+    FastAgentInterruptionReason,
+    'next_turn_reconcile' | 'turn_settled_reconcile'
+  >,
 ): Promise<number> {
   return db.transaction((tx) =>
-    reconcileInferenceRetryNotices(tx, conversationId, false),
+    reconcileInferenceRetryNotices(tx, conversationId, false, reason),
   );
+}
+
+/**
+ * Record why an active retry notice was orphaned without flipping it to a
+ * terminal closeout. Used by an owner that lost the conversation lock: it is
+ * fenced off from terminal writes (a successor may already own the turn), but
+ * this guarded, fill-only stamp is a no-op whenever a successor got there
+ * first, and the lease-gated reconciler later folds the cause into its
+ * closeout.
+ */
+export async function markFastAgentInferenceRetryNoticeInterruption(
+  conversationId: string,
+  eventId: string,
+  reason: FastAgentInterruptionReason,
+): Promise<void> {
+  await db
+    .update(fastAgentMessages)
+    .set({
+      metadata: sql`coalesce(${fastAgentMessages.metadata}, '{}'::jsonb) || ${JSON.stringify({ interruptionReason: reason })}::jsonb`,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(fastAgentMessages.conversationId, conversationId),
+        eq(fastAgentMessages.eventId, eventId),
+        activeInferenceRetryNoticeWhere(),
+        sql`${fastAgentMessages.metadata}->>'interruptionReason' IS NULL`,
+      ),
+    );
 }
 
 export async function reconcileExpiredFastAgentInferenceRetryNotices(
@@ -179,7 +241,12 @@ export async function reconcileExpiredFastAgentInferenceRetryNotices(
     // The per-conversation lock and lease recheck prevent a renewed active
     // turn from being reconciled after the candidate scan races with it.
     reconciled += await db.transaction((tx) =>
-      reconcileInferenceRetryNotices(tx, candidate.conversationId, true),
+      reconcileInferenceRetryNotices(
+        tx,
+        candidate.conversationId,
+        true,
+        'expired_lease_reconcile',
+      ),
     );
   }
   return reconciled;

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -93,7 +93,10 @@ import { RemoteFastAgentSettingsSkillSource } from './fast-agent-settings-skill-
 import { buildFastAgentExplicitSkillInvocationContext } from './fast-agent-skill-invocation';
 import {
   INTERRUPTED_INFERENCE_RETRY_MESSAGE,
+  markFastAgentInferenceRetryNoticeInterruption,
   reconcileFastAgentInferenceRetryNotices,
+  RESTARTED_ACTIVE_TURN_MESSAGE,
+  type FastAgentInterruptionReason,
 } from './fast-agent-conversation-repository';
 import {
   bindFastAgentNativeToolExecutor,
@@ -1246,6 +1249,7 @@ export async function answerFastAgentQuestion({
     nativeMessage,
     inferenceRetryNotice = false,
     visibleInTranscript = true,
+    interruptionReason,
   }: {
     reply: FastAgentReply;
     event: { eventId: string; turnSeq: number };
@@ -1253,6 +1257,7 @@ export async function answerFastAgentQuestion({
     nativeMessage?: NonTaskOpenCodeCompletedMessage | null;
     inferenceRetryNotice?: boolean;
     visibleInTranscript?: boolean;
+    interruptionReason?: FastAgentInterruptionReason;
   }) =>
     persistCanonicalMessage(
       {
@@ -1274,6 +1279,7 @@ export async function answerFastAgentQuestion({
                 inferenceRetryActive: reply.purpose === 'progress',
               }
             : {}),
+          ...(interruptionReason ? { interruptionReason } : {}),
           ...(platformMessageId ? { platformMessageId } : {}),
         },
         payload: {
@@ -1400,6 +1406,7 @@ export async function answerFastAgentQuestion({
     reply: FastAgentReply,
     bestEffort = false,
     onDelivered?: () => void,
+    interruptionReason?: FastAgentInterruptionReason,
   ): Promise<boolean> => {
     if (!inferenceRetryCanonicalEvent) {
       return false;
@@ -1419,6 +1426,7 @@ export async function answerFastAgentQuestion({
         event: retryEvent,
         inferenceRetryNotice: true,
         visibleInTranscript: false,
+        interruptionReason,
       });
       return false;
     }
@@ -1433,6 +1441,7 @@ export async function answerFastAgentQuestion({
           reply,
           event: retryEvent,
           inferenceRetryNotice: true,
+          interruptionReason,
         });
         throw error;
       }
@@ -1450,6 +1459,7 @@ export async function answerFastAgentQuestion({
         event: retryEvent,
         inferenceRetryNotice: true,
         visibleInTranscript: false,
+        interruptionReason,
       });
       return false;
     }
@@ -1464,6 +1474,7 @@ export async function answerFastAgentQuestion({
         event: retryEvent,
         platformMessageId: inferenceRetryReply.messageId,
         inferenceRetryNotice: true,
+        interruptionReason,
       });
     }
     return true;
@@ -1534,7 +1545,10 @@ export async function answerFastAgentQuestion({
       FAST_AGENT_HUMAN_STEER_POLL_INTERVAL_MS,
     );
     humanSteerPollTimer.unref();
-    await reconcileFastAgentInferenceRetryNotices(session.id).catch((error) => {
+    await reconcileFastAgentInferenceRetryNotices(
+      session.id,
+      'next_turn_reconcile',
+    ).catch((error) => {
       console.warn(
         `[Fast Agent] Failed to reconcile interrupted inference retry notices: ${formatErrorForLog(error)}`,
       );
@@ -2989,6 +3003,15 @@ export async function answerFastAgentQuestion({
         terminalError instanceof FastAgentProcessShutdownError;
       const lockOwnershipLost =
         terminalError instanceof FastAgentTurnLockLostError;
+      const interruptionReason: FastAgentInterruptionReason =
+        shutdownInterrupted
+          ? 'api_shutdown'
+          : lockOwnershipLost
+            ? 'lock_lost'
+            : 'turn_aborted';
+      console.error(
+        `[Fast Agent] Turn interrupted (reason=${interruptionReason}, conversation=${canonicalConversationId ?? 'unknown'}, retryNoticeVisible=${Boolean(inferenceRetryReply)}, error=${formatErrorForLog(terminalError)})`,
+      );
       try {
         if (canonicalConversationId) {
           fastAgentOpenCodeSessionManager.invalidate(canonicalConversationId);
@@ -2997,14 +3020,20 @@ export async function answerFastAgentQuestion({
           await replaceInferenceRetryReply(
             {
               purpose: 'closeout',
-              message: INTERRUPTED_INFERENCE_RETRY_MESSAGE,
+              // A shutdown is a restart the user can see through honestly;
+              // other aborts keep the generic retry-interruption wording.
+              message: shutdownInterrupted
+                ? RESTARTED_ACTIVE_TURN_MESSAGE
+                : INTERRUPTED_INFERENCE_RETRY_MESSAGE,
             },
             true,
+            undefined,
+            interruptionReason,
           );
         } else if (shutdownInterrupted && !isInstructionClosed()) {
           const reply = {
             purpose: 'closeout' as const,
-            message: INTERRUPTED_INFERENCE_RETRY_MESSAGE,
+            message: RESTARTED_ACTIVE_TURN_MESSAGE,
           };
           try {
             const posted = await adapter.postReply(reply);
@@ -3017,12 +3046,30 @@ export async function answerFastAgentQuestion({
                 allocateCanonicalEvent(`assistant:${nextAssistantOrdinal++}`),
               platformMessageId: posted?.messageId,
               inferenceRetryNotice: Boolean(retryEvent),
+              interruptionReason,
             });
           } catch (postError) {
             console.error(
               `[Fast Agent] Failed to post shutdown closeout: ${formatErrorForLog(postError)}`,
             );
           }
+        } else if (
+          lockOwnershipLost &&
+          canonicalConversationId &&
+          inferenceRetryCanonicalEvent
+        ) {
+          // This owner is fenced off from terminal writes, but the fill-only
+          // cause stamp is safe: it no-ops once a successor reconciles the
+          // notice, and the reconciler folds it into its later closeout.
+          await markFastAgentInferenceRetryNoticeInterruption(
+            canonicalConversationId,
+            inferenceRetryCanonicalEvent.eventId,
+            'lock_lost',
+          ).catch((markError) => {
+            console.warn(
+              `[Fast Agent] Failed to record lock-lost interruption cause: ${formatErrorForLog(markError)}`,
+            );
+          });
         }
       } finally {
         if (shutdownInterrupted) {
@@ -3111,6 +3158,7 @@ export async function answerFastAgentQuestion({
       if (inferenceRetryAttempted) {
         await reconcileFastAgentInferenceRetryNotices(
           canonicalConversationId,
+          'turn_settled_reconcile',
         ).catch((error) => {
           console.warn(
             `[Fast Agent] Failed to reconcile settled inference retry notices: ${formatErrorForLog(error)}`,


### PR DESCRIPTION
## Problem

The closeout "The inference retry was interrupted before it completed. Please send the request again." is written by five different code paths with different causes, and nothing records which one fired. That makes its frequency impossible to attribute: an API restart during a normal (non-retrying) turn, a lost Redis conversation lock, and the scheduled reconciler stamping an orphaned retry notice all produce the same text.

Two of those paths are also dishonest today:

- On API shutdown, the message is posted for **any** active turn, including turns that were never retrying. The user is told a retry was interrupted when the service simply restarted mid-response.
- A turn that loses its conversation lock dies silently, and the reconciler later labels it with the generic retry text, erasing the actual cause.

## Change

- Every writer of an interrupted-turn closeout now stamps a machine-readable `interruptionReason` into the canonical message metadata: `api_shutdown`, `turn_aborted`, `lock_lost`, `next_turn_reconcile`, `turn_settled_reconcile`, or `expired_lease_reconcile`. Occurrence counts per cause become a metadata query instead of an investigation.
- The abort path logs one structured line per interruption (reason, conversation, whether a retry notice was visible) for log-based attribution.
- Shutdown closeouts now use honest copy: "Roomote restarted while working on this request. Please send it again."
- A lock-lost owner records its cause with a guarded, fill-only stamp (`markFastAgentInferenceRetryNoticeInterruption`). It cannot flip the notice to terminal (the owner is fenced off from terminal writes because a successor may already own the turn) and it no-ops once a successor or the reconciler has settled the notice. The reconciler preserves a pre-recorded cause and only fills in its own reason when nobody recorded one.

No schema change: the stamp lives in the existing `fast_agent_messages.metadata` jsonb, so N-1 rollback is unaffected.

## Validation

- `@roomote/cloud-agents` fast-agent service + conversation repository suites: 137 passed (includes new coverage for the shutdown copy, lock-lost stamping, fill-only semantics, and reason preservation through reconciliation).
- `@roomote/bullmq` sessions-reconcile suite: 7 passed against the test database.
- `pnpm lint:fast`, `pnpm check-types:fast`, `pnpm knip` all pass.

## Context

First of a planned sequence: attribution (this PR), then bounded drain on API shutdown so deploys stop killing in-flight turns, then mid-turn renewal of the responding lease so the reconciler stops stamping turns that are still running.