### PR TITLE
[Fix] Live Fast turns get stamped as interrupted after 15 minutes

### DIFF
--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-conversation-repository.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-conversation-repository.test.ts
@@ -16,6 +16,7 @@ import {
   markFastAgentInferenceRetryNoticeInterruption,
   reconcileExpiredFastAgentInferenceRetryNotices,
   reconcileFastAgentInferenceRetryNotices,
+  renewFastSessionRespondingLease,
 } from '../fast-agent-conversation-repository';
 import { FAST_AGENT_REACTION_INPUT_TYPE } from '../fast-agent-conversation';
 import { hasFastAgentSession } from '../fast-agent-session';
@@ -979,5 +980,57 @@ describe('Fast conversation repository', () => {
         interruptionReason: stamped ? 'lock_lost' : 'next_turn_reconcile',
       });
     }
+  });
+
+  it('renews only a live responding lease', async () => {
+    const user = await createUser();
+    const session = await fastAgentConversationRepository.getOrCreate({
+      userId: user.id,
+      conversation: {
+        surface: 'web',
+        workspaceId: user.id,
+        conversationId: crypto.randomUUID(),
+      },
+    });
+    const readLease = async () => {
+      const [row] = await db
+        .select({ respondingUntil: sessions.respondingUntil })
+        .from(sessions)
+        .where(eq(sessions.fastConversationId, session.id));
+      return row?.respondingUntil ?? null;
+    };
+
+    // A cleared lease is fenced out: a stale renewal cannot resurrect it.
+    await db
+      .update(sessions)
+      .set({ respondingUntil: null })
+      .where(eq(sessions.fastConversationId, session.id));
+    await expect(renewFastSessionRespondingLease(session.id)).resolves.toBe(
+      false,
+    );
+    await expect(readLease()).resolves.toBeNull();
+
+    // An expired lease is fenced out and left untouched.
+    const expired = new Date(Date.now() - 1_000);
+    await db
+      .update(sessions)
+      .set({ respondingUntil: expired })
+      .where(eq(sessions.fastConversationId, session.id));
+    await expect(renewFastSessionRespondingLease(session.id)).resolves.toBe(
+      false,
+    );
+    await expect(readLease()).resolves.toEqual(expired);
+
+    // A live lease is extended.
+    const live = new Date(Date.now() + 60_000);
+    await db
+      .update(sessions)
+      .set({ respondingUntil: live })
+      .where(eq(sessions.fastConversationId, session.id));
+    await expect(renewFastSessionRespondingLease(session.id)).resolves.toBe(
+      true,
+    );
+    const renewed = await readLease();
+    expect(renewed?.getTime()).toBeGreaterThan(live.getTime());
   });
 });

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -237,6 +237,7 @@ import {
   FastAgentProcessShutdownError,
   FastAgentTurnLockLostError,
 } from '../fast-agent-turn-lock';
+import { FAST_RESPONDING_LEASE_RENEW_MS } from '../fast-agent-constants';
 
 const baseParams = {
   question: 'What does this service do?',
@@ -2605,6 +2606,55 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
       );
     } finally {
       timeout.mockRestore();
+    }
+  });
+
+  it('renews the responding lease on wall clock while a long turn executes', async () => {
+    vi.useFakeTimers();
+    mocks.getUnifiedSession.mockResolvedValue({ id: 'session-1' });
+    let finishInference: (() => void) | undefined;
+    mocks.generateText.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          finishInference = () => resolve('All done.');
+        }),
+    );
+    const leaseExtensions = () =>
+      mocks.touchSessionActivity.mock.calls.filter(
+        ([, , , update]) => update?.respondingUntil instanceof Date,
+      );
+
+    try {
+      const answer = answerFastAgentQuestion({
+        ...baseParams,
+        adapter: callbacks(),
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(leaseExtensions()).toHaveLength(1);
+
+      // No assistant message persists during this stretch; only the
+      // wall-clock renewal keeps the lease ahead of the reconciler.
+      await vi.advanceTimersByTimeAsync(FAST_RESPONDING_LEASE_RENEW_MS);
+      expect(leaseExtensions()).toHaveLength(2);
+      await vi.advanceTimersByTimeAsync(FAST_RESPONDING_LEASE_RENEW_MS);
+      expect(leaseExtensions()).toHaveLength(3);
+
+      finishInference?.();
+      await vi.advanceTimersByTimeAsync(0);
+      await answer;
+
+      // Settling the turn clears the lease and stops the renewal timer.
+      expect(mocks.touchSessionActivity).toHaveBeenLastCalledWith(
+        expect.anything(),
+        'session-1',
+        expect.any(Number),
+        { respondingUntil: null },
+      );
+      const settledCalls = mocks.touchSessionActivity.mock.calls.length;
+      await vi.advanceTimersByTimeAsync(FAST_RESPONDING_LEASE_RENEW_MS * 2);
+      expect(mocks.touchSessionActivity.mock.calls).toHaveLength(settledCalls);
+    } finally {
+      vi.useRealTimers();
     }
   });
 

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -2658,6 +2658,74 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
     }
   });
 
+  it('waits out an in-flight lease renewal before settling the lease', async () => {
+    vi.useFakeTimers();
+    mocks.getUnifiedSession.mockResolvedValue({ id: 'session-1' });
+    let releaseRenewal: (() => void) | undefined;
+    let leaseWrites = 0;
+    mocks.touchSessionActivity.mockImplementation(
+      async (
+        _db: unknown,
+        _sessionId: unknown,
+        _ts: unknown,
+        update: { respondingUntil?: unknown } | undefined,
+      ) => {
+        if (update?.respondingUntil instanceof Date) {
+          leaseWrites += 1;
+          if (leaseWrites === 2) {
+            // The wall-clock renewal stalls mid-write.
+            await new Promise<void>((resolve) => {
+              releaseRenewal = resolve;
+            });
+          }
+        }
+      },
+    );
+    let finishInference: (() => void) | undefined;
+    mocks.generateText.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          finishInference = () => resolve('All done.');
+        }),
+    );
+
+    try {
+      const answer = answerFastAgentQuestion({
+        ...baseParams,
+        adapter: callbacks(),
+      });
+      let settled = false;
+      void answer.finally(() => {
+        settled = true;
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(FAST_RESPONDING_LEASE_RENEW_MS);
+      expect(releaseRenewal).toBeDefined();
+
+      finishInference?.();
+      await vi.advanceTimersByTimeAsync(1);
+      // Settlement must wait for the stalled renewal so the terminal lease
+      // write cannot be overwritten by the stale extension.
+      expect(settled).toBe(false);
+      const callsBeforeRelease = mocks.touchSessionActivity.mock.calls.length;
+
+      releaseRenewal?.();
+      await vi.advanceTimersByTimeAsync(1);
+      await answer;
+      expect(mocks.touchSessionActivity).toHaveBeenLastCalledWith(
+        expect.anything(),
+        'session-1',
+        expect.any(Number),
+        { respondingUntil: null },
+      );
+      expect(mocks.touchSessionActivity.mock.calls).toHaveLength(
+        callsBeforeRelease + 1,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('posts a terminal closeout when API shutdown interrupts silent retry backoff', async () => {
     const controller = new AbortController();
     const shutdown = new FastAgentProcessShutdownError('SIGTERM');

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -2658,6 +2658,64 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
     }
   });
 
+  it('does not extend the lease when ownership is lost during the renewal lookup', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const lockLost = new FastAgentTurnLockLostError();
+    let releaseLookup: (() => void) | undefined;
+    let lookupCalls = 0;
+    mocks.getUnifiedSession.mockImplementation(async () => {
+      lookupCalls += 1;
+      if (lookupCalls === 2) {
+        // The renewal's session lookup stalls; ownership is lost meanwhile.
+        await new Promise<void>((resolve) => {
+          releaseLookup = resolve;
+        });
+      }
+      return { id: 'session-1' };
+    });
+    mocks.generateText.mockImplementation(
+      (_params: unknown, _session: unknown, options: { signal: AbortSignal }) =>
+        new Promise<string>((_resolve, reject) => {
+          options.signal.addEventListener(
+            'abort',
+            () => reject(options.signal.reason),
+            { once: true },
+          );
+        }),
+    );
+    const leaseExtensions = () =>
+      mocks.touchSessionActivity.mock.calls.filter(
+        ([, , , update]) => update?.respondingUntil instanceof Date,
+      );
+
+    try {
+      const answer = answerFastAgentQuestion({
+        ...baseParams,
+        adapter: callbacks(),
+        signal: controller.signal,
+      });
+      const rejection = expect(answer).rejects.toBe(lockLost);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(leaseExtensions()).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(FAST_RESPONDING_LEASE_RENEW_MS);
+      expect(releaseLookup).toBeDefined();
+
+      controller.abort(lockLost);
+      releaseLookup?.();
+      await vi.advanceTimersByTimeAsync(1);
+      await rejection;
+
+      // The stalled renewal saw the lost ownership after its lookup and
+      // wrote nothing, and the fenced-off owner never cleared the lease.
+      expect(leaseExtensions()).toHaveLength(1);
+      expect(mocks.touchSessionActivity).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('waits out an in-flight lease renewal before settling the lease', async () => {
     vi.useFakeTimers();
     mocks.getUnifiedSession.mockResolvedValue({ id: 'session-1' });

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -29,6 +29,7 @@ const mocks = vi.hoisted(() => ({
   revokeMcpCapabilities: vi.fn(),
   reconcileRetryNotices: vi.fn(),
   markRetryNoticeInterruption: vi.fn(),
+  renewRespondingLease: vi.fn(),
   getUnifiedSession: vi.fn(),
   touchSessionActivity: vi.fn(),
   getSessionForTask: vi.fn(),
@@ -93,6 +94,7 @@ vi.mock('../fast-agent-conversation-repository', () => ({
   reconcileFastAgentInferenceRetryNotices: mocks.reconcileRetryNotices,
   markFastAgentInferenceRetryNoticeInterruption:
     mocks.markRetryNoticeInterruption,
+  renewFastSessionRespondingLease: mocks.renewRespondingLease,
 }));
 
 vi.mock('../../router', () => ({
@@ -380,6 +382,7 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
     mocks.upsertMessage.mockResolvedValue({ initialHumanTurn: true });
     mocks.reconcileRetryNotices.mockResolvedValue(0);
     mocks.markRetryNoticeInterruption.mockResolvedValue(undefined);
+    mocks.renewRespondingLease.mockResolvedValue(true);
     mocks.getActiveTasks.mockResolvedValue([]);
     mocks.getEnvironments.mockResolvedValue([
       {
@@ -2619,10 +2622,6 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
           finishInference = () => resolve('All done.');
         }),
     );
-    const leaseExtensions = () =>
-      mocks.touchSessionActivity.mock.calls.filter(
-        ([, , , update]) => update?.respondingUntil instanceof Date,
-      );
 
     try {
       const answer = answerFastAgentQuestion({
@@ -2630,17 +2629,19 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
         adapter: callbacks(),
       });
       await vi.advanceTimersByTimeAsync(0);
-      expect(leaseExtensions()).toHaveLength(1);
+      expect(mocks.touchSessionActivity).toHaveBeenCalledOnce();
+      expect(mocks.renewRespondingLease).not.toHaveBeenCalled();
 
       // No assistant message persists during this stretch; only the
       // wall-clock renewal keeps the lease ahead of the reconciler.
       await vi.advanceTimersByTimeAsync(FAST_RESPONDING_LEASE_RENEW_MS);
-      expect(leaseExtensions()).toHaveLength(2);
+      expect(mocks.renewRespondingLease).toHaveBeenCalledTimes(1);
       await vi.advanceTimersByTimeAsync(FAST_RESPONDING_LEASE_RENEW_MS);
-      expect(leaseExtensions()).toHaveLength(3);
+      expect(mocks.renewRespondingLease).toHaveBeenCalledTimes(2);
+      expect(mocks.renewRespondingLease).toHaveBeenCalledWith('conversation-1');
 
       finishInference?.();
-      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(1);
       await answer;
 
       // Settling the turn clears the lease and stops the renewal timer.
@@ -2650,29 +2651,25 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
         expect.any(Number),
         { respondingUntil: null },
       );
-      const settledCalls = mocks.touchSessionActivity.mock.calls.length;
       await vi.advanceTimersByTimeAsync(FAST_RESPONDING_LEASE_RENEW_MS * 2);
-      expect(mocks.touchSessionActivity.mock.calls).toHaveLength(settledCalls);
+      expect(mocks.renewRespondingLease).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it('does not extend the lease when ownership is lost during the renewal lookup', async () => {
+  it('stops renewing once ownership is lost, even for a queued renewal', async () => {
     vi.useFakeTimers();
     const controller = new AbortController();
     const lockLost = new FastAgentTurnLockLostError();
-    let releaseLookup: (() => void) | undefined;
-    let lookupCalls = 0;
-    mocks.getUnifiedSession.mockImplementation(async () => {
-      lookupCalls += 1;
-      if (lookupCalls === 2) {
-        // The renewal's session lookup stalls; ownership is lost meanwhile.
-        await new Promise<void>((resolve) => {
-          releaseLookup = resolve;
-        });
-      }
-      return { id: 'session-1' };
+    mocks.getUnifiedSession.mockResolvedValue({ id: 'session-1' });
+    let releaseRenewal: (() => void) | undefined;
+    mocks.renewRespondingLease.mockImplementation(async () => {
+      // The first renewal stalls mid-write; a second tick queues behind it.
+      await new Promise<void>((resolve) => {
+        releaseRenewal = resolve;
+      });
+      return true;
     });
     mocks.generateText.mockImplementation(
       (_params: unknown, _session: unknown, options: { signal: AbortSignal }) =>
@@ -2684,10 +2681,6 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
           );
         }),
     );
-    const leaseExtensions = () =>
-      mocks.touchSessionActivity.mock.calls.filter(
-        ([, , , update]) => update?.respondingUntil instanceof Date,
-      );
 
     try {
       const answer = answerFastAgentQuestion({
@@ -2697,19 +2690,19 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
       });
       const rejection = expect(answer).rejects.toBe(lockLost);
       await vi.advanceTimersByTimeAsync(0);
-      expect(leaseExtensions()).toHaveLength(1);
-
       await vi.advanceTimersByTimeAsync(FAST_RESPONDING_LEASE_RENEW_MS);
-      expect(releaseLookup).toBeDefined();
+      expect(mocks.renewRespondingLease).toHaveBeenCalledTimes(1);
+      expect(releaseRenewal).toBeDefined();
+      await vi.advanceTimersByTimeAsync(FAST_RESPONDING_LEASE_RENEW_MS);
 
       controller.abort(lockLost);
-      releaseLookup?.();
+      releaseRenewal?.();
       await vi.advanceTimersByTimeAsync(1);
       await rejection;
 
-      // The stalled renewal saw the lost ownership after its lookup and
-      // wrote nothing, and the fenced-off owner never cleared the lease.
-      expect(leaseExtensions()).toHaveLength(1);
+      // The queued second renewal saw the lost ownership and never ran, and
+      // the fenced-off owner did not clear the lease.
+      expect(mocks.renewRespondingLease).toHaveBeenCalledTimes(1);
       expect(mocks.touchSessionActivity).toHaveBeenCalledOnce();
     } finally {
       vi.useRealTimers();
@@ -2720,25 +2713,13 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
     vi.useFakeTimers();
     mocks.getUnifiedSession.mockResolvedValue({ id: 'session-1' });
     let releaseRenewal: (() => void) | undefined;
-    let leaseWrites = 0;
-    mocks.touchSessionActivity.mockImplementation(
-      async (
-        _db: unknown,
-        _sessionId: unknown,
-        _ts: unknown,
-        update: { respondingUntil?: unknown } | undefined,
-      ) => {
-        if (update?.respondingUntil instanceof Date) {
-          leaseWrites += 1;
-          if (leaseWrites === 2) {
-            // The wall-clock renewal stalls mid-write.
-            await new Promise<void>((resolve) => {
-              releaseRenewal = resolve;
-            });
-          }
-        }
-      },
-    );
+    mocks.renewRespondingLease.mockImplementation(async () => {
+      // The wall-clock renewal stalls mid-write.
+      await new Promise<void>((resolve) => {
+        releaseRenewal = resolve;
+      });
+      return true;
+    });
     let finishInference: (() => void) | undefined;
     mocks.generateText.mockImplementation(
       () =>
@@ -2765,19 +2746,21 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
       // Settlement must wait for the stalled renewal so the terminal lease
       // write cannot be overwritten by the stale extension.
       expect(settled).toBe(false);
-      const callsBeforeRelease = mocks.touchSessionActivity.mock.calls.length;
+      const settleWrites = () =>
+        mocks.touchSessionActivity.mock.calls.filter(
+          ([, , , update]) => update?.respondingUntil === null,
+        );
+      expect(settleWrites()).toHaveLength(0);
 
       releaseRenewal?.();
       await vi.advanceTimersByTimeAsync(1);
       await answer;
+      expect(settleWrites()).toHaveLength(1);
       expect(mocks.touchSessionActivity).toHaveBeenLastCalledWith(
         expect.anything(),
         'session-1',
         expect.any(Number),
         { respondingUntil: null },
-      );
-      expect(mocks.touchSessionActivity.mock.calls).toHaveLength(
-        callsBeforeRelease + 1,
       );
     } finally {
       vi.useRealTimers();

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-constants.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-constants.ts
@@ -4,6 +4,11 @@ export const FAST_AGENT_MODEL_ROLE = 'orchestration' as const;
 // responses, short enough that a crashed turn self-heals the session status.
 // Streaming touch points re-extend it so long turns keep the lease fresh.
 export const FAST_RESPONDING_LEASE_MS = 15 * 60 * 1000;
+// Assistant-message persists also extend the lease, but a turn can spend
+// longer than the lease inside tool calls or a streaming stretch without
+// persisting one; the time-based renewal keeps the lease fresh for exactly
+// as long as the turn is actually executing.
+export const FAST_RESPONDING_LEASE_RENEW_MS = FAST_RESPONDING_LEASE_MS / 3;
 export const FAST_AGENT_GITHUB_MCP_PATH = '/api/mcp-routing/github';
 export const FAST_AGENT_TASKS_API_PATH = '/api/mcp/tasks';
 export const FAST_AGENT_ENVIRONMENTS_API_PATH = '/api/mcp/environments';

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation-repository.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation-repository.ts
@@ -10,6 +10,8 @@ import {
   advanceSessionNotifiedCursor,
   advanceSessionReadCursor,
   getSessionForFastConversation,
+  gt,
+  isNotNull,
   isNull,
   lt,
   or,
@@ -205,6 +207,33 @@ export async function markFastAgentInferenceRetryNoticeInterruption(
     )
     .returning({ id: fastAgentMessages.id });
   return stamped.length > 0;
+}
+
+/**
+ * Extend the responding lease with the fence in the statement itself: only a
+ * lease that is still live is extended, so a stale renewal from an owner that
+ * lost the conversation mid-write can never resurrect a lease a settlement
+ * or successor already cleared. No read precedes the write, which removes
+ * the check-then-write window entirely. Returns whether a lease was renewed.
+ */
+export async function renewFastSessionRespondingLease(
+  fastConversationId: string,
+): Promise<boolean> {
+  const renewed = await db
+    .update(sessions)
+    .set({
+      respondingUntil: new Date(Date.now() + FAST_RESPONDING_LEASE_MS),
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(sessions.fastConversationId, fastConversationId),
+        isNotNull(sessions.respondingUntil),
+        gt(sessions.respondingUntil, new Date()),
+      ),
+    )
+    .returning({ id: sessions.id });
+  return renewed.length > 0;
 }
 
 export async function reconcileExpiredFastAgentInferenceRetryNotices(

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -259,9 +259,13 @@ async function markFastAgentHumanFollowUpDelivered(id: string): Promise<void> {
 async function setFastSessionResponding(
   fastConversationId: string,
   responding: boolean,
+  /** Re-checked after the session lookup, immediately before the write, so
+   * an owner fenced off mid-lookup cannot extend a successor's lease. */
+  isOwnershipCurrent?: () => boolean,
 ): Promise<void> {
   const session = await getSessionForFastConversation(db, fastConversationId);
   if (!session) return;
+  if (isOwnershipCurrent && !isOwnershipCurrent()) return;
   await touchSessionActivity(db, session.id, Math.floor(Date.now() / 1000), {
     respondingUntil: responding
       ? new Date(Date.now() + FAST_RESPONDING_LEASE_MS)
@@ -1560,7 +1564,11 @@ export async function answerFastAgentQuestion({
         `[Fast Agent] Failed to reconcile interrupted inference retry notices: ${formatErrorForLog(error)}`,
       );
     });
-    await setFastSessionResponding(session.id, true).catch((error) => {
+    await setFastSessionResponding(
+      session.id,
+      true,
+      () => !signal?.aborted,
+    ).catch((error) => {
       console.warn(
         `[sessions] Failed to mark Fast Session active: ${formatErrorForLog(error)}`,
       );
@@ -1577,9 +1585,14 @@ export async function answerFastAgentQuestion({
       respondingLeaseRenewal = respondingLeaseRenewal.then(async () => {
         // Re-check ownership when the chained renewal actually runs: a tick
         // queued behind a slow write must not extend the lease after this
-        // owner was aborted or fenced off.
+        // owner was aborted or fenced off. The predicate re-checks again
+        // after the session lookup, immediately before the write.
         if (signal?.aborted) return;
-        await setFastSessionResponding(session.id, true).catch((error) => {
+        await setFastSessionResponding(
+          session.id,
+          true,
+          () => !signal?.aborted,
+        ).catch((error) => {
           console.warn(
             `[sessions] Failed to renew Fast Session responding lease: ${formatErrorForLog(error)}`,
           );

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -1056,6 +1056,11 @@ export async function answerFastAgentQuestion({
   let activeToolExecutions = 0;
   let humanSteerPollTimer: ReturnType<typeof setInterval> | undefined;
   let respondingLeaseRenewalTimer: ReturnType<typeof setInterval> | undefined;
+  // Renewals chain onto this promise so settlement can await the in-flight
+  // write before recording the terminal lease state; a fire-and-forget tick
+  // could otherwise commit after the settle write and leave an idle Session
+  // marked responding for another lease.
+  let respondingLeaseRenewal: Promise<void> = Promise.resolve();
   let activeHumanSteerPoll = Promise.resolve();
   const injectedHumanFollowUpIds = new Set<string>();
   const humanFollowUpTurnSeqs = new Map<string, number>();
@@ -1569,10 +1574,16 @@ export async function answerFastAgentQuestion({
     // successor's lease.
     respondingLeaseRenewalTimer = setInterval(() => {
       if (signal?.aborted) return;
-      void setFastSessionResponding(session.id, true).catch((error) => {
-        console.warn(
-          `[sessions] Failed to renew Fast Session responding lease: ${formatErrorForLog(error)}`,
-        );
+      respondingLeaseRenewal = respondingLeaseRenewal.then(async () => {
+        // Re-check ownership when the chained renewal actually runs: a tick
+        // queued behind a slow write must not extend the lease after this
+        // owner was aborted or fenced off.
+        if (signal?.aborted) return;
+        await setFastSessionResponding(session.id, true).catch((error) => {
+          console.warn(
+            `[sessions] Failed to renew Fast Session responding lease: ${formatErrorForLog(error)}`,
+          );
+        });
       });
     }, FAST_RESPONDING_LEASE_RENEW_MS);
     respondingLeaseRenewalTimer.unref();
@@ -3156,6 +3167,9 @@ export async function answerFastAgentQuestion({
   } finally {
     if (respondingLeaseRenewalTimer) clearInterval(respondingLeaseRenewalTimer);
     respondingLeaseRenewalTimer = undefined;
+    // Wait out any renewal already in flight so the terminal lease write
+    // below cannot be overwritten by a stale extension.
+    await respondingLeaseRenewal;
     signal?.removeEventListener('abort', stopHumanSteerPolling);
     stopHumanSteerPolling();
     await activeHumanSteerPoll;

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -61,6 +61,7 @@ import { getAvailableEnvironments, type RoutableEnvironment } from '../router';
 import {
   FAST_AGENT_MODEL_ROLE,
   FAST_RESPONDING_LEASE_MS,
+  FAST_RESPONDING_LEASE_RENEW_MS,
 } from './fast-agent-constants';
 import { buildFastAgentSystemPrompt } from './fast-agent-prompt';
 import {
@@ -1054,6 +1055,7 @@ export async function answerFastAgentQuestion({
   let nativeSteer: NonTaskOpenCodeNativeSteer | undefined;
   let activeToolExecutions = 0;
   let humanSteerPollTimer: ReturnType<typeof setInterval> | undefined;
+  let respondingLeaseRenewalTimer: ReturnType<typeof setInterval> | undefined;
   let activeHumanSteerPoll = Promise.resolve();
   const injectedHumanFollowUpIds = new Set<string>();
   const humanFollowUpTurnSeqs = new Map<string, number>();
@@ -1558,6 +1560,22 @@ export async function answerFastAgentQuestion({
         `[sessions] Failed to mark Fast Session active: ${formatErrorForLog(error)}`,
       );
     });
+    // Assistant-message persists extend the lease as a side effect, but a
+    // turn can spend longer than the lease inside tool calls or a streaming
+    // stretch without persisting one, and the expired-lease reconciler would
+    // then stamp its live retry notice as interrupted. Renew on wall clock
+    // for as long as this owner is executing; the tick stops renewing the
+    // moment ownership is aborted so a fenced-off owner cannot extend a
+    // successor's lease.
+    respondingLeaseRenewalTimer = setInterval(() => {
+      if (signal?.aborted) return;
+      void setFastSessionResponding(session.id, true).catch((error) => {
+        console.warn(
+          `[sessions] Failed to renew Fast Session responding lease: ${formatErrorForLog(error)}`,
+        );
+      });
+    }, FAST_RESPONDING_LEASE_RENEW_MS);
+    respondingLeaseRenewalTimer.unref();
     durableOpenCodeSessionId = session.openCodeSessionId;
     activeOpenCodeSessionId = session.openCodeSessionId;
     diagnostics.setCanonicalConversationId(session.id);
@@ -3136,6 +3154,8 @@ export async function answerFastAgentQuestion({
     }
     return lastVisibleMessage || message;
   } finally {
+    if (respondingLeaseRenewalTimer) clearInterval(respondingLeaseRenewalTimer);
+    respondingLeaseRenewalTimer = undefined;
     signal?.removeEventListener('abort', stopHumanSteerPolling);
     stopHumanSteerPolling();
     await activeHumanSteerPoll;

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -96,6 +96,7 @@ import {
   INTERRUPTED_INFERENCE_RETRY_MESSAGE,
   markFastAgentInferenceRetryNoticeInterruption,
   reconcileFastAgentInferenceRetryNotices,
+  renewFastSessionRespondingLease,
   RESTARTED_ACTIVE_TURN_MESSAGE,
   type FastAgentInterruptionReason,
 } from './fast-agent-conversation-repository';
@@ -1583,16 +1584,12 @@ export async function answerFastAgentQuestion({
     respondingLeaseRenewalTimer = setInterval(() => {
       if (signal?.aborted) return;
       respondingLeaseRenewal = respondingLeaseRenewal.then(async () => {
-        // Re-check ownership when the chained renewal actually runs: a tick
-        // queued behind a slow write must not extend the lease after this
-        // owner was aborted or fenced off. The predicate re-checks again
-        // after the session lookup, immediately before the write.
+        // The abort check is only a cheap short-circuit; correctness comes
+        // from the renewal statement itself, which extends the lease only
+        // where it is still live, so a stale write cannot resurrect a lease
+        // a settlement or successor already cleared.
         if (signal?.aborted) return;
-        await setFastSessionResponding(
-          session.id,
-          true,
-          () => !signal?.aborted,
-        ).catch((error) => {
+        await renewFastSessionRespondingLease(session.id).catch((error) => {
           console.warn(
             `[sessions] Failed to renew Fast Session responding lease: ${formatErrorForLog(error)}`,
           );


### PR DESCRIPTION
## Problem

The scheduled reconciler stamps "The inference retry was interrupted..." onto any conversation whose retry notice is still active once the session's responding lease expires. The 15-minute lease is set at turn start and extended only as a side effect of persisting an **assistant message** — tool events and long streaming stretches never touch it. A turn that recovers from a provider blip (leaving its retry notice active by design until the closeout) and then spends 15+ minutes in tool-heavy work gets stamped as interrupted in its canonical transcript **while it is still running**. Long investigation Sessions are exactly this profile, and this is one of the producers the attribution work in #2004 was built to expose (`expired_lease_reconcile`).

## Change

The turn now also renews the responding lease on wall clock, every lease/3 (5 minutes), for as long as it is executing:

- The renewal tick checks turn ownership first, so a fenced-off owner that lost its conversation lock stops renewing immediately and cannot extend a successor's lease.
- Settling the turn stops the timer and clears the lease exactly as before, so `respondingUntil` semantics for idle Sessions are unchanged.
- The assistant-message extension in the repository stays as is; the wall-clock renewal covers the stretches it cannot see.

The reconciler itself is untouched: an expired lease still means what it always meant, it just can no longer be true for a turn that is actively executing.

## Validation

- New regression test: with inference held open and no assistant messages persisting, the lease is renewed at each interval, cleared at settlement, and the timer stops afterward (fake timers).
- Full fast-agent suite in `@roomote/cloud-agents`: 332 tests pass.
- `pnpm lint:fast`, `pnpm check-types:fast`, `pnpm knip` all pass.

## Context

PR 3 of the interruption work: #2004 (attribution) is merged, #2006 (shutdown drain) is in review. After both land, `expired_lease_reconcile` stamps on live turns should drop to zero, and the remaining attribution counts tell us whether #1966's recovery path still earns a merge.