### PR TITLE
[Fix] Keep serving idle Fast integration catalogs instead of blocking on rediscovery

### DIFF
--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-integration-broker.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-integration-broker.test.ts
@@ -458,6 +458,47 @@ describe('fast-agent integration broker', () => {
     expect(mocks.listMcpTools).toHaveBeenCalledTimes(2);
   });
 
+  it('keeps serving a catalog left idle for a long time instead of blocking on rediscovery', async () => {
+    vi.useFakeTimers({ now: new Date('2026-08-19T00:00:00.000Z') });
+    mocks.configuredServers = {
+      notion: {
+        url: 'https://api.example.com/api/mcp/notion',
+        headers: {},
+      },
+    };
+
+    await listFastAgentIntegrations({
+      userId: 'user-1',
+      apiBaseUrl: 'https://api.example.com',
+    });
+    expect(mocks.listMcpTools).toHaveBeenCalledTimes(1);
+
+    // Well past the refresh interval. Another user's cache miss runs the
+    // eviction pass that used to drop entries this old.
+    await vi.advanceTimersByTimeAsync(45 * 60_000);
+    await listFastAgentIntegrations({
+      userId: 'user-2',
+      apiBaseUrl: 'https://api.example.com',
+    });
+    expect(mocks.listMcpTools).toHaveBeenCalledTimes(2);
+
+    mocks.listMcpTools.mockImplementationOnce(
+      () => new Promise(() => undefined),
+    );
+    await expect(
+      listFastAgentIntegrations({
+        userId: 'user-1',
+        apiBaseUrl: 'https://api.example.com',
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: 'notion',
+        tools: [expect.objectContaining({ name: 'search' })],
+      }),
+    ]);
+    expect(mocks.listMcpTools).toHaveBeenCalledTimes(3);
+  });
+
   it('excludes tools disabled by the deployment', async () => {
     mocks.configuredServers = {
       notion: {

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-integration-broker.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-integration-broker.ts
@@ -62,6 +62,7 @@ type IntegrationAuditContext = BrokerContext & {
 
 const FAST_AGENT_INTEGRATION_TOOL_CACHE_TTL_MS = 5 * 60_000;
 const FAST_AGENT_INTEGRATION_TOOL_CACHE_RETRY_MS = 30_000;
+const FAST_AGENT_INTEGRATION_TOOL_CACHE_MAX_ENTRIES = 1_000;
 const FAST_AGENT_INTEGRATION_DISCOVERY_TIMEOUT_MS = 10_000;
 const FAST_AGENT_INTEGRATION_CALL_TIMEOUT_MS = 60_000;
 
@@ -108,6 +109,9 @@ async function listCachedIntegrationTools(options: {
   const { cacheKey, ...clientOptions } = options;
   const cached = integrationToolCache.get(cacheKey);
   if (cached) {
+    // Re-insert so eviction below is least-recently-used rather than oldest.
+    integrationToolCache.delete(cacheKey);
+    integrationToolCache.set(cacheKey, cached);
     if (cached.expiresAt <= Date.now()) {
       // Keep serving the last known-good catalog while refreshing. Fast turns
       // must never wait behind a deployment MCP server that stopped answering
@@ -144,7 +148,7 @@ async function listCachedIntegrationTools(options: {
     FAST_AGENT_INTEGRATION_DISCOVERY_TIMEOUT_MS,
     'Fast integration tool discovery',
   );
-  pruneExpiredIntegrationToolCacheEntries();
+  pruneIntegrationToolCacheEntries();
   integrationToolCache.set(cacheKey, {
     expiresAt: Date.now() + FAST_AGENT_INTEGRATION_TOOL_CACHE_TTL_MS,
     tools,
@@ -162,13 +166,16 @@ async function listCachedIntegrationTools(options: {
 
 // The cache is keyed per user, so on deployments with many Fast users
 // abandoned entries would otherwise accumulate for the process lifetime.
-// Entries still inside the stale-while-refresh window are kept.
-function pruneExpiredIntegrationToolCacheEntries(): void {
-  const cutoff = Date.now() - FAST_AGENT_INTEGRATION_TOOL_CACHE_TTL_MS;
-  for (const [key, entry] of integrationToolCache) {
-    if (entry.expiresAt <= cutoff) {
-      integrationToolCache.delete(key);
-    }
+// Eviction is by count rather than age: a stale catalog is still served
+// instantly while it refreshes in the background, so keeping it around means
+// the first message after an idle stretch never blocks on tool discovery.
+function pruneIntegrationToolCacheEntries(): void {
+  while (
+    integrationToolCache.size >= FAST_AGENT_INTEGRATION_TOOL_CACHE_MAX_ENTRIES
+  ) {
+    const oldestKey = integrationToolCache.keys().next().value;
+    if (oldestKey === undefined) return;
+    integrationToolCache.delete(oldestKey);
   }
 }
 


### PR DESCRIPTION
## Problem

Fast caches each user's deployment MCP tool catalog for five minutes and, after that, serves the stale catalog while a bounded background refresh replaces it. But the eviction pass that runs on a cache miss dropped any entry older than twice that interval. So the first Fast message a user sent after roughly ten minutes of inactivity in a process fell through to a full `tools/list` against every configured MCP server before inference could start. Local api and bullmq logs show this as `preInferenceDurationMs` of 1.3–2.6 s on those turns versus ~100 ms otherwise.

## Change

- Evict cache entries by count (least recently used, bounded at 1000) instead of by age. Hits re-insert the entry so eviction order tracks recency.
- Stale entries of any age are now served immediately while the existing background refresh (10 s discovery timeout, 30 s retry backoff on failure) brings them up to date, which is the same behavior that already applied inside the old window.

Catalog changes are picked up exactly as before: the first turn after the five-minute mark triggers the refresh, and the next turn sees the new catalog. Servers removed from the deployment are never consulted because the resolver no longer returns them.

## Verification

- New test: a catalog left idle for 45 minutes survives another user's cache miss and is served instantly while its refresh hangs.
- `fast-agent-integration-broker.test.ts`: 23 tests pass.
- Pre-push oxlint, typecheck, and knip pass.