### PR TITLE
[Fix] Serve Fast native tools from a shared OpenCode config directory

### DIFF
--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-native-tool-bridge.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-native-tool-bridge.test.ts
@@ -64,13 +64,26 @@ function expectBoundedSpillDescriptor(output: string): void {
 }
 
 describe('Fast native OpenCode tool bridge', () => {
-  it('installs Fast tools in an isolated OpenCode session directory', async () => {
+  it('serves Fast tools from one shared config directory per host', async () => {
     const runtime = await getFastAgentNativeToolRuntime('native-files', []);
     const otherRuntime = await getFastAgentNativeToolRuntime(
       'native-files-other',
       [],
     );
-    const toolsDirectory = join(runtime.directory, '.opencode', 'tools');
+    const sharedToolsDirectory = runtime.env.OPENCODE_CONFIG_DIR;
+    expect(sharedToolsDirectory).toMatch(
+      /roomote-fast-opencode\/shared-tools-[a-f0-9]{32}$/u,
+    );
+    expect(otherRuntime.env.OPENCODE_CONFIG_DIR).toBe(sharedToolsDirectory);
+    expect(buildOpenCodeCliEnv(runtime.env).OPENCODE_CONFIG_DIR).toBe(
+      sharedToolsDirectory,
+    );
+    // The conversation directory itself carries only the session config, so
+    // OpenCode's per-directory boot never runs a dependency install for it.
+    expect((await readdir(runtime.directory)).sort()).toEqual([
+      'opencode.json',
+    ]);
+    const toolsDirectory = join(sharedToolsDirectory!, 'tools');
     const installedToolFiles = await readdir(toolsDirectory);
     const replySource = await readFile(
       join(toolsDirectory, 'send_chat_reply.js'),
@@ -89,7 +102,7 @@ describe('Fast native OpenCode tool bridge', () => {
       'utf8',
     );
     const bridgeSource = await readFile(
-      join(runtime.directory, '.opencode', 'roomote-fast-tool-bridge.js'),
+      join(sharedToolsDirectory!, 'roomote-fast-tool-bridge.js'),
       'utf8',
     );
     const spillReadSource = await readFile(

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-native-tool-bridge.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-native-tool-bridge.ts
@@ -1099,38 +1099,79 @@ async function startBridge(): Promise<FastAgentNativeToolBridge> {
     throw new Error('Fast tool bridge did not receive a TCP address.');
   }
 
+  const sharedToolsDirectory = createSharedToolsDirectory();
+
   return {
     token,
     url: `http://127.0.0.1:${address.port}`,
     env: {
       ROOMOTE_FAST_TOOL_BRIDGE_TOKEN: token,
       ROOMOTE_FAST_TOOL_BRIDGE_URL: `http://127.0.0.1:${address.port}/tool`,
+      // Every Fast conversation gets its own OpenCode project directory, and
+      // OpenCode boots a fresh instance per directory. Serving the native
+      // tools from one extra config directory keeps that per-conversation
+      // boot down to reading `opencode.json`: OpenCode runs a dependency
+      // install (`@opencode-ai/plugin`) for each `.opencode` directory it
+      // loads, which cost roughly a second on the first message of every
+      // conversation when the tools lived inside the conversation directory.
+      OPENCODE_CONFIG_DIR: sharedToolsDirectory,
     },
   };
 }
 
-function createRuntimeDirectory(sessionId: string): string {
+function ensureRuntimeRootDirectory(): string {
   const rootDirectory = join(tmpdir(), 'roomote-fast-opencode');
   mkdirSync(rootDirectory, { recursive: true, mode: 0o700 });
   chmodSync(rootDirectory, 0o700);
+  return rootDirectory;
+}
+
+/**
+ * Materializes the native Fast tools in a content-addressed directory shared
+ * by every conversation on this host. The path hashes the generated sources,
+ * so a deploy that changes or removes a tool lands in a new directory and the
+ * old one is never loaded again, while an unchanged deploy reuses the
+ * directory (and whatever OpenCode already installed into it).
+ */
+function createSharedToolsDirectory(): string {
+  const zodDirectory = resolveZodDirectoryForTools();
+  const contentHash = createHash('sha256')
+    .update(
+      JSON.stringify({
+        layout: 2,
+        bridge: FAST_AGENT_NATIVE_TOOL_BRIDGE_SOURCE,
+        tools: FAST_AGENT_NATIVE_TOOL_SOURCES,
+        zod: zodDirectory,
+      }),
+    )
+    .digest('hex');
   const directory = join(
-    rootDirectory,
-    createHash('sha256').update(sessionId).digest('hex'),
+    ensureRuntimeRootDirectory(),
+    `shared-tools-${contentHash.slice(0, 32)}`,
   );
-  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const toolsDirectory = join(directory, 'tools');
+  mkdirSync(toolsDirectory, { recursive: true, mode: 0o700 });
   chmodSync(directory, 0o700);
-  const toolsDirectory = join(directory, '.opencode', 'tools');
-  // Recreate the tool directory from scratch: a reused runtime directory may
-  // hold tool files from an older code version, and stale tools would stay
-  // loadable (and invokable) after a deploy that removed them.
-  rmSync(toolsDirectory, { recursive: true, force: true });
-  mkdirSync(toolsDirectory, { recursive: true });
   writeFileSync(
-    join(directory, '.opencode', 'package.json'),
+    join(directory, 'package.json'),
     JSON.stringify({ private: true, type: 'module' }),
     'utf8',
   );
-  const toolNodeModules = join(directory, '.opencode', 'node_modules');
+  // OpenCode installs `@opencode-ai/plugin` into every config directory
+  // whose lockfile does not already list it. The Fast tools import only the
+  // bridge shim and the zod link below, so a lockfile that declares the
+  // dependency satisfies that check without a network install (and without
+  // OpenCode rewriting this package.json).
+  writeFileSync(
+    join(directory, 'package-lock.json'),
+    JSON.stringify({
+      name: 'roomote-fast-tools',
+      lockfileVersion: 3,
+      packages: { '': { dependencies: { '@opencode-ai/plugin': '*' } } },
+    }),
+    'utf8',
+  );
+  const toolNodeModules = join(directory, 'node_modules');
   mkdirSync(toolNodeModules, { recursive: true });
   const zodLink = join(toolNodeModules, 'zod');
   try {
@@ -1139,15 +1180,36 @@ function createRuntimeDirectory(sessionId: string): string {
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
   }
-  symlinkSync(resolveZodDirectoryForTools(), zodLink, 'dir');
+  try {
+    symlinkSync(zodDirectory, zodLink, 'dir');
+  } catch (error) {
+    // Another process on this host materialized the same directory between
+    // the unlink and the symlink; the target is identical by construction.
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+  }
   writeFileSync(
-    join(directory, '.opencode', 'roomote-fast-tool-bridge.js'),
+    join(directory, 'roomote-fast-tool-bridge.js'),
     FAST_AGENT_NATIVE_TOOL_BRIDGE_SOURCE,
     'utf8',
   );
   for (const [name, source] of Object.entries(FAST_AGENT_NATIVE_TOOL_SOURCES)) {
     writeFileSync(join(toolsDirectory, `${name}.js`), source, 'utf8');
   }
+  return directory;
+}
+
+function createRuntimeDirectory(sessionId: string): string {
+  const directory = join(
+    ensureRuntimeRootDirectory(),
+    createHash('sha256').update(sessionId).digest('hex'),
+  );
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  chmodSync(directory, 0o700);
+  // Earlier releases wrote the native tools into a per-conversation
+  // `.opencode` directory. A reused conversation directory must shed it: its
+  // presence makes OpenCode run a dependency install on every boot and would
+  // keep stale tool files loadable after a deploy that removed them.
+  rmSync(join(directory, '.opencode'), { recursive: true, force: true });
   return directory;
 }
 


### PR DESCRIPTION
## Problem

The first message of every Fast conversation paid roughly a second of setup before inference started (several seconds on a cold bun cache), even when the OpenCode server was already running.

OpenCode boots a fresh instance per project directory, and its config loader runs an npm install of `@opencode-ai/plugin` for every `.opencode` directory it finds unless that directory's `package-lock.json` already lists the dependency. Fast gave each conversation its own directory containing a `.opencode/tools` folder, so `session.create` triggered that install on every new conversation. In the turn diagnostics this showed up inside `inferenceSetupDurationMs` and looked like server spawn time.

## Change

- The native Fast tools now live in one content-addressed directory per host (`roomote-fast-opencode/shared-tools-<hash>`), handed to OpenCode through `OPENCODE_CONFIG_DIR` in the tool bridge env. The hash covers the generated tool sources, so a deploy that changes or removes a tool lands in a new directory and stale tools are never loadable.
- The shared directory ships a seeded `package-lock.json` that declares `@opencode-ai/plugin`, which satisfies OpenCode's dependency check without a network install. The tools import only the bridge shim and the zod link, so the package itself is not needed.
- The per-conversation directory now holds only `opencode.json` (MCP capability and agent tool filter). A legacy `.opencode` folder in a reused conversation directory is removed so directories written by earlier releases stop re-triggering the install.

## Measurements (local, same OpenCode server)

| Scenario | Before | After |
|---|---|---|
| `session.create` for a new conversation directory | 800–1300 ms | 11–15 ms |
| Fast `inferenceSetupDurationMs`, new conversation, warm process | ~900 ms | ~75 ms |
| Fast `inferenceSetupDurationMs`, new conversation, cold process | 2–7 s | ~1.1 s (server spawn) |

`tool.ids` on a session booted through the shared directory lists all Fast tools (`send_chat_reply`, `launch_task`, `list_skills`, `spill_read`, etc.).

## Verification

- `vitest run src/server/fast-agent` in `@roomote/cloud-agents`: 318 tests pass, including the updated bridge layout test.
- `check-types`, oxlint, and oxfmt clean on the changed files.
- End-to-end Fast turns run against the local deployment with the change in place; replies and tool calls unchanged.